### PR TITLE
feat: add support for sticky columns in child table

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -48,6 +48,7 @@
   "in_list_view",
   "in_standard_filter",
   "in_preview",
+  "sticky",
   "column_break_35",
   "in_filter",
   "in_global_search",
@@ -108,8 +109,7 @@
    "oldfieldtype": "Select",
    "options": "Autocomplete\nAttach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDuration\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nIcon\nImage\nInt\nJSON\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nPhone\nRead Only\nRating\nSection Break\nSelect\nSignature\nSmall Text\nTab Break\nTable\nTable MultiSelect\nText\nText Editor\nTime",
    "reqd": 1,
-   "search_index": 1,
-   "sort_options": 1
+   "search_index": 1
   },
   {
    "bold": 1,
@@ -320,7 +320,6 @@
    "fieldname": "permlevel",
    "fieldtype": "Int",
    "label": "Perm Level",
-   "non_negative": 1,
    "oldfieldname": "permlevel",
    "oldfieldtype": "Int",
    "print_width": "50px",
@@ -601,13 +600,20 @@
    "fieldname": "make_attachment_public",
    "fieldtype": "Check",
    "label": "Make Attachment Public (by default)"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
+   "fieldname": "sticky",
+   "fieldtype": "Check",
+   "label": "Sticky"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-10-15 23:33:03.926033",
+ "modified": "2025-01-30 14:58:19.746600",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/core/doctype/docfield/docfield.py
+++ b/frappe/core/doctype/docfield/docfield.py
@@ -116,6 +116,7 @@ class DocField(Document):
 		show_dashboard: DF.Check
 		show_on_timeline: DF.Check
 		sort_options: DF.Check
+		sticky: DF.Check
 		translatable: DF.Check
 		unique: DF.Check
 		width: DF.Data | None

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -24,6 +24,9 @@ export default class Grid {
 		this.fieldinfo = {};
 		this.doctype = this.df.options;
 
+		this.sticky_row_sum = 71;
+		this.sticky_rows = [];
+
 		if (this.doctype) {
 			this.meta = frappe.get_meta(this.doctype);
 		}
@@ -45,27 +48,23 @@ export default class Grid {
 	}
 
 	setup_tab_listeners() {
-		$(".nav-link").on("shown.bs.tab", () => {
-			this.handle_scroll_bar();
-		});
+		// $(".nav-link").on("shown.bs.tab", () => {
+		// 	this.handle_scroll_bar();
+		// });
 	}
 	handle_scroll_bar() {
-		frappe.utils.sleep(500).then(() => {
-			let grid_body_width = this.wrapper.find(".grid-body").width();
-
-			let grid_scroll_bar = this.wrapper.find(".grid-scroll-bar");
-
-			let grid_scroll_bar_rows = this.wrapper.find(".grid-scroll-bar-rows");
-
-			grid_scroll_bar.width(this.form_grid.width());
-			grid_scroll_bar_rows.width(grid_body_width);
-
-			grid_scroll_bar.on("scroll", (event) => {
-				// Sync the form grid's left position with the scroll bar
-				this.form_grid.css("position", "relative");
-				this.form_grid.css("left", -$(event.currentTarget).scrollLeft() + "px");
-			});
-		});
+		// frappe.utils.sleep(500).then(() => {
+		// 	let grid_body_width = this.wrapper.find(".grid-body").width();
+		// 	let grid_scroll_bar = this.wrapper.find(".grid-scroll-bar");
+		// 	let grid_scroll_bar_rows = this.wrapper.find(".grid-scroll-bar-rows");
+		// 	grid_scroll_bar.width(this.form_grid.width());
+		// 	grid_scroll_bar_rows.width(grid_body_width);
+		// 	grid_scroll_bar.on("scroll", (event) => {
+		// 		// Sync the form grid's left position with the scroll bar
+		// 		this.form_grid.css("position", "relative");
+		// 		this.form_grid.css("left", -$(event.currentTarget).scrollLeft() + "px");
+		// 	});
+		// });
 	}
 
 	get perm() {
@@ -100,9 +99,6 @@ export default class Grid {
 								${__("No rows")}
 							</div>
 						</div>
-					</div>
-					<div class="grid-scroll-bar">
-						<div class="grid-scroll-bar-rows"></div>
 					</div>
 				</div>
 				<div class="small form-clickable-section grid-footer">
@@ -149,56 +145,45 @@ export default class Grid {
 		this.form_grid = this.wrapper.find(".form-grid");
 
 		if (this.form_grid) {
-			this.form_grid.on("wheel", (e) => {
-				const isTrackpad = Math.abs(e.originalEvent.wheelDeltaY) < 50;
-				const delta = e.originalEvent.deltaX;
-				const scroll_bar = this.wrapper.find(".grid-scroll-bar");
-
-				if (isTrackpad) {
-					scroll_bar.scrollLeft(scroll_bar.scrollLeft() + delta);
-				} else {
-					scroll_bar.scrollLeft(scroll_bar.scrollLeft() + delta * 4);
-				}
-
-				// prevent default behaviour when it is scrolled horizontally
-				if (e.originalEvent.deltaX != 0) {
-					e.preventDefault();
-				}
-			});
-			let touchStartX = 0;
-			let touchMoveX = 0;
-			let isTouchScrolling = false;
-
-			// Handle touch start
-			this.form_grid.on("touchstart", (e) => {
-				const touch = e.originalEvent.touches[0];
-				touchStartX = touch.pageX;
-				isTouchScrolling = true;
-			});
-
-			// Handle touch move
-			this.form_grid.on("touchmove", (e) => {
-				if (!isTouchScrolling) return;
-
-				const touch = e.originalEvent.touches[0];
-				touchMoveX = touch.pageX;
-
-				const scrollBar = this.wrapper.find(".grid-scroll-bar");
-				const deltaX = touchStartX - touchMoveX;
-
-				scrollBar.scrollLeft(scrollBar.scrollLeft() + deltaX);
-
-				touchStartX = touchMoveX;
-
-				e.preventDefault();
-			});
-
-			// Handle touch end
-			this.form_grid.on("touchend", () => {
-				isTouchScrolling = false;
-			});
-
-			this.handle_scroll_bar();
+			// this.form_grid.on("wheel", (e) => {
+			// 	const isTrackpad = Math.abs(e.originalEvent.wheelDeltaY) < 50;
+			// 	const delta = e.originalEvent.deltaX;
+			// 	const scroll_bar = this.wrapper.find(".grid-scroll-bar");
+			// 	if (isTrackpad) {
+			// 		scroll_bar.scrollLeft(scroll_bar.scrollLeft() + delta);
+			// 	} else {
+			// 		scroll_bar.scrollLeft(scroll_bar.scrollLeft() + delta * 4);
+			// 	}
+			// 	// prevent default behaviour when it is scrolled horizontally
+			// 	if (e.originalEvent.deltaX != 0) {
+			// 		e.preventDefault();
+			// 	}
+			// });
+			// let touchStartX = 0;
+			// let touchMoveX = 0;
+			// let isTouchScrolling = false;
+			// // Handle touch start
+			// this.form_grid.on("touchstart", (e) => {
+			// 	const touch = e.originalEvent.touches[0];
+			// 	touchStartX = touch.pageX;
+			// 	isTouchScrolling = true;
+			// });
+			// // Handle touch move
+			// this.form_grid.on("touchmove", (e) => {
+			// 	if (!isTouchScrolling) return;
+			// 	const touch = e.originalEvent.touches[0];
+			// 	touchMoveX = touch.pageX;
+			// 	const scrollBar = this.wrapper.find(".grid-scroll-bar");
+			// 	const deltaX = touchStartX - touchMoveX;
+			// 	scrollBar.scrollLeft(scrollBar.scrollLeft() + deltaX);
+			// 	touchStartX = touchMoveX;
+			// 	e.preventDefault();
+			// });
+			// // Handle touch end
+			// this.form_grid.on("touchend", () => {
+			// 	isTouchScrolling = false;
+			// });
+			// this.handle_scroll_bar();
 		}
 		this.setup_add_row();
 
@@ -1105,6 +1090,7 @@ export default class Grid {
 					if (column) {
 						column.in_list_view = 1;
 						column.columns = row.columns;
+						column.sticky = row.sticky;
 						return column;
 					}
 				})

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -44,27 +44,6 @@ export default class Grid {
 		this.is_grid = true;
 		this.debounced_refresh = this.refresh.bind(this);
 		this.debounced_refresh = frappe.utils.debounce(this.debounced_refresh, 100);
-		this.setup_tab_listeners();
-	}
-
-	setup_tab_listeners() {
-		// $(".nav-link").on("shown.bs.tab", () => {
-		// 	this.handle_scroll_bar();
-		// });
-	}
-	handle_scroll_bar() {
-		// frappe.utils.sleep(500).then(() => {
-		// 	let grid_body_width = this.wrapper.find(".grid-body").width();
-		// 	let grid_scroll_bar = this.wrapper.find(".grid-scroll-bar");
-		// 	let grid_scroll_bar_rows = this.wrapper.find(".grid-scroll-bar-rows");
-		// 	grid_scroll_bar.width(this.form_grid.width());
-		// 	grid_scroll_bar_rows.width(grid_body_width);
-		// 	grid_scroll_bar.on("scroll", (event) => {
-		// 		// Sync the form grid's left position with the scroll bar
-		// 		this.form_grid.css("position", "relative");
-		// 		this.form_grid.css("left", -$(event.currentTarget).scrollLeft() + "px");
-		// 	});
-		// });
 	}
 
 	get perm() {
@@ -143,48 +122,6 @@ export default class Grid {
 		frappe.utils.bind_actions_with_object(this.wrapper, this);
 
 		this.form_grid = this.wrapper.find(".form-grid");
-
-		if (this.form_grid) {
-			// this.form_grid.on("wheel", (e) => {
-			// 	const isTrackpad = Math.abs(e.originalEvent.wheelDeltaY) < 50;
-			// 	const delta = e.originalEvent.deltaX;
-			// 	const scroll_bar = this.wrapper.find(".grid-scroll-bar");
-			// 	if (isTrackpad) {
-			// 		scroll_bar.scrollLeft(scroll_bar.scrollLeft() + delta);
-			// 	} else {
-			// 		scroll_bar.scrollLeft(scroll_bar.scrollLeft() + delta * 4);
-			// 	}
-			// 	// prevent default behaviour when it is scrolled horizontally
-			// 	if (e.originalEvent.deltaX != 0) {
-			// 		e.preventDefault();
-			// 	}
-			// });
-			// let touchStartX = 0;
-			// let touchMoveX = 0;
-			// let isTouchScrolling = false;
-			// // Handle touch start
-			// this.form_grid.on("touchstart", (e) => {
-			// 	const touch = e.originalEvent.touches[0];
-			// 	touchStartX = touch.pageX;
-			// 	isTouchScrolling = true;
-			// });
-			// // Handle touch move
-			// this.form_grid.on("touchmove", (e) => {
-			// 	if (!isTouchScrolling) return;
-			// 	const touch = e.originalEvent.touches[0];
-			// 	touchMoveX = touch.pageX;
-			// 	const scrollBar = this.wrapper.find(".grid-scroll-bar");
-			// 	const deltaX = touchStartX - touchMoveX;
-			// 	scrollBar.scrollLeft(scrollBar.scrollLeft() + deltaX);
-			// 	touchStartX = touchMoveX;
-			// 	e.preventDefault();
-			// });
-			// // Handle touch end
-			// this.form_grid.on("touchend", () => {
-			// 	isTouchScrolling = false;
-			// });
-			// this.handle_scroll_bar();
-		}
 		this.setup_add_row();
 
 		this.setup_grid_pagination();

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -934,19 +934,14 @@ export default class GridRow {
 
 		let add_style = "";
 		if (df.sticky) {
-			// add_style = 'position: sticky; z-index: 1;';
 			add_class += " sticky-grid-col";
-			add_style += `left: ${this.grid.sticky_rows[df.fieldname] || 71}px;`;
-			const html_tag_pattern = /<\/?[a-z][\s\S]*>/i;
-
-			if (!html_tag_pattern.test(txt)) {
-				if (!(df.fieldname in this.grid.sticky_rows)) {
-					this.grid.sticky_rows[df.fieldname] = this.grid.sticky_row_sum;
-					this.grid.sticky_row_sum = Object.keys(this.grid.sticky_rows).length
-						? this.grid.sticky_row_sum + col_sizes[colsize]
-						: this.grid.sticky_row_sum;
-				}
+			if (!(df.fieldname in this.grid.sticky_rows)) {
+				this.grid.sticky_rows[df.fieldname] = this.grid.sticky_row_sum;
+				this.grid.sticky_row_sum = Object.keys(this.grid.sticky_rows).length
+					? this.grid.sticky_row_sum + col_sizes[colsize]
+					: this.grid.sticky_row_sum;
 			}
+			add_style += `left: ${this.grid.sticky_rows[df.fieldname] || 71}px;`;
 		}
 
 		let grid;

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -718,7 +718,6 @@ export default class GridRow {
 			let df = fields.find((field) => field?.fieldname === col[0].fieldname);
 
 			this.set_dependant_property(df);
-			// console.log(col);
 
 			let colsize = col[1];
 

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -425,6 +425,7 @@ export default class GridRow {
 			this.selected_columns_for_grid.push({
 				fieldname: row[0].fieldname,
 				columns: row[0].columns || row[0].colsize,
+				sticky: row[0].sticky,
 			});
 		});
 	}
@@ -436,11 +437,14 @@ export default class GridRow {
 			<div class='form-group'>
 				<div class='row' style='margin-bottom:10px;'>
 					<div class='col-1'></div>
-					<div class='col-6' style='padding-left:20px;'>
+					<div class='col-5' style='padding-left:20px;'>
 						${__("Fieldname").bold()}
 					</div>
-					<div class='col-4'>
+					<div class='col-3'>
 						${__("Column Width").bold()}
+					</div>
+					<div class='col-2'>
+						${__("Sticky").bold()}
 					</div>
 					<div class='col-1'></div>
 				</div>
@@ -566,13 +570,19 @@ export default class GridRow {
 							<div class='col-1' style='padding-top: 4px;'>
 								<a style='cursor: grabbing;'>${frappe.utils.icon("drag", "xs")}</a>
 							</div>
-							<div class='col-6' style='padding-top: 5px;'>
+							<div class='col-5' style='padding-top: 5px;'>
 								${__(docfield.label, null, docfield.parent)}
 							</div>
-							<div class='col-4' style='padding-top: 2px; margin-top:-2px;' title='${__("Columns")}'>
+							<div class='col-3' style='padding-top: 2px; margin-top:-2px;' title='${__("Columns")}'>
 								<input class='form-control column-width my-1 input-xs text-right'
 								style='height: 24px; max-width: 80px; background: var(--bg-color);'
 									value='${docfield.columns || cint(d.columns)}'
+									data-fieldname='${docfield.fieldname}' style='background-color: var(--modal-bg); display: inline'>
+							</div>
+							<div class='col-2' title='${__("Sticky")}'>
+								<input type='checkbox' class='form-control sticky-column'
+									style='margin-top: 8px'
+									${docfield.sticky ? "checked" : ""}
 									data-fieldname='${docfield.fieldname}' style='background-color: var(--modal-bg); display: inline'>
 							</div>
 							<div class='col-1' style='padding-top: 3px;'>
@@ -590,6 +600,7 @@ export default class GridRow {
 		this.prepare_handler_for_sort();
 		this.select_on_focus();
 		this.update_column_width();
+		this.update_sticky_column();
 		this.remove_selected_column();
 	}
 
@@ -636,6 +647,19 @@ export default class GridRow {
 					if (row.fieldname === event.target.dataset.fieldname) {
 						row.columns = cint(event.target.value);
 						event.target.defaultValue = cint(event.target.value);
+					}
+				});
+			});
+	}
+
+	update_sticky_column() {
+		$(this.fields_html_wrapper)
+			.find(".sticky-column")
+			.change((event) => {
+				this.selected_columns_for_grid.forEach((row) => {
+					if (row.fieldname === event.target.dataset.fieldname) {
+						row.sticky = cint(event.target.checked);
+						event.target.defaultValue = cint(event.target.checked);
 					}
 				});
 			});
@@ -696,6 +720,7 @@ export default class GridRow {
 			let df = fields.find((field) => field?.fieldname === col[0].fieldname);
 
 			this.set_dependant_property(df);
+			// console.log(col);
 
 			let colsize = col[1];
 
@@ -884,6 +909,20 @@ export default class GridRow {
 	}
 
 	make_column(df, colsize, txt, ci) {
+		let col_sizes = {
+			1: 60,
+			2: 100,
+			3: 140,
+			4: 200,
+			5: 250,
+			6: 300,
+			7: 350,
+			8: 400,
+			9: 450,
+			10: 500,
+			11: 550,
+			12: 600,
+		};
 		let me = this;
 		var add_class =
 			["Text", "Small Text"].indexOf(df.fieldtype) !== -1
@@ -894,6 +933,23 @@ export default class GridRow {
 				? " text-right"
 				: "";
 		add_class += ["Check"].indexOf(df.fieldtype) !== -1 ? " text-center" : "";
+
+		let add_style = "";
+		if (df.sticky) {
+			// add_style = 'position: sticky; z-index: 1;';
+			add_class += " sticky-grid-col";
+			add_style += `left: ${this.grid.sticky_rows[df.fieldname] || 71}px;`;
+			const html_tag_pattern = /<\/?[a-z][\s\S]*>/i;
+
+			if (!html_tag_pattern.test(txt)) {
+				if (!(df.fieldname in this.grid.sticky_rows)) {
+					this.grid.sticky_rows[df.fieldname] = this.grid.sticky_row_sum;
+					this.grid.sticky_row_sum = Object.keys(this.grid.sticky_rows).length
+						? this.grid.sticky_row_sum + col_sizes[colsize]
+						: this.grid.sticky_row_sum;
+				}
+			}
+		}
 
 		let grid;
 		let grid_container;
@@ -950,13 +1006,28 @@ export default class GridRow {
 		}
 
 		var $col = $(
-			'<div class="col grid-static-col col-xs-' + colsize + " " + add_class + '"></div>'
+			`<div class="col grid-static-col col-xs-${colsize} ${add_class}" style="${add_style}"></div>`
 		)
 			.attr("data-fieldname", df.fieldname)
 			.attr("data-fieldtype", df.fieldtype)
 			.data("df", df)
 			.appendTo(this.row)
 			.on("click", function (event) {
+				if (df.fieldtype === "Link") {
+					frappe.utils.sleep(500).then(() => {
+						let element_position = event.target.getBoundingClientRect();
+						$(this)
+							.find(".awesomplete > ul:first-of-type")
+							.css(
+								"top",
+								`${
+									element_position.bottom
+										? element_position.bottom
+										: event.clientY + 20
+								}px`
+							);
+					});
+				}
 				if (frappe.ui.form.editable_row !== me) {
 					var out = me.toggle_editable_row();
 				}

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -408,14 +408,12 @@ export default class GridRow {
 			this.columns = {};
 			this.update_user_settings_for_grid();
 			this.grid_settings_dialog.hide();
-			this.grid.handle_scroll_bar();
 		});
 
 		this.grid_settings_dialog.set_secondary_action_label(__("Reset to default"));
 		this.grid_settings_dialog.set_secondary_action(() => {
 			this.reset_user_settings_for_grid();
 			this.grid_settings_dialog.hide();
-			this.grid.handle_scroll_bar();
 		});
 	}
 

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -27,6 +27,12 @@
 
 	&.with-filter {
 		height: 66px;
+		.grid-row:nth-child(2) {
+			.row-check,
+			.row-index {
+				background-color: var(--fg-color);
+			}
+		}
 	}
 	.filter-row {
 		background-color: var(--bg-color);
@@ -42,6 +48,16 @@
 	.row-index {
 		height: 32px;
 		padding: 4px 8px !important;
+		background-color: var(--subtle-fg);
+	}
+	.row-check,
+	.row-index {
+		position: sticky;
+		left: 0;
+		z-index: 1;
+	}
+	.row-index {
+		left: 31px;
 	}
 	.grid-static-col {
 		padding: 6px 8px !important;
@@ -102,6 +118,16 @@
 .grid-body .data-row {
 	@include get_textstyle("sm", "regular");
 	color: var(--text-muted);
+	.row-check,
+	.row-index {
+		position: sticky;
+		left: 0;
+		background-color: var(--fg-color);
+		z-index: 1;
+	}
+	.row-index {
+		left: 31px;
+	}
 }
 
 .grid-empty,
@@ -206,6 +232,10 @@
 		border-right: 1px solid var(--table-border-color);
 		// overflow: hidden;
 	}
+	.sticky-grid-col {
+		position: sticky;
+		z-index: 1;
+	}
 }
 
 .grid-body {
@@ -216,6 +246,7 @@
 
 	.col:last-child {
 		border: none;
+		background-color: var(--fg-color);
 	}
 
 	.btn-open-row {
@@ -270,7 +301,6 @@
 		}
 
 		.has-error .form-control {
-			z-index: 1;
 			&:focus {
 				border-color: var(--error-border);
 			}
@@ -331,8 +361,28 @@
 			line-height: 1.3 !important;
 		}
 	}
-	.data-row div[data-fieldname="options"] {
-		height: 40px;
+	.data-row {
+		div[data-fieldname="options"],
+		div[data-fieldtype="Text Editor"] {
+			height: 40px;
+		}
+	}
+	.awesomplete > ul {
+		position: fixed !important;
+		left: auto !important;
+		top: auto;
+		width: 250px !important;
+	}
+	.grid-static-col {
+		background-color: var(--fg-color);
+		&.sticky-grid-col {
+			position: sticky;
+			z-index: 1;
+		}
+	}
+	// check if the awesomplete dropdown is hidden
+	.grid-static-col:has(.awesomplete > ul:not([hidden])) {
+		z-index: 2;
 	}
 }
 
@@ -580,6 +630,12 @@
 	margin-bottom: 4px;
 }
 
+.form-grid-container {
+	position: relative;
+	overflow-x: auto;
+	width: 100%;
+}
+
 .form-grid-container:has(.grid-row.grid-row-open) {
 	overflow-x: clip;
 	white-space: normal;
@@ -587,9 +643,6 @@
 	.form-grid {
 		left: 0px !important;
 	}
-}
-.data-row.row {
-	flex-wrap: nowrap;
 }
 .sortable-handle span {
 	width: 31px;
@@ -607,6 +660,7 @@
 	border-top-left-radius: var(--border-radius-md);
 	border-top-right-radius: var(--border-radius-md);
 	border: 1px solid var(--table-border-color);
+	overflow-y: hidden;
 	.form-grid {
 		display: grid;
 		grid-auto-rows: min-content;
@@ -664,6 +718,9 @@
 		.grid-row > .dialog-assignment-row .col:last-child {
 			max-width: 30px;
 			min-width: 30px;
+			position: sticky;
+			right: 0;
+			z-index: 1;
 		}
 		.grid-row > .row .col:nth-child(2),
 		.grid-row > .dialog-assignment-row .col:nth-child(2) {
@@ -675,6 +732,8 @@
 			justify-content: space-between;
 		}
 	}
+	scrollbar-width: auto;
+	scrollbar-color: auto;
 }
 .grid-scroll-bar {
 	overflow-x: auto;

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -757,6 +757,54 @@
 			display: block;
 		}
 	}
+	.column-limit-reached {
+		.form-grid {
+			.grid-static-col.col-xs-2 {
+				flex: 1 0 90px;
+				width: 90px;
+			}
+			.grid-static-col.col-xs-3 {
+				flex: 1 0 120px;
+				width: 120px;
+			}
+			.grid-static-col.col-xs-4 {
+				flex: 1 0 160px;
+				width: 160px;
+			}
+			.grid-static-col.col-xs-5 {
+				flex: 1 0 200px;
+				width: 200px;
+			}
+			.grid-static-col.col-xs-6 {
+				flex: 1 0 240px;
+				width: 240px;
+			}
+			.grid-static-col.col-xs-7 {
+				flex: 1 0 300px;
+				width: 300px;
+			}
+			.grid-static-col.col-xs-8 {
+				flex: 1 0 350px;
+				width: 350px;
+			}
+			.grid-static-col.col-xs-9 {
+				flex: 1 0 400px;
+				width: 400px;
+			}
+			.grid-static-col.col-xs-10 {
+				flex: 1 0 450px;
+				width: 450px;
+			}
+			.grid-static-col.col-xs-11 {
+				flex: 1 0 500px;
+				width: 500px;
+			}
+			.grid-static-col.col-xs-12 {
+				flex: 1 0 550px;
+				width: 550px;
+			}
+		}
+	}
 }
 
 @media (max-width: map-get($grid-breakpoints, "sm")) {


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Add support for sticky columns in child tables, allowing users to select specific columns to remain fixed while scrolling horizontally. This feature improves data accessibility in tables with many columns by ensuring key information, such as 'ID' or 'Name,' remains visible.

> Screenshots/GIFs

https://github.com/user-attachments/assets/05c02def-ccc1-436a-bb04-44c22f005884


`no-docs`


