### PR TITLE
perf: speedup `frappe.call` by ~8x

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1812,6 +1812,9 @@ def call(fn: str | Callable, *args, **kwargs):
 	return fn(*args, **newargs)
 
 
+_cached_inspect_signature = functools.lru_cache(inspect.signature)
+
+
 def get_newargs(fn: Callable, kwargs: dict[str, Any]) -> dict[str, Any]:
 	"""Remove any kwargs that are not supported by the function.
 
@@ -1827,7 +1830,7 @@ def get_newargs(fn: Callable, kwargs: dict[str, Any]) -> dict[str, Any]:
 	# Ref: https://docs.python.org/3/library/inspect.html#inspect.Parameter.kind
 	varkw_exist = False
 
-	signature = inspect.signature(fn)
+	signature = _cached_inspect_signature(fn)
 	fnargs = list(signature.parameters)
 
 	for param_name, parameter in signature.parameters.items():


### PR DESCRIPTION
Function signatures can't change during the lifetime of the process.

Before: 8.81us
After: 1.1us

Benchmarks in caffeine repo

partly https://github.com/frappe/caffeine/issues/18