### PR TITLE
feat: Configurable Timeline Date Format using settings

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -61,6 +61,7 @@
   "form_sidebar",
   "timeline",
   "dashboard",
+  "show_absolute_datetime_foramt",
   "change_password",
   "new_password",
   "logout_all_sessions",
@@ -827,6 +828,12 @@
    "fieldname": "dashboard",
    "fieldtype": "Check",
    "label": "Dashboard"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_absolute_datetime_foramt",
+   "fieldtype": "Check",
+   "label": "Show absolute datetime values"
   }
  ],
  "icon": "fa fa-user",
@@ -885,7 +892,7 @@
   }
  ],
  "make_attachments_public": 1,
- "modified": "2025-03-17 11:29:39.254304",
+ "modified": "2025-05-17 22:04:39.930070",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -126,6 +126,7 @@ class User(Document):
 		search_bar: DF.Check
 		send_me_a_copy: DF.Check
 		send_welcome_email: DF.Check
+		show_absolute_datetime_foramt: DF.Check
 		simultaneous_sessions: DF.Int
 		social_logins: DF.Table[UserSocialLogin]
 		thread_notify: DF.Check

--- a/frappe/public/js/frappe/utils/pretty_date.js
+++ b/frappe/public/js/frappe/utils/pretty_date.js
@@ -77,7 +77,19 @@ function prettyDate(date, mini) {
 
 frappe.provide("frappe.datetime");
 window.comment_when = function (datetime, mini) {
-	var timestamp = frappe.datetime.str_to_user ? frappe.datetime.str_to_user(datetime) : datetime;
+	const date_format_setting = (frappe.boot.sysdefaults.date_format || "dd-mm-yyyy").replace(
+		/dd/g,
+		"DD"
+	);
+	const time_format_setting = frappe.boot.sysdefaults.time_format || "HH:mm:ss";
+	let absolute = frappe.boot.user.show_absolute_datetime_foramt;
+	console.log("absolute : " + absolute);
+	if (absolute === undefined) {
+		return '<span class="frappe-timestamp"></span>';
+	}
+	let formatString = `${date_format_setting} ${time_format_setting}`;
+	const timestamp = moment(datetime).format(formatString);
+	const formatted_datetime = moment(datetime).format(formatString);
 	return (
 		'<span class="frappe-timestamp ' +
 		(mini ? " mini" : "") +
@@ -86,10 +98,11 @@ window.comment_when = function (datetime, mini) {
 		'" title="' +
 		timestamp +
 		'">' +
-		prettyDate(datetime, mini) +
+		(absolute == 1 ? formatted_datetime : prettyDate(datetime, mini)) +
 		"</span>"
 	);
 };
+
 frappe.datetime.comment_when = comment_when;
 frappe.datetime.prettyDate = prettyDate;
 

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -224,6 +224,7 @@ class UserPermissions:
 				"language",
 				"last_name",
 				"mute_sounds",
+				"show_absolute_datetime_foramt",
 				"send_me_a_copy",
 				"user_type",
 				"onboarding_status",


### PR DESCRIPTION
feat: make timeline date format configurable via settings

This feature introduces a system-wide setting that allows administrators to define the date format displayed in timeline views. It supports better customization, enabling formats like DD-MM-YYYY or MM/DD/YYYY to match regional preferences.

The timeline component now dynamically reflects the configured date format across the system, improving consistency and user experience.

Closes: #32498

  
![image](https://github.com/user-attachments/assets/03726765-a7fe-4284-8ba0-d1bd536a1363)

![image](https://github.com/user-attachments/assets/6aebb265-8d40-44b9-b15a-925ccabe1914)

`no-docs`