### PR TITLE
fix(quick_entry): Show submit option only if User can

### DIFF
--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -215,6 +215,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm extends frappe.ui.Dialog {
 				},
 				callback: function (r) {
 					if (
+						r?.message?.docstatus === 0 &&
 						frappe.model.can_submit(me.doctype) &&
 						!frappe.model.has_workflow(me.doctype)
 					) {

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -215,7 +215,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm extends frappe.ui.Dialog {
 				},
 				callback: function (r) {
 					if (
-						frappe.model.is_submittable(me.doctype) &&
+						frappe.model.can_submit(me.doctype) &&
 						!frappe.model.has_workflow(me.doctype)
 					) {
 						frappe.run_serially([


### PR DESCRIPTION
Submit option pops up if a document is submittable, even if its not allowed for the current user.

On clicking that, an insufficient perms error is thrown that looks like:

```
## Not permitted

User beep@boop.org does not have access to this document: Leave Application - HR-LAP-2025-00096
---
You need the 'submit' permission on Leave Application HR-LAP-2025-00096 to perform this action.
```