### PR TITLE
chore: enable Norsk Bokmal (backport #33978)

### DIFF
--- a/frappe/geo/languages.json
+++ b/frappe/geo/languages.json
@@ -224,6 +224,10 @@
   "name": "\u1019\u103c\u1014\u103a\u1019\u102c"
  },
  {
+  "code": "nb",
+  "name": "Norsk Bokmål"
+ },
+ {
   "code": "nl",
   "name": "Nederlands"
  },


### PR DESCRIPTION
This pull request adds support for Norsk Bokmål to the language list in `frappe/geo/languages.json`.