### PR TITLE
fix: Default currency symbol in query report total row

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1743,7 +1743,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				row.is_total_row = true;
 				return row;
 			}, {});
-
+			if (!totalRow["currency"]) {
+					totalRow["currency"] = rows[0]["currency"];
+			}
 			rows.push(totalRow);
 		}
 		return rows;

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1743,8 +1743,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				row.is_total_row = true;
 				return row;
 			}, {});
-			if (!totalRow["currency"]) {
-					totalRow["currency"] = rows[0]["currency"];
+			if (!totalRow["currency"] && rows.length) {
+				totalRow["currency"] = rows[0]["currency"];
 			}
 			rows.push(totalRow);
 		}

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1743,8 +1743,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				row.is_total_row = true;
 				return row;
 			}, {});
-			if (!totalRow["currency"] && rows.length) {
-				totalRow["currency"] = rows[0]["currency"];
+			if (!totalRow?.currency && rows[0]?.currency) {
+				totalRow.currency = rows[0].currency;
 			}
 			rows.push(totalRow);
 		}


### PR DESCRIPTION
Fixes a currency formatting issue in the Accounts Receivable report when printing.

The issue was caused by `getTotalRow()` returns a dictionary where the `currency` key is set to `null`, which led to incorrect formatting during print.

This PR ensures that if currency is null, it is set manually .

Note: This PR does not perform any currency conversion — it only ensures correct formatting via `format_currency()`


## Before

<img width="1121" height="443" alt="Screenshot 2025-07-23 at 12 37 22 PM" src="https://github.com/user-attachments/assets/fb1bb5ac-d0d0-44e6-9a25-17eac5377fb2" />

## After

<img width="1123" height="391" alt="Screenshot 2025-07-23 at 12 56 31 PM" src="https://github.com/user-attachments/assets/a51597e1-d420-4cb8-9ccf-b2eb2dcd6b46" />


Closes #33426 
Support Ticket: https://support.frappe.io/helpdesk/tickets/43595
