### PR TITLE
fix: Resolve PostgreSQL LIKE operator syntax and parameterize search patterns

### DIFF
--- a/frappe/model/utils/rename_field.py
+++ b/frappe/model/utils/rename_field.py
@@ -166,8 +166,8 @@ def update_user_settings(doctype, old_fieldname, new_fieldname):
 	sync_user_settings()
 
 	user_settings = frappe.db.sql(
-		''' select user, doctype, data from `__UserSettings`
-		where doctype=%s and data like %s''',
+		""" select user, doctype, data from `__UserSettings`
+		where doctype=%s and data like %s""",
 		(doctype, f"%{old_fieldname}%"),
 		as_dict=1,
 	)

--- a/frappe/model/utils/rename_field.py
+++ b/frappe/model/utils/rename_field.py
@@ -167,8 +167,8 @@ def update_user_settings(doctype, old_fieldname, new_fieldname):
 
 	user_settings = frappe.db.sql(
 		''' select user, doctype, data from `__UserSettings`
-		where doctype=%s and data like "%%%s%%"''',
-		(doctype, old_fieldname),
+		where doctype=%s and data like %s''',
+		(doctype, f"%{old_fieldname}%"),
 		as_dict=1,
 	)
 


### PR DESCRIPTION
- **Issue**: The existing code incorrectly uses `"%%%s%%"` (double quotes) for the LIKE pattern, causing PostgreSQL to interpret it as a column name. Even with `'%%%s%%'`, it generates invalid syntax like `'%'value'%'` due to improper string concatenation.  
- **Fix**:  
  1. Use **proper parameterization** for the LIKE pattern.  
  2. Replace `"%%%s%%"` with `%s` in the query and dynamically construct the pattern (e.g., `%value%`) in Python before passing it as a parameter.  
  3. Example corrected SQL:  
     ```python  
     frappe.db.sql(  
         '''SELECT user, doctype, data FROM "__UserSettings"  
         WHERE doctype=%s AND data LIKE %s''',  
         (doctype, f"%{old_fieldname}%"),  # Pass pre-formatted pattern  
         as_dict=1  
     )  
     ```  
- **Result**: Generates valid PostgreSQL syntax (e.g., `LIKE '%stop_birthday_reminders%'`). 

The issue happens [here](https://github.com/frappe/hrms/blob/version-15-hotfix/hrms/patches/post_install/rename_stop_to_send_birthday_reminders.py#L10) when using PostgreSQL database.

related: frappe/hrms#1814
related: frappe/hrms#3040