### PR TITLE
build: switch to gunicorn fork

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "cryptography~=43.0.1",
     "cssutils~=2.9.0",
     "email-reply-parser~=0.5.12",
-    "gunicorn~=23.0.0",
+    "gunicorn @ git+https://github.com/frappe/gunicorn@2f5b4923399d18c28e4221f6514792b5cc7d2c21",
     "html5lib~=1.1",
     "ipython~=8.15.0",
     "ldap3~=2.9",


### PR DESCRIPTION
This adds request timeouts for gthread workers.

`gunicorn` repo isn't that active and this issue has been brought up
multiple times so I don't think it's gonna get fixed upstream. This is
our last resort.
