### PR TITLE
feat: Enable _doc_before_save for child documents

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1298,16 +1298,17 @@ class Document(BaseDocument):
 
 		try:
 			self._doc_before_save = frappe.get_doc(self.doctype, self.name, for_update=True)
-			# Match the previous doc for all child tables, so we can use get_doc_before_save() or has_value_changed() on them
-			for child in self._get_table_fields():
-				for row in self.get(child.fieldname):
-					row._doc_before_save = next((d for d in self._doc_before_save.get(child.fieldname, []) if d.name == row.name), None)
-					
 		except frappe.DoesNotExistError:
 			if raise_exception:
 				raise
 
-			frappe.clear_last_message()
+			return frappe.clear_last_message()
+
+		for fieldname in self._table_fieldnames:
+			for row in self.get(fieldname):
+				row._doc_before_save = next(
+					(d for d in self._doc_before_save.get(fieldname, []) if d.name == row.name), None
+				)
 
 	def run_post_save_methods(self):
 		"""Run standard methods after `INSERT` or `UPDATE`. Standard Methods are:

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1298,6 +1298,11 @@ class Document(BaseDocument):
 
 		try:
 			self._doc_before_save = frappe.get_doc(self.doctype, self.name, for_update=True)
+			# Match the previous doc for all child tables, so we can use get_doc_before_save() or has_value_changed() on them
+			for child in self._get_table_fields():
+				for row in self.get(child.fieldname):
+					row._doc_before_save = next((x for x in self._doc_before_save.get(child.fieldname) if x.name == row.name), None)
+					
 		except frappe.DoesNotExistError:
 			if raise_exception:
 				raise

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1307,7 +1307,7 @@ class Document(BaseDocument):
 		for fieldname in self._table_fieldnames:
 			for row in self.get(fieldname):
 				row._doc_before_save = next(
-					(d for d in self._doc_before_save.get(fieldname, []) if d.name == row.name), None
+					(d for d in (self._doc_before_save.get(fieldname) or []) if d.name == row.name), None
 				)
 
 	def run_post_save_methods(self):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1301,7 +1301,7 @@ class Document(BaseDocument):
 			# Match the previous doc for all child tables, so we can use get_doc_before_save() or has_value_changed() on them
 			for child in self._get_table_fields():
 				for row in self.get(child.fieldname):
-					row._doc_before_save = next((x for x in self._doc_before_save.get(child.fieldname) if x.name == row.name), None)
+					row._doc_before_save = next((d for d in self._doc_before_save.get(child.fieldname, []) if d.name == row.name), None)
 					
 		except frappe.DoesNotExistError:
 			if raise_exception:

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -143,6 +143,16 @@ class TestDocument(IntegrationTestCase):
 		self.assertFalse(d.has_value_changed("creation"))
 		self.assertFalse(d.has_value_changed("event_type"))
 
+		user = frappe.get_doc("User", "Administrator")
+		user.load_doc_before_save()
+		role1 = user.roles[0]
+		role2 = user.roles[1]
+
+		role1.role = "New Role"
+
+		self.assertTrue(role1.has_value_changed("role"))
+		self.assertFalse(role2.has_value_changed("role"))
+
 	def test_mandatory(self):
 		# TODO: recheck if it is OK to force delete
 		frappe.delete_doc_if_exists("User", "test_mandatory@example.com", 1)


### PR DESCRIPTION
Right now, calling `get_doc_before_save()` on a child document will not work since the relevant variable `_doc_before_save` is not set for child table documents, only for the parent.

As a result, derived functions such as `get_value_before_save()` and `has_value_changed()` also do not work.

Example:
```python
def test(self):
  for row in self.items:
    print(row.get_doc_before_save()) # -> None
    print(row.get_value_before_save("rate")) # -> None
    print(row.has_value_changed("rate")) # -> Always True (because the value is compared to None)
```

This commit will match the items of all child tables to their doc_before_save, thus fixing the aforementioned methods without introducing an additional database query.

There will be a slight performance impact as we have to loop through all the child rows in all the child tables of a document. However, I tested this by calling `frappe.get_doc()` 10,000 times, and it didn't seem to have a significant impact.