### PR TITLE
fix: show cursor on the element where menu is triggered

### DIFF
--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -120,6 +120,7 @@ frappe.ui.create_menu = function attachContextMenuToElement(
 	right_click,
 	open_on_left
 ) {
+	$(element).css("cursor", "pointer");
 	let contextMenu = new frappe.ui.menu(menuItems, open_on_left);
 
 	frappe.menu_map[$(element).data("menu")] = contextMenu;


### PR DESCRIPTION
Showing cursor on element menu is supposed to be shown 

Video

https://github.com/user-attachments/assets/ca314b94-17ac-4be8-8c25-2e0d9ab7fa58

