### PR TITLE
feat(smtp): Support local_hostname and source_address

### DIFF
--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -72,6 +72,8 @@
   "smtp_port",
   "column_break_38",
   "no_smtp_authentication",
+  "smtp_local_hostname",
+  "smtp_source_address",
   "signature_section",
   "add_signature",
   "signature",
@@ -159,7 +161,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Domain",
-   "options": "Email Domain"
+   "options": "Email Domain",
+   "search_index": 1
   },
   {
    "depends_on": "eval:!doc.domain",
@@ -692,12 +695,26 @@
    "fieldname": "backend_app_flow",
    "fieldtype": "Check",
    "label": "Authenticate as Service Principal"
+  },
+  {
+   "description": "Fully qualified domain name or IP in square brackets",
+   "fetch_from": "domain.smtp_local_hostname",
+   "fieldname": "smtp_local_hostname",
+   "fieldtype": "Data",
+   "label": "Local Hostname (SMTP)"
+  },
+  {
+   "description": "Preferred outgoing network interface IP",
+   "fetch_from": "domain.smtp_source_address",
+   "fieldname": "smtp_source_address",
+   "fieldtype": "Data",
+   "label": "Source Address (SMTP)"
   }
  ],
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-07-18 11:05:57.193762",
+ "modified": "2024-10-10 16:00:13.417591",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -105,8 +105,10 @@ class EmailAccount(Document):
 			"", "Frappe Mail", "GMail", "Sendgrid", "SparkPost", "Yahoo Mail", "Outlook.com", "Yandex.Mail"
 		]
 		signature: DF.TextEditor | None
+		smtp_local_hostname: DF.Data | None
 		smtp_port: DF.Data | None
 		smtp_server: DF.Data | None
+		smtp_source_address: DF.Data | None
 		track_email_status: DF.Check
 		uidnext: DF.Int
 		uidvalidity: DF.Data | None
@@ -498,6 +500,7 @@ class EmailAccount(Document):
 		return oauth_token.get_password("access_token") if oauth_token else None
 
 	def sendmail_config(self):
+		# Select a specific outbound IP when multiple network interfaces are available
 		return {
 			"email_account": self.name,
 			"server": self.smtp_server,
@@ -508,6 +511,8 @@ class EmailAccount(Document):
 			"use_tls": cint(self.use_tls),
 			"use_oauth": self.auth_method == "OAuth",
 			"access_token": self.get_access_token(),
+			"local_hostname": self.smtp_local_hostname,
+			"source_address": (self.smtp_source_address, 0) if self.smtp_source_address else None,
 		}
 
 	def get_smtp_server(self):

--- a/frappe/email/doctype/email_domain/email_domain.json
+++ b/frappe/email/doctype/email_domain/email_domain.json
@@ -24,7 +24,9 @@
   "validate_ssl_certificate_for_outgoing",
   "column_break_18",
   "smtp_port",
-  "append_emails_to_sent_folder"
+  "append_emails_to_sent_folder",
+  "smtp_local_hostname",
+  "smtp_source_address"
  ],
  "fields": [
   {
@@ -141,6 +143,18 @@
    "fieldname": "validate_ssl_certificate_for_outgoing",
    "fieldtype": "Check",
    "label": "Validate SSL Certificate"
+  },
+  {
+   "description": "Fully qualified domain name or IP in square brackets",
+   "fieldname": "smtp_local_hostname",
+   "fieldtype": "Data",
+   "label": "Local Hostname (SMTP)"
+  },
+  {
+   "description": "Preferred outgoing network interface IP",
+   "fieldname": "smtp_source_address",
+   "fieldtype": "Data",
+   "label": "Source Address (SMTP)"
   }
  ],
  "icon": "icon-inbox",
@@ -150,7 +164,7 @@
    "link_fieldname": "domain"
   }
  ],
- "modified": "2024-03-23 16:03:23.836849",
+ "modified": "2024-10-10 15:56:01.121667",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Domain",

--- a/frappe/email/doctype/email_domain/email_domain.py
+++ b/frappe/email/doctype/email_domain/email_domain.py
@@ -24,6 +24,8 @@ EMAIL_DOMAIN_FIELDS = [
 	"use_ssl_for_outgoing",
 	"append_emails_to_sent_folder",
 	"incoming_port",
+	"smtp_local_hostname",
+	"smtp_source_address",
 ]
 
 
@@ -66,8 +68,10 @@ class EmailDomain(Document):
 		domain_name: DF.Data
 		email_server: DF.Data
 		incoming_port: DF.Data | None
+		smtp_local_hostname: DF.Data | None
 		smtp_port: DF.Data | None
 		smtp_server: DF.Data
+		smtp_source_address: DF.Data | None
 		use_imap: DF.Check
 		use_ssl: DF.Check
 		use_ssl_for_outgoing: DF.Check
@@ -123,4 +127,10 @@ class EmailDomain(Document):
 		elif self.use_tls:
 			self.smtp_port = self.smtp_port or 587
 
-		conn_method((self.smtp_server or ""), cint(self.smtp_port), timeout=30).quit()
+		conn_method(
+			(self.smtp_server or ""),
+			cint(self.smtp_port),
+			timeout=30,
+			source_address=(self.smtp_source_address, 0) if self.smtp_source_address else None,
+			local_hostname=self.smtp_local_hostname,
+		).quit()

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -26,6 +26,8 @@ class SMTPServer:
 		use_ssl=None,
 		use_oauth=0,
 		access_token=None,
+		source_address: tuple[str, int] | None = None,
+		local_hostname: str | None = None,
 	):
 		self.login = login
 		self.email_account = email_account
@@ -36,6 +38,8 @@ class SMTPServer:
 		self.use_ssl = use_ssl
 		self.use_oauth = use_oauth
 		self.access_token = access_token
+		self.local_hostname = local_hostname
+		self.source_address = source_address
 		self._session = None
 
 		if not self.server:
@@ -72,7 +76,13 @@ class SMTPServer:
 		SMTP = smtplib.SMTP_SSL if self.use_ssl else smtplib.SMTP
 
 		try:
-			_session = SMTP(self.server, self.port, timeout=2 * 60)
+			_session = SMTP(
+				self.server,
+				self.port,
+				timeout=2 * 60,
+				source_address=self.source_address,
+				local_hostname=self.local_hostname,
+			)
 			if not _session:
 				frappe.msgprint(
 					_("Could not connect to outgoing email server"), raise_exception=frappe.OutgoingEmailError


### PR DESCRIPTION
# Why?

I noticed recently that e-mail sending via Gmail's SMTP relay failed. This happened twice:
* To use the SMTP relay, you provide a specific IP to be whitelisted. However, on machines with multiple network interfaces, `smtplib` only takes the default IP (cf. first result of `ip route`).
* For some reason, calling the SMTP HELO command with an invalid FQDN (one whose DNS resolution fails or does not match the machine's outbound IP) stopped working. This is either a change on Gmail's side, or possibly a change in `smtplib` via an unattended-upgrade, I do not know.

---

**Correct HELO**
![HELO my ip. at your service](https://github.com/user-attachments/assets/37668a45-bd37-4656-8041-d935a6ca85ca)

**Incorrect HELO**
![HELO localhost. connection closed by foreign host](https://github.com/user-attachments/assets/0d8e577b-d78c-4255-b215-b48385bf3902)


## Further reading

- <https://meta.discourse.org/t/discourse-smtp-sends-ehlo-localhost-instead-of-domain-breaking-google-smtp-relay/176755/13>
  > 4.1.1.1 Extended HELLO (EHLO) or HELLO (HELO)
The argument clause contains the fully-qualified domain name of the SMTP client, if one is available. In situations in which the SMTP client system does not have a meaningful domain name (e.g., when its address is dynamically allocated and no reverse mapping record is available), the client SHOULD send an address literal
- <https://meta.discourse.org/t/discourse-smtp-sends-ehlo-localhost-instead-of-domain-breaking-google-smtp-relay/176755/23>
  > It seems clear that localhost is always wrong, but that most SMTP servers ignore that value, so it hasn’t mattered.
- [https://docs.python.org/3/library/smtplib.html#smtplib.SMTP](https://docs.python.org/3/library/smtplib.html#:~:text=If%20specified%2C%20local_hostname%20is%20used%20as%20the%20FQDN%20of%20the%20local%20host%20in%20the%20HELO/EHLO%20command.%20Otherwise%2C%20the%20local%20hostname%20is%20found%20using%20socket.getfqdn().)
  > If specified, local_hostname is used as the FQDN of the local host in the HELO/EHLO command. Otherwise, the local hostname is found using [socket.getfqdn()](https://docs.python.org/3/library/socket.html#socket.getfqdn).
- <https://www.cyberciti.biz/faq/how-to-set-change-fqdn-on-ubuntu-20-04-linux/>
- [https://www.samlogic.net/articles/smtp-commands-reference.htm](https://www.samlogic.net/articles/smtp-commands-reference.htm#:~:text=If%20a%20domain%20name%20is%20used%20as%20an%20argument%20with%20the%20HELO%20command%2C%20it%20must%20be%20a%20fully%20qualified%20domain%20name%20(also%20called%20FQDN).)

## Alternatives to this PR

* Set the global OS-level hostname to a correct FQDN, instead of setting `local_hostname`
* Re-order network interfaces and set the default outbound IP, instead of setting `source_address`

## Compatibility

Keeping the fields empty should not change the current behavior.

## Prior art

https://github.com/frappe/frappe/pull/22124

> no-docs I'm lazy :(

I did not test this in production yet