### PR TITLE
fix(email_group): prevent `StopIteration` when running import on a doctype without email fields

### DIFF
--- a/frappe/email/doctype/email_group/email_group.py
+++ b/frappe/email/doctype/email_group/email_group.py
@@ -38,10 +38,19 @@ class EmailGroup(Document):
 		"""Extract Email Addresses from given doctype and add them to the current list"""
 		meta = frappe.get_meta(doctype)
 		email_field = next(
-			d.fieldname
-			for d in meta.fields
-			if d.fieldtype in ("Data", "Small Text", "Text", "Code") and d.options == "Email"
+			(
+				d.fieldname
+				for d in meta.fields
+				if d.fieldtype in ("Data", "Small Text", "Text", "Code") and d.options == "Email"
+			),
+			None,
 		)
+		if not email_field:
+			frappe.throw(
+				_("No Email field found in {0}").format(doctype),
+				title=_("Invalid Doctype"),
+			)
+
 		unsubscribed_field = "unsubscribed" if meta.get_field("unsubscribed") else None
 		added = 0
 


### PR DESCRIPTION
Reference: support ticket 44288
