### PR TITLE
fix: re-number idx on child table row removal

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -317,6 +317,10 @@ class BaseDocument:
 		if doc.get("parentfield"):
 			self.get(doc.parentfield).remove(doc)
 
+			# re-number idx
+			for i, _d in enumerate(self.get(doc.parentfield)):
+				_d.idx = i + 1
+
 	def _init_child(self, value, key):
 		if not isinstance(value, BaseDocument):
 			if not (doctype := self.get_table_field_doctype(key)):


### PR DESCRIPTION
`idx` value becomes invalid when a row is removed in-between. This is not an issue on normal UI operations, as upon save, the idx values are recalculated.

But, when operating on a submitted document on server-side code, removing a row from child table causes the rows below the removed row to have incorrect idx values.