### PR TITLE
refactor(minor): Backups Page

### DIFF
--- a/frappe/desk/doctype/system_health_report/system_health_report.py
+++ b/frappe/desk/doctype/system_health_report/system_health_report.py
@@ -299,7 +299,7 @@ class SystemHealthReport(Document):
 		self.backups_size = get_directory_size("private", "backups") / (1024 * 1024)
 		self.private_files_size = get_directory_size("private", "files") / (1024 * 1024)
 		self.public_files_size = get_directory_size("public", "files") / (1024 * 1024)
-		self.onsite_backups = len(get_context({}).get("files", []))
+		self.onsite_backups = len(get_context(frappe._dict()).get("files", []))
 
 	@health_check("Users")
 	def fetch_user_stats(self):

--- a/frappe/desk/page/backups/backups.js
+++ b/frappe/desk/page/backups/backups.js
@@ -6,7 +6,9 @@ frappe.pages["backups"].on_page_load = function (wrapper) {
 	});
 
 	page.add_inner_button(__("Set Number of Backups"), function () {
-		frappe.set_route("Form", "System Settings");
+		frappe.set_route("Form", "System Settings").then(() => {
+			cur_frm.scroll_to_field("backup_limit");
+		});
 	});
 
 	page.add_inner_button(__("Download Files Backup"), function () {


### PR DESCRIPTION
 - Don't cache page as it shows outdated backups in the list
 - Check for backups to retain properly by bundling them by "backup" rather than individual files
 - Use cached system settings & new Path library to de-noise
 - Optimize hourly job that deletes > limit_backup num of files

