### PR TITLE
ci: update yarn cache dir command

### DIFF
--- a/.github/workflows/run-indinvidual-tests.yml
+++ b/.github/workflows/run-indinvidual-tests.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         id: yarn-cache


### PR DESCRIPTION
`::set-output name` is deprecated since 3 years.

Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#patching-your-actions-and-workflows