### PR TITLE
fix: add lucide icons to hooks.py

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -37,6 +37,7 @@ app_include_css = [
 app_include_icons = [
 	"/assets/frappe/icons/timeless/icons.svg",
 	"/assets/frappe/icons/espresso/icons.svg",
+	"/assets/frappe/icons/lucide.svg",
 ]
 
 doctype_js = {
@@ -49,6 +50,7 @@ web_include_css = []
 web_include_icons = [
 	"/assets/frappe/icons/timeless/icons.svg",
 	"/assets/frappe/icons/espresso/icons.svg",
+	"/assets/frappe/icons/lucide.svg",
 ]
 
 email_css = ["email.bundle.css"]


### PR DESCRIPTION
Added `lucide.svg` to `hooks.py` to enable the use of Lucide Icons.