### PR TITLE
fix(Table_Multiselect_Field): Mitigate reflected XSS due to search 

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -225,7 +225,6 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				}
 
 				// Sanitize label and description before using them to build HTML
-
 				let _label = frappe.utils.escape_html(me.get_translated(d.label));
 				let html = d.html || "<strong>" + _label + "</strong>";
 				if (

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -224,7 +224,12 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					d.label = d.value;
 				}
 
-				let _label = me.get_translated(d.label);
+				// Sanitize label and description before using them to build HTML
+
+				let _label = frappe.utils.escape_html(me.get_translated(d.label));
+				let _description = d.description
+					? frappe.utils.escape_html(__(d.description))
+					: null;
 				let html = d.html || "<strong>" + _label + "</strong>";
 				if (
 					d.description &&
@@ -232,7 +237,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					// because it will not visible otherwise
 					(me.is_title_link() || d.value !== d.description)
 				) {
-					html += '<br><span class="small">' + __(d.description) + "</span>";
+					html += '<br><span class="small">' + _description + "</span>";
 				}
 				return $(`<div role="option">`)
 					.on("click", (event) => {

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -227,9 +227,6 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				// Sanitize label and description before using them to build HTML
 
 				let _label = frappe.utils.escape_html(me.get_translated(d.label));
-				let _description = d.description
-					? frappe.utils.escape_html(__(d.description))
-					: null;
 				let html = d.html || "<strong>" + _label + "</strong>";
 				if (
 					d.description &&
@@ -237,7 +234,10 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					// because it will not visible otherwise
 					(me.is_title_link() || d.value !== d.description)
 				) {
-					html += '<br><span class="small">' + _description + "</span>";
+					html +=
+						'<br><span class="small">' +
+						__(frappe.utils.escape_html(d.description)) +
+						"</span>";
 				}
 				return $(`<div role="option">`)
 					.on("click", (event) => {

--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -81,28 +81,36 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 		}
 
 		const link_field = this.get_link_field();
+		// Trim the value to remove spaces or only if space is only input
+		if (value && typeof value === "string") {
+			value = value.trim();
+		}
 
 		if (value) {
-			if (this.frm) {
-				const new_row = frappe.model.add_child(
-					this.frm.doc,
-					this.df.options,
-					this.df.fieldname
-				);
-				new_row[link_field.fieldname] = value;
-				this.rows = this.frm.doc[this.df.fieldname];
+			// Only create a pill if the value is a real item from the autocomplete list.
+			// This prevents creating a pill from raw text when the user clicks away.
+			if (this.awesomplete.get_item(value)) {
+				if (this.frm) {
+					const new_row = frappe.model.add_child(
+						this.frm.doc,
+						this.df.options,
+						this.df.fieldname
+					);
+					new_row[link_field.fieldname] = value;
+					this.rows = this.frm.doc[this.df.fieldname];
 
-				this.frm.script_manager.trigger(
-					`${this.df.fieldname}_add`,
-					this.df.options,
-					new_row.name
-				);
-			} else {
-				this.rows.push({
-					[link_field.fieldname]: value,
-				});
+					this.frm.script_manager.trigger(
+						`${this.df.fieldname}_add`,
+						this.df.options,
+						new_row.name
+					);
+				} else {
+					this.rows.push({
+						[link_field.fieldname]: value,
+					});
+				}
+				frappe.utils.add_link_title(link_field.options, value, label);
 			}
-			frappe.utils.add_link_title(link_field.options, value, label);
 		}
 		this._rows_list = this.rows.map((row) => row[link_field.fieldname]);
 		return this.rows;
@@ -165,9 +173,11 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 		const link_field = this.get_link_field();
 		const encoded_value = encodeURIComponent(value);
 		const pill_name = frappe.utils.get_link_title(link_field.options, value) || value;
+		const safe_pill_name = frappe.utils.escape_html(pill_name); // Sanitize the value before making it a HTML pill
+
 		return `
 			<button class="data-pill btn tb-selected-value" data-value="${encoded_value}">
-				<span class="btn-link-to-form">${__(pill_name)}</span>
+				<span class="btn-link-to-form">${__(safe_pill_name)}</span>
 				<span class="btn-remove">${frappe.utils.icon("close")}</span>
 			</button>
 		`;

--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -82,7 +82,7 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 
 		const link_field = this.get_link_field();
 
-		if (value && typeof value === "string") {
+		if (value) {
 			// Trim the value to remove spaces or only if space is only input
 			value = value.trim();
 

--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -81,12 +81,11 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 		}
 
 		const link_field = this.get_link_field();
-		// Trim the value to remove spaces or only if space is only input
-		if (value && typeof value === "string") {
-			value = value.trim();
-		}
 
-		if (value) {
+		if (value && typeof value === "string") {
+			// Trim the value to remove spaces or only if space is only input
+			value = value.trim();
+
 			// Only create a pill if the value is a real item from the autocomplete list.
 			// This prevents creating a pill from raw text when the user clicks away.
 			if (this.awesomplete.get_item(value)) {
@@ -173,11 +172,10 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 		const link_field = this.get_link_field();
 		const encoded_value = encodeURIComponent(value);
 		const pill_name = frappe.utils.get_link_title(link_field.options, value) || value;
-		const safe_pill_name = frappe.utils.escape_html(pill_name); // Sanitize the value before making it a HTML pill
 
 		return `
 			<button class="data-pill btn tb-selected-value" data-value="${encoded_value}">
-				<span class="btn-link-to-form">${__(safe_pill_name)}</span>
+				<span class="btn-link-to-form">${__(frappe.utils.escape_html(pill_name))}</span>
 				<span class="btn-remove">${frappe.utils.icon("close")}</span>
 			</button>
 		`;


### PR DESCRIPTION
feature of table multiselect

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

The issue was raised for a XXS vulnerability, the vulnerability is reflected XXS. I have tested by  trying to create doctype with  vulnerable names so that they can be executed on the client side. Proper checks are in place which does not allow this behavior. Anywhere input which is stored in properly checked. This is reflected XSS.
<img width="1233" height="597" alt="Before" src="https://github.com/user-attachments/assets/43bb54a6-fb27-4184-8db8-5755e7c8b8a8" />



<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
I have properly tested with different payloads the issue is mitigated. The user can type the payload when they try to save frappe will not consider that input. After making the changes tested the open documents all works good.
Here other changes are the pill will be created only if the document exists
<img width="1152" height="429" alt="After" src="https://github.com/user-attachments/assets/72d485f0-f331-47d4-bede-c906536c6c58" />


> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
`no-docs`