### PR TITLE
chore: bump redis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "python-dateutil~=2.8.2",
     "pytz==2023.3",
     "rauth~=0.7.3",
-    "redis~=5.2.0",
+    "redis~=6.2.0",
     "hiredis~=3.0.0",
     "requests-oauthlib~=1.3.1",
     "requests~=2.32.0",


### PR DESCRIPTION
pip install audit is failing in CI 
https://github.com/redis/redis-py/releases/tag/v6.2.0