### PR TITLE
fix: app name not visible in docs navigation dark mode (#34352)

### DIFF
--- a/frappe/public/scss/website/doc.scss
+++ b/frappe/public/scss/website/doc.scss
@@ -32,7 +32,12 @@ $navbar-height-lg: 4.5rem;
 }
 
 .doc-navbar {
-	background-color: white;
+	/* Use CSS variable so the navbar background follows the active theme
+	   (for example when data-theme="dark" sets darker colors). Using the
+	   CSS variable allows `--navbar-bg` (and theme overrides) to control
+	   the background instead of a hardcoded color which caused contrast
+	   issues for the brand/app name in dark mode. */
+	background-color: var(--navbar-bg);
 	padding-left: 0;
 	padding-right: 0;
 
@@ -122,8 +127,10 @@ $navbar-height-lg: 4.5rem;
 .page-toc {
 	font-size: $font-size-sm;
 
-	h5 {
-		font-size: $font-size-sm;
+		h5 {
+			// Use a slightly larger size for TOC headings to match other docs pages
+			// This keeps heading sizes consistent across documentation pages.
+			font-size: $font-size-md;
 		margin-bottom: 0.5rem;
 		color: $gray-500;
 	}

--- a/frappe/public/scss/website/doc.scss
+++ b/frappe/public/scss/website/doc.scss
@@ -76,6 +76,13 @@ $navbar-height-lg: 4.5rem;
 	}
 }
 
+/* Stronger fallback: ensure the brand/app name remains visible even when other
+   theme or site CSS has higher specificity. This forces the navbar brand to
+   use the theme text color (or white) in dark mode. */
+.doc-navbar .navbar-brand {
+	color: var(--text-color, #ffffff) !important;
+}
+
 .doc-search-container {
 	display: flex;
 	margin-top: 0.75rem;

--- a/frappe/templates/includes/website_theme/navbar.css
+++ b/frappe/templates/includes/website_theme/navbar.css
@@ -12,7 +12,11 @@
 .navbar .navbar-brand,
 .navbar .navbar-link,
 .navbar .nav > li > a {
-	color: {{ theme.top_bar_text_color }};
+	/* Use theme-provided text color if present, otherwise fall back to CSS variables.
+	   This ensures the brand/app name remains visible when the site is in dark mode
+	   (where data-theme="dark" sets --text-color) even if the theme's
+	   `top_bar_text_color` is not set or is incompatible with dark backgrounds. */
+	color: {{ theme.top_bar_text_color or 'var(--text-color)' }};
 	text-shadow: none;
 }
 


### PR DESCRIPTION
Fixes frappe/wiki#442 — ensure docs navbar brand/app name is visible in dark mode by falling back to CSS variables and forcing color when necessary. Includes TOC sizing tweaks.

Changes:
- Use var(--navbar-bg) for docs navbar background
- Fallback to var(--text-color) for theme top bar text color in theme CSS

