### PR TITLE
fix(minor): show border on focus when navigating via keyboard

### DIFF
--- a/frappe/public/scss/common/buttons.scss
+++ b/frappe/public/scss/common/buttons.scss
@@ -82,7 +82,7 @@
 		background-color: var(--btn-default-hover-bg);
 		color: var(--text-color);
 	}
-	&:focus {
+	&:focus-visible {
 		box-shadow: var(--focus-default) !important;
 	}
 }

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -136,7 +136,7 @@
 	.row-index {
 		left: 31px;
 	}
-	button.col:focus {
+	button.col:focus-visible {
 		outline: 1px solid #c9c9c9;
 	}
 }

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -50,11 +50,11 @@
 			margin-left: 10px;
 			position: relative;
 			padding: 0px;
-			&:focus {
+			&:focus-visible {
 				outline: 1px solid #c9c9c9;
 			}
 		}
-		&:focus {
+		&:focus-visible {
 			outline: 1px solid #c9c9c9;
 		}
 	}
@@ -514,7 +514,7 @@
 					color: var(--text-color);
 					padding-bottom: 9px;
 				}
-				&:focus {
+				&:focus-visible {
 					outline: none;
 					font-weight: 600;
 				}


### PR DESCRIPTION
Related to https://github.com/frappe/frappe/pull/33609

Show the border only when navigating via keyboard, not when using the mouse.