### PR TITLE
fix: Prevent doctype formatting differences in preview/print-view

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -684,7 +684,8 @@ frappe.ui.form.PrintView = class {
 		this._req = frappe.call({
 			method: "frappe.www.printview.get_html_and_style",
 			args: {
-				doc: this.frm.doc,
+				doc: this.frm.doc.doctype,
+				name: this.frm.doc.name,
 				print_format: this.selected_format(),
 				no_letterhead: !this.with_letterhead() ? 1 : 0,
 				letterhead: this.get_letterhead(),


### PR DESCRIPTION
Set doctype & name instead of json doctype, whose doctype values might be formatted differently, leading to different values in preview/print-view. Read more about the cause in my comment here: https://github.com/frappe/frappe/issues/32941#issuecomment-2974159090

This is more of a partial fix for issue #32941 . Theoretically, the problem could be much bigger as there is a conversion issue from doctype -> json or json -> doctype, maybe even both. 

> [!WARNING]  
> Further investigation is defilitelly needed, but in the meantime, this fix should serve as an effective solution. I'll leave this issue open because of this reason

> [!NOTE]  
> This issue should be backported to v15 and maybe v14 (not tested)