### PR TITLE
fix: hashable is enough to serve as (composite) cache key

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -8,7 +8,7 @@ import re
 import string
 import traceback
 import warnings
-from collections.abc import Iterable, Sequence
+from collections.abc import Hashable, Iterable, Sequence
 from contextlib import contextmanager, suppress
 from time import time
 from typing import TYPE_CHECKING, Any
@@ -594,8 +594,8 @@ class Database:
 		"""
 		out = None
 		cache_key = None
-		if cache and isinstance(filters, FilterValue):
-			cache_key = (doctype, convert_to_value(filters), fieldname)
+		if cache and isinstance(filters, Hashable):
+			cache_key = (doctype, filters, fieldname)
 			if cache_key in self.value_cache:
 				return self.value_cache[cache_key]
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -49,6 +49,9 @@ class DocRef:
 		# Used when requiring its value representation for db interactions, serializations, etc
 		return self.name
 
+	def __hash__(self):
+		return hash(self.doctype + self.name or "")
+
 	def __str__(self):
 		return f"{self.doctype} ({self.name or 'n/a'})"
 


### PR DESCRIPTION
This lowers the requirement for cache keys to their minimum requirement instead of artificially setting a higher bar without need.

I didn't modify the way redis keys are built, because there, it might be handy to keep the string requirement for human inspection.

cc @akhilnarang
