### PR TITLE
fix(report): show add_total_row checkbox if report_type is not 'Repor…

### DIFF
--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -73,6 +73,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: doc.report_type !== \"Report Builder\"",
    "fieldname": "add_total_row",
    "fieldtype": "Check",
    "label": "Add Total Row"
@@ -206,7 +207,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-11 10:42:45.591937",
+ "modified": "2025-03-12 17:08:09.629411",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Report",


### PR DESCRIPTION
Report Builder doesn't use add_total_row anyway, it is redundant to show it in the UI anyway