### PR TITLE
fix: if getpage sends 404 remove it from awesombar results

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -5,7 +5,7 @@ frappe.search.utils = {
 	setup_recent: function () {
 		this.recent = JSON.parse(frappe.boot.user.recent || "[]") || [];
 	},
-
+	results_to_hide: [],
 	get_recent_pages: function (keywords) {
 		if (keywords === null) keywords = "";
 		var me = this,
@@ -105,10 +105,19 @@ frappe.search.utils = {
 			out.index = 80;
 			return out;
 		});
-
+		this.hide_results(options);
 		return options;
 	},
-
+	hide_results(options) {
+		if (this.results_to_hide.length == 0) return;
+		this.results_to_hide.forEach((v, i) => {
+			options.forEach((o, j) => {
+				if (o.value == v) {
+					options.splice(j, 1);
+				}
+			});
+		});
+	},
 	get_frequent_links() {
 		let options = [];
 		frappe.boot.frequently_visited_links.forEach((link) => {

--- a/frappe/public/js/frappe/views/pageview.js
+++ b/frappe/public/js/frappe/views/pageview.js
@@ -39,6 +39,9 @@ frappe.views.pageview = {
 					}
 					callback();
 				},
+				error: function () {
+					frappe.search.utils.results_to_hide.push(name);
+				},
 				freeze: true,
 			});
 		}


### PR DESCRIPTION
Remove the wrong result from awesomebar 
Closes https://github.com/frappe/frappe/issues/33810 

Video 

https://github.com/user-attachments/assets/eae71b3c-41e9-4975-bd5e-d01696c4d7f8

