### PR TITLE
perf: Support running RQ worker without forking

### DIFF
--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -214,7 +214,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 	retval = None
 
 	if is_async:
-		frappe.init(site)
+		frappe.init(site, force=True)
 		frappe.connect()
 		if os.environ.get("CI"):
 			frappe.flags.in_test = True
@@ -281,7 +281,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 
 	finally:
 		if not hasattr(frappe.local, "site"):
-			frappe.init(site)
+			frappe.init(site, force=True)
 			frappe.connect()
 		for after_job_task in frappe.get_hooks("after_job"):
 			frappe.call(after_job_task, method=method_name, kwargs=kwargs, result=retval)


### PR DESCRIPTION
Frappe does everything required to run jobs without forking.
- We cleanup locals
- Global caches are invalidated appropriately
- We destroy connections and open a new one for job/request

So we don't have any safety benefit much from forking for every job.
There can still be some code out in wild that relies on this behaviour
though!

Pros:
- Almost zero-overhead background jobs, just like web requests.

Cons:
- Timeout need to be implemented separately now
- Unknown side effects!
- Some features like "stop job" will need separate implementations.
- Higher idle memory usage - more imported things stay in memory. Need to revisit the `tune_gc` imports for this.

TODO:
- [x] Exit worker completely on timeout - supervisor/workerpool to restart
- [x] Support "stop job" by killing the entire process (?)
- [ ] Try to keep RQ data consistent when timed out or killed.
- [x] Make it configurable, disabled by default
- [x] Periodic exit after `max_jobs=X` to prevent memory leaks
- [x] Worker heartbeats?
- [x] Job heartbeats
