### PR TITLE
feat: add select all button to select all column in child table

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -464,6 +464,8 @@ export default class GridRow {
 					sort_options: false,
 				},
 			],
+			secondary_action_label: __("Select All"),
+			secondary_action: () => this.select_all_columns(docfields),
 		});
 
 		d.set_primary_action(__("Add"), () => {
@@ -486,6 +488,17 @@ export default class GridRow {
 		});
 
 		d.show();
+	}
+
+	select_all_columns(docfields) {
+		docfields.forEach((docfield) => {
+			if (docfield.checked) {
+				return;
+			}
+			$(`.checkbox.unit-checkbox input[type="checkbox"][data-unit="${docfield.value}"]`)
+				.prop("checked", true)
+				.trigger("change");
+		});
 	}
 
 	prepare_columns_for_dialog(selected_fields) {


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Added a "Select All" button to the child table for better UX, allowing users to quickly select all columns at once.

> Explain the **details** for making this change. What existing problem does the pull request solve?

Previously, users had to manually select each column. This change simplifies the process by providing a single-click solution to select all columns.

> Screenshots/GIFs


https://github.com/user-attachments/assets/140db72c-b14d-466d-bffc-7ae2e9fc565d


`no-docs`