### PR TITLE
feat: enhance version tracking by adding inserted values and creator …

### DIFF
--- a/frappe/core/doctype/version/version.py
+++ b/frappe/core/doctype/version/version.py
@@ -57,13 +57,19 @@ class Version(Document):
 
 	def for_insert(self, doc: Document) -> bool:
 		updater_reference = doc.flags.updater_reference
-		if not updater_reference:
-			return False
 
 		data = {
 			"creation": doc.creation,
 			"updater_reference": updater_reference,
 			"created_by": doc.owner,
+			"inserted": [
+				[fieldname, value]
+				for fieldname, value in doc.get_valid_dict(convert_dates_to_str=True).items()
+			],
+			"row_added": [
+				[child.parentfield, child.get_valid_dict(convert_dates_to_str=True)]
+				for child in doc.get_all_children()
+			],
 		}
 		self.set_impersonator(data)
 		self.ref_doctype = doc.doctype

--- a/frappe/core/doctype/version/version_view.html
+++ b/frappe/core/doctype/version/version_view.html
@@ -94,3 +94,56 @@
 	</tbody>
 {% endif %}
 </div>
+
+{% if data.inserted && data.inserted.length %}
+<h4>{{ __("Values Inserted") }}</h4>
+<table class="table table-bordered">
+	<thead>
+		<tr>
+			<td style="width: 33%">{{ __("Property") }}</td>
+			<td style="width: 33%">{{ __("Original Value") }}</td>
+		</tr>
+	</thead>
+	<tbody>
+		{% for item in data.inserted %}
+		<tr>
+			<td>{{ frappe.meta.get_label(doc.ref_doctype, item[0]) }}</td>
+			<td class="diff-add">{{ getEscapedValue(item[1]) }}</td>
+		</tr>
+		{% endfor %}
+	</tbody>
+</table>
+{% endif %}
+
+{% if data.row_added && data.row_added.length %}
+<h3>{{ __("Rows Added") }}</h3>
+<table class="table table-bordered">
+	<thead>
+		<tr>
+			<td style="width: 33%">{{ __("Property") }}</td>
+			<td style="width: 67%">{{ __("Rows Added") }}</td>
+		</tr>
+	</thead>
+	<tbody>
+		{% for item in data.row_added %}
+		<tr>
+			<td>{{ frappe.meta.get_label(doc.ref_doctype, item[0]) }}</td>
+			<td class="diff-add">
+				{% var item_keys = Object.keys(item[1]).sort(); %}
+				<table class="table table-bordered">
+					<tbody>
+						{% for row_key in item_keys %}
+						<tr>
+							<td class="small">{{ row_key }}</td>
+							<td class="small">{{ getEscapedValue(item[1][row_key]) }}</td>
+						</tr>
+						{% endfor %}
+					</tbody>
+				</table>
+			</td>
+		</tr>
+		{% endfor %}
+	</tbody>
+</table>
+
+{% endif %}

--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -253,6 +253,16 @@ function get_version_timeline_content(version_doc, frm) {
 		);
 		out.push(get_version_comment(version_doc, message));
 	}
+
+	if (data.created_by && data.inserted) {
+		let message = get_user_message(
+			version_doc.owner,
+			__("You created this document", null, "Form timeline"),
+			__("{0} created this document", [get_user_link(version_doc.owner)], "Form timeline")
+		);
+		out.push(get_version_comment(version_doc, message));
+	}
+
 	const impersonated_by = data.impersonated_by;
 
 	if (impersonated_by) {


### PR DESCRIPTION
### Description

This PR addresses the missing audit trail when creating new documents in DocTypes with **Track Changes** enabled.
Previously, no `Version` entry was generated on the **first Save (insert)** — only subsequent edits produced diffs. This gap made it impossible for auditors and admins to verify the initial values entered at document creation.

### Solution

* Added logic in `version.py`:

  * Updated the `for_insert()` method to create a **Version snapshot on insert** when Track Changes is enabled.
  * Captures the **full initial state** of the document, including child tables if present.

* Updated `version_view.html`:

  * Enhanced template rendering to handle the new keys introduced for insert snapshots.
  * Ensures the initial snapshot displays consistently alongside later diffs.

* Updated `version_timeline_content_builder.js`:

  * Added checks for the new key to properly render the initial snapshot in the Timeline footer.
  * Ensures users can see the creation entry with baseline values.

### Acceptance Criteria

* ✅ When Track Changes is enabled, creating a new record now produces a `Version` entry.
* ✅ Initial Version payload includes:

  * All tracked fields with their baseline values.
  * Child rows (if enabled).
* ✅ The initial Version entry is visible in the Timeline, ensuring auditors have a complete history from creation onward.

### Screenshots

Issue examples (before fix):
[Provided in the issue description]

### Why This Matters

This change closes an audit gap by ensuring that the very first values entered in a tracked DocType are preserved in a `Version` snapshot.
It improves compliance, accountability, and traceability — critical in regulated environments.

### Related Issue

Fixes: #34115 


### Images

<img width="4552" height="972" alt="image" src="https://github.com/user-attachments/assets/9ed1ec3a-a370-4a5d-b116-56b70b9fc253" />

<img width="1332" height="934" alt="Screenshot from 2025-09-27 03-30-00" src="https://github.com/user-attachments/assets/8a71c3f4-603f-4743-a632-a1cfdb156a61" />

<img width="1332" height="934" alt="Screenshot from 2025-09-27 03-30-15" src="https://github.com/user-attachments/assets/65d857bb-610b-42ff-b8d7-11e443126a53" />
