### PR TITLE
Enhance recipient selection for SMS/WhatsApp notifications by including User and Phone fields

### DIFF
--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -70,7 +70,22 @@ frappe.notification = {
 				});
 			} else if (["WhatsApp", "SMS"].includes(frm.doc.channel)) {
 				receiver_fields = $.map(fields, function (d) {
-					return d.options == "Phone" ? get_select_options(d) : null;
+					// Add User and Phone fields from child into select dropdown
+					if (frappe.model.table_fields.includes(d.fieldtype)) {
+						let child_fields = frappe.get_doc("DocType", d.options).fields;
+						return $.map(child_fields, function (df) {
+							return df.options == "Phone" ||
+								(df.options == "User" && df.fieldtype == "Link")
+								? get_select_options(df, d.fieldname)
+								: null;
+						});
+						// Add User and Phone fields from parent into select dropdown
+					} else {
+						return d.options == "Phone" ||
+							(d.options == "User" && d.fieldtype == "Link")
+							? get_select_options(d)
+							: null;
+					}
 				});
 			}
 

--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -48,45 +48,34 @@ frappe.notification = {
 			// set date changed options
 			frm.set_df_property("date_changed", "options", get_date_change_options());
 
+			// Function to fetch receiver fields based on field type
+			let get_receiver_fields = function (field_type) {
+				return $.map(fields, function (d) {
+					// Add specified fields from child into select dropdown
+					if (frappe.model.table_fields.includes(d.fieldtype)) {
+						let child_fields = frappe.get_doc("DocType", d.options).fields;
+						return $.map(child_fields, function (df) {
+							return df.options == field_type ||
+								(df.options == "User" && df.fieldtype == "Link")
+								? get_select_options(df, d.fieldname)
+								: null;
+						});
+					} else {
+						// Add specified fields from parent into select dropdown
+						return d.options == field_type ||
+							(d.options == "User" && d.fieldtype == "Link")
+							? get_select_options(d)
+							: null;
+					}
+				});
+			};
+			
+			// Set receiver fields based on channel type
 			let receiver_fields = [];
 			if (frm.doc.channel === "Email") {
-				receiver_fields = $.map(fields, function (d) {
-					// Add User and Email fields from child into select dropdown
-					if (frappe.model.table_fields.includes(d.fieldtype)) {
-						let child_fields = frappe.get_doc("DocType", d.options).fields;
-						return $.map(child_fields, function (df) {
-							return df.options == "Email" ||
-								(df.options == "User" && df.fieldtype == "Link")
-								? get_select_options(df, d.fieldname)
-								: null;
-						});
-						// Add User and Email fields from parent into select dropdown
-					} else {
-						return d.options == "Email" ||
-							(d.options == "User" && d.fieldtype == "Link")
-							? get_select_options(d)
-							: null;
-					}
-				});
+				receiver_fields = get_receiver_fields("Email");
 			} else if (["WhatsApp", "SMS"].includes(frm.doc.channel)) {
-				receiver_fields = $.map(fields, function (d) {
-					// Add User and Phone fields from child into select dropdown
-					if (frappe.model.table_fields.includes(d.fieldtype)) {
-						let child_fields = frappe.get_doc("DocType", d.options).fields;
-						return $.map(child_fields, function (df) {
-							return df.options == "Phone" ||
-								(df.options == "User" && df.fieldtype == "Link")
-								? get_select_options(df, d.fieldname)
-								: null;
-						});
-						// Add User and Phone fields from parent into select dropdown
-					} else {
-						return d.options == "Phone" ||
-							(d.options == "User" && d.fieldtype == "Link")
-							? get_select_options(d)
-							: null;
-					}
-				});
+				receiver_fields = get_receiver_fields("Phone");
 			}
 
 			// set email recipient options

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -13,7 +13,7 @@ from frappe.desk.doctype.notification_log.notification_log import enqueue_create
 from frappe.integrations.doctype.slack_webhook_url.slack_webhook_url import send_slack_message
 from frappe.model.document import Document
 from frappe.modules.utils import export_module_json, get_doc_module
-from frappe.utils import add_to_date, cast, nowdate, validate_email_address
+from frappe.utils import add_to_date, cast, nowdate, validate_email_address, validate_phone_number
 from frappe.utils.jinja import validate_template
 from frappe.utils.safe_exec import get_safe_globals
 
@@ -368,7 +368,15 @@ def get_context(context):
 				receiver_list += get_user_info([dict(user_name=doc.get("owner"))], "mobile_no")
 			# For sending messages to the number specified in the receiver field
 			elif recipient.receiver_by_document_field:
-				receiver_list.append(doc.get(recipient.receiver_by_document_field))
+				field_value = doc.get(recipient.receiver_by_document_field)
+
+				# Check if it's not a valid phone number
+				if not validate_phone_number(field_value):
+					user_info = get_user_info([dict(user_name=field_value)], "mobile_no")
+					if user_info:
+						receiver_list += user_info
+				else:
+					receiver_list.append(field_value)
 
 			# For sending messages to specified role
 			if recipient.receiver_by_role:


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This pull request enhances the functionality of recipient selection for SMS and WhatsApp notifications. It improves the ability to select fields linked to users and phone numbers, which previously was limited to fields with the "owner" option and fields where "Phone" was defined. This change resolves this issue: https://github.com/frappe/frappe/issues/28219

> Explain the **details** for making this change. What existing problem does the pull request solve?

Previously, when configuring an SMS or WhatsApp notification, only fields with the "owner" option or fields where "Phone" was defined could be selected in the dropdown for recipients. This limited functionality prevented users from selecting other relevant fields, especially those linked to user data in the documents.

This PR includes the following changes:

- The recipient selection dropdown now includes all fields linked to users and phone numbers.
- The function now supports extracting recipients from child documents and ensures uniqueness in the final recipient list.