### PR TITLE
  fix: enable fetching additional field types in both forms and Quick Entry dialogs

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -740,6 +740,13 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					"Select",
 					"Duration",
 					"Time",
+					"Percent",
+					"Phone",
+					"Barcode",
+					"Autocomplete",
+					"Icon",
+					"Color",
+					"Rating",
 				].includes(df.fieldtype) ||
 				df.read_only == 1 ||
 				df.is_virtual == 1;

--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -223,6 +223,13 @@ frappe.ui.form.ScriptManager = class ScriptManager {
 					"Select",
 					"Duration",
 					"Time",
+					"Percent",
+					"Phone",
+					"Barcode",
+					"Autocomplete",
+					"Icon",
+					"Color",
+					"Rating",
 				].includes(df.fieldtype) ||
 				df.read_only == 1 ||
 				df.is_virtual == 1;


### PR DESCRIPTION
**Summary**
  Enables fetching for additional field types (Percent, Phone, Barcode, Autocomplete, Icon, Color, Rating) in both normal forms and Quick Entry
  dialogs.

  This is a follow-up to PR #34351 