### PR TITLE
fix(minor): address rendering should look same

### DIFF
--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -159,7 +159,6 @@ select.form-control {
 		margin-bottom: var(--margin-sm);
 		border: 1px solid var(--border-color);
 		border-radius: var(--border-radius);
-		@include get_textstyle("sm", "regular");
 		word-wrap: break-word;
 		position: relative;
 		p:last-child {


### PR DESCRIPTION
Before
<img width="343" alt="address rendering looks differnt" src="https://github.com/user-attachments/assets/9ecf2df9-b575-4062-95e3-96aeeb4f54c9" />

After
<img width="343" alt="address rendering same" src="https://github.com/user-attachments/assets/d4ff956c-b35e-43fc-8d5d-2fd4ab931a72" />


Ref Support ticket: https://support.frappe.io/helpdesk/tickets/36148