### PR TITLE
fix(kanban_view): don't always prompt user to create a new board

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -31,7 +31,17 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 			if (!kanbans.length) {
 				return frappe.views.KanbanView.show_kanban_dialog(this.doctype, true);
 			} else if (kanbans.length && frappe.get_route().length !== 4) {
-				return frappe.views.KanbanView.show_kanban_dialog(this.doctype, true);
+				// Try to use the last board the user used, else default to the first available board
+				const last_board = frappe.get_user_settings(this.doctype)["Kanban"]
+					?.last_kanban_board;
+				if (last_board && kanbans.includes(last_board)) {
+					frappe.set_route("List", this.doctype, "Kanban", last_board);
+					return;
+				} else {
+					const first_board = kanbans[0];
+					frappe.set_route("List", this.doctype, "Kanban", first_board.name);
+					return;
+				}
 			} else {
 				this.kanbans = kanbans;
 

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -130,6 +130,10 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 		// pass
 	}
 
+	set_result_height() {
+		// pass
+	}
+
 	toggle_result_area() {
 		this.$result.toggle(this.data.length > 0);
 	}


### PR DESCRIPTION
- fix(kanban): use last board chosen by user, or first available board
- fix(kanban): no-op set_result_height

<hr>

Before this, if you directly opened `/app/{doctype}` for a doctype which had default view set as kanban, you would always be prompted to create a new kanban board.
