### PR TITLE
fix: handle AppSwitcher `this` context

### DIFF
--- a/frappe/public/js/frappe/ui/apps_switcher.js
+++ b/frappe/public/js/frappe/ui/apps_switcher.js
@@ -15,6 +15,7 @@ frappe.ui.AppsSwitcher = class AppsSwitcher {
 			this.app_switcher_menu.toggleClass("hidden");
 		});
 	}
+
 	create_app_data_map() {
 		frappe.boot.app_data_map = {};
 		for (var app of frappe.boot.app_data) {
@@ -147,11 +148,15 @@ frappe.ui.AppsSwitcher = class AppsSwitcher {
 		// re-render the sidebar
 		frappe.app.sidebar.make_sidebar();
 	}
+
 	set_hover() {
-		this.app_switcher.on("mouseover", function (event) {
+		const me = this;
+
+		this.app_switcher.on("mouseover", function () {
 			if ($(this).hasClass("active-sidebar")) return;
 			$(this).addClass("hover");
-			if (!this.sidebar.sidebar_expanded) {
+
+			if (!me.sidebar.sidebar_expanded) {
 				$(this).removeClass("hover");
 			}
 		});
@@ -160,8 +165,10 @@ frappe.ui.AppsSwitcher = class AppsSwitcher {
 			$(this).removeClass("hover");
 		});
 	}
+
 	set_active() {
 		this.app_switcher.toggleClass("active-sidebar");
+
 		if (!this.sidebar.sidebar_expanded) {
 			this.app_switcher.removeClass("active-sidebar");
 		}


### PR DESCRIPTION
**Issue:**


https://github.com/user-attachments/assets/6a4769b5-767b-453b-92b8-0377d277bd42

<br>

<details><summary><strong>See Error Traceback:</strong></summary>

```js
Uncaught TypeError: this.sidebar is undefined
    set_hover apps_switcher.js:154
    jQuery 8
    set_hover apps_switcher.js:151
    AppsSwitcher apps_switcher.js:8
    make_dom sidebar.js:54
    Sidebar sidebar.js:13
    make_sidebar desk.js:91
    startup desk.js:40
    Application desk.js:30
    start_app desk.js:12
    <anonymous> desk.js:25
    jQuery 13
    __require2 libs.bundle.LLRFRX7M.js:16
    <anonymous> jQuery
    <anonymous> libs.bundle.LLRFRX7M.js:21430
3 apps_switcher.js:154:8
    set_hover apps_switcher.js:154
    jQuery 8
    set_hover apps_switcher.js:151
    AppsSwitcher apps_switcher.js:8
    make_dom sidebar.js:54
    Sidebar sidebar.js:13
    make_sidebar desk.js:91
    startup desk.js:40
    Application desk.js:30
    start_app desk.js:12
    <anonymous> desk.js:25
    jQuery 13
    __require2 libs.bundle.LLRFRX7M.js:16
    <anonymous> jQuery
    <anonymous> libs.bundle.LLRFRX7M.js:21430

```


</details> 