### PR TITLE
refactor: remove redundant child table permission checks

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -9,7 +9,6 @@ import frappe.model
 import frappe.utils
 from frappe import _
 from frappe.desk.reportview import validate_args
-from frappe.model.db_query import check_parent_permission
 from frappe.model.utils import is_virtual_doctype
 from frappe.utils import attach_expanded_links, get_safe_filters
 from frappe.utils.caching import http_cache
@@ -47,8 +46,6 @@ def get_list(
 	:param order_by: Order by this fieldname
 	:param limit_start: Start at this index
 	:param limit_page_length: Number of records to be returned (default 20)"""
-	if frappe.is_table(doctype):
-		check_parent_permission(parent, doctype)
 
 	args = frappe._dict(
 		doctype=doctype,
@@ -90,8 +87,6 @@ def get(doctype, name=None, filters=None, parent=None):
 	:param doctype: DocType of the document to be returned
 	:param name: return document of this `name`
 	:param filters: If name is not set, filter by these values and return the first match"""
-	if frappe.is_table(doctype):
-		check_parent_permission(parent, doctype)
 
 	if name:
 		doc = frappe.get_doc(doctype, name)
@@ -113,8 +108,6 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False, paren
 	:param doctype: DocType to be queried
 	:param fieldname: Field to be returned (default `name`)
 	:param filters: dict or string for identifying the record"""
-	if frappe.is_table(doctype):
-		check_parent_permission(parent, doctype)
 
 	if not frappe.has_permission(doctype, parent_doctype=parent):
 		frappe.throw(_("No permission for {0}").format(_(doctype)), frappe.PermissionError)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1350,22 +1350,6 @@ def cast_name(column: str) -> str:
 	return column
 
 
-def check_parent_permission(parent, child_doctype):
-	if parent:
-		# User may pass fake parent and get the information from the child table
-		if child_doctype and not (
-			frappe.db.exists("DocField", {"parent": parent, "options": child_doctype})
-			or frappe.db.exists("Custom Field", {"dt": parent, "options": child_doctype})
-		):
-			raise frappe.PermissionError
-
-		if frappe.permissions.has_permission(parent):
-			return
-
-	# Either parent not passed or the user doesn't have permission on parent doctype of child table!
-	raise frappe.PermissionError
-
-
 def get_order_by(doctype, meta):
 	order_by = ""
 


### PR DESCRIPTION
## Summary

Removes redundant `check_parent_permission` calls from `client.py` and the now-unused `check_parent_permission` function from `db_query.py`.

## Removed Code

### 1. `get_list()` - child table check before `frappe.get_list()`

**Why redundant:** `frappe.get_list()` calls `DatabaseQuery.execute()` which invokes `check_read_permission(doctype, parent_doctype=parent_doctype)`. This calls `frappe.has_permission(..., parent_doctype=...)`, which for child tables triggers `has_child_permission()` - validating the parent-child relationship and parent permissions.

### 2. `get()` - child table check before `frappe.get_doc()`

**Why redundant:** The function calls `doc.check_permission()` after loading the document. This invokes `frappe.has_permission(self.doctype, doc=self, ...)`. For child tables, `has_child_permission()` extracts `parent_doctype` from `child_doc.parenttype` and validates both the relationship and parent permissions.

### 3. `get_value()` - child table check before `frappe.has_permission()`

**Why redundant:** The very next line after the removed check is:
```python
if not frappe.has_permission(doctype, parent_doctype=parent):
    frappe.throw(...)
```
This `has_permission` call with `parent_doctype` already handles child tables via `has_child_permission()`.

### 4. `check_parent_permission()` function in `db_query.py`

**Why removed:** No longer used after the above changes. The `has_child_permission()` function in `permissions.py` provides the same validation (parent-child relationship check via `parent_meta.get_table_fields()`) plus additional permlevel checks that the old function didn't perform.