### PR TITLE
fix: grid header checkbox style

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -58,7 +58,6 @@
 	.grid-static-col,
 	.row-check,
 	.row-index {
-		height: 32px;
 		padding: 4px 8px !important;
 		background-color: var(--subtle-fg);
 	}
@@ -188,6 +187,7 @@
 	input {
 		margin-right: 0 !important;
 		margin-bottom: -3px;
+		margin-top: 5px;
 	}
 
 	&.search {
@@ -686,9 +686,7 @@
 		&:focus-visible {
 			@include grid-focus();
 		}
-		.grid-static-col {
-			height: 40px;
-		}
+
 		.grid-static-col.col-xs-1 {
 			flex: 1 0 60px;
 			width: 60px;


### PR DESCRIPTION
Before
<img width="996" height="238" alt="Screenshot 2025-11-09 at 11 28 39 AM" src="https://github.com/user-attachments/assets/91254cfe-e314-492f-a080-ae6945d7e157" />

After
<img width="966" height="261" alt="Screenshot 2025-11-09 at 11 33 03 AM" src="https://github.com/user-attachments/assets/b1ec839a-d0ea-47e0-92c7-3364c0627c6c" />