### PR TITLE
fix: always restore old user

### DIFF
--- a/frappe/tests/classes/context_managers.py
+++ b/frappe/tests/classes/context_managers.py
@@ -46,12 +46,14 @@ def freeze_time(time_to_freeze: Any, is_utc: bool = False, *args: Any, **kwargs:
 
 @UnitTestCase.registerAs(staticmethod)
 @contextmanager
-def set_user(user: str) -> None:
+def set_user(user: str):
 	"""Temporarily: set the user."""
-	old_user = frappe.session.user
-	frappe.set_user(user)
-	yield
-	frappe.set_user(old_user)
+	try:
+		old_user = frappe.session.user
+		frappe.set_user(user)
+		yield
+	finally:
+		frappe.set_user(old_user)
 
 
 @UnitTestCase.registerAs(staticmethod)


### PR DESCRIPTION
failing of one test should not cause subsequent tests to fail

this was a regression in https://github.com/frappe/frappe/pull/28041