### PR TITLE
feat: Open quick entry form when creating a new doc from a widget (quicklist or shortcuts)

### DIFF
--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -37,13 +37,7 @@ export default class QuickListWidget extends Widget {
 
 		this.add_new_button.appendTo(this.action_area);
 		this.add_new_button.on("click", () => {
-			frappe.set_route(
-				frappe.utils.generate_route({
-					type: "doctype",
-					name: this.document_type,
-					doc_view: "New",
-				})
-			);
+			frappe.new_doc(this.document_type);
 		});
 	}
 

--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -37,7 +37,14 @@ export default class QuickListWidget extends Widget {
 
 		this.add_new_button.appendTo(this.action_area);
 		this.add_new_button.on("click", () => {
-			frappe.new_doc(this.document_type);
+			frappe.ui.form.make_quick_entry(
+				this.document_type,
+				// Callback to ensure no redirection after insert
+				() => {
+					this.body.empty();
+					this.set_body(); // Refresh the quicklist
+				}
+			);
 		});
 	}
 

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -29,6 +29,11 @@ export default class ShortcutWidget extends Widget {
 		this.widget.click((e) => {
 			if (this.in_customize_mode) return;
 
+			if (this.type =="DocType" && this.doc_view == "New"){
+				frappe.new_doc(this.link_to);
+				return;
+			}
+
 			let route = frappe.utils.generate_route({
 				route: this.route,
 				name: this.link_to,

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -29,7 +29,7 @@ export default class ShortcutWidget extends Widget {
 		this.widget.click((e) => {
 			if (this.in_customize_mode) return;
 
-			if (this.type =="DocType" && this.doc_view == "New"){
+			if (this.type == "DocType" && this.doc_view == "New") {
 				frappe.ui.form.make_quick_entry(
 					this.link_to,
 					// Callback to ensure no redirection after insert

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -30,7 +30,11 @@ export default class ShortcutWidget extends Widget {
 			if (this.in_customize_mode) return;
 
 			if (this.type =="DocType" && this.doc_view == "New"){
-				frappe.new_doc(this.link_to);
+				frappe.ui.form.make_quick_entry(
+					this.link_to,
+					// Callback to ensure no redirection after insert
+					() => {}
+				);
 				return;
 			}
 


### PR DESCRIPTION
## Issue
Currently when creating a new document from a quicklist or using a shortcut to create a new document, the quick entry form is bypassed. The user is redirected directly to a blank full form instead, which defeats the purpose of having "quick" functionality.
Furthermore this is poor UX because it is inconsistent with other doc creation methods where the quick entry form pops up.
## Solution
Modified the document creation flow to properly respect the quick entry setting when documents are initiated from quicklist items or shortcuts. The quick entry form will now appear as expected in these scenarios, maintaining consistency with the "quick" functionality these features are meant to provide.
![pr_quickentrywidget](https://github.com/user-attachments/assets/b29e9936-ad25-4950-91f0-f4aba49f6df3)



`no-docs`
