### PR TITLE
feat(cache): server-assisted client-side caching

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2346,23 +2346,6 @@ def get_website_settings(key):
 	return local.website_settings.get(key)
 
 
-def get_system_settings(key: str):
-	"""Return the value associated with the given `key` from System Settings DocType."""
-	if not (system_settings := getattr(local, "system_settings", None)):
-		key = get_document_cache_key("System Settings", "System Settings")
-		try:
-			system_settings = client_cache.get_value(key)
-			if not system_settings:
-				system_settings = frappe.get_doc("System Settings")
-				client_cache.set_value(key, system_settings)
-			local.system_settings = system_settings
-		except DoesNotExistError:  # possible during new install
-			clear_last_message()
-			return
-
-	return system_settings.get(key)
-
-
 def get_active_domains():
 	from frappe.core.doctype.domain_settings.domain_settings import get_active_domains
 
@@ -2498,6 +2481,7 @@ import frappe._optimizations
 
 # Backward compatibility
 from frappe.config import get_common_site_config, get_site_config
+from frappe.core.doctype.system_settings.system_settings import get_system_settings
 from frappe.utils.error import log_error
 
 frappe._optimizations.optimize_all()

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -974,6 +974,7 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 	if (not doctype and not user) or doctype == "DocType":
 		frappe.utils.caching._SITE_CACHE.clear()
 
+	frappe.client_cache.clear_cache()
 	local.role_permissions = {}
 	if hasattr(local, "request_cache"):
 		local.request_cache.clear()

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2347,8 +2347,13 @@ def get_website_settings(key):
 def get_system_settings(key: str):
 	"""Return the value associated with the given `key` from System Settings DocType."""
 	if not (system_settings := getattr(local, "system_settings", None)):
+		key = get_document_cache_key("System Settings", "System Settings")
 		try:
-			local.system_settings = system_settings = get_cached_doc("System Settings")
+			system_settings = client_cache.get_value(key)
+			if not system_settings:
+				system_settings = frappe.get_doc("System Settings")
+				client_cache.set_value(key, system_settings)
+			local.system_settings = system_settings
 		except DoesNotExistError:  # possible during new install
 			clear_last_message()
 			return

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -973,8 +973,8 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 
 	if (not doctype and not user) or doctype == "DocType":
 		frappe.utils.caching._SITE_CACHE.clear()
+		frappe.client_cache.clear_cache()
 
-	frappe.client_cache.clear_cache()
 	local.role_permissions = {}
 	if hasattr(local, "request_cache"):
 		local.request_cache.clear()

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -73,12 +73,12 @@ if TYPE_CHECKING:  # pragma: no cover
 	from frappe.model.document import Document
 	from frappe.query_builder.builder import MariaDB, Postgres
 	from frappe.types.lazytranslatedstring import _LazyTranslate
-	from frappe.utils.redis_wrapper import RedisWrapper, _ClientCache
+	from frappe.utils.redis_wrapper import ClientCache, RedisWrapper
 
 controllers: dict[str, "Document"] = {}
 local = Local()
 cache: Optional["RedisWrapper"] = None
-client_cache: Optional["_ClientCache"] = None
+client_cache: Optional["ClientCache"] = None
 STANDARD_USERS = ("Guest", "Administrator")
 
 _one_time_setup: dict[str, bool] = {}
@@ -398,7 +398,7 @@ _redis_init_lock = threading.Lock()
 
 def setup_redis_cache_connection():
 	"""Defines `frappe.cache` as `RedisWrapper` instance"""
-	from frappe.utils.redis_wrapper import _ClientCache, setup_cache
+	from frappe.utils.redis_wrapper import ClientCache, setup_cache
 
 	global cache
 	global client_cache
@@ -407,7 +407,7 @@ def setup_redis_cache_connection():
 		# We need to check again since someone else might have setup connection before us.
 		if not cache:
 			cache = setup_cache()
-			client_cache = _ClientCache()
+			client_cache = ClientCache()
 
 
 def get_traceback(with_context: bool = False) -> str:

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1592,16 +1592,18 @@ def get_hooks(
 	:param app_name: Filter by app."""
 
 	if app_name:
-		hooks = _dict(_load_app_hooks(app_name))
+		hooks = _load_app_hooks(app_name)
 	else:
 		if conf.developer_mode:
-			hooks = _dict(_load_app_hooks())
+			hooks = _load_app_hooks()
 		else:
-			hooks = _dict(cache.get_value("app_hooks", _load_app_hooks))
-
+			hooks = client_cache.get_value("app_hooks")
+			if hooks is None:
+				hooks = _load_app_hooks()
+				client_cache.set_value("app_hooks", hooks)
 	if hook:
 		return hooks.get(hook, ([] if default == "_KEEP_DEFAULT_LIST" else default))
-	return hooks
+	return _dict(hooks)
 
 
 def append_hook(target, key, value):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1635,7 +1635,7 @@ def setup_module_map(include_all_apps: bool = True) -> None:
 	if include_all_apps:
 		local.app_modules = cache.get_value("app_modules")
 	else:
-		local.app_modules = cache.get_value("installed_app_modules")
+		local.app_modules = client_cache.get_value("installed_app_modules")
 
 	if not local.app_modules:
 		local.app_modules = {}
@@ -1653,7 +1653,7 @@ def setup_module_map(include_all_apps: bool = True) -> None:
 		if include_all_apps:
 			cache.set_value("app_modules", local.app_modules)
 		else:
-			cache.set_value("installed_app_modules", local.app_modules)
+			client_cache.set_value("installed_app_modules", local.app_modules)
 
 	# Init module_app (reverse mapping)
 	local.module_app = {}

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -9,7 +9,6 @@ Note:
 """
 
 import json
-from contextlib import suppress
 from typing import Any
 
 from werkzeug.routing import Rule
@@ -39,15 +38,10 @@ def handle_rpc_call(method: str, doctype: str | None = None):
 		method = hook
 		break
 
-	method_exists = False
-	with suppress(Exception):
-		method_exists = bool(frappe.get_attr(method))
-
 	# via server script
-	if not method_exists:
-		server_script = get_server_script_map().get("_api", {}).get(method)
-		if server_script:
-			return run_server_script(server_script)
+	server_script = get_server_script_map().get("_api", {}).get(method)
+	if server_script:
+		return run_server_script(server_script)
 
 	try:
 		method = frappe.get_attr(method)

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -109,9 +109,10 @@ def clear_global_cache():
 
 def clear_defaults_cache(user=None):
 	if user:
-		frappe.cache.hdel("defaults", [user, *common_default_keys])
+		for key in [user, *common_default_keys]:
+			frappe.client_cache.delete_value(f"defaults::{key}")
 	elif frappe.flags.in_install != "frappe":
-		frappe.cache.delete_value("defaults")
+		frappe.client_cache.delete_keys("defaults::*")
 
 
 def clear_doctype_cache(doctype=None):

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -66,7 +66,6 @@ user_cache_keys = (
 )
 
 doctype_cache_keys = (
-	"doctype_meta",
 	"doctype_form_meta",
 	"table_columns",
 	"last_modified",
@@ -126,6 +125,7 @@ def clear_doctype_cache(doctype=None):
 
 def _clear_doctype_cache_from_redis(doctype: str | None = None):
 	from frappe.desk.notifications import delete_notification_count_for
+	from frappe.model.meta import clear_meta_cache
 
 	to_del = ["is_table", "doctype_modules"]
 
@@ -134,6 +134,7 @@ def _clear_doctype_cache_from_redis(doctype: str | None = None):
 		def clear_single(dt):
 			frappe.clear_document_cache(dt)
 			frappe.cache.hdel_names(doctype_cache_keys, dt)
+			clear_meta_cache(dt)
 
 		clear_single(doctype)
 
@@ -159,6 +160,7 @@ def _clear_doctype_cache_from_redis(doctype: str | None = None):
 		to_del += frappe.cache.get_keys("document_cache::")
 
 	frappe.cache.delete_value(to_del)
+	clear_meta_cache()
 
 
 def clear_controller_cache(doctype=None):

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -158,9 +158,9 @@ def _clear_doctype_cache_from_redis(doctype: str | None = None):
 		# clear all
 		to_del += doctype_cache_keys
 		to_del += frappe.cache.get_keys("document_cache::")
+		clear_meta_cache()
 
 	frappe.cache.delete_value(to_del)
-	clear_meta_cache()
 
 
 def clear_controller_cache(doctype=None):

--- a/frappe/core/doctype/language/language.py
+++ b/frappe/core/doctype/language/language.py
@@ -53,7 +53,7 @@ class Language(Document):
 
 	def on_update(self):
 		frappe.cache.delete_value("languages_with_name")
-		frappe.cache.delete_value("languages")
+		frappe.client_cache.delete_value("languages")
 		self.update_user_defaults()
 
 	def update_user_defaults(self):

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -90,11 +90,11 @@ class ServerScript(Document):
 		self.sync_scheduled_job_type()
 
 	def clear_cache(self):
-		frappe.cache.delete_value("server_script_map")
+		frappe.client_cache.delete_value("server_script_map")
 		return super().clear_cache()
 
 	def on_trash(self):
-		frappe.cache.delete_value("server_script_map")
+		frappe.client_cache.delete_value("server_script_map")
 		if self.script_type == "Scheduler Event":
 			for job in self.scheduled_jobs:
 				scheduled_job_type: ScheduledJobType = frappe.get_doc("Scheduled Job Type", job.name)

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -65,7 +65,7 @@ def get_server_script_map():
 	if frappe.flags.in_patch and not frappe.db.table_exists("Server Script"):
 		return {}
 
-	script_map = frappe.cache.get_value("server_script_map")
+	script_map = frappe.client_cache.get_value("server_script_map")
 	if script_map is None:
 		script_map = {"permission_query": {}}
 		enabled_server_scripts = frappe.get_all(
@@ -83,6 +83,6 @@ def get_server_script_map():
 			else:
 				script_map.setdefault("_api", {})[script.api_method] = script.name
 
-		frappe.cache.set_value("server_script_map", script_map)
+		frappe.client_cache.set_value("server_script_map", script_map)
 
 	return script_map

--- a/frappe/core/doctype/server_script/test_server_script.py
+++ b/frappe/core/doctype/server_script/test_server_script.py
@@ -135,10 +135,10 @@ class TestServerScript(IntegrationTestCase):
 	def tearDownClass(cls):
 		frappe.db.commit()
 		frappe.db.truncate("Server Script")
-		frappe.cache.delete_value("server_script_map")
+		frappe.client_cache.delete_value("server_script_map")
 
 	def setUp(self):
-		frappe.cache.delete_value("server_script_map")
+		frappe.client_cache.delete_value("server_script_map")
 
 	def test_doctype_event(self):
 		todo = frappe.get_doc(doctype="ToDo", description="hello").insert()

--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -234,7 +234,9 @@ def clear_default(key=None, value=None, parent=None, name=None, parenttype=None)
 
 def get_defaults_for(parent="__default"):
 	"""get all defaults"""
-	defaults = frappe.cache.hget("defaults", parent)
+
+	key = f"defaults::{parent}"
+	defaults = frappe.client_cache.get_value(key)
 
 	if defaults is None:
 		# sort descending because first default must get precedence
@@ -260,7 +262,7 @@ def get_defaults_for(parent="__default"):
 			elif d.defvalue is not None:
 				defaults[d.defkey] = d.defvalue
 
-		frappe.cache.hset("defaults", parent, defaults)
+		frappe.client_cache.set_value(key, defaults)
 
 	return defaults
 

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -188,7 +188,7 @@ def is_standard(fieldname):
 	return fieldname in default_fields or fieldname in optional_fields or fieldname in child_table_fields
 
 
-@lru_cache
+@lru_cache(maxsize=1024)
 def extract_fieldnames(field):
 	from frappe.database.schema import SPECIAL_CHAR_PATTERN
 

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 
 import os
-from contextlib import suppress
 from mimetypes import guess_type
 from typing import TYPE_CHECKING
 
@@ -67,15 +66,10 @@ def execute_cmd(cmd, from_async=False):
 		cmd = hook
 		break
 
-	method_exists = False
-	with suppress(Exception):
-		method_exists = bool(get_attr(cmd))
-
 	# via server script
-	if not method_exists:
-		server_script = get_server_script_map().get("_api", {}).get(cmd)
-		if server_script:
-			return run_server_script(server_script)
+	server_script = get_server_script_map().get("_api", {}).get(cmd)
+	if server_script:
+		return run_server_script(server_script)
 
 	try:
 		method = get_attr(cmd)

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -87,7 +87,10 @@ def get_meta(doctype: str | dict | DocRef, cached=True) -> "_Meta":
 
 def clear_meta_cache(doctype: str = "*"):
 	key = f"doctype_meta::{doctype}"
-	frappe.cache.delete_keys(key)
+	if doctype == "*":
+		frappe.cache.delete_keys(key)
+	else:
+		frappe.client_cache.delete_value(key)
 
 
 def load_meta(doctype):

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -75,12 +75,19 @@ def get_meta(doctype: str | dict | DocRef, cached=True) -> "_Meta":
 		if not isinstance(doctype, dict)
 		else doctype.get("doctype")
 	):
-		if meta := frappe.cache.hget("doctype_meta", doctype_name):
+		key = f"doctype_meta::{doctype_name}"
+		if meta := frappe.client_cache.get_value(key):
 			return meta
 
 	meta = Meta(doctype)
-	frappe.cache.hset("doctype_meta", meta.name, meta)
+	key = f"doctype_meta::{meta.name}"
+	frappe.client_cache.set_value(key, meta)
 	return meta
+
+
+def clear_meta_cache(doctype: str = "*"):
+	key = f"doctype_meta::{doctype}"
+	frappe.cache.delete_keys(key)
 
 
 def load_meta(doctype):

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -175,8 +175,11 @@ def normalize_query(query: str) -> str:
 
 
 def record(force=False):
-	if frappe.cache.get_value(RECORDER_INTERCEPT_FLAG) or force:
+	if frappe.client_cache.get_value(RECORDER_INTERCEPT_FLAG) or force:
 		frappe.local._recorder = Recorder(force=force)
+	elif frappe.client_cache.get_value(RECORDER_INTERCEPT_FLAG) is None:
+		# Explicitly set it once so next requests can use client-side cache
+		frappe.client_cache.set_value(RECORDER_INTERCEPT_FLAG, False)
 
 
 def dump():
@@ -342,14 +345,14 @@ def start(
 		request_filter=request_filter,
 		jobs_filter=jobs_filter,
 	).store()
-	frappe.cache.set_value(RECORDER_INTERCEPT_FLAG, 1, expires_in_sec=RECORDER_AUTO_DISABLE)
+	frappe.client_cache.set_value(RECORDER_INTERCEPT_FLAG, True)
 
 
 @frappe.whitelist()
 @do_not_record
 @administrator_only
 def stop(*args, **kwargs):
-	frappe.cache.delete_value(RECORDER_INTERCEPT_FLAG)
+	frappe.client_cache.set_value(RECORDER_INTERCEPT_FLAG, False)
 	frappe.enqueue(post_process, now=frappe.flags.in_test)
 
 

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -175,9 +175,10 @@ def normalize_query(query: str) -> str:
 
 
 def record(force=False):
-	if frappe.client_cache.get_value(RECORDER_INTERCEPT_FLAG) or force:
+	flag_value = frappe.client_cache.get_value(RECORDER_INTERCEPT_FLAG)
+	if flag_value or force:
 		frappe.local._recorder = Recorder(force=force)
-	elif frappe.client_cache.get_value(RECORDER_INTERCEPT_FLAG) is None:
+	elif flag_value is None:
 		# Explicitly set it once so next requests can use client-side cache
 		frappe.client_cache.set_value(RECORDER_INTERCEPT_FLAG, False)
 

--- a/frappe/tests/classes/integration_test_case.py
+++ b/frappe/tests/classes/integration_test_case.py
@@ -129,7 +129,7 @@ class IntegrationTestCase(UnitTestCase):
 			frappe.db.__class__.sql = orig_sql
 
 	@contextmanager
-	def assertRedisCallCounts(self, count: int) -> AbstractContextManager[None]:
+	def assertRedisCallCounts(self, count: int, *, exact=False) -> AbstractContextManager[None]:
 		from frappe.utils.redis_wrapper import RedisWrapper
 
 		commands = []
@@ -146,9 +146,11 @@ class IntegrationTestCase(UnitTestCase):
 			orig_execute = RedisWrapper.execute_command
 			RedisWrapper.execute_command = execute_command_and_count
 			yield
-			self.assertLessEqual(
-				len(commands), count, msg="commands executed: \n" + "\n".join(str(c) for c in commands)
-			)
+			msg = "commands executed: \n" + "\n".join(str(c) for c in commands)
+			if exact:
+				self.assertEqual(len(commands), count, msg=msg)
+			else:
+				self.assertLessEqual(len(commands), count, msg=msg)
 		finally:
 			RedisWrapper.execute_command = orig_execute
 

--- a/frappe/tests/classes/integration_test_case.py
+++ b/frappe/tests/classes/integration_test_case.py
@@ -130,25 +130,27 @@ class IntegrationTestCase(UnitTestCase):
 
 	@contextmanager
 	def assertRedisCallCounts(self, count: int) -> AbstractContextManager[None]:
+		from frappe.utils.redis_wrapper import RedisWrapper
+
 		commands = []
 
 		def execute_command_and_count(*args, **kwargs):
 			ret = orig_execute(*args, **kwargs)
 			key_len = 2
-			if "H" in args[0]:
+			if "H" in args[1]:
 				key_len = 3
-			commands.append((args)[:key_len])
+			commands.append((args)[1 : key_len + 1])
 			return ret
 
 		try:
-			orig_execute = frappe.cache.execute_command
-			frappe.cache.execute_command = execute_command_and_count
+			orig_execute = RedisWrapper.execute_command
+			RedisWrapper.execute_command = execute_command_and_count
 			yield
 			self.assertLessEqual(
 				len(commands), count, msg="commands executed: \n" + "\n".join(str(c) for c in commands)
 			)
 		finally:
-			frappe.cache.execute_command = orig_execute
+			RedisWrapper.execute_command = orig_execute
 
 	@contextmanager
 	def assertRowsRead(self, count: int) -> AbstractContextManager[None]:

--- a/frappe/tests/test_client_cache.py
+++ b/frappe/tests/test_client_cache.py
@@ -56,3 +56,9 @@ class TestClientCache(IntegrationTestCase):
 		c.set_value(frappe.generate_hash(), 42)
 
 		self.assertEqual(len(c.cache), 2)
+
+	def test_shared_keyspace(self):
+		val = frappe.generate_hash()
+		frappe.client_cache.set_value(TEST_KEY, val)
+
+		self.assertEqual(frappe.client_cache.get_value(TEST_KEY), frappe.cache.get_value(TEST_KEY))

--- a/frappe/tests/test_client_cache.py
+++ b/frappe/tests/test_client_cache.py
@@ -2,7 +2,7 @@ import time
 
 import frappe
 from frappe.tests import IntegrationTestCase
-from frappe.utils.redis_wrapper import _ClientCache
+from frappe.utils.redis_wrapper import ClientCache
 
 TEST_KEY = "42"
 
@@ -40,7 +40,7 @@ class TestClientCache(IntegrationTestCase):
 			self.assertEqual(frappe.client_cache.get_value(TEST_KEY), val)
 
 	def test_client_local_cache_ttl(self):
-		c = _ClientCache(ttl=1)
+		c = ClientCache(ttl=1)
 		c.set_value(TEST_KEY, 42)
 		with self.assertRedisCallCounts(0):
 			c.get_value(TEST_KEY)
@@ -50,7 +50,7 @@ class TestClientCache(IntegrationTestCase):
 			c.get_value(TEST_KEY)
 
 	def test_client_cache_maxsize(self):
-		c = _ClientCache(maxsize=2)
+		c = ClientCache(maxsize=2)
 		c.set_value(TEST_KEY, 42)
 		c.set_value(frappe.generate_hash(), 42)
 		c.set_value(frappe.generate_hash(), 42)

--- a/frappe/tests/test_client_cache.py
+++ b/frappe/tests/test_client_cache.py
@@ -1,0 +1,37 @@
+import time
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+TEST_KEY = "42"
+
+
+class TestClientCache(IntegrationTestCase):
+	def setUp(self) -> None:
+		frappe.client_cache.delete_value(TEST_KEY)
+		return super().setUp()
+
+	def test_client_cache_is_used(self):
+		frappe.client_cache.set_value(TEST_KEY, 42)
+		frappe.client_cache.get_value(TEST_KEY)
+		with self.assertRedisCallCounts(0):
+			frappe.client_cache.get_value(TEST_KEY)
+
+	def test_client_cache_is_updated_instantly_noloop(self):
+		val = frappe.generate_hash()
+		frappe.client_cache.set_value(TEST_KEY, val)
+		with self.assertRedisCallCounts(0):  # Locally set value should not be invalidated.
+			self.assertEqual(frappe.client_cache.get_value(TEST_KEY), val)
+
+	def test_invalidation_from_another_client_works(self):
+		val = frappe.generate_hash()
+		frappe.client_cache.set_value(TEST_KEY, val)
+		self.assertEqual(frappe.client_cache.get_value(TEST_KEY), val)
+
+		# frappe.cache is our "another client"
+		val = frappe.generate_hash()
+		frappe.cache.set_value(TEST_KEY, val)
+		time.sleep(0.5)
+
+		with self.assertRedisCallCounts(1):
+			self.assertEqual(frappe.client_cache.get_value(TEST_KEY), val)

--- a/frappe/tests/test_client_cache.py
+++ b/frappe/tests/test_client_cache.py
@@ -25,6 +25,7 @@ class TestClientCache(IntegrationTestCase):
 			self.assertEqual(frappe.client_cache.get_value(TEST_KEY), val)
 
 	def test_invalidation_from_another_client_works(self):
+		frappe.client_cache.reset_statistics()
 		val = frappe.generate_hash()
 		frappe.client_cache.set_value(TEST_KEY, val)
 		self.assertEqual(frappe.client_cache.get_value(TEST_KEY), val)
@@ -38,6 +39,10 @@ class TestClientCache(IntegrationTestCase):
 
 		with self.assertRedisCallCounts(1, exact=True):
 			self.assertEqual(frappe.client_cache.get_value(TEST_KEY), val)
+
+		self.assertEqual(frappe.client_cache.statistics.hits, 1)
+		self.assertEqual(frappe.client_cache.statistics.misses, 1)
+		self.assertEqual(frappe.client_cache.statistics.hit_ratio, 0.5)
 
 	def test_client_local_cache_ttl(self):
 		c = ClientCache(ttl=1)

--- a/frappe/tests/test_client_cache.py
+++ b/frappe/tests/test_client_cache.py
@@ -55,4 +55,4 @@ class TestClientCache(IntegrationTestCase):
 		c.set_value(frappe.generate_hash(), 42)
 		c.set_value(frappe.generate_hash(), 42)
 
-		self.assertEqual(len(c.local_cache), 2)
+		self.assertEqual(len(c.cache), 2)

--- a/frappe/tests/test_client_cache.py
+++ b/frappe/tests/test_client_cache.py
@@ -31,7 +31,9 @@ class TestClientCache(IntegrationTestCase):
 		# frappe.cache is our "another client"
 		val = frappe.generate_hash()
 		frappe.cache.set_value(TEST_KEY, val)
-		time.sleep(0.5)
+		# This is almost instant, but obviously not as fast as running the next instruction in
+		# current thread. So we wait.
+		time.sleep(0.1)
 
 		with self.assertRedisCallCounts(1):
 			self.assertEqual(frappe.client_cache.get_value(TEST_KEY), val)

--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -26,7 +26,7 @@ class TestHooks(IntegrationTestCase):
 		hooks.override_doctype_class = {"ToDo": ["frappe.tests.test_hooks.CustomToDo"]}
 
 		# Clear cache
-		frappe.cache.delete_value("app_hooks")
+		frappe.client_cache.delete_value("app_hooks")
 		clear_controller_cache("ToDo")
 
 		todo = frappe.get_doc(doctype="ToDo", description="asdf")
@@ -53,7 +53,7 @@ class TestHooks(IntegrationTestCase):
 		hooks.has_permission["*"] = wildcard_has_permission_hook
 
 		# Clear cache
-		frappe.cache.delete_value("app_hooks")
+		frappe.client_cache.delete_value("app_hooks")
 
 		# Init User and Address
 		username = "test@example.com"

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -291,20 +291,20 @@ class TestOverheadCalls(FrappeAPITestCase):
 
 	def test_ping_overheads(self):
 		self.get(self.method("ping"), {"sid": "Guest"})
-		with self.assertRedisCallCounts(9), self.assertQueryCount(self.BASE_SQL_CALLS):
+		with self.assertRedisCallCounts(10), self.assertQueryCount(self.BASE_SQL_CALLS):
 			self.get(self.method("ping"), {"sid": "Guest"})
 
 	def test_ping_overheads_authenticated(self):
 		sid = self.sid
 		self.get(self.method("ping"), {"sid": sid})
-		with self.assertRedisCallCounts(9), self.assertQueryCount(self.BASE_SQL_CALLS):
+		with self.assertRedisCallCounts(10), self.assertQueryCount(self.BASE_SQL_CALLS):
 			self.get(self.method("ping"), {"sid": sid})
 
 	def test_list_view_overheads(self):
 		sid = self.sid
 		self.get(self.resource("ToDo"), {"sid": sid})
 		self.get(self.resource("ToDo"), {"sid": sid})
-		with self.assertRedisCallCounts(16), self.assertQueryCount(self.BASE_SQL_CALLS + 1):
+		with self.assertRedisCallCounts(24), self.assertQueryCount(self.BASE_SQL_CALLS + 1):
 			self.get(self.resource("ToDo"), {"sid": sid})
 
 	def test_get_doc_overheads(self):

--- a/frappe/tests/test_webform.py
+++ b/frappe/tests/test_webform.py
@@ -80,4 +80,4 @@ def set_webform_hook(key, value):
 			delattr(hooks, hook)
 
 	setattr(hooks, key, value)
-	frappe.cache.delete_key("app_hooks")
+	frappe.client_cache.delete_value("app_hooks")

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -227,7 +227,7 @@ class TestWebsite(IntegrationTestCase):
 		self.assertEqual(response.headers.get("Location"), "/test")
 
 		delattr(frappe.hooks, "website_redirects")
-		frappe.cache.delete_key("app_hooks")
+		frappe.client_cache.delete_value("app_hooks")
 
 	def test_custom_page_renderer(self):
 		from frappe import get_hooks

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -940,16 +940,17 @@ def get_translations(source_text):
 def get_all_languages(with_language_name: bool = False) -> list:
 	"""Return all enabled language codes ar, ch etc."""
 
-	def get_language_codes():
-		return frappe.get_all("Language", filters={"enabled": 1}, pluck="name")
-
 	def get_all_language_with_name():
 		return frappe.get_all("Language", ["language_code", "language_name"], {"enabled": 1})
 
 	if with_language_name:
 		return frappe.cache.get_value("languages_with_name", get_all_language_with_name)
 	else:
-		return frappe.cache.get_value("languages", get_language_codes)
+		languages = frappe.client_cache.get_value("languages")
+		if not languages:
+			languages = frappe.get_all("Language", filters={"enabled": 1}, pluck="name")
+			frappe.client_cache.set_value("languages", languages)
+		return languages
 
 
 def get_preferred_language_cookie():

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -74,7 +74,7 @@ class RedisWrapper(redis.Redis):
 		with suppress(redis.exceptions.ConnectionError):
 			self.set(name=key, value=pickle.dumps(val, protocol=DEFAULT_PICKLE_PROTOCOL), ex=expires_in_sec)
 
-	def get_value(self, key, generator=None, user=None, expires=False, shared=False):
+	def get_value(self, key, generator=None, user=None, expires=False, shared=False, *, use_local_cache=True):
 		"""Return cache value. If not found and generator function is
 		        given, call the generator.
 
@@ -86,7 +86,7 @@ class RedisWrapper(redis.Redis):
 		key = self.make_key(key, user, shared)
 
 		local_cache = frappe.local.cache
-		if key in local_cache:
+		if key in local_cache and use_local_cache:
 			val = local_cache[key]
 
 		else:
@@ -441,7 +441,7 @@ class _ClientCache:
 		except KeyError:
 			pass  # cache miss
 
-		val = self.redis.get_value(key, shared=True)
+		val = self.redis.get_value(key, shared=True, use_local_cache=False)
 
 		# TODO: distinguish between None result and miss
 		if val is None:

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -455,12 +455,14 @@ class _ClientCache:
 		return val
 
 	def set_value(self, key, val):
-		ret = self.redis.set_value(key, val)
-		return ret
+		key = self.redis.make_key(key)
+		self.redis.set_value(key, val, shared=True)
+		self.local_cache[key] = val
 
 	def delete_value(self, key):
-		ret = self.redis.delete_value(key)
-		return ret
+		key = self.redis.make_key(key)
+		self.redis.delete_value(key, shared=True)
+		self.local_cache.pop(key, None)
 
 	def run_invalidator_thread(self):
 		self._watcher = self.monitor.pubsub()

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -13,6 +13,7 @@ from redis.commands.search import Search
 
 import frappe
 from frappe.utils import cstr
+from frappe.utils.data import cint
 
 # 5 is faster than default which is 4.
 # Python uses old protocol for backward compatibility, we don't support anything <3.10.
@@ -418,6 +419,9 @@ class _ClientCache:
 			connection_class=_TrackedConnection,
 			_monitor_id=self.monitor_id,
 		)
+		protocol = self.redis.get_connection_kwargs().get("protocol")
+		if cint(protocol) == 3:
+			frappe.throw("RESP3 is not supported.")
 		self.invalidator_thread = self.run_invalidator_thread()
 		self.local_cache = {}
 		self._conn_retries = 0

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -529,6 +529,13 @@ class ClientCache:
 		with self.lock:
 			self.cache.pop(key, None)
 
+	def delete_keys(self, pattern):
+		keys = self.redis.get_keys(pattern)
+		self.redis.delete_value(keys, shared=True, make_keys=False)
+		with self.lock:
+			for key in keys:
+				self.cache.pop(key, None)
+
 	def run_invalidator_thread(self):
 		self._watcher = self.invalidator.pubsub()
 		self._watcher.subscribe(**{"__redis__:invalidate": self._handle_invalidation})

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -408,8 +408,6 @@ class _TrackedConnection(redis.Connection):
 
 
 class _ClientCache:
-	INVALIDATE_CHANNELS = ("__redis__:invalidate", b"__redis__:invalidate")
-
 	def __init__(self) -> None:
 		self.monitor = RedisWrapper.from_url(frappe.conf.get("redis_cache"))
 		self.monitor_id = self.monitor.client_id()
@@ -449,7 +447,8 @@ class _ClientCache:
 		return self._watcher.run_in_thread(sleep_time=None, daemon=True)
 
 	def handle_invalidation(self, message):
-		if message["channel"] not in self.INVALIDATE_CHANNELS:
-			return
+		if message["data"] is None:
+			# Flushall
+			self.local_cache.clear()
 		for key in message["data"]:
 			self.local_cache.pop(key, None)

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -425,7 +425,7 @@ class _ClientCache:
 		)
 		protocol = self.redis.get_connection_kwargs().get("protocol")
 		if cint(protocol) == 3:
-			frappe.throw("RESP3 is not supported while connecting to Redis.")
+			frappe.throw("RESP3 is not supported while connecting to Redis.")  # nosemgrep
 		self.invalidator_thread = self.run_invalidator_thread()
 		self.local_cache: dict[bytes, _ClientCacheValue] = {}
 		self.cache_healthy = True

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -542,6 +542,7 @@ class ClientCache:
 		if message["data"] is None:
 			# Flushall
 			self.clear_cache()
+			return
 		with self.lock:
 			for key in message["data"]:
 				self.cache.pop(key, None)

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -462,6 +462,12 @@ class _ClientCache:
 		key = self.redis.make_key(key)
 		self.redis.set_value(key, val, shared=True)
 		self.local_cache[key] = (val, time.monotonic() + self.local_ttl)
+		# XXX: We need to tell redis that we indeed read this key we just wrote
+		# This is an edge case:
+		# - Client A writes a key and reads it again from local cache
+		# - Client B overwrites this key, but since client A never "read" it from Redis, Redis
+		#   doesn't send invalidation.
+		_ = self.redis.get_value(key, shared=True, use_local_cache=False)
 
 	def delete_value(self, key):
 		key = self.redis.make_key(key)

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -433,7 +433,7 @@ class _ClientCache:
 		key = self.redis.make_key(key)
 
 		if time.monotonic() > self.expiration:
-			self.local_cache.clear()
+			self.clear_cache()
 			self.expiration = time.monotonic() + self.ttl
 
 		try:
@@ -474,7 +474,7 @@ class _ClientCache:
 	def _handle_invalidation(self, message):
 		if message["data"] is None:
 			# Flushall
-			self.local_cache.clear()
+			self.clear_cache()
 		for key in message["data"]:
 			self.local_cache.pop(key, None)
 
@@ -487,3 +487,6 @@ class _ClientCache:
 			time.sleep(1)
 		else:
 			raise
+
+	def clear_cache(self):
+		self.local_cache.clear()

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -441,7 +441,7 @@ class _ClientCache:
 		except KeyError:
 			pass  # cache miss
 
-		val = self.redis.get_value(key, shared=True, use_local_cache=False)
+		val = self.redis.get_value(key, shared=True, use_local_cache=not self.cache_healthy)
 
 		# Note: We should not "cache" the cache-misses in client cache.
 		# This cache is long lived and "misses" are not tracked by redis so they'll never get


### PR DESCRIPTION
> It's a Bird... It's a Plane... It's ~~Redis~~ dict[str, Any].

Why?
- Frequently fetching same things that dont change for days is bad: https://ankush.dev/p/flamegraph-missing-forest-for-trees
- We can afford to spend some more memory / worker. I am budgeting for at least 5MB/worker to speed up repeated Redis cache access.


TODO:
- [x] Finalize "design":
	- Redis-py's official implementation supports a lot of things but it's also very slow compared to this basic implementation.
	- Currently I only intend to support get/set/delete.
	- hset/hget/hdel and any other fancy feature won't be supported. They are misused everywhere in current codebase.
	- This cache has to be inflexible enough so I can control most variables for best perf. So I don't intend to expose this to applications just yet. Indirectly all apps benefit anyway.
	- There is no partitioning between `cache` and `client_cache` they read the same exact data and can invalidate each other. This is done to allow progressive refactoring. Since we don't use `BCAST` mode this has no extra costs. 
- [x] Make it thread-safe
- [x] Check for data races
- [x] Add a fixed TTL
- [x] Limit # of keys, budget for 5-10MB of memory usage per worker.
- [ ] Somehow only enable in long-lived processes? RQ's forked worker don't benefit and add extra overhead.
- [x] try to reduce # of connections required - 3 -> 2?
- [x] PubSub thread reliability:
	- [x] Add exc handler
	- [x] ~Unsubscribe on closing?~ not required? We exit completely. 
	- [x] Disable on losing connection, ~~reattach somehow?~~ (Unnecessary overengineering)
- [x] Migrate majority of repeated accesses that don't change often to client-cache
  - [x] meta
  - [x] recorder
  - [x] `is_table`
  - [x] module map
  - [x] hooks
  - [x] languages
  - [x] defaults
  - [x] system settings
  - [x] ~translations~ too big
  - [x] server script map
  - [x] More? In separate PRs as we discover them
- [x] tests
- [x] add docs inside code
- [x] use per-key TTL, avoid cache stampede 

Reference:
- https://redis.io/docs/latest/develop/reference/client-side-caching/


Numbers: 

| Benchmark    | meta_before | meta_after              |
|--------------|:-----------:|:-----------------------:|
| orm_get_meta | 11.0 ms     | 82.5 us: 132.83x faster |

(More to come)


`no-docs` - Strictly internal, please don't use this outside of the framework. There be dragons. 