### PR TITLE
feat: report view bulk column select

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1610,6 +1610,18 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 						},
 					});
 
+					const $bulk = $(`
+						<div class="mb-3">
+							<button class="btn btn-default btn-xs" data-action="select_all">${__("Select All")}</button>
+							<button class="btn btn-default btn-xs" data-action="unselect_all">${__("Unselect All")}</button>
+						</div>
+					`);
+					const toggleAll = (checked) =>
+						d.$wrapper.find(":checkbox").prop("checked", checked).trigger("change");
+					$bulk.on("click", "[data-action=select_all]", () => toggleAll(true));
+					$bulk.on("click", "[data-action=unselect_all]", () => toggleAll(false));
+					d.$body.prepend($bulk);
+
 					d.$body.prepend(`
 						<div class="columns-search">
 							<input type="text" placeholder="${__(

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1585,7 +1585,10 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 						fields: this.get_dialog_fields(),
 						primary_action: (values) => {
 							// doctype fields
-							let fields = values[this.doctype].map((f) => [f, this.doctype]);
+							let fields = (values[this.doctype] || []).map((f) => [
+								f,
+								this.doctype,
+							]);
 							delete values[this.doctype];
 
 							// child table fields


### PR DESCRIPTION
#### Summary

This PR introduces bulk selection actions in the **Pick Columns** dialog of Report View. Users can now quickly select or unselect all available columns with a single click.

#### Changes

* Added **“Select All”** and **“Unselect All”** buttons above the column list.
* Implemented a `toggleAll` function to update all checkboxes at once.
* Fixed a potential error when no columns are selected by safely handling `values[this.doctype]`.

#### Benefits

* Improves usability when working with large reports.
* Saves time by avoiding manual checkbox clicks for each column.
* Prevents runtime errors when all columns are unselected.

**Before**
<img width="895" height="675" alt="image" src="https://github.com/user-attachments/assets/f150474e-ff64-4599-9409-f1691695026d" />

**After**

[Screencast from 12-10-25 12:21:41 PM IST.webm](https://github.com/user-attachments/assets/cc3e8ec0-ae92-4880-bf60-c4ef5499d848)


`no-docs`