### PR TITLE
feat: Add Grid Page Length field for child tables in DocType

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -31,6 +31,7 @@
   "is_calendar_and_gantt",
   "editable_grid",
   "quick_entry",
+  "grid_page_length",
   "cb01",
   "track_changes",
   "track_seen",
@@ -680,6 +681,14 @@
    "hidden": 1,
    "label": "Row Format",
    "options": "Dynamic\nCompressed"
+  },
+  {
+    "default": "50",
+    "depends_on": "istable",
+    "fieldname": "grid_page_length",
+    "fieldtype": "Int",
+    "label": "Grid Page Length",
+    "non_negative": 1
   }
  ],
  "icon": "fa fa-bolt",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -121,6 +121,7 @@ class DocType(Document):
 		engine: DF.Literal["InnoDB", "MyISAM"]
 		fields: DF.Table[DocField]
 		force_re_route_to_default_view: DF.Check
+		grid_page_length: DF.Int
 		has_web_view: DF.Check
 		hide_toolbar: DF.Check
 		icon: DF.Data | None

--- a/frappe/public/js/frappe/form/grid_pagination.js
+++ b/frappe/public/js/frappe/form/grid_pagination.js
@@ -5,7 +5,7 @@ export default class GridPagination {
 	}
 
 	setup_pagination() {
-		this.page_length = 50;
+		this.page_length = this.grid.meta?.grid_page_length || 50;
 		this.page_index = 1;
 		this.total_pages = Math.ceil(this.grid.data.length / this.page_length);
 


### PR DESCRIPTION
## Enhancement: Configurable Grid Page Length for Child Tables

## Overview
This PR introduces a `grid_page_length` field in the **DocType** document, allowing users to configure how many records are displayed per page in a **child table**. This provides greater flexibility and improves usability for managing child table data efficiently.

## Changes Implemented
- Added a **new integer field** called `grid_page_length` in the **DocType** document.  
- **Default value:** `50` (maintaining current behavior).  
- **Visibility:** Only applicable for **child tables**.  
- **Functionality:** The number of rows displayed per page in child tables now respects the value set in `grid_page_length`.  

## Why is this needed?
Currently, the **child table page size** is **fixed at 50** and cannot be changed. This PR allows users to **dynamically adjust** the number of records per page, improving usability when handling **large or small datasets**.

## How to Test?
1. Go to **DocType settings**.  
2. Locate the new **Grid Page Length** field (only for child tables).  
3. Set a custom value (e.g., `10`, `20`, `100`).  
4. Open a form with a child table and observe that the number of rows displayed per page updates accordingly.  

## Impact and Compatibility
- **Backward compatible**: Default remains `50` unless explicitly changed.  
- **No breaking changes expected**.  

## Processflow

https://github.com/user-attachments/assets/9b90aa25-8d49-4832-804a-7025465b78e2



## Related Issues/Discussions
[#28817 ](https://github.com/frappe/frappe/issues/28817)


`no-docs`