### PR TITLE
fix(test): insert translation

### DIFF
--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -394,7 +394,7 @@ def insert_translations():
 	]
 
 	for doc in translation:
-		if not frappe.db.exists("doc"):
+		if not frappe.db.exists(doc):
 			frappe.get_doc(doc).insert()
 
 


### PR DESCRIPTION
`control_link.js` in Cypress is failing because of this