### PR TITLE
fix: dont allow editing sidebar

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -128,7 +128,10 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 	}
 	check_editing_access() {
 		if (!frappe.boot.developer_mode) {
-			this.dropdown_items.splice(1, 1);
+			let edit_sidebar_index = this.dropdown_items.findIndex((f) => {
+				return f.name == "edit-sidebar";
+			});
+			this.dropdown_items.splice(edit_sidebar_index, 1);
 		}
 	}
 	add_app_item(item) {


### PR DESCRIPTION
Broke recently due to sibling workspaces