### PR TITLE
fix: correct Toggle Logic for Prepared Report in update_disable_prepared_report

### DIFF
--- a/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.py
+++ b/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.py
@@ -71,7 +71,7 @@ class RolePermissionforPageandReport(Document):
 			frappe.db.sql(
 				"""update `tabReport` set disable_prepared_report = %s, prepared_report = %s
 				where name = %s""",
-				(self.disable_prepared_report, not self.disable_prepared_report, self.report),
+				(self.disable_prepared_report, cint(not self.disable_prepared_report), self.report),
 			)
 
 	def get_args(self, row=None):


### PR DESCRIPTION
### Summary
This pull request corrects the logic in the `update_disable_prepared_report` method to ensure that the `prepared_report` field is properly updated as the inverse of `disable_prepared_report`.

### Changes
- Replaced direct negation (`not self.disable_prepared_report`) with `cint(not self.disable_prepared_report)` to correctly handle the conversion to an integer (0/1), aligning with database expectations.
- Maintained the use of `frappe.db.sql` for explicit control over the update operation, as originally intended.

### Why this change?
Using `not` directly returns a boolean (`True`/`False`), whereas the database expects an integer (`1`/`0`). This update ensures compatibility with MariaDB/MySQL requirements and prevents potential data inconsistencies.

### Testing
- Verified that toggling the `disable_prepared_report` flag correctly updates both fields in `tabReport`.
- Ensured no regressions by reviewing related functionalities relying on report settings.

## Full Traceback
```
06:29:29 web.1         | Traceback (most recent call last):
06:29:29 web.1         |   File "apps/frappe/frappe/app.py", line 98, in application
06:29:29 web.1         |     response = frappe.api.handle()
06:29:29 web.1         |                ^^^^^^^^^^^^^^^^^^^
06:29:29 web.1         |   File "apps/frappe/frappe/api.py", line 55, in handle
06:29:29 web.1         |     return frappe.handler.handle()
06:29:29 web.1         |            ^^^^^^^^^^^^^^^^^^^^^^^
06:29:29 web.1         |   File "apps/frappe/frappe/handler.py", line 49, in handle
06:29:29 web.1         |     data = execute_cmd(cmd)
06:29:29 web.1         |            ^^^^^^^^^^^^^^^^
06:29:29 web.1         |   File "apps/frappe/frappe/handler.py", line 84, in execute_cmd
06:29:29 web.1         |     return frappe.call(method, **frappe.form_dict)
06:29:29 web.1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
06:29:29 web.1         |   File "apps/frappe/frappe/__init__.py", line 1627, in call
06:29:29 web.1         |     return fn(*args, **newargs)
06:29:29 web.1         |            ^^^^^^^^^^^^^^^^^^^^
06:29:29 web.1         |   File "apps/frappe/frappe/handler.py", line 334, in run_doc_method
06:29:29 web.1         |     response = doc.run_method(method)
06:29:29 web.1         |                ^^^^^^^^^^^^^^^^^^^^^^
06:29:29 web.1         |   File "apps/frappe/frappe/model/document.py", line 945, in run_method
06:29:29 web.1         |     out = Document.hook(fn)(self, *args, **kwargs)
06:29:29 web.1         |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
06:29:29 web.1         |   File "apps/frappe/frappe/model/document.py", line 1297, in composer
06:29:29 web.1         |     return composed(self, method, *args, **kwargs)
06:29:29 web.1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
06:29:29 web.1         |   File "apps/frappe/frappe/model/document.py", line 1279, in runner
06:29:29 web.1         |     add_to_return_value(self, fn(self, *args, **kwargs))
06:29:29 web.1         |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
06:29:29 web.1         |   File "apps/frappe/frappe/model/document.py", line 942, in fn
06:29:29 web.1         |     return method_object(*args, **kwargs)
06:29:29 web.1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
06:29:29 web.1         |   File "apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.py", line 50, in update_report_page_data
06:29:29 web.1         |     self.update_disable_prepared_report()
06:29:29 web.1         |   File "apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.py", line 71, in update_disable_prepared_report
06:29:29 web.1         |     frappe.db.sql(
06:29:29 web.1         |   File "apps/frappe/frappe/database/postgres/database.py", line 209, in sql
06:29:29 web.1         |     return super().sql(modify_query(query), modify_values(values), *args, **kwargs)
06:29:29 web.1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
06:29:29 web.1         |   File "apps/frappe/frappe/database/database.py", line 244, in sql
06:29:29 web.1         |     self._cursor.execute(query, values)
06:29:29 web.1         | psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type smallint: "False"
06:29:29 web.1         | LINE 1: ...set disable_prepared_report = '1', prepared_report = 'False'
```