### PR TITLE
fix: translate standard sidebar items

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -240,7 +240,7 @@ frappe.ui.Sidebar = class Sidebar {
 		this.standard_items = [];
 		if (!frappe.is_mobile()) {
 			this.standard_items.push({
-				label: "Search",
+				label: __("Search"),
 				icon: "search",
 				type: "Button",
 				id: "navbar-modal-search",
@@ -251,7 +251,7 @@ frappe.ui.Sidebar = class Sidebar {
 			});
 		}
 		this.standard_items.push({
-			label: "Notification",
+			label: __("Notification"),
 			icon: "bell",
 			type: "Button",
 			class: "sidebar-notification hidden",


### PR DESCRIPTION
Previously standard sidebar items were not being translated
<img width="236" height="148" alt="Screenshot 2025-12-07 at 8 47 42 PM" src="https://github.com/user-attachments/assets/1338cd53-7e2d-497f-aa48-7a6fbf90f008" />
