### PR TITLE
feat: Make Web Template's Fields to support the use of multiple Table Break fields and to support sub-field ranges of Table Break fields.

### DIFF
--- a/frappe/public/js/frappe/utils/web_template.js
+++ b/frappe/public/js/frappe/utils/web_template.js
@@ -44,7 +44,7 @@ function open_web_template_values_editor(template, current_values = {}) {
 							columns: current_table.fields.length === 1 ? 10 : 5,
 						})),
 						data: current_values[current_table.fieldname] || [],
-						get_data: () => current_values[current_table.fieldname] || [],
+						get_data: () => current_table && current_table.fieldname ? current_values[current_table.fieldname] || [] : [],
 					});
 					current_table = null;
 				} else {


### PR DESCRIPTION
Make Web Template's Fields to support the use of multiple Table Break fields and to support sub-field ranges of Table Break fields.

To implement the subfield range of Table Break fields, simply add a field with the same Table Break field name after the subfield that needs to be terminated. Field name like this: Table Break1>Data1>Data2>Table Break1

pic:
![image](https://github.com/user-attachments/assets/58d36634-ceff-4ff6-a315-a09e28c4d49e)
![image](https://github.com/user-attachments/assets/e2cdfa8e-f86f-4d14-b7e2-e932a2585131)
