### PR TITLE
perf: lazy documents

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1993,7 +1993,7 @@ import frappe._optimizations
 from frappe.cache_manager import clear_cache, reset_metadata_version
 from frappe.config import get_common_site_config, get_conf, get_site_config
 from frappe.core.doctype.system_settings.system_settings import get_system_settings
-from frappe.model.document import get_doc
+from frappe.model.document import get_doc, get_lazy_doc
 from frappe.model.meta import get_meta
 from frappe.realtime import publish_progress, publish_realtime
 from frappe.utils import get_traceback, mock, parse_json, safe_eval

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -847,7 +847,7 @@ def has_website_permission(doc=None, ptype="read", user=None, verbose=False, doc
 
 	if doc:
 		if isinstance(doc, str):
-			doc = get_doc(doctype, doc)
+			doc = get_lazy_doc(doctype, doc)
 
 		doctype = doc.doctype
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -76,7 +76,8 @@ if TYPE_CHECKING:  # pragma: no cover
 	from frappe.types.lazytranslatedstring import _LazyTranslate
 	from frappe.utils.redis_wrapper import ClientCache, RedisWrapper
 
-controllers: dict[str, "Document"] = {}
+controllers: dict[str, type] = {}
+lazy_controllers: dict[str, type] = {}
 local = Local()
 cache: Optional["RedisWrapper"] = None
 client_cache: Optional["ClientCache"] = None

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -176,10 +176,14 @@ def _clear_doctype_cache_from_redis(doctype: str | None = None):
 def clear_controller_cache(doctype=None, *, site=None):
 	if not doctype:
 		frappe.controllers.pop(site or frappe.local.site, None)
+		frappe.lazy_controllers.pop(site or frappe.local.site, None)
 		return
 
 	if site_controllers := frappe.controllers.get(site or frappe.local.site):
 		site_controllers.pop(doctype, None)
+
+	if lazy_site_controllers := frappe.lazy_controllers.get(site or frappe.local.site):
+		lazy_site_controllers.pop(doctype, None)
 
 
 def get_doctype_map(doctype, name, filters=None, order_by=None):

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -312,7 +312,7 @@ def get_doc_permissions(doctype: str, docname: str):
 	:param doctype: DocType of the document to be evaluated
 	:param docname: `name` of the document to be evaluated
 	"""
-	doc = frappe.get_doc(doctype, docname)
+	doc = frappe.get_lazy_doc(doctype, docname)
 	return {"permissions": frappe.permissions.get_doc_permissions(doc)}
 
 
@@ -325,7 +325,7 @@ def get_password(doctype: str, name: str, fieldname: str):
 	:param fieldname: `fieldname` of the password property
 	"""
 	frappe.only_for("System Manager")
-	return frappe.get_doc(doctype, name).get_password(fieldname)
+	return frappe.get_lazy_doc(doctype, name).get_password(fieldname)
 
 
 from frappe.deprecation_dumpster import get_js as _get_js
@@ -361,7 +361,7 @@ def attach_file(
 	:param is_private: Attach file as private file (1 or 0)
 	:param docfield: file to attach to (optional)"""
 
-	doc = frappe.get_doc(doctype, docname)
+	doc = frappe.get_lazy_doc(doctype, docname)
 	doc.check_permission()
 
 	file = frappe.get_doc(

--- a/frappe/core/doctype/docshare/docshare.py
+++ b/frappe/core/doctype/docshare/docshare.py
@@ -46,7 +46,7 @@ class DocShare(Document):
 
 	def get_doc(self):
 		if not getattr(self, "_doc", None):
-			self._doc = frappe.get_doc(self.share_doctype, self.share_name)
+			self._doc = frappe.get_lazy_doc(self.share_doctype, self.share_name)
 		return self._doc
 
 	def validate_user(self):

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -132,7 +132,7 @@ def get_desktop_icons(user=None):
 
 				user_icons.append(standard_icon)
 
-		user_blocked_modules = frappe.get_doc("User", user).get_blocked_modules()
+		user_blocked_modules = frappe.get_lazy_doc("User", user).get_blocked_modules()
 		for icon in user_icons:
 			if icon.module_name in user_blocked_modules:
 				icon.hidden = 1

--- a/frappe/desk/doctype/tag/tag.py
+++ b/frappe/desk/doctype/tag/tag.py
@@ -115,7 +115,7 @@ class DocTags:
 			frappe.db.sql(
 				"update `tab{}` set _user_tags={} where name={}".format(self.dt, "%s", "%s"), (tags, dn)
 			)
-			doc = frappe.get_doc(self.dt, dn)
+			doc = frappe.get_lazy_doc(self.dt, dn)
 			update_tags(doc, tags)
 		except Exception as e:
 			if frappe.db.is_missing_column(e):

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -96,7 +96,7 @@ def get_docinfo(doc=None, doctype=None, name=None):
 	from frappe.share import _get_users as get_docshares
 
 	if not doc:
-		doc = frappe.get_doc(doctype, name)
+		doc = frappe.get_lazy_doc(doctype, name)
 		doc.check_permission("read")
 
 	all_communications = _get_communications(doc.doctype, doc.name, limit=21)
@@ -205,7 +205,7 @@ def get_versions(doc: "Document") -> list[dict]:
 def get_communications(doctype, name, start=0, limit=20):
 	from frappe.utils import cint
 
-	doc = frappe.get_doc(doctype, name)
+	doc = frappe.get_lazy_doc(doctype, name)
 	doc.check_permission("read")
 
 	return _get_communications(doctype, name, cint(start), cint(limit))

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -27,7 +27,7 @@ def add_comment(
 	reference_doctype: str, reference_name: str, content: str, comment_email: str, comment_by: str
 ) -> "Comment":
 	"""Allow logged user with permission to read document to add a comment"""
-	reference_doc = frappe.get_doc(reference_doctype, reference_name)
+	reference_doc = frappe.get_lazy_doc(reference_doctype, reference_name)
 	reference_doc.check_permission()
 
 	comment = frappe.new_doc("Comment")
@@ -58,7 +58,7 @@ def update_comment(name, content):
 		frappe.throw(_("Comment can only be edited by the owner"), frappe.PermissionError)
 
 	if doc.reference_doctype and doc.reference_name:
-		reference_doc = frappe.get_doc(doc.reference_doctype, doc.reference_name)
+		reference_doc = frappe.get_lazy_doc(doc.reference_doctype, doc.reference_name)
 		reference_doc.check_permission()
 
 		doc.content = extract_images_from_html(reference_doc, content, is_private=True)

--- a/frappe/desk/like.py
+++ b/frappe/desk/like.py
@@ -88,5 +88,5 @@ def remove_like(doctype, name):
 
 
 def add_comment(doctype, name):
-	doc = frappe.get_doc(doctype, name)
+	doc = frappe.get_lazy_doc(doctype, name)
 	doc.add_comment("Like", _("Liked"))

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -251,7 +251,7 @@ def get_open_count(doctype: str, name: str, items=None):
 	if frappe.flags.in_migrate or frappe.flags.in_install:
 		return {"count": []}
 
-	doc = frappe.get_doc(doctype, name)
+	doc = frappe.get_lazy_doc(doctype, name)
 	doc.check_permission()
 	meta = doc.meta
 	links = meta.get_dashboard_data()

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -233,7 +233,7 @@ def get_context(context):
 		)
 
 		for d in doc_list:
-			doc = frappe.get_doc(self.document_type, d.name)
+			doc = frappe.get_lazy_doc(self.document_type, d.name)
 
 			if self.condition and not frappe.safe_eval(self.condition, None, get_context(doc)):
 				continue
@@ -282,7 +282,7 @@ def get_context(context):
 		self.db_set("datetime_last_run", now)  # set reference now for next run
 
 		for d in doc_list:
-			doc = frappe.get_doc(self.document_type, d.name)
+			doc = frappe.get_lazy_doc(self.document_type, d.name)
 
 			if self.condition and not frappe.safe_eval(self.condition, None, get_context(doc)):
 				continue
@@ -443,7 +443,7 @@ def get_context(context):
 				communication_type="Automated Message",
 			).get("name")
 			# set the outgoing email account because we did in fact send it via sendmail above
-			comm = frappe.get_doc("Communication", communication)
+			comm = frappe.get_lazy_doc("Communication", communication)
 			comm.get_outgoing_email_account()
 
 		frappe.sendmail(

--- a/frappe/email/inbox.py
+++ b/frappe/email/inbox.py
@@ -42,7 +42,7 @@ def create_email_flag_queue(names, action):
 	"""create email flag queue to mark email either as read or unread"""
 
 	def mark_as_seen_unseen(name, action):
-		doc = frappe.get_doc("Communication", name)
+		doc = frappe.get_lazy_doc("Communication", name)
 		if action == "Read":
 			doc.add_seen()
 		else:

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -128,7 +128,7 @@ def upload_file():
 		else:
 			raise frappe.PermissionError
 	else:
-		user: User = frappe.get_doc("User", frappe.session.user)
+		user: User = frappe.get_lazy_doc("User", frappe.session.user)
 		ignore_permissions = False
 
 	files = frappe.request.files
@@ -210,7 +210,7 @@ def check_write_permission(doctype: str | None = None, name: str | None = None):
 		return
 
 	try:
-		doc = frappe.get_doc(doctype, name)
+		doc = frappe.get_lazy_doc(doctype, name)
 	except frappe.DoesNotExistError:
 		# doc has not been inserted yet, name is set to "new-some-doctype"
 		# If doc inserts fine then only this attachment will be linked see file/utils.py:relink_mismatched_files

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1983,7 +1983,7 @@ class LazyChildTable:
 		self.fieldname = fieldname
 		self.doctype = doctype
 
-	def __get__(self, doc, objtype=None):
+	def __get__(self, doc: Document, objtype=None):
 		# TODO: review cached_property magic
 		children = frappe.db.sql(
 			"""SELECT * FROM {table_name}
@@ -1998,5 +1998,6 @@ class LazyChildTable:
 		)
 
 		# Update __dict__ and convert to Document objects
+		doc.__dict__[self.fieldname] = []
 		doc.extend(self.fieldname, children or [])
 		return doc.__dict__[self.fieldname]  # Note: avoid any high level access here

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -139,7 +139,7 @@ def get_doc_from_dict(data: dict[str, Any], **kwargs) -> "Document":
 	raise ImportError(data["doctype"])
 
 
-def get_lazy_doc(doctype: str, name: str):
+def get_lazy_doc(doctype: str, name: str) -> "Document":
 	assert doctype != "DocType", "DocType can not be lazy loaded"
 
 	controller = get_lazy_controller(doctype)
@@ -1944,7 +1944,7 @@ def _document_values_generator(
 
 @frappe.whitelist()
 def unlock_document(doctype: str, name: str):
-	frappe.get_doc(doctype, name).unlock()
+	frappe.get_lazy_doc(doctype, name).unlock()
 	frappe.msgprint(frappe._("Document Unlocked"), alert=True)
 
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -21,7 +21,7 @@ from frappe.core.doctype.server_script.server_script_utils import run_server_scr
 from frappe.desk.form.document_follow import follow_document
 from frappe.integrations.doctype.webhook import run_webhooks
 from frappe.model import optional_fields, table_fields
-from frappe.model.base_document import BaseDocument, get_controller
+from frappe.model.base_document import BaseDocument, D, get_controller
 from frappe.model.docstatus import DocStatus
 from frappe.model.naming import set_new_name, validate_name
 from frappe.model.utils import is_virtual_doctype, simple_singledispatch
@@ -1983,10 +1983,23 @@ class LazyDocument:
 
 	@override
 	def get(self: Document, key, filters=None, limit=None, default=None):
+		# Ensure that table descriptor is triggered at least once
 		if isinstance(key, str) and key in self._table_fieldnames:
-			# Trigger populating of __dict__
 			getattr(self, key, None)
 		return super().get(key, filters, limit, default)
+
+	@override
+	def extend(self: Document, key, value):
+		# Ensure that table descriptor is triggered at least once
+		if isinstance(key, str) and key in self._table_fieldnames:
+			getattr(self, key, None)
+		return super().extend(key, value)
+
+	@override
+	def append(self, key: str, value: D | dict | None = None, position: int = -1) -> D:
+		if isinstance(key, str) and key in self._table_fieldnames:
+			getattr(self, key, None)
+		return super().append(key, value, position)
 
 	@override
 	def db_update_all(self):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -9,7 +9,7 @@ from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from functools import wraps
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, Union, overload
 
 from typing_extensions import Self, override
 from werkzeug.exceptions import NotFound
@@ -1983,11 +1983,10 @@ class LazyDocument:
 
 	@override
 	def get(self: Document, key, filters=None, limit=None, default=None):
-		if isinstance(key, str):
+		if isinstance(key, str) and key in self._table_fieldnames:
 			# Trigger populating of __dict__
 			getattr(self, key, None)
-		parent = cast(Document, super())
-		return parent.get(key, filters, limit, default)
+		return super().get(key, filters, limit, default)
 
 	@override
 	def db_update_all(self):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -140,6 +140,8 @@ def get_doc_from_dict(data: dict[str, Any], **kwargs) -> "Document":
 
 
 def get_lazy_doc(doctype: str, name: str):
+	assert doctype != "DocType", "DocType can not be lazy loaded"
+
 	controller = get_lazy_controller(doctype)
 	if controller:
 		return controller(doctype, name)
@@ -1950,6 +1952,7 @@ def get_lazy_controller(doctype):
 
 		lazy_controller = type(f"Lazy{original_controller.__name__}", (LazyDocument, original_controller), {})
 		meta = frappe.get_meta(doctype)
+		assert not meta.is_virtual, "Virtual DocTypes can not be lazy loaded"
 		for fieldname, child_doctype in meta._table_doctypes.items():
 			setattr(lazy_controller, fieldname, LazyChildTable(fieldname, child_doctype))
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -2017,3 +2017,5 @@ class LazyChildTable:
 		# Update __dict__ and convert to Document objects
 		doc.extend(fieldname, children)
 		return __dict[fieldname]
+
+	# Note: Don't implement __set__ method! https://docs.python.org/3/howto/descriptor.html#descriptor-protocol

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -129,10 +129,8 @@ def has_permission(
 
 	if doc:
 		if isinstance(doc, str | int):
-			if meta.is_virtual or doctype == "DocType":
-				doc = frappe.get_doc(meta.name, doc)
-			else:  # perf: Avoid loading child tables for perm checks
-				doc = frappe.get_lazy_doc(meta.name, doc)
+			# perf: Avoid loading child tables for perm checks
+			doc = frappe.get_lazy_doc(meta.name, doc)
 		perm = get_doc_permissions(doc, user=user, ptype=ptype, debug=debug).get(ptype)
 		if not perm:
 			debug and _debug_log(

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -129,7 +129,10 @@ def has_permission(
 
 	if doc:
 		if isinstance(doc, str | int):
-			doc = frappe.get_doc(meta.name, doc)
+			if meta.is_virtual or doctype == "DocType":
+				doc = frappe.get_doc(meta.name, doc)
+			else:  # perf: Avoid loading child tables for perm checks
+				doc = frappe.get_lazy_doc(meta.name, doc)
 		perm = get_doc_permissions(doc, user=user, ptype=ptype, debug=debug).get(ptype)
 		if not perm:
 			debug and _debug_log(

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -277,7 +277,7 @@ class Session:
 			self.insert_session_record()
 
 			# update user
-			user = frappe.get_doc("User", self.data["user"])
+			user = frappe.get_lazy_doc("User", self.data["user"])
 			user_doctype = frappe.qb.DocType("User")
 			(
 				frappe.qb.update(user_doctype)

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -125,7 +125,7 @@ def set_docshare_permission(doctype, name, user, permission_to, value=1, everyon
 @frappe.whitelist()
 def get_users(doctype: str, name: str) -> list:
 	"""Get list of users with which this document is shared"""
-	doc = frappe.get_doc(doctype, name)
+	doc = frappe.get_lazy_doc(doctype, name)
 	return _get_users(doc)
 
 

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -541,6 +541,10 @@ class TestDocument(IntegrationTestCase):
 			self.assertEqual(guest_role.role, "Guest")
 			self.assertIsInstance(guest_role, type(eager_guest.roles[0]))
 
+		# Only one query for one table access
+		with self.assertQueryCount(1):
+			_ = guest.role_profiles
+
 		# No queries for repeat access, same object
 		with self.assertQueryCount(0):
 			guest_role_repeat_access = guest.roles[0]
@@ -551,6 +555,8 @@ class TestDocument(IntegrationTestCase):
 
 		# things accessing __dict__ by default should be updated too
 		self.assertTrue(frappe.get_lazy_doc("User", "Guest").get("roles"))
+
+		guest.save()
 
 
 class TestDocumentWebView(IntegrationTestCase):

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -550,12 +550,14 @@ class TestDocument(IntegrationTestCase):
 			guest_role_repeat_access = guest.roles[0]
 		self.assertIs(guest_role, guest_role_repeat_access)
 
+		# Same object after first access
 		with self.assertQueryCount(0):
 			self.assertIs(guest.roles, guest.get("roles"))
 
 		# things accessing __dict__ by default should be updated too
 		self.assertTrue(frappe.get_lazy_doc("User", "Guest").get("roles"))
 
+	def test_lazy_doc_efficient_saves(self):
 		# Only touched tables and self should be updated
 		guest = frappe.get_lazy_doc("User", "Guest")
 		with self.assertQueryCount(1):

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -556,6 +556,18 @@ class TestDocument(IntegrationTestCase):
 		# things accessing __dict__ by default should be updated too
 		self.assertTrue(frappe.get_lazy_doc("User", "Guest").get("roles"))
 
+		# Only touched tables and self should be updated
+		guest = frappe.get_lazy_doc("User", "Guest")
+		with self.assertQueryCount(1):
+			guest.db_update_all()
+
+		guest = frappe.get_lazy_doc("User", "Guest")
+		_ = guest.roles
+		with self.assertQueryCount(1 + len(guest.roles)):
+			guest.db_update_all()
+
+		# Save should works, it won't be efficient because internal code will just trigger fetching
+		# of child tables to resave them.
 		guest.save()
 
 

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -527,76 +527,6 @@ class TestDocument(IntegrationTestCase):
 		changed_val = frappe.db.get_single_value(c.doctype, key)
 		self.assertEqual(val, changed_val)
 
-	def test_lazy_documents(self):
-		# Warmup meta etc
-		_ = frappe.get_lazy_doc("User", "Guest")
-		eager_guest: User = frappe.get_doc("User", "Guest")
-
-		# Only one query for parent document
-		with self.assertQueryCount(1):
-			guest: User = frappe.get_lazy_doc("User", "Guest")
-			self.assertEqual(guest.user_type, "Website User")
-
-		# Only one query for one table access
-		with self.assertQueryCount(1):
-			guest_role = guest.roles[0]
-			self.assertEqual(guest_role.role, "Guest")
-			self.assertIsInstance(guest_role, type(eager_guest.roles[0]))
-
-		# Only one query for one table access
-		with self.assertQueryCount(1):
-			_ = guest.role_profiles
-
-		# No queries for repeat access, same object
-		with self.assertQueryCount(0):
-			guest_role_repeat_access = guest.roles[0]
-		self.assertIs(guest_role, guest_role_repeat_access)
-
-		# Same object after first access
-		with self.assertQueryCount(0):
-			self.assertIs(guest.roles, guest.get("roles"))
-
-		# things accessing __dict__ by default should be updated too
-		self.assertTrue(frappe.get_lazy_doc("User", "Guest").get("roles"))
-
-	def test_lazy_doc_efficient_saves(self):
-		# Only touched tables and self should be updated
-		guest = frappe.get_lazy_doc("User", "Guest")
-		with self.assertQueryCount(1):
-			guest.db_update_all()
-
-		guest = frappe.get_lazy_doc("User", "Guest")
-		_ = guest.roles
-		with self.assertQueryCount(1 + len(guest.roles)):
-			guest.db_update_all()
-
-		# Save should works, it won't be efficient because internal code will just trigger fetching
-		# of child tables to resave them.
-		guest.save()
-
-	def test_lazy_magic(self):
-		self.assertIsNone(getattr(LazyChildTable, "__set__", None))
-
-		guest = frappe.get_lazy_doc("User", "Guest")
-		# table fields will be populated on first access
-		self.assertIsNone(guest.__dict__.get("roles"))
-		roles = guest.roles
-		self.assertIs(guest.__dict__.get("roles"), roles)
-
-		# Allow overriding from user code
-		roles_copy = deepcopy(roles)
-		guest.roles = roles_copy
-		self.assertIs(guest.__dict__.get("roles"), roles_copy)
-
-		with patch(f"{LazyChildTable.__module__}.{LazyChildTable.__name__}.__get__") as getter:
-			_ = guest.roles
-			self.assertFalse(getter.called)
-
-		guest = frappe.get_lazy_doc("User", "Guest")
-		with patch(f"{LazyChildTable.__module__}.{LazyChildTable.__name__}.__get__") as getter:
-			_ = guest.roles
-			self.assertTrue(getter.called)
-
 
 class TestDocumentWebView(IntegrationTestCase):
 	def get(self, path, user="Guest"):
@@ -734,3 +664,84 @@ class TestDocumentWebView(IntegrationTestCase):
 		)
 		self.assertEqual(sent_docs - all_docs, set(), "All docs should be inserted")
 		self.assertEqual(sent_child_docs - all_child_docs, set(), "All child docs should be inserted")
+
+
+class TestLazyDocument(IntegrationTestCase):
+	def test_lazy_documents(self):
+		# Warmup meta etc
+		_ = frappe.get_lazy_doc("User", "Guest")
+		eager_guest: User = frappe.get_doc("User", "Guest")
+
+		# Only one query for parent document
+		with self.assertQueryCount(1):
+			guest: User = frappe.get_lazy_doc("User", "Guest")
+			self.assertEqual(guest.user_type, "Website User")
+
+		# Only one query for one table access
+		with self.assertQueryCount(1):
+			guest_role = guest.roles[0]
+			self.assertEqual(guest_role.role, "Guest")
+			self.assertIsInstance(guest_role, type(eager_guest.roles[0]))
+
+		# Only one query for one table access
+		with self.assertQueryCount(1):
+			_ = guest.role_profiles
+
+		# No queries for repeat access, same object
+		with self.assertQueryCount(0):
+			guest_role_repeat_access = guest.roles[0]
+		self.assertIs(guest_role, guest_role_repeat_access)
+
+		# Same object after first access
+		with self.assertQueryCount(0):
+			self.assertIs(guest.roles, guest.get("roles"))
+
+		# things accessing __dict__ by default should be updated too
+		self.assertTrue(frappe.get_lazy_doc("User", "Guest").get("roles"))
+
+	def test_lazy_doc_efficient_saves(self):
+		# Only touched tables and self should be updated
+		guest = frappe.get_lazy_doc("User", "Guest")
+		with self.assertQueryCount(1):
+			guest.db_update_all()
+
+		guest = frappe.get_lazy_doc("User", "Guest")
+		_ = guest.roles
+		with self.assertQueryCount(1 + len(guest.roles)):
+			guest.db_update_all()
+
+		# Save should works, it won't be efficient because internal code will just trigger fetching
+		# of child tables to resave them.
+		guest.save()
+
+	def test_lazy_magic(self):
+		self.assertIsNone(getattr(LazyChildTable, "__set__", None))
+
+		guest = frappe.get_lazy_doc("User", "Guest")
+		# table fields will be populated on first access
+		self.assertIsNone(guest.__dict__.get("roles"))
+		roles = guest.roles
+		self.assertIs(guest.__dict__.get("roles"), roles)
+
+		# Allow overriding from user code
+		roles_copy = deepcopy(roles)
+		guest.roles = roles_copy
+		self.assertIs(guest.__dict__.get("roles"), roles_copy)
+
+		with patch(f"{LazyChildTable.__module__}.{LazyChildTable.__name__}.__get__") as getter:
+			_ = guest.roles
+			self.assertFalse(getter.called)
+
+		guest = frappe.get_lazy_doc("User", "Guest")
+		with patch(f"{LazyChildTable.__module__}.{LazyChildTable.__name__}.__get__") as getter:
+			_ = guest.roles
+			self.assertTrue(getter.called)
+
+	def test_append_extend(self):
+		guest = frappe.get_lazy_doc("User", "Guest")
+		_ = guest.append("roles")
+		self.assertEqual(len(guest.roles), 2)
+
+		guest = frappe.get_lazy_doc("User", "Guest")
+		_ = guest.extend("roles", [{}])
+		self.assertEqual(len(guest.roles), 2)

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -483,7 +483,7 @@ def get_context(context):
 			return False
 
 		if self.apply_document_permissions:
-			return frappe.get_doc(doctype, name).has_permission(permtype=ptype)
+			return frappe.get_last_doc(doctype, name).has_permission(permtype=ptype)
 
 		# owner matches
 		elif frappe.db.get_value(doctype, name, "owner") == frappe.session.user:
@@ -558,7 +558,7 @@ def accept(web_form, data):
 	files = []
 	files_to_delete = []
 
-	web_form = frappe.get_doc("Web Form", web_form)
+	web_form = frappe.get_lazy_doc("Web Form", web_form)
 	doctype = web_form.doc_type
 	user = frappe.session.user
 
@@ -654,7 +654,7 @@ def accept(web_form, data):
 
 @frappe.whitelist()
 def delete(web_form_name: str, docname: str | int):
-	web_form = frappe.get_doc("Web Form", web_form_name)
+	web_form = frappe.get_lazy_doc("Web Form", web_form_name)
 
 	owner = frappe.db.get_value(web_form.doc_type, docname, "owner")
 	if frappe.session.user == owner and web_form.allow_delete:
@@ -665,7 +665,7 @@ def delete(web_form_name: str, docname: str | int):
 
 @frappe.whitelist()
 def delete_multiple(web_form_name: str, docnames):
-	web_form = frappe.get_doc("Web Form", web_form_name)
+	web_form = frappe.get_lazy_doc("Web Form", web_form_name)
 
 	docnames = json.loads(docnames)
 
@@ -691,7 +691,7 @@ def delete_multiple(web_form_name: str, docnames):
 
 
 def check_webform_perm(doctype, name):
-	doc = frappe.get_doc(doctype, name)
+	doc = frappe.get_lazy_doc(doctype, name)
 	if hasattr(doc, "has_webform_permission"):
 		if doc.has_webform_permission():
 			return True
@@ -762,7 +762,7 @@ def get_in_list_view_fields(doctype):
 
 
 def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=False):
-	web_form: WebForm = frappe.get_doc("Web Form", web_form_name)
+	web_form: WebForm = frappe.get_lazy_doc("Web Form", web_form_name)
 
 	if web_form.login_required and frappe.session.user == "Guest":
 		frappe.throw(_("You must be logged in to use this form."), frappe.PermissionError)

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -197,7 +197,7 @@ def get_list_context(context, doctype, web_form_name=None):
 
 	# get context from web form module
 	if web_form_name:
-		web_form = frappe.get_doc("Web Form", web_form_name)
+		web_form = frappe.get_lazy_doc("Web Form", web_form_name)
 		list_context = update_context_from_module(get_web_form_module(web_form), list_context)
 
 	# get path from '/templates/' folder of the doctype

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -60,7 +60,7 @@ def get_context(context) -> PrintContext:
 	if frappe.form_dict.doc:
 		doc = frappe.form_dict.doc
 	else:
-		doc = frappe.get_doc(frappe.form_dict.doctype, frappe.form_dict.name)
+		doc = frappe.get_lazy_doc(frappe.form_dict.doctype, frappe.form_dict.name)
 
 	set_link_titles(doc)
 
@@ -340,7 +340,7 @@ def get_html_and_style(
 	"""Return `html` and `style` of print format, used in PDF etc."""
 
 	if isinstance(name, str):
-		document = frappe.get_doc(doc, name)
+		document = frappe.get_lazy_doc(doc, name)
 	else:
 		document = frappe.get_doc(json.loads(doc))
 
@@ -371,7 +371,7 @@ def get_rendered_raw_commands(doc: str, name: str | None = None, print_format: s
 	"""Return Rendered Raw Commands of print format, used to send directly to printer."""
 
 	if isinstance(name, str):
-		document = frappe.get_doc(doc, name)
+		document = frappe.get_lazy_doc(doc, name)
 	else:
 		document = frappe.get_doc(json.loads(doc))
 


### PR DESCRIPTION
~~_barely_~~ mostly working proof of concept.

TL;DR Load child tables from DB when they're accessed, else don't.


TODO: 
- [x] See if property indirection can be removed after first access ~unlikely though.~ possible with non-data descriptors :sparkles: 
- [x] Make it work with `doc.get`
- [x] Make it work with `doc.db_update_all()` - only update touched data.
- [x] ~Make it work with `doc.save` - ONLY save accessed tables~ nearly impossible because everything is read during validations... also `doc.modified`
- [x] Use in framework in few places where it makes sense
- [x] Audit `__dict__` direct accesses -> only `doc.get` does it
- [x] Block all unsupported usage - `DocType`, `virtual` etc


Reference: This is similar/same as `cached_property` https://docs.python.org/3/howto/descriptor.html

5x faster on User :smile: Speedup depends on usage and complexity of document. 

```
In [2]: %timeit frappe.get_doc("User", "Guest")
1.4 ms ± 8.5 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [3]: %timeit frappe.get_lazy_doc("User", "Guest")
262 µs ± 3.36 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
