### PR TITLE
fix: populate filters for number card of type report

### DIFF
--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -90,6 +90,11 @@ export default class NumberCardWidget extends Widget {
 					[`${filter[0]}.${filter[1]}`]: [filter[2], filter[3]],
 				});
 			}, {});
+		} else {
+			const filters = this.get_filters();
+			if (filters && Object.keys(filters).length) {
+				frappe.route_options = filters;
+			}
 		}
 
 		frappe.set_route(route);

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -82,16 +82,14 @@ export default class NumberCardWidget extends Widget {
 			type: is_document_type ? "doctype" : "report",
 			is_query_report: !is_document_type,
 		});
-
+		const filters = this.get_filters();
 		if (is_document_type) {
-			const filters = JSON.parse(this.card_doc.filters_json);
 			frappe.route_options = filters.reduce((acc, filter) => {
 				return Object.assign(acc, {
 					[`${filter[0]}.${filter[1]}`]: [filter[2], filter[3]],
 				});
 			}, {});
 		} else {
-			const filters = this.get_filters();
 			if (filters && Object.keys(filters).length) {
 				frappe.route_options = filters;
 			}


### PR DESCRIPTION
Filters for number card of type report were not populated


## Before


https://github.com/user-attachments/assets/a363fe19-c92e-4739-819b-feaa77ab034b

## After


https://github.com/user-attachments/assets/aa06a2b8-a18d-4520-aae4-9ef82da3fba7


Support Ticket: https://support.frappe.io/helpdesk/tickets/46312?view=VIEW-HD+Ticket-003
