### PR TITLE
perf: use `client_cache` for `print_sql`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -421,10 +421,10 @@ def errprint(msg: str) -> None:
 
 
 def print_sql(enable: bool = True) -> None:
-	if frappe.conf.allow_tests and frappe.conf.developer_mode:
-		cache.set_value("flag_print_sql", enable)
-	else:
-		frappe.throw("`frappe.print_sql` only works in `developer_mode` with `allow_tests` enabled on site.")
+	if not local.conf.allow_tests:
+		frappe.throw("`frappe.print_sql` only works with `allow_tests` site config enabled.")
+
+	client_cache.set_value("flag_print_sql", enable)
 
 
 def log(msg: str) -> None:

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -472,7 +472,7 @@ class ClientCache:
 			self.invalidator_id = self.invalidator.client_id()
 		except redis.exceptions.ConnectionError:
 			# Redis not available, this can happen during setup/startup time
-			self.redis = frappe.cache
+			self.redis = frappe.local.cache
 			self.healthy = False
 
 		# These are local hits and misses, *not* global.

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -472,7 +472,7 @@ class ClientCache:
 			self.invalidator_id = self.invalidator.client_id()
 		except redis.exceptions.ConnectionError:
 			# Redis not available, this can happen during setup/startup time
-			self.redis = frappe.local.cache
+			self.redis = frappe.cache
 			self.healthy = False
 
 		# These are local hits and misses, *not* global.


### PR DESCRIPTION
_NOTE: updated_

- removed `developer_mode` condition
- use client cache