### PR TITLE
fix: Don't check PDF content if not defined

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -390,7 +390,7 @@ class File(Document):
 			)
 
 	def check_content(self):
-		if self.file_type == "PDF" and not pdf_contains_js(self._content):
+		if self.file_type == "PDF" and self._content and not pdf_contains_js(self._content):
 			frappe.throw(_("PDF cannot be uploaded, It contains unsafe content"))
 
 	def validate_duplicate_entry(self):


### PR DESCRIPTION
Not all Files have content: a simple link to a PDF is a valid File but has no content

re: https://github.com/frappe/frappe/pull/33675