### PR TITLE
fix(quick_list): Ensure fields exist before fetching

### DIFF
--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -205,8 +205,13 @@ export default class QuickListWidget extends Widget {
 
 			let add_fields = frappe.listview_settings?.[this.document_type]?.add_fields;
 			if (Array.isArray(add_fields)) {
-				fields.push(...add_fields);
-				fields = [...new Set(fields)];
+				for (const fieldname of add_fields) {
+					// Only keep fields that exist and are permitted
+					if (frappe.meta.has_field(this.document_type, fieldname)) {
+						fields.push(fieldname);
+					}
+				}
+				fields = [...new Set(fields)]; // Remove duplicates
 			}
 
 			let quick_list_filter = frappe.utils.process_filter_expression(this.quick_list_filter);


### PR DESCRIPTION
Apply suggestion from https://github.com/frappe/frappe/commit/1e08c456dcb29c75bdbe2e2a7c79844db2b3c25c#commitcomment-149428941, might not hurt to have an additional validation