### PR TITLE
Revert "fix(HTML Editor): extraction of images"

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1371,11 +1371,11 @@ class BaseDocument:
 	def cast(self, value, df):
 		return cast_fieldtype(df.fieldtype, value, show_warning=False)
 
-	def _extract_images_from_editor(self):
+	def _extract_images_from_text_editor(self):
 		from frappe.core.doctype.file.utils import extract_images_from_doc
 
 		if self.doctype != "DocType":
-			for df in self.meta.get("fields", {"fieldtype": ("in", ("Text Editor", "HTML Editor"))}):
+			for df in self.meta.get("fields", {"fieldtype": ("=", "Text Editor")}):
 				extract_images_from_doc(self, df.fieldname)
 
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -740,7 +740,7 @@ class Document(BaseDocument, DocRef):
 		self._fix_rating_value()
 		self._validate_code_fields()
 		self._sync_autoname_field()
-		self._extract_images_from_editor()
+		self._extract_images_from_text_editor()
 		self._sanitize_content()
 		self._save_passwords()
 		self.validate_workflow()
@@ -753,7 +753,7 @@ class Document(BaseDocument, DocRef):
 			d._fix_rating_value()
 			d._validate_code_fields()
 			d._sync_autoname_field()
-			d._extract_images_from_editor()
+			d._extract_images_from_text_editor()
 			d._sanitize_content()
 			d._save_passwords()
 		if self.is_new():


### PR DESCRIPTION
Reverts frappe/frappe#28873


Parsing what is present in HTML field is not desired either. This was just supposed to be a dumb text field with different UI. Image parsing is for pasted links inside text editor, not HTML editor. 