### PR TITLE
perf: do not validate user on session resume

### DIFF
--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -205,7 +205,9 @@ class Session:
 	__slots__ = ("_update_in_cache", "data", "full_name", "sid", "time_diff", "user", "user_type")
 
 	def __init__(self, user, resume=False, full_name=None, user_type=None):
-		self.sid = cstr(frappe.form_dict.get("sid") or unquote(frappe.request.cookies.get("sid", "Guest")))
+		self.sid = cstr(
+			frappe.form_dict.pop("sid", None) or unquote(frappe.request.cookies.get("sid", "Guest"))
+		)
 		self.user = user
 		self.user_type = user_type
 		self.full_name = full_name

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -303,7 +303,6 @@ class Session:
 		if data:
 			self.data.update({"data": data, "user": data.user, "sid": self.sid})
 			self.user = data.user
-			self.validate_user()
 			validate_ip_address(self.user)
 		else:
 			self.start_as_guest()


### PR DESCRIPTION
If session is active then obviously user is enabled. When users are disabled their active sessions are cleared.
