### PR TITLE
fix: revert to simpler LocalProxy override

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -16,6 +16,7 @@ from urllib.parse import quote
 
 import werkzeug.utils
 from werkzeug.exceptions import Forbidden, NotFound
+from werkzeug.local import LocalProxy
 from werkzeug.wrappers import Response
 from werkzeug.wsgi import wrap_file
 
@@ -26,12 +27,10 @@ import frappe.utils
 from frappe import _
 from frappe.core.doctype.access_log.access_log import make_access_log
 from frappe.utils import format_timedelta
-from frappe.utils.local import LocalProxy, WerkzeugLocalProxy
 
 if TYPE_CHECKING:
 	from frappe.core.doctype.file.file import File
 
-LocalProxyTypes = LocalProxy | WerkzeugLocalProxy
 DateOrTimeTypes = datetime.date | datetime.datetime | datetime.time
 
 
@@ -222,7 +221,7 @@ def json_handler(obj):
 	elif isinstance(obj, datetime.timedelta):
 		return format_timedelta(obj)
 
-	elif isinstance(obj, LocalProxyTypes):
+	elif isinstance(obj, LocalProxy):
 		return str(obj)
 
 	elif hasattr(obj, "__json__"):


### PR DESCRIPTION
I've been on Python3.11 for a long time. Didn't know it had [this issue](https://github.com/python/cpython/issues/102213).

Today, I moved to Python3.13 and realized that I've been trying to solve a problem that doesn't exist in newer Python versions.

`__getattr__` isn't expensive at all anymore. To compare, `frappe._dict.__getattr__` was 86% faster on Python3.13 on my local machine.

So I am reverting to a simpler, more maintainable `LocalProxy` implementation - which is faster on Python3.13. I am keeping the `Local` implementation as-is because we don't need nested contexts that werkzeug has to provision for.

---

TL;DR: Always use the latest Python version for development.