### PR TITLE
fix!: per child level 'depends on' conditions

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -531,7 +531,7 @@ export default class Grid {
 				grid_row = new GridRow({
 					parent: $rows,
 					parent_df: this.df,
-					docfields: this.docfields,
+					docfields: JSON.parse(JSON.stringify(this.docfields)),
 					doc: d,
 					frm: this.frm,
 					grid: this,


### PR DESCRIPTION
Currently, if you set any `depends_on` (display, reqd, read only) on any child table (dialogs too), the result is affected on all `DocField`s of the table ie. the condition's result is applied to all the child rows and is not specific to one child row.

Assume the conditions is: `read_only_depends_on: "eval:!doc.__islocal",`

Before:
![CleanShot 2025-12-08 at 16 51 17](https://github.com/user-attachments/assets/426db0c9-afd4-4610-bb09-c9ac8df71570)


After:
![CleanShot 2025-12-08 at 16 49 30](https://github.com/user-attachments/assets/408cef72-56b7-4919-ab91-82a1c4178e50)

Root cause: `DocField`s were shared with the entire grid.
Fixed by: Deep copying the `DocField`s, unsure of the performance implications