### PR TITLE
fix!: disallow setting link values not matching filters

### DIFF
--- a/cypress/integration/control_link.js
+++ b/cypress/integration/control_link.js
@@ -79,7 +79,7 @@ context("Control Link", () => {
 	it("should unset invalid value", () => {
 		get_dialog_with_link().as("dialog");
 
-		cy.intercept("/api/method/frappe.client.validate_link*").as("validate_link");
+		cy.intercept("/api/method/frappe.client.validate_link_and_fetch*").as("validate_link");
 		cy.get(".frappe-control[data-fieldname=link] input").focus().as("input");
 		// Wait for dropdown to appear (request might be cached)
 		cy.get("@input").parent().findByRole("listbox").should("be.visible");
@@ -92,7 +92,7 @@ context("Control Link", () => {
 	it("should be possible set empty value explicitly", () => {
 		get_dialog_with_link().as("dialog");
 
-		cy.intercept("/api/method/frappe.client.validate_link*").as("validate_link");
+		cy.intercept("/api/method/frappe.client.validate_link_and_fetch*").as("validate_link");
 
 		cy.get(".frappe-control[data-fieldname=link] input").focus().as("input");
 		// Wait for dropdown to appear (request might be cached)
@@ -179,7 +179,7 @@ context("Control Link", () => {
 	it("should update dependant fields (via fetch_from)", () => {
 		cy.get("@todos").then((todos) => {
 			cy.visit(`/desk/todo/${todos[0]}`);
-			cy.intercept("/api/method/frappe.client.validate_link*").as("validate_link");
+			cy.intercept("/api/method/frappe.client.validate_link_and_fetch*").as("validate_link");
 
 			cy.fill_field("assigned_by", cy.config("testUser"), "Link");
 			cy.call("frappe.client.get_value", {
@@ -203,7 +203,7 @@ context("Control Link", () => {
 				""
 			);
 
-			cy.window().its("cur_frm.doc.assigned_by").should("eq", null);
+			cy.window().its("cur_frm.doc.assigned_by").should("eq", undefined);
 
 			// set valid value again
 			cy.get("@input").clear().focus();

--- a/cypress/integration/dashboard_chart.js
+++ b/cypress/integration/dashboard_chart.js
@@ -12,6 +12,9 @@ context("Dashboard Chart", () => {
 		cy.fill_field("chart_name", "Test Chart", "Data");
 		cy.fill_field("document_type", "Workspace Link", "Link");
 
+		// wait for link field events to complete
+		cy.wait(1000);
+
 		cy.get('[data-fieldname="filters_json"]').click();
 		cy.get(".modal-dialog", { timeout: 500 }).should("be.visible");
 

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -9,6 +9,7 @@ import frappe.model
 import frappe.utils
 from frappe import _
 from frappe.desk.reportview import validate_args
+from frappe.desk.search import make_filter_tuple, search_widget
 from frappe.model.utils import is_virtual_doctype
 from frappe.utils import attach_expanded_links, get_safe_filters
 from frappe.utils.caching import http_cache
@@ -406,52 +407,76 @@ def is_document_amended(doctype: str, docname: str):
 	return False
 
 
-@frappe.whitelist()
-def validate_link(doctype: str, docname: str, fields=None):
-	if not isinstance(doctype, str):
-		frappe.throw(_("DocType must be a string"))
-
-	if not isinstance(docname, str):
-		frappe.throw(_("Document Name must be a string"))
-
-	parent_doctype = None
-	if doctype != "DocType":
-		if frappe.get_meta(doctype).istable:  # needed for links to child rows
-			parent_doctype = frappe.db.get_value(doctype, docname, "parenttype")
-		if not (
-			frappe.has_permission(doctype, "select", parent_doctype=parent_doctype)
-			or frappe.has_permission(doctype, "read", parent_doctype=parent_doctype)
-		):
-			frappe.throw(
-				_("You do not have Read or Select Permissions for {}").format(frappe.bold(doctype)),
-				frappe.PermissionError,
-			)
-
-	values = frappe._dict()
+@frappe.whitelist(methods=["GET", "POST"])
+def validate_link_and_fetch(
+	doctype: str,
+	docname: str,
+	fields_to_fetch: list[str] | str | None = None,
+	# search_widget parameters
+	query: str | None = None,
+	filters: dict | list | str | None = None,
+	**search_args,
+):
+	if not docname:
+		frappe.throw(_("Document Name must not be empty"))
 
 	if is_virtual_doctype(doctype):
 		try:
-			frappe.get_doc(doctype, docname)
-			values.name = docname
+			doc = frappe.get_doc(doctype, docname)
+			doc.check_permission("select" if frappe.only_has_select_perm(doctype) else "read")
+			return {"name": doc.name}
+
 		except frappe.DoesNotExistError:
 			frappe.clear_last_message()
-			frappe.msgprint(
-				_("Document {0} {1} does not exist").format(frappe.bold(doctype), frappe.bold(docname)),
+			return {}
+
+	fields_to_fetch = frappe.parse_json(fields_to_fetch)
+
+	# only cache is no fields to fetch and no filters specified by user
+	can_cache = not (fields_to_fetch or filters)
+
+	# Use search_widget to validate - ensures filters/custom queries are respected
+	# in addition to standard permission checks
+	search_args["txt"] = docname
+	search_result = frappe.call(
+		search_widget,
+		doctype=doctype,
+		query=query,
+		filters=filters,
+		**search_args,
+		for_link_validation=True,
+	)
+
+	if not search_result:
+		return {}  # does not exist or filtered out
+
+	# get value in the right case and type (str | int)
+	# for matching with search result
+	columns_to_fetch = ["name"]
+	if frappe.is_table(doctype):
+		columns_to_fetch.append("parenttype")  # for child table permission check
+
+	values = frappe.db.get_value(doctype, docname, columns_to_fetch, as_dict=True)
+	name_to_compare = values.name
+	# this will be used to fetch fields later
+	parent_doctype = values.pop("parenttype", None)
+
+	if not name_to_compare:
+		return {}  # does not exist
+
+	# for custom queries that don't respect filters
+	if not any(item[0] == name_to_compare for item in search_result):
+		return {}  # no permission or filtered out
+
+	if not fields_to_fetch:
+		if can_cache:
+			frappe.local.response_headers.set(
+				"Cache-Control", "private,max-age=1800,stale-while-revalidate=7200"
 			)
 		return values
 
-	values.name = frappe.db.get_value(doctype, docname, cache=True)
-
-	fields = frappe.parse_json(fields)
-	if not values.name:
-		return values
-
-	if not fields:
-		frappe.local.response_headers.set("Cache-Control", "private,max-age=1800,stale-while-revalidate=7200")
-		return values
-
 	try:
-		values.update(get_value(doctype, fields, docname, parent=parent_doctype))
+		values.update(get_value(doctype, fields_to_fetch, docname, parent=parent_doctype))
 	except frappe.PermissionError:
 		frappe.clear_last_message()
 		frappe.msgprint(

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -432,8 +432,8 @@ def validate_link_and_fetch(
 
 	fields_to_fetch = frappe.parse_json(fields_to_fetch)
 
-	# only cache is no fields to fetch and no filters specified by user
-	can_cache = not (fields_to_fetch or filters)
+	# only cache is no fields to fetch and request is GET
+	can_cache = not fields_to_fetch and frappe.request.method == "GET"
 
 	# Use search_widget to validate - ensures filters/custom queries are respected
 	# in addition to standard permission checks

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -16,6 +16,8 @@ from frappe.utils import cint, cstr, escape_html, unique
 from frappe.utils.caching import http_cache
 from frappe.utils.data import make_filter_tuple
 
+PAGE_LENGTH_FOR_LINK_VALIDATION = 25_000
+
 
 def sanitize_searchfield(searchfield: str):
 	if not searchfield:
@@ -130,7 +132,7 @@ def search_widget(
 		# for custom queries that don't respect filters but respect limit (rare)
 		# or for when we have to rely on txt
 		# we want to match "A" with "A" only and not "A1", "BA" etc.
-		page_length = 100_000
+		page_length = PAGE_LENGTH_FOR_LINK_VALIDATION
 
 	if query:  # Query = custom search query i.e. python function
 		try:

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -76,6 +76,7 @@ def search_widget(
 	ignore_user_permissions: bool = False,
 	*,
 	link_fieldname: str | None = None,
+	for_link_validation: bool = False,
 ):
 	if ignore_user_permissions:
 		if reference_doctype and link_fieldname:
@@ -102,6 +103,34 @@ def search_widget(
 
 	if not query and doctype in standard_queries:
 		query = standard_queries[doctype][-1]
+
+	if filters is None:
+		filters = {}
+
+	are_filters_dict = isinstance(filters, dict)
+	include_disabled = False
+	if not query and are_filters_dict:
+		if "include_disabled" in filters:
+			if filters["include_disabled"] == 1:
+				include_disabled = True
+			filters.pop("include_disabled")
+
+		filters = [make_filter_tuple(doctype, key, value) for key, value in filters.items()]
+		are_filters_dict = False
+
+	if for_link_validation:
+		if are_filters_dict:
+			# we add filter if possible, otherwise rely on txt
+			if "name" not in filters:
+				filters["name"] = txt
+		else:
+			filters.append([doctype, "name", "=", txt])
+
+		as_dict = False
+		# for custom queries that don't respect filters but respect limit (rare)
+		# or for when we have to rely on txt
+		# we want to match "A" with "A" only and not "A1", "BA" etc.
+		page_length = 100_000
 
 	if query:  # Query = custom search query i.e. python function
 		try:
@@ -132,17 +161,6 @@ def search_widget(
 				return []
 
 	meta = frappe.get_meta(doctype)
-
-	include_disabled = False
-	if filters and "include_disabled" in filters:
-		if filters["include_disabled"] == 1:
-			include_disabled = True
-		filters.pop("include_disabled")
-
-	if isinstance(filters, dict):
-		filters = [make_filter_tuple(doctype, key, value) for key, value in filters.items()]
-	elif filters is None:
-		filters = []
 	or_filters = []
 
 	# build from doctype
@@ -189,7 +207,7 @@ def search_widget(
 	# `idx` is number of times a document is referred, check link_count.py
 	order_by = f"idx desc, {order_by_based_on_meta}"
 
-	if not meta.translated_doctype:
+	if not for_link_validation and not meta.translated_doctype:
 		_txt = frappe.db.escape((txt or "").replace("%", "").replace("@", ""))
 		# locate returns 0 if string is not found, convert 0 to null and then sort null to end in order by
 		_relevance_expr = {"DIV": [1, {"NULLIF": [{"LOCATE": [_txt, "name"]}, 0]}]}
@@ -214,29 +232,30 @@ def search_widget(
 		strict=False,
 	)
 
-	if meta.translated_doctype:
-		# Filtering the values array so that query is included in very element
-		values = (
-			result
-			for result in values
-			if any(
-				re.search(f"{re.escape(txt)}.*", _(cstr(value)) or "", re.IGNORECASE)
-				for value in (result.values() if as_dict else result)
+	if not for_link_validation:
+		if meta.translated_doctype:
+			# Filtering the values array so that query is included in very element
+			values = (
+				result
+				for result in values
+				if any(
+					re.search(f"{re.escape(txt)}.*", _(cstr(value)) or "", re.IGNORECASE)
+					for value in (result.values() if as_dict else result)
+				)
 			)
-		)
 
-	# Sorting the values array so that relevant results always come first
-	# This will first bring elements on top in which query is a prefix of element
-	# Then it will bring the rest of the elements and sort them in lexicographical order
-	values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
+		# Sorting the values array so that relevant results always come first
+		# This will first bring elements on top in which query is a prefix of element
+		# Then it will bring the rest of the elements and sort them in lexicographical order
+		values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
 
-	# remove _relevance from results
-	if not meta.translated_doctype:
-		if as_dict:
-			for r in values:
-				r.pop("_relevance", None)
-		else:
-			values = [r[:-1] for r in values]
+		# remove _relevance from results
+		if not meta.translated_doctype:
+			if as_dict:
+				for r in values:
+					r.pop("_relevance", None)
+			else:
+				values = [r[:-1] for r in values]
 
 	return values
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -375,9 +375,9 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 	}
 
 	/**
-	 * Determine if we should use GET (enables HTTP caching) or POST.
-	 * Use GET for empty searches with filters that fit in URL.
-	 * Use POST for searches with text or large filters.
+	 * Helps determine if we should use GET (enables HTTP caching) or POST.
+	 * Use GET for filters that fit in URL.
+	 * Use POST for large filters.
 	 */
 	are_filters_large(filters, max_get_size = 2000) {
 		if (!filters) return [false, filters];


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/34063
Closes https://github.com/frappe/frappe/issues/7235

## Summary

Refactors link field validation to properly respect filters, improving security and data integrity by preventing users from setting link values that don't match configured filters.

## Changes

### Backend (`frappe/client.py`)
- **Replaced `validate_link` with `validate_link_and_fetch`**: New unified API that validates links while respecting all filters (static, dynamic, custom queries)
- **Filter validation**: Now calls `search_widget` with filters to ensure the entered value passes all configured restrictions
- **Returns empty dict `{}` instead of `{"name": None}`** when validation fails (document doesn't exist or is filtered out)

### Search optimization (`frappe/desk/search.py`)
- Added `for_link_validation` parameter to `search_widget`
- When validating, sets `page_length=25_000` to handle custom queries that don't respect filters
- Skips unnecessary processing (translation, relevance sorting) during validation for better performance

### Frontend (`frappe/public/js/frappe/form/controls/link.js`)
- **Refactored `validate_link_and_fetch`**: Now uses new API and passes all search args (filters, query, etc.)
- **Extracted `get_search_args`**: Reusable method for building search parameters
- **Improved debounce handling**: Cancels pending search when validation runs
- **Smart caching**: Uses GET cached requests when possible
- **Cleaner field updates**: Sets `undefined` (not `null`) when validation fails, matching JS conventions
- Fixed `on_input` to work without event parameter (for programmatic calls)

### Tests
- Updated test to use `validate_link_and_fetch` and verify filter behavior
- Added test cases for filtered validation scenarios
- Updated Cypress tests for new API endpoint

## Breaking Changes

- `validate_link` API is removed (replaced by `validate_link_and_fetch`)
- Invalid links now set field to `undefined` instead of `null` in JS