### PR TITLE
feat: highlight code in HTML field

### DIFF
--- a/frappe/public/js/frappe/form/controls/html.js
+++ b/frappe/public/js/frappe/form/controls/html.js
@@ -4,8 +4,7 @@ frappe.ui.form.ControlHTML = class ControlHTML extends frappe.ui.form.Control {
 		this.disp_area = this.wrapper;
 	}
 	refresh_input() {
-		var content = this.get_content();
-		if (content) this.$wrapper.html(content);
+		this.html();
 	}
 	get_content() {
 		var content = this.df.options || "";
@@ -17,7 +16,11 @@ frappe.ui.form.ControlHTML = class ControlHTML extends frappe.ui.form.Control {
 		}
 	}
 	html(html) {
-		this.$wrapper.html(html || this.get_content());
+		const content = html || this.get_content();
+		this.$wrapper.html(content);
+		if (content.includes("<pre")) {
+			frappe.utils.highlight_pre(this.$wrapper);
+		}
 	}
 	set_value(html) {
 		if (html.appendTo) {

--- a/frappe/public/js/frappe/form/controls/html.js
+++ b/frappe/public/js/frappe/form/controls/html.js
@@ -18,7 +18,7 @@ frappe.ui.form.ControlHTML = class ControlHTML extends frappe.ui.form.Control {
 	html(html) {
 		const content = html || this.get_content();
 		this.$wrapper.html(content);
-		if (content.includes("<pre")) {
+		if (typeof content === "string" && /<pre[\s>]/i.test(content)) {
 			frappe.utils.highlight_pre(this.$wrapper);
 		}
 	}

--- a/frappe/public/js/frappe/form/controls/html.js
+++ b/frappe/public/js/frappe/form/controls/html.js
@@ -4,7 +4,10 @@ frappe.ui.form.ControlHTML = class ControlHTML extends frappe.ui.form.Control {
 		this.disp_area = this.wrapper;
 	}
 	refresh_input() {
-		this.html();
+		const content = this.get_content();
+		if (content) {
+			this._set_html(content);
+		}
 	}
 	get_content() {
 		var content = this.df.options || "";
@@ -16,11 +19,7 @@ frappe.ui.form.ControlHTML = class ControlHTML extends frappe.ui.form.Control {
 		}
 	}
 	html(html) {
-		const content = html || this.get_content();
-		this.$wrapper.html(content);
-		if (typeof content === "string" && /<pre[\s>]/i.test(content)) {
-			frappe.utils.highlight_pre(this.$wrapper);
-		}
+		this._set_html(html || this.get_content());
 	}
 	set_value(html) {
 		if (html.appendTo) {
@@ -32,5 +31,11 @@ frappe.ui.form.ControlHTML = class ControlHTML extends frappe.ui.form.Control {
 			this.html(html);
 		}
 		return Promise.resolve();
+	}
+	_set_html(html) {
+		this.$wrapper.html(html);
+		if (typeof html === "string" && /<pre[\s>]/i.test(html)) {
+			frappe.utils.highlight_pre(this.$wrapper);
+		}
 	}
 };


### PR DESCRIPTION
Notice the condition examples  are highlighted as python code.

<img width="935" height="179" alt="Bildschirmfoto 2025-10-21 um 19 13 40" src="https://github.com/user-attachments/assets/6c4acea1-37d9-4f08-ac75-5d412fc7fa9a" />

This particular example depends on https://github.com/frappe/frappe/pull/34467

> no-docs