### PR TITLE
fix: Backups were not showing on the Download Backups page due to a time conversion issue

### DIFF
--- a/frappe/desk/page/backups/backups.html
+++ b/frappe/desk/page/backups/backups.html
@@ -1,7 +1,7 @@
 <!-- jinja -->
-<div class="row download-backups">
+<div class="row download-backups py-4 px-4 m-0">
     {% for f in files %}
-    <div class="col-lg-3 col-md-4 col-12">
+    <div class="col-lg-3 col-md-4 col-12 pr-4 pl-0">
         <a href="{{ f[0] }}" target="_blank" rel="noopener noreferrer" class="frappe-card download-backup-card">
             <div>
                 {{ f[1] }}

--- a/frappe/desk/page/backups/backups.py
+++ b/frappe/desk/page/backups/backups.py
@@ -10,7 +10,7 @@ from frappe.utils.data import convert_utc_to_system_timezone
 
 def get_time(path: Path):
 	return convert_utc_to_system_timezone(
-		datetime.datetime.fromtimestamp(path.stat().st_mtime, tz=datetime.UTC)
+		datetime.datetime.fromtimestamp(path.stat().st_mtime, tz=datetime.timezone.utc)
 	).strftime("%a %b %d %H:%M %Y")
 
 

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -165,7 +165,7 @@ class TestAuth(IntegrationTestCase):
 		client = FrappeClient(self.HOST_NAME, self.test_user_email, self.test_user_password)
 
 		expiry_time = next(x for x in client.session.cookies if x.name == "sid").expires
-		current_time = datetime.datetime.now(tz=datetime.UTC).timestamp()
+		current_time = datetime.datetime.now(tz=datetime.timezone.utc).timestamp()
 		self.assertAlmostEqual(get_expiry_in_seconds(), expiry_time - current_time, delta=60 * 60)
 
 


### PR DESCRIPTION
Backups were not showing on the Download Backups page due to a time conversion issue. The datetime.UTC alias was added in Python 3.11. Also fixed some styles.


After fix:
<img width="1217" height="298" alt="Screenshot 2025-10-09 at 5 03 08 PM" src="https://github.com/user-attachments/assets/5009fdf2-474d-4406-b044-bb3c4d242b80" />


Fixes https://github.com/frappe/erpnext/issues/49264
Fixes https://github.com/frappe/frappe/issues/23190