### PR TITLE
fix: auto email report - type missmatch error in dynamic report filters

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -218,15 +218,15 @@ class AutoEmailReport(Document):
 			if self.dynamic_date_period == "Daily":
 				from_date = add_to_date(to_date, days=-1)
 			elif self.dynamic_date_period == "Weekly":
-				from_date = get_first_day_of_week(from_date)
+				from_date = get_first_day_of_week(from_date, as_str=True)
 			elif self.dynamic_date_period == "Monthly":
-				from_date = get_first_day(from_date)
+				from_date = get_first_day(from_date, as_str=True)
 			elif self.dynamic_date_period == "Quarterly":
-				from_date = get_quarter_start(from_date)
+				from_date = get_quarter_start(from_date, as_str=True)
 			elif self.dynamic_date_period == "Half Yearly":
-				from_date = get_half_year_start(from_date)
+				from_date = get_half_year_start(as_str=True)
 			elif self.dynamic_date_period == "Yearly":
-				from_date = get_year_start(from_date)
+				from_date = get_year_start(from_date, as_str=True)
 
 			self.set_date_filters(from_date, to_date)
 		else:


### PR DESCRIPTION
When using dynamic report filters in Auto Email Report, type of from_date and to_date filters are mismatching (when enabling the Use First Day of Period option) 

issue:

https://github.com/user-attachments/assets/bb0a9926-65db-4fc7-93bc-ac625d9e6d45

