### PR TITLE
Revert "fix: don't skip perm check when Apply Strict User Permissions is enabled (#29916)"

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -66,6 +66,9 @@ def get_mapped_doc(
 	ignore_child_tables=False,
 	cached=False,
 ):
+	apply_strict_user_permissions = frappe.get_system_settings("apply_strict_user_permissions")
+
+	# main
 	if not target_doc:
 		target_doctype = table_maps[from_doctype]["doctype"]
 		if table_maps[from_doctype].get("on_parent"):
@@ -87,7 +90,7 @@ def get_mapped_doc(
 	else:
 		ret_doc = target_doc
 
-	if not ignore_permissions:
+	if not apply_strict_user_permissions and not ignore_permissions:
 		target_doc.check_permission("create")
 
 	if cached:
@@ -170,7 +173,7 @@ def get_mapped_doc(
 	ret_doc.run_method("after_mapping", source_doc)
 	ret_doc.set_onload("load_after_mapping", True)
 
-	if not ignore_permissions:
+	if apply_strict_user_permissions and not ignore_permissions:
 		ret_doc.check_permission("create")
 
 	return ret_doc


### PR DESCRIPTION
This reverts commit 4a0ccf6d76d2858f673d213bb2a765122a68f2d1 (#29916) in order to avoid unintended changes.

Better design:

- `get_mapped_doc` doesn't care about permissions
- permissions are checked before and/or after calling `get_mapped_doc`