### PR TITLE
feat: App-Defined Workflow Tasks and Server Scripts on Transition

### DIFF
--- a/frappe/core/doctype/server_script/server_script.js
+++ b/frappe/core/doctype/server_script/server_script.js
@@ -129,6 +129,21 @@ select name from \`tabPerson\`
 where tenant_id = 2
 order by creation desc
 </code></pre>
+
+<hr>
+
+<h4>Workflow Task</h4>
+<p>Execute when a particular <a href="/app/workflow-action-master">Workflow Action Master</a> is executed.</p>
+<p>Gets the document which the action is being applied on in the <code>doc</code> variable.</p>
+<code><pre>
+# create a customer with the same name as the given document
+
+customer = frappe.new_doc("Customer")
+customer.customer_name = doc.first_name + " " + doc.last_name # we get this from the workflow action
+customer.customer_type = "Company"
+
+c.save()
+</code></pre>
 `);
 	},
 });

--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -32,7 +32,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Script Type",
-   "options": "DocType Event\nScheduler Event\nPermission Query\nAPI",
+   "options": "DocType Event\nScheduler Event\nPermission Query\nAPI\nWorkflow Task",
    "reqd": 1
   },
   {
@@ -151,7 +151,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2024-05-08 03:21:54.169380",
+ "modified": "2025-07-03 16:12:29.676150",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",
@@ -171,6 +171,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -80,7 +80,9 @@ class ServerScript(Document):
 		rate_limit_seconds: DF.Int
 		reference_doctype: DF.Link | None
 		script: DF.Code
-		script_type: DF.Literal["DocType Event", "Scheduler Event", "Permission Query", "API"]
+		script_type: DF.Literal[
+			"DocType Event", "Scheduler Event", "Permission Query", "API", "Workflow Task"
+		]
 	# end: auto-generated types
 
 	def validate(self):

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -218,6 +218,19 @@ class ServerScript(Document):
 		if locals["conditions"]:
 			return locals["conditions"]
 
+	def execute_workflow_task(self, doc: Document):
+		"""
+		Specific to Workflow Tasks via Workflow Action Master
+		"""
+		if self.script_type != "Workflow Task":
+			raise frappe.DoesNotExistError
+
+		safe_exec(
+			self.script,
+			_locals={"doc": doc},
+			script_filename=self.name,
+		)
+
 
 @frappe.whitelist()
 @http_cache(max_age=10 * 60, stale_while_revalidate=6 * 60 * 60)

--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -67,7 +67,7 @@ def run_webhooks(doc, method):
 		elif frappe.safe_eval(webhook.condition, eval_locals=get_context(doc)):
 			trigger_webhook = True
 
-		if trigger_webhook and event and frappe.scrub(webhook.webhook_docevent) == event:
+		if trigger_webhook and event and webhook.webhook_docevent == event:
 			_add_webhook_to_queue(webhook, doc)
 
 

--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -67,7 +67,7 @@ def run_webhooks(doc, method):
 		elif frappe.safe_eval(webhook.condition, eval_locals=get_context(doc)):
 			trigger_webhook = True
 
-		if trigger_webhook and event and webhook.webhook_docevent == event:
+		if trigger_webhook and event and frappe.scrub(webhook.webhook_docevent) == event:
 			_add_webhook_to_queue(webhook, doc)
 
 

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -47,7 +47,7 @@ class TestWebhook(IntegrationTestCase):
 			{
 				"name": frappe.generate_hash(),
 				"webhook_doctype": "User",
-				"webhook_docevent": "after_insert",
+				"webhook_docevent": "After Insert",
 				"request_url": "https://httpbin.org/post",
 				"condition": "doc.email",
 				"enabled": True,
@@ -55,7 +55,7 @@ class TestWebhook(IntegrationTestCase):
 			{
 				"name": frappe.generate_hash(),
 				"webhook_doctype": "User",
-				"webhook_docevent": "after_insert",
+				"webhook_docevent": "After Insert",
 				"request_url": "https://httpbin.org/post",
 				"condition": "doc.first_name",
 				"enabled": False,
@@ -91,7 +91,7 @@ class TestWebhook(IntegrationTestCase):
 
 		webhook_fields = {
 			"webhook_doctype": "User",
-			"webhook_docevent": "after_insert",
+			"webhook_docevent": "After Insert",
 			"request_url": "https://httpbin.org/post",
 		}
 
@@ -144,7 +144,7 @@ class TestWebhook(IntegrationTestCase):
 	def test_validate_doc_events(self):
 		"Test creating a submit-related webhook for a non-submittable DocType"
 
-		self.webhook.webhook_docevent = "on_submit"
+		self.webhook.webhook_docevent = "On Submit"
 		self.assertRaises(frappe.ValidationError, self.webhook.save)
 
 	@timeout(5, "Test webhooks should never wait, check mocked responses.")
@@ -227,7 +227,7 @@ class TestWebhook(IntegrationTestCase):
 		wh_config = {
 			"doctype": "Webhook",
 			"webhook_doctype": "Note",
-			"webhook_docevent": "on_change",
+			"webhook_docevent": "On Change",
 			"enabled": 1,
 			"request_url": "https://httpbin.org/post",
 			"request_method": "POST",
@@ -272,7 +272,7 @@ class TestWebhook(IntegrationTestCase):
 		wh_config = {
 			"doctype": "Webhook",
 			"webhook_doctype": "Note",
-			"webhook_docevent": "after_insert",
+			"webhook_docevent": "After Insert",
 			"enabled": 1,
 			"request_url": "https://httpbin.org/anything/{{ doc.doctype }}",
 			"is_dynamic_url": 1,
@@ -304,7 +304,7 @@ class TestWebhook(IntegrationTestCase):
 		wh_config = {
 			"doctype": "Webhook",
 			"webhook_doctype": "Note",
-			"webhook_docevent": "after_insert",
+			"webhook_docevent": "After Insert",
 			"enabled": 1,
 			"request_url": "https://httpbin.org/anything/{{doc.doctype}}",
 			"is_dynamic_url": 0,

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -47,7 +47,7 @@ class TestWebhook(IntegrationTestCase):
 			{
 				"name": frappe.generate_hash(),
 				"webhook_doctype": "User",
-				"webhook_docevent": "After Insert",
+				"webhook_docevent": "after_insert",
 				"request_url": "https://httpbin.org/post",
 				"condition": "doc.email",
 				"enabled": True,
@@ -55,7 +55,7 @@ class TestWebhook(IntegrationTestCase):
 			{
 				"name": frappe.generate_hash(),
 				"webhook_doctype": "User",
-				"webhook_docevent": "After Insert",
+				"webhook_docevent": "after_insert",
 				"request_url": "https://httpbin.org/post",
 				"condition": "doc.first_name",
 				"enabled": False,
@@ -91,7 +91,7 @@ class TestWebhook(IntegrationTestCase):
 
 		webhook_fields = {
 			"webhook_doctype": "User",
-			"webhook_docevent": "After Insert",
+			"webhook_docevent": "after_insert",
 			"request_url": "https://httpbin.org/post",
 		}
 
@@ -144,7 +144,7 @@ class TestWebhook(IntegrationTestCase):
 	def test_validate_doc_events(self):
 		"Test creating a submit-related webhook for a non-submittable DocType"
 
-		self.webhook.webhook_docevent = "On Submit"
+		self.webhook.webhook_docevent = "on_submit"
 		self.assertRaises(frappe.ValidationError, self.webhook.save)
 
 	@timeout(5, "Test webhooks should never wait, check mocked responses.")
@@ -227,7 +227,7 @@ class TestWebhook(IntegrationTestCase):
 		wh_config = {
 			"doctype": "Webhook",
 			"webhook_doctype": "Note",
-			"webhook_docevent": "On Change",
+			"webhook_docevent": "on_change",
 			"enabled": 1,
 			"request_url": "https://httpbin.org/post",
 			"request_method": "POST",
@@ -272,7 +272,7 @@ class TestWebhook(IntegrationTestCase):
 		wh_config = {
 			"doctype": "Webhook",
 			"webhook_doctype": "Note",
-			"webhook_docevent": "After Insert",
+			"webhook_docevent": "after_insert",
 			"enabled": 1,
 			"request_url": "https://httpbin.org/anything/{{ doc.doctype }}",
 			"is_dynamic_url": 1,
@@ -304,7 +304,7 @@ class TestWebhook(IntegrationTestCase):
 		wh_config = {
 			"doctype": "Webhook",
 			"webhook_doctype": "Note",
-			"webhook_docevent": "After Insert",
+			"webhook_docevent": "after_insert",
 			"enabled": 1,
 			"request_url": "https://httpbin.org/anything/{{doc.doctype}}",
 			"is_dynamic_url": 0,

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -56,7 +56,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Doc Event",
-   "options": "After Insert\nOn Update\nOn Submit\nOn Cancel\nOn Trash\nOn Update After Commit\nOn Change\nWorkflow Transition",
+   "options": "after_insert\non_update\non_submit\non_cancel\non_trash\non_update_after_submit\non_change\nworkflow_transition",
    "set_only_once": 1
   },
   {
@@ -189,7 +189,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2025-07-09 17:22:38.276809",
+ "modified": "2025-07-18 18:22:38.276809",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",
@@ -209,7 +209,6 @@
    "write": 1
   }
  ],
- "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -56,7 +56,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Doc Event",
-   "options": "after_insert\non_update\non_submit\non_cancel\non_trash\non_update_after_submit\non_change",
+   "options": "After Insert\nOn Update\nOn Submit\nOn Cancel\nOn Trash\nOn Update After Commit\nOn Change",
    "set_only_once": 1
   },
   {
@@ -189,7 +189,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2024-10-28 12:21:52.172428",
+ "modified": "2025-07-09 16:01:59.142710",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",
@@ -209,6 +209,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -56,7 +56,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Doc Event",
-   "options": "After Insert\nOn Update\nOn Submit\nOn Cancel\nOn Trash\nOn Update After Commit\nOn Change",
+   "options": "After Insert\nOn Update\nOn Submit\nOn Cancel\nOn Trash\nOn Update After Commit\nOn Change\nWorkflow Transition",
    "set_only_once": 1
   },
   {
@@ -189,7 +189,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2025-07-09 16:01:59.142710",
+ "modified": "2025-07-09 17:22:38.276809",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -186,7 +186,7 @@ def enqueue_webhook(doc, webhook) -> None:
 			if i != 2:
 				continue
 			else:
-				if webhook.webhook_docevent == "Workflow Transition":
+				if webhook.webhook_docevent == "workflow_transition":
 					raise e
 
 

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -42,13 +42,13 @@ class Webhook(Document):
 		timeout: DF.Int
 		webhook_data: DF.Table[WebhookData]
 		webhook_docevent: DF.Literal[
-			"after_insert",
-			"on_update",
-			"on_submit",
-			"on_cancel",
-			"on_trash",
-			"on_update_after_submit",
-			"on_change",
+			"After Insert",
+			"On Update",
+			"On Submit",
+			"On Cancel",
+			"On Trash",
+			"On Update After Commit",
+			"On Change",
 		]
 		webhook_doctype: DF.Link
 		webhook_headers: DF.Table[WebhookHeader]
@@ -72,9 +72,9 @@ class Webhook(Document):
 		if self.webhook_doctype:
 			is_submittable = frappe.get_value("DocType", self.webhook_doctype, "is_submittable")
 			if not is_submittable and self.webhook_docevent in [
-				"on_submit",
-				"on_cancel",
-				"on_update_after_submit",
+				"On Submit",
+				"On Cancel",
+				"On Update After Submit",
 			]:
 				frappe.throw(_("DocType must be Submittable for the selected Doc Event"))
 

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -69,7 +69,7 @@ class Webhook(Document):
 	def on_update(self):
 		frappe.client_cache.delete_value("webhooks")
 
-	def execute_for_doc(self, doc):
+	def execute_for_doc(self, doc: Document):
 		enqueue_webhook(doc, self)
 
 	def validate_docevent(self):

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -42,14 +42,14 @@ class Webhook(Document):
 		timeout: DF.Int
 		webhook_data: DF.Table[WebhookData]
 		webhook_docevent: DF.Literal[
-			"After Insert",
-			"On Update",
-			"On Submit",
-			"On Cancel",
-			"On Trash",
-			"On Update After Commit",
-			"On Change",
-			"Workflow Transition",
+			"after_insert",
+			"on_update",
+			"on_submit",
+			"on_cancel",
+			"on_trash",
+			"on_update_after_submit",
+			"on_change",
+			"workflow_transition",
 		]
 		webhook_doctype: DF.Link
 		webhook_headers: DF.Table[WebhookHeader]
@@ -76,9 +76,9 @@ class Webhook(Document):
 		if self.webhook_doctype:
 			is_submittable = frappe.get_value("DocType", self.webhook_doctype, "is_submittable")
 			if not is_submittable and self.webhook_docevent in [
-				"On Submit",
-				"On Cancel",
-				"On Update After Submit",
+				"on_submit",
+				"on_cancel",
+				"on_update_after_submit",
 			]:
 				frappe.throw(_("DocType must be Submittable for the selected Doc Event"))
 

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -49,6 +49,7 @@ class Webhook(Document):
 			"On Trash",
 			"On Update After Commit",
 			"On Change",
+			"Workflow Transition",
 		]
 		webhook_doctype: DF.Link
 		webhook_headers: DF.Table[WebhookHeader]
@@ -67,6 +68,9 @@ class Webhook(Document):
 
 	def on_update(self):
 		frappe.client_cache.delete_value("webhooks")
+
+	def execute_for_doc(self, doc):
+		enqueue_webhook(doc, self)
 
 	def validate_docevent(self):
 		if self.webhook_doctype:
@@ -144,7 +148,8 @@ def get_context(doc):
 def enqueue_webhook(doc, webhook) -> None:
 	request_url = headers = data = r = None
 	try:
-		webhook: Webhook = frappe.get_doc("Webhook", webhook.get("name"))
+		if not isinstance(webhook, Document):
+			webhook: Webhook = frappe.get_doc("Webhook", webhook.get("name"))
 		request_url = webhook.request_url
 		if webhook.is_dynamic_url:
 			request_url = frappe.render_template(webhook.request_url, get_context(doc))
@@ -180,6 +185,9 @@ def enqueue_webhook(doc, webhook) -> None:
 			sleep(3 * i + 1)
 			if i != 2:
 				continue
+			else:
+				if webhook.webhook_docevent == "Workflow Transition":
+					raise e
 
 
 def log_request(

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -147,10 +147,7 @@ def apply_workflow(doc, action):
 					 		"frappe.dotted.path.create_customer"}]
 		"""
 
-		if frappe.in_test:
-			tasks = {"Create Note": "frappe.workflow.doctype.workflow.test_workflow.create_new_note"}
-		else:
-			tasks = {i["name"]: i["method"] for i in frappe.get_hooks("workflow_methods")}
+		tasks = {i["name"]: i["method"] for i in frappe.get_hooks("workflow_methods")}
 
 		sync_tasks = []
 		async_tasks = []

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -131,9 +131,11 @@ def apply_workflow(doc, action):
 
 	if transition.transition_tasks:
 		workflow_transitions = frappe.db.get_all(
-			"Workflow Transition Task", {"parent": transition.transition_tasks, "enabled": True}, ["*"]
+			"Workflow Transition Task",
+			{"parent": transition.transition_tasks, "enabled": True},
+			["task", "link", "asynchronous"],
+			order_by="idx",
 		)
-		workflow_transitions.sort(key=lambda i: i["idx"])
 
 		"""app-specific actions defined by the user
 		Example:

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -170,7 +170,7 @@ def apply_workflow(doc, action):
 				except KeyError:
 					frappe.throw(_('There is no task called "{}"').format(workflow_transition.task))
 
-			if workflow_transition.execute_asynchronously:
+			if workflow_transition.asynchronous:
 				async_tasks.append(task_method)
 			else:
 				sync_tasks.append(task_method)

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -126,6 +126,40 @@ def apply_workflow(doc, action):
 	if next_state.update_field:
 		doc.set(next_state.update_field, next_state.update_value)
 
+	if transition.transition_tasks:
+		workflow_transitions = frappe.db.get_all(
+			"Workflow Transition Task", {"parent": transition.transition_tasks, "enabled": True}, ["*"]
+		)
+		workflow_transitions.sort(key=lambda i: i["idx"])
+
+		"""app-specific actions defined by the user
+		Example:
+		def create_customer(doc):
+			<your-code>
+
+		this goes in the hooks.py
+		workflow_methods = [{"name": "Create a customer", "method":
+					 		"frappe.dotted.path.create_customer"}]
+		"""
+
+		tasks = {i["name"]: i["method"] for i in frappe.get_hooks("workflow_methods")}
+
+		sync_tasks = []
+		async_tasks = []
+		for workflow_transition in workflow_transitions:
+			task_method = frappe.get_attr(tasks[workflow_transition.task])
+
+			if workflow_transition.execute_asynchronously:
+				async_tasks.append(task_method)
+			else:
+				sync_tasks.append(task_method)
+
+		for sync_task in sync_tasks:
+			sync_task(doc)
+
+		for async_task in async_tasks:
+			frappe.enqueue(async_task, doc=doc, enqueue_after_commit=True)
+
 	new_docstatus = DocStatus(next_state.doc_status or 0)
 	if doc.docstatus.is_draft() and new_docstatus.is_draft():
 		doc.save()

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
 	from frappe.workflow.doctype.workflow.workflow import Workflow
 
 
+DEFAULT_WORKFLOW_TASKS = ["Webhook", "Server Script"]
+
+
 class WorkflowStateError(frappe.ValidationError):
 	pass
 
@@ -148,9 +151,16 @@ def apply_workflow(doc, action):
 		async_tasks = []
 		for workflow_transition in workflow_transitions:
 			# edge-case with user-defined server scripts
-			if workflow_transition.task == "Server Script":
-				server_script = frappe.get_doc("Server Script", workflow_transition.server_script)
-				task_method = server_script.execute_workflow_task
+			if workflow_transition.task in DEFAULT_WORKFLOW_TASKS:
+				match workflow_transition.task:
+					case "Webhook":
+						webhook = frappe.get_doc("Webhook", workflow_transition.link)
+						task_method = webhook.execute_for_doc
+
+					case "Server Script":
+						server_script = frappe.get_doc("Server Script", workflow_transition.link)
+						task_method = server_script.execute_workflow_task
+
 			else:  # normal app-defined tasks
 				try:
 					task_method = frappe.get_attr(tasks[workflow_transition.task])

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -145,7 +145,10 @@ def apply_workflow(doc, action):
 					 		"frappe.dotted.path.create_customer"}]
 		"""
 
-		tasks = {i["name"]: i["method"] for i in frappe.get_hooks("workflow_methods")}
+		if frappe.in_test:
+			tasks = {"Create Note": "frappe.workflow.doctype.workflow.test_workflow.create_new_note"}
+		else:
+			tasks = {i["name"]: i["method"] for i in frappe.get_hooks("workflow_methods")}
 
 		sync_tasks = []
 		async_tasks = []

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -162,9 +162,11 @@ def apply_workflow(doc, action):
 			else:
 				sync_tasks.append(task_method)
 
+		# will execute in the same transaction as the rest of the transition
 		for sync_task in sync_tasks:
 			sync_task(doc)
 
+		# will spawn separate background jobs. Use for asynchronous, optional tasks.
 		for async_task in async_tasks:
 			frappe.enqueue(async_task, doc=doc, enqueue_after_commit=True)
 

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -147,7 +147,10 @@ def apply_workflow(doc, action):
 		sync_tasks = []
 		async_tasks = []
 		for workflow_transition in workflow_transitions:
-			task_method = frappe.get_attr(tasks[workflow_transition.task])
+			try:
+				task_method = frappe.get_attr(tasks[workflow_transition.task])
+			except KeyError:
+				frappe.throw(_('There is no task called "{}"').format(workflow_transition.task))
 
 			if workflow_transition.execute_asynchronously:
 				async_tasks.append(task_method)

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -147,10 +147,15 @@ def apply_workflow(doc, action):
 		sync_tasks = []
 		async_tasks = []
 		for workflow_transition in workflow_transitions:
-			try:
-				task_method = frappe.get_attr(tasks[workflow_transition.task])
-			except KeyError:
-				frappe.throw(_('There is no task called "{}"').format(workflow_transition.task))
+			# edge-case with user-defined server scripts
+			if workflow_transition.task == "Server Script":
+				server_script = frappe.get_doc("Server Script", workflow_transition.server_script)
+				task_method = server_script.execute_workflow_task
+			else:  # normal app-defined tasks
+				try:
+					task_method = frappe.get_attr(tasks[workflow_transition.task])
+				except KeyError:
+					frappe.throw(_('There is no task called "{}"').format(workflow_transition.task))
 
 			if workflow_transition.execute_asynchronously:
 				async_tasks.append(task_method)

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -247,4 +247,3 @@ frappe.patches.v14_0.fix_user_settings_collation
 execute:frappe.call("frappe.core.doctype.system_settings.system_settings.sync_system_settings")
 frappe.patches.v15_0.migrate_to_utm
 frappe.patches.v16_0.add_module_deprecation_warning
-frappe.patches.v16_0.webhook_docevent_unscrub

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -247,3 +247,4 @@ frappe.patches.v14_0.fix_user_settings_collation
 execute:frappe.call("frappe.core.doctype.system_settings.system_settings.sync_system_settings")
 frappe.patches.v15_0.migrate_to_utm
 frappe.patches.v16_0.add_module_deprecation_warning
+frappe.patches.v16_0.webhook_docevent_unscrub

--- a/frappe/patches/v16_0/webhook_docevent_unscrub.py
+++ b/frappe/patches/v16_0/webhook_docevent_unscrub.py
@@ -1,0 +1,9 @@
+import frappe
+
+
+def execute():
+	webhooks = frappe.get_all("Webhook", ["name", "webhook_docevent"])
+	for webhook in webhooks:
+		frappe.db.set_value(
+			"Webhook", webhook.name, "webhook_docevent", frappe.unscrub(webhook.webhook_docevent)
+		)

--- a/frappe/patches/v16_0/webhook_docevent_unscrub.py
+++ b/frappe/patches/v16_0/webhook_docevent_unscrub.py
@@ -1,9 +1,0 @@
-import frappe
-
-
-def execute():
-	webhooks = frappe.get_all("Webhook", ["name", "webhook_docevent"])
-	for webhook in webhooks:
-		frappe.db.set_value(
-			"Webhook", webhook.name, "webhook_docevent", frappe.unscrub(webhook.webhook_docevent)
-		)

--- a/frappe/public/js/workflow_builder/components/Properties.vue
+++ b/frappe/public/js/workflow_builder/components/Properties.vue
@@ -18,7 +18,9 @@ let properties = computed(() => {
 	if (store.workflow.selected && "action" in store.workflow.selected.data) {
 		title.value = __("Transition Properties");
 		return store.transitionfields.filter((df) =>
-			["action", "allowed", "allow_self_approval", "condition"].includes(df.fieldname)
+			["action", "allowed", "allow_self_approval", "condition", "transition_tasks"].includes(
+				df.fieldname
+			)
 		);
 	} else if (store.workflow.selected && "state" in store.workflow.selected.data) {
 		title.value = __("State Properties");

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -2,6 +2,8 @@
 # License: MIT. See LICENSE
 from unittest.mock import patch
 
+import responses
+
 import frappe
 from frappe.model.workflow import (
 	WorkflowTransitionError,
@@ -30,6 +32,7 @@ class TestWorkflow(IntegrationTestCase):
 	def tearDown(self):
 		frappe.set_user("Administrator")
 		self.patcher.stop()
+
 		frappe.delete_doc("Workflow", "Test ToDo")
 
 	def test_default_condition(self):
@@ -129,7 +132,19 @@ class TestWorkflow(IntegrationTestCase):
 
 	# app-defined workflow task tests start here
 	def test_sync_tasks(self, doc=None):
-		"""test simple workflow"""
+		"""test workflow with workflow tasks (server scripts, webhooks and app-defined methods)"""
+
+		# for webhooks
+		self.responses = responses.RequestsMock()
+		self.responses.start()
+
+		self.responses.add(
+			responses.POST,
+			"https://workflowtasks.org/post",
+			status=200,
+			json={},
+		)
+
 		domain = frappe.new_doc("Domain")
 		domain.domain = random_string(length=10)
 		domain.save()
@@ -151,6 +166,11 @@ class TestWorkflow(IntegrationTestCase):
 			frappe.db.exists("Note", {"title": "workflow - " + domain.name, "content": "workflow test"})
 		)
 		self.assertTrue(frappe.db.exists("Domain", {"name": "workflow - " + domain.name}))
+		self.assertTrue(frappe.db.exists("Webhook Request Log", {"url": "https://workflowtasks.org/post"}))
+
+		# for webhooks
+		self.responses.stop()
+		self.responses.reset()
 
 		return domain
 
@@ -223,11 +243,13 @@ def create_domain_workflow():
 			frappe.get_doc("User", UI_TEST_USER).add_roles(TEST_ROLE)
 
 	server_script = create_new_server_script()
+	webhook = create_new_webhook()
 
 	pending_to_approved_transition = frappe.new_doc("Workflow Transition Tasks")
 	pending_to_approved_transition.name = random_string(length=10)
 	pending_to_approved_transition.append("tasks", {"task": "Create Note"})
 	pending_to_approved_transition.append("tasks", {"task": "Server Script", "link": server_script.name})
+	pending_to_approved_transition.append("tasks", {"task": "Webhook", "link": webhook.name})
 
 	pending_to_approved_transition.save()
 
@@ -299,3 +321,15 @@ domain.save()
 	server_script.save()
 
 	return server_script
+
+
+def create_new_webhook():
+	webhook = frappe.new_doc("Webhook")
+	webhook.__newname = random_string(10)
+	webhook.webhook_docevent = "workflow_transition"
+	webhook.webhook_doctype = "Domain"
+	webhook.request_method = "POST"
+	webhook.request_url = "https://workflowtasks.org/post"
+	webhook.save()
+
+	return webhook

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -222,17 +222,7 @@ def create_domain_workflow():
 		if frappe.db.exists("User", UI_TEST_USER):
 			frappe.get_doc("User", UI_TEST_USER).add_roles(TEST_ROLE)
 
-	server_script = frappe.new_doc("Server Script")
-	server_script.name = random_string(length=10)
-	server_script.script_type = "Workflow Task"
-	server_script.script = """
-# create a domain with the same name as the given document
-domain = frappe.new_doc("Domain")
-domain.domain = "workflow - " + doc.name
-
-domain.save()
-	"""
-	server_script.save()
+	server_script = create_new_server_script()
 
 	pending_to_approved_transition = frappe.new_doc("Workflow Transition Tasks")
 	pending_to_approved_transition.name = random_string(length=10)
@@ -293,3 +283,19 @@ def create_new_note(doc):
 	note.content = "workflow test"
 
 	note.save()
+
+
+def create_new_server_script():
+	server_script = frappe.new_doc("Server Script")
+	server_script.name = random_string(length=10)
+	server_script.script_type = "Workflow Task"
+	server_script.script = """
+# create a domain with the same name as the given document
+domain = frappe.new_doc("Domain")
+domain.domain = "workflow - " + doc.name
+
+domain.save()
+	"""
+	server_script.save()
+
+	return server_script

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -18,6 +18,7 @@ class TestWorkflow(IntegrationTestCase):
 	def setUpClass(cls):
 		super().setUpClass()
 		make_test_records("User")
+		cls.enterClassContext(cls.enable_safe_exec())
 
 	def setUp(self):
 		self.patcher = patch("frappe.attach_print", return_value={})

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -137,7 +137,7 @@ class TestWorkflow(IntegrationTestCase):
 		self.assertTrue(
 			frappe.db.exists("Note", {"title": "workflow - " + todo.name, "content": "workflow test"})
 		)
-		self.assertTrue(frappe.db.exists("Customer", {"customer_name": "workflow - " + todo.name}))
+		self.assertTrue(frappe.db.exists("Domain", {"name": "workflow - " + todo.name}))
 
 		return todo
 
@@ -159,12 +159,11 @@ def create_todo_workflow():
 	server_script.name = random_string(length=10)
 	server_script.script_type = "Workflow Task"
 	server_script.script = """
-# create a customer with the same name as the given document
-customer = frappe.new_doc("Customer")
-customer.customer_name = "workflow - " + doc.name
-customer.customer_type = "Company"
+# create a domain with the same name as the given document
+domain = frappe.new_doc("Domain")
+domain = "workflow - " + doc.name
 
-customer.save()
+domain.save()
 	"""
 	server_script.save()
 

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -161,7 +161,7 @@ def create_todo_workflow():
 	server_script.script = """
 # create a domain with the same name as the given document
 domain = frappe.new_doc("Domain")
-domain = "workflow - " + doc.name
+domain.domain = "workflow - " + doc.name
 
 domain.save()
 	"""

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -25,6 +25,7 @@ class TestWorkflow(IntegrationTestCase):
 		self.patcher.start()
 		frappe.db.delete("Workflow Action")
 		self.workflow = create_todo_workflow()
+		create_domain_workflow()
 
 	def tearDown(self):
 		frappe.set_user("Administrator")
@@ -129,17 +130,29 @@ class TestWorkflow(IntegrationTestCase):
 	# app-defined workflow task tests start here
 	def test_sync_tasks(self, doc=None):
 		"""test simple workflow"""
-		todo = doc or self.test_default_condition()
+		domain = frappe.new_doc("Domain")
+		domain.domain = random_string(length=10)
+		domain.save()
 
-		apply_workflow(todo, "Approve")
+		with self.patch_hooks(
+			{
+				"workflow_methods": [
+					{
+						"name": "Create Note",
+						"method": "frappe.workflow.doctype.workflow.test_workflow.create_new_note",
+					}
+				]
+			}
+		):
+			apply_workflow(domain, "Approve")
 
 		# refer create_new_task()
 		self.assertTrue(
-			frappe.db.exists("Note", {"title": "workflow - " + todo.name, "content": "workflow test"})
+			frappe.db.exists("Note", {"title": "workflow - " + domain.name, "content": "workflow test"})
 		)
-		self.assertTrue(frappe.db.exists("Domain", {"name": "workflow - " + todo.name}))
+		self.assertTrue(frappe.db.exists("Domain", {"name": "workflow - " + domain.name}))
 
-		return todo
+		return domain
 
 
 def create_todo_workflow():
@@ -147,6 +160,60 @@ def create_todo_workflow():
 
 	if frappe.db.exists("Workflow", "Test ToDo"):
 		frappe.delete_doc("Workflow", "Test ToDo")
+
+	TEST_ROLE = "Test Approver"
+
+	if not frappe.db.exists("Role", TEST_ROLE):
+		frappe.get_doc(doctype="Role", role_name=TEST_ROLE).insert(ignore_if_duplicate=True)
+		if frappe.db.exists("User", UI_TEST_USER):
+			frappe.get_doc("User", UI_TEST_USER).add_roles(TEST_ROLE)
+
+	workflow = frappe.new_doc("Workflow")
+	workflow.workflow_name = "Test ToDo"
+	workflow.document_type = "ToDo"
+	workflow.workflow_state_field = "workflow_state"
+	workflow.is_active = 1
+	workflow.send_email_alert = 1
+	workflow.append("states", dict(state="Pending", allow_edit="All"))
+	workflow.append(
+		"states",
+		dict(state="Approved", allow_edit=TEST_ROLE, update_field="status", update_value="Closed"),
+	)
+	workflow.append("states", dict(state="Rejected", allow_edit=TEST_ROLE))
+	workflow.append(
+		"transitions",
+		dict(
+			state="Pending",
+			action="Approve",
+			next_state="Approved",
+			allowed=TEST_ROLE,
+			allow_self_approval=1,
+		),
+	)
+	workflow.append(
+		"transitions",
+		dict(
+			state="Pending",
+			action="Reject",
+			next_state="Rejected",
+			allowed=TEST_ROLE,
+			allow_self_approval=1,
+		),
+	)
+	workflow.append(
+		"transitions",
+		dict(state="Rejected", action="Review", next_state="Pending", allowed="All", allow_self_approval=1),
+	)
+	workflow.insert(ignore_permissions=True)
+
+	return workflow
+
+
+def create_domain_workflow():
+	from frappe.tests.ui_test_helpers import UI_TEST_USER
+
+	if frappe.db.exists("Workflow", "Test Domain"):
+		frappe.delete_doc("Workflow", "Test Domain")
 
 	TEST_ROLE = "Test Approver"
 
@@ -175,8 +242,8 @@ domain.save()
 	pending_to_approved_transition.save()
 
 	workflow = frappe.new_doc("Workflow")
-	workflow.workflow_name = "Test ToDo"
-	workflow.document_type = "ToDo"
+	workflow.workflow_name = "Test Domain"
+	workflow.document_type = "Domain"
 	workflow.workflow_state_field = "workflow_state"
 	workflow.is_active = 1
 	workflow.send_email_alert = 1

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -8,7 +8,6 @@ from frappe.model.workflow import (
 	apply_workflow,
 	get_common_transition_actions,
 )
-from frappe.query_builder import DocType
 from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import make_test_records
 from frappe.utils import random_string
@@ -126,6 +125,21 @@ class TestWorkflow(IntegrationTestCase):
 			"invalid python code" in str(se.exception).lower(), msg="Python code validation not working"
 		)
 
+	# app-defined workflow task tests start here
+	def test_sync_tasks(self, doc=None):
+		"""test simple workflow"""
+		todo = doc or self.test_default_condition()
+
+		apply_workflow(todo, "Approve")
+
+		# refer create_new_task()
+		self.assertTrue(
+			frappe.db.exists("Note", {"title": "workflow - " + todo.name, "content": "workflow test"})
+		)
+		self.assertTrue(frappe.db.exists("Customer", {"customer_name": "workflow - " + todo.name}))
+
+		return todo
+
 
 def create_todo_workflow():
 	from frappe.tests.ui_test_helpers import UI_TEST_USER
@@ -139,6 +153,26 @@ def create_todo_workflow():
 		frappe.get_doc(doctype="Role", role_name=TEST_ROLE).insert(ignore_if_duplicate=True)
 		if frappe.db.exists("User", UI_TEST_USER):
 			frappe.get_doc("User", UI_TEST_USER).add_roles(TEST_ROLE)
+
+	server_script = frappe.new_doc("Server Script")
+	server_script.name = random_string(length=10)
+	server_script.script_type = "Workflow Task"
+	server_script.script = """
+# create a customer with the same name as the given document
+customer = frappe.new_doc("Customer")
+customer.customer_name = "workflow - " + doc.name
+customer.customer_type = "Company"
+
+customer.save()
+	"""
+	server_script.save()
+
+	pending_to_approved_transition = frappe.new_doc("Workflow Transition Tasks")
+	pending_to_approved_transition.name = random_string(length=10)
+	pending_to_approved_transition.append("tasks", {"task": "Create Note"})
+	pending_to_approved_transition.append("tasks", {"task": "Server Script", "link": server_script.name})
+
+	pending_to_approved_transition.save()
 
 	workflow = frappe.new_doc("Workflow")
 	workflow.workflow_name = "Test ToDo"
@@ -160,6 +194,7 @@ def create_todo_workflow():
 			next_state="Approved",
 			allowed=TEST_ROLE,
 			allow_self_approval=1,
+			transition_tasks=pending_to_approved_transition.name,
 		),
 	)
 	workflow.append(
@@ -183,3 +218,11 @@ def create_todo_workflow():
 
 def create_new_todo():
 	return frappe.get_doc(doctype="ToDo", description="workflow " + random_string(10)).insert()
+
+
+def create_new_note(doc):
+	note = frappe.new_doc("Note")
+	note.title = "workflow - " + doc.name
+	note.content = "workflow test"
+
+	note.save()

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.model.workflow import DEFAULT_WORKFLOW_TASKS
 from frappe.utils import cint
 
 
@@ -135,4 +136,4 @@ def get_workflow_state_count(doctype, workflow_state_field, states):
 
 @frappe.whitelist(methods=["GET"])
 def get_workflow_methods():
-	return [i["name"] for i in frappe.get_hooks("workflow_methods")] + ["Server Script"]
+	return [i["name"] for i in frappe.get_hooks("workflow_methods")] + DEFAULT_WORKFLOW_TASKS

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -135,4 +135,4 @@ def get_workflow_state_count(doctype, workflow_state_field, states):
 
 @frappe.whitelist(methods=["GET"])
 def get_workflow_methods():
-	return [i["name"] for i in frappe.get_hooks("workflow_methods")]
+	return [i["name"] for i in frappe.get_hooks("workflow_methods")] + ["Server Script"]

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -131,3 +131,8 @@ def get_workflow_state_count(doctype, workflow_state_field, states):
 			group_by=workflow_state_field,
 		)
 		return [r for r in result if r[workflow_state_field]]
+
+
+@frappe.whitelist(methods=["GET"])
+def get_workflow_methods():
+	return [i["name"] for i in frappe.get_hooks("workflow_methods")]

--- a/frappe/workflow/doctype/workflow_transition/workflow_transition.json
+++ b/frappe/workflow/doctype/workflow_transition/workflow_transition.json
@@ -12,6 +12,7 @@
   "allowed",
   "allow_self_approval",
   "send_email_to_creator",
+  "transition_tasks",
   "conditions",
   "condition",
   "column_break_7",
@@ -99,17 +100,24 @@
    "fieldname": "send_email_to_creator",
    "fieldtype": "Check",
    "label": "Send Email To Creator"
+  },
+  {
+   "fieldname": "transition_tasks",
+   "fieldtype": "Link",
+   "label": "Transition Tasks",
+   "options": "Workflow Transition Tasks"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-24 02:47:44.188152",
+ "modified": "2025-07-04 15:56:34.345888",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Transition",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/frappe/workflow/doctype/workflow_transition/workflow_transition.py
+++ b/frappe/workflow/doctype/workflow_transition/workflow_transition.py
@@ -24,6 +24,7 @@ class WorkflowTransition(Document):
 		parenttype: DF.Data
 		send_email_to_creator: DF.Check
 		state: DF.Link
+		transition_tasks: DF.Link | None
 		workflow_builder_id: DF.Data | None
 	# end: auto-generated types
 

--- a/frappe/workflow/doctype/workflow_transition_task/test_workflow_transition_task.py
+++ b/frappe/workflow/doctype/workflow_transition_task/test_workflow_transition_task.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestWorkflowTransitionTask(IntegrationTestCase):
+	"""
+	Integration tests for WorkflowTransitionTask.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.js
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Workflow Transition Task", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
@@ -7,7 +7,8 @@
  "field_order": [
   "task",
   "execute_asynchronously",
-  "enabled"
+  "enabled",
+  "server_script"
  ],
  "fields": [
   {
@@ -33,13 +34,22 @@
    "in_list_view": 1,
    "in_preview": 1,
    "label": "Enabled"
+  },
+  {
+   "depends_on": "eval: doc.task == \"Server Script\"",
+   "fetch_if_empty": 1,
+   "fieldname": "server_script",
+   "fieldtype": "Link",
+   "label": "Server Script",
+   "mandatory_depends_on": "eval: doc.task == \"Server Script\"",
+   "options": "Server Script"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-08 12:24:30.067609",
+ "modified": "2025-07-08 12:39:07.174698",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Transition Task",

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
@@ -1,0 +1,60 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-07-04 16:41:15.904217",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "task",
+  "execute_asynchronously",
+  "enabled"
+ ],
+ "fields": [
+  {
+   "fieldname": "task",
+   "fieldtype": "Autocomplete",
+   "in_preview": 1,
+   "label": "Task"
+  },
+  {
+   "default": "0",
+   "fieldname": "execute_asynchronously",
+   "fieldtype": "Check",
+   "in_preview": 1,
+   "label": "Execute Asynchronously"
+  },
+  {
+   "default": "0",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "in_preview": 1,
+   "label": "Enabled"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-07-04 16:43:26.076598",
+ "modified_by": "Administrator",
+ "module": "Workflow",
+ "name": "Workflow Transition Task",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
@@ -6,7 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "task",
-  "execute_asynchronously",
+  "asynchronous",
   "enabled",
   "link"
  ],
@@ -18,15 +18,6 @@
    "in_preview": 1,
    "label": "Task",
    "reqd": 1
-  },
-  {
-   "default": "0",
-   "description": "Will spawn separate background jobs. Use for asynchronous, optional tasks. Failure won't stop the transition, unlike normal actions.\n",
-   "fieldname": "execute_asynchronously",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "in_preview": 1,
-   "label": "Execute Asynchronously"
   },
   {
    "default": "1",
@@ -44,13 +35,22 @@
    "label": "Link",
    "mandatory_depends_on": "eval: [\"Server Script\", \"Webhook\"].includes(doc.task)",
    "options": "task"
+  },
+  {
+   "default": "0",
+   "description": "Spawns actions in a background job",
+   "fieldname": "asynchronous",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "in_preview": 1,
+   "label": "Asynchronous"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-10 11:35:02.282263",
+ "modified": "2025-07-14 12:13:18.108225",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Transition Task",

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
@@ -21,6 +21,7 @@
   },
   {
    "default": "0",
+   "description": "Will spawn separate background jobs. Use for asynchronous, optional tasks. Failure won't stop the transition, unlike normal actions.\n",
    "fieldname": "execute_asynchronously",
    "fieldtype": "Check",
    "in_list_view": 1,
@@ -28,7 +29,7 @@
    "label": "Execute Asynchronously"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "enabled",
    "fieldtype": "Check",
    "in_list_view": 1,
@@ -49,7 +50,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-08 12:39:07.174698",
+ "modified": "2025-07-08 15:19:11.326777",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Transition Task",

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
@@ -13,13 +13,16 @@
   {
    "fieldname": "task",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "in_preview": 1,
-   "label": "Task"
+   "label": "Task",
+   "reqd": 1
   },
   {
    "default": "0",
    "fieldname": "execute_asynchronously",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "in_preview": 1,
    "label": "Execute Asynchronously"
   },
@@ -27,6 +30,7 @@
    "default": "0",
    "fieldname": "enabled",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "in_preview": 1,
    "label": "Enabled"
   }
@@ -35,7 +39,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-07 14:56:34.689483",
+ "modified": "2025-07-08 12:24:30.067609",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Transition Task",

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
@@ -12,7 +12,7 @@
  "fields": [
   {
    "fieldname": "task",
-   "fieldtype": "Autocomplete",
+   "fieldtype": "Select",
    "in_preview": 1,
    "label": "Task"
   },
@@ -33,26 +33,14 @@
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
+ "istable": 1,
  "links": [],
- "modified": "2025-07-04 16:43:26.076598",
+ "modified": "2025-07-07 14:56:34.689483",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Transition Task",
  "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
+ "permissions": [],
  "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.json
@@ -8,7 +8,7 @@
   "task",
   "execute_asynchronously",
   "enabled",
-  "server_script"
+  "link"
  ],
  "fields": [
   {
@@ -37,20 +37,20 @@
    "label": "Enabled"
   },
   {
-   "depends_on": "eval: doc.task == \"Server Script\"",
+   "depends_on": "eval: [\"Server Script\", \"Webhook\"].includes(doc.task)",
    "fetch_if_empty": 1,
-   "fieldname": "server_script",
-   "fieldtype": "Link",
-   "label": "Server Script",
-   "mandatory_depends_on": "eval: doc.task == \"Server Script\"",
-   "options": "Server Script"
+   "fieldname": "link",
+   "fieldtype": "Dynamic Link",
+   "label": "Link",
+   "mandatory_depends_on": "eval: [\"Server Script\", \"Webhook\"].includes(doc.task)",
+   "options": "task"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-08 15:19:11.326777",
+ "modified": "2025-07-10 11:35:02.282263",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Transition Task",

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.py
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.py
@@ -19,6 +19,7 @@ class WorkflowTransitionTask(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		server_script: DF.Link | None
 		task: DF.Literal[None]
 	# end: auto-generated types
 

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.py
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, Frappe Technologies and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
@@ -16,7 +16,10 @@ class WorkflowTransitionTask(Document):
 
 		enabled: DF.Check
 		execute_asynchronously: DF.Check
-		task: DF.Autocomplete | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		task: DF.Literal[None]
 	# end: auto-generated types
 
 	pass

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.py
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class WorkflowTransitionTask(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		enabled: DF.Check
+		execute_asynchronously: DF.Check
+		task: DF.Autocomplete | None
+	# end: auto-generated types
+
+	pass

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.py
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.py
@@ -14,8 +14,8 @@ class WorkflowTransitionTask(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		asynchronous: DF.Check
 		enabled: DF.Check
-		execute_asynchronously: DF.Check
 		link: DF.DynamicLink | None
 		parent: DF.Data
 		parentfield: DF.Data

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.py
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.py
@@ -16,10 +16,10 @@ class WorkflowTransitionTask(Document):
 
 		enabled: DF.Check
 		execute_asynchronously: DF.Check
+		link: DF.DynamicLink | None
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		server_script: DF.Link | None
 		task: DF.Literal[None]
 	# end: auto-generated types
 

--- a/frappe/workflow/doctype/workflow_transition_tasks/test_workflow_transition_tasks.py
+++ b/frappe/workflow/doctype/workflow_transition_tasks/test_workflow_transition_tasks.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestWorkflowTransitionTasks(IntegrationTestCase):
+	"""
+	Integration tests for WorkflowTransitionTasks.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.js
+++ b/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.js
@@ -16,4 +16,14 @@ frappe.ui.form.on("Workflow Transition Tasks", {
 				);
 			});
 	},
+
+	setup: function (frm) {
+		frm.set_query("server_script", "tasks", () => {
+			return {
+				filters: {
+					script_type: "Workflow Task",
+				},
+			};
+		});
+	},
 });

--- a/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.js
+++ b/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.js
@@ -16,14 +16,4 @@ frappe.ui.form.on("Workflow Transition Tasks", {
 				);
 			});
 	},
-
-	setup: function (frm) {
-		frm.set_query("server_script", "tasks", () => {
-			return {
-				filters: {
-					script_type: "Workflow Task",
-				},
-			};
-		});
-	},
 });

--- a/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.js
+++ b/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Workflow Transition Tasks", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.js
+++ b/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.js
@@ -1,8 +1,19 @@
 // Copyright (c) 2025, Frappe Technologies and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Workflow Transition Tasks", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Workflow Transition Tasks", {
+	refresh: function (frm) {
+		frappe
+			.call({
+				method: "frappe.workflow.doctype.workflow.workflow.get_workflow_methods",
+				type: "GET",
+			})
+			.then((options) => {
+				frm.get_field("tasks").grid.update_docfield_property(
+					"task",
+					"options",
+					options.message
+				);
+			});
+	},
+});

--- a/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.json
+++ b/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "prompt",
  "creation": "2025-07-04 15:41:50.296193",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -18,10 +19,11 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-04 15:54:46.997291",
+ "modified": "2025-07-08 12:23:01.908648",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Transition Tasks",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {

--- a/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.json
+++ b/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.json
@@ -1,0 +1,44 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-07-04 15:41:50.296193",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "tasks"
+ ],
+ "fields": [
+  {
+   "fieldname": "tasks",
+   "fieldtype": "Table",
+   "label": "Tasks",
+   "options": "Workflow Transition Task"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-07-04 15:54:46.997291",
+ "modified_by": "Administrator",
+ "module": "Workflow",
+ "name": "Workflow Transition Tasks",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.py
+++ b/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.py
@@ -13,11 +13,11 @@ class WorkflowTransitionTasks(Document):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
-		from frappe.workflow.doctype.workflow_transition_action_task.workflow_transition_action_task import (
-			WorkflowTransitionActionTask,
+		from frappe.workflow.doctype.workflow_transition_task.workflow_transition_task import (
+			WorkflowTransitionTask,
 		)
 
-		tasks: DF.Table[WorkflowTransitionActionTask]
+		tasks: DF.Table[WorkflowTransitionTask]
 	# end: auto-generated types
 
 	pass

--- a/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.py
+++ b/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2025, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class WorkflowTransitionTasks(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+		from frappe.workflow.doctype.workflow_transition_action_task.workflow_transition_action_task import (
+			WorkflowTransitionActionTask,
+		)
+
+		tasks: DF.Table[WorkflowTransitionActionTask]
+	# end: auto-generated types
+
+	pass


### PR DESCRIPTION
# Introduction
- Adds the ability to execute actions defined on the app-level through the hook `workflow_methods`.
- There are currently two kinds of tasks that are executed:
  1. **Synchronous Tasks**: Executed in the main thread in the order they are defined in the Workflow Transition Tasks DocType. Failure of any one of the tasks will stop the transition from changing the state and rollback.
  2. **Asynchronous Tasks**: Executed independently in background jobs of their own.
- 'Server Script' is also type of task, where user can plug in any server script of the type 'Workflow Task' and use it like any other task.
- Any dotted path method defined through the `workflow_methods` hook has to accept `doc: Document` as the parameter, which is the document on which the transition is being applied.
Example: 
```python
# hooks.py
workflow_methods = [{"name": "Create a customer", "method":
					 "myapp.shop.doctype.kirana.create_customer"}]

# myapp/shop/doctype/kirana.py
def create_customer(doc):
    customer = frappe.new_doc("Customer")
    customer.customer_name = "Customer " + doc.name
    customer.customer_type = "Individual"

    customer.save()
```


# Checklist
- [x] App-defined tasks through the `workflow_methods` hook
- [x] Server Script integration with the type `Workflow Task`
- [x] Webhook integration
- [x] Write tests

`no-docs`