### PR TITLE
feat: Auto append email account name to 'append_to' doctype

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -77,6 +77,7 @@
   "email_append_to",
   "sender_field",
   "sender_name_field",
+  "sender_email_account_field",
   "subject_field",
   "fields_tab",
   "fields_section",
@@ -707,6 +708,12 @@
    "fieldtype": "Int",
    "label": "Rows Threshold for Grid Search",
    "non_negative": 1
+  },
+  {
+   "depends_on": "email_append_to",
+   "fieldname": "sender_email_account_field",
+   "fieldtype": "Data",
+   "label": "Sender Email Account Field"
   }
  ],
  "grid_page_length": 50,
@@ -785,7 +792,7 @@
    "link_fieldname": "document_type"
   }
  ],
- "modified": "2025-06-24 07:46:34.380662",
+ "modified": "2025-07-19 11:56:19.636440",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -77,7 +77,7 @@
   "email_append_to",
   "sender_field",
   "sender_name_field",
-  "sender_email_account_field",
+  "recipient_account_field",
   "subject_field",
   "fields_tab",
   "fields_section",
@@ -711,9 +711,9 @@
   },
   {
    "depends_on": "email_append_to",
-   "fieldname": "sender_email_account_field",
+   "fieldname": "recipient_account_field",
    "fieldtype": "Data",
-   "label": "Sender Email Account Field"
+   "label": "Recipient Account Field"
   }
  ],
  "grid_page_length": 50,
@@ -792,7 +792,7 @@
    "link_fieldname": "document_type"
   }
  ],
- "modified": "2025-07-19 11:56:19.636440",
+ "modified": "2025-07-19 12:23:16.296416",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -163,6 +163,7 @@ class DocType(Document):
 		row_format: DF.Literal["Dynamic", "Compressed"]
 		rows_threshold_for_grid_search: DF.Int
 		search_fields: DF.Data | None
+		sender_email_account_field: DF.Data | None
 		sender_field: DF.Data | None
 		sender_name_field: DF.Data | None
 		show_name_in_global_search: DF.Check

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -158,12 +158,12 @@ class DocType(Document):
 		queue_in_background: DF.Check
 		quick_entry: DF.Check
 		read_only: DF.Check
+		recipient_account_field: DF.Data | None
 		restrict_to_domain: DF.Link | None
 		route: DF.Data | None
 		row_format: DF.Literal["Dynamic", "Compressed"]
 		rows_threshold_for_grid_search: DF.Int
 		search_fields: DF.Data | None
-		sender_email_account_field: DF.Data | None
 		sender_field: DF.Data | None
 		sender_name_field: DF.Data | None
 		show_name_in_global_search: DF.Check

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -49,6 +49,7 @@
   "email_append_to",
   "sender_field",
   "sender_name_field",
+  "sender_email_account_field",
   "subject_field",
   "section_break_8",
   "sort_field",
@@ -415,6 +416,12 @@
    "fieldname": "protect_attached_files",
    "fieldtype": "Check",
    "label": "Protect Attached Files"
+  },
+  {
+   "depends_on": "email_append_to",
+   "fieldname": "sender_email_account_field",
+   "fieldtype": "Data",
+   "label": "Sender Email Account Field"
   }
  ],
  "hide_toolbar": 1,
@@ -423,7 +430,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-27 18:22:32.618603",
+ "modified": "2025-07-19 11:56:01.780636",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -49,7 +49,7 @@
   "email_append_to",
   "sender_field",
   "sender_name_field",
-  "sender_email_account_field",
+  "recipient_account_field",
   "subject_field",
   "section_break_8",
   "sort_field",
@@ -419,9 +419,9 @@
   },
   {
    "depends_on": "email_append_to",
-   "fieldname": "sender_email_account_field",
+   "fieldname": "recipient_account_field",
    "fieldtype": "Data",
-   "label": "Sender Email Account Field"
+   "label": "Recipient Account Field"
   }
  ],
  "hide_toolbar": 1,
@@ -430,7 +430,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-19 11:56:01.780636",
+ "modified": "2025-07-19 12:23:41.564203",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -74,8 +74,8 @@ class CustomizeForm(Document):
 		protect_attached_files: DF.Check
 		queue_in_background: DF.Check
 		quick_entry: DF.Check
+		recipient_account_field: DF.Data | None
 		search_fields: DF.Data | None
-		sender_email_account_field: DF.Data | None
 		sender_field: DF.Data | None
 		sender_name_field: DF.Data | None
 		show_preview_popup: DF.Check

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -75,6 +75,7 @@ class CustomizeForm(Document):
 		queue_in_background: DF.Check
 		quick_entry: DF.Check
 		search_fields: DF.Data | None
+		sender_email_account_field: DF.Data | None
 		sender_field: DF.Data | None
 		sender_name_field: DF.Data | None
 		show_preview_popup: DF.Check

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -850,6 +850,9 @@ class InboundMail(Email):
 		if email_fields.sender_name_field:
 			parent.set(email_fields.sender_name_field, frappe.as_unicode(self.from_real_name))
 
+		if email_fields.sender_email_account_field:
+			parent.set(email_fields.sender_email_account_field, self.email_account.name)
+
 		parent.flags.ignore_mandatory = True
 
 		try:
@@ -891,7 +894,7 @@ class InboundMail(Email):
 		"""Return Email related fields of a doctype."""
 		fields = frappe._dict()
 
-		email_fields = ["subject_field", "sender_field", "sender_name_field"]
+		email_fields = ["subject_field", "sender_field", "sender_name_field", "sender_email_account_field"]
 		meta = frappe.get_meta(doctype)
 
 		for field in email_fields:

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -850,8 +850,8 @@ class InboundMail(Email):
 		if email_fields.sender_name_field:
 			parent.set(email_fields.sender_name_field, frappe.as_unicode(self.from_real_name))
 
-		if email_fields.sender_email_account_field:
-			parent.set(email_fields.sender_email_account_field, self.email_account.name)
+		if email_fields.recipient_account_field:
+			parent.set(email_fields.recipient_account_field, self.email_account.name)
 
 		parent.flags.ignore_mandatory = True
 
@@ -894,7 +894,7 @@ class InboundMail(Email):
 		"""Return Email related fields of a doctype."""
 		fields = frappe._dict()
 
-		email_fields = ["subject_field", "sender_field", "sender_name_field", "sender_email_account_field"]
+		email_fields = ["subject_field", "sender_field", "sender_name_field", "recipient_account_field"]
 		meta = frappe.get_meta(doctype)
 
 		for field in email_fields:


### PR DESCRIPTION
While receiving email from any account, if we create a document from that email account, we don't have any provision to know "from which email account" the "document" was created from.

This PR adds a provision to do so by adding "sender_email_account_field" in doctype.py, similar to other email fields such as "sender_field"


Adding the email account field to the doctype:
<img width="1440" height="799" alt="image" src="https://github.com/user-attachments/assets/fc2805cb-d161-469b-8e72-7c454a023f7f" />


Sending Email to the account:
<img width="608" height="250" alt="image" src="https://github.com/user-attachments/assets/5579b543-7404-4e5c-8d47-d741a23d31d7" />


The email account attached to the created ticket:
<img width="714" height="324" alt="image" src="https://github.com/user-attachments/assets/c56f8d8d-9803-42e3-982f-0123532fe39d" />


docs: `no-docs`
