### PR TITLE
refactor: utcfromtimestamp -> fromtimestamp(timezone.utc)

### DIFF
--- a/frappe/desk/page/backups/backups.py
+++ b/frappe/desk/page/backups/backups.py
@@ -10,9 +10,9 @@ from frappe.utils.data import convert_utc_to_system_timezone
 def get_context(context):
 	def get_time(path):
 		dt = os.path.getmtime(path)
-		return convert_utc_to_system_timezone(datetime.datetime.utcfromtimestamp(dt)).strftime(
-			"%a %b %d %H:%M %Y"
-		)
+		return convert_utc_to_system_timezone(
+			datetime.datetime.fromtimestamp(dt, tz=datetime.timezone.utc)
+		).strftime("%a %b %d %H:%M %Y")
 
 	def get_encrytion_status(path):
 		if "-enc" in path:

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -389,7 +389,7 @@ class Email:
 		if self.mail["Date"]:
 			try:
 				utc = email.utils.mktime_tz(email.utils.parsedate_tz(self.mail["Date"]))
-				utc_dt = datetime.datetime.utcfromtimestamp(utc)
+				utc_dt = datetime.datetime.fromtimestamp(utc, tz=datetime.timezone.utc)
 				self.date = convert_utc_to_system_timezone(utc_dt).strftime("%Y-%m-%d %H:%M:%S")
 			except Exception:
 				self.date = now()


### PR DESCRIPTION
It's deprecated now:

```DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).```
