### PR TITLE
feat: add support of expand in rest api v1/document_list

### DIFF
--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -4,10 +4,6 @@ from werkzeug.routing import Rule
 
 import frappe
 from frappe import _
-from frappe.desk.form.load import (
-	get_title_values_for_link_and_dynamic_link_fields,
-	get_title_values_for_table_and_multiselect_fields,
-)
 from frappe.utils.data import sbool
 
 
@@ -82,7 +78,7 @@ def read_doc(doctype: str, name: str):
 	doc.check_permission("read")
 	doc.apply_fieldlevel_read_permissions()
 	doc_dict = doc.as_dict()
-	if frappe.form_dict.get("expand_links") and json.loads(frappe.form_dict["expand_links"]):
+	if frappe.form_dict.get("expand_links") and frappe.form_dict["expand_links"]:
 		get_values_for_link_and_dynamic_link_fields(doc_dict)
 		get_values_for_table_and_multiselect_fields(doc_dict)
 
@@ -100,7 +96,7 @@ def get_values_for_link_and_dynamic_link_fields(doc_dict):
 		doctype = field.options if field.fieldtype == "Link" else doc_dict.get(field.options)
 
 		link_doc = frappe.get_doc(doctype, doc_fieldvalue)
-		doc_dict.update({"_expanded_" + field.fieldname: link_doc})
+		doc_dict.update({field.fieldname: link_doc})
 
 
 def get_values_for_table_and_multiselect_fields(doc_dict):

--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -4,6 +4,7 @@ from werkzeug.routing import Rule
 
 import frappe
 from frappe import _
+from frappe.utils import attach_expanded_links
 from frappe.utils.data import sbool
 
 
@@ -104,11 +105,8 @@ def get_values_for_table_and_multiselect_fields(doc_dict):
 	table_fields = meta.get_table_fields()
 
 	for field in table_fields:
-		if not doc_dict.get(field.fieldname):
-			continue
-
-		for value in doc_dict.get(field.fieldname):
-			value.update(get_values_for_link_and_dynamic_link_fields(value))
+		table_link_fieldnames = [f.fieldname for f in frappe.get_meta(field.options).get_link_fields()]
+		attach_expanded_links(field.options, doc_dict.get(field.fieldname), table_link_fieldnames)
 
 
 def execute_doc_method(doctype: str, name: str, method: str | None = None):

--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -78,7 +78,7 @@ def read_doc(doctype: str, name: str):
 	doc.check_permission("read")
 	doc.apply_fieldlevel_read_permissions()
 	doc_dict = doc.as_dict()
-	if frappe.form_dict.get("expand_links") and frappe.form_dict["expand_links"]:
+	if sbool(frappe.form_dict.get("expand_links")):
 		get_values_for_link_and_dynamic_link_fields(doc_dict)
 		get_values_for_table_and_multiselect_fields(doc_dict)
 

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -111,7 +111,7 @@ def get_list(
 			val = li.get(fieldname)
 			val_title = doctype_title_maps.get(link_doctype, {}).get(val)
 			if val and val_title:
-				li["_expanded_" + fieldname] = val_title
+				li[fieldname] = val_title
 
 	return _list
 

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -96,18 +96,12 @@ def get_list(
 		doctype_title_maps = {}
 
 	for link_doctype, values in doctype_values.items():
-		link_meta = frappe.get_meta(link_doctype)
-		if not link_meta.title_field or not link_meta.show_title_field_in_link:
-			continue
-
-		title_field = link_meta.title_field
-
 		records = frappe.get_all(
 			link_doctype,
 			filters={"name": ["in", list(values)]},
-			fields=["name", title_field],
+			fields=["*"],
 		)
-		doctype_title_maps[link_doctype] = {r["name"]: r[title_field] for r in records}
+		doctype_title_maps[link_doctype] = {r["name"]: r for r in records}
 
 	for li in _list:
 		for fieldname in expand:
@@ -117,7 +111,7 @@ def get_list(
 			val = li.get(fieldname)
 			val_title = doctype_title_maps.get(link_doctype, {}).get(val)
 			if val and val_title:
-				li["_" + fieldname + "_title"] = val_title
+				li["_expanded_" + fieldname] = val_title
 
 	return _list
 

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -142,6 +142,7 @@ class TestResourceAPI(FrappeAPITestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
+		cls.GENERATED_DOCUMENTS = []
 		for _ in range(20):
 			doc = frappe.get_doc(
 				{
@@ -150,7 +151,6 @@ class TestResourceAPI(FrappeAPITestCase):
 					"allocated_to": "test@example.com",
 				}
 			).insert()
-			cls.GENERATED_DOCUMENTS = []
 			cls.GENERATED_DOCUMENTS.append(doc.name)
 		frappe.db.commit()
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2779,6 +2779,37 @@ def map_trackers(url_trackers: dict, create: bool = False):
 
 
 def attach_expanded_links(doctype: str, docs: list, fields_to_expand: list):
+	"""
+	Expands specified link or dynamic link fields in a list of documents by replacing
+	their linked values (names) with full document records.
+
+	This function takes a list of documents and a list of link fieldnames that should be
+	expanded. For each specified field, it retrieves all referenced linked records from
+	the corresponding doctypes and replaces the link value in each document with the
+	full linked record (as a dict).
+
+	Args:
+		doctype (str): The parent doctype of the provided documents.
+		docs (list[dict]): A list of document dictionaries whose link fields are to be expanded.
+		fields_to_expand (list[str]): A list of fieldnames corresponding to link or dynamic
+			link fields that should be expanded.
+
+	Returns:
+		None: The function modifies the `docs` list in place.
+
+	Example:
+		>>> docs = [{"customer": "CUST-001"}, {"customer": "CUST-002"}]
+		>>> attach_expanded_links("Sales Invoice", docs, ["customer"])
+		>>> docs[0]["customer"]
+		{
+			"name": "CUST-001",
+			"customer_name": "John Doe",
+			"customer_group": "Retail",
+			...
+		}
+
+	"""
+
 	if not fields_to_expand:
 		return
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2804,7 +2804,7 @@ def attach_expanded_links(doctype: str, docs: list, fields_to_expand: list):
 	doctype_title_maps = {}
 
 	for link_doctype, values in doctype_values.items():
-		records = frappe.get_all(
+		records = frappe.get_list(
 			link_doctype,
 			filters={"name": ["in", list(values)]},
 			fields=["*"],


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

For Link fields In REST API v1, while fetching list of records only link names are returned which are not helpful and requires seperate request to fetch link titles. This change fixes this issue, adding link names in query_params fetches respective link titles. 

Inspired from https://github.com/frappe/frappe/issues/22762

- [x] document_list
add expand_links param when fetching records of particular doctype to fetch whole link field's record

`GET /api/resource/:doctype/:name?expand_links=True`

```
[{
"name": "record 1",
"priority": {
"name": "Low",
"creation": "...",
}]

```

- [x] read_doc
add expand param which is array of link names which we desire to fetch link field's whole record

`GET /api/resource/:doctype?expand=["link_1", "link_2"]`
```
{
"link_1": {
...fields
},
"link_2": {
...fields
},
}
```
- [ ] docs