### PR TITLE
fix: return after setting value in set_route_filters

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -604,13 +604,13 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			this.prepared_report_name = route_options.prepared_report_name;
 
 			const promises = filters_to_set.map((f) => {
-				return () => {
+				return async () => {
 					let value = route_options[f.df.fieldname];
 					if (typeof value === "string" && value[0] === "[") {
 						// multiselect array
 						value = JSON.parse(value);
 					}
-					f.set_value(value);
+					await f.set_value(value);
 				};
 			});
 			promises.push(() => {


### PR DESCRIPTION
Issue: filter getting empty due to on_change is called before setting all values in set route.

Before:

https://github.com/user-attachments/assets/5d7a8639-1f23-40d6-9d0b-eaf223a7ffd9

After:

https://github.com/user-attachments/assets/4b0fcfaf-6270-4dc6-8787-8895580ff558


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/35810
closes: https://github.com/frappe/erpnext/issues/47113