### PR TITLE
fix(Form Builder): emit modified check field values as 0/1 instead of raw boolean values

### DIFF
--- a/frappe/public/js/form_builder/components/controls/CheckControl.vue
+++ b/frappe/public/js/form_builder/components/controls/CheckControl.vue
@@ -30,7 +30,7 @@ let display_checked = computed(() => {
 				type="checkbox"
 				:checked="display_checked"
 				:disabled="read_only"
-				@change="(event) => $emit('update:modelValue', event.target.checked)"
+				@change="(event) => $emit('update:modelValue', event.target.checked ? 1 : 0)"
 			/>
 			<span class="label-area" :class="{ reqd: df.reqd }">{{ __(df.label) }}</span>
 		</label>


### PR DESCRIPTION
This PR implements my proposed solution for Issue #34655. It emits modified values for check fields in the format expected by Frappe, 0/1, instead of false/true which is currently causing checkboxes to be displayed in the wrong state.

Before change:
<img width="1233" height="447" alt="checkbox-after-modification" src="https://github.com/user-attachments/assets/cec5ecfb-7c53-4747-83cd-e1c4c078ade2" />

After change:
<img width="1248" height="436" alt="checkbox-after-modification-fixed" src="https://github.com/user-attachments/assets/3b638e45-9189-444c-9b6e-2bddacab247c" />

closes #34655 