### PR TITLE
fix(load): Don't fetch Dynamic Link titles if missing doctype

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -435,7 +435,7 @@ def get_title_values_for_link_and_dynamic_link_fields(doc, link_fields=None):
 
 		doctype = field.options if field.fieldtype == "Link" else doc.get(field.options)
 
-		meta = frappe.get_meta(doctype)
+		meta = frappe.get_meta(doctype) if doctype else None
 		if not meta or not meta.title_field or not meta.show_title_field_in_link:
 			continue
 


### PR DESCRIPTION
I normal usage, it's not possible for a Dynamic Link to have a value but no associated reference DocType. _**But…**_

---

…to be cautious, don't assume it's always the case. Also, the following lines assume that `meta` might be optional, but frappe.get_meta always returns a result or throws an exception, so they only make sense if you check first that the reference doctype is defined.

```py
		if not meta or not meta.title_field or not meta.show_title_field_in_link:
			continue
```