### PR TITLE
feat: extend Contact doctype with Business Unit field

### DIFF
--- a/frappe/contacts/doctype/contact/contact.json
+++ b/frappe/contacts/doctype/contact/contact.json
@@ -38,6 +38,7 @@
   "links",
   "is_primary_contact",
   "more_info",
+  "business_unit",
   "department",
   "unsubscribed"
  ],
@@ -250,6 +251,11 @@
    "hidden": 1,
    "label": "Full Name",
    "read_only": 1
+  },
+  {
+   "fieldname": "business_unit",
+   "fieldtype": "Data",
+   "label": "Business Unit"
   }
  ],
  "icon": "fa fa-user",
@@ -257,11 +263,10 @@
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:01:30.937045",
+ "modified": "2024-10-24 18:25:29.249126",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Contact",
- "name_case": "Title Case",
  "naming_rule": "By script",
  "owner": "Administrator",
  "permissions": [

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -23,6 +23,7 @@ class Contact(Document):
 		from frappe.types import DF
 
 		address: DF.Link | None
+		business_unit: DF.Data | None
 		company_name: DF.Data | None
 		department: DF.Data | None
 		designation: DF.Data | None


### PR DESCRIPTION
Contacts in medium-large companies are frequently associated with a Business Unit (or 'Division') that is distinct from their department (eg., Consumer, Enterprise, Government). This commit extends the Contact doctype by adding a 'Business Unit' field in which to track this data.
![image](https://github.com/user-attachments/assets/1e7ddcdc-889b-46c8-a8ea-94622471e2b9)
