### PR TITLE
fix: correct home link redirection in my account page

### DIFF
--- a/frappe/www/me.html
+++ b/frappe/www/me.html
@@ -71,7 +71,7 @@
 </div>
 
 <div class="portal-footer">
-	<a href="/">
+	<a href="/app/home">
 		<svg class="right-icon icon icon-md"><use href="#icon-home"></use></svg>
 		{{ _("Home") }}
 	</a>


### PR DESCRIPTION
**Description**

- Updated the "Home" link in the footer of the "My Account" page to redirect to /app/home instead of /.
- Fixed an issue where clicking the "Home" button redirected to the same page instead of the correct destination.