### PR TITLE
fix: remove child tables from Role Permission Manager dropdown

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -49,6 +49,13 @@ frappe.PermissionEngine = class PermissionEngine {
 			label: __("Document Type"),
 			fieldtype: "Link",
 			options: "DocType",
+			get_query: function () {
+				return {
+					filters: {
+						istable: 0
+					}
+				};
+			},
 			change: function () {
 				frappe.set_route("permission-manager", this.get_value());
 			},

--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -52,8 +52,8 @@ frappe.PermissionEngine = class PermissionEngine {
 			get_query: function () {
 				return {
 					filters: {
-						istable: 0
-					}
+						istable: 0,
+					},
 				};
 			},
 			change: function () {


### PR DESCRIPTION
Fixes #32378

This removes child tables (DocTypes where istable = 1) from the document dropdown in Role Permission Manager.

I saw no pull request was open, so I made this change. If it's already being worked on, feel free to close it.
