### PR TITLE
refactor: Replace hard-coded pg default port with PostgresDatabase.default_port

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -420,10 +420,11 @@ def get_site_config(sites_path: str | None = None, site_path: str | None = None)
 	# Generalized env variable overrides and defaults
 	def db_default_ports(db_type):
 		from frappe.database.mariadb.database import MariaDBDatabase
+		from frappe.database.postgres.database import PostgresDatabase
 
 		return {
 			"mariadb": MariaDBDatabase.default_port,
-			"postgres": 5432,
+			"postgres": PostgresDatabase.default_port,
 		}[db_type]
 
 	config["redis_queue"] = (


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Using `frappe.database.postgres.database.PostgresDatabase.default_port` instead of a hard-coded value allows the default_port field to be changed arbitrarily (highly unlikely though) without worrying about breaking behavior elsewhere and is consistent with how the default port is fetched for `mariadb` connections. One more place where something similar could be done is [frappe.connections.utils.check_database](https://github.com/Priyansh121096/frappe/blob/0fcf2f22133bcea4ec36f2c065dcd20fbef3757c/frappe/utils/connections.py#L37).

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
