### PR TITLE
fix: add progress bar styling to dark theme

### DIFF
--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -122,6 +122,12 @@ $check-icon-dark: url("data:image/svg+xml, <svg viewBox='0 0 8 7' fill='none' xm
 		--icon-stroke: var(--gray-300);
 	}
 
+	// progress bar
+	--progress-bar-bg: var(--light);
+	.progress {
+		background-color: var(--gray-700);
+	}
+
 	// input
 	--input-disabled-bg: none;
 


### PR DESCRIPTION
Closes #31805
![image](https://github.com/user-attachments/assets/7c1172b2-b346-4af3-99a5-fcc837ae81ae)
