### PR TITLE
refactor!: Change db.value_cache data structure

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -977,6 +977,8 @@ def get_document_cache_key(doctype: str, name: str):
 
 
 def clear_document_cache(doctype: str, name: str | None = None) -> None:
+	frappe.db.value_cache.pop(doctype, None)
+
 	def clear_in_redis():
 		if name is not None:
 			cache.delete_value(get_document_cache_key(doctype, name))

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -864,8 +864,6 @@ class Database:
 		frappe.qb.into("Singles").columns("doctype", "field", "value").insert(*singles_data).run(debug=debug)
 		frappe.clear_document_cache(doctype, doctype)
 
-		self.value_cache.pop(doctype, None)
-
 	def get_single_value(self, doctype: str, fieldname: str, cache: bool = True):
 		"""Get property of Single DocType. Cache locally by default
 
@@ -975,8 +973,6 @@ class Database:
 			query = query.set(column, value)
 
 		query.run(debug=debug)
-
-		self.value_cache.pop(dt, None)
 
 	def bulk_update(
 		self,

--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -576,7 +576,7 @@ def get_tests_CompatFrappeTestCase():
 		traceback.print_stack(limit=10)
 
 	def _rollback_db():
-		frappe.db.value_cache = {}
+		frappe.db.value_cache.clear()
 		frappe.db.rollback()
 
 	def _restore_thread_locals(flags):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -706,7 +706,7 @@ class Document(BaseDocument, DocRef):
 				)
 
 		if self.doctype in frappe.db.value_cache:
-			del frappe.db.value_cache[self.doctype]
+			frappe.db.value_cache.pop(self.doctype, None)
 
 	def set_user_and_timestamp(self):
 		self._original_modified = self.modified

--- a/frappe/tests/classes/context_managers.py
+++ b/frappe/tests/classes/context_managers.py
@@ -88,8 +88,6 @@ def change_settings(doctype, settings_dict=None, /, commit=False, **settings) ->
 	for key, value in settings_dict.items():
 		setattr(settings, key, value)
 	settings.save(ignore_permissions=True)
-	# singles are cached by default, clear to avoid flake
-	frappe.db.value_cache[settings] = {}
 	if commit:
 		frappe.db.commit()
 	yield

--- a/frappe/tests/classes/integration_test_case.py
+++ b/frappe/tests/classes/integration_test_case.py
@@ -183,7 +183,7 @@ def _commit_watcher():
 
 
 def _rollback_db():
-	frappe.db.value_cache = {}
+	frappe.db.value_cache.clear()
 	frappe.db.rollback()
 
 

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -252,7 +252,6 @@ class TestWebsite(IntegrationTestCase):
 			self.assertEqual(response.status_code, 404)
 
 	def test_printview_page(self):
-		frappe.db.value_cache[("DocType", "Language", "name")] = (("Language",),)
 		frappe.set_user("Administrator")
 		content = get_response_content("/Language/ru")
 		self.assertIn('<div class="print-format">', content)

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -12,6 +12,7 @@ import re
 import time
 import typing
 from code import compile_command
+from collections import defaultdict
 from enum import Enum
 from functools import lru_cache
 from typing import Any, Literal, Optional, TypeVar
@@ -2709,6 +2710,11 @@ def mock(type, size=1, locale="en"):
 	from frappe.utils import squashify
 
 	return squashify(results)
+
+
+# Recursive default dict with arbitrary levels of nesting
+def recursive_defaultdict():
+	return defaultdict(recursive_defaultdict)
 
 
 # This is used in test to count memory overhead of default imports.

--- a/frappe/website/doctype/blog_post/test_blog_post.py
+++ b/frappe/website/doctype/blog_post/test_blog_post.py
@@ -74,9 +74,6 @@ class TestBlogPost(IntegrationTestCase):
 		category_page_link = next(iter(soup.find_all("a", href=re.compile(blog.blog_category))))
 		category_page_url = category_page_link["href"]
 
-		cached_value = frappe.db.value_cache.get(("DocType", "Blog Post", "name"))
-		frappe.db.value_cache[("DocType", "Blog Post", "name")] = (("Blog Post",),)
-
 		# Visit the category page (by following the link found in above stage)
 		set_request(path=category_page_url)
 		category_page_response = get_response()
@@ -85,7 +82,6 @@ class TestBlogPost(IntegrationTestCase):
 		self.assertIn(blog.title, category_page_html)
 
 		# Cleanup
-		frappe.db.value_cache[("DocType", "Blog Post", "name")] = cached_value
 		frappe.delete_doc("Blog Post", blog.name)
 		frappe.delete_doc("Blog Category", blog.blog_category)
 


### PR DESCRIPTION
This is internal change but it allows us to do granular cache clearing based on doctype, docname etc.
