### PR TITLE
Enhance recipient selection for SMS/WhatsApp notifications by including User and Phone fields

### DIFF
--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -70,7 +70,22 @@ frappe.notification = {
 				});
 			} else if (["WhatsApp", "SMS"].includes(frm.doc.channel)) {
 				receiver_fields = $.map(fields, function (d) {
-					return d.options == "Phone" ? get_select_options(d) : null;
+					// Add User and Phone fields from child into select dropdown
+					if (frappe.model.table_fields.includes(d.fieldtype)) {
+						let child_fields = frappe.get_doc("DocType", d.options).fields;
+						return $.map(child_fields, function (df) {
+							return df.options == "Phone" ||
+								(df.options == "User" && df.fieldtype == "Link")
+								? get_select_options(df, d.fieldname)
+								: null;
+						});
+						// Add User and Phone fields from parent into select dropdown
+					} else {
+						return d.options == "Phone" ||
+							(d.options == "User" && d.fieldtype == "Link")
+							? get_select_options(d)
+							: null;
+					}
 				});
 			}
 


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This pull request enhances the functionality of recipient selection for SMS and WhatsApp notifications. It improves the ability to select fields linked to users and phone numbers, which previously was limited to fields with the "owner" option and fields where "Phone" was defined. This change resolves this issue: https://github.com/frappe/frappe/issues/28219

> Explain the **details** for making this change. What existing problem does the pull request solve?

Previously, when configuring an SMS or WhatsApp notification, only fields with the "owner" option or fields where "Phone" was defined could be selected in the dropdown for recipients. This limited functionality prevented users from selecting other relevant fields, especially those linked to user data in the documents.

This PR includes the following changes:

- The recipient selection dropdown now includes all fields linked to users and phone numbers.
- The function now supports extracting recipients from child documents and ensures uniqueness in the final recipient list.

