### PR TITLE
fix: get_doc is not usable on jinja template in notification

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -734,11 +734,12 @@ def evaluate_alert(doc: Document, alert, event=None):
 
 
 def get_context(doc):
-	Frappe = namedtuple("frappe", ["utils"])
+	Frappe = namedtuple("frappe", ["frappe"])
+	frappe = Frappe(frappe=get_safe_globals().get("frappe"))
 	return {
 		"doc": doc,
 		"nowdate": nowdate,
-		"frappe": Frappe(utils=get_safe_globals().get("frappe").get("utils")),
+		"frappe": frappe.frappe,
 	}
 
 

--- a/frappe/email/doctype/notification/test_notification.py
+++ b/frappe/email/doctype/notification/test_notification.py
@@ -478,7 +478,7 @@ class TestNotification(IntegrationTestCase):
 		frappe.delete_doc_if_exists("Notification", "ToDo Status Update")
 		frappe.delete_doc_if_exists("Notification", "Contact Status Update")
 
-	def test_notification_jinja_template(self):
+	def test_notification_with_jinja_template(self):
 		"""Test Notification with Jinja Template"""
 		notification = frappe.get_doc(
 			{
@@ -488,7 +488,7 @@ class TestNotification(IntegrationTestCase):
 				"document_type": "ToDo",
 				"event": "Save",
 				"condition": "doc.status == 'Open'",
-				"message": "Today Date: {{ frappe.utils.today() }}",
+				"message": "{% set val = frappe.get_doc('ToDo', doc.name) %} ToDo allocated to {{ doc.allocated_to }}",
 				"channel": "Email",
 				"recipients": [{"receiver_by_document_field": "allocated_to"}],
 			}
@@ -496,18 +496,8 @@ class TestNotification(IntegrationTestCase):
 		frappe.db.commit()
 
 		todo = frappe.new_doc("ToDo")
-		todo.description = "Test Notification"
-		todo.save()
-
-		assign_to.add(
-			{
-				"assign_to": ["test1@example.com"],
-				"doctype": todo.doctype,
-				"name": todo.name,
-				"description": "Check Email notification with Jinja template",
-			}
-		)
-		todo.status = "Closed"
+		todo.description = "Checking email notification with jinja template"
+		todo.allocated_to = "test1@example.com"
 		todo.save()
 
 		email_queue = frappe.get_doc(

--- a/frappe/email/doctype/notification/test_notification.py
+++ b/frappe/email/doctype/notification/test_notification.py
@@ -493,7 +493,6 @@ class TestNotification(IntegrationTestCase):
 				"recipients": [{"receiver_by_document_field": "allocated_to"}],
 			}
 		).insert()
-		frappe.db.commit()
 
 		todo = frappe.new_doc("ToDo")
 		todo.description = "Checking email notification with jinja template"

--- a/frappe/email/doctype/notification/test_notification.py
+++ b/frappe/email/doctype/notification/test_notification.py
@@ -478,6 +478,47 @@ class TestNotification(IntegrationTestCase):
 		frappe.delete_doc_if_exists("Notification", "ToDo Status Update")
 		frappe.delete_doc_if_exists("Notification", "Contact Status Update")
 
+	def test_notification_jinja_template(self):
+		"""Test Notification with Jinja Template"""
+		notification = frappe.get_doc(
+			{
+				"doctype": "Notification",
+				"name": "Notification with Jinja Template",
+				"subject": "{{ doc.name }}",
+				"document_type": "ToDo",
+				"event": "Save",
+				"condition": "doc.status == 'Open'",
+				"message": "Today Date: {{ frappe.utils.today() }}",
+				"channel": "Email",
+				"recipients": [{"receiver_by_document_field": "allocated_to"}],
+			}
+		).insert()
+		frappe.db.commit()
+
+		todo = frappe.new_doc("ToDo")
+		todo.description = "Test Notification"
+		todo.save()
+
+		assign_to.add(
+			{
+				"assign_to": ["test1@example.com"],
+				"doctype": todo.doctype,
+				"name": todo.name,
+				"description": "Check Email notification with Jinja template",
+			}
+		)
+		todo.status = "Closed"
+		todo.save()
+
+		email_queue = frappe.get_doc(
+			"Email Queue", {"reference_doctype": "ToDo", "reference_name": todo.name}
+		)
+		self.assertTrue(email_queue)
+
+		recipients = [d.recipient for d in email_queue.recipients]
+		self.assertTrue("test1@example.com" in recipients)
+		self.assertEqual(notification.enabled, 1)
+
 
 """
 PROOF OF TEST for TestNotificationOffsetRange below.


### PR DESCRIPTION
Issue: get_doc is not usable in jinja template while sending email notification in develop branch.
Issue No: [27856](https://github.com/frappe/frappe/issues/27856)

Before:
[Screencast from 15-10-24 06:15:35 PM IST.webm](https://github.com/user-attachments/assets/c1a7b937-cb9d-4d4f-aa04-1fba255e6286)

After:
[Screencast from 15-10-24 06:19:30 PM IST.webm](https://github.com/user-attachments/assets/125271ad-7bdd-483f-8425-c1b0fb73d3de)



