### PR TITLE
fix!: clear cache and prevent data access after DocType deletion

### DIFF
--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -856,6 +856,16 @@ class TestDocType(IntegrationTestCase):
 		)
 		self.assertRaises(frappe.ValidationError, doctype.insert)
 
+	def test_delete_doc_clears_cache(self):
+		dt = new_doctype(
+			fields=[{"fieldname": "test_fdname", "fieldtype": "Data", "label": "Test Field"}],
+		).insert()
+		frappe.get_meta(dt.name)
+		frappe.delete_doc("DocType", dt.name, force=1, delete_permanently=False)
+		frappe.db.commit()
+		with self.assertRaises(frappe.DoesNotExistError):
+			frappe.get_meta(dt.name)
+
 
 def new_doctype(
 	name: str | None = None,

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -143,10 +143,8 @@ def delete_doc(
 				except (OSError, KeyError):
 					# in case a doctype doesnt have any controller code  nor any app and module
 					pass
-			try:
-				frappe.clear_cache(doctype=name)
-			except frappe.DoesNotExistError:
-				pass
+
+			frappe.clear_cache(doctype=name)
 
 		else:
 			# Lock the doc without waiting

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -143,6 +143,10 @@ def delete_doc(
 				except (OSError, KeyError):
 					# in case a doctype doesnt have any controller code  nor any app and module
 					pass
+			try:
+				frappe.clear_cache(doctype=name)
+			except frappe.DoesNotExistError:
+				pass
 
 		else:
 			# Lock the doc without waiting

--- a/frappe/tests/test_fixture_import.py
+++ b/frappe/tests/test_fixture_import.py
@@ -32,15 +32,13 @@ class TestFixtureImport(IntegrationTestCase):
 		self.assertFalse(frappe.db.exists("DocType", "temp_doctype"))
 
 		self.create_new_doctype("temp_doctype")
+		frappe.db.commit()
 
 		dummy_name_list = ["jhon", "jane"]
 		path_to_exported_fixtures = self.insert_dummy_data_and_export("temp_doctype", dummy_name_list)
 		frappe.db.truncate("temp_doctype")
 
 		import_doc(path_to_exported_fixtures)
-
-		delete_doc("DocType", "temp_doctype", delete_permanently=True)
-		os.remove(path_to_exported_fixtures)
 
 		self.assertEqual(frappe.db.count("temp_doctype"), len(dummy_name_list))
 
@@ -52,6 +50,10 @@ class TestFixtureImport(IntegrationTestCase):
 			imported_data.add(item["member_name"])
 
 		self.assertEqual(set(dummy_name_list), imported_data)
+
+		delete_doc("DocType", "temp_doctype", delete_permanently=True)
+		frappe.db.commit()
+		os.remove(path_to_exported_fixtures)
 
 	def test_singles_fixtures_import(self):
 		self.assertFalse(frappe.db.exists("DocType", "temp_singles"))


### PR DESCRIPTION
**Problem:**
Bug: After deleting a DocType, calling frappe.db.get_all without the order_by argument correctly throws a "Doctype not found" error. However, adding an order_by argument causes frappe.db.get_all to return data from the deleted DocType’s underlying table, which is unexpected. This inconsistency allows data access from a deleted DocType and could cause confusion or security concerns.
Resolving Issue: #33852 

**Before:** 
```shell
Calling without order_by:

text
frappe.db.get_all("Your Doctype", fields=["*"])
# Output: frappe.exceptions.DoesNotExistError: DocType 'Deleted Doctype' not found
Calling with order_by:

text
frappe.db.get_all("Your Doctype", fields=["*"], order_by="creation desc")
# Output: Returns list of records from deleted DocType's table unexpectedly
```
**After:** 
<img width="1376" height="508" alt="image" src="https://github.com/user-attachments/assets/80f59744-4403-4b49-bf4b-13ad9e65e315" />

<img width="1378" height="596" alt="image" src="https://github.com/user-attachments/assets/d5121a1a-d1c3-4c09-90aa-4697f163c1a9" />

<img width="1386" height="226" alt="image" src="https://github.com/user-attachments/assets/2fe57167-eead-4d95-9fee-dfa5b433dc2b" />

fixes #33852 