### PR TITLE
fix(notifications): Not properly handling external child tables in get_external_links()

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -326,7 +326,13 @@ def get_internal_links(doc, link, link_doctype):
 
 
 def get_external_links(doctype, name, links):
-	fieldname = links.get("non_standard_fieldnames", {}).get(doctype, links.get("fieldname"))
+	if links.get("non_standard_fieldnames"):
+		fieldname = links.get("non_standard_fieldnames", {}).get(doctype)
+	elif links.get("internal_links"):
+		fieldname = links.get("internal_links", {}).get(doctype)[1]
+	else:
+		fieldname = links.get("fieldname")
+
 	filters = {fieldname: name}
 
 	# updating filters based on dynamic_links


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

I've come across a weird case where documents links are not properly displayed under certain circumstances, when using child tables. The first external link has a count but not the second one. This is due to a bug in get_external_links.

![image](https://github.com/user-attachments/assets/f5ee0ec1-4fb7-4462-ac10-ac9b1c6a1333)

![image](https://github.com/user-attachments/assets/835b5776-192a-44b0-bb1c-4c90e9920895)


<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

In this scenario, we have the following structure:

## DocA

```
 "fields": [
  {
   "fieldname": "value_list",
   "fieldtype": "Table MultiSelect",
   "label": "value list",
   "options": "MyChild"
  }
 ],
```

## DocB

```
 "fields": [
  {
   "fieldname": "value_list2",
   "fieldtype": "Table MultiSelect",
   "label": "value list",
   "options": "MyChild2"
  }
 ],
```

## MyChild 

```
 "fields": [
  {
   "fieldname": "myvaluelist",
   "fieldtype": "Link",
   "in_list_view": 1,
   "label": "MyValueList",
   "options": "MyValueList"
  }
 ],
```

## MyChild2

```
 "fields": [
  {
   "fieldname": "myvaluelist2",
   "fieldtype": "Link",
   "in_list_view": 1,
   "label": "MyValueList",
   "options": "MyValueList"
  }
 ],
```

## The value list with links

```
"fields": [
  {
   "fieldname": "some_value",
   "fieldtype": "Data",
   "in_list_view": 1,
   "label": "Some value",
   "reqd": 1
  }
 ],
 "links": [
    {
     "is_child_table": 1,
     "link_doctype": "MyChild",
     "link_fieldname": "myvaluelist",
     "parent_doctype": "DocA",
     "table_fieldname": "value_list"
    },
    {
     "is_child_table": 1,
     "link_doctype": "MyChild2",
     "link_fieldname": "myvaluelist2",
     "parent_doctype": "DocB",
     "table_fieldname": "value_list2"
    }
   ],
```

In this scenario, the `fieldname` will always be equal to `myvaluelist` but it should be equal to `myvaluelist2` when parsing the second link. I could confirm with a debugger. 

![image](https://github.com/user-attachments/assets/c5bd4a52-13bf-4f01-8deb-cd7759e7f871)

As a result, the `get_external_links()` function raise an unknown column error and the count is set to 0.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
