### PR TITLE
fix: improve shortcuts for German keyboard layout

### DIFF
--- a/frappe/public/js/frappe/ui/alt_keyboard_shortcuts.js
+++ b/frappe/public/js/frappe/ui/alt_keyboard_shortcuts.js
@@ -198,9 +198,9 @@ frappe.ui.keys.AltShortcutGroup = class AltShortcutGroup {
 			.filter((s) => !s.page)
 			.some((s) => s.shortcut === `alt+${letter}`);
 		return (
-				letter in this.shortcuts_dict ||
-				is_in_global_shortcut ||
-				this.blacklisted_letters.includes(letter.toLowerCase())
+			letter in this.shortcuts_dict ||
+			is_in_global_shortcut ||
+			this.blacklisted_letters.includes(letter.toLowerCase())
 		);
 	}
 };

--- a/frappe/public/js/frappe/ui/alt_keyboard_shortcuts.js
+++ b/frappe/public/js/frappe/ui/alt_keyboard_shortcuts.js
@@ -97,11 +97,10 @@ frappe.ui.keys.AltShortcutGroup = class AltShortcutGroup {
 		this.shortcuts_dict = {};
 
 		const locale = new Intl.Locale(navigator.language);
-		const is_mac = window.navigator.platform === "MacIntel";
 		// Skip certain Keys for different Languages on different Platforms
 		switch (locale.language) {
 			case "de":
-				if (is_mac) {
+				if (frappe.utils.is_mac()) {
 					this.blacklisted_letters = ["e", "l"];
 				} else {
 					this.blacklisted_letters = ["q"];

--- a/frappe/public/js/frappe/ui/alt_keyboard_shortcuts.js
+++ b/frappe/public/js/frappe/ui/alt_keyboard_shortcuts.js
@@ -97,20 +97,19 @@ frappe.ui.keys.AltShortcutGroup = class AltShortcutGroup {
 		this.shortcuts_dict = {};
 
 		const locale = new Intl.Locale(navigator.language);
-		const is_mac = (window.navigator.platform === "MacIntel")
+		const is_mac = window.navigator.platform === "MacIntel";
 		// Skip certain Keys for different Languages on different Platforms
 		switch (locale.language) {
-			case 'de':
+			case "de":
 				if (is_mac) {
-					this.blacklisted_letters = ["e", "l"]
-				}
-				else {
+					this.blacklisted_letters = ["e", "l"];
+				} else {
 					this.blacklisted_letters = ["q"];
 				}
 
 				break;
 			default:
-				this.blacklisted_letters = []
+				this.blacklisted_letters = [];
 				break;
 		}
 
@@ -198,6 +197,10 @@ frappe.ui.keys.AltShortcutGroup = class AltShortcutGroup {
 		let is_in_global_shortcut = frappe.ui.keys.standard_shortcuts
 			.filter((s) => !s.page)
 			.some((s) => s.shortcut === `alt+${letter}`);
-		return letter in this.shortcuts_dict || is_in_global_shortcut || this.blacklisted_letters.includes(letter.toLowerCase());
+		return (
+				letter in this.shortcuts_dict ||
+				is_in_global_shortcut ||
+				this.blacklisted_letters.includes(letter.toLowerCase())
+		);
 	}
 };

--- a/frappe/public/js/frappe/ui/alt_keyboard_shortcuts.js
+++ b/frappe/public/js/frappe/ui/alt_keyboard_shortcuts.js
@@ -95,6 +95,25 @@ function get_shortcut_for_key(key) {
 frappe.ui.keys.AltShortcutGroup = class AltShortcutGroup {
 	constructor() {
 		this.shortcuts_dict = {};
+
+		const locale = new Intl.Locale(navigator.language);
+		const is_mac = (window.navigator.platform === "MacIntel")
+		// Skip certain Keys for different Languages on different Platforms
+		switch (locale.language) {
+			case 'de':
+				if (is_mac) {
+					this.blacklisted_letters = ["e", "l"]
+				}
+				else {
+					this.blacklisted_letters = ["q"];
+				}
+
+				break;
+			default:
+				this.blacklisted_letters = []
+				break;
+		}
+
 		$current_dropdown = null;
 		this.bind_events();
 		frappe.ui.keys.bind_shortcut_group_event();
@@ -179,6 +198,6 @@ frappe.ui.keys.AltShortcutGroup = class AltShortcutGroup {
 		let is_in_global_shortcut = frappe.ui.keys.standard_shortcuts
 			.filter((s) => !s.page)
 			.some((s) => s.shortcut === `alt+${letter}`);
-		return letter in this.shortcuts_dict || is_in_global_shortcut;
+		return letter in this.shortcuts_dict || is_in_global_shortcut || this.blacklisted_letters.includes(letter.toLowerCase());
 	}
 };

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -526,11 +526,13 @@ frappe.ui.Page = class Page {
 			$li.addClass("user-action").insertBefore(this.divider);
 		}
 
-		// alt shortcut
-		frappe.ui.keys
-			.get_shortcut_group(parent.get(0))
-			.add($link, $link.find(".menu-item-label"));
-
+		// if an shortcut is already set, dont set an alt Shortcut
+		if(!shortcut){
+			// alt shortcut
+			frappe.ui.keys
+				.get_shortcut_group(parent.get(0))
+				.add($link, $link.find(".menu-item-label"));
+		}
 		return $link;
 	}
 

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -527,7 +527,7 @@ frappe.ui.Page = class Page {
 		}
 
 		// if an shortcut is already set, dont set an alt Shortcut
-		if(!shortcut){
+		if (!shortcut) {
 			// alt shortcut
 			frappe.ui.keys
 				.get_shortcut_group(parent.get(0))


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->


Improves Keyboard Handling with German Keyboard Layout


<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

On a Mac with a German layout, pressing Alt + E should result in the character €, and Alt + L should result in @.
On a Windows/Linux machine, Alt + Q should produce @.

Before the changes, Alt + E always tried to submit the document, as the button was labeled "Einreichen".

The changes in alt_keyboard_shortcuts.js prevent the usage of certain letters for shortcuts.
The section can be adapted for multiple languages.

The adaptation in page.js prevents duplicate linking if a shortcut is already defined for an entry.
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
