### PR TITLE
fix: set `print_logs=False` for some `has_permission()` calls

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -204,13 +204,13 @@ def get_versions(doc: "Document") -> list[dict]:
 
 
 def get_error_log_exists(doc: "Document") -> bool:
-	if has_permission("Error Log"):
+	if has_permission("Error Log", print_logs=False):
 		return frappe.db.exists("Error Log", {"reference_doctype": doc.doctype, "reference_name": doc.name})
 	return False
 
 
 def get_webhook_request_log_exists(doc: "Document") -> bool:
-	if has_permission("Webhook Request Log"):
+	if has_permission("Webhook Request Log", print_logs=False):
 		return frappe.db.exists(
 			"Webhook Request Log", {"reference_doctype": doc.doctype, "reference_document": doc.name}
 		)


### PR DESCRIPTION
This otherwise results in a lot of spam like: https://github.com/frappe/frappe/pull/27931#issuecomment-2396505626

Fixes #27931
