### PR TITLE
fix: View logging fails if no referrer

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2245,6 +2245,8 @@ def get_imaginary_pixel_response():
 
 
 def is_site_link(link: str) -> bool:
+	if not link:
+		return False
 	if link.startswith("/"):
 		return True
 	return urlparse(link).netloc == urlparse(frappe.utils.get_url()).netloc


### PR DESCRIPTION
```
AttributeError: 'NoneType' object has no attribute 'startswith'
  File "frappe/app.py", line 110, in application
    response = frappe.api.handle(request)
  File "frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
  File "frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
  File "frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
  File "frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "__init__.py", line 1680, in call
    return fn(*args, **newargs)
  File "frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
  File "frappe/website/doctype/web_page_view/web_page_view.py", line 58, in make_view_log
    if not frappe.utils.is_site_link(path):
  File "frappe/utils/data.py", line 2488, in is_site_link
    if link.startswith("/"):
```

(cherry picked from commit b71d01e1b44434a8f2241327f4109c0f6f209c6a)

<hr>

Sentry: FRAPPE-67P