### PR TITLE
fix: check if get_route property exists before calling

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -282,7 +282,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 
 	handle_focus() {
 		const me = this;
-		if (frappe.get_route()) {
+		if (frappe.get_route?.()) {
 			if (frappe.get_route()[0] == "Form") {
 				if (!me.last_focus) me.last_focus = document.activeElement;
 			}


### PR DESCRIPTION
Breaks web forms attachments. 