### PR TITLE
Validate reply-to email for incoming emails in email class

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -432,7 +432,9 @@ class Email:
 		_from_email = self.decode_email(self.mail.get("X-Original-From") or self.mail["From"])
 		_reply_to = self.decode_email(self.mail.get("Reply-To"))
 
-		if _reply_to and not frappe.db.get_value("Email Account", {"email_id": _reply_to}, "email_id"):
+		if _reply_to and not frappe.db.get_value(
+			"Email Account", {"email_id": _reply_to, "enable_incoming": 1}, "email_id"
+		):
 			self.from_email = extract_email_id(_reply_to)
 		else:
 			self.from_email = extract_email_id(_from_email)


### PR DESCRIPTION
Quick improvement/fix: Ensure the reply-to email is valid and enabled for incoming emails when setting the from email in the email class.
Please
backport version-15-hotfix