### PR TITLE
fix: make arrows left in widgets in rtl languages 

### DIFF
--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -158,10 +158,11 @@ export default class QuickListWidget extends Widget {
 				</div>
 			`).appendTo($quick_list_item);
 		}
-
-		$(`<div class="right-arrow">${frappe.utils.icon("right", "xs")}</div>`).appendTo(
-			$quick_list_item
-		);
+		let icon_to_append = `<div class="right-arrow">${frappe.utils.icon("right", "xs")}</div>`;
+		if (frappe.utils.is_rtl(frappe.boot.lang)) {
+			icon_to_append = `<div class="left-arrow">${frappe.utils.icon("left", "xs")}</div>`;
+		}
+		$(icon_to_append).appendTo($quick_list_item);
 
 		$quick_list_item.click((e) => {
 			if (e.ctrlKey || e.metaKey) {

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -59,10 +59,11 @@ export default class ShortcutWidget extends Widget {
 
 	set_actions() {
 		if (this.in_customize_mode) return;
-
-		$(frappe.utils.icon("es-line-arrow-up-right", "xs", "", "", "ml-2")).appendTo(
-			this.action_area
-		);
+		let icon_to_append = frappe.utils.icon("es-line-arrow-up-right", "xs", "", "", "ml-2");
+		if (frappe.utils.is_rtl(frappe.boot.lang)) {
+			icon_to_append = frappe.utils.icon("es-line-arrow-up-left", "xs", "", "", "ml-2");
+		}
+		$(icon_to_append).appendTo(this.action_area);
 
 		this.widget.addClass("shortcut-widget-box");
 


### PR DESCRIPTION
Reference ticket: https://support.frappe.io/helpdesk/tickets/34045