### PR TITLE
chore: update boostrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "air-datepicker": "git+https://github.com/frappe/air-datepicker",
     "autoprefixer": "10",
     "awesomplete": "^1.1.5",
-    "bootstrap": "4.6.2",
+    "bootstrap": "5.0.0",
     "chalk": "^2.3.2",
     "cliui": "^7.0.4",
     "cookie": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -576,10 +576,10 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-bootstrap@4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.2.tgz#8e0cd61611728a5bf65a3a2b8d6ff6c77d5d7479"
-  integrity sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==
+bootstrap@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.0.0.tgz#97635ac0e0d6cb466700ebf0fd266bfabf352ed2"
+  integrity sha512-tmhPET9B9qCl8dCofvHeiIhi49iBt0EehmIsziZib65k1erBW1rHhj2s/2JsuQh5Pq+xz2E9bEbzp9B7xHG+VA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Updating bootstrap to 5.0.0
I have checked the migration guide https://getbootstrap.com/docs/5.0/migration/