### PR TITLE
Added the triggers for attachment add & attachment remove

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -219,6 +219,12 @@ frappe.ui.form.Attachments = class Attachments {
 				me.remove_fileid(fileid);
 				me.frm.sidebar.reload_docinfo();
 				if (callback) callback();
+
+				// Trigger a custom event for attachment removed
+				$(document).trigger("frappe.attachment_removed", {
+					frm: me.frm,
+					fileid: fileid
+				});
 			},
 		});
 	}
@@ -261,6 +267,12 @@ frappe.ui.form.Attachments = class Attachments {
 		if (this.fieldname) {
 			this.frm.set_value(this.fieldname, attachment.file_url);
 		}
+
+		// Trigger a custom event for attachment added
+		$(document).trigger("frappe.attachment_added", {
+			frm: this.frm,
+			attachment: attachment
+		});
 	}
 	update_attachment(attachment) {
 		if (attachment.name) {

--- a/hooks.md
+++ b/hooks.md
@@ -34,3 +34,17 @@
 
 1. `permission_query_conditions:[doctype]` - method to return additional query conditions at time of report / list etc.
 1. `has_permission:[doctype]` - method to call permissions to check at individual level
+
+#### Javascript Events (Client-side Hooks)
+
+- `frappe.attachment_added` — Triggered when an attachment is added via the form sidebar.
+- `frappe.attachment_removed` — Triggered when an attachment is removed via the form sidebar.
+
+Example usage:
+```js
+$(document).on("frappe.attachment_added", function(e, data) {
+    // data.attachment, data.frm
+});
+$(document).on("frappe.attachment_removed", function(e, data) {
+    // data.fileid, data.frm
+});


### PR DESCRIPTION
### feat(attachments): add client-side hooks for tracking attachment add/remove events

This PR introduces custom JavaScript events that are triggered when attachments are added or removed via the form sidebar. This feature allows developers to easily track and respond to attachment changes in client-side scripts.

---

### 📌 Background

Related to: [#32659](https://github.com/frappe/frappe/issues/32659)  
There was a request for built-in client-side hooks to track file attachment actions (adding/removing). This PR provides that functionality through jQuery event triggers.

---

### ✨ What's New

Two custom events are now triggered on the document object:

#### 1. `frappe.attachment_added`

- Triggered when an attachment is added to a form.
- **Payload**:  
  ```js
  {
    frm: [frappe.form],
    attachment: [File Doc]
  }

#### 2. `frappe.attachment_removed`

- Triggered when an attachment is removed from a form.
- **Payload**:

```js
{
  frm: [frappe.form],
  fileid: [string]
}
```

### 🧪 Example Usage

```js
$(document).on("frappe.attachment_added", function (e, data) {
    console.log("Attachment added:", data.attachment);
});

$(document).on("frappe.attachment_removed", function (e, data) {
    console.log("Attachment removed:", data.fileid);
});
```

 --- 

### ✅ Checklist

* [x] Code follows the Frappe coding standards
* [x] Hooks are properly documented with usage examples
* [x] Tested locally with forms supporting file attachments
* [x] Does not introduce breaking changes
* [x] Relevant PR comment includes `closes #32659`

---

### 🔗 Related Links

* Issue: [#32659](https://github.com/frappe/frappe/issues/32659)
* [Frappe PR Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist)

