### PR TITLE
feat: add link to doctype item from list

### DIFF
--- a/frappe/public/js/frappe/form/link_selector.js
+++ b/frappe/public/js/frappe/form/link_selector.js
@@ -96,12 +96,13 @@ frappe.ui.form.LinkSelector = class LinkSelector {
 							repl(
 								'<div class="row link-select-row">\
 						<div class="col-xs-4">\
-							<b><a href="#">%(name)s</a></b></div>\
+							<b><a href="%(link)s">%(name)s</a></b></div>\
 						<div class="col-xs-8">\
 							<span class="text-muted">%(values)s</span></div>\
 						</div>',
 								{
 									name: v[0],
+									link: frappe.utils.get_form_link(me.doctype, v[0], false),
 									values: v.splice(1).join(", "),
 								}
 							)


### PR DESCRIPTION
https://imgur.com/DHgG7dh.png
add link to the doctype referenced inside the grid 

http://localhost:8000/app/material-request
http://localhost:8000/app/bom
http://localhost:8000/app/blanket-order
http://localhost:8000/app/doctype/Opportunity
http://localhost:8000/app/journal-entry


![image](https://github.com/user-attachments/assets/d7a818f3-036e-4ff4-8b59-f09921aff200)
