### PR TITLE
fix: ignore virtual fields in filter UI

### DIFF
--- a/frappe/public/js/frappe/ui/filters/field_select.js
+++ b/frappe/public/js/frappe/ui/filters/field_select.js
@@ -117,6 +117,10 @@ frappe.ui.FieldSelect = class FieldSelect {
 		// main table
 		var main_table_fields = std_filters.concat(frappe.meta.docfield_list[me.doctype]);
 		$.each(frappe.utils.sort(main_table_fields, "label", "string"), function (i, df) {
+			if (df.is_virtual) {
+				return;
+			}
+
 			let doctype =
 				frappe.get_meta(me.doctype).istable && me.parent_doctype
 					? me.parent_doctype
@@ -128,7 +132,7 @@ frappe.ui.FieldSelect = class FieldSelect {
 
 		// child tables
 		$.each(me.table_fields, function (i, table_df) {
-			if (table_df.options) {
+			if (table_df.options && !table_df.is_virtual) {
 				let child_table_fields = [].concat(frappe.meta.docfield_list[table_df.options]);
 
 				if (table_df.fieldtype === "Table MultiSelect") {


### PR DESCRIPTION
Filters usually result in a DB query, where virtual fields cannot be found. To avoid related error messages, this PR excludes virtual fields from the filter UI.