### PR TITLE
fix: Module not found error for custom doctypes

### DIFF
--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -564,7 +564,16 @@ def _get_linked_doctypes(doctype, without_ignore_user_permissions_enabled=False)
 			continue
 		ret[dt] = {"get_parent": True}
 
+	custom_doctypes = frappe.get_all(
+		doctype="DocType", filters=[["custom", "=", 1], ["name", "in", list(ret.keys())]], as_list=True
+	)
+
+	custom_doctypes = [item[0] for item in custom_doctypes]
+
 	for dt in list(ret):
+		# if the custom checkbox is checked, then don't load the module of the DocType because it doesn't belong to any app.
+		if dt in custom_doctypes:
+			continue
 		try:
 			doctype_module = load_doctype_module(dt)
 		except (ImportError, KeyError):

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -247,7 +247,7 @@ def load_doctype_module(doctype, module=None, prefix="", suffix=""):
 	module = module or get_doctype_module(doctype)
 	app = get_module_app(module)
 	key = (app, doctype, prefix, suffix)
-	module_name = get_module_name(doctype, module, prefix, suffix)
+	module_name = get_module_name(doctype, module, prefix, suffix, app)
 
 	if key not in doctype_python_modules:
 		try:


### PR DESCRIPTION
Support ticket: https://support.frappe.io/helpdesk/tickets/35786

It was fetching the module of the custom app, and during this process, it tried to fetch the app of the custom module. However, the custom module doesn't have any app, which is why it was throwing an error.

- Before

https://github.com/user-attachments/assets/2bf27fd5-5617-4326-a7a6-3cbf9be88782


- After

https://github.com/user-attachments/assets/cee16490-2905-45ed-8f81-813d2650b9ab

