### PR TITLE
fix: use set_value to mark form as dirty on clear

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -36,8 +36,8 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					me.$link.toggle(true);
 					me.$link_open.attr("href", frappe.utils.get_form_link(doctype, name));
 					me.$link_clear.on("click", function () {
-						me.$input.val("").trigger("input");
 						me.$link.toggle(false);
+						me.set_value("");
 						me.validate();
 					});
 				}


### PR DESCRIPTION
fixes #28176