### PR TITLE
fix: restrict image size in comments

### DIFF
--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -337,3 +337,7 @@
 	color: var(--text-muted);
 	font-style: normal;
 }
+
+.ql-bubble .ql-editor img {
+	max-width: 500px !important;
+}


### PR DESCRIPTION
Before 
<img width="1440" alt="Screenshot 2025-01-27 at 3 44 27 PM" src="https://github.com/user-attachments/assets/86cd546c-7e97-4ef1-be56-6364fcf41cd8" />

After

<img width="1440" alt="Screenshot 2025-01-27 at 3 48 10 PM" src="https://github.com/user-attachments/assets/79ee2ea6-5eef-41a8-9c10-b9daa78eca6d" />


