### PR TITLE
fix: link field overlapping issue

### DIFF
--- a/frappe/public/js/frappe/form/link_selector.js
+++ b/frappe/public/js/frappe/form/link_selector.js
@@ -97,9 +97,9 @@ frappe.ui.form.LinkSelector = class LinkSelector {
 						var row = $(
 							repl(
 								'<div class="row link-select-row">\
-						<div class="col-xs-4">\
+						<div class="col-xs-4 ellipsis">\
 							<b><a href="#">%(name)s</a></b></div>\
-						<div class="col-xs-8">\
+						<div class="col-xs-8 ellipsis">\
 							<span class="text-muted">%(values)s</span></div>\
 						</div>',
 								{

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -190,7 +190,7 @@ select.form-control {
 
 	.link-btn {
 		@extend .action-btn;
-		background-color: none;
+		background-color: var(--control-bg);
 		display: none;
 	}
 }


### PR DESCRIPTION
Support Ticket: https://support.frappe.io/helpdesk/tickets/30148

> Screenshots/GIFs

Before
![image](https://github.com/user-attachments/assets/108afa01-8cdc-4132-bf54-68b84f2bb597)
![image](https://github.com/user-attachments/assets/a7aa200e-5b93-40a1-baaf-137240ee7a66)


After
![image](https://github.com/user-attachments/assets/618b2a62-a96f-438b-8af1-15ff8b4d4302)
![image](https://github.com/user-attachments/assets/7b37a6d7-c894-40ba-905e-257834d37d5b)


