### PR TITLE
fix: page permissions

### DIFF
--- a/frappe/core/doctype/page/page.json
+++ b/frappe/core/doctype/page/page.json
@@ -102,7 +102,7 @@
  "icon": "fa fa-file",
  "idx": 1,
  "links": [],
- "modified": "2024-03-23 16:03:33.657255",
+ "modified": "2024-12-21 13:45:12.362999",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Page",
@@ -126,6 +126,15 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "report": 1,
+   "role": "Desk User",
+   "select": 1,
+   "share": 1
   }
  ],
  "sort_field": "creation",


### PR DESCRIPTION
Users without Administrator/System Manager Role cannot add a "Page" to a WorkSpace, since it does not allow selecting it.

Only the selection permission was added to "Desk User"



https://github.com/user-attachments/assets/1ae310e8-7899-4256-8364-262bf9e16bcf

