### PR TITLE
fix: Hide descendants for specific document types

### DIFF
--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -216,7 +216,7 @@ class TestUserPermission(IntegrationTestCase):
 		if not frappe.db.exists("Doctype", "Person"):
 			doc = new_doctype(
 				"Person",
-				fields=[{"label": "Person Name", "fieldname": "person_name", "field_type": "Data"}],
+				fields=[{"label": "Person Name", "fieldname": "person_name", "fieldtype": "Data"}],
 				unique=0,
 			)
 			doc.is_tree = 1
@@ -233,8 +233,8 @@ class TestUserPermission(IntegrationTestCase):
 			secret_doc = new_doctype(
 				"Secret",
 				fields=[
-					{"label": "Person", "fieldname": "person", "field_type": "Link"},
-					{"label": "Person Secret", "fieldname": "person_secret", "field_type": "Data"},
+					{"label": "Person", "fieldname": "person", "fieldtype": "Link", "options": "Person"},
+					{"label": "Person Secret", "fieldname": "person_secret", "fieldtype": "Data"},
 				],
 			)
 			secret_doc.insert()
@@ -243,9 +243,16 @@ class TestUserPermission(IntegrationTestCase):
 			{"doctype": "Secret", "person": child_record.name, "person_secret": "Top Secret"}
 		).insert()
 
-		add_user_permissions(
-			get_params(user, "Person", parent_record.name, applicable=["Secret"], hide_descendants=1)
-		)
+		frappe.get_doc(
+			{
+				"doctype": "User Permission",
+				"user": user.name,
+				"allow": "Person",
+				"for_value": parent_record.name,
+				"applicable_for": "Secret",
+				"hide_descendants": 1,
+			}
+		).insert()
 
 		# passes as it should
 		self.assertTrue(has_user_permission(frappe.get_doc("Person", child_record.name), user.name))

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -209,6 +209,49 @@ class TestUserPermission(IntegrationTestCase):
 		self.assertEqual(visible_names_after_hide_descendants, ["Parent"])
 		frappe.set_user("Administrator")
 
+	def test_user_perm_for_nested_document_specifically_for_applicable_doctype(self):
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		user = create_user("parent_user@example.com")
+		if not frappe.db.exists("Doctype", "Person"):
+			doc = new_doctype(
+				"Person",
+				fields=[{"label": "Person Name", "fieldname": "person_name", "field_type": "Data"}],
+				unique=0,
+			)
+			doc.is_tree = 1
+			doc.insert()
+
+		parent_record = frappe.get_doc({"doctype": "Person", "person_name": "Parent", "is_group": 1}).insert()
+		child_record = frappe.get_doc(
+			{"doctype": "Person", "person_name": "Child", "is_group": 0, "parent_person": parent_record.name}
+		).insert()
+
+		add_user_permissions(get_params(user, "Person", parent_record.name))
+
+		if not frappe.db.exists("Doctype", "Secret"):
+			secret_doc = new_doctype(
+				"Secret",
+				fields=[
+					{"label": "Person", "fieldname": "person", "field_type": "Link"},
+					{"label": "Person Secret", "fieldname": "person_secret", "field_type": "Data"},
+				],
+			)
+			secret_doc.insert()
+
+		child_secret = frappe.get_doc(
+			{"doctype": "Secret", "person": child_record.name, "person_secret": "Top Secret"}
+		).insert()
+
+		add_user_permissions(
+			get_params(user, "Person", parent_record.name, applicable=["Secret"], hide_descendants=1)
+		)
+
+		# passes as it should
+		self.assertTrue(has_user_permission(frappe.get_doc("Person", child_record.name), user.name))
+		# doesn't: is this not how permissions supposed to work?
+		self.assertFalse(has_user_permission(frappe.get_doc("Secret", child_secret.name), user.name))
+
 	def test_user_perm_on_new_doc_with_field_default(self):
 		"""Test User Perm impact on frappe.new_doc. with *field* default value"""
 		frappe.set_user("Administrator")

--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import json
+from collections import defaultdict
 
 import frappe
 from frappe import _
@@ -103,34 +104,78 @@ def get_user_permissions(user=None):
 	if cached_user_permissions is not None:
 		return cached_user_permissions
 
-	out = {}
+	out = defaultdict(list)
 
 	def add_doc_to_perm(perm, doc_name, is_default):
 		# group rules for each type
 		# for example if allow is "Customer", then build all allowed customers
 		# in a list
-		if not out.get(perm.allow):
-			out[perm.allow] = []
-
 		out[perm.allow].append(
 			frappe._dict(
 				{"doc": doc_name, "applicable_for": perm.get("applicable_for"), "is_default": is_default}
 			)
 		)
 
-	try:
-		for perm in frappe.get_all(
+	def get_permissions_grouped_by_allowed(user):
+		grouped = defaultdict(list)
+		for user_perm in frappe.get_all(
 			"User Permission",
 			fields=["allow", "for_value", "applicable_for", "is_default", "hide_descendants"],
 			filters=dict(user=user),
 		):
-			meta = frappe.get_meta(perm.allow)
-			add_doc_to_perm(perm, perm.for_value, perm.is_default)
+			grouped[(user_perm.allow, user_perm.for_value)].append(user_perm)
 
-			if meta.is_nested_set() and not perm.hide_descendants:
-				decendants = frappe.db.get_descendants(perm.allow, perm.for_value)
-				for doc in decendants:
-					add_doc_to_perm(perm, doc, False)
+		return grouped
+
+	try:
+		grouped_by_allowed = get_permissions_grouped_by_allowed(user)
+
+		for (doctype, for_value), perms in grouped_by_allowed.items():
+			meta = frappe.get_meta(doctype)
+			# flat doctype, add perms as is
+			if not meta.is_nested_set():
+				for perm in perms:
+					add_doc_to_perm(perm, perm.for_value, perm.is_default)
+				continue
+
+			if meta.is_nested_set():
+				doctypes_to_hide = [p.applicable_for for p in perms if p.hide_descendants == 1]
+
+				# netsed doctype but hide descendent is checked for all document types: doctypes_to_hide = [None]
+				if len(doctypes_to_hide) == 1 and not doctypes_to_hide[0]:
+					for perm in perms:
+						add_doc_to_perm(perm, perm.for_value, perm.is_default)
+				# nested doctype but hide descendants is not checked for any document type
+				elif len(doctypes_to_hide) == 0:
+					for perm in perms:
+						# so add perms for for_value and all it's descendants
+						add_doc_to_perm(perm, perm.for_value, perm.is_default)
+						descendants = frappe.db.get_descendants(doctype, for_value)
+						for descendant in descendants:
+							add_doc_to_perm(perm, descendant, perm.is_default)
+				# nested doctype but hide descendants is checked for one more document types
+				else:
+					linked_doctypes = get_linked_doctypes(doctype)
+
+					# add perms for for_value for all linked doctypes
+					for linked_doctype in linked_doctypes.keys():
+						modified_perm = frappe._dict(
+							allow=doctype, for_value=for_value, applicable_for=linked_doctype, is_default=0
+						)
+
+						add_doc_to_perm(modified_perm, modified_perm.for_value, modified_perm.is_default)
+
+					# add perms for for_value's descedants for all except doctypes to hide
+					for linked_doctype in set(linked_doctypes.keys()) - set(doctypes_to_hide):
+						decendants = frappe.db.get_descendants(doctype, for_value)
+						for descendant in decendants:
+							modified_perm = frappe._dict(
+								allow=doctype,
+								for_value=descendant,
+								applicable_for=linked_doctype,
+								is_default=0,
+							)
+							add_doc_to_perm(modified_perm, modified_perm.for_value, modified_perm.is_default)
 
 		out = frappe._dict(out)
 		frappe.cache.hset("user_permissions", user, out)


### PR DESCRIPTION
Description of #12209 mentions this exact use case but the test fails

### Case
- Reportee Employee gets access to all their documents plus all the documents of their reporters
- Reportee Employee should not have access to any specific secret doctype documents of their reporters

### Problem
https://github.com/frappe/frappe/blob/fd4bb5a426fd3ee6420d08a7a18a258b0dfa0f53/frappe/core/doctype/user_permission/user_permission.py#L128-L133
This adds a permission object `{"doc_name" : "Reportee Employee", "applicable_for": None, "hide_descendants" : 0}` which allows access to all document types even if other user permissions have hide_descendants checked

### The way it's solved now
The bulk update can be used to create majority of user permissions and then hide for individual doctypes
If the same bulk update option is used to create permission for subsequent documents if the user, allow and for_value are same then it updates the existing instead of adding the new one 

https://github.com/user-attachments/assets/7da4cc12-ddf8-4f24-b808-4bbae81373ec
 

### Possible Fix
So instead if any document type has hide_descendants == 1 for a specific document, instead of adding permissions from user permissions documents, a permission list is built using linked doctypes such that the final list contains all the permitted documents and excludes non-permitted ones

The flow looks complicated but it's really an extension of how the descendants permissions were added
Can restructure some bits for readability, but wanted to know if the approach is okay