### PR TITLE
fix: sort file/dir names for fixtures

### DIFF
--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -30,7 +30,7 @@ def import_fixtures(app):
 	if not os.path.exists(fixtures_path):
 		return
 
-	fixture_files = os.listdir(fixtures_path)
+	fixture_files = sorted(os.listdir(fixtures_path))
 
 	for fname in fixture_files:
 		if not fname.endswith(".json"):


### PR DESCRIPTION
It turns out that the fixture sorting just works for nested directories and not files directly under the fixtures folder. This PR should fix that.

Ticket: https://support.frappe.io/helpdesk/tickets/47114?view=VIEW-HD+Ticket-610