### PR TITLE
fix(api/v1): don't use `as_dict()` unless `expand_links` is passed

### DIFF
--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -78,12 +78,13 @@ def read_doc(doctype: str, name: str):
 	doc = frappe.get_doc(doctype, name)
 	doc.check_permission("read")
 	doc.apply_fieldlevel_read_permissions()
-	doc_dict = doc.as_dict()
 	if sbool(frappe.form_dict.get("expand_links")):
+		doc_dict = doc.as_dict()
 		get_values_for_link_and_dynamic_link_fields(doc_dict)
 		get_values_for_table_and_multiselect_fields(doc_dict)
+		return doc_dict
 
-	return doc_dict
+	return doc
 
 
 def get_values_for_link_and_dynamic_link_fields(doc_dict):


### PR DESCRIPTION
That sets all keys to null if they don't exist, a breaking change.

Reference: #34027, support ticket 53139
