### PR TITLE
fix: dont let email queue stay in Sending status

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -180,7 +180,7 @@ def get_queue():
 	)
 
 
-def mark_sending_emails_as_not_sent():
+def retry_sending_emails():
 	emails_in_sending = frappe.get_all(
 		"Email Queue", filters={"status": "Sending"}, fields=["name", "modified"]
 	)

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+from datetime import timedelta
 
 import frappe
 from frappe import _, msgprint
@@ -177,3 +178,27 @@ def get_queue():
 		{"now": now_datetime()},
 		as_dict=True,
 	)
+
+
+def mark_sending_emails_as_not_sent():
+	emails_in_sending = frappe.get_all(
+		"Email Queue", filters={"status": "Sending"}, fields=["name", "modified"]
+	)
+	for e in emails_in_sending:
+		if now_datetime() - e["modified"] > timedelta(minutes=15):
+			update_fields = {}
+			email_queue = frappe.get_doc("Email Queue", e["name"])
+			sent_to_atleast_one_recipient = any(
+				rec.recipient for rec in email_queue.recipients if rec.is_mail_sent()
+			)
+			if email_queue.retry < cint(frappe.db.get_system_setting("email_retry_limit")) or 3:
+				update_fields.update(
+					{
+						"status": "Partially Sent" if sent_to_atleast_one_recipient else "Not Sent",
+						"retry": email_queue.retry + 1,
+					}
+				)
+			else:
+				update_fields.update({"status": "Error"})
+				update_fields.update({"error": frappe.get_traceback()})
+			email_queue.update_status(**update_fields, commit=True)

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 import frappe
 from frappe import _, msgprint
-from frappe.email.doctype.email_queue.email_queue import get_email_retry_limit
 from frappe.utils import cint, cstr, get_url, now_datetime
 from frappe.utils.data import getdate
 from frappe.utils.verified_command import get_signed_params, verify_request
@@ -192,7 +191,7 @@ def retry_sending_emails():
 			sent_to_atleast_one_recipient = any(
 				rec.recipient for rec in email_queue.recipients if rec.is_mail_sent()
 			)
-			if email_queue.retry < get_email_retry_limit():
+			if email_queue.retry < cint(frappe.db.get_system_setting("email_retry_limit")) or 3:
 				update_fields.update(
 					{
 						"status": "Partially Sent" if sent_to_atleast_one_recipient else "Not Sent",
@@ -201,5 +200,5 @@ def retry_sending_emails():
 				)
 			else:
 				update_fields.update({"status": "Error"})
-				update_fields.update({"error": "Retry limit execedded"})
+				update_fields.update({"error": "Retry Limit Exceeded"})
 			email_queue.update_status(**update_fields, commit=True)

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -217,6 +217,7 @@ scheduler_events = {
 	},
 	"all": [
 		"frappe.email.queue.flush",
+		"frappe.email.queue.mark_sending_emails_as_not_sent",
 		"frappe.monitor.flush",
 		"frappe.integrations.doctype.google_calendar.google_calendar.sync",
 	],

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -217,7 +217,7 @@ scheduler_events = {
 	},
 	"all": [
 		"frappe.email.queue.flush",
-		"frappe.email.queue.mark_sending_emails_as_not_sent",
+		"frappe.email.queue.retry_sending_emails",
 		"frappe.monitor.flush",
 		"frappe.integrations.doctype.google_calendar.google_calendar.sync",
 	],


### PR DESCRIPTION
Email Queue get stuck in Sending state, where they are not retried by the flush job

Ref ticket https://support.frappe.io/helpdesk/tickets/42785 