### PR TITLE
fix: stop validation when click pervious btn

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -103,10 +103,6 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		$(".web-form-footer .left-area").prepend(this.$previous_button);
 
 		this.$previous_button.on("click", () => {
-			// let is_validated = me.validate_section();
-
-			// if (!is_validated) return false;
-
 			/**
 				The eslint utility cannot figure out if this is an infinite loop in backwards and
 				throws an error. Disabling for-direction just for this section.

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -103,9 +103,9 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		$(".web-form-footer .left-area").prepend(this.$previous_button);
 
 		this.$previous_button.on("click", () => {
-			let is_validated = me.validate_section();
+			// let is_validated = me.validate_section();
 
-			if (!is_validated) return false;
+			// if (!is_validated) return false;
 
 			/**
 				The eslint utility cannot figure out if this is an infinite loop in backwards and


### PR DESCRIPTION
When clicking the 'Previous' button in the web form, there is no need to trigger full form validation on this action