### PR TITLE
ci: make db-migration arifact part of the workflow inputs

### DIFF
--- a/.github/workflows/_base-migration.yml
+++ b/.github/workflows/_base-migration.yml
@@ -63,7 +63,6 @@ jobs:
         bench --site test_site --force restore ${GITHUB_WORKSPACE}/$(basename "$DB_ARTIFACT_URL")
 
         function update_to_version() {
-            eval "$(tombl -e FRAPPE_DEPENDENCIES=tool.bench.frappe-dependencies ${GITHUB_WORKSPACE}/apps/${{ github.event.repository.name }}/pyproject.toml)" || true
             version="$1"
             if [ -z "$version" ]; then
                 base_ref="${{ github.base_ref || github.ref_name }}"

--- a/.github/workflows/_base-migration.yml
+++ b/.github/workflows/_base-migration.yml
@@ -17,6 +17,9 @@ on:
         required: false
         type: number
         default: 20
+      db-artifact-url:
+        required: false
+        type: string
 jobs:
   migration-test:
     name: Migrate
@@ -52,11 +55,12 @@ jobs:
         ${{ inputs.pre }}
 
     - name: Download database artifact
+      env:
+        DB_ARTIFACT_URL: ${{ inputs.db-artifact-url }}
       run: |
-        eval "$(tombl -e MIGRATION_DB=tool.frappe-ci.setup.migration-db ${GITHUB_WORKSPACE}/apps/${{ github.event.repository.name }}/pyproject.toml)" || exit 0
         source ${GITHUB_WORKSPACE}/env/bin/activate
-        wget "$MIGRATION_DB"
-        bench --site test_site --force restore ${GITHUB_WORKSPACE}/$(basename "$MIGRATION_DB")
+        wget "$DB_ARTIFACT_URL"
+        bench --site test_site --force restore ${GITHUB_WORKSPACE}/$(basename "$DB_ARTIFACT_URL")
 
         function update_to_version() {
             eval "$(tombl -e FRAPPE_DEPENDENCIES=tool.bench.frappe-dependencies ${GITHUB_WORKSPACE}/apps/${{ github.event.repository.name }}/pyproject.toml)" || true

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -56,7 +56,7 @@ jobs:
     needs: checkrun
     uses: frappe/frappe/.github/workflows/_base-migration.yml@develop
     with:
-      db-artifact-url: https://frappeframework.com/files/v13-frappe.sql.gz
+      # db-artifact-url: https://frappeframework.com/files/v13-frappe.sql.gz
       python-version: '3.10'
       node-version: 20
       fake-success: ${{ needs.checkrun.outputs.build != 'strawberry' }}

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -56,6 +56,7 @@ jobs:
     needs: checkrun
     uses: frappe/frappe/.github/workflows/_base-migration.yml@develop
     with:
+      db-artifact-url: https://frappeframework.com/files/v13-frappe.sql.gz
       python-version: '3.10'
       node-version: 20
       fake-success: ${{ needs.checkrun.outputs.build != 'strawberry' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,9 +149,6 @@ responses = "==0.23.1"
 freezegun = "~=1.2.2"
 pdbpp = "~=0.10.3"
 
-[tool.frappe-ci.setup]
-migration-db = "https://frappeframework.com/files/v13-frappe.sql.gz"
-
 [tool.ruff]
 line-length = 110
 target-version = "py310"


### PR DESCRIPTION
- **ci: make db-migration arifact part of the workflow inputs**
- **ci: chore cleanup**

There's no need nor value to constitute a new `pyproject.toml` config item. Having the migration db url as workflow input, it remains in-context and documented.
