### PR TITLE
fix(UX): block inserting more than 5000 items in table

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1112,6 +1112,9 @@ export default class Grid {
 							var data = frappe.utils.csv_to_array(
 								frappe.utils.get_decoded_string(file.dataurl)
 							);
+							if (cint(data.length) - 7 > 5000) {
+								frappe.throw(__("Cannot import table with more than 5000 rows."));
+							}
 							// row #2 contains fieldnames;
 							var fieldnames = data[2];
 							me.frm.clear_table(me.df.fieldname);


### PR DESCRIPTION
The "upload" feature allows adding arbitrary number of rows and browsers
usually can't handle >1000 well in current grid (+ backend doesn't
support this either)
