### PR TITLE
fix: configure if email is sent to creator

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -299,7 +299,8 @@ def get_users_next_action_data(transitions, doc):
 		filtered_users = [
 			user for user in users if has_approval_access(user, doc, transition) and user_has_permission(user)
 		]
-
+		if doc.get("owner") and not transition.get("send_email_to_creator"):
+			filtered_users.remove(doc.get("owner"))
 		for user in filtered_users:
 			if not user_data_map.get(user):
 				user_data_map[user] = frappe._dict(

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -299,7 +299,7 @@ def get_users_next_action_data(transitions, doc):
 		filtered_users = [
 			user for user in users if has_approval_access(user, doc, transition) and user_has_permission(user)
 		]
-		if doc.get("owner") and not transition.get("send_email_to_creator"):
+		if doc.get("owner") in filtered_users and not transition.get("send_email_to_creator"):
 			filtered_users.remove(doc.get("owner"))
 		for user in filtered_users:
 			if not user_data_map.get(user):

--- a/frappe/workflow/doctype/workflow_transition/workflow_transition.json
+++ b/frappe/workflow/doctype/workflow_transition/workflow_transition.json
@@ -94,7 +94,7 @@
    "label": "Workflow Builder ID"
   },
   {
-   "default": "1",
+   "default": "0",
    "depends_on": "eval: doc.allow_self_approval == 1",
    "fieldname": "send_email_to_creator",
    "fieldtype": "Check",
@@ -110,7 +110,6 @@
  "name": "Workflow Transition",
  "owner": "Administrator",
  "permissions": [],
- "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/frappe/workflow/doctype/workflow_transition/workflow_transition.json
+++ b/frappe/workflow/doctype/workflow_transition/workflow_transition.json
@@ -95,7 +95,7 @@
   },
   {
    "default": "1",
-   "depends_on": "eval: doc.allow_self_approval === \"1\"",
+   "depends_on": "eval: doc.allow_self_approval == 1",
    "fieldname": "send_email_to_creator",
    "fieldtype": "Check",
    "label": "Send Email To Creator"
@@ -104,7 +104,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-24 02:03:23.926703",
+ "modified": "2025-03-24 02:47:44.188152",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Transition",

--- a/frappe/workflow/doctype/workflow_transition/workflow_transition.json
+++ b/frappe/workflow/doctype/workflow_transition/workflow_transition.json
@@ -11,6 +11,7 @@
   "next_state",
   "allowed",
   "allow_self_approval",
+  "send_email_to_creator",
   "conditions",
   "condition",
   "column_break_7",
@@ -91,17 +92,25 @@
    "fieldtype": "Data",
    "hidden": 1,
    "label": "Workflow Builder ID"
+  },
+  {
+   "default": "1",
+   "depends_on": "eval: doc.allow_self_approval === \"1\"",
+   "fieldname": "send_email_to_creator",
+   "fieldtype": "Check",
+   "label": "Send Email To Creator"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-23 16:04:05.493534",
+ "modified": "2025-03-24 02:03:23.926703",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Transition",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/frappe/workflow/doctype/workflow_transition/workflow_transition.py
+++ b/frappe/workflow/doctype/workflow_transition/workflow_transition.py
@@ -22,6 +22,7 @@ class WorkflowTransition(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		send_email_to_creator: DF.Check
 		state: DF.Link
 		workflow_builder_id: DF.Data | None
 	# end: auto-generated types


### PR DESCRIPTION
Reference ticket https://support.frappe.io/helpdesk/tickets/34460
When transition in workflow has self approval allowed , it sends email to creator by default made it configurable 