### PR TITLE
perf: generate auto email reports in background

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -7,6 +7,10 @@ from datetime import timedelta
 from email.utils import formataddr
 
 import frappe
+import frappe.email
+import frappe.email.doctype
+import frappe.email.doctype.auto_email_report
+import frappe.email.doctype.auto_email_report.auto_email_report
 from frappe import _
 from frappe.desk.query_report import build_xlsx_data
 from frappe.model.document import Document
@@ -305,25 +309,35 @@ def send_now(name):
 def send_daily():
 	"""Check reports to be sent daily"""
 
-	current_day = calendar.day_name[now_datetime().weekday()]
 	enabled_reports = frappe.get_all(
 		"Auto Email Report", filters={"enabled": 1, "frequency": ("in", ("Daily", "Weekdays", "Weekly"))}
 	)
 
 	for report in enabled_reports:
-		auto_email_report = frappe.get_doc("Auto Email Report", report.name)
+		frappe.enqueue(
+			"frappe.email.doctype.auto_email_report.auto_email_report.process_auto_email_report",
+			report=report,
+		)
 
-		# if not correct weekday, skip
-		if auto_email_report.frequency == "Weekdays":
-			if current_day in ("Saturday", "Sunday"):
-				continue
-		elif auto_email_report.frequency == "Weekly":
-			if auto_email_report.day_of_week != current_day:
-				continue
-		try:
-			auto_email_report.send()
-		except Exception:
-			auto_email_report.log_error(f"Failed to send {auto_email_report.name} Auto Email Report")
+
+def process_auto_email_report(report):
+	"""Process and send the Auto Email Report based on frequency"""
+
+	current_day = calendar.day_name[now_datetime().weekday()]
+
+	auto_email_report = frappe.get_doc("Auto Email Report", report.name)
+
+	# if not correct weekday, skip
+	if auto_email_report.frequency == "Weekdays":
+		if current_day in ("Saturday", "Sunday"):
+			return
+	elif auto_email_report.frequency == "Weekly":
+		if auto_email_report.day_of_week != current_day:
+			return
+	try:
+		auto_email_report.send()
+	except Exception:
+		auto_email_report.log_error(f"Failed to send {auto_email_report.name} Auto Email Report")
 
 
 def send_monthly():

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -7,10 +7,6 @@ from datetime import timedelta
 from email.utils import formataddr
 
 import frappe
-import frappe.email
-import frappe.email.doctype
-import frappe.email.doctype.auto_email_report
-import frappe.email.doctype.auto_email_report.auto_email_report
 from frappe import _
 from frappe.desk.query_report import build_xlsx_data
 from frappe.model.document import Document

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -313,6 +313,7 @@ def send_daily():
 		frappe.enqueue(
 			"frappe.email.doctype.auto_email_report.auto_email_report.process_auto_email_report",
 			report=report,
+			queue="long",
 		)
 
 


### PR DESCRIPTION
Reference https://github.com/frappe/frappe/pull/31594#issuecomment-2709543787

Previous Attempt: https://github.com/frappe/frappe/pull/31594

Some auto email reports timed out when there was too much data, so we are sending all emails in separate queues instead of sending them all in one background job.

![image](https://github.com/user-attachments/assets/b91f7112-7fd0-43dd-866d-5902dd7083ec)
![image](https://github.com/user-attachments/assets/c6c97ba7-671e-4816-b83e-44da122b4876)
