### PR TITLE
feat: Enable "Apply Strict User Permissions" on a per-user basis

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -26,9 +26,10 @@
   "currency_precision",
   "rounding_method",
   "permissions",
-  "apply_strict_user_permissions",
   "column_break_21",
   "allow_older_web_view_links",
+  "column_break_yuvf",
+  "apply_strict_user_permissions",
   "security_tab",
   "security",
   "session_expiry",
@@ -220,6 +221,7 @@
    "description": "If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User",
    "fieldname": "apply_strict_user_permissions",
    "fieldtype": "Check",
+   "hidden": 1,
    "label": "Apply Strict User Permissions"
   },
   {
@@ -692,12 +694,16 @@
    "fieldtype": "Link",
    "label": "Currency",
    "options": "Currency"
+  },
+  {
+   "fieldname": "column_break_yuvf",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2024-11-04 15:51:39.954876",
+ "modified": "2024-11-27 00:33:01.115484",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -34,6 +34,8 @@
   "modules_html",
   "block_modules",
   "home_settings",
+  "permissions_section",
+  "apply_strict_user_permissions",
   "short_bio",
   "gender",
   "birth_date",
@@ -825,6 +827,19 @@
    "fieldname": "dashboard",
    "fieldtype": "Check",
    "label": "Dashboard"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "permissions_section",
+   "fieldtype": "Section Break",
+   "label": "Permissions"
+  },
+  {
+   "default": "0",
+   "description": "If Apply Strict User Permission is checked and User Permission is defined for a DocType for this User, then all the documents where value of the link is blank, will not be shown to this User",
+   "fieldname": "apply_strict_user_permissions",
+   "fieldtype": "Check",
+   "label": "Apply Strict User Permissions"
   }
  ],
  "icon": "fa fa-user",
@@ -887,7 +902,7 @@
    "link_fieldname": "user"
   }
  ],
- "modified": "2024-09-27 11:41:13.336662",
+ "modified": "2024-11-27 00:23:36.345399",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -67,6 +67,7 @@ class User(Document):
 		allowed_in_mentions: DF.Check
 		api_key: DF.Data | None
 		api_secret: DF.Password | None
+		apply_strict_user_permissions: DF.Check
 		banner_image: DF.AttachImage | None
 		bio: DF.SmallText | None
 		birth_date: DF.Date | None

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1015,7 +1015,7 @@ class DatabaseQuery:
 
 			if user_permission_values:
 				docs = []
-				if frappe.get_system_settings("apply_strict_user_permissions"):
+				if frappe.db.get_value("User", frappe.session.user, "apply_strict_user_permissions"):
 					condition = ""
 				else:
 					empty_value_condition = cast_name(

--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -66,8 +66,7 @@ def get_mapped_doc(
 	ignore_child_tables=False,
 	cached=False,
 ):
-	apply_strict_user_permissions = frappe.get_system_settings("apply_strict_user_permissions")
-
+	apply_strict_user_permissions = frappe.db.get_value("User", frappe.session.user, "apply_strict_user_permissions")
 	# main
 	if not target_doc:
 		target_doctype = table_maps[from_doctype]["doctype"]

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -334,7 +334,7 @@ def has_user_permission(doc, user=None, debug=False):
 
 	# don't apply strict user permissions for single doctypes since they contain empty link fields
 	apply_strict_user_permissions = (
-		False if doc.meta.issingle else frappe.get_system_settings("apply_strict_user_permissions")
+		False if doc.meta.issingle else frappe.db.get_value("User", user, "apply_strict_user_permissions")
 	)
 	if apply_strict_user_permissions:
 		debug and _debug_log("Strict user permissions will be applied")


### PR DESCRIPTION
Previously, the "Apply Strict User Permissions" setting was defined globally in the system settings. With this update, the feature can now be enabled on a per-user basis under the Permissions section within the user configuration. This allows for greater flexibility and control over user-specific permissions.

![image](https://github.com/user-attachments/assets/ebd7e4c2-9324-4ade-8a16-109d13f44297)

