### PR TITLE
fix: give proper variables to popover-header

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -584,3 +584,8 @@
 		padding-top: var(--padding-md);
 	}
 }
+
+.popover-header {
+	background: var(--bg-color);
+	color: var(--ink-gray-9);
+}


### PR DESCRIPTION
<img width="275" height="113" alt="Screenshot 2025-11-21 at 5 34 38 PM" src="https://github.com/user-attachments/assets/a5071361-a4ac-47dc-ae7a-615faca4176b" />

Fixes dark mode for popover on form