### PR TITLE
fix(Notification): create system notification when explicitly enabled

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -419,7 +419,12 @@ def get_context(context):
 				self.send_a_slack_msg(doc, context)
 			elif self.channel == "SMS":
 				self.send_sms(doc, context)
-			elif self.channel == "System Notification" or self.send_system_notification:
+			elif self.channel == "System Notification":
+				self.create_system_notification(doc, context)
+
+			# Additionally, if explicitly enabled, create a system notification
+			# even when the primary channel is not "System Notification".
+			if self.send_system_notification and self.channel != "System Notification":
 				self.create_system_notification(doc, context)
 		except Exception:
 			self.log_error("Failed to send Notification")


### PR DESCRIPTION
Fixed the conditional logic in `send_notification_by_channel` to ensure that a system notification is created if `self.send_system_notification` is enabled, even when the primary channel is not "System Notification".

This matches the expected behavior: when a user selects the "Email" _Channel_ and enables _Send System Notification_, both should be sent.