### PR TITLE
fix: move child table checks to within `set_input()`

### DIFF
--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -32,12 +32,6 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 
 		frappe.utils.bind_actions_with_object(this.$value, this);
 		this.toggle_reload_button();
-
-		// Don't allow attaching to child tables for new documents
-		if (this.doc?.__islocal && this.doc.parent) {
-			this.$input.prop("disabled", true);
-			this.$input.attr("title", __("Save to enable file upload"));
-		}
 	}
 	clear_attachment() {
 		let me = this;
@@ -125,7 +119,11 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 				`);
 			}
 		} else {
-			this.$input.toggle(true);
+			// Don't allow attaching to child tables for new documents
+			if (this.doc?.__islocal && this.doc.parent) {
+				this.$input.prop("disabled", true);
+				this.$input.attr("title", __("Save to enable file upload"));
+			}
 			this.$value.toggle(false);
 		}
 	}


### PR DESCRIPTION
Otherwise changes to the table can trigger this and allow uploading

Reference: support ticket 30739
