### PR TITLE
fix: remove add doc button in list view if user is restricted with user permission

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -51,6 +51,7 @@ frappe.views.BaseList = class BaseList {
 
 		this.can_create = frappe.model.can_create(this.doctype);
 		this.can_write = frappe.model.can_write(this.doctype);
+		this.user_permission_not_exists = frappe.model.user_permission_not_exists(this.doctype);
 
 		this.fields = [];
 		this.filters = [];

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -283,7 +283,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	set_primary_action() {
-		if (this.can_create && !frappe.boot.read_only) {
+
+		if (this.can_create && !frappe.boot.read_only && this.user_permission_not_exists) {
 			const doctype_name = __(frappe.router.doctype_layout) || __(this.doctype);
 			this.page.set_primary_action(
 				__("Add {0}", [doctype_name], "Primary action in list view"),

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -359,7 +359,7 @@ $.extend(frappe.model, {
 	},
 
 	user_permission_not_exists: function (doctype) {
-		const user_permission = frappe.boot.user.user_permission || {};
+		const user_permission = frappe.boot.user.user_permissions || {};
 		return !user_permission.hasOwnProperty(doctype);
 	},
 

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -358,6 +358,11 @@ $.extend(frappe.model, {
 		return frappe.boot.user.can_cancel.indexOf(doctype) !== -1;
 	},
 
+	user_permission_not_exists: function (doctype) {
+		const user_permission = frappe.boot.user.user_permission || {};
+		return !user_permission.hasOwnProperty(doctype);
+	},
+
 	has_workflow: function (doctype) {
 		return frappe.get_list("Workflow", { document_type: doctype, is_active: 1 }).length;
 	},


### PR DESCRIPTION
Closes  #33965

> Please provide enough information so that others can review your pull request:
- If user has `Create` access and also restricted  to one doc with user permission
- `Add` doc button will be visible in list view and after entering the all details
- When user saves the do it throws and error `Not Permitted Error`

<img width="1918" height="569" alt="image" src="https://github.com/user-attachments/assets/36737123-66eb-4360-92f7-42e50c87a5cf" />

> Explain the **details** for making this change. What existing problem does the pull request solve?
- For Better UX, `Add` button should not visible if user permission is created for the specific doctype

> Screenshots/GIFs
### If user is restricted with user permission
<img width="1911" height="494" alt="image" src="https://github.com/user-attachments/assets/b5ce24a0-ab9d-453b-98ce-1b63389797d5" />

### With no restriction
<img width="1920" height="777" alt="image" src="https://github.com/user-attachments/assets/123f37d1-8a17-43c8-9ca4-a6da817f49d6" />
