### PR TITLE
fix(db_query): allow filtering `name: None`

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -878,7 +878,7 @@ from {tables}
 				fallback = "''"
 
 			elif f.fieldname == "name":
-				value = f.value
+				value = f.value if f.value is not None else ""
 				fallback = "''"
 
 			elif (

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1201,6 +1201,7 @@ class TestDBQuery(IntegrationTestCase):
 		self.assertIn("''", query)
 		self.assertNotIn("\\'", query)
 		self.assertNotIn("ifnull", query)
+		self.assertFalse(frappe.get_all("DocField", {"name": None}))
 
 	def test_ifnull_fallback_types(self):
 		query = frappe.get_all("DocField", {"fieldname": ("!=", None)}, run=0)


### PR DESCRIPTION
This doesn't make any sense, but ig it might get introduced via indirect
calls, so better to handle this in code explicitly.

closes https://github.com/frappe/frappe/issues/32643
