### PR TITLE
perf: use raw query for reading int-pk docs too

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -231,7 +231,7 @@ class Document(BaseDocument, DocRef):
 			self._fix_numeric_types()
 
 		else:
-			if not is_doctype and isinstance(self.name, str):
+			if not is_doctype and isinstance(self.name, str | int):
 				for_update = ""
 				if self.flags.for_update and frappe.db.db_type != "sqlite":
 					for_update = "FOR UPDATE"


### PR DESCRIPTION
Currently only string PK is supported but that wasn't the intention,
isinstance check is only there to avoid dicts/filters.
