### PR TITLE
feat(api/v2): allow setting  name while creating document

### DIFF
--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -39,8 +39,6 @@ def handle_rpc_call(method: str):
 def create_doc(doctype: str):
 	data = get_request_form_data()
 	data.pop("doctype", None)
-	if (name := data.get("name")) and isinstance(name, str):
-		frappe.flags.api_name_set = True
 	return frappe.new_doc(doctype, **data).insert()
 
 

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -171,8 +171,6 @@ def count(doctype: str) -> int:
 def create_doc(doctype: str):
 	data = frappe.form_dict
 	data.pop("doctype", None)
-	if (name := data.get("name")) and isinstance(name, str):
-		frappe.flags.api_name_set = True
 	return frappe.new_doc(doctype, **data).insert().as_dict()
 
 

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -171,7 +171,13 @@ def count(doctype: str) -> int:
 def create_doc(doctype: str):
 	data = frappe.form_dict
 	data.pop("doctype", None)
-	return frappe.new_doc(doctype, **data).insert().as_dict()
+
+	doc = frappe.new_doc(doctype, **data)
+
+	if (name := data.get("name")) and isinstance(name, str | int):
+		doc.flags.name_set = True
+
+	return doc.insert().as_dict()
 
 
 def copy_doc(doctype: str, name: str, ignore_no_copy: bool = True):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -646,7 +646,7 @@ class Document(BaseDocument):
 	def set_new_name(self, force=False, set_name=None, set_child_names=True):
 		"""Calls `frappe.naming.set_new_name` for parent and child docs."""
 
-		if (frappe.flags.api_name_set or self.flags.name_set) and not force:
+		if self.flags.name_set and not force:
 			return
 
 		autoname = self.meta.autoname or ""


### PR DESCRIPTION
- Revert "Merge pull request #32327 from akhilnarang/allow-passing-name-in-api"
- feat(api/v2): set name if passed when creating document

Followup to #32327
