### PR TITLE
fix: Update sessions in cache after a miss

### DIFF
--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -386,9 +386,7 @@ class Session:
 		if frappe.session.user == "Guest":
 			return
 
-		now = frappe.utils.now()
-
-		Sessions = frappe.qb.DocType("Sessions")
+		now = frappe.utils.now_datetime()
 
 		# update session in db
 		last_updated = self.data.data.last_updated
@@ -396,9 +394,13 @@ class Session:
 
 		# database persistence is secondary, don't update it too often
 		updated_in_db = False
-		if (force or (time_diff is None) or (time_diff > 600)) and not frappe.flags.read_only:
+		if (
+			force or (time_diff is None) or (time_diff > 600) or self._update_in_cache
+		) and not frappe.flags.read_only:
 			self.data.data.last_updated = now
 			self.data.data.lang = str(frappe.lang)
+
+			Sessions = frappe.qb.DocType("Sessions")
 			# update sessions table
 			(
 				frappe.qb.update(Sessions)


### PR DESCRIPTION
Session cache isn't getting updated on first creation / restart / eviction.

IMO we should merge session update code and do it in init_request instead of at end of request?
