### PR TITLE
fix!: restrict HTTP methods for some public methods

### DIFF
--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -271,9 +271,9 @@ def run_doc_method(method: str, document: dict[str, Any] | str, kwargs=None):
 url_rules = [
 	# RPC calls
 	Rule("/method/login", endpoint=login),
-	Rule("/method/logout", endpoint=logout),
+	Rule("/method/logout", endpoint=logout, methods=["POST"]),
 	Rule("/method/ping", endpoint=frappe.ping),
-	Rule("/method/upload_file", endpoint=upload_file),
+	Rule("/method/upload_file", endpoint=upload_file, methods=["POST"]),
 	Rule("/method/<method>", endpoint=handle_rpc_call),
 	Rule(
 		"/method/run_doc_method",

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -105,13 +105,13 @@ def is_valid_http_method(method):
 		frappe.throw_permission_error()
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True, methods=["POST"])
 def logout():
 	frappe.local.login_manager.logout()
 	frappe.db.commit()
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True, methods=["POST"])
 def web_logout():
 	frappe.local.login_manager.logout()
 	frappe.db.commit()
@@ -120,7 +120,7 @@ def web_logout():
 	)
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True, methods=["POST"])
 def upload_file():
 	user = None
 	if frappe.session.user == "Guest":

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -140,7 +140,7 @@ def get_login_with_email_link_ratelimit() -> int:
 	return frappe.get_system_settings("rate_limit_email_link_login") or 5
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True, methods=["POST"])
 @rate_limit(limit=get_login_with_email_link_ratelimit, seconds=60 * 60)
 def send_login_link(email: str):
 	if not frappe.get_system_settings("login_with_email_link"):


### PR DESCRIPTION
[updated migration guide](https://github.com/frappe/frappe/wiki/Migrating-to-version-16#some-whitelisted-methods-now-require-post)