### PR TITLE
fix: always print tracebacks

### DIFF
--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -2,7 +2,6 @@
 
 import importlib
 import json
-import linecache
 import os
 import sys
 import traceback
@@ -67,39 +66,9 @@ class CliCtxObj:
 
 
 def handle_exception(cmd, info_name, exc):
-	tb = sys.exc_info()[2]
-	while tb.tb_next:
-		tb = tb.tb_next
-	frame = tb.tb_frame
-	filename = frame.f_code.co_filename
-	lineno = frame.f_lineno
+	click.echo(traceback.format_exc())
 
-	click.secho("\n:: ", nl=False)
-	click.secho(f"{exc}", fg="red", bold=True, nl=False)
-	click.secho(" ::")
-	click.secho("\nContext:", fg="yellow", bold=True)
-	click.secho(f" File '{filename}', line {lineno}\n")
-	context_lines = 5
-	start = max(1, lineno - context_lines)
-	end = lineno + context_lines + 1
-
-	for i in range(start, end):
-		line = linecache.getline(filename, i).rstrip()
-		if i == lineno:
-			click.secho(f"{i:4d}> {line}", fg="red")
-		else:
-			click.echo(f"{i:4d}: {line}")
-
-	show_exception = (
-		(not sys.stdout.isatty())
-		or os.environ.get("FRAPPE_ALWAYS_SHOW_FULL_TRACEBACKS")
-		or click.confirm("\nDo you want to see the full traceback?", default=True)
-	)
-	if show_exception:
-		click.secho("\nFull traceback:", fg="red")
-		click.echo(traceback.format_exc())
-
-		click.echo(exc)
+	click.echo(exc)
 
 
 def main():

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -90,8 +90,10 @@ def handle_exception(cmd, info_name, exc):
 		else:
 			click.echo(f"{i:4d}: {line}")
 
-	show_exception = (not sys.stdout.isatty()) or click.confirm(
-		"\nDo you want to see the full traceback?", default=False
+	show_exception = (
+		(not sys.stdout.isatty())
+		or os.environ.get("FRAPPE_ALWAYS_SHOW_FULL_TRACEBACKS")
+		or click.confirm("\nDo you want to see the full traceback?", default=True)
 	)
 	if show_exception:
 		click.secho("\nFull traceback:", fg="red")


### PR DESCRIPTION
I don't recall ever hitting "no" to this prompt. It's of no use for me.

Example of useless prompting.
```
Context:
 File '/home/ankush/.pyenv/versions/3.12.7/lib/python3.12/subprocess.py', line 413

 408:     retcode = call(*popenargs, **kwargs)
 409:     if retcode:
 410:         cmd = kwargs.get("args")
 411:         if cmd is None:
 412:             cmd = popenargs[0]
 413>         raise CalledProcessError(retcode, cmd)
 414:     return 0
 415:
 416:
 417: def check_output(*popenargs, timeout=None, **kwargs):
 418:     r"""Run command with arguments and return its output.

Do you want to see the full traceback? [y/N]:

```


IMO asking developers to not print 10 lines is a waste of time. I'd rather have 10 extra lines of context than manually interact with a terminal to show/not show it.