### PR TITLE
fix: clear doc_events_hooks cache during uninstallation of app

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -924,7 +924,7 @@ def get_installed_apps(*, _ensure_on_bench: bool = False) -> list[str]:
 
 def get_doc_hooks():
 	"""Return hooked methods for given doc. Expand the dict tuple if required."""
-	if not hasattr(local, "doc_events_hooks"):
+	if not hasattr(local, "doc_events_hooks") or local.doc_events_hooks is None:
 		hooks = get_hooks("doc_events", {})
 		out = {}
 		for key, value in hooks.items():

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -924,7 +924,7 @@ def get_installed_apps(*, _ensure_on_bench: bool = False) -> list[str]:
 
 def get_doc_hooks():
 	"""Return hooked methods for given doc. Expand the dict tuple if required."""
-	if not hasattr(local, "doc_events_hooks") or local.doc_events_hooks is None:
+	if not getattr(local, "doc_events_hooks", None):
 		hooks = get_hooks("doc_events", {})
 		out = {}
 		for key, value in hooks.items():

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -359,6 +359,7 @@ def remove_from_installed_apps(app_name):
 			"DefaultValue", {"defkey": "installed_apps"}, "defvalue", json.dumps(installed_apps)
 		)
 		_clear_cache("__global")
+		frappe.local.doc_events_hooks = None
 		frappe.get_single("Installed Applications").update_versions()
 		frappe.db.commit()
 		if frappe.flags.in_install:


### PR DESCRIPTION
During the uninstallation of an app, the `Installed Application` document is updated, and the `doc_events` hooks of the uninstalled app are executed since they are served from the cache.

Fixed it to clear the cached `doc_events_hooks` during the app's uninstallation process.