### PR TITLE
fix: Exclude perm restricted fields from standard list filter

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -836,8 +836,9 @@ class FilterArea {
 			doctype_fields
 				.filter(
 					(df) =>
-						df.fieldname === title_field ||
-						(df.in_standard_filter && frappe.model.is_value_type(df.fieldtype))
+						(df.fieldname === title_field ||
+							(df.in_standard_filter && frappe.model.is_value_type(df.fieldtype))) &&
+						frappe.perm.has_perm(this.list_view.doctype, df.permlevel)
 				)
 				.map((df) => {
 					let options = df.options;


### PR DESCRIPTION
- A user, "A", **with** the perm level access to field "Total Leave Days" (having permlevel 2), can see it in the standard filter
	<img width="800" alt="Screenshot 2025-04-11 at 4 49 49 PM" src="https://github.com/user-attachments/assets/cc5d9951-761d-404b-80a0-a5de2560a8ca" />
- A user, "MD", **without** perm level access to "Total Leave Days" could also see it in the standard filters. Although the field is rightfully hidden in the list header columns
   <img width="800" alt="Screenshot 2025-04-11 at 5 02 00 PM" src="https://github.com/user-attachments/assets/3e44586f-4fff-409d-b76f-8e6abc281a47" />

**Fix:**
- A user **without** perm level access to this field should not see it in the list filters
   <img width="800" alt="Screenshot 2025-04-11 at 4 52 17 PM" src="https://github.com/user-attachments/assets/7c1683c0-e8d6-4edc-ac69-3b6059fd4934" />

> This works fine for list view columns and the dynamic filters
