### PR TITLE
Allow assigning documents via Auto Repeat

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.json
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.json
@@ -21,6 +21,9 @@
   "repeat_on_last_day",
   "column_break_12",
   "next_schedule_date",
+  "section_break_looa",
+  "generate_separate_documents_for_each_assignee",
+  "assignee",
   "section_break_16",
   "repeat_on_days",
   "notification",
@@ -86,7 +89,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Frequency",
-   "options": "\nDaily\nWeekly\nMonthly\nQuarterly\nHalf-yearly\nYearly",
+   "options": "\nDaily\nWeekly\nFortnightly\nMonthly\nQuarterly\nHalf-yearly\nYearly",
    "reqd": 1
   },
   {
@@ -198,10 +201,26 @@
    "depends_on": "eval:doc.frequency==='Weekly';",
    "fieldname": "section_break_16",
    "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "generate_separate_documents_for_each_assignee",
+   "fieldtype": "Check",
+   "label": "Generate Separate Documents For Each Assignee"
+  },
+  {
+   "fieldname": "section_break_looa",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "assignee",
+   "fieldtype": "Table MultiSelect",
+   "label": "Assignee",
+   "options": "Auto Repeat User"
   }
  ],
  "links": [],
- "modified": "2025-01-20 14:15:55.287788",
+ "modified": "2025-06-09 18:20:23.775881",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Auto Repeat",
@@ -245,6 +264,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "reference_document",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -233,7 +233,7 @@ class AutoRepeat(Document):
 					for new_doc in new_docs:
 						self.send_notification(new_doc)
 				else:
-					self.send_notification(new_doc)
+					self.send_notification(new_docs)
 		except Exception:
 			error_log = self.log_error(
 				_("Auto repeat failed. Please enable auto repeat after fixing the issues.")

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -13,7 +13,7 @@ from frappe.contacts.doctype.contact.contact import (
 	get_contacts_linking_to,
 )
 from frappe.core.doctype.communication.email import make
-from frappe.desk.form import assign_to
+from frappe.desk.form.assign_to import add as assign_to
 from frappe.model.document import Document
 from frappe.utils import (
 	add_days,
@@ -49,11 +49,16 @@ class AutoRepeat(Document):
 
 	if TYPE_CHECKING:
 		from frappe.automation.doctype.auto_repeat_day.auto_repeat_day import AutoRepeatDay
+		from frappe.automation.doctype.auto_repeat_user.auto_repeat_user import AutoRepeatUser
 		from frappe.types import DF
 
+		assignee: DF.TableMultiSelect[AutoRepeatUser]
 		disabled: DF.Check
 		end_date: DF.Date | None
-		frequency: DF.Literal["", "Daily", "Weekly", "Monthly", "Quarterly", "Half-yearly", "Yearly"]
+		frequency: DF.Literal[
+			"", "Daily", "Weekly", "Fortnightly", "Monthly", "Quarterly", "Half-yearly", "Yearly"
+		]
+		generate_separate_documents_for_each_assignee: DF.Check
 		message: DF.Text | None
 		next_schedule_date: DF.Date | None
 		notify_by_email: DF.Check
@@ -219,9 +224,16 @@ class AutoRepeat(Document):
 
 	def create_documents(self):
 		try:
-			new_doc = self.make_new_document()
+			if self.generate_separate_documents_for_each_assignee and self.assignee:
+				new_docs = self.make_new_documents()
+			else:
+				new_docs = self.make_new_document([assignee.user for assignee in self.assignee])
 			if self.notify_by_email and self.recipients:
-				self.send_notification(new_doc)
+				if isinstance(new_docs, list):
+					for new_doc in new_docs:
+						self.send_notification(new_doc)
+				else:
+					self.send_notification(new_doc)
 		except Exception:
 			error_log = self.log_error(
 				_("Auto repeat failed. Please enable auto repeat after fixing the issues.")
@@ -232,7 +244,14 @@ class AutoRepeat(Document):
 			if self.reference_document and not frappe.in_test:
 				self.notify_error_to_user(error_log)
 
-	def make_new_document(self):
+	def make_new_documents(self):
+		docs = []
+		for assignee in self.assignee:
+			new_doc = self.make_new_document(assignee=[assignee.user])
+			docs.append(new_doc)
+		return docs
+
+	def make_new_document(self, assignee=None):
 		reference_doc = frappe.get_doc(self.reference_doctype, self.reference_document)
 		new_doc = frappe.copy_doc(reference_doc, ignore_no_copy=False)
 		self.update_doc(new_doc, reference_doc)
@@ -242,7 +261,14 @@ class AutoRepeat(Document):
 			"label": _("via Auto Repeat"),
 		}
 		new_doc.insert(ignore_permissions=True)
-
+		if assignee:
+			args = {
+				"assign_to": assignee,
+				"doctype": self.reference_doctype,
+				"name": new_doc.name,
+				"description": new_doc.get_title(),
+			}
+			assign_to(args=args)
 		if self.submit_on_creation:
 			new_doc.submit()
 
@@ -348,6 +374,8 @@ class AutoRepeat(Document):
 	def get_days(self, schedule_date):
 		if self.frequency == "Weekly":
 			days = self.get_offset_for_weekly_frequency(schedule_date)
+		elif self.frequency == "Fortnightly":
+			days = 14
 		else:
 			# daily frequency
 			days = 1

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -274,11 +274,16 @@ class TestAutoRepeat(IntegrationTestCase):
 
 		new_todo = frappe.get_doc("ToDo", new_todo)
 		self.assertEqual(todo.get("description"), new_todo.get("description"))
-		self.assertListEqual(list(new_todo.get_assigned_users()), ["Administrator", "Guest"])
+		self.assertListEqual(
+			sorted(list(new_todo.get_assigned_users())),
+			sorted(["Administrator", "Guest"]),
+		)
 
 	def test_auto_repeat_assignee_with_separate_documents(self):
 		todo = frappe.get_doc(
-			doctype="ToDo", description="test assignee todo with multiple doc", assigned_by="Administrator"
+			doctype="ToDo",
+			description="test assignee todo with multiple doc",
+			assigned_by="Administrator",
 		).insert()
 
 		doc = make_auto_repeat(reference_document=todo.name)

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -85,6 +85,32 @@ class TestAutoRepeat(IntegrationTestCase):
 
 		self.assertEqual(todo.get("description"), new_todo.get("description"))
 
+	def test_fortnightly_auto_repeat(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test fortnightly todo", assigned_by="Administrator"
+		).insert()
+
+		doc = make_auto_repeat(
+			reference_doctype="ToDo",
+			frequency="Fortnightly",
+			reference_document=todo.name,
+			start_date=add_days(today(), -14),
+		)
+
+		self.assertEqual(doc.next_schedule_date, today())
+		data = get_auto_repeat_entries(getdate(today()))
+		create_repeated_entries(data)
+		frappe.db.commit()
+
+		todo = frappe.get_doc(doc.reference_doctype, doc.reference_document)
+		self.assertEqual(todo.auto_repeat, doc.name)
+
+		new_todo = frappe.db.get_value("ToDo", {"auto_repeat": doc.name, "name": ("!=", todo.name)}, "name")
+
+		new_todo = frappe.get_doc("ToDo", new_todo)
+
+		self.assertEqual(todo.get("description"), new_todo.get("description"))
+
 	def test_weekly_auto_repeat_with_weekdays(self):
 		todo = frappe.get_doc(
 			doctype="ToDo", description="test auto repeat with weekdays", assigned_by="Administrator"
@@ -220,6 +246,63 @@ class TestAutoRepeat(IntegrationTestCase):
 			doc.reference_doctype, filters={"auto_repeat": doc.name}, fields=["docstatus"], limit=1
 		)
 		self.assertEqual(docnames[0].docstatus, 1)
+
+	def test_auto_repeat_assignee(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test assignee todo", assigned_by="Administrator"
+		).insert()
+
+		doc = make_auto_repeat(reference_document=todo.name)
+		doc.update(
+			{
+				"assignee": [
+					{"user": "Administrator"},
+					{"user": "Guest"},
+				]
+			}
+		)
+		doc.save()
+		self.assertEqual(doc.next_schedule_date, today())
+		data = get_auto_repeat_entries(getdate(today()))
+		create_repeated_entries(data)
+		frappe.db.commit()
+
+		todo = frappe.get_doc(doc.reference_doctype, doc.reference_document)
+		self.assertEqual(todo.auto_repeat, doc.name)
+
+		new_todo = frappe.db.get_value("ToDo", {"auto_repeat": doc.name, "name": ("!=", todo.name)}, "name")
+
+		new_todo = frappe.get_doc("ToDo", new_todo)
+		self.assertEqual(todo.get("description"), new_todo.get("description"))
+		self.assertListEqual(list(new_todo.get_assigned_users()), ["Administrator", "Guest"])
+
+	def test_auto_repeat_assignee_with_separate_documents(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description="test assignee todo with multiple doc", assigned_by="Administrator"
+		).insert()
+
+		doc = make_auto_repeat(reference_document=todo.name)
+		doc.update(
+			{
+				"assignee": [
+					{"user": "Administrator"},
+					{"user": "Guest"},
+				],
+				"generate_separate_documents_for_each_assignee": 1,
+			}
+		)
+		doc.save()
+		self.assertEqual(doc.next_schedule_date, today())
+		data = get_auto_repeat_entries(getdate(today()))
+		create_repeated_entries(data)
+		frappe.db.commit()
+
+		todo = frappe.get_doc(doc.reference_doctype, doc.reference_document)
+		self.assertEqual(todo.auto_repeat, doc.name)
+
+		new_todo_count = frappe.db.count("ToDo", {"auto_repeat": doc.name, "name": ("!=", todo.name)}, "name")
+
+		self.assertEqual(new_todo_count, 2)
 
 
 def make_auto_repeat(**args):

--- a/frappe/automation/doctype/auto_repeat_user/auto_repeat_user.json
+++ b/frappe/automation/doctype/auto_repeat_user/auto_repeat_user.json
@@ -1,0 +1,35 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-06-09 18:19:22.034128",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "user"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-06-09 18:19:41.543336",
+ "modified_by": "Administrator",
+ "module": "Automation",
+ "name": "Auto Repeat User",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/automation/doctype/auto_repeat_user/auto_repeat_user.py
+++ b/frappe/automation/doctype/auto_repeat_user/auto_repeat_user.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2025, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class AutoRepeatUser(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		user: DF.Link
+	# end: auto-generated types
+
+	pass


### PR DESCRIPTION
## Description

This PR introduces new functionality to the **Auto Repeat** feature:

* Users can now be assigned to the documents generated through Auto Repeat.
* Optionally, a separate document can be created for each assignee.
* Added support for **fortnightly** (every two weeks) document creation.

