### PR TITLE
feat: format IBANs in Data field

### DIFF
--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -77,7 +77,7 @@ display_fieldtypes = (
 
 numeric_fieldtypes = ("Currency", "Int", "Long Int", "Float", "Percent", "Check")
 
-data_field_options = ("Email", "Name", "Phone", "URL", "Barcode")
+data_field_options = ("Email", "Name", "Phone", "URL", "Barcode", "IBAN")
 
 default_fields = (
 	"doctype",

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -73,6 +73,9 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		if (this.df.options == "Barcode") {
 			this.setup_barcode_field();
 		}
+		if (this.df.options == "IBAN") {
+			this.setup_iban_field();
+		}
 	}
 
 	setup_url_field() {
@@ -115,6 +118,12 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 			setTimeout(() => {
 				this.$link.toggle(false);
 			}, 500);
+		});
+	}
+
+	setup_iban_field() {
+		this.$input.on("blur", () => {
+			this.set_formatted_input(this.get_input_value());
 		});
 	}
 
@@ -257,7 +266,16 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		return this.$input ? this.$input.val() : undefined;
 	}
 	format_for_input(val) {
+		if (this.df.options == "IBAN" && val) {
+			return val.replaceAll(" ", "").replace(/(.{4})(?=.)/g, "$1 ");
+		}
 		return val == null ? "" : val;
+	}
+	parse(value) {
+		if (this.df.options == "IBAN" && value) {
+			return value.replaceAll(" ", "");
+		}
+		return value;
 	}
 	validate(v) {
 		if (!v) {


### PR DESCRIPTION
IBANs are long strings of characters like "DE02120300000000202051". For better readability, they are usually rendered in blocks of four, e.g. "DE02 1203 0000 0000 2020 51". However, the value for processing, e.g. in a Bank Transaction, needs to be without spaces.

With this PR, we allow to specify the option "IBAN" on any "Data" field, to enable said formatting and parsing in the frontend. The particular doctype should still enforce the no-spaces in the backend.

The behavior is as follows:

- The user can enter any value, with or without spaces at arbitrary positions
- We always store the value without spaces
- We always display the value in blocks of four

https://github.com/user-attachments/assets/0bd28daa-8637-490d-9e95-c4d22bd5273a

Use cases are in ERPNext's **Bank Account**, **Bank Guarantee**, **Payment Request**, **Bank Transaction** and **Employee** DocTypes.

Resolves https://github.com/frappe/erpnext/issues/35721

Docs: https://docs.frappe.io/framework/user/en/basics/doctypes/fieldtypes