### PR TITLE
feat: add per-DocType permission control for public file uploads

### DIFF
--- a/cypress/integration/file_uploader.js
+++ b/cypress/integration/file_uploader.js
@@ -1,6 +1,6 @@
 context("FileUploader", () => {
 	before(() => {
-		cy.login();
+		cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 	});
 
 	beforeEach(() => {
@@ -51,5 +51,333 @@ context("FileUploader", () => {
 			.its("response.body.message")
 			.should("have.property", "file_name", "example.json");
 		cy.get(".modal:visible").should("not.exist");
+	});
+
+	context("Public file upload permissions", () => {
+		let test_user;
+		let test_role = "Test File Uploader Role";
+
+		before(() => {
+			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
+			cy.visit("/desk");
+			cy.wait(1000);
+
+			// Check if role exists, create if it doesn't
+			cy.call("frappe.client.get", {
+				doctype: "Role",
+				filters: { name: test_role },
+			})
+				.then((result) => {
+					if (!result || result.length === 0) {
+						return cy.call("frappe.client.insert", {
+							doc: {
+								doctype: "Role",
+								role_name: test_role,
+							},
+						});
+					}
+				})
+				.then(() => {
+					// Create test user
+					test_user = `test_file_uploader_${Date.now()}@example.com`;
+					return cy.call("frappe.client.insert", {
+						doc: {
+							doctype: "User",
+							email: test_user,
+							first_name: "Test",
+							new_password: "Eastern_43A1W",
+							send_welcome_email: 0,
+							roles: [
+								{
+									role: test_role,
+								},
+							],
+						},
+					});
+				});
+
+			// Note: upload_public_files is a standard right (in std_rights), so it doesn't need a Permission Type
+			// It's available for all doctypes by default
+		});
+
+		after(() => {
+			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
+			// Clean up test user and role
+			if (test_user) {
+				cy.remove_doc("User", test_user, true);
+			}
+			cy.remove_doc("Role", test_role, true);
+		});
+
+		it("Administrator should see Private checkbox and toggle button", () => {
+			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
+			cy.visit("/desk");
+			cy.wait(2000);
+
+			open_upload_dialog();
+
+			// Add a file
+			cy.get_open_dialog()
+				.find(".file-upload-area")
+				.selectFile("cypress/fixtures/example.json", {
+					action: "drag-drop",
+				});
+
+			cy.wait(500);
+
+			// Check for Private checkbox
+			cy.get_open_dialog().find(".frappe-checkbox").contains("Private").should("be.visible");
+
+			// Check for toggle button
+			cy.get_open_dialog()
+				.find(".modal-footer .btn-secondary")
+				.should("be.visible")
+				.should("contain", "Set all");
+
+			cy.hide_dialog();
+		});
+
+		it("User with permission should see Private checkbox and toggle button", () => {
+			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
+			cy.visit("/desk");
+			cy.wait(1000);
+
+			// Grant upload_public_files permission using permission_manager API
+			cy.call("frappe.core.page.permission_manager.permission_manager.add", {
+				parent: "File",
+				role: test_role,
+				permlevel: 0,
+			});
+			cy.call("frappe.core.page.permission_manager.permission_manager.update", {
+				doctype: "File",
+				role: test_role,
+				permlevel: 0,
+				ptype: "read",
+				value: 1,
+			});
+			cy.call("frappe.core.page.permission_manager.permission_manager.update", {
+				doctype: "File",
+				role: test_role,
+				permlevel: 0,
+				ptype: "write",
+				value: 1,
+			});
+			cy.call("frappe.core.page.permission_manager.permission_manager.update", {
+				doctype: "File",
+				role: test_role,
+				permlevel: 0,
+				ptype: "upload_public_files",
+				value: 1,
+			});
+
+			// Clear cache and wait for permissions to be saved
+			cy.clear_cache();
+			cy.wait(2000);
+
+			// Login as test user and reload to get fresh permissions
+			cy.login(test_user, "Eastern_43A1W");
+			cy.visit("/desk");
+			cy.wait(2000);
+
+			// Verify permission is loaded in frontend and ensure metadata is loaded
+			cy.window()
+				.its("frappe")
+				.then((frappe) => {
+					return new Promise((resolve) => {
+						frappe.model.with_doctype("File", () => {
+							expect(
+								frappe.perm.has_perm("File", 0, "upload_public_files")
+							).to.equal(true);
+							// Ensure metadata is cached and loaded
+							const meta = frappe.get_meta("File");
+							expect(meta).to.not.be.undefined;
+							// Verify the permission is in the cached permissions
+							const perms = frappe.perm.get_perm("File");
+							expect(perms[0].upload_public_files).to.equal(1);
+							resolve();
+						});
+					});
+				});
+
+			// Wait a bit more to ensure Vue reactivity has processed
+			cy.wait(1000);
+
+			open_upload_dialog();
+
+			// Add a file
+			cy.get_open_dialog()
+				.find(".file-upload-area")
+				.selectFile("cypress/fixtures/example.json", {
+					action: "drag-drop",
+				});
+
+			// Wait for file to be processed - check for file name first
+			cy.get_open_dialog().find(".file-name").should("contain", "example.json");
+
+			// Wait for Vue component to render and evaluate computed properties
+			// The checkbox visibility depends on the computed property which checks permissions
+			cy.wait(1500);
+
+			// Verify permission check works in the dialog context
+			cy.get_open_dialog().then(() => {
+				cy.window()
+					.its("frappe")
+					.then((frappe) => {
+						// Ensure File metadata is loaded and permission is available
+						frappe.model.with_doctype("File", () => {
+							const can_upload = frappe.utils.can_upload_public_files("File");
+							expect(can_upload).to.equal(true);
+						});
+					});
+			});
+
+			// Check for Private checkbox - look for label with "Private" text directly
+			// The checkbox should appear in the config-area when permission is granted
+			// Use a more specific selector that waits for the element to appear
+			cy.get_open_dialog()
+				.find(".file-preview-outline")
+				.should("be.visible")
+				.should("contain", "Private")
+				.find("label.frappe-checkbox")
+				.contains("Private")
+				.should("be.visible");
+
+			// Check for toggle button in modal footer
+			cy.get_open_dialog()
+				.find(".modal-footer")
+				.findByRole("button", { name: /set all/i })
+				.should("be.visible");
+
+			cy.hide_dialog();
+		});
+
+		it("User without permission should NOT see Private checkbox and toggle button", () => {
+			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
+			cy.visit("/desk");
+			cy.wait(1000);
+
+			// Revoke upload_public_files permission using permission_manager API
+			cy.call("frappe.core.page.permission_manager.permission_manager.add", {
+				parent: "File",
+				role: test_role,
+				permlevel: 0,
+			});
+			cy.call("frappe.core.page.permission_manager.permission_manager.update", {
+				doctype: "File",
+				role: test_role,
+				permlevel: 0,
+				ptype: "read",
+				value: 1,
+			});
+			cy.call("frappe.core.page.permission_manager.permission_manager.update", {
+				doctype: "File",
+				role: test_role,
+				permlevel: 0,
+				ptype: "write",
+				value: 1,
+			});
+			cy.call("frappe.core.page.permission_manager.permission_manager.update", {
+				doctype: "File",
+				role: test_role,
+				permlevel: 0,
+				ptype: "upload_public_files",
+				value: 0,
+			});
+
+			// Clear cache and wait for permissions to be saved
+			cy.clear_cache();
+			cy.wait(2000);
+
+			// Login as test user and reload to get fresh permissions
+			cy.login(test_user, "Eastern_43A1W");
+			cy.visit("/desk");
+			cy.wait(2000);
+
+			open_upload_dialog();
+
+			// Add a file
+			cy.get_open_dialog()
+				.find(".file-upload-area")
+				.selectFile("cypress/fixtures/example.json", {
+					action: "drag-drop",
+				});
+
+			// Wait for file to be processed - check for file name first
+			cy.get_open_dialog().find(".file-name").should("contain", "example.json");
+			cy.wait(1000);
+
+			// Private checkbox should NOT be visible - config-area should be empty or not contain Private label
+			cy.get_open_dialog()
+				.find(".file-preview-outline")
+				.should("be.visible")
+				.within(() => {
+					cy.get(".config-area").should("exist").should("not.contain", "Private");
+				});
+
+			// Toggle button should NOT be visible in modal footer
+			cy.get_open_dialog().find(".modal-footer").should("not.contain", "Set all");
+
+			cy.hide_dialog();
+		});
+
+		it("User without permission should be forced to upload private files", () => {
+			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
+			cy.visit("/desk");
+			cy.wait(1000);
+
+			// Ensure upload_public_files permission is revoked using permission_manager API
+			cy.call("frappe.core.page.permission_manager.permission_manager.add", {
+				parent: "File",
+				role: test_role,
+				permlevel: 0,
+			}).then(() => {
+				cy.call("frappe.core.page.permission_manager.permission_manager.update", {
+					doctype: "File",
+					role: test_role,
+					permlevel: 0,
+					ptype: "read",
+					value: 1,
+				});
+				cy.call("frappe.core.page.permission_manager.permission_manager.update", {
+					doctype: "File",
+					role: test_role,
+					permlevel: 0,
+					ptype: "write",
+					value: 1,
+				});
+				cy.call("frappe.core.page.permission_manager.permission_manager.update", {
+					doctype: "File",
+					role: test_role,
+					permlevel: 0,
+					ptype: "upload_public_files",
+					value: 0,
+				});
+			});
+
+			// Login as test user
+			cy.login(test_user, "Eastern_43A1W");
+			cy.visit("/desk");
+			cy.wait(2000);
+
+			open_upload_dialog();
+
+			// Add a file
+			cy.get_open_dialog()
+				.find(".file-upload-area")
+				.selectFile("cypress/fixtures/example.json", {
+					action: "drag-drop",
+				});
+
+			cy.wait(500);
+
+			// Upload the file
+			cy.intercept("POST", "/api/method/upload_file").as("upload_file");
+			cy.get_open_dialog().findByRole("button", { name: "Upload" }).click();
+			cy.wait("@upload_file").its("response.statusCode").should("eq", 200);
+
+			// File should be uploaded as private (default behavior when permission is missing)
+			cy.wait(1000);
+			cy.get(".modal:visible").should("not.exist");
+		});
 	});
 });

--- a/cypress/integration/file_uploader.js
+++ b/cypress/integration/file_uploader.js
@@ -102,6 +102,8 @@ context("FileUploader", () => {
 
 		after(() => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
+			cy.visit("/desk");
+			cy.wait(2000); // Ensure page is fully loaded
 			// Clean up test user and role
 			if (test_user) {
 				cy.remove_doc("User", test_user, true);
@@ -321,9 +323,12 @@ context("FileUploader", () => {
 		});
 
 		it("User without permission should be forced to upload private files", () => {
+			// Ensure we're logged in as Administrator first
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
-			cy.wait(1000);
+			// Wait for page to fully load - ensure frappe object is available
+			cy.window().its("frappe").should("exist");
+			cy.wait(2000);
 
 			// Ensure upload_public_files permission is revoked using permission_manager API
 			cy.call("frappe.core.page.permission_manager.permission_manager.add", {
@@ -357,6 +362,8 @@ context("FileUploader", () => {
 			// Login as test user
 			cy.login(test_user, "Eastern_43A1W");
 			cy.visit("/desk");
+			// Wait for page to fully load - ensure frappe object is available
+			cy.window().its("frappe").should("exist");
 			cy.wait(2000);
 
 			open_upload_dialog();

--- a/cypress/integration/file_uploader.js
+++ b/cypress/integration/file_uploader.js
@@ -5,6 +5,8 @@ context("FileUploader", () => {
 
 	beforeEach(() => {
 		cy.visit("/desk");
+		// Wait for page to fully load - ensure frappe object is available
+		cy.window().its("frappe").should("exist");
 		cy.wait(2000); // workspace can load async and clear active dialog
 	});
 
@@ -62,39 +64,31 @@ context("FileUploader", () => {
 			cy.visit("/desk");
 			cy.wait(1000);
 
-			// Check if role exists, create if it doesn't
-			cy.call("frappe.client.get", {
-				doctype: "Role",
-				filters: { name: test_role },
-			})
-				.then((result) => {
-					if (!result || result.length === 0) {
-						return cy.call("frappe.client.insert", {
-							doc: {
-								doctype: "Role",
-								role_name: test_role,
+			// Create role (ignore if it already exists)
+			cy.insert_doc(
+				"Role",
+				{
+					role_name: test_role,
+				},
+				true // ignore_duplicate
+			).then(() => {
+				// Create test user
+				test_user = `test_file_uploader_${Date.now()}@example.com`;
+				return cy.call("frappe.client.insert", {
+					doc: {
+						doctype: "User",
+						email: test_user,
+						first_name: "Test",
+						new_password: "Eastern_43A1W",
+						send_welcome_email: 0,
+						roles: [
+							{
+								role: test_role,
 							},
-						});
-					}
-				})
-				.then(() => {
-					// Create test user
-					test_user = `test_file_uploader_${Date.now()}@example.com`;
-					return cy.call("frappe.client.insert", {
-						doc: {
-							doctype: "User",
-							email: test_user,
-							first_name: "Test",
-							new_password: "Eastern_43A1W",
-							send_welcome_email: 0,
-							roles: [
-								{
-									role: test_role,
-								},
-							],
-						},
-					});
+						],
+					},
 				});
+			});
 
 			// Note: upload_public_files is a standard right (in std_rights), so it doesn't need a Permission Type
 			// It's available for all doctypes by default
@@ -103,6 +97,8 @@ context("FileUploader", () => {
 		after(() => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
+			// Wait for page to fully load - ensure frappe object is available
+			cy.window().its("frappe").should("exist");
 			cy.wait(2000); // Ensure page is fully loaded
 			// Clean up test user and role
 			if (test_user) {
@@ -256,6 +252,8 @@ context("FileUploader", () => {
 		it("User without permission should NOT see Private checkbox and toggle button", () => {
 			cy.login("Administrator", Cypress.env("adminPassword") || "admin");
 			cy.visit("/desk");
+			// Wait for page to fully load - ensure frappe object is available
+			cy.window().its("frappe").should("exist");
 			cy.wait(1000);
 
 			// Revoke upload_public_files permission using permission_manager API
@@ -293,6 +291,8 @@ context("FileUploader", () => {
 			// Login as test user and reload to get fresh permissions
 			cy.login(test_user, "Eastern_43A1W");
 			cy.visit("/desk");
+			// Wait for page to fully load - ensure frappe object is available
+			cy.window().its("frappe").should("exist");
 			cy.wait(2000);
 
 			open_upload_dialog();

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -1037,6 +1037,83 @@ def setup_chrome():
 	setup_chromium()
 
 
+@click.command("allow-public-files")
+@click.argument("app")
+@pass_context
+def allow_public_files(context: CliCtxObj, app):
+	"""Enable upload_public_files permission for all DocPerm entries of an app"""
+	if not context.sites:
+		raise SiteNotSpecifiedError
+
+	for site in context.sites:
+		try:
+			frappe.init(site)
+			frappe.connect()
+
+			# Get all modules for the app
+			if app not in frappe.local.app_modules:
+				click.echo(f"App '{app}' not found or not installed")
+				continue
+
+			modules = frappe.local.app_modules[app]
+			# Convert module names to their unscrubbed form for querying
+			module_names = [frappe.unscrub(m) for m in modules]
+
+			# Get all doctypes for these modules
+			doctypes = frappe.get_all(
+				"DocType",
+				filters={"module": ["in", module_names]},
+				fields=["name"],
+				pluck="name",
+			)
+
+			if not doctypes:
+				click.echo(f"No doctypes found for app '{app}'")
+				continue
+
+			click.echo(
+				f"Updating upload_public_files permission for {len(doctypes)} doctypes in app '{app}'..."
+			)
+
+			# Format doctypes for IN clause
+			doctypes_tuple = tuple(doctypes)
+			doctypes_placeholders = ",".join(["%s"] * len(doctypes))
+
+			# Update DocPerm entries
+			frappe.db.sql(
+				f"""
+				UPDATE `tabDocPerm`
+				SET `upload_public_files` = 1
+				WHERE `parent` IN ({doctypes_placeholders})
+					AND (`upload_public_files` = 0 OR `upload_public_files` IS NULL)
+				""",
+				doctypes_tuple,
+			)
+			docperm_count = frappe.db._cursor.rowcount
+
+			# Update Custom DocPerm entries
+			frappe.db.sql(
+				f"""
+				UPDATE `tabCustom DocPerm`
+				SET `upload_public_files` = 1
+				WHERE `parent` IN ({doctypes_placeholders})
+					AND (`upload_public_files` = 0 OR `upload_public_files` IS NULL)
+				""",
+				doctypes_tuple,
+			)
+			custom_docperm_count = frappe.db._cursor.rowcount
+
+			frappe.db.commit()
+
+			click.echo(
+				f"✓ Updated {docperm_count} DocPerm entries and {custom_docperm_count} Custom DocPerm entries"
+			)
+			click.echo(f"✓ Public file uploads are now enabled for all doctypes in app '{app}'")
+
+		finally:
+			frappe.destroy()
+
+
 commands = [
 	build,
 	clear_cache,
@@ -1070,4 +1147,5 @@ commands = [
 	rebuild_global_search,
 	list_sites,
 	setup_chrome,
+	allow_public_files,
 ]

--- a/frappe/core/doctype/custom_docperm/custom_docperm.json
+++ b/frappe/core/doctype/custom_docperm/custom_docperm.json
@@ -31,7 +31,8 @@
   "column_break_19",
   "share",
   "print",
-  "email"
+  "email",
+  "upload_public_files"
  ],
  "fields": [
   {
@@ -210,6 +211,12 @@
    "fieldname": "email",
    "fieldtype": "Check",
    "label": "Email"
+  },
+  {
+   "default": "1",
+   "fieldname": "upload_public_files",
+   "fieldtype": "Check",
+   "label": "Upload Public Files"
   },
   {
    "fieldname": "parent",

--- a/frappe/core/doctype/docperm/docperm.json
+++ b/frappe/core/doctype/docperm/docperm.json
@@ -30,7 +30,8 @@
   "column_break_19",
   "share",
   "print",
-  "email"
+  "email",
+  "upload_public_files"
  ],
  "fields": [
   {
@@ -199,6 +200,12 @@
    "fieldname": "email",
    "fieldtype": "Check",
    "label": "Email"
+  },
+  {
+   "default": "1",
+   "fieldname": "upload_public_files",
+   "fieldtype": "Check",
+   "label": "Upload Public Files"
   },
   {
    "default": "0",

--- a/frappe/core/doctype/file/file.js
+++ b/frappe/core/doctype/file/file.js
@@ -15,6 +15,20 @@ frappe.ui.form.on("File", {
 			frm.add_custom_button(__("Download"), () => frm.trigger("download"), "fa fa-download");
 		}
 
+		// Check permission to upload public files based on attached doctype
+		const doctype_to_check = frm.doc.attached_to_doctype || "File";
+		const can_upload_public = frappe.utils.can_upload_public_files(doctype_to_check);
+
+		// Disable is_private field if user doesn't have permission (force private)
+		if (!can_upload_public) {
+			frm.set_df_property("is_private", "read_only", 1);
+			if (!frm.doc.is_private) {
+				frm.set_value("is_private", 1);
+			}
+		} else {
+			frm.set_df_property("is_private", "read_only", 0);
+		}
+
 		if (!frm.doc.is_private) {
 			frm.dashboard.set_headline(
 				__("This file is public. It can be accessed without authentication."),

--- a/frappe/core/doctype/file/file.js
+++ b/frappe/core/doctype/file/file.js
@@ -16,18 +16,29 @@ frappe.ui.form.on("File", {
 		}
 
 		// Check permission to upload public files based on attached doctype
+		// If attached_to_doctype is present, check that doctype
+		// If not attached (uploading from File doctype itself), check "File" doctype permissions
 		const doctype_to_check = frm.doc.attached_to_doctype || "File";
-		const can_upload_public = frappe.utils.can_upload_public_files(doctype_to_check);
+		// Ensure doctype metadata is loaded before checking permissions
+		frappe.model.with_doctype(doctype_to_check, () => {
+			const can_upload_public = frappe.utils.can_upload_public_files(doctype_to_check);
 
-		// Disable is_private field if user doesn't have permission (force private)
-		if (!can_upload_public) {
-			frm.set_df_property("is_private", "read_only", 1);
-			if (!frm.doc.is_private) {
-				frm.set_value("is_private", 1);
+			if (!can_upload_public) {
+				// User doesn't have permission: cannot upload public files or change private to public
+				// Make field read-only
+				frm.set_df_property("is_private", "read_only", 1);
+				// If file is currently public (is_private = 0), force it to private
+				if (!frm.doc.is_private) {
+					frm.doc.is_private = 1;
+					frm.set_value("is_private", 1).then(() => {
+						frm.refresh_field("is_private");
+					});
+				}
+			} else {
+				// User has permission: can upload public files and toggle between public/private
+				frm.set_df_property("is_private", "read_only", 0);
 			}
-		} else {
-			frm.set_df_property("is_private", "read_only", 0);
-		}
+		});
 
 		if (!frm.doc.is_private) {
 			frm.dashboard.set_headline(

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -813,7 +813,16 @@ class File(Document):
 			self.is_private = cint(self.file_url.startswith("/private"))
 
 	def enforce_public_file_restrictions(self):
-		"""Enforce permission check for public file uploads based on attached doctype."""
+		"""Enforce permission check for public file uploads based on attached doctype.
+
+		Permission check logic:
+		- If file is attached to a doctype (e.g., "Item"), check permissions for that doctype
+		- If file is NOT attached to any doctype (attached_to_doctype is None), check "File" doctype permissions
+		- If file is attached to "File" doctype itself, check "File" doctype permissions
+
+		In summary: "File" doctype permissions only matter when reference doc is not defined
+		or when uploading attachments on File itself.
+		"""
 		if cint(self.is_private):
 			return
 
@@ -821,15 +830,14 @@ class File(Document):
 		if frappe.session.user == "Administrator":
 			return
 
-		# Determine which doctype to check permissions for
-		doctype_to_check = self.attached_to_doctype or "File"
-
+		# Check permission on the attached document if available, otherwise check on File itself
+		# This way, conditions like "Is Owner" and "User Permissions" apply automatically
 		try:
-			if not frappe.has_permission(doctype_to_check, "upload_public_files"):
-				msg = _("You do not have permission to upload public files")
-				if self.attached_to_doctype:
-					msg += f" for {_(doctype_to_check)}"
-				raise frappe.PermissionError(msg)
+			if self.attached_to_doctype and self.attached_to_name:
+				doc = frappe.get_doc(self.attached_to_doctype, self.attached_to_name)
+				doc.check_permission("upload_public_files")
+			else:
+				self.check_permission("upload_public_files")
 		except frappe.PermissionError:
 			raise
 		except Exception:

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -816,33 +816,27 @@ class File(Document):
 		"""Enforce permission check for public file uploads based on attached doctype.
 
 		Permission check logic:
-		- If file is attached to a doctype (e.g., "Item"), check permissions for that doctype
-		- If file is NOT attached to any doctype (attached_to_doctype is None), check "File" doctype permissions
-		- If file is attached to "File" doctype itself, check "File" doctype permissions
-
-		In summary: "File" doctype permissions only matter when reference doc is not defined
-		or when uploading attachments on File itself.
+		- If file is public and attached to a doctype (e.g., "Custom"), check permissions for that doctype
+		- If file is NOT attached to any doctype (uploading from File doctype itself), check "File" doctype permissions
+		- Only validates if file is public
 		"""
 		if cint(self.is_private):
 			return
 
-		# Administrator bypasses all permission checks
-		if frappe.session.user == "Administrator":
-			return
+		# Determine which doctype to check permissions for
+		# If attached to a doctype, check that doctype; otherwise check "File" doctype
+		if self.attached_to_doctype and self.attached_to_name:
+			doctype_to_check = self.attached_to_doctype
+		else:
+			# File uploaded directly from File doctype itself
+			doctype_to_check = "File"
 
-		# Check permission on the attached document if available, otherwise check on File itself
-		# This way, conditions like "Is Owner" and "User Permissions" apply automatically
-		try:
-			if self.attached_to_doctype and self.attached_to_name:
-				doc = frappe.get_doc(self.attached_to_doctype, self.attached_to_name)
-				doc.check_permission("upload_public_files")
-			else:
-				self.check_permission("upload_public_files")
-		except frappe.PermissionError:
-			raise
-		except Exception:
-			# If permission type doesn't exist or other error, allow by default (backward compatibility)
-			pass
+		# Check permission using the helper function
+		if not can_upload_public_files_for_doctype(doctype_to_check):
+			frappe.throw(
+				_("You do not have permission to upload public files for {0}.").format(doctype_to_check),
+				frappe.PermissionError,
+			)
 
 	@frappe.whitelist()
 	def optimize_file(self):
@@ -899,6 +893,44 @@ class File(Document):
 def on_doctype_update():
 	frappe.db.add_index("File", ["attached_to_doctype", "attached_to_name"])
 	frappe.db.add_index("File", ["file_url(100)"])
+
+
+def can_upload_public_files_for_doctype(doctype, user=None):
+	"""Check if user can upload public files for the given doctype.
+
+	Permission check logic:
+	- Administrator: Always allowed (bypass all checks)
+	- Permission = 0 (explicit disable): Only private files allowed (returns False)
+	- Permission = 1 (explicit enable): Both public and private files allowed (returns True)
+	- Permission NOT defined: Treat as 0 (only private files allowed, returns False)
+
+	For users with multiple roles:
+	- If any role has value 1 → ENABLED (returns True)
+	- Else if any role has value 0 → DISABLED (returns False)
+	- Else → NOT DEFINED → treat as 0 (returns False)
+
+	Args:
+		doctype: The doctype to check permissions for
+		user: The user to check permissions for (defaults to current session user)
+
+	Returns:
+		True if user can upload public files, False otherwise
+	"""
+	user = user or frappe.session.user
+
+	# Administrator bypasses all permission checks
+	if user == "Administrator":
+		return True
+
+	try:
+		# Use frappe.has_permission which handles multiple roles correctly:
+		# - If any role has 1 → returns True
+		# - If all roles have 0 or not defined → returns False
+		return frappe.has_permission(doctype, "upload_public_files", user=user)
+	except Exception:
+		# If permission type doesn't exist or other error,
+		# treat as 0 (only private files allowed)
+		return False
 
 
 def has_permission(doc, ptype=None, user=None, debug=False):

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -819,24 +819,21 @@ class File(Document):
 		- If file is public and attached to a doctype (e.g., "Custom"), check permissions for that doctype
 		- If file is NOT attached to any doctype (uploading from File doctype itself), check "File" doctype permissions
 		- Only validates if file is public
+		- Skips check if ignore_permissions flag is set (e.g., during tests or system operations)
 		"""
 		if cint(self.is_private):
 			return
 
-		# Determine which doctype to check permissions for
-		# If attached to a doctype, check that doctype; otherwise check "File" doctype
+		# Skip permission check if ignore_permissions flag is set
+		if self.flags.ignore_permissions:
+			return
+
+		# Check permission on the attached doctype if present, otherwise on File doctype itself
 		if self.attached_to_doctype and self.attached_to_name:
-			doctype_to_check = self.attached_to_doctype
+			frappe.has_permission(self.attached_to_doctype, "upload_public_files", throw=True)
 		else:
 			# File uploaded directly from File doctype itself
-			doctype_to_check = "File"
-
-		# Check permission using the helper function
-		if not can_upload_public_files_for_doctype(doctype_to_check):
-			frappe.throw(
-				_("You do not have permission to upload public files for {0}.").format(doctype_to_check),
-				frappe.PermissionError,
-			)
+			frappe.has_permission("File", "upload_public_files", throw=True)
 
 	@frappe.whitelist()
 	def optimize_file(self):
@@ -893,44 +890,6 @@ class File(Document):
 def on_doctype_update():
 	frappe.db.add_index("File", ["attached_to_doctype", "attached_to_name"])
 	frappe.db.add_index("File", ["file_url(100)"])
-
-
-def can_upload_public_files_for_doctype(doctype, user=None):
-	"""Check if user can upload public files for the given doctype.
-
-	Permission check logic:
-	- Administrator: Always allowed (bypass all checks)
-	- Permission = 0 (explicit disable): Only private files allowed (returns False)
-	- Permission = 1 (explicit enable): Both public and private files allowed (returns True)
-	- Permission NOT defined: Treat as 0 (only private files allowed, returns False)
-
-	For users with multiple roles:
-	- If any role has value 1 → ENABLED (returns True)
-	- Else if any role has value 0 → DISABLED (returns False)
-	- Else → NOT DEFINED → treat as 0 (returns False)
-
-	Args:
-		doctype: The doctype to check permissions for
-		user: The user to check permissions for (defaults to current session user)
-
-	Returns:
-		True if user can upload public files, False otherwise
-	"""
-	user = user or frappe.session.user
-
-	# Administrator bypasses all permission checks
-	if user == "Administrator":
-		return True
-
-	try:
-		# Use frappe.has_permission which handles multiple roles correctly:
-		# - If any role has 1 → returns True
-		# - If all roles have 0 or not defined → returns False
-		return frappe.has_permission(doctype, "upload_public_files", user=user)
-	except Exception:
-		# If permission type doesn't exist or other error,
-		# treat as 0 (only private files allowed)
-		return False
 
 
 def has_permission(doc, ptype=None, user=None, debug=False):

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -142,6 +142,7 @@ class File(Document):
 		self.validate_file_url()
 		self.validate_file_on_disk()
 		self.file_size = frappe.form_dict.file_size or self.file_size
+		self.enforce_public_file_restrictions()
 
 	def validate_attachment_references(self):
 		if not self.attached_to_doctype:
@@ -258,6 +259,10 @@ class File(Document):
 		# as old_file_url to avoid a FileNotFoundError for this case.
 		if updated_file_url == old_file_url:
 			return
+
+		# If changing from private to public, check permission BEFORE moving the file
+		if not cint(self.is_private):
+			self.enforce_public_file_restrictions()
 
 		if not source.exists():
 			frappe.throw(
@@ -806,6 +811,30 @@ class File(Document):
 
 		if self.file_url:
 			self.is_private = cint(self.file_url.startswith("/private"))
+
+	def enforce_public_file_restrictions(self):
+		"""Enforce permission check for public file uploads based on attached doctype."""
+		if cint(self.is_private):
+			return
+
+		# Administrator bypasses all permission checks
+		if frappe.session.user == "Administrator":
+			return
+
+		# Determine which doctype to check permissions for
+		doctype_to_check = self.attached_to_doctype or "File"
+
+		try:
+			if not frappe.has_permission(doctype_to_check, "upload_public_files"):
+				msg = _("You do not have permission to upload public files")
+				if self.attached_to_doctype:
+					msg += f" for {_(doctype_to_check)}"
+				raise frappe.PermissionError(msg)
+		except frappe.PermissionError:
+			raise
+		except Exception:
+			# If permission type doesn't exist or other error, allow by default (backward compatibility)
+			pass
 
 	@frappe.whitelist()
 	def optimize_file(self):

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -980,15 +980,8 @@ class TestPublicFileUploadPermissions(IntegrationTestCase):
 			)
 			user.insert()
 			user.add_roles("Test File Uploader")
-		# Create Permission Type for upload_public_files on File doctype if it doesn't exist
-		if not frappe.db.exists("Permission Type", {"perm_type": "upload_public_files", "doc_type": "File"}):
-			frappe.get_doc(
-				{
-					"doctype": "Permission Type",
-					"perm_type": "upload_public_files",
-					"doc_type": "File",
-				}
-			).insert(ignore_permissions=True)
+		# Note: upload_public_files is a standard right (in std_rights), so it doesn't need a Permission Type
+		# It's automatically available for all doctypes
 
 	def tearDown(self):
 		frappe.set_user("Administrator")
@@ -1032,8 +1025,8 @@ class TestPublicFileUploadPermissions(IntegrationTestCase):
 		if custom_docperm_name:
 			frappe.db.set_value("Custom DocPerm", custom_docperm_name, "upload_public_files", 1)
 
-		# Commit changes and clear all caches
-		frappe.db.commit()
+		# Clear all caches
+		# Note: No manual commit needed - framework handles transactions automatically
 
 		# Verify permission was set
 		custom_docperm_value = frappe.db.get_value(
@@ -1088,8 +1081,8 @@ class TestPublicFileUploadPermissions(IntegrationTestCase):
 		if custom_docperm_name:
 			frappe.db.set_value("Custom DocPerm", custom_docperm_name, "upload_public_files", 0)
 
-		# Commit changes and clear all caches
-		frappe.db.commit()
+		# Clear all caches
+		# Note: No manual commit needed - framework handles transactions automatically
 		frappe.clear_cache()
 		frappe.reload_doctype("File")
 		frappe.set_user("test_file_uploader@example.com")
@@ -1121,8 +1114,8 @@ class TestPublicFileUploadPermissions(IntegrationTestCase):
 		if custom_docperm_name:
 			frappe.db.set_value("Custom DocPerm", custom_docperm_name, "upload_public_files", 0)
 
-		# Commit changes and clear all caches
-		frappe.db.commit()
+		# Clear all caches
+		# Note: No manual commit needed - framework handles transactions automatically
 		frappe.clear_cache()
 		frappe.reload_doctype("File")
 		frappe.set_user("test_file_uploader@example.com")
@@ -1155,8 +1148,8 @@ class TestPublicFileUploadPermissions(IntegrationTestCase):
 		if custom_docperm_name:
 			frappe.db.set_value("Custom DocPerm", custom_docperm_name, "upload_public_files", 0)
 
-		# Commit changes and clear all caches
-		frappe.db.commit()
+		# Clear all caches
+		# Note: No manual commit needed - framework handles transactions automatically
 		frappe.clear_cache()
 		frappe.reload_doctype("File")
 		frappe.set_user("Administrator")
@@ -1184,7 +1177,7 @@ class TestPublicFileUploadPermissions(IntegrationTestCase):
 		frappe.delete_doc("File", file_name, force=1)
 
 	def test_permission_check_based_on_attached_doctype(self):
-		"""Permission check should be based on attached_to_doctype, not just File doctype"""
+		"""Permission check should be based on attached_to_doctype, not File doctype fallback"""
 		from frappe.permissions import add_permission, update_permission_property
 
 		# Create a test doctype
@@ -1220,7 +1213,7 @@ class TestPublicFileUploadPermissions(IntegrationTestCase):
 		update_permission_property("File", "Test File Uploader", 0, "read", 1)
 		update_permission_property("File", "Test File Uploader", 0, "write", 1)
 
-		# Set upload_public_files to 0 directly
+		# Set upload_public_files to 0 directly (explicitly disabled for File doctype)
 		custom_docperm_name = frappe.db.get_value(
 			"Custom DocPerm",
 			{"parent": "File", "role": "Test File Uploader", "permlevel": 0},
@@ -1228,8 +1221,7 @@ class TestPublicFileUploadPermissions(IntegrationTestCase):
 		if custom_docperm_name:
 			frappe.db.set_value("Custom DocPerm", custom_docperm_name, "upload_public_files", 0)
 
-		# Commit changes and clear all caches
-		frappe.db.commit()
+		# Clear all caches
 		frappe.clear_cache()
 		frappe.reload_doctype("File")
 		frappe.reload_doctype("Test File Attachment")
@@ -1239,7 +1231,9 @@ class TestPublicFileUploadPermissions(IntegrationTestCase):
 		test_doc.insert()
 
 		frappe.set_user("test_file_uploader@example.com")
-		# Should be able to upload public file when attached to Test File Attachment
+
+		# Test 1: Should be able to upload public file when attached to Test File Attachment
+		# (checks Test File Attachment permissions, not File doctype)
 		file_doc = frappe.get_doc(
 			{
 				"doctype": "File",
@@ -1252,9 +1246,70 @@ class TestPublicFileUploadPermissions(IntegrationTestCase):
 		)
 		file_doc.save()
 		self.assertEqual(file_doc.is_private, 0)
+		file_doc.delete()
+
+		# Test 2: Should NOT be able to upload public file when NOT attached
+		# (checks File doctype permissions, which is set to 0)
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "test_standalone_file.txt",
+				"content": "test content",
+				"is_private": 0,
+				# No attached_to_doctype - uploading from File doctype itself
+			}
+		)
+		with self.assertRaises(frappe.PermissionError):
+			file_doc.save()
 
 		# Cleanup
 		frappe.set_user("Administrator")
-		file_doc.delete()
 		test_doc.delete()
 		frappe.delete_doc("DocType", "Test File Attachment", force=1)
+
+	def test_permission_not_defined_treated_as_disabled(self):
+		"""Permission NOT defined should be treated as 0 (disabled), not allowed by default"""
+		from frappe.permissions import add_permission, update_permission_property
+
+		# Grant read/write but do NOT set upload_public_files at all (not defined)
+		add_permission("File", "Test File Uploader", 0)
+		update_permission_property("File", "Test File Uploader", 0, "read", 1)
+		update_permission_property("File", "Test File Uploader", 0, "write", 1)
+		# Do NOT set upload_public_files - it should be treated as 0 (disabled)
+
+		# Clear all caches
+		frappe.clear_cache()
+		frappe.reload_doctype("File")
+
+		frappe.set_user("test_file_uploader@example.com")
+
+		# Verify permission check returns False (not defined = 0)
+		self.assertFalse(
+			frappe.has_permission("File", "upload_public_files", user="test_file_uploader@example.com"),
+			"Permission not defined should be treated as 0 (disabled)",
+		)
+
+		# Should NOT be able to upload public files
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "test_public_file.txt",
+				"content": "test content",
+				"is_private": 0,
+			}
+		)
+		with self.assertRaises(frappe.PermissionError):
+			file_doc.save()
+
+		# Should still be able to upload private files
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "test_private_file.txt",
+				"content": "test content",
+				"is_private": 1,
+			}
+		)
+		file_doc.save()
+		self.assertEqual(file_doc.is_private, 1)
+		file_doc.delete()

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -21,7 +21,7 @@ from frappe.core.doctype.file.utils import get_corrupted_image_msg, get_extensio
 from frappe.desk.form.utils import add_comment
 from frappe.exceptions import ValidationError
 from frappe.tests import IntegrationTestCase
-from frappe.utils import get_files_path, set_request
+from frappe.utils import cint, get_files_path, set_request
 
 if TYPE_CHECKING:
 	from frappe.core.doctype.file.file import File
@@ -958,3 +958,303 @@ class TestGuestFileAndAttachments(IntegrationTestCase):
 		self.assertEqual(doc_pri.get_content(), content)
 		doc_pri.delete()
 		self.assertFalse(os.path.exists(doc_pri.get_full_path()))
+
+
+class TestPublicFileUploadPermissions(IntegrationTestCase):
+	"""Test permission-based restrictions for public file uploads"""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		# Create test role
+		if not frappe.db.exists("Role", "Test File Uploader"):
+			frappe.get_doc({"doctype": "Role", "role_name": "Test File Uploader"}).insert()
+		# Create test user
+		if not frappe.db.exists("User", "test_file_uploader@example.com"):
+			user = frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": "test_file_uploader@example.com",
+					"first_name": "Test",
+					"send_welcome_email": 0,
+				}
+			)
+			user.insert()
+			user.add_roles("Test File Uploader")
+		# Create Permission Type for upload_public_files on File doctype if it doesn't exist
+		if not frappe.db.exists("Permission Type", {"perm_type": "upload_public_files", "doc_type": "File"}):
+			frappe.get_doc(
+				{
+					"doctype": "Permission Type",
+					"perm_type": "upload_public_files",
+					"doc_type": "File",
+				}
+			).insert(ignore_permissions=True)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		# Clean up test files
+		test_files = frappe.get_all("File", filters={"owner": "test_file_uploader@example.com"}, pluck="name")
+		for file_name in test_files:
+			try:
+				frappe.delete_doc("File", file_name, force=1)
+			except Exception:
+				pass
+
+	def test_administrator_can_upload_public_files(self):
+		"""Administrator should be able to upload public files without restrictions"""
+		frappe.set_user("Administrator")
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "test_public_file.txt",
+				"content": "test content",
+				"is_private": 0,
+			}
+		)
+		file_doc.save()
+		self.assertEqual(file_doc.is_private, 0)
+		file_doc.delete()
+
+	def test_user_with_permission_can_upload_public_files(self):
+		"""User with upload_public_files permission should be able to upload public files"""
+		from frappe.permissions import add_permission, update_permission_property
+
+		# Grant upload_public_files permission to Test File Uploader role
+		add_permission("File", "Test File Uploader", 0)
+		update_permission_property("File", "Test File Uploader", 0, "read", 1)
+		update_permission_property("File", "Test File Uploader", 0, "write", 1)
+
+		# Set upload_public_files directly using SQL since update_permission_property might not handle it
+		custom_docperm_name = frappe.db.get_value(
+			"Custom DocPerm",
+			{"parent": "File", "role": "Test File Uploader", "permlevel": 0},
+		)
+		if custom_docperm_name:
+			frappe.db.set_value("Custom DocPerm", custom_docperm_name, "upload_public_files", 1)
+
+		# Commit changes and clear all caches
+		frappe.db.commit()
+
+		# Verify permission was set
+		custom_docperm_value = frappe.db.get_value(
+			"Custom DocPerm",
+			{"parent": "File", "role": "Test File Uploader", "permlevel": 0},
+			"upload_public_files",
+		)
+		self.assertEqual(
+			int(custom_docperm_value or 0), 1, "upload_public_files permission should be set to 1"
+		)
+
+		# Clear all caches and reload
+		frappe.clear_cache()
+		frappe.clear_cache(doctype="File")
+		del frappe.local.role_permissions
+		frappe.reload_doctype("File")
+
+		frappe.set_user("test_file_uploader@example.com")
+
+		# Verify permission check works
+		self.assertTrue(
+			frappe.has_permission("File", "upload_public_files", user="test_file_uploader@example.com"),
+			"User should have upload_public_files permission",
+		)
+
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "test_public_file.txt",
+				"content": "test content",
+				"is_private": 0,
+			}
+		)
+		file_doc.save()
+		self.assertEqual(file_doc.is_private, 0)
+		file_doc.delete()
+
+	def test_user_without_permission_cannot_upload_public_files(self):
+		"""User without upload_public_files permission should not be able to upload public files"""
+		from frappe.permissions import add_permission, update_permission_property
+
+		# Grant read/write but NOT upload_public_files permission
+		add_permission("File", "Test File Uploader", 0)
+		update_permission_property("File", "Test File Uploader", 0, "read", 1)
+		update_permission_property("File", "Test File Uploader", 0, "write", 1)
+
+		# Set upload_public_files to 0 directly
+		custom_docperm_name = frappe.db.get_value(
+			"Custom DocPerm",
+			{"parent": "File", "role": "Test File Uploader", "permlevel": 0},
+		)
+		if custom_docperm_name:
+			frappe.db.set_value("Custom DocPerm", custom_docperm_name, "upload_public_files", 0)
+
+		# Commit changes and clear all caches
+		frappe.db.commit()
+		frappe.clear_cache()
+		frappe.reload_doctype("File")
+		frappe.set_user("test_file_uploader@example.com")
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "test_public_file.txt",
+				"content": "test content",
+				"is_private": 0,
+			}
+		)
+		with self.assertRaises(frappe.PermissionError):
+			file_doc.save()
+
+	def test_user_without_permission_can_upload_private_files(self):
+		"""User without upload_public_files permission should still be able to upload private files"""
+		from frappe.permissions import add_permission, update_permission_property
+
+		# Grant read/write but NOT upload_public_files permission
+		add_permission("File", "Test File Uploader", 0)
+		update_permission_property("File", "Test File Uploader", 0, "read", 1)
+		update_permission_property("File", "Test File Uploader", 0, "write", 1)
+
+		# Set upload_public_files to 0 directly
+		custom_docperm_name = frappe.db.get_value(
+			"Custom DocPerm",
+			{"parent": "File", "role": "Test File Uploader", "permlevel": 0},
+		)
+		if custom_docperm_name:
+			frappe.db.set_value("Custom DocPerm", custom_docperm_name, "upload_public_files", 0)
+
+		# Commit changes and clear all caches
+		frappe.db.commit()
+		frappe.clear_cache()
+		frappe.reload_doctype("File")
+		frappe.set_user("test_file_uploader@example.com")
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "test_private_file.txt",
+				"content": "test content",
+				"is_private": 1,
+			}
+		)
+		file_doc.save()
+		self.assertEqual(file_doc.is_private, 1)
+		file_doc.delete()
+
+	def test_user_cannot_toggle_private_to_public_without_permission(self):
+		"""User without permission should not be able to toggle file from private to public"""
+		from frappe.permissions import add_permission, update_permission_property
+
+		# Grant read/write but NOT upload_public_files permission
+		add_permission("File", "Test File Uploader", 0)
+		update_permission_property("File", "Test File Uploader", 0, "read", 1)
+		update_permission_property("File", "Test File Uploader", 0, "write", 1)
+
+		# Set upload_public_files to 0 directly
+		custom_docperm_name = frappe.db.get_value(
+			"Custom DocPerm",
+			{"parent": "File", "role": "Test File Uploader", "permlevel": 0},
+		)
+		if custom_docperm_name:
+			frappe.db.set_value("Custom DocPerm", custom_docperm_name, "upload_public_files", 0)
+
+		# Commit changes and clear all caches
+		frappe.db.commit()
+		frappe.clear_cache()
+		frappe.reload_doctype("File")
+		frappe.set_user("Administrator")
+		# Create a private file as Administrator
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "test_private_file.txt",
+				"content": "test content",
+				"is_private": 1,
+			}
+		)
+		file_doc.save()
+		file_name = file_doc.name
+
+		# Try to toggle to public as test user
+		frappe.set_user("test_file_uploader@example.com")
+		file_doc = frappe.get_doc("File", file_name)
+		file_doc.is_private = 0
+		with self.assertRaises(frappe.PermissionError):
+			file_doc.save()
+
+		# Cleanup
+		frappe.set_user("Administrator")
+		frappe.delete_doc("File", file_name, force=1)
+
+	def test_permission_check_based_on_attached_doctype(self):
+		"""Permission check should be based on attached_to_doctype, not just File doctype"""
+		from frappe.permissions import add_permission, update_permission_property
+
+		# Create a test doctype
+		test_doctype = frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"name": "Test File Attachment",
+				"module": "Core",
+				"custom": 1,
+				"fields": [{"fieldname": "test_field", "fieldtype": "Data", "label": "Test Field"}],
+			}
+		)
+		if not frappe.db.exists("DocType", "Test File Attachment"):
+			test_doctype.insert()
+
+		# Note: upload_public_files is a standard right (in std_rights), so it doesn't need a Permission Type
+		# It's available for all doctypes by default
+
+		# Grant upload_public_files permission on Test File Attachment but NOT on File
+		add_permission("Test File Attachment", "Test File Uploader", 0)
+		update_permission_property("Test File Attachment", "Test File Uploader", 0, "read", 1)
+		update_permission_property("Test File Attachment", "Test File Uploader", 0, "write", 1)
+
+		# Set upload_public_files directly
+		custom_docperm_name = frappe.db.get_value(
+			"Custom DocPerm",
+			{"parent": "Test File Attachment", "role": "Test File Uploader", "permlevel": 0},
+		)
+		if custom_docperm_name:
+			frappe.db.set_value("Custom DocPerm", custom_docperm_name, "upload_public_files", 1)
+
+		add_permission("File", "Test File Uploader", 0)
+		update_permission_property("File", "Test File Uploader", 0, "read", 1)
+		update_permission_property("File", "Test File Uploader", 0, "write", 1)
+
+		# Set upload_public_files to 0 directly
+		custom_docperm_name = frappe.db.get_value(
+			"Custom DocPerm",
+			{"parent": "File", "role": "Test File Uploader", "permlevel": 0},
+		)
+		if custom_docperm_name:
+			frappe.db.set_value("Custom DocPerm", custom_docperm_name, "upload_public_files", 0)
+
+		# Commit changes and clear all caches
+		frappe.db.commit()
+		frappe.clear_cache()
+		frappe.reload_doctype("File")
+		frappe.reload_doctype("Test File Attachment")
+
+		# Create a test document
+		test_doc = frappe.get_doc({"doctype": "Test File Attachment", "test_field": "test"})
+		test_doc.insert()
+
+		frappe.set_user("test_file_uploader@example.com")
+		# Should be able to upload public file when attached to Test File Attachment
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "test_attached_file.txt",
+				"content": "test content",
+				"is_private": 0,
+				"attached_to_doctype": "Test File Attachment",
+				"attached_to_name": test_doc.name,
+			}
+		)
+		file_doc.save()
+		self.assertEqual(file_doc.is_private, 0)
+
+		# Cleanup
+		frappe.set_user("Administrator")
+		file_doc.delete()
+		test_doc.delete()
+		frappe.delete_doc("DocType", "Test File Attachment", force=1)

--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -336,6 +336,7 @@ frappe.PermissionEngine = class PermissionEngine {
 			"export",
 			"share",
 			"mask",
+			"upload_public_files",
 		];
 	}
 

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -252,3 +252,4 @@ frappe.patches.v16_0.auto_generate_desktop_icon_and_sidebar
 frappe.patches.v16_0.add_private_workspaces_to_sidebar
 frappe.core.doctype.communication_link.patches.copy_communication_date_to_link
 frappe.core.doctype.communication.patches.drop_ref_dt_dn_index
+frappe.patches.v16_0.set_default_upload_public_files_permission

--- a/frappe/patches/v16_0/set_default_upload_public_files_permission.py
+++ b/frappe/patches/v16_0/set_default_upload_public_files_permission.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2025, Frappe Technologies and Contributors
+# License: MIT. See LICENSE
+
+"""Set upload_public_files permission to 1 (checked) by default for all existing DocPerm entries"""
+
+import frappe
+
+
+def execute():
+	"""Set upload_public_files=1 for all existing DocPerm and Custom DocPerm entries where it's not already set"""
+	# Update all DocPerm entries where upload_public_files is 0 or NULL
+	frappe.db.sql(
+		"""
+		UPDATE `tabDocPerm`
+		SET `upload_public_files` = 1
+		WHERE `upload_public_files` = 0 OR `upload_public_files` IS NULL
+	"""
+	)
+	# Update all Custom DocPerm entries where upload_public_files is 0 or NULL
+	frappe.db.sql(
+		"""
+		UPDATE `tabCustom DocPerm`
+		SET `upload_public_files` = 1
+		WHERE `upload_public_files` = 0 OR `upload_public_files` IS NULL
+	"""
+	)
+	frappe.db.commit()

--- a/frappe/patches/v16_0/set_default_upload_public_files_permission.py
+++ b/frappe/patches/v16_0/set_default_upload_public_files_permission.py
@@ -24,4 +24,3 @@ def execute():
 		WHERE `upload_public_files` = 0 OR `upload_public_files` IS NULL
 	"""
 	)
-	frappe.db.commit()

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -25,6 +25,7 @@ std_rights = (
 	"import",
 	"export",
 	"share",
+	"upload_public_files",
 )
 
 rights = std_rights

--- a/frappe/public/js/frappe/file_uploader/FilePreview.vue
+++ b/frappe/public/js/frappe/file_uploader/FilePreview.vue
@@ -92,6 +92,9 @@ let emit = defineEmits(["toggle_optimize", "toggle_private", "toggle_image_cropp
 // props
 const props = defineProps({
 	file: Object,
+	doctype: {
+		default: null,
+	},
 	allow_toggle_private: {
 		default: true,
 	},
@@ -128,7 +131,12 @@ let allow_toggle_optimize = computed(() => {
 	);
 });
 let allow_toggle_private = computed(() => {
-	return props.allow_toggle_private && !uploaded.value && !props.file.failed;
+	if (!props.allow_toggle_private || uploaded.value || props.file.failed) {
+		return false;
+	}
+	// Check permission based on doctype (fallback to "File" if not provided)
+	const doctype_to_check = props.doctype || "File";
+	return frappe.utils.can_upload_public_files(doctype_to_check);
 });
 let is_cropable = computed(() => {
 	let croppable_types = ["image/jpeg", "image/png"];

--- a/frappe/public/js/frappe/file_uploader/FilePreview.vue
+++ b/frappe/public/js/frappe/file_uploader/FilePreview.vue
@@ -134,9 +134,9 @@ let allow_toggle_private = computed(() => {
 	if (!props.allow_toggle_private || uploaded.value || props.file.failed) {
 		return false;
 	}
-	// Check permission based on doctype (fallback to "File" if not provided)
-	const doctype_to_check = props.doctype || "File";
-	return frappe.utils.can_upload_public_files(doctype_to_check);
+	// Check permission based on doctype
+	// If doctype is not provided, utils.js will default to "File"
+	return frappe.utils.can_upload_public_files(props.doctype);
 });
 let is_cropable = computed(() => {
 	let croppable_types = ["image/jpeg", "image/png"];

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -198,6 +198,7 @@
 					v-for="(file, i) in files"
 					:key="file.name"
 					:file="file"
+					:doctype="doctype"
 					:allow_toggle_private="allow_toggle_private"
 					:allow_toggle_optimize="allow_toggle_optimize"
 					@remove="remove_file(file)"

--- a/frappe/public/js/frappe/file_uploader/file_uploader.bundle.js
+++ b/frappe/public/js/frappe/file_uploader/file_uploader.bundle.js
@@ -92,7 +92,8 @@ class FileUploader {
 			() => this.uploader.files,
 			(files) => {
 				let all_private = files.every((file) => file.private);
-				if (this.dialog && frappe.utils.can_upload_public_files(this.doctype || "File")) {
+				// If doctype is not provided, utils.js will default to "File"
+				if (this.dialog && frappe.utils.can_upload_public_files(this.doctype)) {
 					this.dialog.set_secondary_action_label(
 						all_private ? __("Set all public") : __("Set all private")
 					);
@@ -142,8 +143,8 @@ class FileUploader {
 	}
 
 	make_dialog(title) {
-		const doctype_to_check = this.doctype || "File";
-		const can_upload_public = frappe.utils.can_upload_public_files(doctype_to_check);
+		// If doctype is not provided, utils.js will default to "File"
+		const can_upload_public = frappe.utils.can_upload_public_files(this.doctype);
 
 		const dialog_options = {
 			title: title || __("Upload"),

--- a/frappe/public/js/frappe/file_uploader/file_uploader.bundle.js
+++ b/frappe/public/js/frappe/file_uploader/file_uploader.bundle.js
@@ -30,6 +30,9 @@ class FileUploader {
 	} = {}) {
 		frm && frm.attachments.max_reached(true);
 
+		// Store doctype for permission checks
+		this.doctype = doctype;
+
 		if (!wrapper) {
 			this.make_dialog(dialog_title);
 		} else {
@@ -89,7 +92,7 @@ class FileUploader {
 			() => this.uploader.files,
 			(files) => {
 				let all_private = files.every((file) => file.private);
-				if (this.dialog) {
+				if (this.dialog && frappe.utils.can_upload_public_files(this.doctype || "File")) {
 					this.dialog.set_secondary_action_label(
 						all_private ? __("Set all public") : __("Set all private")
 					);
@@ -139,18 +142,27 @@ class FileUploader {
 	}
 
 	make_dialog(title) {
-		this.dialog = new frappe.ui.Dialog({
+		const doctype_to_check = this.doctype || "File";
+		const can_upload_public = frappe.utils.can_upload_public_files(doctype_to_check);
+
+		const dialog_options = {
 			title: title || __("Upload"),
 			primary_action_label: __("Upload"),
 			primary_action: () => this.upload_files(),
-			secondary_action_label: __("Set all private"),
-			secondary_action: () => {
-				this.uploader.toggle_all_private();
-			},
 			on_page_show: () => {
 				this.uploader.wrapper_ready = true;
 			},
-		});
+		};
+
+		// Only show toggle button if user has permission to upload public files
+		if (can_upload_public) {
+			dialog_options.secondary_action_label = __("Set all private");
+			dialog_options.secondary_action = () => {
+				this.uploader.toggle_all_private();
+			};
+		}
+
+		this.dialog = new frappe.ui.Dialog(dialog_options);
 
 		this.wrapper = this.dialog.body;
 		this.dialog.show();

--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -30,6 +30,7 @@ $.extend(frappe.perm, {
 		"print",
 		"email",
 		"share",
+		"upload_public_files",
 	],
 
 	doctype_perm: {},

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1954,10 +1954,11 @@ Object.assign(frappe.utils, {
 
 	/**
 	 * Check if current user can upload public files for the given doctype.
-	 * @param {string} doctype - The doctype to check permissions for. Defaults to "File" if not provided.
+	 * Uses cached permissions for performance, but server-side is authoritative.
+	 * @param {string} doctype - The doctype to check permissions for. Must be provided.
 	 * @returns {boolean}
 	 */
-	can_upload_public_files(doctype = "File") {
+	can_upload_public_files(doctype) {
 		// Administrator has all permissions
 		if (
 			frappe.session.user === "Administrator" ||
@@ -1965,11 +1966,19 @@ Object.assign(frappe.utils, {
 		) {
 			return true;
 		}
+		// If doctype is not provided, we're uploading from File doctype itself
+		// So check "File" doctype permissions
+		if (!doctype) {
+			doctype = "File";
+		}
 		try {
+			// Use cached permissions for UI responsiveness
+			// Server-side will always validate and block if needed
 			return frappe.perm.has_perm(doctype, 0, "upload_public_files");
 		} catch (e) {
-			// If permission type doesn't exist, allow by default (backward compatibility)
-			return true;
+			// If permission type doesn't exist or permission is not defined,
+			// treat as 0 (only private files allowed)
+			return false;
 		}
 	},
 });

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1951,4 +1951,25 @@ Object.assign(frappe.utils, {
 			});
 		});
 	},
+
+	/**
+	 * Check if current user can upload public files for the given doctype.
+	 * @param {string} doctype - The doctype to check permissions for. Defaults to "File" if not provided.
+	 * @returns {boolean}
+	 */
+	can_upload_public_files(doctype = "File") {
+		// Administrator has all permissions
+		if (
+			frappe.session.user === "Administrator" ||
+			frappe.user_roles.includes("Administrator")
+		) {
+			return true;
+		}
+		try {
+			return frappe.perm.has_perm(doctype, 0, "upload_public_files");
+		} catch (e) {
+			// If permission type doesn't exist, allow by default (backward compatibility)
+			return true;
+		}
+	},
 });


### PR DESCRIPTION
# Add Per-DocType Permission Control for Public File Uploads

## Summary

This PR introduces granular permission control for public file uploads on a per-DocType basis. Previously, file upload permissions were global. Now, administrators can control which roles can upload public files for specific DocTypes through the Role Permission Manager.

## Problem Statement

Previously, there was no way to restrict public file uploads on a per-DocType basis. For example, you couldn't allow a role to upload public files for "Item" but not for "Customer". This PR adds a new `upload_public_files` permission type that can be configured per DocType and role combination.

## Solution

### Key Features

1. **New Permission Type**: Added `upload_public_files` as a standard permission right (similar to `read`, `write`, etc.)
2. **Per-DocType Control**: Permission is checked based on the `attached_to_doctype` of the file,
3. **Role Permission Manager Integration**: The permission appears as a checkbox in the Role Permission Manager for all DocTypes
4. **UI Updates**: 
   - File uploader dialog shows/hides "Private" checkbox and "Set all private/public" toggle based on permission
   - File form disables `is_private` field if user lacks permission
5. **Backend Validation**: Server-side validation ensures users cannot upload public files without proper permission
6. **Administrator Bypass**: Administrator role bypasses all permission checks (standard Frappe behavior)

#### Migration

- **`frappe/patches/v16_0/set_default_upload_public_files_permission.py`**: 
  - Sets `upload_public_files = 1` for all existing DocPerm and Custom DocPerm entries
  - Ensures backward compatibility (existing permissions default to allowing public uploads)

### Bench Command

To enable public file uploads for all doctypes in an app:

```bash
bench --site <site-name> allow-public-files <app-name>
```

**Example:**
```bash
bench --site localhost allow-public-files frappe
bench --site localhost allow-public-files erpnext
```

This command:
- Updates all DocPerm entries for doctypes in the specified app
- Updates all Custom DocPerm entries for doctypes in the specified app
- Sets `upload_public_files = 1` only where it's currently `0` or `NULL`
- Useful for bulk updates after installing/updating apps

## Usage

### For Administrators

1. Navigate to **Role Permission Manager**
2. Select a **Role** and **DocType**
3. Check/uncheck the **"Upload Public Files"** checkbox
4. Save the permission

### Example Scenarios

**Scenario 1**: Doctype named "Custom"
- When uploading/attaching a file to this DocType:
  - **Permission = 0 (explicitly disabled)** → Only private files allowed
  - **Permission = 1 (explicitly enabled)** → Public + private files allowed
  - **Permission NOT defined** → Treated as 0 (only private files allowed)
  - **Administrator** → Always allowed (bypass)
- **No File doctype fallback**: When attached to "Custom", only "Custom" DocType permissions are checked

**Scenario 2**: Uploading directly from File DocType
- When user uploads a file directly from the "File" DocType form (not attached to any document):
  - Checks "File" DocType permissions
  - Same permission logic applies (0 = disabled, 1 = enabled, not defined = disabled)
  
  **Scenario 3**: Multiple Roles
- If user has multiple roles with different permission values:
  - **Any role has value 1** → ENABLED (can upload public files)
  - **All roles have value 0** → DISABLED (only private files)
  - **All roles have permission NOT defined** → Treated as 0 (only private files)


## Backward Compatibility

- **Default Behavior**: All existing DocPerm entries are set to `upload_public_files = 1` via migration patch
- **Graceful Degradation**: If permission type doesn't exist (older versions), the system allows public uploads by default
- **No Breaking Changes**: Existing installations will continue to work as before after migration


### Migration
- `frappe/patches/v16_0/set_default_upload_public_files_permission.py` - Migration patch
- `frappe/patches.txt` - Added patch entry

## Testing

### Python Unit Tests

Added comprehensive test suite in `frappe/core/doctype/file/test_file.py`:

### Cypress UI Tests

Added UI tests in `cypress/integration/file_uploader.js`:

## Screenshots

- Role Permission Manager with "Upload Public Files" checkbox

<img width="2449" height="384" alt="Screenshot 2025-12-02 174820" src="https://github.com/user-attachments/assets/ae38869f-2172-4cde-8017-bd04cfc34135" />

- File uploader dialog with "Private" checkbox visible (user with permission)
<img width="1210" height="587" alt="Screenshot 2025-11-25 104500" src="https://github.com/user-attachments/assets/550e94cb-aa09-4b5a-9b70-20c3b29d6ee6" />


- File uploader dialog without "Private" checkbox (user without permission)
<img width="1228" height="657" alt="Screenshot 2025-11-25 104427" src="https://github.com/user-attachments/assets/5d40d51e-852d-446b-ba3b-2bdde429f40c" />

- File form with `is_private` field disabled (user without permission)
<img width="1382" height="904" alt="Screenshot 2025-11-25 114119" src="https://github.com/user-attachments/assets/8168f06c-ea94-48f4-a590-320b2ff30862" />

-Bench Command
<img width="1740" height="212" alt="Screenshot 2025-12-05 125927" src="https://github.com/user-attachments/assets/eb9b82c6-f278-46c3-a799-75d7d3b90396" />


## Documentation
Docs: https://docs.frappe.io/erpnext/user/manual/en/role-based-permissions

## Checklist

- [x] Code follows Frappe coding standards
- [x] Tests added/updated (Python unit tests + Cypress UI tests)
- [x] Migration patch added for backward compatibility
- [x] Documentation updated (this PR description)
- [x] No breaking changes introduced
- [x] Administrator bypass works correctly
- [x] Permission check works per-DocType
- [x] UI elements show/hide correctly based on permissions
- [x] Backend validation prevents unauthorized public uploads


## Notes

- The permission defaults to `1` (checked) for all existing DocPerm entries to maintain backward compatibility
- Administrator role always bypasses permission checks (standard Frappe behavior)
- Permission is checked based on `attached_to_doctype`, falling back to "File" if not attached
- The feature is fully backward compatible and requires no manual intervention after migration

