### PR TITLE
fix: Keep HTTP caches private by default

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -246,8 +246,8 @@ def process_response(response):
 	if frappe.local.response.can_cache:
 		response.headers.extend(
 			{
-				# default: 5m (proxy), 5m (client), 3h (allow stale resources for this long if upstream is down)
-				"Cache-Control": "public,s-maxage=300,max-age=300,stale-while-revalidate=10800",
+				# default: 5m (client), 3h (allow stale resources for this long if upstream is down)
+				"Cache-Control": "private,max-age=300,stale-while-revalidate=10800",
 			}
 		)
 	else:


### PR DESCRIPTION
Developers can easily enable `can_cache` without knowing what it
entails. Public cache means proxy can likely cache things without
talking to backend.

Obviously many endpoints which can be cached on client side should
probably not be cached in proxy.

E.g. linked PR to the PR that added this feature suggest caching
notification log for short time... we don't want to leak one user's
cached notification to another user.

I don't buy that developers should know about cache implementation to
ensure it's secure or correct to enable it on certain endpoint. In
addition to that, we have very few mechanisms to burst cache
inside proxy. End user hitting ctrl+shift+r won't do anything if proxy
wants to serve stale response.

We should figure out better way to instruct FW about final cache
control headers than hardcoding it IMO.

Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#directives 