### PR TITLE
fix: documentation link email linking to doc

### DIFF
--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -497,7 +497,7 @@
   },
   {
    "default": "0",
-   "description": "For more information, <a class=\"text-muted\" href=\"https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document\">click here</a>.",
+   "description": "For more information, <a class=\"text-muted\" href=\"https://docs.frappe.io/erpnext/user/manual/en/linking-emails-to-document\">click here</a>.",
    "fieldname": "enable_automatic_linking",
    "fieldtype": "Check",
    "hide_days": 1,


### PR DESCRIPTION
This one:

<img width="1610" height="732" alt="CleanShot 2025-08-08 at 11 28 13@2x" src="https://github.com/user-attachments/assets/c7bd9999-2059-4571-952b-35d3bc2b111f" />
