### PR TITLE
fix: add use_csv_sniffer initialization for v16+ compatibility

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -262,10 +262,13 @@ def import_file(doctype, file_path, import_type, submit_after_import=False, cons
 	"""
 
 	data_import = frappe.new_doc("Data Import")
+	data_import.reference_doctype = doctype
+	data_import.import_file = file_path
 	data_import.submit_after_import = submit_after_import
 	data_import.import_type = (
 		"Insert New Records" if import_type.lower() == "insert" else "Update Existing Records"
 	)
+	data_import.set_payload_count()
 
 	i = Importer(doctype=doctype, file_path=file_path, data_import=data_import, console=console)
 	i.import_data()

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -268,6 +268,7 @@ def import_file(doctype, file_path, import_type, submit_after_import=False, cons
 	data_import.import_type = (
 		"Insert New Records" if import_type.lower() == "insert" else "Update Existing Records"
 	)
+	data_import.use_csv_sniffer = False  # Default to False for command line imports
 	data_import.set_payload_count()
 
 	i = Importer(doctype=doctype, file_path=file_path, data_import=data_import, console=console)


### PR DESCRIPTION
## Enhancement: Forward compatibility for v16+ csv_sniffer field

### Context
This PR builds on the core `payload_count` fix to ensure complete compatibility with Frappe v16+ installations where the `use_csv_sniffer` field was introduced (January 2025).

### Problem
Without this enhancement, the core fix may encounter AttributeError on v16+ installations due to the missing `use_csv_sniffer` field initialization.

### Solution
- Adds `use_csv_sniffer=False` default for command-line imports
- Maintains backward compatibility with v15 and earlier
- Provides sensible defaults for the new field

### Dependencies
- **Requires**: Core payload_count fix (PR #1)
- **Target**: v16+ installations only
- **Compatibility**: Safe fallback for older versions

This enhancement ensures the data import fix works seamlessly across all Frappe versions, including the latest v16+ releases with csv_sniffer functionality.