### PR TITLE
fix: show correct link titles in report view

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -150,6 +150,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		if (!this.group_by) {
 			this.init_chart();
 		}
+
 		this.set_link_title_field_value();
 	}
 
@@ -159,7 +160,12 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				this.link_title_doctype_fields[key],
 				key
 			);
-			document.querySelector(`a[data-name="${key}"]`).innerHTML = link_title;
+
+			if (link_title !== undefined) {
+				document.querySelectorAll(`a[data-name="${key}"]`).forEach((el) => {
+					el.innerHTML = link_title;
+				});
+			}
 		});
 	}
 


### PR DESCRIPTION
### Before
<img width="615" alt="Screenshot 2025-06-12 at 18 01 38" src="https://github.com/user-attachments/assets/07a02c59-df71-40c4-b0f4-76d36789db74" />


### After
<img width="612" alt="Screenshot 2025-06-12 at 17 58 50" src="https://github.com/user-attachments/assets/e225d3f3-45a4-4766-ad7d-28974a8f26d3" />