### PR TITLE
fix: enable fetching datetime fields in Quick Entry dialogs

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -743,6 +743,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					"Float",
 					"Int",
 					"Date",
+					"Datetime",
 					"Select",
 					"Duration",
 					"Time",


### PR DESCRIPTION
  This fixes datetime field fetching in Quick Entry dialogs.

  PR #28602 fixed normal forms but missed Quick Entry. This PR adds the same fix to Quick Entry by adding `"Datetime"` to the fetchable field types in
  `link.js`.

  Now datetime fields work in both normal forms and Quick Entry dialogs.

  Related: #28583, #28602

**Question for maintainers:**

  While fixing this, I noticed other field types are also missing from both files:
  - `Long Text`, `Percent`, `Phone`, `Barcode`, `Autocomplete`, `Icon`, `Color`, `Rating`

  Were these intentionally excluded, or should I create a follow-up PR to add them as well?

**Before**

https://github.com/user-attachments/assets/4b4e172c-90ad-4377-a07c-ee391eeee634

**After**

https://github.com/user-attachments/assets/733aa3c4-6d0a-4da5-997b-7d0a1ee367f1
