### PR TITLE
fix: Treeview ux cleanup

### DIFF
--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -33,6 +33,7 @@
 			</div>
 			<div class="flex col page-actions justify-content-end">
 				<!-- buttons -->
+				<div class="filters"></div>
 				<div class="custom-actions hide hidden-xs hidden-md"></div>
 				<div class="standard-actions flex">
 					<span class="page-icon-group hide hidden-xs hidden-sm"></span>

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -1,6 +1,6 @@
 <div class="page-head flex">
 	<div class="container">
-		<div class="row flex align-center page-head-content justify-between">
+		<div class="row flex-nowrap align-center page-head-content justify-between">
 			<div class="col-md-4 col-sm-6 col-xs-7 page-title">
 				<!-- <div class="title-image hide hidden-md hidden-lg"></div> -->
 				<!-- title -->

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -33,7 +33,7 @@
 			</div>
 			<div class="flex col page-actions justify-content-end">
 				<!-- buttons -->
-				<div class="filters"></div>
+				<div class="filters flex"></div>
 				<div class="custom-actions hide hidden-xs hidden-md"></div>
 				<div class="standard-actions flex">
 					<span class="page-icon-group hide hidden-xs hidden-sm"></span>

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -636,7 +636,10 @@ frappe.ui.Page = class Page {
 			});
 		}
 	}
-
+	add_divider_to_button_group(group) {
+		var $group = this.get_or_add_inner_group_button(group);
+		$('<li class="dropdown-divider"></li>').appendTo($group.find(".dropdown-menu"));
+	}
 	/*
 	 * Add button to button group. If there exists another button with the same label,
 	 * `add_inner_button` will not add the new button to the button group even if the callback

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -593,7 +593,7 @@ frappe.ui.Page = class Page {
 		return $('<li class="dropdown-divider"></li>').appendTo(this.menu);
 	}
 
-	get_or_add_inner_group_button(label) {
+	get_or_add_inner_group_button(label, align_right) {
 		var $group = this.inner_toolbar.find(
 			`.inner-group-button[data-label="${encodeURIComponent(label)}"]`
 		);
@@ -604,7 +604,7 @@ frappe.ui.Page = class Page {
 						${label}
 						${frappe.utils.icon("select", "xs")}
 					</button>
-					<div role="menu" class="dropdown-menu"></div>
+					<div role="menu" class="dropdown-menu ${align_right ? "dropdown-menu-right" : ""}"></div>
 				</div>`
 			).appendTo(this.inner_toolbar);
 		}
@@ -650,7 +650,7 @@ frappe.ui.Page = class Page {
 	 * @param {object} action - function to be called when button is clicked
 	 * @param {string} group - Label of the group button
 	 */
-	add_inner_button(label, action, group, type = "default") {
+	add_inner_button(label, action, group, type = "default", align_right = false) {
 		var me = this;
 		let _action = function () {
 			let btn = $(this);
@@ -667,7 +667,7 @@ frappe.ui.Page = class Page {
 		}
 
 		if (group) {
-			var $group = this.get_or_add_inner_group_button(group);
+			var $group = this.get_or_add_inner_group_button(group, align_right);
 			$(this.inner_toolbar).removeClass("hide");
 
 			if (!this.is_in_group_button_dropdown($group.find(".dropdown-menu"), "a", label)) {

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -135,6 +135,7 @@ frappe.ui.Page = class Page {
 		this.indicator = this.wrapper.find(".indicator-pill");
 
 		this.page_actions = this.wrapper.find(".page-actions");
+		this.filters = this.wrapper.find(".filters");
 
 		this.btn_primary = this.page_actions.find(".primary-action");
 		this.btn_secondary = this.page_actions.find(".btn-secondary");
@@ -890,6 +891,9 @@ frappe.ui.Page = class Page {
 				delay: { show: 600, hide: 100 },
 				trigger: "hover",
 			});
+		if (parent == this.filters) {
+			this.restyle_field(f);
+		}
 
 		// html fields in toolbar are only for display
 		if (df.fieldtype == "HTML") {
@@ -913,6 +917,12 @@ frappe.ui.Page = class Page {
 		if (df["default"]) f.set_input(df["default"]);
 		this.fields_dict[df.fieldname || df.label] = f;
 		return f;
+	}
+	restyle_field(f) {
+		$(f.wrapper).removeClass("col-md-2").css("margin", "0px");
+
+		$(f.wrapper).find("select").css("width", "140px");
+		$(f.wrapper).find(".select-icon").css("top", "2px");
 	}
 	clear_fields() {
 		this.page_form.empty();

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -108,14 +108,13 @@ frappe.views.TreeView = class TreeView {
 		}
 
 		if (frappe.meta.has_field(me.doctype, "disabled")) {
-			$(
-				"<div class='checkbox'><label><input type='checkbox'> Include Disabled </label></div>"
-			).appendTo(this.page.inner_toolbar);
-			this.page.inner_toolbar
-				.addClass("flex align-center")
-				.on("click", "input[type='checkbox']", function () {
+			this.page.add_inner_button(
+				__("Include Disabled"),
+				function () {
 					me.rebuild_tree();
-				});
+				},
+				__("Expand")
+			);
 		}
 
 		if (this.opts.show_expand_all) {

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -173,7 +173,11 @@ frappe.views.TreeView = class TreeView {
 				};
 			}
 
-			me.page.add_field(filter);
+			if (filter.render_on_toolbar) {
+				me.page.add_field(filter, me.page.filters);
+			} else {
+				me.page.add_field(filter);
+			}
 
 			if (filter.default) {
 				$("[data-fieldname='" + filter.fieldname + "']").trigger("change");

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -1,6 +1,5 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // MIT License. See license.txt
-
 frappe.provide("frappe.treeview_settings");
 frappe.provide("frappe.views.trees");
 window.cur_tree = null;
@@ -110,7 +109,8 @@ frappe.views.TreeView = class TreeView {
 			this.page.add_inner_button(
 				__("Include Disabled"),
 				function () {
-					me.rebuild_tree();
+					me.toggle_disable(event.target);
+					me.make_tree();
 				},
 				__("Expand"),
 				"default",
@@ -203,6 +203,16 @@ frappe.views.TreeView = class TreeView {
 			},
 		});
 	}
+	toggle_disable(el) {
+		if (this.args["include_disabled"]) {
+			this.args["include_disabled"] = false;
+			el.innerText = el.innerText.replace("Exclude", "Include");
+		} else {
+			this.args["include_disabled"] = true;
+			console.log(el);
+			el.innerText = el.innerText.replace("Include", "Exclude");
+		}
+	}
 	make_tree() {
 		$(this.parent).find(".tree").remove();
 
@@ -210,12 +220,6 @@ frappe.views.TreeView = class TreeView {
 		var use_value = this.root_value;
 		if (use_value == null) {
 			use_value = use_label;
-		}
-
-		if (this.page?.inner_toolbar) {
-			this.args["include_disabled"] = this.page.inner_toolbar
-				.find("input[type='checkbox']")
-				.prop("checked");
 		}
 
 		this.tree = new frappe.ui.Tree({
@@ -242,10 +246,11 @@ frappe.views.TreeView = class TreeView {
 		cur_tree.view_name = "Tree";
 		this.post_render();
 	}
-
+	toggle_label() {
+		console.log("hello");
+	}
 	rebuild_tree() {
 		let me = this;
-
 		frappe.call({
 			method: "frappe.utils.nestedset.rebuild_tree",
 			args: {

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -61,7 +61,6 @@ frappe.views.TreeView = class TreeView {
 		this.make_page();
 		this.make_filters();
 		this.root_value = null;
-
 		if (me.opts.get_tree_root) {
 			this.get_root();
 		}
@@ -113,7 +112,9 @@ frappe.views.TreeView = class TreeView {
 				function () {
 					me.rebuild_tree();
 				},
-				__("Expand")
+				__("Expand"),
+				"default",
+				true
 			);
 		}
 
@@ -123,7 +124,9 @@ frappe.views.TreeView = class TreeView {
 				function () {
 					me.tree.load_children(me.tree.root_node, false);
 				},
-				__("Expand")
+				__("Expand"),
+				"default",
+				true
 			);
 
 			this.page.add_inner_button(
@@ -131,7 +134,9 @@ frappe.views.TreeView = class TreeView {
 				function () {
 					me.tree.load_children(me.tree.root_node, true);
 				},
-				__("Expand")
+				__("Expand"),
+				"default",
+				true
 			);
 		}
 
@@ -186,7 +191,6 @@ frappe.views.TreeView = class TreeView {
 	}
 	get_root() {
 		var me = this;
-
 		frappe.call({
 			method: me.get_tree_nodes,
 			args: me.args,

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -119,13 +119,21 @@ frappe.views.TreeView = class TreeView {
 		}
 
 		if (this.opts.show_expand_all) {
-			this.page.add_inner_button(__("Collapse All"), function () {
-				me.tree.load_children(me.tree.root_node, false);
-			});
+			this.page.add_inner_button(
+				__("Collapse All"),
+				function () {
+					me.tree.load_children(me.tree.root_node, false);
+				},
+				__("Expand")
+			);
 
-			this.page.add_inner_button(__("Expand All"), function () {
-				me.tree.load_children(me.tree.root_node, true);
-			});
+			this.page.add_inner_button(
+				__("Expand All"),
+				function () {
+					me.tree.load_children(me.tree.root_node, true);
+				},
+				__("Expand")
+			);
 		}
 
 		if (this.opts.view_template) {

--- a/frappe/public/scss/common/flex.scss
+++ b/frappe/public/scss/common/flex.scss
@@ -7,6 +7,11 @@
 	flex-direction: column;
 }
 
+.flex-nowrap {
+	@extend .flex;
+	flex-wrap: nowrap;
+}
+
 .justify-center {
 	justify-content: center;
 }


### PR DESCRIPTION
This PR fixes

1. On a window resize the page head was wrapping text now it has a flex-wrap
2. The include disabled , collpase/ expand all, is merged into the same button group
3. added a divider to button group method
4. dropdown alignment is configurable through function
5. filter can be on rendered on toolbar with render_on_toolbar flag in filters in treeview

<img width="1038" alt="coa resize" src="https://github.com/user-attachments/assets/6934d12e-5daa-4765-adc4-cd8a0a15cc1a" />



https://github.com/user-attachments/assets/929757e9-b1e7-4dde-9a98-e6d85fb8a503



