### PR TITLE
chore(SocketIO): log connect error to console

### DIFF
--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -65,6 +65,10 @@ class RealTimeClient {
 			return;
 		}
 
+		this.socket.on("connect_error", function (err) {
+			console.error("Error connecting to socket.io:", err.message);
+		});
+
 		this.socket.on("msgprint", function (message) {
 			frappe.msgprint(message);
 		});


### PR DESCRIPTION
### Why?

Currently, no middleware error is shown to the user, making it hard to debug.

Ref: https://socket.io/docs/v4/middlewares/#handling-middleware-error

![CleanShot 2025-01-23 at 12 40 53@2x](https://github.com/user-attachments/assets/61130be2-27ad-44d3-939a-02731fe841d1)

