### PR TITLE
build(deps): bump google libraries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,9 @@ dependencies = [
     # integration dependencies
     "boto3~=1.34.143",
     "dropbox~=11.36.2",
-    "google-api-python-client~=2.2.0",
-    "google-auth-oauthlib~=0.4.4",
-    "google-auth~=1.29.0",
+    "google-api-python-client~=2.172.0",
+    "google-auth-oauthlib~=1.2.2",
+    "google-auth~=2.40.3",
     "posthog~=3.21.0",
     "vobject~=0.9.7",
 ]


### PR DESCRIPTION
They depend on protobuf, GHSA-8qvm-5x2c-j2w7
