### PR TITLE
fix(billing): better check for `setup_complete`

### DIFF
--- a/frappe/public/js/billing.bundle.js
+++ b/frappe/public/js/billing.bundle.js
@@ -4,7 +4,7 @@ let isFCUser = false;
 $(document).ready(function () {
 	if (
 		frappe.boot.is_fc_site &&
-		frappe.boot.setup_complete === 1 &&
+		!!frappe.boot.setup_complete &&
 		!frappe.is_mobile() &&
 		frappe.user.has_role("System Manager")
 	) {


### PR DESCRIPTION
Earlier we used to have 1 or 0, but now it returns `true` or `false`. Changing the code so that it can support both cases.

