### PR TITLE
fix: top-align checkbox input & left-align description with label

### DIFF
--- a/frappe/public/scss/common/global.scss
+++ b/frappe/public/scss/common/global.scss
@@ -12,7 +12,7 @@ body {
 .checkbox {
 	label {
 		display: inline-flex;
-		align-items: center;
+		align-items: start;
 		margin-bottom: 0;
 	}
 	--checkbox-right-margin: 8px;
@@ -25,6 +25,23 @@ body {
 	.input-area,
 	.disp-area {
 		display: flex;
+	}
+
+	.input-area {
+		padding-top: 2.5px;
+
+		@media (max-width: map-get($grid-breakpoints, "lg")) {
+			padding-top: 1px;
+		}
+	}
+
+	.help-box {
+		padding-left: 22px;
+		margin-top: 0px;
+
+		@media (max-width: map-get($grid-breakpoints, "lg")) {
+			padding-left: 26px;
+		}
 	}
 }
 

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -186,6 +186,7 @@
 		.avatar {
 			height: 32px;
 			width: 32px;
+			margin-top: 1px;
 		}
 		.frappe-control {
 			padding-right: 0;

--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -419,8 +419,8 @@ kbd {
 	background-color: var(--control-bg);
 	font-family: var(--font-stack);
 	color: var(--text-light);
-	line-height: 1.2em;
-	letter-spacing: 0.02em;
+	line-height: 0.9em;
+	letter-spacing: 0.06em;
 	height: 20px;
 	padding: 4px 8px;
 }

--- a/frappe/public/scss/website/base.scss
+++ b/frappe/public/scss/website/base.scss
@@ -15,8 +15,8 @@ kbd {
 	background-color: var(--control-bg);
 	font-family: var(--font-stack);
 	color: var(--text-light);
-	line-height: 1.2em;
-	letter-spacing: 0.02em;
+	line-height: 0.9em;
+	letter-spacing: 0.06em;
 	height: 20px;
 	padding: 4px 8px;
 }


### PR DESCRIPTION
### Top-align checkbox & left-align description with label

| Before | After |
|--------|--------|
| <img width="2496" height="1368" alt="Screen Shot 2025-07-19 at 19 31 22" src="https://github.com/user-attachments/assets/79fdc101-17db-456d-aac4-ae61a5234906" /> | <img width="2496" height="1368" alt="Screen Shot 2025-07-19 at 19 31 47" src="https://github.com/user-attachments/assets/6b7703e2-2054-4b55-8bbc-a7645af0a5aa" /> |
| <img width="820" height="800" alt="Screen Shot 2025-07-19 at 19 31 11" src="https://github.com/user-attachments/assets/f816c482-aadf-41cb-9136-637c2824ea91" /> | <img width="820" height="800" alt="Screen Shot 2025-07-19 at 19 30 22" src="https://github.com/user-attachments/assets/5f02950b-7d7e-45e6-9fd6-334a2a91eff5" /> | 


### Center-align keyboard shortcut label

| Before | After |
|--------|--------|
| <img width="400" height="520" alt="Screenshot 2025-07-19 at 20-00-15 Accounts Settings" src="https://github.com/user-attachments/assets/dfc719e7-ec22-4359-b478-410bf5f9af4f" /> | <img width="400" height="520" alt="Screenshot 2025-07-19 at 19-59-32 Accounts Settings" src="https://github.com/user-attachments/assets/e1cbf422-701c-4eb5-9159-b908ce760f9c" /> |
