### PR TITLE
fix: Git branch is not mandatory

### DIFF
--- a/frappe/core/doctype/installed_application/installed_application.json
+++ b/frappe/core/doctype/installed_application/installed_application.json
@@ -17,8 +17,7 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Git Branch",
-   "read_only": 1,
-   "reqd": 1
+   "read_only": 1
   },
   {
    "columns": 2,
@@ -35,8 +34,7 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Application Version",
-   "read_only": 1,
-   "reqd": 1
+   "read_only": 1
   },
   {
    "columns": 2,
@@ -58,7 +56,7 @@
  "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2025-05-22 12:26:49.523690",
+ "modified": "2025-05-27 12:26:49.523690",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Installed Application",


### PR DESCRIPTION
You can have an app without git repo :shrug:


closes https://github.com/frappe/frappe/issues/33123 