### PR TITLE
fix: do not allow renaming if autoname & title_field is same

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -74,6 +74,14 @@ frappe.ui.form.Toolbar = class Toolbar {
 		let doc_field = this.frm.get_docfield(title_field);
 
 		if (
+			this.frm.meta.naming_rule === "By fieldname" &&
+			this.frm.meta.autoname === "field:" + title_field &&
+			!this.frm.meta.allow_rename
+		) {
+			return false;
+		}
+
+		if (
 			title_field &&
 			this.frm.perm[0].write &&
 			!this.frm.doc.__islocal &&

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -211,23 +211,33 @@ frappe.ui.form.Toolbar = class Toolbar {
 				});
 			}
 
+			let is_title_field_same_as_autoname = false;
+
 			// check if docname is updatable
 			if (me.can_rename()) {
 				let label = __("New Name");
 				if (me.frm.meta.autoname && me.frm.meta.autoname.startsWith("field:")) {
 					let fieldname = me.frm.meta.autoname.split(":")[1];
 					label = __("New {0}", [__(me.frm.get_docfield(fieldname).label)]);
+					is_title_field_same_as_autoname = fieldname === title_field;
+				}
+
+				if (!is_title_field_same_as_autoname) {
+					fields.push(
+						...[
+							{
+								label: label,
+								fieldname: "name",
+								fieldtype: "Data",
+								reqd: 1,
+								default: docname,
+							},
+						]
+					);
 				}
 
 				fields.push(
 					...[
-						{
-							label: label,
-							fieldname: "name",
-							fieldtype: "Data",
-							reqd: 1,
-							default: docname,
-						},
 						{
 							label: __("Merge with existing"),
 							fieldname: "merge",
@@ -248,6 +258,11 @@ frappe.ui.form.Toolbar = class Toolbar {
 				d.set_primary_action(__("Rename"), (values) => {
 					d.disable_primary_action();
 					d.hide();
+
+					if (is_title_field_same_as_autoname) {
+						values.name = values.title;
+					}
+
 					this.rename_document_title(values.name, values.title, values.merge)
 						.then(() => {
 							d.hide();


### PR DESCRIPTION
If `naming_rule` is set as "By fieldname" & `autoname` is same as `title_field` and `allow_rename` is not set
Then rename should not be allowed because it will try to rename the title field but it doesn't work because same field is used as name field.

If `allow_rename `is set then allow renaming but instead of showing `title_field` & `name` which in this case is same show only one field in rename modal, but set both in backend.