### PR TITLE
fix: correct SQL string formatting in get_sql_string method

### DIFF
--- a/frappe/public/js/frappe/ui/sort_selector.js
+++ b/frappe/public/js/frappe/ui/sort_selector.js
@@ -196,12 +196,12 @@ frappe.ui.SortSelector = class SortSelector {
 		}
 	}
 	get_sql_string() {
-		// build string like: `tabSales Invoice`.subject, `tabSales Invoice`.name desc
+		// build string like: `tabSales Invoice`.`subject`, `tabSales Invoice`.`name` desc
 		const table_name = "`tab" + this.doctype + "`";
-		const sort_by = `${table_name}.${this.sort_by}`;
+		const sort_by = `${table_name}.\`${this.sort_by}\``;
 		if (!["name", "creation", "modified"].includes(this.sort_by)) {
 			// add name column for deterministic ordering
-			return `${sort_by} ${this.sort_order}, ${table_name}.name ${this.sort_order}`;
+			return `${sort_by} ${this.sort_order}, ${table_name}.\`name\` ${this.sort_order}`;
 		} else {
 			return `${sort_by} ${this.sort_order}`;
 		}


### PR DESCRIPTION
The method generated SQL strings in an inconsistent format, such as ``` `tabUser`.creation desc ```, instead of the expected ``` `tabUser`.`creation` desc ``` with proper backticks around both table and field names. 

This inconsistency caused the condition if (order_by.includes("`.`")) to fail during parsing.