### PR TITLE
fix: empty space between two sections

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -115,6 +115,11 @@
 
 .form-section.card-section.hide-border {
 	border-bottom: none;
+	padding-bottom: 0;
+
+	&:not(:has(.section-head)) {
+		padding-top: 0;
+	}
 }
 
 .form-dashboard-section {


### PR DESCRIPTION
### Before
![CleanShot 2025-06-03 at 15 33 13@2x](https://github.com/user-attachments/assets/d9945025-3b6a-4255-a43b-a12490b7febe)


### After
![CleanShot 2025-06-03 at 15 32 47@2x](https://github.com/user-attachments/assets/b7174f67-703f-4ab7-b78f-82465ba986e2)

This only affects sections that has "hide_border" checked