### PR TITLE
feat : adding filters for number cards

### DIFF
--- a/frappe/desk/doctype/dashboard/dashboard.js
+++ b/frappe/desk/doctype/dashboard/dashboard.js
@@ -4,7 +4,12 @@
 frappe.ui.form.on("Dashboard", {
 	refresh: function (frm) {
 		frm.add_custom_button(__("Show Dashboard"), () =>
-			frappe.set_route("dashboard-view", frm.doc.name)
+			window.open(
+			`/app/dashboard-view/${frm.doc.name}` +
+				(frm.doc.custom_reference_doctype
+					? `?doctype=${encodeURIComponent(frm.doc.custom_reference_doctype)}`
+					: "")
+			)
 		);
 
 		if (!frappe.boot.developer_mode && frm.doc.is_standard) {

--- a/frappe/desk/doctype/dashboard/dashboard.json
+++ b/frappe/desk/doctype/dashboard/dashboard.json
@@ -8,6 +8,7 @@
  "engine": "InnoDB",
  "field_order": [
   "dashboard_name",
+  "reference_doctype",
   "is_default",
   "is_standard",
   "module",
@@ -64,13 +65,21 @@
    "label": "Module",
    "mandatory_depends_on": "eval: doc.is_standard",
    "options": "Module Def"
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "label": "Reference Doctype",
+   "link_filters": "[[\"DocType\",\"issingle\",\"=\",0],[\"DocType\",\"is_tree\",\"=\",0],[\"DocType\",\"istable\",\"=\",0]]",
+   "options": "DocType"
   }
  ],
  "links": [],
- "modified": "2024-03-23 16:02:16.071715",
+ "modified": "2024-12-09 20:58:01.514618",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -108,7 +117,7 @@
   }
  ],
  "quick_entry": 1,
- "sort_field": "creation",
+ "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
  "title_field": "dashboard_name",

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -126,6 +126,7 @@ export default class NumberCardWidget extends Widget {
 				method: this.card_doc.method,
 				args: {
 					filters: this.filters,
+					card_filters: this.card_filters || "",
 				},
 				get_number: (res) => this.get_number_for_custom_card(res),
 			},
@@ -143,6 +144,7 @@ export default class NumberCardWidget extends Widget {
 				args: {
 					doc: this.card_doc,
 					filters: this.filters,
+					card_filters: this.card_filters || "",
 				},
 				get_number: (res) => this.get_number_for_doctype_card(res),
 			},

--- a/frappe/public/js/frappe/widgets/widget_group.js
+++ b/frappe/public/js/frappe/widgets/widget_group.js
@@ -83,6 +83,7 @@ export default class WidgetGroup {
 			...widget,
 			widget_type: this.type,
 			container: this.body,
+			card_filters: this.card_filters || "",
 			height: this.height || null,
 			options: {
 				...this.options,
@@ -205,18 +206,17 @@ export class SingleWidgetGroup {
 		let widget_object = frappe.widget.make_widget({
 			...widget,
 			widget_type: this.type,
-			container: this.body,
-			card_filters: this.card_filters || "",
+			container: this.container,
 			height: this.height || null,
 			options: {
 				...this.options,
-				on_delete: (name) => this.on_delete(name),
+				on_delete: () => this.on_delete(),
+				on_edit: () => this.on_edit(widget_object),
 			},
 		});
-	
 		this.widgets_list.push(widget_object);
 		this.widgets_dict[widget.name] = widget_object;
-	
+
 		return widget_object;
 	}
 

--- a/frappe/public/js/frappe/widgets/widget_group.js
+++ b/frappe/public/js/frappe/widgets/widget_group.js
@@ -205,17 +205,18 @@ export class SingleWidgetGroup {
 		let widget_object = frappe.widget.make_widget({
 			...widget,
 			widget_type: this.type,
-			container: this.container,
+			container: this.body,
+			card_filters: this.card_filters || "",
 			height: this.height || null,
 			options: {
 				...this.options,
-				on_delete: () => this.on_delete(),
-				on_edit: () => this.on_edit(widget_object),
+				on_delete: (name) => this.on_delete(name),
 			},
 		});
+	
 		this.widgets_list.push(widget_object);
 		this.widgets_dict[widget.name] = widget_object;
-
+	
 		return widget_object;
 	}
 


### PR DESCRIPTION
in this pr i added filters for number cards so that we can add filter dynamically. i also observed there are dynamic filters already in the number card doctype but its very confusing to use and not sure they are working or not.

filters group is created based on reference doctype field given  in the dashboard doctype and applies filters to number cards which belongs to that reference doctype. if the number card reference doctype and dashboard reference doctype doesn't matches then it simply skip filter part and renders normally.

[number_card_filters.webm](https://github.com/user-attachments/assets/6cb19562-1e31-4bc1-991e-5e8393b5a5ff)
