### PR TITLE
Fix: Updated sidebar title to "Frappe App"

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar.js
@@ -203,7 +203,7 @@ frappe.ui.Sidebar = class Sidebar {
 			parent_pages = parent_pages.filter((p) => p.public && app_workspaces.includes(p.name));
 		}
 
-		this.build_sidebar_section("Frappe App", parent_pages);
+		this.build_sidebar_section("Frappe Dashboard", parent_pages);
 
 		// Scroll sidebar to selected page if it is not in viewport.
 		this.wrapper.find(".selected").length &&

--- a/frappe/public/js/frappe/ui/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar.js
@@ -203,7 +203,7 @@ frappe.ui.Sidebar = class Sidebar {
 			parent_pages = parent_pages.filter((p) => p.public && app_workspaces.includes(p.name));
 		}
 
-		this.build_sidebar_section("All", parent_pages);
+		this.build_sidebar_section("Frappe App", parent_pages);
 
 		// Scroll sidebar to selected page if it is not in viewport.
 		this.wrapper.find(".selected").length &&

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -387,6 +387,8 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			}
 		}
 	}
+	// Adds an option to generate a random password if user types "random"
+
 
 	make_random(txt) {
 		if (txt.toLowerCase().includes("random")) {

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -339,6 +339,8 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			});
 		}
 	}
+	// Adds calculator option to evaluate expressions typed in the search bar
+
 
 	make_calculator(txt) {
 		function getDecimalPlaces(num) {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Minor UI improvement: Updated the sidebar title from "All" to "Frappe App" in frappe/public/js/frappe/ui/sidebar.js to make the section label more descriptive.

Explain the details for making this change. What existing problem does the pull request solve?

This change improves UI clarity. The label "All" was generic and could confuse users. "Frappe App" provides a clearer context, enhancing user navigation within the sidebar.

Screenshots/GIFs

Not applicable – this is a single-line label change in the UI.