### PR TITLE
fix: rate limit issue on sending email login link

### DIFF
--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -136,8 +136,12 @@ def login_via_token(login_token: str):
 	)
 
 
+def get_login_with_email_link_ratelimit() -> int:
+	return frappe.get_system_settings("rate_limit_email_link_login") or 5
+
+
 @frappe.whitelist(allow_guest=True)
-@rate_limit(limit=5, seconds=60 * 60)
+@rate_limit(limit=get_login_with_email_link_ratelimit, seconds=60 * 60)
 def send_login_link(email: str):
 	if not frappe.get_system_settings("login_with_email_link"):
 		return
@@ -169,10 +173,6 @@ def _generate_temporary_login_link(email: str, expiry: int):
 	frappe.cache.set_value(f"one_time_login_key:{key}", email, expires_in_sec=expiry * 60)
 
 	return get_url(f"/api/method/frappe.www.login.login_via_key?key={key}")
-
-
-def get_login_with_email_link_ratelimit() -> int:
-	return frappe.get_system_settings("rate_limit_email_link_login") or 5
 
 
 @frappe.whitelist(allow_guest=True, methods=["GET"])


### PR DESCRIPTION
Support ticket: https://support.frappe.io/helpdesk/tickets/41272

Update the hardcoded rate limit to fetch the value dynamically from the system settings.

<hr>

Followup to #25599