### PR TITLE
fix(UX): Show reason for read only form in headline

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -428,7 +428,11 @@ frappe.ui.form.Form = class FrappeForm {
 			this.read_only = frappe.workflow.is_read_only(this.doctype, this.docname);
 			if (this.read_only) {
 				this.set_read_only();
-				frappe.show_alert(__("This form is not editable due to a Workflow."));
+				this.dashboard.set_headline(
+					__("This form is not editable due to a Workflow."),
+					"blue",
+					true
+				);
 			}
 
 			// check if doctype is already open


### PR DESCRIPTION
Alt fix for alert added via https://github.com/frappe/frappe/pull/20077 which looks like an error message and is confusing to new users.

