### PR TITLE
perf: skip order by for open_count

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -351,6 +351,7 @@ def get_doc_count(doctype, filters):
 			limit=100,
 			distinct=True,
 			ignore_ifnull=True,
+			order_by=None,
 		)
 	)
 


### PR DESCRIPTION
- Not required, we are just counting
- Helps in *some cases* because no need to scan in modified order.
- Semantically correct anyway so eh.
