### PR TITLE
fix: item code not showing in the error message

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1891,11 +1891,15 @@ def logger(
 	)
 
 
-def get_desk_link(doctype, name):
+def get_desk_link(doctype, name, show_title_with_name=False):
 	meta = get_meta(doctype)
 	title = get_value(doctype, name, meta.get_title_field())
 
-	html = '<a href="/app/Form/{doctype}/{name}" style="font-weight: bold;">{doctype_local} {title_local}</a>'
+	if show_title_with_name and name != title:
+		html = '<a href="/app/Form/{doctype}/{name}" style="font-weight: bold;">{doctype_local} {name}: {title_local}</a>'
+	else:
+		html = '<a href="/app/Form/{doctype}/{name}" style="font-weight: bold;">{doctype_local} {title_local}</a>'
+
 	return html.format(doctype=doctype, name=name, doctype_local=_(doctype), title_local=_(title))
 
 


### PR DESCRIPTION
Before Change

<img width="708" alt="Screenshot 2025-04-08 at 1 27 27 PM" src="https://github.com/user-attachments/assets/dab35437-a769-46c4-95b6-5918a66f4b7f" />



After Change

<img width="756" alt="Screenshot 2025-04-08 at 1 26 59 PM" src="https://github.com/user-attachments/assets/f7c6d31a-d556-4726-9180-90295e27b007" />
