### PR TITLE
fix!: use Field instead of Column for field-to-field comparison in query filters

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 from pypika.enums import Arithmetic
-from pypika.queries import Column, QueryBuilder, Table
+from pypika.queries import QueryBuilder, Table
 from pypika.terms import AggregateFunction, ArithmeticExpression, Star, Term, ValueWrapper
 
 import frappe
@@ -452,7 +452,7 @@ class Engine:
 	def _build_criterion_for_simple_filter(
 		self,
 		field: str | Field,
-		value: FilterValue | Field | Column | list | set | None,
+		value: FilterValue | Field | list | set | None,
 		operator: str = "=",
 		doctype: str | None = None,
 	) -> "Criterion | None":
@@ -461,8 +461,8 @@ class Engine:
 
 		_field = self._validate_and_prepare_filter_field(field, doctype)
 
-		if isinstance(value, Field | Column):
-			_value = self._validate_and_prepare_filter_field(value.name, doctype)
+		if isinstance(value, Field):
+			_value = value
 		else:
 			# Regular value processing for literal comparisons like: table.field = 'value'
 			_value = convert_to_value(value)

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -13,7 +13,7 @@ from frappe.desk.reportview import get_filters_cond
 from frappe.handler import execute_cmd
 from frappe.model.db_query import DatabaseQuery, get_between_date_filter
 from frappe.permissions import add_user_permission, clear_user_permissions_for_doctype
-from frappe.query_builder import Column
+from frappe.query_builder import Field
 from frappe.tests import IntegrationTestCase
 from frappe.tests.test_helpers import setup_for_tests
 from frappe.tests.test_query_builder import db_type_is, run_only_if
@@ -854,17 +854,17 @@ class TestDBQuery(IntegrationTestCase):
 			self.assertTrue(len(doctypes[0]) == 3)
 			self.assertTrue(isinstance(doctypes[0][2], datetime.datetime))
 
-	def test_column_comparison(self):
-		"""Test DatabaseQuery.execute to test column comparison"""
+	def test_field_comparison(self):
+		"""Test DatabaseQuery.execute to test field comparison"""
 		users_unedited = frappe.get_all(
 			"User",
-			filters={"creation": Column("modified")},
+			filters={"creation": Field("modified")},
 			fields=["name", "creation", "modified"],
 			limit=1,
 		)
 		users_edited = frappe.get_all(
 			"User",
-			filters={"creation": ("!=", Column("modified"))},
+			filters={"creation": ("!=", Field("modified"))},
 			fields=["name", "creation", "modified"],
 			limit=1,
 		)


### PR DESCRIPTION
## Breaking Change

`Column` is no longer supported as a filter value in `frappe.get_all`/`frappe.get_list`. Use `Field` instead.

### Before
```python
from frappe.query_builder import Column
frappe.get_all("User", filters={"creation": Column("modified")})
```

### After
```python
from frappe.query_builder import Field
frappe.get_all("User", filters={"creation": Field("modified")})
```

## Rationale

`Field` is the right way to do this in pypika. `Column` is when you want to select a static value ([example](https://github.com/frappe/erpnext/blob/47a6d34224a4310953da90e987f662e42dd05505/erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py#L298)).