### PR TITLE
fix: pass `ignore_user_permissions` flag to search query methods

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -101,6 +101,7 @@ def search_widget(
 				filters,
 				as_dict=as_dict,
 				reference_doctype=reference_doctype,
+				ignore_user_permissions=ignore_user_permissions,
 			)
 		except (frappe.PermissionError, frappe.AppNotInstalledError, ImportError):
 			if frappe.local.conf.developer_mode:


### PR DESCRIPTION
`ignore_user_permissions` is set from the field property and it can't be used in custom queries.