### PR TITLE
feat: add in support for `_inplacevar_`

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -12,6 +12,7 @@ from types import FunctionType, MethodType, ModuleType
 from typing import TYPE_CHECKING, Any
 
 import RestrictedPython.Guards
+from AccessControl.ZopeGuards import protected_inplacevar
 from RestrictedPython import PrintCollector, compile_restricted, safe_globals
 from RestrictedPython.transformer import RestrictingNodeTransformer
 
@@ -313,6 +314,7 @@ def get_safe_globals():
 	# allow iterators and list comprehension
 	out._getiter_ = iter
 	out._iter_unpack_sequence_ = RestrictedPython.Guards.guarded_iter_unpack_sequence
+	out._inplacevar_ = protected_inplacevar
 
 	# add common python builtins
 	out.update(get_python_builtins())
@@ -727,4 +729,5 @@ WHITELISTED_SAFE_EVAL_GLOBALS = {
 	"_getitem_": _getitem,
 	"_getiter_": iter,
 	"_iter_unpack_sequence_": RestrictedPython.Guards.guarded_iter_unpack_sequence,
+	"_inplacevar_": protected_inplacevar,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "PyQRCode~=1.2.1",
     "PyYAML~=6.0.1",
     "RestrictedPython~=8.0",
+    "AccessControl~=7.2",
     "WeasyPrint==59.0",
     "pydyf==0.10.0",
     "Werkzeug==3.0.6",


### PR DESCRIPTION
Resolves #31913

<hr>

Allows usage of things like `a += b`

<hr>

Reference: https://github.com/zopefoundation/AccessControl/blob/7.2/src/AccessControl/ZopeGuards.py#L701
