### PR TITLE
perf: Limit get_open_count to 1s for each count query

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -457,18 +457,14 @@ frappe.ui.form.Dashboard = class FormDashboard {
 		$.each(count.internal_links_found, function (i, d) {
 			me.frm.dashboard.set_badge_count_for_internal_link(
 				d.doctype,
-				cint(d.open_count),
-				cint(d.count),
+				d.open_count,
+				d.count,
 				d.names
 			);
 		});
 
 		$.each(count.external_links_found, function (i, d) {
-			me.frm.dashboard.set_badge_count_for_external_link(
-				d.doctype,
-				cint(d.open_count),
-				cint(d.count)
-			);
+			me.frm.dashboard.set_badge_count_for_external_link(d.doctype, d.open_count, d.count);
 		});
 	}
 
@@ -499,14 +495,20 @@ frappe.ui.form.Dashboard = class FormDashboard {
 			$link
 				.find(".open-notification")
 				.removeClass("hidden")
-				.html(open_count > 99 ? "99+" : open_count);
+				.html(cint(open_count) > 99 ? "99+" : open_count);
 		}
 
 		if (count) {
 			$link
 				.find(".count")
 				.removeClass("hidden")
-				.text(count > 99 ? "99+" : count);
+				.text(cint(count) > 99 ? "99+" : count)
+				.attr(
+					"title",
+					count != "?"
+						? __("Count of linked documents")
+						: __("Accurate count can not be fetched, click here to view all documents")
+				);
 		}
 	}
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/63bbc56c-1532-4584-9939-5d0658aa828f)


If left unoptimized, this wreaks havoc on database servers and has little value. If it's valuable, people will complain about "?" and it will get fixed.

This constraint on runtime should always be present.


towards https://github.com/frappe/caffeine/issues/63
similar to https://github.com/frappe/frappe/pull/30050 


![image](https://github.com/user-attachments/assets/c849a6b7-6256-4b27-b185-91e82ef9ca0a)


