### PR TITLE
Allow to manually send an email even if queue is disabled

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.js
+++ b/frappe/email/doctype/email_queue/email_queue.js
@@ -14,10 +14,21 @@ frappe.ui.form.on("Email Queue", {
 					callback: function () {
 						frm.reload_doc();
 						if (cint(frappe.sys_defaults.suspend_email_queue)) {
-							frappe.show_alert(
+							// Dialog to confirm if user wants to resume sending emails
+							frappe.confirm(
 								__(
-									"Email queue is currently suspended. Resume to automatically send emails."
-								)
+									"Email Queue is suspended. Do you want to send this email anyway?"
+								),
+								function () {
+									frappe.call({
+										method:
+											"frappe.email.doctype.email_queue.email_queue.send_now",
+										args: {
+											name: frm.doc.name,
+											force_send: true
+										},
+									});
+								}
 							);
 						}
 					},

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -156,9 +156,9 @@ class EmailQueue(Document):
 
 		return True
 
-	def send(self, smtp_server_instance: SMTPServer = None, frappe_mail_client: FrappeMail = None):
+	def send(self, smtp_server_instance: SMTPServer = None, frappe_mail_client: FrappeMail = None, force_send = False):
 		"""Send emails to recipients."""
-		if not self.can_send_now():
+		if not self.can_send_now() and not force_send:
 			return
 
 		with SendMailContext(self, smtp_server_instance, frappe_mail_client) as ctx:
@@ -423,7 +423,6 @@ class SendMailContext:
 		file.content = content
 		file.insert()
 
-
 @frappe.whitelist()
 def retry_sending(queues: str | list[str]):
 	if not frappe.has_permission("Email Queue", throw=True):
@@ -444,11 +443,11 @@ def retry_sending(queues: str | list[str]):
 
 
 @frappe.whitelist()
-def send_now(name):
+def send_now(name, force_send=False):
 	record = EmailQueue.find(name)
 	if record:
 		record.check_permission()
-		record.send()
+		record.send(force_send = force_send)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
This allows manual sending of selected emails even if the Queue itself is disabled.

Backport to v15.
