### PR TITLE
fix(sqlite): Use DEFERRED isolation level

### DIFF
--- a/frappe/database/sqlite/database.py
+++ b/frappe/database/sqlite/database.py
@@ -105,7 +105,6 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 
 	def get_connection(self, read_only: bool = False):
 		conn = self.create_connection(read_only)
-		conn.isolation_level = None
 		conn.create_function("regexp", 2, regexp)
 		conn.create_function("regexp_replace", 3, regexp_replace)
 		pragmas = {

--- a/frappe/database/sqlite/database.py
+++ b/frappe/database/sqlite/database.py
@@ -110,6 +110,7 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 		pragmas = {
 			"journal_mode": "WAL",
 			"synchronous": "NORMAL",
+			"busy_timeout": 5000,  # in milliseconds
 		}
 		cursor = conn.cursor()
 		for pragma, value in pragmas.items():


### PR DESCRIPTION
SQLite connection starts with autocommit if isolation level hasn't provided.

Set transaction isolation level to `DEFERRED` during connection creation for read-write mode.

https://www.sqlite.org/lang_transaction.html