### PR TITLE
fix: clear print format selector if default print format is absent

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -751,13 +751,12 @@ frappe.ui.form.PrintView = class {
 		if (
 			frappe.meta
 				.get_print_formats(this.frm.doctype)
-				.includes(this.print_format_selector.val()) ||
-			!this.frm.meta.default_print_format
+				.includes(this.print_format_selector.val())
 		)
 			return;
 
 		this.print_format_selector.empty();
-		this.print_format_selector.val(this.frm.meta.default_print_format);
+		this.print_format_selector.val(this.frm.meta.default_print_format || "");
 	}
 
 	selected_format() {


### PR DESCRIPTION
Closes: #30052 
