### PR TITLE
feat(create_new): drop fieldtype check for filling from route

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -60,11 +60,7 @@ $.extend(frappe.model, {
 		if (frappe.route_options && !doc.parent) {
 			$.each(frappe.route_options, function (fieldname, value) {
 				var df = frappe.meta.has_field(doctype, fieldname);
-				if (
-					df &&
-					["Link", "Data", "Select", "Dynamic Link"].includes(df.fieldtype) &&
-					!df.no_copy
-				) {
+				if (df && !df.no_copy) {
 					doc[fieldname] = value;
 				}
 			});


### PR DESCRIPTION
__Seems__ to be fine now, maybe caused issues when added in 2016

Tried a few scenarios, route options is cleared going from list -> create page

Might cause issues with quick entry - let's see

<hr>

Reference: support ticket 28774
