### PR TITLE
fix: update cache key for table_columns to new format

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -944,7 +944,8 @@ def trim_tables(doctype=None, dry_run=False, quiet=False):
 
 
 def trim_table(doctype, dry_run=True):
-	frappe.cache.hdel("table_columns", f"tab{doctype}")
+	key = f"table_columns::tab{doctype}"
+	frappe.cache.delete_value(key)
 	ignore_fields = default_fields + optional_fields + child_table_fields
 	columns = frappe.db.get_table_columns(doctype)
 	fields = frappe.get_meta(doctype, cached=False).get_fieldnames_with_value()


### PR DESCRIPTION
This PR updates the cache key used for storing and retrieving table columns in Frappe. The previous key format was f"table_columns", f"tab{doctype}", which has now been replaced with a new format: f"table_columns::{table}".

Steps to reproduce:
1. Add a custom field to a doctype.
2. Remove the field and save the doctype.
3. Trim the table.
4. Now again try to trim the table, it throws the error as **pymysql.err.OperationalError: (1091, "Can't DROP COLUMN `field_name`; check that it exists")**

Expected behaviour:
After trimming the table, if user tries it again it should show popup of **This doctype has no orphan fields to trim**
