### PR TITLE
feat: add, before_remove and remove event triggers for Table MultiSelect

### DIFF
--- a/frappe/custom/doctype/client_script/client_script.js
+++ b/frappe/custom/doctype/client_script/client_script.js
@@ -17,7 +17,7 @@ frappe.ui.form.on("Client Script", {
 				frappe.model.with_doctype(frm.doc.dt, () => {
 					const child_tables = frappe.meta
 						.get_docfields(frm.doc.dt, null, {
-							fieldtype: "Table",
+							fieldtype: ["in", ["Table", "Table MultiSelect"]],
 						})
 						.map((df) => df.options);
 


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

This will help better developer experience when working with fields of type Table MultiSelect. Currently, in order to do stuff on add / remove actions of a Table MultiSelect will need iterating through the child table.

Relevant for [Marley Healthcare](https://github.com/earthians/marley) app when a practitioner adds / removes a diagnosis the medical codes related to the diagnosis need to be updated in related documents.

Also updated Client Script to allow listing Table MultiSelect under Add script for Child Table button.

**Note: Form Render and Move are not handled as those events are not relevant to the control**

> Screenshots/GIFs

<img width="1435" alt="client-script" src="https://github.com/user-attachments/assets/5062ecd4-35fc-427d-b796-7126573614b9">


Just doing a `console.log()` here in the gif

https://github.com/user-attachments/assets/74675166-db51-4559-9d01-5b8d4d64f8bf

Draft [docs]( https://frappeframework.com/docs/user/en/api/form?editWiki=1&wikiPagePatch=0fuauhvo2t )