### PR TITLE
fix(user): strip html tags from user name

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -182,6 +182,7 @@ class User(Document):
 		self.populate_role_profile_roles()
 		self.check_roles_added()
 		self.set_system_user()
+		self.clean_name()
 		self.set_full_name()
 		self.check_enable_disable()
 		self.ensure_unique_roles()
@@ -309,6 +310,11 @@ class User(Document):
 	def has_website_permission(self, ptype, user, verbose=False):
 		"""Return True if current user is the session user."""
 		return self.name == frappe.session.user
+
+	def clean_name(self):
+		self.first_name = escape_html(self.first_name)
+		self.middle_name = escape_html(self.middle_name)
+		self.last_name = escape_html(self.last_name)
 
 	def set_full_name(self):
 		self.full_name = " ".join(filter(None, [self.first_name, self.last_name]))


### PR DESCRIPTION
Thanks to Tyler Ramsbey from Rhino Security Labs for reporting this.

Additionally, thanks to [Syed Ali Abbas](https://pk.linkedin.com/in/syed-ali-abbas-77b9a81ba) for reporting it as well around the same time.

<hr>

Reference: support ticket 24484
