### PR TITLE
fix: spacing issue between field and label

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -21,7 +21,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 				`<div class="frappe-control">
 				<div class="form-group">
 					<div class="clearfix">
-						<label class="control-label" style="padding-right: 0px;"></label>
+						<label class="control-label" style="padding-right: 1px;"></label>
 						<span class="help"></span>
 					</div>
 					<div class="control-input-wrapper">


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/44673

> Please provide enough information so that others can review your pull request:

- Fixes the issue where the label was overlapping or sticking to the input field. Added padding to create proper spacing between the label and the field

### Before
![image](https://github.com/user-attachments/assets/60c153fd-1cba-4351-948d-9df9c97b89c2)

### After
![image](https://github.com/user-attachments/assets/3d3bb43c-3d90-4d35-87ce-598f893923db)


