### PR TITLE
feat: removal of orphan entities

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -127,6 +127,8 @@ class Workspace(Document):
 	def on_trash(self):
 		if self.public and not is_workspace_manager():
 			frappe.throw(_("You need to be Workspace Manager to delete a public workspace."))
+		self.delete_desktop_icon()
+		self.delete_workspace_sidebar()
 		self.delete_from_my_workspaces()
 
 	def delete_from_my_workspaces(self):
@@ -142,6 +144,25 @@ class Workspace(Document):
 
 		if self.module and frappe.conf.developer_mode:
 			delete_folder(self.module, "Workspace", self.title)
+
+	def delete_desktop_icon(self):
+		if self.public:
+			desktop_icon = frappe.get_all(
+				"Desktop Icon",
+				filters=[{"link_type": "Workspace"}, {"link_to": self.name}],
+				limit=1,
+				pluck="name",
+			)
+			if desktop_icon:
+				frappe.delete_doc("Desktop Icon", desktop_icon)
+
+	def delete_workspace_sidebar(self):
+		if self.public:
+			workspace_sidebar = frappe.get_all(
+				"Workspace Sidebar", filters=[{"name": self.name}], limit=1, pluck="name"
+			)
+			if workspace_sidebar:
+				frappe.delete_doc("Workspace Sidebar", workspace_sidebar[0])
 
 	@staticmethod
 	def get_module_wise_workspaces():

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -154,7 +154,7 @@ class Workspace(Document):
 				pluck="name",
 			)
 			if desktop_icon:
-				frappe.delete_doc("Desktop Icon", desktop_icon)
+				frappe.delete_doc("Desktop Icon", desktop_icon[0])
 
 	def delete_workspace_sidebar(self):
 		if self.public:

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -184,6 +184,7 @@ class SiteMigration:
 
 		frappe.model.sync.remove_orphan_entities()
 
+		frappe.model.sync.delete_duplicate_icons()
 		print("Syncing portal menu...")
 		frappe.get_single("Portal Settings").sync_menu()
 

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -182,6 +182,8 @@ class SiteMigration:
 		print("Removing orphan doctypes...")
 		frappe.model.sync.remove_orphan_doctypes()
 
+		frappe.model.sync.remove_orphan_entities()
+
 		print("Syncing portal menu...")
 		frappe.get_single("Portal Settings").sync_menu()
 

--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -205,7 +205,7 @@ def remove_orphan_entities():
 		"Workspace": {"public": 1},
 		"Page": {"standard": "Yes"},
 		"Report": {"is_standard": "Yes"},
-		"Dashboard": {"is_standard": False},
+		"Dashboard": {"is_standard": True},
 	}
 	for entity in entites:
 		print(f"Removing orphan {entity}s")

--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -249,4 +249,4 @@ def delete_duplicate_icons():
 					frappe.delete_doc("Desktop Icon", i)
 
 	# save the deleted icons
-	frappe.db.commit()  # semgrep
+	frappe.db.commit()  # nosemgrep

--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -224,7 +224,8 @@ def remove_orphan_entities():
 
 				except Exception as e:
 					print(e)
-			frappe.db.commit()
+			# save the deleted ones
+			frappe.db.commit()  # nosemgrep
 
 
 def check_if_record_exists(module_path, entity_type, module_name, name):


### PR DESCRIPTION
This PR contains code that will clean up orphan entities. As in standard Pages, Reports, Dashboard, Workspace
Orphan as in the json files are removed but it still exists in the db
Heavily inspired by orphan doctype method

`no-docs`