### PR TITLE
fix: default document cache expiry + monitor persistence

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1264,7 +1264,7 @@ def get_cached_doc(*args: Any, **kwargs: Any) -> "Document":
 
 
 def _set_document_in_cache(key: str, doc: "Document") -> None:
-	cache.set_value(key, doc)
+	cache.set_value(key, doc, expires_in_sec=3600)
 
 
 def can_cache_doc(args) -> str | None:

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -587,4 +587,5 @@ persistent_cache_keys = [
 	"insert_queue_for_*",  # Deferred Insert
 	"recorder-*",  # Recorder
 	"global_search_queue",
+	"monitor-transactions",
 ]


### PR DESCRIPTION
identified while doing this: https://github.com/frappe/press/pull/2373 