### PR TITLE
fix: extend_notification_header

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -16,7 +16,8 @@
   "attachment_link",
   "open_reference_document",
   "from_user",
-  "link"
+  "link",
+  "email_header"
  ],
  "fields": [
   {
@@ -98,12 +99,17 @@
    "fieldtype": "Data",
    "hidden": 1,
    "label": "Link"
+  },
+  {
+   "fieldname": "email_header",
+   "fieldtype": "Data",
+   "label": "Email Header"
   }
  ],
  "hide_toolbar": 1,
  "in_create": 1,
  "links": [],
- "modified": "2024-08-03 09:38:10.497711",
+ "modified": "2025-05-10 23:58:54.717673",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Log",
@@ -119,6 +125,7 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -152,12 +152,12 @@ def get_email_header(doc, language: str | None = None):
 		"Assignment": _("Assignment Update on {0}", lang=language).format(docname),
 		"Share": _("New Document Shared {0}", lang=language).format(docname),
 	}
-	header_map = {
-		**header_map,
-		**format_email_header(
-			frappe.get_hooks("notification_email_header"), language=language, docname=docname
-		),
-	}
+	additional_email_headers = frappe.get_hooks("notification_email_header")
+	if len(additional_email_headers) > 0:
+		header_map = {
+			**header_map,
+			**format_email_header(additional_email_headers, language=language, docname=docname),
+		}
 	return header_map[doc.type or "Default"]
 
 

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -152,8 +152,20 @@ def get_email_header(doc, language: str | None = None):
 		"Assignment": _("Assignment Update on {0}", lang=language).format(docname),
 		"Share": _("New Document Shared {0}", lang=language).format(docname),
 	}
-
+	header_map = {
+		**header_map,
+		**format_email_header(
+			frappe.get_hooks("notification_email_header"), language=language, docname=docname
+		),
+	}
 	return header_map[doc.type or "Default"]
+
+
+def format_email_header(header_map, language, docname):
+	messages = []
+	for v in list(header_map.values()):
+		messages.append(_(v[0], lang=language).format(docname))
+	return dict(zip(header_map.keys(), messages, strict=True))
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -152,13 +152,9 @@ def get_email_header(doc, language: str | None = None):
 		"Assignment": _("Assignment Update on {0}", lang=language).format(docname),
 		"Share": _("New Document Shared {0}", lang=language).format(docname),
 	}
-	additional_email_headers = frappe.get_hooks("notification_email_header")
-	if len(additional_email_headers) > 0:
-		header_map = {
-			**header_map,
-			**format_email_header(additional_email_headers, language=language, docname=docname),
-		}
-	return header_map[doc.type or "Default"]
+	if not doc.email_header:
+		doc.email_header = header_map[doc.type or "default"]
+	return doc.email_header
 
 
 def format_email_header(header_map, language, docname):

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -671,9 +671,6 @@ frappe.ui.form.Form = class FrappeForm {
 
 			route_callback(this);
 		}
-		if (frappe.route_hooks.post_after_load) {
-			frappe.route_hooks.post_after_load(this);
-		}
 	}
 
 	refresh_fields() {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -671,6 +671,9 @@ frappe.ui.form.Form = class FrappeForm {
 
 			route_callback(this);
 		}
+		if (frappe.route_hooks.post_after_load) {
+			frappe.route_hooks.post_after_load(this);
+		}
 	}
 
 	refresh_fields() {

--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -163,6 +163,11 @@ frappe.ui.form.ScriptManager = class ScriptManager {
 				handlers.new_style.push(fn);
 			});
 		}
+		if (frappe.ui.form.handlers["*"] && frappe.ui.form.handlers["*"][event_name]) {
+			$.each(frappe.ui.form.handlers["*"][event_name], function (i, fn) {
+				handlers.new_style.push(fn);
+			});
+		}
 		if (this.frm.cscript && this.frm.cscript[event_name]) {
 			handlers.old_style.push(event_name);
 		}


### PR DESCRIPTION
This PR adds 2 things
1.  A new email header field on Notification Log to allow adding the email header via the EPS app (previously wrote a hook for this)
2. It adds * in client script to allow writing script for all forms 

All of the above changes are used here https://github.com/frappe/eps/tree/custom-field-notication