### PR TITLE
perf: Make `frappe._dict` great again

### DIFF
--- a/.github/workflows/_base-migration.yml
+++ b/.github/workflows/_base-migration.yml
@@ -104,7 +104,7 @@ jobs:
             if pgrep honcho > /dev/null; then
                 echo "Stopping honcho process..."
                 pgrep honcho | xargs kill
-                sleep 5
+                sleep 10
             fi
 
             echo "Setting up environment..."

--- a/frappe/types/frappedict.py
+++ b/frappe/types/frappedict.py
@@ -16,19 +16,13 @@ class _dict(dict[_KT, _VT]):
 
 	__slots__ = ()
 
-	def __getattr__(self, k: str) -> _VT | None:
-		return super().get(k)  # type: ignore[arg-type]
+	# NOTE(perf): Do NOT use super() here, it's an unnecessary function call!
+	# Refer: https://github.com/frappe/frappe/pull/16449
 
-	@override
-	def __setattr__(self, k: str, v: _VT) -> None:
-		return super().__setitem__(k, v)  # type: ignore[index]
-
-	@override
-	def __delattr__(self, k: str):
-		return super().__delitem__(k)  # type: ignore[arg-type]
-
-	def __setstate__(self, m: Mapping[_KT, _VT]) -> None:
-		return super().update(m)
+	__getattr__ = dict.get
+	__setattr__ = dict.__setitem__
+	__delattr__ = dict.__delitem__
+	__setstate__ = dict.update
 
 	@override
 	def __getstate__(self) -> Self:


### PR DESCRIPTION
Using `super()` is an unnecessary cost. This class is used A LOT. This PR is restoring a fix made in https://github.com/frappe/frappe/pull/16449/ with more reliable measurements (?)



Benchmarks:

| operation    |  before   | after   | speedup |
| --- | --- | --- | --- |
| getattr <br> `'d.x' --setup='import frappe; d=frappe._dict(); d.x = 1'` |  364 ns +- 3 ns   |  110 ns +- 1 ns   |  3.30x   |
| setattr <br> `'d.x = 1' --setup='import frappe; d=frappe._dict()'` |  455 ns +- 2 ns   |  255 ns +- 2 ns   | 1.78x    |

Notes: 

- Disable JIT before benchmarking. Don't benchmark using a function call, this is too small to show up in those benchmarks. `pyperf` has amazing `timeit` utility for measuring sub-millisecond operations. (It's similar to `%timeit` but it automates repeating and calibrating measurements)
- Please consider performance while adding types, it's almost always possible to achieve good typing without this.
- Also `frappe._dict` is almost always used as `dict[Any, Any]` or `dict[str, Any]`, type annotations are useless here!
