### PR TITLE
fix: give priority to user setting on sorting

### DIFF
--- a/frappe/public/js/frappe/ui/sort_selector.js
+++ b/frappe/public/js/frappe/ui/sort_selector.js
@@ -103,13 +103,15 @@ frappe.ui.SortSelector = class SortSelector {
 
 		var { meta_sort_field, meta_sort_order } = this.get_meta_sort_field();
 
-		if (meta_sort_field) {
-			this.args.sort_by = meta_sort_field;
-			this.args.sort_order = meta_sort_order;
-		} else {
-			// default
-			this.args.sort_by = "creation";
-			this.args.sort_order = "desc";
+		if (!this.args.sort_by) {
+			if (meta_sort_field) {
+				this.args.sort_by = meta_sort_field;
+				this.args.sort_order = meta_sort_order;
+			} else {
+				// default
+				this.args.sort_by = "creation";
+				this.args.sort_order = "desc";
+			}
 		}
 
 		if (!this.args.sort_by_label) {


### PR DESCRIPTION
Support ticket: https://support.frappe.io/helpdesk/tickets/33972

It was giving priority to the doctype setting sorting option, but ideally, it should give priority to the user setting.