### PR TITLE
feat: export selected custom fields

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -247,61 +247,68 @@ frappe.ui.form.on("Customize Form", {
 							doctype: "Custom Field",
 							filters: { dt: frm.doc.doc_type },
 							fields: ["fieldname", "label", "fieldtype"],
-							order_by: "idx"
+							order_by: "idx",
 						},
-						callback: function(r) {
+						callback: function (r) {
 							let custom_fields = r.message || [];
-							
-							let custom_fields_options = custom_fields.map(field => ({
+
+							let custom_fields_options = custom_fields.map((field) => ({
 								label: `${field.label || field.fieldname}`,
 								value: field.fieldname,
-								description: `Type: ${field.fieldtype}`
+								description: `Type: ${field.fieldtype}`,
 							}));
 
-							let default_custom_fields = custom_fields.map(f => f.fieldname).join(",");
+							let default_custom_fields = custom_fields
+								.map((f) => f.fieldname)
+								.join(",");
 
-							frappe.prompt([
-								{
-									fieldtype: "Link",
-									fieldname: "module",
-									options: "Module Def",
-									label: __("Module to Export"),
-									reqd: 1,
+							frappe.prompt(
+								[
+									{
+										fieldtype: "Link",
+										fieldname: "module",
+										options: "Module Def",
+										label: __("Module to Export"),
+										reqd: 1,
+									},
+									{
+										fieldtype: "MultiSelect",
+										fieldname: "custom_fields",
+										label: __("Custom Fields to Export"),
+										description: __(
+											"Select which custom fields to include in the export. Leave empty to export all custom fields."
+										),
+										options: custom_fields_options,
+										default: default_custom_fields,
+									},
+									{
+										fieldtype: "Check",
+										fieldname: "sync_on_migrate",
+										label: __("Sync on Migrate"),
+										default: 1,
+									},
+									{
+										fieldtype: "Check",
+										fieldname: "with_permissions",
+										label: __("Export Custom Permissions"),
+										default: 0,
+									},
+								],
+								function (data) {
+									frappe.call({
+										method: "frappe.modules.utils.export_customizations",
+										args: {
+											doctype: frm.doc.doc_type,
+											module: data.module,
+											sync_on_migrate: data.sync_on_migrate,
+											with_permissions: data.with_permissions,
+											custom_fields: data.custom_fields || "",
+										},
+									});
 								},
-								{
-									fieldtype: "MultiSelect",
-									fieldname: "custom_fields",
-									label: __("Custom Fields to Export"),
-									description: __("Select which custom fields to include in the export. Leave empty to export all custom fields."),
-									options: custom_fields_options,
-									default: default_custom_fields,
-								},
-								{
-									fieldtype: "Check",
-									fieldname: "sync_on_migrate",
-									label: __("Sync on Migrate"),
-									default: 1,
-								},
-								{
-									fieldtype: "Check",
-									fieldname: "with_permissions",
-									label: __("Export Custom Permissions"),
-									default: 0,
-								},
-							], function(data) {
-								frappe.call({
-									method: "frappe.modules.utils.export_customizations",
-									args: {
-										doctype: frm.doc.doc_type,
-										module: data.module,
-										sync_on_migrate: data.sync_on_migrate,
-										with_permissions: data.with_permissions,
-										custom_fields: data.custom_fields || ""
-									}
-								});
-								
-							}, __("Select Module"));
-						}
+								__("Select Module")
+							);
+						},
 					});
 				},
 				__("Actions")

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -299,6 +299,7 @@ frappe.ui.form.on("Customize Form", {
 										custom_fields: data.custom_fields || ""
 									}
 								});
+								
 							}, __("Select Module"));
 						}
 					});

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -241,44 +241,67 @@ frappe.ui.form.on("Customize Form", {
 			frm.add_custom_button(
 				__("Export Customizations"),
 				function () {
-					frappe.prompt(
-						[
-							{
-								fieldtype: "Link",
-								fieldname: "module",
-								options: "Module Def",
-								label: __("Module to Export"),
-								reqd: 1,
-							},
-							{
-								fieldtype: "Check",
-								fieldname: "sync_on_migrate",
-								label: __("Sync on Migrate"),
-								default: 1,
-							},
-							{
-								fieldtype: "Check",
-								fieldname: "with_permissions",
-								label: __("Export Custom Permissions"),
-								description: __(
-									"Exported permissions will be force-synced on every migrate overriding any other customization."
-								),
-								default: 0,
-							},
-						],
-						function (data) {
-							frappe.call({
-								method: "frappe.modules.utils.export_customizations",
-								args: {
-									doctype: frm.doc.doc_type,
-									module: data.module,
-									sync_on_migrate: data.sync_on_migrate,
-									with_permissions: data.with_permissions,
-								},
-							});
+					frappe.call({
+						method: "frappe.client.get_list",
+						args: {
+							doctype: "Custom Field",
+							filters: { dt: frm.doc.doc_type },
+							fields: ["fieldname", "label", "fieldtype"],
+							order_by: "idx"
 						},
-						__("Select Module")
-					);
+						callback: function(r) {
+							let custom_fields = r.message || [];
+							
+							let custom_fields_options = custom_fields.map(field => ({
+								label: `${field.label || field.fieldname}`,
+								value: field.fieldname,
+								description: `Type: ${field.fieldtype}`
+							}));
+
+							let default_custom_fields = custom_fields.map(f => f.fieldname).join(",");
+
+							frappe.prompt([
+								{
+									fieldtype: "Link",
+									fieldname: "module",
+									options: "Module Def",
+									label: __("Module to Export"),
+									reqd: 1,
+								},
+								{
+									fieldtype: "MultiSelect",
+									fieldname: "custom_fields",
+									label: __("Custom Fields to Export"),
+									description: __("Select which custom fields to include in the export. Leave empty to export all custom fields."),
+									options: custom_fields_options,
+									default: default_custom_fields,
+								},
+								{
+									fieldtype: "Check",
+									fieldname: "sync_on_migrate",
+									label: __("Sync on Migrate"),
+									default: 1,
+								},
+								{
+									fieldtype: "Check",
+									fieldname: "with_permissions",
+									label: __("Export Custom Permissions"),
+									default: 0,
+								},
+							], function(data) {
+								frappe.call({
+									method: "frappe.modules.utils.export_customizations",
+									args: {
+										doctype: frm.doc.doc_type,
+										module: data.module,
+										sync_on_migrate: data.sync_on_migrate,
+										with_permissions: data.with_permissions,
+										custom_fields: data.custom_fields || ""
+									}
+								});
+							}, __("Select Module"));
+						}
+					});
 				},
 				__("Actions")
 			);

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -53,7 +53,7 @@ def get_doc_module(module: str, doctype: str, name: str) -> "ModuleType":
 
 @frappe.whitelist()
 def export_customizations(
-	module: str, doctype: str, sync_on_migrate: bool = False, with_permissions: bool = False
+	module: str, doctype: str, sync_on_migrate: bool = False, with_permissions: bool = False, custom_fields: str | None = None
 ):
 	"""Export Custom Field and Property Setter for the current document to the app folder.
 	This will be synced with bench migrate"""
@@ -64,8 +64,16 @@ def export_customizations(
 	if not frappe.conf.developer_mode:
 		frappe.throw(_("Only allowed to export customizations in developer mode"))
 
+	all_custom_fields = frappe.get_all("Custom Field", fields="*", filters={"dt": doctype}, order_by="name")
+	
+	if custom_fields:
+		selected_fieldnames = set([f.strip() for f in custom_fields.split(',') if f.strip()])
+		selected_custom_fields = [cf for cf in all_custom_fields if cf.fieldname in selected_fieldnames]
+	else:
+		selected_custom_fields = all_custom_fields
+
 	custom = {
-		"custom_fields": frappe.get_all("Custom Field", fields="*", filters={"dt": doctype}, order_by="name"),
+		"custom_fields": selected_custom_fields,
 		"property_setters": frappe.get_all(
 			"Property Setter", fields="*", filters={"doc_type": doctype}, order_by="name"
 		),
@@ -82,7 +90,7 @@ def export_customizations(
 
 	# also update the custom fields and property setters for all child tables
 	for d in frappe.get_meta(doctype).get_table_fields():
-		export_customizations(module, d.options, sync_on_migrate, with_permissions)
+		export_customizations(module, d.options, sync_on_migrate, with_permissions, custom_fields)
 
 	if custom["custom_fields"] or custom["property_setters"] or custom["custom_perms"]:
 		folder_path = os.path.join(get_module_path(module), "custom")

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -72,6 +72,7 @@ def export_customizations(
 	else:
 		selected_custom_fields = all_custom_fields
 
+
 	custom = {
 		"custom_fields": selected_custom_fields,
 		"property_setters": frappe.get_all(

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -53,7 +53,11 @@ def get_doc_module(module: str, doctype: str, name: str) -> "ModuleType":
 
 @frappe.whitelist()
 def export_customizations(
-	module: str, doctype: str, sync_on_migrate: bool = False, with_permissions: bool = False, custom_fields: str | None = None
+	module: str,
+	doctype: str,
+	sync_on_migrate: bool = False,
+	with_permissions: bool = False,
+	custom_fields: str | None = None,
 ):
 	"""Export Custom Field and Property Setter for the current document to the app folder.
 	This will be synced with bench migrate"""
@@ -65,13 +69,12 @@ def export_customizations(
 		frappe.throw(_("Only allowed to export customizations in developer mode"))
 
 	all_custom_fields = frappe.get_all("Custom Field", fields="*", filters={"dt": doctype}, order_by="name")
-	
+
 	if custom_fields:
-		selected_fieldnames = set([f.strip() for f in custom_fields.split(',') if f.strip()])
+		selected_fieldnames = set([f.strip() for f in custom_fields.split(",") if f.strip()])
 		selected_custom_fields = [cf for cf in all_custom_fields if cf.fieldname in selected_fieldnames]
 	else:
 		selected_custom_fields = all_custom_fields
-
 
 	custom = {
 		"custom_fields": selected_custom_fields,


### PR DESCRIPTION
### Summary

Enhances the "Export Customizations" functionality in Customize Form by allowing users to select specific custom fields for export.

### Changes

- Added UI MultiSelect for selecting custom fields based on the selected DocType.
- Modified `export_customizations` method to accept a `custom_fields` parameter.
- Ensured backward compatibility (exports all fields when none selected).
- Tested on version-15 instance.

### Related Issue

Fixes #33200
