### PR TITLE
fix: make Text Editor field respect read-only state in child table

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -233,7 +233,7 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 				},
 			},
 			theme: this.df.theme || "snow",
-			readOnly: this.disabled,
+			readOnly: this.disabled || this.df.read_only,
 			bounds: this.quill_container[0],
 			placeholder: this.df.placeholder || "",
 		};


### PR DESCRIPTION
Support ticket: https://support.frappe.io/helpdesk/tickets/41377

## Before

https://github.com/user-attachments/assets/bb27920b-4681-4c6e-a8b3-56abdd8f0a37


## After

https://github.com/user-attachments/assets/ed64422e-06aa-40d5-b90a-e0bf61c30676


