### PR TITLE
fix: allow multiple `@rate_limit` decorators to be considered

### DIFF
--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -153,6 +153,9 @@ def rate_limit(
 
 			cache_key = frappe.cache.make_key(f"rl:{frappe.form_dict.cmd}:{identity}")
 
+			if not callable(seconds):
+				cache_key += f":{seconds}".encode()
+
 			value = frappe.cache.get(cache_key)
 			if not value:
 				frappe.cache.setex(cache_key, seconds, 0)


### PR DESCRIPTION
Currently, rate limiting does not support multiple `@rate_limit` decorators on the same method. This is because the cache key used for rate limiting is based only on the command (frappe.form_dict.cmd) and identity (identity). As a result, only two decorators, one with a key-based limit and one with an IP-based limit can be applied at a time.

Use Case: Adding multiple rate limits with different time windows (e.g., 10 requests per minute, 20 per 5 minutes, 30 per hour) allows for more granular traffic control. This helps prevent both short-term abuse (burst attacks) and long-term misuse (high traffic).