### PR TITLE
perf: Don't query redirects on existing session

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -205,8 +205,7 @@ class LoginManager:
 			frappe.response["full_name"] = self.full_name
 
 		# redirect information
-		redirect_to = frappe.cache.hget("redirect_after_login", self.user)
-		if redirect_to:
+		if not resume and (redirect_to := frappe.cache.hget("redirect_after_login", self.user)):
 			frappe.local.response["redirect_to"] = redirect_to
 			frappe.cache.hdel("redirect_after_login", self.user)
 

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -291,8 +291,14 @@ class TestOverheadCalls(FrappeAPITestCase):
 
 	def test_ping_overheads(self):
 		self.get(self.method("ping"), {"sid": "Guest"})
-		with self.assertRedisCallCounts(13), self.assertQueryCount(self.BASE_SQL_CALLS):
+		with self.assertRedisCallCounts(10), self.assertQueryCount(self.BASE_SQL_CALLS):
 			self.get(self.method("ping"), {"sid": "Guest"})
+
+	def test_ping_overheads_authenticated(self):
+		sid = self.sid
+		self.get(self.method("ping"), {"sid": sid})
+		with self.assertRedisCallCounts(10), self.assertQueryCount(self.BASE_SQL_CALLS):
+			self.get(self.method("ping"), {"sid": sid})
 
 	def test_list_view_overheads(self):
 		sid = self.sid


### PR DESCRIPTION
This is only used for a new user. After that it's never used but still present in EVERY request!

Note: This isn't typical "redirect after login" that's handled by the URL itself. This is used when a user visits a page and is asked to sign up first.

https://ankush.dev/p/flamegraph-missing-forest-for-trees

towards https://github.com/frappe/caffeine/issues/15
