### PR TITLE
fix: focus btn only if grid is editable

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1457,7 +1457,10 @@ export default class GridRow {
 			this.grid_form.wrapper.css("display", "none");
 		}
 		this.wrapper.removeClass("grid-row-open");
-		this.open_form_button.parent().focus();
+
+		if (this.grid.meta.editable_grid) {
+			this.open_form_button.parent().focus();
+		}
 	}
 	has_prev() {
 		return this.doc.idx > 1;


### PR DESCRIPTION
Currently if in child table editable_grid is unchecked the hide_form() calls `this.open_form_button.parent().focus()` which gives this error.

<img width="664" height="74" alt="Screenshot 2025-10-06 at 12 22 45 AM" src="https://github.com/user-attachments/assets/9a86c353-2310-4587-b112-16a5d40b31d2" />

Due to which when user clicks on a link field, the pages don't reload automatically and needs to be refreshed manually.

## Before
https://github.com/user-attachments/assets/c5de86af-9dd6-4138-84e7-c9f4d0c3bf19

## After

https://github.com/user-attachments/assets/3319fa02-4d01-468c-9cc9-899858ef875b


Support: https://support.frappe.io/helpdesk/tickets/49210

