### PR TITLE
ci: add UI tests template to boilerplate

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -702,16 +702,22 @@ on:
       - {branch_name}
   pull_request:
 
-concurrency:
-  group: {branch_name}-{app_name}-${{{{ github.event.number }}}}
-  cancel-in-progress: true
-
 jobs:
   tests:
+    name: ${{ matrix.test }} tests
     runs-on: ubuntu-latest
+
     strategy:
-      fail-fast: false
-    name: Server
+      matrix:
+        include:
+          - test: unit
+            run: bench run-tests --app {app_name}
+          - test: ui
+            run: |
+              echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
+              nohup bench start &> bench.log &
+              sleep 10
+              bench run-ui-tests {app_name} --headless
 
     services:
       redis-cache:
@@ -793,12 +799,17 @@ jobs:
           bench build
         env:
           CI: 'Yes'
-
-      - name: Run Tests
+      
+      - name: Setup Site
         working-directory: /home/runner/frappe-bench
         run: |
-          bench --site test_site set-config allow_tests true
-          bench --site test_site run-tests --app {app_name}
+          bench use test_site
+          bench execute frappe.utils.install.complete_setup_wizard
+          bench set-config allow_tests true
+
+      - name: Run ${{ matrix.test }} tests
+        working-directory: /home/runner/frappe-bench
+        run: ${{ matrix.run }}
         env:
           TYPE: server
 """

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -704,15 +704,15 @@ on:
 
 jobs:
   tests:
-    name: ${{{{ matrix.test }}}} tests
+    name: ${{{{ matrix.test }}}} Tests
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         include:
-          - test: unit
+          - test: Unit
             run: bench run-tests --app {app_name}
-          - test: ui
+          - test: UI
             run: |
               echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
               nohup bench start &> bench.log &
@@ -807,7 +807,7 @@ jobs:
           bench execute frappe.utils.install.complete_setup_wizard
           bench set-config allow_tests true
 
-      - name: Run ${{{{ matrix.test }}}} tests
+      - name: Run ${{{{ matrix.test }}}} Tests
         working-directory: /home/runner/frappe-bench
         run: ${{{{ matrix.run }}}}
         env:

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -704,7 +704,7 @@ on:
 
 jobs:
   tests:
-    name: ${{ matrix.test }} tests
+    name: ${{{{ matrix.test }}}} tests
     runs-on: ubuntu-latest
 
     strategy:
@@ -807,9 +807,9 @@ jobs:
           bench execute frappe.utils.install.complete_setup_wizard
           bench set-config allow_tests true
 
-      - name: Run ${{ matrix.test }} tests
+      - name: Run ${{{{ matrix.test }}}} tests
         working-directory: /home/runner/frappe-bench
-        run: ${{ matrix.run }}
+        run: ${{{{ matrix.run }}}}
         env:
           TYPE: server
 """


### PR DESCRIPTION
closes #33081

## Motivation
As stated in the issue, the current boilerplate for github workflows is lacking support for UI tests. This addresses this issue. 

## Solution
This changes adds a testing matrix, which creates one job for unit tests, and another for ui tests. Since they both depend on the same setup and services, this felt like the cleanest way to do it. Perhaps later [anchors](https://github.com/actions/runner/issues/1182) could be used  

## Caveats
Naturally, if the UI tests are not setup properly (e.g. no `cypress` dir in the project), then the UI test job will fail. Open to suggestion if we want to change this behaviour (e.g. also create a cypress folder if user requests templated workflows)

## Next
Currently UI tests does not support parallelization. This can be something that can be addressed as optimization.   