### PR TITLE
feat(utils): Enhance shell execution with passthrough support for real-time database restore progress

### DIFF
--- a/frappe/database/db_manager.py
+++ b/frappe/database/db_manager.py
@@ -62,30 +62,34 @@ class DbManager:
 
 		import shlex
 		from shutil import which
-
 		from frappe.database import get_command
 		from frappe.utils import execute_in_shell
 
-		# Ensure that the entire process fails if any part of the pipeline fails
 		command: list[str] = ["set -o pipefail;"]
 
-		# Handle gzipped backups
+		quoted_source = shlex.quote(source)
+
+		# Handle gzipped backups with optional pv
 		if source.endswith(".gz"):
 			if gzip := which("gzip"):
-				command.extend([gzip, "-cd", source, "|"])
+				if which("pv"):
+					command.append(f"pv {quoted_source} | {gzip} -cd |")
+				else:
+					command.append(f"{gzip} -cd {quoted_source} |")
 			else:
 				raise Exception("`gzip` not installed")
 		else:
-			command.extend(["cat", source, "|"])
+			if which("pv"):
+				command.append(f"pv {quoted_source} |")
+			else:
+				command.append(f"cat {quoted_source} |")
 
+		# Filter problematic MariaDB lines
 		if frappe.conf.db_type == "mariadb":
-			# Newer versions of MariaDB add in a line that'll break on older versions, so remove it
-			command.extend(["sed", r"'/\/\*M\{0,1\}!999999\\- enable the sandbox mode \*\//d'", "|"])
+			command.append("sed '/\\/\\*M\\{0,1\\}!999999\\- enable the sandbox mode \\*\\//d' |")
+			command.append("sed '/\\/\\*![0-9]* DEFINER=[^ ]* SQL SECURITY DEFINER \\*\\//d' |")
 
-			# Remove view security definers
-			command.extend(["sed", r"'/\/\*![0-9]* DEFINER=[^ ]* SQL SECURITY DEFINER \*\//d'", "|"])
-
-		# Generate the restore command
+		# Construct the database restore command
 		bin, args, bin_name = get_command(
 			socket=frappe.conf.db_socket,
 			host=frappe.conf.db_host,
@@ -99,8 +103,11 @@ class DbManager:
 				_("{} not found in PATH! This is required to restore the database.").format(bin_name),
 				exc=frappe.ExecutableNotFound,
 			)
-		command.append(bin)
-		command.append(shlex.join(args))
 
-		execute_in_shell(" ".join(command), check_exit_code=True, verbose=verbose)
-		frappe.cache.delete_keys("")  # Delete all keys associated with this site.
+		command.append(f"{bin} {shlex.join(args)}")
+
+		# Execute and stream output live to terminal
+		execute_in_shell(" ".join(command), check_exit_code=True, verbose=verbose, passthrough=True)
+
+		# Clear cache for fresh DB state
+		frappe.cache.delete_keys("")

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -449,43 +449,50 @@ def unesc(s, esc_chars):
 	return s
 
 
-def execute_in_shell(cmd, verbose=False, low_priority=False, check_exit_code=False):
-	# using Popen instead of os.system - as recommended by python docs
+def execute_in_shell(cmd, verbose=False, low_priority=False, check_exit_code=False, passthrough=False):
 	import shlex
-	import tempfile
+	import shutil
+	import os
 	from subprocess import Popen
+	from tempfile import TemporaryFile
 
 	if isinstance(cmd, list):
-		# ensure it's properly escaped; only a single string argument executes via shell
 		cmd = shlex.join(cmd)
 
-	with tempfile.TemporaryFile() as stdout, tempfile.TemporaryFile() as stderr:
-		kwargs = {
-			"shell": True,
-			"stdout": stdout,
-			"stderr": stderr,
-			"executable": shutil.which("bash") or "/bin/bash",
-		}
+	kwargs = {
+		"shell": True,
+		"executable": shutil.which("bash") or "/bin/bash",
+	}
 
-		if low_priority:
-			kwargs["preexec_fn"] = lambda: os.nice(10)
+	if low_priority:
+		kwargs["preexec_fn"] = lambda: os.nice(10)
 
+	if passthrough:
+		# Directly stream output to terminal (useful for tools like `pv`)
 		p = Popen(cmd, **kwargs)
 		exit_code = p.wait()
+		out, err = b"", b""
+	else:
+		with TemporaryFile() as stdout, TemporaryFile() as stderr:
+			kwargs["stdout"] = stdout
+			kwargs["stderr"] = stderr
 
-		stdout.seek(0)
-		out = stdout.read()
+			p = Popen(cmd, **kwargs)
+			exit_code = p.wait()
 
-		stderr.seek(0)
-		err = stderr.read()
+			stdout.seek(0)
+			out = stdout.read()
+
+			stderr.seek(0)
+			err = stderr.read()
 
 	failed = check_exit_code and exit_code
 
 	if verbose or failed:
 		if err:
-			print(err)
+			print(err.decode(errors="replace"))
 		if out:
-			print(out)
+			print(out.decode(errors="replace"))
 
 	if failed:
 		raise frappe.CommandFailedError(


### PR DESCRIPTION
Adds a **passthrough** flag to the execute_in_shell utility, enabling **real-time progress** feedback (e.g., from pv) directly to the terminal.

It improves visibility during long-running operations like database restores.

Previously, command outputs were only visible after the operation completed, making it difficult to track progress for large restores.
With this change:

When passthrough is enabled, output (like pv progress) is streamed live.

If passthrough is disabled, output capture works as before.

restore_database now uses pv when available, improving restore experience without affecting gzip handling or MariaDB-specific filters.

Before:
No live progress; command output shown only after completion.
![Before](https://github.com/user-attachments/assets/d7c106bb-9d7b-4b8a-92c1-8f25a8b57df4)

After:
Real-time progress feedback while restoring database (if pv is installed).
![After](https://github.com/user-attachments/assets/c3313fbb-194a-47ba-b52f-1b6584100e4a)
