### PR TITLE
feat: Add WebAuthn passkey authentication support

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -43,6 +43,7 @@
   "allow_login_using_mobile_number",
   "allow_login_using_user_name",
   "column_break_uhqk",
+  "login_with_passkey",
   "login_with_email_link",
   "login_with_email_link_expiry",
   "rate_limit_email_link_login",
@@ -752,6 +753,12 @@
    "fieldtype": "Select",
    "label": "Show External Link Warning",
    "options": "Never\nAsk\nAlways"
+  },
+  {
+   "default": "0",
+   "fieldname": "login_with_passkey",
+   "fieldtype": "Check",
+   "label": "Login with Passkey"
   }
  ],
  "icon": "fa fa-cog",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -70,6 +70,7 @@ class SystemSettings(Document):
 		log_api_requests: DF.Check
 		login_with_email_link: DF.Check
 		login_with_email_link_expiry: DF.Int
+		login_with_passkey: DF.Check
 		logout_on_password_reset: DF.Check
 		max_auto_email_report_per_user: DF.Int
 		max_file_size: DF.Int

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -120,6 +120,9 @@ frappe.ui.form.on("User", {
 
 		if (!frm.is_new()) {
 			if (has_access_to_edit_user()) {
+				// Add passkey management buttons if enabled and user can manage own passkeys
+				frm.trigger("setup_passkey_buttons");
+
 				frm.add_custom_button(
 					__("Set User Permissions"),
 					function () {
@@ -363,6 +366,37 @@ frappe.ui.form.on("User", {
 			window.location.reload();
 		}
 	},
+	setup_passkey_buttons: function (frm) {
+		// Only show passkey buttons for current user (not Guest/Administrator)
+		if (
+			frappe.session.user !== frm.doc.name ||
+			["Guest", "Administrator"].includes(frm.doc.name)
+		) {
+			return;
+		}
+
+		frappe.db
+			.get_single_value("System Settings", "login_with_passkey")
+			.then((isEnabled) => {
+				if (!isEnabled) return;
+
+				frm.add_custom_button(
+					__("Register New"),
+					() => start_passkey_registration(frm),
+					__("Passkeys")
+				);
+
+				frm.add_custom_button(
+					__("Manage / Revoke"),
+					() => show_active_passkeys(frm),
+					__("Passkeys")
+				);
+			})
+			.catch((error) => {
+				console.warn("Failed to check passkey settings:", error);
+			});
+	},
+
 	setup_impersonation: function (frm) {
 		if (
 			frappe.session.user === "Administrator" &&
@@ -498,4 +532,258 @@ function show_api_key_dialog(api_key, api_secret) {
 		"yellow",
 		1
 	);
+}
+
+async function start_passkey_registration(frm) {
+	if (!navigator.credentials) {
+		frappe.msgprint("Passkeys are not supported in this browser.");
+		return;
+	}
+
+	try {
+		const challengeResponse = await frappe.call({
+			method: "frappe.integrations.passkey.register_challenge",
+			args: { email: frm.doc.email, user_display_name: frm.doc.full_name },
+		});
+
+		const credential = await create_new_passkey(challengeResponse.message);
+
+		const credentialResponse = {
+			id: credential.id,
+			rawId: frappe.utils.buffer_to_base64url(credential.rawId),
+			response: {
+				attestationObject: frappe.utils.buffer_to_base64url(
+					credential.response.attestationObject
+				),
+				clientDataJSON: frappe.utils.buffer_to_base64url(
+					credential.response.clientDataJSON
+				),
+			},
+			type: credential.type,
+			title: detect_device_label(),
+		};
+
+		await verify_passkey_with_server(frm, credentialResponse);
+	} catch (error) {
+		show_error_message(error);
+	}
+}
+
+async function create_new_passkey(publicKeyOptions) {
+	const credential = await navigator.credentials.create({
+		publicKey: prepare_publickey_options(publicKeyOptions),
+	});
+
+	if (!credential) {
+		throw new Error("User cancelled passkey creation");
+	}
+
+	return credential;
+}
+
+function prepare_publickey_options(options) {
+	const prepared = { ...options };
+	prepared.challenge = frappe.utils.base64url_to_uint8array(options.challenge);
+	prepared.user.id = frappe.utils.base64url_to_uint8array(options.user.id);
+
+	if (prepared.excludeCredentials) {
+		prepared.excludeCredentials = prepared.excludeCredentials.map((credential) => ({
+			...credential,
+			id: frappe.utils.base64url_to_uint8array(credential.id),
+		}));
+	}
+	return prepared;
+}
+
+function detect_device_label() {
+	const userAgent = navigator.userAgent;
+	const browserMatch = userAgent.match(/(opera|chrome|safari|firefox|msie|edg)\/?\s*([\d\.]+)/i);
+	const browser = browserMatch?.[1] || "Unknown Browser";
+	const platform = navigator.userAgentData?.platform || navigator.platform || "Unknown Device";
+	return `${browser} - ${platform}`;
+}
+
+async function verify_passkey_with_server(frm, credentialResponse) {
+	try {
+		const response = await frappe.call({
+			method: "frappe.integrations.passkey.register_verify",
+			args: { email: frm.doc.email, credential: credentialResponse },
+		});
+
+		if (response.message.success) {
+			return await prompt_passkey_label(frm, response.message.credential_id);
+		}
+
+		const errorMessage = response.message.error || "Passkey registration failed.";
+		frappe.msgprint(errorMessage);
+	} catch (error) {
+		show_error_message(error);
+	}
+}
+
+function prompt_passkey_label(frm, credentialId) {
+	return new Promise((resolve, reject) => {
+		frappe.prompt(
+			[{ fieldname: "label", label: "Passkey Label", fieldtype: "Data" }],
+			async (values) => {
+				try {
+					await frappe.call({
+						method: "frappe.integrations.passkey.update_passkey_label",
+						args: { credential_id: credentialId, label: values.label },
+					});
+
+					frappe.msgprint("Passkey registered successfully!");
+					frm.reload_doc();
+					resolve();
+				} catch (error) {
+					show_error_message(error);
+					reject(error);
+				}
+			},
+			__("Passkey registered. Add Label for Passkey"),
+			__("Save")
+		);
+	});
+}
+
+function show_active_passkeys(frm) {
+	frappe
+		.call({
+			method: "frappe.integrations.passkey.get_active_passkeys",
+			args: { user: frm.doc.name },
+		})
+		.then((response) => {
+			const passkeys = response.message || [];
+
+			if (!passkeys.length) {
+				frappe.msgprint("No active passkeys found.");
+				return;
+			}
+
+			const dialog = new frappe.ui.Dialog({
+				title: `Active Passkeys for ${frm.doc.full_name}`,
+				fields: [
+					{
+						fieldname: "passkey_list",
+						fieldtype: "HTML",
+						options: generate_passkey_list_html(passkeys),
+					},
+				],
+				primary_action_label: "Close",
+				primary_action() {
+					dialog.hide();
+				},
+			});
+
+			dialog.show();
+
+			dialog.$wrapper.on("click", ".btn-revoke-passkey", function () {
+				const passkeyName = $(this).data("name");
+				const passkeyTitle = $(this).data("title");
+
+				dialog.hide();
+
+				frappe.confirm(
+					`Are you sure you want to revoke passkey: ${frappe.utils.escape_html(
+						passkeyTitle
+					)}?`,
+					() => {
+						frappe
+							.call({
+								method: "frappe.integrations.passkey.revoke_passkey",
+								args: { name: passkeyName },
+							})
+							.then((revokeResponse) => {
+								if (revokeResponse.message?.success) {
+									frappe.msgprint(
+										`Passkey "${frappe.utils.escape_html(
+											passkeyTitle
+										)}" revoked successfully.`
+									);
+									frm.reload_doc();
+								} else {
+									show_error_message({
+										name: "Revoke Failed",
+										message: revokeResponse.message?.error || "Unknown error",
+									});
+									dialog.show();
+								}
+							})
+							.catch((error) => {
+								show_error_message(error);
+								dialog.show();
+							});
+					},
+					() => {
+						dialog.show();
+					}
+				);
+			});
+		})
+		.catch((error) => {
+			show_error_message(error);
+		});
+}
+
+function generate_passkey_list_html(passkeys) {
+	return passkeys
+		.map((passkey) => {
+			const title = frappe.utils.escape_html(passkey.title || "Untitled");
+			const addedDate = passkey.creation
+				? frappe.datetime.str_to_user(passkey.creation)
+				: "N/A";
+			const lastUsed =
+				passkey.sign_count > 0 && passkey.last_used
+					? frappe.datetime.comment_when(passkey.last_used)
+					: "Never";
+
+			return `
+				<div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:5px;">
+					<div>
+						<strong>${title}</strong><br>
+						<small>Added on ${addedDate} | Last used ${lastUsed}</small>
+					</div>
+					<button class="btn btn-xs btn-danger btn-revoke-passkey"
+						data-name="${frappe.utils.escape_html(passkey.name)}"
+						data-title="${title}">
+						Revoke
+					</button>
+				</div>`;
+		})
+		.join("");
+}
+
+function show_error_message(error) {
+	if (!error) {
+		frappe.msgprint("An unknown error occurred.");
+		return;
+	}
+
+	let title = "Error";
+	let message = "An error occurred";
+
+	// Handle WebAuthn specific errors
+	if (error.name === "NotAllowedError") {
+		title = "Passkey Error";
+		message = "User cancelled or passkey operation not allowed.";
+	} else if (error.name === "InvalidStateError") {
+		title = "Passkey Error";
+		message = "Passkey already registered for this device.";
+	} else if (error.name === "NotSupportedError") {
+		title = "Passkey Error";
+		message = "Passkeys are not supported on this device.";
+	} else if (error.name === "SecurityError") {
+		title = "Passkey Error";
+		message = "Security error occurred during passkey operation.";
+	} else {
+		// Handle generic errors
+		title = error.name || "Error";
+		message = error.message || "An error occurred";
+	}
+
+	frappe.msgprint({
+		title: title,
+		message: message,
+		indicator: "red",
+	});
 }

--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -66,6 +66,7 @@
   "new_password",
   "logout_all_sessions",
   "reset_password_key",
+  "passkey_user_id",
   "last_reset_password_key_generated_on",
   "last_password_reset_date",
   "redirect_url",
@@ -835,6 +836,15 @@
    "fieldname": "show_absolute_datetime_in_timeline",
    "fieldtype": "Check",
    "label": "Show Absolute Datetime in Timeline"
+  },
+  {
+   "fieldname": "passkey_user_id",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Passkey User ID",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "icon": "fa fa-user",
@@ -888,7 +898,7 @@
   }
  ],
  "make_attachments_public": 1,
- "modified": "2025-06-05 23:55:27.884061",
+ "modified": "2025-09-27 16:50:19.275654",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -117,6 +117,7 @@ class User(Document):
 		new_password: DF.Password | None
 		notifications: DF.Check
 		onboarding_status: DF.SmallText | None
+		passkey_user_id: DF.Data | None
 		phone: DF.Data | None
 		redirect_url: DF.SmallText | None
 		reset_password_key: DF.Data | None
@@ -824,6 +825,14 @@ class User(Document):
 
 	def validate_ip_addr(self):
 		self.restrict_ip = ",".join(self.get_restricted_ip_list())
+
+	def get_passkey_user_id(self):
+		if not self.passkey_user_id:
+			from webauthn.helpers import bytes_to_base64url, generate_user_handle
+
+			self.passkey_user_id = bytes_to_base64url(generate_user_handle())
+			self.save(ignore_permissions=True)
+		return self.passkey_user_id
 
 
 @frappe.whitelist()

--- a/frappe/integrations/doctype/user_passkey/test_user_passkey.py
+++ b/frappe/integrations/doctype/user_passkey/test_user_passkey.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestUserPasskey(IntegrationTestCase):
+	"""
+	Integration tests for UserPasskey.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/frappe/integrations/doctype/user_passkey/user_passkey.js
+++ b/frappe/integrations/doctype/user_passkey/user_passkey.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("User Passkey", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe/integrations/doctype/user_passkey/user_passkey.json
+++ b/frappe/integrations/doctype/user_passkey/user_passkey.json
@@ -1,0 +1,95 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:PK-{YYYY}-{#####}",
+ "creation": "2025-09-06 22:00:06.929935",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "user",
+  "sign_count",
+  "column_break_yptd",
+  "status",
+  "credential_id",
+  "public_key"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title",
+   "read_only": 1
+  },
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "User",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sign_count",
+   "fieldtype": "Int",
+   "label": "Sign Count",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_yptd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Active",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "\nActive\nRevoked",
+   "read_only": 1
+  },
+  {
+   "fieldname": "credential_id",
+   "fieldtype": "Data",
+   "label": "Credential ID",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "public_key",
+   "fieldtype": "Small Text",
+   "label": "Public Key",
+   "no_copy": 1,
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "in_create": 1,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-09-27 17:15:24.564679",
+ "modified_by": "Administrator",
+ "module": "Integrations",
+ "name": "User Passkey",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/integrations/doctype/user_passkey/user_passkey.py
+++ b/frappe/integrations/doctype/user_passkey/user_passkey.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class UserPasskey(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		credential_id: DF.Data | None
+		public_key: DF.SmallText | None
+		sign_count: DF.Int
+		status: DF.Literal["", "Active", "Revoked"]
+		title: DF.Data | None
+		user: DF.Link | None
+	# end: auto-generated types
+
+	pass

--- a/frappe/integrations/passkey.py
+++ b/frappe/integrations/passkey.py
@@ -1,0 +1,368 @@
+import json
+import re
+import uuid
+from urllib.parse import urlparse
+
+from webauthn import (
+	generate_authentication_options,
+	generate_registration_options,
+	verify_authentication_response,
+	verify_registration_response,
+)
+from webauthn.helpers import base64url_to_bytes, bytes_to_base64url, generate_user_handle
+from webauthn.helpers.options_to_json_dict import options_to_json_dict
+from webauthn.helpers.structs import (
+	AuthenticatorSelectionCriteria,
+	PublicKeyCredentialDescriptor,
+	PublicKeyCredentialType,
+	ResidentKeyRequirement,
+	UserVerificationRequirement,
+)
+
+import frappe
+from frappe import _
+from frappe.auth import LoginManager
+
+# Constants
+MAX_PASSKEYS_PER_USER = 3
+CHALLENGE_EXPIRY_SECONDS = 300
+PASSKEY_BATCH_SIZE = 1000
+
+
+def _sanitize_cache_key(key: str) -> str:
+	"""Sanitize cache key to prevent path traversal"""
+	return re.sub(r"[^a-zA-Z0-9_@.-]", "_", key)
+
+
+def _validate_user_access(user: str) -> None:
+	"""Validate user exists and current user has access"""
+	if not user:
+		frappe.throw(_("User is required"))
+
+	if not frappe.db.exists("User", user):
+		frappe.throw(_("Invalid user"))
+
+	# Only allow users to manage their own passkeys (except System Manager)
+	if user != frappe.session.user and not frappe.has_permission("User", "write"):
+		frappe.throw(_("Access denied"))
+
+
+def _validate_passkey_registration(email: str) -> list:
+	"""Validate user can register new passkey and return existing passkeys"""
+	_validate_user_access(email)
+
+	user_active_passkeys = frappe.get_all(
+		"User Passkey", filters={"user": email, "status": "Active"}, fields=["credential_id"]
+	)
+
+	if len(user_active_passkeys) >= MAX_PASSKEYS_PER_USER:
+		frappe.throw(
+			_("You can have a maximum of {0} active passkeys. Revoke an old one to add a new device.").format(
+				MAX_PASSKEYS_PER_USER
+			)
+		)
+
+	return user_active_passkeys
+
+
+def _get_or_create_user_id(email: str) -> bytes:
+	"""Get or create passkey user ID for the user"""
+	user = frappe.get_doc("User", email)
+	return base64url_to_bytes(user.get_passkey_user_id())
+
+
+def _create_exclude_credentials(user_active_passkeys: list) -> list:
+	"""Create exclude credentials list for registration"""
+	return [
+		PublicKeyCredentialDescriptor(
+			id=base64url_to_bytes(cred.credential_id), type=PublicKeyCredentialType.PUBLIC_KEY
+		)
+		for cred in user_active_passkeys
+	]
+
+
+@frappe.whitelist()
+def register_challenge(email: str, user_display_name: str):
+	"""Generate passkey registration challenge"""
+	try:
+		if not email or not user_display_name:
+			return {"success": False, "error": _("Email and display name are required")}
+
+		user_active_passkeys = _validate_passkey_registration(email)
+		user_id = _get_or_create_user_id(email)
+		exclude_credentials = _create_exclude_credentials(user_active_passkeys)
+
+		authenticator_selection = AuthenticatorSelectionCriteria(
+			resident_key=ResidentKeyRequirement.DISCOURAGED,
+			user_verification=UserVerificationRequirement.PREFERRED,
+		)
+
+		registration_options = generate_registration_options(
+			rp_id=urlparse(frappe.utils.get_url()).hostname,
+			rp_name="Frappe",
+			user_name=email,
+			user_id=user_id,
+			user_display_name=user_display_name,
+			exclude_credentials=exclude_credentials,
+			authenticator_selection=authenticator_selection,
+		)
+
+		cache_key = f"passkey_challenge:{_sanitize_cache_key(email)}"
+		frappe.cache().set(cache_key, registration_options.challenge, CHALLENGE_EXPIRY_SECONDS)
+
+		return options_to_json_dict(registration_options)
+
+	except frappe.ValidationError:
+		raise
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "Passkey Registration Challenge Failed")
+		return {"success": False, "error": _("Failed to generate registration challenge")}
+
+
+@frappe.whitelist()
+def register_verify(email: str, credential):
+	"""Verify passkey registration"""
+	try:
+		if not email:
+			return {"success": False, "error": _("Email is required")}
+
+		_validate_user_access(email)
+
+		if isinstance(credential, str):
+			credential = json.loads(credential)
+
+		cache_key = f"passkey_challenge:{_sanitize_cache_key(email)}"
+		expected_challenge = frappe.cache().get(cache_key)
+		if not expected_challenge:
+			return {"success": False, "error": _("Registration challenge not found or expired")}
+
+		verified_credential = verify_registration_response(
+			credential=credential,
+			expected_challenge=expected_challenge,
+			expected_rp_id=urlparse(frappe.utils.get_url()).hostname,
+			expected_origin=frappe.utils.get_url(),
+			require_user_verification=True,
+		)
+
+		if verified_credential:
+			credential_id = bytes_to_base64url(verified_credential.credential_id)
+
+			# Check if credential already exists
+			if frappe.db.exists("User Passkey", {"credential_id": credential_id, "user": email}):
+				return {"success": False, "error": _("This passkey is already registered")}
+
+			# Create new passkey record
+			passkey = frappe.new_doc("User Passkey")
+			passkey.user = email
+			passkey.credential_id = credential_id
+			passkey.public_key = bytes_to_base64url(verified_credential.credential_public_key)
+			passkey.sign_count = verified_credential.sign_count
+			passkey.title = credential.get("title", _("Unnamed Passkey"))
+			passkey.flags.ignore_permissions = True
+			passkey.insert()
+
+			# Clear challenge from cache
+			frappe.cache().delete(cache_key)
+
+			return {"success": True, "credential_id": credential_id}
+
+		return {"success": False, "error": _("Credential verification failed")}
+
+	except frappe.ValidationError:
+		raise
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "Passkey Registration Verify Failed")
+		return {"success": False, "error": _("Registration verification failed")}
+
+
+def _get_all_active_passkeys():
+	"""Get all active passkeys with pagination fallback"""
+	passkeys = []
+	start = 0
+
+	while True:
+		batch = frappe.get_all(
+			"User Passkey",
+			filters={"status": "Active"},
+			fields=["credential_id"],
+			limit=PASSKEY_BATCH_SIZE,
+			start=start,
+			order_by="creation desc",
+		)
+
+		if not batch:
+			break
+
+		passkeys.extend(batch)
+		start += PASSKEY_BATCH_SIZE
+
+		# Safety limit to prevent infinite loops
+		if len(passkeys) > 50000:  # Reasonable upper limit
+			frappe.log_error("Too many active passkeys detected", "Passkey Login Challenge")
+			break
+
+	return passkeys
+
+
+@frappe.whitelist(allow_guest=True)
+def login_challenge():
+	"""Generate passkey authentication challenge"""
+	try:
+		active_passkeys = _get_all_active_passkeys()
+
+		allow_credentials = [
+			PublicKeyCredentialDescriptor(
+				id=base64url_to_bytes(d["credential_id"]), type=PublicKeyCredentialType.PUBLIC_KEY
+			)
+			for d in active_passkeys
+		]
+
+		auth_options = generate_authentication_options(
+			rp_id=urlparse(frappe.utils.get_url()).hostname, allow_credentials=allow_credentials
+		)
+
+		# Use UUID for cache key to avoid user enumeration
+		cache_id = str(uuid.uuid4())
+		cache_key = f"passkey_challenge:{_sanitize_cache_key(cache_id)}"
+		frappe.cache().set(cache_key, auth_options.challenge, CHALLENGE_EXPIRY_SECONDS)
+
+		response = options_to_json_dict(auth_options)
+		response["cache_id"] = cache_id
+		return response
+
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "Passkey Login Challenge Failed")
+		return {"success": False, "error": _("Failed to generate login challenge")}
+
+
+@frappe.whitelist(allow_guest=True)
+def login_verify(credential_response):
+	"""Verify passkey authentication"""
+	try:
+		if isinstance(credential_response, str):
+			credential_response = json.loads(credential_response)
+
+		cache_id = credential_response.get("cache_id")
+		if not cache_id:
+			return {"success": False, "error": _("Invalid authentication request")}
+
+		cache_key = f"passkey_challenge:{_sanitize_cache_key(cache_id)}"
+		expected_challenge = frappe.cache().get(cache_key)
+		if not expected_challenge:
+			return {"success": False, "error": _("Login challenge not found or expired")}
+
+		credential_id = credential_response.get("id")
+		if not credential_id:
+			return {"success": False, "error": _("Invalid credential")}
+
+		try:
+			passkey_doc = frappe.get_doc("User Passkey", {"credential_id": credential_id})
+		except frappe.DoesNotExistError:
+			return {"success": False, "error": _("Passkey not found")}
+
+		if passkey_doc.status != "Active":
+			return {"success": False, "error": _("Passkey is inactive")}
+
+		public_key_bytes = base64url_to_bytes(passkey_doc.public_key)
+
+		verified_auth = verify_authentication_response(
+			credential=credential_response,
+			expected_challenge=expected_challenge,
+			expected_rp_id=urlparse(frappe.utils.get_url()).hostname,
+			expected_origin=frappe.utils.get_url(),
+			credential_public_key=public_key_bytes,
+			credential_current_sign_count=passkey_doc.sign_count,
+			require_user_verification=False,
+		)
+
+		# Update sign count
+		passkey_doc.sign_count = verified_auth.new_sign_count
+		passkey_doc.save(ignore_permissions=True)
+
+		# Login user
+		login_manager = LoginManager()
+		login_manager.login_as(passkey_doc.user)
+
+		# Clear challenge from cache
+		frappe.cache().delete(cache_key)
+
+		return {"success": True, "message": _("Logged in"), "home_page": "/app"}
+
+	except frappe.ValidationError:
+		raise
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "Passkey Login Verify Failed")
+		return {"success": False, "error": _("Authentication failed")}
+
+
+@frappe.whitelist()
+def update_passkey_label(credential_id: str, label: str):
+	"""Update passkey label/title"""
+	try:
+		if not credential_id or not label:
+			return {"success": False, "error": _("Credential ID and label are required")}
+
+		# Validate user owns this passkey
+		passkey = frappe.get_doc("User Passkey", {"credential_id": credential_id})
+		_validate_user_access(passkey.user)
+
+		frappe.db.set_value("User Passkey", {"credential_id": credential_id}, "title", label)
+		frappe.db.commit()
+
+		return {"success": True}
+
+	except frappe.DoesNotExistError:
+		return {"success": False, "error": _("Passkey not found")}
+	except frappe.ValidationError:
+		raise
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "Update Passkey Label Failed")
+		return {"success": False, "error": _("Failed to update passkey label")}
+
+
+@frappe.whitelist()
+def get_active_passkeys(user: str):
+	"""Get user's active passkeys"""
+	try:
+		_validate_user_access(user)
+
+		passkeys = frappe.get_all(
+			"User Passkey",
+			filters={"user": user, "status": "Active"},
+			fields=["name", "creation", "credential_id", "title", "sign_count", "modified as last_used"],
+			order_by="creation desc",
+		)
+
+		return passkeys
+
+	except frappe.ValidationError:
+		raise
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "Get Active Passkeys Failed")
+		return []
+
+
+@frappe.whitelist()
+def revoke_passkey(name: str):
+	"""Revoke a passkey"""
+	try:
+		if not name:
+			return {"success": False, "error": _("Passkey name is required")}
+
+		try:
+			doc = frappe.get_doc("User Passkey", name)
+		except frappe.DoesNotExistError:
+			return {"success": False, "error": _("Passkey not found")}
+
+		_validate_user_access(doc.user)
+
+		doc.status = "Revoked"
+		doc.save(ignore_permissions=True)
+
+		return {"success": True}
+
+	except frappe.ValidationError:
+		raise
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "Revoke Passkey Failed")
+		return {"success": False, "error": _("Failed to revoke passkey")}

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1884,4 +1884,44 @@ Object.assign(frappe.utils, {
 			});
 		});
 	},
+	/**
+	 * Converts a base64url string to Uint8Array for WebAuthn operations.
+	 * @param {string} base64url_string - The base64url encoded string
+	 * @returns {Uint8Array} - The decoded byte array
+	 * @throws {Error} - If the input string is invalid
+	 */
+	base64url_to_uint8array(base64url_string) {
+		if (!base64url_string || typeof base64url_string !== "string") {
+			throw new Error("Invalid input: expected non-empty string");
+		}
+		try {
+			const base64 = base64url_string.replace(/-/g, "+").replace(/_/g, "/");
+			const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+			const raw = window.atob(padded);
+			return Uint8Array.from([...raw].map((c) => c.charCodeAt(0)));
+		} catch (e) {
+			throw new Error(`Invalid base64url string: ${e.message}`);
+		}
+	},
+
+	/**
+	 * Converts an ArrayBuffer to base64url string for WebAuthn operations.
+	 * @param {ArrayBuffer|Uint8Array} buffer - The buffer to encode
+	 * @returns {string} - The base64url encoded string
+	 * @throws {Error} - If the buffer is invalid or encoding fails
+	 */
+	buffer_to_base64url(buffer) {
+		if (!buffer) {
+			throw new Error("Invalid input: buffer is required");
+		}
+		try {
+			const uint8Array = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+			return btoa(String.fromCharCode(...uint8Array))
+				.replace(/\+/g, "-")
+				.replace(/\//g, "_")
+				.replace(/=+$/, "");
+		} catch (e) {
+			throw new Error(`Failed to encode buffer to base64url: ${e.message}`);
+		}
+	},
 });

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -75,6 +75,109 @@ login.bind_events = function () {
 		return false;
 	});
 
+	$(".btn-login-with-passkey").on("click", async function (event) {
+		const button = $(this);
+		const originalText = button.text();
+
+		event.preventDefault();
+
+		// Check browser support
+		if (!navigator.credentials || !window.PublicKeyCredential) {
+			frappe.msgprint("Passkeys are not supported in this browser.");
+			return;
+		}
+
+		// Prevent double-click
+		if (button.prop("disabled")) {
+			return;
+		}
+
+		button.prop("disabled", true).text("Authenticating...");
+
+		try {
+			// Get challenge from server
+			const challengeResponse = await frappe.call({
+				args: { cmd: "frappe.integrations.passkey.login_challenge" },
+				freeze: true
+			});
+
+			if (!challengeResponse.message) {
+				throw new Error("Invalid challenge response from server");
+			}
+
+			const loginOptions = { ...challengeResponse.message };
+
+			// Convert base64url strings to Uint8Array
+			loginOptions.challenge = frappe.utils.base64url_to_uint8array(loginOptions.challenge);
+			if (loginOptions.allowCredentials?.length) {
+				loginOptions.allowCredentials = loginOptions.allowCredentials.map(credential => ({
+					...credential,
+					id: frappe.utils.base64url_to_uint8array(credential.id)
+				}));
+			}
+
+			button.text("Touch your authenticator...");
+
+			// Get credential from authenticator
+			const credential = await navigator.credentials.get({
+				publicKey: loginOptions,
+				signal: AbortSignal.timeout(60000) // 60 second timeout
+			});
+
+			if (!credential) {
+				throw new Error("User cancelled passkey authentication");
+			}
+
+			button.text("Verifying...");
+
+			// Prepare credential response for server
+			const credentialResponse = {
+				id: credential.id,
+				rawId: frappe.utils.buffer_to_base64url(credential.rawId),
+				response: {
+					authenticatorData: frappe.utils.buffer_to_base64url(credential.response.authenticatorData),
+					clientDataJSON: frappe.utils.buffer_to_base64url(credential.response.clientDataJSON),
+					signature: frappe.utils.buffer_to_base64url(credential.response.signature),
+					userHandle: credential.response.userHandle
+						? frappe.utils.buffer_to_base64url(credential.response.userHandle)
+						: null
+				},
+				type: credential.type,
+				cache_id: loginOptions.cache_id
+			};
+
+			// Verify with server
+			const verifyResponse = await frappe.call({
+				args: {
+					cmd: "frappe.integrations.passkey.login_verify",
+					credential_response: credentialResponse
+				},
+				freeze: true
+			});
+
+			if (!verifyResponse.message?.success) {
+				const errorMessage = verifyResponse.message?.error || "Login verification failed";
+				frappe.msgprint(errorMessage);
+				return;
+			}
+
+			// Success - redirect
+			button.text("Success!");
+			const redirectUrl = frappe.utils.sanitise_redirect(
+				frappe.utils.get_url_arg("redirect-to")
+			) || verifyResponse.message.home_page || "/app";
+
+			window.location.href = redirectUrl;
+
+		} catch (error) {
+			console.error("Passkey login error:", error);
+			show_passkey_login_error(error);
+		} finally {
+			// Always re-enable button
+			button.prop("disabled", false).text(originalText);
+		}
+	});
+
 	$(".toggle-password").click(function () {
 		var input = $($(this).attr("toggle"));
 		if (input.attr("type") == "password") {
@@ -387,3 +490,21 @@ var continue_email = function (setup, prompt) {
 }
 
 login.route();
+
+function show_passkey_login_error(error) {
+	let message = "An error occurred during passkey login.";
+
+	if (error.name === "NotAllowedError") {
+		message = "User cancelled or passkey login not allowed.";
+	} else if (error.name === "InvalidStateError") {
+		message = "Invalid passkey state.";
+	} else if (error.name === "NotSupportedError") {
+		message = "Passkeys are not supported on this device.";
+	} else if (error.name === "SecurityError") {
+		message = "Security error occurred during passkey login.";
+	} else if (error.message) {
+		message = error.message;
+	}
+
+	frappe.msgprint(message);
+}

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -127,6 +127,18 @@
 							</div>
 						</div>
 						{% endif %}
+
+						{% if login_with_passkey %}
+						<div class="login-with-passkey social-login-buttons">
+							<div class="login-button-wrapper">
+								<button
+									class="btn btn-block btn-default btn-sm btn-login-option btn-login-with-passkey"
+									type="button">
+									{{ _("Login with a passkey") }}
+								</button>
+							</div>
+						</div>
+						{% endif %}
 					</div>
 				</div>
 				{% else %}

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -111,6 +111,7 @@ def get_context(context):
 
 	context["login_label"] = f" {_('or')} ".join(login_label)
 
+	context["login_with_passkey"] = frappe.get_system_settings("login_with_passkey")
 	context["login_with_email_link"] = frappe.get_system_settings("login_with_email_link")
 	context["login_with_frappe_cloud_url"] = (
 		f"{get_site_login_url()}?site={frappe.local.site}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dependencies = [
     "xlrd~=2.0.2",
     "zxcvbn~=4.5.0",
     "markdownify~=1.1.0",
+    "webauthn~=2.7.0",
 
     # integration dependencies
     "google-api-python-client~=2.172.0",


### PR DESCRIPTION
### **What This Does**

Adds passwordless login using passkeys (fingerprint, face ID, or security keys) to Frappe.

https://github.com/user-attachments/assets/1534e566-3946-47a7-8c31-a3e518498a34


### **New Features**

- Login without password - Users can login with fingerprint/face ID
- Register passkeys - Add new passkeys from User doctype
- Manage passkeys - View and remove existing passkeys

### **How It Works**

1. User clicks "Register Passkey" in User doctype (Max 3 passkeys per user)
2. Browser asks for fingerprint/face ID
3. Passkey is saved with device name
4. On login page, user can click passkey button instead of entering email or password
5. Browser verifies identity and logs user in
