### PR TITLE
fix: Don't assume homogeneous data in meta tables

### DIFF
--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -798,10 +798,12 @@ class TestDocType(IntegrationTestCase):
 
 	def test_meta_serialization(self):
 		doctype = new_doctype(
-			fields=[{"fieldname": "some_fieldname", "fieldtype": "Data", "set_only_once": 1}]
+			fields=[{"fieldname": "some_fieldname", "fieldtype": "Data", "set_only_once": 1}],
+			is_submittable=1,
 		).insert()
 		doc = frappe.new_doc(doctype.name, some_fieldname="something").insert()
 		doc.save()
+		doc.submit()
 		frappe.get_meta(doctype.name).as_dict()
 
 

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -796,6 +796,14 @@ class TestDocType(IntegrationTestCase):
 		)
 		self.assertRaises(frappe.ValidationError, recursive_dt.insert)
 
+	def test_meta_serialization(self):
+		doctype = new_doctype(
+			fields=[{"fieldname": "some_fieldname", "fieldtype": "Data", "set_only_once": 1}]
+		).insert()
+		doc = frappe.new_doc(doctype.name, some_fieldname="something").insert()
+		doc.save()
+		frappe.get_meta(doctype.name).as_dict()
+
 
 def new_doctype(
 	name: str | None = None,

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -188,6 +188,8 @@ class Meta(Document):
 
 	def as_dict(self, no_nulls=False):
 		def serialize(doc):
+			if isinstance(doc, dict):
+				return doc.copy()
 			out = {}
 			for key, value in doc.__dict__.items():
 				if isinstance(value, list | tuple):


### PR DESCRIPTION
Steps to reproduce:
- enable developer mode (doesn't happen in prod)
- Save a document with "set only once" fields
- Reload the page (this requests meta again which is now polluted and will fail)

Why this happens?
- `Meta` is client-cached now, so when you save a document, that object now has `self._set_only_once_field` some of which are are "fake fields" in form of `dict`: https://github.com/frappe/frappe/blob/42fd0eca35e0d46616365b36cf16a2fdeec8bffb/frappe/model/meta.py#L239-L249  https://github.com/frappe/frappe/blob/42fd0eca35e0d46616365b36cf16a2fdeec8bffb/frappe/model/meta.py#L136-L139
- This isn't a problem on it's own but `Meta` has custom serializer which assumes type of all list items is same as first one: https://github.com/frappe/frappe/blob/42fd0eca35e0d46616365b36cf16a2fdeec8bffb/frappe/model/meta.py#L194-L200
- In some sense, this was always broken, but never got uncovered because fresh `Meta` copy was created for each request. 


This is new category of bug surfaced because meta objects now live
longer than request and all kinds of weird `self._cached_property`
starts getting serialized.

TODO:
- [x] Audit all usage
- [x] add a test for this
- [x] document it better (I have something else WIP now, will revisit this PR tomorrow)