### PR TITLE
fix: group by parent child error message

### DIFF
--- a/frappe/public/js/frappe/ui/group_by/group_by.html
+++ b/frappe/public/js/frappe/ui/group_by/group_by.html
@@ -10,11 +10,14 @@
 				<option value="" disabled selected>{{ __("Select Group By...") }}</option>
 				{% for (var parent_doctype in group_by_conditions) { %}
 					{% for (var val of group_by_conditions[parent_doctype]) { %}
+						{% field_name = val.label || val.fieldname %}
+						{% if(val.parent && doctype != val.parent) field_name += " ("+parent_doctype+")"  %}
 						<option
 							data-doctype="{{parent_doctype}}"
 							value="{{val.fieldname}}"
+							data-parent-doctype="{{doctype}}"
 						>
-							{{ __(val.label || val.fieldname, null, val.parent ) }}
+							{{ __(field_name, null, val.parent ) }}
 						</option>
 					{% } %}
 				{% } %}

--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -243,6 +243,11 @@ frappe.ui.GroupBy = class {
 	}
 
 	apply_group_by() {
+		if (this.group_by_doctype != this.aggregate_on_doctype) {
+			frappe.msgprint("Parent-to-child or child-to-parent grouping is not allowed.");
+			return false;
+		}
+
 		this.group_by = "`tab" + this.group_by_doctype + "`.`" + this.group_by_field + "`";
 
 		if (this.aggregate_function === "count") {

--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -244,7 +244,7 @@ frappe.ui.GroupBy = class {
 
 	apply_group_by() {
 		if (this.group_by_doctype != this.aggregate_on_doctype) {
-			frappe.msgprint("Parent-to-child or child-to-parent grouping is not allowed.");
+			frappe.msgprint(__("Parent-to-child or child-to-parent grouping is not allowed."));
 			return false;
 		}
 


### PR DESCRIPTION
When you select a field from the parent doctype in Group By and a field from the child doctype in Aggregate, it throws a permission error. This error is misleading. Additionally, added the parent doctype name as a prefix to child doctype fields to differentiate field names.

Support ticket: https://support.frappe.io/helpdesk/tickets/30620