### PR TITLE
feat: declare system dependencies for frappix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,3 +152,18 @@ typing-modules = ["frappe.types.DF"]
 quote-style = "double"
 indent-style = "tab"
 docstring-code-format = true
+
+[tool.frappix]
+# use identifier from https://search.nixos.org/packages
+nixpkgs-deps = [
+    "mariadb",
+    "restic",
+    "wkhtmltopdf-bin",
+    "which",
+    "gzip",
+    "bash",
+    "redis",
+    "nodejs_22",
+    "python312",
+]
+


### PR DESCRIPTION
This PR introduces system dependencies declaration for Frappix in the `pyproject.toml` file. It adds a new `[tool.frappix]` section with a `nixpkgs-deps` list, specifying essential packages required for the Frappe framework to function properly.

 The declared dependencies include:

- Database: MariaDB
- Backup tool: Restic
- PDF generation: wkhtmltopdf
- Utility tools: which, gzip, bash
- Caching: Redis
- Runtime environments: Node.js 22 and Python 3.12

This change streamlines the setup process for Frappix environments and ensures consistent system dependencies across different installations.

It could potentially be leveraged in the future for faster CI setup through enhanced determinism and thus caching.