### PR TITLE
fix: condition based alert for Submittable DocTypes while Save and Submit

### DIFF
--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -47,7 +47,10 @@ def savedocs(doc, action):
 	send_updated_docs(doc)
 
 	add_data_to_monitor(doctype=doc.doctype, action=action)
-	frappe.msgprint(frappe._("Saved"), indicator="green", alert=True)
+	if doc.docstatus.is_submitted():
+		frappe.msgprint(frappe._("Submitted"), indicator="green", alert=True)
+	else:
+		frappe.msgprint(frappe._("Saved"), indicator="green", alert=True)
 
 
 @frappe.whitelist()

--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -47,10 +47,8 @@ def savedocs(doc, action):
 	send_updated_docs(doc)
 
 	add_data_to_monitor(doctype=doc.doctype, action=action)
-	if doc.docstatus.is_submitted():
-		frappe.msgprint(frappe._("Submitted"), indicator="green", alert=True)
-	else:
-		frappe.msgprint(frappe._("Saved"), indicator="green", alert=True)
+	status_message = "Submitted" if doc.docstatus.is_submitted() else "Saved"
+	frappe.msgprint(frappe._(status_message), indicator="green", alert=True)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Inserted a condition based alert to display

- **Saved** when saving
- **Submitted** when submitting

Closes #31935 