### PR TITLE
feat: use `cached_property` without locks on all supported Python versions

### DIFF
--- a/frappe/commands/test_commands.py
+++ b/frappe/commands/test_commands.py
@@ -901,7 +901,7 @@ class TestAddNewUser(BaseTestCommands):
 
 class TestBenchBuild(IntegrationTestCase):
 	def test_build_assets_size_check(self):
-		CURRENT_SIZE = 3.3  # MB
+		CURRENT_SIZE = 3.4  # MB
 		JS_ASSET_THRESHOLD = 0.01
 
 		hooks = frappe.get_hooks()

--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -175,7 +175,7 @@ class TestRQJob(IntegrationTestCase):
 		# If this starts failing analyze memory usage using memray or some equivalent tool to find
 		# offending imports/function calls.
 		# Refer this PR: https://github.com/frappe/frappe/pull/21467
-		LAST_MEASURED_USAGE = 41
+		LAST_MEASURED_USAGE = 42
 		if frappe.conf.use_mysqlclient:
 			# TEMP: Add extra allowance for running two connectors, this should be rolled back before v16
 			LAST_MEASURED_USAGE += 2

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -3,7 +3,6 @@
 import datetime
 import json
 import weakref
-from functools import cached_property
 from types import MappingProxyType
 from typing import TYPE_CHECKING, TypeVar
 
@@ -24,6 +23,7 @@ from frappe.model.naming import set_new_name
 from frappe.model.utils.link_count import notify_link_count
 from frappe.modules import load_doctype_module
 from frappe.utils import (
+	cached_property,
 	cast_fieldtype,
 	cint,
 	compare,

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -19,7 +19,7 @@ import json
 import os
 import typing
 from datetime import datetime
-from functools import cached_property, singledispatchmethod
+from functools import singledispatchmethod
 from types import NoneType
 
 import click
@@ -43,7 +43,7 @@ from frappe.model.document import Document
 from frappe.model.workflow import get_workflow_name
 from frappe.modules import load_doctype_module
 from frappe.types import DocRef
-from frappe.utils import cast, cint, cstr
+from frappe.utils import cached_property, cast, cint, cstr
 from frappe.utils.data import add_to_date, get_datetime
 
 DEFAULT_FIELD_LABELS = {

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -19,7 +19,7 @@ from collections.abc import (
 )
 from email.header import decode_header, make_header
 from email.utils import formataddr, parseaddr
-from typing import TypedDict
+from typing import TypeAlias, TypedDict
 
 from werkzeug.test import Client
 
@@ -44,6 +44,8 @@ EMAIL_MATCH_PATTERN = re.compile(
 )
 
 UNSET = object()
+
+PropertyType: TypeAlias = property | functools.cached_property
 
 
 if sys.version_info < (3, 11):
@@ -666,7 +668,7 @@ def is_markdown(text):
 
 def is_a_property(x) -> bool:
 	"""Get properties (@property, @cached_property) in a controller class"""
-	return isinstance(x, property | functools.cached_property)
+	return isinstance(x, PropertyType)
 
 
 def get_sites(sites_path=None):
@@ -1151,3 +1153,48 @@ def safe_eval(code, eval_globals=None, eval_locals=None):
 	from frappe.utils.safe_exec import safe_eval
 
 	return safe_eval(code, eval_globals, eval_locals)
+
+
+class cached_property(functools.cached_property):
+	"""
+	A simpler `functools.cached_property` implementation without locks.
+	This isn't needed in Python 3.12+, since lock was removed in newer versions.
+	Hence, in those versions, it returns the `functools.cached_property` object.
+
+	This does not prevent a possible race condition in multi-threaded usage.
+	The getter function could run more than once on the same instance,
+	with the latest run setting the cached value. If the cached property is
+	idempotent or otherwise not harmful to run more than once on an instance,
+	this is fine. If synchronization is needed, implement the necessary locking
+	inside the decorated getter function or around the cached property access.
+	"""
+
+	def __new__(cls, func):
+		if sys.version_info.minor >= 12:
+			return functools.cached_property(func)
+
+		return super().__new__(cls)
+
+	def __init__(self, func):
+		self.func = func
+		self.attrname = None
+		self.__doc__ = func.__doc__
+		self.__module__ = func.__module__
+
+	def __set_name__(self, owner, name):
+		if self.attrname is None:
+			self.attrname = name
+
+		elif name != self.attrname:
+			raise TypeError(
+				"Cannot assign the same cached_property to two different names "
+				f"({self.attrname!r} and {name!r})."
+			)
+
+	def __get__(self, instance, owner=None):
+		if instance is None:
+			return self
+
+		value = self.func(instance)
+		instance.__dict__[self.attrname] = value
+		return value


### PR DESCRIPTION
Closes #32076 

`no-docs`