### PR TITLE
fix: try setting request IP from request.remote_addr if possible

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -66,6 +66,9 @@ class HTTPRequest:
 		elif frappe.get_request_header("REMOTE_ADDR"):
 			frappe.local.request_ip = frappe.get_request_header("REMOTE_ADDR")
 
+		elif frappe.request and getattr(frappe.request, "remote_addr", None):
+			frappe.local.request_ip = frappe.request.remote_addr
+
 		else:
 			frappe.local.request_ip = "127.0.0.1"
 


### PR DESCRIPTION
Reference: support ticket 49527

<hr>

Some misconfigured setups don't have the IP set in the headers

<hr>

Thanks to Praveen Kumar for reporting an issue that turned out to be caused by this.

