### PR TITLE
fix: Get field currency based on default company if company is not available on doc

### DIFF
--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -287,7 +287,6 @@ $.extend(frappe.meta, {
 	get_field_currency: function (df, doc) {
 		var currency = frappe.boot.sysdefaults.currency || "USD";
 		if (!doc && cur_frm) doc = cur_frm.doc;
-
 		if (df && df.options) {
 			if (df.options.indexOf(":") != -1) {
 				var options = df.options.split(":");
@@ -299,7 +298,8 @@ $.extend(frappe.meta, {
 						if (!docname && cur_frm) {
 							docname = cur_frm.doc[options[1]];
 						}
-					} else {
+					}
+					if (!docname) {
 						// Try to get default value, useful for cases like Company overridden in session defaults
 						docname = frappe.defaults.get_user_default(options[1]);
 					}


### PR DESCRIPTION
In the report, the currency symbol is shown incorrectly for base_currency fields (Company:company:default_currency) if the company column is not selected. In those cases, currently system shows the currency for the last created company.

After the fix, the system will show the currency for the default company.

Fixes #31985 
