### PR TITLE
Fix(socketio):the ultimate socket io fix

### DIFF
--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -46,14 +46,14 @@ class RealTimeClient {
 
 		// Enable secure option when using HTTPS
 		if (window.location.protocol == "https:") {
-			this.socket = io(this.get_host(port), {
+			this.socket = io(this.get_namespace(), {
 				secure: true,
 				withCredentials: true,
 				reconnectionAttempts: 3,
 				autoConnect: !lazy_connect,
 			});
 		} else if (window.location.protocol == "http:") {
-			this.socket = io(this.get_host(port), {
+			this.socket = io(this.get_namespace(), {
 				withCredentials: true,
 				reconnectionAttempts: 3,
 				autoConnect: !lazy_connect,
@@ -113,9 +113,19 @@ class RealTimeClient {
 		});
 	}
 
+	get_namespace() {
+		return `/${frappe.boot.sitename}`
+	}
+	
 	get_host(port = 9000) {
 		let host = window.location.origin;
-		if (window.dev_server) {
+		let onLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+		let hasPort = window.location.port !== '';
+		let isHttp = window.location.protocol === 'http:';
+
+		let usePortBasedUrlForSocketIO = onLocalhost ||hasPort||isHttp;
+
+		if (usePortBasedUrlForSocketIO &&  window.dev_server) {
 			let parts = host.split(":");
 			port = frappe.boot.socketio_port || port.toString() || "9000";
 			if (parts.length > 2) {
@@ -123,7 +133,7 @@ class RealTimeClient {
 			}
 			host = host + ":" + port;
 		}
-		return host + `/${frappe.boot.sitename}`;
+		return host;
 	}
 
 	subscribe(task_id, opts) {

--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -11,7 +11,10 @@ function authenticate_with_frappe(socket, next) {
 		next(new Error("Invalid namespace"));
 	}
 
-	if (get_hostname(socket.request.headers.host) != get_hostname(socket.request.headers.origin)) {
+	const refererUrl = new URL(socket.request.headers.referer);
+	const originCheck = (get_hostname(socket.request.headers.host) != get_hostname(socket.request.headers.origin))
+	const refererCheck = (get_hostname(socket.request.headers.host) != refererUrl.hostname);
+	if (!(originCheck || refererCheck)) {
 		next(new Error("Invalid origin"));
 		return;
 	}

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -5,7 +5,8 @@ function get_url(socket, path) {
 	if (!path) {
 		path = "";
 	}
-	let url = socket.request.headers.origin;
+	let referer = new URL(socket.request.headers.referer);
+	let url = socket.request.headers.origin || referer.origin;
 	if (conf.developer_mode) {
 		let [protocol, host, port] = url.split(":");
 		port = conf.webserver_port;


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? frappe 15 develop, and maybe the other versions?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->


> Please provide enough information so that others can review your pull request:

many have been experiencing socket io issues, and after investigating further i found several stuff related to these issues in thread below.
[https://github.com/frappe/frappe/issues/33212](url)


several flaws in the socket io logic:
1. some browser removes origin from header (see images contains no header origin)
attached shown that a websocket polling GET request can at times have no origin, which breaks the logic. requiring header origin checks
this fixed this by falling back to referrer origin (see image attached)

2. socket io namespace and host url are two different thing, with two different purpose.
(eg:https://test.com/socket.io vs https://test.com/namespace1/socket.io vs https://test.com:9000/namespace2/socket.io ), the logic needs to be separated, this fixed it by dividing get_namespace() and get_host()
this also solves complex cases where the namespaces is different from the url/directory (eg: using reverse proxy server setup) 

> Screenshots/GIFs
<!-- Add images/recordings to better visualize the change: expected/current behavior -->
<img width="987" height="502" alt="image" src="https://github.com/user-attachments/assets/76a082d0-4359-4a67-a076-9ba7a5bdda70" />
