### PR TITLE
fix: update `setup_complete` based on current app

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -283,7 +283,8 @@ frappe.Application = class Application {
 
 			let current_app = localStorage.current_app;
 			if (current_app) {
-				frappe.boot.setup_complete = frappe.boot.setup_wizard_not_required_apps?.includes(current_app) ||
+				frappe.boot.setup_complete =
+					frappe.boot.setup_wizard_not_required_apps?.includes(current_app) ||
 					frappe.boot.setup_wizard_completed_apps?.includes(current_app);
 			}
 

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -280,6 +280,13 @@ frappe.Application = class Application {
 			if (frappe.boot.print_css) {
 				frappe.dom.set_style(frappe.boot.print_css, "print-style");
 			}
+
+			let current_app = localStorage.current_app;
+			if (current_app) {
+				frappe.boot.setup_complete = frappe.boot.setup_wizard_not_required_apps?.includes(current_app) ||
+					frappe.boot.setup_wizard_completed_apps?.includes(current_app);
+			}
+
 			frappe.user.name = frappe.boot.user.name;
 			frappe.router.setup();
 		} else {

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -128,13 +128,8 @@ frappe.router = {
 		if (!frappe.app) return;
 
 		let sub_path = this.get_sub_path();
-		let current_app = localStorage.current_app;
 
-		if (
-			frappe.boot.setup_complete ||
-			(current_app && frappe.boot.setup_wizard_not_required_apps?.includes(current_app)) ||
-			(current_app && frappe.boot.setup_wizard_completed_apps?.includes(current_app))
-		) {
+		if (frappe.boot.setup_complete) {
 			!frappe.re_route["setup-wizard"] && (frappe.re_route["setup-wizard"] = "app");
 		} else if (!sub_path.startsWith("setup-wizard")) {
 			frappe.re_route["setup-wizard"] && delete frappe.re_route["setup-wizard"];


### PR DESCRIPTION
If there are multiple apps and one of them has an incomplete setup, then none of the app's workspaces are accessible because the sidebar is not initialised

https://github.com/frappe/frappe/blob/f8a6cf899579e96ea63739b191f819ae0d0e4a57/frappe/public/js/frappe/ui/sidebar.js#L7-L10

```
sidebar.js:193 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'find')
    at Sidebar.make_sidebar (sidebar.js:193:20)
    at Sidebar.setup_pages (sidebar.js:177:9)
    at new Workspace (workspace.js:50:16)
    at frappe.standard_pages.Workspaces (workspace.js:14:21)
    at Object.with_page (pageview.js:11:27)
    at pageview.js:52:26
    at Object.with_doctype (model.js:242:16)
    at Object.show (pageview.js:51:16)
    at Object.render_page (router.js:320:27)
    at Object.render (router.js:294:9)
```







