### PR TITLE
perf: Don't update list view settings on every query

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1142,6 +1142,10 @@ class DatabaseQuery:
 
 	def update_user_settings(self):
 		# update user settings if new search
+		if not self.save_user_settings_fields and not getattr(self, "user_settings", None):
+			# Nothing has changed or needs to be changed
+			return
+
 		user_settings = json.loads(get_user_settings(self.doctype))
 
 		if hasattr(self, "user_settings"):


### PR DESCRIPTION
It literally doesn't do anything ever.

User settings are explicitly updated using `user_settings.save` endpoint.
