### PR TITLE
fix: selection of timezone after changing the language

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -427,7 +427,7 @@ frappe.setup.slides_settings = [
 			};
 
 			if (frappe.setup.data.regional_data) {
-				this.setup_fields(slide);
+				setup_fields(slide);
 			} else {
 				frappe.setup.utils.load_regional_data(slide, setup_fields);
 			}
@@ -525,7 +525,7 @@ frappe.setup.utils = {
 				if (r.message) {
 					frappe.wizard.values.currency = r.message.currency;
 					frappe.wizard.values.country = r.message.country;
-					frappe.wizard.values.timezone = r.message.timezone;
+					frappe.wizard.values.timezone = r.message.time_zone;
 					frappe.wizard.values.language = r.message.language;
 
 					frappe.db.get_value(


### PR DESCRIPTION
It works without changing language because the timezone was auto-filled on country selection.

`no-docs`
