### PR TITLE
fix(email): Fix and improve linking of incoming email, Closes #32542

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -760,7 +760,18 @@ class InboundMail(Email):
 			return self._reference_document
 
 		reference_document = ""
-		parent = self.parent_email_queue() or self.parent_communication()
+
+		parent_email_queue = self.parent_email_queue()
+		parent_communication = self.parent_communication()
+
+		parent = None
+
+		if parent_email_queue and parent_email_queue.reference_doctype:
+			parent = parent_email_queue
+		elif parent_communication and parent_communication.reference_doctype:
+			parent = parent_communication
+		else:
+			parent = None
 
 		if parent and parent.reference_doctype:
 			reference_doctype, reference_name = parent.reference_doctype, parent.reference_name
@@ -768,6 +779,10 @@ class InboundMail(Email):
 
 		if not reference_document and self.email_account.append_to:
 			reference_document = self.match_record_by_subject_and_sender(self.email_account.append_to)
+
+		# If it was first reply to sent mail (from ERP), then we will take parent communication as reference document.
+		if not reference_document and self.is_reply_to_system_sent_mail():
+			reference_document = parent_communication
 
 		self._reference_document = reference_document or ""
 		return self._reference_document


### PR DESCRIPTION
# Details

- This PR fixes and improves inbound email reference document finding mechanism
- Mainly, it checks if the reply is to system sent mail (from frappe), if yes and `reference_document` could not be found, it will use `parent_communication` as `reference_document`
- Additionaly, it corrects behaviour of finding parent and adding `reference_doctype` of parent as required. This is fixing edge-cases where you could have parent available, but reference doc not in that parent not available

# Additional

Please
backport version-15
Closes #32542