### PR TITLE
feat: add option to update modified timestamp

### DIFF
--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -59,6 +59,10 @@ class Comment(Document):
 		notify_mentions(self.reference_doctype, self.reference_name, self.content)
 		self.notify_change("add")
 
+		# update modified timestamp of reference document
+		if frappe.db.get_single_value("System Settings", "update_timestamp_on_new_comment"):
+			frappe.get_doc(self.reference_doctype, self.reference_name).update_modified()
+
 	def validate(self):
 		if not self.comment_email:
 			self.comment_email = frappe.session.user

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -196,6 +196,12 @@ class Communication(Document, CommunicationEmailMixin):
 
 		self.notify_change("add")
 
+		# update modified timestamp of reference document
+		if self.sent_or_received == "Received" and frappe.db.get_single_value(
+			"System Settings", "update_timestamp_on_new_communication"
+		):
+			frappe.get_doc(self.reference_doctype, self.reference_name).update_modified()
+
 	def set_signature_in_email_content(self):
 		"""Set sender's User.email_signature or default outgoing's EmailAccount.signature to the email"""
 		if not self.content:

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -29,6 +29,10 @@
   "apply_strict_user_permissions",
   "column_break_21",
   "allow_older_web_view_links",
+  "activity_section",
+  "update_timestamp_on_new_comment",
+  "column_break_ypvn",
+  "update_timestamp_on_new_communication",
   "security_tab",
   "security",
   "session_expiry",
@@ -699,12 +703,33 @@
    "fieldname": "hide_empty_read_only_fields",
    "fieldtype": "Check",
    "label": "Hide Empty Read-Only Fields"
+  },
+  {
+   "fieldname": "activity_section",
+   "fieldtype": "Section Break",
+   "label": "Activity"
+  },
+  {
+   "default": "0",
+   "fieldname": "update_timestamp_on_new_comment",
+   "fieldtype": "Check",
+   "label": "Update timestamp on new comment"
+  },
+  {
+   "fieldname": "column_break_ypvn",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "update_timestamp_on_new_communication",
+   "fieldtype": "Check",
+   "label": "Update timestamp on new communication."
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2024-12-03 16:23:09.410614",
+ "modified": "2025-01-14 17:20:11.784170",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -96,6 +96,8 @@ class SystemSettings(Document):
 		time_format: DF.Literal["HH:mm:ss", "HH:mm"]
 		time_zone: DF.Literal[None]
 		two_factor_method: DF.Literal["OTP App", "SMS", "Email"]
+		update_timestamp_on_new_comment: DF.Check
+		update_timestamp_on_new_communication: DF.Check
 		use_number_format_from_currency: DF.Check
 		welcome_email_template: DF.Link | None
 	# end: auto-generated types


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/44330 and https://github.com/frappe/crm/issues/492

> Please provide enough information so that others can review your pull request:

https://github.com/frappe/erpnext/issues/43968

> Explain the **details** for making this change. What existing problem does the pull request solve?

- Add fields in system setting
![image](https://github.com/user-attachments/assets/e291ac0f-1a1c-4112-81fc-9dce67b6c648)
- When new communication is received, then update the modified timestamp.
- When a new comment is added, update the modified timestamp.


`no-docs`
