### PR TITLE
fix(data import): use translated column names for validations as per user-set language

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -494,7 +494,7 @@ class ImportFile:
 			frappe.throw(_("Import template should contain a Header row."), title=_("Template Error"))
 
 		for field in mandatory_fields:
-			if field not in headers:
+			if field not in headers or _(field) not in headers:
 				frappe.throw(
 					_(
 						"Mandatory field {0} is missing in the import template for {1}. Please correct the template and try again."


### PR DESCRIPTION
**Problem:**
**fix(Data Import):** Since the last update of Frappe v15.91.0, the `Data Import` feature seems to be having problems in languages other than english i.e. the column names are having issues with translations. On insertion of the file, an error message pops up indicating “Mandatory field Warehouse Name is missing in the import template for Warehouse. Please correct the template and try again.”  because in french the column name is “Nom de l'Entrepôt”. This indicates that the column name comparison is happening in `English` instead of  respecting the language that is supposed to be used i.e over here `French`. This PR aims to fix this issue by respecting user-set language and accordingly using the translated column names for validations instead of a fixed english comparison. This PR's primary purpose is to resolve issue #35045 and to resolve a support ticket for the same. 

Note: **This PR is a follow-up to a bug in [commit be4f2a4](https://github.com/frappe/frappe/commit/be4f2a474c18ecb80a69bee11fa543e7513408e6). The PR fixes the bug to ensure column translations are respected before validations.**

**Before**:
<img width="1252" height="619" alt="image" src="https://github.com/user-attachments/assets/8ecdde2f-b444-49f3-bb43-61cace4df704" />


**After**:
<img width="1478" height="950" alt="image" src="https://github.com/user-attachments/assets/b7cdb144-4415-4832-a77e-d84502d381be" />


fixes #35045 