### PR TITLE
refactor: improve maintainability with a simple dispatcher (backport #27975)

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import time
 from collections.abc import Generator, Iterable
+from functools import singledispatchmethod
 from typing import TYPE_CHECKING, Any, Optional
 
 from werkzeug.exceptions import NotFound
@@ -18,7 +19,7 @@ from frappe.model import optional_fields, table_fields
 from frappe.model.base_document import BaseDocument, get_controller
 from frappe.model.docstatus import DocStatus
 from frappe.model.naming import set_new_name, validate_name
-from frappe.model.utils import is_virtual_doctype
+from frappe.model.utils import is_virtual_doctype, simple_singledispatch
 from frappe.model.workflow import set_workflow_state_on_action, validate_workflow
 from frappe.types import DF
 from frappe.utils import compare, cstr, date_diff, file_lock, flt, get_datetime_str, now
@@ -33,8 +34,9 @@ DOCUMENT_LOCK_EXPIRTY = 12 * 60 * 60  # All locks expire in 12 hours automatical
 DOCUMENT_LOCK_SOFT_EXPIRY = 60 * 60  # Let users force-unlock after 60 minutes
 
 
-def get_doc(*args, **kwargs):
-	"""returns a frappe.model.Document object.
+@simple_singledispatch
+def get_doc(*args, **kwargs) -> "Document":
+	"""Return a `frappe.model.Document` object.
 
 	:param arg1: Document dict or DocType name.
 	:param arg2: [optional] document name.
@@ -60,31 +62,35 @@ def get_doc(*args, **kwargs):
 	        # select a document for update
 	        user = get_doc("User", "test@example.com", for_update=True)
 	"""
-	if args:
-		if isinstance(args[0], BaseDocument):
-			# already a document
-			return args[0]
-		elif isinstance(args[0], str):
-			doctype = args[0]
+	if not args and kwargs:
+		return get_doc_from_dict(kwargs)
+	else:
+		raise ValueError("First non keyword argument must be a string, dict or DocRef")
 
-		elif isinstance(args[0], dict):
-			# passed a dict
-			kwargs = args[0]
 
-		else:
-			raise ValueError("First non keyword argument must be a string or dict")
+@get_doc.register(BaseDocument)
+def _basedoc(doc: BaseDocument, *args, **kwargs) -> "Document":
+	return doc
 
-	if len(args) < 2 and kwargs:
-		if "doctype" in kwargs:
-			doctype = kwargs["doctype"]
-		else:
-			raise ValueError('"doctype" is a required key')
 
+@get_doc.register(str)
+def get_doc_str(doctype: str, name: str | None = None, **kwargs) -> "Document":
+	# if no name: it's a single
 	controller = get_controller(doctype)
 	if controller:
-		return controller(*args, **kwargs)
+		return controller(doctype, name, **kwargs)
 
 	raise ImportError(doctype)
+
+
+@get_doc.register(dict)
+def get_doc_from_dict(data: dict[str, Any], **kwargs) -> "Document":
+	if "doctype" not in data:
+		raise ValueError('"doctype" is a required key')
+	controller = get_controller(data["doctype"])
+	if controller:
+		return controller(**data)
+	raise ImportError(data["doctype"])
 
 
 class Document(BaseDocument):
@@ -111,34 +117,43 @@ class Document(BaseDocument):
 		self.doctype = None
 		self.name = None
 		self.flags = frappe._dict()
-
-		if args and args[0]:
-			if isinstance(args[0], str):
-				# first arugment is doctype
-				self.doctype = args[0]
-
-				# doctype for singles, string value or filters for other documents
-				self.name = self.doctype if len(args) == 1 else args[1]
-
-				# for_update is set in flags to avoid changing load_from_db signature
-				# since it is used in virtual doctypes and inherited in child classes
-				self.flags.for_update = kwargs.get("for_update")
-				self.load_from_db()
-				return
-
-			if isinstance(args[0], dict):
-				# first argument is a dict
-				kwargs = args[0]
-
-		if kwargs:
-			# init base document
-			super().__init__(kwargs)
-			self.init_child_tables()
-			self.init_valid_columns()
+		if args:
+			self._init_dispatch(args[0], *args[1:], **kwargs)
+		elif kwargs:
+			self._init_from_kwargs(kwargs)
 
 		else:
-			# incorrect arguments. let's not proceed.
 			raise ValueError("Illegal arguments")
+
+	def _init_from_kwargs(self, kwargs):
+		super().__init__(kwargs)
+		self.init_child_tables()
+		self.init_valid_columns()
+
+	def _init_known_doc(self, doctype, name, **kwargs):
+		self.doctype = doctype
+		self.name = name
+		# for_update is set in flags to avoid changing load_from_db signature
+		# since it is used in virtual doctypes and inherited in child classes
+		self.flags.for_update = kwargs.get("for_update")
+		self.load_from_db()
+		if kwargs:  # ad-hoc overrides
+			self._init_from_kwargs(kwargs)
+
+	@singledispatchmethod
+	def _init_dispatch(self, arg, *args, **kwargs):
+		raise ValueError(f"Unsupported argument type: {type(arg)}")
+
+	@_init_dispatch.register(str)
+	def _init_str(self, doctype, *args, **kwargs):
+		# use doctype as name for single
+		name = doctype if not args else args[0]
+		self._init_known_doc(doctype, name, **kwargs)
+
+	@_init_dispatch.register(dict)
+	def _init_dict(self, arg_dict, **kwargs):
+		# discard any further keyword args
+		self._init_from_kwargs(arg_dict)
 
 	@property
 	def is_locked(self):

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -17,6 +17,7 @@ Example:
 import json
 import os
 from datetime import datetime
+from functools import singledispatchmethod
 
 import click
 
@@ -55,10 +56,20 @@ DEFAULT_FIELD_LABELS = {
 }
 
 
-def get_meta(doctype, cached=True) -> "Meta":
-	cached = cached and isinstance(doctype, str)
-	if cached and (meta := frappe.cache.hget("doctype_meta", doctype)):
-		return meta
+def get_meta(doctype: str | Document, cached=True) -> "Meta":
+	"""Get metadata for a doctype.
+
+	Args:
+	    doctype: The doctype as a string or Document object.
+	    cached: Whether to use cached metadata (default: True).
+
+	Returns:
+	    Meta object for the given doctype.
+	"""
+	doctype_name = getattr(doctype, "doctype", doctype)
+	if cached and not isinstance(doctype, Document):
+		if meta := frappe.cache.hget("doctype_meta", doctype_name):
+			return meta
 
 	meta = Meta(doctype)
 	frappe.cache.hset("doctype_meta", meta.name, meta)
@@ -110,12 +121,18 @@ class Meta(Document):
 		frappe._dict(fieldname="owner", fieldtype="Data"),
 	)
 
-	def __init__(self, doctype):
-		if isinstance(doctype, Document):
-			super().__init__(doctype.as_dict())
-		else:
-			super().__init__("DocType", doctype)
+	@singledispatchmethod
+	def __init__(self, arg):
+		raise TypeError(f"Unsupported argument type: {type(arg)}")
 
+	@__init__.register(str)
+	def _(self, doctype):
+		super().__init__("DocType", doctype)
+		self.process()
+
+	@__init__.register(Document)
+	def _(self, doc):
+		super().__init__(doc.as_dict())
 		self.process()
 
 	def load_from_db(self):

--- a/frappe/model/utils/__init__.py
+++ b/frappe/model/utils/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import re
+from functools import wraps
 
 import frappe
 from frappe import _
@@ -144,3 +145,29 @@ def is_single_doctype(doctype: str) -> bool:
 		return False
 
 	return frappe.db.get_value("DocType", doctype, "issingle")
+
+
+def simple_singledispatch(func):
+	registry = {}
+
+	def dispatch(arg):
+		for cls in arg.__class__.__mro__:
+			if cls in registry:
+				return registry[cls]
+		return func
+
+	def register(type_):
+		def decorator(f):
+			registry[type_] = f
+			return f
+
+		return decorator
+
+	@wraps(func)
+	def wrapper(*args, **kw):
+		if not args:
+			return func(*args, **kw)
+		return dispatch(args[0])(*args, **kw)
+
+	wrapper.register = register
+	return wrapper


### PR DESCRIPTION
##### Prepares and endorses: https://github.com/frappe/frappe/pull/27973

## Refactor: Improve Maintainability with Simple Dispatcher

This PR introduces a simple dispatcher to improve the maintainability of the `get_doc` function in `frappe/model/document.py`. Key changes include:

- Implemented a `simple_singledispatch` decorator for cleaner function dispatching
- Refactored `get_doc` to use the new dispatcher, improving readability and extensibility
- Separated logic for different input types (string, dict, BaseDocument) into distinct functions
- Added type hints for better code clarity

These changes make the code more modular, easier to understand, and simpler to extend in the future.
<hr>

This is an ~~automatic~~ backport of pull request #27975 done by ~~[Mergify](https://mergify.com)~~ @blaggacao .


The goal of this backport, since it was expected to have conflicts, is to ensure that it is done timely with the relevant context still present in the author.

cc @akhilnarang 
