### PR TITLE
fix(testing): tolerate missing app.tests module

### DIFF
--- a/frappe/testing/environment.py
+++ b/frappe/testing/environment.py
@@ -103,9 +103,12 @@ class IntegrationTestPreparation:
 	@debug_timer
 	def _create_global_test_record_dependencies(app: str, category: str):
 		"""Create global test record dependencies"""
-		test_module = frappe.get_module(f"{app}.tests")
-		if hasattr(test_module, "global_test_dependencies"):
-			logger.info(f"Creating global test record dependencies for {category} tests on {app} ...")
-			for doctype in test_module.global_test_dependencies:
-				logger.debug(f"Creating global test records for {doctype}")
-				make_test_records(doctype, commit=True)
+		try:
+			test_module = frappe.get_module(f"{app}.tests")
+			if hasattr(test_module, "global_test_dependencies"):
+				logger.info(f"Creating global test record dependencies for {category} tests on {app} ...")
+				for doctype in test_module.global_test_dependencies:
+					logger.debug(f"Creating global test records for {doctype}")
+					make_test_records(doctype, commit=True)
+		except ModuleNotFoundError:
+			pass


### PR DESCRIPTION
This reinstates `run-tests` for apps which don't declare a `app.tests` module, at all.

c/o https://github.com/frappe/frappe/pull/28000