### PR TITLE
fix: ensure that the role exists

### DIFF
--- a/frappe/patches/v16_0/move_role_desk_settings_to_user.py
+++ b/frappe/patches/v16_0/move_role_desk_settings_to_user.py
@@ -11,10 +11,10 @@ def execute():
 	for user in frappe.get_list("User"):
 		user_desk_settings = {}
 		for role_name in frappe.get_roles(username=user.name):
-			role = roles[role_name]
-			for key in desk_properties:
-				if role.get(key) is None:
-					role[key] = 1
-				user_desk_settings[key] = user_desk_settings.get(key) or role.get(key)
+			if role := roles.get(role_name):
+				for key in desk_properties:
+					if role.get(key) is None:
+						role[key] = 1
+					user_desk_settings[key] = user_desk_settings.get(key) or role.get(key)
 
 		frappe.db.set_value("User", user.name, user_desk_settings)


### PR DESCRIPTION
Some setups can have broken links here, resulting in a KeyError

Reference: https://frappecloud.com/dashboard/sites/frappeio.frappe.cloud/jobs/52a4feb928
