### PR TITLE
fix: check permissions as per specified user

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -116,6 +116,8 @@ class DatabaseQuery:
 		*,
 		parent_doctype=None,
 	) -> list:
+		self.user = user or frappe.session.user
+
 		if not ignore_permissions:
 			self.check_read_permission(self.doctype, parent_doctype=parent_doctype)
 
@@ -167,7 +169,6 @@ class DatabaseQuery:
 		self.as_list = as_list
 		self.ignore_ifnull = ignore_ifnull
 		self.flags.ignore_permissions = ignore_permissions
-		self.user = user or frappe.session.user
 		self.update = update
 		self.user_settings_fields = copy.deepcopy(self.fields)
 		self.run = run


### PR DESCRIPTION
Permitted docs for user inaccurately used to show all documents for a user who doesn't have the permission for the specified doctype at all:

![image](https://github.com/user-attachments/assets/d141c0bb-bb6f-4697-87e2-bafc879afb37)

In above example, the user actually doesn't have any permission for Employee at all.

This happened because the initial check_read_permission assumed frappe.session.user as the user to check permission for, instead of user specified in arguments.

After fix: 
![image](https://github.com/user-attachments/assets/c88a2b85-03ba-426c-bd1f-2bef3494462a)
