### PR TITLE
fix(site-migration): running post-model-sync patches after syncing cu…

### DIFF
--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -119,9 +119,6 @@ class SiteMigration:
 			skip_failing=self.skip_failing, patch_type=PatchType.pre_model_sync
 		)
 		frappe.model.sync.sync_all()
-		frappe.modules.patch_handler.run_all(
-			skip_failing=self.skip_failing, patch_type=PatchType.post_model_sync
-		)
 
 	@atomic
 	def post_schema_updates(self):
@@ -131,6 +128,7 @@ class SiteMigration:
 		* Sync fixtures & custom scripts
 		* Sync in-Desk Module Dashboards
 		* Sync customizations: Custom Fields, Property Setters, Custom Permissions
+  		* Runngin post-model-sync patches
 		* Sync Frappe's internal language master
 		* Flush deferred inserts made during maintenance mode.
 		* Sync Portal Menu Items
@@ -149,6 +147,11 @@ class SiteMigration:
 
 		print("Syncing customizations...")
 		sync_customizations()
+
+		print("Running post-model-sync patches...")
+		frappe.modules.patch_handler.run_all(
+			skip_failing=self.skip_failing, patch_type=PatchType.post_model_sync
+		)
 
 		print("Syncing languages...")
 		sync_languages()


### PR DESCRIPTION
**Issue**
When a developer creates a new custom field and attempts to use it immediately in a patch, the patch execution fails because the new field does not yet exist in the database schema.
The current workaround is to manually trigger a customization sync within the patch itself. However, this approach is:

- Not recommended, as it introduces unnecessary overhead in patches.
- Prone to errors, as developers often forget to include the sync step.

**The Fix**
Ensure that post-model-sync patches are executed after syncing customizations, so the new custom fields are available in the database schema before the patches run.


**Changes Made**
Adjusted the sequence to first sync customizations and then run post-model-sync patches.
This eliminates the need for manual customization sync inside patches.

**Affected versions**

1. version 16.x.x-develop
2. version 15
3. version 14
