### PR TITLE
fix: add Translator role to Translation DocType

### DIFF
--- a/frappe/core/doctype/translation/translation.json
+++ b/frappe/core/doctype/translation/translation.json
@@ -101,6 +101,18 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Translator",
+   "share": 1,
+   "write": 1
   }
  ],
  "sort_field": "creation",


### PR DESCRIPTION
Add the Translator role to DocType Translation, allowing users with the Translator role to add and delete translations.