### PR TITLE
fix: custom number card duration format issue

### DIFF
--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -230,6 +230,17 @@ export default class NumberCardWidget extends Widget {
 			const shortened_number = frappe.utils.shorten_number(this.number, default_country, 5);
 			number_parts = shortened_number.split(" ");
 		}
+
+		// done to add duration support in number card
+		if (df.fieldtype === "Duration") {
+			const duration_options = {
+				hide_days: df.hide_days ? 1 : 0,
+				hide_seconds: df.hide_seconds ? 1 : 0
+			};
+			this.formatted_number = frappe.utils.get_formatted_duration(this.number, duration_options);
+			return;
+		}		
+
 		const symbol = number_parts[1] || "";
 		// done to add multicurrency support in number card
 		if (this.card_doc.currency) {

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -235,11 +235,14 @@ export default class NumberCardWidget extends Widget {
 		if (df.fieldtype === "Duration") {
 			const duration_options = {
 				hide_days: df.hide_days ? 1 : 0,
-				hide_seconds: df.hide_seconds ? 1 : 0
+				hide_seconds: df.hide_seconds ? 1 : 0,
 			};
-			this.formatted_number = frappe.utils.get_formatted_duration(this.number, duration_options);
+			this.formatted_number = frappe.utils.get_formatted_duration(
+				this.number,
+				duration_options
+			);
 			return;
-		}		
+		}
 
 		const symbol = number_parts[1] || "";
 		// done to add multicurrency support in number card


### PR DESCRIPTION
fix: custom number card duration format issue

Explaination : 
When we can create custom number card and choose fieldtype as a Duration then when ever number is very long then number convert into currency but actual they have convert into the duration format so it is not working so fix that issue and also please check video of the below showcase the difference

before code implement result :
[Screencast from 2025-06-08 10-33-20.webm](https://github.com/user-attachments/assets/b12e65f9-6c8d-4830-a0e7-4c1c647e5790)

after code implement result :
[Screencast from 2025-06-08 10-32-37.webm](https://github.com/user-attachments/assets/91bf7713-4532-47bb-84f6-37b575067b7c)

