### PR TITLE
feat: add allowed referrers to loosen csrf prevention

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -86,6 +86,7 @@ class HTTPRequest:
 				(frappe.get_request_header("X-Frappe-CSRF-Token") or frappe.form_dict.pop("csrf_token", None))
 				== saved_token
 			)
+			or self.is_allowed_referrer()
 		):
 			return
 
@@ -94,6 +95,21 @@ class HTTPRequest:
 
 	def set_lang(self):
 		frappe.local.lang = get_language()
+
+	def is_allowed_referrer(self):
+		referrer = frappe.get_request_header("Referer")
+		origin = frappe.get_request_header("Origin")
+
+		# Get the list of allowed referrers from cache or configuration
+		allowed_referrers = frappe.cache.get_value(
+			"allowed_referrers",
+			generator=lambda: frappe.conf.get("allowed_referrers", []),
+		)
+
+		# Check if the referrer or origin is in the allowed list
+		return (referrer and any(referrer.startswith(allowed) for allowed in allowed_referrers)) or (
+			origin and any(origin == allowed for allowed in allowed_referrers)
+		)
 
 
 class LoginManager:

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -4,12 +4,14 @@ import datetime
 import time
 
 import requests
+from werkzeug.test import EnvironBuilder
+from werkzeug.wrappers import Request
 
 import frappe
 from frappe.auth import LoginAttemptTracker
 from frappe.frappeclient import AuthError, FrappeClient
 from frappe.sessions import Session, get_expired_sessions, get_expiry_in_seconds
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, UnitTestCase
 from frappe.tests.test_api import FrappeAPITestCase
 from frappe.utils import get_datetime, get_site_url, now
 from frappe.utils.data import add_to_date
@@ -163,6 +165,39 @@ class TestAuth(IntegrationTestCase):
 		expiry_time = next(x for x in client.session.cookies if x.name == "sid").expires
 		current_time = datetime.datetime.now(tz=datetime.UTC).timestamp()
 		self.assertAlmostEqual(get_expiry_in_seconds(), expiry_time - current_time, delta=60 * 60)
+
+
+class TestAllowedReferrer(UnitTestCase):
+	def test_is_allowed_referrer(self):
+		def create_request(headers):
+			builder = EnvironBuilder(headers=headers)
+			env = builder.get_environ()
+			return Request(env)
+
+		# Test with valid referrer
+		frappe.cache.set_value("allowed_referrers", ["https://example.com"])
+		frappe.local.request = create_request({"Referer": "https://example.com/some/path"})
+		http_request = frappe.auth.HTTPRequest()
+		self.assertTrue(http_request.is_allowed_referrer())
+
+		# Test with invalid referrer
+		frappe.local.request = create_request({"Referer": "https://malicious.com"})
+		http_request = frappe.auth.HTTPRequest()
+		self.assertFalse(http_request.is_allowed_referrer())
+
+		# Test with valid origin
+		frappe.local.request = create_request({"Origin": "https://example.com"})
+		http_request = frappe.auth.HTTPRequest()
+		self.assertTrue(http_request.is_allowed_referrer())
+
+		# Test with invalid origin
+		frappe.local.request = create_request({"Origin": "https://malicious.com"})
+		http_request = frappe.auth.HTTPRequest()
+		self.assertFalse(http_request.is_allowed_referrer())
+
+		# Clean up
+		frappe.cache.delete_value("allowed_referrers")
+		frappe.local.request = None
 
 
 class TestLoginAttemptTracker(IntegrationTestCase):


### PR DESCRIPTION
##### Docs: A mention should be added here https://frappeframework.com/docs/user/en/basics/site_config

---

**Prior**

- A payment flow using POST onto a checkout page was blocked for logged in users (only)

**Now**

- Allowed referres can be specified in the configuration file, e.g. the name of ecommerce sites allowed to checkout

---

AI Review:

> 1. In the `validate_csrf_token` method:
>    ```python
>    or self.is_allowed_referrer()
>    ```
>    This line has been added to the conditions, allowing requests from approved referrers to bypass the CSRF token check.
> 
> 2. A new method `is_allowed_referrer` has been added:
>    ```python
>    def is_allowed_referrer(self):
>        referrer = frappe.get_request_header("Referer")
>        origin = frappe.get_request_header("Origin")
> 
>        # Get the list of allowed referrers from cache or configuration
>        allowed_referrers = frappe.cache().get_value(
>            "allowed_referrers",
>            generator=lambda: frappe.conf.get("allowed_referrers", []),
>            expires_in_sec=3600,  # Cache for 1 hour
>        )
> 
>        # Check if the referrer or origin is in the allowed list
>        return (referrer and any(referrer.startswith(allowed) for allowed in allowed_referrers)) or (
>            origin and any(origin == allowed for allowed in allowed_referrers)
>        )
>    ```
> 
>    This method:
>    - Retrieves the `Referer` and `Origin` headers from the request.
>    - Uses the cache to get the list of allowed referrers, with a lambda function to fetch from configuration if not in cache.
>    - Checks if either the `Referer` or `Origin` matches any of the allowed referrers.
> 
> The implementation looks correct and aligns with the requirements we discussed. It provides a way to bypass CSRF checks for specific, allowed referrers while maintaining security for other requests.
> 
> A few points to note:
> 
> 1. The caching mechanism is well implemented, using Frappe's built-in caching with a 1-hour expiration.
> 2. The method checks both `Referer` and `Origin` headers, which is good for compatibility with different types of requests.
> 3. The `startswith` check for referrers allows for more flexible matching (e.g., matching subpaths of allowed domains).
> 
> Overall, this implementation looks solid and should work as intended. Just ensure that you've thoroughly tested it in a safe environment before deploying to production, and make sure to keep the `allowed_referrers` list in your configuration up-to-date and secure.