### PR TITLE
ci: Run optimized python and control warnings

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -47,6 +47,8 @@ jobs:
     env:
       NODE_ENV: "production"
       PYTHONOPTIMIZE: 2
+      # noisy 3rd party library warnings
+      PYTHONWARNINGS: "module,ignore:::babel.messages.extract"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -46,6 +46,7 @@ jobs:
     timeout-minutes: 30
     env:
       NODE_ENV: "production"
+      PYTHONOPTIMIZE: 2
 
     strategy:
       fail-fast: false

--- a/frappe/parallel_test_runner.py
+++ b/frappe/parallel_test_runner.py
@@ -32,8 +32,6 @@ class ParallelTestRunner:
 		self.total_tests = 0
 		self.test_result = None
 		self.setup_test_file_list()
-		warnings.simplefilter("module", DeprecationWarning)
-		warnings.simplefilter("module", PendingDeprecationWarning)
 
 	def setup_and_run(self):
 		self.setup_test_site()

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -175,15 +175,13 @@ def normalize_query(query: str) -> str:
 
 
 def record(force=False):
-	if __debug__:
-		if frappe.cache.get_value(RECORDER_INTERCEPT_FLAG) or force:
-			frappe.local._recorder = Recorder(force=force)
+	if frappe.cache.get_value(RECORDER_INTERCEPT_FLAG) or force:
+		frappe.local._recorder = Recorder(force=force)
 
 
 def dump():
-	if __debug__:
-		if hasattr(frappe.local, "_recorder"):
-			frappe.local._recorder.dump()
+	if hasattr(frappe.local, "_recorder"):
+		frappe.local._recorder.dump()
 
 
 class Recorder:

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -10,6 +10,8 @@ from urllib.parse import parse_qs, urlparse
 
 import cssutils
 import pdfkit
+
+pdfkit.source.unicode = str  # NOTE: upstream bug; PYTHONOPTIMIZE=1 optimized this away
 from bs4 import BeautifulSoup
 from packaging.version import Version
 from pypdf import PdfReader, PdfWriter


### PR DESCRIPTION
- **ci: run doubly optimized python**
  strips `assert`, `__debug__`-guarded paths and docstrings from bincode
  - https://docs.python.org/3/using/cmdline.html#cmdoption-O
  - https://docs.python.org/3/using/cmdline.html#cmdoption-OO

- **ci: control python warnings**
  configure CI warnings; do a full run before release
  - https://docs.python.org/3/using/cmdline.html#cmdoption-OO

- **fix: monkey patch pdfkit**

- **fix: recorder; don't guard on python optimization level** (likely wrong use of `__debug__`)
  
cc @akhilnarang 
