### PR TITLE
test(postgres): added PostgreSQL variant for start/kill job test

### DIFF
--- a/frappe/core/doctype/prepared_report/test_prepared_report.py
+++ b/frappe/core/doctype/prepared_report/test_prepared_report.py
@@ -63,9 +63,12 @@ class TestPreparedReport(IntegrationTestCase):
 		self.assertEqual(len(prepared_data["result"]), len(generated_data["result"]))
 		self.assertEqual(len(prepared_data), len(generated_data))
 
-	@run_only_if(db_type_is.MARIADB)
 	def test_start_status_and_kill_jobs(self):
-		with test_report(report_type="Query Report", query="select sleep(10)") as report:
+		if frappe.db.db_type == "postgres":
+			query = "select pg_sleep(5)"
+		elif frappe.db.db_type == "mariadb":
+			query = "select sleep(5)"
+		with test_report(report_type="Query Report", query=query) as report:
 			doc = self.create_prepared_report(report.name)
 			self.wait_for_status(doc, "Started")
 			job_id = doc.job_id


### PR DESCRIPTION
**Problem:**
Test: This PR is part of resolving a part of issue: #21613 . The problem was that there was no test running for Postgres variant to start/kill job for a prepared_report. This PR aims to fix that by adding a dedicated test for Postgres.

**Before**:

There was no test. 

**After**

<img width="1950" height="532" alt="image" src="https://github.com/user-attachments/assets/aa22e983-81d0-4dc1-8fbb-eeffc125e092" />



related to #21613 