### PR TITLE
chore: use deprecation dumpster for remaining deprecated decorator

### DIFF
--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -981,3 +981,23 @@ def compat_preload_test_records_upfront(candidates: list):
 						doc = json.loads(f.read())
 						doctype = doc["name"]
 						make_test_records(doctype, commit=True)
+
+
+@deprecated(
+	"frappe.utils.data.get_number_format_info",
+	"unknown",
+	"v16",
+	"Use `NumberFormat.from_string()` from `frappe.utils.number_format` instead",
+)
+def get_number_format_info(format: str) -> tuple[str, str, int]:
+	"""DEPRECATED: use `NumberFormat.from_string()` from `frappe.utils.number_format` instead.
+
+	Return the decimal separator, thousands separator and precision for the given number `format` string.
+
+	e.g. get_number_format_info('#,##,###.##') -> ('.', ',', 2)
+
+	Will return ('.', ',', 2) for format strings which can't be guessed.
+	"""
+	from frappe.utils.number_format import NUMBER_FORMAT_MAP
+
+	return NUMBER_FORMAT_MAP.get(format) or (".", ",", 2)

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1425,21 +1425,24 @@ def fmt_money(
 	return amount
 
 
-# keep for backwards compatibility
-number_format_info = NUMBER_FORMAT_MAP
+from frappe.deprecation_dumpster import get_number_format_info
 
 
-@deprecated
-def get_number_format_info(format: str) -> tuple[str, str, int]:
-	"""DEPRECATED: use `NumberFormat.from_string()` from `frappe.utils.number_format` instead.
+def __getattr__(name):
+	if name == "number_format_info":
+		from frappe.deprecation_dumpster import deprecation_warning
+		from frappe.utils.number_format import NUMBER_FORMAT_MAP
 
-	Return the decimal separator, thousands separator and precision for the given number `format` string.
-
-	e.g. get_number_format_info('#,##,###.##') -> ('.', ',', 2)
-
-	Will return ('.', ',', 2) for format strings which can't be guessed.
-	"""
-	return NUMBER_FORMAT_MAP.get(format) or (".", ",", 2)
+		deprecation_warning(
+			"unkown",
+			"v16",
+			"use frappe.utils.number_format.NUMBER_FORMAT_MAP instead of frappe.utils.data.number_format_info",
+		)
+	else:
+		try:
+			globals()[name]
+		except KeyError:
+			raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 #


### PR DESCRIPTION
cc @akhilnarang - this shows how to deprecate a module attribute properly using a module-level `__getattr__`