### PR TITLE
feat: add read only document mode

### DIFF
--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -11,6 +11,12 @@ class SiteNotSpecifiedError(Exception):
 		super(Exception, self).__init__(self.message)
 
 
+class DatabaseModificationError(Exception):
+	"""Error raised when attempting to modify the database in a read-only document context."""
+
+	pass
+
+
 class UrlSchemeNotSupported(Exception):
 	pass
 

--- a/frappe/tests/test_document_ro_mode.py
+++ b/frappe/tests/test_document_ro_mode.py
@@ -1,0 +1,191 @@
+import unittest
+from contextlib import contextmanager
+
+import frappe
+from frappe.model.document import Document, read_only_document
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestReadOnlyDocument(FrappeTestCase):
+	def setUp(self):
+		# Create a test document
+		self.test_doc = frappe.get_doc({"doctype": "ToDo", "description": "Test ToDo"})
+		self.test_doc.insert()
+
+	def tearDown(self):
+		# Delete the test document
+		frappe.delete_doc("ToDo", self.test_doc.name)
+
+	def test_read_only_save(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.save()
+
+	def test_read_only_insert(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				frappe.get_doc({"doctype": "ToDo", "description": "Another Test ToDo"}).insert()
+
+	def test_read_only_delete(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.delete()
+
+	def test_read_only_submit(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.submit()
+
+	def test_read_only_cancel(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.cancel()
+
+	def test_read_only_db_set(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.db_set("status", "Closed")
+
+	def test_read_only_nested_calls(self):
+		def nested_save():
+			self.test_doc.save()
+
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				nested_save()
+
+	def test_read_only_context_manager_restoration(self):
+		original_save = Document.save
+
+		with read_only_document():
+			self.assertNotEqual(Document.save, original_save)
+
+		self.assertEqual(Document.save, original_save)
+
+	def test_nested_read_only_document(self):
+		# Check that read_only_depth is not set initially
+		self.assertFalse(hasattr(frappe.local, "read_only_depth"))
+
+		with read_only_document():
+			# Check that read_only_depth is set to 1
+			self.assertEqual(frappe.local.read_only_depth, 1)
+
+			# Attempt to modify the document
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.description = "Modified in outer context"
+				self.test_doc.save()
+
+			with read_only_document():
+				# Check that read_only_depth is incremented to 2
+				self.assertEqual(frappe.local.read_only_depth, 2)
+
+				# Attempt to modify the document in nested context
+				with self.assertRaises(frappe.DatabaseModificationError):
+					self.test_doc.description = "Modified in inner context"
+					self.test_doc.save()
+
+			# Check that read_only_depth is back to 1 after nested context
+			self.assertEqual(frappe.local.read_only_depth, 1)
+
+			# Attempt to modify the document again
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.description = "Modified after inner context"
+				self.test_doc.save()
+
+		# Check that read_only_depth is removed after all contexts are closed
+		self.assertFalse(hasattr(frappe.local, "read_only_depth"))
+
+		# Verify that document can be modified outside read_only_document
+		self.test_doc.description = "Modified outside read_only_document"
+		self.test_doc.save()
+		self.assertEqual(self.test_doc.description, "Modified outside read_only_document")
+
+	def test_error_log_exception_in_read_only(self):
+		with read_only_document():
+			# Attempt to insert an Error Log
+			error_log = frappe.get_doc({"doctype": "Error Log", "error": "Test error in read-only mode"})
+
+			# This should not raise an exception
+			error_log.insert()
+
+			# Verify that the Error Log was inserted
+			self.assertTrue(error_log.name)
+
+			# Attempt to modify a different document
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.description = "Modified in read-only mode"
+				self.test_doc.save()
+
+		# Clean up the inserted Error Log
+		frappe.delete_doc("Error Log", error_log.name)
+
+	def test_read_only_multiple_documents(self):
+		doc1 = frappe.get_doc({"doctype": "ToDo", "description": "Test ToDo 1"})
+		doc2 = frappe.get_doc({"doctype": "ToDo", "description": "Test ToDo 2"})
+
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				doc1.insert()
+			with self.assertRaises(frappe.DatabaseModificationError):
+				doc2.insert()
+
+	def test_read_only_custom_method(self):
+		class CustomDocument(Document):
+			def custom_save(self):
+				self.save()
+
+		custom_doc = CustomDocument({"doctype": "ToDo", "description": "Custom Test ToDo"})
+
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				custom_doc.custom_save()
+
+	def test_read_only_exception_handling(self):
+		@contextmanager
+		def exception_raiser():
+			raise Exception("Test exception")
+			yield
+
+		try:
+			with read_only_document(), exception_raiser():
+				pass
+		except Exception:
+			pass
+
+		# Ensure methods are restored even if an exception occurs
+		self.assertEqual(Document.save, self.test_doc.__class__.save)
+
+	def test_read_only_nested_context_managers(self):
+		original_save = Document.save
+
+		with read_only_document():
+			self.assertNotEqual(Document.save, original_save)
+
+			with read_only_document():
+				self.assertNotEqual(Document.save, original_save)
+
+			self.assertNotEqual(Document.save, original_save)
+
+		self.assertEqual(Document.save, original_save)
+
+	def test_read_only_method_call_details(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError) as cm:
+				self.test_doc.save()
+
+			self.assertIn("Cannot call save in read-only document mode", str(cm.exception))
+
+	def test_read_only_does_not_affect_reads(self):
+		with read_only_document():
+			# These operations should not raise exceptions
+			doc = frappe.get_doc("ToDo", self.test_doc.name)
+			self.assertEqual(doc.description, "Test ToDo")
+
+			docs = frappe.get_all("ToDo", filters={"name": self.test_doc.name})
+			self.assertEqual(len(docs), 1)
+
+	def test_read_only_with_new_document_instance(self):
+		with read_only_document():
+			new_doc = frappe.new_doc("ToDo")
+			with self.assertRaises(frappe.DatabaseModificationError):
+				new_doc.insert()


### PR DESCRIPTION
## Description & motivation

This PR introduces a read-only mode for documents in Frappe, aiming to improve code quality, maintainability, and enforce better separation of concerns in the document lifecycle. The changes include:

1. Adding a `read_only_document` context manager to temporarily disable database modification methods on Document objects.
2. Introducing a new `DatabaseModificationError` exception for read-only violations.
3. Implementing comprehensive test cases to ensure the functionality works as expected.

The primary motivations for these changes are:

1. To place mappings from one doctype to another in read-only mode, simplifying maintenance and improving code quality. This will prevent unintended modifications to critical data relationships.

2. To restrict the database operations in certain document APIs, in order to improve performance and encourage lazy and final "flushing" to the database. For example, the `self.validate()` may not have a vested and defendable case for allowing database writes.

3. To force downstream code to clean up and refactor existing code smells and state loops spread throughout the codebase. By enforcing stricter rules on when and how document modifications can occur, we encourage better coding practices and more modular design.

These changes will lead to more robust and maintainable code, reducing the likelihood of bugs caused by unexpected state changes and improving the overall quality of the Frappe framework.

## Migration
If you need this paragraph, please refer to https://github.com/frappe/erpnext/pull/43301/files

## To-do before merge

- [x] Consider adding migration guides for downstream code that may be affected by these changes
- [x] Perform thorough testing in a staging environment to ensure no unintended side effects (running in production for a couple of months now)

## Validation of models

- All existing tests pass
- New test cases have been added to cover the read-only functionality

## Changes to existing models

- Added `DatabaseModificationError` to `frappe/exceptions.py`
- Modified `frappe/model/document.py` to include the `read_only_document` context manager
- Added new test file `frappe/tests/test_document_ro_mode.py`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
