### PR TITLE
fix: dont recheck `healthy` state after value is retrieved from client cache

### DIFF
--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -500,7 +500,7 @@ class ClientCache:
 		key = self.redis.make_key(key, shared=shared)
 		try:
 			val = self.cache[key]
-			if time.monotonic() < val.expiry and self.healthy:
+			if time.monotonic() < val.expiry:
 				self.hits += 1
 				return val.value
 		except KeyError:


### PR DESCRIPTION
already checked here:
https://github.com/frappe/frappe/blob/98fbec469e2760ea365235ddb78a254f2c659003/frappe/utils/redis_wrapper.py#L497

keeping this one, state may have changed while waiting on lock to get released:
https://github.com/frappe/frappe/blob/98fbec469e2760ea365235ddb78a254f2c659003/frappe/utils/redis_wrapper.py#L515