### PR TITLE
fix: Get host URL when printing outside of request

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -21,6 +21,7 @@ from frappe import _
 from frappe.core.doctype.file.utils import find_file_by_url
 from frappe.utils import cstr, scrub_urls
 from frappe.utils.caching import redis_cache
+from frappe.utils.data import get_url
 from frappe.utils.jinja_globals import bundled_asset, is_rtl
 
 cssutils.log.setLog(frappe.logger("cssutils"))
@@ -456,3 +457,10 @@ def pdf_contains_js(file_content: bytes):
 		pass
 
 	return False
+
+
+def get_host_url():
+	if frappe.request:
+		return frappe.request.host_url
+	else:
+		return get_url() + "/"

--- a/frappe/utils/pdf_generator/browser.py
+++ b/frappe/utils/pdf_generator/browser.py
@@ -3,6 +3,7 @@ from typing import ClassVar
 from bs4 import BeautifulSoup
 
 import frappe
+from frappe.utils.pdf import get_host_url
 from frappe.utils.print_utils import convert_uom, parse_float_and_unit
 
 
@@ -95,7 +96,7 @@ class Browser:
 
 	def setup_body_page(self):
 		self.body_page = self.new_page("body")
-		self.body_page.set_tab_url(frappe.request.host_url)
+		self.body_page.set_tab_url(get_host_url())
 		self.body_page.wait_for_navigate()
 		self.body_page.set_content(str(self.soup))
 
@@ -394,11 +395,11 @@ class Browser:
 		# It sends CDP command to the browser to open a new tab.
 		if header_content := self.soup.find(id="header-html"):
 			self.header_page = self.new_page("header")
-			self.header_page.set_tab_url(frappe.request.host_url)
+			self.header_page.set_tab_url(get_host_url())
 
 		if footer_content := self.soup.find(id="footer-html"):
 			self.footer_page = self.new_page("footer")
-			self.footer_page.set_tab_url(frappe.request.host_url)
+			self.footer_page.set_tab_url(get_host_url())
 
 		self.header_content = header_content
 		self.footer_content = footer_content

--- a/frappe/utils/pdf_generator/page.py
+++ b/frappe/utils/pdf_generator/page.py
@@ -3,6 +3,7 @@ import time
 import urllib
 
 import frappe
+from frappe.utils.pdf import get_host_url
 
 """
 CDP commands documentation can be found here.
@@ -124,8 +125,8 @@ class Page:
 				data["request_id"] = params["requestId"]
 				url = params["request"]["url"]
 
-				if url.startswith(frappe.request.host_url):
-					path = url.replace(frappe.request.host_url, "").split("?v", 1)[0]
+				if url.startswith(get_host_url()):
+					path = url.replace(get_host_url(), "").split("?v", 1)[0]
 					if path.startswith("assets/") or path.startswith("files/"):
 						path = urllib.parse.unquote(path)
 						if path.startswith("files/"):


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/34669

All the credit goes to @cogk for fixing this over at the https://github.com/frappe/print_designer/ repo in his PR: https://github.com/frappe/print_designer/pull/464

All I have done here is confirmed the issue is the same and the fix is the same in frappe/frappe:develop and ported those code changes from the print_designer app into the frappe app. By substituting the function frappe.request.host_url with get_host_url, emails sent from the queue that have an attached pdf that was generated from the chrome pdf generator can be sent properly instead of failing with "RuntimeError: object is not bound."

It would be awesome if this could be merged into develop in time to be merged into the first version-16 beta. Thank you!