### PR TITLE
fix: consider default_log_clearing_doctypes as well for clear_log_table

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -1328,19 +1328,18 @@ def clear_log_table(context: CliCtxObj, doctype, days, no_backup):
 
 	ref: https://mariadb.com/kb/en/big-deletes/#deleting-more-than-half-a-table
 	"""
-	from frappe.core.doctype.log_settings.log_settings import LOG_DOCTYPES
 	from frappe.core.doctype.log_settings.log_settings import clear_log_table as clear_logs
 	from frappe.utils.backups import scheduled_backup
 
 	if not context.sites:
 		raise SiteNotSpecifiedError
 
-	if doctype not in LOG_DOCTYPES:
-		raise frappe.ValidationError(f"Unsupported logging DocType: {doctype}")
-
 	for site in context.sites:
 		frappe.init(site)
 		frappe.connect()
+
+		if doctype not in frappe.get_hooks("default_log_clearing_doctypes", {}):
+			raise frappe.ValidationError(f"Unsupported logging DocType: {doctype}")
 
 		if not no_backup:
 			scheduled_backup(

--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -147,18 +147,6 @@ def get_log_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	return supported_doctypes[start:page_len]
 
 
-LOG_DOCTYPES = [
-	"Scheduled Job Log",
-	"Activity Log",
-	"Route History",
-	"Email Queue",
-	"Email Queue Recipient",
-	"Error Log",
-	"OAuth Bearer Token",
-	"API Request Log",
-]
-
-
 def clear_log_table(doctype, days=90):
 	"""If any logtype table grows too large then clearing it with DELETE query
 	is not feasible in reasonable time. This command copies recent data to new
@@ -168,7 +156,7 @@ def clear_log_table(doctype, days=90):
 	"""
 	from frappe.utils import get_table_name
 
-	if doctype not in LOG_DOCTYPES:
+	if doctype not in frappe.get_hooks("default_log_clearing_doctypes", {}):
 		raise frappe.ValidationError(f"Unsupported logging DocType: {doctype}")
 
 	original = get_table_name(doctype)

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -567,6 +567,7 @@ default_log_clearing_doctypes = {
 	"Route History": 90,
 	"OAuth Bearer Token": 30,
 	"API Request Log": 90,
+	"Email Queue Recipient": 30,  # this is added as a dummy placeholder and clearing is handled by Email Queue itself
 }
 
 # These keys will not be erased when doing frappe.clear_cache()


### PR DESCRIPTION
essentially what the title says - this will allow apps to do log clearing on their doctypes if they want