### PR TITLE
fix: clear all cache after uninstalling apps

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -333,6 +333,7 @@ def install_app(name, verbose=False, set_as_patched=True, force=False):
 	for after_sync in app_hooks.after_sync or []:
 		frappe.get_attr(after_sync)()  #
 
+	frappe.clear_cache()
 	frappe.client_cache.erase_persistent_caches()
 	frappe.flags.in_install = False
 
@@ -416,6 +417,7 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 		remove_from_installed_apps(app_name)
 		frappe.get_single("Installed Applications").update_versions()
 		frappe.db.commit()
+		frappe.clear_cache()
 
 	for after_uninstall in app_hooks.after_uninstall or []:
 		frappe.get_attr(after_uninstall)()
@@ -427,6 +429,9 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 
 	click.secho(f"Uninstalled App {app_name} from Site {site}", fg="green")
 	frappe.flags.in_uninstall = False
+
+	if not dry_run:
+		frappe.clear_cache()
 
 
 def _delete_modules(modules: list[str], dry_run: bool) -> list[str]:


### PR DESCRIPTION
Hooks, installed apps, cached documents etc... so many things to clear: just clear everything on install / uninstall. 