### PR TITLE
fix: offset child row index by 1 for correct display

### DIFF
--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -163,7 +163,7 @@ function get_version_timeline_content(version_doc, frm) {
 								frappe.meta.get_label(frm.fields_dict[row[0]].grid.doctype, p[0]),
 								format_content_for_timeline(p[1]),
 								format_content_for_timeline(p[2]),
-								row[1],
+								row[1] + 1,
 							])
 						);
 					}


### PR DESCRIPTION
Child table row indices are 1-based, so the activity log should also display them as 1-based.

## Before


https://github.com/user-attachments/assets/159f4006-a65c-4ab9-9f12-40776374b6c3


## After


https://github.com/user-attachments/assets/ab019f3b-6695-47d5-b3f5-5e882a14fade



Support: https://support.frappe.io/helpdesk/tickets/46829?view=VIEW-HD+Ticket-003