### PR TITLE
feat: add background color to search

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -157,6 +157,14 @@
 	}
 
 	.standard-items-sections {
+		.navbar-search-bar {
+			background-color: var(--control-bg-on-gray);
+			border-radius: var(--border-radius);
+			padding-right: 7px;
+			.standard-sidebar-item a:hover {
+				background-color: var(--control-bg-on-gray);
+			}
+		}
 		.dropdown-notifications {
 			.notifications-list {
 				left: 3.4%;


### PR DESCRIPTION
<img width="492" height="856" alt="image" src="https://github.com/user-attachments/assets/e9adbcce-6188-4bc3-ba36-80f08ecd45fd" />


`no-docs`