### PR TITLE
fix(Comment): logic for update notification

### DIFF
--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -66,7 +66,7 @@ class Comment(Document):
 
 	def on_update(self):
 		update_comment_in_doc(self)
-		if self.is_new():
+		if not self.is_new():
 			self.notify_change("update")
 
 	def on_trash(self):


### PR DESCRIPTION
After inserting a _new comment_, we trigger `self.notify_change("add")`. So `self.notify_change("update")` should likely be triggered for an _existing comment_ only.

Introduced in https://github.com/frappe/frappe/commit/4f32726cd7cc56fe1ba89bed6f852d85e5dca916