### PR TITLE
fix: exclude table fields from available field types in AddFieldButton

### DIFF
--- a/frappe/public/js/form_builder/components/AddFieldButton.vue
+++ b/frappe/public/js/form_builder/components/AddFieldButton.vue
@@ -64,6 +64,9 @@ const fields = computed(() => {
 			if (in_list(frappe.model.layout_fields, df)) {
 				return false;
 			}
+			if (store.doc.istable && in_list(frappe.model.table_fields, df)) {
+				return false;
+			}
 			return true;
 		})
 		.map((df) => {


### PR DESCRIPTION
Added filtering logic to exclude table field types when working with child tables.