### PR TITLE
chore: update .editorconfig to align with Frappe's code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,6 @@
 root = true
 
 [*]
-indent_style = space
-indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,21 +1,12 @@
-# Root editor config file
 root = true
 
-# Common settings
 [*]
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-charset = utf-8
-
-# python, js indentation settings
-[{*.py,*.js,*.vue,*.css,*.scss,*.html}]
-indent_style = tab
-indent_size = 4
-max_line_length = 99
-
-# JSON files - mostly doctype schema files
-[{*.json}]
-insert_final_newline = false
 indent_style = space
-indent_size = 1
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Originally added an .editorconfig file to enforce consistent formatting across editors.

Based on maintainer feedback, removed `indent_style` and `indent_size` to follow Frappe’s style conventions.

This update ensures consistent line endings, whitespace rules, and contributes to cross-platform code hygiene.
