### PR TITLE
fix (communication): Relink communication doctype selection dialog shows commas under some doctypes

### DIFF
--- a/frappe/core/doctype/communication/communication.js
+++ b/frappe/core/doctype/communication/communication.js
@@ -142,9 +142,6 @@ frappe.ui.form.on("Communication", {
 					options: "DocType",
 					label: __("Reference Doctype"),
 					fieldname: "reference_doctype",
-					get_query: function () {
-						return { query: "frappe.email.get_communication_doctype" };
-					},
 				},
 				{
 					fieldtype: "Dynamic Link",


### PR DESCRIPTION
This function is causing some doctypes to display with a single comma character below them during the relink dialog.

closes #32188

Please backport to version-15-hotfix and version-14-hotfix

Removing the unnecessary function turns this:

![434984555-ed06905b-aa5f-48bc-8c71-73759fd31e13](https://github.com/user-attachments/assets/cf385b39-ca18-46f9-b670-0db2e934418a)

Into this:

![image](https://github.com/user-attachments/assets/fb9aa98b-d577-4695-854a-d6addf81a291)

