### PR TITLE
fix: adjust left margin to prevent label overlap

### DIFF
--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -431,6 +431,7 @@ input.list-header-checkbox {
 			background-color: var(--control-bg);
 			min-width: 21px;
 			border-radius: 22px;
+			margin-left: 6px;
 		}
 	}
 


### PR DESCRIPTION
**Before :**
![Screenshot from 2025-05-28 01-02-25](https://github.com/user-attachments/assets/5131bd3c-4d1e-4a1b-8bba-61c31412c14b)

**After :**

![image](https://github.com/user-attachments/assets/15e8fae2-7551-4ea7-b5c0-7f19c6681f0f)

no-docs

closes : #31441