### PR TITLE
chore: disallow user from creating API Request Log

### DIFF
--- a/frappe/core/doctype/api_request_log/api_request_log.json
+++ b/frappe/core/doctype/api_request_log/api_request_log.json
@@ -34,9 +34,10 @@
   }
  ],
  "grid_page_length": 50,
+ "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-21 17:09:55.054044",
+ "modified": "2025-10-29 11:26:28.177653",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "API Request Log",


### PR DESCRIPTION
#32622 "API Request Log" doctype is meant to be system-generated only. But users can manually create logs, which may lead to inconsistencies and data pollution.