### PR TITLE
perf: manually cast doc.name to string

### DIFF
--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -235,7 +235,7 @@ def get_comments(doctype, doc_name, frequency, user):
 
 def is_document_followed(doctype, doc_name, user):
 	return frappe.db.exists(
-		"Document Follow", {"ref_doctype": doctype, "ref_docname": doc_name, "user": user}
+		"Document Follow", {"ref_doctype": doctype, "ref_docname": str(doc_name), "user": user}
 	)
 
 

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -177,7 +177,7 @@ def get_milestones(doctype, name):
 	return frappe.get_all(
 		"Milestone",
 		fields=["creation", "owner", "track_field", "value"],
-		filters=dict(reference_type=doctype, reference_name=name),
+		filters=dict(reference_type=doctype, reference_name=str(name)),
 	)
 
 
@@ -185,7 +185,7 @@ def get_attachments(dt, dn):
 	return frappe.get_all(
 		"File",
 		fields=["name", "file_name", "file_url", "is_private"],
-		filters={"attached_to_name": dn, "attached_to_doctype": dt},
+		filters={"attached_to_name": str(dn), "attached_to_doctype": dt},
 	)
 
 
@@ -333,7 +333,7 @@ def get_communication_data(
 		},
 		dict(
 			doctype=doctype,
-			name=name,
+			name=str(name),
 			start=frappe.utils.cint(start),
 			limit=limit,
 		),
@@ -347,7 +347,7 @@ def get_assignments(dt, dn):
 		fields=["name", "allocated_to as owner", "description", "status"],
 		filters={
 			"reference_type": dt,
-			"reference_name": dn,
+			"reference_name": str(dn),
 			"status": ("not in", ("Cancelled", "Closed")),
 			"allocated_to": ("is", "set"),
 		},
@@ -368,7 +368,7 @@ def get_view_logs(doc: "Document") -> list[dict]:
 		"View Log",
 		filters={
 			"reference_doctype": doc.doctype,
-			"reference_name": doc.name,
+			"reference_name": str(doc.name),
 		},
 		fields=["name", "creation", "owner"],
 		order_by="creation desc",
@@ -383,7 +383,7 @@ def get_tags(doctype: str, name: str) -> str:
 
 	tags = frappe.get_all(
 		"Tag Link",
-		filters={"document_type": doctype, "document_name": name},
+		filters={"document_type": doctype, "document_name": str(name)},
 		fields=["tag"],
 		pluck="tag",
 	)

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -148,7 +148,7 @@ def _get_users(doc: "Document") -> list:
 			"owner",
 			"creation",
 		],
-		filters=dict(share_doctype=doc.doctype, share_name=doc.name),
+		filters=dict(share_doctype=doc.doctype, share_name=str(doc.name)),
 	)
 
 


### PR DESCRIPTION
This avoid full table scans and undesired implicit casting at MySQL level.


Lessen impact of https://github.com/frappe/frappe/issues/32287 