### PR TITLE
fix: reduce child table extra space for fewer rows

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -6,8 +6,12 @@
 	border: 1px solid var(--table-border-color);
 	border-radius: var(--border-radius-md);
 	color: var(--text-color);
-	min-height: 150px;
+	min-height: 60px;
 	background-color: var(--subtle-accent);
+	
+	&:has(.grid-body .rows:not(:empty)) {
+		min-height: auto;
+	}
 }
 
 .form-grid.error {


### PR DESCRIPTION
## Description

This PR fixes issue #34248 where child tables displayed excessive whitespace when containing fewer rows. The problem was caused by a fixed `min-height: 150px` on the `.form-grid` class, which created unnecessary vertical space regardless of content.

## Problem

**Before**: Child tables with 1-2 rows showed large empty spaces (~150px minimum height) below the content, making forms look cluttered and wasting vertical space. This was particularly noticeable in forms with multiple child tables or when child tables had only a few entries.

**Root Cause**: The CSS rule `.form-grid { min-height: 150px; }` forced all child tables to maintain a minimum height of 150px, even when the actual content required much less space.

## Solution

**After**: Child tables now adapt their height based on content while maintaining a reasonable minimum height (60px) for empty states and proper visual hierarchy.

## Changes Made

- **Reduced default min-height**: Changed from 150px to 60px for better proportion
- **Added dynamic height adjustment**: Used modern CSS `:has()` selector to set `min-height: auto` when rows are present
- **Maintained UX consistency**: Empty tables still have appropriate minimum height for usability

## Technical Details

**File Modified**: `frappe/public/scss/common/grid.scss`

**CSS Changes**:
```scss
.form-grid {
    border: 1px solid var(--table-border-color);
    border-radius: var(--border-radius-md);
    color: var(--text-color);
    min-height: 60px; // ✅ Reduced from 150px
    background-color: var(--subtle-accent);
    
    // ✅ NEW: Dynamic height when content is present
    &:has(.grid-body .rows:not(:empty)) {
        min-height: auto;
    }
}