### PR TITLE
ci: invert language mapping

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -5,6 +5,8 @@ pull_request_title: "fix: sync translations from crowdin"
 pull_request_labels:
   - translation
   - skip-release-notes
+pull_request_reviewers:
+  - barredterra # change to your GitHub username if you copied this file
 commit_message: "fix: %language% translations"
 append_commit_message: false
 languages_mapping:

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,6 @@
 files:
   - source: /frappe/locale/main.pot
-    translation: /frappe/locale/%locale_with_underscore%.po
+    translation: /frappe/locale/%two_letters_code%.po
 pull_request_title: "fix: sync translations from crowdin"
 pull_request_labels:
   - translation
@@ -8,19 +8,5 @@ pull_request_labels:
 commit_message: "fix: %language% translations"
 append_commit_message: false
 languages_mapping:
-  locale_with_underscore:
-    ar: ar
-    bs: bs
-    de: de
-    eo: eo
-    es-ES: es
-    fa: fa
-    fr: fr
-    hr: hr
-    hu: hu
-    pl: pl
-    ru: ru
-    sv-SE: sv
-    th: th
-    tr: tr
-    zh-CN: zh
+  two_letters_code:
+    pt-BR: pt_BR


### PR DESCRIPTION
My premise in #31778 was wrong:

> I think the other way around (e.g. mapping pt to pt_BR) doesn't make sense.

The key is supposed to be crowdin's internal language code. This means we can simplify the mapping to list only the exceptions.