### PR TITLE
test: remove `in_test` exception in `only_for`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -744,7 +744,7 @@ def only_for(roles: list[str] | tuple[str] | str, message=False):
 	:param roles: Permitted role(s)
 	"""
 
-	if in_test or local.session.user == "Administrator":
+	if local.session.user == "Administrator":
 		return
 
 	if isinstance(roles, str):

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -175,12 +175,11 @@ class TestReport(IntegrationTestCase):
 		)
 
 	def test_report_permissions(self):
-		frappe.set_user("test@example.com")
-		frappe.db.delete("Has Role", {"parent": frappe.session.user, "role": "Test Has Role"})
-		frappe.db.commit()
+		# create role "Test Has Role"
 		if not frappe.db.exists("Role", "Test Has Role"):
 			frappe.get_doc({"doctype": "Role", "role_name": "Test Has Role"}).insert(ignore_permissions=True)
 
+		# create report "Test Report"
 		if not frappe.db.exists("Report", "Test Report"):
 			report = frappe.get_doc(
 				{
@@ -195,8 +194,10 @@ class TestReport(IntegrationTestCase):
 		else:
 			report = frappe.get_doc("Report", "Test Report")
 
-		self.assertNotEqual(report.is_permitted(), True)
-		frappe.set_user("Administrator")
+		with self.set_user("test@example.com"):
+			# remove role "Test Has Role" from user if found
+			frappe.db.delete("Has Role", {"parent": frappe.session.user, "role": "Test Has Role"})
+			self.assertNotEqual(report.is_permitted(), True)
 
 	def test_report_custom_permissions(self):
 		frappe.set_user("test@example.com")

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -200,9 +200,10 @@ class TestReport(IntegrationTestCase):
 			self.assertNotEqual(report.is_permitted(), True)
 
 	def test_report_custom_permissions(self):
-		frappe.set_user("test@example.com")
+		# delete custom role if exists
 		frappe.db.delete("Custom Role", {"report": "Test Custom Role Report"})
-		frappe.db.commit()  # nosemgrep
+
+		# create report if not exists
 		if not frappe.db.exists("Report", "Test Custom Role Report"):
 			report = frappe.get_doc(
 				{
@@ -217,8 +218,11 @@ class TestReport(IntegrationTestCase):
 		else:
 			report = frappe.get_doc("Report", "Test Custom Role Report")
 
-		self.assertEqual(report.is_permitted(), True)
+		# check report is permitted without custom role created
+		with self.set_user("test@example.com"):
+			self.assertEqual(report.is_permitted(), True)
 
+		# create custom role for report
 		frappe.get_doc(
 			{
 				"doctype": "Custom Role",
@@ -228,8 +232,9 @@ class TestReport(IntegrationTestCase):
 			}
 		).insert(ignore_permissions=True)
 
-		self.assertNotEqual(report.is_permitted(), True)
-		frappe.set_user("Administrator")
+		# check report is not permitted with custom role created
+		with self.set_user("test@example.com"):
+			self.assertNotEqual(report.is_permitted(), True)
 
 	# test for the `_format` method if report data doesn't have sort_by parameter
 	def test_format_method(self):

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -566,8 +566,8 @@ class TestDBQuery(IntegrationTestCase):
 		# to avoid if_owner filter
 		update("Nested DocType", "All", 0, "if_owner", 0)
 
-		frappe.set_user("test2@example.com")
-		data = DatabaseQuery("Nested DocType").execute()
+		with self.set_user("test2@example.com"):
+			data = DatabaseQuery("Nested DocType").execute()
 
 		# children of root folder (for which we added user permission) should be accessible
 		self.assertTrue({"name": "Level 2 A"} in data)
@@ -577,7 +577,6 @@ class TestDBQuery(IntegrationTestCase):
 		self.assertFalse({"name": "Level 1 B"} in data)
 		self.assertFalse({"name": "Level 2 B"} in data)
 		update("Nested DocType", "All", 0, "if_owner", 1)
-		frappe.set_user("Administrator")
 
 	def test_filter_sanitizer(self):
 		self.assertRaises(

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -594,36 +594,35 @@ class TestPermissions(IntegrationTestCase):
 
 		frappe.clear_cache(doctype="Blog Post")
 
-		frappe.set_user("test2@example.com")
+		with self.set_user("test2@example.com"):
+			doc = frappe.get_doc(
+				{
+					"doctype": "Blog Post",
+					"blog_category": "-test-blog-category",
+					"blogger": "_Test Blogger 1",
+					"title": "_Test Blog Post Title New 1",
+					"content": "_Test Blog Post Content",
+				}
+			)
 
-		doc = frappe.get_doc(
-			{
-				"doctype": "Blog Post",
-				"blog_category": "-test-blog-category",
-				"blogger": "_Test Blogger 1",
-				"title": "_Test Blog Post Title New 1",
-				"content": "_Test Blog Post Content",
-			}
-		)
+			doc.insert()
 
-		doc.insert()
+			getdoc("Blog Post", doc.name)
+			doclist = [d.name for d in frappe.response.docs]
+			self.assertTrue(doc.name in doclist)
 
-		getdoc("Blog Post", doc.name)
-		doclist = [d.name for d in frappe.response.docs]
-		self.assertTrue(doc.name in doclist)
+		with self.set_user("testperm@example.com"):
+			# Website Manager able to read
+			getdoc("Blog Post", doc.name)
+			doclist = [d.name for d in frappe.response.docs]
+			self.assertTrue(doc.name in doclist)
 
-		frappe.set_user("testperm@example.com")
+			# Website Manager should not be able to delete
+			self.assertRaises(frappe.PermissionError, frappe.delete_doc, "Blog Post", doc.name)
 
-		# Website Manager able to read
-		getdoc("Blog Post", doc.name)
-		doclist = [d.name for d in frappe.response.docs]
-		self.assertTrue(doc.name in doclist)
+		with self.set_user("test2@example.com"):
+			frappe.delete_doc("Blog Post", "-test-blog-post-title-new-1")
 
-		# Website Manager should not be able to delete
-		self.assertRaises(frappe.PermissionError, frappe.delete_doc, "Blog Post", doc.name)
-
-		frappe.set_user("test2@example.com")
-		frappe.delete_doc("Blog Post", "-test-blog-post-title-new-1")
 		update("Blog Post", "Website Manager", 0, "delete", 1, 1)
 
 	def test_clear_user_permissions(self):

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -868,8 +868,8 @@ class TestQuery(IntegrationTestCase):
 
 		test2user = frappe.get_doc("User", "test2@example.com")
 		test2user.add_roles("Blogger")
-		frappe.set_user("test2@example.com")
-		data = frappe.qb.get_query("Nested DocType", ignore_permissions=False).run(as_dict=1)
+		with self.set_user("test2@example.com"):
+			data = frappe.qb.get_query("Nested DocType", ignore_permissions=False).run(as_dict=1)
 
 		# Children of the permitted node should be accessible
 		self.assertTrue(any(d.name == "Level 2 A" for d in data))
@@ -879,7 +879,6 @@ class TestQuery(IntegrationTestCase):
 		self.assertFalse(any(d.name == "Level 2 B" for d in data))
 
 		update("Nested DocType", "All", 0, "if_owner", 1)  # Reset to default
-		frappe.set_user("Administrator")
 
 	def test_is_set_is_not_set(self):
 		"""Test is set and is not set filters"""


### PR DESCRIPTION
sometimes we want to test if `only_for` is working 😄 

this was added 8y ago in https://github.com/frappe/frappe/commit/3f91c9455f4fbe6c0def79d12159398253cfeea4