### PR TITLE
fix: reorder session initialization in HTTPRequest to Fix Language Handling

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -38,11 +38,11 @@ class HTTPRequest:
 		# load cookies
 		self.set_cookies()
 
-		# login and start/resume user session
-		self.set_session()
-
 		# set request language
 		self.set_lang()
+
+		# login and start/resume user session
+		self.set_session()
 
 		# match csrf token from current session
 		self.validate_csrf_token()
@@ -631,7 +631,7 @@ def validate_oauth(authorization_header):
 	Authenticate request using OAuth and set session user
 
 	Args:
-	        authorization_header (list of str): The 'Authorization' header containing the prefix and token
+			authorization_header (list of str): The 'Authorization' header containing the prefix and token
 	"""
 
 	from frappe.integrations.oauth2 import get_oauth_server
@@ -671,7 +671,7 @@ def validate_auth_via_api_keys(authorization_header):
 	Authenticate request using API keys and set session user
 
 	Args:
-	        authorization_header (list of str): The 'Authorization' header containing the prefix and token
+			authorization_header (list of str): The 'Authorization' header containing the prefix and token
 	"""
 
 	try:


### PR DESCRIPTION
**PR Description:**  
This PR addresses an issue where the language preference passed via `_lang` in `form_dict` during a login attempt did not take effect when the login failed (e.g., due to incorrect credentials).  

### Changes Made:  
1. Reordered the `set_lang` method to be executed before the `set_session` method in the `HTTPRequest` class.  
2. Ensured that the language is set properly before user sessions are initialized, allowing error messages to reflect the correct language preference if `_lang` is passed in the request.  

### Issue Resolved:  
- When a user logs in and the attempt fails (e.g., incorrect password), the error message always appears in the default language, ignoring the `_lang` parameter in the request.  
- This fix ensures the `_lang` parameter is respected and reflected in the error messages during failed login attempts.

### Backport Note:
- This change should be backported to the `version-14` branch to ensure consistent language handling in error messages for users using that version.

### Screenshots
- Before the fixes
![image](https://github.com/user-attachments/assets/4dd729d0-da9a-446b-9c97-c12c0d74089b)
- After the fixes
![image](https://github.com/user-attachments/assets/5115482c-712c-40f2-bab2-2884af86af26)
