### PR TITLE
fix(ListView): remove min width in responsive

### DIFF
--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -571,6 +571,7 @@ input.list-header-checkbox {
 						padding-left: 10px;
 						.list-row-col {
 							margin-right: 0px;
+							min-width: auto;
 						}
 					}
 					.mobile-layout:not(.mobile-layout ~ .mobile-layout) {


### PR DESCRIPTION
## Before
<img width="846" height="1320" alt="image" src="https://github.com/user-attachments/assets/c0a9aa19-7942-4872-848c-a666771d509b" />


## After
<img width="868" height="1338" alt="image" src="https://github.com/user-attachments/assets/2669a4b3-9afb-41f7-b00b-7db0984255ba" />
