### PR TITLE
fix: data import inserting new records, child table not getting updated

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -268,6 +268,7 @@ class Importer:
 		}
 
 		new_doc.insert()
+		new_doc.save()
 		if meta.is_submittable and self.data_import.submit_after_import:
 			new_doc.submit()
 		return new_doc


### PR DESCRIPTION
When Data Importing new Records to a DocType which has Child Tables, the tables are no getting saved after importing.
The Columns and Fields are correctly Mapped, but still not updating.

So after adding new_doc.save() after new_doc.insert(), it is working.

Please Check @ankush 

![image](https://github.com/user-attachments/assets/7c46617a-6360-4bbf-9488-eef579f1cd0d)
