### PR TITLE
fix(email_account): don't show gmail help text after selecting another provider

### DIFF
--- a/frappe/email/doctype/email_account/email_account.js
+++ b/frappe/email/doctype/email_account/email_account.js
@@ -117,23 +117,33 @@ function set_default_max_attachment_size(frm) {
 }
 function add_helpful_links(frm) {
 	// For better UX
-	switch (frm.doc.service) {
-		case "GMail":
-			frm.set_df_property(
-				"password",
-				"description",
-				'To generate password visit <a href="https://knowledge.workspace.google.com/kb/how-to-create-app-passwords-000009237"> here'
-			);
-			break;
-		case "Frappe Mail":
-			frm.set_df_property(
-				"api_secret",
-				"description",
-				'To know more visit <a href="https://github.com/frappe/mail"> here'
-			);
-			break;
+	if (frm.doc.service === "GMail") {
+		frm.set_df_property(
+			"password",
+			"description",
+			__("To generate password click {0}", [
+				"<a href='https://knowledge.workspace.google.com/kb/how-to-create-app-passwords-000009237' target='_blank'>" +
+					__("here") +
+					"</a>",
+			])
+		);
+	} else {
+		frm.set_df_property("password", "description", "");
+	}
+
+	if (frm.doc.service === "Frappe Mail") {
+		frm.set_df_property(
+			"api_secret",
+			"description",
+			__("To know more click {0}", [
+				"<a href='https://github.com/frappe/mail' target='_blank'>" + __("here") + "</a>",
+			])
+		);
+	} else {
+		frm.set_df_property("api_secret", "description", "");
 	}
 }
+
 frappe.ui.form.on("Email Account", {
 	service: function (frm) {
 		$.each(frappe.email_defaults[frm.doc.service], function (key, value) {


### PR DESCRIPTION
After #29226 we got the gmail help URL for all providers if you select gmail and switch to another
