### PR TITLE
fix: dont move focus on the last row

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1121,14 +1121,14 @@ export default class GridRow {
 
 		this.columns[df.fieldname] = $col;
 		this.columns_list.push($col);
-		if (ci == 0 && !this.header_row) {
+		if (ci == 0 && this.header_row) {
 			$col.attr("tabIndex", 0);
 			$col.on("focus", function () {
 				if (me.grid.grid_rows.length == 0) {
 					me.grid.add_new_row();
 				}
 				me.grid.grid_rows[me.grid.grid_rows.length - 1].toggle_editable_row(true);
-				me.grid.set_focus_on_row();
+				me.grid.set_focus_on_row(0);
 				$col.attr("tabIndex", "");
 			});
 		}


### PR DESCRIPTION
This PR fixes the a issue in Child tables where clicking on any element takes you to the last row

Video

https://github.com/user-attachments/assets/672cb36e-0be7-4e6a-839c-55415208450a

