### PR TITLE
fix: backport restore command to work around backup restore issue with old v13 installations

### DIFF
--- a/frappe/database/db_manager.py
+++ b/frappe/database/db_manager.py
@@ -65,35 +65,40 @@ class DbManager:
 
 	@staticmethod
 	def restore_database(target, source, user, password):
-		from frappe.utils import make_esc
+		from shutil import which
+
+		from frappe import _
+		from frappe.utils import execute_in_shell, make_esc
 
 		esc = make_esc("$ ")
 
-		from distutils.spawn import find_executable
+		# Ensure that the entire process fails if any part of the pipeline fails
+		command = ["set -o pipefail;"]
 
-		pv = find_executable("pv")
-		if pv:
-			pipe = "{pv} {source} |".format(pv=pv, source=source)
-			source = ""
+		# Handle gzipped backups
+		if source.endswith(".gz"):
+			if gzip := which("gzip"):
+				command.extend([gzip, "-cd", source, "|"])
+			else:
+				raise Exception("`gzip` not installed")
 		else:
-			pipe = ""
-			source = "< {source}".format(source=source)
+			command.extend(["cat", source, "|"])
 
-		if pipe:
-			print("Restoring Database file...")
+		# Newer versions of MariaDB add in a line that'll break on older versions, so remove it
+		command.extend(["sed", r"'/\/\*M\{0,1\}!999999\\- enable the sandbox mode \*\//d'", "|"])
 
-		command = (
-			"{pipe} mysql -u {user} -p{password} -h{host} "
-			+ ("-P{port}" if frappe.db.port else "")
-			+ " {target} {source}"
+		# Generate the restore command
+		bin = (
+			"mysql -u {user} -p{password} -h{host} " + ("-P{port}" if frappe.db.port else "") + " {target}"
 		)
-		command = command.format(
-			pipe=pipe,
+		bin = bin.format(
 			user=esc(user),
 			password=esc(password),
 			host=esc(frappe.db.host),
 			target=esc(target),
-			source=source,
 			port=frappe.db.port,
 		)
-		os.system(command)
+
+		command.append(bin)
+
+		execute_in_shell(" ".join(command), check_exit_code=True, verbose=False)

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -394,11 +394,17 @@ def unesc(s, esc_chars):
 def execute_in_shell(cmd, verbose=False, low_priority=False, check_exit_code=False):
 	# using Popen instead of os.system - as recommended by python docs
 	import tempfile
+	from shutil import which
 	from subprocess import Popen
 
 	with tempfile.TemporaryFile() as stdout:
 		with tempfile.TemporaryFile() as stderr:
-			kwargs = {"shell": True, "stdout": stdout, "stderr": stderr}
+			kwargs = {
+				"shell": True,
+				"stdout": stdout,
+				"stderr": stderr,
+				"executable": which("bash") or "/bin/bash",
+			}
 
 			if low_priority:
 				kwargs["preexec_fn"] = lambda: os.nice(10)


### PR DESCRIPTION
See: https://github.com/frappe/frappe/pull/27831
And: https://github.com/MariaDB/server/commit/d20518168aff435a4843eebb108e5b9df24c19fb#diff-2af757996671100e35b2650825a86d9a7f3d2b3bc538e9267c4195ca2e0b19caR758

This also changes the default shell to bash, which might be my biggest concern here.
We are currently looking to use our branch with existing v13 installations while this PR is in discussion.