### PR TITLE
 feat(Assignment_Rule): Add the user group functionality to the Assignment Rule Doctype.

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.js
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2019, Frappe Technologies and contributors
 // For license information, please see license.txt
+let debounce_timer;
 
 frappe.ui.form.on("Assignment Rule", {
 	refresh: function (frm) {
@@ -73,5 +74,34 @@ frappe.ui.form.on("Assignment Rule", {
 				frm.set_df_property("due_date_based_on", "hidden", !options.length)
 			);
 		}
+	},
+	user_group: function (frm) {
+		clearTimeout(debounce_timer); // Adding debounce to avoid multiple calls
+		let existing_users = frm.doc.users.map((row) => row.user); // Storing current users to avoid duplicates
+		debounce_timer = setTimeout(() => {
+			let selected_group = (frm.doc.user_group || []).map((row) => row.user_group).pop();
+			if (typeof selected_group === ("undefined" || null || "")) {
+				return; // If no group is selected, do nothing
+			} else {
+				frappe.call({
+					// Did want to directly make a db call to fetch users from the group
+					method: "frappe.core.doctype.user_group.user_group.get_users_from_group",
+					args: {
+						user_group: selected_group,
+					},
+					callback: function (r) {
+						if (r.message) {
+							r.message.forEach((user) => {
+								if (!existing_users.includes(user.user)) {
+									let row = frm.add_child("users");
+									row.user = user.user;
+								}
+							});
+							frm.refresh_field("users");
+						}
+					},
+				});
+			}
+		}, 500); // Not too long or too short, just enough to avoid multiple calls
 	},
 });

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.json
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -24,6 +24,7 @@
   "assignment_days",
   "assign_to_users_section",
   "rule",
+  "user_group",
   "field",
   "users",
   "last_user"
@@ -150,11 +151,18 @@
    "fieldtype": "Select",
    "label": "Field",
    "mandatory_depends_on": "eval: doc.rule == 'Based on Field'"
+  },
+  {
+   "depends_on": "eval: doc.rule !== 'Based on Field'",
+   "fieldname": "user_group",
+   "fieldtype": "Table MultiSelect",
+   "label": "User Group",
+   "options": "Assignment Rule Group"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:01:27.590910",
+ "modified": "2025-07-10 04:21:56.932768",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Assignment Rule",
@@ -174,6 +182,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -404,6 +404,10 @@ def get_repeated(values: Iterable) -> list:
 def sync_users_from_group(doc, method=None):
 	"""Executed when ever there is a update in user group members"""
 
+	# Execute the hook only if it's fired by User Group Doctype.
+	if doc.doctype != "User Group":
+		return
+
 	group_name = doc.name
 
 	# Cache old members in before_update, this is useful where users who

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -20,9 +20,8 @@ class AssignmentRule(Document):
 
 	if TYPE_CHECKING:
 		from frappe.automation.doctype.assignment_rule_day.assignment_rule_day import AssignmentRuleDay
-		from frappe.automation.doctype.assignment_rule_user.assignment_rule_user import (
-			AssignmentRuleUser,
-		)
+		from frappe.automation.doctype.assignment_rule_group.assignment_rule_group import AssignmentRuleGroup
+		from frappe.automation.doctype.assignment_rule_user.assignment_rule_user import AssignmentRuleUser
 		from frappe.types import DF
 
 		assign_condition: DF.Code
@@ -37,6 +36,7 @@ class AssignmentRule(Document):
 		priority: DF.Int
 		rule: DF.Literal["Round Robin", "Load Balancing", "Based on Field"]
 		unassign_condition: DF.Code | None
+		user_group: DF.TableMultiSelect[AssignmentRuleGroup]
 		users: DF.TableMultiSelect[AssignmentRuleUser]
 	# end: auto-generated types
 

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -399,3 +399,77 @@ def get_repeated(values: Iterable) -> list:
 			unique.add(value)
 
 	return [str(x) for x in repeated]
+
+
+def sync_users_from_group(doc, method=None):
+	"""Executed when ever there is a update in user group members"""
+
+	group_name = doc.name
+
+	# Cache old members in before_update, this is useful where users who
+	# are not part of group.For the  individual users.
+	if method == "before_update":
+		old = frappe.get_all("User Group Member", filters={"parent": group_name}, pluck="user") or []
+		doc._old_members = set(old)
+		return
+
+	# Check the changed members
+	old_members = getattr(doc, "_old_members", set()) or set()
+	members_updated_group = (
+		frappe.get_all("User Group Member", filters={"parent": group_name}, pluck="user") or []
+	)
+	new_members = set(members_updated_group)
+
+	added = new_members - old_members
+	removed = old_members - new_members
+
+	# If the user group update doesn't affect the assigned users, return.
+	if not (added or removed):
+		return
+
+	# Get all the Assignment Rules Documents which are assigned to this updated group
+	rule_names = (
+		frappe.get_all("Assignment Rule Group", filters={"user_group": group_name}, pluck="parent") or []
+	)
+	if not rule_names:
+		return
+
+	# Get all the rules with the assigned groups
+	rows = (
+		frappe.get_all(
+			"Assignment Rule Group",
+			filters={"parent": ["in", rule_names]},
+			fields=["parent as rule", "user_group"],
+		)
+		or []
+	)
+
+	groups_by_rule = {}
+	for row in rows:
+		groups_by_rule.setdefault(row.rule, []).append(row.user_group)
+
+	# For each document add or remove users where
+	for rule_name, groups_list in groups_by_rule.items():
+		if not groups_list:
+			continue
+
+		rule = frappe.get_doc("Assignment Rule", rule_name)
+
+		# add newly added users
+		for user in added:
+			if not any(row.user == user for row in rule.get("users") or []):
+				rule.append("users", {"user": user})
+
+		# remove users who left this group and are in no other group of this rule
+		for user in removed:
+			other = [group for group in groups_list if group != group_name]
+			still_in = False
+			if other:
+				still_in = frappe.db.exists("User Group Member", {"parent": ["in", other], "user": user})
+			if not still_in:
+				for user_row in list(rule.get("users") or []):
+					if user_row.user == user:
+						rule.remove(user_row)
+						break
+
+		rule.save(ignore_permissions=True)

--- a/frappe/automation/doctype/assignment_rule_group/assignment_rule_group.json
+++ b/frappe/automation/doctype/assignment_rule_group/assignment_rule_group.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-07-09 22:12:06.732861",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "user_group"
+ ],
+ "fields": [
+  {
+   "fieldname": "user_group",
+   "fieldtype": "Link",
+   "label": "User Group",
+   "options": "User Group"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-07-09 22:16:02.018050",
+ "modified_by": "Administrator",
+ "module": "Automation",
+ "name": "Assignment Rule Group",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/automation/doctype/assignment_rule_group/assignment_rule_group.py
+++ b/frappe/automation/doctype/assignment_rule_group/assignment_rule_group.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2025, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class AssignmentRuleGroup(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		user_group: DF.Link | None
+	# end: auto-generated types
+
+	pass

--- a/frappe/core/doctype/user_group/user_group.py
+++ b/frappe/core/doctype/user_group/user_group.py
@@ -25,3 +25,20 @@ class UserGroup(Document):
 
 	def on_trash(self):
 		frappe.cache.delete_key("user_groups")
+
+
+@frappe.whitelist()
+def get_users_from_group(user_group):
+	"""This function fetches users from a given user group"""
+	# Did not want to directly make a db call from the client-side code to fetch users from the group
+	# Checked other code onlt assign_to.js is adding users which is making a db call
+	try:
+		if not frappe.has_permission("User Group", "read", user_group):
+			message = frappe._("You do not have permission to read this User Group")
+			frappe.throw(message)
+		return frappe.get_list(
+			"User Group Member", parent_doctype="User Group", filters={"parent": user_group}, fields=["user"]
+		)
+	except Exception as e:
+		frappe.log_error(title="Error fetching users from user group", message=str(e))
+		return []

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -153,6 +153,7 @@ doc_events = {
 			"frappe.desk.notifications.clear_doctype_notifications",
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
 			"frappe.core.doctype.file.utils.attach_files_to_document",
+			"frappe.automation.doctype.assignment_rule.assignment_rule.sync_users_from_group",
 			"frappe.automation.doctype.assignment_rule.assignment_rule.apply",
 			"frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date",
 			"frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type",


### PR DESCRIPTION
Add the user group functionality to the Assignment Rule Doctype where users are auto-populated.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

This issue has been raised as there is no functionality to assign to user group in assignment rule.
Before
![Before](https://github.com/user-attachments/assets/e9ded88f-e218-4be1-bd16-f418ce810ad3)


<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

The PR adds the functionality where on selecting the user group users are auto-populated. Duplicates are also checked.
After
![After](https://github.com/user-attachments/assets/5cc2470b-7903-492f-8fce-2e12a0545bb1)


<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

As suggested making users field optional will affect other functions as the users field depends on the rule of assignment, by making user group optional. If user group is selected the users required condition fulfills.
If users are selected there is no need to select group.

When the "Based on Field" option is selected.
![After_Based_on_Field_Option](https://github.com/user-attachments/assets/bc03af47-3189-4d51-a26d-1f3ae5ebdfe5)


> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->

`no-docs`
