### PR TITLE
fix: store childtable fieldname in query param

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1900,14 +1900,19 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	get_search_params() {
 		let search_params = new URLSearchParams();
-
 		this.get_filters_for_args().forEach((filter) => {
-			if (filter[2] === "=") {
-				search_params.append(filter[1], filter[3]);
-			} else {
-				search_params.append(filter[1], JSON.stringify([filter[2], filter[3]]));
-			}
+			const doctype = filter[0];
+			const field = filter[1];
+			const operator = filter[2];
+			const value = filter[3];
+
+			const key = doctype === this.doctype ? field : `${doctype}.${field}`;
+
+			const val = operator === "=" ? value : JSON.stringify([operator, value]);
+
+			search_params.append(key, val);
 		});
+
 		return search_params;
 	}
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1906,11 +1906,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			const operator = filter[2];
 			const value = filter[3];
 
-			const key = doctype === this.doctype ? field : `${doctype}.${field}`;
+			const query_key = doctype === this.doctype ? field : `${doctype}.${field}`;
+			const query_value = operator === "=" ? value : JSON.stringify([operator, value]);
 
-			const val = operator === "=" ? value : JSON.stringify([operator, value]);
-
-			search_params.append(key, val);
+			search_params.append(query_key, query_value);
 		});
 
 		return search_params;


### PR DESCRIPTION
If Parent and Child have a field with same name and you apply filter to child table field. On refresh that filter was overridden by parent doctype's field.


## Before



https://github.com/user-attachments/assets/f23c31a1-b662-42e6-bf7f-ca7860bdb1ac





## After




https://github.com/user-attachments/assets/5db2cccf-5057-437d-9a65-a98fbd866c9a




Closes #34780 
