### PR TITLE
refactor: translate tooltip text of page

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -765,7 +765,7 @@ frappe.ui.Page = class Page {
 		}
 		let title_wrapper = this.$title_area.find(".title-text");
 		title_wrapper.html(title);
-		title_wrapper.attr("title", tooltip_label || this.title);
+		title_wrapper.attr("title", __(tooltip_label) || this.title);
 
 		if (tooltip_label) {
 			title_wrapper.tooltip({ delay: { show: 600, hide: 100 }, trigger: "hover" });


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/45366

Adds translation for the tooltip text



