### PR TITLE
test(postgres): enable test_restore for postgres

### DIFF
--- a/frappe/commands/test_commands.py
+++ b/frappe/commands/test_commands.py
@@ -244,7 +244,10 @@ class TestCommands(BaseTestCommands):
 		self.assertEqual(self.returncode, 0)
 		self.assertEqual(self.stdout, frappe.bold(text="DocType"))
 
-	@run_only_if(db_type_is.MARIADB)
+	@skipIf(
+		frappe.conf.db_type == "sqlite",
+		"Not for SQLite for now",
+	)
 	def test_restore(self):
 		# step 0: create a site to run the test on
 		global_config = {


### PR DESCRIPTION
**Problem:**
test(Postgres): This PR is particularly related to enabling `test_restore` to run in Postgres CI. This PR is also a step forward towards resolving #21613 and completes a part of the Postgres TODO #34660 .

**Before**:
Test was skipped for Postgres.



related to #34660 