### PR TITLE
feat(recorder): remove strip_dirs in Recorder python cProcfile

### DIFF
--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -252,9 +252,7 @@ class Recorder:
 		if self.config.profile or self.profiler:
 			self.profiler.disable()
 			profiler_output = io.StringIO()
-			pstats.Stats(self.profiler, stream=profiler_output).strip_dirs().sort_stats(
-				"cumulative"
-			).print_stats(200)
+			pstats.Stats(self.profiler, stream=profiler_output).sort_stats("cumulative").print_stats(200)
 			profile = profiler_output.getvalue()
 			profiler_output.close()
 			return profile


### PR DESCRIPTION
> Flowing Review :

Simply remove `strip_dirs`


> Please provide enough information so that others can review your pull request:

In Recorder, as it is a real master feature to debug what happen on request on Frappe, there is with cProfile a possible missing feature that allow to display full path of python files used.

My use case is : 

- with custom app, when there are classes overrides, the override class can have the same file name as the original one (it's a current best practice to keep original project directory and file structure to keep tracks of what custom app changes)

With the actual recorder output, it's not easy to find if it's "core class" called or an override class that come from custom application

> Explain the **details** for making this change. What existing problem does the pull request solve?

**Outdated**
This PR will add a checkbox on Recorder start process to ask it complete file path have to be outputted

> Screenshots/GIFs

<img width="836" height="740" alt="image" src="https://github.com/user-attachments/assets/42816fce-5219-45ba-9a75-4eadb66143a3" />

If checked, result will be 
<img width="925" height="528" alt="image" src="https://github.com/user-attachments/assets/dc6dbade-511f-4ca0-8d37-04c588cb4a15" />


else, it's like before


Security note : as this Doctype is reserved to Administrator, it's not a problem regarding displaying path of python file called

Note to reviewer : If you merge this PR, could you please add tag to backport in version-15 ?


