### PR TITLE
feat: let's use email template for auto email report

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.json
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.json
@@ -33,6 +33,7 @@
   "sender",
   "frequency",
   "format",
+  "email_template",
   "section_break_15",
   "description"
  ],
@@ -217,10 +218,17 @@
    "fieldname": "use_first_day_of_period",
    "fieldtype": "Check",
    "label": "Use First Day of Period"
+  },
+  {
+   "depends_on": "eval:doc.format == 'HTML'",
+   "fieldname": "email_template",
+   "fieldtype": "Link",
+   "label": "Email template",
+   "options": "Email Template"
   }
  ],
  "links": [],
- "modified": "2024-03-23 16:01:28.131581",
+ "modified": "2025-04-27 14:38:52.028064",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Auto Email Report",
@@ -251,6 +259,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -47,6 +47,7 @@ class AutoEmailReport(Document):
 		dynamic_date_period: DF.Literal[
 			"", "Daily", "Weekly", "Monthly", "Quarterly", "Half Yearly", "Yearly"
 		]
+		email_template: DF.Link | None
 		email_to: DF.SmallText
 		enabled: DF.Check
 		filter_meta: DF.Text | None
@@ -191,8 +192,13 @@ class AutoEmailReport(Document):
 		date_time = global_date_format(now()) + " " + format_time(now())
 		report_doctype = frappe.db.get_value("Report", self.report, "ref_doctype")
 
+		template = (
+			frappe.get_value("Email Template", self.email_template, "response_html")
+			or "frappe/templates/emails/auto_email_report.html"
+		)
+
 		return frappe.render_template(
-			"frappe/templates/emails/auto_email_report.html",
+			template,
 			{
 				"title": self.name,
 				"description": self.description,

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -71,6 +71,10 @@ class AutoEmailReport(Document):
 		if frappe.db.exists("Auto Email Report", self.name):
 			self.name = append_number_if_name_exists("Auto Email Report", self.name)
 
+	def before_save(self):
+		if self.format != "HTML":
+			self.email_template = None
+
 	def validate(self):
 		self.validate_report_count()
 		self.validate_emails()


### PR DESCRIPTION
Currently, the only (known) way to change email template for Auto Email report is changing directly the html file, since template file reference is hardcoded.

After this change we can add a template for each report.
![image](https://github.com/user-attachments/assets/4a2ed635-4a74-444b-b7df-f51c8666d2be)



