### PR TITLE
fix: Make sending emails via Sengrid work

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -143,6 +143,9 @@ class EmailAccount(Document):
 		else:
 			self.login_id = None
 
+		if self.service == "Sendgrid":
+			self.login_id = "apikey"
+
 		if self.service == "Frappe Mail":
 			self.use_imap = 0
 			self.always_use_account_email_id_as_sender = 1


### PR DESCRIPTION
This PR allows users to  setup Sendgrid Email successfully 
For frappe people refer this. https://support.frappe.io/helpdesk/tickets/29832
This fix is done by following the Sendgrid docs : https://www.twilio.com/docs/sendgrid/ui/account-and-settings/account


Before:


https://github.com/user-attachments/assets/450f6b6a-4aab-4a8b-bc80-a228c8105f56

After:

https://github.com/user-attachments/assets/00fb3b48-b96e-41c9-8de4-dbc3041c8471



