### PR TITLE
fix: trim preload Link header to stay under size limits

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -594,8 +594,23 @@ def add_preload_for_bundled_assets(response):
 		for svg in frappe.local.preload_assets["icons"]
 	)
 
+	SAFE_LIMIT = 3800
 	if links:
-		response.headers["Link"] = ",".join(links)
+		final_links = []
+		current_size = 0
+
+		for link in links:
+			link_size = len(link.encode("utf-8"))
+			needed_size = link_size + (1 if final_links else 0)
+
+			if current_size + needed_size > SAFE_LIMIT:
+				break
+
+			final_links.append(link)
+			current_size += needed_size
+
+		if final_links:
+			response.headers["Link"] = ",".join(final_links)
 
 
 @lru_cache

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -594,7 +594,8 @@ def add_preload_for_bundled_assets(response):
 		for svg in frappe.local.preload_assets["icons"]
 	)
 
-	SAFE_LIMIT = 3800
+	# Safe limit for Link header length (~4 KB is the default max in Nginx)
+	MAX_LINK_HEADER_BYTES = 3800
 	if links:
 		final_links = []
 		current_size = 0
@@ -603,7 +604,7 @@ def add_preload_for_bundled_assets(response):
 			link_size = len(link.encode("utf-8"))
 			needed_size = link_size + (1 if final_links else 0)
 
-			if current_size + needed_size > SAFE_LIMIT:
+			if current_size + needed_size > MAX_LINK_HEADER_BYTES:
 				break
 
 			final_links.append(link)


### PR DESCRIPTION
Limits link header to stay with in 4kb 


Support:
1. https://support.frappe.io/helpdesk/tickets/46912?view=VIEW-HD+Ticket-003
2. https://support.frappe.io/helpdesk/tickets/46919?view=VIEW-HD+Ticket-003
3. https://support.frappe.io/helpdesk/tickets/46652?view=VIEW-HD+Ticket-003
