### PR TITLE
feat: add support for client_credentials in frappe oauth

### DIFF
--- a/frappe/integrations/doctype/oauth_client/oauth_client.json
+++ b/frappe/integrations/doctype/oauth_client/oauth_client.json
@@ -37,10 +37,11 @@
    "reqd": 1
   },
   {
+   "depends_on": "eval:doc.grant_type==\"Client Credentials\";",
    "fieldname": "user",
    "fieldtype": "Link",
-   "hidden": 1,
    "label": "User",
+   "mandatory_depends_on": "eval:doc.grant_type==\"Client Credentials\"",
    "options": "User"
   },
   {
@@ -101,7 +102,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Grant Type",
-   "options": "Authorization Code\nImplicit"
+   "options": "Authorization Code\nImplicit\nClient Credentials"
   },
   {
    "fieldname": "cb_2",
@@ -124,7 +125,7 @@
   }
  ],
  "links": [],
- "modified": "2024-04-29 12:07:07.946980",
+ "modified": "2025-06-09 09:22:45.298346",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Client",
@@ -143,6 +144,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/integrations/doctype/oauth_client/oauth_client.py
+++ b/frappe/integrations/doctype/oauth_client/oauth_client.py
@@ -22,7 +22,7 @@ class OAuthClient(Document):
 		client_id: DF.Data | None
 		client_secret: DF.Data | None
 		default_redirect_uri: DF.Data
-		grant_type: DF.Literal["Authorization Code", "Implicit"]
+		grant_type: DF.Literal["Authorization Code", "Implicit", "Client Credentials"]
 		redirect_uris: DF.Text | None
 		response_type: DF.Literal["Code", "Token"]
 		scopes: DF.Text

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -195,7 +195,7 @@ class OAuthWebRequestValidator(RequestValidator):
 	def validate_grant_type(self, client_id, grant_type, client, request, *args, **kwargs):
 		# Clients should only be allowed to use one type of grant.
 		# In this case, it must be "authorization_code" or "refresh_token"
-		return grant_type in ["authorization_code", "refresh_token", "password"]
+		return grant_type in ["authorization_code", "refresh_token", "password", "client_credentials"]
 
 	def save_bearer_token(self, token, request, *args, **kwargs):
 		# Remember to associate it with request.scopes, request.user and
@@ -207,15 +207,20 @@ class OAuthWebRequestValidator(RequestValidator):
 		otoken = frappe.new_doc("OAuth Bearer Token")
 		otoken.client = request.client["name"]
 		try:
-			otoken.user = (
-				request.user
-				if request.user
-				else frappe.db.get_value(
+			if request.user:
+				otoken.user = request.user
+			elif request.body and request.body.get("refresh_token"):
+				otoken.user = frappe.db.get_value(
 					"OAuth Bearer Token",
 					{"refresh_token": request.body.get("refresh_token")},
 					"user",
 				)
-			)
+			elif request.grant_type == "client_credentials":
+				otoken.user = frappe.db.get_value(
+					"OAuth Client",
+					request.client["name"],
+					"user"
+				)
 		except Exception:
 			otoken.user = frappe.session.user
 


### PR DESCRIPTION

Closes: https://github.com/frappe/frappe/issues/32841#issue-3129100093


This PR adds support for client_credentials grant type to frappe oauth. Since it was already implemented as described [here](https://discuss.frappe.io/t/oauth-2-0-client-credentials-grant-for-server-to-server-api-calls/138978/4?u=vijaywm), the changes are:
- add "client_credentials" in the allowed grant types
- on creation of OAuth Bearer Token, if grant_type is client_credentials, then set the user to user set in OAuth Client