### PR TITLE
fix: clear cache using client_cache

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -95,7 +95,7 @@ def get_meta(doctype: str | dict | DocRef, cached=True) -> "_Meta":
 def clear_meta_cache(doctype: str = "*"):
 	key = f"doctype_meta::{doctype}"
 	if doctype == "*":
-		frappe.cache.delete_keys(key)
+		frappe.client_cache.delete_keys(key)
 	else:
 		frappe.client_cache.delete_value(key)
 


### PR DESCRIPTION
It's faster than relying on indirect invalidations. This was avoided
before only because delete_keys didn't exist on client_cache.
