### PR TITLE
fix: print format for reports

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -3,6 +3,7 @@
 
 frappe.ui.form.on("Print Format", "onload", function (frm) {
 	frm.add_fetch("doc_type", "module", "module");
+	frm.add_fetch("report", "module", "module");
 });
 
 frappe.ui.form.on("Print Format", {
@@ -73,7 +74,8 @@ frappe.ui.form.on("Print Format", {
 	},
 	print_format_for: function (frm) {
 		if (frm.doc.print_format_for === "Report") {
-			frm.set_value("print_format_type", "JS");
+			frm.set_value("standard", "No");
+			frm.set_value("custom_format", 1);
 		}
 	},
 	hide_absolute_value_field: function (frm) {

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -81,6 +81,7 @@
    "oldfieldname": "standard",
    "oldfieldtype": "Select",
    "options": "No\nYes",
+   "read_only_depends_on": "eval:doc.print_format_for === \"Report\";",
    "reqd": 1,
    "search_index": 1
   },
@@ -88,7 +89,8 @@
    "default": "0",
    "fieldname": "custom_format",
    "fieldtype": "Check",
-   "label": "Custom Format"
+   "label": "Custom Format",
+   "read_only_depends_on": "eval:doc.print_format_for===\"Report\";"
   },
   {
    "depends_on": "eval:doc.custom_format || doc.print_format_for == \"Report\"",
@@ -101,8 +103,7 @@
    "fieldname": "print_format_type",
    "fieldtype": "Select",
    "label": "Print Format Type",
-   "options": "Jinja\nJS",
-   "read_only_depends_on": "eval:doc.print_format_for == \"Report\""
+   "options": "Jinja\nJS"
   },
   {
    "default": "0",
@@ -112,7 +113,7 @@
    "label": "Raw Printing"
   },
   {
-   "depends_on": "eval:(!doc.raw_printing) || (doc.print_format_for == \"Report\")",
+   "depends_on": "eval:!doc.raw_printing",
    "fieldname": "html",
    "fieldtype": "Code",
    "label": "HTML",
@@ -291,7 +292,7 @@
  "icon": "fa fa-print",
  "idx": 1,
  "links": [],
- "modified": "2025-07-02 11:07:42.812225",
+ "modified": "2025-09-16 11:20:20.151669",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -62,7 +62,8 @@ class PrintFormat(Document):
 
 	def before_save(self):
 		if self.print_format_for == "Report":
-			self.print_format_type = "JS"
+			self.custom_format = 1
+			self.standard = "No"
 
 	def get_html(self, docname, letterhead=None):
 		return get_html(self.doc_type, docname, self.name, letterhead)
@@ -86,7 +87,9 @@ class PrintFormat(Document):
 		self.extract_images()
 
 		if not self.module:
-			self.module = frappe.db.get_value("DocType", self.doc_type, "module")
+			doc_type = "DocType" if self.print_format_for == "DocType" else "Report"
+			document_name = self.doc_type if self.print_format_for == "DocType" else self.report
+			self.module = frappe.db.get_value(doc_type, document_name, "module")
 
 		if self.html and self.print_format_type != "JS":
 			validate_template(self.html)

--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -27,6 +27,8 @@ frappe.ui.get_print_settings = function (pdf, callback, letter_head, pick_column
 			get_query: () => ({
 				filters: {
 					print_format_for: "Report",
+					print_format_type: "JS",
+					report: frappe.query_report ? frappe.query_report.report_name : "",
 					disabled: 0,
 				},
 			}),


### PR DESCRIPTION
Changes include:
- For every "Report" Print Format, the `standard` option will be set to "No," and `custom_format` will be enabled. This change is necessary because a default Print Format template is hard-coded for all Reports, and the feature is made only for custom print formats for Reports.

	<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/cfee8ec2-61db-4f71-ae30-04e1d40d1ef4" />

- Earlier, for "Report" Print Format, the `print_format_type` was only available for "JS" type, which made it difficult to handle custom print format on the server-side. Now, both "JS" and "Jinja" are available.

	- Before:	
		
		<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/6c7c1a06-18ea-4765-9411-e06c3561add1" />


	- After:
	
		<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/ac0245d4-e750-44d7-9e38-44cc99de7352" />

- Now, on the Report View Print Settings dialog, the `report` lists down the Print Formats available only for that Report.

	- Before:
	
		<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/9aecf511-ef0e-454c-98f4-f285c4a57a50" />

	- After:

		<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/1d3ca40b-d0a0-4f6e-ac65-8b86aedfa51d" />
