### PR TITLE
feat: add functions to generate filtered list URLs and links for doctypes

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2007,6 +2007,41 @@ def get_url_to_report_with_filters(name, filters, report_type=None, doctype=None
 	return get_url(uri=f"/app/query-report/{quoted(name)}?{filters}")
 
 
+def get_filtered_list_url(doctype: str, docnames: list[str] | None = None) -> str:
+	"""
+	Get a filtered list view URL for a doctype with specific document names.
+
+	:param doctype: The doctype name
+	:param docnames: List of document names to filter
+
+	:return: URL to the filtered list view
+	"""
+	list_url = get_url_to_list(doctype)
+
+	if not docnames:
+		return list_url
+
+	return "".join((list_url, "?", urlencode({"name": json.dumps(["in", docnames])})))
+
+
+def get_filtered_list_link(doctype: str, docnames: list[str] | None = None, label: str | None = None) -> str:
+	"""
+	Get an HTML link to a filtered list view for a doctype with specific document names.
+
+	:param doctype: The doctype name
+	:param docnames: List of document names to filter
+	:param label: Optional label for the link. If not provided, uses doctype
+
+	:return: HTML link to the filtered list view
+	"""
+	from frappe import _
+
+	url = get_filtered_list_url(doctype, docnames)
+	label = label or _(doctype)
+
+	return f"""<a href="{url}">{label}</a>"""
+
+
 def sql_like(value: str, pattern: str) -> bool:
 	if not (isinstance(pattern, str) and isinstance(value, str)):
 		return False


### PR DESCRIPTION
### Requirement

When multiple documents are created through a workflow, generally system shows a message dialog containing links to each created document.

This becomes difficult to read, and if the user clicks one document link, the message dialog disappears — making it hard to track the remaining documents.

Using this utility, we can **redirect the user to a filtered List View** showing all the created documents together.

This improves readability and allows the user to see and manage all created records at once.

### Example Use Case

**Creating Work Orders from Production Planning (ERPNext)**

#### Before

A long message dialog displays multiple document links (hard to read and easy to lose).

<img width="792" height="271" alt="image" src="https://github.com/user-attachments/assets/fd2ffc7f-1a8d-49f3-9e2f-6f76ebf8ed13" />

#### After

The user is automatically redirected to the **Work Order List View**, filtered to show only the newly created documents.

 <img width="800" height="230" alt="image" src="https://github.com/user-attachments/assets/ac39c6e9-3538-40ee-8455-305a7bfd4456" />  
 
 <img width="1402" height="453" alt="image" src="https://github.com/user-attachments/assets/79bc1c6f-de0e-4b72-9df2-a96050d693dc" />

### Details

**Doctype:**

```py
"Work Order"
```

**Created Document Names:**

```py
['MFG-WO-2025-00027', 'MFG-WO-2025-00028', 'MFG-WO-2025-00029']
```

**Generated URL (Filtered List View):**

```py
'http://develop.localhost:8000/app/work-order?name=%5B%22in%22%2C+%5B%22MFG-WO-2025-00027%22%2C+%22MFG-WO-2025-00028%22%2C+%22MFG-WO-2025-00029%22%5D%5D'
```

- Working PR in ERPNext: https://github.com/frappe/erpnext/pull/50224

---

- docs: https://docs.frappe.io/framework/user/en/api/utils#get_filtered_list_url