### PR TITLE
perf: cache get_doc in prints/jinja

### DIFF
--- a/frappe/tests/test_pdf.py
+++ b/frappe/tests/test_pdf.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import io
+from unittest.mock import patch
 
 from pypdf import PdfReader
 
@@ -94,3 +95,15 @@ class TestPdf(IntegrationTestCase):
 
 		# If image was actually retrieved then size will be  in few kbs, else bytes.
 		self.assertGreaterEqual(len(pdf), 10_000)
+
+	def test_jinja_get_doc_calls(self):
+		html = """ <div>{{ frappe.get_doc("User", "Guest").name }}" </div>
+					<div>{{ frappe.get_doc("User", "Guest").name }}" </div>
+					<div>{{ frappe.get_doc("User", "Guest").name }}" </div>
+		"""
+
+		frappe.render_template(html)
+
+		with patch("frappe.get_doc") as gd:
+			frappe.render_template(html)
+			self.assertEqual(gd.call_count, 1)

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -48,6 +48,12 @@ def request_cache(func: Callable) -> Callable:
 	```
 	"""
 
+	def clear_cache():
+		if _cache := getattr(frappe.local, "request_cache", None):
+			_cache[func].clear()
+
+	func.clear_cache = clear_cache
+
 	@wraps(func)
 	def wrapper(*args, **kwargs):
 		_cache = getattr(frappe.local, "request_cache", None)

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.utils.caching import site_cache
+from frappe.utils.caching import request_cache, site_cache
 
 
 def get_jenv():
@@ -23,6 +23,10 @@ def get_jenv():
 	jenv.filters = default_jenv.filters.copy()
 
 	jenv.globals.update(get_safe_globals())
+
+	# PERF: Reuse `get_doc` results during a render assuming it can't change during render.
+	jenv.globals["frappe"]["get_doc"] = cached_get_doc
+
 	methods, filters = get_jinja_hooks()
 	jenv.globals.update(methods or {})
 	jenv.filters.update(filters or {})
@@ -207,6 +211,23 @@ def set_filters(jenv):
 			"flt": flt,
 		}
 	)
+
+
+def cached_get_doc(*args, **kwargs):
+	"""Optimized get_doc version for Jinja/Prints.
+
+	This fetches all unique docs only once per request assuming document can't change during
+	render/print"""
+	if not kwargs and len(args) <= 2 and all(isinstance(a, str) for a in args):
+		return _request_cached_get_doc(*args)
+	else:
+		# Fall back to regular for dict inputs or filters.
+		return frappe.get_doc(*args, **kwargs)
+
+
+@request_cache
+def _request_cached_get_doc(doctype, name):
+	return frappe.get_doc(doctype, name)
 
 
 def get_jinja_hooks():


### PR DESCRIPTION
People end up writing get_doc in a loop that results in 1000s of get_doc
calls and print format never renders. This simple change replaces
`get_doc` with what is semantically same as `get_cached_doc`.


Why not just use `get_cached_doc` then?

- That puts it in cache and we might never read it again.
- Brings all redis cache semantics into picture, we don't need it here. 