### PR TITLE
feat: allow setting a custom threshold value for prepared reports

### DIFF
--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -19,6 +19,7 @@
   "prepared_report",
   "add_translate_data",
   "timeout",
+  "prepared_report_threshold",
   "filters_section",
   "filters",
   "columns_section",
@@ -202,12 +203,18 @@
    "fieldname": "add_translate_data",
    "fieldtype": "Check",
    "label": "Add Translate Data"
+  },
+  {
+   "description": "Specify a custom threshold for converting to a prepared report, default threshold is 15 seconds",
+   "fieldname": "prepared_report_threshold",
+   "fieldtype": "Int",
+   "label": "Prepared Report Threshold (In Seconds)"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-12 17:08:09.629411",
+ "modified": "2025-04-10 00:49:49.735649",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Report",

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -40,6 +40,7 @@ class Report(Document):
 		letter_head: DF.Link | None
 		module: DF.Link | None
 		prepared_report: DF.Check
+		prepared_report_threshold: DF.Int
 		query: DF.Code | None
 		ref_doctype: DF.Link
 		reference_report: DF.Data | None
@@ -159,7 +160,7 @@ class Report(Document):
 
 	def execute_script_report(self, filters):
 		# save the timestamp to automatically set to prepared
-		threshold = 15
+		threshold = self.prepared_report_threshold or 15
 
 		start_time = datetime.datetime.now()
 		prepared_report_watcher = None


### PR DESCRIPTION
Closes #31995. The change also maintains the original 15 seconds threshold for backwards compatibility.