### PR TITLE
fix: handle empty images

### DIFF
--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -238,6 +238,10 @@ def extract_images_from_html(doc: "Document", content: str, is_private: bool = F
 		if b"," in content:
 			content = content.split(b",")[1]
 
+		if not content:
+			# if there is no content, return the original tag
+			return match.group(0)
+
 		try:
 			content = safe_b64decode(content)
 		except BinasciiError:


### PR DESCRIPTION
Receiving an email that contains an empty image, e.g. `<img src=3D"data:image/gif;base64,">`, resulted in an error due to file validations when trying to save the image to disk. Now we leave content-less image tags unchanged.

Resolves #28668
