### PR TITLE
perf: ~10x faster server script execution

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -177,7 +177,7 @@ def get_safe_globals():
 		time_format = "HH:mm:ss"
 		number_format = NumberFormat.from_string("#,###.##")
 
-	add_data_utils(datautils)
+	datautils.update(SAFE_DATA_UTILS)
 
 	form_dict = getattr(frappe.local, "form_dict", frappe._dict())
 
@@ -585,12 +585,6 @@ def _write(obj):
 	return obj
 
 
-def add_data_utils(data):
-	for key, obj in frappe.utils.data.__dict__.items():
-		if key in VALID_UTILS:
-			data[key] = obj
-
-
 def add_module_properties(module, data, filter_method):
 	for key, obj in module.__dict__.items():
 		if key.startswith("_"):
@@ -720,6 +714,9 @@ VALID_UTILS = (
 	"parse_json",
 	"orjson_dumps",
 )
+
+
+SAFE_DATA_UTILS = {key: frappe.utils.data.__dict__[key] for key in VALID_UTILS}
 
 
 WHITELISTED_SAFE_EVAL_GLOBALS = {

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -295,9 +295,7 @@ def get_safe_globals():
 		get_visible_columns=get_visible_columns,
 	)
 
-	add_module_properties(
-		frappe.exceptions, out.frappe, lambda obj: inspect.isclass(obj) and issubclass(obj, Exception)
-	)
+	out.frappe.update(SAFE_EXCEPTIONS)
 
 	if frappe.response:
 		out.frappe.response = frappe.response
@@ -585,7 +583,8 @@ def _write(obj):
 	return obj
 
 
-def add_module_properties(module, data, filter_method):
+def get_module_properties(module, filter_method):
+	data = {}
 	for key, obj in module.__dict__.items():
 		if key.startswith("_"):
 			# ignore
@@ -594,6 +593,7 @@ def add_module_properties(module, data, filter_method):
 		if filter_method(obj):
 			# only allow functions
 			data[key] = obj
+	return data
 
 
 VALID_UTILS = (
@@ -735,3 +735,7 @@ SAFE_ORJSON = NamespaceDict(loads=orjson.loads, dumps=orjson.dumps)
 for key, val in vars(orjson).items():
 	if key.startswith("OPT_"):
 		SAFE_ORJSON[key] = val
+
+SAFE_EXCEPTIONS = get_module_properties(
+	frappe.exceptions, lambda obj: inspect.isclass(obj) and issubclass(obj, Exception)
+)

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -82,7 +82,7 @@ class FrappePrintCollector(PrintCollector):
 
 def is_safe_exec_enabled() -> bool:
 	# server scripts can only be enabled via common_site_config.json
-	return bool(frappe.get_common_site_config(cached=bool(frappe.request)).get(SAFE_EXEC_CONFIG_KEY))
+	return bool(frappe.get_common_site_config(cached=True).get(SAFE_EXEC_CONFIG_KEY))
 
 
 def safe_exec(
@@ -121,7 +121,7 @@ def safe_exec(
 	return exec_globals, _locals
 
 
-@site_cache(maxsize=32, ttl=60 * 60)
+@site_cache(maxsize=32)
 def _compile_code(script: str, filename: str, mode: str = "exec"):
 	return compile_restricted(script, filename=filename, policy=FrappeTransformer, mode=mode)
 


### PR DESCRIPTION
Basic af optimization that were just overlooked.

- Compute things only once
- Compile things only once

Benchmark
```bash 
λ bench  --site bench.localhost run-microbenchmarks -p5 --filter=safe_exec
```
Mean +- std dev
Before: 689 us +- 6 us
After: 66.9 us +- 1.4 us