### PR TITLE
refactor(printview): first check for doc permissions, then for website

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -375,12 +375,12 @@ def get_rendered_raw_commands(doc: str, name: str | None = None, print_format: s
 
 
 def validate_print_permission(doc: "Document") -> None:
-	if frappe.has_website_permission(doc):
-		return
-
 	for ptype in ("read", "print"):
 		if frappe.has_permission(doc.doctype, ptype, doc):
 			return
+
+	if frappe.has_website_permission(doc):
+		return
 
 	if (key := frappe.form_dict.key) and isinstance(key, str):
 		validate_key(key, doc)


### PR DESCRIPTION
This broke for some cases because people had doc permissions, but `has_website_permission()` returns False
