### PR TITLE
feat: Allow multi-file upload and folder selection in Attach field

### DIFF
--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -69,7 +69,9 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 	}
 	set_upload_options() {
 		let options = {
-			allow_multiple: false,
+			allow_multiple: true,
+			folder: this.df.folder || "Home/Attachments",
+			allow_folder_creation: true,
 			on_success: (file) => {
 				this.on_upload_complete(file);
 				this.toggle_reload_button();
@@ -136,11 +138,21 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 
 	async on_upload_complete(attachment) {
 		if (this.frm) {
-			await this.parse_validate_and_set_in_model(attachment.file_url);
-			this.frm.attachments.update_attachment(attachment);
+			const attachments = Array.isArray(attachment) ? attachment : [attachment];
+			for (const att of attachments) {
+				await this.parse_validate_and_set_in_model(att.file_url);
+				this.frm.attachments.update_attachment(att);
+			}
+			if (attachments.length > 0) {
+				this.set_value(attachments[0].file_url);
+			}
 			this.frm.doc.docstatus == 1 ? this.frm.save("Update") : this.frm.save();
+		} else {
+			const attachments = Array.isArray(attachment) ? attachment : [attachment];
+			if (attachments.length > 0) {
+				this.set_value(attachments[0].file_url);
+			}
 		}
-		this.set_value(attachment.file_url);
 	}
 
 	toggle_reload_button() {

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -239,6 +239,8 @@ frappe.ui.form.Attachments = class Attachments {
 			docname: this.frm.docname,
 			frm: this.frm,
 			folder: "Home/Attachments",
+			allow_multiple: true,
+			allow_folder_creation: true,
 			on_success: (file_doc) => {
 				this.attachment_uploaded(file_doc);
 			},
@@ -255,11 +257,14 @@ frappe.ui.form.Attachments = class Attachments {
 	}
 	attachment_uploaded(attachment) {
 		this.dialog && this.dialog.hide();
-		this.update_attachment(attachment);
+		const attachments = Array.isArray(attachment) ? attachment : [attachment];
+		for (const att of attachments) {
+			this.update_attachment(att);
+		}
 		this.frm.sidebar.reload_docinfo();
 
-		if (this.fieldname) {
-			this.frm.set_value(this.fieldname, attachment.file_url);
+		if (this.fieldname && attachments.length > 0) {
+			this.frm.set_value(this.fieldname, attachments[0].file_url);
 		}
 	}
 	update_attachment(attachment) {


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes

Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation
- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md
- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

**Branch to be merged in:** `develop`

**PR name:** `feat: Allow multi-file upload and folder selection in Attach field`

### Problem Solved

This PR improves the usability of the "Attach" and "Attach Image" fields in Frappe, which previously had the following limitations:

- Only single file uploads were supported.
- Folder selection was limited to either `public` or `private`.
- Users couldn’t create or select custom folders during the upload process.

These constraints made file organization difficult and inefficient, particularly when working with multiple attachments or structured directories.

### Details of the Change

This enhancement introduces the following features to the "Attach" field:

- **Multi-File Upload:** Users can now upload multiple files in a single action.
- **Custom Folder Selection:** Users can specify a target folder path for uploaded files (e.g., `/files/invoices/`).
- **Folder Creation Support:** Users can create new folders directly from the file upload dialog.

These changes provide better control and flexibility for managing files and improve the overall user experience in document-heavy workflows.

### Tests

Functionality has been tested in a local environment and works as expected. UI and unit tests have not been executed as part of this submission.

### Documentation

Documentation for the "Attach" field should be updated to reflect the new capabilities: multi-file upload, custom folder selection, and in-dialog folder creation.


**closes #33299**
