### PR TITLE
fix: check if doc name is string

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -656,8 +656,10 @@ $.extend(frappe.model, {
 	},
 
 	get_doc_title(doc) {
-		if (doc.name.startsWith("new-" + doc.doctype.toLowerCase().replace(/ /g, "-"))) {
-			return __("New {0}", [__(doc.doctype)]);
+		if (typeof doc.name == "string") {
+			if (doc.name.startsWith("new-" + doc.doctype.toLowerCase().replace(/ /g, "-"))) {
+				return __("New {0}", [__(doc.doctype)]);
+			}
 		}
 		let meta = frappe.get_meta(doc.doctype);
 		if (meta.title_field) {


### PR DESCRIPTION
Before
<img width="1440" alt="doc name string fail" src="https://github.com/user-attachments/assets/31ebeeb3-f3b6-4136-960e-dfdaa3bd2db6" />

After:

<img width="1092" alt="fix doc name work" src="https://github.com/user-attachments/assets/c4f17a9a-1f70-45c4-99bc-a499d0aad133" />
