### PR TITLE
perf: Apply backpressure on link counts

### DIFF
--- a/frappe/model/utils/link_count.py
+++ b/frappe/model/utils/link_count.py
@@ -29,6 +29,9 @@ ignore_doctypes = {
 }
 
 
+LINK_COUNT_BUFFER_SIZE = 256
+
+
 def notify_link_count(doctype, name):
 	"""updates link count for given document"""
 
@@ -50,13 +53,18 @@ def flush_local_link_count():
 
 	link_count = frappe.cache.get_value("_link_count") or {}
 
+	flush = False
 	for key, value in new_links.items():
 		if key in link_count:
 			link_count[key] += value
-		else:
+		elif len(link_count) < LINK_COUNT_BUFFER_SIZE:
 			link_count[key] = value
+		else:
+			continue
+		flush = True
 
-	frappe.cache.set_value("_link_count", link_count)
+	if flush:
+		frappe.cache.set_value("_link_count", link_count)
 	new_links.clear()
 
 


### PR DESCRIPTION
Brought to you by https://github.com/frappe/erpc

Context: This is a QoL feature to highlight the most used items. But in high throughput environments where a lot of new documents are being created, this becomes a major bottleneck.

Fix: Limit the size of counts that can be buffered before they're flushed.

Statistically, this will still work just as well as it did before... maybe not that well on large datasets because of the small sample size.


![image](https://github.com/user-attachments/assets/30bb70e5-7e00-46e7-95ae-ddaba00242be)



Before: 67K transactions/hour @ ~7s p99 latency


![image](https://github.com/user-attachments/assets/6724e863-c90d-4336-a7db-26f0efee7b0c)


After: 98K transactions/hour @ ~2s p99 latency

![image](https://github.com/user-attachments/assets/b60d5854-de8d-442c-aad9-f5270e80d6d0)


Note: these runs have few more optimizations, but this PR is dominant one. 