### PR TITLE
feat(Email Queue): add banner if sending is disabled

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.js
+++ b/frappe/email/doctype/email_queue/email_queue.js
@@ -43,5 +43,11 @@ frappe.ui.form.on("Email Queue", {
 				});
 			});
 		}
+
+		if (frm.doc.__onload?.mute_emails) {
+			frm.dashboard.set_headline(
+				__("Automatic sending of emails is disabled via site config.")
+			);
+		}
 	},
 });

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -12,7 +12,7 @@ from email.policy import SMTP
 from typing import TYPE_CHECKING
 
 import frappe
-from frappe import _, safe_encode, task
+from frappe import _, are_emails_muted, safe_encode, task
 from frappe.core.utils import html2text
 from frappe.database.database import savepoint
 from frappe.email.doctype.email_account.email_account import EmailAccount
@@ -73,6 +73,9 @@ class EmailQueue(Document):
 	# end: auto-generated types
 
 	DOCTYPE = "Email Queue"
+
+	def onload(self):
+		self.set_onload("mute_emails", bool(are_emails_muted()))
 
 	def set_recipients(self, recipients):
 		self.set("recipients", [])


### PR DESCRIPTION
If you're just looking from a desk user perspective, everything seems fine. Manual sending of emails works, the "flush emails" job completes successfully, but emails are still not getting flushed. There's no way to tell what's going on. 

This pull request adds support for indicating when automatic email sending is disabled via site configuration. It introduces backend logic to detect the muted state and updates the frontend to display a dashboard headline when emails are muted.

**Backend: Email muting detection**

* Added import and usage of `are_emails_muted` to check if email sending is disabled in `email_queue.py`.
* Implemented an `onload` method in the `EmailQueue` class to set the `mute_emails` flag in the form's onload data when emails are muted.

**Frontend: User notification**

* Updated `email_queue.js` to display a dashboard headline notifying users when automatic email sending is disabled via site config.

<img width="1126" height="178" alt="Bildschirmfoto 2025-11-12 um 15 58 50" src="https://github.com/user-attachments/assets/e9305db9-956b-454a-9d4f-e0e4e654e56b" />

> no-docs