### PR TITLE
fix: prevent sidebar click from refreshing page

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -239,18 +239,35 @@ frappe.ui.sidebar_item.TypeSectionBreak = class SectionBreakSidebarItem extends 
 	setup_event_listner() {
 		const me = this;
 
-		$(this.wrapper.find(".standard-sidebar-item")[0]).on("click", (e) => {
+		const toggle_section = () => {
 			me.collapsed = me.$drop_icon.find("use").attr("href") === "#icon-chevron-down";
 			me.toggle();
+			me.save_section_break_state();
+		};
 
-			if (e.originalEvent.isTrusted) {
-				me.save_section_break_state();
-			}
-			if (!frappe.app.sidebar.sidebar_expanded) {
+		const expand_sidebar_if_collapsed = () => {
+			if (frappe.app.sidebar && !frappe.app.sidebar.sidebar_expanded) {
 				frappe.app.sidebar.open();
-				this.open();
 			}
-		});
+		};
+
+		const handle_click = (e, is_arrow_click = false) => {
+			e.preventDefault();
+			e.stopPropagation();
+
+			expand_sidebar_if_collapsed();
+
+			if (!is_arrow_click && $(e.target).closest(".drop-icon").length) {
+				return;
+			}
+
+			toggle_section();
+		};
+
+		this.$drop_icon.on("click", (e) => handle_click(e, true));
+
+		const $item = $(this.wrapper).find(".standard-sidebar-item").eq(0);
+		$item.on("click", handle_click);
 	}
 	save_section_break_state() {
 		if (!this.section_breaks_state[this.workspace_title]) {


### PR DESCRIPTION
**Issue :** 

Clicking a sidebar item (label or open/close icon) refreshes the current page instead of just expanding/collapsing it.

**Before :**


https://github.com/user-attachments/assets/5ad7d7f6-9380-4bee-9cf0-eac7f6a7bae1



**After :**


https://github.com/user-attachments/assets/4c9bcce9-3c96-47ff-8c1d-09f932d43d0c

