### PR TITLE
feat: Add `--skip-fixtures` Option to `bench migrate` Command

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -691,8 +691,9 @@ def disable_user(context: CliCtxObj, email):
 @click.command("migrate")
 @click.option("--skip-failing", is_flag=True, help="Skip patches that fail to run")
 @click.option("--skip-search-index", is_flag=True, help="Skip search indexing for web documents")
+@click.option("--skip-fixtures", is_flag=True, help="Skip loading fixtures")
 @pass_context
-def migrate(context: CliCtxObj, skip_failing=False, skip_search_index=False):
+def migrate(context: CliCtxObj, skip_failing=False, skip_search_index=False, skip_fixtures=False):
 	"Run patches, sync schema and rebuild files/translations"
 
 	from frappe.migrate import SiteMigration
@@ -701,8 +702,7 @@ def migrate(context: CliCtxObj, skip_failing=False, skip_search_index=False):
 		click.secho(f"Migrating {site}", fg="green")
 		try:
 			SiteMigration(
-				skip_failing=skip_failing,
-				skip_search_index=skip_search_index,
+				skip_failing=skip_failing, skip_search_index=skip_search_index, skip_fixtures=skip_fixtures
 			).run(site=site)
 		finally:
 			print()

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -71,9 +71,12 @@ class SiteMigration:
 	- run after migrate hooks
 	"""
 
-	def __init__(self, skip_failing: bool = False, skip_search_index: bool = False) -> None:
+	def __init__(
+		self, skip_failing: bool = False, skip_search_index: bool = False, skip_fixtures: bool = False
+	) -> None:
 		self.skip_failing = skip_failing
 		self.skip_search_index = skip_search_index
+		self.skip_fixtures = skip_fixtures
 
 	def setUp(self):
 		"""Complete setup required for site migration"""
@@ -143,9 +146,11 @@ class SiteMigration:
 		"""
 		print("Syncing jobs...")
 		sync_jobs()
-
-		print("Syncing fixtures...")
-		sync_fixtures()
+		if not self.skip_fixtures:
+			print("Syncing fixtures...")
+			sync_fixtures()
+		else:
+			print("Skipping fixtures...")
 		sync_standard_items()
 
 		print("Syncing dashboards...")


### PR DESCRIPTION
# PR: Add `--skip-fixtures` Option to `bench migrate` Command

## Description
This pull request introduces a new `--skip-fixtures` option to the `bench migrate` CLI command in Frappe.  
When this flag is provided, fixture syncing will be skipped during migration.

---

## Motivation
In certain development and deployment scenarios, syncing fixtures during migration may not be required or desirable.  
This new option gives developers and system administrators better control over the migration process, improving flexibility and reducing migration time when fixtures are not needed.

---

## Changes
- Added `--skip-fixtures` flag to the `migrate` command in `site.py`.  
- Passed the `skip_fixtures` argument to the `SiteMigration` class.  
- Modified the migration process to print a message:  

## Usage
Run the following command to skip fixtures during migration:

```bash
bench migrate <your-site-name>  --skip-fixtures
```
## Impact
- **No breaking changes** — existing behavior remains intact.  
- By default, fixtures will continue to sync during migration unless the `--skip-fixtures` flag is used.  
- Provides faster migrations when fixture syncing is not required.  
- Adds flexibility for developers and system administrators to control the migration process.  
