### PR TITLE
feat: backport keyboard numeric inputmode (from PR 27043)

### DIFF
--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -7,10 +7,11 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 	make_input() {
 		if (this.$input) return;
 
-		let { html_element, input_type } = this.constructor;
+		let { html_element, input_type, input_mode } = this.constructor;
 
 		this.$input = $("<" + html_element + ">")
 			.attr("type", input_type)
+			.attr("inputmode", input_mode)
 			.attr("autocomplete", "off")
 			.addClass("input-with-feedback form-control")
 			.prependTo(this.input_area);

--- a/frappe/public/js/frappe/form/controls/int.js
+++ b/frappe/public/js/frappe/form/controls/int.js
@@ -1,5 +1,6 @@
 frappe.ui.form.ControlInt = class ControlInt extends frappe.ui.form.ControlData {
 	static trigger_change_on_input_event = false;
+	static input_mode = "numeric";
 	make() {
 		super.make();
 	}


### PR DESCRIPTION
This pull request is a backport of PR #27043 from the `develop branch`, addressing issue #33626.

It ensures that on mobile devices, numeric fields use `inputmode="numeric"` to hint the keyboard to show the numeric keypad, while keeping `type="text"` to maintain backward compatibility
