### PR TITLE
fix: erase cron frequency when type changes

### DIFF
--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -139,7 +139,7 @@ class ServerScript(Document):
 			{
 				"method": frappe.scrub(f"{self.name}-{self.event_frequency}"),
 				"frequency": self.event_frequency,
-				"cron_format": self.cron_format,
+				"cron_format": self.cron_format if self.event_frequency == "Cron" else "",
 				"stopped": self.disabled,
 			}
 		).save()


### PR DESCRIPTION
Right now hidden cron field is taking priority over event_frequency.
Which is confusing and not something anyone expects.
