### PR TITLE
fix: redirect to role permission tab when add roles button is clicked

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -855,8 +855,12 @@ class User(Document):
 			indicator="orange",
 			primary_action={
 				"label": _("Add Roles"),
-				"client_action": "frappe.set_route",
-				"args": ["Form", self.doctype, self.name],
+				"client_action": "eval",
+				"args": f"""
+							frappe.set_route('Form', 'User', {self.name}) + history.replaceState(null, '', '#roles_permissions_tab')
+							cur_frm.refresh()
+							cur_dialog.hide()
+						""",
 			},
 		)
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -857,7 +857,7 @@ class User(Document):
 				"label": _("Add Roles"),
 				"client_action": "eval",
 				"args": f"""
-							frappe.set_route('Form', 'User', {self.name}) + history.replaceState(null, '', '#roles_permissions_tab')
+							frappe.set_route('Form', 'User', '{self.name}') + history.replaceState(null, '', '#roles_permissions_tab')
 							cur_frm.refresh()
 							cur_dialog.hide()
 						""",


### PR DESCRIPTION
**Issue**: When creating a user, we get a pop up with a button to "Add Roles" for the specific user. However on clicking, instead of redirecting to "Roles & Permissions" tab, this button does nothing.

**Before**:
<video src="https://github.com/user-attachments/assets/189826b5-5877-4f38-bdd2-b795899d6164"></video>

**After**:
<video src="https://github.com/user-attachments/assets/20cdd91c-15d8-40fc-aa80-dc976027ba49"></video>
