### PR TITLE
refactor: simplify SmallText formatter by referencing Text directly

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -323,9 +323,7 @@ frappe.form.formatters = {
 		});
 		return html;
 	},
-	SmallText: function (value) {
-		return frappe.form.formatters.Text(value);
-	},
+	SmallText: frappe.form.formatters.Text,
 	TextEditor: function (value) {
 		let formatted_value = frappe.form.formatters.Text(value);
 		// to use ql-editor styles


### PR DESCRIPTION
If options of fieldtype `Small Text` contained text "URL" then it should have formatted the value in an `<a>` tag but since the df was not an parameter in `SmallText`'s formatter, it was not converted to `<a>` tag.

Now if we write "URL" in the options of fieldtype `Small Text`, It will be converted into `<a>` tag