### PR TITLE
feat: add ability to disable new product suggestion

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -96,6 +96,7 @@
   "disable_system_update_notification",
   "disable_change_log_notification",
   "hide_empty_read_only_fields",
+  "disable_product_suggestion",
   "backups_tab",
   "sec_backup_limit",
   "backup_limit",
@@ -770,12 +771,18 @@
   {
    "fieldname": "column_break_bzfr",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_product_suggestion",
+   "fieldtype": "Check",
+   "label": "Disable Product Suggestion"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2025-11-04 16:47:54.230874",
+ "modified": "2025-11-23 13:17:57.577690",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -43,6 +43,7 @@ class SystemSettings(Document):
 		deny_multiple_sessions: DF.Check
 		disable_change_log_notification: DF.Check
 		disable_document_sharing: DF.Check
+		disable_product_suggestion: DF.Check
 		disable_standard_email_footer: DF.Check
 		disable_system_update_notification: DF.Check
 		disable_user_pass_login: DF.Check

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -198,7 +198,7 @@ frappe.ui.form.PrintView = class {
 		this.setup_customize_dialog();
 
 		// print designer link
-		if (frappe.boot.sysdefaults.disable_product_suggestion !== "1") {
+		if (!cint(frappe.boot.sysdefaults.disable_product_suggestion)) {
 			if (Object.keys(frappe.boot.versions).includes("print_designer")) {
 				this.page.add_inner_message(`
 				<a style="line-height: 2.4" href="/app/print-designer?doctype=${this.frm.doctype}">

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -198,18 +198,20 @@ frappe.ui.form.PrintView = class {
 		this.setup_customize_dialog();
 
 		// print designer link
-		if (Object.keys(frappe.boot.versions).includes("print_designer")) {
-			this.page.add_inner_message(`
-			<a style="line-height: 2.4" href="/app/print-designer?doctype=${this.frm.doctype}">
-				${__("Try the new Print Designer")}
-			</a>
-			`);
-		} else {
-			this.page.add_inner_message(`
-			<a style="line-height: 2.4" href="https://frappecloud.com/marketplace/apps/print_designer?utm_source=framework-desk&utm_medium=print-view&utm_campaign=try-link">
-				${__("Try the new Print Designer")}
-			</a>
-			`);
+		if (frappe.boot.sysdefaults.disable_product_suggestion !== "1") {
+			if (Object.keys(frappe.boot.versions).includes("print_designer")) {
+				this.page.add_inner_message(`
+				<a style="line-height: 2.4" href="/app/print-designer?doctype=${this.frm.doctype}">
+					${__("Try the new Print Designer")}
+				</a>
+				`);
+			} else {
+				this.page.add_inner_message(`
+				<a style="line-height: 2.4" href="https://frappecloud.com/marketplace/apps/print_designer?utm_source=framework-desk&utm_medium=print-view&utm_campaign=try-link">
+					${__("Try the new Print Designer")}
+				</a>
+				`);
+			}
 		}
 		let tasks = [
 			this.set_default_print_format,

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -294,7 +294,7 @@ frappe.views.ListSidebar = class ListSidebar {
 	}
 
 	add_insights_banner() {
-		if (frappe.boot.sysdefaults.disable_product_suggestion == "1") {
+		if (cint(frappe.boot.sysdefaults.disable_product_suggestion)) {
 			return;
 		}
 
@@ -313,7 +313,7 @@ frappe.views.ListSidebar = class ListSidebar {
 	}
 
 	add_crm_banner() {
-		if (frappe.boot.sysdefaults.disable_product_suggestion == "1") {
+		if (cint(frappe.boot.sysdefaults.disable_product_suggestion)) {
 			return;
 		}
 
@@ -329,7 +329,7 @@ frappe.views.ListSidebar = class ListSidebar {
 	}
 
 	add_helpdesk_banner() {
-		if (frappe.boot.sysdefaults.disable_product_suggestion == "1") {
+		if (cint(frappe.boot.sysdefaults.disable_product_suggestion)) {
 			return;
 		}
 

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -294,6 +294,10 @@ frappe.views.ListSidebar = class ListSidebar {
 	}
 
 	add_insights_banner() {
+		if (frappe.boot.sysdefaults.disable_product_suggestion == "1") {
+			return;
+		}
+
 		if (this.list_view.view != "Report") {
 			return;
 		}
@@ -309,6 +313,10 @@ frappe.views.ListSidebar = class ListSidebar {
 	}
 
 	add_crm_banner() {
+		if (frappe.boot.sysdefaults.disable_product_suggestion == "1") {
+			return;
+		}
+
 		if (this.list_view.meta.module != "CRM" || this.list_view.view != "List") {
 			return;
 		}
@@ -321,6 +329,10 @@ frappe.views.ListSidebar = class ListSidebar {
 	}
 
 	add_helpdesk_banner() {
+		if (frappe.boot.sysdefaults.disable_product_suggestion == "1") {
+			return;
+		}
+
 		if (this.list_view.meta.module != "Support" || this.list_view.view != "List") {
 			return;
 		}


### PR DESCRIPTION
Sometimes we need to hide this kind of messages for users.


**Before**

<img width="1412" height="909" alt="image" src="https://github.com/user-attachments/assets/c3be249d-ede2-4fd8-bae1-754319543221" />

<img width="1390" height="905" alt="image" src="https://github.com/user-attachments/assets/4d3e3d97-887e-40b7-b31f-6a32c0ccb9f4" />




**After**

<img width="1434" height="815" alt="image" src="https://github.com/user-attachments/assets/53d43ec4-c90c-4d20-a4f2-56e573007cfa" />

<img width="1441" height="843" alt="image" src="https://github.com/user-attachments/assets/c65b96bc-8730-4a23-b9f1-57fe2d3bb887" />

<img width="1445" height="904" alt="image" src="https://github.com/user-attachments/assets/205db8f0-0d01-458c-9bba-4a594b9767f6" />


Handled CRM and Helpdesk product advertisement too.
Since we are using system settings for disable this, think is a balanced option.


`no-docs`
