### PR TITLE
perf: speedup `@redis_cache` by 2x-20x

### DIFF
--- a/frappe/tests/test_caching.py
+++ b/frappe/tests/test_caching.py
@@ -110,6 +110,7 @@ class TestRedisCache(FrappeAPITestCase):
 		self.assertEqual(function_call_count, 1)
 
 		time.sleep(CACHE_TTL * 1.5)
+		frappe.local.cache.clear()
 		self.assertEqual(calculate_area(10), 314)
 		self.assertEqual(function_call_count, 2)
 

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -32,6 +32,7 @@ from frappe.tests import IntegrationTestCase
 from frappe.tests.test_api import FrappeAPITestCase
 from frappe.tests.test_query_builder import run_only_if
 from frappe.utils import cint
+from frappe.utils.caching import redis_cache
 from frappe.website.path_resolver import PathResolver
 
 TEST_USER = "test@example.com"
@@ -201,8 +202,25 @@ class TestPerformance(IntegrationTestCase):
 
 	def test_get_doc_cache_calls(self):
 		frappe.get_doc("User", "Administrator")
-		with self.assertRedisCallCounts(1):
+		with self.assertRedisCallCounts(0):
 			frappe.get_doc("User", "Administrator")
+
+	def test_local_caching(self):
+		frappe.get_cached_doc("User", "Administrator")
+		with self.assertRedisCallCounts(0):
+			frappe.get_cached_doc("User", "Administrator")
+
+	def test_redis_cache_calls(self):
+		redis_cached_func()  # warmup
+
+		# Repeat call should use locally cached value
+		with self.assertRedisCallCounts(0):
+			redis_cached_func()
+
+		frappe.local.cache.clear()
+		# Without local cache - only one call required
+		with self.assertRedisCallCounts(1):
+			redis_cached_func()
 
 	def test_one_time_setup(self):
 		site = frappe.local.site
@@ -245,3 +263,8 @@ class TestOverheadCalls(FrappeAPITestCase):
 		self.get(self.resource("User", "Administrator"), {"sid": sid})
 		with self.assertRedisCallCounts(19), self.assertQueryCount(self.BASE_SQL_CALLS + 1 + tables):
 			self.get(self.resource("User", "Administrator"), {"sid": sid})
+
+
+@redis_cache
+def redis_cached_func():
+	return 42

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -164,8 +164,15 @@ def redis_cache(ttl: int | None = 3600, user: str | bool | None = None, shared: 
 		@wraps(func)
 		def redis_cache_wrapper(*args, **kwargs):
 			func_call_key = func_key + "::" + str(__generate_request_cache_key(args, kwargs))
+			cached_val = frappe.cache.get_value(func_call_key, user=user, shared=shared)
+			if cached_val is not None:
+				return cached_val
+
+			# Edge Case: None can mean two things: cache miss or the result itself is `None`
+			# RedisWrapper doesn't give us any way to handle this cleanly.
 			if frappe.cache.exists(func_call_key, user=user, shared=shared):
-				return frappe.cache.get_value(func_call_key, user=user, shared=shared)
+				return None
+
 			val = func(*args, **kwargs)
 			ttl = getattr(func, "ttl", 3600)
 			frappe.cache.set_value(func_call_key, val, expires_in_sec=ttl, user=user, shared=shared)

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -60,8 +60,7 @@ class RedisWrapper(redis.Redis):
 		"""
 		key = self.make_key(key, user, shared)
 
-		if not expires_in_sec:
-			frappe.local.cache[key] = val
+		frappe.local.cache[key] = val
 
 		with suppress(redis.exceptions.ConnectionError):
 			self.set(name=key, value=pickle.dumps(val), ex=expires_in_sec)


### PR DESCRIPTION
We make 2 redis call instead of 1. This was done to ensure functions returning `None` can be cached. 

BUT this means everything now has this overhead of almost 2x redis cost. This PR rearranges the check in a way that most common reads will now not have to pay this extra cost.

Microbenchmarks results:

First access is faster by 2x.
bench_utils_bench_redis_cache_deco_without_local_cache: 13.0 ms +- 0.1 ms -> 6.60 ms +- 0.06 ms: 1.98x faster

Repeat accesses are faster by 24x :woozy_face: 
bench_utils_bench_redis_cache_deco_with_local_cache: 6.76 ms +- 0.07 ms ->  281 us +- 2 us: 24.07x faster


Closes https://github.com/frappe/caffeine/issues/11 


Unrelated potentially _breaking_ fixes:

- Expirable keys are always cached in `frappe.local`. This check is also nonsensical since they get cached on 2nd run anyway. Think of this as "repeatable read" if you want to. :woozy_face:  