### PR TITLE
feat: lazy documents in jinja

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1035,6 +1035,7 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 	:param doctype: If doctype is given, only DocType cache is cleared."""
 	import frappe.cache_manager
 	import frappe.utils.caching
+	from frappe.model.document import DocumentProxy
 	from frappe.website.router import clear_routing_cache
 
 	if doctype:
@@ -1057,6 +1058,7 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 			get_attr(fn)()
 
 	frappe.utils.caching._SITE_CACHE.clear()
+	DocumentProxy._get_fields.cache_clear()
 	local.role_permissions = {}
 	if hasattr(local, "request_cache"):
 		local.request_cache.clear()

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1058,7 +1058,8 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 			get_attr(fn)()
 
 	frappe.utils.caching._SITE_CACHE.clear()
-	DocumentProxy._get_fields.cache_clear()
+	DocumentProxy._fields_cache.clear()
+	DocumentProxy._values_cache.clear()
 	local.role_permissions = {}
 	if hasattr(local, "request_cache"):
 		local.request_cache.clear()

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1035,7 +1035,6 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 	:param doctype: If doctype is given, only DocType cache is cleared."""
 	import frappe.cache_manager
 	import frappe.utils.caching
-	from frappe.model.document import DocumentProxy
 	from frappe.website.router import clear_routing_cache
 
 	if doctype:
@@ -1058,8 +1057,6 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 			get_attr(fn)()
 
 	frappe.utils.caching._SITE_CACHE.clear()
-	DocumentProxy._fields_cache.clear()
-	DocumentProxy._values_cache.clear()
 	local.role_permissions = {}
 	if hasattr(local, "request_cache"):
 		local.request_cache.clear()

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -221,10 +221,14 @@ class DocumentProxy(DocRef):
 		return key in self._fieldnames
 
 	def __repr__(self):
-		return f"{self.__class__.__name__}({self.doctype}, {self.name})"
+		return f"<{self.__class__.__name__}: doctype={self.doctype} name={self.name or 'n/a'}>"
 
 	def __str__(self):
-		return self.name or self.__repr__()
+		# we explictly deviate from the DocRef stringer as
+		# we need to render the value in jinja environments
+		# in caes of no value and the user not guarding the snippet against it,
+		# we want to "soft error" by printing the full object representation
+		return self.__value__() or self.__repr__()
 
 	def __bool__(self):
 		return bool(self.name)
@@ -246,10 +250,10 @@ class DocumentProxyList:
 		return len(self.values)
 
 	def __str__(self):
-		return f"{self.__class__.__name__}({self.doctype}, {len(self)} items)"
+		return f"{self.doctype}, {len(self)} items"
 
 	def __repr__(self):
-		return self.__str__()
+		return f"<{self.__class__.__name__}: {self.doctype} {len(self)} items>"
 
 
 class Document(BaseDocument, DocRef):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -5,7 +5,7 @@ import json
 import time
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
-from functools import singledispatchmethod, wraps
+from functools import cache, singledispatchmethod, wraps
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, Union, overload
 
@@ -160,6 +160,96 @@ def read_only_document(context=None):
 
 			# Clean up the thread-local variable
 			del frappe.local.read_only_depth
+
+
+class DocumentProxy(DocRef):
+	def __init__(self, doctype, name):
+		super().__init__(doctype, name)
+		self._doc = None
+
+	@classmethod
+	@cache
+	def _get_fields(cls, doctype):
+		from frappe.model import data_fieldtypes, default_fields, table_fields
+		from frappe.model.meta import get_default_df
+
+		meta = frappe.get_meta(doctype)
+
+		return {
+			# all meta fields with values
+			f.fieldname: f
+			for f in meta.fields
+			if f.fieldtype in (*data_fieldtypes, *table_fields)
+		} | {
+			# all default fields
+			f.fieldname: f
+			for f in (get_default_df(n) for n in default_fields)
+		}
+
+	@property
+	def _fieldnames(self):
+		return self._get_fields(self.doctype).keys()
+
+	def _fields(self, fieldname):
+		return self._get_fields(self.doctype)[fieldname]
+
+	def __getattr__(self, attr):
+		if attr in self._fieldnames:
+			value = None
+			if self.name:
+				if self._doc is None:
+					self._doc = frappe.get_doc(self.doctype, self.name)
+				value = self._doc.get(attr)
+			field = self._fields(attr)
+			if field.fieldtype == "Link":
+				linked_doctype = field.options
+				return DocumentProxy(linked_doctype, value)
+			if field.fieldtype == "Dynamic Link":
+				linked_doctype = self._doc.get(field.options)
+				return DocumentProxy(linked_doctype, value)
+			if field.fieldtype in ("Table", "Table MultiSelect"):
+				linked_doctype = field.options
+				return DocumentProxyList(linked_doctype, value)
+
+			return value
+		raise AttributeError(f"'{self.doctype}' object proxy has no attribute '{attr}'")
+
+	def __getitem__(self, key):
+		return self.__getattr__(key)
+
+	def __contains__(self, key):
+		return key in self._fieldnames
+
+	def __repr__(self):
+		return f"{self.__class__.__name__}({self.doctype}, {self.name})"
+
+	def __str__(self):
+		return self.name or self.__repr__()
+
+	def __bool__(self):
+		return bool(self.name)
+
+
+class DocumentProxyList:
+	def __init__(self, doctype, values):
+		self.doctype = doctype
+		self.values = values
+
+	def __iter__(self):
+		for value in self.values:
+			yield DocumentProxy(self.doctype, value.name)
+
+	def __getitem__(self, index):
+		return DocumentProxy(self.doctype, self.values[index].name)
+
+	def __len__(self):
+		return len(self.values)
+
+	def __str__(self):
+		return f"{self.__class__.__name__}({self.doctype}, {len(self)} items)"
+
+	def __repr__(self):
+		return self.__str__()
 
 
 class Document(BaseDocument, DocRef):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -78,7 +78,10 @@ def _basedoc(doc: BaseDocument, *args, **kwargs) -> "Document":
 
 
 @get_doc.register(DocRef)
-def _docref(doc_ref: DocRef, **kwargs) -> "Document":
+def _docref(doc_ref: DocRef, *args, **kwargs) -> "Document":
+	if args:
+		# compat with frappe.get_doc(d.ref_doctype, d.ref_docname)
+		return _docref(args[0], **kwargs)
 	return get_doc(doc_ref.doctype, doc_ref.name, **kwargs)
 
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -213,7 +213,8 @@ class DocumentProxy(DocRef):
 				return DocumentProxyList(linked_doctype, [v.name for v in value], self)
 
 			return value
-		raise AttributeError(f"'{self.doctype}' object proxy has no attribute '{attr}'")
+		else:
+			return getattr(self._doc, attr, None)
 
 	def __getitem__(self, key):
 		return self.__getattr__(key)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -166,9 +166,9 @@ def read_only_document(context=None):
 
 
 class DocumentProxy(DocRef):
-	def __init__(self, doctype, name, parent=None):
+	def __init__(self, doctype, name, parent=None, doc=None):
 		super().__init__(doctype, name)
-		self._doc = None
+		self.__dict__["_doc"] = doc
 		self._super = parent or self
 
 	@classmethod
@@ -191,6 +191,20 @@ class DocumentProxy(DocRef):
 		}
 
 	@property
+	def _doc(self):
+		if self.__dict__["_doc"] is None:
+			# print("Last 3 frames of the traceback:")
+			# import traceback
+
+			# for frame in traceback.extract_stack()[-4:-1]:  # Get the last 3 frames, excluding this line
+			# 	filename, line_number, function_name, text = frame
+			# 	print(f"  File '{filename}', line {line_number}, in {function_name}")
+			# 	if text:
+			# 		print(f"    {text.strip()}")
+			self.__dict__["_doc"] = frappe.get_doc(self.doctype, self.name)
+		return self.__dict__["_doc"]
+
+	@property
 	def _fieldnames(self):
 		return self._get_fields(self.doctype).keys()
 
@@ -201,8 +215,6 @@ class DocumentProxy(DocRef):
 		if attr in self._fieldnames:
 			value = None
 			if self.name:
-				if self._doc is None:
-					self._doc = frappe.get_doc(self.doctype, self.name)
 				value = self._doc.get(attr)
 			field = self._fields(attr)
 			if field.fieldtype == "Link":

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -3,11 +3,12 @@
 import hashlib
 import json
 import time
+from collections import defaultdict
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
-from functools import cache, singledispatchmethod, wraps
+from functools import singledispatchmethod, wraps
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, Union, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, TypeAlias, Union, overload
 
 from werkzeug.exceptions import NotFound
 
@@ -166,29 +167,35 @@ def read_only_document(context=None):
 
 
 class DocumentProxy(DocRef):
+	_fields_cache: ClassVar = {}
+	_values_cache: ClassVar = defaultdict(dict)
+	_undefined = object()
+
 	def __init__(self, doctype, name, parent=None, doc=None):
 		super().__init__(doctype, name)
 		self.__dict__["_doc"] = doc
 		self._super = parent or self
 
 	@classmethod
-	@cache
 	def _get_fields(cls, doctype):
-		from frappe.model import data_fieldtypes, default_fields, table_fields
-		from frappe.model.meta import get_default_df
+		cache_key = (frappe.local.site, doctype)
+		if cache_key not in cls._fields_cache:
+			from frappe.model import data_fieldtypes, default_fields, table_fields
+			from frappe.model.meta import get_default_df
 
-		meta = frappe.get_meta(doctype)
+			meta = frappe.get_meta(doctype)
 
-		return {
-			# all meta fields with values
-			f.fieldname: f
-			for f in meta.fields
-			if f.fieldtype in (*data_fieldtypes, *table_fields)
-		} | {
-			# all default fields
-			f.fieldname: f
-			for f in (get_default_df(n) for n in default_fields)
-		}
+			cls._fields_cache[cache_key] = {
+				# all meta fields with values
+				f.fieldname: f
+				for f in meta.fields
+				if f.fieldtype in (*data_fieldtypes, *table_fields)
+			} | {
+				# all default fields
+				f.fieldname: f
+				for f in (get_default_df(n) for n in default_fields)
+			}
+		return cls._fields_cache[cache_key]
 
 	@property
 	def _doc(self):
@@ -211,7 +218,7 @@ class DocumentProxy(DocRef):
 	def _fields(self, fieldname):
 		return self._get_fields(self.doctype)[fieldname]
 
-	def __getattr__(self, attr):
+	def __getattr_value__(self, attr):
 		if attr in self._fieldnames:
 			value = None
 			if self.name:
@@ -226,10 +233,17 @@ class DocumentProxy(DocRef):
 			if field.fieldtype in ("Table", "Table MultiSelect"):
 				linked_doctype = field.options
 				return DocumentProxyList(linked_doctype, [v.name for v in value], self)
-
 			return value
-		else:
-			return getattr(self._doc, attr, None)
+		return self._undefined
+
+	def __getattr__(self, attr):
+		cache_key = (self.doctype, str(self.name), attr)
+		if cache_key not in self._values_cache[frappe.local.site]:
+			value = self.__getattr_value__(attr)
+			if value is self._undefined:
+				return getattr(self._doc, attr, None)
+			self._values_cache[frappe.local.site][cache_key] = value
+		return self._values_cache[frappe.local.site][cache_key]
 
 	def __getitem__(self, key):
 		return self.__getattr__(key)
@@ -250,20 +264,30 @@ class DocumentProxy(DocRef):
 	def __bool__(self):
 		return bool(self.name)
 
+	# def __del__(self) -> None:
+	# 	print(f"deleting {self.doctype} {self}")
+
 
 class DocumentProxyList:
 	def __init__(self, doctype: str, values: list[str], parent):
 		self.doctype = doctype
 		self.values = values
 		self._super = parent
+		self._cached_items = None
 
 	def __iter__(self):
-		for value in self.values:
-			yield type(self._super)(self.doctype, value, self._super)
+		if self._cached_items is None:
+			self._cached_items = [
+				type(self._super)(self.doctype, value, self._super) for value in self.values
+			]
+		yield from self._cached_items
 
 	def __getitem__(self, index):
-		value = self.values[index]
-		return type(self._super)(self.doctype, value, self._super)
+		if self._cached_items is None:
+			self._cached_items = [
+				type(self._super)(self.doctype, value, self._super) for value in self.values
+			]
+		return self._cached_items[index]
 
 	def __len__(self):
 		return len(self.values)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -163,9 +163,10 @@ def read_only_document(context=None):
 
 
 class DocumentProxy(DocRef):
-	def __init__(self, doctype, name):
+	def __init__(self, doctype, name, parent=None):
 		super().__init__(doctype, name)
 		self._doc = None
+		self._super = parent or self
 
 	@classmethod
 	@cache
@@ -203,13 +204,13 @@ class DocumentProxy(DocRef):
 			field = self._fields(attr)
 			if field.fieldtype == "Link":
 				linked_doctype = field.options
-				return DocumentProxy(linked_doctype, value)
+				return type(self)(linked_doctype, value, self)
 			if field.fieldtype == "Dynamic Link":
 				linked_doctype = self._doc.get(field.options)
-				return DocumentProxy(linked_doctype, value)
+				return type(self)(linked_doctype, value, self)
 			if field.fieldtype in ("Table", "Table MultiSelect"):
 				linked_doctype = field.options
-				return DocumentProxyList(linked_doctype, value)
+				return DocumentProxyList(linked_doctype, [v.name for v in value], self)
 
 			return value
 		raise AttributeError(f"'{self.doctype}' object proxy has no attribute '{attr}'")
@@ -226,7 +227,7 @@ class DocumentProxy(DocRef):
 	def __str__(self):
 		# we explictly deviate from the DocRef stringer as
 		# we need to render the value in jinja environments
-		# in caes of no value and the user not guarding the snippet against it,
+		# in case of no value and the user not guarding the snippet against it,
 		# we want to "soft error" by printing the full object representation
 		return self.__value__() or self.__repr__()
 
@@ -235,16 +236,18 @@ class DocumentProxy(DocRef):
 
 
 class DocumentProxyList:
-	def __init__(self, doctype, values):
+	def __init__(self, doctype: str, values: list[str], parent):
 		self.doctype = doctype
 		self.values = values
+		self._super = parent
 
 	def __iter__(self):
 		for value in self.values:
-			yield DocumentProxy(self.doctype, value.name)
+			yield type(self._super)(self.doctype, value, self._super)
 
 	def __getitem__(self, index):
-		return DocumentProxy(self.doctype, self.values[index].name)
+		value = self.values[index]
+		return type(self._super)(self.doctype, value, self._super)
 
 	def __len__(self):
 		return len(self.values)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -3,12 +3,11 @@
 import hashlib
 import json
 import time
-from collections import defaultdict
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
-from functools import singledispatchmethod, wraps
+from functools import cached_property, singledispatchmethod, wraps
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, TypeAlias, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, Union, overload
 
 from werkzeug.exceptions import NotFound
 
@@ -167,89 +166,70 @@ def read_only_document(context=None):
 
 
 class DocumentProxy(DocRef):
-	_fields_cache: ClassVar = {}
-	_values_cache: ClassVar = defaultdict(dict)
 	_undefined = object()
 
 	def __init__(self, doctype, name, parent=None, doc=None):
 		super().__init__(doctype, name)
-		self.__dict__["_doc"] = doc
 		self._super = parent or self
+		if doc is not None:
+			# micro-optimization: seed the cache, if object pointer is already available
+			self.__dict__["_doc"] = doc
 
-	@classmethod
-	def _get_fields(cls, doctype):
-		cache_key = (frappe.local.site, doctype)
-		if cache_key not in cls._fields_cache:
-			from frappe.model import data_fieldtypes, default_fields, table_fields
-			from frappe.model.meta import get_default_df
+	@cached_property
+	def _fields(self, doctype):
+		from frappe.model import data_fieldtypes, default_fields, table_fields
+		from frappe.model.meta import get_default_df
 
-			meta = frappe.get_meta(doctype)
+		meta = frappe.get_meta(doctype)
 
-			cls._fields_cache[cache_key] = {
-				# all meta fields with values
-				f.fieldname: f
-				for f in meta.fields
-				if f.fieldtype in (*data_fieldtypes, *table_fields)
-			} | {
-				# all default fields
-				f.fieldname: f
-				for f in (get_default_df(n) for n in default_fields)
-			}
-		return cls._fields_cache[cache_key]
+		return {
+			# all meta fields with values
+			f.fieldname: f
+			for f in meta.fields
+			if f.fieldtype in (*data_fieldtypes, *table_fields)
+		} | {
+			# all default fields
+			f.fieldname: f
+			for f in (get_default_df(n) for n in default_fields)
+		}
 
-	@property
+	@cached_property
 	def _doc(self):
-		if self.__dict__["_doc"] is None:
-			# print("Last 3 frames of the traceback:")
-			# import traceback
+		return frappe.get_cached_doc(self.doctype, self.name)
 
-			# for frame in traceback.extract_stack()[-4:-1]:  # Get the last 3 frames, excluding this line
-			# 	filename, line_number, function_name, text = frame
-			# 	print(f"  File '{filename}', line {line_number}, in {function_name}")
-			# 	if text:
-			# 		print(f"    {text.strip()}")
-			self.__dict__["_doc"] = frappe.get_doc(self.doctype, self.name)
-		return self.__dict__["_doc"]
-
-	@property
-	def _fieldnames(self):
-		return self._get_fields(self.doctype).keys()
-
-	def _fields(self, fieldname):
-		return self._get_fields(self.doctype)[fieldname]
-
+	# override this method in custom proxy for attribute overlay
 	def __getattr_value__(self, attr):
-		if attr in self._fieldnames:
+		if attr in self._fields.keys():
 			value = None
-			if self.name:
+			if self.name:  # only process named documents
 				value = self._doc.get(attr)
 			field = self._fields(attr)
-			if field.fieldtype == "Link":
-				linked_doctype = field.options
-				return type(self)(linked_doctype, value, self)
-			if field.fieldtype == "Dynamic Link":
-				linked_doctype = self._doc.get(field.options)
-				return type(self)(linked_doctype, value, self)
-			if field.fieldtype in ("Table", "Table MultiSelect"):
-				linked_doctype = field.options
-				return DocumentProxyList(linked_doctype, [v.name for v in value], self)
+			match field.fieldtype:
+				case "Link":
+					linked_doctype = field.options
+					return type(self)(linked_doctype, value, self)
+				case "Dynamic Link":
+					linked_doctype = self._doc.get(field.options)
+					return type(self)(linked_doctype, value, self)
+				case ("Table", "Table MultiSelect"):
+					linked_doctype = field.options
+					return DocumentProxyList(linked_doctype, [v.name for v in value], self)
 			return value
 		return self._undefined
 
 	def __getattr__(self, attr):
-		cache_key = (self.doctype, str(self.name), attr)
-		if cache_key not in self._values_cache[frappe.local.site]:
-			value = self.__getattr_value__(attr)
-			if value is self._undefined:
-				return getattr(self._doc, attr, None)
-			self._values_cache[frappe.local.site][cache_key] = value
-		return self._values_cache[frappe.local.site][cache_key]
+		value = self.__getattr_value__(attr)
+		if value is self._undefined:
+			# attribute delegation for compatibility reasons only
+			# at least not encouraged in rendering contexts
+			return getattr(self._doc, attr, None)
+		return value
 
 	def __getitem__(self, key):
 		return self.__getattr__(key)
 
 	def __contains__(self, key):
-		return key in self._fieldnames
+		return key in self._fields.keys()
 
 	def __repr__(self):
 		return f"<{self.__class__.__name__}: doctype={self.doctype} name={self.name or 'n/a'}>"
@@ -263,9 +243,6 @@ class DocumentProxy(DocRef):
 
 	def __bool__(self):
 		return bool(self.name)
-
-	# def __del__(self) -> None:
-	# 	print(f"deleting {self.doctype} {self}")
 
 
 class DocumentProxyList:

--- a/frappe/tests/test_jinja.py
+++ b/frappe/tests/test_jinja.py
@@ -723,10 +723,11 @@ class TestRenderTemplateWithGlobals(IntegrationTestCase):
 
 		result = render_template("frappe/tests/test_template_globals.html", context)
 
+		self.assertIn("Proxy: <DocumentProxy: doctype=Language name=n/a>", result)
+
 		# Test JSON
-		self.assertIn(
-			'JSON Dumps: {\n "lang": "DocumentProxy(Language, None)",\n "user": "Administrator"\n}', result
-		)
+		# a n/a document proxy becomes null via the json_handler's evaluation of __value__()
+		self.assertIn('JSON Dumps: {\n "lang": null,\n "user": "Administrator"\n}', result)
 
 		# Test frappe.bold
 		self.assertIn("<strong>Administrator</strong>", result)

--- a/frappe/tests/test_jinja.py
+++ b/frappe/tests/test_jinja.py
@@ -1,0 +1,346 @@
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+import frappe
+from frappe import _dict
+from frappe.model.document import Document, DocumentProxy
+from frappe.utils.jinja import process_context, render_template
+
+
+class TestDocumentProxy(unittest.TestCase):
+	def setUp(self):
+		self.mock_doc = Mock(spec=Document, doctype="Test DocType")
+		self.mock_doc.name = "TEST001"
+
+		self.mock_meta = Mock()
+		self.mock_meta.fields = [
+			_dict({"fieldname": "test_field", "fieldtype": "Data"}),
+			_dict({"fieldname": "link_field", "fieldtype": "Link", "options": "Linked DocType"}),
+		]
+
+		self.mock_get_meta = patch("frappe.get_meta", return_value=self.mock_meta).start()
+		self.mock_get_doc = patch("frappe.get_doc", return_value=self.mock_doc).start()
+
+		# Add this assertion to ensure the mock_doc is recognized as a Document instance
+		self.assertTrue(isinstance(self.mock_doc, Document))
+
+	def tearDown(self):
+		patch.stopall()
+		DocumentProxy._get_fields.cache_clear()  # Clear the LRU cache
+
+	def test_document_proxy_creation(self):
+		proxy = DocumentProxy("Test DocType", "TEST001")
+
+		self.assertEqual(proxy.doctype, "Test DocType")
+		self.assertEqual(proxy.name, "TEST001")
+		self.assertEqual(str(proxy), "TEST001")
+
+	def test_document_proxy_field_access(self):
+		proxy = DocumentProxy("Test DocType", "TEST001")
+
+		# Assert that get_doc is not called before field access
+		self.mock_get_doc.assert_not_called()
+
+		# Access a field
+		self.assertEqual(proxy.test_field, "Test Value")
+
+		# Now assert that get_doc has been called once
+		self.mock_get_doc.assert_called_once_with("Test DocType", "TEST001")
+
+	def test_document_proxy_field_caching(self):
+		# Create two different DocumentProxy instances for the same doctype
+		proxy1 = DocumentProxy("Test DocType", "TEST001")
+		proxy2 = DocumentProxy("Test DocType", "TEST002")
+
+		# Access a field on the first proxy to trigger _get_fields
+		_ = proxy1.test_field
+
+		# Reset the mock to clear the call count
+		self.mock_get_meta.reset_mock()
+
+		# Access a field on the second proxy
+		_ = proxy2.test_field
+
+		# Assert that get_meta was not called again
+		self.mock_get_meta.assert_not_called()
+
+		# Create a DocumentProxy for a different doctype
+		proxy3 = DocumentProxy("Another DocType", "TEST003")
+
+		# Access a field on the new proxy
+		_ = proxy3.test_field
+
+		# Assert that get_meta was called once for the new doctype
+		self.mock_get_meta.assert_called_once_with("Another DocType")
+
+	def test_document_proxy_link_field(self):
+		proxy = DocumentProxy("Test DocType", "TEST001")
+		linked_proxy = proxy.link_field
+
+		self.assertIsInstance(linked_proxy, DocumentProxy)
+		self.assertEqual(linked_proxy.doctype, "Linked DocType")
+		self.assertEqual(linked_proxy.name, "LINK001")
+
+	def test_document_proxy_invalid_field(self):
+		proxy = DocumentProxy("Test DocType", "TEST001")
+
+		with self.assertRaises(AttributeError):
+			proxy.invalid_field
+
+	def test_document_proxy_contains(self):
+		proxy = DocumentProxy("Test DocType", "TEST001")
+
+		# Test for existing fields
+		self.assertIn("test_field", proxy)
+		self.assertIn("link_field", proxy)
+
+		# Test for non-existing field
+		self.assertNotIn("non_existing_field", proxy)
+
+		# Ensure that __contains__ doesn't trigger document fetch
+		self.mock_get_doc.assert_not_called()
+
+		# Access a field to trigger document fetch
+		_ = proxy.test_field
+
+		# Check that get_doc was called once
+		self.mock_get_doc.assert_called_once_with("Test DocType", "TEST001")
+
+		# Test again after document fetch
+		self.assertIn("test_field", proxy)
+		self.assertNotIn("non_existing_field", proxy)
+
+
+class TestProcessContext(unittest.TestCase):
+	def setUp(self):
+		self.mock_doc = Mock(spec=Document, doctype="Test DocType")
+		self.mock_doc.name = "TEST001"
+		self.mock_doc.get.side_effect = lambda field: {
+			"test_field": "Test Value",
+			"link_field": "LINK001",
+			"nested_field": "TEST001",
+		}[field]
+
+		self.mock_meta = Mock()
+		self.mock_meta.fields = [
+			_dict({"fieldname": "test_field", "fieldtype": "Data"}),
+			_dict({"fieldname": "link_field", "fieldtype": "Link", "options": "Linked DocType"}),
+			_dict({"fieldname": "nested_field", "fieldtype": "Link", "options": "Test DocType"}),
+		]
+
+		self.mock_get_meta = patch("frappe.get_meta", return_value=self.mock_meta).start()
+		self.mock_get_doc = patch("frappe.get_doc", return_value=self.mock_doc).start()
+
+		# Add this assertion to ensure the mock_doc is recognized as a Document instance
+		self.assertTrue(isinstance(self.mock_doc, Document))
+
+	def tearDown(self):
+		patch.stopall()
+		DocumentProxy._get_fields.cache_clear()  # Clear the LRU cache
+
+	def test_process_context_non_completion(self):
+		context = {
+			"doc": self.mock_doc,  # Level 0
+			"value": "test",
+			"list": [1, 2, 3],
+			"dict": {
+				"key": "value",
+				"nested_doc": self.mock_doc,  # Infinite recursion
+				"deeper": {
+					"nested_doc": self.mock_doc,  # Level 2
+					"deepest": {
+						"nested_doc": self.mock_doc,  # Level 3
+					},
+				},
+			},
+		}
+
+		processed = process_context(context)
+
+		# Check level 0
+		self.assertIsInstance(processed["doc"], DocumentProxy)
+
+		# Check Recursion
+		self.assertIsInstance(processed["dict"]["nested_doc"], DocumentProxy)
+		self.assertIsInstance(processed["dict"]["nested_doc"].nested_field, DocumentProxy)
+		self.assertIsInstance(processed["dict"]["nested_doc"]["nested_field"]["nested_field"], DocumentProxy)
+
+		# Check level 2
+		self.assertIsInstance(processed["dict"]["deeper"]["nested_doc"], DocumentProxy)
+
+		# Check level 3 (should not be a DocumentProxy)
+		self.assertNotIsInstance(processed["dict"]["deeper"]["deepest"]["nested_doc"], DocumentProxy)
+
+		# Check other values remain unchanged
+		self.assertEqual(processed["value"], "test")
+		self.assertEqual(processed["list"], [1, 2, 3])
+		self.assertEqual(processed["dict"]["key"], "value")
+
+	def test_process_context_completion(self):
+		context = {"doc": self.mock_doc, "value": "test", "list": [1, 2, 3], "dict": {"key": "value"}}
+
+		completion_list = process_context(context, for_code_completion=True)
+
+		expected_keys = [
+			"doc",
+			"doc.test_field",
+			"doc.link_field",
+			"value",
+			"list",
+			"dict",
+			"dict.key",
+		]
+
+		completion_keys = [item["value"] for item in completion_list]
+		for key in expected_keys:
+			self.assertIn(key, completion_keys)
+
+	def test_process_context_completion_nested(self):
+		context = {
+			"doc": self.mock_doc,  # Level 0
+			"nested": {
+				"doc": self.mock_doc,  # Level 1
+				"deeper": {
+					"doc": self.mock_doc,  # Level 2
+					"deepest": {
+						"doc": self.mock_doc,  # Level 3
+					},
+				},
+				"list": [1, {"key": "value"}],
+			},
+		}
+
+		completion_list = process_context(context, for_code_completion=True)
+
+		expected_keys = [
+			"doc",
+			"doc.test_field",
+			"doc.link_field",
+			"doc.nested_field",
+			"doc.nested_field",
+			"doc.nested_field.test_field",
+			"doc.nested_field.link_field",
+			"doc.nested_field.nested_field",
+			"nested",
+			"nested.doc",
+			"nested.doc.test_field",
+			"nested.doc.link_field",
+			"nested.doc.nested_field",
+			"nested.deeper",
+			"nested.deeper.doc",  # no recursion anymore
+			"nested.deeper.deepest",  # no recursion
+			"nested.list",
+		]
+
+		unexpected_keys = [
+			"nested.deeper.deepest.doc",
+		]
+
+		completion_keys = [item["value"] for item in completion_list]
+
+		# Check for expected keys
+		for key in expected_keys:
+			self.assertIn(key, completion_keys)
+
+		# Check that unexpected keys (level 3) are not present
+		for key in unexpected_keys:
+			self.assertNotIn(key, completion_keys)
+
+
+class CustomDocumentProxy(DocumentProxy):
+	def __getattr__(self, attr):
+		if attr in self._fieldnames:
+			if self._doc is None:
+				self._doc = frappe.get_doc(self.doctype, self.name)
+			value = self._doc.get(attr)
+			return f"Custom_{value}"
+		return super().__getattr__(attr)
+
+
+class TestCustomDocumentProxy(unittest.TestCase):
+	def setUp(self):
+		self.mock_doc = Mock(spec=Document, doctype="Test DocType")
+		self.mock_doc.name = "TEST001"
+		self.mock_doc.get.return_value = "Test Value"
+
+		self.mock_meta = Mock()
+		self.mock_meta.fields = [
+			_dict({"fieldname": "test_field", "fieldtype": "Data"}),
+		]
+
+		self.mock_get_meta = patch("frappe.get_meta", return_value=self.mock_meta).start()
+		self.mock_get_doc = patch("frappe.get_doc", return_value=self.mock_doc).start()
+		# Add this assertion to ensure the mock_doc is recognized as a Document instance
+		self.assertTrue(isinstance(self.mock_doc, Document))
+
+	def tearDown(self):
+		patch.stopall()
+		DocumentProxy._get_fields.cache_clear()  # Clear the LRU cache
+
+	def test_custom_document_proxy(self):
+		context = {"doc": self.mock_doc}
+		template = "{{ doc.test_field }}"
+
+		with patch("frappe.utils.jinja.get_jenv") as mock_get_jenv:
+			mock_jenv = Mock()
+			mock_get_jenv.return_value = mock_jenv
+			mock_template = Mock()
+			mock_jenv.from_string.return_value = mock_template
+
+			# Render with default DocumentProxy
+			render_template(template, context)
+			args, _ = mock_template.render.call_args
+			self.assertIsInstance(args[0]["doc"], DocumentProxy)
+
+			# Render with CustomDocumentProxy
+			render_template(template, context, document_proxy_class=CustomDocumentProxy)
+			args, _ = mock_template.render.call_args
+			self.assertIsInstance(args[0]["doc"], CustomDocumentProxy)
+			self.assertEqual(args[0]["doc"].test_field, "Custom_Test Value")
+
+	def test_process_context_with_custom_proxy(self):
+		context = {"doc": self.mock_doc}
+
+		# Process context with default DocumentProxy
+		processed_default = process_context(context)
+		self.assertIsInstance(processed_default["doc"], DocumentProxy)
+		self.assertEqual(processed_default["doc"].test_field, "Test Value")
+
+		# Process context with CustomDocumentProxy
+		processed_custom = process_context(context, document_proxy_class=CustomDocumentProxy)
+		self.assertIsInstance(processed_custom["doc"], CustomDocumentProxy)
+		self.assertEqual(processed_custom["doc"].test_field, "Custom_Test Value")
+
+
+def run_specific_test(test_class, test_case=None):
+	if test_case:
+		suite = unittest.TestSuite()
+		suite.addTest(test_class(test_case))
+	else:
+		suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
+
+	runner = unittest.TextTestRunner(verbosity=2)
+	runner.run(suite)
+
+
+if __name__ == "__main__":
+	# Mock Frappe environment
+	frappe.conf = Mock()
+	frappe.conf.developer_mode = False
+	frappe.local = Mock()
+	frappe.local.site = "test_site"
+	if len(sys.argv) > 1:
+		test_class_name = sys.argv[1]
+		test_case_name = sys.argv[2] if len(sys.argv) > 2 else None
+
+		# Get the test class by name
+		test_class = globals().get(test_class_name)
+		if not test_class:
+			print(f"Test class '{test_class_name}' not found.")
+			sys.exit(1)
+
+		run_specific_test(test_class, test_case_name)
+	else:
+		# Run all tests
+		unittest.main()

--- a/frappe/tests/test_jinja.py
+++ b/frappe/tests/test_jinja.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, call, patch
 import frappe
 from frappe import _dict, scrub
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
-from frappe.model.document import Document, DocumentProxy
+from frappe.model.document import Document, DocumentProxy, DocumentProxyList
 from frappe.tests import IntegrationTestCase, UnitTestCase
 from frappe.utils.jinja import process_context, render_template
 
@@ -749,6 +749,84 @@ class TestRenderTemplateWithGlobals(IntegrationTestCase):
 
 		# Test scrub
 		self.assertIn("administrator", result)
+
+
+class TestComplexCustomDocumentProxy(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		# Create test data
+		cls.test_user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"name": "test.dian@example.com",
+				"email": "test.dian@example.com",
+				"first_name": "Test",
+				"last_name": "DIAN",
+				"user_type": "System User",
+				"send_welcome_email": 0,
+				"language": "de",
+			}
+		).insert(ignore_permissions=True)
+		cls.test_user.add_tag("IVA @ 19")
+		cls.test_user.add_tag("Discount")
+
+	def setUp(self):
+		class TestCustomDocumentProxy(DocumentProxy):
+			def __init__(self, *args, **kwargs):
+				super().__init__(*args, **kwargs)
+				# eager attr overlay
+				if self.doctype == "User":
+					if self.last_name == "DIAN":
+						self.dian_id_no = "123456789"
+						self.dian_id_dv = "0"
+
+			def __getattr__(self, attr):
+				match (self.doctype, attr):
+					# lazy attr addition
+					case ("User", "dian_role"):
+						return frappe._dict(
+							{
+								"role_name": "Test DIAN Role",
+								"country_code": "CO",
+							}
+						)
+					case ("User", "tags"):
+						tags = self._doc.get("_user_tags").split(",")
+						return DocumentProxyList("Tag", [t for t in tags if t in ["Discount"]], self)
+					case ("User", "taxes"):
+						tags = self._doc.get("_user_tags").split(",")
+						return DocumentProxyList("Tag", [t for t in tags if t in ["IVA @ 19"]], self)
+				return super().__getattr__(attr)
+
+		self.CustomDocumentProxy = TestCustomDocumentProxy
+
+	def test_custom_proxy_nesting(self):
+		proxy = self.CustomDocumentProxy("User", self.test_user.name)
+		self.assertIsInstance(proxy.language, self.CustomDocumentProxy)
+
+	def test_eager_attr_overlay(self):
+		proxy = self.CustomDocumentProxy("User", self.test_user.name)
+		self.assertEqual(proxy.dian_id_no, "123456789")
+		self.assertEqual(proxy.dian_id_dv, "0")
+
+	def test_lazy_attr_overlay(self):
+		proxy = self.CustomDocumentProxy("User", self.test_user.name)
+		dian_role = proxy.dian_role
+		self.assertEqual(dian_role.role_name, "Test DIAN Role")
+		self.assertEqual(dian_role.country_code, "CO")
+
+	def test_attr_partition(self):
+		proxy = self.CustomDocumentProxy("User", self.test_user.name)
+
+		# Test partitions
+		self.assertEqual(len(proxy.tags), 1)
+		self.assertEqual(proxy.tags[0].name, "Discount")
+		self.assertEqual(len(proxy.taxes), 1)
+		self.assertEqual(proxy.taxes[0].name, "IVA @ 19")
+
+		# Test proxy class propagation
+		self.assertIsInstance(proxy.tags[0], self.CustomDocumentProxy)
 
 
 class TestDocumentProxyRendering(IntegrationTestCase):

--- a/frappe/tests/test_jinja.py
+++ b/frappe/tests/test_jinja.py
@@ -306,7 +306,10 @@ class TestProcessContext(UnitTestCase):
 			{"value": "dict.key", "score": 6, "meta": "ctx"},
 		]
 
-		self.assertEqual(completion_list, expected_items)
+		self.assertEqual(
+			set(tuple(item.items()) for item in completion_list),
+			set(tuple(item.items()) for item in expected_items),
+		)
 
 	def test_process_context_completion_with_get_keys_for_autocomplete(self):
 		from frappe.utils.safe_exec import NamespaceDict
@@ -385,7 +388,10 @@ class TestProcessContext(UnitTestCase):
 			{"value": "frappe.utils.cint", "score": 9, "meta": "ctx"},
 		]
 
-		self.assertEqual(completion_list, expected_items)
+		self.assertEqual(
+			set(tuple(item.items()) for item in completion_list),
+			set(tuple(item.items()) for item in expected_items),
+		)
 
 
 class CustomDocumentProxy(DocumentProxy):

--- a/frappe/tests/test_template.html
+++ b/frappe/tests/test_template.html
@@ -1,0 +1,5 @@
+<h1>Welcome, {{ user.first_name }}</h1>
+<p>
+	{{ user.first_name }} reports to {{ user.reports_to.first_name }} {{ user.reports_to.last_name }},
+	who reports to {{ user.reports_to.reports_to.first_name }} {{ user.reports_to.reports_to.last_name }}.
+</p>

--- a/frappe/tests/test_template_globals.html
+++ b/frappe/tests/test_template_globals.html
@@ -10,6 +10,9 @@
   <h2>Escape the DocumentProxy using frappe.get_doc</h2>
   <p>User dict name: {{ frappe.get_doc(user).as_dict()["name"] }}</p>
 
+  <h2>Null value DocumentProxy</h2>
+  <p>Proxy: {{ user.language }}</p>
+
   <h2>JSON</h2>
   <p>JSON Dumps: {{ as_json({"user": user, "lang": user.language}) }}</p>
 

--- a/frappe/tests/test_template_globals.html
+++ b/frappe/tests/test_template_globals.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+
+<body>
+  <h1>Testing DocumentProxy with Global Context Items</h1>
+
+  <h2>Assert the DocumentProxy via the implicit calling signature of frappe.get_meta</h2>
+  <p>Meta name: {{ frappe.get_meta(user).name }}</p>
+
+  <h2>Escape the DocumentProxy using frappe.get_doc</h2>
+  <p>User dict name: {{ frappe.get_doc(user).as_dict()["name"] }}</p>
+
+  <h2>JSON</h2>
+  <p>JSON Dumps: {{ as_json({"user": user, "lang": user.language}) }}</p>
+
+  <h2>dict</h2>
+  <p>{{ dict(key=user).key }}</p>
+
+  <h2>_dict</h2>
+  <p>{{ _dict(key=user).key }}</p>
+
+  <h2>frappe.format_value</h2>
+  <p>{{ frappe.format_value(1000, {"fieldtype": "Currency"}) }}</p>
+
+  <h2>frappe.bold</h2>
+  <p>{{ frappe.bold(user) }}</p>
+
+  <h2>frappe.utils.get_url</h2>
+  <p>{{ frappe.utils.get_url("lang/" ~ user) }}</p>
+
+  <h2>frappe.render_template</h2>
+  <p>{{ frappe.render_template("Hello {{ name }} in {{ lang }}", {"name": user, "lang": user}) }}</p>
+
+  <h2>frappe.db.get_value</h2>
+  <p>User email: {{ frappe.db.get_value("User", user, "email") }}</p>
+
+  <h2>frappe.get_fullname</h2>
+  <p>{{ frappe.get_fullname() }}</p>
+
+  <h2>_</h2>
+  <p>{{ _(user) }} speaks {{ _(user) }}</p>
+
+  <h2>scrub</h2>
+  <p>{{ scrub(user) }}</p>
+</body>
+
+</html>

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -1,5 +1,57 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+	from frappe.model.document import DocumentProxy
+
+
+def process_context(
+	context: dict[Any],
+	for_code_completion: bool = False,
+	document_proxy_class: type["DocumentProxy"] | None = None,
+):
+	from frappe.model.document import Document, DocumentProxy
+
+	if not document_proxy_class:  # lazy import
+		document_proxy_class = DocumentProxy
+
+	if for_code_completion:
+
+		def process_value(key, value, prefix="", depth=0):
+			full_key = f"{prefix}.{key}" if prefix else key
+			result = [{"value": full_key, "score": 1000, "meta": "ctx"}]
+			if depth >= 2:
+				return result
+
+			if isinstance(value, Document):  # on entry
+				value = document_proxy_class(value.doctype, value.name)
+			if isinstance(value, document_proxy_class):
+				for field in value._fieldnames:
+					result.extend(process_value(field, getattr(value, field), full_key, depth + 1))
+			elif isinstance(value, dict):
+				for k, v in value.items():
+					result.extend(process_value(k, v, full_key, depth + 1))
+
+			return result
+
+		completion_list = []
+		for key, value in context.items():
+			completion_list.extend(process_value(key, value))
+		return completion_list
+
+	else:
+
+		def process_value(value, depth=0):
+			if isinstance(value, Document):
+				return document_proxy_class(value.doctype, value.name)
+			elif isinstance(value, dict) and not depth >= 2:
+				return {k: process_value(v, depth + 1) for k, v in value.items()}
+			return value
+
+		return {key: process_value(value) for key, value in context.items()}
+
+
 def get_jenv():
 	import frappe
 
@@ -69,7 +121,13 @@ def validate_template(html):
 		frappe.throw(f"Syntax error in template as line {e.lineno}: {e.message}")
 
 
-def render_template(template, context=None, is_path=None, safe_render=True):
+def render_template(
+	template,
+	context=None,
+	is_path=None,
+	safe_render=True,
+	document_proxy_class: type["DocumentProxy"] | None = None,
+):
 	"""Render a template using Jinja
 
 	:param template: path or HTML containing the jinja template
@@ -87,6 +145,8 @@ def render_template(template, context=None, is_path=None, safe_render=True):
 
 	if context is None:
 		context = {}
+
+	context = process_context(context, document_proxy_class=document_proxy_class)
 
 	jenv: SandboxedEnvironment = get_jenv()
 	if is_path or guess_is_path(template):

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -6,11 +6,15 @@ if TYPE_CHECKING:
 	from frappe.model.document import DocumentProxy
 
 
+class ProcessedContext(dict):
+	"""A simple wrapper class to indicate that the context has been processed"""
+
+
 def process_context(
 	context: dict[Any],
 	for_code_completion: bool = False,
 	document_proxy_class: type["DocumentProxy"] | None = None,
-):
+) -> ProcessedContext:
 	from frappe.model.document import Document, DocumentProxy
 
 	if not document_proxy_class:  # lazy import
@@ -39,7 +43,7 @@ def process_context(
 				return {k: process_value(v, depth + 1) for k, v in value.items()}
 			return value
 
-		return {key: process_value(value) for key, value in context.items()}
+		return ProcessedContext({key: process_value(value) for key, value in context.items()})
 
 
 def get_jenv():
@@ -113,9 +117,9 @@ def validate_template(html):
 
 def render_template(
 	template,
-	context=None,
-	is_path=None,
-	safe_render=True,
+	context: dict[str, Any] | ProcessedContext | None = None,
+	is_path: bool = False,
+	safe_render: bool = True,
 	document_proxy_class: type["DocumentProxy"] | None = None,
 ):
 	"""Render a template using Jinja
@@ -136,7 +140,8 @@ def render_template(
 	if context is None:
 		context = {}
 
-	context = process_context(context, document_proxy_class=document_proxy_class)
+	if not isinstance(context, ProcessedContext):
+		context = process_context(context, document_proxy_class=document_proxy_class)
 
 	jenv: SandboxedEnvironment = get_jenv()
 	if is_path or guess_is_path(template):

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -39,7 +39,7 @@ def process_context(
 
 		def process_value(value, depth=0):
 			if isinstance(value, Document):
-				return document_proxy_class(value.doctype, value.name)
+				return document_proxy_class(value.doctype, value.name, doc=value)
 			elif isinstance(value, dict) and not depth >= 2:
 				return _dict({k: process_value(v, depth + 1) for k, v in value.items()})
 			return value

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -16,6 +16,7 @@ def process_context(
 	document_proxy_class: type["DocumentProxy"] | None = None,
 ) -> ProcessedContext:
 	from frappe.model.document import Document, DocumentProxy
+	from frappe.types import _dict
 
 	if not document_proxy_class:  # lazy import
 		document_proxy_class = DocumentProxy
@@ -40,7 +41,7 @@ def process_context(
 			if isinstance(value, Document):
 				return document_proxy_class(value.doctype, value.name)
 			elif isinstance(value, dict) and not depth >= 2:
-				return {k: process_value(v, depth + 1) for k, v in value.items()}
+				return _dict({k: process_value(v, depth + 1) for k, v in value.items()})
 			return value
 
 		return ProcessedContext({key: process_value(value) for key, value in context.items()})

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -136,7 +136,9 @@ def render_template(
 	from jinja2 import TemplateError
 	from jinja2.sandbox import SandboxedEnvironment
 
-	from frappe import _, get_traceback, throw
+	import frappe
+	from frappe import _
+	from frappe.model.document import DocumentProxy
 
 	if context is None:
 		context = {}
@@ -150,15 +152,15 @@ def render_template(
 		compiled_template = jenv.get_template(template)
 	else:
 		if safe_render and ".__" in template:
-			throw(_("Illegal template"))
+			frappe.throw(_("Illegal template"))
 		try:
 			compiled_template = jenv.from_string(template)
 		except TemplateError:
 			import html
 
-			throw(
+			frappe.throw(
 				title="Jinja Template Error",
-				msg=f"<pre>{template}</pre><pre>{html.escape(get_traceback())}</pre>",
+				msg=f"<pre>{template}</pre><pre>{html.escape(frappe.get_traceback())}</pre>",
 			)
 
 	import time
@@ -172,8 +174,10 @@ def render_template(
 	except Exception as e:
 		import html
 
-		throw(title="Context Error", msg=f"<pre>{html.escape(get_traceback())}</pre>", exc=e)
+		frappe.throw(title="Context Error", msg=f"<pre>{html.escape(frappe.get_traceback())}</pre>", exc=e)
 	finally:
+		if site := getattr(frappe.local, "site", None):
+			DocumentProxy._values_cache[site].clear()
 		if is_path:
 			logger.debug(f"Rendering time: {time.monotonic() - start_time:.6f} seconds ({template})")
 		else:

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -176,8 +176,6 @@ def render_template(
 
 		frappe.throw(title="Context Error", msg=f"<pre>{html.escape(frappe.get_traceback())}</pre>", exc=e)
 	finally:
-		if site := getattr(frappe.local, "site", None):
-			DocumentProxy._values_cache[site].clear()
 		if is_path:
 			logger.debug(f"Rendering time: {time.monotonic() - start_time:.6f} seconds ({template})")
 		else:


### PR DESCRIPTION
##### Upstream of https://github.com/frappe/erpnext/pull/44174

closes: https://github.com/frappe/frappe/issues/28722

##### At one glance
```nunjucks
<h1>Welcome, {{ user.first_name }}</h1>
<p>
{{ user.first_name }} reports to {{ user.reports_to.first_name }} {{ user.reports_to.last_name }},
who reports to {{ user.reports_to.reports_to.first_name }} {{ user.reports_to.reports_to.last_name }}.
</p>
```
<sup>note the seamless link traversal</sup>

## Jinja Template Rendering Enhancements

This PR introduces significant improvements to Frappe's Jinja template rendering system, focusing on security, performance, and developer experience.

### Key Changes

1. **DocumentProxy Class**: Implemented a new `DocumentProxy` class to provide secure and efficient access to document fields in Jinja templates.

2. **Context Processing**: Added a `process_context` function to prepare the context for template rendering, with special handling for code completion scenarios.

3. **Link Field Handling**: Improved handling of Link fields, automatically creating nested DocumentProxy objects for linked documents.

4. **Depth-Limited Processing**: Implemented a depth limit for nested document processing to prevent excessive recursion and improve performance during code completion processing; only traverse dictionaries eagerly two levels down to look for potential Document.

5. **Code Completion Support**: Enhanced the context processing to generate completion suggestions for use in IDEs and code editors.

### New Tests

Added comprehensive unit tests in `test_jinja.py` to cover:
- DocumentProxy creation and field access
- Field caching mechanism
- Link field handling
- Context processing for both rendering and code completion
- Nested document handling

### Impact

These changes will improve template rendering security by restricting access to document fields, enhance performance through caching, and provide better developer tooling support with improved code completion, while automatically traversing link fields.

### To Dos

- [x] Validated server script completion works as expected after integration
- [x] Handle Dynamic Links
- [x] Handle iterable fields (child tables)
- [x] Allow to pass a different DocumentProxy (e.g. for different bindings in EDI scenarios)
- [x] Dogfood in production and report back
- [x] Assert the stringer is enough in most common template scenarios; maybe add stringifiers to `get_doc` et al. \*
- [x] Assert jina rendering does really not have support for a special `__renderer__` instead of a stringer

### Notes for Reviewers
- Please pay special attention to the exhaustive test cases and validate them.
- Consider the fact that the code completion is non-critical functionality, but makes up a nice integration test case.
- Review the entire design of this feature; e.g. should it be generalized (maybe later?)

This PR prepares for improvements on https://github.com/frappe/erpnext/pull/43425 and relates to our ongoing efforts to improve template rendering capabilities and security for EDI processing.



\* Would be an independently good idea to increase type safety
