### PR TITLE
ci: configure language mapping for crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -7,3 +7,20 @@ pull_request_labels:
   - skip-release-notes
 commit_message: "fix: %language% translations"
 append_commit_message: false
+languages_mapping:
+  locale_with_underscore:
+    ar_SA: ar
+    bs_BA: bs
+    de_DE: de
+    eo_UY: eo
+    es_ES: es
+    fa_IR: fa
+    fr_FR: fr
+    hr_HR: hr
+    hu_HU: hu
+    pl_PL: pl
+    ru_RU: ru
+    sv_SE: sv
+    th_TH: th
+    tr_TR: tr
+    zh_CN: zh


### PR DESCRIPTION
We need to use `%locale_with_underscore%` for languages like Brazilian Portuguese. However, we use two-letter-codes for the main dialect (e. g. "de", not "de_DE"). Hence, we need to map the `locale_with_underscore` back to two-letter-codes for these languages. I think the other way around (e.g. mapping `pt` to `pt_BR`) doesn't make sense.

Ref: https://crowdin.github.io/crowdin-cli/advanced#languages-mapping-configuration