### PR TITLE
refactor: comply js filter getter with #28218

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1331,7 +1331,7 @@ frappe.ui.form.Form = class FrappeForm {
 		let filters, sort_field, sort_order;
 		let list_view = frappe.get_list_view(this.doctype);
 		if (list_view) {
-			filters = list_view.get_filters_for_args();
+			filters = list_view.filter_area?.get() || [];
 			sort_field = list_view.sort_by;
 			sort_order = list_view.sort_order;
 		} else {

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -467,21 +467,15 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	get_filter_value(fieldname) {
-		const filter = this.get_filters_for_args().filter((f) => f[1] == fieldname)[0];
+		const filter = (this.filter_area?.get() || []).filter((f) => f[1] == fieldname)[0];
 		if (!filter) return;
 		if (filter[2] === "like") return filter[3]?.replace(/^%?|%$/g, "");
 		else if (filter[2] === "not set") return null;
 		else return filter[3];
 	}
 
-	get_filters_for_args() {
-		// filters might have a fifth param called hidden,
-		// we don't want to pass that server side
-		return this.filter_area ? this.filter_area.get().map((filter) => filter.slice(0, 4)) : [];
-	}
-
 	get_args() {
-		let filters = this.get_filters_for_args();
+		let filters = this.filter_area?.get() || [];
 		let group_by = this.get_group_by();
 		let group_by_required =
 			Array.isArray(filters) &&

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -225,7 +225,7 @@ frappe.views.ListSidebar = class ListSidebar {
 				// wait for list filter area to be generated before getting filters, or fallback to default filters
 				filters:
 					(me.list_view.filter_area
-						? me.list_view.get_filters_for_args()
+						? me.list_view.filter_area.get()
 						: me.default_filters) || [],
 			},
 			callback: function (r) {

--- a/frappe/public/js/frappe/list/list_sidebar_group_by.js
+++ b/frappe/public/js/frappe/list/list_sidebar_group_by.js
@@ -161,7 +161,7 @@ frappe.views.ListGroupBy = class ListGroupBy {
 	}
 
 	get_group_by_count(field) {
-		let current_filters = this.list_view.get_filters_for_args();
+		let current_filters = this.list_view.filter_area?.get() || [];
 
 		// remove filter of the current field
 		current_filters = current_filters.filter(

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1009,7 +1009,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		return frappe.db
 			.count(this.doctype, {
-				filters: this.get_filters_for_args(),
+				filters: this.filter_area?.get() || [],
 				limit: this.count_upper_bound,
 			})
 			.then((total_count) => {
@@ -1706,7 +1706,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	get_search_params() {
 		let search_params = new URLSearchParams();
 
-		this.get_filters_for_args().forEach((filter) => {
+		(this.filter_area?.get() || []).forEach((filter) => {
 			if (filter[2] === "=") {
 				search_params.append(filter[1], filter[3]);
 			} else {

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -328,7 +328,6 @@ frappe.ui.Filter = class {
 			this.field.df.fieldname,
 			this.get_condition(),
 			this.get_selected_value(),
-			this.hidden,
 		];
 	}
 

--- a/frappe/types/filter.py
+++ b/frappe/types/filter.py
@@ -103,7 +103,7 @@ class FilterTuple(_FilterTuple):
 					deprecation_warning(
 						"2024-12-05",
 						"v16",
-						f"List type filters now should have 2, 3 or 4 elements: got 5 (Input: {s!r}). Hint: you probably need to remove the last filter element, a no-op from history.",
+						f"List type filters now should have 2, 3 or 4 elements: got 5 (Input: {s!r}). Hint: you probably need to remove the last filter element, a no-op from history. See also: https://github.com/frappe/frappe/pull/28682",
 					)
 					doctype, fieldname, operator, value, _noop = s
 				else:


### PR DESCRIPTION
I have concluded after ~2 hours of analysis: `hidden` is filter display state only - see email inbox js

Ref:

- https://github.com/frappe/frappe/pull/28218#issuecomment-2519663143
- https://github.com/frappe/frappe/pull/28218#issuecomment-2519778003
- https://github.com/frappe/frappe/pull/28678 (this PR is a follow up)

cc @ruchamahabal 