### PR TITLE
feat: Disable allow renaming country

### DIFF
--- a/frappe/geo/doctype/country/country.json
+++ b/frappe/geo/doctype/country/country.json
@@ -1,7 +1,6 @@
 {
  "actions": [],
  "allow_import": 1,
- "allow_rename": 1,
  "autoname": "field:country_name",
  "creation": "2013-01-19 10:23:30",
  "doctype": "DocType",
@@ -54,7 +53,7 @@
  "icon": "fa fa-globe",
  "idx": 1,
  "links": [],
- "modified": "2022-08-05 18:33:27.880783",
+ "modified": "2024-11-27 16:56:04.850422",
  "modified_by": "Administrator",
  "module": "Geo",
  "name": "Country",


### PR DESCRIPTION
Issue: [Closes #44199](https://github.com/frappe/erpnext/issues/44199#issue-2669068028)

Solution: Disable allow renaming for country doctype.

Backport needed: Version-15, Version-14