### PR TITLE
fix: Show shared events to user

### DIFF
--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -5,6 +5,7 @@
 import json
 
 import frappe
+import frappe.share
 from frappe import _
 from frappe.contacts.doctype.contact.contact import get_default_contact
 from frappe.desk.doctype.notification_settings.notification_settings import (
@@ -232,18 +233,8 @@ def get_permission_query_conditions(user):
 	if not user:
 		user = frappe.session.user
 	query = f"""(`tabEvent`.`event_type`='Public' or `tabEvent`.`owner`={frappe.db.escape(user)})"""
-	DocShare = frappe.qb.DocType("DocShare")
-	shared_events = (
-		frappe.qb.from_(DocShare)
-		.select(DocShare.share_name)
-		.where(
-			(DocShare.share_doctype == "Event")
-			& ((DocShare.user == user) | (DocShare.user.isnull()))
-			& (DocShare.read == 1)
-		)
-	).run(as_dict=True)
+	shared_events = frappe.share.get_shared("Event", user=user)
 	if shared_events:
-		shared_events = [e.share_name for e in shared_events]
 		query += f" or `tabEvent`.`name` in ({', '.join([frappe.db.escape(e) for e in shared_events])})"
 	return query
 

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -233,8 +233,7 @@ def get_permission_query_conditions(user):
 	if not user:
 		user = frappe.session.user
 	query = f"""(`tabEvent`.`event_type`='Public' or `tabEvent`.`owner`={frappe.db.escape(user)})"""
-	shared_events = frappe.share.get_shared("Event", user=user)
-	if shared_events:
+	if shared_events := frappe.share.get_shared("Event", user=user):
 		query += f" or `tabEvent`.`name` in ({', '.join([frappe.db.escape(e) for e in shared_events])})"
 	return query
 

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -242,8 +242,8 @@ def get_permission_query_conditions(user):
 			& (DocShare.read == 1)
 		)
 	).run(as_dict=True)
-	shared_events = [e.share_name for e in shared_events]
 	if shared_events:
+		shared_events = [e.share_name for e in shared_events]
 		query += f" or `tabEvent`.`name` in ({', '.join([frappe.db.escape(e) for e in shared_events])})"
 	return query
 

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -231,7 +231,21 @@ def delete_communication(event, reference_doctype, reference_docname):
 def get_permission_query_conditions(user):
 	if not user:
 		user = frappe.session.user
-	return f"""(`tabEvent`.`event_type`='Public' or `tabEvent`.`owner`={frappe.db.escape(user)})"""
+	query = f"""(`tabEvent`.`event_type`='Public' or `tabEvent`.`owner`={frappe.db.escape(user)})"""
+	DocShare = frappe.qb.DocType("DocShare")
+	shared_events = (
+		frappe.qb.from_(DocShare)
+		.select(DocShare.share_name)
+		.where(
+			(DocShare.share_doctype == "Event")
+			& ((DocShare.user == user) | (DocShare.user.isnull()))
+			& (DocShare.read == 1)
+		)
+	).run(as_dict=True)
+	shared_events = [e.share_name for e in shared_events]
+	if shared_events:
+		query += f" or `tabEvent`.`name` in ({', '.join([frappe.db.escape(e) for e in shared_events])})"
+	return query
 
 
 def has_permission(doc, user):


### PR DESCRIPTION

> Please provide enough information so that others can review your pull request:

See : #31980 


> Screenshots/GIFs

Event is shared with user
![image](https://github.com/user-attachments/assets/9a937040-a506-46c5-a07a-e4f06ba531f8)

event appears in  list view and access is granted
![image](https://github.com/user-attachments/assets/c45ed48f-79c8-41ec-855e-f236b66f800f)

