### PR TITLE
fix: indicator translation

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -282,7 +282,10 @@ frappe.ui.form.Toolbar = class Toolbar {
 		if (
 			this.frm.save_disabled &&
 			indicator &&
-			[__("Saved"), __("Not Saved")].includes(indicator[0])
+			[
+				__("Saved", null, this.frm.doctype),
+				__("Not Saved", null, this.frm.doctype),
+			].includes(indicator[0])
 		) {
 			return;
 		}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1158,11 +1158,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		];
 		const title = docstatus_description[doc.docstatus || 0];
 		if (indicator) {
-			return `<span class="indicator-pill ${
-				indicator[1]
-			} filterable no-indicator-dot ellipsis"
+			return `<span class="indicator-pill ${indicator[1]} filterable no-indicator-dot ellipsis"
 				data-filter='${indicator[2]}' title='${title}'>
-				<span class="ellipsis"> ${__(indicator[0])}</span>
+				<span class="ellipsis"> ${indicator[0]}</span>
 			</span>`;
 		}
 		return "";
@@ -1171,7 +1169,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	get_indicator_dot(doc) {
 		const indicator = frappe.get_indicator(doc, this.doctype);
 		if (!indicator) return "";
-		return `<span class='indicator ${indicator[1]}' title='${__(indicator[0])}'></span>`;
+		return `<span class='indicator ${indicator[1]}' title='${indicator[0]}'></span>`;
 	}
 
 	get_image_url(doc) {

--- a/frappe/public/js/frappe/model/indicator.js
+++ b/frappe/public/js/frappe/model/indicator.js
@@ -25,7 +25,7 @@ frappe.has_indicator = function (doctype) {
 
 frappe.get_indicator = function (doc, doctype, show_workflow_state) {
 	if (doc.__unsaved) {
-		return [__("Not Saved"), "orange"];
+		return [__("Not Saved", null, doctype), "orange"];
 	}
 
 	if (!doctype) doctype = doc.doctype;
@@ -64,25 +64,25 @@ frappe.get_indicator = function (doc, doctype, show_workflow_state) {
 			}
 			if (!colour) colour = "gray";
 
-			return [__(value), colour, workflow_fieldname + ",=," + value];
+			return [__(value, null, doctype), colour, workflow_fieldname + ",=," + value];
 		}
 	}
 
 	// draft if document is submittable
 	if (is_submittable && doc.docstatus == 0 && !settings.has_indicator_for_draft) {
-		return [__("Draft"), "red", "docstatus,=,0"];
+		return [__("Draft", null, doctype), "red", "docstatus,=,0"];
 	}
 
 	// cancelled
 	if (is_submittable && doc.docstatus == 2 && !settings.has_indicator_for_cancelled) {
-		return [__("Cancelled"), "red", "docstatus,=,2"];
+		return [__("Cancelled", null, doctype), "red", "docstatus,=,2"];
 	}
 
 	// based on document state
 	if (doc.status && meta && meta.states && meta.states.find((d) => d.title === doc.status)) {
 		let state = meta.states.find((d) => d.title === doc.status);
 		let color_class = frappe.scrub(state.color, "-");
-		return [__(doc.status), color_class, "status,=," + doc.status];
+		return [__(doc.status, null, doctype), color_class, "status,=," + doc.status];
 	}
 
 	if (settings.get_indicator) {
@@ -92,29 +92,33 @@ frappe.get_indicator = function (doc, doctype, show_workflow_state) {
 
 	// if submittable
 	if (is_submittable && doc.docstatus == 1) {
-		return [__("Submitted"), "blue", "docstatus,=,1"];
+		return [__("Submitted", null, doctype), "blue", "docstatus,=,1"];
 	}
 
 	// based on status
 	if (doc.status) {
-		return [__(doc.status), frappe.utils.guess_colour(doc.status), "status,=," + doc.status];
+		return [
+			__(doc.status, null, doctype),
+			frappe.utils.guess_colour(doc.status),
+			"status,=," + doc.status,
+		];
 	}
 
 	// based on enabled
 	if (frappe.meta.has_field(doctype, "enabled")) {
 		if (doc.enabled) {
-			return [__("Enabled"), "blue", "enabled,=,1"];
+			return [__("Enabled", null, doctype), "blue", "enabled,=,1"];
 		} else {
-			return [__("Disabled"), "grey", "enabled,=,0"];
+			return [__("Disabled", null, doctype), "grey", "enabled,=,0"];
 		}
 	}
 
 	// based on disabled
 	if (frappe.meta.has_field(doctype, "disabled")) {
 		if (doc.disabled) {
-			return [__("Disabled"), "grey", "disabled,=,1"];
+			return [__("Disabled", null, doctype), "grey", "disabled,=,1"];
 		} else {
-			return [__("Enabled"), "blue", "disabled,=,0"];
+			return [__("Enabled", null, doctype), "blue", "disabled,=,0"];
 		}
 	}
 };

--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -155,7 +155,7 @@ export default class QuickListWidget extends Widget {
 		if (indicator) {
 			$(`
 				<div class="status indicator-pill ${indicator[1]} ellipsis">
-					${__(indicator[0])}
+					${indicator[0]}
 				</div>
 			`).appendTo($quick_list_item);
 		}


### PR DESCRIPTION
- Use doctype as context for translating indicator

    This makes it easier to add correct translations. A short status word often has multiple meanings.

- Avoid double translation

    `frappe.get_indicator` already returns a translated label. We should not translate it again, because double translation can have weird results for some words, e.g. Left (en) -> Links (en/de) -> Verknüpfungen (de).
