### PR TITLE
feat(error_log): add in some request/job metadata

### DIFF
--- a/frappe/core/doctype/error_log/error_log.json
+++ b/frappe/core/doctype/error_log/error_log.json
@@ -12,7 +12,8 @@
   "section_break_5",
   "method",
   "error",
-  "trace_id"
+  "trace_id",
+  "metadata"
  ],
  "fields": [
   {
@@ -66,13 +67,19 @@
    "fieldtype": "Data",
    "label": "Trace ID",
    "read_only": 1
+  },
+  {
+   "fieldname": "metadata",
+   "fieldtype": "Code",
+   "label": "Metadata",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-warning-sign",
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2024-12-09 14:22:44.819718",
+ "modified": "2025-11-27 18:04:21.399557",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Error Log",
@@ -90,6 +97,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/core/doctype/error_log/error_log.py
+++ b/frappe/core/doctype/error_log/error_log.py
@@ -17,6 +17,7 @@ class ErrorLog(Document):
 		from frappe.types import DF
 
 		error: DF.Code | None
+		metadata: DF.Code | None
 		method: DF.Data | None
 		reference_doctype: DF.Link | None
 		reference_name: DF.Data | None


### PR DESCRIPTION
Makes it easier to identify what exactly triggered this

<img width="917" height="305" alt="image" src="https://github.com/user-attachments/assets/f600a043-f8a0-4819-9b4b-4d38bcafff54" />

<hr>

no-docs
