### PR TITLE
feat: new `extend_doctype_class` hook

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -70,6 +70,25 @@ UNPICKLABLE_KEYS = (
 )
 
 
+def _reconstruct_extended_instance(doctype, state):
+	"""Helper function to reconstruct an extended class instance during unpickling.
+
+	This function is called during unpickling to recreate the extended class
+	based on current hooks and restore the instance state.
+	"""
+	# Get the current extended class (uses caching from get_controller)
+	extended_class = get_controller(doctype)
+	instance = extended_class.__new__(extended_class)
+
+	# Use __setstate__ if available, otherwise directly update __dict__
+	if hasattr(instance, "__setstate__"):
+		instance.__setstate__(state)
+	else:
+		instance.__dict__.update(state)
+
+	return instance
+
+
 def get_controller(doctype):
 	"""Return the locally cached **class** object of the given DocType.
 
@@ -160,7 +179,24 @@ def get_extended_class(base_class, doctype):
 	# Create the extended class by combining extension classes with base class
 	# Extension classes come first in MRO, then base class
 	class_name = f"Extended{base_class.__name__}"
-	extended_class = type(class_name, (*extension_classes, base_class), {})
+
+	def __reduce__(self):
+		"""Make extended class instances pickle-able.
+
+		When unpickling, this will use get_controller() to recreate the extended class
+		based on current hooks, ensuring the instance respects the current environment.
+		Respects the BaseDocument's __getstate__ method for proper state handling.
+		"""
+
+		return (_reconstruct_extended_instance, (self.doctype, self.__getstate__()))
+
+	extended_class = type(
+		class_name,
+		(*extension_classes, base_class),
+		{
+			"__reduce__": __reduce__,
+		},
+	)
 
 	return extended_class
 

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -195,6 +195,7 @@ def get_extended_class(base_class, doctype):
 		(*extension_classes, base_class),
 		{
 			"__reduce__": __reduce__,
+			"__module__": base_class.__module__,
 		},
 	)
 

--- a/frappe/tests/test_base_document.py
+++ b/frappe/tests/test_base_document.py
@@ -1,5 +1,28 @@
-from frappe.model.base_document import BaseDocument
+import frappe
+from frappe.desk.doctype.todo.todo import ToDo
+from frappe.model.base_document import BaseDocument, get_extended_class
 from frappe.tests import IntegrationTestCase
+
+
+class TestExtensionA(BaseDocument):
+	def extension_method_a(self):
+		return "method_a"
+
+
+class TestExtensionB(BaseDocument):
+	def extension_method_b(self):
+		return "method_b"
+
+
+class TestToDoExtension(BaseDocument):
+	"""Extension class that overrides ToDo's validate method"""
+
+	def validate(self):
+		# Add our custom logic
+		self.custom_validation_called = True
+
+	def extension_method(self):
+		return "extension_method_called"
 
 
 class TestBaseDocument(IntegrationTestCase):
@@ -15,3 +38,106 @@ class TestBaseDocument(IntegrationTestCase):
 		doc.docstatus = 2
 		self.assertTrue(doc.docstatus.is_cancelled())
 		self.assertEqual(doc.docstatus, 2)
+
+	def test_get_extended_class_with_no_extensions(self):
+		"""Test that get_extended_class returns the base class when no extensions are provided."""
+
+		with self.patch_hooks({"extend_doctype_class": {}}):
+			result = get_extended_class(ToDo, "ToDo")
+			self.assertEqual(result, ToDo)
+
+		with self.patch_hooks({"extend_doctype_class": {"ToDo": []}}):
+			result = get_extended_class(ToDo, "ToDo")
+			self.assertEqual(result, ToDo)
+
+	def test_get_extended_class_with_extensions(self):
+		"""Test that get_extended_class properly combines extension classes with base class."""
+		# Mock frappe.get_hooks to return extension paths
+		extensions = [
+			"frappe.tests.test_base_document.TestExtensionA",
+			"frappe.tests.test_base_document.TestExtensionB",
+		]
+
+		with self.patch_hooks({"extend_doctype_class": {"ToDo": extensions}}):
+			extended_class = get_extended_class(ToDo, "ToDo")
+
+			# Test that the extended class is different from base class
+			self.assertNotEqual(extended_class, ToDo)
+
+			# Test that the extended class has all methods from extensions and base
+			instance = extended_class({"doctype": "ToDo"})
+			self.assertTrue(hasattr(instance, "extension_method_a"))
+			self.assertTrue(hasattr(instance, "extension_method_b"))
+
+			# Test that methods work correctly
+			self.assertEqual(instance.extension_method_a(), "method_a")
+			self.assertEqual(instance.extension_method_b(), "method_b")
+
+			# Test MRO (Method Resolution Order) - extensions should come first in reverse order
+			mro_classes = [cls.__name__ for cls in extended_class.__mro__]
+			self.assertIn("TestExtensionB", mro_classes)
+			self.assertIn("TestExtensionA", mro_classes)
+			self.assertIn("ToDo", mro_classes)
+
+			# TestExtensionB should come before TestExtensionA (reverse order)
+			idx_b = mro_classes.index("TestExtensionB")
+			idx_a = mro_classes.index("TestExtensionA")
+			idx_base = mro_classes.index("ToDo")
+			self.assertLess(idx_b, idx_a)
+			self.assertLess(idx_a, idx_base)
+
+	def test_extension_overrides_todo_method(self):
+		"""Test that an extension can override methods from the actual ToDo class"""
+		from frappe.desk.doctype.todo.todo import ToDo
+
+		# Mock the hooks to include our ToDo extension
+		extensions = ["frappe.tests.test_base_document.TestToDoExtension"]
+
+		with self.patch_hooks({"extend_doctype_class": {"ToDo": extensions}}):
+			extended_class = get_extended_class(ToDo, "ToDo")
+
+			# Test that the extended class is different from base ToDo
+			self.assertNotEqual(extended_class, ToDo)
+
+			# Create an instance of the extended ToDo
+			instance = extended_class({"doctype": "ToDo"})
+
+			# Test that extension method is available
+			self.assertTrue(hasattr(instance, "extension_method"))
+			self.assertEqual(instance.extension_method(), "extension_method_called")
+
+			# Test that the validate method is overridden
+			# The extension's validate method should set custom_validation_called = True
+			instance.validate()
+			self.assertTrue(getattr(instance, "custom_validation_called", False))
+
+			# Test MRO - extension should come before ToDo class
+			mro_classes = [cls.__name__ for cls in extended_class.__mro__]
+			self.assertIn("TestToDoExtension", mro_classes)
+			self.assertIn("ToDo", mro_classes)
+
+			# TestToDoExtension should come before ToDo
+			idx_extension = mro_classes.index("TestToDoExtension")
+			idx_todo = mro_classes.index("ToDo")
+			self.assertLess(idx_extension, idx_todo)
+
+	def test_extension_invalid_path_raises_exception(self):
+		"""Test that an invalid extension path raises an appropriate exception"""
+		from frappe.desk.doctype.todo.todo import ToDo
+
+		# Mock the hooks to include an invalid extension path
+		path_to_invalid_extension = "invalid.module.path.NonExistentClass"
+
+		extensions = [
+			"frappe.tests.test_base_document.TestExtensionA",  # valid
+			path_to_invalid_extension,  # invalid
+		]
+
+		with self.patch_hooks({"extend_doctype_class": {"ToDo": extensions}}):
+			# Test that frappe.ValidationError is raised for invalid extension path
+			with self.assertRaises(frappe.ValidationError) as context:
+				get_extended_class(ToDo, "ToDo")
+
+			# Check that the error message mentions the invalid path
+			error_message = str(context.exception)
+			self.assertIn(path_to_invalid_extension, error_message)


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/33940

docs: https://docs.frappe.io/framework/user/en/python-api/hooks#extend-doctype-class