### PR TITLE
perf: queue auto email report separately

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -271,6 +271,7 @@ class AutoEmailReport(Document):
 			attachments=attachments,
 			reference_doctype=self.doctype,
 			reference_name=self.name,
+			queue_separately=True,
 		)
 
 	def dynamic_date_filters_set(self):


### PR DESCRIPTION
Support Ticket: 32254

Some auto email reports timed out when there was too much data, so we are sending all emails in separate queues instead of sending them all in one background job.

Background Job
![image](https://github.com/user-attachments/assets/2245b2ab-98e1-4dbb-8f90-9d2981199e6f)
Auto Email Report
![image](https://github.com/user-attachments/assets/2ce521be-3eea-42dc-9bab-6c5ed3663539)
