### PR TITLE
feat(report-builder): Enable editing standard reports in developer mode

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -321,7 +321,7 @@ def save_report(name, doctype, report_settings):
 
 	if frappe.db.exists("Report", name):
 		report = frappe.get_doc("Report", name)
-		if report.is_standard == "Yes":
+		if report.is_standard == "Yes" and not frappe.local.dev_server:
 			frappe.throw(_("Standard Reports cannot be edited"))
 
 		if report.report_type != "Report Builder":

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -321,7 +321,7 @@ def save_report(name, doctype, report_settings):
 
 	if frappe.db.exists("Report", name):
 		report = frappe.get_doc("Report", name)
-		if report.is_standard == "Yes" and not frappe.local.dev_server:
+		if report.is_standard == "Yes" and not frappe.conf.developer_mode:
 			frappe.throw(_("Standard Reports cannot be edited"))
 
 		if report.report_type != "Report Builder":

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1715,9 +1715,24 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 		const can_edit_or_delete = (action) => {
 			const method = action == "delete" ? "can_delete" : "can_write";
+			const is_standard_report = this.report_doc && this.report_doc.is_standard === "Yes";
+			const is_developer_mode = frappe.boot.developer_mode;
+
+			// For standard reports, only allow save (not delete) in developer mode
+			if (is_standard_report) {
+				if (action === "delete") {
+					return false; // Never allow deleting standard reports
+				}
+				return (
+					is_developer_mode &&
+					(frappe.model[method]("Report") ||
+						this.report_doc.owner === frappe.session.user)
+				);
+			}
+
+			// For non-standard reports, use existing logic
 			return (
 				this.report_doc &&
-				this.report_doc.is_standard !== "Yes" &&
 				(frappe.model[method]("Report") || this.report_doc.owner === frappe.session.user)
 			);
 		};


### PR DESCRIPTION
## Summary

This PR enables developers to edit standard Report Builder reports when developer mode is active, while maintaining system integrity by preventing deletion of standard reports.

## Changes Made

### Frontend (`report_view.js`)
- Modified `can_edit_or_delete()` function to check developer mode for standard reports
- **Save button**: Shows for standard reports only when `frappe.boot.developer_mode` is true
- **Delete button**: Always hidden for standard reports (safety measure)
- Maintains existing behavior for non-standard reports

### Backend (`reportview.py`)
- Updated `save_report()` function to allow editing standard reports when `frappe.local.dev_server` is true
- Maintains consistency with existing `delete_report()` function logic
- Preserves production safety by blocking standard report modifications in production

no-docs
