### PR TITLE
fix: remove explicit call to add `migration_hash` column

### DIFF
--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -78,8 +78,6 @@ class SiteMigration:
 		frappe.flags.touched_tables = set()
 		self.touched_tables_file = frappe.get_site_path("touched_tables.json")
 		frappe.clear_cache()
-		add_column(doctype="DocType", column_name="migration_hash", fieldtype="Data")
-		frappe.clear_cache()
 
 		if os.path.exists(self.touched_tables_file):
 			os.remove(self.touched_tables_file)


### PR DESCRIPTION
this was added in v14. direct upgrade to v16 is not supported anyway from v13.