### PR TITLE
fix: prevent layout shifts due to scrollbar (backport #31793)

### DIFF
--- a/frappe/public/scss/desk/scrollbar.scss
+++ b/frappe/public/scss/desk/scrollbar.scss
@@ -6,6 +6,7 @@
 
 html {
 	scrollbar-width: auto;
+	scrollbar-gutter: stable;
 }
 
 /* Works on Chrome, Edge, and Safari */


### PR DESCRIPTION
### Before

Layout shifts when changing between a view with scrollbar and a view without scrollbar.

https://github.com/user-attachments/assets/3ec12193-9396-4fb1-acbb-7db48a269303

(few item templates, don't need a scrollbar; many regular items)

### After

Layout stays fixed.

https://github.com/user-attachments/assets/6b5f82e1-576e-4f49-88dc-a10790b7391c
