### PR TITLE
test(custom_buttons): fix sidebar collapse logic

### DIFF
--- a/cypress/integration/custom_buttons.js
+++ b/cypress/integration/custom_buttons.js
@@ -40,13 +40,10 @@ describe(
 	() => {
 		before(() => {
 			cy.login();
-			cy.visit(`/desk/note/new`);
-			// close the sidebar cause default is expanded
-			cy.get(".body-sidebar-container").then(($sidebar) => {
-				if ($sidebar.hasClass("expanded")) {
-					cy.get(".body-sidebar .collapse-sidebar-link").click();
-					cy.get(".body-sidebar-container").should("not.have.class", "expanded");
-				}
+			cy.visit(`/desk/note/new`, {
+				onBeforeLoad: (win) => {
+					win.localStorage.setItem("sidebar-expanded", "false");
+				},
 			});
 		});
 


### PR DESCRIPTION
Make sidebar collapse logic more robust by setting localStorage directly.
