### PR TITLE
feat: allow to store form tours in custom module

### DIFF
--- a/frappe/desk/doctype/form_tour/form_tour.json
+++ b/frappe/desk/doctype/form_tour/form_tour.json
@@ -72,11 +72,11 @@
   {
    "depends_on": "eval: doc.ui_tour && doc.is_standard",
    "fetch_from": "reference_doctype.module",
+   "fetch_if_empty": 1,
    "fieldname": "module",
    "fieldtype": "Link",
    "label": "Module",
-   "options": "Module Def",
-   "read_only": 1
+   "options": "Module Def"
   },
   {
    "fieldname": "column_break_6",
@@ -178,7 +178,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:03:25.983797",
+ "modified": "2024-11-17 13:06:48.120836",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Form Tour",


### PR DESCRIPTION
**Before**

It was not possible to store a form tour as part of an Onboarding in a custom app's module if the reference document was, for example, part of erpnext.

**Now**

The `module` field can be freely set, leading to exporting the form tour into said module.
Only if it's not manually set, the one from the reference doctype will be fetched on save.
