### PR TITLE
backport: PR 22210 from develop 

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -262,9 +262,11 @@ def import_file(doctype, file_path, import_type, submit_after_import=False, cons
 	i.import_data()
 
 
-def import_doc(path, pre_process=None):
+def import_doc(path, pre_process=None, sort=False):
 	if os.path.isdir(path):
 		files = [os.path.join(path, f) for f in os.listdir(path)]
+		if sort:
+			files.sort()
 	else:
 		files = [path]
 

--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -111,6 +111,70 @@ class TestHooks(FrappeTestCase):
 
 		event.delete()
 
+	def test_fixture_prefix(self):
+		import os
+		import shutil
+		from frappe import hooks
+		from frappe.utils.fixtures import export_fixtures
+
+		app = "frappe"
+		if(os.path.isdir(frappe.get_app_path(app, "fixtures"))):
+			shutil.rmtree(frappe.get_app_path(app, "fixtures"))
+
+		# use any set of core doctypes for test purposes
+		hooks.fixtures = [
+			{"dt": "User"},
+			{"dt": "Contact"},
+			{"dt": "Role"},
+		]
+		hooks.fixture_auto_order = False
+		# every call to frappe.get_hooks loads the hooks module into cache
+		# therefor the cache has to be invalidated after every manual overwriting of hooks
+		# TODO replace with a more elegant solution if there is one or build a util function for this purpose
+		if frappe._load_app_hooks.__wrapped__ in frappe.local.request_cache.keys():
+			del frappe.local.request_cache[frappe._load_app_hooks.__wrapped__]
+		self.assertEqual([False], frappe.get_hooks("fixture_auto_order", app_name=app))
+		self.assertEqual([
+			{"dt": "User"},
+			{"dt": "Contact"},
+			{"dt": "Role"},
+		], frappe.get_hooks("fixtures", app_name=app))
+
+		export_fixtures(app)
+		# use assertCountEqual (replaced assertItemsEqual), beacuse os.listdir might return the list in a different order, depending on OS
+		self.assertCountEqual(["user.json", "contact.json", "role.json"], os.listdir(frappe.get_app_path(app, "fixtures")))
+
+
+		hooks.fixture_auto_order = True
+		del frappe.local.request_cache[frappe._load_app_hooks.__wrapped__]
+		self.assertEqual([True], frappe.get_hooks("fixture_auto_order", app_name=app))
+
+		shutil.rmtree(frappe.get_app_path(app, "fixtures"))
+		export_fixtures(app)
+		self.assertCountEqual(["1_user.json", "2_contact.json", "3_role.json"], os.listdir(frappe.get_app_path(app, "fixtures")))
+
+
+		hooks.fixtures = [
+			{
+				"dt": "User",
+				"prefix": "my_prefix"},
+			{"dt": "Contact"},
+			{"dt": "Role"},
+		]
+		hooks.fixture_auto_order = False
+
+		del frappe.local.request_cache[frappe._load_app_hooks.__wrapped__]
+		shutil.rmtree(frappe.get_app_path(app, "fixtures"))
+		export_fixtures(app)
+		self.assertCountEqual(["my_prefix_user.json", "contact.json", "role.json"], os.listdir(frappe.get_app_path(app, "fixtures")))
+
+
+		hooks.fixture_auto_order = True
+		del frappe.local.request_cache[frappe._load_app_hooks.__wrapped__]
+		shutil.rmtree(frappe.get_app_path(app, "fixtures"))
+		export_fixtures(app)
+		self.assertCountEqual(["1_my_prefix_user.json", "2_contact.json", "3_role.json"], os.listdir(frappe.get_app_path(app, "fixtures")))
+
 
 class TestAPIHooks(FrappeAPITestCase):
 	def test_auth_hook(self):


### PR DESCRIPTION
Backporting this PR should not be a problem as it's existing in develop since 2 years from now.

Indeed, this feature is very useful in cases where a custom field is defined on a doctype and then an instance of this doctype is added via a fixture file. If it's done in this order, there's no problem, but sometimes it's done the other way round and causes an error during installation or migrate.

fix!: deterministic fixture import order  (#22210)

* feat: #20753 fixture export prefix and fixture import order

(cherry picked from commit 6a9c56a568e4ccf181fe9cb4153d0b9e4f02ac3d)

* refactor: clarify prefix logic, see https://github.com/frappe/frappe/pull/20852/files/c4866921dfaa397bdea9a6c1a01c85d21218b593#r1196249038

(cherry picked from commit cd2519e71e5545bd4c706369df3ea05843a0bfd9)

* style: format

* refactor: conditionally sort documents when importing

* refactor: simplify code

* feat: Unittest as requested in https://github.com/frappe/frappe/pull/22210#discussion_r1331587501