### PR TITLE
refactor: Hide Rename option for System Generated custom fields

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.js
+++ b/frappe/custom/doctype/custom_field/custom_field.js
@@ -112,32 +112,32 @@ frappe.ui.form.on("Custom Field", {
 		}
 	},
 	add_rename_field(frm) {
-		if (!frm.is_new()) {
-			frm.add_custom_button(__("Rename Fieldname"), () => {
-				frappe.prompt(
-					{
-						fieldtype: "Data",
-						label: __("Fieldname"),
-						fieldname: "fieldname",
-						reqd: 1,
-						default: frm.doc.fieldname,
-					},
-					function (data) {
-						frappe
-							.xcall(
-								"frappe.custom.doctype.custom_field.custom_field.rename_fieldname",
-								{
-									custom_field: frm.doc.name,
-									fieldname: data.fieldname,
-								}
-							)
-							.then(() => frm.reload());
-					},
-					__("Rename Fieldname"),
-					__("Rename")
-				);
-			});
-		}
+		if (frm.is_new() || frm.doc.is_system_generated) return;
+
+		frm.add_custom_button(__("Rename Fieldname"), () => {
+			frappe.prompt(
+				{
+					fieldtype: "Data",
+					label: __("Fieldname"),
+					fieldname: "fieldname",
+					reqd: 1,
+					default: frm.doc.fieldname,
+				},
+				function (data) {
+					frappe
+						.xcall(
+							"frappe.custom.doctype.custom_field.custom_field.rename_fieldname",
+							{
+								custom_field: frm.doc.name,
+								fieldname: data.fieldname,
+							}
+						)
+						.then(() => frm.reload());
+				},
+				__("Rename Fieldname"),
+				__("Rename")
+			);
+		});
 	},
 });
 


### PR DESCRIPTION
- When Custom Field is **System Generated** then it is not allowed to rename a fieldname. That's why showing a custom button for renaming a field is not require.

<img width="851" height="293" alt="image" src="https://github.com/user-attachments/assets/6bdf0c09-3925-4744-bf0f-9ac50aea52f4" />


> [!NOTE]
> Backport to V-15 