### PR TITLE
feat: configure SMS OTP template for 2FA

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -51,12 +51,15 @@
   "column_break_34",
   "allow_login_after_fail",
   "two_factor_authentication",
+  "column_break_odhl",
   "enable_two_factor_auth",
   "bypass_2fa_for_retricted_ip_users",
   "bypass_restrict_ip_check_if_2fa_enabled",
+  "column_break_bzfr",
   "two_factor_method",
   "lifespan_qrcode_image",
   "otp_issuer_name",
+  "otp_sms_template",
   "password_tab",
   "password_settings",
   "logout_on_password_reset",
@@ -752,12 +755,27 @@
    "fieldtype": "Select",
    "label": "Show External Link Warning",
    "options": "Never\nAsk\nAlways"
+  },
+  {
+   "fieldname": "column_break_odhl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.enable_two_factor_auth==1 && doc.two_factor_method==\"SMS\"",
+   "description": "OTP placeholder should be defined as <code>{{ otp }}</code> ",
+   "fieldname": "otp_sms_template",
+   "fieldtype": "Small Text",
+   "label": "OTP SMS Template"
+  },
+  {
+   "fieldname": "column_break_bzfr",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2025-09-24 16:04:02.016562",
+ "modified": "2025-11-04 16:47:54.230874",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -164,7 +164,9 @@ class SystemSettings(Document):
 
 		if "{{otp}}" not in self.otp_sms_template.replace(" ", ""):
 			frappe.throw(
-				_("OTP SMS Template must contain <code>{{otp}}</code> placeholder to insert the OTP.")
+				_("OTP SMS Template must contain <code>{0}</code> placeholder to insert the OTP.").format(
+					"{{otp}}"
+				)
 			)
 
 	def validate_user_pass_login(self):

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -89,6 +89,7 @@ class SystemSettings(Document):
 			"#,###",
 		]
 		otp_issuer_name: DF.Data | None
+		otp_sms_template: DF.SmallText | None
 		password_reset_limit: DF.Int
 		rate_limit_email_link_login: DF.Int
 		reset_password_link_expiry_duration: DF.Duration | None
@@ -145,6 +146,7 @@ class SystemSettings(Document):
 		self.validate_user_pass_login()
 		self.validate_backup_limit()
 		self.validate_file_extensions()
+		self.validate_otp_sms_template()
 
 		if not self.link_field_results_limit:
 			self.link_field_results_limit = 10
@@ -154,6 +156,15 @@ class SystemSettings(Document):
 			label = _(self.meta.get_label("link_field_results_limit"))
 			frappe.msgprint(
 				_("{0} can not be more than {1}").format(label, 50), alert=True, indicator="yellow"
+			)
+
+	def validate_otp_sms_template(self):
+		if not self.enable_two_factor_auth or self.two_factor_method != "SMS" or not self.otp_sms_template:
+			return
+
+		if "{{otp}}" not in self.otp_sms_template.replace(" ", ""):
+			frappe.throw(
+				_("OTP SMS Template must contain <code>{{otp}}</code> placeholder to insert the OTP.")
 			)
 
 	def validate_user_pass_login(self):

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -320,7 +320,8 @@ def send_token_via_sms(otpsecret, token=None, phone_no=None):
 		return False
 
 	hotp = pyotp.HOTP(otpsecret)
-	args = {ss.message_parameter: f"Your verification code is {hotp.at(int(token))}"}
+	otp = hotp.at(int(token))
+	args = {ss.message_parameter: get_rendered_sms_otp_template(otp)}
 
 	for d in ss.get("parameters"):
 		args[d.parameter] = d.value
@@ -339,6 +340,14 @@ def send_token_via_sms(otpsecret, token=None, phone_no=None):
 		**sms_args,
 	)
 	return True
+
+
+def get_rendered_sms_otp_template(otp: str) -> str:
+	default_template = "Your verification code is {otp}"
+	custom_template = frappe.get_system_settings("otp_sms_template")
+	template = custom_template or default_template
+
+	return frappe.render_template(template, {"otp": otp})
 
 
 def send_token_via_email(user, token, otp_secret, otp_issuer, subject=None, message=None):

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -321,7 +321,7 @@ def send_token_via_sms(otpsecret, token=None, phone_no=None):
 
 	hotp = pyotp.HOTP(otpsecret)
 	otp = hotp.at(int(token))
-	args = {ss.message_parameter: get_rendered_sms_otp_template(otp)}
+	args = {ss.message_parameter: get_rendered_otp_message(otp)}
 
 	for d in ss.get("parameters"):
 		args[d.parameter] = d.value
@@ -342,7 +342,7 @@ def send_token_via_sms(otpsecret, token=None, phone_no=None):
 	return True
 
 
-def get_rendered_sms_otp_template(otp: str) -> str:
+def get_rendered_otp_message(otp: str) -> str:
 	default_template = "Your verification code is {{otp}}"
 	custom_template = frappe.get_system_settings("otp_sms_template")
 	template = custom_template or default_template

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -343,7 +343,7 @@ def send_token_via_sms(otpsecret, token=None, phone_no=None):
 
 
 def get_rendered_sms_otp_template(otp: str) -> str:
-	default_template = "Your verification code is {otp}"
+	default_template = "Your verification code is {{otp}}"
 	custom_template = frappe.get_system_settings("otp_sms_template")
 	template = custom_template or default_template
 


### PR DESCRIPTION
Allow users to configure the OTP SMS template:

<img width="2416" height="1158" alt="CleanShot 2025-11-04 at 17 05 23@2x" src="https://github.com/user-attachments/assets/c5dbb24a-d7b7-4b24-b50a-4aa069dea1d2" />


`no-docs`