### PR TITLE
fix: added method to get vanilla controller for overriden doctypes

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -72,10 +72,11 @@ def get_controller(doctype):
 
 	return site_controllers[doctype]
 
+
 def get_vanilla_controller(doctype):
 	from frappe.model.document import Document
 	from frappe.utils.nestedset import NestedSet
-    
+
 	module_name = "Core"
 	if doctype not in DOCTYPES_FOR_DOCTYPE:
 		doctype_info = frappe.db.get_value("DocType", doctype, fieldname="*")
@@ -100,6 +101,7 @@ def get_vanilla_controller(doctype):
 		raise ImportError(f"{doctype}: {classname} is not a subclass of BaseDocument")
 
 	return class_
+
 
 def import_controller(doctype):
 	from frappe.model.document import Document

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -82,6 +82,8 @@ def get_vanilla_controller(doctype):
 				return NestedSet if doctype_info.is_tree else Document
 			module_name = doctype_info.module
 
+	module_path = None
+
 	module = load_doctype_module(doctype, module_name)
 	classname = doctype.replace(" ", "").replace("-", "")
 	class_ = getattr(module, classname, None)

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -73,6 +73,8 @@ def get_controller(doctype):
 	return site_controllers[doctype]
 
 def get_vanilla_controller(doctype):
+	from frappe.model.document import Document
+	from frappe.utils.nestedset import NestedSet
     
 	module_name = "Core"
 	if doctype not in DOCTYPES_FOR_DOCTYPE:

--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -51,7 +51,7 @@ non_nullable_types = {
 
 class TypeExporter:
 	def __init__(self, doc):
-		from frappe.model.base_document import get_vanilla_controller, get_controller
+		from frappe.model.base_document import get_controller, get_vanilla_controller
 
 		self.doc = doc
 		self.doctype = doc.name

--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -51,7 +51,7 @@ non_nullable_types = {
 
 class TypeExporter:
 	def __init__(self, doc):
-		from frappe.model.base_document import get_controller
+		from frappe.model.base_document import get_vanilla_controller, get_controller
 
 		self.doc = doc
 		self.doctype = doc.name
@@ -59,7 +59,7 @@ class TypeExporter:
 
 		self.imports = {"from frappe.types import DF"}
 		self.indent = "\t"
-		self.controller_path = Path(inspect.getfile(get_controller(self.doctype)))
+		self.controller_path = Path(inspect.getfile(get_vanilla_controller(self.doctype)))
 
 	def export_types(self):
 		self._guess_indentation()


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/25152

Added a get_vanilla_controller method in base_document.py and hooked it up to exporter.py (types)