### PR TITLE
feat: import custom DocType Links on app install/migrate

### DIFF
--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -151,6 +151,19 @@ def sync_customizations_for_doctype(data: dict, folder: str, filename: str = "")
 							custom_field.flags.ignore_validate = True
 							custom_field.update(d)
 							custom_field.db_update()
+				case "DocType Link":
+					for d in data[key]:
+						link = frappe.db.get_value(
+							"DocType Link", {"parent": doc_type, "link_doctype": d.get("link_doctype")}
+						)
+						if not link:
+							d["owner"] = "Administrator"
+							_insert(d)
+						else:
+							doc_link = frappe.get_doc("DocType Link", link)
+							doc_link.flags.ignore_validate = True
+							doc_link.update(d)
+							doc_link.db_update()
 				case "Property Setter":
 					# Property setter implement their own deduplication, we can just sync them as is
 					for d in data[key]:
@@ -179,6 +192,9 @@ def sync_customizations_for_doctype(data: dict, folder: str, filename: str = "")
 	if data["custom_fields"]:
 		sync("custom_fields", "Custom Field", "dt")
 		update_schema = True
+
+	if data.get("links", False):
+		sync("links", "DocType Link", "parent")
 
 	if data["property_setters"]:
 		sync("property_setters", "Property Setter", "doc_type")

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -154,7 +154,12 @@ def sync_customizations_for_doctype(data: dict, folder: str, filename: str = "")
 				case "DocType Link":
 					for d in data[key]:
 						link = frappe.db.get_value(
-							"DocType Link", {"parent": doc_type, "link_doctype": d.get("link_doctype")}
+							"DocType Link",
+							{
+								"parent": doc_type,
+								"link_doctype": d.get("link_doctype"),
+								"link_fieldname": d.get("link_fieldname"),
+							},
 						)
 						if not link:
 							d["owner"] = "Administrator"

--- a/frappe/tests/test_modules.py
+++ b/frappe/tests/test_modules.py
@@ -195,7 +195,7 @@ def note_customizations():
 				"parentfield": "links",
 				"link_doctype": "User",
 				"link_fieldname": "owner",
-				"group": "Test Group"
+				"group": "Test Group",
 			}
 		).insert()
 

--- a/frappe/tests/test_modules.py
+++ b/frappe/tests/test_modules.py
@@ -88,7 +88,7 @@ class TestUtils(IntegrationTestCase):
 		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
 	)
 	def test_sync_customizations(self):
-		with note_customizations() as (custom_field, property_setter):
+		with note_customizations() as (custom_field, property_setter, doctype_link):
 			file_path = export_customizations(module="Custom", doctype="Note", sync_on_migrate=True)
 			custom_field.db_set("modified", now_datetime())
 			custom_field.reload()
@@ -105,6 +105,7 @@ class TestUtils(IntegrationTestCase):
 			sync_customizations(app="frappe")
 			self.assertTrue(property_setter.doctype, property_setter.name)
 			self.assertTrue(custom_prop_setter.doctype, custom_prop_setter.name)
+			self.assertTrue(doctype_link.doctype, doctype_link.name)
 
 			self.assertTrue(file_path.endswith("/custom/custom/note.json"))
 			self.assertTrue(os.path.exists(file_path))
@@ -185,9 +186,21 @@ def note_customizations():
 		property_setter = make_property_setter(
 			"Note", fieldname="content", property="bold", value="1", property_type="Check"
 		)
-		yield custom_field, property_setter
+
+		doctype_link = frappe.get_doc({
+			"doctype": "DocType Link",
+			"parent": "Note",
+			"parenttype": "DocType",
+			"parentfield": "links",
+			"link_doctype": "User",
+			"link_fieldname": "owner",
+			"group": "Test Group"
+		}).insert()
+
+		yield custom_field, property_setter, doctype_link
 	finally:
 		custom_field.delete()
 		property_setter.delete()
+		doctype_link.delete()
 		trim_table("Note", dry_run=False)
 		delete_path(frappe.get_module_path("Desk", "Note"))

--- a/frappe/tests/test_modules.py
+++ b/frappe/tests/test_modules.py
@@ -187,15 +187,17 @@ def note_customizations():
 			"Note", fieldname="content", property="bold", value="1", property_type="Check"
 		)
 
-		doctype_link = frappe.get_doc({
-			"doctype": "DocType Link",
-			"parent": "Note",
-			"parenttype": "DocType",
-			"parentfield": "links",
-			"link_doctype": "User",
-			"link_fieldname": "owner",
-			"group": "Test Group"
-		}).insert()
+		doctype_link = frappe.get_doc(
+			{
+				"doctype": "DocType Link",
+				"parent": "Note",
+				"parenttype": "DocType",
+				"parentfield": "links",
+				"link_doctype": "User",
+				"link_fieldname": "owner",
+				"group": "Test Group"
+			}
+		).insert()
 
 		yield custom_field, property_setter, doctype_link
 	finally:


### PR DESCRIPTION
At the moment, [Export Customizations](https://docs.frappe.io/framework/user/en/guides/app-development/exporting-customizations) defines a `links` section on the customization json for any Document Links defined in Customize Form, but the `sync_customizations_for_doctype` function responsible to import these customizations ignores them. This PR fixes that and allows for importing `DocType Link` customizations.

Fixes #32094

no-docs