### PR TITLE
fix(auto email report): add get_data function to multiselectlist filters

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -138,13 +138,14 @@ frappe.ui.form.on("Auto Email Report", {
 				if (val.fieldtype != "Break") {
 					if (val.fieldtype === "MultiSelectList") {
 						val.get_data = (txt) => {
-							if (!dialog || !val.options) return;
+							if (!dialog || !val.options) return [];
 
-							let doctype_link = Array.isArray(val.options)
-								? val.options
-								: frappe.scrub(val.options) === val.options
-								? dialog.get_value(val.options)
-								: val.options;
+							if (Array.isArray(val.options)) return val.options;
+
+							const doctype_link =
+								frappe.scrub(val.options) === val.options
+									? dialog.get_value(val.options)
+									: val.options;
 
 							return doctype_link
 								? frappe.db.get_link_options(doctype_link, txt)

--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -101,7 +101,7 @@ frappe.ui.form.on("Auto Email Report", {
 			);
 
 			var filters = {};
-
+			var dialog;
 			let report_filters;
 
 			if (
@@ -136,6 +136,21 @@ frappe.ui.form.on("Auto Email Report", {
 			$.each(report_filters, function (key, val) {
 				// Remove break fieldtype from the filters
 				if (val.fieldtype != "Break") {
+					if (val.fieldtype === "MultiSelectList") {
+						val.get_data = (txt) => {
+							if (!dialog || !val.options) return;
+
+							let doctype_link = Array.isArray(val.options)
+								? val.options
+								: frappe.scrub(val.options) === val.options
+								? dialog.get_value(val.options)
+								: val.options;
+
+							return doctype_link
+								? frappe.db.get_link_options(doctype_link, txt)
+								: [];
+						};
+					}
 					report_filters_list.push(val);
 				}
 			});
@@ -156,7 +171,7 @@ frappe.ui.form.on("Auto Email Report", {
 			});
 
 			table.on("click", function () {
-				var dialog = new frappe.ui.Dialog({
+				dialog = new frappe.ui.Dialog({
 					fields: report_filters,
 					primary_action: function () {
 						var values = this.get_values();


### PR DESCRIPTION
**Issue:**
Unable to select the value in MultiSelectList field, while creating auto email report.
**ref:** [30346](https://support.frappe.io/helpdesk/tickets/30346)

**Before:**

https://github.com/user-attachments/assets/67556746-4907-4207-9a3c-3c7156e5ce99

**After:**

https://github.com/user-attachments/assets/6d714795-489e-4931-917f-bbb4867ce48b


**Backport need for v14 and v15**