### PR TITLE
Introducing Frappe Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
 	<a href="https://codecov.io/gh/frappe/frappe">
 		<img src="https://codecov.io/gh/frappe/frappe/branch/develop/graph/badge.svg?token=XoTa679hIj"/>
 	</a>
+	<a href="https://gurubase.io/g/frappe">
+		<img src="https://img.shields.io/badge/Gurubase-Ask%20Frappe%20Guru-006BFF"/>
+	</a>
 </div>
 
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Frappe Guru](https://gurubase.io/g/frappe) to Gurubase. Frappe Guru uses the data from this repo and data from the [docs](https://frappeframework.com/docs/user/en/basics) to answer questions by leveraging the LLM.

In this PR, I showcased the "Frappe Guru" badge, which highlights that Frappe now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Frappe Guru in Gurubase, just let me know that's totally fine.
