### PR TITLE
feat(geo): Add Kosovo(XK) country details to country_info.json

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -2988,6 +2988,19 @@
   ],
   "isd": "+260"
  },
+ "Kosovo": {
+  "code": "xk",
+  "currency": "EUR",
+  "currency_fraction": "Cent",
+  "currency_fraction_units": 100,
+  "currency_name": "Euro",
+  "currency_symbol": "€",
+  "number_format": "#,###.##",
+  "timezones": [
+    "Europe/Belgrade"
+  ],
+  "isd": "+383"
+ },
  "Zimbabwe": {
   "code": "zw",
   "currency": "ZWL",


### PR DESCRIPTION
**Ref:** [51433](https://support.frappe.io/helpdesk/tickets/51433)

Added the country Kosovo (XK) in the `country_info.json` file.

### Added country Info:
  - **Country:** Kosovo  
  - **Code:** XK  
  - **Currency:** EUR (Euro)  
  - **Currency symbol:** €  
  - **Currency fraction:** Cent (100 units)  
  - **Timezone:** Europe/Belgrade  
  - **ISD code:** +383  
  - **Number format:** #,###.##
  
 **backport needed: v15**
