### PR TITLE
fix(email): don't try to parse flags that seem to be invalid

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -283,7 +283,7 @@ class EmailServer:
 
 	def get_email_seen_status(self, uid, flag_string):
 		"""parse the email FLAGS response"""
-		if not flag_string:
+		if not flag_string or not isinstance(flag_string, str | bytes):
 			return None
 
 		flags = []


### PR DESCRIPTION
Sometimes we get invalid flags from `imap.uid()`, like `[b'System Error (Failure)']`

This leads to the flag getting parsed as 83 (basically `ord('S')`)

Reference: support ticket 27426
