### PR TITLE
fix: resolve issue in validate_user_pass_login frappe#33528

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -156,9 +156,8 @@ class SystemSettings(Document):
 
 		social_login_enabled = frappe.db.exists("Social Login Key", {"enable_social_login": 1})
 		ldap_enabled = frappe.db.get_single_value("LDAP Settings", "enabled")
-		login_with_email_link_enabled = frappe.db.get_single_value("System Settings", "login_with_email_link")
 
-		if not (social_login_enabled or ldap_enabled or login_with_email_link_enabled):
+		if not (social_login_enabled or ldap_enabled or self.login_with_email_link):
 			frappe.throw(
 				_(
 					"Please enable atleast one Social Login Key or LDAP or Login With Email Link before disabling username/password based login."


### PR DESCRIPTION
Fixed #33528

During validation of System Settings, the `login_with_email_link` value was being read directly from the database instead of using `self.login_with_email_link`. This caused incorrect validation logic by mixing the current (saved) state with the new (unsaved) state.

For more details see the issue
