### PR TITLE
fix: remove between filter for time field

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -42,6 +42,7 @@ frappe.ui.Filter = class {
 			Date: ["like", "not like"],
 			Datetime: ["like", "not like", "in", "not in", "=", "!="],
 			Data: ["Between", "Timespan"],
+			Time: ["Between", "Timespan"],
 			Select: ["like", "not like", "Between", "Timespan"],
 			Link: ["Between", "Timespan", ">", "<", ">=", "<="],
 			Currency: ["Between", "Timespan"],


### PR DESCRIPTION
Support ticket: https://support.frappe.io/helpdesk/tickets/39492

Currently, the time field does not support the 'between' filter in the UI, so it has been removed for now.