### PR TITLE
perf: speedup `get_datetime` parsing by ~9.5x

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -667,6 +667,17 @@ class TestDateUtils(IntegrationTestCase):
 		self.assertEqual(get_year_ending(date(2021, 1, 1)), date(2021, 12, 31))
 		self.assertEqual(get_year_ending(date(2021, 1, 31)), date(2021, 12, 31))
 
+	@given(st.datetimes())
+	def test_get_datetime(self, original):
+		parsed = get_datetime(str(original))
+		self.assertEqual(parsed, original)
+
+	@given(st.datetimes(timezones=st.timezones()))
+	def test_get_datetime_tz_aware(self, original):
+		parsed = get_datetime(str(original))
+		original = original.replace(tzinfo=None)
+		self.assertEqual(parsed, original)
+
 	def test_pretty_date(self):
 		from frappe import _
 


### PR DESCRIPTION
Simple: Use `fromisoformat` written in C instead of Python parser. 

Why this is important?
- Every document has 2 datetime fields, ERPNext has more!
- When you do SQL queries that select datetime fields, this parsing was a significant part of it. This speeds up `select *` queries on doctype tables by ~1.45x :smile: 


Benchmarks:

```
λ bench  --site bench.localhost run-microbenchmarks --affinity 0 --filter=bench_parse_datetime
```

Before: 11.4 us +- 0.1 us
After: 1.20 us +- 0.01 us
