### PR TITLE
chore: clarify arg type in parse_json

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -839,7 +839,7 @@ def parse_json(val):
 	"""
 	if isinstance(val, str):
 		val = json.loads(val)
-	if isinstance(val, dict):
+	if not isinstance(frappe._dict) and isinstance(val, dict):
 		val = frappe._dict(val)
 	return val
 


### PR DESCRIPTION
~~Not sure if this is already optimized away by the interpreter, in case it's not: now we do.~~
