### PR TITLE
fix: apply all filters from a number card correctly

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2338,7 +2338,12 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			let doctype = null;
 
 			let value_array;
-			if ($.isArray(value) && value[0].startsWith("[") && value[0].endsWith("]")) {
+			if (
+				Array.isArray(value) &&
+				!Array.isArray(value[0]) &&
+				value[0].startsWith("[") &&
+				value[0].endsWith("]")
+			) {
 				value_array = [];
 				for (var i = 0; i < value.length; i++) {
 					value_array.push(JSON.parse(value[i]));
@@ -2365,13 +2370,17 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			if (doctype) {
 				if (value_array) {
 					for (var j = 0; j < value_array.length; j++) {
-						if ($.isArray(value_array[j])) {
+						if (Array.isArray(value_array[j])) {
 							filters.push([doctype, field, value_array[j][0], value_array[j][1]]);
 						} else {
 							filters.push([doctype, field, "=", value_array[j]]);
 						}
 					}
-				} else if ($.isArray(value)) {
+				} else if (Array.isArray(value) && Array.isArray(value[0])) {
+					value.forEach((val) => {
+						filters.push([doctype, field, val[0], val[1]]);
+					});
+				} else if (Array.isArray(value)) {
 					filters.push([doctype, field, value[0], value[1]]);
 				} else {
 					filters.push([doctype, field, "=", value]);

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -85,9 +85,18 @@ export default class NumberCardWidget extends Widget {
 		const filters = this.get_filters();
 		if (is_document_type) {
 			frappe.route_options = filters.reduce((acc, filter) => {
-				return Object.assign(acc, {
-					[`${filter[0]}.${filter[1]}`]: [filter[2], filter[3]],
-				});
+				const field = filter[1];
+				const value = [filter[2], filter[3]];
+
+				// if we have multiple filters for the same field,
+				// we convert it into an array
+				if (acc[field]) {
+					acc[field].push(value);
+				} else {
+					acc[field] = [value];
+				}
+
+				return acc;
 			}, {});
 		} else {
 			if (filters && Object.keys(filters).length) {


### PR DESCRIPTION
**Existing problem:** This change fixes a bug where number cards with multiple filters on the same field would only have the last filter applied when navigating to list view.

The solution is a two-part fix:
1. In `number_card_widget.js`, the logic for the filter is updated to group multiple conditions for the same field into a nested array.
2. In `list_view.js`, the `parse_filters_from_route_options` function is updated to parse this.

**Example:**
We have a number card 'Open Opps By Probability' with 2 filters on same field down below.

<img width="1920" height="928" alt="Number card 'Open Opps By Probability' with 2 filters on same field" src="https://github.com/user-attachments/assets/4fdd049c-8eb8-4a47-8918-c330c4379883" />

Before, clicking the number card only applies the last filter.

![before](https://github.com/user-attachments/assets/cdf4f70e-ed12-4ebb-8a40-fe69b10d8133)

After the changes, both filters are applied.

![after](https://github.com/user-attachments/assets/29375958-5fec-4dcb-83c8-30f094920705)

> **Tests**: I have manually tested this fix and confirmed that it works as expected (as shown in the GIF). I have found the official guides for automated testing and I am keen to learn how to write a proper UI test for this. As I am still new to the Frappe testing framework, I have submitted this PR without an automated test for now to get the code fix into the review queue. I would be very grateful if a maintainer could confirm if a UI test is required for this change and perhaps point me to a similar existing test I could use as a reference.

Fixes #33415