### PR TITLE
fix(report_view): skip read_only condition checking for reportview

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -714,6 +714,8 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			!df.hidden &&
 			// not a standard field i.e., owner, modified_by, etc.
 			frappe.model.is_non_std_field(df.fieldname) &&
+			// don't check read_only_depends_on if there's child table fields
+			!this.meta.fields.some((df) => df.fieldtype === "Table") &&
 			df.read_only_depends_on &&
 			!this.evaluate_read_only_depends_on(df.read_only_depends_on, data)
 		);


### PR DESCRIPTION
Child tables are represented differently and so some conditions can't be parsed

Resolves #29035
