### PR TITLE
feat: Allow more colours in the calendar view

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -120,6 +120,7 @@ frappe.views.Calendar = class Calendar {
 			success: "green",
 			warning: "orange",
 			default: "blue",
+			notice: "yellow",
 		};
 		this.get_default_options();
 	}

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -120,7 +120,6 @@ frappe.views.Calendar = class Calendar {
 			success: "green",
 			warning: "orange",
 			default: "blue",
-			notice: "yellow",
 		};
 		this.get_default_options();
 	}
@@ -421,7 +420,8 @@ frappe.views.Calendar = class Calendar {
 	prepare_colors(d) {
 		let color, color_name;
 		if (this.get_css_class) {
-			color_name = this.color_map[this.get_css_class(d)] || "blue";
+			color_name = this.get_css_class(d);
+			color_name = this.color_map[color_name] || color_name || "blue";
 
 			if (color_name.startsWith("#")) {
 				color_name = frappe.ui.color.validate_hex(color_name) ? color_name : "blue";


### PR DESCRIPTION
Why only have 4 when you can have more?
<img width="900" alt="Screenshot 2025-02-19 at 5 26 05 PM" src="https://github.com/user-attachments/assets/f585166b-8b47-4c5a-b8a4-e0a03aaa2119" />
