### PR TITLE
feat: Add wildcard support for `webform_include_js` hook

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -464,7 +464,9 @@ def get_context(context):
 			if os.path.exists(js_path):
 				script = frappe.render_template(open(js_path).read(), context)
 
-				for path in get_code_files_via_hooks("webform_include_js", context.doc_type):
+				for path in get_code_files_via_hooks(
+					"webform_include_js", context.doc_type
+				) + get_code_files_via_hooks("webform_include_js", "*"):
 					custom_js = frappe.render_template(open(path).read(), context)
 					script = "\n\n".join([script, custom_js])
 


### PR DESCRIPTION
### Summary
Extended the `webform_include_js` hook to support wildcard (`*`) patterns, allowing JavaScript files to be included across all webform types.

### Changes
- Modified webform JavaScript inclusion logic to check for both specific doc_type hooks and wildcard hooks
- Added support for `webform_include_js` hook with `*` parameter to include JS files globally across all webforms

### Usage
Developers can now register JavaScript files to be included in all webforms by using the wildcard pattern:

```python
# hooks.py
webform_include_js = {
    "*": [
        "assets/js/global_webform.js",
        "assets/js/common_validation.js"
    ],
    "Lead": [
        "assets/js/lead_specific.js"
    ]
}