### PR TITLE
fix: set a fix width of sidebar header

### DIFF
--- a/frappe/public/scss/desk/sidebar_header.scss
+++ b/frappe/public/scss/desk/sidebar_header.scss
@@ -44,7 +44,7 @@
 	position: absolute;
 	top: 60px;
 	left: 9px;
-	width: 92%;
+	width: 200px;
 	padding: 6px;
 	border-radius: var(--border-radius-lg);
 	background: var(--surface-modal);


### PR DESCRIPTION
Sidebar header becomes huge when sidebar is collapsed 


This fixes that

