### PR TITLE
refactor: simplified Button Text Logic for Custom Navigation Links

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -51,15 +51,12 @@ frappe.ui.form.on("DocType", {
 		}
 
 		if (!frm.is_new() && !frm.doc.istable) {
-			if (frm.doc.issingle) {
-				frm.add_custom_button(__("Go to {0}", [__(frm.doc.name)]), () => {
-					window.open(`/app/${frappe.router.slug(frm.doc.name)}`);
-				});
-			} else {
-				frm.add_custom_button(__("Go to {0} List", [__(frm.doc.name)]), () => {
-					window.open(`/app/${frappe.router.slug(frm.doc.name)}`);
-				});
-			}
+			const button_text = frm.doc.issingle
+				? __("Go to {0}", [__(frm.doc.name)])
+				: __("Go to {0} List", [__(frm.doc.name)]);
+			frm.add_custom_button(button_text, () => {
+				window.open(`/app/${frappe.router.slug(frm.doc.name)}`);
+			});
 		}
 
 		const customize_form_link = `<a href="/app/customize-form">${__("Customize Form")}</a>`;


### PR DESCRIPTION
This PR refactors the logic for adding custom navigation buttons in forms. The existing code had repetitive `if-else` conditions for handling the text differences between single and list views. 

Changes:
- Consolidated the repeated logic into a more efficient structure.
- Used a single conditional to differentiate between "Go to {0}" and "Go to {0} List" button labels.
- Reduced redundancy and improved code readability.

This update maintains the same functionality while making the code cleaner and easier to maintain.