### PR TITLE
fix: Left_Right_to_Left_Align_Right_Align

### DIFF
--- a/frappe/desk/doctype/form_tour_step/form_tour_step.json
+++ b/frappe/desk/doctype/form_tour_step/form_tour_step.json
@@ -72,7 +72,7 @@
    "fieldname": "position",
    "fieldtype": "Select",
    "label": "Position",
-   "options": "Left\nLeft Center\nLeft Bottom\nTop\nTop Center\nTop Right\nRight\nRight Center\nRight Bottom\nBottom\nBottom Center\nBottom Right\nMid Center"
+   "options": "Left Align\nLeft Center\nLeft Bottom\nTop\nTop Center\nTop Right Align\nRight Align\nRight Center\nRight Bottom\nBottom\nBottom Center\nBottom Right\nMid Center"
   },
   {
    "depends_on": "has_next_condition",

--- a/frappe/desk/doctype/form_tour_step/form_tour_step.json
+++ b/frappe/desk/doctype/form_tour_step/form_tour_step.json
@@ -72,7 +72,7 @@
    "fieldname": "position",
    "fieldtype": "Select",
    "label": "Position",
-   "options": "Left Align\nLeft Center\nLeft Bottom\nTop\nTop Center\nTop Right Align\nRight Align\nRight Center\nRight Bottom\nBottom\nBottom Center\nBottom Right\nMid Center"
+   "options": "Left Align\nLeft Center Align\nLeft Bottom Align\nTop Align\nTop Center Align\nTop Right Align\nRight Align\nRight Center Align\nRight Bottom Align\nBottom Align\nBottom Center Align\nBottom Right Align\nMid Center Align"
   },
   {
    "depends_on": "has_next_condition",

--- a/frappe/printing/doctype/letter_head/letter_head.json
+++ b/frappe/printing/doctype/letter_head/letter_head.json
@@ -120,7 +120,7 @@
    "fieldname": "align",
    "fieldtype": "Select",
    "label": "Align",
-   "options": "Left\nRight\nCenter"
+   "options": "Left Align\nRight Align\nCenter Align"
   },
   {
    "fieldname": "image_height",
@@ -157,7 +157,7 @@
    "fieldname": "footer_align",
    "fieldtype": "Select",
    "label": "Align",
-   "options": "Left\nRight\nCenter"
+   "options": "Left Align\nRight Align\nCenter Align"
   },
   {
    "default": "HTML",

--- a/frappe/website/doctype/web_page/web_page.json
+++ b/frappe/website/doctype/web_page/web_page.json
@@ -177,7 +177,7 @@
    "fieldname": "text_align",
    "fieldtype": "Select",
    "label": "Text Align",
-   "options": "Left\nCenter\nRight"
+   "options": "Left Align\nCenter Align\nRight Align"
   },
   {
    "depends_on": "insert_style",


### PR DESCRIPTION
Left and Right is used in Frappe as position and in ERPNext as status in "options"
Change it so it reflects position and give possibility to translate "Left" in ERPNext as status in other languages than english

Backport to version-15 