### PR TITLE
fix: import rq.Job correctly

### DIFF
--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -11,6 +11,7 @@ import redis
 from redis.exceptions import BusyLoadingError, ConnectionError
 from rq import Connection, Queue, Worker
 from rq.exceptions import NoSuchJobError
+from rq.job import Job
 from rq.logutils import setup_loghandlers
 from rq.worker import RandomWorker, RoundRobinWorker
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
@@ -22,10 +23,6 @@ from frappe.utils import cint, cstr, get_bench_id
 from frappe.utils.commands import log
 from frappe.utils.deprecations import deprecation_warning
 from frappe.utils.redis_queue import RedisQueue
-
-if TYPE_CHECKING:
-	from rq.job import Job
-
 
 # TTL to keep RQ job logs in redis for.
 RQ_JOB_FAILURE_TTL = 7 * 24 * 60 * 60  # 7 days instead of 1 year (default)


### PR DESCRIPTION
`failed_job_registry` requires it
Broken since #22199

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/rq/worker.py", line 1439, in perform_job
    job.execute_failure_callback(self.death_penalty_class, *exc_info)
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/rq/job.py", line 1376, in execute_failure_callback
    self.failure_callback(self, self.connection, *exc_info)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 487, in truncate_failed_registry
    for job_obj in Job.fetch_many(job_ids=job_ids, connection=connection):
                   ^^^
NameError: name 'Job' is not defined```
