### PR TITLE
chore(deps): switch to our fork of rq

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "hiredis~=2.0.0",
     "requests-oauthlib~=1.3.0",
     "requests~=2.32.0",
-    "rq~=1.14.1",
+    "rq @ git+https://github.com/frappe/rq@8414b230e1fa797b40922351652f63552310046a",
     "rsa>=4.1",
     "semantic-version~=2.10.0",
     "sqlparse~=0.5.0",


### PR DESCRIPTION
Can't upgrade v14 to rq 1.15 because of breaking changes, but it has a fix we need on 1.14
