### PR TITLE
feat: allow Context for translation in DocField.description for Base Input

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -206,7 +206,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 			return;
 		}
 		if (this.df.description) {
-			this.$wrapper.find(".help-box").html(__(this.df.description));
+			this.$wrapper.find(".help-box").html(__(this.df.description, null, this.df.parent));
 			this.toggle_description(true);
 		} else {
 			this.set_empty_description();


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Some description provided by DocField on Base Input can need to be contextualized for their translation

> Explain the **details** for making this change. What existing problem does the pull request solve?

As label displayed in Form for DocField (https://github.com/frappe/frappe/blob/62c9f89fbbef6f67ae5a1843f386802778a449da/frappe/public/js/frappe/form/column.js#L33), the translation context should be provided also for description

> no-docs

Note to reviewer : If you are agreed to merge, could you please add backport-15 label ?

