### PR TITLE
fix(DX): log execution time in `ms`

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -297,7 +297,7 @@ class Database:
 
 		if debug:
 			time_end = time()
-			frappe.log(f"Execution time: {time_end - time_start:.2f} sec")
+			frappe.log(f"Execution time: {(time_end - time_start) * 1000:.3f} ms")
 
 		self.log_query(query, query_type, values, debug)
 


### PR DESCRIPTION
Before:
```
Execution time: 0.00 sec
select name, is_group from tabAccount
Execution time: 0.01 sec
select
			name as gl_entry, posting_date, account, party_type, party,
			voucher_type, voucher_subtype, voucher_no, 
			cost_center, project, 
			against_voucher_type, against_voucher, account_currency,
			against, is_opening, creation , debit, credit, debit_in_account_currency,
		credit_in_account_currency 
		from `tabGL Entry`
		where company='_Test Company' and (posting_date <='2025-04-23' or is_opening = 'Yes') and (finance_book in (NULL, '') OR finance_book IS NULL) and is_cancelled = 0
		order by account, posting_date, creation
Execution time: 0.00 sec
select name, bill_no from `tabPurchase Invoice`
		where docstatus = 1 and bill_no is not null and bill_no != ''

```

After:
```
Execution time: 1.310 ms
select name, is_group from tabAccount
Execution time: 8.302 ms
select
			name as gl_entry, posting_date, account, party_type, party,
			voucher_type, voucher_subtype, voucher_no, 
			cost_center, project, 
			against_voucher_type, against_voucher, account_currency,
			against, is_opening, creation , debit, credit, debit_in_account_currency,
		credit_in_account_currency 
		from `tabGL Entry`
		where company='_Test Company' and (posting_date <='2025-04-23' or is_opening = 'Yes') and (finance_book in (NULL, '') OR finance_book IS NULL) and is_cancelled = 0
		order by account, posting_date, creation
Execution time: 0.437 ms
select name, bill_no from `tabPurchase Invoice`
		where docstatus = 1 and bill_no is not null and bill_no != ''
```