### PR TITLE
perf!: speedup `@site_cache` by ~4x

### DIFF
--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -204,6 +204,16 @@ class TestPerformance(IntegrationTestCase):
 		with self.assertRedisCallCounts(1):
 			frappe.get_doc("User", "Administrator")
 
+	def test_one_time_setup(self):
+		site = frappe.local.site
+		frappe.init(site, force=True)
+		run = frappe.qb._BuilderClasss.run
+
+		frappe.init(site, force=True)
+		patched_run = frappe.qb._BuilderClasss.run
+
+		self.assertIs(run, patched_run, "frappe.init should run one-time patching code just once")
+
 
 @run_only_if(db_type_is.MARIADB)
 class TestOverheadCalls(FrappeAPITestCase):

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. Check LICENSE
 
-import datetime
 import json
+import time
 from collections import defaultdict
 from collections.abc import Callable
 from functools import wraps
@@ -113,9 +113,7 @@ def site_cache(ttl: int | None = None, maxsize: int | None = None) -> Callable:
 
 		if ttl is not None and not callable(ttl):
 			func.ttl = ttl
-			func.expiration = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
-				seconds=func.ttl
-			)
+			func.expiration = time.monotonic() + func.ttl
 
 		if maxsize is not None and not callable(maxsize):
 			func.maxsize = maxsize
@@ -125,13 +123,12 @@ def site_cache(ttl: int | None = None, maxsize: int | None = None) -> Callable:
 			if site := getattr(frappe.local, "site", None):
 				func_call_key = json.dumps((args, kwargs))
 
-				if hasattr(func, "ttl") and datetime.datetime.now(datetime.timezone.utc) >= func.expiration:
+				if hasattr(func, "ttl") and time.monotonic() >= func.expiration:
 					func.clear_cache()
-					func.expiration = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
-						seconds=func.ttl
-					)
+					func.expiration = time.monotonic() + func.ttl
 
 				if hasattr(func, "maxsize") and len(_SITE_CACHE[func_key][site]) >= func.maxsize:
+					# Note: This implements FIFO eviction policty
 					_SITE_CACHE[func_key][site].pop(next(iter(_SITE_CACHE[func_key][site])), None)
 
 				if func_call_key not in _SITE_CACHE[func_key][site]:

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -122,7 +122,7 @@ def site_cache(ttl: int | None = None, maxsize: int | None = None) -> Callable:
 
 		@wraps(func)
 		def site_cache_wrapper(*args, **kwargs):
-			if getattr(frappe.local, "initialised", None):
+			if site := getattr(frappe.local, "site", None):
 				func_call_key = json.dumps((args, kwargs))
 
 				if hasattr(func, "ttl") and datetime.datetime.now(datetime.timezone.utc) >= func.expiration:
@@ -131,15 +131,13 @@ def site_cache(ttl: int | None = None, maxsize: int | None = None) -> Callable:
 						seconds=func.ttl
 					)
 
-				if hasattr(func, "maxsize") and len(_SITE_CACHE[func_key][frappe.local.site]) >= func.maxsize:
-					_SITE_CACHE[func_key][frappe.local.site].pop(
-						next(iter(_SITE_CACHE[func_key][frappe.local.site])), None
-					)
+				if hasattr(func, "maxsize") and len(_SITE_CACHE[func_key][site]) >= func.maxsize:
+					_SITE_CACHE[func_key][site].pop(next(iter(_SITE_CACHE[func_key][site])), None)
 
-				if func_call_key not in _SITE_CACHE[func_key][frappe.local.site]:
-					_SITE_CACHE[func_key][frappe.local.site][func_call_key] = func(*args, **kwargs)
+				if func_call_key not in _SITE_CACHE[func_key][site]:
+					_SITE_CACHE[func_key][site][func_call_key] = func(*args, **kwargs)
 
-				return _SITE_CACHE[func_key][frappe.local.site][func_call_key]
+				return _SITE_CACHE[func_key][site][func_call_key]
 
 			return func(*args, **kwargs)
 

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. Check LICENSE
 
-import json
 import time
 from collections import defaultdict
 from collections.abc import Callable
@@ -121,7 +120,7 @@ def site_cache(ttl: int | None = None, maxsize: int | None = None) -> Callable:
 		@wraps(func)
 		def site_cache_wrapper(*args, **kwargs):
 			if site := getattr(frappe.local, "site", None):
-				func_call_key = json.dumps((args, kwargs))
+				func_call_key = __generate_request_cache_key(args, kwargs)
 
 				if hasattr(func, "ttl") and time.monotonic() >= func.expiration:
 					func.clear_cache()


### PR DESCRIPTION
BREAKING CHANGE: `@site_cache` won't accept unhashable arguments from now on.

I want to use `@site_cache` in a lot more places, but for that I need it to be fast enough.

Currently following inefficiencies exist:
- `frappe.local.site` is accessed many times, each one is a function call and access to ctxvar
- `json.dump` is used to allow unhashable types, it's _quite slow_.
- `datetime` is used for TTL, which is slightly slower than monotonic time.

This PR fixes all three. Results:

bench_utils_bench_site_cache_many_args: 4.03 us +- 0.02 us -> 932 ns +- 9 ns: 4.32x faster
bench_utils_bench_site_cache_no_arg: 4.04 us +- 0.02 us -> 931 ns +- 10 ns: 4.33x faster
bench_utils_bench_site_cache_with_ttl: 4.71 us +- 0.02 us -> 1.11 us +- 0.01 us: 4.24x faster

Geometric mean: 4.30x faster



