### PR TITLE
test(custom_buttons): improve sidebar collapse logic to check for expanded state

### DIFF
--- a/cypress/integration/custom_buttons.js
+++ b/cypress/integration/custom_buttons.js
@@ -42,7 +42,12 @@ describe(
 			cy.login();
 			cy.visit(`/desk/note/new`);
 			// close the sidebar cause default is expanded
-			cy.get(".body-sidebar .collapse-sidebar-link").click();
+			cy.get(".body-sidebar-container").then(($sidebar) => {
+				if ($sidebar.hasClass("expanded")) {
+					cy.get(".body-sidebar .collapse-sidebar-link").click();
+					cy.get(".body-sidebar-container").should("not.have.class", "expanded");
+				}
+			});
 		});
 
 		test_button_names.forEach((button_name) => {


### PR DESCRIPTION
This pull request makes a small improvement to the Cypress test for custom buttons by ensuring the sidebar is collapsed before proceeding. This helps maintain a consistent test environment and avoids issues if the sidebar is already collapsed.

This test has been failing on unrelated PRs, e.g. https://github.com/frappe/frappe/actions/runs/19555455038/job/55996781250?pr=34808

Updated the test setup in `cypress/integration/custom_buttons.js` to check if `.body-sidebar-container` has the `expanded` class before attempting to collapse the sidebar, preventing unnecessary clicks and ensuring the sidebar is in the correct state for the test.