### PR TITLE
chore: enable Norsk Bokmal

### DIFF
--- a/frappe/geo/languages.csv
+++ b/frappe/geo/languages.csv
@@ -53,6 +53,7 @@ mn,Монгол,0
 mr,मराठी,0
 ms,Melayu,0
 my,မြန်မာ,0
+nb,Norsk Bokmål,1
 nl,Nederlands,0
 no,Norsk,0
 pl,Polski,0


### PR DESCRIPTION
This pull request adds support for Norsk Bokmål to the language list in `frappe/geo/languages.csv`.