### PR TITLE
fix: Encode URL filters to handle special characters

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1897,7 +1897,7 @@ def get_link_to_report(
 					for value in v
 				)
 			else:
-				conditions.append(str(k) + "=" + str(v))
+				conditions.append(str(k) + "=" + quote(str(v)))
 
 		filters = "&".join(conditions)
 


### PR DESCRIPTION
Support ticket: [Support Ticket  - 31671](https://support.frappe.io/helpdesk/tickets/31671)

Before:
- Filters were not encoded, so when a special character like `&` appeared in the Company field, the filters were not applied correctly.

<img width="1178" alt="Screenshot 2025-02-13 at 3 43 07 PM" src="https://github.com/user-attachments/assets/709e8f06-e314-459e-bda9-2f9b066f4a32" />


After:
- Now, filters are properly encoded, ensuring that special characters like `&` do not break the URL.


<img width="1178" alt="Screenshot 2025-02-13 at 3 45 07 PM" src="https://github.com/user-attachments/assets/482666de-cdde-49f1-9a76-2caf84d98dda" />


Company Filters is Now Applied