### PR TITLE
fix: is_frappe_app check not wai for --soft-link apps

### DIFF
--- a/esbuild/utils.js
+++ b/esbuild/utils.js
@@ -105,7 +105,6 @@ function is_frappe_app(app_name, app_path) {
 	/**
 	 * Same as the is_frappe_app check in frappe/bench
 	 */
-	if (!fs.lstatSync(app_path).isDirectory()) return false;
 
 	const files_in_app = ["hooks.py", "modules.txt", "patches.txt"];
 


### PR DESCRIPTION
Removed the directory check, as it was returning false when an app was installed using bench get-app --soft-link option as in that case the apps are symlinks not directories

Any thoughts on this minor fix @18alantom ?

closes #28410