### PR TITLE
fix(QueryReport)!: respect user permissions in Link fields

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -899,6 +899,9 @@ def validate_filters_permissions(report_name, filters=None, user=None, js_filter
 	if not filters:
 		return
 
+	if js_filters is None:
+		js_filters = []
+
 	if isinstance(js_filters, str):
 		js_filters = json.loads(js_filters)
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -199,10 +199,11 @@ def run(
 	is_tree=False,
 	parent_field=None,
 	are_default_filters=True,
+	js_filters=None,
 ):
 	if not user:
 		user = frappe.session.user
-	validate_filters_permissions(report_name, filters, user)
+	validate_filters_permissions(report_name, filters, user, js_filters)
 	report = get_report_doc(report_name)
 	if not frappe.has_permission(report.ref_doctype, "report"):
 		frappe.msgprint(
@@ -894,25 +895,36 @@ def get_user_match_filters(doctypes, user):
 	return match_filters
 
 
-def validate_filters_permissions(report_name, filters=None, user=None):
+def validate_filters_permissions(report_name, filters=None, user=None, js_filters=None):
 	if not filters:
 		return
+
+	# print(filters, "filters \n\n\n")
+	# print(js_filters, "js_filters \n\n\n")
+
+	# print(frappe.query_reports["Trial Balance"], " query report \n\n\n")
+
+	if isinstance(js_filters, str):
+		js_filters = json.loads(js_filters)
 
 	if isinstance(filters, str):
 		filters = json.loads(filters)
 
 	report = frappe.get_doc("Report", report_name)
-	for field in report.filters:
-		if field.fieldname in filters and field.fieldtype == "Link":
-			linked_doctype = field.options
+
+	for field in report.filters + js_filters:
+		if hasattr(field, "as_dict"):
+			field = field.as_dict()
+		if field.get("fieldname") in filters and field.get("fieldtype") == "Link":
+			linked_doctype = field.get("options")
 			if not has_permission(
-				doctype=linked_doctype, ptype="read", doc=filters[field.fieldname], user=user
+				doctype=linked_doctype, ptype="read", doc=filters[field.get("fieldname")], user=user
 			) and not has_permission(
-				doctype=linked_doctype, ptype="select", doc=filters[field.fieldname], user=user
+				doctype=linked_doctype, ptype="select", doc=filters[field.get("fieldname")], user=user
 			):
 				frappe.throw(
 					_("You do not have permission to access {0}: {1}.").format(
-						linked_doctype, filters[field.fieldname]
+						linked_doctype, filters[field.get("fieldname")]
 					)
 				)
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -899,11 +899,6 @@ def validate_filters_permissions(report_name, filters=None, user=None, js_filter
 	if not filters:
 		return
 
-	# print(filters, "filters \n\n\n")
-	# print(js_filters, "js_filters \n\n\n")
-
-	# print(frappe.query_reports["Trial Balance"], " query report \n\n\n")
-
 	if isinstance(js_filters, str):
 		js_filters = json.loads(js_filters)
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -719,6 +719,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			filters.prepared_report_name = this.prepared_report_name;
 		}
 
+		// console.log(this.filters);
+		// console.log(frappe.query_reports[this.report_name].filters);
+
 		return new Promise((resolve) => {
 			this.last_ajax = frappe.call({
 				method: "frappe.desk.query_report.run",
@@ -730,6 +733,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					is_tree: this.report_settings.tree,
 					parent_field: this.report_settings.parent_field,
 					are_default_filters: are_default_filters,
+					js_filters: frappe.query_reports[this.report_name]?.filters,
 				},
 				callback: resolve,
 				always: () => this.page.btn_secondary.prop("disabled", false),

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -719,9 +719,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			filters.prepared_report_name = this.prepared_report_name;
 		}
 
-		// console.log(this.filters);
-		// console.log(frappe.query_reports[this.report_name].filters);
-
 		return new Promise((resolve) => {
 			this.last_ajax = frappe.call({
 				method: "frappe.desk.query_report.run",


### PR DESCRIPTION
If a user has permission for only one of two Cost Centers, the Link field correctly displays only the permitted one in the dropdown.
However, if the user manually types or pastes the name of the other (unauthorized) Cost Center, it is accepted without any permission validation.

This PR fixes the issue by enforcing permission checks even when values are manually entered into Link fields.

https://support.frappe.io/helpdesk/tickets/47622