### PR TITLE
feat: execute tasks when a workflow action/transition is applied

### DIFF
--- a/frappe/core/doctype/server_script/server_script.js
+++ b/frappe/core/doctype/server_script/server_script.js
@@ -129,6 +129,21 @@ select name from \`tabPerson\`
 where tenant_id = 2
 order by creation desc
 </code></pre>
+
+<hr>
+
+<h4>Workflow Task</h4>
+<p>Execute when a particular <a href="/app/workflow-action-master">Workflow Action Master</a> is executed.</p>
+<p>Gets the document which the action is being applied on in the <code>doc</code> variable.</p>
+<code><pre>
+# create a customer with the same name as the given document
+
+customer = frappe.new_doc("Customer")
+customer.customer_name = doc.first_name + " " + doc.last_name # we get this from the workflow action
+customer.customer_type = "Company"
+
+c.save()
+</code></pre>
 `);
 	},
 });

--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -32,7 +32,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Script Type",
-   "options": "DocType Event\nScheduler Event\nPermission Query\nAPI",
+   "options": "DocType Event\nScheduler Event\nPermission Query\nAPI\nWorkflow Task",
    "reqd": 1
   },
   {
@@ -151,7 +151,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2024-05-08 03:21:54.169380",
+ "modified": "2025-07-03 16:12:29.676150",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",
@@ -171,6 +171,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -80,7 +80,9 @@ class ServerScript(Document):
 		rate_limit_seconds: DF.Int
 		reference_doctype: DF.Link | None
 		script: DF.Code
-		script_type: DF.Literal["DocType Event", "Scheduler Event", "Permission Query", "API"]
+		script_type: DF.Literal[
+			"DocType Event", "Scheduler Event", "Permission Query", "API", "Workflow Task"
+		]
 	# end: auto-generated types
 
 	def validate(self):

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -204,6 +204,19 @@ class ServerScript(Document):
 
 		safe_exec(self.script, script_filename=self.name)
 
+	def execute_workflow_task(self, doc: Document):
+		"""
+		Specific to Workflow Tasks via Workflow Action Master
+		"""
+		if self.script_type != "Workflow Task":
+			raise frappe.DoesNotExistError
+
+		safe_exec(
+			self.script,
+			_locals={"doc": doc},
+			script_filename=self.name,
+		)
+
 	def get_permission_query_conditions(self, user: str) -> list[str]:
 		"""Specific to Permission Query Server Scripts.
 

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -126,6 +126,14 @@ def apply_workflow(doc, action):
 	if next_state.update_field:
 		doc.set(next_state.update_field, next_state.update_value)
 
+	sync_tasks, async_tasks = get_workflow_tasks(action)
+
+	# execute order-sensitive tasks. Also ensures if the previous fails the next doesn't continue
+	frappe.enqueue(execute_sync_tasks, tasks=sync_tasks, doc=doc, enqueue_after_commit=True)
+
+	# tasks that can be executed freely
+	execute_async_tasks(async_tasks, doc)
+
 	new_docstatus = DocStatus(next_state.doc_status or 0)
 	if doc.docstatus.is_draft() and new_docstatus.is_draft():
 		doc.save()
@@ -375,3 +383,44 @@ def set_workflow_state_on_action(doc, workflow_name, action):
 		if state.doc_status == docstatus:
 			doc.set(workflow_state_field, state.state)
 			return
+
+
+def get_workflow_tasks(action):
+	workflow_action_master_task_doc = frappe.qb.DocType("Workflow Action Master Task")
+	query = (
+		frappe.qb.from_(workflow_action_master_task_doc)
+		.where(workflow_action_master_task_doc.parent == action)
+		.where(workflow_action_master_task_doc.enabled)
+		.select(
+			workflow_action_master_task_doc.server_script,
+			workflow_action_master_task_doc.execute_asynchronously,
+		)
+		.orderby(workflow_action_master_task_doc.idx)
+	)
+	tasks = query.run(as_dict=True)
+	sync_tasks = []
+	async_tasks = []
+
+	for task in tasks:
+		if task.execute_asynchronously:
+			async_tasks.append(task.server_script)
+		else:
+			sync_tasks.append(task.server_script)
+
+	return sync_tasks, async_tasks
+
+
+def execute_sync_tasks(tasks, doc):
+	for task in tasks:
+		doc.load_from_db()
+		execute_task(task, doc)
+
+
+def execute_async_tasks(tasks, doc):
+	for task in tasks:
+		frappe.enqueue(execute_task, task=task, doc=doc, enqueue_after_commit=True)
+
+
+def execute_task(task, doc):
+	server_script = frappe.get_doc("Server Script", task)
+	server_script.execute_workflow_task(doc)

--- a/frappe/workflow/doctype/workflow_action_master/test_workflow_action_master.py
+++ b/frappe/workflow/doctype/workflow_action_master/test_workflow_action_master.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestWorkflowActionMaster(IntegrationTestCase):
+	"""
+	Integration tests for WorkflowActionMaster.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/frappe/workflow/doctype/workflow_action_master/workflow_action_master.json
+++ b/frappe/workflow/doctype/workflow_action_master/workflow_action_master.json
@@ -23,14 +23,13 @@
    "fieldname": "workflow_action_master_tasks",
    "fieldtype": "Table",
    "label": "Workflow Action Master Tasks",
-   "options": "Workflow Action Master Task",
-   "reqd": 1
+   "options": "Workflow Action Master Task"
   }
  ],
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2025-07-03 15:53:37.001170",
+ "modified": "2025-07-03 19:08:20.050242",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Action Master",

--- a/frappe/workflow/doctype/workflow_action_master/workflow_action_master.json
+++ b/frappe/workflow/doctype/workflow_action_master/workflow_action_master.json
@@ -7,7 +7,8 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "workflow_action_name"
+  "workflow_action_name",
+  "workflow_action_master_tasks"
  ],
  "fields": [
   {
@@ -17,12 +18,19 @@
    "label": "Workflow Action Name",
    "reqd": 1,
    "unique": 1
+  },
+  {
+   "fieldname": "workflow_action_master_tasks",
+   "fieldtype": "Table",
+   "label": "Workflow Action Master Tasks",
+   "options": "Workflow Action Master Task",
+   "reqd": 1
   }
  ],
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2024-03-23 16:04:05.108415",
+ "modified": "2025-07-03 15:53:37.001170",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Action Master",
@@ -40,6 +48,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/workflow/doctype/workflow_action_master/workflow_action_master.py
+++ b/frappe/workflow/doctype/workflow_action_master/workflow_action_master.py
@@ -12,7 +12,11 @@ class WorkflowActionMaster(Document):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
+		from frappe.workflow.doctype.workflow_action_master_task.workflow_action_master_task import (
+			WorkflowActionMasterTask,
+		)
 
+		workflow_action_master_tasks: DF.Table[WorkflowActionMasterTask]
 		workflow_action_name: DF.Data
 	# end: auto-generated types
 

--- a/frappe/workflow/doctype/workflow_action_master_task/workflow_action_master_task.json
+++ b/frappe/workflow/doctype/workflow_action_master_task/workflow_action_master_task.json
@@ -1,0 +1,51 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-07-03 15:48:52.902509",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "server_script",
+  "enabled",
+  "execute_asynchronously"
+ ],
+ "fields": [
+  {
+   "fieldname": "server_script",
+   "fieldtype": "Link",
+   "in_preview": 1,
+   "label": "Server Script",
+   "options": "Server Script"
+  },
+  {
+   "default": "0",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "in_preview": 1,
+   "label": "Enabled"
+  },
+  {
+   "default": "0",
+   "description": "Spawns a separate job to execute instead of being sequentially executed with other jobs",
+   "fieldname": "execute_asynchronously",
+   "fieldtype": "Check",
+   "in_preview": 1,
+   "label": "Execute Asynchronously"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-07-03 17:47:34.907596",
+ "modified_by": "Administrator",
+ "module": "Workflow",
+ "name": "Workflow Action Master Task",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/workflow/doctype/workflow_action_master_task/workflow_action_master_task.py
+++ b/frappe/workflow/doctype/workflow_action_master_task/workflow_action_master_task.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class WorkflowActionMasterTask(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		enabled: DF.Check
+		execute_asynchronously: DF.Check
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		server_script: DF.Link | None
+	# end: auto-generated types
+
+	pass


### PR DESCRIPTION
- Adds the ability to execute server scripts when a workflow action is applied to a doctype.
- There are two types of tasks:
  1. **Synchronous**: The default; executed in the order they are present in the Workflow Actions Master in the same bakground job.
  2. **Asynchronous**: Executed as soon as the state is applied and in separate background jobs of their own.

The document to which the action is being applied is provided to the server script in the form of the variable `doc`

The sample below creates an entry in Customer whenever a Loan Application's workflow state is changed to 'Initiated' and the Customer's name is the same as that of the Loan Application using `doc`:


https://github.com/user-attachments/assets/2c64eb45-6d60-42e1-b393-0231bb1c6fed



