### PR TITLE
Link field filter not validated when pasting value manually #34363

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -417,57 +417,93 @@ def is_document_amended(doctype, docname):
 
 @frappe.whitelist()
 def validate_link(doctype: str, docname: str, fields=None):
-	if not isinstance(doctype, str):
-		frappe.throw(_("DocType must be a string"))
+	try:
+		if not isinstance(doctype, str):
+			frappe.throw(_("DocType must be a string"))
 
-	if not isinstance(docname, str):
-		frappe.throw(_("Document Name must be a string"))
+		if not isinstance(docname, str):
+			frappe.throw(_("Document Name must be a string"))
 
-	if doctype != "DocType":
-		parent_doctype = None
-		if frappe.get_meta(doctype).istable:  # needed for links to child rows
-			parent_doctype = frappe.db.get_value(doctype, docname, "parenttype")
-		if not (
-			frappe.has_permission(doctype, "select", parent_doctype=parent_doctype)
-			or frappe.has_permission(doctype, "read", parent_doctype=parent_doctype)
-		):
-			frappe.throw(
-				_("You do not have Read or Select Permissions for {}").format(frappe.bold(doctype)),
-				frappe.PermissionError,
+		if doctype != "DocType":
+			parent_doctype = None
+			if frappe.get_meta(doctype).istable:  # needed for links to child rows
+				parent_doctype = frappe.db.get_value(doctype, docname, "parenttype")
+			if not (
+				frappe.has_permission(doctype, "select", parent_doctype=parent_doctype)
+				or frappe.has_permission(doctype, "read", parent_doctype=parent_doctype)
+			):
+				frappe.throw(
+					_("You do not have Read or Select Permissions for {}").format(frappe.bold(doctype)),
+					frappe.PermissionError,
+				)
+
+		values = frappe._dict()
+
+		if is_virtual_doctype(doctype):
+			try:
+				frappe.get_doc(doctype, docname)
+				values.name = docname
+			except frappe.DoesNotExistError:
+				frappe.clear_last_message()
+				frappe.msgprint(
+					_("Document {0} {1} does not exist").format(frappe.bold(doctype), frappe.bold(docname)),
+				)
+			return values
+
+		values.name = frappe.db.get_value(doctype, docname, cache=True)
+
+		# filters from Link field definition (get_query filters)
+		filters = frappe.local.form_dict.get("filters")
+
+		filters = json.loads(filters) if filters else {}
+		if filters and isinstance(filters, dict):
+			
+			description = frappe.local.form_dict.get("description")
+			desc = description.split("Filters applied for")[1]
+
+			row = frappe.db.get_value(
+				doctype, docname, list(filters.keys()), as_dict=True
 			)
+			if not row:
+				frappe.throw(_("Invalid {0}: {1}").format(_(doctype), docname))
+			for key, expected in filters.items():
+				if isinstance(expected, (list, tuple)):
+					if row.get(key) not in expected:
+						frappe.throw(
+							_(
+								"Value '<b>{0}</b>' is does not match filters. {1}"
+							).format(docname, desc),
+							title=_("Invalid Link Value"),
+						)
+						return {"error": True }
+				elif row.get(key) != expected:
+					frappe.throw(
+						_(
+							"Value '<b>{0}</b>' is does not match filters. {1}"
+						).format(docname, _(doctype), desc),
+						title=_("Invalid Link Value"),
+					)
+					return {"error": True}
 
-	values = frappe._dict()
+		fields = frappe.parse_json(fields)
+		if not values.name or not fields:
+			return values
 
-	if is_virtual_doctype(doctype):
 		try:
-			frappe.get_doc(doctype, docname)
-			values.name = docname
-		except frappe.DoesNotExistError:
+			values.update(get_value(doctype, fields, docname))
+		except frappe.PermissionError:
 			frappe.clear_last_message()
 			frappe.msgprint(
-				_("Document {0} {1} does not exist").format(frappe.bold(doctype), frappe.bold(docname)),
+				_("You need {0} permission to fetch values from {1} {2}").format(
+					frappe.bold(_("Read")), frappe.bold(doctype), frappe.bold(docname)
+				),
+				title=_("Cannot Fetch Values"),
+				indicator="orange",
 			)
+
 		return values
-
-	values.name = frappe.db.get_value(doctype, docname, cache=True)
-
-	fields = frappe.parse_json(fields)
-	if not values.name or not fields:
-		return values
-
-	try:
-		values.update(get_value(doctype, fields, docname))
-	except frappe.PermissionError:
-		frappe.clear_last_message()
-		frappe.msgprint(
-			_("You need {0} permission to fetch values from {1} {2}").format(
-				frappe.bold(_("Read")), frappe.bold(doctype), frappe.bold(docname)
-			),
-			title=_("Cannot Fetch Values"),
-			indicator="orange",
-		)
-
-	return values
+	except Exception as e:
+		frappe.log_error("Error: While Validating Link filters", f"doctype: {doctype}\ndocname: {docname}\nfields: {fields}\nError: {e}")
 
 
 def insert_doc(doc) -> "Document":

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -688,8 +688,13 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					doctype: options,
 					docname: value,
 					fields: columns_to_fetch,
+					filters: (typeof this.get_query === "function" && this.get_query()?.filters) || {},
+					description: this.get_filter_description((typeof this.get_query === "function" && this.get_query()?.filters) || {})
 				})
 				.then((response) => {
+					if (!response){
+						return ""
+					}
 					if (!this.docname || !columns_to_fetch.length) {
 						return response.name;
 					}

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -695,11 +695,12 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					if (!response){
 						return ""
 					}
-					if (!this.docname || !columns_to_fetch.length) {
+					if (this.frm && !this.docname) {
 						return response.name;
 					}
-					update_dependant_fields(response);
-					return response.name;
+					if (!columns_to_fetch.length) {
+						return response.name;
+					}
 				});
 		} else {
 			update_dependant_fields({});


### PR DESCRIPTION
**Title:**
Link field filter not validated when pasting value manually

**Description:**
Link field filter works correctly in dropdown, but if I paste a value that doesn’t match the filter (e.g., an item with Allow Sales = 0), Frappe still allows saving.

It should show a message or prevent saving when the pasted value doesn’t meet the filter condition.

**Steps to Reproduce:**
Add a filter in link field, e.g.:

get_query: () => ({ filters: { allow_sales: 1 } })
Open the form → dropdown shows only items with Allow Sales = 1 ✅
Copy an item code with Allow Sales = 0 and paste it in the field ❌
Save → record is saved without validation.
**Expected Result:**
Frappe should not allow saving invalid values or should show a warning message.

**Actual Result:**
Filter is ignored when value is pasted manually.

**Video:**
https://github.com/user-attachments/assets/aabd6a22-4f31-4d25-86ca-49b2e5984497

**Environment:**
Frappe Version: v15.57.2
Browser: Chrome
OS: Ubuntu

**Solution**

https://github.com/user-attachments/assets/5dfce4be-1e0f-46a3-b89a-feaa7f67e29e

