### PR TITLE
feat: validate amended from record docstatus

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -392,6 +392,7 @@ class Document(BaseDocument, DocRef):
 		self.flags.in_insert = True
 
 		if self.get("amended_from"):
+			self.validate_amended_from()
 			self.copy_attachments_from_amended_from()
 
 		relink_mismatched_files(self)
@@ -479,6 +480,13 @@ class Document(BaseDocument, DocRef):
 			delattr(self, "__unsaved")
 
 		return self
+
+	def validate_amended_from(self):
+		if frappe.db.get_value(self.doctype, self.get("amended_from"), "docstatus") != 2:
+			message = _(
+				"{0} cannot be amended because it is not cancelled. Please cancel the document before creating an amendment."
+			).format(frappe.utils.get_link_to_form(self.doctype, self.get("amended_from")))
+			frappe.throw(message, title=_("Amendment Not Allowed"))
 
 	def copy_attachments_from_amended_from(self):
 		"""Copy attachments from `amended_from`"""


### PR DESCRIPTION
Issue: While doing data import if a user give submitted record in amended from field the creation is happening.

Solution: Added a validation for amended from record in insert.

Before:

![Screenshot from 2024-11-20 19-17-10](https://github.com/user-attachments/assets/5f0cffd7-a774-4379-984b-cc50e87abdc4)


After:

![image](https://github.com/user-attachments/assets/a8d67f7a-ed31-4bb9-8a79-21b3a5b2e81d)


Backport needed: Version 15
