### PR TITLE
fix: illegal characters in Excel export

### DIFF
--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -13,7 +13,9 @@ from openpyxl.workbook.child import INVALID_TITLE_REGEX
 import frappe
 from frappe.utils.html_utils import unescape_html
 
-ILLEGAL_CHARACTERS_RE = re.compile(r"[\000-\010]|[\013-\014]|[\016-\037]|\uFEFF|\uFFFE|\uFFFF|[\uD800-\uDFFF]")
+ILLEGAL_CHARACTERS_RE = re.compile(
+	r"[\000-\010]|[\013-\014]|[\016-\037]|\uFEFF|\uFFFE|\uFFFF|[\uD800-\uDFFF]"
+)
 
 
 # return xlsx file object

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -13,7 +13,7 @@ from openpyxl.workbook.child import INVALID_TITLE_REGEX
 import frappe
 from frappe.utils.html_utils import unescape_html
 
-ILLEGAL_CHARACTERS_RE = re.compile(r"[\000-\010]|[\013-\014]|[\016-\037]")
+ILLEGAL_CHARACTERS_RE = re.compile(r"[\000-\010]|[\013-\014]|[\016-\037]|\uFEFF|\uFFFE|\uFFFF|[\uD800-\uDFFF]")
 
 
 # return xlsx file object


### PR DESCRIPTION
https://github.com/frappe/frappe/issues/27930

- \uFEFF: Byte Order Mark (BOM)

- \uFFFE and \uFFFF: Reserved noncharacters

- [\uD800-\uDFFF]: Invalid Unicode surrogates (if unpaired)

Before: 
[Screencast from 15-04-25 06:46:08 PM IST.webm](https://github.com/user-attachments/assets/41a311e5-0e3b-4d76-87c1-beeb9c4be0a0)


After:
[Screencast from 15-04-25 06:55:58 PM IST.webm](https://github.com/user-attachments/assets/94d7264a-ee88-473d-9067-5ba4b956689e)
