### PR TITLE
fix: active tab minor misalignment issue

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -501,6 +501,7 @@
 					font-weight: 600;
 					border-bottom: 1px solid var(--primary);
 					color: var(--text-color);
+					padding-bottom: 9px;
 				}
 			}
 		}


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/45135

> Explain the **details** for making this change. What existing problem does the pull request solve?

Previously, it was moving text up to 1 pixel when switching tabs; now, it doesn't move the text up or down 1 pixel when switching tabs.

## Screenshots/GIFs
### Before

https://github.com/user-attachments/assets/718494b4-bc6a-4528-8f67-9756089d33f4

### After

https://github.com/user-attachments/assets/bea3f089-f4f3-42b4-961d-da8eecbc7b46

