### PR TITLE
fix(web): Ensure that header values are strings

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -546,14 +546,14 @@ def build_response(path, data, http_status_code, headers: dict | None = None):
 	response = Response()
 	response.data = set_content_type(response, data, path)
 	response.status_code = http_status_code
-	response.headers["X-Page-Name"] = cstr(path.encode("ascii", errors="xmlcharrefreplace"))
+	response.headers["X-Page-Name"] = cstr(cstr(path).encode("ascii", errors="xmlcharrefreplace"))
 	response.headers["X-From-Cache"] = frappe.local.response.from_cache or False
 
 	add_preload_for_bundled_assets(response)
 
 	if headers:
 		for key, val in headers.items():
-			response.headers[key] = cstr(val.encode("ascii", errors="xmlcharrefreplace"))
+			response.headers[key] = cstr(cstr(val).encode("ascii", errors="xmlcharrefreplace"))
 
 	return response
 


### PR DESCRIPTION
Values in the `headers` parameter MUST be strings in order for the `.encode` method call to work, so `cstr` is a no-op in most cases. When a non-string value was erroneously provided, the page returned a 500 error. This has been fixed.

Example:

```py
frappe.redirect(None)
```
