### PR TITLE
fix(dashboard_chart): specify doctype name in group by field

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -274,7 +274,7 @@ def get_group_by_chart_config(chart, filters) -> dict | None:
 		],
 		filters=filters,
 		parent_doctype=chart.parent_document_type,
-		group_by=group_by_field,
+		group_by=group_by_field if "." in group_by_field else f"`tab{doctype}`.`{group_by_field}`",
 		order_by="count desc",
 		ignore_ifnull=True,
 	)


### PR DESCRIPTION
This is to avoid ambiguous group by when the field occurs in parent doctype + in child table filters

Reference: support ticket 53053
