### PR TITLE
feat: include print format name in Access Log during print

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -111,7 +111,7 @@ def get_context(context) -> PrintContext:
 		"doctype": frappe.form_dict.doctype,
 		"name": frappe.form_dict.name,
 		"key": frappe.form_dict.get("key"),
-		"print_format": getattr(print_format, "name", None),
+		"print_format": print_format_name,
 		"letterhead": letterhead,
 		"no_letterhead": frappe.form_dict.no_letterhead,
 		"pdf_generator": frappe.form_dict.get("pdf_generator", "wkhtmltopdf"),

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -90,8 +90,15 @@ def get_context(context) -> PrintContext:
 			settings=settings,
 		)
 
+	# Include selected print format name in access log
+	print_format_name = getattr(print_format, "name", "Standard")
+
 	make_access_log(
-		doctype=frappe.form_dict.doctype, document=frappe.form_dict.name, file_type="PDF", method="Print"
+		doctype=frappe.form_dict.doctype,
+		document=frappe.form_dict.name,
+		file_type="PDF",
+		method="Print",
+		page=f"Print Format: {print_format_name}",
 	)
 
 	return {


### PR DESCRIPTION
### Summary

This PR logs the selected Print Format name in the Access Log when a document is printed. It helps improve auditability when multiple print formats are available for a DocType.

### Details

- Stores the print format name in the `page` field.
- Falls back to "Standard" if no specific format is selected.
- No schema changes.


**Before**
![image](https://github.com/user-attachments/assets/0a33a500-68d4-4605-8d39-ecc8a404ce5e)

**After**
![image](https://github.com/user-attachments/assets/92d74a74-3484-49f2-a6f3-e44d2917136e)


Closes #32342
