### PR TITLE
fix(doctype): Dont reset owner in developer_mode

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -336,7 +336,7 @@ class DocType(Document):
 		if self.is_virtual and self.custom:
 			frappe.throw(_("Not allowed to create custom Virtual DocType."), CannotCreateStandardDoctypeError)
 
-		if frappe.conf.get("developer_mode"):
+		if frappe.conf.developer_mode and not self.owner:
 			self.owner = "Administrator"
 			self.modified_by = "Administrator"
 


### PR DESCRIPTION
If owner is set, this flow will lead to validate_set_only_once raising error.

**Use case:** Custom DocType created on a production site, then gets complex
enough to be moved into an App. This error pops up in developer mode.