### PR TITLE
fix!: Don't update document from keyword args

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -194,8 +194,6 @@ class Document(BaseDocument):
 		# since it is used in virtual doctypes and inherited in child classes
 		self.flags.for_update = kwargs.pop("for_update", None)
 		self.load_from_db()
-		if kwargs:  # ad-hoc overrides
-			self._init_from_kwargs(kwargs)
 
 	def _init_dispatch(self, arg, *args, **kwargs):
 		if isinstance(arg, str):


### PR DESCRIPTION
Right now if you do this:

`get_doc(doctype, name, field=value)` then it loads document from DB and then updates field to value on the document.

This is an absurd API and I don't think it was ever done intentionally.