### PR TITLE
feat: allow to save image imported from url

### DIFF
--- a/cypress/integration/file_uploader.js
+++ b/cypress/integration/file_uploader.js
@@ -52,4 +52,39 @@ context("FileUploader", () => {
 			.should("have.property", "file_name", "example.json");
 		cy.get(".modal:visible").should("not.exist");
 	});
+
+	describe("Web Link Upload", () => {
+		beforeEach(() => {
+			open_upload_dialog();
+			cy.get_open_dialog().find("button").contains("Link").click();
+		});
+
+		it("should show image URL input when 'Link' is clicked", () => {
+			cy.get(".form-check").should("contain", "Upload to Library");
+		});
+
+		it("should show 'Optimize Image' checkbox when upload to library is selected", () => {
+			cy.get("#upload-to-library").check({ force: true });
+			cy.get("#optimize-image").should("exist");
+		});
+
+		it("should show an error for invalid URL format", () => {
+			const invalidUrl = "not-a-valid-url";
+
+			cy.get_open_dialog().findByPlaceholderText("Attach a web link").type(invalidUrl);
+			cy.get_open_dialog().findByRole("button", { name: "Upload" }).click();
+
+			cy.on("window:alert", (text) => {
+				expect(text).to.contain("The provided URL is not valid.");
+			});
+		});
+
+		it("should show an error when no URL is provided", () => {
+			cy.get_open_dialog().findByRole("button", { name: "Upload" }).click();
+
+			cy.on("window:alert", (text) => {
+				expect(text).to.contain("Invalid URL");
+			});
+		});
+	});
 });

--- a/frappe/core/api/image_import.py
+++ b/frappe/core/api/image_import.py
@@ -1,0 +1,131 @@
+import frappe
+import requests
+import mimetypes
+import os
+import hashlib
+import logging
+from urllib.parse import urlparse
+from frappe import _
+
+@frappe.whitelist(allow_guest=True)
+def import_image_from_url(url=None, optimize=False):
+    logger = frappe.logger()
+
+    # Handle JSON POST input
+    if not url:
+        url = frappe.form_dict.get("url")
+    optimize = frappe.form_dict.get("optimize", optimize) in [True, "1", "true", "True"]
+
+    if not url:
+        frappe.throw(_("Image URL is required."))
+
+    # Validate URL format
+    parsed_url = urlparse(url)
+    if not parsed_url.scheme or not parsed_url.netloc:
+        frappe.throw(_("The provided URL is not valid."))
+
+    # Fetch the image
+    try:
+        response = requests.get(url, timeout=5)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        logger.error(f"Image fetch failed for URL {url}: {e}")
+        frappe.throw(_("Failed to fetch image from URL."))
+
+    # Validate content type
+    content_type = response.headers.get("Content-Type", "")
+    if not content_type.startswith("image/"):
+        frappe.throw(_("The URL does not point to a valid image."))
+
+    # Validate image content
+    content = response.content
+    if not content:
+        frappe.throw(_("The image content is empty."))
+
+    # Validate file size
+    max_size = frappe.get_system_settings("max_file_size") or 25 * 1024 * 1024
+    if len(content) > max_size:
+        frappe.throw(_("The image size exceeds the maximum allowed size of {0} MB.").format(max_size // (1024 * 1024)))
+
+    # Determine file extension and name
+    extension = mimetypes.guess_extension(content_type) or ".png"
+    base_name = os.path.basename(parsed_url.path)
+    if not base_name:
+        base_name = "imported_image"
+    if not base_name.endswith(extension):
+        base_name += extension
+
+    # Optionally hash to avoid duplicates
+    hash_digest = hashlib.md5(content).hexdigest()
+    filename = f"{hash_digest}{extension}"
+
+    # Optimize image if requested
+    if optimize:
+        try:
+            from frappe.utils.image import optimize_image
+            content = optimize_image(content=content, content_type=content_type)
+        except Exception as e:
+            logger.warning(f"Image optimization failed: {e}")
+
+    # Create and insert the file document
+    file_doc = frappe.get_doc({
+        "doctype": "File",
+        "file_name": filename,
+        "content": content,
+        "is_private": 1,
+        "folder": folder,
+    }).insert(ignore_permissions=True)
+
+    logger.info(f"Image successfully imported as: {file_doc.file_url}")
+
+    return {
+        "file_url": file_doc.file_url,
+        "name": file_doc.name,
+    }
+
+def validate_url_scheme(scheme: str):
+    if scheme not in ["http", "https"]:
+        frappe.throw(_("Only HTTP and HTTPS URLs are allowed."))
+
+def get_max_allowed_size():
+    setting = frappe.get_system_settings("max_file_size")
+    return int(setting) if setting else 25 * 1024 * 1024
+
+def ensure_folder(path: str):
+    parts = path.strip("/").split("/")
+    parent = None
+    for part in parts:
+        if part == "Home" and parent is None:
+            parent = "Home"
+            continue
+        if not frappe.db.exists("File", {"file_name": part, "folder": parent or "Home"}):
+            frappe.get_doc({
+                "doctype": "File",
+                "file_name": part,
+                "is_folder": 1,
+                "folder": parent or "Home"
+            }).insert(ignore_permissions=True)
+        parent = f"{parent}/{part}" if parent else part
+
+def get_unique_filename(folder: str, original_name: str) -> str:
+    name, ext = os.path.splitext(original_name)
+    filename = original_name
+    if not frappe.db.exists("File", {"file_name": filename, "folder": folder}):
+        return filename
+    index = 1
+    while True:
+        filename = f"{name}({index}){ext}"
+        if not frappe.db.exists("File", {"file_name": filename, "folder": folder}):
+            return filename
+        index += 1
+
+def find_existing_file_with_same_content(folder: str, content: bytes):
+    files = frappe.get_all("File", filters={"folder": folder}, fields=["name", "file_name", "file_url"])
+    for f in files:
+        doc = frappe.get_doc("File", f.name)
+        try:
+            if doc.get_content() == content:
+                return doc
+        except Exception:
+            continue
+    return None

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -141,6 +141,7 @@ def upload_file():
 	method = frappe.form_dict.method
 	filename = frappe.form_dict.file_name
 	optimize = frappe.form_dict.optimize
+	upload_to_library = frappe.form_dict.get("upload_to_library")
 	content = None
 
 	if library_file := frappe.form_dict.get("library_file_name"):
@@ -197,6 +198,8 @@ def upload_file():
 				"file_url": file_url,
 				"is_private": cint(is_private),
 				"content": content,
+				"optimize": optimize,
+				"uploaded_to_library": upload_to_library,
 			}
 		).save(ignore_permissions=ignore_permissions)
 

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -216,6 +216,14 @@
 			@hide-browser="show_file_browser = false"
 		/>
 		<WebLink ref="web_link" v-if="show_web_link" @hide-web-link="show_web_link = false" />
+        <div v-if="show_web_link" class="form-check mt-2">
+            <input type="checkbox" id="upload-to-library" v-model="upload_to_library" class="form-check-input" />
+            <label for="upload-to-library" class="form-check-label">{{ __("Upload to Library") }}</label>
+        </div>
+        <div v-if="show_web_link && upload_to_library" class="form-check mt-2">
+            <input type="checkbox" id="optimize-image" v-model="optimize_image" class="form-check-input" />
+            <label for="optimize-image" class="form-check-label">{{ __("Optimize Image") }}</label>
+        </div>
 	</div>
 </template>
 
@@ -312,6 +320,8 @@ let google_drive_settings = ref({
 	enabled: false,
 });
 let wrapper_ready = ref(false);
+let upload_to_library = ref(false);
+let optimize_image = ref(false);
 
 // created
 if (props.allow_take_photo) {
@@ -524,19 +534,41 @@ function upload_via_file_browser() {
 		library_file_name: selected_file.value,
 	});
 }
-function upload_via_web_link() {
-	let file_url = web_link.value.url;
-	if (!file_url) {
-		frappe.msgprint(__("Invalid URL"));
-		close_dialog.value = true;
-		return Promise.reject();
-	}
-	file_url = decodeURI(file_url);
-	close_dialog.value = true;
-	return upload_file({
-		file_url,
-	});
-}
+async function upload_via_web_link() {
+    let file_url = web_link.value.url;
+    if (!file_url) {
+        frappe.msgprint(__("Invalid URL"));
+        close_dialog.value = true;
+        return Promise.reject();
+    }
+    file_url = decodeURI(file_url);
+    close_dialog.value = true;
+
+    // Se for para importar para a library, chama o endpoint novo
+    if (upload_to_library.value) {
+        return frappe.call({
+            method: "frappe.core.api.image_import.import_image_from_url",
+            args: {
+                url: file_url,
+                optimize: optimize_image.value,
+            },
+            callback: (r) => {
+                if (props.on_success) {
+                    props.on_success(r.message);
+                }
+            },
+            error: (err) => {
+                frappe.msgprint(__("Failed to import image: ") + err.message);
+            }
+        });
+    }
+
+    // Caso contrário, faz upload normal
+    return upload_file({
+        file_url,
+        private: !props.make_attachments_public
+    });
+} 
 function return_as_dataurl() {
 	let promises = files.value.map((file) =>
 		frappe.dom.file_to_base64(file.file_obj).then((dataurl) => {
@@ -668,6 +700,10 @@ function upload_file(file, i) {
 		if (props.method) {
 			form_data.append("method", props.method);
 		}
+
+		if (file.upload_to_library) {
+            form_data.append("upload_to_library", true);
+        }
 
 		if (file.optimize) {
 			form_data.append("optimize", true);

--- a/frappe/tests/test_image_import.py
+++ b/frappe/tests/test_image_import.py
@@ -1,0 +1,86 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from unittest.mock import patch, MagicMock
+from frappe.core.api import image_import
+
+
+class TestImageImport(FrappeTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.valid_url = "https://example.com/image.png"
+        cls.fake_image = b"fake_image_data"
+        cls.default_headers = {
+            "Content-Type": "image/png",
+            "Content-Length": str(len(cls.fake_image))
+        }
+
+    def mock_response(self, content=None, content_type="image/png", status_code=200, headers=None):
+        content = content if content is not None else self.fake_image
+        headers = headers or {
+            "Content-Type": content_type,
+            "Content-Length": str(len(content))
+        }
+        mock = MagicMock()
+        mock.status_code = status_code
+        mock.content = content
+        mock.headers = headers
+        mock.raise_for_status = MagicMock()
+        return mock
+
+    @patch("requests.get")
+    def test_import_valid_png_image(self, mock_get):
+        mock_get.return_value = self.mock_response()
+        result = image_import.import_image_from_url(url=self.valid_url, optimize=False)
+        self.assertIn("file_url", result)
+        self.assertIn(".png", result["file_url"])
+
+    @patch("requests.get")
+    @patch("frappe.utils.image.optimize_image")
+    def test_import_and_optimize_image(self, mock_optimize, mock_get):
+        mock_get.return_value = self.mock_response()
+        mock_optimize.return_value = b"optimized_image_data"
+        result = image_import.import_image_from_url(url=self.valid_url, optimize=True)
+        self.assertIn("file_url", result)
+
+    def test_invalid_url_format_throws(self):
+        with self.assertRaises(Exception) as ctx:
+            image_import.import_image_from_url(url="not a valid url")
+        self.assertIn("valid", str(ctx.exception))
+
+    @patch("requests.get")
+    def test_non_image_content_type_rejected(self, mock_get):
+        mock_get.return_value = self.mock_response(content_type="text/html")
+        with self.assertRaises(Exception) as ctx:
+            image_import.import_image_from_url(url="https://example.com/page.html")
+        self.assertIn("valid image", str(ctx.exception))
+
+    @patch("requests.get")
+    def test_empty_image_content_throws(self, mock_get):
+        mock_get.return_value = self.mock_response(content=b"")
+        with self.assertRaises(Exception):
+            image_import.import_image_from_url(url=self.valid_url)
+
+    @patch("requests.get")
+    @patch("frappe.get_system_settings")
+    def test_image_exceeding_max_size_throws(self, mock_settings, mock_get):
+        mock_settings.return_value = 5 * 1024 * 1024  # 5 MB
+        mock_get.return_value = self.mock_response(content=b"x" * (6 * 1024 * 1024))
+        with self.assertRaises(Exception):
+            image_import.import_image_from_url(url=self.valid_url)
+
+    @patch("requests.get")
+    def test_unsupported_file_format_throws(self, mock_get):
+        mock_get.return_value = self.mock_response(content_type="image/bmp")
+        with self.assertRaises(Exception) as ctx:
+            image_import.import_image_from_url(url=self.valid_url)
+        self.assertIn("Unsupported file format", str(ctx.exception))
+
+    @patch("frappe.db.exists")
+    @patch("frappe.get_doc")
+    def test_folder_creation(self, mock_get_doc, mock_db_exists):
+        mock_db_exists.side_effect = lambda doctype, filters: False
+        mock_get_doc.return_value = MagicMock()
+
+        image_import.ensure_folder("Home/Library/TestFolder")
+        mock_get_doc.assert_called()


### PR DESCRIPTION
Added support for importing images via web URL in the FileUploader, including optional upload to the users' Library and Image optimization. On the backend, implemented validation, download, and storage as private File documents, preserving original filenames with duplication handling. Covered with integration and Cypress frontend tests that pass locally.

Here is a youtube video with a demonstration of the implemented feature: https://youtu.be/NlCwu9vZlI4?si=zZtnsdh8N04c8CWF&t=28

Commit message follows [Conventional Commits 1.0.0-beta.3](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)

Closes #32415 
