### PR TITLE
fix: Enable fetching datetime fields from linked doctypes using fetch_from

### DIFF
--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -214,6 +214,7 @@ frappe.ui.form.ScriptManager = class ScriptManager {
 					"Float",
 					"Int",
 					"Date",
+					"Datetime",
 					"Select",
 					"Duration",
 					"Time",


### PR DESCRIPTION
Closes #28583
This fix resolves an issue where Datetime fields were not fetched correctly using the fetch_from property in linked doctypes. While Date, Data, and other fields fetched as expected, Datetime fields remained blank. With this update, Datetime fields now fetch correctly.

**Before:**



[before.webm](https://github.com/user-attachments/assets/8375d99a-985e-4e1f-976b-95ea0edefb19)

**After:**

[after.webm](https://github.com/user-attachments/assets/c02bb34c-da2b-4139-b3b8-a307e3c29273)

