### PR TITLE
fix!: Always cast `db.get_value` results for single doctypes

### DIFF
--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -120,10 +120,6 @@ class TestUser(IntegrationTestCase):
 
 		self.assertEqual(frappe.db.get_value("User", "xxxtest@example.com"), None)
 
-		frappe.db.set_single_value("Website Settings", "_test", "_test_val")
-		self.assertEqual(frappe.db.get_value("Website Settings", None, "_test"), "_test_val")
-		self.assertEqual(frappe.db.get_value("Website Settings", "Website Settings", "_test"), "_test_val")
-
 	def test_high_permlevel_validations(self):
 		user = frappe.get_meta("User")
 		self.assertTrue("roles" in [d.fieldname for d in user.get_high_permlevel_fields()])

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -551,7 +551,6 @@ class Database:
 		        # returns default date_format
 		        frappe.db.get_value("System Settings", None, "date_format")
 		"""
-
 		result = self.get_values(
 			doctype,
 			filters,
@@ -730,9 +729,20 @@ class Database:
 		:param filters: Filters (dict).
 		:param doctype: DocType name.
 		"""
+
+		from frappe.model.meta import get_default_df
+
+		meta = frappe.get_meta(doctype)
+
+		def _cast(field, val):
+			df = meta.get_field(field) or get_default_df(field)
+			if not df:
+				return val
+			return cast_fieldtype(df.fieldtype, val)
+
 		if fields == "*" or isinstance(filters, dict):
 			# check if single doc matches with filters
-			values = self.get_singles_dict(doctype)
+			values = self.get_singles_dict(doctype, cast=True)
 			if isinstance(filters, dict):
 				for key, value in filters.items():
 					if values.get(key) != value:
@@ -759,6 +769,9 @@ class Database:
 				return []
 
 			r = _dict(r)
+			for k, v in r.items():
+				r[k] = _cast(k, v)
+
 			if update:
 				r.update(update)
 
@@ -863,7 +876,16 @@ class Database:
 		frappe.qb.into("Singles").columns("doctype", "field", "value").insert(*singles_data).run(debug=debug)
 		frappe.clear_document_cache(doctype, doctype)
 
-	def get_single_value(self, doctype: str, fieldname: str, cache: bool = True):
+	def get_single_value(
+		self,
+		doctype: str,
+		fieldname: str,
+		cache: bool = True,
+		*,
+		debug=False,
+		for_update=False,
+		run=True,
+	):
 		"""Get property of Single DocType. Cache locally by default
 
 		:param doctype: DocType of the single object whose value is requested
@@ -874,17 +896,23 @@ class Database:
 		        # Get the default value of the company from the Global Defaults doctype.
 		        company = frappe.db.get_single_value('Global Defaults', 'default_company')
 		"""
-		if cache and fieldname in self.value_cache[doctype]:
+		from frappe.model.meta import get_default_df
+
+		if cache and not for_update and run and fieldname in self.value_cache[doctype]:
 			return self.value_cache[doctype][fieldname]
 
 		val = frappe.qb.get_query(
 			table="Singles",
 			filters={"doctype": doctype, "field": fieldname},
 			fields="value",
-		).run()
+			for_update=for_update,
+		).run(debug=debug, run=run)
+		if not run:
+			return val
+
 		val = val[0][0] if val else None
 
-		df = frappe.get_meta(doctype).get_field(fieldname)
+		df = frappe.get_meta(doctype).get_field(fieldname) or get_default_df(fieldname)
 
 		if not df:
 			frappe.throw(
@@ -895,7 +923,8 @@ class Database:
 
 		val = cast_fieldtype(df.fieldtype, val)
 
-		self.value_cache[doctype][fieldname] = val
+		if cache and not for_update and run:
+			self.value_cache[doctype][fieldname] = val
 
 		return val
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -180,10 +180,39 @@ class TestDB(IntegrationTestCase):
 		self.assertEqual(lang, frappe.db.get_single_value("System Settings", "language"))
 		self.assertEqual(date_format, frappe.db.get_single_value("System Settings", "date_format"))
 
+	def test_casted_get_value_singles(self):
+		telemetry = frappe.db.get_value("System Settings", None, "enable_telemetry")
+		self.assertEqual(type(telemetry), int)
+		telemetry = frappe.db.get_value("System Settings", "System Settings", "enable_telemetry")
+		self.assertEqual(type(telemetry), int)
+
+		# Edge case in calling get_value
+		dt_name = frappe.db.get_value("DocType", "DocType", "name")
+		self.assertEqual(dt_name, "DocType")
+
+		timestamp = frappe.db.get_value("System Settings", None, "modified")
+		self.assertEqual(type(timestamp), datetime.datetime)
+
 	def test_singles_get_values_variant(self):
 		[[lang, date_format]] = frappe.db.get_values("System Settings", fieldname=["language", "date_format"])
 		self.assertEqual(lang, frappe.db.get_single_value("System Settings", "language"))
 		self.assertEqual(date_format, frappe.db.get_single_value("System Settings", "date_format"))
+
+	def test_get_value_casts_singles(self):
+		doc = frappe.get_doc("System Settings")
+		results = frappe.db.get_value("System Settings", None, ["language", "date_format"], as_dict=True)
+		self.assertEqual(doc.language, results.language)
+		self.assertEqual(doc.date_format, results.date_format)
+
+		# Multiple fields as ordered result
+		doc = frappe.get_doc("System Settings")
+		[lang, date_format] = frappe.db.get_value("System Settings", None, ["language", "date_format"])
+		self.assertEqual(doc.language, lang)
+		self.assertEqual(doc.date_format, date_format)
+
+		# single field as dict
+		results = frappe.db.get_value("System Settings", None, "enable_telemetry", as_dict=True)
+		self.assertEqual(results, {"enable_telemetry": doc.enable_telemetry})
 
 	def test_log_touched_tables(self):
 		frappe.flags.in_migrate = True


### PR DESCRIPTION
BREAKING CHANGE.

`db.get_value` will now effectively work like `db.get_single_value` i.e. returned values will be casted according to field types. 

This can likely break existing code, but this behaviour has caused more bugs. So someday we have to deal with it.

Also depracated this behaviour, it won't be removed ever because it's such an old behaviour but expect warnings in log to migrate to `db.get_single_value`.


Updated https://github.com/frappe/frappe/wiki/Migrating-to-nightly-version 