### PR TITLE
perf: use system settings instead of defaults

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -582,7 +582,7 @@ Run the following in your first cell to connect notebook to frappe
 import frappe
 frappe.init('{site}', sites_path='{sites_path}')
 frappe.connect()
-frappe.local.lang = frappe.db.get_default('lang')
+frappe.local.lang = frappe.get_system_settings('language')
 frappe.db.connect()
 ```
 	"""
@@ -623,7 +623,7 @@ def console(context: CliCtxObj, autoreload=False):
 	site = get_site(context)
 	frappe.init(site)
 	frappe.connect()
-	frappe.local.lang = frappe.db.get_default("lang")
+	frappe.local.lang = frappe.get_system_settings("language")
 
 	from atexit import register
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -451,7 +451,7 @@ def get_expired_threshold():
 
 
 def get_expiry_period():
-	exp_sec = frappe.defaults.get_global_default("session_expiry") or "240:00:00"
+	exp_sec = frappe.get_system_settings("session_expiry") or "240:00:00"
 
 	# incase seconds is missing
 	if len(exp_sec.split(":")) == 2:

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -77,7 +77,7 @@ def get_language(lang_list: list | None = None) -> str:
 			return parent_language
 
 	# fallback to language set in System Settings or "en"
-	return frappe.db.get_default("lang") or "en"
+	return frappe.get_system_settings("language") or "en"
 
 
 @functools.lru_cache
@@ -100,7 +100,7 @@ def get_user_lang(user: str | None = None) -> str:
 	# User.language => Session Defaults => frappe.local.lang => 'en'
 	return (
 		frappe.get_cached_value("User", user, "language")
-		or frappe.db.get_default("lang")
+		or frappe.get_system_settings("language")
 		or frappe.local.lang
 		or "en"
 	)


### PR DESCRIPTION
Fetching defaults adds quite a lot of overhead. System settings on other hand are readily available.

These defaults are just copies of what is already present in system settings. This could be mildly breaking but I don't know any good use cases for this:
- Expiry is always supposed to be global setting
- Language already has user specific settings, defaults are a fallback. 

This change should drop some 6%-8% of overheads.

![image](https://github.com/user-attachments/assets/80340a09-f2be-4e45-9f1a-5f6ad03ff22e)


There is some more usage left but that will require working on client-side caching for Redis, so leaving that part for now.

Partly https://github.com/frappe/caffeine/issues/15 