### PR TITLE
fix: consider parent doctype when validating link to child row

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -405,13 +405,16 @@ def validate_link(doctype: str, docname: str, fields=None):
 	if not isinstance(docname, str):
 		frappe.throw(_("Document Name must be a string"))
 
-	if doctype != "DocType" and not (
-		frappe.has_permission(doctype, "select") or frappe.has_permission(doctype, "read")
-	):
-		frappe.throw(
-			_("You do not have Read or Select Permissions for {}").format(frappe.bold(doctype)),
-			frappe.PermissionError,
-		)
+	if doctype != "DocType":
+		parent_doctype = frappe.db.get_value(doctype, docname, "parenttype")  # needed for links to child rows
+		if not (
+			frappe.has_permission(doctype, "select", parent_doctype=parent_doctype)
+			or frappe.has_permission(doctype, "read", parent_doctype=parent_doctype)
+		):
+			frappe.throw(
+				_("You do not have Read or Select Permissions for {}").format(frappe.bold(doctype)),
+				frappe.PermissionError,
+			)
 
 	values = frappe._dict()
 

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -406,7 +406,9 @@ def validate_link(doctype: str, docname: str, fields=None):
 		frappe.throw(_("Document Name must be a string"))
 
 	if doctype != "DocType":
-		parent_doctype = frappe.db.get_value(doctype, docname, "parenttype")  # needed for links to child rows
+		parent_doctype = None
+		if frappe.get_meta(doctype).istable:  # needed for links to child rows
+			parent_doctype = frappe.db.get_value(doctype, docname, "parenttype")
 		if not (
 			frappe.has_permission(doctype, "select", parent_doctype=parent_doctype)
 			or frappe.has_permission(doctype, "read", parent_doctype=parent_doctype)

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -155,6 +155,25 @@ class TestClient(IntegrationTestCase):
 		self.assertEqual(get("ToDo", filters={}), get("ToDo", filters="{}"))
 		todo.delete()
 
+	def test_client_validatate_link(self):
+		from frappe.client import validate_link
+
+		# Basic test
+		self.assertTrue(validate_link("User", "Guest"))
+
+		# fixes capitalization
+		if frappe.db.db_type == "mariadb":
+			self.assertEqual(validate_link("User", "GueSt"), {"name": "Guest"})
+
+		# Fetch
+		self.assertEqual(validate_link("User", "Guest", fields=["enabled"]), {"name": "Guest", "enabled": 1})
+
+		# Permissions
+		with self.set_user("Guest"), self.assertRaises(frappe.PermissionError):
+			self.assertEqual(
+				validate_link("User", "Guest", fields=["enabled"]), {"name": "Guest", "enabled": 1}
+			)
+
 	def test_client_insert(self):
 		from frappe.client import insert
 


### PR DESCRIPTION
Link fields can also point to child table rows. However, this case was not considered in `validate_link`.

E.g. https://github.com/frappe/erpnext/pull/42926 supports linking a **Purchase Receipt Item** in **Asset**, but for non-Admins `validate_link` throws an error when using this:

```
14:51:11 web.1      | Traceback (most recent call last):
14:51:11 web.1      |   File "apps/frappe/frappe/app.py", line 114, in application
14:51:11 web.1      |     response = frappe.api.handle(request)
14:51:11 web.1      |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
14:51:11 web.1      |   File "apps/frappe/frappe/api/__init__.py", line 49, in handle
14:51:11 web.1      |     data = endpoint(**arguments)
14:51:11 web.1      |            ^^^^^^^^^^^^^^^^^^^^^
14:51:11 web.1      |   File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
14:51:11 web.1      |     return frappe.handler.handle()
14:51:11 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^
14:51:11 web.1      |   File "apps/frappe/frappe/handler.py", line 50, in handle
14:51:11 web.1      |     data = execute_cmd(cmd)
14:51:11 web.1      |            ^^^^^^^^^^^^^^^^
14:51:11 web.1      |   File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
14:51:11 web.1      |     return frappe.call(method, **frappe.form_dict)
14:51:11 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
14:51:11 web.1      |   File "apps/frappe/frappe/__init__.py", line 1726, in call
14:51:11 web.1      |     return fn(*args, **newargs)
14:51:11 web.1      |            ^^^^^^^^^^^^^^^^^^^^
14:51:11 web.1      |   File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
14:51:11 web.1      |     return func(*args, **kwargs)
14:51:11 web.1      |            ^^^^^^^^^^^^^^^^^^^^^
14:51:11 web.1      |   File "apps/frappe/frappe/client.py", line 429, in validate_link
14:51:11 web.1      |     frappe.throw(
14:51:11 web.1      |   File "apps/frappe/frappe/__init__.py", line 603, in throw
14:51:11 web.1      |     msgprint(
14:51:11 web.1      |   File "apps/frappe/frappe/__init__.py", line 568, in msgprint
14:51:11 web.1      |     _raise_exception()
14:51:11 web.1      |   File "apps/frappe/frappe/__init__.py", line 519, in _raise_exception
14:51:11 web.1      |     raise exc
14:51:11 web.1      | frappe.exceptions.PermissionError: You do not have Read or Select Permissions for Purchase Receipt Item
```

The `has_permission` docstring states:

```
:param parent_doctype: Required when checking permission for a child DocType (unless doc is specified).
```

This PR adds this parameter for child table rows. For non-table DocTypes it will be `None`.