### PR TITLE
feat(login): add checkbox to make LDAP default login

### DIFF
--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.json
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -7,6 +7,8 @@
  "engine": "InnoDB",
  "field_order": [
   "enabled",
+  "column_break_1",
+  "default_login",
   "ldap_server_settings_section",
   "ldap_directory_server",
   "column_break_4",
@@ -296,12 +298,22 @@
    "fieldname": "do_not_create_new_user",
    "fieldtype": "Check",
    "label": "Do Not Create New User "
+  },
+  {
+   "fieldname": "column_break_1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "default_login",
+   "fieldtype": "Check",
+   "label": "Default Login"
   }
  ],
  "in_create": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-23 16:03:28.700269",
+ "modified": "2025-05-04 09:30:32.929307",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "LDAP Settings",

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.json
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -7,8 +7,8 @@
  "engine": "InnoDB",
  "field_order": [
   "enabled",
-  "column_break_1",
-  "default_login",
+  "column_break_qied",
+  "default_to_ldap_login",
   "ldap_server_settings_section",
   "ldap_directory_server",
   "column_break_4",
@@ -300,20 +300,20 @@
    "label": "Do Not Create New User "
   },
   {
-   "fieldname": "column_break_1",
+   "fieldname": "column_break_qied",
    "fieldtype": "Column Break"
   },
   {
    "default": "0",
-   "fieldname": "default_login",
+   "fieldname": "default_to_ldap_login",
    "fieldtype": "Check",
-   "label": "Default Login"
+   "label": "Default to LDAP Login"
   }
  ],
  "in_create": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-04 09:30:32.929307",
+ "modified": "2025-05-04 18:19:14.313425",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "LDAP Settings",

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -36,6 +36,7 @@ class LDAPSettings(Document):
 		from frappe.types import DF
 
 		base_dn: DF.Data
+		default_login: DF.Check
 		default_role: DF.Link | None
 		default_user_type: DF.Link
 		do_not_create_new_user: DF.Check
@@ -169,11 +170,13 @@ class LDAPSettings(Document):
 	@staticmethod
 	def get_ldap_client_settings() -> dict:
 		# return the settings to be used on the client side.
-		result = {"enabled": False}
+		result = {"enabled": False, "default_login": False}
 		ldap = frappe.get_cached_doc("LDAP Settings")
 		if ldap.enabled:
 			result["enabled"] = True
 			result["method"] = "frappe.integrations.doctype.ldap_settings.ldap_settings.login"
+			if ldap.default_login:
+				result["default_login"] = True
 		return result
 
 	@classmethod

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -36,8 +36,8 @@ class LDAPSettings(Document):
 		from frappe.types import DF
 
 		base_dn: DF.Data
-		default_login: DF.Check
 		default_role: DF.Link | None
+		default_to_ldap_login: DF.Check
 		default_user_type: DF.Link
 		do_not_create_new_user: DF.Check
 		enabled: DF.Check
@@ -170,13 +170,13 @@ class LDAPSettings(Document):
 	@staticmethod
 	def get_ldap_client_settings() -> dict:
 		# return the settings to be used on the client side.
-		result = {"enabled": False, "default_login": False}
+		result = {"enabled": False, "default_to_ldap_login": False}
 		ldap = frappe.get_cached_doc("LDAP Settings")
 		if ldap.enabled:
 			result["enabled"] = True
 			result["method"] = "frappe.integrations.doctype.ldap_settings.ldap_settings.login"
-			if ldap.default_login:
-				result["default_login"] = True
+			if ldap.default_to_ldap_login:
+				result["default_to_ldap_login"] = True
 		return result
 
 	@classmethod

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -175,8 +175,7 @@ class LDAPSettings(Document):
 		if ldap.enabled:
 			result["enabled"] = True
 			result["method"] = "frappe.integrations.doctype.ldap_settings.ldap_settings.login"
-			if ldap.default_to_ldap_login:
-				result["default_to_ldap_login"] = True
+			result["default_to_ldap_login"] = ldap.default_to_ldap_login
 		return result
 
 	@classmethod

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -40,15 +40,15 @@
 </div>
 {% endif %}
 <div class="page-card-actions">
-	{% if ldap_settings and ldap_settings.default_login %}
+	{% if ldap_settings and ldap_settings.default_to_ldap_login %}
 	<button class="btn btn-sm btn-primary btn-block btn-login btn-ldap-login">
 		{{ _("Login with LDAP") }}</button>
 	{% endif %}
 	{% if not disable_user_pass_login %}
-	<button class="btn btn-sm {{ "btn-default" if ldap_settings and ldap_settings.default_login else "btn-primary" }} btn-block btn-login" type="submit">
+	<button class="btn btn-sm {{ "btn-default" if ldap_settings and ldap_settings.default_to_ldap_login else "btn-primary" }} btn-block btn-login" type="submit">
 		{{ _("Login") }}</button>
 	{% endif %}
-	{% if ldap_settings and ldap_settings.enabled and not ldap_settings.default_login %}
+	{% if ldap_settings and ldap_settings.enabled and not ldap_settings.default_to_ldap_login %}
 	<button class="btn btn-sm {{ "btn-primary" if disable_user_pass_login else "btn-default" }} btn-block btn-login btn-ldap-login">
 		{{ _("Login with LDAP") }}</button>
 	{% endif %}

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -40,11 +40,15 @@
 </div>
 {% endif %}
 <div class="page-card-actions">
+	{% if ldap_settings and ldap_settings.default_login %}
+	<button class="btn btn-sm btn-primary btn-block btn-login btn-ldap-login">
+		{{ _("Login with LDAP") }}</button>
+	{% endif %}
 	{% if not disable_user_pass_login %}
-	<button class="btn btn-sm btn-primary btn-block btn-login" type="submit">
+	<button class="btn btn-sm {{ "btn-default" if ldap_settings and ldap_settings.default_login else "btn-primary" }} btn-block btn-login" type="submit">
 		{{ _("Login") }}</button>
 	{% endif %}
-	{% if ldap_settings and ldap_settings.enabled %}
+	{% if ldap_settings and ldap_settings.enabled and not ldap_settings.default_login %}
 	<button class="btn btn-sm {{ "btn-primary" if disable_user_pass_login else "btn-default" }} btn-block btn-login btn-ldap-login">
 		{{ _("Login with LDAP") }}</button>
 	{% endif %}


### PR DESCRIPTION
Add a checkbox to set the **Login with LDAP** button as the default login action when both **LDAP login** and **Default Login** are **enabled**. This also allows users to trigger LDAP login by pressing the Enter key on the keyboard  [LDAP login with enter key](https://discuss.frappe.io/t/ldap-login-with-enter-key/104499).

![image](https://github.com/user-attachments/assets/41a8df37-0f1a-4b87-8bf6-9445385bc5db)


Please
backport version-15-hotfix
backport version-14-hotfix