### PR TITLE
feat: MariaDB 11.8 support

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -100,7 +100,7 @@ runs:
     run: |
       # Install System Dependencies
       start_time=$(date +%s)
-
+      curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | sudo bash
       sudo apt -qq update
       sudo apt -qq remove mysql-server mysql-client
       sudo apt -qq install libcups2-dev redis-server mariadb-client libmariadb-dev
@@ -121,6 +121,7 @@ runs:
       python -m venv ${GITHUB_WORKSPACE}/env
       source ${GITHUB_WORKSPACE}/env/bin/activate
       pip install --quiet --upgrade pip
+      pip cache remove mysqlclient
 
       pip install --quiet frappe-bench
 

--- a/.github/workflows/_base-migration.yml
+++ b/.github/workflows/_base-migration.yml
@@ -33,7 +33,7 @@ jobs:
       DB_ROOT_PASSWORD: db_root
     services:
       mariadb:
-        image: mariadb:11.3
+        image: mariadb:11.8
         ports:
           - 3306:3306
         options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3

--- a/.github/workflows/_base-server-tests.yml
+++ b/.github/workflows/_base-server-tests.yml
@@ -66,7 +66,7 @@ jobs:
         index: ${{ fromJson(needs.gen-idx-integration.outputs.indices) }}
     services:
       mariadb:
-        image: mariadb:11.3
+        image: mariadb:11.8
         ports:
           - 3306:3306
         options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3

--- a/.github/workflows/_base-ui-tests.yml
+++ b/.github/workflows/_base-ui-tests.yml
@@ -55,7 +55,7 @@ jobs:
         index: ${{ fromJson(needs.gen-idx-integration.outputs.indices) }}
     services:
       mariadb:
-        image: mariadb:11.3
+        image: mariadb:11.8
         ports:
           - 3306:3306
         options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3

--- a/.github/workflows/run-indinvidual-tests.yml
+++ b/.github/workflows/run-indinvidual-tests.yml
@@ -60,7 +60,7 @@ jobs:
 
     services:
       mysql:
-        image: mariadb:11.3
+        image: mariadb:11.8
         env:
           MARIADB_ROOT_PASSWORD: db_root
         ports:

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -109,9 +109,9 @@ def check_compatible_versions():
 				f"Warning: MariaDB version {version} is older than 10.6 which is not supported by Frappe",
 				fg="yellow",
 			)
-		elif version_tuple > (11, 3):
+		elif version_tuple > (11, 8):
 			click.secho(
-				f"Warning: MariaDB version {version} is newer than 11.3 which is not yet tested with Frappe Framework.",
+				f"Warning: MariaDB version {version} is newer than 11.8 which is not yet tested with Frappe Framework.",
 				fg="yellow",
 			)
 	except Exception:

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -133,7 +133,7 @@ class TestPerformance(IntegrationTestCase):
 		"""Ideally should be ran against gunicorn worker, though I have not seen any difference
 		when using werkzeug's run_simple for synchronous requests."""
 
-		EXPECTED_RPS = 120  # measured on GHA
+		EXPECTED_RPS = 140  # measured on GHA
 		FAILURE_THREASHOLD = 0.1
 
 		req_count = 1000


### PR DESCRIPTION
Prepare for 11.8 LTS

TODO:

- [x] fix snapshot violations https://github.com/frappe/frappe/pull/32318
- [x] Add better error messages for snapshot violation https://github.com/frappe/frappe/pull/32318
- [x] Audit breaking changes
- [x] Audit default variable changes wrt 10.6 (current "stable" branch default)
- [x] Run performance microbenchmarks 
- [x] Figure out why performance test is only failing in CI :woozy_face: 


References:

Snapshot isolation:

- https://mariadb.com/kb/en/innodb-system-variables/#innodb_snapshot_isolation 
- https://jepsen.io/blog/2024-11-07-mariadb-snapshot-isolation 
- https://jepsen.io/consistency/models/snapshot-isolation

Changelogs:

- https://mariadb.com/kb/en/what-is-mariadb-118/
- https://mariadb.com/kb/en/mariadb-11-4-2-release-notes/ 
- https://mariadb.com/kb/en/mariadb-11-0-2-release-notes/
- https://mariadb.com/kb/en/mariadb-10-11-2-release-notes/
- https://mariadb.com/kb/en/mariadb-10-10-2-release-notes/
- https://mariadb.com/kb/en/mariadb-1092-release-notes/
- https://mariadb.com/kb/en/mariadb-1083-release-notes/
- https://mariadb.com/kb/en/mariadb-1072-release-notes/

