### PR TITLE
fix!: remove default value from time field

### DIFF
--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -146,8 +146,8 @@ def set_dynamic_default_values(doc, parent_doc, parentfield):
 			elif df.fieldtype == "Datetime" and df.default.lower() == "now":
 				doc[df.fieldname] = now_datetime()
 
-		if df.fieldtype == "Time":
-			doc[df.fieldname] = nowtime()
+			elif df.fieldtype == "Time" and df.default.lower() == "now":
+				doc[df.fieldname] = nowtime()
 
 	if parent_doc:
 		doc["parent"] = parent_doc.name


### PR DESCRIPTION
Previously, the time field would take the current time even if no value was set. Now, it will only take the current time if "Now" is specified in the options.

Support ticket: https://support.frappe.io/helpdesk/tickets/43621

Discussion: https://discuss.frappe.io/t/how-to-stop-autofilling-of-time-filedtype-on-saving-the-doctype/118054