### PR TITLE
perf: chain db transactions

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -128,7 +128,7 @@ def application(request: Request):
 	except Exception as e:
 		response = e.get_response(request.environ) if isinstance(e, HTTPException) else handle_exception(e)
 		if db := getattr(frappe.local, "db", None):
-			db.rollback()
+			db.rollback(chain=True)
 
 	else:
 		sync_database()
@@ -398,9 +398,9 @@ def sync_database():
 
 	# if HTTP method would change server state, commit if necessary
 	if frappe.local.request.method in UNSAFE_HTTP_METHODS or frappe.local.flags.commit:
-		db.commit()
+		db.commit(chain=True)
 	else:
-		db.rollback()
+		db.rollback(chain=True)
 
 	# update session
 	if session := getattr(frappe.local, "session_obj", None):

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -272,7 +272,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 		retval = method(**kwargs)
 
 	except (frappe.db.InternalError, frappe.RetryBackgroundJobError) as e:
-		frappe.db.rollback()
+		frappe.db.rollback(chain=True)
 
 		if retry < 5 and (
 			isinstance(e, frappe.RetryBackgroundJobError)
@@ -293,15 +293,15 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 			raise
 
 	except Exception as e:
-		frappe.db.rollback()
+		frappe.db.rollback(chain=True)
 		frappe.log_error(title=method_name)
 		frappe.monitor.add_data_to_monitor(exception=e.__class__.__name__)
-		frappe.db.commit()
+		frappe.db.commit(chain=True)
 		print(frappe.get_traceback())
 		raise
 
 	else:
-		frappe.db.commit()
+		frappe.db.commit(chain=True)
 		return retval
 
 	finally:


### PR DESCRIPTION
This reduces one query on most requests by chaining `begin` with commit/rollback.

https://github.com/frappe/caffeine/issues/28
