### PR TITLE
fix(utils) - Correct spelling of 'specified' in frappe/commands/utils.py

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -175,7 +175,7 @@ def destroy_all_sessions(context: CliCtxObj, reason=None):
 @click.option("--format", "-f", type=click.Choice(["text", "json"]), default="text")
 @pass_context
 def show_config(context: CliCtxObj, format):
-	"Print configuration file to STDOUT in speified format"
+	"Print configuration file to STDOUT in specified format"
 
 	if not context.sites:
 		raise SiteNotSpecifiedError


### PR DESCRIPTION
Fixes a small spelling mistake with commands.