### PR TITLE
feat: add select all button to multiSelect field

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -14,7 +14,10 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 					</li>
 					<div class="selectable-items">
 					</div>
-					<li class="text-right">
+					<li class="d-flex justify-content-end">
+						<button class="btn btn-secondary btn-xs select-all-options text-nowrap mr-2">
+							${__("Select All")}
+						</button>
 						<button class="btn btn-primary btn-xs clear-selections text-nowrap">
 							${__("Clear All")}
     					</button>
@@ -38,6 +41,9 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 		});
 		this.$list_wrapper.on("click", ".clear-selections", (e) => {
 			this.clear_all_selections();
+		});
+		this.$list_wrapper.on("click", ".select-all-options", (e) => {
+			this.select_all_options();
 		});
 		this.$list_wrapper.on("click", ".selectable-item", (e) => {
 			let $target = $(e.currentTarget);
@@ -126,6 +132,14 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 	clear_all_selections() {
 		this.values = [];
 		this._selected_values = [];
+		this.update_status();
+		this.set_selectable_items(this._options);
+		this.parse_validate_and_set_in_model("");
+	}
+
+	select_all_options() {
+		this.values = this._options.map((opt) => opt.value);
+		this._selected_values = this._options.slice();
 		this.update_status();
 		this.set_selectable_items(this._options);
 		this.parse_validate_and_set_in_model("");


### PR DESCRIPTION
This PR adds a **Select All** button to the MultiSelect field dropdown, allowing users to quickly select all available options at once.

  This follows the same implementation pattern as PR #28507, which added the Clear All button.
  **Closes:** #34528

**Before**

<img width="1285" height="645" alt="Screenshot 2025-11-08 at 12 51 13 PM" src="https://github.com/user-attachments/assets/2a5a4c36-59d3-423b-93ca-1a819dfa9132" />


**After**

https://github.com/user-attachments/assets/eab43016-00bc-49bf-8202-0a0585cfd74c



`no-docs`