### PR TITLE
fix: remove extra height on grid form when open

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -507,7 +507,7 @@
 
 .grid-row-open .form-in-grid {
 	opacity: 1;
-	height: 100%;
+	height: auto;
 	overflow: auto;
 	margin: auto;
 	padding: var(--padding-sm) var(--padding-md);
@@ -517,6 +517,10 @@
 	left: 50%;
 	transform: translate(-50%, 0%);
 	width: 100%;
+	.grid-form-body {
+		max-height: 80vh;
+		overflow: scroll;
+	}
 }
 
 .grid-form-heading {


### PR DESCRIPTION
- Before
![image](https://github.com/user-attachments/assets/00b92ada-6a29-4726-8a9c-992ec7813984)

- After
![image](https://github.com/user-attachments/assets/86d5b804-ce38-4998-ad40-e381ac47d144)

- Stick header at the top while scrolling

https://github.com/user-attachments/assets/a2cc5bd1-9ebf-447a-8feb-9483b7674225

