### PR TITLE
fix(email-template): correct Jinja syntax in file_backup_notification.html

### DIFF
--- a/frappe/templates/emails/file_backup_notification.html
+++ b/frappe/templates/emails/file_backup_notification.html
@@ -1,6 +1,6 @@
 Hello,
 
 <br>
-<p> {{ _("Please use following links to download file backup.") </p>
-<p> {{ _("Public Files Backup:") <a href='{{ backup_path_files }}'>{{ backup_path_files }}</a> </p>
-<p> {{ _("Private Files Backup:") <a href='{{ backup_path_private_files }}'>{{ backup_path_private_files }}</a> </p>
+<p>{{ _("Please use following links to download file backup.") }}</p>
+<p>{{ _("Public Files Backup:") }} <a href="{{ backup_path_files }}">{{ backup_path_files }}</a></p>
+<p>{{ _("Private Files Backup:") }} <a href="{{ backup_path_private_files }}">{{ backup_path_private_files }}</a></p>


### PR DESCRIPTION
Description
This PR fixes a TemplateSyntaxError in the file_backup_notification.html email template caused by missing Jinja closing braces (}}) and improper <p> tag closures.

Corrected Jinja expressions for translated strings.

Moved <a> tags outside Jinja blocks.

Ensured proper HTML structure.

Before:

Backup email jobs failed with jinja2.exceptions.TemplateSyntaxError: unexpected '/'


After:

Jobs completed.

Screenshots
<img width="1292" height="697" alt="Screenshot 2025-08-01 at 6 14 44 PM" src="https://github.com/user-attachments/assets/8ee8cf8d-aebd-450c-8400-bac58d1dd15b" />


Testing

Manually triggered backup_files_and_notify_user via bench.

Verified no error in RQ worker logs.