### PR TITLE
feat(utils): replace custom email parsing with RFC-compliant validation

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -577,6 +577,39 @@ class TestValidationUtils(IntegrationTestCase):
 			"erp+Job%20Applicant=JA00004@frappe.com",
 		)
 
+		# RFC 5322 format - Display name with comma (main bug fix)
+		self.assertEqual(
+			validate_email_address('"Lastname, Firstname" <test@example.com>'), "test@example.com"
+		)
+		self.assertEqual(validate_email_address('"Doe, John" <john.doe@example.com>'), "john.doe@example.com")
+
+		# RFC 5322 format - Display name without comma
+		self.assertEqual(validate_email_address("Test User <test@example.com>"), "test@example.com")
+
+		# RFC 5322 format - Multiple emails
+		self.assertEqual(
+			validate_email_address('"Last, First" <test1@example.com>, "Another, Name" <test2@example.com>'),
+			"test1@example.com, test2@example.com",
+		)
+
+		# RFC 5322 format - Mixed with plain emails
+		self.assertEqual(
+			validate_email_address("Test User <test@example.com>, plain@example.com"),
+			"test@example.com, plain@example.com",
+		)
+
+		# Emails with newlines
+		self.assertEqual(
+			validate_email_address("test1@example.com\ntest2@example.com"),
+			"test1@example.com, test2@example.com",
+		)
+
+		# Undisclosed recipients should be filtered
+		self.assertEqual(validate_email_address("undisclosed-recipients:;"), "")
+		self.assertEqual(
+			validate_email_address("test@example.com, undisclosed-recipients:;"), "test@example.com"
+		)
+
 	def test_valid_phone(self):
 		valid_phones = ["+91 1234567890", ""]
 


### PR DESCRIPTION

## Fix: RFC-Compliant Email Validation Using `getaddresses` (Fixes #27337)

### ❌ Problem

Frappe’s current `validate_email_address` fails for valid RFC 5322 formatted emails, especially when display names include commas.

Example that **should be valid** but currently fails:

```

"Gritton, Howard" [[hgrit@example.com](mailto:hgrit@example.com)](mailto:hgrit@example.com)

````

The old implementation splits on commas:

```python
email_str.split(",")
````

This corrupts display names and produces invalid fragments such as:

* `"Gritton`
* ` Howard" <hgrit@example.com>`

Result:
`InvalidEmailAddressError` is thrown inside `Communication.validate`, breaking:

* Incoming email creation
* CRM Communication linking
* Support ticket ingestion
* Any feature that saves or updates `Communication` documents

This is a real production issue.

---

## ✅ Solution

Replaced the custom parsing logic with Python’s standard library:

```python
from email.utils import getaddresses
```

This properly parses **all RFC-compliant formats**, including:

* `"Last, First" <email@example.com>`
* `John Doe <john@example.com>`
* `email@example.com`
* Multi-line lists of addresses
* Mixed display-name + plain-address lists

After stdlib parsing, the address is still validated using Frappe’s existing:

```
EMAIL_MATCH_PATTERN
```

So email syntax security and sanitation remain unchanged.

---

## 🧪 Test Improvements

Added tests for scenarios the old implementation couldn’t handle:

* Display names containing commas
* Multi-line email inputs
* Mixed RFC-compliant + plain addresses
* Empty address parsed from display name
* Throw=True behavior for invalid formats
* Proper skipping of `undisclosed-recipient`

These tests ensure backward compatibility while validating new behavior.

---

## 📌 Before vs After

| Input                                              | Old Behavior                           | New Behavior                           |
| -------------------------------------------------- | -------------------------------------- | -------------------------------------- |
| `"Gritton, Howard" <hgrit@example.com>`            | ❌ Throws `InvalidEmailAddressError`    | ✅ `hgrit@example.com`                  |
| `"Doe, John" <john@example.com>, jane@example.com` | ❌ Incorrect split, first item rejected | ✅ `john@example.com, jane@example.com` |
| `"A, B" <a@example.com>`                           | ❌ Rejected due to comma                | ✅ Valid                                |
| `"User One" user@example.com`                      | ⚠️ Inconsistently handled              | ❌ Correctly rejected                   |
| `undisclosed-recipient:;`                          | ❌ Sometimes treated as invalid         | ✔ Skipped cleanly                      |

---

## 🔒 Why This Matters

This is not a cosmetic change — the old validator **breaks real workflows**.

* Modern email clients (Gmail, Outlook, Apple Mail) use RFC 5322 by default
* Incoming replies can’t be saved as Communication if the sender has a comma in their display name
* CRM, Helpdesk, and Email Inbox workflows silently fail due to incorrect parsing
* Using the Python stdlib is safer, more correct, and more maintainable than custom parsing

This PR aligns Frappe with real-world email behavior and prevents data loss.

---

## 📁 Linked Issue

Fixes [#27337](https://github.com/frappe/frappe/issues/27337)

no-docs