### PR TITLE
fix(csvutils): drop sniffer code

### DIFF
--- a/frappe/core/doctype/data_import/data_import.json
+++ b/frappe/core/doctype/data_import/data_import.json
@@ -16,6 +16,7 @@
   "google_sheets_url",
   "refresh_google_sheet",
   "column_break_5",
+  "use_csv_sniffer",
   "custom_delimiters",
   "delimiter_options",
   "status",
@@ -183,11 +184,18 @@
    "fieldname": "custom_delimiters",
    "fieldtype": "Check",
    "label": "Custom Delimiters"
+  },
+  {
+   "default": "0",
+   "description": "Use if the default settings don't seem to detect your data correctly",
+   "fieldname": "use_csv_sniffer",
+   "fieldtype": "Check",
+   "label": "Detect CSV type"
   }
  ],
  "hide_toolbar": 1,
  "links": [],
- "modified": "2024-04-27 20:42:35.843158",
+ "modified": "2025-01-14 17:36:22.389195",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Data Import",

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -40,6 +40,7 @@ class DataImport(Document):
 		submit_after_import: DF.Check
 		template_options: DF.Code | None
 		template_warnings: DF.Code | None
+		use_csv_sniffer: DF.Check
 	# end: auto-generated types
 
 	def validate(self):
@@ -127,7 +128,7 @@ class DataImport(Document):
 		return self.get_importer().export_import_log()
 
 	def get_importer(self):
-		return Importer(self.reference_doctype, data_import=self)
+		return Importer(self.reference_doctype, data_import=self, use_sniffer=self.use_csv_sniffer)
 
 
 @frappe.whitelist()

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -26,9 +26,12 @@ DURATION_PATTERN = re.compile(r"^(?:(\d+d)?((^|\s)\d+h)?((^|\s)\d+m)?((^|\s)\d+s
 
 
 class Importer:
-	def __init__(self, doctype, data_import=None, file_path=None, import_type=None, console=False):
+	def __init__(
+		self, doctype, data_import=None, file_path=None, import_type=None, console=False, use_sniffer=False
+	):
 		self.doctype = doctype
 		self.console = console
+		self.use_sniffer = use_sniffer
 
 		self.data_import = data_import
 		if not self.data_import:
@@ -45,6 +48,7 @@ class Importer:
 			self.template_options,
 			self.import_type,
 			console=self.console,
+			use_sniffer=self.use_sniffer,
 		)
 
 	def get_data_for_import_preview(self):
@@ -402,13 +406,16 @@ class Importer:
 
 
 class ImportFile:
-	def __init__(self, doctype, file, template_options=None, import_type=None, *, console=False):
+	def __init__(
+		self, doctype, file, template_options=None, import_type=None, *, console=False, use_sniffer=False
+	):
 		self.doctype = doctype
 		self.template_options = template_options or frappe._dict(column_to_field_map=frappe._dict())
 		self.column_to_field_map = self.template_options.column_to_field_map
 		self.import_type = import_type
 		self.warnings = []
 		self.console = console
+		self.use_sniffer = use_sniffer
 
 		self.file_doc = self.file_path = self.google_sheets_url = None
 		if isinstance(file, str):
@@ -605,7 +612,7 @@ class ImportFile:
 			frappe.throw(_("Import template should be of type .csv, .xlsx or .xls"), title=error_title)
 
 		if extension == "csv":
-			data = read_csv_content(content)
+			data = read_csv_content(content, use_sniffer=self.use_sniffer)
 		elif extension == "xlsx":
 			data = read_xlsx_file_from_attached_file(fcontent=content)
 		elif extension == "xls":

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -61,7 +61,7 @@ class TestImporter(IntegrationTestCase):
 
 	def test_data_validation_semicolon_success(self):
 		import_file = get_import_file("sample_import_file_semicolon")
-		data_import = self.get_importer(doctype_name, import_file, update=True)
+		data_import = self.get_importer(doctype_name, import_file, update=True, use_sniffer=True)
 
 		doc = data_import.get_preview_from_template().get("data", [{}])
 
@@ -72,7 +72,7 @@ class TestImporter(IntegrationTestCase):
 	def test_data_validation_semicolon_failure(self):
 		import_file = get_import_file("sample_import_file_semicolon")
 
-		data_import = self.get_importer_semicolon(doctype_name, import_file)
+		data_import = self.get_importer_semicolon(doctype_name, import_file, use_sniffer=True)
 		doc = data_import.get_preview_from_template().get("data", [{}])
 		# if semicolon delimiter detection fails, and falls back to comma,
 		# column number will be less than 15 -> 2 (+1 id)
@@ -155,22 +155,24 @@ class TestImporter(IntegrationTestCase):
 		self.assertEqual(updated_doc.table_field_1[0].child_description, "child description")
 		self.assertEqual(updated_doc.table_field_1_again[0].child_title, "child title again")
 
-	def get_importer(self, doctype, import_file, update=False):
+	def get_importer(self, doctype, import_file, update=False, use_sniffer=False):
 		data_import = frappe.new_doc("Data Import")
 		data_import.import_type = "Insert New Records" if not update else "Update Existing Records"
 		data_import.reference_doctype = doctype
 		data_import.import_file = import_file.file_url
+		data_import.use_csv_sniffer = use_sniffer
 		data_import.insert()
 		# Commit so that the first import failure does not rollback the Data Import insert.
 		frappe.db.commit()
 
 		return data_import
 
-	def get_importer_semicolon(self, doctype, import_file, update=False):
+	def get_importer_semicolon(self, doctype, import_file, update=False, use_sniffer=False):
 		data_import = frappe.new_doc("Data Import")
 		data_import.import_type = "Insert New Records" if not update else "Update Existing Records"
 		data_import.reference_doctype = doctype
 		data_import.import_file = import_file.file_url
+		data_import.use_csv_sniffer = use_sniffer
 		# deliberately overwrite default delimiter options here, causing to fail when parsing `;`
 		data_import.delimiter_options = ","
 		data_import.insert()

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 import csv
 import json
+from csv import Sniffer
 from io import StringIO
 
 import requests
@@ -37,7 +38,7 @@ def read_csv_content_from_attached_file(doc):
 		)
 
 
-def read_csv_content(fcontent):
+def read_csv_content(fcontent, use_sniffer: bool = False):
 	if not isinstance(fcontent, str):
 		decoded = False
 		for encoding in FILE_ENCODING_OPTIONS:
@@ -56,10 +57,32 @@ def read_csv_content(fcontent):
 
 	fcontent = fcontent.encode("utf-8")
 	content = [frappe.safe_decode(line) for line in fcontent.splitlines(True)]
+	dialect = csv.get_dialect("excel")
+
+	if use_sniffer:
+		sniffer = Sniffer()
+		# Don't need to use whole csv, if more than 20 rows, use just first 20
+		sample_content = content[:20] if len(content) > 20 else content
+		# only testing for most common delimiter types, this later can be extended
+		# init default dialect, to avoid lint errors
+		try:
+			# csv by default uses excel dialect, which is not always correct
+			dialect = sniffer.sniff(
+				sample="\n".join(sample_content), delimiters=frappe.flags.delimiter_options
+			)
+		except csv.Error:
+			# if sniff fails, show alert on user interface. Fall back to use default dialect (excel)
+			frappe.msgprint(
+				_(
+					"Delimiter detection failed. Try to enable custom delimiters and adjust the delimiter options as per your data."
+				),
+				indicator="orange",
+				alert=True,
+			)
 
 	try:
 		rows = []
-		for row in csv.reader(content):
+		for row in csv.reader(content, dialect=dialect):
 			r = []
 			for val in row:
 				# decode everything

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 import csv
 import json
-from csv import Sniffer
 from io import StringIO
 
 import requests
@@ -58,28 +57,9 @@ def read_csv_content(fcontent):
 	fcontent = fcontent.encode("utf-8")
 	content = [frappe.safe_decode(line) for line in fcontent.splitlines(True)]
 
-	sniffer = Sniffer()
-	# Don't need to use whole csv, if more than 20 rows, use just first 20
-	sample_content = content[:20] if len(content) > 20 else content
-	# only testing for most common delimiter types, this later can be extended
-	# init default dialect, to avoid lint errors
-	dialect = csv.get_dialect("excel")
-	try:
-		# csv by default uses excel dialect, which is not always correct
-		dialect = sniffer.sniff(sample="\n".join(sample_content), delimiters=frappe.flags.delimiter_options)
-	except csv.Error:
-		# if sniff fails, show alert on user interface. Fall back to use default dialect (excel)
-		frappe.msgprint(
-			_(
-				"Delimiter detection failed. Try to enable custom delimiters and adjust the delimiter options as per your data."
-			),
-			indicator="orange",
-			alert=True,
-		)
-
 	try:
 		rows = []
-		for row in csv.reader(content, dialect=dialect):
+		for row in csv.reader(content):
 			r = []
 			for val in row:
 				# decode everything


### PR DESCRIPTION
This seems to break certain CSVs, which the default excel dialect can handle fine

If someone wants this - we could add an option to allow users to use sniffer instead of excel dialect

Follow up to #26183

<hr>

Example CSV with breakage:

```csv
"ID", "Title", "Message"
"Database Usage","Database Usage","Hi,

You can check the docs
[here](https://frappecloud.com/docs/faq#what-is-the-difference-between-database-and-disk-space)
on how the database usage is calculated on Frappe Cloud dashboard.

Also, you can check the standard report ""Database Storage Usage by Tables"" which
tells you how much database is being consumed by which table.

"
```

