### PR TITLE
fix(link): dont force set value in model

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -134,7 +134,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			frappe.utils.add_link_title(this.df.options, value, label);
 		}
 
-		return this.validate_and_set_in_model(value, e, true);
+		return this.validate_and_set_in_model(value, e);
 	}
 	parse(value) {
 		return strip_html(value);


### PR DESCRIPTION
This client script get triggers twice
```
frappe.ui.form.on('ToDo', {

reference_type(frm) {

    frappe.msgprint('select field is changed')

}

})
```
Before

https://github.com/user-attachments/assets/8fabafca-257b-442d-beed-78a56a9b64b2



After

https://github.com/user-attachments/assets/c25d2ac1-8b87-4887-8cca-5cdaea068d07




Support ticket:  https://support.frappe.io/helpdesk/tickets/36880