### PR TITLE
fix: check document-level permissions in validate_link

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -417,12 +417,9 @@ def validate_link(doctype: str, docname: str, fields=None):
 		frappe.throw(_("Document Name must be a string"))
 
 	if doctype != "DocType":
-		parent_doctype = None
-		if frappe.get_meta(doctype).istable:  # needed for links to child rows
-			parent_doctype = frappe.db.get_value(doctype, docname, "parenttype")
 		if not (
-			frappe.has_permission(doctype, "select", parent_doctype=parent_doctype)
-			or frappe.has_permission(doctype, "read", parent_doctype=parent_doctype)
+			frappe.has_permission(doctype, "select", doc=docname)
+			or frappe.has_permission(doctype, "read", doc=docname)
 		):
 			frappe.throw(
 				_("You do not have Read or Select Permissions for {}").format(frappe.bold(doctype)),


### PR DESCRIPTION
 ### Description

  Fixes security issue where `validate_link()` bypassed document-level User Permissions when users manually type into Link
  fields.

  **Problem:**
  - Only checked DocType-level Role Permissions
  - Did NOT check document-level User Permissions
  - Security risk: users could validate links to restricted documents

  **Solution:**
  - Pass `doc=docname` to `has_permission()` calls
  - Checks both Role + User Permissions
  - Removes redundant `parent_doctype` fetching

  **Why `parent_doctype` removal is safe:**

  `has_permission()` with `doc=docname` automatically handles child tables:
  - Detects child table ([permissions.py:120](https://github.com/frappe/frappe/blob/develop/frappe/permissions.py#L120))
  - Fetches parent info internally 
  ([permissions.py:797-805](https://github.com/frappe/frappe/blob/develop/frappe/permissions.py#L797-L805))
  - Overwrites any external `parent_doctype` parameter with DB value 
  ([permissions.py:805](https://github.com/frappe/frappe/blob/develop/frappe/permissions.py#L805))

  Result: 1 DB query instead of 2 (more efficient).

  ### Addresses Reviewer Feedback

  This PR addresses @sagarvora's feedback from the reverted PR #34064:

  ✅ **Fixed:** Check read OR select (not just read)
  ✅ **Fixed:** Avoid double perm checks by passing `doc=docname` directly

  ❓ **Question:** [`ignore_user_permissions`](https://github.com/frappe/frappe/pull/34064#discussion_r2428510625) was mentioned
   in the revert but was never part of the original code. Should I add it  ?

  cc: @sagarvora @iamejaaz

  ### Related
  - Addresses feedback from reverted PR #34064
  - Closes #34063
