### PR TITLE
feat: Included disable on filter link field

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -117,6 +117,12 @@ def search_widget(
 
 	meta = frappe.get_meta(doctype)
 
+	include_disabled = False
+	if filters and "include_disabled" in filters:
+		if filters["include_disabled"] == 1:
+			include_disabled = True
+		filters.pop("include_disabled")
+
 	if isinstance(filters, dict):
 		filters = [make_filter_tuple(doctype, key, value) for key, value in filters.items()]
 	elif filters is None:
@@ -147,10 +153,11 @@ def search_widget(
 			if not meta.translated_doctype and (f == "name" or (fmeta and fmeta.fieldtype in field_types)):
 				or_filters.append([doctype, f.strip(), "like", f"%{txt}%"])
 
-	if meta.get("fields", {"fieldname": "enabled", "fieldtype": "Check"}):
-		filters.append([doctype, "enabled", "=", 1])
-	if meta.get("fields", {"fieldname": "disabled", "fieldtype": "Check"}):
-		filters.append([doctype, "disabled", "!=", 1])
+	if not include_disabled:
+		if meta.get("fields", {"fieldname": "enabled", "fieldtype": "Check"}):
+			filters.append([doctype, "enabled", "=", 1])
+		if meta.get("fields", {"fieldname": "disabled", "fieldtype": "Check"}):
+			filters.append([doctype, "disabled", "!=", 1])
 
 	# format a list of fields combining search fields and filter fields
 	fields = get_std_fields_list(meta, searchfield or "name")


### PR DESCRIPTION
Fix issue https://github.com/frappe/frappe/issues/34010

**Step**

1. Customer is disabled
<img width="1832" height="656" alt="Selection_092" src="https://github.com/user-attachments/assets/7edfc8cb-c44a-4679-b4fa-ed2350c4f5aa" />

2. Add filter included_disabled in link field
<img width="1206" height="667" alt="Selection_093" src="https://github.com/user-attachments/assets/1c795ed9-2151-4b1c-b1fa-c36d170fb1c2" />

3. all data will show in link field (included disabled)
<img width="1768" height="651" alt="Selection_094" src="https://github.com/user-attachments/assets/fa8a45a2-a38d-4f30-8ec4-5d70cbca083f" />

`no-docs`