### PR TITLE
fix: add type casting to getting value from single DocType(s)

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -726,6 +726,17 @@ class Database:
 				distinct=distinct,
 			).run(pluck=pluck, debug=debug, as_dict=False)
 
+			meta = frappe.get_meta(doctype)
+			field_types = {field.fieldname: field.fieldtype for field in meta.fields}
+			r_list = [
+				(
+					fieldname[0],
+					int(fieldname[1]) if field_types.get(fieldname[0]) == "Check" else fieldname[1],
+				)
+				for fieldname in r
+			]
+			r = tuple(r_list)
+
 			if not run:
 				return r
 


### PR DESCRIPTION
closes #28726 


> Please provide enough information so that others can review your pull request:

When using `frappe.db.get_value()` with singles DocType it results in giving string value for all field types irrespective of if it should return numeric datatypes instead.

> Explain the **details** for making this change. What existing problem does the pull request solve?

Unlike usual DocTypes which makes different columns with different datatypes based on field type, a single DocType uses the tabSingle table and stores value in `value` column which is always a string.
This causes issues with fields of different types, such as check, percent, float, int, rating etc... where it can be assumed that the value should be a numeric value such as 0, 1, 2.5 but instead gives a string.

To solve this, we can check the fieldname provided to `frappe.db.get_value()` against the meta to check the field type and convert to the relevant type

For values which could have precision attached to them, we first check for it in the field meta, if not found then we get that from the settings, if still not present then we directly convert the values.

> Screenshots/GIFs

<img width="600" alt="Screenshot 2024-12-11 at 1 06 30 AM" src="https://github.com/user-attachments/assets/c4d48f2a-81af-411a-93fa-40598a2c3909">

