### PR TITLE
fix: misalignment of attachment icon and title

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -147,7 +147,7 @@ frappe.ui.form.Attachments = class Attachments {
 			};
 		}
 
-		const icon = `<a href="/app/file/${fileid}">
+		const icon = `<a href="/app/file/${fileid}" class="attachment-icon">
 				${frappe.utils.icon(attachment.is_private ? "es-line-lock" : "es-line-unlock", "sm ml-0")}
 			</a>`;
 

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -766,6 +766,9 @@ body {
 			margin-left: var(--margin-xs);
 			text-align: left;
 		}
+		.attachment-icon {
+			line-height: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/45136

> Explain the **details** for making this change. What existing problem does the pull request solve?

- The padlock icon and filename were not vertically aligned due to an issue with line height.
- Setting the line-height property to 0 resolves the misalignment and ensures proper vertical alignment of the elements.

> Screenshots/GIFs

- Before
![image](https://github.com/user-attachments/assets/0a9220d7-ebc0-489f-bc55-660cc95837c0)


- After
![image](https://github.com/user-attachments/assets/0c5002b4-fb42-45e5-a2be-8da44a4102d8)

