### PR TITLE
fix: Bind field object to onchange event on grid_row

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1122,7 +1122,7 @@ export default class GridRow {
 		if (!field.df.onchange_modified) {
 			var field_on_change_function = field.df.onchange;
 			field.df.onchange = (e) => {
-				field_on_change_function && field_on_change_function(e);
+				field_on_change_function && field_on_change_function.bind(field)(e);
 				this.refresh_field(field.df.fieldname);
 			};
 


### PR DESCRIPTION
Bind field object to onchange event on grid_row.

Issue:
In the work order "alternate item" dialog, onchange event of alternate item/warehouse not working. Internal issue no #23906.
