### PR TITLE
fix: Never query `flag_print_sql` in `developer_mode=0`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -522,7 +522,10 @@ def errprint(msg: str) -> None:
 
 
 def print_sql(enable: bool = True) -> None:
-	return cache.set_value("flag_print_sql", enable)
+	if frappe.conf.allow_tests and frappe.conf.developer_mode:
+		cache.set_value("flag_print_sql", enable)
+	else:
+		frappe.throw("`frappe.print_sql` only works in `developer_mode` with `allow_tests` enabled on site.")
 
 
 def log(msg: str) -> None:

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -339,7 +339,11 @@ class Database:
 		"""Takes the query and logs it to various interfaces according to the settings."""
 		_query = None
 
-		if frappe.conf.allow_tests and frappe.cache.get_value("flag_print_sql"):
+		if (
+			frappe.conf.allow_tests
+			and frappe.conf.developer_mode
+			and frappe.cache.get_value("flag_print_sql")
+		):
 			_query = _query or str(mogrified_query)
 			print(_query)
 


### PR DESCRIPTION
Unnecessary overhead and need to disable this everytime I want to get
realistic performance numbers out.

All the performance affecting toggles should be directly controlled by
just `developer_mode` alone.
