### PR TITLE
perf: cast int-link field filters to string

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -871,7 +871,7 @@ class DatabaseQuery:
 					value = value.replace("\\", "\\\\").replace("%", "%%")
 
 			elif f.operator == "=" and df and df.fieldtype in ["Link", "Data"]:  # TODO: Refactor if possible
-				value = f.value or "''"
+				value = cstr(f.value) or "''"
 				fallback = "''"
 
 			elif f.fieldname == "name":


### PR DESCRIPTION
Comparing varchar field with ints makes indexes unusable in MariaDB.

This PR is just one small fix for DB query, similar fixes won't be made
for DB APIs which do not assume anything about database schema.
