### PR TITLE
fix: reconnect on operational error too

### DIFF
--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -98,7 +98,7 @@ def dangerously_reconnect_on_connection_abort(func):
 		try:
 			return func(*args, **kwargs)
 		except Exception as e:
-			if frappe.db.is_interface_error(e):
+			if frappe.db.is_interface_error(e) or isinstance(e, frappe.db.OperationalError):
 				frappe.db.connect()
 				return func(*args, **kwargs)
 			raise


### PR DESCRIPTION
MySQL seems to raise diff error based on which state the connection was
in when remote connection closed. Anyway, this should guard against both
kinds of failures.


This is particularly bad on setup with replica, as the primary connection is idle until report gets generated.

![image](https://github.com/user-attachments/assets/10cf75e8-c9fe-4ba7-a863-256791310f97)
