### PR TITLE
fix(auto repeat): validate start and end date

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -92,8 +92,8 @@ class AutoRepeat(Document):
 
 	def before_insert(self):
 		if not frappe.in_test:
-			start_date = getdate(self.start_date)
-			today_date = getdate(today())
+			start_date = self.start_date
+			today_date = today()
 			if start_date <= today_date:
 				self.start_date = today_date
 
@@ -140,6 +140,8 @@ class AutoRepeat(Document):
 
 		if self.end_date:
 			self.validate_from_to_dates("start_date", "end_date")
+		if self.end_date == today():
+			frappe.throw(_("End Date should not be the same as today date"))
 
 		if self.end_date == self.start_date:
 			frappe.throw(

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -141,7 +141,7 @@ class AutoRepeat(Document):
 		if self.end_date:
 			self.validate_from_to_dates("start_date", "end_date")
 		if self.end_date == today():
-			frappe.throw(_("End Date should not be the same as today date"))
+			frappe.throw(_("End Date cannot be today."))
 
 		if self.end_date == self.start_date:
 			frappe.throw(


### PR DESCRIPTION
Issue: Auto Repeat  End Date is not validated correctly

Ref: [#46528](https://support.frappe.io/helpdesk/tickets/46528)

Before:

https://github.com/user-attachments/assets/807fb071-9732-42a7-8258-684ff6811221

After: 

https://github.com/user-attachments/assets/01a97dc4-5ca9-4a2f-8159-de35224f8865

Backport needed: v15