### PR TITLE
fix(restore): check for `AES` instead of `cipher` to detect encrypted backup

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -225,7 +225,7 @@ def _restore(
 		click.secho("Failed to detect type of backup file", fg="red")
 		sys.exit(1)
 
-	if "cipher" in out.decode().split(":")[-1].strip():
+	if "AES" in out.decode().split(":")[-1].strip():
 		if encryption_key:
 			click.secho("Encrypted backup file detected. Decrypting using provided key.", fg="yellow")
 


### PR DESCRIPTION
Seems more consistent, have seen the following outputs with `file`:

- GPG symmetrically encrypted data (AES256 cipher)
- PGP symmetric key encrypted data - AES with 256-bit key salted & iterated - SHA512 .

<hr>

Closes #33607
