### PR TITLE
perf: Add prefix index for file_url

### DIFF
--- a/frappe/core/doctype/file/file.json
+++ b/frappe/core/doctype/file/file.json
@@ -190,7 +190,7 @@
  "icon": "fa fa-file",
  "idx": 1,
  "links": [],
- "modified": "2024-05-09 11:46:42.917146",
+ "modified": "2025-01-15 11:46:42.917146",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "File",

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -797,6 +797,7 @@ class File(Document):
 
 def on_doctype_update():
 	frappe.db.add_index("File", ["attached_to_doctype", "attached_to_name"])
+	frappe.db.add_index("File", ["file_url(100)"])
 
 
 def has_permission(doc, ptype=None, user=None, debug=False):


### PR DESCRIPTION
Currently it's full table scan, that too on a TEXT field filter.

It's used for finding file docs when `fid` isn't specified. However, users can share URL or use it without specifying `fid`.

In any case, this is still required.

Towards https://github.com/frappe/caffeine/issues/32#issuecomment-2566194521 