### PR TITLE
perf: add cache-control headers on private files

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -236,25 +236,17 @@ def log_request(request, response):
 		)
 
 
-def process_response(response):
+def process_response(response: Response):
 	if not response:
 		return
 
 	# cache control
 	# read: https://simonhearne.com/2022/caching-header-best-practices/
 	if frappe.local.response.can_cache:
-		response.headers.extend(
-			{
-				# default: 5m (client), 3h (allow stale resources for this long if upstream is down)
-				"Cache-Control": "private,max-age=300,stale-while-revalidate=10800",
-			}
-		)
+		# default: 5m (client), 3h (allow stale resources for this long if upstream is down)
+		response.headers.setdefault("Cache-Control", "private,max-age=300,stale-while-revalidate=10800")
 	else:
-		response.headers.extend(
-			{
-				"Cache-Control": "no-store,no-cache,must-revalidate,max-age=0",
-			}
-		)
+		response.headers.setdefault("Cache-Control", "no-store,no-cache,must-revalidate,max-age=0")
 
 	# Set cookies, only if response is non-cacheable to avoid proxy cache invalidation
 	if hasattr(frappe.local, "cookie_manager") and not frappe.local.response.can_cache:

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -293,6 +293,7 @@ def send_private_file(path: str) -> Response:
 		path = "/protected/" + path
 		response = Response()
 		response.headers["X-Accel-Redirect"] = quote(frappe.utils.encode(path))
+		response.headers["Cache-Control"] = "private,max-age=3600,stale-while-revalidate=86400"
 
 	else:
 		filepath = frappe.utils.get_site_path(path)


### PR DESCRIPTION
Private files are fetched on every request (or rather, etag validated, still an RT with python + stupidly costly perm checks) 

That's insane!

![image](https://github.com/user-attachments/assets/3a529dc0-219d-4998-bce0-0551101da35c)

Fix:
- Client(browser) side cache
- 1 hr expiry
- 1 day revalidation
- etagged by nginx in default config (so no data transfer on expiry still)

I will increase the duration over time.

In conjunction with https://github.com/frappe/agent/pull/157
