### PR TITLE
perf: persistent jenv, ~7x faster `/login`

### DIFF
--- a/frappe/core/doctype/navbar_settings/navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.py
@@ -24,8 +24,10 @@ class NavbarSettings(Document):
 
 
 def get_app_logo():
-	app_logo = frappe.get_website_settings("app_logo") or frappe.db.get_single_value(
-		"Navbar Settings", "app_logo", cache=True
+	app_logo = frappe.get_website_settings("app_logo") or frappe.get_cached_value(
+		"Navbar Settings",
+		"Navbar Settings",
+		"app_logo",
 	)
 
 	if not app_logo:

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -68,6 +68,7 @@ from frappe.utils.data import (
 	get_url_to_form,
 	get_year_ending,
 	getdate,
+	is_invalid_date_string,
 	now_datetime,
 	nowtime,
 	pretty_date,
@@ -669,11 +670,15 @@ class TestDateUtils(IntegrationTestCase):
 
 	@given(st.datetimes())
 	def test_get_datetime(self, original):
+		if is_invalid_date_string(str(original)):
+			return
 		parsed = get_datetime(str(original))
 		self.assertEqual(parsed, original)
 
 	@given(st.datetimes(timezones=st.timezones()))
 	def test_get_datetime_tz_aware(self, original):
+		if is_invalid_date_string(str(original)):
+			return
 		parsed = get_datetime(str(original))
 		self.assertEqual(parsed, original)
 

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -18,6 +18,7 @@ def get_jenv():
 	if not frappe._dev_server:
 		jenv.cache = default_jenv.cache
 
+	# Note: Overlay by default is "linked", we need to copy everything we are updating.
 	jenv.globals = default_jenv.globals.copy()
 	jenv.filters = default_jenv.filters.copy()
 
@@ -116,7 +117,7 @@ def render_template(template, context=None, is_path=None, safe_render=True):
 	try:
 		if is_path or guess_is_path(template):
 			is_path = True
-			compiled_template = compile_template(template)
+			compiled_template = get_template(template)
 		else:
 			jenv: SandboxedEnvironment = get_jenv()
 			if safe_render and ".__" in template:
@@ -165,12 +166,6 @@ def get_jloader():
 	jloader = _get_jloader()
 	frappe.local.jloader = jloader  # backward compat
 	return jloader
-
-
-@site_cache(ttl=10 * 60, maxsize=16)
-def compile_template(path):
-	jenv = get_jenv()
-	return jenv.get_template(path)
 
 
 @site_cache(ttl=10 * 60, maxsize=8)

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -6,35 +6,39 @@ from frappe.utils.caching import site_cache
 
 def get_jenv():
 	import frappe
+	from frappe.utils.safe_exec import get_safe_globals
 
-	if not getattr(frappe.local, "jenv", None):
-		from jinja2 import DebugUndefined
-		from jinja2.sandbox import SandboxedEnvironment
+	jenv = _get_jenv()
+	jenv.globals.update(get_safe_globals())  # TODO: This isn't thread safe.
+	frappe.local.jenv = jenv
+	return jenv
 
-		from frappe.utils.safe_exec import UNSAFE_ATTRIBUTES, get_safe_globals
 
-		UNSAFE_ATTRIBUTES = UNSAFE_ATTRIBUTES - {"format", "format_map"}
+@site_cache(ttl=10 * 60, maxsize=4)
+def _get_jenv():
+	from jinja2 import DebugUndefined
+	from jinja2.sandbox import SandboxedEnvironment
 
-		class FrappeSandboxedEnvironment(SandboxedEnvironment):
-			def is_safe_attribute(self, obj, attr, *args, **kwargs):
-				if attr in UNSAFE_ATTRIBUTES:
-					return False
+	from frappe.utils.safe_exec import UNSAFE_ATTRIBUTES, get_safe_globals
 
-				return super().is_safe_attribute(obj, attr, *args, **kwargs)
+	UNSAFE_ATTRIBUTES = UNSAFE_ATTRIBUTES - {"format", "format_map"}
 
-		# frappe will be loaded last, so app templates will get precedence
-		jenv = FrappeSandboxedEnvironment(loader=get_jloader(), undefined=DebugUndefined)
-		set_filters(jenv)
+	class FrappeSandboxedEnvironment(SandboxedEnvironment):
+		def is_safe_attribute(self, obj, attr, *args, **kwargs):
+			if attr in UNSAFE_ATTRIBUTES:
+				return False
 
-		jenv.globals.update(get_safe_globals())
+			return super().is_safe_attribute(obj, attr, *args, **kwargs)
 
-		methods, filters = get_jinja_hooks()
-		jenv.globals.update(methods or {})
-		jenv.filters.update(filters or {})
+	# frappe will be loaded last, so app templates will get precedence
+	jenv = FrappeSandboxedEnvironment(loader=get_jloader(), undefined=DebugUndefined)
+	set_filters(jenv)
 
-		frappe.local.jenv = jenv
+	methods, filters = get_jinja_hooks()
+	jenv.globals.update(methods or {})
+	jenv.filters.update(filters or {})
 
-	return frappe.local.jenv
+	return jenv
 
 
 def get_template(path):


### PR DESCRIPTION
We waste a significant amount of time in parsing Jinja templates on endpoints like `/login` and similar simple template pages:

![image](https://github.com/user-attachments/assets/8ba5c957-8bfa-4f40-80a3-1fbed3944bab)


This small change speeds up *most* on-disk web template-based workloads by at least 2x because they aren't parsed on every request anymore.

My goal was just to optimize the login page render:

| Benchmark                      | before  | after                 |
|--------------------------------|:-------:|:---------------------:|
| web_requests_login_page_render | 85.1 ms | 11.8 ms: 7.23x faster |



TODO:
- [x] Don't cache things in developer mode, does it matter? Since we reload code anyway? :thinking: 
- [x] Add test for request specific jenv globals
- [x] Test apps like `wiki` (in prod :moyai: )

closes https://github.com/frappe/caffeine/issues/29