### PR TITLE
fix: handle get_count for doctypes with reserved keywords in name

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -67,8 +67,9 @@ def get_count() -> int | None:
 
 	# args.limit is specified to avoid getting accurate count.
 	if not args.limit:
-		args.fields = [f"count({fieldname}) as total_count"]
-		return execute(**args)[0].get("total_count")
+		args.fields = [fieldname]
+		partial_query = execute(**args, run=0)
+		return frappe.db.sql(f"select count(*) from ( {partial_query} ) p")[0][0]
 
 	args.fields = [fieldname]
 	partial_query = execute(**args, run=0)


### PR DESCRIPTION
Previously, get_count failed for DocTypes like `Deleted Document` without limit. Since execute() flagged the word "delete" inside the expression and raised `Use of sub-query or function is restricted`.

Now, get_count works for DocTypes like Deleted Document without limit, the same as it does with limit.

## Before

https://github.com/user-attachments/assets/6c836c4f-5c39-426c-819f-23486742f454

## After

https://github.com/user-attachments/assets/5b6efecf-c609-496e-a74f-9ed83d9404a8

Support: https://support.frappe.io/helpdesk/tickets/46548?view=VIEW-HD+Ticket-003
