### PR TITLE
fix: store unsubscribe params properly

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.json
+++ b/frappe/email/doctype/email_queue/email_queue.json
@@ -20,7 +20,7 @@
   "send_after",
   "priority",
   "add_unsubscribe_link",
-  "unsubscribe_param",
+  "unsubscribe_params",
   "unsubscribe_method",
   "expose_recipients",
   "attachments",
@@ -115,12 +115,6 @@
    "label": "Add Unsubscribe Link"
   },
   {
-   "fieldname": "unsubscribe_param",
-   "fieldtype": "Data",
-   "label": "Unsubscribe Param",
-   "read_only": 1
-  },
-  {
    "fieldname": "unsubscribe_method",
    "fieldtype": "Data",
    "label": "Unsubscribe Method"
@@ -148,13 +142,19 @@
    "fieldtype": "Link",
    "label": "Email Account",
    "options": "Email Account"
+  },
+  {
+   "fieldname": "unsubscribe_params",
+   "fieldtype": "Code",
+   "label": "Unsubscribe Params",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-envelope",
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2025-02-20 19:21:09.652451",
+ "modified": "2025-03-07 15:56:13.341958",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Queue",

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -63,7 +63,7 @@ class EmailQueue(Document):
 		show_as_cc: DF.SmallText | None
 		status: DF.Literal["Not Sent", "Sending", "Sent", "Partially Sent", "Error"]
 		unsubscribe_method: DF.Data | None
-		unsubscribe_param: DF.Data | None
+		unsubscribe_params: DF.Code | None
 	# end: auto-generated types
 
 	DOCTYPE = "Email Queue"
@@ -351,7 +351,7 @@ class SendMailContext:
 				reference_name=self.queue_doc.reference_name,
 				email=recipient_email,
 				unsubscribe_method=self.queue_doc.unsubscribe_method,
-				unsubscribe_params=self.queue_doc.unsubscribe_param,
+				unsubscribe_params=self.queue_doc.unsubscribe_params,
 			)
 
 		return quopri.encodestring(unsubscribe_url.encode()).decode()

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -93,6 +93,9 @@ class EmailQueue(Document):
 		if not data.get("recipients"):
 			return
 
+		if isinstance(data["unsubscribe_params"], dict):
+			data["unsubscribe_params"] = json.dumps(data["unsubscribe_params"])
+
 		recipients = data.pop("recipients")
 		doc = frappe.new_doc(cls.DOCTYPE)
 		doc.update(data)

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -220,7 +220,6 @@ class Newsletter(WebsiteGenerator):
 			template="newsletter",
 			add_unsubscribe_link=self.send_unsubscribe_link,
 			unsubscribe_method="/unsubscribe",
-			unsubscribe_params={"name": self.name},
 			reference_doctype=self.doctype,
 			reference_name=self.name,
 			queue_separately=True,

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -87,7 +87,7 @@ def get_unsubcribed_url(reference_doctype, reference_name, email, unsubscribe_me
 		"name": cstr(reference_name),
 	}
 	if unsubscribe_params:
-		params.update(unsubscribe_params)
+		params.update(frappe.parse_json(unsubscribe_params))
 
 	return get_url(unsubscribe_method + "?" + get_signed_params(params))
 


### PR DESCRIPTION
Earlier we had a field `unsubscribe_param` but it wasn't used anywhere to store the params. This made sure only email, doctype and docname was passed as the params while unsubscribing and no custom params were passed (using `unsubscribe_params`).
