### PR TITLE
refactor(bench-class): swap init entrypoint

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -178,7 +178,7 @@ def init_request(request):
 	frappe.local.is_ajax = frappe.get_request_header("X-Requested-With") == "XMLHttpRequest"
 
 	site = _site or request.headers.get("X-Frappe-Site-Name") or get_site_name(request.host)
-	frappe.init(site, sites_path=_sites_path, force=True)
+	frappe.init(str(site), sites_path=_sites_path, force=True)
 
 	if not (frappe.local.conf and frappe.local.conf.db_name):
 		# site does not exist

--- a/frappe/bencher.py
+++ b/frappe/bencher.py
@@ -1,0 +1,301 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Final
+
+from frappe.config import ConfigHandler
+
+
+class BenchNotScopedError(NotImplementedError):
+	pass
+
+
+class BenchSiteNotLoadedError(ValueError):
+	pass
+
+
+class PathLike:
+	def __fspath__(self):
+		return str(self.path)
+
+
+class Serializable:
+	def __json__(self):
+		return {k: v for k, v in self.__dict__.items()}
+
+
+class Benched(PathLike, Serializable):
+	def __init__(self, path: str | None = None, parent_path: Path | None = None):
+		path = (
+			path
+			or os.environ.get(f"FRAPPE_{self.__class__.__name__.upper()}_PATH")
+			or (parent_path.joinpath(self.__class__.__name__.lower()) if parent_path else None)
+			# only for Bench class ...
+			or (
+				# TODO: legacy, remove
+				os.environ.get("FRAPPE_BENCH_ROOT") if isinstance(self, Bench) else None
+			)
+			or (
+				# TODO: unsave relative reference, remove
+				Path(__file__).resolve().parents[3]  # bench folder in standard layout
+				if isinstance(self, Bench)
+				else None
+			)
+			or (Path("~/frappe-bench").expanduser() if isinstance(self, Bench) else None)
+		)
+
+		if path is None:
+			raise ValueError(f"Unable to determine path for {self.__class__.__name__}")
+
+		self.path = Path(path)
+
+
+class Frapped:
+	python_path: Path
+
+	def __bool__(self):
+		return self._is_frapped()
+
+	def _is_frapped(self):
+		return self.python_path.is_dir() and self.python_path.joinpath(".frappe").exists()
+
+
+class Apps(Benched):
+	def __init__(self, path: str | None = None, parent_path: str | None = None):
+		super().__init__(path, parent_path)
+		self._apps = None
+
+	def __str__(self):
+		return (
+			repr(self)
+			+ ("\n * Apps Path: " + str(self.path))
+			+ ("\n * Loaded Apps:\n\t" + ("\n\t".join([str(app) for app in self.apps]) or "n/a"))
+		)
+
+	class App(Frapped, PathLike, Serializable):
+		def __init__(self, name: str, path: str):
+			self.name = name
+			self.path = Path(path)
+			self.python_path = self.path.joinpath(self.name)
+			self._modules = None
+
+		def __str__(self):
+			return self.name
+
+		class Module(Frapped, PathLike, Serializable):
+			def __init__(self, name: str, path: str):
+				self.name = name
+				self.path = Path(path)
+				self.python_path = self.path
+
+		@property
+		def modules(self) -> dict[str, Module]:
+			if self._modules is None:
+				self._modules = {
+					d: module
+					for d in self.python_path.iterdir()
+					if (module := self.Module(d, self.python_path)) and module
+				}
+			return self._modules
+
+		def __iter__(self):
+			return iter(self.modules.values())
+
+		def __len__(self):
+			return len(self.modules)
+
+		def __getitem__(self, key):
+			return self.modules[key]
+
+	@property
+	def apps(self) -> dict[str, App]:
+		if self._apps is None:
+			self._apps = {
+				d: app for d in self.path.iterdir() if d.is_dir() and (app := self.App(d, self.path)) and app
+			}
+		return self._apps
+
+	def __iter__(self):
+		return iter(self.apps.values())
+
+	def __len__(self):
+		return len(self.apps)
+
+	def __getitem__(self, key):
+		return self.apps[key]
+
+
+class Logs(Benched):
+	def __init__(self, path: str | None = None, parent_path: Path | None = None):
+		super().__init__(path, parent_path)
+
+	def get_log_file(self, log_type: str):
+		return self.path.joinpath(f"{log_type}.log")
+
+
+class Run(Benched):
+	def __init__(self, path: str | None = None, parent_path: Path | None = None):
+		super().__init__(
+			path
+			# config is the legacy naming of this folder; a misnomer
+			or (parent_path.joinpath("config") if parent_path else None),
+			parent_path,
+		)
+
+
+class Sites(Benched, ConfigHandler):
+	ALL_SITES: Final = "__all-sites__"
+
+	def __init__(self, path: str | None = None, parent_path: Path | None = None, bench: "Bench" = None):
+		Benched.__init__(self, path, parent_path)
+		ConfigHandler.__init__(self, self.path.joinpath("common_site_config.json"))
+		self.__sites = None
+		self.bench = bench
+		# security: self.site_name attribute scopes access
+		self.site_name = os.environ.get("FRAPPE_SITE") or self.config.get("default_site")
+		self._iterator = None
+
+	def __str__(self):
+		return (
+			repr(self)
+			+ ("\n * Sites Path: " + str(self.path))
+			+ ("\n * Scoped Site: " + (self.site_name or "n/a"))
+			+ ("\n * Loaded Sites:\n\t" + ("\n\t".join([str(site) for site in self]) or "n/a"))
+		)
+
+	class Site(ConfigHandler, PathLike, Serializable):
+		def __init__(self, name: str, path: str, bench: "super.Bench"):
+			self.name = name
+			self.path = Path(path)
+			self.bench: "Bench" = bench
+			self._combined_config = None
+			ConfigHandler.__init__(self, self.path.joinpath("site_config.json"))
+
+		def __eq__(self, o):
+			return self.name == str(o)
+
+		def __hash__(self):
+			return hash(self.name)
+
+		def __str__(self):
+			return self.name
+
+		def __fspath__(self):
+			return str(self.path)
+
+		def __json__(self):
+			excluded = (
+				"bench",  # prevent circular deps
+				"_ConfigHandler__config",  # holds file contents
+				"_config_stale",  # never stale after accessored
+			)
+			naming = {"_combined_config": "config"}
+			return {naming.get(k, k): v for k, v in self.__dict__.items() if k not in excluded}
+
+		@property
+		def config(self) -> dict[str, Any]:
+			if self._combined_config is None or self._config_stale:
+				site_config = super().config.copy()
+				config = self.bench.sites.config.copy()
+				config.update(site_config)
+				self._combined_config = config
+			return self._combined_config
+
+	def add_site(self, site_name: str):
+		site_path = self.path.joinpath(site_name)
+		os.makedirs(site_path, exist_ok=True)
+		for dir_path in [
+			site_path.joinpath("public", "files"),
+			site_path.joinpath("private", "backups"),
+			site_path.joinpath("private", "files"),
+			site_path.joinpath("locks"),
+			site_path.joinpath("logs"),
+		]:
+			os.makedirs(dir_path, exist_ok=True)
+		self.__sites[site_name] = self.Site(site_name, site_path)
+
+	def remove_site(self, site_name: str):
+		if site_name in self.__sites:
+			del self.__sites[site_name]
+			# site_path = self.path.joinpath(site_name)
+			# Note: This doesn't actually delete the site directory, just removes it from the sites dict
+			# Actual deletion should be handled separately with proper safeguards
+
+	def scope(self, site_name: str | None = None) -> Site:
+		if site_name is None:
+			return self.site
+
+		self.__sites = None
+		self.site_name = site_name
+
+		if self.site_name != self.ALL_SITES:
+			return self.site
+
+	@property
+	def scoped(self) -> bool:
+		return bool(self.site_name) and self.site_name != self.ALL_SITES
+
+	@property
+	def site(self) -> Site:
+		# security: self.site_name attribute scopes access
+		if not self.site_name or self.site_name == self.ALL_SITES:
+			raise BenchNotScopedError("Sites was not scoped to a single site, yet.")
+		return self[self.site_name]
+
+	@property
+	def _sites(self) -> dict[str, Site]:
+		if self.__sites is None:
+			self.__sites = {}
+
+			def _process(path: Path):
+				if path.is_dir() and path.joinpath("site_config.json").exists():
+					self.__sites[path.name] = self.Site(path.name, path, self.bench)
+
+			# security: self.site_name attribute scopes access
+			if self.site_name and self.site_name != self.ALL_SITES:
+				_process(self.path.joinpath(self.site_name))
+			elif self.site_name == self.ALL_SITES:
+				for site_path in self.path.iterdir():
+					_process(site_path)
+		return self.__sites
+
+	def __iter__(self):
+		# security: self.site_name attribute scopes access
+		if self.site_name == self.ALL_SITES:
+			return iter(self._sites.values())
+		elif self.site_name:
+			return iter([self[self.site_name]])
+		raise BenchNotScopedError("Sites was not scoped, yet.")
+
+	def __len__(self):
+		return len(self._sites)
+
+	def __getitem__(self, key):
+		try:
+			return self._sites[key]
+		except KeyError:
+			raise BenchSiteNotLoadedError(f"Site '{key}' was not loaded")
+
+
+class Bench(Benched):
+	def __init__(self, path: str | None = None):
+		super().__init__(path)
+		self.apps = Apps(parent_path=self.path)
+		self.logs = Logs(parent_path=self.path)
+		self.run = Run(parent_path=self.path)
+		self.sites = Sites(parent_path=self.path, bench=self)
+
+	def scope(self, site_name: str):
+		return self.sites.scope(site_name)
+
+	@property
+	def scoped(self):
+		return self.sites.scoped
+
+	def __str__(self):
+		return (
+			repr(self)
+			+ ("\n * Bench Path: " + str(self.path))
+			+ ("\n\n" + str(self.apps))
+			+ ("\n\n" + str(self.sites))
+		)

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -215,7 +215,7 @@ def setup():
 		except ImportError:
 			pass
 	app_paths = [os.path.dirname(pymodule.__file__) for pymodule in pymodules]
-	assets_path = os.path.join(frappe.local.sites_path, "assets")
+	assets_path = frappe.bench.sites.path / "assets"
 
 
 def bundle(
@@ -265,7 +265,7 @@ def watch(apps=None):
 	if apps:
 		command += f" --apps {apps}"
 
-	live_reload = frappe.utils.cint(os.environ.get("LIVE_RELOAD", frappe.conf.live_reload))
+	live_reload = frappe.utils.cint(frappe.bench.sites.config.get("live_reload"))
 
 	if live_reload:
 		command += " --live-reload"

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -63,8 +63,6 @@ def build(
 	from frappe.gettext.translate import compile_translations
 	from frappe.utils.synchronization import filelock
 
-	frappe.init("")
-
 	if not apps and app:
 		apps = app
 
@@ -77,7 +75,7 @@ def build(
 			skip_frappe = False
 
 		# don't minify in developer_mode for faster builds
-		development = frappe.local.conf.developer_mode or frappe.local.dev_server
+		development = frappe.bench.sites.config.get("developer_mode") or frappe._dev_server
 		mode = "development" if development else "production"
 		if production:
 			mode = "production"
@@ -112,7 +110,6 @@ def watch(apps=None):
 	"Watch and compile JS and CSS files as and when they change"
 	from frappe.build import watch
 
-	frappe.init("")
 	watch(apps)
 
 
@@ -900,7 +897,6 @@ def get_version(output):
 	from frappe.utils.change_log import get_app_branch
 	from frappe.utils.commands import render_table
 
-	frappe.init("")
 	data = []
 
 	for app in sorted(frappe.get_all_apps()):

--- a/frappe/config.py
+++ b/frappe/config.py
@@ -1,0 +1,75 @@
+import importlib
+import json
+import os
+import traceback
+from typing import Any
+
+
+class ConfigHandler:
+	default_config = (
+		("redis_queue", "redis://127.0.0.1:11311"),
+		("redis_cache", "redis://127.0.0.1:13311"),
+		("db_type", "mariadb"),
+		("db_host", "127.0.0.1"),
+		("db_port", 3306),
+		("db_socket", None),
+	)
+
+	def _apply_dynamic_defaults(self):
+		if not self._config.get("db_user"):
+			self._config["db_user"] = self._config.get("db_name")
+		if not self._config.get("db_name"):
+			self._config["db_name"] = self._config.get("db_user")
+		if self._config.get("db_type") == "postrges":
+			self._config["db_port"] = 5432
+
+	def __init__(self, config_path: str):
+		self.config_path = config_path
+		self._config = None
+		self.__config = None
+		self._config_stale = True
+
+	def _handle_sighup(self, signum, frame):
+		self._config_stale = True
+
+	@property
+	def config(self) -> dict[str, Any]:
+		if self._config is None or self._config_stale:
+			if os.path.exists(self.config_path):
+				with open(self.config_path) as f:
+					self.__config = json.load(f)
+			else:
+				self.__config = {}
+			self._config = dict(self.default_config, **self.__config)
+			self._update_from_env()
+			self._apply_extra_config()
+			self._apply_dynamic_defaults()
+			self._config_stale = False
+		return self._config
+
+	def update_config(self, updates: dict[str, Any]):
+		self.__config.update(updates)
+		with open(self.config_path, "w") as f:
+			from frappe.utils.response import json_handler
+
+			json.dump(self.__config, f, indent=2, default=json_handler)
+		self._config_stale = True
+
+	def _update_from_env(self):
+		for key in self._config.keys():
+			env_key = f"FRAPPE_{key.upper()}"
+			if env_value := os.environ.get(env_key):
+				self._config[key] = env_value
+
+	def _apply_extra_config(self):
+		extra_config = self._config.get("extra_config")
+		if extra_config:
+			if isinstance(extra_config, str):
+				extra_config = [extra_config]
+			for hook in extra_config:
+				try:
+					module, method = hook.rsplit(".", 1)
+					self._config.update(getattr(importlib.import_module(module), method)())
+				except Exception:
+					print(f"Config hook {hook} failed")
+					traceback.print_exc()

--- a/frappe/config.py
+++ b/frappe/config.py
@@ -60,6 +60,13 @@ class ConfigHandler:
 			env_key = f"FRAPPE_{key.upper()}"
 			if env_value := os.environ.get(env_key):
 				self._config[key] = env_value
+				continue
+			# TODO: rmove legacy env variable
+			if key == "live_reload":
+				env_key = "LIVE_RELOAD"
+				if env_value := os.environ.get(env_key):
+					self._config[key] = env_value
+					continue
 
 	def _apply_extra_config(self):
 		extra_config = self._config.get("extra_config")

--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -123,6 +123,28 @@ def deprecation_warning(marked: str, graduation: str, msg: str):
 
 
 ### Party starts here
+
+
+@deprecated(
+	"frappe.init (old calling signature)",
+	"2024-09-13",
+	"v17",
+	"Use the new calling signature: frappe.init(site: frappe.bencher.Sites.Site, force: bool = False) 🎉🗑️",
+	stacklevel=3,  # get past functools.dispatch
+)
+def old_init(site, sites_path, new_site, force) -> None:
+	from pathlib import Path
+
+	from frappe import _init
+	from frappe.bencher import Bench
+
+	implied_bench_path = Path(sites_path).resolve().parent
+	bench = Bench(implied_bench_path)
+	bench.scope(site)
+
+	return _init(bench.sites.site, force)
+
+
 def _old_deprecated(func):
 	return deprecated(
 		"frappe.deprecations.deprecated",

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -4,6 +4,11 @@
 # BEWARE don't put anything in this file except exceptions
 from werkzeug.exceptions import NotFound
 
+from .bencher import (
+	BenchNotScopedError,
+	BenchSiteNotLoadedError,
+)
+
 
 class SiteNotSpecifiedError(Exception):
 	def __init__(self, *args, **kwargs):

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -560,9 +560,8 @@ def make_conf(
 		db_port=db_port,
 		db_user=db_user,
 	)
-	sites_path = frappe.local.sites_path
 	frappe.destroy()
-	frappe.init(site, sites_path=sites_path)
+	frappe.init(site)
 
 
 def make_site_config(

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -671,7 +671,7 @@ def is_a_property(x) -> bool:
 
 def get_sites(sites_path=None):
 	if not sites_path:
-		sites_path = getattr(frappe.local, "sites_path", None) or "."
+		sites_path = frappe.bench.sites.path
 
 	sites = []
 	for site in os.listdir(sites_path):

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -300,13 +300,12 @@ def start_worker(
 	_start_sentry()
 	_freeze_gc()
 
-	with frappe.init_site():
-		# empty init is required to get redis_queue from common_site_config.json
-		redis_connection = get_redis_conn(username=rq_username, password=rq_password)
+	# empty init is required to get redis_queue from common_site_config.json
+	redis_connection = get_redis_conn(username=rq_username, password=rq_password)
 
-		if queue:
-			queue = [q.strip() for q in queue.split(",")]
-		queues = get_queue_list(queue, build_queue_name=True)
+	if queue:
+		queue = [q.strip() for q in queue.split(",")]
+	queues = get_queue_list(queue, build_queue_name=True)
 
 	if os.environ.get("CI"):
 		setup_loghandlers("ERROR")
@@ -370,12 +369,11 @@ def start_worker_pool(
 
 	_freeze_gc()
 
-	with frappe.init_site():
-		redis_connection = get_redis_conn()
+	redis_connection = get_redis_conn()
 
-		if queue:
-			queue = [q.strip() for q in queue.split(",")]
-		queues = get_queue_list(queue, build_queue_name=True)
+	if queue:
+		queue = [q.strip() for q in queue.split(",")]
+	queues = get_queue_list(queue, build_queue_name=True)
 
 	if os.environ.get("CI"):
 		setup_loghandlers("ERROR")
@@ -504,9 +502,6 @@ def validate_queue(queue: str, default_queue_list: list | None = None) -> None:
 	reraise=True,
 )
 def get_redis_conn(username=None, password=None):
-	if not hasattr(frappe.local, "conf"):
-		raise Exception("You need to call frappe.init")
-
 	conf = frappe.get_site_config()
 	if not conf.redis_queue:
 		raise Exception("redis_queue missing in common_site_config.json")

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -143,10 +143,8 @@ def get_sites(site_arg: str) -> list[str]:
 		return frappe.utils.get_sites()
 	elif site_arg:
 		return [site_arg]
-	elif os.environ.get("FRAPPE_SITE"):
-		return [os.environ.get("FRAPPE_SITE")]
-	elif default_site := frappe.get_conf().default_site:
-		return [default_site]
+	elif frappe.bench.scoped:
+		return [frappe.bench.sites.site]
 	# This is not supported, just added here for warning.
 	elif (site := frappe.read_file("currentsite.txt")) and site.strip():
 		click.secho(

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -82,8 +82,7 @@ def sleep_duration(tick):
 def enqueue_events_for_all_sites() -> None:
 	"""Loop through sites and enqueue events that are not already queued"""
 
-	with frappe.init_site():
-		sites = get_sites()
+	sites = get_sites()
 
 	# Sites are sorted in alphabetical order, shuffle to randomize priorities
 	random.shuffle(sites)


### PR DESCRIPTION
- **feat: Add nested class hierarchy for Bench folder layout** &rarr; https://github.com/frappe/frappe/pull/28158
- **refactor: ready frappe.init for new signature via singledispatch**

## Refactor frappe.init for New Signature via singledispatch

This PR builds upon the [previous nested class hierarchy implementation](https://github.com/frappe/frappe/pull/28158), focusing on refactoring `frappe.init` to support a new signature using `singledispatch`. Key changes include:

- Introduced `@functools.singledispatch` for `frappe.init` to handle different argument types
- Added a new `_init` function that accepts `Sites.Site` object as an argument
- Moved the old `init` function to `deprecation_dumpster.py` as `old_init`
- Updated type hints and imports to support the new structure
- Added `site` to local variables in `frappe/__init__.py`
- Replaced `get_site_config()` with `site.config` in the new `_init` function

This refactoring prepares Frappe for a more object-oriented approach to site initialization, improving type safety and flexibility while maintaining backwards compatibility through the deprecation system.
