### PR TITLE
fix: dark mode for folder icons and desktop icon access restrict

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -42,6 +42,7 @@ def get_bootinfo():
 
 	# user
 	get_user(bootinfo)
+	# desktop icon info
 
 	# system info
 	bootinfo.sitename = frappe.local.site
@@ -56,6 +57,7 @@ def get_bootinfo():
 	bootinfo.modules = {}
 	bootinfo.module_list = []
 	load_desktop_data(bootinfo)
+	bootinfo.desktop_icons = get_desktop_icons(bootinfo=bootinfo)
 	bootinfo.letter_heads = get_letter_heads()
 	bootinfo.active_domains = frappe.get_active_domains()
 	bootinfo.all_domains = [d.get("name") for d in frappe.get_all("Domain")]
@@ -149,7 +151,6 @@ def load_conf_settings(bootinfo):
 def load_desktop_data(bootinfo):
 	from frappe.desk.desktop import get_workspace_sidebar_items
 
-	bootinfo.desktop_icons = get_desktop_icons()
 	bootinfo.workspaces = get_workspace_sidebar_items()
 	bootinfo.show_app_icons_as_folder = frappe.db.get_single_value(
 		"Desktop Settings", "show_app_icons_as_folder"

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -4,6 +4,10 @@
     --desktop-modal-height: 448px;
     --folder-thumbnail-icon-height: 12px;
     --desktop-icon-dimension: 54px;
+    --folder-icon-background-color: var(--surface-gray-1);
+}
+[data-theme="dark"]{
+    --folder-icon-background-color: #2b2b2b;
 }
 .desktop-wrapper{
     max-width: 100%;
@@ -201,11 +205,11 @@
 }
 
 .folder-icon{
-    background-color: var(--gray-50) !important;
+   background-color: var(--folder-icon-background-color) !important;
     box-shadow: 0px 0px 1px 0px rgba(0, 0, 0, 0.14);
     padding: 7px;
     align-items: normal;
-
+    box-shadow: 0 0 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.14);
     & .icons{
         gap: 2.1px;
         margin-top: 0px;


### PR DESCRIPTION
PR fixes 

1. dark mode for folder icon
2. Restrictions for Desktop Icons


Dark mode for folder

<img width="1440" height="722" alt="Screenshot 2025-11-19 at 10 30 55 AM" src="https://github.com/user-attachments/assets/d0a09cc2-da49-4cb2-a923-417f9edfa3cf" />


