### PR TITLE
feat: active app telemetry

### DIFF
--- a/frappe/api/__init__.py
+++ b/frappe/api/__init__.py
@@ -8,9 +8,8 @@ from werkzeug.routing import Map, Submount
 from werkzeug.wrappers import Request, Response
 
 import frappe
-import frappe.client
 from frappe import _
-from frappe.pulse.app_activity_event import log_app_activity
+from frappe.pulse.app_heartbeat_event import log_app_heartbeat
 from frappe.utils.response import build_response
 
 
@@ -68,7 +67,7 @@ def handle(request: Request):
 	data = build_response("json")
 
 	with suppress(Exception):
-		log_app_activity(arguments)
+		log_app_heartbeat(arguments)
 
 	return data
 

--- a/frappe/api/__init__.py
+++ b/frappe/api/__init__.py
@@ -9,7 +9,7 @@ from werkzeug.wrappers import Request, Response
 
 import frappe
 from frappe import _
-from frappe.pulse.app_heartbeat_event import log_app_heartbeat
+from frappe.pulse.app_heartbeat_event import capture_app_heartbeat
 from frappe.utils.response import build_response
 
 
@@ -67,7 +67,7 @@ def handle(request: Request):
 	data = build_response("json")
 
 	with suppress(Exception):
-		log_app_heartbeat(arguments)
+		capture_app_heartbeat(arguments)
 
 	return data
 

--- a/frappe/api/__init__.py
+++ b/frappe/api/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+from contextlib import suppress
 from enum import Enum
 
 from werkzeug.exceptions import NotFound
@@ -9,6 +10,7 @@ from werkzeug.wrappers import Request, Response
 import frappe
 import frappe.client
 from frappe import _
+from frappe.pulse.app_activity_event import log_app_activity
 from frappe.utils.response import build_response
 
 
@@ -63,7 +65,12 @@ def handle(request: Request):
 
 	if data is not None:
 		frappe.response["data"] = data
-	return build_response("json")
+	data = build_response("json")
+
+	with suppress(Exception):
+		log_app_activity(arguments)
+
+	return data
 
 
 # Merge all API version routing rules

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -214,6 +214,11 @@ scheduler_events = {
 		"0/10 * * * *": [
 			"frappe.email.doctype.email_account.email_account.pull",
 		],
+		# 6 hours
+		"0 */6 * * *": [
+			"frappe.pulse.app_activity_event.send",
+		],
+
 		# Hourly but offset by 30 minutes
 		"30 * * * *": [],
 		# Daily but offset by 45 minutes

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -209,14 +209,11 @@ scheduler_events = {
 			"frappe.automation.doctype.reminder.reminder.send_reminders",
 			"frappe.model.utils.link_count.update_link_count",
 			"frappe.search.sqlite_search.build_index_if_not_exists",
+			"frappe.pulse.client.send_queued_events",
 		],
 		# 10 minutes
 		"0/10 * * * *": [
 			"frappe.email.doctype.email_account.email_account.pull",
-		],
-		# 6 hours
-		"0 */6 * * *": [
-			"frappe.pulse.app_heartbeat_event.send",
 		],
 		# Hourly but offset by 30 minutes
 		"30 * * * *": [],

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -216,7 +216,7 @@ scheduler_events = {
 		],
 		# 6 hours
 		"0 */6 * * *": [
-			"frappe.pulse.app_activity_event.send",
+			"frappe.pulse.app_heartbeat_event.send",
 		],
 		# Hourly but offset by 30 minutes
 		"30 * * * *": [],

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -218,7 +218,6 @@ scheduler_events = {
 		"0 */6 * * *": [
 			"frappe.pulse.app_activity_event.send",
 		],
-
 		# Hourly but offset by 30 minutes
 		"30 * * * *": [],
 		# Daily but offset by 45 minutes

--- a/frappe/pulse/app_activity_event.py
+++ b/frappe/pulse/app_activity_event.py
@@ -8,7 +8,7 @@ KEY = "pulse:active_apps"
 EXPIRY = 60 * 60 * 12  # 12 hours
 
 
-def log_app_activity(args):
+def log_app_activity(req_params):
 	if not is_enabled() or frappe.session.user in ("Guest", "Administrator"):
 		return
 
@@ -16,8 +16,8 @@ def log_app_activity(args):
 	if status_code and not (200 <= status_code < 300):
 		return
 
-	method = args.get("method") or frappe.form_dict.get("method")
-	doctype = args.get("doctype") or frappe.form_dict.get("doctype")
+	method = req_params.get("method") or frappe.form_dict.get("method")
+	doctype = req_params.get("doctype") or frappe.form_dict.get("doctype")
 
 	if not method and not doctype:
 		return

--- a/frappe/pulse/app_activity_event.py
+++ b/frappe/pulse/app_activity_event.py
@@ -1,0 +1,82 @@
+import frappe
+from frappe.modules import get_doctype_module
+from frappe.utils.caching import site_cache
+
+from .client import is_enabled, post_events
+
+KEY = "pulse:active_apps"
+EXPIRY = 60 * 60 * 12  # 12 hours
+
+
+def log_app_activity(args):
+	if not is_enabled() or frappe.session.user in ("Guest", "Administrator"):
+		return
+
+	status_code = frappe.response.http_status_code or 0
+	if status_code and not (200 <= status_code < 300):
+		return
+
+	method = args.get("method") or frappe.form_dict.get("method")
+	doctype = args.get("doctype") or frappe.form_dict.get("doctype")
+
+	if not method and not doctype:
+		return
+
+	app_name = None
+	if method and "." in method and not method.startswith("frappe."):
+		app_name = method.split(".", 1)[0]
+
+	if not app_name and doctype:
+		module = get_doctype_module(doctype)
+		app_name = app_module_map().get(module)
+
+	if app_name and app_name != "frappe":
+		_mark_active(app_name)
+
+
+def send():
+	if not is_enabled():
+		return
+
+	active_apps = frappe.cache.get_value(KEY) or set()
+	if not active_apps:
+		return
+
+	events = []
+	for app in active_apps:
+		events.append(
+			{
+				"name": "app_activity",
+				"app": app,
+				"app_version": _get_app_version(app),
+			}
+		)
+
+	try:
+		if post_events(events):
+			frappe.cache.delete_value(KEY)
+	except Exception:
+		frappe.log_error(title="Failed to send app activity events")
+
+
+def _mark_active(app):
+	active_apps = frappe.cache.get_value(KEY) or set()
+	if app not in active_apps:
+		active_apps.add(app)
+		frappe.cache.set_value(KEY, active_apps)
+		ttl = frappe.cache.ttl(KEY)
+		if ttl in (-1, None):
+			frappe.cache.expire(KEY, EXPIRY)
+
+
+def _get_app_version(app_name: str) -> str:
+	try:
+		return frappe.get_attr(app_name + ".__version__")
+	except Exception:
+		return "0.0.1"
+
+
+@site_cache()
+def app_module_map():
+	defs = frappe.get_all("Module Def", fields=["name", "app_name"])
+	return {d.name: d.app_name for d in defs}

--- a/frappe/pulse/app_heartbeat_event.py
+++ b/frappe/pulse/app_heartbeat_event.py
@@ -5,9 +5,6 @@ from frappe.utils.caching import site_cache
 
 from .client import capture, is_enabled
 
-KEY = "pulse:active_apps"
-EXPIRY = 60 * 60 * 12  # 12 hours
-
 
 def capture_app_heartbeat(req_params):
 	if not should_capture():

--- a/frappe/pulse/app_heartbeat_event.py
+++ b/frappe/pulse/app_heartbeat_event.py
@@ -8,7 +8,7 @@ KEY = "pulse:active_apps"
 EXPIRY = 60 * 60 * 12  # 12 hours
 
 
-def log_app_activity(req_params):
+def log_app_heartbeat(req_params):
 	if not is_enabled() or frappe.session.user in ("Guest", "Administrator"):
 		return
 
@@ -46,7 +46,7 @@ def send():
 	for app in active_apps:
 		events.append(
 			{
-				"name": "app_activity",
+				"name": "app_heartbeat",
 				"app": app,
 				"app_version": _get_app_version(app),
 			}
@@ -56,7 +56,7 @@ def send():
 		if post_events(events):
 			frappe.cache.delete_value(KEY)
 	except Exception:
-		frappe.log_error(title="Failed to send app activity events")
+		frappe.log_error(title="Failed to send app heartbeat events")
 
 
 def _mark_active(app):

--- a/frappe/pulse/client.py
+++ b/frappe/pulse/client.py
@@ -50,7 +50,7 @@ def _is_ratelimited(event_key, interval):
 		return False
 
 	interval_seconds = parse_interval(interval)
-	last_sent_key = f"pulse:last_sent:{event_key}"
+	last_sent_key = f"pulse-client:last_sent:{event_key}"
 	last_sent = frappe.cache.get_value(last_sent_key)
 
 	if last_sent and time.monotonic() - float(last_sent) < interval_seconds:
@@ -62,13 +62,13 @@ def _is_ratelimited(event_key, interval):
 def _update_ratelimit(event_key, interval):
 	if not interval:
 		return
-	last_sent_key = f"pulse:last_sent:{event_key}"
+	last_sent_key = f"pulse-client:last_sent:{event_key}"
 	frappe.cache.set_value(last_sent_key, time.monotonic(), expires_in_sec=86400)  # 24h TTL
 
 
 def _queue_event(event):
-	frappe.cache.lpush("pulse:events", frappe.as_json(event))
-	frappe.cache.ltrim("pulse:events", 0, 4999)
+	frappe.cache.lpush("pulse-client:events", frappe.as_json(event))
+	frappe.cache.ltrim("pulse-client:events", 0, 4999)
 
 
 def send_queued_events():
@@ -89,7 +89,7 @@ def get_next_batch(batch_size=100):
 	"""Get batch of events from the queue"""
 	events = []
 	for _ in range(batch_size):
-		event_json = frappe.cache.rpop("pulse:events")
+		event_json = frappe.cache.rpop("pulse-client:events")
 		if not event_json:
 			break
 		event_json = event_json.decode()

--- a/frappe/pulse/client.py
+++ b/frappe/pulse/client.py
@@ -1,6 +1,10 @@
-from datetime import datetime, timezone
+import time
+from contextlib import suppress
+
+from orjson import JSONDecodeError
 
 import frappe
+from frappe.pulse.utils import anonymize_user, ensure_http, parse_interval, utc_iso
 from frappe.utils import get_request_session
 from frappe.utils.caching import site_cache
 from frappe.utils.frappecloud import on_frappecloud
@@ -17,52 +21,111 @@ def is_enabled() -> bool:
 	)
 
 
-def post_events(events):
-	events = _sanitize_events(events)
+def capture(event_name, site=None, app=None, user=None, properties=None, interval=None):
+	if not is_enabled():
+		return
+
+	try:
+		event_key = f"{event_name}:{site}:{app}:{user}"
+		if _is_ratelimited(event_key, interval):
+			return
+
+		_queue_event(
+			{
+				"event_name": event_name,
+				"captured_at": utc_iso(),
+				"app": app,
+				"user": anonymize_user(user),
+				"site": site or frappe.local.site,
+				"properties": properties,
+			}
+		)
+		_update_ratelimit(event_key, interval)
+	except Exception as e:
+		frappe.logger().error(f"Pulse event capture failed: {e!s}")
+
+
+def _is_ratelimited(event_key, interval):
+	if not interval:
+		return False
+
+	interval_seconds = parse_interval(interval)
+	last_sent_key = f"pulse:last_sent:{event_key}"
+	last_sent = frappe.cache.get_value(last_sent_key)
+
+	if last_sent and time.monotonic() - float(last_sent) < interval_seconds:
+		return True
+
+	return False
+
+
+def _update_ratelimit(event_key, interval):
+	if not interval:
+		return
+	last_sent_key = f"pulse:last_sent:{event_key}"
+	frappe.cache.set_value(last_sent_key, time.monotonic(), expires_in_sec=86400)  # 24h TTL
+
+
+def _queue_event(event):
+	frappe.cache.lpush("pulse:events", frappe.as_json(event))
+	frappe.cache.ltrim("pulse:events", 0, 4999)
+
+
+def send_queued_events():
+	batch_size = 100
+	max_batches = 10
+	for _ in range(max_batches):
+		events = get_next_batch(batch_size)
+		if not events:
+			break
+		try:
+			if not post(events):
+				frappe.logger().error("Pulse sending events failed: non-2xx response")
+		except Exception as e:
+			frappe.logger().error(f"Pulse sending events failed: {e!s}")
+
+
+def get_next_batch(batch_size=100):
+	"""Get batch of events from the queue"""
+	events = []
+	for _ in range(batch_size):
+		event_json = frappe.cache.rpop("pulse:events")
+		if not event_json:
+			break
+		event_json = event_json.decode()
+		with suppress(JSONDecodeError):
+			data = frappe.parse_json(event_json)
+			events.append(data)
+	return events
+
+
+def post(events):
+	# TODO: implement retry logic
 	session = _create_session()
-	resp = session.post(_get_ingest_url(), data=events, timeout=5.0)
+	url = _get_ingest_url()
+	data = frappe.as_json({"events": events})
+	resp = session.post(url, data=data, timeout=15)
 	return 200 <= resp.status_code < 300
 
 
 def _create_session():
 	api_key = frappe.conf.get("pulse_api_key")
 	session = get_request_session()
-	if api_key:
-		session.headers.update({"Authorization": f"Bearer {api_key}"})
+	session.headers.update(
+		{
+			"Content-Type": "application/json",
+			"X-Pulse-API-Key": api_key,
+		}
+	)
 	return session
 
 
 def _get_ingest_url():
 	host = frappe.conf.get("pulse_host") or "https://pulse.m.frappe.cloud"
-	if not host.startswith("http"):
-		host = "https://" + host
+	host = ensure_http(host)
 	host = host.rstrip("/")
 
-	endpoint = frappe.conf.get("pulse_ingest_endpoint") or "/api/method/pulse.api.ingest"
+	endpoint = frappe.conf.get("pulse_ingest_endpoint") or "/api/method/pulse.api.bulk_ingest"
 	endpoint = endpoint.lstrip("/")
 
 	return f"{host}/{endpoint}"
-
-
-def _sanitize_events(events):
-	_events = []
-	if not isinstance(events, list):
-		_events = [events]
-
-	for event in events:
-		if not isinstance(event, dict) or "name" not in event:
-			continue
-		event["site"] = event["site"] or frappe.local.site
-		event["timestamp"] = event["timestamp"] or _utc_iso()
-		event["frappe_version"] = event["frappe_version"] or _get_frappe_version()
-		_events.append(event)
-
-	return _events
-
-
-def _get_frappe_version() -> str:
-	return getattr(frappe, "__version__", "unknown")
-
-
-def _utc_iso() -> str:
-	return datetime.now(timezone.utc).isoformat(timespec="seconds")

--- a/frappe/pulse/client.py
+++ b/frappe/pulse/client.py
@@ -10,6 +10,7 @@ from frappe.utils.caching import site_cache
 from frappe.utils.frappecloud import on_frappecloud
 
 
+@frappe.whitelist()
 @site_cache()
 def is_enabled() -> bool:
 	return (
@@ -70,6 +71,9 @@ def _queue_event(event):
 	frappe.cache.lpush("pulse-client:events", frappe.as_json(event))
 	frappe.cache.ltrim("pulse-client:events", 0, 4999)
 
+
+def queue_length():
+	return frappe.cache.llen("pulse-client:events")
 
 def send_queued_events():
 	batch_size = 100

--- a/frappe/pulse/client.py
+++ b/frappe/pulse/client.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timezone
+
+import frappe
+from frappe.utils import get_request_session
+from frappe.utils.caching import site_cache
+from frappe.utils.frappecloud import on_frappecloud
+
+
+@site_cache()
+def is_enabled() -> bool:
+	return (
+		not frappe.conf.get("developer_mode", 0)
+		and not frappe.conf.get("pulse_disabled", 0)
+		and frappe.conf.get("pulse_api_key")
+		and on_frappecloud()
+		and frappe.get_system_settings("enable_telemetry")
+	)
+
+
+def post_events(events):
+	events = _sanitize_events(events)
+	session = _create_session()
+	resp = session.post(_get_ingest_url(), data=events, timeout=5.0)
+	return 200 <= resp.status_code < 300
+
+
+def _create_session():
+	api_key = frappe.conf.get("pulse_api_key")
+	session = get_request_session()
+	if api_key:
+		session.headers.update({"Authorization": f"Bearer {api_key}"})
+	return session
+
+
+def _get_ingest_url():
+	host = frappe.conf.get("pulse_host") or "https://pulse.m.frappe.cloud"
+	if not host.startswith("http"):
+		host = "https://" + host
+	host = host.rstrip("/")
+
+	endpoint = frappe.conf.get("pulse_ingest_endpoint") or "/api/method/pulse.api.ingest"
+	endpoint = endpoint.lstrip("/")
+
+	return f"{host}/{endpoint}"
+
+
+def _sanitize_events(events):
+	_events = []
+	if not isinstance(events, list):
+		_events = [events]
+
+	for event in events:
+		if not isinstance(event, dict) or "name" not in event:
+			continue
+		event["site"] = event["site"] or frappe.local.site
+		event["timestamp"] = event["timestamp"] or _utc_iso()
+		event["frappe_version"] = event["frappe_version"] or _get_frappe_version()
+		_events.append(event)
+
+	return _events
+
+
+def _get_frappe_version() -> str:
+	return getattr(frappe, "__version__", "unknown")
+
+
+def _utc_iso() -> str:
+	return datetime.now(timezone.utc).isoformat(timespec="seconds")

--- a/frappe/pulse/client.py
+++ b/frappe/pulse/client.py
@@ -75,6 +75,7 @@ def _queue_event(event):
 def queue_length():
 	return frappe.cache.llen("pulse-client:events")
 
+
 def send_queued_events():
 	batch_size = 100
 	max_batches = 10

--- a/frappe/pulse/utils.py
+++ b/frappe/pulse/utils.py
@@ -1,0 +1,97 @@
+import hashlib
+from datetime import datetime, timezone
+
+import frappe
+
+
+def anonymize_user(user):
+	"""
+	Create consistent anonymous ID from user email.
+	Same email always produces same anonymous ID.
+	"""
+	if not user or user in frappe.STANDARD_USERS:
+		return user
+
+	# Use site-specific salt for additional security
+	site_salt = frappe.local.site or "default"
+
+	# Create deterministic hash
+	hash_input = f"{user}:{site_salt}".encode()
+	user_hash = hashlib.sha256(hash_input).hexdigest()
+
+	# Return first 12 characters for readability
+	return f"anon_{user_hash[:12]}"
+
+
+def parse_interval(interval):
+	"""
+	Parse interval string or integer into seconds.
+
+	Args:
+	    interval: Can be:
+	        - Integer: seconds (e.g., 3600)
+	        - String: number + unit (e.g., "1h", "30m", "7d")
+
+	Returns:
+	    int: Total seconds
+
+	Examples:
+	    parse_interval(3600) -> 3600
+	    parse_interval("1h") -> 3600
+	    parse_interval("30m") -> 1800
+	    parse_interval("7d") -> 604800
+	"""
+	if interval is None:
+		return None
+
+	# If already an integer, return as-is (assuming seconds)
+	if isinstance(interval, int):
+		return interval
+
+	# Parse string format
+	interval = str(interval).strip().lower()
+
+	# Extract number and unit
+	if interval[-1].isdigit():
+		# No unit specified, assume seconds
+		return int(interval)
+
+	unit = interval[-1]
+	try:
+		number = int(interval[:-1])
+	except ValueError:
+		raise ValueError(f"Invalid interval format: {interval}")
+
+	# Convert to seconds
+	multipliers = {
+		"s": 1,  # seconds
+		"m": 60,  # minutes
+		"h": 3600,  # hours
+		"d": 86400,  # days
+		"w": 604800,  # weeks
+		"y": 31536000,  # years
+	}
+
+	if unit not in multipliers:
+		raise ValueError(f"Invalid time unit '{unit}'. Use: s, m, h, d, w, y")
+
+	return number * multipliers[unit]
+
+
+def get_frappe_version() -> str:
+	return getattr(frappe, "__version__", "unknown")
+
+
+def utc_iso() -> str:
+	return datetime.now(timezone.utc).isoformat()
+
+
+def get_app_version(app_name: str) -> str:
+	try:
+		return frappe.get_attr(app_name + ".__version__")
+	except Exception:
+		return "0.0.1"
+
+
+def ensure_http(url: str) -> str:
+	return url if url.startswith(("http://", "https://")) else "https://" + url

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -19,7 +19,6 @@ import werkzeug.utils
 from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.local import LocalProxy
 from werkzeug.wrappers import Response
-from werkzeug.wsgi import wrap_file
 
 import frappe
 import frappe.model.document
@@ -306,26 +305,26 @@ def send_private_file(path: str) -> Response:
 		response = Response()
 		response.headers["X-Accel-Redirect"] = quote(frappe.utils.encode(path))
 		response.headers["Cache-Control"] = "private,max-age=3600,stale-while-revalidate=86400"
+		response.headers["Accept-Ranges"] = "bytes"
 
 	else:
 		filepath = frappe.utils.get_site_path(path)
-		try:
-			f = open(filepath, "rb")
-		except OSError:
+		if not os.path.exists(filepath):
 			raise NotFound
 
-		response = Response(wrap_file(frappe.local.request.environ, f), direct_passthrough=True)
+		mimetype = mimetypes.guess_type(filename)[0] or "application/octet-stream"
 
-	# no need for content disposition and force download. let browser handle its opening.
-	# Except for those that can be injected with scripts.
+		extension = os.path.splitext(path)[1]
+		blacklist = [".svg", ".html", ".htm", ".xml"]
+		as_attachment = extension.lower() in blacklist
 
-	extension = os.path.splitext(path)[1]
-	blacklist = [".svg", ".html", ".htm", ".xml"]
+		send_kwargs = dict(mimetype=mimetype, conditional=True, as_attachment=as_attachment)
+		environ = frappe.local.request.environ
 
-	if extension.lower() in blacklist:
-		response.headers.add("Content-Disposition", "attachment", filename=filename)
-
-	response.mimetype = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+		if as_attachment:
+			response = werkzeug.utils.send_file(filepath, environ, download_name=filename, **send_kwargs)
+		else:
+			response = werkzeug.utils.send_file(filepath, environ, **send_kwargs)
 
 	return response
 

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -312,19 +312,17 @@ def send_private_file(path: str) -> Response:
 		if not os.path.exists(filepath):
 			raise NotFound
 
-		mimetype = mimetypes.guess_type(filename)[0] or "application/octet-stream"
-
 		extension = os.path.splitext(path)[1]
 		blacklist = [".svg", ".html", ".htm", ".xml"]
 		as_attachment = extension.lower() in blacklist
 
-		send_kwargs = dict(mimetype=mimetype, conditional=True, as_attachment=as_attachment)
-		environ = frappe.local.request.environ
-
-		if as_attachment:
-			response = werkzeug.utils.send_file(filepath, environ, download_name=filename, **send_kwargs)
-		else:
-			response = werkzeug.utils.send_file(filepath, environ, **send_kwargs)
+		response = werkzeug.utils.send_file(
+			filepath,
+			environ=frappe.local.request.environ,
+			conditional=True,
+			as_attachment=as_attachment,
+			download_name=filename if as_attachment else None,
+		)
 
 	return response
 


### PR DESCRIPTION
If telemetry is enabled & is hosted on frappe cloud, then log active apps in `frappe.cache` based on API requests and send an event. 

`no-docs`