### PR TITLE
feat(ListView): add configuration to disable scrolling

### DIFF
--- a/frappe/desk/doctype/list_view_settings/list_view_settings.json
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.json
@@ -12,6 +12,7 @@
   "disable_auto_refresh",
   "allow_edit",
   "disable_automatic_recency_filters",
+  "disable_scrolling",
   "total_fields",
   "fields_html",
   "fields"
@@ -39,7 +40,7 @@
    "fieldname": "total_fields",
    "fieldtype": "Select",
    "label": "Maximum Number of Fields",
-   "options": "\n4\n5\n6\n7\n8\n9\n10\n15\n20\n25\n30"
+   "options": "\n4\n5\n6\n7\n8\n9\n10"
   },
   {
    "fieldname": "fields_html",
@@ -71,11 +72,17 @@
    "fieldname": "disable_automatic_recency_filters",
    "fieldtype": "Check",
    "label": "Disable Automatic Recency Filters"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_scrolling",
+   "fieldtype": "Check",
+   "label": "Disable Scrolling"
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-03-24 14:17:39.888956",
+ "modified": "2025-08-21 12:22:55.055708",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "List View Settings",

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.json
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.json
@@ -40,7 +40,7 @@
    "fieldname": "total_fields",
    "fieldtype": "Select",
    "label": "Maximum Number of Fields",
-   "options": "\n4\n5\n6\n7\n8\n9\n10"
+   "options": "\n4\n5\n6\n7\n8\n9\n10\n15\n20\n25\n30"
   },
   {
    "fieldname": "fields_html",
@@ -82,7 +82,7 @@
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-08-21 12:22:55.055708",
+ "modified": "2025-08-21 12:51:32.954333",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "List View Settings",

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.py
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.py
@@ -19,9 +19,10 @@ class ListViewSettings(Document):
 		disable_automatic_recency_filters: DF.Check
 		disable_comment_count: DF.Check
 		disable_count: DF.Check
+		disable_scrolling: DF.Check
 		disable_sidebar_stats: DF.Check
 		fields: DF.Code | None
-		total_fields: DF.Literal["", "4", "5", "6", "7", "8", "9", "10", "15", "20", "25", "30"]
+		total_fields: DF.Literal["", "4", "5", "6", "7", "8", "9", "10"]
 	# end: auto-generated types
 
 	pass

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.py
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.py
@@ -22,7 +22,7 @@ class ListViewSettings(Document):
 		disable_scrolling: DF.Check
 		disable_sidebar_stats: DF.Check
 		fields: DF.Code | None
-		total_fields: DF.Literal["", "4", "5", "6", "7", "8", "9", "10"]
+		total_fields: DF.Literal["", "4", "5", "6", "7", "8", "9", "10", "15", "20", "25", "30"]
 	# end: auto-generated types
 
 	pass

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -633,6 +633,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		// clear rows
 		this.$result.find(".list-row-container").remove();
 		this.parent.page.main.parent().addClass("list-view");
+		if (this.list_view_settings?.disable_scrolling && !frappe.is_mobile()) {
+			this.parent.page.main.parent().addClass("disable-scrolling");
+		}
 		this.render_header();
 
 		let has_assignto = false;
@@ -1006,6 +1009,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	 * The width for each column is applied as both a fixed `width` and a flexible `flex` property.
 	 */
 	apply_column_widths() {
+		if (this.list_view_settings?.disable_scrolling) return;
 		Object.entries(this.column_max_widths).forEach(([fieldname, width]) => {
 			$(`.${fieldname}`).css({
 				width: width,

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -1,7 +1,30 @@
-// .layout-main-section {
-// 	overflow: hidden;
-
-// }
+.layout-main-section-wrapper:not(.disable-scrolling) {
+	.frappe-list {
+		.result-container {
+			.result {
+				min-width: 100%;
+				width: auto;
+				.list-row-container {
+					width: fit-content;
+					min-width: 100%;
+				}
+				.list-row-container:first-child {
+					position: sticky;
+					top: 0;
+					z-index: 2;
+				}
+				.list-row-container {
+					.level-left {
+						.list-row-col {
+							min-width: 150px;
+							max-width: 400px;
+						}
+					}
+				}
+			}
+		}
+	}
+}
 
 .freeze-row {
 	.level-left,
@@ -538,6 +561,23 @@ input.list-header-checkbox {
 			overflow-x: auto;
 			.result {
 				overflow: auto;
+			}
+		}
+	}
+}
+
+.disable-scrolling {
+	.frappe-list {
+		.list-row-container {
+			width: auto;
+			.level-left {
+				flex: 0;
+				.list-row-col {
+					min-width: auto;
+				}
+			}
+			.level-right {
+				box-shadow: none;
 			}
 		}
 	}

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -180,32 +180,6 @@
 .layout-main-section {
 	scroll-margin-top: var(--navbar-height);
 
-	.frappe-list {
-		.result-container {
-			.result {
-				min-width: 100%;
-				width: auto;
-				.list-row-container {
-					width: fit-content;
-					min-width: 100%;
-				}
-				.list-row-container:first-child {
-					position: sticky;
-					top: 0;
-					z-index: 2;
-				}
-				.list-row-container {
-					.level-left {
-						.list-row-col {
-							min-width: 150px;
-							max-width: 400px;
-						}
-					}
-				}
-			}
-		}
-	}
-
 	.frappe-list,
 	.report-wrapper {
 		.result,


### PR DESCRIPTION
Add an option to make the scrollable list view configurable. If the user doesn't want it, they can disable it through the settings.
<img width="1128" height="732" alt="image" src="https://github.com/user-attachments/assets/20d704c3-b9ee-445b-a0c2-48720e7a6358" />

`no-docs`
