### PR TITLE
ci: pin smtp4dev

### DIFF
--- a/.github/workflows/_base-server-tests.yml
+++ b/.github/workflows/_base-server-tests.yml
@@ -85,7 +85,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: ${{ env.DB_ROOT_PASSWORD }}
       smtp_server:
-        image: rnwood/smtp4dev
+        image: rnwood/smtp4dev@3.6.1
         ports:
           - 2525:25
           - 3000:80


### PR DESCRIPTION
Recent versions have breaking changes. We use internal HTTP APIs to test things. 