### PR TITLE
fix(get_events): Pass date objects instead of string

### DIFF
--- a/frappe/core/notifications.py
+++ b/frappe/core/notifications.py
@@ -37,8 +37,8 @@ def get_things_todo(as_list=False):
 def get_todays_events(as_list: bool = False):
 	"""Returns a count of todays events in calendar"""
 	from frappe.desk.doctype.event.event import get_events
-	from frappe.utils import nowdate
+	from frappe.utils import getdate
 
-	today = nowdate()
+	today = getdate()
 	events = get_events(today, today)
 	return events if as_list else len(events)

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -3,7 +3,7 @@
 
 
 import json
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 
 import frappe
 from frappe import _
@@ -239,7 +239,7 @@ def has_permission(doc, user):
 
 
 def send_event_digest():
-	today = nowdate()
+	today = getdate()
 
 	# select only those users that have event reminder email notifications enabled
 	users = [


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/32246

