### PR TITLE
fix: format value in custom dashboard chart

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -599,6 +599,12 @@ export default class ChartWidget extends Widget {
 			options = this.report_result.chart.options;
 		}
 
+		if (this.chart_doc.chart_type == "Custom" && this.chart_doc.custom_options) {
+			let chart_options = JSON.parse(this.chart_doc.custom_options);
+			fieldtype = chart_options.fieldtype;
+			options = chart_options.options;
+		}	
+
 		chart_args.tooltipOptions = {
 			formatTooltipY: (value) =>
 				frappe.format(

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -603,7 +603,7 @@ export default class ChartWidget extends Widget {
 			let chart_options = JSON.parse(this.chart_doc.custom_options);
 			fieldtype = chart_options.fieldtype;
 			options = chart_options.options;
-		}	
+		}
 
 		chart_args.tooltipOptions = {
 			formatTooltipY: (value) =>


### PR DESCRIPTION
- Fixed an issue where hovering box values were not formatted as currency when the chart type is set to custom.

Before Code:
<video src="https://github.com/user-attachments/assets/22789686-1c4a-417b-8d76-c7f93c5f7e8d"> 

After Code:
<video src="https://github.com/user-attachments/assets/07ff3cee-5179-41cf-bf5f-83cb384ebda1">


