### PR TITLE
Make get_default_contact whitelist

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -253,7 +253,7 @@ def download_vcards(contacts: str):
 	frappe.response["filecontent"] = "\n".join(vcards).encode("utf-8")
 	frappe.response["type"] = "binary"
 
-
+@frappe.whitelist()
 def get_default_contact(doctype, name):
 	"""Return default contact for the given doctype, name."""
 	out = frappe.db.sql(


### PR DESCRIPTION
Like `get_default_address` whitelisted make `get_default_contact` whitelisted too, in order to fetch default contact from client side.