### PR TITLE
ci: add action to trigger downstream ci runs

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,21 @@
+name: Downstream
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    strategy:
+      matrix:
+        repo:
+          - frappe/erpnext
+          - frappe/lending
+          - frappe/hrms
+    steps:
+      - name: Dispatch Downstream CI (if supported)
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CI_PAT }}
+          repository: ${{ matrix.repo }}
+          event-type: frappe-framework-change
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
This action can be triggered manually.

It emits the `frappe-framework-change` event alongside `ref` and `sha` to downstream repositories.

This gives downstream CIs the chance to capture the upstream intent "we think there may be something not so well tested and would like you to pre-validate this change in your codebase" and report success or failure accordingly.

This allows to stabilize around a fully tested API and mitigate the risk of accidental breakage associated with untested historical API surfaces.

