### PR TITLE
fix(client): pass parent_doctype when fetching fields for child table links

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -416,8 +416,8 @@ def validate_link(doctype: str, docname: str, fields=None):
 	if not isinstance(docname, str):
 		frappe.throw(_("Document Name must be a string"))
 
+	parent_doctype = None
 	if doctype != "DocType":
-		parent_doctype = None
 		if frappe.get_meta(doctype).istable:  # needed for links to child rows
 			parent_doctype = frappe.db.get_value(doctype, docname, "parenttype")
 		if not (
@@ -453,7 +453,7 @@ def validate_link(doctype: str, docname: str, fields=None):
 		return values
 
 	try:
-		values.update(get_value(doctype, fields, docname))
+		values.update(get_value(doctype, fields, docname, parent=parent_doctype))
 	except frappe.PermissionError:
 		frappe.clear_last_message()
 		frappe.msgprint(

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -174,6 +174,24 @@ class TestClient(IntegrationTestCase):
 				validate_link("User", "Guest", fields=["enabled"]), {"name": "Guest", "enabled": 1}
 			)
 
+	def test_validate_link_child_table(self):
+		"""
+		Test validate_link works for child table doctypes with field fetch.
+		"""
+		from frappe.client import validate_link
+
+		self.addCleanup(frappe.db.rollback)
+
+		user = frappe.get_doc("User", "Administrator")
+		user.append("block_modules", {"module": "Setup"})
+		user.save()
+
+		child_row = user.block_modules[-1]
+
+		result = validate_link("Block Module", child_row.name, fields=["module"])
+		self.assertEqual(result.get("name"), child_row.name)
+		self.assertEqual(result.get("module"), "Setup")
+
 	def test_client_insert(self):
 		from frappe.client import insert
 


### PR DESCRIPTION
When `validate_link` is called for a child table doctype with `fields` to fetch, the `parent_doctype` was not being passed to `get_value`. This caused permission errors since child table queries require the parent context.

**Fix:** Pass `parent_doctype` to the `get_value` call when fetching additional fields.

**Test:** Added `test_validate_link_child_table` to verify the fix.

Closes #14969