### PR TITLE
feat: allow users to define max signups per hour

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -37,6 +37,7 @@
   "column_break_txqh",
   "deny_multiple_sessions",
   "disable_user_pass_login",
+  "max_signups_per_hour",
   "login_methods_section",
   "allow_login_using_mobile_number",
   "allow_login_using_user_name",
@@ -727,12 +728,19 @@
    "fieldname": "log_api_requests",
    "fieldtype": "Check",
    "label": "Log API Requests"
+  },
+  {
+   "default": "300",
+   "fieldname": "max_signups_per_hour",
+   "fieldtype": "Int",
+   "label": "Max Signups Per Hour",
+   "non_negative": 1
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2025-06-05 20:54:53.538436",
+ "modified": "2025-09-03 10:23:09.830755",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -37,7 +37,7 @@
   "column_break_txqh",
   "deny_multiple_sessions",
   "disable_user_pass_login",
-  "max_signups_per_hour",
+  "max_signups_allowed_per_hour",
   "login_methods_section",
   "allow_login_using_mobile_number",
   "allow_login_using_user_name",
@@ -731,16 +731,16 @@
   },
   {
    "default": "300",
-   "fieldname": "max_signups_per_hour",
+   "fieldname": "max_signups_allowed_per_hour",
    "fieldtype": "Int",
-   "label": "Max Signups Per Hour",
+   "label": "Max signups allowed per hour",
    "non_negative": 1
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2025-09-03 10:23:09.830755",
+ "modified": "2025-09-03 10:52:38.096662",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -73,7 +73,7 @@ class SystemSettings(Document):
 		max_auto_email_report_per_user: DF.Int
 		max_file_size: DF.Int
 		max_report_rows: DF.Int
-		max_signups_per_hour: DF.Int
+		max_signups_allowed_per_hour: DF.Int
 		minimum_password_score: DF.Literal["1", "2", "3", "4"]
 		number_format: DF.Literal[
 			"#,###.##",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -73,6 +73,7 @@ class SystemSettings(Document):
 		max_auto_email_report_per_user: DF.Int
 		max_file_size: DF.Int
 		max_report_rows: DF.Int
+		max_signups_per_hour: DF.Int
 		minimum_password_score: DF.Literal["1", "2", "3", "4"]
 		number_format: DF.Literal[
 			"#,###.##",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1035,7 +1035,8 @@ def sign_up(email: str, full_name: str, redirect_to: str) -> tuple[int, str]:
 		else:
 			return 0, _("Registered but disabled")
 	else:
-		if frappe.db.get_creation_count("User", 60) > 300:
+		max_signups_per_hour = cint(frappe.get_system_settings("max_signups_per_hour") or 300)
+		if frappe.db.get_creation_count("User", 60) > max_signups_per_hour:
 			frappe.respond_as_web_page(
 				_("Temporarily Disabled"),
 				_(

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1035,8 +1035,8 @@ def sign_up(email: str, full_name: str, redirect_to: str) -> tuple[int, str]:
 		else:
 			return 0, _("Registered but disabled")
 	else:
-		max_signups_per_hour = cint(frappe.get_system_settings("max_signups_per_hour") or 300)
-		if frappe.db.get_creation_count("User", 60) > max_signups_per_hour:
+		max_signups_allowed_per_hour = cint(frappe.get_system_settings("max_signups_allowed_per_hour") or 300)
+		if frappe.db.get_creation_count("User", 60) > max_signups_allowed_per_hour:
 			frappe.respond_as_web_page(
 				_("Temporarily Disabled"),
 				_(

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1037,7 +1037,7 @@ def sign_up(email: str, full_name: str, redirect_to: str) -> tuple[int, str]:
 	else:
 		max_signups_allowed_per_hour = cint(frappe.get_system_settings("max_signups_allowed_per_hour") or 300)
 		users_created_past_hour = frappe.db.get_creation_count("User", 60)
-		if users_created_past_hour > max_signups_allowed_per_hour:
+		if users_created_past_hour >= max_signups_allowed_per_hour:
 			frappe.respond_as_web_page(
 				_("Temporarily Disabled"),
 				_(

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1036,7 +1036,8 @@ def sign_up(email: str, full_name: str, redirect_to: str) -> tuple[int, str]:
 			return 0, _("Registered but disabled")
 	else:
 		max_signups_allowed_per_hour = cint(frappe.get_system_settings("max_signups_allowed_per_hour") or 300)
-		if frappe.db.get_creation_count("User", 60) > max_signups_allowed_per_hour:
+		users_created_past_hour = frappe.db.get_creation_count("User", 60)
+		if users_created_past_hour > max_signups_allowed_per_hour:
 			frappe.respond_as_web_page(
 				_("Temporarily Disabled"),
 				_(


### PR DESCRIPTION
## Issue

Hard coded value for max no. of **User creation**  per hour for signup.
When we launch a site at any event this creates a bottleneck.

## Solution

<img width="1470" height="832" alt="Screenshot 2025-09-03 at 10 55 38 AM" src="https://github.com/user-attachments/assets/246d0959-8b6b-4065-9135-d5e17d584f21" />


> no-docs

Support: https://support.frappe.io/helpdesk/tickets/47572