### PR TITLE
fix: always show docname as breadcrumb title

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -208,8 +208,6 @@ frappe.breadcrumbs = {
 
 		let title = frappe.model.get_doc_title(doc);
 
-		if (title == doc.name) return; // title and name are same, don't add breadcrumb
-
 		let form_route = `/app/${frappe.router.slug(doctype)}/${encodeURIComponent(docname)}`;
 		this.append_breadcrumb_element(form_route, doc.name);
 


### PR DESCRIPTION
It is required to have the docname displayed as the title in some cases. The copy function also depends on having the document name visible in the breadcrumb.

Previously, the breadcrumb title was not displayed when the title and doc.name were the same. This caused usability issues when the document title was intentionally identical to its name but still needed to be visible (for example, when copying or referencing documents).

This change ensures the docname is always shown as the breadcrumb title, even if it matches the document’s title.