### PR TITLE
fix: Permission and session errors while using office 365 social login

### DIFF
--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -161,7 +161,7 @@ def get_info_via_oauth(provider: str, code: str, decoder: Callable | None = None
 
 	if not (info.get("email_verified") or info.get("email")):
 		frappe.throw(_("Email not verified with {0}").format(provider.title()))
-	
+
 	info["email"] = info.get("email", "").lower()
 	info["upn"] = info.get("upn", "").lower()
 

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -161,6 +161,9 @@ def get_info_via_oauth(provider: str, code: str, decoder: Callable | None = None
 
 	if not (info.get("email_verified") or info.get("email")):
 		frappe.throw(_("Email not verified with {0}").format(provider.title()))
+	
+	info["email"] = info.get("email", "").lower()
+	info["upn"] = info.get("upn", "").lower()
 
 	return info
 


### PR DESCRIPTION
### Fix

1. **Issue:** Getting permissions issue while using Office 365 login method  
2. **Resolution:** System did not lower the important data getting from the Social Login Provider such as email, upn by which session data are not getting properly prepared after login  

**Session data before** = `{'data': {'user': 'Test.SSO@*******.com', 'session_ip': '127.0.0.1', 'last_updated': '2025-09-01 14:20:28.527069', 'session_expiry': '06:00:00', 'creation': '2025-09-01 14:20:28.527328', 'full_name': 'Guest', 'user_type': 'System User', 'device': 'desktop'}, 'user': 'Test.SSO@*******.com', 'sid': '******************************************'}`  

**Session data after** = `{'data': {'user': 'test.ssp@*******.com', 'session_ip': '127.0.0.1', 'last_updated': '2025-09-01 14:20:28.527069', 'session_expiry': '06:00:00', 'creation': '2025-09-01 14:20:28.527328', 'full_name': 'Guest', 'user_type': 'System User', 'device': 'desktop'}, 'user': 'test.sso@*******.com', 'sid': '******************************************'}`  

For the instance check the below issue  
<img width="1083" height="617" alt="image" src="https://github.com/user-attachments/assets/72d57bd1-7f33-45b6-9508-eed9b124d9a0" />
In the image user have the right to edit also action on draft state but still he does not able to do.  

<img width="1165" height="628" alt="image" src="https://github.com/user-attachments/assets/82bc61f6-8659-43fc-b148-12659544f010" />
After the fix employee can edit and send the doc to next state  


### Other ref
PR https://github.com/frappe/frappe/pull/33867