### PR TITLE
LDAP: escape special characters in `entry_dn` to prevent `LDAPInvalidFilterError`

### DIFF
--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -13,6 +13,7 @@ from ldap3.core.exceptions import (
 	LDAPInvalidFilterError,
 	LDAPNoSuchObjectResult,
 )
+from ldap3.utils.conv import escape_filter_chars
 from ldap3.utils.hashed import hashed
 
 import frappe
@@ -272,7 +273,7 @@ class LDAPSettings(Document):
 		if self.ldap_directory_server.lower() == "active directory":
 			ldap_object_class = "Group"
 			ldap_group_members_attribute = "member"
-			user_search_str = user.entry_dn
+			user_search_str = escape_filter_chars(user.entry_dn)
 
 		elif self.ldap_directory_server.lower() == "openldap":
 			ldap_object_class = "posixgroup"


### PR DESCRIPTION
`entry_dn` can contain special characters like parenthesis (e.g. to surround nicknames), but these will be interpreted as part of the filter syntax when not escaped and lead to an LDAPInvalidFilterError

You can recreate this by having a user in the AD where `givenName` contains a pair of parenthesis:
* `Theodore (Teddy)`

Example for `entry_dn` (slightly adjusted to not expose my companies AD details):
* without the patch: `'CN=Roosevelt\\, Theodore (Teddy),OU=User,OU=<Country>,OU=<Group>,DC=<Company>,DC=local'`
* with the patch: `'CN=Roosevelt\\5c, Theodore \\28Teddy\\29,OU=User,OU=<Country>,OU=<Group>,DC=<Company>,DC=local'`

I don't have the means to try out if the same can happen when using `openldap` or `custom`.



Please backport to version-14 and version-15