### PR TITLE
fix(print-format): typo in doctype

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -23,7 +23,7 @@ frappe.ui.form.on("Print Format", {
 	},
 	render_buttons: function (frm) {
 		frm.page.clear_inner_toolbar();
-		if (!frm.is_new() && frm.doc.print_format_for === "Doctype") {
+		if (!frm.is_new() && frm.doc.print_format_for === "DocType") {
 			if (!frm.doc.custom_format) {
 				frm.add_custom_button(__("Edit Format"), function () {
 					if (!frm.doc.doc_type) {


### PR DESCRIPTION
Typo: "Doctype" to "DocType" in Print Format `render_buttons` validation 

Before:

<img width="1792" height="1120" alt="Screenshot 2025-08-22 at 9 52 34 PM" src="https://github.com/user-attachments/assets/91d59479-24bb-42e9-aeef-a8e9c8be8b75" />

After:

<img width="1792" height="1120" alt="Screenshot 2025-08-22 at 9 51 38 PM" src="https://github.com/user-attachments/assets/f416f2e3-ce73-45b2-9d44-0f60a7e55392" />
