### PR TITLE
fix: allow `Float` fields to be empty

### DIFF
--- a/frappe/public/js/frappe/form/controls/currency.js
+++ b/frappe/public/js/frappe/form/controls/currency.js
@@ -1,9 +1,4 @@
 frappe.ui.form.ControlCurrency = class ControlCurrency extends frappe.ui.form.ControlFloat {
-	format_for_input(value) {
-		var formatted_value = format_number(value, this.get_number_format(), this.get_precision());
-		return isNaN(Number(value)) ? "" : formatted_value;
-	}
-
 	get_precision() {
 		// always round based on field precision or currency's precision
 		// this method is also called in this.parse()

--- a/frappe/public/js/frappe/form/controls/float.js
+++ b/frappe/public/js/frappe/form/controls/float.js
@@ -5,16 +5,17 @@ frappe.ui.form.ControlFloat = class ControlFloat extends frappe.ui.form.ControlI
 	}
 
 	format_for_input(value) {
-		var number_format;
-		if (this.df.fieldtype === "Float" && this.df.options && this.df.options.trim()) {
-			number_format = this.get_number_format();
+		if (value === null || value === undefined || isNaN(Number(value))) {
+			return "";
 		}
-		var formatted_value = format_number(value, number_format, this.get_precision());
-		return isNaN(Number(value)) ? "" : formatted_value;
+
+		return format_number(value, this.get_number_format(), this.get_precision());
 	}
 
 	get_number_format() {
-		var currency = frappe.meta.get_field_currency(this.df, this.get_doc());
+		if (this.df.fieldtype === "Float" && !this.df.options?.trim()) return;
+
+		const currency = frappe.meta.get_field_currency(this.df, this.get_doc());
 		return get_number_format(currency);
 	}
 


### PR DESCRIPTION
The changes in #13011 prevent a Float field from ever being unset, because `Number(null)` evaluates to `0` while `parseFloat(null)` evaluates to `NaN`

This PR adds special condition to set `''` (empty string) for `null` values as well. Also, `ControlCurrency` now inherits `ControlFloat`'s  `format_for_input`.

---

### Before

![before float not empty](https://github.com/user-attachments/assets/ec94fa41-e009-485f-a4ad-d2a306ab7d56)


### After

![after float empty](https://github.com/user-attachments/assets/807b586b-0da4-49fe-b293-0553574d7a89)

