### PR TITLE
refactor: hide sidebar

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -172,7 +172,6 @@ frappe.views.BaseList = class BaseList {
 		this.page.main.addClass("layout-main-list");
 		this.page.page_form.removeClass("row").addClass("flex");
 		this.hide_page_form && this.page.page_form.hide();
-		this.hide_sidebar && this.$page.addClass("no-list-sidebar");
 		this.setup_page_head();
 	}
 
@@ -277,7 +276,10 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	setup_side_bar() {
-		if (this.hide_sidebar || !frappe.boot.desk_settings.list_sidebar) return;
+		if (this.page.disable_sidebar_toggle) {
+			return;
+		}
+
 		this.list_sidebar = new frappe.views.ListSidebar({
 			doctype: this.doctype,
 			stats: this.stats,

--- a/frappe/public/js/frappe/list/list_factory.js
+++ b/frappe/public/js/frappe/list/list_factory.js
@@ -27,9 +27,11 @@ frappe.views.ListFactory = class ListFactory extends frappe.views.Factory {
 
 		frappe.provide("frappe.views.list_view." + doctype);
 
+		const hide_sidebar = view_class.no_sidebar || !frappe.boot.desk_settings.list_sidebar;
+
 		frappe.views.list_view[me.page_name] = new view_class({
 			doctype: doctype,
-			parent: me.make_page(true, me.page_name, "Right"),
+			parent: me.make_page(true, me.page_name, hide_sidebar ? null : "Right"),
 		});
 
 		me.set_cur_list();

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1777,7 +1777,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		items.push({
 			label: __("Toggle Sidebar", null, "Button in list view menu"),
 			action: () => this.toggle_side_bar(),
-			condition: () => !this.hide_sidebar,
+			condition: () => !this.page.disable_sidebar_toggle,
 			standard: true,
 			shortcut: "Ctrl+K",
 		});

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -194,6 +194,7 @@ frappe.ui.Page = class Page {
 		let sidebar_wrapper = this.wrapper.find(".layout-side-section");
 		if (this.disable_sidebar_toggle || !sidebar_wrapper.length) {
 			sidebar_toggle.last().remove();
+			this.wrapper.addClass("no-list-sidebar");
 		} else {
 			if (!frappe.is_mobile()) {
 				sidebar_toggle.attr("title", __("Toggle Sidebar"));

--- a/frappe/public/js/frappe/views/dashboard/dashboard_view.js
+++ b/frappe/public/js/frappe/views/dashboard/dashboard_view.js
@@ -5,6 +5,8 @@ frappe.views.DashboardView = class DashboardView extends frappe.views.ListView {
 		return "Dashboard";
 	}
 
+	static no_sidebar = true;
+
 	setup_defaults() {
 		return super.setup_defaults().then(() => {
 			this.page_title = __("{0} Dashboard", [__(this.doctype)]);
@@ -16,7 +18,6 @@ frappe.views.DashboardView = class DashboardView extends frappe.views.ListView {
 	render() {}
 
 	setup_page() {
-		this.hide_sidebar = true;
 		this.hide_page_form = true;
 		this.hide_filters = true;
 		this.hide_sort_selector = true;

--- a/frappe/public/js/frappe/views/factory.js
+++ b/frappe/public/js/frappe/views/factory.js
@@ -45,6 +45,7 @@ frappe.make_page = function (double_column, page_name, sidebar_position) {
 		parent: page,
 		single_column: !double_column,
 		sidebar_position: sidebar_position,
+		disable_sidebar_toggle: !sidebar_position,
 	});
 
 	frappe.container.change_to(page_name);

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -4,6 +4,7 @@ frappe.provide("frappe.views");
 
 frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 	static full_page = true;
+	static no_sidebar = true;
 
 	static load_last_view() {
 		const route = frappe.get_route();
@@ -133,14 +134,10 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 	}
 
 	setup_page() {
-		this.hide_sidebar = true;
 		this.hide_page_form = true;
 		this.hide_card_layout = true;
 		this.hide_sort_selector = true;
 		super.setup_page();
-
-		this.page.disable_sidebar_toggle = true;
-		this.page.setup_sidebar_toggle();
 	}
 
 	setup_view() {


### PR DESCRIPTION
The sidebar is part of the page, which is created before the view. Hiding the sidebar should not be the responsibility of the view. E.g. because it causes flickers due to the sidebar being loaded first and then hidden again.

With this PR, views can have static a property `no_sidebar`. This is read before the page is created. The page controller can then correctly skip the sidebar creation.

This also resolves a bug in v15 where the sidebar toggle was still visible even though the sidebar was disabled for the user.

Ideas how to test this PR:

- Sidebar is visible in list view, if not disabled for the user
- Sidebar and sidebar toggle are not visible in list view, if disabled for the user
- Sidebar is not visible in Kanban and dashboard view
- If commenting out the `no_sidebar` property on kanban or dashboard view, the sidebar is visible