### PR TITLE
fix(DatabaseQuery): allow distinct order_by for MariaDB

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -304,8 +304,7 @@ class DatabaseQuery:
 		if self.distinct:
 			args.fields = "distinct " + args.fields
 			if frappe.db.db_type == "postgres":
-				# PostgreSQL requires ORDER BY expressions to appear in SELECT list when using DISTINCT
-				args.order_by = ""
+				raise NotImplementedError("DISTINCT queries with ORDER BY are not supported on PostgreSQL")
 
 		# Postgres requires any field that appears in the select clause to also
 		# appear in the order by and group by clause

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -304,7 +304,8 @@ class DatabaseQuery:
 		if self.distinct:
 			args.fields = "distinct " + args.fields
 			if frappe.db.db_type == "postgres":
-				args.order_by = ""  # TODO: recheck for alternative
+				# PostgreSQL requires ORDER BY expressions to appear in SELECT list when using DISTINCT
+				args.order_by = ""
 
 		# Postgres requires any field that appears in the select clause to also
 		# appear in the order by and group by clause

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -303,7 +303,8 @@ class DatabaseQuery:
 
 		if self.distinct:
 			args.fields = "distinct " + args.fields
-			args.order_by = ""  # TODO: recheck for alternative
+			if frappe.db.db_type == "postgres":
+				args.order_by = ""  # TODO: recheck for alternative
 
 		# Postgres requires any field that appears in the select clause to also
 		# appear in the order by and group by clause

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -304,7 +304,8 @@ class DatabaseQuery:
 		if self.distinct:
 			args.fields = "distinct " + args.fields
 			if frappe.db.db_type == "postgres":
-				raise NotImplementedError("DISTINCT queries with ORDER BY are not supported on PostgreSQL")
+				# PostgreSQL requires ORDER BY expressions to appear in SELECT list when using DISTINCT
+				args.order_by = ""
 
 		# Postgres requires any field that appears in the select clause to also
 		# appear in the order by and group by clause


### PR DESCRIPTION
Disclaimer: this PR is entirely AI slop, I only tested that it works for MariaDB. And it should logically work for postgres since the behavior is unchanged there.

### Summary
This PR fixes an unnecessary limitation where `ORDER BY` was disabled for all databases when using `DISTINCT` queries. The restriction is now applied only to PostgreSQL, where it's actually required by the database engine.

### Background
Since the PostgreSQL support was added in 2018 (commit 2e6a202652), the `DatabaseQuery` class has been clearing the `order_by` clause whenever `distinct=True` is used, regardless of database type:

```python
if self.distinct:
    args.fields = "distinct " + args.fields
    args.order_by = ""  # TODO: recheck for alternative
```

### Problem
**PostgreSQL Requirement:** PostgreSQL strictly enforces the SQL standard that requires any expression in the `ORDER BY` clause to appear in the `SELECT` list when using `DISTINCT`. This can cause errors like:
```
ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list
```

**MariaDB/MySQL Flexibility:** However, MariaDB and MySQL are more permissive and allow ordering by columns that don't appear in the `SELECT` list, even when using `DISTINCT`.

By applying this restriction to all databases, MariaDB/MySQL users have been unnecessarily prevented from using `DISTINCT` with `ORDER BY`, even though their database fully supports it.

### Solution
Make the `ORDER BY` clearing conditional on the database type:

```python
if self.distinct:
    args.fields = "distinct " + args.fields
    if frappe.db.db_type == "postgres":
        args.order_by = ""  # PostgreSQL requires ORDER BY expressions to appear in SELECT list when using DISTINCT
```

This approach:
- **Maintains PostgreSQL compatibility** by keeping the workaround where needed
- **Enables full functionality for MariaDB/MySQL** users
- **Follows existing patterns** in the same file (see line 223 for similar PostgreSQL-specific handling)
- **Aligns with test suite** which skips DISTINCT tests for PostgreSQL (`@run_only_if(db_type_is.MARIADB)` at line 1215)

### Impact
- **MariaDB/MySQL users:** Can now use `DISTINCT` with `ORDER BY` in queries like:
  ```python
  frappe.get_all("DocType", 
      fields=["name"], 
      distinct=True, 
      order_by="modified desc")
  ```
- **PostgreSQL users:** No change in behavior (workaround remains active)

### Related

- Original PostgreSQL support PR: #5919 (2018)
