### PR TITLE
perf: transform ifnull into two conditions

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -889,6 +889,14 @@ from {tables}
 				value = f.value
 				fallback = "''"
 
+			elif (
+				df
+				and (db_type := cstr(frappe.db.type_map.get(df.fieldtype, " ")[0]))
+				and db_type in ("varchar", "text", "longtext", "smalltext", "json")
+			):
+				value = cstr(f.value)
+				fallback = "''"
+
 			else:
 				value = flt(f.value)
 				fallback = 0

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -924,6 +924,9 @@ from {tables}
 			# intersection instead of full table scans.
 			if fallback == value and f.operator == "=":
 				condition = f"( {column_name} is NULL OR {column_name} {f.operator} {value} )"
+			elif fallback == value and f.operator == "!=":
+				# NULL != anything is always NULL, so won't match
+				condition = f"{column_name} {f.operator} {value}"
 			else:
 				condition = f"ifnull({column_name}, {fallback}) {f.operator} {value}"
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -841,22 +841,14 @@ from {tables}
 				fallback = f"'{FallBackDateTimeStr}'"
 
 			elif f.operator.lower() == "is":
+				fallback = "''"
 				if f.value == "set":
 					f.operator = "!="
-					# Value can technically be null, but comparing with null will always be falsy
-					# Not using coalesce here is faster because indexes can be used.
-					# null != '' -> null ~ falsy
-					# '' != '' -> false
 					can_be_null = False
 				elif f.value == "not set":
 					f.operator = "="
-					fallback = "''"
 					can_be_null = not getattr(df, "not_nullable", False)
-
-				value = ""
-
-				if can_be_null and "ifnull" not in column_name.lower():
-					column_name = f"ifnull({column_name}, {fallback})"
+				f.value = value = ""
 
 			elif df and df.fieldtype == "Date":
 				value = frappe.db.format_date(f.value)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -241,11 +241,11 @@ class DatabaseQuery:
 			args = self.prepare_select_args(args)
 
 		query = """select {fields}
-			from {tables}
-			{conditions}
-			{group_by}
-			{order_by}
-			{limit}""".format(**args)
+from {tables}
+{conditions}
+{group_by}
+{order_by}
+{limit}""".format(**args)
 
 		return frappe.db.sql(
 			query,

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1200,6 +1200,14 @@ class TestDBQuery(IntegrationTestCase):
 		query = frappe.get_all("DocField", {"fieldname": None}, run=0)
 		self.assertIn("''", query)
 		self.assertNotIn("\\'", query)
+		self.assertNotIn("ifnull", query)
+
+	def test_ifnull_fallback_types(self):
+		query = frappe.get_all("DocField", {"fieldname": ("!=", None)}, run=0)
+		# Fallbacks should always be of correct type
+		self.assertIn("''", query)
+		self.assertNotIn("0", query)
+		self.assertNotIn("ifnull", query)
 
 
 class TestReportView(IntegrationTestCase):


### PR DESCRIPTION
`ifnull` just ensures that column index can't be used. Certain `ifnull` usage can be trivially broken into two separate conditions and both conditions can individually use indexes, so the query planner performs index intersection instead of full table scan.

This doesn't magically fix all problems, if underlying column isn't indexed then this change is of no use. BUT this at least gives a chance to optimizers to identify and auto tune queries... which is otherwise impossible.

Example:


```
MariaDB [_d90d7ebde9d08bc1]> analyze select name from `tabDocField` where fieldname = '';
+------+-------------+-------------+------+---------------+-----------+---------+-------+------+--------+----------+------------+--------------------------+
| id   | select_type | table       | type | possible_keys | key       | key_len | ref   | rows | r_rows | filtered | r_filtered | Extra                    |
+------+-------------+-------------+------+---------------+-----------+---------+-------+------+--------+----------+------------+--------------------------+
|    1 | SIMPLE      | tabDocField | ref  | fieldname     | fieldname | 563     | const | 1    | 0.00   |   100.00 |     100.00 | Using where; Using index |
+------+-------------+-------------+------+---------------+-----------+---------+-------+------+--------+----------+------------+--------------------------+
1 row in set (0.001 sec)

MariaDB [_d90d7ebde9d08bc1]> analyze select name from `tabDocField` where fieldname is null;
+------+-------------+-------------+------+---------------+-----------+---------+-------+------+--------+----------+------------+--------------------------+
| id   | select_type | table       | type | possible_keys | key       | key_len | ref   | rows | r_rows | filtered | r_filtered | Extra                    |
+------+-------------+-------------+------+---------------+-----------+---------+-------+------+--------+----------+------------+--------------------------+
|    1 | SIMPLE      | tabDocField | ref  | fieldname     | fieldname | 563     | const | 1    | 0.00   |   100.00 |     100.00 | Using where; Using index |
+------+-------------+-------------+------+---------------+-----------+---------+-------+------+--------+----------+------------+--------------------------+
1 row in set (0.001 sec)

MariaDB [_d90d7ebde9d08bc1]> analyze select name from `tabDocField` where fieldname is null or fieldname = '';
+------+-------------+-------------+-------------+---------------+-----------+---------+-------+------+--------+----------+------------+--------------------------+
| id   | select_type | table       | type        | possible_keys | key       | key_len | ref   | rows | r_rows | filtered | r_filtered | Extra                    |
+------+-------------+-------------+-------------+---------------+-----------+---------+-------+------+--------+----------+------------+--------------------------+
|    1 | SIMPLE      | tabDocField | ref_or_null | fieldname     | fieldname | 563     | const | 2    | 0.00   |   100.00 |     100.00 | Using where; Using index |
+------+-------------+-------------+-------------+---------------+-----------+---------+-------+------+--------+----------+------------+--------------------------+
1 row in set (0.010 sec)

MariaDB [_d90d7ebde9d08bc1]> analyze select name from `tabDocField` where coalesce(fieldname, '') = '';
+------+-------------+-------------+-------+---------------+-----------+---------+------+------+---------+----------+------------+--------------------------+
| id   | select_type | table       | type  | possible_keys | key       | key_len | ref  | rows | r_rows  | filtered | r_filtered | Extra                    |
+------+-------------+-------------+-------+---------------+-----------+---------+------+------+---------+----------+------------+--------------------------+
|    1 | SIMPLE      | tabDocField | index | NULL          | fieldname | 563     | NULL | 3058 | 3058.00 |   100.00 |       0.00 | Using where; Using index |
+------+-------------+-------------+-------+---------------+-----------+---------+------+------+---------+----------+------------+--------------------------+
1 row in set (0.011 sec)
```

TODO:
- [x] `=` operator
- [x] `!=` operator