### PR TITLE
fix: translation on multiselect causes glith on filter #28170

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -521,7 +521,20 @@ frappe.ui.filter_utils = {
 
 		// given
 		if (fieldtype) {
-			df.fieldtype = fieldtype;
+			df.fieldtype = fieldtype; 
+			if (df.original_type == "Select" && df.fieldtype == "MultiSelect") {
+				const formattedOptions = [];
+				df.options.split('\n').forEach(line => {
+					const option = line.trim();
+					if (option) {
+						formattedOptions.push({
+							value: option,
+							label: option
+						});
+					}
+				});
+				df.options = formattedOptions;
+			}
 			return;
 		}
 


### PR DESCRIPTION
Branch: Develop

change the text field options format to object with values and labels
to be correct translated from __() command inside the multiselect field type


Search using "="  as a filter.
https://prnt.sc/kc0PVyFen3xS

before fix "in":
https://prnt.sc/kISm08QJFdH9

After fix "in":
https://prnt.sc/z95-sGEqpTY2
