### PR TITLE
fix: Hooks values should be prepended instead of appended.

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1631,7 +1631,7 @@ def append_hook(target, key, value):
 		target.setdefault(key, [])
 		if not isinstance(value, list):
 			value = [value]
-		target[key].extend(value)
+		target[key] = value + target[key]
 
 
 def setup_module_map(include_all_apps: bool = True) -> None:


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes
-->
> Please provide enough information so that others can review your pull request:

This pull request allows hooks defined in frappe to be overridden from custom apps. Previously, certain hooks hardcoded in ERPNext could not be cleanly replaced by downstream apps, limiting flexibility and customization capabilities in real-world deployments.

> Explain the **details** for making this change. What existing problem does the pull request solve?

Frappe previously extended hook values using .extend(), which appended custom app hooks to the existing list. This made it difficult to override core frappe hooks because Frappe values would always come first.

`target[key].extend(value)  # Appended custom hook`

After 

`target[key] = value + target[key]  # Prepend custom hook`

