### PR TITLE
fix: don't show filters and columns for Report Builder reports

### DIFF
--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -162,7 +162,7 @@
    "label": "Filters"
   },
   {
-   "depends_on": "eval:doc.report_type != \"Custom Report\"",
+   "depends_on": "eval:![\"Custom Report\", \"Report Builder\"].includes(doc.report_type)",
    "fieldname": "filters",
    "fieldtype": "Table",
    "label": "Filters",
@@ -177,7 +177,7 @@
    "label": "Columns"
   },
   {
-   "depends_on": "eval:doc.report_type != \"Custom Report\"",
+   "depends_on": "eval:![\"Custom Report\", \"Report Builder\"].includes(doc.report_type)",
    "fieldname": "columns",
    "fieldtype": "Table",
    "label": "Columns",
@@ -207,7 +207,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-12 17:08:09.629411",
+ "modified": "2025-08-28 18:28:32.510719",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Report",


### PR DESCRIPTION
Fixes #33824

Everything is read from JSON:

<img width="1946" height="852" alt="CleanShot 2025-08-28 at 18 33 04@2x" src="https://github.com/user-attachments/assets/ce7fe91d-b3c8-40f6-9ac9-e7ea7a07a334" />
