### PR TITLE
Revert "feat: Use RESP3 for Redis cache connections"

### DIFF
--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -364,7 +364,7 @@ def setup_cache():
 			redis_class=RedisWrapper,
 		)
 
-	return RedisWrapper.from_url(frappe.conf.get("redis_cache"), protocol=3)
+	return RedisWrapper.from_url(frappe.conf.get("redis_cache"))
 
 
 def get_sentinel_connection(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "pytz==2023.3",
     "rauth~=0.7.3",
     "redis~=5.2.0",
-    "hiredis~=3.1.0",
+    "hiredis~=3.0.0",
     "setproctitle~=1.3.3",
     "requests-oauthlib~=1.3.1",
     "requests~=2.32.0",


### PR DESCRIPTION
Reverts frappe/frappe#28929

This breaks redisearch because RESP3 doesn't decode response for some reason.