### PR TITLE
fix(Table MultiSelect): support creating new linked doc and trigger events reliably

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -184,8 +184,12 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		frappe.route_options.name_field = this.get_label_value();
 
 		// reference to calling link
-		frappe._from_link = frappe.utils.deep_clone(this);
-		frappe._from_link_scrollY = $(document).scrollTop();
+		frappe._from_link = {
+			field_obj: this,
+			from_doctype: this.doctype,
+			from_docname: this.doc?.name,
+			scrollY: $(document).scrollTop(),
+		};
 
 		frappe.ui.form.make_quick_entry(doctype, (doc) => {
 			return me.set_value(doc.name);

--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -12,7 +12,7 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 		});
 
 		// used as an internal model to store values
-		this.rows = this.frm?.doc[this.df.fieldname] || [];
+		this.rows = this._get_rows() || [];
 		// used as an internal model to filter awesomplete values
 		this._rows_list = [];
 
@@ -28,33 +28,32 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 
 			const value = decodeURIComponent($value.data().value);
 			const link_field = this.get_link_field();
-			this.rows = this.rows.filter((row) => {
-				if (row[link_field.fieldname] !== value) {
-					return row;
-				} else {
-					frappe.run_serially([
-						() => {
-							return this.frm.script_manager.trigger(
-								`before_${this.df.fieldname}_remove`,
-								this.df.options,
-								row.name
-							);
-						},
-						() => {
-							frappe.model.clear_doc(this.df.options, row.name);
+			const rows = this._get_rows().filter((row) => {
+				if (row[link_field.fieldname] !== value) return row;
 
-							this.frm.dirty();
-							this.refresh();
+				frappe.run_serially([
+					() => {
+						return this.frm?.script_manager.trigger(
+							`before_${this.df.fieldname}_remove`,
+							this.df.options,
+							row.name
+						);
+					},
+					() => {
+						frappe.model.clear_doc(this.df.options, row.name);
 
-							return this.frm.script_manager.trigger(
-								`${this.df.fieldname}_remove`,
-								this.df.options,
-								row.name
-							);
-						},
-					]);
-				}
+						this.frm?.dirty();
+						this.refresh();
+
+						return this.frm?.script_manager.trigger(
+							`${this.df.fieldname}_remove`,
+							this.df.options,
+							row.name
+						);
+					},
+				]);
 			});
+			this._update_rows(rows);
 		});
 		this.$input_area.on("click", ".btn-link-to-form", (e) => {
 			const $target = $(e.currentTarget);
@@ -67,61 +66,60 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 		this.$input.on("keydown", (e) => {
 			// if backspace key pressed on empty input, delete last value
 			if (e.keyCode == frappe.ui.keyCode.BACKSPACE && e.target.value === "") {
-				this.rows = this.rows.slice(0, this.rows.length - 1);
-				this.parse_validate_and_set_in_model("");
+				const rows = this._get_rows().slice(0, -1);
+				this.parse_validate_and_set_in_model(rows);
 			}
 		});
+	}
+	_get_rows() {
+		return this.get_model_value() || this.rows;
+	}
+	_update_rows(rows) {
+		this.rows = rows;
+
+		const link_fieldname = this.get_link_field().fieldname;
+		this._rows_list = rows.map((row) => row[link_fieldname]);
+
+		return rows;
 	}
 	setup_buttons() {
 		this.$input_area.find(".link-btn").remove();
 	}
 	parse(value) {
-		if (typeof value == "object" || !this.rows) {
+		let rows = this._get_rows();
+
+		if (typeof value == "object" || !rows) {
 			return value;
 		}
 
 		const link_field = this.get_link_field();
 		value = value?.trim();
-		if (!value) return this.rows;
+		if (!value) return rows;
 
 		// clear input to prevent multiple additions
 		this.set_input_value("");
 
+		let new_row;
 		if (this.frm) {
-			// ⚠️ we are setting the model value earlier
-			// it will need to be removed if validation fails.
-			const new_row = frappe.model.add_child(
-				this.frm.doc,
-				this.df.options,
-				this.df.fieldname
-			);
+			new_row = frappe.model.add_child(this.frm.doc, this.df.options, this.df.fieldname);
 			new_row[link_field.fieldname] = value;
-			this.rows = this.frm.doc[this.df.fieldname];
+
+			// to ensure we pop from the correct rows array
+			rows = this.get_model_value();
+			rows.pop();
 		} else {
-			this.rows.push({
+			new_row = {
 				[link_field.fieldname]: value,
-			});
+			};
 		}
 
-		return this.rows;
-	}
-	get_model_value() {
-		let value = super.get_model_value();
-		return value ? value.filter((d) => !d.__islocal) : value;
-	}
-	_update_rows(rows) {
-		this.rows = this.frm?.doc[this.df.fieldname] || rows;
-
-		const link_fieldname = this.get_link_field().fieldname;
-		this._rows_list = this.rows.map((row) => row[link_fieldname]);
-
-		return rows;
+		return [...rows, new_row];
 	}
 	async validate(value) {
 		const rows = (value || []).slice();
 
 		if (rows.length === 0) {
-			return this._update_rows(rows);
+			return rows;
 		}
 
 		const all_rows_except_last = rows.slice(0, rows.length - 1);
@@ -136,33 +134,39 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 			frappe.utils.is_empty(link_value) ||
 			all_rows_except_last.map((row) => row[link_field.fieldname]).includes(link_value)
 		) {
-			// model value may already be set in parse
-			frappe.model.clear_doc(last_row.doctype, last_row.name);
-			return this._update_rows(all_rows_except_last);
+			return all_rows_except_last;
 		}
 
 		if (!this.df.ignore_link_validation) {
 			const validated_value = await this.validate_link_and_fetch(link_value);
 			if (frappe.utils.is_empty(validated_value)) {
-				// model value may already be set in parse
-				frappe.model.clear_doc(last_row.doctype, last_row.name);
-				return this._update_rows(all_rows_except_last);
+				return all_rows_except_last;
 			}
 			last_row[link_field.fieldname] = validated_value;
 		}
 
-		// trigger row added event
-		this.frm?.script_manager.trigger(
-			`${this.df.fieldname}_add`,
-			this.df.options,
-			last_row.name
-		);
-		return this._update_rows(rows);
+		return rows;
+	}
+	async set_model_value(value) {
+		const old_length = this._get_rows()?.length || 0;
+		const new_length = value?.length || 0;
+		const result = super.set_model_value(...arguments);
+		this._update_rows(value);
+
+		if (new_length - old_length === 1 && this.frm) {
+			// trigger add event only if one row is added
+			const new_row = value[value.length - 1];
+			await this.frm.script_manager.trigger(
+				`${this.df.fieldname}_add`,
+				this.df.options,
+				new_row.name
+			);
+		}
+		return result;
 	}
 	set_formatted_input(value) {
-		this.rows = value || [];
 		const link_field = this.get_link_field();
-		const values = this.rows.map((row) => row[link_field.fieldname]);
+		const values = (value || []).map((row) => row[link_field.fieldname]);
 		this.set_pill_html(values);
 	}
 	set_pill_html(values) {

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -244,68 +244,62 @@ frappe.ui.form.remove_old_form_route = () => {
 	);
 };
 
-frappe.ui.form.update_calling_link = (newdoc) => {
+frappe.ui.form.update_calling_link = async (newdoc) => {
 	if (!frappe._from_link) return;
-	var doc = frappe.get_doc(frappe._from_link.doctype, frappe._from_link.docname);
 
-	let is_valid_doctype = () => {
-		if (frappe._from_link.df.fieldtype === "Link") {
-			return newdoc.doctype === frappe._from_link.df.options;
-		} else {
-			// dynamic link, type is dynamic
-			return newdoc.doctype === doc[frappe._from_link.df.options];
+	const { field_obj, from_doctype, from_docname, scrollY } = frappe._from_link;
+	const df = field_obj.df;
+
+	if (!["Link", "Dynamic Link", "Table MultiSelect"].includes(df.fieldtype)) return;
+
+	const doc = frappe.get_doc(from_doctype, from_docname);
+
+	const is_valid_doctype = () => {
+		switch (df.fieldtype) {
+			case "Link":
+				return newdoc.doctype === df.options;
+			case "Dynamic Link":
+				return newdoc.doctype === doc[df.options];
+			case "Table MultiSelect":
+				return newdoc.doctype === field_obj.get_options();
 		}
 	};
 
-	if (is_valid_doctype()) {
-		frappe.model.with_doctype(newdoc.doctype, () => {
-			let meta = frappe.get_meta(newdoc.doctype);
-			// set value
-			if (doc && doc.parentfield) {
-				//update values for child table
-				$.each(
-					frappe._from_link.frm.fields_dict[doc.parentfield].grid.grid_rows,
-					function (index, field) {
-						if (field.doc && field.doc.name === frappe._from_link.docname) {
-							if (meta.title_field && meta.show_title_field_in_link) {
-								frappe.utils.add_link_title(
-									newdoc.doctype,
-									newdoc.name,
-									newdoc[meta.title_field]
-								);
-							}
-							frappe._from_link.set_value(newdoc.name);
-						}
-					}
-				);
-			} else {
-				if (meta.title_field && meta.show_title_field_in_link) {
-					frappe.utils.add_link_title(
-						newdoc.doctype,
-						newdoc.name,
-						newdoc[meta.title_field]
-					);
-				}
-				frappe._from_link.set_value(newdoc.name);
-			}
+	if (!is_valid_doctype()) return;
 
-			// refresh field
-			frappe._from_link.refresh();
-
-			// if from form, switch
-			if (frappe._from_link.frm) {
-				frappe
-					.set_route(
-						"Form",
-						frappe._from_link.frm.doctype,
-						frappe._from_link.frm.docname
-					)
-					.then(() => {
-						frappe.utils.scroll_to(frappe._from_link_scrollY);
-					});
-			}
-
-			frappe._from_link = null;
-		});
+	// switch back to the original doc first,
+	// this is necessary in case from_link.doctype === newdoc.doctype
+	if (field_obj.frm) {
+		await frappe.set_route("Form", from_doctype, from_docname);
+		frappe.utils.scroll_to(scrollY);
 	}
+
+	delete frappe._from_link;
+
+	await frappe.model.with_doctype(newdoc.doctype);
+	const meta = frappe.get_meta(newdoc.doctype);
+
+	// update link title cache
+	if (meta.title_field && meta.show_title_field_in_link) {
+		frappe.utils.add_link_title(newdoc.doctype, newdoc.name, newdoc[meta.title_field]);
+	}
+
+	// set value
+	if (doc && doc.parentfield) {
+		//update values for child table
+		$.each(
+			field_obj.frm.fields_dict[doc.parentfield].grid.grid_rows,
+			function (_index, field) {
+				if (field.doc && field.doc.name === from_docname) {
+					field_obj.set_value(newdoc.name);
+				}
+			}
+		);
+	} else {
+		// parsing is needed for table multiselect to convert string to array
+		field_obj.parse_validate_and_set_in_model(newdoc.name);
+	}
+
+	// refresh field
+	field_obj.refresh();
 };

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -3,7 +3,6 @@
 
 import deep_equal from "fast-deep-equal";
 import number_systems from "./number_systems";
-import cloneDeepWith from "lodash/cloneDeepWith";
 
 frappe.provide("frappe.utils");
 
@@ -1020,10 +1019,6 @@ Object.assign(frappe.utils, {
 
 	deep_equal(a, b) {
 		return deep_equal(a, b);
-	},
-
-	deep_clone(obj, customizer) {
-		return cloneDeepWith(obj, customizer);
 	},
 
 	file_name_ellipsis(filename, length) {


### PR DESCRIPTION
https://github.com/user-attachments/assets/8aa38feb-5994-4a19-9d37-7fda8b4d0cee

## Problem
When creating a new document from a Table MultiSelect field's "Create new" option, `update_calling_link` didn't support Table MultiSelect fields. This meant:
1. The newly created doc wasn't added to the Table MultiSelect field
2. The `{fieldname}_add` event wasn't triggered

Additionally, the `_add` event was triggered in `parse()` which could fire before the value was actually set in the model.

## Solution

### 1. Support Table MultiSelect in `update_calling_link`
- Store `field_obj` reference instead of deep cloning the control (while preserving needed properties)
- Add Table MultiSelect to the supported fieldtypes validation
- Route back to original form **before** setting value (ensure that self-linking doctype case where the form object is reused works. ref: #18330)

### 2. Reliable event triggering
- Move `{fieldname}_add` event trigger from `parse()` to `set_model_value()`
- Event now fires after the value is confirmed in the model

### 3. Refactor Table MultiSelect internals
- Use `_get_rows()` consistently to get rows from model as source of truth
- Simplify `parse()` to return the new rows array without side effects
- Remove manual `this.frm.doc[fieldname]` sync (model handles this)

### 4. Cleanup (mildly breaking)
- Remove unused `frappe.utils.deep_clone` utility and `lodash/cloneDeepWith` import (this import was actually not in our package.json - was a dependency of a dependency)

`no-docs`