### PR TITLE
refactor: add validation and refactor code of auto repeat

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.json
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.json
@@ -8,15 +8,13 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "section_break_1",
-  "disabled",
-  "section_break_3",
   "reference_doctype",
   "reference_document",
   "submit_on_creation",
   "column_break_5",
   "start_date",
   "end_date",
+  "disabled",
   "section_break_10",
   "frequency",
   "repeat_on_day",
@@ -37,10 +35,6 @@
   "status"
  ],
  "fields": [
-  {
-   "fieldname": "section_break_1",
-   "fieldtype": "Section Break"
-  },
   {
    "fieldname": "reference_doctype",
    "fieldtype": "Link",
@@ -84,7 +78,8 @@
   },
   {
    "fieldname": "section_break_10",
-   "fieldtype": "Section Break"
+   "fieldtype": "Tab Break",
+   "label": "Schedule"
   },
   {
    "fieldname": "frequency",
@@ -114,9 +109,8 @@
    "search_index": 1
   },
   {
-   "collapsible": 1,
    "fieldname": "notification",
-   "fieldtype": "Section Break",
+   "fieldtype": "Tab Break",
    "label": "Notification"
   },
   {
@@ -181,10 +175,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "section_break_3",
-   "fieldtype": "Section Break"
-  },
-  {
    "default": "0",
    "depends_on": "eval:doc.frequency === 'Monthly'",
    "fieldname": "repeat_on_last_day",
@@ -211,10 +201,11 @@
   }
  ],
  "links": [],
- "modified": "2024-03-23 16:01:28.502039",
+ "modified": "2025-01-20 14:15:55.287788",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Auto Repeat",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -104,6 +104,8 @@ class AutoRepeat(Document):
 			self.next_schedule_date = None
 		else:
 			self.next_schedule_date = self.get_next_schedule_date(schedule_date=self.start_date)
+			if self.end_date and getdate(self.end_date) < getdate(self.next_schedule_date):
+				frappe.throw("The Next Scheduled Date cannot be later than the End Date.")
 
 	def unlink_if_applicable(self):
 		if self.status == "Completed" or self.disabled:
@@ -204,7 +206,7 @@ class AutoRepeat(Document):
 		if self.end_date:
 			next_date = self.get_next_schedule_date(schedule_date=start_date, for_full_schedule=True)
 
-			while getdate(next_date) < getdate(end_date):
+			while getdate(next_date) <= getdate(end_date):
 				row = {
 					"reference_document": self.reference_document,
 					"frequency": self.frequency,
@@ -221,7 +223,9 @@ class AutoRepeat(Document):
 			if self.notify_by_email and self.recipients:
 				self.send_notification(new_doc)
 		except Exception:
-			error_log = self.log_error("Auto repeat failed")
+			error_log = self.log_error(
+				"Auto repeat failed. Please enable auto repeat after fixing the issues."
+			)
 
 			self.disable_auto_repeat()
 
@@ -314,14 +318,9 @@ class AutoRepeat(Document):
 			month_count = 0
 
 		day_count = 0
-		if month_count and self.repeat_on_last_day:
-			day_count = 31
+		if month_count:
+			day_count = 31 if self.repeat_on_last_day else self.repeat_on_day or None
 			next_date = get_next_date(self.start_date, month_count, day_count)
-		elif month_count and self.repeat_on_day:
-			day_count = self.repeat_on_day
-			next_date = get_next_date(self.start_date, month_count, day_count)
-		elif month_count:
-			next_date = get_next_date(self.start_date, month_count)
 		else:
 			days = self.get_days(schedule_date)
 			next_date = add_days(schedule_date, days)
@@ -483,6 +482,9 @@ def make_auto_repeat_entry():
 		data = get_auto_repeat_entries(date)
 		frappe.enqueue(enqueued_method, data=data)
 
+	# Set auto-repeat to complete when all auto-repeats are added to the queue
+	set_auto_repeat_as_completed()
+
 
 def create_repeated_entries(data):
 	for d in data:
@@ -501,12 +503,18 @@ def create_repeated_entries(data):
 def get_auto_repeat_entries(date=None):
 	if not date:
 		date = getdate(today())
-	return frappe.get_all(
-		"Auto Repeat", filters=[["next_schedule_date", "<=", date], ["status", "=", "Active"]]
+
+	auto_repeat = frappe.qb.DocType("Auto Repeat")
+	query = frappe.qb.from_(auto_repeat)
+	query = query.select("name")
+	query = query.where(
+		(auto_repeat.next_schedule_date <= date)
+		& (auto_repeat.status == "Active")
+		& ((auto_repeat.end_date <= auto_repeat.next_schedule_date) | (auto_repeat.end_date.isnull()))
 	)
+	return query.run(as_dict=1)
 
 
-# called through hooks
 def set_auto_repeat_as_completed():
 	auto_repeat = frappe.get_all("Auto Repeat", filters={"status": ["!=", "Disabled"]})
 	for entry in auto_repeat:

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -105,7 +105,7 @@ class AutoRepeat(Document):
 		else:
 			self.next_schedule_date = self.get_next_schedule_date(schedule_date=self.start_date)
 			if self.end_date and getdate(self.end_date) < getdate(self.next_schedule_date):
-				frappe.throw("The Next Scheduled Date cannot be later than the End Date.")
+				frappe.throw(_("The Next Scheduled Date cannot be later than the End Date."))
 
 	def unlink_if_applicable(self):
 		if self.status == "Completed" or self.disabled:
@@ -224,7 +224,7 @@ class AutoRepeat(Document):
 				self.send_notification(new_doc)
 		except Exception:
 			error_log = self.log_error(
-				"Auto repeat failed. Please enable auto repeat after fixing the issues."
+				_("Auto repeat failed. Please enable auto repeat after fixing the issues.")
 			)
 
 			self.disable_auto_repeat()

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -251,7 +251,6 @@ scheduler_events = {
 		"frappe.social.doctype.energy_point_settings.energy_point_settings.allocate_review_points",
 		"frappe.integrations.doctype.google_contacts.google_contacts.sync",
 		"frappe.automation.doctype.auto_repeat.auto_repeat.make_auto_repeat_entry",
-		"frappe.automation.doctype.auto_repeat.auto_repeat.set_auto_repeat_as_completed",
 	],
 	"daily_long": [
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_daily",


### PR DESCRIPTION
> Change in PR

- Added validation to ensure that the **Next Schedule Date** cannot be greater than the **End Date** if the **End Date** is specified.
- Fetched only those records where the **Next Schedule Date** is less than or equal to the **End Date**.
- Modified the error log message for better clarity.
- Added Tabs in the forms.
- Call `set_auto_repeat_as_completed` method after the job is successfully added in queue.

> Screenshots/GIFs

![image](https://github.com/user-attachments/assets/6d82ce8a-7fc4-4500-b6c3-89765cb26354)

![image](https://github.com/user-attachments/assets/1799704b-919e-4b2a-b611-4ed40310adbc)

![image](https://github.com/user-attachments/assets/3b94ec8f-9edd-47af-bfdd-29522f4e9412)

