### PR TITLE
feat(password-reset-form): add show/hide toggle option to password reset form

### DIFF
--- a/frappe/templates/styles/card_style.css
+++ b/frappe/templates/styles/card_style.css
@@ -90,3 +90,26 @@ button#update {
 	max-width: 100%;
 	vertical-align: middle;
 }
+.field-icon {
+	left: 9px;
+	top: 5px;
+	position: absolute;
+	z-index: 2;
+	fill: var(--text-light);
+}
+.password-field {
+	position: relative;
+
+	input {
+		padding-left: 35px;
+	}
+
+	.toggle-password {
+		right: 9px;
+		top: 5px;
+		position: absolute;
+		z-index: 2;
+		cursor: pointer;
+		font-size: 12px;
+	}
+}

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -35,17 +35,30 @@
 		<form id="reset-password" style="width: 100%">
 			<div class="form-group">
 				<input id="old_password" type="password"
-					class="form-control mb-4" placeholder="{{ _('Old Password') }}" autocomplete="current-password">
+					class="form-control mb-4" placeholder="{{ _('Old Password') }}" autocomplete="current-password" required>
 			</div>
 			<div class="form-group">
-				<input id="new_password" type="password"
-					class="form-control mb-4" placeholder="{{ _('New Password') }}" autocomplete="new-password">
-				<span class="password-strength-indicator indicator"></span>
+				<div class="password-field">
+					<input type="password" id="new_password"
+						class="form-control mb-4" placeholder="{{ _('New Password') }}" autocomplete="new-password" required>
+					<span class="password-strength-indicator indicator"></span>
+					<svg class="field-icon password-icon" width="16" height="16" viewBox="0 0 16 16" fill="none"
+						xmlns="http://www.w3.org/2000/svg">
+							<use class="es-lock" href="#es-line-lock"></use>
+					</svg>
+					<span toggle="#new_password" class="toggle-password text-muted">{{ _('Show') }}</span>					 
+				</div>
 			</div>
 			<div class="form-group">
-				<input id="confirm_password" type="password"
-					class="form-control mb-4" placeholder="{{ _('Confirm Password') }}" autocomplete="new-password">
-
+				<div class="password-field">
+					<input id="confirm_password" type="password"
+						class="form-control mb-4" placeholder="{{ _('Confirm Password') }}" autocomplete="new-password" required>
+					<svg class="field-icon password-icon" width="16" height="16" viewBox="0 0 16 16" fill="none"
+						xmlns="http://www.w3.org/2000/svg">
+							<use class="es-lock" href="#es-line-lock"></use>
+					</svg>
+					<span toggle="#confirm_password" class="toggle-password text-muted">{{ _('Show') }}</span>						
+				</div>
 			</div>
 			<p class="password-mismatch-message text-muted small hidden mt-2"></p>
 			<p class='password-strength-message text-muted small mt-2 hidden'></p>
@@ -95,6 +108,18 @@ frappe.ready(function() {
 	new_password.on("keypress", function(e) {
 		if(e.which===13) update_button.click();
 	})
+
+	$(".toggle-password").click(function() {
+		let input = $($(this).attr("toggle"))
+
+		if(input.attr("type") == "password") {
+			input.attr("type", "text")
+			$(this).text({{ _("Hide") | tojson }});
+		} else {
+			input.attr("type", "password")
+			$(this).text({{ _("Show") | tojson }});
+		}
+	});
 
 	update_button.click(function() {
 		var args = {
@@ -300,7 +325,6 @@ frappe.ready(function() {
 		}
 	};
 });
-
 </script>
 
 {% endblock %}


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

    The issue has been raised as there is no toggle option in the reset password form.
    
    
![Before_Changes](https://github.com/user-attachments/assets/4f9a9e31-ebde-4f93-9d22-45558a9b9ada)


<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

    Added the option to toggle the password fields in the reset form.
    I tried to use existing format to code and keep consistence in the UI with the Login Form.
    
    Password reset form.
    
![After_Changes](https://github.com/user-attachments/assets/8e74bc1d-36a8-4697-b358-b78cb1cfa1b2)

   Login Form.
   
![Login_Form](https://github.com/user-attachments/assets/2ae2bbb8-70fe-44de-98e6-ad77ccbb9ec5)



<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
