### PR TITLE
fix: format Percent value like Float

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -99,7 +99,7 @@ frappe.form.formatters = {
 			docfield.precision ||
 			cint(frappe.boot.sysdefaults && frappe.boot.sysdefaults.float_precision) ||
 			2;
-		return frappe.form.formatters._right(flt(value, precision) + "%", options);
+		return frappe.form.formatters._right(format_number(value, null, precision) + "%", options);
 	},
 	Rating: function (value, docfield) {
 		let rating_html = "";


### PR DESCRIPTION
Percent fields were not using the correct local decimal separators.

### Before

(with German separators enabled)

<img width="270" height="136" alt="Bildschirmfoto 2025-10-01 um 19 44 57" src="https://github.com/user-attachments/assets/e132ece6-5b84-43a7-a401-f09ca88d27d0" />

### After

(with German separators enabled)

<img width="270" height="136" alt="Bildschirmfoto 2025-10-01 um 19 44 42" src="https://github.com/user-attachments/assets/acb5b619-da3b-4ab8-8992-b8ccb860ca73" />
