### PR TITLE
perf: Speedup empty `db.{commit|rollback}` by ~2x

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1152,8 +1152,7 @@ class Database:
 
 		self.before_commit.run()
 
-		self.sql("commit")
-		self.begin()  # explicitly start a new transaction
+		self.sql("commit and chain")
 
 		self.after_commit.run()
 
@@ -1167,8 +1166,7 @@ class Database:
 
 			self.before_rollback.run()
 
-			self.sql("rollback")
-			self.begin()
+			self.sql("rollback and chain")
 
 			self.after_rollback.run()
 		else:


### PR DESCRIPTION
Ref: 
- https://mariadb.com/kb/en/commit/
- https://mariadb.com/kb/en/rollback/

Both Postgres and MariaDB support re-creating a new transaction using single command, so, no need to send 2 separate commands :smile:  

| Benchmark                                      | before | db-api commit                | manually chaining                |
|------------------------------------------------|:------:|:--------------------:|:--------------------:|
| bench_database_bench_empty_transaction_cycling | 237 us | 163 us: 1.46x faster | 118 us: 2.01x faster |


Note: 2x obviously won't hold when there's something to flush to disk because it will require an `fsync`. This should still help in the vast majority of read-only requests.

Side effects:

- None known

~~1. No more "logging" of these queries, can be solved by just fake logging.
2. Things that don't start transaction will now also won't rollback.
   So `ping` might not even connect to DB.~~ 

Note: previous impl used `conn.commit()` feature of DB-API 2.0 but they don't allow chaining so in the end they are less efficient than a single query that can do both.


closes https://github.com/frappe/caffeine/issues/28 