### PR TITLE
fix: Remove misleading `os.O_NONBLOCK` flag

### DIFF
--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -127,7 +127,7 @@ def flush():
 		logs = frappe.cache.lrange(MONITOR_REDIS_KEY, 0, -1)
 		if logs:
 			logs = list(map(frappe.safe_decode, logs))
-			with open(log_file(), "a", os.O_NONBLOCK) as f:
+			with open(log_file(), "a") as f:
 				f.write("\n".join(logs))
 				f.write("\n")
 			# Remove fetched entries from cache


### PR DESCRIPTION
It works likes that in C `open(2)` for file descriptors, not in python :)

In Python it's setting buffering to enum value which in this case is 2048, if it were lower number this would've made performance worse. Even 2048 is arguably, slightly worse as default would've been 4k on most systems. 

ref:
- https://man7.org/linux/man-pages/man2/open.2.html#DESCRIPTION
- https://docs.python.org/3/library/functions.html#open
