### PR TITLE
fix: don't override setstate

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -177,11 +177,6 @@ class BaseDocument:
 		state.pop("meta", None)
 		state.pop("permitted_fieldnames", None)
 		state.pop("_parent_doc", None)
-		state.pop("flags", None)
-
-	def __setstate__(self, state):
-		self.__dict__ = state
-		self.flags = _dict()
 
 	def update(self, d):
 		"""Update multiple fields of a doctype using a dictionary of key-value pairs.


### PR DESCRIPTION
Meta sometimes break because of this, I don't quite know why but this
change isn't that useful, so best to revert it for now.
