### PR TITLE
fix: prevent layout shifts due to scrollbar

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -64,7 +64,9 @@ body {
 	overflow: scroll;
 	overflow-x: hidden;
 	overflow-y: visible;
+	scrollbar-gutter: stable;
 }
+
 .body-sidebar-container {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
### Before

Layout shifts when changing between a workspace with scrollbar and a workspace without scrollbar.

https://github.com/user-attachments/assets/c5159b64-1060-44a3-9748-3d72777a7258


### After

Layout stays fixed.

https://github.com/user-attachments/assets/7b4d8e41-fb29-4b48-a224-d80fcc1cbc13

