### PR TITLE
perf(event): get_events performance and Google Calendar integration fixes

### DIFF
--- a/frappe/desk/doctype/event/event.json
+++ b/frappe/desk/doctype/event/event.json
@@ -247,9 +247,9 @@
    "fieldname": "google_calendar_event_id",
    "fieldtype": "Data",
    "label": "Google Calendar Event ID",
+   "length": 320,
    "no_copy": 1,
-   "read_only": 1,
-   "length": 320
+   "read_only": 1
   },
   {
    "default": "0",
@@ -287,16 +287,17 @@
   },
   {
    "fieldname": "google_meet_link",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "label": "Google Meet Link",
    "no_copy": 1,
    "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "icon": "fa fa-calendar",
  "idx": 1,
  "links": [],
- "modified": "2023-06-23 10:33:15.685368",
+ "modified": "2025-04-10 13:08:32.540745",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Event",
@@ -328,6 +329,7 @@
   }
  ],
  "read_only": 1,
+ "row_format": "Dynamic",
  "sender_field": "sender",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -274,6 +274,8 @@ def get_events(
 ) -> list[frappe._dict]:
 	user = user or frappe.session.user
 	EventLikeDict: TypeAlias = Event | frappe._dict
+	resolved_events: list[EventLikeDict] = []
+	days_range = (end - start).days
 
 	if isinstance(filters, str):
 		filters = json.loads(filters)
@@ -348,64 +350,60 @@ def get_events(
 		as_dict=True,
 	)
 
-	add_events = []
-	remove_events = []
+	def resolve_event(e: EventLikeDict, target_date: "date"):
+		"""Record the event if it falls within the date range and is not excluded by the weekday."""
+		if e.repeat_on == "Weekly" and not e[weekdays[target_date.weekday()]]:
+			return
 
-	def add_event(e: EventLikeDict, d: "date"):
+		if not (
+			e.starts_on.date() <= target_date
+			and target_date >= start
+			and target_date <= end
+			and target_date <= repeat_till
+		):
+			return
+
+		ends_on_date = add_days(target_date, (e.ends_on - e.starts_on).days) if e.ends_on else None
+
+		if ends_on_date and e.repeat_till and ((ends_on_date > e.repeat_till) or (ends_on_date < start)):
+			return
+
 		new_event = e.copy()
-		new_event.starts_on = datetime.combine(d, e.starts_on.time())
+		new_event.starts_on = datetime.combine(target_date, e.starts_on.time())
+		new_event.ends_on = datetime.combine(ends_on_date, e.ends_on.time()) if ends_on_date else None
 
-		if e.ends_on:
-			end_date = add_days(d, date_diff(e.ends_on, e.starts_on)) if (e.starts_on and e.ends_on) else d
-			new_event.ends_on = datetime.combine(end_date, e.ends_on.time())
-
-		add_events.append(new_event)
+		resolved_events.append(new_event)
 
 	for e in event_candidates:
 		if not e.repeat_this_event:
+			resolved_events.append(e)
+			continue
+
+		if e.repeat_till and e.repeat_till < start:
 			continue
 
 		event_start = e.starts_on.date()
 		repeat_till = getdate(e.repeat_till or "3000-01-01")
 
-		def within_range(d):
-			return d >= getdate(start) and d <= getdate(end) and d <= repeat_till
-
 		if e.repeat_on == "Yearly":
 			for year in range(start.year, end.year + 1):
-				d = date(year, event_start.month, event_start.day)
-				if within_range(d):
-					add_event(e, d)
-			remove_events.append(e)
+				resolve_event(e, target_date=event_start.replace(year=year))
 
 		elif e.repeat_on == "Monthly":
-			start_date = date(start.year, start.month, event_start.day)
-			for i in range((date_diff(end, start) // 30) + 3):
-				d = add_months(start_date, i)
-				if within_range(d):
-					add_event(e, d)
-			remove_events.append(e)
+			start_date = start.replace(day=event_start.day)
+			for i in range((days_range // 30) + 3):
+				resolve_event(e, target_date=add_months(start_date, i))
 
-		elif e.repeat_on == "Weekly":
-			for cnt in range(date_diff(end, start) + 1):
-				d = add_days(start, cnt)
-				if e[weekdays[d.weekday()]] and within_range(d):
-					add_event(e, d)
-			remove_events.append(e)
-
-		elif e.repeat_on == "Daily":
-			for cnt in range(date_diff(end, start) + 1):
-				d = add_days(start, cnt)
-				if within_range(d):
-					add_event(e, d)
-			remove_events.append(e)
+		elif e.repeat_on in ("Weekly", "Daily"):
+			for i in range(days_range + 1):
+				resolve_event(e, target_date=add_days(start, i))
 
 	# Remove events that are not in the range and boolean weekdays fields
-	return [
-		{fieldname: fieldvalue for fieldname, fieldvalue in event.items() if fieldname not in weekdays}
-		for event in event_candidates + add_events
-		if event not in remove_events
-	]
+	for event in resolved_events:
+		for fieldname in weekdays:
+			event.pop(fieldname, None)
+
+	return resolved_events
 
 
 def delete_events(ref_type, ref_name, delete_event=False):

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -2,8 +2,8 @@
 # License: MIT. See LICENSE
 
 
-from datetime import date, datetime
 import json
+from datetime import date, datetime
 
 import frappe
 from frappe import _
@@ -35,7 +35,7 @@ communication_mapping = {
 	"Other": "Other",
 }
 
-from typing import TYPE_CHECKING, Optional, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
 if TYPE_CHECKING:
 	from frappe.core.doctype.communication.communication import Communication
@@ -270,7 +270,7 @@ def send_event_digest():
 
 @frappe.whitelist()
 def get_events(
-	start: date, end: date, user: Optional[str] = None, for_reminder: bool = False, filters=None
+	start: date, end: date, user: str | None = None, for_reminder: bool = False, filters=None
 ) -> list[frappe._dict]:
 	user = user or frappe.session.user
 	EventLikeDict: TypeAlias = Event | frappe._dict

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 
+from datetime import date, datetime
 import json
 
 import frappe
@@ -15,11 +16,8 @@ from frappe.model.document import Document
 from frappe.utils import (
 	add_days,
 	add_months,
-	cint,
-	cstr,
 	date_diff,
 	format_datetime,
-	get_datetime_str,
 	get_fullname,
 	getdate,
 	now_datetime,
@@ -37,7 +35,7 @@ communication_mapping = {
 	"Other": "Other",
 }
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, TypeAlias
 
 if TYPE_CHECKING:
 	from frappe.core.doctype.communication.communication import Communication
@@ -271,9 +269,11 @@ def send_event_digest():
 
 
 @frappe.whitelist()
-def get_events(start, end, user=None, for_reminder=False, filters=None) -> list[frappe._dict]:
-	if not user:
-		user = frappe.session.user
+def get_events(
+	start: date, end: date, user: Optional[str] = None, for_reminder: bool = False, filters=None
+) -> list[frappe._dict]:
+	user = user or frappe.session.user
+	EventLikeDict: TypeAlias = Event | frappe._dict
 
 	if isinstance(filters, str):
 		filters = json.loads(filters)
@@ -284,7 +284,7 @@ def get_events(start, end, user=None, for_reminder=False, filters=None) -> list[
 	if "`tabEvent Participants`" in filter_condition:
 		tables.append("`tabEvent Participants`")
 
-	events = frappe.db.sql(
+	event_candidates: list[EventLikeDict] = frappe.db.sql(
 		"""
 		SELECT `tabEvent`.name,
 				`tabEvent`.subject,
@@ -345,122 +345,67 @@ def get_events(start, end, user=None, for_reminder=False, filters=None) -> list[
 			"end": end,
 			"user": user,
 		},
-		as_dict=1,
+		as_dict=True,
 	)
 
-	# process recurring events
-	start = start.split(" ", 1)[0]
-	end = end.split(" ", 1)[0]
 	add_events = []
 	remove_events = []
 
-	def add_event(e, date):
+	def add_event(e: EventLikeDict, d: "date"):
 		new_event = e.copy()
+		new_event.starts_on = datetime.combine(d, e.starts_on.time())
 
-		enddate = (
-			add_days(date, int(date_diff(e.ends_on.split(" ", 1)[0], e.starts_on.split(" ", 1)[0])))
-			if (e.starts_on and e.ends_on)
-			else date
-		)
-
-		new_event.starts_on = date + " " + e.starts_on.split(" ")[1]
-		new_event.ends_on = new_event.ends_on = enddate + " " + e.ends_on.split(" ")[1] if e.ends_on else None
+		if e.ends_on:
+			end_date = add_days(d, date_diff(e.ends_on, e.starts_on)) if (e.starts_on and e.ends_on) else d
+			new_event.ends_on = datetime.combine(end_date, e.ends_on.time())
 
 		add_events.append(new_event)
 
-	for e in events:
-		if e.repeat_this_event:
-			e.starts_on = get_datetime_str(e.starts_on)
-			e.ends_on = get_datetime_str(e.ends_on) if e.ends_on else None
+	for e in event_candidates:
+		if not e.repeat_this_event:
+			continue
 
-			event_start, time_str = get_datetime_str(e.starts_on).split(" ")
+		event_start = e.starts_on.date()
+		repeat_till = getdate(e.repeat_till or "3000-01-01")
 
-			repeat = "3000-01-01" if cstr(e.repeat_till) == "" else e.repeat_till
+		def within_range(d):
+			return d >= getdate(start) and d <= getdate(end) and d <= repeat_till
 
-			if e.repeat_on == "Yearly":
-				start_year = cint(start.split("-", 1)[0])
-				end_year = cint(end.split("-", 1)[0])
+		if e.repeat_on == "Yearly":
+			for year in range(start.year, end.year + 1):
+				d = date(year, event_start.month, event_start.day)
+				if within_range(d):
+					add_event(e, d)
+			remove_events.append(e)
 
-				# creates a string with date (27) and month (07) eg: 07-27
-				event_start = "-".join(event_start.split("-")[1:])
+		elif e.repeat_on == "Monthly":
+			start_date = date(start.year, start.month, event_start.day)
+			for i in range((date_diff(end, start) // 30) + 3):
+				d = add_months(start_date, i)
+				if within_range(d):
+					add_event(e, d)
+			remove_events.append(e)
 
-				# repeat for all years in period
-				for year in range(start_year, end_year + 1):
-					date = str(year) + "-" + event_start
-					if (
-						getdate(date) >= getdate(start)
-						and getdate(date) <= getdate(end)
-						and getdate(date) <= getdate(repeat)
-					):
-						add_event(e, date)
+		elif e.repeat_on == "Weekly":
+			for cnt in range(date_diff(end, start) + 1):
+				d = add_days(start, cnt)
+				if e[weekdays[d.weekday()]] and within_range(d):
+					add_event(e, d)
+			remove_events.append(e)
 
-				remove_events.append(e)
+		elif e.repeat_on == "Daily":
+			for cnt in range(date_diff(end, start) + 1):
+				d = add_days(start, cnt)
+				if within_range(d):
+					add_event(e, d)
+			remove_events.append(e)
 
-			if e.repeat_on == "Monthly":
-				# creates a string with date (27) and month (07) and year (2019) eg: 2019-07-27
-				year, month = start.split("-", maxsplit=2)[:2]
-				date = f"{year}-{month}-" + event_start.split("-", maxsplit=3)[2]
-
-				# last day of month issue, start from prev month!
-				try:
-					getdate(date)
-				except Exception:
-					# Don't show any message to the user
-					frappe.clear_last_message()
-
-					date = date.split("-")
-					date = date[0] + "-" + str(cint(date[1]) - 1) + "-" + date[2]
-
-				start_from = date
-				for i in range(int(date_diff(end, start) / 30) + 3):
-					if (
-						getdate(date) >= getdate(start)
-						and getdate(date) <= getdate(end)
-						and getdate(date) <= getdate(repeat)
-						and getdate(date) >= getdate(event_start)
-					):
-						add_event(e, date)
-
-					date = add_months(start_from, i + 1)
-				remove_events.append(e)
-
-			if e.repeat_on == "Weekly":
-				for cnt in range(date_diff(end, start) + 1):
-					date = add_days(start, cnt)
-					if (
-						getdate(date) >= getdate(start)
-						and getdate(date) <= getdate(end)
-						and getdate(date) <= getdate(repeat)
-						and getdate(date) >= getdate(event_start)
-						and e[weekdays[getdate(date).weekday()]]
-					):
-						add_event(e, date)
-
-				remove_events.append(e)
-
-			if e.repeat_on == "Daily":
-				for cnt in range(date_diff(end, start) + 1):
-					date = add_days(start, cnt)
-					if (
-						getdate(date) >= getdate(event_start)
-						and getdate(date) <= getdate(end)
-						and getdate(date) <= getdate(repeat)
-					):
-						add_event(e, date)
-
-				remove_events.append(e)
-
-	for e in remove_events:
-		events.remove(e)
-
-	events = events + add_events
-
-	for e in events:
-		# remove weekday properties (to reduce message size)
-		for w in weekdays:
-			del e[w]
-
-	return events
+	# Remove events that are not in the range and boolean weekdays fields
+	return [
+		{fieldname: fieldvalue for fieldname, fieldvalue in event.items() if fieldname not in weekdays}
+		for event in event_candidates + add_events
+		if event not in remove_events
+	]
 
 
 def delete_events(ref_type, ref_name, delete_event=False):

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -333,7 +333,12 @@ def sync_events_from_google_calendar(g_calendar, method=None):
 				with suppress(IndexError):
 					recurrence = event.get("recurrence")[0]
 
-			if not frappe.db.exists("Event", {"google_calendar_event_id": event.get("id")}):
+			# NOTE: Skip if event is already synced; Frappe doesn't track individual
+			# instances of recurring events, so we need to check if the event is already
+			# synced in Frappe Calendar
+			if event.get("recurringEventId"):
+				...
+			elif not frappe.db.exists("Event", {"google_calendar_event_id": event.get("id")}):
 				insert_event_to_calendar(account, event, recurrence)
 			else:
 				update_event_in_calendar(account, event, recurrence)

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -657,7 +657,7 @@ def google_calendar_to_repeat_on(*, start, end, recurrence=None):
 			repeat_on[google_calendar_days[repeat_day]] = 1
 
 	if byday and repeat_on["repeat_on"] == "Monthly":
-		byday = byday.split("=")[1]
+		byday = byday[0]
 		repeat_day_week_number, repeat_day_name = None, None
 
 		for num in ["-2", "-1", "1", "2", "3", "4", "5"]:

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -771,7 +771,7 @@ def get_week_number(dt: date):
 	dom = dt.day
 	adjusted_dom = dom + first_day.weekday()
 
-	return int(ceil(adjusted_dom / 7.0))
+	return ceil(adjusted_dom / 7.0)
 
 
 def get_recurrence_parameters(recurrence: str) -> RecurrenceParameters:

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -384,14 +384,17 @@ class NotificationsView extends BaseNotificationsView {
 class EventsView extends BaseNotificationsView {
 	make() {
 		let today = frappe.datetime.get_today();
-		frappe
-			.xcall("frappe.desk.doctype.event.event.get_events", {
+		frappe.call({
+			method: "frappe.desk.doctype.event.event.get_events",
+			args: {
 				start: today,
 				end: today,
-			})
-			.then((event_list) => {
-				this.render_events_html(event_list);
-			});
+			},
+			type: "GET",
+			callback: ({ message }) => {
+				this.render_events_html(message);
+			},
+		});
 	}
 
 	render_events_html(event_list) {


### PR DESCRIPTION
### Highlights

* Makes `frappe.desk.doctype.event.event.get_events` 14-15x faster
* URLs under `Event.google_meet_link` are much bigger nowadays - updated fieldtype to Small Text
* Don't sync recurring events from Google Calendars since Frappe doesn't support relevant features - faster syncs & de-duplicated events
* Fix `get_events`'s quirks that seemed like clear bugs

```python
# before
In [2]: %timeit frappe.call("frappe.desk.doctype.event.event.get_events", doctype="Event", start="2025-03-31", end="2025-05-12", filters=[["Event","status","=","Open", False]
   ...: ], user='gavin.dsouza@simplesimple.org')
34.9 ms ± 2.34 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

# after
In [2]: %timeit frappe.call("frappe.desk.doctype.event.event.get_events", doctype="Event", start=date(2025, 3, 31), end=date(2025, 5, 12), filters=[["Event","status","=","Ope
   ...: n", False]], user='gavin.dsouza@simplesimple.org')
2.41 ms ± 51.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

A breaking change that should be a problem in rare cases - if get_events is being used programmatically and passes `start` & `end` as string, this change breaks support for that🤞🏼 

Follow up of #31772 