### PR TITLE
refactor(address_query): enhance function signature with type hints and default parameters

### DIFF
--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -262,8 +262,18 @@ def get_company_address(company):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def address_query(doctype, txt, searchfield, start, page_len, filters):
+def address_query(
+	doctype: str = "Address",
+	txt: str = "",
+	searchfield: str = "name",
+	start: int = 0,
+	page_len: int = 10,
+	filters: dict | None = None,
+):
 	from frappe.desk.search import search_widget
+
+	if not filters:
+		filters = {}
 
 	_filters = []
 	if link_doctype := filters.pop("link_doctype", None):

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -263,6 +263,9 @@ def get_company_address(company):
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def address_query(
+	# The `doctype` parameter is required for API compatibility with the
+	# `@frappe.validate_and_sanitize_search_inputs` decorator, but is not used in this function.
+	# The function is hardcoded to operate on the "Address" doctype.
 	doctype: str = "Address",
 	txt: str = "",
 	searchfield: str = "name",


### PR DESCRIPTION
Calling queries like this one is tedious, because we need to explicitly set a ton of parameters that often have sane defaults. By providing default parameters and type hints, they become much easier to reuse.

Before:

```
GET /api/method/frappe.contacts.doctype.address.address.address_query?doctype=Address&txt=&searchfield=name&start=0&page_len=10&filters={}
```

After:

```
GET /api/method/frappe.contacts.doctype.address.address.address_query
```

If this seems acceptable, I'd like to apply the same change to other queries as well.
