### PR TITLE
fix: always defer access log insertion

### DIFF
--- a/frappe/core/doctype/access_log/access_log.py
+++ b/frappe/core/doctype/access_log/access_log.py
@@ -54,13 +54,10 @@ def make_access_log(
 	page=None,
 	columns=None,
 ):
-	user = frappe.session.user
-	in_request = frappe.request and frappe.request.method == "GET"
-
 	access_log = frappe.get_doc(
 		{
 			"doctype": "Access Log",
-			"user": user,
+			"user": frappe.session.user,
 			"export_from": doctype,
 			"reference_document": document,
 			"file_type": file_type,
@@ -72,17 +69,10 @@ def make_access_log(
 		}
 	)
 
-	if frappe.flags.read_only:
+	if not frappe.in_test:
 		access_log.deferred_insert()
-		return
 	else:
 		access_log.db_insert()
-
-	# `frappe.db.commit` added because insert doesnt `commit` when called in GET requests like `printview`
-	# dont commit in test mode. It must be tempting to put this block along with the in_request in the
-	# whitelisted method...yeah, don't do it. That part would be executed possibly on a read only DB conn
-	if not frappe.in_test or in_request:
-		frappe.db.commit()
 
 
 # only for backward compatibility


### PR DESCRIPTION
- this does not need to be instantly available, deferred inserts are flushed every 15 minutes
- deferring is good for DB: bulk creation, stored nearby in fewer pages