### PR TITLE
feat(DX): let users skip next scheduled job execution

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -3,7 +3,14 @@
   {
    "action": "frappe.core.doctype.scheduled_job_type.scheduled_job_type.execute_event",
    "action_type": "Server Action",
+   "group": "Actions",
    "label": "Execute"
+  },
+  {
+   "action": "frappe.core.doctype.scheduled_job_type.scheduled_job_type.skip_next_execution",
+   "action_type": "Server Action",
+   "group": "Actions",
+   "label": "Skip Next Execution"
   }
  ],
  "creation": "2024-02-23 10:41:33.059393",
@@ -110,7 +117,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2025-05-05 18:24:38.816989",
+ "modified": "2025-06-03 09:26:47.961601",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -196,6 +196,15 @@ def execute_event(doc: str):
 	return doc
 
 
+@frappe.whitelist()
+def skip_next_execution(doc: str):
+	frappe.only_for("System Manager")
+	doc = json.loads(doc)
+	doc: ScheduledJobType = frappe.get_doc("Scheduled Job Type", doc.get("name"))
+	doc.last_execution = doc.next_execution
+	return doc.save()
+
+
 def run_scheduled_job(scheduled_job_type: str, job_type: str | None = None):
 	"""This is a wrapper function that runs a hooks.scheduler_events method"""
 	if frappe.conf.maintenance_mode:


### PR DESCRIPTION
Useful sometimes when configuring or re-configuring CRONs to avoid
duplicate executions.

Also, you can skip anniversary emails 🥴
