### PR TITLE
Fix: Exclude "No Copy" Fields in Child Table Duplication

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -881,20 +881,25 @@ export default class Grid {
 	}
 
 	duplicate_row(d, copy_doc) {
+		const noCopyFields = new Set([
+			"creation",
+			"modified",
+			"modified_by",
+			"idx",
+			"owner",
+			"parent",
+			"doctype",
+			"name",
+			"parentfield",
+		]);
+
+		const docfields = frappe.get_meta(this.doctype).fields || [];
+		$.each(docfields, function (_index, df) {
+			if (cint(df.no_copy)) noCopyFields.add(df.fieldname);
+		});
+
 		$.each(copy_doc, function (key, value) {
-			if (
-				![
-					"creation",
-					"modified",
-					"modified_by",
-					"idx",
-					"owner",
-					"parent",
-					"doctype",
-					"name",
-					"parentfield",
-				].includes(key)
-			) {
+			if (!noCopyFields.has(key)) {
 				d[key] = value;
 			}
 		});


### PR DESCRIPTION
**Description:**
This PR resolves the issue where fields marked with the "No Copy" in child tables were incorrectly duplicated. The fix ensures these fields are excluded during duplication.

Closes #28537

**Changes:**

- Updated the `duplicate_row` method to dynamically exclude "No Copy" fields.
- Improved logic using a Set for faster field exclusion.

**Before**

[before.webm](https://github.com/user-attachments/assets/551f61c5-17ef-4f46-b5f8-52a30b3a0c26)

**After**

[after.webm](https://github.com/user-attachments/assets/4769f509-72d9-4749-aea6-e94038f00ebf)

