### PR TITLE
fix: bump iterator batch size

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -47,7 +47,7 @@ INDEX_PATTERN = re.compile(r"\s*\([^)]+\)\s*")
 SINGLE_WORD_PATTERN = re.compile(r'([`"]?)(tab([A-Z]\w+))\1')
 MULTI_WORD_PATTERN = re.compile(r'([`"])(tab([A-Z]\w+)( [A-Z]\w+)+)\1')
 
-SQL_ITERATOR_BATCH_SIZE = 100
+SQL_ITERATOR_BATCH_SIZE = 1000
 
 
 TRANSACTION_DISABLED_MSG = """Commit/rollback are disabled during certain events. This command will


### PR DESCRIPTION
100 is too small, 10,000 is too big... 1000 is a decent middle ground.
