### PR TITLE
fix: show bulk approve as failed when message has error

### DIFF
--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -345,7 +345,7 @@ def _bulk_workflow_action(docnames, doctype, action):
 						frappe.message_log.pop()
 						message_dict = {"docname": docname, "message": message.get("message")}
 
-						if message.get("raise_exception", False):
+						if message.get("raise_exception", False) or "Error" in message.get("message", ""):
 							failed_transactions[docname].append(message_dict)
 						else:
 							successful_transactions[docname].append(message_dict)


### PR DESCRIPTION
Ref Ticket: https://support.frappe.io/helpdesk/tickets/49180

When a Bulk Transaction fails it due to some error in this case it was a Mandatory Error it was showing success and not failed

Before
<img width="604" height="231" alt="Screenshot 2025-09-22 at 4 57 49 PM" src="https://github.com/user-attachments/assets/a56e0df1-a103-44be-8cc1-6c80a741955f" />

After
<img width="635" height="226" alt="Screenshot 2025-09-22 at 4 58 16 PM" src="https://github.com/user-attachments/assets/160333ed-352a-4067-b109-92381e074374" />



