### PR TITLE
fix: support "Timespan" in `evaluate_filters`

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -24,7 +24,6 @@ from frappe.utils import (
 	add_trackers_to_url,
 	ceil,
 	dict_to_str,
-	evaluate_filters,
 	execute_in_shell,
 	floor,
 	flt,
@@ -59,6 +58,7 @@ from frappe.utils.data import (
 	cint,
 	cstr,
 	duration_to_seconds,
+	evaluate_filters,
 	expand_relative_urls,
 	get_datetime,
 	get_first_day_of_week,
@@ -217,6 +217,14 @@ class TestFilters(IntegrationTestCase):
 
 		for filter, expected_result in test_cases:
 			self.assertEqual(evaluate_filters(doc, filter), expected_result, msg=f"{filter}")
+
+	def test_timespan(self):
+		doc = {
+			"doctype": "User",
+			"last_password_reset_date": getdate(),
+		}
+		self.assertTrue(evaluate_filters(doc, [("last_password_reset_date", "Timespan", "today")]))
+		self.assertFalse(evaluate_filters(doc, [("last_password_reset_date", "Timespan", "last year")]))
 
 
 class TestMoney(IntegrationTestCase):

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -226,6 +226,12 @@ class TestFilters(IntegrationTestCase):
 		self.assertTrue(evaluate_filters(doc, [("last_password_reset_date", "Timespan", "today")]))
 		self.assertFalse(evaluate_filters(doc, [("last_password_reset_date", "Timespan", "last year")]))
 
+		doc = {
+			"doctype": "User",
+			"last_password_reset_date": None,
+		}
+		self.assertFalse(evaluate_filters(doc, [("last_password_reset_date", "Timespan", "today")]))
+
 
 class TestMoney(IntegrationTestCase):
 	def test_money_in_words(self):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2004,6 +2004,9 @@ def filter_operator_is(value: str, pattern: str) -> bool:
 
 
 def filter_operator_timespan(value: str, pattern: str) -> bool:
+	if not value:
+		return False
+
 	date_range = get_timespan_date_range(pattern)
 	return date_range[0] <= getdate(value) <= date_range[1]
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2003,6 +2003,11 @@ def filter_operator_is(value: str, pattern: str) -> bool:
 		frappe.throw(frappe._(f"Invalid argument for operator 'IS': {pattern}"))
 
 
+def filter_operator_timespan(value: str, pattern: str) -> bool:
+	date_range = get_timespan_date_range(pattern)
+	return date_range[0] <= getdate(value) <= date_range[1]
+
+
 operator_map = {
 	# startswith
 	"^": lambda a, b: (a or "").startswith(b),
@@ -2021,6 +2026,7 @@ operator_map = {
 	"like": sql_like,
 	"not like": lambda a, b: not sql_like(a, b),
 	"is": filter_operator_is,
+	"Timespan": filter_operator_timespan,
 }
 
 
@@ -2039,7 +2045,8 @@ def evaluate_filters(doc: "Mapping", filters: FilterSignature):
 def compare(val1: Any, condition: str, val2: Any, fieldtype: str | None = None):
 	if fieldtype:
 		val1 = cast(fieldtype, val1)
-		val2 = cast(fieldtype, val2)
+		if condition != "Timespan":
+			val2 = cast(fieldtype, val2)
 	if condition in operator_map:
 		return operator_map[condition](val1, val2)
 


### PR DESCRIPTION
`frappe.utils.data.evaluate_filters(doc, filters)` can be used to check if a specific document matches a set of filters. 
Until now, this didn't support the "Timespan" operator. This PR adds it.

Ref: IBT