### PR TITLE
perf: faster `init_valid_columns`

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -273,10 +273,10 @@ class Meta(Document):
 		return fields
 
 	def get_valid_columns(self) -> list[str]:
-		return self._valid_columns
+		return self._valid_columns_
 
 	@cached_property
-	def _valid_columns(self):
+	def _valid_columns_(self):
 		table_exists = frappe.db.table_exists(self.name)
 		if self.name in self.special_doctypes and table_exists:
 			valid_columns = get_table_columns(self.name)


### PR DESCRIPTION
- `_valid_columns` now cached at doc-level. renamed field with same name in meta to avoid conflict.
- remove redundant `default_fields` loop in `init_valid_columns`. these are already there in `meta._valid_columns`
- store `self.__dict__` in a var - used repeatedly