### PR TITLE
fix: exclude if owner from accessing all report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -14,7 +14,7 @@ from frappe.desk.reportview import clean_params, parse_json
 from frappe.model.utils import render_include
 from frappe.modules import get_module_path, scrub
 from frappe.monitor import add_data_to_monitor
-from frappe.permissions import get_role_permissions, has_permission
+from frappe.permissions import get_role_permissions, get_valid_perms, has_permission
 from frappe.utils import cint, cstr, flt, format_duration, get_html_format, sbool
 
 
@@ -710,10 +710,8 @@ def has_match(
 				# so that even if one of the sets allows a match, it is true
 
 				if match:
-					if not frappe.has_permission(
-						doctype=ref_doctype, ptype="read", throw=False, ignore_share_permissions=True
-					):
-						match = False
+					valid_perms = get_valid_perms(doctype=ref_doctype)
+					match = any(perm.get("read") and not perm.get("if_owner") for perm in valid_perms)
 
 				matched_for_doctype = matched_for_doctype or match
 


### PR DESCRIPTION
Continuation of https://github.com/frappe/frappe/pull/32539
Fixed the issue where users with the 'Only If Creator' role had full report access.