### PR TITLE
feat: secure path on api to mtls usage with NGINX

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -895,18 +895,21 @@ def sendmail(
 
 
 whitelisted = set()
+secure_methods = set()
 guest_methods = set()
 xss_safe_methods = set()
 allowed_http_methods_for_whitelisted_func = {}
 
 
-def whitelist(allow_guest=False, xss_safe=False, methods=None):
+def whitelist(allow_guest=False, xss_safe=False, methods=None, secure=None):
 	"""
 	Decorator for whitelisting a function and making it accessible via HTTP.
 	Standard request will be `/api/method/[path.to.method]`
 
 	:param allow_guest: Allow non logged-in user to access this method.
 	:param methods: Allowed http method to access the method.
+	:param secure: Allowed method to be acessed only with mTLS validated path with nginx.
+					Request will be `/api/secure/[path.to.method]`
 
 	Use as:
 
@@ -921,7 +924,7 @@ def whitelist(allow_guest=False, xss_safe=False, methods=None):
 	def innerfn(fn):
 		from frappe.utils.typing_validations import validate_argument_types
 
-		global whitelisted, guest_methods, xss_safe_methods, allowed_http_methods_for_whitelisted_func
+		global whitelisted, guest_methods, xss_safe_methods, allowed_http_methods_for_whitelisted_func, secure_methods
 
 		# validate argument types only if request is present
 		in_request_or_test = lambda: getattr(local, "request", None) or local.flags.in_test  # noqa: E731
@@ -935,7 +938,11 @@ def whitelist(allow_guest=False, xss_safe=False, methods=None):
 		else:
 			fn = validate_argument_types(fn, apply_condition=in_request_or_test)
 
-		whitelisted.add(fn)
+		if secure:
+			secure_methods.add(fn)
+		else:
+			whitelisted.add(fn)
+
 		allowed_http_methods_for_whitelisted_func[fn] = methods
 
 		if allow_guest:
@@ -952,12 +959,19 @@ def whitelist(allow_guest=False, xss_safe=False, methods=None):
 def is_whitelisted(method):
 	from frappe.utils import sanitize_html
 
-	is_guest = session["user"] == "Guest"
-	if method not in whitelisted or is_guest and method not in guest_methods:
+	def _raise_exception(method):
 		summary = _("You are not permitted to access this resource.")
 		detail = _("Function {0} is not whitelisted.").format(bold(f"{method.__module__}.{method.__name__}"))
 		msg = f"<details><summary>{summary}</summary>{detail}</details>"
 		throw(msg, PermissionError, title=_("Method Not Allowed"))
+
+	is_guest = session["user"] == "Guest"
+	if form_dict.url_secure_mtls:
+		if method not in secure_methods or is_guest and method not in guest_methods:
+			_raise_exception(method)
+	elif method not in whitelisted or is_guest and method not in guest_methods:
+		_raise_exception(method)
+
 
 	if is_guest and method not in xss_safe_methods:
 		# strictly sanitize form_dict

--- a/frappe/api/__init__.py
+++ b/frappe/api/__init__.py
@@ -28,6 +28,7 @@ def handle(request: Request):
 	Different versions have different specification but broadly following things are supported:
 
 	- `/api/method/{methodname}` will call a whitelisted method
+	- `/api/secure/{methodname}` will call a secure method with nginx mtls
 	- `/api/resource/{doctype}` will query a table
 	        examples:
 	        - `?fields=["name", "owner"]`

--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -36,6 +36,11 @@ def handle_rpc_call(method: str):
 	return frappe.handler.handle()
 
 
+def handle_secure_rpc_call(method: str):
+	frappe.form_dict.url_secure_mtls = 1
+	return handle_rpc_call(method)
+
+
 def create_doc(doctype: str):
 	data = get_request_form_data()
 	data.pop("doctype", None)
@@ -109,6 +114,7 @@ def get_request_form_data():
 
 url_rules = [
 	Rule("/method/<path:method>", endpoint=handle_rpc_call),
+	Rule("/secure/<path:method>", endpoint=handle_secure_rpc_call),
 	Rule("/resource/<doctype>", methods=["GET"], endpoint=document_list),
 	Rule("/resource/<doctype>", methods=["POST"], endpoint=create_doc),
 	Rule("/resource/<doctype>/<path:name>/", methods=["GET"], endpoint=read_doc),

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -53,6 +53,11 @@ def handle_rpc_call(method: str, doctype: str | None = None):
 	return frappe.call(method, **frappe.form_dict)
 
 
+def handle_secure_rpc_call(method: str):
+	frappe.form_dict.url_secure_mtls = 1
+	return handle_rpc_call(method)
+
+
 def login():
 	"""Login happens implicitly, this function doesn't do anything."""
 	pass
@@ -181,6 +186,7 @@ url_rules = [
 		endpoint=lambda: frappe.call(run_doc_method, **frappe.form_dict),
 	),
 	Rule("/method/<doctype>/<method>", endpoint=handle_rpc_call),
+	Rule("/secure/<method>", endpoint=handle_secure_rpc_call),
 	# Document level APIs
 	Rule("/document/<doctype>", methods=["GET"], endpoint=document_list),
 	Rule("/document/<doctype>", methods=["POST"], endpoint=create_doc),


### PR DESCRIPTION
This pull request is related to a pull request opened on the bench: https://github.com/frappe/bench/pull/1587

A new path has been created:

/api/secure/{methodname}
/api/v2/secure/{methodname}

"Secure" methods cannot be accessed via /api/method/{methodname}, this method forces requests to come through the correct path, so nginx will perform all security validation and force the use of mTLS on this path.


If I need to do some kind of test, or documentation, give me the direction and I will do it.