### PR TITLE
fix: increase failure threshold for preapred report

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -18,7 +18,7 @@ from frappe.utils import add_to_date, now
 from frappe.utils.background_jobs import enqueue
 
 # If prepared report runs for longer than this time it's automatically considered as failed
-FAILURE_THRESHOLD = 60 * 60
+FAILURE_THRESHOLD = 6 * 60 * 60
 REPORT_TIMEOUT = 25 * 60
 
 


### PR DESCRIPTION
Because of long queues and longer reports
