### PR TITLE
fix: redundant comment in form timeline

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -155,7 +155,7 @@ class File(Document):
 		self.validate_protected_file()
 		self._delete_file_on_disk()
 		if not self.is_folder:
-			self.add_comment_in_reference_doc("Attachment Removed", _("Removed {0}").format(self.file_name))
+			self.add_comment_in_reference_doc("Attachment Removed", _("{0}").format(self.file_name))
 
 	def on_rollback(self):
 		rollback_flags = ("new_file", "original_content", "original_path")
@@ -767,7 +767,7 @@ class File(Document):
 
 		self.add_comment_in_reference_doc(
 			"Attachment",
-			_("Added {0}").format(f"<a href='{file_url}' target='_blank'>{file_name}</a>{icon}"),
+			_("{0}").format(f"<a href='{file_url}' target='_blank'>{file_name}</a>{icon}"),
 		)
 
 	def add_comment_in_reference_doc(self, comment_type, text):


### PR DESCRIPTION
**ISSUE:**
When adding and removing attachments, the comments in the timeline show redundant messages like:

- When adding: "You attached Added file.csv"
- When removing: "You removed attachment Removed file.csv"

**BEFORE:**

<img width="1305" alt="Screenshot 2025-04-16 at 7 32 21 PM" src="https://github.com/user-attachments/assets/52519d65-c42c-4b40-add2-9383bb778fd0" />


**FIX:** Removed the "Added" and "Removed" prefix from the filenames to show correct comments as below:

When adding: "You attached file.csv"
When removing: "You removed attachment file.csv"

**AFTER:**

<img width="1307" alt="Screenshot 2025-04-16 at 7 47 04 PM" src="https://github.com/user-attachments/assets/97705a0c-c20f-4f21-a3bc-8447b71a7805" />
