### PR TITLE
revert: remove hashable behavior of DocRef

### DIFF
--- a/frappe/types/docref.py
+++ b/frappe/types/docref.py
@@ -15,20 +15,6 @@ class DocRef:
 		return self.name
 
 	@override
-	def __hash__(self: Union[type, "DocRef"]) -> int:
-		if isinstance(self, type):
-			raise TypeError("Only document instances can be hashed.")
-		try:
-			name = self.name
-		except AttributeError:
-			raise TypeError("Partially instantiated document instances can't be hashed.")
-		if name:
-			return hash(self.doctype + name)
-		raise TypeError(
-			f"Only named documents can be hashed; maybe the document ({self.doctype}) is unsaved."
-		)
-
-	@override
 	def __str__(self) -> str:
 		return f"{self.doctype} ({self.name or 'n/a'})"
 


### PR DESCRIPTION
- hash implementation is not good:
  - can cause collisions with actual strings
  - there is no sentinel between doctype and docname

original reason no longer valid: https://github.com/frappe/frappe/pull/28189

also hashability qualifies as a feature and should not be hidden inside an innocent looking fix in my opinion