### PR TITLE
fix(auto_repeat): render template from DB

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.js
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.js
@@ -85,14 +85,17 @@ frappe.ui.form.on("Auto Repeat", {
 	},
 
 	preview_message: function (frm) {
+		if (frm.is_dirty()) {
+			frappe.msgprint(__("Please save the form before previewing the message"));
+			return;
+		}
+
 		if (frm.doc.message) {
 			frappe.call({
 				method: "frappe.automation.doctype.auto_repeat.auto_repeat.generate_message_preview",
+				type: "POST",
 				args: {
-					reference_dt: frm.doc.reference_doctype,
-					reference_doc: frm.doc.reference_document,
-					subject: frm.doc.subject,
-					message: frm.doc.message,
+					name: frm.doc.name,
 				},
 				callback: function (r) {
 					if (r.message) {

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -605,14 +605,15 @@ def update_reference(docname: str, reference: str):
 	return "success"  # backward compatbility
 
 
-@frappe.whitelist()
-def generate_message_preview(reference_dt, reference_doc, message=None, subject=None):
+@frappe.whitelist(methods=["POST"])
+def generate_message_preview(name: str):
 	frappe.has_permission("Auto Repeat", "write", throw=True)
-	doc = frappe.get_doc(reference_dt, reference_doc)
+	auto_repeat = frappe.get_doc("Auto Repeat", str(name))
+	doc = frappe.get_doc(auto_repeat.reference_doctype, auto_repeat.reference_document)
 	doc.check_permission()
 	subject_preview = _("Please add a subject to your email")
-	msg_preview = frappe.render_template(message, {"doc": doc})
-	if subject:
-		subject_preview = frappe.render_template(subject, {"doc": doc})
+	msg_preview = frappe.render_template(auto_repeat.message, {"doc": doc})
+	if auto_repeat.subject:
+		subject_preview = frappe.render_template(auto_repeat.subject, {"doc": doc})
 
 	return {"message": msg_preview, "subject": subject_preview}


### PR DESCRIPTION
Don't allow client to pass in a template to render
Also change endpoint to POST

Reference: support ticket 52394
