### PR TITLE
fix: also assign if ToDo is created via interaction modal

### DIFF
--- a/frappe/public/js/frappe/views/interaction.js
+++ b/frappe/public/js/frappe/views/interaction.js
@@ -281,31 +281,29 @@ frappe.views.InteractionComposer = class InteractionComposer {
 	}
 
 	assign_document(doc, assignee) {
-		if (doc.doctype != "ToDo") {
-			frappe.call({
-				method: "frappe.desk.form.assign_to.add",
-				args: {
-					doctype: doc.doctype,
-					name: doc.name,
-					assign_to: JSON.stringify([assignee]),
-				},
-				callback: function (r) {
-					if (!r.exc) {
-						frappe.show_alert({
-							message: __("The document has been assigned to {0}", [assignee]),
-							indicator: "green",
-						});
-						return;
-					} else {
-						frappe.show_alert({
-							message: __("The document could not be correctly assigned"),
-							indicator: "orange",
-						});
-						return;
-					}
-				},
-			});
-		}
+		frappe.call({
+			method: "frappe.desk.form.assign_to.add",
+			args: {
+				doctype: doc.doctype,
+				name: doc.name,
+				assign_to: JSON.stringify([assignee]),
+			},
+			callback: function (r) {
+				if (!r.exc) {
+					frappe.show_alert({
+						message: __("The document has been assigned to {0}", [assignee]),
+						indicator: "green",
+					});
+					return;
+				} else {
+					frappe.show_alert({
+						message: __("The document could not be correctly assigned"),
+						indicator: "orange",
+					});
+					return;
+				}
+			},
+		});
 	}
 
 	add_attachments(doc, attachments) {


### PR DESCRIPTION
Issue: When task is created in Lead, ToDo is created but it is not assigned to the user selected.