### PR TITLE
fix(ListView): adjust sidebar width for better layout on xl screens

### DIFF
--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -120,6 +120,10 @@
 	min-width: var(--sidebar-width);
 	border-left: 1px solid var(--border-color);
 
+	@media (max-width: map-get($grid-breakpoints, "xl")) {
+		min-width: calc(35vw - var(--sidebar-width));
+	}
+
 	.sidebar-section {
 		padding: var(--padding-sm) var(--padding-md);
 	}


### PR DESCRIPTION
Previously, the sidebar was getting cut off on extra-large screens. This fix adjusts its width dynamically based on the viewport to ensure it fits properly across responsive layouts.

## Before
<img width="2058" height="870" alt="image" src="https://github.com/user-attachments/assets/0855b398-a80f-47de-ac9a-edd266fa44d0" />


## After
<img width="2072" height="864" alt="image" src="https://github.com/user-attachments/assets/33a6fbac-795a-4926-8747-9af3aaf4c25a" />
