### PR TITLE
  fix: validate allow_import and import permission in Data Import

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -14,6 +14,7 @@ from frappe.core.doctype.data_import.importer import Importer
 from frappe.model import CORE_DOCTYPES
 from frappe.model.document import Document
 from frappe.modules.import_file import import_file_by_path
+from frappe.utils import cint
 from frappe.utils.background_jobs import enqueue, get_redis_conn, is_job_enqueued
 from frappe.utils.csvutils import validate_google_sheets_url
 
@@ -68,6 +69,20 @@ class DataImport(Document):
 	def validate_doctype(self):
 		if self.reference_doctype in BLOCKED_DOCTYPES:
 			frappe.throw(_("Importing {0} is not allowed.").format(self.reference_doctype))
+
+		meta = frappe.get_meta(self.reference_doctype)
+		if not cint(meta.allow_import):
+			frappe.throw(
+				_("Data Import is not allowed for {0}. Enable 'Allow Import' in DocType settings.").format(
+					self.reference_doctype
+				)
+			)
+
+		if not frappe.has_permission(self.reference_doctype, "import"):
+			frappe.throw(
+				_("You do not have import permission for {0}").format(self.reference_doctype),
+				frappe.PermissionError,
+			)
 
 	def validate_import_file(self):
 		if self.import_file:

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -231,6 +231,7 @@ def create_doctype_if_not_exists(doctype_name, force=False):
 			"module": "Custom",
 			"custom": 1,
 			"autoname": "field:title",
+			"allow_import": 1,
 			"fields": [
 				{"label": "Title", "fieldname": "title", "reqd": 1, "fieldtype": "Data"},
 				{"label": "Description", "fieldname": "description", "fieldtype": "Small Text"},
@@ -257,7 +258,7 @@ def create_doctype_if_not_exists(doctype_name, force=False):
 					"options": table_1_name,
 				},
 			],
-			"permissions": [{"role": "System Manager"}],
+			"permissions": [{"role": "System Manager", "import": 1}],
 		}
 	).insert()
 


### PR DESCRIPTION
**Summary**
  - Link field dropdown filters DocTypes on frontend, but backend had no validation
  - Users could bypass filter by manually typing DocType name and save
  - Added 2 validations:
    1. Check if DocType has `allow_import` enabled
    2. Check if user has import permission for the DocType

**Before**

https://github.com/user-attachments/assets/a29f6334-b28b-4cee-8ae8-12f1aa29adc9

**After**

https://github.com/user-attachments/assets/328abb00-8c5e-437f-b5f2-89a4c3293882

