### PR TITLE
fix: allow login with email addresses containing apostrophes

### DIFF
--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -17,7 +17,7 @@ login.bind_events = function () {
 		event.preventDefault();
 		var args = {};
 		args.cmd = "login";
-		args.usr = frappe.utils.xss_sanitise(($("#login_email").val() || "").trim());
+		args.usr = ($("#login_email").val() || "").trim();
 		args.pwd = $("#login_password").val();
 		if (!args.usr || !args.pwd) {
 			{# striptags is used to remove newlines, e is used for escaping #}


### PR DESCRIPTION
## Problem
Users with apostrophes in their email addresses (e.g., `name'test@mail.com`) are unable to log into Frappe instances. The login form returns "Invalid Login. Try again." error even with correct credentials.

Apostrophes are valid characters in email addresses according to [RFC standards](https://www.rfc-editor.org/rfc/rfc5322#section-3.2.3) and should be accepted by Frappe Applications. 

## Root Cause
The issue is in `frappe/templates/includes/login/login.js` line 19, where the login form applies `frappe.utils.xss_sanitise()` to the email address:

```javascript
args.usr = frappe.utils.xss_sanitise(($("#login_email").val() || "").trim());
```

The `xss_sanitise` function escapes apostrophes to HTML entities (`'` → `&#x27;`), making the email address invalid for backend authentication.

## Solution
Remove the `xss_sanitise` call from the login form to make it consistent with other forms (signup, forgot password, email link login) which don't sanitize email addresses.

## Changes Made
- **File**: `frappe/templates/includes/login/login.js`
- **Line 19**: Removed `frappe.utils.xss_sanitise()` wrapper around email input
- **Before**: `args.usr = frappe.utils.xss_sanitise(($("#login_email").val() || "").trim());`
- **After**: `args.usr = ($("#login_email").val() || "").trim();`

## Security Impact
Low risk - email addresses don't typically contain HTML/JavaScript that needs sanitization, and the backend has proper validation measures in place. The backend authentication system (`User.find_by_credentials`) performs proper database queries and validation.

## Testing
- ✅ Users with apostrophes in email addresses can now log in successfully
- ✅ Users with regular email addresses continue to work as expected

**Before (Login fails):**
- User enters: `name'test@mail.com`
- Frontend sends: `name&#x27;test@mail.com`
- Result: "Invalid Login. Try again." error

**After (Login succeeds):**
- User enters: `name'test@mail.com`
- Frontend sends: `name'test@mail.com`
- Result: Successful login

---

*closes https://github.com/frappe/frappe/issues/33375*