### PR TITLE
fix: Kanban view link draggable issue

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
@@ -590,6 +590,7 @@ frappe.provide("frappe.views");
 				animation: 150,
 				dataIdAttr: "data-name",
 				forceFallback: true,
+				fallbackTolerance: 20,
 				onStart: function () {
 					wrapper.find(".kanban-card.add-card").fadeOut(200, function () {
 						wrapper.find(".kanban-cards").height("100vh");


### PR DESCRIPTION
Support ticket: https://support.frappe.io/helpdesk/tickets/30749

Add a fallback tolerance of 20px to the drag element, so the card will only move after it has been dragged by 20px.