### PR TITLE
feat: Lightweight test runner

### DIFF
--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -9,9 +9,6 @@ import click
 
 import frappe
 from frappe.commands import get_site, pass_context
-from frappe.testing.config import TestParameters
-from frappe.testing.loader import FrappeTestLoader
-from frappe.testing.result import FrappeTestResult
 from frappe.utils.bench_helper import CliCtxObj
 
 if TYPE_CHECKING:
@@ -40,6 +37,8 @@ def main(
 ) -> None:
 	"""Main function to run tests"""
 	if lightmode:
+		from frappe.testing.config import TestParameters
+
 		test_params = TestParameters(
 			site=site,
 			app=app,
@@ -181,7 +180,10 @@ def main(
 		testing_module_logger.debug(f"Total test run time: {end_time - start_time:.3f} seconds")
 
 
-def run_tests_in_light_mode(test_params: TestParameters):
+def run_tests_in_light_mode(test_params):
+	from frappe.testing.loader import FrappeTestLoader
+	from frappe.testing.result import FrappeTestResult
+
 	# init environment
 	frappe.init(test_params.site)
 	if not frappe.db:

--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -1,17 +1,17 @@
-import importlib
 import os
 import subprocess
 import sys
 import time
 import unittest
-from collections import deque
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import click
 
 import frappe
 from frappe.commands import get_site, pass_context
+from frappe.testing.config import TestParameters
+from frappe.testing.loader import FrappeTestLoader
+from frappe.testing.result import FrappeTestResult
 from frappe.utils.bench_helper import CliCtxObj
 
 if TYPE_CHECKING:
@@ -40,8 +40,6 @@ def main(
 ) -> None:
 	"""Main function to run tests"""
 	if light:
-		from frappe.modules.utils import get_module_name
-		from frappe.testing.config import TestParameters
 		from frappe.testing.environment import _disable_scheduler_if_needed
 
 		test_params = TestParameters(
@@ -69,83 +67,8 @@ def main(
 		_disable_scheduler_if_needed()
 		frappe.clear_cache()
 
-		class FrappeTestLoader(unittest.TestLoader):
-			def recursive_load_suites_in_pymodule(self, suite):
-				suites_queue = deque([suite])
-				while suites_queue:
-					suite = suites_queue.popleft()
-					for elem in suite:
-						if elem.countTestCases():
-							if isinstance(elem, unittest.TestSuite):
-								suites_queue.append(elem)
-							elif isinstance(elem, unittest.TestCase):
-								if self.params.tests:
-									if elem._testMethodName in self.params.tests:
-										self.testsuite.addTest(elem)
-								else:
-									self.testsuite.addTest(elem)
-
-			def load_testsuites_in_pymodule(self, file_modules):
-				for module in file_modules:
-					suite = unittest.defaultTestLoader.loadTestsFromModule(module)
-					self.recursive_load_suites_in_pymodule(suite)
-
-			def load_pymodule_for_files(self, files: list):
-				"""
-				files: list of tuple of (Path, str)
-				"""
-				_file_modules = []
-				for app_path, test_file in files:
-					module_name = (
-						f"{'.'.join(test_file.relative_to(app_path.parent).parent.parts)}.{test_file.stem}"
-					)
-					module = importlib.import_module(module_name)
-					_file_modules.append(module)
-				return _file_modules
-
-			def get_files(self, apps: list) -> list:
-				files = []
-				for app in apps:
-					app_path = Path(frappe.get_app_path(app))
-					for test_file in app_path.glob("**/test_*.py"):
-						files.append((app_path, test_file))
-				return files
-
-			def discover_tests(self, params: TestParameters) -> unittest.TestSuite:
-				self.params = params
-				self.testsuite = unittest.TestSuite()
-
-				if self.params.tests:
-					# handle --test; highest priority; will ignore --doctype and --app
-					files = self.get_files(frappe.get_installed_apps())
-					file_pymodules = self.load_pymodule_for_files(files)
-					self.load_testsuites_in_pymodule(file_pymodules)
-
-				elif self.params.doctype:
-					# handle --doctype; will ignore --app
-					module = frappe.get_cached_value("DocType", self.params.doctype, "module")
-					app = frappe.get_cached_value("Module Def", module, "app_name")
-					pymodule_name = get_module_name(self.params.doctype, module, "test_", app=app)
-					pymodule = importlib.import_module(pymodule_name)
-					self.load_testsuites_in_pymodule([pymodule])
-
-				elif self.params.app:
-					# handle --app
-					files = self.get_files([self.params.app])
-					file_pymodules = self.load_pymodule_for_files(files)
-					self.load_testsuites_in_pymodule(file_pymodules)
-
-				elif self.params.module:
-					# handle --module; supports --test as well
-					pymodule = importlib.import_module(self.params.module)
-					self.load_testsuites_in_pymodule([pymodule])
-
-				return self.testsuite
-
 		suite = FrappeTestLoader().discover_tests(test_params)
-		print("Test Cases:", suite.countTestCases())
-		res = unittest.TextTestRunner().run(suite)
-		print("Result:", res)
+		res = unittest.TextTestRunner(resultclass=FrappeTestResult).run(suite)
 
 	else:
 		import logging

--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -40,8 +40,6 @@ def main(
 ) -> None:
 	"""Main function to run tests"""
 	if lightmode:
-		from frappe.testing.environment import _disable_scheduler_if_needed
-
 		test_params = TestParameters(
 			site=site,
 			app=app,
@@ -197,7 +195,7 @@ def run_tests_in_light_mode(test_params: TestParameters):
 	frappe.clear_cache()
 
 	suite = FrappeTestLoader().discover_tests(test_params)
-	unittest.TextTestRunner(resultclass=FrappeTestResult).run(suite)
+	unittest.TextTestRunner(failfast=test_params.failfast, resultclass=FrappeTestResult).run(suite)
 
 
 def _setup_xml_output(junit_xml_output):

--- a/frappe/testing/config.py
+++ b/frappe/testing/config.py
@@ -16,8 +16,6 @@ class TestConfig:
 
 @dataclass
 class TestParameters:
-	"""Configuration class for test runner"""
-
 	site: str | None = None
 	app: str | None = None
 	module: str | None = None

--- a/frappe/testing/config.py
+++ b/frappe/testing/config.py
@@ -12,3 +12,22 @@ class TestConfig:
 	pdb_on_exceptions: tuple | None = None
 	selected_categories: list[str] = field(default_factory=list)
 	skip_before_tests: bool = False
+
+
+@dataclass
+class TestParameters:
+	"""Configuration class for test runner"""
+
+	site: str | None = None
+	app: str | None = None
+	module: str | None = None
+	doctype: str | None = None
+	module_def: str | None = None
+	verbose: bool = False
+	tests: tuple = ()
+	force: bool = False
+	profile: bool = False
+	junit_xml_output: str | None = None
+	doctype_list_path: str | None = None
+	failfast: bool = False
+	case: str | None = None

--- a/frappe/testing/loader.py
+++ b/frappe/testing/loader.py
@@ -26,7 +26,7 @@ class FrappeTestLoader(unittest.TestLoader):
 
 	def load_testsuites_in_pymodule(self, file_modules):
 		for module in file_modules:
-			suite = unittest.defaultTestLoader.loadTestsFromModule(module)
+			suite = self.loadTestsFromModule(module)
 			self.recursive_load_suites_in_pymodule(suite)
 
 	def load_pymodule_for_files(self, files: list):

--- a/frappe/testing/loader.py
+++ b/frappe/testing/loader.py
@@ -1,0 +1,80 @@
+import importlib
+import unittest
+from collections import deque
+from pathlib import Path
+
+import frappe
+from frappe.modules.utils import get_module_name
+from frappe.testing.config import TestParameters
+
+
+class FrappeTestLoader(unittest.TestLoader):
+	def recursive_load_suites_in_pymodule(self, suite):
+		suites_queue = deque([suite])
+		while suites_queue:
+			suite = suites_queue.popleft()
+			for elem in suite:
+				if elem.countTestCases():
+					if isinstance(elem, unittest.TestSuite):
+						suites_queue.append(elem)
+					elif isinstance(elem, unittest.TestCase):
+						if self.params.tests:
+							if elem._testMethodName in self.params.tests:
+								self.testsuite.addTest(elem)
+						else:
+							self.testsuite.addTest(elem)
+
+	def load_testsuites_in_pymodule(self, file_modules):
+		for module in file_modules:
+			suite = unittest.defaultTestLoader.loadTestsFromModule(module)
+			self.recursive_load_suites_in_pymodule(suite)
+
+	def load_pymodule_for_files(self, files: list):
+		"""
+		files: list of tuple of (Path, str)
+		"""
+		_file_modules = []
+		for app_path, test_file in files:
+			module_name = f"{'.'.join(test_file.relative_to(app_path.parent).parent.parts)}.{test_file.stem}"
+			module = importlib.import_module(module_name)
+			_file_modules.append(module)
+		return _file_modules
+
+	def get_files(self, apps: list) -> list:
+		files = []
+		for app in apps:
+			app_path = Path(frappe.get_app_path(app))
+			for test_file in app_path.glob("**/test_*.py"):
+				files.append((app_path, test_file))
+		return files
+
+	def discover_tests(self, params: TestParameters) -> unittest.TestSuite:
+		self.params = params
+		self.testsuite = unittest.TestSuite()
+
+		if self.params.tests:
+			# handle --test; highest priority; will ignore --doctype and --app
+			files = self.get_files(frappe.get_installed_apps())
+			file_pymodules = self.load_pymodule_for_files(files)
+			self.load_testsuites_in_pymodule(file_pymodules)
+
+		elif self.params.doctype:
+			# handle --doctype; will ignore --app
+			module = frappe.get_cached_value("DocType", self.params.doctype, "module")
+			app = frappe.get_cached_value("Module Def", module, "app_name")
+			pymodule_name = get_module_name(self.params.doctype, module, "test_", app=app)
+			pymodule = importlib.import_module(pymodule_name)
+			self.load_testsuites_in_pymodule([pymodule])
+
+		elif self.params.app:
+			# handle --app
+			files = self.get_files([self.params.app])
+			file_pymodules = self.load_pymodule_for_files(files)
+			self.load_testsuites_in_pymodule(file_pymodules)
+
+		elif self.params.module:
+			# handle --module; supports --test as well
+			pymodule = importlib.import_module(self.params.module)
+			self.load_testsuites_in_pymodule([pymodule])
+
+		return self.testsuite

--- a/frappe/testing/result.py
+++ b/frappe/testing/result.py
@@ -199,7 +199,7 @@ class FrappeTestResult(unittest.TextTestResult):
 
 	def addSuccess(self, test):
 		super(unittest.TextTestResult, self).addSuccess(test)
-		elapsed = time.time() - self._started_at
+		elapsed = time.monotonic() - self._started_at
 		threshold_passed = elapsed >= SLOW_TEST_THRESHOLD
 		elapsed = click.style(f" ({elapsed:.03}s)", fg="red") if threshold_passed else ""
 		click.echo(f"  {click.style(' ✔ ', fg='green')} {self.getTestMethodName(test)}{elapsed}")


### PR DESCRIPTION
# Reason
In the effort to bring [determinism to Test Suites](https://github.com/frappe/erpnext/issues/47394), a simple, no-frills Test Runner is needed. 


# Design
Bare bones approach. This test runner does not do any complex lazy-loading or handle `test_records.json`. It fetches Test Suites and runs them, that's it.

## Summary of changes
1. new test loader class `FrappeTestLoader`
2. new test result class `FrappeTestResult`
3. new parameter `--lightmode` is available for 'run-tests' command


The goal is to iteratively refactor ERPNext and HRMS using the lightmode. Once all tests pass in CI and locally on a clean-slate and on re-runs, this Test Runner will be made default.

`no-docs`