### PR TITLE
fix(print): handle custom format with custom module

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -438,21 +438,23 @@ def get_print_format(doctype: str, print_format: "PrintFormat") -> str:
 
 	# server, find template
 	module = print_format.module or frappe.db.get_value("DocType", doctype, "module")
-	path = os.path.join(
-		get_module_path(module, "Print Format", print_format.name),
-		frappe.scrub(print_format.name) + ".html",
-	)
 
-	if os.path.exists(path):
-		with open(path) as pffile:
-			return pffile.read()
-	else:
+	is_custom_module = frappe.get_cached_value("Module Def", module, "custom")
+	if is_custom_module:
 		if print_format.raw_printing:
 			return print_format.raw_commands
 		if print_format.html:
 			return print_format.html
 
-		frappe.throw(_("No template found at path: {0}").format(path), frappe.TemplateNotFoundError)
+	path = os.path.join(
+		get_module_path(module, "Print Format", print_format.name),
+		frappe.scrub(print_format.name) + ".html",
+	)
+	if os.path.exists(path):
+		with open(path) as pffile:
+			return pffile.read()
+
+	frappe.throw(_("No template found at path: {0}").format(path), frappe.TemplateNotFoundError)
 
 
 def make_layout(doc: "Document", meta: "Meta", format_data=None) -> list:


### PR DESCRIPTION
### The Problem

* Create a custom doctype in a custom module
* Create a print format for that doctype with "custom_format" checked (enabled Jinja/HTML field)
* Try to print:

    ![CleanShot 2025-02-21 at 13 03 08@2x](https://github.com/user-attachments/assets/feafd016-dfdb-4fe7-903f-4a9426f8afb1)

### Reason

This happens because the code does not handle this case and tries to look for the template in the file system.

### The Solution

Do not try to look for a file if the module is custom.


Co-authored-by: Aman <amanupadhayay2906@gmail.com>
Co-authored-by: Khushbu <mittalk1802@gmail.com>
Co-authored-by: Manya <girdharmanya28@gmail.com>
Co-authored-by: Ritika <ritika@korecent.com>
Co-authored-by: Siddharth <siddharth.khati03@gmail.com>
Co-authored-by: Yashvi <yashvi@korecent.com>
