### PR TITLE
fix: misc issues

### DIFF
--- a/frappe/core/doctype/doctype/doctype_list.js
+++ b/frappe/core/doctype/doctype/doctype_list.js
@@ -19,7 +19,7 @@ frappe.listview_settings["DocType"] = {
 		let non_developer = frappe.session.user !== "Administrator" || !frappe.boot.developer_mode;
 		let fields = [
 			{
-				label: __("DocType Name"),
+				label: __("Name"),
 				fieldname: "name",
 				fieldtype: "Data",
 				reqd: 1,

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -11,6 +11,7 @@
   "language",
   "column_break_3",
   "time_zone",
+  "currency",
   "enable_onboarding",
   "setup_complete",
   "disable_document_sharing",
@@ -684,12 +685,19 @@
    "fieldname": "use_number_format_from_currency",
    "fieldtype": "Check",
    "label": "Use Number Format from Currency"
+  },
+  {
+   "description": "Default display currency",
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "options": "Currency"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2024-09-26 16:20:59.417151",
+ "modified": "2024-11-04 15:51:39.954876",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -32,6 +32,7 @@ class SystemSettings(Document):
 		bypass_2fa_for_retricted_ip_users: DF.Check
 		bypass_restrict_ip_check_if_2fa_enabled: DF.Check
 		country: DF.Link | None
+		currency: DF.Link | None
 		currency_precision: DF.Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
 		date_format: DF.Literal[
 			"yyyy-mm-dd", "dd-mm-yyyy", "dd/mm/yyyy", "dd.mm.yyyy", "mm/dd/yyyy", "mm-dd-yyyy"

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -176,6 +176,7 @@ def update_system_settings(args):  # nosemgrep
 			"country": args.get("country"),
 			"language": get_language_code(args.get("language")) or "en",
 			"time_zone": args.get("timezone"),
+			"currency": args.get("currency"),
 			"float_precision": 3,
 			"rounding_method": "Banker's Rounding",
 			"date_format": frappe.db.get_value("Country", args.get("country"), "date_format"),

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -285,7 +285,7 @@ $.extend(frappe.meta, {
 	},
 
 	get_field_currency: function (df, doc) {
-		var currency = frappe.boot.sysdefaults.currency;
+		var currency = frappe.boot.sysdefaults.currency || "USD";
 		if (!doc && cur_frm) doc = cur_frm.doc;
 
 		if (df && df.options) {

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -145,6 +145,7 @@ select.form-control {
 	.control-label.reqd:after {
 		content: " *";
 		color: var(--red-400);
+		white-space: nowrap;
 	}
 	.help:empty {
 		display: none;


### PR DESCRIPTION
### Default Currency Issue

Earlier if you didn't configure a currency for a field, the default used for formatting to be AED. I went to change it to USD, but found out that the issue was even funnier. Although, **we captured currency during the setup wizard, we didn't store it anywhere.** Even further, we were expecting it to exists when looking for default currency. This PR also fixes that by storing the default display currency in system settings:

![CleanShot 2024-11-04 at 16 20 27@2x](https://github.com/user-attachments/assets/b7f6a9f5-53df-4248-98de-ee0733676cc6)

### Other minor fixes

- fix(UI): succinct field name for DocType name input
- fix: don't wrap reqd symbol to new line (for future stuff)

![CleanShot 2024-11-04 at 15 05 37@2x](https://github.com/user-attachments/assets/3da31fa2-cc6e-4581-9162-689bd671bcee)




