### PR TITLE
fix!: Send `now=True` emails using background jobs

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -759,7 +759,14 @@ class QueueBuilder:
 		if not queue_separately:
 			recipients = list(set(final_recipients + self.final_cc() + self.bcc))
 			q = EmailQueue.new({**queue_data, **{"recipients": recipients}}, ignore_permissions=True)
-			send_now and q.send()
+			if send_now:
+				frappe.enqueue_doc(
+					q.doctype,
+					q.name,
+					queue="short",
+					enqueue_after_commit=True,
+					at_front_when_starved=True,
+				)
 			return q
 		else:
 			if send_now and len(final_recipients) >= 1000:


### PR DESCRIPTION
fixes https://github.com/frappe/frappe/issues/33343 and https://github.com/frappe/frappe/pull/33308#discussion_r2207032848

This is mildly breaking:
1. The email is now sent via an immediately fired background job and never in same transaction.
2. It might not be sent if transaction is not commited.