### PR TITLE
perf(postgres): skip unnecessary migrations in PostgreSQL

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -443,6 +443,8 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			CASE LOWER(a.data_type)
 				WHEN 'character varying' THEN CONCAT('varchar(', a.character_maximum_length ,')')
 				WHEN 'timestamp without time zone' THEN 'timestamp'
+				WHEN 'integer' THEN 'int'
+				WHEN 'numeric' THEN CONCAT('decimal(', a.numeric_precision, ',', a.numeric_scale, ')')
 				ELSE a.data_type
 			END AS type,
 			BOOL_OR(b.index) AS index,
@@ -459,7 +461,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 				ON SUBSTRING(b.indexdef, '(.*)') LIKE CONCAT('%', a.column_name, '%')
 			WHERE a.table_name = '{table_name}'
 				AND a.table_schema = '{self.db_schema}'
-			GROUP BY a.column_name, a.data_type, a.column_default, a.character_maximum_length, a.is_nullable;
+			GROUP BY a.column_name, a.data_type, a.column_default, a.character_maximum_length, a.is_nullable, a.numeric_precision, a.numeric_scale;
 		""",
 			as_dict=1,
 		)

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -1,4 +1,5 @@
 import random
+from unittest.case import skipIf
 
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
@@ -207,7 +208,10 @@ class TestDBUpdate(IntegrationTestCase):
 
 
 class TestDBUpdateSanityChecks(IntegrationTestCase):
-	@run_only_if(db_type_is.MARIADB)
+	@skipIf(
+		(frappe.conf.db_type == "sqlite"),
+		"Not for SQLite for now",
+	)
 	def test_no_unnecessary_migrates(self):
 		doctypes = frappe.get_all("DocType", {"is_virtual": 0, "custom": 0}, pluck="name")
 


### PR DESCRIPTION
**Problem:**
perf(Postgres): This fix is particularly related to enabling `test_no_unnecessary_migrates` to run in Postgres CI and also fixes the underlying implementation by avoiding unnecessary schema migrations due to a type mismatch which caused the test to fail and occurs due to aliasing in Postgres as explained in detail in #34660 , and defacto improving performance. This PR is also a step forward towards resolving #21613 and completes a part of the Postgres TODO #34660 .

**Before**: 
There were unnecessary schema migrations happening even though underlying type is the same in postgres, an alias problem to be precise. This causes an unnecessary and futile performance drag.

**After**:
The Types are normalized maintaining a semantic comparison instead of a literal one for postgres, thus skipping any unnecessary migrations that could occur.

<img width="1538" height="466" alt="image" src="https://github.com/user-attachments/assets/693ada51-fe7b-4b30-9c18-6cea2cbb3508" />


EDIT: Have to modify `get_table_columns_description` in postgres DB file to include precision and length for decimal/numeric! ... Fixed in SQL, this now handles the "known" aliases

related to #34660 