### PR TITLE
ci: trigger ci runs from upstream fix

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   dispatch:
+    runs-on: "ubuntu-latest"
     strategy:
       matrix:
         repo:


### PR DESCRIPTION
oversight from https://github.com/frappe/frappe/pull/28272

I know this looks bad, but how do you really test CI without CI :smile: 