### PR TITLE
fix: link field option disappear

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -367,11 +367,13 @@
 			height: 40px;
 		}
 	}
-	.awesomplete > ul {
-		position: fixed !important;
-		left: auto !important;
-		top: auto;
-		width: 250px !important;
+	.grid-row:not(.grid-row-open) {
+		.awesomplete > ul {
+			position: fixed !important;
+			left: auto !important;
+			top: auto;
+			width: 250px !important;
+		}
 	}
 	.grid-static-col {
 		background-color: var(--fg-color);


### PR DESCRIPTION
Closes #31237

Link field option disappear when grid row is open
