### PR TITLE
refactor(Listview): replace box-shadow with border

### DIFF
--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -146,8 +146,8 @@
 		position: sticky;
 		right: 0;
 		background-color: var(--bg-color);
-		box-shadow: -5px 0px 5px var(--highlight-color);
-		padding: 6px 10px;
+		border-left: 2px solid var(--highlight-color);
+		padding: 9px 10px;
 	}
 
 	.tag-col {
@@ -228,7 +228,7 @@
 		background-color: var(--subtle-fg);
 		border-radius: var(--border-radius);
 		height: var(--list-row-height);
-		box-shadow: none;
+		border-left: none;
 		&:hover {
 			background-color: var(--subtle-fg);
 		}
@@ -577,7 +577,7 @@ input.list-header-checkbox {
 				}
 			}
 			.level-right {
-				box-shadow: none;
+				border-left: none;
 			}
 		}
 	}
@@ -646,7 +646,7 @@ input.list-header-checkbox {
 				.level-right {
 					flex: 0 0 auto;
 					width: auto;
-					box-shadow: none;
+					border-left: none;
 					.level-item.visible-xs {
 						margin-top: 5px;
 					}


### PR DESCRIPTION
The box shadow was a bit distracting and didn’t look good, so I replaced it with a border.
<img width="850" height="648" alt="image" src="https://github.com/user-attachments/assets/5617d056-7035-485a-b1d2-85e781d6a80c" />
