### PR TITLE
fix: datetime utils

### DIFF
--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -143,26 +143,40 @@ $.extend(frappe.datetime, {
 		return (frappe.sys_defaults && frappe.sys_defaults.date_format) || "yyyy-mm-dd";
 	},
 
+	/**
+	 * Converts a datetime string from system format to user format.
+	 *
+	 * If a full datetime string is provided, it is assumed to be in the system
+	 * timezone and converted to the user's timezone.
+	 *
+	 * @param {string} val - The datetime string to convert
+	 * @param {boolean} only_time - If true, parses and returns a time string only
+	 * @param {boolean} only_date - If true, parses and returns a date string only
+	 * @returns {string} The datetime string in user format
+	 */
 	str_to_user: function (val, only_time = false, only_date = false) {
-		if (!val) return "";
+		if (!val) {
+			return "";
+		}
+
 		const user_date_fmt = frappe.datetime.get_user_date_fmt().toUpperCase();
 		const user_time_fmt = frappe.datetime.get_user_time_fmt();
-		let user_format = user_time_fmt;
 
 		if (only_time) {
 			let date_obj = moment(val, frappe.defaultTimeFormat);
-			return date_obj.format(user_format);
-		} else if (only_date) {
+			return date_obj.format(user_time_fmt);
+		} else if (only_date || (typeof val === "string" && val.indexOf(" ") === -1)) {
 			let date_obj = moment(val, frappe.defaultDateFormat);
 			return date_obj.format(user_date_fmt);
 		} else {
-			let date_obj = moment.tz(val, frappe.boot.time_zone.system);
-			if (typeof val !== "string" || val.indexOf(" ") === -1) {
-				user_format = user_date_fmt;
-			} else {
-				user_format = user_date_fmt + " " + user_time_fmt;
-			}
-			return date_obj.clone().tz(frappe.boot.time_zone.user).format(user_format);
+			const system_datetime = moment.tz(
+				val,
+				frappe.defaultDatetimeFormat,
+				frappe.boot.time_zone.system
+			);
+			const user_datetime = system_datetime.clone().tz(frappe.boot.time_zone.user);
+
+			return user_datetime.format(user_date_fmt + " " + user_time_fmt);
 		}
 	},
 

--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -18,7 +18,7 @@ $.extend(frappe.datetime, {
 		let date_obj = null;
 		if (frappe.boot.time_zone && frappe.boot.time_zone.system && frappe.boot.time_zone.user) {
 			date_obj = moment
-				.tz(date, frappe.boot.time_zone.system)
+				.tz(date, frappe.defaultDatetimeFormat, frappe.boot.time_zone.system)
 				.clone()
 				.tz(frappe.boot.time_zone.user);
 		} else {


### PR DESCRIPTION
I wanted to suggest usage of our datetime utils in another PR, tried it out and noticed weird behavior. This is my attempt to fix this.

`moment.tz()` is used to parse a datetime object while assuming a particular timezone.

When parsing a datetime string without timezone information, we explicitly pass the system's datetime fomat: `moment(my_date_string, "YYYY-MM-DD HH:mm:ss")`. This ensures correct results.

However, while parsing with a particular timezone, we used to omit the system datetime fomat: `moment.tz(my_date_string, "Europe/Berlin")`. In this case, moment will try to guess the format, which can lead to incorrect results.

The most important change of this PR is that we now also specify the format while parsing with a timezone: `moment.tz(my_date_string, "YYYY-MM-DD HH:mm:ss", "Europe/Berlin")`.

Apart from this, I've also refactored and documented `str_to_user`.

### Before

```js
frappe.datetime.prettyDate("2025-01-13 18:15:00.087528") // 1 hour ago
frappe.datetime.prettyDate("2025-01-13 18:15:0.087528") // 5 minutes ago
```

(The latter slightly malformed date was observed in ERPNext POS.)

### After

```js
frappe.datetime.prettyDate("2025-01-13 18:15:00.087528") // 1 hour ago
frappe.datetime.prettyDate("2025-01-13 18:15:0.087528") // 1 hour ago
```