### PR TITLE
feat: new doc via link query

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -316,7 +316,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 										"</span>",
 									label: __("Create a new {0}", [__(me.get_options())]),
 									value: "create_new__link_option",
-									action: me.new_doc,
+									action: me.custom_new_doc || me.new_doc,
 								});
 							}
 
@@ -593,6 +593,11 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					// turn off value translation
 					if (q.translate_values !== undefined) {
 						this.translate_values = q.translate_values;
+					}
+
+					if (q.new_doc && typeof q.new_doc === "function") {
+						this.custom_new_doc = q.new_doc;
+						delete q.new_doc;
 					}
 
 					// extend args for custom functions


### PR DESCRIPTION
Allows control over how new docs get created from a link field:

```js
frm.set_query("primary_contact", function (doc) {
	return {
		filters: { is_primary_contact: 1 },
		new_doc: () => {
			frappe.new_doc("Contact", {
				is_primary_contact: 1,
			});
		},
	};
});
```

### Discussion

The old/established way of doing this is setting route options for a field:

- https://github.com/frappe/frappe/blob/727775f82089f9125855e62d11f7f3c96d65b865/frappe/public/js/frappe/form/controls/link.js#L178
- https://github.com/frappe/erpnext/blob/ddc97df31a27f4dc9a4d1ad9cd10984af60766e6/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js#L122

@sagarvora's concern is that this configuration of new doc is unexpected in `set_query` (because it's not setting a query). We should rather create a different method with an adequate name, like `frm.configure_link`.