### PR TITLE
refactor: improve some caches

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -65,7 +65,7 @@ def get_bootinfo():
 		d.parent for d in frappe.get_all("DocField", {"fieldname": "lft"}, ["parent"])
 	]
 	add_home_page(bootinfo, doclist)
-	bootinfo.page_info = get_allowed_pages()
+	bootinfo.page_info = get_allowed_pages(cache=True)
 	load_translations(bootinfo)
 	add_timezone_info(bootinfo)
 	load_conf_settings(bootinfo)
@@ -221,27 +221,25 @@ def get_allowed_report_names(cache=False) -> set[str]:
 
 
 def get_user_pages_or_reports(parent, cache=False):
+	cache_key = f"has_role:{parent}"
 	if cache:
-		has_role = frappe.cache.get_value("has_role:" + parent, user=frappe.session.user)
+		has_role = frappe.cache.hget(cache_key, frappe.session.user)
 		if has_role:
 			return has_role
 
 	roles = frappe.get_roles()
 	has_role = {}
 
-	page = DocType("Page")
-	report = DocType("Report")
-
+	parentTable = DocType(parent)
 	is_report = parent == "Report"
 
 	if is_report:
-		columns = (report.name.as_("title"), report.ref_doctype, report.report_type)
+		columns = (parentTable.name.as_("title"), parentTable.ref_doctype, parentTable.report_type)
 	else:
-		columns = (page.title.as_("title"),)
+		columns = (parentTable.title.as_("title"),)
 
 	customRole = DocType("Custom Role")
 	hasRole = DocType("Has Role")
-	parentTable = DocType(parent)
 
 	# get pages or reports set on custom role
 	pages_with_custom_roles = (
@@ -277,7 +275,7 @@ def get_user_pages_or_reports(parent, cache=False):
 	)
 
 	if is_report:
-		pages_with_standard_roles = pages_with_standard_roles.where(report.disabled == 0)
+		pages_with_standard_roles = pages_with_standard_roles.where(parentTable.disabled == 0)
 
 	pages_with_standard_roles = pages_with_standard_roles.run(as_dict=True)
 
@@ -321,8 +319,8 @@ def get_user_pages_or_reports(parent, cache=False):
 		for r in non_permitted_reports:
 			has_role.pop(r, None)
 
-	# Expire every six hours
-	frappe.cache.set_value("has_role:" + parent, has_role, frappe.session.user, 21600)
+	# Set in cache
+	frappe.cache.hset(cache_key, frappe.session.user, has_role)
 	return has_role
 
 

--- a/frappe/core/doctype/custom_role/custom_role.py
+++ b/frappe/core/doctype/custom_role/custom_role.py
@@ -25,6 +25,13 @@ class CustomRole(Document):
 		if self.report and not self.ref_doctype:
 			self.ref_doctype = frappe.db.get_value("Report", self.report, "ref_doctype")
 
+	def clear_cache(self):
+		super().clear_cache()
+		frappe.db.after_commit.add(self._clear_has_role_cache)
+
+	def _clear_has_role_cache(self):
+		frappe.cache.delete_value(f"has_role:{'Report' if self.report else 'Page'}")
+
 	def get_permission_log_options(self, event=None):
 		if self.report:
 			return {"for_doctype": "Report", "for_document": self.report, "fields": ["roles"]}

--- a/frappe/core/doctype/page/page.py
+++ b/frappe/core/doctype/page/page.py
@@ -99,6 +99,21 @@ class Page(Document):
 }}"""
 					)
 
+	def clear_cache(self):
+		super().clear_cache()
+		if (
+			getattr(self, "_action", None) == "save"
+			and (previous := self.get_doc_before_save())
+			and ({role.role for role in self.roles} == {role.role for role in previous.roles})
+		):
+			# if roles are same when saving, do not update has_role cache
+			return
+
+		frappe.db.after_commit.add(self._clear_has_role_cache)
+
+	def _clear_has_role_cache(self):
+		frappe.cache.delete_value("has_role:Page")
+
 	def as_dict(self, **kwargs):
 		d = super().as_dict(**kwargs)
 		for key in ("script", "style", "content"):

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -83,6 +83,21 @@ class Report(Document):
 	def on_update(self):
 		self.export_doc()
 
+	def clear_cache(self):
+		super().clear_cache()
+		if (
+			getattr(self, "_action", None) == "save"
+			and (previous := self.get_doc_before_save())
+			and ({role.role for role in self.roles} == {role.role for role in previous.roles})
+		):
+			# if roles are same when saving, do not update has_role cache
+			return
+
+		frappe.db.after_commit.add(self._clear_has_role_cache)
+
+	def _clear_has_role_cache(self):
+		frappe.cache.delete_value("has_role:Report")
+
 	def before_export(self, doc):
 		doc.letterhead = None
 		doc.prepared_report = 0

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -38,7 +38,7 @@ def get_permission_query_conditions(user):
 	module_condition = False
 
 	allowed_doctypes = [frappe.db.escape(doctype) for doctype in frappe.permissions.get_doctypes_with_read()]
-	allowed_reports = [frappe.db.escape(report) for report in get_allowed_report_names()]
+	allowed_reports = [frappe.db.escape(report) for report in get_allowed_report_names(cache=True)]
 	allowed_modules = [
 		frappe.db.escape(module.get("module_name")) for module in get_modules_from_all_apps_for_user()
 	]
@@ -76,7 +76,7 @@ def has_permission(doc, ptype, user):
 		if has_common(roles, allowed):
 			return True
 	elif doc.chart_type == "Report":
-		if doc.report_name in get_allowed_report_names():
+		if doc.report_name in get_allowed_report_names(cache=True):
 			return True
 	else:
 		allowed_doctypes = frappe.permissions.get_doctypes_with_read()

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -115,7 +115,7 @@ def has_permission(doc, ptype, user):
 		return True
 
 	if doc.type == "Report":
-		if doc.report_name in get_allowed_report_names():
+		if doc.report_name in get_allowed_report_names(cache=True):
 			return True
 	else:
 		allowed_doctypes = tuple(frappe.permissions.get_doctypes_with_read())

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -70,7 +70,7 @@ class TestPermissionQueries(IntegrationTestCase):
 		).insert(ignore_permissions=True)
 
 		get_user_pages_or_reports("Report")
-		allowed_reports = frappe.cache.get_value("has_role:Report", user=frappe.session.user)
+		allowed_reports = frappe.cache.hget("has_role:Report", frappe.session.user)
 
 		# Test user must not see admin user's report
 		self.assertNotIn("Test Admin Report", allowed_reports)

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -12,6 +12,7 @@ from frappe.core.doctype.domain_settings.domain_settings import get_active_modul
 from frappe.permissions import AUTOMATIC_ROLES, get_roles, get_valid_perms
 from frappe.query_builder import DocType, Order
 from frappe.query_builder.functions import Concat_ws
+from frappe.utils import cached_property
 
 if TYPE_CHECKING:
 	from frappe.core.doctype.user.user import User
@@ -43,26 +44,11 @@ class UserPermissions:
 		self.can_email = []
 		self.allow_modules = []
 		self.in_create = []
-		self.setup_user()
 
-	def setup_user(self):
-		def get_user_doc():
-			user = None
-			try:
-				user = frappe.get_doc("User", self.name).as_dict()
-			except frappe.DoesNotExistError:
-				pass
-			except Exception as e:
-				# install boo-boo
-				if not frappe.db.is_table_missing(e):
-					raise
-
-			return user
-
-		if not frappe.flags.in_install_db and not frappe.flags.in_test:
-			user_doc = frappe.cache.hget("user_doc", self.name, get_user_doc)
-			if user_doc:
-				self.doc = frappe.get_doc(user_doc)
+	@cached_property
+	def doc(self):
+		"""return user doc"""
+		return frappe.get_doc("User", self.name)
 
 	def get_roles(self):
 		"""get list of roles"""
@@ -210,10 +196,10 @@ class UserPermissions:
 		return self.can_read
 
 	def load_user(self):
-		d = frappe.db.get_value(
+		d = frappe.get_cached_value(
 			"User",
 			self.name,
-			[
+			(
 				"creation",
 				"desk_theme",
 				"code_editor_type",
@@ -228,7 +214,7 @@ class UserPermissions:
 				"user_type",
 				"onboarding_status",
 				"default_workspace",
-			],
+			),
 			as_dict=True,
 		)
 
@@ -271,7 +257,7 @@ class UserPermissions:
 		return d
 
 	def get_all_reports(self):
-		return get_allowed_reports()
+		return get_allowed_reports(cache=True)
 
 
 def get_user_fullname(user: str) -> str:


### PR DESCRIPTION
- remove `UserPermissions.setup_user` - it's not used (added better cached property fallback instead, not sure if it is used though)
- `db.get_value` => `get_cached_value` in `UserPermissions.load_user`
- use `hget/hset` for `has_role` caches
- use `has_role` caches more often
- add eviction for `has_role` caches