### PR TITLE
perf: speed up `@request_cache` by ~2x

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -270,6 +270,7 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force: bool =
 	local.valid_columns = {}
 	local.new_doc_templates = {}
 
+	local.request_cache = defaultdict(dict)
 	local.jenv = None
 	local.jloader = None
 	local.cache = {}


### PR DESCRIPTION
- Eagerly initialize request_cache, all requests use it, so what is the
  point of doing it lazily?
- Reduce accesses to `frappe.local` namespace, get cache once and reuse
  it in rest of the execution.

Before: 1250ns +/- 1%
After: 645ns +/- 1%

Source: Trust me bro.
(no really, for now just trust me or look at the diff)
