### PR TITLE
fix: increase length for value field in sms parameter

### DIFF
--- a/frappe/core/doctype/sms_parameter/sms_parameter.json
+++ b/frappe/core/doctype/sms_parameter/sms_parameter.json
@@ -25,6 +25,7 @@
    "in_list_view": 1,
    "label": "Value",
    "print_width": "150px",
+   "length": 255,
    "reqd": 1,
    "width": "150px"
   },
@@ -39,7 +40,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-23 16:03:38.659977",
+ "modified": "2025-03-12 19:40:34.519601",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "SMS Parameter",


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Have changed the the value field in the child table of sms parameter to varchar(255) from 140

> Explain the **details** for making this change. What existing problem does the pull request solve?

Some sms provider's api key are beyond 140 characters, allowing 255 data long will cater for users that are with providers that go beyond the length of 140.

closes https://github.com/frappe/frappe/issues/27857
See also #27859 