### PR TITLE
build!: bump RQ to 2.x

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -105,7 +105,7 @@ class DataImport(Document):
 		if is_scheduler_inactive() and not run_now:
 			frappe.throw(_("Scheduler is inactive. Cannot import data."), title=_("Scheduler Inactive"))
 
-		job_id = f"data_import::{self.name}"
+		job_id = f"data_import||{self.name}"
 
 		if not is_job_enqueued(job_id):
 			enqueue(

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -95,7 +95,7 @@ class ScheduledJobType(Document):
 	@property
 	def rq_job_id(self):
 		"""Unique ID created to deduplicate jobs with single RQ call."""
-		return f"scheduled_job::{self.name}"
+		return f"scheduled_job||{self.name}"
 
 	@property
 	def next_execution(self):

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -611,7 +611,7 @@ def create_job_id(job_id: str | None = None) -> str:
 
 	if not job_id:
 		job_id = str(uuid4())
-	return f"{frappe.local.site}::{job_id}"
+	return f"{frappe.local.site}||{job_id}"
 
 
 def is_job_enqueued(job_id: str) -> bool:

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -327,6 +327,7 @@ def start_worker(
 		date_format="%Y-%m-%d %H:%M:%S",
 		log_format="%(asctime)s,%(msecs)03d %(message)s",
 		dequeue_strategy=strategy,
+		with_scheduler=False,
 	)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     # We depend on internal attributes of RQ.
     # Do NOT add loose requirements on RQ versions.
     # Audit the code changes w.r.t. background_jobs.py before updating.
-    "rq==1.16.2",
+    "rq==2.1.0",
     "rsa>=4.1",
     "semantic-version~=2.10.0",
     "sentry-sdk~=1.37.1",


### PR DESCRIPTION
Removed `:` from Job IDs. All other required changes were apparently already done.


Ref:
- https://github.com/frappe/frappe/pull/30935
- https://github.com/frappe/frappe/blob/3821a3cf5f836f9e8706f0ab63db5a72867730b6/frappe/utils/background_jobs.py#L334-L337 