### PR TITLE
feat: set report filters from route options

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -30,7 +30,11 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				this.report_doc = doc;
 				this.report_doc.json = JSON.parse(this.report_doc.json);
 
-				this.filters = this.report_doc.json.filters;
+				this.filters = [
+					...this.report_doc.json.filters,
+					...this.parse_filters_from_route_options(),
+				];
+
 				this.order_by = this.report_doc.json.order_by;
 				this.add_totals_row = this.report_doc.json.add_totals_row;
 				this.page_title = __(this.report_name);


### PR DESCRIPTION
### Before

Opening `/app/timesheet/view/report/My Timesheet Report?project=Test` did not set a filter.

### After

Opening `/app/timesheet/view/report/My Timesheet Report?project=Test` sets the filter `["Timesheet Detail", "project", "=", "Test"]`, as expected.

---

> no-docs

Ref: DRC-118