### PR TITLE
fix(grid): return if no df

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -688,6 +688,7 @@ export default class GridRow {
 		this.grid.visible_columns.forEach((col, ci) => {
 			// to get update df for the row
 			let df = fields.find((field) => field?.fieldname === col[0].fieldname);
+			if (!df) return;
 
 			this.set_dependant_property(df);
 


### PR DESCRIPTION
Certain cases seem to cause this for web forms

Support ticket - 23256

```
grid_row.js:730 Uncaught TypeError: Cannot read properties of undefined (reading 'reqd')
    at fn.set_dependant_property (grid_row.js:730:8)
    at grid_row.js:688:9
    at Array.forEach (<anonymous>)
    at fn.setup_columns (grid_row.js:684:29)
    at fn.render_row (grid_row.js:310:8)
    at fn.make (grid_row.js:40:22)
    at new fn (grid_row.js:12:8)
    at vr.render_result_rows (grid.js:480:20)
    at vr.refresh (grid.js:438:8)
    at vr.add_new_row (grid.js:839:10)
```
