### PR TITLE
fix: don't allow attaching a file to a child table in a new document

### DIFF
--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -32,6 +32,12 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 
 		frappe.utils.bind_actions_with_object(this.$value, this);
 		this.toggle_reload_button();
+
+		// Don't allow attaching to child tables for new documents
+		if (this.doc.__islocal && this.doc.parent) {
+			this.$input.prop("disabled", true);
+			this.$input.attr("title", __("Save to enable file upload"));
+		}
 	}
 	clear_attachment() {
 		let me = this;


### PR DESCRIPTION
The end result is decently broken, and we don't have a proper way to represent files attached to a child table right now
