### PR TITLE
feat: add on_session_end hook to handle session end events in Frappe

### DIFF
--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -97,6 +97,7 @@ def delete_session(sid=None, user=None, reason="Session Expired"):
 	logout_feed(user, reason)
 	frappe.db.delete("Sessions", {"sid": sid})
 	frappe.db.commit()
+	frappe.auth.LoginManager().run_trigger("on_session_end")
 
 	frappe.cache.hdel("session", sid)
 


### PR DESCRIPTION
This PR introduces a new on_session_end hook in Frappe, which is triggered whenever a user’s session ends. This includes both explicit logouts and session expiry due to inactivity.

# hooks.py
on_session_end = "my_app.session_hooks.cleanup_on_session_end"

