### PR TITLE
fix: check `score` in response to set strength indicator

### DIFF
--- a/frappe/public/js/frappe/form/controls/password.js
+++ b/frappe/public/js/frappe/form/controls/password.js
@@ -75,10 +75,9 @@ frappe.ui.form.ControlPassword = class ControlPassword extends frappe.ui.form.Co
 				new_password: value || "",
 			},
 			callback: function (r) {
-				if (r.message) {
-					let score = r.message.score;
-					var indicators = ["red", "red", "orange", "blue", "green"];
-					me.set_strength_indicator(indicators[score]);
+				if (r.message.score !== undefined && r.message.score !== null) {
+					const indicators = ["red", "red", "orange", "blue", "green"];
+					me.set_strength_indicator(indicators[r.message.score]);
 				}
 			},
 		});


### PR DESCRIPTION
Previous PR: https://github.com/frappe/frappe/pull/31185

### Issue

When `Enable Password Policy` is unchecked changing any password field throws error.

![image](https://github.com/user-attachments/assets/afb5c589-f9fc-489f-ab01-a6b3dd49b5bf)

https://github.com/user-attachments/assets/b5335cf6-e363-4ba5-adb2-e7abfefae4f2

**Reason:**

![image](https://github.com/user-attachments/assets/679dbc31-543e-46c7-bb48-d8f15a9e623a)

https://github.com/frappe/frappe/blob/ff6407b9771acc44a10aca1cd379ae45cd6f3e7c/frappe/core/doctype/user/user.py#L926


Backport: 15 and 14