### PR TITLE
chore: add .gitattributes for line endings and linguist overrides

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Handle line endings
+*.py text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.csv text eol=lf
+*.sh text eol=lf
+
+# Mark binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.svg binary
+
+# linguist overrides (for GitHub language stats)
+*.py linguist-language=Python
+*.js linguist-language=JavaScript
+*.json linguist-language=JSON
+*.md linguist-language=Markdown
+*.yml linguist-language=YAML
+*.yaml linguist-language=YAML
+*.csv linguist-language=CSV
+
+# Prevent diff for lock files
+yarn.lock -diff
+package-lock.json -diff 


### PR DESCRIPTION
This PR adds a `.gitattributes` file to:

- Ensure consistent line endings across different operating systems
- Mark binary files (e.g., images, PDFs)
- Improve GitHub linguist language detection
- Prevent diffs on lock files like `package-lock.json` and `yarn.lock`

This helps maintain cross-platform compatibility and improves code hygiene.
