### PR TITLE
feat: Add Julian Day to Auto Naming series

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -359,6 +359,8 @@ def parse_naming_series(
 			part = today.strftime("%d")
 		elif e == "YYYY":
 			part = today.strftime("%Y")
+		elif e == "JJJ":
+			part = today.strftime("%j")
 		elif e == "WW":
 			part = determine_consecutive_week_number(today)
 		elif e == "timestamp":


### PR DESCRIPTION
Julian dates are standard with both Batch Dates and Serial Numbers.

Though they are used in many other naming conventions as well.

![image](https://github.com/user-attachments/assets/8997e1c8-3aa6-4275-984b-9bd8566baa15)

![image](https://github.com/user-attachments/assets/b390b175-38d1-47dc-8516-735d72b78b1a)

`no-docs`