### PR TITLE
feat: Dropdown Console

### DIFF
--- a/frappe/desk/doctype/system_console/system_console.py
+++ b/frappe/desk/doctype/system_console/system_console.py
@@ -29,7 +29,9 @@ class SystemConsole(Document):
 		try:
 			frappe.local.debug_log = []
 			if self.type == "Python":
-				safe_exec(self.console, script_filename="System Console")
+				safe_exec(
+					self.console, script_filename="System Console", restrict_commit_rollback=not self.commit
+				)
 				self.output = "\n".join(frappe.debug_log)
 			elif self.type == "SQL":
 				self.output = frappe.as_json(read_sql(self.console, as_dict=1))

--- a/frappe/public/js/desk.bundle.js
+++ b/frappe/public/js/desk.bundle.js
@@ -79,6 +79,7 @@ import "./frappe/views/pageview.js";
 import "./frappe/ui/toolbar/awesome_bar.js";
 import "./frappe/ui/notifications/notifications.js";
 import "./frappe/ui/toolbar/search.js";
+import "./frappe/ui/dropdown_console.js";
 import "./frappe/ui/toolbar/tag_utils.js";
 import "./frappe/ui/toolbar/search.html";
 import "./frappe/ui/toolbar/search_utils.js";

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -242,9 +242,7 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 	}
 
 	set_focus() {
-		if (!this.editor) return;
-		this.editor.focus();
-		this.editor.gotoLine(this.editor.session.getLength(), Infinity);
+		this.editor?.focus();
 	}
 
 	load_lib() {

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -241,6 +241,12 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 		return this.editor ? this.editor.session.getValue() : "";
 	}
 
+	set_focus() {
+		if (!this.editor) return;
+		this.editor.focus();
+		this.editor.gotoLine(this.editor.session.getLength(), Infinity);
+	}
+
 	load_lib() {
 		if (this.library_loaded) return this.library_loaded;
 

--- a/frappe/public/js/frappe/ui/dropdown_console.js
+++ b/frappe/public/js/frappe/ui/dropdown_console.js
@@ -36,7 +36,43 @@ export class DropdownConsole {
 			}
 		}
 
+		this.bind_executer();
 		this.load_completion();
+	}
+
+	bind_executer() {
+		let me = this;
+		setTimeout(() => {
+			const field = this.dialog.get_field("console");
+			let editor = field.editor;
+			editor.setKeyboardHandler(null); // sorry emacs/vim users
+			editor.commands.addCommand({
+				name: "execute_code",
+				bindKey: {
+					// Shortcut keys
+					win: "Ctrl-Enter",
+					mac: "Command-Enter",
+				},
+				exec: function (editor) {
+					me.execute_code();
+				},
+			});
+		}, 200); // XXX: figure out a way to chain with readiness of ace?
+	}
+
+	async execute_code() {
+		this.dialog.set_value("output", "");
+		frappe
+			.xcall("frappe.desk.doctype.system_console.system_console.execute_code", {
+				doc: {
+					console: this.dialog.get_value("console"),
+					doctype: "System Console",
+					type: "Python",
+				},
+			})
+			.then(({ output }) => {
+				this.dialog.set_value("output", output);
+			});
 	}
 
 	async load_completion() {

--- a/frappe/public/js/frappe/ui/dropdown_console.js
+++ b/frappe/public/js/frappe/ui/dropdown_console.js
@@ -1,0 +1,30 @@
+export class DropdownConsole {
+	constructor() {
+		this.dialog = new frappe.ui.Dialog({
+			title: __("System Console"),
+			minimizable: true,
+			size: "large",
+			fields: [
+				{
+					description: "To execute press ctrl/cmd+enter.",
+					fieldname: "console",
+					fieldtype: "Code",
+					label: "Console",
+					options: "Python",
+					min_lines: 20,
+					max_lines: 20,
+				},
+				{
+					fieldname: "output",
+					fieldtype: "Code",
+					label: "Output",
+					read_only: 1,
+				},
+			],
+		});
+	}
+
+	show() {
+		this.dialog.show();
+	}
+}

--- a/frappe/public/js/frappe/ui/dropdown_console.js
+++ b/frappe/public/js/frappe/ui/dropdown_console.js
@@ -8,9 +8,12 @@ export class DropdownConsole {
 			size: "large",
 			fields: [
 				{
-					description: `To execute press ctrl/cmd+enter.
+					description: `
+					${frappe.utils.icon("solid-warning", "xs")}
+					WARNING: Executing random untested code here is dangerous, use with extreme caution. <br>
+					Usage: To execute press ctrl/cmd+enter.
 					To minimize this window press Escape.
-					Press shift+t to bring it back.
+					Press shift+t to bring the window back.
 					`,
 					fieldname: "console",
 					fieldtype: "Code",
@@ -115,12 +118,18 @@ export class DropdownConsole {
 					doctype: "System Console",
 					type: "Python",
 				},
+			},
+			"POST",
+			{
+				freeze: true,
+				freeze_message: __("Executing Code"),
 			}
 		);
 		const end = frappe.datetime.now_datetime(true);
 		this.dialog.set_value("output", output);
 		const time_taken = moment(end).diff(start, "milliseconds");
-		output_field.set_description(`Executed in ${time_taken} milliseconds`);
+		output_field.set_description(`Executed in ${time_taken} milliseconds.
+			<a target="_blank" href="/app/console-log?owner=${frappe.session.user}" >View Logs</a>`);
 	}
 
 	async load_completions() {

--- a/frappe/public/js/frappe/ui/dropdown_console.js
+++ b/frappe/public/js/frappe/ui/dropdown_console.js
@@ -42,7 +42,6 @@ export class DropdownConsole {
 	async load_completion() {
 		let me = this;
 		setTimeout(() => {
-			// TODO: add contextual completions here, current docfields?
 			frappe
 				.xcall(
 					"frappe.core.doctype.server_script.server_script.get_autocompletion_items",
@@ -52,7 +51,18 @@ export class DropdownConsole {
 				)
 				.then((items) => {
 					const field = me.dialog.get_field("console");
-					field.df.autocompletions = items;
+					const custom_completions = [];
+					if (cur_frm && !cur_frm.is_new()) {
+						frappe.meta
+							.get_fieldnames(cur_frm.doc.doctype, cur_frm.doc.parent, {
+								fieldtype: ["not in", frappe.model.no_value_type],
+							})
+							.forEach((fieldname) => {
+								custom_completions.push(`doc.${fieldname}`);
+							});
+					}
+
+					field.df.autocompletions = [...items, ...custom_completions];
 				});
 		}, 100);
 	}

--- a/frappe/public/js/frappe/ui/dropdown_console.js
+++ b/frappe/public/js/frappe/ui/dropdown_console.js
@@ -26,5 +26,14 @@ export class DropdownConsole {
 
 	show() {
 		this.dialog.show();
+		if (cur_frm && !cur_frm.is_new()) {
+			let current_code = this.dialog.get_value("console");
+			if (!current_code) {
+				this.dialog.set_value(
+					"console",
+					`doc = frappe.get_doc("${cur_frm.doc.doctype}", "${cur_frm.doc.name}")\n`
+				);
+			}
+		}
 	}
 }

--- a/frappe/public/js/frappe/ui/dropdown_console.js
+++ b/frappe/public/js/frappe/ui/dropdown_console.js
@@ -35,5 +35,25 @@ export class DropdownConsole {
 				);
 			}
 		}
+
+		this.load_completion();
+	}
+
+	async load_completion() {
+		let me = this;
+		setTimeout(() => {
+			// TODO: add contextual completions here, current docfields?
+			frappe
+				.xcall(
+					"frappe.core.doctype.server_script.server_script.get_autocompletion_items",
+					null,
+					"GET",
+					{ cache: true }
+				)
+				.then((items) => {
+					const field = me.dialog.get_field("console");
+					field.df.autocompletions = items;
+				});
+		}, 100);
 	}
 }

--- a/frappe/public/js/frappe/ui/dropdown_console.js
+++ b/frappe/public/js/frappe/ui/dropdown_console.js
@@ -104,6 +104,9 @@ export class DropdownConsole {
 	async execute_code() {
 		await this.sleep(50); // ace often takes time to push changes
 		this.dialog.set_value("output", "");
+		const output_field = this.dialog.get_field("output");
+		output_field.set_description("");
+		const start = frappe.datetime.now_datetime(true);
 		let { output } = await frappe.xcall(
 			"frappe.desk.doctype.system_console.system_console.execute_code",
 			{
@@ -114,7 +117,10 @@ export class DropdownConsole {
 				},
 			}
 		);
+		const end = frappe.datetime.now_datetime(true);
 		this.dialog.set_value("output", output);
+		const time_taken = moment(end).diff(start, "milliseconds");
+		output_field.set_description(`Executed in ${time_taken} milliseconds`);
 	}
 
 	async load_completions() {

--- a/frappe/public/js/frappe/ui/dropdown_console.js
+++ b/frappe/public/js/frappe/ui/dropdown_console.js
@@ -7,7 +7,10 @@ export class DropdownConsole {
 			size: "large",
 			fields: [
 				{
-					description: "To execute press ctrl/cmd+enter.",
+					description: `To execute press ctrl/cmd+enter.
+					To minimize this window press Escape.
+					Press shift+t to bring it back.
+					`,
 					fieldname: "console",
 					fieldtype: "Code",
 					label: "Console",

--- a/frappe/public/js/frappe/ui/dropdown_console.js
+++ b/frappe/public/js/frappe/ui/dropdown_console.js
@@ -3,6 +3,7 @@ export class DropdownConsole {
 		this.dialog = new frappe.ui.Dialog({
 			title: __("System Console"),
 			minimizable: true,
+			no_cancel_flag: true, // ugh
 			size: "large",
 			fields: [
 				{
@@ -21,6 +22,24 @@ export class DropdownConsole {
 					read_only: 1,
 				},
 			],
+		});
+
+		// Make it static and avoid closing on escape.
+		// Not using dialog.static here because then it's not dismissable at all.
+		this.dialog.$wrapper.modal({
+			backdrop: "static",
+			keyboard: false,
+		});
+
+		let me = this;
+		this.dialog.$wrapper.on("keydown", function (e) {
+			if (e.key === "Escape") {
+				e.preventDefault();
+				if (!me.dialog.is_minimized) {
+					me.dialog.toggle_minimize();
+				}
+				return false;
+			}
 		});
 	}
 

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -352,6 +352,9 @@ function close_grid_and_dialog() {
 frappe.ui.keys.add_shortcut({
 	shortcut: "shift+t",
 	action: function (e) {
+		if (!frappe.user.has_role("System Manager")) {
+			return;
+		}
 		if (cur_dialog?.is_minimized) {
 			cur_dialog.toggle_minimize();
 			cur_dialog.focus_on_first_input();

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -1,4 +1,5 @@
 import "./alt_keyboard_shortcuts";
+import { DropdownConsole } from "./dropdown_console";
 
 frappe.provide("frappe.ui.keys.handlers");
 
@@ -347,3 +348,13 @@ function close_grid_and_dialog() {
 		return false;
 	}
 }
+
+frappe.ui.keys.add_shortcut({
+	shortcut: "shift+t",
+	action: function (e) {
+		let dropdown_console = new DropdownConsole();
+		dropdown_console.show();
+		return false;
+	},
+	description: __("Open console"),
+});

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -352,9 +352,13 @@ function close_grid_and_dialog() {
 frappe.ui.keys.add_shortcut({
 	shortcut: "shift+t",
 	action: function (e) {
-		let dropdown_console = new DropdownConsole();
-		dropdown_console.show();
-		return false;
+		if (cur_dialog?.is_minimized) {
+			cur_dialog.toggle_minimize();
+			cur_dialog.focus_on_first_input();
+		} else {
+			let dropdown_console = new DropdownConsole();
+			dropdown_console.show();
+		}
 	},
 	description: __("Open console"),
 });


### PR DESCRIPTION
Ever used `~` to open console in counter-strike or Linux desktops? Now you can do that on Frappe sites too.

Fully keyboard driven:
- `shift+t`: Open console or expand minimized console
- `escape`: minimize console
- `ctrl+enter`: execute code

This brings `Systems Console` everywhere. No need to open a separate tab during development, you can use the dropdown console as scratchpad instead.

Contextual features:
- Automatically `get_doc`s current document in the code. Yes, it uses `cur_frm` liberally! Sue me.
- autocompletion for `doc.fieldname`

Demo:

[dembugging.webm](https://github.com/user-attachments/assets/bec884c8-2a7c-470b-b75f-bed6545abd53)



TODO:
- [x] Security audit (uses same backend APIs as system console)
- [x] Mild refactor? very hacky code. 10% is even vibe coded :smile: 
- [x] Links to console logs
- [x] Stronger warnings
- [x] show execution time

`no-docs` Discovery: power-users only. Usage: Self-documented in UI.