### PR TITLE
fix: properly resolve dynamic link options in list and report view filters

### DIFF
--- a/frappe/public/js/frappe/form/controls/dynamic_link.js
+++ b/frappe/public/js/frappe/form/controls/dynamic_link.js
@@ -11,8 +11,11 @@ frappe.ui.form.ControlDynamicLink = class ControlDynamicLink extends frappe.ui.f
 				// for list page
 				options = cur_list.page.fields_dict[this.df.options].get_input_value();
 			}
-			if (cur_page) {
-				options = cur_page.page.fields_dict[this.df.options].get_input_value();
+			else if (cur_page) {
+				const selector = `input[data-fieldname="${this.df.options}"]`;
+				let input = null;
+				input = $(cur_page.page).find(selector);
+				options = input.val();
 			}
 		} else {
 			options = frappe.model.get_value(this.df.parent, this.docname, this.df.options);

--- a/frappe/public/js/frappe/form/controls/dynamic_link.js
+++ b/frappe/public/js/frappe/form/controls/dynamic_link.js
@@ -7,17 +7,12 @@ frappe.ui.form.ControlDynamicLink = class ControlDynamicLink extends frappe.ui.f
 			//for dialog box
 			options = cur_dialog.get_value(this.df.options);
 		} else if (!cur_frm) {
-			const selector = `input[data-fieldname="${this.df.options}"]`;
-			let input = null;
 			if (cur_list) {
 				// for list page
-				input = cur_list.filter_area.standard_filters_wrapper.find(selector);
+				options = cur_list.page.fields_dict[this.df.options].get_input_value();
 			}
 			if (cur_page) {
-				input = $(cur_page.page).find(selector);
-			}
-			if (input) {
-				options = input.val();
+				options = cur_page.page.fields_dict[this.df.options].get_input_value();
 			}
 		} else {
 			options = frappe.model.get_value(this.df.parent, this.docname, this.df.options);

--- a/frappe/public/js/frappe/form/controls/dynamic_link.js
+++ b/frappe/public/js/frappe/form/controls/dynamic_link.js
@@ -10,12 +10,10 @@ frappe.ui.form.ControlDynamicLink = class ControlDynamicLink extends frappe.ui.f
 			if (cur_list) {
 				// for list page
 				options = cur_list.page.fields_dict[this.df.options].get_input_value();
-			}
-			else if (cur_page) {
+			} else if (cur_page) {
 				const selector = `input[data-fieldname="${this.df.options}"]`;
-				let input = null;
-				input = $(cur_page.page).find(selector);
-				options = input.val();
+				let input = $(cur_page.page).find(selector);
+				options = input.length ? input.val() : null;
 			}
 		} else {
 			options = frappe.model.get_value(this.df.parent, this.docname, this.df.options);


### PR DESCRIPTION
The dynamic link control does not take into account translated options and doesn't work properly. I used `get_input_value` which uses `title_value_map` object (translated option -> untranslated option)



<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
