### PR TITLE
feat: save select-all checkbox state across pages

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -211,6 +211,7 @@ export default class Grid {
 				for (let ri = (page_index - 1) * page_length; ri < result_length; ri++) {
 					this.grid_rows[ri].select(checked);
 				}
+				this.grid_pagination.save_page_checkbox_state();
 			} else if (docname) {
 				if (e.shiftKey && this.last_checked_docname) {
 					this.check_range(docname, this.last_checked_docname, checked);

--- a/frappe/public/js/frappe/form/grid_pagination.js
+++ b/frappe/public/js/frappe/form/grid_pagination.js
@@ -150,6 +150,7 @@ export default class GridPagination {
 		} else {
 			this.page_index = index;
 		}
+		this.restore_page_checkbox_state();
 		let $rows = $(this.grid.parent).find(".rows").empty();
 		this.grid.render_result_rows($rows, true);
 		if (this.$page_number) {
@@ -161,6 +162,23 @@ export default class GridPagination {
 		if (!from_refresh) {
 			this.grid.scroll_to_top();
 		}
+	}
+
+	save_page_checkbox_state() {
+		if (!this.page_checkbox_states) {
+			this.page_checkbox_states = {};
+		}
+		this.page_checkbox_states[this.page_index] = this.wrapper
+			.find(".grid-heading-row .grid-row-check")
+			.prop("checked");
+	}
+
+	restore_page_checkbox_state() {
+		if (!this.page_checkbox_states) {
+			return;
+		}
+		const checked = this.page_checkbox_states[this.page_index] === true;
+		this.wrapper.find(".grid-heading-row .grid-row-check").prop("checked", checked);
 	}
 
 	go_to_last_page_to_add_row() {


### PR DESCRIPTION
This change makes the “Select All” checkbox remember its state when switching pages in a paginated grid.
Before, the “Select All” checkbox was not reset when switching pages and was not in sync with the selected rows.

Closes #33970 