### PR TITLE
Update navbar_settings.py

### DIFF
--- a/frappe/core/doctype/navbar_settings/navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.py
@@ -44,7 +44,10 @@ class NavbarSettings(Document):
 
 
 def get_app_logo():
-	app_logo = frappe.db.get_single_value("Navbar Settings", "app_logo", cache=True)
+	app_logo = frappe.get_website_settings("app_logo") 
+	if not app_logo:
+		app_logo =  frappe.db.get_single_value("Navbar Settings", "app_logo", cache=True)
+		
 	if not app_logo:
 		logos = frappe.get_hooks("app_logo_url")
 		app_logo = logos[0]


### PR DESCRIPTION
I found an issue with function "get_app_logo()" in "frappe/core/doctype/navbar_settings/navbar_settings.py". 
It's not trying to retrieve the logo from "Website Settings" as it was happening before, so I wrote a possible fix that will be able to try to retrieve logo from website settings "before" and if it is not setup from other locations.