### PR TITLE
fix(minor): UI fixes

### DIFF
--- a/frappe/core/doctype/file/file.js
+++ b/frappe/core/doctype/file/file.js
@@ -47,6 +47,7 @@ frappe.ui.form.on("File", {
 			$preview = $(`<div class="img_preview">
 				<img
 					class="img-responsive"
+					style="max-width: 500px";
 					src="${frappe.utils.escape_html(frm.doc.file_url)}"
 					onerror="${frm.toggle_display("preview", false)}"
 				/>

--- a/frappe/public/scss/desk/list_sidebar.scss
+++ b/frappe/public/scss/desk/list_sidebar.scss
@@ -45,11 +45,9 @@
 				text-decoration: none;
 			}
 			.applied {
-				position: absolute;
-				left: 10px;
-				.icon use {
-					stroke-width: 2;
-				}
+				display: flex;
+				align-items: center;
+				margin-right: 5px;
 			}
 		}
 		.empty-state {


### PR DESCRIPTION
This PR fixes two small issues 
Before
Tick icon on list filter
<img width="205" height="167" alt="list filter tick icon broken " src="https://github.com/user-attachments/assets/a3aa6c87-a675-42ca-887d-066135e7367b" />



Image preview in File Form
<img width="1230" height="900" alt="image preview too big" src="https://github.com/user-attachments/assets/e8ed7f7e-56f3-43c2-ae86-5a67f8f32725" />

After
Tick icon on list filter
<img width="210" height="162" alt="list filter tick fixed" src="https://github.com/user-attachments/assets/1b1f826c-e074-4422-a771-1db577992c8a" />

Image preview in File Form
<img width="1157" height="713" alt="file preview fixed" src="https://github.com/user-attachments/assets/ac79a5bf-dd60-4aa6-8369-4a5793c17dd4" />
