### PR TITLE
fix: rename state to workflow state

### DIFF
--- a/frappe/integrations/doctype/token_cache/token_cache.json
+++ b/frappe/integrations/doctype/token_cache/token_cache.json
@@ -55,7 +55,7 @@
   {
    "fieldname": "state",
    "fieldtype": "Data",
-   "label": "State",
+   "label": "Token State",
    "read_only": 1
   },
   {

--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -162,8 +162,8 @@ frappe.ui.form.on("Workflow", {
 			frm.state_table_html = `<table class="table state-table table-bordered" style="margin:0px; width: 65%">
 				<thead style="font-size: 12px">
 					<tr class="text-muted">
-						<th>${__("State")}</th>
-						<th>${__("Count")}</th>
+						<th>${__("Workflow State")}</th>
+						<th>${__("Workflow Count")}</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
+++ b/frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
@@ -25,7 +25,7 @@
    "fieldname": "state",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "State",
+   "label": "Workflow State",
    "options": "Workflow State",
    "print_width": "160px",
    "reqd": 1,

--- a/frappe/workflow/doctype/workflow_state/workflow_state.json
+++ b/frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -17,7 +17,7 @@
    "fieldname": "workflow_state_name",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "State",
+   "label": "Workflow State",
    "reqd": 1,
    "unique": 1
   },

--- a/frappe/workflow/doctype/workflow_transition/workflow_transition.json
+++ b/frappe/workflow/doctype/workflow_transition/workflow_transition.json
@@ -22,7 +22,7 @@
    "fieldname": "state",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "State",
+   "label": "Workflow State",
    "options": "Workflow State",
    "print_width": "200px",
    "reqd": 1,


### PR DESCRIPTION
Rename "state" to "workflow state" to be able to translate as "State" word is already used

Backport to v15