### PR TITLE
feat: :sparkles: addes x-priority option to email header and frappe.sendmail

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -514,6 +514,7 @@ def sendmail(
 	print_letterhead=False,
 	with_container=False,
 	email_read_tracker_url=None,
+	x_priority: Literal[1, 3, 5] = 3,
 ) -> Optional["EmailQueue"]:
 	"""Send email using user's default **Email Account** or global default **Email Account**.
 
@@ -541,6 +542,7 @@ def sendmail(
 	:param args: Arguments for rendering the template
 	:param header: Append header in email
 	:param with_container: Wraps email inside a styled container
+	:param x_priority: 1 = HIGHEST, 3 = NORMAL, 5 = LOWEST
 	"""
 
 	if recipients is None:
@@ -596,6 +598,7 @@ def sendmail(
 		print_letterhead=print_letterhead,
 		with_container=with_container,
 		email_read_tracker_url=email_read_tracker_url,
+		x_priority=x_priority,
 	)
 
 	# build email queue and send the email if send_now is True.

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -1,11 +1,15 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
+from __future__ import annotations
+
 import email.utils
 import os
 import re
 from email import policy
 from email.header import Header
 from email.mime.multipart import MIMEMultipart
+from typing import TYPE_CHECKING
 
 import frappe
 from frappe.email.doctype.email_account.email_account import EmailAccount
@@ -22,6 +26,9 @@ from frappe.utils import (
 	to_markdown,
 )
 from frappe.utils.pdf import get_pdf
+
+if TYPE_CHECKING:
+	from typing import Literal
 
 EMBED_PATTERN = re.compile("""embed=["'](.*?)["']""")
 
@@ -44,6 +51,7 @@ def get_email(
 	expose_recipients=None,
 	inline_images=None,
 	header=None,
+	x_priority: Literal[1, 3, 5] = 3,
 ):
 	"""Prepare an email with the following format:
 	- multipart/mixed
@@ -72,6 +80,7 @@ def get_email(
 		bcc=bcc,
 		email_account=email_account,
 		expose_recipients=expose_recipients,
+		x_priority=x_priority,
 	)
 
 	if not content.strip().startswith("<"):
@@ -117,6 +126,7 @@ class EMail:
 		bcc=(),
 		email_account=None,
 		expose_recipients=None,
+		x_priority: Literal[1, 3, 5] = 3,
 	):
 		from email import charset as Charset
 
@@ -141,6 +151,8 @@ class EMail:
 		self.cc = cc or []
 		self.bcc = bcc or []
 		self.html_set = False
+
+		self.x_priority: Literal[1, 3, 5] = x_priority
 
 		self.email_account = email_account or EmailAccount.find_outgoing(
 			match_by_email=sender, _raise_error=True
@@ -314,6 +326,13 @@ class EMail:
 			"CC": ", ".join(self.cc) if self.cc and self.expose_recipients == "header" else None,
 			"X-Frappe-Site": get_url(),
 		}
+
+		if self.x_priority != 3:
+			headers.update(
+				{
+					"X-Priority": str(self.x_priority),
+				}
+			)
 
 		# reset headers as values may be changed.
 		for key, val in headers.items():


### PR DESCRIPTION
## Description

I want to be able to send email with different priorities / importance shown in the email, e.g. in outlook shown as an exclamation mark or an arrow. 
This should be an optional argument since I want to send normal emails most of the time and the existing code still has to work.

This PR introduces this change:
I can set the "X-Priority" when calling the `frappe.sendmail` function. This argument will be passed to the email header where it will be set to the correct Header Setting to take effect.

## Additional notes
I firstly created this with an Enum however I wasn't sure where to create the Enum. I would have had to import this very specific Enum in the `frappe/__init__.py` to set the default value. I did not feel comfortable with it. I would be willing to use an enum again if someone could tell me where best to create it and if it would be alright to import it in the `frappe/__init__.py`.

If there are other questions about my code, feel free to ask 


## Backport
when merging this a backport to v-15 would be much appreciated.