### PR TITLE
revert: "fix(UX): Show reason for read only form in headline (#31511)"

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -428,11 +428,7 @@ frappe.ui.form.Form = class FrappeForm {
 			this.read_only = frappe.workflow.is_read_only(this.doctype, this.docname);
 			if (this.read_only) {
 				this.set_read_only();
-				this.dashboard.set_headline(
-					__("This form is not editable due to a Workflow."),
-					"blue",
-					true
-				);
+				frappe.show_alert(__("This form is not editable due to a Workflow."));
 			}
 
 			// check if doctype is already open


### PR DESCRIPTION
This reverts commit 49fe1cd3cccf84ea27aefa5682b06c952cedf99b.

Causes form to not load:

```
request.js:311 TypeError: Cannot read properties of undefined (reading 'set_headline')
    at f.refresh (form.js:431:20)
    at frappe.views.FormFactory.render (formview.js:107:45)
    at formview.js:91:9
    at Object.callback (model.js:332:19)
    at Object.t [as success_callback] (request.js:87:16)
    at 200 (request.js:135:34)
    at Object.<anonymous> (request.js:307:6)
```
