### PR TITLE
fix: Clear cache when EPS enabled/disabled

### DIFF
--- a/frappe/social/doctype/energy_point_settings/energy_point_settings.py
+++ b/frappe/social/doctype/energy_point_settings/energy_point_settings.py
@@ -23,7 +23,9 @@ class EnergyPointSettings(Document):
 		review_levels: DF.Table[ReviewLevel]
 	# end: auto-generated types
 
-	pass
+	def on_update(self):
+		if self.has_value_changed("enabled"):
+			frappe.cache.delete_key("bootinfo")
 
 
 def is_energy_point_enabled():


### PR DESCRIPTION
### Context

Switching on/off requires (implicitly) for Admins to run `bench clear-cache` while we just need bootinfo cache to be cleared.