### PR TITLE
fix: show scrollbar on grid row form only if needed

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -521,7 +521,7 @@
 
 	.grid-form-body {
 		max-height: 80vh;
-		overflow: scroll;
+		overflow: auto;
 	}
 }
 


### PR DESCRIPTION
Before

<img width="1857" height="824" alt="image" src="https://github.com/user-attachments/assets/709e3795-c407-4a97-87c5-a6fcacdbeae2" />


After

<img width="1885" height="796" alt="image" src="https://github.com/user-attachments/assets/86951475-a50a-41f7-bec0-18b560d75973" />

`no-docs`
