### PR TITLE
feat: let's custom message for copy_to_clipboard

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1031,11 +1031,11 @@ Object.assign(frappe.utils, {
 		}
 		return decoded;
 	},
-	copy_to_clipboard(string) {
+	copy_to_clipboard(string, message) {
 		const show_success_alert = () => {
 			frappe.show_alert({
 				indicator: "green",
-				message: __("Copied to clipboard."),
+				message: message || __("Copied to clipboard."),
 			});
 		};
 		if (navigator.clipboard && window.isSecureContext) {


### PR DESCRIPTION
Just let's show custom toast message on clipboard copying.
<img width="1268" height="912" alt="image" src="https://github.com/user-attachments/assets/ec8374df-fe2f-4a9f-a579-a0868a08328a" />
Closes https://github.com/frappe/frappe/issues/34837

`no-docs`