### PR TITLE
fix: restrict workflow actions in report view

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -59,11 +59,15 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	}
 
 	setup_events() {
+		const me = this;
 		if (this.list_view_settings?.disable_auto_refresh) {
 			return;
 		}
 		frappe.realtime.doctype_subscribe(this.doctype);
 		frappe.realtime.on("list_update", (data) => this.on_update(data));
+		this.page.actions_btn_group.on("show.bs.dropdown", () => {
+			me.toggle_workflow_actions();
+		});
 	}
 
 	setup_page() {


### PR DESCRIPTION
Workflow actions are shown in report view enough if user doesnt have the allowed role, it is restricted in list view but not in report view

Before
<img width="1381" height="757" alt="Screenshot 2025-07-24 at 10 21 12 AM" src="https://github.com/user-attachments/assets/3a412af0-21de-4c96-88f7-e293d68cc9d3" />

After
<img width="1388" height="654" alt="Screenshot 2025-07-24 at 10 24 15 AM" src="https://github.com/user-attachments/assets/5b569f8f-3fce-4d34-80a0-d89a20ce791a" />



