### PR TITLE
fix: register fault hander after gunicorn registers signals

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -279,6 +279,7 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force: bool =
 	if not _one_time_setup.get(local.conf.db_type):
 		patch_query_execute()
 		patch_query_aggregation()
+		frappe._optimizations.register_fault_handler()
 		_one_time_setup[local.conf.db_type] = True
 
 	setup_module_map(include_all_apps=not (frappe.request or frappe.job or frappe.flags.in_migrate))

--- a/frappe/_optimizations.py
+++ b/frappe/_optimizations.py
@@ -30,8 +30,6 @@ def optimize_all():
 	optimize_gc_parameters()
 	optimize_gc_for_copy_on_write()
 	optimize_for_gil_contention()
-	register_fault_handler()
-	os.register_at_fork(after_in_child=register_fault_handler)
 
 
 def optimize_gc_parameters():


### PR DESCRIPTION
Ugh, currently gunicorn is overriding our signal handler and we don't
care about gunicorn's SIGUSR1 handler.

Broke it in recent refactors: https://github.com/frappe/frappe/pull/28832 