### PR TITLE
perf: defer view log and enhance flushing

### DIFF
--- a/frappe/deferred_insert.py
+++ b/frappe/deferred_insert.py
@@ -31,7 +31,7 @@ def save_to_db():
 		record_count = 0
 		queue_key = get_key_name(key)
 		doctype = get_doctype_name(key)
-		while frappe.cache.llen(queue_key) > 0 and record_count <= 500:
+		while frappe.cache.llen(queue_key) > 0 and record_count <= 10000:
 			records = frappe.cache.lpop(queue_key)
 			records = json.loads(records.decode("utf-8"))
 			if isinstance(records, dict):
@@ -41,6 +41,11 @@ def save_to_db():
 			for record in records:
 				record_count += 1
 				insert_record(record, doctype)
+				if record_count % 100 == 0:
+					frappe.db.commit()
+
+			if record_count % 100 == 0:
+				frappe.db.commit()
 
 
 def insert_record(record: Union[dict, "Document"], doctype: str):

--- a/frappe/website/doctype/web_page_view/web_page_view.py
+++ b/frappe/website/doctype/web_page_view/web_page_view.py
@@ -93,10 +93,7 @@ def make_view_log(
 	view.visitor_id = visitor_id
 
 	try:
-		if frappe.flags.read_only:
-			view.deferred_insert()
-		else:
-			view.insert(ignore_permissions=True)
+		view.deferred_insert()
 	except Exception:
 		frappe.clear_last_message()
 


### PR DESCRIPTION
1. Always defer web page view logs
2. Commit frequently in deferred_insert, increase limit on flushed document in single job.

Partially resolves https://github.com/frappe/frappe/issues/25777