### PR TITLE
perf: speedup `frappe.qb.get_query` by 2x-4x

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -5,7 +5,9 @@ from frappe import _
 from frappe.utils import cint, cstr, flt
 from frappe.utils.defaults import get_not_null_defaults
 
+# This matches anything that isn't [a-zA-Z0-9_]
 SPECIAL_CHAR_PATTERN = re.compile(r"[\W]", flags=re.UNICODE)
+
 VARCHAR_CAST_PATTERN = re.compile(r"varchar\(([\d]+)\)")
 
 


### PR DESCRIPTION
Each field was getting parsed on every query generation :woozy_face: even something as dumb as `*`.


Benchmarks:

bench_qb_bench_qb_get_query: 339 us +- 3 us -> 147 us +- 1 us: 2.31x faster
bench_qb_bench_qb_get_query_multiple_fields: 876 us +- 7 us -> 200 us +- 1 us: 4.37x faster
bench_qb_bench_qb_simple_get_query: 282 us +- 2 us -> 147 us +- 1 us: 1.91x faster

While numbers vary, the variation is almost related with # of fields you have in your query. More fields => higher speedup after this fix... so with 10 fields you might see 10x speedup :woozy_face: 

partly https://github.com/frappe/caffeine/issues/24