### PR TITLE
perf: Avoid Coalesce in QB `is` implementation

### DIFF
--- a/frappe/database/operator_map.py
+++ b/frappe/database/operator_map.py
@@ -95,7 +95,14 @@ def func_between(key: Field, value: list | tuple) -> frappe.qb:
 
 def func_is(key, value):
 	"Wrapper for IS"
-	return Coalesce(key, "") != "" if value.lower() == "set" else Coalesce(key, "") == ""
+
+	match value.lower():
+		case "set":
+			return key != ""
+		case "not set":
+			return key.isnull() | (key == "")
+		case _:
+			raise ValueError("`is` operator only supports `set` and `not set` as value")
 
 
 def func_timespan(key: Field, value: str) -> frappe.qb:


### PR DESCRIPTION
Same as https://github.com/frappe/frappe/pull/32377 but for QB 