### PR TITLE
chore(docref): fix circular imports

### DIFF
--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -4,9 +4,9 @@
 from functools import cached_property, wraps
 
 import frappe
-from frappe.model.document import DocRef
 from frappe.query_builder.builder import MariaDB, Postgres
 from frappe.query_builder.functions import Function
+from frappe.types import DocRef
 
 Query = str | MariaDB | Postgres
 QueryValues = tuple | list | dict | None

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -368,8 +368,6 @@ class BaseDocument:
 	def get_valid_dict(
 		self, sanitize=True, convert_dates_to_str=False, ignore_nulls=False, ignore_virtual=False
 	) -> _dict:
-		from frappe.model.document import DocRef
-
 		d = _dict()
 		field_values = self.__dict__
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -23,7 +23,7 @@ from frappe.model.docstatus import DocStatus
 from frappe.model.naming import set_new_name, validate_name
 from frappe.model.utils import is_virtual_doctype, simple_singledispatch
 from frappe.model.workflow import set_workflow_state_on_action, validate_workflow
-from frappe.types import DF
+from frappe.types import DF, DocRef
 from frappe.utils import compare, cstr, date_diff, file_lock, flt, now
 from frappe.utils.data import get_absolute_url, get_datetime, get_timedelta, getdate
 from frappe.utils.global_search import update_global_search
@@ -36,27 +36,6 @@ if TYPE_CHECKING:
 
 DOCUMENT_LOCK_EXPIRTY = 12 * 60 * 60  # All locks expire in 12 hours automatically
 DOCUMENT_LOCK_SOFT_EXPIRY = 60 * 60  # Let users force-unlock after 60 minutes
-
-
-class DocRef:
-	"""A lightweight reference to a document, containing just the doctype and name."""
-
-	def __init__(self, doctype: str, name: str):
-		self.doctype = doctype
-		self.name = name
-
-	def __value__(self):
-		# Used when requiring its value representation for db interactions, serializations, etc
-		return self.name
-
-	def __hash__(self):
-		return hash(self.doctype + self.name or "")
-
-	def __str__(self):
-		return f"{self.doctype} ({self.name or 'n/a'})"
-
-	def __repr__(self):
-		return f"<{self.__class__.__name__}: doctype={self.doctype} name={self.name or 'n/a'}>"
 
 
 @simple_singledispatch

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -38,9 +38,10 @@ from frappe.model.base_document import (
 	TABLE_DOCTYPES_FOR_DOCTYPE,
 	BaseDocument,
 )
-from frappe.model.document import DocRef, Document
+from frappe.model.document import Document
 from frappe.model.workflow import get_workflow_name
 from frappe.modules import load_doctype_module
+from frappe.types import DocRef
 from frappe.utils import cast, cint, cstr
 
 DEFAULT_FIELD_LABELS = {

--- a/frappe/tests/test_doc_ref.py
+++ b/frappe/tests/test_doc_ref.py
@@ -1,6 +1,7 @@
 import frappe
-from frappe.model.document import DocRef, Document, get_doc
+from frappe.model.document import Document, get_doc
 from frappe.tests import IntegrationTestCase
+from frappe.types import DocRef
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["User"]
 

--- a/frappe/types/__init__.py
+++ b/frappe/types/__init__.py
@@ -1,0 +1,2 @@
+from .docref import DocRef
+from .frappedict import _dict

--- a/frappe/types/docref.py
+++ b/frappe/types/docref.py
@@ -1,0 +1,25 @@
+from typing_extensions import override
+
+
+class DocRef:
+	"""A lightweight reference to a document, containing just the doctype and name."""
+
+	def __init__(self, doctype: str, name: str):
+		self.doctype = doctype
+		self.name = name
+
+	def __value__(self) -> str:
+		# Used when requiring its value representation for db interactions, serializations, etc
+		return self.name
+
+	@override
+	def __hash__(self) -> int:
+		return hash(self.doctype + self.name or "")
+
+	@override
+	def __str__(self) -> str:
+		return f"{self.doctype} ({self.name or 'n/a'})"
+
+	@override
+	def __repr__(self) -> str:
+		return f"<{self.__class__.__name__}: doctype={self.doctype} name={self.name or 'n/a'}>"


### PR DESCRIPTION
DocRef needs to live alongside other types which may use it to avoid circular imports.

(types shouldn't depend on non-type imports)
