### PR TITLE
fix: remove no-op parameter from filter JSON

### DIFF
--- a/frappe/desk/dashboard_chart/login/login.json
+++ b/frappe/desk/dashboard_chart/login/login.json
@@ -8,7 +8,7 @@
  "doctype": "Dashboard Chart",
  "document_type": "Activity Log",
  "dynamic_filters_json": "[]",
- "filters_json": "[[\"Activity Log\",\"status\",\"=\",\"Success\",false]]",
+ "filters_json": "[[\"Activity Log\",\"status\",\"=\",\"Success\"]]",
  "group_by_type": "Count",
  "idx": 0,
  "is_public": 0,

--- a/frappe/desk/number_card/failed_login_attempts/failed_login_attempts.json
+++ b/frappe/desk/number_card/failed_login_attempts/failed_login_attempts.json
@@ -7,7 +7,7 @@
  "doctype": "Number Card",
  "document_type": "Activity Log",
  "dynamic_filters_json": "[]",
- "filters_json": "[[\"Activity Log\",\"status\",\"=\",\"Failed\",false]]",
+ "filters_json": "[[\"Activity Log\",\"status\",\"=\",\"Failed\"]]",
  "function": "Count",
  "idx": 0,
  "is_public": 0,

--- a/frappe/desk/number_card/published_web_forms/published_web_forms.json
+++ b/frappe/desk/number_card/published_web_forms/published_web_forms.json
@@ -7,7 +7,7 @@
  "doctype": "Number Card",
  "document_type": "Web Form",
  "dynamic_filters_json": "[]",
- "filters_json": "[[\"Web Form\",\"published\",\"=\",1,false]]",
+ "filters_json": "[[\"Web Form\",\"published\",\"=\",1]]",
  "function": "Count",
  "idx": 0,
  "is_public": 0,

--- a/frappe/desk/number_card/published_web_pages/published_web_pages.json
+++ b/frappe/desk/number_card/published_web_pages/published_web_pages.json
@@ -7,7 +7,7 @@
  "doctype": "Number Card",
  "document_type": "Web Page",
  "dynamic_filters_json": "[]",
- "filters_json": "[[\"Web Page\",\"published\",\"=\",1,false]]",
+ "filters_json": "[[\"Web Page\",\"published\",\"=\",1]]",
  "function": "Count",
  "idx": 0,
  "is_public": 0,


### PR DESCRIPTION
This was deprecated even with db_query, qb doesn't support at all.
