### PR TITLE
feat(ui): Add dropdown support to primary action button

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -323,14 +323,70 @@ frappe.ui.Page = class Page {
 		frappe.ui.keys.get_shortcut_group(this).add(btn, text_span.length ? text_span : btn);
 	}
 
-	set_primary_action(label, click, icon, working_label) {
-		this.set_action(this.btn_primary, {
-			label: label,
-			click: click,
-			icon: icon,
-			working_label: working_label,
+	set_primary_action(
+		label,
+		click,
+		icon,
+		working_label,
+		is_dropdown = false,
+		dropdown_items = []
+	) {
+		if (is_dropdown) {
+			return this._create_dropdown_primary_action(label, icon, dropdown_items);
+		} else {
+			this.set_action(this.btn_primary, {
+				label: label,
+				click: click,
+				icon: icon,
+				working_label: working_label,
+			});
+			return this.btn_primary;
+		}
+	}
+
+	_create_dropdown_primary_action(label, icon, dropdown_items) {
+		// Clear existing primary action
+		this.clear_primary_action();
+
+		// Create dropdown structure
+		const dropdownHTML = `
+		<div class="dropdown primary-action-dropdown">
+			<button class="btn btn-primary dropdown-toggle" type="button"
+					data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+				${icon ? frappe.utils.icon(icon) : ""}
+				<span class="hidden-xs">${label}</span>
+			</button>
+			<ul class="dropdown-menu" role="menu"></ul>
+		</div>
+	`;
+
+		// Add dropdown to primary action area
+		this.btn_primary.replaceWith(dropdownHTML);
+		this.btn_primary = this.page_actions.find(".primary-action-dropdown > button");
+		this.primary_dropdown_menu = this.page_actions.find(
+			".primary-action-dropdown .dropdown-menu"
+		);
+
+		// Add dropdown items
+		dropdown_items.forEach((item) => {
+			this.add_primary_dropdown_item(item.label, item.click, item.icon);
 		});
 		return this.btn_primary;
+	}
+
+	add_primary_dropdown_item(label, click, icon = null) {
+		const iconHTML = icon ? `${frappe.utils.icon(icon)} ` : "";
+		const $item = $(`
+        <a class="dropdown-item" href="#" onclick="return false;">
+            ${iconHTML}${label}
+        </a>
+    `).appendTo(this.primary_dropdown_menu);
+
+		$item.on("click", (e) => {
+			return click();
+		});
+
+		return $item;
 	}
 
 	set_secondary_action(label, click, icon, working_label) {


### PR DESCRIPTION
**Summary**
This enhancement extends the set_primary_action method in Frappe's UI Page component to support dropdown menus, enabling developers to group multiple related actions under a single primary button while maintaining a clean and organized user interface.

**Problem Statement**
Right now, developers have to choose between:

Using just one main action button, OR
Adding multiple buttons that clutter the toolbar

**Solution**
The enhanced set_primary_action method now accepts optional parameters to create a dropdown menu, allowing logical grouping of related actions without compromising UI cleanliness.

**Dropdown Implementation**

<img width="1024" height="1014" alt="dropdown_items_listview" src="https://github.com/user-attachments/assets/a2ffe4d6-865d-4306-862a-223d5e0616ab" />


**Files Modified**
frappe/ui/page.js - Enhanced Page class functionality

**Referenced video**

[Screencast from 10-09-25 02:43:20 PM IST.webm](https://github.com/user-attachments/assets/1ae1511d-2648-41c3-82f4-ca74b47a01e3)


