### PR TITLE
ci: Don't specify client version

### DIFF
--- a/.github/helper/install_dependencies.sh
+++ b/.github/helper/install_dependencies.sh
@@ -6,7 +6,7 @@ echo "Setting Up System Dependencies..."
 echo "::group::apt packages"
 sudo apt update
 sudo apt remove mysql-server mysql-client
-sudo apt install libcups2-dev redis-server mariadb-client-10.6
+sudo apt install libcups2-dev redis-server mariadb-client
 
 install_wkhtmltopdf() {
   wget -q https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb

--- a/.github/helper/install_dependencies.sh
+++ b/.github/helper/install_dependencies.sh
@@ -9,8 +9,8 @@ sudo apt remove mysql-server mysql-client
 sudo apt install libcups2-dev redis-server mariadb-client
 
 install_wkhtmltopdf() {
-  wget -q https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb
-  sudo apt install ./wkhtmltox_0.12.6-1.focal_amd64.deb
+  wget -q https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+  sudo apt install ./wkhtmltox_0.12.6.1-2.jammy_amd64.deb
 }
 install_wkhtmltopdf &
 echo "::endgroup::"


### PR DESCRIPTION
Clients work on mysql protocol ABI which works for huge ranges of
servers.

```
  Package mariadb-client-10.6 is not available, but is referred to by another package.
  This may mean that the package is missing, has been obsoleted, or
  is only available from another source
  However the following packages replace it:
    mariadb-client
  
  E: Package 'mariadb-client-10.6' has no installation candidate
```

<hr>

Also bump wkhtmltox version