### PR TITLE
perf: Throttle UX features aggresively on large tables

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1250,6 +1250,10 @@ class Database:
 			frappe.cache.set_value(f"doctype:count:{dt}", count, expires_in_sec=86400)
 		return count
 
+	def estimate_count(self, doctype: str) -> int:
+		"""Get estimated count of total rows in a table."""
+		raise NotImplementedError
+
 	@staticmethod
 	def format_date(date):
 		return getdate(date).strftime("%Y-%m-%d")

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -541,3 +541,12 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 		finally:
 			self._cursor = original_cursor
 			new_cursor.close()
+
+	def estimate_count(self, doctype: str):
+		"""Get estimated count of total rows in a table."""
+		from frappe.utils.data import cint
+
+		table = get_table_name(doctype)
+
+		count = self.sql("select table_rows from information_schema.tables where table_name = %s", table)
+		return cint(count[0][0]) if count else 0

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -483,6 +483,14 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 	def get_database_list(self):
 		return self.sql("SELECT datname FROM pg_database", pluck=True)
 
+	def estimate_count(self, doctype: str):
+		"""Get estimated count of total rows in a table."""
+		from frappe.utils.data import cint
+
+		table = get_table_name(doctype)
+		count = self.sql("select reltuples from pg_class where relname = %s", table)
+		return cint(count[0][0]) if count else 0
+
 
 def modify_query(query):
 	""" "Modifies query according to the requirements of postgres"""

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -59,6 +59,11 @@ DEFAULT_FIELD_LABELS = {
 	"_assign": _lt("Assigned To"),
 }
 
+# When number of rows in a table exceeds this number, we disable certain features automatically.
+# This is done to avoid hammering the site with unnecessary requests that are just meant for
+# improving UX.
+LARGE_TABLE_THRESHOLD = 100_000
+
 
 def get_meta(doctype: str | dict | DocRef, cached=True) -> "_Meta":
 	"""Get metadata for a doctype.
@@ -185,6 +190,7 @@ class Meta(Document):
 		self.get_valid_columns()
 		self.set_custom_permissions()
 		self.add_custom_links_and_actions()
+		self.is_large_table = frappe.db.estimate_count(self.name) > LARGE_TABLE_THRESHOLD
 
 	def as_dict(self, no_nulls=False):
 		def serialize(doc):

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -24,9 +24,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	constructor(opts) {
 		super(opts);
 		this.show();
+		const meta = frappe.get_meta(this.doctype);
 		this.debounced_refresh = frappe.utils.debounce(
 			this.process_document_refreshes.bind(this),
-			5000
+			meta?.is_large_table ? 15000 : 2000
 		);
 		this.count_upper_bound = 1001;
 		this._element_factory = new ElementFactory(this.doctype);

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -500,7 +500,8 @@ frappe.ui.filter_utils = {
 	},
 
 	get_default_condition(df) {
-		if (df.fieldtype == "Data") {
+		const meta = frappe.get_meta(df.parent);
+		if (df.fieldtype == "Data" && !meta?.is_large_table) {
 			return "like";
 		} else if (df.fieldtype == "Date" || df.fieldtype == "Datetime") {
 			return "Between";

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -510,6 +510,9 @@ class TestDB(IntegrationTestCase):
 
 		self.assertEqual(frappe.db.exists(dt, [["name", "=", dn]]), dn)
 
+	def test_estimated_count(self):
+		self.assertGreater(frappe.db.estimate_count("DocField"), 100)
+
 	def test_datetime_serialization(self):
 		dt = now_datetime()
 		dt = dt.replace(microsecond=0)


### PR DESCRIPTION
When table size exceeds a certain threshold (100K rows), the following behavior will change automatically:

- filters will not default to `like`, users can pick it still if they want to. 
- listview auto-refresh is debounced by 15s instead of 2s (default)


More can be added as we discover them, fixing all those problems in one shot is not possible.