### PR TITLE
chore: move docs link to documentation instead of description

### DIFF
--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -497,7 +497,7 @@
   },
   {
    "default": "0",
-   "description": "For more information, <a class=\"text-muted\" href=\"https://docs.frappe.io/erpnext/user/manual/en/linking-emails-to-document\">click here</a>.",
+   "documentation_url": "https://docs.frappe.io/erpnext/user/manual/en/linking-emails-to-document",
    "fieldname": "enable_automatic_linking",
    "fieldtype": "Check",
    "hide_days": 1,
@@ -713,7 +713,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "make_attachments_public": 1,
- "modified": "2025-03-10 14:22:11.021118",
+ "modified": "2025-08-12 14:21:32.125212",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",


### PR DESCRIPTION
<img width="962" height="1026" alt="CleanShot 2025-08-12 at 14 21 52@2x" src="https://github.com/user-attachments/assets/4098b952-6891-4d61-ad91-3a7cba2a07f0" />
