### PR TITLE
fix: gracefully handle missing `from` header in email

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -446,6 +446,15 @@ class Email:
 		_from_email = self.decode_email(self.mail.get("X-Original-From") or self.mail["From"])
 		_reply_to = self.decode_email(self.mail.get("Reply-To"))
 
+		if not _from_email:
+			# happens in some cases when email server is misconfigured
+			# should not fail the entire syncing process
+			frappe.log_error(
+				f"Email missing `From` header. UID: {getattr(self, 'uid', 'unknown')}", str(self.mail)
+			)
+			self.from_email = None
+			return
+
 		if _reply_to and not frappe.db.get_value(
 			"Email Account", {"email_id": _reply_to, "enable_incoming": 1}, "email_id"
 		):
@@ -453,9 +462,7 @@ class Email:
 		else:
 			self.from_email = extract_email_id(_from_email)
 
-		if self.from_email:
-			self.from_email = self.from_email.lower()
-
+		self.from_email = self.from_email.lower()
 		self.from_real_name = parse_addr(_from_email)[0] if "@" in _from_email else _from_email
 
 	@staticmethod

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -105,8 +105,10 @@ def get_formatted_email(user, mail=None):
 		return cstr(make_header(decode_header(formataddr((fullname, mail)))))
 
 
-def extract_email_id(email):
+def extract_email_id(email: str) -> str:
 	"""fetch only the email part of the Email Address"""
+	if not email:
+		return ""
 	return cstr(parse_addr(email)[1])
 
 


### PR DESCRIPTION
If just one of the emails doesn't have a `From` header, the syncing keeps failing altogether:

<img width="2684" height="1134" alt="CleanShot 2025-09-16 at 10 55 07@2x" src="https://github.com/user-attachments/assets/3f2b725a-45aa-4269-add2-66c048a32d47" />

### Fix

Skip parsing the header if it is not present.

https://support.frappe.io/helpdesk/tickets/48403?view=VIEW-HD+Ticket-610