### PR TITLE
fix: handle user does not exist when session resume

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -131,7 +131,7 @@ class LoginManager:
 				self.make_session(resume=True)
 				self.get_user_info()
 				self.set_user_info(resume=True)
-			except AttributeError:
+			except (AttributeError, frappe.DoesNotExistError):
 				self.user = "Guest"
 				self.get_user_info()
 				self.make_session()


### PR DESCRIPTION
### The Problem

Steps to replicate:

1. Login as a user, say `old@email.com`.
2. Rename yourself (your user), to let's say: `new@email.com`
3. Refresh

You should start getting `Internal Server Error` on production and this on local:

https://github.com/user-attachments/assets/48ff13fa-d79c-4f67-9299-5b0b66549962

This is because the cookies still contain the old user's info. If `LoginManager` tries to resume session with old credentials, a `DoesNotExist` exception is raised which is not handled. 

