### PR TITLE
fix: Disable link field triggers

### DIFF
--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -316,6 +316,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm extends frappe.ui.Dialog {
 				this.after_insert(frm);
 			};
 		}
+		this.doc.__run_link_triggers = false;
 		frappe.set_route("Form", this.doctype, this.doc.name);
 	}
 


### PR DESCRIPTION
Disable link field triggers while opening doc from quick entry to avoid link field re-validation which sometime overrides some `fetch_from` values.

**Before:**

https://github.com/user-attachments/assets/190c869d-9a9b-4393-ad51-7003f825628f


**After:**


https://github.com/user-attachments/assets/2b11a687-40cd-486d-b130-11a487635fa0



