### PR TITLE
perf: cache link previews for 10 minutes

### DIFF
--- a/frappe/desk/link_preview.py
+++ b/frappe/desk/link_preview.py
@@ -1,8 +1,10 @@
 import frappe
 from frappe.model import no_value_fields, table_fields
+from frappe.utils.caching import http_cache
 
 
 @frappe.whitelist()
+@http_cache(max_age=60 * 10)
 def get_preview_data(doctype, docname):
 	preview_fields = []
 	meta = frappe.get_meta(doctype)

--- a/frappe/public/js/frappe/ui/link_preview.js
+++ b/frappe/public/js/frappe/ui/link_preview.js
@@ -131,10 +131,15 @@ frappe.ui.LinkPreview = class {
 	}
 
 	get_preview_data() {
-		return frappe.xcall("frappe.desk.link_preview.get_preview_data", {
-			doctype: this.doctype,
-			docname: this.name,
-		});
+		return frappe.xcall(
+			"frappe.desk.link_preview.get_preview_data",
+			{
+				doctype: this.doctype,
+				docname: this.name,
+			},
+			"GET",
+			{ cache: true }
+		);
 	}
 
 	init_preview_popover(preview_data) {


### PR DESCRIPTION
Often used for masters and often never change. Worth caching client side.
