### PR TITLE
feat: plumbing for virtual child table

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1606,10 +1606,9 @@ def validate_fields(meta: Meta):
 				title=_("Invalid Option"),
 			)
 
-		if not (meta.is_virtual == child_doctype_meta.is_virtual):
-			error_msg = " should be virtual." if meta.is_virtual else " cannot be virtual."
+		if meta.is_virtual and not child_doctype_meta.is_virtual:
 			frappe.throw(
-				_("Child Table {0} for field {1}" + error_msg).format(
+				_("Child Table {0} for field {1} should be virtual").format(
 					frappe.bold(doctype), frappe.bold(docfield.fieldname)
 				),
 				title=_("Invalid Option"),

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -541,36 +541,6 @@ class TestDocType(FrappeTestCase):
 		self.assertEqual(doc.is_virtual, 1)
 		self.assertFalse(frappe.db.table_exists("Test Virtual Doctype"))
 
-	def test_create_virtual_doctype_as_child_table(self):
-		"""Test virtual DocType as Child Table below a normal DocType."""
-		frappe.delete_doc_if_exists("DocType", "Test Parent Virtual DocType", force=1)
-		frappe.delete_doc_if_exists("DocType", "Test Virtual DocType as Child Table", force=1)
-
-		virtual_doc = new_doctype("Test Virtual DocType as Child Table")
-		virtual_doc.is_virtual = 1
-		virtual_doc.istable = 1
-		virtual_doc.insert(ignore_permissions=True)
-
-		doc = frappe.get_doc("DocType", "Test Virtual DocType as Child Table")
-
-		self.assertEqual(doc.is_virtual, 1)
-		self.assertEqual(doc.istable, 1)
-		self.assertFalse(frappe.db.table_exists("Test Virtual DocType as Child Table"))
-
-		parent_doc = new_doctype("Test Parent Virtual DocType")
-		parent_doc.append(
-			"fields",
-			{
-				"fieldname": "virtual_child_table",
-				"fieldtype": "Table",
-				"options": "Test Virtual DocType as Child Table",
-			},
-		)
-		self.assertRaises(frappe.exceptions.ValidationError, parent_doc.insert)
-		parent_doc.is_virtual = 1
-		parent_doc.insert(ignore_permissions=True)
-		self.assertFalse(frappe.db.table_exists("Test Parent Virtual DocType"))
-
 	def test_default_fieldname(self):
 		fields = [
 			{"label": "title", "fieldname": "title", "fieldtype": "Data", "default": "{some_fieldname}"}

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -185,24 +185,31 @@ class Document(BaseDocument):
 		self.flags.pop("ignore_children", None)
 
 		for df in self._get_table_fields():
+			args = {
+				"filters": {
+					"parent": str(self.name),
+					"parenttype": self.doctype,
+					"parentfield": df.fieldname,
+				},
+				"order_by": "idx asc",
+				"as_dict": True,
+				"for_update": self.flags.for_update,
+			}
 			# Make sure not to query the DB for a child table, if it is a virtual one.
 			# During frappe is installed, the property "is_virtual" is not available in tabDocType, so
 			# we need to filter those cases for the access to frappe.db.get_value() as it would crash otherwise.
 			if hasattr(self, "doctype") and not hasattr(self, "module") and is_virtual_doctype(df.options):
-				self.set(df.fieldname, [])
-				continue
-
-			children = (
-				frappe.db.get_values(
-					df.options,
-					{"parent": str(self.name), "parenttype": self.doctype, "parentfield": df.fieldname},
-					"*",
-					as_dict=True,
-					order_by="idx asc",
-					for_update=self.flags.for_update,
+				controller = get_controller(df.options)
+				children = controller.get_list({"fields": "*", **args}) or []
+			else:
+				children = (
+					frappe.db.get_values(
+						df.options,
+						fieldname="*",
+						**args,
+					)
+					or []
 				)
-				or []
-			)
 
 			self.set(df.fieldname, children)
 


### PR DESCRIPTION
Call the virtual controller's `get_list` to populate a child table.

This implementation is meant for `version-15` only. The logic is slightly different in `develop` and will be implemented separately, if this feature is going to be accepted.

This PR enables one more way to use virtual DocTypes by changing, effectively, two lines of code:

```diff
- self.set(df.fieldname, [])
- continue
+ controller = get_controller(df.options)
+ children = controller.get_list({"fields": "*", **args}) or []
```

E.g. we can use this to show a read-only overview of times logged against an **Issue**, by adding a virtual child table as a custom field:

![Bildschirmfoto 2025-06-19 um 18 25 18](https://github.com/user-attachments/assets/c80dc00c-ef18-4d85-917c-97d23c7354f8)

<details>
<summary>Code snippet for screenshot</summary>

```python
class IssueTimesheetDetail(Document):
	# ...
	@staticmethod
	def get_list(args):
		filters = args.get("filters", {})

		return frappe.get_list(
			"Timesheet",
			fields=[
				"`tabTimesheet Detail`.name",
				"`tabTimesheet Detail`.activity_type",
				"`tabTimesheet Detail`.from_time",
				"`tabTimesheet Detail`.hours",
				"`tabTimesheet Detail`.description",
			],
			filters={"issue": filters["parent"]},
		)
```

</details>

The general use case for this feature, regardless of the specific implementation, is this: instead of linking to a separate report, we can show an overview of related data directly in the form (without storing it again).

Todo:

- [ ] The report builder runs a DB query straight away, so selecting virtual ct fields there will cause an error. Solution: don't offer virtual ct fields in report builder.
- [ ] Downside: virtual DocTypes use properties for virtual child tables. Here, we introduce a second way of implementing virtual child tables.

Ref: ABI-8

Resolves https://github.com/frappe/frappe/issues/31976