### PR TITLE
fix: Excessive gap locking from hash naming

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -280,8 +280,7 @@ def make_autoname(key="", doctype="", doc="", *, ignore_validate=False):
 	                DE/09/01/00001 where 09 is the year, 01 is the month and 00001 is the series
 	"""
 	if key == "hash":
-		# Makeshift "ULID": first 4 chars are based on timestamp, other 6 are random
-		return _get_timestamp_prefix() + _generate_random_string(6)
+		return _generate_random_string(10)
 
 	series = NamingSeries(key)
 	return series.generate_next_name(doc, ignore_validate=ignore_validate)

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import time
+import unittest
 from uuid import UUID
 
 import uuid_utils
@@ -407,6 +408,7 @@ class TestNaming(IntegrationTestCase):
 			expected_name = "TODO-" + nowdate().split("-")[1] + "-" + "0001"
 			self.assertEqual(name, expected_name)
 
+	@unittest.skip("This is not supported anymore, see #28349.")
 	@retry(
 		retry=retry_if_exception_type(AssertionError),
 		stop=stop_after_attempt(3),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/57f6d068-c89b-40c0-9e3b-00d5e818daf4)


Because of large common prefix, hash naming becomes "too sequential" when
doing a lot of concurrent writes.

I don't know a good tradeoff between both use cases:
1. Lots of reads - prefers large shared prefix.
2. Lots of writes - prefers small shared prefix.

But as of now this punishes writes too badly in form of excessive
locking. Until a better fix is found, it's better to keep it prefix free.

---

A better fix would be a tradeoff of between these three:

1. Readers - temporal locality should result in spatial locality on disk. (fewer pages accessed)
2. Single writer - temporal locality should result in spatial locality. (fewer dirty pages)
3. Multiple writers - temporal locality should NOT result in spatial locality. (less lock contention)

temporal locality = data inserted around same time
spatial locality = data sits next to each other in DB pages.

This can be achieved by adding a small request/job specific part to
prefix so each concurrent request has it's own different locality when
writing data.
