### PR TITLE
fix: more bad migrations and sanity test

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -316,20 +316,25 @@ class DbColumn:
 		else:
 			cur_default = current_def.get("default")
 			new_default = self.default
-			if cur_default == "NULL" or cur_default is None:
+			if cur_default == "NULL":
 				cur_default = None
 			else:
 				# Strip quotes from default value
 				# eg. database returns default value as "'System Manager'"
-				cur_default = cur_default.lstrip("'").rstrip("'")
+				cur_default = cur_default.lstrip("'").rstrip("'").replace("\\\\", "\\")
 
 			fieldtype = self.fieldtype
+			db_field_type = frappe.db.type_map.get(fieldtype)
 			if fieldtype in ["Int", "Check"]:
 				cur_default = cint(cur_default)
 				new_default = cint(new_default)
 			elif fieldtype in ["Currency", "Float", "Percent"]:
 				cur_default = flt(cur_default)
 				new_default = flt(new_default)
+			elif db_field_type and db_field_type[0] in ("varchar", "longtext", "text"):
+				new_default = cstr(new_default)
+				if not current_def.get("not_nullable"):
+					cur_default = cstr(cur_default)
 			return cur_default != new_default
 
 	def default_changed_for_decimal(self, current_def):

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -276,7 +276,7 @@ class DbColumn:
 
 		# type
 		if current_def["type"] != column_type and not (
-			# XXX: MariaDB JSON is same as longtext and informatio schema still returns longtext
+			# XXX: MariaDB JSON is same as longtext and information schema still returns longtext
 			current_def["type"] == "longtext" and column_type == "json" and frappe.db.db_type == "mariadb"
 		):
 			self.table.change_type.append(self)
@@ -344,7 +344,7 @@ class DbColumn:
 
 			elif (
 				current_def["default"]
-				and float(current_def["default"]) == 0.0
+				and flt(current_def["default"]) == 0.0
 				and self.default in ("", None, 0.0)
 			):
 				return False

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -275,7 +275,10 @@ class DbColumn:
 			return
 
 		# type
-		if current_def["type"] != column_type:
+		if current_def["type"] != column_type and not (
+			# XXX: MariaDB JSON is same as longtext and informatio schema still returns longtext
+			current_def["type"] == "longtext" and column_type == "json" and frappe.db.db_type == "mariadb"
+		):
 			self.table.change_type.append(self)
 
 		# unique

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -175,6 +175,19 @@ class TestDBUpdate(IntegrationTestCase):
 		self.assertEqual(frappe.db.get_column_type(referring_doctype.name, link), "uuid")
 
 
+class TestDBUpdateSanityChecks(IntegrationTestCase):
+	@run_only_if(db_type_is.MARIADB)
+	def test_no_unnecessary_migrates(self):
+		def reload_all():
+			for doctype in frappe.get_all("DocType", {"is_virtual": 0, "custom": 0}, pluck="name"):
+				frappe.reload_doctype(doctype, force=True)
+
+		# Warmup
+		reload_all()
+		with self.assertQueryCount(0, query_type=("alter",)):
+			reload_all()
+
+
 def get_fieldtype_from_def(field_def):
 	fieldtuple = frappe.db.type_map.get(field_def.fieldtype, ("", 0))
 	fieldtype = fieldtuple[0]

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -178,14 +178,11 @@ class TestDBUpdate(IntegrationTestCase):
 class TestDBUpdateSanityChecks(IntegrationTestCase):
 	@run_only_if(db_type_is.MARIADB)
 	def test_no_unnecessary_migrates(self):
-		def reload_all():
-			for doctype in frappe.get_all("DocType", {"is_virtual": 0, "custom": 0}, pluck="name"):
+		for doctype in frappe.get_all("DocType", {"is_virtual": 0, "custom": 0}, pluck="name"):
+			with self.subTest(f"Check {doctype}"):
 				frappe.reload_doctype(doctype, force=True)
-
-		# Warmup
-		reload_all()
-		with self.assertQueryCount(0, query_type=("alter",)):
-			reload_all()
+				with self.assertQueryCount(0, query_type=("alter",)):
+					frappe.reload_doctype(doctype, force=True)
 
 
 def get_fieldtype_from_def(field_def):


### PR DESCRIPTION
- test: prevent unnecessary migrations
- fix: Avoid resyncing JSON repeatedly
- fix: Varchar not nullable defaults should be casted
- fix: force cast to float before
