### PR TITLE
fix: hide dropdown top separator in desktop view

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -517,9 +517,9 @@ frappe.ui.Page = class Page {
 		} else {
 			this.divider = parent.find(".dropdown-divider.user-action");
 			if (!this.divider.length) {
-				this.divider = $('<li class="dropdown-divider user-action"></li>').prependTo(
-					parent
-				);
+				this.divider = $(
+					'<li class="dropdown-divider user-action visible-xs"></li>'
+				).prependTo(parent);
 			}
 			$li.addClass("user-action").insertBefore(this.divider);
 		}


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/45137

> Explain the **details** for making this change. What existing problem does the pull request solve?

Previously, the refresh button was visible only on XS screens, while the divider was visible across all screen sizes. This update ensures that the divider is now only shown on XS screens, providing a more consistent and responsive design.

> Screenshots/GIFs

- Before
![image](https://github.com/user-attachments/assets/13ed31c4-c9de-4bfe-a953-b1e9fca9cdab)

- After
![image](https://github.com/user-attachments/assets/974cec7e-7827-4cc6-8628-1ac2b300826a)

