### PR TITLE
feat: translate filename of exported report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -416,7 +416,7 @@ def _export_query(form_params, csv_params, populate_response=True):
 	if not populate_response:
 		return report_name, file_extension, content
 
-	provide_binary_file(report_name, file_extension, content)
+	provide_binary_file(_(report_name), file_extension, content)
 
 
 def valid_report_name(report_name, suffix):

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -483,7 +483,7 @@ def _export_query(form_params, csv_params, populate_response=True):
 	if not populate_response:
 		return title, file_extension, content
 
-	provide_binary_file(title, file_extension, content)
+	provide_binary_file(_(title), file_extension, content)
 
 
 def append_totals_row(data):


### PR DESCRIPTION
Ensure the filename of an exported report (Excel, CSV) is the same as the localized report name the user sees in the UI. This is relevant for UX, as the user would be confused by the filename containing terms they've never seen in the UI.

### Before

German user looks at report "Bilanz" (Balance Sheet), exports to Excel, the provided file is called "Balance Sheet.xlsx" (not translated).

### After

German user looks at report "Bilanz" (Balance Sheet), exports to Excel, the provided file is called "Bilanz.xlsx" (translated).

> no-docs