### PR TITLE
chore: make bench_helper executable

### DIFF
--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -1,3 +1,5 @@
+#!/bin/env python3
+
 import importlib
 import json
 import linecache


### PR DESCRIPTION
I need a real entry point that isn't wrapped by bench CLI. This makes no difference at runtime for anyone. 


You can now use it like this to run most frappe commands, this was possible before but it required `python3 ...bench_helper.py`:

```
# CWD is {frappe_bench}/sites
../apps/frappe/frappe/utils/bench_helper.py  frappe command
```