### PR TITLE
feat: include min and max in Dashboard Chart - Chart Type

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -107,7 +107,7 @@ frappe.ui.form.on("Dashboard Chart", {
 
 	set_time_series: function (frm) {
 		// set timeseries based on chart type
-		if (["Count", "Average", "Sum"].includes(frm.doc.chart_type)) {
+		if (["Count", "Average", "Sum", "Minimum", "Maximum"].includes(frm.doc.chart_type)) {
 			frm.set_value("timeseries", 1);
 		} else if (frm.doc.chart_type == "Custom") {
 			return;

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -60,7 +60,7 @@
    "fieldname": "chart_type",
    "fieldtype": "Select",
    "label": "Chart Type",
-   "options": "Count\nSum\nAverage\nGroup By\nCustom\nReport",
+   "options": "Count\nSum\nAverage\nMinimum\nMaximum\nGroup By\nCustom\nReport",
    "set_only_once": 1
   },
   {
@@ -79,13 +79,13 @@
    "set_only_once": 1
   },
   {
-   "depends_on": "eval: doc.timeseries && ['Count', 'Sum', 'Average'].includes(doc.chart_type)",
+   "depends_on": "eval: doc.timeseries && ['Count', 'Sum', 'Average', 'Minimum', 'Maximum'].includes(doc.chart_type)",
    "fieldname": "based_on",
    "fieldtype": "Select",
    "label": "Time Series Based On"
   },
   {
-   "depends_on": "eval: ['Sum', 'Average'].includes(doc.chart_type)\n",
+   "depends_on": "eval: ['Sum', 'Average', 'Minimum', 'Maximum'].includes(doc.chart_type)\n",
    "fieldname": "value_based_on",
    "fieldtype": "Select",
    "label": "Value Based On"

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -56,7 +56,7 @@ def get_permission_query_conditions(user):
 			or `tabDashboard Chart`.`module` is NULL""".format(allowed_modules=",".join(allowed_modules))
 
 	return f"""
-		((`tabDashboard Chart`.`chart_type` in ('Count', 'Sum', 'Average', 'Group By')
+		((`tabDashboard Chart`.`chart_type` in ('Count', 'Sum', 'Average', 'Minimum', 'Maximum', 'Group By')
 		and {doctype_condition})
 		or
 		(`tabDashboard Chart`.`chart_type` = 'Report'
@@ -201,7 +201,7 @@ def get_chart_config(chart, filters, timespan, timegrain, from_date, to_date):
 
 	data = frappe.get_list(
 		doctype,
-		fields=[datefield, f"SUM({value_field})", "COUNT(*)"],
+		fields=[datefield, f"SUM({value_field})", "COUNT(*)", f"MIN({value_field})", f"MAX({value_field})"],
 		filters=filters,
 		group_by=datefield,
 		order_by=datefield,
@@ -292,6 +292,8 @@ def get_aggregate_function(chart_type):
 		"Sum": "SUM",
 		"Count": "COUNT",
 		"Average": "AVG",
+		"Minimum": "MIN",
+		"Maximum": "MAX"
 	}[chart_type]
 
 
@@ -301,16 +303,30 @@ def get_result(data, timegrain, from_date, to_date, chart_type):
 	data_index = 0
 	if data:
 		for d in result:
+			min_value = None
+			max_value = None
 			count = 0
 			while data_index < len(data) and getdate(data[data_index][0]) <= d[0]:
 				d[1] += flt(data[data_index][1])
 				count += flt(data[data_index][2])
+				val_min = flt(data[data_index][3])
+				val_max = flt(data[data_index][4])
+				if min_value is None or val_min < min_value:
+					min_value = val_min
+				if max_value is None or val_max > max_value:
+					max_value = val_max
 				data_index += 1
 			if chart_type == "Average" and not count == 0:
 				d[1] = d[1] / count
 			if chart_type == "Count":
 				d[1] = count
-
+			if chart_type == "Minimum":
+					d[1] = min_value
+			if chart_type == "Maximum":
+					d[1] = max_value
+	# Remove dates without valid data since displaying 0 or NaN for min/max is misleading.
+	if chart_type in ("Minimum", "Maximum"):
+		result = [r for r in result if r[1] is not None]
 	return result
 
 
@@ -337,7 +353,7 @@ class DashboardChart(Document):
 		aggregate_function_based_on: DF.Literal[None]
 		based_on: DF.Literal[None]
 		chart_name: DF.Data
-		chart_type: DF.Literal["Count", "Sum", "Average", "Group By", "Custom", "Report"]
+		chart_type: DF.Literal["Count", "Sum", "Average", "Minimum", "Maximum", "Group By", "Custom", "Report"]
 		color: DF.Color | None
 		currency: DF.Link | None
 		custom_options: DF.Code | None

--- a/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
@@ -233,6 +233,62 @@ class TestDashboardChart(FrappeTestCase):
 			self.assertEqual(result.get("labels"), ["12-30-2018", "01-06-2019", "01-13-2019", "01-20-2019"])
 			self.assertEqual(result.get("datasets")[0].get("values"), [50.0, 150.0, 266.6666666666667, 0.0])
 
+	def test_min_dashboard_chart(self):
+		insert_test_records()
+
+		if frappe.db.exists("Dashboard Chart", "Test Minimum Dashboard Chart"):
+			frappe.delete_doc("Dashboard Chart", "Test Minimum Dashboard Chart")
+
+		frappe.get_doc(
+			dict(
+				doctype="Dashboard Chart",
+				chart_name="Test Minimum Dashboard Chart",
+				chart_type="Minimum",
+				document_type="Communication",
+				based_on="communication_date",
+				value_based_on="rating",
+				timespan="Select Date Range",
+				time_interval="Weekly",
+				from_date=datetime(2018, 12, 30),
+				to_date=datetime(2019, 1, 15),
+				filters_json="[]",
+				timeseries=1,
+			)
+		).insert()
+
+		with patch.object(frappe.utils.data, "get_first_day_of_the_week", return_value="Monday"):
+			result = get(chart_name="Test Minimum Dashboard Chart", refresh=1)
+			self.assertEqual(result.get("labels"), ["12-30-2018", "01-06-2019", "01-13-2019"])
+			self.assertEqual(result.get("datasets")[0].get("values"), [50.0, 100.0, 100.0])
+
+	def test_max_dashboard_chart(self):
+		insert_test_records()
+
+		if frappe.db.exists("Dashboard Chart", "Test Maximum Dashboard Chart"):
+			frappe.delete_doc("Dashboard Chart", "Test Maximum Dashboard Chart")
+
+		frappe.get_doc(
+			dict(
+				doctype="Dashboard Chart",
+				chart_name="Test Maximum Dashboard Chart",
+				chart_type="Maximum",
+				document_type="Communication",
+				based_on="communication_date",
+				value_based_on="rating",
+				timespan="Select Date Range",
+				time_interval="Weekly",
+				from_date=datetime(2018, 12, 30),
+				to_date=datetime(2019, 1, 15),
+				filters_json="[]",
+				timeseries=1,
+			)
+		).insert()
+
+		with patch.object(frappe.utils.data, "get_first_day_of_the_week", return_value="Monday"):
+			result = get(chart_name="Test Maximum Dashboard Chart", refresh=1)
+			self.assertEqual(result.get("labels"), ["12-30-2018", "01-06-2019", "01-13-2019"])
+			self.assertEqual(result.get("datasets")[0].get("values"), [50.0, 200.0, 400.0])
+
 	def test_user_date_label_dashboard_chart(self):
 		frappe.delete_doc_if_exists("Dashboard Chart", "Test Dashboard Chart Date Label")
 


### PR DESCRIPTION
 Closes #34430

Before:
<img width="1552" height="908" alt="Screenshot 2025-10-16 at 2 48 48 PM" src="https://github.com/user-attachments/assets/57f0b135-7272-40e9-8b0b-f9f358588adb" />

Now:
<img width="1552" height="908" alt="Screenshot 2025-10-16 at 3 37 52 PM" src="https://github.com/user-attachments/assets/dfa64bd7-4ab3-426c-a2c6-4db6541d529a" />
<img width="1552" height="908" alt="Screenshot 2025-10-16 at 3 46 03 PM" src="https://github.com/user-attachments/assets/c60e2644-4ff5-4a68-bb98-d3c2254ebc98" />
<img width="1552" height="908" alt="Screenshot 2025-10-16 at 3 45 17 PM" src="https://github.com/user-attachments/assets/b83d8093-f8d5-4dd9-a744-82e1457e5b2b" />

