### PR TITLE
fix: Update session after request

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -403,7 +403,7 @@ def sync_database():
 
 	# update session
 	if session := getattr(frappe.local, "session_obj", None):
-		session.update()
+		frappe.request.after_response.add(session.update)
 
 
 # Always initialize sentry SDK if the DSN is sent


### PR DESCRIPTION
Avoid commit in request. This is session maintenance work anyway, doesn't need to happen in same request.
