### PR TITLE
fix(EmailAccount): Fix always_bcc condition

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -691,8 +691,8 @@ class QueueBuilder:
 
 	def prepare_email_content(self):
 		email_account = self.get_outgoing_email_account()
-		if isinstance(self._bcc, list) and email_account.always_bcc is not None:
-			self._bcc.append(str(email_account.always_bcc))
+		if isinstance(self._bcc, list) and email_account.always_bcc:
+			self._bcc.append(email_account.always_bcc)
 		mail = get_email(
 			recipients=self.final_recipients(),
 			sender=self.sender,


### PR DESCRIPTION
**don't forget to backport to v15**

An empty string matches the `is not None` condition, which is undesired. Removed redundant (imho) `str()`. If it's not a string then its string representation probably isn't a valid email address anyways.

re: #28961