### PR TITLE
fix: forward-compatibility for lazy documents

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2483,3 +2483,5 @@ if _tune_gc:
 
 # Remove references to pattern that are pre-compiled and loaded to global scopes.
 re.purge()
+
+get_lazy_doc = get_doc


### PR DESCRIPTION
This just makes it easy to maintain code without worrying about
accidentally introducing a feature that only exists in "future".
