### PR TITLE
refactor: add type hints and docstring to `delete_doc`

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -32,7 +32,46 @@ def delete_doc(
 	delete_permanently=False,
 ):
 	"""
-	Deletes a doc(dt, dn) and validates if it is not submitted and not linked in a live record
+	Deletes a document and validates if it is not submitted and not linked in a live record.
+
+	Args:
+		doctype (str, optional): The document type to delete. If not provided,
+			retrieved from frappe.form_dict.get("dt"). Defaults to None.
+		name (str | int | list, optional): The name/ID of the document(s) to delete.
+			Can be a single name or a list of names. If not provided,
+			retrieved from frappe.form_dict.get("dn"). Defaults to None.
+		force (bool, optional): When True, bypasses link existence checks and allows
+			deletion of documents that are linked to other records. Also allows
+			deletion of standard DocTypes. Defaults to 0 (False).
+		ignore_doctypes (list, optional): A list of child doctypes to ignore when
+			deleting child table records associated with the document. Defaults to None.
+		for_reload (bool, optional): When True, indicates the deletion is for reloading
+			purposes (like during doctype updates). Skips certain validations like
+			permissions and on_trash methods, and automatically sets delete_permanently=True.
+			Defaults to False.
+		ignore_permissions (bool, optional): When True, bypasses permission checks
+			during deletion. Useful for system operations. Defaults to False.
+		flags (dict, optional): Additional flags to set on the document during the
+			deletion process. These flags affect document behavior during deletion.
+			Defaults to None.
+		ignore_on_trash (bool, optional): When True, skips calling the document's
+			on_trash method, which typically contains cleanup logic. Defaults to False.
+		ignore_missing (bool, optional): When True, doesn't raise an error if the
+			document doesn't exist and returns False. When False, raises
+			frappe.DoesNotExistError if document is missing. Defaults to True.
+		delete_permanently (bool, optional): When True, permanently deletes the document
+			without adding it to the "Deleted Document" table for recovery purposes.
+			When False, the document is soft-deleted and can be recovered. Defaults to False.
+
+	Raises:
+		frappe.DoesNotExistError: When document doesn't exist and ignore_missing=False.
+		frappe.LinkExistsError: When document is linked to other records and force=False.
+		frappe.PermissionError: When user doesn't have delete permissions and ignore_permissions=False.
+		frappe.ValidationError: When trying to delete a submitted document.
+		frappe.QueryTimeoutError: When document is locked by another user.
+
+	Returns:
+		bool: False if document doesn't exist and ignore_missing=True, otherwise None.
 	"""
 	if not ignore_doctypes:
 		ignore_doctypes = []

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+from typing import Any
 
 import frappe
 import frappe.defaults
@@ -20,17 +21,17 @@ from frappe.utils.password import delete_all_passwords_for
 
 
 def delete_doc(
-	doctype=None,
-	name=None,
-	force=0,
-	ignore_doctypes=None,
-	for_reload=False,
-	ignore_permissions=False,
-	flags=None,
-	ignore_on_trash=False,
-	ignore_missing=True,
-	delete_permanently=False,
-):
+	doctype: str | None = None,
+	name: str | int | list[str | int] | None = None,
+	force: int | bool = 0,
+	ignore_doctypes: list[str] | None = None,
+	for_reload: bool = False,
+	ignore_permissions: bool = False,
+	flags: dict[str, Any] | None = None,
+	ignore_on_trash: bool = False,
+	ignore_missing: bool = True,
+	delete_permanently: bool = False,
+) -> bool | None:
 	"""
 	Deletes a document and validates if it is not submitted and not linked in a live record.
 


### PR DESCRIPTION
This pull request improves the documentation of the `delete_doc` function in `frappe/model/delete_doc.py`. The main change is the addition of explicit type annotations for all parameters and the return value, along with a comprehensive docstring that details the arguments, exceptions, and return behavior.