### PR TITLE
fix: escape backslashes in `repl` to prevent syntax errors

### DIFF
--- a/frappe/model/utils/__init__.py
+++ b/frappe/model/utils/__init__.py
@@ -73,7 +73,9 @@ def render_include(content):
 					if path.endswith(".html"):
 						include = html_to_js_template(path, include)
 
-					content = re.sub(rf"""{{% include\s['"]{path}['"]\s%}}""", include, content)
+					content = re.sub(
+						rf"""{{% include\s['"]{path}['"]\s%}}""", include.replace("\\", "\\\\"), content
+					)
 
 		else:
 			break


### PR DESCRIPTION
### Before
Python processes the backslash escapes in the `repl` parameter of `re.sub`

From [python.org](https://docs.python.org/3/library/re.html):

> _repl_ can be a string or a function; if it is a string, any backslash escapes in it are processed. That is, `\n` is converted to a single newline character, `\r` is converted to a carriage return, and so forth. Unknown escapes of ASCII letters are reserved for future use and treated as errors.

```py
\n => \n
\\n => \n # problem!
```
Usage like this one led to syntax error:
```py
render_include('{% include "erpnext/stock/report/stock_balance/stock_balance.js" %}')
```

Because the file had a string with a newline literal.

### After
```py
\n => \\n => \n
\\n => \\\\n => \\n
```
