### PR TITLE
fix: Fix #31554 return ISO formatted string in get_datetime_str() wit…

### DIFF
--- a/frappe/tests/test_data.py
+++ b/frappe/tests/test_data.py
@@ -1,0 +1,33 @@
+import unittest
+from datetime import datetime, date
+from frappe.utils.data import get_datetime_str
+
+
+class TestGetDatetimeStr(unittest.TestCase):
+
+    def test_datetime_input(self):
+        dt = datetime(2025, 3, 28, 15, 30, 45)
+        result = get_datetime_str(dt)
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, '2025-03-28 15:30:45')
+
+    def test_date_input(self):
+        d = date(2025, 3, 28)
+        result = get_datetime_str(d)
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, '2025-03-28 00:00:00')
+
+    def test_string_input(self):
+        dt_str = '2025-03-28 10:20:30'
+        result = get_datetime_str(dt_str)
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, '2025-03-28 10:20:30')
+
+    def test_invalid_string_input(self):
+        invalid_str = 'not-a-valid-date'
+        with self.assertRaises(ValueError):
+            get_datetime_str(invalid_str)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -652,7 +652,7 @@ def get_datetime_str(datetime_obj: DateTimeLikeObject) -> str:
 	"""Return the given datetime like object (datetime.date, datetime.datetime, string) as a string in `yyyy-mm-dd hh:mm:ss` format."""
 	if isinstance(datetime_obj, str):
 		datetime_obj = get_datetime(datetime_obj)
-	return datetime_obj.strftime(DATETIME_FORMAT)
+	return datetime_obj.strftime('%Y-%m-%d %H:%M:%S')
 
 
 def get_date_str(date_obj: DateTimeLikeObject) -> str:


### PR DESCRIPTION
Fix: ensure get_datetime_str returns ISO formatted string without microseconds

**This pull request replaces [#32000](https://github.com/frappe/frappe/pull/32000)**

The original PR was closed automatically by GitHub after a history rewrite (force-push) removed the base commit. As per GitHub restrictions, such pull requests cannot be reopened once their original commit history is lost.


The `get_datetime_str()` function previously returned datetime strings
including microseconds (e.g., "2025-03-27 14:23:12.123456"), which is
inconsistent with the expected ISO format: "YYYY-MM-DD HH:mm:ss".

This inconsistency could lead to issues in parts of the system that rely
on strict formatting — such as integrations, data exports, or internal
comparisons.

### Changes:
- Updated `get_datetime_str()` to use `strftime('%Y-%m-%d %H:%M:%S')`
- Ensured the output format excludes microseconds
- Added a unit test (`test_data.py`) to validate expected behavior

This PR restores consistency with the expected format and improves overall reliability
for systems that consume date strings in this format.

I apologize for the confusion caused during the rebase cleanup.  
This PR is clean, ready for review, and should fully replace #32000.

Closes #31554

---

### Video Demonstration:

[▶ Watch the video here](https://youtu.be/l_QfO0laA1c)

The video shows:
- How the new implementation fixes the format

---

### Commit Message Follows:
[Conventional Commits 1.0.0-beta.3](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
