### PR TITLE
fix: add regex to get the correct country name

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -672,6 +672,7 @@ frappe.setup.utils = {
 		slide.get_input("country").on("change", function () {
 			let data = frappe.setup.data.regional_data;
 			let country = slide.get_input("country").val();
+			country = country.replace(/\s*\([^)]*\)/, "");
 			if (!(country in data.country_info)) return;
 
 			let $timezone = slide.get_input("timezone");


### PR DESCRIPTION
This fixes an issue in the setup wizard for mynamar where the details weren't being filled automatically. We had the data in our country_info.json. The key was a mismatch


Before

<img width="1440" height="900" alt="Screenshot 2025-11-29 at 7 19 36 PM" src="https://github.com/user-attachments/assets/dafa0c0f-395c-4b95-a741-fccb75f5f622" />


After

<img width="1440" height="900" alt="Screenshot 2025-11-29 at 7 22 26 PM" src="https://github.com/user-attachments/assets/527160f7-8031-480f-9f1d-052b3e6f2f8a" />


Ref ticket https://support.frappe.io/helpdesk/tickets/54054

