### PR TITLE
fix: report header not translated

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1231,6 +1231,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	prepare_columns(columns) {
+		let is_query_generated_report =
+			this.report_doc.query &&
+			this.report_doc.query != undefined &&
+			this.report_doc.query != "";
 		return columns.map((column) => {
 			column = frappe.report_utils.prepare_field_from_column(column);
 
@@ -1279,7 +1283,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				id: column.fieldname,
 				// The column label should have already been translated in the
 				// backend. Translating it again would cause unexpected behaviour.
-				name: column.label,
+
+				// Translating based on condition: when a report is generated through a query, the label is not translated.
+				name: is_query_generated_report ? __(column.label) : column.label,
 				width: parseInt(column.width) || null,
 				editable: column.editable ?? false,
 				compareValue: compareFn,


### PR DESCRIPTION
Support ticket: https://support.frappe.io/helpdesk/tickets/33548

When a report is generated through a query, the headers are not translated, so now they are translated based on a condition.

- Before
![image](https://github.com/user-attachments/assets/aa7cacc1-932c-4a8f-920b-a70e9612e7b1)

- After
![image](https://github.com/user-attachments/assets/2279be4a-bbc9-48dc-82f5-d8d86f817eab)

- Translation
![image](https://github.com/user-attachments/assets/104bca9e-30c3-4af0-b327-55ae4216db3c)
