### PR TITLE
fix: splash logo is not rendering properly

### DIFF
--- a/frappe/templates/includes/splash_screen.html
+++ b/frappe/templates/includes/splash_screen.html
@@ -1,4 +1,4 @@
 <div class="centered splash">
 	<img src="{{ splash_image or "/assets/frappe/images/frappe-framework-logo.svg" }}"
-		style="width: 100px; height: 100px;">
+		style="width: auto; max-width: 200px;">
 </div>


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/45072

> Explain the **details** for making this change. What existing problem does the pull request solve?

The Splash image was not rendering properly due to fixed height and width values.

- Removed the fixed height and width attributes.
- Set a max-width to ensure the image scales properly without breaking its layout.

> Screenshots/GIFs

- Before
![image](https://github.com/user-attachments/assets/bb89195a-cac1-43be-bd4b-ce6190fbbd30)

- After
![image](https://github.com/user-attachments/assets/a4d5509e-a318-46bf-9b11-924cf76f815d)

