### PR TITLE
fix: newsletter scheduling mail

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: 'node_modules|.git'
-default_stages: [commit]
+default_stages: [pre-commit]
 fail_fast: false
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: 'node_modules|.git'
-default_stages: [pre-commit]
+default_stages: [commit]
 fail_fast: false
 
 

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -147,6 +147,9 @@ class Newsletter(WebsiteGenerator):
 			frappe.throw(_("Newsletter must be published to send webview link in email"))
 
 	def validate_scheduling_date(self):
+		if getattr(frappe.flags, "is_scheduler_running", False):
+			return
+
 		if (
 			self.schedule_sending
 			and frappe.utils.get_datetime(self.schedule_send) < frappe.utils.now_datetime()
@@ -394,6 +397,8 @@ def get_list_context(context=None):
 
 def send_scheduled_email():
 	"""Send scheduled newsletter to the recipients."""
+	frappe.flags.is_scheduler_running = True
+
 	scheduled_newsletter = frappe.get_all(
 		"Newsletter",
 		filters={
@@ -419,6 +424,8 @@ def send_scheduled_email():
 
 		if not frappe.flags.in_test:
 			frappe.db.commit()
+
+	frappe.flags.is_scheduler_running = False
 
 
 @frappe.whitelist(allow_guest=True)


### PR DESCRIPTION
fixes: #28396

Before: When the scheduler tried to send newsletters set for a past date, it ran into an error because the system checked and blocked any past dates. This stopped scheduled emails from being sent if they missed their original time.

After the Fix: We added a way for the system to skip the past-date check only when the scheduler runs. Now, newsletters set for a past time can still be sent by the scheduler, while users are still prevented from choosing past dates when scheduling manually.