### PR TITLE
ci: this adds universal runtime typechecking during tests to test runners

### DIFF
--- a/frappe/parallel_test_runner.py
+++ b/frappe/parallel_test_runner.py
@@ -14,6 +14,7 @@ import requests
 import frappe
 from frappe.tests.utils import make_test_records
 
+from .testing.environment import _decorate_all_methods_and_functions_with_type_checker
 from .testing.result import TestResult
 
 click_ctx = click.get_current_context(True)
@@ -49,6 +50,7 @@ class ParallelTestRunner:
 		frappe.flags.in_test = True
 		frappe.clear_cache()
 		frappe.utils.scheduler.disable_scheduler()
+		_decorate_all_methods_and_functions_with_type_checker()
 		self.before_test_setup()
 
 	def before_test_setup(self):

--- a/frappe/testing/environment.py
+++ b/frappe/testing/environment.py
@@ -24,6 +24,8 @@ import inspect
 import logging
 import unittest
 
+import tomllib
+
 import frappe
 import frappe.utils.scheduler
 from frappe.tests.utils import make_test_records
@@ -85,9 +87,21 @@ def _disable_scheduler_if_needed():
 def _decorate_all_methods_and_functions_with_type_checker():
 	from frappe.utils.typing_validations import validate_argument_types
 
-	# TODO: dial this up slowly and fix errors along the way
-	max_depth = 1
-	skip_namespaces = ["frappe.deprecation_dumpster", "frappe.utils.typing_validations"]
+	def _get_config_from_pyproject(app_path):
+		try:
+			with open(f"{app_path}/pyproject.toml", "rb") as f:
+				config = tomllib.load(f)
+				return (
+					config.get("tool", {})
+					.get("frappe", {})
+					.get("testing", {})
+					.get("function_type_validation", {})
+				)
+		except FileNotFoundError:
+			return {}
+		except tomllib.TOMLDecodeError:
+			logger.warning(f"Failed to parse pyproject.toml for app {app_path}")
+			return {}
 
 	def _decorate_callable(obj, apps, parent_module):
 		# whitelisted methods are already checked, see frappe.whitelist
@@ -99,7 +113,9 @@ def _decorate_all_methods_and_functions_with_type_checker():
 		elif module := getattr(obj, "__module__", ""):
 			if (app := module.split(".", 1)[0]) and app not in apps:
 				return obj
-			elif any(module.startswith(n) for n in skip_namespaces):
+			config = _get_config_from_pyproject(frappe.get_app_source_path(app))
+			skip_namespaces = config.get("skip_namespaces", [])
+			if any(module.startswith(n) for n in skip_namespaces):
 				return obj
 
 		@functools.wraps(obj)
@@ -116,16 +132,9 @@ def _decorate_all_methods_and_functions_with_type_checker():
 
 		return wrapper
 
-	def _decorate_module(module, apps, current_depth=0):
+	def _decorate_module(module, apps, current_depth, max_depth):
 		if current_depth >= max_depth:
 			return
-		elif name := module.__name__:
-			if name.split(".", 1)[0] not in apps:
-				return
-			elif "deprecation_dumpster" in name:
-				return
-			elif "typing_validations" in name:
-				return
 		if (app := module.__name__.split(".", 1)[0]) and app not in apps:
 			return
 		for name in dir(module):
@@ -135,16 +144,21 @@ def _decorate_all_methods_and_functions_with_type_checker():
 					continue
 				setattr(module, name, _decorate_callable(obj, apps, module))
 			elif inspect.ismodule(obj):
-				_decorate_module(obj, apps, current_depth + 1)
+				if hasattr(obj, "_is_decorated_for_validate_argument_types"):
+					continue
+				obj._is_decorated_for_validate_argument_types = True
+				_decorate_module(obj, apps, current_depth + 1, max_depth)
 
 	for app in (apps := frappe.get_installed_apps()):
+		config = _get_config_from_pyproject(frappe.get_app_source_path(app))
+		max_depth = config.get("max_module_depth", float("inf"))
 		logger.info(
 			f"Decorating callables with type validator up to module depth {max_depth+1} in {app!r} ..."
 		)
 		for module_name in frappe.local.app_modules.get(app) or []:
 			try:
 				module = frappe.get_module(f"{app}.{module_name}")
-				_decorate_module(module, apps)
+				_decorate_module(module, apps, 0, max_depth)
 			except ImportError:
 				logger.error(f"Error importing module {app}.{module_name}")
 

--- a/frappe/testing/environment.py
+++ b/frappe/testing/environment.py
@@ -19,6 +19,8 @@ These functions and classes are typically used by the test runner to set up
 and tear down the test environment before and after test execution.
 """
 
+import functools
+import inspect
 import logging
 import unittest
 
@@ -52,6 +54,8 @@ def _initialize_test_environment(site, config):
 	frappe.flags.print_messages = logger.getEffectiveLevel() < logging.INFO
 	frappe.flags.tests_verbose = logger.getEffectiveLevel() < logging.INFO
 
+	_decorate_all_methods_and_functions_with_type_checker()
+
 
 def _cleanup_after_tests():
 	"""Perform cleanup operations after running tests"""
@@ -75,6 +79,74 @@ def _disable_scheduler_if_needed():
 	scheduler_disabled_by_user = frappe.utils.scheduler.is_scheduler_disabled(verbose=False)
 	if not scheduler_disabled_by_user:
 		frappe.utils.scheduler.disable_scheduler()
+
+
+@debug_timer
+def _decorate_all_methods_and_functions_with_type_checker():
+	from frappe.utils.typing_validations import validate_argument_types
+
+	# TODO: dial this up slowly and fix errors along the way
+	max_depth = 1
+	skip_namespaces = ["frappe.deprecation_dumpster", "frappe.utils.typing_validations"]
+
+	def _decorate_callable(obj, apps, parent_module):
+		# whitelisted methods are already checked, see frappe.whitelist
+		if getattr(obj, "__func__", obj) in frappe.whitelisted:
+			return obj
+		# Check if the function is already decorated
+		elif hasattr(obj, "_is_decorated_for_validate_argument_types"):
+			return obj
+		elif module := getattr(obj, "__module__", ""):
+			if (app := module.split(".", 1)[0]) and app not in apps:
+				return obj
+			elif any(module.startswith(n) for n in skip_namespaces):
+				return obj
+
+		@functools.wraps(obj)
+		def wrapper(*args, **kwargs):
+			try:
+				return validate_argument_types(obj)(*args, **kwargs)
+			except TypeError as e:
+				# breakpoint()
+				raise e
+
+		wrapper._is_decorated_for_validate_argument_types = True
+
+		logger.debug(f"... patching {obj.__module__}.{obj.__name__} in {parent_module.__name__}")
+
+		return wrapper
+
+	def _decorate_module(module, apps, current_depth=0):
+		if current_depth >= max_depth:
+			return
+		elif name := module.__name__:
+			if name.split(".", 1)[0] not in apps:
+				return
+			elif "deprecation_dumpster" in name:
+				return
+			elif "typing_validations" in name:
+				return
+		if (app := module.__name__.split(".", 1)[0]) and app not in apps:
+			return
+		for name in dir(module):
+			obj = getattr(module, name)
+			if inspect.isfunction(obj):
+				if not hasattr(obj, "__annotations__"):
+					continue
+				setattr(module, name, _decorate_callable(obj, apps, module))
+			elif inspect.ismodule(obj):
+				_decorate_module(obj, apps, current_depth + 1)
+
+	for app in (apps := frappe.get_installed_apps()):
+		logger.info(
+			f"Decorating callables with type validator up to module depth {max_depth+1} in {app!r} ..."
+		)
+		for module_name in frappe.local.app_modules.get(app) or []:
+			try:
+				module = frappe.get_module(f"{app}.{module_name}")
+				_decorate_module(module, apps)
+			except ImportError:
+				logger.error(f"Error importing module {app}.{module_name}")
 
 
 class IntegrationTestPreparation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,13 @@ test = [
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.frappe.testing.function_type_validation]
+max_module_depth = 1
+skip_namespaces = [
+    "frappe.deprecation_dumpster",
+    "frappe.utils.typing_validations",
+]
+
 [tool.bench.dev-dependencies]
 coverage = "~=6.5.0"
 Faker = "~=18.10.1"


### PR DESCRIPTION
> [!IMPORTANT]
> ##### For Downstream:
> ###### please configure `tool.frappe.testing.*` in  your `pyproject.toml` according to your needs (see frappe's `pyproject.toml` for the options)


> [!NOTE]
> - `max_module_depth` means: _"Decorate functions with a type validator during tests up to this level deep recursing modules and packages"_
> - `skip_namespaces` means: _"Entirely exempt these namespace prefixes from this procedure"_


> [!TIP]
> Under the hood, the well-known (from `frappe.whitelist`) typing validations are recursively applied to all functions within modules and packages. This works by replacing in-place (monkey patching) each function with a decorated alternative.
> Namespace checkers make sure that no recursions into library packages could happen and only functions part of installed apps are decorated, whereby each app is governed by its own `pyproject.toml`. 
> This can sometimes lead to unexpected external effects on your own CI that should be collaboratively resolved with (the maintainers of) your co-dependent apps.
> #### Example Config
> ```toml
> # hrms/pyproject.toml
> [tool.frappe.testing.function_type_validation]
> max_module_depth = 1  # this patches all functions within `hrms/__init__.py`
> ```
> ```toml
> # hrms/pyproject.toml
> [tool.frappe.testing.function_type_validation]
> max_module_depth = 2   # this patches all functions within `lending/{__init__.py,*.py,*/__init__.py}`
> skip_namespaces = [
>     "lending.foo",  # but exempts `lending.foo` as well as `lending.foo.*` from patching
> ]
> ```


This PR expands on the precedent implemented on `frappe.whitelist` and enables universal
type checking in test runners.

This ensures that, where types are defined, they are now validated that at least no type
employed during tests is missing in the declaration.

Or in other words: **At least not "lie" about types**


**Example debug output** (for context of what this does):

(with app scope `--app erpnext`)


```console
2024-11-28 13:23:32,561 DEBUG frappe.testing Initializing test environment for site: test_site
2024-11-28 13:23:32,932 INFO frappe.testing Decorating callables with type validator up to module depth 2 in 'frappe' ...
2024-11-28 13:23:32,932 DEBUG frappe.testing ... patching frappe.email.get_system_managers in frappe.email
2024-11-28 13:23:32,933 DEBUG frappe.testing ... patching frappe.email.sendmail_to_system_managers in frappe.email
2024-11-28 13:23:32,933 INFO frappe.testing Decorating callables with type validator up to module depth 2 in 'erpnext' ...
2024-11-28 13:23:32,935 DEBUG frappe.testing ... patching frappe._ in erpnext.stock
2024-11-28 13:23:32,935 DEBUG frappe.testing ... patching erpnext.stock.get_company_default_inventory_account in erpnext.stock
2024-11-28 13:23:32,935 DEBUG frappe.testing ... patching erpnext.stock.get_warehouse_account in erpnext.stock
2024-11-28 13:23:32,935 DEBUG frappe.testing ... patching erpnext.stock.get_warehouse_account_map in erpnext.stock
2024-11-28 13:23:32,935 DEBUG frappe.testing ... patching frappe._ in erpnext.utilities
2024-11-28 13:23:32,936 DEBUG frappe.testing ... patching frappe.utils.data.cstr in erpnext.utilities
2024-11-28 13:23:32,936 DEBUG frappe.testing ... patching erpnext.utilities.activation.get_level in erpnext.utilities
2024-11-28 13:23:32,936 DEBUG frappe.testing ... patching erpnext.utilities.get_site_info in erpnext.utilities
2024-11-28 13:23:32,936 DEBUG frappe.testing ... patching erpnext.utilities.payment_app_import_guard in erpnext.utilities
2024-11-28 13:23:32,936 DEBUG frappe.testing ... patching erpnext.utilities.update_doctypes in erpnext.utilities
2024-11-28 13:23:32,936 DEBUG frappe.testing ... patching frappe._ in erpnext.regional
2024-11-28 13:23:32,936 DEBUG frappe.testing ... patching erpnext.regional.check_deletion_permission in erpnext.regional
2024-11-28 13:23:32,937 DEBUG frappe.testing ... patching erpnext.regional.create_transaction_log in erpnext.regional
2024-11-28 13:23:32,937 DEBUG frappe.testing ... patching erpnext.get_region in erpnext.regional
2024-11-28 13:23:32,938 INFO frappe.testing Decorating callables with type validator up to module depth 2 in 'payments' ...
2024-11-28 13:23:32,939 DEBUG frappe.testing  _decorate_all_methods_and_functions_with_type_checker  ⌛ 0.007 seconds
```

Note: It is in-place monkey patching and updating the namespace of each import, separately. This is ok.