### PR TITLE
fix: add link_filters to filter area configuration

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -934,6 +934,7 @@ class FilterArea {
 						onchange: () => this.debounced_refresh_list_view(),
 						ignore_link_validation: fieldtype === "Dynamic Link",
 						is_filter: 1,
+						link_filters: df.link_filters,
 					};
 				})
 		);


### PR DESCRIPTION
# fix: apply link_filters property in List View standard filters

closes #34257

## Problem

Link fields with `link_filters` property defined in DocType configuration were not being respected when creating standard filters in List View. This caused Link fields to show all available options instead of the filtered subset defined in the DocType metadata.

**Root Cause:** The `make_standard_filters` method in the `FilterArea` class was not including the `link_filters` property when constructing the filter configuration object from the DocField definition.

## Solution

Added `link_filters` property to the config variable construction in `FilterArea.make_standard_filters()` method. This ensures that Link field filters defined at the DocType level are properly applied when rendering List View filters.

**Changes Made:**
- Modified `FilterArea.make_standard_filters()` to include `df.link_filters` in the filter config
- Link fields in List View now properly respect their configured `link_filters` property
- Filters are applied consistently between Form View and List View

## Testing

**Before:**
- Link fields in List View filters showed all available options
- `link_filters` property was ignored in List View context
- Inconsistent behavior between Form View (filters applied) and List View (filters ignored)

**After:**
- Link fields in List View filters correctly apply `link_filters` property
- Filtered options match the DocType configuration
- Consistent filtering behavior across Form and List Views

**Test Cases Verified:**
1. Created a Link field with `link_filters` property in a custom DocType
2. Opened List View and added the Link field as a filter
3. Confirmed dropdown shows only filtered options (not all records)
4. Verified filter selection and application works correctly

---