### PR TITLE
feat: Restriction for creation of multiple client script for same doctype

### DIFF
--- a/frappe/custom/doctype/client_script/client_script.py
+++ b/frappe/custom/doctype/client_script/client_script.py
@@ -25,3 +25,11 @@ class ClientScript(Document):
 
 	def on_trash(self):
 		frappe.clear_cache(doctype=self.dt)
+
+	def before_save(self):
+		script_exists = self.is_dt_script_already_exists()
+		if script_exists:
+			frappe.throw(f"Client Script for {self.dt} Doctype Already Exists")
+
+	def is_dt_script_already_exists(self):
+		return frappe.db.exists("Client Script", {"dt": self.dt})


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:
- Restrict the Creation of multiple doc for same doctype
> Explain the **details** for making this change. What existing problem does the pull request solve?
- Recently, I learned that people are creating multiple different documents for client scripts based on their requirements.
- They create a separate document for each feature.
- I wondered why it isn’t restricted to having only one document per doctype.
- Mostly, non-coders make this kind of mistake.
> Screenshots/GIFs

https://github.com/user-attachments/assets/27654fd2-756e-44e9-954f-dbe9cf4f61a5

