### PR TITLE
fix: setup wizard broken during site restoration (v14->v15)

### DIFF
--- a/frappe/core/doctype/installed_applications/installed_applications.json
+++ b/frappe/core/doctype/installed_applications/installed_applications.json
@@ -18,7 +18,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-03-23 16:03:27.992755",
+ "modified": "2025-06-30 21:26:13.462828",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Installed Applications",
@@ -36,8 +36,8 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": [],
- "track_changes": 1
+ "states": []
 }

--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -71,6 +71,8 @@ class InstalledApplications(Document):
 			return
 
 		frappe.reload_doc("core", "doctype", "installed_application")
+		frappe.reload_doc("core", "doctype", "installed_applications")
+		frappe.reload_doc("integrations", "doctype", "webhook")
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Issue 1
```

 File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 904, in remove_from_installed_apps
    remove_from_installed_apps(app)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/installer.py", line 362, in remove_from_installed_apps
    frappe.get_single("Installed Applications").update_versions()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/installed_applications/installed_applications.py", line 52, in update_versions
    self.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 378, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 410, in _save
    self.set_name_in_children()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 923, in set_name_in_children
    set_new_name(d)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/naming.py", line 140, in set_new_name
    doc.run_method("before_naming")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1010, in run_method
    run_webhooks(self, method)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/integrations/doctype/webhook/__init__.py", line 32, in run_webhooks
    webhooks = frappe.cache.get_value("webhooks", get_all_webhooks)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/redis_wrapper.py", line 101, in get_value
    val = generator()
          ^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/integrations/doctype/webhook/__init__.py", line 9, in get_all_webhooks
    webhooks_list = frappe.get_all(
                    ^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 2046, in get_all
    return get_list(doctype, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 2021, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 191, in execute
    result = self.build_and_run()
             ^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 232, in build_and_run
    return frappe.db.sql(
           ^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 230, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/cursors.py", line 153, in execute
    result = self._query(query)
             ^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 563, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 825, in _read_query_result
    result.read()
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 1199, in read
    first_packet = self.connection._read_packet()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 775, in _read_packet
    packet.raise_for_error()
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/protocol.py", line 219, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1054, "Unknown column 'background_jobs_queue' in 'SELECT'")

```


Issue 2

```
    remove_from_installed_apps(app)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/installer.py", line 359, in remove_from_installed_apps
    frappe.get_single("Installed Applications").update_versions()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/installed_applications/installed_applications.py", line 56, in update_versions
    self.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 483, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 536, in _save
    self.run_post_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1333, in run_post_save_methods
    self.save_version()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1472, in save_version
    version.insert(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 424, in insert
    self.db_insert(ignore_if_duplicate=ignore_if_duplicate)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 639, in db_insert
    frappe.db.sql(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 271, in sql
    self.execute_query(query, values)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 366, in execute_query
    return self._cursor.execute(query, values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/MySQLdb/cursors.py", line 179, in execute
    res = self._query(mogrified_query)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/MySQLdb/cursors.py", line 330, in _query
    db.query(q)
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/MySQLdb/connections.py", line 280, in query
    _mysql.connection.query(self, query)
MySQLdb.OperationalError: (1366, "Incorrect integer value: 'dbih557qcf' for column `_4f56b7b5caad43ec`.`tabVersion`.`name` at row 1")

(1366, "Incorrect integer value: 'dbih557qcf' for column `_4f56b7b5caad43ec`.`tabVersion`.`name` at row 1")
```