### PR TITLE
feat: configure Min Max dates for Date Range field

### DIFF
--- a/frappe/public/js/frappe/form/controls/date_range.js
+++ b/frappe/public/js/frappe/form/controls/date_range.js
@@ -19,6 +19,8 @@ frappe.ui.form.ControlDateRange = class ControlDateRange extends frappe.ui.form.
 			range: true,
 			autoClose: true,
 			toggleSelected: false,
+			minDate: this.df.min_date,
+			maxDate: this.df.max_date,
 			firstDay: frappe.datetime.get_first_day_of_the_week_index(),
 		};
 		this.datepicker_options.dateFormat = frappe.boot.sysdefaults.date_format || "yyyy-mm-dd";

--- a/frappe/public/js/frappe/form/controls/date_range.js
+++ b/frappe/public/js/frappe/form/controls/date_range.js
@@ -1,10 +1,15 @@
 frappe.ui.form.ControlDateRange = class ControlDateRange extends frappe.ui.form.ControlData {
 	make_input() {
 		super.make_input();
-		this.set_date_options();
-		this.set_datepicker();
+		this.make_picker();
 		this.refresh();
 	}
+
+	make_picker() {
+		this.set_date_options();
+		this.set_datepicker();
+	}
+
 	set_date_options() {
 		var me = this;
 


### PR DESCRIPTION
### Issue

When **Date Range** field is used in page/report/dialog `min` and `max` date were not directly supported from field's df, which require more lines of code.


`no-docs`