### PR TITLE
fix: always show standard items in sidebar

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -26,6 +26,7 @@ frappe.ui.Sidebar = class Sidebar {
 
 	prepare() {
 		try {
+			this.add_standard_items();
 			this.sidebar_data = frappe.boot.workspace_sidebar_item[this.workspace_title];
 			this.workspace_sidebar_items = this.sidebar_data.items;
 			if (this.edit_mode) {
@@ -213,7 +214,6 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 	create_sidebar(items) {
 		this.empty();
-		this.add_standard_items(items);
 		if (items && items.length > 0) {
 			items.forEach((w) => {
 				if (!w.display_depends_on || frappe.utils.eval(w.display_depends_on)) {
@@ -403,9 +403,11 @@ frappe.ui.Sidebar = class Sidebar {
 				if (sidebars.length == 0) {
 					let module_name = router.meta?.module;
 					if (module_name) {
-						frappe.app.sidebar.setup(
-							this.sidebar_module_map[module_name][0] || module_name
-						);
+						let sidebar_title =
+							(this.sidebar_module_map[module_name] &&
+								this.sidebar_module_map[module_name][0]) ||
+							module_name;
+						frappe.app.sidebar.setup(sidebar_title);
 					}
 				} else {
 					if (this.sidebar_title && sidebars.includes(this.workspace_title)) {

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -99,7 +99,13 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 				false,
 				`var(${this.header_bg_color})`
 			);
+		} else {
+			this.header_icon = this.get_default_icon();
+			this.header_icon = `<img src=${this.header_icon}></img>`;
 		}
+	}
+	get_default_icon() {
+		return frappe.boot.app_data[0].app_logo_url;
 	}
 	get_desktop_icon_by_label(title, filters) {
 		if (!filters) {

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -4,7 +4,10 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 		this.item = opts.item;
 		this.container = opts.container;
 		this.nested_items = opts.item.nested_items || [];
-		this.workspace_title = $(".body-sidebar").attr("data-title").toLowerCase();
+		this.workspace_title =
+			($(".body-sidebar").attr("data-title") &&
+				$(".body-sidebar").attr("data-title").toLowerCase()) ||
+			frappe.app.sidebar.sidebar_title;
 		this.prepare(opts);
 		this.make();
 	}


### PR DESCRIPTION
Before
<img width="1440" height="774" alt="Screenshot 2025-12-04 at 5 26 24 PM" src="https://github.com/user-attachments/assets/405e2c92-6b87-40cb-b948-96ebb67132c6" />


After
<img width="1439" height="775" alt="Screenshot 2025-12-04 at 5 22 37 PM" src="https://github.com/user-attachments/assets/7a03e716-b23f-4e2e-935f-2637c6a0b853" />
