### PR TITLE
Fix: Website route rules Ordering

### DIFF
--- a/frappe/website/path_resolver.py
+++ b/frappe/website/path_resolver.py
@@ -183,7 +183,7 @@ def get_website_rules():
 	"""Get website route rules from hooks and DocType route"""
 
 	def _get():
-		rules = frappe.get_hooks("website_route_rules")
+		rules = frappe.get_hooks("website_route_rules")[::-1]
 		for d in frappe.get_all("DocType", "name, route", dict(has_web_view=1)):
 			if d.route:
 				rules.append(dict(from_route="/" + d.route.strip("/"), to_route=d.name))


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

The website_route_rules are pulled from each app and prepended to the route list. This logic prevents custom apps from overriding the parent apps. To solve this issue, the website_route_rules should be reversed. 

> Explain the **details** for making this change. What existing problem does the pull request solve?

Website route rules in Frappe cannot be overridden by child apps—Frappe routes always take precedence. I attempted to override the /orders route in a child app, but it consistently defaults to the /orders route defined in ERPNext.

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
