### PR TITLE
fix: mismatch child table background color

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -47,6 +47,7 @@
 		.search {
 			// TODO: Align with table grid without overwriting padding if possible
 			padding: 4px 7px 4px 7px !important;
+			background-color: var(--fg-color);
 		}
 	}
 


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/c81367f7-700b-4ae3-88ae-892639d25074)


## After
![image](https://github.com/user-attachments/assets/8761bdc3-48e3-416f-9bb0-90ca233d4ae5)
