### PR TITLE
fix: add more control on workflow state to alllow sending emails

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -111,7 +111,11 @@ def process_workflow_actions(doc, state):
 	roles = {t.allowed for t in next_possible_transitions}
 	create_workflow_actions_for_roles(roles, doc)
 
-	if send_email_alert(workflow):
+	if send_email_alert(workflow) and frappe.db.get_value(
+		"Workflow Document State",
+		filters={"parent": workflow, "state": get_doc_workflow_state(doc)},
+		fieldname="send_email",
+	):
 		enqueue(
 			send_workflow_action_email,
 			queue="short",

--- a/frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
+++ b/frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
@@ -16,6 +16,7 @@
   "avoid_status_override",
   "next_action_email_template",
   "allow_edit",
+  "send_email",
   "section_break_9",
   "message",
   "workflow_builder_id"
@@ -105,17 +106,25 @@
    "fieldname": "avoid_status_override",
    "fieldtype": "Check",
    "label": "Don't Override Status"
+  },
+  {
+   "default": "1",
+   "description": "Send email when document transitions to the state.",
+   "fieldname": "send_email",
+   "fieldtype": "Check",
+   "label": "Send Email On State"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-23 16:04:05.286225",
+ "modified": "2025-04-01 23:35:56.203734",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Document State",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/workflow/doctype/workflow_document_state/workflow_document_state.py
+++ b/frappe/workflow/doctype/workflow_document_state/workflow_document_state.py
@@ -23,6 +23,7 @@ class WorkflowDocumentState(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		send_email: DF.Check
 		state: DF.Link
 		update_field: DF.Literal[None]
 		update_value: DF.Data | None


### PR DESCRIPTION
When a doc transitions to state X you can now configure whether to send email on that Workflow State
Support ticket : https://support.frappe.io/helpdesk/tickets/34460