### PR TITLE
Fix email reply handling and formatting

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -929,7 +929,6 @@ frappe.views.CommunicationComposer = class {
 		const last_email = this.last_email || (this.frm && this.frm.timeline.get_last_email(true));
 
 		if (!last_email) return "";
-		console.log("Text", last_email.text_content);
 
 		var last_email_content = "";
 		if (last_email.text_content) last_email_content = last_email.text_content;

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -4,7 +4,7 @@
 import localforage from "localforage";
 
 frappe.last_edited_communication = {};
-const separator_element = "<div>---</div>";
+const separator_element = "<div><br/><br/></div>";
 
 frappe.views.CommunicationComposer = class {
 	constructor(opts) {
@@ -871,7 +871,7 @@ frappe.views.CommunicationComposer = class {
 			message += signature;
 		}
 
-		if (this.is_a_reply && !this.reply_set) {
+		if (this.is_a_reply && !this.content_set && !this.reply_set) {
 			message += this.get_earlier_reply();
 		}
 
@@ -929,11 +929,18 @@ frappe.views.CommunicationComposer = class {
 		const last_email = this.last_email || (this.frm && this.frm.timeline.get_last_email(true));
 
 		if (!last_email) return "";
-		let last_email_content = last_email.original_comment || last_email.content;
+		console.log("Text", last_email.text_content);
 
-		// convert the email context to text as we are enclosing
-		// this inside <blockquote>
-		last_email_content = this.html2text(last_email_content).replace(/\n/g, "<br>");
+		var last_email_content = "";
+		if (last_email.text_content) last_email_content = last_email.text_content;
+		else {
+			// Prefer original_comment if available (unformatted), else fall back to rendered content
+			let html =
+				frappe.utils.escape_html(last_email.original_comment) || last_email.content || "";
+			// Convert HTML to plain text, then back to HTML for safe quoting, if we do not have text_content
+			// Convert HTML to plain text, then replace all line breaks (CR, LF, CRLF) with <br>
+			last_email_content = this.html2text(html).replace(/(\r\n|\r|\n)+/g, "<br>");
+		}
 
 		// clip last email for a maximum of 20k characters
 		// to prevent the email content from getting too large
@@ -948,16 +955,17 @@ frappe.views.CommunicationComposer = class {
 
 		this.reply_set = true;
 
-		return `
-			<div><br></div>
-			${separator_element || ""}
-			<p>
-			${__("On {0}, {1} wrote:", [communication_date, last_email.sender])}
-			</p>
-			<blockquote>
-			${last_email_content}
-			</blockquote>
-		`;
+		return (
+			(separator_element || "") +
+			"<p>" +
+			__("On {0}, {1} wrote:", [communication_date, last_email.sender]) +
+			"</p>" +
+			"<blockquote>" +
+			'<div class="replybody">' +
+			last_email_content +
+			"</div>" +
+			"</blockquote>"
+		);
 	}
 
 	html2text(html) {


### PR DESCRIPTION
Update the email separator to improve visual clarity and enhance the handling of the last email content in replies. Ensure that the last email is appended only once and prioritize using `text_content` when available. This addresses issues with duplicate replies and formatting inconsistencies.

Closes #32605
Please
backport version-15