### PR TITLE
perf: Evict site cache only on `frappe.clear_cache()`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -968,7 +968,9 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 		for fn in get_hooks("clear_cache"):
 			get_attr(fn)()
 
-	frappe.utils.caching._SITE_CACHE.clear()
+	if (not doctype and not user) or doctype == "DocType":
+		frappe.utils.caching._SITE_CACHE.clear()
+
 	local.role_permissions = {}
 	if hasattr(local, "request_cache"):
 		local.request_cache.clear()


### PR DESCRIPTION
For doctype/user specific cache eviction, no need to remove site_cache.

Rationale:
- Site cache is worker specific, so this eviction doesn't help much.
- Anything that might need to be evicted from site cache should be
  manually cleared or use a TTL.

Maybe we can just replace all of site_cache usage with
https://github.com/frappe/frappe/pull/28992 once it's stable.
