### PR TITLE
fix(socketio): pass auth token if available instead of cookie

### DIFF
--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -32,7 +32,7 @@ function authenticate_with_frappe(socket, next) {
 	}
 
 	let auth_req = request.get(get_url(socket, "/api/method/frappe.realtime.get_user_info"));
-	if (authorization_header){
+	if (authorization_header) {
 		auth_req = auth_req.set("Authorization", authorization_header);
 	} else if (cookies.sid) {
 		auth_req = auth_req.query({ sid: cookies.sid });

--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -32,10 +32,10 @@ function authenticate_with_frappe(socket, next) {
 	}
 
 	let auth_req = request.get(get_url(socket, "/api/method/frappe.realtime.get_user_info"));
-	if (cookies.sid) {
-		auth_req = auth_req.query({ sid: cookies.sid });
-	} else {
+	if (authorization_header){
 		auth_req = auth_req.set("Authorization", authorization_header);
+	} else if (cookies.sid) {
+		auth_req = auth_req.query({ sid: cookies.sid });
 	}
 
 	auth_req


### PR DESCRIPTION
This is the same as #26766, but ported to version-15.

---

For mobile apps, the cookie sent for a Socket connection has the SID as "Guest". Even though an Authorization token was sent, since the cookie SID was "Guest", it was used for the request.

This PR changes the order of application of headers to the request in authenticate.js. If an auth token is passed, send that in the header, else send the cookie SID.