### PR TITLE
perf!: Speedup link validations, fetch, docstatus

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -847,6 +847,8 @@ class BaseDocument:
 	def get_invalid_links(self, is_submittable=False):
 		"""Return list of invalid links and also update fetch values if not set."""
 
+		is_submittable = is_submittable or self.meta.is_submittable
+
 		def get_msg(df, docname):
 			# check if parentfield exists (only applicable for child table doctype)
 			if self.get("parentfield"):
@@ -859,79 +861,73 @@ class BaseDocument:
 
 		for df in self.meta.get_link_fields() + self.meta.get("fields", {"fieldtype": ("=", "Dynamic Link")}):
 			docname = self.get(df.fieldname)
+			if not docname:
+				continue
 
-			if docname:
-				if df.fieldtype == "Link":
-					doctype = df.options
-					if not doctype:
-						frappe.throw(_("Options not set for link field {0}").format(df.fieldname))
-				else:
-					doctype = self.get(df.options)
-					if not doctype:
-						frappe.throw(_("{0} must be set first").format(self.meta.get_label(df.options)))
-					invalidate_distinct_link_doctypes(df.parent, df.options, doctype)
+			if df.fieldtype == "Link":
+				doctype = df.options
+				if not doctype:
+					frappe.throw(_("Options not set for link field {0}").format(df.fieldname))
+			else:
+				assert df.fieldtype == "Dynamic Link"
+				doctype = self.get(df.options)
+				if not doctype:
+					frappe.throw(_("{0} must be set first").format(self.meta.get_label(df.options)))
+				invalidate_distinct_link_doctypes(df.parent, df.options, doctype)
 
+			meta = frappe.get_meta(doctype)
+			if not meta.istable:
+				notify_link_count(doctype, docname)
+
+			check_docstatus = is_submittable and frappe.get_meta(doctype).is_submittable
+
+			# get a map of values ot fetch along with this link query
+			# that are mapped as link_fieldname.source_fieldname in Options of
+			# Readonly or Data or Text type fields
+			fields_to_fetch = [
+				_df
+				for _df in self.meta.get_fields_to_fetch(df.fieldname)
+				if not _df.get("fetch_if_empty")
+				or (_df.get("fetch_if_empty") and not self.get(_df.fieldname))
+			]
+			values_to_fetch = (
+				"name",
+				*(_df.fetch_from.split(".")[-1] for _df in fields_to_fetch),
+			)
+			if check_docstatus:
+				values_to_fetch += ("docstatus",)
+
+			if not meta.get("is_virtual"):
+				values = frappe.db.get_value(doctype, docname, values_to_fetch, as_dict=True, cache=True)
+				if not values:  # NOTE: DB Value cache does negative caching, which is hard to remove now.
+					values = frappe.db.get_value(doctype, docname, values_to_fetch, as_dict=True)
+			else:
+				values = frappe.get_doc(doctype, docname).as_dict()
+
+			# fallback to dict with field_to_fetch=None if link field value is not found
+			# (for compatibility, `values` must have same data type)
+			values = values or _dict.fromkeys(values_to_fetch, None)
+
+			if getattr(meta, "issingle", 0):
+				values.name = doctype
+
+			if not df.get("is_virtual"):
 				# MySQL is case insensitive. Preserve case of the original docname in the Link Field.
+				setattr(self, df.fieldname, values.name)
 
-				# get a map of values ot fetch along with this link query
-				# that are mapped as link_fieldname.source_fieldname in Options of
-				# Readonly or Data or Text type fields
+			for _df in fields_to_fetch:
+				if self.is_new() or not self.docstatus.is_submitted() or _df.allow_on_submit:
+					self.set_fetch_from_value(doctype, _df, values)
 
-				meta = frappe.get_meta(doctype)
-				fields_to_fetch = [
-					_df
-					for _df in self.meta.get_fields_to_fetch(df.fieldname)
-					if not _df.get("fetch_if_empty")
-					or (_df.get("fetch_if_empty") and not self.get(_df.fieldname))
-				]
-				if not meta.get("is_virtual"):
-					if not fields_to_fetch:
-						# cache a single value type
-						values = frappe.db.get_value(
-							doctype, docname, ("name", "docstatus"), cache=True, as_dict=True
-						)
-					else:
-						values_to_fetch = (
-							"name",
-							"docstatus",
-							*(_df.fetch_from.split(".")[-1] for _df in fields_to_fetch),
-						)
+			if not values.name:
+				invalid_links.append((df.fieldname, docname, get_msg(df, docname)))
 
-						# fallback to dict with field_to_fetch=None if link field value is not found
-						# (for compatibility, `values` must have same data type)
-						empty_values = _dict({value: None for value in values_to_fetch})
-						values = (
-							frappe.db.get_value(doctype, docname, values_to_fetch, as_dict=True, cache=True)
-							or empty_values
-						)
-
-				if getattr(meta, "issingle", 0):
-					values.name = doctype
-
-				if meta.get("is_virtual"):
-					values = frappe.get_doc(doctype, docname).as_dict()
-
-				if values:
-					if not df.get("is_virtual"):
-						setattr(self, df.fieldname, values.name)
-
-					for _df in fields_to_fetch:
-						if self.is_new() or not self.docstatus.is_submitted() or _df.allow_on_submit:
-							self.set_fetch_from_value(doctype, _df, values)
-
-					if not meta.istable:
-						notify_link_count(doctype, docname)
-
-					if not values.name:
-						invalid_links.append((df.fieldname, docname, get_msg(df, docname)))
-
-					elif (
-						df.fieldname != "amended_from"
-						and (is_submittable or self.meta.is_submittable)
-						and frappe.get_meta(doctype).is_submittable
-						and DocStatus(values.docstatus or 0).is_cancelled()
-					):
-						cancelled_links.append((df.fieldname, docname, get_msg(df, docname)))
+			elif (
+				df.fieldname != "amended_from"
+				and check_docstatus
+				and DocStatus(values.docstatus or 0).is_cancelled()
+			):
+				cancelled_links.append((df.fieldname, docname, get_msg(df, docname)))
 
 		return invalid_links, cancelled_links
 

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -887,10 +887,13 @@ class BaseDocument:
 				if not meta.get("is_virtual"):
 					if not fields_to_fetch:
 						# cache a single value type
-						values = _dict(name=frappe.db.get_value(doctype, docname, "name", cache=True))
+						values = frappe.db.get_value(
+							doctype, docname, ("name", "docstatus"), cache=True, as_dict=True
+						)
 					else:
 						values_to_fetch = (
 							"name",
+							"docstatus",
 							*(_df.fetch_from.split(".")[-1] for _df in fields_to_fetch),
 						)
 
@@ -926,7 +929,7 @@ class BaseDocument:
 						df.fieldname != "amended_from"
 						and (is_submittable or self.meta.is_submittable)
 						and frappe.get_meta(doctype).is_submittable
-						and DocStatus(frappe.db.get_value(doctype, docname, "docstatus") or 0).is_cancelled()
+						and DocStatus(values.docstatus or 0).is_cancelled()
 					):
 						cancelled_links.append((df.fieldname, docname, get_msg(df, docname)))
 

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -889,16 +889,16 @@ class BaseDocument:
 						# cache a single value type
 						values = _dict(name=frappe.db.get_value(doctype, docname, "name", cache=True))
 					else:
-						values_to_fetch = ["name"] + [
-							_df.fetch_from.split(".")[-1] for _df in fields_to_fetch
-						]
+						values_to_fetch = (
+							"name",
+							*(_df.fetch_from.split(".")[-1] for _df in fields_to_fetch),
+						)
 
 						# fallback to dict with field_to_fetch=None if link field value is not found
 						# (for compatibility, `values` must have same data type)
 						empty_values = _dict({value: None for value in values_to_fetch})
-						# don't cache if fetching other values too
 						values = (
-							frappe.db.get_value(doctype, docname, values_to_fetch, as_dict=True)
+							frappe.db.get_value(doctype, docname, values_to_fetch, as_dict=True, cache=True)
 							or empty_values
 						)
 

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -1171,7 +1171,7 @@ if sys.version_info.minor < 12:
 		inside the decorated getter function or around the cached property access.
 		"""
 
-		def __init__(self, func: Callable[[Any], T]) -> T:
+		def __init__(self, func: Callable[[Any], T]):
 			self.func = func
 			self.attrname = None
 			self.__doc__ = func.__doc__


### PR DESCRIPTION
- Cache `fetch_from` in same request
- Query `docstatus` in one query

Essentially, for single link type with single value there will now only be maximum one query.

TODO:
- [x] Test against ERPNext CI https://github.com/frappe/erpnext/actions/runs/15458168785 