### PR TITLE
fix: resolve issue #34079 – Allow User to Save Private Workspace settings

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.js
+++ b/frappe/desk/doctype/workspace/workspace.js
@@ -25,10 +25,8 @@ frappe.ui.form.on("Workspace", {
 		);
 
 		if (
-			frm.doc.for_user ||
-			(frm.doc.public &&
-				!frm.has_perm("write") &&
-				!frappe.user.has_role("Workspace Manager"))
+			(frm.doc.for_user && frm.doc.for_user !== frappe.session.user) ||
+			(frm.doc.public && !frappe.user.has_role("Workspace Manager"))
 		) {
 			frm.trigger("disable_form");
 


### PR DESCRIPTION
This PR fixes an issue where users with private workspace were unable to access or save their workspace settings. After this change, private workspace users can access and save their settings without any errors or restrictions.

closes #34079