### PR TITLE
fix: Add check for print style disabled state before use - partial fix for #27965

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -578,7 +578,11 @@ def get_print_style(
 
 	css = frappe.get_template("templates/styles/standard.css").render(context)
 
-	if style and frappe.db.exists("Print Style", style) and not frappe.db.get_value("Print Style", style, "disabled"):
+	if (
+		style
+	    and frappe.db.exists("Print Style", style)
+	    and not frappe.db.get_value("Print Style", style, "disabled")
+	):
 		css = css + "\n" + frappe.db.get_value("Print Style", style, "css")
 
 	# move @import to top

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -578,7 +578,7 @@ def get_print_style(
 
 	css = frappe.get_template("templates/styles/standard.css").render(context)
 
-	if style and frappe.db.exists("Print Style", style):
+	if style and frappe.db.exists("Print Style", style) and not frappe.db.get_value("Print Style", style, "disabled"):
 		css = css + "\n" + frappe.db.get_value("Print Style", style, "css")
 
 	# move @import to top


### PR DESCRIPTION
This pull request will check if the requested print style (doctype) is disabled before adding it into the print css.

Currently, print styles are still being applied if they are set in Print Settings, but disabled in Print Style page. Is it intended?

If there are further tests required, I'd like to get some help - do I just need to add additional test cases or do I need to run all tests/ add some test result file for github actions? Thanks for helping me out here.

partially fixes #27965 