### PR TITLE
fix(link): enhance input validation for autocomplete selection

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -307,12 +307,25 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 
 			me.autocomplete_open = false;
 
-			// prevent selection on tab
-			let TABKEY = 9;
-			if (e.keyCode === TABKEY) {
-				e.preventDefault();
-				me.awesomplete.close();
-				return false;
+			// prevent selection on tab/enter if input doesn't match
+			const TABKEY = 9;
+			const ENTERKEY = 13;
+			const event = o.originalEvent;
+			if (event && [TABKEY, ENTERKEY].includes(event.keyCode)) {
+				const input = me.get_label_value().toLowerCase();
+				if (!input && event.keyCode === TABKEY) {
+					e.preventDefault();
+					me.awesomplete.close();
+					return false;
+				} else if (input && !me.input_matches_item(input, item)) {
+					e.preventDefault();
+
+					// prevent browser default tab behavior (focus change)
+					if (event.preventDefault) {
+						event.preventDefault();
+					}
+					return false;
+				}
 			}
 
 			if (item.action) {
@@ -338,6 +351,20 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				me.$input.val("");
 			}
 		});
+	}
+
+	/**
+	 * Checks if the current input matches any property (label, value, or description)
+	 * of the provided autocomplete item (case-insensitive).
+	 *
+	 * @param {string} input - The current input value.
+	 * @param {Object} item - The autocomplete item to check against.
+	 * @returns {boolean} - True if input matches the label, value, or description.
+	 */
+	input_matches_item(input, item) {
+		const item_label = (this.get_translated(item.label || item.value) || "").toLowerCase();
+		const item_description = (item.description || "").toLowerCase();
+		return input && (item_label.includes(input) || item_description.includes(input));
 	}
 
 	/**


### PR DESCRIPTION
Issue:

> I have a link field called 'Project' in a child table. I type in my three-letter project code and hit Tab. Due to excessive debouncing, another project remains at the top of the drop-down menu when I press the tab key. This project is selected even though it does not match my input.

Behavior with this fix:

```mermaid
graph TD
    Start[Focus Link Field] --> CheckValue{Value entered?}

    %% Branch 1: No Value
    CheckValue -- No --> KeyNoVal{Key Pressed?}
    
    KeyNoVal -- Tab --> OutNoneNext[<b>Select:</b> None<br/><b>Action:</b> Close Autocomplete, Jump to Next Field]
    KeyNoVal -- Enter --> OutFocus[<b>Select:</b> Focused Item<br/><b>Action:</b> Close Autocomplete]

    %% Branch 2: Value Entered
    CheckValue -- Yes --> CheckMatch{Match Status?}

    %% Sub-branch: Match Found
    CheckMatch -- Matches focused item --> KeyMatch{Key Pressed?}
    
    %% NEW LOGIC HERE:
    KeyMatch -- Tab --> OutFocusNext[<b>Select:</b> Focused Item<br/><b>Action:</b> Close Autocomplete, Jump to Next Field]
    KeyMatch -- Enter --> OutFocus[<b>Select:</b> Focused Item<br/><b>Action:</b> Close Autocomplete]

    %% Sub-branch: Loading
    CheckMatch -- Doesn't match focused item (still loading) --> KeyLoad{Key Pressed?}
    KeyLoad -- Tab / Enter --> OutWait[<b>Select:</b> Nothing<br/><b>Action:</b> Wait for results]

    %% Styling
    classDef terminal fill:#f9f9f9,stroke:#333,stroke-width:2px;
    classDef decision fill:#e1f5fe,stroke:#01579b,stroke-width:2px;
    classDef outcome fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px;
    classDef wait fill:#ffebee,stroke:#c62828,stroke-width:2px;

    class Start terminal;
    class CheckValue,KeyNoVal,CheckMatch,KeyMatch,KeyLoad decision;
    class OutNoneNext,OutFocus,OutFocusNext outcome;
    class OutWait wait;
```

<details>
<summary>Plain text version</summary>

- Focus link field
	- No value entered
		- Tab: closes autocomplete, selects no item and jumps to next field
		- Enter: closes autocomplete, selects the focused item
	- Some value entered
		- 	The value matches the top item:
			- Tab: closes autocomplete, selects the focused item and jumps to next field
			- Enter: closes autocomplete, selects the focused item
		- The value doesn't match the focused item (results are still being loaded)
			- Tab/Enter: do nothing (wait for results to show up)

</details>

Underlying assumption: valid awesomeplete items will always contain the search input as a substring.

Resolves https://github.com/frappe/frappe/pull/34689#issuecomment-3576102883