### PR TITLE
perf: Fork multiple workerpool from same process

### DIFF
--- a/frappe/commands/scheduler.py
+++ b/frappe/commands/scheduler.py
@@ -218,6 +218,7 @@ def start_worker(queue, quiet=False, rq_username=None, rq_password=None, burst=F
 	"--queue",
 	type=str,
 	help="Queue to consume from. Multiple queues can be specified using comma-separated string. If not specified all queues are consumed.",
+	multiple=True,
 )
 @click.option("--num-workers", type=int, default=2, help="Number of workers to spawn in pool.")
 @click.option("--quiet", is_flag=True, default=False, help="Hide Log Outputs")

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from contextlib import suppress
 from functools import lru_cache
+from multiprocessing import Process
 from threading import Thread
 from typing import Any, NoReturn
 from uuid import uuid4
@@ -408,7 +409,7 @@ class FrappeWorkerNoFork(FrappeWorker):
 
 
 def start_worker_pool(
-	queue: str | None = None,
+	queue: list[str] | None = None,
 	num_workers: int = 1,
 	quiet: bool = False,
 	burst: bool = False,
@@ -430,6 +431,27 @@ def start_worker_pool(
 	import frappe.website.path_resolver  # all the page types and resolver
 	# end: module pre-loading
 
+	if not queue:
+		# Start in same process
+		_start_worker_pool(queue, num_workers, quiet, burst)
+	elif len(queue) == 1 and isinstance(queue, tuple):
+		_start_worker_pool(queue[0], num_workers, quiet, burst)
+	else:
+		processes = []
+		# Fork a workerpool for each queue combination with same workers
+		for q in queue:
+			process = Process(
+				target=_start_worker_pool,
+				kwargs={"queue": q, "num_workers": num_workers, "quiet": quiet, "burst": burst},
+			)
+			process.start()
+			processes.append(process)
+
+		for process in processes:
+			process.join()
+
+
+def _start_worker_pool(queue, num_workers, quiet, burst) -> NoReturn:
 	with frappe.init_site():
 		redis_connection = get_redis_conn()
 


### PR DESCRIPTION
This should ideally reduce memory usage by resuing imported memory from
heap. Moreso when forking is disabled in workers.

```bash
bench worker-pool --num-workers=4 —queue short,default —queue long,default
```


Numbers with 1 worker in each pool sitting idle after performing some basic jobs:

Before: 2x workerpool (PSS) -  141MB
After: 1x process + 2x workerpool children - 98MB

**1.43x** 

TODO:
- [ ] tests
- [ ] check signal propagation
- [ ] Auto restarts?
- [ ] preloads


closes https://github.com/frappe/caffeine/issues/39 