### PR TITLE
fix: show communication based on recipient and sender

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -490,8 +490,8 @@ def get_permission_query_conditions_for_communication(user):
 			return """`tabCommunication`.communication_medium!='Email'"""
 
 		email_accounts = ['"{}"'.format(account.get("email_account")) for account in accounts]
-		return """`tabCommunication`.email_account in ({email_accounts})""".format(
-			email_accounts=",".join(email_accounts)
+		return """`tabCommunication`.email_account in ({email_accounts}) or `tabCommunication`.recipients LIKE '%{user}%' or `tabCommunication`.sender LIKE '%{user}%'""".format(
+			email_accounts=",".join(email_accounts), user=user
 		)
 
 


### PR DESCRIPTION
There are two users A@example.com and B@example.com who have respective email accounts. 
If there is a email addressed to both the A and B it is only visible to one of them cause permission query condition did a check with the link field email account which can only carry one of them as value. 

ref ticket https://support.frappe.io/helpdesk/tickets/38900