### PR TITLE
perf: commit only if file is imported

### DIFF
--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -109,11 +109,12 @@ def sync_for(app_name, force=0, reset_permissions=False):
 
 	if l:
 		for i, doc_path in enumerate(files):
-			import_file_by_path(
+			imported = import_file_by_path(
 				doc_path, force=force, ignore_version=True, reset_permissions=reset_permissions
 			)
 
-			frappe.db.commit()
+			if imported:
+				frappe.db.commit(chain=True)
 
 			# show progress bar
 			update_progress_bar(f"Updating DocTypes for {app_name}", i, l)

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -108,9 +108,10 @@ def import_file_by_path(
 		docs = read_doc_from_file(path)
 	except OSError:
 		print(f"{path} missing")
-		return
+		return False
 
 	calculated_hash = calculate_hash(path)
+	imported = False
 
 	if docs:
 		if not isinstance(docs, list):
@@ -147,6 +148,7 @@ def import_file_by_path(
 				reset_permissions=reset_permissions,
 				path=path,
 			)
+			imported = True
 
 			if doc["doctype"] == "DocType":
 				doctype_table = DocType("DocType")
@@ -163,7 +165,7 @@ def import_file_by_path(
 			if new_modified_timestamp:
 				update_modified(new_modified_timestamp, doc)
 
-	return True
+	return imported
 
 
 def read_doc_from_file(path):


### PR DESCRIPTION
- corrects the return value of `import_file_by_path`
- commits only if file is imported during migration
- `commit` has the new `chain` flag set to `True`