### PR TITLE
refactor: use frappe.bench for path access

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -83,7 +83,10 @@ if TYPE_CHECKING:  # pragma: no cover
 	from frappe.utils.redis_wrapper import RedisWrapper
 
 controllers: dict[str, "Document"] = {}
-local = Local()
+
+from frappe.deprecation_dumpster import get_local_with_deprecations
+
+local = get_local_with_deprecations()
 bench = Bench()
 cache: Optional["RedisWrapper"] = None
 STANDARD_USERS = ("Guest", "Administrator")
@@ -252,8 +255,10 @@ def init(site: str, sites_path: str | Path = ".", new_site: bool = False, force:
 		bench.sites = Sites(frappe.bench, sites_path)
 	local.site = site
 	bench.sites.site_name = site
+	# TODO: START instrumented by deprecation dumpster - remove from v18
 	local.sites_path = str(bench.sites.path)
 	local.site_path = str(bench.site.path) if bench.scoped else ""
+	# TODO: END  instrumented by deprecation dumpster - remove from v18
 	local.all_apps = None
 
 	local.request_ip = None

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -83,10 +83,7 @@ if TYPE_CHECKING:  # pragma: no cover
 	from frappe.utils.redis_wrapper import RedisWrapper
 
 controllers: dict[str, "Document"] = {}
-
-from frappe.deprecation_dumpster import get_local_with_deprecations
-
-local = get_local_with_deprecations()
+local = Local()
 bench = Bench()
 cache: Optional["RedisWrapper"] = None
 STANDARD_USERS = ("Guest", "Administrator")
@@ -262,10 +259,6 @@ def init(site: str, sites_path: str | Path = ".", new_site: bool = False, force:
 		bench.sites = Sites(frappe.bench, sites_path)
 	local.site = site
 	bench.sites.site_name = site
-	# TODO: START instrumented by deprecation dumpster - remove from v18
-	local.sites_path = str(bench.sites.path)
-	local.site_path = str(bench.site.path) if bench.scoped else ""
-	# TODO: END  instrumented by deprecation dumpster - remove from v18
 	local.all_apps = None
 
 	local.request_ip = None

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -26,6 +26,7 @@ import traceback
 import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterable
+from pathlib import Path
 from typing import (
 	TYPE_CHECKING,
 	Any,
@@ -51,7 +52,7 @@ from frappe.query_builder.utils import (
 from frappe.utils.caching import request_cache
 from frappe.utils.data import cint, cstr, sbool
 
-from .bench_interface import Bench
+from .bench_interface import Bench, Sites
 
 # Local application imports
 from .exceptions import *
@@ -220,7 +221,7 @@ if TYPE_CHECKING:  # pragma: no cover
 	lang: str
 
 
-def init(site: str, sites_path: str = ".", new_site: bool = False, force: bool = False) -> None:
+def init(site: str, sites_path: str | Path = ".", new_site: bool = False, force: bool = False) -> None:
 	"""Initialize frappe for the current site. Reset thread locals `frappe.local`"""
 	if getattr(local, "initialised", None) and not force:
 		return
@@ -247,10 +248,12 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force: bool =
 	local.locked_documents: list[Document] = []
 	local.test_objects = defaultdict(list)
 
+	if Path(sites_path).resolve() != bench.sites.path:
+		bench.sites = Sites(frappe.bench, sites_path)
 	local.site = site
-	local.site_name = site  # implicitly scopes bench
-	local.sites_path = sites_path
-	local.site_path = os.path.join(sites_path, site)
+	bench.sites.site_name = site
+	local.sites_path = str(bench.sites.path)
+	local.site_path = str(bench.site.path) if bench.scoped else ""
 	local.all_apps = None
 
 	local.request_ip = None
@@ -366,13 +369,15 @@ def connect_replica() -> bool:
 	return True
 
 
-def get_site_config(sites_path: str | None = None, site_path: str | None = None) -> _dict[str, Any]:
+def get_site_config(
+	sites_path: str | Path | None = None, site_path: str | Path | None = None
+) -> _dict[str, Any]:
 	"""Return `site_config.json` combined with `sites/common_site_config.json`.
 	`site_config` is a set of site wide settings like database name, password, email etc."""
 	config: _dict[str, Any] = _dict()
 
-	sites_path = sites_path or getattr(local, "sites_path", None)
-	site_path = site_path or getattr(local, "site_path", None)
+	sites_path = str(sites_path) if sites_path else str(bench.sites.path)
+	site_path = str(site_path) if site_path else str(bench.site.path) if bench.scoped else None
 
 	common_config = get_common_site_config(sites_path)
 
@@ -448,14 +453,14 @@ def get_site_config(sites_path: str | None = None, site_path: str | None = None)
 	return config
 
 
-def get_common_site_config(sites_path: str | None = None) -> _dict[str, Any]:
+def get_common_site_config(sites_path: str | Path | None = None) -> _dict[str, Any]:
 	"""Return common site config as dictionary.
 
 	This is useful for:
 	- checking configuration which should only be allowed in common site config
 	- When no site context is present and fallback is required.
 	"""
-	sites_path = sites_path or getattr(local, "sites_path", None)
+	sites_path = str(sites_path) if sites_path else str(bench.sites.path)
 
 	common_site_config = os.path.join(sites_path, "common_site_config.json")
 	if os.path.exists(common_site_config):
@@ -1571,9 +1576,8 @@ def get_site_path(*joins):
 	"""Return path of current site.
 
 	:param *joins: Join additional path elements using `os.path.join`."""
-	from os.path import join
 
-	return join(local.site_path, *joins)
+	return bench.site.path.joinpath(*joins)
 
 
 def get_pymodule_path(modulename, *joins):
@@ -1597,12 +1601,12 @@ def get_module_list(app_name):
 def get_all_apps(with_internal_apps=True, sites_path=None):
 	"""Get list of all apps via `sites/apps.txt`."""
 	if not sites_path:
-		sites_path = local.sites_path
+		sites_path = str(bench.sites.path)
 
 	apps = get_file_items(os.path.join(sites_path, "apps.txt"), raise_not_found=True)
 
 	if with_internal_apps:
-		for app in get_file_items(os.path.join(local.site_path, "apps.txt")):
+		for app in get_file_items(os.path.join(bench.site.path, "apps.txt")):
 			if app not in apps:
 				apps.append(app)
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -252,6 +252,13 @@ def init(site: str, sites_path: str | Path = ".", new_site: bool = False, force:
 	local.test_objects = defaultdict(list)
 
 	if Path(sites_path).resolve() != bench.sites.path:
+		from frappe.deprecation_dumpster import deprecation_warning
+
+		deprecation_warning(
+			"2024-12-06",
+			"v17",
+			"Specifying a distinct 'sites_path' to 'frappe.init' as an argument is deprecated, use FRAPPE_SITES_PATH env variable, instead.",
+		)
 		bench.sites = Sites(frappe.bench, sites_path)
 	local.site = site
 	bench.sites.site_name = site

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1603,14 +1603,14 @@ def get_module_list(app_name):
 	return get_file_items(get_app_path(app_name, "modules.txt"))
 
 
-def get_all_apps(with_internal_apps=True, sites_path=None):
+def get_all_apps(sites_path=None):
 	"""Get list of all apps via `sites/apps.txt`."""
 	if not sites_path:
 		sites_path = str(bench.sites.path)
 
 	apps = get_file_items(os.path.join(sites_path, "apps.txt"), raise_not_found=True)
 
-	if with_internal_apps:
+	if bench.scoped:
 		for app in get_file_items(os.path.join(bench.site.path, "apps.txt")):
 			if app not in apps:
 				apps.append(app)
@@ -1746,7 +1746,7 @@ def setup_module_map(include_all_apps: bool = True) -> None:
 	if not local.app_modules:
 		local.app_modules = {}
 		if include_all_apps:
-			apps = get_all_apps(with_internal_apps=True)
+			apps = get_all_apps()
 		else:
 			apps = get_installed_apps(_ensure_on_bench=True)
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -479,7 +479,13 @@ def serve(
 
 	if Path(sites_path).resolve() != frappe.bench.sites.path:
 		from frappe.bencher import Sites
+		from frappe.deprecation_dumpster import deprecation_warning
 
+		deprecation_warning(
+			"2024-12-06",
+			"v17",
+			"Specifying a distinct 'sites_path' to 'frappe.app.serve' as an argument is deprecated, use FRAPPE_SITES_PATH env variable, instead.",
+		)
 		frappe.bench.sites = Sites(frappe.bench, sites_path)
 
 	from werkzeug.serving import run_simple

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -31,7 +31,6 @@ from frappe.website.page_renderers.error_page import ErrorPage
 from frappe.website.serve import get_response
 
 _site = None
-_sites_path = os.environ.get("SITES_PATH", ".")
 
 
 # If gc.freeze is done then importing modules before forking allows us to share the memory
@@ -173,7 +172,7 @@ def init_request(request):
 	frappe.local.is_ajax = frappe.get_request_header("X-Requested-With") == "XMLHttpRequest"
 
 	site = _site or request.headers.get("X-Frappe-Site-Name") or get_site_name(request.host)
-	frappe.init(site, sites_path=_sites_path, force=True)
+	frappe.init(site, sites_path=frappe.bench.sites.path, force=True)
 
 	if not (frappe.local.conf and frappe.local.conf.db_name):
 		# site does not exist
@@ -474,9 +473,14 @@ def serve(
 	sites_path=".",
 	proxy=False,
 ):
-	global application, _site, _sites_path
+	global application, _site
 	_site = site
-	_sites_path = sites_path
+	from pathlib import Path
+
+	if Path(sites_path).resolve() != frappe.bench.sites.path:
+		from frappe.bencher import Sites
+
+		frappe.bench.sites = Sites(frappe.bench, sites_path)
 
 	from werkzeug.serving import run_simple
 
@@ -512,11 +516,10 @@ def serve(
 
 
 def application_with_statics():
-	global application, _sites_path
+	global application
 
-	application = SharedDataMiddleware(application, {"/assets": str(os.path.join(_sites_path, "assets"))})
-
-	application = StaticDataMiddleware(application, {"/files": str(os.path.abspath(_sites_path))})
+	application = SharedDataMiddleware(application, {"/assets": str(frappe.bench.sites.path / "assets")})
+	application = StaticDataMiddleware(application, {"/files": str(frappe.bench.sites.path)})
 
 	return application
 

--- a/frappe/bench_interface.py
+++ b/frappe/bench_interface.py
@@ -326,7 +326,7 @@ class Site(ConfigHandler, _Serializable):
 		return {naming.get(k, k): v for k, v in self.__dict__.items() if k not in excluded}  # type: ignore[no-any-expr]
 
 
-class Sites(_PathResolvable, ConfigHandler, _Serializable):
+class Sites(ConfigHandler, _PathResolvable, _Serializable):
 	SCOPE_ALL_SITES: Final = "__scope-all-sites__"
 	__sites: dict[str, Site]
 	__path_name = "sites"

--- a/frappe/bench_interface.py
+++ b/frappe/bench_interface.py
@@ -61,6 +61,8 @@ __all__ = [
 # used to implement legacy code paths to keep the main path clean
 _current_bench: "Bench"
 
+from frappe.deprecation_dumpster import deprecation_warning
+
 
 class BenchNotScopedError(NotImplementedError):
 	pass
@@ -331,6 +333,11 @@ class Sites(_PathResolvable, ConfigHandler, _Serializable):
 	__env_variable = "FRAPPE_SITES_PATH"
 
 	if legacy_env_path := os.environ.get("SITES_PATH"):
+		deprecation_warning(
+			"2024-12-06",
+			"v17",
+			"Specifying sites path via SITES_PATH env variable is deprecated, use the canonical FRAPPE_SITES_PATH, instead.",
+		)
 		os.environ["FRAPPE_SITES_PATH"] = legacy_env_path
 
 	def __init__(self, *, bench: "Bench", path: str | Path | None = None, parent_path: Path | None = None):
@@ -446,6 +453,11 @@ class Sites(_PathResolvable, ConfigHandler, _Serializable):
 class Bench(_PathResolvable, _Serializable):
 	__env_variable = "FRAPPE_BENCH_PATH"
 	if legacy_env_path := os.environ.get("FRAPPE_BENCH_ROOT"):
+		deprecation_warning(
+			"2024-12-06",
+			"v17",
+			"Specifying sites path via FRAPPE_BENCH_ROOT env variable is deprecated, use the canonical FRAPPE_BENCH_PATH, instead.",
+		)
 		os.environ["FRAPPE_BENCH_PATH"] = legacy_env_path
 	if not os.environ.get("FRAPPE_BENCH_PATH") and (legacy_env_path_sites := os.environ.get("SITES_PATH")):
 		os.environ["FRAPPE_BENCH_PATH"] = str(Path(legacy_env_path_sites).resolve().parent)

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import subprocess
+from pathlib import Path
 from subprocess import getoutput
 from tempfile import mkdtemp
 from urllib.parse import urlparse
@@ -15,7 +16,6 @@ import frappe
 
 timestamps = {}
 app_paths = None
-sites_path = os.path.abspath(os.getcwd())
 WHITESPACE_PATTERN = re.compile(r"\s+")
 HTML_COMMENT_PATTERN = re.compile(r"(<!--.*?-->)")
 
@@ -43,12 +43,16 @@ def download_file(url, prefix):
 
 def build_missing_files():
 	"""Check which files dont exist yet from the assets.json and run build for those files"""
+	if Path(os.path.abspath(os.getcwd())).resolve() != frappe.bench.sites.path:
+		from frappe.bencher import Sites
+
+		frappe.bench.sites = Sites(frappe.bench, os.path.abspath(os.getcwd()))
 
 	missing_assets = []
 	current_asset_files = []
 
 	for type in ["css", "js"]:
-		folder = os.path.join(sites_path, "assets", "frappe", "dist", type)
+		folder = frappe.bench.sites.path / "assets" / "frappe" / "dist" / type
 		current_asset_files.extend(os.listdir(folder))
 
 	development = frappe.local.conf.developer_mode or frappe.local.dev_server
@@ -137,7 +141,8 @@ def download_frappe_assets(verbose=True) -> bool:
 	"""Download and set up Frappe assets if they exist based on the current commit HEAD.
 	Return True if correctly setup else return False.
 	"""
-	frappe_head = getoutput("cd ../apps/frappe && git rev-parse HEAD")
+	frappe_path = frappe.bench.apps["frappe"].path
+	frappe_head = getoutput(f"cd {frappe_path} && git rev-parse HEAD")
 
 	if not frappe_head:
 		return False
@@ -215,7 +220,7 @@ def setup():
 		except ImportError:
 			pass
 	app_paths = [os.path.dirname(pymodule.__file__) for pymodule in pymodules]
-	assets_path = os.path.join(frappe.local.sites_path, "assets")
+	assets_path = frappe.bench.sites.path / "assets"
 
 
 def bundle(

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -43,17 +43,6 @@ def download_file(url, prefix):
 
 def build_missing_files():
 	"""Check which files dont exist yet from the assets.json and run build for those files"""
-	if Path(os.path.abspath(os.getcwd())).resolve() != frappe.bench.sites.path:
-		from frappe.bencher import Sites
-		from frappe.deprecation_dumpster import deprecation_warning
-
-		deprecation_warning(
-			"2024-12-06",
-			"v17",
-			"Calling frappe.build.build_missing_files from the current working directory distinct of the sites directory is deprecated, use FRAPPE_SITES_PATH env variable, instead.",
-		)
-		frappe.bench.sites = Sites(frappe.bench, os.path.abspath(os.getcwd()))
-
 	missing_assets = []
 	current_asset_files = []
 

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -209,7 +209,7 @@ def setup():
 	global app_paths, assets_path
 
 	pymodules = []
-	for app in frappe.get_all_apps(True):
+	for app in frappe.get_all_apps():
 		try:
 			pymodules.append(frappe.get_module(app))
 		except ImportError:

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -45,7 +45,13 @@ def build_missing_files():
 	"""Check which files dont exist yet from the assets.json and run build for those files"""
 	if Path(os.path.abspath(os.getcwd())).resolve() != frappe.bench.sites.path:
 		from frappe.bencher import Sites
+		from frappe.deprecation_dumpster import deprecation_warning
 
+		deprecation_warning(
+			"2024-12-06",
+			"v17",
+			"Calling frappe.build.build_missing_files from the current working directory distinct of the sites directory is deprecated, use FRAPPE_SITES_PATH env variable, instead.",
+		)
 		frappe.bench.sites = Sites(frappe.bench, os.path.abspath(os.getcwd()))
 
 	missing_assets = []

--- a/frappe/commands/redis_utils.py
+++ b/frappe/commands/redis_utils.py
@@ -22,7 +22,13 @@ def create_rq_users(set_admin_password=False, use_rq_auth=False):
 	"""
 	if Path(os.getcwd()).resolve() != frappe.bench.sites.path:
 		from frappe.bencher import Sites
+		from frappe.deprecation_dumpster import deprecation_warning
 
+		deprecation_warning(
+			"2024-12-06",
+			"v17",
+			"Calling frappe.commands.redis_utils.create_rq_user from the current working directory distinct of the sites directory is deprecated, use FRAPPE_SITES_PATH env variable to specify a distinct sites directory, instead.",
+		)
 		frappe.bench.sites = Sites(frappe.bench, os.getcwd())
 
 	from frappe.installer import update_site_config

--- a/frappe/commands/redis_utils.py
+++ b/frappe/commands/redis_utils.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import click
 
@@ -19,6 +20,11 @@ def create_rq_users(set_admin_password=False, use_rq_auth=False):
 	acl config file will be used by redis server while starting the server
 	and app config is used by app while connecting to redis server.
 	"""
+	if Path(os.getcwd()).resolve() != frappe.bench.sites.path:
+		from frappe.bencher import Sites
+
+		frappe.bench.sites = Sites(frappe.bench, os.getcwd())
+
 	from frappe.installer import update_site_config
 	from frappe.utils.redis_queue import RedisQueue
 
@@ -30,21 +36,22 @@ def create_rq_users(set_admin_password=False, use_rq_auth=False):
 	with open(acl_file_path, "w") as f:
 		f.writelines([acl + "\n" for acl in acl_list])
 
-	sites_path = os.getcwd()
-	common_site_config_path = os.path.join(sites_path, "common_site_config.json")
+	common_site_config_path = frappe.bench.sites.path / "common_site_config.json"
 	update_site_config(
 		"rq_username",
 		user_credentials["bench"][0],
 		validate=False,
-		site_config_path=common_site_config_path,
+		site_config_path=str(common_site_config_path),
 	)
 	update_site_config(
 		"rq_password",
 		user_credentials["bench"][1],
 		validate=False,
-		site_config_path=common_site_config_path,
+		site_config_path=str(common_site_config_path),
 	)
-	update_site_config("use_rq_auth", use_rq_auth, validate=False, site_config_path=common_site_config_path)
+	update_site_config(
+		"use_rq_auth", use_rq_auth, validate=False, site_config_path=str(common_site_config_path)
+	)
 
 	click.secho(
 		"* ACL and site configs are updated with new user credentials. "

--- a/frappe/commands/redis_utils.py
+++ b/frappe/commands/redis_utils.py
@@ -20,17 +20,6 @@ def create_rq_users(set_admin_password=False, use_rq_auth=False):
 	acl config file will be used by redis server while starting the server
 	and app config is used by app while connecting to redis server.
 	"""
-	if Path(os.getcwd()).resolve() != frappe.bench.sites.path:
-		from frappe.bencher import Sites
-		from frappe.deprecation_dumpster import deprecation_warning
-
-		deprecation_warning(
-			"2024-12-06",
-			"v17",
-			"Calling frappe.commands.redis_utils.create_rq_user from the current working directory distinct of the sites directory is deprecated, use FRAPPE_SITES_PATH env variable to specify a distinct sites directory, instead.",
-		)
-		frappe.bench.sites = Sites(frappe.bench, os.getcwd())
-
 	from frappe.installer import update_site_config
 	from frappe.utils.redis_queue import RedisQueue
 

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -793,10 +793,9 @@ def _use(site, sites_path="."):
 def use(site, sites_path="."):
 	from frappe.installer import update_site_config
 
-	if os.path.exists(os.path.join(sites_path, site)):
-		sites_path = os.getcwd()
-		conifg = os.path.join(sites_path, "common_site_config.json")
-		update_site_config("default_site", site, validate=False, site_config_path=conifg)
+	if (frappe.bench.sites.path / site).exists():
+		conifg = frappe.bench.sites.path / "common_site_config.json"
+		update_site_config("default_site", site, validate=False, site_config_path=str(conifg))
 		print(f"Current Site set to {site}")
 	else:
 		print(f"Site {site} does not exist")

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import typing
+from pathlib import Path
 
 import click
 
@@ -181,7 +182,10 @@ def show_config(context: CliCtxObj, format):
 		raise SiteNotSpecifiedError
 
 	sites_config = {}
-	sites_path = os.getcwd()
+	if Path(os.getcwd()).resolve() != frappe.bench.sites.path:
+		from frappe.bencher import Sites
+
+		frappe.bench.sites = Sites(frappe.bench, os.getcwd())
 
 	from frappe.utils.commands import render_table
 
@@ -206,7 +210,9 @@ def show_config(context: CliCtxObj, format):
 				click.echo()
 			click.secho(f"Site {site}", fg="yellow")
 
-		configuration = frappe.get_site_config(sites_path=sites_path, site_path=site)
+		configuration = frappe.get_site_config(
+			sites_path=frappe.bench.sites.path, site_path=frappe.bench.site.path
+		)
 
 		if format == "text":
 			data = transform_config(configuration)
@@ -566,7 +572,6 @@ def jupyter(context: CliCtxObj):
 	frappe.init(site)
 
 	jupyter_notebooks_path = os.path.abspath(frappe.get_site_path("jupyter_notebooks"))
-	sites_path = os.path.abspath(frappe.get_site_path(".."))
 
 	try:
 		os.stat(jupyter_notebooks_path)
@@ -580,7 +585,7 @@ Starting Jupyter notebook
 Run the following in your first cell to connect notebook to frappe
 ```
 import frappe
-frappe.init('{site}', sites_path='{sites_path}')
+frappe.init('{site}', sites_path='{frappe.bench.sites.path}')
 frappe.connect()
 frappe.local.lang = frappe.db.get_default('lang')
 frappe.db.connect()
@@ -871,9 +876,12 @@ def set_config(context: CliCtxObj, key, value, global_=False, parse=False):
 		value = ast.literal_eval(value)
 
 	if global_:
-		sites_path = os.getcwd()
-		common_site_config_path = os.path.join(sites_path, "common_site_config.json")
-		update_site_config(key, value, validate=False, site_config_path=common_site_config_path)
+		if Path(os.getcwd()).resolve() != frappe.bench.sites.path:
+			from frappe.bencher import Sites
+
+			frappe.bench.sites = Sites(frappe.bench, os.getcwd())
+		common_site_config_path = frappe.bench.sites.path / "common_site_config.json"
+		update_site_config(key, value, validate=False, site_config_path=str(common_site_config_path))
 	else:
 		if not context.sites:
 			raise SiteNotSpecifiedError

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -182,17 +182,6 @@ def show_config(context: CliCtxObj, format):
 		raise SiteNotSpecifiedError
 
 	sites_config = {}
-	if Path(os.getcwd()).resolve() != frappe.bench.sites.path:
-		from frappe.bencher import Sites
-		from frappe.deprecation_dumpster import deprecation_warning
-
-		deprecation_warning(
-			"2024-12-06",
-			"v17",
-			"Calling frappe.commands.utils.show_config from the current working directory distinct of the sites directory is deprecated, use FRAPPE_SITES_PATH env variable to specify a distinct sites directory, instead.",
-		)
-		frappe.bench.sites = Sites(frappe.bench, os.getcwd())
-
 	from frappe.utils.commands import render_table
 
 	def transform_config(config, prefix=None):
@@ -882,16 +871,6 @@ def set_config(context: CliCtxObj, key, value, global_=False, parse=False):
 		value = ast.literal_eval(value)
 
 	if global_:
-		if Path(os.getcwd()).resolve() != frappe.bench.sites.path:
-			from frappe.bencher import Sites
-			from frappe.deprecation_dumpster import deprecation_warning
-
-			deprecation_warning(
-				"2024-12-06",
-				"v17",
-				"Calling frappe.commands.utils.set_config from the current working directory distinct of the sites directory is deprecated, use FRAPPE_SITES_PATH env variable to specify a distinct sites directory, instead.",
-			)
-			frappe.bench.sites = Sites(frappe.bench, os.getcwd())
 		common_site_config_path = frappe.bench.sites.path / "common_site_config.json"
 		update_site_config(key, value, validate=False, site_config_path=str(common_site_config_path))
 	else:

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -184,7 +184,13 @@ def show_config(context: CliCtxObj, format):
 	sites_config = {}
 	if Path(os.getcwd()).resolve() != frappe.bench.sites.path:
 		from frappe.bencher import Sites
+		from frappe.deprecation_dumpster import deprecation_warning
 
+		deprecation_warning(
+			"2024-12-06",
+			"v17",
+			"Calling frappe.commands.utils.show_config from the current working directory distinct of the sites directory is deprecated, use FRAPPE_SITES_PATH env variable to specify a distinct sites directory, instead.",
+		)
 		frappe.bench.sites = Sites(frappe.bench, os.getcwd())
 
 	from frappe.utils.commands import render_table
@@ -878,7 +884,13 @@ def set_config(context: CliCtxObj, key, value, global_=False, parse=False):
 	if global_:
 		if Path(os.getcwd()).resolve() != frappe.bench.sites.path:
 			from frappe.bencher import Sites
+			from frappe.deprecation_dumpster import deprecation_warning
 
+			deprecation_warning(
+				"2024-12-06",
+				"v17",
+				"Calling frappe.commands.utils.set_config from the current working directory distinct of the sites directory is deprecated, use FRAPPE_SITES_PATH env variable to specify a distinct sites directory, instead.",
+			)
 			frappe.bench.sites = Sites(frappe.bench, os.getcwd())
 		common_site_config_path = frappe.bench.sites.path / "common_site_config.json"
 		update_site_config(key, value, validate=False, site_config_path=str(common_site_config_path))

--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -235,6 +235,22 @@ def get_local_with_deprecations() -> "Local":
 		# 		"'local.sites_path' will be deprecated: use 'frappe.bench.sites.path instead'",
 		# 	),
 		# )
+		sites_path = DeprecatedLocalAttribute(
+			"sites_path",
+			lambda: deprecation_warning(
+				"2024-12-06",
+				"v17",
+				"'local.sites_path' will be deprecated: use 'frappe.bench.sites.path instead'",
+			),
+		)
+		site_path = DeprecatedLocalAttribute(
+			"site_path",
+			lambda: deprecation_warning(
+				"2024-12-06",
+				"v17",
+				"'local.site_path' will be deprecated: use 'frappe.bench.site.path instead'",
+			),
+		)
 
 	return LocalWithDeprecations()
 

--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -235,22 +235,6 @@ def get_local_with_deprecations() -> "Local":
 		# 		"'local.sites_path' will be deprecated: use 'frappe.bench.sites.path instead'",
 		# 	),
 		# )
-		sites_path = DeprecatedLocalAttribute(
-			"sites_path",
-			lambda: deprecation_warning(
-				"2024-12-06",
-				"v17",
-				"'local.sites_path' will be deprecated: use 'frappe.bench.sites.path instead'",
-			),
-		)
-		site_path = DeprecatedLocalAttribute(
-			"site_path",
-			lambda: deprecation_warning(
-				"2024-12-06",
-				"v17",
-				"'local.site_path' will be deprecated: use 'frappe.bench.site.path instead'",
-			),
-		)
 
 	return LocalWithDeprecations()
 

--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -318,7 +318,7 @@ def get_js(items):
 		if ".." in src or src[0] != "assets":
 			frappe.throw(_("Invalid file path: {0}").format("/".join(src)))
 
-		contentpath = os.path.join(frappe.local.sites_path, *src)
+		contentpath = frappe.bench.sites.path.joinpath(*src)
 		with open(contentpath) as srcfile:
 			code = frappe.utils.cstr(srcfile.read())
 
@@ -819,12 +819,14 @@ def get_tests_CompatFrappeTestCase():
 			from frappe.installer import update_site_config
 			from frappe.utils.safe_exec import SAFE_EXEC_CONFIG_KEY
 
-			cls._common_conf = os.path.join(frappe.local.sites_path, "common_site_config.json")
-			update_site_config(SAFE_EXEC_CONFIG_KEY, 1, validate=False, site_config_path=cls._common_conf)
+			cls._common_conf = frappe.bench.sites.path / "common_site_config.json"
+			update_site_config(
+				SAFE_EXEC_CONFIG_KEY, 1, validate=False, site_config_path=str(cls._common_conf)
+			)
 
 			cls.addClassCleanup(
 				lambda: update_site_config(
-					SAFE_EXEC_CONFIG_KEY, 0, validate=False, site_config_path=cls._common_conf
+					SAFE_EXEC_CONFIG_KEY, 0, validate=False, site_config_path=str(cls._common_conf)
 				)
 			)
 

--- a/frappe/gettext/translate.py
+++ b/frappe/gettext/translate.py
@@ -127,7 +127,7 @@ def generate_pot(target_app: str | None = None):
 		subdir = os.path.basename(dirpath)
 		return not (subdir.startswith(".") or subdir.startswith("_"))
 
-	apps = [target_app] if target_app else frappe.get_all_apps(True)
+	apps = [target_app] if target_app else frappe.get_all_apps()
 	default_method_map = get_method_map("frappe")
 
 	keywords = DEFAULT_KEYWORDS.copy()
@@ -176,7 +176,7 @@ def get_is_gitignored_function_for_app(app: str | None):
 
 
 def new_po(locale, target_app: str | None = None):
-	apps = [target_app] if target_app else frappe.get_all_apps(True)
+	apps = [target_app] if target_app else frappe.get_all_apps()
 
 	for app in apps:
 		po_path = get_po_path(app, locale)
@@ -195,7 +195,7 @@ def new_po(locale, target_app: str | None = None):
 
 
 def compile_translations(target_app: str | None = None, locale: str | None = None, force=False):
-	apps = [target_app] if target_app else frappe.get_all_apps(True)
+	apps = [target_app] if target_app else frappe.get_all_apps()
 	tasks = []
 	for app in apps:
 		locales = [locale] if locale else get_locales(app)
@@ -234,7 +234,7 @@ def update_po(target_app: str | None = None, locale: str | None = None):
 	track of available keys, and missing translations
 	:param target_app: Limit operation to `app`, if specified
 	"""
-	apps = [target_app] if target_app else frappe.get_all_apps(True)
+	apps = [target_app] if target_app else frappe.get_all_apps()
 
 	for app in apps:
 		locales = [locale] if locale else get_locales(app)
@@ -247,7 +247,7 @@ def update_po(target_app: str | None = None, locale: str | None = None):
 
 
 def migrate(app: str | None = None, locale: str | None = None):
-	apps = [app] if app else frappe.get_all_apps(True)
+	apps = [app] if app else frappe.get_all_apps()
 
 	for app in apps:
 		if locale:

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 from collections import OrderedDict
 from contextlib import suppress
+from pathlib import Path
 from shutil import which
 
 import click
@@ -744,33 +745,49 @@ def _guess_mariadb_version() -> tuple[int] | None:
 def extract_files(site_name, file_path):
 	import shutil
 	import subprocess
+	import tempfile
 
 	from frappe.utils import get_bench_relative_path
 
-	file_path = get_bench_relative_path(file_path)
+	file_path = Path(get_bench_relative_path(file_path)).resolve()
 
-	# Need to do frappe.init to maintain the site locals
+	# Need to do frappe.init to scope bench
 	frappe.init(site_name)
-	abs_site_path = os.path.abspath(frappe.get_site_path())
 
 	# Copy the files to the parent directory and extract
-	shutil.copy2(os.path.abspath(file_path), abs_site_path)
+	shutil.copy2(file_path, frappe.bench.site.path)
+	archive_path = frappe.bench.site.path / file_path.name
 
 	# Get the file name splitting the file path on
-	tar_name = os.path.split(file_path)[1]
-	tar_path = os.path.join(abs_site_path, tar_name)
-
+	folders = ("public", "private")
 	try:
-		if file_path.endswith(".tar"):
-			subprocess.check_output(["tar", "xvf", tar_path, "--strip", "2"], cwd=abs_site_path)
-		elif file_path.endswith(".tgz"):
-			subprocess.check_output(["tar", "zxvf", tar_path, "--strip", "2"], cwd=abs_site_path)
+		with tempfile.TemporaryDirectory() as temp_dir:
+			shutil.unpack_archive(archive_path, extract_dir=temp_dir)
+			for folder in folders:
+				if (
+					sentinel := (Path(temp_dir) / folder / "files" / ".bkp_relative_to_site_root")
+				) and sentinel.exists():
+					sentinel.unlink()
+					shutil.copytree(temp_dir, frappe.bench.site.path, dirs_exist_ok=True)
+					break
+			else:
+				# requiring tar on old style backups in order to strip parent dirs
+				subprocess.check_output(
+					[
+						"tar",
+						"xvf" if file_path.suffix == ".tar" else "zxvf",
+						archive_path,
+						"--strip",
+						"2",
+					],
+					cwd=frappe.bench.site.path,
+				)
 	except Exception:
 		raise
 	finally:
 		frappe.destroy()
 
-	return tar_path
+	return archive_path
 
 
 def is_downgrade(sql_file_path, verbose=False):

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -558,9 +558,8 @@ def make_conf(
 		db_port=db_port,
 		db_user=db_user,
 	)
-	sites_path = frappe.local.sites_path
 	frappe.destroy()
-	frappe.init(site, sites_path=sites_path)
+	frappe.init(site, sites_path=frappe.bench.sites.path)
 
 
 def make_site_config(
@@ -573,7 +572,7 @@ def make_site_config(
 	db_port=None,
 	db_user=None,
 ):
-	frappe.create_folder(os.path.join(frappe.local.site_path))
+	frappe.create_folder(str(frappe.bench.site.path))
 	site_file = get_site_config_path()
 
 	if not os.path.exists(site_file):
@@ -642,7 +641,7 @@ def _update_config_file(key: str, value, config_file: str):
 
 
 def get_site_config_path():
-	return os.path.join(frappe.local.site_path, "site_config.json")
+	return str(frappe.bench.site.path / "site_config.json")
 
 
 def get_conf_params(db_name=None, db_password=None):

--- a/frappe/tests/classes/context_managers.py
+++ b/frappe/tests/classes/context_managers.py
@@ -122,10 +122,10 @@ def enable_safe_exec() -> None:
 	from frappe.installer import update_site_config
 	from frappe.utils.safe_exec import SAFE_EXEC_CONFIG_KEY
 
-	conf = os.path.join(frappe.local.sites_path, "common_site_config.json")
-	update_site_config(SAFE_EXEC_CONFIG_KEY, 1, validate=False, site_config_path=conf)
+	conf = frappe.bench.sites.path / "common_site_config.json"
+	update_site_config(SAFE_EXEC_CONFIG_KEY, 1, validate=False, site_config_path=str(conf))
 	yield
-	update_site_config(SAFE_EXEC_CONFIG_KEY, 0, validate=False, site_config_path=conf)
+	update_site_config(SAFE_EXEC_CONFIG_KEY, 0, validate=False, site_config_path=str(conf))
 
 
 @UnitTestCase.registerAs(staticmethod)

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -910,7 +910,7 @@ class TestBenchBuild(BaseTestCommands):
 		default_bundle_size = 0.0
 
 		for chunk in default_bundle:
-			abs_path = Path.cwd() / frappe.local.sites_path / bundled_asset(chunk)[1:]
+			abs_path = (frappe.bench.sites.path / bundled_asset(chunk)[1:]).resolve()
 			default_bundle_size += abs_path.stat().st_size
 
 		self.assertLessEqual(

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -258,10 +258,16 @@ class TestCommands(BaseTestCommands):
 
 		with self.switch_site(TEST_SITE):
 			public_file = frappe.new_doc(
-				"File", file_name=f"test_{frappe.generate_hash()}", content=frappe.generate_hash()
+				"File",
+				file_name=f"test_{frappe.generate_hash()}",
+				content=frappe.generate_hash(),
+				is_private=False,
 			).insert()
 			private_file = frappe.new_doc(
-				"File", file_name=f"test_{frappe.generate_hash()}", content=frappe.generate_hash()
+				"File",
+				file_name=f"test_{frappe.generate_hash()}",
+				content=frappe.generate_hash(),
+				is_private=True,
 			).insert()
 
 		# test 1: bench restore from full backup

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -715,7 +715,7 @@ def get_untranslated(lang, untranslated_file, get_all=False, app="_ALL_APPS"):
 	:param untranslated_file: Output file path.
 	:param get_all: Return all strings, translated or not."""
 	clear_cache()
-	apps = frappe.get_all_apps(True)
+	apps = frappe.get_all_apps()
 	if app != "_ALL_APPS":
 		if app not in apps:
 			print(f"Application {app} not found!")
@@ -784,7 +784,7 @@ def update_translations(lang, untranslated_file, translated_file, app="_ALL_APPS
 		translation_dict[restore_newlines(key)] = restore_newlines(value)
 
 	full_dict.update(translation_dict)
-	apps = frappe.get_all_apps(True)
+	apps = frappe.get_all_apps()
 
 	if app != "_ALL_APPS":
 		if app not in apps:
@@ -802,7 +802,7 @@ def import_translations(lang, path):
 	full_dict = get_all_translations(lang)
 	full_dict.update(get_translation_dict_from_file(path, lang, "import"))
 
-	for app in frappe.get_all_apps(True):
+	for app in frappe.get_all_apps():
 		write_translations_file(app, lang, full_dict)
 
 

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -550,7 +550,7 @@ def get_messages_from_include_files(app_name=None):
 
 	for js_path in include_js:
 		file_path = bundled_asset(js_path)
-		relative_path = os.path.join(frappe.local.sites_path, file_path.lstrip("/"))
+		relative_path = frappe.bench.sites.path.joinpath(file_path.lstrip("/"))
 		messages_from_file = get_messages_from_file(relative_path)
 		messages.extend(messages_from_file)
 

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -19,6 +19,7 @@ from collections.abc import (
 )
 from email.header import decode_header, make_header
 from email.utils import formataddr, parseaddr
+from pathlib import Path
 from typing import TypedDict
 
 from werkzeug.test import Client
@@ -496,12 +497,12 @@ def execute_in_shell(cmd, verbose=False, low_priority=False, check_exit_code=Fal
 def get_path(*path, **kwargs):
 	base = kwargs.get("base")
 	if not base:
-		base = frappe.local.site_path
-	return os.path.join(base, *path)
+		base = frappe.bench.site.path
+	return str(os.path.join(base, *path))
 
 
 def get_site_base_path():
-	return frappe.local.site_path
+	return str(frappe.bench.site.path)
 
 
 def get_site_path(*path):
@@ -671,7 +672,11 @@ def is_a_property(x) -> bool:
 
 def get_sites(sites_path=None):
 	if not sites_path:
-		sites_path = getattr(frappe.local, "sites_path", None) or "."
+		if Path(os.getcwd()).resolve() != frappe.bench.sites.path:
+			from frappe.bencher import Sites
+
+			frappe.bench.sites = Sites(frappe.bench, os.getcwd())
+		sites_path = frappe.bench.sites.path
 
 	sites = []
 	for site in os.listdir(sites_path):
@@ -944,7 +949,7 @@ def get_file_size(path, format=False):
 
 def get_build_version():
 	try:
-		return str(os.path.getmtime(os.path.join(frappe.local.sites_path, "assets/assets.json")))
+		return str(os.path.getmtime(frappe.bench.sites.path / "assets" / "assets.json"))
 	except OSError:
 		# .build can sometimes not exist
 		# this is not a major problem so send fallback

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -672,16 +672,6 @@ def is_a_property(x) -> bool:
 
 def get_sites(sites_path=None):
 	if not sites_path:
-		if Path(os.getcwd()).resolve() != frappe.bench.sites.path:
-			from frappe.bencher import Sites
-			from frappe.deprecation_dumpster import deprecation_warning
-
-			deprecation_warning(
-				"2024-12-06",
-				"v17",
-				"Relying on '.' to establishin  'sites_path' in 'frappe.utils.get_sites' is deprecated, pass sites_path= argument, instead.",
-			)
-			frappe.bench.sites = Sites(frappe.bench, os.getcwd())
 		sites_path = frappe.bench.sites.path
 
 	sites = []

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -674,7 +674,13 @@ def get_sites(sites_path=None):
 	if not sites_path:
 		if Path(os.getcwd()).resolve() != frappe.bench.sites.path:
 			from frappe.bencher import Sites
+			from frappe.deprecation_dumpster import deprecation_warning
 
+			deprecation_warning(
+				"2024-12-06",
+				"v17",
+				"Relying on '.' to establishin  'sites_path' in 'frappe.utils.get_sites' is deprecated, pass sites_path= argument, instead.",
+			)
 			frappe.bench.sites = Sites(frappe.bench, os.getcwd())
 		sites_path = frappe.bench.sites.path
 

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -343,30 +343,26 @@ class BackupGenerator:
 			print(template.format(_type.title(), os.path.abspath(info["path"]), info["size"]))
 
 	def backup_files(self):
+		import shutil
+		import tempfile
+		from pathlib import Path
+
 		for folder in ("public", "private"):
-			files_path = frappe.get_site_path(folder, "files")
-			backup_path = self.backup_path_files if folder == "public" else self.backup_path_private_files
+			sentinel = frappe.bench.site.path / folder / "files" / ".bkp_relative_to_site_root"
+			sentinel.touch()
 
-			if self.compress_files:
-				cmd_string = "set -o pipefail; tar cf - {1} | gzip > {0}"
-			else:
-				cmd_string = "tar -cf {0} {1}"
-
-			try:
-				frappe.utils.execute_in_shell(
-					cmd_string.format(backup_path, files_path),
-					verbose=self.verbose,
-					low_priority=True,
-					check_exit_code=True,
+			with tempfile.TemporaryDirectory() as temp_dir:
+				shutil.move(
+					shutil.make_archive(
+						Path(temp_dir) / "archive",
+						"tar" if not self.compress_files else "xztar",
+						frappe.bench.site.path,
+						f"{folder}/files",
+					),
+					# fix to the contstant extension which may well be a public contract
+					self.backup_path_files if folder == "public" else self.backup_path_private_files,
 				)
-			except frappe.CommandFailedError as e:
-				if e.err and "file changed as we read it" in e.err:
-					click.secho(
-						"Ignoring `tar: file changed as we read it` to prevent backup failure",
-						fg="red",
-					)
-				else:
-					raise e
+			sentinel.unlink()
 
 	def copy_site_config(self):
 		site_config_backup_path = self.backup_path_conf

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -194,7 +194,7 @@ def get_frappe_help():
 
 
 def get_apps():
-	return frappe.get_all_apps(with_internal_apps=False, sites_path=".")
+	return [str(app) for app in frappe.bench.apps]
 
 
 if __name__ == "__main__":

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -240,7 +240,7 @@ PATCH_TEMPLATE = textwrap.dedent(
 
 class PatchCreator:
 	def __init__(self):
-		self.all_apps = frappe.get_all_apps(sites_path=".", with_internal_apps=False)
+		self.all_apps = [str(app) for app in frappe.bench.apps]
 
 		self.app = None
 		self.app_dir = None

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -299,7 +299,7 @@ def prepare_header_footer(soup: BeautifulSoup):
 	styles = soup.find_all("style")
 
 	print_css = bundled_asset("print.bundle.css").lstrip("/")
-	css = frappe.read_file(os.path.join(frappe.local.sites_path, print_css))
+	css = frappe.read_file(frappe.bench.sites.path.joinpath(print_css))
 
 	# extract header and footer
 	for html_id in ("header-html", "footer-html"):


### PR DESCRIPTION
This PR:
 - accesses site paths via (new) canonical `frappe.bench.site{,s}.path`
 - deprecates access to `frappe.local.site{,s}_path`
