### PR TITLE
fix: prioritize English language selection for Guest user with additional browser language settings

### DIFF
--- a/frappe/geo/languages.csv
+++ b/frappe/geo/languages.csv
@@ -11,7 +11,7 @@ cs,Čeština,0
 da,Dansk,0
 de,Deutsch,1
 el,Ελληνικά,0
-en,English,0
+en,English,1
 en-GB,English (United Kingdom),0
 en-US,English (United States),0
 eo,In-Context Translation,0


### PR DESCRIPTION
Description:
- Resolved an issue where the system incorrectly activated a non-English language for Guest users, even when English was the primary language in the browser settings.
- The bug occurred when additional languages (e.g., Arabic) were configured in the browser and one of those languages was already enabled in Frappe.
- Ensured that English is included for Guest users when it is present in the browser language list.
- Added a fix to explicitly enable English language for Guest users to prevent unintended language switching.

![Screenshot from 2025-03-11 03-45-16](https://github.com/user-attachments/assets/eef50f3b-9551-4587-8c6e-b59675823d5a)

Steps to Reproduce:
- Create a new clean site and add additional languages (e.g., Arabic) in the browser settings.
- Ensure the additional language (e.g., Arabic) is already enabled in the database, which is by default.
- Observe that the system switches to the non-English translation (e.g., Arabic) for Guest users, even if English is the primary language in the browser settings.

Root Cause Analysis:
- Initially suspected `translate.py` was involved in language resolution.
- Checked enabled languages at the console using:
  `frappe.get_all("Language", filters={"enabled": 1}, pluck="name")`
  Result: ['fr', 'fa', 'es', 'de', 'ar']

![Screenshot from 2025-03-11 04-04-41](https://github.com/user-attachments/assets/07d236de-984c-4892-bcc2-53ae97175b1e)

- Identified that English was not enabled in the system, despite being a default requirement.
- Traced the issue to `languages.csv`, where English was not included among the enabled languages.

Fix:
- Enabled English in `languages.csv` to ensure it is included among the supported languages.
- This ensures English is chosen when included in the browser settings, resolving the issue.
