### PR TITLE
test: reduce noise in test output

### DIFF
--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -97,7 +97,7 @@ def main(
 	for handler in testing_module_logger.handlers:
 		if file := getattr(handler, "baseFilename", None):
 			click.secho(
-				f"Detailed logs{' (augment with --verbose)' if not verbose else ''}: {click.style(file, bold=True)}"
+				f"View detailed logs{' (using --verbose)' if not verbose else ''}: {click.style(file, bold=True)}"
 			)
 
 	test_config = TestConfig(

--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -142,38 +142,6 @@ def main(
 			results.append([app, category, runner.run(suite)])
 
 		success = all(r.wasSuccessful() for _, _, r in results)
-		click.secho("\nTest Results:", fg="cyan", bold=True)
-
-		def _print_result(app, category, result):
-			tests_run = result.testsRun
-			failures = len(result.failures)
-			errors = len(result.errors)
-			click.echo(
-				f"\n{click.style(f'{category} Tests in {app}:', bold=True)}\n"
-				f"  Ran: {click.style(f'{tests_run:<3}', fg='cyan')}"
-				f"  Failures: {click.style(f'{failures:<3}', fg='red' if failures else 'green')}"
-				f"  Errors: {click.style(f'{errors:<3}', fg='red' if errors else 'green')}"
-			)
-
-			if failures > 0:
-				click.echo(f"\n{click.style(category + ' Test Failures:', fg='red', bold=True)}")
-				for i, failure in enumerate(result.failures, 1):
-					click.echo(f"  {i}. {click.style(str(failure[0]), fg='yellow')}")
-
-			if errors > 0:
-				click.echo(f"\n{click.style(category + ' Test Errors:', fg='red', bold=True)}")
-				for i, error in enumerate(result.errors, 1):
-					click.echo(f"  {i}. {click.style(str(error[0]), fg='yellow')}")
-					click.echo(click.style("     " + str(error[1]).split("\n")[-2], fg="red"))
-
-		for app, category, result in results:
-			_print_result(frappe.unscrub(app or "Unspecified App"), frappe.unscrub(category), result)
-
-		if success:
-			click.echo(f"\n{click.style('All tests passed successfully!', fg='green', bold=True)}")
-		else:
-			click.echo(f"\n{click.style('Some tests failed or encountered errors.', fg='red', bold=True)}")
-
 		if not success:
 			sys.exit(1)
 

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -637,6 +637,7 @@ class TestBackups(BaseTestCommands):
 				except OSError:
 					pass
 
+	@run_only_if(db_type_is.MARIADB)
 	def test_backup_no_options(self):
 		"""Take a backup without any options"""
 		before_backup = fetch_latest_backups(partial=True)

--- a/frappe/tests/utils/generators.py
+++ b/frappe/tests/utils/generators.py
@@ -169,7 +169,7 @@ def _generate_records_for(
 	# to completely bypass the standard loading and create test records
 	# according to custom logic.
 	if hasattr(test_module, "_make_test_records"):
-		logger.warning("↺" + logstr)
+		logger.info("↺" + logstr)
 		testing_logger.info(
 			f" Made  + {index_doctype:<30} via {initial_doctype} through {test_module._make_test_records}"
 		)
@@ -189,12 +189,12 @@ def _generate_records_for(
 			test_records = load_test_records_for(index_doctype)
 
 		if not test_records:
-			logger.warning("➛ " + logstr + " (missing)")
+			logger.info("➛ " + logstr + " (missing)")
 			frappe.local.test_objects[index_doctype] = []  # avoid noisy retries on multiple invocations
 			print_mandatory_fields(index_doctype, initial_doctype)
 			return
 
-		logger.warning("↺ " + logstr)
+		logger.info("↺ " + logstr)
 		testing_logger.info(f" Synced  + {index_doctype:<30} via {initial_doctype}")
 
 		yield from _sync_records(index_doctype, test_records, reset=reset, commit=commit)


### PR DESCRIPTION
Before:
```
λ bench --site dev.localhost run-tests --skip-before-tests --module frappe.tests.test_rate_limiter --test test_headers_under_limit
Starting test run with parameters: site=dev.localhost, module=frappe.tests.test_rate_limiter, verbose=False, tests=('test_headers_under_limit',), force=False, profile=False, failfast=False, skip_before_tests=True, debug=False, selected_categories=[]
Detailed logs (augment with --verbose): /home/ankush/benches/develop/logs/frappe.testing.log
➛  Domain via User (missing)
➛  Package via User (missing)
➛  Module Def via User (missing)
➛  Email Template via User (missing)
↺  Role via User
➛  DocType via User (missing)
➛  Language via User (missing)
➛  Role Profile via User (missing)
➛  Module Profile via User (missing)
➛  Gender via User (missing)
➛  Letter Head via User (missing)
↺  Report via User
➛  Number Card via User (missing)
➛  Dashboard Chart Source via User (missing)
➛  Dashboard Chart via User (missing)
➛  Kanban Board via User (missing)
↺  Country via User
➛  Custom HTML Block via User (missing)
➛  Workspace via User (missing)
➛  User Type via User (missing)
↺  Email Domain via User
↺  Connected App via User
↺  Email Account via User
↺  User via User

Running 1 integration tests for frappe

frappe.tests.test_rate_limiter.TestRateLimiter
    ✔  test_headers_under_limit


----------------------------------------------------------------------
Ran 1 test in 0.027s

OK

Test Results:

Integration Tests in Frappe:
  Ran: 1    Failures: 0    Errors: 0

All tests passed successfully!
```

After:

```
λ bench --site dev.localhost run-tests --skip-before-tests --module frappe.tests.test_rate_limiter --test test_headers_under_limit
Starting test run with parameters: site=dev.localhost, module=frappe.tests.test_rate_limiter, verbose=False, tests=('test_headers_under_limit',), force=False, profile=False, failfast=False, skip_before_tests=True, debug=False, selected_categories=[]
View detailed logs (using --verbose): /home/ankush/benches/develop/logs/frappe.testing.log

Running 1 integration tests for frappe

frappe.tests.test_rate_limiter.TestRateLimiter
    ✔  test_headers_under_limit


----------------------------------------------------------------------
Ran 1 test in 0.030s

OK
```