### PR TITLE
fix: compare lowercase keyword in global search

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -377,7 +377,7 @@ frappe.search.utils = {
 				var field_text = "";
 				for (var i = 0; i < parts.length; i++) {
 					var part = parts[i];
-					if (part.toLowerCase().indexOf(keywords) !== -1) {
+					if (part.toLowerCase().indexOf(keywords.toLowerCase()) !== -1) {
 						// If the field contains the keyword
 						let colon_index, field_value;
 						if (part.indexOf(" &&& ") !== -1) {


### PR DESCRIPTION
search part in global search is compared with keyword. first one is converted to lowercase, but keyword not - so this was only working with lowercase searches.