### PR TITLE
fix: setup wizard broken during site restoration (v14->v15)

### DIFF
--- a/frappe/core/doctype/installed_applications/installed_applications.json
+++ b/frappe/core/doctype/installed_applications/installed_applications.json
@@ -18,7 +18,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2020-05-12 10:09:14.310622",
+ "modified": "2025-06-30 20:20:07.982632",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Installed Applications",
@@ -38,5 +38,5 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
- "track_changes": 1
+ "states": []
 }


### PR DESCRIPTION
```
 remove_from_installed_apps(app)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/installer.py", line 359, in remove_from_installed_apps
    frappe.get_single("Installed Applications").update_versions()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/installed_applications/installed_applications.py", line 56, in update_versions
    self.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 483, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 536, in _save
    self.run_post_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1333, in run_post_save_methods
    self.save_version()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1472, in save_version
    version.insert(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 424, in insert
    self.db_insert(ignore_if_duplicate=ignore_if_duplicate)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 639, in db_insert
    frappe.db.sql(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 271, in sql
    self.execute_query(query, values)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 366, in execute_query
    return self._cursor.execute(query, values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/MySQLdb/cursors.py", line 179, in execute
    res = self._query(mogrified_query)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/MySQLdb/cursors.py", line 330, in _query
    db.query(q)
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/MySQLdb/connections.py", line 280, in query
    _mysql.connection.query(self, query)
MySQLdb.OperationalError: (1366, "Incorrect integer value: 'dbih557qcf' for column `_4f56b7b5caad43ec`.`tabVersion`.`name` at row 1")

(1366, "Incorrect integer value: 'dbih557qcf' for column `_4f56b7b5caad43ec`.`tabVersion`.`name` at row 1")

```

Removed track changes for Installed Applications