### PR TITLE
perf: Only filter last 3 months of data by default on large tables

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -44,6 +44,7 @@ from frappe.model.workflow import get_workflow_name
 from frappe.modules import load_doctype_module
 from frappe.types import DocRef
 from frappe.utils import cast, cint, cstr
+from frappe.utils.data import add_to_date, get_datetime
 
 DEFAULT_FIELD_LABELS = {
 	"name": _lt("ID"),
@@ -62,7 +63,8 @@ DEFAULT_FIELD_LABELS = {
 # When number of rows in a table exceeds this number, we disable certain features automatically.
 # This is done to avoid hammering the site with unnecessary requests that are just meant for
 # improving UX.
-LARGE_TABLE_THRESHOLD = 100_000
+LARGE_TABLE_SIZE_THRESHOLD = 100_000
+LARGE_TABLE_RECENCY_THRESHOLD = 30  # days
 
 
 def get_meta(doctype: str | dict | DocRef, cached=True) -> "_Meta":
@@ -190,7 +192,7 @@ class Meta(Document):
 		self.get_valid_columns()
 		self.set_custom_permissions()
 		self.add_custom_links_and_actions()
-		self.is_large_table = frappe.db.estimate_count(self.name) > LARGE_TABLE_THRESHOLD
+		self.check_if_large_table()
 
 	def as_dict(self, no_nulls=False):
 		def serialize(doc):
@@ -508,6 +510,23 @@ class Meta(Document):
 						new_list.append(d)
 
 				self.set(fieldname, new_list)
+
+	def check_if_large_table(self):
+		"""Apply some heuristics to detect large tables.
+
+		UI code can use this information to adapt accordingly."""
+		# Note: `modified` should be used in older versions.
+		self.is_large_table = False
+		if not frappe.db.table_exists(self.name):  # During install, new migrate
+			return
+
+		recent_change = frappe.db.get_value(self.name, {}, "creation", order_by="creation desc")
+		self.is_large_table = (
+			not self.istable
+			and frappe.db.estimate_count(self.name) > LARGE_TABLE_SIZE_THRESHOLD
+			and recent_change
+			and get_datetime(recent_change) > add_to_date(None, days=-1 * LARGE_TABLE_RECENCY_THRESHOLD)
+		)
 
 	def init_field_caches(self):
 		# field map

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -25,9 +25,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		super(opts);
 		this.show();
 		const meta = frappe.get_meta(this.doctype);
+		this.is_large_table = meta?.is_large_table;
+
 		this.debounced_refresh = frappe.utils.debounce(
 			this.process_document_refreshes.bind(this),
-			meta?.is_large_table ? 15000 : 2000
+			this.is_large_table ? 15000 : 2000
 		);
 		this.count_upper_bound = 1001;
 		this._element_factory = new ElementFactory(this.doctype);
@@ -106,9 +108,23 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				return f;
 			});
 		}
+		this.add_recent_filter_on_large_tables();
 
 		this.patch_refresh_and_load_lib();
 		return this.get_list_view_settings();
+	}
+
+	add_recent_filter_on_large_tables() {
+		if (!this.is_large_table) {
+			return;
+		}
+		// Note: versions older than v16 should use "modified" here.
+		const recency_field = "creation";
+
+		if (this.filters.filter((arr) => arr?.includes(recency_field)).length) {
+			return;
+		}
+		this.filters.push([this.doctype, recency_field, "Timespan", "last 90 days"]);
 	}
 
 	on_sort_change(sort_by, sort_order) {
@@ -519,6 +535,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	before_refresh() {
 		if (frappe.route_options && this.filter_area) {
 			this.filters = this.parse_filters_from_route_options();
+			this.add_recent_filter_on_large_tables();
 			frappe.route_options = null;
 
 			if (this.filters.length > 0) {

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -612,7 +612,17 @@ frappe.ui.filter_utils = {
 
 	get_timespan_options(periods) {
 		const period_map = {
-			Last: ["7 Days", "14 Days", "30 Days", "Week", "Month", "Quarter", "6 months", "Year"],
+			Last: [
+				"7 Days",
+				"14 Days",
+				"30 Days",
+				"90 Days",
+				"Week",
+				"Month",
+				"Quarter",
+				"6 months",
+				"Year",
+			],
 			This: ["Week", "Month", "Quarter", "Year"],
 			Next: ["7 Days", "14 Days", "30 Days", "Week", "Month", "Quarter", "6 months", "Year"],
 		};

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -899,20 +899,13 @@ def get_timespan_date_range(
 
 	match timespan:
 		case "last 7 days":
-			return (
-				add_to_date(today, days=-7),
-				today,
-			)
+			return (add_to_date(today, days=-7), today)
 		case "last 14 days":
-			return (
-				add_to_date(today, days=-14),
-				today,
-			)
+			return (add_to_date(today, days=-14), today)
 		case "last 30 days":
-			return (
-				add_to_date(today, days=-30),
-				today,
-			)
+			return (add_to_date(today, days=-30), today)
+		case "last 90 days":
+			return (add_to_date(today, days=-90), today)
 		case "last week":
 			return (
 				get_first_day_of_week(add_to_date(today, days=-7)),


### PR DESCRIPTION
Applying something basic filter like `order id like %xyz%` can result in
full table scan on **years of data**. This isn't necessary most of the time.

Interactive filtering/queries are usually done on recent data, so add this filter
to ensure only recent data is checked first.

Users can remove this filter if they want to.


Before: 
![image](https://github.com/user-attachments/assets/de84edc6-e06e-4ed8-8496-e89e29df5790)



After (same query with default recency filter): ~30-40x faster on this site consistently
![image](https://github.com/user-attachments/assets/cf55d5b7-b197-4d6a-811b-06f51a6a9ac5)

