### PR TITLE
fix: dont send mail to assignee again if assignee was sender

### DIFF
--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -84,7 +84,7 @@ class CommunicationEmailMixin:
 			assignees = set(self.get_assignees())
 			# Check and remove If user disabled notifications for incoming emails on assigned document.
 			for assignee in assignees.copy():
-				if not is_email_notifications_enabled_for_type(assignee, "threads_on_assigned_document"):
+				if self.sender_mailid == assignee or (not is_email_notifications_enabled_for_type(assignee, "threads_on_assigned_document")):
 					assignees.remove(assignee)
 			cc.update(assignees)
 

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -84,9 +84,7 @@ class CommunicationEmailMixin:
 			assignees = set(self.get_assignees()) - {self.sender_mailid}
 			# Check and remove If user disabled notifications for incoming emails on assigned document.
 			for assignee in assignees.copy():
-				if self.sender_mailid == assignee or (
-+					not is_email_notifications_enabled_for_type(assignee, "threads_on_assigned_document")
-+				):
+				if not is_email_notifications_enabled_for_type(assignee, "threads_on_assigned_document"):
 					assignees.remove(assignee)
 			cc.update(assignees)
 

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -81,7 +81,7 @@ class CommunicationEmailMixin:
 			if doc_owner := self.get_owner():
 				cc.append(doc_owner)
 			cc = set(cc) - {self.sender_mailid}
-			assignees = set(self.get_assignees())
+			assignees = set(self.get_assignees()) - {self.sender_mailid}
 			# Check and remove If user disabled notifications for incoming emails on assigned document.
 			for assignee in assignees.copy():
 				if self.sender_mailid == assignee or (

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -84,7 +84,9 @@ class CommunicationEmailMixin:
 			assignees = set(self.get_assignees())
 			# Check and remove If user disabled notifications for incoming emails on assigned document.
 			for assignee in assignees.copy():
-				if self.sender_mailid == assignee or (not is_email_notifications_enabled_for_type(assignee, "threads_on_assigned_document")):
+				if self.sender_mailid == assignee or (
++					not is_email_notifications_enabled_for_type(assignee, "threads_on_assigned_document")
++				):
 					assignees.remove(assignee)
 			cc.update(assignees)
 


### PR DESCRIPTION
Hello everyone :)

This fix addresses an issue with incoming emails.

Example:
Let’s say you have a document, like a ToDo, and multiple users (including yourself) are assigned to it. If you reply to an email related to that ToDo, your reply gets sent to all assignees — including yourself. So you end up receiving your own response, which is unnecessary.

The update adds a check:
If the sender of the email is an assignee, they won’t receive their own reply again.

Please backport to v15 if possible :)

Best regards
Meike