### PR TITLE
Revert "fix: added api to get translation messages for portal apps (backport #28638)"

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -132,16 +132,6 @@ def get_messages_for_boot():
 	return get_all_translations(frappe.local.lang)
 
 
-@frappe.whitelist(allow_guest=True)
-def get_app_translations():
-	if frappe.session.user != "Guest":
-		language = frappe.db.get_value("User", frappe.session.user, "language")
-	else:
-		language = frappe.db.get_single_value("System Settings", "language")
-
-	return get_all_translations(language)
-
-
 def get_all_translations(lang: str) -> dict[str, str]:
 	"""Load and return the entire translations dictionary for a language from apps + user translations.
 


### PR DESCRIPTION
Reverts frappe/frappe#28640

<hr>

This is unused.