### PR TITLE
feat: add attachments_must_be_private to doctype

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -56,6 +56,7 @@
   "allow_events_in_timeline",
   "allow_auto_repeat",
   "make_attachments_public",
+  "attachments_must_be_private",
   "view_settings",
   "show_title_field_in_link",
   "translated_doctype",
@@ -605,6 +606,12 @@
    "label": "Make Attachments Public by Default"
   },
   {
+     "default": "0",
+     "fieldname": "attachments_must_be_private",
+     "fieldtype": "Check",
+     "label": "Attachments Must Be Private"
+   },
+   {
    "default": "0",
    "depends_on": "eval: doc.is_submittable",
    "description": "Enabling this will submit documents in background",
@@ -792,7 +799,7 @@
    "link_fieldname": "document_type"
   }
  ],
- "modified": "2025-09-23 06:48:13.555017",
+ "modified": "2025-10-16 13:23:15.386425",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -137,6 +137,7 @@ class DocType(Document):
 		istable: DF.Check
 		links: DF.Table[DocTypeLink]
 		make_attachments_public: DF.Check
+		attachments_must_be_private: DF.Check
 		max_attachments: DF.Int
 		migration_hash: DF.Data | None
 		module: DF.Link

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -34,6 +34,7 @@
   "column_break_21",
   "allow_copy",
   "make_attachments_public",
+  "attachments_must_be_private",
   "protect_attached_files",
   "view_settings_section",
   "title_field",
@@ -353,6 +354,12 @@
    "label": "Make Attachments Public by Default"
   },
   {
+     "default": "0",
+     "fieldname": "attachments_must_be_private",
+     "fieldtype": "Check",
+     "label": "Attachments Must Be Private"
+   },
+   {
    "default": "0",
    "description": "Enabling this will submit documents in background",
    "fieldname": "queue_in_background",
@@ -445,7 +452,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-09-23 07:13:52.631903",
+ "modified": "2025-10-16 13:24:14.896552",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -60,6 +60,7 @@ class CustomizeForm(Document):
 		link_filters: DF.JSON | None
 		links: DF.Table[DocTypeLink]
 		make_attachments_public: DF.Check
+		attachments_must_be_private: DF.Check
 		max_attachments: DF.Int
 		naming_rule: DF.Literal[
 			"",
@@ -734,6 +735,7 @@ doctype_properties = {
 	"editable_grid": "Check",
 	"max_attachments": "Int",
 	"make_attachments_public": "Check",
+	"attachments_must_be_private": "Check",
 	"protect_attached_files": "Check",
 	"track_changes": "Check",
 	"track_views": "Check",

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -144,6 +144,10 @@ def upload_file():
 	optimize = frappe.form_dict.optimize
 	content = None
 
+	attachments_must_be_private = doctype and frappe.get_meta(doctype).attachments_must_be_private
+	if attachments_must_be_private:
+		is_private = True
+
 	if library_file := frappe.form_dict.get("library_file_name"):
 		frappe.has_permission("File", doc=library_file, throw=True)
 		doc = frappe.get_value(
@@ -152,7 +156,8 @@ def upload_file():
 			["is_private", "file_url", "file_name"],
 			as_dict=True,
 		)
-		is_private = doc.is_private
+		# Use library file's privacy setting unless doctype requires private attachments
+		is_private = doc.is_private if not attachments_must_be_private else True
 		file_url = doc.file_url
 		filename = doc.file_name
 

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -198,7 +198,7 @@
 					v-for="(file, i) in files"
 					:key="file.name"
 					:file="file"
-					:allow_toggle_private="allow_toggle_private"
+					:allow_toggle_private="allow_toggle_private && !attachments_must_be_private"
 					:allow_toggle_optimize="allow_toggle_optimize"
 					@remove="remove_file(file)"
 					@toggle_private="file.private = !file.private"
@@ -277,6 +277,9 @@ const props = defineProps({
 		default: null,
 	},
 	make_attachments_public: {
+		default: null,
+	},
+	attachments_must_be_private: {
 		default: null,
 	},
 	restrictions: {
@@ -428,6 +431,10 @@ function add_files(file_array) {
 		.map((file) => {
 			let is_image = file.type.startsWith("image");
 			let size_kb = file.size / 1024;
+			const is_private = props.attachments_must_be_private
+				? true
+				: !props.make_attachments_public;
+
 			return {
 				file_obj: file,
 				cropper_file: file,
@@ -441,7 +448,7 @@ function add_files(file_array) {
 				request_succeeded: false,
 				error_message: null,
 				uploading: false,
-				private: !props.make_attachments_public,
+				private: is_private,
 			};
 		});
 
@@ -660,7 +667,9 @@ function upload_file(file, i) {
 		if (file.file_obj) {
 			form_data.append("file", file.file_obj, file.name);
 		}
-		form_data.append("is_private", +file.private);
+		const is_private = props.attachments_must_be_private ? true : file.private;
+		form_data.append("is_private", +is_private);
+
 		form_data.append("folder", props.folder);
 
 		if (file.file_url) {

--- a/frappe/public/js/frappe/file_uploader/file_uploader.bundle.js
+++ b/frappe/public/js/frappe/file_uploader/file_uploader.bundle.js
@@ -22,6 +22,7 @@ class FileUploader {
 		attach_doc_image,
 		frm,
 		make_attachments_public,
+		attachments_must_be_private,
 		allow_web_link,
 		allow_take_photo,
 		allow_toggle_private,
@@ -31,7 +32,7 @@ class FileUploader {
 		frm && frm.attachments.max_reached(true);
 
 		if (!wrapper) {
-			this.make_dialog(dialog_title);
+			this.make_dialog(dialog_title, attachments_must_be_private);
 		} else {
 			this.wrapper = wrapper.get ? wrapper.get(0) : wrapper;
 		}
@@ -61,6 +62,7 @@ class FileUploader {
 			disable_file_browser,
 			attach_doc_image,
 			make_attachments_public,
+			attachments_must_be_private,
 			allow_web_link,
 			allow_take_photo,
 			allow_toggle_private,
@@ -89,7 +91,7 @@ class FileUploader {
 			() => this.uploader.files,
 			(files) => {
 				let all_private = files.every((file) => file.private);
-				if (this.dialog) {
+				if (this.dialog && !attachments_must_be_private) {
 					this.dialog.set_secondary_action_label(
 						all_private ? __("Set all public") : __("Set all private")
 					);
@@ -138,19 +140,24 @@ class FileUploader {
 		return this.uploader.upload_files(this.dialog);
 	}
 
-	make_dialog(title) {
-		this.dialog = new frappe.ui.Dialog({
+	make_dialog(title, attachments_must_be_private) {
+		const dialog_config = {
 			title: title || __("Upload"),
 			primary_action_label: __("Upload"),
 			primary_action: () => this.upload_files(),
-			secondary_action_label: __("Set all private"),
-			secondary_action: () => {
-				this.uploader.toggle_all_private();
-			},
 			on_page_show: () => {
 				this.uploader.wrapper_ready = true;
 			},
-		});
+		};
+
+		if (!attachments_must_be_private) {
+			dialog_config.secondary_action_label = __("Set all private");
+			dialog_config.secondary_action = () => {
+				this.uploader.toggle_all_private();
+			};
+		}
+
+		this.dialog = new frappe.ui.Dialog(dialog_config);
 
 		this.wrapper = this.dialog.body;
 		this.dialog.show();

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -84,6 +84,9 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 			options.make_attachments_public = this.df.make_attachment_public
 				? 1
 				: this.frm.meta.make_attachments_public;
+			options.attachments_must_be_private = this.df.attachments_must_be_private
+				? 1
+				: this.frm.meta.attachments_must_be_private;
 		}
 
 		if (this.df.options) {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -369,6 +369,8 @@ frappe.ui.form.Form = class FrappeForm {
 				on_success(file_doc) {
 					me.attachments.attachment_uploaded(file_doc);
 				},
+				make_attachments_public: me.meta.make_attachments_public,
+				attachments_must_be_private: me.meta.attachments_must_be_private,
 			});
 		});
 	}

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -244,6 +244,7 @@ frappe.ui.form.Attachments = class Attachments {
 			},
 			restrictions,
 			make_attachments_public: this.frm.meta.make_attachments_public,
+			attachments_must_be_private: this.frm.meta.attachments_must_be_private,
 		});
 	}
 	get_args() {


### PR DESCRIPTION
## feat: Add "Attachments Must Be Private" setting for DocTypes

This PR introduces a new DocType-level setting called "Attachments Must Be Private" that allows administrators to enforce private attachments for specific DocTypes, providing enhanced security control over sensitive documents and preventing accidental public exposure of confidential files.

**Problem**: Currently, Frappe lacks a mechanism to enforce private attachments for sensitive DocTypes. Users can accidentally make confidential documents publicly accessible, creating potential security risks for organizations handling sensitive data.

**Solution**: This PR adds an "Attachments Must Be Private" checkbox that:
- Automatically enforces private attachments when enabled for a DocType
- Provides server-side validation to prevent security bypasses
- Hides the public/private toggle in the UI when this setting is active
- Maintains full backward compatibility with existing DocTypes and attachments