### PR TITLE
feat: pdf option in auto email report

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.json
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.json
@@ -182,7 +182,7 @@
    "fieldname": "format",
    "fieldtype": "Select",
    "label": "Format",
-   "options": "HTML\nXLSX\nCSV",
+   "options": "HTML\nXLSX\nCSV\nPDF",
    "reqd": 1
   },
   {
@@ -220,7 +220,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-23 16:01:28.131581",
+ "modified": "2025-07-04 17:33:36.750217",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Auto Email Report",
@@ -251,6 +251,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -9,6 +9,7 @@ from email.utils import formataddr
 import frappe
 from frappe import _
 from frappe.desk.query_report import build_xlsx_data
+from frappe.email.email_body import get_formatted_html
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 from frappe.utils import (
@@ -29,6 +30,7 @@ from frappe.utils import (
 	validate_email_address,
 )
 from frappe.utils.csvutils import to_csv
+from frappe.utils.pdf import get_pdf
 from frappe.utils.xlsxutils import make_xlsx
 
 
@@ -51,7 +53,7 @@ class AutoEmailReport(Document):
 		enabled: DF.Check
 		filter_meta: DF.Text | None
 		filters: DF.Text | None
-		format: DF.Literal["HTML", "XLSX", "CSV"]
+		format: DF.Literal["HTML", "XLSX", "CSV", "PDF"]
 		frequency: DF.Literal["Daily", "Weekdays", "Weekly", "Monthly"]
 		from_date_field: DF.Literal[None]
 		no_of_rows: DF.Int
@@ -109,7 +111,7 @@ class AutoEmailReport(Document):
 
 	def validate_report_format(self):
 		"""check if user has select correct report format"""
-		valid_report_formats = ["HTML", "XLSX", "CSV"]
+		valid_report_formats = ["HTML", "XLSX", "CSV", "PDF"]
 		if self.format not in valid_report_formats:
 			frappe.throw(
 				_("{0} is not a valid report format. Report format should one of the following {1}").format(
@@ -183,6 +185,16 @@ class AutoEmailReport(Document):
 
 			xlsx_data, column_widths = build_xlsx_data(report_data, [], 1, ignore_visible_idx=True)
 			return to_csv(xlsx_data)
+
+		elif self.format == "PDF":
+			columns, data = make_links(columns, data)
+			columns = update_field_types(columns)
+			options = {}
+
+			if len(columns) > 8:
+				options["orientation"] = "landscape"
+			html = get_formatted_html(subject=self.name, message=self.get_html_table(columns, data))
+			return get_pdf(html, options)
 
 		else:
 			frappe.throw(_("Invalid Output Format"))

--- a/frappe/email/doctype/auto_email_report/test_auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/test_auto_email_report.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import json
+from io import BytesIO
+
+from pypdf import PdfReader
 
 import frappe
 from frappe.tests import IntegrationTestCase
@@ -27,6 +30,11 @@ class TestAutoEmailReport(IntegrationTestCase):
 		auto_email_report.format = "XLSX"
 
 		data = auto_email_report.get_report_content()
+
+		auto_email_report.format = "PDF"
+
+		data = auto_email_report.get_report_content()
+		PdfReader(stream=BytesIO(data))
 
 	def test_dynamic_date_filters(self):
 		auto_email_report = get_auto_email_report()


### PR DESCRIPTION
Added an option to send Reports in PDF Format on the Auto Email Report.

Screenshot:
	![image](https://github.com/user-attachments/assets/93c0ffe1-f05b-4fc6-a835-e15c0c04216a)	
	
PDF:
	![image](https://github.com/user-attachments/assets/625f214b-5027-4192-8818-8dd7456d273c)


#no-docs