### PR TITLE
feat: add Make 'name' searchable in Global Search in custom form

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -44,6 +44,7 @@
   "force_re_route_to_default_view",
   "column_break_29",
   "show_preview_popup",
+  "show_name_in_global_search",
   "email_settings_section",
   "default_email_template",
   "column_break_26",
@@ -430,6 +431,12 @@
    "fieldtype": "Int",
    "label": "Rows Threshold for Grid Search",
    "non_negative": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "show_name_in_global_search",
+   "fieldtype": "Check",
+   "label": "Make \"name\" searchable in Global Search"
   }
  ],
  "hide_toolbar": 1,

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -79,6 +79,7 @@ class CustomizeForm(Document):
 		search_fields: DF.Data | None
 		sender_field: DF.Data | None
 		sender_name_field: DF.Data | None
+		show_name_in_global_search: DF.Check
 		show_preview_popup: DF.Check
 		show_title_field_in_link: DF.Check
 		sort_field: DF.Literal[None]
@@ -307,6 +308,8 @@ class CustomizeForm(Document):
 		)
 
 	def set_property_setters_for_doctype(self, meta):
+		if self.get("show_name_in_global_search") != meta.get("show_name_in_global_search"):
+			self.flags.rebuild_doctype_for_global_search = True
 		for prop, prop_type in doctype_properties.items():
 			if self.get(prop) != meta.get(prop):
 				self.make_property_setter(prop, self.get(prop), prop_type)
@@ -736,6 +739,7 @@ doctype_properties = {
 	"track_views": "Check",
 	"allow_auto_repeat": "Check",
 	"allow_import": "Check",
+	"show_name_in_global_search": "Check",
 	"show_preview_popup": "Check",
 	"default_email_template": "Data",
 	"email_append_to": "Check",


### PR DESCRIPTION
Make "name" searchable in Global Search  is not available in custom form.


## Before


https://github.com/user-attachments/assets/7b8dc262-f131-4551-a96e-15d6a749907c


## After

https://github.com/user-attachments/assets/7931600e-2bd4-4fa3-b724-5d95ed01b9b1

>no-docs

Closes #34107