### PR TITLE
fix(custom fields): added a method to delete custom_fields

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -440,3 +440,19 @@ def _update_fieldname_references(field: CustomField, old_fieldname: str, new_fie
 		"insert_after",
 		new_fieldname,
 	)
+
+
+def delete_custom_fields(custom_fields: dict):
+	"""
+	:param custom_fields: a dict like `{'Email Communication': [{fieldname: 'company', ...}]}`
+	"""
+	for doctype, fields in custom_fields.items():
+		frappe.db.delete(
+			"Custom Field",
+			{
+				"fieldname": ("in", [field["fieldname"] for field in fields]),
+				"dt": doctype,
+			},
+		)
+
+		frappe.clear_cache(doctype=doctype)


### PR DESCRIPTION
Introduced a method for deleting custom fields, which can be used to remove system-generated custom fields installed during the app's installation when the app is uninstalled.