### PR TITLE
perf: faster page view count queries

### DIFF
--- a/frappe/website/doctype/web_page_view/web_page_view.json
+++ b/frappe/website/doctype/web_page_view/web_page_view.json
@@ -24,7 +24,8 @@
    "fieldname": "path",
    "fieldtype": "Data",
    "label": "Path",
-   "set_only_once": 1
+   "set_only_once": 1,
+   "search_index": 1
   },
   {
    "fieldname": "referrer",

--- a/frappe/website/doctype/web_page_view/web_page_view.py
+++ b/frappe/website/doctype/web_page_view/web_page_view.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 import frappe
 import frappe.utils
 from frappe.model.document import Document
+from frappe.utils.caching import redis_cache
 
 
 class WebPageView(Document):
@@ -101,9 +102,10 @@ def make_view_log(
 
 
 @frappe.whitelist()
+@redis_cache(ttl=5 * 60)
 def get_page_view_count(path):
 	return frappe.db.count("Web Page View", filters={"path": path})
 
 
 def is_tracking_enabled():
-	return frappe.db.get_single_value("Website Settings", "enable_view_tracking")
+	return frappe.get_website_settings("enable_view_tracking")


### PR DESCRIPTION
1. This data doesn't need to be updated in real-time. Use 5 min cache.
2. Index the field for query, we are doing FTS on 1.6mil rows.

Brought to you by: https://frappecloud.com/dashboard/database-analyzer 

![image](https://github.com/user-attachments/assets/cf1884ed-e856-447b-8100-7398851cda5a)

