### PR TITLE
fix: order by for sqlite in search_widget

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -179,7 +179,7 @@ def search_widget(
 		_relevance_expr = {"DIV": [1, {"NULLIF": [{"LOCATE": [_txt, "name"]}, 0]}]}
 
 		# For MariaDB, wrap in IFNULL for sorting to push nulls to end
-		if frappe.db.db_type == "mariadb":
+		if frappe.db.db_type in ("mariadb", "sqlite"):
 			_relevance = {"IFNULL": [_relevance_expr, -9999], "as": "_relevance"}
 			formatted_fields.append(_relevance)
 			order_by = f"_relevance desc, {order_by}"


### PR DESCRIPTION
fixes this error for sqlite which I faced during module search during DocType creation:
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 61, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 52, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1127, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/desk/search.py", line 57, in search_link
    return build_for_autosuggest(results, doctype=doctype)
  File "apps/frappe/frappe/desk/search.py", line 286, in build_for_autosuggest
    results.extend({"value": item[0], "description": to_string(item[1:])} for item in res)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/search.py", line 286, in <genexpr>
    results.extend({"value": item[0], "description": to_string(item[1:])} for item in res)
                             ~~~~^^^
IndexError: tuple index out of range

```
<img width="774" height="269" alt="image" src="https://github.com/user-attachments/assets/80d9d3da-1650-4881-9cfa-15854cce906f" />
