### PR TITLE
chore: remove method that does nothing

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -387,7 +387,6 @@ def clear_cache(path=None):
 		frappe.cache.hdel("website_redirects", path)
 		delete_page_cache(path)
 	else:
-		clear_sitemap()
 		frappe.clear_cache("Guest")
 		delete_page_cache()
 		keys += [
@@ -406,10 +405,6 @@ def clear_cache(path=None):
 
 def clear_website_cache(path=None):
 	clear_cache(path)
-
-
-def clear_sitemap():
-	delete_page_cache("*")
 
 
 def get_frontmatter(string):


### PR DESCRIPTION
`clear_sitemap` attempts to remove a specific cache called `website_page::*` which does not exist. the `delete_page_cache` call below it is the one that actually works.