### PR TITLE
fix: send only fields marked `in_list_view` in `www.list.get_list_data`

### DIFF
--- a/frappe/templates/includes/list/list.js
+++ b/frappe/templates/includes/list/list.js
@@ -1,34 +1,12 @@
 frappe.ready(function() {
-	var next_start = {{ next_start or 0 }};
-	var result_wrapper = $(".website-list .result");
-
 	$(".website-list .btn-more").on("click", function() {
-		var btn = $(this);
-		var data = $.extend(frappe.utils.get_query_params(), {
-			doctype: "{{ doctype }}",
-			txt: "{{ (txt or '')|e }}",
-			limit_start: next_start,
-			pathname: location.pathname,
-		});
-		data.web_form_name = frappe.web_form_name;
-		data.pathname = location.pathname;
-		btn.prop("disabled", true);
-		return $.ajax({
-			url:"/api/method/frappe.www.list.get",
-			data: data,
-			statusCode: {
-				200: function(data) {
-					var data = data.message;
-					next_start = data.next_start;
-					$.each(data.result, function(i, d) {
-						$(d).appendTo(result_wrapper);
-					});
-					toggle_more(data.show_more);
-				}
-			}
-		}).always(function() {
-			btn.prop("disabled", false);
-		});
+		const q = frappe.utils.get_query_params();
+		if (q.limit) {
+			q.limit = parseInt(q.limit);
+			q.limit += 20;
+		} else q.limit = 40;
+		const s = frappe.utils.make_query_string(q);
+		location.href = `${location.origin}${location.pathname}${s}`;
 	});
 	var toggle_more = function(show) {
 		if (!show) {

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -17,7 +17,10 @@ def get_context(context, **dict_params):
 
 	Also update `get_list_context` from the doctype module file."""
 	frappe.local.form_dict.update(dict_params)
+	frappe.local.form_dict.limit = cint(frappe.local.form_dict.limit, 20)
 	doctype = frappe.local.form_dict.doctype
+	if not doctype:
+		frappe.throw("No DocType", exc=frappe.PageDoesNotExistError)
 	context.parents = [{"route": "me", "title": _("My Account")}]
 	context.meta = frappe.get_meta(doctype)
 	context.update(get_list_context(context, doctype) or {})
@@ -26,7 +29,6 @@ def get_context(context, **dict_params):
 	context.update(get(**frappe.local.form_dict))
 
 
-@frappe.whitelist(allow_guest=True)
 def get(doctype, txt=None, limit_start=0, limit=20, pathname=None, **kwargs):
 	"""Return processed HTML page for a standard listing."""
 	limit_start = cint(limit_start)
@@ -78,7 +80,7 @@ def get(doctype, txt=None, limit_start=0, limit=20, pathname=None, **kwargs):
 def get_list_data(
 	doctype, txt=None, limit_start=0, fields=None, cmd=None, limit=20, web_form_name=None, **kwargs
 ):
-	"""Return processed HTML page for a standard listing."""
+	"""Returns public list data"""
 	limit_start = cint(limit_start)
 
 	if frappe.is_table(doctype):
@@ -91,6 +93,12 @@ def get_list_data(
 	controller = get_controller(doctype)
 	meta = frappe.get_meta(doctype)
 
+	list_view_fields = set([df.fieldname for df in meta.fields if df.in_list_view])
+	list_view_fields.add("name")
+	if fields:
+		fields = [f for f in fields if f in list_view_fields]
+	else:
+		fields = list(list_view_fields)
 	filters = prepare_filters(doctype, controller, kwargs)
 	list_context = get_list_context(frappe._dict(), doctype, web_form_name)
 	list_context.title_field = getattr(controller, "website", {}).get(
@@ -110,6 +118,9 @@ def get_list_data(
 		limit_page_length=limit,
 		order_by=list_context.order_by or "creation desc",
 	)
+
+	if not list_context.get_list:
+		kwargs["fields"] = fields
 
 	# allow guest if flag is set
 	if not list_context.get_list and (list_context.allow_guest or meta.allow_guest_to_view):


### PR DESCRIPTION
The www list get API call is an ancient interface that allows unchecked public access to the database, by default all fields are returned and bypasses all normal permissions checks.

I have attempted to secure the interface as simply as possible because it is simply not used any more and should probably be removed altogether.

version-15
version-14
version-13