### PR TITLE
fix(query_report): Validate filters using `select` permission, not `read`

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -195,10 +195,10 @@ def run(
 	parent_field=None,
 	are_default_filters=True,
 ):
-	validate_filters_permissions(report_name, filters, user)
-	report = get_report_doc(report_name)
 	if not user:
 		user = frappe.session.user
+	validate_filters_permissions(report_name, filters, user)
+	report = get_report_doc(report_name)
 	if not frappe.has_permission(report.ref_doctype, "report"):
 		frappe.msgprint(
 			_("Must have report permission to access this report."),

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -799,7 +799,9 @@ def validate_filters_permissions(report_name, filters=None, user=None):
 	for field in report.filters:
 		if field.fieldname in filters and field.fieldtype == "Link":
 			linked_doctype = field.options
-			if not has_permission(doctype=linked_doctype, ptype="select", doc=filters[field.fieldname], user=user):
+			if not has_permission(
+				doctype=linked_doctype, ptype="select", doc=filters[field.fieldname], user=user
+			):
 				frappe.throw(
 					_("You do not have permission to access {0}: {1}.").format(
 						linked_doctype, filters[field.fieldname]

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -799,7 +799,7 @@ def validate_filters_permissions(report_name, filters=None, user=None):
 	for field in report.filters:
 		if field.fieldname in filters and field.fieldtype == "Link":
 			linked_doctype = field.options
-			if not has_permission(doctype=linked_doctype, doc=filters[field.fieldname], user=user):
+			if not has_permission(doctype=linked_doctype, ptype="select", doc=filters[field.fieldname], user=user):
 				frappe.throw(
 					_("You do not have permission to access {0}: {1}.").format(
 						linked_doctype, filters[field.fieldname]


### PR DESCRIPTION
~~Weird bug here: the `user` variable can be `None`, and causes reports to fail when there _**are**_ filters, but to work fine when there aren't any filter~~

Wait it's not that… `ptype` should be set to `"select"`, which was the actual bug I encountered

re: https://github.com/frappe/frappe/pull/27771
re: https://github.com/frappe/frappe/pull/28371