### PR TITLE
fix(background_jobs): init site if required for after_job hooks

### DIFF
--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -276,6 +276,9 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 		return retval
 
 	finally:
+		if not hasattr(frappe.local, "site"):
+			frappe.init(site)
+			frappe.connect()
 		for after_job_task in frappe.get_hooks("after_job"):
 			frappe.call(after_job_task, method=method_name, kwargs=kwargs, result=retval)
 		frappe.local.job.after_job.run()

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -254,6 +254,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 			# 1213 = deadlock
 			# 1205 = lock wait timeout
 			# or RetryBackgroundJobError is explicitly raised
+			frappe.job.after_job.reset()
 			frappe.destroy()
 			time.sleep(retry + 1)
 


### PR DESCRIPTION
If a job has been retried, we'll enter the finally section after `frappe.destroy()` has been called

Make sure we call `init()` and `connect()` in such a scenario