### PR TITLE
fix: active tab bottom border not visible in dark mode

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -498,7 +498,7 @@
 
 				&.active {
 					font-weight: 600;
-					border-bottom: 1px solid var(--primary);
+					border-bottom: 1px solid var(--text-color);
 					color: var(--text-color);
 					padding-bottom: 9px;
 				}


### PR DESCRIPTION
This fixes an issue where the bottom border for active tabs was not showing in dark mode.

**Before**
![image](https://github.com/user-attachments/assets/a7a49700-e4a9-4995-8bd8-c74db6ac44ea)

**After**
![image](https://github.com/user-attachments/assets/954e80ce-af47-47f6-a22b-9ba81b941f20)

Fixes: #32386