### PR TITLE
Feat: Add Clear All Button to MultiSelect Field

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -14,6 +14,11 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 					</li>
 					<div class="selectable-items">
 					</div>
+					<li class="text-right">
+						<button class="btn btn-primary btn-xs clear-selections text-nowrap">
+							Clear All
+    					</button>
+					</li>
 				</ul>
 			</div>
 		`;
@@ -30,6 +35,9 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 		this.highlighted = -1;
 		this.$list_wrapper.on("click", ".dropdown-menu", (e) => {
 			e.stopPropagation();
+		});
+		this.$list_wrapper.on("click", ".clear-selections", (e) => {
+			this.clear_all_selections();
 		});
 		this.$list_wrapper.on("click", ".selectable-item", (e) => {
 			let $target = $(e.currentTarget);
@@ -113,6 +121,14 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 		if (this.df.input_class) {
 			this.$list_wrapper.addClass(this.df.input_class);
 		}
+	}
+
+	clear_all_selections() {
+		this.values = [];
+		this._selected_values = [];
+		this.update_status();
+		this.set_selectable_items(this._options);
+		this.parse_validate_and_set_in_model("");
 	}
 
 	toggle_select_item($selectable_item) {


### PR DESCRIPTION
**Description**:
<!-- no-docs -->

This PR adds a Clear All button to the MultiSelect field dropdown, making it easier for users to clear all selected items at once instead of removing them one by one.

Before:

![image](https://github.com/user-attachments/assets/0d90d995-f853-4c95-a876-761da1840611)

After:

[Screencast from 19-11-24 12:54:23 PM IST.webm](https://github.com/user-attachments/assets/c0fc0ece-242f-41ce-8274-9e44bd3e659a)

