### PR TITLE
fix: frappe.local has not _realtime_log

### DIFF
--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -84,6 +84,8 @@ def publish_realtime(
 
 
 def flush_realtime_log():
+	if not hasattr(frappe.local, "_realtime_log"):
+		return
 	for args in frappe.local._realtime_log:
 		frappe.realtime.emit_via_redis(*args)
 


### PR DESCRIPTION
Avoid error if `_realtime_log` was not initialized
backport to `version-15` 
