### PR TITLE
fix: Translate link fields in Webform

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -741,12 +741,17 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 	fields = ["name as value"]
 
 	meta = frappe.get_meta(doctype)
-	if meta.title_field and meta.show_title_field_in_link:
+	show_title_field = meta.title_field and meta.show_title_field_in_link
+
+	if show_title_field:
 		fields.append(f"{meta.title_field} as label")
 
 	link_options = frappe.get_all(doctype, filters, fields)
 
-	if meta.title_field and meta.show_title_field_in_link:
+	if show_title_field:
+		if meta.translated_doctype:
+			# Translate the labels if "Translate Link Fields" is enabled
+			link_options = [{"value": row.value, "label": _(row.label)} for row in link_options]
 		return json.dumps(link_options, default=str)
 	else:
 		return "\n".join([str(doc.value) for doc in link_options])

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -752,8 +752,14 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 		if meta.translated_doctype:
 			# Translate the labels if "Translate Link Fields" is enabled
 			link_options = [{"value": row.value, "label": _(row.label)} for row in link_options]
+
 		return json.dumps(link_options, default=str)
 	else:
+		if meta.translated_doctype:
+			# Add `label` as the translated name if "Translate Link Fields" is enabled
+			return [{"value": row.value, "label": _(row.value)} for row in link_options]
+
+		# Use the actual names as options without labels
 		return "\n".join([str(doc.value) for doc in link_options])
 
 


### PR DESCRIPTION
> The navbar seems to be missing in web forms. Unrelated to this PR.

## Working
- A User that has their language set to DE (via language switcher) wants to read link options in DE.
- The labels are translated (if "Show Title in Link Field" and "Translate Link Fields" are set).
- These values are carried correctly to the record
   ![2025-03-10 6 10 06 PM](https://github.com/user-attachments/assets/bc0f10a1-4d20-4c93-9cb5-d6b193105db5)
- Link field doctypes without title fields (just names) that have translatable links enabled are also translated
   ![2025-03-11 8 02 09 PM](https://github.com/user-attachments/assets/b50b5339-44ba-4dc2-b1ad-bca43b8f7006)


### To Simulate
- I used an existing Issue webform and disabled Login Required (to test the language switcher)
- Create a dummy doctype ("Issue Category") with field `category_name` that is translatable
- For this new doctype enable "Show Title in Link Field" and "Translate Link Fields" 
- Add this to the webform doctype (Issue) and to the webform fields
- Create some records and add translations for them