### PR TITLE
feat: Make page max-width responsive design

### DIFF
--- a/frappe/public/scss/common/css_variables.scss
+++ b/frappe/public/scss/common/css_variables.scss
@@ -19,7 +19,7 @@ $disabled-input-height: 22px;
 	--margin-xl: 30px;
 	--margin-2xl: 40px;
 
-	--page-max-width: 900px;
+	--page-max-width: 100%;
 
 	--modal-shadow: var(--shadow-md);
 	--card-shadow: var(--shadow-sm);
@@ -158,5 +158,21 @@ $disabled-input-height: 22px;
 
 	@include media-breakpoint-down(md) {
 		--checkbox-size: 18px;
+	}
+
+	@include media-breakpoint-up(md) {
+		--page-max-width: 900px;
+	}
+
+	@include media-breakpoint-up(lg) {
+		--page-max-width: 1200px;
+	}
+
+	@include media-breakpoint-up(xl) {
+		--page-max-width: 1400px;
+	}
+
+	@include media-breakpoint-up(2xl) {
+		--page-max-width: 1600px;
 	}
 }


### PR DESCRIPTION
## Description
This PR makes the `--page-max-width` CSS variable responsive to better utilize screen space on larger displays while maintaining optimal readability across all device sizes.

## Problem
Previously, `--page-max-width` was fixed at `900px`, which caused excessive empty space on the left and right sides of the content on large screens (≥1200px), resulting in poor space utilization.

## Solution
Implemented a responsive breakpoint system for `--page-max-width` that adapts to different screen sizes:

- **Mobile (< 768px)**: `100%` - Full width for optimal mobile experience
- **Tablet (≥ 768px)**: `900px` - Maintains the original desktop width
- **Desktop (≥ 992px)**: `1200px` - Better utilization of medium screens
- **Large Desktop (≥ 1200px)**: `1400px` - Improved space usage on large displays
- **Extra Large (≥ 1440px)**: `1600px` - Maximum width for very large screens

### Before
<img width="1600" height="747" alt="Screenshot from 2025-11-20 11-00-30" src="https://github.com/user-attachments/assets/82168ebc-1228-440e-acd6-ff5798e008eb" />

### After
<img width="1600" height="747" alt="Screenshot from 2025-11-20 10-58-54" src="https://github.com/user-attachments/assets/01d3fc01-225b-4379-83f6-cafedb91ff1d" />

## Changes Made
- Updated `frappe/public/scss/common/css_variables.scss`:
  - Changed base `--page-max-width` from `900px` to `100%`
  - Added responsive breakpoints using `@include media-breakpoint-up()` mixins

## Impact
This change affects all components using `--page-max-width`, including:
- Form sections
- Page containers

no-docs