### PR TITLE
fix: set print format as default

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -140,11 +140,10 @@ class PrintFormat(Document):
 
 
 @frappe.whitelist()
-def make_default(name):
+def make_default(name: str):
 	"""Set print format as default"""
-	frappe.has_permission("Print Format", "write", throw=True)
-
 	print_format = frappe.get_doc("Print Format", name)
+	print_format.check_permission("write")
 
 	doctype = frappe.get_doc("DocType", print_format.doc_type)
 	if doctype.custom:


### PR DESCRIPTION
- add param type hint
- check write perms on the specific Print Format
