### PR TITLE
fix: find message id from in_reply_to field in communication

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -731,7 +731,8 @@ class QueueBuilder:
 		if self.read_receipt:
 			mail.msg_root["Disposition-Notification-To"] = self.sender
 		if self.in_reply_to:
-			mail.set_in_reply_to(self.in_reply_to)
+			if message_id := frappe.db.get_value("Communication", self.in_reply_to, "message_id"):
+				mail.set_in_reply_to(get_string_between("<", message_id, ">"))
 		return mail
 
 	def process(self, send_now=False) -> EmailQueue | None:


### PR DESCRIPTION
**Issue:**

When using the `in_reply_to` parameter in `frappe.sendmail`, an Email Queue is created that attempts to set the `In-Reply-To` header in the outgoing email.

However, the `in_reply_to` parameter refers to a Communication document (Link field), not directly to a message ID. As a result, the correct email header is not set, which breaks the threading of email conversations.

**Solution:**

Retrieve the `message_id` from the Communication document specified by the `in_reply_to` parameter, and set this value in the `In-Reply-To` header of the outgoing email to ensure proper email threading.
