### PR TITLE
refactor: add frappe.bench

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -248,6 +248,7 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force: bool =
 	local.test_objects = defaultdict(list)
 
 	local.site = site
+	local.site_name = site  # implicitly scopes bench
 	local.sites_path = sites_path
 	local.site_path = os.path.join(sites_path, site)
 	local.all_apps = None

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -371,7 +371,7 @@ def get_site_config(sites_path: str | None = None, site_path: str | None = None)
 	`site_config` is a set of site wide settings like database name, password, email etc."""
 	config: _dict[str, Any] = _dict()
 
-	sites_path = sites_path or getattr(local, "sites_path", None)
+	sites_path = sites_path or frappe.bench.sites.path
 	site_path = site_path or getattr(local, "site_path", None)
 
 	common_config = get_common_site_config(sites_path)
@@ -455,7 +455,7 @@ def get_common_site_config(sites_path: str | None = None) -> _dict[str, Any]:
 	- checking configuration which should only be allowed in common site config
 	- When no site context is present and fallback is required.
 	"""
-	sites_path = sites_path or getattr(local, "sites_path", None)
+	sites_path = sites_path or frappe.bench.sites.path
 
 	common_site_config = os.path.join(sites_path, "common_site_config.json")
 	if os.path.exists(common_site_config):
@@ -472,8 +472,7 @@ def get_conf(site: str | None = None) -> _dict[str, Any]:
 		return local.conf
 
 	# if no site, get from common_site_config.json
-	with init_site(site):
-		return local.conf
+	return frappe._dict(frappe.bench.sites.config)
 
 
 class init_site:
@@ -1586,11 +1585,11 @@ def get_module_list(app_name):
 def get_all_apps(with_internal_apps=True, sites_path=None):
 	"""Get list of all apps via `sites/apps.txt`."""
 	if not sites_path:
-		sites_path = local.sites_path
+		sites_path = frappe.bench.sites.path
 
 	apps = get_file_items(os.path.join(sites_path, "apps.txt"), raise_not_found=True)
 
-	if with_internal_apps:
+	if with_internal_apps and local("site_path"):
 		for app in get_file_items(os.path.join(local.site_path, "apps.txt")):
 			if app not in apps:
 				apps.append(app)

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -51,6 +51,8 @@ from frappe.query_builder.utils import (
 from frappe.utils.caching import request_cache
 from frappe.utils.data import cint, cstr, sbool
 
+from .bencher import Bench
+
 # Local application imports
 from .exceptions import *
 from .types.frappedict import _dict
@@ -81,6 +83,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 controllers: dict[str, "Document"] = {}
 local = Local()
+bench = Bench()
 cache: Optional["RedisWrapper"] = None
 STANDARD_USERS = ("Guest", "Administrator")
 

--- a/frappe/bencher.py
+++ b/frappe/bencher.py
@@ -184,7 +184,7 @@ class Sites(Benched, ConfigHandler):
 		ConfigHandler.__init__(self, self.path.joinpath("common_site_config.json"))
 		self.__sites = None
 		self.bench = bench
-		# security: self.site_name attribute scopes access
+		# security: site_name is now stored in thread-local storage
 		self.site_name = os.environ.get("FRAPPE_SITE") or self.config.get("default_site")
 		self._iterator = None
 
@@ -195,6 +195,18 @@ class Sites(Benched, ConfigHandler):
 			+ ("\n * Scoped Site: " + (self.site_name or "n/a"))
 			+ ("\n * Loaded Sites:\n\t" + ("\n\t".join([str(site) for site in self]) or "n/a"))
 		)
+
+	@property
+	def site_name(self):
+		import frappe
+
+		return getattr(frappe.local, "site_name", None)
+
+	@site_name.setter
+	def site_name(self, value):
+		import frappe
+
+		frappe.local.site_name = value
 
 	class Site(ConfigHandler, PathLike, Serializable):
 		def __init__(self, name: str, path: str, bench: "super.Bench"):
@@ -269,7 +281,7 @@ class Sites(Benched, ConfigHandler):
 
 	@property
 	def site(self) -> Site:
-		# security: self.site_name attribute scopes access
+		# security: site_name is now stored in thread-local storage
 		if not self.site_name or self.site_name == self.ALL_SITES:
 			raise BenchNotScopedError("Sites was not scoped to a single site, yet.")
 		return self[self.site_name]
@@ -283,7 +295,7 @@ class Sites(Benched, ConfigHandler):
 				if path.is_dir() and path.joinpath("site_config.json").exists():
 					self.__sites[path.name] = self.Site(path.name, path, self.bench)
 
-			# security: self.site_name attribute scopes access
+			# security: site_name is now stored in thread-local storage
 			if self.site_name and self.site_name != self.ALL_SITES:
 				_process(self.path.joinpath(self.site_name))
 			elif self.site_name == self.ALL_SITES:

--- a/frappe/bencher.py
+++ b/frappe/bencher.py
@@ -1,0 +1,335 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Final
+
+from frappe.config import ConfigHandler
+
+global _current_bench  # used to implement legacy code paths to keep the main path clean
+
+
+class BenchNotScopedError(NotImplementedError):
+	pass
+
+
+class BenchSiteNotLoadedError(ValueError):
+	pass
+
+
+class PathLike:
+	def __fspath__(self):
+		return str(self.path)
+
+
+class Serializable:
+	def __json__(self):
+		return {k: v for k, v in self.__dict__.items()}
+
+
+class Benched(PathLike, Serializable):
+	def __init__(self, path: str | None = None, parent_path: Path | None = None):
+		path = (
+			path
+			or os.environ.get(f"FRAPPE_{self.__class__.__name__.upper()}_PATH")
+			or (parent_path.joinpath(self.__class__.__name__.lower()) if parent_path else None)
+			# only for Bench class ...
+			or (
+				# TODO: legacy, remove
+				os.environ.get("FRAPPE_BENCH_ROOT") if isinstance(self, Bench) else None
+			)
+			or (
+				# TODO: unsave relative reference, remove
+				Path(__file__).resolve().parents[3]  # bench folder in standard layout
+				if isinstance(self, Bench)
+				else None
+			)
+			or (Path("~/frappe-bench").expanduser() if isinstance(self, Bench) else None)
+		)
+
+		if path is None:
+			raise ValueError(f"Unable to determine path for {self.__class__.__name__}")
+
+		self.path = Path(path)
+
+
+class Frapped:
+	python_path: Path
+
+	def __bool__(self):
+		return (
+			self._is_frapped()
+			or (isinstance(self, Apps.App) and self._is_app_apped())
+			or (isinstance(self, Apps.App.Module) and self._is_module_moduled())
+		)
+
+	def _is_frapped(self):
+		return self.python_path.is_dir() and self.python_path.joinpath(".frappe").exists()
+
+	def _is_app_apped(self):
+		res = self.name in _current_bench.sites.path.joinpath("apps.txt").read_text()
+		if res:
+			from frappe.deprecation_dumpster import deprecation_warning
+
+			deprecation_warning(
+				"2024-10-18",
+				"v18",
+				f"Instead of adding {self.name} to sites/apps.txt, drop an empty file at {self.python_path}/.frappe",
+			)
+			return res
+		return False
+
+	def _is_module_moduled(self):
+		res = self.name.title() in self.app.python_path.joinpath("modules.txt").read_text()
+		if res:
+			from frappe.deprecation_dumpster import deprecation_warning
+
+			deprecation_warning(
+				"2024-10-18",
+				"v18",
+				f"Instead of adding {self.name.title()} to {self.app.python_path}/modules.txt, drop an empty file at {self.python_path}/.frappe",
+			)
+			return res
+		return False
+
+
+class Apps(Benched):
+	def __init__(self, path: str | None = None, parent_path: str | None = None):
+		super().__init__(path, parent_path)
+		self._apps = None
+
+	def __str__(self):
+		return (
+			repr(self)
+			+ ("\n * Apps Path: " + str(self.path))
+			+ ("\n * Loaded Apps:\n\t" + ("\n\t".join([str(app) for app in self.apps]) or "n/a"))
+		)
+
+	class App(Frapped, PathLike, Serializable):
+		def __init__(self, name: str, path: str):
+			self.name = name
+			self.path = Path(path)
+			self.python_path = self.path.joinpath(self.name)
+			self._modules = None
+
+		def __str__(self):
+			return self.name
+
+		class Module(Frapped, PathLike, Serializable):
+			def __init__(self, name: str, path: str, app: "Apps.App"):
+				self.app = app
+				self.name = name
+				self.path = Path(path)
+				self.python_path = self.path
+
+		@property
+		def modules(self) -> dict[str, Module]:
+			if self._modules is None:
+				self._modules = {
+					d.name: module
+					for d in self.python_path.iterdir()
+					if d.is_dir() and (module := self.Module(d.name, d, self))
+				}
+			return self._modules
+
+		def __iter__(self):
+			return iter(self.modules.values())
+
+		def __len__(self):
+			return len(self.modules)
+
+		def __getitem__(self, key):
+			return self.modules[key]
+
+	@property
+	def apps(self) -> dict[str, App]:
+		if self._apps is None:
+			self._apps = {
+				d.name: app for d in self.path.iterdir() if d.is_dir() and (app := self.App(d.name, d))
+			}
+		return self._apps
+
+	def __iter__(self):
+		return iter(self.apps.values())
+
+	def __len__(self):
+		return len(self.apps)
+
+	def __getitem__(self, key):
+		return self.apps[key]
+
+
+class Logs(Benched):
+	def __init__(self, path: str | None = None, parent_path: Path | None = None):
+		super().__init__(path, parent_path)
+
+	def get_log_file(self, log_type: str):
+		return self.path.joinpath(f"{log_type}.log")
+
+
+class Run(Benched):
+	def __init__(self, path: str | None = None, parent_path: Path | None = None):
+		super().__init__(
+			path
+			# config is the legacy naming of this folder; a misnomer
+			or (parent_path.joinpath("config") if parent_path else None),
+			parent_path,
+		)
+
+
+class Sites(Benched, ConfigHandler):
+	ALL_SITES: Final = "__all-sites__"
+
+	def __init__(self, path: str | None = None, parent_path: Path | None = None, bench: "Bench" = None):
+		Benched.__init__(self, path, parent_path)
+		ConfigHandler.__init__(self, self.path.joinpath("common_site_config.json"))
+		self.__sites = None
+		self.bench = bench
+		# security: self.site_name attribute scopes access
+		self.site_name = os.environ.get("FRAPPE_SITE") or self.config.get("default_site")
+		self._iterator = None
+
+	def __str__(self):
+		return (
+			repr(self)
+			+ ("\n * Sites Path: " + str(self.path))
+			+ ("\n * Scoped Site: " + (self.site_name or "n/a"))
+			+ ("\n * Loaded Sites:\n\t" + ("\n\t".join([str(site) for site in self]) or "n/a"))
+		)
+
+	class Site(ConfigHandler, PathLike, Serializable):
+		def __init__(self, name: str, path: str, bench: "super.Bench"):
+			self.name = name
+			self.path = Path(path)
+			self.bench: "Bench" = bench
+			self._combined_config = None
+			ConfigHandler.__init__(self, self.path.joinpath("site_config.json"))
+
+		def __eq__(self, o):
+			return self.name == str(o)
+
+		def __hash__(self):
+			return hash(self.name)
+
+		def __str__(self):
+			return self.name
+
+		def __fspath__(self):
+			return str(self.path)
+
+		def __json__(self):
+			excluded = (
+				"bench",  # prevent circular deps
+				"_ConfigHandler__config",  # holds file contents
+				"_config_stale",  # never stale after accessored
+			)
+			naming = {"_combined_config": "config"}
+			return {naming.get(k, k): v for k, v in self.__dict__.items() if k not in excluded}
+
+		@property
+		def config(self) -> dict[str, Any]:
+			if self._combined_config is None or self._config_stale:
+				site_config = super().config.copy()
+				config = self.bench.sites.config.copy()
+				config.update(site_config)
+				self._combined_config = config
+			return self._combined_config
+
+	def add_site(self, site_name: str):
+		site_path = self.path.joinpath(site_name)
+		for dir_path in [
+			site_path.joinpath("public", "files"),
+			site_path.joinpath("private", "backups"),
+			site_path.joinpath("private", "files"),
+			site_path.joinpath("locks"),
+			site_path.joinpath("logs"),
+		]:
+			dir_path.mkdir(parents=True, exist_ok=True)
+		self.__sites[site_name] = self.Site(site_name, site_path)
+
+	def remove_site(self, site_name: str):
+		if site_name in self.__sites:
+			del self.__sites[site_name]
+			# site_path = self.path.joinpath(site_name)
+			# Note: This doesn't actually delete the site directory, just removes it from the sites dict
+			# Actual deletion should be handled separately with proper safeguards
+
+	def scope(self, site_name: str | None = None) -> Site:
+		if site_name is None:
+			return self.site
+
+		self.__sites = None
+		self.site_name = site_name
+
+		if self.site_name != self.ALL_SITES:
+			return self.site
+
+	@property
+	def scoped(self) -> bool:
+		return bool(self.site_name) and self.site_name != self.ALL_SITES
+
+	@property
+	def site(self) -> Site:
+		# security: self.site_name attribute scopes access
+		if not self.site_name or self.site_name == self.ALL_SITES:
+			raise BenchNotScopedError("Sites was not scoped to a single site, yet.")
+		return self[self.site_name]
+
+	@property
+	def _sites(self) -> dict[str, Site]:
+		if self.__sites is None:
+			self.__sites = {}
+
+			def _process(path: Path):
+				if path.is_dir() and path.joinpath("site_config.json").exists():
+					self.__sites[path.name] = self.Site(path.name, path, self.bench)
+
+			# security: self.site_name attribute scopes access
+			if self.site_name and self.site_name != self.ALL_SITES:
+				_process(self.path.joinpath(self.site_name))
+			elif self.site_name == self.ALL_SITES:
+				for site_path in self.path.iterdir():
+					_process(site_path)
+		return self.__sites
+
+	def __iter__(self):
+		# security: self.site_name attribute scopes access
+		if self.site_name == self.ALL_SITES:
+			return iter(self._sites.values())
+		elif self.site_name:
+			return iter([self[self.site_name]])
+		raise BenchNotScopedError("Sites was not scoped, yet.")
+
+	def __len__(self):
+		return len(self._sites)
+
+	def __getitem__(self, key):
+		try:
+			return self._sites[key]
+		except KeyError:
+			raise BenchSiteNotLoadedError(f"Site '{key}' was not loaded")
+
+
+class Bench(Benched):
+	def __init__(self, path: str | None = None):
+		super().__init__(path)
+		self.logs = Logs(parent_path=self.path)
+		self.run = Run(parent_path=self.path)
+		self.sites = Sites(parent_path=self.path, bench=self)
+		global _current_bench
+		_current_bench = self
+		self.apps = Apps(parent_path=self.path)
+
+	def scope(self, site_name: str):
+		return self.sites.scope(site_name)
+
+	@property
+	def scoped(self):
+		return self.sites.scoped
+
+	def __str__(self):
+		return (
+			repr(self)
+			+ ("\n * Bench Path: " + str(self.path))
+			+ ("\n\n" + str(self.apps))
+			+ ("\n\n" + str(self.sites))
+		)

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -15,7 +15,6 @@ import frappe
 
 timestamps = {}
 app_paths = None
-sites_path = os.path.abspath(os.getcwd())
 WHITESPACE_PATTERN = re.compile(r"\s+")
 HTML_COMMENT_PATTERN = re.compile(r"(<!--.*?-->)")
 
@@ -48,7 +47,7 @@ def build_missing_files():
 	current_asset_files = []
 
 	for type in ["css", "js"]:
-		folder = os.path.join(sites_path, "assets", "frappe", "dist", type)
+		folder = frappe.bench.sites.path.joinpath("assets", "frappe", "dist", type)
 		current_asset_files.extend(os.listdir(folder))
 
 	development = frappe.local.conf.developer_mode or frappe.local.dev_server
@@ -137,7 +136,8 @@ def download_frappe_assets(verbose=True) -> bool:
 	"""Download and set up Frappe assets if they exist based on the current commit HEAD.
 	Return True if correctly setup else return False.
 	"""
-	frappe_head = getoutput("cd ../apps/frappe && git rev-parse HEAD")
+	frappe_path = frappe.bench.apps["frappe"].path
+	frappe_head = getoutput(f"cd {frappe_path} && git rev-parse HEAD")
 
 	if not frappe_head:
 		return False
@@ -215,7 +215,7 @@ def setup():
 		except ImportError:
 			pass
 	app_paths = [os.path.dirname(pymodule.__file__) for pymodule in pymodules]
-	assets_path = os.path.join(frappe.local.sites_path, "assets")
+	assets_path = frappe.bench.sites.path / "assets"
 
 
 def bundle(
@@ -265,7 +265,7 @@ def watch(apps=None):
 	if apps:
 		command += f" --apps {apps}"
 
-	live_reload = frappe.utils.cint(os.environ.get("LIVE_RELOAD", frappe.conf.live_reload))
+	live_reload = frappe.utils.cint(frappe.bench.sites.config.get("live_reload"))
 
 	if live_reload:
 		command += " --live-reload"

--- a/frappe/commands/redis_utils.py
+++ b/frappe/commands/redis_utils.py
@@ -30,8 +30,7 @@ def create_rq_users(set_admin_password=False, use_rq_auth=False):
 	with open(acl_file_path, "w") as f:
 		f.writelines([acl + "\n" for acl in acl_list])
 
-	sites_path = os.getcwd()
-	common_site_config_path = os.path.join(sites_path, "common_site_config.json")
+	common_site_config_path = frappe.bench.sites.path / "common_site_config.json"
 	update_site_config(
 		"rq_username",
 		user_credentials["bench"][0],

--- a/frappe/commands/redis_utils.py
+++ b/frappe/commands/redis_utils.py
@@ -19,7 +19,6 @@ def create_rq_users(set_admin_password=False, use_rq_auth=False):
 	acl config file will be used by redis server while starting the server
 	and app config is used by app while connecting to redis server.
 	"""
-	from frappe.installer import update_site_config
 	from frappe.utils.redis_queue import RedisQueue
 
 	acl_file_path = os.path.abspath("../config/redis_queue.acl")
@@ -30,20 +29,13 @@ def create_rq_users(set_admin_password=False, use_rq_auth=False):
 	with open(acl_file_path, "w") as f:
 		f.writelines([acl + "\n" for acl in acl_list])
 
-	common_site_config_path = frappe.bench.sites.path / "common_site_config.json"
-	update_site_config(
-		"rq_username",
-		user_credentials["bench"][0],
-		validate=False,
-		site_config_path=common_site_config_path,
+	frappe.bench.sites.update_config(
+		{
+			"rq_username": user_credentials["bench"][0],
+			"rq_password": user_credentials["bench"][1],
+			"use_rq_auth": use_rq_auth,
+		}
 	)
-	update_site_config(
-		"rq_password",
-		user_credentials["bench"][1],
-		validate=False,
-		site_config_path=common_site_config_path,
-	)
-	update_site_config("use_rq_auth", use_rq_auth, validate=False, site_config_path=common_site_config_path)
 
 	click.secho(
 		"* ACL and site configs are updated with new user credentials. "

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -793,9 +793,8 @@ def _use(site, sites_path="."):
 def use(site, sites_path="."):
 	from frappe.installer import update_site_config
 
-	if os.path.exists(os.path.join(sites_path, site)):
-		sites_path = os.getcwd()
-		conifg = os.path.join(sites_path, "common_site_config.json")
+	if (frappe.bench.sites.path / site).exists():
+		conifg = frappe.bench.sites.path / "common_site_config.json"
 		update_site_config("default_site", site, validate=False, site_config_path=conifg)
 		print(f"Current Site set to {site}")
 	else:

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -791,11 +791,8 @@ def _use(site, sites_path="."):
 
 
 def use(site, sites_path="."):
-	from frappe.installer import update_site_config
-
 	if (frappe.bench.sites.path / site).exists():
-		conifg = frappe.bench.sites.path / "common_site_config.json"
-		update_site_config("default_site", site, validate=False, site_config_path=conifg)
+		frappe.bench.sites.update_config({"default_site": site})
 		print(f"Current Site set to {site}")
 	else:
 		print(f"Site {site} does not exist")

--- a/frappe/config.py
+++ b/frappe/config.py
@@ -1,0 +1,84 @@
+import importlib
+import json
+import os
+import traceback
+from typing import Any
+
+from filelock import FileLock, Timeout
+
+
+class ConfigHandler:
+	default_config = (
+		("redis_queue", "redis://127.0.0.1:11311"),
+		("redis_cache", "redis://127.0.0.1:13311"),
+		("db_type", "mariadb"),
+		("db_host", "127.0.0.1"),
+		("db_port", 3306),
+		("db_socket", None),
+	)
+
+	def _apply_dynamic_defaults(self):
+		if not self._config.get("db_user"):
+			self._config["db_user"] = self._config.get("db_name")
+		if not self._config.get("db_name"):
+			self._config["db_name"] = self._config.get("db_user")
+		if self._config.get("db_type") == "postrges":
+			self._config["db_port"] = 5432
+
+	def __init__(self, config_path: str):
+		self.config_path = config_path
+		self._config = None
+		self.__config = None
+		self._config_stale = True
+
+	def _handle_sighup(self, signum, frame):
+		self._config_stale = True
+
+	@property
+	def config(self) -> dict[str, Any]:
+		if self._config is None or self._config_stale:
+			if os.path.exists(self.config_path):
+				with open(self.config_path) as f:
+					self.__config = json.load(f)
+			else:
+				self.__config = {}
+			self._config = dict(self.default_config, **self.__config)
+			self._update_from_env()
+			self._apply_extra_config()
+			self._apply_dynamic_defaults()
+			self._config_stale = False
+		return self._config
+
+	def update_config(self, updates: dict[str, Any]):
+		self.__config.update(updates)
+		try:
+			with FileLock(f"{self.config_path}.lock", timeout=5):
+				with open(self.config_path, "w") as f:
+					from frappe.utils.response import json_handler
+
+					json.dump(self.__config, f, indent=2, default=json_handler, sort_keys=True)
+		except Timeout as e:
+			from frappe import log_error
+
+			log_error(f"Filelock: Failed to aquire {self.config_path}.lock")
+			raise e
+		self._config_stale = True
+
+	def _update_from_env(self):
+		for key in self._config.keys():
+			env_key = f"FRAPPE_{key.upper()}"
+			if env_value := os.environ.get(env_key):
+				self._config[key] = env_value
+
+	def _apply_extra_config(self):
+		extra_config = self._config.get("extra_config")
+		if extra_config:
+			if isinstance(extra_config, str):
+				extra_config = [extra_config]
+			for hook in extra_config:
+				try:
+					module, method = hook.rsplit(".", 1)
+					self._config.update(getattr(importlib.import_module(module), method)())
+				except Exception:
+					print(f"Config hook {hook} failed")
+					traceback.print_exc()

--- a/frappe/config.py
+++ b/frappe/config.py
@@ -70,6 +70,13 @@ class ConfigHandler:
 			env_key = f"FRAPPE_{key.upper()}"
 			if env_value := os.environ.get(env_key):
 				self._config[key] = env_value
+				continue
+			# TODO: rmove legacy env variable
+			if key == "live_reload":
+				env_key = "LIVE_RELOAD"
+				if env_value := os.environ.get(env_key):
+					self._config[key] = env_value
+					continue
 
 	def _apply_extra_config(self):
 		extra_config = self._config.get("extra_config")

--- a/frappe/config.py
+++ b/frappe/config.py
@@ -46,7 +46,8 @@ class ConfigHandler:
 			self._update_from_env()
 			self._apply_extra_config()
 			self._apply_dynamic_defaults()
-			self._config_stale = False
+			# TODO: enable in-memory caching only once we have identified a mechanism to hot-reload on external config changes
+			# self._config_stale = False
 		return self._config
 
 	def update_config(self, updates: dict[str, Any]):

--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -202,7 +202,7 @@ def get_js(items):
 		if ".." in src or src[0] != "assets":
 			frappe.throw(_("Invalid file path: {0}").format("/".join(src)))
 
-		contentpath = os.path.join(frappe.local.sites_path, *src)
+		contentpath = frappe.bench.sites.path.joinpath(*src)
 		with open(contentpath) as srcfile:
 			code = frappe.utils.cstr(srcfile.read())
 

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -4,6 +4,11 @@
 # BEWARE don't put anything in this file except exceptions
 from werkzeug.exceptions import NotFound
 
+from .bencher import (
+	BenchNotScopedError,
+	BenchSiteNotLoadedError,
+)
+
 
 class SiteNotSpecifiedError(Exception):
 	def __init__(self, *args, **kwargs):

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -560,9 +560,8 @@ def make_conf(
 		db_port=db_port,
 		db_user=db_user,
 	)
-	sites_path = frappe.local.sites_path
 	frappe.destroy()
-	frappe.init(site, sites_path=sites_path)
+	frappe.init(site)
 
 
 def make_site_config(
@@ -608,7 +607,7 @@ def update_site_config(key, value, validate=True, site_config_path=None):
 		site_config_path = get_site_config_path()
 
 	# Sometimes global config file is passed directly to this function
-	_is_global_conf = "common_site_config" in site_config_path
+	_is_global_conf = "common_site_config" in str(site_config_path)
 
 	with filelock("site_config", is_global=_is_global_conf):
 		_update_config_file(key=key, value=value, config_file=site_config_path)

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -607,10 +607,11 @@ def update_site_config(key, value, validate=True, site_config_path=None):
 		site_config_path = get_site_config_path()
 
 	# Sometimes global config file is passed directly to this function
-	_is_global_conf = "common_site_config" in str(site_config_path)
-
-	with filelock("site_config", is_global=_is_global_conf):
-		_update_config_file(key=key, value=value, config_file=site_config_path)
+	if "common_site_config" in str(site_config_path):
+		frappe.bench.sites.update_config({key: value})
+	else:
+		with filelock("site_config"):
+			_update_config_file(key=key, value=value, config_file=site_config_path)
 
 
 def _update_config_file(key: str, value, config_file: str):

--- a/frappe/tests/classes/context_managers.py
+++ b/frappe/tests/classes/context_managers.py
@@ -117,13 +117,11 @@ def enable_safe_exec() -> None:
 	"""Temporarily: enable safe exec (server scripts)."""
 	import os
 
-	from frappe.installer import update_site_config
 	from frappe.utils.safe_exec import SAFE_EXEC_CONFIG_KEY
 
-	conf = frappe.bench.sites.path.joinpath("common_site_config.json")
-	update_site_config(SAFE_EXEC_CONFIG_KEY, 1, validate=False, site_config_path=conf)
+	frappe.bench.sites.update_config({SAFE_EXEC_CONFIG_KEY: 1})
 	yield
-	update_site_config(SAFE_EXEC_CONFIG_KEY, 0, validate=False, site_config_path=conf)
+	frappe.bench.sites.update_config({SAFE_EXEC_CONFIG_KEY: 0})
 
 
 @UnitTestCase.registerAs(staticmethod)

--- a/frappe/tests/classes/context_managers.py
+++ b/frappe/tests/classes/context_managers.py
@@ -120,7 +120,7 @@ def enable_safe_exec() -> None:
 	from frappe.installer import update_site_config
 	from frappe.utils.safe_exec import SAFE_EXEC_CONFIG_KEY
 
-	conf = os.path.join(frappe.local.sites_path, "common_site_config.json")
+	conf = frappe.bench.sites.path.joinpath("common_site_config.json")
 	update_site_config(SAFE_EXEC_CONFIG_KEY, 1, validate=False, site_config_path=conf)
 	yield
 	update_site_config(SAFE_EXEC_CONFIG_KEY, 0, validate=False, site_config_path=conf)

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -910,7 +910,7 @@ class TestBenchBuild(BaseTestCommands):
 		default_bundle_size = 0.0
 
 		for chunk in default_bundle:
-			abs_path = Path.cwd() / frappe.local.sites_path / bundled_asset(chunk)[1:]
+			abs_path = (frappe.bench.sites.path / bundled_asset(chunk)[1:]).resolve()
 			default_bundle_size += abs_path.stat().st_size
 
 		self.assertLessEqual(

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -540,7 +540,7 @@ def get_messages_from_include_files(app_name=None):
 
 	for js_path in include_js:
 		file_path = bundled_asset(js_path)
-		relative_path = os.path.join(frappe.local.sites_path, file_path.lstrip("/"))
+		relative_path = frappe.bench.sites.path.joinpath(file_path.lstrip("/"))
 		messages_from_file = get_messages_from_file(relative_path)
 		messages.extend(messages_from_file)
 

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -671,7 +671,7 @@ def is_a_property(x) -> bool:
 
 def get_sites(sites_path=None):
 	if not sites_path:
-		sites_path = getattr(frappe.local, "sites_path", None) or "."
+		sites_path = frappe.bench.sites.path
 
 	sites = []
 	for site in os.listdir(sites_path):
@@ -944,7 +944,7 @@ def get_file_size(path, format=False):
 
 def get_build_version():
 	try:
-		return str(os.path.getmtime(os.path.join(frappe.local.sites_path, "assets/assets.json")))
+		return str(os.path.getmtime(frappe.bench.sites.path.joinpath("assets", "assets.json")))
 	except OSError:
 		# .build can sometimes not exist
 		# this is not a major problem so send fallback

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -44,8 +44,7 @@ def get_queues_timeout() -> dict[str, int]:
 
 	:return: Dictionary of queue name to timeout
 	"""
-	common_site_config = frappe.get_conf()
-	custom_workers_config = common_site_config.get("workers", {})
+	custom_workers_config = frappe.bench.sites.config.get("workers", {})
 	default_timeout = 300
 
 	# Note: Order matters here

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -194,7 +194,7 @@ def get_frappe_help():
 
 
 def get_apps():
-	return frappe.get_all_apps(with_internal_apps=False, sites_path=".")
+	return frappe.get_all_apps(with_internal_apps=False)
 
 
 if __name__ == "__main__":

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -234,7 +234,7 @@ PATCH_TEMPLATE = textwrap.dedent(
 
 class PatchCreator:
 	def __init__(self):
-		self.all_apps = frappe.get_all_apps(sites_path=".", with_internal_apps=False)
+		self.all_apps = frappe.get_all_apps(with_internal_apps=False)
 
 		self.app = None
 		self.app_dir = None

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -299,7 +299,7 @@ def prepare_header_footer(soup: BeautifulSoup):
 	styles = soup.find_all("style")
 
 	print_css = bundled_asset("print.bundle.css").lstrip("/")
-	css = frappe.read_file(os.path.join(frappe.local.sites_path, print_css))
+	css = frappe.read_file(frappe.bench.sites.path.joinpath(print_css))
 
 	# extract header and footer
 	for html_id in ("header-html", "footer-html"):

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -79,7 +79,7 @@ class FrappePrintCollector(PrintCollector):
 
 def is_safe_exec_enabled() -> bool:
 	# server scripts can only be enabled via common_site_config.json
-	return bool(frappe.get_common_site_config().get(SAFE_EXEC_CONFIG_KEY))
+	return bool(frappe.bench.sites.config.get(SAFE_EXEC_CONFIG_KEY))
 
 
 def safe_exec(

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -242,5 +242,4 @@ def get_scheduler_status():
 
 
 def get_scheduler_tick() -> int:
-	conf = frappe.get_conf()
-	return cint(conf.scheduler_tick_interval) or DEFAULT_SCHEDULER_TICK
+	return cint(frappe.bench.sites.config.get("scheduler_tick_interval")) or DEFAULT_SCHEDULER_TICK

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -82,8 +82,7 @@ def sleep_duration(tick):
 def enqueue_events_for_all_sites() -> None:
 	"""Loop through sites and enqueue events that are not already queued"""
 
-	with frappe.init_site():
-		sites = get_sites()
+	sites = get_sites()
 
 	# Sites are sorted in alphabetical order, shuffle to randomize priorities
 	random.shuffle(sites)


### PR DESCRIPTION
- **feat: Add nested class hierarchy for Bench folder layout**
- **refactor: add global frappe.bench and reduce use of sites_path**

This PR introduces a global `frappe.bench` reference and refactors the codebase to reduce reliance on `sites_path`. Key changes include:

- Introduced global `frappe.bench` reference
- Updated path management in multiple files to use `frappe.bench.sites.path`
- Refactored file operations to use the new path structure
- Adjusted site configuration and asset management functions

These changes improve code maintainability and consistency in handling site-related paths throughout the Frappe Framework.

