### PR TITLE
feat: Optionally show a warning when opening an external link

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -30,6 +30,7 @@
   "apply_strict_user_permissions",
   "column_break_21",
   "allow_older_web_view_links",
+  "show_external_link_warning",
   "security_tab",
   "security",
   "session_expiry",
@@ -744,12 +745,19 @@
    "fieldtype": "Int",
    "label": "Max signups allowed per hour",
    "non_negative": 1
+  },
+  {
+   "default": "Never",
+   "fieldname": "show_external_link_warning",
+   "fieldtype": "Select",
+   "label": "Show External Link Warning",
+   "options": "Never\nAsk\nAlways"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2025-09-03 10:52:38.096662",
+ "modified": "2025-09-24 16:04:02.016562",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -97,6 +97,7 @@ class SystemSettings(Document):
 		session_expiry: DF.Data | None
 		setup_complete: DF.Check
 		show_absolute_datetime_in_timeline: DF.Check
+		show_external_link_warning: DF.Literal["Never", "Ask", "Always"]
 		store_attached_pdf_document: DF.Check
 		strip_exif_metadata_from_uploaded_images: DF.Check
 		time_format: DF.Literal["HH:mm:ss", "HH:mm"]

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -181,6 +181,7 @@ def get():
 	bootinfo["user"]["impersonated_by"] = frappe.session.data.get("impersonated_by")
 	bootinfo["navbar_settings"] = frappe.client_cache.get_doc("Navbar Settings")
 	bootinfo.has_app_updates = has_app_update_notifications()
+	bootinfo.show_external_link_warning = frappe.get_system_settings("show_external_link_warning")
 
 	return bootinfo
 


### PR DESCRIPTION
This PR adds an **optional** feature to show a warning modal to desk users before they navigate to an external link from within the Desk. The feature has three modes: "Never" = the current behavior, "Always" = always show the popup for external links, and "Ask" which adds a checkbox to ignore a whole domain (see screen capture below).

<img width="532" height="239" alt="image" src="https://github.com/user-attachments/assets/182b2b9c-2194-45a9-9444-e5aa8dadef72" />

---

The main goal is to add a basic barrier against phishing attacks that could happen inside the Desk (yes it happens).
Hopefully, showing a warning + the full URL might encourage users to pause and actually think before clicking the link again.

This is kinda effective when the link is added in a Comment, because the text is fully customizable there, this includes obfuscating an URL with a slight misspelling, like [https://myerp.example.com](https://myrep.example.com) (which links to my**re**p.example.com).

Obviously this does not prevent all the social engineering attacks, but if this is coupled with the same mechanism in other tools (mail client, videoconference tool, etc.), it could actually work. Also it's a nice way to make people more careful about operational cybersecurity. We could even add a "Report malicious URL" button but this need to be thinked about more.


---

# Documentation

I wrote a draft in https://docs.frappe.io/framework/user/en/security-faqs _(patch `87i0huqtja`)_

> ### Frappe allows adding links to external websites in comments
> In a collaborative environment like Frappe, linking to external tools and resources is often a necessary part of the workflow, so disabling them completely isn't practical. To address the potential phishing risks, it is possible to display a warning modal before a user leaves the Desk. This feature can be enabled from "System Settings" > "Show External Link Warning".
