### PR TITLE
feat: add 'show full number' option to number card

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -21,6 +21,7 @@
   "report_function",
   "is_public",
   "currency",
+  "show_full_number",
   "custom_configuration_section",
   "filters_config",
   "stats_section",
@@ -207,10 +208,17 @@
    "fieldtype": "Link",
    "label": "Currency",
    "options": "Currency"
+  },
+  {
+   "default": "0",
+   "description": "Check to show full numeric value (e.g. 1,234,567 instead of 1.2M)",
+   "fieldname": "show_full_number",
+   "fieldtype": "Check",
+   "label": "Show Full Number"
   }
  ],
  "links": [],
- "modified": "2025-01-28 18:22:27.268239",
+ "modified": "2025-05-21 17:33:04.908518",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",
@@ -250,6 +258,7 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "label, document_type",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -211,7 +211,7 @@
   },
   {
    "default": "0",
-   "description": "Check to show full numeric value (e.g. 1,234,567 instead of 1.2M)",
+   "description": "Check to display the full numeric value (e.g., 1,234,567 instead of 1.2M).",
    "fieldname": "show_full_number",
    "fieldtype": "Check",
    "label": "Show Full Number"

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -39,6 +39,7 @@ class NumberCard(Document):
 		report_field: DF.Literal[None]
 		report_function: DF.Literal["Sum", "Average", "Minimum", "Maximum"]
 		report_name: DF.Link | None
+		show_full_number: DF.Check
 		show_percentage_stats: DF.Check
 		stats_time_interval: DF.Literal["Daily", "Weekly", "Monthly", "Yearly"]
 		type: DF.Literal["Document Type", "Report", "Custom"]

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -218,8 +218,17 @@ export default class NumberCardWidget extends Widget {
 
 	set_formatted_number(df, doc) {
 		const default_country = frappe.sys_defaults.country;
-		const shortened_number = frappe.utils.shorten_number(this.number, default_country, 5);
-		let number_parts = shortened_number.split(" ");
+
+		let number_parts;
+
+		// Use full number if the checkbox is enabled
+		if (this.card_doc.show_full_number) {
+			number_parts = [this.number.toString(), ""];
+		} else {
+			const shortened_number = frappe.utils.shorten_number(this.number, default_country, 5);
+			number_parts = shortened_number.split(" ");
+		}
+
 		// done to add multicurrency support in number card
 		if (this.card_doc.currency) {
 			this.formatted_number =


### PR DESCRIPTION
This adds a checkbox **"Show Full Number"** to the **Number Card** doctype.

* By default, number cards show shortened values (e.g. `1.2M`) — no change to existing functionality.
* This extends the feature for users who want to show the full number (e.g. `1,200,000`).
* Useful for dashboards in **finance**, **audit**, or **reporting**, where exact values are needed.

---

## 📸 Screenshots

**Default (unchecked):**

![image](https://github.com/user-attachments/assets/d5feb912-7467-4271-88dd-f513855d31fa)


**With "Show Full Number" checked:**

![image](https://github.com/user-attachments/assets/7cd7a326-0a3c-4248-aae9-b72d44ec80c6)

`no-docs`

