### PR TITLE
fix(Role Profile): enable `translated_doctype`

### DIFF
--- a/frappe/core/doctype/role_profile/role_profile.json
+++ b/frappe/core/doctype/role_profile/role_profile.json
@@ -36,6 +36,7 @@
    "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "links": [
   {
    "link_doctype": "User",
@@ -43,7 +44,7 @@
    "table_fieldname": "role_profiles"
   }
  ],
- "modified": "2024-03-23 16:03:37.104710",
+ "modified": "2025-11-15 20:00:18.844434",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Role Profile",
@@ -74,9 +75,11 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
  "title_field": "role_profile",
- "track_changes": 1
+ "track_changes": 1,
+ "translated_doctype": 1
 }


### PR DESCRIPTION
This way, Role Profiles can be created in English, but still show the localized names in the form header and in link fields.

All other changes (`grid_page_length`, `row_format`) are auto-generated new default values.