### PR TITLE
feat: make desk installable as PWA

### DIFF
--- a/frappe/www/desk.html
+++ b/frappe/www/desk.html
@@ -17,6 +17,7 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="white">
 		<meta name="mobile-web-app-capable" content="yes">
 		<title>{{ app_name }}</title>
+		<link rel="manifest" href="/manifest.json" />
 		<link rel="shortcut icon"
 			href="{{ favicon or "/assets/frappe/images/frappe-favicon.svg" }}" type="image/x-icon">
 		<link rel="icon"

--- a/frappe/www/manifest.json
+++ b/frappe/www/manifest.json
@@ -1,0 +1,11 @@
+{
+	"id": "{{ id }}",
+	"name": "{{ app_name }}",
+	"scope": "/desk/",
+	"start_url": "/desk",
+	"icons": [
+		{
+			"src": "{{ app_logo }}"
+		}
+	]
+}

--- a/frappe/www/manifest.json
+++ b/frappe/www/manifest.json
@@ -3,6 +3,7 @@
 	"name": "{{ app_name }}",
 	"scope": "/desk/",
 	"start_url": "/desk",
+	"display": "minimal-ui",
 	"icons": [
 		{
 			"src": "{{ app_logo }}"

--- a/frappe/www/manifest.py
+++ b/frappe/www/manifest.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.core.doctype.navbar_settings.navbar_settings import get_app_logo
+from frappe.utils.data import get_url
+
+
+def get_context(context):
+	context.update(
+		{
+			"id": get_url(),
+			"app_name": (
+				frappe.get_website_settings("app_name") or frappe.get_system_settings("app_name") or "Frappe"
+			),
+			"app_logo": get_app_logo(),
+		}
+	)
+
+	return context


### PR DESCRIPTION
This pull request adds support for a web app manifest to enable Progressive Web App (PWA) features in the application. The main changes include adding a `manifest.json` file, updating the HTML to reference it, and introducing a context provider for manifest data.

Manifest support and PWA improvements:

* Added a new `manifest.json` template in `frappe/www/manifest.json` that defines the web app manifest structure, including dynamic fields for app ID, name, and logo.
* Updated `frappe/www/app.html` to include a `<link rel="manifest" href="/manifest.json" />` tag, allowing browsers to detect and use the manifest file.

Context and dynamic data provisioning:

* Introduced `frappe/www/manifest.py` to provide dynamic context values (such as app ID, name, and logo) for the manifest template, using system and website settings.

---

> Because PWAs are websites, they have the same basic features as any other website: at least one HTML page, which very probably loads some CSS and JavaScript. Like a normal website, the JavaScript loaded by the page has a global Window object and can access all the Web APIs that are available through that object.
>
> Beyond that, a PWA has some additional features:
>
> - A web app manifest file, which, at a minimum, provides information that the browser needs to install the PWA, such as the app name and icon.
> - Optionally, a service worker to provide an offline experience.

https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/What_is_a_progressive_web_app#technical_features_of_pwas

> no-docs