### PR TITLE
chore: enforce conventional commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 exclude: 'node_modules|.git'
 default_stages: [pre-commit]
+default_install_hook_types: [pre-commit, commit-msg]
 fail_fast: false
 
 
@@ -68,6 +69,13 @@ repos:
                 frappe/templates/includes/.*|
                 frappe/public/js/lib/.*
             )$
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.22.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ['conventional-changelog-conventionalcommits']
 
 ci:
     autoupdate_schedule: weekly


### PR DESCRIPTION
Enforce conventional commits via pre-commit.

Note: You'll need to re-run `pre-commit install` for this change to take effect.

The additional dependency is needed because it is used as `parserPreset` in `commitlint.config.js`