### PR TITLE
fix: don't prompt users unless we have a TTY

### DIFF
--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -129,7 +129,7 @@ def get_root_connection():
 			frappe.flags.root_login = (
 				frappe.conf.get("mariadb_root_login")
 				or frappe.conf.get("root_login")
-				or input("Enter mysql super user [root]: ")
+				or (sys.__stdin__.isatty() and input("Enter mysql super user [root]: "))
 				or "root"
 			)
 

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -60,13 +60,14 @@ def import_db_from_sql(source_sql=None, verbose=False):
 
 def get_root_connection():
 	if not frappe.local.flags.root_connection:
+		import sys
 		from getpass import getpass
 
 		if not frappe.flags.root_login:
 			frappe.flags.root_login = (
 				frappe.conf.get("postgres_root_login")
 				or frappe.conf.get("root_login")
-				or input("Enter postgres super user [postgres]: ")
+				or (sys.__stdin__.isatty() and input("Enter postgres super user [postgres]: "))
 				or "postgres"
 			)
 


### PR DESCRIPTION
This can break automated runs (which earlier worked)

Follow up to #28636 
