### PR TITLE
fix: correct monthly sales history

### DIFF
--- a/frappe/utils/goal.py
+++ b/frappe/utils/goal.py
@@ -28,7 +28,7 @@ def get_monthly_results(
 			table=goal_doctype,
 			fields=[
 				DateFormat(Table[date_col], date_format).as_("month_year"),
-				Function(aggregation, goal_field),
+				Function(aggregation, Table[goal_field]),
 			],
 			filters=filters,
 			validate_filters=True,


### PR DESCRIPTION
<img width="771" height="651" alt="Screenshot from 2025-09-19 03-19-17" src="https://github.com/user-attachments/assets/f901a7ea-f6e7-4464-9946-19b055e6e042" />

### depend on pull request  https://github.com/frappe/erpnext/pull/49624

fix: correct monthly sales history 
##Bug Fix

    in Doc Type Company there are field sales_monthly_history Calculate Sales Monthly History
    Fixed an issue in sales_monthly_history where sum('base_grand_total') was treated as a string instead of a field reference.
    Now Sales Monthly History works correctly and monthly sales values are reflected in Company .

Before

Sales Monthlysales History always returned {}
After

Correct monthly sales history are displayed, e.g. {"09-2025": 1000.0}
files i edit

1- erpnext/erpnext/setup/doctype/company/company.py
2- frappe/frappe/utils/goal.py
