### PR TITLE
fix(link.js): pass value to super.set_formatted_input

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -90,7 +90,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		}
 	}
 	set_formatted_input(value) {
-		super.set_formatted_input();
+		super.set_formatted_input(value);
 		if (!value) return;
 
 		if (!this.title_value_map) {


### PR DESCRIPTION
Previously, the method called super.set_formatted_input() without arguments, causing the parent class to receive undefined and leading to inconsistent behavior when formatting input values.

`no-docs`