### PR TITLE
perf: use client cache for notifications

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -69,7 +69,6 @@ doctype_cache_keys = (
 	"doctype_form_meta",
 	"last_modified",
 	"linked_doctypes",
-	"notifications",
 	"workflow",
 	"data_import_column_header_map",
 )
@@ -130,6 +129,7 @@ def clear_doctype_cache(doctype=None):
 
 def _clear_doctype_cache_from_redis(doctype: str | None = None):
 	from frappe.desk.notifications import delete_notification_count_for
+	from frappe.email.doctype.notification.notification import clear_notification_cache
 	from frappe.model.meta import clear_meta_cache
 
 	to_del = ["is_table", "doctype_modules"]
@@ -166,6 +166,7 @@ def _clear_doctype_cache_from_redis(doctype: str | None = None):
 			to_del += frappe.cache.get_keys(pattern)
 		clear_meta_cache()
 
+	clear_notification_cache()
 	frappe.cache.delete_value(to_del)
 
 

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -160,10 +160,13 @@ class Notification(Document):
 		self.validate_forbidden_document_types()
 		self.validate_condition()
 		self.validate_standard()
-		frappe.cache.hdel("notifications", self.document_type)
+		clear_notification_cache()
+
+	def clear_cache(self):
+		super().clear_cache()
+		clear_notification_cache()
 
 	def on_update(self):
-		frappe.cache.hdel("notifications", self.document_type)
 		path = export_module_json(self, self.is_standard, self.module)
 		if path and self.message:
 			extension = FORMATS.get(self.message_type, ".md")
@@ -641,7 +644,11 @@ def get_context(context):
 		self.message = self.get_template(md_as_html=True)
 
 	def on_trash(self):
-		frappe.cache.hdel("notifications", self.document_type)
+		clear_notification_cache()
+
+
+def clear_notification_cache():
+	frappe.client_cache.delete_keys("notifications::")
 
 
 @frappe.whitelist()

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -11,7 +11,6 @@ import frappe
 import frappe.model.sync
 import frappe.modules.patch_handler
 import frappe.translate
-from frappe.cache_manager import clear_global_cache
 from frappe.core.doctype.language.language import sync_languages
 from frappe.core.doctype.navbar_settings.navbar_settings import sync_standard_items
 from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
@@ -80,7 +79,7 @@ class SiteMigration:
 		self.touched_tables_file = frappe.get_site_path("touched_tables.json")
 		frappe.clear_cache()
 		add_column(doctype="DocType", column_name="migration_hash", fieldtype="Data")
-		clear_global_cache()
+		frappe.clear_cache()
 
 		if os.path.exists(self.touched_tables_file):
 			os.remove(self.touched_tables_file)


### PR DESCRIPTION
Speeds up `doc.save` by avoiding this redis call every time
