### PR TITLE
fix: Skip ruff qa on auto-generated typing blocks

### DIFF
--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -22,8 +22,12 @@ from frappe.types import DF
 
 field_template = "{field}: {type}"
 
-start_block = "# begin: auto-generated types"
-end_block = "# end: auto-generated types"
+start_block = """# begin: auto-generated types
+# ruff: noqa
+"""
+end_block = """# ruff: noqa
+# end: auto-generated types
+"""
 
 type_code_block_template = """{start_block}
 # This code is auto-generated. Do not modify anything in this block.


### PR DESCRIPTION
Closes #31925 