### PR TITLE
fix: do not automatically set enable prepared report if it is manuall…

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -131,7 +131,7 @@ class Report(Document):
 
 		# automatically set as prepared
 		execution_time = (datetime.datetime.now() - start_time).total_seconds()
-		if execution_time > threshold and not self.prepared_report and not frappe.conf.developer_mode:
+		if execution_time > threshold and not self.disable_prepared_report and not self.prepared_report and not frappe.conf.developer_mode:
 			frappe.enqueue(enable_prepared_report, report=self.name)
 
 		frappe.cache().hset("report_execution_time", self.name, execution_time)


### PR DESCRIPTION
As detailed in this post https://discuss.frappe.io/t/prepared-report-auto-enable-even-after-switching-to-disabled/150845

When a user dset the disable prepared report by  going to Role Permissions for Page and Report. After a set time the system re-enables the enable prepared report

I think that if the user manually set the disable prepared report there is a reason and that the system shouldn't just re-enable it again

From I've seen the disable_prepared_report is set on the Role permission for Page and Report so I used that column to check if it manually disabled