### PR TITLE
fix: return empty string instead of undefined for URL and IBAN options

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -35,11 +35,11 @@ frappe.form.formatters = {
 	},
 	Data: function (value, df) {
 		if (df && df.options == "URL") {
-			if (!value) return;
+			if (!value) return "";
 			return `<a href="${value}" title="Open Link" target="_blank">${value}</a>`;
 		}
 		if (df && df.options == "IBAN") {
-			if (!value) return;
+			if (!value) return "";
 			return frappe.utils.get_formatted_iban(value);
 		}
 		value = value == null ? "" : value;


### PR DESCRIPTION
If the value is null or non existant, it shows undefined.

## Before:
<img width="1247" height="462" alt="image" src="https://github.com/user-attachments/assets/2a2519e3-9a1e-4e1c-b9fd-48938ad9f52e" />

## After:
<img width="1185" height="440" alt="image" src="https://github.com/user-attachments/assets/10570e60-2d95-4dff-84fe-fc16d1979bb6" />
