### PR TITLE
fix: show rows number copied to clipboard

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2412,7 +2412,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 							.join("\t");
 					});
 					const clipboard_data = [headers, ...rows].join("\n"); // Copy to clipboard
-					frappe.utils.copy_to_clipboard(clipboard_data);
+					const message = __("Copied {0} rows to clipboard", [selected_items.length]);
+					frappe.utils.copy_to_clipboard(clipboard_data, message);
 				},
 				standard: true,
 			};


### PR DESCRIPTION
Following https://github.com/frappe/frappe/pull/34836
Using https://github.com/frappe/frappe/pull/34839

<img width="1268" height="912" alt="image" src="https://github.com/user-attachments/assets/69b2ca94-631d-44c0-914e-3a5621a78ac6" />

