### PR TITLE
fix(attach): don't crash when a web form field is read-only

### DIFF
--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -94,7 +94,6 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 		this.last_value = this.value;
 		this.value = value;
 		if (this.value) {
-			this.$input.toggle(false);
 			// value can also be using this format: FILENAME,DATA_URL
 			// Important: We have to be careful because normal filenames may also contain ","
 			let file_url_parts = this.value.match(/^([^:]+),(.+):(.+)$/);
@@ -103,11 +102,22 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 				filename = file_url_parts[1];
 				dataurl = file_url_parts[2] + ":" + file_url_parts[3];
 			}
-			this.$value
-				.toggle(true)
-				.find(".attached-file-link")
-				.html(filename || this.value)
-				.attr("href", dataurl || this.value);
+			if (this.$input && this.$value) {
+				this.$input.toggle(false);
+				this.$value
+					.toggle(true)
+					.find(".attached-file-link")
+					.html(filename || this.value)
+					.attr("href", dataurl || this.value);
+			} else {
+				this.$wrapper.html(`
+					  <div class="attached-file flex justify-between align-center">
+						<div class="ellipsis">
+						  <a href="${dataurl || this.value}" target="_blank">${filename || this.value}</a>
+						</div>
+					  </div>
+				`);
+			}
 		} else {
 			this.$input.toggle(true);
 			this.$value.toggle(false);


### PR DESCRIPTION
`this.$input` and `this.$value` are undefined in those cases

reference: support ticket 25934

<hr>

Create a web form with an attach field marked as read only, with a default value

Before: 
![image](https://github.com/user-attachments/assets/504c0ec5-42f5-4b75-b62f-20ee7c33cb61)


After: 

![image](https://github.com/user-attachments/assets/d4351b7a-6e30-4963-bc7b-062b73eade25)

