### PR TITLE
refactor: Enhance grid configuration

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -702,7 +702,7 @@
    "label": "Protect Attached Files"
   },
   {
-   "default": "0",
+   "default": "20",
    "depends_on": "istable",
    "fieldname": "rows_threshold_for_grid_search",
    "fieldtype": "Int",
@@ -792,7 +792,7 @@
    "link_fieldname": "document_type"
   }
  ],
- "modified": "2025-07-19 12:23:16.296416",
+ "modified": "2025-09-23 06:48:13.555017",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -13,6 +13,7 @@
   "label",
   "search_fields",
   "grid_page_length",
+  "rows_threshold_for_grid_search",
   "link_filters",
   "column_break_5",
   "istable",
@@ -422,6 +423,13 @@
    "fieldname": "recipient_account_field",
    "fieldtype": "Data",
    "label": "Recipient Account Field"
+  },
+  {
+   "depends_on": "istable",
+   "fieldname": "rows_threshold_for_grid_search",
+   "fieldtype": "Int",
+   "label": "Rows Threshold for Grid Search",
+   "non_negative": 1
   }
  ],
  "hide_toolbar": 1,
@@ -430,7 +438,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-19 12:23:41.564203",
+ "modified": "2025-09-23 07:13:52.631903",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -75,6 +75,7 @@ class CustomizeForm(Document):
 		queue_in_background: DF.Check
 		quick_entry: DF.Check
 		recipient_account_field: DF.Data | None
+		rows_threshold_for_grid_search: DF.Int
 		search_fields: DF.Data | None
 		sender_field: DF.Data | None
 		sender_name_field: DF.Data | None
@@ -748,6 +749,7 @@ doctype_properties = {
 	"force_re_route_to_default_view": "Check",
 	"translated_doctype": "Check",
 	"grid_page_length": "Int",
+	"rows_threshold_for_grid_search": "Int",
 }
 
 docfield_properties = {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -8,7 +8,7 @@ export default class GridRow {
 		this.set_docfields();
 		this.columns = {};
 		this.columns_list = [];
-		this.depandant_fields = {
+		this.dependent_fields = {
 			mandatory: [],
 			read_only: [],
 		};
@@ -161,7 +161,7 @@ export default class GridRow {
 		this.grid.add_new_row(idx, null, show, copy_doc);
 	}
 	move() {
-		// promopt the user where they want to move this row
+		// prompt the user where they want to move this row
 		var me = this;
 		frappe.prompt(
 			{
@@ -803,7 +803,7 @@ export default class GridRow {
 			this.evaluate_depends_on_value(df.mandatory_depends_on)
 		) {
 			df.reqd = 1;
-			this.depandant_fields["mandatory"].push(df);
+			this.dependent_fields["mandatory"].push(df);
 		}
 
 		if (
@@ -812,16 +812,16 @@ export default class GridRow {
 			this.evaluate_depends_on_value(df.read_only_depends_on)
 		) {
 			df.read_only = 1;
-			this.depandant_fields["read_only"].push(df);
+			this.dependent_fields["read_only"].push(df);
 		}
 	}
 
-	refresh_depedency() {
-		this.depandant_fields["read_only"].forEach((df) => {
+	refresh_dependency() {
+		this.dependent_fields["read_only"].forEach((df) => {
 			df.read_only = 0;
 			this.set_dependant_property(df);
 		});
-		this.depandant_fields["mandatory"].forEach((df) => {
+		this.dependent_fields["mandatory"].forEach((df) => {
 			df.reqd = 0;
 			this.set_dependant_property(df);
 		});
@@ -1017,7 +1017,7 @@ export default class GridRow {
 			}
 		}
 
-		// Delay date_picker widget to prevent temparary layout shift (UX).
+		// Delay date_picker widget to prevent temporary layout shift (UX).
 		function handle_date_picker() {
 			let date_time_picker = document.querySelectorAll(".datepicker.active")[0];
 
@@ -1185,7 +1185,7 @@ export default class GridRow {
 		// df.onchange is common for all rows in grid
 		let field_on_change_function = df.onchange;
 		field.df.change = (e) => {
-			this.refresh_depedency();
+			this.refresh_dependency();
 			// trigger onchange with current grid row field as "this"
 			field_on_change_function && field_on_change_function.apply(field, [e]);
 			me.refresh_field(field.df.fieldname);

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -13,6 +13,7 @@ export default class GridRow {
 			read_only: [],
 		};
 		this.row_check_html = '<input type="checkbox" class="grid-row-check" tabIndex="-1">';
+		this.default_rows_threshold_for_grid_search = 20;
 		this.make();
 	}
 	make() {
@@ -871,7 +872,7 @@ export default class GridRow {
 		let show_length =
 			this.grid?.meta?.rows_threshold_for_grid_search > 0
 				? this.grid.meta.rows_threshold_for_grid_search
-				: 20;
+				: this.default_rows_threshold_for_grid_search;
 		this.show_search =
 			this.show_search &&
 			(this.grid?.data?.length >= show_length || this.grid.filter_applied);


### PR DESCRIPTION
**Issue:** For grid configuration, some PR did not backport to v-15. And there are some missing implementation which is require to make it fully functional

---

**Previous PRs:**

- https://github.com/frappe/frappe/pull/31371
- https://github.com/frappe/frappe/pull/31382
- https://github.com/frappe/frappe/pull/32567

---

**Changes:**

1. Update default value of **Rows Threshold for Grid Search** to `20`
2. Used variable instead of hard coded rows threshold
3. Update the **Customization Form** for `Rows Threshold for Grid Search`
4. Removed typos

---

@iamejaaz below tasks requires?

- [ ] patch to update default value for **Rows Threshold for Grid Search**
- [ ] validation for `Rows Threshold for Grid Search`, that is must never greater than `Grid Page Length`

---

> [!IMPORTANT]
> These 2 PR need to be backport to V-15 
> - https://github.com/frappe/frappe/pull/31382
> - https://github.com/frappe/frappe/pull/32567

- **And this PR need to be backport**