### PR TITLE
fix: set datepicker language

### DIFF
--- a/frappe/public/js/frappe/form/controls/date_range.js
+++ b/frappe/public/js/frappe/form/controls/date_range.js
@@ -7,8 +7,10 @@ frappe.ui.form.ControlDateRange = class ControlDateRange extends frappe.ui.form.
 	}
 	set_date_options() {
 		var me = this;
+
+		let lang = frappe.boot?.user?.language;
 		this.datepicker_options = {
-			language: "en",
+			language: $.fn.datepicker.language[lang] ? lang : "en",
 			range: true,
 			autoClose: true,
 			toggleSelected: false,


### PR DESCRIPTION
Datepicker control should display the user's language when adding date range filters.
Backport to version 15