### PR TITLE
revert: disable attach fields in unsaved child table rows

### DIFF
--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -34,7 +34,7 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 		this.toggle_reload_button();
 
 		// Don't allow attaching to child tables for new documents
-		if (this.doc?.__islocal && this.doc.parent) {
+		if (this.doc.__islocal && this.doc.parent) {
 			this.$input.prop("disabled", true);
 			this.$input.attr("title", __("Save to enable file upload"));
 		}

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -32,6 +32,12 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 
 		frappe.utils.bind_actions_with_object(this.$value, this);
 		this.toggle_reload_button();
+
+		// Don't allow attaching to child tables for new documents
+		if (this.doc?.__islocal && this.doc.parent) {
+			this.$input.prop("disabled", true);
+			this.$input.attr("title", __("Save to enable file upload"));
+		}
 	}
 	clear_attachment() {
 		let me = this;
@@ -119,11 +125,7 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 				`);
 			}
 		} else {
-			// Don't allow attaching to child tables for new documents
-			if (this.doc?.__islocal && this.doc.parent) {
-				this.$input.prop("disabled", true);
-				this.$input.attr("title", __("Save to enable file upload"));
-			}
+			this.$input.toggle(true);
 			this.$value.toggle(false);
 		}
 	}

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -32,12 +32,6 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 
 		frappe.utils.bind_actions_with_object(this.$value, this);
 		this.toggle_reload_button();
-
-		// Don't allow attaching to child tables for new documents
-		if (this.doc.__islocal && this.doc.parent) {
-			this.$input.prop("disabled", true);
-			this.$input.attr("title", __("Save to enable file upload"));
-		}
 	}
 	clear_attachment() {
 		let me = this;


### PR DESCRIPTION
- **Revert "fix: move child table checks to within `set_input()`"**
- **Revert "fix(attach): fix crash on web page builder"**
- **Revert "fix: don't allow attaching a file to a child table in a new document"**

<hr>

Resolves #31135

<hr>

This behaviour has been confusing for many users, so we'll try the other approach instead.
