### PR TITLE
feat: add shortcut to refresh print preview

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -362,6 +362,14 @@ frappe.ui.form.PrintView = class {
 		this.wrapper.find(".print-toolbar a.btn-default").each((i, el) => {
 			frappe.ui.keys.get_shortcut_group(this.frm.page).add($(el));
 		});
+
+		frappe.ui.keys.add_shortcut({
+			shortcut: "shift+r",
+			action: (e) => {
+				this.refresh_print_format();
+			},
+			description: __("Refresh Print Preview"),
+		});
 	}
 
 	set_default_letterhead() {
@@ -480,6 +488,17 @@ frappe.ui.form.PrintView = class {
 
 		setTimeout(() => {
 			$print_format.height(this.$print_format_body.find(".print-format").outerHeight());
+
+			let iframe = this.print_wrapper.find("iframe.print-format-container")[0];
+
+			let iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+
+			iframeDoc.addEventListener("keydown", (e) => {
+				if (e.shiftKey && e.key.toLowerCase() === "r") {
+					e.preventDefault();
+					this.refresh_print_format();
+				}
+			});
 		}, 500);
 	}
 

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -489,16 +489,24 @@ frappe.ui.form.PrintView = class {
 		setTimeout(() => {
 			$print_format.height(this.$print_format_body.find(".print-format").outerHeight());
 
-			let iframe = this.print_wrapper.find("iframe.print-format-container")[0];
+			// Add keyboard shortcut to refresh the print preview inside the iframe,
+			// since Frappe's default shortcuts don't work within iframes.
 
-			let iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+			const iframe = this.print_wrapper.find("iframe.print-format-container")[0];
+			const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
 
-			iframeDoc.addEventListener("keydown", (e) => {
-				if (e.shiftKey && e.key.toLowerCase() === "r") {
-					e.preventDefault();
-					this.refresh_print_format();
-				}
-			});
+			// Add a flag on the iframe document to avoid duplicate listeners
+			if (!iframeDoc._refreshShortcutAttached) {
+				iframeDoc.addEventListener("keydown", (e) => {
+					if (e.shiftKey && e.key.toLowerCase() === "r") {
+						e.preventDefault();
+						this.refresh_print_format();
+					}
+				});
+
+				// Set the flag so this block won't run again
+				iframeDoc._refreshShortcutAttached = true;
+			}
 		}, 500);
 	}
 


### PR DESCRIPTION
Add a keyboard shortcut (Shift + R) to the print preview for refreshing the document. This enhances the user experience by allowing quick access to the refresh functionality without using the mouse.

`no-docs`