### PR TITLE
feat: Duplicate Row Button in Child Table for Duplicating Multiple Rows

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -242,8 +242,8 @@ export default class Grid {
 		let selected_children = this.get_selected_children();
 		selected_children.forEach((doc) => {
 			this.add_new_row(null, null, true, doc, true);
-			this.refresh();
 		});
+		this.refresh();
 	}
 
 	delete_rows() {

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -87,6 +87,10 @@ export default class Grid {
 								data-action="delete_rows">
 								${__("Delete")}
 							</button>
+							<button type="button" class="btn btn-xs btn-secondary grid-remove-rows hidden"
+								data-action="duplicate_rows">
+								${__("Duplicate Row")}
+							</button>
 							<button type="button" class="btn btn-xs btn-danger grid-remove-all-rows hidden"
 								data-action="delete_all_rows">
 								${__("Delete All")}
@@ -232,6 +236,14 @@ export default class Grid {
 			row.select(checked);
 			row.row_check?.find(".grid-row-check").prop("checked", checked);
 		}
+	}
+
+	duplicate_rows() {
+		let selected_children = this.get_selected_children();
+		selected_children.forEach((doc) => {
+			this.add_new_row(null, null, true, doc, true);
+			this.refresh();
+		});
 	}
 
 	delete_rows() {

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -243,7 +243,6 @@ export default class Grid {
 		selected_children.forEach((doc) => {
 			this.add_new_row(null, null, true, doc, true);
 		});
-		this.refresh();
 	}
 
 	delete_rows() {

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -241,7 +241,8 @@ export default class Grid {
 	duplicate_rows() {
 		let selected_children = this.get_selected_children();
 		selected_children.forEach((doc) => {
-			this.add_new_row(null, null, true, doc, true);
+			this.add_new_row(null, null, false, doc, false);
+			this.check_range(doc.name, doc.name, false);
 		});
 	}
 


### PR DESCRIPTION
Grid: Duplicate Row Button(Table Field) -> It allows multiple rows to be duplicated
closes : #32548

![image](https://github.com/user-attachments/assets/b3f5881f-d994-4dff-aeda-1b870c14400d)

`no-docs`

