### PR TITLE
fix(style): padding added in query-report view

### DIFF
--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -86,6 +86,8 @@
 
 .report-wrapper {
 	overflow: auto;
+	padding-left: 15px;
+	padding-right: 15px;
 }
 
 .report-view {
@@ -290,4 +292,8 @@
 	.group-by-box .row > div[class*="col-sm-"] {
 		margin-bottom: 5px;
 	}
+}
+
+.input-group > * {
+	margin-right: 10px;
 }


### PR DESCRIPTION
Before:
<img width="1280" alt="padding -report" src="https://github.com/user-attachments/assets/b5042ab1-df36-46c9-bc45-bf22e57fb1de" />


After:
<img width="1318" alt="Screenshot 2025-01-03 at 10 54 01 AM" src="https://github.com/user-attachments/assets/a0f08a1b-c9ec-4719-81ee-efae2642a693" />

Resolves frappe/erpnext#44984