### PR TITLE
fix(schema): Fix default value change detection for Time fields

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -347,11 +347,7 @@ class DbColumn:
 			if cur_default in ("", None) and self.default in ("", None):
 				return False
 
-			elif (
-				cur_default
-				and flt(cur_default) == 0.0
-				and self.default in ("", None, 0.0)
-			):
+			elif cur_default and flt(cur_default) == 0.0 and self.default in ("", None, 0.0):
 				return False
 
 			elif cur_default in ("", None):

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -338,18 +338,21 @@ class DbColumn:
 			return cur_default != new_default
 
 	def default_changed_for_decimal(self, current_def):
+		cur_default = current_def["default"]
+		if cur_default == "NULL":
+			cur_default = None
 		try:
-			if current_def["default"] in ("", None) and self.default in ("", None):
+			if cur_default in ("", None) and self.default in ("", None):
 				return False
 
 			elif (
-				current_def["default"]
-				and flt(current_def["default"]) == 0.0
+				cur_default
+				and flt(cur_default) == 0.0
 				and self.default in ("", None, 0.0)
 			):
 				return False
 
-			elif current_def["default"] in ("", None):
+			elif cur_default in ("", None):
 				try:
 					# check if new default value is valid
 					float(self.default)
@@ -363,7 +366,7 @@ class DbColumn:
 
 			else:
 				# NOTE float() raise ValueError when "" or None is passed
-				return float(current_def["default"]) != float(self.default)
+				return float(cur_default) != float(self.default)
 		except TypeError:
 			return True
 

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -331,6 +331,8 @@ class DbColumn:
 			elif fieldtype in ["Currency", "Float", "Percent"]:
 				cur_default = flt(cur_default)
 				new_default = flt(new_default)
+			elif fieldtype == "Time":
+				return self.default_changed_for_time(cur_default, new_default)
 			elif db_field_type and db_field_type[0] in ("varchar", "longtext", "text"):
 				new_default = cstr(new_default)
 				if not current_def.get("not_nullable"):
@@ -369,6 +371,24 @@ class DbColumn:
 				return float(cur_default) != float(self.default)
 		except TypeError:
 			return True
+
+	def default_changed_for_time(self, cur_default: str, new_default: str):
+		from datetime import datetime
+
+		# Normalize time values to HH:MM:SS.ssssss format, from formats: HH:MM:SS.ssssss, HH:MM:SS, HH:MM
+		def normalize_time(val):
+			if not val:
+				return None
+			for fmt in ("%H:%M:%S.%f", "%H:%M:%S", "%H:%M"):
+				try:
+					return datetime.strptime(val, fmt).time().strftime("%H:%M:%S.%f")
+				except ValueError:
+					continue
+			return val
+
+		cur = normalize_time(cur_default)
+		new = normalize_time(new_default)
+		return cur != new
 
 
 def validate_column_name(n):

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -347,7 +347,7 @@ class DbColumn:
 			if cur_default in ("", None) and self.default in ("", None):
 				return False
 
-			elif cur_default and flt(cur_default) == 0.0 and self.default in ("", None, 0.0):
+			elif flt(cur_default) == 0.0 and flt(self.default) == 0.0:
 				return False
 
 			elif cur_default in ("", None):


### PR DESCRIPTION
Make the handling of default values for decimal column coherent with the handling for non-decimal columns.
This helps avoid `ValueError: could not convert string to float: 'NULL'`
_I've encountered the error but is it really a real error that happens outside of a test env?_

https://github.com/frappe/frappe/blob/a6e87dad27fa4c9b278db41b7bcfe1955805dcdc/frappe/database/schema.py#L319-L320

# Stack trace

<details>

<summary>Stack trace triggered by creating a custom field (SLA fields) while running tests in a custom app</summary>

```py
  File "/apps/frappe/frappe/model/document.py", line 1185, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    args = ()
    kwargs = {}
    method = 'on_update'
    method_object = <bound method CustomField.on_update of <CustomField: doctype=Custom Field Lead-service_level_section>>
    self = <CustomField: doctype=Custom Field Lead-service_level_section>
  File "/apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 214, in on_update
    frappe.db.updatedb(self.dt)
    self = <CustomField: doctype=Custom Field Lead-service_level_section>
    validate_fields_for_doctype = <function validate_fields_for_doctype>
  File "/apps/frappe/frappe/database/mariadb/mysqlclient.py", line 492, in updatedb
    db_table.sync()
    db_table = <frappe.database.mariadb.schema.MariaDBTable object>
    doctype = 'Lead'
    meta = None
    res = ((0,),)
    self = <frappe.database.mariadb.mysqlclient.MariaDBDatabase object>
  File "/apps/frappe/frappe/database/schema.py", line 48, in sync
    self.alter()
    self = <frappe.database.mariadb.schema.MariaDBTable object>
  File "/apps/frappe/frappe/database/mariadb/schema.py", line 74, in alter
    col.build_for_alter_table(self.current_columns.get(col.fieldname.lower()))
    col = <frappe.database.schema.DbColumn object>
    self = <frappe.database.mariadb.schema.MariaDBTable object>
  File "/apps/frappe/frappe/database/schema.py", line 308, in build_for_alter_table
    self.default_changed(current_def)
    column_type = 'decimal(21,9)'
    current_def = {'name': 'total_hold_time', 'type': 'decimal(21,9)', 'default': 'NULL', 'index': 0, 'unique': 0, 'not_nullable': 0}
    self = <frappe.database.schema.DbColumn object>
  File "/apps/frappe/frappe/database/schema.py", line 331, in default_changed
    return self.default_changed_for_decimal(current_def)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    current_def = {'name': 'total_hold_time', 'type': 'decimal(21,9)', 'default': 'NULL', 'index': 0, 'unique': 0, 'not_nullable': 0}
    self = <frappe.database.schema.DbColumn object>
  File "/apps/frappe/frappe/database/schema.py", line 358, in default_changed_for_decimal
    and float(current_def["default"]) == 0.0
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    current_def = {'name': 'total_hold_time', 'type': 'decimal(21,9)', 'default': 'NULL', 'index': 0, 'unique': 0, 'not_nullable': 0}
    self = <frappe.database.schema.DbColumn object>
ValueError: could not convert string to float: 'NULL'
```

</details>