### PR TITLE
fix filter "in" translation problem #28170

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -486,6 +486,19 @@ frappe.ui.filter_utils = {
 		// given
 		if (fieldtype) {
 			df.fieldtype = fieldtype;
+			if (df.original_type == "Select" && df.fieldtype == "MultiSelect") {
+				const formattedOptions = [];
+				df.options.split('\n').forEach(line => {
+					const option = line.trim();
+					if (option) {
+						formattedOptions.push({
+							value: option,
+							label: option
+							});
+					}
+				});
+				df.options = formattedOptions;
+			  }
 			return;
 		}
 

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -484,7 +484,7 @@ frappe.ui.filter_utils = {
 		df.ignore_link_validation = true;
 
 		// given
-		if (fieldtype) {
+		if (fieldtype) {																 
 			df.fieldtype = fieldtype;
 			if (df.original_type == "Select" && df.fieldtype == "MultiSelect") {
 				const formattedOptions = [];
@@ -494,11 +494,11 @@ frappe.ui.filter_utils = {
 						formattedOptions.push({
 							value: option,
 							label: option
-							});
+						});
 					}
 				});
 				df.options = formattedOptions;
-			  }
+			}
 			return;
 		}
 

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -484,7 +484,7 @@ frappe.ui.filter_utils = {
 		df.ignore_link_validation = true;
 
 		// given
-		if (fieldtype) {																 
+		if (fieldtype) {
 			df.fieldtype = fieldtype;
 			if (df.original_type == "Select" && df.fieldtype == "MultiSelect") {
 				const formattedOptions = [];


### PR DESCRIPTION
change the text field options format to object with values and labels
to be correct translated from __() command inside the multiselect field type
