### PR TITLE
fix: template error on custom print format

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -438,19 +438,20 @@ def get_print_format(doctype: str, print_format: "PrintFormat") -> str:
 	module = print_format.module or frappe.db.get_value("DocType", doctype, "module")
 
 	is_custom_module = frappe.get_cached_value("Module Def", module, "custom")
-	if is_custom_module:
-		if print_format.raw_printing:
-			return print_format.raw_commands
-		if print_format.html:
-			return print_format.html
 
-	path = os.path.join(
-		get_module_path(module, "Print Format", print_format.name),
-		frappe.scrub(print_format.name) + ".html",
-	)
-	if os.path.exists(path):
-		with open(path) as pffile:
-			return pffile.read()
+	if not is_custom_module:
+		path = os.path.join(
+			get_module_path(module, "Print Format", print_format.name),
+			frappe.scrub(print_format.name) + ".html",
+		)
+		if os.path.exists(path):
+			with open(path) as pffile:
+				return pffile.read()
+
+	if print_format.raw_printing:
+		return print_format.raw_commands
+	if print_format.html:
+		return print_format.html
 
 	frappe.throw(_("No template found at path: {0}").format(path), frappe.TemplateNotFoundError)
 


### PR DESCRIPTION
Revert some of the changes from https://github.com/frappe/frappe/pull/31372

When printing a document with a custom print format, it throws a "No template found at path:" error.


================================================================
![image](https://github.com/user-attachments/assets/84f23b6c-2e05-4b08-84d9-1a6b2638dbc0)

Edit: Test cases are pending