### PR TITLE
fix(macos): added ipv6 to hosts file

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -784,7 +784,7 @@ def reload_doctype(context: CliCtxObj, doctype):
 def add_to_hosts(context: CliCtxObj):
 	"Add site to hosts"
 	for site in context.sites:
-		frappe.commands.popen(f"echo 127.0.0.1\t{site} | sudo tee -a /etc/hosts")
+		frappe.commands.popen(f"echo '127.0.0.1\t{site}\n::1\t{site}' | sudo tee -a /etc/hosts")
 	if not context.sites:
 		raise SiteNotSpecifiedError
 


### PR DESCRIPTION
macos takes 5-10 second on dns when `*.local` is used unless ipv6 is added to hosts file.

source: https://stackoverflow.com/questions/10064581/how-can-i-eliminate-slow-resolving-loading-of-localhost-virtualhost-a-2-3-secon/17982964#17982964

Adding this even though it's edge case because it's not apparent and wasted few days debugging something else to make it faster.

### Before

<img width="384" alt="Before Add to hosts" src="https://github.com/user-attachments/assets/c9b67c88-23bb-4590-9049-7ea748b6a4d3" />
<img width="1513" alt="Before" src="https://github.com/user-attachments/assets/36e4877d-531e-45d2-8449-2693dd27c096" />

### After

<img width="345" alt="After Add to hosts" src="https://github.com/user-attachments/assets/4c205050-b1f3-4fe2-967d-98a27a53d7b3" />

<img width="1527" alt="After" src="https://github.com/user-attachments/assets/ee7899e1-088e-4cfb-9e9c-81d56da082f3" />