### PR TITLE
Add quick install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ After a couple of minutes, site should be accessible on your localhost port: 808
 See [Frappe Docker](https://github.com/frappe/frappe_docker?tab=readme-ov-file#to-run-on-arm64-architecture-follow-this-instructions) for ARM based docker setup.
 
 ## Development Setup
+
+### Quick Install (Ubuntu/Debian/macOS)
+
+Run this command to set up a full Frappe Bench environment:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/gurbaxani/frappe-bench-install-script/trunk/install-frappe-bench.sh | bash
+```
+
+> **Note:** This is a community-maintained script and not officially supported by the Frappe team. Always review the script before running it on your system.
+
+
 ### Manual Install
 
 The Easy Way: our install script for bench will install all dependencies (e.g. MariaDB). See https://github.com/frappe/bench for more details.


### PR DESCRIPTION
Added a “Quick Install” section to the README that provides a one-line setup command for Frappe Bench on Ubuntu, Debian, and macOS.

This community-maintained script automates the installation of all prerequisites (MariaDB, Python, Node, Redis, Yarn, wkhtmltopdf) and configures the environment for immediate use. It’s designed for developers who want to get started quickly without manually following multiple setup steps.

> **Note:** The script is unofficial and includes a clear disclaimer asking users to review its contents before running.

