### PR TITLE
fix: Wildcard cache clearing for doctypes

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -139,6 +139,9 @@ def _clear_doctype_cache_from_redis(doctype: str | None = None):
 
 		def clear_single(dt):
 			frappe.clear_document_cache(dt)
+			# Wild card for all keys containing this doctype.
+			# this can be excessive but this function isn't called often... ideally.
+			frappe.client_cache.delete_keys(f"*{dt}*")
 			frappe.cache.hdel_names(doctype_cache_keys, dt)
 			clear_meta_cache(dt)
 


### PR DESCRIPTION
Clear all keys that contain doctype name. This is just a hack to avoid
dealing with many random partial caches that exist.

Possible improvement:
- Standardize ALL doctype specific cache keys so this becomes simpler and more reliable.
