### PR TITLE
feat: Adding option to trim custom tables

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -32,13 +32,10 @@ frappe.ui.form.on("DocType", {
 	},
 
 	refresh: function (frm) {
-		if(frm.doc.custom === 1) {
-			frm.add_custom_button(
-				__("Trim Table"),
-				function () {
-					frm.trigger("trim_table");
-				}
-			);
+		if (frm.doc.custom === 1) {
+			frm.add_custom_button(__("Trim Table"), function () {
+				frm.trigger("trim_table");
+			});
 		}
 
 		frm.set_query("role", "permissions", function (doc) {
@@ -144,7 +141,6 @@ frappe.ui.form.on("DocType", {
 			frm.form_wrapper.removeClass("mb-1");
 		}
 	},
-
 });
 
 frappe.ui.form.on("DocField", {

--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -145,39 +145,6 @@ frappe.ui.form.on("DocType", {
 		}
 	},
 
-	async trim_table(frm) {
-		let dropped_columns = await frappe.xcall(
-			"frappe.custom.doctype.customize_form.customize_form.get_orphaned_columns",
-			{ doctype: frm.doc.name }
-		);
-
-		if (!dropped_columns?.length) {
-			frappe.toast(__("This doctype has no orphan fields to trim"));
-			return;
-		}
-		let msg = __(
-			"Warning: DATA LOSS IMMINENT! Proceeding will permanently delete following database columns from doctype {0}:",
-			[frm.doc.name.bold()]
-		);
-		msg += "<ol>" + dropped_columns.map((col) => `<li>${col}</li>`).join("") + "</ol>";
-		msg += __("This action is irreversible. Do you wish to continue?");
-
-		frappe.confirm(msg, () => {
-			return frm.call({
-				doc: frm.doc,
-				method: "trim_table",
-				callback: function (r) {
-					if (!r.exc) {
-						frappe.show_alert({
-							message: __("Table Trimmed"),
-							indicator: "green",
-						});
-						frm.refresh();
-					}
-				},
-			});
-		});
-	},
 });
 
 frappe.ui.form.on("DocField", {

--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -32,6 +32,15 @@ frappe.ui.form.on("DocType", {
 	},
 
 	refresh: function (frm) {
+		if(frm.doc.custom === 1) {
+			frm.add_custom_button(
+				__("Trim Table"),
+				function () {
+					frm.trigger("trim_table");
+				}
+			);
+		}
+
 		frm.set_query("role", "permissions", function (doc) {
 			if (doc.custom && frappe.session.user != "Administrator") {
 				return {
@@ -134,6 +143,40 @@ frappe.ui.form.on("DocType", {
 			frm.form_wrapper.find(".form-message").show();
 			frm.form_wrapper.removeClass("mb-1");
 		}
+	},
+
+	async trim_table(frm) {
+		let dropped_columns = await frappe.xcall(
+			"frappe.custom.doctype.customize_form.customize_form.get_orphaned_columns",
+			{ doctype: frm.doc.name }
+		);
+
+		if (!dropped_columns?.length) {
+			frappe.toast(__("This doctype has no orphan fields to trim"));
+			return;
+		}
+		let msg = __(
+			"Warning: DATA LOSS IMMINENT! Proceeding will permanently delete following database columns from doctype {0}:",
+			[frm.doc.name.bold()]
+		);
+		msg += "<ol>" + dropped_columns.map((col) => `<li>${col}</li>`).join("") + "</ol>";
+		msg += __("This action is irreversible. Do you wish to continue?");
+
+		frappe.confirm(msg, () => {
+			return frm.call({
+				doc: frm.doc,
+				method: "trim_table",
+				callback: function (r) {
+					if (!r.exc) {
+						frappe.show_alert({
+							message: __("Table Trimmed"),
+							indicator: "green",
+						});
+						frm.refresh();
+					}
+				},
+			});
+		});
 	},
 });
 

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1055,6 +1055,16 @@ class DocType(Document):
 			)
 			return True
 
+	@frappe.whitelist()
+	def trim_table(self):
+		from frappe.model.meta import trim_table
+		"""Removes database fields that don't exist in the doctype.
+
+		This may be needed as maintenance since removing a field in a DocType
+		doesn't automatically delete the db field.
+		"""
+		trim_table(self.name, dry_run=False)
+
 
 def validate_series(dt, autoname=None, name=None):
 	"""Validate if `autoname` property is correctly set."""

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1058,6 +1058,7 @@ class DocType(Document):
 	@frappe.whitelist()
 	def trim_table(self):
 		from frappe.model.meta import trim_table
+
 		"""Removes database fields that don't exist in the doctype.
 
 		This may be needed as maintenance since removing a field in a DocType

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -202,40 +202,6 @@ frappe.ui.form.on("Customize Form", {
 		);
 	},
 
-	async trim_table(frm) {
-		let dropped_columns = await frappe.xcall(
-			"frappe.custom.doctype.customize_form.customize_form.get_orphaned_columns",
-			{ doctype: frm.doc.doc_type }
-		);
-
-		if (!dropped_columns?.length) {
-			frappe.toast(__("This doctype has no orphan fields to trim"));
-			return;
-		}
-		let msg = __(
-			"Warning: DATA LOSS IMMINENT! Proceeding will permanently delete following database columns from doctype {0}:",
-			[frm.doc.doc_type.bold()]
-		);
-		msg += "<ol>" + dropped_columns.map((col) => `<li>${col}</li>`).join("") + "</ol>";
-		msg += __("This action is irreversible. Do you wish to continue?");
-
-		frappe.confirm(msg, () => {
-			return frm.call({
-				doc: frm.doc,
-				method: "trim_table",
-				callback: function (r) {
-					if (!r.exc) {
-						frappe.show_alert({
-							message: __("Table Trimmed"),
-							indicator: "green",
-						});
-						frappe.customize_form.clear_locals_and_refresh(frm);
-					}
-				},
-			});
-		});
-	},
-
 	setup_export(frm) {
 		if (frappe.boot.developer_mode) {
 			frm.add_custom_button(

--- a/frappe/public/js/frappe/doctype/index.js
+++ b/frappe/public/js/frappe/doctype/index.js
@@ -222,4 +222,51 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 			update_fieldname_options();
 		}
 	}
+
+	async trim_table() {
+		let frm = this.frm;
+		let doctype = null;
+		if (frm.doc.doctype === "DocType") {
+			doctype = frm.doc.name;
+		} else {
+			// In customize form name field is "Customize Form". Doctype name is stored in doc_type.
+			doctype = frm.doc.doc_type;
+		}
+
+		let dropped_columns = await frappe.xcall(
+			"frappe.custom.doctype.customize_form.customize_form.get_orphaned_columns",
+			{ doctype: doctype }
+		);
+
+		if (!dropped_columns?.length) {
+			frappe.toast(__("This doctype has no orphan fields to trim"));
+			return;
+		}
+		let msg = __(
+			"Warning: DATA LOSS IMMINENT! Proceeding will permanently delete following database columns from doctype {0}:",
+			[frm.doc.name.bold()]
+		);
+		msg += "<ol>" + dropped_columns.map((col) => `<li>${col}</li>`).join("") + "</ol>";
+		msg += __("This action is irreversible. Do you wish to continue?");
+
+		frappe.confirm(msg, () => {
+			return frm.call({
+				doc: frm.doc,
+				method: "trim_table",
+				callback: function (r) {
+					if (!r.exc) {
+						frappe.show_alert({
+							message: __("Table Trimmed"),
+							indicator: "green",
+						});
+						if (frm.doc.doctype === "DocType") {
+							frm.refresh();
+						} else {
+							frappe.customize_form.clear_locals_and_refresh(frm);
+						}
+					}
+				},
+			});
+		});
+	}
 };


### PR DESCRIPTION
Currently there is no option to trim custom doctypes. Adding the functionality in doctype page for custom doctypes.

`no-docs`