### PR TITLE
fix: Print exception if asset linking is failed

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -385,8 +385,9 @@ def make_asset_dirs(hard_link=False):
 		try:
 			print(start_message, end="\r")
 			link_assets_dir(source, target, hard_link=hard_link)
-		except Exception:
-			print(fail_message, end="\r")
+		except Exception as e:
+			print(e)
+			print(fail_message)
 
 	click.echo(unstrip(click.style("✔", fg="green") + " Application Assets Linked") + "\n")
 


### PR DESCRIPTION
Print exception if asset linking is failed. Required for debugging.