### PR TITLE
feat: format date and date-time fields on export

### DIFF
--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -25,8 +25,7 @@ def get_excel_date_format():
 	time_format = frappe.get_system_settings("time_format")
 
 	# Excel-compatible format
-	date_format = date_format.upper().replace("YYYY", "yyyy").replace("DD", "dd").replace("MM", "mm")
-	time_format = time_format.upper().replace("HH", "hh").replace("MM", "mm").replace("SS", "ss")
+	date_format = date_format.replace("mm", "MM")
 
 	return date_format, time_format
 

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+import datetime
 import re
 from io import BytesIO
 
 import openpyxl
 import xlrd
 from openpyxl import load_workbook
+from openpyxl.cell import WriteOnlyCell
 from openpyxl.styles import Font
 from openpyxl.utils import get_column_letter
 from openpyxl.workbook.child import INVALID_TITLE_REGEX
@@ -16,6 +18,11 @@ from frappe.utils.html_utils import unescape_html
 ILLEGAL_CHARACTERS_RE = re.compile(
 	r"[\000-\010]|[\013-\014]|[\016-\037]|\uFEFF|\uFFFE|\uFFFF|[\uD800-\uDFFF]"
 )
+
+
+def get_excel_date_format():
+	frappe_format = frappe.get_system_settings("date_format") or "yyyy-mm-dd"
+	return frappe_format.upper().replace("YYYY", "yyyy").replace("DD", "dd").replace("MM", "mm")
 
 
 # return xlsx file object
@@ -34,6 +41,8 @@ def make_xlsx(data, sheet_name, wb=None, column_widths=None):
 	row1 = ws.row_dimensions[1]
 	row1.font = Font(name="Calibri", bold=True)
 
+	date_format = get_excel_date_format()
+
 	for row in data:
 		clean_row = []
 		for item in row:
@@ -46,7 +55,15 @@ def make_xlsx(data, sheet_name, wb=None, column_widths=None):
 				# Remove illegal characters from the string
 				value = ILLEGAL_CHARACTERS_RE.sub("", value)
 
-			clean_row.append(value)
+			if isinstance(value, datetime.date | datetime.datetime):
+				if isinstance(value, datetime.datetime):
+					date_format += " HH:MM:SS"
+
+				cell = WriteOnlyCell(ws, value=value)
+				cell.number_format = date_format
+				clean_row.append(cell)
+			else:
+				clean_row.append(value)
 
 		ws.append(clean_row)
 

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -21,8 +21,14 @@ ILLEGAL_CHARACTERS_RE = re.compile(
 
 
 def get_excel_date_format():
-	frappe_format = frappe.get_system_settings("date_format") or "yyyy-mm-dd"
-	return frappe_format.upper().replace("YYYY", "yyyy").replace("DD", "dd").replace("MM", "mm")
+	date_format = frappe.get_system_settings("date_format")
+	time_format = frappe.get_system_settings("time_format")
+
+	# Excel-compatible format
+	date_format = date_format.upper().replace("YYYY", "yyyy").replace("DD", "dd").replace("MM", "mm")
+	time_format = time_format.upper().replace("HH", "hh").replace("MM", "mm").replace("SS", "ss")
+
+	return date_format, time_format
 
 
 # return xlsx file object
@@ -41,7 +47,7 @@ def make_xlsx(data, sheet_name, wb=None, column_widths=None):
 	row1 = ws.row_dimensions[1]
 	row1.font = Font(name="Calibri", bold=True)
 
-	date_format = get_excel_date_format()
+	date_format, time_format = get_excel_date_format()
 
 	for row in data:
 		clean_row = []
@@ -56,11 +62,12 @@ def make_xlsx(data, sheet_name, wb=None, column_widths=None):
 				value = ILLEGAL_CHARACTERS_RE.sub("", value)
 
 			if isinstance(value, datetime.date | datetime.datetime):
+				number_format = date_format
 				if isinstance(value, datetime.datetime):
-					date_format += " HH:MM:SS"
+					number_format = f"{date_format} {time_format}"
 
 				cell = WriteOnlyCell(ws, value=value)
-				cell.number_format = date_format
+				cell.number_format = number_format
 				clean_row.append(cell)
 			else:
 				clean_row.append(value)


### PR DESCRIPTION
Support: https://support.frappe.io/helpdesk/tickets/45517

In the earlier implementation, date and datetime fields were exported in their raw database format. This PR introduces proper formatting for these fields during export to improve readability and consistency.

`no-docs`