### PR TITLE
fix: Condition for processing `like` operators

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -870,7 +870,7 @@ class DatabaseQuery:
 				value = get_time(f.value).strftime("%H:%M:%S.%f")
 				fallback = "'00:00:00'"
 
-			elif f.operator.lower() in ("like", "not like") or (
+			elif f.operator.lower() in ("like", "not like") and (
 				isinstance(f.value, str)
 				and (not df or df.fieldtype not in ["Float", "Int", "Currency", "Percent", "Check"])
 			):


### PR DESCRIPTION
This should've been `and` but it's been that way for so long idk if it
will work now.
