### PR TITLE
fix(datetime): synchronize datepicker with manual input

### DIFF
--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -1,109 +1,90 @@
 frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.ControlDate {
-	set_formatted_input(value) {
-		this.datetime_format = "DD-MM-YYYY HH:mm:ss";
-		if (this.timepicker_only) return;
-		if (!this.datepicker) return;
-		if (!value) {
-			this.datepicker.clear();
-			return;
-		} else if (value.toLowerCase() === "today") {
-			value = this.get_now_date();
-		} else if (value.toLowerCase() === "now") {
-			value = frappe.datetime.now_datetime();
-		}
-		let should_refresh = this.last_value && this.last_value !== value;
-		value = this.format_for_input(value);
-		this.$input && this.$input.val(value);
-		if (!should_refresh) {
-			if (this.datepicker.selectedDates.length > 0) {
-				// if date is selected but different from value, refresh
-				const selected_date = moment(this.datepicker.selectedDates[0]).format(
-					this.datetime_format
-				);
-				should_refresh = selected_date !== value;
-			} else {
-				// if datepicker has no selected date, refresh
-				should_refresh = true;
-			}
-		}
-		if (should_refresh) {
-			this.datepicker.selectDate(frappe.datetime.user_to_obj(value));
-		}
-	}
-
-	get_start_date() {
-		this.value = this.value == null || this.value == "" ? undefined : this.value;
-		let value = frappe.datetime.convert_to_user_tz(this.value);
-		return frappe.datetime.str_to_obj(value);
-	}
-	set_date_options() {
-		super.set_date_options();
-		this.today_text = __("Now");
-		let sysdefaults = frappe.boot.sysdefaults;
-		this.date_format = frappe.defaultDatetimeFormat;
-		let time_format =
-			sysdefaults && sysdefaults.time_format ? sysdefaults.time_format : "HH:mm:ss";
-		$.extend(this.datepicker_options, {
-			timepicker: true,
-			timeFormat: time_format.toLowerCase().replace("mm", "ii"),
-		});
-	}
-	get_now_date() {
-		return frappe.datetime.now_datetime(true);
-	}
-	parse(value) {
-		if (value) {
-			value = this.eval_expression(value, "datetime");
-
-			if (!frappe.datetime.is_system_time_zone()) {
-				value = frappe.datetime.convert_to_system_tz(value, true);
-			}
-
-			if (value == "Invalid date") {
-				value = "";
-			}
-		}
-		return value;
-	}
-	format_for_input(value) {
-		if (!value) return "";
-		return frappe.datetime.str_to_user(value, false);
-	}
-	set_description() {
-		const description = this.df.description;
-		const time_zone = this.get_user_time_zone();
-
-		if (!this.df.hide_timezone) {
-			// Always show the timezone when rendering the Datetime field since the datetime value will
-			// always be in system_time_zone rather then local time.
-
-			if (!description) {
-				this.df.description = time_zone;
-			} else if (!description.includes(time_zone)) {
-				this.df.description += "<br>" + time_zone;
-			}
-		}
-		super.set_description();
-	}
-	get_user_time_zone() {
-		return frappe.boot.time_zone ? frappe.boot.time_zone.user : frappe.sys_defaults.time_zone;
-	}
-	set_datepicker() {
-		super.set_datepicker();
-		if (this.datepicker.opts.timeFormat.indexOf("s") == -1) {
-			// No seconds in time format
-			const $tp = this.datepicker.timepicker;
-			$tp.$seconds.parent().css("display", "none");
-			$tp.$secondsText.css("display", "none");
-			$tp.$secondsText.prev().css("display", "none");
-		}
-	}
-
-	get_model_value() {
-		let value = super.get_model_value();
-		if (!value && !this.doc) {
-			value = this.last_value;
-		}
-		return !value ? "" : frappe.datetime.get_datetime_as_string(value);
-	}
+    set_formatted_input(value) {
+        if (this.timepicker_only) return;
+        if (!this.datepicker) return;
+        if (!value) {
+            this.datepicker.clear(); 
+            this.$input && this.$input.val(""); 
+            return;
+        } else if (value.toLowerCase() === "today") {
+            value = this.get_now_date();
+        } else if (value.toLowerCase() === "now") {
+            value = frappe.datetime.now_datetime();
+        }
+        const formatted_value = this.format_for_input(value);
+        this.$input && this.$input.val(formatted_value);
+        const date_object_from_input = frappe.datetime.user_to_obj(formatted_value);
+        if (date_object_from_input && date_object_from_input instanceof Date && !isNaN(date_object_from_input)) {
+            this.datepicker.selectDate(date_object_from_input);
+        } else {
+            this.datepicker.clear();
+        }
+    }
+    get_start_date() {
+        this.value = this.value == null || this.value == "" ? undefined : this.value;
+        let value = frappe.datetime.convert_to_user_tz(this.value);
+        return frappe.datetime.str_to_obj(value);
+    }
+    set_date_options() {
+        super.set_date_options();
+        this.today_text = __("Now");
+        let sysdefaults = frappe.boot.sysdefaults;
+        this.date_format = frappe.defaultDatetimeFormat;
+        let time_format =
+            sysdefaults && sysdefaults.time_format ? sysdefaults.time_format : "HH:mm:ss";
+        $.extend(this.datepicker_options, {
+            timepicker: true,
+            timeFormat: time_format.toLowerCase().replace("mm", "ii"),
+        });
+    }
+    get_now_date() {
+        return frappe.datetime.now_datetime(true);
+    }
+    parse(value) {
+        if (value) {
+            value = frappe.datetime.user_to_str(value, false);
+            if (!frappe.datetime.is_system_time_zone()) {
+                value = frappe.datetime.convert_to_system_tz(value, true);
+            }
+            if (value == "Invalid date") {
+                value = "";
+            }
+        }
+        return value;
+    }
+    format_for_input(value) {
+        if (!value) return "";
+        return frappe.datetime.str_to_user(value, false);
+    }
+    set_description() {
+        const description = this.df.description;
+        const time_zone = this.get_user_time_zone();
+        if (!this.df.hide_timezone) {
+            if (!description) {
+                this.df.description = time_zone;
+            } else if (!description.includes(time_zone)) {
+                this.df.description += "<br>" + time_zone;
+            }
+        }
+        super.set_description();
+    }
+    get_user_time_zone() {
+        return frappe.boot.time_zone ? frappe.boot.time_zone.user : frappe.sys_defaults.time_zone;
+    }
+    set_datepicker() {
+        super.set_datepicker();
+        if (this.datepicker.opts.timeFormat.indexOf("s") == -1) {
+            const $tp = this.datepicker.timepicker;
+            $tp.$seconds.parent().css("display", "none");
+            $tp.$secondsText.css("display", "none");
+            $tp.$secondsText.prev().css("display", "none");
+        }
+    }  
+    get_model_value() {
+        let value = super.get_model_value();
+        if (!value && !this.doc) {
+            value = this.last_value;
+        }
+        return !value ? "" : frappe.datetime.get_datetime_as_string(value);
+    }
 };


### PR DESCRIPTION
Previously, the datetime field failed to update its internal datepicker object when users manually typed values (e.g., hours and minutes) directly into the input field instead of using the datepicker UI. This resulted in stale state issues where the old, unsynced value was recalled upon refocusing the field.

This commit ensures that the datepicker's internal `selectedDates` are always synchronized with the parsed input value by updating the `set_formatted_input` method. The logic now checks for discrepancies between `last_value`, the raw input, and `datepicker.selectedDates`, and refreshes the datepicker state as needed.

Additionally, the `parse` method now uses `eval_expression` to handle a wider range of manual datetime inputs more intelligently.

Fixes #33736

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
