### PR TITLE
feat: Add Julian Day to Name Series parse switch

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -364,6 +364,8 @@ def parse_naming_series(
 			part = today.strftime("%d")
 		elif e == "YYYY":
 			part = today.strftime("%Y")
+		elif e == "JJJ":
+			part = today.strftime("%j")
 		elif e == "WW":
 			part = determine_consecutive_week_number(today)
 		elif e == "timestamp":

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -364,8 +364,6 @@ def parse_naming_series(
 			part = today.strftime("%d")
 		elif e == "YYYY":
 			part = today.strftime("%Y")
-		elif e == "JJJ":
-			part = today.strftime("%j")
 		elif e == "WW":
 			part = determine_consecutive_week_number(today)
 		elif e == "timestamp":

--- a/frappe/patches/v16_0/update_expression_series.py
+++ b/frappe/patches/v16_0/update_expression_series.py
@@ -28,6 +28,8 @@ def execute():
 				part = creation.strftime("%d")
 			elif e == "YYYY":
 				part = creation.strftime("%Y")
+			elif e == "JJJ":
+				part = creation.strftime("%j")
 			elif e == "WW":
 				part = determine_consecutive_week_number(creation)
 			elif e == "timestamp":

--- a/frappe/patches/v16_0/update_expression_series.py
+++ b/frappe/patches/v16_0/update_expression_series.py
@@ -27,8 +27,6 @@ def execute():
 			elif e == "DD":
 				part = creation.strftime("%d")
 			elif e == "YYYY":
-				part = creation.strftime("%Y")
-			elif e == "JJJ":
 				part = creation.strftime("%j")
 			elif e == "WW":
 				part = determine_consecutive_week_number(creation)

--- a/frappe/patches/v16_0/update_expression_series.py
+++ b/frappe/patches/v16_0/update_expression_series.py
@@ -28,8 +28,6 @@ def execute():
 				part = creation.strftime("%d")
 			elif e == "YYYY":
 				part = creation.strftime("%Y")
-			elif e == "JJJ":
-				part = creation.strftime("%j")
 			elif e == "WW":
 				part = determine_consecutive_week_number(creation)
 			elif e == "timestamp":

--- a/frappe/patches/v16_0/update_expression_series.py
+++ b/frappe/patches/v16_0/update_expression_series.py
@@ -27,7 +27,7 @@ def execute():
 			elif e == "DD":
 				part = creation.strftime("%d")
 			elif e == "YYYY":
-				part = creation.strftime("%j")
+				part = creation.strftime("%Y")
 			elif e == "WW":
 				part = determine_consecutive_week_number(creation)
 			elif e == "timestamp":


### PR DESCRIPTION
Julian dates are standard with both Batch Dates and Serial Numbers.

Though they are used in many other naming conventions as well.

![image](https://github.com/user-attachments/assets/8997e1c8-3aa6-4275-984b-9bd8566baa15)

![image](https://github.com/user-attachments/assets/b390b175-38d1-47dc-8516-735d72b78b1a)

`no-docs`