### PR TITLE
fix: respect `override_whitelisted_method` in `map_docs`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2043,6 +2043,14 @@ def validate_and_sanitize_search_inputs(fn):
 	return wrapper
 
 
+def override_whitelisted_method(original_method: str) -> str:
+	"""Return the last override or the original whitelisted method."""
+	for override in reversed(frappe.get_hooks("override_whitelisted_methods", {}).get(original_method, [])):
+		return override
+
+	return original_method
+
+
 # Backward compatibility
 from frappe.utils.messages import *  # noqa: I001
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2045,10 +2045,8 @@ def validate_and_sanitize_search_inputs(fn):
 
 def override_whitelisted_method(original_method: str) -> str:
 	"""Return the last override or the original whitelisted method."""
-	for override in reversed(frappe.get_hooks("override_whitelisted_methods", {}).get(original_method, [])):
-		return override
-
-	return original_method
+	overrides = frappe.get_hooks("override_whitelisted_methods", {}).get(original_method, [])
+	return overrides[-1] if overrides else original_method
 
 
 # Backward compatibility

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -33,10 +33,7 @@ def handle_rpc_call(method: str, doctype: str | None = None):
 		module = load_doctype_module(doctype)
 		method = module.__name__ + "." + method
 
-	for hook in reversed(frappe.get_hooks("override_whitelisted_methods", {}).get(method, [])):
-		# override using the last hook
-		method = hook
-		break
+	method = frappe.override_whitelisted_method(method)
 
 	# via server script
 	server_script = get_server_script_map().get("_api", {}).get(method)

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -62,10 +62,7 @@ def handle():
 
 def execute_cmd(cmd, from_async=False):
 	"""execute a request as python module"""
-	for hook in reversed(frappe.get_hooks("override_whitelisted_methods", {}).get(cmd, [])):
-		# override using the last hook
-		cmd = hook
-		break
+	cmd = frappe.override_whitelisted_method(cmd)
 
 	# via server script
 	server_script = get_server_script_map().get("_api", {}).get(cmd)

--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -39,8 +39,8 @@ def map_docs(method, source_names, target_doc, args=None):
 
 	e.g. args: "{ 'supplier': 'XYZ' }"
 	"""
+	method = frappe.get_attr(frappe.override_whitelisted_method(method))
 
-	method = frappe.get_attr(method)
 	frappe.is_whitelisted(method)
 
 	for src in json.loads(source_names):

--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -15,13 +15,7 @@ def make_mapped_doc(method, source_name, selected_children=None, args=None):
 	Set `selected_children` as flags for the `get_mapped_doc` method.
 
 	Called from `open_mapped_doc` from create_new.js"""
-
-	for hook in reversed(frappe.get_hooks("override_whitelisted_methods", {}).get(method, [])):
-		# override using the last hook
-		method = hook
-		break
-
-	method = frappe.get_attr(method)
+	method = frappe.get_attr(frappe.override_whitelisted_method(method))
 
 	frappe.is_whitelisted(method)
 


### PR DESCRIPTION
- Overriding whitelisted methods was re-implemented in three different places. -> Refactored into a single util.
- `map_docs` didn't care about overridden methods. It always called the original. -> Fixed to respect overrides.

Ref: LAN-865