### PR TITLE
fix(email_account): select backend_app_flow when retrieving email_account

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -887,6 +887,7 @@ def pull(now=False):
 		.select(
 			doctype.name,
 			doctype.auth_method,
+			doctype.backend_app_flow,
 			doctype.connected_app,
 			doctype.connected_user,
 		)


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

The `if` statement on line 899 uses the `backend_app_flow` variable of the `email_account` type. However, it is never retrieved from the database and hence not used.

> Explain the **details** for making this change. What existing problem does the pull request solve?

This broke the Backend App Flow (https://github.com/frappe/frappe/issues/27148) and was probably overlooked in the PR (https://github.com/frappe/frappe/pull/27167). Without retrieving the `backend_app_flow` variable it is impossible to retrieve email.