### PR TITLE
fix: set bcc in emails

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -490,7 +490,7 @@ def get_permission_query_conditions_for_communication(user):
 			return """`tabCommunication`.communication_medium!='Email'"""
 
 		email_accounts = ['"{}"'.format(account.get("email_account")) for account in accounts]
-		return """`tabCommunication`.email_account in ({email_accounts}) or `tabCommunication`.recipients LIKE '%{user}%' or `tabCommunication`.sender LIKE '%{user}%'""".format(
+		return """`tabCommunication`.email_account in ({email_accounts}) or `tabCommunication`.recipients LIKE '%{user}%' or `tabCommunication`.sender LIKE '%{user}%' or `tabCommunication`.cc LIKE '%{user}%' or `tabCommunication`.bcc LIKE '%{user}%'""".format(
 			email_accounts=",".join(email_accounts), user=user
 		)
 

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -639,6 +639,9 @@ class InboundMail(Email):
 		communication = self.is_exist_in_system()
 		if communication:
 			communication.update_db(uid=self.uid)
+			data = self.as_dict()
+			if data.get("bcc") and not communication.bcc:
+				communication.update_db(bcc=data.get("bcc"))
 			communication.reload()
 			return communication
 
@@ -907,6 +910,7 @@ class InboundMail(Email):
 			"sender": self.from_email,
 			"recipients": self.decode_email(self.mail.get("To") or ""),
 			"cc": self.decode_email(self.mail.get("CC") or ""),
+			"bcc": self.decode_email(self.mail.get("BCC") or ""),
 			"email_account": self.email_account.name,
 			"communication_medium": "Email",
 			"uid": self.uid,


### PR DESCRIPTION
Sets bcc in emails if it present 
On a condition if there are 2 email accounts and there is a email with Account A in cc and Account B in bcc 
The email already exists in the system simply update the bcc field 


Ref ticktet https://support.frappe.io/helpdesk/tickets/38900