### PR TITLE
fix: Use DOMParser in `is_html` + Handle html input in `show_message`

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -116,8 +116,9 @@ frappe.ui.form.Layout = class Layout {
 			// wrap in a block if `html` does not contain html tags
 			$html = $("<div class='form-message border-bottom'></div>").text(html);
 		} else {
-			$html = $(html);
-			$html.addClass("form-message border-bottom");
+			// Wrap in a block just in case the string does not begin with a tag
+			// as Jquery assumes it to be a CSS selector and breaks.
+			$html = $("<div class='form-message border-bottom'>").html(html);
 		}
 
 		// Add close button to block if not permanent

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -157,16 +157,12 @@ Object.assign(frappe.utils, {
 	is_html: function (txt) {
 		if (!txt) return false;
 
-		if (
-			txt.indexOf("<br>") == -1 &&
-			txt.indexOf("<p") == -1 &&
-			txt.indexOf("<img") == -1 &&
-			txt.indexOf("<div") == -1 &&
-			!txt.includes("<span")
-		) {
-			return false;
-		}
-		return true;
+		const doc = new DOMParser().parseFromString(txt, "text/html");
+		const nodes = doc.body.childNodes || [];
+
+		// check if any of the nodes are element nodes
+		// Ref: https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+		return [...nodes].some((node) => node.nodeType === 1);
 	},
 	is_mac: function () {
 		return window.navigator.platform === "MacIntel";


### PR DESCRIPTION
## 1
- Post https://github.com/frappe/frappe/pull/31514 headlines with anchor tags were broken
   ![image](https://github.com/user-attachments/assets/7f2d8da9-78d7-49ba-b0f5-196d8ef793ba)
- We moved to using `frappe.utils.is_html` instead of reinventing the util to have a single util responsible
- `frappe.utils.is_html` did not account for anchor tags
- **Solution:** Use the `DOMParser` browser API in `frappe.utils.is_html`  to check dynamically. This solution supports all element nodes.
- **Working:**
	- <img width="500" alt="Screenshot 2025-03-12 at 4 34 16 PM" src="https://github.com/user-attachments/assets/123a5935-43eb-46f4-89b6-e631a7c4f9d2" />


## 2
- While trying to convert an HTML string to a DOM Object, `$()` fails to parse the string if it does not start with a tag
- It assumes the string to be CSS Selectors without a starting tag
- In a case like `Hi look at this link: <a href="https://github.com">Click Me</a>`, the parsing was unsuccessful
- **Solution:** Wrap the HTML input in a `div` before converting the input, so it starts with a tag always
- **Working:**
	- <img width="500" alt="Screenshot 2025-03-12 at 4 29 07 PM" src="https://github.com/user-attachments/assets/feab3f43-66b7-4e21-a976-05681a7640a3" />
	- <img width="500" alt="Screenshot 2025-03-12 at 4 29 37 PM" src="https://github.com/user-attachments/assets/8679495a-1f34-4a22-813e-fae6e077ba3f" />
	- <img width="500" alt="Screenshot 2025-03-12 at 4 30 03 PM" src="https://github.com/user-attachments/assets/9208da7a-8172-4ac1-949b-c98b66eca3f8" />
