### PR TITLE
feat: enable non negative validation for Percent type fields

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -499,7 +499,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\"], doc.fieldtype)",
+   "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
    "fieldname": "non_negative",
    "fieldtype": "Check",
    "label": "Non Negative"
@@ -609,17 +609,19 @@
    "label": "Sticky"
   }
  ],
+ "grid_page_length": 50,
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-30 14:58:19.746600",
+ "modified": "2025-08-26 22:08:20.940308",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",
  "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "ASC",
  "states": []

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -787,7 +787,7 @@ class Document(BaseDocument):
 				)
 
 		for df in self.meta.get(
-			"fields", {"non_negative": ("=", 1), "fieldtype": ("in", ["Int", "Float", "Currency"])}
+			"fields", {"non_negative": ("=", 1), "fieldtype": ("in", ["Int", "Float", "Currency", "Percent"])}
 		):
 			if flt(self.get(df.fieldname)) < 0:
 				msg = get_msg(df)


### PR DESCRIPTION
fixes #33758 

Tested by setting negative value to Process Loss Percentage field of the BOM DocType in ERPNext
<img width="895" height="586" alt="image" src="https://github.com/user-attachments/assets/6b5ac33a-a5c3-463e-8f23-4c89ed989a36" />

`no-docs`