### PR TITLE
perf: use cached user and compile regex

### DIFF
--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -6,6 +6,9 @@ import re
 import frappe
 from frappe import _
 
+# check if route is /app or /app/* and not /app1 or /app1/*
+DESK_APP_PATTERN = re.compile(r"^/app(/.*)?$")
+
 
 @frappe.whitelist()
 def get_apps():
@@ -43,10 +46,8 @@ def get_route(app_name):
 
 def is_desk_apps(apps):
 	for app in apps:
-		# check if route is /app or /app/* and not /app1 or /app1/*
-		pattern = r"^/app(/.*)?$"
 		route = app.get("route")
-		if route and not re.match(pattern, route):
+		if route and not re.match(DESK_APP_PATTERN, route):
 			return False
 	return True
 
@@ -59,7 +60,7 @@ def get_default_path():
 		return None
 
 	system_default_app = frappe.get_system_settings("default_app")
-	user_default_app = frappe.db.get_value("User", frappe.session.user, "default_app")
+	user_default_app = frappe.get_cached_value("User", frappe.session.user, "default_app")
 	if system_default_app and not user_default_app:
 		return get_route(system_default_app)
 	elif user_default_app:

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -387,7 +387,7 @@ def get_enabled_system_users() -> list[dict]:
 
 
 def is_website_user(username: str | None = None) -> str | None:
-	return frappe.db.get_value("User", username or frappe.session.user, "user_type") == "Website User"
+	return frappe.get_cached_value("User", username or frappe.session.user, "user_type") == "Website User"
 
 
 def is_system_user(username: str | None = None) -> str | None:

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -166,11 +166,13 @@ def get_boot_data():
 	from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
 	from frappe.locale import get_date_format, get_first_day_of_the_week, get_number_format, get_time_format
 
+	apps = get_apps()
+
 	return {
 		"lang": frappe.local.lang or "en",
 		"apps_data": {
-			"apps": get_apps() or [],
-			"is_desk_apps": 1 if bool(is_desk_apps(get_apps())) else 0,
+			"apps": apps or [],
+			"is_desk_apps": 1 if bool(is_desk_apps(apps)) else 0,
 			"default_path": get_default_path() or "",
 		},
 		"sysdefaults": {


### PR DESCRIPTION
improves performance of https://github.com/frappe/frappe/pull/27292

---

`is_website_user` is used in other apps - ERPNext and India Compliance. prominently it's used in the `add_to_apps_screen` hook's `has_permission` implementation which gets called [frequently](https://github.com/frappe/frappe/blob/e08efc8a64154c3e7c3e01804fcc7d45f6728cbe/frappe/apps.py#L26).

`get_default_path` is also called frequently.