### PR TITLE
fix: allow to reset rating input if not mandatory

### DIFF
--- a/frappe/public/js/frappe/form/controls/rating.js
+++ b/frappe/public/js/frappe/form/controls/rating.js
@@ -47,12 +47,25 @@ frappe.ui.form.ControlRating = class ControlRating extends frappe.ui.form.Contro
 		let star_value = el.data("rating");
 		let left_half = false;
 		let cls = "star-click";
+		let out_of_ratings = this.df.options || 5;
 		if (!click) cls = "star-hover";
 
 		if (ev.pageX - el.offset().left < el.width() / 2) {
 			left_half = true;
 			star_value--;
 		}
+
+		if (click && !this.df.reqd) {
+			let fractional_star_value = star_value;
+			if (left_half) {
+				fractional_star_value += 0.5;
+			}
+			if (this.get_value() == fractional_star_value / out_of_ratings) {
+				star_value = 0;
+				left_half = false;
+			}
+		}
+
 		el.parent()
 			.children("svg")
 			.each(function (e) {
@@ -67,7 +80,6 @@ frappe.ui.form.ControlRating = class ControlRating extends frappe.ui.form.Contro
 				}
 			});
 		if (click) {
-			let out_of_ratings = this.df.options || 5;
 			star_value = star_value / out_of_ratings;
 
 			this.validate_and_set_in_model(star_value, ev);


### PR DESCRIPTION
If a rating field is not mandatory and the user selects the same rating again then it should reset the rating by setting value to 0.

Solution:

- If the field is mandatory, this PR won't change the functionality.
- If field is optional then it will allow to reset by selecting the same rating again
- Usually when a user wants to unselect anything, the first go to trial is clicking it again, hence it is intuitive to how users might think on accidentally selecting a rating.
- This will prevent the cumbersome alternative of refreshing the form and filling everything again.

Recording of fix:

https://github.com/user-attachments/assets/dc87abbe-895d-4012-a4d1-f74e0dba5697


closes #27922