### PR TITLE
feat: allow disabling specific dates in DatePicker

### DIFF
--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -77,6 +77,17 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 
 				this.update_datepicker_position();
 			},
+			onRenderCell: (date, cellType) => {
+				if (cellType === "day" && this.df.disabled_dates) {
+					const formattedDate = moment(date).format("YYYY-MM-DD");
+					if (this.df.disabled_dates.includes(formattedDate)) {
+						return {
+							disabled: true,
+							classes: "disabled",
+						};
+					}
+				}
+			},
 			...this.get_df_options(),
 		};
 	}


### PR DESCRIPTION
This PR introduces support for disabling specific dates in the DatePicker control by using a new property: **set_disabled_dates**.

Developers can now pass an array of dates (in 'YYYY-MM-DD' format) to disable them in the calendar UI. This is useful in cases where certain days (e.g. holidays, non-working days) should not be selectable by users.

### Technical Details
Modified `frappe/public/js/frappe/form/controls/date.js`

Used the **onRenderCell** hook

Checks if **this.df.set_disabled_dates** exists and disables the matching dates.

### Code added:
```javascript
onRenderCell: (date, cellType) => {
	if (cellType === 'day' && this.df.set_disabled_dates) {
		const formattedDate = moment(date).format('YYYY-MM-DD');
		if (this.df.set_disabled_dates.includes(formattedDate)) {
			return {
				disabled: true,
				classes: 'disabled'
			};
		}
	}
},
```

**Example Usage**
```javascript
frappe.ui.form.on('Your Doctype', {
	onload(frm) {
		frm.fields_dict["your_date_field"].df.set_disabled_dates = [
			"2025-04-20", // Sunday
			"2025-04-21"
		];
	}
});
```

**Why It Matters**
There is currently no built-in way to disable specific dates in the Frappe DatePicker. This addition provides a flexible and developer-friendly approach to add that behavior without needing to override or modify core widgets via hacky scripts.

<img width="451" alt="image" src="https://github.com/user-attachments/assets/767c06d4-e92b-4bfb-9829-729cdedc7a8d" />

`no-docs`
