### PR TITLE
fix: add param `is_system_generated=True` to `make_property_setter`

### DIFF
--- a/frappe/custom/doctype/property_setter/property_setter.py
+++ b/frappe/custom/doctype/property_setter/property_setter.py
@@ -78,6 +78,7 @@ def make_property_setter(
 	property_type,
 	for_doctype=False,
 	validate_fields_for_doctype=True,
+	is_system_generated=True,
 ):
 	# WARNING: Ignores Permissions
 	property_setter = frappe.get_doc(
@@ -89,6 +90,7 @@ def make_property_setter(
 			"property": property,
 			"value": value,
 			"property_type": property_type,
+			"is_system_generated": is_system_generated,
 		}
 	)
 	property_setter.flags.ignore_permissions = True


### PR DESCRIPTION
Defaults to `True` so that it behaves the same way as `make_custom_field` and `frappe.make_property_setter`.

Motivation: we use this method in our custom apps and I was surprised to discover that `is_system_generated` was not automatically set to `True`.
