### PR TITLE
perf: cache link validation for new doc

### DIFF
--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -65,7 +65,7 @@ def set_user_and_static_default_values(doc):
 			)
 			if user_default_value is not None:
 				# if fieldtype is link check if doc exists
-				if df.fieldtype != "Link" or frappe.db.exists(df.options, user_default_value):
+				if df.fieldtype != "Link" or frappe.db.exists(df.options, user_default_value, cache=True):
 					doc.set(df.fieldname, user_default_value)
 
 			else:


### PR DESCRIPTION
ERPNext often has same links repeated in multiple child table rows
