### PR TITLE
fix: Link Selector links replicating

### DIFF
--- a/frappe/public/js/frappe/form/link_selector.js
+++ b/frappe/public/js/frappe/form/link_selector.js
@@ -123,7 +123,7 @@ frappe.ui.form.LinkSelector = class LinkSelector {
 										me.page_length = previous_start + previous_page_length;
 										me.search();
 										me.start = previous_start;
-										me.page_length = previous_page_length;					
+										me.page_length = previous_page_length;
 									});
 								} else {
 									if (me.target.doctype)

--- a/frappe/public/js/frappe/form/link_selector.js
+++ b/frappe/public/js/frappe/form/link_selector.js
@@ -116,7 +116,15 @@ frappe.ui.form.LinkSelector = class LinkSelector {
 								if (me.target.is_grid) {
 									// set in grid
 									// call search after value is set to get latest filtered results
-									me.set_in_grid(value).then(() => me.search());
+									me.set_in_grid(value).then(() => {
+										let previous_start = me.start;
+										let previous_page_length = me.page_length;
+										me.start = 0;
+										me.page_length = previous_start + previous_page_length;
+										me.search();
+										me.start = previous_start;
+										me.page_length = previous_page_length;					
+									});
 								} else {
 									if (me.target.doctype)
 										me.target.parse_validate_and_set_in_model(value);


### PR DESCRIPTION
### How to Simulate 

- [ ] Choose a DocType that has the "Add Multiples" button, and click it
- [ ] Scroll down and click in "More" button
- [ ] Add some item near to the new "More" button; The last loaded items is loaded again, replicating them.

### Before

![Before](https://github.com/user-attachments/assets/004975dc-a989-4182-8df8-6ff205132c64)

### After

![After](https://github.com/user-attachments/assets/175400fd-4438-4ac4-a328-6e4a7d55c03f)
