### PR TITLE
fix: remove `frappe.utils.is_empty`

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1482,7 +1482,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				const docfield = frappe.query_report.get_filter(fieldname).df;
 				const value = applied_filters[fieldname];
 
-				if (frappe.utils.is_empty(value) || docfield.hidden_due_to_dependency) {
+				if (docfield.hidden_due_to_dependency) {
 					return null;
 				}
 


### PR DESCRIPTION
- Issue: https://github.com/frappe/frappe/pull/28331#issuecomment-2460817493

---
- PR where `is_empty` added in condition: https://github.com/frappe/frappe/pull/28373

- PR where `is_empty` defined in utils: https://github.com/frappe/frappe/pull/27016

---
`is_empty` not backported yet in **version-15**.

