### PR TITLE
perf: Speedup `get_doc` by another ~1.5x

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1380,13 +1380,7 @@ def get_doc(*args: Any, **kwargs: Any) -> "Document":
 	"""
 	import frappe.model.document
 
-	doc = frappe.model.document.get_doc(*args, **kwargs)
-
-	# Replace cache if stale one exists
-	if not kwargs.get("for_update") and (key := can_cache_doc(args)) and cache.exists(key):
-		_set_document_in_cache(key, doc)
-
-	return doc
+	return frappe.model.document.get_doc(*args, **kwargs)
 
 
 def get_last_doc(

--- a/frappe/core/doctype/role_profile/role_profile.py
+++ b/frappe/core/doctype/role_profile/role_profile.py
@@ -26,6 +26,7 @@ class RoleProfile(Document):
 		self.name = self.role_profile
 
 	def on_update(self):
+		self.clear_cache()
 		self.queue_action(
 			"update_all_users",
 			now=frappe.flags.in_test or frappe.flags.in_install,


### PR DESCRIPTION
This was added long ago to make up for bad cache invalidation which I believe was "fixed" here: https://github.com/frappe/frappe/pull/21216

Anyway, some unreliability in cached documents is still expected, don't use them if it's a concern!


This fix eliminates one redis call for each `get_doc`.


Mean +- std dev: 7.29 ms +- 0.11 ms -> 4.85 ms +- 0.04 ms: **1.50x faster**


Closes https://github.com/frappe/caffeine/issues/16 