### PR TITLE
feat: add option to disallow Google Drive in file uploader

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -150,7 +150,7 @@
 						<div class="mt-1">{{ __("Camera") }}</div>
 					</button>
 					<button
-						v-if="google_drive_settings.enabled"
+						v-if="allow_google_drive && google_drive_settings.enabled"
 						class="btn btn-file-upload"
 						@click="show_google_drive_picker"
 					>
@@ -288,6 +288,9 @@ const props = defineProps({
 	allow_toggle_optimize: {
 		default: true,
 	},
+	allow_google_drive: {
+		default: true,
+	},
 });
 
 // variables
@@ -315,7 +318,7 @@ if (props.allow_take_photo) {
 	allow_take_photo.value = window.navigator.mediaDevices;
 }
 
-if (frappe.user_id !== "Guest") {
+if (frappe.user_id !== "Guest" && props.allow_google_drive) {
 	frappe.call({
 		// method only available after login
 		method: "frappe.integrations.doctype.google_settings.google_settings.get_file_picker_settings",

--- a/frappe/public/js/frappe/file_uploader/file_uploader.bundle.js
+++ b/frappe/public/js/frappe/file_uploader/file_uploader.bundle.js
@@ -25,6 +25,7 @@ class FileUploader {
 		allow_take_photo,
 		allow_toggle_private,
 		allow_toggle_optimize,
+		allow_google_drive,
 	} = {}) {
 		frm && frm.attachments.max_reached(true);
 
@@ -63,6 +64,7 @@ class FileUploader {
 			allow_take_photo,
 			allow_toggle_private,
 			allow_toggle_optimize,
+			allow_google_drive,
 		});
 		SetVueGlobals(app);
 		this.uploader = app.mount(this.wrapper);


### PR DESCRIPTION
https://github.com/frappe/frappe/pull/27851 made it possible to disable Photo, URL and Library in file upload dialogs. This PR adds an option to disable the Google Drive file picker for specific file uploads, even if the integration is enabled. This is useful because for Google Drive files we just attach a URL. But in some cases we require the upload of an actual file (e.g. for data import).

> no-docs