### PR TITLE
refactor: Replace hard-coded pg default port with PostgresDatabase.default_port

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -419,12 +419,16 @@ def get_site_config(sites_path: str | None = None, site_path: str | None = None)
 
 	# Generalized env variable overrides and defaults
 	def db_default_ports(db_type):
-		from frappe.database.mariadb.database import MariaDBDatabase
+		if db_type == "mariadb":
+			from frappe.database.mariadb.database import MariaDBDatabase
 
-		return {
-			"mariadb": MariaDBDatabase.default_port,
-			"postgres": 5432,
-		}[db_type]
+			return MariaDBDatabase.default_port
+		elif db_type == "postgres":
+			from frappe.database.postgres.database import PostgresDatabase
+
+			return PostgresDatabase.default_port
+
+		raise ValueError(f"Unsupported db_type={db_type}")
 
 	config["redis_queue"] = (
 		os.environ.get("FRAPPE_REDIS_QUEUE") or config.get("redis_queue") or "redis://127.0.0.1:11311"


### PR DESCRIPTION
Per [this comment](https://github.com/frappe/frappe/pull/27989#discussion_r1798321920), conditionally import the database class per the db_type in the config to make sure setups without postgres do not break on the import.

CC: @akhilnarang , @blaggacao 
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
