### PR TITLE
fix: get_datetime_as_string should respect time_format

### DIFF
--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -168,11 +168,8 @@ $.extend(frappe.datetime, {
 
 	get_datetime_as_string: function (d) {
 		let sysdefaults = frappe.boot.sysdefaults;
-		let date_format = frappe.defaultDateFormat;
-		let time_format =
-			sysdefaults && sysdefaults.time_format
-				? sysdefaults.time_format
-				: frappe.defaultTimeFormat;
+		let date_format = sysdefaults?.date_format || frappe.defaultDateFormat;
+		let time_format = sysdefaults?.time_format || frappe.defaultTimeFormat;
 		let datetime_format = date_format + " " + time_format;
 		return moment(d).format(datetime_format);
 	},

--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -167,7 +167,14 @@ $.extend(frappe.datetime, {
 	},
 
 	get_datetime_as_string: function (d) {
-		return moment(d).format("YYYY-MM-DD HH:mm:ss");
+		let sysdefaults = frappe.boot.sysdefaults;
+		let date_format = frappe.defaultDateFormat;
+		let time_format =
+			sysdefaults && sysdefaults.time_format
+				? sysdefaults.time_format
+				: frappe.defaultTimeFormat;
+		let datetime_format = date_format + " " + time_format;
+		return moment(d).format(datetime_format);
 	},
 
 	user_to_str: function (val, only_time = false) {


### PR DESCRIPTION
get_datetime_as_string until now always uses "YYYY-MM-DD HH:mm:ss" regardless of the settings in sysdefaults, even if "HH:mm" is selected as default value.
This can cause rounding errors when client side math is performed before submitting a DocType.
An example is the calculation of erpnext Timesheet hours, where the hours are calculated with seconds included, but the from_time and to_time field contain only minute accurate information after submission.

This fix selects the correct datetime format from the sysdefaults and formats the datetime accordingly.
