### PR TITLE
fix(toolbar): prevent event propagation on app version click

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/about.js
+++ b/frappe/public/js/frappe/ui/toolbar/about.js
@@ -145,7 +145,8 @@ frappe.ui.misc.about = function () {
 	});
 
 	// Listener for copy app version
-	$(dialog.body).on("click", ".app-version", function () {
+	$(dialog.body).on("click", ".app-version", function (event) {
+		event.stopPropagation();
 		const title = $(this).attr("title");
 		if (title) {
 			frappe.utils.copy_to_clipboard(title);


### PR DESCRIPTION
**Problem:**
Clicking on an individual app version in the About dialog was copying all apps instead of just that specific app.

**Solution:**
Added proper event handling to prevent event bubbling:

Added event parameter to the click handler
Added `event.stopPropagation()` to stop the event from triggering other handlers