### PR TITLE
fix(website): `frappe.call` for website now handles 417 errors

### DIFF
--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -96,6 +96,18 @@ $.extend(frappe, {
 				403: function () {
 					frappe.msgprint(__("Not permitted"));
 				},
+				417: function (xhr) {
+					var data = xhr.responseJSON;
+					if (!data) {
+						try {
+							data = JSON.parse(xhr.responseText);
+						} catch (e) {
+							data = xhr.responseText;
+						}
+					}
+					if (opts.callback) opts.callback(data);
+					if (opts.error) opts.error(data);
+				},
 				200: function (data) {
 					if (opts.callback) opts.callback(data);
 					if (opts.success) opts.success(data);


### PR DESCRIPTION
This is to bring parity between the two `frappe.call` methods: one for the website and one for the framework.

Addresses #32290

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> NOTE: This only addresses one (Error 417) of the missing error code handlers in the `frappe.call` method for the website which resulted in a mismatch between the documented behaviour of the `frappe.call` method and the actual result. Other error codes may need to be handled as well.
