### PR TITLE
ci: upload cypress recordings on test failure

### DIFF
--- a/.github/workflows/_base-ui-tests.yml
+++ b/.github/workflows/_base-ui-tests.yml
@@ -103,6 +103,7 @@ jobs:
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 
       - name: Run Tests
+        id: ui-tests
         run: |
           source ${GITHUB_WORKSPACE}/env/bin/activate
           bench --site test_site \
@@ -129,11 +130,13 @@ jobs:
           name: coverage-js-${{ matrix.index }}
           path: ./apps/${{ github.event.repository.name }}/.cypress-coverage/clover.xml
       - name: Compress Cypress Videos
+        if: steps.ui-tests.outcome == 'failure'
         run: | 
             if find ./cypressVideos -mindepth 1 | read; then
               zip -r cypress_recordings.zip ./cypressVideos
             fi
       - name: Upload Cypress Videos
+        if: steps.ui-tests.outcome == 'failure'
         uses: actions/upload-artifact@v5
         with:
           name: Cypress CI Video Recordings


### PR DESCRIPTION
In GitHub Actions, when a step fails (like a failing test in "Run Tests"), all subsequent steps are skipped by default unless they explicitly specify when they should run.

We want the upload video steps to run only when "Run Tests" failed.

Extends https://github.com/frappe/frappe/pull/35022
