### PR TITLE
fix(communication): add ability for users to change status of communication, fixes #32525

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -124,7 +124,7 @@ class Communication(Document, CommunicationEmailMixin):
 	no_feed_on_delete = True
 	DOCTYPE = "Communication"
 
-	def check_permission(self, permtype="read", permlevel=None):
+	def check_permission(self, permtype=None, permlevel=None):
 		"""
 		Raise `frappe.PermissionError` if not permitted.
 
@@ -134,24 +134,33 @@ class Communication(Document, CommunicationEmailMixin):
 
 		Before performing the permission check, the method loads the document's
 		state before saving and logs any changed fields. If the only changed field
-		is "status", the permission type is set to "read".
+		is "status", the permission type is set to "read" if the user have "read"
+		permission. Otherwise, the original permission type is used.
 
 		Args:
-			permtype (str): The type of permission to check. Defaults to "read".
-			permlevel (int, optional): The level of permission to check. Defaults to None.
+		        permtype (str): The type of permission to check. Defaults to "read".
+		        permlevel (int, optional): The level of permission to check. Defaults to None.
 
 		Returns:
-			bool: True if the user has the required permission, otherwise raises `frappe.PermissionError`.
+		        bool: True if the user has the required permission, otherwise raises `frappe.PermissionError`.
 
 		Raises:
-			frappe.PermissionError: If the user does not have the required permission.
+		        frappe.PermissionError: If the user does not have the required permission.
 		"""
 		"""Raise `frappe.PermissionError` if not permitted"""
+		kwargs = {}
+		if permtype is not None:
+			kwargs["permtype"] = permtype
+		if permlevel is not None:
+			kwargs["permlevel"] = permlevel
+
 		self.get_latest()
 		changed_fields = self.get_changed_fields()
 		if changed_fields and len(list(changed_fields)) == 1 and changed_fields["status"] is not None:
-			permtype="read"
-		return super().check_permission(permtype, permlevel)
+			kwargs["permtype"] = "read"
+			if self.has_permission("read"):
+				kwargs["permtype"] = "read"
+		return super().check_permission(**kwargs)
 
 	def onload(self):
 		"""create email flag queue"""

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -124,6 +124,35 @@ class Communication(Document, CommunicationEmailMixin):
 	no_feed_on_delete = True
 	DOCTYPE = "Communication"
 
+	def check_permission(self, permtype="read", permlevel=None):
+		"""
+		Raise `frappe.PermissionError` if not permitted.
+
+		This method checks if the current user has the specified permission type
+		(`permtype`) at the given permission level (`permlevel`). If the user does
+		not have the required permission, a `frappe.PermissionError` is raised.
+
+		Before performing the permission check, the method loads the document's
+		state before saving and logs any changed fields. If the only changed field
+		is "status", the permission type is set to "read".
+
+		Args:
+			permtype (str): The type of permission to check. Defaults to "read".
+			permlevel (int, optional): The level of permission to check. Defaults to None.
+
+		Returns:
+			bool: True if the user has the required permission, otherwise raises `frappe.PermissionError`.
+
+		Raises:
+			frappe.PermissionError: If the user does not have the required permission.
+		"""
+		"""Raise `frappe.PermissionError` if not permitted"""
+		self.get_latest()
+		changed_fields = self.get_changed_fields()
+		if changed_fields and len(list(changed_fields)) == 1 and changed_fields["status"] is not None:
+			permtype="read"
+		return super().check_permission(permtype, permlevel)
+
 	def onload(self):
 		"""create email flag queue"""
 		if (

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -503,6 +503,15 @@ class Document(BaseDocument):
 	def get_doc_before_save(self) -> "Document":
 		return getattr(self, "_doc_before_save", None)
 
+	def get_changed_fields(self) -> dict:
+		"""Return changed fields"""
+		changed = {}
+		for key in self.get_valid_columns():
+			if self.has_value_changed(key):
+				changed[key] = self.get(key)
+
+		return changed
+
 	def has_value_changed(self, fieldname):
 		"""Return True if value has changed before and after saving."""
 		from datetime import date, datetime, timedelta


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

- It fixes, that now you can close/reopen if you have only read access
- Adding a method `get_changed_fields` to do checking of changed columns in current document. We need it in this bugfix, for checking if only `status` field was changed. I found it useful also for other potential features, so added it to `Document` class directly.
- For more details, look into issue mentioned bellow
- Closes #32525
- Please backport version-15