### PR TITLE
chore(commands/version)!: use `plain` output instead of `legacy` by default

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -914,7 +914,7 @@ def set_config(context: CliCtxObj, key, value, global_=False, parse=False):
 	"output",
 	type=click.Choice(["plain", "table", "json", "legacy"]),
 	help="Output format",
-	default="legacy",
+	default="plain",
 )
 def get_version(output):
 	"""Show the versions of all the installed apps."""


### PR DESCRIPTION
This includes the commit hash in the output, which is useful

Seen a few bug reports regarding `develop` branch, would be useful to know the exact hash
