### PR TITLE
fix: multicheck style

### DIFF
--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -21,6 +21,7 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 		const columns = this.df.columns;
 		this.$checkbox_area = $('<div class="checkbox-options"></div>').appendTo(this.wrapper);
 		this.$checkbox_area.get(0).style.setProperty("--checkbox-options-columns", columns);
+		this.$checkbox_area.get(0).style.setProperty("padding", "1em");
 	}
 
 	refresh() {
@@ -154,8 +155,8 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 	get_checkbox_element(option) {
 		return $(`
 			<div class="checkbox unit-checkbox">
-				<label title="${option.description || ""}">
-					<input type="checkbox" data-unit="${option.value}"></input>
+				<label title="${option.description || ""}" style="display: flex; align-items: center;">
+					<input type="checkbox" data-unit="${option.value}" style="flex-shrink: 0;">
 					<span class="label-area" data-unit="${option.value}">${option.label}</span>
 				</label>
 			</div>


### PR DESCRIPTION
### Before

- long labels decrease checkbox size
- no padding around checkboxes, field label "User" is not clearly offset

<img width="574" height="906" alt="Bildschirmfoto 2025-10-05 um 18 23 51" src="https://github.com/user-attachments/assets/9a479ed5-b616-49d9-b5c6-cd96557fd479" />

### After

- long labels do not decrease checkbox size
- padding around checkboxes, field label "User" is clearly offset

<img width="574" height="906" alt="Bildschirmfoto 2025-10-05 um 18 23 36" src="https://github.com/user-attachments/assets/16e507fd-80be-40a0-9b3f-752a453d1202" />

