### PR TITLE
refactor: server script autocompletion to be more generic (backport #28180)

### DIFF
--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -2,7 +2,7 @@
 # License: MIT. See LICENSE
 
 from functools import partial
-from types import FunctionType, MethodType, ModuleType
+from itertools import chain
 
 import frappe
 from frappe import _
@@ -10,7 +10,7 @@ from frappe.model.document import Document
 from frappe.rate_limiter import rate_limit
 from frappe.utils.safe_exec import (
 	FrappeTransformer,
-	NamespaceDict,
+	get_keys_for_autocomplete,
 	get_safe_globals,
 	is_safe_exec_enabled,
 	safe_exec,
@@ -208,41 +208,15 @@ class ServerScript(Document):
 		        For e.g., ["frappe.utils.cint", "frappe.get_all", ...]
 		"""
 
-		def get_keys(obj):
-			out = []
-			for key in obj:
-				if key.startswith("_"):
-					continue
-				value = obj[key]
-				if isinstance(value, NamespaceDict | dict) and value:
-					if key == "form_dict":
-						out.append(["form_dict", 7])
-						continue
-					for subkey, score in get_keys(value):
-						fullkey = f"{key}.{subkey}"
-						out.append([fullkey, score])
-				else:
-					if isinstance(value, type) and issubclass(value, Exception):
-						score = 0
-					elif isinstance(value, ModuleType):
-						score = 10
-					elif isinstance(value, FunctionType | MethodType):
-						score = 9
-					elif isinstance(value, type):
-						score = 8
-					elif isinstance(value, dict):
-						score = 7
-					else:
-						score = 6
-					out.append([key, score])
-			return out
-
-		items = frappe.cache.get_value("server_script_autocompletion_items")
-		if not items:
-			items = get_keys(get_safe_globals())
-			items = [{"value": d[0], "score": d[1]} for d in items]
-			frappe.cache.set_value("server_script_autocompletion_items", items)
-		return items
+		return frappe.cache.get_value(
+			"server_script_autocompletion_items",
+			generator=lambda: list(
+				chain.from_iterable(
+					get_keys_for_autocomplete(key, value, meta="utils")
+					for key, value in get_safe_globals().items()
+				),
+			),
+		)
 
 
 def setup_scheduler_events(script_name: str, frequency: str, cron_format: str | None = None):

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -7,6 +7,9 @@ import mimetypes
 import types
 from contextlib import contextmanager
 from functools import lru_cache
+from itertools import chain
+from types import FunctionType, MethodType, ModuleType
+from typing import TYPE_CHECKING, Any
 
 import RestrictedPython.Guards
 from RestrictedPython import PrintCollector, compile_restricted, safe_globals
@@ -303,6 +306,52 @@ def get_safe_globals():
 	out.update(get_python_builtins())
 
 	return out
+
+
+def get_keys_for_autocomplete(
+	key: str,
+	value: Any,
+	prefix: str = "",
+	offset: int = 0,
+	meta: str = "ctx",
+	depth: int = 0,
+	max_depth: int | None = None,
+):
+	if max_depth and depth > max_depth:
+		return
+	full_key = f"{prefix}.{key}" if prefix else key
+	if key.startswith("_"):
+		return
+	if isinstance(value, NamespaceDict | dict) and value:
+		if key == "form_dict":
+			yield {"value": full_key, "score": offset + 7, "meta": meta}
+		else:
+			yield from chain.from_iterable(
+				get_keys_for_autocomplete(
+					key,
+					value,
+					full_key,
+					offset,
+					meta,
+					depth + 1,
+					max_depth=max_depth,
+				)
+				for key, value in value.items()
+			)
+	else:
+		if isinstance(value, type) and issubclass(value, Exception):
+			score = offset + 0
+		elif isinstance(value, ModuleType):
+			score = offset + 10
+		elif isinstance(value, FunctionType | MethodType):
+			score = offset + 9
+		elif isinstance(value, type):
+			score = offset + 8
+		elif isinstance(value, dict):
+			score = offset + 7
+		else:
+			score = offset + 6
+		yield {"value": full_key, "score": score, "meta": meta}
 
 
 def is_job_queued(job_name, queue="default"):


### PR DESCRIPTION
(cherry picked from commit 8b1180ba27d6ae2c7ec23fd597a1b45bf3964590)


This PR refactors the server script autocompletion logic to make it more generic and reusable:

- Moves the core autocompletion logic to `get_keys_for_autocomplete()` in `safe_exec.py`
  - Makes it more versatile by adding prefix, max-depth and score-offset
- Updates `get_autocompletion_items()` to use the new generic function
- Improves typing and removes unused imports
- Simplifies caching logic for autocompletion items

These changes make the autocompletion system more flexible and easier to maintain going forward.
<hr>

This is an ~~automatic~~ backport of pull request #28180 done by ~~[Mergify](https://mergify.com)~~ @blaggacao.

... while context is still fresh; prepares potential (!) backport of https://github.com/frappe/frappe/pull/27963
