### PR TITLE
fix: link field issue with scrollable child table in safari

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -591,11 +591,11 @@
 	display: block;
 }
 
-.form-grid-container {
-	overflow-x: clip;
-}
 .data-row.row {
 	flex-wrap: nowrap;
+}
+.frappe-control[data-fieldtype="Table"].form-group:has(.column-limit-reached) {
+	overflow-x: clip;
 }
 .column-limit-reached {
 	background-color: var(--subtle-accent);


### PR DESCRIPTION
Closes #28698 

> Explain the **details** for making this change. What existing problem does the pull request solve?

Add an overflow style to the parent element to prevent hiding the options of the link field.

> Screenshots/GIFs

https://github.com/user-attachments/assets/e0856b5c-5fa3-4529-ba7c-6c45cd30b21b


