### PR TITLE
perf: faster `LocalProxy`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -102,7 +102,7 @@ def _get_local_proxy(self: Local, name: str) -> LocalProxy:
 
 		raise RuntimeError("object is not bound") from None
 
-	lp = LocalProxy(_local_contextvar, name)
+	lp = LocalProxy(_get_current_object)
 	object.__setattr__(lp, "_get_current_object", _get_current_object)
 	return lp
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -89,6 +89,27 @@ if _dev_server:
 	warnings.simplefilter("always", PendingDeprecationWarning)
 
 
+def _get_local_proxy(self: Local, name: str) -> LocalProxy:
+	"""Get local proxy object by name."""
+
+	_local_contextvar = self._Local__storage
+
+	def _get_current_object() -> Any:
+		obj = _local_contextvar.get(None)
+
+		if obj is not None and name in obj:
+			return obj[name]
+
+		raise RuntimeError("object is not bound") from None
+
+	lp = LocalProxy(_local_contextvar, name)
+	object.__setattr__(lp, "_get_current_object", _get_current_object)
+	return lp
+
+
+Local.__call__ = _get_local_proxy
+
+
 def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
 	"""Return translated string in current lang, if exists.
 	Usage:

--- a/frappe/tests/test_local_proxy.py
+++ b/frappe/tests/test_local_proxy.py
@@ -1,0 +1,52 @@
+import time
+from threading import Thread
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+# Note: These tests are adapted from official tests: https://github.com/pallets/werkzeug/blob/main/tests/test_local.py
+# We use them to check if our overrides of localproxy work fine.
+# Reused under BSD 3 clause license: https://github.com/pallets/werkzeug/blob/main/LICENSE.txt
+
+
+class TestFrappeLocal(IntegrationTestCase):
+	def test_basic_local(self):
+		ns = frappe.local
+		ns.foo = 0
+		values = []
+
+		def value_setter(idx):
+			time.sleep(0.01 * idx)
+			ns.foo = idx
+			time.sleep(0.02)
+			values.append(ns.foo)
+
+		threads = [Thread(target=value_setter, args=(x,)) for x in [1, 2, 3]]
+		for thread in threads:
+			thread.start()
+		for thread in threads:
+			thread.join()
+		assert sorted(values) == [1, 2, 3]
+
+		def delfoo():
+			del ns.foo
+
+		delfoo()
+		self.assertRaises(AttributeError, lambda: ns.foo)
+		self.assertRaises(AttributeError, delfoo)
+
+	def test_proxy_local(self):
+		ns = frappe.local
+		ns.foo = []
+		p = ns("foo")
+		p.append(42)
+		p.append(23)
+		p[1:] = [1, 2, 3]
+		assert p == [42, 1, 2, 3]
+		assert p == ns.foo
+		ns.foo += [1]
+		assert list(p) == [42, 1, 2, 3, 1]
+		p_from_local = ns("foo")
+		p_from_local.append(2)
+		assert p == p_from_local
+		assert p._get_current_object() is ns.foo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "RestrictedPython~=7.4",
     "WeasyPrint==59.0",
     "pydyf==0.10.0",
-    "Werkzeug~=3.0.1",
+    "Werkzeug==3.0.6",
     "Whoosh~=2.7.4",
     "beautifulsoup4~=4.12.2",
     "bleach-allowlist~=1.0.3",


### PR DESCRIPTION
#### before

```python
In [4]: %timeit frappe.db.set_value
919 ns ± 6.2 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [6]: %timeit frappe.db.set_value
929 ns ± 1.63 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

#### after (~350ns / 40% reduction in getattr)

```python
In [1]: %timeit frappe.db.set_value
587 ns ± 1.11 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [3]: %timeit frappe.db.set_value
585 ns ± 1.52 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

```

#### for context

```python
In [1]: %timeit frappe.local.db.set_value
399 ns ± 1.81 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```