### PR TITLE
perf: speedup pickling of document objects

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -176,6 +176,11 @@ class BaseDocument:
 		state.pop("meta", None)
 		state.pop("permitted_fieldnames", None)
 		state.pop("_parent_doc", None)
+		state.pop("flags", None)
+
+	def __setstate__(self, state):
+		self.__dict__ = state
+		self.flags = _dict()
 
 	def update(self, d):
 		"""Update multiple fields of a doctype using a dictionary of key-value pairs.


### PR DESCRIPTION
1. Use the latest protocol - this has no measurable performance benefit for small data like ours. But it might help for large data :shrug: Cached documents are ~1-4KB in size.
2. Remove `doc.flags` - not necessary and also shouldn't even be cached from correctness perspective.


This has a nominal 4-8% performance improvement. You can dismiss it entirely as a measurement error too, but still this is the right thing to do. 

More information/investigation logs here: https://github.com/frappe/caffeine/issues/25