### PR TITLE
feat(translations): add hook to exclude translatable strings from dependencies

### DIFF
--- a/frappe/gettext/translate.py
+++ b/frappe/gettext/translate.py
@@ -10,6 +10,7 @@ from babel.messages.catalog import Catalog
 from babel.messages.extract import DEFAULT_KEYWORDS, extract_from_dir
 from babel.messages.mofile import read_mo, write_mo
 from babel.messages.pofile import read_po, write_po
+from click import secho
 
 import frappe
 from frappe.utils import get_bench_path
@@ -136,6 +137,7 @@ def generate_pot(target_app: str | None = None):
 	for app in apps:
 		app_path = frappe.get_pymodule_path(app, "..")
 		catalog = new_catalog(app)
+		ignored_strings = _get_ignored_strings(app)
 
 		# Each file will only be processed by the first method that matches,
 		# so more specific methods should come first.
@@ -148,10 +150,43 @@ def generate_pot(target_app: str | None = None):
 			if not message:
 				continue
 
+			if (message, context) in ignored_strings:
+				continue
+
 			catalog.add(message, locations=[(filename, lineno)], auto_comments=comments, context=context)
 
 		pot_path = write_catalog(app, catalog)
 		print(f"POT file created at {pot_path}")
+
+
+def _get_ignored_strings(app: str) -> set[tuple[str, str | None]]:
+	"""Return a set of tuples (message, context) that should be excluded from the given app's POT file.
+
+	Example:
+	    If [app]/hooks.py contains:
+	        ignore_translatable_strings_from = ["frappe"]
+
+	    Then this will return a set of tuples (message, context) with all
+	    entries from frappe's POT file.
+	"""
+	ignored_strings = set()
+	for ignore_app in frappe.get_hooks("ignore_translatable_strings_from", [], app_name=app):
+		if ignore_app == app:
+			raise ValueError(
+				f"Invalid configuration: App '{app}' cannot ignore its own translatable strings. "
+				f"Remove '{app}' from the 'ignore_translatable_strings_from' hook in {app}/hooks.py to fix this."
+			)
+
+		try:
+			catalog = get_catalog(ignore_app)
+		except ModuleNotFoundError:
+			secho(f"App {ignore_app} not found. Skipping", err=True, fg="yellow")
+			continue
+
+		for message in catalog:
+			ignored_strings.add((message.id, message.context))
+
+	return ignored_strings
 
 
 def get_is_gitignored_function_for_app(app: str | None):

--- a/frappe/gettext/translate.py
+++ b/frappe/gettext/translate.py
@@ -180,13 +180,25 @@ def _get_ignored_strings(app: str) -> set[tuple[str, str | None]]:
 		try:
 			catalog = get_catalog(ignore_app)
 		except ModuleNotFoundError:
-			secho(f"App '{ignore_app}' is not installed. Skipping", err=True, fg="yellow")
+			secho(
+				f"App '{ignore_app}' specified in '{app}/hooks.py' 'ignore_translatable_strings_from' hook is not installed. Skipping",
+				err=True,
+				fg="yellow",
+			)
 			continue
 		except ImportError:
-			secho(f"App '{ignore_app}' hooks.py could not be imported. Skipping", err=True, fg="yellow")
+			secho(
+				f"App '{ignore_app}' specified in '{app}/hooks.py' 'ignore_translatable_strings_from' hook could not be imported. Skipping",
+				err=True,
+				fg="yellow",
+			)
 			continue
 		except AttributeError:
-			secho(f"Site not initialized. Cannot load app '{ignore_app}'. Skipping", err=True, fg="yellow")
+			secho(
+				f"Site not initialized. Cannot load app '{ignore_app}' specified in '{app}/hooks.py' 'ignore_translatable_strings_from' hook. Skipping",
+				err=True,
+				fg="yellow",
+			)
 			continue
 
 		for message in catalog:

--- a/frappe/gettext/translate.py
+++ b/frappe/gettext/translate.py
@@ -180,7 +180,13 @@ def _get_ignored_strings(app: str) -> set[tuple[str, str | None]]:
 		try:
 			catalog = get_catalog(ignore_app)
 		except ModuleNotFoundError:
-			secho(f"App {ignore_app} not found. Skipping", err=True, fg="yellow")
+			secho(f"App '{ignore_app}' is not installed. Skipping", err=True, fg="yellow")
+			continue
+		except ImportError:
+			secho(f"App '{ignore_app}' hooks.py could not be imported. Skipping", err=True, fg="yellow")
+			continue
+		except AttributeError:
+			secho(f"Site not initialized. Cannot load app '{ignore_app}'. Skipping", err=True, fg="yellow")
 			continue
 
 		for message in catalog:

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -643,6 +643,11 @@ app_license = "{app_license}"
 # 	"Logging DocType Name": 30  # days to retain logs
 # }}
 
+# Translation
+# ------------
+# List of apps whose translatable strings should be excluded from this app's translations.
+# ignore_translatable_strings_from = []
+
 """
 
 gitignore_template = """# Byte-compiled / optimized / DLL files


### PR DESCRIPTION
### Summary
Adds support for the `ignore_translatable_strings_from` hook that allows apps to exclude translatable strings from specified dependency apps when generating POT files. This prevents duplication of translations that already exist in parent/dependency apps.

### Problem
Custom apps frequently contain strings that already have translations in core apps (like Frappe or ERPNext). This creates unnecessary duplication in translation files and makes it harder to track which translations are actually needed for the custom app.

**Impact:**
- ERPNext could reduce its translation file by ~8,000 lines (13%) by ignoring Frappe strings
- HRMS could reduce by ~4,500 lines (28%) by ignoring Frappe and ERPNext strings

### Solution
This PR introduces a new hook that allows apps to specify which dependency apps' translations should be excluded from their POT generation:

```python
# In hooks.py
ignore_translatable_strings_from = ["frappe", "erpnext"]
```

### Changes
1. **Core functionality** (`frappe/gettext/translate.py`):
   - Added `_get_ignored_strings()` helper function that builds a set of (message, context) tuples from specified apps' POT files
   - Modified POT generation to filter out ignored strings during catalog building
   - Added validation to prevent apps from ignoring themselves (raises `ValueError`)
   - Added color-coded warning (yellow) when specified apps are not found

2. **Developer experience** (`frappe/utils/boilerplate.py`):
   - Added hook documentation to the boilerplate template for new apps
   - Includes clear usage example

### Technical Details
- **Performance:** Uses set-based lookups for efficient filtering - each membership test is O(1) on average, making it suitable for large translation catalogs.
- **Safety:** Validates that apps don't ignore themselves and provides clear error messages
- **Graceful degradation:** Missing apps trigger warnings but don't break the build

### Testing
To test this feature:
1. Add `ignore_translatable_strings_from = ["frappe"]` to a custom app's `hooks.py`
2. Run `bench generate-pot-file` for the app
3. Verify that strings present in Frappe's POT file are excluded from the generated POT file

### Documentation
> no-docs (will add after merge)

---

**Resolves #34541**