### PR TITLE
perf: skip link checking on property setters

### DIFF
--- a/frappe/custom/doctype/property_setter/property_setter.py
+++ b/frappe/custom/doctype/property_setter/property_setter.py
@@ -110,4 +110,4 @@ def delete_property_setter(doc_type, property=None, field_name=None, row_name=No
 
 	property_setters = frappe.db.get_values("Property Setter", filters)
 	for ps in property_setters:
-		frappe.get_doc("Property Setter", ps).delete(ignore_permissions=True)
+		frappe.get_doc("Property Setter", ps).delete(ignore_permissions=True, force=True)


### PR DESCRIPTION
These are internal and never "back linked"
