### PR TITLE
feat: utility to commit certain queries after sending response

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import frappe
 import frappe.email.smtp
 from frappe import _
+from frappe.database.utils import commit_after_response
 from frappe.email.email_body import get_message_id
 from frappe.utils import (
 	cint,
@@ -272,7 +273,7 @@ def add_attachments(name: str, attachments: Iterable[str | dict]) -> None:
 
 @frappe.whitelist(allow_guest=True, methods=("GET",))
 def mark_email_as_seen(name: str | None = None):
-	frappe.request.after_response.add(lambda: _mark_email_as_seen(name))
+	commit_after_response(lambda: _mark_email_as_seen(name))
 	frappe.response.update(frappe.utils.get_imaginary_pixel_response())
 
 
@@ -281,8 +282,6 @@ def _mark_email_as_seen(name):
 		update_communication_as_read(name)
 	except Exception:
 		frappe.log_error("Unable to mark as seen", None, "Communication", name)
-
-	frappe.db.commit()  # nosemgrep: after_response requires explicit commit
 
 
 def update_communication_as_read(name):

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -8,6 +8,7 @@ from functools import cached_property, wraps
 import frappe
 from frappe.query_builder.builder import MariaDB, Postgres, SQLite
 from frappe.query_builder.functions import Function
+from frappe.utils import CallbackManager
 
 Query = str | MariaDB | Postgres | SQLite
 QueryValues = tuple | list | dict | None
@@ -109,3 +110,37 @@ def dangerously_reconnect_on_connection_abort(func):
 			raise
 
 	return wrapper
+
+
+def commit_after_response(func):
+	"""
+	Runs and commits some queries after response is sent.
+	Works only if in a request context and not in tests.
+	Calls function immediately otherwise.
+	"""
+
+	request = getattr(frappe.local, "request", False)
+	if not request or frappe.in_test:
+		func()
+		return
+
+	callback_manager = getattr(request, "commit_after_response", None)
+	if callback_manager is None:
+		# if no callback manager, create one
+		callback_manager = CallbackManager()
+		request.commit_after_response = callback_manager
+
+		# add a function to run queries and commit after response
+		def run_queries_and_commit():
+			db = getattr(frappe.local, "db", None)
+			if not db:
+				# try reconnecting to the database
+				frappe.connect(set_admin_as_user=False)
+				db = frappe.local.db
+
+			callback_manager.run()
+			db.commit()  # nosemgrep
+
+		request.after_response.add(run_queries_and_commit)
+
+	callback_manager.add(func)

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -138,7 +138,17 @@ def commit_after_response(func):
 				frappe.connect(set_admin_as_user=False)
 				db = frappe.local.db
 
-			callback_manager.run()
+			savepoint_name = "commit_after_response"
+
+			while callback_manager._functions():
+				_func = callback_manager._functions.popleft()
+				try:
+					db.savepoint(savepoint_name)
+					_func()
+				except Exception:
+					db.rollback(save_point=savepoint_name)
+					frappe.log_error(title="Error executing commit_after_response callback")
+
 			db.commit()  # nosemgrep
 
 		request.after_response.add(run_queries_and_commit)

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -112,6 +112,30 @@ def dangerously_reconnect_on_connection_abort(func):
 	return wrapper
 
 
+class CommitAfterResponseManager(CallbackManager):
+	__slots__ = ()
+
+	def run(self):
+		db = getattr(frappe.local, "db", None)
+		if not db:
+			# try reconnecting to the database
+			frappe.connect(set_admin_as_user=False)
+			db = frappe.local.db
+
+		savepoint_name = "commit_after_response"
+
+		while self._functions:
+			_func = self._functions.popleft()
+			try:
+				db.savepoint(savepoint_name)
+				_func()
+			except Exception:
+				db.rollback(save_point=savepoint_name)
+				frappe.log_error(title="Error executing commit_after_response callback")
+
+		db.commit()  # nosemgrep
+
+
 def commit_after_response(func):
 	"""
 	Runs and commits some queries after response is sent.
@@ -127,30 +151,8 @@ def commit_after_response(func):
 	callback_manager = getattr(request, "commit_after_response", None)
 	if callback_manager is None:
 		# if no callback manager, create one
-		callback_manager = CallbackManager()
+		callback_manager = CommitAfterResponseManager()
 		request.commit_after_response = callback_manager
-
-		# add a function to run queries and commit after response
-		def run_queries_and_commit():
-			db = getattr(frappe.local, "db", None)
-			if not db:
-				# try reconnecting to the database
-				frappe.connect(set_admin_as_user=False)
-				db = frappe.local.db
-
-			savepoint_name = "commit_after_response"
-
-			while callback_manager._functions():
-				_func = callback_manager._functions.popleft()
-				try:
-					db.savepoint(savepoint_name)
-					_func()
-				except Exception:
-					db.rollback(save_point=savepoint_name)
-					frappe.log_error(title="Error executing commit_after_response callback")
-
-			db.commit()  # nosemgrep
-
-		request.after_response.add(run_queries_and_commit)
+		request.after_response.add(callback_manager.run)
 
 	callback_manager.add(func)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -18,6 +18,7 @@ import frappe
 from frappe import _, is_whitelisted, msgprint
 from frappe.core.doctype.file.utils import relink_mismatched_files
 from frappe.core.doctype.server_script.server_script_utils import run_server_script_for_doc_event
+from frappe.database.utils import commit_after_response
 from frappe.desk.form.document_follow import follow_document
 from frappe.integrations.doctype.webhook import run_webhooks
 from frappe.model import optional_fields, table_fields
@@ -1626,10 +1627,11 @@ class Document(BaseDocument):
 
 			if user not in _seen:
 				_seen.append(user)
-				frappe.db.set_value(
-					self.doctype, self.name, "_seen", json.dumps(_seen), update_modified=False
+				commit_after_response(
+					lambda: frappe.db.set_value(
+						self.doctype, self.name, "_seen", json.dumps(_seen), update_modified=False
+					)
 				)
-				frappe.local.flags.commit = True
 
 	def add_viewed(self, user=None, force=False, unique_views=False):
 		"""Add a view log for the current document"""
@@ -1655,8 +1657,7 @@ class Document(BaseDocument):
 		if frappe.flags.read_only:
 			view_log.deferred_insert()
 		else:
-			view_log.insert(ignore_permissions=True)
-			frappe.local.flags.commit = True
+			commit_after_response(lambda: view_log.insert(ignore_permissions=True))
 
 		return view_log
 


### PR DESCRIPTION
- [ ] tests

`no-docs`: can be documented together with `after_response` when we decide to make it a first-class feature.