### PR TITLE
fix: Faulty HTML tag check condition in `show_message`

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -112,7 +112,8 @@ frappe.ui.form.Layout = class Layout {
 
 		// Prepare Block
 		let $html;
-		if (html.substring(0, 1) !== "<") {
+		const contains_html_tag = /<[a-z][\s\S]*>/i.test(html);
+		if (!contains_html_tag) {
 			// wrap in a block if `html` does not contain html tags
 			$html = $("<div class='form-message border-bottom'></div>").text(html);
 		} else {

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -112,8 +112,7 @@ frappe.ui.form.Layout = class Layout {
 
 		// Prepare Block
 		let $html;
-		const contains_html_tag = /<[a-z][\s\S]*>/i.test(html);
-		if (!contains_html_tag) {
+		if (!frappe.utils.is_html(html)) {
 			// wrap in a block if `html` does not contain html tags
 			$html = $("<div class='form-message border-bottom'></div>").text(html);
 		} else {


### PR DESCRIPTION
Partly introduced via https://github.com/frappe/frappe/pull/31459

## Issue
- This faultily excluded cases where the first character is not `<`. Assume input string `\n\t\t<div>Hi</div>`
- Such  HTML strings were wrongly assumed not to contain tags and were stringified into a div in the `if` block
- This broke the rendering of HTML type headlines
   <img width="700" alt="Screenshot 2025-03-04 at 9 29 55 PM" src="https://github.com/user-attachments/assets/af3b0b19-d1dd-47c2-8707-566ccfe7d55f" />


## Fix
- Regex check to see if the string contains HTML tags
- This correctly passes the string to the `else` block
   <img width="700" alt="Screenshot 2025-03-04 at 9 28 43 PM" src="https://github.com/user-attachments/assets/fb760fd8-8b52-4fee-a9bd-942682801244" />