### PR TITLE
fix: translation backport command (CLI)

### DIFF
--- a/frappe/commands/gettext.py
+++ b/frappe/commands/gettext.py
@@ -81,8 +81,8 @@ def create_po_file(context, locale: str, app: str | None = None):
 
 @click.command("update-csv-from-po")
 @click.argument("app", nargs=1)
-@click.argument("locale", nargs=1)
-def update_csv_from_po(app: str, locale: str) -> None:
+@click.option("--locale", help="Update CSV file only for this locale. eg: de")
+def update_csv_from_po(app: str, locale: str | None = None) -> None:
 	"""Add missing translations from PO file to CSV file.
 
 	How to:


### PR DESCRIPTION
Optimize the CLI command for backporting translations for multiple locales at once.

### Old

```bash
bench update-csv-from-po hrms de
# regenerates main.pot
# updates de.po
# updates de.csv
```

Since we support 17 languages at the moment, running this command for each locale became a bit tedious.

### New

```bash
bench update-csv-from-po hrms
# regenerates main.pot
# for locale in all_locales:
#     updates [locale].po
#     updates [locale].csv

bench update-csv-from-po hrms --locale de
# regenerates main.pot
# updates de.po
# updates de.csv
```

This is breaking, but I think there are very very few people using this command and this PR will also benefit them.

> [!NOTE]
> The prerequisite for this command is that you've manually copied your app's `locale` dir from `develop` to `version-15-hotfix`.