### PR TITLE
fix: update email template hex code according to espresso

### DIFF
--- a/frappe/public/scss/email.bundle.scss
+++ b/frappe/public/scss/email.bundle.scss
@@ -1,17 +1,19 @@
 $white: #fff;
-$gray-900: #1f272e;
-$gray-800: #333c44;
-$gray-700: #505a62;
-$gray-600: #687178;
-$gray-500: #98a1a9;
-$gray-400: #c0c6cc;
-$gray-300: #dce0e3;
-$gray-200: #ebeef0;
-$gray-100: #f4f5f6;
-$gray-50: #f9fafa;
-$primary: #2490ef;
 
 $blue-500: #2d95f0;
+
+$gray-50: #f8f8f8;
+$gray-100: #f3f3f3;
+$gray-200: #ededed;
+$gray-300: #e2e2e2;
+$gray-400: #c7c7c7;
+$gray-500: #999999;
+$gray-600: #7c7c7c;
+$gray-700: #525252;
+$gray-800: #383838;
+$gray-900: #171717;
+$primary: $gray-900;
+
 
 $text-color: $gray-900;
 $border-color: $gray-100;

--- a/frappe/public/scss/email.bundle.scss
+++ b/frappe/public/scss/email.bundle.scss
@@ -14,7 +14,6 @@ $gray-800: #383838;
 $gray-900: #171717;
 $primary: $gray-900;
 
-
 $text-color: $gray-900;
 $border-color: $gray-100;
 $dark-border-color: $gray-200;


### PR DESCRIPTION
The variables in "email.bundle.scss" are not updated according to Espresso

e.g

old $primary: #2490ef;

new $primary: #171717;


