### PR TITLE
fix: prefill values in the query report's multi select

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -587,7 +587,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	set_filters(filters) {
 		this.filters.map((f) => {
-			f.set_input(filters[f.fieldname]);
+			if (f.fieldtype == "MultiSelectList") {
+				f.set_value(filters[f.fieldname]);
+			} else {
+				f.set_input(filters[f.fieldname]);
+			}
 		});
 	}
 

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -93,7 +93,7 @@
 }
 
 .layout-main-section-wrapper {
-	flex-grow: 1;
+	width: 100%;
 }
 
 .layout-main-section.frappe-card {


### PR DESCRIPTION
Support ticket https://support.frappe.io/helpdesk/tickets/30369

The multi-select filters were not selected by default in the query report.

- Before

https://github.com/user-attachments/assets/62ff8771-186f-4567-8e7d-e7d7421de13b


- After

https://github.com/user-attachments/assets/f7938b0c-a339-420e-86d7-35327476a676

