### PR TITLE
refactor: temporary key for child rows

### DIFF
--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -20,6 +20,10 @@ def savedocs(doc, action):
 	if doc.get("__islocal") and doc.name.startswith("new-" + doc.doctype.lower().replace(" ", "-")):
 		# required to relink missing attachments if they exist.
 		doc.__temporary_name = doc.name
+
+	for child in doc.get_all_children():
+		child.__temporary_name = child.name
+
 	set_local_name(doc)
 
 	# action

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -353,6 +353,7 @@ class BaseDocument:
 
 		if not getattr(value, "name", None):
 			value.__dict__["__islocal"] = 1
+			value.__dict__["__temporary_name"] = frappe.generate_hash(length=10)
 
 		return value
 


### PR DESCRIPTION
# Scenario
Some child table rows need to store permanent reference of it's siblings

# Current Limitation
## UI (Desk) based usage
When the document is unsaved, framework gives them a throwaway `name` like `new-sales-invoice-item-sdjkfg`. Upon `save`, permanent names are generated which overrides `name`.

## Server-side usage
Ex: When a document is created directly on the server-side
Here, framework does not give any throwaway name. But there is still the need to uniquely identify rows.

# Light-weight solution
An attribute `__temporary_row_key` on each child table row can help in mapping the rows before and after save.

Ex:
Before saving the document, throwaway names' are stored as attribute
```
| name                          | ... | attribute '__temporary_name'  |
|-------------------------------+-----+-------------------------------|
| new-sales-invoice-item-sdjkfg |     | new-sales-invoice-item-sdjkfg |
| new-sales-invoice-item-eirwhn |     | new-sales-invoice-item-eirwhn |
```

Upon save, permanent names' are generated. But the attribute can be used to map throwaway key with permanent key
```
| name   | ... | attribute '__temporary_name'  |
|--------+-----+-------------------------------|
| poiurt |     | new-sales-invoice-item-sdjkfg |
| tuincs |     | new-sales-invoice-item-eirwhn |
```


Required for: https://github.com/frappe/erpnext/issues/44929