### PR TITLE
fix: better system settings layout

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -95,8 +95,11 @@
   "system_updates_section",
   "disable_system_update_notification",
   "disable_change_log_notification",
+  "column_break_ncjm",
   "hide_empty_read_only_fields",
   "disable_product_suggestion",
+  "column_break_yaxd",
+  "column_break_rbsx",
   "backups_tab",
   "sec_backup_limit",
   "backup_limit",
@@ -777,12 +780,24 @@
    "fieldname": "disable_product_suggestion",
    "fieldtype": "Check",
    "label": "Disable Product Suggestion"
+  },
+  {
+   "fieldname": "column_break_ncjm",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_yaxd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_rbsx",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2025-11-23 13:17:57.577690",
+ "modified": "2025-11-24 15:57:24.227252",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",


### PR DESCRIPTION
After https://github.com/frappe/frappe/pull/34849

Now looks this way ...
<img width="1670" height="814" alt="image" src="https://github.com/user-attachments/assets/ada8548c-791f-4b24-9140-3165fde17dd2" />

@NagariaHussain @iamejaaz For this I left 2 empty column break. Looks better.

Alternative:
<img width="1679" height="807" alt="image" src="https://github.com/user-attachments/assets/c3f0e67b-213f-4519-812b-10f90a41f876" />


