### PR TITLE
refactor: change filter from tuple to dict

### DIFF
--- a/frappe/search/website_search.py
+++ b/frappe/search/website_search.py
@@ -94,7 +94,7 @@ def slugs_with_web_view(_items_to_index):
 	for doctype in doctype_with_web_views:
 		if doctype.is_published_field:
 			fields = ["route", doctype.website_search_field]
-			filters = ({doctype.is_published_field: 1},)
+			filters = {doctype.is_published_field: 1}
 			if doctype.website_search_field:
 				docs = frappe.get_all(doctype.name, filters=filters, fields=[*fields, "title"])
 				for doc in docs:


### PR DESCRIPTION
While list/dict both work and technically so does a tuple,
the original intention in #13831 seems to have been a dict.
A trailing comma got left behind, which changed it to a tuple.
