### PR TITLE
feat: Add Username in set_show_users Message Print

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -339,10 +339,11 @@ frappe.PermissionEngine = class PermissionEngine {
 					method: "get_users_with_role",
 					args: {
 						role: role,
+						is_pluck: 0
 					},
 					callback: function (r) {
 						r.message = $.map(r.message, function (p) {
-							return $.format('<a href="/app/user/{0}">{1}</a>', [p, p]);
+							return $.format('<a href="/app/user/{0}">{1}</a> ({2})', [p[0], p[0], p[1]]);
 						});
 						frappe.msgprint(
 							__("Users with role {0}:", [__(role)]) +

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -166,9 +166,9 @@ def reset(doctype):
 
 
 @frappe.whitelist()
-def get_users_with_role(role):
+def get_users_with_role(role, is_pluck=1):
 	frappe.only_for("System Manager")
-	return _get_user_with_role(role)
+	return _get_user_with_role(role, is_pluck)
 
 
 @frappe.whitelist()

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -419,7 +419,7 @@ def get_users() -> list[dict]:
 	]
 
 
-def get_users_with_role(role: str) -> list[str]:
+def get_users_with_role(role: str, is_pluck=1) -> list[str]:
 	User = DocType("User")
 	HasRole = DocType("Has Role")
 
@@ -430,9 +430,9 @@ def get_users_with_role(role: str) -> list[str]:
 			(HasRole.role == role)
 			& (User.name != "Administrator")
 			& (User.enabled == 1)
-			& (HasRole.parent == User.name)
+			& (HasRole.parent == User.name, User.full_name)
 		)
 		.select(User.name)
 		.distinct()
-		.run(pluck=True)
+		.run(pluck=bool(int(is_pluck)))
 	)


### PR DESCRIPTION
### What was done ###

- The user's full name has been added to your role string;

### Images ###
<img width="1920" height="920" alt="permission_manager_msgprint" src="https://github.com/user-attachments/assets/fff1b8d5-8f96-4e22-bd86-ce40bcb09746" />
