### PR TITLE
fix: remove whitespace from restrict ip and always check request_ip

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -22,7 +22,7 @@ import frappe.rate_limiter
 import frappe.recorder
 import frappe.utils.response
 from frappe import _
-from frappe.auth import SAFE_HTTP_METHODS, UNSAFE_HTTP_METHODS, HTTPRequest, validate_auth
+from frappe.auth import SAFE_HTTP_METHODS, UNSAFE_HTTP_METHODS, HTTPRequest, check_request_ip, validate_auth
 from frappe.middlewares import StaticDataMiddleware
 from frappe.utils import CallbackManager, cint, get_site_name
 from frappe.utils.data import escape_html
@@ -199,6 +199,8 @@ def init_request(request):
 
 	for before_request_task in frappe.get_hooks("before_request"):
 		frappe.call(before_request_task)
+
+	check_request_ip()
 
 
 def setup_read_only_mode():

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -200,8 +200,6 @@ def init_request(request):
 	for before_request_task in frappe.get_hooks("before_request"):
 		frappe.call(before_request_task)
 
-	check_request_ip()
-
 
 def setup_read_only_mode():
 	"""During maintenance_mode reads to DB can still be performed to reduce downtime. This

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -464,7 +464,6 @@ def validate_ip_address(user):
 	if not ip_list:
 		return
 
-	# check if request ip is set before comaparing
 	check_request_ip()
 	for ip in ip_list:
 		if frappe.local.request_ip.startswith(ip):

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -720,4 +720,4 @@ def validate_auth_via_hooks():
 
 def check_request_ip():
 	if frappe.local.request_ip is None:
-		frappe.throw(title="Error", msg="Request IP is not set")
+		frappe.local.request_ip = "127.0.0.1"

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -460,9 +460,12 @@ def validate_ip_address(user):
 
 	user_info = frappe.get_cached_doc("User", user)
 	ip_list = user_info.get_restricted_ip_list()
+
 	if not ip_list:
 		return
 
+	# check if request ip is set before comaparing
+	check_request_ip()
 	for ip in ip_list:
 		if frappe.local.request_ip.startswith(ip):
 			return
@@ -713,3 +716,8 @@ def validate_api_key_secret(api_key, api_secret, frappe_authorization_source=Non
 def validate_auth_via_hooks():
 	for auth_hook in frappe.get_hooks("auth_hooks", []):
 		frappe.get_attr(auth_hook)()
+
+
+def check_request_ip():
+	if frappe.local.request_ip is None:
+		frappe.throw(title="Error", msg="Request IP is not set")

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -196,7 +196,8 @@ class User(Document):
 		self.validate_allowed_modules()
 		self.validate_user_image()
 		self.set_time_zone()
-		self.validate_ip_addr()
+		if self.restrict_ip:
+			self.validate_ip_addr()
 
 		if self.language == "Loading...":
 			self.language = None
@@ -814,17 +815,10 @@ class User(Document):
 
 	def validate_ip_addr(self):
 		# remove whitespace
-		if not self.restrict_ip:
-			return
-		if str.isspace(self.restrict_ip):
-			self.restrict_ip = None
+		if self.restrict_ip.find(",") != -1:
+			self.restrict_ip = self.restrict_ip.strip()
 		else:
-			if self.restrict_ip.find(",") != -1:
-				ip_string = ""
-				for s in self.restrict_ip.split(","):
-					s.strip()
-					ip_string = s + ","
-				self.restrict_ip = ip_string
+			self.restrict_ip = ",".join(self.get_restricted_ip_list())
 
 
 @frappe.whitelist()

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -814,6 +814,8 @@ class User(Document):
 
 	def validate_ip_addr(self):
 		# remove whitespace
+		if not self.restrict_ip:
+			return
 		if str.isspace(self.restrict_ip):
 			self.restrict_ip = None
 		else:

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -814,7 +814,6 @@ class User(Document):
 		)
 
 	def validate_ip_addr(self):
-		self.restrict_ip = self.restrict_ip.strip()
 		self.restrict_ip = ",".join(self.get_restricted_ip_list())
 
 
@@ -1320,7 +1319,7 @@ def get_restricted_ip_list(user):
 	if not user.restrict_ip:
 		return
 
-	return [i.strip() for i in user.restrict_ip.split(",")]
+	return [i.strip() for i in user.restrict_ip.strip().split(",")]
 
 
 @frappe.whitelist(methods=["POST"])

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -196,6 +196,7 @@ class User(Document):
 		self.validate_allowed_modules()
 		self.validate_user_image()
 		self.set_time_zone()
+		self.validate_ip_addr()
 
 		if self.language == "Loading...":
 			self.language = None
@@ -810,6 +811,18 @@ class User(Document):
 				"args": ["Form", self.doctype, self.name],
 			},
 		)
+
+	def validate_ip_addr(self):
+		# remove whitespace
+		if str.isspace(self.restrict_ip):
+			self.restrict_ip = None
+		else:
+			if self.restrict_ip.find(",") != -1:
+				ip_string = ""
+				for s in self.restrict_ip.split(","):
+					s.strip()
+					ip_string = s + ","
+				self.restrict_ip = ip_string
 
 
 @frappe.whitelist()

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -814,11 +814,8 @@ class User(Document):
 		)
 
 	def validate_ip_addr(self):
-		# remove whitespace
-		if self.restrict_ip.find(",") != -1:
-			self.restrict_ip = self.restrict_ip.strip()
-		else:
-			self.restrict_ip = ",".join(self.get_restricted_ip_list())
+		self.restrict_ip = self.restrict_ip.strip()
+		self.restrict_ip = ",".join(self.get_restricted_ip_list())
 
 
 @frappe.whitelist()


### PR DESCRIPTION
This PR fixes a issue which came  on FC  today where logging in as Admin was failing it was due to a whitespace. 