### PR TITLE
fix: add support for CSV files for non desk users

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -36,7 +36,6 @@ ALLOWED_MIMETYPES = (
 	"text/plain",
 	"video/quicktime",
 	"video/mp4",
-	"text/csv",
 )
 
 
@@ -181,7 +180,7 @@ def upload_file():
 	if content is not None and (frappe.session.user == "Guest" or (user and not user.has_desk_access())):
 		filetype = guess_type(filename)[0]
 		if filetype not in ALLOWED_MIMETYPES:
-			frappe.throw(_("You can only upload JPG, PNG, PDF, TXT or Microsoft documents."))
+			frappe.throw(_("You can only upload JPG, PNG, PDF, TXT, CSV or Microsoft documents."))
 
 	if method:
 		method = frappe.get_attr(method)

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -36,6 +36,7 @@ ALLOWED_MIMETYPES = (
 	"text/plain",
 	"video/quicktime",
 	"video/mp4",
+	"text/csv",
 )
 
 


### PR DESCRIPTION
<img width="1118" alt="image" src="https://github.com/user-attachments/assets/3783880e-acf2-42b3-8fd7-9d978abf2d84" />

Currently users who don't have access to desk, can only upload these formats.
<img width="428" alt="image" src="https://github.com/user-attachments/assets/9ad40fd6-0e17-4b8c-9f76-2fcbb3ec8648" />

Since we support Excel files, CSVs should also be allowed, hence added the support for CSV files
