### PR TITLE
fix: add flag for initial email sync

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -219,6 +219,9 @@ class EmailServer:
 		uidnext = int(self.parse_imap_response("UIDNEXT", message[0]) or "1")
 		frappe.db.set_value("Email Account", self.settings.email_account, "uidnext", uidnext)
 
+		if uid_validity is None:
+			frappe.flags.initial_sync = True
+
 		if not uid_validity or uid_validity != current_uid_validity:
 			# uidvalidity changed & all email uids are reindexed by server
 			frappe.db.set_value(
@@ -249,7 +252,7 @@ class EmailServer:
 				)
 
 			sync_count = 100 if uid_validity else int(self.settings.initial_sync_count)
-			from_uid = 1 if uidnext < (sync_count + 1) or (uidnext - sync_count) < 1 else uidnext - sync_count
+			from_uid = 1 if uidnext < (sync_count + 1) or (-sync_count) < 1 else uidnext - sync_count
 			# sync last 100 email
 			self.settings.email_sync_rule = f"UID {from_uid}:{uidnext}"
 			self.uid_reindexed = True

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -252,7 +252,7 @@ class EmailServer:
 				)
 
 			sync_count = 100 if uid_validity else int(self.settings.initial_sync_count)
-			from_uid = 1 if uidnext < (sync_count + 1) or (-sync_count) < 1 else uidnext - sync_count
+			from_uid = 1 if uidnext < (sync_count + 1) or (uidnext - sync_count) < 1 else uidnext - sync_count
 			# sync last 100 email
 			self.settings.email_sync_rule = f"UID {from_uid}:{uidnext}"
 			self.uid_reindexed = True


### PR DESCRIPTION
Add a flag for emails created during the initial sync

the variable `uid_validity` is during the initial sync, so we can use that to create the flag.

**Use Case:**
Currently, acknowledgment emails are sent for all incoming emails, including old ones fetched during the initial sync. This leads to unnecessary responses.

**Solution:**
Add a flag to identify emails from the initial sync, so we can skip sending acknowledgment emails for them.

