### PR TITLE
fix: language change on setup wizard doesnt load options

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -427,7 +427,7 @@ frappe.setup.slides_settings = [
 			};
 
 			if (frappe.setup.data.regional_data) {
-				this.setup_fields(slide);
+				setup_fields(slide);
 			} else {
 				frappe.setup.utils.load_regional_data(slide, setup_fields);
 			}


### PR DESCRIPTION
Fixed the issue of options not loading for other fields on Language change on the Setup Wizard.

Before:

https://github.com/user-attachments/assets/b8013aba-890c-4004-9dfc-2ebca6a12111

After:

https://github.com/user-attachments/assets/88acfa50-f4ba-400d-bfb6-8894c2b7d566
