### PR TITLE
feat: Add extraction for quick_list labels in workspace

### DIFF
--- a/frappe/gettext/extractors/workspace.py
+++ b/frappe/gettext/extractors/workspace.py
@@ -68,6 +68,16 @@ def extract(fileobj, *args, **kwargs):
 		for shortcut in data.get("shortcuts", [])
 		if shortcut.get("format")
 	)
+	yield from (
+		(
+			None,
+			"_",
+			quick_list.get("label"),
+			[f"Label of a quick_list in the {workspace_name} Workspace"],
+		)
+		for quick_list in data.get("quick_lists", [])
+		if quick_list.get("label")
+	)
 
 	content = json.loads(data.get("content", "[]"))
 	for item in content:


### PR DESCRIPTION
Added the extractor for quick_list labels in workspaces.
This doesn't add any new translation strings to this project, but it does in frappe/hrms.

no-docs