### PR TITLE
fix: add module information to property setter

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1171,7 +1171,7 @@ def get_newargs(fn: Callable, kwargs: dict[str, Any]) -> dict[str, Any]:
 
 
 def make_property_setter(
-	args, ignore_validate=False, validate_fields_for_doctype=True, is_system_generated=True
+	args, ignore_validate=False, validate_fields_for_doctype=True, is_system_generated=True, *, module=None
 ):
 	"""Create a new **Property Setter** (for overriding DocType and DocField properties).
 
@@ -1210,6 +1210,7 @@ def make_property_setter(
 				"doctype": "Property Setter",
 				"doctype_or_field": args.doctype_or_field,
 				"doc_type": doctype,
+				"module": module,
 				"field_name": args.fieldname,
 				"row_name": args.row_name,
 				"property": args.property,


### PR DESCRIPTION
**Issue:** When creating `Property Setters` from a **Custom App** using `after_install` or any other method, the **Module** cannot be set.

> [!NOTE]
> Backport to V-15 and V-14 