### PR TITLE
fix: don't try to rename a doctype that doesn't exist

### DIFF
--- a/frappe/patches/v15_0/migrate_to_utm.py
+++ b/frappe/patches/v15_0/migrate_to_utm.py
@@ -7,5 +7,9 @@ def execute():
 	"""
 	if frappe.db.exists("DocType", "UTM Campaign"):
 		return
+
+	if not frappe.db.exists("DocType", "Marketing Campaign"):
+		return
+
 	frappe.rename_doc("DocType", "Marketing Campaign", "UTM Campaign", force=True)
 	frappe.reload_doctype("UTM Campaign", force=True)


### PR DESCRIPTION
When migrating a database that doesn't contain a table for "Marketing Campaign" yet (because it was added in a later, in-between version), this patch used to fail. Now we attempt to rename the doctype only if it exists.

The patch was introduced in https://github.com/frappe/frappe/pull/27801
