### PR TITLE
fix: remove trailing spaces in translatable strings

### DIFF
--- a/frappe/core/doctype/access_log/access_log.json
+++ b/frappe/core/doctype/access_log/access_log.json
@@ -37,7 +37,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "User ",
+   "label": "User",
    "options": "User",
    "read_only": 1
   },

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.json
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.json
@@ -55,7 +55,7 @@
   },
   {
    "collapsible": 1,
-   "description": "Change the starting / current sequence number of an existing series. <br>\n\nWarning: Incorrectly updating counters can prevent documents from getting created. ",
+   "description": "Change the starting / current sequence number of an existing series. <br>\n\nWarning: Incorrectly updating counters can prevent documents from getting created.",
    "fieldname": "update_series",
    "fieldtype": "Section Break",
    "label": "Update Series Counter"

--- a/frappe/core/doctype/rq_job/rq_job.js
+++ b/frappe/core/doctype/rq_job/rq_job.js
@@ -13,7 +13,7 @@ frappe.ui.form.on("RQ Job", {
 			frm.add_custom_button(__("Force Stop job"), () => {
 				frappe.confirm(
 					__(
-						"This will terminate the job immediately and might be dangerous, are you sure? "
+						"This will terminate the job immediately and might be dangerous, are you sure?"
 					),
 					() => {
 						frappe

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -304,7 +304,7 @@
    "default": "10",
    "fieldname": "allow_consecutive_login_attempts",
    "fieldtype": "Int",
-   "label": "Allow Consecutive Login Attempts "
+   "label": "Allow Consecutive Login Attempts"
   },
   {
    "fieldname": "column_break_34",
@@ -706,7 +706,7 @@
   },
   {
    "default": "100000",
-   "description": "This value specifies the max number of rows that can be rendered in report view. ",
+   "description": "This value specifies the max number of rows that can be rendered in report view.",
    "fieldname": "max_report_rows",
    "fieldtype": "Int",
    "label": "Max Report Rows"

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -231,7 +231,7 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 			? frappe.last_response.setup_wizard_failure_message
 			: __("Failed to complete setup");
 
-		this.update_setup_message(__("Could not start up: ") + fail_msg);
+		this.update_setup_message(__("Could not start up:") + " " + fail_msg);
 
 		this.$working_state.find(".title").html(__("Setup failed"));
 

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -257,7 +257,7 @@
   {
    "default": "250",
    "depends_on": "use_imap",
-   "description": "Total number of emails to sync in initial sync process ",
+   "description": "Total number of emails to sync in initial sync process",
    "fieldname": "initial_sync_count",
    "fieldtype": "Select",
    "hide_days": 1,

--- a/frappe/email/doctype/email_template/email_template.json
+++ b/frappe/email/doctype/email_template/email_template.json
@@ -51,7 +51,7 @@
    "depends_on": "eval:doc.use_html",
    "fieldname": "response_html",
    "fieldtype": "Code",
-   "label": "Response ",
+   "label": "Response",
    "options": "Jinja"
   }
  ],

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.json
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -295,7 +295,7 @@
    "description": "Do not create new user if user with email does not exist in the system",
    "fieldname": "do_not_create_new_user",
    "fieldtype": "Check",
-   "label": "Do Not Create New User "
+   "label": "Do Not Create New User"
   }
  ],
  "in_create": 1,

--- a/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
+++ b/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
@@ -37,7 +37,7 @@
    "label": "API Secret"
   },
   {
-   "description": "Enabling this will register your site on a central relay server to send push notifications for all installed apps through Firebase Cloud Messaging. This server only stores user tokens and error logs, and no messages are saved. ",
+   "description": "Enabling this will register your site on a central relay server to send push notifications for all installed apps through Firebase Cloud Messaging. This server only stores user tokens and error logs, and no messages are saved.",
    "fieldname": "section_break_qgjr",
    "fieldtype": "Section Break",
    "label": "Relay Settings"

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1791,9 +1791,12 @@ class Document(BaseDocument):
 		if date_diff(to_date, from_date) < 0:
 			table_row = ""
 			if self.meta.istable:
-				table_row = _("{0} row #{1}: ").format(
-					_(frappe.unscrub(self.parentfield)),
-					self.idx,
+				table_row = (
+					_("{0} row #{1}:").format(
+						_(frappe.unscrub(self.parentfield)),
+						self.idx,
+					)
+					+ " "
 				)
 
 			frappe.throw(

--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -216,7 +216,7 @@ frappe.ui.form.qz_fail = function (e) {
 	// notify qz errors
 	frappe.show_alert(
 		{
-			message: __("QZ Tray Failed: ") + e.toString(),
+			message: __("QZ Tray Failed:") + " " + e.toString(),
 			indicator: "red",
 		},
 		20

--- a/frappe/public/js/frappe/widgets/links_widget.js
+++ b/frappe/public/js/frappe/widgets/links_widget.js
@@ -65,7 +65,7 @@ export default class LinksWidget extends Widget {
 						<div class="arrow"></div>
 						<h3 class="popover-title" style="display: none;"></h3>
 						<div class="popover-content" style="padding: 12px;">
-							<div class="small text-muted">${__("You need to create these first: ")}</div>
+							<div class="small text-muted">${__("You need to create these first:") + " "}</div>
 							<div class="small">${item.incomplete_dependencies.join(", ")}</div>
 						</div>
 					</div>`;

--- a/frappe/templates/emails/download_data.html
+++ b/frappe/templates/emails/download_data.html
@@ -6,5 +6,5 @@
     <a href="{{ link }}" rel="nofollow" class="btn btn-primary btn-sm primary-action" style="padding: 8px 20px;">{{ _("Download Data") }}</a>
 </p>
 <p style="font-size: 85%;">
-    {{_("You can also copy-paste this ")}} <a href="{{ link }}">{{_("Download Link")}}</a>{{_(" to your browser")}}
+    {{_("You can also copy-paste this")}} <a href="{{ link }}">{{_("Download Link")}}</a> {{_("to your browser")}}
 </p>

--- a/frappe/templates/emails/new_message.html
+++ b/frappe/templates/emails/new_message.html
@@ -1,4 +1,4 @@
-<p>{{ _("You have a new message from: ") }}<b>{{ from }}</b></p>
+<p>{{ _("You have a new message from:") }} <b>{{ from }}</b></p>
 <p>{{ message }}</p>
 <div class="more-info">
 	<a href="{{ link }}">{{ _("Login and view in Browser") }}</a>

--- a/frappe/templates/includes/comments/comments.html
+++ b/frappe/templates/includes/comments/comments.html
@@ -1,7 +1,7 @@
 <div class="comment-view mb-6">
 	{% if not comment_list %}
 		<div class="no-comment">
-			<p class="text-muted small">{{ _("No comments yet. ") }}
+			<p class="text-muted small">{{ _("No comments yet.") }}
 				<span class="hidden login-required">
 					<a href="/login?redirect-to={{ pathname }}">{{ _("Login to start a new discussion") }}</a>
 				</span>

--- a/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
+++ b/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
@@ -40,7 +40,7 @@
   {
    "fieldname": "deletion_steps",
    "fieldtype": "Table",
-   "label": "Deletion Steps ",
+   "label": "Deletion Steps",
    "options": "Personal Data Deletion Step"
   }
  ],

--- a/frappe/www/qrcode.html
+++ b/frappe/www/qrcode.html
@@ -16,7 +16,7 @@
 			</ol>
 		</p>
 		<br>
-		<p class='text-muted small'>{{ _("Authentication Apps you can use are: ") }}
+		<p class='text-muted small'>{{ _("Authentication Apps you can use are:") }}
 			FreeOTP, Google Authenticator, Lastpass Authenticator, Authy and Duo Mobile.
 		</p>
 	</div>


### PR DESCRIPTION
This change removes leading and trailing whitespace from translatable strings across various file types (.py, .js, .json, .html).

Fixes #32466