### PR TITLE
fix: allow child-to-parent grouping in report view

### DIFF
--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -246,9 +246,12 @@ frappe.ui.GroupBy = class {
 		if (
 			this.group_by_doctype &&
 			this.aggregate_on_doctype &&
+			this.aggregate_on_doctype != this.doctype &&
 			this.group_by_doctype != this.aggregate_on_doctype
 		) {
-			frappe.msgprint(__("Parent-to-child or child-to-parent grouping is not allowed."));
+			frappe.msgprint(
+				__("Parent-to-child or child-to-different-child grouping is not allowed.")
+			);
 			return false;
 		}
 


### PR DESCRIPTION
Issue: Allow grouping for child  to parent  doc in report view.

Ref: [#41530](https://support.frappe.io/helpdesk/tickets/41530)

Before:

https://github.com/user-attachments/assets/5b407394-621d-4363-be6a-6504f237daee

After:

https://github.com/user-attachments/assets/52ca41c9-09b9-44dd-bac5-8bac45742247

Backport needed: v15
