### PR TITLE
feat(postgres): add unbuffered cursor in postgres

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -315,6 +315,12 @@ class Database:
 		if auto_commit:
 			self.commit()
 
+		if self.db_type == "postgres" and getattr(self._cursor, "name", None):
+			"""named cursors in Postgres are lazy and don't retrieve column names immediately,
+			so explicitly performed here to avoid early exit during `unbuffered_cursor` usage
+			"""
+			self._cursor.fetchmany(0)
+
 		if not self._cursor.description:
 			return ()
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -1,4 +1,5 @@
 import re
+from contextlib import contextmanager
 
 import psycopg2
 import psycopg2.extensions
@@ -490,6 +491,23 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		table = get_table_name(doctype)
 		count = self.sql("select reltuples from pg_class where relname = %s", table)
 		return cint(count[0][0]) if count else 0
+
+	@contextmanager
+	def unbuffered_cursor(self):
+		"""Unbuffered cursor in Postgres can only call .execute() once,
+		usage:
+			with frappe.db.unbuffered_cursor():
+				frappe.db.sql()
+		"""
+		try:
+			if not self._conn:
+				self.connect()
+			original_cursor = self._cursor
+			new_cursor = self._cursor = self._conn.cursor(name="ss_cursor")
+			yield
+		finally:
+			self._cursor = original_cursor
+			new_cursor.close()
 
 
 def modify_query(query):

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1212,6 +1212,42 @@ class TestSqlIterator(IntegrationTestCase):
 		with frappe.db.unbuffered_cursor():
 			self.test_db_sql_iterator()
 
+	@run_only_if(db_type_is.POSTGRES)
+	def test_unbuffered_cursor_postgres(self):
+		test_queries = [
+			"select * from `tabCountry` order by name",
+			"select code from `tabCountry` order by name",
+			"select code from `tabCountry` order by name limit 5",
+		]
+
+		for query in test_queries:
+			with frappe.db.unbuffered_cursor():
+				iter_query_val = list(frappe.db.sql(query, as_dict=True, as_iterator=True))
+			query_val = frappe.db.sql(query, as_dict=True)
+			self.assertEqual(
+				query_val,
+				iter_query_val,
+				msg=f"{query=} results not same as iterator",
+			)
+
+			with frappe.db.unbuffered_cursor():
+				iter_query_val = list(frappe.db.sql(query, pluck=True, as_iterator=True))
+			query_val = frappe.db.sql(query, pluck=True)
+			self.assertEqual(
+				query_val,
+				iter_query_val,
+				msg=f"{query=} results not same as iterator",
+			)
+
+			with frappe.db.unbuffered_cursor():
+				iter_query_val = list(frappe.db.sql(query, as_list=True, as_iterator=True))
+			query_val = frappe.db.sql(query, as_list=True)
+			self.assertEqual(
+				query_val,
+				iter_query_val,
+				msg=f"{query=} results not same as iterator",
+			)
+
 
 class ExtIntegrationTestCase(IntegrationTestCase):
 	def assertSqlException(self):


### PR DESCRIPTION
**Problem:**
feat(Postgres): This PR focusses on implementing Server Side Cursor in Postgres as is implemented in MariaDB, and is a performance based feature implementation. This PR is also a step forward towards resolving #21613 and completes a part of the Postgres TODO #34660 .

**Theoretics:**
1. Similar to MariaDB, server side cursors aka unbuffered cursors can be implemented in postgres too as is done in this PR. However there is no such equivalent class to the `SSCursor` class in MariaDB and instead server side cursors can be implemented by naming a cursor as done in the PR. Unnamed cursors are default client side cursors.
2. The default itersize value in Psycopg 2 is 2000, thus to parity match to MariaDB, the itersize is set as 1 indicating fetching of a single row as is in MariaDB.

**Before**:
`@Unimplemented` + Test was skipped for Postgres.
<img width="1910" height="532" alt="image" src="https://github.com/user-attachments/assets/f99bf1b5-b222-446f-a0a7-96838780b22e" />

**After**:
<img width="1880" height="378" alt="image" src="https://github.com/user-attachments/assets/ea37c08e-7b9e-4543-b510-5446a4feee12" />

<img width="2072" height="632" alt="image" src="https://github.com/user-attachments/assets/60dfde28-4663-460e-b841-daee58c9a472" />

Edit 1: The feat won't be used because of the architectural pattern of code written where we swap cursors ... (need to think on a way to use pg ss cursor for the same...)
Edit 2: Possibly track query that needs server side streaming, and use the SS cursor only for that query given that Postgres makes a lot of noise when trying to execute multiple queries , it only allows one 😐 ...Proof-of-concept works!! Achieves similar perf. as that of MariaDB!

**Documentation/Usage:**
```python
# Example: 
		with frappe.db.unbuffered_cursor():
				iter_query_val = list(frappe.db.sql(query, pluck=True, as_iterator=True))
```

The `unbuffered_cursor` in Postgres can only .execute() once given this is how it works in Postgres, so for every time a query needs unbuffered behavior, one has to use `with frappe.db.unbuffered_cursor():` every time :) .

related to #34660 
