### PR TITLE
perf: Skip link checking on internal deletes

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -150,7 +150,7 @@ def remove(doctype, role, permlevel, if_owner=0):
 		"Custom DocPerm", {"parent": doctype, "role": role, "permlevel": permlevel, "if_owner": if_owner}
 	)
 	for name in custom_docperms:
-		frappe.delete_doc("Custom DocPerm", name, ignore_permissions=True)
+		frappe.delete_doc("Custom DocPerm", name, ignore_permissions=True, force=True)
 
 	if not frappe.get_all("Custom DocPerm", {"parent": doctype}):
 		frappe.throw(_("There must be atleast one permission rule."), title=_("Cannot Remove"))

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -110,7 +110,7 @@ class Event(Document):
 		)
 		if communications:
 			for communication in communications:
-				frappe.delete_doc_if_exists("Communication", communication.name)
+				frappe.delete_doc_if_exists("Communication", communication.name, force=True)
 
 	def sync_communication(self):
 		if self.event_participants:

--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -75,7 +75,7 @@ def unfollow_document(doctype, doc_name, user):
 		limit=1,
 	)
 	if doc:
-		frappe.delete_doc("Document Follow", doc[0].name)
+		frappe.delete_doc("Document Follow", doc[0].name, force=True)
 		frappe.toast(_("Un-following document {0}").format(doc_name))
 		return False
 	return False

--- a/frappe/desk/like.py
+++ b/frappe/desk/like.py
@@ -83,6 +83,7 @@ def remove_like(doctype, name):
 			)
 		],
 		ignore_permissions=True,
+		force=True,
 	)
 
 

--- a/frappe/email/doctype/email_group/email_group.py
+++ b/frappe/email/doctype/email_group/email_group.py
@@ -93,7 +93,7 @@ class EmailGroup(Document):
 
 	def on_trash(self):
 		for d in frappe.get_all("Email Group Member", "name", {"email_group": self.name}):
-			frappe.delete_doc("Email Group Member", d.name)
+			frappe.delete_doc("Email Group Member", d.name, force=True)
 
 
 @frappe.whitelist()

--- a/frappe/email/inbox.py
+++ b/frappe/email/inbox.py
@@ -75,7 +75,7 @@ def create_email_flag_queue(names, action):
 
 			for queue in email_flag_queue:
 				if queue.action != action:
-					frappe.delete_doc("Email Flag Queue", queue.name, ignore_permissions=True)
+					frappe.delete_doc("Email Flag Queue", queue.name, ignore_permissions=True, force=True)
 				elif queue.action == action:
 					# Read or Unread request for email is already available
 					create_new = False

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -263,7 +263,7 @@ def update_assignments(old: str, new: str, doctype: str) -> None:
 		)
 
 		for todo in todos:
-			frappe.delete_doc("ToDo", todo.name)
+			frappe.delete_doc("ToDo", todo.name, force=True)
 
 	unique_assignments = list(set(old_assignments + new_assignments))
 	frappe.db.set_value(doctype, new, "_assign", frappe.as_json(unique_assignments, indent=0))

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -161,7 +161,7 @@ class OAuthWebRequestValidator(RequestValidator):
 
 			if code_challenge and not request.code_verifier:
 				if frappe.db.exists("OAuth Authorization Code", code):
-					frappe.delete_doc("OAuth Authorization Code", code, ignore_permissions=True)
+					frappe.delete_doc("OAuth Authorization Code", code, ignore_permissions=True, force=True)
 					frappe.db.commit()
 				return False
 

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -572,7 +572,7 @@ def remove_user_permission(doctype, name, user):
 	user_permission_name = frappe.db.get_value(
 		"User Permission", dict(user=user, allow=doctype, for_value=name)
 	)
-	frappe.delete_doc("User Permission", user_permission_name)
+	frappe.delete_doc("User Permission", user_permission_name, force=True)
 
 
 def clear_user_permissions_for_doctype(doctype, user=None):
@@ -581,7 +581,7 @@ def clear_user_permissions_for_doctype(doctype, user=None):
 		filters["user"] = user
 	user_permissions_for_doctype = frappe.get_all("User Permission", filters=filters)
 	for d in user_permissions_for_doctype:
-		frappe.delete_doc("User Permission", d.name)
+		frappe.delete_doc("User Permission", d.name, force=True)
 
 
 def can_import(doctype, raise_exception=False):
@@ -692,7 +692,7 @@ def reset_perms(doctype):
 
 	delete_notification_count_for(doctype)
 	for custom_docperm in frappe.get_all("Custom DocPerm", filters={"parent": doctype}, pluck="name"):
-		frappe.delete_doc("Custom DocPerm", custom_docperm, ignore_permissions=True)
+		frappe.delete_doc("Custom DocPerm", custom_docperm, ignore_permissions=True, force=True)
 
 
 def get_linked_doctypes(dt: str) -> list:


### PR DESCRIPTION
These are deletes that aren't user triggered and these documents are
typically never "linked" somewhere else. So skip all expensive link /
dynamic link checks.
