### PR TITLE
feat: add method `db.remove_unique`

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -432,6 +432,23 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 					add unique `{}`({})""".format(doctype, constraint_name, ", ".join(fields))
 			)
 
+	def remove_unique(self, doctype, fields, constraint_name=None):
+		if isinstance(fields, str):
+			fields = [fields]
+		if not constraint_name:
+			constraint_name = "unique_" + "_".join(fields)
+
+		if self.sql(
+			"""select CONSTRAINT_NAME from information_schema.TABLE_CONSTRAINTS
+			where table_name=%s and constraint_type='UNIQUE' and CONSTRAINT_NAME=%s""",
+			("tab" + doctype, constraint_name),
+		):
+			self.commit()
+			self.sql(
+				"""alter table `tab{}`
+					drop index `{}`""".format(doctype, constraint_name)
+			)
+
 	def updatedb(self, doctype, meta=None):
 		"""
 		Syncs a `DocType` to the table

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -433,6 +433,37 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 				.as_string(self._conn)
 			)
 
+	def remove_unique(self, doctype, fields, constraint_name=None):
+		if isinstance(fields, str):
+			fields = [fields]
+		if not constraint_name:
+			constraint_name = "unique_" + "_".join(fields)
+
+		if self.sql(
+			"""
+			SELECT CONSTRAINT_NAME
+			FROM information_schema.TABLE_CONSTRAINTS
+			WHERE table_name=%s
+			AND constraint_type='UNIQUE'
+			AND constraint_schema=%s
+			AND CONSTRAINT_NAME=%s""",
+			("tab" + doctype, self.db_schema, constraint_name),
+		):
+			self.commit()
+
+			self.sql(
+				sql.SQL(
+					"""ALTER TABLE {schema}.{table}
+					DROP CONSTRAINT {constraint}"""
+				)
+				.format(
+					schema=sql.Identifier(self.db_schema),
+					table=sql.Identifier("tab" + doctype),
+					constraint=sql.Identifier(constraint_name),
+				)
+				.as_string(self._conn)
+			)
+
 	def get_table_columns_description(self, table_name):
 		"""Return list of columns with description."""
 		# pylint: disable=W1401

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -654,6 +654,10 @@ class TestDB(IntegrationTestCase):
 	def test_db_explain(self):
 		frappe.db.sql("select 1", debug=1, explain=1)
 
+	def test_unique(self):
+		frappe.db.add_unique("User", ["email", "first_name"])
+		frappe.db.remove_unique("User", ["email", "first_name"])
+
 
 @run_only_if(db_type_is.MARIADB)
 class TestDDLCommandsMaria(IntegrationTestCase):

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -655,8 +655,33 @@ class TestDB(IntegrationTestCase):
 		frappe.db.sql("select 1", debug=1, explain=1)
 
 	def test_unique(self):
+		def insert_user(name):
+			frappe.db.multisql(
+				sql_dict={
+					"mariadb": "insert into `tabUser` (`name`, `email`, `first_name`) values (%(name)s, %(email)s, %(email)s)",
+					"postgres": 'insert into "tabUser" ("name", "email", "first_name") values (%(name)s, %(email)s, %(email)s)',
+				},
+				values={"email": "test_unique@example.org", "name": name},
+			)
+
 		frappe.db.add_unique("User", ["email", "first_name"])
+
+		# Add first record, should not raise error
+		insert_user(1)
+
+		# Add second record, should raise error
+		try:
+			insert_user(2)
+		except Exception as e:
+			self.assertTrue(frappe.db.is_unique_key_violation(e))
+
 		frappe.db.remove_unique("User", ["email", "first_name"])
+
+		# Add record after removing unique, should not raise error
+		insert_user(3)
+
+		# Cleanup
+		frappe.db.delete("User", {"email": "test_unique@example.org"})
 
 
 @run_only_if(db_type_is.MARIADB)


### PR DESCRIPTION
Adds a method `db.remove_unique` for having a way to undo `db.add_unique`.

Will add docs below https://frappeframework.com/docs/user/en/api/database#frappedbadd_unique after merge.