### PR TITLE
feat(socketio): print socket.io address on node socketio console

### DIFF
--- a/realtime/index.js
+++ b/realtime/index.js
@@ -90,5 +90,9 @@ const subscriber = get_redis_subscriber();
 let uds = conf.socketio_uds;
 let port = conf.socketio_port;
 server.listen(uds || port, () => {
-	console.log("Realtime service listening on: ", uds || port);
+	if (uds) {
+		console.log(`Realtime service listening on UDS: ${uds}`);
+	} else {
+		console.log(`Realtime service listening on: ws://0.0.0.0:${port}`);
+	}
 });


### PR DESCRIPTION
get address of interfaces and print on the console log to make IDEs like vscode autoforward the port during development and debugging in the format of `ws://host:port`, this makes easier for devs to have the ports autoforward instead of manually publishing them in the IDE.

this mostly accounts those who develop in non-docker environments, and this would make debug easier if it's required

can also be backported to version 15 and 14 if possible