### PR TITLE
build: bump markdownify to 0.14.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "uuid-utils~=0.10.0",
     "xlrd~=2.0.1",
     "zxcvbn~=4.4.28",
-    "markdownify~=0.11.6",
+    "markdownify~=0.14.1",
 
     # integration dependencies
     "boto3~=1.34.143",


### PR DESCRIPTION
This would fix the [warning](https://github.com/advisories/GHSA-7mpr-5m44-h73r)