### PR TITLE
chore(decrypt): mention the key in error if specificed

### DIFF
--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -133,7 +133,7 @@ def two_factor_is_enabled_for_(user):
 def get_otpsecret_for_(user):
 	"""Set OTP Secret for user even if not set."""
 	if otp_secret := get_default(user + "_otpsecret"):
-		return decrypt(otp_secret)
+		return decrypt(otp_secret, key=f"{user}.otpsecret")
 
 	otp_secret = b32encode(os.urandom(10)).decode("utf-8")
 	set_default(user + "_otpsecret", encrypt(otp_secret))

--- a/frappe/utils/password.py
+++ b/frappe/utils/password.py
@@ -34,7 +34,7 @@ def get_decrypted_password(doctype, name, fieldname="password", raise_exception=
 	).run()
 
 	if result and result[0][0]:
-		return decrypt(result[0][0])
+		return decrypt(result[0][0], key=f"{doctype}.{name}.{fieldname}")
 
 	elif raise_exception:
 		frappe.throw(
@@ -183,7 +183,7 @@ def encrypt(txt, encryption_key=None):
 	return cstr(cipher_suite.encrypt(encode(txt)))
 
 
-def decrypt(txt, encryption_key=None):
+def decrypt(txt, encryption_key=None, key: str | None = None):
 	# Only use encryption_key value generated with Fernet.generate_key().decode()
 
 	try:
@@ -192,12 +192,13 @@ def decrypt(txt, encryption_key=None):
 	except InvalidToken:
 		# encryption_key in site_config is changed and not valid
 		frappe.throw(
-			_("Encryption key is invalid! Please check site_config.json")
-			+ "<br>"
+			(_("Failed to decrypt key {0}").format(key) + "<br><br>" if key else "")
+			+ _("Encryption key is invalid! Please check site_config.json")
+			+ "<br><br>"
 			+ _(
 				"If you have recently restored the site you may need to copy the site config contaning original Encryption Key."
 			)
-			+ "<br>"
+			+ "<br><br>"
 			+ _(
 				"Please visit https://frappecloud.com/docs/sites/migrate-an-existing-site#encryption-key for more information."
 			),


### PR DESCRIPTION
This would allow the user to know which key is failing, and just update that if required

Resolves #27727

<hr>

![image](https://github.com/user-attachments/assets/d82f88e5-7e2e-448d-bfc6-590743f55af5)
