### PR TITLE
perf: reduce RQ Worker's polling frequency

### DIFF
--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -346,6 +346,26 @@ class FrappeWorker(Worker):
 
 		Thread(target=start_scheduler, daemon=True).start()
 
+	def subscribe(self):
+		"""Subscribe to this worker's channel"""
+		# This function is overridden to increase the timeout of pubsub thread. Default is 0.2
+		# second which is too frequent for us, this change sets it to 2s which is 10x the default.
+		# ref: https://github.com/frappe/caffeine/issues/46
+
+		# The pubsub thread is responsible for handling three commands from master process:
+		# 1. shutdown
+		# 2. stop current job
+		# 3. Kill forked horse (~ force stop the job)
+
+		# Impact of increasing timeout: shutdown might have up to 2s before background thread
+		# times out and is joined with main thread. Ideally, we should not have to do this at all.
+		# But the code that handles blocking socket behaviour is deep inside redis-py/hiredis.
+
+		self.log.info("Subscribing to channel %s", self.pubsub_channel_name)
+		self.pubsub = self.connection.pubsub()
+		self.pubsub.subscribe(**{self.pubsub_channel_name: self.handle_payload})
+		self.pubsub_thread = self.pubsub.run_in_thread(sleep_time=2, daemon=True)
+
 
 def start_worker_pool(
 	queue: str | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ dependencies = [
     "setproctitle~=1.3.3",
     "requests-oauthlib~=1.3.1",
     "requests~=2.32.0",
+    # We depend on internal attributes of RQ.
+    # Do NOT add loose requirements on RQ versions.
+    # Audit the code changes w.r.t. background_jobs.py before updating.
     "rq==1.16.2",
     "rsa>=4.1",
     "semantic-version~=2.10.0",


### PR DESCRIPTION
This function is overridden to increase the timeout of pub-sub thread. Default is 0.2 second which is too frequent for us, this change sets it to 2s which is 10x the default. 

The pub-sub thread is responsible for handling three commands from master process:
1. shutdown
2. stop current job
3. Kill forked horse (~ force stop the job)

Impact of increasing timeout: shutdown might have to wait up to 2s before the background thread times out and is joined with main thread. Ideally, we should not have to do this at all. But the code that handles blocking socket behaviour is deep inside redis-py/hiredis.


This behavior should be tested by worker-pool/worker tests I wrote before. Anyway, only overriding worker-pool on develop for now, will monitor for errors.

This PR can be reverted if upstream fix is accepted: https://github.com/rq/rq/pull/2172 

