### PR TITLE
fix: check user permissions on computed child tables

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -452,7 +452,7 @@ def has_user_permission(doc, user=None, debug=False, *, ptype=None):
 	if not check_user_permission_on_link_fields(doc):
 		return False
 
-	for d in doc.get_all_children():
+	for d in doc.get_all_children(include_computed=True):
 		if not check_user_permission_on_link_fields(d):
 			return False
 


### PR DESCRIPTION
When checking user permissions on a document, the code now includes computed child tables (virtual tables) in addition to regular child tables.

This ensures that user permission checks on link fields are also applied to computed child tables, maintaining consistent permission enforcement across all child table types.