### PR TITLE
fix: play_sound api replay media from beginning for same media

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -816,6 +816,9 @@ Object.assign(frappe.utils, {
 
 			var audio = $("#sound-" + name)[0];
 			audio.volume = audio.getAttribute("volume");
+			if (!audio.paused) {
+				audio.currentTime = 0;
+			}
 			audio.play();
 		} catch (e) {
 			console.log("Cannot play sound", name, e);


### PR DESCRIPTION
Fixed the issue where if the `play_sound` API is called while executing itself for the same media file, it does not restart playing the media file from the beginning.