### PR TITLE
perf: "random" naming to improve concurrency and locality

### DIFF
--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -83,7 +83,7 @@ class Monitor:
 			self.data.job.scheduled = True
 
 		if job := rq.get_current_job():
-			self.data.uuid = job.id
+			self.data.job_id = job.id
 			waitdiff = self.data.timestamp - job.enqueued_at.replace(tzinfo=datetime.timezone.utc)
 			self.data.job.wait = int(waitdiff.total_seconds() * 1000000)
 

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 
 import time
-import unittest
 from uuid import UUID
 
 import uuid_utils
@@ -407,7 +406,6 @@ class TestNaming(IntegrationTestCase):
 			expected_name = "TODO-" + nowdate().split("-")[1] + "-" + "0001"
 			self.assertEqual(name, expected_name)
 
-	@unittest.skip("This is not supported anymore, see #28349.")
 	@retry(
 		retry=retry_if_exception_type(AssertionError),
 		stop=stop_after_attempt(3),


### PR DESCRIPTION
This feels over-engineered and it kinda is, but other efforts to
introduce sequential naming/UUID naming haven't been that fruitful
either.

10 character random "hash" is now changed to:

1. first character - last character in UUID4 ID of request/job
2. three characters - derived from current timestamp.
4. 6 characters - random data.

This satisfies all three requirements:

1. Readers - temporal locality should result in spatial locality on disk. (fewer pages accessed)
2. Single writer - temporal locality should result in spatial locality. (fewer dirty pages)
3. Multiple writers + updater - temporal locality should NOT result in spatial locality @ suprenum (less lock contention)

Mostly concludes https://github.com/frappe/frappe/pull/25309 and https://github.com/frappe/frappe/pull/28349

**Rough probability numbers**

Assumptions:
- Unique per worker prefix - 16 (uuid's base16 version)
- Rough time spent generating names - 10% of request (very very conservative estimate)

Probability(collision) = P(at least one prefix collision) * P(time collision)
Probability(collision) = (1 - p(all different)) * 10%
Probability(collision) = (1 - (16! / 16-N! ) / 16^N ) * 10%

| N (concurrency) | Probability(collision) |
| --- | --- |
| 1  |    0.0% |
| 2  |    0.6% |
| 3  |    1.8% |
| 4  |    3.3% |
| 5  |    5.0% |
| 6  |    6.6% |
| 7  |    7.9% |
| 8  |    8.8% |
