### PR TITLE
fix(email): Fix sender and recipients decoding

### DIFF
--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -127,7 +127,7 @@ class EMail:
 			recipients = split_emails(recipients)
 
 		# remove null
-		recipients = filter(None, (strip(r) for r in recipients))
+		recipients = list(filter(None, (strip(r) for r in recipients)))
 
 		self.sender = sender
 		self.reply_to = reply_to or sender

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -127,7 +127,7 @@ class EMail:
 			recipients = split_emails(recipients)
 
 		# remove null
-		recipients = list(filter(None, (strip(r) for r in recipients)))
+		recipients = [r for r in (strip(r) for r in recipients) if r]
 
 		self.sender = sender
 		self.reply_to = reply_to or sender

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -448,7 +448,7 @@ class Email:
 	def decode_email(email: bytes | str | None) -> str | None:
 		if not email:
 			return
-		email = frappe.as_unicode(email).replace('"', " ").replace("'", " ")
+		email = frappe.as_unicode(email)
 		try:
 			parts = decode_header(email)
 		except HeaderParseError:
@@ -899,8 +899,8 @@ class InboundMail(Email):
 			"sent_or_received": "Received",
 			"sender_full_name": self.from_real_name,
 			"sender": self.from_email,
-			"recipients": self.mail.get("To"),
-			"cc": self.mail.get("CC"),
+			"recipients": self.decode_email(self.mail.get("To") or ""),
+			"cc": self.decode_email(self.mail.get("CC") or ""),
 			"email_account": self.email_account.name,
 			"communication_medium": "Email",
 			"uid": self.uid,


### PR DESCRIPTION
Email recipients are not decoded at all, making the `recipients` field in Communication pretty much useless in some cases:

![](https://github.com/user-attachments/assets/ac1b0a1b-aa16-4168-8738-9339e9283257)

---

# Changes

- fix handling of email address inside of the sender name
  `To: "fail@example.com" <success@example.com>`
- decode CC email header
- decode Recipients email header
- fix handling of escaped quote characters `"` inside of the sender name
  `To: "\"fail@example.com\" via ABC" <success@example.com>`
  What happened before: invalid result because there is no way to differentiate 
  ![](https://github.com/user-attachments/assets/ab1dff78-e122-4222-8d62-0541d138efe9)
  What happens now: quoted result remains quoted
  ![](https://github.com/user-attachments/assets/a1e80933-2cc9-4a58-ba43-3bdce23a19fb)
  I'm open to suggestions on this point because I'm not sure what the correct handling should be: drop all quotes?

---

See test cases for more information.