### PR TITLE
ci: always upload cypress recordings

### DIFF
--- a/.github/workflows/_base-ui-tests.yml
+++ b/.github/workflows/_base-ui-tests.yml
@@ -130,13 +130,13 @@ jobs:
           name: coverage-js-${{ matrix.index }}
           path: ./apps/${{ github.event.repository.name }}/.cypress-coverage/clover.xml
       - name: Compress Cypress Videos
-        if: steps.ui-tests.outcome == 'failure'
+        if: always() && steps.ui-tests.outcome == 'failure'
         run: | 
             if find ./cypressVideos -mindepth 1 | read; then
               zip -r cypress_recordings.zip ./cypressVideos
             fi
       - name: Upload Cypress Videos
-        if: steps.ui-tests.outcome == 'failure'
+        if: always() && steps.ui-tests.outcome == 'failure'
         uses: actions/upload-artifact@v5
         with:
           name: Cypress CI Video Recordings


### PR DESCRIPTION
Changed the `if` condition for compressing and uploading Cypress videos to use `always() && steps.ui-tests.outcome == 'failure'`, ensuring these steps run regardless of prior step failures.

Extends https://github.com/frappe/frappe/pull/35022