### PR TITLE
fix: show chart tooltip in report currency

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1046,7 +1046,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					frappe.format(d, {
 						fieldtype: options.fieldtype,
 						options: options.options,
-					}),
+					}, options.options, options),
 			};
 		}
 		options.axisOptions = {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1043,10 +1043,15 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		if (options.fieldtype) {
 			options.tooltipOptions = {
 				formatTooltipY: (d) =>
-					frappe.format(d, {
-						fieldtype: options.fieldtype,
-						options: options.options,
-					}, options.options, options),
+					frappe.format(
+						d,
+						{
+							fieldtype: options.fieldtype,
+							options: options.options,
+						},
+						options.options,
+						options
+					),
 			};
 		}
 		options.axisOptions = {


### PR DESCRIPTION
Issue: When there are multiple companies with different currencies, the report chart tooltip shows the global default currency instead of the report currency
ref: [21723](https://support.frappe.io/helpdesk/tickets/21723)

Before: 
![tooltip-issue](https://github.com/user-attachments/assets/e65df244-2955-4d72-b339-fe6f66cf14ef)

After:
![tooltip-fix](https://github.com/user-attachments/assets/1ffb11e2-a58a-4b57-91c8-b1d432f9a77a)

Backport needed: v14 & v15