### PR TITLE
Revert "fix: Improper routing for Report links when added to cards in workspaces"

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1304,7 +1304,8 @@ Object.assign(frappe.utils, {
 				if (item.is_query_report) {
 					route = "query-report/" + item.name;
 				} else if (!item.is_query_report && item.report_ref_doctype) {
-					route = frappe.router.slug(item.report_ref_doctype) + "/view/report/";
+					route =
+						frappe.router.slug(item.report_ref_doctype) + "/view/report/" + item.name;
 				} else {
 					route = "report/" + item.name;
 				}


### PR DESCRIPTION
Reverts frappe/frappe#29104

Doesn't seem to make sense here