### PR TITLE
fix: Dont show estimate tooltip on small counts

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -652,7 +652,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		let $count = this.get_count_element();
 		this.get_count_str().then((count) => {
 			$count.html(`<span>${count}</span>`);
-			if (this.count_upper_bound) {
+			if (
+				this.count_upper_bound &&
+				(this.total_count == this.count_upper_bound || this.total_count == null)
+			) {
 				$count.attr(
 					"title",
 					__(


### PR DESCRIPTION
These are "accurate" even with max limits. The estimated count message only makes sense for:

- when count is 1001 (same as max limit)
- when count isn't fetched at all (because of timeout)
