### PR TITLE
fix: auto-refresh reports when date filter is cleared , fix :  Prevent auto-filling of mandatory Float fields with 0.0 to ensure user input is required for validation.

### DIFF
--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -37,6 +37,17 @@ def make_new_doc(doctype):
 	set_user_and_static_default_values(doc)
 
 	doc._fix_numeric_types()
+
+	# Ensure mandatory numeric fields don't get auto-filled with 0.0/0
+	meta = frappe.get_meta(doctype)
+	for df in meta.get("fields"):
+		if (
+			df.reqd
+			and df.fieldtype in ("Float", "Currency", "Percent")
+			and doc.get(df.fieldname) in (0, 0.0)
+		):
+			doc[df.fieldname] = None
+
 	doc = doc.get_valid_dict(sanitize=False)
 	doc["doctype"] = doctype
 	doc["__islocal"] = 1

--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -18,7 +18,11 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 		if (this.timepicker_only) return;
 		if (!this.datepicker) return;
 		if (!value) {
+			// Clear any selected date and trigger change so that dependent listeners (e.g. report filters)
+			// detect that the value has been emptied and can refresh automatically.
 			this.datepicker.clear();
+			// Manually fire the change event because datepicker.clear() does not emit it.
+			this.$input && this.$input.trigger("change");
 			return;
 		}
 


### PR DESCRIPTION
Previously, clearing a non-mandatory date filter in reports did not trigger a refresh, leading to stale results. Now, when a date filter is emptied, a change event is triggered so that dependent report handlers detect the update and refresh automatically. This improves UX and supports optional date filters in custom reports.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
