### PR TITLE
feat: new REST API for copy_doc

### DIFF
--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -95,6 +95,17 @@ def create_doc(doctype: str):
 	return frappe.new_doc(doctype, **data).insert()
 
 
+def copy_doc(doctype: str, name: str, ignore_no_copy: bool = True):
+	"""Return a clean copy of the given document that can be modified and posted as a new document."""
+	doc = frappe.get_doc(doctype, name)
+	doc.check_permission("read")
+	doc.apply_fieldlevel_read_permissions()
+
+	copy = frappe.copy_doc(doc, ignore_no_copy=ignore_no_copy)
+
+	return copy.as_dict(no_private_properties=True, no_nulls=True)
+
+
 def update_doc(doctype: str, name: str):
 	data = frappe.form_dict
 
@@ -186,6 +197,7 @@ url_rules = [
 	Rule("/document/<doctype>", methods=["GET"], endpoint=document_list),
 	Rule("/document/<doctype>", methods=["POST"], endpoint=create_doc),
 	Rule("/document/<doctype>/<path:name>/", methods=["GET"], endpoint=read_doc),
+	Rule("/document/<doctype>/<path:name>/copy", methods=["GET"], endpoint=copy_doc),
 	Rule("/document/<doctype>/<path:name>/", methods=["PATCH", "PUT"], endpoint=update_doc),
 	Rule("/document/<doctype>/<path:name>/", methods=["DELETE"], endpoint=delete_doc),
 	Rule(

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -84,6 +84,25 @@ class TestResourceAPIV2(FrappeAPITestCase):
 		self.assertIsInstance(docname, str)
 		self.GENERATED_DOCUMENTS.append(docname)
 
+	def test_copy_document(self):
+		doc = frappe.get_doc(self.DOCTYPE, self.GENERATED_DOCUMENTS[0])
+
+		response = self.get(self.resource(self.DOCTYPE, doc.name, "copy"))
+		self.assertEqual(response.status_code, 200)
+		data = response.json["data"]
+
+		self.assertEqual(data["doctype"], self.DOCTYPE)
+		self.assertEqual(data["description"], doc.description)
+		self.assertEqual(data["status"], doc.status)
+		self.assertEqual(data["priority"], doc.priority)
+
+		self.assertNotIn("name", data)
+		self.assertNotIn("creation", data)
+		self.assertNotIn("modified", data)
+		self.assertNotIn("modified_by", data)
+		self.assertNotIn("owner", data)
+		self.assertNotIn("docstatus", data)
+
 	def test_delete_document(self):
 		doc_to_delete = choice(self.GENERATED_DOCUMENTS)
 		response = self.delete(self.resource(self.DOCTYPE, doc_to_delete))


### PR DESCRIPTION
This PR adds an API method for calling `frappe.copy_doc()`. This is useful because `copy_doc` relies on a lot of internal information which is not readily available to the caller.

The use case for this is when we want to duplicate an existing document via REST API. This was previously non-trivial. Now we can call `GET /api/v2/document/<doctype>/<path:name>/copy` to retrieve a clean copy of the existing document, add any additional information for no-copy fields, then send it to `POST /api/v2/document/<doctype>`.

For example:

```
GET /api/v2/document/Item/660/copy

{
  "data": {
    "idx": 0,
    "naming_series": "###",
    "item_code": "660",
    "item_name": "Book",
    "item_group": "All Item Groups",
    "stock_uom": "Nos",
    "disabled": 0,
    "allow_alternative_item": 0,
    "is_stock_item": 0,
    "has_variants": 0,
    "include_item_in_manufacturing": 0,
    "opening_stock": 0,
    "valuation_rate": 0,
    "standard_rate": 0,
    "is_fixed_asset": 0,
    "auto_create_assets": 0,
    "is_grouped_asset": 0,
    "over_delivery_receipt_allowance": 0,
    "over_billing_allowance": 0,
    "description": "Buch",
    "shelf_life_in_days": 0,
    "end_of_life": "2099-12-31",
    "default_material_request_type": "Purchase",
    "valuation_method": "",
    "weight_per_unit": 0,
    "allow_negative_stock": 0,
    "has_batch_no": 0,
    "create_new_batch": 0,
    "has_expiry_date": 0,
    "retain_sample": 0,
    "sample_quantity": 0,
    "has_serial_no": 0,
    "variant_based_on": "Item Attribute",
    "enable_deferred_expense": 0,
    "no_of_months_exp": 0,
    "enable_deferred_revenue": 0,
    "no_of_months": 0,
    "min_order_qty": 0,
    "safety_stock": 0,
    "is_purchase_item": 1,
    "lead_time_days": 0,
    "last_purchase_rate": 0,
    "is_customer_provided_item": 0,
    "delivered_by_supplier": 0,
    "country_of_origin": "Germany",
    "grant_commission": 1,
    "is_sales_item": 0,
    "max_discount": 0,
    "inspection_required_before_purchase": 0,
    "inspection_required_before_delivery": 0,
    "is_sub_contracted_item": 0,
    "customer_code": "",
    "total_projected_qty": 0,
    "doctype": "Item",
    "customer_items": [],
    "barcodes": [],
    "uoms": [
      {
        "idx": 1,
        "uom": "Nos",
        "conversion_factor": 1,
        "parent": "660",
        "parentfield": "uoms",
        "parenttype": "Item",
        "doctype": "UOM Conversion Detail"
      }
    ],
    "item_defaults": [
      {
        "idx": 1,
        "company": "ALYF",
        "parent": "660",
        "parentfield": "item_defaults",
        "parenttype": "Item",
        "doctype": "Item Default"
      }
    ],
    "supplier_items": [],
    "reorder_levels": [],
    "taxes": [],
    "attributes": []
  }
}
```

Docs: [docs.frappe.io/framework/user/en/guides/integration/rest_api?editWiki=1&wikiPagePatch=h3k13ru4je](https://docs.frappe.io/framework/user/en/guides/integration/rest_api?editWiki=1&wikiPagePatch=h3k13ru4je)