### PR TITLE
fix(ui): enable vertical scrolling on sidebar with overflow-y

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -101,7 +101,8 @@ body {
 		flex-wrap: nowrap;
 
 		gap: 2px;
-		overflow: hidden;
+		overflow-y: auto;
+		overflow-x: hidden;
 		position: static;
 		font-size: var(--text-base);
 		// transition: width 200ms;
@@ -252,7 +253,7 @@ body {
 		}
 		.body-sidebar-top {
 			width: 100%;
-			overflow-y: hidden;
+			overflow-y: auto;
 		}
 		.sidebar-item-container {
 			width: 100%;


### PR DESCRIPTION
This PR improves the usability of the sidebar in Frappe by enabling vertical scrolling (`overflow-y: auto`).  
Previously, when content in the sidebar exceeded the visible area, it would be hidden and inaccessible.  
Now, users can scroll to view all sidebar content.

## 🎥 Before & After Demo

https://github.com/user-attachments/assets/0997ecd4-3d4f-4a40-9b26-7ebd5eee03b6