### PR TITLE
refactor: use composite unique index in Email Account

### DIFF
--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -95,8 +95,7 @@
    "in_list_view": 1,
    "label": "Email Address",
    "options": "Email",
-   "reqd": 1,
-   "unique": 1
+   "reqd": 1
   },
   {
    "default": "0",
@@ -697,7 +696,7 @@
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-07-18 11:05:57.193762",
+ "modified": "2024-11-11 10:12:06.667888",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -1034,3 +1034,11 @@ def set_email_password(email_account, password):
 			return False
 
 	return True
+
+
+def on_doctype_update() -> None:
+	frappe.db.add_unique(
+		"Email Account",
+		["email_id", "enable_incoming", "enable_outgoing"],
+		constraint_name="unique_email_account_type",
+	)

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -432,7 +432,9 @@ class Email:
 		_from_email = self.decode_email(self.mail.get("X-Original-From") or self.mail["From"])
 		_reply_to = self.decode_email(self.mail.get("Reply-To"))
 
-		if _reply_to and not frappe.db.get_value("Email Account", {"email_id": _reply_to}, "email_id"):
+		if _reply_to and not frappe.db.get_value(
+			"Email Account", {"email_id": _reply_to, "enable_incoming": 1}, "email_id"
+		):
 			self.from_email = extract_email_id(_reply_to)
 		else:
 			self.from_email = extract_email_id(_from_email)


### PR DESCRIPTION
Use case: Email sending is configured in X email service, and receiving is in Y email service.

Removed the unique index from `email_id` and added a multi-column unique index on `email_id`, `enable_incoming` and `enable_outgoing`.

![image](https://github.com/user-attachments/assets/f9d01650-26fd-4503-9b4d-fbe5a3392677)

![image](https://github.com/user-attachments/assets/c4d52625-3a0d-4d70-aac3-661f56abfb5d)
