### PR TITLE
fix: Avoid unnecessary syncing defaults

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -332,7 +332,13 @@ class DbColumn:
 	def default_changed_for_decimal(self, current_def):
 		try:
 			if current_def["default"] in ("", None) and self.default in ("", None):
-				# both none, empty
+				return False
+
+			elif (
+				current_def["default"]
+				and float(current_def["default"]) == 0.0
+				and self.default in ("", None, 0.0)
+			):
 				return False
 
 			elif current_def["default"] in ("", None):


### PR DESCRIPTION
When default is `'0.0000'` (string) it gets synced again and again even
though it will end up being 0 again.
