### PR TITLE
fix: remove Jinja placeholder for title on web template when it is not defined

### DIFF
--- a/frappe/website/web_template/hero/hero.html
+++ b/frappe/website/web_template/hero/hero.html
@@ -1,6 +1,8 @@
 <div class="hero {{ 'align-center' if align == 'Center' else '' }}">
 	<div class="hero-content">
+		{%- if title -%}
 		<h1 class="hero-title">{{ _(title) }}</h1>
+		{%- endif -%}
 		{%- if subtitle -%}
 		<p class="hero-subtitle">
 			{{ _(subtitle) }}

--- a/frappe/website/web_template/hero_with_right_image/hero_with_right_image.html
+++ b/frappe/website/web_template/hero_with_right_image/hero_with_right_image.html
@@ -1,9 +1,11 @@
 <div class="hero-with-right-image">
 	<div class="hero-content">
 		<div>
+			{%- if title -%}
 			<h1 class="hero-title">
 				{{ _(title) }}
 			</h1>
+			{%- endif -%}
 			{%- if subtitle -%}
 			<p class="hero-subtitle">
 				{{ _(subtitle) }}

--- a/frappe/website/web_template/section_with_collapsible_content/section_with_collapsible_content.html
+++ b/frappe/website/web_template/section_with_collapsible_content/section_with_collapsible_content.html
@@ -1,5 +1,7 @@
 <div class="section-with-collapsible-content {{ 'align-center' if align == 'Center' else '' }}">
+	{%- if title -%}
 	<h2 class="section-title">{{ _(title) }}</h2>
+	{%- endif -%}
 	{%- if subtitle -%}
 	<p class="section-description">{{ _(subtitle) }}</p>
 	{%- endif -%}

--- a/frappe/website/web_template/section_with_cta/section_with_cta.html
+++ b/frappe/website/web_template/section_with_cta/section_with_cta.html
@@ -1,6 +1,8 @@
 <div class="section-cta-container">
 	<div class="section-cta">
+		{%- if title -%}
 		<h2 class="title mt-0">{{ _(title) }}</h2>
+		{%- endif -%}
 		{%- if subtitle -%}
 		<p class="subtitle">{{ _(subtitle) }}</p>
 		{%- endif -%}

--- a/frappe/website/web_template/section_with_embed/section_with_embed.html
+++ b/frappe/website/web_template/section_with_embed/section_with_embed.html
@@ -1,5 +1,7 @@
 <div class="section-with-embed">
+	{%- if title -%}
 	<h2 class="section-title">{{ _(title) }}</h2>
+	{%- endif -%}
 	{%- if subtitle -%}
 	<p class="section-description">{{ _(subtitle) }}</p>
 	{%- endif -%}

--- a/frappe/website/web_template/section_with_image/section_with_image.html
+++ b/frappe/website/web_template/section_with_image/section_with_image.html
@@ -1,5 +1,7 @@
 <div class="section-with-image {{ 'align-center' if align == 'Center' else '' }}">
+	{%- if title -%}
 	<h2 class="section-title">{{ _(title) }}</h2>
+	{%- endif -%}
 	{%- if subtitle -%}
 	<p class="section-description">{{ _(subtitle) }}</p>
 	{%- endif -%}

--- a/frappe/website/web_template/section_with_image_grid/section_with_image_grid.html
+++ b/frappe/website/web_template/section_with_image_grid/section_with_image_grid.html
@@ -1,5 +1,7 @@
 <div class="section-with-image-grid">
-	<h2 class="section-title">{{ title }}</h2>
+	{%- if title -%}
+	<h2 class="section-title">{{ _(title) }}</h2>
+	{%- endif -%}
 	<p class="section-description">{{ subtitle }}</p>
 
 	<div class="section-image-grid">

--- a/frappe/website/web_template/section_with_small_cta/section_with_small_cta.html
+++ b/frappe/website/web_template/section_with_small_cta/section_with_small_cta.html
@@ -1,7 +1,9 @@
 <div class="section-cta-container">
 	<div class="section-small-cta">
 		<div>
-			<h3 class="section-title">{{ title or '' }}</h3>
+			{%- if title -%}
+			<h2 class="section-title">{{ _(title) }}</h2>
+			{%- endif -%}
 			{%- if subtitle -%}
 			<p class="subtitle">{{ subtitle }}</p>
 			{%- endif -%}


### PR DESCRIPTION
This PR fixes an issue where the jinja place holder `{{ title }}` shows on some web templates when it is undefined (see below).
![image](https://github.com/user-attachments/assets/7de9883d-4073-48dc-a54f-b550a6f3326e)
