### PR TITLE
fix: use strip_html() instead of escape_html()

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -31,7 +31,7 @@ from frappe.utils import (
 	now_datetime,
 	today,
 )
-from frappe.utils.data import sha256_hash
+from frappe.utils.data import sha256_hash, strip_html
 from frappe.utils.password import check_password, get_password_reset_limit
 from frappe.utils.password import update_password as _update_password
 from frappe.utils.user import get_system_managers
@@ -229,8 +229,6 @@ class User(Document):
 		self.roles = [r for r in self.roles if r.role in new_roles]
 		self.append_roles(*new_roles)
 
-	from frappe.deprecation_dumpster import validate_roles
-
 	def move_role_profile_name_to_role_profiles(self):
 		"""This handles old role_profile_name field if programatically set.
 
@@ -314,9 +312,12 @@ class User(Document):
 		return self.name == frappe.session.user
 
 	def clean_name(self):
-		self.first_name = escape_html(self.first_name)
-		self.middle_name = escape_html(self.middle_name)
-		self.last_name = escape_html(self.last_name)
+		if self.first_name:
+			self.first_name = strip_html(self.first_name)
+		if self.middle_name:
+			self.middle_name = strip_html(self.middle_name)
+		if self.last_name:
+			self.last_name = strip_html(self.last_name)
 
 	def set_full_name(self):
 		self.full_name = " ".join(filter(None, [self.first_name, self.last_name]))


### PR DESCRIPTION
escape_html() removes `'`, which can be used in names
