### PR TITLE
feat: warn on multiple class overrides

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -296,6 +296,14 @@ def install_app(name, verbose=False, set_as_patched=True, force=False):
 
 	print(f"\nInstalling {name}...")
 
+	other_class_overrides = frappe.get_hooks("override_doctype_class")
+	if (
+		other_class_overrides
+		and app_hooks.override_doctype_class
+		and any(dt in app_hooks.override_doctype_class for dt in other_class_overrides)
+	):
+		click.secho(f"App {name} overrides a doctype that is already overridden by another app.", fg="yellow")
+
 	if name != "frappe":
 		frappe.only_for("System Manager")
 


### PR DESCRIPTION
Print a warning when we install an app that overrides a controller that is already overridden by an installed app.

Same on migrate, since overrides can be introduced via updates after first install:

<img width="802" height="102" alt="Bildschirmfoto 2025-09-26 um 17 48 17" src="https://github.com/user-attachments/assets/a7bb41a5-3d8e-4a7b-a047-6e6894825a5e" />


> no-docs