### PR TITLE
fix: use number format from currency if defined

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -895,29 +895,30 @@ def get_field_currency(df, doc=None):
 
 def get_field_precision(df, doc=None, currency=None):
 	"""get precision based on DocField options and fieldvalue in doc"""
-	from frappe.locale import get_number_format
-	from frappe.utils.number_format import NumberFormat
-
 	if df.precision:
 		precision = cint(df.precision)
 
 	elif df.fieldtype == "Currency":
 		precision = cint(frappe.db.get_default("currency_precision"))
 		if not precision:
-			use_format_from_currency = frappe.get_system_settings("use_number_format_from_currency")
-			number_format = get_number_format()
-			if use_format_from_currency:
-				currency_format = frappe.db.get_value(
-					"Currency", currency or get_field_currency(df, doc), "number_format", cache=True
-				)
-				number_format = (
-					NumberFormat.from_string(currency_format) if currency_format else number_format
-				)
-			precision = number_format.precision
+			precision = get_precision_from_currency_format(currency or get_field_currency(df, doc))
 	else:
 		precision = cint(frappe.db.get_default("float_precision")) or 3
 
 	return precision
+
+
+def get_precision_from_currency_format(currency: str) -> int:
+	"""Get precision from currency format string if applicable."""
+	from frappe.locale import get_number_format
+	from frappe.utils.number_format import NumberFormat
+
+	use_format_from_currency = frappe.get_system_settings("use_number_format_from_currency")
+	number_format = get_number_format()
+	if use_format_from_currency:
+		currency_format = frappe.db.get_value("Currency", currency, "number_format", cache=True)
+		number_format = NumberFormat.from_string(currency_format) if currency_format else number_format
+	return number_format.precision
 
 
 def get_default_df(fieldname):

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -896,6 +896,7 @@ def get_field_currency(df, doc=None):
 def get_field_precision(df, doc=None, currency=None):
 	"""get precision based on DocField options and fieldvalue in doc"""
 	from frappe.locale import get_number_format
+	from frappe.utils.number_format import NumberFormat
 
 	if df.precision:
 		precision = cint(df.precision)
@@ -903,7 +904,15 @@ def get_field_precision(df, doc=None, currency=None):
 	elif df.fieldtype == "Currency":
 		precision = cint(frappe.db.get_default("currency_precision"))
 		if not precision:
+			use_format_from_currency = frappe.get_system_settings("use_number_format_from_currency")
 			number_format = get_number_format()
+			if use_format_from_currency:
+				currency_format = frappe.db.get_value(
+					"Currency", currency or get_field_currency(df, doc), "number_format", cache=True
+				)
+				number_format = (
+					NumberFormat.from_string(currency_format) if currency_format else number_format
+				)
 			precision = number_format.precision
 	else:
 		precision = cint(frappe.db.get_default("float_precision")) or 3


### PR DESCRIPTION
### Problem

Number format from currency was not being used for getting the precision even if enabled from System Settings. It was only being used in the frontend (JS side). This in turn caused the formatting of the currency to be incorrect.

### Solution 

Check for number format in currency if available

Ref: https://support.frappe.io/helpdesk/tickets/50937?view=VIEW-HD+Ticket-805