### PR TITLE
fix: ignore validation in to, cc & bcc multiselect field in New Email modal

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -55,6 +55,7 @@ frappe.views.CommunicationComposer = class {
 				reqd: 0,
 				fieldname: "recipients",
 				default: this.get_default_recipients("recipients"),
+				ignore_validation: true,
 				onchange: function () {
 					me.sanitize_emails(this);
 				},
@@ -77,6 +78,7 @@ frappe.views.CommunicationComposer = class {
 				fieldtype: "MultiSelect",
 				fieldname: "cc",
 				default: this.get_default_recipients("cc"),
+				ignore_validation: true,
 				onchange: function () {
 					me.sanitize_emails(this);
 				},
@@ -86,6 +88,7 @@ frappe.views.CommunicationComposer = class {
 				fieldtype: "MultiSelect",
 				fieldname: "bcc",
 				default: this.get_default_recipients("bcc"),
+				ignore_validation: true,
 				onchange: function () {
 					me.sanitize_emails(this);
 				},


### PR DESCRIPTION
Steps to reproduce issue:
1. Open any doctype with `email` field set as random email which is not a contact or user
2. Click `+ New Email` and add another email in `to` screen hangs

Cause:
Since first email which gets added automatically is not a contact and when we add another existing email the option of the multiselect (to) field is set as `valid_emails` which is list of existing contacts and when `multiselect.js` validate method is called the random email first one is not part of this `valid_emails` list because of which it returns empty value and it goes on loop.

Fix:
Ignoring the validation make sense here since the `to`, `cc`, `bcc` can be any random emails it doesn't need to be part of contact emails.

multiselect.js validate method
<img width="892" height="552" alt="Screenshot 2025-07-15 at 5 37 34 PM" src="https://github.com/user-attachments/assets/9e910123-0540-4b37-9b16-7b913b77736f" />
