### PR TITLE
feat: declare system dependencies for frappix (#28197)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,3 +144,16 @@ quote-style = "double"
 indent-style = "tab"
 docstring-code-format = true
 
+[tool.frappix]
+# use identifier from https://search.nixos.org/packages
+nixpkgs-deps = [
+    "mariadb",
+    "restic",
+    "wkhtmltopdf-bin",
+    "which",
+    "gzip",
+    "bash",
+    "redis",
+    "nodejs_20",
+    "python312",
+]


### PR DESCRIPTION
(cherry picked from commit 085d2b7803d6c9bcf95cd33f5f901374b7ee162c)

# Conflicts:
#	pyproject.toml

Fixed version of mergify pr: https://github.com/frappe/frappe/pull/28200