### PR TITLE
fix(UX): simplified group node term

### DIFF
--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -355,7 +355,7 @@ frappe.views.TreeView = class TreeView {
 		var node = me.tree.get_selected_node();
 
 		if (!(node && node.expandable)) {
-			frappe.msgprint(__("Select a group node first."));
+			frappe.msgprint(__("Select a group folder first."));
 			return;
 		}
 
@@ -415,8 +415,10 @@ frappe.views.TreeView = class TreeView {
 			{
 				fieldtype: "Check",
 				fieldname: "is_group",
-				label: __("Group Node"),
-				description: __("Further nodes can be only created under 'Group' type nodes"),
+				label: __("Group Folder"),
+				description: __(
+					"Further sub-groups can only be created under folders marked as 'Group'"
+				),
 			},
 		];
 

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -355,7 +355,7 @@ frappe.views.TreeView = class TreeView {
 		var node = me.tree.get_selected_node();
 
 		if (!(node && node.expandable)) {
-			frappe.msgprint(__("Select a group folder first."));
+			frappe.msgprint(__("Select a group {0} first.", [__(me.doctype)]));
 			return;
 		}
 
@@ -415,9 +415,9 @@ frappe.views.TreeView = class TreeView {
 			{
 				fieldtype: "Check",
 				fieldname: "is_group",
-				label: __("Group Folder"),
+				label: __("Is Group"),
 				description: __(
-					"Further sub-groups can only be created under folders marked as 'Group'"
+					"Further sub-groups can only be created under records marked as 'Group'"
 				),
 			},
 		];


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->
Problem:

Simplified the term node to a more UX friendly term "folder". This in turn is to Improve UX and enhance simplicity since node is a programming term and would be unclear for non-technical users. This change simplifies that by changing the term "Node" to "Folder" that is easily comprehensible for both technical and non-technical users.

The Related Issue can be found here: 

#34190

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Before: 
<img width="892" height="396" alt="image" src="https://github.com/user-attachments/assets/45ad3ced-088b-4ee4-997c-d36a10af8827" />

After:

<img width="1266" height="413" alt="image" src="https://github.com/user-attachments/assets/49338d9f-9a87-4b1a-9e35-47c5ffc561b0" />



fixes #34190