### PR TITLE
fix: prevent updating first_responded_on on automated message

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -644,7 +644,10 @@ def update_first_response_time(parent, communication):
 			is_system_user(communication.sender)
 			or frappe.get_cached_value("User", frappe.session.user, "user_type") == "System User"
 		):
-			if communication.sent_or_received == "Sent":
+			if (
+				communication.sent_or_received == "Sent"
+				and communication.communication_type == "Communication"
+			):
 				first_responded_on = communication.creation
 				if parent.meta.has_field("first_responded_on"):
 					parent.db_set("first_responded_on", first_responded_on)


### PR DESCRIPTION
Prevent updating `first_responded_on` field for Automated Message type Communications.

In the ERPNext Support Module, if an email notification is set up to be sent out when a Service Level Agreement (SLA) is nearing failure for any Issue, this notification email is treated as the first response. Consequently, the "first_responded_on" field gets updated accordingly, which should not happen. 

https://support.frappe.io/helpdesk/tickets/36797