### PR TITLE
Print Language Not Working in ERPNext v15.51.0 / Frappe v15.55.1 #45778

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -38,11 +38,11 @@ class HTTPRequest:
 		# load cookies
 		self.set_cookies()
 
-		# set request language
-		self.set_lang()
-
 		# login and start/resume user session
 		self.set_session()
+
+		# set request language
+		self.set_lang()
 
 		# match csrf token from current session
 		self.validate_csrf_token()


### PR DESCRIPTION
Observed Changes in HTTPRequest Class
@ ~/frappe-bench/apps/frappe/frappe/auth.py
In the current version:

# Set request language
self.set_lang()

# Login and start/resume user session
self.set_session()
In the previous (working) version:

# Login and start/resume user session
self.set_session()

# Set request language
self.set_lang()
Impact of the Change
This change appears to cause the system to prioritize the user's session language over the "Print Language" setting. As a result, documents always follow the user's UI language instead of the selected print language.
