### PR TITLE
fix: backward compatible date parsing

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -675,7 +675,6 @@ class TestDateUtils(IntegrationTestCase):
 	@given(st.datetimes(timezones=st.timezones()))
 	def test_get_datetime_tz_aware(self, original):
 		parsed = get_datetime(str(original))
-		original = original.replace(tzinfo=None)
 		self.assertEqual(parsed, original)
 
 	def test_pretty_date(self):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -168,13 +168,7 @@ def get_datetime(
 	try:
 		# PERF: Our DATETIME_FORMAT is same as ISO format.
 		# fromisoformat is written in C so it's better than using strptime parser
-		dt_object = datetime.datetime.fromisoformat(datetime_str)
-
-		# fromisoformat also adds tzinfo if present in src string,
-		# so we strip it before returning
-		if dt_object.tzinfo:
-			return dt_object.replace(tzinfo=None)
-		return dt_object
+		return datetime.datetime.fromisoformat(datetime_str)
 	except ValueError:
 		return parser.parse(datetime_str)
 


### PR DESCRIPTION
Even though we never use tz aware object in frappe, this function
previously used to retain them, so keep TZinfo for the sake of compat.

Nothing should be affected ideally.

Broke in b890467e2723eaf7b173830ec7323c0d69867c12