### PR TITLE
refactor: modify error message for query report with insufficient permissions

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -39,7 +39,7 @@ def get_report_doc(report_name):
 
 	if not doc.is_permitted():
 		frappe.throw(
-			_("You don't have access to Report: {0} or its referenced report").format(_(report_name)),
+			_("You don't have access to Report: {0}").format(_(doc.name)),
 			frappe.PermissionError,
 		)
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -39,7 +39,7 @@ def get_report_doc(report_name):
 
 	if not doc.is_permitted():
 		frappe.throw(
-			_("You don't have access to Report: {0}").format(_(report_name)),
+			_("You don't have access to Report: {0} or its referenced report").format(_(report_name)),
 			frappe.PermissionError,
 		)
 


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

- The `get_report_doc()` function checks for reference report permissions when accessing the current report. However, the error message only displays the name of the report. As a result, users may struggle to understand that they also need reference report permissions to access the report.
