### PR TITLE
feat: Add "In the Past" option to filter dates starting from yesterday

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -593,6 +593,7 @@ frappe.ui.filter_utils = {
 				"Tomorrow",
 				"This",
 				"Next",
+				"In the past"
 			]);
 		}
 		if (condition === "is") {

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -373,7 +373,7 @@ def get_system_timezone() -> str:
 
 def convert_utc_to_timezone(utc_timestamp: datetime.datetime, time_zone: str) -> datetime.datetime:
 	if utc_timestamp.tzinfo is None:
-		utc_timestamp = utc_timestamp.replace(tzinfo=ZoneInfo(time_zone))
+		utc_timestamp = utc_timestamp.replace(tzinfo=ZoneInfo("UTC"))
 
 	try:
 		return utc_timestamp.astimezone(ZoneInfo(time_zone))

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -32,6 +32,7 @@ from frappe.utils.number_format import NUMBER_FORMAT_MAP, NumberFormat
 DateTimeLikeObject = str | datetime.date | datetime.datetime
 NumericType = int | float
 TimespanOptions = Literal[
+	"in the past",
 	"last week",
 	"last month",
 	"last quarter",
@@ -372,7 +373,7 @@ def get_system_timezone() -> str:
 
 def convert_utc_to_timezone(utc_timestamp: datetime.datetime, time_zone: str) -> datetime.datetime:
 	if utc_timestamp.tzinfo is None:
-		utc_timestamp = utc_timestamp.replace(tzinfo=ZoneInfo("UTC"))
+		utc_timestamp = utc_timestamp.replace(tzinfo=ZoneInfo(time_zone))
 
 	try:
 		return utc_timestamp.astimezone(ZoneInfo(time_zone))
@@ -948,6 +949,11 @@ def get_timespan_date_range(
 			return (
 				get_quarter_start(add_to_date(today, months=3)),
 				get_quarter_ending(add_to_date(today, months=6)),
+			)
+		case "in the past":
+			return (
+				get_first_day(add_to_date(today, years=-99)),
+				add_to_date(today, days=-1),
 			)
 		case "next year":
 			return (


### PR DESCRIPTION
Description
This PR introduces a new option for the Timespan filter, named "In the Past". This option fetches all dates in the past starting from yesterday, allowing for more flexible date-based filtering.

Changes Made
Added "In the Past" logic to the Timespan filter.
Dates from today backward (excluding today) are included in the results.
Updated unit tests to include cases for this new filter.
Ensured compatibility with existing Timespan logic.
Motivation
The existing Timespan filter lacked the ability to select all past dates starting from yesterday. This new option resolves this limitation, enhancing usability for scenarios where only historical data is relevant.

How It Works
When the "In the Past" option is selected, the filter:
Identifies yesterday's date as the starting point.
Retrieves all dates before today.
The implementation ensures that today's date is excluded, and results only contain dates strictly in the past.
Question:
Does the name "In the Past" work well for this filter? I want to ensure the naming is intuitive for all users.
Screenshots
![WhatsApp Image 2024-12-16 at 15 32 28](https://github.com/user-attachments/assets/e0a8989f-9305-42b2-ac22-5a2adbdc8fcb)

Example: Selecting the "In the Past" option

Example: Filtered results when using "In the Past"

Tests
Added unit tests to validate:
Dates correctly excluded starting from today.
All past dates from yesterday are included.
Verified the new functionality does not interfere with existing filters.
Documentation
Updated documentation to include:
Definition and usage of the new "In the Past" filter.
Examples demonstrating its behavior.