### PR TITLE
feat: sidebar with log links

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -153,7 +153,7 @@ def enqueue_webhook(doc, webhook) -> None:
 
 	except Exception as e:
 		frappe.logger().debug({"enqueue_webhook_error": e})
-		log_request(webhook.name, doc.name, request_url, headers, data)
+		log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data)
 		return
 
 	for i in range(3):
@@ -167,16 +167,16 @@ def enqueue_webhook(doc, webhook) -> None:
 			)
 			r.raise_for_status()
 			frappe.logger().debug({"webhook_success": r.text})
-			log_request(webhook.name, doc.name, request_url, headers, data, r)
+			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data, r)
 			break
 
 		except requests.exceptions.ReadTimeout as e:
 			frappe.logger().debug({"webhook_error": e, "try": i + 1})
-			log_request(webhook.name, doc.name, request_url, headers, data)
+			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data)
 
 		except Exception as e:
 			frappe.logger().debug({"webhook_error": e, "try": i + 1})
-			log_request(webhook.name, doc.name, request_url, headers, data, r)
+			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data, r)
 			sleep(3 * i + 1)
 			if i != 2:
 				continue
@@ -184,6 +184,7 @@ def enqueue_webhook(doc, webhook) -> None:
 
 def log_request(
 	webhook: str,
+	doctype: str,
 	docname: str,
 	url: str,
 	headers: dict,
@@ -194,6 +195,7 @@ def log_request(
 		{
 			"doctype": "Webhook Request Log",
 			"webhook": webhook,
+			"reference_doctype": doctype,
 			"reference_document": docname,
 			"user": frappe.session.user if frappe.session.user else None,
 			"url": url,

--- a/frappe/integrations/doctype/webhook_request_log/webhook_request_log.json
+++ b/frappe/integrations/doctype/webhook_request_log/webhook_request_log.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "webhook",
+  "reference_doctype",
   "reference_document",
   "headers",
   "data",
@@ -74,12 +75,20 @@
    "fieldtype": "Link",
    "label": "Webhook",
    "options": "Webhook"
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Reference Doctype",
+   "read_only": 1
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:04:03.509383",
+ "modified": "2024-09-14 05:52:41.583612",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook Request Log",

--- a/frappe/integrations/doctype/webhook_request_log/webhook_request_log.py
+++ b/frappe/integrations/doctype/webhook_request_log/webhook_request_log.py
@@ -17,6 +17,7 @@ class WebhookRequestLog(Document):
 		data: DF.Code | None
 		error: DF.Text | None
 		headers: DF.Code | None
+		reference_doctype: DF.Data | None
 		reference_document: DF.Data | None
 		response: DF.Code | None
 		url: DF.Data | None

--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -33,7 +33,7 @@ frappe.db = {
 					r.message && r.message.name ? resolve(true) : resolve(false);
 				});
 			} else if (typeof nameOrFilters === "object") {
-				frappe.db.count(doctype, { filters: filters, limit: 1 }).then((count) => {
+				frappe.db.count(doctype, { filters: nameOrFilters, limit: 1 }).then((count) => {
 					resolve(count > 0);
 				});
 			}

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -35,6 +35,8 @@ frappe.ui.form.Sidebar = class {
 
 		this.setup_keyboard_shortcuts();
 		this.show_auto_repeat_status();
+		this.show_error_log_status();
+		this.show_webhook_request_log_status();
 		frappe.ui.form.setup_user_image_event(this.frm);
 
 		this.refresh();
@@ -144,16 +146,52 @@ frappe.ui.form.Sidebar = class {
 					fieldname: ["frequency"],
 				},
 				callback: function (res) {
-					me.sidebar
-						.find(".auto-repeat-status")
-						.removeClass("hidden")
-						.html(__("Repeats {0}", [__(res.message.frequency)]));
-					me.sidebar.find(".auto-repeat-status").on("click", function () {
+					let el = me.sidebar.find(".auto-repeat-status");
+					el.find("span").html(__("Repeats {0}", [__(res.message.frequency)]));
+					el.closest(".sidebar-section").removeClass("hidden");
+					el.show();
+					el.on("click", function () {
 						frappe.set_route("Form", "Auto Repeat", me.frm.doc.auto_repeat);
 					});
 				},
 			});
 		}
+	}
+
+	show_error_log_status() {
+		const me = this;
+		const filters = {
+			reference_doctype: this.frm.doc.doctype,
+			reference_name: this.frm.doc.name,
+		};
+		frappe.db.exists("Error Log", filters).then((exists) => {
+			if (exists) {
+				let el = me.sidebar.find(".error-log-status");
+				el.closest(".sidebar-section").removeClass("hidden");
+				el.show();
+				el.on("click", function () {
+					frappe.set_route("List", "Error Log", filters);
+				});
+			}
+		});
+	}
+
+	show_webhook_request_log_status() {
+		const me = this;
+		const filters = {
+			reference_doctype: this.frm.doc.doctype,
+			reference_document: this.frm.doc.name,
+		};
+		frappe.db.exists("Webhook Request Log", filters).then((exists) => {
+			if (exists) {
+				let el = me.sidebar.find(".webhook-request-log-status");
+				el.closest(".sidebar-section").removeClass("hidden");
+				el.show();
+				el.on("click", function () {
+					frappe.set_route("List", "Webhook Request Log", filters);
+				});
+			}
+		});
 	}
 
 	make_tags() {

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -136,7 +136,9 @@
 	</div>
 </div>
 <div class="sidebar-section hidden">
-	<a><span class="auto-repeat-status"><span></a>
+	<a><li class="indicator red blink error-log-status" style="display: none;">{%= __("Error Logs") %}</li></a>
+	<a><li class="indicator yellow webhook-request-log-status" style="display: none;">{%= __("Webhook Logs") %}</li></a>
+	<a><li class="indicator blue auto-repeat-status" style="display: none;"></li></a>
 </div>
 <div class="sidebar-section text-muted">
 	<div class="pageview-count hidden"></div>


### PR DESCRIPTION
- fixup: fix: align signature with backend; use count for perf on filters
- feat: add link to (various) logs in sidebar

## Improve Situational Awarness (Automation)

![image](https://github.com/user-attachments/assets/94464a50-535b-4f82-98a7-7149440bb6db)

---
![image](https://github.com/user-attachments/assets/a6b3d97d-59e1-472c-a389-6b429f183f64)


**Auto Repeat is neutral blue, webhook yellow because currently there's no way to parse the return status, so we can't know if it's good or bad, just "pay attention"**


## Note

- This also fixes the repeated document hint (section wasn't un-hidden due to an oversight in the js code).
- Error Log blink, because they should really be tended to.
- Should help us all improve the accuracy of Error Logs, as a positive long term side effect of this increased visibility.

`no-docs`