### PR TITLE
fix: validate dot in numeric placeholders

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -71,15 +71,13 @@ class NamingSeries:
 				exc=InvalidNamingSeriesError,
 			)
 
-		if "#" in self.series:
-			hash_index = self.series.find("#")
-			if not hash_index == 0 and self.series[hash_index - 1] != ".":
-				frappe.throw(
-					_(
-						"Invalid naming series {}: dot (.) missing before the numeric placeholders. Kindly use a format like <b>ABCD.#####</b>."
-					).format(frappe.bold(self.series)),
-					exc=InvalidNamingSeriesError,
-				)
+		if "#" in self.series and ".#" not in self.series:
+			frappe.throw(
+				_(
+					"Invalid naming series {}: dot (.) missing before the numeric placeholders. Kindly use a format like <b>ABCD.#####</b>."
+				).format(frappe.bold(self.series)),
+				exc=InvalidNamingSeriesError,
+			)
 
 	def generate_next_name(self, doc: "Document", *, ignore_validate=False) -> str:
 		if not ignore_validate:

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -71,6 +71,16 @@ class NamingSeries:
 				exc=InvalidNamingSeriesError,
 			)
 
+		if "#" in self.series:
+			hash_index = self.series.find("#")
+			if not hash_index == 0 and self.series[hash_index - 1] != ".":
+				frappe.throw(
+					_(
+						"Invalid naming series {}: dot (.) missing before the numeric placeholders. Kindly use a format like <b>ABCD.#####</b>."
+					).format(frappe.bold(self.series)),
+					exc=InvalidNamingSeriesError,
+				)
+
 	def generate_next_name(self, doc: "Document", *, ignore_validate=False) -> str:
 		if not ignore_validate:
 			self.validate()


### PR DESCRIPTION
**Issue** :  During the validation of the naming series. the current implementation allows user to enter a dot (.) after the numeric placeholder (#).

**Ref** : [46145](https://support.frappe.io/helpdesk/tickets/46145) 

**Before :** 

<img width="1919" height="443" alt="Before" src="https://github.com/user-attachments/assets/e407b909-63ab-4776-b7fe-b4a12d12d61f" />

**After :**

<img width="1911" height="407" alt="After" src="https://github.com/user-attachments/assets/26e7ed3e-357f-453c-b914-5805d297ac17" />


**Backport Needed** : v15