### PR TITLE
build: bump gunicorn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "cryptography~=44.0.1",
     "cssutils~=2.9.0",
     "email-reply-parser~=0.5.12",
-    "gunicorn @ git+https://github.com/frappe/gunicorn@6b60bcff7ec2cf90680d7eb4af79d62f0f01711e",
+    "gunicorn @ git+https://github.com/frappe/gunicorn@bb554053bb87218120d76ab6676af7015680e8b6",
     "html5lib~=1.1",
     "ipython~=8.15.0",
     "ldap3~=2.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "cryptography~=44.0.1",
     "cssutils~=2.9.0",
     "email-reply-parser~=0.5.12",
-    "gunicorn @ git+https://github.com/frappe/gunicorn@72c1e495d89259151e73947a057432d528b06bb0",
+    "gunicorn @ git+https://github.com/frappe/gunicorn@6b60bcff7ec2cf90680d7eb4af79d62f0f01711e",
     "html5lib~=1.1",
     "ipython~=8.15.0",
     "ldap3~=2.9",


### PR DESCRIPTION
Applies https://github.com/frappe/gunicorn/pull/7

`gthread` autorestart and draining during timeout both suffer from a common issue - termination of ongoing / half-incomplete requests.

- This isn't intentional but side effect of recent gunicorn design changes which split request acceptance into two separate `accept` and `recv`. 
- This is done to let `gunicorn` handle bad clients that open a connection and then don't send anything.
- We always use nginx reverse proxy which buffers requests before sending so we don't have to worry about such bad clients. Nginx is the client for gunicorn.
- Our fork also has a request timeout implementation.

Reverted original fix so request handling is now back to `accept` + `recv` in the same routine. 