### PR TITLE
fix: convert frappe.boot to JSON properly

### DIFF
--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -95,7 +95,7 @@
 	{% block base_scripts %}
 	<!-- js should be loaded in body! -->
 	<script>
-		frappe.boot = {{ boot }}
+		frappe.boot = {{ boot | json }}
 		// for backward compatibility of some libs
 		frappe.sys_defaults = frappe.boot.sysdefaults;
 	</script>

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -163,7 +163,7 @@
 
 {% block script %}
 	<script>
-		frappe.boot = {{ boot }};
+		frappe.boot = {{ boot | json }};
 		frappe._messages = {{ translated_messages }};
 		frappe.web_form_doc = {{ web_form_doc | json }};
 		frappe.reference_doc = {{ reference_doc | json }};

--- a/frappe/website/doctype/web_form/templates/web_list.html
+++ b/frappe/website/doctype/web_form/templates/web_list.html
@@ -24,7 +24,7 @@
 
 {% block script %}
 	<script>
-		frappe.boot = {{ boot }};
+		frappe.boot = {{ boot | json }};
 		frappe._messages = {{ translated_messages }};
 		frappe.web_form_doc = {{ web_form_doc | json }};
 	</script>

--- a/frappe/www/app.html
+++ b/frappe/www/app.html
@@ -51,7 +51,7 @@
 
 			if (!window.frappe) window.frappe = {};
 
-			frappe.boot = JSON.parse({{ boot }});
+			frappe.boot = {{ boot | json }};
 			frappe._messages = frappe.boot["__messages"];
 			frappe.csrf_token = "{{ csrf_token }}";
 

--- a/frappe/www/app.py
+++ b/frappe/www/app.py
@@ -43,7 +43,6 @@ def get_context(context):
 
 	# TODO: Find better fix
 	boot_json = CLOSING_SCRIPT_TAG_PATTERN.sub("", boot_json)
-	boot_json = json.dumps(boot_json)
 
 	hooks = frappe.get_hooks()
 	app_include_js = hooks.get("app_include_js", []) + frappe.conf.get("app_include_js", [])
@@ -63,7 +62,7 @@ def get_context(context):
 			"layout_direction": "rtl" if is_rtl() else "ltr",
 			"lang": frappe.local.lang,
 			"sounds": hooks["sounds"],
-			"boot": boot if context.get("for_mobile") else boot_json,
+			"boot": boot if context.get("for_mobile") else json.loads(boot_json),
 			"desk_theme": boot.get("desk_theme") or "Light",
 			"csrf_token": csrf_token,
 			"google_analytics_id": frappe.conf.get("google_analytics_id"),


### PR DESCRIPTION
We have `frappe.as_json` set as the jinja filter for json

`None` values just result in an undefined frappe.boot otherwise,
and we get a lot of `ReferenceError`s, as javascript doesn't know what `None` is.

<hr>

Resolves #28764
