### PR TITLE
fix: fetch data from submitted child rows for global search indexing

### DIFF
--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -197,7 +197,7 @@ def get_children_data(doctype, meta):
 			child_records = frappe.get_all(
 				child.options,
 				fields=child_fieldnames,
-				filters={"docstatus": ["!=", 1], "parenttype": doctype},
+				filters={"docstatus": ["!=", 2], "parenttype": doctype},
 			)
 
 			for record in child_records:


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Child table records with `docstatus = 1` were being omitted from global search index data (I am not sure if that was the intended behaviour). This resulted in incorrect search results when searching for fields in child tables for submitted documents.

Closes #31402 
