### PR TITLE
fix(user): make attachments in email signature public

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -889,7 +889,8 @@
    "link_fieldname": "user"
   }
  ],
- "modified": "2025-02-21 20:11:36.150167",
+ "make_attachments_public": 1,
+ "modified": "2025-03-17 11:29:39.254304",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",


### PR DESCRIPTION
Closes #31715, it's a signature so there shouldn't be much issue making the attachments public by default