### PR TITLE
fix: update idx and name in table before rendering result rows

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -126,6 +126,7 @@ export default class Grid {
 		this.setup_add_row();
 
 		this.setup_grid_pagination();
+		this.update_idx_and_name();
 
 		this.custom_buttons = {};
 		this.grid_buttons = this.wrapper.find(".grid-buttons");
@@ -146,6 +147,17 @@ export default class Grid {
 		} else {
 			description_wrapper.hide();
 		}
+	}
+
+	update_idx_and_name() {
+		this.data.forEach((d, ri) => {
+			if (d.idx === undefined) {
+				d.idx = ri + 1;
+			}
+			if (d.name === undefined) {
+				d.name = "row " + d.idx;
+			}
+		});
 	}
 
 	set_doc_url() {


### PR DESCRIPTION
Issue

In the dialog, when pagination is present, the idx is assigned to the first page only. If a user searches directly from the first page without rendering other pages, an incorrect idx value gets removed because no idx is assigned.

Steps to Replicate:

Create a sales order with more than 50 items (to enable pagination).
After submitting, use the "Update Items" feature and delete any item whose serial number is greater than 50 by directly searching for it using the search bar.
Two items will get deleted: one with valid data and another with an idx value that was incorrectly assigned during the search.
Solution:
Assign idx to whole data before rendering pagination.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/20413

Related PR: #27502 
