### PR TITLE
feat: display two lines in image view

### DIFF
--- a/frappe/public/scss/desk/image_view.scss
+++ b/frappe/public/scss/desk/image_view.scss
@@ -160,6 +160,13 @@
 
 			.ellipsis {
 				vertical-align: bottom;
+
+				// Display two lines instead of one
+				white-space: normal;
+				display: -webkit-box;
+				line-clamp: 2;
+				-webkit-line-clamp: 2;
+				-webkit-box-orient: vertical;
 			}
 
 			display: flex;


### PR DESCRIPTION
### Before
Long titles are cut after one line

![Bildschirmfoto 2025-01-06 um 22 01 22](https://github.com/user-attachments/assets/58ccf8b8-291b-4656-b2bf-76ab646564b6)


### After
Long titles are cut after two lines

![Bildschirmfoto 2025-01-06 um 22 00 21](https://github.com/user-attachments/assets/7ee4070f-879f-4e7c-8e14-1803c9fdecc9)

> no-docs