### PR TITLE
Fix: fix typo in scheduler interval references to respect `scheduler_tick_interval`

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -123,7 +123,7 @@ class ScheduledJobType(Document):
 			"Hourly": "0 * * * *",
 			"Hourly Long": "0 * * * *",
 			"Hourly Maintenance": f"{hourly_site_offset} * * * *",
-			"All": f"*/{(frappe.get_conf().scheduler_interval or 240) // 60} * * * *",
+			"All": f"*/{(frappe.get_conf().scheduler_tick_interval or 240) // 60} * * * *",
 		}
 
 		if not self.cron_format:

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -35,7 +35,7 @@ def cprint(*args, **kwargs):
 
 def start_scheduler() -> NoReturn:
 	"""Run enqueue_events_for_all_sites based on scheduler tick.
-	Specify scheduler_interval in seconds in common_site_config.json"""
+	Specify scheduler_tick_interval in seconds in common_site_config.json"""
 
 	tick = get_scheduler_tick()
 	set_niceness()


### PR DESCRIPTION
This changes correct a typo in the scheduled job type configuration, ensuring that the `scheduler_tick_interval` is used instead of the incorrect `scheduler_interval`. This allows scheduled jobs of type "All" to respect the configured interval, fixing the issue where they were running every 4 minutes regardless of the set interval.

Closes #32573