### PR TITLE
fix: disappearing frontend asset bundles

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -158,12 +158,23 @@ async function update_assets_obj(app, assets, assets_rtl) {
 	const app_path = path.join(apps_path, app, app);
 	const dist_path = path.join(app_path, "public", "dist");
 	const files = await glob("**/*.bundle.*.{js,css}", { cwd: dist_path });
-	const prefix = path.join("/", "assets", app, "dist");
+	const assets_dist = path.join("assets", app, "dist");
+	const prefix = path.join("/", assets_dist);
 
 	// eg: "js/marketplace.bundle.6SCSPSGQ.js"
 	for (const file of files) {
+		const source_path = path.join(dist_path, file);
+		const dest_path = path.join(sites_path, assets_dist, file);
+
+		// Copy asset file from app/public to sites/assets
+		if (!fs.existsSync(dest_path)) {
+			const dest_dir = path.dirname(dest_path);
+			fs.mkdirSync(dest_dir, { recursive: true });
+			fs.copyFileSync(source_path, dest_path);
+		}
+
 		// eg: [ "marketplace", "bundle", "6SCSPSGQ", "js" ]
-		const parts = path.parse(file).base.split(".");
+		const parts = path.basename(file).split(".");
 
 		// eg: "marketplace.bundle.js"
 		const key = [...parts.slice(0, -2), parts.at(-1)].join(".");


### PR DESCRIPTION
![Screenshot 2024-10-08 at 12 15 45](https://github.com/user-attachments/assets/35243ac6-a0e8-4317-817c-e923bff1a4e3)

Bundles tend to be missing after build during `get-app`. This seems to happen even if `bench build` is called after `get-app`. This PR aims to fix that 🤞

Alright, this should handle missing assets caused due to installation of app from cache. Probably doesn't catch disappearing bundles if not installed from cache. The build code could use a refactor. Whoever attempts to do so, please add it to `frappe/bench`.