### PR TITLE
feat: specify row compression for tables

### DIFF
--- a/frappe/core/doctype/communication/communication.json
+++ b/frappe/core/doctype/communication/communication.json
@@ -372,7 +372,7 @@
  "idx": 1,
  "links": [],
  "make_attachments_public": 1,
- "modified": "2024-03-23 16:01:30.219380",
+ "modified": "2025-02-20 19:19:29.427081",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Communication",
@@ -427,6 +427,7 @@
    "role": "All"
   }
  ],
+ "row_format": "Compressed",
  "search_fields": "subject",
  "sender_field": "sender",
  "sort_field": "creation",

--- a/frappe/core/doctype/deleted_document/deleted_document.json
+++ b/frappe/core/doctype/deleted_document/deleted_document.json
@@ -60,7 +60,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2024-03-23 16:02:17.664513",
+ "modified": "2025-02-20 19:22:00.734438",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Deleted Document",
@@ -73,6 +73,7 @@
    "role": "System Manager"
   }
  ],
+ "row_format": "Compressed",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -94,6 +94,7 @@
   "advanced",
   "engine",
   "migration_hash",
+  "row_format",
   "connections_tab"
  ],
  "fields": [
@@ -671,6 +672,14 @@
    "fieldname": "fields_tab",
    "fieldtype": "Tab Break",
    "label": "Fields"
+  },
+  {
+   "default": "Dynamic",
+   "fieldname": "row_format",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Row Format",
+   "options": "Dynamic\nCompressed"
   }
  ],
  "icon": "fa fa-bolt",
@@ -753,7 +762,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2024-11-30 16:09:21.536704",
+ "modified": "2025-02-20 19:05:52.119679",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -158,6 +158,7 @@ class DocType(Document):
 		read_only: DF.Check
 		restrict_to_domain: DF.Link | None
 		route: DF.Data | None
+		row_format: DF.Literal["Dynamic", "Compressed"]
 		search_fields: DF.Data | None
 		sender_field: DF.Data | None
 		sender_name_field: DF.Data | None

--- a/frappe/core/doctype/version/version.json
+++ b/frappe/core/doctype/version/version.json
@@ -53,7 +53,7 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2024-03-23 16:04:01.627592",
+ "modified": "2025-02-20 19:20:33.616072",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Version",
@@ -73,6 +73,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Compressed",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/core/doctype/view_log/view_log.json
+++ b/frappe/core/doctype/view_log/view_log.json
@@ -33,7 +33,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-23 16:04:01.764239",
+ "modified": "2025-02-20 19:21:33.012224",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "View Log",
@@ -50,6 +50,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Compressed",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -63,7 +63,7 @@ class MariaDBTable(DBTable):
 			idx int not null default '0',
 			{additional_definitions})
 			ENGINE={engine}
-			ROW_FORMAT=DYNAMIC
+			ROW_FORMAT={(self.meta.get("row_format") or "Dynamic").upper()}
 			CHARACTER SET=utf8mb4
 			COLLATE=utf8mb4_unicode_ci"""
 

--- a/frappe/email/doctype/email_queue/email_queue.json
+++ b/frappe/email/doctype/email_queue/email_queue.json
@@ -154,7 +154,7 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2024-03-23 16:03:24.379339",
+ "modified": "2025-02-20 19:21:09.652451",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Queue",
@@ -170,6 +170,7 @@
    "role": "System Manager"
   }
  ],
+ "row_format": "Compressed",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/website/doctype/web_page_view/web_page_view.json
+++ b/frappe/website/doctype/web_page_view/web_page_view.json
@@ -24,8 +24,8 @@
    "fieldname": "path",
    "fieldtype": "Data",
    "label": "Path",
-   "set_only_once": 1,
-   "search_index": 1
+   "search_index": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "referrer",
@@ -94,7 +94,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2024-03-23 16:04:02.743377",
+ "modified": "2025-02-20 19:20:47.267461",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Page View",
@@ -115,6 +115,7 @@
  ],
  "quick_entry": 1,
  "read_only": 1,
+ "row_format": "Compressed",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
Certain tables contain A LOT of duplicate data, it makes sense to enable
compressed row format on them by default. I've seen 5-10 fold reduction
in DB size after enabling compressed format on select few tables.

This has some performance overhead:
- both compressed and uncompressed pages live in buffer pool.
- compression/decompression cpu overheads
- Frequent random accesses are worse than `dynamic`

Note:
- These cons don't apply much on DocTypes I am enabling this for.
- I am not enabling this on existing sites, migration can take a long
  time! Do it manually with `transform-database` command if you want to.


closes https://github.com/frappe/caffeine/issues/61 