### PR TITLE
fix: validate mandatory fields before workflow action

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -17,7 +17,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 
 	var save = function () {
 		$(frm.wrapper).addClass("validated-form");
-		if ((action !== "Save" || frm.is_dirty()) && check_mandatory()) {
+		if ((action !== "Save" || frm.is_dirty()) && frappe.ui.form.check_mandatory(frm)) {
 			_call({
 				method: "frappe.desk.form.save.savedocs",
 				args: { doc: frm.doc, action: action },
@@ -63,116 +63,6 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 			btn: btn,
 			freeze_message: freeze_message,
 		});
-	};
-
-	var check_mandatory = function () {
-		var has_errors = false;
-		frm.scroll_set = false;
-
-		if (frm.doc.docstatus == 2) return true; // don't check for cancel
-
-		$.each(frappe.model.get_all_docs(frm.doc), function (i, doc) {
-			var error_fields = [];
-			var folded = false;
-
-			$.each(frappe.meta.docfield_list[doc.doctype] || [], function (i, docfield) {
-				if (docfield.fieldname) {
-					const df = frappe.meta.get_docfield(doc.doctype, docfield.fieldname, doc.name);
-
-					if (df.fieldtype === "Fold") {
-						folded = frm.layout.folded;
-					}
-
-					if (
-						is_docfield_mandatory(doc, df) &&
-						!frappe.model.has_value(doc.doctype, doc.name, df.fieldname)
-					) {
-						has_errors = true;
-						error_fields[error_fields.length] = __(df.label, null, df.parent);
-						// scroll to field
-						if (!frm.scroll_set) {
-							scroll_to(doc.parentfield || df.fieldname);
-						}
-
-						if (folded) {
-							frm.layout.unfold();
-							folded = false;
-						}
-					}
-				}
-			});
-
-			if (frm.is_new() && frm.meta.autoname === "Prompt" && !frm.doc.__newname) {
-				has_errors = true;
-				error_fields = [__("Name"), ...error_fields];
-			}
-
-			if (error_fields.length) {
-				let meta = frappe.get_meta(doc.doctype);
-				let message;
-				if (meta.istable) {
-					const table_field = frappe.meta.docfield_map[doc.parenttype][doc.parentfield];
-
-					const table_label = __(
-						table_field.label || frappe.unscrub(table_field.fieldname)
-					).bold();
-
-					message = __("Mandatory fields required in table {0}, Row {1}", [
-						table_label,
-						doc.idx,
-					]);
-				} else {
-					message = __("Mandatory fields required in {0}", [__(doc.doctype)]);
-				}
-				message = message + "<br><br><ul><li>" + error_fields.join("</li><li>") + "</ul>";
-				frappe.msgprint({
-					message: message,
-					indicator: "red",
-					title: __("Missing Fields"),
-				});
-				frm.refresh();
-			}
-		});
-
-		return !has_errors;
-	};
-
-	let is_docfield_mandatory = function (doc, df) {
-		if (df.reqd) return true;
-		if (!df.mandatory_depends_on || !doc) return;
-
-		let out = null;
-		let expression = df.mandatory_depends_on;
-		let parent = frappe.get_meta(df.parent);
-
-		if (typeof expression === "boolean") {
-			out = expression;
-		} else if (typeof expression === "function") {
-			out = expression(doc);
-		} else if (expression.substr(0, 5) == "eval:") {
-			try {
-				out = frappe.utils.eval(expression.substr(5), { doc, parent });
-				if (parent && parent.istable && expression.includes("is_submittable")) {
-					out = true;
-				}
-			} catch (e) {
-				frappe.throw(__('Invalid "mandatory_depends_on" expression'));
-			}
-		} else {
-			var value = doc[expression];
-			if ($.isArray(value)) {
-				out = !!value.length;
-			} else {
-				out = !!value;
-			}
-		}
-
-		return out;
-	};
-
-	const scroll_to = (fieldname) => {
-		frm.scroll_to_field(fieldname);
-		frm.scroll_set = true;
 	};
 
 	var _call = function (opts) {
@@ -224,6 +114,116 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 		cancel();
 	} else {
 		save();
+	}
+};
+
+frappe.ui.form.check_mandatory = function (frm) {
+	var has_errors = false;
+	frm.scroll_set = false;
+
+	if (frm.doc.docstatus == 2) return true; // don't check for cancel
+
+	$.each(frappe.model.get_all_docs(frm.doc), function (i, doc) {
+		var error_fields = [];
+		var folded = false;
+
+		$.each(frappe.meta.docfield_list[doc.doctype] || [], function (i, docfield) {
+			if (docfield.fieldname) {
+				const df = frappe.meta.get_docfield(doc.doctype, docfield.fieldname, doc.name);
+
+				if (df.fieldtype === "Fold") {
+					folded = frm.layout.folded;
+				}
+
+				if (
+					is_docfield_mandatory(doc, df) &&
+					!frappe.model.has_value(doc.doctype, doc.name, df.fieldname)
+				) {
+					has_errors = true;
+					error_fields[error_fields.length] = __(df.label, null, df.parent);
+					// scroll to field
+					if (!frm.scroll_set) {
+						scroll_to(doc.parentfield || df.fieldname);
+					}
+
+					if (folded) {
+						frm.layout.unfold();
+						folded = false;
+					}
+				}
+			}
+		});
+
+		if (frm.is_new() && frm.meta.autoname === "Prompt" && !frm.doc.__newname) {
+			has_errors = true;
+			error_fields = [__("Name"), ...error_fields];
+		}
+
+		if (error_fields.length) {
+			let meta = frappe.get_meta(doc.doctype);
+			let message;
+			if (meta.istable) {
+				const table_field = frappe.meta.docfield_map[doc.parenttype][doc.parentfield];
+
+				const table_label = __(
+					table_field.label || frappe.unscrub(table_field.fieldname)
+				).bold();
+
+				message = __("Mandatory fields required in table {0}, Row {1}", [
+					table_label,
+					doc.idx,
+				]);
+			} else {
+				message = __("Mandatory fields required in {0}", [__(doc.doctype)]);
+			}
+			message = message + "<br><br><ul><li>" + error_fields.join("</li><li>") + "</ul>";
+			frappe.msgprint({
+				message: message,
+				indicator: "red",
+				title: __("Missing Fields"),
+			});
+			frm.refresh();
+		}
+	});
+
+	return !has_errors;
+
+	function is_docfield_mandatory(doc, df) {
+		if (df.reqd) return true;
+		if (!df.mandatory_depends_on || !doc) return;
+
+		let out = null;
+		let expression = df.mandatory_depends_on;
+		let parent = frappe.get_meta(df.parent);
+
+		if (typeof expression === "boolean") {
+			out = expression;
+		} else if (typeof expression === "function") {
+			out = expression(doc);
+		} else if (expression.substr(0, 5) == "eval:") {
+			try {
+				out = frappe.utils.eval(expression.substr(5), { doc, parent });
+				if (parent && parent.istable && expression.includes("is_submittable")) {
+					out = true;
+				}
+			} catch (e) {
+				frappe.throw(__('Invalid "mandatory_depends_on" expression'));
+			}
+		} else {
+			var value = doc[expression];
+			if ($.isArray(value)) {
+				out = !!value.length;
+			} else {
+				out = !!value;
+			}
+		}
+
+		return out;
+	}
+
+	function scroll_to(fieldname) {
+		frm.scroll_to_field(fieldname);
+		frm.scroll_set = true;
 	}
 };
 

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -98,6 +98,7 @@ frappe.ui.form.States = class FormStates {
 
 		frappe.workflow.get_transitions(this.frm.doc).then((transitions) => {
 			this.frm.page.clear_actions_menu();
+			const frm = this.frm;
 			transitions.forEach((d) => {
 				if (frappe.user_roles.includes(d.allowed) && has_approval_access(d)) {
 					added = true;
@@ -105,6 +106,7 @@ frappe.ui.form.States = class FormStates {
 						// set the workflow_action for use in form scripts
 						frappe.dom.freeze();
 						me.frm.selected_workflow_action = d.action;
+						if (!frappe.ui.form.check_mandatory(frm)) return frappe.dom.unfreeze();
 						me.frm.script_manager.trigger("before_workflow_action").then(() => {
 							frappe
 								.xcall("frappe.model.workflow.apply_workflow", {


### PR DESCRIPTION
This pull request refactors the form save logic in `frappe/public/js/frappe/form/save.js` by extracting the mandatory field check into a reusable function. It also ensures that mandatory field validation is performed before workflow actions in `workflow.js`. 

* Updated the save logic to use the new `frappe.ui.form.check_mandatory(frm)` function, replacing the previous local function `var check_mandatory = function () {... }`.
* Updated `workflow.js` to use the new `frappe.ui.form.check_mandatory(frm)` function, ensuring mandatory fields are validated before proceeding with workflow actions.


`no-docs`

closes #34038 