### PR TITLE
fix: Allow cancellation/rename of doctypes linked by a virtual custom field

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -509,6 +509,8 @@ def get_link_fields(doctype: str) -> list[dict]:
 		)
 		if virtual_doctypes:
 			custom_fields = custom_fields.where(cf.dt.notin(virtual_doctypes))
+		if frappe.db.has_column("Custom Field", "is_virtual"):
+			custom_fields = custom_fields.where(cf.is_virtual == 0)
 		custom_fields = custom_fields.run(as_dict=True)
 
 		ps_issingle = frappe.qb.from_(dt).select(dt.issingle).where(dt.name == ps.doc_type).as_("issingle")

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -488,16 +488,13 @@ def get_link_fields(doctype: str) -> list[dict]:
 			.inner_join(dt)
 			.on(df.parent == dt.name)
 			.select(df.parent, df.fieldname, dt.issingle.as_("issingle"))
-			.where((df.options == doctype) & (df.fieldtype == "Link"))
+			.where(
+				(df.options == doctype) & (df.fieldtype == "Link")
+				& (dt.is_virtual == 0) & (df.is_virtual == 0)
+			)
 		)
 
-		if frappe.db.has_column("DocField", "is_virtual"):
-			standard_fields_query = standard_fields_query.where(df.is_virtual == 0)
-
-		virtual_doctypes = []
-		if frappe.db.has_column("DocType", "is_virtual"):
-			virtual_doctypes = frappe.get_all("DocType", {"is_virtual": 1}, pluck="name")
-			standard_fields_query = standard_fields_query.where(dt.is_virtual == 0)
+		virtual_doctypes = frappe.get_all("DocType", {"is_virtual": 1}, pluck="name")
 
 		standard_fields = standard_fields_query.run(as_dict=True)
 
@@ -505,12 +502,10 @@ def get_link_fields(doctype: str) -> list[dict]:
 		custom_fields = (
 			frappe.qb.from_(cf)
 			.select(cf.dt.as_("parent"), cf.fieldname, cf_issingle)
-			.where((cf.options == doctype) & (cf.fieldtype == "Link"))
+			.where((cf.options == doctype) & (cf.fieldtype == "Link") & (cf.is_virtual == 0))
 		)
 		if virtual_doctypes:
 			custom_fields = custom_fields.where(cf.dt.notin(virtual_doctypes))
-		if frappe.db.has_column("Custom Field", "is_virtual"):
-			custom_fields = custom_fields.where(cf.is_virtual == 0)
 		custom_fields = custom_fields.run(as_dict=True)
 
 		ps_issingle = frappe.qb.from_(dt).select(dt.issingle).where(dt.name == ps.doc_type).as_("issingle")

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -489,8 +489,10 @@ def get_link_fields(doctype: str) -> list[dict]:
 			.on(df.parent == dt.name)
 			.select(df.parent, df.fieldname, dt.issingle.as_("issingle"))
 			.where(
-				(df.options == doctype) & (df.fieldtype == "Link")
-				& (dt.is_virtual == 0) & (df.is_virtual == 0)
+				(df.options == doctype)
+				& (df.fieldtype == "Link")
+				& (dt.is_virtual == 0)
+				& (df.is_virtual == 0)
 			)
 		)
 


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Currently, get_link_fields in frappe/model/rename_doc is used in two places - when renaming a document, and when cancelling a document (to check for back-links).

There is a check to exclude virtual fields from _standard_ fields. This prevents an error when cancelling or renaming a document linked by a document with a standard virtual field, because otherwise there will be a database call for a field which doesn't exist.

However, there is no check for _custom_ fields. It is perfectly possible to have a custom field on a standard doctype which is a virtual link field, and create the @property for this using an over-ridden doctype. We do this in several places in our custom app (on standard ERPNext doctypes), and have to patch in a fixed check_no_back_links_exist on other standard doctypes that are linked by these fields.

How to recreate this situation (somewhat involved):

Create a test application (just to avoid messing with core Frappe code; not strictly required).
Create a new standard doctype 'Test Linker' (or alternative just use an existing standard doctype later).
Create a new submittable doctype 'Test Target'.
Customize the 'Test Linker' doctype to add a virtual link field to 'Test Target' (note that it must be a _custom_ field i.e. using Customize Form, not DocType to create this).
Add code to Test Linker for the virtual code (e.g. @property; def my_virtual_link_field(self): return None or similar)
Create a new Test Target document. Submit it then cancel it. Error (trying to get a value for your virtual link field).

The solution for this is extremely straightforward: mirror the solution used for standard fields for custom fields.