### PR TITLE
fix: validate mandatory fields in import file

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -78,6 +78,7 @@ class DataImport(Document):
 		if not self.google_sheets_url:
 			return
 		validate_google_sheets_url(self.google_sheets_url)
+		self.get_importer()
 
 	def set_payload_count(self, importer: Importer | None = None):
 		if self.import_file:

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -483,11 +483,14 @@ class ImportFile:
 				title=_("Template Error"),
 			)
 
-	def validate_data_from_template_file(self, data):
+	def validate_columns_of_import_file(self, data):
 		mandatory_fields = self.get_mandatory_fields()
 		headers = data[0] if data else []
 
-		if not headers:
+		if len(headers) == 1 and ";" in headers[0]:
+			return
+
+		if not len(headers):
 			frappe.throw(_("Import template should contain a Header row."), title=_("Template Error"))
 
 		for field in mandatory_fields:
@@ -644,7 +647,7 @@ class ImportFile:
 		elif extension == "xls":
 			data = read_xls_file_from_attached_file(content)
 
-		self.validate_data_from_template_file(data)
+		self.validate_columns_of_import_file(data)
 		return data
 
 


### PR DESCRIPTION
When a file is added for import, mandatory fields are not validated. Instead, when a user starts importing thats when they get to know if they have missed mandatory fields after the import has failed.

This change validates that all mandatory fields are present, right after the import file has been saved.