### PR TITLE
fix: make app installation possible again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "PyPika==0.48.9",
     "mysqlclient==2.2.7",
     "PyQRCode~=1.2.1",
-    "PyYAML~=6.0.1",
+    "PyYAML~=6.0.2",
     "RestrictedPython~=8.0",
     "WeasyPrint==59.0",
     "pydyf==0.10.0",


### PR DESCRIPTION
version bump for pyYAML to make the installation possible again. before cython threw an error on the installation

## Description

I wanted to init a new bench on the develop branch. However the init caused some cryptic errors. 
After a while of research I found out that cython had a few problems. I also found out that pyYAML and cython have problems in specific version. 
That was when I noticed a new version of pyYAML: 6.0.2

The release notes of the version state the support for the needed cython version: https://github.com/yaml/pyyaml/releases/tag/6.0.2

After changing this locally the init worked just fine
