### PR TITLE
perf: index document name on error log

### DIFF
--- a/frappe/core/doctype/error_log/error_log.json
+++ b/frappe/core/doctype/error_log/error_log.json
@@ -42,8 +42,7 @@
    "in_standard_filter": 1,
    "label": "Reference DocType",
    "options": "DocType",
-   "read_only": 1,
-   "search_index": 1
+   "read_only": 1
   },
   {
    "fieldname": "reference_name",
@@ -51,7 +50,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Reference Name",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "column_break_3",
@@ -72,7 +72,7 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2024-06-05 05:34:35.048489",
+ "modified": "2024-12-09 14:22:44.819718",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Error Log",


### PR DESCRIPTION
Moved index from doctype to docname. Docname always has higher
cardinality. Even if you filter by both it shouldn't matter as
cross-doctype name conflicts are rather rare.

Perf impact of this change should be net 0 but it does addresses problem of
indeterministic load times based on how many errors exist in db.

closes https://github.com/frappe/frappe/issues/28713
