### PR TITLE
refactor: Move children load db into separate method

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -255,6 +255,15 @@ class Document(BaseDocument):
 			super().__init__(d)
 		self.flags.pop("ignore_children", None)
 
+		self.load_children_from_db()
+
+		# sometimes __setup__ can depend on child values, hence calling again at the end
+		if hasattr(self, "__setup__"):
+			self.__setup__()
+
+		return self
+
+	def load_children_from_db(self):
 		for df in self._get_table_fields():
 			# Make sure not to query the DB for a child table, if it is a virtual one.
 			# During frappe is installed, the property "is_virtual" is not available in tabDocType, so
@@ -276,10 +285,6 @@ class Document(BaseDocument):
 			)
 
 			self.set(df.fieldname, children)
-
-		# sometimes __setup__ can depend on child values, hence calling again at the end
-		if hasattr(self, "__setup__"):
-			self.__setup__()
 
 		return self
 


### PR DESCRIPTION
### Does this change the bottom line?

No

### Why then?

To make it easier to load documents "lazily", utilizing the following pattern (/hack):

```python
for offer in frappe.get_all("Offer", fields="*"):
    o = frappe.get_doc({"doctype": "Offer"} | offer)
    if o.is_valid_sale() and o.is_liked_provider():
        o.submit_in_five_days()
     else:
        o.load_children_from_db()
        o.process_offending_rulesets_and_raise()
```