### PR TITLE
fix(activity_log): strip html from full name before inserting

### DIFF
--- a/frappe/core/doctype/activity_log/activity_log.py
+++ b/frappe/core/doctype/activity_log/activity_log.py
@@ -6,7 +6,7 @@ from frappe.core.utils import set_timeline_doc
 from frappe.model.document import Document
 from frappe.query_builder import DocType, Interval
 from frappe.query_builder.functions import Now
-from frappe.utils import get_fullname, now
+from frappe.utils import get_fullname, now, strip_html
 
 
 class ActivityLog(Document):
@@ -36,7 +36,7 @@ class ActivityLog(Document):
 	# end: auto-generated types
 
 	def before_insert(self):
-		self.full_name = get_fullname(self.user)
+		self.full_name = strip_html(get_fullname(self.user))
 		self.date = now()
 
 	def validate(self):


### PR DESCRIPTION
People can pass in HTML in the login page, it gets rendered here

Thanks to Tyler Ramsbey from Rhino Security Labs for reporting this

<hr>

Reference: support ticket 24484
