### PR TITLE
fix: system settings layout

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -95,6 +95,7 @@
   "system_updates_section",
   "disable_system_update_notification",
   "disable_change_log_notification",
+  "column_break_ewhs",
   "hide_empty_read_only_fields",
   "disable_product_suggestion",
   "backups_tab",
@@ -777,12 +778,16 @@
    "fieldname": "disable_product_suggestion",
    "fieldtype": "Check",
    "label": "Disable Product Suggestion"
+  },
+  {
+   "fieldname": "column_break_ewhs",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2025-11-23 13:17:57.577690",
+ "modified": "2025-12-01 00:12:17.823242",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",


### PR DESCRIPTION
Following 
https://github.com/frappe/frappe/pull/34849
https://github.com/frappe/frappe/pull/34863

Before

<img width="1431" height="813" alt="image" src="https://github.com/user-attachments/assets/c1594d84-2513-42c7-bfb0-051fe19aec75" />


After

<img width="1679" height="807" alt="image" src="https://github.com/user-attachments/assets/3ec7194c-bbcf-4b14-9e0d-d6a904924862" />

`no-docs`