### PR TITLE
fix(change_log): skip checking if `develop` is part of the detected version

### DIFF
--- a/frappe/utils/change_log.py
+++ b/frappe/utils/change_log.py
@@ -184,6 +184,9 @@ def check_for_update():
 		branch_version = (
 			apps[app]["branch_version"].split(" ", 1)[0] if apps[app].get("branch_version", "") else ""
 		)
+		if "develop" in branch_version:
+			return updates
+
 		instance_version = Version(branch_version or apps[app].get("version"))
 
 		github_version, org_name = check_release_on_github(owner, repo, instance_version)


### PR DESCRIPTION
Resolves #28327
