### PR TITLE
fix: apply full width on grid row form

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -509,12 +509,16 @@
 	overflow: auto;
 	margin: auto;
 	padding: var(--padding-sm) var(--padding-md);
-	max-width: 865px;
 	position: fixed;
 	top: 5%;
 	left: 50%;
 	transform: translate(-50%, 0%);
-	width: 100%;
+	width: 80%;
+
+	body:not(.full-width) & {
+		max-width: var(--page-max-width);
+	}
+
 	.grid-form-body {
 		max-height: 80vh;
 		overflow: scroll;


### PR DESCRIPTION
Full width mode

Before
<img width="1857" height="824" alt="image" src="https://github.com/user-attachments/assets/ef2c4bd3-f693-4012-aeae-1f4f09232ddf" />

After
<img width="1917" height="836" alt="image" src="https://github.com/user-attachments/assets/8543f3c3-ad0f-4d6c-93dc-8b50f91e7149" />

@barredterra @iamejaaz what do you think?

`no-docs`