### PR TITLE
fix: version diff for empty datetime fields

### DIFF
--- a/frappe/core/doctype/version/version.py
+++ b/frappe/core/doctype/version/version.py
@@ -76,7 +76,6 @@ class Version(Document):
 
 
 def get_diff(old, new, for_child=False, compare_cancelled=False):
-	print(old.as_json(), new.as_json())
 	"""Get diff between 2 document objects
 
 	If there is a change, then returns a dict like:

--- a/frappe/core/doctype/version/version.py
+++ b/frappe/core/doctype/version/version.py
@@ -4,7 +4,7 @@
 import json
 
 import frappe
-from frappe.model import no_value_fields, table_fields
+from frappe.model import datetime_fields, no_value_fields, table_fields
 from frappe.model.document import Document
 from frappe.utils import cstr
 
@@ -76,6 +76,7 @@ class Version(Document):
 
 
 def get_diff(old, new, for_child=False, compare_cancelled=False):
+	print(old.as_json(), new.as_json())
 	"""Get diff between 2 document objects
 
 	If there is a change, then returns a dict like:
@@ -119,6 +120,10 @@ def get_diff(old, new, for_child=False, compare_cancelled=False):
 		old_value, new_value = old.get(df.fieldname), new.get(df.fieldname)
 		if df.fieldtype in ("Link", "Dynamic Link"):
 			old_value, new_value = cstr(old_value), cstr(new_value)
+
+		if df.fieldtype in datetime_fields:
+			if old_value is None and new_value == "":
+				new_value = None
 
 		if not for_child and df.fieldtype in table_fields:
 			old_rows_by_name = {}


### PR DESCRIPTION
### Problem

<img width="2266" height="1122" alt="CleanShot 2025-08-11 at 16 16 41@2x" src="https://github.com/user-attachments/assets/5b74cc75-c0ad-4e9a-80bb-bd27690581dc" />

If the developer sets any datetime type of field to `""` before save, the version log captured it as different from `null` (which it is actually set to before putting into db) and even though it was a change from `null` to `null`, version log said something else:

<img width="2298" height="952" alt="CleanShot 2025-08-11 at 16 14 59@2x" src="https://github.com/user-attachments/assets/0d76406b-8189-4c72-9051-bb2c5b76c408" />

### Solution

Set the datetime field to null before calculating the diff for version.


Ticket: https://support.frappe.io/helpdesk/tickets/45952?view=VIEW-HD+Ticket-003