### PR TITLE
Login email icon

### DIFF
--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -87,7 +87,8 @@ body {
 
 			.field-icon {
 				left: 9px;
-				top: 5px;
+				top: 50%;
+				transform: translateY(-50%);
 				position: absolute;
 				z-index: 2;
 				fill: var(--text-light);

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -182,14 +182,9 @@
 					<div class="email-field">
 						<input type="email" id="forgot_email" class="form-control"
 							placeholder="{{ _('Email Address') }}" required autofocus autocomplete="username">
-						<svg class="field-icon email-icon" width="20" height="20" viewBox="0 0 20 20" fill="none"
+						<svg class="field-icon email-icon" width="16" height="16" viewBox="0 0 16 16" fill="none"
 							xmlns="http://www.w3.org/2000/svg">
-							<path
-								d="M2.5 7.65149V15.0757C2.5 15.4374 2.64367 15.7842 2.8994 16.04C3.15513 16.2957 3.50198 16.4394 3.86364 16.4394H16.1364C16.498 16.4394 16.8449 16.2957 17.1006 16.04C17.3563 15.7842 17.5 15.4374 17.5 15.0757V7.65149"
-								stroke="#74808B" stroke-miterlimit="10" stroke-linecap="square" />
-							<path
-								d="M17.5 7.57572V5.53026C17.5 5.1686 17.3563 4.82176 17.1006 4.56603C16.8449 4.31029 16.498 4.16663 16.1364 4.16663H3.86364C3.50198 4.16663 3.15513 4.31029 2.8994 4.56603C2.64367 4.82176 2.5 5.1686 2.5 5.53026V7.57572L10 10.8333L17.5 7.57572Z"
-								stroke="#74808B" stroke-miterlimit="10" stroke-linecap="square" />
+							<use class="es-lock" href="#es-line-email"></use>
 						</svg>
 
 					</div>
@@ -214,14 +209,9 @@
 					<div class="email-field">
 						<input type="email" id="login_with_email_link_email" class="form-control"
 							placeholder="{{ _('Email Address') }}" required autofocus autocomplete="username">
-						<svg class="field-icon email-icon" width="20" height="20" viewBox="0 0 20 20" fill="none"
+						<svg class="field-icon email-icon" width="16" height="16" viewBox="0 0 16 16" fill="none"
 							xmlns="http://www.w3.org/2000/svg">
-							<path
-								d="M2.5 7.65149V15.0757C2.5 15.4374 2.64367 15.7842 2.8994 16.04C3.15513 16.2957 3.50198 16.4394 3.86364 16.4394H16.1364C16.498 16.4394 16.8449 16.2957 17.1006 16.04C17.3563 15.7842 17.5 15.4374 17.5 15.0757V7.65149"
-								stroke="#74808B" stroke-miterlimit="10" stroke-linecap="square" />
-							<path
-								d="M17.5 7.57572V5.53026C17.5 5.1686 17.3563 4.82176 17.1006 4.56603C16.8449 4.31029 16.498 4.16663 16.1364 4.16663H3.86364C3.50198 4.16663 3.15513 4.31029 2.8994 4.56603C2.64367 4.82176 2.5 5.1686 2.5 5.53026V7.57572L10 10.8333L17.5 7.57572Z"
-								stroke="#74808B" stroke-miterlimit="10" stroke-linecap="square" />
+							<use class="es-lock" href="#es-line-email"></use>
 						</svg>
 					</div>
 				</div>


### PR DESCRIPTION
_Fix for center align icon_
**Before:**
<img width="1048" height="594" alt="image" src="https://github.com/user-attachments/assets/ecdcfdc5-dda7-4826-b7b2-fce04648680c" />

**After:**
<img width="1045" height="588" alt="image" src="https://github.com/user-attachments/assets/b82c6a2d-3a5a-47b4-8ecf-8b976e3afc67" />


_Fix for unified email icons - (This issue is only seen in the develop branch)_

**Before:**
<img width="691" height="464" alt="image" src="https://github.com/user-attachments/assets/033d3861-efe7-43da-abad-2b2defa48711" />
<img width="834" height="586" alt="image" src="https://github.com/user-attachments/assets/210ae801-006f-466a-a30a-beb65267d343" />

**After:**
<img width="890" height="557" alt="image" src="https://github.com/user-attachments/assets/bbacf02f-6fa1-48aa-904c-06824dc0ea1e" />
<img width="802" height="541" alt="image" src="https://github.com/user-attachments/assets/89227767-6832-45d4-885e-33795a8035de" />


