### PR TITLE
fix(event)!: Add "delete" permission for Desk Users

### DIFF
--- a/frappe/desk/doctype/event/event.json
+++ b/frappe/desk/doctype/event/event.json
@@ -297,7 +297,7 @@
  "icon": "fa fa-calendar",
  "idx": 1,
  "links": [],
- "modified": "2025-06-17 15:31:01.945146",
+ "modified": "2025-07-23 17:46:08.183584",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Event",
@@ -306,6 +306,7 @@
  "permissions": [
   {
    "create": 1,
+   "delete": 1,
    "email": 1,
    "print": 1,
    "read": 1,


### PR DESCRIPTION
If I'm not mistaken, there is no way for a non-System Manager to delete an Event, seems weird to me. There is the custom controller anyways so damage is limited.

Before this change: it's not possible to delete any Event unless you are a System Manager
After this change: ***any*** Desk User will be able to delete ***a public*** Event + their own Events.

https://github.com/frappe/frappe/blob/aca28018973ff9f10c176321516a76109673b548/frappe/desk/doctype/event/event.py#L240-L244