### PR TITLE
fix: dont trigger change when date/datetime is on grid

### DIFF
--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -1,5 +1,6 @@
 frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlData {
 	static trigger_change_on_input_event = false;
+	on_grid = false;
 	make_input() {
 		super.make_input();
 		this.make_picker();
@@ -68,7 +69,9 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 			maxDate: this.df.max_date,
 			firstDay: frappe.datetime.get_first_day_of_the_week_index(),
 			onSelect: () => {
-				this.$input.trigger("change");
+				if (!this.on_grid) {
+					this.$input.trigger("change");
+				}
 			},
 			onShow: () => {
 				this.datepicker.$datepicker

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -1,4 +1,5 @@
 frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.ControlDate {
+	on_grid = false;
 	set_formatted_input(value) {
 		if (this.timepicker_only) return;
 		if (!this.datepicker) return;

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1163,7 +1163,7 @@ export default class GridRow {
 			grid_row: this,
 			value: this.doc[df.fieldname],
 		});
-
+		field.on_grid = true;
 		// sync get_query
 		field.get_query = this.grid.get_field(df.fieldname).get_query;
 		// df.onchange is common for all rows in grid


### PR DESCRIPTION
Grid_row has a change event, when air-picker selectDate function is used it calls the onSelect function mentioned 
in datepicker options for date and datetime controls.
Modern versions of the air-picker library provide a `{silent: true}` option which help us skip calling onSelect function which causes the recursion. Updating the library may requires more changes hence avoiding that

Before

https://github.com/user-attachments/assets/97c8f2b2-5263-457f-babe-e8429981d386

After

https://github.com/user-attachments/assets/bc19377a-a284-4cc0-b4a6-518813e82f11

Ref ticket: https://support.frappe.io/helpdesk/tickets/41793