### PR TITLE
fix: convert numeric values to strings when searching string fields

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -192,6 +192,23 @@ class Engine:
 		elif not _value and isinstance(_value, list | tuple):
 			_value = ("",)
 
+		if isinstance(_value, int | float) and isinstance(_field, Field):
+			try:
+				field_meta = frappe.get_meta(self.doctype).get_field(field)
+				if field_meta and field_meta.fieldtype in (
+					"Data",
+					"Text",
+					"Small Text",
+					"Text Editor",
+					"Code",
+					"Link",
+					"Dynamic Link",
+				):
+					_value = str(_value)
+			except Exception:
+				# this is safer than allowing implicit type conversion
+				_value = str(_value)
+
 		# Nested set
 		if _operator in OPERATOR_MAP["nested_set"]:
 			hierarchy = _operator


### PR DESCRIPTION
## Summary
Fixes issue #33497 where `frappe.db.get_value()` returns wrong records when searching string fields with numeric values.

## Problem
When using numeric values (int/float) to search string fields, the database performs implicit type conversion leading to lexicographic comparison instead of exact matching. For example:
- Searching for `supplier_part_no = 902042` (integer) returns `"902042-CAMP"` instead of `"902042"`

## Solution
- Added type conversion logic in `_apply_filter` method
- Converts int/float values to strings for string field types (Data, Text, Link, etc.)
- Prevents implicit database type conversion that causes incorrect results
- Maintains backward compatibility with existing string searches

Fixes #33497