### PR TITLE
fix: duplicate/copy doc

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -593,6 +593,7 @@
    "fieldname": "api_key",
    "fieldtype": "Data",
    "label": "API Key",
+   "no_copy": 1,
    "permlevel": 1,
    "read_only": 1,
    "unique": 1
@@ -887,7 +888,7 @@
    "link_fieldname": "user"
   }
  ],
- "modified": "2024-09-27 11:41:13.336662",
+ "modified": "2024-12-31 19:35:17.052698",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -294,7 +294,8 @@ $.extend(frappe.model, {
 				df &&
 				key.substr(0, 2) != "__" &&
 				!no_copy_list.includes(key) &&
-				!(df && !from_amend && cint(df.no_copy) == 1)
+				!(df && !from_amend && cint(df.no_copy) == 1) &&
+				df.fieldtype !== "Password"
 			) {
 				var value = doc[key] || [];
 				if (frappe.model.table_fields.includes(df.fieldtype)) {

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -283,12 +283,12 @@ $.extend(frappe.model, {
 	},
 
 	copy_doc: function (doc, from_amend, parent_doc, parentfield) {
-		var no_copy_list = ["name", "amended_from", "amendment_date", "cancel_reason"];
-		var newdoc = frappe.model.get_new_doc(doc.doctype, parent_doc, parentfield);
+		let no_copy_list = ["name", "amended_from", "amendment_date", "cancel_reason"];
+		let newdoc = frappe.model.get_new_doc(doc.doctype, parent_doc, parentfield);
 
-		for (var key in doc) {
-			// dont copy name and blank fields
-			var df = frappe.meta.get_docfield(doc.doctype, key);
+		for (const key in doc) {
+			// don't copy name and blank fields
+			let df = frappe.meta.get_docfield(doc.doctype, key);
 
 			if (
 				df &&
@@ -297,10 +297,10 @@ $.extend(frappe.model, {
 				!(df && !from_amend && cint(df.no_copy) == 1) &&
 				df.fieldtype !== "Password"
 			) {
-				var value = doc[key] || [];
+				let value = doc[key] || [];
 				if (frappe.model.table_fields.includes(df.fieldtype)) {
-					for (var i = 0, j = value.length; i < j; i++) {
-						var d = value[i];
+					for (let i = 0, j = value.length; i < j; i++) {
+						let d = value[i];
 						frappe.model.copy_doc(d, from_amend, newdoc, df.fieldname);
 					}
 				} else {
@@ -309,7 +309,7 @@ $.extend(frappe.model, {
 			}
 		}
 
-		var user = frappe.session.user;
+		let user = frappe.session.user;
 
 		newdoc.__islocal = 1;
 		newdoc.docstatus = 0;

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -290,13 +290,12 @@ $.extend(frappe.model, {
 			// don't copy name and blank fields
 			let df = frappe.meta.get_docfield(doc.doctype, key);
 
-			if (
-				df &&
-				key.substring(0, 2) != "__" &&
-				!no_copy_list.includes(key) &&
-				!(df && !from_amend && cint(df.no_copy) == 1) &&
-				df.fieldtype !== "Password"
-			) {
+			const is_internal_field = key.substring(0, 2) === "__";
+			const is_blocked_field = no_copy_list.includes(key);
+			const is_no_copy = !from_amend && df && cint(df.no_copy) == 1;
+			const is_password = df && df.fieldtype === "Password";
+
+			if (df && !is_internal_field && !is_blocked_field && !is_no_copy && !is_password) {
 				let value = doc[key] || [];
 				if (frappe.model.table_fields.includes(df.fieldtype)) {
 					for (let i = 0, j = value.length; i < j; i++) {

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -286,7 +286,7 @@ $.extend(frappe.model, {
 		let no_copy_list = ["name", "amended_from", "amendment_date", "cancel_reason"];
 		let newdoc = frappe.model.get_new_doc(doc.doctype, parent_doc, parentfield);
 
-		for (const key in doc) {
+		for (let key in doc) {
 			// don't copy name and blank fields
 			let df = frappe.meta.get_docfield(doc.doctype, key);
 

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -292,7 +292,7 @@ $.extend(frappe.model, {
 
 			if (
 				df &&
-				key.substr(0, 2) != "__" &&
+				key.substring(0, 2) != "__" &&
 				!no_copy_list.includes(key) &&
 				!(df && !from_amend && cint(df.no_copy) == 1) &&
 				df.fieldtype !== "Password"


### PR DESCRIPTION
#### Problem

We happily used the `Duplicate` feature in DocType form to duplicate a `Social Login Key` document, only to find it does not show up in login page even on enabling. There are no errors, etc. But on reading code, it is found out that if the `client_secret` is missing, it will be ignored while rendering. But why is the `client_secret` missing (using `get_password` utils), I can see it in my form?:

![CleanShot 2024-12-31 at 22 37 30@2x](https://github.com/user-attachments/assets/432cec3a-772b-4391-8571-b70d44fb68e2)

Actually, only the obscured `****` thing is copied over and not the actual password from the backend. This leads to surprises.

#### Solution

The simplest solution is to not copy password fields on Duplicate/Copy Doc. This is what this PR does.

#### Extra Stuff

- fix: don't copy over API Key in User DocType
- refactor(copy_doc): replace `var` with let/const
- fix: update deprecated string method