### PR TITLE
fix: display placeholder text for code‐type input

### DIFF
--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -82,6 +82,7 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 		}
 
 		this.editor.setTheme("ace/theme/tomorrow");
+		this.editor.setOption("placeholder", this.df.placeholder);
 		this.editor.setOption("showPrintMargin", false);
 		this.editor.setOption("wrap", this.df.wrap);
 		this.set_language();


### PR DESCRIPTION
There was no placeholders rendered for code form fields. This fix uses Ace editor's placeholder EditorOption to render the placeholder appropriately inside the editor.

Fixes #34488

<img width="696" height="359" alt="image" src="https://github.com/user-attachments/assets/bc29f025-c95d-4fb4-a9bb-0ed92809f528" />
