### PR TITLE
fix: remove typo from setting current app

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -79,7 +79,8 @@ frappe.breadcrumbs = {
 			frappe.workspace_map[breadcrumbs.workspace]?.app &&
 			frappe.workspace_map[breadcrumbs.workspace]?.app != frappe.current_app
 		) {
-			frappe.app.sidebar.set_current_app(frappe.workspace_map[breadcrumbs.workspace].app);
+			const app = frappe.workspace_map[breadcrumbs.workspace].app;
+			frappe.app.sidebar.apps_switcher.set_current_app(app);
 		}
 
 		this.toggle(true);


### PR DESCRIPTION
### Issue

<details>
<summary>See issue</summary>

https://github.com/user-attachments/assets/d78d8090-cbc2-4b50-a6f3-1d77673d25bd

</details>

### Traceback
<details>
<summary>See Tranceback</summary>

```log
Uncaught (in promise) TypeError: frappe.app.sidebar.set_current_app is not a function
    update breadcrumbs.js:82
    add breadcrumbs.js:44
    initialize_new_doc form.js:593
    promise callback*initialize_new_doc form.js:584
    trigger_onload form.js:565
    refresh form.js:449
    render formview.js:107
    fetch_and_render formview.js:91
    callback model.js:332
    callback request.js:86
    200 request.js:134
    call request.js:306
    jQuery 6
    call request.js:280
    call request.js:110
    with_doc model.js:324
    with_doc model.js:314
    fetch_and_render formview.js:80
    show_doc formview.js:75
    make_and_show formview.js:32
    make formview.js:15
    with_doctype model.js:242
    make formview.js:12
    show factory.js:25
    render_page router.js:310
    render router.js:289
    route router.js:144
    set_route desk.js:182
    startup desk.js:55
    Application desk.js:30
    start_app desk.js:12
    <anonymous> desk.js:25
    jQuery 13
    __require2 libs.bundle.LLRFRX7M.js:16
    <anonymous> jQuery
    <anonymous> libs.bundle.LLRFRX7M.js:21430
breadcrumbs.js:82:22

```

</details>

#### Issue Commit: https://github.com/frappe/frappe/commit/d49340245e6bc7594928c6f2cc5992992ccabe88#diff-04c8e2c7dad1e188c23543502476aab5b2dca5a6d534039a8afab67aa22514a5R81

