### PR TITLE
feat: formula support and fix for dynamic options in Bulk Update

### DIFF
--- a/frappe/desk/doctype/bulk_update/bulk_update.js
+++ b/frappe/desk/doctype/bulk_update/bulk_update.js
@@ -20,47 +20,34 @@ frappe.ui.form.on("Bulk Update", {
 			if (!frm.doc.update_value) {
 				frappe.throw(__('Field "value" is mandatory. Please specify value to be updated'));
 			} else {
-				frappe
-					.call({
-						method: "frappe.desk.doctype.bulk_update.bulk_update.validate_formula",
-						args: {
-							doctype: frm.doc.document_type,
-							field: frm.doc.field,
-							value: frm.doc.update_value,
-						},
-					})
-					.then(() => {
-						let confirmation_message = __(
-							"Are you sure you want to update <b>{0}</b> to <b>{1}</b> for all records. <br><br> Do you want to continue?",
-							[frm.doc.field, frm.doc.update_value]
-						);
-						frappe.confirm(
-							confirmation_message,
-							() => {
-								frm.call("bulk_update").then((r) => {
-									let failed = r.message || [];
+				let confirmation_message = __(
+					"Are you sure you want to update <b>{0}</b> to <b>{1}</b> for all records. <br><br> Do you want to continue?",
+					[frm.doc.field, frm.doc.update_value]
+				);
+				frappe.confirm(
+					confirmation_message,
+					() => {
+						frm.call("bulk_update").then((r) => {
+							let failed = r.message || [];
 
-									if (failed.length) {
-										frappe.throw(
-											__("Cannot update {0}", [
-												failed
-													.map((f) => (f.bold ? f.bold() : f))
-													.join(", "),
-											])
-										);
-									}
-									frappe.msgprint({
-										title: __("Success"),
-										message: __("Updated Successfully"),
-										indicator: "green",
-									});
-									frappe.hide_progress();
-									frm.save();
-								});
-							},
-							() => {}
-						);
-					});
+							if (failed.length) {
+								frappe.throw(
+									__("Cannot update {0}", [
+										failed.map((f) => (f.bold ? f.bold() : f)).join(", "),
+									])
+								);
+							}
+							frappe.msgprint({
+								title: __("Success"),
+								message: __("Updated Successfully"),
+								indicator: "green",
+							});
+							frappe.hide_progress();
+							frm.save();
+						});
+					},
+					() => {}
+				);
 			}
 		});
 	},

--- a/frappe/desk/doctype/bulk_update/bulk_update.js
+++ b/frappe/desk/doctype/bulk_update/bulk_update.js
@@ -12,6 +12,10 @@ frappe.ui.form.on("Bulk Update", {
 			};
 		});
 
+		if (frm.doc.document_type) {
+			frm.trigger("document_type");
+		}
+
 		frm.page.set_primary_action(__("Update"), function () {
 			if (!frm.doc.update_value) {
 				frappe.throw(__('Field "value" is mandatory. Please specify value to be updated'));

--- a/frappe/desk/doctype/bulk_update/bulk_update.js
+++ b/frappe/desk/doctype/bulk_update/bulk_update.js
@@ -20,27 +20,47 @@ frappe.ui.form.on("Bulk Update", {
 			if (!frm.doc.update_value) {
 				frappe.throw(__('Field "value" is mandatory. Please specify value to be updated'));
 			} else {
-				frm.call("bulk_update").then((r) => {
-					let failed = r.message;
-					if (!failed) failed = [];
-
-					if (failed.length && !r._server_messages) {
-						frappe.throw(
-							__("Cannot update {0}", [
-								failed.map((f) => (f.bold ? f.bold() : f)).join(", "),
-							])
+				frappe
+					.call({
+						method: "frappe.desk.doctype.bulk_update.bulk_update.validate_formula",
+						args: {
+							doctype: frm.doc.document_type,
+							field: frm.doc.field,
+							value: frm.doc.update_value,
+						},
+					})
+					.then(() => {
+						let confirmation_message = __(
+							"Are you sure you want to update <b>{0}</b> to <b>{1}</b> for all records. <br><br> Do you want to continue?",
+							[frm.doc.field, frm.doc.update_value]
 						);
-					} else {
-						frappe.msgprint({
-							title: __("Success"),
-							message: __("Updated Successfully"),
-							indicator: "green",
-						});
-					}
+						frappe.confirm(
+							confirmation_message,
+							() => {
+								frm.call("bulk_update").then((r) => {
+									let failed = r.message || [];
 
-					frappe.hide_progress();
-					frm.save();
-				});
+									if (failed.length) {
+										frappe.throw(
+											__("Cannot update {0}", [
+												failed
+													.map((f) => (f.bold ? f.bold() : f))
+													.join(", "),
+											])
+										);
+									}
+									frappe.msgprint({
+										title: __("Success"),
+										message: __("Updated Successfully"),
+										indicator: "green",
+									});
+									frappe.hide_progress();
+									frm.save();
+								});
+							},
+							() => {}
+						);
+					});
 			}
 		});
 	},

--- a/frappe/desk/doctype/bulk_update/bulk_update.py
+++ b/frappe/desk/doctype/bulk_update/bulk_update.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.core.doctype.submission_queue.submission_queue import queue_submission
 from frappe.model.document import Document
-from frappe.utils import cint
+from frappe.utils import cint,flt
 from frappe.utils.scheduler import is_scheduler_inactive
 
 
@@ -90,7 +90,9 @@ def _bulk_action(doctype, docnames, action, data, task_id=None):
 				doc.cancel()
 				message = _("Cancelling {0}").format(doctype)
 			elif action == "update" and not doc.docstatus.is_cancelled():
-				doc.update(data)
+				for field, val in data.items():
+					val = apply_formula(doc, field, val)
+					doc.set(field, val)
 				doc.save()
 				message = _("Updating {0}").format(doctype)
 			else:
@@ -111,3 +113,34 @@ def _bulk_action(doctype, docnames, action, data, task_id=None):
 
 
 from frappe.deprecation_dumpster import show_progress
+
+
+def apply_formula(doc, field, update_value):
+    if (
+        not update_value
+        or not isinstance(update_value, str)
+        or not update_value.startswith("=")
+    ):
+        return update_value
+
+    formula = update_value[1:]  # remove '='
+    current_val = flt(doc.get(field) or 0)
+
+    try:
+        if formula.startswith("+"):
+            return current_val + flt(formula[1:])
+        elif formula.startswith("-"):
+            return current_val - flt(formula[1:])
+        elif formula.startswith("*"):
+            return current_val * flt(formula[1:])
+        elif formula.startswith("/"):
+            operand = flt(formula[1:])
+            return current_val / operand if operand != 0 else current_val
+        elif formula.startswith("%"):
+            operand = flt(formula[1:])
+            return current_val % operand if operand != 0 else current_val
+
+        context = {"current": current_val}
+        return frappe.safe_eval(formula, context)
+    except Exception:
+        return update_value

--- a/frappe/desk/doctype/bulk_update/bulk_update.py
+++ b/frappe/desk/doctype/bulk_update/bulk_update.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
+import re
+
 import frappe
 from frappe import _
-import re
 from frappe.core.doctype.submission_queue.submission_queue import queue_submission
 from frappe.model.document import Document
-from frappe.utils import cint,flt
+from frappe.utils import cint, flt
 from frappe.utils.scheduler import is_scheduler_inactive
 
 
@@ -117,77 +118,75 @@ from frappe.deprecation_dumpster import show_progress
 
 
 def apply_formula(doc, field, update_value):
-    """Apply numeric or formula-based updates to a field value.
+	"""Apply numeric or formula-based updates to a field value.
 
-    Supports:
-    - Plain numbers (e.g. 123, 45.6)
-    - Short formulas (e.g. =+10, =*2, =/3)
-    - Expressions with 'current' (e.g. =(current+20))
-    """
+	Supports:
+	- Plain numbers (e.g. 123, 45.6)
+	- Short formulas (e.g. =+10, =*2, =/3)
+	- Expressions with 'current' (e.g. =(current+20))
+	"""
 
-    if not update_value:
-        return update_value
+	if not update_value:
+		return update_value
 
-    if not isinstance(update_value, str):
-        return update_value  # ignore non-string inputs
+	if not isinstance(update_value, str):
+		return update_value  # ignore non-string inputs
 
-    update_value = update_value.strip()
-    current_val = flt(doc.get(field) or 0)
+	update_value = update_value.strip()
+	current_val = flt(doc.get(field) or 0)
 
-    # Allow plain numbers
-    if re.fullmatch(r"-?\d+(\.\d+)?", update_value):
-        return flt(update_value)
+	# Allow plain numbers
+	if re.fullmatch(r"-?\d+(\.\d+)?", update_value):
+		return flt(update_value)
 
-    # Formulas must start with '='
-    if not update_value.startswith("="):
-        frappe.throw(
-            _(
-                "Invalid input. Please enter a number or a formula (e.g. 123, =+10, =*2, =(current+20))"
-            )
-        )
+	# Formulas must start with '='
+	if not update_value.startswith("="):
+		frappe.throw(
+			_("Invalid input. Please enter a number or a formula (e.g. 123, =+10, =*2, =(current+20))")
+		)
 
-    formula = update_value[1:].strip()
-    if not formula:
-        frappe.throw(_("Formula cannot be empty. Example: =+10, =*2, =(current+20)"))
+	formula = update_value[1:].strip()
+	if not formula:
+		frappe.throw(_("Formula cannot be empty. Example: =+10, =*2, =(current+20)"))
 
-    if formula[0] in ["+", "-", "*", "/", "%"]:
-        operand_str = formula[1:].strip()
-        if not re.fullmatch(r"-?\d+(\.\d+)?", operand_str):
-            frappe.throw(_("Invalid formula. Example: =+10, =*2, =(current+20)"))
+	if formula[0] in ["+", "-", "*", "/", "%"]:
+		operand_str = formula[1:].strip()
+		if not re.fullmatch(r"-?\d+(\.\d+)?", operand_str):
+			frappe.throw(_("Invalid formula. Example: =+10, =*2, =(current+20)"))
 
-        operand = flt(operand_str)
+		operand = flt(operand_str)
 
-        if formula[0] == "+":
-            return current_val + operand
-        if formula[0] == "-":
-            return current_val - operand
-        if formula[0] == "*":
-            return current_val * operand
-        if formula[0] == "/":
-            if operand == 0:
-                frappe.throw(_("Division by zero is not allowed"))
-            return current_val / operand
-        if formula[0] == "%":
-            if operand == 0:
-                frappe.throw(_("Modulo by zero is not allowed"))
-            return current_val % operand
+		if formula[0] == "+":
+			return current_val + operand
+		if formula[0] == "-":
+			return current_val - operand
+		if formula[0] == "*":
+			return current_val * operand
+		if formula[0] == "/":
+			if operand == 0:
+				frappe.throw(_("Division by zero is not allowed"))
+			return current_val / operand
+		if formula[0] == "%":
+			if operand == 0:
+				frappe.throw(_("Modulo by zero is not allowed"))
+			return current_val % operand
 
-    try:
-        return frappe.safe_eval(formula, {"current": current_val})
-    except Exception:
-        frappe.throw(_("Invalid formula. Example: =+10, =*2, =(current+20)"))
+	try:
+		return frappe.safe_eval(formula, {"current": current_val})
+	except Exception:
+		frappe.throw(_("Invalid formula. Example: =+10, =*2, =(current+20)"))
 
 
 @frappe.whitelist()
-def validate_formula(doctype, field, value):
-    """Validate a formula"""
-    if not value or not isinstance(value, str):
-        return True
+def validate_formula(doctype: str, field: str, value: str) -> bool:
+	"""Validate a formula"""
+	if not value or not isinstance(value, str):
+		return True
 
-    if value.strip() == "=":
-        frappe.throw(_("Formula cannot be empty. Example: =+10, =*2, =(current+20)"))
+	if value.strip() == "=":
+		frappe.throw(_("Formula cannot be empty. Example: =+10, =*2, =(current+20)"))
 
-    doc = frappe.new_doc(doctype)
-    apply_formula(doc, field, value)
+	doc = frappe.new_doc(doctype)
+	apply_formula(doc, field, value)
 
-    return True
+	return True

--- a/frappe/desk/doctype/bulk_update/bulk_update.py
+++ b/frappe/desk/doctype/bulk_update/bulk_update.py
@@ -119,14 +119,25 @@ def _bulk_action(doctype, docnames, action, data, task_id=None):
 
 from frappe.deprecation_dumpster import show_progress
 
+NUMERIC_PATTERN = re.compile(r"^-?\d+(\.\d+)?$")
 
-def apply_formula(doc, field, update_value):
-	"""Apply numeric or formula-based updates to a field value.
+
+def apply_formula(doc: Document | dict, field: str, update_value: str | int | float | None) -> float:
+	"""
+	Apply numeric or formula-based updates to a field value.
 
 	Supports:
-	- Plain numbers (e.g. 123, 45.6)
-	- Short formulas (e.g. =+10, =*2, =/3)
-	- Expressions with 'current' (e.g. =(current+20))
+	- Plain numbers: 123, 45.6
+	- Short formulas: =+10, =*2, =/3
+	- Expressions with 'current': =(current+20)
+
+	Args:
+		doc (Union[Document, dict]): Frappe document or dict containing the field.
+		field (str): Field name to update.
+		update_value (Union[str, int, float, None]): Number or formula as string.
+
+	Returns:
+		float: Updated value after applying the formula.
 	"""
 
 	if not update_value:
@@ -139,7 +150,7 @@ def apply_formula(doc, field, update_value):
 	current_val = flt(doc.get(field) or 0)
 
 	# Allow plain numbers
-	if re.fullmatch(r"-?\d+(\.\d+)?", update_value):
+	if NUMERIC_PATTERN.fullmatch(update_value):
 		return flt(update_value)
 
 	# Formulas must start with '='
@@ -154,7 +165,7 @@ def apply_formula(doc, field, update_value):
 
 	if formula[0] in ["+", "-", "*", "/", "%"]:
 		operand_str = formula[1:].strip()
-		if not re.fullmatch(r"-?\d+(\.\d+)?", operand_str):
+		if not NUMERIC_PATTERN.fullmatch(operand_str):
 			frappe.throw(_("Invalid formula. Example: =+10, =*2, =(current+20)"))
 
 		operand = flt(operand_str)

--- a/frappe/desk/doctype/bulk_update/bulk_update.py
+++ b/frappe/desk/doctype/bulk_update/bulk_update.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe import _
+import re
 from frappe.core.doctype.submission_queue.submission_queue import queue_submission
 from frappe.model.document import Document
 from frappe.utils import cint,flt
@@ -116,31 +117,77 @@ from frappe.deprecation_dumpster import show_progress
 
 
 def apply_formula(doc, field, update_value):
-    if (
-        not update_value
-        or not isinstance(update_value, str)
-        or not update_value.startswith("=")
-    ):
+    """Apply numeric or formula-based updates to a field value.
+
+    Supports:
+    - Plain numbers (e.g. 123, 45.6)
+    - Short formulas (e.g. =+10, =*2, =/3)
+    - Expressions with 'current' (e.g. =(current+20))
+    """
+
+    if not update_value:
         return update_value
 
-    formula = update_value[1:]  # remove '='
+    if not isinstance(update_value, str):
+        return update_value  # ignore non-string inputs
+
+    update_value = update_value.strip()
     current_val = flt(doc.get(field) or 0)
 
-    try:
-        if formula.startswith("+"):
-            return current_val + flt(formula[1:])
-        elif formula.startswith("-"):
-            return current_val - flt(formula[1:])
-        elif formula.startswith("*"):
-            return current_val * flt(formula[1:])
-        elif formula.startswith("/"):
-            operand = flt(formula[1:])
-            return current_val / operand if operand != 0 else current_val
-        elif formula.startswith("%"):
-            operand = flt(formula[1:])
-            return current_val % operand if operand != 0 else current_val
+    # Allow plain numbers
+    if re.fullmatch(r"-?\d+(\.\d+)?", update_value):
+        return flt(update_value)
 
-        context = {"current": current_val}
-        return frappe.safe_eval(formula, context)
+    # Formulas must start with '='
+    if not update_value.startswith("="):
+        frappe.throw(
+            _(
+                "Invalid input. Please enter a number or a formula (e.g. 123, =+10, =*2, =(current+20))"
+            )
+        )
+
+    formula = update_value[1:].strip()
+    if not formula:
+        frappe.throw(_("Formula cannot be empty. Example: =+10, =*2, =(current+20)"))
+
+    if formula[0] in ["+", "-", "*", "/", "%"]:
+        operand_str = formula[1:].strip()
+        if not re.fullmatch(r"-?\d+(\.\d+)?", operand_str):
+            frappe.throw(_("Invalid formula. Example: =+10, =*2, =(current+20)"))
+
+        operand = flt(operand_str)
+
+        if formula[0] == "+":
+            return current_val + operand
+        if formula[0] == "-":
+            return current_val - operand
+        if formula[0] == "*":
+            return current_val * operand
+        if formula[0] == "/":
+            if operand == 0:
+                frappe.throw(_("Division by zero is not allowed"))
+            return current_val / operand
+        if formula[0] == "%":
+            if operand == 0:
+                frappe.throw(_("Modulo by zero is not allowed"))
+            return current_val % operand
+
+    try:
+        return frappe.safe_eval(formula, {"current": current_val})
     except Exception:
-        return update_value
+        frappe.throw(_("Invalid formula. Example: =+10, =*2, =(current+20)"))
+
+
+@frappe.whitelist()
+def validate_formula(doctype, field, value):
+    """Validate a formula"""
+    if not value or not isinstance(value, str):
+        return True
+
+    if value.strip() == "=":
+        frappe.throw(_("Formula cannot be empty. Example: =+10, =*2, =(current+20)"))
+
+    doc = frappe.new_doc(doctype)
+    apply_formula(doc, field, value)
+
+    return True

--- a/frappe/desk/doctype/bulk_update/bulk_update.py
+++ b/frappe/desk/doctype/bulk_update/bulk_update.py
@@ -27,6 +27,9 @@ class BulkUpdate(Document):
 		update_value: DF.SmallText
 	# end: auto-generated types
 
+	def validate(self):
+		validate_formula(self.doctype, self.field, self.update_value)
+
 	@frappe.whitelist()
 	def bulk_update(self):
 		self.check_permission("write")

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -314,6 +314,7 @@ export default class BulkOperations {
 			);
 		});
 		const status_regex = /status/i;
+		const numeric_fieldtypes = ["Int", "Float", "Currency", "Percent"];
 
 		const default_field = field_options.find((value) => status_regex.test(value));
 
@@ -398,6 +399,10 @@ export default class BulkOperations {
 			new_df.label = __("Value");
 			new_df.onchange = show_help_text;
 
+			if (numeric_fieldtypes.includes(new_df.fieldtype)) {
+				new_df.fieldtype = "Data";
+			}
+
 			delete new_df.depends_on;
 			dialogObj.replace_field("value", new_df);
 			show_help_text();
@@ -405,12 +410,24 @@ export default class BulkOperations {
 
 		function show_help_text() {
 			let value = dialog.get_value("value");
+			let fieldname = dialog.get_value("field");
+			let fieldtype = field_mappings[fieldname]?.fieldtype;
+
 			if (value == null || value === "") {
-				dialog.set_df_property(
-					"value",
-					"description",
-					__("You have not entered a value. The field will be set to empty.")
-				);
+				if (numeric_fieldtypes.includes(fieldtype)) {
+					dialog.set_df_property(
+						"value",
+						"description",
+						__("Enter a number or formula (e.g. =*2, +10, /3)")
+					);
+				}
+				else{
+					dialog.set_df_property(
+						"value",
+						"description",
+						__("You have not entered a value. The field will be set to empty.")
+					);
+				}
 			} else {
 				dialog.set_df_property("value", "description", "");
 			}

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -342,36 +342,59 @@ export default class BulkOperations {
 				},
 			],
 			primary_action: ({ value }) => {
-				const fieldname = field_mappings[dialog.get_value("field")].fieldname;
-				dialog.disable_primary_action();
-				frappe
-					.call({
-						method: "frappe.desk.doctype.bulk_update.bulk_update.submit_cancel_or_update_docs",
-						args: {
-							doctype: this.doctype,
-							freeze: true,
-							docnames: docnames,
-							action: "update",
-							data: {
-								[fieldname]: value || null,
-							},
-						},
-					})
-					.then((r) => {
-						let failed = r.message || [];
+				const field_label = dialog.get_value("field");
+				const fieldname = field_mappings[field_label].fieldname;
 
-						if (failed.length && !r._server_messages) {
-							dialog.enable_primary_action();
-							frappe.throw(
-								__("Cannot update {0}", [
-									failed.map((f) => (f.bold ? f.bold() : f)).join(", "),
-								])
-							);
+				dialog.hide();
+				frappe.call({
+					method: "frappe.desk.doctype.bulk_update.bulk_update.validate_formula",
+					args: {
+						doctype: this.doctype,
+						field: fieldname,
+						value: value,
+					},
+				}).then(() => {
+					let confirmation_message = __(
+						"Are you sure you want to update <b>{0}</b> to <b>{1}</b> for <b>{2}</b> record(s). Do you want to continue?",
+						[field_label, value, docnames.length]
+					);
+					frappe.confirm(
+						confirmation_message,
+						() => {
+							dialog.disable_primary_action();
+							frappe
+								.call({
+									method: "frappe.desk.doctype.bulk_update.bulk_update.submit_cancel_or_update_docs",
+									args: {
+										doctype: this.doctype,
+										freeze: true,
+										docnames: docnames,
+										action: "update",
+										data: {
+											[fieldname]: value,
+										},
+									},
+								})
+								.then((r) => {
+									let failed = r.message || [];
+									if (failed.length && !r._server_messages) {
+										dialog.enable_primary_action();
+										frappe.throw(
+											__("Cannot update {0}", [
+												failed.map((f) => (f.bold ? f.bold() : f)).join(", "),
+											])
+										);
+									}
+									done();
+									dialog.hide();
+									frappe.show_alert(__("Updated successfully"));
+								});
+						},
+						() => {
+							dialog.show();
 						}
-						done();
-						dialog.hide();
-						frappe.show_alert(__("Updated successfully"));
-					});
+					);
+				});
 			},
 			primary_action_label: __("Update {0} records", [docnames.length]),
 		});

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -346,55 +346,59 @@ export default class BulkOperations {
 				const fieldname = field_mappings[field_label].fieldname;
 
 				dialog.hide();
-				frappe.call({
-					method: "frappe.desk.doctype.bulk_update.bulk_update.validate_formula",
-					args: {
-						doctype: this.doctype,
-						field: fieldname,
-						value: value,
-					},
-				}).then(() => {
-					let confirmation_message = __(
-						"Are you sure you want to update <b>{0}</b> to <b>{1}</b> for <b>{2}</b> record(s). Do you want to continue?",
-						[field_label, value, docnames.length]
-					);
-					frappe.confirm(
-						confirmation_message,
-						() => {
-							dialog.disable_primary_action();
-							frappe
-								.call({
-									method: "frappe.desk.doctype.bulk_update.bulk_update.submit_cancel_or_update_docs",
-									args: {
-										doctype: this.doctype,
-										freeze: true,
-										docnames: docnames,
-										action: "update",
-										data: {
-											[fieldname]: value,
-										},
-									},
-								})
-								.then((r) => {
-									let failed = r.message || [];
-									if (failed.length && !r._server_messages) {
-										dialog.enable_primary_action();
-										frappe.throw(
-											__("Cannot update {0}", [
-												failed.map((f) => (f.bold ? f.bold() : f)).join(", "),
-											])
-										);
-									}
-									done();
-									dialog.hide();
-									frappe.show_alert(__("Updated successfully"));
-								});
+				frappe
+					.call({
+						method: "frappe.desk.doctype.bulk_update.bulk_update.validate_formula",
+						args: {
+							doctype: this.doctype,
+							field: fieldname,
+							value: value,
 						},
-						() => {
-							dialog.show();
-						}
-					);
-				});
+					})
+					.then(() => {
+						let confirmation_message = __(
+							"Are you sure you want to update <b>{0}</b> to <b>{1}</b> for <b>{2}</b> record(s). Do you want to continue?",
+							[field_label, value, docnames.length]
+						);
+						frappe.confirm(
+							confirmation_message,
+							() => {
+								dialog.disable_primary_action();
+								frappe
+									.call({
+										method: "frappe.desk.doctype.bulk_update.bulk_update.submit_cancel_or_update_docs",
+										args: {
+											doctype: this.doctype,
+											freeze: true,
+											docnames: docnames,
+											action: "update",
+											data: {
+												[fieldname]: value,
+											},
+										},
+									})
+									.then((r) => {
+										let failed = r.message || [];
+										if (failed.length && !r._server_messages) {
+											dialog.enable_primary_action();
+											frappe.throw(
+												__("Cannot update {0}", [
+													failed
+														.map((f) => (f.bold ? f.bold() : f))
+														.join(", "),
+												])
+											);
+										}
+										done();
+										dialog.hide();
+										frappe.show_alert(__("Updated successfully"));
+									});
+							},
+							() => {
+								dialog.show();
+							}
+						);
+					});
 			},
 			primary_action_label: __("Update {0} records", [docnames.length]),
 		});
@@ -443,8 +447,7 @@ export default class BulkOperations {
 						"description",
 						__("Enter a number or formula (e.g. =*2, +10, /3)")
 					);
-				}
-				else{
+				} else {
 					dialog.set_df_property(
 						"value",
 						"description",


### PR DESCRIPTION
Summary
This PR introduces formula-based updates in the Bulk Update tool and fixes a UI issue where dynamic options were removed after refreshing.

---

Enhancements:
- Added formula-based updates in Bulk Update
- Users can now apply expressions to update field values dynamically instead of only static values

- Example: 
  =*1.1 → increase value by 10%
  =+500 → add a fixed buffer
  =/2 → cut value in half
  =(current+1000)*1.05 → custom formula using the current field

Fixes:
- Resolved issue where dynamic options(field) disappeared on refresh in Bulk Update
- Options now persist correctly until a new DocType is selected

---

Demo Video

https://github.com/user-attachments/assets/77a65ba6-d2cc-40fa-8d70-f46dfb19a2f7



