### PR TITLE
refactor: use `doc.check_permission`

### DIFF
--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -72,8 +72,7 @@ def read_doc(doctype: str, name: str):
 		return execute_doc_method(doctype, name)
 
 	doc = frappe.get_doc(doctype, name)
-	if not doc.has_permission("read"):
-		raise frappe.PermissionError
+	doc.check_permission("read")
 	doc.apply_fieldlevel_read_permissions()
 	return doc
 
@@ -84,14 +83,11 @@ def execute_doc_method(doctype: str, name: str, method: str | None = None):
 	doc.is_whitelisted(method)
 
 	if frappe.request.method == "GET":
-		if not doc.has_permission("read"):
-			frappe.throw(_("Not permitted"), frappe.PermissionError)
+		doc.check_permission("read")
 		return doc.run_method(method, **frappe.form_dict)
 
 	elif frappe.request.method == "POST":
-		if not doc.has_permission("write"):
-			frappe.throw(_("Not permitted"), frappe.PermissionError)
-
+		doc.check_permission("write")
 		return doc.run_method(method, **frappe.form_dict)
 
 

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -36,11 +36,7 @@ def getdoc(doctype, name, user=None):
 		frappe.clear_last_message()
 		return []
 
-	if not doc.has_permission("read"):
-		frappe.flags.error_message = _("Insufficient Permission for {0}").format(
-			frappe.bold(_(doctype) + " " + name)
-		)
-		raise frappe.PermissionError(("read", doctype, name))
+	doc.check_permission("read")
 
 	run_onload(doc)
 	doc.apply_fieldlevel_read_permissions()
@@ -95,8 +91,7 @@ def get_docinfo(doc=None, doctype=None, name=None):
 
 	if not doc:
 		doc = frappe.get_doc(doctype, name)
-		if not doc.has_permission("read"):
-			raise frappe.PermissionError
+		doc.check_permission("read")
 
 	all_communications = _get_communications(doc.doctype, doc.name, limit=21)
 	automated_messages = [
@@ -222,8 +217,7 @@ def get_communications(doctype, name, start=0, limit=20):
 	from frappe.utils import cint
 
 	doc = frappe.get_doc(doctype, name)
-	if not doc.has_permission("read"):
-		raise frappe.PermissionError
+	doc.check_permission("read")
 
 	return _get_communications(doctype, name, cint(start), cint(limit))
 

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -270,8 +270,10 @@ def run_doc_method(method, docs=None, dt=None, dn=None, arg=None, args=None):
 		doc._original_modified = doc.modified
 		doc.check_if_latest()
 
-	if not doc or not doc.has_permission("read"):
+	if not doc:
 		frappe.throw_permission_error()
+
+	doc.check_permission("read")
 
 	try:
 		args = frappe.parse_json(args)

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -235,15 +235,11 @@ def update_flags(doc, flags=None, ignore_permissions=False):
 
 def check_permission_and_not_submitted(doc):
 	# permission
-	if (
-		not doc.flags.ignore_permissions
-		and frappe.session.user != "Administrator"
-		and (not doc.has_permission("delete") or (doc.doctype == "DocType" and not doc.custom))
-	):
-		frappe.msgprint(
-			_("User not allowed to delete {0}: {1}").format(doc.doctype, doc.name),
-			raise_exception=frappe.PermissionError,
-		)
+	if not doc.flags.ignore_permissions and frappe.session.user != "Administrator":
+		if doc.doctype == "DocType" and not doc.custom:
+			frappe.throw(_("Only the Administrator can delete a standard DocType."))
+		else:
+			doc.check_permission("delete")
 
 	# check if submitted
 	if doc.meta.is_submittable and doc.docstatus.is_submitted():


### PR DESCRIPTION
The pattern 

```python
if not doc.has_permission(perm):
		raise frappe.PermissionError
```

is used in some places. I think we can replace this with `doc.check_permission(perm)`, as defined below:

https://github.com/frappe/frappe/blob/c8ff316f94aaeb128b974a412648ac9125716029/frappe/model/document.py#L310-L334

However, I'm not 100% sure if the bare `PermissionError` were intended here.