### PR TITLE
chore: fix file naming for Crowdin integration

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,6 @@
 files:
   - source: /frappe/locale/main.pot
-    translation: /frappe/locale/%two_letters_code%.po
+    translation: /frappe/locale/%locale_with_underscore%.po
 pull_request_title: "fix: sync translations from crowdin"
 pull_request_labels:
   - translation


### PR DESCRIPTION
The recently added locale pt_BR was falsely added as pt. This PR changes file naming from two-letter codes to locale with underscore.