### PR TITLE
Fixing Issue no. 45353 , highlighting the active module in the sidebar

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -242,12 +242,13 @@ frappe.views.Workspace = class Workspace {
 				.find(".workspace-icon")
 				.html(frappe.utils.icon(this._page.icon || "folder-normal", "md"));
 
-				//HIGHLISHTING THE ACTIVE SPACEBAR 
-                 setTimeout(() => {
-	             this.sidebar.$sidebar.find(".sidebar-item").removeClass("active");
-	             this.sidebar.$sidebar.find(`[data-name="${current_page.name}"]`).addClass("active");
-                    }, 0);
-
+			// Highlighting the active sidebar
+			setTimeout(() => {
+				this.sidebar.$sidebar.find(".sidebar-item").removeClass("active");
+				this.sidebar.$sidebar
+					.find(`[data-name="${current_page.name}"]`)
+					.addClass("active");
+			}, 0);
 
 			localStorage.current_page = current_page.name;
 			localStorage.is_current_page_public = current_page.public ? "true" : "false";

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -242,6 +242,13 @@ frappe.views.Workspace = class Workspace {
 				.find(".workspace-icon")
 				.html(frappe.utils.icon(this._page.icon || "folder-normal", "md"));
 
+				//HIGHLISHTING THE ACTIVE SPACEBAR 
+                 setTimeout(() => {
+	             this.sidebar.$sidebar.find(".sidebar-item").removeClass("active");
+	             this.sidebar.$sidebar.find(`[data-name="${current_page.name}"]`).addClass("active");
+                    }, 0);
+
+
 			localStorage.current_page = current_page.name;
 			localStorage.is_current_page_public = current_page.public ? "true" : "false";
 		}


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->



> Explain the **details** for making this change. What existing problem does the pull request solve?

Right now, when we switch between workspaces, the sidebar doesn’t show which one is open, so it’s a bit confusing. I added a small code change in workspace.js so that the current workspace gets an .active highlight in the sidebar. This makes it easier to know where you are while using ERPNext.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs
The below diagram shows the before/after effect of the change: the currently open workspace is now visibly highlighted in the sidebar

<img width="1051" height="277" alt="image" src="https://github.com/user-attachments/assets/8d56fd77-d645-4cbb-8c9b-ddf1809a8c1a" />


<!-- Add images/recordings to better visualize the change: expected/current behavior -->
