### PR TITLE
feat: OAuth2 updates, adds RFC 8414, 7591, 9278

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -275,10 +275,12 @@ def process_response(response: Response):
 
 
 def set_cors_headers(response):
+	allowed_origins = frappe.conf.allow_cors
+	if hasattr(frappe.local, "allow_cors"):
+		allowed_origins = frappe.local.allow_cors
+
 	if not (
-		(allowed_origins := frappe.conf.allow_cors)
-		and (request := frappe.local.request)
-		and (origin := request.headers.get("Origin"))
+		allowed_origins and (request := frappe.local.request) and (origin := request.headers.get("Origin"))
 	):
 		return
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -22,6 +22,7 @@ import frappe.recorder
 import frappe.utils.response
 from frappe import _
 from frappe.auth import SAFE_HTTP_METHODS, UNSAFE_HTTP_METHODS, HTTPRequest, check_request_ip, validate_auth
+from frappe.integrations.oauth2 import handle_wellknown
 from frappe.middlewares import StaticDataMiddleware
 from frappe.permissions import handle_does_not_exist_error
 from frappe.utils import CallbackManager, cint, get_site_name
@@ -125,10 +126,8 @@ def application(request: Request):
 		elif request.path.startswith("/private/files/"):
 			response = frappe.utils.response.download_private_file(request.path)
 
-		elif request.path.startswith("/.well-known/oauth-authorization-server") and request.method == "GET":
-			from frappe.integrations.oauth2 import get_authorization_server_metadata
-
-			response = get_authorization_server_metadata()
+		elif request.path.startswith("/.well-known/") and request.method == "GET":
+			response = handle_wellknown(request.path)
 
 		elif request.method in ("GET", "HEAD", "POST"):
 			response = get_response()

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -125,6 +125,11 @@ def application(request: Request):
 		elif request.path.startswith("/private/files/"):
 			response = frappe.utils.response.download_private_file(request.path)
 
+		elif request.path.startswith("/.well-known/oauth-authorization-server") and request.method == "GET":
+			from frappe.integrations.oauth2 import get_authorization_server_metadata
+
+			response = get_authorization_server_metadata()
+
 		elif request.method in ("GET", "HEAD", "POST"):
 			response = get_response()
 

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -413,6 +413,7 @@ before_request = [
 	"frappe.recorder.record",
 	"frappe.monitor.start",
 	"frappe.rate_limiter.apply",
+	"frappe.integrations.oauth2.set_cors_for_privileged_requests",
 ]
 
 after_request = [

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -62,10 +62,6 @@ website_route_rules = [
 
 website_redirects = [
 	{"source": r"/desk(.*)", "target": r"/app\1"},
-	{
-		"source": "/.well-known/openid-configuration",
-		"target": "/api/method/frappe.integrations.oauth2.openid_configuration",
-	},
 ]
 
 base_template = "templates/base.html"

--- a/frappe/integrations/README.md
+++ b/frappe/integrations/README.md
@@ -1,0 +1,26 @@
+# Integrations
+
+## OAuth 2
+
+Frappe Framwork uses [`oauthlib`](https://github.com/oauthlib/oauthlib) to manage OAuth2 requirements. A Frappe instance can function as all of these:
+
+1. **Resource Server**: contains resources, for example the data in your DocTypes.
+2. **Authorization Server**: server that issues tokens to access some resource.
+3. **Client**: app that requires access to some resource on a resource server.
+
+Different DocTypes and features pertain to each of roles:
+
+0. **Common**:
+   - **OAuth Settings**: allows configuring certain OAuth features.
+1. **Authorization Server**
+   - **OAuth Client**: keeps records of _clients_ registered with the frappe instance.
+   - **OAuth Bearer Token**: tokens given out to registered _clients_ are maintained here.
+   - **OAuth Authorization Code**: keeps track of OAuth codes a client responds with in exchange for a token.
+   - **OAuth Provider Settings**: allows skipping authorization
+2. **Client**
+   - **Connected App**: keeps records of _authorization servers_ against whom this frappe instance is registered as a _client_ so some resource can be accessed. Eg. a users Google Drive account.
+   - **Social Key Login**: similar to **Connected App**, but for the purpose of logging into the frappe instance. Eg. a users Google account to enable "Login with Google".
+   - **Token Cache**: tokens received by the Frappe instance when accessing a **Connected App**.
+3.
+
+## OAuth Settings

--- a/frappe/integrations/README.md
+++ b/frappe/integrations/README.md
@@ -2,7 +2,7 @@
 
 ## OAuth 2
 
-Frappe Framwork uses [`oauthlib`](https://github.com/oauthlib/oauthlib) to manage OAuth2 requirements. A Frappe instance can function as all of these:
+Frappe Framework uses [`oauthlib`](https://github.com/oauthlib/oauthlib) to manage OAuth2 requirements. A Frappe instance can function as all of these:
 
 1. **Resource Server**: contains resources, for example the data in your DocTypes.
 2. **Authorization Server**: server that issues tokens to access some resource.

--- a/frappe/integrations/README.md
+++ b/frappe/integrations/README.md
@@ -8,19 +8,55 @@ Frappe Framwork uses [`oauthlib`](https://github.com/oauthlib/oauthlib) to manag
 2. **Authorization Server**: server that issues tokens to access some resource.
 3. **Client**: app that requires access to some resource on a resource server.
 
-Different DocTypes and features pertain to each of roles:
+DocTypes pertaining to the above roles:
 
-0. **Common**:
-   - **OAuth Settings**: allows configuring certain OAuth features.
-1. **Authorization Server**
+1. **Common**
+   - **OAuth Settings**: allows configuring certain OAuth features pertaining to the three roles.
+2. **Authorization Server**
    - **OAuth Client**: keeps records of _clients_ registered with the frappe instance.
    - **OAuth Bearer Token**: tokens given out to registered _clients_ are maintained here.
    - **OAuth Authorization Code**: keeps track of OAuth codes a client responds with in exchange for a token.
-   - **OAuth Provider Settings**: allows skipping authorization
-2. **Client**
+   - **OAuth Provider Settings**: allows skipping authorization. `[DEPRECATED]` use **OAuth Settings** instead.
+3. **Client**
    - **Connected App**: keeps records of _authorization servers_ against whom this frappe instance is registered as a _client_ so some resource can be accessed. Eg. a users Google Drive account.
    - **Social Key Login**: similar to **Connected App**, but for the purpose of logging into the frappe instance. Eg. a users Google account to enable "Login with Google".
    - **Token Cache**: tokens received by the Frappe instance when accessing a **Connected App**.
-3.
 
-## OAuth Settings
+### Features
+
+Additional features over `oauthlib` that have implemented in the Framework:
+
+- **Dynamic Client Registration**: allows a client to register itself without manual configuration by the resource owner. [RFC7591](https://datatracker.ietf.org/doc/html/rfc7591)
+- **Authorization Server Metadata Discovery**: allows a client to view the instance's auth server (itself) metadata such as auth end points. [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414)
+- **Resource Server Metadata Discovery**: allows a client to view the instance's resource server metadata such as documentation, auth servers, etc. [RFC9278](https://datatracker.ietf.org/doc/html/rfc9728)
+
+### Additional Docs
+
+Documentation of various OAuth2 features:
+
+1. [How to setup OAuth 2?](https://docs.frappe.io/framework/user/en/guides/integration/how_to_set_up_oauth)
+2. [OAuth 2](https://docs.frappe.io/framework/user/en/guides/integration/rest_api/oauth-2)
+3. [Token Based Authentication](https://docs.frappe.io/framework/user/en/guides/integration/rest_api/token_based_authentication)
+4. [Using Frappe as OAuth Service](https://docs.frappe.io/framework/user/en/using_frappe_as_oauth_service)
+5. [Social Login Key](https://docs.frappe.io/framework/user/en/guides/integration/social_login_key)
+6. [Connected App](https://docs.frappe.io/framework/user/en/guides/app-development/connected-app)
+
+> [!WARNING]
+>
+> Some of these might be outdated, it is always recommended to check the code
+> when in doubt.
+
+### OAuth Settings
+
+A Single doctype that allows configuring OAuth2 related features. It is
+recommended to open the DocType page itself as each field and section has a
+sufficiently descriptive help text.
+
+The settings allow toggling the following features:
+
+- Authorization check when active token is present using the _Skip Authorization_ field. _**Note**: Keep this unchecked in production._
+- **Authorization Server Metadata Discovery**: by toggling the _Show Auth Server Metadata_ field.
+- **Dynamic Client Registration**: by toggling the _Enable Dynamic Client Registration_ field.
+- **Resource Server Metadata Discovery**: by toggling the _Show Protected Resource Metadata_.
+
+The remaining fields (in the **Resource Server** section) are used only when responding to requests on `/.well-known/oauth-protected-resource`

--- a/frappe/integrations/README.md
+++ b/frappe/integrations/README.md
@@ -59,4 +59,12 @@ The settings allow toggling the following features:
 - **Dynamic Client Registration**: by toggling the _Enable Dynamic Client Registration_ field.
 - **Resource Server Metadata Discovery**: by toggling the _Show Protected Resource Metadata_.
 
-The remaining fields (in the **Resource Server** section) are used only when responding to requests on `/.well-known/oauth-protected-resource`
+The remaining fields (in the **Resource** section) are used only when responding to requests on `/.well-known/oauth-protected-resource`
+
+> **Regarding Public Clients**
+>
+> Public clients, for example an SPA, have restricted access by default. This
+> restriction is applied by use of CORS.
+>
+> To side-step this restriction for certain trusted clients, you may add their
+> hostnames to the **Allowed Public Client Origins** field.

--- a/frappe/integrations/README.md
+++ b/frappe/integrations/README.md
@@ -28,7 +28,7 @@ Additional features over `oauthlib` that have implemented in the Framework:
 
 - **Dynamic Client Registration**: allows a client to register itself without manual configuration by the resource owner. [RFC7591](https://datatracker.ietf.org/doc/html/rfc7591)
 - **Authorization Server Metadata Discovery**: allows a client to view the instance's auth server (itself) metadata such as auth end points. [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414)
-- **Resource Server Metadata Discovery**: allows a client to view the instance's resource server metadata such as documentation, auth servers, etc. [RFC9278](https://datatracker.ietf.org/doc/html/rfc9728)
+- **Resource Server Metadata Discovery**: allows a client to view the instance's resource server metadata such as documentation, auth servers, etc. [RFC9728](https://datatracker.ietf.org/doc/html/rfc9728)
 
 ### Additional Docs
 

--- a/frappe/integrations/doctype/oauth_client/oauth_client.json
+++ b/frappe/integrations/doctype/oauth_client/oauth_client.json
@@ -7,17 +7,26 @@
  "engine": "InnoDB",
  "field_order": [
   "client_id",
-  "app_name",
   "user",
   "allowed_roles",
   "cb_1",
   "client_secret",
-  "skip_authorization",
-  "sb_1",
-  "scopes",
-  "cb_3",
-  "redirect_uris",
   "default_redirect_uri",
+  "skip_authorization",
+  "client_metadata_section",
+  "app_name",
+  "scopes",
+  "column_break_htfq",
+  "redirect_uris",
+  "section_break_ggiv",
+  "client_uri",
+  "software_id",
+  "tos_uri",
+  "contacts",
+  "column_break_ziii",
+  "logo_uri",
+  "software_version",
+  "policy_uri",
   "sb_advanced",
   "grant_type",
   "cb_2",
@@ -27,13 +36,13 @@
   {
    "fieldname": "client_id",
    "fieldtype": "Data",
-   "label": "App Client ID",
+   "label": "Client ID",
    "read_only": 1
   },
   {
    "fieldname": "app_name",
    "fieldtype": "Data",
-   "label": "App Name",
+   "label": "App Name (Client Name)",
    "reqd": 1
   },
   {
@@ -50,7 +59,7 @@
   {
    "fieldname": "client_secret",
    "fieldtype": "Data",
-   "label": "App Client Secret",
+   "label": "Client Secret",
    "read_only": 1
   },
   {
@@ -61,20 +70,12 @@
    "label": "Skip Authorization"
   },
   {
-   "fieldname": "sb_1",
-   "fieldtype": "Section Break"
-  },
-  {
    "default": "all openid",
    "description": "A list of resources which the Client App will have access to after the user allows it.<br> e.g. project",
    "fieldname": "scopes",
    "fieldtype": "Text",
    "label": "Scopes",
    "reqd": 1
-  },
-  {
-   "fieldname": "cb_3",
-   "fieldtype": "Column Break"
   },
   {
    "description": "URIs for receiving authorization code once the user allows access, as well as failure responses. Typically a REST endpoint exposed by the Client App.\n<br>e.g. http://hostname/api/method/frappe.integrations.oauth2_logins.login_via_facebook",
@@ -121,10 +122,77 @@
    "fieldtype": "Table MultiSelect",
    "label": "Allowed Roles",
    "options": "OAuth Client Role"
+  },
+  {
+   "fieldname": "client_metadata_section",
+   "fieldtype": "Section Break",
+   "label": "Client Metadata"
+  },
+  {
+   "depends_on": "eval: doc.client_uri",
+   "description": "URL of a web page providing information about the client.",
+   "fieldname": "client_uri",
+   "fieldtype": "Data",
+   "label": "Client URI"
+  },
+  {
+   "fieldname": "column_break_htfq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.client_uri",
+   "description": "URL that references a logo for the client.",
+   "fieldname": "logo_uri",
+   "fieldtype": "Data",
+   "label": "Logo URI"
+  },
+  {
+   "fieldname": "section_break_ggiv",
+   "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "eval: doc.software_id",
+   "description": "Unique ID assigned by the client developer used to identify the client software to be dynamically registered.\n<br>\n<b>Should remain same</b> across multiple versions or updates of the software.",
+   "fieldname": "software_id",
+   "fieldtype": "Data",
+   "label": "Software ID"
+  },
+  {
+   "fieldname": "column_break_ziii",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.software_version",
+   "description": "A version identifier string for the client software.\n<br>\nThe value of the should change on any update of the client software with the same Software ID.",
+   "fieldname": "software_version",
+   "fieldtype": "Data",
+   "label": "Software Version"
+  },
+  {
+   "depends_on": "eval: doc.tos_uri",
+   "description": "URL that points to a human-readable terms of service document for the client. Should be shown to end-user before authorizing.",
+   "fieldname": "tos_uri",
+   "fieldtype": "Data",
+   "label": "TOS URI"
+  },
+  {
+   "depends_on": "eval: doc.policy_uri",
+   "description": "URL that points to a human-readable policy document for the client. Should be shown to end-user before authorizing.",
+   "fieldname": "policy_uri",
+   "fieldtype": "Data",
+   "label": "Policy URI"
+  },
+  {
+   "depends_on": "eval: doc.contacts",
+   "description": "New lines separated list of strings representing ways to contact people responsible for this client, typically email addresses.",
+   "fieldname": "contacts",
+   "fieldtype": "Small Text",
+   "label": "Contacts"
   }
  ],
+ "grid_page_length": 50,
  "links": [],
- "modified": "2024-04-29 12:07:07.946980",
+ "modified": "2025-07-02 11:52:00.978956",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Client",
@@ -143,6 +211,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/integrations/doctype/oauth_client/oauth_client.json
+++ b/frappe/integrations/doctype/oauth_client/oauth_client.json
@@ -29,6 +29,7 @@
   "policy_uri",
   "sb_advanced",
   "grant_type",
+  "token_endpoint_auth_method",
   "cb_2",
   "response_type"
  ],
@@ -188,11 +189,19 @@
    "fieldname": "contacts",
    "fieldtype": "Small Text",
    "label": "Contacts"
+  },
+  {
+   "default": "Client Secret Basic",
+   "description": "Value of \"None\" implies a public client. In such a case Client Secret is not given to the client and token exchange makes use of PKCE.",
+   "fieldname": "token_endpoint_auth_method",
+   "fieldtype": "Select",
+   "label": "Token Endpoint Auth Method",
+   "options": "Client Secret Basic\nClient Secret Post\nNone"
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-07-02 11:52:00.978956",
+ "modified": "2025-07-04 14:07:36.146393",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Client",

--- a/frappe/integrations/doctype/oauth_client/oauth_client.py
+++ b/frappe/integrations/doctype/oauth_client/oauth_client.py
@@ -21,12 +21,19 @@ class OAuthClient(Document):
 		app_name: DF.Data
 		client_id: DF.Data | None
 		client_secret: DF.Data | None
+		client_uri: DF.Data | None
+		contacts: DF.SmallText | None
 		default_redirect_uri: DF.Data
 		grant_type: DF.Literal["Authorization Code", "Implicit"]
+		logo_uri: DF.Data | None
+		policy_uri: DF.Data | None
 		redirect_uris: DF.Text | None
 		response_type: DF.Literal["Code", "Token"]
 		scopes: DF.Text
 		skip_authorization: DF.Check
+		software_id: DF.Data | None
+		software_version: DF.Data | None
+		tos_uri: DF.Data | None
 		user: DF.Link | None
 	# end: auto-generated types
 

--- a/frappe/integrations/doctype/oauth_client/oauth_client.py
+++ b/frappe/integrations/doctype/oauth_client/oauth_client.py
@@ -1,7 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
+import datetime
+import time
+
 import frappe
+import frappe.utils
 from frappe import _
 from frappe.model.document import Document
 from frappe.permissions import SYSTEM_USER_ROLE
@@ -33,6 +37,7 @@ class OAuthClient(Document):
 		skip_authorization: DF.Check
 		software_id: DF.Data | None
 		software_version: DF.Data | None
+		token_endpoint_auth_method: DF.Literal["Client Secret Basic", "Client Secret Post", "None"]
 		tos_uri: DF.Data | None
 		user: DF.Link | None
 	# end: auto-generated types
@@ -62,3 +67,18 @@ class OAuthClient(Document):
 		"""Returns true if session user is allowed to use this client."""
 		allowed_roles = {d.role for d in self.allowed_roles}
 		return bool(allowed_roles & set(frappe.get_roles()))
+
+	def is_public_client(self) -> bool:
+		return self.token_endpoint_auth_method == "None"
+
+	def client_id_issued_at(self) -> int:
+		"""Returns UNIX timestamp (seconds since epoch) of the client creation time."""
+
+		if isinstance(self.creation, datetime.datetime):
+			return int(self.creation.timestamp())
+
+		try:
+			d = datetime.datetime.fromisoformat(self.creation)
+			return int(d.timestamp())
+		except Exception:
+			return int(frappe.utils.now_datetime().timestamp())

--- a/frappe/integrations/doctype/oauth_provider_settings/oauth_provider_settings.py
+++ b/frappe/integrations/doctype/oauth_provider_settings/oauth_provider_settings.py
@@ -19,10 +19,3 @@ class OAuthProviderSettings(Document):
 	# end: auto-generated types
 
 	pass
-
-
-def get_oauth_settings():
-	"""Return OAuth settings."""
-	return frappe._dict(
-		{"skip_authorization": frappe.db.get_single_value("OAuth Provider Settings", "skip_authorization")}
-	)

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.js
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("OAuth Settings", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.json
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.json
@@ -14,6 +14,7 @@
   "resource_name",
   "resource_policy_uri",
   "show_protected_resource_metadata",
+  "show_social_login_key_as_authorization_server",
   "column_break_zyte",
   "resource_documentation",
   "resource_tos_uri",
@@ -70,7 +71,7 @@
   },
   {
    "default": "1",
-   "description": "Allows clients to fetch metadata from the <code>/.well-known/oauth-protected-resource</code> endpoint.",
+   "description": "Allows clients to fetch metadata from the <code>/.well-known/oauth-protected-resource</code> endpoint. Reference: <a href=\"https://datatracker.ietf.org/doc/html/rfc9728#name-protected-resource-metadata\">RFC9728</a>",
    "fieldname": "show_protected_resource_metadata",
    "fieldtype": "Check",
    "label": "Show Protected Resource Metadata"
@@ -94,13 +95,20 @@
    "fieldname": "skip_authorization",
    "fieldtype": "Check",
    "label": "Skip Authorization"
+  },
+  {
+   "default": "0",
+   "description": "Allows enabled Social Login Key Base URL to be shown as authorization server.",
+   "fieldname": "show_social_login_key_as_authorization_server",
+   "fieldtype": "Check",
+   "label": "Show Social Login Key as Authorization Server"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-03 14:29:35.314601",
+ "modified": "2025-07-04 11:20:15.528611",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Settings",

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.json
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.json
@@ -6,15 +6,21 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "authorization_tab",
   "authorization_server_section",
   "show_auth_server_metadata",
-  "enable_dynamic_client_registration",
   "skip_authorization",
+  "column_break_ogmd",
+  "enable_dynamic_client_registration",
+  "allowed_origins_for_public_client_registration",
+  "resource_tab",
+  "config_section",
+  "show_protected_resource_metadata",
+  "column_break_wlfj",
+  "show_social_login_key_as_authorization_server",
   "resource_server_section",
   "resource_name",
   "resource_policy_uri",
-  "show_protected_resource_metadata",
-  "show_social_login_key_as_authorization_server",
   "column_break_zyte",
   "resource_documentation",
   "resource_tos_uri",
@@ -22,10 +28,10 @@
  ],
  "fields": [
   {
-   "description": "These fields are used to provide resource server metadata to clients querying the \"/.well-known/oauth-protected-resource\" end point. For additional reference view: https://datatracker.ietf.org/doc/html/rfc9728",
+   "description": "These fields are used to provide resource server metadata to clients querying the \"well known protected resource\" end point.",
    "fieldname": "resource_server_section",
    "fieldtype": "Section Break",
-   "label": "Resource Server"
+   "label": "Metadata"
   },
   {
    "default": "Frappe Framework Application",
@@ -59,8 +65,7 @@
   },
   {
    "fieldname": "authorization_server_section",
-   "fieldtype": "Section Break",
-   "label": "Authorization Server"
+   "fieldtype": "Section Break"
   },
   {
    "default": "1",
@@ -102,13 +107,42 @@
    "fieldname": "show_social_login_key_as_authorization_server",
    "fieldtype": "Check",
    "label": "Show Social Login Key as Authorization Server"
+  },
+  {
+   "fieldname": "column_break_ogmd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "authorization_tab",
+   "fieldtype": "Tab Break",
+   "label": "Authorization"
+  },
+  {
+   "fieldname": "resource_tab",
+   "fieldtype": "Tab Break",
+   "label": "Resource"
+  },
+  {
+   "fieldname": "config_section",
+   "fieldtype": "Section Break",
+   "label": "Config"
+  },
+  {
+   "fieldname": "column_break_wlfj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "New line separated list of allowed public client URLs (eg <code>https://frappe.io</code>), or <code>*</code> to accept all.\n<br>\nPublic clients are restricted by default.",
+   "fieldname": "allowed_origins_for_public_client_registration",
+   "fieldtype": "Small Text",
+   "label": "Allowed Origins for Public Client Registration"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-04 11:20:15.528611",
+ "modified": "2025-07-04 12:05:50.723018",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Settings",

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.json
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.json
@@ -12,7 +12,7 @@
   "skip_authorization",
   "column_break_ogmd",
   "enable_dynamic_client_registration",
-  "allowed_origins_for_public_client_registration",
+  "allowed_public_client_origins",
   "resource_tab",
   "config_section",
   "show_protected_resource_metadata",
@@ -133,16 +133,16 @@
   },
   {
    "description": "New line separated list of allowed public client URLs (eg <code>https://frappe.io</code>), or <code>*</code> to accept all.\n<br>\nPublic clients are restricted by default.",
-   "fieldname": "allowed_origins_for_public_client_registration",
+   "fieldname": "allowed_public_client_origins",
    "fieldtype": "Small Text",
-   "label": "Allowed Origins for Public Client Registration"
+   "label": "Allowed Public Client Origins"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-04 12:05:50.723018",
+ "modified": "2025-07-04 15:01:45.453238",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Settings",

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.json
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.json
@@ -21,7 +21,7 @@
  ],
  "fields": [
   {
-   "description": "These settings are used when this Frappe instance functions as a resource server.",
+   "description": "These fields are used to provide resource server metadata to clients querying the \"/.well-known/oauth-protected-resource\" end point. For additional reference view: https://datatracker.ietf.org/doc/html/rfc9728",
    "fieldname": "resource_server_section",
    "fieldtype": "Section Break",
    "label": "Resource Server"
@@ -63,7 +63,7 @@
   },
   {
    "default": "1",
-   "description": "Allows clients to fetch metadata from the <code>/.well-known/oauth-authorization-server</code> endpoint.",
+   "description": "Allows clients to fetch metadata from the <code>/.well-known/oauth-authorization-server</code> endpoint. Reference: <a href=\"https://datatracker.ietf.org/doc/html/rfc8414\">RFC8414</a>",
    "fieldname": "show_auth_server_metadata",
    "fieldtype": "Check",
    "label": "Show Auth Server Metadata"
@@ -83,7 +83,7 @@
   },
   {
    "default": "1",
-   "description": "Allows clients to register themselves without manual intervention. Registration creates a <b>OAuth Client</b> entry.",
+   "description": "Allows clients to register themselves without manual intervention. Registration creates a <b>OAuth Client</b> entry. Reference: <a href=\"https://datatracker.ietf.org/doc/html/rfc7591\">RFC7591</a>",
    "fieldname": "enable_dynamic_client_registration",
    "fieldtype": "Check",
    "label": "Enable Dynamic Client Registration"
@@ -100,7 +100,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-03 14:07:31.542741",
+ "modified": "2025-07-03 14:29:35.314601",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Settings",

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.json
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.json
@@ -9,6 +9,7 @@
   "authorization_server_section",
   "show_auth_server_metadata",
   "enable_dynamic_client_registration",
+  "skip_authorization",
   "resource_server_section",
   "resource_name",
   "resource_policy_uri",
@@ -86,13 +87,20 @@
    "fieldname": "enable_dynamic_client_registration",
    "fieldtype": "Check",
    "label": "Enable Dynamic Client Registration"
+  },
+  {
+   "default": "0",
+   "description": "Allows skipping authorization if a user has active tokens.",
+   "fieldname": "skip_authorization",
+   "fieldtype": "Check",
+   "label": "Skip Authorization"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-03 12:49:31.650861",
+ "modified": "2025-07-03 14:07:31.542741",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Settings",

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.json
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.json
@@ -1,0 +1,116 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-07-03 12:04:14.759362",
+ "description": "A Frappe Framework instance can function as an OAuth Client, Resource, or Authorization server. This DocType contains settings related to all three.",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "authorization_server_section",
+  "show_auth_server_metadata",
+  "enable_dynamic_client_registration",
+  "resource_server_section",
+  "resource_name",
+  "resource_policy_uri",
+  "show_protected_resource_metadata",
+  "column_break_zyte",
+  "resource_documentation",
+  "resource_tos_uri",
+  "scopes_supported"
+ ],
+ "fields": [
+  {
+   "description": "These settings are used when this Frappe instance functions as a resource server.",
+   "fieldname": "resource_server_section",
+   "fieldtype": "Section Break",
+   "label": "Resource Server"
+  },
+  {
+   "default": "Frappe Framework Application",
+   "description": "Human-readable name intended for display to the end user.",
+   "fieldname": "resource_name",
+   "fieldtype": "Data",
+   "label": "Resource Name"
+  },
+  {
+   "fieldname": "column_break_zyte",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "https://docs.frappe.io/framework",
+   "description": "URL of a human-readable page with info that developers might need.",
+   "fieldname": "resource_documentation",
+   "fieldtype": "Data",
+   "label": "Resource Documentation"
+  },
+  {
+   "description": "URL of human-readable page with info on requirements about how the client can use the data.",
+   "fieldname": "resource_policy_uri",
+   "fieldtype": "Data",
+   "label": "Resource Policy URI"
+  },
+  {
+   "description": "URL of human-readable page with info about the protected resource's terms of service.",
+   "fieldname": "resource_tos_uri",
+   "fieldtype": "Data",
+   "label": "Resource TOS URI"
+  },
+  {
+   "fieldname": "authorization_server_section",
+   "fieldtype": "Section Break",
+   "label": "Authorization Server"
+  },
+  {
+   "default": "1",
+   "description": "Allows clients to fetch metadata from the <code>/.well-known/oauth-authorization-server</code> endpoint.",
+   "fieldname": "show_auth_server_metadata",
+   "fieldtype": "Check",
+   "label": "Show Auth Server Metadata"
+  },
+  {
+   "default": "1",
+   "description": "Allows clients to fetch metadata from the <code>/.well-known/oauth-protected-resource</code> endpoint.",
+   "fieldname": "show_protected_resource_metadata",
+   "fieldtype": "Check",
+   "label": "Show Protected Resource Metadata"
+  },
+  {
+   "description": "New line separated list of scope values.",
+   "fieldname": "scopes_supported",
+   "fieldtype": "Small Text",
+   "label": "Scopes Supported"
+  },
+  {
+   "default": "1",
+   "description": "Allows clients to register themselves without manual intervention. Registration creates a <b>OAuth Client</b> entry.",
+   "fieldname": "enable_dynamic_client_registration",
+   "fieldtype": "Check",
+   "label": "Enable Dynamic Client Registration"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2025-07-03 12:49:31.650861",
+ "modified_by": "Administrator",
+ "module": "Integrations",
+ "name": "OAuth Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.py
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.py
@@ -14,7 +14,7 @@ class OAuthSettings(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		allowed_origins_for_public_client_registration: DF.SmallText | None
+		allowed_public_client_origins: DF.SmallText | None
 		enable_dynamic_client_registration: DF.Check
 		resource_documentation: DF.Data | None
 		resource_name: DF.Data | None

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.py
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.py
@@ -14,6 +14,7 @@ class OAuthSettings(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		allowed_origins_for_public_client_registration: DF.SmallText | None
 		enable_dynamic_client_registration: DF.Check
 		resource_documentation: DF.Data | None
 		resource_name: DF.Data | None

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.py
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2025, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class OAuthSettings(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		enable_dynamic_client_registration: DF.Check
+		resource_documentation: DF.Data | None
+		resource_name: DF.Data | None
+		resource_policy_uri: DF.Data | None
+		resource_tos_uri: DF.Data | None
+		scopes_supported: DF.SmallText | None
+		show_auth_server_metadata: DF.Check
+		show_protected_resource_metadata: DF.Check
+	# end: auto-generated types
+
+	pass

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.py
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.py
@@ -22,6 +22,7 @@ class OAuthSettings(Document):
 		scopes_supported: DF.SmallText | None
 		show_auth_server_metadata: DF.Check
 		show_protected_resource_metadata: DF.Check
+		skip_authorization: DF.Check
 	# end: auto-generated types
 
 	pass

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.py
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.py
@@ -22,6 +22,7 @@ class OAuthSettings(Document):
 		scopes_supported: DF.SmallText | None
 		show_auth_server_metadata: DF.Check
 		show_protected_resource_metadata: DF.Check
+		show_social_login_key_as_authorization_server: DF.Check
 		skip_authorization: DF.Check
 	# end: auto-generated types
 

--- a/frappe/integrations/doctype/oauth_settings/test_oauth_settings.py
+++ b/frappe/integrations/doctype/oauth_settings/test_oauth_settings.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestOAuthSettings(IntegrationTestCase):
+	"""
+	Integration tests for OAuthSettings.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/frappe/integrations/doctype/social_login_key/social_login_key.json
+++ b/frappe/integrations/doctype/social_login_key/social_login_key.json
@@ -20,6 +20,7 @@
   "base_url",
   "configuration_section",
   "sign_ups",
+  "show_in_resource_metadata",
   "client_urls",
   "authorize_url",
   "access_token_url",
@@ -172,11 +173,19 @@
    "fieldtype": "Select",
    "label": "Sign ups",
    "options": "\nAllow\nDeny"
+  },
+  {
+   "default": "1",
+   "description": "Allows clients to view this as an Authorization Server when querying the <code>/.well-known/oauth-protected-resource</code> end point.",
+   "fieldname": "show_in_resource_metadata",
+   "fieldtype": "Check",
+   "label": "Show in Resource Metadata"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-06 15:22:46.342392",
+ "modified": "2025-07-03 12:47:01.696817",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Social Login Key",
@@ -195,6 +204,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/integrations/doctype/social_login_key/social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/social_login_key.py
@@ -54,6 +54,7 @@ class SocialLoginKey(Document):
 		icon: DF.Data | None
 		provider_name: DF.Data
 		redirect_url: DF.Data | None
+		show_in_resource_metadata: DF.Check
 		sign_ups: DF.Literal["", "Allow", "Deny"]
 		social_login_provider: DF.Literal[
 			"Custom",

--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -11,12 +11,10 @@ from werkzeug.exceptions import NotFound
 
 import frappe
 from frappe import oauth
-from frappe.integrations.doctype.oauth_provider_settings.oauth_provider_settings import (
-	get_oauth_settings,
-)
 from frappe.integrations.utils import (
 	OAuth2DynamicClientMetadata,
 	create_new_oauth_client,
+	get_oauth_settings,
 	validate_dynamic_client_metadata,
 )
 from frappe.oauth import (

--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -444,14 +444,19 @@ def _get_protected_resource_metadata():
 
 
 def is_oauth_metadata_enabled(label: Literal["resource", "auth_server"]):
-	fieldname = (
-		"show_auth_server_metadata" if label == "authorization" else "show_protected_resource_metadata"
-	)
+	if label not in ["resource", "auth_server"]:
+		return False
 
-	return frappe.get_cached_value(
-		"OAuth Settings",
-		"OAuth Settings",
-		fieldname,
+	fieldname = "show_auth_server_metadata"
+	if label == "resource":
+		fieldname = "show_protected_resource_metadata"
+
+	return bool(
+		frappe.get_cached_value(
+			"OAuth Settings",
+			"OAuth Settings",
+			fieldname,
+		)
 	)
 
 

--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -252,7 +252,7 @@ def create_new_oauth_client(client: OAuth2DynamicClientMetadata):
 	if client.software_version:
 		doc.software_version = client.software_version
 
-	doc.save()
+	doc.save(ignore_permissions=True)
 	return doc
 
 

--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -210,11 +210,11 @@ def validate_dynamic_client_metadata(client: OAuth2DynamicClientMetadata):
 	if client.token_endpoint_auth_method not in ["client_secret_basic"]:
 		invalidation_reasons.append("only client_secret_basic token_endpoint_auth_method is supported")
 
-	if client.grant_types not in ["authorization_code"]:
+	if client.grant_types and not set(client.grant_types).issubset({"authorization_code", "refresh_token"}):
 		invalidation_reasons.append("only authorization_code and refresh_token grant types are supported")
 
-	if client.response_types not in ["code"]:
-		invalidation_reasons.append("only code response_type is supported")
+	if client.response_types and not all(rt == "code" for rt in client.response_types):
+		invalidation_reasons.append("only 'code' response_type is supported")
 
 	if not frappe.conf.developer_mode and any(c.scheme != "https" for c in client.redirect_uris):
 		invalidation_reasons.append("redirect_uris must be https")

--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -3,7 +3,7 @@
 
 import datetime
 import json
-from typing import cast
+from typing import Any, cast
 from urllib.parse import parse_qs
 
 from pydantic import BaseModel, HttpUrl
@@ -254,3 +254,17 @@ def create_new_oauth_client(client: OAuth2DynamicClientMetadata):
 
 	doc.save()
 	return doc
+
+
+def get_oauth_settings():
+	"""Return OAuth settings."""
+	settings: dict[str, Any] = frappe._dict({"skip_authorization": None})
+	if frappe.get_cached_value("OAuth Settings", "OAuth Settings", "skip_authorization"):
+		settings["skip_authorization"] = "Auto"  # based on legacy OAuth Provider Settings value
+
+	elif value := frappe.get_cached_value(
+		"OAuth Provider Settings", "OAuth Provider Settings", "skip_authorization"
+	):
+		settings["skip_authorization"] = value
+
+	return settings

--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -3,10 +3,46 @@
 
 import datetime
 import json
+from typing import cast
 from urllib.parse import parse_qs
 
+from pydantic import BaseModel, HttpUrl
+
 import frappe
+from frappe.integrations.doctype.oauth_client.oauth_client import OAuthClient
 from frappe.utils import get_request_session
+
+
+class OAuth2DynamicClientMetadata(BaseModel):
+	"""
+	OAuth 2.0 Dynamic Client Registration Metadata.
+
+	As defined in RFC7591 - OAuth 2.0 Dynamic Client Registration Protocol
+	https://datatracker.ietf.org/doc/html/rfc7591#section-2
+	"""
+
+	#  Used to identify the client to the authorization server
+	redirect_uris: list[HttpUrl]
+	token_endpoint_auth_method: str | None = "client_secret_basic"
+	grant_types: list[str] | None = ["authorization_code"]
+	response_types: list[str] | None = ["code"]
+
+	#  Client identifiers shown to user
+	client_name: str
+	scope: str
+	client_uri: HttpUrl | None = None
+	logo_uri: HttpUrl | None = None
+
+	#  Client contact and other information for the client
+	contacts: list[str] | None = None
+	tos_uri: HttpUrl | None = None
+	policy_uri: HttpUrl | None = None
+	software_id: str | None = None
+	software_version: str | None = None
+
+	#  JSON Web Key Set (JWKS) not used here
+	jwks_uri: HttpUrl | None = None
+	jwks: dict | None = None
 
 
 def make_request(method: str, url: str, auth=None, headers=None, data=None, json=None, params=None):
@@ -164,3 +200,57 @@ def get_json(obj):
 def json_handler(obj):
 	if isinstance(obj, datetime.date | datetime.timedelta | datetime.datetime):
 		return str(obj)
+
+
+def validate_dynamic_client_metadata(client: OAuth2DynamicClientMetadata):
+	invalidation_reasons = []
+	if len(client.redirect_uris) == 0:
+		invalidation_reasons.append("redirect_uris is required")
+
+	if client.token_endpoint_auth_method not in ["client_secret_basic"]:
+		invalidation_reasons.append("only client_secret_basic token_endpoint_auth_method is supported")
+
+	if client.grant_types not in ["authorization_code"]:
+		invalidation_reasons.append("only authorization_code and refresh_token grant types are supported")
+
+	if client.response_types not in ["code"]:
+		invalidation_reasons.append("only code response_type is supported")
+
+	if not frappe.conf.developer_mode and any(c.scheme != "https" for c in client.redirect_uris):
+		invalidation_reasons.append("redirect_uris must be https")
+
+	if invalidation_reasons:
+		return ",\n".join(invalidation_reasons)
+
+	return None
+
+
+def create_new_oauth_client(client: OAuth2DynamicClientMetadata):
+	doc = cast(OAuthClient, frappe.get_doc({"doctype": "OAuth Client"}))
+	redirect_uris = [str(uri) for uri in client.redirect_uris]
+
+	doc.app_name = client.client_name
+	doc.scopes = client.scope
+	doc.redirect_uris = "\n".join(redirect_uris)
+	doc.default_redirect_uri = redirect_uris[0]
+	doc.response_type = "Code"
+	doc.grant_type = "Authorization Code"
+	doc.skip_authorization = False
+
+	if client.client_uri:
+		doc.client_uri = client.client_uri.encoded_string()
+	if client.logo_uri:
+		doc.logo_uri = client.logo_uri.encoded_string()
+	if client.tos_uri:
+		doc.tos_uri = client.tos_uri.encoded_string()
+	if client.policy_uri:
+		doc.policy_uri = client.policy_uri.encoded_string()
+	if client.contacts:
+		doc.contacts = "\n".join(client.contacts)
+	if client.software_id:
+		doc.software_id = client.software_id
+	if client.software_version:
+		doc.software_version = client.software_version
+
+	doc.save()
+	return doc


### PR DESCRIPTION
### What is it

- [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414): allows a client to get metadata about the auth server, i.e. sidesteps a user having to know auth server urls.
- [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591): allows a client to be dynamically registered by calling the registration endpoint; i.e. sidesteps manually creating an **OAuth Client** entry.
- [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728): allows a resource server to publish its metadata, like auth servers used, etc.

### Changes

- Adds handler for `/.well-known/oauth-authorization-server`.
- Updates **OAuth Client** with additional fields.
- Adds client registration end point at `/api/method/frappe.integrations.oauth2.register_client`.
- Adds handler for `/.well-known/oauth-protected-resource`.
- Adds **OAuth Settings** to toggle and configure the features in this PR.
- Adds `WWW-Authenticate` header on 401 and 403 responses.
- Adds a `before_request` hook to handle CORS requirements for public clients.

### Details

**RFC8414** treats the Frappe instance as the **Authorization Server**, i.e. the **Resource Server** is the **Authorization Server**. We have the (poorly named) **Social Login Key** doctype which allows registering other authorization servers.

A client can view these (unless disabled) at the `/.well-known/oauth-protected-resource` endpoint and register against them if required. This endpoint shows the Frappe instance as the first authorization server.

A quirk of our implementation is that we give clients a refresh token even though a refresh token grant is not registered with the Frappe app as an Authorization Server.

---


[docs](https://docs.frappe.io/framework/oauth2) · [readme](https://github.com/frappe/frappe/blob/befca37299a58f00ef852c17f98d876e5b88681a/frappe/integrations/README.md)