### PR TITLE
fix(ui): Ensure manual datetime input persists after blur

### DIFF
--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -90,6 +90,16 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 	}
 	set_datepicker() {
 		super.set_datepicker();
+		// This event handler ensures that if a user manually types a value
+		// and clicks away, the change is saved to the datepicker's internal state.
+		this.$input.on("change", () => {
+			const value = this.$input.val();
+			if (this.datepicker && value) {
+				const new_date = frappe.datetime.str_to_obj(value);
+				this.datepicker.selectDate(new_date, true);
+			}
+		});
+
 		if (this.datepicker.opts.timeFormat.indexOf("s") == -1) {
 			// No seconds in time format
 			const $tp = this.datepicker.timepicker;


### PR DESCRIPTION
This PR fixes an issue where manually editing the time in a Datetime field would not be saved if the user clicked away and then re-focused the field.

The root cause was that the datepicker's internal state was not being updated on the input's `change` event. This change adds an event listener that parses the manual input and uses `datepicker.selectDate()` to synchronize the state.

Closes #33736