### PR TITLE
feat: Use RESP3 for Redis cache connections

### DIFF
--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -364,7 +364,7 @@ def setup_cache():
 			redis_class=RedisWrapper,
 		)
 
-	return RedisWrapper.from_url(frappe.conf.get("redis_cache"))
+	return RedisWrapper.from_url(frappe.conf.get("redis_cache"), protocol=3)
 
 
 def get_sentinel_connection(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "pytz==2023.3",
     "rauth~=0.7.3",
     "redis~=5.2.0",
-    "hiredis~=3.0.0",
+    "hiredis~=3.1.0",
     "setproctitle~=1.3.3",
     "requests-oauthlib~=1.3.1",
     "requests~=2.32.0",


### PR DESCRIPTION
RESP3 has PUSH support which is useful for implementing client side
caching. Enabling this before I work on that to test if anything breaks
with this.

No need to do this for background jobs instance just yet, infrequent
accesses and performance doesn't matter as much.


RESP3 is supposedly slightly faster but since we pickle everything 
that translates to 0 benefit for us. Few things that directly use 
Redis APIs like rate limiter will benefit though.

`no-docs` - this is "internal" change. 
We have been requiring Redis 6 for years now, so nothing changes 
from dependencies POV either. 