### PR TITLE
test: skip DB-specific tests using new unimplemented_for decorator

### DIFF
--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -78,7 +78,7 @@ class TestImporter(IntegrationTestCase):
 		self.assertEqual(len(preview.columns), 16)
 
 	# ignored on postgres because myisam doesn't exist on pg
-	@unimplemented_for(db_type_is.POSTGRES or db_type_is.SQLITE)
+	@unimplemented_for(db_type_is.POSTGRES, db_type_is.SQLITE)
 	def test_data_import_without_mandatory_values(self):
 		import_file = get_import_file("sample_import_file_without_mandatory")
 		data_import = self.get_importer(doctype_name, import_file)

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe.core.doctype.data_import.importer import Importer
 from frappe.tests import IntegrationTestCase
-from frappe.tests.test_query_builder import db_type_is, run_only_if
+from frappe.tests.test_query_builder import db_type_is, unimplemented_for
 from frappe.utils import format_duration, getdate
 
 doctype_name = "DocType for Import"
@@ -78,7 +78,7 @@ class TestImporter(IntegrationTestCase):
 		self.assertEqual(len(preview.columns), 16)
 
 	# ignored on postgres because myisam doesn't exist on pg
-	@run_only_if(db_type_is.MARIADB)
+	@unimplemented_for(db_type_is.POSTGRES or db_type_is.SQLITE)
 	def test_data_import_without_mandatory_values(self):
 		import_file = get_import_file("sample_import_file_without_mandatory")
 		data_import = self.get_importer(doctype_name, import_file)

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -15,7 +15,7 @@ from frappe.database.utils import FallBackDateTimeStr
 from frappe.query_builder import Field
 from frappe.query_builder.functions import Concat_ws
 from frappe.tests import IntegrationTestCase, timeout
-from frappe.tests.test_query_builder import db_type_is, run_only_if
+from frappe.tests.test_query_builder import db_type_is, run_only_if, unimplemented_for
 from frappe.utils import add_days, now, random_string, set_request
 from frappe.utils.data import now_datetime
 from frappe.utils.testutils import clear_custom_fields
@@ -1207,7 +1207,7 @@ class TestSqlIterator(IntegrationTestCase):
 				msg=f"{query=} results not same as iterator",
 			)
 
-	@run_only_if(db_type_is.MARIADB)
+	@unimplemented_for(db_type_is.POSTGRES, db_type_is.SQLITE)
 	def test_unbuffered_cursor(self):
 		with frappe.db.unbuffered_cursor():
 			self.test_db_sql_iterator()

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -28,9 +28,7 @@ def run_only_if(dbtype: db_type_is) -> Callable:
 
 def unimplemented_for(*dbtypes: db_type_is) -> Callable:
 	current_db_type = db_type_is(frappe.conf.db_type)
-	db_names = ", ".join(str(db.value) for db in dbtypes)
-
-	return unittest.skipIf(current_db_type in dbtypes, f"Not Implemented for {db_names}")
+	return unittest.skipIf(current_db_type in dbtypes, f"Not Implemented for {current_db_type.value}")
 
 
 @run_only_if(db_type_is.MARIADB)

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -26,8 +26,11 @@ def run_only_if(dbtype: db_type_is) -> Callable:
 	return unittest.skipIf(db_type_is(frappe.conf.db_type) != dbtype, f"Only runs for {dbtype.value}")
 
 
-def unimplemented_for(dbtype: db_type_is) -> Callable:
-	return unittest.skipIf(db_type_is(frappe.conf.db_type) == dbtype, f"Not Implemented for {dbtype.value}")
+def unimplemented_for(*dbtypes: db_type_is) -> Callable:
+	current_db_type = db_type_is(frappe.conf.db_type)
+	db_names = ", ".join(str(db.value) for db in dbtypes)
+
+	return unittest.skipIf(current_db_type in dbtypes, f"Not Implemented for {db_names}")
 
 
 @run_only_if(db_type_is.MARIADB)

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -26,6 +26,10 @@ def run_only_if(dbtype: db_type_is) -> Callable:
 	return unittest.skipIf(db_type_is(frappe.conf.db_type) != dbtype, f"Only runs for {dbtype.value}")
 
 
+def unimplemented_for(dbtype: db_type_is) -> Callable:
+	return unittest.skipIf(db_type_is(frappe.conf.db_type) == dbtype, f"Not Implemented for {dbtype.value}")
+
+
 @run_only_if(db_type_is.MARIADB)
 class TestCustomFunctionsMariaDB(IntegrationTestCase):
 	def test_concat(self):


### PR DESCRIPTION
**Problem:**
test: This PR focusses on creating a custom decorator `unimplemented_for` and is mostly just so Postgres Support can be tracked. This decorator can be used to skip tests whose underlying implementations don't exist for a particular DB and can be used to track the same. This PR is also a step forward towards resolving #21613 and completes a part of the Postgres TODO #34660.
