### PR TITLE
fix: persistent per-site test record creation log file name

### DIFF
--- a/frappe/tests/utils/generators.py
+++ b/frappe/tests/utils/generators.py
@@ -306,8 +306,9 @@ class TestRecordLog:
 
 
 def _after_install_clear_test_log():
-	with open(frappe.get_site_path(PERSISTENT_TEST_LOG_FILE), "w") as f:
-		f.write("{}")
+	log_file_path = frappe.get_site_path(PERSISTENT_TEST_LOG_FILE)
+	if os.path.exists(log_file_path):
+		os.remove(log_file_path)
 
 
 def make_test_records(doctype, force=False, commit=False):

--- a/frappe/tests/utils/generators.py
+++ b/frappe/tests/utils/generators.py
@@ -263,9 +263,12 @@ def print_mandatory_fields(doctype):
 	testing_logger.warning(" | ".join(msg.strip().splitlines()))
 
 
+PERSISTENT_TEST_LOG_FILE = ".test_records.jsonl"
+
+
 class TestRecordLog:
 	def __init__(self):
-		self.log_file = Path(frappe.get_site_path(".test_log.jsonl"))
+		self.log_file = Path(frappe.get_site_path(PERSISTENT_TEST_LOG_FILE))
 		self._log = None
 
 	def get(self):
@@ -303,7 +306,7 @@ class TestRecordLog:
 
 
 def _after_install_clear_test_log():
-	with open(frappe.get_site_path(".test_log"), "w") as f:
+	with open(frappe.get_site_path(PERSISTENT_TEST_LOG_FILE), "w") as f:
 		f.write("{}")
 
 


### PR DESCRIPTION
cc @ruthra-kumar 

ref: https://github.com/frappe/frappe/blob/8c22ac302c446e947835446be0c75f79ba7e31d9/frappe/test_runner.py#L233 (not able to use TG)