### PR TITLE
perf: cache fetch from value too

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -887,16 +887,16 @@ class BaseDocument:
 						# cache a single value type
 						values = _dict(name=frappe.db.get_value(doctype, docname, "name", cache=True))
 					else:
-						values_to_fetch = ["name"] + [
-							_df.fetch_from.split(".")[-1] for _df in fields_to_fetch
-						]
+						values_to_fetch = (
+							"name",
+							*(_df.fetch_from.split(".")[-1] for _df in fields_to_fetch),
+						)
 
 						# fallback to dict with field_to_fetch=None if link field value is not found
 						# (for compatibility, `values` must have same data type)
 						empty_values = _dict({value: None for value in values_to_fetch})
-						# don't cache if fetching other values too
 						values = (
-							frappe.db.get_value(doctype, docname, values_to_fetch, as_dict=True)
+							frappe.db.get_value(doctype, docname, values_to_fetch, as_dict=True, cache=True)
 							or empty_values
 						)
 


### PR DESCRIPTION
Consider any "items" table in ERPNext, same item and warehouses are used
10s of times in a single document, every one of them triggers fetch from
query, even though it can't possibly change during the DB transaction.

This change now caches the fetched value too.
