### PR TITLE
perf: speedup `get_website_settings`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2338,7 +2338,7 @@ def safe_eval(code, eval_globals=None, eval_locals=None):
 def get_website_settings(key):
 	if not hasattr(local, "website_settings"):
 		try:
-			local.website_settings = get_cached_doc("Website Settings")
+			local.website_settings = client_cache.get_doc("Website Settings")
 		except DoesNotExistError:
 			clear_last_message()
 			return

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -227,10 +227,7 @@ def get_system_settings(key: str):
 	"""Return the value associated with the given `key` from System Settings DocType."""
 	if not (system_settings := getattr(frappe.local, "system_settings", None)):
 		try:
-			system_settings = frappe.client_cache.get_value(cache_key)
-			if not system_settings:
-				system_settings = frappe.get_cached_doc("System Settings")
-				frappe.client_cache.set_value(cache_key, system_settings)
+			system_settings = frappe.client_cache.get_doc("System Settings")
 			frappe.local.system_settings = system_settings
 		except frappe.DoesNotExistError:  # possible during new install
 			frappe.clear_last_message()

--- a/frappe/locale.py
+++ b/frappe/locale.py
@@ -47,6 +47,6 @@ def get_locale_value(key: str, language: str | None = None) -> str | None:
 	"""
 	lang = language or frappe.local.lang
 	if lang:
-		value = frappe.db.get_value("Language", lang, key)
+		value = frappe.client_cache.get_doc("Language", lang).get(key)
 
 	return value or frappe.db.get_default(key)

--- a/frappe/tests/test_client_cache.py
+++ b/frappe/tests/test_client_cache.py
@@ -111,3 +111,8 @@ class TestClientCache(IntegrationTestCase):
 
 		with self.assertRedisCallCounts(0):
 			self.assertEqual(frappe.client_cache.get_value(TEST_KEY, generator=lambda: val), val)
+
+	def test_get_doc(self):
+		frappe.client_cache.get_doc("User", "Guest")
+		with self.assertRedisCallCounts(0):
+			frappe.client_cache.get_doc("User", "Guest")

--- a/frappe/tests/test_client_cache.py
+++ b/frappe/tests/test_client_cache.py
@@ -106,7 +106,7 @@ class TestClientCache(IntegrationTestCase):
 
 	def test_generator(self):
 		val = frappe.generate_hash()
-		with self.assertRedisCallCounts(2, exact=True):
+		with self.assertRedisCallCounts(3, exact=True):
 			self.assertEqual(frappe.client_cache.get_value(TEST_KEY, generator=lambda: val), val)
 
 		with self.assertRedisCallCounts(0):

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -531,6 +531,17 @@ class ClientCache:
 		#   doesn't send invalidation.
 		_ = self.redis.get_value(key, shared=True, use_local_cache=not self.healthy)
 
+	def get_doc(self, doctype: str, name: str | None = None):
+		"""Utility to fetch and store documents in client cache.
+
+		Use sparingly, this should ideally be used for settings and doctypes that have few known
+		number of documents.
+		"""
+		if not name:
+			name = doctype  # singles
+		key = frappe.get_document_cache_key(doctype, name)
+		return self.get_value(key, generator=lambda: frappe.get_doc(doctype, name))
+
 	def ensure_max_size(self):
 		if len(self.cache) >= self.maxsize:
 			with self.lock, suppress(RuntimeError):

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -171,7 +171,7 @@ class WebsiteSettings(Document):
 def get_website_settings(context=None):
 	hooks = frappe.get_hooks()
 	context = frappe._dict(context or {})
-	settings: WebsiteSettings = frappe.get_cached_doc("Website Settings")
+	settings: WebsiteSettings = frappe.client_cache.get_doc("Website Settings")
 
 	context = context.update(
 		{

--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -154,7 +154,7 @@ class WebsiteTheme(Document):
 def get_active_theme() -> Optional["WebsiteTheme"]:
 	if website_theme := frappe.get_website_settings("website_theme"):
 		try:
-			return frappe.get_cached_doc("Website Theme", website_theme)
+			return frappe.client_cache.get_doc("Website Theme", website_theme)
 		except frappe.DoesNotExistError:
 			frappe.clear_last_message()
 			pass

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -183,7 +183,8 @@ def get_boot_data():
 		},
 		"time_zone": {
 			"system": get_system_timezone(),
-			"user": frappe.db.get_value("User", frappe.session.user, "time_zone") or get_system_timezone(),
+			"user": frappe.get_cached_value("User", frappe.session.user, "time_zone")
+			or get_system_timezone(),
 		},
 		"assets_json": get_assets_json(),
 		"sitename": frappe.local.site,


### PR DESCRIPTION
This code was comically slow:
- Fetching same data from multiple sources.
- Using DB query for fetching multiple defaults that can be all fetched at once
- Using redis for things that change very slowly - theme, website settings etc
