### PR TITLE
fix(delete_doc): Check if submittable before docstatus validation

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -246,7 +246,7 @@ def check_permission_and_not_submitted(doc):
 		)
 
 	# check if submitted
-	if doc.docstatus.is_submitted():
+	if doc.meta.is_submittable and doc.docstatus.is_submitted():
 		frappe.msgprint(
 			_("{0} {1}: Submitted Record cannot be deleted. You must {2} Cancel {3} it first.").format(
 				_(doc.doctype),


### PR DESCRIPTION
**Why?:** `docstatus` column exists on all DocType tables and unchecking "is_submittable" doesn't unset the values that trigger this flow