### PR TITLE
fix(list_view): check that a title field is set before trying to use it

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -209,7 +209,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					) {
 						frappe.model.with_doctype(df.options, () => {
 							const meta = frappe.get_meta(df.options);
-							if (meta.show_title_field_in_link) {
+							if (meta.show_title_field_in_link && meta.title_field) {
 								this.link_field_title_fields[
 									typeof f === "string" ? f : f.fieldname
 								] = meta.title_field;


### PR DESCRIPTION
Otherwise enabling the checkbox for `Warehouse` and trying to load `Stock Ledger Entry`
results in `warehouse. as warehouse_`

Reference: support ticket 25082
https://katb.in/axoyidatibe
