### PR TITLE
perf: Avoid setting defaults on `new_doc`

### DIFF
--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -28,7 +28,9 @@ def get_new_doc(doctype, parent_doc=None, parentfield=None, as_dict=False):
 	if as_dict:
 		return doc
 	else:
-		return frappe.get_doc(doc)
+		doc = frappe.get_doc(doc)
+		doc.flags.defaults_set = True
+		return doc
 
 
 def make_new_doc(doctype):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -944,7 +944,7 @@ class Document(BaseDocument, DocRef):
 		return permissions
 
 	def _set_defaults(self):
-		if frappe.flags.in_import:
+		if frappe.flags.in_import or self.flags.defaults_set:
 			return
 
 		if self.is_new():


### PR DESCRIPTION
Following piece of code sets defaults TWICE, this is done to make
`get_doc(...).insert()` similar to `new_doc(...).insert()` however this
is unnecessary AND incorrect when doing on new doc with defaults already
set.

```
doc = frappe.new_doc(...)
doc.insert()
```

Note: This is potentially breaking for code that was erasing defaults (?)

TODO:
- [ ] Run ERPNext CI
