### PR TITLE
feat: Dynamic and configurable child table search bar

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -33,6 +33,7 @@
   "editable_grid",
   "quick_entry",
   "grid_page_length",
+  "grid_search_field_length",
   "cb01",
   "track_changes",
   "track_seen",
@@ -697,9 +698,18 @@
    "fieldname": "protect_attached_files",
    "fieldtype": "Check",
    "label": "Protect Attached Files"
+  },
+  {
+   "default": "0",
+   "depends_on": "istable",
+   "fieldname": "grid_search_field_length",
+   "fieldtype": "Int",
+   "label": "Grid Search Field Length",
+   "non_negative": 1
   }
  ],
  "grid_page_length": 50,
+ "grid_search_field_length": 50,
  "icon": "fa fa-bolt",
  "idx": 6,
  "index_web_pages_for_search": 1,
@@ -775,7 +785,7 @@
    "link_fieldname": "document_type"
   }
  ],
- "modified": "2025-03-27 18:16:53.286909",
+ "modified": "2025-05-18 06:10:30.044174",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -704,7 +704,7 @@
    "depends_on": "istable",
    "fieldname": "grid_search_field_length",
    "fieldtype": "Int",
-   "label": "Grid Search Field Length",
+   "label": "Rows Threshold for Grid Search",
    "non_negative": 1
   }
  ],

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -33,7 +33,7 @@
   "editable_grid",
   "quick_entry",
   "grid_page_length",
-  "grid_search_field_length",
+  "rows_threshold_for_grid_search",
   "cb01",
   "track_changes",
   "track_seen",
@@ -702,14 +702,13 @@
   {
    "default": "0",
    "depends_on": "istable",
-   "fieldname": "grid_search_field_length",
+   "fieldname": "rows_threshold_for_grid_search",
    "fieldtype": "Int",
    "label": "Rows Threshold for Grid Search",
    "non_negative": 1
   }
  ],
  "grid_page_length": 50,
- "grid_search_field_length": 50,
  "icon": "fa fa-bolt",
  "idx": 6,
  "index_web_pages_for_search": 1,
@@ -785,7 +784,7 @@
    "link_fieldname": "document_type"
   }
  ],
- "modified": "2025-05-18 06:10:30.044174",
+ "modified": "2025-05-21 21:58:59.947374",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -122,6 +122,7 @@ class DocType(Document):
 		fields: DF.Table[DocField]
 		force_re_route_to_default_view: DF.Check
 		grid_page_length: DF.Int
+		grid_search_field_length: DF.Int
 		has_web_view: DF.Check
 		hide_toolbar: DF.Check
 		icon: DF.Data | None

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -122,7 +122,6 @@ class DocType(Document):
 		fields: DF.Table[DocField]
 		force_re_route_to_default_view: DF.Check
 		grid_page_length: DF.Int
-		grid_search_field_length: DF.Int
 		has_web_view: DF.Check
 		hide_toolbar: DF.Check
 		icon: DF.Data | None
@@ -162,6 +161,7 @@ class DocType(Document):
 		restrict_to_domain: DF.Link | None
 		route: DF.Data | None
 		row_format: DF.Literal["Dynamic", "Compressed"]
+		rows_threshold_for_grid_search: DF.Int
 		search_fields: DF.Data | None
 		sender_field: DF.Data | None
 		sender_name_field: DF.Data | None

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -852,9 +852,10 @@ export default class GridRow {
 
 	show_search_row() {
 		// show or remove search columns based on grid rows
-		let show_length = this.grid?.meta?.grid_search_field_length
-			? this.grid.meta.grid_search_field_length > 0
-			: 20;
+		let show_length =
+			this.grid?.meta?.grid_search_field_length > 0
+				? this.grid.meta.grid_search_field_length
+				: 20;
 		this.show_search =
 			this.show_search &&
 			(this.grid?.data?.length >= show_length || this.grid.filter_applied);

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -852,8 +852,12 @@ export default class GridRow {
 
 	show_search_row() {
 		// show or remove search columns based on grid rows
+		let show_length = this.grid?.meta?.grid_search_field_length
+			? this.grid.meta.grid_search_field_length > 0
+			: 20;
 		this.show_search =
-			this.show_search && (this.grid?.data?.length >= 20 || this.grid.filter_applied);
+			this.show_search &&
+			(this.grid?.data?.length >= show_length || this.grid.filter_applied);
 		!this.show_search && this.wrapper.remove();
 		return this.show_search;
 	}

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -853,8 +853,8 @@ export default class GridRow {
 	show_search_row() {
 		// show or remove search columns based on grid rows
 		let show_length =
-			this.grid?.meta?.grid_search_field_length > 0
-				? this.grid.meta.grid_search_field_length
+			this.grid?.meta?.rows_threshold_for_grid_search > 0
+				? this.grid.meta.rows_threshold_for_grid_search
 				: 20;
 		this.show_search =
 			this.show_search &&


### PR DESCRIPTION
feat: make search bar threshold configurable

Allows customization of the minimum row count before the search bar appears in child tables. 
The default remains 20, but it can now be configured to values like 10 or 5 via settings.

Closes #31636

![image](https://github.com/user-attachments/assets/4f98f36a-5075-4277-8798-1db32235b10b)

`no-docs`