### PR TITLE
Fix issue #24222. Accept list values for JSON fieldtype in postgres

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -399,6 +399,9 @@ class BaseDocument:
 							eval_locals={"doc": self},
 						)
 
+				if frappe.db.db_type == "postgres":
+					table_fields += ("JSON", )
+				
 				if isinstance(value, list) and df.fieldtype not in table_fields:
 					frappe.throw(_("Value for {0} cannot be a list").format(_(df.label, context=df.parent)))
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist
-->


This PR addresses [this issue](https://github.com/frappe/frappe/issues/24222) where frappe throws an error "Value for Condition JSON cannot be a list" when saving an doctype with a JSON field which has a list value.


Currently, this prohibits reading/opening doctypes on the desk as well as deletion.

Closes #24222


Screenshots/GIFs

![image](https://github.com/user-attachments/assets/ccbf4397-8028-4844-8590-27646f73e9ad)