### PR TITLE
fix: permission error when permission docname is none

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -351,7 +351,7 @@ def has_user_permission(doc, user=None, debug=False):
 		# if allowed_docs is empty it states that there is no applicable permission under the current doctype
 
 		# only check if allowed_docs is not empty
-		if allowed_docs and str(docname) not in allowed_docs:
+		if allowed_docs and docname and str(docname) not in allowed_docs:
 			# no user permissions for this doc specified
 			debug and _debug_log(
 				"User doesn't have access to this document because of User Permissions, allowed documents: "


### PR DESCRIPTION
Support ticket: https://support.frappe.io/helpdesk/tickets/39801

Even though the user has permission to create the doctype, it throws an error saying they don't have permission to create it.

**Steps to replicate:**

1. Create the following warehouse structure:

   * **A** (Parent)
   * **B** (Child of A)

2. Assign a user permission for **Warehouse B** to **User1**.

3. When **User1** tries to create a new warehouse, a permission error is thrown.

