### PR TITLE
feat: Confirmation dialog when workflow action button is clicked

### DIFF
--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -102,25 +102,34 @@ frappe.ui.form.States = class FormStates {
 				if (frappe.user_roles.includes(d.allowed) && has_approval_access(d)) {
 					added = true;
 					me.frm.page.add_action_item(__(d.action), function () {
+						frappe.confirm(
+							__("Are you sure you want to take this action?"),
+							function () {
+								frappe.dom.freeze();
+								me.frm.selected_workflow_action = d.action;
+								me.frm.script_manager
+									.trigger("before_workflow_action")
+									.then(() => {
+										frappe
+											.xcall("frappe.model.workflow.apply_workflow", {
+												doc: me.frm.doc,
+												action: d.action,
+											})
+											.then((doc) => {
+												frappe.model.sync(doc);
+												me.frm.refresh();
+												me.frm.selected_workflow_action = null;
+												me.frm.script_manager.trigger(
+													"after_workflow_action"
+												);
+											})
+											.finally(() => {
+												frappe.dom.unfreeze();
+											});
+									});
+							}
+						);
 						// set the workflow_action for use in form scripts
-						frappe.dom.freeze();
-						me.frm.selected_workflow_action = d.action;
-						me.frm.script_manager.trigger("before_workflow_action").then(() => {
-							frappe
-								.xcall("frappe.model.workflow.apply_workflow", {
-									doc: me.frm.doc,
-									action: d.action,
-								})
-								.then((doc) => {
-									frappe.model.sync(doc);
-									me.frm.refresh();
-									me.frm.selected_workflow_action = null;
-									me.frm.script_manager.trigger("after_workflow_action");
-								})
-								.finally(() => {
-									frappe.dom.unfreeze();
-								});
-						});
 					});
 				}
 			});


### PR DESCRIPTION
Implemented a confirmation dialog that appears when the workflow action button is clicked.
This helps prevent accidental workflow changes by prompting users to confirm their action before proceeding.


Before :

[Screencast from 2025-05-21 23-19-35.webm](https://github.com/user-attachments/assets/11579f70-1f9d-4e73-94b7-244aa2b883eb)

After :

[Screencast from 2025-05-21 23-32-37.webm](https://github.com/user-attachments/assets/d02e5185-7870-4d4e-9d53-630af1e62561)

closes : #9552

no-docs