### PR TITLE
fix: check Submission Queue already exists for the record

### DIFF
--- a/frappe/core/doctype/submission_queue/submission_queue.py
+++ b/frappe/core/doctype/submission_queue/submission_queue.py
@@ -164,18 +164,18 @@ class SubmissionQueue(Document):
 
 
 def queue_submission(doc: Document, action: str, alert: bool = True):
-	existing_queue = frappe.db.get_value(
+	if existing_queue := frappe.db.get_value(
 		"Submission Queue", {"ref_doctype": doc.doctype, "ref_docname": doc.name, "status": "Queued"}
-	)
-	if existing_queue:
+	):
 		frappe.msgprint(
-			_("Already in Submission Queue.You can track the progress over {0}.").format(
-				f"<a href='/app/submission-queue/{existing_queue}'><b>here</b></a>"
-			),
+			_(
+				"This document has already been queued for submission. You can track the progress over {0}."
+			).format(f"<a href='/app/submission-queue/{existing_queue}'><b>here</b></a>"),
 			indicator="orange",
 			alert=True,
 		)
 		return
+
 	queue = frappe.new_doc("Submission Queue")
 	queue.ref_doctype = doc.doctype
 	queue.ref_docname = doc.name

--- a/frappe/core/doctype/submission_queue/submission_queue.py
+++ b/frappe/core/doctype/submission_queue/submission_queue.py
@@ -164,6 +164,18 @@ class SubmissionQueue(Document):
 
 
 def queue_submission(doc: Document, action: str, alert: bool = True):
+	existing_queue = frappe.db.get_value(
+		"Submission Queue", {"ref_doctype": doc.doctype, "ref_docname": doc.name, "status": "Queued"}
+	)
+	if existing_queue:
+		frappe.msgprint(
+			_("Already in Submission Queue.You can track the progress over {0}.").format(
+				f"<a href='/app/submission-queue/{existing_queue}'><b>here</b></a>"
+			),
+			indicator="orange",
+			alert=True,
+		)
+		return
 	queue = frappe.new_doc("Submission Queue")
 	queue.ref_doctype = doc.doctype
 	queue.ref_docname = doc.name


### PR DESCRIPTION
**Issue:**  System allows us to  create more than one Submission Queue per record,results in multiple workers being assigned to the same job and  DocumentLockedError

**Before:**

[Screencast from 2025-09-23 12-33-27.webm](https://github.com/user-attachments/assets/c67dbb03-afda-4a40-9676-6f4df472c8b1)

<img width="1910" height="375" alt="Screenshot from 2025-09-23 12-39-14" src="https://github.com/user-attachments/assets/da601cf9-81eb-472b-b929-798d28000e48" />

**After:**

[Screencast from 2025-09-23 13-48-03.webm](https://github.com/user-attachments/assets/86a6fb0d-950c-4029-a20f-1997d29c8b50)


**Backport Needed V15**