### PR TITLE
perf: split maintenance tasks into separate queue

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -67,7 +67,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Frequency",
-   "options": "All\nHourly\nHourly Long\nDaily\nDaily Long\nWeekly\nWeekly Long\nMonthly\nMonthly Long\nCron\nYearly\nAnnual",
+   "options": "All\nHourly\nHourly Long\nHourly Maintenance\nDaily\nDaily Long\nDaily Maintenance\nWeekly\nWeekly Long\nMonthly\nMonthly Long\nCron\nYearly\nAnnual",
    "read_only": 1,
    "reqd": 1
   },
@@ -110,7 +110,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2025-01-13 10:39:39.975031",
+ "modified": "2025-05-05 18:24:38.816989",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",
@@ -130,6 +130,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -204,9 +204,6 @@ scheduler_events = {
 		],
 		# 15 minutes
 		"0/15 * * * *": [
-			"frappe.oauth.delete_oauth2_data",
-			"frappe.website.doctype.web_page.web_page.check_publish_status",
-			"frappe.twofactor.delete_all_barcodes_for_users",
 			"frappe.email.doctype.email_account.email_account.notify_unreplied",
 			"frappe.utils.global_search.sync_global_search",
 			"frappe.deferred_insert.save_to_db",
@@ -217,13 +214,9 @@ scheduler_events = {
 			"frappe.email.doctype.email_account.email_account.pull",
 		],
 		# Hourly but offset by 30 minutes
-		"30 * * * *": [
-			"frappe.core.doctype.prepared_report.prepared_report.expire_stalled_report",
-		],
+		"30 * * * *": [],
 		# Daily but offset by 45 minutes
-		"45 0 * * *": [
-			"frappe.core.doctype.log_settings.log_settings.run_log_clean_up",
-		],
+		"45 0 * * *": [],
 	},
 	"all": [
 		"frappe.email.queue.flush",
@@ -231,28 +224,39 @@ scheduler_events = {
 		"frappe.integrations.doctype.google_calendar.google_calendar.sync",
 	],
 	"hourly": [
+		"frappe.email.doctype.newsletter.newsletter.send_scheduled_email",
+	],
+	# Maintenance queue happen roughly once an hour but don't align with wall-clock time of *:00
+	# Use these for when you don't care about when the job runs but just need some guarantee for
+	# frequency.
+	"hourly_maintenance": [
 		"frappe.model.utils.link_count.update_link_count",
 		"frappe.model.utils.user_settings.sync_user_settings",
 		"frappe.desk.page.backups.backups.delete_downloadable_backups",
 		"frappe.desk.form.document_follow.send_hourly_updates",
-		"frappe.email.doctype.newsletter.newsletter.send_scheduled_email",
 		"frappe.website.doctype.personal_data_deletion_request.personal_data_deletion_request.process_data_deletion_request",
+		"frappe.core.doctype.prepared_report.prepared_report.expire_stalled_report",
+		"frappe.twofactor.delete_all_barcodes_for_users",
+		"frappe.oauth.delete_oauth2_data",
+		"frappe.website.doctype.web_page.web_page.check_publish_status",
 	],
 	"daily": [
-		"frappe.desk.notifications.clear_notifications",
 		"frappe.desk.doctype.event.event.send_event_digest",
-		"frappe.sessions.clear_expired_sessions",
 		"frappe.email.doctype.notification.notification.trigger_daily_alerts",
-		"frappe.website.doctype.personal_data_deletion_request.personal_data_deletion_request.remove_unverified_record",
 		"frappe.desk.form.document_follow.send_daily_updates",
-		"frappe.integrations.doctype.google_contacts.google_contacts.sync",
-		"frappe.automation.doctype.auto_repeat.auto_repeat.make_auto_repeat_entry",
 	],
-	"daily_long": [
+	"daily_long": [],
+	"daily_maintenance": [
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_daily",
 		"frappe.integrations.doctype.s3_backup_settings.s3_backup_settings.take_backups_daily",
-		"frappe.email.doctype.auto_email_report.auto_email_report.send_daily",
 		"frappe.integrations.doctype.google_drive.google_drive.daily_backup",
+		"frappe.email.doctype.auto_email_report.auto_email_report.send_daily",
+		"frappe.desk.notifications.clear_notifications",
+		"frappe.sessions.clear_expired_sessions",
+		"frappe.website.doctype.personal_data_deletion_request.personal_data_deletion_request.remove_unverified_record",
+		"frappe.integrations.doctype.google_contacts.google_contacts.sync",
+		"frappe.automation.doctype.auto_repeat.auto_repeat.make_auto_repeat_entry",
+		"frappe.core.doctype.log_settings.log_settings.run_log_clean_up",
 	],
 	"weekly_long": [
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_weekly",


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/32270

TL;DR: I've moved some (almost 80%) of hourly/daily jobs that don't have strict wall clock frequency requirements. They'll now execute at random times but with same frequency.

This isn't truly "random", it's quite deterministic based on site name. Site's name is hashed to find out roughly when all of its jobs should run. This still ensures that in large multi tenant deploys all the jobs will be sufficiently spaced out across entire hour.
