### PR TITLE
fix(style): fix right sidebar height

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -513,7 +513,6 @@ body {
 	// padding-right: 30px;
 	width: 220px;
 	border-left: 1px solid var(--border-color);
-	height: 100vh;
 	.sidebar-section {
 		padding: var(--padding-md);
 		border-bottom: 1px solid var(--border-color);


### PR DESCRIPTION
This PR fixes layout height issues and overflow issues
Before 
<img width="1440" alt="Remove overflow" src="https://github.com/user-attachments/assets/27ab9d02-e258-44ed-a83e-6cdaf39200d9" />

![6048443933350021094](https://github.com/user-attachments/assets/1c8cad47-2614-49b0-b7cb-2801b6db0c2b)


After:

https://github.com/user-attachments/assets/0d35ea33-b473-4c83-a2dc-dfd747a6bd3c

