### PR TITLE
fix: enable email composing if cc or bcc field is provided without recipients

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -764,8 +764,8 @@ frappe.views.CommunicationComposer = class {
 		const me = this;
 		this.dialog.hide();
 
-		if (!form_values.recipients) {
-			frappe.msgprint(__("Enter Email Recipient(s)"));
+		if (!form_values.recipients && !form_values.cc && !form_values.bcc) {
+			frappe.msgprint(__("Enter Email Recipient(s) in the To, CC, or BCC fields"));
 			return;
 		}
 


### PR DESCRIPTION
Fixed the issue that prevented sending an email without specifying `recipients` in the Email Composer. Now, emails can be sent if any of the `recipients`, `cc`, or `bcc` fields are filled out.

Depends on #34946