### PR TITLE
fix: add missing translation function to webform list strings

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form_list.js
+++ b/frappe/public/js/frappe/web_form/web_form_list.js
@@ -279,7 +279,7 @@ export default class WebFormList {
 		const actions = $(".web-list-actions");
 
 		frappe.has_permission(this.doctype, "", "delete", () => {
-			this.add_button(actions, "delete-rows", "danger", true, "Delete", () =>
+			this.add_button(actions, "delete-rows", "danger", true, __("Delete"), () =>
 				this.delete_rows()
 			);
 		});
@@ -302,7 +302,7 @@ export default class WebFormList {
 	create_more() {
 		if (this.rows.length >= this.page_length) {
 			const footer = $(".web-list-footer");
-			this.add_button(footer, "more", "secondary", false, "Load More", () => this.more());
+			this.add_button(footer, "more", "secondary", false, __("Load More"), () => this.more());
 		}
 	}
 

--- a/frappe/public/js/frappe/web_form/web_form_list.js
+++ b/frappe/public/js/frappe/web_form/web_form_list.js
@@ -302,7 +302,9 @@ export default class WebFormList {
 	create_more() {
 		if (this.rows.length >= this.page_length) {
 			const footer = $(".web-list-footer");
-			this.add_button(footer, "more", "secondary", false, __("Load More"), () => this.more());
+			this.add_button(footer, "more", "secondary", false, __("Load More"), () =>
+				this.more()
+			);
 		}
 	}
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

Buttons "Delete" and "Load More" are not translated in Web Form List because the translation function __() is not applied in the strings.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

Simply added the __() function to the strings.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<img width="818" alt="Screenshot 2025-06-24 at 18 40 10" src="https://github.com/user-attachments/assets/fb681bb1-8749-4dff-a2ee-c5c57bbc120b" />

<img width="839" alt="Screenshot 2025-06-24 at 22 48 28" src="https://github.com/user-attachments/assets/694ed8e5-6e92-4d9a-84c8-79fb72fbfb63" />


<!-- Add images/recordings to better visualize the change: expected/current behavior -->
