### PR TITLE
fix: not able to generate stock balance report

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -5,6 +5,7 @@ import json
 from contextlib import suppress
 from typing import Any
 
+from pymysql.err import OperationalError
 from rq import get_current_job
 
 import frappe
@@ -234,6 +235,14 @@ def create_json_gz_file(data, dt, dn, report_name):
 	encoded_content = frappe.safe_encode(frappe.as_json(data, indent=None, separators=(",", ":")))
 	compressed_content = gzip.compress(encoded_content)
 
+	try:
+		create_file_for_prepared_report(json_filename, dt, dn, compressed_content)
+	except OperationalError:
+		frappe.db.connect()
+		create_file_for_prepared_report(json_filename, dt, dn, compressed_content)
+
+
+def create_file_for_prepared_report(json_filename, dt, dn, compressed_content):
 	# Call save() file function to upload and attach the file
 	_file = frappe.get_doc(
 		{


### PR DESCRIPTION
```
Traceback with variables (most recent call last):
File "apps/frappe/frappe/core/doctype/prepared_report/prepared_report.py", line 81, in generate_report
create_json_gz_file(result, instance.doctype, instance.name)
prepared_report = 'd8f0304bbd'
instance = <PreparedReport: d8f0304bbd>
report = <Report: Stock Balance>
result = {'result': [{'item_code': '5ee20765afb82c416ad28998', 'warehouse': 'DHR-DAMAGE - AK', 'item_group': 'All Item Groups', 'company': 'Octopolis Technologies Pvt Ltd', 'currency': 0.0, 'stock_uom': 'Nos', 'item_name': 'Ghadi Detergent Powder 1kg', 'opening_qty': 1.0, 'opening_val': 47.966, 'opening_fifo_queue': [], 'in_qty': 0.0, 'in_val': 0.0, 'out_qty': 0.0, 'out_val': 0.0, 'bal_qty': 1.0, 'bal_val': 47.966, 'val_rate': 47.966}, {'item_code': '6007f7a5eb18623f9c49c50c', 'warehouse': 'DHR-DAMAGE - AK', 'item_group': 'All Item Groups', 'company': 'Octopolis Technologies Pvt Ltd', 'currency': 0.0, 'stock_uom': 'Nos', 'item_name': 'Tata Tea Premium India ki Chai 1kg', 'opening_qty': 3.0, 'opening_val': 861.906, 'opening_fifo_queue': [], 'in_qty': 0.0, 'in_val': 0.0, 'out_qty': 0.0, 'out_val': 0.0, 'bal_qty': 3.0, 'bal_val': 861.906, 'val_rate': 287.302}, {'item_code': '603cefc4ae7d2527a811ee7e', 'warehouse': 'DHR-DAMAGE - AK', 'item_group': 'All Item Groups', 'company': 'Octopolis Technologi...
File "apps/frappe/frappe/core/doctype/prepared_report/prepared_report.py", line 179, in create_json_gz_file
_file = frappe.get_doc(
data = {'result': [{'item_code': '5ee20765afb82c416ad28998', 'warehouse': 'DHR-DAMAGE - AK', 'item_group': 'All Item Groups', 'company': 'Octopolis Technologies Pvt Ltd', 'currency': 0.0, 'stock_uom': 'Nos', 'item_name': 'Ghadi Detergent Powder 1kg', 'opening_qty': 1.0, 'opening_val': 47.966, 'opening_fifo_queue': [], 'in_qty': 0.0, 'in_val': 0.0, 'out_qty': 0.0, 'out_val': 0.0, 'bal_qty': 1.0, 'bal_val': 47.966, 'val_rate': 47.966}, {'item_code': '6007f7a5eb18623f9c49c50c', 'warehouse': 'DHR-DAMAGE - AK', 'item_group': 'All Item Groups', 'company': 'Octopolis Technologies Pvt Ltd', 'currency': 0.0, 'stock_uom': 'Nos', 'item_name': 'Tata Tea Premium India ki Chai 1kg', 'opening_qty': 3.0, 'opening_val': 861.906, 'opening_fifo_queue': [], 'in_qty': 0.0, 'in_val': 0.0, 'out_qty': 0.0, 'out_val': 0.0, 'bal_qty': 3.0, 'bal_val': 861.906, 'val_rate': 287.302}, {'item_code': '603cefc4ae7d2527a811ee7e', 'warehouse': 'DHR-DAMAGE - AK', 'item_group': 'All Item Groups', 'company': 'Octopolis Technologi...
dt = 'Prepared Report'
dn = 'd8f0304bbd'
json_filename = '2024-8-11-10:6.json.gz'
encoded_content = b'{"chart":null,"columns":[{"fieldname":"item_code","fieldtype":"Link","label":"Item","options":"Item","width":100},{"fieldname":"item_name","label":"Item Name","width":150},{"fieldname":"item_group","fieldtype":"Link","label":"Item Group","options":"Item Group","width":100},{"fieldname":"warehouse","fieldtype":"Link","label":"Warehouse","options":"Warehouse","width":100},{"fieldname":"stock_uom","fieldtype":"Link","label":"Stock UOM","options":"UOM","width":90},{"convertible":"qty","fieldname":"bal_qty","fieldtype":"Float","label":"Balance Qty","width":100},{"fieldname":"bal_val","fieldtype":"Currency","label":"Balance Value","options":"Company:company:default_currency","width":100},{"convertible":"qty","fieldname":"opening_qty","fieldtype":"Float","label":"Opening Qty","width":100},{"fieldname":"opening_val","fieldtype":"Currency","label":"Opening Value","options":"Company:company:default_currency","width":110},{"convertible":"qty","fieldname":"in_qty","fieldtype":"Float","label":"In...
compressed_content = b'\x1f\x8b\x08\x00\xdf\xd4gf\x02\xff\xec\xbd\xdbr\xdbH\xb6-\xfa+\x88z\xe8~\xe8\x16"\xef\x97z9!Ye\xb9\xca\x92\xad\x96\\\xf6^\xbd\xcf\x8e\x8e\x04\x90\x90\xb8L\x91Z\xbcTY\xbd\xe3\xfc\xfb\xc9\x04\x01\x90H&)&\x08\xc1r\x93QA\xbb$S)rN\xce\x9c\xf71\xfe\xefO\xe9\xbd\x9a\xcc~\xfay4\x1f\x0e\xff\xfeS:\x1e\xce\x1fF\xd3\x9f~\xfe\xdf\xff\xf7\xa7|\xa0\x87\xd9H=\xe8\x9f~\xfei0\xd3\x0f\xffJ\xc7\x99\xfe\xe9\xef\x8b\xef\xcf\x9e\x1e\xed\xf7/\x07\xa3\xaf\xe6[C\x95\xe8\xa1\xf9\xf2W\xf34\xf3\xe5\xf8q6\x18\xdbS\xaao\xfc9\xc8f\xf7?\xfd\x0c\x01\xf8\xff\xfe\xee9\xb8\xf8\xff\xe6)\xd1\x87\xc5\xf7\xaa\x9f\xa4\xfe\x9f\xbc\x9b\x8c\xe7\x8f\xcf\xbf\xa6\xe8\xa2|^\xf3\x95\xd5\xdf\xde\xfc\xfa\xfeT\x13}?\x9eO\x9fy\xe3_V\x9e\xb6\xfc\x1d\xab\xdf\xdd\xfc+\xa6\xb3q\xfa\xf5_\xf3\xf1\xc3\xf6_qk\x9f\x16\xfd\xfe\xf1\xaa\xf1+\x16_\x97\x87\xcb\xe2\xect<\xfaCOf\x83dhO\xf9\x9f\xd9Sun\xf9\xfb\x125\xfc\xd7\xcaw\xcb\xdf\xf6v8V\xb3\x95_w\xa6\x86j\x94\xea\xe8\x1f\xc537\xbfz{\xda\x1fj\xe8\x9c\xf6f>\x99\xe8Q\xfa\xe49\xf0\xb3\x1a\xce\x9bbz3~xT...
File "apps/frappe/frappe/__init__.py", line 1200, in get_doc
doc = frappe.model.document.get_doc(*args, **kwargs)
args = ({'doctype': 'File', 'file_name': '2024-8-11-10:6.json.gz', 'attached_to_doctype': 'Prepared Report', 'attached_to_name': 'd8f0304bbd', 'content': b'\x1f\x8b\x08\x00\xdf\xd4gf\x02\xff\xec\xbd\xdbr\xdbH\xb6-\xfa+\x88z\xe8~\xe8\x16"\xef\x97z9!Ye\xb9\xca\x92\xad\x96\\\xf6^\xbd\xcf\x8e\x8e\x04\x90\x90\xb8L\x91Z\xbcTY\xbd\xe3\xfc\xfb\xc9\x04\x01\x90H&)&\x08\xc1r\x93QA\xbb$S)rN\xce\x9c\xf71\xfe\xefO\xe9\xbd\x9a\xcc~\xfay4\x1f\x0e\xff\xfeS:\x1e\xce\x1fF\xd3\x9f~\xfe\xdf\xff\xf7\xa7|\xa0\x87\xd9H=\xe8\x9f~\xfei0\xd3\x0f\xffJ\xc7\x99\xfe\xe9\xef\x8b\xef\xcf\x9e\x1e\xed\xf7/\x07\xa3\xaf\xe6[C\x95\xe8\xa1\xf9\xf2W\xf34\xf3\xe5\xf8q6\x18\xdbS\xaao\xfc9\xc8f\xf7?\xfd\x0c\x01\xf8\xff\xfe\xee9\xb8\xf8\xff\xe6)\xd1\x87\xc5\xf7\xaa\x9f\xa4\xfe\x9f\xbc\x9b\x8c\xe7\x8f\xcf\xbf\xa6\xe8\xa2|^\xf3\x95\xd5\xdf\xde\xfc\xfa\xfeT\x13}?\x9eO\x9fy\xe3_V\x9e\xb6\xfc\x1d\xab\xdf\xdd\xfc+\xa6\xb3q\xfa\xf5_\xf3\xf1\xc3\xf6_qk\x9f\x16\xfd\xfe\xf1\xaa\xf1+\x16_\x97\x87\xcb\xe2\xect<\xfaCOf\x83dhO\xf9\x9f\xd9Sun\xf9\xfb...
kwargs = {}
frappe = <module 'frappe' from 'apps/frappe/frappe/__init__.py'>
File "apps/frappe/frappe/model/document.py", line 76, in get_doc
controller = get_controller(doctype)
args = ({'doctype': 'File', 'file_name': '2024-8-11-10:6.json.gz', 'attached_to_doctype': 'Prepared Report', 'attached_to_name': 'd8f0304bbd', 'content': b'\x1f\x8b\x08\x00\xdf\xd4gf\x02\xff\xec\xbd\xdbr\xdbH\xb6-\xfa+\x88z\xe8~\xe8\x16"\xef\x97z9!Ye\xb9\xca\x92\xad\x96\\\xf6^\xbd\xcf\x8e\x8e\x04\x90\x90\xb8L\x91Z\xbcTY\xbd\xe3\xfc\xfb\xc9\x04\x01\x90H&)&\x08\xc1r\x93QA\xbb$S)rN\xce\x9c\xf71\xfe\xefO\xe9\xbd\x9a\xcc~\xfay4\x1f\x0e\xff\xfeS:\x1e\xce\x1fF\xd3\x9f~\xfe\xdf\xff\xf7\xa7|\xa0\x87\xd9H=\xe8\x9f~\xfei0\xd3\x0f\xffJ\xc7\x99\xfe\xe9\xef\x8b\xef\xcf\x9e\x1e\xed\xf7/\x07\xa3\xaf\xe6[C\x95\xe8\xa1\xf9\xf2W\xf34\xf3\xe5\xf8q6\x18\xdbS\xaao\xfc9\xc8f\xf7?\xfd\x0c\x01\xf8\xff\xfe\xee9\xb8\xf8\xff\xe6)\xd1\x87\xc5\xf7\xaa\x9f\xa4\xfe\x9f\xbc\x9b\x8c\xe7\x8f\xcf\xbf\xa6\xe8\xa2|^\xf3\x95\xd5\xdf\xde\xfc\xfa\xfeT\x13}?\x9eO\x9fy\xe3_V\x9e\xb6\xfc\x1d\xab\xdf\xdd\xfc+\xa6\xb3q\xfa\xf5_\xf3\xf1\xc3\xf6_qk\x9f\x16\xfd\xfe\xf1\xaa\xf1+\x16_\x97\x87\xcb\xe2\xect<\xfaCOf\x83dhO\xf9\x9f\xd9Sun\xf9\xfb...
kwargs = {'doctype': 'File', 'file_name': '2024-8-11-10:6.json.gz', 'attached_to_doctype': 'Prepared Report', 'attached_to_name': 'd8f0304bbd', 'content': b'\x1f\x8b\x08\x00\xdf\xd4gf\x02\xff\xec\xbd\xdbr\xdbH\xb6-\xfa+\x88z\xe8~\xe8\x16"\xef\x97z9!Ye\xb9\xca\x92\xad\x96\\\xf6^\xbd\xcf\x8e\x8e\x04\x90\x90\xb8L\x91Z\xbcTY\xbd\xe3\xfc\xfb\xc9\x04\x01\x90H&)&\x08\xc1r\x93QA\xbb$S)rN\xce\x9c\xf71\xfe\xefO\xe9\xbd\x9a\xcc~\xfay4\x1f\x0e\xff\xfeS:\x1e\xce\x1fF\xd3\x9f~\xfe\xdf\xff\xf7\xa7|\xa0\x87\xd9H=\xe8\x9f~\xfei0\xd3\x0f\xffJ\xc7\x99\xfe\xe9\xef\x8b\xef\xcf\x9e\x1e\xed\xf7/\x07\xa3\xaf\xe6[C\x95\xe8\xa1\xf9\xf2W\xf34\xf3\xe5\xf8q6\x18\xdbS\xaao\xfc9\xc8f\xf7?\xfd\x0c\x01\xf8\xff\xfe\xee9\xb8\xf8\xff\xe6)\xd1\x87\xc5\xf7\xaa\x9f\xa4\xfe\x9f\xbc\x9b\x8c\xe7\x8f\xcf\xbf\xa6\xe8\xa2|^\xf3\x95\xd5\xdf\xde\xfc\xfa\xfeT\x13}?\x9eO\x9fy\xe3_V\x9e\xb6\xfc\x1d\xab\xdf\xdd\xfc+\xa6\xb3q\xfa\xf5_\xf3\xf1\xc3\xf6_qk\x9f\x16\xfd\xfe\xf1\xaa\xf1+\x16_\x97\x87\xcb\xe2\xect<\xfaCOf\x83dhO\xf9\x9f\xd9Sun\xf9\xfb\...
doctype = 'File'
File "apps/frappe/frappe/model/base_document.py", line 94, in get_controller
site_controllers[doctype] = _get_controller()
_get_controller = <function get_controller.<locals>._get_controller at 0x7f69811df880>
site_controllers = {'Prepared Report': <class 'frappe.core.doctype.prepared_report.prepared_report.PreparedReport'>, 'Report': <class 'frappe.core.doctype.report.report.Report'>, 'Has Role': <class 'frappe.core.doctype.has_role.has_role.HasRole'>}
doctype = 'File'
File "apps/frappe/frappe/model/base_document.py", line 60, in _get_controller
module_name, custom = frappe.db.get_value(
Document = <class 'frappe.model.document.Document'>
NestedSet = <class 'frappe.utils.nestedset.NestedSet'>
doctype = 'File'
File "apps/frappe/frappe/database/database.py", line 568, in get_value
result = self.get_values(
self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7f69bcc09ae0>
doctype = 'DocType'
filters = 'File'
fieldname = ('module', 'custom')
ignore = None
as_dict = False
debug = False
order_by = 'KEEP_DEFAULT_ORDERING'
cache = True
for_update = False
run = True
pluck = False
distinct = False
skip_locked = False
wait = True
File "apps/frappe/frappe/database/database.py", line 672, in get_values
out = self._get_values_from_table(
self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7f69bcc09ae0>
doctype = 'DocType'
filters = 'File'
fieldname = ('module', 'custom')
ignore = None
as_dict = False
debug = False
order_by = 'modified'
update = None
cache = True
for_update = False
run = True
pluck = False
distinct = False
limit = 1
skip_locked = False
wait = True
out = None
fields = ('module', 'custom')
File "apps/frappe/frappe/database/database.py", line 910, in _get_values_from_table
return query.run(as_dict=as_dict, debug=debug, update=update, run=run, pluck=pluck)
self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7f69bcc09ae0>
fields = ('module', 'custom')
filters = 'File'
doctype = 'DocType'
as_dict = False
debug = False
order_by = 'modified'
update = None
for_update = False
skip_locked = False
wait = True
run = True
pluck = False
distinct = False
limit = 1
query = SELECT `module`,`custom` FROM `tabDocType` WHERE `name`='File' ORDER BY `modified` DESC LIMIT 1
File "apps/frappe/frappe/query_builder/utils.py", line 87, in execute_query
result = frappe.db.sql(query, params, *args, **kwargs) # nosemgrep
query = 'SELECT `module`,`custom` FROM `tabDocType` WHERE `name`=%(param1)s ORDER BY `modified` DESC LIMIT 1'
args = ()
kwargs = {'as_dict': False, 'debug': False, 'update': None, 'run': True, 'pluck': False}
child_queries = []
params = {'param1': 'File'}
execute_child_queries = <function patch_query_execute.<locals>.execute_child_queries at 0x7f69b6f79900>
prepare_query = <function patch_query_execute.<locals>.prepare_query at 0x7f69b6f79990>
File "apps/frappe/frappe/database/database.py", line 244, in sql
self._cursor.execute(query, values)
self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7f69bcc09ae0>
query = 'SELECT `module`,`custom` FROM `tabDocType` WHERE `name`=%(param1)s ORDER BY `modified` DESC LIMIT 1 /* FRAPPE_TRACE_ID: 1d13878d-a238-4f55-8a9b-34c66714021b */'
values = {'param1': 'File'}
as_dict = False
as_list = 0
formatted = 0
debug = False
ignore_ddl = 0
as_utf8 = 0
auto_commit = 0
update = None
explain = False
run = True
pluck = False
as_iterator = False
trace_id = '1d13878d-a238-4f55-8a9b-34c66714021b'
File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 158, in execute
result = self._query(query)
self = <pymysql.cursors.Cursor object at 0x7f69b6685930>
query = "SELECT `module`,`custom` FROM `tabDocType` WHERE `name`='File' ORDER BY `modified` DESC LIMIT 1 /* FRAPPE_TRACE_ID: 1d13878d-a238-4f55-8a9b-34c66714021b */"
args = {'param1': 'File'}
File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 325, in _query
conn.query(q)
self = <pymysql.cursors.Cursor object at 0x7f69b6685930>
q = "SELECT `module`,`custom` FROM `tabDocType` WHERE `name`='File' ORDER BY `modified` DESC LIMIT 1 /* FRAPPE_TRACE_ID: 1d13878d-a238-4f55-8a9b-34c66714021b */"
conn = <pymysql.connections.Connection object at 0x7f69b65d42b0>
File "env/lib/python3.10/site-packages/pymysql/connections.py", line 548, in query
self._execute_command(COMMAND.COM_QUERY, sql)
self = <pymysql.connections.Connection object at 0x7f69b65d42b0>
sql = b"SELECT `module`,`custom` FROM `tabDocType` WHERE `name`='File' ORDER BY `modified` DESC LIMIT 1 /* FRAPPE_TRACE_ID: 1d13878d-a238-4f55-8a9b-34c66714021b */"
unbuffered = False
File "env/lib/python3.10/site-packages/pymysql/connections.py", line 818, in _execute_command
self._write_bytes(packet)
self = <pymysql.connections.Connection object at 0x7f69b65d42b0>
command = 3
sql = b"SELECT `module`,`custom` FROM `tabDocType` WHERE `name`='File' ORDER BY `modified` DESC LIMIT 1 /* FRAPPE_TRACE_ID: 1d13878d-a238-4f55-8a9b-34c66714021b */"
packet_size = 156
prelude = b'\x9c\x00\x00\x00\x03'
packet = b"\x9c\x00\x00\x00\x03SELECT `module`,`custom` FROM `tabDocType` WHERE `name`='File' ORDER BY `modified` DESC LIMIT 1 /* FRAPPE_TRACE_ID: 1d13878d-a238-4f55-8a9b-34c66714021b */"
File "env/lib/python3.10/site-packages/pymysql/connections.py", line 763, in _write_bytes
raise err.OperationalError(
self = <pymysql.connections.Connection object at 0x7f69b65d42b0>
data = b"\x9c\x00\x00\x00\x03SELECT `module`,`custom` FROM `tabDocType` WHERE `name`='File' ORDER BY `modified` DESC LIMIT 1 /* FRAPPE_TRACE_ID: 1d13878d-a238-4f55-8a9b-34c66714021b */"
pymysql.err.OperationalError: (2006, "MySQL server has gone away (ConnectionResetError(104, 'Connection reset by peer'))")
```