### PR TITLE
fix: use link title as address title

### DIFF
--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -57,9 +57,8 @@ class Address(Document):
 		self.flags.linked = False
 
 	def autoname(self):
-		if not self.address_title:
-			if self.links:
-				self.address_title = self.links[0].link_name
+		if not self.address_title and self.links:
+			self.address_title = self.links[0].link_title or self.links[0].link_name
 
 		if self.address_title:
 			self.name = cstr(self.address_title).strip() + "-" + cstr(_(self.address_type)).strip()


### PR DESCRIPTION
When we use _Naming Series_ for naming parties like **Lead** or **Customer**, the addresses we add to them get our internal ID as the _Address Title_. However, a shipment addressed to "CUST-0001" is unlikely to arrive.

By preferring the _Link Title_ (usually the party name), shipments are more likely to arrive.