### PR TITLE
fix: Clear DB value cache after commit/rollback

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1192,6 +1192,7 @@ class Database:
 			self.sql("commit")
 			self.begin()
 
+		self.value_cache.clear()
 		self.after_commit.run()
 
 	def rollback(self, *, save_point=None, chain=False):
@@ -1206,10 +1207,12 @@ class Database:
 
 			if chain:
 				self.sql("rollback and chain")
+				self.value_cache.clear()
 			else:
 				self.sql("rollback")
 				self.begin()
 
+			self.value_cache.clear()
 			self.after_rollback.run()
 		else:
 			warnings.warn(message=TRANSACTION_DISABLED_MSG, stacklevel=2)


### PR DESCRIPTION
Respect repeatable read, but not beyond transaction, if transaction is committed during a request then cache should be invalidated.

This will likely slow down some code in a loop that did repeated queries + commit but we can't compromise correctness here.
