### PR TITLE
fix: hide create button for cancelled doc in dashboard links

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1954,7 +1954,7 @@ frappe.ui.form.Form = class FrappeForm {
 		if (this.can_make_methods && this.can_make_methods[doctype]) {
 			return this.can_make_methods[doctype](this);
 		} else {
-			if (this.meta.is_submittable && !this.doc.docstatus == 1) {
+			if (this.meta.is_submittable && this.doc.docstatus !== 1) {
 				return false;
 			} else {
 				return true;


### PR DESCRIPTION
Before:
```js
if (this.meta.is_submittable && !this.doc.docstatus == 1)
```
- Incorrectly compared `!this.doc.docstatus` to `1` due to operator precedence.

[before_dash.webm](https://github.com/user-attachments/assets/f15e1fa8-1605-4dd8-9fe3-d215ef024ad9)


After:
```js
if (this.meta.is_submittable && this.doc.docstatus !== 1)
```
- Used strict comparison to correctly check if `docstatus` is not equal to `1`.

[after_dash.webm](https://github.com/user-attachments/assets/cd3c79c4-e59b-4fc8-939b-1663eafd338c)
