### PR TITLE
chore: remove invalid call to super() on a dead code

### DIFF
--- a/frappe/query_builder/builder.py
+++ b/frappe/query_builder/builder.py
@@ -33,18 +33,6 @@ class Base:
 		table_name = get_table_name(table_name)
 		return Table(table_name, *args, **kwargs)
 
-	@classmethod
-	def into(cls, table, *args, **kwargs) -> QueryBuilder:
-		if isinstance(table, str):
-			table = cls.DocType(table)
-		return super().into(table, *args, **kwargs)
-
-	@classmethod
-	def update(cls, table, *args, **kwargs) -> QueryBuilder:
-		if isinstance(table, str):
-			table = cls.DocType(table)
-		return super().update(table, *args, **kwargs)
-
 
 class MariaDB(Base, MySQLQuery):
 	Field = terms.Field


### PR DESCRIPTION
 - 'Base' class implicitly inherits 'object' which doesn't have 'into' or 'update' methods so call to `super()` will throw error
 - These methods are never reached during runtime - dead code