### PR TITLE
fix(ListView): multiple scroll on report view

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -632,6 +632,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	render_list() {
 		// clear rows
 		this.$result.find(".list-row-container").remove();
+		this.parent.page.main.parent().addClass("list-view");
 		this.render_header();
 
 		let has_assignto = false;

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -532,6 +532,17 @@ input.list-header-checkbox {
 	z-index: 0;
 }
 
+.list-view {
+	.frappe-list {
+		.result-container {
+			overflow-x: auto;
+			.result {
+				overflow: auto;
+			}
+		}
+	}
+}
+
 @media (max-width: map-get($grid-breakpoints, "lg")) {
 	.layout-main-section-wrapper {
 		width: 100%;

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -182,7 +182,6 @@
 
 	.frappe-list {
 		.result-container {
-			overflow-x: auto;
 			.result {
 				min-width: 100%;
 				width: auto;
@@ -213,10 +212,6 @@
 		.no-result,
 		.freeze {
 			min-height: 200px;
-		}
-
-		.result {
-			overflow: auto;
 		}
 	}
 


### PR DESCRIPTION
Due to some recent changes in the List View, a scroll was also appearing in the Report View. To fix this, I added a specific class to the List View—similar to the one used in the Report View—and applied CSS based on that.