### PR TITLE
fix: export query report hidden columns

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1622,25 +1622,27 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			});
 		}
 
-		if (this.report_settings.export_hidden_fields) {
+		if (this.report_settings.export_hidden_cols) {
 			const hidden_fields = [];
 			this.columns.forEach((column) => {
 				if (column.hidden) {
 					hidden_fields.push(column.label);
 				}
 			});
-			extra_fields.push(
-				{
-					fieldname: "column_break_1",
-					fieldtype: "Column Break",
-				},
-				{
-					label: __("Include hidden columns"),
-					fieldname: "include_hidden_columns",
-					description: __("Hidden columns include: {0}", [hidden_fields.join(", ")]),
-					fieldtype: "Check",
-				}
-			);
+			if (hidden_fields.length) {
+				extra_fields.push(
+					{
+						fieldname: "column_break_1",
+						fieldtype: "Column Break",
+					},
+					{
+						label: __("Include hidden columns"),
+						fieldname: "include_hidden_columns",
+						description: __("Hidden columns include: {0}", [hidden_fields.join(", ")]),
+						fieldtype: "Check",
+					}
+				);
+			}
 		}
 
 		this.export_dialog = frappe.report_utils.get_export_dialog(


### PR DESCRIPTION
Changes include:
- Renamed the property from `export_hidden_fields` to `export_hidden_cols`.
- The `Include hidden columns` field will only appear on the dialog if hidden columns exist on the Query Report.

Ref: #33333 