### PR TITLE
feat: flow tracing

### DIFF
--- a/frappe/automation/workspace/tools/tools.json
+++ b/frappe/automation/workspace/tools/tools.json
@@ -1,6 +1,7 @@
 {
+ "app": "frappe",
  "charts": [],
- "content": "[{\"id\":\"sR-UFcO7II\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Import Data\",\"col\":3}},{\"id\":\"IkcVmgWb3z\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"ToDo\",\"col\":3}},{\"id\":\"6wir-jZFRE\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"File\",\"col\":3}},{\"id\":\"45a1jzQkTm\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Assignment Rule\",\"col\":3}},{\"id\":\"EgtURZsoiF\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"0yceBIfhHM\",\"type\":\"card\",\"data\":{\"card_name\":\"Data\",\"col\":4}},{\"id\":\"42WbBA9rpj\",\"type\":\"card\",\"data\":{\"card_name\":\"Tools\",\"col\":4}},{\"id\":\"wE9n7TIrAc\",\"type\":\"card\",\"data\":{\"card_name\":\"Alerts and Notifications\",\"col\":4}},{\"id\":\"7_U7_xCOos\",\"type\":\"card\",\"data\":{\"card_name\":\"Email\",\"col\":4}},{\"id\":\"3imoh2oqsJ\",\"type\":\"card\",\"data\":{\"card_name\":\"Printing\",\"col\":4}},{\"id\":\"SlYKJZj5r3\",\"type\":\"card\",\"data\":{\"card_name\":\"Automation\",\"col\":4}},{\"id\":\"O7jrc2YQTN\",\"type\":\"card\",\"data\":{\"card_name\":\"Newsletter\",\"col\":4}}]",
+ "content": "[{\"id\":\"sR-UFcO7II\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Import Data\",\"col\":3}},{\"id\":\"IkcVmgWb3z\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"ToDo\",\"col\":3}},{\"id\":\"6wir-jZFRE\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"File\",\"col\":3}},{\"id\":\"45a1jzQkTm\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Assignment Rule\",\"col\":3}},{\"id\":\"EgtURZsoiF\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"0yceBIfhHM\",\"type\":\"card\",\"data\":{\"card_name\":\"Data\",\"col\":4}},{\"id\":\"42WbBA9rpj\",\"type\":\"card\",\"data\":{\"card_name\":\"Tools\",\"col\":4}},{\"id\":\"wE9n7TIrAc\",\"type\":\"card\",\"data\":{\"card_name\":\"Alerts and Notifications\",\"col\":4}},{\"id\":\"7_U7_xCOos\",\"type\":\"card\",\"data\":{\"card_name\":\"Email\",\"col\":4}},{\"id\":\"3imoh2oqsJ\",\"type\":\"card\",\"data\":{\"card_name\":\"Printing\",\"col\":4}},{\"id\":\"SlYKJZj5r3\",\"type\":\"card\",\"data\":{\"card_name\":\"Automation\",\"col\":4}},{\"id\":\"O7jrc2YQTN\",\"type\":\"card\",\"data\":{\"card_name\":\"Newsletter\",\"col\":4}},{\"id\":\"vjTBvMu1rU\",\"type\":\"card\",\"data\":{\"card_name\":\"Flows\",\"col\":4}}]",
  "creation": "2020-03-02 14:53:24.980279",
  "custom_blocks": [],
  "docstatus": 0,
@@ -320,9 +321,39 @@
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "description": "Organize transactions and automations into business flows and trace individual transactions.",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Flows",
+   "link_count": 2,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Business Flow",
+   "link_count": 0,
+   "link_to": "Business Flow",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Flow Tracer",
+   "link_count": 0,
+   "link_to": "Flow Tracer",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2024-09-03 21:54:05.403066",
+ "modified": "2024-09-30 20:11:32.244959",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Tools",
@@ -360,5 +391,6 @@
    "type": "DocType"
   }
  ],
- "title": "Tools"
+ "title": "Tools",
+ "type": "Workspace"
 }

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -162,7 +162,9 @@ def set_value(doctype, name, fieldname, value=None):
 	:param fieldname: fieldname string or JSON / dict with key value pair
 	:param value: value if fieldname is JSON / dict"""
 
-	if fieldname in (frappe.model.default_fields + frappe.model.child_table_fields):
+	if fieldname in (
+		frappe.model.default_fields + frappe.model.child_table_fields + frappe.model.tracer_fields
+	):
 		frappe.throw(_("Cannot edit standard fields"))
 
 	if not value:

--- a/frappe/core/doctype/business_flow/business_flow.js
+++ b/frappe/core/doctype/business_flow/business_flow.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Business Flow", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe/core/doctype/business_flow/business_flow.json
+++ b/frappe/core/doctype/business_flow/business_flow.json
@@ -1,0 +1,103 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:title",
+ "creation": "2024-09-30 17:42:05.900927",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "documentation_section",
+  "description",
+  "entrypoint_section",
+  "entrypoint_document",
+  "column_break_gubz",
+  "entrypoint_condition"
+ ],
+ "fields": [
+  {
+   "description": "Unless an override is forced in code, the system associates this flow with the <a href=\"/app/flow-tracer\"><i>Flow Tracer</i></a> during its creation and when the given condition is met on the entry point document.",
+   "fieldname": "entrypoint_section",
+   "fieldtype": "Section Break",
+   "label": "Entrypoint"
+  },
+  {
+   "fieldname": "entrypoint_document",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Document",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_gubz",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "entrypoint_condition",
+   "fieldtype": "Code",
+   "in_list_view": 1,
+   "label": "Condition",
+   "options": "Python",
+   "reqd": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "documentation_section",
+   "fieldtype": "Section Break",
+   "label": "Documentation"
+  },
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Markdown Editor"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [
+  {
+   "group": "Automation",
+   "link_doctype": "Server Script",
+   "link_fieldname": "business_flow"
+  },
+  {
+   "group": "Automation",
+   "link_doctype": "Notification",
+   "link_fieldname": "business_flow"
+  },
+  {
+   "group": "Automation",
+   "link_doctype": "Webhook",
+   "link_fieldname": "business_flow"
+  }
+ ],
+ "modified": "2024-09-30 20:11:51.627721",
+ "modified_by": "Administrator",
+ "module": "Core",
+ "name": "Business Flow",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/core/doctype/business_flow/business_flow.json
+++ b/frappe/core/doctype/business_flow/business_flow.json
@@ -2,6 +2,7 @@
  "actions": [],
  "allow_rename": 1,
  "autoname": "field:title",
+ "beta": 1,
  "creation": "2024-09-30 17:42:05.900927",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -77,7 +78,7 @@
    "link_fieldname": "business_flow"
   }
  ],
- "modified": "2024-09-30 20:11:51.627721",
+ "modified": "2024-10-01 01:05:29.571150",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Business Flow",

--- a/frappe/core/doctype/business_flow/business_flow.py
+++ b/frappe/core/doctype/business_flow/business_flow.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class BusinessFlow(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		description: DF.MarkdownEditor | None
+		entrypoint_condition: DF.Code
+		entrypoint_document: DF.Link
+		title: DF.Data
+	# end: auto-generated types
+
+	pass

--- a/frappe/core/doctype/business_flow/test_business_flow.py
+++ b/frappe/core/doctype/business_flow/test_business_flow.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBusinessFlow(FrappeTestCase):
+	pass

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -35,6 +35,7 @@
   "track_changes",
   "track_seen",
   "track_views",
+  "trace_flow",
   "custom",
   "beta",
   "is_virtual",
@@ -672,6 +673,14 @@
    "fieldname": "fields_tab",
    "fieldtype": "Tab Break",
    "label": "Fields"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.istable && !doc.issingle",
+   "description": "If enabled, and this document is traced across an end-to-end business flow.",
+   "fieldname": "trace_flow",
+   "fieldtype": "Check",
+   "label": "Trace Flow"
   }
  ],
  "icon": "fa fa-bolt",
@@ -754,7 +763,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2024-08-14 17:04:47.278892",
+ "modified": "2024-09-30 21:24:18.185989",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -170,6 +170,7 @@ class DocType(Document):
 		subject_field: DF.Data | None
 		timeline_field: DF.Data | None
 		title_field: DF.Data | None
+		trace_flow: DF.Check
 		track_changes: DF.Check
 		track_seen: DF.Check
 		track_views: DF.Check
@@ -209,6 +210,7 @@ class DocType(Document):
 		self.make_repeatable()
 		self.validate_nestedset()
 		self.validate_child_table()
+		self.validate_trace_flow()
 		self.validate_website()
 		self.validate_virtual_doctype_methods()
 		self.ensure_minimum_max_attachment_limit()
@@ -1004,6 +1006,17 @@ class DocType(Document):
 		add_column(self.name, "parent", "Data")
 		add_column(self.name, "parenttype", "Data")
 		add_column(self.name, "parentfield", "Data")
+
+	def validate_trace_flow(self):
+		if not self.get("trace_flow") or self.get("is_virtual"):
+			return
+
+		self.add_trace_fields()
+
+	def add_trace_fields(self):
+		from frappe.database.schema import add_column
+
+		add_column(self.name, "tracer", "Link")
 
 	def get_max_idx(self):
 		"""Return the highest `idx`."""

--- a/frappe/core/doctype/flow_tracer/flow_tracer.js
+++ b/frappe/core/doctype/flow_tracer/flow_tracer.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Flow Tracer", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe/core/doctype/flow_tracer/flow_tracer.json
+++ b/frappe/core/doctype/flow_tracer/flow_tracer.json
@@ -1,0 +1,56 @@
+{
+ "actions": [],
+ "autoname": "UUID",
+ "creation": "2024-09-30 17:47:38.915440",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "business_flow",
+  "column_break_dfrq",
+  "merged_into"
+ ],
+ "fields": [
+  {
+   "fieldname": "business_flow",
+   "fieldtype": "Link",
+   "label": "Business Flow",
+   "options": "Business Flow"
+  },
+  {
+   "fieldname": "column_break_dfrq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "merged_into",
+   "fieldtype": "Link",
+   "label": "Merged Into",
+   "options": "Flow Tracer"
+  }
+ ],
+ "in_create": 1,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-09-30 20:32:19.980832",
+ "modified_by": "Administrator",
+ "module": "Core",
+ "name": "Flow Tracer",
+ "naming_rule": "UUID",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/core/doctype/flow_tracer/flow_tracer.py
+++ b/frappe/core/doctype/flow_tracer/flow_tracer.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2024, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class FlowTracer(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		business_flow: DF.Link | None
+		merged_into: DF.Link | None
+	# end: auto-generated types
+
+	pass

--- a/frappe/core/doctype/flow_tracer/test_flow_tracer.py
+++ b/frappe/core/doctype/flow_tracer/test_flow_tracer.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestFlowTracer(FrappeTestCase):
+	pass

--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -14,6 +14,7 @@
   "api_method",
   "allow_guest",
   "column_break_3",
+  "business_flow",
   "module",
   "disabled",
   "section_break_8",
@@ -142,6 +143,13 @@
    "fieldname": "cron_format",
    "fieldtype": "Data",
    "label": "Cron Format"
+  },
+  {
+   "description": "In which this server script participates.",
+   "fieldname": "business_flow",
+   "fieldtype": "Link",
+   "label": "Business Flow",
+   "options": "Business Flow"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -151,7 +159,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2024-05-08 03:21:54.169380",
+ "modified": "2024-09-30 17:54:27.652902",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -32,6 +32,7 @@ class ServerScript(Document):
 
 		allow_guest: DF.Check
 		api_method: DF.Data | None
+		business_flow: DF.Link | None
 		cron_format: DF.Data | None
 		disabled: DF.Check
 		doctype_event: DF.Literal[

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -12,7 +12,13 @@ import frappe
 import frappe.permissions
 from frappe import _
 from frappe.core.doctype.access_log.access_log import make_access_log
-from frappe.model import child_table_fields, default_fields, get_permitted_fields, optional_fields
+from frappe.model import (
+	child_table_fields,
+	default_fields,
+	get_permitted_fields,
+	optional_fields,
+	tracer_fields,
+)
 from frappe.model.base_document import get_controller
 from frappe.model.db_query import DatabaseQuery
 from frappe.model.utils import is_virtual_doctype
@@ -185,7 +191,12 @@ def raise_invalid_field(fieldname):
 def is_standard(fieldname):
 	if "." in fieldname:
 		fieldname = fieldname.split(".")[1].strip("`")
-	return fieldname in default_fields or fieldname in optional_fields or fieldname in child_table_fields
+	return (
+		fieldname in default_fields
+		or fieldname in optional_fields
+		or fieldname in child_table_fields
+		or fieldname in tracer_fields
+	)
 
 
 @lru_cache

--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -8,6 +8,7 @@
  "engine": "InnoDB",
  "field_order": [
   "enabled",
+  "business_flow",
   "is_standard",
   "module",
   "column_break_2",
@@ -311,12 +312,19 @@
    "fieldtype": "Datetime",
    "label": "Last Run",
    "read_only": 1
+  },
+  {
+   "description": "In which this notification participates.",
+   "fieldname": "business_flow",
+   "fieldtype": "Link",
+   "label": "Business Flow",
+   "options": "Business Flow"
   }
  ],
  "icon": "fa fa-envelope",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-12 10:28:35.077180",
+ "modified": "2024-09-30 17:56:05.339425",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -34,6 +34,7 @@ class Notification(Document):
 		from frappe.types import DF
 
 		attach_print: DF.Check
+		business_flow: DF.Link | None
 		channel: DF.Literal["Email", "Slack", "System Notification", "SMS"]
 		condition: DF.Code | None
 		date_changed: DF.Literal[None]

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -8,6 +8,7 @@
  "field_order": [
   "sb_doc_events",
   "webhook_doctype",
+  "business_flow",
   "cb_doc_events",
   "webhook_docevent",
   "enabled",
@@ -181,6 +182,12 @@
    "fieldname": "background_jobs_queue",
    "fieldtype": "Autocomplete",
    "label": "Background Jobs Queue"
+  },
+  {
+   "fieldname": "business_flow",
+   "fieldtype": "Link",
+   "label": "Business Flow",
+   "options": "Business Flow"
   }
  ],
  "links": [
@@ -189,7 +196,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2024-07-22 09:23:32.642172",
+ "modified": "2024-09-30 18:05:36.093870",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -32,6 +32,7 @@ class Webhook(Document):
 		from frappe.types import DF
 
 		background_jobs_queue: DF.Autocomplete | None
+		business_flow: DF.Link | None
 		condition: DF.SmallText | None
 		enable_security: DF.Check
 		enabled: DF.Check

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -89,6 +89,8 @@ default_fields = (
 	"idx",
 )
 
+tracer_fields = ("tracer",)
+
 child_table_fields = ("parent", "parentfield", "parenttype")
 
 optional_fields = ("_user_tags", "_comments", "_assign", "_liked_by", "_seen")
@@ -114,6 +116,7 @@ core_doctypes_list = (
 	"Property Setter",
 	"Custom Field",
 	"Client Script",
+	"Flow Tracer",
 )
 
 log_types = (
@@ -149,6 +152,7 @@ std_fields = [
 	{"fieldname": "_liked_by", "fieldtype": "Data", "label": "Liked By"},
 	{"fieldname": "_comments", "fieldtype": "Text", "label": "Comments"},
 	{"fieldname": "_assign", "fieldtype": "Text", "label": "Assigned To"},
+	{"fieldname": "tracer", "fieldtype": "Link", "label": "Flow Tracer", "options": "Flow Tracer"},
 	{"fieldname": "docstatus", "fieldtype": "Int", "label": "Document Status"},
 ]
 
@@ -224,14 +228,14 @@ def get_permitted_fields(
 		return valid_columns
 
 	# DocType has only fields of type Table (Table, Table MultiSelect)
-	if set(valid_columns).issubset(default_fields):
+	if set(valid_columns).issubset(default_fields + tracer_fields):
 		return valid_columns
 
 	if permission_type is None:
 		permission_type = "select" if frappe.only_has_select_perm(doctype, user=user) else "read"
 
 	meta_fields = meta.default_fields.copy()
-	optional_meta_fields = [x for x in optional_fields if x in valid_columns]
+	optional_meta_fields = [x for x in (*optional_fields, *tracer_fields) if x in valid_columns]
 
 	if permitted_fields := meta.get_permitted_fieldnames(
 		parenttype=parenttype,

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -16,6 +16,7 @@ from frappe.model import (
 	float_like_fields,
 	get_permitted_fields,
 	table_fields,
+	tracer_fields,
 )
 from frappe.model.docstatus import DocStatus
 from frappe.model.naming import set_new_name
@@ -488,6 +489,7 @@ class BaseDocument:
 		self,
 		no_nulls=False,
 		no_default_fields=False,
+		no_tracer_fields=False,
 		convert_dates_to_str=False,
 		no_child_table_fields=False,
 		no_private_properties=False,
@@ -510,6 +512,11 @@ class BaseDocument:
 
 		if no_default_fields:
 			for key in default_fields:
+				if key in doc:
+					del doc[key]
+
+		if no_tracer_fields:
+			for key in tracer_fields:
 				if key in doc:
 					del doc[key]
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -350,6 +350,7 @@ class Document(BaseDocument):
 		self.run_before_save_methods()
 		self._validate()
 		self.set_docstatus()
+		self.set_tracer()
 		self.flags.in_insert = False
 
 		# run validate, on update etc.
@@ -642,6 +643,17 @@ class Document(BaseDocument):
 
 		for d in self.get_all_children():
 			d.docstatus = self.docstatus
+
+	def set_tracer(self):
+		if (
+			getattr(self.meta, "trace_flow", False)
+			and not getattr(self.meta, "issingle", False)
+			and self.is_new()
+			and self.tracer is None
+		):
+			tracer = frappe.new_doc("Flow Tracer")
+			tracer.db_insert()
+			self.tracer = tracer.name
 
 	def _validate(self):
 		self._validate_mandatory()

--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -4,7 +4,7 @@ import json
 
 import frappe
 from frappe import _
-from frappe.model import child_table_fields, default_fields, table_fields
+from frappe.model import child_table_fields, default_fields, table_fields, tracer_fields
 from frappe.utils import cstr
 
 
@@ -199,7 +199,7 @@ def map_fields(source_doc, target_doc, table_map, source_parent):
 			for d in source_doc.meta.get("fields")
 			if (d.no_copy == 1 or d.fieldtype in table_fields)
 		]
-		+ [d.fieldname for d in target_doc.meta.get("fields") if (d.fieldtype in table_fields)]
+		+ (list(tracer_fields) if not target_doc.meta.get("trace_flow") else [])
 		+ list(default_fields)
 		+ list(child_table_fields)
 		+ list(table_map.get("field_no_map", []))

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -31,6 +31,7 @@ from frappe.model import (
 	no_value_fields,
 	optional_fields,
 	table_fields,
+	tracer_fields,
 )
 from frappe.model.base_document import (
 	DOCTYPE_TABLE_FIELDS,
@@ -50,6 +51,7 @@ DEFAULT_FIELD_LABELS = {
 	"modified": _lt("Last Updated On"),
 	"modified_by": _lt("Last Updated By"),
 	"owner": _lt("Created By"),
+	"tracer": _lt("Flow Tracer"),
 	"_user_tags": _lt("Tags"),
 	"_liked_by": _lt("Liked By"),
 	"_comments": _lt("Comments"),
@@ -110,6 +112,7 @@ class Meta(Document):
 	standard_set_once_fields = (
 		frappe._dict(fieldname="creation", fieldtype="Datetime"),
 		frappe._dict(fieldname="owner", fieldtype="Data"),
+		frappe._dict(fieldname="tracer", fieldtype="Link"),
 	)
 
 	def __init__(self, doctype):
@@ -228,6 +231,8 @@ class Meta(Document):
 				]
 				if self.istable:
 					self._valid_columns += list(child_table_fields)
+				if self.trace_flow:
+					self._valid_columns += list(tracer_fields)
 
 		return self._valid_columns
 
@@ -241,6 +246,8 @@ class Meta(Document):
 				]
 				if self.istable:
 					self._valid_fields += list(child_table_fields)
+				if self.trace_flow:
+					self._valid_fields += list(tracer_fields)
 
 		return self._valid_fields
 

--- a/frappe/model/utils/__init__.py
+++ b/frappe/model/utils/__init__.py
@@ -19,6 +19,7 @@ STANDARD_FIELD_CONVERSION_MAP = {
 	"_comments": "Text",
 	"_assign": "Text",
 	"docstatus": "Int",
+	"tracer": "Data",
 }
 INCLUDE_DIRECTIVE_PATTERN = re.compile(r"""{% include\s['"](.*)['"]\s%}""")
 

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -37,6 +37,7 @@ frappe.ui.form.Sidebar = class {
 		this.show_auto_repeat_status();
 		this.show_error_log_status();
 		this.show_webhook_request_log_status();
+		this.show_flow_trace_status();
 		frappe.ui.form.setup_user_image_event(this.frm);
 
 		this.refresh();
@@ -184,6 +185,17 @@ frappe.ui.form.Sidebar = class {
 					reference_doctype: this.frm.doc.doctype,
 					reference_document: this.frm.doc.name,
 				});
+			});
+		}
+	}
+
+	show_flow_trace_status() {
+		if (this.frm.doc.tracer) {
+			let el = this.sidebar.find(".flow-trace-status");
+			el.closest(".sidebar-section").removeClass("hidden");
+			el.show();
+			el.on("click", () => {
+				frappe.set_route("Form", "Flow Tracer", this.frm.doc.tracer);
 			});
 		}
 	}

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -138,6 +138,7 @@
 <div class="sidebar-section hidden">
 	<a><li class="indicator red blink error-log-status" style="display: none;">{%= __("Error Logs") %}</li></a>
 	<a><li class="indicator yellow webhook-request-log-status" style="display: none;">{%= __("Webhook Logs") %}</li></a>
+	<a><li class="indicator grey flow-trace-status" style="display: none;">{%= __("Trace Flow") %}</li></a>
 	<a><li class="indicator blue auto-repeat-status" style="display: none;"></li></a>
 </div>
 <div class="sidebar-section text-muted">

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -73,6 +73,7 @@ $.extend(frappe.model, {
 		"_liked_by",
 		"docstatus",
 		"idx",
+		"tracer",
 	],
 
 	child_table_field_list: ["parent", "parenttype", "parentfield"],
@@ -93,6 +94,7 @@ $.extend(frappe.model, {
 		"Property Setter",
 		"Custom Field",
 		"Client Script",
+		"Flow Tracer",
 	],
 
 	restricted_fields: [
@@ -106,6 +108,7 @@ $.extend(frappe.model, {
 		"file_list",
 		"flags",
 		"docstatus",
+		"tracer",
 	],
 
 	html_fieldtypes: [
@@ -134,6 +137,12 @@ $.extend(frappe.model, {
 		{ fieldname: "_liked_by", fieldtype: "Data", label: __("Liked By") },
 		{ fieldname: "_comments", fieldtype: "Text", label: __("Comments") },
 		{ fieldname: "_assign", fieldtype: "Text", label: __("Assigned To") },
+		{
+			fieldname: "tracer",
+			fieldtype: "Link",
+			label: __("Flow Tracer"),
+			option: "Flow Tracer",
+		},
 		{ fieldname: "docstatus", fieldtype: "Int", label: __("Document Status") },
 	],
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2013,7 +2013,7 @@ def get_filter(doctype: str, f: dict | list | tuple, filters_config=None) -> "fr
 	}
 	"""
 	from frappe.database.utils import NestedSetHierarchy
-	from frappe.model import child_table_fields, default_fields, optional_fields
+	from frappe.model import child_table_fields, default_fields, optional_fields, tracer_fields
 
 	if isinstance(f, dict):
 		key, value = next(iter(f.items()))
@@ -2065,7 +2065,9 @@ def get_filter(doctype: str, f: dict | list | tuple, filters_config=None) -> "fr
 	if f.operator.lower() not in valid_operators:
 		frappe.throw(frappe._("Operator must be one of {0}").format(", ".join(valid_operators)))
 
-	if f.doctype and (f.fieldname not in default_fields + optional_fields + child_table_fields):
+	if f.doctype and (
+		f.fieldname not in default_fields + optional_fields + child_table_fields + tracer_fields
+	):
 		# verify fieldname belongs to the doctype
 		meta = frappe.get_meta(f.doctype)
 		if not meta.has_field(f.fieldname):


### PR DESCRIPTION
###### This is Work In Progress
###### This is marked as Beta

## Add Business Flow and Flow Tracing functionality

### Motivation

This PR introduces a new "Business Flow" feature to Frappe, allowing users to organize transactions and automations into coherent business processes. The motivation behind this addition is to provide better visibility and traceability for complex business operations that span multiple documents and automated actions.

By implementing Business Flows and Flow Tracing, we aim to:

1. Improve transparency in business processes
2. Enhance debugging capabilities for complex workflows
3. Provide a structured way to document and manage end-to-end business operations
4. Enable easier auditing and compliance tracking

### Changes

This PR includes the following key changes:

1. New DocType: "Business Flow"
   - Allows defining entry points for business flows
   - Links to related automations (Server Scripts, Notifications, Webhooks) - "meta associations"
   - [ ] New applicability condition via this meta association on Scripts, Notifications, Webhooks (additive and preemptive to python condition)
   - [ ] Links flow instances (Flow Tracer) - "instance associations"

2. New DocType: "Flow Tracer"
   - Represents a process token (equivalent to a the idea of a"BPMN Execution Token")

3. [ ] New DocType: "Flow Tracer Event Log" &mdash; **maybe not; see: https://github.com/frappe/frappe/pull/27944#issuecomment-2385533141**
   - [ ] Records a an event log for export to https://xes-standard.org/ and ingestion in Process Mining tools \*
     <sup>\* https://processintelligence.solutions/static/api/2.7.11/api.html</sup>
   - [ ] New `emit_flow_trace_event` Document function for data collection

4. Updates to existing DocTypes:
   - Added "Trace Flow" option to DocType settings
   - New "Flows" card in the Tools workspace

5. Core updates:
   - Modified `insert` function to handle new tracer fields
     - [ ] Implement Business Flow association based on entry point & condition
   - Added flow tracing fields as a list of special fields with special semantics
   - Added flow tracing fields to mapped fields if target DocType also has flow tracing enabled
   - [ ] Added flow tracing inference on `reference_{doctype,name}` fields
     - [ ] Converge nomenclature
     - [ ] Nudging in the DocType / Customize Form view
   - [ ] Added Flow Tracer merging; maybe requires permeation of https://github.com/frappe/frappe/pull/26991 for reaching stability

6. UI enhancements:
   - New "Flows" section in the Tools workspace for easy access to Business Flow and Flow Tracer
   - New "Trace Flow" link in the Form Sidebar
   - [ ] New "Flow Tracing" view section on the Flow Tracer form as the primary auditing tool
   - [ ] Stats section on the "Flow Tracer" Form
   - [ ] New "Live"-BPMN Instance visualizer on "Flow Tracer", if associated Business Flow has BPMN attached \*
   - [ ] New "Live" BPMN Overview visualized on "Business Flow", if it has BMPN attached \*

\* Using: https://dev.to/process-analytics/getting-started-with-bpmn-visualization-3dno

### TBD: Testing

- Manual testing of flow creation and association with documents is recommended

### Notes

- This feature is currently in beta and marked as such in the DocType definition
- Further documentation and user guides will be needed to fully explain the functionality and best practices for using Business Flows
