### PR TITLE
feat: Raw Html Emails

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -51,6 +51,7 @@ def make(
 	print_language=None,
 	now=False,
 	raw_html=False,
+	add_css=True,
 	**kwargs,
 ) -> dict[str, str]:
 	"""Make a new communication. Checks for email permissions for specified Document.
@@ -71,6 +72,7 @@ def make(
 	:param email_template: Template which is used to compose mail .
 	:param send_after: Send after the given datetime.
 	:param raw_html: Whether to use html version of email template
+	:param add_css: Add default CSS from hooks/email_css to the email template (default **True**)
 	"""
 	from frappe.utils.commands import warn
 
@@ -120,6 +122,7 @@ def make(
 		print_language=print_language,
 		now=now,
 		raw_html=raw_html,
+		add_css=add_css,
 	)
 
 
@@ -149,6 +152,7 @@ def _make(
 	print_language=None,
 	now=False,
 	raw_html=False,
+	add_css=True,
 ) -> dict[str, str]:
 	"""Internal method to make a new communication that ignores Permission checks."""
 
@@ -207,6 +211,7 @@ def _make(
 			print_language=print_language,
 			now=now,
 			raw_html=raw_html,
+			add_css=add_css,
 		)
 
 	emails_not_sent_to = comm.exclude_emails_list(include_sender=send_me_a_copy)

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -86,7 +86,7 @@ def make(
 	if doctype and name:
 		frappe.has_permission(doctype, doc=name, ptype="email", throw=True)
 
-	if raw_html and email_template and not frappe.get_value("Email Template", email_template, "use_html"):
+	if raw_html and email_template and not frappe.get_cached_value("Email Template", email_template, "use_html"):
 		warn(
 			_(
 				"Raw HTML can be used only with Email Templates having 'Use HTML' checked. "
@@ -184,7 +184,7 @@ def _make(
 		}
 	)
 	comm.flags.skip_add_signature = not add_signature or (
-		raw_html and frappe.get_value("Email Template", email_template, "use_html")
+		raw_html and frappe.get_cached_value("Email Template", email_template, "use_html")
 	)
 	comm.insert(ignore_permissions=True)
 

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -86,7 +86,11 @@ def make(
 	if doctype and name:
 		frappe.has_permission(doctype, doc=name, ptype="email", throw=True)
 
-	if raw_html and email_template and not frappe.get_cached_value("Email Template", email_template, "use_html"):
+	if (
+		raw_html
+		and email_template
+		and not frappe.get_cached_value("Email Template", email_template, "use_html")
+	):
 		warn(
 			_(
 				"Raw HTML can be used only with Email Templates having 'Use HTML' checked. "

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -50,6 +50,7 @@ def make(
 	send_after=None,
 	print_language=None,
 	now=False,
+	raw_html=False,
 	**kwargs,
 ) -> dict[str, str]:
 	"""Make a new communication. Checks for email permissions for specified Document.
@@ -69,6 +70,7 @@ def make(
 	:param send_me_a_copy: Send a copy to the sender (default **False**).
 	:param email_template: Template which is used to compose mail .
 	:param send_after: Send after the given datetime.
+	:param raw_html: Whether to use html version of email template
 	"""
 	if kwargs:
 		from frappe.utils.commands import warn
@@ -107,6 +109,7 @@ def make(
 		send_after=send_after,
 		print_language=print_language,
 		now=now,
+		raw_html=raw_html,
 	)
 
 
@@ -135,6 +138,7 @@ def _make(
 	send_after=None,
 	print_language=None,
 	now=False,
+	raw_html=False,
 ) -> dict[str, str]:
 	"""Internal method to make a new communication that ignores Permission checks."""
 
@@ -190,6 +194,7 @@ def _make(
 			print_letterhead=print_letterhead,
 			print_language=print_language,
 			now=now,
+			raw_html=raw_html,
 		)
 
 	emails_not_sent_to = comm.exclude_emails_list(include_sender=send_me_a_copy)

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -259,6 +259,7 @@ class CommunicationEmailMixin:
 		is_inbound_mail_communcation=None,
 		print_language=None,
 		raw_html=False,
+		add_css=True,
 	) -> dict:
 		outgoing_email_account = self.get_outgoing_email_account()
 		if not outgoing_email_account:
@@ -309,6 +310,7 @@ class CommunicationEmailMixin:
 			"print_letterhead": print_letterhead,
 			"send_after": self.send_after,
 			"raw_html": raw_html,
+			"add_css": add_css,
 		}
 
 	def send_email(
@@ -321,6 +323,7 @@ class CommunicationEmailMixin:
 		print_language=None,
 		now=False,
 		raw_html=False,
+		add_css=True,
 	):
 		if input_dict := self.sendmail_input_dict(
 			print_html=print_html,
@@ -330,5 +333,6 @@ class CommunicationEmailMixin:
 			is_inbound_mail_communcation=is_inbound_mail_communcation,
 			print_language=print_language,
 			raw_html=raw_html,
+			add_css=add_css,
 		):
 			frappe.sendmail(now=now, **input_dict)

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -258,6 +258,7 @@ class CommunicationEmailMixin:
 		print_letterhead=None,
 		is_inbound_mail_communcation=None,
 		print_language=None,
+		raw_html=False,
 	) -> dict:
 		outgoing_email_account = self.get_outgoing_email_account()
 		if not outgoing_email_account:
@@ -307,6 +308,7 @@ class CommunicationEmailMixin:
 			"is_notification": (self.sent_or_received == "Received"),
 			"print_letterhead": print_letterhead,
 			"send_after": self.send_after,
+			"raw_html": raw_html,
 		}
 
 	def send_email(
@@ -318,6 +320,7 @@ class CommunicationEmailMixin:
 		is_inbound_mail_communcation=None,
 		print_language=None,
 		now=False,
+		raw_html=False,
 	):
 		if input_dict := self.sendmail_input_dict(
 			print_html=print_html,
@@ -326,5 +329,6 @@ class CommunicationEmailMixin:
 			print_letterhead=print_letterhead,
 			is_inbound_mail_communcation=is_inbound_mail_communcation,
 			print_language=print_language,
+			raw_html=raw_html,
 		):
 			frappe.sendmail(now=now, **input_dict)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -555,7 +555,7 @@ class User(Document):
 		if custom_template:
 			from frappe.email.doctype.email_template.email_template import get_email_template
 
-			email_template = get_email_template(custom_template, args)
+			email_template = get_email_template(custom_template, args, sender=sender)
 			subject = email_template.get("subject")
 			content = email_template.get("message")
 

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -150,6 +150,7 @@ def sendmail(
 	email_read_tracker_url=None,
 	x_priority: Literal[1, 3, 5] = 3,
 	email_headers=None,
+	raw_html=False,
 ) -> EmailQueue | None:
 	"""Send email using user's default **Email Account** or global default **Email Account**.
 
@@ -179,6 +180,7 @@ def sendmail(
 	:param with_container: Wraps email inside a styled container
 	:param x_priority: 1 = HIGHEST, 3 = NORMAL, 5 = LOWEST
 	:param email_headers: Additional headers to be added in the email, e.g. {"X-Custom-Header": "value"} or {"Custom-Header": "value"}. Automatically prepends "X-" to the header name if not present.
+	:param raw_html: Whether to treat email template as a complete HTML file
 	"""
 
 	from frappe.utils.jinja import get_email_from_template
@@ -238,6 +240,7 @@ def sendmail(
 		email_read_tracker_url=email_read_tracker_url,
 		x_priority=x_priority,
 		email_headers=email_headers,
+		raw_html=raw_html,
 	)
 
 	# build email queue and send the email if send_now is True.

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -151,6 +151,7 @@ def sendmail(
 	x_priority: Literal[1, 3, 5] = 3,
 	email_headers=None,
 	raw_html=False,
+	add_css=True,
 ) -> EmailQueue | None:
 	"""Send email using user's default **Email Account** or global default **Email Account**.
 
@@ -181,6 +182,7 @@ def sendmail(
 	:param x_priority: 1 = HIGHEST, 3 = NORMAL, 5 = LOWEST
 	:param email_headers: Additional headers to be added in the email, e.g. {"X-Custom-Header": "value"} or {"Custom-Header": "value"}. Automatically prepends "X-" to the header name if not present.
 	:param raw_html: Whether to treat email template as a complete HTML file
+	:param add_css: Whether to add CSS from hooks/email_css to the email template
 	"""
 
 	from frappe.utils.jinja import get_email_from_template
@@ -241,6 +243,7 @@ def sendmail(
 		x_priority=x_priority,
 		email_headers=email_headers,
 		raw_html=raw_html,
+		add_css=add_css,
 	)
 
 	# build email queue and send the email if send_now is True.

--- a/frappe/email/doctype/email_queue/email_queue.json
+++ b/frappe/email/doctype/email_queue/email_queue.json
@@ -25,7 +25,8 @@
   "expose_recipients",
   "attachments",
   "retry",
-  "email_account"
+  "email_account",
+  "raw_html"
  ],
  "fields": [
   {
@@ -148,13 +149,20 @@
    "fieldtype": "Code",
    "label": "Unsubscribe Params",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "raw_html",
+   "fieldtype": "Check",
+   "label": "Send As Raw HTML",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-envelope",
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2025-03-07 15:56:13.341958",
+ "modified": "2025-11-19 11:18:45.574190",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Queue",

--- a/frappe/email/doctype/email_queue/email_queue.json
+++ b/frappe/email/doctype/email_queue/email_queue.json
@@ -152,6 +152,7 @@
   },
   {
    "default": "0",
+   "description": "Raw HTML emails are rendered as complete Jinja templates. Otherwise, emails are wrapped in the standard.html email template, which inserts brand_logo, header and footer.",
    "fieldname": "raw_html",
    "fieldtype": "Check",
    "label": "Send As Raw HTML",
@@ -162,7 +163,7 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2025-11-19 11:18:45.574190",
+ "modified": "2026-01-06 05:45:35.503215",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Queue",

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -60,6 +60,7 @@ class EmailQueue(Document):
 		message: DF.Code | None
 		message_id: DF.SmallText | None
 		priority: DF.Int
+		raw_html: DF.Check
 		recipients: DF.Table[EmailQueueRecipient]
 		reference_doctype: DF.Link | None
 		reference_name: DF.Data | None
@@ -518,6 +519,7 @@ class QueueBuilder:
 		email_read_tracker_url=None,
 		x_priority: Literal[1, 3, 5] = 3,
 		email_headers=None,
+		raw_html=False,
 	):
 		"""Add email to sending queue (Email Queue)
 
@@ -545,6 +547,7 @@ class QueueBuilder:
 		:param email_read_tracker_url: A URL for tracking whether an email is read by the recipient.
 		:param x_priority: 1 = HIGHEST, 3 = NORMAL, 5 = LOWEST
 		:param email_headers: Additional headers to be added in the email, e.g. {"X-Custom-Header": "value"} or {"Custom-Header": "value"}. Automatically prepends "X-" to the header name if not present.
+		:param raw_html: Whether to treat email template as a complete HTML file
 		"""
 
 		self._unsubscribe_method = unsubscribe_method
@@ -582,6 +585,7 @@ class QueueBuilder:
 		self.print_letterhead = print_letterhead
 		self.email_read_tracker_url = email_read_tracker_url
 		self.email_headers = email_headers
+		self.raw_html = raw_html
 
 	@property
 	def unsubscribe_method(self):
@@ -638,6 +642,7 @@ class QueueBuilder:
 			email_account=email_account,
 			unsubscribe_link=self.unsubscribe_message(),
 			with_container=self.with_container,
+			raw_html=self.raw_html,
 		)
 
 	def should_include_unsubscribe_link(self):
@@ -843,6 +848,7 @@ class QueueBuilder:
 			"show_as_bcc": ",".join(self.final_bcc()),
 			"email_account": email_account_name or None,
 			"email_read_tracker_url": self.email_read_tracker_url,
+			"raw_html": self.raw_html,
 		}
 
 		if include_recipients:

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -520,6 +520,7 @@ class QueueBuilder:
 		x_priority: Literal[1, 3, 5] = 3,
 		email_headers=None,
 		raw_html=False,
+		add_css=True,
 	):
 		"""Add email to sending queue (Email Queue)
 
@@ -548,6 +549,7 @@ class QueueBuilder:
 		:param x_priority: 1 = HIGHEST, 3 = NORMAL, 5 = LOWEST
 		:param email_headers: Additional headers to be added in the email, e.g. {"X-Custom-Header": "value"} or {"Custom-Header": "value"}. Automatically prepends "X-" to the header name if not present.
 		:param raw_html: Whether to treat email template as a complete HTML file
+		:param add_css: Add default CSS from hooks/email_css to the email template (default True)
 		"""
 
 		self._unsubscribe_method = unsubscribe_method
@@ -586,6 +588,7 @@ class QueueBuilder:
 		self.email_read_tracker_url = email_read_tracker_url
 		self.email_headers = email_headers
 		self.raw_html = raw_html
+		self.add_css = add_css
 
 	@property
 	def unsubscribe_method(self):
@@ -643,6 +646,7 @@ class QueueBuilder:
 			unsubscribe_link=self.unsubscribe_message(),
 			with_container=self.with_container,
 			raw_html=self.raw_html,
+			add_css=self.add_css,
 		)
 
 	def should_include_unsubscribe_link(self):
@@ -849,6 +853,7 @@ class QueueBuilder:
 			"email_account": email_account_name or None,
 			"email_read_tracker_url": self.email_read_tracker_url,
 			"raw_html": self.raw_html,
+			"add_css": self.add_css,
 		}
 
 		if include_recipients:

--- a/frappe/email/doctype/email_template/email_template.py
+++ b/frappe/email/doctype/email_template/email_template.py
@@ -37,19 +37,38 @@ class EmailTemplate(Document):
 	def get_formatted_response(self, doc):
 		return frappe.render_template(self.response_, doc)
 
-	def get_formatted_email(self, doc):
+	def get_formatted_email(self, doc, sender=None):
 		if isinstance(doc, str):
 			doc = json.loads(doc)
+
+		if self.use_html:
+			doc = self.inject_email_account(doc, sender)
 
 		return {
 			"subject": self.get_formatted_subject(doc),
 			"message": self.get_formatted_response(doc),
 		}
 
+	def inject_email_account(self, doc, sender=None):
+		from frappe.email.doctype.email_account.email_account import EmailAccount
+		from frappe.email.email_body import get_footer, get_signature
+
+		if sender:
+			kwargs = {"match_by_email": sender}
+		else:
+			kwargs = {"match_by_doctype": doc.get("doctype")}
+		email_account = EmailAccount.find_outgoing(**kwargs)
+
+		if email_account:
+			doc.update(
+				{"email_signature": get_signature(email_account), "email_footer": get_footer(email_account)}
+			)
+		return doc
+
 
 @frappe.whitelist()
-def get_email_template(template_name, doc):
+def get_email_template(template_name, doc, sender=None):
 	"""Return the processed HTML of a email template with the given doc"""
 
 	email_template = frappe.get_doc("Email Template", template_name)
-	return email_template.get_formatted_email(doc)
+	return email_template.get_formatted_email(doc, sender=sender)

--- a/frappe/email/doctype/email_template/email_template.py
+++ b/frappe/email/doctype/email_template/email_template.py
@@ -57,9 +57,8 @@ class EmailTemplate(Document):
 			kwargs = {"match_by_email": sender}
 		else:
 			kwargs = {"match_by_doctype": doc.get("doctype")}
-		email_account = EmailAccount.find_outgoing(**kwargs)
 
-		if email_account:
+		if email_account := EmailAccount.find_outgoing(**kwargs):
 			doc.update(
 				{"email_signature": get_signature(email_account), "email_footer": get_footer(email_account)}
 			)

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -382,6 +382,7 @@ def get_formatted_html(
 	sender=None,
 	with_container=False,
 	raw_html=False,
+	add_css=True,
 ):
 	email_account = email_account or EmailAccount.find_outgoing(match_by_email=sender)
 
@@ -411,7 +412,7 @@ def get_formatted_html(
 	if unsubscribe_link:
 		html = html.replace("<!--unsubscribe link here-->", unsubscribe_link.html)
 
-	return inline_style_in_html(html, add_css=not raw_html)
+	return inline_style_in_html(html, add_css=add_css)
 
 
 @frappe.whitelist()

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -392,9 +392,9 @@ def get_formatted_html(
 		"print_html": print_html,
 		"subject": subject,
 	}
+
 	if raw_html:
 		rendered_email = frappe.render_template(message, params)
-
 	else:
 		params.update(
 			{

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -381,29 +381,42 @@ def get_formatted_html(
 	unsubscribe_link: frappe._dict | None = None,
 	sender=None,
 	with_container=False,
+	raw_html=False,
 ):
 	email_account = email_account or EmailAccount.find_outgoing(match_by_email=sender)
 
-	rendered_email = frappe.get_template("templates/emails/standard.html").render(
-		{
-			"brand_logo": get_brand_logo(email_account) if with_container or header else None,
-			"with_container": with_container,
-			"site_url": get_url(),
-			"header": get_header(header),
-			"content": message,
-			"footer": get_footer(email_account, footer),
-			"title": subject,
-			"print_html": print_html,
-			"subject": subject,
-		}
-	)
+	if raw_html:
+		rendered_email = frappe.render_template(
+			message,
+			{
+				"site_url": get_url(),
+				"title": subject,
+				"print_html": print_html,
+				"subject": subject,
+			},
+		)
+
+	else:
+		rendered_email = frappe.get_template("templates/emails/standard.html").render(
+			{
+				"brand_logo": get_brand_logo(email_account) if with_container or header else None,
+				"with_container": with_container,
+				"site_url": get_url(),
+				"header": get_header(header),
+				"content": message,
+				"footer": get_footer(email_account, footer),
+				"title": subject,
+				"print_html": print_html,
+				"subject": subject,
+			}
+		)
 
 	html = scrub_urls(rendered_email)
 
 	if unsubscribe_link:
 		html = html.replace("<!--unsubscribe link here-->", unsubscribe_link.html)
 
-	return inline_style_in_html(html)
+	return inline_style_in_html(html, add_css=not raw_html)
 
 
 @frappe.whitelist()
@@ -418,17 +431,20 @@ def get_email_html(template, args, subject, header=None, with_container=False):
 	return get_formatted_html(subject, email[0], header=header, with_container=with_container)
 
 
-def inline_style_in_html(html):
+def inline_style_in_html(html, add_css=True):
 	"""Convert email.css and html to inline-styled html."""
 	from premailer import Premailer
 
 	from frappe.utils.jinja_globals import bundled_asset
 
-	# get email css files from hooks
-	css_files = frappe.get_hooks("email_css")
-	css_files = [bundled_asset(path) for path in css_files]
-	css_files = [path.lstrip("/") for path in css_files]
-	css_files = [css_file for css_file in css_files if os.path.exists(os.path.abspath(css_file))]
+	if add_css:
+		# get email css files from hooks
+		css_files = frappe.get_hooks("email_css")
+		css_files = [bundled_asset(path) for path in css_files]
+		css_files = [path.lstrip("/") for path in css_files]
+		css_files = [css_file for css_file in css_files if os.path.exists(os.path.abspath(css_file))]
+	else:
+		css_files = None
 
 	p = Premailer(
 		html=html, external_styles=css_files, strip_important=False, allow_loading_external_files=True

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -385,31 +385,26 @@ def get_formatted_html(
 ):
 	email_account = email_account or EmailAccount.find_outgoing(match_by_email=sender)
 
+	params = {
+		"site_url": get_url(),
+		"title": subject,
+		"print_html": print_html,
+		"subject": subject,
+	}
 	if raw_html:
-		rendered_email = frappe.render_template(
-			message,
-			{
-				"site_url": get_url(),
-				"title": subject,
-				"print_html": print_html,
-				"subject": subject,
-			},
-		)
+		rendered_email = frappe.render_template(message, params)
 
 	else:
-		rendered_email = frappe.get_template("templates/emails/standard.html").render(
+		params.update(
 			{
 				"brand_logo": get_brand_logo(email_account) if with_container or header else None,
 				"with_container": with_container,
-				"site_url": get_url(),
 				"header": get_header(header),
 				"content": message,
 				"footer": get_footer(email_account, footer),
-				"title": subject,
-				"print_html": print_html,
-				"subject": subject,
 			}
 		)
+		rendered_email = frappe.get_template("templates/emails/standard.html").render(params)
 
 	html = scrub_urls(rendered_email)
 

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -90,15 +90,6 @@ frappe.views.CommunicationComposer = class {
 				fieldname: "send_after",
 			},
 			{
-				label: __("Use HTML"),
-				fieldtype: "Check",
-				fieldname: "use_html",
-				default: 0,
-				onchange: () => {
-					me.on_use_html_toggle();
-				},
-			},
-			{
 				fieldtype: "Section Break",
 				fieldname: "email_template_section_break",
 				hidden: 1,
@@ -127,13 +118,9 @@ frappe.views.CommunicationComposer = class {
 				fieldname: "use_html",
 				default: 0,
 				hidden: 1,
-				onchange: function (e) {
-					if (!e) return;
-					if (e.target.checked) {
-						me.dialog.set_value("html_content", me.dialog.get_value("content"));
-					} else {
-						me.dialog.set_value("content", me.dialog.get_value("html_content"));
-					}
+				description: "Use Raw HTML email editor.",
+				onchange: (event) => {
+					me.on_use_html_toggle(event);
 				},
 			},
 			{ fieldtype: "Section Break" },
@@ -158,13 +145,6 @@ frappe.views.CommunicationComposer = class {
 				onchange: frappe.utils.debounce(this.save_as_draft.bind(this), 300),
 				depends_on: "eval:doc.use_html",
 				options: "HTML",
-			},
-			{
-				label: __("Message"),
-				fieldtype: "HTML Editor",
-				fieldname: "content_html",
-				hidden: 1,
-				onchange: frappe.utils.debounce(this.save_as_draft.bind(this), 300),
 			},
 			{
 				fieldtype: "Button",
@@ -1077,13 +1057,16 @@ frappe.views.CommunicationComposer = class {
 		return this.get_content_field().set_value(value);
 	}
 
-	on_use_html_toggle() {
+	on_use_html_toggle(event) {
+		if (!event) return;
+
 		this.save_as_draft();
-		const use_html = this.dialog.get_value("use_html");
+		const use_html = event.target.checked;
 
-		this.dialog.set_df_property("content", "hidden", use_html);
-		this.dialog.set_df_property("content_html", "hidden", !use_html);
-
-		this.dialog.set_value("email_template", "");
+		if (use_html) {
+			this.dialog.set_value("html_content", this.dialog.get_value("content"));
+		} else {
+			this.dialog.set_value("content", this.dialog.get_value("html_content"));
+		}
 	}
 };

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -450,6 +450,7 @@ frappe.views.CommunicationComposer = class {
 				args: {
 					template_name: email_template,
 					doc: me.doc,
+					sender: me.dialog.get_value("sender") || "",
 				},
 				callback(r) {
 					prepend_reply(r.message);

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -212,6 +212,13 @@ frappe.views.CommunicationComposer = class {
 			},
 			{ fieldtype: "Column Break" },
 			{
+				label: __("Add CSS"),
+				fieldtype: "Check",
+				fieldname: "add_css",
+				default: 1,
+				depends_on: "eval:doc.use_html",
+			},
+			{
 				label: __("Select Attachments"),
 				fieldtype: "HTML",
 				fieldname: "select_attachments",
@@ -881,6 +888,7 @@ frappe.views.CommunicationComposer = class {
 				send_after: form_values.send_after ? form_values.send_after : null,
 				print_language: form_values.print_language,
 				raw_html: form_values.use_html,
+				add_css: form_values.add_css,
 			},
 			btn,
 			callback(r) {

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -252,6 +252,13 @@ frappe.views.CommunicationComposer = class {
 		return fields;
 	}
 
+	get_content_field() {
+		const content_field = this.dialog.fields_dict.use_html.value
+			? this.dialog.fields_dict.html_content
+			: this.dialog.fields_dict.content;
+		return content_field;
+	}
+
 	get_default_recipients(fieldname) {
 		if (this.frm?.events.get_email_recipients) {
 			return (this.frm.events.get_email_recipients(this.frm, fieldname) || []).join(", ");

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -846,6 +846,7 @@ frappe.views.CommunicationComposer = class {
 				print_letterhead: me.is_print_letterhead_checked(),
 				send_after: form_values.send_after ? form_values.send_after : null,
 				print_language: form_values.print_language,
+				raw_html: form_values.use_html,
 			},
 			btn,
 			callback(r) {

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -127,6 +127,15 @@ frappe.views.CommunicationComposer = class {
 				fieldtype: "Text Editor",
 				fieldname: "content",
 				onchange: frappe.utils.debounce(this.save_as_draft.bind(this), 300),
+				depends_on: "eval:!doc.use_html",
+			},
+			{
+				label: __("HTML Message"),
+				fieldtype: "Code",
+				fieldname: "html_content",
+				onchange: frappe.utils.debounce(this.save_as_draft.bind(this), 300),
+				depends_on: "eval:doc.use_html",
+				options: "HTML",
 			},
 			{
 				label: __("Message"),
@@ -180,6 +189,19 @@ frappe.views.CommunicationComposer = class {
 				depends_on: "attach_document_print",
 			},
 			{ fieldtype: "Column Break" },
+			{
+				label: __("Use HTML"),
+				fieldtype: "Check",
+				fieldname: "use_html",
+				default: 0,
+				onchange: function (e) {
+					if (e.target.checked) {
+						me.dialog.set_value("html_content", me.dialog.get_value("content"));
+					} else {
+						me.dialog.set_value("content", me.dialog.get_value("html_content"));
+					}
+				},
+			},
 			{
 				label: __("Select Attachments"),
 				fieldtype: "HTML",
@@ -520,7 +542,7 @@ frappe.views.CommunicationComposer = class {
 		if (this.message) return;
 
 		const last_edited = this.get_last_edited_communication();
-		if (!last_edited.content && !last_edited.content_html) return;
+		if (!last_edited.content && !last_edited.html_content) return;
 
 		// prevent re-triggering of email template
 		if (last_edited.email_template) {

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -260,10 +260,11 @@ frappe.views.CommunicationComposer = class {
 	}
 
 	get_content_field() {
-		const content_field = this.dialog.fields_dict.use_html.value
-			? this.dialog.fields_dict.html_content
-			: this.dialog.fields_dict.content;
-		return content_field;
+		if (this.dialog.fields_dict.use_html.value) {
+			return this.dialog.fields_dict.html_content;
+		} else {
+			return this.dialog.fields_dict.content;
+		}
 	}
 
 	get_default_recipients(fieldname) {
@@ -1066,11 +1067,6 @@ frappe.views.CommunicationComposer = class {
 
 		const text = frappe.utils.html2text(html);
 		return text.replace(/\n{3,}/g, "\n\n");
-	}
-
-	get_content_field() {
-		const use_html = this.dialog.get_value("use_html");
-		return use_html ? this.dialog.fields_dict.content_html : this.dialog.fields_dict.content;
 	}
 
 	get_email_content() {

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -134,6 +134,7 @@ def render_template(template, context=None, is_path=None, safe_render=True):
 			title="Jinja Template Error",
 			msg=f"<pre>{template}</pre><pre>{html.escape(get_traceback())}</pre>",
 		)
+		return ""
 
 	import time
 

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -134,7 +134,6 @@ def render_template(template, context=None, is_path=None, safe_render=True):
 			title="Jinja Template Error",
 			msg=f"<pre>{template}</pre><pre>{html.escape(get_traceback())}</pre>",
 		)
-		return ""
 
 	import time
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

I've been working on adding Raw HTML so that designers can drop in Email Templates from figma, and with a bit of Jinja syntactic sugar, I can get my Quotes, Sales Orders, and Invoices looking great.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

Fixes Issues:-
- https://github.com/frappe/frappe/issues/34698
- https://github.com/frappe/frappe/issues/26420

Here is the To Do list I put in Issue #34698, with added comments below **in bold**:-

- [x] Add a "Raw HTML" checkbox somewhere, either to the Email Template, or to the Email itself. Keep existing functionality the same, adding the option for full control of HTML emails.
    **A "Use HTML" button has been added to the Email Dialog. However, it will only show when an Email Template is added, and one for which "Use HTML" has been selected there, too.**

- [ ] Fix Issue https://github.com/frappe/frappe/issues/26396. <!--[if mso]> comments need to work.
    **It seems not possible to fix this without replacing `bleach` for something else. I have suggested replacing bleach with `nh3` and provided a PR, in https://github.com/frappe/frappe/pull/34740**

- [x] When rendering the template, with [frappe.utils.jinja.render_template](https://github.com/frappe/frappe/blob/6c9c76a63cd1e95c9b95a1dd0d5fdb6e88f810c1/frappe/utils/jinja.py#L101C5-L101C20), add the Email Account's footnote and signature to the context. This would allow the designer to decide where to put the footnote and signature, as of course it needs to go within the <html> tags.
    **Done. I went with `email_signature` and `email_footer`. These are inserted into the Email when an Email Template is added to the Email Editor.**

- [x] If no longer sanitising Emails, it is worth double-checking security on the relevant API and that the User is properly Authenticated and Authorised to POST there. Otherwise, why are we sanitising a trusted user's HTML input?
    **I am pretty happy with this implementation, in that no less or more sanitisation happens than previously.**

- [x] As a side-quest, replace bleach with [nh3](https://github.com/messense/nh3), considering that https://github.com/mozilla/bleach/issues/698, as @SvbZ3r0 pointed out in Issue https://github.com/frappe/frappe/issues/26396. Benefit from ~20x performance improvements in html sanitisation, according to the code author's tests. (This should be a separate Issue IMO)
    **As mentioned, done in PR https://github.com/frappe/frappe/pull/34740**

TODOs

 - Update Documentation
 - Probably add some unit tests...

> Screenshots/GIFs


https://github.com/user-attachments/assets/ffa831b1-4195-4e55-8ab9-196bd15cb252

EDIT: Added an "Add CSS" button to the Email Communication dialog, so users can chose whether or not to include Quill's CSS. Option depends on "Use HTML". Screenshot:-

<img width="776" height="682" alt="Frappe-Email-Raw-HTML-Add-CSS" src="https://github.com/user-attachments/assets/54b22c7a-1342-46b4-b3f1-c357caf09270" />
