### PR TITLE
fix: prevent random redirect on setup wizard even after all apps setup is done

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -281,13 +281,7 @@ frappe.Application = class Application {
 				frappe.dom.set_style(frappe.boot.print_css, "print-style");
 			}
 
-			let current_app = localStorage.current_app;
-			if (current_app) {
-				frappe.boot.setup_complete =
-					frappe.boot.setup_wizard_not_required_apps?.includes(current_app) ||
-					frappe.boot.setup_wizard_completed_apps?.includes(current_app);
-			}
-
+			frappe.boot.setup_complete = frappe.boot.sysdefaults["setup_complete"];
 			frappe.user.name = frappe.boot.user.name;
 			frappe.router.setup();
 		} else {


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

Partially addresses : https://github.com/frappe/frappe/issues/33298

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

After debugging the issue, I found that the [endpoint](https://github.com/frappe/frappe/blob/db5433a98dcfe4e0073f176076db19735ff1f63d/frappe/apps.py#L97) is called each time someone changes the app on the `/apps` page.

We already have an `is_setup_complete` function that is used throughout the codebase to identify if setup is complete. I have updated the code to use the same [variable](https://github.com/frappe/frappe/blob/db5433a98dcfe4e0073f176076db19735ff1f63d/frappe/boot.py#L49) here instead of the old condition.

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->

**Before:**

https://github.com/user-attachments/assets/82131df2-2033-4e16-8ef8-7f6761fda5ac

**After:**

https://github.com/user-attachments/assets/ab048747-a1b3-4011-b39b-eec95cf0545f