### PR TITLE
feat: Improve readability of preview pop-up

### DIFF
--- a/frappe/desk/link_preview.py
+++ b/frappe/desk/link_preview.py
@@ -33,8 +33,7 @@ def get_preview_data(doctype, docname):
 	preview_fields.append(image_field)
 	preview_fields.append("name")
 
-	preview_data = frappe.get_list(
-		doctype, filters={"name": docname}, fields=preview_fields, limit=1)
+	preview_data = frappe.get_list(doctype, filters={"name": docname}, fields=preview_fields, limit=1)
 
 	if not preview_data:
 		return

--- a/frappe/desk/link_preview.py
+++ b/frappe/desk/link_preview.py
@@ -1,13 +1,16 @@
 import frappe
 from frappe.model import no_value_fields, table_fields
 from frappe.utils.caching import http_cache
+from frappe.www.printview import set_link_titles
 
 
 @frappe.whitelist()
 @http_cache(max_age=60 * 10)
 def get_preview_data(doctype, docname):
 	preview_fields = []
-	meta = frappe.get_meta(doctype)
+	doc = frappe.get_doc(doctype, docname)
+	set_link_titles(doc)
+	meta = doc.meta
 	if not meta.show_preview_popup:
 		return
 
@@ -30,7 +33,8 @@ def get_preview_data(doctype, docname):
 	preview_fields.append(image_field)
 	preview_fields.append("name")
 
-	preview_data = frappe.get_list(doctype, filters={"name": docname}, fields=preview_fields, limit=1)
+	preview_data = frappe.get_list(
+		doctype, filters={"name": docname}, fields=preview_fields, limit=1)
 
 	if not preview_data:
 		return
@@ -46,8 +50,9 @@ def get_preview_data(doctype, docname):
 	for key, val in preview_data.items():
 		if val and meta.has_field(key) and key not in [image_field, title_field, "name"]:
 			formatted_preview_data[meta.get_field(key).label] = frappe.format(
-				val,
-				meta.get_field(key).fieldtype,
+				value=val,
+				doc=doc,
+				df=meta.get_field(key),
 				translated=True,
 			)
 


### PR DESCRIPTION

> Please provide enough information so that others can review your pull request:

This PR addresses the lack of proper formatting for link fields in the preview pop-up. Previously, these fields would display the internal document name (e.g., a code or ID), making the preview less useful.


> Explain the **details** for making this change. What existing problem does the pull request solve?

The get_preview_data function has been refactored to first retrieve the full document and its metadata. By passing the document (doc) and field definition (df) to frappe.format, the function can now correctly format link fields to show their human-readable titles.

This enhancement significantly improves the clarity and user experience of the preview functionality.


> Screenshots/GIFs

Before
<img width="265" height="596" alt="image" src="https://github.com/user-attachments/assets/1deb8418-7dae-4be5-8bc7-0f50e62ed37e" />

After:
<img width="272" height="554" alt="image" src="https://github.com/user-attachments/assets/a3485633-105d-461f-90bf-0d35cc218447" />


`no-docs`