### PR TITLE
perf: Make get_query query mutable

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -75,6 +75,7 @@ class Engine:
 			self.query = qb.from_(self.table).delete()
 		else:
 			self.query = qb.from_(self.table)
+			self.query.immutable = False
 			self.apply_fields(fields)
 
 		self.apply_filters(filters)
@@ -95,6 +96,7 @@ class Engine:
 		if group_by:
 			self.query = self.query.groupby(group_by)
 
+		self.query.immutable = True
 		return self.query
 
 	def validate_doctype(self):


### PR DESCRIPTION
pypika internally keeps copying query builder object because everything
is supposed to be immutable in pypika design, this however is terribly
slow. Often query generation takes more time than query execution.

This PR makes query builder mutable inside `get_query` function to avoid
copying while applying fields, filters, limit, order etc.

It's marked as immutable again when sending it back to users of the API.

This is ~1.15x faster.
