### PR TITLE
fix: toggle full width

### DIFF
--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -924,8 +924,11 @@ body {
 	@media (min-width: map-get($grid-breakpoints, "lg")) {
 		.layout-main {
 			height: calc(100vh - var(--navbar-height) - var(--page-head-height) - 5px);
-			max-width: var(--page-max-width);
 			margin: auto;
+
+			body:not(.full-width) & {
+				max-width: var(--page-max-width);
+			}
 
 			.layout-main-section {
 				border: 0px;

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -81,8 +81,11 @@
 
 .section-head,
 .section-body {
-	max-width: var(--page-max-width);
 	margin: auto !important;
+
+	body:not(.full-width) & {
+		max-width: var(--page-max-width);
+	}
 }
 
 #doctype-form_builder_tab .section-body {
@@ -446,7 +449,9 @@
 }
 
 .form-footer {
-	max-width: var(--page-max-width);
+	body:not(.full-width) & {
+		max-width: var(--page-max-width);
+	}
 	margin: auto;
 	padding: 0 15px;
 

--- a/frappe/public/scss/desk/tree.scss
+++ b/frappe/public/scss/desk/tree.scss
@@ -1,7 +1,10 @@
 .treeview {
 	.layout-main-section {
-		max-width: var(--page-max-width);
 		margin: auto;
+
+		body:not(.full-width) & {
+			max-width: var(--page-max-width);
+		}
 	}
 }
 


### PR DESCRIPTION
Restores functionality of the "Toggle Full Width" button by not applying `max-width` on containers when the `full-width` class is set on the `body` element.

### Workspace

<img width="1911" height="968" alt="workspace" src="https://github.com/user-attachments/assets/31a44d10-5c7a-44ca-a52d-805943287909" />

### Form

<img width="1911" height="968" alt="form" src="https://github.com/user-attachments/assets/06b0e56c-81a8-45f0-be37-b2bc7565a591" />

### Tree

<img width="1911" height="968" alt="Bildschirmfoto 2025-11-09 um 17 09 16" src="https://github.com/user-attachments/assets/87848e7e-8129-4b3a-957c-08a85991cae6" />

Resolves #34635