### PR TITLE
fix: don't call `file.check_content()` twice

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -141,7 +141,6 @@ class File(Document):
 		self.validate_file_url()
 		self.validate_file_on_disk()
 		self.file_size = frappe.form_dict.file_size or self.file_size
-		self.check_content()
 
 	def validate_attachment_references(self):
 		if not self.attached_to_doctype:


### PR DESCRIPTION
This first call was sometimes done when `_content` wasn't set, resulting in:

```
  File "apps/frappe/frappe/core/doctype/file/file.py", line 138, in validate
    self.check_content()
  File "apps/frappe/frappe/core/doctype/file/file.py", line 381, in check_content
    if self.file_type == "PDF" and self._content and pdf_contains_js(self._content):
                                   ^^^^^^^^^^^^^
AttributeError: 'File' object has no attribute '_content'
```

Just calling it in `write_file()` seems good enough

<hr>

Reference: support ticket 49058
