### PR TITLE
chore(ui-tests): don't print subprocess traceback

### DIFF
--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -484,9 +484,9 @@ def run_ui_tests(
 	click.secho("Running Cypress...", fg="yellow")
 	try:
 		frappe.commands.popen(formatted_command, cwd=app_base_path, raise_err=True)
-	except subprocess.CalledProcessError:
+	except subprocess.CalledProcessError as e:
 		click.secho("Cypress tests failed", fg="red")
-		sys.exit(1)
+		raise click.exceptions.Exit(1) from e
 
 
 commands = [

--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -482,7 +482,11 @@ def run_ui_tests(
 		formatted_command += " " + " ".join(cypressargs)
 
 	click.secho("Running Cypress...", fg="yellow")
-	frappe.commands.popen(formatted_command, cwd=app_base_path, raise_err=True)
+	try:
+		frappe.commands.popen(formatted_command, cwd=app_base_path, raise_err=True)
+	except subprocess.CalledProcessError:
+		click.secho("Cypress tests failed", fg="red")
+		sys.exit(1)
 
 
 commands = [


### PR DESCRIPTION
We have the cypress error from its output above, just a simple error message is enough here

Resolves #28611
