### PR TITLE
 fix: replace deprecated initHighlighting() with highlightAll()

### DIFF
--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -284,7 +284,7 @@ $.extend(frappe, {
 	},
 
 	highlight_code_blocks: function () {
-		hljs.initHighlighting();
+		hljs.highlightAll();
 	},
 	bind_filters: function () {
 		// set in select


### PR DESCRIPTION
### fix: replace deprecated initHighlighting() with highlightAll()

---

## Description
This Pull Request fixes a frontend deprecation warning caused by the use of `hljs.initHighlighting()` in Frappe’s JavaScript codebase.  
The method has been deprecated since **Highlight.js v10.6.0** and replaced with `hljs.highlightAll()`.

This update ensures compatibility with newer versions of Highlight.js and removes unnecessary console warnings.

---

## Before
```
Deprecated as of 10.6.0. initHighlighting() is deprecated. Use highlightAll() instead.
```

---

## After
✅ No deprecation warnings appear in the console.  
✅ Syntax highlighting continues to work correctly.

---

## Technical Details
- Replaced:
  ```js
  hljs.initHighlighting();
  ```
  with:
  ```js
  hljs.highlightAll();
  ```
- Verified UI and highlighting behavior remain unchanged.
- No backend or API changes were made.

---

## Testing Instructions
1. Pull this branch.
2. Run the following command to rebuild assets:
   ```bash
   bench build
   ```
3. Open any Frappe page containing code blocks.
4. Open the browser console and confirm that the deprecation warning no longer appears.

---

## Environment
| Key | Value |
|-----|--------|
 **Frappe Version** | v15.86.0 |
| **Bench Version** | v5.25.11 |
| **Environment** | Development |
| **Browser** | Chrome 141 |
| **OS** | Windows 10 / Ubuntu 22.04 |

---

## Related Issue
 <!-- Replace XXXX with the issue number once created -->

---

## Checklist
- [x] Follows Frappe PR and commit conventions  
- [x] Tested locally without regressions  
- [x] `bench build` executed successfully  
- [x] Verified UI stability  
- [x] Fix addresses the reported issue

---

### Summary
This PR updates Frappe’s frontend to use `hljs.highlightAll()` instead of the deprecated `initHighlighting()` method.  
It removes console warnings and ensures continued compatibility with the latest Highlight.js releases.
