### PR TITLE
fix: Notification get_receiver_fields phone field function

### DIFF
--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -95,7 +95,7 @@ frappe.notification = {
 				});
 			} else if (["WhatsApp", "SMS"].includes(frm.doc.channel)) {
 				receiver_fields = get_receiver_fields(fields, function (df) {
-					df.options == "Phone" || df.options == "Mobile";
+					return df.options == "Phone" || df.options == "Mobile";
 				});
 			}
 


### PR DESCRIPTION
This is a very simple fix: "Receiver By Document Field" in Notification should allow phone fields when the Notification channel is WhatsApp or SMS.

the `is_extra_receiver_field` property on `get_receiver_fields` has a proper `return` when used to find email fields for the Email channel:
```python
	if (frm.doc.channel === "Email") {
		receiver_fields = get_receiver_fields(fields, function (df) {
			return df.options == "Email";
		});
	}
```
but was missing a `return` when fetching phone fields for the Whatsapp or Phone channels:
```python
	} else if (["WhatsApp", "SMS"].includes(frm.doc.channel)) {
		receiver_fields = get_receiver_fields(fields, function (df) {
			df.options == "Phone" || df.options == "Mobile";
		});
	}
```
this pr fixes that.

before the fix no options were available but "owner"

after this fix:
![image](https://github.com/user-attachments/assets/66ad3da3-e007-4102-974c-0a7849f03113)
