### PR TITLE
fix: Allow read-only fields to display even without value

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -88,6 +88,7 @@
   "system_updates_section",
   "disable_system_update_notification",
   "disable_change_log_notification",
+  "hide_empty_read_only_fields",
   "backups_tab",
   "sec_backup_limit",
   "backup_limit",
@@ -692,12 +693,18 @@
    "fieldtype": "Link",
    "label": "Currency",
    "options": "Currency"
+  },
+  {
+   "default": "1",
+   "fieldname": "hide_empty_read_only_fields",
+   "fieldtype": "Check",
+   "label": "Hide Empty Read-Only Fields"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2024-11-04 15:51:39.954876",
+ "modified": "2024-12-03 16:23:09.410614",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -60,6 +60,7 @@ class SystemSettings(Document):
 		float_precision: DF.Literal["", "2", "3", "4", "5", "6", "7", "8", "9"]
 		force_user_to_reset_password: DF.Int
 		force_web_capture_mode_for_uploads: DF.Check
+		hide_empty_read_only_fields: DF.Check
 		hide_footer_in_auto_email_reports: DF.Check
 		language: DF.Link
 		lifespan_qrcode_image: DF.Int

--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -123,9 +123,12 @@ frappe.ui.form.Control = class BaseControl {
 			this.doctype &&
 			status === "Read" &&
 			!this.only_input &&
+			is_null(value) &&
+			cint(frappe.boot.sysdefaults.hide_empty_read_only_fields) &&
 			!["HTML", "Image", "Button", "Geolocation"].includes(this.df.fieldtype)
 		) {
 			if (explain) console.log("By Hide Read-only, null fields: None");
+			status = "None";
 		}
 
 		return status;

--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -123,11 +123,9 @@ frappe.ui.form.Control = class BaseControl {
 			this.doctype &&
 			status === "Read" &&
 			!this.only_input &&
-			is_null(value) &&
 			!["HTML", "Image", "Button", "Geolocation"].includes(this.df.fieldtype)
 		) {
 			if (explain) console.log("By Hide Read-only, null fields: None");
-			status = "None";
 		}
 
 		return status;


### PR DESCRIPTION
### Description
This PR modifies the logic to ensure read-only fields are always displayed, even if they have no value. Previously, these fields were hidden when empty, which caused confusion and limited usability for users who wanted to showcase fields for context or placeholders.

I have not removed the entire condition but only modified the part that hides fields without a value. If any further changes are required, I am open to suggestions from the Frappe team.

### Pros

- **Improved User Experience:** Users can now see all read-only fields, even if they are empty, providing better context and reducing confusion.
- **Customization Flexibility:** Aligns with many user requests to display all fields for specific business use cases.
- **Consistency:** Maintains a uniform layout by preventing unexpected hiding of fields.

### Related Discussion:
This change is inspired by feedback from the community. Refer to this [Frappe Discussion Post](https://discuss.frappe.io/t/read-only-and-empty-should-not-hide-the-field/48877) for more context.

#### Before Change
![image](https://github.com/user-attachments/assets/6cb64611-5d56-4954-89b4-2de8279089d2)

#### After Change
![image](https://github.com/user-attachments/assets/cdcc8444-3f9e-4847-9083-012a9b785d7e)


