### PR TITLE
fix: return 1 or 0 instead of boolean for `is_fc_site` boot data

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -188,7 +188,7 @@ def get_boot_data():
 		},
 		"assets_json": get_assets_json(),
 		"sitename": frappe.local.site,
-		"is_fc_site": is_fc_site(),
+		"is_fc_site": 1 if is_fc_site() else 0,
 	}
 
 


### PR DESCRIPTION
Sometimes the boolean value is returned without converting to a JS boolean value and can cause the below error


<img width="567" alt="Screenshot 2025-03-17 at 12 06 29 PM" src="https://github.com/user-attachments/assets/dd2f27c6-5bf4-4ef1-8371-71f8bca207fc" />

