### PR TITLE
perf: speedup docinfo - skip tags when not used

### DIFF
--- a/frappe/desk/doctype/tag_link/tag_link.json
+++ b/frappe/desk/doctype/tag_link/tag_link.json
@@ -46,7 +46,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-23 16:03:39.781828",
+ "modified": "2025-02-04 12:02:03.779623",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Tag Link",
@@ -79,6 +79,5 @@
  "read_only": 1,
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": [],
- "track_changes": 1
+ "states": []
 }

--- a/frappe/desk/doctype/tag_link/tag_link.py
+++ b/frappe/desk/doctype/tag_link/tag_link.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
@@ -18,6 +18,23 @@ class TagLink(Document):
 		document_type: DF.Link | None
 		tag: DF.Link | None
 		title: DF.Data | None
+
 	# end: auto-generated types
 
-	pass
+	def clear_cache(self):
+		super().clear_cache()
+		if has_tags(self.document_type):
+			frappe.client_cache.delete_value(f"doctype_has_tags::{self.document_type}")
+
+
+def on_doctype_update():
+	frappe.db.add_index("Tag Link", ["document_type", "document_name"])
+
+
+def has_tags(doctype: str):
+	"""Short circuit checks for tags by first checking if users even uses tags"""
+
+	def check_db():
+		return frappe.db.exists("Tag Link", {"document_type": doctype})
+
+	return frappe.client_cache.get_value(f"doctype_has_tags::{doctype}", generator=check_db)

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -388,7 +388,7 @@ def get_tags(doctype: str, name: str) -> str:
 	from frappe.desk.doctype.tag_link.tag_link import has_tags
 
 	if not has_tags(doctype):
-		return
+		return ""
 
 	tags = frappe.get_all(
 		"Tag Link",
@@ -401,18 +401,14 @@ def get_tags(doctype: str, name: str) -> str:
 
 
 def get_document_email(doctype, name):
+	from frappe.email.doctype.email_account.email_account import get_automatic_email_link
+
 	email = get_automatic_email_link()
 	if not email:
 		return None
 
 	email = email.split("@")
 	return f"{email[0]}+{quote_plus(doctype)}={quote_plus(cstr(name))}@{email[1]}"
-
-
-def get_automatic_email_link():
-	return frappe.db.get_value(
-		"Email Account", {"enable_incoming": 1, "enable_automatic_linking": 1}, "email_id"
-	)
 
 
 def get_additional_timeline_content(doctype, docname):

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -385,6 +385,11 @@ def get_view_logs(doc: "Document") -> list[dict]:
 
 
 def get_tags(doctype: str, name: str) -> str:
+	from frappe.desk.doctype.tag_link.tag_link import has_tags
+
+	if not has_tags(doctype):
+		return
+
 	tags = frappe.get_all(
 		"Tag Link",
 		filters={"document_type": doctype, "document_name": name},

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -253,6 +253,10 @@ class EmailAccount(Document):
 			used_oauth=self.auth_method == "OAuth",
 		)
 
+	def clear_cache(self):
+		super().clear_cache()
+		frappe.client_cache.delete_value("automatic_linking_email")
+
 	def there_must_be_only_one_default(self):
 		"""If current Email Account is default, un-default all other accounts."""
 		for field in ("default_incoming", "default_outgoing"):
@@ -1041,6 +1045,15 @@ def set_email_password(email_account, password):
 			return False
 
 	return True
+
+
+def get_automatic_email_link():
+	def check_db():
+		return frappe.db.get_value(
+			"Email Account", {"enable_incoming": 1, "enable_automatic_linking": 1}, "email_id"
+		)
+
+	return frappe.client_cache.get_value("automatic_linking_email", generator=check_db())
 
 
 def on_doctype_update() -> None:


### PR DESCRIPTION
- Tags weren't indexed!
- If doctype doesn't use tags (many) then don't query them
- Cache default email link account.

