### PR TITLE
fix(phone_field): Allow conventional international phone number formats.

### DIFF
--- a/frappe/public/js/frappe/form/controls/phone.js
+++ b/frappe/public/js/frappe/form/controls/phone.js
@@ -160,7 +160,8 @@ frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlD
 		if (!this.country_codes) {
 			await this.setup_country_codes();
 		}
-		// spiliting if there are multiple hyphens
+
+		// splitting if there are multiple hyphens
 		const parts = value ? value.split("-") : [];
 
 		// Get the full country code
@@ -188,8 +189,8 @@ frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlD
 			this.update_padding();
 			this.$input.val(parts.join("-"));
 
+			// Return if we have a valid number with country code
 			return;
-			// Return if we have a vaild number with country code
 		} else if (this.$isd.text().trim() && this.value) {
 			let code_number = this.$isd.text() + "-" + value;
 			this.set_value(code_number);

--- a/frappe/public/js/frappe/form/controls/phone.js
+++ b/frappe/public/js/frappe/form/controls/phone.js
@@ -22,6 +22,15 @@ frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlD
 	}
 
 	input_events() {
+		// Allows only numbers and common formatting characters, to allow conventional format.
+		this.$input.on("input", () => {
+			const current_value = this.$input.val();
+			const formatted_value = current_value.replace(/[^0-9 ()+.-]/g, "");
+			if (current_value !== formatted_value) {
+				this.$input.val(formatted_value);
+			}
+		});
+
 		this.$input.keydown((e) => {
 			const key_code = e.keyCode;
 			if ([frappe.ui.keyCode.BACKSPACE].includes(key_code)) {
@@ -151,22 +160,36 @@ frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlD
 		if (!this.country_codes) {
 			await this.setup_country_codes();
 		}
-		if (value && value.includes("-") && value.split("-").length == 2) {
+		// spiliting if there are multiple hyphens
+		const parts = value ? value.split("-") : [];
+
+		// Get the full country code
+		const matched_country_data =
+			parts.length > 1 &&
+			Object.values(this.country_codes).find(
+				(c) => String(c.isd).replace("+", "") === String(parts[0]).replace("+", "")
+			);
+
+		// Assign the country code and flag icon in the country code field
+		if (matched_country_data) {
 			if (!this.selected_icon.find("svg").hasClass("hide")) {
 				this.selected_icon.find("svg").toggleClass("hide");
 			}
-			let isd = this.value.split("-")[0];
-			this.get_country_code_and_change_flag(isd);
-			this.country_code_picker.set_country(isd);
+
+			// We will use the official ISD we found
+			const canonical_isd = matched_country_data.isd;
+			parts.shift();
+
+			// We will use the canonical isd not numeric isd
+			this.get_country_code_and_change_flag(canonical_isd);
+			this.country_code_picker.set_country(canonical_isd);
 			this.country_code_picker.refresh();
-			if (
-				this.country_code_picker.country &&
-				this.country_code_picker.country !== this.$isd.text()
-			) {
-				this.$isd.length && this.$isd.text(isd);
-			}
+			this.$isd.length && this.$isd.text(canonical_isd);
 			this.update_padding();
-			this.$input.val(value.split("-").pop());
+			this.$input.val(parts.join("-"));
+
+			return;
+			// Return if we have a vaild number with country code
 		} else if (this.$isd.text().trim() && this.value) {
 			let code_number = this.$isd.text() + "-" + value;
 			this.set_value(code_number);


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

The issue was raised as the phone field is allowing text characters, I have made changes to allow character so most of the international formats can be allowed while properly parsing the country code. Tested this will work if the input is pasted.
Prior to changes. If we just  allow numbers the international numbers with space format are not allowed which is prompting the number field is incorrect which caused this many changes. If we want complete solution covering all the 
formats we have to use standard library.
<img width="933" height="364" alt="Before" src="https://github.com/user-attachments/assets/80ceea41-4132-45f2-b8c9-1b52c01da351" />

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Properly tested for different international format. If paste the number with international country code it will populate the country code field. Changed the code where necessary only.
<img width="933" height="364" alt="After" src="https://github.com/user-attachments/assets/3f22b22d-49c3-4f40-893c-f7f0e33b0d75" />


> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
`no-doc`