### PR TITLE
fix: Alllow `Bulk Edit` in `Table` other than DocType

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1192,7 +1192,10 @@ export default class Grid {
 				data.push([__("The CSV format is case sensitive")]);
 				data.push([__("Do not edit headers which are preset in the template")]);
 				data.push(["------"]);
-				$.each(frappe.get_meta(this.df.options).fields, (i, df) => {
+
+				const fields = this.frm ? frappe.get_meta(this.df.options).fields : this.df.fields;
+
+				$.each(fields, (i, df) => {
 					// don't include the read-only field in the template
 					if (frappe.model.is_value_type(df.fieldtype)) {
 						data[1].push(df.label);
@@ -1207,7 +1210,9 @@ export default class Grid {
 				});
 
 				// add data
-				$.each(this.frm.doc[this.df.fieldname] || [], (i, d) => {
+				const values = this.frm ? this.frm.doc[this.df.fieldname] : this.df.data;
+
+				$.each(values || [], (i, d) => {
 					var row = [];
 					$.each(data[2], (i, fieldname) => {
 						var value = d[fieldname];

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -19,8 +19,8 @@ frappe.ui.form.close_grid_form = function () {
 };
 
 export default class Grid {
-	constructor(opts) {
-		$.extend(this, opts);
+	constructor(options) {
+		$.extend(this, options);
 		this.fieldinfo = {};
 		this.doctype = this.df.options;
 
@@ -44,6 +44,15 @@ export default class Grid {
 		this.is_grid = true;
 		this.debounced_refresh = this.refresh.bind(this);
 		this.debounced_refresh = frappe.utils.debounce(this.debounced_refresh, 100);
+
+		// for bulk update csv file structure
+		this.csv_row_index = {
+			title: 0,
+			label: 1,
+			fieldname: 2,
+			description: 3,
+			data: 7,
+		};
 	}
 
 	get perm() {
@@ -1128,13 +1137,15 @@ export default class Grid {
 				$.each(fields, (i, df) => {
 					// don't include the read-only field in the template
 					if (frappe.model.is_value_type(df.fieldtype)) {
-						data[1].push(df.label);
-						data[2].push(df.fieldname);
+						data[this.csv_row_index.label].push(df.label);
+						data[this.csv_row_index.fieldname].push(df.fieldname);
+
 						let description = (df.description || "") + " ";
 						if (df.fieldtype === "Date") {
 							description += frappe.boot.sysdefaults.date_format;
 						}
-						data[3].push(description);
+						data[this.csv_row_index.description].push(description);
+
 						docfields.push(df);
 					}
 				});

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -19,8 +19,8 @@ frappe.ui.form.close_grid_form = function () {
 };
 
 export default class Grid {
-	constructor(opt) {
-		$.extend(this, opt);
+	constructor(opts) {
+		$.extend(this, opts);
 		this.fieldinfo = {};
 		this.doctype = this.df.options;
 

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1176,14 +1176,6 @@ export default class Grid {
 	}
 
 	setup_upload() {
-		const value_formatter_map = {
-			Date: (val) => (val ? frappe.datetime.user_to_str(val) : val),
-			Int: (val) => cint(val),
-			Check: (val) => cint(val),
-			Float: (val) => flt(val),
-			Currency: (val) => flt(val),
-		};
-
 		const me = this;
 
 		frappe.flags.no_socketio = true;
@@ -1198,92 +1190,83 @@ export default class Grid {
 						allowed_file_types: [".csv"],
 					},
 					on_success(file) {
+						function clear_table() {
+							if (me.frm) {
+								me.frm.clear_table(me.df.fieldname);
+							} else {
+								me.df.data = [];
+							}
+						}
+
+						function refresh_table() {
+							if (me.frm) {
+								me.frm.refresh_field(me.df.fieldname);
+							} else {
+								me.refresh();
+							}
+						}
+
+						function get_row_field(fieldname) {
+							if (me.frm) {
+								return frappe.meta.get_docfield(me.df.options, fieldname);
+							}
+
+							return me.df.fields.find((d) => d.fieldname === fieldname);
+						}
+
+						const value_formatter_map = {
+							Date: (val) => (val ? frappe.datetime.user_to_str(val) : val),
+							Int: (val) => cint(val),
+							Check: (val) => cint(val),
+							Float: (val) => flt(val),
+							Currency: (val) => flt(val),
+						};
+
+						// read csv file
 						const data = frappe.utils.csv_to_array(
 							frappe.utils.get_decoded_string(file.dataurl)
 						);
 
-						if (cint(data.length) - 7 > 5000) {
+						if (cint(data.length) - me.csv_row_index.data > 5000) {
 							frappe.throw(__("Cannot import table with more than 5000 rows."));
 						}
 
-						// row #2 contains fieldnames;
-						const fieldnames = data[2];
+						const fieldnames = data[me.csv_row_index.fieldname];
 
-						if (me.frm) {
-							me.frm.clear_table(me.df.fieldname);
+						// inserting rows into table
+						clear_table();
 
-							$.each(data, (i, row) => {
-								if (i > 6) {
-									let blank_row = true;
+						for (let i = me.csv_row_index.data; i < data.length; i++) {
+							const row = data[i];
 
-									$.each(row, function (ci, value) {
-										if (value) {
-											blank_row = false;
-											return false;
-										}
-									});
+							// Check if row is not entirely blank
+							const has_value = row.some((value) => !!value);
+							if (!has_value) continue;
 
-									if (!blank_row) {
-										const d = me.frm.add_child(me.df.fieldname);
+							let d = {};
 
-										$.each(row, (ci, value) => {
-											const fieldname = fieldnames[ci];
-											const df = frappe.meta.get_docfield(
-												me.df.options,
-												fieldname
-											);
-											if (df) {
-												d[fieldnames[ci]] = value_formatter_map[
-													df.fieldtype
-												]
-													? value_formatter_map[df.fieldtype](value)
-													: value;
-											}
-										});
-									}
-								}
-							});
+							if (me.frm) {
+								d = me.frm.add_child(me.df.fieldname);
+							}
 
-							me.frm.refresh_field(me.df.fieldname);
-						} else {
-							me.df.data = [];
+							for (let ci = 0; ci < row.length; ci++) {
+								const value = row[ci];
+								const fieldname = fieldnames[ci];
+								const field = get_row_field(fieldname);
 
-							$.each(data, (i, row) => {
-								if (i > 6) {
-									let blank_row = true;
+								if (!field) continue;
 
-									$.each(row, function (ci, value) {
-										if (value) {
-											blank_row = false;
-											return false;
-										}
-									});
+								d[fieldname] = value_formatter_map[field.fieldtype]
+									? value_formatter_map[field.fieldtype](value)
+									: value;
+							}
 
-									if (!blank_row) {
-										let d = {};
-
-										$.each(row, (ci, value) => {
-											const fieldname = fieldnames[ci];
-											const fields = me.df.fields;
-											const field = fields.find(
-												(d) => d.fieldname === fieldname
-											);
-
-											if (field) {
-												d[fieldnames[ci]] = value_formatter_map[
-													field.fieldtype
-												]
-													? value_formatter_map[field.fieldtype](value)
-													: value;
-											}
-										});
-										me.df.data.push(d);
-									}
-								}
-							});
-
-							me.refresh();
+							if (!me.frm) {
+								me.df.data.push(d);
+							}
 						}
+
+						refresh_table();
 
 						frappe.msgprint({
 							message: __("Table updated"),

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1246,11 +1246,7 @@ export default class Grid {
 							const has_value = row.some((value) => !!value);
 							if (!has_value) continue;
 
-							let d = {};
-
-							if (me.frm) {
-								d = me.frm.add_child(me.df.fieldname);
-							}
+							const d = me.frm ? me.frm.add_child(me.df.fieldname) : {};
 
 							for (let ci = 0; ci < row.length; ci++) {
 								const value = row[ci];

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1133,38 +1133,81 @@ export default class Grid {
 							}
 							// row #2 contains fieldnames;
 							var fieldnames = data[2];
-							me.frm.clear_table(me.df.fieldname);
-							$.each(data, (i, row) => {
-								if (i > 6) {
-									var blank_row = true;
-									$.each(row, function (ci, value) {
-										if (value) {
-											blank_row = false;
-											return false;
-										}
-									});
 
-									if (!blank_row) {
-										var d = me.frm.add_child(me.df.fieldname);
-										$.each(row, (ci, value) => {
-											var fieldname = fieldnames[ci];
-											var df = frappe.meta.get_docfield(
-												me.df.options,
-												fieldname
-											);
-											if (df) {
-												d[fieldnames[ci]] = value_formatter_map[
-													df.fieldtype
-												]
-													? value_formatter_map[df.fieldtype](value)
-													: value;
+							if (me.frm) {
+								me.frm.clear_table(me.df.fieldname);
+
+								$.each(data, (i, row) => {
+									if (i > 6) {
+										var blank_row = true;
+										$.each(row, function (ci, value) {
+											if (value) {
+												blank_row = false;
+												return false;
 											}
 										});
-									}
-								}
-							});
 
-							me.frm.refresh_field(me.df.fieldname);
+										if (!blank_row) {
+											var d = me.frm.add_child(me.df.fieldname);
+											$.each(row, (ci, value) => {
+												var fieldname = fieldnames[ci];
+												var df = frappe.meta.get_docfield(
+													me.df.options,
+													fieldname
+												);
+												if (df) {
+													d[fieldnames[ci]] = value_formatter_map[
+														df.fieldtype
+													]
+														? value_formatter_map[df.fieldtype](value)
+														: value;
+												}
+											});
+										}
+									}
+								});
+
+								me.frm.refresh_field(me.df.fieldname);
+							} else {
+								me.df.data = [];
+
+								$.each(data, (i, row) => {
+									if (i > 6) {
+										var blank_row = true;
+										$.each(row, function (ci, value) {
+											if (value) {
+												blank_row = false;
+												return false;
+											}
+										});
+
+										if (!blank_row) {
+											var d = {};
+											$.each(row, (ci, value) => {
+												const fieldname = fieldnames[ci];
+												const fields = me.df.fields;
+												const field = fields.find(
+													(d) => d.fieldname === fieldname
+												);
+
+												if (field) {
+													d[fieldnames[ci]] = value_formatter_map[
+														field.fieldtype
+													]
+														? value_formatter_map[field.fieldtype](
+																value
+														  )
+														: value;
+												}
+											});
+											me.df.data.push(d);
+										}
+									}
+								});
+
+								me.refresh();
+							}
+
 							frappe.msgprint({
 								message: __("Table updated"),
 								title: __("Success"),

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1206,14 +1206,6 @@ export default class Grid {
 							}
 						}
 
-						function get_row_field(fieldname) {
-							if (me.frm) {
-								return frappe.meta.get_docfield(me.df.options, fieldname);
-							}
-
-							return me.df.fields.find((d) => d.fieldname === fieldname);
-						}
-
 						const value_formatter_map = {
 							Date: (val) => (val ? frappe.datetime.user_to_str(val) : val),
 							Int: (val) => cint(val),
@@ -1232,6 +1224,13 @@ export default class Grid {
 						}
 
 						const fieldnames = data[me.csv_row_index.fieldname];
+						const row_field_df = {};
+
+						for (let fieldname of fieldnames) {
+							row_field_df[fieldname] = me.frm
+								? frappe.meta.get_docfield(me.df.options, fieldname)
+								: me.df.fields.find((d) => d.fieldname === fieldname);
+						}
 
 						// inserting rows into table
 						clear_table();
@@ -1252,12 +1251,12 @@ export default class Grid {
 							for (let ci = 0; ci < row.length; ci++) {
 								const value = row[ci];
 								const fieldname = fieldnames[ci];
-								const field = get_row_field(fieldname);
+								const df = row_field_df[fieldname];
 
-								if (!field) continue;
+								if (!df) continue;
 
-								d[fieldname] = value_formatter_map[field.fieldtype]
-									? value_formatter_map[field.fieldtype](value)
+								d[fieldname] = value_formatter_map[df.fieldtype]
+									? value_formatter_map[df.fieldtype](value)
 									: value;
 							}
 

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1267,9 +1267,8 @@ export default class Grid {
 
 						refresh_table();
 
-						frappe.msgprint({
+						frappe.show_alert({
 							message: __("Table updated"),
-							title: __("Success"),
 							indicator: "green",
 						});
 					},

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1100,7 +1100,7 @@ export default class Grid {
 
 	setup_allow_bulk_edit() {
 		let me = this;
-		if (this.frm && this.frm.get_docfield(this.df.fieldname)?.allow_bulk_edit) {
+		if (this.df.allow_bulk_edit) {
 			// download
 			this.setup_download();
 

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1106,13 +1106,15 @@ export default class Grid {
 	}
 
 	setup_download() {
-		let title = this.df.label || frappe.model.unscrub(this.df.fieldname);
+		const title = this.df.label || frappe.model.unscrub(this.df.fieldname);
+
 		$(this.wrapper)
 			.find(".grid-download")
 			.removeClass("hidden")
 			.on("click", () => {
-				var data = [];
-				var docfields = [];
+				const data = [];
+				const docfields = [];
+
 				data.push([__("Bulk Edit {0}", [title])]);
 				data.push([]);
 				data.push([]);
@@ -1141,9 +1143,10 @@ export default class Grid {
 				const values = this.frm ? this.frm.doc[this.df.fieldname] : this.df.data;
 
 				$.each(values || [], (i, d) => {
-					var row = [];
+					const row = [];
+
 					$.each(data[2], (i, fieldname) => {
-						var value = d[fieldname];
+						let value = d[fieldname];
 
 						// format date
 						if (docfields[i].fieldtype === "Date" && value) {
@@ -1152,6 +1155,7 @@ export default class Grid {
 
 						row.push(value || "");
 					});
+
 					data.push(row);
 				});
 
@@ -1169,7 +1173,7 @@ export default class Grid {
 			Currency: (val) => flt(val),
 		};
 
-		let me = this;
+		const me = this;
 
 		frappe.flags.no_socketio = true;
 		$(this.wrapper)
@@ -1183,21 +1187,24 @@ export default class Grid {
 						allowed_file_types: [".csv"],
 					},
 					on_success(file) {
-						var data = frappe.utils.csv_to_array(
+						const data = frappe.utils.csv_to_array(
 							frappe.utils.get_decoded_string(file.dataurl)
 						);
+
 						if (cint(data.length) - 7 > 5000) {
 							frappe.throw(__("Cannot import table with more than 5000 rows."));
 						}
+
 						// row #2 contains fieldnames;
-						var fieldnames = data[2];
+						const fieldnames = data[2];
 
 						if (me.frm) {
 							me.frm.clear_table(me.df.fieldname);
 
 							$.each(data, (i, row) => {
 								if (i > 6) {
-									var blank_row = true;
+									let blank_row = true;
+
 									$.each(row, function (ci, value) {
 										if (value) {
 											blank_row = false;
@@ -1206,10 +1213,11 @@ export default class Grid {
 									});
 
 									if (!blank_row) {
-										var d = me.frm.add_child(me.df.fieldname);
+										const d = me.frm.add_child(me.df.fieldname);
+
 										$.each(row, (ci, value) => {
-											var fieldname = fieldnames[ci];
-											var df = frappe.meta.get_docfield(
+											const fieldname = fieldnames[ci];
+											const df = frappe.meta.get_docfield(
 												me.df.options,
 												fieldname
 											);
@@ -1231,7 +1239,8 @@ export default class Grid {
 
 							$.each(data, (i, row) => {
 								if (i > 6) {
-									var blank_row = true;
+									let blank_row = true;
+
 									$.each(row, function (ci, value) {
 										if (value) {
 											blank_row = false;
@@ -1240,7 +1249,8 @@ export default class Grid {
 									});
 
 									if (!blank_row) {
-										var d = {};
+										let d = {};
+
 										$.each(row, (ci, value) => {
 											const fieldname = fieldnames[ci];
 											const fields = me.df.fields;

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1099,125 +1099,10 @@ export default class Grid {
 	}
 
 	setup_allow_bulk_edit() {
-		let me = this;
-		if (this.df.allow_bulk_edit) {
-			// download
-			this.setup_download();
+		if (!this.df.allow_bulk_edit) return;
 
-			const value_formatter_map = {
-				Date: (val) => (val ? frappe.datetime.user_to_str(val) : val),
-				Int: (val) => cint(val),
-				Check: (val) => cint(val),
-				Float: (val) => flt(val),
-				Currency: (val) => flt(val),
-			};
-
-			// upload
-			frappe.flags.no_socketio = true;
-			$(this.wrapper)
-				.find(".grid-upload")
-				.removeClass("hidden")
-				.on("click", () => {
-					new frappe.ui.FileUploader({
-						as_dataurl: true,
-						allow_multiple: false,
-						restrictions: {
-							allowed_file_types: [".csv"],
-						},
-						on_success(file) {
-							var data = frappe.utils.csv_to_array(
-								frappe.utils.get_decoded_string(file.dataurl)
-							);
-							if (cint(data.length) - 7 > 5000) {
-								frappe.throw(__("Cannot import table with more than 5000 rows."));
-							}
-							// row #2 contains fieldnames;
-							var fieldnames = data[2];
-
-							if (me.frm) {
-								me.frm.clear_table(me.df.fieldname);
-
-								$.each(data, (i, row) => {
-									if (i > 6) {
-										var blank_row = true;
-										$.each(row, function (ci, value) {
-											if (value) {
-												blank_row = false;
-												return false;
-											}
-										});
-
-										if (!blank_row) {
-											var d = me.frm.add_child(me.df.fieldname);
-											$.each(row, (ci, value) => {
-												var fieldname = fieldnames[ci];
-												var df = frappe.meta.get_docfield(
-													me.df.options,
-													fieldname
-												);
-												if (df) {
-													d[fieldnames[ci]] = value_formatter_map[
-														df.fieldtype
-													]
-														? value_formatter_map[df.fieldtype](value)
-														: value;
-												}
-											});
-										}
-									}
-								});
-
-								me.frm.refresh_field(me.df.fieldname);
-							} else {
-								me.df.data = [];
-
-								$.each(data, (i, row) => {
-									if (i > 6) {
-										var blank_row = true;
-										$.each(row, function (ci, value) {
-											if (value) {
-												blank_row = false;
-												return false;
-											}
-										});
-
-										if (!blank_row) {
-											var d = {};
-											$.each(row, (ci, value) => {
-												const fieldname = fieldnames[ci];
-												const fields = me.df.fields;
-												const field = fields.find(
-													(d) => d.fieldname === fieldname
-												);
-
-												if (field) {
-													d[fieldnames[ci]] = value_formatter_map[
-														field.fieldtype
-													]
-														? value_formatter_map[field.fieldtype](
-																value
-														  )
-														: value;
-												}
-											});
-											me.df.data.push(d);
-										}
-									}
-								});
-
-								me.refresh();
-							}
-
-							frappe.msgprint({
-								message: __("Table updated"),
-								title: __("Success"),
-								indicator: "green",
-							});
-						},
-					});
-					return false;
-				});
-		}
+		this.setup_download();
+		this.setup_upload();
 	}
 
 	setup_download() {
@@ -1271,6 +1156,121 @@ export default class Grid {
 				});
 
 				frappe.tools.downloadify(data, null, title);
+				return false;
+			});
+	}
+
+	setup_upload() {
+		const value_formatter_map = {
+			Date: (val) => (val ? frappe.datetime.user_to_str(val) : val),
+			Int: (val) => cint(val),
+			Check: (val) => cint(val),
+			Float: (val) => flt(val),
+			Currency: (val) => flt(val),
+		};
+
+		let me = this;
+
+		frappe.flags.no_socketio = true;
+		$(this.wrapper)
+			.find(".grid-upload")
+			.removeClass("hidden")
+			.on("click", () => {
+				new frappe.ui.FileUploader({
+					as_dataurl: true,
+					allow_multiple: false,
+					restrictions: {
+						allowed_file_types: [".csv"],
+					},
+					on_success(file) {
+						var data = frappe.utils.csv_to_array(
+							frappe.utils.get_decoded_string(file.dataurl)
+						);
+						if (cint(data.length) - 7 > 5000) {
+							frappe.throw(__("Cannot import table with more than 5000 rows."));
+						}
+						// row #2 contains fieldnames;
+						var fieldnames = data[2];
+
+						if (me.frm) {
+							me.frm.clear_table(me.df.fieldname);
+
+							$.each(data, (i, row) => {
+								if (i > 6) {
+									var blank_row = true;
+									$.each(row, function (ci, value) {
+										if (value) {
+											blank_row = false;
+											return false;
+										}
+									});
+
+									if (!blank_row) {
+										var d = me.frm.add_child(me.df.fieldname);
+										$.each(row, (ci, value) => {
+											var fieldname = fieldnames[ci];
+											var df = frappe.meta.get_docfield(
+												me.df.options,
+												fieldname
+											);
+											if (df) {
+												d[fieldnames[ci]] = value_formatter_map[
+													df.fieldtype
+												]
+													? value_formatter_map[df.fieldtype](value)
+													: value;
+											}
+										});
+									}
+								}
+							});
+
+							me.frm.refresh_field(me.df.fieldname);
+						} else {
+							me.df.data = [];
+
+							$.each(data, (i, row) => {
+								if (i > 6) {
+									var blank_row = true;
+									$.each(row, function (ci, value) {
+										if (value) {
+											blank_row = false;
+											return false;
+										}
+									});
+
+									if (!blank_row) {
+										var d = {};
+										$.each(row, (ci, value) => {
+											const fieldname = fieldnames[ci];
+											const fields = me.df.fields;
+											const field = fields.find(
+												(d) => d.fieldname === fieldname
+											);
+
+											if (field) {
+												d[fieldnames[ci]] = value_formatter_map[
+													field.fieldtype
+												]
+													? value_formatter_map[field.fieldtype](value)
+													: value;
+											}
+										});
+										me.df.data.push(d);
+									}
+								}
+							});
+
+							me.refresh();
+						}
+
+						frappe.msgprint({
+							message: __("Table updated"),
+							title: __("Success"),
+							indicator: "green",
+						});
+					},
+				});
 				return false;
 			});
 	}

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -19,8 +19,8 @@ frappe.ui.form.close_grid_form = function () {
 };
 
 export default class Grid {
-	constructor(options) {
-		$.extend(this, options);
+	constructor(opt) {
+		$.extend(this, opt);
 		this.fieldinfo = {};
 		this.doctype = this.df.options;
 

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1224,12 +1224,16 @@ export default class Grid {
 						}
 
 						const fieldnames = data[me.csv_row_index.fieldname];
+						const fields = me.frm
+							? frappe.get_meta(me.df.options).fields
+							: me.df.fields;
+
 						const row_field_df = {};
 
-						for (let fieldname of fieldnames) {
-							row_field_df[fieldname] = me.frm
-								? frappe.meta.get_docfield(me.df.options, fieldname)
-								: me.df.fields.find((d) => d.fieldname === fieldname);
+						for (const df of fields) {
+							if (df && df.fieldname) {
+								row_field_df[df.fieldname] = df;
+							}
 						}
 
 						// inserting rows into table


### PR DESCRIPTION
**Issue:** `Upload` and `Download` buttons are not available when `Table` field used in dialogs even if giving `allow_bulk_edit: 1` .

---

**Before:**

https://github.com/user-attachments/assets/fe37ad1a-eba3-445f-9723-bbad18448eca

**After:**

https://github.com/user-attachments/assets/5233dd80-647b-4273-a8fa-93f99934833a

---

**Changes Made**

- for consistency use variable for to know what index is representing in `CSV` file

```js
		this.csv_row_index = {
			title: 0,
			label: 1,
			fieldname: 2,
			description: 3,
			data: 7,
		};
``` 

- separate `Upload` functionality from `setup_allow_bulk_edit`

- extra check if `frm` is not available

- refactor `upload` logic to get easily insert data into table

- replace `var` with `let` / `const`

---

To demonstrate the changes, add

```js
allow_bulk_edit: 1
```

Here, https://github.com/frappe/erpnext/blob/dd027f09ac01657dae2e08869cd057aa7bbc5af9/erpnext/public/js/utils.js#L868 

> [!NOTE]
> Backport to V-15 and V-14 