### PR TITLE
fix(testing)!: ensure idempotency on the test environment user

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -19,6 +19,7 @@ module.exports = {
 				"revert",
 				"style",
 				"test",
+				"deprecate", // deprecation decision
 			],
 		],
 	},

--- a/frappe/parallel_test_runner.py
+++ b/frappe/parallel_test_runner.py
@@ -85,6 +85,14 @@ class ParallelTestRunner:
 			print("running tests from", "/".join(file_info))
 			return
 
+		from frappe.deprecation_dumpster import deprecation_warning
+
+		deprecation_warning(
+			"2024-11-13",
+			"v17",
+			"Setting the test environment user to 'Administrator' by the test runner is deprecated. The UnitTestCase now ensures a consistent user environment on set up and tear down at the class level. ",
+		)
+		frappe.set_user("Administrator")
 		path, filename = file_info
 		module = self.get_module(path, filename)
 		test_suite = unittest.TestSuite()

--- a/frappe/parallel_test_runner.py
+++ b/frappe/parallel_test_runner.py
@@ -85,7 +85,6 @@ class ParallelTestRunner:
 			print("running tests from", "/".join(file_info))
 			return
 
-		frappe.set_user("Administrator")
 		path, filename = file_info
 		module = self.get_module(path, filename)
 		test_suite = unittest.TestSuite()

--- a/frappe/tests/classes/unit_test_case.py
+++ b/frappe/tests/classes/unit_test_case.py
@@ -49,6 +49,10 @@ class UnitTestCase(unittest.TestCase, BaseTestCase):
 		super().setUpClass()
 		cls.doctype = _get_doctype_from_module(cls)
 		cls.module = frappe.get_module(cls.__module__)
+		# Test Environment
+		frappe.set_user("Administrator")
+		# Test Environment (cleanup)
+		cls.addClassCleanup(frappe.set_user, "Administrator")
 		cls._unit_test_case_class_setup_done = True
 
 	def assertQueryEqual(self, first: str, second: str) -> None:


### PR DESCRIPTION
1. It moves the `frappe.set_user("Administrator")` call from the `ParallelTestRunner` to the `UnitTestCase` class.
2. It adds a cleanup method to ensure the user is reset to "Administrator" after each test class.
3. These changes aim to improve the consistency and idempotency of the test environment setup.

---

This change represents an important step towards improving test environment guarantees. Let me explain why this is significant:

## Improved Consistency and Reliability

The commit moves the user setup from the `ParallelTestRunner` to the `UnitTestCase` class. This change ensures that every test case starts with a consistent user environment, specifically the "Administrator" user. By setting the user at the class level and adding a cleanup method, it guarantees that:

1. All tests within a class begin with the same user context.
2. The user context is reset to "Administrator" after each test class runs.

This approach enhances the **idempotency** of tests, meaning that regardless of the order or number of times tests are run, they should produce consistent results.

## Better Isolation and Reproducibility

By managing the user context at the test case level, this change improves test isolation. Each test class now has its own controlled environment, reducing the risk of one test affecting another due to user-related side effects. This isolation is crucial for:

- Reproducing test results consistently
- Debugging issues more effectively
- Preventing unexpected interactions between different test cases

## Alignment with Best Practices

This modification aligns with several test environment management best practices:

1. **Standardized Operations**: It establishes a consistent approach to user management across all test cases.
2. **Automation**: By incorporating user setup and cleanup into the test framework, it reduces manual intervention and potential human errors.
3. **Isolation**: It ensures that each test class operates in a controlled, isolated user environment.

In conclusion, this change contributes to a more stable, consistent, and reliable test environment, which is crucial for ensuring the accuracy and dependability of test results in the software development lifecycle.


---

## Backwards Compat

- For consistency and in an attempt to write self-documenting, sound code, this PR proposes to deprecate the user being set by the parallel test runner (only!)
- This ensures that users of `parallel-test-runner` which rely on this singular setting in their test harnesses are being warned with sufficient anticipation and informed that we transition towards a per-class user environment
- It gives them enough time to transition, even if they do not use `UnitTestCase` in their test harness

## BREAKING

Unfortunately, for users of `UnitTestCase` and its derived classes (e.g. `IntegrationTestCase`), this change is braking for current test suites which &mdash; against all best practices &mdash; explicitly or accidentally rely on the missing idempotent behavior.