### PR TITLE
feat: add skip to content accessibility styles

### DIFF
--- a/frappe/public/css/tree.css
+++ b/frappe/public/css/tree.css
@@ -93,3 +93,22 @@ ul.tree-children {
 .tree-link.active ~ .balance-area {
   color: #36414C !important;
 }
+
+/* Accessibility: Skip to Main Content link */
+.skip-to-content {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: #000;
+  color: #fff;
+  padding: 8px 16px;
+  z-index: 1000;
+  text-decoration: none;
+  transition: top 0.3s ease;
+  border-radius: 4px;
+}
+
+.skip-to-content:focus {
+  top: 0;
+}
+

--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -56,12 +56,14 @@
 </head>
 <body frappe-session-status="{{ 'logged-in' if frappe.session.user != 'Guest' else 'logged-out'}}" data-path="{{ path | e }}" {%- if template and template.endswith('.md') %} frappe-content-type="markdown" {%- endif %} class="{{ body_class or ''}}">
 	{%- block banner -%}
-		{% include "templates/includes/banner_extension.html" ignore missing %}
+	   <a href="#main-content" class="skip-to-content">Skip to Main Content</a>
 
-		{% if banner_html -%}
-		{{ banner_html or "" }}
-		{%- endif %}
-	{%- endblock -%}
+	   {% include "templates/includes/banner_extension.html" ignore missing %}
+
+	   {% if banner_html -%}
+		  {{ banner_html or "" }}
+	   {%- endif %}
+    {%- endblock -%}
 
 	{%- block navbar -%}
 		{{ web_block(

--- a/frappe/templates/web.html
+++ b/frappe/templates/web.html
@@ -13,7 +13,7 @@
 	</div>
 
 	{% block page_container %}
-	<main class="{% if not full_width %}container{% endif %}">
+	<main id="main-content" class="{% if not full_width %}container{% endif %}">
 		<div class="page-header-wrapper">
 			<div class="page-header">
 				{% block header %}{% endblock %}


### PR DESCRIPTION
### Summary

This PR introduces a **"Skip to main content"** link to improve accessibility for keyboard and screen reader users.

### Details

- Added `.skip-to-content` accessibility styles in `base.html` template.  
- Ensures the skip link is hidden by default and becomes visible when focused.  
- Provides keyboard users a quick way to bypass navigation and jump directly to the main content.  
- Improves compliance with accessibility standards (WCAG 2.1).

### Why is this needed?

Currently, there is no quick way for keyboard/screen reader users to skip repetitive navigation links.  
This change makes the framework more inclusive and user-friendly.

### Related Issue

Closes #33001

### Checklist

- [x] Code changes are minimal and focused  
- [x] Follows commit message convention (`feat: ...`)  
- [x] Tested locally for expected behavior  
- [x] No breaking changes introduced  

