### PR TITLE
fix: handle between condition properly in get_link_to_report filters

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -31,6 +31,7 @@ from frappe.utils import (
 	get_bench_path,
 	get_file_timestamp,
 	get_gravatar,
+	get_link_to_report,
 	get_site_info,
 	get_sites,
 	get_url,
@@ -341,6 +342,13 @@ class TestFilters(IntegrationTestCase):
 		self.assertTrue(compare(None, "is", "NOT SET"))
 		self.assertTrue(compare(None, "is", "Not Set"))
 		self.assertTrue(compare(None, "is", "not set"))
+
+	def test_get_link_to_report_with_between_filter(self):
+		filters = {
+			"creation": [["between", ["2024-01-01", "2024-12-31"]]],
+		}
+		link = get_link_to_report(name="ToDo", filters=filters)
+		self.assertIn('creation=["between",["2024-01-01","2024-12-31"]]', link)
 
 
 class TestMoney(IntegrationTestCase):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1936,10 +1936,23 @@ def get_link_to_report(
 		conditions = []
 		for k, v in filters.items():
 			if isinstance(v, list):
-				conditions.extend(
-					str(k) + "=" + '["' + str(value[0] + '"' + "," + '"' + str(value[1]) + '"]')
-					for value in v
-				)
+				for value in v:
+					if value[0] == "between":
+						conditions.append(
+							str(k)
+							+ "="
+							+ '["'
+							+ str(value[0])
+							+ '",["'
+							+ str(value[1][0])
+							+ '","'
+							+ str(value[1][1])
+							+ '"]]'
+						)
+					else:
+						conditions.append(
+							str(k) + "=" + '["' + str(value[0] + '"' + "," + '"' + str(value[1]) + '"]')
+						)
 			else:
 				conditions.append(str(k) + "=" + quote(str(v)))
 


### PR DESCRIPTION
The previous implementation of get_link_to_report failed when filter values included a between condition, as it didn’t format the range correctly.
This update adds explicit handling for the between operator.