### PR TITLE
fix: Apply permlevel for update_doc endpoint in v2 API

### DIFF
--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -110,7 +110,7 @@ def update_doc(doctype: str, name: str):
 	data.pop("flags", None)
 	doc.update(data)
 	doc.save()
-    doc.apply_fieldlevel_read_permissions()
+	doc.apply_fieldlevel_read_permissions()
 	
 	# check for child table doctype
 	if doc.get("parenttype"):

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -110,7 +110,7 @@ def update_doc(doctype: str, name: str):
 	data.pop("flags", None)
 	doc.update(data)
 	doc.save()
-	doc.apply_fieldlevel_read_permissions()
+    doc.apply_fieldlevel_read_permissions()
 	
 	# check for child table doctype
 	if doc.get("parenttype"):

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -111,7 +111,7 @@ def update_doc(doctype: str, name: str):
 	doc.update(data)
 	doc.save()
 	doc.apply_fieldlevel_read_permissions()
-	
+
 	# check for child table doctype
 	if doc.get("parenttype"):
 		frappe.get_doc(doc.parenttype, doc.parent).save()

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -110,7 +110,8 @@ def update_doc(doctype: str, name: str):
 	data.pop("flags", None)
 	doc.update(data)
 	doc.save()
-
+	doc.apply_fieldlevel_read_permissions()
+	
 	# check for child table doctype
 	if doc.get("parenttype"):
 		frappe.get_doc(doc.parenttype, doc.parent).save()


### PR DESCRIPTION
Apply Read Permission to returned fields of API v2

Bug Fix for: https://github.com/frappe/frappe/issues/32045

With this change, the API v2 now checks which fields the user is allowed to see when updating documents. In comparison to the "read_doc" method, the call to "apply_fieldlevel_read_permissions" did not yet exist when saving.

The document function “save” only checks whether the permissions for write and save are available. When the document is returned, however, no check is made at any point as to which fields the user is actually permitted to read.
With "Read_doc", the permission check is carried out in the API and fields are then checked directly.