### PR TITLE
fix(socketio): use auth header if available when making permission requests

### DIFF
--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -32,7 +32,7 @@ function authenticate_with_frappe(socket, next) {
 	}
 
 	let auth_req = request.get(get_url(socket, "/api/method/frappe.realtime.get_user_info"));
-	if (authorization_header){
+	if (authorization_header) {
 		auth_req = auth_req.set("Authorization", authorization_header);
 	} else if (cookies.sid) {
 		auth_req = auth_req.query({ sid: cookies.sid });

--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -32,10 +32,10 @@ function authenticate_with_frappe(socket, next) {
 	}
 
 	let auth_req = request.get(get_url(socket, "/api/method/frappe.realtime.get_user_info"));
-	if (cookies.sid) {
-		auth_req = auth_req.query({ sid: cookies.sid });
-	} else {
+	if (authorization_header){
 		auth_req = auth_req.set("Authorization", authorization_header);
+	} else if (cookies.sid) {
+		auth_req = auth_req.query({ sid: cookies.sid });
 	}
 
 	auth_req

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -10,10 +10,10 @@ function get_url(socket, path) {
 // Authenticates a partial request created using superagent
 function frappe_request(path, socket) {
 	const partial_req = request.get(get_url(socket, path));
-	if (socket.sid) {
-		return partial_req.query({ sid: socket.sid });
-	} else if (socket.authorization_header) {
+	if (socket.authorization_header) {
 		return partial_req.set("Authorization", socket.authorization_header);
+	} else if (socket.sid) {
+		return partial_req.query({ sid: socket.sid });
 	}
 }
 


### PR DESCRIPTION
Missed in #31864 

Use the auth token if available, and if not, use the cookie SID. This is already handled in the develop branch.