### PR TITLE
fix(style): Image Cut off fixed

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -476,6 +476,7 @@ body {
 			transition: opacity 0.3s;
 			border-radius: var(--border-radius-lg);
 			border: 1px solid var(--border-color);
+			width: 100%;
 		}
 
 		.sidebar-image-wrapper:hover {
@@ -512,7 +513,7 @@ body {
 	// padding-right: 30px;
 	width: 220px;
 	border-left: 1px solid var(--border-color);
-
+	height: 100vh;
 	.sidebar-section {
 		padding: var(--padding-md);
 		border-bottom: 1px solid var(--border-color);


### PR DESCRIPTION
Image in the layout sidebar used to cutoff 
Resolves #28652 #28372
Before:

<img width="218" alt="padding-before" src="https://github.com/user-attachments/assets/156eeb77-d72f-4876-9180-d44b2161be44" />

After:
<img width="181" alt="padding-after" src="https://github.com/user-attachments/assets/5f218ff9-c5d7-4345-92af-e4fc181573ce" />




