### PR TITLE
fix: all redis databases being flushed after bench build

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -262,7 +262,7 @@ def bundle(
 	frappe.commands.popen(command, cwd=frappe_app_path, env=get_node_env(), raise_err=True)
 
 	with suppress(Exception):
-		frappe.cache.flushall()
+		frappe.cache.flushdb()
 
 
 def watch(apps=None):


### PR DESCRIPTION
Frappe flushes all Redis databases after a bench build, but if it really needs to, it should only flush the assigned database using `FLUSHDB`.

Is this flushing even required? I’m pretty sure many installations rely on the frappe redis DB, and a bench build (asset build) should not clear the entire database, not even the assigned one.

If it’s really required, best would be to identify keys / prefix that needs to be cleared.

Ref #34859 
Ref #29878