### PR TITLE
fix: add spacing between barcode input and preview

### DIFF
--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -310,6 +310,7 @@ textarea.form-control {
 }
 
 .barcode-wrapper {
+	margin-top: var(--margin-xs);
 	text-align: center;
 	background-color: var(--control-bg);
 	border-radius: var(--border-radius);


### PR DESCRIPTION
**Problem**
  The barcode input field and the barcode graphic were too close together, causing them to appear overlapping. This made it unclear which element was for editing vs. display only.


  **Before:**

<img width="462" height="206" alt="before" src="https://github.com/user-attachments/assets/c0f5bef3-e6d8-48e7-944c-953318edcbc6" />


  **After:**

<img width="443" height="199" alt="after" src="https://github.com/user-attachments/assets/c1a12ba5-c57d-4750-abe0-9f4dff8fb38a" />
