### PR TITLE
fix: handle None session.data in maintenance mode (fixes #33258)

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -232,13 +232,13 @@ def get_safe_globals():
 			get_fullname=frappe.utils.get_fullname,
 			get_gravatar=frappe.utils.get_gravatar_url,
 			full_name=frappe.local.session.data.full_name
-			if getattr(frappe.local, "session", None)
+			if getattr(frappe.local, "session", None) and getattr(frappe.local.session, "data", None)
 			else "Guest",
 			request=getattr(frappe.local, "request", {}),
 			session=frappe._dict(
 				user=user,
 				csrf_token=frappe.local.session.data.csrf_token
-				if getattr(frappe.local, "session", None)
+				if getattr(frappe.local, "session", None) and getattr(frappe.local.session, "data", None)
 				else "",
 			),
 			make_get_request=frappe.integrations.utils.make_get_request,

--- a/frappe/website/page_renderers/base_template_page.py
+++ b/frappe/website/page_renderers/base_template_page.py
@@ -16,7 +16,7 @@ class BaseTemplatePage(BaseRenderer):
 		self.context.update(frappe.local.conf.get("website_context") or {})
 
 	def add_csrf_token(self, html):
-		if frappe.local.session:
+		if frappe.local.session and getattr(frappe.local.session, "data", None):
 			csrf_token = frappe.local.session.data.csrf_token
 			return html.replace(
 				"<!-- csrf_token -->", f'<script>frappe.csrf_token = "{csrf_token}";</script>'


### PR DESCRIPTION
## Description
Fixes the maintenance mode bug where `AttributeError: 'NoneType' object has no attribute 'full_name'` occurs when `session.data` is None.

## Root Cause
The code was checking if `frappe.local.session` exists but not checking if `frappe.local.session.data` exists, causing crashes during maintenance mode.

## Changes Made
- **File 1**: `frappe/utils/safe_exec.py` (lines 234-236, 241-243)
  - Added null check for `session.data` before accessing `full_name` and `csrf_token`
- **File 2**: `frappe/website/page_renderers/base_template_page.py` (line 20)
  - Added null check for `session.data` before accessing `csrf_token`

## Testing
- ✅ Maintenance mode now works without crashes
- ✅ Session handling is robust and safe
- ✅ CSRF token access is properly protected

## Related Issue
Closes #33258

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)