### PR TITLE
fix: keep a large enough limit on group-by query

### DIFF
--- a/frappe/desk/listview.py
+++ b/frappe/desk/listview.py
@@ -71,6 +71,7 @@ def get_group_by_count(doctype: str, current_filters: str, field: str) -> list[d
 		group_by=f"`tab{doctype}`.{field}",
 		fields=["count(*) as count", f"`{field}` as name"],
 		order_by="count desc",
+		limit=1000,
 	)
 
 	if field == "owner":


### PR DESCRIPTION
Small change on top of https://github.com/frappe/frappe/pull/28740

Reason: Site with many many users might still have huge # of rows being
returned. E.g. FC.

This just makes UX slightly bad, but there's easy workaround for it.
Users can just apply this filter -> "Owner = Self", whether users know
it or not is a different question.
