### PR TITLE
fix(permissions): handle document creation access when ownership is not assigned

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -306,10 +306,15 @@ def get_role_permissions(doctype_meta, user=None, is_owner=None, debug=False):
 				and ptype != "create"
 			):
 				perms["if_owner"][ptype] = cint(pvalue and is_owner)
-				# has no access if not owner
-				# only provide select or read access so that user is able to at-least access list
-				# (and the documents will be filtered based on owner sin further checks)
-				perms[ptype] = 1 if ptype in ("select", "read") else 0
+
+				# Handle document creation case where ownership is not yet assigned
+				if is_owner is None and ptype == "write":
+					perms[ptype] = cint(pvalue)
+				else:
+					# has no access if not owner
+					# only provide select or read access so that user is able to at-least access list
+					# (and the documents will be filtered based on owner sin further checks)
+					perms[ptype] = 1 if ptype in ("select", "read") else 0
 
 		frappe.local.role_permissions[cache_key] = perms
 


### PR DESCRIPTION
### **PR Description:**  
This PR enhances the permission evaluation logic to accurately handle cases where ownership has not yet been assigned, particularly during document creation. Previously, users with `if_owner` permissions faced issues when performing actions like file uploads because ownership was not established at creation time.  

### **Key Enhancements:**  
- Ensures that `write` permissions are granted appropriately when `is_owner` is `None`, preventing unintended restrictions.  
- Restricts access to other permissions unless explicitly allowed (`read` or `select`).  
- Improves code readability and maintainability by clearly separating the document creation case from standard permission checks.  

This fix ensures that users with `if_owner` permissions can proceed with necessary actions (e.g., file uploads) while creating a document without compromising security or existing permission rules.