### PR TITLE
fix: keep setup_complete in sync

### DIFF
--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -54,6 +54,8 @@ class InstalledApplications(Document):
 			)
 
 		self.save()
+		frappe.clear_cache(doctype="System Settings")
+		frappe.db.set_single_value("System Settings", "setup_complete", frappe.is_setup_complete())
 
 	def get_app_wise_setup_details(self):
 		"""Get app wise setup details from the Installed Application doctype"""

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -369,7 +369,9 @@ def _get_default_roles() -> set[str]:
 def disable_future_access():
 	frappe.db.set_default("desktop:home_page", "workspace")
 	# Enable onboarding after install
+	frappe.clear_cache(doctype="System Settings")
 	frappe.db.set_single_value("System Settings", "enable_onboarding", 1)
+	frappe.db.set_single_value("System Settings", "setup_complete", frappe.is_setup_complete())
 
 
 @frappe.whitelist()


### PR DESCRIPTION
For backward compatibility of whatever reads System Settings.

related: https://github.com/frappe/frappe/pull/32640 