### PR TITLE
fix: redirect cssutils logger to file

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2390,7 +2390,9 @@ loggers: dict[str, "Logger"] = {}
 log_level: int | None = None
 
 
-def logger(module=None, with_more_info=False, allow_site=True, filter=None, max_size=100_000, file_count=20):
+def logger(
+	module=None, with_more_info=False, allow_site=True, filter=None, max_size=100_000, file_count=20
+) -> "Logger":
 	"""Return a python logger that uses StreamHandler."""
 	from frappe.utils.logger import get_logger
 

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -23,6 +23,8 @@ from frappe.utils import cstr, scrub_urls
 from frappe.utils.caching import redis_cache
 from frappe.utils.jinja_globals import bundled_asset, is_rtl
 
+cssutils.log.setLog(frappe.logger("cssutils"))
+
 PDF_CONTENT_ERRORS = [
 	"ContentNotFoundError",
 	"ContentOperationNotPermittedError",


### PR DESCRIPTION
Finally redirect these to the frappe logging:

```
ERROR	PropertyValue: Missing token for production Choice(ColorValue, Dimension, URIValue, Value, variable, MSValue, CSSCalc, function): ('HASH', '#0000001a', 1, 3215)
ERROR	PropertyValue: Unknown syntax or no value: 0 3px 6px #0000001a
ERROR	CSSStyleDeclaration: Syntax Error in Property: box-shadow:0 3px 6px #0000001a
```