### PR TITLE
fix: Reload Document Before Updating Title

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -91,6 +91,7 @@ def update_document_title(
 
 	if title_updated:
 		try:
+			doc.reload()
 			setattr(doc, title_field, updated_title)
 			doc.save()
 			frappe.msgprint(_("Saved"), alert=True, indicator="green")


### PR DESCRIPTION
Issue:

- The document is modified before the `Title` is updated, triggering the error message: `Document has been modified...`
- This issue occurs when updating both **Item Name** and **Item Code** simultaneously.

![Screenshot 2025-02-27 at 12 43 21 PM](https://github.com/user-attachments/assets/5cb01d31-3000-4f24-a824-15fdcc4504a2)
