### PR TITLE
fix: escape HTML in filename before display

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -436,9 +436,6 @@ class File(Document):
 		else:
 			self.file_name = re.sub(r"/", "", self.file_name)
 
-		# Escape HTML characters in file name
-		self.file_name = escape_html(self.file_name)
-
 	def generate_content_hash(self):
 		if self.content_hash or not self.file_url or self.is_remote_file:
 			return

--- a/frappe/core/doctype/file/file_list.js
+++ b/frappe/core/doctype/file/file_list.js
@@ -1,0 +1,7 @@
+frappe.listview_settings["File"] = {
+	formatters: {
+		file_name: function (value) {
+			return frappe.utils.escape_html(value || "");
+		},
+	},
+};

--- a/frappe/public/js/frappe/views/file/file_view.js
+++ b/frappe/public/js/frappe/views/file/file_view.js
@@ -213,6 +213,7 @@ frappe.views.FileView = class FileView extends frappe.views.ListView {
 			title = d.file_name || d.file_url;
 		}
 
+		title = frappe.utils.escape_html(title);
 		title = title.slice(0, 60);
 		d._title = title;
 		d.icon_class = icon_class;


### PR DESCRIPTION
- Revert "fix: sanitize HTML in file names before saving (#34192)"
- feat: escape file name before display

<hr>

Previous method can cause issues in some cases - ticket 49942

Attachment links pointing to original name, etc. Main issue was just displaying the original unescaped HTML - simpler to fix it right there rather than trying to change the data.
