### PR TITLE
refactor: readability of translation tests

### DIFF
--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -26,15 +26,15 @@ class TestTranslation(IntegrationTestCase):
 
 	def test_doctype(self):
 		translation_data = get_translation_data()
-		for key, val in translation_data.items():
-			frappe.local.lang = key
-			original_translation = _(val[0])
+		for lang, (source_string, new_translation) in translation_data.items():
+			frappe.local.lang = lang
+			original_translation = _(source_string)
 
-			translation = create_translation(key, val)
-			self.assertEqual(_(val[0]), val[1])
+			doc = create_translation(lang, source_string, new_translation)
+			self.assertEqual(_(source_string), new_translation)
 
-			frappe.delete_doc("Translation", translation.name)
-			self.assertEqual(_(val[0]), original_translation)
+			frappe.delete_doc("Translation", doc.name)
+			self.assertEqual(_(source_string), original_translation)
 
 	def test_parent_language(self):
 		data = {
@@ -47,9 +47,9 @@ class TestTranslation(IntegrationTestCase):
 			},
 		}
 
-		for ss, lm in data.items():
-			for l, st in lm.items():
-				create_translation(l, (ss, st))
+		for source_string, translations in data.items():
+			for lang, translation in translations.items():
+				create_translation(lang, source_string, translation)
 
 		frappe.local.lang = "es"
 
@@ -87,7 +87,7 @@ class TestTranslation(IntegrationTestCase):
 			los procesadores Intel Core i5 e i7 de quinta generación con Intel HD Graphics 6000 son capaces de hacerlo.
 		"""
 
-		create_translation("es", [source, target])
+		create_translation("es", source, target)
 
 		source = """
 			<span style="font-family: &quot;Amazon Ember&quot;, Arial, sans-serif; font-size:
@@ -117,10 +117,10 @@ def get_translation_data():
 	}
 
 
-def create_translation(key, val):
-	translation = frappe.new_doc("Translation")
-	translation.language = key
-	translation.source_text = val[0]
-	translation.translated_text = val[1]
-	translation.save()
-	return translation
+def create_translation(lang, source_string, new_translation):
+	doc = frappe.new_doc("Translation")
+	doc.language = lang
+	doc.source_text = source_string
+	doc.translated_text = new_translation
+	doc.save()
+	return doc

--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -30,10 +30,10 @@ class TestTranslation(IntegrationTestCase):
 			frappe.local.lang = lang
 			original_translation = _(source_string)
 
-			doc = create_translation(lang, source_string, new_translation)
+			docname = create_translation(lang, source_string, new_translation)
 			self.assertEqual(_(source_string), new_translation)
 
-			frappe.delete_doc("Translation", doc.name)
+			frappe.delete_doc("Translation", docname)
 			self.assertEqual(_(source_string), original_translation)
 
 	def test_parent_language(self):
@@ -117,10 +117,11 @@ def get_translation_data():
 	}
 
 
-def create_translation(lang, source_string, new_translation):
+def create_translation(lang, source_string, new_translation) -> str:
 	doc = frappe.new_doc("Translation")
 	doc.language = lang
 	doc.source_text = source_string
 	doc.translated_text = new_translation
 	doc.save()
-	return doc
+
+	return doc.name


### PR DESCRIPTION
Less unspecific `key`, `val`, more speaking variable names.
