### PR TITLE
fix: add h4 to h6 tags in text editor text dropdown

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -286,7 +286,7 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 
 	get_toolbar_options() {
 		return [
-			[{ header: [1, 2, 3, false] }],
+			[{ header: [1, 2, 3, 4, 5, 6, false] }],
 			[{ size: font_sizes }],
 			["bold", "italic", "underline", "strike", "clean"],
 			[{ color: [] }, { background: [] }],


### PR DESCRIPTION
In the text formatting of the text editor there were h1 to h3 tags present
This PR adds a h4 to h6 tags.

<img width="234" alt="h6 tags" src="https://github.com/user-attachments/assets/9b6cb960-8404-4b93-a6d2-1952c578fc5a" />

Ref ticket https://support.frappe.io/helpdesk/tickets/40215