### PR TITLE
fix(ci): update pypdf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.1",
-    "pypdf~=6.1.3",
+    "pypdf==6.4.0",
     "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
     "mysqlclient==2.2.7",
     "PyQRCode~=1.2.1",


### PR DESCRIPTION
Read through https://github.com/py-pdf/pypdf/releases/tag/6.4.0
Nothing major has changed


Wanted to make CI green again

<hr>

Resolves https://github.com/advisories/GHSA-m449-cwjh-6pw7