### PR TITLE
fix: option to opt out of automatic filters

### DIFF
--- a/frappe/desk/doctype/list_view_settings/list_view_settings.json
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.json
@@ -11,6 +11,7 @@
   "disable_sidebar_stats",
   "disable_auto_refresh",
   "allow_edit",
+  "disable_automatic_recency_filters",
   "total_fields",
   "fields_html",
   "fields"
@@ -64,10 +65,17 @@
    "fieldname": "allow_edit",
    "fieldtype": "Check",
    "label": "Allow Bulk Editing"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_automatic_recency_filters",
+   "fieldtype": "Check",
+   "label": "Disable Automatic Recency Filters"
   }
  ],
+ "grid_page_length": 50,
  "links": [],
- "modified": "2024-08-21 18:17:24.889783",
+ "modified": "2025-03-12 16:28:46.073808",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "List View Settings",
@@ -86,6 +94,7 @@
   }
  ],
  "read_only": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.py
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.py
@@ -16,6 +16,7 @@ class ListViewSettings(Document):
 
 		allow_edit: DF.Check
 		disable_auto_refresh: DF.Check
+		disable_automatic_recency_filters: DF.Check
 		disable_comment_count: DF.Check
 		disable_count: DF.Check
 		disable_sidebar_stats: DF.Check

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -108,14 +108,12 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				return f;
 			});
 		}
-		this.add_recent_filter_on_large_tables();
-
 		this.patch_refresh_and_load_lib();
-		return this.get_list_view_settings();
+		return this.get_list_view_settings().then(() => this.add_recent_filter_on_large_tables());
 	}
 
 	add_recent_filter_on_large_tables() {
-		if (!this.is_large_table) {
+		if (!this.is_large_table || this.list_view_settings?.disable_automatic_recency_filters) {
 			return;
 		}
 		// Note: versions older than v16 should use "modified" here.


### PR DESCRIPTION
In rare cases, where this is really getting in the way, it can now be disabled. I'm yet to find such cases. 

TODO: Add indicator/explanation _somewhere_