### PR TITLE
refactor(Contact): make `get_contact_name` more robust

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -415,9 +415,13 @@ def get_contact_with_phone_number(number):
 	return contacts[0].parent if contacts else None
 
 
-def get_contact_name(email_id):
-	contact = frappe.get_all("Contact Email", filters={"email_id": email_id}, fields=["parent"], limit=1)
-	return contact[0].parent if contact else None
+def get_contact_name(email_id: str) -> str | None:
+	"""Return the contact ID for the given email ID."""
+	for contact_id in frappe.get_all(
+		"Contact Email", filters={"email_id": email_id, "parenttype": "Contact"}, pluck="parent"
+	):
+		if frappe.db.exists("Contact", contact_id):
+			return contact_id
 
 
 def get_contacts_linking_to(doctype, docname, fields=None):


### PR DESCRIPTION
Handle the following scenarios gracefully:

- The **Contact Email** table is re-used on a doctype other than **Contact**
- The **Contact Email** table has orphaned rows, lacking a corresponding **Contact**