### PR TITLE
feat: (UI) Show document title in Global Search result

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -447,7 +447,7 @@ frappe.search.utils = {
 			data.forEach(function (d) {
 				// more properties
 				result = {
-					label: d.name,
+					label: d.title || d.name, // show title if exists
 					value: d.name,
 					description: make_description(d.content, d.name),
 					route: ["Form", d.doctype, d.name],

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -517,6 +517,8 @@ def search(text, start=0, limit=20, doctype=""):
 					meta = frappe.get_meta(r.doctype)
 					if meta.image_field:
 						r.image = frappe.db.get_value(r.doctype, r.name, meta.image_field)
+					if meta.title_field:
+						r.title = frappe.db.get_value(r.doctype, r.name, meta.title_field)
 				except Exception:
 					frappe.clear_messages()
 


### PR DESCRIPTION
Showing title in n Global Search result, if title field set in doctype settings

> Please provide enough information so that others can review your pull request:

Issue info: #29130

> Explain the **details** for making this change. What existing problem does the pull request solve?

If this pull request is accepted, users will be able to see the document title if specified in the doctype settings, instead of just a non-informative document name.


> Screenshots/GIFs

Before:
![image](https://github.com/user-attachments/assets/21c5d037-cfca-4e0c-b7e5-974ebb0dac86)
After:
![image](https://github.com/user-attachments/assets/6f65c2e6-678b-4837-82ad-7bcc3a260290)

`no-docs`


