### PR TITLE
fix: find workflow by id instead of state name

### DIFF
--- a/frappe/public/js/workflow_builder/store.js
+++ b/frappe/public/js/workflow_builder/store.js
@@ -173,8 +173,18 @@ export const useStore = defineStore("workflow-builder-store", () => {
 
 		actions.forEach((action) => {
 			let states = workflow.value.elements.filter((e) => e.type == "state");
-			let state = states.find((state) => state.data.state == action.data.from);
-			let next_state = states.find((state) => state.data.state == action.data.to);
+
+			let state = states.find(
+				(state) => state.data.workflow_builder_id == action.data.from_id
+			);
+			let next_state = states.find(
+				(state) => state.data.workflow_builder_id == action.data.to_id
+			);
+
+			if (action.data.to.length === 0 && next_state != undefined) {
+				action.data.to = next_state.data.state;
+			}
+
 			let error = validate_transitions(state.data, next_state.data);
 			if (error) {
 				frappe.throw({


### PR DESCRIPTION
Only way to use the workflow builder right now is to create all the states first, set their names/state prop and then map the actions. If you try to setup actions before properly setting state prop the Save has very inconsistent behaviour.

Steps to Replicate:
- Create state-node and join action-node before setting the state/name prop of the state-node
- Try to save

https://github.com/user-attachments/assets/bc8ed11d-3512-4de5-8aac-3efd74dc4d94

Issue: Currently we find the next_state by comparing for state/name prop
Solution: This PR compares using workflow_builder_id of the next/connected state for action and explicitly sets the action.data.to state-name if it's not set previously.


> no-docs