### PR TITLE
feat: redirect to new record after rename

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -229,6 +229,15 @@ def rename_doc(
 			indicator="green",
 		)
 
+	# let people watching the old form know that it has been renamed
+	frappe.publish_realtime(
+		event="doc_rename",
+		message={"doctype": doctype, "old": old, "new": new},
+		doctype=doctype,
+		docname=old,
+		after_commit=True,
+	)
+
 	return new
 
 

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -333,6 +333,14 @@ frappe.ui.form.Form = class FrappeForm {
 		$(document).on("rename", (ev, dt, old_name, new_name) => {
 			if (dt == this.doctype) this.rename_notify(dt, old_name, new_name);
 		});
+
+		frappe.realtime.on("doc_rename", (data) => {
+			// the current form has been renamed by some backend process
+			if (data.doctype == this.doctype && data.old == this.docname) {
+				// the current form does not exist anymore, route to the new one
+				frappe.set_route("Form", this.doctype, data.new);
+			}
+		});
 	}
 
 	setup_file_drop() {


### PR DESCRIPTION
If I'm watching a record that has been renamed in the backend, I should get redirected to the new record ASAP. Otherwise I'll get all sorts of errors from actions on the current form, using a name that doesn't exist anymore or that already belongs to another record.

As far as I can tell, the current functionality only redirects the user if they triggered the rename from the front end.

> no-docs

If this is valid and doesn't cause any trouble, it should also go into v15 and v14.