### PR TITLE
fix: grid button labels and visibility

### DIFF
--- a/cypress/integration/depends_on.js
+++ b/cypress/integration/depends_on.js
@@ -111,7 +111,7 @@ context("Depends On", () => {
 		cy.fill_field("dependant_field", "Some Value");
 		//cy.fill_field('test_field', 'Some Other Value');
 		cy.get('.frappe-control[data-fieldname="child_test_depends_on_field"]').as("table");
-		cy.get("@table").findByRole("button", { name: "Add Row" }).click();
+		cy.get("@table").findByRole("button", { name: "Add row" }).click();
 		cy.get("@table").find('[data-idx="1"]').as("row1");
 		cy.get("@row1").find(".btn-open-row").click();
 		cy.get("@row1").find(".form-in-grid").as("row1-form_in_grid");

--- a/cypress/integration/grid_pagination.js
+++ b/cypress/integration/grid_pagination.js
@@ -43,7 +43,7 @@ context("Grid Pagination", () => {
 		cy.get("@table").find(".current-page-number").should("have.value", "21");
 		cy.get("@table").find(".total-page-number").should("contain", "21");
 		cy.get("@table").find(".grid-body .grid-row .grid-row-check").click({ force: true });
-		cy.get("@table").findByRole("button", { name: "Delete" }).click();
+		cy.get("@table").findByRole("button", { name: "Delete row" }).click();
 		cy.get("@table").find(".grid-body .row-index").last().should("contain", 1000);
 		cy.get("@table").find(".current-page-number").should("have.value", "20");
 		cy.get("@table").find(".total-page-number").should("contain", "20");

--- a/cypress/integration/grid_pagination.js
+++ b/cypress/integration/grid_pagination.js
@@ -38,7 +38,7 @@ context("Grid Pagination", () => {
 	it("adds and deletes rows and changes page", () => {
 		cy.visit("/desk/contact/Test Contact");
 		cy.get('.frappe-control[data-fieldname="phone_nos"]').as("table");
-		cy.get("@table").findByRole("button", { name: "Add Row" }).click();
+		cy.get("@table").findByRole("button", { name: "Add row" }).click();
 		cy.get("@table").find(".grid-body .row-index").should("contain", 1001);
 		cy.get("@table").find(".current-page-number").should("have.value", "21");
 		cy.get("@table").find(".total-page-number").should("contain", "21");

--- a/cypress/integration/grid_row_form_tabs.js
+++ b/cypress/integration/grid_row_form_tabs.js
@@ -25,7 +25,7 @@ context("Grid Row Form Tabs", () => {
 
 		// Add a row to the child table
 		cy.get('.frappe-control[data-fieldname="items"]').as("table");
-		cy.get("@table").findByRole("button", { name: "Add Row" }).click();
+		cy.get("@table").findByRole("button", { name: "Add row" }).click();
 
 		// Open the grid row form
 		cy.get("@table").find('[data-idx="1"]').as("row1");
@@ -48,7 +48,7 @@ context("Grid Row Form Tabs", () => {
 
 		// Add a row to the child table
 		cy.get('.frappe-control[data-fieldname="items"]').as("table");
-		cy.get("@table").findByRole("button", { name: "Add Row" }).click();
+		cy.get("@table").findByRole("button", { name: "Add row" }).click();
 
 		// Open the grid row form
 		cy.get("@table").find('[data-idx="1"]').as("row1");
@@ -88,8 +88,8 @@ context("Grid Row Form Tabs", () => {
 
 		// Add two rows to the child table
 		cy.get('.frappe-control[data-fieldname="items"]').as("table");
-		cy.get("@table").findByRole("button", { name: "Add Row" }).click();
-		cy.get("@table").findByRole("button", { name: "Add Row" }).click();
+		cy.get("@table").findByRole("button", { name: "Add row" }).click();
+		cy.get("@table").findByRole("button", { name: "Add row" }).click();
 
 		// Open first row and switch to Details tab
 		cy.get("@table").find('[data-idx="1"]').as("row1");
@@ -118,7 +118,7 @@ context("Grid Row Form Tabs", () => {
 
 		// Add a row to the child table
 		cy.get('.frappe-control[data-fieldname="items"]').as("table");
-		cy.get("@table").findByRole("button", { name: "Add Row" }).click();
+		cy.get("@table").findByRole("button", { name: "Add row" }).click();
 
 		// Open the grid row form
 		cy.get("@table").find('[data-idx="1"]').as("row1");

--- a/cypress/integration/web_form.js
+++ b/cypress/integration/web_form.js
@@ -122,7 +122,7 @@ context("Web Form", () => {
 		cy.findByRole("tab", { name: "Settings" }).click();
 
 		cy.get('[data-fieldname="list_columns"] .grid-footer button')
-			.contains("Add Row")
+			.contains("Add row")
 			.as("add-row");
 
 		cy.get("@add-row").click();

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -137,7 +137,6 @@ export default class Grid {
 		this.remove_rows_button = this.grid_buttons.find(".grid-remove-rows");
 		this.duplicate_rows_button = this.grid_buttons.find(".grid-duplicate-rows");
 		this.remove_all_rows_button = this.grid_buttons.find(".grid-remove-all-rows");
-		this.duplicate_row_button = this.grid_buttons.find(".grid-duplicate-row");
 
 		this.setup_allow_bulk_edit();
 		this.setup_check();
@@ -369,7 +368,7 @@ export default class Grid {
 			return;
 		}
 
-		this.duplicate_row_button.toggleClass(
+		this.duplicate_rows_button.toggleClass(
 			"hidden",
 			this.wrapper.find(".grid-body .grid-row-check:checked:first").length ? false : true
 		);
@@ -578,7 +577,7 @@ export default class Grid {
 			) {
 				// add 'hidden' to buttons
 				this.wrapper
-					.find(".grid-add-row, .grid-add-multiple-rows, .grid-duplicate-row")
+					.find(".grid-add-row, .grid-add-multiple-rows, .grid-duplicate-rows")
 					.addClass("hidden");
 			} else {
 				// show buttons

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -87,20 +87,20 @@ export default class Grid {
 								data-action="delete_rows">
 								${__("Delete")}
 							</button>
-							<button type="button" class="btn btn-xs btn-secondary hidden grid-duplicate-row"
-								data-action="duplicate_rows">
-								${__("Duplicate Row")}
-							</button>
 							<button type="button" class="btn btn-xs btn-danger grid-remove-all-rows hidden"
-								data-action="delete_all_rows">
-								${__("Delete All")}
+							data-action="delete_all_rows">
+							${__("Delete all")}
+							</button>
+							<button type="button" class="btn btn-xs btn-secondary grid-duplicate-rows hidden"
+								data-action="duplicate_rows">
+								${__("Duplicate rows")}
 							</button>
 							<!-- hack to allow firefox include this in tabs -->
 							<button type="button" class="btn btn-xs btn-secondary grid-add-row">
-								${__("Add Row")}
+								${__("Add row")}
 							</button>
 							<button type="button" class="grid-add-multiple-rows btn btn-xs btn-secondary hidden">
-								${__("Add Multiple")}</a>
+								${__("Add multiple")}</a>
 							</button>
 						</div>
 						<div class="grid-pagination">
@@ -135,6 +135,7 @@ export default class Grid {
 		this.grid_buttons = this.wrapper.find(".grid-buttons");
 		this.grid_custom_buttons = this.wrapper.find(".grid-custom-buttons");
 		this.remove_rows_button = this.grid_buttons.find(".grid-remove-rows");
+		this.duplicate_rows_button = this.grid_buttons.find(".grid-duplicate-rows");
 		this.remove_all_rows_button = this.grid_buttons.find(".grid-remove-all-rows");
 		this.duplicate_row_button = this.grid_buttons.find(".grid-duplicate-row");
 
@@ -219,6 +220,16 @@ export default class Grid {
 				this.grid_rows_by_docname[docname].select(checked);
 				this.last_checked_docname = docname;
 			}
+
+			const num_selected_rows = this.get_selected_children().length;
+
+			// toggle "Add Row" button
+			this.wrapper.find(".grid-add-row").toggleClass("hidden", num_selected_rows > 0);
+
+			// update "Delete" button label
+			this.remove_rows_button.text(__("Delete {0} rows", [num_selected_rows]));
+			this.duplicate_rows_button.text(__("Duplicate {0} rows", [num_selected_rows]));
+
 			this.refresh_remove_rows_button();
 			this.refresh_duplicate_rows_button();
 		});
@@ -293,7 +304,8 @@ export default class Grid {
 	}
 
 	delete_all_rows() {
-		frappe.confirm(__("Are you sure you want to delete all rows?"), () => {
+		const num_rows = this.data.length;
+		frappe.confirm(__("Are you sure you want to delete all {0} rows?", [num_rows]), () => {
 			this.frm.doc[this.df.fieldname] = [];
 			$(this.parent).find(".rows").empty();
 			this.grid_rows = [];
@@ -324,10 +336,11 @@ export default class Grid {
 			return;
 		}
 
-		this.remove_rows_button.toggleClass(
-			"hidden",
-			this.wrapper.find(".grid-body .grid-row-check:checked:first").length ? false : true
-		);
+		const show_buttons = this.wrapper.find(".grid-body .grid-row-check:checked:first").length
+			? false
+			: true;
+		this.remove_rows_button.toggleClass("hidden", show_buttons);
+		this.duplicate_rows_button.toggleClass("hidden", show_buttons);
 
 		let select_all_checkbox_checked = this.wrapper.find(
 			".grid-heading-row .grid-row-check:checked:first"
@@ -335,6 +348,10 @@ export default class Grid {
 		let show_delete_all_btn =
 			select_all_checkbox_checked && this.data.length > this.get_selected_children().length;
 		this.remove_all_rows_button.toggleClass("hidden", !show_delete_all_btn);
+
+		if (show_delete_all_btn) {
+			this.remove_all_rows_button.text(__("Delete all {0} rows", [this.data.length]));
+		}
 	}
 
 	debounced_refresh_remove_rows_button = frappe.utils.debounce(
@@ -547,8 +564,13 @@ export default class Grid {
 		if (this.is_editable()) {
 			this.wrapper.find(".grid-footer").toggle(true);
 
+			const num_selected_rows = this.get_selected_children().length;
 			// show, hide buttons to add rows
-			if (this.cannot_add_rows || (this.df && this.df.cannot_add_rows)) {
+			if (
+				this.cannot_add_rows ||
+				(this.df && this.df.cannot_add_rows) ||
+				num_selected_rows > 0
+			) {
 				// add 'hidden' to buttons
 				this.wrapper
 					.find(".grid-add-row, .grid-add-multiple-rows, .grid-duplicate-row")

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -226,9 +226,14 @@ export default class Grid {
 			// toggle "Add Row" button
 			this.wrapper.find(".grid-add-row").toggleClass("hidden", num_selected_rows > 0);
 
-			// update "Delete" button label
-			this.remove_rows_button.text(__("Delete {0} rows", [num_selected_rows]));
-			this.duplicate_rows_button.text(__("Duplicate {0} rows", [num_selected_rows]));
+			// update "Delete" and "Duplicate" button labels
+			if (num_selected_rows == 1) {
+				this.remove_rows_button.text(__("Delete row"));
+				this.duplicate_rows_button.text(__("Duplicate row"));
+			} else {
+				this.remove_rows_button.text(__("Delete {0} rows", [num_selected_rows]));
+				this.duplicate_rows_button.text(__("Duplicate {0} rows", [num_selected_rows]));
+			}
 
 			this.refresh_remove_rows_button();
 			this.refresh_duplicate_rows_button();

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -222,7 +222,7 @@ export default class Grid {
 
 			const num_selected_rows = this.get_selected_children().length;
 
-			// toggle "Add Row" button
+			// toggle "Add row" button
 			this.wrapper.find(".grid-add-row").toggleClass("hidden", num_selected_rows > 0);
 
 			// update "Delete" and "Duplicate" button labels

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -377,7 +377,7 @@ def get_context(context):
 					"No Data",
 					"Delete",
 					"Delete All",
-					"Add Row",
+					"Add row",
 					"Add Multiple",
 					"Download",
 					"of",


### PR DESCRIPTION
Before | After
-------|-------
<img width="935" height="178" alt="unchecked before" src="https://github.com/user-attachments/assets/f1333187-6d19-4448-bb81-7ad3a63bd25f" /> | <img width="935" height="178" alt="unchecked after" src="https://github.com/user-attachments/assets/eca23182-0df7-4b87-8540-afcf08bcaf59" /> Unchanged
<img width="935" height="178" alt="select all before" src="https://github.com/user-attachments/assets/bc5b5b07-258d-4813-aa32-4fc29f0afcd0" /> |  <img width="935" height="178" alt="select all after" src="https://github.com/user-attachments/assets/096aec78-3c60-4858-9824-41a780364339" /> Delete buttons show count and are next to each other, duplicate button shows count, "Add row" button is hidden
<img width="935" height="178" alt="select before" src="https://github.com/user-attachments/assets/dba21e81-cf70-4ea0-a5e7-99c69603d62d" /> |  <img width="935" height="178" alt="select after" src="https://github.com/user-attachments/assets/6697f603-556e-4d03-b9d4-75d01c5b039d" /> Delete and duplicate buttons show count, "Add row" button is hidden

