### PR TITLE
revert: meta signature

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -518,7 +518,7 @@ class DocType(Document):
 			self.setup_autoincrement_and_sequence()
 
 		try:
-			frappe.db.updatedb(self.name, Meta(None, bootstrap=self))
+			frappe.db.updatedb(self.name, Meta(self))
 		except Exception as e:
 			print(f"\n\nThere was an issue while migrating the DocType: {self.name}\n")
 			raise e

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -19,8 +19,6 @@ import json
 import os
 import typing
 from datetime import datetime
-from functools import singledispatchmethod
-from types import NoneType
 
 import click
 
@@ -67,24 +65,22 @@ LARGE_TABLE_SIZE_THRESHOLD = 100_000
 LARGE_TABLE_RECENCY_THRESHOLD = 30  # days
 
 
-def get_meta(doctype: str | dict | DocRef, cached=True) -> "_Meta":
+def get_meta(doctype: "str | DocType", cached: bool = True) -> "_Meta":
 	"""Get metadata for a doctype.
 
 	Args:
-	    doctype: The doctype as a string, dict, DocRef (also: Document) object.
+	    doctype: The doctype as a string object.
 	    cached: Whether to use cached metadata (default: True).
 
 	Returns:
 	    Meta object for the given doctype.
 	"""
-	if cached and (
-		doctype_name := getattr(doctype, "doctype", doctype)
-		if not isinstance(doctype, dict)
-		else doctype.get("doctype")
+	if (
+		cached
+		and isinstance(doctype, str)
+		and (meta := frappe.client_cache.get_value(f"doctype_meta::{doctype}"))
 	):
-		key = f"doctype_meta::{doctype_name}"
-		if meta := frappe.client_cache.get_value(key):
-			return meta
+		return meta
 
 	meta = Meta(doctype)
 	key = f"doctype_meta::{meta.name}"
@@ -145,28 +141,12 @@ class Meta(Document):
 		frappe._dict(fieldname="owner", fieldtype="Data"),
 	)
 
-	@singledispatchmethod
-	def __init__(self, arg, bootstrap: Document = None):
-		raise TypeError(f"Unsupported argument type: {type(arg)}")
+	def __init__(self, doctype: "str | DocType"):
+		if isinstance(doctype, Document):
+			super().__init__(doctype.as_dict())
+		else:
+			super().__init__("DocType", doctype)
 
-	@__init__.register(str)
-	def _(self, doctype):
-		super().__init__("DocType", doctype)
-		self.process()
-
-	@__init__.register(DocRef)
-	def _(self, doc_ref):
-		super().__init__("DocType", doc_ref.doctype)
-		self.process()
-
-	@__init__.register(dict)
-	def _(self, doc_ref):
-		super().__init__("DocType", doc_ref.get("doctype"))
-		self.process()
-
-	@__init__.register(NoneType)
-	def _(self, _args, bootstrap):
-		super().__init__(bootstrap.as_dict())
 		self.process()
 
 	def load_from_db(self):

--- a/frappe/tests/test_doc_ref.py
+++ b/frappe/tests/test_doc_ref.py
@@ -49,18 +49,6 @@ class TestDocRef(IntegrationTestCase):
 		test_doc.reload()
 		self.assertEqual(test_doc.description, "Revised Test ToDo")
 
-	def test_get_meta_with_doc_ref(self):
-		# Test get_meta with DocRef
-		doc_ref = DocRef("User", "test@example.com")
-		meta = frappe.get_meta(doc_ref)
-
-		# Check more attributes of the meta
-		self.assertEqual(meta.name, "User")
-		self.assertEqual(meta.module, "Core")
-		self.assertTrue("email" in [f.fieldname for f in meta.fields])
-		self.assertTrue("first_name" in [f.fieldname for f in meta.fields])
-		self.assertTrue("last_name" in [f.fieldname for f in meta.fields])
-
 	def test_doc_ref_value_representation(self):
 		# Test the value representation of DocRef
 		doc_ref = DocRef("User", "test@example.com")


### PR DESCRIPTION
reverts some of the changes introduced in https://github.com/frappe/frappe/pull/28526 and https://github.com/frappe/frappe/pull/27975

changing the signature of `frappe.get_meta` isn't as innocuous as it might seem at first. it is used in a LOT of code and can affect security.

ERPNext Run: https://github.com/frappe/erpnext/actions/runs/14419605343