### PR TITLE
feat: show search on Nav on mobile devices

### DIFF
--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -41,9 +41,9 @@
 
 .desktop-navbar-modal-search{
     background-color: var(--control-bg);
-	border-radius: var(--border-radius-sm);
-	padding: 6px 10px;
-	width: 100%;
+    border-radius: var(--border-radius-sm);
+    padding: 6px 10px;
+    width: 100%;
 }
 #brand-logo{
     width: auto;

--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -16,7 +16,7 @@
             >
                 <span class="desktop-search-icon">
                     <svg class="icon icon-sm"><use href="#icon-search"></use></svg>
-                    Search
+                    {{ _("Search") }}
                 </span>
                 <span>
                     {{ "⌘ K" if is_mac else "Ctrl K" }}

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -234,8 +234,9 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 	add_standard_items(items) {
 		if (this.standard_items_setup) return;
-		this.standard_items = [
-			{
+		this.standard_items = [];
+		if (!frappe.is_mobile()) {
+			this.standard_items.push({
 				label: "Search",
 				icon: "search",
 				type: "Button",
@@ -243,8 +244,9 @@ frappe.ui.Sidebar = class Sidebar {
 				suffix: {
 					keyboard_shortcut: "CtrlK",
 				},
-			},
-		];
+				class: "navbar-search-bar hidden",
+			});
+		}
 		this.standard_items.forEach((w) => {
 			this.add_item(this.$standard_items_sections, w);
 		});

--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -10,6 +10,21 @@
 			</a>
 			<ul class="nav navbar-nav d-none d-sm-flex" id="navbar-breadcrumbs"></ul>
 			<div class="collapse navbar-collapse justify-content-end">
+				{% if frappe.is_mobile() %}
+					<div class="search-bar text-muted hidden">
+						<div
+							id="navbar-modal-search"
+							class="navbar-modal-search-mobile"
+							placeholder="Search for type a command"
+						>
+						<span class="search-icon">
+							<svg class="icon icon-sm"><use href="#icon-search"></use></svg>
+							{{ __("Search") }}
+						</span>
+						<span>{%= frappe.utils.is_mac() ? '⌘ + K' : 'Ctrl + K' %}</span>
+					</div>
+					</div>
+				{% endif %}
 				<ul class="navbar-nav">
 					<li class="nav-item dropdown dropdown-notifications dropdown-mobile hidden">
 						<button

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -54,14 +54,7 @@
 
 	svg {
 		stroke: var(--text-light);
-	}
-
-	.search-icon {
-		position: absolute;
-		margin-left: 12px;
-		display: flex;
-		align-items: center;
-		height: 100%;
+		margin-bottom: 2px;
 	}
 	.awesomplete {
 		width: 100%;
@@ -87,6 +80,14 @@
 		input::placeholder {
 			color: var(--text-light);
 		}
+	}
+	.navbar-modal-search-mobile {
+		background-color: var(--control-bg);
+		border-radius: var(--border-radius-sm);
+		padding: 6px 10px;
+		width: 100%;
+		display: flex;
+		justify-content: space-between;
 	}
 }
 


### PR DESCRIPTION
Using the search from the sidebar is confusing and annoying, so on mobile devices moved the search bar to the navbar.
<img width="838" height="1350" alt="image" src="https://github.com/user-attachments/assets/a057fd67-0fcf-425a-b689-3f5fe535de9a" />


`no-docs`