### PR TITLE
perf: store website route map in site cache

### DIFF
--- a/frappe/website/path_resolver.py
+++ b/frappe/website/path_resolver.py
@@ -2,9 +2,10 @@ import re
 
 import click
 import werkzeug.routing.exceptions
-from werkzeug.routing import Rule
+from werkzeug.routing import Map, Rule
 
 import frappe
+from frappe.utils.caching import site_cache
 from frappe.website.page_renderers.document_page import DocumentPage
 from frappe.website.page_renderers.list_page import ListPage
 from frappe.website.page_renderers.not_found_page import NotFoundPage
@@ -13,7 +14,7 @@ from frappe.website.page_renderers.redirect_page import RedirectPage
 from frappe.website.page_renderers.static_page import StaticPage
 from frappe.website.page_renderers.template_page import TemplatePage
 from frappe.website.page_renderers.web_form import WebFormPage
-from frappe.website.router import evaluate_dynamic_routes
+from frappe.website.router import evaluate_dynamic_route_from_map
 from frappe.website.utils import can_cache, get_home_page
 
 
@@ -178,29 +179,21 @@ def resolve_path(path):
 
 def resolve_from_map(path):
 	"""transform dynamic route to a static one from hooks and route defined in doctype"""
-	rules = [
-		Rule(r["from_route"], endpoint=r["to_route"], defaults=r.get("defaults")) for r in get_website_rules()
-	]
-
-	return evaluate_dynamic_routes(rules, path) or path
+	return evaluate_dynamic_route_from_map(get_website_route_map(), path)
 
 
-def get_website_rules():
+@site_cache
+def get_website_route_map():
 	"""Get website route rules from hooks and DocType route"""
 
-	def _get():
-		rules = frappe.get_hooks("website_route_rules")
-		for d in frappe.get_all("DocType", "name, route", dict(has_web_view=1)):
-			if d.route:
-				rules.append(dict(from_route="/" + d.route.strip("/"), to_route=d.name))
+	rules = frappe.get_hooks("website_route_rules")
+	for d in frappe.get_all("DocType", ["name", "route"], {"has_web_view": 1}):
+		if d.route:
+			rules.append({"from_route": "/" + d.route.strip("/"), "to_route": d.name})
 
-		return rules
+	rules = [Rule(r["from_route"], endpoint=r["to_route"], defaults=r.get("defaults")) for r in rules]
 
-	if frappe.local.dev_server:
-		# dont cache in development
-		return _get()
-
-	return frappe.cache.get_value("website_route_rules", _get)
+	return Map(rules)
 
 
 def validate_path(path: str):

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -63,19 +63,25 @@ def evaluate_dynamic_routes(rules, path):
 	Use Werkzeug routing to evaluate dynamic routes like /project/<name>
 	https://werkzeug.palletsprojects.com/en/1.0.x/routing/
 	"""
-	route_map = Map(rules)
-	endpoint = None
 
-	if hasattr(frappe.local, "request") and frappe.local.request.environ:
-		urls = route_map.bind_to_environ(frappe.local.request.environ)
-		try:
-			endpoint, args = urls.match("/" + path)
-			if args:
-				# don't cache when there's a query string!
-				frappe.local.no_cache = 1
-				frappe.local.form_dict.update(args)
-		except NotFound:
-			pass
+	return evaluate_dynamic_route_from_map(Map(rules), path)
+
+
+def evaluate_dynamic_route_from_map(route_map, path):
+	environ = hasattr(frappe.local, "request") and frappe.local.request.environ
+	if not environ:
+		return
+
+	endpoint = None
+	urls = route_map.bind_to_environ(environ)
+	try:
+		endpoint, args = urls.match("/" + path)
+		if args:
+			# don't cache when there's a query string!
+			frappe.local.no_cache = 1
+			frappe.local.form_dict.update(args)
+	except NotFound:
+		pass
 
 	return endpoint
 

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -390,10 +390,10 @@ def clear_cache(path=None):
 		clear_sitemap()
 		frappe.clear_cache("Guest")
 		delete_page_cache()
+		clear_website_route_map()
 		keys += [
 			"portal_menu_items",
 			"home_page",
-			"website_route_rules",
 			"doctypes_with_web_view",
 			"website_redirects",
 		]
@@ -402,6 +402,12 @@ def clear_cache(path=None):
 
 	for method in frappe.get_hooks("website_clear_cache"):
 		frappe.get_attr(method)(path)
+
+
+def clear_website_route_map():
+	from frappe.website.path_resolver import get_website_route_map
+
+	get_website_route_map.clear_cache()
 
 
 def clear_website_cache(path=None):


### PR DESCRIPTION
- caching the map generated by werkzeug saves ~10ms in each request
- it's not pickle-able, using site cache
- removing `dev_server` condition - not necessary