### PR TITLE
fix: align signature with backend; use count for perf on filters

### DIFF
--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -24,11 +24,19 @@ frappe.db = {
 			});
 		});
 	},
-	exists: function (doctype, name) {
+	exists: function (doctype, nameOrFilters) {
 		return new Promise((resolve) => {
-			frappe.db.get_value(doctype, { name: name }, "name").then((r) => {
-				r.message && r.message.name ? resolve(true) : resolve(false);
-			});
+			let filters;
+			if (typeof nameOrFilters === "string") {
+				// may be cached and more effecient
+				frappe.db.get_value(doctype, { name: nameOrFilters }, "name").then((r) => {
+					r.message && r.message.name ? resolve(true) : resolve(false);
+				});
+			} else if (typeof nameOrFilters === "object") {
+				frappe.db.count(doctype, { filters: filters, limit: 1 }).then((count) => {
+					resolve(count > 0);
+				});
+			}
 		});
 	},
 	get_value: function (doctype, filters, fieldname, callback, parent_doc) {


### PR DESCRIPTION
- Aligns js `frappe.db.exists` with python signature
- Uses count for efficiency on filters (only)