### PR TITLE
fix: allow custom fonts in wkhtmltopdf

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -616,7 +616,11 @@ def get_print_style(
 def get_font(
 	print_settings: "PrintSettings", print_format: Optional["PrintFormat"] = None, for_legacy=False
 ) -> str:
-	default = "var(--font-stack)"
+	default = """
+	"InterVariable", "Inter", "saudiriyal", "-apple-system", "BlinkMacSystemFont",
+		"Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+		"Helvetica Neue", sans-serif;
+	"""
 	if for_legacy:
 		return default
 


### PR DESCRIPTION
# Issue
Custom fonts are not being used by `wkhtmltopdf` for printing documents. 

## Example
A custom font [was made](https://github.com/frappe/frappe/pull/31910) to support SAR currency.
In Desk:
![Screenshot from 2025-04-13 14-53-35](https://github.com/user-attachments/assets/349794c2-8910-4e2f-b02c-ebe497a98133)

PDF:
![Screenshot from 2025-04-13 11-22-33](https://github.com/user-attachments/assets/5c669cfe-72c5-4217-a93f-300db90f2f1c)


# Cause
wkhtmltopdf doesn't support CSS3 variables - https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3253#issuecomment-267594288. So `var(--font-stack)` text is used as is, which means the fonts' listed in the variable is never used.

# After Fix
![Screenshot from 2025-04-13 14-59-21](https://github.com/user-attachments/assets/7f2f9411-884d-407e-9404-2382705d179b)



I couldn't find a way to get `--font-stack` from `scss` into python. So, have hardcoded it. Open to suggestions.


Required by: https://github.com/frappe/frappe/pull/31910
Introduced by: https://github.com/frappe/frappe/pull/23935