### PR TITLE
fix(TextEditor): restore image alignment after save

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -89,7 +89,7 @@ Quill.register(MyLink, true);
 
 // image uploader
 const Uploader = Quill.import("modules/uploader");
-Uploader.DEFAULTS.mimetypes.push("image/gif");
+Uploader.DEFAULTS.mimetypes.push("image/gif", "image/webp");
 
 // inline style
 const BackgroundStyle = Quill.import("attributors/style/background");

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -310,7 +310,6 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 	}
 
 	set_formatted_input(value) {
-		console.log(value);
 		if (!this.quill) return;
 		if (value === this.get_input_value()) return;
 		if (!value) {
@@ -320,14 +319,12 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 		}
 
 		// set html without triggering a focus
-		console.log(value);
 		const delta = this.quill.clipboard.convert(
 			{ html: value, text: "" },
 			{
 				image: MyImage,
 			}
 		);
-		console.log(delta);
 		this.quill.setContents(delta);
 	}
 

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -51,7 +51,27 @@ Quill.register(Table, true);
 
 // link without href
 var Link = Quill.import("formats/link");
+var Image = Quill.import("formats/image");
 
+class MyImage extends Image {
+	static create(value) {
+		let node = super.create(value);
+		let attrs = ["style", "align", "src"];
+		attrs.forEach((a) => {
+			if (value[a]) node.setAttribute(a, value[a]);
+		});
+		return node;
+	}
+	static value(node) {
+		return {
+			align: node.align,
+			style: node.style.cssText,
+			src: node.src,
+		};
+	}
+}
+
+Quill.register(MyImage, true);
 class MyLink extends Link {
 	static create(value) {
 		let node = super.create(value);
@@ -290,6 +310,7 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 	}
 
 	set_formatted_input(value) {
+		console.log(value);
 		if (!this.quill) return;
 		if (value === this.get_input_value()) return;
 		if (!value) {
@@ -299,7 +320,14 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 		}
 
 		// set html without triggering a focus
-		const delta = this.quill.clipboard.convert({ html: value, text: "" });
+		console.log(value);
+		const delta = this.quill.clipboard.convert(
+			{ html: value, text: "" },
+			{
+				image: MyImage,
+			}
+		);
+		console.log(delta);
 		this.quill.setContents(delta);
 	}
 


### PR DESCRIPTION
Image alignment in the Text Editor (Quill) was not restored while saving. It is correctly stored in the DB but wasnt shown/added back while showing the saved text

Before

https://github.com/user-attachments/assets/f23f8c89-941a-4130-a306-13d8d6fe3b92

After 


https://github.com/user-attachments/assets/ef82e6bc-5440-4952-bfc3-19524f758a39

Ref Ticket: https://support.frappe.io/helpdesk/tickets/38342

Also adds support for adding webp images 
Ref Ticket: https://support.frappe.io/helpdesk/tickets/37611 
