### PR TITLE
test: fix record creation on reentry

### DIFF
--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -346,9 +346,9 @@ def test_runner_print_mandatory_fields(*args, **kwargs):
 	"no public api anymore",
 )
 def test_runner_get_test_record_log(doctype):
-	from frappe.tests.utils.generators import TestRecordLog
+	from frappe.tests.utils.generators import TestRecordManager
 
-	return TestRecordLog().get(doctype)
+	return TestRecordManager().get(doctype)
 
 
 @deprecated(
@@ -358,9 +358,9 @@ def test_runner_get_test_record_log(doctype):
 	"no public api anymore",
 )
 def test_runner_add_to_test_record_log(doctype):
-	from frappe.tests.utils.generators import TestRecordLog
+	from frappe.tests.utils.generators import TestRecordManager
 
-	return TestRecordLog().add(doctype)
+	return TestRecordManager().add(doctype)
 
 
 @deprecated(

--- a/frappe/tests/utils/generators.py
+++ b/frappe/tests/utils/generators.py
@@ -147,7 +147,7 @@ def load_test_records_for(index_doctype) -> dict[str, Any] | list:
 
 
 def _generate_all_records_towards(
-	index_doctype, force=False, commit=False
+	index_doctype, reset=False, commit=False
 ) -> Generator[tuple[str, int], None, None]:
 	"""Generate test records for the given doctype and its dependencies."""
 
@@ -156,12 +156,14 @@ def _generate_all_records_towards(
 	visited = set(frappe.local.test_objects.keys())
 	for _index_doctype in get_missing_records_doctypes(index_doctype, visited):
 		# Create all test records and yield
-		res = list(_generate_records_for(_index_doctype, force, commit, initial_doctype=index_doctype))
+		res = list(
+			_generate_records_for(_index_doctype, reset=reset, commit=commit, initial_doctype=index_doctype)
+		)
 		yield (_index_doctype, len(res))
 
 
 def _generate_records_for(
-	index_doctype: str, force: bool = False, commit: bool = False, initial_doctype: str | None = None
+	index_doctype: str, reset: bool = False, commit: bool = False, initial_doctype: str | None = None
 ) -> Generator[tuple[str, "Document"], None, None]:
 	"""Create and yield test records for a specific doctype."""
 	module: str
@@ -204,11 +206,11 @@ def _generate_records_for(
 		logger.warning("↺ " + logstr)
 		testing_logger.info(f" Synced  + {index_doctype:<30} via {initial_doctype}")
 
-		yield from _sync_records(index_doctype, test_records, force, commit=commit)
+		yield from _sync_records(index_doctype, test_records, reset=reset, commit=commit)
 
 
-global test_record_log_instance
-test_record_log_instance = None
+global test_record_manager_instance
+test_record_manager_instance = None
 
 
 def _sync_records(
@@ -225,9 +227,9 @@ def _sync_records(
 	# persistence log indexed by the register doctype. It also serves as proof of
 	# records at the time of creation and contains the db values
 
-	global test_record_log_instance
-	if test_record_log_instance is None:
-		test_record_log_instance = TestRecordLog()
+	global test_record_manager_instance
+	if test_record_manager_instance is None:
+		test_record_manager_instance = TestRecordManager()
 
 	def _load(do_create=True):
 		created, loaded = [], []
@@ -250,12 +252,12 @@ def _sync_records(
 				frappe.local.test_objects[index_doctype].append(MappingProxyType(record))
 
 		if not do_create:
-			loaded.extend(test_record_log_instance.get_records(index_doctype))
+			loaded.extend(test_record_manager_instance.get_records(index_doctype))
 			_logstr = f"{index_doctype} ({len(loaded)})"
 			testing_logger.info(f"         > {_logstr:<30} into cls.globalTestRecords, only")
 		else:
 			# we keep an mpty created = [] on purpose to persist proof of prior processing of the index doctype
-			test_record_log_instance.add(index_doctype, created)
+			test_record_manager_instance.add(index_doctype, created)
 			_logstr = f"{index_doctype} ({len(created)} / {len(loaded) + len(created)})"
 			testing_logger.info(f"         > {_logstr:<30} into Database & Journal / cls.globalTestRecords")
 
@@ -267,12 +269,13 @@ def _sync_records(
 	# Please keep the decision tree intact, even if some branches may seem redundant
 	# this is for clarity, documentation and future modifications or enhancements
 	# of this critical loading api
-	if index_doctype in test_record_log_instance.get():
+	if index_doctype in test_record_manager_instance.get():
 		# Scenario: secondary call or re-execution
 		if reset:
 			# Scenario: secondary call with force
 			frappe.local.test_objects[index_doctype] = []
-			test_record_log_instance.remove(index_doctype)
+			test_record_manager_instance.remove(index_doctype)
+			testing_logger.info(f"         > {index_doctype:<30} removed from journal")
 			yield from _load()
 
 		else:
@@ -367,8 +370,9 @@ def print_mandatory_fields(doctype, initial_doctype):
 PERSISTENT_TEST_LOG_FILE = ".test_records.jsonl"
 
 
-class TestRecordLog:
+class TestRecordManager:
 	def __init__(self):
+		testing_logger.debug(f"{self} initialized")
 		self.log_file = Path(frappe.get_site_path(PERSISTENT_TEST_LOG_FILE))
 		self._log = None
 
@@ -377,29 +381,29 @@ class TestRecordLog:
 			self._log = self._read_log()
 		return self._log
 
-	def get_records(self, doctype) -> list["Document"]:
+	def get_records(self, index_doctype) -> list["Document"]:
 		log = self.get()
-		return log.get(doctype, [])
+		return log.get(index_doctype, [])
 
-	def add(self, doctype, records: list["Document"]):
+	def add(self, index_doctype, records: list["Document"]):
 		if records:
-			self._append_to_log(doctype, records)
+			self._append_to_log(index_doctype, records)
 			if self._log is None:
 				self.get()
-			self._log.setdefault(doctype, []).extend(records)
-			testing_logger.debug(f"        > {doctype:<30} ({len(records)}) added to {self.log_file}")
+			self._log.setdefault(index_doctype, []).extend(records)
+			testing_logger.debug(f"        > {index_doctype:<30} ({len(records)}) added to {self.log_file}")
 
-	def remove(self, doctype):
+	def remove(self, index_doctype):
 		"""
 		Remove all records for the specified doctype from the log.
 		"""
-		if doctype in self.get():
-			del self._log[doctype]
-			self._remove_from_log(doctype)
-			testing_logger.debug(f"        > {doctype:<30} deleted from {self.log_file}")
+		if index_doctype in self.get():
+			del self._log[index_doctype]
+			self._remove_from_log(index_doctype)
+			testing_logger.debug(f"        > {index_doctype:<30} deleted from {self.log_file}")
 
-	def _append_to_log(self, doctype, records: list["Document"]):
-		entry = {"doctype": doctype, "records": records}
+	def _append_to_log(self, index_doctype, records: list["Document"]):
+		entry = {"doctype": index_doctype, "records": records}
 		with self.log_file.open("a") as f:
 			f.write(frappe.as_json(entry, indent=None) + "\n")
 
@@ -409,19 +413,19 @@ class TestRecordLog:
 			with self.log_file.open() as f:
 				for line in f:
 					entry = json.loads(line)
-					doctype = entry["doctype"]
+					index_doctype = entry["doctype"]
 					records = entry["records"]
-					log.setdefault(doctype, []).extend(
+					log.setdefault(index_doctype, []).extend(
 						frappe.get_doc(r["doctype"], r["name"]) for r in records
 					)
 		return log
 
-	def _remove_from_log(self, doctype):
+	def _remove_from_log(self, index_doctype):
 		temp_file = self.log_file.with_suffix(".temp")
 		with self.log_file.open("r") as input_file, temp_file.open("w") as output_file:
 			for line in input_file:
 				entry = json.loads(line)
-				if entry["doctype"] != doctype:
+				if entry["doctype"] != index_doctype:
 					output_file.write(line)
 		temp_file.replace(self.log_file)
 
@@ -434,12 +438,12 @@ def _after_install_clear_test_log():
 
 def make_test_records(doctype, force=False, commit=False):
 	"""Generate test records for the given doctype and its dependencies."""
-	return list(_generate_all_records_towards(doctype, force, commit))
+	return list(_generate_all_records_towards(doctype, reset=force, commit=commit))
 
 
 def make_test_records_for_doctype(doctype, force=False, commit=False):
 	"""Create test records for a specific doctype."""
-	return list(r.name for tag, r in _generate_records_for(doctype, force, commit))
+	return list(r.name for tag, r in _generate_records_for(doctype, reset=force, commit=commit))
 
 
 def make_test_objects(doctype=None, test_records=None, reset=False, commit=False):


### PR DESCRIPTION
This avoids record recreation during re-execution of tests on the same database.

It does not change the behavior of other secondary calls to a default `make_test_records[force=False)`. 

Their behavior remains ill-defined and they should be avoided. We might eventually outright ban them in the future to clean up the api.

cc @ruthra-kumar 
