### PR TITLE
fix: don't catch S3 upload error prematurely

### DIFF
--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -187,10 +187,5 @@ def backup_to_s3():
 
 def upload_file_to_s3(filename, folder, conn, bucket):
 	destpath = os.path.join(folder, os.path.basename(filename))
-	try:
-		print("Uploading file:", filename)
-		conn.upload_file(filename, bucket, destpath)  # Requires PutObject permission
-
-	except Exception:
-		frappe.log_error()
-		notify()
+	print("Uploading file:", filename)
+	conn.upload_file(filename, bucket, destpath)  # Requires PutObject permission


### PR DESCRIPTION
If we catch and log the error in `upload_file_to_s3`, nothing will trigger this email notification about the failed backup:

https://github.com/frappe/frappe/blob/a04aba0408c6caefe3ef446ba7e6f11cb61caf66/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py#L120-L121