### PR TITLE
feat: Adding option to centre frappe Dialog Box

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -14,7 +14,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 		this.is_dialog = true;
 		this.last_focus = null;
 
-		$.extend(this, { animate: true, size: null, auto_make: true }, opts);
+		$.extend(this, { animate: true, size: null, auto_make: true, centered: false }, opts);
 		if (this.auto_make) {
 			this.make();
 		}
@@ -34,6 +34,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 		if (!this.size) this.set_modal_size();
 
 		this.wrapper = this.$wrapper.find(".modal-dialog").get(0);
+		if (this.centered) $(this.wrapper).addClass("modal-dialog-centered");
 		if (this.size == "small") $(this.wrapper).addClass("modal-sm");
 		else if (this.size == "large") $(this.wrapper).addClass("modal-lg");
 		else if (this.size == "extra-large") $(this.wrapper).addClass("modal-xl");

--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -345,3 +345,13 @@ body.modal-open[style^="padding-right"] {
 		}
 	}
 }
+.modal-dialog-centered {
+	display: flex;
+	align-items: center;
+	min-height: calc(100% - 1rem);
+}
+@media (min-width: 576px) {
+	.modal-dialog-centered {
+		min-height: calc(100% - 3.5rem);
+	}
+}


### PR DESCRIPTION
This enhancement adds an option to center the dialog box within the viewport, improving the user experience by ensuring that dialogs are consistently positioned, especially on pages with dynamic content or varying screen sizes.


This update enhances the flexibility and usability of Frappe's dialog boxes, providing developers with more control over their layout and presentation.


[Screencast from 29-09-25 03_04_27 PM IST.webm](https://github.com/user-attachments/assets/4bc51cb9-acd4-4ef8-bea2-cc063e1249df)

Documentation Link: https://docs.frappe.io/framework/user/en/api/dialog
