### PR TITLE
fix: random row name for insecure contexts

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -164,7 +164,7 @@ export default class Grid {
 	}
 
 	get_random_name() {
-		return crypto.randomUUID().slice(0, 8);
+		return Math.random().toString(36).slice(2, 10);
 	}
 
 	set_doc_url() {


### PR DESCRIPTION
`crypto.randomUUID` is only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts), meaning TLS-protected or localhost. This PR replaces that with `Math.random`, which is available in insecure contexts as well, more predictable (pseudo-random, but we don't care for this use case), but has a lower chance of key collisions (that's even better).

Resolves https://github.com/frappe/frappe/pull/32512#issuecomment-2966215907
