### PR TITLE
fix: correct data while exporting with translate values

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -426,7 +426,7 @@ def export_query():
 				_(value) if translatable_fields[idx] else value for idx, value in enumerate(row)
 			]
 			processed_data.append(processed_row)
-			data.extend(processed_data)
+		data.extend(processed_data)
 
 	data = handle_duration_fieldtype_values(doctype, data, db_query.fields)
 


### PR DESCRIPTION
When you export the report and have "translate value" checked it was generating wrong data in the excel

Data in report:

<img width="874" alt="translate value" src="https://github.com/user-attachments/assets/52bed249-8d71-4300-960b-5705fa1d2a07" />

Data in export(excel)

<img width="874" alt="translate report " src="https://github.com/user-attachments/assets/f8179403-29cf-411b-a36e-47890c5b06de" />



