### PR TITLE
fix: remove hidden argument from filters

### DIFF
--- a/frappe/automation/workspace/tools/tools.json
+++ b/frappe/automation/workspace/tools/tools.json
@@ -327,7 +327,7 @@
    "doc_view": "",
    "label": "ToDo",
    "link_to": "ToDo",
-   "stats_filter": "[[\"ToDo\",\"status\",\"=\",\"Open\",false]]",
+   "stats_filter": "[[\"ToDo\",\"status\",\"=\",\"Open\"]]",
    "type": "DocType"
   },
   {

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -161,10 +161,6 @@ frappe.ui.Filter = class {
 		} else {
 			promise = this.update_filter_tag();
 		}
-
-		if (this.hidden) {
-			promise.then(() => this.$filter_tag.hide());
-		}
 	}
 
 	freeze() {
@@ -333,7 +329,6 @@ frappe.ui.Filter = class {
 			this.field.df.fieldname,
 			this.get_condition(),
 			this.get_selected_value(),
-			this.hidden,
 		];
 	}
 

--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -172,7 +172,7 @@ frappe.ui.FilterGroup = class {
 		return frappe.run_serially(promises).then(() => this.update_filters());
 	}
 
-	add_filter(doctype, fieldname, condition, value, hidden) {
+	add_filter(doctype, fieldname, condition, value) {
 		if (!fieldname) return Promise.resolve();
 		// adds a new filter, returns true if filter has been added
 
@@ -184,7 +184,7 @@ frappe.ui.FilterGroup = class {
 			// only allow 1 new filter at a time!
 			return Promise.resolve();
 		} else {
-			let args = [doctype, fieldname, condition, value, hidden];
+			let args = [doctype, fieldname, condition, value];
 			const promise = this.push_new_filter(args, is_new_filter);
 			return promise && promise.then ? promise : Promise.resolve();
 		}
@@ -221,7 +221,7 @@ frappe.ui.FilterGroup = class {
 		}
 	}
 
-	_push_new_filter(doctype, fieldname, condition, value, hidden = false) {
+	_push_new_filter(doctype, fieldname, condition, value) {
 		let args = {
 			parent: this.wrapper,
 			parent_doctype: this.doctype,
@@ -230,7 +230,6 @@ frappe.ui.FilterGroup = class {
 			fieldname: fieldname,
 			condition: condition,
 			value: value,
-			hidden: hidden,
 			index: this.filters.length + 1,
 			on_change: (update) => {
 				if (update) this.update_filters();


### PR DESCRIPTION
## Remove hidden argument from filters

This PR removes the `hidden` argument from filter arrays to eliminate server-side deprecation warnings.

### Problem
The filter system was generating deprecation warnings because frontend JavaScript was sending 5-element filter arrays `[doctype, fieldname, condition, value, hidden]` while the server expects 4-element arrays.

### Changes
- `frappe/public/js/frappe/ui/filters/filter_list.js`: Removed `hidden` parameter from method signature
- `frappe/public/js/frappe/ui/filters/filter.js`: Updated `get_value()` to return `[doctype, fieldname, condition, value]`
- `frappe/automation/workspace/tools/tools.json`: Fixed stats_filter format

**Closes #33987**