### PR TITLE
fix(Number Card): permission query and frontend perms

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -202,7 +202,9 @@ frappe.ui.form.on("Number Card", {
 		let is_dynamic_filter = (f) => ["Date", "DateRange"].includes(f.fieldtype) && f.default;
 
 		let wrapper = $(frm.get_field("filters_json").wrapper).empty();
-		let table = $(`<table class="table table-bordered" style="cursor:pointer; margin:0px;">
+		let table = $(`<table class="table table-bordered" style="cursor:${
+			frm.has_perm("write") ? "pointer" : "default"
+		}; margin:0px;">
 			<thead>
 				<tr>
 					<th style="width: 20%">${__("Filter")}</th>
@@ -212,7 +214,10 @@ frappe.ui.form.on("Number Card", {
 			</thead>
 			<tbody></tbody>
 		</table>`).appendTo(wrapper);
-		$(`<p class="text-muted small">${__("Click table to edit")}</p>`).appendTo(wrapper);
+
+		if (frm.has_perm("write")) {
+			$(`<p class="text-muted small">${__("Click table to edit")}</p>`).appendTo(wrapper);
+		}
 
 		let filters = JSON.parse(frm.doc.filters_json || "[]");
 		let filters_set = false;
@@ -273,6 +278,10 @@ frappe.ui.form.on("Number Card", {
 		}
 
 		table.on("click", () => {
+			if (!frm.has_perm("write")) {
+				return;
+			}
+
 			if (!frappe.boot.developer_mode && frm.doc.is_standard) {
 				frappe.throw(__("Cannot edit filters for standard number cards"));
 			}
@@ -332,8 +341,9 @@ frappe.ui.form.on("Number Card", {
 
 		let wrapper = $(frm.get_field("dynamic_filters_json").wrapper).empty();
 
-		frm.dynamic_filter_table =
-			$(`<table class="table table-bordered" style="cursor:pointer; margin:0px;">
+		frm.dynamic_filter_table = $(`<table class="table table-bordered" style="cursor:${
+			frm.has_perm("write") ? "pointer" : "default"
+		}; margin:0px;">
 			<thead>
 				<tr>
 					<th style="width: 20%">${__("Filter")}</th>
@@ -360,6 +370,10 @@ frappe.ui.form.on("Number Card", {
 		);
 
 		frm.dynamic_filter_table.on("click", () => {
+			if (!frm.has_perm("write")) {
+				return;
+			}
+
 			if (!frappe.boot.developer_mode && frm.doc.is_standard) {
 				frappe.throw(__("Cannot edit filters for standard number cards"));
 			}

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -26,6 +26,7 @@ frappe.ui.form.on("Number Card", {
 			frm.trigger("render_filters_table");
 		}
 		frm.trigger("set_parent_document_type");
+		frm.trigger("set_document_type_description");
 
 		if (!frm.is_new()) {
 			frm.trigger("create_add_to_dashboard_button");
@@ -67,6 +68,8 @@ frappe.ui.form.on("Number Card", {
 	},
 
 	type: function (frm) {
+		frm.trigger("set_document_type_description");
+
 		if (frm.doc.type == "Report") {
 			frm.set_query("report_name", () => {
 				return {
@@ -466,6 +469,22 @@ frappe.ui.form.on("Number Card", {
 			if (parents.length === 1) {
 				frm.set_value("parent_document_type", parents[0]);
 			}
+		}
+	},
+
+	set_document_type_description: function (frm) {
+		if (frm.doc.type == "Custom") {
+			frm.set_df_property(
+				"document_type",
+				"description",
+				__(
+					"This card is visible only to Administrator and System Managers by default. Set a DocType to share with users who have read access.",
+					null,
+					"Number Card"
+				)
+			);
+		} else {
+			frm.set_df_property("document_type", "description", "");
 		}
 	},
 });

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -39,7 +39,7 @@
  "fields": [
   {
    "depends_on": "eval: ['Document Type', 'Custom'].includes(doc.type)",
-   "description": "Restrict visibility to users with read access to this doctype.",
+   "description": "This card is visible only to Administrator and System Managers by default. Set a DocType to share with users who have read access.",
    "fieldname": "document_type",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -230,7 +230,7 @@
   }
  ],
  "links": [],
- "modified": "2025-09-17 18:21:52.136320",
+ "modified": "2025-09-17 20:03:07.331957",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -38,7 +38,8 @@
  ],
  "fields": [
   {
-   "depends_on": "eval: doc.type == 'Document Type'",
+   "depends_on": "eval: ['Document Type', 'Custom'].includes(doc.type)",
+   "description": "Restrict visibility to users with read access to this doctype.",
    "fieldname": "document_type",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -229,7 +230,7 @@
   }
  ],
  "links": [],
- "modified": "2025-05-21 17:33:04.908518",
+ "modified": "2025-09-17 18:21:52.136320",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -39,7 +39,6 @@
  "fields": [
   {
    "depends_on": "eval: ['Document Type', 'Custom'].includes(doc.type)",
-   "description": "This card is visible only to Administrator and System Managers by default. Set a DocType to share with users who have read access.",
    "fieldname": "document_type",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -230,7 +229,7 @@
   }
  ],
  "links": [],
- "modified": "2025-09-17 20:03:07.331957",
+ "modified": "2025-09-17 21:00:11.351605",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -7,9 +7,10 @@ from frappe.boot import get_allowed_report_names
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 from frappe.modules.export_file import export_to_files
+from frappe.permissions import get_doctypes_with_read
 from frappe.query_builder import Criterion
 from frappe.query_builder.utils import DocType
-from frappe.utils import cint, flt
+from frappe.utils import flt
 from frappe.utils.modules import get_modules_from_all_apps_for_user
 
 
@@ -78,55 +79,46 @@ class NumberCard(Document):
 
 
 def get_permission_query_conditions(user=None):
-	if not user:
-		user = frappe.session.user
-
-	if user == "Administrator":
+	# The user param is ignored because `get_allowed_report_names` and `get_doctypes_with_read` don't support it.
+	if frappe.session.user == "Administrator":
 		return
 
-	roles = frappe.get_roles(user)
-	if "System Manager" in roles:
+	if "System Manager" in frappe.get_roles():
 		return None
 
-	doctype_condition = False
-	module_condition = False
+	allowed_reports = get_allowed_report_names()
+	allowed_doctypes = get_doctypes_with_read()
+	allowed_modules = [module.get("module_name") for module in get_modules_from_all_apps_for_user()]
 
-	allowed_doctypes = [frappe.db.escape(doctype) for doctype in frappe.permissions.get_doctypes_with_read()]
-	allowed_modules = [
-		frappe.db.escape(module.get("module_name")) for module in get_modules_from_all_apps_for_user()
-	]
-
-	if allowed_doctypes:
-		doctype_condition = """(`tabNumber Card`.`document_type` in ({allowed_doctypes})
-			OR (`tabNumber Card`.`type` = 'Custom' AND (`tabNumber Card`.`document_type` IS NULL OR `tabNumber Card`.`document_type` = '')))""".format(
-			allowed_doctypes=",".join(allowed_doctypes)
+	nc = frappe.qb.DocType("Number Card")
+	conditions = (
+		((nc.type == "Report") & nc.report_name.isin(allowed_reports))
+		| (
+			(nc.type == "Custom")
+			& (nc.document_type.isnull() | (nc.document_type == "") | nc.document_type.isin(allowed_doctypes))
 		)
-	if allowed_modules:
-		module_condition = """`tabNumber Card`.`module` in ({allowed_modules})
-			or `tabNumber Card`.`module` is NULL""".format(allowed_modules=",".join(allowed_modules))
+		| ((nc.type == "Document Type") & nc.document_type.isin(allowed_doctypes))
+	) & (nc.module.isin(allowed_modules) | nc.module.isnull() | nc.module == "")
 
-	return f"""
-		{doctype_condition}
-		and
-		{module_condition}
-	"""
+	return conditions.get_sql(quote_char="`")
 
 
 def has_permission(doc, ptype, user):
-	roles = frappe.get_roles(user)
-	if "System Manager" in roles:
+	# The user param is ignored because `get_allowed_report_names` and `get_doctypes_with_read` don't support it.
+	if frappe.session.user == "Administrator":
+		return
+
+	if "System Manager" in frappe.get_roles():
 		return True
 
-	if doc.type == "Report":
-		if doc.report_name in get_allowed_report_names():
-			return True
-	elif doc.type == "Custom" and not doc.document_type:
-		# Allow Custom cards without document_type (doctype filtering doesn't apply)
+	if doc.type == "Report" and doc.report_name in get_allowed_report_names():
 		return True
-	else:
-		allowed_doctypes = tuple(frappe.permissions.get_doctypes_with_read())
-		if doc.document_type in allowed_doctypes:
-			return True
+
+	if doc.type == "Custom" and (not doc.document_type or doc.document_type in get_doctypes_with_read()):
+		return True
+
+	if doc.type == "Document Type" and doc.document_type in get_doctypes_with_read():
+		return True
 
 	return False
 

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -84,7 +84,7 @@ def get_permission_query_conditions(user=None):
 		return
 
 	if "System Manager" in frappe.get_roles():
-		return None
+		return
 
 	allowed_reports = get_allowed_report_names()
 	allowed_doctypes = get_doctypes_with_read()
@@ -93,10 +93,7 @@ def get_permission_query_conditions(user=None):
 	nc = frappe.qb.DocType("Number Card")
 	conditions = (
 		((nc.type == "Report") & nc.report_name.isin(allowed_reports))
-		| (
-			(nc.type == "Custom")
-			& (nc.document_type.isnull() | (nc.document_type == "") | nc.document_type.isin(allowed_doctypes))
-		)
+		| ((nc.type == "Custom") & nc.document_type.isin(allowed_doctypes))
 		| ((nc.type == "Document Type") & nc.document_type.isin(allowed_doctypes))
 	) & (nc.module.isin(allowed_modules) | nc.module.isnull() | nc.module == "")
 
@@ -114,7 +111,7 @@ def has_permission(doc, ptype, user):
 	if doc.type == "Report" and doc.report_name in get_allowed_report_names():
 		return True
 
-	if doc.type == "Custom" and (not doc.document_type or doc.document_type in get_doctypes_with_read()):
+	if doc.type == "Custom" and doc.document_type in get_doctypes_with_read():
 		return True
 
 	if doc.type == "Document Type" and doc.document_type in get_doctypes_with_read():

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -97,7 +97,8 @@ def get_permission_query_conditions(user=None):
 	]
 
 	if allowed_doctypes:
-		doctype_condition = "`tabNumber Card`.`document_type` in ({allowed_doctypes})".format(
+		doctype_condition = """(`tabNumber Card`.`document_type` in ({allowed_doctypes})
+			OR (`tabNumber Card`.`type` = 'Custom' AND (`tabNumber Card`.`document_type` IS NULL OR `tabNumber Card`.`document_type` = '')))""".format(
 			allowed_doctypes=",".join(allowed_doctypes)
 		)
 	if allowed_modules:
@@ -119,6 +120,9 @@ def has_permission(doc, ptype, user):
 	if doc.type == "Report":
 		if doc.report_name in get_allowed_report_names():
 			return True
+	elif doc.type == "Custom" and not doc.document_type:
+		# Allow Custom cards without document_type (doctype filtering doesn't apply)
+		return True
 	else:
 		allowed_doctypes = tuple(frappe.permissions.get_doctypes_with_read())
 		if doc.document_type in allowed_doctypes:

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -106,7 +106,7 @@ def get_permission_query_conditions(user=None):
 def has_permission(doc, ptype, user):
 	# The user param is ignored because `get_allowed_report_names` and `get_doctypes_with_read` don't support it.
 	if frappe.session.user == "Administrator":
-		return
+		return True
 
 	if "System Manager" in frappe.get_roles():
 		return True


### PR DESCRIPTION
### Issue

- If the **Number Card** is of type "Custom" (method), the `document_type` field was hidden and non-required. Since users don't have read perms on "empty" doctype, they couldn't see these cards (only Admin and System Manager).
- For security reasons, we cannot relax these perms. However, we can unhide the `document_type` field so devs can set it to make the card available to regular users. To make this more transparent, we can add a description.
- Regarding the frontend form, users with read access to **Number Card** shouldn't be able to edit filter values by clicking on the table.

### Changes

This pull request improves the permission handling and user interface for Number Cards, ensuring that only users with write access can edit filters and that permission checks are more robust and maintainable. The changes also refine field visibility logic and update backend permission queries for clarity and correctness.

**Permission handling and UI improvements:**

* The filter tables in `number_card.js` now only show a pointer cursor and the "Click table to edit" message if the user has write permission, preventing confusion for users without edit access. Clicking the table to edit filters is also restricted to users with write permission.
* The `depends_on` condition for the `document_type` field in `number_card.json` has been updated to show the field for both "Document Type" and "Custom" Number Cards, improving usability for custom scenarios.

**Backend permission logic updates:**

* The permission query logic in `number_card.py` has been refactored to construct conditions using the query builder for better readability and maintainability. The function now also handles "Custom" type Number Cards correctly. 
