### PR TITLE
fix!: Dont silently ignore bad filters

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -143,6 +143,10 @@ class Engine:
 						self.apply_filters(filter)
 					elif isinstance(filter, list | tuple):
 						self.apply_list_filters(filter)
+					else:
+						raise ValueError(f"Unknown filter type: {type(filters)}")
+		else:
+			raise ValueError(f"Unknown filter type: {type(filters)}")
 
 	def apply_list_filters(self, filter: list):
 		if len(filter) == 2:
@@ -154,6 +158,8 @@ class Engine:
 		elif len(filter) == 4:
 			doctype, field, operator, value = filter
 			self._apply_filter(field, value, operator, doctype)
+		else:
+			raise ValueError(f"Unknown filter format: {filter}")
 
 	def apply_dict_filters(self, filters: dict[str, FilterValue | list]):
 		for field, value in filters.items():


### PR DESCRIPTION
Right now if types don't match QB just returns last document values :facepalm: 


After this change, if types don't match an exception is raised... this is almost always a bug.