### PR TITLE
fix: HTML sanitation for XSS mitigation

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -25,6 +25,7 @@ from frappe.utils import (
 	get_url,
 )
 from frappe.utils.file_manager import is_safe_path
+from frappe.utils.html_utils import escape_html
 from frappe.utils.image import optimize_image, strip_exif_data
 from frappe.utils.pdf import pdf_contains_js
 
@@ -784,7 +785,7 @@ class File(Document):
 	def create_attachment_record(self):
 		icon = ' <i class="fa fa-lock text-warning"></i>' if self.is_private else ""
 		file_url = quote(frappe.safe_encode(self.file_url), safe="/:") if self.file_url else self.file_name
-		file_name = self.file_name or self.file_url
+		file_name = escape_html(self.file_name or self.file_url)
 
 		self.add_comment_in_reference_doc(
 			"Attachment",

--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -416,7 +416,7 @@ function format_content_for_timeline(content) {
 
 function get_user_link(user) {
 	const user_display_text = frappe.user_info(user).fullname || "";
-	return frappe.utils.get_form_link("User", user, true, user_display_text);
+	return frappe.utils.get_form_link("User", user, true, frappe.utils.xss_sanitise(user_display_text));
 }
 
 function get_user_message(user, message_self, message_other) {

--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -416,7 +416,12 @@ function format_content_for_timeline(content) {
 
 function get_user_link(user) {
 	const user_display_text = frappe.user_info(user).fullname || "";
-	return frappe.utils.get_form_link("User", user, true, frappe.utils.xss_sanitise(user_display_text));
+	return frappe.utils.get_form_link(
+		"User",
+		user,
+		true,
+		frappe.utils.xss_sanitise(user_display_text)
+	);
 }
 
 function get_user_message(user, message_self, message_other) {

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -126,7 +126,7 @@ frappe.ui.form.Attachments = class Attachments {
 			<a href="${file_url}" target="_blank" title="${frappe.utils.escape_html(file_name)}"
 				class="ellipsis attachment-file-label"
 			>
-				<span>${file_name}</span>
+				<span>${frappe.utils.xss_sanitise(file_name)}</span>
 			</a>`;
 
 		let remove_action = null;


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

Hi,

This PR aims at correcting small XSS sanitation issues that we were made aware of.

1.When a file is created, a comment is generated, but the file name is not escaped before insertion in the database
2. One can add HTML text in its User first or last name and it is rendered as HTML instead of being sanitized upfront
3. File names are currently not XSS sanitized when displayed in forms

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

Here are the screenshots, after the fix, for each point:
1.
<img width="1049" height="276" alt="image" src="https://github.com/user-attachments/assets/9fb875da-d59c-473b-98e5-d9d4f349aefa" />


2.
<img width="816" height="68" alt="image" src="https://github.com/user-attachments/assets/36b026d3-6c7a-4683-a354-6cb15822ac2f" />


3.
<img width="488" height="208" alt="image" src="https://github.com/user-attachments/assets/cb1f5b1b-28b3-404f-adc1-b0d50f9fccbd" />


<!-- Add images/recordings to better visualize the change: expected/current behavior -->

Thanks in advance for your feedback