### PR TITLE
fix: mask passwords

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -640,17 +640,17 @@ frappe.request.report_error = function (xhr, request_opts) {
 };
 
 frappe.request.cleanup_request_opts = function (request_opts) {
-	var doc = (request_opts.args || {}).doc;
+	let doc = (request_opts.args || {}).doc;
 	if (doc) {
 		doc = JSON.parse(doc);
-		$.each(Object.keys(doc), function (i, key) {
-			if (key.indexOf("password") !== -1 && doc[key]) {
-				// mask the password
-				doc[key] = "*****";
-			}
-		});
+		frappe.utils.mask_passwords(doc);
 		request_opts.args.doc = JSON.stringify(doc);
 	}
+
+	if (request_opts.args) {
+		frappe.utils.mask_passwords(request_opts.args);
+	}
+
 	return request_opts;
 };
 

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1807,4 +1807,19 @@ Object.assign(frappe.utils, {
 
 		return false;
 	},
+
+	/**
+	 * Masks passwords in an object by replacing the values of keys containing
+	 * "password" or "passphrase" with "*****".
+	 *
+	 * @param {Object} obj - The object to mask passwords in.
+	 */
+	mask_passwords(obj) {
+		const KEYWORDS_TO_MASK = ["password", "passphrase"];
+		for (const key in obj) {
+			if (KEYWORDS_TO_MASK.some((keyword) => key.indexOf(keyword) !== -1) && obj[key]) {
+				obj[key] = "*****";
+			}
+		}
+	},
 });

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1817,7 +1817,7 @@ Object.assign(frappe.utils, {
 	mask_passwords(obj) {
 		const KEYWORDS_TO_MASK = ["password", "passphrase"];
 		for (const key of Object.keys(obj)) {
-			if (KEYWORDS_TO_MASK.some((keyword) => key.indexOf(keyword) !== -1) && obj[key]) {
+			if (KEYWORDS_TO_MASK.some((keyword) => key.includes(keyword)) && obj[key]) {
 				obj[key] = "*****";
 			}
 		}

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1816,7 +1816,7 @@ Object.assign(frappe.utils, {
 	 */
 	mask_passwords(obj) {
 		const KEYWORDS_TO_MASK = ["password", "passphrase"];
-		for (const key in obj) {
+		for (const key of Object.keys(obj)) {
 			if (KEYWORDS_TO_MASK.some((keyword) => key.indexOf(keyword) !== -1) && obj[key]) {
 				obj[key] = "*****";
 			}


### PR DESCRIPTION
This PR improves the redacting of request data in the error log that the user can copy from an error message in the frontend:

<img width="575" height="197" alt="Bildschirmfoto 2025-08-13 um 17 45 26" src="https://github.com/user-attachments/assets/0c48b032-96b2-4792-80b5-f59bd5cb2531" />

- Extracted masking into separate utility function.
- Added `"passphrase"` to blacklist.
- Also redact other request args, not only `doc`.

<details>
<summary>Error Log Example</summary>

### Request Data
```
{
	"type": "POST",
	"args": {
		"payment_order": "dakp47m7do",
		"user_id": "3amfqinkt3",
		"banking_passphrase": "*****"
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/banking.sepa.doctype.payment_order.payment_order.send_to_bank",
	"request_id": null
}
```

(Previously, the `banking_passphrase` in this example was not redacted.)

</details>

