### PR TITLE
chore: Drop pdbpp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,6 @@ watchdog = "~=3.0.0"
 hypothesis = "~=6.77.0"
 responses = "==0.23.1"
 freezegun = "~=1.2.2"
-pdbpp = "~=0.10.3"
 
 [tool.ruff]
 line-length = 110


### PR DESCRIPTION
Breaks console sometimes, don't see as much value TBH

```
Traceback (most recent call last):
  File "/Users/mihirkandoi/Developer/frappe-develop/apps/frappe/frappe/utils/bench_helper.py", line 48, in invoke
    return super().invoke(ctx)
           ~~~~~~~~~~~~~~^^^^^
  File "/Users/mihirkandoi/Developer/frappe-develop/env/lib/python3.13/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/mihirkandoi/Developer/frappe-develop/env/lib/python3.13/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mihirkandoi/Developer/frappe-develop/env/lib/python3.13/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/Users/mihirkandoi/Developer/frappe-develop/env/lib/python3.13/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/mihirkandoi/Developer/frappe-develop/apps/frappe/frappe/commands/__init__.py", line 28, in _func
    ret = f(ctx.obj, *args, **kwargs)
  File "/Users/mihirkandoi/Developer/frappe-develop/apps/frappe/frappe/commands/utils.py", line 646, in console
    from IPython.terminal.embed import InteractiveShellEmbed
  File "/Users/mihirkandoi/Developer/frappe-develop/env/lib/python3.13/site-packages/IPython/__init__.py", line 53, in <module>
    from .core.application import Application
  File "/Users/mihirkandoi/Developer/frappe-develop/env/lib/python3.13/site-packages/IPython/core/application.py", line 26, in <module>
    from IPython.core import release, crashhandler
  File "/Users/mihirkandoi/Developer/frappe-develop/env/lib/python3.13/site-packages/IPython/core/crashhandler.py", line 27, in <module>
    from IPython.core import ultratb
  File "/Users/mihirkandoi/Developer/frappe-develop/env/lib/python3.13/site-packages/IPython/core/ultratb.py", line 111, in <module>
    from IPython.core import debugger
  File "/Users/mihirkandoi/Developer/frappe-develop/env/lib/python3.13/site-packages/IPython/core/debugger.py", line 122, in <module>
    from pdb import Pdb as OldPdb
  File "/Users/mihirkandoi/Developer/frappe-develop/env/lib/python3.13/site-packages/_pdbpp_path_hack/pdb.py", line 5, in <module>
    exec(compile(f.read(), pdb_path, 'exec'))
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mihirkandoi/Developer/frappe-develop/env/lib/python3.13/site-packages/pdb.py", line 28, in <module>
    __version__ = fancycompleter.LazyVersion('pdbpp')
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'fancycompleter' has no attribute 'LazyVersion'

module 'fancycompleter' has no attribute 'LazyVersion'
```
