### PR TITLE
fix(blog): Strip tags before truncating content for intro

### DIFF
--- a/frappe/website/doctype/blog_post/blog_post.py
+++ b/frappe/website/doctype/blog_post/blog_post.py
@@ -69,8 +69,7 @@ class BlogPost(WebsiteGenerator):
 
 		if not self.blog_intro:
 			content = get_html_content_based_on_type(self, "content", self.content_type)
-			self.blog_intro = content[:200]
-			self.blog_intro = strip_html_tags(self.blog_intro)
+			self.blog_intro = strip_html_tags(content)[:200]
 
 		if self.blog_intro:
 			self.blog_intro = self.blog_intro[:200]


### PR DESCRIPTION
There is no esay way to truncate an HTML string, so the truncation must happen after conversion to HTML. It's a bit wasteful, but pretty much required unless we drop the last partial HTML start or end tag.

`strip_html_tags("<strong>Lorem ipsum … </strong>"[:200])` = `"Lorem ipsum … </str"` (not good)