### PR TITLE
feat: include hidden columns in query report export file

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -330,6 +330,7 @@ def export_query():
 	include_indentation = form_params.include_indentation
 	include_filters = form_params.include_filters
 	visible_idx = form_params.visible_idx
+	include_hidden_columns = form_params.include_hidden_columns
 
 	if isinstance(visible_idx, str):
 		visible_idx = json.loads(visible_idx)
@@ -347,7 +348,11 @@ def export_query():
 
 	format_fields(data)
 	xlsx_data, column_widths = build_xlsx_data(
-		data, visible_idx, include_indentation, include_filters=include_filters
+		data,
+		visible_idx,
+		include_indentation,
+		include_filters=include_filters,
+		include_hidden_columns=include_hidden_columns,
 	)
 
 	if file_format_type == "CSV":
@@ -393,7 +398,14 @@ def format_fields(data: frappe._dict) -> None:
 					row[index] = round(row[index], col.get("precision"))
 
 
-def build_xlsx_data(data, visible_idx, include_indentation, include_filters=False, ignore_visible_idx=False):
+def build_xlsx_data(
+	data,
+	visible_idx,
+	include_indentation,
+	include_filters=False,
+	ignore_visible_idx=False,
+	include_hidden_columns=False,
+):
 	EXCEL_TYPES = (
 		str,
 		bool,
@@ -433,7 +445,7 @@ def build_xlsx_data(data, visible_idx, include_indentation, include_filters=Fals
 
 	column_data = []
 	for column in data.columns:
-		if column.get("hidden"):
+		if column.get("hidden") and not cint(include_hidden_columns):
 			continue
 		column_data.append(_(column.get("label")))
 		column_width = cint(column.get("width", 0))
@@ -449,7 +461,7 @@ def build_xlsx_data(data, visible_idx, include_indentation, include_filters=Fals
 			row_data = []
 			if isinstance(row, dict):
 				for col_idx, column in enumerate(data.columns):
-					if column.get("hidden"):
+					if column.get("hidden") and not cint(include_hidden_columns):
 						continue
 					label = column.get("label")
 					fieldname = column.get("fieldname")

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1622,6 +1622,27 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			});
 		}
 
+		if (this.report_settings.export_hidden_fields) {
+			const hidden_fields = [];
+			this.columns.forEach((column) => {
+				if (column.hidden) {
+					hidden_fields.push(column.label);
+				}
+			});
+			extra_fields.push(
+				{
+					fieldname: "column_break_1",
+					fieldtype: "Column Break",
+				},
+				{
+					label: __("Include hidden columns"),
+					fieldname: "include_hidden_columns",
+					description: __("Hidden columns include: {0}", [hidden_fields.join(", ")]),
+					fieldtype: "Check",
+				}
+			);
+		}
+
 		this.export_dialog = frappe.report_utils.get_export_dialog(
 			__(this.report_name),
 			extra_fields,
@@ -1629,6 +1650,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				file_format,
 				include_indentation,
 				include_filters,
+				include_hidden_columns,
 				csv_delimiter,
 				csv_quoting,
 				csv_decimal_sep,
@@ -1669,6 +1691,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					csv_decimal_sep,
 					include_indentation,
 					include_filters,
+					include_hidden_columns,
 				};
 
 				open_url_post(frappe.request.url, args);


### PR DESCRIPTION
Some reports may contain columns that are not required in Desk View but are needed in the Exported File.

For example, in the Trial Balance Report, the Account column already has the Account Name with Account Number; however, the user may require separate columns for Account Name and Account Number on the exported file.

Changes include:

- Added a field on Export Dialog, `Include hidden columns`, which, if enabled, will include the hidden fields of that Report in the Exported File. The names of the hidden fields are displayed in the description of the field. 
  
  <img width="1214" height="632" alt="image" src="https://github.com/user-attachments/assets/6353885d-ce3f-44ab-8964-010f9faaa13d" />

- To enable the `Include hidden columns` field on the export dialog, add the ~`export_hidden_fields`~ `export_hidden_cols`[^1] property and set it to `true` on the `.js` file of the Query Report.


[^1]: Changes made in PR #33350

<!-- no-docs -->
