### PR TITLE
fix: allow user to set custom thresold for their scrip report

### DIFF
--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -19,6 +19,7 @@
   "prepared_report",
   "add_translate_data",
   "timeout",
+  "threshold",
   "filters_section",
   "filters",
   "columns_section",
@@ -191,18 +192,13 @@
    "fieldname": "timeout",
    "fieldtype": "Int",
    "label": "Timeout (In Seconds)"
-  },
-  {
-   "default": "0",
-   "fieldname": "add_translate_data",
-   "fieldtype": "Check",
-   "label": "Add Translate Data"
   }
  ],
+ "grid_page_length": 50,
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-12 17:08:09.629411",
+ "modified": "2025-05-26 09:41:50.013765",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Report",

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -47,8 +47,8 @@ class Report(Document):
 		report_script: DF.Code | None
 		report_type: DF.Literal["Report Builder", "Query Report", "Script Report", "Custom Report"]
 		roles: DF.Table[HasRole]
+		threshold: DF.Int
 		timeout: DF.Int
-
 	# end: auto-generated types
 	def validate(self):
 		"""only administrator can save standard report"""
@@ -155,7 +155,7 @@ class Report(Document):
 
 	def execute_script_report(self, filters):
 		# save the timestamp to automatically set to prepared
-		threshold = 15
+		threshold = self.threshold if self.threshold else 15
 		res = []
 
 		start_time = datetime.datetime.now()


### PR DESCRIPTION
Ref:
https://github.com/frappe/frappe/issues/31362
https://github.com/frappe/frappe/issues/31482
https://github.com/frappe/frappe/pull/29874
https://github.com/frappe/frappe/pull/21485


Allow user to configure their custom threshold before setting `Script Report` as Prepared Report

![image](https://github.com/user-attachments/assets/c0e39710-ead7-4a4d-a5f4-04f743be312b)
