### PR TITLE
chore: update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: 'node_modules|.git'
-default_stages: [commit]
+default_stages: [pre-commit]
 fail_fast: false
 
 


### PR DESCRIPTION
Otherwise there was always a warning:

```
[WARNING] top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```

(cherry picked from commit 0f27bb495c5b67043e0eb68640d06fab9a87232c)
