### PR TITLE
fix(list_view): use more filter type values to set value on new entry

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -294,8 +294,14 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	make_new_doc() {
 		const doctype = this.doctype;
 		const options = {};
+		const allowed_filter_types = [
+			"=",
+			"descendants of (inclusive)",
+			"descendants of",
+			"ancestors of",
+		];
 		this.filter_area.get().forEach((f) => {
-			if (f[2] === "=" && frappe.model.is_non_std_field(f[1])) {
+			if (allowed_filter_types.includes(f[2]) && frappe.model.is_non_std_field(f[1])) {
 				options[f[1]] = f[3];
 			}
 		});


### PR DESCRIPTION
Allow using more types of filter values to pre-fill data on new entry.

Behaviour before the change:

https://github.com/user-attachments/assets/0cfcae04-9b4a-4039-809e-a719cd966520

Behaviour after the change:

https://github.com/user-attachments/assets/d9aca117-a17d-44eb-bf31-c83609aa1f62


