### PR TITLE
fix(UX): show source of automatically created document

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -236,6 +236,11 @@ class AutoRepeat(Document):
 		reference_doc = frappe.get_doc(self.reference_doctype, self.reference_document)
 		new_doc = frappe.copy_doc(reference_doc, ignore_no_copy=False)
 		self.update_doc(new_doc, reference_doc)
+		new_doc.flags.updater_reference = {
+			"doctype": self.doctype,
+			"docname": self.name,
+			"label": _("via Auto Repeat"),
+		}
 		new_doc.insert(ignore_permissions=True)
 
 		if self.submit_on_creation:

--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -240,6 +240,19 @@ function get_version_timeline_content(version_doc, frm) {
 			}
 		}
 	});
+
+	if (data.created_by && updater_reference) {
+		let message = get_user_message(
+			version_doc.owner,
+			__("You created this document {0}", [updater_reference_link], "Form timeline"),
+			__(
+				"{0} created this document {1}",
+				[get_user_link(version_doc.owner), updater_reference_link],
+				"Form timeline"
+			)
+		);
+		out.push(get_version_comment(version_doc, message));
+	}
 	const impersonated_by = data.impersonated_by;
 
 	if (impersonated_by) {


### PR DESCRIPTION
originating doc is clickable, not visible in screenshot.


![image](https://github.com/user-attachments/assets/a9ecddd1-05d7-4ba9-bbfe-06eba6e394b2)
