### PR TITLE
fix(sidebar): hide collapse in edit mode and fix workspace links

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -200,7 +200,12 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 	make_sidebar() {
 		this.empty();
-		this.wrapper.find(".collapse-sidebar-link").removeClass("hidden");
+		// Display collapse button when sidebar is not in edit mode
+		if (!this.edit_mode) {
+			this.wrapper.find(".collapse-sidebar-link").removeClass("hidden");
+		} else {
+			this.wrapper.find(".collapse-sidebar-link").addClass("hidden");
+		}
 		this.create_sidebar(this.workspace_sidebar_items);
 
 		// Scroll sidebar to selected page if it is not in viewport.
@@ -787,7 +792,7 @@ frappe.ui.Sidebar = class Sidebar {
 		const me = this;
 		this.save_sidebar_button = this.wrapper.find(".save-sidebar");
 		this.discard_button = this.wrapper.find(".discard-button");
-		this.save_sidebar_button.on("click", async function (event) {
+		this.save_sidebar_button.off("click").on("click", async function (event) {
 			frappe.show_alert({
 				message: __("Saving Sidebar"),
 				indicator: "success",

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -47,15 +47,19 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 	fetch_sibling_workspaces() {
 		let sibling_workspaces = [];
 		let workspaces = frappe.current_app.workspaces;
-		workspaces.splice(workspaces.indexOf(this.title), 1);
 		workspaces.forEach((w) => {
-			let item = {
-				name: w.toLowerCase(),
-				label: w,
-				icon: "wallpaper",
-				url: frappe.utils.generate_route({ type: "Workspace", route: w.toLowerCase() }),
-			};
-			sibling_workspaces.push(item);
+			if (w !== this.title) {
+				let item = {
+					name: w.toLowerCase(),
+					label: w,
+					icon: "wallpaper",
+					url: frappe.utils.generate_route({
+						type: "Workspace",
+						route: frappe.router.slug(w),
+					}),
+				};
+				sibling_workspaces.push(item);
+			}
 		});
 		return sibling_workspaces;
 	}


### PR DESCRIPTION
**Issue :**

- Collapse sidebar button was visible in edit mode when it should be hidden.

- Save Sidebar button was getting multiple click handlers, causing it to trigger more than once.

- Workspace list was being modified, and some workspace links were generated incorrectly.

**Before :**


https://github.com/user-attachments/assets/d8c96a84-85eb-4f3e-98b5-4d13d8c792c9



**After :**


https://github.com/user-attachments/assets/8b1fda98-b3e5-43ed-9def-aa470d1be1f1

