### PR TITLE
fix: alignment and icon color for attachments

### DIFF
--- a/frappe/public/js/frappe/dom.js
+++ b/frappe/public/js/frappe/dom.js
@@ -328,7 +328,7 @@ frappe.get_data_pill = (
 	if (remove_action) {
 		let remove_btn = $(`
 			<span class="remove-btn cursor-pointer">
-				${frappe.utils.icon("close", "sm")}
+				${frappe.utils.icon("close", "sm", "es-icon")}
 			</span>
 		`);
 		if (typeof remove_action === "function") {

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -648,6 +648,7 @@ body {
 			width: 94px;
 			display: block;
 			margin-left: var(--margin-xs);
+			text-align: left;
 		}
 	}
 }

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -635,7 +635,6 @@ body {
 		@include get_textstyle("sm", "regular");
 		justify-content: space-between;
 		box-shadow: none;
-		line-height: 1;
 	}
 }
 .attachment-row {


### PR DESCRIPTION
Before
<img width="172" alt="Screenshot 2024-10-08 at 4 53 48 PM" src="https://github.com/user-attachments/assets/86dce729-ed4a-44be-bb19-f16c3438dabc">
After
<img width="172" alt="Screenshot 2024-10-08 at 4 48 45 PM" src="https://github.com/user-attachments/assets/a86f6599-d6a6-461e-829c-bc73c00005c8">
