### PR TITLE
feat: Add a field to accept allowed embedding domains

### DIFF
--- a/cypress/integration/web_form.js
+++ b/cypress/integration/web_form.js
@@ -87,6 +87,10 @@ context("Web Form", () => {
 		cy.visit("/app/web-form/note");
 
 		cy.findByRole("tab", { name: "Settings" }).click();
+
+		cy.wait(100);
+		cy.get(".section-head").contains("List Settings").scrollIntoView();
+
 		cy.fill_field("list_title", "Note List");
 
 		cy.save();

--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -31,6 +31,7 @@
   "allow_comments",
   "show_attachments",
   "allow_incomplete",
+  "allowed_embedding_domains",
   "section_break_2",
   "max_attachment_size",
   "condition_section",
@@ -401,13 +402,19 @@
    "fieldname": "hide_footer",
    "fieldtype": "Check",
    "label": "Hide footer"
+  },
+  {
+   "description": "Specify the domains or origins that are permitted to embed this form. Enter one domain per line (e.g., https://example.com). If no domains are specified, the form can only be embedded on the same origin.",
+   "fieldname": "allowed_embedding_domains",
+   "fieldtype": "Small Text",
+   "label": "Allowed Embedding Domains"
   }
  ],
  "has_web_view": 1,
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2024-09-11 14:28:39.391595",
+ "modified": "2024-10-18 11:19:53.969109",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",

--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -17,23 +17,25 @@
   "introduction_text",
   "web_form_fields",
   "settings_tab",
-  "login_required",
-  "allow_multiple",
-  "allow_edit",
-  "allow_delete",
+  "access_control_section",
   "anonymous",
-  "hide_navbar",
-  "hide_footer",
+  "login_required",
   "column_break_2",
   "apply_document_permissions",
+  "allow_edit",
+  "allow_multiple",
+  "allow_delete",
+  "form_settings_section",
+  "allow_incomplete",
+  "allow_comments",
   "allow_print",
   "print_format",
-  "allow_comments",
-  "show_attachments",
-  "allow_incomplete",
-  "allowed_embedding_domains",
-  "section_break_2",
   "max_attachment_size",
+  "show_attachments",
+  "column_break_hhec",
+  "hide_navbar",
+  "hide_footer",
+  "allowed_embedding_domains",
   "condition_section",
   "condition_description",
   "condition_json",
@@ -112,7 +114,7 @@
    "depends_on": "eval:!doc.anonymous",
    "fieldname": "login_required",
    "fieldtype": "Check",
-   "label": "Login required"
+   "label": "Login Required"
   },
   {
    "default": "0",
@@ -182,9 +184,10 @@
    "options": "Web Form Field"
   },
   {
+   "description": "Set size in MB",
    "fieldname": "max_attachment_size",
    "fieldtype": "Int",
-   "label": "Max Attachment Size (in MB)"
+   "label": "Max Attachment Size"
   },
   {
    "description": "For help see <a href=\"https://frappeframework.com/docs/user/en/guides/portal-development/web-forms\" target=\"_blank\">Client Script API and Examples</a>",
@@ -300,10 +303,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "section_break_2",
-   "fieldtype": "Section Break"
-  },
-  {
    "collapsible": 1,
    "collapsible_depends_on": "show_list",
    "depends_on": "eval:!doc.anonymous",
@@ -372,9 +371,10 @@
   },
   {
    "default": "0",
+   "description": "If enabled, all responses on the web form will be submitted anonymously",
    "fieldname": "anonymous",
    "fieldtype": "Check",
-   "label": "Anonymous"
+   "label": "Anonymous Responses"
   },
   {
    "fieldname": "condition_description",
@@ -408,13 +408,27 @@
    "fieldname": "allowed_embedding_domains",
    "fieldtype": "Small Text",
    "label": "Allowed Embedding Domains"
+  },
+  {
+   "fieldname": "access_control_section",
+   "fieldtype": "Section Break",
+   "label": "Access Control"
+  },
+  {
+   "fieldname": "form_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Form Settings"
+  },
+  {
+   "fieldname": "column_break_hhec",
+   "fieldtype": "Column Break"
   }
  ],
  "has_web_view": 1,
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2024-10-18 11:19:53.969109",
+ "modified": "2024-10-21 11:49:54.025258",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",

--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -114,7 +114,7 @@
    "depends_on": "eval:!doc.anonymous",
    "fieldname": "login_required",
    "fieldtype": "Check",
-   "label": "Login Required"
+   "label": "Login required"
   },
   {
    "default": "0",
@@ -187,25 +187,25 @@
    "description": "Set size in MB",
    "fieldname": "max_attachment_size",
    "fieldtype": "Int",
-   "label": "Max Attachment Size"
+   "label": "Max attachment size"
   },
   {
    "description": "For help see <a href=\"https://frappeframework.com/docs/user/en/guides/portal-development/web-forms\" target=\"_blank\">Client Script API and Examples</a>",
    "fieldname": "client_script",
    "fieldtype": "Code",
-   "label": "Client Script"
+   "label": "Client script"
   },
   {
    "default": "Save",
    "fieldname": "button_label",
    "fieldtype": "Data",
-   "label": "Submit Button Label"
+   "label": "Submit button label"
   },
   {
    "description": "Message to be displayed on successful completion",
    "fieldname": "success_message",
    "fieldtype": "Text",
-   "label": "Success Message"
+   "label": "Success message"
   },
   {
    "description": "Go to this URL after completing the form",
@@ -267,7 +267,7 @@
   {
    "fieldname": "list_setting_message",
    "fieldtype": "HTML",
-   "label": "List Setting Message"
+   "label": "List setting message"
   },
   {
    "fieldname": "customization_tab",
@@ -277,7 +277,7 @@
   {
    "fieldname": "success_title",
    "fieldtype": "Data",
-   "label": "Success Title"
+   "label": "Success title"
   },
   {
    "fieldname": "banner_image",
@@ -349,12 +349,12 @@
   {
    "fieldname": "meta_title",
    "fieldtype": "Data",
-   "label": "Meta Title"
+   "label": "Meta title"
   },
   {
    "fieldname": "meta_description",
    "fieldtype": "Small Text",
-   "label": "Meta Description"
+   "label": "Meta description"
   },
   {
    "fieldname": "column_break_khxs",
@@ -363,7 +363,7 @@
   {
    "fieldname": "meta_image",
    "fieldtype": "Attach Image",
-   "label": "Meta Image"
+   "label": "Meta image"
   },
   {
    "fieldname": "column_break_vdhm",
@@ -374,12 +374,12 @@
    "description": "If enabled, all responses on the web form will be submitted anonymously",
    "fieldname": "anonymous",
    "fieldtype": "Check",
-   "label": "Anonymous Responses"
+   "label": "Anonymous responses"
   },
   {
    "fieldname": "condition_description",
    "fieldtype": "HTML",
-   "label": "Condition Description",
+   "label": "Condition description",
    "options": "<p>Multiple webforms can be created for a single doctype. Add filters specific to this webform to display correct record after submission.</p><p>For Example:</p>\n<p>If you create a separate webform every year to capture feedback from employees add a \n field named year in doctype and add a filter <b>year = 2023</b></p>\n"
   },
   {
@@ -407,7 +407,7 @@
    "description": "Specify the domains or origins that are permitted to embed this form. Enter one domain per line (e.g., https://example.com). If no domains are specified, the form can only be embedded on the same origin.",
    "fieldname": "allowed_embedding_domains",
    "fieldtype": "Small Text",
-   "label": "Allowed Embedding Domains"
+   "label": "Allowed embedding domains"
   },
   {
    "fieldname": "access_control_section",
@@ -428,7 +428,7 @@
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2024-10-21 11:49:54.025258",
+ "modified": "2024-10-21 12:04:47.314849",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -34,6 +34,7 @@ class WebForm(WebsiteGenerator):
 		allow_incomplete: DF.Check
 		allow_multiple: DF.Check
 		allow_print: DF.Check
+		allowed_embedding_domains: DF.SmallText | None
 		anonymous: DF.Check
 		apply_document_permissions: DF.Check
 		banner_image: DF.AttachImage | None

--- a/frappe/website/page_renderers/web_form.py
+++ b/frappe/website/page_renderers/web_form.py
@@ -1,3 +1,4 @@
+import frappe
 from frappe.website.page_renderers.document_page import DocumentPage
 from frappe.website.router import get_page_info_from_web_form
 
@@ -8,6 +9,14 @@ class WebFormPage(DocumentPage):
 		if web_form:
 			self.doctype = "Web Form"
 			self.docname = web_form.name
+			self.set_headers()
 			return True
 		else:
 			return False
+
+	def set_headers(self):
+		doc = frappe.get_cached_doc(self.doctype, self.docname)
+		allowed_embedding_domains = doc.allowed_embedding_domains
+		if allowed_embedding_domains:
+			allowed_embedding_domains = allowed_embedding_domains.replace("\n", " ")
+			self.headers = {"Content-Security-Policy": f"frame-ancestors 'self' {allowed_embedding_domains}"}


### PR DESCRIPTION
Add an option to allow other domains to embed a webform.

<img width="1426" alt="Screenshot 2024-10-18 at 11 27 00 AM" src="https://github.com/user-attachments/assets/773f2e53-6b09-418e-af5d-4ea5b014758a">

Setting domain will add following header to the Web Form request allowing it to be embedded on different domain.
<img width="1426" alt="Screenshot 2024-10-18 at 11 27 21 AM" src="https://github.com/user-attachments/assets/d4ec0093-de7c-4262-83ca-4d7c20027ad9">

**Edit:** Re-organized fields in the form (bit better grouping and field description)
	<img width="1704" alt="Screenshot 2024-10-21 at 12 18 28 PM" src="https://github.com/user-attachments/assets/faf281d8-0e11-4e81-9ff7-da77d54f3f59">



**Ticket ID:** 23808

> no-docs