### PR TITLE
perf: faster meta serialisation

### DIFF
--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -71,9 +71,10 @@ class FormMeta(Meta):
 
 	def as_dict(self, no_nulls=False):
 		d = super().as_dict(no_nulls=no_nulls)
+		__dict = self.__dict__
 
 		for k in ASSET_KEYS:
-			d[k] = self.get(k)
+			d[k] = __dict.get(k)
 
 		return d
 

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -250,13 +250,7 @@ $.extend(frappe.model, {
 			// meta has sugar, like __js and other properties that doc won't have
 			frappe.meta.__doctype_meta = JSON.parse(JSON.stringify(meta));
 		}
-		for (const asset_key of [
-			"__list_js",
-			"__custom_list_js",
-			"__calendar_js",
-			"__map_js",
-			"__tree_js",
-		]) {
+		for (const asset_key of ["__list_js", "__custom_list_js", "__calendar_js", "__tree_js"]) {
 			if (meta[asset_key]) {
 				new Function(meta[asset_key])();
 			}


### PR DESCRIPTION
- remove dead code
- rewrite meta.as_dict
- don't serialise cache keys

#### sales invoice bundle test

**before**

```
In [9]: %timeit json.dumps(bundle, default=json_handler)
26.9 ms ± 398 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

**after**

```
In [5]: %timeit -n20 json.dumps(bundle, default=json_handler)
7.33 ms ± 122 μs per loop (mean ± std. dev. of 7 runs, 20 loops each)
```