### PR TITLE
fix: Avoid sending empty filters from list view

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -268,6 +268,7 @@ frappe.ui.FilterGroup = class {
 	get_filters() {
 		return this.filters
 			.filter((f) => f.field)
+			.filter((f) => f.get_selected_value() != null)
 			.map((f) => {
 				return f.get_value();
 			});


### PR DESCRIPTION
1. Go to list view
2. Open filters
3. Click somewhere on filter popover, that triggers list view refresh.
4. params will contain empty filter.

This is never intended behaviour AFAIK.

Root cause behind https://github.com/frappe/frappe/issues/32645 and https://github.com/frappe/frappe/issues/32643 
