### PR TITLE
Fix/non developer condition

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -41,7 +41,7 @@ frappe.ui.form.on("DocType", {
 			}
 		});
 
-		if (frappe.session.user !== "Administrator" || !frappe.boot.developer_mode) {
+		if (frappe.session.user !== "Administrator" && !frappe.boot.developer_mode) {
 			if (frm.is_new()) {
 				frm.set_value("custom", 1);
 			}

--- a/frappe/core/doctype/doctype/doctype_list.js
+++ b/frappe/core/doctype/doctype/doctype_list.js
@@ -16,7 +16,7 @@ frappe.listview_settings["DocType"] = {
 			editable_grid = 1,
 		} = args || {};
 
-		let non_developer = frappe.session.user !== "Administrator" || !frappe.boot.developer_mode;
+		let non_developer = frappe.session.user !== "Administrator" && !frappe.boot.developer_mode;
 		let fields = [
 			{
 				label: __("DocType Name"),


### PR DESCRIPTION
I adjusted the condition for developer mode validation in the doctype files, but I'm not sure if there is a specific reason for the code being in this form or if this is indeed a gap.
I was using an application that was in developer mode, and I tried to create a doctype using a user that is not Administrator, but the doctype was always being created as 'Custom'.