### PR TITLE
ci: fix permissions for "Auto-label PRs based on title"

### DIFF
--- a/.github/workflows/label-base-on-title.yml
+++ b/.github/workflows/label-base-on-title.yml
@@ -1,7 +1,7 @@
 name: "Auto-label PRs based on title"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 
 jobs:


### PR DESCRIPTION
> `pull_request_target` runs in the context of the target repository of the PR, rather than in the merge commit. This means the standard checkout action uses the target repository to prevent accidental usage of the user supplied code.
> These safeguards enable granting the `pull_request_target` additional permissions. The reason to introduce the `pull_request_target` trigger was to enable workflows to label PRs (e.g. `needs review`) or to comment on the PR. The intent is to use the trigger for PRs that do not require dangerous processing, say building or running the content of the PR.

https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

This should enable the labeler to run on PRs made from forks.