### PR TITLE
fix: Forward `shared` flag to cache generator

### DIFF
--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -102,7 +102,7 @@ class RedisWrapper(redis.Redis):
 			if not expires:
 				if val is None and generator:
 					val = generator()
-					self.set_value(original_key, val, user=user)
+					self.set_value(original_key, val, user=user, shared=shared)
 
 				else:
 					local_cache[key] = val


### PR DESCRIPTION
Right now assets.json is read on every requests because of this bug.

Assets.json code:
- reads shared keyspace
- updates site local keyspace
- reads shared again, so never finds it in cache.