### PR TITLE
fix: use context explicitly for translation in web_form

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -346,7 +346,19 @@ def get_context(context):
 
 		messages.extend(col.get("label") if col else "" for col in self.list_columns)
 
-		context.translated_messages = frappe.as_json({message: _(message) for message in messages if message})
+		translated_messages = {}
+
+		for message in messages:
+			if not message:
+				continue
+
+			if ":" in message:
+				msg, ctx = message.split(":", 1)
+				translated_messages[message] = _(msg, context=ctx)
+			else:
+				translated_messages[message] = _(message)
+
+		context.translated_messages = frappe.as_json(translated_messages)
 
 	def load_list_data(self, context):
 		if not self.list_columns:


### PR DESCRIPTION
Closes #31244, #31249, #32331 

> Screenshots/GIFs

![image](https://github.com/user-attachments/assets/5c0cc7f5-5466-404d-bedc-f370ff917969)
