### PR TITLE
ci: support downstream erpnext migration within exception code path

### DIFF
--- a/frappe/parallel_test_runner.py
+++ b/frappe/parallel_test_runner.py
@@ -102,6 +102,9 @@ class ParallelTestRunner:
 		if hasattr(module, "test_dependencies"):
 			for doctype in module.test_dependencies:
 				make_test_records(doctype, commit=True)
+		if hasattr(module, "EXTRA_TEST_RECORD_DEPENDENCIES"):
+			for doctype in module.EXTRA_TEST_RECORD_DEPENDENCIES:
+				make_test_records(doctype, commit=True)
 
 		if os.path.basename(os.path.dirname(path)) == "doctype":
 			# test_data_migration_connector.py > data_migration_connector.json


### PR DESCRIPTION
This is a practical prerequisite to automated refactoring in ERPNext, moving away from the now deprecated and ambiguous declarations ( `test_dependencies` vs `EXTRA_TEST_RECORD_DEPENDENCIES`) and to reduce the deprecation warning pressure (which unfortunately currently is immense).

cc @ruthra-kumar
