### PR TITLE
fix: Table MultiSelect _remove not reflecting removed row

### DIFF
--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -41,7 +41,10 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 							);
 						},
 						() => {
-							this.parse_validate_and_set_in_model("");
+							frappe.model.clear_doc(this.df.options, row.name);
+
+							this.frm.dirty();
+							this.refresh();
 
 							return this.frm.script_manager.trigger(
 								`${this.df.fieldname}_remove`,


### PR DESCRIPTION
_remove event was not refreshing the list in handler code. Handled the remove event similar to the grid row remove.

Before:
https://github.com/user-attachments/assets/85c26f30-ec67-4535-a06b-2a6d7d67a096

After:
https://github.com/user-attachments/assets/dda54157-a911-484c-ab30-c0d6c21173c5

<hr>

Fixes #28660
