### PR TITLE
fix: increase label field length to 255 chars

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -85,6 +85,7 @@
    "fieldtype": "Data",
    "in_filter": 1,
    "label": "Label",
+   "length": 255,
    "no_copy": 1,
    "oldfieldname": "label",
    "oldfieldtype": "Data"
@@ -468,11 +469,12 @@
    "label": "Placeholder"
   }
  ],
+ "grid_page_length": 50,
  "icon": "fa fa-glass",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-28 20:19:35.935720",
+ "modified": "2025-10-10 11:10:23.862393",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",
@@ -501,6 +503,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "dt,label,fieldtype,options",
  "sort_field": "creation",
  "sort_order": "DESC",


### PR DESCRIPTION
Some custom field labels were getting truncated when exceeding 140 characters.

This caused issues during customization of complex forms where descriptive labels were required.