### PR TITLE
refactor: parse package metadata for attribution page

### DIFF
--- a/frappe/www/attribution.html
+++ b/frappe/www/attribution.html
@@ -45,18 +45,10 @@
                             </td>
                             <td class="type">{{ package.type }}</td>
                             <td class="license">
-                                {% if package.type == "Python" %}
-                                    {{ package.license or "Unknown" }}
-                                {% else %}
-                                    <i class="fa fa-spinner fa-spin"></i>
-                                {% endif %}
+                                {{ package.license or "Unknown" }}
                             </td>
                             <td class="author">
-                                {% if package.type == "Python" %}
-                                    {{ package.author or "Unknown" }}
-                                {% else %}
-                                    <i class="fa fa-spinner fa-spin"></i>
-                                {% endif %}
+                                {{ package.author or "Unknown" }}
                             </td>
                         </tr>
                         {% endfor %}
@@ -68,42 +60,5 @@
     </table>
 </section>
 {% endfor %}
-
-<script>
-    const tables = document.querySelectorAll('table.table-striped');
-    tables.forEach((table) => {
-        var package_cells = table.querySelectorAll('td.package');
-        package_cells.forEach((package_cell) => {
-            var name = package_cell.innerText;
-            var type_cell = package_cell.nextElementSibling;
-            var license_cell = type_cell.nextElementSibling;
-            var author_cell = license_cell.nextElementSibling;
-            if (type_cell.innerText === "JavaScript") {
-                get_info_from_npm(name).then((info) => {
-                    license_cell.innerText = info.license?.slice(0, 50);
-                    author_cell.innerText = info.author;
-                });
-            }
-        });
-    })
-
-    function get_info_from_npm(package) {
-        const registry_url = `https://registry.npmjs.org/${package}`;
-        return fetch(registry_url)
-            .then((response) => response.json())
-            .then((data) => {
-                return {
-                    license: (
-                        typeof data.license === "object" ? data.license.type : data.license
-                    ) || "Unknown",
-                    author: (
-                        data.author?.name ||
-                        data.maintainers?.map((c) => c.name).join(", ") ||
-                        "Unknown"
-                    )
-                }
-            });
-    }
-</script>
 
 {% endblock %}

--- a/frappe/www/attribution.html
+++ b/frappe/www/attribution.html
@@ -44,8 +44,20 @@
                                 {{ package.name | e }}
                             </td>
                             <td class="type">{{ package.type }}</td>
-                            <td class="license"><i class="fa fa-spinner fa-spin"></i></td>
-                            <td class="author"><i class="fa fa-spinner fa-spin"></i></td>
+                            <td class="license">
+                                {% if package.type == "Python" %}
+                                    {{ package.license or "Unknown" }}
+                                {% else %}
+                                    <i class="fa fa-spinner fa-spin"></i>
+                                {% endif %}
+                            </td>
+                            <td class="author">
+                                {% if package.type == "Python" %}
+                                    {{ package.author or "Unknown" }}
+                                {% else %}
+                                    <i class="fa fa-spinner fa-spin"></i>
+                                {% endif %}
+                            </td>
                         </tr>
                         {% endfor %}
                     </tbody>
@@ -72,12 +84,6 @@
                     author_cell.innerText = info.author;
                 });
             }
-            else if (type_cell.innerText === "Python") {
-                get_info_from_pypi(name).then((info) => {
-                    license_cell.innerText = info.license?.slice(0, 50);
-                    author_cell.innerText = info.author;
-                });
-            }
         });
     })
 
@@ -93,24 +99,6 @@
                     author: (
                         data.author?.name ||
                         data.maintainers?.map((c) => c.name).join(", ") ||
-                        "Unknown"
-                    )
-                }
-            });
-    }
-
-    function get_info_from_pypi(package) {
-        const registry_url = `https://pypi.org/pypi/${package}/json`;
-        return fetch(registry_url)
-            .then((response) => response.json())
-            .then((data) => {
-                return {
-                    license: data.info.license || "Unknown",
-                    author: (
-                        data.info.author ||
-                        data.info.maintainer ||
-                        data.info.author_email ||
-                        data.info.maintainer_email ||
                         "Unknown"
                     )
                 }

--- a/frappe/www/attribution.py
+++ b/frappe/www/attribution.py
@@ -2,6 +2,7 @@ import contextlib
 import importlib.metadata
 import json
 import re
+from functools import cache
 from pathlib import Path
 
 import tomli
@@ -24,6 +25,7 @@ def get_context(context):
 	context.apps = apps
 
 
+@cache
 def get_app_info(app: str):
 	app_info = get_pyproject_info(app)
 	result = {

--- a/frappe/www/attribution.py
+++ b/frappe/www/attribution.py
@@ -2,7 +2,6 @@ import contextlib
 import importlib.metadata
 import json
 import re
-from functools import cache
 from pathlib import Path
 
 import tomli
@@ -25,7 +24,6 @@ def get_context(context):
 	context.apps = apps
 
 
-@cache
 def get_app_info(app: str):
 	app_info = get_pyproject_info(app)
 	result = {

--- a/frappe/www/attribution.py
+++ b/frappe/www/attribution.py
@@ -1,3 +1,4 @@
+import contextlib
 import importlib.metadata
 import json
 import re
@@ -79,13 +80,52 @@ def parse_classifiers(classifiers: list[str]) -> str | None:
 def get_js_deps(app: str) -> list[dict]:
 	package_json = Path(frappe.get_app_path(app, "..", "package.json"))
 	if not package_json.exists():
-		return {}
+		return []
 
 	with open(package_json) as f:
 		package = json.load(f)
 
 	packages = package.get("dependencies", {}).keys()
-	return [{"name": name, "type": "JavaScript"} for name in packages]
+	result = []
+
+	# Get the node_modules directory
+	node_modules_path = Path(frappe.get_app_path(app, "..", "node_modules"))
+
+	for name in packages:
+		# Initialize with basic info
+		package_info = {"name": name, "type": "JavaScript", "license": "Unknown", "author": "Unknown"}
+
+		# Try to find package.json in node_modules
+		package_json_path = node_modules_path / name / "package.json"
+		if package_json_path.exists():
+			pkg_data = None
+			with contextlib.suppress(json.JSONDecodeError):
+				pkg_data = json.loads(package_json_path.read_text())
+			if not pkg_data:
+				continue
+
+			# Extract license info
+			license_info = pkg_data.get("license")
+			if isinstance(license_info, dict):
+				license_info = license_info.get("type")
+
+			if license_info:
+				package_info["license"] = license_info
+
+			# Extract author info
+			author = pkg_data.get("author")
+			if isinstance(author, dict):
+				author = author.get("name")
+			if not author:
+				maintainers = pkg_data.get("maintainers", [])
+				if maintainers:
+					author = ", ".join([m for m in maintainers if m])
+			if author:
+				package_info["author"] = author
+
+		result.append(package_info)
+
+	return result
 
 
 def get_pyproject_info(app: str) -> dict:

--- a/frappe/www/attribution.py
+++ b/frappe/www/attribution.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import json
 import re
 from pathlib import Path
@@ -33,11 +34,46 @@ def get_app_info(app: str):
 
 	for requirement in app_info.get("dependencies", []):
 		name = parse_pip_requirement(requirement)
-		result["dependencies"].append({"name": name, "type": "Python"})
+		metadata = get_python_package_metadata(name)
+		result["dependencies"].append(
+			{"name": name, "type": "Python", "license": metadata["license"], "author": metadata["author"]}
+		)
 
 	result["dependencies"].extend(get_js_deps(app))
 
 	return result
+
+
+def get_python_package_metadata(package_name: str) -> dict:
+	"""Get metadata for a Python package using importlib.metadata"""
+	try:
+		metadata = importlib.metadata.metadata(package_name)
+		return {
+			"license": (
+				metadata.get("License-Expression")
+				or parse_classifiers(metadata.get_all("Classifier", []))
+				or metadata.get("License")  # May contain a full license text, less preferred
+				or "Unknown"
+			),
+			"author": (
+				metadata.get("Author")
+				or metadata.get("Maintainer")
+				or metadata.get("Author-email")
+				or metadata.get("Maintainer-email")
+				or "Unknown"
+			),
+		}
+	except importlib.metadata.PackageNotFoundError:
+		return {"license": "Unknown", "author": "Unknown"}
+
+
+def parse_classifiers(classifiers: list[str]) -> str | None:
+	"""Parse classifiers to get the license"""
+	for classifier in classifiers:
+		if classifier.startswith("License ::"):
+			return classifier.split("::")[-1].strip()
+
+	return None
 
 
 def get_js_deps(app: str) -> list[dict]:


### PR DESCRIPTION
Parse local package metadata instead of requesting it from pypi / npmjs.

Resolves https://github.com/frappe/frappe/issues/31770
