### PR TITLE
fix: do not show debug message when traceback is disallowed

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -212,7 +212,7 @@ def _make_logs_v2():
 	if frappe.local.message_log:
 		response["messages"] = frappe.local.message_log
 
-	if frappe.debug_log:
+	if frappe.debug_log and is_traceback_allowed():
 		response["debug"] = [{"message": m} for m in frappe.local.debug_log]
 
 

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -199,7 +199,7 @@ def _make_logs_v1():
 			[orjson.dumps(d).decode() for d in frappe.local.message_log]
 		).decode()
 
-	if frappe.debug_log:
+	if frappe.debug_log and is_traceback_allowed():
 		response["_debug_messages"] = orjson.dumps(frappe.local.debug_log).decode()
 
 	if frappe.flags.error_message:


### PR DESCRIPTION
Hi,

> Please provide enough information so that others can review your pull request:

Currently, it is possible to disable error tracebacks in API request errors.
But we noticed, that this setting doesn't disable Debug log messages in the javascript console.
Especially SQL syntax errors.
Eg.

<img width="1412" height="754" alt="image" src="https://github.com/user-attachments/assets/6973bcf1-503c-4250-8571-d70bb4793693" />

As you can see, the whole SQL query is revealed to the end user, which is fine in a development environment, but could be a security issue in a production environment.

> Explain the **details** for making this change. What existing problem does the pull request solve?

My proposal is to simply apply the same rule as for `frappe.error_log` and only display debug messages when traceback is allowed.


> Screenshots/GIFs

Behavior after the change and with traceback disallowed:
<img width="1453" height="340" alt="image" src="https://github.com/user-attachments/assets/0dbf8b49-e169-46b2-930d-0a7d91a43aef" />



<!-- Add images/recordings to better visualize the change: expected/current behavior -->

Thanks in advance for your feedback.
