### PR TITLE
Feat: Database SSL one way support

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -146,7 +146,7 @@ class MariaDBConnectionUtil:
 		if frappe.conf.db_ssl_ca:
 			ssl_config = {
 				"ca": frappe.conf.db_ssl_ca,
-				"check_hostname": frappe.conf.get("db_ssl_check_hostname", True),
+				"check_hostname": frappe.conf.get("db_ssl_check_hostname", None),
 			}
 
 			# Add client certificates for mutual SSL if available

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -146,7 +146,7 @@ class MariaDBConnectionUtil:
 		if frappe.conf.db_ssl_ca:
 			ssl_config = {
 				"ca": frappe.conf.db_ssl_ca,
-				"check_hostname": frappe.conf.get("db_ssl_check_hostname", None),
+				"check_hostname": frappe.conf.db_ssl_check_hostname,
 			}
 
 			# Add client certificates for mutual SSL if available

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -146,17 +146,15 @@ class MariaDBConnectionUtil:
 		if frappe.conf.db_ssl_ca:
 			ssl_config = {
 				"ca": frappe.conf.db_ssl_ca,
-				"check_hostname": frappe.conf.get("db_ssl_check_hostname", True)
+				"check_hostname": frappe.conf.get("db_ssl_check_hostname", True),
 			}
 
 			# Add client certificates for mutual SSL if available
 			if frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
-				ssl_config.update({
-					"cert": frappe.conf.db_ssl_cert,
-					"key": frappe.conf.db_ssl_key
-				})
+				ssl_config.update({"cert": frappe.conf.db_ssl_cert, "key": frappe.conf.db_ssl_key})
 
 			conn_settings["ssl"] = ssl_config
+
 		return conn_settings
 
 

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -142,12 +142,21 @@ class MariaDBConnectionUtil:
 		if frappe.conf.local_infile:
 			conn_settings["local_infile"] = frappe.conf.local_infile
 
-		if frappe.conf.db_ssl_ca and frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
-			conn_settings["ssl"] = {
+		# Configure SSL settings
+		if frappe.conf.db_ssl_ca:
+			ssl_config = {
 				"ca": frappe.conf.db_ssl_ca,
-				"cert": frappe.conf.db_ssl_cert,
-				"key": frappe.conf.db_ssl_key,
+				"check_hostname": frappe.conf.get("db_ssl_check_hostname", True)
 			}
+
+			# Add client certificates for mutual SSL if available
+			if frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
+				ssl_config.update({
+					"cert": frappe.conf.db_ssl_cert,
+					"key": frappe.conf.db_ssl_key
+				})
+
+			conn_settings["ssl"] = ssl_config
 		return conn_settings
 
 

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -147,15 +147,12 @@ class MariaDBConnectionUtil:
 		if frappe.conf.db_ssl_ca:
 			ssl_config = {
 				"ca": frappe.conf.db_ssl_ca,
-				"check_hostname": frappe.conf.get("db_ssl_check_hostname", True)
+				"check_hostname": frappe.conf.get("db_ssl_check_hostname", True),
 			}
 
 			# Add client certificates for mutual SSL if available
 			if frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
-				ssl_config.update({
-					"cert": frappe.conf.db_ssl_cert,
-					"key": frappe.conf.db_ssl_key
-				})
+				ssl_config.update({"cert": frappe.conf.db_ssl_cert, "key": frappe.conf.db_ssl_key})
 
 			conn_settings["ssl"] = ssl_config
 

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -147,7 +147,7 @@ class MariaDBConnectionUtil:
 		if frappe.conf.db_ssl_ca:
 			ssl_config = {
 				"ca": frappe.conf.db_ssl_ca,
-				"check_hostname": frappe.conf.get("db_ssl_check_hostname", True),
+				"check_hostname": frappe.conf.get("db_ssl_check_hostname", None),
 			}
 
 			# Add client certificates for mutual SSL if available

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -147,7 +147,7 @@ class MariaDBConnectionUtil:
 		if frappe.conf.db_ssl_ca:
 			ssl_config = {
 				"ca": frappe.conf.db_ssl_ca,
-				"check_hostname": frappe.conf.get("db_ssl_check_hostname", None),
+				"check_hostname": frappe.conf.db_ssl_check_hostname,
 			}
 
 			# Add client certificates for mutual SSL if available

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -143,12 +143,21 @@ class MariaDBConnectionUtil:
 		if frappe.conf.local_infile:
 			conn_settings["local_infile"] = frappe.conf.local_infile
 
-		if frappe.conf.db_ssl_ca and frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
-			conn_settings["ssl"] = {
+		# Configure SSL settings
+		if frappe.conf.db_ssl_ca:
+			ssl_config = {
 				"ca": frappe.conf.db_ssl_ca,
-				"cert": frappe.conf.db_ssl_cert,
-				"key": frappe.conf.db_ssl_key,
+				"check_hostname": frappe.conf.get("db_ssl_check_hostname", True)
 			}
+
+			# Add client certificates for mutual SSL if available
+			if frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
+				ssl_config.update({
+					"cert": frappe.conf.db_ssl_cert,
+					"key": frappe.conf.db_ssl_key
+				})
+
+			conn_settings["ssl"] = ssl_config
 
 		return conn_settings
 


### PR DESCRIPTION
Update SSL bit to support one-way connection 


Closes: #33043 

- [x] Backwards compatible with 2 way SSL
- [x] Tested with one way SSL
- [ ] Docs: https://docs.frappe.io/framework/user/en/basics/site_config#remote-database-host-settings