### PR TITLE
refactor: fetch openID config in backend

### DIFF
--- a/frappe/integrations/doctype/connected_app/connected_app.js
+++ b/frappe/integrations/doctype/connected_app/connected_app.js
@@ -4,21 +4,13 @@
 frappe.ui.form.on("Connected App", {
 	refresh: (frm) => {
 		frm.add_custom_button(__("Get OpenID Configuration"), async () => {
-			if (!frm.doc.openid_configuration) {
-				frappe.msgprint(__("Please enter OpenID Configuration URL"));
-			} else {
-				try {
-					const response = await fetch(frm.doc.openid_configuration);
-					const oidc = await response.json();
-					frm.set_value("authorization_uri", oidc.authorization_endpoint);
-					frm.set_value("token_uri", oidc.token_endpoint);
-					frm.set_value("userinfo_uri", oidc.userinfo_endpoint);
-					frm.set_value("introspection_uri", oidc.introspection_endpoint);
-					frm.set_value("revocation_uri", oidc.revocation_endpoint);
-				} catch (error) {
-					frappe.msgprint(__("Please check OpenID Configuration URL"));
-				}
-			}
+			frm.call("get_openid_configuration").then(({ message: oidc }) => {
+				frm.set_value("authorization_uri", oidc.authorization_endpoint);
+				frm.set_value("token_uri", oidc.token_endpoint);
+				frm.set_value("userinfo_uri", oidc.userinfo_endpoint);
+				frm.set_value("introspection_uri", oidc.introspection_endpoint);
+				frm.set_value("revocation_uri", oidc.revocation_endpoint);
+			});
 		});
 
 		if (!frm.is_new()) {
@@ -26,7 +18,7 @@ frappe.ui.form.on("Connected App", {
 				frappe.call({
 					method: "initiate_web_application_flow",
 					doc: frm.doc,
-					callback: function (r) {
+					callback: (r) => {
 						window.open(r.message, "_blank");
 					},
 				});

--- a/frappe/integrations/doctype/connected_app/connected_app.js
+++ b/frappe/integrations/doctype/connected_app/connected_app.js
@@ -11,6 +11,7 @@ frappe.ui.form.on("Connected App", {
 				frm.set_value("introspection_uri", oidc.introspection_endpoint);
 				frm.set_value("revocation_uri", oidc.revocation_endpoint);
 
+				frm.fields_dict.authorization_uri.section.collapse(false); // Un-collapse
 				frappe.show_alert(__("OpenID Configuration fetched successfully!"));
 			});
 		});

--- a/frappe/integrations/doctype/connected_app/connected_app.js
+++ b/frappe/integrations/doctype/connected_app/connected_app.js
@@ -10,6 +10,8 @@ frappe.ui.form.on("Connected App", {
 				frm.set_value("userinfo_uri", oidc.userinfo_endpoint);
 				frm.set_value("introspection_uri", oidc.introspection_endpoint);
 				frm.set_value("revocation_uri", oidc.revocation_endpoint);
+
+				frappe.show_alert(__("OpenID Configuration fetched successfully!"));
 			});
 		});
 

--- a/frappe/integrations/doctype/connected_app/connected_app.py
+++ b/frappe/integrations/doctype/connected_app/connected_app.py
@@ -9,6 +9,7 @@ from requests_oauthlib import OAuth2Session
 
 import frappe
 from frappe import _
+from frappe.integrations.utils import make_get_request
 from frappe.model.document import Document
 
 if any((os.getenv("CI"), frappe.conf.developer_mode, frappe.conf.allow_tests)):
@@ -46,6 +47,12 @@ class ConnectedApp(Document):
 	"""Connect to a remote oAuth Server. Retrieve and store user's access token
 	in a Token Cache.
 	"""
+
+	@frappe.whitelist()
+	def get_openid_configuration(self):
+		if not self.openid_configuration:
+			frappe.throw(_("Please enter OpenID Configuration URL"))
+		return make_get_request(self.openid_configuration)
 
 	def validate(self):
 		base_url = frappe.utils.get_url()


### PR DESCRIPTION
### What has changed?

The `fetch` used to happen on the frontend, which almost always caused a `cors` error. This PR moves the fetch to backend and also minor UX improvements.