### PR TITLE
fix(query): check standard field definitions

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1476,7 +1476,12 @@ class Engine:
 			return "''"
 
 		if df is None:
-			return "''"
+			# Try to get standard field definition
+			from frappe.model.meta import get_default_df
+
+			df = get_default_df(fieldname)
+			if df is None:
+				return "''"
 
 		fieldtype = df.fieldtype
 


### PR DESCRIPTION
```
Error in query:
invalid input syntax for type smallint: ""
LINE 1: ..." WHERE "permlevel"= '0' AND coalesce("docstatus",'')= '0' A...
                                                             ^

Traceback (most recent call last):
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 112, in new_site
    _new_site(
    ~~~~~~~~~^
        db_name,
     ^^^^^^^^
    ...<16 lines>...
        mariadb_user_host_login_scope=mariadb_user_host_login_scope,
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/installer.py", line 112, in _new_site
    install_app(app, verbose=verbose, set_as_patched=not source_sql, force=False)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/installer.py", line 321, in install_app
    sync_for(name, force=force, reset_permissions=True)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/model/sync.py", line 131, in sync_for
    imported = import_file_by_path(
        doc_path, force=force, ignore_version=True, reset_permissions=reset_permissions
    )
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 144, in import_file_by_path
    import_doc(
    ~~~~~~~~~~^
        docdict=doc,
     ^^^^^^^^^^^^
    ...<4 lines>...
        path=path,
     ^^^^^^^^^^
    )
    ^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 218, in import_doc
    doc = frappe.get_doc(docdict)
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/model/utils/__init__.py", line 218, in wrapper
    return dispatch(args[0])(*args, **kw)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 141, in get_doc_from_dict
    return controller(**data)
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py", line 38, in __init__
    self.can_read = self.get_cached("user_perm_can_read", self.get_can_read_items)
                    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py", line 104, in get_cached
    value = fallback_fn()
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py", line 47, in get_can_read_items
    self.user.build_permissions()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/utils/user.py", line 116, in build_permissions
    self.build_perm_map()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/utils/user.py", line 98, in build_perm_map
    for r in get_valid_perms():
             ~~~~~~~~~~~~~~~^^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/permissions.py", line 490, in get_valid_perms
    perms = get_perms_for(roles)
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/permissions.py", line 562, in get_perms_for
    return frappe.get_all(perm_doctype, fields=["*"], filters=filters)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1385, in get_all
    return get_list(doctype, *args, **kwargs)
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1360, in get_list
    return frappe.model.qb_query.DatabaseQuery(doctype).execute(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/model/qb_query.py", line 205, in execute
    result = query.run(debug=debug, as_dict=not as_list, update=update)
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/query_builder/utils.py", line 85, in execute_query
    result = frappe.local.db.sql(query, params, *args, **kwargs)  # nosemgrep
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/database/postgres/database.py", line 233, in sql
    return super().sql(modify_query(query), modify_values(values), *args, **kwargs)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 272, in sql
    self.execute_query(query, values)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/home/akhil/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 366, in execute_query
    return self._cursor.execute(query, values)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type smallint: ""
LINE 1: ..." WHERE "permlevel"= '0' AND coalesce("docstatus",'')= '0' A...
```