### PR TITLE
feat: add background color to Number Card

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -31,7 +31,9 @@
   "dynamic_filters_section",
   "dynamic_filters_json",
   "section_break_16",
-  "color"
+  "color",
+  "column_break_xtre",
+  "background_color"
  ],
  "fields": [
   {
@@ -207,10 +209,19 @@
    "fieldtype": "Link",
    "label": "Currency",
    "options": "Currency"
+  },
+  {
+   "fieldname": "column_break_xtre",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "background_color",
+   "fieldtype": "Color",
+   "label": "Background Color"
   }
  ],
  "links": [],
- "modified": "2025-01-28 18:22:27.268239",
+ "modified": "2025-05-21 10:49:51.759985",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",
@@ -250,6 +261,7 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "label, document_type",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -23,6 +23,7 @@ class NumberCard(Document):
 		from frappe.types import DF
 
 		aggregate_function_based_on: DF.Literal[None]
+		background_color: DF.Color | None
 		color: DF.Color | None
 		currency: DF.Link | None
 		document_type: DF.Link | None

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -157,6 +157,7 @@ export default class NumberCardWidget extends Widget {
 	async render_card() {
 		this.prepare_actions();
 		this.set_title();
+		this.card_doc?.background_color && this.widget.css("background-color", this.card_doc.background_color);
 		this.set_loading_state();
 
 		if (!this.card_doc.type) {

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -157,7 +157,8 @@ export default class NumberCardWidget extends Widget {
 	async render_card() {
 		this.prepare_actions();
 		this.set_title();
-		this.card_doc?.background_color && this.widget.css("background-color", this.card_doc.background_color);
+		this.card_doc?.background_color &&
+			this.widget.css("background-color", this.card_doc.background_color);
 		this.set_loading_state();
 
 		if (!this.card_doc.type) {


### PR DESCRIPTION
> feature :  Allow to set different background color in number cards.

The key changes include adding a new `background_color` field  in Number card doctype and updating the widget rendering logic (in number_card_widget.js) to apply the background color.


> Screenshots/Recordings

https://github.com/user-attachments/assets/df53be8c-530a-40c6-b8e9-f51942f43650

`no-docs`

