### PR TITLE
refactor: Allow isolated headlines/intros in the form

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -101,7 +101,7 @@ frappe.ui.form.Layout = class Layout {
 
 	/**Render a message block with its own color and close button
 	 * @param {String} html - message or HTML to be displayed
-	 * @param {String} color - color of the block
+	 * @param {String} color - color of the block. One of "yellow", "blue", "red", "green" or "orange". Defaults to "blue".
 	 * @param {Boolean} permanent - if true, the block will not have a close button
 	 */
 	show_message(html, color, permanent = false) {

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -23,7 +23,9 @@ frappe.ui.form.Layout = class Layout {
 			this.parent = this.body;
 		}
 		this.wrapper = $('<div class="form-layout">').appendTo(this.parent);
-		this.message = $('<div class="form-message hidden"></div>').appendTo(this.wrapper);
+		this.message = $('<div class="form-message-container hidden"></div>').appendTo(
+			this.wrapper
+		);
 		this.page = $('<div class="form-page"></div>').appendTo(this.wrapper);
 
 		if (!this.fields) {
@@ -98,27 +100,40 @@ frappe.ui.form.Layout = class Layout {
 	}
 
 	show_message(html, color, permanent = false) {
-		if (this.message_color) {
-			// remove previous color
-			this.message.removeClass(this.message_color);
-		}
-		let close_message = $(`<div class="close-message">${frappe.utils.icon("close")}</div>`);
-		this.message_color =
-			color && ["yellow", "blue", "red", "green", "orange"].includes(color) ? color : "blue";
-		if (html) {
-			if (html.substr(0, 1) !== "<") {
-				// wrap in a block
-				html = "<div>" + html + "</div>";
-			}
-			this.message.removeClass("hidden").addClass(this.message_color);
-			$(html).appendTo(this.message);
-			if (!permanent) {
-				close_message.appendTo(this.message);
-				close_message.on("click", () => this.message.empty().addClass("hidden"));
-			}
-		} else {
+		/**Render a message block with its own color and close button
+		 * @param {String} html - message or HTML to be displayed
+		 * @param {String} color - color of the block
+		 * @param {Boolean} permanent - if true, the block will not have a close button
+		 */
+		if (!html) {
 			this.message.empty().addClass("hidden");
+			return;
 		}
+
+		// Prepare Block
+		let $html;
+		if (html.substr(0, 1) !== "<") {
+			// wrap in a block if `html` does not contain html tags
+			$html = $("<div class='form-message'></div>").text(html);
+		} else {
+			$html = $(html);
+			$html.addClass("form-message");
+		}
+
+		// Add close button to block if not permanent
+		const close_message = $(`<div class="close-message">${frappe.utils.icon("close")}</div>`);
+		if (!permanent) {
+			close_message.appendTo($html);
+			close_message.on("click", () => $html.remove());
+		}
+
+		// Add block color and append to parent container `form-message-container`
+		const block_color =
+			color && ["yellow", "blue", "red", "green", "orange"].includes(color) ? color : "blue";
+		$html.addClass(block_color).appendTo(this.message);
+
+		// Show parent container if hidden
+		this.message.removeClass("hidden");
 	}
 
 	render(new_fields) {

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -99,12 +99,12 @@ frappe.ui.form.Layout = class Layout {
 		return fields;
 	}
 
+	/**Render a message block with its own color and close button
+	 * @param {String} html - message or HTML to be displayed
+	 * @param {String} color - color of the block
+	 * @param {Boolean} permanent - if true, the block will not have a close button
+	 */
 	show_message(html, color, permanent = false) {
-		/**Render a message block with its own color and close button
-		 * @param {String} html - message or HTML to be displayed
-		 * @param {String} color - color of the block
-		 * @param {Boolean} permanent - if true, the block will not have a close button
-		 */
 		if (!html) {
 			this.message.empty().addClass("hidden");
 			return;
@@ -112,12 +112,12 @@ frappe.ui.form.Layout = class Layout {
 
 		// Prepare Block
 		let $html;
-		if (html.substr(0, 1) !== "<") {
+		if (html.substring(0, 1) !== "<") {
 			// wrap in a block if `html` does not contain html tags
-			$html = $("<div class='form-message'></div>").text(html);
+			$html = $("<div class='form-message border-bottom'></div>").text(html);
 		} else {
 			$html = $(html);
-			$html.addClass("form-message");
+			$html.addClass("form-message border-bottom");
 		}
 
 		// Add close button to block if not permanent


### PR DESCRIPTION
## Issue
- `show_message` groups all headlines passed to it and assumes the state of the last headline
- The first headline is supposed to be a **permanent** (non-dismissable) and **blue** headline
- The second is supposed to be a **temporary** (dismissable) and **yellow headline**
   <img width="700" alt="Screenshot 2025-02-28 at 8 42 09 PM" src="https://github.com/user-attachments/assets/4cf5b089-ab17-4586-a09b-c9ec86208f03" />

Yet they are grouped -> the intent is completely ignored -> the outcome isn't what was expected
An independently set headline can't stand out and the message is lost when grouped with another headline

## Proposed Fix
- Each attempt to `show_message` should be rendered as a separate block with its own color and close button
  <img width="700" alt="Screenshot 2025-02-28 at 8 46 38 PM" src="https://github.com/user-attachments/assets/20ba8e5d-a449-47d3-a6e3-d1ff472da1e1" />
- Removal affects the right headline
   ![2025-02-28 8 50 20 PM](https://github.com/user-attachments/assets/eaa84a16-d5ae-4f91-ab1c-62bbc24d4417)
- Restructure: `.form-message-container` contains `.form-message` blocks

>[!NOTE]
> (pls zoom) To the reviewer:
> Do we want to show separation in cases of separate headlines that have the same color (with a bottom border) or do we continue as it was?
> <img width="700" alt="Screenshot 2025-02-28 at 9 00 47 PM" src="https://github.com/user-attachments/assets/c9c1d13c-4224-4f8e-8a33-10ca52e60ff2" />
> It could look like this with separation:
> <img width="700" alt="Screenshot 2025-02-28 at 9 01 47 PM" src="https://github.com/user-attachments/assets/f7475c1b-aed0-433a-baaa-a52df93ce58a" />

TODO:

- [ ] For develop only: `show_message` should not  unset headlines if HTML is ""