### PR TITLE
fix: correct boolean logic in test helper condition

### DIFF
--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -1,3 +1,5 @@
+import os
+
 import frappe
 from frappe import _
 from frappe.permissions import AUTOMATIC_ROLES
@@ -8,8 +10,10 @@ UI_TEST_USER = "frappe@example.com"
 
 
 def whitelist_for_tests(fn):
-	if frappe.request and not frappe.in_test and not frappe._dev_server:
-		frappe.throw("Cannot run UI tests. Use a development server with `bench start`")
+	if frappe.request and not (frappe._dev_server and (frappe.conf.allow_tests or os.environ.get("CI"))):
+		frappe.throw(  # nosemgrep: frappe-missing-translate-function-python
+			'Cannot run UI tests. Use a development server with "bench start" and ensure that the "allow_tests" site config is enabled.'
+		)
 
 	return frappe.whitelist()(fn)
 


### PR DESCRIPTION
The `whitelist_for_tests` decorator was checking `frappe.in_test`, which is only set during Python unit test execution. UI tests run against a separate dev server process where `in_test=False`, making the check ineffective.

Changed to check `frappe.conf.allow_tests` or `CI` environment variable instead, which persist across server processes and properly gate access to test helper endpoints.