### PR TITLE
fix: remove text align justify from newsletter

### DIFF
--- a/frappe/templates/emails/newsletter.html
+++ b/frappe/templates/emails/newsletter.html
@@ -1,4 +1,4 @@
-<div style="text-align: justify;">
+<div>
     <div style="width: 600px;  margin: 10px auto;">
         {{ message }}
     </div>


### PR DESCRIPTION
`text-align: justify` is a crime against humanity