### PR TITLE
fix(pdf_merge): respect `output` parameter if no header or footer

### DIFF
--- a/frappe/utils/pdf_generator/pdf_merge.py
+++ b/frappe/utils/pdf_generator/pdf_merge.py
@@ -31,6 +31,9 @@ class PDFTransformer:
 		footer = self.footer_pdf
 
 		if not header and not footer:
+			if output:
+				output.append_pages_from_reader(body)
+				return output
 			return body
 
 		body_height = body.pages[0].mediabox.top


### PR DESCRIPTION
Resolves #34573
