### PR TITLE
Fixed transaction log report

### DIFF
--- a/frappe/core/report/transaction_log_report/transaction_log_report.py
+++ b/frappe/core/report/transaction_log_report/transaction_log_report.py
@@ -30,7 +30,7 @@ def get_data(filters=None):
 				integrity = False
 			else:
 				integrity = check_data_integrity(
-					l.chaining_hash, l.transaction_hash, l.previous_hash, previous_hash[0][0]
+					l.chaining_hash, l.transaction_hash, l.previous_hash, previous_hash[0]["chaining_hash"]
 				)
 
 			result.append(
@@ -72,7 +72,7 @@ def check_data_integrity(chaining_hash, transaction_hash, registered_previous_ha
 
 def calculate_chain(transaction_hash, previous_hash):
 	sha = hashlib.sha256()
-	sha.update(str(transaction_hash) + str(previous_hash))
+	sha.update(transaction_hash.encode("utf-8") + previous_hash.encode("utf-8"))
 	return sha.hexdigest()
 
 


### PR DESCRIPTION
The transaction log report seems to be broken (possibly since commit 980f50c from 2021). Fixed the ORM errors an the hashlib encoding signature.

This is necessary to meet legal obligations in France and Germany and should probably get some automated tests.