### PR TITLE
fix(doctype): restrict length to 61 characters

### DIFF
--- a/frappe/core/doctype/doctype/doctype_list.js
+++ b/frappe/core/doctype/doctype/doctype_list.js
@@ -24,6 +24,7 @@ frappe.listview_settings["DocType"] = {
 				fieldtype: "Data",
 				reqd: 1,
 				default: doctype_name,
+				length: 61,
 			},
 			{ fieldtype: "Column Break" },
 			{


### PR DESCRIPTION
Default is 140 here, but we restrict it to 61 in the backend
(tab+name should be 64 characters max)
