### PR TITLE
feat: unambiguous icon in link field

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -15,7 +15,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			<input type="text" class="input-with-feedback form-control">
 			<span class="link-btn">
 				<a class="btn-open" tabIndex='-1' style="display: inline-block;" title="${__("Open Link")}">
-					${frappe.utils.icon("arrow-right", "xs")}
+					${frappe.utils.icon("external-link", "xs")}
 				</a>
 			</span>
 		</div>`).prependTo(this.input_area);


### PR DESCRIPTION
## Problem
The link icon that appears on hover on link field (right arrow) is ambiguous. I've helped a lot of new users get to grip with Frappe/ERPNext over the last years and nearly all of them think this is to confirm the selection rather than an external link. They click on it, get taken to the linked doc and end up confused and frustrated. At best they make the mistake a few times but I've seen casual user still get it wrong years down the line.

## Solution
Use a clearer "link" icon.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/d0f1645d-2ef1-4f87-a413-8e879af532c2" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/62d153e5-45c6-4c5c-8263-9254435d2a14" />

## Further possible improvements
Clicking outside of the cell to validate selection is unintuitive and another source of frustration to new users (I've witnessed that firsthand also). Adding an additionnal "check" icon may help there. I've not included this in the PR but wanted to share the suggestion. Also the return key should validate the selection.
