### PR TITLE
fix: Update values on conflict in global search

### DIFF
--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -219,9 +219,15 @@ def insert_values_for_multiple_docs(all_contents):
 		# ignoring duplicate keys for doctype_name
 		frappe.db.multisql(
 			{
-				"mariadb": """INSERT IGNORE INTO `__global_search`
+				"mariadb": """INSERT INTO `__global_search`
 				(doctype, name, content, published, title, route)
-				VALUES {} """.format(", ".join(batch_values)),
+				VALUES {}
+				ON DUPLICATE KEY UPDATE
+					content=VALUE(content),
+					published=VALUE(published),
+					title=VALUE(title),
+					route=VALUE(route)
+				""".format(", ".join(batch_values)),
 				"postgres": """INSERT INTO `__global_search`
 				(doctype, name, content, published, title, route)
 				VALUES {}

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -422,6 +422,7 @@ def sync_value_in_queue(value):
 		frappe.cache.lpush("global_search_queue", json.dumps(value))
 	except redis.exceptions.ConnectionError:
 		# not connected, sync directly
+		assert not frappe.flags.in_test, "Should not fail silently in tests"
 		sync_value(value)
 
 


### PR DESCRIPTION
Fixes recent global search test failures.

Uses combination of https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/inserting-loading-data/insert-on-duplicate-key-update and https://mariadb.com/docs/server/reference/sql-functions/secondary-functions/miscellaneous-functions/values-value to fix conflicts in bulk updates.