### PR TITLE
fix:Enhance user permission logic to allow creation of new documents (#28830)

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -315,8 +315,9 @@ def has_user_permission(doc, user=None):
 
 		# if allowed_docs is empty it states that there is no applicable permission under the current doctype
 
-		# only check if allowed_docs is not empty
-		if allowed_docs and str(docname) not in allowed_docs:
+
+		# only check if allowed_docs is not empty and the doc in not new
+		if allowed_docs and docname not in allowed_docs and not doc.get("__islocal"):
 			# no user permissions for this doc specified
 			push_perm_check_log(_("Not allowed for {0}: {1}").format(_(doctype), docname))
 			return False


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes

-->

> Please provide enough information so that others can review your pull request:

This PR enhances the user permission logic to allow the creation of new documents. Previously, users with valid permissions but restricted access to linked doctypes couldn't create new documents. This change ensures that the `__islocal` flag is respected during user permission checks, allowing document creation while maintaining security.

> Explain the **details** for making this change. What existing problem does the pull request solve?

- **Issue**: Users with appropriate roles and permissions couldn't create new documents if they had user-level restrictions on certain linked doctypes.
- **Fix**: Updated the `frappe/permissions.py` logic to check for `__islocal` before enforcing user permissions on the document itself.

fixes #28830

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->

---

### About [RUKN Software](https://www.linkedin.com/company/ruknsoftware/):

At **RUKN Software**, we are actively developing an app named **Branchy** that heavily relies on dynamic user permissions. This app enables permissions to be applied based on values, such as specific Item Groups or conditions. However, this bug has been a blocker for implementing key functionalities, as it disrupts the expected behavior of user permissions in the framework.

The issue appears to be general across all doctypes where user permissions are applied to link fields. Using **Item Group** as a use case:
- Users with specific permissions to certain Item Groups encounter issues when creating new documents, as the framework fails to respect the `__islocal` flag during user permission checks.

We would greatly appreciate a prompt resolution of this issue to ensure seamless handling of user permissions and to unblock critical features for our app.

---

### Additional Context:

This PR is crucial for ensuring that:
- User permissions work correctly when creating new documents.
- Framework functionality aligns with the expectations of developers and users relying on dynamic permissions.

Please feel free to reach out if further clarification or testing is needed. We’re happy to contribute to making Frappe better!

