### PR TITLE
style: fix errormsg to refer postgres instead of mariadb

### DIFF
--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -39,7 +39,7 @@ def bootstrap_database(verbose, source_sql=None):
 		secho(
 			"Table 'tabDefaultValue' missing in the restored site. "
 			"This happens when the backup fails to restore. Please check that the file is valid\n"
-			"Do go through the above output to check the exact error message from MariaDB",
+			"Do go through the above output to check the exact error message from Postgres",
 			fg="red",
 		)
 		sys.exit(1)


### PR DESCRIPTION
Simple patch, as the error message in postgres/setup_db.py contains string "MariaDB", which can be confusing. 
