### PR TITLE
feat: Added doctype-wise control for printing draft and cancelled documents

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -56,6 +56,8 @@
   "allow_events_in_timeline",
   "allow_auto_repeat",
   "make_attachments_public",
+  "allow_print_for_draft",
+  "allow_print_for_cancelled",
   "view_settings",
   "show_title_field_in_link",
   "translated_doctype",
@@ -706,6 +708,20 @@
    "fieldtype": "Int",
    "label": "Rows Threshold for Grid Search",
    "non_negative": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "is_submittable",
+   "fieldname": "allow_print_for_draft",
+   "fieldtype": "Check",
+   "label": "Allow Print for Draft"
+  },
+  {
+   "default": "0",
+   "depends_on": "is_submittable",
+   "fieldname": "allow_print_for_cancelled",
+   "fieldtype": "Check",
+   "label": "Allow Print for Cancelled"
   }
  ],
  "grid_page_length": 50,
@@ -784,7 +800,7 @@
    "link_fieldname": "document_type"
   }
  ],
- "modified": "2025-05-21 21:58:59.947374",
+ "modified": "2025-05-26 22:58:30.588110",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -34,6 +34,8 @@
   "allow_copy",
   "make_attachments_public",
   "protect_attached_files",
+  "allow_print_for_draft",
+  "allow_print_for_cancelled",
   "view_settings_section",
   "title_field",
   "show_title_field_in_link",
@@ -415,6 +417,18 @@
    "fieldname": "protect_attached_files",
    "fieldtype": "Check",
    "label": "Protect Attached Files"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_print_for_draft",
+   "fieldtype": "Check",
+   "label": "Allow Print for Draft"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_print_for_cancelled",
+   "fieldtype": "Check",
+   "label": "Allow Print for Cancelled"
   }
  ],
  "hide_toolbar": 1,
@@ -423,7 +437,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-27 18:22:32.618603",
+ "modified": "2025-05-26 23:05:11.800834",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -43,6 +43,8 @@ class CustomizeForm(Document):
 		allow_auto_repeat: DF.Check
 		allow_copy: DF.Check
 		allow_import: DF.Check
+		allow_print_for_cancelled: DF.Check
+		allow_print_for_draft: DF.Check
 		autoname: DF.Data | None
 		default_email_template: DF.Link | None
 		default_print_format: DF.Link | None
@@ -747,6 +749,8 @@ doctype_properties = {
 	"force_re_route_to_default_view": "Check",
 	"translated_doctype": "Check",
 	"grid_page_length": "Int",
+	"allow_print_for_draft": "Check",
+	"allow_print_for_cancelled": "Check",
 }
 
 docfield_properties = {

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -342,9 +342,8 @@ frappe.ui.form.Toolbar = class Toolbar {
 	}
 
 	add_print() {
-		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings");
-		const allow_print_for_draft = cint(print_settings.allow_print_for_draft);
-		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
+		const allow_print_for_draft = cint(this.frm.meta.allow_print_for_draft);
+		const allow_print_for_cancelled = cint(this.frm.meta.allow_print_for_cancelled);
 
 		if (
 			!frappe.model.is_submittable(this.frm.doc.doctype) ||

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -342,8 +342,13 @@ frappe.ui.form.Toolbar = class Toolbar {
 	}
 
 	add_print() {
-		const allow_print_for_draft = cint(this.frm.meta.allow_print_for_draft);
-		const allow_print_for_cancelled = cint(this.frm.meta.allow_print_for_cancelled);
+		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings");
+		const allow_print_for_draft =
+			cint(this.frm.meta.allow_print_for_draft) &&
+			cint(print_settings.allow_print_for_draft);
+		const allow_print_for_cancelled =
+			cint(this.frm.meta.allow_print_for_cancelled) &&
+			cint(print_settings.allow_print_for_cancelled);
 
 		if (
 			!frappe.model.is_submittable(this.frm.doc.doctype) ||

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -6,9 +6,11 @@ export default class BulkOperations {
 
 	print(docs) {
 		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings");
-		const allow_print_for_draft = cint(print_settings.allow_print_for_draft);
+		const allow_print_for_draft = cint(frappe.get_meta(this.doctype).allow_print_for_draft);
 		const is_submittable = frappe.model.is_submittable(this.doctype);
-		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
+		const allow_print_for_cancelled = cint(
+			frappe.get_meta(this.doctype).allow_print_for_cancelled
+		);
 		const letterheads = this.get_letterhead_options();
 		const MAX_PRINT_LIMIT = 500;
 		const BACKGROUND_PRINT_THRESHOLD = 25;

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -6,11 +6,14 @@ export default class BulkOperations {
 
 	print(docs) {
 		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings");
-		const allow_print_for_draft = cint(frappe.get_meta(this.doctype).allow_print_for_draft);
+
+		const allow_print_for_draft =
+			cint(this.frm.meta.allow_print_for_draft) &&
+			cint(print_settings.allow_print_for_draft);
 		const is_submittable = frappe.model.is_submittable(this.doctype);
-		const allow_print_for_cancelled = cint(
-			frappe.get_meta(this.doctype).allow_print_for_cancelled
-		);
+		const allow_print_for_cancelled =
+			cint(this.frm.meta.allow_print_for_cancelled) &&
+			cint(print_settings.allow_print_for_cancelled);
 		const letterheads = this.get_letterhead_options();
 		const MAX_PRINT_LIMIT = 500;
 		const BACKGROUND_PRINT_THRESHOLD = 25;


### PR DESCRIPTION

<img width="917" height="467" alt="image" src="https://github.com/user-attachments/assets/136f72fe-a71b-41e5-ab35-d4ccfac2c63e" />


feat: Added doctype-wise control for printing draft and cancelled documents

changes:

Allow printing draft documents.
Allow printing cancelled documents.
Priting will follow the options from doctype level not from global print settings
no-docs

closes: https://github.com/frappe/frappe/issues/6502