### PR TITLE
feat: allow tel: protocol in hyperlinks

### DIFF
--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -126,7 +126,7 @@ def clean_email_html(html):
 		},
 		attributes=["border", "colspan", "rowspan", "src", "href", "style", "id"],
 		css_sanitizer=css_sanitizer,
-		protocols=["cid", "http", "https", "mailto", "data"],
+		protocols=["cid", "http", "https", "mailto", "data", "tel"],
 		strip=True,
 		strip_comments=True,
 	)
@@ -185,7 +185,7 @@ def sanitize_html(html, linkify=False, always_sanitize=False):
 		attributes=attributes,
 		css_sanitizer=css_sanitizer,
 		strip_comments=False,
-		protocols={"cid", "http", "https", "mailto"},
+		protocols={"cid", "http", "https", "mailto", "tel"},
 	)
 
 	return escaped_html


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

I've been working with the Email system this week and one thing I noticed was that Signatures, configured in Email Account, strip out `tel:` hrefs.

Having looked at the code, it would appear that `tel:` hrefs will be stripped out of all sanitised HTML, including website content, etc. I don't see why one would want to strip out `tel:` hrefs and have therefore allowed the `tel:` protocol in both `sanitize_html` and `clean_email_html`.

In the long run, and as mentioned in the following Issues, `bleach` is deprecated, so its use should ideally be replaced by `nh3`. But this is a quick, easy and relatively safe fix with the existing codebase.

  - https://github.com/mozilla/bleach/issues/698
  - https://github.com/frappe/frappe/issues/26396
  - https://github.com/frappe/frappe/issues/34698

> Explain the **details** for making this change. What existing problem does the pull request solve?

I personally like hyperlinking phone numbers in my email signatures, as otherwise it can be a bit fiddly highlighting the number, copying to a preferred phone app and maybe editing it if it is formatted for display rather than for an application.

By that last comment, I mean sometimes for example a UK phone number is displayed in an email signature like `+44-(0)-208-123-4567`. The `(0)` can be used when calling domestically, but an application typically would want the number formatted like `+442081234567`, without any additional characters or that `(0)` in the middle.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

Here is a before and after of the suggested code fix, when sending an email from a Sales Invoice (or any Document):-

<table>
<tr>
<th>Before fix</th>
<th>After fix</th>
</tr>
<tr>
<td><img width="800" height="835" alt="Screenshot 2025-11-14 at 14 59 08" src="https://github.com/user-attachments/assets/53d9e48e-dafa-4046-97f9-a11cfd37ed94" /></td>
<td><img width="799" height="852" alt="Screenshot 2025-11-14 at 14 57 50" src="https://github.com/user-attachments/assets/7ac5d80f-511e-446c-b23f-01e5b45a5162" /></td>
</tr>
</table>


<!-- Add images/recordings to better visualize the change: expected/current behavior -->
