### PR TITLE
fix: validate field name starting with number

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -7,6 +7,7 @@ from frappe.utils.defaults import get_not_null_defaults
 
 SPECIAL_CHAR_PATTERN = re.compile(r"[\W]", flags=re.UNICODE)
 VARCHAR_CAST_PATTERN = re.compile(r"varchar\(([\d]+)\)")
+STARTS_WITH_NUM_PATTERN = re.compile(r"^\d")
 
 
 class InvalidColumnName(frappe.ValidationError):
@@ -350,6 +351,14 @@ def validate_column_name(n):
 		frappe.throw(
 			_("Fieldname {0} cannot have special characters like {1}").format(
 				frappe.bold(cstr(n)), special_characters
+			),
+			frappe.db.InvalidColumnName,
+		)
+	if starts_with_number := STARTS_WITH_NUM_PATTERN.findall(n):
+		starts_with_number = ", ".join(f'"{c}"' for c in starts_with_number)
+		frappe.throw(
+			_("Fieldname {0} cannot start with integer values like {1}").format(
+				frappe.bold(cstr(n)), starts_with_number
 			),
 			frappe.db.InvalidColumnName,
 		)

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -1,4 +1,5 @@
 import re
+from string import digits
 
 import frappe
 from frappe import _
@@ -7,7 +8,6 @@ from frappe.utils.defaults import get_not_null_defaults
 
 SPECIAL_CHAR_PATTERN = re.compile(r"[\W]", flags=re.UNICODE)
 VARCHAR_CAST_PATTERN = re.compile(r"varchar\(([\d]+)\)")
-STARTS_WITH_NUM_PATTERN = re.compile(r"^\d")
 
 
 class InvalidColumnName(frappe.ValidationError):
@@ -354,12 +354,9 @@ def validate_column_name(n):
 			),
 			frappe.db.InvalidColumnName,
 		)
-    from string import digits
-    if n[0] in digits:
+	if n[0] in digits:
 		frappe.throw(
-			_("Fieldname {0} cannot start with integer values like {1}").format(
-				frappe.bold(cstr(n)), n[0]
-			),
+			_("Fieldname {0} cannot start with integer values like {1}").format(frappe.bold(cstr(n)), n[0]),
 			frappe.db.InvalidColumnName,
 		)
 	return n

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -354,11 +354,11 @@ def validate_column_name(n):
 			),
 			frappe.db.InvalidColumnName,
 		)
-	if starts_with_number := STARTS_WITH_NUM_PATTERN.findall(n):
-		starts_with_number = ", ".join(f'"{c}"' for c in starts_with_number)
+    from string import digits
+    if n[0] in digits:
 		frappe.throw(
 			_("Fieldname {0} cannot start with integer values like {1}").format(
-				frappe.bold(cstr(n)), starts_with_number
+				frappe.bold(cstr(n)), n[0]
 			),
 			frappe.db.InvalidColumnName,
 		)

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -996,59 +996,6 @@ class TestDBQuery(IntegrationTestCase):
 
 		dt.delete(ignore_permissions=True)
 
-	def test_fieldname_starting_with_int(self):
-		from frappe.core.doctype.doctype.test_doctype import new_doctype
-
-		frappe.delete_doc_if_exists("DocType", "dt_with_int_named_fieldname")
-		frappe.delete_doc_if_exists("DocType", "table_dt")
-
-		table_dt = new_doctype(
-			"table_dt",
-			istable=1,
-			fields=[{"label": "1field", "fieldname": "2field", "fieldtype": "Data"}],
-		).insert()
-
-		dt = new_doctype(
-			"dt_with_int_named_fieldname",
-			fields=[
-				{"label": "1field", "fieldname": "1field", "fieldtype": "Data"},
-				{
-					"label": "2table_field",
-					"fieldname": "2table_field",
-					"fieldtype": "Table",
-					"options": table_dt.name,
-				},
-			],
-		).insert(ignore_permissions=True)
-
-		dt_data = frappe.get_doc({"doctype": "dt_with_int_named_fieldname", "1field": "10"}).insert(
-			ignore_permissions=True
-		)
-
-		query = DatabaseQuery("dt_with_int_named_fieldname")
-		self.assertTrue(query.execute(filters={"1field": "10"}))
-		self.assertTrue(query.execute(filters={"1field": ["like", "1%"]}))
-		self.assertTrue(query.execute(filters={"1field": ["in", "1,2,10"]}))
-		self.assertTrue(query.execute(filters={"1field": ["is", "set"]}))
-		self.assertFalse(query.execute(filters={"1field": ["not like", "1%"]}))
-		self.assertTrue(query.execute(filters=[["table_dt", "2field", "is", "not set"]]))
-
-		frappe.get_doc(
-			{
-				"doctype": table_dt.name,
-				"2field": "10",
-				"parent": dt_data.name,
-				"parenttype": dt_data.doctype,
-				"parentfield": "2table_field",
-			}
-		).insert(ignore_permissions=True)
-
-		self.assertTrue(query.execute(filters=[["table_dt", "2field", "is", "set"]]))
-
-		# cleanup
-		dt.delete()
-		table_dt.delete()
-
 	def test_permission_query_condition(self):
 		from frappe.desk.doctype.dashboard_settings.dashboard_settings import (
 			create_dashboard_settings,


### PR DESCRIPTION
Issue: Users are able to create a field name starting with number that does not work with Python or JS. [Closes #27729](https://github.com/frappe/frappe/issues/27729)

Solution: Added a validation for field name starting with number.

![image](https://github.com/user-attachments/assets/b8950721-b23b-40e0-864c-cea0c049c070)

Backport needed: Version 15, Version 14