### PR TITLE
fix: Don't cache anything hashable

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -86,7 +86,7 @@ runs:
 
   - name: Maybe clone additional apps
     shell: bash -e {0}
-    env: 
+    env:
       org: ${{ env.FRAPPE_GH_ORG || github.repository_owner }}
       ref: ${{ github.event.client_payload.frappe_sha || github.base_ref || github.ref_name }}
     run: |
@@ -148,7 +148,7 @@ runs:
 
       sudo apt -qq update
       sudo apt -qq remove mysql-server mysql-client
-      sudo apt -qq install libcups2-dev redis-server mariadb-client-10.6
+      sudo apt -qq install libcups2-dev redis-server mariadb-client
 
       if [ "$(lsb_release -rs)" = "22.04" ]; then
           wget -q -O /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -595,7 +595,7 @@ class Database:
 		"""
 		out = None
 		cache_key = None
-		if cache and isinstance(filters, Hashable):
+		if cache and isinstance(filters, str):
 			cache_key = (doctype, filters, fieldname)
 			if cache_key in self.value_cache:
 				return self.value_cache[cache_key]


### PR DESCRIPTION
If filters are list or dict then they aren't hashable, there was little
reason to do this IMO.

If something is indeed cacheable then where is the eviction for it?
simple k:v is only thing we can realistically cache here.

Partially reverts https://github.com/frappe/frappe/pull/28189 