### PR TITLE
Fix(email): fix email reply subject formatting to prevent double and missing prefixes

### DIFF
--- a/frappe/core/doctype/communication/communication.js
+++ b/frappe/core/doctype/communication/communication.js
@@ -265,9 +265,10 @@ frappe.ui.form.on("Communication", {
 	reply: function (frm) {
 		var args = frm.events.get_mail_args(frm);
 		$.extend(args, {
-			subject: __("Re: {0}", [frm.doc.subject]),
+			subject: frm.doc.subject,
 			recipients: frm.doc.sender,
 			is_a_reply: true,
+			reply_type: frappe.constants.communication.email_reply_type.REPLY,
 		});
 
 		new frappe.views.CommunicationComposer(args);
@@ -276,10 +277,11 @@ frappe.ui.form.on("Communication", {
 	reply_all: function (frm) {
 		var args = frm.events.get_mail_args(frm);
 		$.extend(args, {
-			subject: __("Res: {0}", [frm.doc.subject]),
+			subject: frm.doc.subject,
 			recipients: frm.doc.sender,
 			cc: frm.doc.cc,
 			is_a_reply: true,
+			reply_type: frappe.constants.communication.email_reply_type.REPLY_ALL,
 		});
 		new frappe.views.CommunicationComposer(args);
 	},
@@ -288,8 +290,9 @@ frappe.ui.form.on("Communication", {
 		var args = frm.events.get_mail_args(frm);
 		$.extend(args, {
 			forward: true,
-			subject: __("Fw: {0}", [frm.doc.subject]),
+			subject: frm.doc.subject,
 			is_a_reply: true,
+			reply_type: frappe.constants.communication.email_reply_type.FORWARD,
 		});
 
 		new frappe.views.CommunicationComposer(args);
@@ -307,7 +310,7 @@ frappe.ui.form.on("Communication", {
 		return {
 			frm: frm,
 			doc: frm.doc,
-			last_email: frm.doc,
+			current_replyto_email: frm.doc,
 			sender: sender_email_id,
 			attachments: frm.doc.attachments,
 		};

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -555,6 +555,11 @@ class FormTimeline extends BaseTimeline {
 			reply_all: reply_all,
 		};
 
+		if (args.is_a_reply)
+			args.reply_type = reply_all
+				? frappe.constants.communication.email_reply_type.REPLY_ALL
+				: frappe.constants.communication.email_reply_type.REPLY;
+
 		const email_accounts = frappe.boot.email_accounts
 			.filter((account) => {
 				return (
@@ -584,9 +589,10 @@ class FormTimeline extends BaseTimeline {
 
 		if (this.frm.doctype === "Communication") {
 			args.message = "";
-			args.last_email = this.frm.doc;
+			args.current_replyto_email = this.frm.doc;
 			args.recipients = this.frm.doc.sender;
-			args.subject = __("Re: {0}", [this.frm.doc.subject]);
+			args.subject = this.frm.doc.subject;
+			args.reply_type = frappe.constants.communication.email_reply_type.reply_type.REPLY;
 		} else {
 			const comment_value = frappe.markdown(this.frm.comment_box.get_value());
 			args.message = strip_html(comment_value) ? comment_value : "";

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -3,6 +3,22 @@
 
 import localforage from "localforage";
 
+frappe.provide("frappe.constants.communication");
+
+// ENUM of available email reply types
+/**
+ * Enum for email reply types.
+ * @readonly
+ * @enum {string}
+ */
+const EMAIL_REPLY_TYPE = {
+	REPLY: "REPLY",
+	REPLY_ALL: "REPLY_ALL",
+	FORWARD: "FORWARD",
+};
+
+frappe.constants.communication.email_reply_type = EMAIL_REPLY_TYPE;
+
 frappe.last_edited_communication = {};
 const separator_element = "<div>---</div>";
 
@@ -18,6 +34,8 @@ frappe.views.CommunicationComposer = class {
 
 	make() {
 		const me = this;
+
+		this.last_email = this.get_last_email() || this.current_replyto_email;
 
 		this.dialog = new frappe.ui.Dialog({
 			title: this.title || this.subject || __("New Email"),
@@ -323,6 +341,12 @@ frappe.views.CommunicationComposer = class {
 		}
 	}
 
+	clean_subject(subject) {
+		if (typeof subject !== "string" || !subject) return subject;
+		const regex = /(^\s*(fw|fwd|wg)[\[\]().\- ]*[^:]*:|\s*(re|aw)[\[\]().\- ]*[^:]*:\s*)*/gi;
+		return subject.replace(regex, "").trim();
+	}
+
 	setup_subject_and_recipients() {
 		this.subject = this.subject || "";
 
@@ -342,17 +366,12 @@ frappe.views.CommunicationComposer = class {
 
 		if (!this.subject && this.frm) {
 			// get subject from last communication
-			const last = this.frm.timeline.get_last_email();
+			const last = this.last_email;
 
 			if (last) {
 				this.subject = last.subject;
 				if (!this.recipients) {
 					this.recipients = last.sender;
-				}
-
-				// prepend "Re:"
-				if (strip(this.subject.toLowerCase().split(":")[0]) != "re") {
-					this.subject = __("Re: {0}", [this.subject]);
 				}
 			}
 
@@ -374,6 +393,21 @@ frappe.views.CommunicationComposer = class {
 			if (!cstr(this.subject).includes(identifier)) {
 				this.subject = `${this.subject} (${identifier})`;
 			}
+		}
+
+		this.subject = this.clean_subject(this.subject);
+
+		// Prepend "Re:" or "Fw:" to the subject
+		switch (this.reply_type) {
+			case frappe.constants.communication.email_reply_type.REPLY:
+			case frappe.constants.communication.email_reply_type.REPLY_ALL:
+				// Use "Re:" universally to keep it simple and clear
+				this.subject = __("Re: {0}", [this.subject]);
+				break;
+			case frappe.constants.communication.email_reply_type.FORWARD:
+				// Use "Fw:" for forwards
+				this.subject = __("Fw: {0}", [this.subject]);
+				break;
 		}
 
 		if (this.frm && !this.recipients) {
@@ -923,10 +957,14 @@ frappe.views.CommunicationComposer = class {
 		return "<br>" + signature;
 	}
 
+	get_last_email() {
+		return this.frm && this.frm.timeline.get_last_email(false);
+	}
+
 	get_earlier_reply() {
 		this.reply_set = false;
 
-		const last_email = this.last_email || (this.frm && this.frm.timeline.get_last_email(true));
+		const last_email = this.last_email;
 
 		if (!last_email) return "";
 		let last_email_content = last_email.original_comment || last_email.content;


### PR DESCRIPTION
Standardize the email reply subject formatting to ensure that when replying to an already replied email, the subject is correctly set to `Re: subject` without additional prefixes like `Re: Re:`. This change also introduces constants for different reply types to improve code clarity and maintainability.

Closes #32571
Please
backport version-15