### PR TITLE
refactor: introduce lightmode in parallel test runner

### DIFF
--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -370,6 +370,7 @@ def run_tests(
 )
 @click.option("--use-orchestrator", is_flag=True, help="Use orchestrator to run parallel tests")
 @click.option("--dry-run", is_flag=True, default=False, help="Dont actually run tests")
+@click.option("--lightmode", is_flag=True, default=False, help="Skips all before test setup")
 @pass_context
 def run_parallel_tests(
 	context: CliCtxObj,
@@ -379,6 +380,7 @@ def run_parallel_tests(
 	with_coverage=False,
 	use_orchestrator=False,
 	dry_run=False,
+	lightmode=False,
 ):
 	from traceback_with_variables import activate_by_import
 
@@ -399,6 +401,7 @@ def run_parallel_tests(
 				build_number=build_number,
 				total_builds=total_builds,
 				dry_run=dry_run,
+				lightmode=lightmode,
 			)
 		mode = "Orchestrator" if use_orchestrator else "Parallel"
 		banner = f"""


### PR DESCRIPTION
## Reason

Same as https://github.com/frappe/frappe/pull/32726 - a flag to forcefully disable ALL preloading behavior.

Disabling the preloading behavior in parallel test runner is much simpler as there are only 2 places where it is called, which can simply be ignored using a flag.