### PR TITLE
perf: don't load doc before save for child tables

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1396,7 +1396,7 @@ class Document(BaseDocument, DocRef):
 			self.set("modified_by", frappe.session.user)
 
 		# load but do not reload doc_before_save because before_change or on_change might expect it
-		if not self.get_doc_before_save():
+		if not self.get_doc_before_save() and not self.meta.istable:
 			self.load_doc_before_save()
 
 		# to trigger notification on value change


### PR DESCRIPTION
Consider this:

```python
for row in doc.get_children():
    row.db_set("amount", 0)
```

This sounds like it will do one write query for each row but it does 2
because of this unnecessary locking of child tables.
