### PR TITLE
fix: Handle math domain error in money_in_words for currencies with zero fraction units

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1534,7 +1534,9 @@ def money_in_words(
 	number_format = get_number_format()
 
 	fraction_units = frappe.db.get_value("Currency", main_currency, "fraction_units", cache=True)
-	fraction_length = math.ceil(math.log10(fraction_units)) or number_format.precision
+	fraction_length = (
+		math.ceil(math.log10(fraction_units)) if fraction_units and fraction_units > 0 else 0
+	) or number_format.precision
 
 	n = f"%.{fraction_length}f" % number
 


### PR DESCRIPTION
## Problem

When processing transactions with currencies that have zero fraction units (like KRW - Korean Won), the `money_in_words` function throws a `ValueError: math domain error` because it attempts to calculate `math.log10(0)`.

**Error Details:**
```python
ValueError: math domain error
  File "apps/frappe/frappe/utils/data.py", line 1537, in money_in_words
    fraction_length = math.ceil(math.log10(fraction_units)) or number_format.precision
```

This occurs during:
- Demo data creation for ERPNext
- Purchase Order validation
- Any transaction involving currencies without fractional units

## Root Cause

The function assumes all currencies have fractional units > 0, but currencies like KRW, JPY, and others have `fraction_units = 0`. When `math.log10(0)` is called, it raises a ValueError because log(0) is mathematically undefined.

```python
fraction_units = frappe.db.get_value("Currency", main_currency, "fraction_units", cache=True)
fraction_length = math.ceil(math.log10(fraction_units)) or number_format.precision  # Error here
```

## Solution

Add a proper check for `fraction_units > 0` before calling `math.log10()`:

```python
fraction_length = (
    math.ceil(math.log10(fraction_units)) if fraction_units and fraction_units > 0 else 0
) or number_format.precision
```

## Changes Made

- **Safe math operation**: Check `fraction_units > 0` before calling `math.log10()`
- **Fallback value**: Use `0` for currencies without fractional units
- **Preserve existing logic**: Maintain the `or number_format.precision` fallback

## Testing

- ✅ Tested with KRW (Korean Won) - no more math domain error
- ✅ Verified `money_in_words(40000.0, 'KRW')` returns `"KRW Forty Thousand only."`
- ✅ Preserves existing functionality for currencies with fractional units
- ✅ Demo data creation now works without errors

## Impact

- **Low Risk**: Minimal code change with safe fallback
- **High Value**: Fixes critical error preventing transaction processing
- **Backward Compatible**: No changes to existing behavior for currencies with fractional units
- **Global Fix**: Resolves issue for all currencies without fractional units (KRW, JPY, etc.)

## Related Issues

This fix resolves transaction validation failures and demo data creation errors for any ERPNext installation using currencies without fractional units.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author