### PR TITLE
perf: pre-create `UnionType` objects

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 	from frappe.model.document import Document
 
 D = TypeVar("D", bound="Document")
+DatetimeTypes = datetime.date | datetime.datetime | datetime.time | datetime.timedelta
 
 
 max_positive_value = {"smallint": 2**15 - 1, "int": 2**31 - 1, "bigint": 2**63 - 1}
@@ -460,9 +461,7 @@ class BaseDocument:
 				):
 					value = None
 
-			if convert_dates_to_str and isinstance(
-				value, datetime.datetime | datetime.date | datetime.time | datetime.timedelta
-			):
+			if convert_dates_to_str and isinstance(value, DatetimeTypes):
 				value = str(value)
 
 			if ignore_nulls and not is_virtual_field and value is None:

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -8,7 +8,9 @@ import mimetypes
 import os
 import sys
 import uuid
+from collections.abc import Iterable
 from pathlib import Path
+from re import Match
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
@@ -29,7 +31,8 @@ from frappe.utils.local import LocalProxy, WerkzeugLocalProxy
 if TYPE_CHECKING:
 	from frappe.core.doctype.file.file import File
 
-LocalProxyType = LocalProxy | WerkzeugLocalProxy
+LocalProxyTypes = LocalProxy | WerkzeugLocalProxy
+DateOrTimeTypes = datetime.date | datetime.datetime | datetime.time
 
 
 def report_error(status_code):
@@ -212,19 +215,14 @@ def _make_logs_v2():
 
 def json_handler(obj):
 	"""serialize non-serializable data for json"""
-	from collections.abc import Iterable
-	from re import Match
 
-	if isinstance(obj, datetime.date | datetime.datetime | datetime.time):
+	if isinstance(obj, DateOrTimeTypes):
 		return str(obj)
 
 	elif isinstance(obj, datetime.timedelta):
 		return format_timedelta(obj)
 
-	elif isinstance(obj, decimal.Decimal):
-		return float(obj)
-
-	elif isinstance(obj, LocalProxyType):
+	elif isinstance(obj, LocalProxyTypes):
 		return str(obj)
 
 	elif hasattr(obj, "__json__"):
@@ -232,6 +230,9 @@ def json_handler(obj):
 
 	elif isinstance(obj, Iterable):
 		return list(obj)
+
+	elif isinstance(obj, decimal.Decimal):
+		return float(obj)
 
 	elif isinstance(obj, Match):
 		return obj.string


### PR DESCRIPTION
This is apparently expensive in functions called repeatedly.

### Before

```py
In [8]: %timeit dic = d.as_dict(convert_dates_to_str=True)
1.18 ms ± 13 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [11]: %timeit json.dumps(dic, default=json_handler, separators=(",", ":"))
378 µs ± 924 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

### After

```py
In [7]: %timeit dic = d.as_dict(convert_dates_to_str=True)
740 µs ± 14.4 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [12]: %timeit json.dumps(dic, default=json_handler, separators=(",", ":"))
316 µs ± 8 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```