### PR TITLE
feat: Allow local translation as input for doctype

### DIFF
--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -102,8 +102,7 @@ def get_communication_doctype(doctype, txt, searchfield, start, page_len, filter
 
 	for dt in com_doctypes:
 		if dt in can_read:
-			translated = _(dt)
-			if txt_lower in dt.lower() or txt_lower in translated.lower():
+			if txt_lower in dt.lower() or txt_lower in _(dt).lower():
 				results.append([dt])
 
 	return results

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -79,6 +79,7 @@ def get_communication_doctype(doctype, txt, searchfield, start, page_len, filter
 	user_perms = frappe.utils.user.UserPermissions(frappe.session.user)
 	user_perms.build_permissions()
 	can_read = user_perms.can_read
+	from frappe import _
 	from frappe.modules import load_doctype_module
 
 	com_doctypes = []
@@ -96,7 +97,16 @@ def get_communication_doctype(doctype, txt, searchfield, start, page_len, filter
 			d[0] for d in frappe.db.get_values("DocType", {"issingle": 0, "istable": 0, "hide_toolbar": 0})
 		]
 
-	return [[dt] for dt in com_doctypes if txt.lower().replace("%", "") in dt.lower() and dt in can_read]
+	results = []
+	txt_lower = txt.lower().replace("%", "")
+
+	for dt in com_doctypes:
+		if dt in can_read:
+			translated = _(dt)
+			if txt_lower in dt.lower() or txt_lower in translated.lower():
+				results.append([dt])
+
+	return results
 
 
 def sendmail(


### PR DESCRIPTION
In the communication doctype, using the "Relink" button, in any selected translation, the selection field for "Reference DocType" shows the translated string of the doctype, but the search does not allow input in the local language. The doctype name has to typed in English.

This PR allows search in the translated version as well as in English.

<img width="1142" height="864" alt="grafik" src="https://github.com/user-attachments/assets/22d3062e-e702-4e5e-960b-800ead385f77" />
