### PR TITLE
fix: load html5-qrcode globally to prevent scanner breakage

### DIFF
--- a/frappe/public/js/controls.bundle.js
+++ b/frappe/public/js/controls.bundle.js
@@ -2,3 +2,7 @@ import "air-datepicker/dist/js/datepicker.min.js";
 import "./frappe/form/controls/datepicker_i18n.js";
 import "./frappe/ui/capture.js";
 import "./frappe/form/controls/control.js";
+import { Html5Qrcode, Html5QrcodeScanner } from "html5-qrcode";
+
+window.Html5Qrcode = Html5Qrcode;
+window.Html5QrcodeScanner = Html5QrcodeScanner;

--- a/frappe/public/js/frappe/scanner/index.js
+++ b/frappe/public/js/frappe/scanner/index.js
@@ -97,6 +97,6 @@ frappe.ui.Scanner = class Scanner {
 	}
 
 	load_lib() {
-		return frappe.require("/assets/frappe/node_modules/html5-qrcode/html5-qrcode.min.js");
+		return Promise.resolve();
 	}
 };


### PR DESCRIPTION
resolve issue arise due to https://github.com/frappe/frappe/pull/33973

<img width="1275" height="513" alt="Screenshot 2025-11-23 140209" src="https://github.com/user-attachments/assets/5acdc438-1787-40e7-beb3-d0f58eeb1ac8" />
