### PR TITLE
fix: update expression series duplicate issue

### DIFF
--- a/frappe/patches/v16_0/update_expression_series.py
+++ b/frappe/patches/v16_0/update_expression_series.py
@@ -62,8 +62,4 @@ def execute():
 		current = current[0].get("current")
 
 		for uniq_expr in uniq_exprs:
-			expr_exists = (frappe.qb.from_(Series).select("*").where(Series.name == uniq_expr)).run(
-				as_dict=True
-			)
-			if not expr_exists:
-				(frappe.qb.into(Series).columns("name", "current").insert(uniq_expr, current + 1)).run()
+			(frappe.qb.into(Series).columns("name", "current").insert(uniq_expr, current + 1).ignore()).run()


### PR DESCRIPTION
Support Tickets
https://support.frappe.io/helpdesk/tickets/30955
https://support.frappe.io/helpdesk/tickets/30953

The Update Expression series patch was failing due to a duplicate issue in version 15 on Frappe Cloud (but not locally), possibly because of a Python version difference. To address this, instead of manually fetching records, validating the condition, and inserting records only if they don't exist, I added the IGNORE clause to the query. This prevents a DB error from being thrown when a record already exists.
