### PR TITLE
feat: make custom prefix for custom fields configurable

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -14,6 +14,7 @@
   "enable_onboarding",
   "setup_complete",
   "disable_document_sharing",
+  "add_custom_prefix",
   "date_and_number_format",
   "date_format",
   "time_format",
@@ -684,12 +685,18 @@
    "fieldname": "use_number_format_from_currency",
    "fieldtype": "Check",
    "label": "Use Number Format from Currency"
+  },
+  {
+   "default": "1",
+   "fieldname": "add_custom_prefix",
+   "fieldtype": "Check",
+   "label": "Add \"custom\" Prefix to Custom Fields"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2024-09-26 16:20:59.417151",
+ "modified": "2024-10-14 11:07:40.795263",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -17,6 +17,7 @@ class SystemSettings(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		add_custom_prefix: DF.Check
 		allow_consecutive_login_attempts: DF.Int
 		allow_error_traceback: DF.Check
 		allow_guests_to_upload_files: DF.Check

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -148,7 +148,9 @@ class CustomField(Document):
 			self.fieldname = "".join(
 				[c for c in cstr(label).replace(" ", "_") if c.isdigit() or c.isalpha() or c == "_"]
 			)
-			self.fieldname = f"custom_{self.fieldname}"
+			add_custom_prefix = frappe.get_value("System Settings", None, "add_custom_prefix")
+			if add_custom_prefix == 1:
+				self.fieldname = f"custom_{self.fieldname}"
 
 		# fieldnames should be lowercase
 		self.fieldname = self.fieldname.lower()


### PR DESCRIPTION

Added a checkbox in System Settings to enable/disable the feature to add "custom" prefix in custom fields.
![image](https://github.com/user-attachments/assets/d6a16cf2-49d7-4d41-a2f2-94ef24f369eb)