### PR TITLE
fix: prevent duration field from opening when set to read only

### DIFF
--- a/frappe/public/js/frappe/form/controls/duration.js
+++ b/frappe/public/js/frappe/form/controls/duration.js
@@ -103,6 +103,7 @@ frappe.ui.form.ControlDuration = class ControlDuration extends frappe.ui.form.Co
 		});
 
 		this.$input.on("focus", () => {
+			if (this.df.read_only) return;
 			this.$picker.show();
 			let is_picker_set = this.is_duration_picker_set(this.inputs);
 			if (!is_picker_set) {


### PR DESCRIPTION
Prevents the duration picker from opening in a child table when set to read only.

Closes #34495 