### PR TITLE
fix: print translations not working

### DIFF
--- a/frappe/tests/test_printview.py
+++ b/frappe/tests/test_printview.py
@@ -30,3 +30,51 @@ class PrintViewTest(IntegrationTestCase):
 
 		# cancelled doc can't be printed by default
 		self.assertRaises(frappe.PermissionError, frappe.attach_print, doc.doctype, doc.name)
+
+	def test_print_languages(self):
+		user = frappe.get_last_doc("User")
+
+		messages_before = frappe.get_message_log()
+		ret = get_html_and_style(doc=user.as_json(), print_format="Standard", no_letterhead=1)
+		messages_after = frappe.get_message_log()
+
+		if len(messages_after) > len(messages_before):
+			new_messages = messages_after[len(messages_before) :]
+			self.fail("Print view showing error/warnings: \n" + "\n".join(str(msg) for msg in new_messages))
+
+		# html should exist
+		self.assertTrue(bool(ret["html"]))
+
+		frappe.form_dict["_lang"] = "en"
+		messages_before = frappe.get_message_log()
+		ret_en = get_html_and_style(doc=user.as_json(), print_format="Standard", no_letterhead=1)
+		messages_after = frappe.get_message_log()
+
+		if len(messages_after) > len(messages_before):
+			new_messages = messages_after[len(messages_before) :]
+			self.fail("Print view showing error/warnings: \n" + "\n".join(str(msg) for msg in new_messages))
+
+		# html should exist
+		self.assertTrue(bool(ret_en["html"]))
+
+		self.assertEqual(ret, ret_en)
+
+		frappe.form_dict["_lang"] = "de"
+		messages_before = frappe.get_message_log()
+		ret_de = get_html_and_style(doc=user.as_json(), print_format="Standard", no_letterhead=1)
+		messages_after = frappe.get_message_log()
+
+		if len(messages_after) > len(messages_before):
+			new_messages = messages_after[len(messages_before) :]
+			self.fail("Print view showing error/warnings: \n" + "\n".join(str(msg) for msg in new_messages))
+
+		# html should exist
+		self.assertTrue(bool(ret_de["html"]))
+
+		self.assertNotEqual(ret_de, ret_en)
+
+		self.assertRegex(ret_de["html"], "<div>Nutzer</div>")
+		self.assertRegex(ret_en["html"], "<div>User</div>")
+
+		# html should exist
+		self.assertTrue(bool(ret["html"]))


### PR DESCRIPTION
closes #28356 
The selection of a print language is now respected again by adding print_language() in the printview.
Also added test case to make sure the printview and pdf is created in the language specified.

Should probably be backported to v15
