### PR TITLE
refactor: throw errors in a pythonic way (deprecates)

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -553,6 +553,7 @@ def msgprint(
 	wide: bool = False,
 	*,
 	realtime=False,
+	__frappe_exc_id: str | None = None,
 ) -> None:
 	"""Print a message to the user (via HTTP response).
 	Messages are sent in the `__server_messages` property in the
@@ -616,9 +617,9 @@ def msgprint(
 	if alert:
 		out.alert = 1
 
-	if raise_exception:
+	if raise_exception or __frappe_exc_id:
 		out.raise_exception = 1
-		out.__frappe_exc_id = generate_hash()
+		out.__frappe_exc_id = __frappe_exc_id or generate_hash()
 
 	if primary_action:
 		out.primary_action = primary_action
@@ -650,6 +651,22 @@ def clear_last_message():
 		local.message_log = local.message_log[:-1]
 
 
+class Throw(Exception):
+	def __init__(self, msg, title=None, is_minimizable=False, wide=False, as_list=False, primary_action=None):
+		super().__init__(msg)
+		self.__frappe_exc_id = generate_hash()
+		msgprint(
+			msg,
+			title=title,
+			indicator="red",
+			is_minimizable=is_minimizable,
+			wide=wide,
+			as_list=as_list,
+			primary_action=primary_action,
+			__frappe_exc_id=self.__frappe_exc_id,
+		)
+
+
 def throw(
 	msg: str,
 	exc: type[Exception] = ValidationError,
@@ -669,16 +686,19 @@ def throw(
 	:param as_list: [optional] If `msg` is a list, render as un-ordered list.
 	:param primary_action: [optional] Bind a primary server/client side action.
 	"""
-	msgprint(
+	# Create and raise the Throw instance
+	throw_instance = Throw(
 		msg,
-		raise_exception=exc,
 		title=title,
-		indicator="red",
 		is_minimizable=is_minimizable,
 		wide=wide,
 		as_list=as_list,
 		primary_action=primary_action,
 	)
+	# Raise the specified exception
+	exception = exc(str(throw_instance))
+	exception.__frappe_exc_id = throw_instance.__frappe_exc_id
+	raise exception
 
 
 def throw_permission_error():

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -696,6 +696,8 @@ def throw(
 		primary_action=primary_action,
 	)
 	# Raise the specified exception
+	if isinstance(exc, Exception):
+		raise ValidationError(msg) from exc
 	exception = exc(str(throw_instance))
 	exception._frappe_exc_id = throw_instance._frappe_exc_id
 	raise exception

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -553,7 +553,7 @@ def msgprint(
 	wide: bool = False,
 	*,
 	realtime=False,
-	__frappe_exc_id: str | None = None,
+	_frappe_exc_id: str | None = None,
 ) -> None:
 	"""Print a message to the user (via HTTP response).
 	Messages are sent in the `__server_messages` property in the
@@ -580,8 +580,8 @@ def msgprint(
 				exc = raise_exception(msg)
 			else:
 				exc = ValidationError(msg)
-			if out.__frappe_exc_id:
-				exc.__frappe_exc_id = out.__frappe_exc_id
+			if out._frappe_exc_id:
+				exc._frappe_exc_id = out._frappe_exc_id
 			raise exc
 
 	if flags.mute_messages:
@@ -617,9 +617,9 @@ def msgprint(
 	if alert:
 		out.alert = 1
 
-	if raise_exception or __frappe_exc_id:
+	if raise_exception or _frappe_exc_id:
 		out.raise_exception = 1
-		out.__frappe_exc_id = __frappe_exc_id or generate_hash()
+		out._frappe_exc_id = _frappe_exc_id or generate_hash()
 
 	if primary_action:
 		out.primary_action = primary_action
@@ -654,7 +654,7 @@ def clear_last_message():
 class Throw(Exception):
 	def __init__(self, msg, title=None, is_minimizable=False, wide=False, as_list=False, primary_action=None):
 		super().__init__(msg)
-		self.__frappe_exc_id = generate_hash()
+		self._frappe_exc_id = generate_hash()
 		msgprint(
 			msg,
 			title=title,
@@ -663,7 +663,7 @@ class Throw(Exception):
 			wide=wide,
 			as_list=as_list,
 			primary_action=primary_action,
-			__frappe_exc_id=self.__frappe_exc_id,
+			_frappe_exc_id=self._frappe_exc_id,
 		)
 
 
@@ -697,7 +697,7 @@ def throw(
 	)
 	# Raise the specified exception
 	exception = exc(str(throw_instance))
-	exception.__frappe_exc_id = throw_instance.__frappe_exc_id
+	exception._frappe_exc_id = throw_instance._frappe_exc_id
 	raise exception
 
 

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -64,11 +64,11 @@ def report_error(status_code):
 
 def _link_error_with_message_log(error_log, exception, message_logs):
 	for message in list(message_logs):
-		if message.get("__frappe_exc_id") == getattr(exception, "__frappe_exc_id", None):
+		if message.get("_frappe_exc_id") == getattr(exception, "_frappe_exc_id", None):
 			error_log.update(message)
 			message_logs.remove(message)
 			error_log.pop("raise_exception", None)
-			error_log.pop("__frappe_exc_id", None)
+			error_log.pop("_frappe_exc_id", None)
 			return
 
 


### PR DESCRIPTION
### Before

```python
try:
	signed = self.sign(render, doc)
except Exception as e:
	frappe.throw(str(e), title="EDI Validation Error")
```
> [!WARNING]
> Convoluted Traceback

### After

```python
try:
	signed = self.sign(render, doc)
except Exception as e:
	raise frappe.Throw(str(e), title="EDI Signing Error") from e
```
>[!NOTE]
> Clean Traceback

---
![image](https://github.com/user-attachments/assets/53052ecc-2257-47d6-98e4-417983b52a28)