### PR TITLE
fix(fc-billing): switch manage billing to a button instead of div

### DIFF
--- a/frappe/public/js/billing.bundle.js
+++ b/frappe/public/js/billing.bundle.js
@@ -39,7 +39,7 @@ function setErrorMessage(message) {
 
 function addManageBillingDropdown() {
 	$(".dropdown-navbar-user .dropdown-menu .dropdown-divider").before(
-		`<div class="dropdown-item login-to-fc" target="_blank">Manage Billing</div>`
+		`<button class="dropdown-item login-to-fc" target="_blank">Manage Billing</button>`
 	);
 }
 


### PR DESCRIPTION
fixes the issue where the cursor is of type text instead of pointer

`no-docs`