### PR TITLE
build(deps): bump weasyprint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "PyYAML~=6.0.2",
     "RestrictedPython~=8.0",
     "AccessControl~=7.2",
-    "WeasyPrint==59.0",
+    "WeasyPrint==66.0",
     "pydyf==0.11.0",
     "Werkzeug==3.1.3",
     "Whoosh~=2.7.4",


### PR DESCRIPTION
Fixes an error with pydyf

```
  File "env/lib/python3.11/site-packages/weasyprint/document.py", line 399, in write_pdf
    pdf = generate_pdf(self, target, zoom, **options)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/weasyprint/pdf/__init__.py", line 120, in generate_pdf
    pdf = pydyf.PDF((version or '1.7'), identifier)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: PDF.__init__() takes 1 positional argument but 3 were given
```
