### PR TITLE
fix: pluralize/unpluralize rows number message

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2412,7 +2412,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 							.join("\t");
 					});
 					const clipboard_data = [headers, ...rows].join("\n"); // Copy to clipboard
-					const message = __("Copied {0} rows to clipboard", [selected_items.length]);
+					const message = __("Copied {0} {1} to clipboard", [
+						selected_items.length,
+						selected_items.length === 1 ? __("row") : __("rows"),
+					]);
 					frappe.utils.copy_to_clipboard(clipboard_data, message);
 				},
 				standard: true,


### PR DESCRIPTION
Inspired by @NagariaHussain 😉 
Follow https://github.com/frappe/frappe/pull/34845

before

<img width="1525" height="918" alt="image" src="https://github.com/user-attachments/assets/aa05437c-81ea-4fd8-9e7f-d9efe61219ff" />

after

<img width="1506" height="875" alt="image" src="https://github.com/user-attachments/assets/be4ef7ee-add2-4e58-84f1-42397a97650b" />
