### PR TITLE
fix: remove duplicate clear_cache calls

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1314,8 +1314,6 @@ class Document(BaseDocument, DocRef):
 
 	def clear_cache(self):
 		frappe.clear_document_cache(self.doctype, self.name)
-		frappe.db.after_commit.add(lambda: frappe.clear_document_cache(self.doctype, self.name))
-		frappe.db.after_rollback.add(lambda: frappe.clear_document_cache(self.doctype, self.name))
 
 	def reset_seen(self):
 		"""Clear _seen property and set current user as seen"""


### PR DESCRIPTION
This is internally handled in clear_document_cache

Fix was only required for websitegenerator specific things.
