### PR TITLE
Revert "fix: Pin web workers by default"

### DIFF
--- a/frappe/_optimizations.py
+++ b/frappe/_optimizations.py
@@ -93,9 +93,7 @@ def freeze_gc():
 
 
 def optimize_for_gil_contention():
-	from frappe.utils import sbool
-
-	if not bool(sbool(os.environ.get("FRAPPE_PERF_PIN_WORKERS", True))):
+	if not os.environ.get("FRAPPE_PERF_PIN_WORKERS"):
 		return
 
 	if "gunicorn" not in str(sys.argv[0]):


### PR DESCRIPTION
Reverts frappe/frappe#31739

Don't see any major benefits, but do see bad effects of this in some cases. So better to enable this only for benchmarking. 