### PR TITLE
Fix: Correct doc_status field type to prevent errors in Workflow Document State

### DIFF
--- a/frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
+++ b/frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
@@ -36,7 +36,7 @@
    "default": "0",
    "description": "0 - Draft; 1 - Submitted; 2 - Cancelled",
    "fieldname": "doc_status",
-   "fieldtype": "Select",
+   "fieldtype": "Int",
    "in_list_view": 1,
    "label": "Doc Status",
    "options": "0\n1\n2",


### PR DESCRIPTION
**Description:**

This PR resolves the issue described in bug report [#46633](https://github.com/frappe/frappe/issues/35361) from the ERPNext repository, where the doc_status field in the Workflow Document State doctype was not functioning correctly in certain views. **Specifically:**

-When editing a state using the visual workflow builder, the doc_status field displayed as expected.

-However, when using another view, it displayed a dropdown with options like "draft", "submitted", and "cancelled".

-Selecting any of these options and attempting to save resulted in an error stating that the value should be 0, 1, or 2.

-The issue occurred because the doc_status field was using the wrong data type, which caused the dropdown values to be treated incorrectly.

**Fix:**

-The doc_status field in frappe/workflow/doctype/workflow_document_state/workflow_document_state.json was modified, changing its data type from Select to Int to ensure it properly handles values 0, 1, or 2.

-This change ensures that the field works correctly across both views, without causing errors when saving.

**Changes made:**

Updated the doc_status field from Select to Int in the relevant doctype JSON file.