### PR TITLE
chore(typing): fix some (exotic) type errors treewide

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -402,9 +402,9 @@ class DocType(Document):
 				frappe.db.sql(query)
 
 	def validate_document_type(self):
-		if self.document_type == "Transaction":
+		if self.document_type == "Transaction":  # type: ignore[comparison-overlap]
 			self.document_type = "Document"
-		if self.document_type == "Master":
+		if self.document_type == "Master":  # type: ignore[comparison-overlap]
 			self.document_type = "Setup"
 
 	def validate_website(self):

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -48,7 +48,7 @@ def get_doctype_name(table_name: str) -> str:
 
 
 class LazyString:
-	def _setup(self) -> None:
+	def _setup(self) -> str:
 		raise NotImplementedError
 
 	@cached_property
@@ -68,7 +68,7 @@ class LazyDecode(LazyString):
 	def __init__(self, value: str) -> None:
 		self._value = value
 
-	def _setup(self) -> None:
+	def _setup(self) -> str:
 		return self._value.decode()
 
 

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -734,7 +734,7 @@ def evaluate_alert(doc: Document, alert, event=None):
 
 
 def get_context(doc):
-	Frappe = namedtuple("frappe", ["frappe"])
+	Frappe = namedtuple("Frappe", ["frappe"])
 	frappe = Frappe(frappe=get_safe_globals().get("frappe"))
 	return {
 		"doc": doc,

--- a/frappe/tests/classes/context_managers.py
+++ b/frappe/tests/classes/context_managers.py
@@ -198,7 +198,7 @@ def trace_fields(
 	field_name: str | None = None,
 	forbidden_values: list | None = None,
 	custom_validation: Callable | None = None,
-	**field_configs: dict[str, dict[str, list | Callable]],
+	**field_configs: dict[str, list | Callable | None],
 ) -> "Document":
 	"""
 	A context manager for temporarily tracing fields in a DocType.

--- a/frappe/tests/utils/generators.py
+++ b/frappe/tests/utils/generators.py
@@ -36,7 +36,7 @@ __all__ = [
 
 
 @cache
-def get_modules(doctype) -> (str, ModuleType):
+def get_modules(doctype) -> tuple[str, ModuleType]:
 	"""Get the modules for the specified doctype"""
 	module = frappe.db.get_value("DocType", doctype, "module")
 	try:

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -172,7 +172,7 @@ def enqueue(
 		return q.enqueue_call(
 			"frappe.utils.background_jobs.execute_job",
 			on_success=Callback(func=on_success) if on_success else None,
-			on_failure=Callback(func=on_failure) if on_failure else None,
+			on_failure=Callback(func=on_failure),
 			timeout=timeout,
 			kwargs=queue_args,
 			at_front=at_front,

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -381,7 +381,7 @@ class BackupGenerator:
 		import frappe.utils
 		from frappe.utils.change_log import get_app_branch
 
-		gzip_exc = which("gzip")
+		gzip_exc: str = which("gzip")
 		if not gzip_exc:
 			frappe.throw(
 				_("gzip not found in PATH! This is required to take a backup."), exc=frappe.ExecutableNotFound

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -72,11 +72,9 @@ def handle_exception(cmd, info_name, exc):
 	filename = frame.f_code.co_filename
 	lineno = frame.f_lineno
 
-	(
-		click.secho("\n:: ", nl=False),
-		click.secho(f"{exc}", fg="red", bold=True, nl=False),
-		click.secho(" ::"),
-	)
+	click.secho("\n:: ", nl=False)
+	click.secho(f"{exc}", fg="red", bold=True, nl=False)
+	click.secho(" ::")
 	click.secho("\nContext:", fg="yellow", bold=True)
 	click.secho(f" File '{filename}', line {lineno}\n")
 	context_lines = 5
@@ -106,7 +104,7 @@ def main():
 	FrappeClickWrapper(click.Group, handle_exception)(commands=commands)(prog_name="bench")
 
 
-def get_app_groups() -> dict[str, click.Group]:
+def get_app_groups() -> dict[str, click.Group | click.Command]:
 	"""Get all app groups, put them in main group "frappe" since bench is
 	designed to only handle that"""
 	commands = {}
@@ -143,8 +141,8 @@ def get_sites(site_arg: str) -> list[str]:
 		return frappe.utils.get_sites()
 	elif site_arg:
 		return [site_arg]
-	elif os.environ.get("FRAPPE_SITE"):
-		return [os.environ.get("FRAPPE_SITE")]
+	elif env_site := os.environ.get("FRAPPE_SITE"):
+		return [env_site]
 	elif default_site := frappe.get_conf().default_site:
 		return [default_site]
 	# This is not supported, just added here for warning.

--- a/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
@@ -266,15 +266,15 @@ class PersonalDataDeletionRequest(Document):
 		self.add_deletion_steps()
 
 		self.full_match_doctypes = (
-			x
-			for x in self.full_match_privacy_docs
-			if filter(lambda x: x.document_type == x and x.status == "Pending", self.deletion_steps)
+			doc
+			for doc in self.full_match_privacy_docs
+			if filter(lambda x: x.document_type == doc and x.status == "Pending", self.deletion_steps)
 		)
 
 		self.partial_match_doctypes = (
-			x
-			for x in self.partial_privacy_docs
-			if filter(lambda x: x.document_type == x and x.status == "Pending", self.deletion_steps)
+			doc
+			for doc in self.partial_privacy_docs
+			if filter(lambda x: x.document_type == doc and x.status == "Pending", self.deletion_steps)
 		)
 
 		for doctype in self.full_match_doctypes:

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -41,13 +41,21 @@ class PrintContext(TypedDict):
 def get_context(context) -> PrintContext:
 	"""Build context for print"""
 	if not ((frappe.form_dict.doctype and frappe.form_dict.name) or frappe.form_dict.doc):
-		return {
-			"body": f"""
-				<h1>Error</h1>
-				<p>Parameters doctype and name required</p>
-				<pre>{escape_html(frappe.as_json(frappe.form_dict, indent=2))}</pre>
-				"""
-		}
+		return PrintContext(
+			print_style="",
+			comment="",
+			title="Error",
+			lang="en",
+			layout_direction="ltr",
+			doctype="",
+			name="",
+			key="",
+			body=f"""
+<h1>Error</h1>
+<p>Parameters doctype and name required</p>
+<pre>{escape_html(frappe.as_json(frappe.form_dict, indent=2))}</pre>
+""",
+		)
 
 	if frappe.form_dict.doc:
 		doc = frappe.form_dict.doc
@@ -310,7 +318,7 @@ def get_html_and_style(
 	trigger_print: bool = False,
 	style: str | None = None,
 	settings: str | None = None,
-) -> dict[str, str]:
+) -> dict[str, str | None]:
 	"""Return `html` and `style` of print format, used in PDF etc."""
 
 	if isinstance(name, str):


### PR DESCRIPTION
These type errors where among the more exotic ones so that it was feasible to address them tree-wide at once.
