### PR TITLE
fix: hide collapse in edit mode and fix workspace links

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -200,14 +200,6 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 	make_sidebar() {
 		this.empty();
-
-		// Display collapse button when sidebar is not in edit mode
-		if (!this.edit_mode) {
-			this.wrapper.find(".collapse-sidebar-link").removeClass("hidden");
-		} else {
-			this.wrapper.find(".collapse-sidebar-link").addClass("hidden");
-		}
-
 		this.create_sidebar(this.workspace_sidebar_items);
 
 		// Scroll sidebar to selected page if it is not in viewport.
@@ -484,6 +476,7 @@ frappe.ui.Sidebar = class Sidebar {
 				me.show_new_dialog();
 			});
 		} else {
+			this.wrapper.removeAttr("data-mode");
 			$(this.active_item).addClass("active-sidebar");
 			$(".collapse-sidebar-link").removeClass("hidden");
 			this.wrapper.find(".edit-mode").addClass("hidden");

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -200,7 +200,14 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 	make_sidebar() {
 		this.empty();
-		this.wrapper.find(".collapse-sidebar-link").removeClass("hidden");
+
+		// Display collapse button when sidebar is not in edit mode
+		if (!this.edit_mode) {
+			this.wrapper.find(".collapse-sidebar-link").removeClass("hidden");
+		} else {
+			this.wrapper.find(".collapse-sidebar-link").addClass("hidden");
+		}
+
 		this.create_sidebar(this.workspace_sidebar_items);
 
 		// Scroll sidebar to selected page if it is not in viewport.
@@ -808,7 +815,7 @@ frappe.ui.Sidebar = class Sidebar {
 		const me = this;
 		this.save_sidebar_button = this.wrapper.find(".save-sidebar");
 		this.discard_button = this.wrapper.find(".discard-button");
-		this.save_sidebar_button.on("click", async function (event) {
+		this.save_sidebar_button.off("click").on("click", async function (event) {
 			frappe.show_alert({
 				message: __("Saving Sidebar"),
 				indicator: "success",

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -59,7 +59,7 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 					icon: "wallpaper",
 					url: frappe.utils.generate_route({
 						type: "Workspace",
-						route: w.toLowerCase(),
+						route: frappe.router.slug(w),
 					}),
 				};
 				sibling_workspaces.push(item);


### PR DESCRIPTION
**Issue :**

- Collapse sidebar button was visible in edit mode when it should be hidden.
- Save Sidebar button was getting multiple click handlers, causing it to trigger more than once.
- Some workspace links were generated incorrectly.

**Before :**


https://github.com/user-attachments/assets/1e7056b3-f1f0-4c66-8e71-8994e4f88086



**After :**


https://github.com/user-attachments/assets/d4e14752-abb2-4206-90c4-5a8008aa99ce

 