### PR TITLE
perf: Hard-limit `get_count` runtime to 1 second

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -620,7 +620,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		let $count = this.get_count_element();
 		this.get_count_str().then((count) => {
 			$count.html(`<span>${count}</span>`);
-			if (this.count_upper_bound && this.count_upper_bound == this.total_count) {
+			if (this.count_upper_bound) {
 				$count.attr(
 					"title",
 					__(
@@ -1017,13 +1017,15 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				Boolean(this.count_upper_bound)
 			)
 			.then((total_count) => {
-				this.total_count = total_count || current_count;
+				this.total_count = total_count;
 				this.count_without_children =
 					count_without_children !== current_count ? count_without_children : undefined;
 
 				let count_str;
 				if (this.total_count === this.count_upper_bound) {
 					count_str = `${format_number(this.total_count - 1, null, 0)}+`;
+				} else if (this.total_count == null) {
+					count_str = "??";
 				} else {
 					count_str = format_number(this.total_count, null, 0);
 				}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e81558ea-14ff-4f32-9143-f1f7a8271721)

Builds on top of: 
- https://github.com/frappe/frappe/pull/25348 
- https://github.com/frappe/frappe/pull/29871

We have limited count to 1000 by default but this can still easily read
entire table if:
- There are filters and filters don't use index and there aren't 1000
  matching rows.
- There are 1000 matching rows but they are sparse enough to still cause a lot of reads

This unknown tail latency by default is not acceptable, so any count query that fails to return results in 1 second will be terminated. Users will need to explicitly ask for an accurate count.


This "timeout" is cached too. So unless the user opts for an accurate number, there won't be any harm from repeat requests. 

With this PR following configuration is no longer required for the vast majority of users:


![image](https://github.com/user-attachments/assets/64f126a5-247a-4ae5-b776-189d1fe2e911)
