### PR TITLE
fix: make max report rows configurable

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -96,6 +96,7 @@
   "advanced_tab",
   "prepared_report_section",
   "max_auto_email_report_per_user",
+  "max_report_rows",
   "background_workers",
   "enable_scheduler",
   "dormant_days",
@@ -699,12 +700,18 @@
    "fieldname": "hide_empty_read_only_fields",
    "fieldtype": "Check",
    "label": "Hide Empty Read-Only Fields"
+  },
+  {
+   "default": "100000",
+   "fieldname": "max_report_rows",
+   "fieldtype": "Int",
+   "label": "Max Report Rows"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2025-04-15 14:12:11.443610",
+ "modified": "2025-05-19 12:45:29.975162",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -703,6 +703,7 @@
   },
   {
    "default": "100000",
+   "description": "This value specifies the max number of rows that can be rendered in report view. ",
    "fieldname": "max_report_rows",
    "fieldtype": "Int",
    "label": "Max Report Rows"
@@ -711,7 +712,7 @@
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2025-05-19 12:45:29.975162",
+ "modified": "2025-05-19 14:17:40.748786",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -71,6 +71,7 @@ class SystemSettings(Document):
 		logout_on_password_reset: DF.Check
 		max_auto_email_report_per_user: DF.Int
 		max_file_size: DF.Int
+		max_report_rows: DF.Int
 		minimum_password_score: DF.Literal["1", "2", "3", "4"]
 		number_format: DF.Literal[
 			"#,###.##",

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1023,18 +1023,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.tree_report = this.data.some((d) => "indent" in d);
 	}
 
-	async render_datatable() {
+	render_datatable() {
 		let data = this.data;
 		let columns = this.columns.filter((col) => !col.hidden);
 
-		if (!this.max_report_rows) {
-			this.max_report_rows = await frappe.db.get_single_value(
-				"System Settings",
-				"max_report_rows"
-			);
-		}
-
-		if (data.length > this.max_report_rows) {
+		if (data.length > (cint(frappe.boot.sysdefaults.max_report_rows) || 100000)) {
 			let msg = __(
 				"This report contains {0} rows and is too big to display in browser, you can {1} this report instead.",
 				[cstr(format_number(data.length, null, 0)).bold(), __("export").bold()]

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1023,11 +1023,18 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.tree_report = this.data.some((d) => "indent" in d);
 	}
 
-	render_datatable() {
+	async render_datatable() {
 		let data = this.data;
 		let columns = this.columns.filter((col) => !col.hidden);
 
-		if (data.length > 200000) {
+		if (!this.max_report_rows) {
+			this.max_report_rows = await frappe.db.get_single_value(
+				"System Settings",
+				"max_report_rows"
+			);
+		}
+
+		if (data.length > this.max_report_rows) {
 			let msg = __(
 				"This report contains {0} rows and is too big to display in browser, you can {1} this report instead.",
 				[cstr(format_number(data.length, null, 0)).bold(), __("export").bold()]


### PR DESCRIPTION
This PR makes the max rows to show in report configurable
https://github.com/frappe/frappe/pull/32419#issuecomment-2889792331