### PR TITLE
chore: remove duplicate call of access log

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -72,10 +72,6 @@ def get_context(context) -> PrintContext:
 
 	print_format = get_print_format_doc(None, meta=meta)
 
-	make_access_log(
-		doctype=frappe.form_dict.doctype, document=frappe.form_dict.name, file_type="PDF", method="Print"
-	)
-
 	if print_format and print_format.get("print_format_builder_beta"):
 		from frappe.utils.weasyprint import get_html
 


### PR DESCRIPTION
This function was called multiple times, possibly during conflict resolution, so I'm removing the duplicate calls.