### PR TITLE
test(postgres): enable test_unique_index_on_alter for postgres

### DIFF
--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -76,6 +76,8 @@ class PostgresTable(DBTable):
 
 		query = [f"ADD COLUMN `{col.fieldname}` {col.get_definition()}" for col in self.add_column]
 
+		new_column_names = {col.fieldname for col in self.add_column}
+
 		for col in self.change_type:
 			using_clause = ""
 			if col.fieldtype in ("Datetime"):
@@ -124,9 +126,10 @@ class PostgresTable(DBTable):
 
 		for col in self.add_unique:
 			# if index key not exists
-			create_contraint_query += 'CREATE UNIQUE INDEX IF NOT EXISTS "unique_{index_name}" ON `{table_name}`(`{field}`);'.format(
-				index_name=col.fieldname, table_name=self.table_name, field=col.fieldname
-			)
+			if col.fieldname not in new_column_names:
+				create_contraint_query += 'CREATE UNIQUE INDEX IF NOT EXISTS "unique_{index_name}" ON `{table_name}`(`{field}`);'.format(
+					index_name=col.fieldname, table_name=self.table_name, field=col.fieldname
+				)
 
 		drop_contraint_query = ""
 		for col in self.drop_index:

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -139,7 +139,6 @@ class TestDBUpdate(IntegrationTestCase):
 				with self.subTest(f"Checking index {doctype.name} - {field.fieldname}"):
 					self.check_unique_indexes(doctype.name, field.fieldname)
 
-	@run_only_if(db_type_is.MARIADB)
 	def test_unique_index_on_alter(self):
 		"""Only one unique index should be added"""
 


### PR DESCRIPTION
**Problem:**
test(Postgres): This fix is particularly related to enabling `test_unique_index_on_alter` to run in Postgres CI and also fixes the underlying implementation by avoiding unnecessary `unique` index creations, and defacto improving performance. This PR is also a step forward towards resolving #21613 and completes a part of the Postgres TODO #34660 .

**Before**:
Test was skipped for Postgres.

**After**:
<img width="1956" height="606" alt="image" src="https://github.com/user-attachments/assets/32f4d0dc-1bcf-4007-9128-9a4460112601" />

related to #34660 
