### PR TITLE
fix: ensure comments are properly added to timeline and refreshed

### DIFF
--- a/frappe/public/js/frappe/form/footer/footer.js
+++ b/frappe/public/js/frappe/form/footer/footer.js
@@ -40,9 +40,15 @@ frappe.ui.form.Footer = class FormFooter {
 							comment_email: frappe.session.user,
 							comment_by: frappe.session.user_fullname,
 						})
-						.then(() => {
+						.then((comment) => {
+							let comment_item = this.frm.timeline.get_comment_timeline_item(comment);
+
 							this.frm.comment_box.set_value("");
 							frappe.utils.play_sound("click");
+
+							this.frm.timeline.add_timeline_item(comment_item);
+							this.frm.get_docinfo().comments.push(comment);
+							this.refresh_comments_count && this.refresh_comments_count();
 						})
 						.finally(() => {
 							this.frm.comment_box.enable();


### PR DESCRIPTION
## Issue #33877 
Comments were not appearing in the timeline immediately after submission, requiring users to refresh the page to see their newly added comments.

## Solution
Fixed the comment submission flow to properly handle the server response and update the timeline in real-time:
- Update document info comments array
- Refresh comment count display

## Changes Made
- Modified `frappe/public/js/frappe/form/footer/footer.js`
- Updated comment submission success handler to process response and update timeline

## Testing
- [x] Comments appear immediately in timeline after submission
- [x] Comment count updates correctly
- [x] No regression in existing functionality

## Screenshots/GIFs

### Before


### After
