### PR TITLE
fix(DocType): offer "Calendar" as Default View

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -858,7 +858,7 @@ $.extend(frappe.model, {
 			let meta = frappe.get_meta(doctype);
 			let default_views = ["List", "Report", "Dashboard", "Kanban"];
 
-			if (meta.is_calendar_and_gantt && frappe.views.calendar[doctype]) {
+			if (meta.is_calendar_and_gantt) {
 				let views = ["Calendar", "Gantt"];
 				default_views.push(...views);
 			}


### PR DESCRIPTION
`frappe.views.calendar[doctype]` is usually undefined in the context of the DocType editor, it's only populated when opening the calendar.

### Before

https://github.com/user-attachments/assets/6f6a9662-5062-4653-b25c-bb7b0d2c68bf

Cannot select "Calendar" as _Default View_, for a doctype marked as _Is Calendar Gantt_

### After

https://github.com/user-attachments/assets/11af291a-9dff-4677-88fd-fc0e0bd593c6

Can select "Calendar" as _Default View_, for a doctype marked as _Is Calendar Gantt_