### PR TITLE
fix: add multicurrency support in number card and dashboard chart 

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -33,6 +33,7 @@
   "time_interval",
   "timeseries",
   "type",
+  "currency",
   "filters_section",
   "filters_json",
   "dynamic_filters_section",
@@ -286,10 +287,16 @@
    "fieldtype": "Table",
    "label": "Roles",
    "options": "Has Role"
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "options": "Currency"
   }
  ],
  "links": [],
- "modified": "2024-06-03 13:29:57.960271",
+ "modified": "2025-02-01 21:06:05.808591",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -349,6 +349,7 @@ class DashboardChart(Document):
 		chart_name: DF.Data
 		chart_type: DF.Literal["Count", "Sum", "Average", "Group By", "Custom", "Report"]
 		color: DF.Color | None
+		currency: DF.Link | None
 		custom_options: DF.Code | None
 		document_type: DF.Link | None
 		dynamic_filters_json: DF.Code | None

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -20,6 +20,7 @@
   "report_field",
   "report_function",
   "is_public",
+  "currency",
   "custom_configuration_section",
   "filters_config",
   "stats_section",
@@ -200,10 +201,16 @@
    "fieldtype": "Link",
    "label": "Parent Document Type",
    "options": "DocType"
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "options": "Currency"
   }
  ],
  "links": [],
- "modified": "2024-03-23 16:03:32.189147",
+ "modified": "2025-01-28 18:22:27.268239",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -24,6 +24,7 @@ class NumberCard(Document):
 
 		aggregate_function_based_on: DF.Literal[None]
 		color: DF.Color | None
+		currency: DF.Link | None
 		document_type: DF.Link | None
 		dynamic_filters_json: DF.Code | None
 		filters_config: DF.Code | None

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -605,14 +605,20 @@ export default class ChartWidget extends Widget {
 			options = chart_options.options;
 		}
 
-		chart_args.tooltipOptions = {
-			formatTooltipY: (value) =>
-				frappe.format(
-					value,
-					{ fieldtype, options },
-					{ always_show_decimals: true, inline: true }
-				),
-		};
+		if (this.chart_doc.currency) {
+			chart_args.tooltipOptions = {
+				formatTooltipY: (value) => format_currency(value, this.chart_doc.currency),
+			};
+		} else {
+			chart_args.tooltipOptions = {
+				formatTooltipY: (value) =>
+					frappe.format(
+						value,
+						{ fieldtype, options },
+						{ always_show_decimals: true, inline: true }
+					),
+			};
+		}
 
 		if (this.chart_doc.type == "Heatmap") {
 			const heatmap_year = parseInt(

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -220,7 +220,11 @@ export default class NumberCardWidget extends Widget {
 		const default_country = frappe.sys_defaults.country;
 		const shortened_number = frappe.utils.shorten_number(this.number, default_country, 5);
 		let number_parts = shortened_number.split(" ");
-
+		// done to add multicurrency support in number card
+		if (this.card_doc.currency) {
+			this.formatted_number = format_currency(number_parts[0], this.card_doc.currency);
+			return;
+		}
 		const symbol = number_parts[1] || "";
 		number_parts[0] = window.convert_old_to_new_number_format(number_parts[0]);
 		const formatted_number = frappe.format(number_parts[0], df, null, doc);


### PR DESCRIPTION
In a multicompany setup of ERPNext you may need the ability for number cards and dashboard chart to have a different currency than the one set in as the default currency

For frappe people https://support.frappe.io/helpdesk/tickets/30068


<img width="1020" alt="Screenshot 2025-02-02 at 10 18 04 PM" src="https://github.com/user-attachments/assets/49d8db60-8663-41bf-9795-4fc4dceaf151" />



https://github.com/user-attachments/assets/52bc2ce5-f61b-45fe-8b54-371080cae3d8

