### PR TITLE
refactor: allow defer_insert in doc.log_error

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1703,10 +1703,14 @@ class Document(BaseDocument):
 
 		return view_log
 
-	def log_error(self, title=None, message=None):
+	def log_error(self, title=None, message=None, *, defer_insert=False):
 		"""Helper function to create an Error Log"""
 		return frappe.log_error(
-			message=message, title=title, reference_doctype=self.doctype, reference_name=self.name
+			message=message,
+			title=title,
+			reference_doctype=self.doctype,
+			reference_name=self.name,
+			defer_insert=defer_insert,
 		)
 
 	def get_signature(self):


### PR DESCRIPTION
Added an optional `defer_insert` keyword argument to the `log_error` method in `frappe/model/document.py`, passing it through to `frappe.log_error` to support deferred error log insertion.