### PR TITLE
fix: query report export dialog not updating on switching to other report

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -167,6 +167,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.show_save = false;
 		this.menu_items = this.get_menu_items();
 		this.datatable = null;
+		this.export_dialog = null;
 
 		frappe.run_serially([
 			() => this.get_report_doc(),


### PR DESCRIPTION
Resolved the issue where switching from one report to another, the title and other filters don't get updated on the Export Dialog.

https://github.com/user-attachments/assets/4d9e9e0b-6d27-429c-b6b1-4699aaa82c58

Resolved:

https://github.com/user-attachments/assets/78f8d940-f097-4f13-99f8-2138cae0c746

