### PR TITLE
perf!: faster frappedict getattr

### DIFF
--- a/frappe/types/frappedict.py
+++ b/frappe/types/frappedict.py
@@ -25,6 +25,14 @@ class _dict(dict[_KT, _VT]):
 	__setstate__ = dict.update
 
 	@override
+	def __getattribute__(self, name):
+		if name in _dict_attributes:
+			return object.__getattribute__(self, name)
+
+		if name in self:
+			return self[name]
+
+	@override
 	def __getstate__(self) -> Self:
 		return self
 
@@ -51,3 +59,6 @@ class _dict(dict[_KT, _VT]):
 	@override
 	def copy(self) -> "_dict[_KT, _VT]":
 		return _dict(self)
+
+
+_dict_attributes = frozenset(dir(_dict))

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -48,6 +48,8 @@ SERVER_SCRIPT_FILE_PREFIX = "<serverscript>"
 class NamespaceDict(frappe._dict):
 	"""Raise AttributeError if function not found in namespace"""
 
+	__getattribute__ = dict.__getattribute__
+
 	def __getattr__(self, key):
 		ret = self.get(key)
 		if (not ret and key.startswith("__")) or (key not in self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,7 +226,6 @@ files = [
     "frappe/types/__init__.py",
     "frappe/types/DF.py",
     "frappe/types/docref.py",
-    "frappe/types/frappedict.py",
     "frappe/types/filter.py",
 ]
 exclude = [


### PR DESCRIPTION
- ~60% faster
- ⚠️ breaks class inheritance, example:
    https://github.com/frappe/frappe/blob/20220ef894439706443d6b31b44179400672f25d/frappe/utils/safe_exec.py#L48
    
    fix is simple, add this line to your class to restore earlier behaviour:
    ```py
    __getattribute__ = dict.__getattribute__
    ```
