### PR TITLE
fix: update modified timestamp when Workflow Action is completed

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -16,7 +16,7 @@ from frappe.model.workflow import (
 	send_email_alert,
 )
 from frappe.query_builder import DocType
-from frappe.utils import get_datetime, get_url
+from frappe.utils import get_datetime, get_url, now_datetime
 from frappe.utils.background_jobs import enqueue
 from frappe.utils.data import get_link_to_form
 from frappe.utils.user import get_users_with_role
@@ -264,6 +264,8 @@ def update_completed_workflow_actions_using_role(user=None, workflow_action=None
 		.set(WorkflowAction.status, "Completed")
 		.set(WorkflowAction.completed_by, user)
 		.set(WorkflowAction.completed_by_role, workflow_action[0].role)
+		.set(WorkflowAction.modified, now_datetime())
+		.set(WorkflowAction.modified_by, user)
 		.where(WorkflowAction.name == workflow_action[0].name)
 	).run()
 


### PR DESCRIPTION
**Problem:**
Bug: When a Workflow Action is approved and the document status changes to Completed, the modified field in the database does not automatically update.
This causes modified to remain equal to the creation timestamp, even though the record was updated.
Resolving Issue: #33885 

**Before:** 

<img width="1358" height="380" alt="image" src="https://github.com/user-attachments/assets/78517a45-aad0-4d77-89a9-330e4b231d54" />

**After:**

<img width="1538" height="326" alt="image" src="https://github.com/user-attachments/assets/52c76dcb-09cd-44be-985e-0affeaf41dcb" />


fixes #33885 