### PR TITLE
fix: populate field dropdown if document type is selected

### DIFF
--- a/frappe/desk/doctype/bulk_update/bulk_update.js
+++ b/frappe/desk/doctype/bulk_update/bulk_update.js
@@ -2,9 +2,6 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Bulk Update", {
-	onload: function (frm) {
-		frm.trigger("set_field_options");
-	},
 	refresh: function (frm) {
 		frm.set_query("document_type", function () {
 			return {
@@ -14,7 +11,7 @@ frappe.ui.form.on("Bulk Update", {
 				],
 			};
 		});
-
+		frm.trigger("set_field_options");
 		frm.page.set_primary_action(__("Update"), function () {
 			if (!frm.doc.update_value) {
 				frappe.throw(__('Field "value" is mandatory. Please specify value to be updated'));

--- a/frappe/desk/doctype/bulk_update/bulk_update.js
+++ b/frappe/desk/doctype/bulk_update/bulk_update.js
@@ -2,6 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Bulk Update", {
+	onload: function (frm) {
+		frm.trigger("set_field_options");
+	},
 	refresh: function (frm) {
 		frm.set_query("document_type", function () {
 			return {
@@ -42,6 +45,9 @@ frappe.ui.form.on("Bulk Update", {
 	},
 
 	document_type: function (frm) {
+		frm.trigger("set_field_options");
+	},
+	set_field_options(frm) {
 		// set field options
 		if (!frm.doc.document_type) return;
 


### PR DESCRIPTION
Steps to reproduce:

1. Go to **Bulk Update** DocType and do a bulk update
2. Now refresh the page the field dropdown is not auto populated.

## Before


https://github.com/user-attachments/assets/1906b65a-819f-4559-a40b-2e23a33e56ea


## After

<img width="1470" height="832" alt="Screenshot 2025-09-15 at 12 56 35 PM" src="https://github.com/user-attachments/assets/54239bc7-98ff-4c88-acd1-00e0c10e87e2" />


Support: https://support.frappe.io/helpdesk/tickets/47603?view=VIEW-HD+Ticket-003