### PR TITLE
fix: skip preloading bundled assets if `http_status_code` is 404

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -557,7 +557,8 @@ def build_response(path, data, http_status_code, headers: dict | None = None):
 	response.headers["X-Page-Name"] = cstr(cstr(path).encode("ascii", errors="xmlcharrefreplace"))
 	response.headers["X-From-Cache"] = frappe.local.response.from_cache or False
 
-	add_preload_for_bundled_assets(response)
+	if http_status_code != 404:
+		add_preload_for_bundled_assets(response)
 
 	if headers:
 		for key, val in headers.items():


### PR DESCRIPTION
## Problem

`build_response` for all Page Renderers, adds preload links for bundled assets. All renderers extending the base template preload these links **including the 404 page**. 

Now, even if you have a custom page renderer written that doesn't extend the base template, this preload link addition is triggered whenever you hit a 404 on any asset - image, fonts, etc.

![telegram-cloud-document-5-6244413558214365924](https://github.com/user-attachments/assets/6e5fbdd3-73ff-4e17-a555-21a6f6673ea7)

## Before

<details>
<summary>Eg: StudioAppRenderer uses its own template</summary>

```python
class StudioAppRenderer(DocumentPage):
	def can_render(self):
		if app := self.find_app_for_path():
			self.doctype = "Studio App"
			self.docname = app
			return True

		return False

	def find_app_for_path(self):
		app_route = self.path.split("/")[0]
		return frappe.db.get_value("Studio App", dict(route=app_route), "name")

class StudioApp(WebsiteGenerator):
	website = frappe._dict(
		template="templates/generators/renderer.html", # template
		page_title_field="app_title",
		condition_field="published",
	)

```
</details>

Whenever it hits 404 for something:

<img width="1436" alt="warnings" src="https://github.com/user-attachments/assets/515e89ec-73b2-44fa-8cd5-3054c4db02cc" />


All these extra scripts also get loaded that the renderer never asked for, due to the templates extending the base:

404.html → web.html → base.html

<img width="1436" alt="extra-scripts" src="https://github.com/user-attachments/assets/e7038307-6d9c-42fb-9e39-247ee9e8cf15" />

Happens on Frappe Builder too when you hit 404

<img width="1436" alt="extra" src="https://github.com/user-attachments/assets/59e4779f-b5bb-43ee-b1bd-2ec365cf7b33" />


## After

Skip preloading bundled assets if status code = 404 because it's useless and we might hit 404 on any response.

<img width="1436" alt="image" src="https://github.com/user-attachments/assets/519de502-d07f-456c-86c8-3df647bbf3d2" />

<img width="1436" alt="image" src="https://github.com/user-attachments/assets/553258cf-b756-446e-bc4a-4f17bba69507" />
