### PR TITLE
refactor: Extracting notification logic into a separate function

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -333,21 +333,8 @@ def get_context(context):
 
 		if self.is_standard:
 			self.load_standard_properties(context)
-		try:
-			if self.channel == "Email":
-				self.send_an_email(doc, context)
 
-			if self.channel == "Slack":
-				self.send_a_slack_msg(doc, context)
-
-			if self.channel == "SMS":
-				self.send_sms(doc, context)
-
-			if self.channel == "System Notification" or self.send_system_notification:
-				self.create_system_notification(doc, context)
-
-		except Exception:
-			self.log_error("Failed to send Notification")
+		self.send_notification_by_channel(doc, context)
 
 		if self.set_property_after_alert:
 			allow_update = True
@@ -375,6 +362,20 @@ def get_context(context):
 					doc.flags.in_notification_update = False
 			except Exception:
 				self.log_error("Document update failed")
+
+	def send_notification_by_channel(self, doc, context):
+		"""Send notification based on the specified channel."""
+		try:
+			if self.channel == "Email":
+				self.send_an_email(doc, context)
+			elif self.channel == "Slack":
+				self.send_a_slack_msg(doc, context)
+			elif self.channel == "SMS":
+				self.send_sms(doc, context)
+			elif self.channel == "System Notification" or self.send_system_notification:
+				self.create_system_notification(doc, context)
+		except Exception:
+			self.log_error("Failed to send Notification")
 
 	def create_system_notification(self, doc, context):
 		subject = self.subject


### PR DESCRIPTION
- Created `send_notification_by_channel` method to handle notification sending by channel and make it easier to extend the channels with a new channel in an custom app

- Simplified `send` method by moving channel-based notification logic to the new function



