### PR TITLE
fix: set distinct name for grid row

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -154,9 +154,13 @@ export default class Grid {
 				d.idx = ri + 1;
 			}
 			if (d.name === undefined) {
-				d.name = "row " + d.idx;
+				d.name = this.get_random_name();
 			}
 		});
+	}
+
+	get_random_name() {
+		return crypto.randomUUID().slice(0, 8);
 	}
 
 	set_doc_url() {
@@ -484,7 +488,7 @@ export default class Grid {
 				d.idx = ri + 1;
 			}
 			if (d.name === undefined) {
-				d.name = "row " + d.idx;
+				d.name = this.get_random_name();
 			}
 			let grid_row;
 			if (this.grid_rows[ri] && !append_row) {


### PR DESCRIPTION
### Problem

https://github.com/user-attachments/assets/d8b2d8a3-10c6-4f7b-89f9-6ed425d2f460

Add two rows to a grid.

```js
if (d.name === undefined) {
	d.name = "row " + d.idx;
}
```

According to the code above, we now have: `["row 1", "row 2"]`
Now drag the second row to the first position: `["row 2", "row 1"]`
Remove the second row: `["row 2"]`
Add a new second row: `["row 2", "row 2"]`

So, with the old implementation it's easy to get name collisions. IMO, row names need to be distinct to be useful.

Fix: use eight random characters as the row ID (name)

```js
if (d.name === undefined) {
	d.name = crypto.randomUUID().slice(0, 8);
}
```

CC @ljain112, @vishakhdesai

Ref: IDM-219