### PR TITLE
fix: let's translate data on standard report excel/csv exporting #27124

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -454,17 +454,17 @@ def get_field_info(fields, doctype):
 			df = frappe.get_meta(parenttype).get_field(fieldname)
 			if df and df.fieldtype in ("Data", "Select", "Small Text", "Text"):
 				name = df.name
-				label = df.label
+				label = _(df.label)
 				fieldtype = df.fieldtype
 				translatable = df.translatable if hasattr(df, "translatable") else False
 			elif df and df.fieldtype == "Link" and frappe.get_meta(df.options).translated_doctype:
 				name = df.name
-				label = df.label
+				label = _(df.label)
 				fieldtype = df.fieldtype
 				translatable = True
 			else:
 				name = fieldname
-				label = fieldname
+				label = _(fieldname)
 				fieldtype = "Data"
 				translatable = False
 

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -450,7 +450,7 @@ def get_field_info(fields, doctype):
 			translatable = True
 		else:
 			df = frappe.get_meta(parenttype).get_field(fieldname)
-			if df and df.fieldtype in ("Data", "Select", "Small Text", "Text Editor", "Text"):
+			if df and df.fieldtype in ("Data", "Select", "Small Text", "Text"):
 				name = df.name
 				label = df.label
 				fieldtype = df.fieldtype

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -357,7 +357,7 @@ def export_query():
 	title = form_params.pop("title", doctype)
 	csv_params = pop_csv_params(form_params)
 	add_totals_row = 1 if form_params.pop("add_totals_row", None) == "1" else None
-	translate_values = int(form_params.pop("translate_values", 0))
+	translate_values = 1 if form_params.pop("translate_values", None) == "1" else None
 
 	frappe.permissions.can_export(doctype, raise_exception=True)
 
@@ -464,7 +464,7 @@ def get_field_info(fields, doctype):
 				translatable = True
 			else:
 				name = fieldname
-				label = _(fieldname)
+				label = _(df.label) if df else _(fieldname)
 				fieldtype = "Data"
 				translatable = False
 

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -461,7 +461,7 @@ def get_field_info(fields, doctype):
 				name = df.name
 				label = _(df.label)
 				fieldtype = df.fieldtype
-				translatable = df.translatable if hasattr(df, "translatable") else False
+				translatable = getattr(df, "translatable", False)
 			elif df and df.fieldtype == "Link" and frappe.get_meta(df.options).translated_doctype:
 				name = df.name
 				label = _(df.label)

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -377,7 +377,13 @@ def export_query():
 		ret = append_totals_row(ret)
 
 	data = [[_("Sr"), *get_labels(db_query.fields, doctype)]]
-	data.extend([i + 1, *list(row)] for i, row in enumerate(ret))
+	if frappe.local.lang == "en":
+		data.extend([i + 1, *list(row)] for i, row in enumerate(ret))
+	else:
+		for i, row in enumerate(ret):
+			data.append([i + 1] + list(map(_, row)))
+	
+	
 	data = handle_duration_fieldtype_values(doctype, data, db_query.fields)
 
 	if file_format_type == "CSV":

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -436,12 +436,17 @@ def append_totals_row(data):
 
 def get_field_info(fields, doctype):
 	"""Get column names, labels, field types, and translatable properties based on column names."""
+
 	field_info = []
 	for key in fields:
+		df = None
 		try:
 			parenttype, fieldname = parse_field(key)
 		except ValueError:
-			continue
+			# handles aggregate functions
+			parenttype = doctype
+			fieldname = key.split("(", 1)[0]
+			fieldname = fieldname[0].upper() + fieldname[1:]
 
 		parenttype = parenttype or doctype
 

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1553,7 +1553,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 					const args = this.get_args();
 					const selected_items = this.get_checked_items(true);
 
-					let extra_fields = null;
+					let extra_fields = [];
 					if (this.list_view_settings.disable_count) {
 						extra_fields = [
 							{
@@ -1573,6 +1573,12 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 							},
 						];
 					}
+					extra_fields.push({
+						fieldtype: "Check",
+						fieldname: "translate_values",
+						label: __("Translate values"),
+						default: 1,
+					});
 
 					const d = frappe.report_utils.get_export_dialog(
 						__(this.doctype),
@@ -1581,6 +1587,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 							args.cmd = "frappe.desk.reportview.export_query";
 							args.file_format_type = data.file_format;
 							args.title = this.report_name || this.doctype;
+							args.translate_values = data.translate_values;
 
 							if (data.file_format == "CSV") {
 								args.csv_delimiter = data.csv_delimiter;

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1573,12 +1573,14 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 							},
 						];
 					}
-					extra_fields.push({
-						fieldtype: "Check",
-						fieldname: "translate_values",
-						label: __("Translate values"),
-						default: 1,
-					});
+					if (frappe.boot.lang !== "en") {
+						extra_fields.push({
+							fieldtype: "Check",
+							fieldname: "translate_values",
+							label: __("Translate values"),
+							default: 1,
+						});
+					}
 
 					const d = frappe.report_utils.get_export_dialog(
 						__(this.doctype),


### PR DESCRIPTION
- **fix: let's translate data on report excel exporting**
- **refactor: consider fieldtype for translation**
- **fix: exclude text editor**
- **feat: translate values option in export dialog**
- **fix: always translate labels**
- **fix: show translate option just if needed**
- **fix: get label instead fieldname & discard int for get form_param**
- **fix: handle aggregate columns**
- **refactor: use getattr fallback instead conditional to get translatable**

Manual backport of #27124 because mergify can't deal with merge commits :'D
