### PR TITLE
feat: bulk update docs using `case when` queries

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -31,6 +31,7 @@ from frappe.database.utils import (
 )
 from frappe.exceptions import DoesNotExistError, ImplicitCommitError
 from frappe.monitor import get_trace_id
+from frappe.query_builder import Case
 from frappe.query_builder.functions import Count
 from frappe.utils import CallbackManager, cint, get_datetime, get_table_name, getdate, now, sbool
 from frappe.utils import cast as cast_fieldtype
@@ -955,6 +956,139 @@ class Database:
 
 		if dt in self.value_cache:
 			del self.value_cache[dt]
+
+	def bulk_update(
+		self,
+		doctype: str,
+		doc_updates: dict,
+		*,
+		chunk_size: int = 100,
+		modified=None,
+		modified_by=None,
+		update_modified: bool = True,
+		debug=False,
+	):
+		"""
+		:param doctype: DocType to update
+		:param doc_updates: Dictionary of key (docname) and values to update
+		:param chunk_size: Number of documents to update in a single transaction
+		:param modified: Use this as the `modified` timestamp.
+		:param modified_by: Set this user as `modified_by`.
+		:param update_modified: default True. Update `modified` and `modified_by` fields
+		:param debug: Print the query in the developer / js console.
+
+		doc_updates should be in the following format:
+		```py
+		{
+		    "docname1": {
+		        "field1": "value1",
+		        "field2": "value2",
+		        ...
+		    },
+		    "docname2": {
+		        "field1": "value1",
+		        "field2": "value2",
+		        ...
+		    },
+		}
+		```
+
+		Note:
+		    - Bigger chunk sizes could be less performant. Use appropriate chunk size based on the number of fields to update.
+
+		"""
+		if not doc_updates:
+			return
+
+		modified_dict = (
+			self._get_update_dict(
+				{}, None, modified=modified, modified_by=modified_by, update_modified=update_modified
+			)
+			if update_modified
+			else None
+		)
+
+		total_docs = len(doc_updates)
+		iterator = iter(doc_updates.items())
+
+		for __ in range(0, total_docs, chunk_size):
+			doc_chunk = dict(itertools.islice(iterator, chunk_size))
+			self._build_and_run_bulk_update_query(doctype, doc_chunk, modified_dict, debug)
+
+	@staticmethod
+	def _build_and_run_bulk_update_query(doctype: str, doc_updates: dict, modified_dict=None, debug=False):
+		"""
+		:param doctype: DocType to update
+		:param doc_updates: Dictionary of key (docname) and values to update
+		:param debug: Print the query in the developer / js console.
+
+		---
+
+		doc_updates should be in the following format:
+		```py
+		{
+		    "docname1": {
+		        "field1": "value1",
+		        "field2": "value2",
+		        ...
+		    },
+		    "docname2": {
+		        "field1": "value1",
+		        "field2": "value2",
+		        ...
+		    },
+		}
+		```
+
+		---
+
+		Query will be built as:
+		```sql
+		UPDATE `tabItem`
+		SET `status` = CASE
+		    WHEN `name` = 'Item-1' THEN 'Close'
+		    WHEN `name` = 'Item-2' THEN 'Open'
+		    WHEN `name` = 'Item-3' THEN 'Close'
+		    WHEN `name` = 'Item-4' THEN 'Cancelled'
+		    ELSE `status`
+		end,
+		`description` = CASE
+		    WHEN `name` = 'Item-1' THEN 'This is the first task'
+		    WHEN `name` = 'Item-2' THEN 'This is the second task'
+		    WHEN `name` = 'Item-3' THEN 'This is the third task'
+		    WHEN `name` = 'Item-4' THEN 'This is the fourth task'
+		    ELSE `description`
+		end
+		WHERE  `name` IN ( 'Item-1', 'Item-2', 'Item-3', 'Item-4' )
+		```
+		"""
+		if not doc_updates:
+			return
+
+		dt = frappe.qb.DocType(doctype)
+		update_query = frappe.qb.update(dt)
+
+		conditions = {}
+		docnames = list(doc_updates.keys())
+
+		for docname, row in doc_updates.items():
+			for field, value in row.items():
+				# CASE
+				if field not in conditions:
+					conditions[field] = Case()
+
+				# WHEN
+				conditions[field].when(dt.name == docname, value)
+
+		for field in conditions:
+			# ELSE
+			update_query = update_query.set(dt[field], conditions[field].else_(dt[field]))
+
+		if modified_dict:
+			for column, value in modified_dict.items():
+				update_query = update_query.set(dt[column], value)
+
+		update_query.where(dt.name.isin(docnames)).run(debug=debug)
 
 	def set_global(self, key, val, user="__global"):
 		"""Save a global key value. Global values will be automatically set if they match fieldname."""

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -963,10 +963,10 @@ class Database:
 		doc_updates: dict,
 		*,
 		chunk_size: int = 100,
-		modified=None,
-		modified_by=None,
+		modified: str | None = None,
+		modified_by: str | None = None,
 		update_modified: bool = True,
-		debug=False,
+		debug: bool = False,
 	):
 		"""
 		:param doctype: DocType to update
@@ -1000,13 +1000,11 @@ class Database:
 		if not doc_updates:
 			return
 
-		modified_dict = (
-			self._get_update_dict(
+		modified_dict = None
+		if update_modified:
+			modified_dict = self._get_update_dict(
 				{}, None, modified=modified, modified_by=modified_by, update_modified=update_modified
 			)
-			if update_modified
-			else None
-		)
 
 		total_docs = len(doc_updates)
 		iterator = iter(doc_updates.items())
@@ -1016,7 +1014,9 @@ class Database:
 			self._build_and_run_bulk_update_query(doctype, doc_chunk, modified_dict, debug)
 
 	@staticmethod
-	def _build_and_run_bulk_update_query(doctype: str, doc_updates: dict, modified_dict=None, debug=False):
+	def _build_and_run_bulk_update_query(
+		doctype: str, doc_updates: dict, modified_dict: dict | None = None, debug: bool = False
+	):
 		"""
 		:param doctype: DocType to update
 		:param doc_updates: Dictionary of key (docname) and values to update

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -550,6 +550,60 @@ class TestDB(IntegrationTestCase):
 
 		frappe.db.delete("ToDo", {"description": test_body})
 
+	def test_bulk_update(self):
+		test_body = f"test_bulk_update - {random_string(10)}"
+
+		frappe.db.bulk_insert(
+			"ToDo",
+			["name", "description"],
+			[[f"ToDo Test Bulk Update {i}", test_body] for i in range(20)],
+			ignore_duplicates=True,
+		)
+
+		record_names = frappe.get_all("ToDo", filters={"description": test_body}, pluck="name")
+
+		new_descriptions = {name: f"{test_body} - updated - {random_string(10)}" for name in record_names}
+
+		# update with same fields to update
+		frappe.db.bulk_update(
+			"ToDo", {name: {"description": new_descriptions[name]} for name in record_names}
+		)
+
+		# check if all records were updated
+		updated_records = dict(
+			frappe.get_all(
+				"ToDo", filters={"name": ("in", record_names)}, fields=["name", "description"], as_list=True
+			)
+		)
+		self.assertDictEqual(new_descriptions, updated_records)
+
+		# update with different fields to update
+		updates = {
+			record_names[0]: {"priority": "High", "status": "Closed"},
+			record_names[1]: {"status": "Closed"},
+		}
+		frappe.db.bulk_update("ToDo", updates)
+
+		priority, status = frappe.db.get_value("ToDo", record_names[0], ["priority", "status"])
+
+		self.assertEqual(priority, "High")
+		self.assertEqual(status, "Closed")
+
+		# further updates with different fields to update
+		updates = {record_names[0]: {"status": "Open"}, record_names[1]: {"priority": "Low"}}
+		frappe.db.bulk_update("ToDo", updates)
+
+		priority, status = frappe.db.get_value("ToDo", record_names[0], ["priority", "status"])
+		self.assertEqual(priority, "High")  # should stay the same
+		self.assertEqual(status, "Open")
+
+		priority, status = frappe.db.get_value("ToDo", record_names[1], ["priority", "status"])
+		self.assertEqual(priority, "Low")
+		self.assertEqual(status, "Closed")  # should stay the same
+
+		# cleanup
+		frappe.db.delete("ToDo", {"name": ("in", record_names)})
+
 	def test_count(self):
 		frappe.db.delete("Note")
 


### PR DESCRIPTION
### Motivation

When patching data, performance is usually a concern and there is always a worry to update values in a performant way.

### Implementation

Use of CASE..WHEN statements, with a chunk size of 100, reduces the number of DB requests and also keeps query manageable.

### Example Implementation

For India Compliance App, we were required to update tax details for all Sales Invoices and this approach with appropriate chunk size helped us keep the update performant. ([reference](https://github.com/resilient-tech/india-compliance/blob/d82ab151fafb8680ec7c66036bbaff2f628c5111/india_compliance/patches/post_install/improve_item_tax_template.py#L342))

---

### Performance Comparison

Updating 1_00_000 items with 2 keys, `item_name` and `description`.

#### Update using `set_value` 

![image](https://github.com/user-attachments/assets/1acf31cb-62cb-40ab-88a4-4fa6537ebdae)

#### Bulk Update with `chunk_size = 100`

![image](https://github.com/user-attachments/assets/f6a30545-f568-4627-87e4-37c589f26f6f)

#### Bulk Update with `chunk_size = 1000`

![image](https://github.com/user-attachments/assets/d66356da-b610-4837-8c4a-4d64d3a36825)

Bulk update reduces the number of database calls and makes the update ~5x faster.

---

### Documentation

To be updated after this PR is merged at: https://frappeframework.com/docs/user/en/api/database

### frappe.db.bulk_update

`frappe.db.bulk_update(doctype, doc_updates)`

Updates multiple docs with *different* values in a performant way.

Note:
     - Use `frappe.db.set_value` if value to update is same across docs
     - Bigger chunk sizes could be less performant. Use appropriate chunk size based on the number of fields to update.

Example:

```py
# Signature
frappe.db.bulk_update("DocType", {
    "DocName1": {
        "field1": "value1",
        "field2": "value2",
    },
    ...
})

# Example
frappe.db.bulk_update("Item", {
    "ItemCode1": {
        "item_name": "New Item Name ItemCode1",
        "description": "New Item Description ItemCode1",
    },
    "ItemCode2": {
        "item_name": "New Item Name ItemCode2",
        "uom": "New UOM",
    },
    ...
})
```

