### PR TITLE
fix(ci): set mariadb version in repo setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -100,7 +100,7 @@ runs:
     run: |
       # Install System Dependencies
       start_time=$(date +%s)
-      curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | sudo bash
+      curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version="mariadb-11.8.5"
 
       sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
       wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -


### PR DESCRIPTION
Suddenly environment setup in UI tests has started to fail

Seen in the CI run for https://github.com/frappe/frappe/pull/34732 

<img width="749" height="293" alt="Screenshot 2025-11-17 at 11 34 21 PM" src="https://github.com/user-attachments/assets/08de0c34-3416-493d-bf60-a5dac1f81cdc" />


cc: @akhilnarang 
