### PR TITLE
fix(build): `os.replace` -> `shutil.move`

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -196,7 +196,7 @@ def symlink(target, link_name, overwrite=False):
 		if os.path.isdir(link_name):
 			raise IsADirectoryError(f"Cannot symlink over existing directory: '{link_name}'")
 		try:
-			os.replace(temp_link_name, link_name)
+			shutil.move(temp_link_name, link_name)
 		except AttributeError:
 			os.renames(temp_link_name, link_name)
 	except Exception:


### PR DESCRIPTION
In some cases, while running in docker, we end up with:

```
[Errno 18] Invalid cross-device link: 'tmp<hash>' -> './assets/frappe'
```

Using `shutil.move` fixes this as it supports different filesystems, `os.replace` doesn't

Resolves #28833
