### PR TITLE
fix: "Undefined" shown in global search results

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -585,7 +585,10 @@ frappe.search.utils = {
 			return score;
 		}
 		if (score == 0) {
-			return { score, item };
+			return {
+				score: score,
+				marked_string: item,
+			};
 		}
 
 		// Create Boolean mask to mark matching indices in the item string


### PR DESCRIPTION
"Undefined" is visible on global search results:

![image](https://github.com/user-attachments/assets/3cbe017e-95f4-4236-8fc1-fc3bdcc32fdc)

This fix restores the original fieldnames:

![image](https://github.com/user-attachments/assets/4838a034-124a-4c42-bc18-186b274f451d)

This PR is the successor of #31773
