### PR TITLE
refactor(test_search): foreign language search tests

### DIFF
--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -243,17 +243,21 @@ def custom_translation(language: str, source_text: str, translated_text: str):
 	doc.translated_text = translated_text
 	doc.save()
 
-	yield
-
-	doc.delete()
+	try:
+		yield
+	finally:
+		doc.delete()
 
 
 @contextmanager
 def use_language(language: str):
 	original_lang = frappe.local.lang
 	frappe.local.lang = language
-	yield
-	frappe.local.lang = original_lang
+
+	try:
+		yield
+	finally:
+		frappe.local.lang = original_lang
 
 
 def teardown_test_link_field_order(TestCase):

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import re
+from contextlib import contextmanager
 from functools import partial
 
 import frappe
@@ -78,16 +79,13 @@ class TestSearch(IntegrationTestCase):
 		# Check whether searching for parent also list out children
 		self.assertEqual(len(results), len(self.child_doctypes_names) + 1)
 
-	# Search for the word "pay", part of the word "pays" (country) in french.
 	def test_link_search_in_foreign_language(self):
-		try:
-			frappe.local.lang = "fr"
+		with custom_translation("fr", "Country", "Pays"), use_language("fr"):
 			output = search_widget(doctype="DocType", txt="pay", page_length=20)
-
-			result = [["found" for x in y if x == "Country"] for y in output]
-			self.assertTrue(["found"] in result)
-		finally:
-			frappe.local.lang = "en"
+			results = [result[0] for result in output]
+			self.assertIn(
+				"Country", results, "Search results for 'pay' in French should include 'Country' ('Pays')"
+			)
 
 	def test_doctype_search_in_foreign_language(self):
 		def do_search(txt: str):
@@ -100,20 +98,16 @@ class TestSearch(IntegrationTestCase):
 				searchfield=None,
 			)
 
-		try:
-			frappe.local.lang = "en"
-			results = do_search("user")
-			self.assertIn("User", [x["value"] for x in results])
+		results = do_search("user")
+		self.assertIn("User", [x["value"] for x in results])
 
-			frappe.local.lang = "fr"
+		with custom_translation("fr", "User", "Utilisateur"), use_language("fr"):
 			results = do_search("utilisateur")
 			self.assertIn("User", [x["value"] for x in results])
 
-			frappe.local.lang = "de"
+		with custom_translation("de", "User", "Nutzer"), use_language("de"):
 			results = do_search("nutzer")
 			self.assertIn("User", [x["value"] for x in results])
-		finally:
-			frappe.local.lang = "en"
 
 	def test_validate_and_sanitize_search_inputs(self):
 		# should raise error if searchfield is injectable
@@ -233,6 +227,27 @@ def setup_test_link_field_order(TestCase):
 			}
 		).insert(ignore_if_duplicate=True)
 		TestCase.child_doctype_list.append(temp)
+
+
+@contextmanager
+def custom_translation(language: str, source_text: str, translated_text: str):
+	doc = frappe.new_doc("Translation")
+	doc.language = language
+	doc.source_text = source_text
+	doc.translated_text = translated_text
+	doc.save()
+
+	yield
+
+	doc.delete()
+
+
+@contextmanager
+def use_language(language: str):
+	original_lang = frappe.local.lang
+	frappe.local.lang = language
+	yield
+	frappe.local.lang = original_lang
 
 
 def teardown_test_link_field_order(TestCase):

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -89,7 +89,7 @@ class TestSearch(IntegrationTestCase):
 
 	def test_doctype_search_in_foreign_language(self):
 		def do_search(txt: str):
-			return search_link(
+			results = search_link(
 				doctype="DocType",
 				txt=txt,
 				query="frappe.core.report.permitted_documents_for_user.permitted_documents_for_user.query_doctypes",
@@ -97,17 +97,23 @@ class TestSearch(IntegrationTestCase):
 				page_length=20,
 				searchfield=None,
 			)
+			return [x["value"] for x in results]
 
-		results = do_search("user")
-		self.assertIn("User", [x["value"] for x in results])
+		self.assertIn("User", do_search("user"))
 
 		with custom_translation("fr", "User", "Utilisateur"), use_language("fr"):
-			results = do_search("utilisateur")
-			self.assertIn("User", [x["value"] for x in results])
+			self.assertIn(
+				"User",
+				do_search("utilisateur"),
+				"Search results for 'utilisateur' in French should include 'User' ('Utilisateur')",
+			)
 
 		with custom_translation("de", "User", "Nutzer"), use_language("de"):
-			results = do_search("nutzer")
-			self.assertIn("User", [x["value"] for x in results])
+			self.assertIn(
+				"User",
+				do_search("nutzer"),
+				"Search results for 'nutzer' in German should include 'User' ('Nutzer')",
+			)
 
 	def test_validate_and_sanitize_search_inputs(self):
 		# should raise error if searchfield is injectable


### PR DESCRIPTION
- Create custom **Translation** records to ensure the needed translations are present, no matter what happens to translation files.
- Use context managers for creating translations and setting the language.
