### PR TITLE
fix: Implement backpressure for background jobs

### DIFF
--- a/frappe/desk/doctype/system_health_report/system_health_report.js
+++ b/frappe/desk/doctype/system_health_report/system_health_report.js
@@ -67,8 +67,8 @@ frappe.ui.form.on("System Health Report", {
 		const style = document.createElement("style");
 		style.innerText = `.health-check-failed {
 				font-weight: bold;
-				color: var(--text-colour);
-				background-color: var(--bg-red);
+				color: var(--text-colour) !important;
+				background-color: var(--bg-red) !important;
 			}`;
 		document.head.appendChild(style);
 

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -263,6 +263,10 @@ class SessionBootFailed(ValidationError):
 	http_status_code = 500
 
 
+class QueueOverloaded(ValidationError):
+	http_status_code = 503
+
+
 class PrintFormatError(ValidationError):
 	pass
 


### PR DESCRIPTION
Why? Avoid indefinitely and silently growing queue of background jobs.

- Limit queued jobs to 500 by default. Configurable from common site configuration.
- To handle large shared benches a small number per site is also added. 
