### PR TITLE
fix: allow images to take natural width in desktop screen

### DIFF
--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -44,7 +44,9 @@
     left: 10px;
     top: 4px;
 }
-
+#brand-logo{
+    width: auto;
+}
 .desktop-search-icon > .icon {
     stroke: var(--ink-gray-4);
     stroke-width: 1px;

--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -3,7 +3,7 @@
     <header class="navbar navbar-expand navbar-container" role="navigation">
         <div class="navbar-home">
             <img
-                class="brand-logo"
+                id="brand-logo"
                 src="{{ brand_logo |e }}"
                 alt="{{ _("App Logo") |e }}"
             >

--- a/frappe/public/scss/desk/menu.scss
+++ b/frappe/public/scss/desk/menu.scss
@@ -9,6 +9,7 @@
 	border-radius: var(--border-radius-lg);
 	background: var(--surface-modal);
 	box-shadow: var(--shadow-xl);
+	z-index: 1030;
 }
 
 .dropdown-menu-item {

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -280,7 +280,3 @@
 .indent + .nested-container {
 	margin-left: 16px;
 }
-.context-menu {
-	position: absolute;
-	z-index: 1030;
-}


### PR DESCRIPTION
Allow images to be wider
Before

<img width="323" height="575" alt="Screenshot 2025-11-28 at 11 40 43 AM" src="https://github.com/user-attachments/assets/924a8c0a-bfdf-4b2b-86d4-7dfdca04dde3" />

After
<img width="325" height="284" alt="Screenshot 2025-11-28 at 2 52 16 AM" src="https://github.com/user-attachments/assets/2221b297-d0d7-4b4e-ba7a-e00c2d7b15e8" />

And apply correct z-index via menu