### PR TITLE
fix(postgres): fix query for pg compatibility in clear_log_table

### DIFF
--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -176,18 +176,30 @@ def clear_log_table(doctype, days=90):
 	backup = f"{original} backup_table"
 
 	try:
-		frappe.db.sql_ddl(f"CREATE TABLE `{temporary}` LIKE `{original}`")
+		if frappe.db.db_type == "postgres":
+			frappe.db.sql_ddl(f'CREATE TABLE "{temporary}" (LIKE "{original}" INCLUDING ALL)')
 
-		# Copy all recent data to new table
-		frappe.db.sql(
-			f"""INSERT INTO `{temporary}`
-				SELECT * FROM `{original}`
-				WHERE `{original}`.`creation` > NOW() - INTERVAL '{days}' DAY"""
-		)
-		frappe.db.sql_ddl(f"RENAME TABLE `{original}` TO `{backup}`, `{temporary}` TO `{original}`")
+			frappe.db.sql(
+				f"""INSERT INTO "{temporary}"
+					SELECT * FROM "{original}"
+					WHERE "{original}"."creation" > NOW() - INTERVAL '{days}' DAY"""
+			)
+			frappe.db.sql_ddl(f'ALTER TABLE "{original}" RENAME TO "{backup}"')
+			frappe.db.sql_ddl(f'ALTER TABLE "{temporary}" RENAME TO "{original}"')
+		elif frappe.db.db_type == "mariadb":
+			frappe.db.sql_ddl(f"CREATE TABLE `{temporary}` LIKE `{original}`")
+
+			# Copy all recent data to new table
+			frappe.db.sql(
+				f"""INSERT INTO `{temporary}`
+					SELECT * FROM `{original}`
+					WHERE `{original}`.`creation` > NOW() - INTERVAL '{days}' DAY"""
+			)
+			frappe.db.sql_ddl(f"RENAME TABLE `{original}` TO `{backup}`, `{temporary}` TO `{original}`")
 	except Exception:
 		frappe.db.rollback()
 		frappe.db.sql_ddl(f"DROP TABLE IF EXISTS `{temporary}`")
 		raise
 	else:
 		frappe.db.sql_ddl(f"DROP TABLE `{backup}`")
+		frappe.db.commit()


### PR DESCRIPTION
**Problem:**
fix(Postgres): This fix is particularly related to fixing the `clear_log_table` command and pertains to the fact that this test passes in MariaDB but fails in Postgres due to the way the query is written in the function. The PR adds PG-specific query and thus enables to `clear_log_table` using command as follows and also enables the test to run in the Postgres CI: 
> bench --site {site} clear-log-table --days=30 --doctype='Error Log'

 This PR is also a step forward towards resolving #21613 and completes a part of the Postgres TODO #34660 .

**Before**:

Skipped for Postgres 

<img width="1926" height="758" alt="image" src="https://github.com/user-attachments/assets/da61cf82-767d-4d5c-a5f5-3714869d6ac4" />



**After**:

<img width="1926" height="588" alt="image" src="https://github.com/user-attachments/assets/b8cb2fee-0910-4fbd-a9ad-77f0a9e5e4ac" />


related to #34660 