### PR TITLE
fix: remove get_query function for clean doctype selection

### DIFF
--- a/frappe/core/doctype/communication/communication.js
+++ b/frappe/core/doctype/communication/communication.js
@@ -142,9 +142,6 @@ frappe.ui.form.on("Communication", {
 					options: "DocType",
 					label: __("Reference Doctype"),
 					fieldname: "reference_doctype",
-					get_query: function () {
-						return { query: "frappe.email.get_communication_doctype" };
-					},
 				},
 				{
 					fieldtype: "Dynamic Link",


### PR DESCRIPTION
This function is causing some doctypes to display with a single comma character below them during the relink dialog.

closes https://github.com/frappe/frappe/issues/32188

Please backport to version-15-hotfix and version-14-hotfix

Removing the unnecessary function turns this:
![434988744-cf385b39-ca18-46f9-b670-0db2e934418a](https://github.com/user-attachments/assets/4c8cfbf4-ffea-40df-955e-2a90c129c7a4)


Into this:
![434988766-fb9aa98b-d577-4695-854a-d6addf81a291](https://github.com/user-attachments/assets/7689d0aa-9778-44cf-b75c-479eca4c5ae6)

