### PR TITLE
perf: 10000s of times faster global search

### DIFF
--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -489,10 +489,11 @@ def search(text, start=0, limit=20, doctype=""):
 			continue
 
 		global_search = frappe.qb.Table("__global_search")
-		rank = Match(global_search.content).Against(word).as_("rank")
+		rank = Match(global_search.content).Against(word)
 		query = (
 			frappe.qb.from_(global_search)
-			.select(global_search.doctype, global_search.name, global_search.content, rank)
+			.select(global_search.doctype, global_search.name, global_search.content, rank.as_("rank"))
+			.where(rank)
 			.orderby("rank", order=frappe.qb.desc)
 			.limit(limit)
 		)


### PR DESCRIPTION
In a new installment of *"how did it ever work"* - global search wasn't filtering by the matched rows, just ranking, so effectively reading ENTIRE global search table all the time. 

I have no idea why this is being done here but it's horrible from performance POV. Not adding `MATCH` in where clause makes the fulltext index worthless.

![image](https://github.com/user-attachments/assets/7a70423c-3bc4-433c-bfe1-5dcc05af719e)

