### PR TITLE
fix(workflow_action): Pass context as dict to render template

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -476,6 +476,9 @@ def get_email_template_from_workflow(doc):
 
 	if not template_name:
 		return
+
+	if isinstance(doc, Document):
+		doc = doc.as_dict()
 	return get_email_template(template_name, doc)
 
 


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/28751

Please backport to V15 and V14