### PR TITLE
fix(Notification): include "Attach Image" fieldtype in attachment options

### DIFF
--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -107,7 +107,9 @@ frappe.notification = {
 			);
 
 			// set options for "From Attach Field"
-			let attach_fields = fields.filter((d) => d.fieldtype === "Attach");
+			let attach_fields = fields.filter((d) =>
+				["Attach", "Attach Image"].includes(d.fieldtype)
+			);
 			let attach_options = $.map(attach_fields, function (d) {
 				return get_select_options(d);
 			});


### PR DESCRIPTION
This pull request makes a minor improvement to the attachment options in the notification settings by allowing fields of type `Attach Image` to be included alongside `Attach` fields.