### PR TITLE
changed frappe.dev to frappe.local in local developement setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,10 @@ To setup the repository locally follow the steps mentioned below:
 2. In a separate terminal window, run the following commands:
    ```
    # Create a new site
-   bench new-site frappe.local
-   
-   # Map your site to localhost
-   bench --site frappe.local add-to-hosts
+   bench new-site frappe.localhost
    ```
 
-3. Open the URL `http://frappe.local:8000/app` in your browser, you should see the app running
+3. Open the URL `http://frappe.localhost:8000/app` in your browser, you should see the app running
 
 ## Learning and community
 

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ To setup the repository locally follow the steps mentioned below:
 2. In a separate terminal window, run the following commands:
    ```
    # Create a new site
-   bench new-site frappe.dev
+   bench new-site frappe.local
    
    # Map your site to localhost
-   bench --site frappe.dev add-to-hosts
+   bench --site frappe.local add-to-hosts
    ```
 
-3. Open the URL `http://frappe.dev:8000/app` in your browser, you should see the app running
+3. Open the URL `http://frappe.local:8000/app` in your browser, you should see the app running
 
 ## Learning and community
 


### PR DESCRIPTION
More and more browsers are forcing .dev domains to https causing issues while development for more information:
https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts/

While workarounds are there it causes issues when new developers want to try frappe on their local thus causing frustration:
https://superuser.com/questions/565409/how-to-stop-an-automatic-redirect-from-http-to-https-in-chrome/1251483#1251483
