### PR TITLE
test: add `ignore_missing` param to `cy.remove_doc`

### DIFF
--- a/cypress/integration/workspace_blocks.js
+++ b/cypress/integration/workspace_blocks.js
@@ -11,6 +11,7 @@ context("Workspace Blocks", () => {
 	});
 
 	it("Create Test Page", () => {
+		cy.remove_doc("Workspace", `Test Block Page-${Cypress.config("testUser")}`, true);
 		cy.intercept({
 			method: "POST",
 			url: "api/method/frappe.desk.doctype.workspace.workspace.new_page",

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -125,7 +125,7 @@ Cypress.Commands.add("get_doc", (doctype, name) => {
 		});
 });
 
-Cypress.Commands.add("remove_doc", (doctype, name) => {
+Cypress.Commands.add("remove_doc", (doctype, name, ignore_missing) => {
 	return cy
 		.window()
 		.its("frappe.csrf_token")
@@ -138,9 +138,9 @@ Cypress.Commands.add("remove_doc", (doctype, name) => {
 						Accept: "application/json",
 						"X-Frappe-CSRF-Token": csrf_token,
 					},
+					failOnStatusCode: !ignore_missing,
 				})
 				.then((res) => {
-					expect(res.status).eq(202);
 					return res.body;
 				});
 		});


### PR DESCRIPTION
This makes it easier to clean up db state before running a test.

E.g. `cypress/integration/workspace_blocks.js` wants to create a new workspace. This will fail if the workspace exists already. Hence, this test could only run once and subsequent runs would fail. With this new param, we can just always try to delete the existing workspace first and ignore deletion failures if it doesn't exist yet.