### PR TITLE
fix: don't show deprecation on a effective no-op

### DIFF
--- a/frappe/parallel_test_runner.py
+++ b/frappe/parallel_test_runner.py
@@ -85,14 +85,15 @@ class ParallelTestRunner:
 			print("running tests from", "/".join(file_info))
 			return
 
-		from frappe.deprecation_dumpster import deprecation_warning
+		if frappe.session.user != "Administrator":
+			from frappe.deprecation_dumpster import deprecation_warning
 
-		deprecation_warning(
-			"2024-11-13",
-			"v17",
-			"Setting the test environment user to 'Administrator' by the test runner is deprecated. The UnitTestCase now ensures a consistent user environment on set up and tear down at the class level. ",
-		)
-		frappe.set_user("Administrator")
+			deprecation_warning(
+				"2024-11-13",
+				"v17",
+				"Setting the test environment user to 'Administrator' by the test runner is deprecated. The UnitTestCase now ensures a consistent user environment on set up and tear down at the class level. ",
+			)
+			frappe.set_user("Administrator")
 		path, filename = file_info
 		module = self.get_module(path, filename)
 		from frappe.deprecation_dumpster import compat_preload_test_records_upfront


### PR DESCRIPTION
This is designed to improve the noise-to-signal ratio by not shoring the notice if it didn't do anything.