### PR TITLE
chore: remove doctype overrides from hooks template

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -522,14 +522,6 @@ app_license = "{app_license}"
 # 	"Event": "frappe.desk.doctype.event.event.has_permission",
 # }}
 
-# DocType Class
-# ---------------
-# Override standard doctype classes
-
-# override_doctype_class = {{
-# 	"ToDo": "custom_app.overrides.CustomToDo"
-# }}
-
 # Document Events
 # ---------------
 # Hook on document methods and events


### PR DESCRIPTION
This is a shit feature, don't advertise it to the world or make it easy
to use it.
