### PR TITLE
feat: Added placeholder docfield, customize form field, and custom field

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -75,6 +75,7 @@
   "column_break_22",
   "description",
   "documentation_url",
+  "placeholder",
   "oldfieldname",
   "oldfieldtype"
  ],
@@ -586,13 +587,18 @@
    "fieldname": "show_on_timeline",
    "fieldtype": "Check",
    "label": "Show on Timeline"
+  },
+  {
+   "fieldname": "placeholder",
+   "fieldtype": "Data",
+   "label": "Placeholder"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-07-30 13:15:32.037892",
+ "modified": "2024-09-28 20:17:43.400728",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/core/doctype/docfield/docfield.py
+++ b/frappe/core/doctype/docfield/docfield.py
@@ -100,6 +100,7 @@ class DocField(Document):
 		parentfield: DF.Data
 		parenttype: DF.Data
 		permlevel: DF.Int
+		placeholder: DF.Data | None
 		precision: DF.Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
 		print_hide: DF.Check
 		print_hide_if_no_value: DF.Check

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -11,6 +11,7 @@
   "dt",
   "module",
   "label",
+  "placeholder",
   "label_help",
   "fieldname",
   "insert_after",
@@ -460,13 +461,18 @@
    "fieldname": "show_dashboard",
    "fieldtype": "Check",
    "label": "Show Dashboard"
+  },
+  {
+   "fieldname": "placeholder",
+   "fieldtype": "Data",
+   "label": "Placeholder"
   }
  ],
  "icon": "fa fa-glass",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-04-12 16:25:50.349736",
+ "modified": "2024-09-28 20:19:35.935720",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -101,6 +101,7 @@ class CustomField(Document):
 		non_negative: DF.Check
 		options: DF.SmallText | None
 		permlevel: DF.Int
+		placeholder: DF.Data | None
 		precision: DF.Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
 		print_hide: DF.Check
 		print_hide_if_no_value: DF.Check

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -793,6 +793,7 @@ docfield_properties = {
 	"hide_seconds": "Check",
 	"is_virtual": "Check",
 	"link_filters": "JSON",
+	"placeholder": "Data",
 }
 
 doctype_link_properties = {

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -59,6 +59,7 @@
   "hide_days",
   "column_break_21",
   "description",
+  "placeholder",
   "print_hide",
   "print_hide_if_no_value",
   "print_width",
@@ -478,13 +479,18 @@
    "fieldname": "link_filters",
    "fieldtype": "JSON",
    "label": "Link Filters"
+  },
+  {
+   "fieldname": "placeholder",
+   "fieldtype": "Data",
+   "label": "Placeholder"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-08-22 10:51:16.201589",
+ "modified": "2024-09-28 20:24:03.278884",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.py
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.py
@@ -96,6 +96,7 @@ class CustomizeFormField(Document):
 		parentfield: DF.Data
 		parenttype: DF.Data
 		permlevel: DF.Int
+		placeholder: DF.Data | None
 		precision: DF.Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
 		print_hide: DF.Check
 		print_hide_if_no_value: DF.Check


### PR DESCRIPTION
Currently, there is no **placeholder** in form fields. Now with this feature you will be able to add **placeholder** to form fields

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/17c61940-9965-432e-81ab-ebff2abee056">

<img width="1437" alt="image" src="https://github.com/user-attachments/assets/d2ab5a00-1bb3-4e98-8c10-8128206941e5">


>no-docs