### PR TITLE
fix: custom dashboard chart format according to the chart option

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -596,6 +596,12 @@ export default class ChartWidget extends Widget {
 			options = this.report_result.chart.options;
 		}
 
+		if (this.chart_doc.chart_type == "Custom" && this.chart_doc.custom_options) {
+			let chart_options = JSON.parse(this.chart_doc.custom_options);
+			fieldtype = chart_options.fieldtype;
+			options = chart_options.options;
+		}
+
 		chart_args.tooltipOptions = {
 			formatTooltipY: (value) =>
 				frappe.format(


### PR DESCRIPTION
version 15 and 14

fixes: https://discuss.frappe.io/t/dashboard-chart-amount/137316?u=ncp

**Before:**

![image](https://github.com/user-attachments/assets/ee2c5586-5a7c-44c7-bcd9-b27199691b9b)

<img width="574" alt="image" src="https://github.com/user-attachments/assets/fcdda897-99f1-43fc-a17b-22d2492c67a9">


**After:**

![image](https://github.com/user-attachments/assets/9ae354e6-3deb-4e13-a7d2-4055edbcd62e)
