### PR TITLE
fix: validate link field values against filter criteria

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -660,7 +660,12 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		// List of doctypes that should be excluded from the filter validation
 		const white_listed_doctype = ["[Select]"];
 
-		if (!white_listed_doctype.includes(options) && this.awesomplete?._list && this.frm && value) {
+		if (
+			!white_listed_doctype.includes(options) &&
+			this.awesomplete?._list &&
+			this.frm &&
+			value
+		) {
 			// Check if the entered value exists in the filtered awesomplete list
 			const found = this.awesomplete._list.find((item) => item.value === value);
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -656,6 +656,22 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			return;
 		}
 
+		// Validate against filtered awesomplete list to respect filter criteria
+		// List of doctypes that should be excluded from the filter validation
+		const white_listed_doctype = ["[Select]"];
+
+		if (!white_listed_doctype.includes(options) && this.awesomplete?._list && this.frm && value) {
+			// Check if the entered value exists in the filtered awesomplete list
+			const found = this.awesomplete._list.find((item) => item.value === value);
+
+			if (!found) {
+				// Value doesn't exist in the filtered list - reject it
+				frappe.msgprint(__("{0} {1} does not match filters", [options, value.bold()]));
+				// Return undefined to signal validation failure
+				return undefined;
+			}
+		}
+
 		const columns_to_fetch = Object.values(this.fetch_map);
 
 		// if default and no fetch, no need to validate


### PR DESCRIPTION
## Description

This PR fixes issue #7235 where link fields would accept values that exist in the database but don't match the configured filter criteria.

### Problem
When a link field has filters configured (via `get_query`, `df.filters`, or `link_filters`), the field would validate that the value exists in the database but would **not** validate that the value matches the filter criteria. This allowed users to enter values that should be filtered out.

**Example:** A Customer link field with filter `{"disabled": 0}` would still accept disabled customers if entered manually.

### Solution
Added client-side validation in the `validate_link_and_fetch` method to check if the entered value exists in the filtered awesomplete suggestion list before accepting it. If the value is not found in the filtered list, an error message is displayed and the validation returns `undefined`.

### Changes
- Added validation logic in `validate_link_and_fetch` method to check against the filtered awesomplete list
- Displays user-friendly error message: `"{DocType} {value} does not match filters"`
- Returns `undefined` to signal validation failure
- Whitelists `"[Select]"` doctype from validation to maintain backward compatibility

### Technical Details
The fix works by:
1. Checking if the entered value exists in `this.awesomplete._list` (which contains only filtered results)
2. If the value is not found in the filtered list, it means the value doesn't match the filter criteria
3. Displays an error message and rejects the value

### Screenshots

#### Before Fix (Bug Behavior)
<img width="1469" height="287" alt="image" src="https://github.com/user-attachments/assets/eec00869-1881-4280-96c1-fc4ef3ed8ddb" />
<img width="1697" height="463" alt="image" src="https://github.com/user-attachments/assets/458d5ada-ca92-4797-a073-49685b04595f" />

#### After Fix (Expected Behavior)
<img width="1916" height="281" alt="image" src="https://github.com/user-attachments/assets/7780f124-c97d-461e-b698-49c0aae98436" />

### Example Test Case

**Setup:**
```python
# In a DocType form script or get_query
frappe.ui.form.on('Sales Order', {
    onload: function(frm) {
        frm.set_query('customer', function() {
            return {
                filters: {
                    'disabled': 0
                }
            };
        });
    }
});
```

**Test:**
1. Create/find a disabled customer
2. Try to manually enter the disabled customer name in the Customer field
3. **Expected:** Error message appears and value is rejected
4. **Actual (before fix):** Value was accepted

### Impact
- **Breaking Changes:** None
- **Backward Compatibility:** Maintained - whitelisted `"[Select]"` doctype
- **Performance:** Minimal - only adds a simple array find operation
- **User Experience:** Improved - prevents invalid data entry

### Related Issues
Closes #7235

---

### Additional Notes

This is a client-side validation that complements the existing server-side validation. The awesomplete list is already filtered based on the query criteria, so this fix simply ensures that manually entered values are also validated against the same filtered list.
