### PR TITLE
fix: translate desktop icons

### DIFF
--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -12,7 +12,7 @@ const jump_to_field = (field_label) => {
 };
 
 const type_value = (value) => {
-	cy.focused().clear().type(value).type("{esc}");
+	cy.focused().clear({ force: true }).type(value).type("{esc}");
 };
 
 context("Form", () => {

--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -12,7 +12,7 @@ const jump_to_field = (field_label) => {
 };
 
 const type_value = (value) => {
-	cy.focused().clear({ force: true }).type(value).type("{esc}");
+	cy.focused().clear().type(value).type("{esc}");
 };
 
 context("Form", () => {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -509,6 +509,7 @@ class DesktopIconGrid {
 class DesktopIcon {
 	constructor(icon, in_folder) {
 		this.icon_data = icon;
+		this.icon_data.label = __(this.icon_data.label);
 		this.icon_title = this.icon_data.label;
 		this.icon_subtitle = "";
 		this.icon_type = this.icon_data.icon_type;

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -285,7 +285,12 @@ class DesktopIconGrid {
 
 	prepare() {
 		this.total_pages = 1;
-		this.icons_data = this.icons_data.sort((a, b) => a.name.localeCompare(b.name));
+		this.icons_data = this.icons_data.sort((a, b) => {
+			if (a.idx === b.idx) {
+				return a.label.localeCompare(b.label); // sort by label if idx is the same
+			}
+			return a.idx - b.idx; // sort by idx
+		});
 		this.icons_data_by_page =
 			this.icons_data || this.split_data(this.icons_data, this.page_size.total());
 	}
@@ -465,7 +470,7 @@ class DesktopIconGrid {
 						if (evt.to.parentElement == evt.from.parentElement) {
 							let reordered_icons = me.sortable.toArray();
 							let filters = {
-								parent_icon: me.parent_icon?.icon_data.label || null,
+								parent_icon: me.parent_icon?.icon_data.label || "" || null,
 							};
 							me.reorder_icons(reordered_icons, filters);
 							me.parent_icon?.render_folder_thumbnail();
@@ -495,11 +500,12 @@ class DesktopIconGrid {
 	}
 	reorder_icons(reordered_icons, filters) {
 		reordered_icons.forEach((d, idx) => {
-			let icon = get_desktop_icon_by_label(d, filters);
+			let icon = get_desktop_icon_by_label(d);
 			if (icon) {
 				icon.idx = idx;
 			}
 		});
+		frappe.boot.desktop_icons.sort((a, b) => a.idx - b.idx);
 	}
 	add_to_main_screen(title) {
 		let icon = get_desktop_icon_by_label(title);

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -12,7 +12,7 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 				label: "Workspaces",
 				icon: "wallpaper",
 				condition: function () {
-					return me.sibling_workspaces.length > 0;
+					return me.sibling_workspaces && me.sibling_workspaces.length > 0;
 				},
 				items: this.sibling_workspaces,
 			},


### PR DESCRIPTION
<img width="174" height="151" alt="Screenshot 2025-12-05 at 10 55 29 AM" src="https://github.com/user-attachments/assets/efbc31db-9387-4f79-8ccd-439e7df04e99" />

Desktop labels are now translated


Closes https://github.com/frappe/frappe/issues/35081