### PR TITLE
feat: Better API Keys dialog

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -340,8 +340,12 @@ frappe.ui.form.on("User", {
 					const api_secret = r.message.api_secret;
 
 					let keys_summary = __("API Key: {0}", [`<code>${api_key}</code>`]);
-					keys_summary += `<br/>${__("API Secret: {0}", [`<code>${api_secret}</code>`])}`;
-					keys_summary += `<br/><br/>${__("Store the API Secret securely, it won't be displayed again.")}`;
+					keys_summary += `<br/>${__("API Secret: {0}", [
+						`<code>${api_secret}</code>`,
+					])}`;
+					keys_summary += `<br/><br/>${__(
+						"Store the API Secret securely, it won't be displayed again."
+					)}`;
 
 					const api_keys_dialog = frappe.msgprint(keys_summary, __("API Keys"));
 					api_keys_dialog.set_primary_action(__("Copy token to clipboard"), () => {

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -336,7 +336,19 @@ frappe.ui.form.on("User", {
 			},
 			callback: function (r) {
 				if (r.message) {
-					frappe.msgprint(__("Save API Secret: {0}", [r.message.api_secret]));
+					const api_key = r.message.api_key;
+					const api_secret = r.message.api_secret;
+
+					let keys_summary = __("API Key: {0}", [`<code>${api_key}</code>`]);
+					keys_summary += `<br/>${__("API Secret: {0}", [`<code>${api_secret}</code>`])}`;
+					keys_summary += `<br/><br/>${__("Store the API Secret securely, it won't be displayed again.")}`;
+
+					const api_keys_dialog = frappe.msgprint(keys_summary, __("API Keys"));
+					api_keys_dialog.set_primary_action(__("Copy token to clipboard"), () => {
+						const token = `${api_key}:${api_secret}`;
+						frappe.utils.copy_to_clipboard(token);
+					});
+
 					frm.reload_doc();
 				}
 			},

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1343,7 +1343,7 @@ def generate_keys(user: str):
 	user_details.api_secret = api_secret
 	user_details.save()
 
-	return {"api_secret": api_secret}
+	return {"api_key": user_details.api_key, "api_secret": api_secret}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
> (me after lots of training sessions) Okay, thats it, I will fix it now 🤣 

### The Friction

Currently, if I generate API keys, the dialog only shows me the API secret, and not the API key, so I have to:
  - Close the dialog
  - Again open the collapsed section
  - Copy the API key from there
  - Use it

This PR enhances the dialog to show both the API Key and Secret as well as a handy button to copy the token to clipboard (because many times you want to copy the token itself!).

### Before


https://github.com/user-attachments/assets/1ecd738a-09f6-4bca-88a0-99d200ce76fc




### After

https://github.com/user-attachments/assets/eaa03a9d-40d0-4163-aeb5-c8147deca65b


`no-docs`
