### PR TITLE
feat: enable dynamic, custom list filter options

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -791,7 +791,7 @@ class FilterArea {
 		});
 	}
 
-	make_standard_filters() {
+	async make_standard_filters() {
 		this.standard_filters_wrapper = this.list_view.page.page_form.find(
 			".standard-filter-section"
 		);
@@ -807,12 +807,24 @@ class FilterArea {
 			});
 		}
 
-		if (this.list_view.custom_filter_configs) {
-			this.list_view.custom_filter_configs.forEach((config) => {
-				config.onchange = () => this.debounced_refresh_list_view();
-			});
+		if (
+			this.list_view.custom_filter_configs ||
+			this.list_view.settings.custom_filter_configs
+		) {
+			const custom_filter_configs =
+				this.list_view.custom_filter_configs ||
+				this.list_view.settings.custom_filter_configs;
+			await Promise.resolve(
+				typeof custom_filter_configs === "function"
+					? custom_filter_configs()
+					: custom_filter_configs
+			).then((configs) => {
+				configs.forEach((config) => {
+					config.onchange = () => this.debounced_refresh_list_view();
+				});
 
-			fields = fields.concat(this.list_view.custom_filter_configs);
+				fields = fields.concat(configs);
+			});
 		}
 
 		const doctype_fields = this.list_view.meta.fields;


### PR DESCRIPTION
**Before**

- It was impossible to configure custom list filters, e.g. with dynamic options

**Now**

- Custom list filters can be configured as part of `listview_settings`

**Example**
```js
frappe.listview_settings["EDI Submit Config"] = {
  hide_name_column: true,
  hide_name_filter: true,
  custom_filter_configs: () => frappe.xcall(
      "erpnext.edi.doctype.edi_submit_config.edi_submit_config.get_submit_config_type_options", null, "GET"
  ).then(options => {
    return [{
        fieldname: 'config_type',
        label: __('Config Type'),
        condition: '=',
        is_filter: 1,
        fieldtype: 'Select',
        options: ['', ...options],
    }]
  }),
}
```
```python
@frappe.whitelist()
def get_submit_config_type_options():
	return frappe.get_hooks("edi_submit_config_type_values")
```