### PR TITLE
fix: permit email sending when recipients, cc are empty but bcc has value

### DIFF
--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -271,7 +271,7 @@ class CommunicationEmailMixin:
 		)
 		bcc = self.get_mail_bcc_with_displayname(is_inbound_mail_communcation=is_inbound_mail_communcation)
 
-		if not (recipients or cc):
+		if not (recipients or cc or bcc):
 			return {}
 
 		final_attachments = self.mail_attachments(


### PR DESCRIPTION
Fixed the issue where emails were not added to the Email Queue if the To and CC fields were empty, despite a value in BCC.