### PR TITLE
perf: Apply force cache busting only for site assets

### DIFF
--- a/frappe/public/js/frappe/assets.js
+++ b/frappe/public/js/frappe/assets.js
@@ -93,10 +93,14 @@ class AssetManager {
 
 		let fetched_assets = {};
 		async function fetch_item(path) {
-			// Add the version to the URL to bust the cache for non-bundled assets
 			let url = new URL(path, window.location.origin);
 
-			if (!path.includes(".bundle.") && !url.searchParams.get("v")) {
+			// Add the version to the URL to bust the cache for non-bundled assets
+			if (
+				url.hostname === window.location.hostname &&
+				!path.includes(".bundle.") &&
+				!url.searchParams.get("v")
+			) {
 				url.searchParams.append("v", version_string);
 			}
 			const response = await fetch(url.toString());


### PR DESCRIPTION
Don't apply `v` searchParam override for `frappe.require` calls that fetch assets from say - CDNs or external mechanisms that usually handle this themselves via URLs & cache control headers.
