### PR TITLE
chore: add webform list empty state messages to load_translations

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -288,6 +288,8 @@ def get_context(context):
 			"Page {0} of {1}",
 			"Couldn't save, please check the data you have entered",
 			"Validation Error",
+			"No {0} found",
+			"Create a new {0}",
 			self.title,
 			self.introduction_text,
 			self.success_title,


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

When the WebForm list is empty, the message and the button text are not translated because they are not included in the message list in the web_form.py file.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

The solution is simply add these messages to the list so the translations can be loaded correctly.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

Before the changes:

<img width="1279" alt="Screenshot 2025-04-28 at 19 22 53" src="https://github.com/user-attachments/assets/8615e828-140d-4dd6-9d21-81164942079f" />

After changes:

<img width="1303" alt="Screenshot 2025-04-28 at 19 22 23" src="https://github.com/user-attachments/assets/f47ed987-208b-4b14-a566-3e993e9d33eb" />


<!-- Add images/recordings to better visualize the change: expected/current behavior -->
