### PR TITLE
feat: redirect to print format doc when type is jinja

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -259,10 +259,18 @@ frappe.ui.form.PrintView = class {
 			print_format.name &&
 			(print_format.print_format_builder || print_format.print_format_builder_beta) &&
 			print_format.standard === "No";
-		let is_standard_but_editable = print_format.name && print_format.custom_format;
 
-		if (is_standard_but_editable) {
-			frappe.set_route("Form", "Print Format", print_format.name);
+		let is_standard_jinja_custom =
+			print_format.standard === "Yes" &&
+			print_format.custom_format &&
+			print_format.print_format_type === "Jinja";
+
+		if (is_standard_jinja_custom) {
+			let doc = frappe.get_doc("Print Format", print_format.name);
+			frappe.model.with_doctype("Print Format", () => {
+				let newdoc = frappe.model.copy_doc(doc);
+				frappe.set_route("Form", "Print Format", newdoc.name);
+			});
 			return;
 		}
 		if (is_custom_format) {

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -273,6 +273,14 @@ frappe.ui.form.PrintView = class {
 			});
 			return;
 		}
+
+		let is_editable = print_format.name && print_format.custom_format;
+
+		if (is_editable) {
+			frappe.set_route("Form", "Print Format", print_format.name);
+			return;
+		}
+
 		if (is_custom_format) {
 			if (print_format.print_format_builder_beta) {
 				frappe.set_route("print-format-builder-beta", print_format.name);


### PR DESCRIPTION
Previously, all custom print formats were opened in the Print Format Builder. This change adds a condition to detect standard Jinja-based custom formats and redirects the user to the Print Format doctype form instead of the builder.
Ref: https://github.com/frappe/erpnext/pull/49508


https://github.com/user-attachments/assets/1daf49a5-b5be-4984-8b8b-9e8f1b6aec47



`no-docs`