### PR TITLE
fix: applying user permissions on doctype with self links (#28830)

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -27,6 +27,7 @@
   "rounding_method",
   "permissions",
   "apply_strict_user_permissions",
+  "apply_user_permissions_on_self_link_fields",
   "column_break_21",
   "allow_older_web_view_links",
   "security_tab",
@@ -223,6 +224,13 @@
    "fieldtype": "Check",
    "label": "Apply Strict User Permissions"
   },
+  {
+    "default": "1",
+    "description": "If Apply User Permission on self Link Field is checked and User Permission is defined for a DocType for a User, then user permission is checked Otherwise document is allowed",
+    "fieldname": "apply_user_permissions_on_self_link_fields",
+    "fieldtype": "Check",
+    "label": "Apply User Permissions on self Link Fields"
+   },
   {
    "fieldname": "security",
    "fieldtype": "Section Break"

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -985,7 +985,9 @@ class DatabaseQuery:
 
 		match_filters = {}
 		match_conditions = []
-		apply_user_permissions_on_self_link_fields = frappe.get_system_settings("apply_user_permissions_on_self_link_fields")
+		apply_user_permissions_on_self_link_fields = frappe.get_system_settings(
+			"apply_user_permissions_on_self_link_fields"
+		)
 
 		for df in doctype_link_fields:
 			if df.get("ignore_user_permissions"):

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -985,8 +985,13 @@ class DatabaseQuery:
 
 		match_filters = {}
 		match_conditions = []
+		apply_user_permissions_on_self_link_fields = frappe.get_system_settings("apply_user_permissions_on_self_link_fields")
+
 		for df in doctype_link_fields:
 			if df.get("ignore_user_permissions"):
+				continue
+
+			if not apply_user_permissions_on_self_link_fields and self.doctype == df.get("options"):
 				continue
 
 			user_permission_values = user_permissions.get(df.get("options"), {})

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -339,7 +339,9 @@ def has_user_permission(doc, user=None, debug=False):
 	if apply_strict_user_permissions:
 		debug and _debug_log("Strict user permissions will be applied")
 
-	apply_user_permissions_on_self_link_fields = frappe.get_system_settings("apply_user_permissions_on_self_link_fields")
+	apply_user_permissions_on_self_link_fields = frappe.get_system_settings(
+		"apply_user_permissions_on_self_link_fields"
+	)
 
 	if apply_user_permissions_on_self_link_fields:
 		debug and _debug_log("Strict user permissions will be applied on self link fields")

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -339,6 +339,11 @@ def has_user_permission(doc, user=None, debug=False):
 	if apply_strict_user_permissions:
 		debug and _debug_log("Strict user permissions will be applied")
 
+	apply_user_permissions_on_self_link_fields = frappe.get_system_settings("apply_user_permissions_on_self_link_fields")
+
+	if apply_user_permissions_on_self_link_fields:
+		debug and _debug_log("Strict user permissions will be applied on self link fields")
+
 	doctype = doc.get("doctype")
 	docname = doc.get("name")
 
@@ -380,6 +385,9 @@ def has_user_permission(doc, user=None, debug=False):
 			# empty value, do you still want to apply user permissions?
 			if not d.get(field.fieldname) and not apply_strict_user_permissions:
 				# nah, not strict
+				continue
+
+			if not apply_user_permissions_on_self_link_fields and doc.get("doctype") == field.options:
 				continue
 
 			if field.options not in user_permissions:

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -80,7 +80,6 @@ class TestPermissions(IntegrationTestCase):
 		ss.flags.ignore_mandatory = 1
 		ss.save()
 
-
 	def test_basic_permission(self):
 		post = frappe.get_doc("Blog Post", "-test-blog-post")
 		self.assertTrue(post.has_permission("read"))


### PR DESCRIPTION
If user permissions restrict documents based on certain values in a link field, we cannot access those documents—even if the user permissions allow it—in the case of self-linking doctypes like trees. To address this, we should ignore user permissions on self-links.

***Example:*** If we are given access to a specific item group but do not have access to its parent group, we are unable to read that document. As a temporary workaround, if we provide access to all parent item groups, it allows us to read those documents as well, which might not be correct.

With this PR, it is no longer necessary to grant access to parent item groups, ensuring proper functionality without overextending permissions.   

fixes #28830 