### PR TITLE
feat: provide an option to show or hide applied filters in report pri…

### DIFF
--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -1,4 +1,10 @@
-frappe.ui.get_print_settings = function (pdf, callback, letter_head, pick_columns) {
+frappe.ui.get_print_settings = function (
+	pdf,
+	callback,
+	letter_head,
+	pick_columns,
+	has_filters = false
+) {
 	var print_settings = locals[":Print Settings"]["Print Settings"];
 
 	var company = frappe.defaults.get_default("company");
@@ -46,6 +52,14 @@ frappe.ui.get_print_settings = function (pdf, callback, letter_head, pick_column
 			default: letter_head || default_letter_head,
 		},
 	];
+
+	if (has_filters) {
+		columns.push({
+			label: __("Include filters"),
+			fieldtype: "Check",
+			fieldname: "include_filters",
+		});
+	}
 
 	if (pick_columns) {
 		columns.push(

--- a/frappe/public/js/frappe/views/reports/print_grid.html
+++ b/frappe/public/js/frappe/views/reports/print_grid.html
@@ -3,9 +3,9 @@
 <h2>{{ __(title) }}</h2>
 <hr>
 {% endif %}
-{% if subtitle %}
-{{ subtitle }}
-<hr>
+{% if subtitle && print_settings.include_filters %}
+	{{ subtitle }}
+	<hr>
 {% endif %}
 <table class="table table-bordered">
 	<!-- heading -->

--- a/frappe/public/js/frappe/views/reports/print_grid.html
+++ b/frappe/public/js/frappe/views/reports/print_grid.html
@@ -3,7 +3,7 @@
 <h2>{{ __(title) }}</h2>
 <hr>
 {% endif %}
-{% if subtitle && print_settings.include_filters %}
+{% if subtitle %}
 	{{ subtitle }}
 	<hr>
 {% endif %}

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1785,7 +1785,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 						false,
 						(print_settings) => this.print_report(print_settings),
 						this.report_doc.letter_head,
-						this.get_visible_columns()
+						this.get_visible_columns(),
+						true
 					);
 					this.add_portrait_warning(dialog);
 				},
@@ -1799,7 +1800,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 						false,
 						(print_settings) => this.pdf_report(print_settings),
 						this.report_doc.letter_head,
-						this.get_visible_columns()
+						this.get_visible_columns(),
+						true
 					);
 
 					this.add_portrait_warning(dialog);

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1495,7 +1495,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		frappe.render_grid({
 			template: print_settings.columns ? "print_grid" : custom_format,
 			title: __(this.report_name),
-			subtitle: filters_html,
+			subtitle: print_settings?.include_filters ? filters_html : null,
 			print_settings: print_settings,
 			landscape: landscape,
 			filters: this.get_filter_values(),
@@ -1525,7 +1525,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		const template = print_settings.columns || !custom_format ? "print_grid" : custom_format;
 		const content = frappe.render_template(template, {
 			title: __(this.report_name),
-			subtitle: filters_html,
+			subtitle: print_settings?.include_filters ? filters_html : null,
 			filters: applied_filters,
 			data: data,
 			original_data: this.data,


### PR DESCRIPTION
Issue:
When a report is viewed in print view, the applied filters are always shown by default. 

Solution:
Added a checkbox in the "Print Settings" dialog box to include filters in the print view

Before:

https://github.com/user-attachments/assets/fd3a9415-d8c3-4eed-85c8-faeeac1305f0

After:

https://github.com/user-attachments/assets/983504a3-0e64-4c1f-be90-15b5cf0a2a66

Backport Needed: V15

`no-docs`
