### PR TITLE
fix(Website): description not clearly visible

### DIFF
--- a/frappe/public/scss/website/index.scss
+++ b/frappe/public/scss/website/index.scss
@@ -182,7 +182,7 @@ a.card-link:hover {
 }
 
 .text-extra-muted {
-	color: #d1d8dd !important;
+	color: var(--gray-500) !important;
 }
 
 .no-underline {


### PR DESCRIPTION
### Before
<img width="1698" height="896" alt="image" src="https://github.com/user-attachments/assets/d69155fb-56d2-4feb-bd2b-5403bd98e01a" />


### After
<img width="1684" height="994" alt="image" src="https://github.com/user-attachments/assets/eaea9f1f-1d53-4b6c-9925-a713e9133b54" />
