### PR TITLE
fix: extract translatable strings from the whole repo

### DIFF
--- a/babel_extractors.csv
+++ b/babel_extractors.csv
@@ -1,11 +1,11 @@
-hooks.py,frappe.gettext.extractors.navbar.extract
+**/hooks.py,frappe.gettext.extractors.navbar.extract
 **/doctype/*/*.json,frappe.gettext.extractors.doctype.extract
 **/workspace/*/*.json,frappe.gettext.extractors.workspace.extract
 **/onboarding_step/*/*.json,frappe.gettext.extractors.onboarding_step.extract
 **/module_onboarding/*/*.json,frappe.gettext.extractors.module_onboarding.extract
 **/report/*/*.json,frappe.gettext.extractors.report.extract
 **.py,frappe.gettext.extractors.python.extract
-templates/**.js,frappe.gettext.extractors.html_template.extract
+**/templates/**.js,frappe.gettext.extractors.html_template.extract
 **.js,frappe.gettext.extractors.javascript.extract
 **.html,frappe.gettext.extractors.html_template.extract
 **.vue,frappe.gettext.extractors.html_template.extract

--- a/frappe/gettext/translate.py
+++ b/frappe/gettext/translate.py
@@ -132,7 +132,7 @@ def generate_pot(target_app: str | None = None):
 	keywords["_lt"] = None
 
 	for app in apps:
-		app_path = frappe.get_pymodule_path(app)
+		app_path = frappe.get_pymodule_path(app, "..")
 		catalog = new_catalog(app)
 
 		# Each file will only be processed by the first method that matches,


### PR DESCRIPTION
Extract translatable strings from the whole repo, not just the python module. This is necessary for apps that track frontend code in a separate folder, outside of the python module (e.g. frappe/lms).

I've checked compatibility with erpnext and hrms.

> [!WARNING]
> This will cause a huuuge diff, because the source path of every translatable string will change.