### PR TITLE
feat: add hook to allow downstream apps to add auto-loading instrumentation for their doctypes

### DIFF
--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -126,7 +126,9 @@ def get_doc_files(files, start_path):
 
 	files = files or []
 
-	for _module, doctype in IMPORTABLE_DOCTYPES:
+	for _module, doctype in IMPORTABLE_DOCTYPES + [
+		(None, frappe.scrub(dt)) for dt in frappe.get_hooks("importable_doctypes")
+	]:
 		doctype_path = os.path.join(start_path, doctype)
 		if os.path.exists(doctype_path):
 			for docname in os.listdir(doctype_path):

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -458,6 +458,9 @@ app_license = "{app_license}"
 # automatically create page for each record of this doctype
 # website_generators = ["Web Page"]
 
+# automatically load and sync documents of this doctype from downstream apps
+# importable_doctypes = [doctype_1]
+
 # Jinja
 # ----------
 


### PR DESCRIPTION
This allows downstream apps to declare importable doc types.

**Example**

- `erpnext`
```python
importable_doctypes = ["EDI Template"]
```

- downstream
```console
colombia_dian/colombia_dian/edi_template/dian_e_invoice/
colombia_dian/colombia_dian/edi_template/dian_e_invoice/dian_e_invoice.check.xml
colombia_dian/colombia_dian/edi_template/dian_e_invoice/dian_e_invoice.json
colombia_dian/colombia_dian/edi_template/dian_e_invoice/dian_e_invoice.xml
```

cc @barredterra 