### PR TITLE
fix: update Keycloak redirect_url to correct login method endpoint

### DIFF
--- a/frappe/integrations/doctype/social_login_key/social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/social_login_key.py
@@ -218,7 +218,7 @@ class SocialLoginKey(Document):
 			"provider_name": "Keycloak",
 			"enable_social_login": 1,
 			"custom_base_url": 1,
-			"redirect_url": "/api/method/frappe.integrations.oauth2_logins.login_via_keycloak/keycloak",
+			"redirect_url": "/api/method/frappe.integrations.oauth2_logins.login_via_keycloak",
 			"api_endpoint": "/protocol/openid-connect/userinfo",
 			"api_endpoint_args": None,
 			"authorize_url": "/protocol/openid-connect/auth",


### PR DESCRIPTION
Issue:
Keycloak login was failing due to an incorrect redirect_url
(`/login_via_keycloak/keycloak`), which resulted in a 403 error.

Solution:
Updated the redirect_url to the correct endpoint
`/api/method/frappe.integrations.oauth2_logins.login_via_keycloak` to
Align with Frappe's expected OAuth2 login flow.

Before:

[before url change.webm](https://github.com/user-attachments/assets/6d5256a7-9758-4cb3-a5a3-6140e1d97496)

After:

[after url change.webm](https://github.com/user-attachments/assets/91bab80a-2e95-4f03-88a2-143dc1ac8a00)

Backport Needed: Version-15