### PR TITLE
fix: ensure 'Year' filter loads for Additional Salary Tool in Auto Email Report

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -152,6 +152,23 @@ frappe.ui.form.on("Auto Email Report", {
 								: [];
 						};
 					}
+					// Handle Select fields that need dynamic options (like year)
+					if (val.fieldtype === "Select" && val.fieldname === "year" && !val.options) {
+						if (reference_report?.onload) {
+							const methodMatch = reference_report.onload.toString().match(/method:\s*["']([^"']+)["']/);
+							if (methodMatch?.[1]) {
+								frappe.call({
+									method: methodMatch[1],
+									callback: function (r) {
+										if (r.message) {
+											const years = typeof r.message === "string" ? r.message.split("\n") : r.message;
+											val.options = years.map(year => ({ value: year.trim(), label: year.trim() }));
+										}
+									}
+								});
+							}
+						}
+					}
 					report_filters_list.push(val);
 				}
 			});


### PR DESCRIPTION
### Summary

Fixes an issue where the **'Year' filter** was not loading when configuring **Additional Salary Tool** in Auto Email Report. The filter would only appear if the report was opened manually beforehand. This PR ensures the filter is properly loaded from the report’s `onload` method when setting up the Auto Email Report directly.

### Issue

- https://github.com/frappe/hrms/issues/112
