### PR TITLE
ci: add cypress recordings to a path and upload them

### DIFF
--- a/.github/workflows/_base-ui-tests.yml
+++ b/.github/workflows/_base-ui-tests.yml
@@ -128,6 +128,16 @@ jobs:
         with:
           name: coverage-js-${{ matrix.index }}
           path: ./apps/${{ github.event.repository.name }}/.cypress-coverage/clover.xml
+      - name: Compress Cypress Videos
+        run: |
+          zip -r cypress_recordings.zip ./cypressVideos
+      - name: Upload Cypress Videos
+        uses: actions/upload-artifact@v5
+        with:
+          name: Cypress CI Video Recordings
+          path: ./cypress_recordings.zip
+
+        
 
       - name: Upload coverage data
         uses: actions/upload-artifact@v5
@@ -135,7 +145,7 @@ jobs:
         with:
           name: coverage-py-${{ matrix.index }}
           path: ./sites/*-coverage*.xml
-
+    
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: ${{ failure() && contains( github.event.pull_request.labels.*.name, 'debug-gha') }}

--- a/.github/workflows/_base-ui-tests.yml
+++ b/.github/workflows/_base-ui-tests.yml
@@ -129,8 +129,10 @@ jobs:
           name: coverage-js-${{ matrix.index }}
           path: ./apps/${{ github.event.repository.name }}/.cypress-coverage/clover.xml
       - name: Compress Cypress Videos
-        run: |
-          zip -r cypress_recordings.zip ./cypressVideos
+        run: | 
+            if find ./cypressVideos -mindepth 1 | read; then
+              zip -r cypress_recordings.zip ./cypressVideos
+            fi
       - name: Upload Cypress Videos
         uses: actions/upload-artifact@v5
         with:

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,5 +1,6 @@
 const { defineConfig } = require("cypress");
 const fs = require("fs");
+const path = require("path");
 
 module.exports = defineConfig({
 	projectId: "92odwv",
@@ -8,6 +9,7 @@ module.exports = defineConfig({
 	defaultCommandTimeout: 20000,
 	pageLoadTimeout: 15000,
 	video: true,
+	videosFolder: path.resolve(__dirname, "..", "..") + "/cypressVideos/",
 	viewportHeight: 960,
 	viewportWidth: 1400,
 	retries: {


### PR DESCRIPTION
This PR contains a workaround to fetch cypress recordings 