### PR TITLE
fix: dont allow reordering of icons on mobile

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -436,52 +436,56 @@ class DesktopIconGrid {
 		const me = this;
 		this.hoverTarget = null;
 		this.hoverTimer = null;
-		this.sortable = new Sortable($(grid).get(0), {
-			swapThreshold: 0.09,
-			animation: 150,
-			sort: true, // keep sorting normally
-			dragoverBubble: true,
-			group: {
-				name: "desktop",
-				put: true,
-				pull: true,
-			},
-			setData: function (/** DataTransfer */ dataTransfer, /** HTMLElement*/ dragEl) {
-				let title = $(dragEl).find(".icon-title").text();
-				let icon = me.icons.find((d) => {
-					return d.icon_title === title;
-				});
-				dataTransfer.setData("text/plain", JSON.stringify(icon.icon_data)); // `dataTransfer` object of HTML5 DragEvent
-			},
-			onEnd: function (evt) {
-				if (evt.oldIndex !== evt.newIndex) {
-					if (evt.to.parentElement == evt.from.parentElement) {
-						let reordered_icons = me.sortable.toArray();
-						let filters = {
-							parent_icon: me.parent_icon?.icon_data.label || null,
-						};
-						me.reorder_icons(reordered_icons, filters);
-						me.parent_icon?.render_folder_thumbnail();
-					} else {
-						let from = $(evt.from.parentElement);
-						let to = $(evt.to.parentElement);
-						let title = $(evt.item).find(".icon-title").text();
-						let selected_icon = get_desktop_icon_by_label(title);
-						if ($(to.get(0).parentElement)) {
-							me.reorder_icons(me.sortable.toArray());
-							me.reorder_icons(
-								frappe.pages["desktop"].desktop_page.icon_grid.sortable.toArray()
-							);
-							selected_icon.idx = evt.newIndex;
-							selected_icon.parent_icon = null;
+		if (!frappe.is_mobile()) {
+			this.sortable = new Sortable($(grid).get(0), {
+				swapThreshold: 0.09,
+				animation: 150,
+				sort: true, // keep sorting normally
+				dragoverBubble: true,
+				group: {
+					name: "desktop",
+					put: true,
+					pull: true,
+				},
+				setData: function (/** DataTransfer */ dataTransfer, /** HTMLElement*/ dragEl) {
+					let title = $(dragEl).find(".icon-title").text();
+					let icon = me.icons.find((d) => {
+						return d.icon_title === title;
+					});
+					dataTransfer.setData("text/plain", JSON.stringify(icon.icon_data)); // `dataTransfer` object of HTML5 DragEvent
+				},
+				onEnd: function (evt) {
+					if (evt.oldIndex !== evt.newIndex) {
+						if (evt.to.parentElement == evt.from.parentElement) {
+							let reordered_icons = me.sortable.toArray();
+							let filters = {
+								parent_icon: me.parent_icon?.icon_data.label || null,
+							};
+							me.reorder_icons(reordered_icons, filters);
+							me.parent_icon?.render_folder_thumbnail();
+						} else {
+							let from = $(evt.from.parentElement);
+							let to = $(evt.to.parentElement);
+							let title = $(evt.item).find(".icon-title").text();
+							let selected_icon = get_desktop_icon_by_label(title);
+							if ($(to.get(0).parentElement)) {
+								me.reorder_icons(me.sortable.toArray());
+								me.reorder_icons(
+									frappe.pages[
+										"desktop"
+									].desktop_page.icon_grid.sortable.toArray()
+								);
+								selected_icon.idx = evt.newIndex;
+								selected_icon.parent_icon = null;
+							}
 						}
+					} else {
+						frappe.toast("Nothing changed");
 					}
-				} else {
-					frappe.toast("Nothing changed");
-				}
-				save_desktop();
-			},
-		});
+					save_desktop();
+				},
+			});
+		}
 	}
 	reorder_icons(reordered_icons, filters) {
 		reordered_icons.forEach((d, idx) => {


### PR DESCRIPTION
This is temporary but neccessary until we don't figure out a nice icon editing UX