### PR TITLE
fix: Set pointer-events to none on frappe-control highlight pseudo element

### DIFF
--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -662,6 +662,7 @@ details > summary:focus {
 		bottom: var(--wrap-padding);
 		left: var(--wrap-padding);
 		right: var(--wrap-padding);
+		pointer-events: none;
 	}
 }
 


### PR DESCRIPTION
Closes #31817