### PR TITLE
fix: web form allow incomplete feature not working

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -641,6 +641,10 @@ def accept(web_form, data):
 		# insert
 		doc = frappe.new_doc(doctype)
 
+	# Set ignore_mandatory flag if allow_incomplete is enabled
+	if web_form.allow_incomplete:
+		doc.flags.ignore_mandatory = True
+
 	# set values
 	for field in web_form.web_form_fields:
 		fieldname = field.fieldname
@@ -671,7 +675,7 @@ def accept(web_form, data):
 		if web_form.login_required and frappe.session.user == "Guest":
 			frappe.throw(_("You must login to submit this form"))
 
-		ignore_mandatory = True if files else False
+		ignore_mandatory = True if (files or web_form.allow_incomplete) else False
 
 		doc.insert(ignore_permissions=True, ignore_mandatory=ignore_mandatory)
 


### PR DESCRIPTION
**Summary**
Fixes the "Allow Incomplete" checkbox in web forms. This feature was not working - users got 500 errors when trying to save incomplete forms.

 Fixes #22802