### PR TITLE
feat!: Apply permissions in frappe.qb.get_query

### DIFF
--- a/.github/helper/documentation.py
+++ b/.github/helper/documentation.py
@@ -11,6 +11,7 @@ WEBSITE_REPOS = [
 DOCUMENTATION_DOMAINS = [
 	"docs.erpnext.com",
 	"frappeframework.com",
+	"docs.frappe.io",
 ]
 
 

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -72,6 +72,7 @@ def document_list(doctype: str):
 	from frappe.model.base_document import get_controller
 
 	args = frappe.request.args
+	frappe.has_permission(doctype, throw=True)
 
 	fields = frappe.parse_json(args.get("fields", None))
 	filters = frappe.parse_json(args.get("filters", None))

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -170,7 +170,6 @@ def execute_doc_method(doctype: str, name: str, method: str | None = None):
 
 	doc.check_permission(PERMISSION_MAP[frappe.request.method])
 	result = doc.run_method(method, **frappe.form_dict)
-	doc.reload()
 	frappe.response.docs.append(doc.as_dict())
 	return result
 

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -97,11 +97,8 @@ def document_list(doctype: str):
 			query = return_value
 
 	data = query.run(as_dict=True, debug=debug)
-
-	return {
-		"result": data[:limit],
-		"has_next_page": len(data) > limit,
-	}
+	frappe.response["has_next_page"] = len(data) > limit
+	return data[:limit]
 
 
 def count(doctype: str) -> int:

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -71,7 +71,7 @@ def read_doc(doctype: str, name: str):
 def document_list(doctype: str):
 	from frappe.model.base_document import get_controller
 
-	args = frappe.request.args
+	args = frappe.form_dict
 
 	fields = frappe.parse_json(args.get("fields", None))
 	filters = frappe.parse_json(args.get("filters", None))
@@ -80,6 +80,7 @@ def document_list(doctype: str):
 	limit = cint(args.get("limit", 20))
 	group_by = args.get("group_by", None)
 	debug = args.get("debug", False)
+	as_dict = args.get("as_dict", True)
 
 	query = frappe.qb.get_query(
 		table=doctype,
@@ -97,7 +98,7 @@ def document_list(doctype: str):
 		if return_value is not None:
 			query = return_value
 
-	data = query.run(as_dict=True, debug=debug)
+	data = query.run(as_dict=as_dict, debug=debug)
 	frappe.response["has_next_page"] = len(data) > limit
 	return data[:limit]
 

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -170,7 +170,10 @@ def execute_doc_method(doctype: str, name: str, method: str | None = None):
 	doc.is_whitelisted(method)
 
 	doc.check_permission(PERMISSION_MAP[frappe.request.method])
-	return doc.run_method(method, **frappe.form_dict)
+	result = doc.run_method(method, **frappe.form_dict)
+	doc.reload()
+	frappe.response.docs.append(doc.as_dict())
+	return result
 
 
 def run_doc_method(method: str, document: dict[str, Any] | str, kwargs=None):

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -15,7 +15,7 @@ from werkzeug.routing import Rule
 
 import frappe
 import frappe.client
-from frappe import _, cint, get_newargs, is_whitelisted
+from frappe import _, cint, cstr, get_newargs, is_whitelisted
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
 from frappe.handler import is_valid_http_method, run_server_script, upload_file
 
@@ -65,7 +65,14 @@ def read_doc(doctype: str, name: str):
 	doc = frappe.get_doc(doctype, name)
 	doc.check_permission("read")
 	doc.apply_fieldlevel_read_permissions()
-	return doc.as_dict()
+	_doc = doc.as_dict()
+
+	for key in _doc:
+		df = doc.meta.get_field(key)
+		if df and df.fieldtype == "Link" and isinstance(_doc.get(key), int):
+			_doc[key] = cstr(_doc.get(key))
+
+	return _doc
 
 
 def document_list(doctype: str):

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -65,7 +65,7 @@ def read_doc(doctype: str, name: str):
 	doc = frappe.get_doc(doctype, name)
 	doc.check_permission("read")
 	doc.apply_fieldlevel_read_permissions()
-	return doc
+	return doc.as_dict()
 
 
 def document_list(doctype: str):
@@ -96,8 +96,6 @@ def document_list(doctype: str):
 		if return_value is not None:
 			query = return_value
 
-	print(query)
-
 	data = query.run(as_dict=True, debug=debug)
 
 	return {
@@ -119,7 +117,7 @@ def create_doc(doctype: str):
 	data.pop("doctype", None)
 	if (name := data.get("name")) and isinstance(name, str):
 		frappe.flags.api_name_set = True
-	return frappe.new_doc(doctype, **data).insert()
+	return frappe.new_doc(doctype, **data).insert().as_dict()
 
 
 def copy_doc(doctype: str, name: str, ignore_no_copy: bool = True):
@@ -146,7 +144,7 @@ def update_doc(doctype: str, name: str):
 	if doc.get("parenttype"):
 		frappe.get_doc(doc.parenttype, doc.parent).save()
 
-	return doc
+	return doc.as_dict()
 
 
 def delete_doc(doctype: str, name: str):

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -72,7 +72,6 @@ def document_list(doctype: str):
 	from frappe.model.base_document import get_controller
 
 	args = frappe.request.args
-	frappe.has_permission(doctype, throw=True)
 
 	fields = frappe.parse_json(args.get("fields", None))
 	filters = frappe.parse_json(args.get("filters", None))
@@ -90,6 +89,7 @@ def document_list(doctype: str):
 		offset=start,
 		limit=limit + 1,
 		group_by=group_by,
+		ignore_permissions=False,
 	)
 	controller = get_controller(doctype)
 	if hasattr(controller, "get_list"):

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -197,7 +197,7 @@ class Engine:
 			self.query = dynamic_field.apply_join(self.query)
 			_field = dynamic_field.field
 		elif self.validate_filters and SPECIAL_CHAR_PATTERN.search(_field):
-			frappe.throw(_("Invalid filter: {0}").format(_field))
+			frappe.throw(_("Invalid filter: {0}").format(_field), frappe.PermissionError)
 		elif not doctype or doctype == self.doctype:
 			_field = self.table[field]
 		elif doctype:
@@ -379,7 +379,9 @@ class Engine:
 			)
 
 		if not has_permission("select") and not has_permission("read"):
-			frappe.throw(_("Insufficient Permission for {0}").format(frappe.bold(self.doctype)))
+			frappe.throw(
+				_("Insufficient Permission for {0}").format(frappe.bold(self.doctype)), frappe.PermissionError
+			)
 
 	def apply_field_permissions(self):
 		"""Allow fields that user has permission to read"""
@@ -553,7 +555,9 @@ class Permission:
 				user=kwargs.get("user"),
 				parent_doctype=kwargs.get("parent_doctype"),
 			):
-				frappe.throw(_("Insufficient Permission for {0}").format(frappe.bold(dt)))
+				frappe.throw(
+					_("Insufficient Permission for {0}").format(frappe.bold(dt)), frappe.PermissionError
+				)
 
 	@staticmethod
 	def get_tables_from_query(query: str):

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -389,7 +389,7 @@ class Engine:
 			permission_type=self.get_permission_type(self.doctype),
 			ignore_virtual=True,
 		)
-		filtered_fields = []
+		allowed_fields = []
 		for field in self.fields:
 			if isinstance(field, ChildTableField):
 				permitted_child_fields = get_permitted_fields(
@@ -399,10 +399,10 @@ class Engine:
 					ignore_virtual=True,
 				)
 				if field.child_fieldname in permitted_child_fields:
-					filtered_fields.append(field)
+					allowed_fields.append(field)
 			elif isinstance(field, LinkTableField):
 				if field.link_fieldname in permitted_fields:
-					filtered_fields.append(field)
+					allowed_fields.append(field)
 			elif isinstance(field, ChildQuery):
 				permitted_child_fields = get_permitted_fields(
 					doctype=field.doctype,
@@ -411,12 +411,13 @@ class Engine:
 					ignore_virtual=True,
 				)
 				field.fields = [f for f in field.fields if f in permitted_child_fields]
+				allowed_fields.append(field)
 			elif isinstance(field, Field):
 				if field.name == "*":
-					filtered_fields.extend(self.parse_fields(permitted_fields))
+					allowed_fields.extend(self.parse_fields(permitted_fields))
 				elif field.name in permitted_fields:
-					filtered_fields.append(field)
-		return filtered_fields
+					allowed_fields.append(field)
+		return allowed_fields
 
 	def get_user_permission_conditions(self, role_permissions):
 		"""Build conditions for user permissions and return tuple of (conditions, fetch_shared_docs)"""

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1,7 +1,6 @@
 import re
-from ast import literal_eval
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import sqlparse
 from pypika.queries import QueryBuilder, Table
@@ -30,11 +29,6 @@ TABLE_NAME_PATTERN = re.compile(r"^[\w -]*$", flags=re.ASCII)
 # Pattern to validate field names in SELECT:
 # Allows: name, `name`, name as alias, `name` as alias, `table name`.`name`, `table name`.`name` as alias, table.name, table.name as alias
 ALLOWED_FIELD_PATTERN = re.compile(r"^(?:(`[\w\s-]+`|\w+)\.)?(`\w+`|\w+)(?:\s+as\s+\w+)?$", flags=re.ASCII)
-
-# Pattern to validate field names used in various SQL clauses (WHERE, GROUP BY, ORDER BY):
-# Allows simple field names, backticked names, and table-qualified names (e.g., name, `name`, `table`.`name`, table.name)
-# Does NOT allow aliases ('as alias') or functions.
-ALLOWED_SQL_FIELD_PATTERN = re.compile(r"^(?:(`\w+`|\w+)\.)?(`\w+`|\w+)$", flags=re.ASCII)
 
 # Regex to parse field names:
 # Group 1: Optional quote for table name

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -794,3 +794,25 @@ class RawCriterion(Term):
 
 	def get_sql(self, **kwargs: Any) -> str:
 		return self.sql_string
+
+	def __and__(self, other):
+		return CombinedRawCriterion(self, other, "AND")
+
+	def __or__(self, other):
+		return CombinedRawCriterion(self, other, "OR")
+
+	def __invert__(self):
+		return RawCriterion(f"NOT ({self.sql_string})")
+
+
+class CombinedRawCriterion(RawCriterion):
+	def __init__(self, left, right, operator):
+		self.left = left
+		self.right = right
+		self.operator = operator
+		super(RawCriterion, self).__init__()
+
+	def get_sql(self, **kwargs: Any) -> str:
+		left_sql = self.left.get_sql(**kwargs) if hasattr(self.left, "get_sql") else str(self.left)
+		right_sql = self.right.get_sql(**kwargs) if hasattr(self.right, "get_sql") else str(self.right)
+		return f"({left_sql}) {self.operator} ({right_sql})"

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -29,12 +29,12 @@ TABLE_NAME_PATTERN = re.compile(r"^[\w -]*$", flags=re.ASCII)
 
 # Pattern to validate field names in SELECT:
 # Allows: name, `name`, name as alias, `name` as alias, `table name`.`name`, `table name`.`name` as alias, table.name, table.name as alias
-ALLOWED_FIELD_PATTERN = re.compile(r"^(?:`?[\w\s-]+`?\.)?(`?\w+`?|\w+)(?:\s+as\s+\w+)?$", flags=re.ASCII)
+ALLOWED_FIELD_PATTERN = re.compile(r"^(?:(`[\w\s-]+`|\w+)\.)?(`\w+`|\w+)(?:\s+as\s+\w+)?$", flags=re.ASCII)
 
 # Pattern to validate field names used in various SQL clauses (WHERE, GROUP BY, ORDER BY):
 # Allows simple field names, backticked names, and table-qualified names (e.g., name, `name`, `table`.`name`, table.name)
 # Does NOT allow aliases ('as alias') or functions.
-ALLOWED_SQL_FIELD_PATTERN = re.compile(r"^(?:`?\w+`?\.)?(`?\w+`?|\w+)$", flags=re.ASCII)
+ALLOWED_SQL_FIELD_PATTERN = re.compile(r"^(?:(`\w+`|\w+)\.)?(`\w+`|\w+)$", flags=re.ASCII)
 
 # Regex to parse field names:
 # Group 1: Optional quote for table name
@@ -1328,9 +1328,6 @@ class CombinedRawCriterion(RawCriterion):
 		super(RawCriterion, self).__init__()
 
 	def get_sql(self, **kwargs: Any) -> str:
-		left_sql = self.left.get_sql(**kwargs) if hasattr(self.left, "get_sql") else str(self.left)
-		right_sql = self.right.get_sql(**kwargs) if hasattr(self.right, "get_sql") else str(self.right)
-		return f"({left_sql}) {self.operator} ({right_sql})"
 		left_sql = self.left.get_sql(**kwargs) if hasattr(self.left, "get_sql") else str(self.left)
 		right_sql = self.right.get_sql(**kwargs) if hasattr(self.right, "get_sql") else str(self.right)
 		return f"({left_sql}) {self.operator} ({right_sql})"

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1201,7 +1201,9 @@ class Document(BaseDocument):
 		self.docstatus = DocStatus.CANCELLED
 		return self.save()
 
-	def _rename(self, name: str, merge: bool = False, force: bool = False, validate_rename: bool = True):
+	def _rename(
+		self, name: str | int, merge: bool = False, force: bool = False, validate_rename: bool = True
+	):
 		"""Rename the document. Triggers frappe.rename_doc, then reloads."""
 		from frappe.model.rename_doc import rename_doc
 
@@ -1238,7 +1240,7 @@ class Document(BaseDocument):
 		self.run_method("on_discard")
 
 	@frappe.whitelist()
-	def rename(self, name: str, merge=False, force=False, validate_rename=True):
+	def rename(self, name: str | int, merge=False, force=False, validate_rename=True):
 		"""Rename the document to `name`. This transforms the current object."""
 		return self._rename(name=name, merge=merge, force=force, validate_rename=validate_rename)
 

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -113,7 +113,7 @@ class TestResourceAPIV2(FrappeAPITestCase):
 
 	def test_delete_document(self):
 		doc_to_delete = choice(self.GENERATED_DOCUMENTS)
-		response = self.delete(self.resource(self.DOCTYPE, doc_to_delete))
+		response = self.delete(self.resource(self.DOCTYPE, doc_to_delete), data={"sid": self.sid})
 		self.assertEqual(response.status_code, 202)
 		self.assertDictEqual(response.json, {"data": "ok"})
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -374,7 +374,7 @@ class TestDB(IntegrationTestCase):
 			random_field,
 		)
 		self.assertEqual(
-			next(iter(frappe.get_all("ToDo", fields=[{"COUNT": random_field}], limit=1)[0])),
+			next(iter(frappe.get_all("ToDo", fields=[f"count(`{random_field}`)"], limit=1)[0])),
 			"count" if frappe.conf.db_type == "postgres" else f"count(`{random_field}`)",
 		)
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -75,7 +75,7 @@ class TestDB(IntegrationTestCase):
 			frappe.db.sql("SELECT Max(name) FROM tabUser")[0][0],
 		)
 		self.assertEqual(
-			frappe.db.get_value("User", {}, {"MIN": "name"}, order_by=None),
+			frappe.db.get_value("User", {}, [{"MIN": "name"}], order_by=None),
 			frappe.db.sql("SELECT Min(name) FROM tabUser")[0][0],
 		)
 		self.assertIn(
@@ -374,7 +374,7 @@ class TestDB(IntegrationTestCase):
 			random_field,
 		)
 		self.assertEqual(
-			next(iter(frappe.get_all("ToDo", fields=[{"count": random_field}], limit=1)[0])),
+			next(iter(frappe.get_all("ToDo", fields=[{"COUNT": random_field}], limit=1)[0])),
 			"count" if frappe.conf.db_type == "postgres" else f"count(`{random_field}`)",
 		)
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -71,11 +71,11 @@ class TestDB(IntegrationTestCase):
 		self.assertEqual(frappe.db.get_value("User", {"name": ["<", "Adn"]}), "Administrator")
 		self.assertEqual(frappe.db.get_value("User", {"name": ["<=", "Administrator"]}), "Administrator")
 		self.assertEqual(
-			frappe.db.get_value("User", {}, ["Max(name)"], order_by=None),
+			frappe.db.get_value("User", {}, [{"MAX": "name"}], order_by=None),
 			frappe.db.sql("SELECT Max(name) FROM tabUser")[0][0],
 		)
 		self.assertEqual(
-			frappe.db.get_value("User", {}, "Min(name)", order_by=None),
+			frappe.db.get_value("User", {}, {"MIN": "name"}, order_by=None),
 			frappe.db.sql("SELECT Min(name) FROM tabUser")[0][0],
 		)
 		self.assertIn(
@@ -374,7 +374,7 @@ class TestDB(IntegrationTestCase):
 			random_field,
 		)
 		self.assertEqual(
-			next(iter(frappe.get_all("ToDo", fields=[f"count(`{random_field}`)"], limit=1)[0])),
+			next(iter(frappe.get_all("ToDo", fields=[{"count": random_field}], limit=1)[0])),
 			"count" if frappe.conf.db_type == "postgres" else f"count(`{random_field}`)",
 		)
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -33,6 +33,7 @@ def setup_test_user(set_user=False):
 
 	yield test_user
 
+	test_user.reload()
 	test_user.remove_roles("Blogger")
 	test_user.add_roles(*user_roles)
 

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -150,6 +150,7 @@ class TestQuery(IntegrationTestCase):
 			"tabUser.name as alias",
 			"`tabUser`.`name` as alias",
 			"*",
+			"`tabHas Role`.`name`",
 		]
 		invalid_fields = [
 			"name; DROP TABLE users",
@@ -169,6 +170,12 @@ class TestQuery(IntegrationTestCase):
 			"SUM(amount) as total",
 			"COUNT(name) as alias; SELECT 1",
 			"COUNT(name;)",
+			"`name",
+			"name`",
+			"`tabUser.name`",
+			"tabUser.`name",
+			"tabUser`.`name`",
+			"tab`User.name",
 		]
 
 		for field in valid_fields:
@@ -208,6 +215,11 @@ class TestQuery(IntegrationTestCase):
 			"`table`.`invalid-field`",
 			"field with space",
 			"`field with space`",
+			"`name`",
+			"`name",
+			"name`",
+			"tabUser.`name`",
+			"`tabUser.name`",
 		]
 
 		for field in valid_fields:

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -5,6 +5,7 @@ from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.query_builder import Field
 from frappe.query_builder.functions import Abs, Count, Ifnull, Max, Now, Timestamp
 from frappe.tests import IntegrationTestCase
+from frappe.tests.classes.context_managers import enable_safe_exec
 from frappe.tests.test_db_query import (
 	create_nested_doctype,
 	create_nested_doctype_records,
@@ -629,8 +630,9 @@ class TestQuery(IntegrationTestCase):
 		frappe.clear_cache()
 		frappe.hooks.permission_query_conditions = {}  # Clear hooks to test server script alone
 
-		query = frappe.qb.get_query("Dashboard Settings", user=self.user, ignore_permissions=False)
-		self.assertIn(f'`tabDashboard Settings`.`user` = "{self.user}"', str(query))
+		with enable_safe_exec():
+			query = frappe.qb.get_query("Dashboard Settings", user=self.user, ignore_permissions=False)
+			self.assertIn(f'`tabDashboard Settings`.`user` = "{self.user}"', str(query))
 
 		# Cleanup
 		script.delete()

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -119,72 +119,8 @@ class TestQuery(IntegrationTestCase):
 		)
 
 		self.assertEqual(
-			frappe.qb.get_query(
-				"User", fields=["`tabUser`.`name`, Count(`name`) as count"], filters={"name": "Administrator"}
-			).run(),
-			frappe.qb.from_("User")
-			.select(Field("name"), Count("name").as_("count"))
-			.where(Field("name") == "Administrator")
-			.run(),
-		)
-
-		self.assertEqual(
-			frappe.qb.get_query(
-				"User",
-				fields=["`tabUser`.`name`, Count(`name`) as `count`"],
-				filters={"name": "Administrator"},
-			).run(),
-			frappe.qb.from_("User")
-			.select(Field("name"), Count("name").as_("count"))
-			.where(Field("name") == "Administrator")
-			.run(),
-		)
-
-		self.assertEqual(
-			frappe.qb.get_query(
-				"User", fields="`tabUser`.`name`, Count(`name`) as `count`", filters={"name": "Administrator"}
-			).run(),
-			frappe.qb.from_("User")
-			.select(Field("name"), Count("name").as_("count"))
-			.where(Field("name") == "Administrator")
-			.run(),
-		)
-
-	def test_functions_fields(self):
-		self.assertEqual(
-			frappe.qb.get_query("User", fields="Count(name)", filters={}).get_sql(),
-			frappe.qb.from_("User").select(Count(Field("name"))).get_sql(),
-		)
-
-		self.assertEqual(
-			frappe.qb.get_query("User", fields=["Count(name)", "Max(name)"], filters={}).get_sql(),
-			frappe.qb.from_("User").select(Count(Field("name")), Max(Field("name"))).get_sql(),
-		)
-
-		self.assertEqual(
-			frappe.qb.get_query("User", fields=["abs(name-email)", "Count(name)"], filters={}).get_sql(),
-			frappe.qb.from_("User")
-			.select(Abs(Field("name") - Field("email")), Count(Field("name")))
-			.get_sql(),
-		)
-
-		self.assertEqual(
-			frappe.qb.get_query("User", fields=[Count("*")], filters={}).get_sql(),
+			frappe.qb.get_query("User", fields=[Count("*")]).get_sql(),
 			frappe.qb.from_("User").select(Count("*")).get_sql(),
-		)
-
-		self.assertEqual(
-			frappe.qb.get_query("User", fields="timestamp(creation, modified)", filters={}).get_sql(),
-			frappe.qb.from_("User").select(Timestamp(Field("creation"), Field("modified"))).get_sql(),
-		)
-
-		self.assertEqual(
-			frappe.qb.get_query(
-				"User", fields="Count(name) as count, Max(email) as max_email", filters={}
-			).get_sql(),
-			frappe.qb.from_("User")
-			.select(Count(Field("name")).as_("count"), Max(Field("email")).as_("max_email"))
-			.get_sql(),
 		)
 
 	def test_qb_fields(self):
@@ -213,12 +149,6 @@ class TestQuery(IntegrationTestCase):
 			"`name` as alias",
 			"tabUser.name as alias",
 			"`tabUser`.`name` as alias",
-			"COUNT(*)",
-			"COUNT(name)",
-			"COUNT(`name`)",
-			"COUNT(`tabUser`.`name`)",
-			"COUNT(*) as count_alias",
-			"SUM(amount) as total",
 			"*",
 		]
 		invalid_fields = [
@@ -227,7 +157,6 @@ class TestQuery(IntegrationTestCase):
 			"name--comment",
 			"name /* comment */",
 			"name AS alias; --",
-			"COUNT(name) as alias; SELECT 1",
 			"invalid-field-name",
 			"table.invalid-field",
 			"`table`.`invalid-field`",
@@ -235,6 +164,10 @@ class TestQuery(IntegrationTestCase):
 			"`field with space`",
 			"field as alias with space",
 			"field as `alias with space`",
+			"COUNT(*)",
+			"COUNT(name)",
+			"SUM(amount) as total",
+			"COUNT(name) as alias; SELECT 1",
 			"COUNT(name;)",
 		]
 
@@ -399,15 +332,6 @@ class TestQuery(IntegrationTestCase):
 			frappe.qb.get_query(user_doctype, fields="name as owner, email as id", filters={}).get_sql(),
 			frappe.qb.from_(user_doctype)
 			.select(user_doctype.name.as_("owner"), user_doctype.email.as_("id"))
-			.get_sql(),
-		)
-
-		self.assertEqual(
-			frappe.qb.get_query(
-				user_doctype, fields=["Count(name) as count", "email as id"], filters={}
-			).get_sql(),
-			frappe.qb.from_(user_doctype)
-			.select(Count(Field("name")).as_("count"), user_doctype.email.as_("id"))
 			.get_sql(),
 		)
 

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -5,8 +5,16 @@ from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.query_builder import Field
 from frappe.query_builder.functions import Abs, Count, Ifnull, Max, Now, Timestamp
 from frappe.tests import IntegrationTestCase
+from frappe.tests.test_db_query import (
+	create_nested_doctype,
+	create_nested_doctype_records,
+	setup_patched_blog_post,
+	setup_test_user,
+)
 from frappe.tests.test_query_builder import db_type_is, run_only_if
 from frappe.utils.nestedset import get_ancestors_of, get_descendants_of
+
+EXTRA_TEST_RECORD_DEPENDENCIES = ["User", "Blog Post", "Blog Category", "Blogger"]
 
 
 def create_tree_docs():
@@ -252,7 +260,7 @@ class TestQuery(IntegrationTestCase):
 		)
 
 		self.assertRaisesRegex(
-			frappe.ValidationError,
+			frappe.PermissionError,
 			"Invalid filter",
 			lambda: frappe.qb.get_query(
 				"DocType",
@@ -455,3 +463,135 @@ class TestQuery(IntegrationTestCase):
 
 		note1.delete()
 		note2.delete()
+
+	def test_build_match_conditions(self):
+		from frappe.permissions import add_user_permission, clear_user_permissions_for_doctype
+
+		clear_user_permissions_for_doctype("Blog Post", "test2@example.com")
+
+		test2user = frappe.get_doc("User", "test2@example.com")
+		test2user.add_roles("Blogger")
+		frappe.set_user("test2@example.com")
+
+		# Before any user permission is applied, there should be no conditions
+		query = frappe.qb.get_query("Blog Post", ignore_permissions=False)
+		self.assertNotIn("(`tabBlog Post`.`name` in (", str(query))
+
+		# Add user permissions
+		add_user_permission("Blog Post", "-test-blog-post", "test2@example.com", True)
+		add_user_permission("Blog Post", "-test-blog-post-1", "test2@example.com", True)
+
+		# After applying user permission, condition should be in query
+		query = str(frappe.qb.get_query("Blog Post", ignore_permissions=False))
+
+		# Check for user permission condition in the query string
+		if frappe.db.db_type == "mariadb":
+			self.assertIn("`name` IS NULL OR `name` IN ('-test-blog-post-1','-test-blog-post')", query)
+		elif frappe.db.db_type == "postgres":
+			self.assertIn("\"name\" IS NULL OR \"name\" IN ('-test-blog-post-1','-test-blog-post')", query)
+
+		frappe.set_user("Administrator")
+		clear_user_permissions_for_doctype("Blog Post", "test2@example.com")
+		test2user.remove_roles("Blogger")
+
+	def test_ignore_permissions_for_query(self):
+		frappe.set_user("test2@example.com")
+
+		with self.assertRaises(frappe.PermissionError):
+			frappe.qb.get_query("DocType", filters={"istable": 1}, ignore_permissions=False)
+
+		result = frappe.qb.get_query("DocType", filters={"istable": 1}, ignore_permissions=True).run()
+		self.assertTrue(len(result) > 0)
+
+		frappe.set_user("Administrator")
+
+	def test_permlevel_fields(self):
+		"""Test permission level check when querying fields"""
+		with setup_patched_blog_post(), setup_test_user(set_user=True):
+			# Create a test blog post
+			test_post = frappe.get_doc(
+				{
+					"doctype": "Blog Post",
+					"title": "Test Permission Post",
+					"content": "Test Content",
+					"published": 1,
+				}
+			).insert(ignore_permissions=True)
+
+			# Without proper permission, published field should be filtered out
+			data = frappe.qb.get_query(
+				"Blog Post",
+				filters={"name": test_post.name},
+				fields=["name", "published", "title"],
+				ignore_permissions=False,
+			).run(as_dict=1)
+
+			field_list = [field for d in data for field in d.keys()]
+			self.assertIn("title", field_list)
+			self.assertIn("name", field_list)
+			self.assertNotIn("published", field_list)
+
+			# With Administrator, all fields should be accessible
+			frappe.set_user("Administrator")
+			data = frappe.qb.get_query(
+				"Blog Post",
+				filters={"name": test_post.name},
+				fields=["name", "published", "title"],
+				ignore_permissions=False,
+			).run(as_dict=1)
+
+			field_list = [field for d in data for field in d.keys()]
+			self.assertIn("published", field_list)
+
+			test_post.delete()
+
+	def test_nested_permission(self):
+		"""Test permission on nested doctypes"""
+		frappe.set_user("Administrator")
+		create_nested_doctype()
+		create_nested_doctype_records()
+
+		from frappe.permissions import add_user_permission, clear_user_permissions_for_doctype
+
+		clear_user_permissions_for_doctype("Nested DocType")
+
+		# Add user permission for only one root folder
+		add_user_permission("Nested DocType", "Level 1 A", "test2@example.com")
+
+		from frappe.core.page.permission_manager.permission_manager import update
+
+		# To avoid if_owner filter
+		update("Nested DocType", "All", 0, "if_owner", 0)
+
+		test2user = frappe.get_doc("User", "test2@example.com")
+		test2user.add_roles("Blogger")
+		frappe.set_user("test2@example.com")
+		data = frappe.qb.get_query("Nested DocType", ignore_permissions=False).run(as_dict=1)
+
+		# Children of the permitted node should be accessible
+		self.assertTrue(any(d.name == "Level 2 A" for d in data))
+
+		# Other nodes should not be accessible
+		self.assertFalse(any(d.name == "Level 1 B" for d in data))
+		self.assertFalse(any(d.name == "Level 2 B" for d in data))
+
+		update("Nested DocType", "All", 0, "if_owner", 1)  # Reset to default
+		frappe.set_user("Administrator")
+
+	def test_is_set_is_not_set(self):
+		"""Test is set and is not set filters"""
+		result = frappe.qb.get_query("DocType", filters={"autoname": ["is", "not set"]}).run(as_dict=1)
+		self.assertTrue({"name": "Integration Request"} in result)
+		self.assertTrue({"name": "User"} in result)
+		self.assertFalse({"name": "Blogger"} in result)
+
+		result = frappe.qb.get_query("DocType", filters={"autoname": ["is", "set"]}).run(as_dict=1)
+		self.assertTrue({"name": "DocField"} in result)
+		self.assertTrue({"name": "Prepared Report"} in result)
+		self.assertFalse({"name": "Property Setter"} in result)
+
+		# Test with updating value to NULL
+		frappe.db.set_value("DocType", "Property Setter", "autoname", None, update_modified=False)
+
+		result = frappe.qb.get_query("DocType", filters={"autoname": ["is", "set"]}).run(as_dict=1)
+		self.assertFalse(any(d.name == "Property Setter" for d in result))

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -514,9 +514,10 @@ class TestQuery(IntegrationTestCase):
 					"doctype": "Blog Post",
 					"title": "Test Permission Post",
 					"content": "Test Content",
+					"blog_category": "-test-blog-category",
 					"published": 1,
 				}
-			).insert(ignore_permissions=True)
+			).insert(ignore_permissions=True, ignore_mandatory=True)
 
 			# Without proper permission, published field should be filtered out
 			data = frappe.qb.get_query(

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -52,7 +52,7 @@ def report_error(status_code):
 		case ApiVersion.V2:
 			error_log = {"type": exc_type.__name__}
 			if allow_traceback:
-				frappe.errprint(traceback)
+				print(traceback)
 				error_log["exception"] = traceback
 			_link_error_with_message_log(error_log, exc_value, frappe.message_log)
 			frappe.local.response.errors = [error_log]

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -52,6 +52,7 @@ def report_error(status_code):
 		case ApiVersion.V2:
 			error_log = {"type": exc_type.__name__}
 			if allow_traceback:
+				frappe.errprint(traceback)
 				error_log["exception"] = traceback
 			_link_error_with_message_log(error_log, exc_value, frappe.message_log)
 			frappe.local.response.errors = [error_log]


### PR DESCRIPTION
### Apply Comprehensive Permissions

- User, Role, Share Permissions
- Linked/Child Document Permissions
- Field-Level Permissions: `fields`, `filters`, `order_by`, `group_by`

### Prevent Malicious Inputs

**Fields (`SELECT`):**

Allowed
- `name`
- `` `tabUser`.`email` ``
- `field as alias`

Not allowed
- `name; DROP TABLE users`
- `field--comment`
- `invalid-field-name`
- `COUNT(*) as count` (Breaking change)

**Filters (`WHERE`):**

Allowed
- `{"name": "value"}`
- `["status", "=", "Open"]`
- `{"link_field.target_field": "X"}`
- `{"child_field.target_field": "X"}`

Not allowed
- `{"name as alias": "value"}`
- `{"tabUser.name": "value"}`
- `{"name;": "value"}`

**Group By / Order By Clauses:**

Allowed 
- `name ASC`
- `` `tabUser`.`creation` DESC ``

Not allowed
- `name as alias`
- `COUNT(name)`
- `name sideways`

### New SQL Functions syntax

#### Before
```py
frappe.qb.get_query("GP Task", fields=["sum(name) as count"])

frappe.qb.get_query("User", fields=["ifnull(first_name, 'Unknown') as safe_name"])
```

#### After
```py
frappe.qb.get_query("GP Task", fields=[{"SUM": "name", "as": "count"}])

frappe.qb.get_query(
	"User", fields=[{"IFNULL": ["first_name", "'Unknown'"], "as": "safe_name"}]
)
```
❗️This is a breaking change. This affects functions that use frappe.qb.get_query internally (`frappe.db.get_value` and `frappe.db.get_values`). I have updated usages across frappe and [erpnext](https://github.com/frappe/erpnext/pull/47761).



### Add Support for Nested Filter Conditions

The query engine now supports nested filter conditions, allowing for complex boolean logic using `AND` and `OR` operators within a structured list format.

```py

In [1]: frappe.qb.get_query("GP Task", filters=[
            ["status", "=", "Open"], "or", ["priority", "=", "High"]
        ])
Out[1]: SELECT `name` FROM `tabGP Task` WHERE `status`='Open' OR `priority`='High'

In [2]: frappe.qb.get_query(
            "GP Task",
            filters=[
                [["status", "=", "Open"], "or", ["priority", "=", "High"]],
                "and",
                ["owner", "=", "faris@frappe.io"],
            ],
        )
        
Out[2]: SELECT `name` FROM `tabGP Task` WHERE (`status`='Open' OR `priority`='High') AND `owner`='faris@frappe.io'
```

### API v2


- `/api/v2/document/<doctype>` (list endpoint) uses`frappe.qb.get_query`
`frappe.db.get_list` is replaced by `frappe.qb.get_query`
- All endpoints return `doc.as_dict()`, since `doc` only serializes fields with non-null values. `frappe-ui` needs to know when fields are set to `null` as well.

Documentation: https://docs.frappe.io/framework/user/en/api/query-builder?newWiki=1&wikiPagePatch=2tbnj6v3je&editWiki=1

---

Changes driven by this [Gameplan refactor](https://github.com/frappe/gameplan/pull/376) to use new `/api/v2`

Continuing https://github.com/frappe/frappe/pull/29082

