### PR TITLE
fix: align Duration picker layout and background color in child tables

### DIFF
--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -424,7 +424,7 @@ textarea.form-control {
 /* duration control */
 
 .duration-picker {
-	position: absolute;
+	position: fixed;
 	z-index: 999;
 	border-radius: var(--border-radius);
 	box-shadow: var(--shadow-sm);
@@ -470,7 +470,7 @@ textarea.form-control {
 		width: 55px;
 		border: none;
 		color: var(--text-color);
-		background-color: var(--control-bg);
+		background-color: var(--gray-100);
 		border-radius: var(--border-radius);
 		padding: 4px 8px;
 	}

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -486,6 +486,22 @@ textarea.form-control {
 	.picker-row {
 		display: flex;
 		margin: var(--margin-sm);
+
+		.col {
+			&:last-child {
+				.grid-row & {
+					// remove flex and justify content added by grid context
+					display: block;
+					justify-content: initial;
+				}
+			}
+
+			.grid-row & {
+				// remove border and padding added by grid context
+				border-right: none;
+				padding: unset;
+			}
+		}
 	}
 }
 

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -470,7 +470,7 @@ textarea.form-control {
 		width: 55px;
 		border: none;
 		color: var(--text-color);
-		background-color: var(--gray-100);
+		background-color: var(--bg-gray);
 		border-radius: var(--border-radius);
 		padding: 4px 8px;
 	}

--- a/frappe/public/scss/common/form.scss
+++ b/frappe/public/scss/common/form.scss
@@ -35,11 +35,3 @@
 	font-weight: 700;
 	color: var(--heading-color);
 }
-
-.grid-row .duration-picker .picker-row > .col:last-child {
-	display: block;
-	justify-content: initial;
-}
-.grid-row .duration-picker .picker-row > .col {
-	border-right: none;
-}

--- a/frappe/public/scss/common/form.scss
+++ b/frappe/public/scss/common/form.scss
@@ -30,10 +30,16 @@
 	color: var(--heading-color);
 }
 
-.duration-input {
-	background-color: #F3F3F3 !important;
+.head-title {
+	font-size: var(--text-xl);
+	font-weight: 700;
+	color: var(--heading-color);
 }
 
-.duration-picker .picker-row > .col:last-child {
-	display: block !important;
+.grid-row .duration-picker .picker-row > .col:last-child {
+	display: block;
+	justify-content: initial;
+}
+.grid-row .duration-picker .picker-row > .col {
+	border-right: none;
 }

--- a/frappe/public/scss/common/form.scss
+++ b/frappe/public/scss/common/form.scss
@@ -15,6 +15,7 @@
 	.for-description {
 		@include get_textstyle("sm", "regular");
 	}
+
 	min-height: var(--input-height);
 	border-radius: var(--border-radius-sm);
 	padding: 4px 8px;
@@ -27,4 +28,12 @@
 	font-size: var(--text-xl);
 	font-weight: 700;
 	color: var(--heading-color);
+}
+
+.duration-input {
+	background-color: #F3F3F3 !important;
+}
+
+.duration-picker .picker-row > .col:last-child {
+	display: block !important;
 }

--- a/frappe/public/scss/common/form.scss
+++ b/frappe/public/scss/common/form.scss
@@ -29,9 +29,3 @@
 	font-weight: 700;
 	color: var(--heading-color);
 }
-
-.head-title {
-	font-size: var(--text-xl);
-	font-weight: 700;
-	color: var(--heading-color);
-}


### PR DESCRIPTION
This PR fixes a UI inconsistency in the Duration field inside child tables.
The Duration picker (Days, Hours, Minutes, Seconds) in child tables had the following issues:

Missing background color on numeric inputs

Misaligned layout, with the "Seconds" input wrapping to a new line

These issues did not appear in the parent form Duration field.
Attached screenshots show both the broken and corrected layouts.
<img width="1047" height="409" alt="Screenshot 2025-11-11 110616" src="https://github.com/user-attachments/assets/70094f07-5d8f-42f7-b9bc-e8cdca64145f" />
<img width="1769" height="783" alt="Screenshot 2025-11-11 115053" src="https://github.com/user-attachments/assets/ad9b192a-ec8f-45fa-8716-66f311074229" />
