### PR TITLE
test: implement datetime field validation tests

### DIFF
--- a/cypress/integration/datetime_field_form_validation.js
+++ b/cypress/integration/datetime_field_form_validation.js
@@ -1,19 +1,36 @@
-// TODO: Enable this again
-// currently this is flaky possibly because of different timezone in CI
+context("Datetime Field Validation", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/desk");
+		cy.get(".page-container").should("exist");
+		cy.window().should("have.property", "frappe");
+		return cy
+			.window()
+			.its("frappe")
+			.then((frappe) => {
+				return frappe.xcall("frappe.tests.ui_test_helpers.create_datetime_test_doctype");
+			});
+	});
 
-// context('Datetime Field Validation', () => {
-// 	before(() => {
-// 		cy.login();
-// 		cy.visit('/app/communication');
-// 	});
-
-// 	it('datetime field form validation', () => {
-// 		// validating datetime field value when value is set from backend and get validated on form load.
-// 		cy.window().its('frappe').then(frappe => {
-// 			return frappe.xcall("frappe.tests.ui_test_helpers.create_communication_record");
-// 		}).then(doc => {
-// 			cy.visit(`/app/communication/${doc.name}`);
-// 			cy.get('.indicator-pill').should('contain', 'Open').should('have.class', 'red');
-// 		});
-// 	});
-// });
+	it("datetime field form validation", () => {
+		// after loading a precise timestamp that has been set in backend, the
+		// form should not get dirty by (accidentally) making it a less precise timestamp.
+		cy.visit("/desk");
+		cy.window()
+			.its("frappe")
+			.then((frappe) => {
+				return frappe.xcall("frappe.tests.ui_test_helpers.create_datetime_test_record");
+			})
+			.then((doc) => {
+				cy.visit(`/desk/test-datetime-precision/${doc.name}`);
+				cy.get("body").should("have.attr", "data-ajax-state", "complete");
+				cy.window()
+					.its("cur_frm")
+					.then((frm) => {
+						expect(frm.is_dirty()).to.be.false;
+					});
+				cy.get(".indicator-pill").should("contain", "Draft");
+				cy.get(".btn-primary[data-label='Submit']").should("be.visible");
+			});
+	});
+});

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -92,15 +92,36 @@ def create_doctype_for_attachment():
 
 
 @whitelist_for_tests()
-def create_communication_record():
-	doc = frappe.get_doc(
+def create_datetime_test_doctype():
+	dt = frappe.new_doc("DocType")
+	dt.module = "Core"
+	dt.name = "Test Datetime Precision"
+	dt.custom = 1
+	dt.is_submittable = 1
+	dt.autoname = "autoincrement"
+	dt.append(
+		"fields",
 		{
-			"doctype": "Communication",
-			"recipients": "test@gmail.com",
-			"subject": "Test Form Communication 1",
-			"communication_date": frappe.utils.now_datetime(),
-		}
+			"fieldname": "datetime",
+			"fieldtype": "Datetime",
+			"label": "Datetime",
+		},
 	)
+	dt.append(
+		"permissions",
+		{
+			"role": "System Manager",
+			"read": 1,
+			"submit": 1,
+		},
+	)
+	dt.insert(ignore_if_duplicate=True)
+
+
+@whitelist_for_tests()
+def create_datetime_test_record():
+	doc = frappe.new_doc("Test Datetime Precision")
+	doc.datetime = frappe.utils.now_datetime()
 	doc.insert()
 	return doc
 


### PR DESCRIPTION
Added a new test for validating the datetime field in the form to ensure it retains precision after loading a timestamp from the backend. Introduced a helper function to create a test record for the new "Test Datetime Precision" DocType.

A similar test has existed before but has been disabled due to flaky behavior. Using a dedicated doctype here to make it less flaky.

Resolves https://github.com/frappe/frappe/pull/14138#issuecomment-3581495961

## Test case

1. Create a new DocType **Test Datetime Precision** with a single _Datetime_ field
2. Create a new record in the backend, setting the _Datetime_ field to contain a precise millisecond-timestamp
3. Load this record in the frontend

## Failure state

Form shows as "Not Saved" after load, only allowing to save again:

<img width="1036" height="402" alt="Bildschirmfoto 2025-11-26 um 16 36 40" src="https://github.com/user-attachments/assets/04824129-e898-41e9-8132-d2eac9aeca9c" />

## Success state

After reverting 279f08e it works correctly.
Form shows as "Draft" after load, allowing to submit:

<img width="1036" height="402" alt="Bildschirmfoto 2025-11-26 um 16 37 01" src="https://github.com/user-attachments/assets/65ae492c-5cd9-4625-98bb-385f0920d99b" />

