### PR TITLE
fix: hide insert below button in submitted document

### DIFF
--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -71,9 +71,11 @@ export default class GridRowForm {
 						<span class="text-medium"> ${__("Shortcuts")}: </span>
 						<kbd>${__("Ctrl + Up")}</kbd> . <kbd>${__("Ctrl + Down")}</kbd> . <kbd>${__("ESC")}</kbd>
 					</div>
+					<span class="row-actions">
 					<button class="btn btn-secondary btn-sm pull-right grid-append-row">
 						${__("Insert Below")}
 					</button>
+					</span>
 				</div>
 			</div>`;
 

--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -72,9 +72,9 @@ export default class GridRowForm {
 						<kbd>${__("Ctrl + Up")}</kbd> . <kbd>${__("Ctrl + Down")}</kbd> . <kbd>${__("ESC")}</kbd>
 					</div>
 					<span class="row-actions">
-					<button class="btn btn-secondary btn-sm pull-right grid-append-row">
-						${__("Insert Below")}
-					</button>
+						<button class="btn btn-secondary btn-sm pull-right grid-append-row">
+							${__("Insert Below")}
+						</button>
 					</span>
 				</div>
 			</div>`;


### PR DESCRIPTION
Hide insert below button in submitted document

Issue: [Closes #27293](https://github.com/frappe/frappe/issues/27293)

Before:
![screenshot1](https://github.com/user-attachments/assets/37535e0b-edb9-43cb-ba70-fc9bef9d0884)

After:
![image](https://github.com/user-attachments/assets/8bd1cbf0-9c9c-4908-b6b5-03ac12d93345)


Backport needed: Version 15, Version 14