### PR TITLE
Revert "refactor: Replace hard-coded pg default port with PostgresDatabase.default_port"

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -426,11 +426,10 @@ def get_site_config(sites_path: str | None = None, site_path: str | None = None)
 	# Generalized env variable overrides and defaults
 	def db_default_ports(db_type):
 		from frappe.database.mariadb.database import MariaDBDatabase
-		from frappe.database.postgres.database import PostgresDatabase
 
 		return {
 			"mariadb": MariaDBDatabase.default_port,
-			"postgres": PostgresDatabase.default_port,
+			"postgres": 5432,
 		}[db_type]
 
 	config["redis_queue"] = (


### PR DESCRIPTION
Reverts frappe/frappe#27989

This breaks for those who don't have postgres installed :facepalm: 