### PR TITLE
fix: mange specific roles without saving the user doc

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -431,7 +431,6 @@ frappe.ui.form.on("User Role Profile", {
 	},
 	role_profiles_remove: function (frm) {
 		if (frm.doc.role_profiles.length == 0) {
-			console.log(frm.doc.role_profiles.length == 0);
 			frm.roles_editor.disable = 0;
 			frm.roles_editor.show();
 			$(".deselect-all, .select-all").prop("disabled", false);

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -37,18 +37,6 @@ frappe.ui.form.on("User", {
 		}
 	},
 
-	role_profiles: function (frm) {
-		if (frm.doc.role_profiles && frm.doc.role_profiles.length) {
-			frm.roles_editor.disable = 1;
-			frm.call("populate_role_profile_roles").then(() => {
-				frm.roles_editor.show();
-			});
-		} else {
-			frm.roles_editor.disable = 0;
-			frm.roles_editor.show();
-		}
-	},
-
 	module_profile: function (frm) {
 		if (frm.doc.module_profile) {
 			frappe.call({
@@ -428,6 +416,26 @@ frappe.ui.form.on("User Email", {
 				frm.refresh_field("user_emails", cdn, "used_oauth");
 			}
 		);
+	},
+});
+
+frappe.ui.form.on("User Role Profile", {
+	role_profiles_add: function (frm) {
+		if (frm.doc.role_profiles.length > 0) {
+			frm.roles_editor.disable = 1;
+			frm.call("populate_role_profile_roles").then(() => {
+				frm.roles_editor.show();
+			});
+			$(".deselect-all, .select-all").prop("disabled", true);
+		}
+	},
+	role_profiles_remove: function (frm) {
+		if (frm.doc.role_profiles.length == 0) {
+			console.log(frm.doc.role_profiles.length == 0);
+			frm.roles_editor.disable = 0;
+			frm.roles_editor.show();
+			$(".deselect-all, .select-all").prop("disabled", false);
+		}
 	},
 });
 


### PR DESCRIPTION
Closes #33920

> Please provide enough information so that others can review your pull request:

- Once we select the role profile , the roles will be auto selected from role profile
- Now if a user want to select particular role and don't want roles from role profile
- System doesn't allow to do this.
- To bypass this the user must first save the doc and then select specific role
- Once the role profile is set, Select All and Unselect All button functionality works vice versa,
- But from UX point of view the buttons should be disabled if role profile exists


> Explain the **details** for making this change. What existing problem does the pull request solve?
-  Removed the code from `role_profiles` field event and added Table Multiselect  as in V16 it supports the child table events
- Fixed issue where users could not manger change roles immediately after selecting a role profile without saving the document.
- Disabled the `Select All` and `Unselect All` button when role profile exists as it is not required


<!-- Add images/recordings to better visualize the change: expected/current behavior -->

## Before

https://github.com/user-attachments/assets/f1a81ce5-551d-4097-896e-653a8f7e3393



## After
https://github.com/user-attachments/assets/2bd66a23-37ca-4df0-8bf9-ecf33c081464



