### PR TITLE
fix(number_card): use `get_meta` to check if doctype is table

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -448,7 +448,11 @@ frappe.ui.form.on("Number Card", {
 		let document_type = frm.doc.document_type;
 		let doc_is_table =
 			document_type &&
-			(await frappe.db.get_value("DocType", document_type, "istable")).message.istable;
+			(await new Promise((resolve) => {
+				frappe.model.with_doctype(document_type, () => {
+					resolve(frappe.get_meta(document_type).istable);
+				});
+			}));
 
 		frm.set_df_property("parent_document_type", "hidden", !doc_is_table);
 


### PR DESCRIPTION
Not all users can query `DocType` table
