### PR TITLE
fix: get PDF from printview

### DIFF
--- a/frappe/www/printview.html
+++ b/frappe/www/printview.html
@@ -18,7 +18,7 @@
 			{{ _("Print") }}
 		</a>
 		<a class="p-2"
-			href="/api/method/frappe.utils.print_format.download_pdf?doctype={{doctype|e}}&name={{name|e}}&key={{key|e}}">
+			href="/api/method/frappe.utils.print_format.download_pdf?doctype={{doctype|e}}&name={{name|e}}&format={{print_format|e}}&letterhead={{letterhead|e}}&no_letterhead={{no_letterhead|e}}&_lang={{lang|e}}&key={{key|e}}">
 			{{ _('Get PDF') }}
 		</a>
 	</div>

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -97,7 +97,7 @@ def get_context(context) -> PrintContext:
 		"doctype": frappe.form_dict.doctype,
 		"name": frappe.form_dict.name,
 		"key": frappe.form_dict.get("key"),
-		"print_format": print_format.name,
+		"print_format": getattr(print_format, "name", None),
 		"letterhead": letterhead,
 		"no_letterhead": frappe.form_dict.no_letterhead,
 	}

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -97,6 +97,9 @@ def get_context(context) -> PrintContext:
 		"doctype": frappe.form_dict.doctype,
 		"name": frappe.form_dict.name,
 		"key": frappe.form_dict.get("key"),
+		"print_format": print_format.name,
+		"letterhead": letterhead,
+		"no_letterhead": frappe.form_dict.no_letterhead,
 	}
 
 


### PR DESCRIPTION
Clicking "Get PDF" in printview should result in the same view being converted to PDF. So far, we didn't pass the print format and letterhead parameters, sometimes resulting in an entirely different PDF.

For example, you might open the printview with a non-default Print Format and no letterhead, but "Get PDF" directs you to a PDF of the default printview with the default letterhead.
