### PR TITLE
fix: valid password message

### DIFF
--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -91,7 +91,7 @@ frappe.ready(function() {
 	// Info text
 	const password_not_same_as_old_password = "{{ _('New password cannot be same as old password') }}";
 	const password_mismatch = "{{ _('Passwords do not match') }}";
-	const password_strength_message_success = "{{ _('Success! You are good to go 👍') }}";
+	const password_strength_message_success = "{{ _('Password is valid. 👍') }}";
 
 	if(key) {
 		old_password.parent().toggle();


### PR DESCRIPTION
Simple approach to fix https://github.com/frappe/frappe/issues/33604
Just changing the message, without modifying validation workflow. Actually "Confirm" button is disabled anyway ... so UX seems decent.

Before:
<img width="893" height="464" alt="image" src="https://github.com/user-attachments/assets/2e4255f0-fccc-4834-a49b-715b3820c1b4" />

After:
<img width="523" height="310" alt="image" src="https://github.com/user-attachments/assets/cde00a4f-7990-4a4c-a449-7f49a86e06e3" />
