### PR TITLE
fix: allow reselecting same file after removal

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -377,6 +377,7 @@ function on_file_input(e) {
 }
 function remove_file(file) {
 	files.value = files.value.filter((f) => f !== file);
+	if (file_input.value) file_input.value.value = "";
 }
 function toggle_image_cropper(index) {
 	crop_image_with_index.value = show_image_cropper.value ? -1 : index;


### PR DESCRIPTION
**Issue** : When a user select a file via file uploader and delete it before uploading. They are unable to attach the same file again. The file can only be reattached after reopening the dialog box.

**Before:**

https://github.com/user-attachments/assets/606ddcce-5129-4b79-8c18-018bf00161b7

**After:**


https://github.com/user-attachments/assets/f987d2cc-26b0-4cce-9b8d-73d459eec173



