### PR TITLE
fix: Improper routing for Report links when added to cards in workspaces

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1304,8 +1304,7 @@ Object.assign(frappe.utils, {
 				if (item.is_query_report) {
 					route = "query-report/" + item.name;
 				} else if (!item.is_query_report && item.report_ref_doctype) {
-					route =
-						frappe.router.slug(item.report_ref_doctype) + "/view/report/";
+					route = frappe.router.slug(item.report_ref_doctype) + "/view/report/";
 				} else {
 					route = "report/" + item.name;
 				}

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1305,7 +1305,7 @@ Object.assign(frappe.utils, {
 					route = "query-report/" + item.name;
 				} else if (!item.is_query_report && item.report_ref_doctype) {
 					route =
-						frappe.router.slug(item.report_ref_doctype) + "/view/report/" + item.name;
+						frappe.router.slug(item.report_ref_doctype) + "/view/report/";
 				} else {
 					route = "report/" + item.name;
 				}


### PR DESCRIPTION
Adding links for reports to cards rendered incorrect URLs. Fixed the client-side function to render it properly.
<img width="577" alt="Screenshot 2025-01-09 at 6 26 29 PM" src="https://github.com/user-attachments/assets/f64b8468-c5f9-4c70-9ab4-d619e46f1331" />

Before:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/24956f0d-9277-4b02-8226-3bf1695caa8d" />

After:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/419fadbc-cca9-4e9c-a91f-947064a79b64" />
