### PR TITLE
fix: allow bulk delete for docs with workflow

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2178,7 +2178,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		}
 
 		// bulk delete
-		if (frappe.model.can_delete(doctype) && !frappe.model.has_workflow(doctype)) {
+		if (frappe.model.can_delete(doctype) && is_bulk_edit_allowed(doctype)) {
 			actions_menu_items.push(bulk_delete());
 		}
 


### PR DESCRIPTION
Allow Edit in List View Settings will now allow to bulk delete documents with workflow
Ref ticket https://support.frappe.io/helpdesk/tickets/37507