### PR TITLE
fix(report_view): don't disallow editing just if a table exists

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -702,7 +702,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	}
 
 	is_editable(df, data) {
-		return (
+		if (
 			df &&
 			frappe.model.can_write(this.doctype) &&
 			// not a submitted doc or field is allowed to edit after submit
@@ -713,12 +713,16 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			!df.is_virtual &&
 			!df.hidden &&
 			// not a standard field i.e., owner, modified_by, etc.
-			frappe.model.is_non_std_field(df.fieldname) &&
+			frappe.model.is_non_std_field(df.fieldname)
+		) {
 			// don't check read_only_depends_on if there's child table fields
-			!this.meta.fields.some((df) => df.fieldtype === "Table") &&
-			df.read_only_depends_on &&
-			!this.evaluate_read_only_depends_on(df.read_only_depends_on, data)
-		);
+			return (
+				this.meta.fields.some((df) => df.fieldtype === "Table") ||
+				(df.read_only_depends_on &&
+					!this.evaluate_read_only_depends_on(df.read_only_depends_on, data))
+			);
+		}
+		return false;
 	}
 
 	get_data(values) {


### PR DESCRIPTION
If a table exists, go with the previous result. Else check and parse read_only conditions

Fixes #30907
