### PR TITLE
fix: move buttons to top

### DIFF
--- a/frappe/public/js/frappe/form/templates/address_list.html
+++ b/frappe/public/js/frappe/form/templates/address_list.html
@@ -1,3 +1,9 @@
+<p>
+	<button class="btn btn-xs btn-default btn-address">
+		{{ __("New Address") }}
+	</button>
+</p>
+
 <div class="clearfix"></div>
 {% for (const addr of addr_list) { %}
 	<div class="address-box">
@@ -37,8 +43,3 @@
 	<p class="text-muted small">{%= __("No address added yet.") %}</p>
 {% } %}
 
-<p>
-	<button class="btn btn-xs btn-default btn-address">
-		{{ __("New Address") }}
-	</button>
-</p>

--- a/frappe/public/js/frappe/form/templates/contact_list.html
+++ b/frappe/public/js/frappe/form/templates/contact_list.html
@@ -1,3 +1,9 @@
+<p>
+	<button class="btn btn-xs btn-default btn-contact">
+		{{ __("New Contact") }}
+	</button>
+</p>
+
 <div class="clearfix"></div>
 {% for (const contact of contact_list) { %}
 	<div class="address-box">
@@ -84,9 +90,3 @@
 {% if (!contact_list.length) { %}
 	<p class="text-muted small">{%= __("No contacts added yet.") %}</p>
 {% } %}
-
-<p>
-	<button class="btn btn-xs btn-default btn-contact">
-		{{ __("New Contact") }}
-	</button>
-</p>


### PR DESCRIPTION
The "New Address" and "New Contact" buttons are displayed before the list of entries to avoid unnecessary scolling to reach them.

![Bildschirmfoto 2025-04-13 um 22 42 25](https://github.com/user-attachments/assets/c8549ab2-56ca-4f1f-afbc-3b5eca2722ad)


Resolves #12147
