### PR TITLE
fix: prevent mimetype guessing for dynamic routes with email addresses

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -565,23 +565,32 @@ def build_response(path, data, http_status_code, headers: dict | None = None):
 
 
 def set_content_type(response, data, path):
-	if isinstance(data, dict):
-		response.mimetype = "application/json"
-		data = json.dumps(data)
-		return data
+    if isinstance(data, dict):
+        response.mimetype = "application/json"
+        data = json.dumps(data)
 
-	response.mimetype = "text/html"
+        return data
+    response.mimetype = "text/html"
 
-	# ignore paths ending with .com to avoid unnecessary download
-	# https://bugs.python.org/issue22347
-	if "." in path and not path.endswith(".com"):
-		content_type, encoding = mimetypes.guess_type(path)
-		if content_type:
-			response.mimetype = content_type
-			if encoding:
-				response.charset = encoding
+    # Only apply mimetype guessing to static file paths, not dynamic routes
+    # Dynamic routes might contain email addresses with file extensions
+    if (
+        "." in path
+        and not path.endswith(".com")
+        and (
+            path.startswith("/assets/")
+            or path.startswith("/files/")
+            or "/" not in path
+            or path.count("/") == 1
+        )
+    ):  # Simple static files
+        content_type, encoding = mimetypes.guess_type(path)
+        if content_type:
+            response.mimetype = content_type
+            if encoding:
+                response.charset = encoding
 
-	return data
+    return data
 
 
 def add_preload_for_bundled_assets(response):


### PR DESCRIPTION
## Branch Selection
**Target Branch:** `develop`

## Problem Details

Dynamic website routes containing email addresses with file extensions are incorrectly served with wrong Content-Type headers, causing critical user-facing pages to appear blank or completely broken.

**Specific affected routes:**
- `/update-profile/user@domain.es` → served as `text/javascript` instead of `text/html`
- `/profile/admin@site.js` → served as `application/javascript` instead of `text/html`  
- `/contact/support@company.css` → served as `text/css` instead of `text/html`
- Any dynamic route containing email addresses with common file extensions

**User Impact:**
- Portal pages appear with broken html. Sample:

![image](https://github.com/user-attachments/assets/8690866b-4e2b-4813-83fa-b8b4de494779)

- User profile management becomes unusable
- Contact forms and email-based routes fail to render
- Affects any Frappe/ERPNext deployment where users have emails ending in `.es`, `.js`, `.css`, `.py`, etc.
- Critical user workflows break silently with no error messages

## Root Cause Analysis

In `frappe/website/utils.py`, the `set_content_type()` function applies Python's `mimetypes.guess_type()` to all URL paths containing dots, without distinguishing between static files and dynamic routes:

```python
# Problematic code:
if "." in path and not path.endswith(".com"):
    content_type, encoding = mimetypes.guess_type(path)  # Treats email domains as file extensions
    if content_type:
        response.mimetype = content_type