### PR TITLE
fix: clear translation cache for doc before save lang

### DIFF
--- a/frappe/core/doctype/translation/translation.py
+++ b/frappe/core/doctype/translation/translation.py
@@ -36,10 +36,8 @@ class Translation(Document):
 
 	def on_update(self):
 		clear_user_translation_cache(self.language)
-		if self.has_value_changed("language"):
-			doc_before_save = self.get_doc_before_save()
-			if doc_before_save:
-				clear_user_translation_cache(doc_before_save.language)
+		if self.has_value_changed("language") and (doc_before_save := self.get_doc_before_save()):
+			clear_user_translation_cache(doc_before_save.language)
 
 	def on_trash(self):
 		clear_user_translation_cache(self.language)

--- a/frappe/core/doctype/translation/translation.py
+++ b/frappe/core/doctype/translation/translation.py
@@ -35,6 +35,10 @@ class Translation(Document):
 		self.source_text = strip_html_tags(self.source_text).strip()
 
 	def on_update(self):
+		if self.has_value_changed("language"):
+			doc_before_save = self.get_doc_before_save()
+			if doc_before_save:
+				clear_user_translation_cache(doc_before_save.language)
 		clear_user_translation_cache(self.language)
 
 	def on_trash(self):

--- a/frappe/core/doctype/translation/translation.py
+++ b/frappe/core/doctype/translation/translation.py
@@ -35,11 +35,11 @@ class Translation(Document):
 		self.source_text = strip_html_tags(self.source_text).strip()
 
 	def on_update(self):
+		clear_user_translation_cache(self.language)
 		if self.has_value_changed("language"):
 			doc_before_save = self.get_doc_before_save()
 			if doc_before_save:
 				clear_user_translation_cache(doc_before_save.language)
-		clear_user_translation_cache(self.language)
 
 	def on_trash(self):
 		clear_user_translation_cache(self.language)


### PR DESCRIPTION
## Problem

Consider this scenario, you create a translation for `Hindi` and save it. Later on you decide to update the language field to `English`. In the `on_update`, clear cache is called, but with the new language, i.e. `English`. But the `Hindi` translation still remains in cache. 

## Solution

Also clear translate cache for the previously set language value.