### PR TITLE
fix: improve url validation

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -241,7 +241,7 @@ def validate_url(
 	        valid_schemes: if provided checks the given URL's scheme against this
 	"""
 	url = urlparse(txt)
-	is_valid = bool(url.netloc) or (txt and txt.startswith("/"))
+	is_valid = bool(url.scheme and (url.netloc or url.path)) or bool(txt and txt.startswith("/"))
 
 	# Handle scheme validation
 	if isinstance(valid_schemes, str):


### PR DESCRIPTION
Stumbled upon this since paths to local files are currently evaluated as non-valid urls. 
Example: file:///Users/henning/Downloads/test.hmtl

Each valid URL should also have a scheme

