### PR TITLE
fix: there is no attribute for closed, just handle the exception as the docs suggest (ported from frappe/print_designer)

### DIFF
--- a/frappe/utils/pdf_generator/cdp_connection.py
+++ b/frappe/utils/pdf_generator/cdp_connection.py
@@ -93,7 +93,7 @@ class CDPSocketClient:
 
 	async def _disconnect(self):
 		try:
-			if self.connection and not self.connection.closed:
+			if self.connection:
 				await self.connection.close()
 			self.connection = None
 		except Exception:


### PR DESCRIPTION
Ported from https://github.com/frappe/print_designer/pull/496
Credit goes to @NagariaHussain for the fix. I'm just porting it over to frappe/frappe so it can be fixed over here as well.

Closes https://github.com/frappe/frappe/issues/35097