### PR TITLE
fix: enable translated languages

### DIFF
--- a/frappe/geo/languages.csv
+++ b/frappe/geo/languages.csv
@@ -34,7 +34,7 @@ fr,Français,1
 gu,ગુજરાતી,0
 he,עברית,0
 hi,हिन्दी,0
-hr,Hrvatski,0
+hr,Hrvatski,1
 hu,Magyar,0
 id,Indonesia,0
 is,Íslenska,0
@@ -66,17 +66,17 @@ si,සිංහල,0
 sk,Slovenčina,0
 sl,Slovenščina,0
 sq,Shqip,0
-sr,Српски,0
+sr,Српски,1
 sr-CS,Srpski,1
 sv,Svenska,1
 sw,Kiswahili,0
 ta,தமிழ்,0
 te,తెలుగు,0
-th,ไทย,0
+th,ไทย,1
 tr,Türkçe,1
 uk,Українська,0
 ur,اردو,0
 uz,O‘Zbek,0
 vi,Tiếng Việt,0
-zh,中文,0
+zh,中文,1
 zh-TW,繁體中文,0


### PR DESCRIPTION
Languages that have fairly complete translations (>50%) are enabled on new sites by default.
