### PR TITLE
fix: :bug: don't generate type information for virtual fields

### DIFF
--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -99,6 +99,8 @@ class TypeExporter:
 		for field in self.doc.fields:
 			if iskeyword(field.fieldname):
 				continue
+			if field.is_virtual:
+				continue
 			if python_type := self._map_fieldtype(field):
 				self.field_types[field.fieldname] = python_type
 

--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -99,7 +99,7 @@ class TypeExporter:
 		for field in self.doc.fields:
 			if iskeyword(field.fieldname):
 				continue
-			if field.is_virtual:
+			if field.is_virtual and not field.options:
 				continue
 			if python_type := self._map_fieldtype(field):
 				self.field_types[field.fieldname] = python_type


### PR DESCRIPTION
Since you have to manually create a property for each virtual field anway this only leads to linter errors for redeclaration.

If someone wants to see the type of the field anyway, it's line could be generated as a comment instead of beeing withheld. But I don't think I know enough about the code to try this out.