### PR TITLE
feat(workflow): add Enable Action Confirmation checkbox to Workflow Doctype

### DIFF
--- a/frappe/workflow/doctype/workflow/workflow.json
+++ b/frappe/workflow/doctype/workflow/workflow.json
@@ -62,11 +62,11 @@
    "label": "Send Email Alert"
   },
   {
-    "default": "0",
-    "description": "If checked, a confirmation will be required before performing workflow actions.",
-    "fieldname": "enable_action_confirmation",
-    "fieldtype": "Check",
-    "label": "Enable Action Confirmation"
+   "default": "0",
+   "description": "If checked, a confirmation will be required before performing workflow actions.",
+   "fieldname": "enable_action_confirmation",
+   "fieldtype": "Check",
+   "label": "Enable Action Confirmation"
   },
   {
    "description": "Different \"States\" this document can exist in. Like \"Open\", \"Pending Approval\" etc.",
@@ -112,10 +112,11 @@
  "icon": "fa fa-random",
  "idx": 1,
  "links": [],
- "modified": "2024-03-23 16:04:04.849665",
+ "modified": "2025-10-23 21:07:05.944239",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -129,6 +130,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -16,12 +16,11 @@ class Workflow(Document):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
-		from frappe.workflow.doctype.workflow_document_state.workflow_document_state import (
-			WorkflowDocumentState,
-		)
+		from frappe.workflow.doctype.workflow_document_state.workflow_document_state import WorkflowDocumentState
 		from frappe.workflow.doctype.workflow_transition.workflow_transition import WorkflowTransition
 
 		document_type: DF.Link
+		enable_action_confirmation: DF.Check
 		is_active: DF.Check
 		override_status: DF.Check
 		send_email_alert: DF.Check


### PR DESCRIPTION
feat(workflow): add "Enable Action Confirmation" checkbox to Workflow DocType

This commit introduces a new checkbox field `enable_action_confirmation` in the Workflow DocType.
When enabled, ERPNext will prompt users for confirmation before executing a workflow action.

- Enables per-workflow configuration for confirmation dialogs.
- Resolves the "Field not permitted in query: enable_action_confirmation" error.

<img width="3830" height="1990" alt="Workflow-A" src="https://github.com/user-attachments/assets/56a43835-03b5-4968-a905-6ea77ba1f46d" />
<img width="3840" height="1962" alt="Workflow-B" src="https://github.com/user-attachments/assets/00972b30-cbe8-445d-935b-b1f840f54879" />

