### PR TITLE
fix: child row form with sidebar expanded

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -519,6 +519,11 @@
 		max-width: var(--page-max-width);
 	}
 
+	// Adjust position when sidebar is expanded to avoid collision
+	.body-sidebar-container.expanded ~ .main-section & {
+		left: calc(50% + var(--sidebar-width, 220px) / 2);
+	}
+
 	.grid-form-body {
 		max-height: 80vh;
 		overflow: scroll;


### PR DESCRIPTION
Follow https://github.com/frappe/frappe/pull/34964

Before

<img width="1811" height="898" alt="image" src="https://github.com/user-attachments/assets/40356d63-3d12-4666-93ff-ada4c7771ec5" />



After

<img width="1915" height="937" alt="image" src="https://github.com/user-attachments/assets/9740bf44-092d-42bb-9c50-9f545c13e48d" />

`no-docs`
