### PR TITLE
fix: query report read permission issue

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -708,6 +708,13 @@ def has_match(
 
 				# each doctype could have multiple conflicting user permission doctypes, hence using OR
 				# so that even if one of the sets allows a match, it is true
+
+				if match:
+					if not frappe.has_permission(
+						doctype=ref_doctype, ptype="read", throw=False, ignore_share_permissions=True
+					):
+						match = False
+
 				matched_for_doctype = matched_for_doctype or match
 
 				if matched_for_doctype:


### PR DESCRIPTION
If a role doesn't have Read permission for a Doctype, the records still appear in the Query Report. However, when the user tries to open a record, a permission error is thrown.

In this PR, a check has been added to ensure that the role has Read permission before accessing the record.