### PR TITLE
feat: Optionally forward query params while redirecting

### DIFF
--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -180,6 +180,10 @@ class TestWebsite(IntegrationTestCase):
 			"route_redirects",
 			{"source": "/testdoc307", "target": "/testtarget", "redirect_http_status": 307},
 		)
+		website_settings.append(
+			"route_redirects",
+			{"source": "/test-query", "target": "/test-query-new", "forward_query_parameters": 1},
+		)
 		website_settings.save()
 
 		set_request(method="GET", path="/testfrom")
@@ -225,6 +229,11 @@ class TestWebsite(IntegrationTestCase):
 		response = get_response()
 		self.assertEqual(response.status_code, 307)
 		self.assertEqual(response.headers.get("Location"), "/test")
+
+		set_request(method="GET", path="/test-query?param=123")
+		response = get_response()
+		self.assertEqual(response.status_code, 301)
+		self.assertEqual(response.headers.get("Location"), "/test-query-new?param=123")
 
 		delattr(frappe.hooks, "website_redirects")
 		frappe.client_cache.delete_value("app_hooks")

--- a/frappe/website/doctype/website_route_redirect/website_route_redirect.json
+++ b/frappe/website/doctype/website_route_redirect/website_route_redirect.json
@@ -4,8 +4,10 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "column_break_mzuh",
   "source",
   "target",
+  "forward_query_parameters",
   "redirect_http_status"
  ],
  "fields": [
@@ -29,17 +31,29 @@
    "fieldtype": "Select",
    "label": "Redirect HTTP Status",
    "options": "301\n302\n307\n308"
+  },
+  {
+   "fieldname": "column_break_mzuh",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "forward_query_parameters",
+   "fieldtype": "Check",
+   "label": "Forward Query Parameters"
   }
  ],
+ "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2024-03-23 16:04:03.818023",
+ "modified": "2025-10-06 11:45:35.866316",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Website Route Redirect",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "ASC",
  "states": []

--- a/frappe/website/doctype/website_route_redirect/website_route_redirect.py
+++ b/frappe/website/doctype/website_route_redirect/website_route_redirect.py
@@ -14,6 +14,7 @@ class WebsiteRouteRedirect(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		forward_query_parameters: DF.Check
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data


### PR DESCRIPTION
Previously, any redirect set in Website Settings were not forwarding query params from source to target. 

Now, users can optionally enable forwarding of query params when "forward_query_parameters" check is enabled for a "Website Route Redirect" record.

<img width="400" height="549" alt="Screenshot 2025-10-06 at 12 56 37 PM" src="https://github.com/user-attachments/assets/28d84c87-76aa-407f-8764-18abb56f83c8" />


---

**Before:**

If a user visits `/old-page?ref=email&id=123`, they would be redirected to `/new-page`. The query parameters `ref=email&id=123` would be lost.

**Now** (with **forward_query_parameters** enabled for the redirect):

If a user visits `/old-page?ref=email&id=123`, and the "forward_query_parameters" checkbox is enabled for the redirect from `/old-page` to `/new-page`, they will be redirected to `/new-page?ref=email&id=123`. The query parameters are preserved and passed to the new URL.

> no-docs
