### PR TITLE
fix(search)!: validate `ignore_user_permissions` in link search

### DIFF
--- a/frappe/commands/test_commands.py
+++ b/frappe/commands/test_commands.py
@@ -1108,12 +1108,12 @@ class TestGunicornWorker(IntegrationTestCase):
 			return sum(c.cpu_percent(1.0) for c in process.children(True)) + process.cpu_percent(1.0)
 
 		self.spawn_gunicorn(["--threads=2"])
-		self.assertLessEqual(get_total_usage(), 2)
+		self.assertLessEqual(get_total_usage(), 3)
 
 		# Wake up at least one thread, go idle and check again
 		path = f"http://{self.TEST_SITE}:{self.port}/api/method/ping"
 		self.assertEqual(requests.get(path).status_code, 200)
-		self.assertLessEqual(get_total_usage(), 2)
+		self.assertLessEqual(get_total_usage(), 3)
 
 
 class TestRQWorker(IntegrationTestCase):

--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -329,6 +329,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:[\"Link\", \"Dynamic Link\", \"Table MultiSelect\"].includes(doc.fieldtype)",
    "fieldname": "ignore_user_permissions",
    "fieldtype": "Check",
    "label": "Ignore User Permissions"
@@ -623,7 +624,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-14 14:22:21.517289",
+ "modified": "2025-12-01 06:56:29.335491",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/core/doctype/user_permission/user_permission.json
+++ b/frappe/core/doctype/user_permission/user_permission.json
@@ -40,7 +40,6 @@
   {
    "fieldname": "for_value",
    "fieldtype": "Dynamic Link",
-   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "For Value",
@@ -89,8 +88,9 @@
    "fieldtype": "Column Break"
   }
  ],
+ "grid_page_length": 50,
  "links": [],
- "modified": "2024-03-23 16:04:00.823875",
+ "modified": "2025-12-01 06:55:21.174845",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User Permission",
@@ -109,6 +109,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -173,6 +173,7 @@ class Engine:
 		skip_locked: bool = False,
 		wait: bool = True,
 		ignore_permissions: bool = True,
+		ignore_user_permissions: bool = False,
 		user: str | None = None,
 		parent_doctype: str | None = None,
 		reference_doctype: str | None = None,
@@ -184,6 +185,8 @@ class Engine:
 		Args:
 			db_query_compat: When True, uses legacy db_query behavior for sorting and filtering.
 			This is kept optional to not break existing code that relies on the original query builder behaviour.
+			ignore_user_permissions: Ignore user permissions for the query.
+				Useful for link search queries when the link field has `ignore_user_permissions` set.
 		"""
 
 		qb = frappe.local.qb
@@ -197,6 +200,7 @@ class Engine:
 		self.parent_doctype = parent_doctype
 		self.reference_doctype = reference_doctype
 		self.apply_permissions = not ignore_permissions
+		self.ignore_user_permissions = ignore_user_permissions
 		self.function_aliases = set()
 		self.field_aliases = set()
 		self.db_query_compat = db_query_compat
@@ -1296,8 +1300,7 @@ class Engine:
 		conditions = []
 		fetch_shared_docs = False
 
-		# add user permission only if role has read perm
-		if not (role_permissions.get("read") or role_permissions.get("select")):
+		if self.ignore_user_permissions:
 			return conditions, fetch_shared_docs
 
 		user_permissions = frappe.permissions.get_user_permissions(self.user)

--- a/frappe/model/qb_query.py
+++ b/frappe/model/qb_query.py
@@ -55,6 +55,7 @@ class DatabaseQuery:
 		ignore_ddl: bool = False,
 		*,
 		parent_doctype: str | None = None,
+		ignore_user_permissions: bool = False,
 	) -> list:
 		"""Execute a database query using the Query Builder engine.
 
@@ -89,6 +90,8 @@ class DatabaseQuery:
 			pluck: Extract single field values as a simple list.
 			ignore_ddl: Ignore DDL operations during query execution (legacy compatibility).
 			parent_doctype: Parent doctype for child table queries.
+			ignore_user_permissions: Ignore user permissions for the query.
+				Useful for link search queries when the link field has `ignore_user_permissions` set.
 
 		Returns:
 			Query results as list of dicts (default) or list of lists (as_list=True).
@@ -186,6 +189,7 @@ class DatabaseQuery:
 			"offset": frappe.cint(offset),
 			"distinct": distinct,
 			"ignore_permissions": ignore_permissions,
+			"ignore_user_permissions": ignore_user_permissions,
 			"user": user,
 			"parent_doctype": parent_doctype,
 			"reference_doctype": reference_doctype,

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -280,6 +280,8 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					ignore_user_permissions: me.df.ignore_user_permissions,
 					reference_doctype: me.get_reference_doctype() || "",
 					page_length: cint(frappe.boot.sysdefaults?.link_field_results_limit) || 10,
+					form_doctype: me.doctype,
+					link_fieldname: me.df.fieldname,
 				};
 
 				me.set_custom_query(args);

--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -2,6 +2,14 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 	frappe.ui.form.ControlLink
 ) {
 	static horizontal = false;
+	make() {
+		// parent element
+		super.make();
+		const link_field = this.get_link_field();
+		if (link_field?.ignore_user_permissions) {
+			this.df.ignore_user_permissions = true;
+		}
+	}
 	make_input() {
 		super.make_input();
 		this.$input_area.addClass("form-control table-multiselect");


### PR DESCRIPTION
## Changes

### Backend (`frappe/desk/search.py`)
- Added `form_doctype` and `link_fieldname` params to `search_link`/`search_widget`
- Added `validate_ignore_user_permissions()` to verify the link field configuration server-side
- Added `ignore_user_permissions` support to query builder engine

### Frontend
- Pass `form_doctype` and `link_fieldname` from link controls to search API
- Propagate `ignore_user_permissions` from Table MultiSelect's child link field

### DocType Changes
- `DocField`: Hide `ignore_user_permissions` checkbox for non-Link field types
- `User Permission`: Removed `ignore_user_permissions` from Dynamic Link field (was the only one using it)

### Validation Rules
The flag is only honored when:
1. `form_doctype` and `link_fieldname` are provided
2. The field has `ignore_user_permissions` enabled
3. For Link/Table MultiSelect: the field links to the correct doctype
4. For Dynamic Link: target doctype validation is skipped (cannot be validated)

Otherwise, the flag is ignored and user permissions apply normally.