### PR TITLE
fix: setup wizard broken during site restoration

### DIFF
--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -26,6 +26,8 @@ class InstalledApplications(Document):
 	# end: auto-generated types
 
 	def update_versions(self):
+		self.reload_doc_if_required()
+
 		app_wise_setup_details = self.get_app_wise_setup_details()
 
 		self.delete_key("installed_applications")
@@ -63,6 +65,12 @@ class InstalledApplications(Document):
 				as_list=True,
 			)
 		)
+
+	def reload_doc_if_required(self):
+		if frappe.db.has_column("Installed Application", "is_setup_complete"):
+			return
+
+		frappe.reload_doc("core", "doctype", "installed_application")
 
 
 @frappe.whitelist()


### PR DESCRIPTION
```
 File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 904, in remove_from_installed_apps
    remove_from_installed_apps(app)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/installer.py", line 362, in remove_from_installed_apps
    frappe.get_single("Installed Applications").update_versions()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/installed_applications/installed_applications.py", line 29, in update_versions
    app_wise_setup_details = self.get_app_wise_setup_details()
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/installed_applications/installed_applications.py", line 55, in get_app_wise_setup_details
    frappe.get_all(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 2046, in get_all
    return get_list(doctype, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 2021, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 191, in execute
    result = self.build_and_run()
             ^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 232, in build_and_run
    return frappe.db.sql(
           ^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 230, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/cursors.py", line 153, in execute
    result = self._query(query)
             ^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 563, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 825, in _read_query_result
    result.read()
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 1199, in read
    first_packet = self.connection._read_packet()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 775, in _read_packet
    packet.raise_for_error()
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/protocol.py", line 219, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1054, "Unknown column 'is_setup_complete' in 'SELECT'")
```