### PR TITLE
Fix PostgreSQL compatibility in remove_implicit_primary_key patch

### DIFF
--- a/frappe/patches/v15_0/remove_implicit_primary_key.py
+++ b/frappe/patches/v15_0/remove_implicit_primary_key.py
@@ -31,12 +31,12 @@ def execute():
 			and _is_implicit_int_pk(doctype)
 			and not is_autoincremented(doctype)
 		):
-			frappe.db.change_column_type(
-				doctype,
-				"name",
-				type=f"varchar({frappe.db.VARCHAR_LEN})",
-				nullable=True,
-			)
+			if frappe.db.db_type == "mariadb":
+				frappe.db.sql(f"ALTER TABLE `tab{doctype}` MODIFY name varchar({frappe.db.VARCHAR_LEN})")
+			else:
+				frappe.db.sql(
+					f"ALTER TABLE `tab{doctype}` ALTER COLUMN name TYPE varchar({frappe.db.VARCHAR_LEN}) USING name::varchar"
+				)
 
 
 def _is_implicit_int_pk(doctype: str) -> bool:


### PR DESCRIPTION
# Fix PostgreSQL Compatibility in `remove_implicit_primary_key` Patch

## Problem

The `remove_implicit_primary_key` patch was failing on PostgreSQL with the error:

> psycopg2.errors.InvalidTableDefinition: column "name" is in a primary key


This occurred because PostgreSQL refused to alter the `name` column when using the generic `frappe.db.change_column_type()` method, as it couldn't handle the primary key constraint properly.

## Root Cause

- PostgreSQL requires an explicit `USING` clause when converting between data types, especially for primary key columns.
- The generic `change_column_type()` method doesn't provide database-specific handling for constraint-aware type conversions.
- Different SQL syntax requirements between MariaDB and PostgreSQL for column type modifications.

## Solution

- Replaced generic `change_column_type()` calls with direct SQL statements.
- Added database-specific handling for MariaDB and PostgreSQL.
- Implemented proper `USING` clause for PostgreSQL type conversion.

## Changes Made

```python
# Before (PostgreSQL failing):
frappe.db.change_column_type(doctype, "name", type=f"varchar({frappe.db.VARCHAR_LEN})", nullable=True)

# After (PostgreSQL working):
if frappe.db.db_type == "mariadb":
    frappe.db.sql(f"ALTER TABLE `tab{doctype}` MODIFY name varchar({frappe.db.VARCHAR_LEN})")
else:
    frappe.db.sql(f"ALTER TABLE `tab{doctype}` ALTER COLUMN name TYPE varchar({frappe.db.VARCHAR_LEN}) USING name::varchar")
```

## Testing

- ✅ Verified patch works on PostgreSQL (previously failing)
- ✅ Tested with affected doctypes: `Version`, `Error Log`, `Scheduled Job Log`, etc.

## Affected Doctypes

This patch targets system tables with implicit integer primary keys:

- `Version`, `Error Log`, `Scheduled Job Log`  
- `Event Sync/Update Logs`, `Access/View/Activity Logs`  
- `Energy Point Log`, `Notification Log`, `Email Queue`  
- `DocShare`, `Document Follow`, `Console Log`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)  
- [x] Database migration patch improvement  
- [x] PostgreSQL compatibility enhancement  

## Breaking Changes

**None** — this is a backward-compatible fix that maintains existing functionality while adding PostgreSQL support.

---

### backport version-15-hotfix

## Closes: [#24004](https://github.com/frappe/frappe/issues/24004)