### PR TITLE
fix: various fixes for sqlite

### DIFF
--- a/frappe/database/sqlite/database.py
+++ b/frappe/database/sqlite/database.py
@@ -107,6 +107,7 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 		conn = self.create_connection(read_only)
 		conn.isolation_level = None
 		conn.create_function("regexp", 2, regexp)
+		conn.create_function("regexp_replace", 3, regexp_replace)
 		pragmas = {
 			"journal_mode": "WAL",
 			"synchronous": "NORMAL",
@@ -583,3 +584,10 @@ def regexp(expr: str, item: str) -> bool:
 	Although it works in the CLI - doesn't work through python
 	"""
 	return re.search(expr, item) is not None
+
+
+def regexp_replace(item: str, pattern: str, repl: str) -> str:
+	"""
+	Define regexp_replace implementation for SQLite
+	"""
+	return re.sub(pattern, repl, item)

--- a/frappe/database/sqlite/schema.py
+++ b/frappe/database/sqlite/schema.py
@@ -125,7 +125,7 @@ class SQLiteTable(DBTable):
 		if self.meta.sort_field == "modified" and not frappe.db.get_column_index(
 			self.table_name, "modified", unique=False
 		):
-			index_queries.append(f"CREATE INDEX `modified` ON `{self.table_name}` (`modified`)")
+			index_queries.append(f"CREATE INDEX IF NOT EXISTS `modified` ON `{self.table_name}` (`modified`)")
 
 		for query in index_queries:
 			frappe.db.sql_ddl(query)

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -89,7 +89,6 @@ def install_basic_docs():
 			"thread_notify": 0,
 			"send_me_a_copy": 0,
 		},
-		{"doctype": "Role", "role_name": "Translator"},
 		{
 			"doctype": "Workflow State",
 			"workflow_state_name": "Pending",


### PR DESCRIPTION
- fix: drop duplicate `translator` role
- feat: define `regexp_replace`
- fix: create index if it doesn't exist

<hr>

Some of our apps use REGEXP_REPLACE in queries - seems easier to include our own variant rather than change the query based on db_type
