### PR TITLE
fix: invitation user relation

### DIFF
--- a/frappe/core/api/user_invitation.py
+++ b/frappe/core/api/user_invitation.py
@@ -19,7 +19,7 @@ def invite_by_email(
 	# get relevant data from the database
 	accepted_invite_emails = frappe.db.get_all(
 		"User Invitation",
-		filters={"email": ["in", email_list], "status": "Accepted", "app_name": app_name},
+		filters={"email": ["in", email_list], "status": "Accepted", "app_name": app_name, "user": ["is", "set"]},
 		pluck="email",
 	)
 	pending_invite_emails = frappe.db.get_all(

--- a/frappe/core/api/user_invitation.py
+++ b/frappe/core/api/user_invitation.py
@@ -17,6 +17,11 @@ def invite_by_email(
 		frappe.throw(title=_("Invalid input"), msg=_("No email addresses to invite"))
 
 	# get relevant data from the database
+	disabled_user_emails = frappe.db.get_all(
+		"User",
+		filters={"email": ["in", email_list], "enabled": 0},
+		pluck="email",
+	)
 	accepted_invite_emails = frappe.db.get_all(
 		"User Invitation",
 		filters={"email": ["in", email_list], "status": "Accepted", "app_name": app_name, "user": ["is", "set"]},
@@ -29,7 +34,7 @@ def invite_by_email(
 	)
 
 	# create invitation documents
-	to_invite = list(set(email_list) - set(accepted_invite_emails) - set(pending_invite_emails))
+	to_invite = list(set(email_list) - set(disabled_user_emails) - set(accepted_invite_emails) - set(pending_invite_emails))
 	for email in to_invite:
 		frappe.get_doc(
 			doctype="User Invitation",
@@ -40,6 +45,7 @@ def invite_by_email(
 		).insert(ignore_permissions=True)
 
 	return {
+		"disabled_user_emails": disabled_user_emails,
 		"accepted_invite_emails": accepted_invite_emails,
 		"pending_invite_emails": pending_invite_emails,
 		"invited_emails": to_invite,

--- a/frappe/core/api/user_invitation.py
+++ b/frappe/core/api/user_invitation.py
@@ -24,7 +24,12 @@ def invite_by_email(
 	)
 	accepted_invite_emails = frappe.db.get_all(
 		"User Invitation",
-		filters={"email": ["in", email_list], "status": "Accepted", "app_name": app_name, "user": ["is", "set"]},
+		filters={
+			"email": ["in", email_list],
+			"status": "Accepted",
+			"app_name": app_name,
+			"user": ["is", "set"],
+		},
 		pluck="email",
 	)
 	pending_invite_emails = frappe.db.get_all(
@@ -34,7 +39,9 @@ def invite_by_email(
 	)
 
 	# create invitation documents
-	to_invite = list(set(email_list) - set(disabled_user_emails) - set(accepted_invite_emails) - set(pending_invite_emails))
+	to_invite = list(
+		set(email_list) - set(disabled_user_emails) - set(accepted_invite_emails) - set(pending_invite_emails)
+	)
 	for email in to_invite:
 		frappe.get_doc(
 			doctype="User Invitation",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -590,6 +590,13 @@ class User(Document):
 					note.remove(row)
 			note.save(ignore_permissions=True)
 
+		# Unlink user from all of its invitation docs
+		invites = frappe.db.get_all("User Invitation", filters={"email": self.name}, pluck="name")
+		for invite in invites:
+			invite_doc = frappe.get_doc("User Invitation", invite)
+			invite_doc.user = None
+			invite_doc.save(ignore_permissions=True)
+
 	def before_rename(self, old_name, new_name, merge=False):
 		# if merging, delete the old user notification settings
 		if merge:

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -590,13 +590,6 @@ class User(Document):
 					note.remove(row)
 			note.save(ignore_permissions=True)
 
-		# Unlink user from all of its invitation docs
-		invites = frappe.db.get_all("User Invitation", filters={"email": self.name}, pluck="name")
-		for invite in invites:
-			invite_doc = frappe.get_doc("User Invitation", invite)
-			invite_doc.user = None
-			invite_doc.save(ignore_permissions=True)
-
 	def before_rename(self, old_name, new_name, merge=False):
 		# if merging, delete the old user notification settings
 		if merge:

--- a/frappe/core/doctype/user_invitation/internal_doc/index.md
+++ b/frappe/core/doctype/user_invitation/internal_doc/index.md
@@ -104,3 +104,4 @@ Cancels a specific pending invitation associated with an installed Framework app
 - Once an invitation document is created from Desk, all of the fields are immutable except the `Redirect To Path` field which is mutable only when the invitation status is `Pending`.
 - To manually mark an invitation as expired, you can use the `expire` method on the invitation document.
 - To manually cancel an invitation, you can use the `cancel_invite` method on the invitation document.
+- Disabled users cannot be invited. Trying to invite a disabled user from the Desk will generate an error and the whitelisted functions will ignore emails associated with disabled users.

--- a/frappe/core/doctype/user_invitation/test_user_invitation.py
+++ b/frappe/core/doctype/user_invitation/test_user_invitation.py
@@ -20,6 +20,7 @@ emails = [
 	"test_user_invite3@example.com",
 	"test_user_invite4@example.com",
 	"test_user_invite5@example.com",
+	"test_user_invite6@example.com",
 ]
 
 
@@ -155,6 +156,7 @@ class IntegrationTestUserInvitation(IntegrationTestCase):
 			roles=["System Manager"],
 			redirect_to_path="/xyz",
 		)
+		self.assertSequenceEqual(res["disabled_user_emails"], [])
 		self.assertSequenceEqual(res["accepted_invite_emails"], [accepted_invite_email])
 		self.assertSequenceEqual(res["pending_invite_emails"], [pending_invite_email])
 		self.assertSequenceEqual(res["invited_emails"], [email_to_invite])
@@ -162,6 +164,27 @@ class IntegrationTestUserInvitation(IntegrationTestCase):
 		user = frappe.get_doc("User", invitation.email)
 		IntegrationTestUserInvitation.delete_invitation(invitation.name)
 		frappe.delete_doc("User", user.name)
+
+	def test_invite_by_email_api_disabled_user(self):
+		user = frappe.new_doc("User")
+		user.first_name = "Random"
+		user.last_name = "User"
+		user.email = emails[5]
+		user.append_roles("System Manager")
+		user.insert()
+		user.reload()
+		user.enabled = 0
+		user.save()
+		res = invite_by_email(
+			emails=user.email,
+			roles=["System Manager"],
+			redirect_to_path="/xyz",
+		)
+		self.assertSequenceEqual(res["disabled_user_emails"], [user.email])
+		self.assertSequenceEqual(res["accepted_invite_emails"], [])
+		self.assertSequenceEqual(res["pending_invite_emails"], [])
+		self.assertSequenceEqual(res["invited_emails"], [])
+		frappe.delete_doc("User", user.email)
 
 	def test_accept_invitation_api_pass_redirect(self):
 		invitation = frappe.get_doc(

--- a/frappe/core/doctype/user_invitation/test_user_invitation.py
+++ b/frappe/core/doctype/user_invitation/test_user_invitation.py
@@ -138,8 +138,7 @@ class IntegrationTestUserInvitation(IntegrationTestCase):
 			redirect_to_path="/abc",
 			app_name="frappe",
 		).insert()
-		invitation.status = "Accepted"
-		invitation.save()
+		invitation.accept()
 		self.assertEqual(len(self.get_email_names(False)), 1)
 		pending_invite_email = emails[2]
 		frappe.get_doc(
@@ -160,6 +159,9 @@ class IntegrationTestUserInvitation(IntegrationTestCase):
 		self.assertSequenceEqual(res["pending_invite_emails"], [pending_invite_email])
 		self.assertSequenceEqual(res["invited_emails"], [email_to_invite])
 		self.assertEqual(len(self.get_email_names(False)), 3)
+		user = frappe.get_doc("User", invitation.email)
+		IntegrationTestUserInvitation.delete_invitation(invitation.name)
+		frappe.delete_doc("User", user.name)
 
 	def test_accept_invitation_api_pass_redirect(self):
 		invitation = frappe.get_doc(

--- a/frappe/core/doctype/user_invitation/user_invitation.py
+++ b/frappe/core/doctype/user_invitation/user_invitation.py
@@ -84,7 +84,7 @@ class UserInvitation(Document):
 		self._validate_roles()
 		self._validate_email()
 		if frappe.db.get_value(
-			"User Invitation", filters={"email": self.email, "status": "Accepted", "app_name": self.app_name}
+			"User Invitation", filters={"email": self.email, "status": "Accepted", "app_name": self.app_name, "user": ["is", "set"]}
 		):
 			frappe.throw(title=_("Error"), msg=_("invitation already accepted"))
 		if frappe.db.get_value(

--- a/frappe/core/doctype/user_invitation/user_invitation.py
+++ b/frappe/core/doctype/user_invitation/user_invitation.py
@@ -91,6 +91,9 @@ class UserInvitation(Document):
 			"User Invitation", filters={"email": self.email, "status": "Pending", "app_name": self.app_name}
 		):
 			frappe.throw(title=_("Error"), msg=_("invitation already exists"))
+		user_enabled = frappe.db.get_value("User", self.email, "enabled")
+		if user_enabled is not None and user_enabled == 0:
+			frappe.throw(title=_("Error"), msg=_("User is disabled"))
 
 	def _after_insert(self):
 		key = frappe.generate_hash()

--- a/frappe/core/doctype/user_invitation/user_invitation.py
+++ b/frappe/core/doctype/user_invitation/user_invitation.py
@@ -84,7 +84,13 @@ class UserInvitation(Document):
 		self._validate_roles()
 		self._validate_email()
 		if frappe.db.get_value(
-			"User Invitation", filters={"email": self.email, "status": "Accepted", "app_name": self.app_name, "user": ["is", "set"]}
+			"User Invitation",
+			filters={
+				"email": self.email,
+				"status": "Accepted",
+				"app_name": self.app_name,
+				"user": ["is", "set"],
+			},
 		):
 			frappe.throw(title=_("Error"), msg=_("invitation already accepted"))
 		if frappe.db.get_value(

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -414,7 +414,6 @@ ignore_links_on_delete = [
 	"Route History",
 	"Access Log",
 	"Permission Log",
-	"User Invitation",
 ]
 
 # Request Hooks

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -414,6 +414,7 @@ ignore_links_on_delete = [
 	"Route History",
 	"Access Log",
 	"Permission Log",
+	"User Invitation",
 ]
 
 # Request Hooks


### PR DESCRIPTION
Since `User Invitation` documents cannot be deleted via Desk, users associated with user invitations cannot be deleted (a user is linked to one or more user invitations). Also, inviting disabled users should be avoided.

This PR:
1. enables user deletion by unlinking them from the invitations right before deleting the users.
2. disallows inviting disabled users. 


depends-on: #33308 