### PR TITLE
feat: Cancel Button Added for Data Import

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.js
+++ b/frappe/core/doctype/prepared_report/prepared_report.js
@@ -62,6 +62,26 @@ frappe.ui.form.on("Prepared Report", {
 					});
 				});
 			}
+		} else if (frm.doc.status == "Queued" || frm.doc.status == "Started") {
+			frm.add_custom_button(__("Cancel Prepared Report"), () => {
+				frappe.confirm(
+					__(
+						"This will terminate the job immediately and might be dangerous, are you sure?"
+					),
+					() => {
+						frappe
+							.xcall(
+								"frappe.core.doctype.prepared_report.prepared_report.stop_prepared_report",
+								{
+									report_name: frm.doc.name,
+								}
+							)
+							.then((r) => {
+								frm.reload_doc();
+							});
+					}
+				);
+			});
 		}
 	},
 });


### PR DESCRIPTION
**Problem:**
Feat: When running long operations like data imports or bulk updates there's no way to cancel them if something goes wrong. The frappe.show_progress() dialog only shows progress but doesn't let users stop the operation. This means if one accidentally starts importing the wrong file or the process gets stuck, they might have to refresh the entire page which can corrupt data or lose progress.
Resolving Issue: #32673

**Before:**

There was no button, RQ Job page contains "stop job" button which could be used for the same.

**After:**

Demo for Cancellable Data Imports

https://github.com/user-attachments/assets/7087918c-20b2-42b2-89b7-09f1f7ecf3cc


Demo for Prepared Reports


https://github.com/user-attachments/assets/27abe084-febc-4fec-afab-87b8786338ac




related to #32673 