### PR TITLE
fix: translate the sidebar item label

### DIFF
--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -14,7 +14,14 @@ frappe.ui.menu = class ContextMenu {
 		this.template.empty();
 
 		this.menu_items.forEach((f) => {
-			this.add_menu_item(f);
+			f.condition =
+				f.condition ||
+				function () {
+					return true;
+				};
+			if (f.condition()) {
+				this.add_menu_item(f);
+			}
 		});
 
 		// if (!$.contains(document.body, this.template[0])) {

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -217,6 +217,7 @@ frappe.ui.Sidebar = class Sidebar {
 		if (items && items.length > 0) {
 			items.forEach((w) => {
 				if (!w.display_depends_on || frappe.utils.eval(w.display_depends_on)) {
+					w.label = __(w.label);
 					this.add_item(this.$items_container, w);
 				}
 			});

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -5,13 +5,16 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 		this.drop_down_expanded = false;
 		this.title = this.sidebar.sidebar_title;
 		const me = this;
-		this.fetch;
+		this.sibling_workspaces = this.fetch_sibling_workspaces();
 		this.dropdown_items = [
 			{
 				name: "workspaces",
 				label: "Workspaces",
 				icon: "wallpaper",
-				items: this.fetch_sibling_workspaces(),
+				condition: function () {
+					return me.sibling_workspaces.length > 0;
+				},
+				items: this.sibling_workspaces,
 			},
 			{
 				name: "desktop",
@@ -46,18 +49,23 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 	}
 	fetch_sibling_workspaces() {
 		let sibling_workspaces = [];
-		let workspaces = frappe.current_app.workspaces;
-		workspaces.splice(workspaces.indexOf(this.title), 1);
-		workspaces.forEach((w) => {
-			let item = {
-				name: w.toLowerCase(),
-				label: w,
-				icon: "wallpaper",
-				url: frappe.utils.generate_route({ type: "Workspace", route: w.toLowerCase() }),
-			};
-			sibling_workspaces.push(item);
-		});
-		return sibling_workspaces;
+		if (frappe.current_app) {
+			let workspaces = [...frappe.current_app.workspaces];
+			workspaces.splice(workspaces.indexOf(this.title), 1);
+			workspaces.forEach((w) => {
+				let item = {
+					name: w.toLowerCase(),
+					label: w,
+					icon: "wallpaper",
+					url: frappe.utils.generate_route({
+						type: "Workspace",
+						route: w.toLowerCase(),
+					}),
+				};
+				sibling_workspaces.push(item);
+			});
+			return sibling_workspaces;
+		}
 	}
 	make() {
 		$(".sidebar-header").remove();

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.html
@@ -21,8 +21,10 @@
 			</div>
 		{% } else  { %}
             <a
-                href="{{ path }}"
-                target="{%= item.link_type === "URL" ? "_blank" : "" %}"
+                {% if (path) { %}
+                    href="{{ path }}"
+                    target="{%= item.link_type === "URL" ? "_blank" : "" %}"
+                {% } %}
                 class="item-anchor"
             >
                 {% let icon = item.icon %}


### PR DESCRIPTION
Sidebar Items were being translated now they do!

<img width="1440" height="780" alt="Screenshot 2025-12-04 at 1 18 03 AM" src="https://github.com/user-attachments/assets/b6e144f4-69e6-45ef-879d-debc8e842982" />

Also added a functionality where if the app has no workspaces dont show the workspace menu item

