### PR TITLE
fix: don't add 5th element to filter array

### DIFF
--- a/frappe/public/js/form_builder/components/Field.vue
+++ b/frappe/public/js/form_builder/components/Field.vue
@@ -88,9 +88,6 @@ function make_dialog(frm) {
 			let fieldname = props.field.df.fieldname;
 			let field_option = props.field.df.options;
 			let filters = frm.filter_group.get_filters().map((filter) => {
-				// last element is a boolean which hides the filter hence not required to store in meta
-				filter.pop();
-
 				// filter_group component requires options and frm.set_query requires fieldname so storing both
 				filter[0] = field_option;
 				return filter;

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -333,7 +333,6 @@ frappe.ui.Filter = class {
 			this.field.df.fieldname,
 			this.get_condition(),
 			this.get_selected_value(),
-			this.hidden,
 		];
 	}
 


### PR DESCRIPTION
It wasn't used, and now causes an error if passed to query builder.
