### PR TITLE
perf: speedup doc.save

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -69,7 +69,6 @@ doctype_cache_keys = (
 	"doctype_form_meta",
 	"last_modified",
 	"linked_doctypes",
-	"notifications",
 	"workflow",
 	"data_import_column_header_map",
 )
@@ -77,6 +76,7 @@ doctype_cache_keys = (
 wildcard_keys = (
 	"document_cache::*",
 	"table_columns::*",
+	"notifications::*",
 )
 
 

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -13,7 +13,7 @@ doctypes_for_mapping = {
 }
 
 
-def get_doctype_map_key(doctype, name) -> str:
+def get_doctype_map_key(doctype, name="*") -> str:
 	return frappe.scrub(doctype) + "_map" + f"::{name}"
 
 
@@ -43,7 +43,6 @@ global_cache_keys = (
 	"information_schema:counts",
 	"db_tables",
 	"server_script_autocompletion_items",
-	*doctype_map_keys,
 )
 
 user_cache_keys = (
@@ -77,6 +76,7 @@ wildcard_keys = (
 	"document_cache::*",
 	"table_columns::*",
 	"notifications::*",
+	*doctype_map_keys,
 )
 
 

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -13,8 +13,8 @@ doctypes_for_mapping = {
 }
 
 
-def get_doctype_map_key(doctype):
-	return frappe.scrub(doctype) + "_map"
+def get_doctype_map_key(doctype, name) -> str:
+	return frappe.scrub(doctype) + "_map" + f"::{name}"
 
 
 doctype_map_keys = tuple(map(get_doctype_map_key, doctypes_for_mapping))
@@ -179,15 +179,14 @@ def clear_controller_cache(doctype=None):
 
 
 def get_doctype_map(doctype, name, filters=None, order_by=None):
-	return frappe.cache.hget(
-		get_doctype_map_key(doctype),
-		name,
-		lambda: frappe.get_all(doctype, filters=filters, order_by=order_by, ignore_ddl=True),
+	return frappe.client_cache.get_value(
+		get_doctype_map_key(doctype, name),
+		generator=lambda: frappe.get_all(doctype, filters=filters, order_by=order_by, ignore_ddl=True),
 	)
 
 
 def clear_doctype_map(doctype, name):
-	frappe.cache.hdel(frappe.scrub(doctype) + "_map", name)
+	frappe.client_cache.delete_value(get_doctype_map_key(doctype, name))
 
 
 def build_table_count_cache():

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -464,7 +464,7 @@ class Database:
 	@staticmethod
 	def clear_db_table_cache(query):
 		if query and is_query_type(query, ("drop", "create")):
-			frappe.cache.delete_key("db_tables")
+			frappe.client_cache.delete_value("db_tables")
 
 	def get_description(self):
 		"""Return result metadata."""

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -458,7 +458,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 		to_query = not cached
 
 		if cached:
-			tables = frappe.cache.get_value("db_tables")
+			tables = frappe.client_cache.get_value("db_tables")
 			to_query = not tables
 
 		if to_query:
@@ -470,7 +470,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 				.where(information_schema.tables.table_schema == frappe.db.cur_db_name)
 				.run(pluck=True)
 			)
-			frappe.cache.set_value("db_tables", tables)
+			frappe.client_cache.set_value("db_tables", tables)
 
 		return tables
 

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -160,10 +160,10 @@ class Notification(Document):
 		self.validate_forbidden_document_types()
 		self.validate_condition()
 		self.validate_standard()
-		frappe.cache.hdel("notifications", self.document_type)
+		clear_notification_cache()
 
 	def on_update(self):
-		frappe.cache.hdel("notifications", self.document_type)
+		clear_notification_cache()
 		path = export_module_json(self, self.is_standard, self.module)
 		if path and self.message:
 			extension = FORMATS.get(self.message_type, ".md")
@@ -641,7 +641,11 @@ def get_context(context):
 		self.message = self.get_template(md_as_html=True)
 
 	def on_trash(self):
-		frappe.cache.hdel("notifications", self.document_type)
+		clear_notification_cache()
+
+
+def clear_notification_cache():
+	frappe.client_cache.delete_keys("notifications::")
 
 
 @frappe.whitelist()

--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -41,7 +41,7 @@ def run_webhooks(doc, method):
 		return
 
 	# load all webhooks from cache / DB
-	webhooks = frappe.cache.get_value("webhooks", get_all_webhooks)
+	webhooks = frappe.client_cache.get_value("webhooks", generator=get_all_webhooks)
 
 	# get webhooks for this doctype
 	webhooks_for_doc = webhooks.get(doc.doctype, None)

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -134,12 +134,12 @@ class TestWebhook(IntegrationTestCase):
 	def test_webhook_trigger_with_enabled_webhooks(self):
 		"""Test webhook trigger for enabled webhooks"""
 
-		frappe.cache.delete_value("webhooks")
+		frappe.client_cache.delete_value("webhooks")
 
 		# Insert the user to db
 		self.test_user.insert()
 
-		webhooks = frappe.cache.get_value("webhooks")
+		webhooks = frappe.client_cache.get_value("webhooks")
 		self.assertTrue("User" in webhooks)
 		self.assertEqual(len(webhooks.get("User")), 1)
 

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -66,7 +66,7 @@ class Webhook(Document):
 		self.preview_document = None
 
 	def on_update(self):
-		frappe.cache.delete_value("webhooks")
+		frappe.client_cache.delete_value("webhooks")
 
 	def validate_docevent(self):
 		if self.webhook_doctype:

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -11,7 +11,6 @@ import frappe
 import frappe.model.sync
 import frappe.modules.patch_handler
 import frappe.translate
-from frappe.cache_manager import clear_global_cache
 from frappe.core.doctype.language.language import sync_languages
 from frappe.core.doctype.navbar_settings.navbar_settings import sync_standard_items
 from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
@@ -80,7 +79,7 @@ class SiteMigration:
 		self.touched_tables_file = frappe.get_site_path("touched_tables.json")
 		frappe.clear_cache()
 		add_column(doctype="DocType", column_name="migration_hash", fieldtype="Data")
-		clear_global_cache()
+		frappe.clear_cache()
 
 		if os.path.exists(self.touched_tables_file):
 			os.remove(self.touched_tables_file)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1118,18 +1118,18 @@ class Document(BaseDocument, DocRef):
 
 		from frappe.email.doctype.notification.notification import evaluate_alert
 
-		if self.flags.notifications is None:
+		def _get_notifications():
+			"""Return enabled notifications for the current doctype."""
 
-			def _get_notifications():
-				"""Return enabled notifications for the current doctype."""
+			return frappe.get_all(
+				"Notification",
+				fields=["name", "event", "method"],
+				filters={"enabled": 1, "document_type": self.doctype},
+			)
 
-				return frappe.get_all(
-					"Notification",
-					fields=["name", "event", "method"],
-					filters={"enabled": 1, "document_type": self.doctype},
-				)
-
-			self.flags.notifications = frappe.cache.hget("notifications", self.doctype, _get_notifications)
+		notifications = frappe.client_cache.get_value(
+			f"notifications::{self.doctype}", generator=_get_notifications
+		)
 
 		if not self.flags.notifications:
 			return
@@ -1152,7 +1152,7 @@ class Document(BaseDocument, DocRef):
 			# value change is not applicable in insert
 			event_map["on_change"] = "Value Change"
 
-		for alert in self.flags.notifications:
+		for alert in notifications:
 			event = event_map.get(method, None)
 			if event and alert.event == event:
 				_evaluate_alert(alert)


### PR DESCRIPTION
- [x] Eliminate all recurring Redis calls, use client cache for:
	- [x] notifications
	- [x] "doctype maps"
	- [x] webhooks
	- [x] `get_tables`
