### PR TITLE
fix: reset api_name_set flag after record creation

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -647,6 +647,7 @@ class Document(BaseDocument):
 		"""Calls `frappe.naming.set_new_name` for parent and child docs."""
 
 		if (frappe.flags.api_name_set or self.flags.name_set) and not force:
+			frappe.flags.api_name_set = False
 			return
 
 		autoname = self.meta.autoname or ""


### PR DESCRIPTION
Issue: The api_name_set flag was not reset after API record creation, causing errors in later inserts.

Ref: [#42714](https://support.frappe.io/helpdesk/tickets/42714)

Before:

https://github.com/user-attachments/assets/c6c875c0-ed8f-4915-b3f2-cbf03184b1ef

After:

https://github.com/user-attachments/assets/7626be2a-acb7-4f4b-910a-b9835420ab66

Backport needed: v15

