### PR TITLE
fix: remove_plural_from _modal

### DIFF
--- a/cypress/integration/multi_select_dialog.js
+++ b/cypress/integration/multi_select_dialog.js
@@ -41,7 +41,7 @@ context("MultiSelectDialog", () => {
 
 	it("checks multi select dialog api works", () => {
 		open_multi_select_dialog();
-		cy.get_open_dialog().should("contain", "Select Contacts");
+		cy.get_open_dialog().should("contain", "Select Contact");
 	});
 
 	it("checks for filters", () => {

--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -77,8 +77,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 	}
 
 	make() {
-		let doctype_plural = __(this.doctype);
-		let title = __("Select {0}", [this.for_select ? __("value") : doctype_plural]);
+		let title = __("Select {0}", [this.for_select ? __("value") : __(this.doctype)]);
 
 		this.dialog = new frappe.ui.Dialog({
 			title: title,

--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -77,7 +77,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 	}
 
 	make() {
-		let doctype_plural = __(this.doctype).plural();
+		let doctype_plural = __(this.doctype);
 		let title = __("Select {0}", [this.for_select ? __("value") : doctype_plural]);
 
 		this.dialog = new frappe.ui.Dialog({


### PR DESCRIPTION
In english plural ends with "s"
and it is always defined as plural even if you choose one document 

Backport to version-15 
