### PR TITLE
feat: Add button to removing multiple assignments

### DIFF
--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -178,6 +178,20 @@ def remove(doctype, name, assign_to, ignore_permissions=False):
 
 
 @frappe.whitelist()
+def remove_multiple(doctype, names, ignore_permissions=False):
+	docname_list = json.loads(names)
+
+	for name in docname_list:
+		assignments = get({"doctype": doctype, "name": name})
+
+		if not assignments:
+			continue
+
+		for assignment in assignments:
+			remove(doctype, name, assignment.get("owner"), ignore_permissions)
+
+
+@frappe.whitelist()
 def close(doctype: str, name: str, assign_to: str, ignore_permissions=False):
 	if assign_to != frappe.session.user:
 		frappe.throw(_("Only the assignee can complete this to-do."))

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -240,6 +240,27 @@ export default class BulkOperations {
 		}
 	}
 
+	clear_assignment(docnames, done) {
+		if (docnames.length > 0) {
+			frappe
+				.call({
+					method: "frappe.desk.form.assign_to.remove_multiple",
+					args: {
+						doctype: this.doctype,
+						names: docnames,
+						ignore_permissions: true,
+					},
+					freeze: true,
+					freeze_message: "Removing assignments...",
+				})
+				.then(() => {
+					done();
+				});
+		} else {
+			frappe.msgprint(__("Select records for removing assignment"));
+		}
+	}
+
 	apply_assignment_rule(docnames, done) {
 		if (docnames.length > 0) {
 			frappe

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1851,6 +1851,21 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			};
 		};
 
+		const bulk_assignment_clear = () => {
+			return {
+				label: __("Clear Assignment", null, "Button in list view actions menu"),
+				action: () => {
+					this.disable_list_update = true;
+					bulk_operations.clear_assignment(this.get_checked_items(true), () => {
+						this.disable_list_update = false;
+						this.clear_checked_items();
+						this.refresh();
+					});
+				},
+				standard: true,
+			};
+		};
+
 		const bulk_assignment_rule = () => {
 			return {
 				label: __("Apply Assignment Rule", null, "Button in list view actions menu"),
@@ -2018,6 +2033,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		// bulk assignment
 		actions_menu_items.push(bulk_assignment());
+
+		actions_menu_items.push(bulk_assignment_clear());
 
 		actions_menu_items.push(bulk_assignment_rule());
 


### PR DESCRIPTION
Merge 'remove multiple assignments' feature from frappe develop to version-15-hotfix.