### PR TITLE
refactor: build match condition for query builder

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -768,6 +768,22 @@ def build_match_conditions(doctype, user=None, as_condition=True):
 	return match_conditions
 
 
+def build_qb_match_conditions(doctype, user=None) -> list:
+	match_filters = build_match_conditions(doctype, user, False)
+	criterion = []
+	if match_filters:
+		from frappe import qb
+
+		_dt = qb.DocType(doctype)
+
+		for filter in match_filters:
+			for d, names in filter.items():
+				fieldname = d.lower().replace(" ", "_")
+				criterion.append(_dt[fieldname].isin(names))
+
+	return criterion
+
+
 def get_filters_cond(doctype, filters, conditions, ignore_permissions=None, with_match_conditions=False):
 	if isinstance(filters, str):
 		filters = json.loads(filters)


### PR DESCRIPTION
## Issue
Query Builder doesn't handle user permissions. So, the only way to handle them in QB queries is by 

converting to Raw SQL -> get conditions using `build_match_conditions` -> append it to original query and then pass this to `frappe.db.sql`

Ex: 
![Screenshot from 2025-06-17 09-52-57](https://github.com/user-attachments/assets/32358b3a-8ac9-4faa-94be-751a7ca6cb15)


https://github.com/frappe/erpnext/blob/28642dd9bd1b146b4093a9343249f59fcaee0415/erpnext/accounts/report/accounts_receivable/accounts_receivable.py#L857-L866

QB was introduced to avoid manual fiddling of raw sql. But lack of support for handling user permission defeats that purpose.

## Workaround
A utility method to build a list of QB conditions, which can simply be passed to `Criterion.all()`.


![Screenshot from 2025-06-17 09-59-56](https://github.com/user-attachments/assets/44ead215-7371-4795-898c-6e783df4a21c)


A proper fix would require QB to support permission handling automatically. It can include the `ignore_permissions` flag like frappe.db.sql as well.
