### PR TITLE
feat: add placeholder and max_length support to webform fields

### DIFF
--- a/frappe/website/doctype/web_form/web_form.js
+++ b/frappe/website/doctype/web_form/web_form.js
@@ -118,6 +118,7 @@ frappe.ui.form.on("Web Form", {
 							read_only: df.read_only,
 							precision: df.precision,
 							depends_on: df.depends_on,
+							placeholder: df.placeholder,
 							mandatory_depends_on: df.mandatory_depends_on,
 							read_only_depends_on: df.read_only_depends_on,
 						});
@@ -337,6 +338,7 @@ frappe.ui.form.on("Web Form Field", {
 		doc.default = df.default;
 		doc.read_only = df.read_only;
 		doc.depends_on = df.depends_on;
+		doc.placeholder = df.placeholder;
 		doc.mandatory_depends_on = df.mandatory_depends_on;
 		doc.read_only_depends_on = df.read_only_depends_on;
 

--- a/frappe/website/doctype/web_form/web_form.js
+++ b/frappe/website/doctype/web_form/web_form.js
@@ -119,6 +119,7 @@ frappe.ui.form.on("Web Form", {
 							precision: df.precision,
 							depends_on: df.depends_on,
 							placeholder: df.placeholder,
+							max_length: df.length,
 							mandatory_depends_on: df.mandatory_depends_on,
 							read_only_depends_on: df.read_only_depends_on,
 						});
@@ -340,6 +341,7 @@ frappe.ui.form.on("Web Form Field", {
 		doc.depends_on = df.depends_on;
 		doc.placeholder = df.placeholder;
 		doc.mandatory_depends_on = df.mandatory_depends_on;
+		doc.max_length = df.length;
 		doc.read_only_depends_on = df.read_only_depends_on;
 
 		frm.refresh_field("web_form_fields");

--- a/frappe/website/doctype/web_form_field/web_form_field.json
+++ b/frappe/website/doctype/web_form_field/web_form_field.json
@@ -26,7 +26,8 @@
   "section_break_6",
   "description",
   "column_break_8",
-  "default"
+  "default",
+  "placeholder"
  ],
  "fields": [
   {
@@ -152,16 +153,22 @@
    "fieldtype": "Select",
    "label": "Precision",
    "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+  },
+  {
+   "fieldname": "placeholder",
+   "fieldtype": "Data",
+   "label": "Placeholder"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-04-15 16:11:58.469820",
+ "modified": "2025-10-13 16:53:27.147994",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form Field",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/frappe/website/doctype/web_form_field/web_form_field.py
+++ b/frappe/website/doctype/web_form_field/web_form_field.py
@@ -19,34 +19,7 @@ class WebFormField(Document):
 		depends_on: DF.Code | None
 		description: DF.Text | None
 		fieldname: DF.Literal[None]
-		fieldtype: DF.Literal[
-			"Attach",
-			"Attach Image",
-			"Check",
-			"Currency",
-			"Color",
-			"Data",
-			"Date",
-			"Datetime",
-			"Duration",
-			"Float",
-			"HTML",
-			"Int",
-			"Link",
-			"Password",
-			"Phone",
-			"Rating",
-			"Select",
-			"Signature",
-			"Small Text",
-			"Text",
-			"Text Editor",
-			"Table",
-			"Time",
-			"Section Break",
-			"Column Break",
-			"Page Break",
-		]
+		fieldtype: DF.Literal["Attach", "Attach Image", "Check", "Currency", "Color", "Data", "Date", "Datetime", "Duration", "Float", "HTML", "Int", "Link", "Password", "Phone", "Rating", "Select", "Signature", "Small Text", "Text", "Text Editor", "Table", "Time", "Section Break", "Column Break", "Page Break"]
 		hidden: DF.Check
 		label: DF.Data | None
 		mandatory_depends_on: DF.Code | None
@@ -56,6 +29,7 @@ class WebFormField(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		placeholder: DF.Data | None
 		precision: DF.Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
 		read_only: DF.Check
 		read_only_depends_on: DF.Code | None

--- a/frappe/website/doctype/web_form_field/web_form_field.py
+++ b/frappe/website/doctype/web_form_field/web_form_field.py
@@ -19,7 +19,34 @@ class WebFormField(Document):
 		depends_on: DF.Code | None
 		description: DF.Text | None
 		fieldname: DF.Literal[None]
-		fieldtype: DF.Literal["Attach", "Attach Image", "Check", "Currency", "Color", "Data", "Date", "Datetime", "Duration", "Float", "HTML", "Int", "Link", "Password", "Phone", "Rating", "Select", "Signature", "Small Text", "Text", "Text Editor", "Table", "Time", "Section Break", "Column Break", "Page Break"]
+		fieldtype: DF.Literal[
+			"Attach",
+			"Attach Image",
+			"Check",
+			"Currency",
+			"Color",
+			"Data",
+			"Date",
+			"Datetime",
+			"Duration",
+			"Float",
+			"HTML",
+			"Int",
+			"Link",
+			"Password",
+			"Phone",
+			"Rating",
+			"Select",
+			"Signature",
+			"Small Text",
+			"Text",
+			"Text Editor",
+			"Table",
+			"Time",
+			"Section Break",
+			"Column Break",
+			"Page Break",
+		]
 		hidden: DF.Check
 		label: DF.Data | None
 		mandatory_depends_on: DF.Code | None


### PR DESCRIPTION
**Summary**
  Adds placeholder and max_length support to Web Form fields, matching functionality available in DocType forms.

 **Changes**
  - Added `placeholder` field to Web Form Field doctype
  - Copy `placeholder` from DocType when using "Get Fields"
  - Copy `max_length` from DocType when using "Get Fields"


`no-docs`