### PR TITLE
fix(ui): Enable vertical scrolling on the desk sidebar

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -268,6 +268,7 @@ body {
 		.sidebar-items {
 			padding: 0px;
 			width: 100%;
+			overflow-y: auto;
 		}
 		.collapse-sidebar-link {
 			visibility: visible;


### PR DESCRIPTION
This PR fixes a minor usability issue where the desk sidebar would not scroll if its content, such as a long list of workspaces  exceeded the available viewport height.

Changes:

Added `overflow-y: auto`; to the `.sidebar-items` selector in `frappe/public/scss/desk/sidebar.scss`.

This ensures that a scrollbar appears automatically only when needed, improving navigation for users on smaller screens or with many modules enabled.

Before and After:

https://github.com/user-attachments/assets/4fa80b1b-75bd-4aca-bfec-8b472d2b83fb





