### PR TITLE
feat: print with typst

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -68,6 +68,11 @@ frappe.ui.form.on("Print Format", {
 		frm.set_value("line_breaks", value);
 		frm.trigger("render_buttons");
 	},
+	pdf_generator: function (frm) {
+		if (frm.doc.pdf_generator === "typst") {
+			frm.set_value("raw_printing", 1);
+		}
+	},
 	doc_type: function (frm) {
 		frm.trigger("hide_absolute_value_field");
 	},

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -94,7 +94,7 @@
   },
   {
    "default": "Jinja",
-   "depends_on": "custom_format",
+   "depends_on": "eval:doc.custom_format && doc.pdf_generator !== \"typst\"",
    "fieldname": "print_format_type",
    "fieldtype": "Select",
    "label": "Print Format Type",
@@ -262,13 +262,13 @@
    "fieldname": "pdf_generator",
    "fieldtype": "Select",
    "label": "PDF Generator",
-   "options": "wkhtmltopdf"
+   "options": "wkhtmltopdf\ntypst"
   }
  ],
  "icon": "fa fa-print",
  "idx": 1,
  "links": [],
- "modified": "2025-02-14 14:49:39.181074",
+ "modified": "2025-03-15 01:43:05.968377",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",
@@ -291,6 +291,7 @@
    "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -40,7 +40,7 @@ class PrintFormat(Document):
 		page_number: DF.Literal[
 			"Hide", "Top Left", "Top Center", "Top Right", "Bottom Left", "Bottom Center", "Bottom Right"
 		]
-		pdf_generator: DF.Literal["wkhtmltopdf"]
+		pdf_generator: DF.Literal["wkhtmltopdf", "typst"]
 		print_format_builder: DF.Check
 		print_format_builder_beta: DF.Check
 		print_format_type: DF.Literal["Jinja", "JS"]

--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 import frappe
+from frappe.utils.typst import print_with_typst
 
 
 def get_print(
@@ -44,6 +45,9 @@ def get_print(
 				frappe.get_cached_value("Print Format", print_format, "pdf_generator") or "wkhtmltopdf"
 			)
 		local.form_dict.pdf_generator = pdf_generator
+
+	if local.form_dict.pdf_generator == "typst":
+		return print_with_typst(doctype, name, print_format, as_pdf, doc, output, password)
 
 	original_form_dict = copy.deepcopy(local.form_dict)
 	try:

--- a/frappe/utils/typst.py
+++ b/frappe/utils/typst.py
@@ -1,0 +1,103 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from uuid import uuid4
+
+from pypdf import PdfReader, PdfWriter
+
+import frappe
+from frappe.core.doctype.file.utils import get_local_image, get_web_image
+from frappe.model.document import Document
+from frappe.utils.data import to_markdown
+from frappe.utils.pdf import get_file_data_from_writer
+
+
+def print_with_typst(
+	doctype, name, print_format, as_pdf, doc, output: PdfWriter | None = None, password=None
+):
+	if not doc:
+		doc = frappe.get_doc(doctype, name)
+
+	template = frappe.db.get_value("Print Format", print_format, "raw_commands")
+	temp_dirname = Path("/tmp") / str(uuid4())
+	temp_dirname.mkdir(parents=True, exist_ok=False)
+
+	template_path = temp_dirname / "main.typ"
+	template_path.write_text(template)
+
+	doc_dict = get_resolved_dict(doc, temp_dirname)
+	json_path = temp_dirname / "doc.json"
+	json_path.write_text(frappe.as_json(doc_dict))
+
+	# run command
+	subprocess.run(["typst", "compile", template_path])
+
+	output_path = temp_dirname / "main.pdf"
+	if not output_path.exists():
+		raise Exception("Failed to generate PDF")
+
+	reader = PdfReader(output_path)
+
+	if output:
+		output.append_pages_from_reader(reader)
+		return output
+
+	writer = PdfWriter()
+	writer.append_pages_from_reader(reader)
+
+	if password:
+		writer.encrypt(password)
+
+	shutil.rmtree(temp_dirname)
+
+	return get_file_data_from_writer(writer)
+
+
+def get_resolved_dict(doc: "Document", temp_dirname: Path, depth: int = 0) -> dict:
+	"""Resolve links and return as nested JSON"""
+	doc_dict = doc.as_dict()
+	for fieldname, value in doc_dict.items():
+		if value is None:
+			continue
+
+		df = doc.meta.get_field(fieldname)
+		if not df:
+			continue
+
+		if df.fieldtype == "Link" and df.options != "DocType" and depth < 1:
+			doc_dict[df.fieldname] = (
+				get_resolved_dict(frappe.get_doc(df.options, value), temp_dirname, depth + 1) if value else {}
+			)
+		if df.fieldtype == "Dynamic Link" and doc[df.options] and depth < 1:
+			doc_dict[df.fieldname] = (
+				get_resolved_dict(frappe.get_doc(doc[df.options], value), temp_dirname, depth + 1)
+				if value
+				else {}
+			)
+		if df.fieldtype in ("Table", "Table MultiSelect") and depth < 1:
+			for child_row in value:
+				child_row.update(
+					get_resolved_dict(
+						doc.get(fieldname, {"name": child_row["name"]})[0], temp_dirname, depth + 1
+					)
+				)
+		if df.fieldtype in ("Date", "Datetime", "Float", "Int", "Currency", "Duration"):
+			doc_dict[df.fieldname] = {
+				"value": value,
+				"formatted": doc.get_formatted(fieldname),
+			}
+		if df.fieldtype == "Attach Image" and value:
+			if value.startswith(("/files", "/private/files")):
+				image, filename, extn = get_local_image(value)
+			else:
+				image, filename, extn = get_web_image(value)
+
+			image_path = (temp_dirname / filename.lstrip(os.sep)).with_suffix(f".{extn}")
+			image_path.parent.mkdir(parents=True, exist_ok=True)
+			image.save(image_path)
+			doc_dict[df.fieldname] = str(image_path.relative_to(temp_dirname))
+		if df.fieldtype in ("Text Editor"):
+			doc_dict[df.fieldname] = to_markdown(value)
+
+	return doc_dict


### PR DESCRIPTION
Adds [typst](https://typst.app/home) as an optional print backend.

Depends on the `typst` CLI being installed on the host system.

Resolves https://github.com/frappe/frappe/issues/25831#issuecomment-2712178129

If you're new to typst and want to play around, check out our demo repository: https://github.com/alyf-de/typst-demo

### Print Format

![print_format](https://github.com/user-attachments/assets/56176e17-5913-477d-9e49-86e57fd355ff)

<details>
<summary>Raw Commands (<code>main.typ</code>)</summary>

Beware, this template uses some custom fields.

```typst
// 1) Load and parse JSON from doc.json
#let doc = json("doc.json")

// Access dictionary data with .at("key")
#let company = doc.at("company")
#let company_address = doc.at("company_address")
#let items = doc.at("items")


#set page(
  width: 210mm,
  height: 297mm,
  margin: (
    left: 25mm,
    right: 20mm,
    top: 45mm,
    bottom: 40mm,
  ),
  header: [
    #set align(right)
    #image(company.at("company_logo"), width: 30mm)
  ],
  footer: context [
    #set text(8pt)
    #set align(right)
    Page #counter(page).display(
      "1 of 1",
      both: true,
    )
    #set align(left)
    #table(
      columns: (1fr, 1fr, 1fr),
      stroke: none,
      row-gutter: -.5em,
      company.at("name"),
      [Managing director:],
      [Sparkasse Musterstedt],
      company_address.at("address_line1") + ", " + company_address.at("city"),
      [Jon Doe],
      [IBAN: DE12 3456 7890 1234 56],
      [Phone: ] + company.at("phone_no"),
      [VAT ID.: ] + company.at("tax_id"),
      [BIC: WELADE12345],
      [Email: ] + company.at("email"),
      [Register Court: ] + company.at("register_court"),
      [Register Number: ] + company.at("register_number"),
    )
  ]
)

#set text(font: "Arial")

#let vcentered_text(chars) = text(
  baseline: -.5em,
  chars
)

// Folding mark (top)
#place(
  dy: 60mm,
  dx: -13%,
  vcentered_text([---]),
)

// Folding mark (center)
#place(
  dy: 148.5mm - 45mm,
  dx: -13%,
  vcentered_text([-]),
)

// Folding mark (bottom)
#place(
  dy: 160mm,
  dx: -13%,
  vcentered_text([---]),
)

#grid(
  columns: (3fr, 2fr),
  rows: (auto),
  grid(
    rows: auto,
    gutter: 1em,
    text(size: 6pt, company.at("name") + " - " + company_address.at("address_line1") + " - " + company_address.at("city")),
    doc.at("customer_name"),
    doc.at("address_display")
  ),
  table(
    stroke: none,
    columns: (1fr, 1fr),
    align: (left, right),
    text("Invoice Date:"), doc.at("posting_date").at("formatted"),
    text("Due Date:"), doc.at("due_date").at("formatted"),
    text("Our VAT ID:"), company.at("tax_id"),
  )
)

#v(7.5em)

#text(
  weight: "bold",
  [Invoice No.] + " " + doc.at("name")
)
#v(1em)

Dear Sir or Madam

Please allow us to invoice our services as follows:

#v(1em)
#table(
  columns: (3fr, 1fr, 1fr, 1fr),
  align: (left, left, right, right),
  row-gutter: 1em,
  column-gutter: 0.5em,
  stroke: none,
  table.header(
  [*Description*], [*Qty*], [*Price*], [*Amount*]),
  table.hline(),
  ..items.map(
    row => (
      grid(
        gutter: 1em,
        text(weight: "bold", row.at("item_name")), row.at("description"),
      ),
      row.at("qty").at("formatted"), row.at("rate").at("formatted"), row.at("amount").at("formatted")
    )
  ).flatten(),
)
#table(
  columns: (1fr, 1fr),
  align: (left, right),
  row-gutter: 0em,
  column-gutter: 0.5em,
  stroke: none,
  table.hline(),
  [*Net total*], doc.at("net_total").at("formatted"),
  [*VAT*], doc.at("total_taxes_and_charges").at("formatted"),
  [*Grand total*], doc.at("grand_total").at("formatted"),
  table.hline(),
)
```

</details>

### Result

![typst_invoice](https://github.com/user-attachments/assets/43eb709c-a700-4595-b6c9-3efbac0360c2)

### Architecture

Typst can ingest JSON data and files from the same directory. We cannot use jinja templating. We cannot embed images via URL.

We create a temporary directory where we put the following files:

- `main.typ`: contains the raw commands from the Print Format
- `doc.json`: contains the printed doc and all linked docs, resolved as a big JSON structure. HTML is converted to markdown first. Numeric values are represented as an object with keys "value" and "formatted"., e.g. `{"value": 6.99, "formatted": "€ 6,99"}`.
- all images from any "Attach Image" fields

Then, we run `typst compile` in this directory and return the output file.

### To do

- [ ] converting to markdown is just a hack to get rid of ugly html tags. Ideally, we'd convert html content to typst using pandoc.
- [ ] typst can output SVGs instead of PDF. Maybe we can wrap the SVGs in some HTML to produce a nice preview. (
`typst-ts-cli compile -e "main.typ" --format svg_html`)
- [ ] error handling
- [ ] Nice editor with highlighting, autocompletion and preview
- [ ] Provide server script extending a basic `doc.json` as needed
	- [ ] special key `_files`, holding a list of file URLs that will be written to the temp folder
- [ ] can I write to `/tmp` in a docker container?
    - Write to site directory
- [ ] Translations