### PR TITLE
fix(minor): improvements to sidebar

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar.js
@@ -48,7 +48,12 @@ frappe.ui.Sidebar = class Sidebar {
 		this.$sidebar = this.wrapper.find(".sidebar-items");
 
 		this.wrapper.find(".body-sidebar .collapse-sidebar-link").on("click", () => {
+			if (frappe.is_mobile()) this.apps_switcher.app_switcher_menu.toggleClass("hidden");
 			this.toggle_sidebar();
+		});
+
+		this.wrapper.find(".overlay").on("click", () => {
+			this.close_sidebar();
 		});
 
 		this.apps_switcher = new frappe.ui.AppsSwitcher(this);

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -126,8 +126,6 @@ body {
 
 	.sidebar-items {
 		width: 224px;
-		padding-left: 1px;
-		padding-right: 1px;
 		width: 100%;
 	}
 


### PR DESCRIPTION
This PR removes slight jitter from sidebar items when it collapses/expands 
On Mobile click outside to close the sidebar