### PR TITLE
perf: Selectively switch to LIFO ordering when queue is starved

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -80,6 +80,7 @@ class PreparedReport(Document):
 			prepared_report=self.name,
 			timeout=timeout or REPORT_TIMEOUT,
 			enqueue_after_commit=True,
+			at_front_when_starved=True,
 		)
 
 	def get_prepared_data(self, with_file_name=False):

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -55,7 +55,7 @@ def setup_complete(args):
 	is_background_task = frappe.conf.get("trigger_site_setup_in_background")
 
 	if is_background_task:
-		process_setup_stages.enqueue(stages=stages, user_input=args, is_background_task=True)
+		process_setup_stages.enqueue(stages=stages, user_input=args, is_background_task=True, at_front=True)
 		return {"status": "registered"}
 	else:
 		return process_setup_stages(stages, args)

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -248,6 +248,7 @@ def bulk_workflow_approval(docnames, doctype, action):
 			action=action,
 			queue="short",
 			timeout=1000,
+			at_front_when_starved=True,
 		)
 	else:
 		frappe.throw(_("Bulk approval only support up to 500 documents."), title=_("Too Many Documents"))

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -64,6 +64,7 @@ def download_multi_pdf_async(
 		letterhead=letterhead,
 		options=options,
 		queue="long" if doc_count > 20 else "short",
+		at_front_when_starved=True,
 	)
 	frappe.local.response["http_status_code"] = http.HTTPStatus.CREATED
 	return {"task_id": task_id}


### PR DESCRIPTION
When queue is overloaded every job gets delayed by size of the queue,
this means even interactive jobs like prepared reports face significant
wait times.

This flag allows developer to selectively enable LIFO on such jobs where
ordering doesn't matter. Any time we observe queue to be too large,
we'll insert the job at front so it gets highest priority.

This is a common strategy to deal with queue starvation, we are only
applying it explicitly because job execution order matters for
correctness in some cases.
