### PR TITLE
fix: add missing translate function

### DIFF
--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -160,7 +160,12 @@ function get_version_timeline_content(version_doc, frm) {
 					) {
 						parts.push(
 							__("{0} from {1} to {2} in row #{3}", [
-								frappe.meta.get_label(frm.fields_dict[row[0]].grid.doctype, p[0]),
+								__(
+									frappe.meta.get_label(
+										frm.fields_dict[row[0]].grid.doctype,
+										p[0]
+									)
+								),
 								format_content_for_timeline(p[1]),
 								format_content_for_timeline(p[2]),
 								row[1] + 1,


### PR DESCRIPTION
In the timeline section

### Before

<img width="1280" height="617" alt="before" src="https://github.com/user-attachments/assets/254b4122-a524-4e02-a635-4174be5b7e36" />


### After

<img width="1280" height="617" alt="after" src="https://github.com/user-attachments/assets/a91584c2-7cb3-4937-bac0-fb7934a1ac1d" />

backport version-15-hotfix