### PR TITLE
fix(timeline): middle dot and margin

### DIFF
--- a/frappe/public/js/frappe/form/templates/timeline_message_box.html
+++ b/frappe/public/js/frappe/form/templates/timeline_message_box.html
@@ -31,8 +31,8 @@
 					{{ frappe.avatar(doc.owner, "avatar-medium") }}
 					<span class="ml-2" style="font-size: var(--text-base);">{{ doc.user_full_name || frappe.user.full_name(doc.owner) }}</span>
 					<span class="text-muted">{{ __("commented") }}</span>
-					<span> . </span>
-					<span class="margin-left text-muted">
+					<span> · </span>
+					<span class="text-muted">
 						{{ comment_when(doc.communication_date || doc.creation) }}
 					</span>
 				</span>
@@ -42,7 +42,7 @@
 				</span>
 				<div>
 					{{ doc.user_full_name || frappe.user.full_name(doc.owner) }}
-					<span> . </span>
+					<span> · </span>
 					<span class="text-muted">
 						{{ comment_when(doc.communication_date || doc.creation) }}
 					</span>


### PR DESCRIPTION
Before:

![Bildschirmfoto 2025-04-24 um 14 29 50](https://github.com/user-attachments/assets/4445799a-bb23-49ac-a1d4-69d03c84e743)

After:

![Bildschirmfoto 2025-04-24 um 14 29 25](https://github.com/user-attachments/assets/6490aa23-8fbe-4243-9160-092d2435a508)
