### PR TITLE
perf: don't parse comments just to get comment count

### DIFF
--- a/frappe/core/doctype/comment/test_comment.py
+++ b/frappe/core/doctype/comment/test_comment.py
@@ -31,6 +31,15 @@ class TestComment(IntegrationTestCase):
 		self.assertEqual(comments[0].get("name"), comment.name)
 		self.assertEqual(comments[0].get("comment"), comment.content)
 
+		# Check comment count
+		counts = frappe.get_all("ToDo", {"name": test_doc.name}, ["*"], with_comment_count=True)
+		self.assertEqual(counts[0]._comment_count, 1)
+
+		comment = test_doc.add_comment("Comment", "test comment")
+
+		counts = frappe.get_all("ToDo", {"name": test_doc.name}, ["*"], with_comment_count=True)
+		self.assertEqual(counts[0]._comment_count, 2)
+
 		# check document creation
 		comment_1 = frappe.get_all(
 			"Comment",

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1136,8 +1136,9 @@ class DatabaseQuery:
 				continue
 
 			r._comment_count = 0
-			if "_comments" in r:
-				r._comment_count = len(json.loads(r._comments or "[]"))
+			if "_comments" in r and r._comments:
+				# perf: Avoid parsing _comments, they can be huge and this is just a "UX feature"
+				r._comment_count = r._comments.count('"comment"')
 
 	def update_user_settings(self):
 		# update user settings if new search


### PR DESCRIPTION
This parsing isn't necessary and we are copying all of `_comments` just to count how many there are.

Imagine 2500 documents w/ 1-2 auto generated comments each.
