### PR TITLE
fix: updated sidebar icons (#22101)

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar.js
@@ -343,6 +343,16 @@ frappe.ui.Sidebar = class Sidebar {
 				path = "/app/private/" + frappe.router.slug(item.name.split("-")[0]);
 			}
 		}
+		const iconFixes = {
+		"users": "user",
+		"file": "file-text",
+		"tag": "tags",
+		"list": "table",
+		"check": "check-circle"
+	};
+	if (item.icon && iconFixes[item.icon]) {
+		item.icon = iconFixes[item.icon];
+	}
 
 		return $(`
 			<div


### PR DESCRIPTION
This PR updates the sidebar icons as requested in [Issue #22101](https://github.com/frappe/frappe/issues/22101):

- users → user  
- file → file-text  
- tag → tags  
- list → table  
- check → check-circle

These changes help improve icon consistency across the sidebar UI.