### PR TITLE
fix: clarify error message for child tables (backport #28734)

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1603,8 +1603,16 @@ class Document(BaseDocument):
 			return
 
 		if date_diff(to_date, from_date) < 0:
+			table_row = ""
+			if self.meta.istable:
+				table_row = _("{0} row #{1}: ").format(
+					_(frappe.unscrub(self.parentfield)),
+					self.idx,
+				)
+
 			frappe.throw(
-				_("{0} must be after {1}").format(
+				table_row
+				+ _("{0} must be after {1}").format(
 					frappe.bold(_(self.meta.get_label(to_date_field))),
 					frappe.bold(_(self.meta.get_label(from_date_field))),
 				),


### PR DESCRIPTION
We can validate from/to dates on any doc, using this validation helper method:

```python
inv = frappe.get_doc("Sales Invoice", "SINV-0001")
for row in inv.payment_schedule:
	row.validate_from_to_dates("discount_date", "due_date")
```

Before, when applied to a child table, this led to a rather unspecific error message:

> **Due Date** must be after **Discount Date**

Now we also show the table name and row number:

> Payment Schedule row # 1: **Due Date** must be after **Discount Date**

