### PR TITLE
fix(db_query): double-escaped value

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -882,11 +882,11 @@ class DatabaseQuery:
 					value = value.replace("\\", "\\\\").replace("%", "%%")
 
 			elif f.operator == "=" and df and df.fieldtype in ("Link", "Data", "Dynamic Link"):
-				value = cstr(f.value) or "''"
+				value = cstr(f.value)
 				fallback = "''"
 
 			elif f.fieldname == "name":
-				value = f.value or "''"
+				value = f.value
 				fallback = "''"
 
 			else:

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1196,6 +1196,11 @@ class TestDBQuery(IntegrationTestCase):
 		self.assertEqual(count[0], frappe.db.count("Language"))
 		self.assertEqual(count[1], frappe.db.count("Language"))
 
+	def test_ifnull_none(self):
+		query = frappe.get_all("DocField", {"fieldname": None}, run=0)
+		self.assertIn("''", query)
+		self.assertNotIn("\\'", query)
+
 
 class TestReportView(IntegrationTestCase):
 	@run_only_if(db_type_is.MARIADB)  # TODO: postgres name casting is messed up


### PR DESCRIPTION
```
In [1]: print(frappe.get_all("DocField", {"fieldname": None}, run=0))
select `tabDocField`.`name`
from `tabDocField`
where ifnull(`tabDocField`.`fieldname`, '') = '\'\'' -- <== THIS IS WRONG
order by `tabDocField`.`creation` ASC
```