### PR TITLE
fix(Note): make note show up only on login

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -90,6 +90,7 @@ on_session_creation = [
 	"frappe.core.doctype.user.user.notify_admin_access_to_system_manager",
 ]
 
+on_login = "frappe.desk.doctype.note.note._get_unseen_notes"
 on_logout = "frappe.core.doctype.session_default_settings.session_default_settings.clear_session_defaults"
 
 # PDF

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -470,11 +470,12 @@ frappe.Application = class Application {
 		if (frappe.boot.notes.length) {
 			frappe.boot.notes.forEach(function (note) {
 				if (!note.seen || note.notify_on_every_login) {
-					var d = frappe.msgprint({ message: note.content, title: note.title });
+					var d = new frappe.ui.Dialog({ content: note.content, title: note.title });
 					d.keep_open = true;
-					d.custom_onhide = function () {
+					d.msg_area = $('<div class="msgprint">').appendTo(d.body);
+					d.msg_area.append(note.content);
+					d.onhide = function () {
 						note.seen = true;
-
 						// Mark note as read if the Notify On Every Login flag is not set
 						if (!note.notify_on_every_login) {
 							frappe.call({
@@ -483,11 +484,13 @@ frappe.Application = class Application {
 									note: note.name,
 								},
 							});
+						} else {
+							frappe.call({
+								method: "frappe.desk.doctype.note.note.reset_notes",
+							});
 						}
-
-						// next note
-						me.show_notes();
 					};
+					d.show();
 				}
 			});
 		}

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -1,6 +1,6 @@
 import frappe
 from frappe.boot import get_user_pages_or_reports
-from frappe.desk.doctype.note.note import get_unseen_notes, mark_as_seen
+from frappe.desk.doctype.note.note import _get_unseen_notes, get_unseen_notes, mark_as_seen
 from frappe.tests import IntegrationTestCase
 
 
@@ -20,6 +20,7 @@ class TestBootData(IntegrationTestCase):
 		note.insert()
 
 		frappe.set_user("test@example.com")
+		_get_unseen_notes()
 		unseen_notes = [d.title for d in get_unseen_notes()]
 		self.assertListEqual(unseen_notes, ["Test Note"])
 


### PR DESCRIPTION
The issue here is a Note dialog doesnt show up on the "every login" it shows up on every reload.
This PR fixes that 
Reference ticket https://support.frappe.io/helpdesk/tickets/35974

Before:

https://github.com/user-attachments/assets/90f84e47-a7f7-4eac-91ae-2dd34edf2ff1

After

https://github.com/user-attachments/assets/a0c2962f-b0d4-4adf-bd23-dea2afb600bb



