### PR TITLE
fix: capitalize duration label

### DIFF
--- a/frappe/public/js/frappe/form/controls/duration.js
+++ b/frappe/public/js/frappe/form/controls/duration.js
@@ -20,19 +20,19 @@ frappe.ui.form.ControlDuration = class ControlDuration extends frappe.ui.form.Co
 			</div>`
 		);
 		this.$wrapper.append(this.$picker);
-		this.build_numeric_input("days", this.duration_options.hide_days);
-		this.build_numeric_input("hours", false);
-		this.build_numeric_input("minutes", false);
-		this.build_numeric_input("seconds", this.duration_options.hide_seconds);
+		this.build_numeric_input("days", this.duration_options.hide_days, 0, "Days");
+		this.build_numeric_input("hours", false, 0, "Hours");
+		this.build_numeric_input("minutes", false, 0, "Minutes");
+		this.build_numeric_input("seconds", this.duration_options.hide_seconds, 0, "Seconds");
 		this.set_duration_picker_value(this.value);
 		this.$picker.hide();
 		this.bind_events();
 		this.refresh();
 	}
 
-	build_numeric_input(label, hidden, max) {
+	build_numeric_input(name, hidden, max, label) {
 		let $duration_input = $(`
-			<input class="input-sm duration-input" data-duration="${label}" type="number" min="0" value="0">
+			<input class="input-sm duration-input" data-duration="${name}" type="number" min="0" value="0">
 		`);
 
 		let $input = $(`<div class="row duration-row"></div>`).prepend($duration_input);
@@ -41,7 +41,7 @@ frappe.ui.form.ControlDuration = class ControlDuration extends frappe.ui.form.Co
 			$duration_input.attr("max", max);
 		}
 
-		this.inputs[label] = $duration_input;
+		this.inputs[name] = $duration_input;
 
 		let $control = $(`
 			<div class="col duration-col">


### PR DESCRIPTION
Support ticket: https://support.frappe.io/helpdesk/tickets/41467

The duration field was not capitalized, which is not good for user experience. This PR addresses two issues: first, it improves the UX by capitalizing the label; second, it ensures the field gets translated, which wasn't happening previously due to the incorrect casing.