### PR TITLE
feat(search): allows search for translated or untranslated doctypes name

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -586,9 +586,13 @@ frappe.search.utils = {
 	},
 
 	fuzzy_search: function (keywords = "", _item = "", return_marked_string = false) {
-		const item = __(_item);
+		let item = __(_item);
 
-		const [, score, matches] = fuzzy_match(keywords, item, return_marked_string);
+		let [, score, matches] = fuzzy_match(keywords, item, return_marked_string);
+		if (score == 0 && frappe.boot.lang !== "en" && item != _item) {
+			item = _item || "";
+			[, score, matches] = fuzzy_match(keywords, item, return_marked_string);
+		}
 
 		if (!return_marked_string) {
 			return score;


### PR DESCRIPTION
Allows searching through global search for Doctypes either by the translated name or by its original name.

**before**
https://github.com/user-attachments/assets/5802466f-99e9-4547-b9ac-e465d5d34478


**After**
https://github.com/user-attachments/assets/b0dabea7-457a-4b6e-a6e3-1768dd8fe449


Please refer to issue https://github.com/frappe/frappe/issues/33668

no-docs