### PR TITLE
  feat: Support dynamic expressions in workflow update_value field

### DIFF
--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -98,12 +98,18 @@ def is_transition_condition_satisfied(transition, doc) -> bool:
 		return frappe.safe_eval(transition.condition, get_workflow_safe_globals(), dict(doc=doc.as_dict()))
 
 
-def evaluate_workflow_value(value, doc):
+def evaluate_workflow_value(value, evaluate_as_expression, doc):
 	if not value:
 		return None
-	try:
-		return frappe.safe_eval(value, get_workflow_safe_globals(), dict(doc=doc.as_dict()))
-	except Exception:
+	if evaluate_as_expression:
+		try:
+			return frappe.safe_eval(value, get_workflow_safe_globals(), dict(doc=doc.as_dict()))
+		except Exception as e:
+			frappe.throw(
+				_("Invalid expression in Workflow Update Value: {0}").format(e),
+				title=_("Workflow Evaluation Error"),
+			)
+	else:
 		return value
 
 
@@ -136,7 +142,9 @@ def apply_workflow(doc, action):
 
 	# update any additional field
 	if next_state.update_field:
-		update_value = evaluate_workflow_value(next_state.update_value, doc)
+		update_value = evaluate_workflow_value(
+			next_state.update_value, next_state.evaluate_as_expression, doc
+		)
 		doc.set(next_state.update_field, update_value)
 
 	if transition.transition_tasks:

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -98,6 +98,15 @@ def is_transition_condition_satisfied(transition, doc) -> bool:
 		return frappe.safe_eval(transition.condition, get_workflow_safe_globals(), dict(doc=doc.as_dict()))
 
 
+def evaluate_workflow_value(value, doc):
+	if not value:
+		return None
+	try:
+		return frappe.safe_eval(value, get_workflow_safe_globals(), dict(doc=doc.as_dict()))
+	except Exception:
+		return value
+
+
 @frappe.whitelist()
 def apply_workflow(doc, action):
 	"""Allow workflow action on the current doc"""
@@ -127,7 +136,8 @@ def apply_workflow(doc, action):
 
 	# update any additional field
 	if next_state.update_field:
-		doc.set(next_state.update_field, next_state.update_value)
+		update_value = evaluate_workflow_value(next_state.update_value, doc)
+		doc.set(next_state.update_field, update_value)
 
 	if transition.transition_tasks:
 		workflow_transitions = frappe.db.get_all(

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -130,6 +130,57 @@ class TestWorkflow(IntegrationTestCase):
 			"invalid python code" in str(se.exception).lower(), msg="Python code validation not working"
 		)
 
+	def test_dynamic_update_value_expression(self):
+		"""Test dynamic expression evaluation in workflow update_value field"""
+		self.workflow.states[1].update_field = "assigned_by"
+		self.workflow.states[1].update_value = "frappe.session.user"
+		self.workflow.states[1].evaluate_as_expression = 1
+		self.workflow.save()
+
+		todo = create_new_todo()
+		apply_workflow(todo, "Approve")
+
+		self.assertEqual(todo.assigned_by, frappe.session.user)
+
+	def test_dynamic_update_value_with_doc_field(self):
+		"""Test dynamic expression using doc field value"""
+		self.workflow.states[1].update_field = "description"
+		self.workflow.states[1].update_value = "doc.allocated_to or 'No assignee'"
+		self.workflow.states[1].evaluate_as_expression = 1
+		self.workflow.save()
+
+		todo = create_new_todo()
+		todo.allocated_to = "Administrator"
+		todo.save()
+
+		apply_workflow(todo, "Approve")
+
+		self.assertEqual(todo.description, "Administrator")
+
+	def test_static_value_when_expression_disabled(self):
+		"""Test that value is not evaluated when evaluate_as_expression is disabled"""
+		self.workflow.states[1].update_field = "sender"
+		self.workflow.states[1].update_value = "frappe.session.user"
+		self.workflow.states[1].evaluate_as_expression = 0
+		self.workflow.save()
+
+		todo = create_new_todo()
+		apply_workflow(todo, "Approve")
+
+		self.assertEqual(todo.sender, "frappe.session.user")
+
+	def test_invalid_expression_raises_error(self):
+		"""Test that invalid expression raises proper error"""
+		self.workflow.states[1].update_field = "sender"
+		self.workflow.states[1].update_value = "invalid_syntax(("
+		self.workflow.states[1].evaluate_as_expression = 1
+		self.workflow.save()
+
+		todo = create_new_todo()
+
+		with self.assertRaises(frappe.ValidationError):
+			apply_workflow(todo, "Approve")
+
 	# app-defined workflow task tests start here
 	def test_sync_tasks(self, doc=None):
 		"""test workflow with workflow tasks (server scripts, webhooks and app-defined methods)"""

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -159,7 +159,7 @@ class TestWorkflow(IntegrationTestCase):
 
 	def test_static_value_when_expression_disabled(self):
 		"""Test that value is not evaluated when evaluate_as_expression is disabled"""
-		self.workflow.states[1].update_field = "sender"
+		self.workflow.states[1].update_field = "description"
 		self.workflow.states[1].update_value = "frappe.session.user"
 		self.workflow.states[1].evaluate_as_expression = 0
 		self.workflow.save()
@@ -167,11 +167,11 @@ class TestWorkflow(IntegrationTestCase):
 		todo = create_new_todo()
 		apply_workflow(todo, "Approve")
 
-		self.assertEqual(todo.sender, "frappe.session.user")
+		self.assertEqual(todo.description, "frappe.session.user")
 
 	def test_invalid_expression_raises_error(self):
 		"""Test that invalid expression raises proper error"""
-		self.workflow.states[1].update_field = "sender"
+		self.workflow.states[1].update_field = "description"
 		self.workflow.states[1].update_value = "invalid_syntax(("
 		self.workflow.states[1].evaluate_as_expression = 1
 		self.workflow.save()

--- a/frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
+++ b/frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
@@ -51,7 +51,7 @@
    "label": "Update Field"
   },
   {
-   "description": "Value to set when this workflow state is applied. Use plain text (e.g. Approved) or a Expression if \u201cEvaluate as Expression\u201d is enabled.",
+   "description": "Value to set when this workflow state is applied. Use plain text (e.g. Approved) or an expression if \u201cEvaluate as Expression\u201d is enabled.",
    "fieldname": "update_value",
    "fieldtype": "Data",
    "in_list_view": 1,

--- a/frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
+++ b/frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
@@ -50,6 +50,7 @@
    "label": "Update Field"
   },
   {
+   "description": "Static value (e.g., \"Approved\") or dynamic expression (e.g., frappe.session.user, frappe.utils.now(), doc.fieldname)",
    "fieldname": "update_value",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -118,7 +119,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-01 23:35:56.203734",
+ "modified": "2025-10-12 18:34:59.760219",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Document State",

--- a/frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
+++ b/frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
@@ -11,6 +11,7 @@
   "doc_status",
   "update_field",
   "update_value",
+  "evaluate_as_expression",
   "column_break_4",
   "is_optional_state",
   "avoid_status_override",
@@ -50,7 +51,7 @@
    "label": "Update Field"
   },
   {
-   "description": "Static value (e.g., \"Approved\") or dynamic expression (e.g., frappe.session.user, frappe.utils.now(), doc.fieldname)",
+   "description": "Value to set when this workflow state is applied. Use plain text (e.g. Approved) or a Expression if \u201cEvaluate as Expression\u201d is enabled.",
    "fieldname": "update_value",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -114,12 +115,19 @@
    "fieldname": "send_email",
    "fieldtype": "Check",
    "label": "Send Email On State"
+  },
+  {
+   "default": "0",
+   "description": "Check this if the Update Value is a formula or expression (e.g. doc.amount * 2). Leave unchecked for plain text values.",
+   "fieldname": "evaluate_as_expression",
+   "fieldtype": "Check",
+   "label": "Evaluate as Expression"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-12 18:34:59.760219",
+ "modified": "2025-11-08 10:16:23.592473",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Document State",

--- a/frappe/workflow/doctype/workflow_document_state/workflow_document_state.py
+++ b/frappe/workflow/doctype/workflow_document_state/workflow_document_state.py
@@ -17,6 +17,7 @@ class WorkflowDocumentState(Document):
 		allow_edit: DF.Link
 		avoid_status_override: DF.Check
 		doc_status: DF.Literal["0", "1", "2"]
+		evaluate_as_expression: DF.Check
 		is_optional_state: DF.Check
 		message: DF.Text | None
 		next_action_email_template: DF.Link | None


### PR DESCRIPTION
**Summary**
  Allows workflow `update_value` field to accept dynamic Python expressions in addition to static values.

 **Changes**
  - Added `evaluate_workflow_value()` function using same logic as `is_transition_condition_satisfied()`
  - Uses existing `get_workflow_safe_globals()` for secure evaluation
  - Added field description with usage examples

**Use Cases**
  - Set approved_by to current user (`frappe.session.user`)
  - Set approval_date to current time (`frappe.utils.now()`)
  - Copy document field values (`doc.fieldname`)

<img width="954" height="370" alt="Screenshot from 2025-10-15 22-05-42" src="https://github.com/user-attachments/assets/9fe6f8cb-926c-4f5e-b9f6-bc880a48a6fb" />


**Before**

[before.webm](https://github.com/user-attachments/assets/97d3f5dc-c051-4d3d-a2c7-821b163630e1)

**After**

[after.webm](https://github.com/user-attachments/assets/82c02704-f93b-413d-b578-59ee5a5c966e)

