### PR TITLE
fix: allow download via API, if at least one file copy is downloadable

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -11,6 +11,7 @@ import frappe
 import frappe.sessions
 import frappe.utils
 from frappe import _, is_whitelisted, ping
+from frappe.core.doctype.file.utils import find_file_by_url
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
 from frappe.monitor import add_data_to_monitor
 from frappe.permissions import check_doctype_permission
@@ -230,8 +231,8 @@ def download_file(file_url: str):
 	Endpoints : download_file, frappe.core.doctype.file.file.download_file
 	URL Params : file_name = /path/to/file relative to site path
 	"""
-	file: File = frappe.get_doc("File", {"file_url": file_url})
-	if not file.is_downloadable():
+	file = find_file_by_url(file_url)
+	if not file:
 		raise frappe.PermissionError
 
 	frappe.local.response.filename = os.path.basename(file_url)


### PR DESCRIPTION
For file downloads via API, the use case described in the comments of `find_file_by_url` shall be covered:
<img width="596" height="265" alt="A file might be attached to multiple documents. If the file is accessible from any one of those documents then it should be downloadable." src="https://github.com/user-attachments/assets/f62f4f42-3d71-49e6-8666-83450a4713a6" />