### PR TITLE
fix(QuickList): Fetch more fields for get_indicator

### DIFF
--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -203,6 +203,12 @@ export default class QuickListWidget extends Widget {
 			workflow_fieldname && fields.push(workflow_fieldname);
 			fields.push("modified");
 
+			let add_fields = frappe.listview_settings?.[this.document_type]?.add_fields;
+			if (Array.isArray(add_fields)) {
+				fields.push(...add_fields);
+				fields = [...new Set(fields)];
+			}
+
 			let quick_list_filter = frappe.utils.process_filter_expression(this.quick_list_filter);
 
 			let args = {


### PR DESCRIPTION
This caused an issue in ERPNext where Sales Orders with the "To Bill" status were shown as "To Deliver" for no reason. Indeed, the grand_total field was not fetched, thus making the call to get_indicator return the wrong value.

> `frappe.listview_settings["Sales Order"].get_indicator`

![](https://github.com/user-attachments/assets/2978b500-5de0-402e-bf31-f505cb9565ea)
