### PR TITLE
fix: Delete single doctypes from DB when uninstalling app

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -447,6 +447,7 @@ def _delete_modules(modules: list[str], dry_run: bool) -> list[str]:
 
 			if not dry_run:
 				if doctype.issingle:
+					frappe.delete_doc(doctype.name, doctype.name, ignore_on_trash=True, force=True)
 					frappe.delete_doc("DocType", doctype.name, ignore_on_trash=True, force=True)
 				else:
 					drop_doctypes.append(doctype.name)


### PR DESCRIPTION
This is different from dropping code and collecting orpahn doctype.

This is consistent with current behaviour:
- orphaned - drop metadata, keep data.
- uninstall - drop metadata and data.

Why? Leaving bad data behind after uninstallation can cause re-installs to fail if schema has changed in between.