### PR TITLE
perf: speed up `flt` by 1.06x and `get_system_settings` by 1.32x

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2430,14 +2430,14 @@ def get_website_settings(key):
 
 def get_system_settings(key: str):
 	"""Return the value associated with the given `key` from System Settings DocType."""
-	if not hasattr(local, "system_settings"):
+	if not (system_settings := getattr(local, "system_settings", None)):
 		try:
-			local.system_settings = get_cached_doc("System Settings")
+			local.system_settings = system_settings = get_cached_doc("System Settings")
 		except DoesNotExistError:  # possible during new install
 			clear_last_message()
 			return
 
-	return local.system_settings.get(key)
+	return system_settings.get(key)
 
 
 def get_active_domains():

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1541,8 +1541,17 @@ class Document(BaseDocument, DocRef):
 				for df in doc.meta.get("fields", {"fieldtype": ["in", ["Currency", "Float", "Percent"]]})
 			)
 
+		# PERF: flt internally has to resolve this if we don't specify it.
+		rounding_method = frappe.get_system_settings("rounding_method")
 		for fieldname in fieldnames:
-			doc.set(fieldname, flt(doc.get(fieldname), self.precision(fieldname, doc.get("parentfield"))))
+			doc.set(
+				fieldname,
+				flt(
+					doc.get(fieldname),
+					self.precision(fieldname, doc.get("parentfield")),
+					rounding_method=rounding_method,
+				),
+			)
 
 	def get_url(self):
 		"""Return Desk URL for this document."""

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1197,10 +1197,10 @@ def rounded(num, precision=0, rounding_method=None):
 		rounding_method or frappe.get_system_settings("rounding_method") or "Banker's Rounding (legacy)"
 	)
 
-	if rounding_method == "Banker's Rounding (legacy)":
-		return _bankers_rounding_legacy(num, precision)
-	elif rounding_method == "Banker's Rounding":
+	if rounding_method == "Banker's Rounding":
 		return _bankers_rounding(num, precision)
+	elif rounding_method == "Banker's Rounding (legacy)":
+		return _bankers_rounding_legacy(num, precision)
 	elif rounding_method == "Commercial Rounding":
 		return _round_away_from_zero(num, precision)
 	else:


### PR DESCRIPTION
- Where flt is used in loop, resolve the rounding method only once
- Avoid accessing `frappe.local` multiple times - used for resolving rounding method.
