### PR TITLE
fix: controller path for exporting types

### DIFF
--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -17,6 +17,7 @@ from keyword import iskeyword
 from pathlib import Path
 
 import frappe
+from frappe import scrub
 from frappe.types import DF
 
 field_template = "{field}: {type}"
@@ -59,7 +60,12 @@ class TypeExporter:
 
 		self.imports = {"from frappe.types import DF"}
 		self.indent = "\t"
-		self.controller_path = Path(inspect.getfile(get_controller(self.doctype)))
+		self.controller_path = (
+			Path(frappe.get_module_path(doc.module))
+			/ "doctype"
+			/ scrub(self.doctype)
+			/ f"{scrub(self.doctype)}.py"
+		)
 
 	def export_types(self):
 		self._guess_indentation()


### PR DESCRIPTION
When a DocType's controller is overridden by another app, we tried to write type annotations to the path of the overriding controller. Thus, the type annotations never got exported to the original controller. Now we always use the path of the original controller.

E.g. if ERPNext and HRMS are installed and we edit ERPNext's **Timesheet** doctype, the `controller_path` used to be set to `hrms/overrides/employee_timesheet.py`. Now it is correctly set to `erpnext/projects/doctype/timesheet/timesheet.py`.
