### PR TITLE
revert: error/webhook logs on every document

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -129,8 +129,6 @@ def get_docinfo(doc=None, doctype=None, name=None):
 			"is_document_followed": is_document_followed(doc.doctype, doc.name, frappe.session.user),
 			"tags": get_tags(doc.doctype, doc.name),
 			"document_email": get_document_email(doc.doctype, doc.name),
-			"error_log_exists": get_error_log_exists(doc),
-			"webhook_request_log_log_exists": get_webhook_request_log_exists(doc),
 		}
 	)
 
@@ -202,20 +200,6 @@ def get_versions(doc: "Document") -> list[dict]:
 		limit=10,
 		order_by="creation desc",
 	)
-
-
-def get_error_log_exists(doc: "Document") -> bool:
-	if has_permission("Error Log", print_logs=False):
-		return frappe.db.exists("Error Log", {"reference_doctype": doc.doctype, "reference_name": doc.name})
-	return False
-
-
-def get_webhook_request_log_exists(doc: "Document") -> bool:
-	if has_permission("Webhook Request Log", print_logs=False):
-		return frappe.db.exists(
-			"Webhook Request Log", {"reference_doctype": doc.doctype, "reference_document": doc.name}
-		)
-	return False
 
 
 @frappe.whitelist()

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -35,8 +35,6 @@ frappe.ui.form.Sidebar = class {
 
 		this.setup_keyboard_shortcuts();
 		this.show_auto_repeat_status();
-		this.show_error_log_status();
-		this.show_webhook_request_log_status();
 		frappe.ui.form.setup_user_image_event(this.frm);
 
 		this.refresh();
@@ -154,36 +152,6 @@ frappe.ui.form.Sidebar = class {
 						frappe.set_route("Form", "Auto Repeat", me.frm.doc.auto_repeat);
 					});
 				},
-			});
-		}
-	}
-
-	show_error_log_status() {
-		const docinfo = this.frm.get_docinfo();
-		if (docinfo.error_log_exists) {
-			let el = this.sidebar.find(".error-log-status");
-			el.closest(".sidebar-section").removeClass("hidden");
-			el.show();
-			el.on("click", () => {
-				frappe.set_route("List", "Error Log", {
-					reference_doctype: this.frm.doc.doctype,
-					reference_name: this.frm.doc.name,
-				});
-			});
-		}
-	}
-
-	show_webhook_request_log_status() {
-		const docinfo = this.frm.get_docinfo();
-		if (docinfo.webhook_request_log_exists) {
-			let el = this.sidebar.find(".webhook-request-log-status");
-			el.closest(".sidebar-section").removeClass("hidden");
-			el.show();
-			el.on("click", () => {
-				frappe.set_route("List", "Webhook Request Log", {
-					reference_doctype: this.frm.doc.doctype,
-					reference_document: this.frm.doc.name,
-				});
 			});
 		}
 	}

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -136,8 +136,6 @@
 	</div>
 </div>
 <div class="sidebar-section hidden">
-	<a><li class="indicator red blink error-log-status" style="display: none;">{%= __("Error Logs") %}</li></a>
-	<a><li class="indicator yellow webhook-request-log-status" style="display: none;">{%= __("Webhook Logs") %}</li></a>
 	<a><li class="indicator blue auto-repeat-status" style="display: none;"></li></a>
 </div>
 <div class="sidebar-section text-muted">


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/32ab5496-1afb-4584-a26a-34dbfd9aae77)

12% of docinfo on a basically empty database!

This is poorly implemented and adds overheads that don't affect vast majority
of users.

We serve millions of requests for reading a document, it doesn't make
sense to check error and webhooks on all of them. Not all documents even
have this configured.

If you need it, add it using "connections dashboard" or some custom code.
