### PR TITLE
feat: Add support for attaching files with data while data import forattach fields

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -272,6 +272,9 @@ class Importer:
 		}
 
 		new_doc.insert()
+
+		self.validate_and_upload_files(doc, new_doc.name, new_doc)
+
 		if meta.is_submittable and self.data_import.submit_after_import:
 			new_doc.submit()
 		return new_doc
@@ -282,8 +285,9 @@ class Importer:
 
 		updated_doc = frappe.get_doc(self.doctype, doc.get(id_field.fieldname))
 
-		updated_doc.update(doc)
+		self.validate_and_upload_files(doc, doc.get(id_field.fieldname), doc=None)
 
+		updated_doc.update(doc)
 		if get_diff(existing_doc, updated_doc):
 			# update doc if there are changes
 			updated_doc.flags.updater_reference = {
@@ -296,6 +300,25 @@ class Importer:
 		else:
 			# throw if no changes
 			frappe.throw(_("No changes to update"))
+
+	def validate_and_upload_files(self, data, fieldname, doc=None):
+		"""
+		Checks if the provided file have attach fields, if yes then upload and update the file url on the doctype
+		"""
+		attach_fields, is_public = get_attach_fields(self.doctype)
+		if matching_fields := set(data.keys()) & set(attach_fields):
+			for fld in matching_fields:
+				if not data.get(fld):
+					continue
+
+				if os.path.exists(data.get(fld)):
+					file_url = read_and_upload_file(data, self.doctype, fieldname, fld, is_public)
+					if not doc:
+						data[fld] = file_url
+					else:
+						doc.db_set(fld, file_url)
+				else:
+					frappe.throw(_("File {} does not exists in the local file system!").format(data.get(fld)))
 
 	def get_eta(self, current, total, processing_time):
 		self.last_eta = getattr(self, "last_eta", 0)
@@ -1320,3 +1343,43 @@ def create_import_log(data_import, log_index, log_details):
 			"exception": log_details.get("exception"),
 		}
 	).db_insert()
+
+
+def get_attach_fields(doctype):
+	std_field = frappe.db.get_all(
+		"DocField",
+		{"parent": doctype, "fieldtype": ["IN", ["Attach", "Attach Image", "Image"]]},
+		pluck="fieldname",
+	)
+	custom_fields = frappe.db.get_all(
+		"Custom Field",
+		{"dt": doctype, "fieldtype": ["IN", ["Attach", "Attach Image", "Image"]]},
+		pluck="fieldname",
+	)
+	is_public = frappe.db.get_value("DocType", doctype, "make_attachments_public")
+	return std_field + custom_fields, is_public
+
+
+def read_and_upload_file(doc, doctype, docname, field, is_public=0):
+	"""Read and upload then update the file path in the doc"""
+
+	from frappe.utils.file_manager import get_file_name
+
+	file_name = os.path.basename(doc.get(field))
+	with open(doc.get(field), mode="rb") as file:
+		content = file.read()
+
+	file = frappe.get_doc(
+		{
+			"doctype": "File",
+			"attached_to_doctype": doctype,
+			"attached_to_name": docname,
+			"attached_to_field": field,
+			"folder": "Home",
+			"file_name": get_file_name(file_name, frappe.generate_hash(length=8)),
+			"is_private": 0 if is_public else 1,
+			"content": content,
+		}
+	)
+	file.save(ignore_permissions=True)
+	return file.file_url


### PR DESCRIPTION
### Feature: Bulk File Upload in Data Import

**Problem Statement**  
Recently, I faced an issue where a client asked me to update all employee IDs. They shared a ZIP containing 50 ID images in JPEG format. Updating each manually was inefficient, and I found that Data Import did not support attaching files in bulk.  

**Solution**  
I extended the Data Import functionality to support **file uploads for attach fields**. This allows users to bulk update attachments just like any other field.  

For example, in the **Address** Doctype, suppose we have two fields:  
- **Attach (Photo ID)** (custom field)  
- **Attach File (Address Proof)** (standard field)  

Now, these can be populated directly via Data Import by specifying local file paths in the template.

---

### Case 1: New Record Insertion  
I added two new records in the template with file paths for *Address Proof.pdf* and *Photo ID Office.jpg*.  

- If a valid file path is provided, the record imports successfully.  
- If the path is invalid, the system throws an error (e.g., *"File /home/patel/Downloads/Address Proof-12.pdf does not exist in the local file system!"*).  

✅ Successful import example:  
![success](https://github.com/user-attachments/assets/306d8f0a-13d5-4a34-bcd0-6f612e3a7f87)  

❌ Error example:  
![error](https://github.com/user-attachments/assets/14c7110d-c188-4ebf-9f4c-5047acebaa76)  

---

### Case 2: Updating Existing Records  
For existing records, users can specify file paths in the template for fields such as **Photo ID** and **Address Proof**.  

- After uploading the template, the files are correctly attached to the existing records.  
- Invalid or missing paths are handled gracefully (ignored or throw error).  

Example:  
![update](https://github.com/user-attachments/assets/9e69eb71-9390-4300-9319-9d8fae98719e)  

---

**Closing Statement**  
- Existing Data Import functionality remains intact.  
- If a file path is invalid, the system throws an error.  
- If no file is specified, the column is ignored.  
- Uploaded files are private unless the **Always Public** flag is set at the Doctype level.  

This feature makes bulk file uploads for attach fields seamless and efficient.
