### PR TITLE
fix(utils): Fix email validation

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -38,8 +38,13 @@ PHONE_NUMBER_PATTERN = re.compile(r"([0-9\ \+\_\-\,\.\*\#\(\)]){1,20}$")
 PERSON_NAME_PATTERN = re.compile(r"^[\w][\w\'\-]*( \w[\w\'\-]*)*$")
 WHITESPACE_PATTERN = re.compile(r"[\t\n\r]")
 MULTI_EMAIL_STRING_PATTERN = re.compile(r'[,\n](?=(?:[^"]|"[^"]*")*$)')
+
+"""
+    RFC-5322 3.4 Compliant Email Pattern
+    https://regex101.com/library/6EL6YF
+"""
 EMAIL_MATCH_PATTERN = re.compile(
-	r"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?",
+	r"((?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\]))",
 	re.IGNORECASE,
 )
 
@@ -193,7 +198,7 @@ def validate_email_address(email_str, throw=False):
 			return email_id
 
 	out = []
-	for e in email_str.split(","):
+	for e in email_str.split(r",(?=(?:(?:[^\"]*\"){2})*[^\"]*$)"): # Split based on commas not within quotes
 		email = _check(e.strip())
 		if email:
 			out.append(email)


### PR DESCRIPTION
1. Use RFC-5322 compliant email address regular expression
2. Split email address list taking into account commas in display name

Examples of email address that will fail validation and splitting:

"John, Doe" \<john@acme.local\>
