### PR TITLE
perf: No need to set expiry for rate limiter key everytime

### DIFF
--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -54,6 +54,11 @@ class RateLimiter:
 		self.window_number, self.spent = divmod(int(self.start), self.window)
 		self.key = frappe.cache.make_key(f"rate-limit-counter-{self.window_number}")
 		self.counter = cint(frappe.cache.get(self.key))
+		if not self.counter:
+			# This is the first request in this window
+			frappe.cache.incrby(self.key, 0)
+			frappe.cache.expire(self.key, self.window)
+
 		self.remaining = max(self.limit - self.counter, 0)
 		self.reset = self.window - self.spent
 

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -71,10 +71,7 @@ class RateLimiter:
 
 	def update(self):
 		self.record_request_end()
-		pipeline = frappe.cache.pipeline(transaction=False)
-		pipeline.incrby(self.key, self.duration)
-		pipeline.expire(self.key, self.window)
-		pipeline.execute()
+		frappe.cache.incrby(self.key, self.duration)
 
 	def headers(self):
 		self.record_request_end()

--- a/frappe/tests/test_rate_limiter.py
+++ b/frappe/tests/test_rate_limiter.py
@@ -108,3 +108,12 @@ class TestRateLimiter(IntegrationTestCase):
 		self.assertEqual(limiter.duration, cint(frappe.cache.get(limiter.key)))
 
 		frappe.cache.delete(limiter.key)
+
+	def test_window_expires(self):
+		limiter = RateLimiter(1000, 1)
+		self.assertTrue(frappe.cache.exists(limiter.key, shared=True))
+		limiter.update()
+		self.assertTrue(frappe.cache.exists(limiter.key, shared=True))
+		time.sleep(1.1)
+		self.assertFalse(frappe.cache.exists(limiter.key, shared=True))
+		frappe.cache.delete(limiter.key)


### PR DESCRIPTION
I am not entirely sure why we need to expire key on every request. Rate limiter window keys are unique for each hour based on current time divmoded with window size.

At the same time, I've seen incr+expire often in similar rate limiting code. So maybe I am missing something here?

Benchmarks: This makes rate limiter code ~1.15x faster overall. Nothing huge, but if we don't have to do this then why not.

TODO:
- [x] investigate.
