### PR TITLE
feat: Add employee participant selection with permission handling

### DIFF
--- a/frappe/desk/doctype/event/event.js
+++ b/frappe/desk/doctype/event/event.js
@@ -42,6 +42,14 @@ frappe.ui.form.on("Event", {
 			__("Add Participants")
 		);
 
+		frm.add_custom_button(
+			__("Add Employee"),
+			function () {
+				new frappe.desk.eventParticipants(frm, "Employee");
+			},
+			__("Add Participants")
+		);
+
 		const [ends_on_date] = frm.doc.ends_on
 			? frm.doc.ends_on.split(" ")
 			: frm.doc.starts_on?.split(" ") || [];
@@ -105,13 +113,22 @@ frappe.desk.eventParticipants = class eventParticipants {
 		let me = this;
 
 		let table = me.frm.get_field("event_participants").grid;
-		new frappe.ui.form.LinkSelector({
+
+		let link_selector_options = {
 			doctype: me.doctype,
 			dynamic_link_field: "reference_doctype",
 			dynamic_link_reference: me.doctype,
 			fieldname: "reference_docname",
 			target: table,
 			txt: "",
-		});
+		};
+
+		// If Employee doctype, use custom query to handle permissions
+		if (me.doctype === "Employee") {
+			link_selector_options.query =
+				"frappe.desk.doctype.event.event.get_employees_for_event_participation";
+		}
+
+		new frappe.ui.form.LinkSelector(link_selector_options);
 	}
 };

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -6,6 +6,7 @@ import json
 from datetime import date, datetime
 
 import frappe
+import frappe.permissions
 import frappe.share
 from frappe import _
 from frappe.contacts.doctype.contact.contact import get_default_contact
@@ -104,6 +105,32 @@ class Event(Document):
 
 		if not self.sync_with_google_calendar:
 			self.add_video_conferencing = 0
+
+		# Validate participant permissions
+		self.validate_participants_permissions()
+
+	def validate_participants_permissions(self):
+		"""Validate that current user can add the selected participants"""
+		if not self.event_participants:
+			return
+
+		for participant in self.event_participants:
+			if participant.reference_doctype == "Employee":
+				# Check if user has permission to access this employee
+				if not frappe.has_permission("Employee", "read", participant.reference_docname):
+					# Check user permissions
+					user_permissions = frappe.permissions.get_user_permissions(frappe.session.user)
+					employee_permissions = user_permissions.get("Employee", [])
+
+					allowed_employees = [p.get("doc") for p in employee_permissions if p.get("doc")]
+
+					if allowed_employees and participant.reference_docname not in allowed_employees:
+						frappe.throw(
+							_("You don't have permission to add Employee {0} as a participant").format(
+								participant.reference_docname
+							),
+							frappe.PermissionError
+						)
 
 	def before_save(self):
 		self.set_participants_email()
@@ -204,6 +231,43 @@ class Event(Document):
 			participant.email = (
 				frappe.get_value("Contact", participant_contact, "email_id") if participant_contact else None
 			)
+
+
+@frappe.whitelist()
+def get_employees_for_event_participation(txt="", searchfield="employee_name", start=0, page_len=20):
+	"""Get employees that current user can access for adding as event participants"""
+
+	# Check if user has permission to read Employee doctype
+	if not frappe.has_permission("Employee", "read"):
+		return []
+
+	filters = []
+
+	# Get user permissions for Employee
+	user_permissions = frappe.permissions.get_user_permissions(frappe.session.user)
+	employee_permissions = user_permissions.get("Employee", [])
+
+	if employee_permissions:
+		# User has specific employee permissions, filter accordingly
+		allowed_employees = [p.get("doc") for p in employee_permissions if p.get("doc")]
+		if allowed_employees:
+			filters.append(["Employee", "name", "in", allowed_employees])
+
+	# Add text search filter
+	if txt:
+		filters.append(["Employee", searchfield, "like", f"%{txt}%"])
+
+	# Get employees based on filters
+	employees = frappe.get_list(
+		"Employee",
+		fields=["name", "employee_name", "company"],
+		filters=filters,
+		limit_start=start,
+		limit_page_length=page_len,
+		order_by="employee_name"
+	)
+
+	return [[emp.name, emp.employee_name, emp.company] for emp in employees]
 
 
 @frappe.whitelist()


### PR DESCRIPTION
### PR Description

Closes frappe/erpnext#49056

### **Details**
This PR solves the issue where team members cannot add employees as participants in calendar events due to user permission restrictions. Previously, users would encounter permission errors when trying to select employees they don't have explicit access to.

### **Changes Made**
- **Add Employee Button**: Added "Add Employee" button to Event form alongside existing "Add Contacts" button
- **Permission-Aware Selection**: Enhanced eventParticipants class to use custom query that respects user permissions for Employee doctype
- **Server-Side Validation**: Added validation to prevent unauthorized employee additions with clear error messages
- **Backward Compatibility**: Maintained existing Contact functionality without any breaking changes

### **Problem Solved**
- Users can now successfully add employees as event participants within their permission scope
- Clear error handling for permission violations
- Improved user experience with proper employee filtering based on user permissions

### **Technical Implementation**
- Frontend: Added Employee button and enhanced LinkSelector with custom query
- Backend: Implemented `get_employees_for_event_participation()` method with permission filtering
- Validation: Added `validate_participants_permissions()` for server-side security