### PR TITLE
perf(events): get_events performance & Google Calendar Integration fixes

### DIFF
--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -11,8 +11,6 @@ from frappe.commands import get_site, pass_context
 from frappe.utils.bench_helper import CliCtxObj
 
 if TYPE_CHECKING:
-	import unittest
-
 	from frappe.testing import TestRunner
 
 
@@ -46,6 +44,9 @@ def main(
 		discover_module_tests,
 	)
 	from frappe.testing.environment import _cleanup_after_tests, _initialize_test_environment
+	from frappe.tests.utils.generators import _clear_test_log
+
+	_clear_test_log()
 
 	if debug and not debug_exceptions:
 		debug_exceptions = (Exception,)
@@ -275,7 +276,7 @@ def run_tests(
 		site = get_site(context)
 
 		frappe.init(site)
-		allow_tests = frappe.get_conf().allow_tests
+		allow_tests = frappe.conf.allow_tests
 
 		if not (allow_tests or os.environ.get("CI")):
 			click.secho("Testing is disabled for the site!", bold=True)

--- a/frappe/desk/doctype/event/README.md
+++ b/frappe/desk/doctype/event/README.md
@@ -1,1 +1,0 @@
-Calendar Event

--- a/frappe/desk/doctype/event/event.json
+++ b/frappe/desk/doctype/event/event.json
@@ -297,11 +297,7 @@
  "icon": "fa fa-calendar",
  "idx": 1,
  "links": [],
-<<<<<<< HEAD
- "modified": "2024-03-23 16:03:25.511756",
-=======
  "modified": "2025-04-10 13:08:32.540745",
->>>>>>> 08e7abaac3 (fix: Event google URL field not big enough for irl data)
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Event",

--- a/frappe/desk/doctype/event/event.json
+++ b/frappe/desk/doctype/event/event.json
@@ -247,9 +247,9 @@
    "fieldname": "google_calendar_event_id",
    "fieldtype": "Data",
    "label": "Google Calendar Event ID",
+   "length": 320,
    "no_copy": 1,
-   "read_only": 1,
-   "length": 320
+   "read_only": 1
   },
   {
    "default": "0",
@@ -287,16 +287,21 @@
   },
   {
    "fieldname": "google_meet_link",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "label": "Google Meet Link",
    "no_copy": 1,
    "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "icon": "fa fa-calendar",
  "idx": 1,
  "links": [],
+<<<<<<< HEAD
  "modified": "2024-03-23 16:03:25.511756",
+=======
+ "modified": "2025-04-10 13:08:32.540745",
+>>>>>>> 08e7abaac3 (fix: Event google URL field not big enough for irl data)
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Event",
@@ -328,6 +333,7 @@
   }
  ],
  "read_only": 1,
+ "row_format": "Dynamic",
  "sender_field": "sender",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -3,7 +3,7 @@
 
 
 import json
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 import frappe
 from frappe import _
@@ -388,28 +388,35 @@ def get_events(
 		event_start = e.starts_on.date()
 		repeat_till = getdate(e.repeat_till or "3000-01-01")
 
-		if e.repeat_on == "Yearly":
-			for year in range(start.year, end.year + 1):
-				resolve_event(e, target_date=event_start.replace(year=year))
-
-		elif e.repeat_on == "Monthly":
+		try:
 			start_date = start.replace(day=event_start.day)
-			for i in range((days_range // 30) + 3):
-				resolve_event(e, target_date=add_months(start_date, i))
+		except ValueError:
+			# Handle fallback for last day of the month, e.g., 30th, 31st, 29th, 28th
+			start_date = start.replace(month=start.month + 1, day=1) + timedelta(days=-1)
 
-		elif e.repeat_on in ("Weekly", "Daily"):
+		if e.repeat_on == "Daily":
 			for i in range(days_range + 1):
 				resolve_event(e, target_date=add_days(start, i))
 
-		elif e.repeat_on == "Half Yearly":
-			start_date = start.replace(day=event_start.day)
-			for i in range((days_range // 30) + 3):
-				resolve_event(e, target_date=add_months(start_date, i * 6))
+		elif e.repeat_on == "Weekly":
+			for i in range(days_range + 1):
+				resolve_event(e, target_date=add_days(start, i))
 
-		if e.repeat_on == "Quarterly":
-			start_date = start.replace(day=event_start.day)
+		elif e.repeat_on == "Monthly":
+			for i in range((days_range // 30) + 3):
+				resolve_event(e, target_date=add_months(start_date, i))
+
+		elif e.repeat_on == "Quarterly":
 			for i in range((days_range // 30) + 3):
 				resolve_event(e, target_date=add_months(start_date, i * 3))
+
+		elif e.repeat_on == "Yearly":
+			for year in range(start.year, end.year + 1):
+				resolve_event(e, target_date=event_start.replace(year=year))
+
+		elif e.repeat_on == "Half Yearly":
+			for i in range((days_range // 30) + 3):
+				resolve_event(e, target_date=add_months(start_date, i * 6))
 
 	# Remove events that are not in the range and boolean weekdays fields
 	for event in resolved_events:

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -398,13 +398,10 @@ def get_events(
 				target_date = add_days(target_date, 1)
 
 		elif e.repeat_on == "Weekly":
-			first_occurence_in_range = e.starts_on.date()
-			jump_ahead = abs((first_occurence_in_range - start).days // 7)
-			target_date = add_days(first_occurence_in_range, 7 * jump_ahead)
-
+			target_date = start
 			while target_date <= end:
 				resolve_event(e, target_date=target_date, repeat_till=repeat_till)
-				target_date = add_days(target_date, 7)
+				target_date = add_days(target_date, 1)  # Increment by 1 to capture multiple days in the week
 
 		elif e.repeat_on == "Monthly":
 			first_occurence_in_range = e.starts_on.date()

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -2,8 +2,8 @@
 # License: MIT. See LICENSE
 
 
-from datetime import date, datetime
 import json
+from datetime import date, datetime
 
 import frappe
 from frappe import _
@@ -37,7 +37,7 @@ communication_mapping = {
 	"Other": "Other",
 }
 
-from typing import TYPE_CHECKING, Optional, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
 if TYPE_CHECKING:
 	from frappe.core.doctype.communication.communication import Communication
@@ -278,7 +278,7 @@ def get_events(start, end, user=None, for_reminder=False, filters=None) -> list[
 		user = frappe.session.user
 =======
 def get_events(
-	start: date, end: date, user: Optional[str] = None, for_reminder: bool = False, filters=None
+	start: date, end: date, user: str | None = None, for_reminder: bool = False, filters=None
 ) -> list[frappe._dict]:
 	user = user or frappe.session.user
 	EventLikeDict: TypeAlias = Event | frappe._dict

--- a/frappe/desk/doctype/event/test_event.py
+++ b/frappe/desk/doctype/event/test_event.py
@@ -348,6 +348,8 @@ class TestEvent(IntegrationTestCase):
 				"starts_on": "2025-04-15 16:00:00",
 				"repeat_till": "2025-05-06 23:59:59",
 				"tuesday": 1,
+				"wednesday": 1,
+				"friday": 1,
 				"event_type": "Public",
 				"repeat_this_event": 1,
 				"repeat_on": "Weekly",
@@ -361,6 +363,8 @@ class TestEvent(IntegrationTestCase):
 			(date(2025, 4, 15), date(2025, 4, 15)),
 			(date(2025, 4, 22), date(2025, 4, 22)),
 			(date(2025, 4, 29), date(2025, 4, 29)),
+			(date(2025, 4, 30), date(2025, 4, 30)),
+			(date(2025, 5, 2), date(2025, 5, 2)),
 		]
 		for start_date, end_date in applicable_dates:
 			event_list = get_events(start_date, end_date, "Administrator", for_reminder=True)
@@ -384,3 +388,7 @@ class TestEvent(IntegrationTestCase):
 				self.assertFalse(
 					find(event_list, test_record_matched), f"Event found between {start_date} and {end_date}"
 				)
+
+		# Test occurences of events in a timespan
+		event_list = get_events(date(2025, 4, 29), date(2025, 5, 2), "Administrator", for_reminder=True)
+		self.assertEqual(len(event_list), 3)

--- a/frappe/desk/doctype/event/test_event.py
+++ b/frappe/desk/doctype/event/test_event.py
@@ -6,6 +6,7 @@ import json
 from datetime import date
 
 import frappe
+from frappe.core.utils import find
 from frappe.desk.doctype.event.event import get_events
 from frappe.tests import IntegrationTestCase, UnitTestCase
 from frappe.tests.utils import make_test_objects
@@ -127,20 +128,21 @@ class TestEvent(IntegrationTestCase):
 				"repeat_this_event": 1,
 				"repeat_on": "Yearly",
 			}
-		)
-		ev.insert()
+		).insert()
+		def test_record_matched(e):
+			return e.name == ev.name
 
-		ev_list = get_events(date(2014, 2, 1), date(2014, 2, 1), "Administrator", for_reminder=True)
-		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list))))
+		event_list = get_events(date(2014, 2, 1), date(2014, 2, 1), "Administrator", for_reminder=True)
+		self.assertTrue(find(event_list, test_record_matched))
 
-		ev_list1 = get_events(date(2015, 1, 20), date(2015, 1, 20), "Administrator", for_reminder=True)
-		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list1))))
+		event_list = get_events(date(2015, 1, 20), date(2015, 1, 20), "Administrator", for_reminder=True)
+		self.assertFalse(find(event_list, test_record_matched))
 
-		ev_list2 = get_events(date(2014, 2, 20), date(2014, 2, 20), "Administrator", for_reminder=True)
-		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list2))))
+		event_list = get_events(date(2014, 2, 20), date(2014, 2, 20), "Administrator", for_reminder=True)
+		self.assertFalse(find(event_list, test_record_matched))
 
-		ev_list3 = get_events(date(2015, 2, 1), date(2015, 2, 1), "Administrator", for_reminder=True)
-		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list3))))
+		event_list = get_events(date(2015, 2, 1), date(2015, 2, 1), "Administrator", for_reminder=True)
+		self.assertTrue(find(event_list, test_record_matched))
 
 	def test_quaterly_repeat(self):
 		ev = frappe.get_doc(
@@ -153,31 +155,33 @@ class TestEvent(IntegrationTestCase):
 				"repeat_this_event": 1,
 				"repeat_on": "Quarterly",
 			}
-		)
-		ev.insert()
+		).insert()
+		def test_record_matched(e):
+			return e.name == ev.name
+
 		# Test Quaterly months
-		ev_list = get_events(date(2023, 2, 17), date(2023, 2, 17), "Administrator", for_reminder=True)
-		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list))))
+		event_list = get_events(date(2023, 2, 17), date(2023, 2, 17), "Administrator", for_reminder=True)
+		self.assertTrue(find(event_list, test_record_matched))
 
-		ev_list1 = get_events(date(2023, 5, 17), date(2023, 5, 17), "Administrator", for_reminder=True)
-		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list1))))
+		event_list = get_events(date(2023, 5, 17), date(2023, 5, 17), "Administrator", for_reminder=True)
+		self.assertTrue(find(event_list, test_record_matched))
 
-		ev_list2 = get_events(date(2023, 8, 17), date(2023, 8, 17), "Administrator", for_reminder=True)
-		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list2))))
+		event_list = get_events(date(2023, 8, 17), date(2023, 8, 17), "Administrator", for_reminder=True)
+		self.assertTrue(find(event_list, test_record_matched))
 
-		ev_list3 = get_events(date(2023, 11, 17), date(2023, 11, 17), "Administrator", for_reminder=True)
-		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list3))))
+		event_list = get_events(date(2023, 11, 17), date(2023, 11, 17), "Administrator", for_reminder=True)
+		self.assertTrue(find(event_list, test_record_matched))
 
 		# Test before event start date and after event end date
-		ev_list4 = get_events(date(2022, 11, 17), date(2022, 11, 17), "Administrator", for_reminder=True)
-		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list4))))
+		event_list = get_events(date(2022, 11, 17), date(2022, 11, 17), "Administrator", for_reminder=True)
+		self.assertFalse(find(event_list, test_record_matched))
 
-		ev_list4 = get_events(date(2024, 2, 17), date(2024, 2, 17), "Administrator", for_reminder=True)
-		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list4))))
+		event_list = get_events(date(2024, 2, 17), date(2024, 2, 17), "Administrator", for_reminder=True)
+		self.assertFalse(find(event_list, test_record_matched))
 
 		# Test months that aren't part of the quarterly cycle
-		ev_list4 = get_events(date(2023, 12, 17), date(2023, 12, 17), "Administrator", for_reminder=True)
-		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list4))))
+		event_list = get_events(date(2023, 12, 17), date(2023, 12, 17), "Administrator", for_reminder=True)
+		self.assertFalse(find(event_list, test_record_matched))
 
-		ev_list4 = get_events(date(2023, 3, 17), date(2023, 3, 17), "Administrator", for_reminder=True)
-		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list4))))
+		event_list = get_events(date(2023, 3, 17), date(2023, 3, 17), "Administrator", for_reminder=True)
+		self.assertFalse(find(event_list, test_record_matched))

--- a/frappe/desk/doctype/event/test_event.py
+++ b/frappe/desk/doctype/event/test_event.py
@@ -3,9 +3,9 @@
 """Use blog post test to test user permissions logic"""
 
 import json
+from datetime import date
 
 import frappe
-import frappe.defaults
 from frappe.desk.doctype.event.event import get_events
 from frappe.tests import IntegrationTestCase, UnitTestCase
 from frappe.tests.utils import make_test_objects
@@ -130,16 +130,16 @@ class TestEvent(IntegrationTestCase):
 		)
 		ev.insert()
 
-		ev_list = get_events("2014-02-01", "2014-02-01", "Administrator", for_reminder=True)
+		ev_list = get_events(date(2014, 2, 1), date(2014, 2, 1), "Administrator", for_reminder=True)
 		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list))))
 
-		ev_list1 = get_events("2015-01-20", "2015-01-20", "Administrator", for_reminder=True)
+		ev_list1 = get_events(date(2015, 1, 20), date(2015, 1, 20), "Administrator", for_reminder=True)
 		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list1))))
 
-		ev_list2 = get_events("2014-02-20", "2014-02-20", "Administrator", for_reminder=True)
+		ev_list2 = get_events(date(2014, 2, 20), date(2014, 2, 20), "Administrator", for_reminder=True)
 		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list2))))
 
-		ev_list3 = get_events("2015-02-01", "2015-02-01", "Administrator", for_reminder=True)
+		ev_list3 = get_events(date(2015, 2, 1), date(2015, 2, 1), "Administrator", for_reminder=True)
 		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list3))))
 
 	def test_quaterly_repeat(self):
@@ -156,62 +156,28 @@ class TestEvent(IntegrationTestCase):
 		)
 		ev.insert()
 		# Test Quaterly months
-		ev_list = get_events("2023-02-17", "2023-02-17", "Administrator", for_reminder=True)
+		ev_list = get_events(date(2023, 2, 17), date(2023, 2, 17), "Administrator", for_reminder=True)
 		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list))))
 
-		ev_list1 = get_events("2023-05-17", "2023-05-17", "Administrator", for_reminder=True)
+		ev_list1 = get_events(date(2023, 5, 17), date(2023, 5, 17), "Administrator", for_reminder=True)
 		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list1))))
 
-		ev_list2 = get_events("2023-08-17", "2023-08-17", "Administrator", for_reminder=True)
+		ev_list2 = get_events(date(2023, 8, 17), date(2023, 8, 17), "Administrator", for_reminder=True)
 		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list2))))
 
-		ev_list3 = get_events("2023-11-17", "2023-11-17", "Administrator", for_reminder=True)
+		ev_list3 = get_events(date(2023, 11, 17), date(2023, 11, 17), "Administrator", for_reminder=True)
 		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list3))))
 
 		# Test before event start date and after event end date
-		ev_list4 = get_events("2022-11-17", "2022-11-17", "Administrator", for_reminder=True)
+		ev_list4 = get_events(date(2022, 11, 17), date(2022, 11, 17), "Administrator", for_reminder=True)
 		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list4))))
 
-		ev_list4 = get_events("2024-02-17", "2024-02-17", "Administrator", for_reminder=True)
+		ev_list4 = get_events(date(2024, 2, 17), date(2024, 2, 17), "Administrator", for_reminder=True)
 		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list4))))
 
 		# Test months that aren't part of the quarterly cycle
-		ev_list4 = get_events("2023-12-17", "2023-12-17", "Administrator", for_reminder=True)
+		ev_list4 = get_events(date(2023, 12, 17), date(2023, 12, 17), "Administrator", for_reminder=True)
 		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list4))))
 
-		ev_list4 = get_events("2023-03-17", "2023-03-17", "Administrator", for_reminder=True)
-		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list4))))
-
-	def test_half_yearly_repeat(self):
-		ev = frappe.get_doc(
-			{
-				"doctype": "Event",
-				"subject": "_Test Event",
-				"starts_on": "2023-02-17",
-				"repeat_till": "2024-02-17",
-				"event_type": "Public",
-				"repeat_this_event": 1,
-				"repeat_on": "Half Yearly",
-			}
-		)
-		ev.insert()
-		# Test Half Yearly months
-		ev_list = get_events("2023-02-17", "2023-02-17", "Administrator", for_reminder=True)
-		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list))))
-
-		ev_list1 = get_events("2023-08-17", "2023-08-17", "Administrator", for_reminder=True)
-		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list1))))
-
-		# Test before event start date and after event end date
-		ev_list4 = get_events("2022-08-17", "2022-08-17", "Administrator", for_reminder=True)
-		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list4))))
-
-		ev_list4 = get_events("2024-02-17", "2024-02-17", "Administrator", for_reminder=True)
-		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list4))))
-
-		# Test months that aren't part of the half yearly cycle
-		ev_list4 = get_events("2023-12-17", "2023-12-17", "Administrator", for_reminder=True)
-		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list4))))
-
-		ev_list4 = get_events("2023-05-17", "2023-05-17", "Administrator", for_reminder=True)
+		ev_list4 = get_events(date(2023, 3, 17), date(2023, 3, 17), "Administrator", for_reminder=True)
 		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list4))))

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -656,7 +656,7 @@ def google_calendar_to_repeat_on(*, start, end, recurrence=None):
 			repeat_on[google_calendar_days[repeat_day]] = 1
 
 	if byday and repeat_on["repeat_on"] == "Monthly":
-		byday = byday.split("=")[1]
+		byday = byday[0]
 		repeat_day_week_number, repeat_day_name = None, None
 
 		for num in ["-2", "-1", "1", "2", "3", "4", "5"]:

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -333,7 +333,12 @@ def sync_events_from_google_calendar(g_calendar, method=None):
 				with suppress(IndexError):
 					recurrence = event.get("recurrence")[0]
 
-			if not frappe.db.exists("Event", {"google_calendar_event_id": event.get("id")}):
+			# NOTE: Skip if event is already synced; Frappe doesn't track individual
+			# instances of recurring events, so we need to check if the event is already
+			# synced in Frappe Calendar
+			if event.get("recurringEventId"):
+				...
+			elif not frappe.db.exists("Event", {"google_calendar_event_id": event.get("id")}):
 				insert_event_to_calendar(account, event, recurrence)
 			else:
 				update_event_in_calendar(account, event, recurrence)

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -766,7 +766,7 @@ def get_week_number(dt: date):
 	dom = dt.day
 	adjusted_dom = dom + first_day.weekday()
 
-	return int(ceil(adjusted_dom / 7.0))
+	return ceil(adjusted_dom / 7.0)
 
 
 def get_recurrence_parameters(recurrence: str) -> RecurrenceParameters:

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -386,6 +386,7 @@ class NotificationsView extends BaseNotificationsView {
 class EventsView extends BaseNotificationsView {
 	make() {
 		let today = frappe.datetime.get_today();
+<<<<<<< HEAD
 		frappe
 			.xcall(
 				"frappe.desk.doctype.event.event.get_events",
@@ -399,6 +400,19 @@ class EventsView extends BaseNotificationsView {
 			.then((event_list) => {
 				this.render_events_html(event_list);
 			});
+=======
+		frappe.call({
+			method: "frappe.desk.doctype.event.event.get_events",
+			args: {
+				start: today,
+				end: today,
+			},
+			type: "GET",
+			callback: ({ message }) => {
+				this.render_events_html(message);
+			},
+		});
+>>>>>>> 5215f91c0a (fix: Use GET for get_events for notification bar)
 	}
 
 	render_events_html(event_list) {

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -386,7 +386,6 @@ class NotificationsView extends BaseNotificationsView {
 class EventsView extends BaseNotificationsView {
 	make() {
 		let today = frappe.datetime.get_today();
-<<<<<<< HEAD
 		frappe
 			.xcall(
 				"frappe.desk.doctype.event.event.get_events",
@@ -400,19 +399,6 @@ class EventsView extends BaseNotificationsView {
 			.then((event_list) => {
 				this.render_events_html(event_list);
 			});
-=======
-		frappe.call({
-			method: "frappe.desk.doctype.event.event.get_events",
-			args: {
-				start: today,
-				end: today,
-			},
-			type: "GET",
-			callback: ({ message }) => {
-				this.render_events_html(message);
-			},
-		});
->>>>>>> 5215f91c0a (fix: Use GET for get_events for notification bar)
 	}
 
 	render_events_html(event_list) {

--- a/frappe/tests/utils/generators.py
+++ b/frappe/tests/utils/generators.py
@@ -414,7 +414,7 @@ class TestRecordManager:
 		temp_file.replace(self.log_file)
 
 
-def _after_install_clear_test_log():
+def _clear_test_log():
 	log_file_path = frappe.get_site_path(PERSISTENT_TEST_LOG_FILE)
 	if os.path.exists(log_file_path):
 		os.remove(log_file_path)

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -48,9 +48,9 @@ def after_install():
 			frappe.db.set_single_value("System Settings", "setup_complete", 0)
 
 	# clear test log
-	from frappe.tests.utils.generators import _after_install_clear_test_log
+	from frappe.tests.utils.generators import _clear_test_log
 
-	_after_install_clear_test_log()
+	_clear_test_log()
 
 	add_standard_navbar_items()
 


### PR DESCRIPTION
Started as a backport of https://github.com/frappe/frappe/pull/32074 with conflicts but I had to rewrite newer parts of the endpoint that only existed on develop. Added more thorough test cases and re-rewrote the original backport after uncovering buggy behaviour in previous version and previous implementations (including the current).

---

### Highlights

* Makes `frappe.desk.doctype.event.event.get_events` 14-15x faster [benchmark holds up]
* URLs under `Event.google_meet_link` are much bigger nowadays - updated fieldtype to Small Text
* Don't sync recurring events from Google Calendars since Frappe doesn't support relevant features - faster syncs & de-duplicated events
* Fix `get_events`'s quirks that seemed like clear bugs
* Add more test cases

```python
# before
In [2]: %timeit frappe.call("frappe.desk.doctype.event.event.get_events", doctype="Event", start="2025-03-31", end="2025-05-12", filters=[["Event","status","=","Open", False]
   ...: ], user='gavin.dsouza@simplesimple.org')
34.9 ms ± 2.34 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

# after
In [2]: %timeit frappe.call("frappe.desk.doctype.event.event.get_events", doctype="Event", start=date(2025, 3, 31), end=date(2025, 5, 12), filters=[["Event","status","=","Ope
   ...: n", False]], user='gavin.dsouza@simplesimple.org')
2.41 ms ± 51.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

A breaking change that should be a problem in rare cases - if get_events is being used programmatically and passes `start` & `end` as string, this change breaks support for that🤞🏼 

> NOTE: I re-raised this PR from the backport mergify created since this became more unrelated to the initial backported changes. ref: https://github.com/frappe/frappe/pull/32116 