### PR TITLE
fix: allow JSON fields in PostgreSQL to accept list values in get_valid_dict

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -499,8 +499,10 @@ class BaseDocument:
 
 				fieldtype = df.fieldtype
 				if isinstance(value, list) and fieldtype not in table_fields:
-					frappe.throw(_("Value for {0} cannot be a list").format(_(df.label, context=df.parent)))
-
+					if not (frappe.db.db_type == "postgres" and fieldtype in ("JSON",)):
+						frappe.throw(
+							_("Value for {0} cannot be a list").format(_(df.label, context=df.parent))
+						)
 				if fieldtype == "Check":
 					value = 1 if cint(value) else 0
 


### PR DESCRIPTION
# PR: Allow JSON fields in PostgreSQL to accept list values in `get_valid_dict`

## Summary
This PR updates the `get_valid_dict` method in the `Document` class to properly support storing **list values** in `JSON` fields when the site is running on **PostgreSQL**.

## Changes Made
- Modified `get_valid_dict` to adjust validation logic:

  - **Before:** Any list value for non-table fields would raise a validation error.  
  - **After:** Lists are still disallowed for non-table fields **except** when:  
    - The database backend is **PostgreSQL**, and  
    - The field type is **JSON**.  

- Ensures PostgreSQL’s native support for JSON arrays is leveraged without breaking MySQL/MariaDB compatibility.

## Why This Change?
- **MariaDB/MySQL:** JSON fields don’t support storing arrays directly, so lists must remain invalid.  
- **PostgreSQL:** JSON/JSONB fields support both objects and arrays, but current logic incorrectly blocks lists.  

This fix ensures **feature parity across database backends** without breaking compatibility.

## Impact
- **On PostgreSQL:** Developers can now store JSON arrays (lists) directly in JSON fields.  
- **On MariaDB/MySQL:** Behavior remains unchanged — lists are still disallowed for non-table fields.  
- Improves **cross-database consistency** for apps using JSON fields.  

## Testing
- ✅ Verified that lists can be stored in JSON fields on PostgreSQL without errors.  
- ✅ Verified that lists in JSON fields on MariaDB/MySQL still raise a validation error.  
- ✅ Covered edge cases with `None`, empty lists, and nested JSON objects.  
