### PR TITLE
fix(email): handle and add In-Reply-To header correctly when replying, Closes #32525

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -49,6 +49,7 @@ def make(
 	send_after=None,
 	print_language=None,
 	now=False,
+	in_reply_to=None,
 	**kwargs,
 ) -> dict[str, str]:
 	"""Make a new communication. Checks for email permissions for specified Document.
@@ -68,6 +69,10 @@ def make(
 	:param send_me_a_copy: Send a copy to the sender (default **False**).
 	:param email_template: Template which is used to compose mail .
 	:param send_after: Send after the given datetime.
+	:param print_language: Language in which the print is to be sent.
+	:param now: Send email immediately (default **False**).
+	:param in_reply_to: Name of the Communication document to which this communication is a reply.
+	:param kwargs: Deprecated or unsupported options.
 	"""
 	if kwargs:
 		from frappe.utils.commands import warn
@@ -106,6 +111,7 @@ def make(
 		send_after=send_after,
 		print_language=print_language,
 		now=now,
+		in_reply_to=in_reply_to,
 	)
 
 
@@ -134,6 +140,7 @@ def _make(
 	send_after=None,
 	print_language=None,
 	now=False,
+	in_reply_to=None,
 ) -> dict[str, str]:
 	"""Internal method to make a new communication that ignores Permission checks."""
 
@@ -162,6 +169,7 @@ def _make(
 			"has_attachment": 1 if attachments else 0,
 			"communication_type": communication_type,
 			"send_after": send_after,
+			"in_reply_to": in_reply_to,
 		}
 	)
 	comm.flags.skip_add_signature = not add_signature

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -282,7 +282,9 @@ class CommunicationEmailMixin:
 		in_reply_to_messageid = None
 		if self.in_reply_to:
 			try:
-				in_reply_to_messageid = frappe.db.get_value(doctype="Communication", filters=self.in_reply_to, fieldname="message_id")
+				in_reply_to_messageid = frappe.db.get_value(
+					doctype="Communication", filters=self.in_reply_to, fieldname="message_id"
+				)
 			except Exception:
 				# Ignore document is not found
 				pass

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -278,6 +278,15 @@ class CommunicationEmailMixin:
 			print_format=print_format, print_html=print_html, print_language=print_language
 		)
 		incoming_email_account = self.get_incoming_email_account()
+
+		in_reply_to_messageid = None
+		if self.in_reply_to:
+			try:
+				in_reply_to_messageid = frappe.db.get_value(doctype="Communication", filters=self.in_reply_to, fieldname="message_id")
+			except Exception:
+				# Ignore document is not found
+				pass
+
 		return {
 			"recipients": recipients,
 			"cc": cc,
@@ -298,6 +307,7 @@ class CommunicationEmailMixin:
 			"is_notification": (self.sent_or_received == "Received" and True) or False,
 			"print_letterhead": print_letterhead,
 			"send_after": self.send_after,
+			"in_reply_to": in_reply_to_messageid,
 		}
 
 	def send_email(

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -313,7 +313,7 @@ class EMail:
 
 	def set_in_reply_to(self, in_reply_to):
 		"""Used to send the Message-Id of a received email back as In-Reply-To"""
-		self.set_header("In-Reply-To", in_reply_to)
+		self.set_header("In-Reply-To", "<" + in_reply_to + ">")
 
 	def make(self):
 		"""build into msg_root"""

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -795,6 +795,7 @@ frappe.views.CommunicationComposer = class {
 				print_letterhead: me.is_print_letterhead_checked(),
 				send_after: form_values.send_after ? form_values.send_after : null,
 				print_language: form_values.print_language,
+				in_reply_to: this.last_email?.name || null,
 			},
 			btn,
 			callback(r) {


### PR DESCRIPTION
- The in-reply-to mechanism was not working when replying to existing communication/email, this PR fixes that
- More info in #32525
- closes #32525
- After this fix, we can see `In-Reply-To` header included in email replies, which is then correctly showing email threads

Please
backport version-15