### PR TITLE
fix: RTL support by adding dynamic direction attribute to HTML tag

### DIFF
--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- Built on Frappe. https://frappeframework.com/ -->
-<html lang="{{boot.lang}}">
+<html lang="{{boot.lang}}" dir="{{ 'rtl' if is_rtl() else 'ltr' }}">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
This PR fixes the handling of RTL (Right-to-Left) languages by adding a `dir` attribute to the base template.

### Changes:
- Added the `dir` attribute to the `<html>` element, which sets the text direction based on the `is_rtl()` function.
- For RTL languages, the `dir` is set to `rtl`; for LTR languages, it defaults to `ltr`.

### Purpose:
This fix ensures proper text direction for RTL languages (e.g., Arabic), improving language compatibility and display.