### PR TITLE
fix: Translating columns in Query Report

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -144,6 +144,20 @@ class Report(Document):
 			make_boilerplate("controller.py", self, {"name": self.name})
 			make_boilerplate("controller.js", self, {"name": self.name})
 
+	def translate_columns(self, columns):
+		translated_columns = []
+		for column in columns:
+			if isinstance(column, str):
+				translate = column.split(":", 1)
+				translate = '{0}:{1}'.format(_(translate[0]), translate[1])
+			elif isinstance(column, dict) and hasattr(column, 'label'):
+				column.label = _(column.label)
+				translate = column
+			else:
+				translate = column
+			translated_columns.append(translate)
+		return translated_columns
+
 	def execute_query_report(self, filters):
 		if not self.query:
 			frappe.throw(_("Must specify a Query to run"), title=_("Report Document Error"))
@@ -152,8 +166,7 @@ class Report(Document):
 
 		result = [list(t) for t in frappe.db.sql(self.query, filters)]
 		columns = self.get_columns() or [cstr(c[0]) for c in frappe.db.get_description()]
-
-		return [columns, result]
+		return [self.translate_columns(columns), result]
 
 	def execute_script_report(self, filters):
 		# save the timestamp to automatically set to prepared


### PR DESCRIPTION
When we create a Query Report in frappe we haven't translations about columns, this code translate the columns according to the user language settings taking care about 2 types of queries in Query Report Document.

### Before:
![beforeTranslate](https://github.com/user-attachments/assets/44c2de40-bd74-439d-a58e-e670f614edfd)

### After:
![afterTranslate](https://github.com/user-attachments/assets/6f074792-e0b0-45f1-811a-83345488659f)

