### PR TITLE
perf: use client cache for metadata version

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1118,7 +1118,7 @@ def generate_hash(txt: str | None = None, length: int = 56) -> str:
 def reset_metadata_version():
 	"""Reset `metadata_version` (Client (Javascript) build ID) hash."""
 	v = generate_hash()
-	cache.set_value("metadata_version", v)
+	client_cache.set_value("metadata_version", v)
 	return v
 
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -154,7 +154,7 @@ def get():
 		if frappe.local.request:
 			bootinfo["change_log"] = get_change_log()
 
-	bootinfo["metadata_version"] = frappe.cache.get_value("metadata_version")
+	bootinfo["metadata_version"] = frappe.client_cache.get_value("metadata_version")
 	if not bootinfo["metadata_version"]:
 		bootinfo["metadata_version"] = frappe.reset_metadata_version()
 


### PR DESCRIPTION
This doesn't change often but every page load needs it.