### PR TITLE
fix: update delete or cancel popup doc links to handle edge cases

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -13,6 +13,7 @@ from frappe.model.docstatus import DocStatus
 from frappe.model.dynamic_links import get_dynamic_link_map
 from frappe.model.naming import revert_series_if_last
 from frappe.model.utils import is_virtual_doctype
+from frappe.utils.data import get_link_to_form
 from frappe.utils.file_manager import remove_all
 from frappe.utils.global_search import delete_for_document
 from frappe.utils.password import delete_all_passwords_for
@@ -367,8 +368,8 @@ def check_if_doc_is_dynamically_linked(doc, method="Delete"):
 
 
 def raise_link_exists_exception(doc, reference_doctype, reference_docname, row=""):
-	doc_link = f'<a href="/app/Form/{doc.doctype}/{doc.name}">{doc.name}</a>'
-	reference_link = f'<a href="/app/Form/{reference_doctype}/{reference_docname}">{reference_docname}</a>'
+	doc_link = get_link_to_form(doc.doctype, doc.name, doc.name)
+	reference_link = get_link_to_form(reference_doctype, reference_docname, reference_docname)
 
 	# hack to display Single doctype only once in message
 	if reference_doctype == reference_docname:


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

In the "Cannot delete or cancel" popup, which appears when someone tries to delete or cancel a linked document, there is a small bug. it does not correctly parse or generate the URL for DocTypes with a `/` in their Document name.

https://github.com/user-attachments/assets/b4f4899e-7f9e-4f59-9e65-e55d8ec559fb

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The code has been updated to use Frappe’s default `get_link_to_form` function to generate the link in the popup, ensuring URLs are correctly formed even for doctypes with `/` in their name.

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->

**Output after the changes:**

https://github.com/user-attachments/assets/3f68714c-d825-41b0-bb8c-d0a7c8d5b8ea