### PR TITLE
chore: add in system setting to allow using number format from currency

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -18,6 +18,7 @@
   "date_format",
   "time_format",
   "number_format",
+  "use_number_format_from_currency",
   "first_day_of_the_week",
   "column_break_7",
   "float_precision",
@@ -677,12 +678,18 @@
    "fieldname": "rate_limit_email_link_login",
    "fieldtype": "Int",
    "label": "Rate limit for email link login"
+  },
+  {
+   "default": "0",
+   "fieldname": "use_number_format_from_currency",
+   "fieldtype": "Check",
+   "label": "Use Number Format from Currency"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2024-08-20 13:50:49.711427",
+ "modified": "2024-09-26 16:20:59.417151",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -94,6 +94,7 @@ class SystemSettings(Document):
 		time_format: DF.Literal["HH:mm:ss", "HH:mm"]
 		time_zone: DF.Literal[None]
 		two_factor_method: DF.Literal["OTP App", "SMS", "Email"]
+		use_number_format_from_currency: DF.Check
 		welcome_email_template: DF.Link | None
 	# end: auto-generated types
 

--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -177,8 +177,12 @@ function get_currency_symbol(currency) {
 }
 
 function get_number_format(currency) {
+	let sysdefaults = frappe?.boot?.sysdefaults;
 	return (
-		(frappe.boot && frappe.boot.sysdefaults && frappe.boot.sysdefaults.number_format) ||
+		(sysdefaults.use_number_format_from_currency &&
+			currency &&
+			frappe.model.get_value(":Currency", currency, "number_format")) ||
+		sysdefaults.number_format ||
 		"#,###.##"
 	);
 }


### PR DESCRIPTION
Adds back the functionality from #27047 without the risk of breaking existing setups
