### PR TITLE
fix: esbuild with cached flag

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -144,7 +144,7 @@ async function update_assets_json_from_built_assets(apps) {
 	const assets = await get_assets_json_path_and_obj(false);
 	const assets_rtl = await get_assets_json_path_and_obj(true);
 
-	for (const app in apps) {
+	for (const app of apps) {
 		await update_assets_obj(app, assets.obj, assets_rtl.obj);
 	}
 

--- a/esbuild/utils.js
+++ b/esbuild/utils.js
@@ -41,17 +41,6 @@ const bundle_map = app_list.reduce((out, app) => {
 
 const get_public_path = (app) => public_paths[app];
 
-const get_build_json_path = (app) => path.resolve(get_public_path(app), "build.json");
-
-function get_build_json(app) {
-	try {
-		return require(get_build_json_path(app));
-	} catch (e) {
-		// build.json does not exist
-		return null;
-	}
-}
-
 function delete_file(path) {
 	if (fs.existsSync(path)) {
 		fs.unlinkSync(path);
@@ -177,8 +166,6 @@ module.exports = {
 	apps_path,
 	bundle_map,
 	get_public_path,
-	get_build_json_path,
-	get_build_json,
 	delete_file,
 	run_serially,
 	get_cli_arg,


### PR DESCRIPTION
- chore: remove dead code
- fix(esbuild): bug that caused apps to json to not get updated when --using-cached

This was some bug 😅

### Backstory

Our documentation site's (Wiki app) assets used to randomly break after update. 

### Problem 

The assets.json file was not correctly getting generated when the `--using-cached` flag was passed to `esbuild` script. It didn't come to much notice because very few apps (only wiki from the new Frappe products) depend on assets.json being correctly generated (i.e. on utils like `include_script` etc.). 

### Fix

```diff
- for (const app in apps) { // returns index
+ for (const app of apps) { // returns app name
```

