### PR TITLE
fix: webform get fields not fetching description

### DIFF
--- a/frappe/website/doctype/web_form/web_form.js
+++ b/frappe/website/doctype/web_form/web_form.js
@@ -118,6 +118,7 @@ frappe.ui.form.on("Web Form", {
 							read_only: df.read_only,
 							precision: df.precision,
 							depends_on: df.depends_on,
+							description: df.description,
 							mandatory_depends_on: df.mandatory_depends_on,
 							read_only_depends_on: df.read_only_depends_on,
 						});
@@ -337,6 +338,7 @@ frappe.ui.form.on("Web Form Field", {
 		doc.default = df.default;
 		doc.read_only = df.read_only;
 		doc.depends_on = df.depends_on;
+		doc.description = df.description;
 		doc.mandatory_depends_on = df.mandatory_depends_on;
 		doc.read_only_depends_on = df.read_only_depends_on;
 


### PR DESCRIPTION
**Summary**
  When clicking "Get Fields" in Web Form, field descriptions were not copied from DocType.


  Fixes #34368