### PR TITLE
fix: prevent manual typing of restricted values in Link fields

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -437,6 +437,12 @@ def validate_link(doctype: str, docname: str, fields=None):
 	if not values.name:
 		return values
 
+	if not frappe.has_permission(doctype, "read", doc=values.name):
+		frappe.throw(
+			_("You do not have permission to access {0} {1}").format(frappe.bold(doctype), frappe.bold(docname)),
+			frappe.PermissionError,
+		)
+
 	if not fields:
 		frappe.local.response_headers.set("Cache-Control", "private,max-age=1800,stale-while-revalidate=7200")
 		return values

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -439,7 +439,9 @@ def validate_link(doctype: str, docname: str, fields=None):
 
 	if not frappe.has_permission(doctype, "read", doc=values.name):
 		frappe.throw(
-			_("You do not have permission to access {0} {1}").format(frappe.bold(doctype), frappe.bold(docname)),
+			_("You do not have permission to access {0} {1}").format(
+				frappe.bold(doctype), frappe.bold(docname)
+			),
 			frappe.PermissionError,
 		)
 

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -991,6 +991,10 @@ class BaseDocument:
 			):
 				cancelled_links.append((df.fieldname, docname, get_msg(df, docname)))
 
+			elif values.name and not df.get("ignore_user_permissions"):
+				if not frappe.has_permission(doctype, "read", doc=values.name):
+					invalid_links.append((df.fieldname, docname, get_msg(df, docname)))
+
 		return invalid_links, cancelled_links
 
 	def set_fetch_from_value(self, doctype, df, values):

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -991,10 +991,6 @@ class BaseDocument:
 			):
 				cancelled_links.append((df.fieldname, docname, get_msg(df, docname)))
 
-			elif values.name and not df.get("ignore_user_permissions"):
-				if not frappe.has_permission(doctype, "read", doc=values.name):
-					invalid_links.append((df.fieldname, docname, get_msg(df, docname)))
-
 		return invalid_links, cancelled_links
 
 	def set_fetch_from_value(self, doctype, df, values):


### PR DESCRIPTION
## Problem
Users can manually type values in Link fields that they don't have permission to access, bypassing permission restrictions.


closes:  #34063

**before**


https://github.com/user-attachments/assets/6eba915b-17ee-4ffa-a682-591eb3c34121

**Before**

https://github.com/user-attachments/assets/f106dd62-b421-4b0c-9ad0-d91852ac2816


