### PR TITLE
fix: improve float formatting precision handling

### DIFF
--- a/frappe/utils/formatters.py
+++ b/frappe/utils/formatters.py
@@ -91,13 +91,21 @@ def format_value(value, df=None, doc=None, currency=None, translated=False, form
 		# I don't know why we support currency option for float
 		currency = currency or get_field_currency(df, doc)
 
-		# show 1.000000 as 1
-		# options should not specified
-		if not df.options and value is not None:
+		system_float_precision = frappe.db.get_default("float_precision")
+		has_system_precision = system_float_precision is not None and system_float_precision != ""
+		has_explicit_precision = df.precision is not None and df.precision != ""
+		# Auto-detect precision for whole numbers when:
+		# 1. No field-specific precision is set
+		# 2. No system-wide precision is configured
+		# This ensures values like 1.000000 are displayed as "1" instead of "1.000000"
+		if not has_explicit_precision and not has_system_precision and not df.options and value is not None:
 			temp = cstr(value).split(".")
 			if len(temp) == 1 or cint(temp[1]) == 0:
 				precision = 0
-
+		elif (has_explicit_precision or has_system_precision) and not df.options and value is not None:
+			# Format as regular float with specified precision
+			return "%.*f" % (precision, flt(value))
+		
 		return fmt_money(value, precision=precision, currency=currency)
 
 	elif df.get("fieldtype") == "Percent":


### PR DESCRIPTION
## Description
Closes #34531

This PR fixes the issue where Float fields ignore System Settings precision or field precision when values are whole numbers. Previously, whole numbers like `87.0` would display as `87` even when `float_precision = 2` was configured. Now, whole numbers correctly display with the configured precision (e.g., `87.00` when precision is 2).

## Changes Made in `frappe/utils/formatters.py`

### Fixed Float Field Precision Handling (lines 89-109)

**Before:**
- Float fields with whole number values (e.g., 87.0, 2.0) always displayed without decimals, ignoring system settings and field precision
- Auto-detection set precision to 0 for all whole numbers regardless of configured precision

**After:**
- Added checks for system-wide `float_precision` setting and field-level `precision` 
- Auto-detection (precision = 0) now only applies when:
  - No field-specific precision is set (`df.precision` is None or empty)
  - No system-wide precision is configured (`float_precision` is not set)
  - No currency options are set (`df.options` is empty)

## Screenshots
### When precision was not set in system setting and field
**Before:**     ------>      **After:**
<img width="82" height="308" alt="Screenshot 2025-10-30 at 12 48 15 PM" src="https://github.com/user-attachments/assets/77822daa-13ec-42ad-a3a5-b323c2ed4737" />   <img width="75" height="300" alt="Screenshot 2025-10-30 at 12 58 34 PM" src="https://github.com/user-attachments/assets/e14198d2-499a-4f66-a145-2e5e3090360e" />

### When precision was set to 2 in either system setting or field
**Before:**     ------>      **After:**
<img width="77" height="299" alt="Screenshot 2025-10-30 at 12 50 35 PM" src="https://github.com/user-attachments/assets/620c9bc0-477f-4278-b5c5-e2b14759b273" />   <img width="75" height="296" alt="Screenshot 2025-10-30 at 12 59 48 PM" src="https://github.com/user-attachments/assets/bc8a856b-880b-4ed0-be05-90ba8caa4d7b" />

### When precision was set to 3 in either system setting or field
**Before:**     ------>      **After:**
<img width="77" height="301" alt="Screenshot 2025-10-30 at 12 56 15 PM" src="https://github.com/user-attachments/assets/65cc63d7-9e69-44f1-86d4-4f64cb1497a7" />    <img width="75" height="296" alt="Screenshot 2025-10-30 at 1 02 08 PM" src="https://github.com/user-attachments/assets/1fcb0e92-be8c-4180-96dc-a4d776b4ab72" />




