### PR TITLE
docs(google_settings): update documentation link

### DIFF
--- a/frappe/integrations/doctype/google_settings/google_settings.js
+++ b/frappe/integrations/doctype/google_settings/google_settings.js
@@ -5,7 +5,7 @@ frappe.ui.form.on("Google Settings", {
 	refresh: function (frm) {
 		frm.dashboard.set_headline(
 			__("For more information, {0}.", [
-				`<a href='https://erpnext.com/docs/user/manual/en/erpnext_integration/google_settings'>${__(
+				`<a href='https://erpnext.com/docs/user/manual/en/google_settings'>${__(
 					"Click here"
 				)}</a>`,
 			])


### PR DESCRIPTION
This pull request fixes a broken link in the Google Settings doctype's client-side script. The current link points to a non-existent documentation page. The change updates the URL to the new, correct location in the Frappe documentation.