### PR TITLE
fix(Webhook): highlighting  for JSON Request Body

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -130,7 +130,7 @@
    "fieldname": "webhook_json",
    "fieldtype": "Code",
    "label": "JSON Request Body",
-   "options": "JSON"
+   "options": "Jinja"
   },
   {
    "fieldname": "sb_security",
@@ -189,7 +189,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2024-07-22 09:23:32.642172",
+ "modified": "2024-10-28 12:21:52.172428",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",


### PR DESCRIPTION
The JSON request body is  supposed to hold a Jinja template which produces valid JSON. 

### Before

The JSON highlighting shows errors when applied to a valid Jinja template.

![Bildschirmfoto 2024-10-28 um 17 27 40](https://github.com/user-attachments/assets/9e750027-7e2b-4ab9-b563-db7dcb5ee64d)

### After

With Jinja highlighting, everything looks as correct as it is.

![Bildschirmfoto 2024-10-28 um 17 26 41](https://github.com/user-attachments/assets/1f304e32-7b56-4c1e-9d73-8ee9b6bebc03)
