### PR TITLE
fix: sanitize user input during setup wizard

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -50,7 +50,7 @@ def setup_complete(args):
 	if cint(frappe.db.get_single_value("System Settings", "setup_complete")):
 		return {"status": "ok"}
 
-	args = parse_args(args)
+	args = parse_args(sanitize_input(args))
 	stages = get_setup_stages(args)
 	is_background_task = frappe.conf.get("trigger_site_setup_in_background")
 
@@ -249,6 +249,19 @@ def parse_args(args):  # nosemgrep
 	for key, value in args.items():
 		if isinstance(value, str):
 			args[key] = strip(value)
+
+	return args
+
+
+def sanitize_input(args):
+	from frappe.utils import is_html, strip_html_tags
+
+	if isinstance(args, str):
+		args = json.loads(args)
+
+	for key, value in args.items():
+		if is_html(value):
+			args[key] = strip_html_tags(value)
 
 	return args
 


### PR DESCRIPTION
Closes:- [Support Ticket  - 21044](https://support.frappe.io/app/hd-ticket/21044)

Before :
In the setup wizard, if a script such as `<script>alert(1)</script>` was entered in the "Company Name" field, it would execute, leading to a potential cross-site scripting (XSS) vulnerability.

<img width="624" alt="Screenshot 2024-12-23 at 4 41 37 PM" src="https://github.com/user-attachments/assets/2b6f55c7-7c04-40f6-afeb-ba7912e31365" />


After:
 input is sanitized, the company is created with the provided name without script execution.

<img width="1237" alt="Screenshot 2024-12-23 at 4 36 18 PM" src="https://github.com/user-attachments/assets/b513d675-5e89-428e-810f-adb636c46041" />