### PR TITLE
fix(Login): don't prevent login if encryption key is invalid

### DIFF
--- a/frappe/utils/password.py
+++ b/frappe/utils/password.py
@@ -34,7 +34,13 @@ def get_decrypted_password(doctype, name, fieldname="password", raise_exception=
 	).run()
 
 	if result and result[0][0]:
-		return decrypt(result[0][0], key=f"{doctype}.{name}.{fieldname}")
+		try:
+			return decrypt(result[0][0], key=f"{doctype}.{name}.{fieldname}")
+		except frappe.ValidationError as e:
+			if raise_exception:
+				raise e
+
+			return None
 
 	elif raise_exception:
 		frappe.throw(

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -69,7 +69,9 @@ def get_context(context):
 	)
 
 	for provider in providers:
-		client_secret = get_decrypted_password("Social Login Key", provider.name, "client_secret")
+		client_secret = get_decrypted_password(
+			"Social Login Key", provider.name, "client_secret", raise_exception=False
+		)
 		if not client_secret:
 			continue
 


### PR DESCRIPTION
`decrypt` raises a `frappe.ValidationError` if the encryption key is missing/invalid.

If you have a **Social Login Key** configured, the login screen tries to decrypt the `client_secret`. When this fails due to an missing/invalid encryption key, the entire login page stops working.

With this fix, we just skip failed Social Login Keys and load the rest of the login page as usual. `get_decrypted_password` already has a `raise_exception` parameter. We set that to `False` and apply it to the `decrypt` call as well.