### PR TITLE
fix(assignment_rule): only close `Open` ToDos

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -313,6 +313,7 @@ def apply(doc=None, method=None, doctype=None, name=None):
 						filters={
 							"reference_type": doc.doctype,
 							"reference_name": str(doc.name),
+							"status": "Open",
 						},
 						pluck="name",
 					)

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -239,7 +239,7 @@ def clear(doctype, name, ignore_permissions=False):
 	assignments = frappe.get_all(
 		"ToDo",
 		fields=["allocated_to", "name"],
-		filters=dict(reference_type=doctype, reference_name=name),
+		filters=dict(reference_type=doctype, reference_name=name, status="Open"),
 	)
 	if not assignments:
 		return False


### PR DESCRIPTION
Older ToDos can be linked to the same document, and have assignment rules that no longer exist, so trying to update them causes a LinkValidationError
