### PR TITLE
Update schema.py

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -3,7 +3,6 @@ import re
 import frappe
 from frappe import _
 from frappe.utils import cint, cstr, flt
-from frappe.utils.defaults import get_not_null_defaults
 
 SPECIAL_CHAR_PATTERN = re.compile(r"[\W]", flags=re.UNICODE)
 VARCHAR_CAST_PATTERN = re.compile(r"varchar\(([\d]+)\)")
@@ -25,7 +24,6 @@ class DBTable:
 		self.add_column: list[DbColumn] = []
 		self.change_type: list[DbColumn] = []
 		self.change_name: list[DbColumn] = []
-		self.change_nullability: list[DbColumn] = []
 		self.add_unique: list[DbColumn] = []
 		self.add_index: list[DbColumn] = []
 		self.drop_unique: list[DbColumn] = []
@@ -91,16 +89,15 @@ class DBTable:
 				continue
 
 			self.columns[field.get("fieldname")] = DbColumn(
-				table=self,
-				fieldname=field.get("fieldname"),
-				fieldtype=field.get("fieldtype"),
-				length=field.get("length"),
-				default=field.get("default"),
-				set_index=field.get("search_index"),
-				options=field.get("options"),
-				unique=field.get("unique"),
-				precision=field.get("precision"),
-				not_nullable=field.get("not_nullable"),
+				self,
+				field.get("fieldname"),
+				field.get("fieldtype"),
+				field.get("length"),
+				field.get("default"),
+				field.get("search_index"),
+				field.get("options"),
+				field.get("unique"),
+				field.get("precision"),
 			)
 
 	def validate(self):
@@ -174,20 +171,7 @@ class DBTable:
 
 
 class DbColumn:
-	def __init__(
-		self,
-		*,
-		table,
-		fieldname,
-		fieldtype,
-		length,
-		default,
-		set_index,
-		options,
-		unique,
-		precision,
-		not_nullable,
-	):
+	def __init__(self, table, fieldname, fieldtype, length, default, set_index, options, unique, precision):
 		self.table = table
 		self.fieldname = fieldname
 		self.fieldtype = fieldtype
@@ -197,56 +181,36 @@ class DbColumn:
 		self.options = options
 		self.unique = unique
 		self.precision = precision
-		self.not_nullable = not_nullable
 
 	def get_definition(self, for_modification=False):
-		column_def = get_definition(
-			self.fieldtype,
-			precision=self.precision,
-			length=self.length,
-			options=self.options,
-		)
-
+		column_def = get_definition(self.fieldtype, precision=self.precision, length=self.length)
+		print(f"Field: {self.fieldname}, Type: {self.fieldtype}, Default: {self.default}")
 		if not column_def:
 			return column_def
 
-		null = True
-		default = None
-		unique = False
-
 		if self.fieldtype in ("Check", "Int"):
-			default = cint(self.default)
-			null = False
+			default_value = cint(self.default) or 0
+			column_def += f" not null default {default_value}"
 
 		elif self.fieldtype in ("Currency", "Float", "Percent"):
-			default = flt(self.default)
-			null = False
+			default_value = flt(self.default) or 0
+			column_def += f" not null default {default_value}"
+		elif self.fieldtype == "Date":
+			if self.default == "Today" or self.default== "TODAY":
+				column_def += " default CURRENT_DATE()"
+			elif self.default:
+				column_def += f" default {frappe.db.escape(self.default)}"
 
 		elif (
 			self.default
 			and (self.default not in frappe.db.DEFAULT_SHORTCUTS)
 			and not cstr(self.default).startswith(":")
 		):
-			default = frappe.db.escape(self.default)
-
-		if self.not_nullable and null:
-			if default is None:
-				default = get_not_null_defaults(self.fieldtype)
-				if isinstance(default, str):
-					default = frappe.db.escape(default)
-			null = False
+			column_def += f" default {frappe.db.escape(self.default)}"
 
 		if self.unique and not for_modification and (column_def not in ("text", "longtext")):
-			unique = True
-
-		if not null:
-			column_def += " NOT NULL"
-
-		if default is not None:
-			column_def += f" DEFAULT {default}"
-
-		if unique:
-			column_def += " UNIQUE"
+			column_def += " unique"
+		print(f"Final column_def: {column_def}")
 		return column_def
 
 	def build_for_alter_table(self, current_def):
@@ -285,10 +249,6 @@ class DbColumn:
 			and not cstr(self.default).startswith(":")
 		):
 			self.table.set_default.append(self)
-
-		# nullability
-		if self.not_nullable is not None and (self.not_nullable != current_def["not_nullable"]):
-			self.table.change_nullability.append(self)
 
 		# index should be applied or dropped irrespective of type change
 		if (current_def["index"] and not self.set_index) and column_type not in ("text", "longtext"):
@@ -361,19 +321,8 @@ def validate_column_length(fieldname):
 		frappe.throw(_("Fieldname is limited to 64 characters ({0})").format(fieldname))
 
 
-def get_definition(fieldtype, precision=None, length=None, *, options=None):
+def get_definition(fieldtype, precision=None, length=None):
 	d = frappe.db.type_map.get(fieldtype)
-
-	if (
-		fieldtype == "Link"
-		and options
-		# XXX: This might not trigger if referred doctype is not yet created
-		# This is largely limitation of how migration happens though.
-		# Maybe we can sort by creation and then modified?
-		and frappe.db.exists("DocType", options)
-		and frappe.get_meta(options).autoname == "UUID"
-	):
-		d = ("uuid", None)
 
 	if not d:
 		return


### PR DESCRIPTION
When you run `bench --site <site-name> migrate` the default value given for Date data type `Today` is not handled in `schema.py`. That is causing `migrate` to create an error and stop the migration. This commit handles the data type `Date` and default value `Today` - which is the case for example in DocType `Stock Entry` and field `posting_date`
