### PR TITLE
chore: refactor for rq 2.x

### DIFF
--- a/frappe/utils/doctor.py
+++ b/frappe/utils/doctor.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from rq import Connection, Worker
+from rq import Worker
 
 import frappe.utils
 from frappe.utils.background_jobs import get_queue, get_queue_list, get_redis_conn
@@ -8,8 +8,7 @@ from frappe.utils.scheduler import is_scheduler_disabled, is_scheduler_inactive
 
 
 def get_workers():
-	with Connection(get_redis_conn()):
-		return Worker.all()
+	return Worker.all(connection=get_redis_conn())
 
 
 def purge_pending_jobs(event=None, site=None, queue=None):


### PR DESCRIPTION
There's no `Connection` anymore - we need to explicitly pass it in everywhere.

I updated to 2.x locally to reduce logspam because of some deprecated datetime functions, `bench doctor` was broken.

This works on both our current 1.16.2 and 2.0/2.1.
