### PR TITLE
fix: meta signature

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -520,7 +520,7 @@ class DocType(Document):
 			self.setup_autoincrement_and_sequence()
 
 		try:
-			frappe.db.updatedb(self.name, Meta(self))
+			frappe.db.updatedb(self.name, Meta(None, bootstrap=self))
 		except Exception as e:
 			print(f"\n\nThere was an issue while migrating the DocType: {self.name}\n")
 			raise e

--- a/frappe/desk/doctype/todo/test_todo.py
+++ b/frappe/desk/doctype/todo/test_todo.py
@@ -39,7 +39,7 @@ class TestToDo(IntegrationTestCase):
 	def test_fetch_setup(self):
 		frappe.db.delete("ToDo")
 
-		todo_meta = frappe.get_doc("DocType", "ToDo")
+		todo_meta = frappe.get_meta("ToDo")
 		todo_meta.get("fields", dict(fieldname="assigned_by_full_name"))[0].fetch_from = ""
 		todo_meta.save()
 
@@ -48,13 +48,14 @@ class TestToDo(IntegrationTestCase):
 		todo = frappe.get_doc(doctype="ToDo", description="test todo", assigned_by="Administrator").insert()
 		self.assertFalse(todo.assigned_by_full_name)
 
-		todo_meta = frappe.get_doc("DocType", "ToDo")
+		todo_meta = frappe.get_meta("ToDo")
 		todo_meta.get("fields", dict(fieldname="assigned_by_full_name"))[
 			0
 		].fetch_from = "assigned_by.full_name"
 		todo_meta.save()
 
 		todo.reload()
+		todo.save()
 
 		self.assertEqual(
 			todo.assigned_by_full_name, frappe.db.get_value("User", todo.assigned_by, "full_name")
@@ -120,7 +121,7 @@ class TestToDo(IntegrationTestCase):
 		frappe.db.delete("ToDo")
 
 		# Allow user changes
-		todo_meta = frappe.get_doc("DocType", "ToDo")
+		todo_meta = frappe.get_meta("ToDo")
 		field = todo_meta.get("fields", dict(fieldname="assigned_by_full_name"))[0]
 		field.fetch_from = "assigned_by.full_name"
 		field.fetch_if_empty = 1


### PR DESCRIPTION
While https://github.com/frappe/frappe/pull/27975 had been truthful, the original implementation was flawed.

This PR fixes this and implements the user's fair expectation by implementing a special bootstrap escape hatch.

Blocks fix over at https://github.com/frappe/erpnext/pull/44231
