### PR TITLE
fix(mobile): broken onboarding widget

### DIFF
--- a/frappe/public/js/frappe/views/workspace/blocks/onboarding.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/onboarding.js
@@ -106,8 +106,6 @@ export default class Onboarding extends Block {
 	}
 
 	render() {
-		if (frappe.is_mobile()) return;
-
 		this.wrapper = document.createElement("div");
 		this.new("onboarding");
 


### PR DESCRIPTION
It renders clean
<p align="center">
  <img src="https://github.com/user-attachments/assets/37f8b4f7-9740-4bad-b02b-bc9a50829a8b" alt="Before" width="45%" />
  <img src="https://github.com/user-attachments/assets/8bda628e-6f39-43c7-89b0-973c8f179f6d" alt="After" width="45%" />
</p>

