### PR TITLE
refactor: clarify test record dep management in test modules

### DIFF
--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -5,7 +5,7 @@ from frappe.contacts.doctype.contact.contact import get_full_name
 from frappe.email import get_contact_list
 from frappe.tests import IntegrationTestCase, UnitTestCase
 
-test_dependencies = ["Contact", "Salutation"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Contact", "Salutation"]
 
 
 class UnitTestContact(UnitTestCase):

--- a/frappe/core/doctype/docshare/test_docshare.py
+++ b/frappe/core/doctype/docshare/test_docshare.py
@@ -6,7 +6,7 @@ import frappe.share
 from frappe.automation.doctype.auto_repeat.test_auto_repeat import create_submittable_doctype
 from frappe.tests import IntegrationTestCase, UnitTestCase
 
-test_dependencies = ["User"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["User"]
 
 
 class UnitTestDocshare(UnitTestCase):

--- a/frappe/core/doctype/doctype/boilerplate/test_controller._py
+++ b/frappe/core/doctype/doctype/boilerplate/test_controller._py
@@ -5,6 +5,13 @@
 from frappe.tests import IntegrationTestCase, UnitTestCase
 
 
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record depdendencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
 class Test{classname}(UnitTestCase):
 	"""
 	Unit tests for {classname}.

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -14,7 +14,7 @@ from frappe.desk.reportview import save_report as _save_report
 from frappe.tests import IntegrationTestCase, UnitTestCase
 
 test_records = frappe.get_test_records("Report")
-test_dependencies = ["User"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["User"]
 
 
 class UnitTestReport(UnitTestCase):

--- a/frappe/core/doctype/role_profile/test_role_profile.py
+++ b/frappe/core/doctype/role_profile/test_role_profile.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe.tests import IntegrationTestCase, UnitTestCase
 
-test_dependencies = ["Role"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Role"]
 
 
 class UnitTestRoleProfile(UnitTestCase):

--- a/frappe/custom/doctype/customize_form/test_customize_form.py
+++ b/frappe/custom/doctype/customize_form/test_customize_form.py
@@ -9,7 +9,7 @@ from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.tests import IntegrationTestCase, UnitTestCase
 from frappe.tests.utils import make_test_records_for_doctype
 
-test_dependencies = ["Custom Field", "Property Setter"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Custom Field", "Property Setter"]
 
 
 class UnitTestCustomizeForm(UnitTestCase):

--- a/frappe/desk/doctype/todo/test_todo.py
+++ b/frappe/desk/doctype/todo/test_todo.py
@@ -6,7 +6,7 @@ from frappe.model.db_query import DatabaseQuery
 from frappe.permissions import add_permission, reset_perms
 from frappe.tests import IntegrationTestCase, UnitTestCase
 
-test_dependencies = ["User"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["User"]
 
 
 class UnitTestTodo(UnitTestCase):

--- a/frappe/email/doctype/notification/test_notification.py
+++ b/frappe/email/doctype/notification/test_notification.py
@@ -12,7 +12,7 @@ from frappe.tests import IntegrationTestCase, UnitTestCase
 
 from .notification import trigger_notifications
 
-test_dependencies = ["User", "Notification"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["User", "Notification"]
 
 
 @contextmanager

--- a/frappe/integrations/doctype/token_cache/test_token_cache.py
+++ b/frappe/integrations/doctype/token_cache/test_token_cache.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe.tests import IntegrationTestCase, UnitTestCase
 
-test_dependencies = ["User", "Connected App", "Token Cache"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["User", "Connected App", "Token Cache"]
 
 
 class UnitTestTokenCache(UnitTestCase):

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -18,7 +18,7 @@ from frappe.tests import IntegrationTestCase
 from frappe.tests.test_query_builder import db_type_is, run_only_if
 from frappe.utils.testutils import add_custom_field, clear_custom_fields
 
-test_dependencies = ["User", "Blog Post", "Blog Category", "Blogger"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["User", "Blog Post", "Blog Category", "Blogger"]
 
 
 @contextmanager

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -16,7 +16,7 @@ from frappe.query_builder.utils import db_type_is
 from frappe.tests import IntegrationTestCase
 from frappe.tests.test_query_builder import run_only_if
 
-test_dependencies = ["Email Account"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Email Account"]
 
 
 class TestEmail(IntegrationTestCase):

--- a/frappe/tests/test_form_load.py
+++ b/frappe/tests/test_form_load.py
@@ -7,7 +7,7 @@ from frappe.desk.form.load import get_docinfo, getdoc, getdoctype
 from frappe.tests import IntegrationTestCase
 from frappe.utils.file_manager import save_file
 
-test_dependencies = ["Blog Category", "Blogger"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Blog Category", "Blogger"]
 
 
 class TestFormLoad(IntegrationTestCase):

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -26,7 +26,7 @@ from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import make_test_records_for_doctype
 from frappe.utils.data import now_datetime
 
-test_dependencies = ["Blogger", "Blog Post", "User", "Contact", "Salutation"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Blogger", "Blog Post", "User", "Contact", "Salutation"]
 
 
 class TestPermissions(IntegrationTestCase):

--- a/frappe/tests/utils/__init__.py
+++ b/frappe/tests/utils/__init__.py
@@ -47,3 +47,6 @@ from frappe.deprecation_dumpster import (
 from frappe.deprecation_dumpster import (
 	tests_UnitTestCase as UnitTestCase,
 )
+from frappe.deprecation_dumpster import (
+	tests_utils_get_dependencies as get_dependencies,
+)

--- a/frappe/tests/utils/generators.py
+++ b/frappe/tests/utils/generators.py
@@ -48,12 +48,54 @@ def get_dependencies(doctype):
 	options_list = [df.options for df in link_fields]
 
 	if hasattr(test_module, "test_dependencies"):
+		from frappe.deprecation_dumpster import deprecation_warning
+
+		deprecation_warning(
+			"2024-10-09",
+			"v17",
+			"""test_dependencies was clarified to EXTRA_TEST_RECORD_DEPENDENCIES: run:
+```bash
+# Find Python files
+find . -name "*.py" | while read -r file; do
+    # Check if the file contains 'test_dependencies' at the module level
+    if grep -q "^test_dependencies" "$file"; then
+        # Replace 'test_dependencies' with 'EXTRA_TEST_RECORD_DEPENDENCIES'
+        sed -i 's/^test_dependencies/EXTRA_TEST_RECORD_DEPENDENCIES/' "$file"
+        echo "Updated $file"
+    fi
+done
+```""",
+		)
 		options_list += test_module.test_dependencies
+	if hasattr(test_module, "EXTRA_TEST_RECORD_DEPENDENCIES"):
+		options_list += test_module.EXTRA_TEST_RECORD_DEPENDENCIES
 
 	options_list = list(set(options_list))
 
 	if hasattr(test_module, "test_ignore"):
+		from frappe.deprecation_dumpster import deprecation_warning
+
+		deprecation_warning(
+			"2024-10-09",
+			"v17",
+			"""test_ignore was clarified to IGNORE_TEST_RECORD_DEPENDENCIES: run:
+```bash
+# Find Python files
+find . -name "*.py" | while read -r file; do
+    # Check if the file contains 'test_dependencies' at the module level
+    if grep -q "^test_ignore" "$file"; then
+        # Replace 'test_ignore' with 'IGNORE_TEST_RECORD_DEPENDENCIES'
+        sed -i 's/^test_ignore/IGNORE_TEST_RECORD_DEPENDENCIES/' "$file"
+        echo "Updated $file"
+    fi
+done
+```""",
+		)
 		for doctype_name in test_module.test_ignore:
+			if doctype_name in options_list:
+				options_list.remove(doctype_name)
+	if hasattr(test_module, "IGNORE_TEST_RECORD_DEPENDENCIES"):
+		for doctype_name in test_module.IGNORE_TEST_RECORD_DEPENDENCIES:
 			if doctype_name in options_list:
 				options_list.remove(doctype_name)
 

--- a/frappe/website/doctype/blog_post/test_blog_post.py
+++ b/frappe/website/doctype/blog_post/test_blog_post.py
@@ -13,7 +13,7 @@ from frappe.website.serve import get_response
 from frappe.website.utils import clear_website_cache
 from frappe.website.website_generator import WebsiteGenerator
 
-test_dependencies = ["Blog Post"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Blog Post"]
 
 
 class UnitTestBlogPost(UnitTestCase):

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -8,7 +8,7 @@ from frappe.utils import set_request
 from frappe.website.doctype.web_form.web_form import accept
 from frappe.website.serve import get_response_content
 
-test_dependencies = ["Web Form"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Web Form"]
 
 
 class UnitTestWebForm(UnitTestCase):

--- a/frappe/website/doctype/website_route_meta/test_website_route_meta.py
+++ b/frappe/website/doctype/website_route_meta/test_website_route_meta.py
@@ -5,7 +5,7 @@ from frappe.tests import IntegrationTestCase, UnitTestCase
 from frappe.utils import set_request
 from frappe.website.serve import get_response
 
-test_dependencies = ["Blog Post"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Blog Post"]
 
 
 class UnitTestWebsiteRouteMeta(UnitTestCase):


### PR DESCRIPTION
**Migration Script 1**

```bash
# Find Python files
find . -name "*.py" | while read -r file; do
    # Check if the file contains 'test_dependencies' at the module level
    if grep -q "^test_dependencies" "$file"; then
        # Replace 'test_dependencies' with 'EXTRA_TEST_RECORD_DEPENDENCIES'
        sed -i 's/^test_dependencies/EXTRA_TEST_RECORD_DEPENDENCIES/' "$file"
        echo "Updated $file"
    fi
done
```

**Migration Script 2**
```bash
# Find Python files
find . -name "*.py" | while read -r file; do
    # Check if the file contains 'test_ignore' at the module level
    if grep -q "^test_ignore" "$file"; then
        # Replace 'test_ignore' with 'IGNORE_TEST_RECORD_DEPENDENCIES'
        sed -i 's/^test_ignore/IGNORE_TEST_RECORD_DEPENDENCIES/' "$file"
        echo "Updated $file"
    fi
done
```

- **fix: recursion in test record generators**
- **chore: deprecate frappe.tests.utils.get_dependencies**