### PR TITLE
deprecate: frappe.throw for more pythonic frappe.Throw

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -553,6 +553,7 @@ def msgprint(
 	wide: bool = False,
 	*,
 	realtime=False,
+	__frappe_exc_id: str | None = None,
 ) -> None:
 	"""Print a message to the user (via HTTP response).
 	Messages are sent in the `__server_messages` property in the
@@ -616,9 +617,9 @@ def msgprint(
 	if alert:
 		out.alert = 1
 
-	if raise_exception:
+	if raise_exception or __frappe_exc_id:
 		out.raise_exception = 1
-		out.__frappe_exc_id = generate_hash()
+		out.__frappe_exc_id = __frappe_exc_id or generate_hash()
 
 	if primary_action:
 		out.primary_action = primary_action
@@ -650,6 +651,22 @@ def clear_last_message():
 		local.message_log = local.message_log[:-1]
 
 
+class Throw(Exception):
+	def __init__(self, msg, title=None, is_minimizable=False, wide=False, as_list=False, primary_action=None):
+		super().__init__(msg)
+		self.__frappe_exc_id = generate_hash()
+		msgprint(
+			msg,
+			title=title,
+			indicator="red",
+			is_minimizable=is_minimizable,
+			wide=wide,
+			as_list=as_list,
+			primary_action=primary_action,
+			__frappe_exc_id=self.__frappe_exc_id,
+		)
+
+
 def throw(
 	msg: str,
 	exc: type[Exception] = ValidationError,
@@ -669,16 +686,19 @@ def throw(
 	:param as_list: [optional] If `msg` is a list, render as un-ordered list.
 	:param primary_action: [optional] Bind a primary server/client side action.
 	"""
-	msgprint(
+	# Create and raise the Throw instance
+	throw_instance = Throw(
 		msg,
-		raise_exception=exc,
 		title=title,
-		indicator="red",
 		is_minimizable=is_minimizable,
 		wide=wide,
 		as_list=as_list,
 		primary_action=primary_action,
 	)
+	# Raise the specified exception
+	exception = exc(str(throw_instance))
+	exception.__frappe_exc_id = throw_instance.__frappe_exc_id
+	raise exception
 
 
 def throw_permission_error():

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -696,6 +696,8 @@ def throw(
 		primary_action=primary_action,
 	)
 	# Raise the specified exception
+	if isinstance(exc, Exception):
+		raise ValidationError(msg) from exc
 	exception = exc(str(throw_instance))
 	exception._frappe_exc_id = throw_instance._frappe_exc_id
 	raise exception

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -553,7 +553,7 @@ def msgprint(
 	wide: bool = False,
 	*,
 	realtime=False,
-	__frappe_exc_id: str | None = None,
+	_frappe_exc_id: str | None = None,
 ) -> None:
 	"""Print a message to the user (via HTTP response).
 	Messages are sent in the `__server_messages` property in the
@@ -580,8 +580,8 @@ def msgprint(
 				exc = raise_exception(msg)
 			else:
 				exc = ValidationError(msg)
-			if out.__frappe_exc_id:
-				exc.__frappe_exc_id = out.__frappe_exc_id
+			if out._frappe_exc_id:
+				exc._frappe_exc_id = out._frappe_exc_id
 			raise exc
 
 	if flags.mute_messages:
@@ -617,9 +617,9 @@ def msgprint(
 	if alert:
 		out.alert = 1
 
-	if raise_exception or __frappe_exc_id:
+	if raise_exception or _frappe_exc_id:
 		out.raise_exception = 1
-		out.__frappe_exc_id = __frappe_exc_id or generate_hash()
+		out._frappe_exc_id = _frappe_exc_id or generate_hash()
 
 	if primary_action:
 		out.primary_action = primary_action
@@ -654,7 +654,7 @@ def clear_last_message():
 class Throw(Exception):
 	def __init__(self, msg, title=None, is_minimizable=False, wide=False, as_list=False, primary_action=None):
 		super().__init__(msg)
-		self.__frappe_exc_id = generate_hash()
+		self._frappe_exc_id = generate_hash()
 		msgprint(
 			msg,
 			title=title,
@@ -663,7 +663,7 @@ class Throw(Exception):
 			wide=wide,
 			as_list=as_list,
 			primary_action=primary_action,
-			__frappe_exc_id=self.__frappe_exc_id,
+			_frappe_exc_id=self._frappe_exc_id,
 		)
 
 
@@ -697,7 +697,7 @@ def throw(
 	)
 	# Raise the specified exception
 	exception = exc(str(throw_instance))
-	exception.__frappe_exc_id = throw_instance.__frappe_exc_id
+	exception._frappe_exc_id = throw_instance._frappe_exc_id
 	raise exception
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -576,6 +576,13 @@ def msgprint(
 
 	def _raise_exception():
 		if raise_exception:
+			from frappe.deprecation_dumpster import deprecation_warning
+
+			deprecation_warning(
+				"2024-11-18",
+				"v17",
+				"To raise an exception, use `raise frappe.Throw(...) from e` to re-raise or `raise frappe.Throw(...)` otherwise",
+			)
 			if inspect.isclass(raise_exception) and issubclass(raise_exception, Exception):
 				exc = raise_exception(msg)
 			else:
@@ -667,40 +674,7 @@ class Throw(Exception):
 		)
 
 
-def throw(
-	msg: str,
-	exc: type[Exception] = ValidationError,
-	title: str | None = None,
-	is_minimizable: bool = False,
-	wide: bool = False,
-	as_list: bool = False,
-	primary_action=None,
-) -> None:
-	"""Throw execption and show message (`msgprint`).
-
-	:param msg: Message.
-	:param exc: Exception class. Default `frappe.ValidationError`
-	:param title: [optional] Message title. Default: "Message".
-	:param is_minimizable: [optional] Allow users to minimize the modal
-	:param wide: [optional] Show wide modal
-	:param as_list: [optional] If `msg` is a list, render as un-ordered list.
-	:param primary_action: [optional] Bind a primary server/client side action.
-	"""
-	# Create and raise the Throw instance
-	throw_instance = Throw(
-		msg,
-		title=title,
-		is_minimizable=is_minimizable,
-		wide=wide,
-		as_list=as_list,
-		primary_action=primary_action,
-	)
-	# Raise the specified exception
-	if isinstance(exc, Exception):
-		raise ValidationError(msg) from exc
-	exception = exc(str(throw_instance))
-	exception._frappe_exc_id = throw_instance._frappe_exc_id
-	raise exception
+from frappe.deprecation_dumpster import throw
 
 
 def throw_permission_error():

--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -33,8 +33,7 @@ class Color:
 	CYAN = 96
 
 
-class FrappeDeprecationWarning(Warning):
-	...
+class FrappeDeprecationWarning(Warning): ...
 
 
 try:
@@ -904,3 +903,52 @@ def compat_preload_test_records_upfront(candidates: list):
 						doc = json.loads(f.read())
 						doctype = doc["name"]
 						make_test_records(doctype, commit=True)
+
+
+sentinel = object()
+
+
+@deprecated(
+	"frappe.throw",
+	"2024-11-18",
+	"v17",
+	"Instead, use with same arguments the more pythonic `raise frappe.Throw(...) from e` for re-raise or `raise frappe.Throw(...)` otherwise",
+)
+def throw(
+	msg: str,
+	exc: type[Exception] = sentinel,
+	title: str | None = None,
+	is_minimizable: bool = False,
+	wide: bool = False,
+	as_list: bool = False,
+	primary_action=None,
+) -> None:
+	"""Throw execption and show message (`msgprint`).
+
+	:param msg: Message.
+	:param exc: Exception class. Default `frappe.ValidationError`
+	:param title: [optional] Message title. Default: "Message".
+	:param is_minimizable: [optional] Allow users to minimize the modal
+	:param wide: [optional] Show wide modal
+	:param as_list: [optional] If `msg` is a list, render as un-ordered list.
+	:param primary_action: [optional] Bind a primary server/client side action.
+	"""
+	import frappe
+
+	if exc is sentinel:
+		exc = frappe.ValidationError
+	# Create and raise the Throw instance
+	throw_instance = frappe.Throw(
+		msg,
+		title=title,
+		is_minimizable=is_minimizable,
+		wide=wide,
+		as_list=as_list,
+		primary_action=primary_action,
+	)
+	# Raise the specified exception
+	if isinstance(exc, Exception):
+		raise frappe.ValidationError(msg) from exc
+	exception = exc(str(throw_instance))
+	exception._frappe_exc_id = throw_instance._frappe_exc_id
+	raise exception

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -64,11 +64,11 @@ def report_error(status_code):
 
 def _link_error_with_message_log(error_log, exception, message_logs):
 	for message in list(message_logs):
-		if message.get("__frappe_exc_id") == getattr(exception, "__frappe_exc_id", None):
+		if message.get("_frappe_exc_id") == getattr(exception, "_frappe_exc_id", None):
 			error_log.update(message)
 			message_logs.remove(message)
 			error_log.pop("raise_exception", None)
-			error_log.pop("__frappe_exc_id", None)
+			error_log.pop("_frappe_exc_id", None)
 			return
 
 


### PR DESCRIPTION
Following: https://github.com/frappe/frappe/pull/28503


The decision to deprecate is motivated by the goal to transition the codebase to a more pythonic way of doing things to lower the requirement  for python devs to un- and re-learn

The Tracebacks in the new variant are much shorter and less noisy and should help developers and maintainers to more quickly understand the problem.

- [ ] Finally, at least Frappe & ERPNext should be (mass-)migrated to teach proper precedents.
