### PR TITLE
feat: log peak memory usage for Prepared reports

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.json
+++ b/frappe/core/doctype/prepared_report/prepared_report.json
@@ -13,6 +13,7 @@
   "column_break_4",
   "queued_at",
   "report_end_time",
+  "peak_memory_usage",
   "section_break_7",
   "error_message",
   "filters_sb",
@@ -101,11 +102,18 @@
    "is_virtual": 1,
    "label": "Queued At",
    "read_only": 1
+  },
+  {
+   "fieldname": "peak_memory_usage",
+   "fieldtype": "Int",
+   "label": "Peak Memory Usage",
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "in_create": 1,
  "links": [],
- "modified": "2024-03-23 16:03:34.835357",
+ "modified": "2024-12-20 10:18:19.174608",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Prepared Report",

--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -122,6 +122,7 @@ def generate_report(prepared_report):
 
 	instance.report_end_time = frappe.utils.now()
 	instance.peak_memory_usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+	add_data_to_monitor(peak_memory_usage=instance.peak_memory_usage)
 	instance.save(ignore_permissions=True)
 
 	frappe.publish_realtime(

--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 import gzip
 import json
+import resource
 from contextlib import suppress
 from typing import Any
 
@@ -33,6 +34,7 @@ class PreparedReport(Document):
 		error_message: DF.Text | None
 		filters: DF.SmallText | None
 		job_id: DF.Data | None
+		peak_memory_usage: DF.Int
 		queued_at: DF.Datetime | None
 		queued_by: DF.Data | None
 		report_end_time: DF.Datetime | None
@@ -119,6 +121,7 @@ def generate_report(prepared_report):
 		_save_error(instance, error=frappe.get_traceback(with_context=True))
 
 	instance.report_end_time = frappe.utils.now()
+	instance.peak_memory_usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
 	instance.save(ignore_permissions=True)
 
 	frappe.publish_realtime(


### PR DESCRIPTION
Capturing memory usage helps in identifying poorly written reports. 

This is a light-weight, non-invasive way to capture memory usage[^1][^2], so that day-to-day usage of Prepared Reports remain unaffected. 

Logged  in both Prepared Report and Monitor

Ref:
[^1]: `resource` package - https://docs.python.org/3/library/resource.html#resource.getrusage
[^2]: Max Resident Set Size - https://manpages.debian.org/bookworm/manpages-dev/getrusage.2.en.html#ru_maxrss

`no-docs`