### PR TITLE
fix: Pass function reference instead of function call

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -1053,7 +1053,7 @@ def get_automatic_email_link():
 			"Email Account", {"enable_incoming": 1, "enable_automatic_linking": 1}, "email_id"
 		)
 
-	return frappe.client_cache.get_value("automatic_linking_email", generator=check_db())
+	return frappe.client_cache.get_value("automatic_linking_email", generator=check_db)
 
 
 def on_doctype_update() -> None:


### PR DESCRIPTION
Issue due to https://github.com/frappe/frappe/pull/31098