### PR TITLE
feat: print format for Reports

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -23,7 +23,7 @@ frappe.ui.form.on("Print Format", {
 	},
 	render_buttons: function (frm) {
 		frm.page.clear_inner_toolbar();
-		if (!frm.is_new()) {
+		if (!frm.is_new() && frm.doc.print_format_for === "Doctype") {
 			if (!frm.doc.custom_format) {
 				frm.add_custom_button(__("Edit Format"), function () {
 					if (!frm.doc.doc_type) {
@@ -70,6 +70,11 @@ frappe.ui.form.on("Print Format", {
 	},
 	doc_type: function (frm) {
 		frm.trigger("hide_absolute_value_field");
+	},
+	print_format_for: function (frm) {
+		if (frm.doc.print_format_for === "Report") {
+			frm.set_value("print_format_type", "JS");
+		}
 	},
 	hide_absolute_value_field: function (frm) {
 		// TODO: make it work with frm.doc.doc_type

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -285,14 +285,13 @@
    "in_standard_filter": 1,
    "label": "Report",
    "mandatory_depends_on": "eval:doc.print_format_for == \"Report\"",
-   "options": "Report",
-   "reqd": 1
+   "options": "Report"
   }
  ],
  "icon": "fa fa-print",
  "idx": 1,
  "links": [],
- "modified": "2025-07-01 16:25:00.431623",
+ "modified": "2025-07-01 18:02:07.194243",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -6,7 +6,9 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "print_format_for",
   "doc_type",
+  "report",
   "module",
   "default_print_language",
   "column_break_3",
@@ -43,14 +45,15 @@
  ],
  "fields": [
   {
+   "depends_on": "eval:doc.print_format_for == \"Doctype\"",
    "fieldname": "doc_type",
    "fieldtype": "Link",
    "in_filter": 1,
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "DocType",
-   "options": "DocType",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.print_format_for == \"Doctype\"",
+   "options": "DocType"
   },
   {
    "fieldname": "module",
@@ -88,7 +91,7 @@
    "label": "Custom Format"
   },
   {
-   "depends_on": "custom_format",
+   "depends_on": "eval:doc.custom_format || doc.print_format_for == \"Report\"",
    "fieldname": "section_break_6",
    "fieldtype": "Section Break"
   },
@@ -98,16 +101,18 @@
    "fieldname": "print_format_type",
    "fieldtype": "Select",
    "label": "Print Format Type",
-   "options": "Jinja\nJS"
+   "options": "Jinja\nJS",
+   "read_only_depends_on": "eval:doc.print_format_for == \"Report\""
   },
   {
    "default": "0",
+   "depends_on": "custom_format",
    "fieldname": "raw_printing",
    "fieldtype": "Check",
    "label": "Raw Printing"
   },
   {
-   "depends_on": "eval:!doc.raw_printing",
+   "depends_on": "eval:(!doc.raw_printing) || (doc.print_format_for == \"Report\")",
    "fieldname": "html",
    "fieldtype": "Code",
    "label": "HTML",
@@ -263,12 +268,31 @@
    "fieldtype": "Select",
    "label": "PDF Generator",
    "options": "wkhtmltopdf"
+  },
+  {
+   "default": "Doctype",
+   "fieldname": "print_format_for",
+   "fieldtype": "Select",
+   "label": "Print Format For",
+   "options": "Doctype\nReport"
+  },
+  {
+   "depends_on": "eval:doc.print_format_for == \"Report\"",
+   "fieldname": "report",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Report",
+   "mandatory_depends_on": "eval:doc.print_format_for == \"Report\"",
+   "options": "Report",
+   "reqd": 1
   }
  ],
  "icon": "fa fa-print",
  "idx": 1,
  "links": [],
- "modified": "2025-02-14 14:49:39.181074",
+ "modified": "2025-07-01 16:25:00.431623",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",
@@ -291,6 +315,7 @@
    "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -45,14 +45,14 @@
  ],
  "fields": [
   {
-   "depends_on": "eval:doc.print_format_for == \"Doctype\"",
+   "depends_on": "eval:doc.print_format_for == \"DocType\"",
    "fieldname": "doc_type",
    "fieldtype": "Link",
    "in_filter": 1,
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "DocType",
-   "mandatory_depends_on": "eval:doc.print_format_for == \"Doctype\"",
+   "mandatory_depends_on": "eval:doc.print_format_for == \"DocType\"",
    "options": "DocType"
   },
   {
@@ -270,11 +270,11 @@
    "options": "wkhtmltopdf"
   },
   {
-   "default": "Doctype",
+   "default": "DocType",
    "fieldname": "print_format_for",
    "fieldtype": "Select",
    "label": "Print Format For",
-   "options": "Doctype\nReport"
+   "options": "DocType\nReport"
   },
   {
    "depends_on": "eval:doc.print_format_for == \"Report\"",
@@ -291,7 +291,7 @@
  "icon": "fa fa-print",
  "idx": 1,
  "links": [],
- "modified": "2025-07-01 18:02:07.194243",
+ "modified": "2025-07-02 11:07:42.812225",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -47,7 +47,7 @@ class PrintFormat(Document):
 		print_format_type: DF.Literal["Jinja", "JS"]
 		raw_commands: DF.Code | None
 		raw_printing: DF.Check
-		report: DF.Link
+		report: DF.Link | None
 		show_section_headings: DF.Check
 		standard: DF.Literal["No", "Yes"]
 	# end: auto-generated types

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -43,7 +43,7 @@ class PrintFormat(Document):
 		pdf_generator: DF.Literal["wkhtmltopdf"]
 		print_format_builder: DF.Check
 		print_format_builder_beta: DF.Check
-		print_format_for: DF.Literal["Doctype", "Report"]
+		print_format_for: DF.Literal["DocType", "Report"]
 		print_format_type: DF.Literal["Jinja", "JS"]
 		raw_commands: DF.Code | None
 		raw_printing: DF.Check
@@ -59,6 +59,10 @@ class PrintFormat(Document):
 			filters={"document_type": self.doc_type},
 		)
 		self.set_onload("print_templates", templates)
+
+	def before_save(self):
+		if self.print_format_for == "Report":
+			self.print_format_type = "JS"
 
 	def get_html(self, docname, letterhead=None):
 		return get_html(self.doc_type, docname, self.name, letterhead)
@@ -92,6 +96,9 @@ class PrintFormat(Document):
 
 		if self.custom_format and not self.html and not self.raw_printing:
 			frappe.throw(_("{0} is required").format(frappe.bold(_("HTML"))), frappe.MandatoryError)
+
+		if self.print_format_for == "Report" and not self.report:
+			frappe.throw(_("{0} is required").format(frappe.bold(_("Report"))), frappe.MandatoryError)
 
 	def extract_images(self):
 		from frappe.core.doctype.file.utils import extract_images_from_html

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -26,7 +26,7 @@ class PrintFormat(Document):
 		custom_format: DF.Check
 		default_print_language: DF.Link | None
 		disabled: DF.Check
-		doc_type: DF.Link
+		doc_type: DF.Link | None
 		font: DF.Data | None
 		font_size: DF.Int
 		format_data: DF.Code | None
@@ -43,9 +43,11 @@ class PrintFormat(Document):
 		pdf_generator: DF.Literal["wkhtmltopdf"]
 		print_format_builder: DF.Check
 		print_format_builder_beta: DF.Check
+		print_format_for: DF.Literal["Doctype", "Report"]
 		print_format_type: DF.Literal["Jinja", "JS"]
 		raw_commands: DF.Code | None
 		raw_printing: DF.Check
+		report: DF.Link
 		show_section_headings: DF.Check
 		standard: DF.Literal["No", "Yes"]
 	# end: auto-generated types

--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -10,6 +10,29 @@ frappe.ui.get_print_settings = function (pdf, callback, letter_head, pick_column
 
 	var columns = [
 		{
+			fieldtype: "Select",
+			fieldname: "orientation",
+			label: __("Orientation"),
+			options: [
+				{ value: "Landscape", label: __("Landscape") },
+				{ value: "Portrait", label: __("Portrait") },
+			],
+			default: "Landscape",
+		},
+		{
+			fieldtype: "Link",
+			fieldname: "report",
+			label: __("Report"),
+			options: "Print Format",
+			default: letter_head || default_letter_head,
+			get_query: () => ({
+				filters: {
+					print_format_for: "Report",
+					disabled: 0,
+				},
+			}),
+		},
+		{
 			fieldtype: "Check",
 			fieldname: "with_letter_head",
 			label: __("With Letter head"),
@@ -21,16 +44,6 @@ frappe.ui.get_print_settings = function (pdf, callback, letter_head, pick_column
 			depends_on: "with_letter_head",
 			options: "Letter Head",
 			default: letter_head || default_letter_head,
-		},
-		{
-			fieldtype: "Select",
-			fieldname: "orientation",
-			label: __("Orientation"),
-			options: [
-				{ value: "Landscape", label: __("Landscape") },
-				{ value: "Portrait", label: __("Portrait") },
-			],
-			default: "Landscape",
 		},
 	];
 


### PR DESCRIPTION
Previously, print formats were only supported for DocTypes. For reports, they could only be defined through code. This PR adds support for using print formats with reports via the UI.

Add an option in the Print Format to select whether it is for a DocType or a Report. The default is DocType.

## Changes in Print format

https://github.com/user-attachments/assets/84a9b249-45f5-48be-85e6-e6c2ccbbf486


## Demo

https://github.com/user-attachments/assets/1ed32a84-de7a-4c56-8c54-26fa5d473049

`no-docs`
