### PR TITLE
feat: add permission-based recipient filtering and CC by role in Notification

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -577,16 +577,21 @@ def get_context(context):
 			bcc.extend(get_emails_from_template(recipient.bcc, context))
 
 			# CC by role
+			cc_emails = get_emails_from_template(recipient.cc, context) or []
+			role_emails = []
+
 			if recipient.cc_receiver_by_role:
-				cc_emails = get_emails_from_template(recipient.cc, context) or []
 				role_emails = get_info_based_on_role(
 					recipient.cc_receiver_by_role, "email", ignore_permissions=True
 				)
-				emails = role_emails + cc_emails
-				if recipient.check_user_permission:
-					cc.extend(self.filter_by_permission(emails, doc))
-				else:
-					cc.extend(emails)
+
+			if recipient.check_user_permission:
+				allowed_role_emails = self.filter_by_permission(role_emails, doc)
+			else:
+				allowed_role_emails = role_emails
+
+			emails = (allowed_role_emails or []) + cc_emails
+			cc.extend(emails)
 
 			# For sending emails to specified role
 			if recipient.receiver_by_role:

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -14,6 +14,7 @@ from frappe.desk.doctype.notification_log.notification_log import enqueue_create
 from frappe.integrations.doctype.slack_webhook_url.slack_webhook_url import send_slack_message
 from frappe.model.document import Document
 from frappe.modules.utils import export_module_json, get_doc_module
+from frappe.permissions import has_permission
 from frappe.utils import add_to_date, cast, now_datetime, nowdate, validate_email_address
 from frappe.utils.data import evaluate_filters
 from frappe.utils.jinja import validate_template
@@ -572,20 +573,40 @@ def get_context(context):
 						email_ids = email_ids_value.replace(",", "\n")
 						recipients = recipients + email_ids.split("\n")
 
-			cc.extend(get_emails_from_template(recipient.cc, context))
+			# BCC
 			bcc.extend(get_emails_from_template(recipient.bcc, context))
+
+			# CC by role
+			if recipient.cc_receiver_by_role:
+				cc_emails = get_emails_from_template(recipient.cc, context) or []
+				role_emails = get_info_based_on_role(
+					recipient.cc_receiver_by_role, "email", ignore_permissions=True
+				)
+				emails = role_emails + cc_emails
+				if recipient.check_user_permission:
+					cc.extend(self.filter_by_permission(emails, doc))
+				else:
+					cc.extend(emails)
 
 			# For sending emails to specified role
 			if recipient.receiver_by_role:
 				emails = get_info_based_on_role(recipient.receiver_by_role, "email", ignore_permissions=True)
-
-				for email in emails:
-					recipients = recipients + email.split("\n")
+				if recipient.check_user_permission:
+					recipients.extend(self.filter_by_permission(emails, doc))
+				else:
+					recipients.extend(emails)
 
 		if self.send_to_all_assignees:
 			recipients = recipients + get_assignees(doc)
 
 		return list(set(recipients)), list(set(cc)), list(set(bcc))
+
+	def filter_by_permission(self, emails, doc):
+		allowed = []
+		for email in emails:
+			if has_permission(doc.doctype, ptype="read", doc=doc, user=email):
+				allowed.append(email)
+		return allowed
 
 	def get_receiver_list(self, doc, context, field_on_user="mobile_no", recipient_extractor_func=None):
 		"""return receiver list based on the doc field and role specified"""

--- a/frappe/email/doctype/notification_recipient/notification_recipient.json
+++ b/frappe/email/doctype/notification_recipient/notification_recipient.json
@@ -5,8 +5,10 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "check_user_permission",
   "receiver_by_document_field",
   "receiver_by_role",
+  "cc_receiver_by_role",
   "cc",
   "bcc",
   "condition"
@@ -44,18 +46,33 @@
    "in_list_view": 1,
    "label": "Receiver By Role",
    "options": "Role"
+  },
+  {
+   "default": "0",
+   "fieldname": "check_user_permission",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Check User Permission"
+  },
+  {
+   "fieldname": "cc_receiver_by_role",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "CC Receiver By Role",
+   "options": "Role"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-23 16:03:31.847915",
+ "modified": "2025-08-23 21:59:55.039448",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification Recipient",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/frappe/email/doctype/notification_recipient/notification_recipient.py
+++ b/frappe/email/doctype/notification_recipient/notification_recipient.py
@@ -15,6 +15,8 @@ class NotificationRecipient(Document):
 
 		bcc: DF.Code | None
 		cc: DF.Code | None
+		cc_receiver_by_role: DF.Link | None
+		check_user_permission: DF.Check
 		condition: DF.Data | None
 		parent: DF.Data
 		parentfield: DF.Data


### PR DESCRIPTION
## Summary

This PR enhances the **Notification** doctype by introducing additional flexibility in recipient handling.  
It adds support for:
- Checking user permissions before including recipients/CCs.  
- Allowing CC recipients to be selected by role.  

---

## Changes Introduced

### 1. Code Updates
- **Modified:** `get_list_of_recipients` in `notification.py`
  - Added logic to filter recipients and CCs based on user permissions (via `check_user_permission`).
  - Introduced support for `cc_receiver_by_role` to send CC emails to all users with a specific role.
  - Refactored handling of CC and BCC to make role-based and template-based CCs possible.
- **Added:** `filter_by_permission` helper method to ensure only users with **read access** to the document are included as recipients.

### 2. Schema Updates
- **Notification Recipient (Child Table)**  
  Added two new fields:
  ```json
  {
    "default": "0",
    "fieldname": "check_user_permission",
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Check User Permission"
  },
  {
    "fieldname": "cc_receiver_by_role",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "CC Receiver By Role",
    "options": "Role"
  }
## Before vs After

### 3. Before
- Could not restrict recipients/CCs based on **document-level permissions**.  
- No option to add **CC recipients by role**.  
- `cc` was only handled via static template values.  

### After
- Recipients/CCs can now be conditionally included only if they have **read permission** on the document.  
- CCs can be automatically pulled from a specified **Role** (`cc_receiver_by_role`).  

---

## Screenshots 
<img width="1853" height="240" alt="image" src="https://github.com/user-attachments/assets/b4769573-fc5f-45a9-b7a2-12633484bbc7" />

<img width="1862" height="244" alt="image" src="https://github.com/user-attachments/assets/689f6704-26c9-4f2c-9cd4-8fda20a2f397" />


### Notification Recipient Child Table (new fields):
- ✅ **Check User Permission** → ensures recipients/CCs must have access.  
- 📌 **CC Receiver By Role** → include all users of a specific role in CC.  
