### PR TITLE
perf(DX): always cache controllers

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -64,9 +64,6 @@ def get_controller(doctype):
 	:param doctype: DocType name as string.
 	"""
 
-	if frappe.local.dev_server or frappe.flags.in_migrate:
-		return import_controller(doctype)
-
 	site_controllers = frappe.controllers.setdefault(frappe.local.site, {})
 	if doctype not in site_controllers:
 		site_controllers[doctype] = import_controller(doctype)


### PR DESCRIPTION
- This was added back when controllers were cached in redis
- in-process cache gets cleared on reload