### PR TITLE
chore: Drop empty UnitTestCases

### DIFF
--- a/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
@@ -2,19 +2,10 @@
 # License: MIT. See LICENSE
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import make_test_records
 
 TEST_DOCTYPE = "Assignment Test"
-
-
-class UnitTestAssignmentRule(UnitTestCase):
-	"""
-	Unit tests for AssignmentRule.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestAutoAssign(IntegrationTestCase):

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -9,7 +9,7 @@ from frappe.automation.doctype.auto_repeat.auto_repeat import (
 	week_map,
 )
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, add_months, getdate, today
 
 if TYPE_CHECKING:
@@ -30,15 +30,6 @@ def add_custom_fields() -> "CustomField":
 	return create_custom_field("ToDo", df) or frappe.get_doc(
 		"Custom Field", dict(fieldname=df["fieldname"], dt="ToDo")
 	)
-
-
-class UnitTestAutoRepeat(UnitTestCase):
-	"""
-	Unit tests for AutoRepeat.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestAutoRepeat(IntegrationTestCase):

--- a/frappe/automation/doctype/milestone/test_milestone.py
+++ b/frappe/automation/doctype/milestone/test_milestone.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestMilestone(UnitTestCase):
-	"""
-	Unit tests for Milestone.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestMilestone(IntegrationTestCase):

--- a/frappe/automation/doctype/milestone_tracker/test_milestone_tracker.py
+++ b/frappe/automation/doctype/milestone_tracker/test_milestone_tracker.py
@@ -2,16 +2,7 @@
 # License: MIT. See LICENSE
 import frappe
 import frappe.cache_manager
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestMilestoneTracker(UnitTestCase):
-	"""
-	Unit tests for MilestoneTracker.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestMilestoneTracker(IntegrationTestCase):

--- a/frappe/automation/doctype/reminder/test_reminder.py
+++ b/frappe/automation/doctype/reminder/test_reminder.py
@@ -4,17 +4,8 @@
 import frappe
 from frappe.automation.doctype.reminder.reminder import create_new_reminder, send_reminders
 from frappe.desk.doctype.notification_log.notification_log import get_notification_logs
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, now_datetime
-
-
-class UnitTestReminder(UnitTestCase):
-	"""
-	Unit tests for Reminder.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestReminder(IntegrationTestCase):

--- a/frappe/contacts/doctype/address/test_address.py
+++ b/frappe/contacts/doctype/address/test_address.py
@@ -4,16 +4,7 @@ from functools import partial
 
 import frappe
 from frappe.contacts.doctype.address.address import address_query, get_address_display
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestAddress(UnitTestCase):
-	"""
-	Unit tests for Address.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestAddress(IntegrationTestCase):

--- a/frappe/contacts/doctype/address_template/test_address_template.py
+++ b/frappe/contacts/doctype/address_template/test_address_template.py
@@ -2,17 +2,8 @@
 # License: MIT. See LICENSE
 import frappe
 from frappe.contacts.doctype.address_template.address_template import get_default_address_template
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils.jinja import validate_template
-
-
-class UnitTestAddressTemplate(UnitTestCase):
-	"""
-	Unit tests for AddressTemplate.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestAddressTemplate(IntegrationTestCase):

--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -3,18 +3,9 @@
 import frappe
 from frappe.contacts.doctype.contact.contact import get_full_name
 from frappe.email import get_contact_list
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Contact", "Salutation"]
-
-
-class UnitTestContact(UnitTestCase):
-	"""
-	Unit tests for Contact.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestContact(IntegrationTestCase):

--- a/frappe/contacts/doctype/gender/test_gender.py
+++ b/frappe/contacts/doctype/gender/test_gender.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestGender(UnitTestCase):
-	"""
-	Unit tests for Gender.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestGender(IntegrationTestCase):

--- a/frappe/contacts/doctype/salutation/test_salutation.py
+++ b/frappe/contacts/doctype/salutation/test_salutation.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestSalutation(UnitTestCase):
-	"""
-	Unit tests for Salutation.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestSalutation(IntegrationTestCase):

--- a/frappe/core/doctype/access_log/test_access_log.py
+++ b/frappe/core/doctype/access_log/test_access_log.py
@@ -14,17 +14,8 @@ from frappe.core.doctype.data_import.data_import import export_csv
 from frappe.core.doctype.user.user import generate_keys
 
 # imports - standard imports
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import cstr, get_site_url
-
-
-class UnitTestAccessLog(UnitTestCase):
-	"""
-	Unit tests for AccessLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestAccessLog(IntegrationTestCase):

--- a/frappe/core/doctype/activity_log/test_activity_log.py
+++ b/frappe/core/doctype/activity_log/test_activity_log.py
@@ -4,16 +4,7 @@ import time
 
 import frappe
 from frappe.auth import CookieManager, LoginManager
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestActivityLog(UnitTestCase):
-	"""
-	Unit tests for ActivityLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestActivityLog(IntegrationTestCase):

--- a/frappe/core/doctype/api_request_log/test_api_request_log.py
+++ b/frappe/core/doctype/api_request_log/test_api_request_log.py
@@ -2,22 +2,13 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list
 EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-
-
-class UnitTestAPIRequestLog(UnitTestCase):
-	"""
-	Unit tests for APIRequestLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class IntegrationTestAPIRequestLog(IntegrationTestCase):

--- a/frappe/core/doctype/audit_trail/test_audit_trail.py
+++ b/frappe/core/doctype/audit_trail/test_audit_trail.py
@@ -2,17 +2,8 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import today
-
-
-class UnitTestAuditTrail(UnitTestCase):
-	"""
-	Unit tests for AuditTrail.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestAuditTrail(IntegrationTestCase):

--- a/frappe/core/doctype/comment/test_comment.py
+++ b/frappe/core/doctype/comment/test_comment.py
@@ -4,18 +4,9 @@ import json
 
 import frappe
 from frappe.templates.includes.comments.comments import add_comment
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.tests.test_model_utils import set_user
 from frappe.website.doctype.blog_post.test_blog_post import make_test_blog
-
-
-class UnitTestComment(UnitTestCase):
-	"""
-	Unit tests for Comment.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestComment(IntegrationTestCase):

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -6,20 +6,11 @@ import frappe
 from frappe.core.doctype.communication.communication import Communication, get_emails, parse_email
 from frappe.core.doctype.communication.email import add_attachments, make
 from frappe.email.doctype.email_queue.email_queue import EmailQueue
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 if TYPE_CHECKING:
 	from frappe.contacts.doctype.contact.contact import Contact
 	from frappe.email.doctype.email_account.email_account import EmailAccount
-
-
-class UnitTestCommunication(UnitTestCase):
-	"""
-	Unit tests for Communication.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestCommunication(IntegrationTestCase):

--- a/frappe/core/doctype/custom_docperm/test_custom_docperm.py
+++ b/frappe/core/doctype/custom_docperm/test_custom_docperm.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestCustomDocperm(UnitTestCase):
-	"""
-	Unit tests for CustomDocperm.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestCustomDocPerm(IntegrationTestCase):

--- a/frappe/core/doctype/custom_role/test_custom_role.py
+++ b/frappe/core/doctype/custom_role/test_custom_role.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestCustomRole(UnitTestCase):
-	"""
-	Unit tests for CustomRole.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestCustomRole(IntegrationTestCase):

--- a/frappe/core/doctype/data_export/test_data_exporter.py
+++ b/frappe/core/doctype/data_export/test_data_exporter.py
@@ -2,16 +2,7 @@
 # License: MIT. See LICENSE
 import frappe
 from frappe.core.doctype.data_export.exporter import DataExporter
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDataExport(UnitTestCase):
-	"""
-	Unit tests for DataExport.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDataExporter(IntegrationTestCase):

--- a/frappe/core/doctype/data_import/test_data_import.py
+++ b/frappe/core/doctype/data_import/test_data_import.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDataImport(UnitTestCase):
-	"""
-	Unit tests for DataImport.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDataImport(IntegrationTestCase):

--- a/frappe/core/doctype/data_import/test_exporter.py
+++ b/frappe/core/doctype/data_import/test_exporter.py
@@ -3,18 +3,9 @@
 import frappe
 from frappe.core.doctype.data_import.exporter import Exporter
 from frappe.core.doctype.data_import.test_importer import create_doctype_if_not_exists
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 doctype_name = "DocType for Export"
-
-
-class UnitTestDataImport(UnitTestCase):
-	"""
-	Unit tests for DataImport.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestExporter(IntegrationTestCase):

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -2,20 +2,11 @@
 # License: MIT. See LICENSE
 import frappe
 from frappe.core.doctype.data_import.importer import Importer
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.tests.test_query_builder import db_type_is, run_only_if
 from frappe.utils import format_duration, getdate
 
 doctype_name = "DocType for Import"
-
-
-class UnitTestDataImport(UnitTestCase):
-	"""
-	Unit tests for DataImport.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestImporter(IntegrationTestCase):

--- a/frappe/core/doctype/data_import_log/test_data_import_log.py
+++ b/frappe/core/doctype/data_import_log/test_data_import_log.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDataImportLog(UnitTestCase):
-	"""
-	Unit tests for DataImportLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDataImportLog(IntegrationTestCase):

--- a/frappe/core/doctype/deleted_document/test_deleted_document.py
+++ b/frappe/core/doctype/deleted_document/test_deleted_document.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDeletedDocument(UnitTestCase):
-	"""
-	Unit tests for DeletedDocument.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDeletedDocument(IntegrationTestCase):

--- a/frappe/core/doctype/docshare/test_docshare.py
+++ b/frappe/core/doctype/docshare/test_docshare.py
@@ -4,18 +4,9 @@
 import frappe
 import frappe.share
 from frappe.automation.doctype.auto_repeat.test_auto_repeat import create_submittable_doctype
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["User"]
-
-
-class UnitTestDocshare(UnitTestCase):
-	"""
-	Unit tests for Docshare.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestDocShare(IntegrationTestCase):

--- a/frappe/core/doctype/doctype/boilerplate/test_controller._py
+++ b/frappe/core/doctype/doctype/boilerplate/test_controller._py
@@ -2,7 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 
 # On IntegrationTestCase, the doctype test records and all
@@ -11,14 +11,6 @@ from frappe.tests import IntegrationTestCase, UnitTestCase
 EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
-
-class UnitTest{classname}(UnitTestCase):
-	"""
-	Unit tests for {classname}.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class IntegrationTest{classname}(IntegrationTestCase):

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -25,17 +25,8 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.desk.form.load import getdoc
 from frappe.model.delete_doc import delete_controllers
 from frappe.model.sync import remove_orphan_doctypes
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import get_table_name
-
-
-class UnitTestDoctype(UnitTestCase):
-	"""
-	Unit tests for Doctype.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestDocType(IntegrationTestCase):

--- a/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDocumentNamingRule(UnitTestCase):
-	"""
-	Unit tests for DocumentNamingRule.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDocumentNamingRule(IntegrationTestCase):

--- a/frappe/core/doctype/document_naming_rule_condition/test_document_naming_rule_condition.py
+++ b/frappe/core/doctype/document_naming_rule_condition/test_document_naming_rule_condition.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDocumentNamingRuleCondition(UnitTestCase):
-	"""
-	Unit tests for DocumentNamingRuleCondition.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDocumentNamingRuleCondition(IntegrationTestCase):

--- a/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
@@ -7,17 +7,8 @@ from frappe.core.doctype.document_naming_settings.document_naming_settings impor
 	DocumentNamingSettings,
 )
 from frappe.model.naming import NamingSeries, get_default_naming_series
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import cint
-
-
-class UnitTestDocumentNamingSettings(UnitTestCase):
-	"""
-	Unit tests for DocumentNamingSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestNamingSeries(IntegrationTestCase):

--- a/frappe/core/doctype/document_share_key/test_document_share_key.py
+++ b/frappe/core/doctype/document_share_key/test_document_share_key.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDocumentShareKey(UnitTestCase):
-	"""
-	Unit tests for DocumentShareKey.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDocumentShareKey(IntegrationTestCase):

--- a/frappe/core/doctype/domain/test_domain.py
+++ b/frappe/core/doctype/domain/test_domain.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDomain(UnitTestCase):
-	"""
-	Unit tests for Domain.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDomain(IntegrationTestCase):

--- a/frappe/core/doctype/error_log/test_error_log.py
+++ b/frappe/core/doctype/error_log/test_error_log.py
@@ -5,17 +5,8 @@ from unittest.mock import patch
 from ldap3.core.exceptions import LDAPException, LDAPInappropriateAuthenticationResult
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils.error import _is_ldap_exception, guess_exception_source
-
-
-class UnitTestErrorLog(UnitTestCase):
-	"""
-	Unit tests for ErrorLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestErrorLog(IntegrationTestCase):

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -20,7 +20,7 @@ from frappe.core.doctype.file.exceptions import FileTypeNotAllowed
 from frappe.core.doctype.file.utils import get_corrupted_image_msg, get_extension
 from frappe.desk.form.utils import add_comment
 from frappe.exceptions import ValidationError
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import get_files_path, set_request
 
 if TYPE_CHECKING:
@@ -59,15 +59,6 @@ def make_test_image_file(private=False):
 		yield _test_file
 	finally:
 		_test_file.delete()
-
-
-class UnitTestFile(UnitTestCase):
-	"""
-	Unit tests for File.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestSimpleFile(IntegrationTestCase):

--- a/frappe/core/doctype/installed_applications/test_installed_applications.py
+++ b/frappe/core/doctype/installed_applications/test_installed_applications.py
@@ -6,16 +6,7 @@ from frappe.core.doctype.installed_applications.installed_applications import (
 	InvalidAppOrder,
 	update_installed_apps_order,
 )
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestInstalledApplications(UnitTestCase):
-	"""
-	Unit tests for InstalledApplications.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestInstalledApplications(IntegrationTestCase):

--- a/frappe/core/doctype/language/test_language.py
+++ b/frappe/core/doctype/language/test_language.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestLanguage(UnitTestCase):
-	"""
-	Unit tests for Language.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestLanguage(IntegrationTestCase):

--- a/frappe/core/doctype/log_setting_user/test_log_setting_user.py
+++ b/frappe/core/doctype/log_setting_user/test_log_setting_user.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestLogSettingUser(UnitTestCase):
-	"""
-	Unit tests for LogSettingUser.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestLogSettingUser(IntegrationTestCase):

--- a/frappe/core/doctype/log_settings/test_log_settings.py
+++ b/frappe/core/doctype/log_settings/test_log_settings.py
@@ -5,17 +5,8 @@ from datetime import datetime
 
 import frappe
 from frappe.core.doctype.log_settings.log_settings import _supports_log_clearing, run_log_clean_up
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, now_datetime
-
-
-class UnitTestLogSettings(UnitTestCase):
-	"""
-	Unit tests for LogSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestLogSettings(IntegrationTestCase):

--- a/frappe/core/doctype/module_def/test_module_def.py
+++ b/frappe/core/doctype/module_def/test_module_def.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestModuleDef(UnitTestCase):
-	"""
-	Unit tests for ModuleDef.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestModuleDef(IntegrationTestCase):

--- a/frappe/core/doctype/module_profile/test_module_profile.py
+++ b/frappe/core/doctype/module_profile/test_module_profile.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestModuleProfile(UnitTestCase):
-	"""
-	Unit tests for ModuleProfile.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestModuleProfile(IntegrationTestCase):

--- a/frappe/core/doctype/navbar_item/test_navbar_item.py
+++ b/frappe/core/doctype/navbar_item/test_navbar_item.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestNavbarItem(UnitTestCase):
-	"""
-	Unit tests for NavbarItem.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestNavbarItem(IntegrationTestCase):

--- a/frappe/core/doctype/navbar_settings/test_navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/test_navbar_settings.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestNavbarSettings(UnitTestCase):
-	"""
-	Unit tests for NavbarSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestNavbarSettings(IntegrationTestCase):

--- a/frappe/core/doctype/package/test_package.py
+++ b/frappe/core/doctype/package/test_package.py
@@ -5,16 +5,7 @@ import json
 import os
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPackage(UnitTestCase):
-	"""
-	Unit tests for Package.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPackage(IntegrationTestCase):

--- a/frappe/core/doctype/package_import/test_package_import.py
+++ b/frappe/core/doctype/package_import/test_package_import.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPackageImport(UnitTestCase):
-	"""
-	Unit tests for PackageImport.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPackageImport(IntegrationTestCase):

--- a/frappe/core/doctype/package_release/test_package_release.py
+++ b/frappe/core/doctype/package_release/test_package_release.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPackageRelease(UnitTestCase):
-	"""
-	Unit tests for PackageRelease.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPackageRelease(IntegrationTestCase):

--- a/frappe/core/doctype/page/test_page.py
+++ b/frappe/core/doctype/page/test_page.py
@@ -5,16 +5,7 @@ import unittest
 from unittest.mock import patch
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPage(UnitTestCase):
-	"""
-	Unit tests for Page.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPage(IntegrationTestCase):

--- a/frappe/core/doctype/patch_log/test_patch_log.py
+++ b/frappe/core/doctype/patch_log/test_patch_log.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPatchLog(UnitTestCase):
-	"""
-	Unit tests for PatchLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPatchLog(IntegrationTestCase):

--- a/frappe/core/doctype/permission_inspector/test_permission_inspector.py
+++ b/frappe/core/doctype/permission_inspector/test_permission_inspector.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPermissionInspector(UnitTestCase):
-	"""
-	Unit tests for PermissionInspector.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPermissionInspector(IntegrationTestCase):

--- a/frappe/core/doctype/permission_log/test_permission_log.py
+++ b/frappe/core/doctype/permission_log/test_permission_log.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPermissionLog(UnitTestCase):
-	"""
-	Unit tests for PermissionLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPermissionLog(IntegrationTestCase):

--- a/frappe/core/doctype/prepared_report/test_prepared_report.py
+++ b/frappe/core/doctype/prepared_report/test_prepared_report.py
@@ -7,17 +7,8 @@ from contextlib import contextmanager
 import frappe
 from frappe.desk.query_report import generate_report_result, get_report_doc
 from frappe.query_builder.utils import db_type_is
-from frappe.tests import IntegrationTestCase, UnitTestCase, timeout
+from frappe.tests import IntegrationTestCase, timeout
 from frappe.tests.test_query_builder import run_only_if
-
-
-class UnitTestPreparedReport(UnitTestCase):
-	"""
-	Unit tests for PreparedReport.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestPreparedReport(IntegrationTestCase):

--- a/frappe/core/doctype/recorder/test_recorder.py
+++ b/frappe/core/doctype/recorder/test_recorder.py
@@ -8,18 +8,9 @@ import frappe.recorder
 from frappe.core.doctype.recorder.recorder import _optimize_query, serialize_request
 from frappe.query_builder.utils import db_type_is
 from frappe.recorder import get as get_recorder_data
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.tests.test_query_builder import run_only_if
 from frappe.utils import set_request
-
-
-class UnitTestRecorder(UnitTestCase):
-	"""
-	Unit tests for Recorder.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestRecorder(IntegrationTestCase):

--- a/frappe/core/doctype/recorder_query/test_recorder_query.py
+++ b/frappe/core/doctype/recorder_query/test_recorder_query.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestRecorderQuery(UnitTestCase):
-	"""
-	Unit tests for RecorderQuery.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestRecorderQuery(IntegrationTestCase):

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -11,18 +11,9 @@ from frappe.custom.doctype.customize_form.customize_form import reset_customizat
 from frappe.desk.query_report import add_total_row, run, save_report
 from frappe.desk.reportview import delete_report
 from frappe.desk.reportview import save_report as _save_report
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["User"]
-
-
-class UnitTestReport(UnitTestCase):
-	"""
-	Unit tests for Report.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestReport(IntegrationTestCase):

--- a/frappe/core/doctype/role/test_role.py
+++ b/frappe/core/doctype/role/test_role.py
@@ -3,16 +3,7 @@
 
 import frappe
 from frappe.core.doctype.role.role import get_info_based_on_role
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestRole(UnitTestCase):
-	"""
-	Unit tests for Role.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestUser(IntegrationTestCase):

--- a/frappe/core/doctype/role_permission_for_page_and_report/test_role_permission_for_page_and_report.py
+++ b/frappe/core/doctype/role_permission_for_page_and_report/test_role_permission_for_page_and_report.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestRolePermissionForPageAndReport(UnitTestCase):
-	"""
-	Unit tests for RolePermissionForPageAndReport.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestRolePermissionforPageandReport(IntegrationTestCase):

--- a/frappe/core/doctype/role_profile/test_role_profile.py
+++ b/frappe/core/doctype/role_profile/test_role_profile.py
@@ -1,18 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Role"]
-
-
-class UnitTestRoleProfile(UnitTestCase):
-	"""
-	Unit tests for RoleProfile.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestRoleProfile(IntegrationTestCase):

--- a/frappe/core/doctype/role_replication/test_role_replication.py
+++ b/frappe/core/doctype/role_replication/test_role_replication.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestRoleReplication(UnitTestCase):
-	"""
-	Unit tests for RoleReplication.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestRoleReplication(IntegrationTestCase):

--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -10,7 +10,7 @@ from rq.job import Job
 import frappe
 from frappe.core.doctype.rq_job.rq_job import RQJob, remove_failed_jobs, stop_job
 from frappe.installer import update_site_config
-from frappe.tests import IntegrationTestCase, UnitTestCase, timeout
+from frappe.tests import IntegrationTestCase, timeout
 from frappe.utils import cstr, execute_in_shell
 from frappe.utils.background_jobs import get_job_status, is_job_enqueued
 
@@ -21,15 +21,6 @@ def wait_for_completion(job: Job):
 		if not (job.is_queued or job.is_started):
 			break
 		time.sleep(0.2)
-
-
-class UnitTestRqJob(UnitTestCase):
-	"""
-	Unit tests for RqJob.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestRQJob(IntegrationTestCase):

--- a/frappe/core/doctype/rq_worker/test_rq_worker.py
+++ b/frappe/core/doctype/rq_worker/test_rq_worker.py
@@ -3,16 +3,7 @@
 
 import frappe
 from frappe.core.doctype.rq_worker.rq_worker import RQWorker
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestRqWorker(UnitTestCase):
-	"""
-	Unit tests for RqWorker.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestRQWorker(IntegrationTestCase):

--- a/frappe/core/doctype/scheduled_job_log/test_scheduled_job_log.py
+++ b/frappe/core/doctype/scheduled_job_log/test_scheduled_job_log.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestScheduledJobLog(UnitTestCase):
-	"""
-	Unit tests for ScheduledJobLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestScheduledJobLog(IntegrationTestCase):

--- a/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
@@ -4,18 +4,9 @@ from datetime import timedelta
 
 import frappe
 from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import get_datetime
 from frappe.utils.data import add_to_date, now_datetime
-
-
-class UnitTestScheduledJobType(UnitTestCase):
-	"""
-	Unit tests for ScheduledJobType.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestScheduledJobType(IntegrationTestCase):

--- a/frappe/core/doctype/scheduler_event/test_scheduler_event.py
+++ b/frappe/core/doctype/scheduler_event/test_scheduler_event.py
@@ -2,22 +2,13 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list
 EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-
-
-class UnitTestSchedulerEvent(UnitTestCase):
-	"""
-	Unit tests for SchedulerEvent.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class IntegrationTestSchedulerEvent(IntegrationTestCase):

--- a/frappe/core/doctype/server_script/test_server_script.py
+++ b/frappe/core/doctype/server_script/test_server_script.py
@@ -6,7 +6,7 @@ import frappe
 from frappe.core.doctype.scheduled_job_type.scheduled_job_type import ScheduledJobType, sync_jobs
 from frappe.core.doctype.server_script.server_script import ServerScript
 from frappe.frappeclient import FrappeClient, FrappeException
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import get_site_url
 
 scripts = [
@@ -106,15 +106,6 @@ doc.save()
 """,
 	),
 ]
-
-
-class UnitTestServerScript(UnitTestCase):
-	"""
-	Unit tests for ServerScript.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestServerScript(IntegrationTestCase):

--- a/frappe/core/doctype/session_default_settings/test_session_default_settings.py
+++ b/frappe/core/doctype/session_default_settings/test_session_default_settings.py
@@ -5,16 +5,7 @@ from frappe.core.doctype.session_default_settings.session_default_settings impor
 	clear_session_defaults,
 	set_session_default_values,
 )
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestSessionDefaultSettings(UnitTestCase):
-	"""
-	Unit tests for SessionDefaultSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestSessionDefaultSettings(IntegrationTestCase):

--- a/frappe/core/doctype/sms_settings/test_sms_settings.py
+++ b/frappe/core/doctype/sms_settings/test_sms_settings.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestSmsSettings(UnitTestCase):
-	"""
-	Unit tests for SmsSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestSMSSettings(IntegrationTestCase):

--- a/frappe/core/doctype/submission_queue/test_submission_queue.py
+++ b/frappe/core/doctype/submission_queue/test_submission_queue.py
@@ -5,20 +5,11 @@ import time
 import typing
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase, timeout
+from frappe.tests import IntegrationTestCase, timeout
 from frappe.utils.background_jobs import get_queue
 
 if typing.TYPE_CHECKING:
 	from rq.job import Job
-
-
-class UnitTestSubmissionQueue(UnitTestCase):
-	"""
-	Unit tests for SubmissionQueue.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestSubmissionQueue(IntegrationTestCase):

--- a/frappe/core/doctype/system_settings/test_system_settings.py
+++ b/frappe/core/doctype/system_settings/test_system_settings.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestSystemSettings(UnitTestCase):
-	"""
-	Unit tests for SystemSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestSystemSettings(IntegrationTestCase):

--- a/frappe/core/doctype/transaction_log/test_transaction_log.py
+++ b/frappe/core/doctype/transaction_log/test_transaction_log.py
@@ -3,16 +3,7 @@
 import hashlib
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestTransactionLog(UnitTestCase):
-	"""
-	Unit tests for TransactionLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestTransactionLog(IntegrationTestCase):

--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -2,16 +2,7 @@
 # License: MIT. See LICENSE
 import frappe
 from frappe import _
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestTranslation(UnitTestCase):
-	"""
-	Unit tests for Translation.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestTranslation(IntegrationTestCase):

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -22,21 +22,12 @@ from frappe.core.doctype.user.user import (
 from frappe.desk.notifications import extract_mentions
 from frappe.frappeclient import FrappeClient
 from frappe.model.delete_doc import delete_doc
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.tests.classes.context_managers import change_settings
 from frappe.tests.test_api import FrappeAPITestCase
 from frappe.utils import get_url
 
 user_module = frappe.core.doctype.user.user
-
-
-class UnitTestUser(UnitTestCase):
-	"""
-	Unit tests for User.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestUser(IntegrationTestCase):

--- a/frappe/core/doctype/user_group/test_user_group.py
+++ b/frappe/core/doctype/user_group/test_user_group.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestUserGroup(UnitTestCase):
-	"""
-	Unit tests for UserGroup.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestUserGroup(IntegrationTestCase):

--- a/frappe/core/doctype/user_group_member/test_user_group_member.py
+++ b/frappe/core/doctype/user_group_member/test_user_group_member.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestUserGroupMember(UnitTestCase):
-	"""
-	Unit tests for UserGroupMember.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestUserGroupMember(IntegrationTestCase):

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -7,17 +7,8 @@ from frappe.core.doctype.user_permission.user_permission import (
 	remove_applicable,
 )
 from frappe.permissions import add_permission, has_user_permission
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.website.doctype.blog_post.test_blog_post import make_test_blog
-
-
-class UnitTestUserPermission(UnitTestCase):
-	"""
-	Unit tests for UserPermission.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestUserPermission(IntegrationTestCase):

--- a/frappe/core/doctype/user_type/test_user_type.py
+++ b/frappe/core/doctype/user_type/test_user_type.py
@@ -2,16 +2,7 @@
 # License: MIT. See LICENSE
 import frappe
 from frappe.installer import update_site_config
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestUserType(UnitTestCase):
-	"""
-	Unit tests for UserType.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestUserType(IntegrationTestCase):

--- a/frappe/core/doctype/version/test_version.py
+++ b/frappe/core/doctype/version/test_version.py
@@ -4,17 +4,8 @@ import copy
 
 import frappe
 from frappe.core.doctype.version.version import get_diff
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import make_test_objects
-
-
-class UnitTestVersion(UnitTestCase):
-	"""
-	Unit tests for Version.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestVersion(IntegrationTestCase):

--- a/frappe/core/doctype/view_log/test_view_log.py
+++ b/frappe/core/doctype/view_log/test_view_log.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestViewLog(UnitTestCase):
-	"""
-	Unit tests for ViewLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestViewLog(IntegrationTestCase):

--- a/frappe/custom/doctype/client_script/test_client_script.py
+++ b/frappe/custom/doctype/client_script/test_client_script.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestClientScript(UnitTestCase):
-	"""
-	Unit tests for ClientScript.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestClientScript(IntegrationTestCase):

--- a/frappe/custom/doctype/custom_field/test_custom_field.py
+++ b/frappe/custom/doctype/custom_field/test_custom_field.py
@@ -7,16 +7,7 @@ from frappe.custom.doctype.custom_field.custom_field import (
 	create_custom_fields,
 	rename_fieldname,
 )
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestCustomField(UnitTestCase):
-	"""
-	Unit tests for CustomField.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestCustomField(IntegrationTestCase):

--- a/frappe/custom/doctype/customize_form/test_customize_form.py
+++ b/frappe/custom/doctype/customize_form/test_customize_form.py
@@ -6,19 +6,10 @@ import json
 import frappe
 from frappe.core.doctype.doctype.doctype import InvalidFieldNameError
 from frappe.core.doctype.doctype.test_doctype import new_doctype
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import make_test_records_for_doctype
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Custom Field", "Property Setter"]
-
-
-class UnitTestCustomizeForm(UnitTestCase):
-	"""
-	Unit tests for CustomizeForm.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestCustomizeForm(IntegrationTestCase):

--- a/frappe/custom/doctype/doctype_layout/test_doctype_layout.py
+++ b/frappe/custom/doctype/doctype_layout/test_doctype_layout.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDoctypeLayout(UnitTestCase):
-	"""
-	Unit tests for DoctypeLayout.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDocTypeLayout(IntegrationTestCase):

--- a/frappe/custom/doctype/property_setter/test_property_setter.py
+++ b/frappe/custom/doctype/property_setter/test_property_setter.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPropertySetter(UnitTestCase):
-	"""
-	Unit tests for PropertySetter.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPropertySetter(IntegrationTestCase):

--- a/frappe/desk/doctype/bulk_update/test_bulk_update.py
+++ b/frappe/desk/doctype/bulk_update/test_bulk_update.py
@@ -6,16 +6,7 @@ import time
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.desk.doctype.bulk_update.bulk_update import submit_cancel_or_update_docs
-from frappe.tests import IntegrationTestCase, UnitTestCase, timeout
-
-
-class UnitTestBulkUpdate(UnitTestCase):
-	"""
-	Unit tests for BulkUpdate.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase, timeout
 
 
 class TestBulkUpdate(IntegrationTestCase):

--- a/frappe/desk/doctype/changelog_feed/test_changelog_feed.py
+++ b/frappe/desk/doctype/changelog_feed/test_changelog_feed.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestChangelogFeed(UnitTestCase):
-	"""
-	Unit tests for ChangelogFeed.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestChangelogFeed(IntegrationTestCase):

--- a/frappe/desk/doctype/console_log/test_console_log.py
+++ b/frappe/desk/doctype/console_log/test_console_log.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestConsoleLog(UnitTestCase):
-	"""
-	Unit tests for ConsoleLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestConsoleLog(IntegrationTestCase):

--- a/frappe/desk/doctype/custom_html_block/test_custom_html_block.py
+++ b/frappe/desk/doctype/custom_html_block/test_custom_html_block.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestCustomHtmlBlock(UnitTestCase):
-	"""
-	Unit tests for CustomHtmlBlock.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestCustomHTMLBlock(IntegrationTestCase):

--- a/frappe/desk/doctype/dashboard/test_dashboard.py
+++ b/frappe/desk/doctype/dashboard/test_dashboard.py
@@ -2,17 +2,8 @@
 # License: MIT. See LICENSE
 import frappe
 from frappe.core.doctype.user.test_user import test_user
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils.modules import get_modules_from_all_apps_for_user
-
-
-class UnitTestDashboard(UnitTestCase):
-	"""
-	Unit tests for Dashboard.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestDashboard(IntegrationTestCase):

--- a/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
@@ -9,18 +9,9 @@ from dateutil.relativedelta import relativedelta
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.desk.doctype.dashboard_chart.dashboard_chart import get
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import formatdate, get_last_day, getdate
 from frappe.utils.dateutils import get_period, get_period_ending
-
-
-class UnitTestDashboardChart(UnitTestCase):
-	"""
-	Unit tests for DashboardChart.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestDashboardChart(IntegrationTestCase):

--- a/frappe/desk/doctype/dashboard_chart_source/test_dashboard_chart_source.py
+++ b/frappe/desk/doctype/dashboard_chart_source/test_dashboard_chart_source.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDashboardChartSource(UnitTestCase):
-	"""
-	Unit tests for DashboardChartSource.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDashboardChartSource(IntegrationTestCase):

--- a/frappe/desk/doctype/event/test_event.py
+++ b/frappe/desk/doctype/event/test_event.py
@@ -8,17 +8,8 @@ from datetime import date
 import frappe
 from frappe.core.utils import find
 from frappe.desk.doctype.event.event import get_events
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import make_test_objects
-
-
-class UnitTestEvent(UnitTestCase):
-	"""
-	Unit tests for Event.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestEvent(IntegrationTestCase):

--- a/frappe/desk/doctype/form_tour/test_form_tour.py
+++ b/frappe/desk/doctype/form_tour/test_form_tour.py
@@ -2,16 +2,7 @@
 # License: MIT. See LICENSE
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestFormTour(UnitTestCase):
-	"""
-	Unit tests for FormTour.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestFormTour(IntegrationTestCase):

--- a/frappe/desk/doctype/kanban_board/test_kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/test_kanban_board.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestKanbanBoard(UnitTestCase):
-	"""
-	Unit tests for KanbanBoard.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestKanbanBoard(IntegrationTestCase):

--- a/frappe/desk/doctype/list_view_settings/test_list_view_settings.py
+++ b/frappe/desk/doctype/list_view_settings/test_list_view_settings.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestListViewSettings(UnitTestCase):
-	"""
-	Unit tests for ListViewSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestListViewSettings(IntegrationTestCase):

--- a/frappe/desk/doctype/module_onboarding/test_module_onboarding.py
+++ b/frappe/desk/doctype/module_onboarding/test_module_onboarding.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestModuleOnboarding(UnitTestCase):
-	"""
-	Unit tests for ModuleOnboarding.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestModuleOnboarding(IntegrationTestCase):

--- a/frappe/desk/doctype/note/test_note.py
+++ b/frappe/desk/doctype/note/test_note.py
@@ -2,16 +2,7 @@
 # License: MIT. See LICENSE
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestNote(UnitTestCase):
-	"""
-	Unit tests for Note.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestNote(IntegrationTestCase):

--- a/frappe/desk/doctype/notification_log/test_notification_log.py
+++ b/frappe/desk/doctype/notification_log/test_notification_log.py
@@ -3,16 +3,7 @@
 import frappe
 from frappe.core.doctype.user.user import get_system_users
 from frappe.desk.form.assign_to import add as assign_task
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestNotificationLog(UnitTestCase):
-	"""
-	Unit tests for NotificationLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestNotificationLog(IntegrationTestCase):

--- a/frappe/desk/doctype/notification_settings/test_notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/test_notification_settings.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestNotificationSettings(UnitTestCase):
-	"""
-	Unit tests for NotificationSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestNotificationSettings(IntegrationTestCase):

--- a/frappe/desk/doctype/number_card/test_number_card.py
+++ b/frappe/desk/doctype/number_card/test_number_card.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestNumberCard(UnitTestCase):
-	"""
-	Unit tests for NumberCard.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestNumberCard(IntegrationTestCase):

--- a/frappe/desk/doctype/onboarding_permission/test_onboarding_permission.py
+++ b/frappe/desk/doctype/onboarding_permission/test_onboarding_permission.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestOnboardingPermission(UnitTestCase):
-	"""
-	Unit tests for OnboardingPermission.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestOnboardingPermission(IntegrationTestCase):

--- a/frappe/desk/doctype/onboarding_step/test_onboarding_step.py
+++ b/frappe/desk/doctype/onboarding_step/test_onboarding_step.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestOnboardingStep(UnitTestCase):
-	"""
-	Unit tests for OnboardingStep.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestOnboardingStep(IntegrationTestCase):

--- a/frappe/desk/doctype/system_console/test_system_console.py
+++ b/frappe/desk/doctype/system_console/test_system_console.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestSystemConsole(UnitTestCase):
-	"""
-	Unit tests for SystemConsole.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestSystemConsole(IntegrationTestCase):

--- a/frappe/desk/doctype/system_health_report/test_system_health_report.py
+++ b/frappe/desk/doctype/system_health_report/test_system_health_report.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestSystemHealthReport(UnitTestCase):
-	"""
-	Unit tests for SystemHealthReport.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestSystemHealthReport(IntegrationTestCase):

--- a/frappe/desk/doctype/tag/test_tag.py
+++ b/frappe/desk/doctype/tag/test_tag.py
@@ -1,16 +1,7 @@
 import frappe
 from frappe.desk.doctype.tag.tag import add_tag
 from frappe.desk.reportview import get_stats
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestTag(UnitTestCase):
-	"""
-	Unit tests for Tag.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestTag(IntegrationTestCase):

--- a/frappe/desk/doctype/tag_link/test_tag_link.py
+++ b/frappe/desk/doctype/tag_link/test_tag_link.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestTagLink(UnitTestCase):
-	"""
-	Unit tests for TagLink.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestTagLink(IntegrationTestCase):

--- a/frappe/desk/doctype/todo/test_todo.py
+++ b/frappe/desk/doctype/todo/test_todo.py
@@ -4,18 +4,9 @@ import frappe
 from frappe.core.doctype.doctype.doctype import clear_permissions_cache
 from frappe.model.db_query import DatabaseQuery
 from frappe.permissions import add_permission, reset_perms
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["User"]
-
-
-class UnitTestTodo(UnitTestCase):
-	"""
-	Unit tests for Todo.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestToDo(IntegrationTestCase):

--- a/frappe/desk/doctype/workspace/test_workspace.py
+++ b/frappe/desk/doctype/workspace/test_workspace.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestWorkspace(UnitTestCase):
-	"""
-	Unit tests for Workspace.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestWorkspace(IntegrationTestCase):

--- a/frappe/desk/doctype/workspace_settings/test_workspace_settings.py
+++ b/frappe/desk/doctype/workspace_settings/test_workspace_settings.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestWorkspaceSettings(UnitTestCase):
-	"""
-	Unit tests for WorkspaceSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestWorkspaceSettings(IntegrationTestCase):

--- a/frappe/email/doctype/auto_email_report/test_auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/test_auto_email_report.py
@@ -3,18 +3,9 @@
 import json
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, get_link_to_form, today
 from frappe.utils.data import is_html
-
-
-class UnitTestAutoEmailReport(UnitTestCase):
-	"""
-	Unit tests for AutoEmailReport.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestAutoEmailReport(IntegrationTestCase):

--- a/frappe/email/doctype/document_follow/test_document_follow.py
+++ b/frappe/email/doctype/document_follow/test_document_follow.py
@@ -11,16 +11,7 @@ from frappe.desk.like import toggle_like
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Cast_
 from frappe.share import add as share
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDocumentFollow(UnitTestCase):
-	"""
-	Unit tests for DocumentFollow.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDocumentFollow(IntegrationTestCase):

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -13,16 +13,7 @@ from frappe.desk.form.load import get_attachments
 from frappe.email.doctype.email_account.email_account import notify_unreplied
 from frappe.email.email_body import get_message_id
 from frappe.email.receive import Email, InboundMail, SentEmailInInboxError
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestEmailAccount(UnitTestCase):
-	"""
-	Unit tests for EmailAccount.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestEmailAccount(IntegrationTestCase):

--- a/frappe/email/doctype/email_domain/test_email_domain.py
+++ b/frappe/email/doctype/email_domain/test_email_domain.py
@@ -1,17 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import make_test_objects
-
-
-class UnitTestEmailDomain(UnitTestCase):
-	"""
-	Unit tests for EmailDomain.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestDomain(IntegrationTestCase):

--- a/frappe/email/doctype/email_flag_queue/test_email_flag_queue.py
+++ b/frappe/email/doctype/email_flag_queue/test_email_flag_queue.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestEmailFlagQueue(UnitTestCase):
-	"""
-	Unit tests for EmailFlagQueue.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestEmailFlagQueue(IntegrationTestCase):

--- a/frappe/email/doctype/email_group/test_email_group.py
+++ b/frappe/email/doctype/email_group/test_email_group.py
@@ -1,17 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import validate_url
-
-
-class UnitTestEmailGroup(UnitTestCase):
-	"""
-	Unit tests for EmailGroup.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestEmailGroup(IntegrationTestCase):

--- a/frappe/email/doctype/email_group_member/test_email_group_member.py
+++ b/frappe/email/doctype/email_group_member/test_email_group_member.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestEmailGroupMember(UnitTestCase):
-	"""
-	Unit tests for EmailGroupMember.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestEmailGroupMember(IntegrationTestCase):

--- a/frappe/email/doctype/email_queue/test_email_queue.py
+++ b/frappe/email/doctype/email_queue/test_email_queue.py
@@ -4,16 +4,7 @@ import textwrap
 
 import frappe
 from frappe.email.doctype.email_queue.email_queue import SendMailContext, get_email_retry_limit
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestEmailQueue(UnitTestCase):
-	"""
-	Unit tests for EmailQueue.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestEmailQueue(IntegrationTestCase):

--- a/frappe/email/doctype/email_rule/test_email_rule.py
+++ b/frappe/email/doctype/email_rule/test_email_rule.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestEmailRule(UnitTestCase):
-	"""
-	Unit tests for EmailRule.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestEmailRule(IntegrationTestCase):

--- a/frappe/email/doctype/email_template/test_email_template.py
+++ b/frappe/email/doctype/email_template/test_email_template.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestEmailTemplate(UnitTestCase):
-	"""
-	Unit tests for EmailTemplate.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestEmailTemplate(IntegrationTestCase):

--- a/frappe/email/doctype/email_unsubscribe/test_email_unsubscribe.py
+++ b/frappe/email/doctype/email_unsubscribe/test_email_unsubscribe.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestEmailUnsubscribe(UnitTestCase):
-	"""
-	Unit tests for EmailUnsubscribe.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestEmailUnsubscribe(IntegrationTestCase):

--- a/frappe/email/doctype/notification/test_notification.py
+++ b/frappe/email/doctype/notification/test_notification.py
@@ -8,7 +8,7 @@ import frappe
 import frappe.utils
 import frappe.utils.scheduler
 from frappe.desk.form import assign_to
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 from .notification import trigger_notifications
 
@@ -23,15 +23,6 @@ def get_test_notification(config):
 	finally:
 		notification.delete()
 		frappe.db.commit()
-
-
-class UnitTestNotification(UnitTestCase):
-	"""
-	Unit tests for Notification.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestNotification(IntegrationTestCase):

--- a/frappe/email/doctype/unhandled_email/test_unhandled_email.py
+++ b/frappe/email/doctype/unhandled_email/test_unhandled_email.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestUnhandledEmail(UnitTestCase):
-	"""
-	Unit tests for UnhandledEmail.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestUnhandledEmail(IntegrationTestCase):

--- a/frappe/geo/doctype/country/test_country.py
+++ b/frappe/geo/doctype/country/test_country.py
@@ -7,7 +7,7 @@ from frappe.geo.doctype.country.country import (
 	import_country_and_currency,
 )
 from frappe.geo.doctype.currency.currency import enable_default_currencies
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 
 def get_table_snapshot(doctype):
@@ -18,15 +18,6 @@ def get_table_snapshot(doctype):
 		for key in inconsequential_keys:
 			row.pop(key, None)
 	return data
-
-
-class UnitTestCountry(UnitTestCase):
-	"""
-	Unit tests for Country.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestCountry(IntegrationTestCase):

--- a/frappe/geo/doctype/currency/test_currency.py
+++ b/frappe/geo/doctype/currency/test_currency.py
@@ -4,16 +4,7 @@
 # pre loaded
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestCurrency(UnitTestCase):
-	"""
-	Unit tests for Currency.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestUser(IntegrationTestCase):

--- a/frappe/integrations/doctype/connected_app/test_connected_app.py
+++ b/frappe/integrations/doctype/connected_app/test_connected_app.py
@@ -8,7 +8,7 @@ import frappe
 from frappe.integrations.doctype.social_login_key.test_social_login_key import (
 	create_or_update_social_login_key,
 )
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 
 def get_user(usr, pwd):
@@ -46,15 +46,6 @@ def get_oauth_client():
 	oauth_client.insert()
 
 	return oauth_client
-
-
-class UnitTestConnectedApp(UnitTestCase):
-	"""
-	Unit tests for ConnectedApp.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestConnectedApp(IntegrationTestCase):

--- a/frappe/integrations/doctype/dropbox_settings/test_dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/test_dropbox_settings.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDropboxSettings(UnitTestCase):
-	"""
-	Unit tests for DropboxSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDropboxSettings(IntegrationTestCase):

--- a/frappe/integrations/doctype/geolocation_settings/test_geolocation_settings.py
+++ b/frappe/integrations/doctype/geolocation_settings/test_geolocation_settings.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestGeolocationSettings(UnitTestCase):
-	"""
-	Unit tests for GeolocationSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestGeolocationSettings(IntegrationTestCase):

--- a/frappe/integrations/doctype/google_contacts/test_google_contacts.py
+++ b/frappe/integrations/doctype/google_contacts/test_google_contacts.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestGoogleContacts(UnitTestCase):
-	"""
-	Unit tests for GoogleContacts.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestGoogleContacts(IntegrationTestCase):

--- a/frappe/integrations/doctype/google_drive/test_google_drive.py
+++ b/frappe/integrations/doctype/google_drive/test_google_drive.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestGoogleDrive(UnitTestCase):
-	"""
-	Unit tests for GoogleDrive.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestGoogleDrive(IntegrationTestCase):

--- a/frappe/integrations/doctype/google_settings/test_google_settings.py
+++ b/frappe/integrations/doctype/google_settings/test_google_settings.py
@@ -2,18 +2,9 @@
 # License: MIT. See LICENSE
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 from .google_settings import get_file_picker_settings
-
-
-class UnitTestGoogleSettings(UnitTestCase):
-	"""
-	Unit tests for GoogleSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestGoogleSettings(IntegrationTestCase):

--- a/frappe/integrations/doctype/integration_request/test_integration_request.py
+++ b/frappe/integrations/doctype/integration_request/test_integration_request.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestIntegrationRequest(UnitTestCase):
-	"""
-	Unit tests for IntegrationRequest.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestIntegrationRequest(IntegrationTestCase):

--- a/frappe/integrations/doctype/oauth_authorization_code/test_oauth_authorization_code.py
+++ b/frappe/integrations/doctype/oauth_authorization_code/test_oauth_authorization_code.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestOauthAuthorizationCode(UnitTestCase):
-	"""
-	Unit tests for OauthAuthorizationCode.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestOAuthAuthorizationCode(IntegrationTestCase):

--- a/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
+++ b/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestOauthBearerToken(UnitTestCase):
-	"""
-	Unit tests for OauthBearerToken.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestOAuthBearerToken(IntegrationTestCase):

--- a/frappe/integrations/doctype/oauth_client/test_oauth_client.py
+++ b/frappe/integrations/doctype/oauth_client/test_oauth_client.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestOauthClient(UnitTestCase):
-	"""
-	Unit tests for OauthClient.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestOAuthClient(IntegrationTestCase):

--- a/frappe/integrations/doctype/push_notification_settings/test_push_notification_settings.py
+++ b/frappe/integrations/doctype/push_notification_settings/test_push_notification_settings.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPushNotificationSettings(UnitTestCase):
-	"""
-	Unit tests for PushNotificationSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPushNotificationSettings(IntegrationTestCase):

--- a/frappe/integrations/doctype/s3_backup_settings/test_s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/test_s3_backup_settings.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestS3BackupSettings(UnitTestCase):
-	"""
-	Unit tests for S3BackupSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestS3BackupSettings(IntegrationTestCase):

--- a/frappe/integrations/doctype/slack_webhook_url/test_slack_webhook_url.py
+++ b/frappe/integrations/doctype/slack_webhook_url/test_slack_webhook_url.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestSlackWebhookUrl(UnitTestCase):
-	"""
-	Unit tests for SlackWebhookUrl.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestSlackWebhookURL(IntegrationTestCase):

--- a/frappe/integrations/doctype/social_login_key/test_social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/test_social_login_key.py
@@ -7,20 +7,11 @@ from rauth import OAuth2Service
 import frappe
 from frappe.auth import CookieManager, LoginManager
 from frappe.integrations.doctype.social_login_key.social_login_key import BaseUrlNotSetError
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import set_request
 from frappe.utils.oauth import login_via_oauth2
 
 TEST_GITHUB_USER = "githublogin@example.com"
-
-
-class UnitTestSocialLoginKey(UnitTestCase):
-	"""
-	Unit tests for SocialLoginKey.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestSocialLoginKey(IntegrationTestCase):

--- a/frappe/integrations/doctype/token_cache/test_token_cache.py
+++ b/frappe/integrations/doctype/token_cache/test_token_cache.py
@@ -1,18 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["User", "Connected App", "Token Cache"]
-
-
-class UnitTestTokenCache(UnitTestCase):
-	"""
-	Unit tests for TokenCache.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestTokenCache(IntegrationTestCase):

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -13,7 +13,7 @@ from frappe.integrations.doctype.webhook.webhook import (
 	get_webhook_data,
 	get_webhook_headers,
 )
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.tests.classes.context_managers import timeout
 
 
@@ -28,15 +28,6 @@ def get_test_webhook(config):
 		yield wh
 	finally:
 		wh.delete()
-
-
-class UnitTestWebhook(UnitTestCase):
-	"""
-	Unit tests for Webhook.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestWebhook(IntegrationTestCase):

--- a/frappe/integrations/doctype/webhook_request_log/test_webhook_request_log.py
+++ b/frappe/integrations/doctype/webhook_request_log/test_webhook_request_log.py
@@ -2,16 +2,7 @@
 # License: MIT. See LICENSE
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestWebhookRequestLog(UnitTestCase):
-	"""
-	Unit tests for WebhookRequestLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestWebhookRequestLog(IntegrationTestCase):

--- a/frappe/printing/doctype/letter_head/test_letter_head.py
+++ b/frappe/printing/doctype/letter_head/test_letter_head.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestLetterHead(UnitTestCase):
-	"""
-	Unit tests for LetterHead.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestLetterHead(IntegrationTestCase):

--- a/frappe/printing/doctype/network_printer_settings/test_network_printer_settings.py
+++ b/frappe/printing/doctype/network_printer_settings/test_network_printer_settings.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestNetworkPrinterSettings(UnitTestCase):
-	"""
-	Unit tests for NetworkPrinterSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestNetworkPrinterSettings(IntegrationTestCase):

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -6,19 +6,10 @@ import unittest
 from typing import TYPE_CHECKING
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 
 if TYPE_CHECKING:
 	from frappe.printing.doctype.print_format.print_format import PrintFormat
-
-
-class UnitTestPrintFormat(UnitTestCase):
-	"""
-	Unit tests for PrintFormat.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestPrintFormat(IntegrationTestCase):

--- a/frappe/printing/doctype/print_format_field_template/test_print_format_field_template.py
+++ b/frappe/printing/doctype/print_format_field_template/test_print_format_field_template.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPrintFormatFieldTemplate(UnitTestCase):
-	"""
-	Unit tests for PrintFormatFieldTemplate.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPrintFormatFieldTemplate(IntegrationTestCase):

--- a/frappe/printing/doctype/print_heading/test_print_heading.py
+++ b/frappe/printing/doctype/print_heading/test_print_heading.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPrintHeading(UnitTestCase):
-	"""
-	Unit tests for PrintHeading.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPrintHeading(IntegrationTestCase):

--- a/frappe/printing/doctype/print_settings/test_print_settings.py
+++ b/frappe/printing/doctype/print_settings/test_print_settings.py
@@ -1,15 +1,6 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPrintSettings(UnitTestCase):
-	"""
-	Unit tests for PrintSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPrintSettings(IntegrationTestCase):

--- a/frappe/printing/doctype/print_style/test_print_style.py
+++ b/frappe/printing/doctype/print_style/test_print_style.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPrintStyle(UnitTestCase):
-	"""
-	Unit tests for PrintStyle.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPrintStyle(IntegrationTestCase):

--- a/frappe/website/doctype/about_us_settings/test_about_us_settings.py
+++ b/frappe/website/doctype/about_us_settings/test_about_us_settings.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestAboutUsSettings(UnitTestCase):
-	"""
-	Unit tests for AboutUsSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestAboutUsSettings(IntegrationTestCase):

--- a/frappe/website/doctype/blog_category/test_blog_category.py
+++ b/frappe/website/doctype/blog_category/test_blog_category.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestBlogCategory(UnitTestCase):
-	"""
-	Unit tests for BlogCategory.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestBlogCategory(IntegrationTestCase):

--- a/frappe/website/doctype/blog_post/test_blog_post.py
+++ b/frappe/website/doctype/blog_post/test_blog_post.py
@@ -6,7 +6,7 @@ from bs4 import BeautifulSoup
 
 import frappe
 from frappe.custom.doctype.customize_form.customize_form import reset_customization
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import random_string, set_request
 from frappe.website.doctype.blog_post.blog_post import get_blog_list
 from frappe.website.serve import get_response
@@ -14,15 +14,6 @@ from frappe.website.utils import clear_website_cache
 from frappe.website.website_generator import WebsiteGenerator
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Blog Post"]
-
-
-class UnitTestBlogPost(UnitTestCase):
-	"""
-	Unit tests for BlogPost.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestBlogPost(IntegrationTestCase):

--- a/frappe/website/doctype/blog_settings/test_blog_settings.py
+++ b/frappe/website/doctype/blog_settings/test_blog_settings.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestBlogSettings(UnitTestCase):
-	"""
-	Unit tests for BlogSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestBlogSettings(IntegrationTestCase):

--- a/frappe/website/doctype/color/test_color.py
+++ b/frappe/website/doctype/color/test_color.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestColor(UnitTestCase):
-	"""
-	Unit tests for Color.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestColor(IntegrationTestCase):

--- a/frappe/website/doctype/discussion_reply/test_discussion_reply.py
+++ b/frappe/website/doctype/discussion_reply/test_discussion_reply.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDiscussionReply(UnitTestCase):
-	"""
-	Unit tests for DiscussionReply.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDiscussionReply(IntegrationTestCase):

--- a/frappe/website/doctype/discussion_topic/test_discussion_topic.py
+++ b/frappe/website/doctype/discussion_topic/test_discussion_topic.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestDiscussionTopic(UnitTestCase):
-	"""
-	Unit tests for DiscussionTopic.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestDiscussionTopic(IntegrationTestCase):

--- a/frappe/website/doctype/help_article/test_help_article.py
+++ b/frappe/website/doctype/help_article/test_help_article.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestHelpArticle(UnitTestCase):
-	"""
-	Unit tests for HelpArticle.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestHelpArticle(IntegrationTestCase):

--- a/frappe/website/doctype/help_category/test_help_category.py
+++ b/frappe/website/doctype/help_category/test_help_category.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestHelpCategory(UnitTestCase):
-	"""
-	Unit tests for HelpCategory.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestHelpCategory(IntegrationTestCase):

--- a/frappe/website/doctype/personal_data_deletion_request/test_personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/test_personal_data_deletion_request.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timedelta
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.website.doctype.personal_data_deletion_request.personal_data_deletion_request import (
 	process_data_deletion_request,
 	remove_unverified_record,
@@ -11,15 +11,6 @@ from frappe.website.doctype.personal_data_deletion_request.personal_data_deletio
 from frappe.website.doctype.personal_data_download_request.test_personal_data_download_request import (
 	create_user_if_not_exists,
 )
-
-
-class UnitTestPersonalDataDeletionRequest(UnitTestCase):
-	"""
-	Unit tests for PersonalDataDeletionRequest.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestPersonalDataDeletionRequest(IntegrationTestCase):

--- a/frappe/website/doctype/personal_data_download_request/test_personal_data_download_request.py
+++ b/frappe/website/doctype/personal_data_download_request/test_personal_data_download_request.py
@@ -5,19 +5,10 @@ import json
 import frappe
 from frappe.contacts.doctype.contact.contact import get_contact_name
 from frappe.core.doctype.user.user import create_contact
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.website.doctype.personal_data_download_request.personal_data_download_request import (
 	get_user_data,
 )
-
-
-class UnitTestPersonalDataDownloadRequest(UnitTestCase):
-	"""
-	Unit tests for PersonalDataDownloadRequest.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestRequestPersonalData(IntegrationTestCase):

--- a/frappe/website/doctype/portal_settings/test_portal_settings.py
+++ b/frappe/website/doctype/portal_settings/test_portal_settings.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestPortalSettings(UnitTestCase):
-	"""
-	Unit tests for PortalSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestPortalSettings(IntegrationTestCase):

--- a/frappe/website/doctype/utm_campaign/test_utm_campaign.py
+++ b/frappe/website/doctype/utm_campaign/test_utm_campaign.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestUtmCampaign(UnitTestCase):
-	"""
-	Unit tests for UtmCampaign.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestUTMCampaign(IntegrationTestCase):

--- a/frappe/website/doctype/utm_medium/test_utm_medium.py
+++ b/frappe/website/doctype/utm_medium/test_utm_medium.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestUtmMedium(UnitTestCase):
-	"""
-	Unit tests for UtmMedium.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestUTMMedium(IntegrationTestCase):

--- a/frappe/website/doctype/utm_source/test_utm_source.py
+++ b/frappe/website/doctype/utm_source/test_utm_source.py
@@ -2,16 +2,7 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestUtmSource(UnitTestCase):
-	"""
-	Unit tests for UtmSource.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestUTMSource(IntegrationTestCase):

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -3,21 +3,12 @@
 import json
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import set_request
 from frappe.website.doctype.web_form.web_form import accept
 from frappe.website.serve import get_response_content
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Web Form"]
-
-
-class UnitTestWebForm(UnitTestCase):
-	"""
-	Unit tests for WebForm.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestWebForm(IntegrationTestCase):

--- a/frappe/website/doctype/web_page/test_web_page.py
+++ b/frappe/website/doctype/web_page/test_web_page.py
@@ -1,16 +1,7 @@
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.website.path_resolver import PathResolver
 from frappe.website.serve import get_response_content
-
-
-class UnitTestWebPage(UnitTestCase):
-	"""
-	Unit tests for WebPage.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestWebPage(IntegrationTestCase):

--- a/frappe/website/doctype/web_page_view/test_web_page_view.py
+++ b/frappe/website/doctype/web_page_view/test_web_page_view.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestWebPageView(UnitTestCase):
-	"""
-	Unit tests for WebPageView.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestWebPageView(IntegrationTestCase):

--- a/frappe/website/doctype/web_template/test_web_template.py
+++ b/frappe/website/doctype/web_template/test_web_template.py
@@ -3,18 +3,9 @@
 from bs4 import BeautifulSoup
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import set_request
 from frappe.website.serve import get_response
-
-
-class UnitTestWebTemplate(UnitTestCase):
-	"""
-	Unit tests for WebTemplate.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestWebTemplate(IntegrationTestCase):

--- a/frappe/website/doctype/web_template_field/test_web_template_field.py
+++ b/frappe/website/doctype/web_template_field/test_web_template_field.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestWebTemplateField(UnitTestCase):
-	"""
-	Unit tests for WebTemplateField.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestWebTemplateField(IntegrationTestCase):

--- a/frappe/website/doctype/website_route_meta/test_website_route_meta.py
+++ b/frappe/website/doctype/website_route_meta/test_website_route_meta.py
@@ -1,20 +1,11 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.utils import set_request
 from frappe.website.serve import get_response
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Blog Post"]
-
-
-class UnitTestWebsiteRouteMeta(UnitTestCase):
-	"""
-	Unit tests for WebsiteRouteMeta.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestWebsiteRouteMeta(IntegrationTestCase):

--- a/frappe/website/doctype/website_settings/test_website_settings.py
+++ b/frappe/website/doctype/website_settings/test_website_settings.py
@@ -2,17 +2,8 @@
 # License: MIT. See LICENSE
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.website.doctype.website_settings.website_settings import get_website_settings
-
-
-class UnitTestWebsiteSettings(UnitTestCase):
-	"""
-	Unit tests for WebsiteSettings.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestWebsiteSettings(IntegrationTestCase):

--- a/frappe/website/doctype/website_sidebar/test_website_sidebar.py
+++ b/frappe/website/doctype/website_sidebar/test_website_sidebar.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestWebsiteSidebar(UnitTestCase):
-	"""
-	Unit tests for WebsiteSidebar.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestWebsiteSidebar(IntegrationTestCase):

--- a/frappe/website/doctype/website_slideshow/test_website_slideshow.py
+++ b/frappe/website/doctype/website_slideshow/test_website_slideshow.py
@@ -1,16 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestWebsiteSlideshow(UnitTestCase):
-	"""
-	Unit tests for WebsiteSlideshow.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestWebsiteSlideshow(IntegrationTestCase):

--- a/frappe/website/doctype/website_theme/test_website_theme.py
+++ b/frappe/website/doctype/website_theme/test_website_theme.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.website.doctype.website_theme.website_theme import (
 	after_migrate,
 	get_active_theme,
@@ -27,15 +27,6 @@ def website_theme_fixture(**theme):
 
 def get_theme_file(theme):
 	return Path(frappe.get_site_path("public", theme.theme_url[1:]))
-
-
-class UnitTestWebsiteTheme(UnitTestCase):
-	"""
-	Unit tests for WebsiteTheme.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestWebsiteTheme(IntegrationTestCase):

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -9,18 +9,9 @@ from frappe.model.workflow import (
 	get_common_transition_actions,
 )
 from frappe.query_builder import DocType
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import make_test_records
 from frappe.utils import random_string
-
-
-class UnitTestWorkflow(UnitTestCase):
-	"""
-	Unit tests for Workflow.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
 
 
 class TestWorkflow(IntegrationTestCase):

--- a/frappe/workflow/doctype/workflow_action/test_workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/test_workflow_action.py
@@ -2,16 +2,7 @@
 # License: MIT. See LICENSE
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-
-
-class UnitTestWorkflowAction(UnitTestCase):
-	"""
-	Unit tests for WorkflowAction.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from frappe.tests import IntegrationTestCase
 
 
 class TestWorkflowAction(IntegrationTestCase):


### PR DESCRIPTION
- Next to zero adoption after introduction, just noise in codebase.
- <5% tests even run without DB connection. Even things like `flt` and `date` utils require DB connection. This was pointless to begin with. 

I don't see any point in arguing about the purity of test cases when the existence and quality of test cases is the bigger problem.

Dropped using semgrep
