### PR TITLE
fix(testing): pdb post mortem

### DIFF
--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -115,6 +115,7 @@ def main(
 			verbosity=2 if testing_module_logger.getEffectiveLevel() < logging.INFO else 1,
 			tb_locals=testing_module_logger.getEffectiveLevel() <= logging.INFO,
 			cfg=test_config,
+			buffer=not bool(pdb_on_exceptions),
 		)
 
 		if doctype or doctype_list_path:

--- a/frappe/testing/runner.py
+++ b/frappe/testing/runner.py
@@ -52,7 +52,7 @@ class TestRunner(unittest.TextTestRunner):
 		descriptions=True,
 		verbosity=1,
 		failfast=False,
-		buffer=False,
+		buffer=True,
 		resultclass=None,
 		warnings="module",
 		*,


### PR DESCRIPTION
Without this change, `--pdb` would be buffered and no interaction is possible and the post mortem is stuck forever.