### PR TITLE
ci: add unified success check

### DIFF
--- a/.github/workflows/_base-migration.yml
+++ b/.github/workflows/_base-migration.yml
@@ -15,15 +15,6 @@ on:
         type: number
         default: 20
 jobs:
-  # This satisfies the required checks on pull requests if tests are intentionally skipped
-  migration-test-fake:
-    name: Migrate
-    runs-on: ubuntu-latest
-    if: ${{ inputs.fake-success != false }}
-    steps:
-      - name: Pass skipped tests unconditionally
-        run: "echo Skipped"
-
   migration-test:
     name: Migrate
     runs-on: ubuntu-latest
@@ -129,3 +120,22 @@ jobs:
           echo "Printing log: $f";
           cat $f
         done
+
+  migration-test-success:
+    name: Success
+    needs: migration-test
+    runs-on: ubuntu-latest
+    if: ${{ inputs.fake-success == false }}
+    steps:
+      - name: Passed
+        run: "echo Passed"
+
+  # This satisfies the required checks on pull requests if tests are intentionally skipped
+  migration-test-success-fake:
+    name: Success
+    runs-on: ubuntu-latest
+    if: ${{ inputs.fake-success != false }}
+    steps:
+      - name: Pass skipped tests unconditionally
+        run: "echo Skipped"
+

--- a/.github/workflows/_base-server-tests.yml
+++ b/.github/workflows/_base-server-tests.yml
@@ -47,20 +47,6 @@ jobs:
         run: |
           indices=$(seq -s ',' 1 ${{ inputs.parallel-runs }}); echo "indices=[${indices}]" >> $GITHUB_OUTPUT
 
-  # This satisfies the required checks on pull requests if tests are intentionally skipped
-  integration-test-fake:
-    needs: gen-idx-integration
-    name: Integration
-    runs-on: ubuntu-latest
-    if: ${{ inputs.fake-success != false }}
-    strategy:
-      matrix:
-        db: ${{ fromJson(inputs.enable-postgres && '["mariadb", "postgres"]' || '["mariadb"]') }}
-        index: ${{ fromJson(needs.gen-idx-integration.outputs.indices) }}
-    steps:
-      - name: Pass skipped tests unconditionally
-        run: "echo Skipped"
-
   integration-test:
     needs: gen-idx-integration
     name: Integration
@@ -172,3 +158,22 @@ jobs:
             echo "Printing log: $f";
             cat $f
           done
+
+  integration-test-success:
+    needs: [unit-test, integration-test]
+    name: Success
+    runs-on: ubuntu-latest
+    if: ${{ inputs.fake-success == false }}
+    steps:
+      - name: Passed
+        run: "echo Passed"
+
+  # This satisfies the required checks on pull requests if tests are intentionally skipped
+  integration-test-success-fake:
+    name: Success
+    runs-on: ubuntu-latest
+    if: ${{ inputs.fake-success != false }}
+    steps:
+      - name: Pass skipped tests unconditionally
+        run: "echo Skipped"
+

--- a/.github/workflows/_base-ui-tests.yml
+++ b/.github/workflows/_base-ui-tests.yml
@@ -35,20 +35,6 @@ jobs:
         run: |
           indices=$(seq -s ',' 1 ${{ inputs.parallel-runs }}); echo "indices=[${indices}]" >> $GITHUB_OUTPUT
 
-  # This satisfies the required checks on pull requests if tests are intentionally skipped
-  ui-test-fake:
-    needs: gen-idx-integration
-    name: Integration
-    runs-on: ubuntu-latest
-    if: ${{ inputs.fake-success != false }}
-    strategy:
-      matrix:
-        db: ["mariadb"]
-        index: ${{ fromJson(needs.gen-idx-integration.outputs.indices) }}
-    steps:
-      - name: Pass skipped tests unconditionally
-        run: "echo Skipped"
-
   ui-test:
     needs: gen-idx-integration
     name: Integration
@@ -160,3 +146,21 @@ jobs:
             echo "Printing log: $f";
             cat $f
           done
+
+  ui-test-success:
+    needs: ui-test
+    name: Success
+    runs-on: ubuntu-latest
+    if: ${{ inputs.fake-success == false }}
+    steps:
+      - name: Passed
+        run: "echo Passed"
+  # This satisfies the required checks on pull requests if tests are intentionally skipped
+  ui-test-success-fake:
+    name: Success
+    runs-on: ubuntu-latest
+    if: ${{ inputs.fake-success != false }}
+    steps:
+      - name: Pass skipped tests unconditionally
+        run: "echo Skipped"
+


### PR DESCRIPTION
The unified success check should help setting merge requirements more uniformly and make it possible to scale tests more easily without the complicated procedure of adapting the CI checks.