### PR TITLE
fix: only consider the Frappe and ERPNext apps for setup completion checks

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2408,7 +2408,13 @@ def is_setup_complete():
 	if not frappe.db.table_exists("Installed Application"):
 		return is_setup_complete
 
-	if all(frappe.get_all("Installed Application", {"has_setup_wizard": 1}, pluck="is_setup_complete")):
+	if all(
+		frappe.get_all(
+			"Installed Application",
+			{"app_name": ("in", ["frappe", "erpnext"])},
+			pluck="is_setup_complete",
+		)
+	):
 		is_setup_complete = True
 
 	return is_setup_complete

--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -32,17 +32,11 @@ class InstalledApplications(Document):
 
 		self.delete_key("installed_applications")
 		for app in frappe.utils.get_installed_apps_info():
-			has_setup_wizard = 0
-			if app.get("app_name") == "frappe" or frappe.get_hooks(app_name=app.get("app_name")).get(
-				"setup_wizard_stages"
-			):
-				has_setup_wizard = 1
-
+			has_setup_wizard = 1
 			setup_complete = app_wise_setup_details.get(app.get("app_name")) or 0
-			if app.get("app_name") == "india_compliance":
-				setup_complete = app_wise_setup_details.get("erpnext") or 0
-			if app.get("app_name") == "insights":
-				setup_complete = app_wise_setup_details.get("frappe") or 0
+			if app.get("app_name") not in ["frappe", "erpnext"]:
+				setup_complete = 0
+				has_setup_wizard = 0
 
 			self.append(
 				"installed_applications",


### PR DESCRIPTION
Only consider Frappe and ERPNext for frappe setup wizard 

<img width="1332" height="381" alt="image" src="https://github.com/user-attachments/assets/4d88e654-1d8d-4b69-a32a-742b87e21d04" />
