### PR TITLE
fix: Kanban columns expand when card has long text

### DIFF
--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -30,6 +30,7 @@
 		@include transition();
 
 		flex: 1 0 260px;
+		max-width: 300px;
 		border-radius: var(--border-radius);
 		padding: var(--padding-md);
 		min-height: calc(


### PR DESCRIPTION
 ## Bug
  Kanban columns expand horizontally when a card has very long text breaking the layout.

  **Before**

<img width="1480" height="674" alt="Screenshot 2025-10-12 at 5 59 40 PM" src="https://github.com/user-attachments/assets/44ceffee-246b-4dbe-97e9-f0f50fbce4ad" />


**After**

<img width="1470" height="653" alt="Screenshot 2025-10-12 at 5 58 40 PM" src="https://github.com/user-attachments/assets/be05d3f8-f2b2-4e16-b44f-d245520d2a8c" />