### PR TITLE
fix: only show tracebacks to system users

### DIFF
--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -369,12 +369,19 @@ class FrappeClient:
 			print(response.text)
 			raise
 
-		if rjson and ("exc" in rjson) and rjson["exc"]:
+		if rjson and (rjson.get("exc") or rjson.get("exc_type") or rjson.get("errors")):
 			try:
-				exc = json.loads(rjson["exc"])[0]
-				exc = "FrappeClient Request Failed\n\n" + exc
+				exception = ""
+				if rjson.get("exc"):
+					exception = json.loads(rjson["exc"])[0]
+				elif rjson.get("exc_type"):  # Just have type available
+					exception = json.loads(rjson["exc_type"])[0]
+				elif errors := rjson.get("errrors"):
+					exception = errors[0].get("exception") or errors[0].get("type")
+
+				exc = "FrappeClient Request Failed\n\n" + exception
 			except Exception:
-				exc = rjson["exc"]
+				exc = rjson.get("exc")
 
 			raise FrappeException(exc)
 		if "message" in rjson:

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -340,12 +340,12 @@ class TestWebsite(IntegrationTestCase):
 	def test_safe_render(self):
 		content = get_response_content("/_test/_test_safe_render_on")
 		self.assertNotIn("Safe Render On", content)
-		self.assertIn("frappe.exceptions.ValidationError: Illegal template", content)
+		self.assertIn("Show Error", content)
 
 		content = get_response_content("/_test/_test_safe_render_off")
 		self.assertIn("Safe Render Off", content)
 		self.assertIn("test.__test", content)
-		self.assertNotIn("frappe.exceptions.ValidationError: Illegal template", content)
+		self.assertNotIn("Show Error", content)
 
 	def test_never_render(self):
 		from pathlib import Path

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -59,10 +59,13 @@ def report_error(status_code):
 
 
 def is_traceback_allowed():
+	from frappe.permissions import is_system_user
+
 	return (
 		frappe.db
 		and frappe.get_system_settings("allow_error_traceback")
 		and (not frappe.local.flags.disable_traceback or frappe._dev_server)
+		and is_system_user()
 	)
 
 


### PR DESCRIPTION
Website users by design are supposed to be "less trusted", so don't show tracebacks to them.
