### PR TITLE
fix(ui): MultiSelect Field to have same min-width as link field

### DIFF
--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -105,6 +105,10 @@ select.form-control {
 		width: 100%;
 	}
 
+	ul {
+		min-width: 300px;
+	}
+
 	li {
 		padding: var(--padding-sm);
 	}


### PR DESCRIPTION
<img width="1134" height="666" alt="CleanShot 2025-08-08 at 12 42 26@2x" src="https://github.com/user-attachments/assets/f460cbd8-e21e-43de-92a4-5a8202474049" />


Link field for reference:

<img width="1118" height="646" alt="CleanShot 2025-08-08 at 12 43 58@2x" src="https://github.com/user-attachments/assets/8c563bd0-b6bd-42b3-8c44-0a176592ad5f" />


Ticket: https://support.frappe.io/helpdesk/tickets/45788?view=VIEW-HD+Ticket-610