### PR TITLE
feat: Allow for configurable persistant cron jobs without hooks.py

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -14,6 +14,7 @@
   "stopped",
   "method",
   "server_script",
+  "scheduler_event",
   "frequency",
   "cron_format",
   "create_log",
@@ -93,6 +94,13 @@
   {
    "fieldname": "column_break_9",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "scheduler_event",
+   "fieldtype": "Link",
+   "label": "Scheduler Event",
+   "options": "Scheduler Event",
+   "read_only": 1
   }
  ],
  "in_create": 1,
@@ -102,7 +110,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2024-03-30 11:39:49.693632",
+ "modified": "2025-01-13 10:39:39.975031",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -44,6 +44,7 @@ class ScheduledJobType(Document):
 		last_execution: DF.Datetime | None
 		method: DF.Data
 		next_execution: DF.Datetime | None
+		scheduler_event: DF.Link | None
 		server_script: DF.Link | None
 		stopped: DF.Check
 	# end: auto-generated types
@@ -265,6 +266,9 @@ def insert_single_event(frequency: str, event: str, cron_format: str | None = No
 def clear_events(scheduler_events: dict):
 	def event_exists(event) -> bool:
 		if event.server_script:
+			return True
+
+		if event.scheduler_event:
 			return True
 
 		freq = frappe.scrub(event.frequency)

--- a/frappe/core/doctype/scheduler_event/scheduler_event.js
+++ b/frappe/core/doctype/scheduler_event/scheduler_event.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Scheduler Event", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe/core/doctype/scheduler_event/scheduler_event.json
+++ b/frappe/core/doctype/scheduler_event/scheduler_event.json
@@ -1,0 +1,49 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-01-13 10:20:09.095079",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "scheduled_against",
+  "method"
+ ],
+ "fields": [
+  {
+   "fieldname": "scheduled_against",
+   "fieldtype": "Link",
+   "label": "Scheduled Against",
+   "options": "DocType"
+  },
+  {
+   "fieldname": "method",
+   "fieldtype": "Data",
+   "label": "Method"
+  }
+ ],
+ "in_create": 1,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-01-13 10:31:06.968422",
+ "modified_by": "Administrator",
+ "module": "Core",
+ "name": "Scheduler Event",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/core/doctype/scheduler_event/scheduler_event.json
+++ b/frappe/core/doctype/scheduler_event/scheduler_event.json
@@ -24,7 +24,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-13 10:31:06.968422",
+ "modified": "2025-01-13 10:36:52.332434",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduler Event",

--- a/frappe/core/doctype/scheduler_event/scheduler_event.py
+++ b/frappe/core/doctype/scheduler_event/scheduler_event.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class SchedulerEvent(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		method: DF.Data | None
+		scheduled_against: DF.Link | None
+	# end: auto-generated types
+
+	pass

--- a/frappe/core/doctype/scheduler_event/test_scheduler_event.py
+++ b/frappe/core/doctype/scheduler_event/test_scheduler_event.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase, UnitTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class UnitTestSchedulerEvent(UnitTestCase):
+	"""
+	Unit tests for SchedulerEvent.
+	Use this class for testing individual functions and methods.
+	"""
+
+	pass
+
+
+class IntegrationTestSchedulerEvent(IntegrationTestCase):
+	"""
+	Integration tests for SchedulerEvent.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass


### PR DESCRIPTION
# Limitations in Cron job setup
Cron jobs which are created from `scheduler_events` hook maintained in `hooks.py` cannot be adjusted later to have a different trigger interval. This is because on each `bench migrate` framework re-sync's the cron interval based on `hooks.py`.

## Workaround
This can be worked around through `after_migrate` hook. But this not ideal. Job will be deleted and recreated on each migrate. 

<details>

<summary>Example</summary>

```
(.venv) ruthra@ruthra-desktop:~/dev/develop/apps/erpnext$ bench migrate
Migrating develop_site
Updating DocTypes for frappe        : [========================================] 100%
Updating DocTypes for erpnext       : [========================================] 100%
Updating DocTypes for hrms          : [========================================] 100%
Updating DocTypes for payments      : [========================================] 100%
Updating DocTypes for non_profit    : [========================================] 100%
Syncing jobs...                                              <============== deleted here
Syncing fixtures...
Syncing dashboards...
Updating Dashboard for frappe
Updating Dashboard for erpnext
Updating Dashboard for hrms
Updating Dashboard for payments
Updating Dashboard for non_profit
Syncing customizations...
Updating customizations for Address
Updating customizations for Contact
Syncing languages...
Flushing deferred inserts...
Removing orphan doctypes...
Syncing portal menu...
Updating installed applications...
Executing `after_migrate` hooks...                      <================ recreated here
Queued rebuilding of search index for develop_site
```

</details>

# Solution
A new doctype called `Scheduler Event` is introduced. This will serve as a possible anchor for `Scheduled Job Type`, similar to how Server Script serves as a possible anchor.


This allows for,
Programmatically seting up cron job with configurable trigger intervals, that persists across `bench migrate`.

![Screenshot from 2025-01-13 10-38-57](https://github.com/user-attachments/assets/d5b6de81-335c-4723-9804-d831619a0821)

<hr>

docs: https://docs.frappe.io/framework/user/en/api/background_jobs#configurable-scheduler-events