### PR TITLE
fix: format array in link filters

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -503,10 +503,16 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				filter[3].push("...");
 			}
 
-			let value =
-				filter[3] == null || filter[3] === "" ? __("empty") : String(__(filter[3]));
+			let value;
+			if (filter[3] && Array.isArray(filter[3])) {
+				value = filter[3].map((v) => String(__(v)).bold()).join(", ");
+			} else if (filter[3] == null || filter[3] === "") {
+				value = __("empty").bold();
+			} else {
+				value = String(__(filter[3])).bold();
+			}
 
-			return [__(label).bold(), __(filter[2]), value.bold()].join(" ");
+			return [__(label).bold(), __(filter[2]), value].join(" ");
 		}
 
 		let filter_string = filter_array.map(get_filter_description).join(", ");


### PR DESCRIPTION
This pull request updates the filter value rendering logic in the `ControlLink` class to improve how filter descriptions are displayed, especially when the filter value is an array. The change ensures that multiple filter values are shown clearly and consistently in the UI.

Improvements to filter value rendering:

* Updated the `get_filter_description` function in `frappe/public/js/frappe/form/controls/link.js` to handle array values by displaying each element in bold and separating them with commas, improving clarity for multi-value filters.

Before | After
:-------:|:--------:
<img width="239" height="161" alt="Bildschirmfoto 2025-10-04 um 18 45 34" src="https://github.com/user-attachments/assets/da1e66f0-abcc-407c-b0ec-4aee46ad2f4d" /> | <img width="239" height="161" alt="Bildschirmfoto 2025-10-04 um 18 50 47" src="https://github.com/user-attachments/assets/fd200fdc-6c30-4aeb-81d3-5b1ca4439c94" />
`String(values).bold()` produces a bolded list-string of untranslated elements without spaces. | `values.map((v) => String(__(v)).bold()).join(", ")` produces a list-string of translated and bolded elements with spaces.
Forced word break on dash + ellipsis | Proper line break on space