### PR TITLE
fix(datetime): prevent false dirty flag from datetime precision mismatch

### DIFF
--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -41,8 +41,11 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 		if (should_refresh) {
 			// Prevent change event during programmatic update to avoid false dirty flags
 			this._setting_value = true;
-			this.datepicker.selectDate(frappe.datetime.str_to_obj(value));
-			this._setting_value = false;
+			try {
+				this.datepicker.selectDate(frappe.datetime.str_to_obj(value));
+			} finally {
+				this._setting_value = false;
+			}
 		}
 	}
 

--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -39,8 +39,19 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 		}
 
 		if (should_refresh) {
+			// Prevent change event during programmatic update to avoid false dirty flags
+			this._setting_value = true;
 			this.datepicker.selectDate(frappe.datetime.str_to_obj(value));
+			this._setting_value = false;
 		}
+	}
+
+	parse_validate_and_set_in_model(value, e) {
+		// Skip if we're programmatically setting the value (e.g., during form load)
+		if (this._setting_value) {
+			return Promise.resolve();
+		}
+		return super.parse_validate_and_set_in_model(value, e);
 	}
 	set_date_options() {
 		// webformTODO:

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -27,7 +27,10 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 			}
 		}
 		if (should_refresh) {
+			// Prevent change event during programmatic update to avoid false dirty flags
+			this._setting_value = true;
 			this.datepicker.selectDate(frappe.datetime.user_to_obj(value));
+			this._setting_value = false;
 		}
 	}
 
@@ -105,5 +108,14 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 			value = this.last_value;
 		}
 		return value || "";
+	}
+
+	parse_validate_and_set_in_model(value, e) {
+		// Skip if we're programmatically setting the value (e.g., during form load)
+		// This prevents false dirty flags from datetime precision mismatches
+		if (this._setting_value) {
+			return Promise.resolve();
+		}
+		return super.parse_validate_and_set_in_model(value, e);
 	}
 };

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -104,6 +104,6 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 		if (!value && !this.doc) {
 			value = this.last_value;
 		}
-		return !value ? "" : frappe.datetime.get_datetime_as_string(value);
+		return value || "";
 	}
 };

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -29,8 +29,11 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 		if (should_refresh) {
 			// Prevent change event during programmatic update to avoid false dirty flags
 			this._setting_value = true;
-			this.datepicker.selectDate(frappe.datetime.user_to_obj(value));
-			this._setting_value = false;
+			try {
+				this.datepicker.selectDate(frappe.datetime.user_to_obj(value));
+			} finally {
+				this._setting_value = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request improves how date and datetime fields are handled in forms to prevent false dirty flags when values are updated programmatically (such as during form load). The changes ensure that change events are not triggered unnecessarily, which helps maintain accurate form state and prevents issues with dirty flags due to precision mismatches.

**Dirty flag prevention and event handling improvements:**

* Added a `_setting_value` flag in both `ControlDate` (`date.js`) and `ControlDatetime` (`datetime.js`) to indicate when a value is being set programmatically, preventing change events and false dirty flags. 
* Updated the `parse_validate_and_set_in_model` methods in both controls to skip validation and model updates if `_setting_value` is true, ensuring that programmatic updates do not trigger unnecessary events. 

**Datetime value handling:**

* Modified the value getter in `ControlDatetime` to return the raw value or an empty string, removing unnecessary formatting and simplifying the logic.

Test case added here: https://github.com/frappe/frappe/pull/34912