### PR TITLE
feat(Data Import): delete Data Import Log on trash

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -130,6 +130,9 @@ class DataImport(Document):
 	def get_importer(self):
 		return Importer(self.reference_doctype, data_import=self, use_sniffer=self.use_csv_sniffer)
 
+	def on_trash(self):
+		frappe.db.delete("Data Import Log", {"data_import": self.name})
+
 
 @frappe.whitelist()
 def get_preview_from_template(data_import, import_file=None, google_sheets_url=None):


### PR DESCRIPTION
For every row in a **Data Import**, a **Data Import Log** is created. This is not even discoverable for a non-developer, but often the biggest table in a database. The only place where **Data Import Logs** are displayed is in **Data Import**. It's much easier to tell users to delete **Data Imports** than to search for **Data Import Logs** that are no longer needed. Therefore, **Data Import Logs** should be deleted when the corresponding **Data Import** is deleted.

> no-docs