### PR TITLE
fix: table multiselect validation flow

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -128,10 +128,10 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		this.set_input_value(translated_link_text);
 	}
 	parse_validate_and_set_in_model(value, e, label) {
-		if (this.parse) value = this.parse(value, label);
+		if (this.parse) value = this.parse(value);
 		if (label) {
 			this.label = this.get_translated(label);
-			frappe.utils.add_link_title(this.df.options, value, label);
+			frappe.utils.add_link_title(this.get_options(), value, label);
 		}
 
 		return this.validate_and_set_in_model(value, e);


### PR DESCRIPTION
Fixes validation flow issues from #33443 (XSS mitigation for #32470).

**Changes:**
- Clear input immediately in parse() to prevent double-entry
- Properly cleanup model when validation fails
- Only trigger row_add event after successful validation
- Handle empty/duplicate values consistently

**Impact:**
- Maintains XSS protection while fixing manually entered valid values
- Better UX with immediate input clearing