### PR TITLE
Fixed Validation in share.js file

### DIFF
--- a/frappe/share.py
+++ b/frappe/share.py
@@ -36,9 +36,23 @@ def add(doctype, name, user=None, read=1, write=0, submit=0, share=0, everyone=0
 def add_docshare(
 	doctype, name, user=None, read=1, write=0, submit=0, share=0, everyone=0, flags=None, notify=0
 ):
-	"""Share the given document with a user."""
+	"""Share the given document with a user.
+
+	Added validation to prevent sharing with Website Users (except for internal system cases).
+	"""
 	if not user:
 		user = frappe.session.user
+
+	# --- 🔒 Validation: prevent sharing with Website Users ---
+	# Skip if sharing with everyone or the shared document itself is a User record.
+	if not cint(everyone) and doctype != "User":
+		user_type = frappe.db.get_value("User", user, "user_type")
+		if user_type != "System User":
+			frappe.throw(
+				_("You can only share documents with System Users. '{0}' is a {1}.").format(user, user_type),
+				frappe.ValidationError,
+			)
+	# ---------------------------------------------------------
 
 	if not (flags or {}).get("ignore_share_permission"):
 		check_share_permission(doctype, name)


### PR DESCRIPTION
Currently, in Frappe, when sharing a document via the Share dialog:

The dropdown/input only shows System Users, but there is no backend validation on the entered value.
This allows anyone to manually paste the ID of a Website User and successfully share the document with them, bypassing the intended restriction.

This PR adds backend validation to the sharing logic:

When a document is being shared, the system now checks whether the specified user is a System User.
If the user is a Website User, the system prevents the share action and throws a validation error.
This ensures that sharing restrictions are enforced consistently, even if the request is made directly through the API or via custom scripts.

Behavior after this PR:

Only System Users can be shared documents with.
Attempts to share documents with Website Users are blocked at the backend level, ensuring data security and consistent enforcement of permissions.