### PR TITLE
fix: input change handling in FieldGroup

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -48,13 +48,13 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 
 			$(this.wrapper)
 				.find("input, select")
-				.on("change awesomplete-selectcomplete", () => {
-					this.dirty = true;
-					frappe.run_serially([
-						() => frappe.timeout(0.1),
-						() => me.refresh_dependency(),
-					]);
-				});
+				.on(
+					"change input awesomplete-selectcomplete",
+					frappe.utils.debounce(() => {
+						this.dirty = true;
+						me.refresh_dependency();
+					}, 100)
+				);
 		}
 	}
 


### PR DESCRIPTION
Issues:

- `FieldGroup` did not get the `dirty` flag when a field was cleared.
- Constant wait of 100 ms seems unnecessary, we can replace it with "after 100ms of inactivity"

Changes:

* Changed the event listener in `frappe.ui.FieldGroup` to handle `"input"` events in addition to `"change"` and `"awesomplete-selectcomplete"`
* Wrapped the handler in a `frappe.utils.debounce` function to limit how often `refresh_dependency` is called. This replaces the previous use of `frappe.run_serially` and a constant timeout.