### PR TITLE
fix: Preserve Workspace Context in Breadcrumbs

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -50,6 +50,12 @@ frappe.breadcrumbs = {
 	},
 
 	update() {
+		// update the current workspace in local storage
+		const active_route = frappe.get_route();
+		if (active_route[0] === "Workspaces" && active_route[1]) {
+			localStorage.setItem("current_workspace", active_route[1]);
+		}
+
 		var breadcrumbs = this.all[frappe.breadcrumbs.current_page()];
 
 		this.clear();
@@ -129,6 +135,15 @@ frappe.breadcrumbs = {
 	},
 
 	set_workspace(breadcrumbs) {
+		const stored_workspace = localStorage.getItem("current_workspace");
+		// if the current workspace is stored in local storage, use it, otherwise use the workspace from the doctype's module
+		if (stored_workspace) {
+			this.append_breadcrumb_element(
+				`/app/${frappe.router.slug(stored_workspace)}`,
+				__(stored_workspace)
+			);
+			return;
+		}
 		// try and get module from doctype or other settings
 		// then get the workspace for that module
 

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -50,12 +50,27 @@ frappe.breadcrumbs = {
 	},
 
 	update() {
-		// update the current workspace in local storage
+		// Update current workspace in local storage
+		const current_workspace = localStorage.getItem("current_workspace");
 		const active_route = frappe.get_route();
+		const previous_route = frappe.route_history?.[frappe.route_history.length - 2];
+
+		// Determine navigation type
+		const is_awesomebar_navigation = this.detectAwesomebarNavigation(
+			active_route,
+			previous_route
+		);
+		const is_direct_access = !frappe.route_history || frappe.route_history.length <= 1;
+
+		// Clear workspace on direct access or awesomebar navigation
+		if ((is_direct_access || is_awesomebar_navigation) && current_workspace) {
+			localStorage.removeItem("current_workspace");
+		}
+
+		// Set new workspace if navigating to Workspaces
 		if (active_route[0] === "Workspaces" && active_route[1]) {
 			localStorage.setItem("current_workspace", active_route[1]);
 		}
-
 		var breadcrumbs = this.all[frappe.breadcrumbs.current_page()];
 
 		this.clear();
@@ -90,6 +105,48 @@ frappe.breadcrumbs = {
 		}
 
 		this.toggle(true);
+	},
+
+	detectAwesomebarNavigation(active_route, previous_route) {
+		if (!previous_route || !active_route[0]) return false;
+
+		// List to List navigation with different doctypes
+		if (
+			active_route[0] === "List" &&
+			previous_route[0] === "List" &&
+			active_route[1] !== previous_route[1]
+		) {
+			return true;
+		}
+
+		// List to Form navigation with different doctypes
+		if (
+			active_route[0] === "Form" &&
+			previous_route[0] === "List" &&
+			active_route[1] !== previous_route[1]
+		) {
+			return true;
+		}
+
+		// Form to List navigation with different doctypes
+		if (
+			active_route[0] === "List" &&
+			previous_route[0] === "Form" &&
+			active_route[1] !== previous_route[1]
+		) {
+			return true;
+		}
+
+		// Form to Form navigation with different doctypes
+		if (
+			active_route[0] === "Form" &&
+			previous_route[0] === "Form" &&
+			active_route[1] !== previous_route[1]
+		) {
+			return true;
+		}
+
+		return false;
 	},
 
 	set_custom_breadcrumbs(breadcrumbs) {


### PR DESCRIPTION
## 🛠️ Fix: Preserve Workspace Context in Breadcrumbs

### Summary

This PR introduces functionality to:

- ✅ Store the current **Workspace** in `localStorage`
- ✅ Retrieve and use the stored Workspace to set **breadcrumbs** correctly

---

### Problem

When users only have access to a **custom workspace**, and **not the main workspaces (e.g. Accounting)**, they may experience a broken navigation flow:

1. User logs in and accesses a **Custom Workspace**
2. They route to a shortcut (e.g. *Sales Invoice*)
3. The **breadcrumbs** point to first workspace of the doctype's module
4. Clicking the breadcrumb leads to a **403 Not Permitted** error:
<img width="839" height="340" alt="1" src="https://github.com/user-attachments/assets/00aebb51-0e25-4722-be5a-6f98fe2f72c7" />
<img width="788" height="308" alt="2" src="https://github.com/user-attachments/assets/dddbe70a-785f-4b21-a57d-9e2918fa636c" />
<img width="1246" height="385" alt="3" src="https://github.com/user-attachments/assets/008ce8f2-607e-461c-b826-c3f819a2b624" />

---

### Why This Matters

This is a **critical UX issue**:

- ❌ Confusing for users with limited workspace access
- ❌ Breadcrumbs redirect them to unauthorized pages
- ❌ Leads to permission errors and unnecessary support
- ❌ Breaks the intended purpose of **workspace-based role separation**

---

### What This Fix Does

- Stores the active workspace (e.g. `custom-workspace`) in `localStorage`
- Uses the stored value when generating breadcrumbs
- Prevents users from being redirected to inaccessible workspaces

<img width="839" height="340" alt="4" src="https://github.com/user-attachments/assets/9f28781e-4940-49e1-9457-71bce8296105" />

---

### Real-World Impact

💬 As a developer worked with over **10 companies**, I’ve repeatedly witnessed this issue cause **confusion, frustration, and negative feedback** from end users.

> Even users with limited access expect a seamless, intuitive experience. Redirecting them to pages they’re not authorized to view undermines trust and leads to support requests.

---

#### This change is small but **high-impact** and has already helped multiple clients navigate Frappe more smoothly in production.

---

closes #33259 
