### PR TITLE
fix(document): don't try to overwrite name if already set

### DIFF
--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -39,6 +39,8 @@ def handle_rpc_call(method: str):
 def create_doc(doctype: str):
 	data = get_request_form_data()
 	data.pop("doctype", None)
+	if (name := data.get("name")) and isinstance(name, str):
+		frappe.flags.api_name_set = True
 	return frappe.new_doc(doctype, **data).insert()
 
 

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -89,6 +89,8 @@ def count(doctype: str) -> int:
 def create_doc(doctype: str):
 	data = frappe.form_dict
 	data.pop("doctype", None)
+	if (name := data.get("name")) and isinstance(name, str):
+		frappe.flags.api_name_set = True
 	return frappe.new_doc(doctype, **data).insert()
 
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -646,7 +646,7 @@ class Document(BaseDocument, DocRef):
 	def set_new_name(self, force=False, set_name=None, set_child_names=True):
 		"""Calls `frappe.naming.set_new_name` for parent and child docs."""
 
-		if self.flags.name_set and not force:
+		if (frappe.flags.api_name_set or self.flags.name_set) and not force:
 			return
 
 		autoname = self.meta.autoname or ""


### PR DESCRIPTION
This allows us to pass `name` in via API when creating documents.

Resolves #32298
