### PR TITLE
feat: additional options for timespan filter

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -607,9 +607,9 @@ frappe.ui.filter_utils = {
 
 	get_timespan_options(periods) {
 		const period_map = {
-			Last: ["Week", "Month", "Quarter", "6 months", "Year"],
+			Last: ["7 Days", "14 Days", "30 Days", "Week", "Month", "Quarter", "6 months", "Year"],
 			This: ["Week", "Month", "Quarter", "Year"],
-			Next: ["Week", "Month", "Quarter", "6 months", "Year"],
+			Next: ["7 Days", "14 Days", "30 Days", "Week", "Month", "Quarter", "6 months", "Year"],
 		};
 		let options = [];
 		periods.forEach((period) => {

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -898,6 +898,21 @@ def get_timespan_date_range(
 	today = getdate()
 
 	match timespan:
+		case "last 7 days":
+			return (
+				add_to_date(today, days=-7),
+				today,
+			)
+		case "last 14 days":
+			return (
+				add_to_date(today, days=-14),
+				today,
+			)
+		case "last 30 days":
+			return (
+				add_to_date(today, days=-30),
+				today,
+			)
 		case "last week":
 			return (
 				get_first_day_of_week(add_to_date(today, days=-7)),
@@ -938,6 +953,21 @@ def get_timespan_date_range(
 			return (get_quarter_start(today), get_quarter_ending(today))
 		case "this year":
 			return (get_year_start(today), get_year_ending(today))
+		case "next 7 days":
+			return (
+				today,
+				add_to_date(today, days=7),
+			)
+		case "next 14 days":
+			return (
+				today,
+				add_to_date(today, days=14),
+			)
+		case "next 30 days":
+			return (
+				today,
+				add_to_date(today, days=30),
+			)
 		case "next week":
 			return (
 				get_first_day_of_week(add_to_date(today, days=7)),


### PR DESCRIPTION
Add "Last {n} Days" and "Next {n} Days" as options in timespan filter, for n ∈ {7, 14, 30}

This is useful for rolling timespans anchored to the current date. E.g. if you want to filter for upcoming birthdays, neither "This Week" nor "Next Week" are very useful, because they are mutually exclusive. You need "Next {n} Days".

> no-docs