### PR TITLE
fix: dont fetch context for custom doctype based on custom module

### DIFF
--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -187,7 +187,7 @@ def get_list_context(context, doctype, web_form_name=None):
 	# get context for custom webform
 	if meta.custom and web_form_name:
 		webform_list_contexts = frappe.get_hooks("webform_list_context")
-		if webform_list_contexts:
+		if webform_list_contexts and not frappe.get_doc("Module Def", meta.module).custom:
 			out = frappe._dict(frappe.get_attr(webform_list_contexts[0])(meta.module) or {})
 			if out:
 				list_context = out


### PR DESCRIPTION
context: support ticket: 20604

Issue: 
Webform created from custom doctype which was associated to custom module threw module not found error
<img width="615" alt="Screenshot 2024-09-16 at 11 38 57 PM" src="https://github.com/user-attachments/assets/99012014-eb73-479e-8f9a-a6e74dbb9e51">

Cause:
hook "webform_list_context" present in erpnext checks whether module's app is erpnext. if true, it attaches relevant transactions to context. Since, get_modules only returns standard modules i.e modules from module.txt, function threw error "[custom]module not found"

