### PR TITLE
fix: set `currency` system setting in webform `frappe.boot.sysdefaults`

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -179,6 +179,7 @@ def get_boot_data():
 			"time_format": get_time_format(),
 			"first_day_of_the_week": get_first_day_of_the_week(),
 			"number_format": get_number_format().string,
+			"currency": frappe.get_system_settings("currency"),
 		},
 		"time_zone": {
 			"system": get_system_timezone(),


### PR DESCRIPTION
Otherwise this resulted in the fallback `USD` showing for some currency fields in webforms

Follow up to #28364
