### PR TITLE
feat(site): show warning when developer mode is enabled

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -181,6 +181,16 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force: bool =
 	local.task_id = None
 
 	local.conf = get_site_config(sites_path=sites_path, site_path=site_path, cached=bool(frappe.request))
+	# for editable mode check
+	try:
+		from frappe.utils.bench_helper import check_non_editable_apps
+
+		if getattr(conf, "developer_mode", False):
+			check_non_editable_apps()
+
+	except Exception:
+		pass
+
 	local.lang = local.conf.lang or "en"
 
 	local.module_app = None

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -188,16 +188,6 @@ def init_request(request):
 		else:
 			raise frappe.SessionStopped("Session Stopped")
 
-	# for editable mode check
-	try:
-		from frappe.utils.bench_helper import check_non_editable_apps
-
-		if frappe.conf.get("developer_mode"):
-			check_non_editable_apps()
-
-	except Exception:
-		pass
-
 	if request.path.startswith("/api/method/upload_file"):
 		from frappe.core.api.file import get_max_file_size
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -188,6 +188,16 @@ def init_request(request):
 		else:
 			raise frappe.SessionStopped("Session Stopped")
 
+	# for editable mode check
+	try:
+		from frappe.utils.bench_helper import check_non_editable_apps
+
+		if frappe.conf.get("developer_mode"):
+			check_non_editable_apps()
+
+	except Exception:
+		pass
+
 	if request.path.startswith("/api/method/upload_file"):
 		from frappe.core.api.file import get_max_file_size
 

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -170,6 +170,32 @@ def get_apps():
 	return frappe.get_all_apps(with_internal_apps=False, sites_path=".")
 
 
+def check_non_editable_apps():
+	"""
+	Checks installed apps are editable or not
+	"""
+	if not frappe.conf.get("developer_mode"):
+		return
+
+	installed_apps = frappe.get_all_apps()
+	for app in installed_apps:
+		try:
+			spec = importlib.util.find_spec(app)
+			if spec and spec.origin:
+				if "site-packages" in spec.origin or ".egg" in spec.origin:
+					click.secho(
+						f"⚠️ Warning: App '{app}' is installed in non-editable mode (found in .egg)",
+						fg="yellow",
+						color=True,
+					)
+					click.secho(
+						f"Development should use: pip install -e ./apps/{app}", fg="yellow", color=True
+					)
+
+		except Exception:
+			continue
+
+
 if __name__ == "__main__":
 	if not frappe._dev_server:
 		warnings.simplefilter("ignore")


### PR DESCRIPTION
This PR adds a warning message during bench startup if non-editable apps are detected.
It helps developers quickly identify apps that are not editable, preventing confusion during development.

**Changes Introduced**

- Added a check for non-editable apps on bench startup.
- Displayed a clear warning message when such apps are found.
![warning-ss](https://github.com/user-attachments/assets/4f5bea22-48f9-4b09-a588-3b307b166e7e)

Please refer to issue #33385 

Docs: No-Docs