### PR TITLE
feat: docref identifier / proxy

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -365,6 +365,8 @@ class BaseDocument:
 	def get_valid_dict(
 		self, sanitize=True, convert_dates_to_str=False, ignore_nulls=False, ignore_virtual=False
 	) -> _dict:
+		from frappe.model.document import DocRef
+
 		d = _dict()
 		field_values = self.__dict__
 
@@ -430,6 +432,9 @@ class BaseDocument:
 					value = df.default
 				else:
 					value = get_not_null_defaults(df.fieldtype)
+
+			if isinstance(value, DocRef):
+				value = str(value)
 
 			d[fieldname] = value
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1793,12 +1793,6 @@ class Document(BaseDocument, DocRef):
 
 		return f"<{doctype}: {name}{docstatus}{parent}>"
 
-	def __str__(self):
-		name = self.name or "unsaved"
-		doctype = self.__class__.__name__
-
-		return f"{doctype}({name})"
-
 
 def execute_action(__doctype, __name, __action, **kwargs):
 	"""Execute an action on a document (called by background worker)"""

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -38,7 +38,7 @@ from frappe.model.base_document import (
 	TABLE_DOCTYPES_FOR_DOCTYPE,
 	BaseDocument,
 )
-from frappe.model.document import Document
+from frappe.model.document import DocRef, Document
 from frappe.model.workflow import get_workflow_name
 from frappe.modules import load_doctype_module
 from frappe.utils import cast, cint, cstr
@@ -58,11 +58,11 @@ DEFAULT_FIELD_LABELS = {
 }
 
 
-def get_meta(doctype: str | Document, cached=True) -> "_Meta":
+def get_meta(doctype: str | DocRef | Document, cached=True) -> "_Meta":
 	"""Get metadata for a doctype.
 
 	Args:
-	    doctype: The doctype as a string or Document object.
+	    doctype: The doctype as a string, DocRef, or Document object.
 	    cached: Whether to use cached metadata (default: True).
 
 	Returns:
@@ -130,6 +130,11 @@ class Meta(Document):
 	@__init__.register(str)
 	def _(self, doctype):
 		super().__init__("DocType", doctype)
+		self.process()
+
+	@__init__.register(DocRef)
+	def _(self, doc_ref):
+		super().__init__("DocType", doc_ref.doctype)
 		self.process()
 
 	@__init__.register(Document)

--- a/frappe/tests/test_doc_ref.py
+++ b/frappe/tests/test_doc_ref.py
@@ -1,0 +1,72 @@
+import frappe
+from frappe.model.document import DocRef, Document, get_doc
+from frappe.tests import IntegrationTestCase
+
+EXTRA_TEST_RECORD_DEPENDENCIES = ["User"]
+
+
+class TestDocRef(IntegrationTestCase):
+	def test_doc_ref_get_doc(self):
+		# Test using DocRef with get_doc
+		doc_ref = DocRef("User", "test@example.com")
+		user = get_doc(doc_ref)
+
+		# Assert that user is an instance of both Document and DocRef
+		self.assertIsInstance(user, Document)
+		self.assertIsInstance(user, DocRef)
+
+		# Check more attributes
+		self.assertEqual(user.doctype, "User")
+		self.assertEqual(user.name, "test@example.com")
+		self.assertEqual(user.email, "test@example.com")
+		self.assertEqual(user.first_name, "_Test")
+
+	def test_doc_ref_in_query(self):
+		# Test using DocRef in a database query
+		user = frappe.get_doc("User", "test@example.com")
+
+		# Assert that user is an instance of both Document and DocRef
+		self.assertIsInstance(user, Document)
+		self.assertIsInstance(user, DocRef)
+
+		# Create a test document that references the user
+		test_doc = frappe.get_doc(
+			{
+				"doctype": "ToDo",
+				"description": "Test ToDo",
+				"reference_type": "User",
+				"reference_name": user,  # This should work with DocRef
+			}
+		).insert()
+
+		# Getter using the DocRef
+		result = frappe.db.get_value("ToDo", {"reference_name": user}, ["name", "description"])
+		self.assertEqual(result[0], test_doc.name)
+		self.assertEqual(result[1], "Test ToDo")
+		# Setter using Document as DocRef
+		frappe.db.set_value("ToDo", test_doc, "description", "Revised Test ToDo")
+		test_doc.reload()
+		self.assertEqual(test_doc.description, "Revised Test ToDo")
+
+	def test_get_meta_with_doc_ref(self):
+		# Test get_meta with DocRef
+		doc_ref = DocRef("User", "test@example.com")
+		meta = frappe.get_meta(doc_ref)
+
+		# Check more attributes of the meta
+		self.assertEqual(meta.name, "User")
+		self.assertEqual(meta.module, "Core")
+		self.assertTrue("email" in [f.fieldname for f in meta.fields])
+		self.assertTrue("first_name" in [f.fieldname for f in meta.fields])
+		self.assertTrue("last_name" in [f.fieldname for f in meta.fields])
+
+	def test_doc_ref_str_representation(self):
+		# Test the string representation of DocRef
+		doc_ref = DocRef("User", "test@example.com")
+		self.assertEqual(str(doc_ref), "test@example.com")
+
+	def test_doc_ref_attributes(self):
+		# Test DocRef attributes
+		doc_ref = DocRef("User", "test@example.com")
+		self.assertEqual(doc_ref.doctype, "User")
+		self.assertEqual(doc_ref.name, "test@example.com")


### PR DESCRIPTION
##### Consider reviewing first and independently:
- https://github.com/frappe/frappe/pull/27975

# Add DocRef and Enhance Document Handling

## Summary
This PR introduces a new `DocRef` class and enhances the document handling system to allow `DocRef` instances to be used as query or insert values. This change improves type safety and flexibility across the system.

## Changes
1. Introduced `DocRef` class as a lightweight reference to documents.
2. Modified `Engine` class in `frappe/database/query.py` to handle `DocRef` instances.
3. Updated `BaseDocument.get_valid_dict()` to handle `DocRef` instances.
4. Updated `Document` class to inherit from both `BaseDocument` and `DocRef`.

## Details

### New DocRef Class
- Lightweight class containing `doctype` and `name`.
- Implements `__str__` method for compatibility with existing query engine.

### Database Query Changes
- Introduced `FilterValue` type alias to include `DocRef`.
- Updated type hints in `Engine` class methods to use `FilterValue`.
- Added handling for `DocRef` instances in filter application.

### BaseDocument Changes
- Added handling for `DocRef` instances in `get_valid_dict()`.
- ~~Improved variable naming for clarity (changed `value` to `_value`).~~

### get_doc Function
- Registered separate handlers for `DocRef`, alongside `BaseDocument`, `str`, and `dict`.

### Document Class Changes
- `Document` now inherits from both `BaseDocument` and `DocRef`, unifying the interface.

## Impact
This change allows for more intuitive use of Document references in database operations:
- Queries can now accept `DocRef` instances directly as filter values.
- `get_doc()` function now supports `DocRef` as input.
- Improved type safety and clarity in document handling.
- Objects are passed by reference instead of (excessive) string-value copying; should improve performance a bit.

## Example Usage
```python
# Using DocRef
doc_ref = DocRef("User", "test@example.com")
user = get_doc(doc_ref)

# In queries (Document is a DocRef)
db.get_value("User", {"reference_doc": user}, "name")
# instead of: user.name 
```

`no-docs`