### PR TITLE
fix: check if df exist before accessing its properties

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1260,7 +1260,7 @@ class BaseDocument:
 			doctype = self.meta.get_field(parentfield).options if parentfield else self.doctype
 			df = frappe.get_meta(doctype).get_field(fieldname)
 
-			if df.fieldtype in ("Currency", "Float", "Percent"):
+			if df and df.fieldtype in ("Currency", "Float", "Percent"):
 				self._precision[cache_key][fieldname] = get_field_precision(df, self)
 
 		return self._precision[cache_key][fieldname]


### PR DESCRIPTION
fix:  As explained in the issue "https://github.com/frappe/frappe/issues/28039" there is the need to apply a double control to the variable "df" at line 1263 (before 1157), so to resolve the error "AttributeError: 'NoneType' object has no attribute 'fieldtype'"

<!--
Welcome to the Frappe Framework issue tracker! Before creating an issue, please heed the following:

1. This tracker should only be used to report bugs and request features / enhancements to Frappe
    - For questions and general support, use https://stackoverflow.com/questions/tagged/frappe
    - For documentation issues, refer to https://frappeframework.com/docs/user/en or the developer cheetsheet https://github.com/frappe/frappe/wiki/Developer-Cheatsheet
2. Use the search function before creating a new issue. Duplicates will be closed and directed to
   the original discussion.
3. When making a bug report, make sure you provide all required information. The easier it is for
   maintainers to reproduce, the faster it'll be fixed.
4. If you think you know what the reason for the bug is, share it with us. Maybe put in a PR 😉
-->

## Description of the issue

**I found out an issue in Point of Sale using Tax-Rate.**
Basically when I add a product with a defined tax in my basket and I'm going to checkout it I got following error:

`AttributeError: 'NoneType' object has no attribute 'fieldtype' Possible source of error: erpnext (app)`

![Screenshot (135)](https://github.com/user-attachments/assets/8d2d4719-afa5-4087-864b-2f30404b2568)


## Context information (for bug reports)

Digging inside code I found out the issue.
The function `def update_itemised_tax_data(doc)` in `frappe-bench/apps/erpnext/erpnext/regional/italy/utils.py` is making an assignment in line 27 `row.tax_rate = flt(tax_rate, row.precision("tax_rate"))`.

![Screenshot (140)](https://github.com/user-attachments/assets/10e99ba7-1efa-4207-8bb7-d86ab17494f6)

The call function `row.precision("tax_rate")` has its definition `def precision(self, fieldname, parentfield=None) -> int | None` in `frappe-bench/apps/frappe/frappe/model/base_document.py` in line 1133.

![Screenshot (136)](https://github.com/user-attachments/assets/cf27b6d2-5e09-4713-84a7-11d69773e9e0)

At line 1155 (same function) basically we got this issue. 
In this particular circumstances `df = frappe.get_meta(doctype).get_field(fieldname)` is `None` and it create the error in the next `if` statement at line 1157: `if df.fieldtype in ("Currency", "Float", "Percent"):`

## Steps to sort the issue

To sort this annoying issue we need to apply changes at `frappe-bench/apps/frappe/frappe/model/base_document.py`.
We need to check the existence of `df` in the if statement at line 1157: `if df and df.fieldtype in ("Currency", "Float", "Percent"):`

![Screenshot (137)](https://github.com/user-attachments/assets/d46d9470-88ea-4d5b-a998-1d16ede6f924)

## Additional information

OS Rocky Linux 9.4, Frappe Framework: v15.73.0, ERPNext: v15.69.2 


Refs: "https://github.com/frappe/frappe/issues/28039"