### PR TITLE
fix: don't call `.total_seconds()` if the object isn't of type `datetime.timedelta`

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2443,8 +2443,8 @@ class UnicodeWithAttrs(str):
 
 
 def format_timedelta(o: datetime.timedelta) -> str:
-	# mariadb allows a wide diff range - https://mariadb.com/kb/en/time/
-	# but frappe doesnt - i think via babel : only allows 0..23 range for hour
+	# MariaDB allows a wide range - https://mariadb.com/kb/en/time/
+	# but Frappe doesn't - I think via babel : only allows 0..23 range for hour
 	total_seconds = o.total_seconds()
 	hours, remainder = divmod(total_seconds, 3600)
 	minutes, seconds = divmod(remainder, 60)

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2442,10 +2442,13 @@ class UnicodeWithAttrs(str):
 		self.metadata = text.metadata
 
 
-def format_timedelta(o: datetime.timedelta) -> str:
+def format_timedelta(o: datetime.timedelta | str) -> str:
 	# MariaDB allows a wide range - https://mariadb.com/kb/en/time/
 	# but Frappe doesn't - I think via babel : only allows 0..23 range for hour
-	total_seconds = o.total_seconds()
+	if isinstance(o, datetime.timedelta):
+		total_seconds = o.total_seconds()
+	else:
+		total_seconds = cint(o)
 	hours, remainder = divmod(total_seconds, 3600)
 	minutes, seconds = divmod(remainder, 60)
 	rounded_seconds = round(seconds, 6)


### PR DESCRIPTION
- **fix: update comment**
- **fix(format_timedelta): don't try to call `.total_seconds()` if a string was passed in**
