### PR TITLE
fix: Standard field falsy comparisons in db_query

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -885,7 +885,7 @@ from {tables}
 				df
 				and (db_type := cstr(frappe.db.type_map.get(df.fieldtype, " ")[0]))
 				and db_type in ("varchar", "text", "longtext", "smalltext", "json")
-			):
+			) or f.fieldname in ("owner", "modified_by", "parent", "parentfield", "parenttype"):
 				value = cstr(f.value)
 				fallback = "''"
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1202,6 +1202,8 @@ class TestDBQuery(IntegrationTestCase):
 		self.assertNotIn("\\'", query)
 		self.assertNotIn("ifnull", query)
 		self.assertFalse(frappe.get_all("DocField", {"name": None}))
+		self.assertFalse(frappe.get_all("DocField", {"parent": None}))
+		self.assertNotIn("0", frappe.get_all("DocField", {"parent": None}, run=0))
 
 	def test_ifnull_fallback_types(self):
 		query = frappe.get_all("DocField", {"fieldname": ("!=", None)}, run=0)


### PR DESCRIPTION
Extends the fix to standard fields. https://github.com/frappe/frappe/pull/32377/commits/e0f63a928f891d4733b4af9502be7daa86ffbfc3

Closes https://github.com/frappe/frappe/issues/32784
