### PR TITLE
refactor: redo maintenance cron logic

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -3,7 +3,7 @@
 
 import hashlib
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import click
 from croniter import CroniterBadCronError, croniter
@@ -105,8 +105,7 @@ class ScheduledJobType(Document):
 		# Maintenance jobs run at random time, the time is specific to the site though.
 		# This is done to avoid scheduling all maintenance task on all sites at the same time in
 		# multitenant deployments.
-		hourly_site_offset = int(hashlib.sha1(frappe.local.site.encode()).hexdigest(), 16) % 60
-		daily_site_offset = (hourly_site_offset + 30) % 60
+		maintenance_offset = int(hashlib.sha1(frappe.local.site.encode()).hexdigest(), 16) % 60
 
 		CRON_MAP = {
 			"Yearly": "0 0 1 1 *",
@@ -117,10 +116,10 @@ class ScheduledJobType(Document):
 			"Weekly Long": "0 0 * * 0",
 			"Daily": "0 0 * * *",
 			"Daily Long": "0 0 * * *",
-			"Daily Maintenance": f"{daily_site_offset} 0 * * *",
+			"Daily Maintenance": "0 0 * * *",
 			"Hourly": "0 * * * *",
 			"Hourly Long": "0 * * * *",
-			"Hourly Maintenance": f"{hourly_site_offset} * * * *",
+			"Hourly Maintenance": "0 * * * *",
 			"All": f"*/{(frappe.get_conf().scheduler_interval or 240) // 60} * * * *",
 		}
 
@@ -133,6 +132,9 @@ class ScheduledJobType(Document):
 		# A dynamic fallback like current time might miss the scheduler interval and job will never start.
 		last_execution = get_datetime(self.last_execution or self.creation)
 
+		next_execution = croniter(self.cron_format, last_execution).get_next(datetime)
+		if self.frequency in ("Hourly Maintenance", "Daily Maintenance"):
+			next_execution += timedelta(minutes=maintenance_offset)
 		return croniter(self.cron_format, last_execution).get_next(datetime)
 
 	def execute(self):

--- a/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
@@ -117,7 +117,7 @@ class TestScheduledJobType(IntegrationTestCase):
 		sjt = frappe.new_doc(
 			"Scheduled Job Type",
 			frequency="Hourly Maintenance",
-			last_execution=get_datetime("2019-01-01 00:00:00"),
+			last_execution=get_datetime("2019-01-01 23:59:00"),
 		)
 		# Should be within one hour
 		self.assertGreaterEqual(sjt.next_execution, sjt.last_execution)


### PR DESCRIPTION
The effect is same as before, except this allows migrating jobs between
old vs new queues without causing double executions on day of
migrations.
