### PR TITLE
fix: unset z-index on buttons

### DIFF
--- a/frappe/public/scss/common/buttons.scss
+++ b/frappe/public/scss/common/buttons.scss
@@ -91,6 +91,7 @@
 	&:active {
 		background: var(--btn-default-hover-bg);
 		color: var(--text-color);
+		z-index: unset;
 	}
 }
 

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -442,6 +442,9 @@ input.list-header-checkbox {
 	.sort-selector {
 		.btn-group {
 			margin: var(--margin-xs) 0 var(--margin-xs) var(--margin-xs);
+			.btn:focus {
+				z-index: unset;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Before
<img width="412" alt="Screenshot 2025-06-24 at 11 38 50 PM" src="https://github.com/user-attachments/assets/69a50352-d8ef-4f78-b84d-0652236b7c59" />



After
<img width="338" alt="Screenshot 2025-06-24 at 11 39 17 PM" src="https://github.com/user-attachments/assets/40edd67f-7b48-422a-91f9-06c2e8a2bf3d" />

Closes https://github.com/frappe/frappe/issues/29228
