### PR TITLE
fix: set report name as pdf name

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -355,7 +355,7 @@ def export_query():
 		file_extension = "xlsx"
 		content = make_xlsx(xlsx_data, "Query Report", column_widths=column_widths).getvalue()
 
-	for value in data.filters.values():
+	for value in (data.filters or {}).values():
 		if len(report_name) > 200:
 			break
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -355,6 +355,15 @@ def export_query():
 		file_extension = "xlsx"
 		content = make_xlsx(xlsx_data, "Query Report", column_widths=column_widths).getvalue()
 
+	for value in data.filters.values():
+		if len(report_name) > 200:
+			break
+
+		if isinstance(value, list) and value:
+			report_name += "_" + ",".join(value)
+		elif isinstance(value, str) and value not in {"Yes", "No"}:
+			report_name += f"_{value}"
+
 	provide_binary_file(report_name, file_extension, content)
 
 


### PR DESCRIPTION
Issue:
When exporting reports to Excel in ERPNext, the file name does not follow the same naming convention as the PDF export.

ref: [29868](https://github.com/frappe/frappe/issues/29868)

Before:

[report_name_bfr.webm](https://github.com/user-attachments/assets/4020144b-dafb-484b-a310-e32dcf38ea5c)

After:

[report_name_afr.webm](https://github.com/user-attachments/assets/4f9ca8b0-d6d5-4d09-a94f-a1977f19df5b)

Back port needed for version-15