### PR TITLE
perf: remove repeated calls to expensive function (and other improvements)

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -19,6 +19,8 @@ from frappe.model.utils import is_virtual_doctype
 from frappe.utils import add_user_info, cint, format_duration
 from frappe.utils.data import sbool
 
+DISALLOWED_PARAMS = ("cmd", "data", "ignore_permissions", "view", "user", "csrf_token", "join")
+
 
 @frappe.whitelist()
 @frappe.read_only()
@@ -241,8 +243,9 @@ def update_wildcard_field_param(data):
 
 
 def clean_params(data):
-	for param in ("cmd", "data", "ignore_permissions", "view", "user", "csrf_token", "join"):
-		data.pop(param, None)
+	for param in DISALLOWED_PARAMS:
+		if param in data:
+			del data[param]
 
 
 def parse_json(data):

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -62,6 +62,7 @@ no_value_fields = (
 	"Fold",
 	"Heading",
 )
+NO_VALUE_FIELDS = frozenset(no_value_fields)
 
 display_fieldtypes = (
 	"Section Break",
@@ -88,10 +89,12 @@ default_fields = (
 	"docstatus",
 	"idx",
 )
+DEFAULT_FIELDS = frozenset(default_fields)
 
 child_table_fields = ("parent", "parentfield", "parenttype")
 
 optional_fields = ("_user_tags", "_comments", "_assign", "_liked_by", "_seen")
+OPTIONAL_FIELDS = frozenset(optional_fields)
 
 table_fields = ("Table", "Table MultiSelect")
 
@@ -224,7 +227,7 @@ def get_permitted_fields(
 		return valid_columns
 
 	# DocType has only fields of type Table (Table, Table MultiSelect)
-	if set(valid_columns).issubset(default_fields):
+	if DEFAULT_FIELDS.issuperset(valid_columns):
 		return valid_columns
 
 	if permission_type is None:

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -118,6 +118,7 @@ core_doctypes_list = (
 	"Custom Field",
 	"Client Script",
 )
+CORE_DOCTYPES = frozenset(core_doctypes_list)
 
 log_types = (
 	"Version",
@@ -223,7 +224,7 @@ def get_permitted_fields(
 	meta = frappe.get_meta(doctype)
 	valid_columns = meta.get_valid_columns()
 
-	if doctype in core_doctypes_list:
+	if doctype in CORE_DOCTYPES:
 		return valid_columns
 
 	# DocType has only fields of type Table (Table, Table MultiSelect)
@@ -233,24 +234,31 @@ def get_permitted_fields(
 	if permission_type is None:
 		permission_type = "select" if frappe.only_has_select_perm(doctype, user=user) else "read"
 
-	meta_fields = meta.default_fields.copy()
-	optional_meta_fields = [x for x in optional_fields if x in valid_columns]
-
-	if permitted_fields := meta.get_permitted_fieldnames(
+	permitted_fields = meta.get_permitted_fieldnames(
 		parenttype=parenttype,
 		user=user,
 		permission_type=permission_type,
 		with_virtual_fields=not ignore_virtual,
-	):
-		if permission_type == "select":
-			return permitted_fields
+	)
 
-		if meta.istable:
-			meta_fields.extend(child_table_fields)
+	if permission_type == "select":
+		return permitted_fields
 
-		return meta_fields + permitted_fields + optional_meta_fields
+	valid_columns = set(valid_columns)
+	result = [
+		*meta.default_fields,
+		*(fieldname for fieldname in optional_fields if fieldname in valid_columns),
+	]
 
-	return meta_fields + optional_meta_fields
+	if not permitted_fields:
+		return result
+
+	if meta.istable:
+		result.extend(child_table_fields)
+
+	result.extend(permitted_fields)
+
+	return result
 
 
 def is_default_field(fieldname: str) -> bool:

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -164,8 +164,8 @@ class BaseDocument:
 		return frappe.get_meta(self.doctype)
 
 	@cached_property
-	def permitted_fieldnames(self):
-		return get_permitted_fields(doctype=self.doctype, parenttype=getattr(self, "parenttype", None))
+	def permitted_fieldnames(self) -> set[str]:
+		return set(get_permitted_fields(doctype=self.doctype, parenttype=getattr(self, "parenttype", None)))
 
 	@cached_property
 	def _weakref(self):

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -644,15 +644,15 @@ class DatabaseQuery:
 			if column[0] in {"'", '"'}:
 				continue
 
+			doctype = None
+
 			if "." in column:
 				table, column = column.split(".", 1)
 				doctype = self.linked_table_aliases[table] if table in self.linked_table_aliases else table
-				doctype = doctype.replace("`", "").replace("tab", "", 1)
-			else:
-				doctype = self.doctype
+				doctype = doctype.replace("`", "").removeprefix("tab")
 
 			# handle child / joined table fields
-			if doctype != self.doctype:
+			if doctype and doctype != self.doctype:
 				if wrap_grave_quotes(table) not in self.query_tables:
 					raise frappe.PermissionError(doctype)
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -17,7 +17,7 @@ import frappe.share
 from frappe import _
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
 from frappe.database.utils import DefaultOrderBy, FallBackDateTimeStr, NestedSetHierarchy
-from frappe.model import get_permitted_fields, optional_fields
+from frappe.model import OPTIONAL_FIELDS, get_permitted_fields
 from frappe.model.meta import get_table_columns
 from frappe.model.utils import is_virtual_doctype
 from frappe.model.utils.user_settings import get_user_settings, update_user_settings
@@ -561,9 +561,9 @@ class DatabaseQuery:
 	def set_optional_columns(self):
 		"""Removes optional columns like `_user_tags`, `_comments` etc. if not in table"""
 
-		self.fields[:] = [f for f in self.fields if f not in optional_fields or f in self.columns]
+		self.fields[:] = [f for f in self.fields if f not in OPTIONAL_FIELDS or f in self.columns]
 		self.filters[:] = [
-			f for f in self.filters if f.fieldname not in optional_fields or f.fieldname in self.columns
+			f for f in self.filters if f.fieldname not in OPTIONAL_FIELDS or f.fieldname in self.columns
 		]
 
 	def build_conditions(self):
@@ -611,12 +611,15 @@ class DatabaseQuery:
 			return
 
 		asterisk_fields = []
-		permitted_fields = get_permitted_fields(
-			doctype=self.doctype,
-			parenttype=self.parent_doctype,
-			permission_type=self.permission_map.get(self.doctype),
-			ignore_virtual=True,
+		permitted_fields = set(
+			get_permitted_fields(
+				doctype=self.doctype,
+				parenttype=self.parent_doctype,
+				permission_type=self.permission_map.get(self.doctype),
+				ignore_virtual=True,
+			)
 		)
+		permitted_child_table_fields = {}
 
 		for i, field in enumerate(self.fields):
 			# field: 'count(distinct `tabPhoto`.name) as total_count'
@@ -634,35 +637,41 @@ class DatabaseQuery:
 				continue
 
 			# handle pseudo columns
-			elif not column or column.isnumeric():
+			if not column or column.isnumeric():
 				continue
 
 			# labels / pseudo columns or frappe internals
-			elif column[0] in {"'", '"'} or column in optional_fields:
+			if column[0] in {"'", '"'}:
 				continue
 
-			# handle child / joined table fields
-			elif "." in field:
+			if "." in column:
 				table, column = column.split(".", 1)
-				ch_doctype = table
+				doctype = self.linked_table_aliases[table] if table in self.linked_table_aliases else table
+				doctype = doctype.replace("`", "").replace("tab", "", 1)
+			else:
+				doctype = self.doctype
 
-				if ch_doctype in self.linked_table_aliases:
-					ch_doctype = self.linked_table_aliases[ch_doctype]
+			# handle child / joined table fields
+			if doctype != self.doctype:
+				if wrap_grave_quotes(table) not in self.query_tables:
+					raise frappe.PermissionError(doctype)
 
-				ch_doctype = ch_doctype.replace("`", "").replace("tab", "", 1)
-
-				if wrap_grave_quotes(table) in self.query_tables:
-					permitted_child_table_fields = get_permitted_fields(
-						doctype=ch_doctype, parenttype=self.doctype, ignore_virtual=True
+				if doctype not in permitted_child_table_fields:
+					permitted_child_table_fields[doctype] = set(
+						get_permitted_fields(
+							doctype=doctype,
+							parenttype=self.doctype,
+							ignore_virtual=True,
+						)
 					)
-					if column in permitted_child_table_fields or column in optional_fields:
-						continue
-					else:
-						self.remove_field(i)
-				else:
-					raise frappe.PermissionError(ch_doctype)
 
-			elif column in permitted_fields:
+				if column in permitted_child_table_fields[doctype] or column in OPTIONAL_FIELDS:
+					continue
+
+				self.remove_field(i)
+				continue
+
+			if column in OPTIONAL_FIELDS or column in permitted_fields:
 				continue
 
 			# field inside function calls / * handles things like count(*)

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -27,10 +27,10 @@ import click
 import frappe
 from frappe import _, _lt
 from frappe.model import (
+	NO_VALUE_FIELDS,
 	child_table_fields,
 	data_fieldtypes,
 	default_fields,
-	no_value_fields,
 	optional_fields,
 	table_fields,
 )
@@ -266,7 +266,7 @@ class Meta(Document):
 
 	def get_global_search_fields(self):
 		"""Return list of fields with `in_global_search` set and `name` if set."""
-		fields = self.get("fields", {"in_global_search": 1, "fieldtype": ["not in", no_value_fields]})
+		fields = self.get("fields", {"in_global_search": 1, "fieldtype": ["not in", NO_VALUE_FIELDS]})
 		if getattr(self, "show_name_in_global_search", None):
 			fields.append(frappe._dict(fieldtype="Data", fieldname="name", label="Name"))
 
@@ -284,7 +284,7 @@ class Meta(Document):
 			valid_columns = self.default_fields + [
 				df.fieldname
 				for df in self.get("fields")
-				if not df.get("is_virtual") and df.fieldtype in data_fieldtypes
+				if not getattr(df, "is_virtual", False) and df.fieldtype in data_fieldtypes
 			]
 			if self.istable:
 				valid_columns += list(child_table_fields)
@@ -360,7 +360,7 @@ class Meta(Document):
 			link_fields = [df.fieldname for df in self.get_link_fields()]
 
 		for df in self.fields:
-			if df.fieldtype not in no_value_fields and getattr(df, "fetch_from", None):
+			if df.fieldtype not in NO_VALUE_FIELDS and getattr(df, "fetch_from", None):
 				if link_fieldname:
 					if df.fetch_from.startswith(link_fieldname + "."):
 						out.append(df)
@@ -635,10 +635,9 @@ class Meta(Document):
 				self.permissions = [Document(d) for d in custom_perms]
 
 	def get_fieldnames_with_value(self, with_field_meta=False, with_virtual_fields=False):
-		def is_value_field(docfield):
-			return not (
-				(not with_virtual_fields and docfield.get("is_virtual"))
-				or docfield.fieldtype in no_value_fields
+		def is_value_field(df):
+			return (df.fieldtype not in NO_VALUE_FIELDS) and (
+				with_virtual_fields or not getattr(df, "is_virtual", False)
 			)
 
 		if with_field_meta:
@@ -715,7 +714,7 @@ class Meta(Document):
 
 	def get_permlevel_access(self, permission_type="read", parenttype=None, *, user=None):
 		has_access_to = []
-		roles = frappe.get_roles(user)
+		roles = set(frappe.get_roles(user))
 		for perm in self.get_permissions(parenttype):
 			if perm.role in roles and perm.get(permission_type):
 				if perm.permlevel not in has_access_to:


### PR DESCRIPTION
In the Sales Invoice List View:

- `prepare_args` used to take more than 90% of time, actual query taking only around 9%

    ![image](https://github.com/user-attachments/assets/2de5d976-ef8c-4475-abac-103eab457e2a)

- of this, `apply_fieldlevel_read_permissions` used to take more than 90%

    ![image](https://github.com/user-attachments/assets/8edaafbb-e99a-4464-95c2-757cf8bd06f2)

- This was the payload:
    
    ```py
    {'doctype': 'Sales Invoice', 'fields': '["`tabSales Invoice`.`name`","`tabSales Invoice`.`owner`","`tabSales Invoice`.`creation`","`tabSales Invoice`.`modified`","`tabSales Invoice`.`modified_by`","`tabSales Invoice`.`_user_tags`","`tabSales Invoice`.`_comments`","`tabSales Invoice`.`_assign`","`tabSales Invoice`.`_liked_by`","`tabSales Invoice`.`docstatus`","`tabSales Invoice`.`idx`","`tabSales Invoice`.`total`","`tabSales Invoice`.`net_total`","`tabSales Invoice`.`total_taxes_and_charges`","`tabSales Invoice`.`grand_total`","`tabSales Invoice`.`rounding_adjustment`","`tabSales Invoice`.`rounded_total`","`tabSales Invoice`.`total_advance`","`tabSales Invoice`.`outstanding_amount`","`tabSales Invoice`.`discount_amount`","`tabSales Invoice`.`total_billing_amount`","`tabSales Invoice`.`paid_amount`","`tabSales Invoice`.`change_amount`","`tabSales Invoice`.`write_off_amount`","`tabSales Invoice`.`status`","`tabSales Invoice`.`customer_name`","`tabSales Invoice`.`customer`","`tabSales Invoice`.`base_grand_total`","`tabSales Invoice`.`due_date`","`tabSales Invoice`.`company`","`tabSales Invoice`.`currency`","`tabSales Invoice`.`is_return`","`tabSales Invoice`.`_seen`","`tabSales Invoice`.`party_account_currency`"]', 'filters': '[]', 'order_by': '`tabSales Invoice`.creation desc', 'start': '0', 'page_length': '20', 'view': 'List', 'group_by': '', 'with_comment_count': '1', 'cmd': 'frappe.desk.reportview.get'}
    ```
    
    It had 35 fields from the `Sales Invoice` doctype, all containing "dot".
- all fields containing dot were assumed to be child fields, with `get_permitted_fields` being called for each 😄 
- this led to O(n) + 1 (base) calls to an expensive function

This PR fixes that logic and makes some common sense constants and sets for quicker lookup.

#### Before

```py
In [39]: %timeit -n300 get()
3.88 ms ± 82.3 µs per loop (mean ± std. dev. of 7 runs, 300 loops each)
```

#### After

```py
In [45]: %timeit -n300 get()
867 µs ± 27.7 µs per loop (mean ± std. dev. of 7 runs, 300 loops each)
```