### PR TITLE
fix: Copy to Clipboard

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -479,7 +479,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 		// copy doc to clipboard
 		this.page.add_menu_item(
 			__("Copy to Clipboard"),
-			function () {
+			() => {
 				frappe.utils.copy_to_clipboard(JSON.stringify(this.frm.doc));
 			},
 			true


### PR DESCRIPTION
Fixes following issue while using "Copy To Clipboard"

<img width="1437" alt="Screenshot 2024-10-11 at 2 44 41 PM" src="https://github.com/user-attachments/assets/b71c09b0-c3ff-4f7a-ba5e-2e90074f074b">


**Solution:** Use arrow function to access `this` of toolbar instance

This functionality was broken since it was re-introduced ([ref](https://github.com/frappe/frappe/commit/1cc626ff422b9f282d56dce2effdb13383a417a3))


