### PR TITLE
feat: Add hooks for custom SMS and OTP SMS sending

### DIFF
--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -63,10 +63,6 @@ def get_contact_number(contact_name, ref_doctype, ref_name):
 
 @frappe.whitelist()
 def send_sms(receiver_list, msg, sender_name="", success_msg=True):
-	"""
-	Send SMS to a list of receivers. If a hook is defined for 'send_sms', it will be used instead of the default implementation.
-	The hook function should have the same signature as this function.
-	"""
 	import json
 
 	if isinstance(receiver_list, str):

--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -63,6 +63,10 @@ def get_contact_number(contact_name, ref_doctype, ref_name):
 
 @frappe.whitelist()
 def send_sms(receiver_list, msg, sender_name="", success_msg=True):
+	"""
+	Send SMS to a list of receivers. If a hook is defined for 'send_sms', it will be used instead of the default implementation.
+	The hook function should have the same signature as this function.
+	"""
 	import json
 
 	if isinstance(receiver_list, str):
@@ -77,6 +81,12 @@ def send_sms(receiver_list, msg, sender_name="", success_msg=True):
 		"message": frappe.safe_decode(msg).encode("utf-8"),
 		"success_msg": success_msg,
 	}
+
+	# Hook support for custom SMS sender
+	hook_methods = frappe.get_hooks("send_sms")
+	if hook_methods:
+		# Call the last registered hook
+		return frappe.get_attr(hook_methods[-1])(receiver_list, msg, sender_name, success_msg)
 
 	if frappe.db.get_single_value("SMS Settings", "sms_gateway_url"):
 		send_via_gateway(arg)

--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -82,11 +82,9 @@ def send_sms(receiver_list, msg, sender_name="", success_msg=True):
 		"success_msg": success_msg,
 	}
 
-	# Hook support for custom SMS sender
-	hook_methods = frappe.get_hooks("send_sms")
-	if hook_methods:
-		# Call the last registered hook
-		return frappe.get_attr(hook_methods[-1])(receiver_list, msg, sender_name, success_msg)
+	send_sms_hook_methods = frappe.get_hooks("send_sms")
+	if send_sms_hook_methods:
+		return frappe.get_attr(send_sms_hook_methods[-1])(receiver_list, msg, sender_name, success_msg)
 
 	if frappe.db.get_single_value("SMS Settings", "sms_gateway_url"):
 		send_via_gateway(arg)

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -206,22 +206,10 @@ def get_verification_obj(user, token, otp_secret):
 
 
 def process_2fa_for_sms(user, token, otp_secret):
-	"""Process sms method for 2fa.
-
-	The 'mobile_otp_sms_sender' hook allows integration with third-party SMS providers for OTP delivery.
-	When defined, this hook will be used instead of the default SMS implementation.
-	Hook functions must match the signature: send_token_via_sms(otpsecret, token=None, phone_no=None).
-	"""
+	"""Process sms method for 2fa."""
 	phone = frappe.db.get_value("User", user, ["phone", "mobile_no"], as_dict=1)
 	phone = phone.mobile_no or phone.phone
-
-	# Hook support for custom SMS sender
-	hook_methods = frappe.get_hooks("mobile_otp_sms_sender")
-	if hook_methods:
-		status = frappe.get_attr(hook_methods[-1])(otp_secret, token=token, phone_no=phone)
-	else:
-		status = send_token_via_sms(otp_secret, token=token, phone_no=phone)
-
+	status = send_token_via_sms(otp_secret, token=token, phone_no=phone)
 	return {
 		"token_delivery": status,
 		"prompt": status and "Enter verification code sent to {}".format(phone[:4] + "******" + phone[-3:]),
@@ -314,6 +302,11 @@ def get_link_for_qrcode(user, totp_uri):
 
 def send_token_via_sms(otpsecret, token=None, phone_no=None):
 	"""Send token as sms to user."""
+
+	send_token_hook_methods = frappe.get_hooks("send_token_via_sms")
+	if send_token_hook_methods:
+		return frappe.get_attr(send_token_hook_methods[-1])(otpsecret, token, phone_no)
+
 	try:
 		from frappe.core.doctype.sms_settings.sms_settings import send_request
 	except Exception:

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -206,10 +206,22 @@ def get_verification_obj(user, token, otp_secret):
 
 
 def process_2fa_for_sms(user, token, otp_secret):
-	"""Process sms method for 2fa."""
+	"""Process sms method for 2fa.
+
+	The 'mobile_otp_sms_sender' hook allows integration with third-party SMS providers for OTP delivery.
+	When defined, this hook will be used instead of the default SMS implementation.
+	Hook functions must match the signature: send_token_via_sms(otpsecret, token=None, phone_no=None).
+	"""
 	phone = frappe.db.get_value("User", user, ["phone", "mobile_no"], as_dict=1)
 	phone = phone.mobile_no or phone.phone
-	status = send_token_via_sms(otp_secret, token=token, phone_no=phone)
+
+	# Hook support for custom SMS sender
+	hook_methods = frappe.get_hooks("mobile_otp_sms_sender")
+	if hook_methods:
+		status = frappe.get_attr(hook_methods[-1])(otp_secret, token=token, phone_no=phone)
+	else:
+		status = send_token_via_sms(otp_secret, token=token, phone_no=phone)
+
 	return {
 		"token_delivery": status,
 		"prompt": status and "Enter verification code sent to {}".format(phone[:4] + "******" + phone[-3:]),


### PR DESCRIPTION
Introduces two new hooks to make SMS sending in Frappe fully pluggable and override-friendly, enabling custom apps to implement their own SMS providers and logic.

## Changes Made

### 1. `send_sms` Hook

**Purpose:** Allows custom apps to override the default SMS sending logic for notifications, bulk SMS, and other general SMS functionality.

* **Hook registry:** `send_sms`
* **Replaces:** Default implementation in `frappe.core.doctype.sms_settings.sms_settings.send_sms`

**Expected signature:**
```python
def custom_send_sms(receiver_list, msg, sender_name="", success_msg=True):
   pass
```

### 2. `send_token_via_sms` Hook

**Purpose:** Allows custom apps to override SMS OTP sending logic for two-factor authentication and mobile login flows.

* **Hook registry:** `send_token_via_sms`
* **Replaces:** Default implementation in `frappe.twofactor.send_token_via_sms`

**Expected signature:**
```python
def custom_send_token_via_sms(otpsecret, token=None, phone_no=None):
   pass
```

[Documentation](https://docs.frappe.io/framework/user/en/python-api/hooks?editWiki=1&wikiPagePatch=f3lpd2chmi)