### PR TITLE
feat: Dynamic date field selection for naming series instead of current date

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -19,6 +19,7 @@
   "sb1",
   "naming_rule",
   "autoname",
+  "date_based_on",
   "column_break_nexu",
   "title_field",
   "allow_rename",
@@ -706,6 +707,11 @@
    "fieldtype": "Int",
    "label": "Rows Threshold for Grid Search",
    "non_negative": 1
+  },
+  {
+   "fieldname": "date_based_on",
+   "fieldtype": "Data",
+   "label": "Date Based On"
   }
  ],
  "grid_page_length": 50,
@@ -784,7 +790,7 @@
    "link_fieldname": "document_type"
   }
  ],
- "modified": "2025-05-21 21:58:59.947374",
+ "modified": "2025-05-27 15:23:38.452930",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -110,6 +110,7 @@ class DocType(Document):
 		beta: DF.Check
 		color: DF.Data | None
 		custom: DF.Check
+		date_based_on: DF.Data | None
 		default_email_template: DF.Link | None
 		default_print_format: DF.Data | None
 		default_view: DF.Literal[None]
@@ -140,18 +141,7 @@ class DocType(Document):
 		max_attachments: DF.Int
 		migration_hash: DF.Data | None
 		module: DF.Link
-		naming_rule: DF.Literal[
-			"",
-			"Set by user",
-			"Autoincrement",
-			"By fieldname",
-			'By "Naming Series" field',
-			"Expression",
-			"Expression (old style)",
-			"Random",
-			"UUID",
-			"By script",
-		]
+		naming_rule: DF.Literal["", "Set by user", "Autoincrement", "By fieldname", "By \"Naming Series\" field", "Expression", "Expression (old style)", "Random", "UUID", "By script"]
 		nsm_parent_field: DF.Data | None
 		permissions: DF.Table[DocPerm]
 		protect_attached_files: DF.Check
@@ -193,6 +183,7 @@ class DocType(Document):
 		- Check if links point to valid fieldnames"""
 
 		self.check_developer_mode()
+		self.validate_date_based_on()
 
 		self.validate_name()
 
@@ -226,6 +217,17 @@ class DocType(Document):
 
 		if self.default_print_format and not self.custom:
 			frappe.throw(_("Standard DocType cannot have default print format, use Customize Form"))
+
+	def validate_date_based_on(self):
+		if not self.date_based_on:
+			return
+
+		from frappe.core.utils import find
+		date_based_on_field = find(self.fields, lambda d: d.fieldname == self.date_based_on)
+		if not date_based_on_field:
+			frappe.throw(_("Entered field '{0}' doesn't exist in {1}").format(self.date_based_on, self.name))
+		if date_based_on_field.fieldtype not in ["Date", "Datetime"]:
+			frappe.throw(_("Field '{0}' in {1} is not of type Date/Datetime").format(self.date_based_on, self.name))
 
 	def validate_field_name_conflicts(self):
 		"""Check if field names dont conflict with controller properties and methods"""

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -26,7 +26,7 @@ from frappe.desk.form.load import getdoc
 from frappe.model.delete_doc import delete_controllers
 from frappe.model.sync import remove_orphan_doctypes
 from frappe.tests import IntegrationTestCase, UnitTestCase
-from frappe.utils import get_table_name
+from frappe.utils import get_table_name, now_datetime, get_datetime
 
 
 class UnitTestDoctype(UnitTestCase):
@@ -836,6 +836,51 @@ class TestDocType(IntegrationTestCase):
 		self.assertEqual(get_format(compressed_dt), "COMPRESSED")
 		self.assertEqual(get_format(dynamic_dt), "DYNAMIC")
 
+	def test_date_based_on(self):
+		# create a doctype with a date field
+		fields = [
+			{
+				"label": "Posting Date",
+				"fieldtype": "Date",
+				"fieldname": "posting_date",
+				"reqd": 1
+			}
+		]
+
+		dt = new_doctype(
+			name="Date Based On Test",
+			fields=fields,
+			naming_rule="Expression (old style)",
+			autoname="DT-TEST-.YY.-.MM.-.DD.//.#",
+			date_based_on="posting_date"
+		)
+		dt.insert()
+
+		# set date_based_on for that doctype
+
+		# set naming series for that doctype as "DT-TEST-.YY.-.MM.-.DD."
+
+		# create a new record in that doctype (not doctype list) with date as 2025/05/29
+		# asset that documents name is DT-TEST-25-05-29
+		record1 = frappe.get_doc(
+			{
+				"doctype": "Date Based On Test",
+				"posting_date": "2025-05-29"
+			}
+		)
+		record1.insert()
+		self.assertEqual(record1.name.split("//")[0], "DT-TEST-25-05-29")
+
+		# create a new record in that doctype (not doctype list) with date as 2026/12/17
+		# asset that documents name is DT-TEST-26-12-17
+		record2 = frappe.get_doc(
+			{
+				"doctype": "Date Based On Test",
+				"posting_date": "2026-12-17"
+			}
+		)
+		record2.insert()
+		self.assertEqual(record2.name.split("//")[0], "DT-TEST-26-12-17")
 
 def new_doctype(
 	name: str | None = None,

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -27,6 +27,7 @@
   "naming_section",
   "naming_rule",
   "autoname",
+  "date_based_on",
   "form_settings_section",
   "image_field",
   "max_attachments",
@@ -415,6 +416,12 @@
    "fieldname": "protect_attached_files",
    "fieldtype": "Check",
    "label": "Protect Attached Files"
+  },
+  {
+   "description": "The date value of the field/attribute entered here will be used to populate the date elements(DD,MM,YYYY) in the naming of the document, instead of current date.",
+   "fieldname": "date_based_on",
+   "fieldtype": "Data",
+   "label": "Date Based On"
   }
  ],
  "hide_toolbar": 1,
@@ -423,7 +430,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-27 18:22:32.618603",
+ "modified": "2025-05-28 12:29:14.663808",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -44,6 +44,7 @@ class CustomizeForm(Document):
 		allow_copy: DF.Check
 		allow_import: DF.Check
 		autoname: DF.Data | None
+		date_based_on: DF.Data | None
 		default_email_template: DF.Link | None
 		default_print_format: DF.Link | None
 		default_view: DF.Literal[None]
@@ -61,16 +62,7 @@ class CustomizeForm(Document):
 		links: DF.Table[DocTypeLink]
 		make_attachments_public: DF.Check
 		max_attachments: DF.Int
-		naming_rule: DF.Literal[
-			"",
-			"Set by user",
-			"By fieldname",
-			'By "Naming Series" field',
-			"Expression",
-			"Expression (old style)",
-			"Random",
-			"By script",
-		]
+		naming_rule: DF.Literal["", "Set by user", "By fieldname", "By \"Naming Series\" field", "Expression", "Expression (old style)", "Random", "By script"]
 		protect_attached_files: DF.Check
 		queue_in_background: DF.Check
 		quick_entry: DF.Check
@@ -224,6 +216,14 @@ class CustomizeForm(Document):
 	def save_customization(self):
 		if not self.doc_type:
 			return
+	
+		if self.date_based_on:
+			meta = frappe.get_meta(self.doc_type)
+			date_based_on_field = meta.get_field(self.date_based_on)
+			if not date_based_on_field:
+				frappe.throw(_("Entered field '{0}' doesn't exist in {1}").format(self.date_based_on, self.doc_type))
+			if date_based_on_field.fieldtype not in ["Date", "Datetime"]:
+				frappe.throw(_("Field '{0}' in {1} is not of type Date/Datetime").format(self.date_based_on, self.doc_type))
 
 		validate_series(self, self.autoname, self.doc_type)
 		validate_autoincrement_autoname(self)
@@ -740,6 +740,7 @@ doctype_properties = {
 	"subject_field": "Data",
 	"sender_field": "Data",
 	"naming_rule": "Data",
+	"date_based_on": "Data",
 	"autoname": "Data",
 	"show_title_field_in_link": "Check",
 	"is_calendar_and_gantt": "Check",

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -16,7 +16,7 @@ from frappe import _
 from frappe.model import log_types
 from frappe.monitor import get_trace_id
 from frappe.query_builder import DocType
-from frappe.utils import cint, cstr, now_datetime
+from frappe.utils import cint, cstr, now_datetime, get_datetime, getdate
 
 if TYPE_CHECKING:
 	from frappe.model.document import Document
@@ -339,8 +339,12 @@ def parse_naming_series(
 	if not number_generator:
 		number_generator = getseries
 
+	date_source = now_datetime()
+	if date_based_on := frappe.get_meta(doc.doctype).date_based_on:
+		date_source = get_datetime(doc.get(date_based_on))
+
 	series_set = False
-	today = now_datetime()
+
 	for e in parts:
 		if not e:
 			continue
@@ -352,19 +356,19 @@ def parse_naming_series(
 				part = number_generator(name, digits)
 				series_set = True
 		elif e == "YY":
-			part = today.strftime("%y")
+			part = date_source.strftime("%y")
 		elif e == "MM":
-			part = today.strftime("%m")
+			part = date_source.strftime("%m")
 		elif e == "DD":
-			part = today.strftime("%d")
+			part = date_source.strftime("%d")
 		elif e == "YYYY":
-			part = today.strftime("%Y")
+			part = date_source.strftime("%Y")
 		elif e == "JJJ":
-			part = today.strftime("%j")
+			part = date_source.strftime("%j")
 		elif e == "WW":
-			part = determine_consecutive_week_number(today)
+			part = determine_consecutive_week_number(date_source)
 		elif e == "timestamp":
-			part = str(today)
+			part = str(date_source)
 		elif doc and (e.startswith("{") or doc.get(e, _sentinel) is not _sentinel):
 			e = e.replace("{", "").replace("}", "")
 			part = doc.get(e)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3cbf113f-7c49-4474-a157-6439660720d7)
![image](https://github.com/user-attachments/assets/ad462e91-9faf-4891-9259-63c93f9386eb)

Name of the record (If it contains date elements) will be saved according to the date value present in the user-inputted field instead of taking current date/datetime 

