### PR TITLE
fix: check permission on new doc

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -217,7 +217,7 @@ def check_write_permission(doctype: str | None = None, name: str | None = None):
 	except frappe.DoesNotExistError:
 		# doc has not been inserted yet, name is set to "new-some-doctype"
 		# If doc inserts fine then only this attachment will be linked see file/utils.py:relink_mismatched_files
-		check_doctype_permission(doctype, "write")
+		frappe.new_doc(doctype).check_permission("write")
 		return
 
 	doc.check_permission("write")


### PR DESCRIPTION
User might only have "only if creator" permission so checking on doctype
will incorrectly flag it.

Not sure if there's any better/simpler way to handle this. This is weird
edge case on how files operate.
