### PR TITLE
fix: clear cache after db transaction ends

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1307,6 +1307,8 @@ class Document(BaseDocument, DocRef):
 
 	def clear_cache(self):
 		frappe.clear_document_cache(self.doctype, self.name)
+		frappe.db.after_commit.add(lambda: frappe.clear_document_cache(self.doctype, self.name))
+		frappe.db.after_rollback.add(lambda: frappe.clear_document_cache(self.doctype, self.name))
 
 	def reset_seen(self):
 		"""Clear _seen property and set current user as seen"""

--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -70,6 +70,9 @@ class WebsiteGenerator(Document):
 		super().clear_cache()
 		clear_cache(self.route)
 
+		frappe.db.after_commit.add(lambda: clear_cache(self.route))
+		frappe.db.after_rollback.add(lambda: clear_cache(self.route))
+
 	def scrub(self, text):
 		return cleanup_page_name(text).replace("_", "-")
 


### PR DESCRIPTION
This reduces probability of stale cache, but it's still very easily
possible because of repeatable read (!)

Recent example:
- https://github.com/frappe/builder/commit/044edd445e874770dddeda143939ed27ea09ed4e 
- explanation: https://gameplan.frappe.cloud/g/space/230/discussion/3318

![image](https://github.com/user-attachments/assets/ea3800e8-0b5f-4654-9595-c36fd58138d9)
