### PR TITLE
fix: setup wizard fixes

### DIFF
--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -36,6 +36,10 @@ class InstalledApplications(Document):
 			):
 				has_setup_wizard = 1
 
+			setup_complete = app_wise_setup_details.get(app.get("app_name")) or 0
+			if app.get("app_name") == "india_compliance":
+				setup_complete = app_wise_setup_details.get("erpnext") or 0
+
 			self.append(
 				"installed_applications",
 				{
@@ -43,7 +47,7 @@ class InstalledApplications(Document):
 					"app_version": app.get("version") or "UNVERSIONED",
 					"git_branch": app.get("branch") or "UNVERSIONED",
 					"has_setup_wizard": has_setup_wizard,
-					"is_setup_complete": app_wise_setup_details.get(app.get("app_name")) or 0,
+					"is_setup_complete": setup_complete,
 				},
 			)
 

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -132,7 +132,8 @@ frappe.router = {
 
 		if (
 			frappe.boot.setup_complete ||
-			(current_app && frappe.boot.setup_wizard_not_required_apps?.includes(current_app))
+			(current_app && frappe.boot.setup_wizard_not_required_apps?.includes(current_app)) ||
+			(current_app && frappe.boot.setup_wizard_completed_apps?.includes(current_app))
 		) {
 			!frappe.re_route["setup-wizard"] && (frappe.re_route["setup-wizard"] = "app");
 		} else if (!sub_path.startsWith("setup-wizard")) {


### PR DESCRIPTION
fix: setup wizard routing for completed apps
* if `erpnext` setup is complete and `india_compliance` setup is not complete, then opening `erpnext` should show desk, instead of showing the setup wizard

fix: setup completion logic for india_compliance app
* `india_compliance` app uses the `erpnext` setup wizard stages, so it doesn't have its own stages to display when opening the app
* issue is only replicable when `india_compliance` is installed after `erpnext` setup is complete