### PR TITLE
fix: set sender in compose mail if from timeline

### DIFF
--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -564,6 +564,7 @@ class FormTimeline extends BaseTimeline {
 			last_email: communication_doc,
 			subject: communication_doc && communication_doc.subject,
 			reply_all: reply_all,
+			sender: communication_doc?.sender,
 		};
 
 		const email_accounts = frappe.boot.email_accounts


### PR DESCRIPTION
### Before

If the sender does "Reply All", the recipient was getting set to the sender themselves.

### Expected (and after fix)

The recipients should be set to the last email's recipients. The code in  `CommunicationComposer` already handles this case, but the sender was not correctly set on click of these buttons.

> I have also checked this behaviour on GMail.

Ticket: https://support.frappe.io/helpdesk/tickets/44082?view=VIEW-HD+Ticket-610