### PR TITLE
refactor: set button title using attr attribute

### DIFF
--- a/frappe/public/js/frappe/form/controls/button.js
+++ b/frappe/public/js/frappe/form/controls/button.js
@@ -7,9 +7,8 @@ frappe.ui.form.ControlButton = class ControlButton extends frappe.ui.form.Contro
 		var me = this;
 		const btn_type = this.df.primary ? "btn-primary" : "btn-default";
 		const btn_size = this.df.btn_size ? `btn-${this.df.btn_size}` : "btn-xs";
-		this.$input = $(
-			`<button class="btn ${btn_size} ${btn_type} ellipsis" title="${this.df.label}">`
-		)
+		this.$input = $(`<button class="btn ${btn_size} ${btn_type} ellipsis">`)
+			.attr("title", this.df.label)
 			.prependTo(me.input_area)
 			.on("click", function () {
 				me.onclick();


### PR DESCRIPTION

> Please provide enough information so that others can review your pull request:

Updated the button's title attribute to use .attr("title", ...). This ensures any special characters in this.df.label are properly escaped, preventing potential XSS vulnerabilities.


Reference https://github.com/frappe/frappe/pull/29114#discussion_r1913580492