### PR TITLE
fix: decrease wait time in clear filter

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -455,7 +455,7 @@ Cypress.Commands.add("clear_filters", () => {
 		url: "api/method/frappe.model.utils.user_settings.save",
 	}).as("filter-saved");
 	cy.get(".filter-section .filter-button").click({ force: true });
-	cy.wait(300);
+	cy.wait(100);
 	cy.get(".filter-popover").should("exist");
 	cy.get(".filter-popover").then((popover) => {
 		if (popover.find("input.input-with-feedback")[0].value != "") {


### PR DESCRIPTION
This PR fixes the clear filters which breaks the awesome_bar.js, list_view.js 
Cypress Cloud [URL](https://cloud.cypress.io/projects/92odwv/runs/49239/test-results/0ccb3cc3-c4bb-4382-9591-09874c00ccbf?actions=%5B%5D&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%5D&statuses=%5B%7B%22value%22%3A%22FAILED%22%2C%22label%22%3A%22FAILED%22%7D%5D&testingTypesEnum=%5B%5D&utm_source=github)