### PR TITLE
fix: MariaDBDatabase.get_tables() should not query the entire database schema.

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -467,7 +467,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 			tables = (
 				frappe.qb.from_(information_schema.tables)
 				.select(information_schema.tables.table_name)
-				.where(information_schema.tables.table_schema != "information_schema")
+				.where(information_schema.tables.table_schema == frappe.db.cur_db_name)
 				.run(pluck=True)
 			)
 			frappe.cache.set_value("db_tables", tables)


### PR DESCRIPTION
The `MariaDBDatabase.get_tables()` function should **only** return the names of SQL tables that exist in the _current_, _active_ MariaDB database.

For example, assume a MariaDB server exists with 2 Frappe databases:  `db_one` and `db_two`.
* `db_one` already contains a SQL table named `tabMyNewDocType`
* `db_two` does ***not*** contain a SQL table named `tabMyNewDocType`

Now we try to synchronize the `db_two` database against the schema defined in JSON or tabDocType.  The missing the table `tabMyNewDocType` will *not* be created, because `get_tables()` says it already exists.  But that is not true...that SQL table *only* exists in the `db_one` database.

The fix I've written ensures that the correct SQL tables are returned, based on the current, active MariaDB database.