### PR TITLE
fix(perm): check can_read if meta is not present

### DIFF
--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -60,8 +60,12 @@ $.extend(frappe.perm, {
 			perm[0].read = 1;
 		}
 
-		if (!meta) return perm;
-
+		if (!meta) {
+			if (frappe.boot.user.can_read.includes(doctype)) {
+				perm[0].read = 1;
+			}
+			return perm;
+		}
 		perm = frappe.perm.get_role_permissions(meta);
 		const base_perm = perm[0];
 


### PR DESCRIPTION
A user with Accounts Manager has permission to read Cost Center, Account
But frappe.perm.has_perm gives a wrong result which doesnt allow the company form to show view menu in Company form

Before

<img width="1390" height="754" alt="Screenshot 2025-11-11 at 10 10 10 AM" src="https://github.com/user-attachments/assets/65fdc209-ba3f-46d4-83c4-ff98a1cb41dc" />


After

<img width="1388" height="753" alt="Screenshot 2025-11-11 at 10 10 38 AM" src="https://github.com/user-attachments/assets/368265d0-63ba-43c4-9089-2edb0a0d741f" />


I was not able to figure out how to load the meta without making _get_perm async