### PR TITLE
fix: backport german translations from develop

### DIFF
--- a/frappe/translations/de.csv
+++ b/frappe/translations/de.csv
@@ -4899,3 +4899,1804 @@ Quick Lists,Schnelllisten,
 Create Workspace,Arbeitsbereich erstellen,
 Installed Apps,Installierte Apps,
 Lists,Listen,
+'{0}' is not a valid URL,'{0} ist keine gültige URL,
++ Add / Remove Fields,+ Felder hinzufügen / entfernen,
+1 = True & 0 = False,1 = Wahr & 0 = Falsch,
+"1 Currency = [?] Fraction
+For e.g. 1 USD = 100 Cent","1 Einheit = [?] Bruchteile
+ z.B. 1 USD = 100 Cent",
+1 of 2,1 von 2,
+<b>{0}</b> is not a valid URL,<b>{0}</b> ist keine gültige URL,
+"<div class=""alert"">Please don't update it as it can mess up your form. Use the Customize Form View and Custom Fields to set properties!</div>","<div class=""alert"">Bitte nicht direkt bearbeiten, da es Ihr Formular durcheinander bringen kann. Benutzen Sie die Formularansicht und benutzerdefinierte Felder, um Eigenschaften zu setzen!</div>",
+"<h3>Custom CSS Help</h3>
+
+<p>Notes:</p>
+
+<ol>
+<li>All field groups (label + value) are set attributes <code>data-fieldtype</code> and <code>data-fieldname</code></li>
+<li>All values are given class <code>value</code></li>
+<li>All Section Breaks are given class <code>section-break</code></li>
+<li>All Column Breaks are given class <code>column-break</code></li>
+</ol>
+
+<h4>Examples</h4>
+
+<p>1. Left align integers</p>
+
+<pre><code>[data-fieldtype=""Int""] .value { text-align: left; }</code></pre>
+
+<p>1. Add border to sections except the last section</p>
+
+<pre><code>.section-break { padding: 30px 0px; border-bottom: 1px solid #eee; }
+.section-break:last-child { padding-bottom: 0px; border-bottom: 0px;  }</code></pre>
+","<h3>Hilfe zu benutzerdefinierten CSS</h3>
+
+<p>Hinweise:</p>
+
+<ol>
+<li>Alle Feldgruppen (label + value) erhalten die Attribute <code>data-fieldtype</code> und <code>data-fieldname</code></li>
+<li>Alle Werte erhalten die Klasse <code>value</code></li>
+<li>Alle Section Breaks erhalten die Klasse <code>section-break</code></li>
+<li>Alle Column Breaks erhalten die Klasse <code>column-break</code></li>
+</ol>
+
+<h4>Beispiele</h4>
+
+<p>1. Ganzzahlen links ausrichten</p>
+
+<pre><code>[data-fieldtype=""Int""] .value { text-align: left; }</code></pre>
+
+<p>1. Allen Abschnitten außer dem letzten einen Rahmen hinzufügen</p>
+
+<pre><code>.section-break { padding: 30px 0px; border-bottom: 1px solid #eee; }
+.section-break:last-child { padding-bottom: 0px; border-bottom: 0px; }</code></pre>
+",
+"<h3>Print Format Help</h3>
+<hr>
+<h4>Introduction</h4>
+<p>Print Formats are rendered on the server side using the Jinja Templating Language. All forms have access to the <code>doc</code> object which contains information about the document that is being formatted. You can also access common utilities via the <code>frappe</code> module.</p>
+<p>For styling, the Boostrap CSS framework is provided and you can enjoy the full range of classes.</p>
+<hr>
+<h4>References</h4>
+<ol>
+	<li><a href=""http://jinja.pocoo.org/docs/templates/"" target=""_blank"">Jinja Templating Language</a></li>
+	<li><a href=""http://getbootstrap.com"" target=""_blank"">Bootstrap CSS Framework</a></li>
+</ol>
+<hr>
+<h4>Example</h4>
+<pre><code>&lt;h3&gt;{{ doc.select_print_heading or ""Invoice"" }}&lt;/h3&gt;
+&lt;div class=""row""&gt;
+	&lt;div class=""col-md-3 text-right""&gt;Customer Name&lt;/div&gt;
+	&lt;div class=""col-md-9""&gt;{{ doc.customer_name }}&lt;/div&gt;
+&lt;/div&gt;
+&lt;div class=""row""&gt;
+	&lt;div class=""col-md-3 text-right""&gt;Date&lt;/div&gt;
+	&lt;div class=""col-md-9""&gt;{{ doc.get_formatted(""invoice_date"") }}&lt;/div&gt;
+&lt;/div&gt;
+&lt;table class=""table table-bordered""&gt;
+	&lt;tbody&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Sr&lt;/th&gt;
+			&lt;th&gt;Item Name&lt;/th&gt;
+			&lt;th&gt;Description&lt;/th&gt;
+			&lt;th class=""text-right""&gt;Qty&lt;/th&gt;
+			&lt;th class=""text-right""&gt;Rate&lt;/th&gt;
+			&lt;th class=""text-right""&gt;Amount&lt;/th&gt;
+		&lt;/tr&gt;
+		{%- for row in doc.items -%}
+		&lt;tr&gt;
+			&lt;td style=""width: 3%;""&gt;{{ row.idx }}&lt;/td&gt;
+			&lt;td style=""width: 20%;""&gt;
+				{{ row.item_name }}
+				{% if row.item_code != row.item_name -%}
+				&lt;br&gt;Item Code: {{ row.item_code}}
+				{%- endif %}
+			&lt;/td&gt;
+			&lt;td style=""width: 37%;""&gt;
+				&lt;div style=""border: 0px;""&gt;{{ row.description }}&lt;/div&gt;&lt;/td&gt;
+			&lt;td style=""width: 10%; text-align: right;""&gt;{{ row.qty }} {{ row.uom or row.stock_uom }}&lt;/td&gt;
+			&lt;td style=""width: 15%; text-align: right;""&gt;{{
+				row.get_formatted(""rate"", doc) }}&lt;/td&gt;
+			&lt;td style=""width: 15%; text-align: right;""&gt;{{
+				row.get_formatted(""amount"", doc) }}&lt;/td&gt;
+		&lt;/tr&gt;
+		{%- endfor -%}
+	&lt;/tbody&gt;
+&lt;/table&gt;</code></pre>
+<hr>
+<h4>Common Functions</h4>
+<table class=""table table-bordered"">
+	<tbody>
+		<tr>
+			<td style=""width: 30%;""><code>doc.get_formatted(""[fieldname]"", [parent_doc])</code></td>
+			<td>Get document value formatted as Date, Currency, etc. Pass parent <code>doc</code> for currency type fields.</td>
+		</tr>
+		<tr>
+			<td style=""width: 30%;""><code>frappe.db.get_value(""[doctype]"", ""[name]"", ""fieldname"")</code></td>
+			<td>Get value from another document.</td>
+		</tr>
+	</tbody>
+</table>
+","<h3>Hilfe zu Druckformaten</h3>
+<hr>
+<h4>Einführung</h4>
+<p>Druckformate werden auf der Serverseite mit der Jinja Templating Language gerendert. Alle Formulare haben Zugriff auf das <code>doc</code> Objekt, das Informationen über das Dokument enthält, das formatiert wird. Sie können auch über das Modul <code>frappe</code> auf allgemeine Dienstprogramme zugreifen.</p>
+<p>Für das Styling steht Ihnen das Boostrap CSS-Framework zur Verfügung und Sie können die gesamte Bandbreite an Klassen nutzen.</p>
+<hr>
+<h4>Referenzen</h4>
+<ol>
+	<li><a href=""http://jinja.pocoo.org/docs/templates/"" target=""_blank"">Jinja Templating Language</a></li>
+	<li><a href=""http://getbootstrap.com"" target=""_blank"">Bootstrap CSS Framework</a></li>
+</ol>
+<hr>
+<h4>Beispiel</h4>
+<pre><code>&lt;h3&gt;{{ doc.select_print_heading or ""Invoice"" }}&lt;/h3&gt;
+&lt;div class=""row""&gt;
+	&lt;div class=""col-md-3 text-right""&gt;Kundenname&lt;/div&gt;
+	&lt;div class=""col-md-9""&gt;{{ doc.customer_name }}&lt;/div&gt;
+&lt;/div&gt;
+&lt;div class=""row""&gt;
+	&lt;div class=""col-md-3 text-right""&gt;Datum&lt;/div&gt;
+	&lt;div class=""col-md-9""&gt;{{ doc.get_formatted(""invoice_date"") }}&lt;/div&gt;
+&lt;/div&gt;
+&lt;table class=""table table-bordered""&gt;
+	&lt;tbody&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Sr&lt;/th&gt;
+			&lt;th&gt;Artikelname&lt;/th&gt;
+			&lt;th&gt;Beschreibung&lt;/th&gt;
+			&lt;th class=""text-right""&gt;Menge&lt;/th&gt;
+			&lt;th class=""text-right""&gt;Preis&lt;/th&gt;
+			&lt;th class=""text-right""&gt;Betrag&lt;/th&gt;
+		&lt;/tr&gt;
+		{%- for row in doc.items -%}
+		&lt;tr&gt;
+			&lt;td style=""width: 3%;""&gt;{{ row.idx }}&lt;/td&gt;
+			&lt;td style=""width: 20%;""&gt;
+				{{ row.item_name }}
+				{% if row.item_code != row.item_name -%}
+				&lt;br&gt;Artikelcode: {{ row.item_code}}
+				{%- endif %}
+			&lt;/td&gt;
+			&lt;td style=""width: 37%;""&gt;
+				&lt;div style=""border: 0px;""&gt;{{ row.description }}&lt;/div&gt;&lt;/td&gt;
+			&lt;td style=""width: 10%; text-align: right;""&gt;{{ row.qty }} {{ row.uom or row.stock_uom }}&lt;/td&gt;
+			&lt;td style=""width: 15%; text-align: right;""&gt;{{
+				row.get_formatted(""rate"", doc) }}&lt;/td&gt;
+			&lt;td style=""width: 15%; text-align: right;""&gt;{{
+				row.get_formatted(""amount"", doc) }}&lt;/td&gt;
+		&lt;/tr&gt;
+		{%- endfor -%}
+	&lt;/tbody&gt;
+&lt;/table&gt;</code></pre>
+<hr>
+<h4>Gemeinsame Funktionen</h4>
+<table class=""table table-bordered"">
+	<tbody>
+		<tr>
+			<td style=""width: 30%;""><code>doc.get_formatted(""[feldname]"", [übergeordnetes_doc])</code></td>
+			<td>Dokumentwert als Datum, Währung usw. formatiert abrufen. Übergeben Sie das übergeordnete <code>doc</code> für Felder vom Typ Währung.</td>
+		</tr>
+		<tr>
+			<td style=""width: 30%;""><code>frappe.db.get_value(""[doctype]"", ""[name]"", ""fieldname"")</code></td>
+			<td>Holen Sie den Wert aus einem anderen Dokument.</td>
+		</tr>
+	</tbody>
+</table>
+",
+"<h4>Default Template</h4>
+<p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
+<pre><code>{{ address_line1 }}&lt;br&gt;
+{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
+{{ city }}&lt;br&gt;
+{% if state %}{{ state }}&lt;br&gt;{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
+{{ country }}&lt;br&gt;
+{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+</code></pre>","<h4>Standardvorlage</h4>
+<p>Verwendet <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> und alle Felder der Adresse (einschließlich der benutzerdefinierten Felder, falls vorhanden) werden verfügbar sein</p>
+<pre><code>{{ address_line1 }}&lt;br&gt;
+{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
+{{ city }}&lt;br&gt;
+{% if state %}{{ state }}&lt;br&gt;{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
+{{ country }}&lt;br&gt;
+{% if phone %}Telefon: {{ phone }}&lt;br&gt;{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
+{% if email_id %}E-Mail: {{ email_id }}&lt;br&gt;{% endif -%}
+</code></pre>",
+"<h4>Email Reply Example</h4>
+
+<pre>Order Overdue
+
+Transaction {{ name }} has exceeded Due Date. Please take necessary action.
+
+Details
+
+- Customer: {{ customer }}
+- Amount: {{ grand_total }}
+</pre>
+
+<h4>How to get fieldnames</h4>
+
+<p>The fieldnames you can use in your email template are the fields in the document from which you are sending the email. You can find out the fields of any documents via Setup &gt; Customize Form View and selecting the document type (e.g. Sales Invoice)</p>
+
+<h4>Templating</h4>
+
+<p>Templates are compiled using the Jinja Templating Language. To learn more about Jinja, <a class=""strong"" href=""http://jinja.pocoo.org/docs/dev/templates/"">read this documentation.</a></p>
+","<h4>Beispiel für eine E-Mail-Antwort</h4>
+
+<pre>Überfällige Bestellung
+
+Die Transaktion {{ name }} hat das Fälligkeitsdatum überschritten. Bitte ergreifen Sie die notwendigen Maßnahmen.
+
+Details
+
+- Kunde: {{ customer }}
+- Betrag: {{ grand_total }}
+</pre>
+
+<h4>So erhalten Sie Feldnamen</h4>
+
+<p>Die Feldnamen, die Sie in Ihrer E-Mail-Vorlage verwenden können, sind die Felder des Dokuments, aus dem Sie die E-Mail versenden. Sie können die Felder aller Dokumente über Setup &gt; Formularansicht anpassen und den Dokumententyp auswählen (z.B. Verkaufsrechnung)</p>
+
+<h4>Vorlagenerstellung</h4>
+
+<p>Vorlagen werden mit der Jinja-Vorlagensprache erstellt. Wenn Sie mehr über Jinja erfahren möchten, <a class=""strong"" href=""http://jinja.pocoo.org/docs/dev/templates/"">lesen Sie diese Dokumentation.</a></p>
+",
+"<h5 class=""text-muted uppercase"">Or</h5>","<h5 class=""text-muted uppercase"">Oder</h5>",
+"<h5>Message Example</h5>
+
+<pre>&lt;h3&gt;Order Overdue&lt;/h3&gt;
+
+&lt;p&gt;Transaction {{ doc.name }} has exceeded Due Date. Please take necessary action.&lt;/p&gt;
+
+&lt;!-- show last comment --&gt;
+{% if comments %}
+Last comment: {{ comments[-1].comment }} by {{ comments[-1].by }}
+{% endif %}
+
+&lt;h4&gt;Details&lt;/h4&gt;
+
+&lt;ul&gt;
+&lt;li&gt;Customer: {{ doc.customer }}
+&lt;li&gt;Amount: {{ doc.grand_total }}
+&lt;/ul&gt;
+</pre>","<h5>Nachrichtenbeispiel</h5>
+
+<pre>&lt;h3&gt;Bestellung überfällig&lt;/h3&gt;
+
+&lt;p&gt;Transaktion {{ doc.name }} hat das Fälligkeitsdatum überschritten. Bitte ergreifen Sie die notwendigen Maßnahmen.&lt;/p&gt;
+
+&lt;!-- letzten Kommentar anzeigen --&gt;
+{% if comments %}
+Letzter Kommentar: {{ comments[-1].comment }} von {{ comments[-1].by }}
+{% endif %}
+
+&lt;h4&gt;Details&lt;/h4&gt;
+
+&lt;ul&gt;
+&lt;li&gt;Kunde: {{ doc.customer }}
+&lt;li&gt;Betrag: {{ doc.grand_total }}
+&lt;/ul&gt;
+</pre>",
+"<p><strong>Condition Examples:</strong></p>
+<pre>doc.status==""Open""<br>doc.due_date==nowdate()<br>doc.total &gt; 40000
+</pre>","<p><strong>Bedingungsbeispiele:</strong></p>
+<pre>doc.status==""Öffnen""<br>doc.due_date==nowdate()<br>doc.total &gt; 40000
+
+</pre>",
+"<p><strong>Condition Examples:</strong></p>
+<pre>doc.status==""Open""<br>doc.due_date==nowdate()<br>doc.total &gt; 40000
+</pre>
+","<p><strong>Bedingungsbeispiele:</strong></p>
+<pre>doc.status==""Öffnen""<br>doc.due_date==nowdate()<br>doc.total &gt; 40000
+</pre>
+",
+"<p>Multiple webforms can be created for a single doctype. Add filters specific to this webform to display correct record after submission.</p><p>For Example:</p>
+<p>If you create a separate webform every year to capture feedback from employees add a 
+ field named year in doctype and add a filter <b>year = 2023</b></p>
+","<p>Mehrere Webformulare können für ein einzelnes Doctyle erstellt werden. Fügen Sie Filter für dieses Webformular hinzu, um den korrekten Datensatz nach dem Einreichen anzuzeigen.</p><p>Zum Beispiel:</p>
+<p>Wenn Sie jedes Jahr ein separates Webformular erstellen, um Feedback von Mitarbeitern zu erfassen, fügen Sie ein 
+ Feld mit dem Namen Jahr in Doctype hinzu und fügen Sie einen Filter <b>Jahr = 2023</b></p>
+",
+"<p>Set context before rendering a template. Example:</p><p>
+</p><div><pre><code>
+context.project = frappe.get_doc(""Project"", frappe.form_dict.name)
+</code></pre></div>","<p>Legen Sie den Kontext vor der Darstellung einer Vorlage fest. Beispiel:</p><p>
+</p><div><pre><code>
+context.project = frappe.get_doc(""Project"", frappe.form_dict.name)
+</code></pre></div>",
+"<p>To interact with above HTML you will have to use `root_element` as a parent selector.</p><p>For example:</p><pre class=""p-3 bg-gray-100 border-radius rounded-sm mb-0"" style=""width: fit-content;""><code>// here root_element is provided by default
+let some_class_element = root_element.querySelector('.some-class');
+some_class_element.textContent = ""New content"";
+</code></pre>","<p>Um mit dem oben genannten HTML zu interagieren, müssen Sie „root_element“ als übergeordneten Selektor verwenden.</p><p>Zum Beispiel:</p><pre class=""p-3 bg-gray-100 border-radius rounded-sm mb-0"" style=""width: fit-content;""><code>// hier wird root_element standardmäßig bereitgestellt
+let some_class_element = root_element.querySelector('.some-class');
+some_class_element.textContent = ""Neuer Inhalt"";
+</code></pre>",
+"<p>Your OTP secret on {0} has been reset. If you did not perform this reset and did not request it, please contact your System Administrator immediately.</p>","<p>Ihr OTP-Geheimnis auf {0} wurde zurückgesetzt. Wenn Sie diese Rücksetzung nicht durchgeführt und nicht angefordert haben, wenden Sie sich bitte umgehend an Ihren Systemadministrator.</p>",
+"<pre><code>doc.grand_total &gt; 0</code></pre>
+
+<p>Conditions should be written in simple Python. Please use properties available in the form only.</p>
+<p>Allowed functions:
+</p><ul>
+<li>frappe.db.get_value</li>
+<li>frappe.db.get_list</li>
+<li>frappe.session</li>
+<li>frappe.utils.now_datetime</li>
+<li>frappe.utils.get_datetime</li>
+<li>frappe.utils.add_to_date</li>
+<li>frappe.utils.now</li>
+</ul>
+<p>Example: </p><pre><code>doc.creation &gt; frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-5, as_string=True, as_datetime=True) </code></pre><p></p>","<pre><code>doc.grand_total &gt; 0</code></pre>
+
+<p>Bedingungen sollten in einfachem Python geschrieben werden. Bitte verwenden Sie nur die im Formular verfügbaren Eigenschaften.</p>
+<p>Erlaubte Funktionen:
+</p><ul>
+<li>frappe.db.get_value</li>
+<li>frappe.db.get_list</li>
+<li>frappe.session</li>
+<li>frappe.utils.now_datetime</li>
+<li>frappe.utils.get_datetime</li>
+<li>frappe.utils.add_to_date</li>
+<li>frappe.utils.now</li>
+</ul>
+<p>Beispiel: </p><pre><code>doc.creation &gt; frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-5, as_string=True, as_datetime=True) </code></pre><p></p>",
+"<span class=""h2"">Hi,</span>","<span class=""h2"">Hallo,</span>",
+"<span class=""h4""><b>Reports &amp; Masters</b></span>","<span class=""h4""><b>Berichte &amp; Stammdaten</b></span>",
+<strong>Warning:</strong> This field is system generated and may be overwritten by a future update. Modify it using {0} instead.,<strong>Warnung:</strong> Dieses Feld wird vom System generiert und kann durch ein zukünftiges Update überschrieben werden. Ändern Sie es stattdessen mit {0}.,
+"A DocType's name should start with a letter and can only consist of letters, numbers, spaces, underscores and hyphens","Der Name eines DocTypes sollte mit einem Buchstaben beginnen und darf nur aus Buchstaben, Zahlen, Leerzeichen, Unterstrichen und Bindestrichen bestehen",
+A field with the name {0} already exists in {1},Ein Feld mit dem Namen {0} existiert bereits in {1},
+A file with same name {} already exists,Eine Datei mit dem gleichen Namen {} existiert bereits,
+A template already exists for field {0} of {1},Es existiert bereits eine Vorlage für das Feld {0} von {1},
+API Key cannot be regenerated,API-Schlüssel kann nicht neu generiert werden,
+About Us,Über uns,
+Account Deletion Settings,Einstellungen für die Kontolöschung,
+Action Complete,Aktion abgeschlossen,
+Action Label,Aktionsbezeichnung,
+Activate,Aktivieren,
+Add Background Image,Hintergrundbild hinzufügen,
+Add Border at Bottom,Rand unten hinzufügen,
+Add Border at Top,Rand oben hinzufügen,
+Add Query Parameters,Abfrageparameter hinzufügen,
+Add Roles,Rollen hinzufügen,
+Add Space at Bottom,Freiraum darunter hinzufügen,
+Add Space at Top,Freiraum darüber hinzufügen,
+Add Tags,Schlagworte hinzufügen,
+Add Tags,Schlagworte hinzufügen,Button in list view actions menu
+Add Template,Vorlage hinzufügen,
+Add Video Conferencing,Videokonferenz hinzufügen,
+Add a Row,Zeile hinzufügen,
+Add column,Spalte hinzufügen,
+Add page break,Seitenumbruch hinzufügen,
+Add section above,Abschnitt oberhalb hinzufügen,
+Added default log doctypes: {},Standard Log-DocTypes hinzugefügt: {},
+Adds a custom client script to a DocType,Fügt ein benutzerdefiniertes Client-Skript zu einem DocType hinzu,
+After Insert,Nach Einfügen,
+After Submission,Nach der Einreichung,
+Aggregate Field is required to create a number card,"Das Feld Aggregatfunktion wird benötigt, um eine Nummernkarte zu erstellen",
+Align,Ausrichten,
+All fields are necessary to submit the comment.,"Alle Felder sind notwendig, um den Kommentar abzuschicken.",
+"All possible Workflow States and roles of the workflow. Docstatus Options: 0 is ""Saved"", 1 is ""Submitted"" and 2 is ""Cancelled""","Alle möglichen Workflow-Zustände und Rollen des Workflows. Status-Optionen: 0 ist „gespeichert“, 1 ist „gebucht“ und 2 ist „storniert“",
+Allow Guest to comment,Gäste dürfen kommentieren,
+Allow Older Web View Links (Insecure),Ältere Links zur Webansicht erlauben (unsicher),
+Allow Sending Usage Data for Improving Applications,Senden von Nutzungsdaten zur Verbesserung von Anwendungen zulassen,
+"Allow users to log in without a password, using a login link sent to their email","Benutzern erlauben, sich ohne Passwort anzumelden, indem ein Login-Link an ihre E-Mail gesendet wird",
+Allowed Modules,Erlaubte Module,
+Allowed Roles,Erlaubte Rollen,
+Alternative Email ID,Alternative E-Mail-ID,
+Always use this email address as sender address,Diese E-Mail-Adresse immer als Absenderadresse verwenden,
+Always use this name as sender name,Diesen Namen immer als Absender verwenden,
+Amending,Änderung,Freeze message while amending a document
+An unexpected error occurred while authorizing {}.,Beim Autorisieren von {} ist ein unerwarteter Fehler aufgetreten.,
+Anonymization Matrix,Anonymisierungsmatrix,
+App Access Key and/or Secret Key are not present.,App Access Key und/oder Secret Key sind nicht vorhanden.,
+App ID,Anwendungs-ID,
+App Logo,Anwendungslogo,
+"Append as communication against this DocType (must have fields: ""Sender"" and ""Subject""). These fields can be defined in the email settings section of the appended doctype.","Als Kommunikation an diesen DocType anhängen (muss Felder haben: ""Absender"" und ""Betreff""). Diese Felder können im Abschnitt E-Mail-Einstellungen des angehängten DocTyps definiert werden.",
+Apply Assignment Rule,Zuweisungsregel anwenden,Button in list view actions menu
+Apply To,Anwenden auf,
+Apply User Permission On,Benutzer-Berechtigung anwenden auf,
+Are you sure you want to discard the changes?,"Sind Sie sicher, dass Sie die Änderungen verwerfen möchten?",
+Are you sure you want to proceed?,"Sind Sie sicher, dass Sie fortfahren möchten?",
+Are you sure you want to re-enable scheduler?,"Sind Sie sicher, dass Sie den Scheduler wieder aktivieren möchten?",
+Are you sure you want to remove all failed jobs?,"Sind Sie sicher, dass Sie alle fehlgeschlagenen Jobs entfernen möchten?",
+Are you sure you want to remove the {0} filter?,"Sind Sie sicher, dass Sie den Filter {0} entfernen möchten?",
+Are you sure you want to send this newsletter now?,"Sind Sie sicher, dass Sie diesen Newsletter jetzt senden möchten?",
+Arguments,Argumente,
+"As document sharing is disabled, please give them the required permissions before assigning.","Da die Freigabe von Dokumenten deaktiviert ist, erteilen Sie ihnen vor der Zuweisung bitte die erforderlichen Berechtigungen.",
+"As per your request, your account and data on {0} associated with email {1} has been permanently deleted","Wie von Ihnen gewünscht, wurden Ihr Konto und die Daten auf {0}, die mit der E-Mail {1} verbunden sind, endgültig gelöscht",
+Assign To,Zuweisen an,Button in list view actions menu
+Assign a user,Benutzer zuweisen,
+Assigning...,Zuweisen...,
+Assignment Rule is not allowed on {0} document type,Die Zuweisungsregel ist für den Dokumenttyp {0} nicht zulässig,
+Assignment of {0} removed by {1},Zuordnung von {0} entfernt von {1},
+At least one column is required to show in the grid.,Mindestens eine Spalte muss im Raster angezeigt werden.,
+Attach Package,Paket anhängen,
+Attached To Name must be a string or an integer,Angehängt an Name muss eine Zeichenfolge oder eine Ganzzahl sein,
+Attachment Limit Reached,Limit für Anhänge erreicht,
+Audience,Zielgruppe,
+Audit System Hooks,System Hooks überprüfen,
+Audit Trail,Prüfprotokoll,
+Authorization URI,Autorisierungs-URI,
+Authorization error for {}.,Autorisierungsfehler für {}.,
+Authorize API Access,API-Zugriff autorisieren,
+Auto Repeat Day,Tag mit automatischer Wiederholung,
+Auto Repeat Day{0} {1} has been repeated.,Auto-Wiederholung Tag{0} {1} wurde wiederholt.,
+Auto Repeat Schedule,Zeitplan automatisch wiederholen,
+Auto Reply,Automatische Antwort,
+Auto follow documents that are assigned to you,"Dokumenten automatisch folgen, die Ihnen zugewiesen sind",
+Auto follow documents that are shared with you,"Dokumenten automatisch folgen, die mit Ihnen geteilt werden",
+Auto follow documents that you Like,"Dokumenten automatisch folgen, die Ihnen gefallen",
+Auto follow documents that you comment on,"Dokumenten automatisch folgen, die Sie kommentieren",
+Auto follow documents that you create,"Dokumenten automatisch folgen, die Sie erstellen",
+Autocomplete,Autovervollständigung,
+Autoincrement,Autoinkrement,
+Automated Message,Automatisierte Nachricht,
+Automatic,Automatisch,
+Awesome Work,Großartige Arbeit,
+"Awesome, now try making an entry yourself","Super, versuchen Sie jetzt selbst einen Eintrag zu erstellen",
+Back,Zurück,
+Back to Home,Zurück zur Startseite,
+Background Image,Hintergrundbild,
+Background Jobs Check,Überprüfung von Hintergrundprozessen,
+Backing up Data.,Daten werden gesichert.,
+Backup Encryption Key,Backup-Verschlüsselungs-Schlüssel,
+Bad Cron Expression,Ungültiger Cron-Ausdruck,
+Banker's Rounding,Symmetrisches Runden,
+Banker's Rounding (legacy),Symmetrisches Runden (alt),
+Before Print,Vor dem Drucken,
+Before Validate,Vor der Validierung,
+Binary Logging,Binäre Protokollierung,
+Blue,Blau,
+Bottom,Unterseite,
+Bottom Center,Unten Mitte,
+Bottom Left,Unten links,
+Bottom Right,Unten rechts,
+Brand Logo,Markenlogo,
+"Brand is what appears on the top-left of the toolbar. If it is an image, make sure it
+has a transparent background and use the &lt;img /&gt; tag. Keep size as 200px x 30px","Marke ist das, was oben links in der Navigationsleiste erscheint. Wenn es sich um ein Bild handelt, stellen Sie sicher, dass es
+einen transparenten Hintergrund hat und verwenden Sie das &lt;img /&gt; Tag. Die Größe sollte 200px x 30px sein.",
+Browse by category,Nach Kategorie suchen,
+Bucket {0} not found.,Bucket {0} nicht gefunden.,
+Bufferpool Size,Pufferpoolgröße,
+Build,Erstellen,
+Built on {0},Basierend auf {0},
+Bulk Actions,Massenbearbeitung,
+Bulk Edit,Massenbearbeitung,
+Bulk approval only support up to 500 documents.,Massengenehmigung unterstützt nur bis zu 500 Dokumente.,
+Bulk operation is enqueued in background.,Massenoperationen werden im Hintergrund eingereiht.,
+Bulk operations only support up to 500 documents.,Massenvorgänge unterstützen nur bis zu 500 Dokumente.,
+Bulk {0} is enqueued in background.,Massen- {0} ist im Hintergrund eingereiht.,
+"By ""Naming Series"" field","Nach ""Nummernkreis""-Feld",
+"By default, emails are only sent for failed backups.",E-Mails werden standardmäßig nur für fehlgeschlagene Sicherungen versendet.,
+By fieldname,Nach Feldname,
+By script,Per Skript,
+COLOR PICKER,FARBWÄHLER,
+CSS selector for the element you want to highlight.,"CSS-Selektor für das Element, das Sie hervorheben möchten.",
+Can Submit,Kann buchen,
+Can not rename as column {0} is already present on DocType.,"Kann nicht umbenannt werden, da Spalte {0} bereits im DocType vorhanden ist.",
+Can only change to/from Autoincrement naming rule when there is no data in the doctype,"Kann nur zu/von der Benennungsregel Autoincrement wechseln, wenn keine Daten im Doctype vorhanden sind",
+Can only list down the document types which has been linked to the User document type.,"Kann nur die Dokumenttypen auflisten, die mit dem Dokumenttyp Benutzer verknüpft sind.",
+Can't rename {0} to {1} because {0} doesn't exist.,"Kann {0} nicht in {1} umbenennen, da {0} nicht existiert.",
+Cancel,Abbrechen,Button in list view actions menu
+Cancel,Abbrechen,Secondary button in warning dialog
+Cancel All,Alle stornieren,
+Cancel Scheduling,Planung abbrechen,
+Cancel {0} documents?,Abbrechen von {0} Dokumenten?,Title of confirmation dialog
+Cancelling,Stornierung,Freeze message while cancelling a document
+Cannot Download Report due to insufficient permissions,Bericht kann wegen unzureichender Berechtigungen nicht heruntergeladen werden,
+Cannot Update After Submit,Kann nach dem Buchen nicht mehr geändert werden,
+Cannot access file path {0},Zugriff auf Dateipfad {0} nicht möglich,
+Cannot change docstatus from 0 (Draft) to 2 (Cancelled),Status kann nicht von 0 (Entwurf) zu 2 (Abgebrochen) geändert werden,
+Cannot change docstatus from 1 (Submitted) to 0 (Draft),Der Dokumentstatus kann nicht von 1 (Gebucht) auf 0 (Entwurf) geändert werden,
+Cannot change to/from autoincrement autoname in Customize Form,In „Formular anpassen“ kann nicht von/zu Benennungsschema „Autoinkrementierung“ gewechselt werden,
+Cannot create private workspace of other users,Privater Arbeitsbereich für andere Benutzer kann nicht erstellt werden,
+Cannot delete standard document state.,Standarddokumentstatus kann nicht gelöscht werden.,
+Cannot delete standard field <strong>{0}</strong>. You can hide it instead.,Das Standardfeld <strong>{0}</strong>kann nicht gelöscht werden. Sie können es stattdessen ausblenden.,
+Cannot delete system generated field <strong>{0}</strong>. You can hide it instead.,Das vom System generierte Feld <strong>{0}</strong>kann nicht gelöscht werden. Sie können es stattdessen ausblenden.,
+Cannot edit Standard Dashboards,Standard-Dashboards können nicht bearbeitet werden,
+Cannot edit Standard charts,Standarddiagramme können nicht bearbeitet werden,
+Cannot edit filters for standard number cards,Filter für Standardnummernkarten können nicht bearbeitet werden,
+Cannot enable {0} for a non-submittable doctype,{0} kann nicht für einen nicht buchbaren Doctype aktiviert werden,
+Cannot find file {} on disk,Kann Datei {} auf der Festplatte nicht finden,
+Cannot get file contents of a Folder,Dateiinhalt eines Ordners kann nicht abgerufen werden,
+Cannot map because following condition fails:,"Zuordnung nicht möglich, da folgende Bedingung nicht erfüllt ist:",
+Cannot set 'Report' permission if 'Only If Creator' permission is set,"Das Recht 'Bericht' kann nicht gesetzt werden, wenn das Recht 'Nur wenn Ersteller' gesetzt ist",
+Cannot set Notification with event {0} on Document Type {1},Benachrichtigung mit Ereignis {0} im Dokumententyp {1} nicht möglich,
+Cannot share {0} with submit permission as the doctype {1} is not submittable,"Kann {0} nicht mit der Berechtigung zum Buchen teilen, da der Doctype {1} nicht buchbar ist",
+Cannot use {0} in order/group by,{0} kann für die Sortierung oder Gruppierung verwendet werden,
+Capture,Erfassen,
+Card Break,Kartenumbruch,
+Card Links,Karten-Links,
+Change Image,Bild ändern,
+Change Letter Head,Briefkopf ändern,
+Change Print Format,Druckformat ändern,
+"Change the starting / current sequence number of an existing series. <br>
+
+Warning: Incorrectly updating counters can prevent documents from getting created. ","Ändern Sie die initiale bzw. aktuelle Sequenznummer eines bestehenden Nummernkreises. <br>
+
+Warnung: Eine fehlerhafte Aktualisierung der Zähler kann dazu führen, dass keine neuen Dokumente erstellt werden können. ",
+Changelog Feed,Änderungsprotokoll-Feed,
+Changing any setting will reflect on all the email accounts associated with this domain.,Das Ändern einer Einstellung wirkt sich auf alle mit dieser Domain verknüpften E-Mail-Konten aus.,
+Changing rounding method on site with data can result in unexpected behaviour.,Das Ändern der Rundungsmethode einer Instanz mit Daten kann zu unerwartetem Verhalten führen.,
+Check broken links,Überprüfe kaputte Links,
+Check this if you want to force the user to select a series before saving. There will be no default if you check this.,"Hier aktivieren, wenn der Benutzer gezwungen sein soll, vor dem Speichern eine Serie auszuwählen. Bei Aktivierung gibt es keine Standardvorgabe.",
+Checking broken links...,Überprüfe kaputte Links...,
+Child DocTypes are not allowed,Untergeordnete DocTypes sind nicht erlaubt,
+Child Doctype,Untergeordneter DocType,
+Choose a block or continue typing,Wählen Sie einen Block oder tippen Sie weiter,
+Choose an icon,Symbol auswählen,
+Clear & Add Template,Leeren und Vorlage einfügen,
+Clear & Add template,Leeren und Vorlage einfügen,
+Clear Logs After (days),Lösche Logs nach (in Tagen),
+Clear the email message and add the template,Email-Feld leeren und Vorlage einfügen,
+Click on the button to log in to {0},"Klicken Sie auf den Button, um sich bei {0} anzumelden",
+Client Id,Client-ID,
+Cmd+Enter to add comment,"""Strg + Enter"" um Kommentar hinzuzufügen",
+Code challenge method,Code Challenge-Methode,
+Collapse,Zusammenbruch,Shrink code field.
+Collapsible Depends On (JS),"""Faltbar"" hängt ab von (JS)",
+Column width cannot be zero.,Spaltenbreite darf nicht null sein.,
+Comment limit,Kommentarlimit,
+Comment limit per hour,Kommentarlimit pro Stunde,
+Commercial Rounding,Kaufmännisches Runden,
+Communication Logs,Kommunikationsprotokolle,
+Compare Versions,Versionen vergleichen,
+Compilation warning,Kompilierungswarnung,
+Complete Setup,Einrichtung abschließen,Finish the setup wizard
+Completed By Role,Abgeschlossen durch Rolle,
+Completed By User,Abgeschlossen von Benutzer,
+Condition JSON,Bedingung JSON,
+Configure columns for {0},Spalten für {0} konfigurieren,
+"Configure various aspects of how document naming works like naming series, current counter.","Konfigurieren Sie verschiedene Aspekte der Funktionsweise der Dokumentbenennung, z. B. die Nummernkreise und den aktuellen Zähler.",
+Confirm,Bestätigen,Title of confirmation dialog
+Confirm Deletion of Account,Löschen des Kontos bestätigen,
+"Congratulations on completing the module setup. If you want to learn more you can refer to the documentation <a target=""_blank"" href=""{0}"">here</a>.","Herzlichen Glückwunsch zum Abschluss der Modul-Setup. Wenn Sie mehr erfahren möchten, können Sie sich die Dokumentation <a target=""_blank"" href=""{0}"">hier</a> ansehen.",
+Connect to {},Mit {} verbinden,
+Connected App,Verbundene Anwendung,
+Connected User,Verbundener Benutzer,
+Connection Lost,Verbindung verloren,
+Console Logs can not be deleted,Konsolenprotokolle können nicht gelöscht werden,
+Constraints,Einschränkungen,
+Contact Us,Kontakt,
+Content data shoud be a list,Inhaltsdaten sollten eine Liste sein,
+Copy Link,Link kopieren,
+Copy error to clipboard,Fehler in die Zwischenablage kopieren,
+Country Code Required,Landesvorwahl erforderlich,
+Cr,H,Number system
+Create Letter Head,Briefkopf erstellen,
+Create New,Neuen Eintrag erstellen,Create a new document from list view
+Create a new ...,Neuen Eintrag erstellen ...,
+Create or Edit Print Format,Druckformat erstellen oder bearbeiten,
+Cron format is required for job types with Cron frequency.,Das Cron-Format ist für Auftragstypen mit Cron-Häufigkeit erforderlich.,
+Crop,Zuschneiden,
+Current Job ID,Aktuelle Job-ID,
+Current Value,Aktueller Wert,
+Custom Block Name,Benutzerdefinierter Blockname,
+Custom Blocks,Benutzerdefinierte Blöcke,
+Custom Document Types (Select Permission),"Benutzerdefinierte DocTypes (Berechtigung ""auswählen"")",
+Custom Document Types Limit Exceeded,Limit für benutzerdefinierte DocTypes wurde überschritten,
+Custom Group Search,Benutzerdefinierte Gruppensuche,
+"Custom Group Search if filled needs to contain the user placeholder {0}, eg uid={0},ou=users,dc=example,dc=com","Die benutzerdefinierte Gruppensuche muss den Benutzerplatzhalter {0} enthalten, z.B. uid={0},ou=users,dc=example,dc=com",
+Custom HTML Block,Benutzerdefinierter HTML-Block,
+"Custom LDAP Directoy Selected, please ensure 'LDAP Group Member attribute' and 'Group Object Class' are entered","Benutzerdefiniertes LDAP-Verzeichnis ausgewählt. Stellen Sie sicher, dass „LDAP-Gruppenmitgliedsattribut“ und „Gruppenobjektklasse“ eingegeben sind",
+Custom Label,Benutzerdefinierte Bezeichnung,
+Custom Translation,Benutzerdefinierte Übersetzung,
+Custom field renamed to {0} successfully.,Benutzerdefiniertes Feld erfolgreich in {0} umbenannt.,
+Customize,Anpassen,Button in list view menu
+Cyan,Türkis,
+Dark,Dunkel,
+Dark Theme,Dunkles Design,
+Data Clipped,Daten abgeschnitten,
+Data Import Log,Datenimportprotokoll,
+Database,Datenbank,
+Database Processes,Datenbankprozesse,
+Database Storage Usage By Tables,Datenbankspeichernutzung nach Tabellen,
+Database Version,Datenbankversion,
+Date Range,Datumsbereich,
+Deadlock Occurred,Deadlock aufgetreten,
+Default Template For Field,Standardvorlage für Feld,
+Default User Role,Standard-Benutzerrolle,
+Default User Type,Standard-Benutzertyp,
+Default View,Standardansicht,
+Defaults Updated,Standardeinstellungen aktualisiert,
+Delete,Löschen,Button in list view actions menu
+Delete Account,Konto löschen,
+Delete Kanban Board,Kanban-Board löschen,
+Delete {0} item permanently?,Element {0} endgültig löschen?,Title of confirmation dialog
+Delete {0} items permanently?,{0} Elemente dauerhaft löschen?,Title of confirmation dialog
+Deleting {0} records...,Lösche {0} Einträge...,
+Deleting {0}...,Lösche {0}...,
+Deletion Steps ,Schritte zur Löschung ,
+Delimiter must be a single character,Trennzeichen muss ein einzelnes Zeichen sein,
+Deny,Ablehnen,
+Dependencies,Abhängigkeiten,
+Description to inform the user about any action that is going to be performed,"Beschreibung, um den Benutzer über eine Aktion zu informieren, die durchgeführt werden soll",
+Desk Theme,Schreibtisch-Design,
+Diff,Unterschiede,
+Directory Server,Verzeichnisserver,
+Disable Change Log Notification,Änderungsprotokoll-Benachrichtigung deaktivieren,
+Disable Document Sharing,Dokumentenfreigabe deaktivieren,
+Disable Likes,Likes deaktivieren,
+Disable System Update Notification,Systemaktualisierungsbenachrichtigung deaktivieren,
+Disable Username/Password Login,Anmeldung mit Benutzername und Passwort deaktivieren,
+Discard,Verwerfen,Button in web form
+Discard?,Verwerfen?,
+Discussion Reply,Unterhaltungsantwort,
+Discussion Topic,Unterhaltungsthema,
+Dismiss,Entlassen,Stop showing the onboarding widget.
+Display Depends On (JS),Anzeige ist abhängig von (JS),
+Divider,Trenner,
+Do Not Create New User ,Keinen neuen Benutzer erstellen,
+Do not create new user if user with email does not exist in the system,"Keinen neuen Benutzer anlegen, wenn ein Benutzer mit dieser E-Mail-Adresse nicht bereits im System vorhanden ist",
+Do not have permission to access bucket {0}.,"Sie sind nicht berechtigt, auf Bucket {0} zuzugreifen.",
+Do you still want to proceed?,Wollen Sie trotzdem fortfahren?,
+DocType Layout,DocType-Layout,
+DocType Layout Field,DocType-Layout Feld,
+DocType State,DocType-Status,
+DocType must be a string,DocType muss eine Zeichenfolge sein,
+DocType not supported by Log Settings.,DocType wird von den Log-Einstellungen nicht unterstützt.,
+DocType required,DocType erforderlich,
+DocType {0} does not exist.,DocType {0} existiert nicht.,
+DocType {} not found,DocType {} nicht gefunden,
+Doctype name is limited to {0} characters ({1}),Der DocType-Name ist auf {0} Zeichen begrenzt ({1}),
+Document Linking,Dokumenten-Verknüpfung,
+Document Links Row #{0}: Could not find field {1} in {2} DocType,Dokumentenverknüpfungen Zeile #{0}: Feld {1} konnte nicht in DocType {2} gefunden werden,
+Document Links Row #{0}: Invalid doctype or fieldname.,Dokumentenverknüpfungen Zeile #{0}: Ungültiger DocType oder Feldname.,
+Document Links Row #{0}: Parent DocType is mandatory for internal links,Dokumentenverknüpfungen Zeile #{0}: Übergeordneter DocType ist obligatorisch für interne Links,
+Document Links Row #{0}: Table Fieldname is mandatory for internal links,Dokumentverknüpfungen Zeile #{0}: Tabellenfeldname ist obligatorisch für interne Links,
+Document Name must be a string,Dokumentname muss eine Zeichenkette sein,
+Document Naming Settings,Dokumentenbenennungseinstellungen,
+Document Saved,Dokument gespeichert,
+Document Share Key,Dokumentfreigabeschlüssel,
+Document Share Key Expiry (in Days),Gültigkeitsdauer des Dokumentfreigabeschlüssels (in Tagen),
+Document Type and Function are required to create a number card,"Dokumententyp und Funktion werden benötigt, um eine Nummernkarte zu erstellen",
+Document Types (Select Permissions Only),Dokumententypen (nur „Auswahl“-Berechtigungen),
+Document Types and Permissions,Dokumenttypen und Berechtigungen,
+Document Unlocked,Dokument entsperrt,
+Document has been cancelled,Dokument wurde storniert,
+Document has been submitted,Dokument wurde gebucht,
+Document is in draft state,Das Dokument befindet sich im Entwurfsstatus,
+Document not Relinked,Dokument nicht erneut verknüpft,
+Document renaming from {0} to {1} has been queued,Die Umbenennung des Dokuments von {0} in {1} wurde in die Warteschlange gestellt,
+Document {0} {1} does not exist,Dokument {0} {1} existiert nicht,
+Domain Name,Domain-Name,
+"Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","HTML-Tags wie &lt;script&gt; oder Zeichen wie &lt; oder &gt; nicht kodieren, da diese absichtlich in diesem Feld verwendet werden könnten",
+Download,Herunterladen,Export report
+Drag,Ziehen,
+Drag columns to set order. Column width is set in percentage. The total width should not be more than 100. Columns marked in red will be removed.,"Ziehen Sie die Spalten, um die Reihenfolge festzulegen. Die Spaltenbreite wird in Prozent angegeben. Die Gesamtbreite sollte nicht mehr als 100 betragen. Rot markierte Spalten werden entfernt.",
+Duplicate Entry,Duplizierter Eintrag,
+Edit,Bearbeiten,Button in list view actions menu
+Edit,Bearbeiten,Edit grid row
+Edit DocType,DocType bearbeiten,Button in list view menu
+Edit Existing,Bestehende bearbeiten,
+Edit Footer,Fußzeile bearbeiten,
+Edit Header,Kopfzeile bearbeiten,
+Edit Letter Head,Briefkopf bearbeiten,
+Edit Letter Head Footer,Briefkopf-Fußzeile bearbeiten,
+Edit Print Format,Druckformat bearbeiten,
+Edit your response,Antwort bearbeiten,Button in web form
+Editing {0},Bearbeite {0},
+Either key or IP flag is required.,Entweder der key (Schlüssel) oder das IP-Flag ist erforderlich.,
+Element Selector,Elementauswahl,
+Email Account Disabled.,E-Mail-Konto deaktiviert.,
+Email Queue flushing aborted due to too many failures.,Das Leeren der E-Mail-Warteschlange wurde aufgrund zu vieler Fehler abgebrochen.,
+Email Retry Limit,E-Mail-Wiederholungslimit,
+Email Sent At,E-Mail gesendet am,
+Email Threads on Assigned Document,E-Mail-Threads zum zugewiesenen Dokument,
+Email queue is currently suspended. Resume to automatically send emails.,"Die E-Mail-Warteschlange ist derzeit unterbrochen. Fortsetzen, um automatisch E-Mails zu versenden.",
+Emails,E-Mails,
+Enable Email Notification,E-Mail-Benachrichtigung aktivieren,
+Enable Scheduler,Scheduler aktivieren,
+Enable developer mode to create a standard Print Template,"Aktivieren Sie den Entwicklermodus, um eine Standard-Druckvorlage zu erstellen",
+Enable email notification for any comment or likes received on your Blog Post.,E-Mail-Benachrichtigung für Kommentare oder Likes zu Ihren Blog-Beiträgen aktivieren.,
+"Enable if on click
+opens modal.","Aktivieren, wenn bei Klick
+ein Modal geöffnet wird.",
+Enabled Scheduler,Scheduler aktiviert,
+Enables Calendar and Gantt views.,Aktiviert Kalender- und Gantt-Ansichten.,
+Enabling auto reply on an incoming email account will send automated replies to all the synchronized emails. Do you wish to continue?,"Wenn Sie die automatische Beantwortung für ein eingehendes E-Mail-Konto aktivieren, werden automatische Antworten an alle synchronisierten E-Mails gesendet. Möchten Sie fortfahren?",
+Encrypt Backups,Backups verschlüsseln,
+Encryption key is in invalid format!,Der Verschlüsselungsschlüssel hat ein ungültiges Format!,
+Encryption key is invalid! Please check site_config.json,Verschlüsselungsschlüssel ist ungültig! Bitte überprüfen Sie die Datei site_config.json,
+Ended At,Endete am,
+Endpoints,Endpunkte,
+Ensure the user and group search paths are correct.,"Stellen Sie sicher, dass die Suchpfade für Benutzer und Gruppen korrekt sind.",
+Enter Value,Wert eingeben,Title of prompt dialog
+Enter a name for this {0},Geben Sie einen Namen für dieses {0} ein,
+Error,Fehler,Title of error message in web form
+Error Logs,Fehlerprotokolle,
+Error connecting via IMAP/POP3: {e},Fehler beim Verbinden über IMAP/POP3: {e},
+Error connecting via SMTP: {e},Fehler beim Verbinden über SMTP: {e},
+Error in Client Script,Fehler im Client-Skript,
+Error in Client Script.,Fehler im Client-Skript.,
+Error in Header/Footer Script,Fehler im Kopf-/Fußzeilenskript,
+Error in print format on line {0}: {1},Fehler im Druckformat in Zeile {0}: {1},
+Errors,Fehler,
+Event Frequency,Ereignis-Häufigkeit,
+Event Reminders,Ereignis Erinnerungen,
+Events,Ereignisse,
+Exact Copies,Exakte Kopien,
+Example: Setting this to 24:00 will log out a user if they are not active for 24:00 hours.,"Beispiel: Wenn Sie diesen Wert auf 24:00 setzen, wird ein Benutzer abgemeldet, wenn er 24:00 Stunden lang nicht aktiv ist.",
+Executing...,Wird ausgeführt...,
+Executive,Exekutive,
+Expand,Erweitern,Enlarge code field.
+Experimental,Experimentell,
+Expires On,Verfällt am,
+Export,Exportieren,Button in list view actions menu
+Export Import Log,Import-Log exportieren,
+Export Report: {0},Exportbericht: {0},Export report
+Export all matching rows?,Alle übereinstimmenden Zeilen exportieren?,
+Export all {0} rows?,Alle {0} Zeilen exportieren?,
+Export as zip,Als Zip-Datei exportieren,
+Exported permissions will be force-synced on every migrate overriding any other customization.,Exportierte Berechtigungen werden bei jeder Migration zwangsweise synchronisiert und überschreiben dabei alle anderen Anpassungen.,
+Expression,Ausdruck,
+Expression (old style),Ausdruck (alter Stil),
+Extra Parameters,Zusätzliche Parameter,
+Failed Emails,Fehlgeschlagene E-Mails,
+Failed Job Count,Anzahl fehlgeschlagener Jobs,
+Failed Jobs,Fehlgeschlagene Aufträge,
+Failed Logins (Last 30 days),Fehlgeschlagene Anmeldungen (Letzte 30 Tage),
+Failed to compute request body: {},Fehler beim Berechnen des Anfragekörpers: {},
+Failed to decrypt key {0},Schlüssel {0} konnte nicht entschlüsselt werden,
+Failed to enable scheduler: {0},Konnte Zeitplaner nicht aktivieren: {0},
+Failed to evaluate conditions: {},Die Bedingungen konnten nicht ausgewertet werden: {},
+Failed to generate names from the series,Fehler beim Generieren von Namen aus dem Nummernkreis,
+Failed to generate preview of series,Vorschau des Nummernkreises konnte nicht erstellt werden,
+Failed to get method for command {0} with {1},Methode für den Befehl {0} mit {1} konnte nicht abgerufen werden,
+Failed to optimize image: {0},Fehler beim Optimieren des Bilds: {0},
+Failed to send notification email,Fehler beim Senden der Benachrichtigungs-E-Mail,
+Failing Scheduled Jobs (last 7 days),Fehlgeschlagene geplante Aufträge (letzte 7 Tage),
+Failure Rate,Fehlerrate,
+Fetch on Save if Empty,"Beim Speichern abrufen, falls leer",
+"Field ""title"" is mandatory if ""Website Search Field"" is set.","Das Feld ""Titel"" ist obligatorisch, wenn ""Website-Suchfeld"" eingestellt ist.",
+Field Missing,Feld fehlt,
+Field Orientation (Left-Right),Feldausrichtung (links-rechts),
+Field Orientation (Top-Down),Feldausrichtung (oben-unten),
+Field Template,Feldvorlage,
+Field not permitted in query,Feld in der Abfrage nicht erlaubt,
+Field {0} is referring to non-existing doctype {1}.,Das Feld {0} bezieht sich auf einen nicht existierenden Doctype {1}.,
+Fieldname '{0}' conflicting with a {1} of the name {2} in {3},Feldname '{0}' im Konflikt mit einem {1} mit dem Namen {2} in {3},
+Fieldname called {0} must exist to enable autonaming,"Der Feldname {0} muss existieren, um die automatische Benennung zu ermöglichen",
+Fields `file_name` or `file_url` must be set for File,Felder `file_name` oder `file_url` müssen für die Datei gesetzt sein,
+Fieldtype cannot be changed from {0} to {1},Feldtyp kann nicht von {0} auf {1} geändert werden,
+File Storage,Dateispeicher,
+Filtered By,Gefiltert nach,
+Find '{0}' in ...,Finde '{0}' in ...,
+Finished At,Beendet am,
+Folder Name,Ordnername,
+Following Report Filters have missing values:,Die folgenden Berichtsfilter haben fehlende Werte:,
+Following fields have invalid values:,Folgende Felder haben ungültige Werte:,
+Following fields have missing values,Den folgende Feldern fehlen Werte,
+Following links are broken in the email content: {0},Die folgenden Links in der E-Mail sind defekt: {0},
+"Footer ""Powered By""","Fußzeile ""Powered by""",
+Footer Based On,Fußzeile basierend auf,
+Footer Content,Inhalt der Fußzeile,
+Footer HTML set from attachment {0},Fußzeilen-HTML aus Anhang {0} festgelegt,
+Footer Image,Fußzeilenbild,
+Footer Script,Fußzeilenskript,
+"For Links, enter the DocType as range.
+For Select, enter list of Options, each on a new line.","Für Links geben Sie den DocType als Bereich ein.
+Für Auswahl geben Sie eine Liste von Optionen ein, jede in einer neuen Zeile.",
+"For multiple addresses, enter the address on different line. e.g. test@test.com ⏎ test1@test.com",Bei mehreren Adressen geben Sie bitte jede Adresse in einer neuen Zeile ein. z.B. test@test.com ⏎ test1@test.com,
+Force Re-route to Default View,Umleitung zur Standardansicht erzwingen,
+Force Stop job,Job stoppen erzwingen,
+Force Web Capture Mode for Uploads,Web-Capture-Modus für Uploads erzwingen,
+Form,Formular,
+Form Dict,Formular Dict,
+Form Tour,Formular-Tour,
+Form Tour Step,Formular-Tour-Schritt,
+Frappe Light,Frappe Hell,
+Free,Frei,Image Cropper
+From version,Von Version,
+Function {0} is not whitelisted.,Funktion {0} ist nicht freigegeben.,
+General,Allgemein,
+Generate Random Password,Zufälliges Passwort generieren,
+Get Backup Encryption Key,Backup-Verschlüsselungsschlüssel abrufen,
+Get Header and Footer wkhtmltopdf variables,Variablen für Kopf- und Fußzeilen abrufen,
+Get OpenID Configuration,OpenID-Konfiguration abrufen,
+Get PDF,PDF herunterladen,
+Get more insights with,Erhalten Sie mehr Einblicke mit,
+Get notified when an email is received on any of the documents assigned to you.,"Benachrichtigen, wenn eine E-Mail auf einem der Ihnen zugewiesenen Dokumente empfangen wird.",
+Go to this URL after completing the form,Nach dem Ausfüllen des Formulars diese URL aufrufen,
+Google Calendar - Contact / email not found. Did not add attendee for -<br>{0},Google Kalender - Kontakt / E-Mail nicht gefunden. Teilnehmer wurde nicht hinzugefügt für -<br>{0},
+Google Drive Picker Enabled,Google Drive Picker aktiviert,
+Google Meet Link,Google Meet-Link,
+Graph,Diagramm,
+Gray,Grau,
+Green,Grün,
+Grid Shortcuts,Raster-Kurzbefehle,
+Group Object Class,Gruppenobjektklasse,
+Handled Emails,Verarbeitete E-Mails,
+Has Next Condition,Hat nächste Bedingung,
+Header Script,Kopfzeilen-Skript,
+Header/Footer scripts can be used to add dynamic behaviours.,"Kopf-/Fußzeilen-Skripte können verwendet werden, um dynamische Verhaltensweisen hinzuzufügen.",
+Hello,Hallo,
+Help HTML,HTML-Hilfe,
+"Help: To link to another record in the system, use ""/app/note/[Note Name]"" as the Link URL. (don't use ""http://"")","Hilfe: Um einen Link zu einem anderen Datensatz im System zu erstellen, verwenden Sie ""/app/note/[Name der Notiz]"" als Link URL. (ohne ""http://"" und Domain)",
+Helpful,Hilfreich,
+Hidden Fields,Versteckte Felder,
+Hide Buttons,Buttons ausblenden,
+Hide Descendants,Nachkommen ausblenden,
+Hide Error,Fehler ausblenden,
+Hide Preview,Vorschau verbergen,
+"Hide Previous, Next and Close button on highlight dialog.","Die Schaltflächen Zurück, Weiter und Schließen ausblenden.",
+Hide descendant records of <b>For Value</b>.,Untergeordnete Datensätze von <b>Für Wert</b> ausblenden.,
+"I guess you don't have access to any workspace yet, but you can create one just for yourself. Click on the <b>Create Workspace</b> button to create one.<br>","Vermutlich haben Sie noch keinen Zugang zu einem Arbeitsbereich, aber Sie können einen für sich selbst erstellen. Klicken Sie dafür auf die Schaltfläche <b>Arbeitsbereich erstellen</b>.<br>",
+ID (name),ID (Name),
+"IDs must contain only alphanumeric characters, not contain spaces, and should be unique.","IDs dürfen nur alphanumerische Zeichen enthalten, keine Leerzeichen und sollten eindeutig sein.",
+IMAP Details,IMAP-Details,
+IMAP Folder,IMAP-Ordner,
+"If checked, negative numeric values of Currency, Quantity or Count would be shown as positive","Wenn aktiviert, werden negative numerische Werte von Währung, Menge oder Anzahl als positiv angezeigt",
+"If set, only user with these roles can access this chart. If not set, DocType or Report permissions will be used.","Wenn diese Option gesetzt ist, können nur Benutzer mit diesen Rollen auf dieses Diagramm zugreifen. Wenn nicht festgelegt, werden die Berechtigungen für den zugehörigen DocType oder Report verwendet.",
+"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
+","Wenn die Bedingung erfüllt ist, wird der Benutzer mit den Punkten belohnt. z.B. doc.status == 'Closed'
+",
+"If unchecked, the value will always be re-fetched on save.","Wenn diese Option deaktiviert ist, wird der Wert beim Speichern immer erneut abgerufen.",
+If you have recently restored the site you may need to copy the site config contaning original Encryption Key.,"Falls Sie diese Instanz kürzlich wiederhergestellt haben, müssen Sie möglicherweise noch den Verschlüsselungsschlüssel des vorherigen Systems in die Site Config übernehmen.",
+Illegal template,Ungültige Vorlage,
+Image Height,Bildhöhe,
+Image Width,Bildbreite,
+Image link '{0}' is not valid,Bild-Link '{0}' ist ungültig,
+Image optimized,Bild optimiert,
+Image: Corrupted Data Stream,Bild: Beschädigter Datenstrom,
+Implement `clear_old_logs` method to enable auto error clearing.,"Implementieren Sie die Methode `clear_old_logs`, um die automatische Fehlerbereinigung zu aktivieren.",
+Import,Importieren,Button in list view menu
+"Import timed out, please re-try.","Zeitüberschreitung beim Importieren, bitte erneut versuchen.",
+In List Filter,In Listenfilter,
+In Read Only Mode,"Im ""Nur Lesen"" Modus",
+Inavlid Values,Ungültige Werte,
+Include Name Field,Feld „Name“ einbeziehen,
+Incoming (POP/IMAP) Settings,Eingehende (POP/IMAP) Einstellungen,
+Incoming Emails (Last 7 days),Eingehende E-Mails (Letzte 7 Tage),
+Incoming Server,Eingehender Server,
+Incoming Settings,Eingehende Einstellungen,
+Insert Image in Markdown,Bild in Markdown einfügen,
+Instructions,Anweisungen,
+Insufficient Permission Level for {0},Unzureichende Berechtigungsstufe für {0},
+Insufficient Permissions for deleting Report,Unzureichende Berechtigungen um Bericht zu löschen,
+Insufficient Permissions for editing Report,Unzureichende Berechtigungen um Bericht zu bearbeiten,
+Insufficient attachment limit,Unzureichende Begrenzung für Anhänge,
+Intro,Einführung,
+Intro Video URL,Intro Video-URL,
+"Invalid ""mandatory_depends_on"" expression",Ungültiger Ausdruck in Bedingung für Pflichtfeld,
+Invalid Action,Ungültige Aktion,
+Invalid Condition: {},Ungültige Bedingung: {},
+Invalid DocType,Ungültiger DocType,
+Invalid DocType: {0},Ungültiger DocType: {0},
+Invalid Fieldname,Ungültiger Feldname,
+Invalid File URL,Ungültige Datei-URL,
+Invalid Naming Series: {},Ungültiger Nummernkreis: {},
+Invalid Operation,Ungültige Operation,
+Invalid Outgoing Mail Server or Port: {0},Ungültiger Postausgang Server oder Port: {0},
+Invalid Parameters.,Ungültige Parameter.,
+Invalid Phone Number,Ungültige Telefonnummer,
+Invalid Table Fieldname,Ungültiger Tabellenfeldname,
+Invalid Webhook Secret,Ungültiges Webhook Geheimnis,
+Invalid aggregate function,Ungültige Aggregatfunktion,
+Invalid docstatus,Ungültiger Status,
+Invalid name type (integer) for varchar name column,Ungültiger Namenstyp (Ganzzahl) für die Varchar-Namensspalte,
+Invalid naming series {}: dot (.) missing,Ungültiger Nummernkreis {}: Punkt (.) fehlt,
+Invalid redirect regex in row #{}: {},Ungültige Weiterleitungs-Regex in Zeile #{}: {},
+Invalid request arguments,Ungültige Anfrageargumente,
+Invalid values for fields:,Ungültige Werte für Felder:,Error message in web form
+Is Custom,Ist benutzerdefiniert,
+Is Hidden,Ist versteckt,
+Is Query Report,Ist Abfragebericht,
+Is Remote Request?,Ist dies eine Remote-Anfrage?,
+Is System Generated,Wurde vom System generiert,
+Is Table Field,Ist Tabellenfeld,
+Is Virtual,Ist virtuell,
+JS Message,JS-Nachricht,
+Jane Doe,Beate Beispiel,
+Job ID,Job-ID,
+Job Info,Jobinfo,
+Job Name,Jobname,
+Job Status,Jobstatus,
+Job is not running.,Job läuft nicht.,
+Join video conference with {0},Videokonferenz mit {0} beitreten,
+Kanban Settings,Kanban-Einstellungen,Button in kanban view menu
+LDAP Auth,LDAP-Authentifizierung,
+LDAP Custom Settings,LDAP-Benutzereinstellungen,
+LDAP Group Member attribute,LDAP-Gruppenmitgliedsattribut,
+"LDAP Search String must be enclosed in '()' and needs to contian the user placeholder {0}, eg sAMAccountName={0}","Der LDAP-Suchstring muss in '()' eingeschlossen sein und den Benutzerplatzhalter {0} enthalten, z.B. sAMAccountName={0}",
+LDAP Search and Paths,LDAP-Suche und Pfade,
+LDAP Server Settings,LDAP-Servereinstellungen,
+LDAP search path for Groups,LDAP-Suchpfad für Gruppen,
+LDAP search path for Users,LDAP-Suchpfad für Benutzer,
+LDAP settings incorrect. validation response was: {0},LDAP-Einstellungen falsch. Validierungsantwort: {0},
+Last 10 active users,Letzte 10 aktive Benutzer,
+Last Heartbeat,Letzter Herzschlag,
+Last Reset Password Key Generated On,Letzter Schlüssel zum Zurücksetzen des Passworts Erzeugt am,
+Left,Links,alignment
+Left Bottom,Links unten,
+Left Center,Mitte links,
+Length of passed data array is greater than value of maximum allowed label points!,Die Länge des übergebenen Datenarrays ist größer als der Wert der maximal erlaubten Beschriftungspunkte!,
+Let us continue with the onboarding,Lassen Sie uns mit dem Onboarding fortfahren,
+Let's set up your account,Richten wir Ihr Konto ein,
+Letter Head Scripts,Briefkopf-Skripte,
+Letter Head cannot be both disabled and default,Briefkopf kann nicht gleichzeitig deaktiviert und Standard sein,
+License,Lizenz,
+License Type,Lizenztyp,
+Light,Hell,
+Light Blue,Hellblau,
+Light Theme,Helles Design,
+Like limit,Like Limit,
+Like limit per hour,Like Limit pro Stunde,
+Like on {0}: {1},„Gefällt mir“ für {0}: {1},
+Link Count,Link-Anzahl,
+Link Details,Link-Details,
+Link To in Row,„Link zu“ in Zeile,
+Link Type,Linktyp,
+Link Type in Row,„Linktyp“ in Zeile,
+"Link for About Us Page is ""/about"".",Der Link zur Seite „Über uns“ lautet „/about“.,
+"Link that is the website home page. Standard Links (home, login, products, blog, about, contact)","Pfad, der als Startseite verwendet werden soll. Standardpfade: home, login, products, blog, about, contact",
+List / Search Settings,Listen-/Sucheinstellungen,
+List Columns,Listenspalten,
+List Settings,Listeneinstellungen,Button in list view menu
+Load More Communications,Weitere Kommunikation laden,Form timeline
+Loading user profile,Benutzerprofil wird geladen,
+Log DocType,Protokoll-DocType,
+Log In To {0},Anmelden bei {0},
+Log Index,Protokollindex,
+Log out,Abmelden,
+Login Failed please try again,Login fehlgeschlagen. Bitte erneut versuchen.,
+Login Page,Anmeldeseite,
+Login To {0},Anmelden bei {0},
+Login is required to see web form list view. Enable {0} to see list settings,"Um die Listenansicht des Webformulars zu sehen, ist eine Anmeldung erforderlich. Aktivieren Sie {0}, um die Listeneinstellungen zu sehen",
+Login link sent to your email,Ein Anmeldelink wurde an Ihre E-Mail-Adresse gesendet,
+Login to start a new discussion,"Anmelden, um eine neue Unterhaltung zu beginnen",
+Login to {0},Anmelden bei {0},
+Login with Email Link,Mit E-Mail-Link anmelden,
+Login with email link,Mit E-Mail-Link anmelden,
+Login with email link expiry (in minutes),Gültigkeitsdauer des E-Mail-Links (in Minuten),
+Login with username and password is not allowed.,Login mit Benutzername und Passwort ist nicht erlaubt.,
+Logs To Clear,Zu löschende Protokolle,
+Logs to Clear,Zu löschende Protokolle,
+Looks like you haven’t added any third party apps.,Wie es aussieht haben Sie keine Drittanbieter-Apps hinzugefügt.,
+MIT License,MIT-Lizenz,
+Make Attachments Public by Default, Anhänge im Standard als öffentlich markieren,
+Make sure to configure a Social Login Key before disabling to prevent lockout,"Stellen Sie sicher, dass Sie vor der Deaktivierung einen Social Login Key konfigurieren, um eine Sperre zu verhindern",
+Mandatory Depends On (JS),Bedingung für Pflichtfeld (JS),
+Mandatory fields required:,Pflichtfelder erforderlich:,Error message in web form
+Map,Karte,
+Margin Bottom,Abstand unten,
+Margin Left,Abstand links,
+Margin Right,Abstand rechts,
+Margin Top,Abstand oben,
+MariaDB Variables,MariaDB-Variablen,
+Max File Size (MB),Max. Dateigröße (MB),
+Max Height,Max. Höhe,
+Max auto email report per user,Höchstzahl automatischer E-Mail-Berichte pro Benutzer,
+Maximum Attachment Limit of {0} has been reached for {1} {2}.,Die Höchstgrenze für Anhänge von {0} wurde für {1} {2} erreicht.,
+Maximum attachment limit of {0} has been reached.,Die Höchstgrenze für Anhänge von {0} wurde erreicht.,
+"Maximum points allowed after multiplying points with the multiplier value
+(Note: For no limit leave this field empty or set 0)","Maximal erlaubte Punkte nach Multiplikation mit dem Multiplikatorwert
+(Hinweis: Für kein Limit lassen Sie dieses Feld leer oder setzen Sie es auf 0)",
+Meets Condition?,Bedingungen erfüllen?,
+Members,Mitglieder,
+Memory Usage,Arbeitsspeicherauslastung,
+Message,Nachricht,Default title of the message dialog
+Message Sent,Mitteilung gesendet,
+Message Type,Nachrichtentyp,
+Message to be displayed on successful completion,"Nachricht, die nach erfolgreichem Abschluss angezeigt werden soll",
+Messages,Nachrichten,
+Method Not Allowed,Methode nicht erlaubt,
+Method is required to create a number card,"Methode wird benötigt, um eine Nummernkarte zu erstellen",
+Mid Center,Mittig,
+Misconfigured,Falsch konfiguriert,
+Missing DocType,Fehlender DocType,
+Missing Field,Fehlendes Feld,
+Missing Filters Required,Fehlende Filter erforderlich,
+Missing Permission,Fehlende Berechtigung,
+Missing Value,Fehlender Wert,
+Mobile,Mobil,
+Modal Trigger,Modal-Auslöser,
+Module (for export),Modul (für Export),
+Module HTML,Modul HTML,
+Module Profile Name,Modulprofil Name,
+Module {} not found,Modul {} nicht gefunden,
+Monthly Rank,Monatlicher Rang,
+Most probably your password is too long.,Wahrscheinlich ist Ihr Passwort zu lang.,
+Move to next step when clicked inside highlighted area.,"Zum nächsten Schritt bewegen, wenn innerhalb des markierten Bereichs geklickt wird.",
+Mozilla doesn't support :has() so you can pass parent selector here as workaround,"Mozilla unterstützt :has() nicht, daher können Sie hier den übergeordneten Selektor als Workaround übergeben",
+"Must be enclosed in '()' and include '{0}', which is a placeholder for the user/login name. i.e. (&(objectclass=user)(uid={0}))","Muss in '()' eingeschlossen sein und '{0}' enthalten, was ein Platzhalter für den Benutzer-/Loginnamen ist. d.h. (&(objectclass=user)(uid={0}))",
+NOTE: This box is due for depreciation. Please re-setup LDAP to work with the newer settings,"HINWEIS: Dieses Feld ist veraltet. Bitte richten Sie LDAP neu ein, um mit den neueren Einstellungen zu arbeiten",
+"Name already taken, please set a new name","Name bereits vergeben, bitte einen neuen Namen festlegen",
+"Naming Options:
+<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present)</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>
+<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","Benennungsoptionen:
+<ol><li><b>field:[fieldname]</b> - Nach Feld</li><li><b>naming_series:</b> - Nach Nummernkreis (ein Feld namens naming_series muss vorhanden sein)</li><li><b>Prompt</b> - Aufforderung zur Eingabe eines Namens</li><li><b>[series]</b> - Zähler nach Präfix (durch einen Punkt getrennt); zum Beispiel PRE.#####</li>
+<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Ersetzt alle Wörter in geschweiften Klammern (Feldnamen, Datumskürzel (DD, MM, YY), Zähler) durch ihren Wert. Außerhalb der geschweiften Klammern können beliebige Zeichen verwendet werden.</li></ol>",
+Navigate list down,Liste nach unten navigieren,Description of a list view shortcut
+Navigate list up,Liste nach oben navigieren,Description of a list view shortcut
+Navigation Settings,Navigationseinstellungen,
+Need Workspace Manager role to edit private workspace of other users,"Sie benötigen die Rolle des Workspace Managers, um den privaten Arbeitsbereich anderer Benutzer zu bearbeiten",
+Network Printer Settings,Netzwerkdrucker-Einstellungen,
+New Document Form,Neues Dokumentenformular,
+New Users (Last 30 days),Neue Benutzer (Letzte 30 Tage),
+New Workspace,Neuer Arbeitsbereich,
+New password cannot be same as old password,Das neue Passwort darf nicht mit dem alten Passwort identisch sein,
+Newly created user {0} has no roles enabled.,Der neu erstellte Benutzer {0} hat keine aktivierten Rollen.,
+Newsletter Attachment,Newsletter-Anhang,
+Newsletter must be published to send webview link in email,"Newsletter muss veröffentlicht werden, um Webview-Link in der E-Mail zu senden",
+Newsletters,Newsletter,
+Next,Weiter,Go to next slide
+Next Execution,Nächste Ausführung,
+Next Form Tour,Nächste Formular-Tour,
+Next Step Condition,Bedingung für den nächsten Schritt,
+Next on Click,Weiter bei Klick,
+No,Nein,Checkbox is not checked
+No,Nein,Dismiss confirmation dialog
+No Data to Show,Keine Daten anzuzeigen,
+No Images,Keine Bilder,
+No Items Found,Keine Einträge gefunden,
+No Letterhead,Kein Briefkopf,
+No RQ Workers connected. Try restarting the bench.,"Keine RQ-Worker verbunden. Versuchen Sie, die Bench neu zu starten.",
+No Results found,Keine Ergebnisse gefunden,
+No Roles Specified,Keine Rollen festgelegt,
+No Select Field Found,Kein Auswahlfeld gefunden,
+No activities to show,Keine Aktivitäten anzuzeigen,
+No broken links found in the email content,Keine kaputten Links im E-Mail-Inhalt gefunden,
+No changes made because old and new name are the same.,"Keine Änderungen vorgenommen, weil der alte und neue Name gleich sind.",
+No changes to sync,Keine Änderungen zu synchronisieren,
+No changes to update,Keine Änderungen zu aktualisieren,
+No comments yet. ,Noch keine Kommentare. ,
+No permission to '{0}' {1},Keine Berechtigung um '{0}' {1},"{0} = verb, {1} = object"
+No {0},Keine {0},
+No {0} Found,Kein {0} gefunden,
+No {0} found with matching filters. Clear filters to see all {0}.,"Keine {0} mit passenden Filtern gefunden. Löschen Sie Filter, um alle {0} -Einträge zu sehen.",
+Normalized Copies,Normalisierte Kopien,
+Normalized Query,Normalisierte Abfrage,
+Not Helpful,Nicht hilfreich,
+Not Permitted to read {0},Keine Berechtigung zum Lesen von {0},
+Not Set,Nicht eingetragen,Field value is not set
+Not allowed to create custom Virtual DocType.,Das Erstellen eines benutzerdefinierten virtuellen DocTypes ist nicht zulässig.,
+Not allowed via controller permission check,Nicht erlaubt über Controller-Berechtigungsprüfung,
+Note: Etc timezones have their signs reversed.,"Hinweis: Bei ""Etc""-Zeitzonen sind die Vorzeichen umgekehrt.",
+Note: Your request for account deletion will be fulfilled within {0} hours.,Hinweis: Ihr Antrag auf Kontolöschung wird innerhalb von {0} Stunden bearbeitet.,
+Nothing New,Keine Neuigkeiten,
+Nothing left to redo,Nichts mehr zu wiederholen,
+Nothing left to undo,Nichts mehr rückgängig zu machen,
+Number Card Name,Kartenname,
+Number of Queries,Anzahl der Abfragen,
+"Number of attachment fields are more than {}, limit updated to {}.","Anzahl der Anhangsfelder ist größer als {}, Limit auf {} aktualisiert.",
+Number of backups must be greater than zero.,Anzahl der Backups muss größer als Null sein.,
+Number of days after which the document Web View link shared on email will be expired,"Anzahl der Tage, nach denen der per E-Mail geteilte Web View-Link des Dokuments abläuft",
+Number of keys,Anzahl Schlüssel,
+Number of onsite backups,Anzahl der Backups vor Ort,
+OAuth,OAuh,
+OAuth Client Role,OAuth-Client-Rolle,
+OAuth Error,OAuth-Fehler,
+"OAuth has been enabled but not authorised. Please use ""Authorise API Access"" button to do the same.","OAuth wurde aktiviert, aber nicht autorisiert. Bitte verwenden Sie die Schaltfläche „API-Zugang autorisieren“, um dies zu tun.",
+OTP Secret Reset - {0},OTP Geheimnis zurücksetzen - {0},
+Occurrences,Vorkommnisse,
+Offset X,Versatz X,
+Offset Y,Versatz Y,
+Old and new fieldnames are same.,Alte und neue Feldnamen sind gleich.,
+Oldest Unscheduled Job,Ältester ungeplanter Auftrag,
+On Hold,Zurückgestellt,
+On Payment Authorization,Bei Zahlungsautorisierung,
+Onboard,Für Onboarding hervorheben,
+Onboarding Name,Onboarding-Name,
+Onboarding Status,Onboarding-Status,
+Onboarding complete,Onboarding abgeschlossen,
+Only Workspace Manager can edit public workspaces,Nur der Workspace Manager kann öffentliche Arbeitsbereiche bearbeiten,
+Only change this if you want to use other S3 compatible object storage backends.,"Ändern Sie dies nur, wenn Sie andere S3-kompatible Objektspeicher-Backends verwenden möchten.",
+Only for,Nur für,
+Only reports of type Report Builder can be deleted,Nur Berichte aus dem Berichterstellungswerkzeug können gelöscht werden,
+Only reports of type Report Builder can be edited,Nur Berichte aus dem Berichterstellungswerkzeug können bearbeitet werden,
+Only {0} emailed reports are allowed per user.,Pro Benutzer sind nur {0} per E-Mail versandte Berichte erlaubt.,
+Oops! Something went wrong.,Hoppla! Etwas ist schief gelaufen.,
+Open,Offen,Access
+Open Communication,Kommunikation öffnen,
+Open in a new tab,In einer neuen Registerkarte öffnen,
+Open list item,Listenelement öffnen,Description of a list view shortcut
+OpenID Configuration,OpenID-Konfiguration,
+Optimize,Optimieren,
+Optimizing image...,Bild optimieren...,
+Options for Rating field can range from 3 to 10,Optionen für Bewertungsfeld können zwischen 3 und 10 liegen,
+Outgoing (SMTP) Settings,Ausgehende (SMTP) Einstellungen,
+Outgoing Emails (Last 7 days),Ausgehende E-Mails (Letzte 7 Tage),
+Outgoing Server,Ausgehender Server,
+Outgoing Settings,Ausgehende Einstellungen,
+PDF Page Height (in mm),PDF-Seitenhöhe (in mm),
+PDF Page Width (in mm),PDF-Seitenbreite (in mm),
+"PDF printing via ""Raw Print"" is not supported.",Der PDF-Druck über „Raw Print“ wird nicht unterstützt.,
+Package,Paket,
+Package Import,Paket-Import,
+Package Name,Paketname,
+Package Release,Paket-Release,
+Packages,Pakete,
+Page Break,Seitenumbruch,
+Page Height (in mm),Seitenhöhe (in mm),
+Page Margins,Seitenränder,
+Page Number,Seitennummer,
+Page Route,Seitenpfad,
+Page Size,Seitengröße,
+Page Title,Seitentitel,
+Page Width (in mm),Seitenbreite (in mm),
+Page height and width cannot be zero,Seitenhöhe und -Breite können nicht Null sein,
+"Page to show on the website
+","Auf der Website anzuzeigende Seite
+",
+Parent DocType,Übergeordneter DocType,
+Parent Document Type,Übergeordneter DocType,
+Parent Document Type is required to create a number card,"Übergeordneter DocType wird benötigt, um Zahlenkarte zu erstellen",
+Parent Element Selector,Selektor für übergeordnetes Element,
+Parent Field,Übergeordnetes Feld,
+Parent Missing,Stammeintrag fehlt,
+Parent Page,Übergeordnete Seite,
+Parent document type is required to create a dashboard chart,"Übergeordneter Dokumententyp wird benötigt, um ein Dashboard-Diagramm zu erstellen",
+Parentfield not specified in {0}: {1},Das übergeordnete Feld wurde in {0}: {1} nicht angegeben,
+"Parenttype, Parent and Parentfield are required to insert a child record","Übergeordneter Typ, übergeordnetes Element und übergeordnetes Feld sind erforderlich, um einen untergeordneten Datensatz einzufügen",
+Partial,Teilweise,
+Partially Sent,Teilweise gesendet,
+Pass,Erfolgreich,
+Password Email Sent,Passwort E-Mail gesendet,
+Password cannot be filtered,Passwort kann nicht gefiltert werden,
+Password missing in Email Account,Passwort fehlt im E-Mail-Konto,
+Password not found for {0} {1} {2},Passwort für {0} {1} {2} nicht gefunden,
+Password size exceeded the maximum allowed size,Passwort überschreitet die maximal zulässige Länge,
+Password size exceeded the maximum allowed size.,Passwort überschreitet die maximal zulässige Länge.,
+Passwords do not match,Passwörter stimmen nicht überein,
+Patch type {} not found in patches.txt,Patch-Typ {} nicht in patches.txt gefunden,
+Path {0} it not a valid path,{0} ist kein gültiger Pfad,
+Payload Count,Nutzlast Anzahl,
+Pending Emails,Ausstehende E-Mails,
+Pending Jobs,Ausstehende Aufträge,
+Permission Manager,Berechtigungs-Manager,
+Permission Query,Berechtigungsabfrage,
+Permissions Error,Berechtigungsfehler,
+Permitted Roles,Erlaubte Rollen,
+Personal Data Deletion Step,Schritt zum Löschen personenbezogener Daten,
+Phone Number {0} set in field {1} is not valid.,Telefonnummer {0} im Feld {1} ist ungültig.,
+Pink,Rosa,
+Plain Text,Einfacher Text,
+Please Authorize OAuth for Email Account {},Bitte autorisieren Sie OAuth für das E-Mail-Konto {},
+Please attach an image file to set HTML for Footer.,"Bitte fügen Sie eine Bilddatei an, um HTML für die Fußzeile festzulegen.",
+Please attach an image file to set HTML for Letter Head.,"Bitte fügen Sie eine Bilddatei an, um HTML für den Briefkopf festzulegen.",
+Please attach the package,Bitte das Paket anhängen,
+Please check OpenID Configuration URL,Bitte überprüfen Sie die OpenID-Konfigurations-URL,
+Please check your email login credentials.,Bitte überprüfen Sie Ihre E-Mail-Anmeldedaten.,
+Please click on the following link and follow the instructions on the page. {0},Bitte klicken Sie auf den folgenden Link und folgen Sie den Anweisungen auf der Seite. {0},
+Please delete the field from {0} or add the required doctype.,Bitte löschen Sie das Feld von {0} oder fügen Sie den erforderlichen DocType hinzu.,
+Please enable {} before continuing.,Bitte aktivieren Sie {} bevor Sie fortfahren.,
+Please enter OpenID Configuration URL,Bitte geben Sie die OpenID Konfigurations-URL ein,
+Please enter a valid email address.,Bitte geben Sie eine gültige E-Mail-Adresse ein.,
+Please enter both your email and message so that we can get back to you. Thanks!,"Bitte geben Sie sowohl Ihre E-Mail-Adresse als auch Ihre Nachricht an, damit wir uns bei Ihnen melden können. Vielen Dank!",
+Please enter the password for: <b>{0}</b>,Bitte geben Sie das Passwort ein für: <b>{0}</b>,Email Account
+Please enter your new password.,Bitte geben Sie Ihr neues Passwort ein.,
+Please enter your old password.,Bitte geben Sie Ihr altes Passwort ein.,
+Please login to post a comment.,"Bitte melden Sie sich an, um einen Kommentar zu schreiben.",
+Please remove the printer mapping in Printer Settings and try again.,Bitte entfernen Sie die Druckerzuordnung in den Druckereinstellungen und versuchen Sie es erneut.,
+Please select a country code for field {1}.,Bitte wählen Sie einen Ländercode für das Feld {1} aus.,
+Please select prefix first,Bitte zuerst Präfix auswählen,
+Please select the LDAP Directory being used,Bitte wählen Sie das zu verwendende LDAP Verzeichnis,
+Please set Dropbox access keys in site config or doctype,Bitte setzen Sie die Dropbox-Zugriffsschlüssel in der Site Config oder im DocType,
+Please set the document name,Bitte geben Sie den Dokumentnamen ein,
+Please set the series to be used.,Bitte legen Sie die zu verwendende Serie fest.,
+Please setup default outgoing Email Account from Settings > Email Account,Bitte legen Sie das Standard-E-Mail-Konto unter Einstellungen > E-Mail-Konto fest,
+Please specify a valid parent DocType for {0},Bitte geben Sie einen gültigen übergeordneten DocType für {0} an,
+Please update {} before continuing.,"Bitte aktualisieren Sie {}, bevor Sie fortfahren.",
+Please use a valid LDAP search filter,Bitte verwenden Sie einen gültigen LDAP-Suchfilter,
+Please visit https://frappecloud.com/docs/sites/migrate-an-existing-site#encryption-key for more information.,Bitte besuchen Sie https://frappecloud.com/docs/sites/migrate-an-existing-site#encryption-key für weitere Informationen.,
+Polling,Regelmäßige Abfrage,
+Popover Element,Popover-Element,
+Popover or Modal Description,Popover- oder Modal-Beschreibung,
+"Post it here, our mentors will help you out.","Posten Sie es hier, unsere Mentoren werden Ihnen helfen.",
+Posting Timestamp,Zeitstempel der Buchung,
+Prepared report render failed,Das Rendern des vorbereiteten Berichts ist fehlgeschlagen,
+Prepend the template to the email message,Vorlage oberhalb der Email-Nachricht einfügen,
+Preview of generated names,Vorschau der generierten Namen,
+Preview type,Vorschautyp,
+Preview:,Vorschau:,
+Previous,Vorhergehende,Go to previous slide
+Print,Drucken,Button in list view actions menu
+Print Format Builder Beta,Format-Builder Beta drucken,
+Print Format Error,Druckformatfehler,
+Print Format Field Template,Druckformat Feldvorlage,
+Print Heading,Druck-Kopfzeile,
+Printer mapping not set.,Druckerzuordnung nicht gesetzt.,
+Private Files (MB),Private Dateien (MB),
+Proceed,Fortfahren,
+Profile,Profil,
+Public Files (MB),Öffentliche Dateien (MB),
+Publish,Veröffentlichen,
+Publish as a web page,Als Webseite veröffentlichen,
+Publishing Dates,Veröffentlichungsdatum,
+Purple,Lila,
+Put on Hold,Zurückstellen,
+Query Parameters,Abfrageparameter,
+Query must be of SELECT or read-only WITH type.,Die Abfrage muss vom Typ SELECT oder Read-Only WITH sein.,
+Queue,Warteschlange,
+Queue Status,Status der Warteschlange,
+Queue Type(s),Warteschlange Typ(en),
+Queue(s),Warteschlange(n),
+Queued At,Eingereiht am,
+Queued By,Eingereiht von,
+Queued {0} emails,{0} E-Mails in der Warteschlange,
+Queues,Warteschlangen,
+Queuing emails...,E-Mails in die Warteschlange stellen...,
+Quick List Filter,Schnelllisten-Filter,
+Quoting must be between 0 and 3,Einstellung für CSV-Anführungszeichen muss zwischen 0 und 3 liegen,
+Random,Zufällig,
+Rank,Rang,
+Rate limit for email link login,Ratenbegrenzung für die Anmeldung per E-Mail-Link,
+Raw Printing Setting,Einstellung für Rohdruck,
+Raw Printing Settings,Einstellung für Rohdruck,
+Re:,AW:,
+Read Only Depends On (JS),Bedingungen für Schreibschutz (JS),
+Read Only Mode,Nur Lese-Modus,
+Realtime (SocketIO),Echtzeit (SocketIO),
+Rebuilding of tree is not supported for {},Die Neuberechnung des Baums wird für {} nicht unterstützt,
+Received an invalid token type.,Es wurde ein ungültiger Tokentyp empfangen.,
+Recents,Kürzlich aufgerufen,
+Recursive Fetch From,Rekursives Abrufen von,
+Red,Rot,
+Redirect URI,Umleitungs-URI,
+Redirect to this URL after successful confirmation.,Nach erfolgreicher Bestätigung zu dieser URL weiterleiten.,
+Referance Doctype and Dashboard Name both can't be used at the same time.,Referenz-DocType und Dashboard-Name können nicht gleichzeitig verwendet werden.,
+Reference DocType,Referenz DocType,
+Reference Document Name,Name des Referenzdokuments,
+Refreshing,Aktualisiere,Document count in list view
+Release Notes,Versionshinweise,
+Remove Failed Jobs,Fehlgeschlagene Jobs entfernen,
+Remove page break,Seitenumbruch entfernen,
+Remove section,Abschnitt entfernen,
+Rename Fieldname,Feldname umbenennen,
+Render labels to the left and values to the right in this section,Beschriftungen nach links und Werte nach rechts in diesem Abschnitt anordnen,
+"Report Name, Report Field and Fucntion are required to create a number card","Zum Erstellen einer Nummernkarte sind Berichtsname, Berichtsfeld und Funktion erforderlich",
+"Report initiated, click to view status","Bericht initiiert. Klicken Sie hier, um den Status anzuzeigen",
+Report limit reached,Berichtsgrenze erreicht,
+Report {0} deleted,Bericht {0} gelöscht,
+Report {0} saved,Bericht {0} gespeichert,
+Request Body,Body anfordern,
+Request Data,Daten anfordern,
+Request Description,Beschreibung der Anfrage,
+Request Headers,Anfrage-Kopfzeilen,
+Request ID,Anfrage-ID,
+Request Method,Anfragemethode,
+Request Timeout,Zeitüberschreitung der Anfrage,
+"Requires any valid fdn path. i.e. ou=groups,dc=example,dc=com","Benötigt einen gültigen fdn-Pfad. z.B. ou=groups,dc=example,dc=com",
+"Requires any valid fdn path. i.e. ou=users,dc=example,dc=com","Benötigt einen gültigen fdn-Pfad. z.B. ou=users,dc=example,dc=com",
+Reset Changes,Änderungen zurücksetzen,
+Reset Password Link Expiry Duration,Gültigkeitsdauer des Passwort-Links zurücksetzen,
+Response ,Antwort ,
+Rest of the day,Rest des Tages,
+Restrictions,Beschränkungen,Title of message showing restrictions in list view
+Result,Ergebnis,
+Retry Sending,Senden erneut versuchen,
+Revocation URI,Widerrufs-URI,
+Right,Rechts,alignment
+Right Bottom,Rechts unten,
+Right Center,Mitte rechts,
+Role 'All' will be given to all system + website users.,Die Rolle 'Alle' wird allen System + Website-Nutzern zugewiesen.,
+Role 'Desk User' will be given to all system users.,Die Rolle 'Desk User' wird allen Systembenutzern zugewiesen.,
+Role Permissions Manager,Rollenberechtigungen-Manager,Button in list view menu
+Role has been set as per the user type {0},Die Rolle wurde gemäß Benutzertyp {0} festgelegt,
+Rounding Method,Rundungsmethode,
+"Route: Example ""/app""","Route: Beispiel ""/app""",
+Row # {0}: Non administrator user can not set the role {1} to the custom doctype,Zeile # {0}: Nicht-Administrator-Benutzer können die Rolle {1} nicht auf den benutzerdefinierten Doctype einstellen,
+Row #{}: Fieldname is required,Zeile #{}: Feldname ist erforderlich,
+Row Indexes,Zeilen-Indizes,
+"Rule for this doctype, role, permlevel and if-owner combination already exists.","Die Regel für diese Kombination aus Doctype, Rolle, Permlevel und if-owner existiert bereits.",
+Rules,Regeln,
+SMTP Server is required,SMTP-Server ist erforderlich,
+SQL Explain,SQL-Erklärung,
+SQL Output,SQL-Ausgabe,
+SQL Queries,SQL-Abfragen,
+SWATCHES,Farbmuster,
+Save API Secret: {0},API-Geheimnis speichern: {0},
+Save on Completion,Nach Fertigstellung speichern,
+Save the document.,Dokument speichern.,
+Saving,Speichere,Freeze message while saving a document
+Saving Customization...,Speichere Anpassung...,
+Saving this will export this document as well as the steps linked here as json.,"Wenn Sie dies speichern, werden dieses Dokument und die hier verlinkten Schritte als JSON exportiert.",
+Scan QRCode,QR-Code scannen,
+Schedule,Planen,
+Schedule Newsletter,Newsletter planen,
+Schedule sending,Senden planen,
+Schedule sending at a later time,Senden zu einem späteren Zeitpunkt planen,
+Scheduled Jobs Logs,Protokolle geplanter Jobs,
+Scheduled Sending,Geplanter Versand,
+Scheduler,Planer,
+Scheduler Status,Planer-Status,
+Scheduler can not be re-enabled when maintenance mode is active.,"Scheduler kann nicht wieder aktiviert werden, wenn der Wartungsmodus aktiv ist.",
+Scheduler: Active,Planer: Aktiv,
+Scheduler: Inactive,Zeitplaner: Inaktiv,
+Scope,Geltungsbereich,
+Scripting,Skripterstellung,
+Scripting / Style,Skripterstellung / Stil,
+Scripts,Skripte,
+Search Bar,Suchleiste,
+Search Results,Suchergebnisse,
+Search fields,Felder durchsuchen,
+Search for {0},Suche nach {0},
+Section ID,Abschnitts-ID,
+Section Title,Titel des Abschnitts,
+See previous responses,Vorherige Antworten anzeigen,Button in web form
+Select Country,Land auswählen,
+Select Currency,Währung auswählen,
+Select List View,Listenansicht auswählen,
+Select Network Printer,Netzwerkdrucker auswählen,
+Select Page,Seite auswählen,
+Select Report,Bericht auswählen,
+Select Time Zone,Zeitzone auswählen,
+Select Transaction,Bitte Transaktionen auswählen,
+Select Workspace,Arbeitsbereich auswählen,
+Select an Image,Bild auswählen,
+Select list item,Listenelement auswählen,Description of a list view shortcut
+Select multiple list items,Wählen Sie mehrere Listenelemente aus,Description of a list view shortcut
+Select two versions to view the diff.,"Wählen Sie zwei Versionen aus, um den Unterschied anzuzeigen.",
+Send Email At,E-Mail senden am,
+Send Test Email,Test-E-Mail senden,
+Send Web View Link,Webview-Link senden,
+Send a test email,Test-E-Mail senden,
+Send again,Erneut senden,
+Send login link,Anmelde-Link senden,
+Send now,Jetzt senden,
+Sender Email Field,Absender-E-Mail-Feld,
+Sender Name,Absendername,
+Sender Name Field,Absendername Feld,
+Sending emails,Sende E-Mails,
+Sending...,Senden...,
+Sequence Id,Sequenz-ID,
+Series List for this Transaction,Nummernkreise zu diesem Vorgang,
+Series Updated for {},Nummernkreis aktualisiert für {},
+Series counter for {} updated to {} successfully,Nummernkreis-Zähler für {} erfolgreich auf {} aktualisiert,
+Server was too busy to process this request. Please try again.,"Server war zu beschäftigt, um diese Anfrage zu bearbeiten. Bitte versuchen Sie es erneut.",
+Session Expiry (idle timeout),Ablauf der Sitzung (Leerlaufzeit),
+Set,Eingetragen,Field value is set
+Set Limit,Limit festlegen,
+Set Naming Series options on your transactions.,Legen Sie Nummernkreise für Ihre Transaktionen fest.,
+Set Properties,Eigenschaften festlegen,
+Set by user,Von Benutzer festgelegt,
+Set only once,Nur einmal festlegen,
+"Set the filters here. For example:
+<pre class=""small text-muted""><code>
+[{
+	fieldname: ""company"",
+	label: __(""Company""),
+	fieldtype: ""Link"",
+	options: ""Company"",
+	default: frappe.defaults.get_user_default(""Company""),
+	reqd: 1
+},
+{
+	fieldname: ""account"",
+	label: __(""Account""),
+	fieldtype: ""Link"",
+	options: ""Account"",
+	reqd: 1
+}]
+</code></pre>","Legen Sie hier die Filter fest. Beispiel:
+<pre class=""small text-muted""><code>
+[{
+	fieldname: ""company"",
+	label: __(""Company""),
+	fieldtype: ""Link"",
+	options: ""Company"",
+	default: frappe.defaults.get_user_default(""Company""),
+	reqd: 1
+},
+{
+	fieldname: ""account"",
+	label: __(""Account""),
+	fieldtype: ""Link"",
+	options: ""Account"",
+	reqd: 1
+}]
+</code></pre>",
+"Set the path to a whitelisted function that will return the data for the number card in the format:
+
+<pre class=""small text-muted""><code>
+{
+	""value"": value,
+	""fieldtype"": ""Currency"",
+	""route_options"": {""from_date"": ""2023-05-23""},
+	""route"": [""query-report"", ""Permitted Documents For User""]
+}</code></pre>","Tragen Sie den Pfad zu einer freigegebenen Funktion ein, die die Daten für die Zahlenkarte im folgenden Format zurückgibt:
+
+<pre class=""small text-muted""><code>
+{
+	""value"": value,
+	""fieldtype"": ""Currency"",
+	""route_options"": {""from_date"": ""2023-05-23""},
+	""route"": [""query-report"", ""Permitted Documents For User""]
+}</code></pre>",
+Setup Series for transactions,Nummernkreise für Transaktionen einrichten,
+Show All,Alle anzeigen,
+Show Currency Symbol on Right Side,Währungssymbol auf der rechten Seite anzeigen,
+Show Error,Fehler anzeigen,
+Show First Document Tour,Erste Dokumententour anzeigen,
+Show Labels,Labels anzeigen,
+Show Language Picker,Sprachauswahl anzeigen,
+Show Only Failed Logs,Nur fehlgeschlagene Protokolle anzeigen,
+Show Preview,Vorschau anzeigen,
+Show Processlist,Prozessliste anzeigen,
+Show Related Errors,Zugehörige Fehler anzeigen,
+Show Tour,Tour anzeigen,
+Show all blogs,Alle Blogs anzeigen,
+Show link to document,Link zum Dokument anzeigen,
+Show {0} List,{0} Liste anzeigen,
+Sidebar,Seitenleiste,
+Sign Up and Confirmation,Anmeldung und Bestätigung,
+Size (MB),Größe (MB),
+Skipped,Übersprungen,
+"Skipping {0} of {1}, {2}","Überspringe {0} von {1}, {2}",
+Snippet and more variables:  {0},Beispiel und weitere Variablen:  {0},
+SocketIO Ping Check,SocketIO Ping-Prüfung,
+SocketIO Transport Mode,SocketIO-Transportmodus,
+Something went wrong.,Etwas ist schief gelaufen.,
+Sort Options,Optionen sortieren,
+Spacer,Abstandshalter,
+"Special Characters except '-', '#', '.', '/', '{{' and '}}' not allowed in naming series {0}","Sonderzeichen außer &quot;-&quot;, &quot;#&quot;, &quot;.&quot;, &quot;/&quot;, &quot;{{&quot; Und &quot;}}&quot; sind bei der Benennung von Serien nicht zulässig {0}",
+Splash Image,Splash-Bild,
+Sr No.,Pos.,
+Standard Reports cannot be deleted,Standardberichte können nicht gelöscht werden,
+Standard Reports cannot be edited,Standard-Berichte können nicht bearbeitet werden,
+"Standard Web Forms can not be modified, duplicate the Web Form instead.","Standard-Webformulare können nicht geändert werden, duplizieren Sie stattdessen das Webformular.",
+Standard user type {0} can not be deleted.,Standard-Benutzertyp {0} kann nicht gelöscht werden.,
+Start Recording,Aufzeichnung starten,
+Start a new discussion,Eine neue Unterhaltung starten,
+Started At,Gestartet am,
+Statistics,Statistiken,
+Stop,Anhalten,
+Storage Usage (MB),Speichernutzung (MB),
+Storage Usage By Table,Speichernutzung nach Tabelle,
+Store Attached PDF Document,Angehängtes PDF-Dokument speichern,
+Stores the datetime when the last reset password key was generated.,"Speichert das Datum, an dem der letzte Schlüssel zum Zurücksetzen des Passworts generiert wurde.",
+Strip EXIF tags from uploaded images,Exif-Daten von hochgeladenen Bildern entfernen,
+Submit,Buchen,Button in list view actions menu
+Submit,Buchen,Button in web form
+Submit,Buchen,Primary action in dialog
+Submit,Buchen,Primary action of prompt dialog
+Submit,Buchen,Submit password for Email Account
+Submit another response,Eine weitere Antwort senden,Button in web form
+Submit {0} documents?,{0} Dokumente einreichen?,Title of confirmation dialog
+Submitting,Buche,Freeze message while submitting a document
+Success URI,Erfolgs-URI,
+Successful Job Count,Anzahl erfolgreich,
+Successfully imported {0},Erfolgreich importiert {0},
+Successfully updated {0},Erfolgreich aktualisiert {0},
+Switch Camera,Kamera wechseln,
+Switching Camera,Kamera wird gewechselt,
+"Sync token was invalid and has been reset, Retry syncing.",Das Synchronisierungstoken war ungültig und wurde zurückgesetzt. Versuchen Sie die Synchronisierung erneut.,
+Sync {0} Fields,{0} Felder synchronisieren,
+Synced Fields,Synchronisierte Felder,
+Syntax Error,Syntaxfehler,
+System Generated Fields can not be renamed,Systemgenerierte Felder können nicht umbenannt werden,
+System Health Report,Bericht zur Systemgesundheit,
+System Logs,Systemprotokolle,
+System Manager privileges required.,System-Manager-Berechtigungen erforderlich.,
+System Notifications,Systembenachrichtigungen,
+Tab Break,Tab-Umbruch,
+Table Fieldname Missing,Tabellenfeldname fehlt,
+Table Trimmed,Tabelle gekürzt,
+Team Members Subtitle,Teammitglieder Untertitel,
+Telemetry,Telemetrie,
+Template File,Vorlagendatei,
+Templates,Vorlagen,
+Test Job ID,Test-Auftrags-ID,
+"Thank you for reaching out to us. We will get back to you at the earliest.
+
+
+Your query:
+
+{0}","Vielen Dank, dass Sie sich mit uns in Verbindung setzen. Wir werden uns so schnell wie möglich bei Ihnen melden.
+
+
+Ihre Anfrage:
+
+{0}",
+Thanks,Danke,
+"The Client ID obtained from the Google Cloud Console under <a href=""https://console.cloud.google.com/apis/credentials"">
+""APIs &amp; Services"" &gt; ""Credentials""
+</a>","Die Client-ID, die Sie in der Google Cloud Console unter <a href=""https://console.cloud.google.com/apis/credentials"">
+""APIs & Services"" > ""Credentials""
+</a>erhalten",
+The File URL you've entered is incorrect,Die eingegebene Datei-URL ist falsch,
+The User record for this request has been auto-deleted due to inactivity by system admins.,Der Benutzerdatensatz für diese Anfrage wurde aufgrund der Inaktivität der Systemadministratoren automatisch gelöscht.,
+The application name will be used in the Login page.,Der Name der Anwendung wird in der Anmeldeseite verwendet.,
+"The browser API key obtained from the Google Cloud Console under <a href=""https://console.cloud.google.com/apis/credentials"">
+""APIs &amp; Services"" &gt; ""Credentials""
+</a>","Der Browser-API-Schlüssel, den Sie von der Google Cloud Console unter <a href=""https://console.cloud.google.com/apis/credentials"">
+""APIs &amp; Dienste"" &gt; ""Zugangsdaten""
+</a>erhalten",
+The changes have been reverted.,Die Änderungen wurden rückgängig gemacht.,
+The contents of this email are strictly confidential. Please do not forward this email to anyone.,Der Inhalt dieser E-Mail ist streng vertraulich. Bitte leiten Sie diese E-Mail nicht an Dritte weiter.,
+The count shown is an estimated count. Click here to see the accurate count.,"Die angezeigte Anzahl ist eine Schätzung. Klicken Sie hier, um die genaue Anzahl anzuzeigen.",
+"The document type selected is a child table, so the parent document type is required.","Der ausgewählte Dokumenttyp ist eine untergeordnete Tabelle, daher ist der übergeordnete Dokumenttyp erforderlich.",
+The field {0} is mandatory,Das Feld {0} ist ein Pflichtfeld,
+The fieldname you've specified in Attached To Field is invalid,"Der Feldname, den Sie im Angehängten Feld angegeben haben, ist ungültig",
+The following Assignment Days have been repeated: {0},Die folgenden Zuweisungs-Tage wurden wiederholt: {0},
+The following Header Script will add the current date to an element in 'Header HTML' with class 'header-content',Das folgende Header-Skript fügt das aktuelle Datum zu einem Element in 'Header HTML' mit der Klasse 'header-content' hinzu,
+The following values are invalid: {0}. Values must be one of {1},Die folgenden Werte sind ungültig: {0}. Die Werte müssen einer der folgenden sein: {1},
+The following values do not exist for {0}: {1},Die folgenden Werte existieren nicht für {0}: {1},
+The limit has not set for the user type {0} in the site config file.,Das Limit für den Benutzertyp {0} in der Seitenkonfigurationsdatei wurde nicht gesetzt.,
+The link will expire in {0} minutes,Der Link läuft in {0} Minuten ab,
+The link you trying to login is invalid or expired.,"Der Link, mit dem Sie sich anmelden möchten, ist ungültig oder abgelaufen.",
+The next tour will start from where the user left off.,"Die nächste Tour beginnt dort, wo der Benutzer aufgehört hat.",
+The number of seconds until the request expires,Die Anzahl der Sekunden bis die Anfrage abläuft,
+"The project number obtained from Google Cloud Console under <a href=""https://console.cloud.google.com/iam-admin/settings"">
+""IAM &amp; Admin"" &gt; ""Settings""
+</a>","Die Projektnummer aus der Google Cloud Console unter <a href=""https://console.cloud.google.com/iam-admin/settings"">
+""IAM &amp; Admin"" &gt; ""Einstellungen""
+</a>",
+The reset password link has been expired,Der Link zum Zurücksetzen des Passworts ist abgelaufen,
+The reset password link has either been used before or is invalid,Der Link zum Zurücksetzen des Passworts wurde bereits verwendet oder ist ungültig,
+The role {0} should be a custom role.,Die Rolle {0} sollte eine benutzerdefinierte Rolle sein.,
+The selected document {0} is not a {1}.,Das ausgewählte Dokument {0} ist nicht vom Typ {1}.,
+The system is being updated. Please refresh again after a few moments.,Das System wird gerade aktualisiert. Bitte probieren Sie es nach einigen Augenblicken erneut.,
+The total column width cannot be more than 10.,Die Gesamtbreite aller Spalten darf nicht mehr als 10 sein.,
+The total number of user document types limit has been crossed.,Das Limit für die Gesamtzahl der Benutzerdokumenttypen wurde überschritten.,
+The value you pasted was {0} characters long. Max allowed characters is {1}.,"Der Wert, den Sie eingefügt haben, war {0} Zeichen lang. Die maximal erlaubten Zeichen sind {1}.",
+Theme Changed,Design geändert,
+"There are no {0} for this {1}, why don't you start one!","Es gibt keine {0} für diese {1}, warum starten Sie nicht eine!",
+There can be only 9 Page Break fields in a Web Form,Es dürfen höchstens 9 Seitenumbrüche in einem Webformular vorkommen,
+There is nothing new to show you right now.,Es gibt im Moment nichts Neues zu sehen.,
+These settings are required if 'Custom' LDAP Directory is used,"Diese Einstellungen sind erforderlich, wenn das 'Benutzerdefinierte' LDAP-Verzeichnis verwendet wird",
+This Doctype does not contain latitude and longitude fields,Dieser Doctype enthält keine Felder für Breiten- und Längengrade,
+This Doctype does not contain location fields,Dieser DocType enthält keine Standortfelder,
+This action is irreversible. Do you wish to continue?,Diese Aktion ist unumkehrbar. Möchten Sie fortfahren?,
+This doctype has no orphan fields to trim,Dieser Doctype hat keine verwaisten Felder zum Kürzen,
+This document can not be deleted right now as it's being modified by another user. Please try again after some time.,"Dieses Dokument kann im Moment nicht gelöscht werden, da es von einem anderen Benutzer geändert wird. Bitte versuchen Sie es nach einiger Zeit erneut.",
+This document has unsaved changes which might not appear in final PDF. <br> Consider saving the document before printing.,"Dieses Dokument enthält ungespeicherte Änderungen, die möglicherweise nicht in der PDF-Datei erscheinen. <br> Bitte speichern Sie das Dokument vor dem Drucken.",
+This document is currently locked and queued for execution. Please try again after some time.,Dieses Dokument ist derzeit gesperrt und befindet sich in der Warteschlange für die Ausführung. Bitte versuchen Sie es nach einiger Zeit erneut.,
+"This feature can not be used as dependencies are missing.
+				Please contact your system manager to enable this by installing pycups!","Diese Funktion kann nicht verwendet werden, da die Abhängigkeiten fehlen.
+				Bitte wenden Sie sich an Ihren Systemmanager, um diese Funktion durch die Installation von pycups zu aktivieren!",
+"This field will appear only if the fieldname defined here has value OR the rules are true (examples):
+myfield
+eval:doc.myfield=='My Value'
+eval:doc.age&gt;18","Dieses Feld wird nur angezeigt, wenn der hier definierte Feldname Wert hat oder die Regeln wahr sind (Beispiele):
+myfield
+eval:doc.myfield=='Mein Wert'
+eval:doc.age&gt;18",
+This file is public. It can be accessed without authentication.,Diese Datei ist öffentlich. Sie kann ohne Authentifizierung aufgerufen werden.,
+This is the number of the last created transaction with this prefix,Dies ist die Nummer der letzten erstellten Transaktion mit diesem Präfix,
+This newsletter is scheduled to be sent on {0},Dieser Newsletter wird voraussichtlich am {0} verschickt,
+This newsletter was scheduled to send on a later date. Are you sure you want to send it now?,"Der Versand dieses Newsletters war zu einem späteren Zeitpunkt geplant. Sind Sie sicher, dass Sie es jetzt senden möchten?",
+"This report contains {0} rows and is too big to display in browser, you can {1} this report instead.","Dieser Bericht enthält {0} Zeilen und ist zu groß, um im Browser angezeigt zu werden. Sie können diesen Bericht stattdessen unter {1} aufrufen.",
+"This site is in read only mode, full functionality will be restored soon.",Diese Instanz erlaubt derzeit nur lesenden Zugriff. Die volle Funktionalität wird bald wiederhergestellt werden.,
+This site is running in developer mode. Any change made here will be updated in code.,Diese Website läuft im Entwicklermodus. Jede hier vorgenommene Änderung wird im Code aktualisiert.,
+This will reset this tour and show it to all users. Are you sure?,Dadurch wird diese Tour zurückgesetzt und für alle Benutzer sichtbar. Sind Sie sicher?,
+Time Taken,Dauer,
+Timed Out,Zeitüberschreitung,
+Timeless Night,Zeitlose Nacht,
+Timeline,Zeitleiste,
+Timeout,Zeitüberschreitung,
+"To add dynamic subject, use jinja tags like
+
+<div><pre><code>New {{ doc.doctype }} #{{ doc.name }}</code></pre></div>","Um einen dynamischen Betreff hinzuzufügen, verwenden Sie Jinja-Tags wie
+
+<div><pre><code>Neu {{ doc.doctype }} #{{ doc.name }}</code></pre></div>",
+"To add dynamic subject, use jinja tags like
+
+<div><pre><code>{{ doc.name }} Delivered</code></pre></div>","Um einen dynamischen Betreff hinzuzufügen, verwenden Sie Jinja-Tags wie
+
+<div><pre><code>{{ doc.name }} Delivered</code></pre></div>",
+To allow more reports update limit in System Settings.,"Um mehr Berichte zuzulassen, aktualisieren Sie das Limit in den Systemeinstellungen.",
+"To export this step as JSON, link it in a Onboarding document and save the document.","Um diesen Schritt als JSON zu exportieren, verknüpfen Sie ihn in einem Onboarding-Dokument und speichern das Dokument.",
+"To set the role {0} in the user {1}, kindly set the {2} field as {3} in one of the {4} record.","Um die Rolle {0} im Benutzer {1} festzulegen, legen Sie bitte das Feld {2} als {3} in einem der Datensätze {4} fest.",
+"To use Google Indexing, enable <a href=""/app/google-settings"">Google Settings</a>.","Um die Google-Indizierung zu verwenden, aktivieren Sie die <a href=""/app/google-settings"">Google-Einstellungen</a>.",
+To version,Zu Version,
+Toggle Sidebar,Seitenleiste umschalten,Button in list view menu
+Token Type,Token-Art,
+Too Many Documents,Zu viele Dokumente,
+Too many changes to database in single action.,Zu viele Änderungen an der Datenbank in einer einzelnen Aktion.,
+Top,oben,
+Top Center,Oben Mitte,
+Top Errors,Häufigste Fehler,
+Top Left,Oben links,
+Top Right,Oben rechts,
+Topic,Thema,
+Total Background Workers,Gesamtzahl der Hintergrundarbeiter,
+Total Errors (last 1 day),Fehler insgesamt (letzter Tag),
+Total Images,Anzahl Bilder,
+Total Outgoing Emails,Anzahl ausgehender E-Mails,
+Total Recipients,Empfänger insgesamt,
+Total Users,Anzahl der Benutzer,
+Total Working Time,Gesamtarbeitszeit,
+Total:,Summe:,
+Track Steps,Schritte verfolgen,
+"Track if your email has been opened by the recipient.
+<br>
+Note: If you're sending to multiple recipients, even if 1 recipient reads the email, it'll be considered ""Opened""","Verfolgen Sie, ob Ihre E-Mail vom Empfänger geöffnet wurde.
+<br>
+Hinweis: Wenn Sie an mehrere Empfänger senden, gilt die E-Mail auch dann als ""Geöffnet"", wenn nur ein Empfänger sie liest.",
+Trim Table,Tabelle kürzen,
+Try Again,Erneut versuchen,
+Type Distribution,Verteilung nach Typ,
+Type title,Titel eingeben,
+UI Tour,UI-Tour,
+"URIs for receiving authorization code once the user allows access, as well as failure responses. Typically a REST endpoint exposed by the Client App.
+<br>e.g. http://hostname/api/method/frappe.integrations.oauth2_logins.login_via_facebook","URIs für den Empfang des Autorisierungscodes, sobald der Benutzer den Zugriff erlaubt, sowie für Fehlerantworten. In der Regel ein REST-Endpunkt, der von der Client-App bereitgestellt wird.
+<br>z.B. http://hostname/api/method/frappe.integrations.oauth2_logins.login_via_facebook",
+URL must start with http:// or https://,URL muss mit http:// oder https:// beginnen,
+Unable to find DocType {0},DocType {0} kann nicht gefunden werden.,
+Unhandled Emails,Nicht verarbeitete E-Mails,
+Unknown Rounding Method: {},Unbekannte Rundungsmethode: {},
+Unpublish,Zurückziehen,
+Unsafe SQL query,Unsichere SQL-Abfrage,
+Update Hooks Resolution Order,Auflösungsreihenfolge der Hooks aktualisieren,
+Update Order,Reihenfolge aktualisieren,
+Update Password,Passwort ändern,
+Update Series Counter,Nummernkreis-Zähler aktualisieren,
+Update Series Number,Nummernkreis-Wert aktualisieren,
+Update {0} records,{0} Datensätze aktualisieren,
+Updating,Aktualisierung läuft,Freeze message while updating a document
+Updating Email Queue Statuses. The emails will be picked up in the next scheduled run.,Aktualisieren des Status der E-Mail-Warteschlange. Die E-Mails werden beim nächsten geplanten Lauf abgeholt.,
+Updating counter may lead to document name conflicts if not done properly,"Aktualisierungszähler kann zu Dokumentennamenskonflikten führen, wenn sie nicht ordnungsgemäß ausgeführt werden",
+Updating naming series options,Optionen für Nummernkreise werden aktualisiert,
+Updating related fields...,Aktualisiere zugehörige Felder...,
+Upload Image,Bild hochladen,
+Uploading backup to Google Drive.,Hochladen der Sicherung zu Google Drive.,
+Uploading successful.,Hochladen erfolgreich.,
+Uploading to Google Drive,Hochladen zu Google Drive,
+Use Number Format from Currency,Zahlenformat der jeweiligen Währung verwenden,
+Use STARTTLS,STARTTLS verwenden,
+Use different Email ID,Andere E-Mail-Adresse verwenden,
+Use of function {0} in field is restricted,Die Verwendung der Funktion {0} im Feld ist eingeschränkt,
+Use the new Print Format Builder,Den neuen Druckformat-Editor verwenden,
+Used OAuth,OAuh verwendet,
+User Activity Report,Benutzeraktivitätsbericht,
+User Activity Report Without Sort,Benutzeraktivitätsbericht ohne Sortierung,
+User Document Type,Benutzer DocType,
+User Document Types Limit Exceeded,Benutzer DocType Limit überschritten,
+User Group,Benutzergruppe,
+User Group Member,Benutzergruppen-Mitglied,
+User Group Members,Benutzergruppen-Mitglieder,
+User Id Field,Benutzer-Id-Feld,
+User Id Field is mandatory in the user type {0},Benutzer-Id Feld ist obligatorisch in der Benutzerart {0},
+User Permissions,Benutzerberechtigungen,Button in list view menu
+User Role,Benutzerrolle,
+User Select Document Type,Auswahl Benutzer DocType,
+User Type Module,Benutzertyp-Modul,
+User does not exist.,Benutzer existiert nicht.,
+User does not have permission to create the new {0},Der Benutzer hat keine Berechtigung zum Erstellen der neuen {0},
+User must always select,Benutzer muss immer auswählen,
+User with email address {0} does not exist,Benutzer mit E-Mail-Adresse {0} existiert nicht,
+User with email: {0} does not exist in the system. Please ask 'System Administrator' to create the user for you.,"Ein Benutzer mit der E-Mail-Adresse {0} existiert nicht im System. Bitten Sie den 'Systemadministrator', den Benutzer für Sie anzulegen.",
+User {0} is disabled. Please contact your System Manager.,Benutzer {0} ist deaktiviert. Bitte wenden Sie sich an Ihren Systemmanager.,
+User {0} is not permitted to access this document.,"Der Benutzer {0} ist nicht berechtigt, auf dieses Dokument zuzugreifen.",
+Userinfo URI,Benutzerinfo URI,
+Uses system's theme to switch between light and dark mode,"Verwendet das Systemdesign, um zwischen hellem und dunklem Modus zu wechseln",
+Utilization,Auslastung,
+Utilization %,Auslastung %,
+View,Ansicht,
+View Audit Trail,Prüfprotokoll anzeigen,
+View Blog Post,Blogbeitrag anzeigen,
+View Switcher,Ansicht wechseln,
+View your response,Ihre Antwort anzeigen,Button in web form
+Views,Aufrufe,
+Virtual,Virtuell,
+Visibility,Sichtbarkeit,
+Want to discuss?,Möchten Sie mitreden?,
+Warning: DATA LOSS IMMINENT! Proceeding will permanently delete following database columns from doctype {0}:,"Warnung: DROHENDER DATENVERLUST! Wenn Sie fortfahren, werden die folgenden Datenbankspalten von DocType {0} dauerhaft gelöscht:",
+Warning: Updating counter may lead to document name conflicts if not done properly,"Warnung: Die Aktualisierung des Zählers kann zu Konflikten bei den Dokumentennamen führen, wenn sie nicht ordnungsgemäß durchgeführt wird.",
+Watch Tutorial,Tutorial ansehen,
+We do not allow editing of this document. Simply click the Edit button on the workspace page to make your workspace editable and customize it as you wish,"Wir erlauben keine Bearbeitung dieses Dokuments. Klicken Sie einfach auf die Schaltfläche Bearbeiten auf der Arbeitsbereichsseite, um Ihren Arbeitsbereich bearbeitbar zu machen und ihn nach Ihren Wünschen anzupassen.",
+We've received your query!,Wir haben Ihre Anfrage erhalten!,
+Web Form List Column,Web-Formular-Listenspalte,
+Web Template is not specified,Web-Vorlage ist nicht angegeben,
+Webhook Request Log,Webhook-Anfrage-Protokoll,
+Website Search Field,Website-Suchfeld,
+Website Search Field must be a valid fieldname,Website-Suchfeld muss ein gültiger Feldname sein,
+Welcome,Willkommen,
+Welcome URL,Willkommens-URL,
+Welcome Workspace,Willkommens-Arbeitsbereich,
+What's New,Neuigkeiten,
+"When sending document using email, store the PDF on Communication. Warning: This can increase your storage usage.","Wenn Sie ein Dokument per E-Mail versenden, wird die PDF-Datei an die Kommunikation angehängt. Dies kann den Speicherbedarf erhöhen.",
+"When uploading files, force the use of the web-based image capture. If this is unchecked, the default behavior is to use the mobile native camera when use from a mobile is detected.","Erzwingen Sie beim Hochladen von Dateien die Verwendung der webbasierten Bilderfassung. Falls diese Option nicht aktiviert ist, wird standardmäßig die native Kamera des Mobiltelefons verwendet, wenn eine Nutzung von einem Mobiltelefon aus erkannt wird.",
+Worker Information,Arbeitnehmerinformationen,
+Worker Name,Name des Arbeiters,
+Workflow Action Permitted Role,Zulässige Rolle für Workflow-Aktionen,
+Workspace,Arbeitsbereich,
+Workspace <b>{0}</b> does not exist,Arbeitsbereich <b>{0}</b> existiert nicht,
+Workspace Chart,Arbeitsbereich-Diagramm,
+Workspace Custom Block,Arbeitsbereich Benutzerdefinierter Block,
+Workspace Link,Arbeitsbereich-Link,
+Workspace Manager,Arbeitsbereich-Manager,
+Workspace Number Card,Arbeitsbereich-Nummernkarte,
+Workspace Quick List,Arbeitsbereich-Schnellliste,
+Workspace Shortcut,Arbeitsbereich-Verknüpfung,
+Workspaces,Arbeitsbereiche,
+Yellow,Gelb,
+Yes,Ja,Approve confirmation dialog
+Yes,Ja,Checkbox is checked
+You,Sie,Name of the current user. For example: You edited this 5 hours ago.
+You are not allowed to edit the report.,"Sie sind nicht berechtigt, den Bericht zu bearbeiten.",
+You are not permitted to access this page without login.,"Sie sind nicht berechtigt, ohne Anmeldung auf diese Seite zuzugreifen.",
+You are not permitted to access this resource.,"Sie sind nicht berechtigt, auf diese Ressource zuzugreifen.",
+"You are only allowed to update order, do not remove or add apps.","Sie können nur die Reihenfolge verändern, keine Anwendungen entfernen oder hinzufügen.",
+"You are selecting Sync Option as ALL, It will resync all read as well as unread message from server. This may also cause the duplication of Communication (emails).",Sie wählen als Synchronisierungsoption „ALLE“ aus. Dadurch werden alle gelesenen und ungelesenen Nachrichten vom Server neu synchronisiert. Dies kann auch zu einer Duplizierung der Kommunikation (E-Mails) führen.,
+You can also access wkhtmltopdf variables (valid only in PDF print):,Sie können auch auf wkhtmltopdf-Variablen zugreifen (nur im PDF-Druck gültig):,
+You can also copy-paste following link in your browser,Sie können auch den folgenden Link in Ihren Browser kopieren und einfügen,
+You can change the retention policy from {0}.,Sie können die Aufbewahrungsrichtlinie unter {0} ändern.,
+You can continue with the onboarding after exploring this page,Sie können nach Erkundung dieser Seite mit dem Onboarding fortfahren,
+You can disable this {0} instead of deleting it.,"Du kannst diese(n) {0} deaktivieren, anstatt es zu löschen.",
+You can increase the limit from System Settings.,Sie können das Limit in den Systemeinstellungen erhöhen.,
+You can manually remove the lock if you think it's safe: {},"Sie können die Sperre manuell entfernen, wenn Sie denken, dass dies sicher ist: {}",
+You can only insert images in Markdown fields,Sie können nur Bilder in Markdown-Felder einfügen,
+You can only set the 3 custom doctypes in the Document Types table.,Sie können nur die 3 benutzerdefinierten DocTypes in der Tabelle Document Types einstellen.,
+"You can only upload JPG, PNG, PDF, TXT or Microsoft documents.","Sie können nur JPG, PNG, PDF, TXT oder Microsoft-Dokumente hochladen.",
+You can set a high value here if multiple users will be logging in from the same network.,"Sie können hier einen hohen Wert einstellen, wenn sich mehrere Benutzer über dasselbe Netzwerk anmelden.",
+You do not have permission to view this document,"Sie haben keine Berechtigung, dieses Dokument anzuzeigen",
+You don't have permission to access the {0} DocType.,"Sie haben keine Berechtigung, auf den DocType {0} zuzugreifen.",
+You have not entered a value. The field will be set to empty.,Sie haben keinen Wert eingegeben. Das Feld wird auf leer gesetzt.,
+You have received a ❤️ like on your blog post,Sie haben ein ❤️ like für Ihren Blogbeitrag erhalten,
+You have to enable Two Factor Auth from System Settings.,Sie müssen die Zwei-Faktor-Authentifizierung in den Systemeinstellungen aktivieren.,
+You must add atleast one link.,Sie müssen mindestens einen Link hinzufügen.,
+You must be logged in to use this form.,"Sie müssen angemeldet sein, um dieses Formular zu nutzen.",
+You need to be Workspace Manager to edit this document,"Sie müssen Workspace Manager sein, um dieses Dokument zu bearbeiten",
+You need to set one IMAP folder for {0},Sie müssen einen IMAP-Ordner für {0} festlegen,
+You seem to have written your name instead of your email. Please enter a valid email address so that we can get back.,"Sie scheinen Ihren Namen anstelle Ihrer E-Mail-Adresse geschrieben zu haben. Bitte geben Sie eine gültige E-Mail-Adresse ein, damit wir uns zurückmelden können.",
+Your account has been deleted,Ihr Konto wurde gelöscht,
+Your browser does not support the audio element.,Ihr Browser unterstützt das Audio-Element nicht.,
+Your browser does not support the video element.,Ihr Browser unterstützt das Videoelement nicht.,
+Your form has been successfully updated,Ihr Formular wurde erfolgreich aktualisiert,
+Your old password is incorrect.,Ihr altes Passwort ist falsch.,
+Your verification code is {0},Ihr Bestätigungscode ist {0},
+`as_iterator` only works with `as_list=True` or `as_dict=True`,`as_iterator` funktioniert nur mit `as_list=True` oder `as_dict=True`,
+added rows for {0},hat Zeilen für {0} hinzugefügt,
+canceled,storniert,
+commented,kommentierte(n),
+default,standard,
+deferred,aufgeschoben,
+failed,fehlgeschlagen,
+finished,fertig,
+jane@example.com,beate@beispiel.de,
+label,bezeichnung,
+long,lang,
+processlist,Prozessliste,
+queued,warteschlange,
+removed rows for {0},hat Zeilen von {0} entfernt,
+scheduled,geplant,
+short,kurz,
+started,gestartet,
+starting the setup...,Einrichtung wird gestartet...,
+"string value, i.e. group","String-Wert, z. B. Gruppe",
+"string value, i.e. member","String-Wert, z. B. Mitglied",
+"string value, i.e. {0} or uid={0},ou=users,dc=example,dc=com","String-Wert, z.B {0} oder uid={0},ou=users,dc=example,dc=com",
+this form,dieses Formular,
+this shouldn't break,das sollte nicht kaputt gehen,
+via Google Meet,über Google Meet,
+wants to access the following details from your account,möchte auf folgende Details von Ihrem Konto zugreifen,
+when clicked on element it will focus popover if present.,"wenn Sie auf ein Element klicken, wird das Popover aktiviert, falls vorhanden.",
+{0} Liked,{0} Gefällt mir,
+{0} Not allowed to change {1} after submission from {2} to {3},"{0} Es ist nicht erlaubt, {1} nach dem Buchen von {2} auf {3} zu ändern",
+{0} Workspace,Arbeitsbereich {0},
+{0} appreciation point for {1},{0} Wertschätzungspunkt für {1},
+{0} appreciation points for {1},{0} Wertschätzungspunkte für {1},
+"{0} contains an invalid Fetch From expression, Fetch From can't be self-referential.",{0} enthält einen ungültigen Fetch From-Ausdruck. Fetch From kann nicht selbstreferenziell sein.,
+{0} criticism point for {1},{0} Kritikpunkt für {1},
+{0} criticism points for {1},{0} Kritikpunkte für {1},
+{0} format could not be determined from the values in this column. Defaulting to {1}.,Das {0} Format konnte nicht von den Werten in dieser Spalte bestimmt werden. Standard ist {1}.,
+{0} gained {1} points,{0} hat {1} Punkte erhalten,
+{0} gave {1} points,{0} hat {1} Punkte gegeben,
+{0} is a not a valid zip file,{0} ist keine gültige Zip-Datei,
+{0} is not a valid Calendar. Redirecting to default Calendar.,{0} ist kein gültiger Kalender. Weiterleitung zum Standard-Kalender.,
+{0} is not a valid Cron expression.,{0} ist kein gültiger Cron-Ausdruck.,
+{0} is not a valid parent DocType for {1},{0} ist kein gültiger übergeordneter DocType für {1},
+{0} is not a valid parentfield for {1},{0} ist kein gültiges übergeordnetes Feld für {1},
+{0} is not a zip file,{0} ist keine Zip-Datei,
+{0} of {1} sent,{0} von {1} gesendet,
+{0} records are not automatically deleted.,{0} Datensätze werden nicht automatisch gelöscht.,
+{0} records are retained for {1} days.,{0} Datensätze werden für {1} Tage gespeichert.,
+{0} removed their assignment.,{0} hat seine Zuordnung entfernt.,
+{0}: You can increase the limit for the field if required via {1},{0}: Sie können das Limit für das Feld bei Bedarf über {1} erhöhen,
+{0}: fieldname cannot be set to reserved keyword {1},{0}: Feldname kann nicht auf reserviertes Schlüsselwort {1} gesetzt werden,
+{count} cell copied,{count} Zelle kopiert,
+{count} cells copied,{count} Zellen kopiert,
+{count} row selected,{count} Zeile ausgewählt,
+{count} rows selected,{count} Zeilen ausgewählt,
+{} Invalid python code on line {},{} Ungültiger Python-Code in Zeile {},
+{} Published,{} Veröffentlicht,
+{} does not support automated log clearing.,{} unterstützt keine automatische Protokolllöschung.,
+{} field cannot be empty.,{}-Feld darf nicht leer sein.,
+{} has been disabled. It can only be enabled if {} is checked.,"{} wurde deaktiviert. Es kann nur aktiviert werden, wenn {} aktiviert ist.",


### PR DESCRIPTION
Add translations for strings that are translated on `develop` but were missing a translation on `version-14`. Don't change any existing translations.
