### PR TITLE
feat: `get_settings`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1017,7 +1017,7 @@ def get_cached_value(
 	return values
 
 
-def get_settings(setting: str, fieldname: str, *, as_dict: bool = True, cache=True):
+def get_settings(setting: str, fieldname: str, /, *, as_dict: bool = False, cache=True):
 	"""Return the value associated with the given fieldname from settings DocType.
 
 	Usage:

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1017,6 +1017,19 @@ def get_cached_value(
 	return values
 
 
+def get_settings(setting: str, fieldname: str, *, as_dict: bool = True, cache=True):
+	"""Return the value associated with the given fieldname from settings DocType.
+
+	Usage:
+		telemetry_enabled = frappe.get_settings("System Settings", "telemetry_enabled")
+	"""
+
+	if cache:
+		return get_cached_value(setting, setting, fieldname=fieldname, as_dict=as_dict)
+	else:
+		return frappe.db.get_single_value(setting, fieldname=fieldname, cache=False)
+
+
 def get_last_doc(
 	doctype,
 	filters: FilterSignature | None = None,

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1048,7 +1048,7 @@ def sign_up(email: str, full_name: str, redirect_to: str) -> tuple[int, str]:
 		user.insert()
 
 		# set default signup role as per Portal Settings
-		default_role = frappe.db.get_single_value("Portal Settings", "default_role")
+		default_role = frappe.get_settings("Portal Settings", "default_role")
 		if default_role:
 			user.add_roles(default_role)
 

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -538,9 +538,7 @@ def _set_amended_name(doc):
 		"Amended Document Naming Settings", {"document_type": doc.doctype}, "action", cache=True
 	)
 	if not amend_naming_rule:
-		amend_naming_rule = frappe.db.get_single_value(
-			"Document Naming Settings", "default_amend_naming", cache=True
-		)
+		amend_naming_rule = frappe.get_settings("Document Naming Settings", "default_amend_naming")
 
 	if amend_naming_rule == "Default Naming":
 		return

--- a/frappe/printing/doctype/print_settings/print_settings.py
+++ b/frappe/printing/doctype/print_settings/print_settings.py
@@ -75,9 +75,4 @@ class PrintSettings(Document):
 
 @frappe.whitelist()
 def is_print_server_enabled():
-	if not hasattr(frappe.local, "enable_print_server"):
-		frappe.local.enable_print_server = cint(
-			frappe.db.get_single_value("Print Settings", "enable_print_server")
-		)
-
-	return frappe.local.enable_print_server
+	return frappe.get_settings("Print Settings", "enable_print_server")

--- a/frappe/tests/test_test_utils.py
+++ b/frappe/tests/test_test_utils.py
@@ -25,10 +25,10 @@ class TestTestUtils(IntegrationTestCase):
 		with IntegrationTestCase.change_settings(
 			"System Settings", {"logout_on_password_reset": int(not current_setting)}
 		):
-			updated_settings = frappe.get_system_settings("logout_on_password_reset")
+			updated_settings = frappe.get_settings("System Settings", "logout_on_password_reset")
 			self.assertNotEqual(current_setting, updated_settings)
 
-		restored_settings = frappe.get_system_settings("logout_on_password_reset")
+		restored_settings = frappe.get_settings("System Settings", "logout_on_password_reset")
 		self.assertEqual(current_setting, restored_settings)
 
 	def test_time_freezing(self):

--- a/frappe/website/doctype/blog_settings/blog_settings.py
+++ b/frappe/website/doctype/blog_settings/blog_settings.py
@@ -39,8 +39,8 @@ class BlogSettings(Document):
 
 
 def get_like_limit():
-	return frappe.db.get_single_value("Blog Settings", "like_limit") or 5
+	return frappe.get_settings("Blog Settings", "like_limit") or 5
 
 
 def get_comment_limit():
-	return frappe.db.get_single_value("Blog Settings", "comment_limit") or 5
+	return frappe.get_settings("Blog Settings", "comment_limit") or 5

--- a/frappe/www/sitemap.py
+++ b/frappe/www/sitemap.py
@@ -41,7 +41,7 @@ def get_public_pages_from_doctypes():
 	doctypes_with_web_view = get_doctypes_with_web_view()
 
 	robot_parser_instance = None
-	if robots_txt := frappe.db.get_single_value("Website Settings", "robots_txt"):
+	if robots_txt := frappe.get_settings("Website Settings", "robots_txt"):
 		robot_parser_instance = robotparser.RobotFileParser()
 		robot_parser_instance.parse(robots_txt.splitlines())
 


### PR DESCRIPTION
Introduce `get_settings` to get cached single values. Settings should be cached by default. This is same as `get_cached_value` but isn't awkward to use with `None` or repeating doctype name. 