### PR TITLE
fix: OAuth2 absolute authorize, access token and api urls

### DIFF
--- a/frappe/tests/test_oauth20.py
+++ b/frappe/tests/test_oauth20.py
@@ -12,6 +12,7 @@ from frappe.integrations.oauth2 import encode_params
 from frappe.tests import IntegrationTestCase
 from frappe.tests.test_api import get_test_client, make_request, suppress_stdout
 from frappe.tests.utils import make_test_records
+from frappe.utils.oauth import build_oauth_url
 
 if TYPE_CHECKING:
 	from frappe.integrations.doctype.social_login_key.social_login_key import SocialLoginKey
@@ -359,6 +360,28 @@ class TestOAuth20(FrappeRequestTestCase):
 		self.assertEqual(payload["email"], "test@example.com")
 
 		self.assertTrue(payload.get("nonce") == nonce)
+
+	def test_build_oauth_url(self):
+		self.assertEqual(build_oauth_url("https://example.com", "/endpoint"), "https://example.com/endpoint")
+
+		self.assertEqual(build_oauth_url("https://example.com"), "https://example.com")
+
+		self.assertEqual(build_oauth_url("https://example.com", None), "https://example.com")
+
+		self.assertEqual(
+			build_oauth_url("https://example.com", "//endpoint.com/test"),
+			"https://example.com//endpoint.com/test",
+		)
+
+		self.assertEqual(
+			build_oauth_url("https://example.com", "http://endpoint.com/test"), "http://endpoint.com/test"
+		)
+
+		self.assertEqual(
+			build_oauth_url("https://example.com", "https://endpoint.com"), "https://endpoint.com"
+		)
+
+		self.assertEqual(build_oauth_url("https://example.com", ""), "https://example.com")
 
 	def decode_id_token(self, id_token):
 		import jwt

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -61,6 +61,10 @@ def get_oauth2_providers() -> dict[str, dict]:
 			access_token_url = build_oauth_url(provider.base_url, provider.access_token_url)
 			api_endpoint_url = build_oauth_url(provider.base_url, provider.api_endpoint)
 
+		# Keycloak needs this, the base URL also has a route, that urljoin() ignores
+		if provider.name == "keycloak":
+			api_endpoint_url = build_oauth_url(provider.base_url, provider.api_endpoint)
+
 		out[provider.name] = {
 			"flow_params": {
 				"name": provider.name,


### PR DESCRIPTION
Fix for branches 16 (develop) and 15

When creating a custom OAuth2 integration, Authorize URL and Access Token URL is appended to the Base URL provided.  There are situations where these two urls could be running on a different scheme/host/domain to the Base URL.

To fix this, I made it so it's possible to provide a url with a schema and host i.e `https://example.com/auth` rather than just a path to append on the end of the base url.  This is done by checking to see if the Auth, Access or API url contains a schema and netloc using urllib.  If it does, it does not use the Base URL.

Examples of the output of the urls in the `get_oauth2_providers()` method.

|           Base URL             |  Auth URL    |  Current Result                                | Fixed                             |
| -----------------------| ------------| ---------------------------------  | ----------------------|
| `https://a.com` | `/auth`                     | `https://a.com/auth`                       | `https://a.com/auth`   |
| `https://a.com` | `http://b.com/auth`| `https://a.comhttp://b.com/auth`  | `http://b.com/auth`     |


Unit test for new function included.
