### PR TITLE
fix: make collapse button visible in sidebar once edit change is discarded

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -421,7 +421,7 @@ frappe.ui.Sidebar = class Sidebar {
 			});
 		} else {
 			$(this.active_item).addClass("active-sidebar");
-			$(".collapse-sidebar-link").removeClass("hidden");
+			$(".collapse-sidebar-link").removeClass("hidden").css("display", "flex");
 			this.wrapper.find(".edit-mode").addClass("hidden");
 			this.add_new_item_button = this.wrapper.find("[data-name='add-sidebar-item']");
 		}


### PR DESCRIPTION
**Issue**: When clicking on edit sidebar and then discarding the change makes the "Collapse" button stay hidden.

**Before**:
<video src="https://github.com/user-attachments/assets/90b563dc-f950-4a05-bcce-d6765d7c9158"></video>

**After**:
<video src="https://github.com/user-attachments/assets/a46e6357-583c-41e3-8dd8-5f5811a0fc44"></video>