### PR TITLE
fix(email): Prioritize default incoming email account for replies

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -417,15 +417,20 @@ class EmailAccount(Document):
 		:param match_by_email: Find account using emailID
 		:param match_by_doctype: Find account by matching `Append To` doctype
 		"""
-		doc = cls.find_one_by_filters(enable_incoming=1, email_id=match_by_email)
-		if doc:
-			return doc
-
-		doc = cls.find_one_by_filters(enable_incoming=1, append_to=match_by_doctype)
-		if doc:
-			return doc
-
 		doc = cls.find_default_incoming()
+		if doc:
+			return doc
+
+		if match_by_email:
+			doc = cls.find_one_by_filters(enable_incoming=1, email_id=match_by_email)
+			if doc:
+				return doc
+
+		if match_by_doctype:
+			doc = cls.find_one_by_filters(enable_incoming=1, append_to=match_by_doctype)
+			if doc:
+				return doc
+
 		return doc
 
 	@classmethod


### PR DESCRIPTION
Refactor the `get_incoming_server` method to ensure that when the "Default Incoming" email account is enabled, it takes precedence over other email accounts for setting the Reply-To address. This change addresses the issue where the Reply-To was incorrectly set to the sender's email when both the sender and default incoming email had incoming enabled. Now, the Reply-To will consistently reflect the default incoming email account when it is enabled.

Please
backport version-15
Closes #32563