### PR TITLE
Integrate spam filtering for comments

### DIFF
--- a/frappe/core/doctype/comment/comment.js
+++ b/frappe/core/doctype/comment/comment.js
@@ -6,19 +6,39 @@ frappe.ui.form.on("Comment", {
 		if (frm.is_new() || frm.doc.comment_type != "Comment") {
 			return;
 		}
-		const is_spam =
-			["Spam", "Discard"].includes(frm.doc.spam_type) && frm.doc.spam_type != "Pending";
-		frm.add_custom_button(__(`Mark as ${is_spam ? "Ham" : "Spam"}`), function () {
-			frm.call("mark_as_spam_or_ham", { is_spam: !is_spam })
-				.then((r) => {
-					if (r.message) {
-						frm.reload_doc();
-					}
-				})
-				.catch((e) => {
-					frappe.msgprint(__("Unable to mark comment as spam/ham"));
-					console.error(e);
-				});
-		});
+		const type =
+			["Spam", "Discard"].includes(frm.doc.spam_type) && frm.doc.spam_type != "Pending"
+				? "Ham"
+				: "Spam";
+		if (frm.doc.spam_type != "Pending") {
+			frm.add_custom_button(__(`Mark as ${type}`), () => mark_as_spam_or_ham(frm, type));
+		} else {
+			frm.add_custom_button(
+				__(`Mark as Ham`),
+				() => mark_as_spam_or_ham(frm, "hame"),
+				__("Actions")
+			);
+			frm.add_custom_button(
+				__(`Mark as Spam`),
+				() => mark_as_spam_or_ham(frm, "Spam"),
+				__("Actions")
+			);
+		}
 	},
 });
+
+function mark_as_spam_or_ham(frm, spam_type) {
+	frappe.call({
+		method: "frappe.core.doctype.comment.comment.mark_as_spam_or_ham",
+		args: {
+			comment: frm.doc.name,
+			type: spam_type,
+		},
+		freeze: true,
+		callback: function (r) {
+			if (r) {
+				frm.reload_doc();
+			}
+		},
+	});
+}

--- a/frappe/core/doctype/comment/comment.js
+++ b/frappe/core/doctype/comment/comment.js
@@ -2,6 +2,23 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Comment", {
-	// refresh: function(frm) {
-	// }
+	refresh: function (frm) {
+		if (frm.is_new() || frm.doc.comment_type != "Comment") {
+			return;
+		}
+		const is_spam =
+			["Spam", "Discard"].includes(frm.doc.spam_type) && frm.doc.spam_type != "Pending";
+		frm.add_custom_button(__(`Mark as ${is_spam ? "Ham" : "Spam"}`), function () {
+			frm.call("mark_as_spam_or_ham", { is_spam: !is_spam })
+				.then((r) => {
+					if (r.message) {
+						frm.reload_doc();
+					}
+				})
+				.catch((e) => {
+					frappe.msgprint(__("Unable to mark comment as spam/ham"));
+					console.error(e);
+				});
+		});
+	},
 });

--- a/frappe/core/doctype/comment/comment.json
+++ b/frappe/core/doctype/comment/comment.json
@@ -102,18 +102,18 @@
    "label": "IP Address"
   },
   {
-   "default": "Pending",
+   "default": "Review Pending",
    "depends_on": "eval:doc.comment_type==\"Comment\"",
    "fieldname": "spam_type",
    "fieldtype": "Select",
    "label": "Spam Type",
    "no_copy": 1,
-   "options": "\nPending\nSpam\nHam\nDiscard",
+   "options": "\nReview Pending\nSpam\nHam\nDiscard",
    "read_only": 1
   }
  ],
  "links": [],
- "modified": "2025-04-16 18:00:14.765998",
+ "modified": "2025-04-27 12:07:51.904210",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Comment",

--- a/frappe/core/doctype/comment/comment.json
+++ b/frappe/core/doctype/comment/comment.json
@@ -15,6 +15,7 @@
   "reference_doctype",
   "reference_name",
   "reference_owner",
+  "spam_type",
   "section_break_10",
   "content",
   "ip_address"
@@ -58,8 +59,11 @@
    "label": "Seen"
   },
   {
+   "depends_on": "eval:doc.comment_type==\"Comment\"",
    "fieldname": "column_break_5",
-   "fieldtype": "Column Break"
+   "fieldtype": "Column Break",
+   "options": "\nSpam\nHam\nDiscard",
+   "read_only": 1
   },
   {
    "fieldname": "reference_doctype",
@@ -96,10 +100,20 @@
    "fieldtype": "Data",
    "hidden": 1,
    "label": "IP Address"
+  },
+  {
+   "default": "Pending",
+   "depends_on": "eval:doc.comment_type==\"Comment\"",
+   "fieldname": "spam_type",
+   "fieldtype": "Select",
+   "label": "Spam Type",
+   "no_copy": 1,
+   "options": "\nPending\nSpam\nHam\nDiscard",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2024-08-14 16:10:15.413830",
+ "modified": "2025-04-16 18:00:14.765998",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Comment",
@@ -131,6 +145,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -58,7 +58,7 @@ class Comment(Document):
 		reference_name: DF.DynamicLink | None
 		reference_owner: DF.Data | None
 		seen: DF.Check
-		spam_type: DF.Literal["", "Pending", "Spam", "Ham", "Discard"]
+		spam_type: DF.Literal["", "Review Pending", "Spam", "Ham", "Discard"]
 		subject: DF.Text | None
 	# end: auto-generated types
 
@@ -67,9 +67,13 @@ class Comment(Document):
 	def after_insert(self):
 		result = self.delete_if_spam()
 		if result:
-			return
+			self.notify_change("delete")
 		notify_mentions(self.reference_doctype, self.reference_name, self.content)
 		self.notify_change("add")
+
+	def before_validate(self):
+		if not self.ip_address:
+			self.ip_address = frappe.local.request_ip
 
 	def validate(self):
 		if not self.comment_email:
@@ -81,7 +85,7 @@ class Comment(Document):
 		update_comment_in_doc(self)
 		result = self.delete_if_spam()
 		if result:
-			return
+			self.notify_change("delete")
 		if not self.is_new():
 			self.notify_change("update")
 
@@ -121,32 +125,33 @@ class Comment(Document):
 	def validate_spam(self):
 		from bs4 import BeautifulSoup
 
-		akismet_setting = frappe.get_single("Akismet Settings")
-		if self.comment_type != "Comment" and not akismet_setting.enable:
+		spam_filtering = frappe.db.get_single_value("Akismet Settings", "spam_filtering")
+		if self.comment_type != "Comment":
 			return
 
 		comment = BeautifulSoup(self.content, "html.parser").get_text()
 		if not comment:
 			return
+		akismet_client = get_akismet()
 
-		config = Config(key=akismet_setting.get_password("api_key"), url=frappe.local.site)
-		akismet_client = SyncClient.validated_client(config=config)
+		if not akismet_client:
+			return
 
 		result = akismet_client.comment_check(
-			user_ip=self.ip_address if self.ip_address else frappe.local.request_ip,
+			user_ip=self.ip_address,
 			comment_type="comment",
 			comment_content=comment,
 			comment_author=self.comment_by,
 			comment_author_email=self.comment_email,
 		)
 
-		self.spam_type = status_map.get(result, "Pending")
+		self.spam_type = status_map.get(result, "Review Pending")
 
 		if (
 			result in [CheckResponse.DISCARD, CheckResponse.SPAM]
-			and akismet_setting.spam_filtering == "Keep spam comment for review"
+			and spam_filtering == "Keep spam comment for review"
 		):
-			self.spam_type = "Pending"
+			self.spam_type = "Review Pending"
 
 	def delete_if_spam(self):
 		akismet_setting = frappe.get_single("Akismet Settings")
@@ -160,33 +165,51 @@ class Comment(Document):
 			return True
 		return False
 
-	@frappe.whitelist()
-	def mark_as_spam_or_ham(self, is_spam):
-		akismet_setting = frappe.get_single("Akismet Settings")
-		if self.comment_type != "Comment" and not akismet_setting.enable:
-			return
 
-		config = Config(key=akismet_setting.get_password("api_key"), url=frappe.local.site)
-		akismet_client = SyncClient.validated_client(config=config)
+@frappe.whitelist()
+def mark_as_spam_or_ham(comment, type):
+	frappe.only_for(["System Manager"])
 
-		if is_spam:
-			akismet_client.submit_spam(
-				comment_type="comment",
-				comment_author=self.comment_by,
-				comment_author_email=self.comment_email,
-				comment_content=self.content,
-				user_ip=self.ip_address if self.ip_address else frappe.local.request_ip,
-			)
-		else:
-			akismet_client.submit_ham(
-				comment_type="comment",
-				comment_author=self.comment_by,
-				comment_author_email=self.comment_email,
-				comment_content=self.content,
-				user_ip=self.ip_address if self.ip_address else frappe.local.request_ip,
-			)
-		frappe.db.set_value("Comment", self.name, "spam_type", "Ham" if not is_spam else "Spam")
-		return True
+	_mark_as_spam_or_ham(comment, type == "Spam")
+
+	frappe.db.set_value("Comment", comment, "spam_type", type)
+
+
+def _mark_as_spam_or_ham(docname, is_spam):
+	doc = frappe.get_doc("Comment", docname, for_update=False)
+	if doc.comment_type != "Comment":
+		return
+	akismet_client = get_akismet()
+	if not akismet_client:
+		return
+
+	if is_spam:
+		akismet_client.submit_spam(
+			comment_type="comment",
+			comment_author=doc.comment_by,
+			comment_author_email=doc.comment_email,
+			comment_content=doc.content,
+			user_ip=doc.ip_address,
+		)
+	else:
+		akismet_client.submit_ham(
+			comment_type="comment",
+			comment_author=doc.comment_by,
+			comment_author_email=doc.comment_email,
+			comment_content=doc.content,
+			user_ip=doc.ip_address,
+		)
+
+
+def get_akismet() -> SyncClient | None:
+	akismet_setting = frappe.get_single("Akismet Settings")
+	if not akismet_setting.enable:
+		return None
+
+	config = Config(key=akismet_setting.get_password("api_key"), url=frappe.local.site)
+	akismet_client = SyncClient.validated_client(config=config)
+	akismet_client._http_client.timeout = akismet_setting.timeout or 5
+	return akismet_client
 
 
 def on_doctype_update():

--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -2,6 +2,8 @@
 # License: MIT. See LICENSE
 import json
 
+from akismet import CheckResponse, Config, SyncClient
+
 import frappe
 from frappe.database.schema import add_column
 from frappe.desk.notifications import notify_mentions
@@ -9,6 +11,12 @@ from frappe.exceptions import ImplicitCommitError
 from frappe.model.document import Document
 from frappe.model.utils import is_virtual_doctype
 from frappe.website.utils import clear_cache
+
+status_map = {
+	CheckResponse.DISCARD: "Discard",
+	CheckResponse.SPAM: "Spam",
+	CheckResponse.HAM: "Ham",
+}
 
 
 class Comment(Document):
@@ -50,12 +58,16 @@ class Comment(Document):
 		reference_name: DF.DynamicLink | None
 		reference_owner: DF.Data | None
 		seen: DF.Check
+		spam_type: DF.Literal["", "Pending", "Spam", "Ham", "Discard"]
 		subject: DF.Text | None
 	# end: auto-generated types
 
 	no_feed_on_delete = True
 
 	def after_insert(self):
+		result = self.delete_if_spam()
+		if result:
+			return
 		notify_mentions(self.reference_doctype, self.reference_name, self.content)
 		self.notify_change("add")
 
@@ -63,9 +75,13 @@ class Comment(Document):
 		if not self.comment_email:
 			self.comment_email = frappe.session.user
 		self.content = frappe.utils.sanitize_html(self.content, always_sanitize=True)
+		self.validate_spam()
 
 	def on_update(self):
 		update_comment_in_doc(self)
+		result = self.delete_if_spam()
+		if result:
+			return
 		if not self.is_new():
 			self.notify_change("update")
 
@@ -101,6 +117,76 @@ class Comment(Document):
 				_comments.remove(c)
 
 		update_comments_in_parent(self.reference_doctype, self.reference_name, _comments)
+
+	def validate_spam(self):
+		from bs4 import BeautifulSoup
+
+		akismet_setting = frappe.get_single("Akismet Settings")
+		if self.comment_type != "Comment" and not akismet_setting.enable:
+			return
+
+		comment = BeautifulSoup(self.content, "html.parser").get_text()
+		if not comment:
+			return
+
+		config = Config(key=akismet_setting.get_password("api_key"), url=frappe.local.site)
+		akismet_client = SyncClient.validated_client(config=config)
+
+		result = akismet_client.comment_check(
+			user_ip=self.ip_address if self.ip_address else frappe.local.request_ip,
+			comment_type="comment",
+			comment_content=comment,
+			comment_author=self.comment_by,
+			comment_author_email=self.comment_email,
+		)
+
+		self.spam_type = status_map.get(result, "Pending")
+
+		if (
+			result in [CheckResponse.DISCARD, CheckResponse.SPAM]
+			and akismet_setting.spam_filtering == "Keep spam comment for review"
+		):
+			self.spam_type = "Pending"
+
+	def delete_if_spam(self):
+		akismet_setting = frappe.get_single("Akismet Settings")
+		if (
+			self.comment_type == "Comment"
+			and akismet_setting.enable
+			and akismet_setting.spam_filtering == "Silently discard spam comment"
+			and self.spam_type in ["Spam", "Discard"]
+		):
+			self.delete()
+			return True
+		return False
+
+	@frappe.whitelist()
+	def mark_as_spam_or_ham(self, is_spam):
+		akismet_setting = frappe.get_single("Akismet Settings")
+		if self.comment_type != "Comment" and not akismet_setting.enable:
+			return
+
+		config = Config(key=akismet_setting.get_password("api_key"), url=frappe.local.site)
+		akismet_client = SyncClient.validated_client(config=config)
+
+		if is_spam:
+			akismet_client.submit_spam(
+				comment_type="comment",
+				comment_author=self.comment_by,
+				comment_author_email=self.comment_email,
+				comment_content=self.content,
+				user_ip=self.ip_address if self.ip_address else frappe.local.request_ip,
+			)
+		else:
+			akismet_client.submit_ham(
+				comment_type="comment",
+				comment_author=self.comment_by,
+				comment_author_email=self.comment_email,
+				comment_content=self.content,
+				user_ip=self.ip_address if self.ip_address else frappe.local.request_ip,
+			)
+		frappe.db.set_value("Comment", self.name, "spam_type", "Ham" if not is_spam else "Spam")
+		return True
 
 
 def on_doctype_update():

--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -169,21 +169,16 @@ class Comment(Document):
 @frappe.whitelist()
 def mark_as_spam_or_ham(comment, type):
 	frappe.only_for(["System Manager"])
-
-	_mark_as_spam_or_ham(comment, type == "Spam")
-
+	# Can't do doc.save(), since it will be marked pending for review
+	# if spam_filtering is set to "Keep spam comment for review"
 	frappe.db.set_value("Comment", comment, "spam_type", type)
+	doc = frappe.get_doc("Comment", comment, for_update=False)
 
-
-def _mark_as_spam_or_ham(docname, is_spam):
-	doc = frappe.get_doc("Comment", docname, for_update=False)
-	if doc.comment_type != "Comment":
-		return
 	akismet_client = get_akismet()
 	if not akismet_client:
 		return
 
-	if is_spam:
+	if type == "Spam":
 		akismet_client.submit_spam(
 			comment_type="comment",
 			comment_author=doc.comment_by,
@@ -199,6 +194,7 @@ def _mark_as_spam_or_ham(docname, is_spam):
 			comment_content=doc.content,
 			user_ip=doc.ip_address,
 		)
+	doc.notify_change("update")
 
 
 def get_akismet() -> SyncClient | None:
@@ -224,11 +220,11 @@ def update_comment_in_doc(doc):
 
 	`_comments` format
 
-	        {
-	                "comment": [String],
-	                "by": [user],
-	                "name": [Comment Document name]
-	        }"""
+			{
+					"comment": [String],
+					"by": [user],
+					"name": [Comment Document name]
+			}"""
 
 	# only comments get updates, not likes, assignments etc.
 	if doc.doctype == "Comment" and doc.comment_type != "Comment":

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -148,7 +148,7 @@ def add_comments(doc, docinfo):
 
 	comments = frappe.get_all(
 		"Comment",
-		fields=["name", "creation", "content", "owner", "comment_type", "published"],
+		fields=["name", "creation", "content", "owner", "comment_type", "spam_type", "published"],
 		filters={"reference_doctype": doc.doctype, "reference_name": doc.name},
 	)
 

--- a/frappe/integrations/doctype/akismet_settings/akismet_settings.js
+++ b/frappe/integrations/doctype/akismet_settings/akismet_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Akismet Settings", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe/integrations/doctype/akismet_settings/akismet_settings.json
+++ b/frappe/integrations/doctype/akismet_settings/akismet_settings.json
@@ -7,6 +7,8 @@
  "field_order": [
   "enable",
   "api_key",
+  "column_break_ybeu",
+  "timeout",
   "section_break_hjlk",
   "spam_filtering"
  ],
@@ -37,12 +39,23 @@
    "fieldtype": "Select",
    "label": "Spam filtering",
    "options": "Silently discard spam comment\nKeep spam comment for review"
+  },
+  {
+   "fieldname": "column_break_ybeu",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "5",
+   "description": "Set timeout for API",
+   "fieldname": "timeout",
+   "fieldtype": "Int",
+   "label": "Timeout"
   }
  ],
  "grid_page_length": 50,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-16 16:46:31.354406",
+ "modified": "2025-04-19 18:32:47.718214",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Akismet Settings",

--- a/frappe/integrations/doctype/akismet_settings/akismet_settings.json
+++ b/frappe/integrations/doctype/akismet_settings/akismet_settings.json
@@ -1,0 +1,67 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-04-16 16:37:45.450284",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "enable",
+  "api_key",
+  "section_break_hjlk",
+  "spam_filtering"
+ ],
+ "fields": [
+  {
+   "default": "0",
+   "fieldname": "enable",
+   "fieldtype": "Check",
+   "label": "Enable"
+  },
+  {
+   "depends_on": "eval:doc.enable",
+   "fieldname": "api_key",
+   "fieldtype": "Password",
+   "in_list_view": 1,
+   "label": "API Key",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.enable",
+   "fieldname": "section_break_hjlk",
+   "fieldtype": "Section Break",
+   "label": "Filtering"
+  },
+  {
+   "default": "Silently discard spam comment",
+   "fieldname": "spam_filtering",
+   "fieldtype": "Select",
+   "label": "Spam filtering",
+   "options": "Silently discard spam comment\nKeep spam comment for review"
+  }
+ ],
+ "grid_page_length": 50,
+ "issingle": 1,
+ "links": [],
+ "modified": "2025-04-16 16:46:31.354406",
+ "modified_by": "Administrator",
+ "module": "Integrations",
+ "name": "Akismet Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/frappe/integrations/doctype/akismet_settings/akismet_settings.json
+++ b/frappe/integrations/doctype/akismet_settings/akismet_settings.json
@@ -46,6 +46,7 @@
   },
   {
    "default": "5",
+   "depends_on": "eval:doc.enable",
    "description": "Set timeout for API",
    "fieldname": "timeout",
    "fieldtype": "Int",
@@ -55,7 +56,7 @@
  "grid_page_length": 50,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-19 18:32:47.718214",
+ "modified": "2025-05-07 09:55:24.256606",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Akismet Settings",

--- a/frappe/integrations/doctype/akismet_settings/akismet_settings.py
+++ b/frappe/integrations/doctype/akismet_settings/akismet_settings.py
@@ -17,6 +17,5 @@ class AkismetSettings(Document):
 		api_key: DF.Password
 		enable: DF.Check
 		spam_filtering: DF.Literal["Silently discard spam comment", "Keep spam comment for review"]
+		timeout: DF.Int
 	# end: auto-generated types
-
-	pass

--- a/frappe/integrations/doctype/akismet_settings/akismet_settings.py
+++ b/frappe/integrations/doctype/akismet_settings/akismet_settings.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class AkismetSettings(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		api_key: DF.Password
+		enable: DF.Check
+		spam_filtering: DF.Literal["Silently discard spam comment", "Keep spam comment for review"]
+	# end: auto-generated types
+
+	pass

--- a/frappe/integrations/doctype/akismet_settings/test_akismet_settings.py
+++ b/frappe/integrations/doctype/akismet_settings/test_akismet_settings.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase, UnitTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class UnitTestAkismetSettings(UnitTestCase):
+	"""
+	Unit tests for AkismetSettings.
+	Use this class for testing individual functions and methods.
+	"""
+
+	pass
+
+
+class IntegrationTestAkismetSettings(IntegrationTestCase):
+	"""
+	Integration tests for AkismetSettings.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/frappe/public/js/frappe/form/footer/footer.js
+++ b/frappe/public/js/frappe/form/footer/footer.js
@@ -69,17 +69,7 @@ frappe.ui.form.Footer = class FormFooter {
 	}
 
 	refresh_comments_count() {
-		let comments = this.frm.get_docinfo().comments || [];
-		let count = comments.filter((comment) => {
-			if (comment.spam_type) {
-				return (
-					this.frm.doc.owner === frappe.session.user ||
-					frappe.user.has_role("System Manager") ||
-					comment.owner === frappe.session.user
-				);
-			}
-			return true;
-		}).length;
+		let count = (this.frm.get_docinfo().comments || []).length;
 		this.wrapper.find(".comment-count")?.html(count ? `(${count})` : "");
 	}
 

--- a/frappe/public/js/frappe/form/footer/footer.js
+++ b/frappe/public/js/frappe/form/footer/footer.js
@@ -69,7 +69,17 @@ frappe.ui.form.Footer = class FormFooter {
 	}
 
 	refresh_comments_count() {
-		let count = (this.frm.get_docinfo().comments || []).length;
+		let comments = this.frm.get_docinfo().comments || [];
+		let count = comments.filter((comment) => {
+			if (comment.spam_type) {
+				return (
+					this.frm.doc.owner === frappe.session.user ||
+					frappe.user.has_role("System Manager") ||
+					comment.owner === frappe.session.user
+				);
+			}
+			return true;
+		}).length;
 		this.wrapper.find(".comment-count")?.html(count ? `(${count})` : "");
 	}
 

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -328,6 +328,11 @@ class FormTimeline extends BaseTimeline {
 
 	get_comment_timeline_contents() {
 		let comment_timeline_contents = [];
+		if (this.doc_info.comments) {
+			this.doc_info.comments = this.doc_info.comments.filter((comment) => {
+				return !comment.__unsaved;
+			});
+		}
 		(this.doc_info.comments || []).forEach((comment) => {
 			if (comment.spam_type) {
 				if (
@@ -617,7 +622,7 @@ class FormTimeline extends BaseTimeline {
 				const delete_option = $(`
 					<a class="dropdown-item">${__("Delete")}</a>
 				`).click(() => this.delete_comment(doc.name));
-			
+
 				dropdown_menu.append(delete_option);
 			}
 			if (doc.spam_type && frappe.user.has_role("System Manager")) {

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -329,6 +329,15 @@ class FormTimeline extends BaseTimeline {
 	get_comment_timeline_contents() {
 		let comment_timeline_contents = [];
 		(this.doc_info.comments || []).forEach((comment) => {
+			if (comment.spam_type) {
+				if (
+					this.frm.doc.owner != frappe.session.user ||
+					!frappe.user.has_role("System Manager") ||
+					comment.owner != frappe.session.user
+				) {
+					return;
+				}
+			}
 			comment_timeline_contents.push(this.get_comment_timeline_item(comment));
 		});
 		return comment_timeline_contents;
@@ -608,7 +617,46 @@ class FormTimeline extends BaseTimeline {
 				const delete_option = $(`
 					<a class="dropdown-item">${__("Delete")}</a>
 				`).click(() => this.delete_comment(doc.name));
+			
 				dropdown_menu.append(delete_option);
+			}
+			if (doc.spam_type && frappe.user.has_role("System Manager")) {
+				if (doc.spam_type == "Review Pending") {
+					const spam_option = $(`
+						<li>
+							<a class="dropdown-item">
+								${__("Mark as Spam")}
+							</a>
+						</li>
+					`).click(() => this.mark_as_spam_or_ham(doc.name, "Spam"));
+					more_actions_wrapper.find(".dropdown-menu").append(spam_option);
+					const ham_option = $(`
+						<li>
+							<a class="dropdown-item">
+								${__("Mark as Ham")}
+							</a>
+						</li>
+					`).click(() => this.mark_as_spam_or_ham(doc.name, "Ham"));
+					more_actions_wrapper.find(".dropdown-menu").append(ham_option);
+				} else if (doc.spam_type == "Spam") {
+					const ham_option = $(`
+						<li>
+							<a class="dropdown-item">
+								${__("Mark as Ham")}
+							</a>
+						</li>
+					`).click(() => this.mark_as_spam_or_ham(doc.name, "Ham"));
+					more_actions_wrapper.find(".dropdown-menu").append(ham_option);
+				} else {
+					const spam_option = $(`
+						<li>
+							<a class="dropdown-item">
+								${__("Mark as Spam")}
+							</a>
+						</li>
+					`).click(() => this.mark_as_spam_or_ham(doc.name, "Spam"));
+					more_actions_wrapper.find(".dropdown-menu").append(spam_option);
+				}
 			}
 
 			const un_publish_button = $(`
@@ -724,7 +772,17 @@ class FormTimeline extends BaseTimeline {
 				});
 		});
 	}
-
+	mark_as_spam_or_ham(comment_name, spam_type) {
+		return frappe
+			.call("frappe.core.doctype.comment.comment.mark_as_spam_or_ham", {
+				comment: comment_name,
+				type: spam_type,
+			})
+			.then(() => {
+				this.refresh();
+				frappe.utils.play_sound("click");
+			});
+	}
 	update_comment_publicity(comment_name, publish) {
 		let message;
 		if (publish) {

--- a/frappe/public/js/frappe/form/templates/timeline_message_box.html
+++ b/frappe/public/js/frappe/form/templates/timeline_message_box.html
@@ -35,6 +35,13 @@
 					<span class="text-extra-muted">
 						{{ comment_when(doc.communication_date || doc.creation) }}
 					</span>
+					{% if (doc.spam_type && (doc.spam_type === 'Review Pending' || doc.spam_type === 'Spam')) { %}
+					<span class="indicator-pill {{ (doc.spam_type == 'Spam') ? 'red' : 'yellow' }}" title="{%= __(doc.spam_type) %}">
+						<span class="hidden-xs small">
+							{%= __(doc.spam_type) %}
+						</span>
+					</span>
+					{% }  %}
 					{% if (doc.published) { %}
 						<span> · </span>
 						<span class="text-extra-muted" title="{{ __('Visible to website/portal users.') }}">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ dependencies = [
     "posthog~=3.21.0",
     "vobject~=0.9.7",
     "pycountry~=24.6.1",
+    "akismet~=24.11.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description

This PR introduces comment filtering using [Akismet](https://pypi.org/project/akismet/#description) to detect and handle spam comments. The implementation includes an auto-discard feature to automatically remove spam comments and a review mechanism that allows system managers to update the status of flagged comments.


## Screenshot/Screencast

https://github.com/user-attachments/assets/ebc965ae-dca2-4b2a-a290-97cd125bec5e




See #28499
