### PR TITLE
feat(map view): various improvements

### DIFF
--- a/frappe/geo/utils.py
+++ b/frappe/geo/utils.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import frappe
+from frappe.utils.data import flt
 
 
 @frappe.whitelist()
@@ -46,14 +47,19 @@ def merge_location_features_in_one(coords):
 
 def create_gps_markers(coords):
 	"""Build Marker based on latitude and longitude."""
-	geojson_dict = []
-	for i in coords:
-		node = {"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": None}}
-		node["properties"]["name"] = i.name
-		node["geometry"]["coordinates"] = [i.longitude, i.latitude]  # geojson needs it reverse!
-		geojson_dict.append(node.copy())
-
-	return geojson_dict
+	return [
+		{
+			"type": "Feature",
+			"properties": {
+				"name": i.name,
+			},
+			"geometry": {
+				"type": "Point",
+				"coordinates": [flt(i.longitude), flt(i.latitude)],  # geojson needs it reverse!
+			},
+		}
+		for i in coords
+	]
 
 
 def return_location(doctype, filters_sql):

--- a/frappe/public/js/frappe/views/map/map_view.js
+++ b/frappe/public/js/frappe/views/map/map_view.js
@@ -15,22 +15,8 @@ frappe.views.MapView = class MapView extends frappe.views.ListView {
 		this.page_title = __("{0} Map", [this.page_title]);
 	}
 
-	setup_view() {}
-
-	on_filter_change() {
-		this.get_coords();
-	}
-
-	render() {
-		this.get_coords().then(() => {
-			this.render_map_view();
-		});
-		this.$paging_area.find(".level-left").append("<div></div>");
-	}
-
-	render_map_view() {
+	setup_view() {
 		this.map_id = frappe.dom.get_unique_id();
-
 		this.$result.html(`<div id="${this.map_id}" class="map-view-container"></div>`);
 
 		L.Icon.Default.imagePath = frappe.utils.map_defaults.image_path;
@@ -44,16 +30,35 @@ frappe.views.MapView = class MapView extends frappe.views.ListView {
 		);
 
 		L.control.scale().addTo(this.map);
+	}
+
+	render() {
+		this.get_coords().then(() => {
+			this.render_map_data();
+		});
+		this.$paging_area.find(".level-left").append("<div></div>");
+	}
+
+	render_map_data() {
+		// Clear existing markers
+		if (this.markerLayer) {
+			this.map.removeLayer(this.markerLayer);
+		}
+
 		if (this.coords.features && this.coords.features.length) {
-			this.coords.features.forEach((coords) =>
-				L.geoJSON(coords)
-					.bindPopup(
-						frappe.utils.get_form_link(this.doctype, coords.properties.name, true)
-					)
-					.addTo(this.map)
-			);
-			let lastCoords = this.coords.features[0].geometry.coordinates.reverse();
-			this.map.panTo(lastCoords, 8);
+			this.markerLayer = L.featureGroup();
+
+			this.coords.features.forEach((coords) => {
+				const marker = L.geoJSON(coords).bindPopup(
+					frappe.utils.get_form_link(this.doctype, coords.properties.name, true)
+				);
+				this.markerLayer.addLayer(marker);
+			});
+
+			this.markerLayer.addTo(this.map);
+
+			// Fit bounds to show all markers
+			this.map.fitBounds(this.markerLayer.getBounds());
 		}
 	}
 

--- a/frappe/public/js/frappe/views/map/map_view.js
+++ b/frappe/public/js/frappe/views/map/map_view.js
@@ -29,6 +29,7 @@ frappe.views.MapView = class MapView extends frappe.views.ListView {
 			this.map
 		);
 
+		this.bind_leaflet_locate_control();
 		L.control.scale().addTo(this.map);
 	}
 
@@ -90,5 +91,11 @@ frappe.views.MapView = class MapView extends frappe.views.ListView {
 			.then((r) => {
 				this.coords = r.message;
 			});
+	}
+
+	bind_leaflet_locate_control() {
+		// To request location update and set location, sets current geolocation on load
+		this.locate_control = L.control.locate({ position: "topright" });
+		this.locate_control.addTo(this.map);
 	}
 };

--- a/frappe/public/js/frappe/views/map/map_view.js
+++ b/frappe/public/js/frappe/views/map/map_view.js
@@ -45,7 +45,11 @@ frappe.views.MapView = class MapView extends frappe.views.ListView {
 		L.control.scale().addTo(this.map);
 		if (this.coords.features && this.coords.features.length) {
 			this.coords.features.forEach((coords) =>
-				L.geoJSON(coords).bindPopup(coords.properties.name).addTo(this.map)
+				L.geoJSON(coords)
+					.bindPopup(
+						frappe.utils.get_form_link(this.doctype, coords.properties.name, true)
+					)
+					.addTo(this.map)
 			);
 			let lastCoords = this.coords.features[0].geometry.coordinates.reverse();
 			this.map.panTo(lastCoords, 8);

--- a/frappe/public/js/frappe/views/map/map_view.js
+++ b/frappe/public/js/frappe/views/map/map_view.js
@@ -10,6 +10,7 @@ frappe.views.MapView = class MapView extends frappe.views.ListView {
 	}
 
 	setup_defaults() {
+		this.hide_sort_selector = true;
 		super.setup_defaults();
 		this.page_title = __("{0} Map", [this.page_title]);
 	}

--- a/frappe/public/js/frappe/views/map/map_view.js
+++ b/frappe/public/js/frappe/views/map/map_view.js
@@ -85,11 +85,4 @@ frappe.views.MapView = class MapView extends frappe.views.ListView {
 				this.coords = r.message;
 			});
 	}
-
-	get required_libs() {
-		return [
-			"assets/frappe/js/lib/leaflet/leaflet.css",
-			"assets/frappe/js/lib/leaflet/leaflet.js",
-		];
-	}
 };


### PR DESCRIPTION
<img width="1624" alt="Bildschirmfoto 2025-04-09 um 16 03 07" src="https://github.com/user-attachments/assets/2cf68fef-fdba-4b62-b66f-9ddbfa7d0578" />

- Refactored the method that produces GeoJSON markers and added support for coordinates entered in Data fields by converting to float.
- In the marker popup, render a link to the form instead of just the name
- Removed redundant loading of the leaflet libraries, they are already part of the desk bundle and don't need to be loaded again.
- Marked the list view's sort selector as hidden, since sorting has no meaning on a map.
- Added the "locate" control to let users view entries in their proximity
- Separated creating the map and rendering the data. This way we don't have to create a new map every time the data changes (filtering, refresh) and can maintain, among other things, the user's location.

### How to test this PR

Create two DocTypes:

- one with two fields named "latitude" and "longitude" (can be of fieldtype "Data" or "Float")
- another one with a field named "location" (fieldtype "Geolocation")

Then, create some entries, check the map view, set some filters, refresh, delete some entries, refresh, locate yourself, etc.

> no-docs