### PR TITLE
fix: ensure description is a string before checking for <code> tags

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -209,7 +209,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 			const description = __(this.df.description, null, this.df.parent);
 			const help_box = this.$wrapper.find(".help-box");
 			help_box.html(description);
-			if (description.includes("<code")) {
+			if (typeof description === "string" && description.includes("<code")) {
 				frappe.require("syntax_highlighting.bundle.js").then(() => {
 					help_box.find("code").each(function () {
 						hljs.highlightElement(this);


### PR DESCRIPTION
Issue: If the description is passed as an object, an error is raised.
regression: https://github.com/frappe/frappe/pull/33791

Traceback
```
Uncaught (in promise) TypeError: description2.includes is not a function
    set_description base_input.js:212
    set_gstin_status utils.js:126
    _set_gstin_status transaction.js:271
    refresh transaction.js:232
    _handler script_manager.js:30
    runner script_manager.js:109
    trigger script_manager.js:127
    promise callback*frappe.run_serially/< dom.js:276
    run_serially dom.js:274
    trigger script_manager.js:141
    render_form form.js:622
    promise callback*frappe.run_serially/< dom.js:276
    run_serially dom.js:274
    render_form form.js:612
    initialize_new_doc form.js:581
    promise callback*initialize_new_doc form.js:578
    trigger_onload form.js:559
    refresh form.js:448
    render formview.js:107
    fetch_and_render formview.js:91
    callback model.js:283
    callback request.js:87
    200 request.js:135
    call request.js:310
    jQuery 6
    call request.js:284
    call request.js:111
    with_doc model.js:275
    with_doc model.js:265
    fetch_and_render formview.js:80
base_input.js:212:19

```

Use Case: https://github.com/resilient-tech/india-compliance/blob/5a3fc3da7cd21649b86b7def056fa0ba7b089130/india_compliance/public/js/utils.js#L242-L251