### PR TITLE
fix: show same placeholder for awesomebar as the toolbar

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -161,7 +161,7 @@ class DesktopPage {
 		this.handke_route_change();
 	}
 	setup_avatar() {
-		$(".desktop-avatar").html(frappe.avatar(frappe.session.user, "avatar-medium"));
+		$(".desktop-avatar").html(frappe.avatar(frappe.session.user, "avatar-medium")).css("cursor", "pointer");
 		$(".desktop-avatar").data("menu", "user-menu");
 		let menu_items = [
 			{
@@ -197,6 +197,7 @@ class DesktopPage {
 	}
 
 	setup_awesomebar() {
+		$(".desktop-search-wrapper #navbar-search").attr("placeholder",`Search or type a command (${frappe.utils.is_mac() ? "⌘ + K" : "Ctrl + K"})`);
 		if (frappe.boot.desk_settings.search_bar) {
 			let awesome_bar = new frappe.search.AwesomeBar();
 			awesome_bar.setup(".desktop-search-wrapper #navbar-modal-search");

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -161,7 +161,7 @@ class DesktopPage {
 		this.handke_route_change();
 	}
 	setup_avatar() {
-		$(".desktop-avatar").html(frappe.avatar(frappe.session.user, "avatar-medium")).css("cursor", "pointer");
+		$(".desktop-avatar").html(frappe.avatar(frappe.session.user, "avatar-medium"));
 		$(".desktop-avatar").data("menu", "user-menu");
 		let menu_items = [
 			{
@@ -197,7 +197,10 @@ class DesktopPage {
 	}
 
 	setup_awesomebar() {
-		$(".desktop-search-wrapper #navbar-search").attr("placeholder",`Search or type a command (${frappe.utils.is_mac() ? "⌘ + K" : "Ctrl + K"})`);
+		$(".desktop-search-wrapper #navbar-search").attr(
+			"placeholder",
+			`Search or type a command (${frappe.utils.is_mac() ? "⌘ + K" : "Ctrl + K"})`
+		);
 		if (frappe.boot.desk_settings.search_bar) {
 			let awesome_bar = new frappe.search.AwesomeBar();
 			awesome_bar.setup(".desktop-search-wrapper #navbar-modal-search");


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

- fix the issue of cursor pointer not showing on avatar of the desktop page
- show the shortcut on placeholder of the awesome bar in desktop 

> Explain the **details** for making this change. What existing problem does the pull request solve?
- i have added the shortcut key on placeholder in awesome bar using js becouse it was giving issue directly in desktop jinja page

> Screenshots/GIFs
<img width="1353" height="725" alt="image" src="https://github.com/user-attachments/assets/a1d6d054-4728-4d8c-ac35-acbe48ff7fa5" />
