### PR TITLE
Fix(email auth): Receive/Send from Shared Mailboxes Microsoft 365

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -256,7 +256,7 @@ class EmailAccount(Document):
 				"host": self.email_server,
 				"use_ssl": self.use_ssl,
 				"use_starttls": self.use_starttls,
-				"username": getattr(self, "login_id", None) or self.email_id,
+				"username": self.email_id,
 				"use_imap": self.use_imap,
 				"email_sync_rule": email_sync_rule,
 				"incoming_port": get_port(self),


### PR DESCRIPTION
As documented here: https://github.com/frappe/erpnext/issues/13327#issuecomment-1784380446

It should not try to get the login_id as that will be the "personal account" we use to access the shared mailbox. It will then pick up from the personal mailbox instead of the shared mailbox.

After updating the code you will be able to Receive/Send from Shared Mailboxes from Microsoft 365 following this documentation.

https://docs.frappe.io/framework/user/en/microsoft-email-oauth

**Domain configuration :**
![image](https://github.com/user-attachments/assets/c4518d60-422c-4fe3-96fd-eebc067976a8)

**Email Account Configuration :**
![image](https://github.com/user-attachments/assets/c3ab05ba-00ae-4cf0-ab92-d8635d80b1a3)
