### PR TITLE
fix: show barcode icon in dialog

### DIFF
--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -70,7 +70,6 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		if (this.df.options == "URL") {
 			this.setup_url_field();
 		}
-
 		if (this.df.options == "Barcode") {
 			this.setup_barcode_field();
 		}
@@ -148,6 +147,9 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		this.$scan_btn.toggle(true);
 
 		const me = this;
+		$(document).on("frappe.ui.Dialog:shown", function () {
+			me.$scan_btn.toggle(true);
+		});
 		this.$scan_btn.on("click", "a", () => {
 			new frappe.ui.Scanner({
 				dialog: true,


### PR DESCRIPTION
Creating a dialog with barcode options wasnt showing the scanner logo on there

Before
<img width="594" height="291" alt="Screenshot 2025-08-12 at 11 49 52 AM" src="https://github.com/user-attachments/assets/95fdf66a-53da-42cc-96df-afe42333185f" />


After
<img width="770" height="407" alt="Screenshot 2025-08-12 at 11 49 07 AM" src="https://github.com/user-attachments/assets/a201f1f3-2a52-4996-a8fd-95dfb1b71c9b" />

Ref ticket https://support.frappe.io/helpdesk/tickets/46100

