### PR TITLE
fix(document): is_child_table_same for new docs

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -842,9 +842,13 @@ class Document(BaseDocument):
 
 	def is_child_table_same(self, fieldname):
 		"""Validate child table is same as original table before saving"""
+
+		if self.is_new():
+			return False
+
+		same = True
 		value = self.get(fieldname)
 		original_value = self._doc_before_save.get(fieldname)
-		same = True
 
 		if len(original_value) != len(value):
 			same = False


### PR DESCRIPTION
currently the `is_child_table_same` methode runs into an error if the document is new.
```python
AttributeError: 'NoneType' object has no attribute 'get'
```

This happens because `_doc_before_save` is `None` for new documents:
```python
	def load_doc_before_save(self, *, raise_exception: bool = False):
		"""load existing document from db before saving"""

		self._doc_before_save = None

		if self.is_new():
			return
```

Since validation also runs on new documents, this makes `is_child_table_same` unreliable in that context.

My commit updates the method to first check if the document is new. If it is, the method returns `False` immediately. This prevents the `AttributeError` and allows validation to run safely on new documents.