### PR TITLE
refactor: simplify comment refresh

### DIFF
--- a/frappe/public/js/frappe/form/footer/footer.js
+++ b/frappe/public/js/frappe/form/footer/footer.js
@@ -40,14 +40,9 @@ frappe.ui.form.Footer = class FormFooter {
 							comment_email: frappe.session.user,
 							comment_by: frappe.session.user_fullname,
 						})
-						.then((comment) => {
-							let comment_item =
-								this.frm.timeline.get_comment_timeline_item(comment);
+						.then(() => {
 							this.frm.comment_box.set_value("");
 							frappe.utils.play_sound("click");
-							this.frm.timeline.add_timeline_item(comment_item);
-							this.frm.get_docinfo().comments.push(comment);
-							this.refresh_comments_count();
 						})
 						.finally(() => {
 							this.frm.comment_box.enable();

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -745,13 +745,6 @@ class FormTimeline extends BaseTimeline {
 				})
 				.then(() => {
 					frappe.utils.play_sound("click");
-
-					// update the comment info that is stored in the frontend, then refresh the timeline
-					const comment = this.frm
-						.get_docinfo()
-						.comments.find((comment) => comment.name === comment_name);
-					comment.published = publish;
-					this.refresh();
 				});
 		});
 	}

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -2079,16 +2079,11 @@ frappe.ui.form.Form = class FrappeForm {
 					frappe.model.docinfo[doctype][docname][key].splice(docindex, 1);
 				}
 			}
-			// no need to update timeline of owner of comment
-			// gets handled via comment submit code
-			if (
-				!(
-					["add", "update"].includes(action) &&
-					doc.doctype === "Comment" &&
-					doc.owner === frappe.session.user
-				)
-			) {
-				this.timeline && this.timeline.refresh();
+
+			this.timeline && this.timeline.refresh();
+
+			if (["add", "delete"].includes(action) && doc.doctype === "Comment") {
+				this.footer.refresh_comments_count();
 			}
 		});
 	}


### PR DESCRIPTION
Depends on #32282

Before, we had a special code path for rendering new comments created by the current user. With this PR, we start re-using the same mechanism that is applied to all other comment changes (update via socketio). This results in a more consistent behavior and makes it easier to reuse for other features, like #32256.

https://github.com/user-attachments/assets/0ae70bf3-e4b7-4ede-963f-e325da55e648