### PR TITLE
fix(realtime): fetch user_type if not available in session data

### DIFF
--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -121,9 +121,13 @@ def has_permission(doctype: str, name: str) -> bool:
 
 @frappe.whitelist(allow_guest=True)
 def get_user_info():
+	user_type = frappe.session.data.user_type
+	# For requests with Bearer tokens, user_type is not set in the session data
+	if not user_type:
+		user_type = frappe.get_cached_value("User", frappe.session.user, "user_type")
 	return {
 		"user": frappe.session.user,
-		"user_type": frappe.session.data.user_type,
+		"user_type": user_type,
 		"installed_apps": frappe.get_installed_apps(),
 	}
 


### PR DESCRIPTION
When authenticating via tokens, realtime events did not work on the site room since the user_type was not set in session data. This PR explicitly fetches the user_type if not available.

Closes #31862 