### PR TITLE
fix: round seconds to minutes in Duration

### DIFF
--- a/cypress/integration/utils.js
+++ b/cypress/integration/utils.js
@@ -49,6 +49,24 @@ context("Utils", () => {
 				seconds: 0,
 			});
 		});
+
+		run_util("seconds_to_duration", 60 * 60, { hide_seconds: 1 }).then((duration) => {
+			expect(duration).to.deep.equal({
+				days: 0,
+				hours: 1,
+				minutes: 0,
+				seconds: 0,
+			});
+		});
+
+		run_util("seconds_to_duration", 15 * 60, { hide_seconds: 1 }).then((duration) => {
+			expect(duration).to.deep.equal({
+				days: 0,
+				hours: 0,
+				minutes: 15,
+				seconds: 0,
+			});
+		});
 	});
 
 	it("should parse days, hours, minutes and seconds", () => {

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1144,8 +1144,6 @@ Object.assign(frappe.utils, {
 
 	seconds_to_duration(seconds, duration_options) {
 		const floor = seconds > 0 ? Math.floor : Math.ceil;
-		const round_base_60 = (seconds) => floor(seconds / 60 + (seconds > 0 ? 0.5 : -0.5));
-
 		const total_duration = {
 			days: floor(seconds / 86400), // 60 * 60 * 24
 			hours: floor((seconds % 86400) / 3600),
@@ -1159,7 +1157,7 @@ Object.assign(frappe.utils, {
 		}
 
 		if (duration_options && duration_options.hide_seconds) {
-			total_duration.minutes += round_base_60(total_duration.seconds);
+			total_duration.minutes += Math.round(total_duration.seconds / 60);
 			total_duration.seconds = 0;
 		}
 


### PR DESCRIPTION
Resolves bug introduced in #32053 that would lead `frappe.utils.seconds_to_duration(3600, {hide_seconds: 1})
` to return `{days: 0, hours: 1, minutes: -1, seconds: 0}` because `round_base_60` did not handle 0 seconds correctly.

---

This pull request improves the handling and testing of the `seconds_to_duration` utility function, particularly when the `hide_seconds` option is used. The main focus is on fixing the rounding logic for minutes and ensuring correct behavior through additional test cases.

**Improvements to duration calculation:**

* Fixed the rounding logic in `seconds_to_duration` to use `Math.round(total_duration.seconds / 60)` instead of a custom rounding function, ensuring more accurate conversion of seconds to minutes when `hide_seconds` is enabled.

**Testing enhancements:**

* Added new test cases in `cypress/integration/utils.js` to verify that `seconds_to_duration` correctly handles hour and minute conversions when `hide_seconds` is set, improving test coverage for edge cases.

**Code cleanup:**

* Removed the unused `round_base_60` helper function from the `seconds_to_duration` implementation, simplifying the code.