### PR TITLE
fix: add `summary` html element to `acceptable_elements`

### DIFF
--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -311,6 +311,7 @@ acceptable_elements = [
 	"strike",
 	"strong",
 	"sub",
+	"summary",
 	"sup",
 	"table",
 	"tbody",


### PR DESCRIPTION
**Issue:** 

The `summary` html element,

```html
<summary>Hello</summary>
```

is converting to like this:
```html
&lt;summary&gt;Hello&lt;/summary&gt;
```

**Comment DocType:**
![image](https://github.com/user-attachments/assets/63dee4a9-c9ea-49fd-a99d-b1700113e01e)

> [!IMPORTANT]
> Backport is Require
