### PR TITLE
feat: allow Context for translation in DocField.label for Table DocField

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -65,7 +65,7 @@ export default class Grid {
 	make() {
 		let template = `
 			<div class="grid-field">
-				<label class="control-label">${__(this.df.label || "")}</label>
+				<label class="control-label">${__(this.df.label || "", null, this.df.parent)}</label>
 				<span class="help"></span>
 				<p class="text-muted small grid-description"></p>
 				<div class="grid-custom-buttons"></div>


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Some DocField type Table the title display can need to be contextualized for their translation

> Explain the **details** for making this change. What existing problem does the pull request solve?

As label displayed in Form for DocField (https://github.com/frappe/frappe/blob/62c9f89fbbef6f67ae5a1843f386802778a449da/frappe/public/js/frappe/form/column.js#L33), the translation context should be provided also for Title of Table DocField

> no-docs

Note to reviewer : If you are agreed to merge, could you please add backport-15 label ?

