### PR TITLE
fix: show full description of link selector

### DIFF
--- a/frappe/public/js/frappe/form/link_selector.js
+++ b/frappe/public/js/frappe/form/link_selector.js
@@ -99,7 +99,7 @@ frappe.ui.form.LinkSelector = class LinkSelector {
 								'<div class="row link-select-row">\
 						<div class="col-xs-4 ellipsis">\
 							<b><a href="#">%(name)s</a></b></div>\
-						<div class="col-xs-8 ellipsis">\
+						<div class="col-xs-8">\
 							<span class="text-muted">%(values)s</span></div>\
 						</div>',
 								{


### PR DESCRIPTION
Support ticket: https://support.frappe.io/helpdesk/tickets/34188

- Before
![image](https://github.com/user-attachments/assets/c396a853-0427-46b2-98b6-cf774d4351e3)


- After
![image](https://github.com/user-attachments/assets/f86cf7f8-09b7-40f2-8a74-08ab2b29c077)
