### PR TITLE
chore: trigger release PRs early

### DIFF
--- a/.github/workflows/initiate_release.yml
+++ b/.github/workflows/initiate_release.yml
@@ -4,7 +4,7 @@
 name: Create weekly release pull requests
 on:
   schedule:
-    # 9:30 UTC => 3 PM IST Tuesday
+    # 9:00 UTC => 2:30 PM IST Tuesday
     - cron: "0 9 * * 2"
   workflow_dispatch:
 

--- a/.github/workflows/initiate_release.yml
+++ b/.github/workflows/initiate_release.yml
@@ -5,7 +5,7 @@ name: Create weekly release pull requests
 on:
   schedule:
     # 9:30 UTC => 3 PM IST Tuesday
-    - cron: "30 9 * * 2"
+    - cron: "0 9 * * 2"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Too many CI jobs start at 3 PM blocking everything else, so making this one run 30 min before.

