### PR TITLE
fix: translate dashboards legends

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_utils.js
+++ b/frappe/public/js/frappe/views/reports/report_utils.js
@@ -12,7 +12,7 @@ frappe.report_utils = {
 
 		let labels = get_column_values(x_field);
 		let datasets = y_fields.map((y_field) => ({
-			name: __(frappe.model.unscrub(y_field)),
+			name: get_column_label(y_field),
 			values: get_column_values(y_field).map((d) => Number(d)),
 		}));
 
@@ -45,6 +45,15 @@ frappe.report_utils = {
 				return rows.map((row) => row[column_index]);
 			} else {
 				return rows.map((row) => row[column_name]);
+			}
+		}
+
+		function get_column_label(fieldname) {
+			let column = columns.find((column) => column.fieldname === fieldname)
+			if (column && column.label) {
+				return column.label
+			} else {
+				__(frappe.model.unscrub(y_field))
 			}
 		}
 	},

--- a/frappe/public/js/frappe/views/reports/report_utils.js
+++ b/frappe/public/js/frappe/views/reports/report_utils.js
@@ -12,7 +12,7 @@ frappe.report_utils = {
 
 		let labels = get_column_values(x_field);
 		let datasets = y_fields.map((y_field) => ({
-			name: frappe.model.unscrub(y_field),
+			name: __(frappe.model.unscrub(y_field)),
 			values: get_column_values(y_field).map((d) => Number(d)),
 		}));
 


### PR DESCRIPTION
Translate legends on custom dashboards.

1. Try to get the label from columns based on fieldname.
2. if colum based on field is not found, try to get the field name with translation.

## Before: 
![image](https://github.com/user-attachments/assets/e1afc069-2034-4818-bc21-4217a8dd81e4)


## After
![image](https://github.com/user-attachments/assets/339b9835-dcd7-431f-a29b-b73719594ac6)


## How example dashboard was made:
![image](https://github.com/user-attachments/assets/b1f1a7a4-2764-4068-9669-78fa52606307)

