### PR TITLE
fix: deduplicate doctypes in `get_communication_doctype`

### DIFF
--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -100,7 +100,7 @@ def get_communication_doctype(doctype, txt, searchfield, start, page_len, filter
 	results = []
 	txt_lower = txt.lower().replace("%", "")
 
-	for dt in com_doctypes:
+	for dt in list(set(com_doctypes)):
 		if dt in can_read:
 			if txt_lower in dt.lower() or txt_lower in _(dt).lower():
 				results.append([dt])

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -441,7 +441,9 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			if (newArr.length === 0) return [currElem];
 			let element_with_same_value = newArr.find((e) => e.value === currElem.value);
 			if (element_with_same_value) {
-				element_with_same_value.description += `, ${currElem.description}`;
+				if (currElem.description) {
+					element_with_same_value.description += `, ${currElem.description}`;
+				}
 				return [...newArr];
 			}
 			return [...newArr, currElem];


### PR DESCRIPTION
Some doctypes like `Payment Entry`, `Bank Account`, `Pricing Rule` were present in 2 dashboards (customer and supplier dashboard), both of which were included in ERPNext communucation_doctype hooks

This led to some commas showing up in the list in their `description` field due to https://github.com/frappe/frappe/blob/c88cf29a0cdff53a173442a77fda6e363d0dc541/frappe/public/js/frappe/form/controls/link.js#L444

<hr>

Resolves #32188

<hr>

(Technically either the JS or Python fixes work standalone, but seemed better to fix both here)