### PR TITLE
fix: V14 translation on multiselect filter causese glith on search #28170

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -486,6 +486,19 @@ frappe.ui.filter_utils = {
 		// given
 		if (fieldtype) {
 			df.fieldtype = fieldtype;
+			if (df.original_type == "Select" && df.fieldtype == "MultiSelect") {
+				const formattedOptions = [];
+				df.options.split('\n').forEach(line => {
+					const option = line.trim();
+					if (option) {
+						formattedOptions.push({
+							value: option,
+							label: option
+						});
+					}
+				});
+				df.options = formattedOptions;
+			}
 			return;
 		}
 


### PR DESCRIPTION
## problem:
problem found on Development version of search filter interface
 the filter "in" stop working when frappe are translated

before fix "in":
https://prnt.sc/kISm08QJFdH9

After fix "in":
https://prnt.sc/z95-sGEqpTY2

## Steps to reproduce the issue

1. translate erpnext
     e.g: PT-BR
2. the problem was found in any doctype page dynamic filter
    e.g: doctype: Report
3. search using filter "in" on Select type field
   e.g: Report Type:
          https://prnt.sc/kISm08QJFdH9
4. select values translated options to apply filter
5. apply filters 
6. see it doesn't return nothing


## What was done?
make the front-end stop sending translated text to backend query

Branch: V14-hotfix #28170

change the text field options format to object with values and labels
to be correct translated from __() command inside the multiselect field type

