### PR TITLE
feat: initialise and preload system settings and user for setup wizard

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -417,6 +417,7 @@ frappe.setup.slides_settings = [
 		],
 
 		onload: function (slide) {
+			frappe.setup.utils.load_prefilled_data();
 			if (frappe.setup.data.regional_data) {
 				this.setup_fields(slide);
 			} else {
@@ -508,6 +509,17 @@ frappe.setup.slides_settings = [
 ];
 
 frappe.setup.utils = {
+	load_prefilled_data: function () {
+		frappe.call({
+			method: "frappe.desk.page.setup_wizard.setup_wizard.get_prefilled_data",
+			callback: function (r) {
+				if (r.message) {
+					frappe.wizard.values = r.message;
+				}
+			},
+		});
+	},
+
 	load_regional_data: function (slide, callback) {
 		frappe.call({
 			method: "frappe.geo.country_info.get_country_timezone_info",

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -475,6 +475,7 @@ frappe.setup.slides_settings = [
 						: __("Update Password"),
 				fieldtype: "Password",
 				length: 512,
+				depends_on: "eval:!frappe.boot.is_fc_site",
 			},
 		],
 
@@ -492,7 +493,7 @@ frappe.setup.slides_settings = [
 			} else {
 				slide.form.fields_dict.email.df.reqd = 1;
 				slide.form.fields_dict.email.refresh();
-				slide.form.fields_dict.password.df.reqd = 1;
+				if (!frappe.boot.is_fc_site) slide.form.fields_dict.password.df.reqd = 1;
 				slide.form.fields_dict.password.refresh();
 
 				frappe.setup.utils.load_user_details(slide, this.setup_fields);

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -417,11 +417,19 @@ frappe.setup.slides_settings = [
 		],
 
 		onload: function (slide) {
-			frappe.setup.utils.load_prefilled_data();
+			frappe.setup.utils.load_prefilled_data(slide, this.initialize_fields);
+		},
+
+		initialize_fields: function (slide) {
+			const setup_fields = function (slide) {
+				frappe.setup.utils.setup_region_fields(slide);
+				frappe.setup.utils.setup_language_field(slide);
+			};
+
 			if (frappe.setup.data.regional_data) {
 				this.setup_fields(slide);
 			} else {
-				frappe.setup.utils.load_regional_data(slide, this.setup_fields);
+				frappe.setup.utils.load_regional_data(slide, setup_fields);
 			}
 			if (!slide.get_value("language")) {
 				let session_language =
@@ -439,11 +447,6 @@ frappe.setup.slides_settings = [
 			}
 			frappe.setup.utils.bind_region_events(slide);
 			frappe.setup.utils.bind_language_events(slide);
-		},
-
-		setup_fields: function (slide) {
-			frappe.setup.utils.setup_region_fields(slide);
-			frappe.setup.utils.setup_language_field(slide);
 		},
 	},
 	{
@@ -509,13 +512,14 @@ frappe.setup.slides_settings = [
 ];
 
 frappe.setup.utils = {
-	load_prefilled_data: function () {
+	load_prefilled_data: function (slide, callback) {
 		frappe.call({
 			method: "frappe.desk.page.setup_wizard.setup_wizard.get_prefilled_data",
 			callback: function (r) {
 				if (r.message) {
 					frappe.wizard.values = r.message;
 				}
+				callback(slide);
 			},
 		});
 	},

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -514,15 +514,34 @@ frappe.setup.slides_settings = [
 
 frappe.setup.utils = {
 	load_prefilled_data: function (slide, callback) {
-		frappe.call({
-			method: "frappe.desk.page.setup_wizard.setup_wizard.get_prefilled_data",
-			callback: function (r) {
+		frappe.db
+			.get_value("System Settings", "System Settings", [
+				"country",
+				"timezone",
+				"currency",
+				"language",
+			])
+			.then((r) => {
 				if (r.message) {
-					frappe.wizard.values = r.message;
+					frappe.wizard.values.currency = r.message.currency;
+					frappe.wizard.values.country = r.message.country;
+					frappe.wizard.values.timezone = r.message.timezone;
+					frappe.wizard.values.language = r.message.language;
+
+					frappe.db.get_value(
+						"User",
+						{ name: ["not in", ["Administrator", "Guest"]] },
+						["full_name", "email"],
+						(r) => {
+							if (r) {
+								frappe.wizard.values.full_name = r.full_name;
+								frappe.wizard.values.email = r.email;
+							}
+						}
+					);
 				}
 				callback(slide);
-			},
-		});
+			});
 	},
 
 	load_regional_data: function (slide, callback) {

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -61,8 +61,22 @@ def setup_complete(args):
 		return process_setup_stages(stages, args)
 
 
+@frappe.whitelist()
+def prefill_setup_wizard(args):
+	"""Prefill the setup wizard with given values"""
+
+	if cint(frappe.db.get_single_value("System Settings", "setup_complete")):
+		return {"status": "ok"}
+
+	print(args)
+	args = parse_args(sanitize_input(args))
+	stages = get_setup_stages({**args, "complete_setup": False})
+
+	process_setup_stages(stages, args, complete_setup=False)
+
+
 @frappe.task()
-def process_setup_stages(stages, user_input, is_background_task=False):
+def process_setup_stages(stages, user_input, is_background_task=False, complete_setup=True):
 	from frappe.utils.telemetry import capture
 
 	capture("initated_server_side", "setup")
@@ -92,6 +106,11 @@ def process_setup_stages(stages, user_input, is_background_task=False):
 			user=frappe.session.user,
 		)
 	else:
+		if not complete_setup:
+			print("Setup wizard prefill complete")
+			return
+
+		print("Setup wizard complete")
 		run_setup_success(user_input)
 		capture("completed_server_side", "setup")
 		if not is_background_task:
@@ -113,7 +132,7 @@ def update_global_settings(args):  # nosemgrep
 
 
 def run_post_setup_complete(args):  # nosemgrep
-	disable_future_access()
+	disable_future_access(complete_setup=args.get("complete_setup", True))
 	frappe.db.commit()
 	frappe.clear_cache()
 	# HACK: due to race condition sometimes old doc stays in cache.
@@ -283,12 +302,13 @@ def _get_default_roles() -> set[str]:
 	return set(frappe.get_all("Role", pluck="name")) - skip_roles
 
 
-def disable_future_access():
+def disable_future_access(complete_setup=True):
 	frappe.db.set_default("desktop:home_page", "workspace")
 	# Enable onboarding after install
 	frappe.db.set_single_value("System Settings", "enable_onboarding", 1)
 
-	frappe.db.set_single_value("System Settings", "setup_complete", 1)
+	if complete_setup:
+		frappe.db.set_single_value("System Settings", "setup_complete", 1)
 
 
 @frappe.whitelist()

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -14,7 +14,7 @@ from frappe.utils.password import update_password
 from . import install_fixtures
 
 
-def get_setup_stages(args):  # nosemgrep
+def get_setup_stages(args, complete_setup=True):  # nosemgrep
 	# App setup stage functions should not include frappe.db.commit
 	# That is done by frappe after successful completion of all stages
 	stages = [
@@ -27,7 +27,6 @@ def get_setup_stages(args):  # nosemgrep
 		}
 	]
 
-	complete_setup = args.get("complete_setup", True)
 	stages += get_stages_hooks(args)
 	if not complete_setup:
 		return stages
@@ -73,8 +72,8 @@ def prefill_setup_wizard(args):
 	if cint(frappe.db.get_single_value("System Settings", "setup_complete")):
 		return {"status": "ok"}
 
-	args = parse_args(sanitize_input({**args, "complete_setup": False}))
-	stages = get_setup_stages(args)
+	args = parse_args(sanitize_input(args))
+	stages = get_setup_stages(args, complete_setup=False)
 
 	process_setup_stages(stages, args, complete_setup=False)
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -27,7 +27,12 @@ def get_setup_stages(args):  # nosemgrep
 		}
 	]
 
-	stages += get_stages_hooks(args) + get_setup_complete_hooks(args)
+	complete_setup = args.get("complete_setup", True)
+	stages += get_stages_hooks(args)
+	if not complete_setup:
+		return stages
+
+	stages += get_setup_complete_hooks(args)
 
 	stages.append(
 		{
@@ -129,7 +134,7 @@ def update_global_settings(args):  # nosemgrep
 
 
 def run_post_setup_complete(args):  # nosemgrep
-	disable_future_access(complete_setup=args.get("complete_setup", True))
+	disable_future_access()
 	frappe.db.commit()
 	frappe.clear_cache()
 	# HACK: due to race condition sometimes old doc stays in cache.
@@ -299,13 +304,12 @@ def _get_default_roles() -> set[str]:
 	return set(frappe.get_all("Role", pluck="name")) - skip_roles
 
 
-def disable_future_access(complete_setup=True):
+def disable_future_access():
 	frappe.db.set_default("desktop:home_page", "workspace")
 	# Enable onboarding after install
 	frappe.db.set_single_value("System Settings", "enable_onboarding", 1)
 
-	if complete_setup:
-		frappe.db.set_single_value("System Settings", "setup_complete", 1)
+	frappe.db.set_single_value("System Settings", "setup_complete", 1)
 
 
 @frappe.whitelist()

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -68,9 +68,8 @@ def prefill_setup_wizard(args):
 	if cint(frappe.db.get_single_value("System Settings", "setup_complete")):
 		return {"status": "ok"}
 
-	print(args)
-	args = parse_args(sanitize_input(args))
-	stages = get_setup_stages({**args, "complete_setup": False})
+	args = parse_args(sanitize_input({**args, "complete_setup": False}))
+	stages = get_setup_stages(args)
 
 	process_setup_stages(stages, args, complete_setup=False)
 
@@ -107,10 +106,8 @@ def process_setup_stages(stages, user_input, is_background_task=False, complete_
 		)
 	else:
 		if not complete_setup:
-			print("Setup wizard prefill complete")
 			return
 
-		print("Setup wizard complete")
 		run_setup_success(user_input)
 		capture("completed_server_side", "setup")
 		if not is_background_task:
@@ -345,6 +342,25 @@ def load_user_details():
 	return {
 		"full_name": frappe.cache.hget("full_name", "signup"),
 		"email": frappe.cache.hget("email", "signup"),
+	}
+
+
+@frappe.whitelist()
+def get_prefilled_data():
+	"""Get prefilled data for setup wizard"""
+
+	system_settings = frappe.get_cached_doc("System Settings")
+	user = frappe.db.get_value(
+		"User", {"name": ("not in", frappe.STANDARD_USERS)}, ["email", "full_name"], as_dict=True
+	)
+
+	return {
+		"language": system_settings.language,
+		"country": system_settings.country,
+		"currency": system_settings.currency,
+		"timezone": system_settings.time_zone,
+		"full_name": user.full_name if user else "",
+		"email": user.email if user else "",
 	}
 
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -348,25 +348,6 @@ def load_user_details():
 	}
 
 
-@frappe.whitelist()
-def get_prefilled_data():
-	"""Get prefilled data for setup wizard"""
-
-	system_settings = frappe.get_cached_doc("System Settings")
-	user = frappe.db.get_value(
-		"User", {"name": ("not in", frappe.STANDARD_USERS)}, ["email", "full_name"], as_dict=True
-	)
-
-	return {
-		"language": system_settings.language,
-		"country": system_settings.country,
-		"currency": system_settings.currency,
-		"timezone": system_settings.time_zone,
-		"full_name": user.full_name if user else "",
-		"email": user.email if user else "",
-	}
-
-
 def prettify_args(args):  # nosemgrep
 	# remove attachments
 	for key, val in args.items():

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -14,7 +14,7 @@ from frappe.utils.password import update_password
 from . import install_fixtures
 
 
-def get_setup_stages(args, complete_setup=True):  # nosemgrep
+def get_setup_stages(args):  # nosemgrep
 	# App setup stage functions should not include frappe.db.commit
 	# That is done by frappe after successful completion of all stages
 	stages = [
@@ -27,11 +27,7 @@ def get_setup_stages(args, complete_setup=True):  # nosemgrep
 		}
 	]
 
-	stages += get_stages_hooks(args)
-	if not complete_setup:
-		return stages
-
-	stages += get_setup_complete_hooks(args)
+	stages += get_stages_hooks(args) + get_setup_complete_hooks(args)
 
 	stages.append(
 		{
@@ -69,17 +65,32 @@ def setup_complete(args):
 def prefill_setup_wizard(args):
 	"""Prefill the setup wizard with given values"""
 
-	if cint(frappe.db.get_single_value("System Settings", "setup_complete")):
-		return {"status": "ok"}
+	system_settings = frappe.get_single("System Settings")
+
+	if cint(system_settings.setup_complete):
+		return
 
 	args = parse_args(sanitize_input(args))
-	stages = get_setup_stages(args, complete_setup=False)
+	system_settings.update(
+		{
+			"language": args.get("language"),
+			"country": args.get("country"),
+			"currency": args.get("currency"),
+			"time_zone": args.get("time_zone"),
+		}
+	)
+	system_settings.save()
 
-	process_setup_stages(stages, args, complete_setup=False)
+	frappe.get_doc({
+		"doctype": "User",
+		"email": args.get("email"),
+		"first_name": args.get("first_name"),
+		"last_name": args.get("last_name"),
+	}).insert()
 
 
 @frappe.task()
-def process_setup_stages(stages, user_input, is_background_task=False, complete_setup=True):
+def process_setup_stages(stages, user_input, is_background_task=False):
 	from frappe.utils.telemetry import capture
 
 	capture("initated_server_side", "setup")
@@ -109,9 +120,6 @@ def process_setup_stages(stages, user_input, is_background_task=False, complete_
 			user=frappe.session.user,
 		)
 	else:
-		if not complete_setup:
-			return
-
 		run_setup_success(user_input)
 		capture("completed_server_side", "setup")
 		if not is_background_task:

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -81,12 +81,14 @@ def prefill_setup_wizard(args):
 	)
 	system_settings.save()
 
-	frappe.get_doc({
-		"doctype": "User",
-		"email": args.get("email"),
-		"first_name": args.get("first_name"),
-		"last_name": args.get("last_name"),
-	}).insert()
+	frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": args.get("email"),
+			"first_name": args.get("first_name"),
+			"last_name": args.get("last_name"),
+		}
+	).insert()
 
 
 @frappe.task()

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -62,9 +62,7 @@ def setup_complete(args):
 
 
 @frappe.whitelist()
-def prefill_setup_wizard(args):
-	"""Prefill the setup wizard with given values"""
-
+def initialize_system_settings_and_user(args):
 	system_settings = frappe.get_single("System Settings")
 
 	if cint(system_settings.setup_complete):

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -62,29 +62,30 @@ def setup_complete(args):
 
 
 @frappe.whitelist()
-def initialize_system_settings_and_user(args):
+def initialize_system_settings_and_user(system_settings_data, user_data):
 	system_settings = frappe.get_single("System Settings")
 
 	if cint(system_settings.setup_complete):
 		return
 
-	args = parse_args(sanitize_input(args))
+	system_settings_data = parse_args(sanitize_input(system_settings_data))
 	system_settings.update(
 		{
-			"language": args.get("language"),
-			"country": args.get("country"),
-			"currency": args.get("currency"),
-			"time_zone": args.get("time_zone"),
+			"language": system_settings_data.get("language"),
+			"country": system_settings_data.get("country"),
+			"currency": system_settings_data.get("currency"),
+			"time_zone": system_settings_data.get("time_zone"),
 		}
 	)
 	system_settings.save()
 
+	user_data = parse_args(sanitize_input(user_data))
 	frappe.get_doc(
 		{
 			"doctype": "User",
-			"email": args.get("email"),
-			"first_name": args.get("first_name"),
-			"last_name": args.get("last_name"),
+			"email": user_data.get("email"),
+			"first_name": user_data.get("first_name"),
+			"last_name": user_data.get("last_name"),
 		}
 	).insert()
 

--- a/frappe/integrations/frappe_providers/frappecloud_billing.py
+++ b/frappe/integrations/frappe_providers/frappecloud_billing.py
@@ -77,8 +77,7 @@ def api(method, data=None):
 @frappe.whitelist()
 def is_fc_site() -> bool:
 	is_system_manager = frappe.get_roles(frappe.session.user).count("System Manager")
-	setup_completed = frappe.get_system_settings("setup_complete")
-	return bool(is_system_manager and setup_completed and frappe.conf.get("fc_communication_secret"))
+	return bool(is_system_manager and frappe.conf.get("fc_communication_secret"))
 
 
 # login to frappe cloud dashboard


### PR DESCRIPTION
Can be used along with press to pre-fill known data for setup wizard and on user visiting the setup wizard page the values will be auto-filled.

`no-docs`