### PR TITLE
fix: test record generation

### DIFF
--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -61,7 +61,24 @@ def main(
 
 	# Prepare debug log message
 	debug_params = []
-	for param_name in ["site", "app", "module", "doctype", "module_def", "doctype_list_path"]:
+	for param_name in [
+		"site",
+		"app",
+		"module",
+		"doctype",
+		"module_def",
+		"verbose",
+		"tests",
+		"force",
+		"profile",
+		"junit_xml_output",
+		"doctype_list_path",
+		"failfast",
+		"case",
+		"skip_before_tests",
+		"pdb_on_exceptions",
+		"selected_categories",
+	]:
 		param_value = locals()[param_name]
 		if param_value is not None:
 			debug_params.append(f"{param_name}={param_value}")

--- a/frappe/tests/utils/generators.py
+++ b/frappe/tests/utils/generators.py
@@ -214,8 +214,18 @@ def _sync_records(
 			if "doctype" not in record:
 				record["doctype"] = _sub_doctype
 			_rec = _try_create(record)
+			# no_nulls: some buidness logic might check absence of an attribute, closer to the raw records
+			# no_default_fields: we want to keep especially name, doctype
 			# convert_dates_to_str: same as when loaded from log file above
-			_rec = _rec.as_dict(convert_dates_to_str=True)
+			# no_child_table_fields: we don't neer prent{,field,type} et al fields
+			# no_private_properties: these are internal to the document lifecycle and not a property of data records
+			_rec = _rec.as_dict(
+				no_nulls=True,
+				no_default_fields=False,
+				convert_dates_to_str=True,
+				no_child_table_fields=True,
+				no_private_properties=True,
+			)
 			created.append(_rec)
 			frappe.local.test_objects[_sub_doctype].append(MappingProxyType(_rec))
 

--- a/frappe/tests/utils/generators.py
+++ b/frappe/tests/utils/generators.py
@@ -227,7 +227,7 @@ def _sync_records(
 				no_private_properties=True,
 			)
 			created.append(_rec)
-			frappe.local.test_objects[_sub_doctype].append(MappingProxyType(_rec))
+			frappe.local.test_objects[_sub_doctype].append(MappingProxyType(record))
 
 		_logstr = f"{_sub_doctype} ({len(created)})"
 


### PR DESCRIPTION
- **chore: improve log record of testing command invokation**
- **chore(testing): narrower specificacion of the persistence log**
- **fix(testing): append raw record source data to globalTestRecords**
  This, in particular, is a more suitable assumption for a testing engineer:
  they typically wan to frappe.copy_doc from their referencae records; therefore
  their best expectation is to copy from the same datastructure that they commited
  into the repository.

cc @ruthra-kumar about the last commit in particular &mdash; it seems this was the
tacit assumption during erpnext test design and should enable a lot of remaining
test cases to make use of this new code path.


ERPNext Validation Run: https://github.com/frappe/erpnext/actions/runs/11308460604?pr=43621