### PR TITLE
fix: fetch if empty, fetch value even if it has value

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -661,13 +661,18 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				if (this.layout?.set_value) {
 					this.layout.set_value(target_field, field_value);
 				} else if (this.frm) {
-					frappe.model.set_value(
-						this.df.parent,
-						this.docname,
-						target_field,
-						field_value,
-						this.df.fieldtype
-					);
+					let target_df = frappe.meta.get_docfield(this.df.parent, target_field);
+					if (target_df?.fetch_if_empty) {
+						continue;
+					} else {
+						frappe.model.set_value(
+							this.df.parent,
+							this.docname,
+							target_field,
+							field_value,
+							this.df.fieldtype
+						);
+					}
 				}
 			}
 		};


### PR DESCRIPTION
If 'Fetch on save if empty' is enabled, it should not fetch the value if one already exists. However, currently, it is fetching the value even if it already has one.
![image](https://github.com/user-attachments/assets/abc4bdec-4947-4c3b-94d9-b47e7d2d60b9)

The initial PR for 'Fetch on Save if Empty' is this one: https://github.com/frappe/frappe/pull/6991 . In this PR, the behavior was added to **fetch the field value only if it is empty**.

In this https://github.com/frappe/frappe/pull/21643 and this one https://github.com/frappe/frappe/pull/19586 , the behavior was added to fetch the value in the UI only when it doesn't have a value. However, it was reverted in this PR: https://github.com/frappe/frappe/pull/22916/files#diff-19a3ead9a7a390cb6a7019bf0bae26e8b53105476a9df1ceb084586532627147L594-L607

As 'Fetch on Save if Empty' suggests, the value should only be fetched on save if it is empty, not in real-time or when it already has a value.

- Before

https://github.com/user-attachments/assets/4d39cf66-227e-4225-953e-bffdbf906219

- After

https://github.com/user-attachments/assets/f3db4063-6f58-4d3d-9b70-f9f014b7510b

