### PR TITLE
fix(Document): improve `__onload` implementation

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1696,16 +1696,20 @@ class Document(BaseDocument, DocRef):
 		else:
 			return []
 
+	@property
+	def __onload(self):
+		onload = self.get("__onload")
+		if onload is None:
+			onload = frappe._dict()
+			self.set("__onload", onload)
+
+		return onload
+
 	def set_onload(self, key, value):
-		if not self.get("__onload"):
-			self.set("__onload", frappe._dict())
-		self.get("__onload")[key] = value
+		self.__onload[key] = value
 
 	def get_onload(self, key=None):
-		if not key:
-			return self.get("__onload", frappe._dict())
-
-		return self.get("__onload")[key]
+		return self.__onload[key] if key else self.__onload
 
 	def queue_action(self, action, **kwargs):
 		"""Run an action in background. If the action has an inner function,


### PR DESCRIPTION
- Add `__onload` property (is dunder, so accessible only in mangled form outside of class definition)

**improved logic of `get_onload`**
- the second parameter to `doc.get` was being considered a filter, but it is intended to be a default.
- the default value wouldn't have gotten set in doc anyway, and user may end up mutating a dict which does nothing. so set value in doc if not set.