### PR TITLE
fix: Prevent duplicate ToDo creation when assigning

### DIFF
--- a/frappe/public/js/frappe/views/interaction.js
+++ b/frappe/public/js/frappe/views/interaction.js
@@ -261,7 +261,8 @@ frappe.views.InteractionComposer = class InteractionComposer {
 						message: __("{0} created successfully", [form_values.interaction_type]),
 						indicator: "green",
 					});
-					if ("assigned_to" in form_values) {
+
+					if (form_values.interaction_type === "Event" && "assigned_to" in form_values) {
 						me.assign_document(r.message, form_values["assigned_to"]);
 					}
 


### PR DESCRIPTION
Issue: In Event, if you select the ToDo and if there is not assign_to then create todo without assign_to, that is okay but when you select assign_to then it's create a multiple ToDO. first create a todo of doctype and second create a ToDo of previous ToDo which create from the doc. (Same problem on lead side, when creating a new task from activities tab and if assign_to then it creates multiple todos)

For Event, it's worked properly.

[before_todo.webm](https://github.com/user-attachments/assets/e9ad6845-a2cf-4ad7-afdb-20a2a630bce3)

fix: so if In Event, if you select the ToDo then assign_to selected or not selected assign_to but it's create a only one ToDo for that doc.

[after_todo.webm](https://github.com/user-attachments/assets/f8b44cc7-ffdb-4ff6-9ccb-05edb6af0f1f)
