### PR TITLE
refactor: improve maintainability with a simple dispatcher

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -19,6 +19,7 @@ import json
 import os
 import typing
 from datetime import datetime
+from functools import singledispatchmethod
 
 import click
 
@@ -57,10 +58,20 @@ DEFAULT_FIELD_LABELS = {
 }
 
 
-def get_meta(doctype, cached=True) -> "_Meta":
-	cached = cached and isinstance(doctype, str)
-	if cached and (meta := frappe.cache.hget("doctype_meta", doctype)):
-		return meta
+def get_meta(doctype: str | Document, cached=True) -> "_Meta":
+	"""Get metadata for a doctype.
+
+	Args:
+	    doctype: The doctype as a string or Document object.
+	    cached: Whether to use cached metadata (default: True).
+
+	Returns:
+	    Meta object for the given doctype.
+	"""
+	doctype_name = getattr(doctype, "doctype", doctype)
+	if cached and not isinstance(doctype, Document):
+		if meta := frappe.cache.hget("doctype_meta", doctype_name):
+			return meta
 
 	meta = Meta(doctype)
 	frappe.cache.hset("doctype_meta", meta.name, meta)
@@ -112,12 +123,18 @@ class Meta(Document):
 		frappe._dict(fieldname="owner", fieldtype="Data"),
 	)
 
-	def __init__(self, doctype):
-		if isinstance(doctype, Document):
-			super().__init__(doctype.as_dict())
-		else:
-			super().__init__("DocType", doctype)
+	@singledispatchmethod
+	def __init__(self, arg):
+		raise TypeError(f"Unsupported argument type: {type(arg)}")
 
+	@__init__.register(str)
+	def _(self, doctype):
+		super().__init__("DocType", doctype)
+		self.process()
+
+	@__init__.register(Document)
+	def _(self, doc):
+		super().__init__(doc.as_dict())
 		self.process()
 
 	def load_from_db(self):


### PR DESCRIPTION
##### Prepares and endorses: https://github.com/frappe/frappe/pull/27973

## Refactor: Improve Maintainability with Simple Dispatcher

This PR introduces a simple dispatcher to improve the maintainability of the `get_doc` function in `frappe/model/document.py`. Key changes include:

- Implemented a `simple_singledispatch` decorator for cleaner function dispatching
- Refactored `get_doc` to use the new dispatcher, improving readability and extensibility
- Separated logic for different input types (string, dict, BaseDocument) into distinct functions
- Added type hints for better code clarity

These changes make the code more modular, easier to understand, and simpler to extend in the future.
