### PR TITLE
fix: add backward compatibility for 5 item filter

### DIFF
--- a/.github/workflows/_base-migration.yml
+++ b/.github/workflows/_base-migration.yml
@@ -103,7 +103,7 @@ jobs:
             if pgrep honcho > /dev/null; then
                 echo "Stopping honcho process..."
                 pgrep honcho | xargs kill
-                sleep 3
+                sleep 5
             fi
 
             echo "Setting up environment..."

--- a/frappe/types/filter.py
+++ b/frappe/types/filter.py
@@ -97,6 +97,15 @@ class FilterTuple(_FilterTuple):
 					fieldname, operator, value = s
 				elif len(s) == 4:  # type: ignore[redundant-expr]
 					doctype, fieldname, operator, value = s
+				elif len(s) == 5:  # type: ignore[unreachable]
+					from frappe.deprecation_dumpster import deprecation_warning
+
+					deprecation_warning(
+						"2024-12-05",
+						"v16",
+						f"List type filters now should have 2, 3 or 4 elements: got 5 (Input: {s!r}). Hint: you probably need to remove the last filter element, a no-op from history.",
+					)
+					doctype, fieldname, operator, value, _noop = s
 				else:
 					raise ValueError(f"Invalid sequence length: {len(s)}. Expected 2, 3, or 4 elements.")
 			if is_unspecified(doctype) or doctype is None:


### PR DESCRIPTION
In a first iteration towards fixing the issues with https://github.com/frappe/frappe/pull/28218 (and despite my https://github.com/frappe/frappe/pull/28218#issuecomment-2519509105), I decided to try a compatibility fix, since upon first analysis all errors seem to (exclusively) be caused by using old (no-op) data structures for which we can cheaply add a compatibility layer.

#### Graduation Considerations

The proposed decision to graduate in v16 (short notice) is motivated by the fact that this seemed to have been a dead data point for years already, thus: time to clean up, finally. Can be revised with a graduation bump any time, though.