### PR TITLE
fix: keep flags during workflow validation

### DIFF
--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -197,7 +197,8 @@ def validate_workflow(doc):
 				_("Workflow State transition not allowed from {0} to {1}").format(bold_current, bold_next),
 				WorkflowPermissionError,
 			)
-
+			
+		doc._doc_before_save.flags = doc.flags
 		transitions = get_transitions(doc._doc_before_save)
 		transition = [d for d in transitions if d.next_state == next_state]
 		if not transition:


### PR DESCRIPTION
### Description
doc._doc_before_save is used for transitions, which throws a perm error due to doc.flags not being preserved when getting workflow transitions.

### Testing
Observe when a backend method ignores permissions during workflow transition, a permission error is not thrown. Note that `apply_workflow` does not accept an argument for `ignore_permissions`, so this is only relevant when manually performing these transitions by setting the `workflow_state` directly.

Needed in `version-15`