### PR TITLE
fix: Pin web workers by default

### DIFF
--- a/frappe/_optimizations.py
+++ b/frappe/_optimizations.py
@@ -93,7 +93,9 @@ def freeze_gc():
 
 
 def optimize_for_gil_contention():
-	if not os.environ.get("FRAPPE_PERF_PIN_WORKERS"):
+	from frappe.utils import sbool
+
+	if not bool(sbool(os.environ.get("FRAPPE_PERF_PIN_WORKERS", True))):
 		return
 
 	if "gunicorn" not in str(sys.argv[0]):


### PR DESCRIPTION
This has been running fine. Making the envvar opt-out instead of opt-in. 

ref https://github.com/frappe/frappe/pull/28854 