### PR TITLE
fix: print <ol> numbering

### DIFF
--- a/frappe/public/scss/print.bundle.scss
+++ b/frappe/public/scss/print.bundle.scss
@@ -51,7 +51,7 @@
 .filter-row div {
 	display: inline-block;
 }
-// prevent order list from continued numbering
+// prevent <ol> numbering conflicts
 .ql-editor {
 	counter-reset: none;
 }

--- a/frappe/public/scss/print.bundle.scss
+++ b/frappe/public/scss/print.bundle.scss
@@ -51,3 +51,7 @@
 .filter-row div {
 	display: inline-block;
 }
+// prevent order list from continued numbering
+.ql-editor {
+	counter-reset: none;
+}


### PR DESCRIPTION
- Removes global counter for ql-editor. This is necessary because `wkhtmltopdf` does not support `JS` (this is why it works in Editor UI and not generated PDF)


## Before

<img width="793" alt="Screenshot 2025-06-21 at 1 52 56 PM" src="https://github.com/user-attachments/assets/c5ee8ce0-40e1-48b9-926c-f342511c66bb" />

## After

<img width="793" alt="Screenshot 2025-06-21 at 1 53 15 PM" src="https://github.com/user-attachments/assets/fa8d53e6-27ea-4c59-bd6f-cd6f7799e3a0" />


Support Ticket: https://support.frappe.io/helpdesk/tickets/41053