### PR TITLE
feat: OAuth 2.0. Allow including client_id in backend app auth request.

### DIFF
--- a/frappe/integrations/doctype/connected_app/connected_app.py
+++ b/frappe/integrations/doctype/connected_app/connected_app.py
@@ -148,7 +148,7 @@ class ConnectedApp(Document):
 
 		return token_cache
 
-	def get_backend_app_token(self):
+	def get_backend_app_token(self, include_client_id=None):
 		"""Get an Access Token for the Cloud-Registered Service Principal"""
 		# There is no User assigned to the app, so we give it an empty string,
 		# otherwise it will assign the logged in user.
@@ -163,7 +163,11 @@ class ConnectedApp(Document):
 		client = BackendApplicationClient(client_id=self.client_id, scope=self.get_scopes())
 		oauth_session = OAuth2Session(client=client)
 
-		token = oauth_session.fetch_token(self.token_uri, client_secret=self.get_password("client_secret"))
+		token = oauth_session.fetch_token(
+			self.token_uri,
+			client_secret=self.get_password("client_secret"),
+			include_client_id=include_client_id,
+		)
 
 		token_cache.update_data(token)
 		token_cache.save(ignore_permissions=True)


### PR DESCRIPTION
As per [rfc6749 section-3.2.1](https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1), OAuth clients:

> MAY use the "client_id" request parameter to identify itself when sending requests to the token endpoint.

This patch allows to include `client_id` in the OAuth 2.0 BackendAppFlow, for servers that require it. My use case is authenticating against APIs with `grant_type=client_credentials`, `client_id` and `client_secret` to gain an `access_token` that is sent in subsequent HTTP requests.

There is no change to existing code, this just allows changing `include_client_id` from the default value of `None`.