### PR TITLE
perf: faster imports

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1461,6 +1461,10 @@ class Document(BaseDocument, DocRef):
 			doc_to_compare = frappe.get_doc(self.doctype, amended_from)
 
 		version = frappe.new_doc("Version")
+
+		if not doc_to_compare and not self.flags.updater_reference:
+			return
+
 		if version.update_version_info(doc_to_compare, self):
 			version.insert(ignore_permissions=True)
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1350,7 +1350,12 @@ class Document(BaseDocument, DocRef):
 
 	def notify_update(self):
 		"""Publish realtime that the current document is modified"""
-		if frappe.flags.in_patch:
+		if (
+			frappe.flags.in_import
+			or frappe.flags.in_patch
+			or frappe.flags.in_migrate
+			or frappe.flags.in_install
+		):
 			return
 
 		frappe.publish_realtime(

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1320,7 +1320,8 @@ class Document(BaseDocument, DocRef):
 		elif self._action == "update_after_submit":
 			self.run_method("on_update_after_submit")
 
-		self.clear_cache()
+		if not (frappe.flags.in_import and self.is_new()):
+			self.clear_cache()
 
 		if self.flags.get("notify_update", True):
 			self.notify_update()

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1469,11 +1469,6 @@ class Document(BaseDocument, DocRef):
 		if version.update_version_info(doc_to_compare, self):
 			version.insert(ignore_permissions=True)
 
-			if not frappe.flags.in_migrate:
-				# follow since you made a change?
-				if frappe.get_cached_value("User", frappe.session.user, "follow_created_documents"):
-					follow_document(self.doctype, self.name, frappe.session.user)
-
 	@staticmethod
 	def hook(f):
 		"""Decorator: Make method `hookable` (i.e. extensible by another app).


### PR DESCRIPTION
Discovered few slowdowns while bulk importing items for testing

- perf: Skip realtime notifications while importing
- perf: Skip version checking on new docs
- perf: avoid clearing cache for newly imported documents
- fix: duplicate follow

