### PR TITLE
fix: Add a long timeout instead of indefinite blocking

### DIFF
--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -580,7 +580,7 @@ class ClientCache:
 		self._watcher = self.invalidator.pubsub()
 		self._watcher.subscribe(**{"__redis__:invalidate": self._handle_invalidation})
 		return self._watcher.run_in_thread(
-			sleep_time=None,
+			sleep_time=60,
 			daemon=True,
 			exception_handler=self._exception_handler,
 		)


### PR DESCRIPTION
Redis handles non-blocking calls differently and auto-recovers from timeouts
