### PR TITLE
fix: prevent race condition when pasting multiple rows

### DIFF
--- a/frappe/public/js/frappe/form/controls/table.js
+++ b/frappe/public/js/frappe/form/controls/table.js
@@ -128,7 +128,7 @@ frappe.ui.form.ControlTable = class ControlTable extends frappe.ui.form.Control 
 							);
 						}
 					}
-				}, 0);
+				}, i * 50);
 			});
 			return false; // Prevent the default handler from running.
 		});


### PR DESCRIPTION
All didn't get processed properly, details of only one row would get saved

Reference: support ticket 48794
<hr>

Copy a few item codes, try to paste into BOM items table. Only one will get price/name fetched, others wouldn't before this change.