### PR TITLE
fix: correct type check in sql_like function

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2008,7 +2008,7 @@ def get_url_to_report_with_filters(name, filters, report_type=None, doctype=None
 
 
 def sql_like(value: str, pattern: str) -> bool:
-	if not isinstance(pattern, str) and isinstance(value, str):
+	if not (isinstance(pattern, str) and isinstance(value, str)):
 		return False
 	if pattern.startswith("%") and pattern.endswith("%"):
 		return pattern.strip("%") in value


### PR DESCRIPTION
`pattern` and `value` both need to be strings for the following code to work correctly. In the case of the linked issue, `value` was `None`, leading to a `TypeError`.

Introduced in #22017

Resolves #34072
