### PR TITLE
fix(sqlite): user_sync query was wrong

### DIFF
--- a/frappe/model/utils/user_settings.py
+++ b/frappe/model/utils/user_settings.py
@@ -57,8 +57,9 @@ def sync_user_settings():
 				"postgres": """INSERT INTO `__UserSettings` (`user`, `doctype`, `data`)
 				VALUES (%s, %s, %s)
 				ON CONFLICT ("user", "doctype") DO UPDATE SET `data`=%s""",
-				"sqlite": """INSERT OR REPLACE INTO `__UserSettings` (`user`, `doctype`, `data`)
-				VALUES (%s, %s, %s)""",
+				"sqlite": """INSERT INTO `__UserSettings` (`user`, `doctype`, `data`)
+				VALUES (%s, %s, %s)
+				ON CONFLICT (`user`, `doctype`) DO UPDATE SET `data`=%s""",
 			},
 			(user, doctype, data, data),
 			as_dict=1,


### PR DESCRIPTION
Adjust to use `ON CONFLICT` in a similar manner as the others

```
 File "apps/frappe/frappe/model/rename_doc.py", line 192, in rename_doc
    update_user_settings(old, new, link_fields)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/rename_doc.py", line 276, in update_user_settings
    sync_user_settings()
    ~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/model/utils/user_settings.py", line 52, in sync_user_settings
    frappe.db.multisql(
    ^^^^^^^^^^^^^^^^^^^
    ...<12 lines>...
    	as_dict=1,

  File "apps/frappe/frappe/database/database.py", line 1416, in multisql
    return self.sql(query, values, **kwargs)
           ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/sqlite/database.py", line 454, in sql
    return super().sql(*args, **kwargs)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 272, in sql
    self.execute_query(query, values)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/sqlite/database.py", line 443, in execute_query
    return self._cursor.execute(query, values or ())
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
sqlite3.ProgrammingError: Incorrect number of bindings supplied. The current statement uses 3, and there are 4 supplied.
```
