### PR TITLE
fix: don't carry forward cc/bcc if not reply all

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -344,8 +344,11 @@ frappe.views.CommunicationComposer = class {
 			if (this.last_email.sender == this.sender) {
 				this.recipients = this.last_email.recipients;
 			}
-			this.cc = this.last_email.cc;
-			this.bcc = this.last_email.bcc;
+
+			if (this.reply_all) {
+				this.cc = this.last_email.cc;
+				this.bcc = this.last_email.bcc;
+			}
 		}
 
 		if (!this.forward && !this.recipients) {


### PR DESCRIPTION
Currently the CC and BCC were carried forward even if it was **not** reply all.

https://support.frappe.io/helpdesk/tickets/44082?view=VIEW-HD+Ticket-610