### PR TITLE
fix(email): resolve case mismatch in auto-linking from email address

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -579,7 +579,7 @@ def parse_email(email_strings):
 			if not document_parts or len(document_parts) != 2:
 				continue
 
-			doctype = unquote_plus(document_parts[0])
+			doctype = unquote_plus(frappe.unscrub(document_parts[0]))
 			docname = unquote_plus(document_parts[1])
 			yield doctype, docname
 


### PR DESCRIPTION
Support ticket: https://support.frappe.io/helpdesk/tickets/37997

Fixes an issue where automatic linking of emails to documents fails if the email address contains lowercase doctype name.