### PR TITLE
fix: avoid package.json update during cypress install

### DIFF
--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -492,7 +492,16 @@ def run_ui_tests(
 				"@cypress/code-coverage@^3",
 			]
 		)
+
+		# save package.json, install, then restore to avoid modifications
+		package_json_path = frappe.get_app_source_path("frappe", "package.json")
+		with open(package_json_path) as f:
+			package_json_contents = f.read()
+
 		frappe.commands.popen(f"(cd ../frappe && yarn add {packages} --no-lockfile)")
+
+		with open(package_json_path, "w") as f:
+			f.write(package_json_contents)
 
 	# run for headless mode
 	run_or_open = f"run --browser {browser}" if headless else "open"


### PR DESCRIPTION
stores copy - then restores