### PR TITLE
fix: get_table_columns_description() for MariaDB database.py

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -347,7 +347,8 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 			column_key = 'UNI' as 'unique',
 			(is_nullable = 'NO') AS 'not_nullable'
 			from information_schema.columns as columns
-			where table_name = '{table_name}' """,
+			where table_name = '{table_name}'
+   			and table_schema = '{frappe.db.cur_db_name}' """,
 			as_dict=1,
 		)
 


### PR DESCRIPTION
Please see previous pull request:
https://github.com/frappe/frappe/pull/28846

This is the same problem/situation, just a different function.

When Frappe Framework wants to know the name of a table's columns, it should only examine the current, active MariaDB database schema.