### PR TITLE
fix: dashboard view margin

### DIFF
--- a/frappe/core/page/dashboard_view/dashboard_view.js
+++ b/frappe/core/page/dashboard_view/dashboard_view.js
@@ -20,7 +20,7 @@ frappe.pages["dashboard-view"].on_page_load = function (wrapper) {
 class Dashboard {
 	constructor(wrapper) {
 		this.wrapper = $(wrapper);
-		$(`<div class="dashboard" style="overflow: visible; margin: var(--margin-sm);">
+		$(`<div class="dashboard" style="overflow: visible; margin: var(--margin-md);">
 			<div class="dashboard-graph"></div>
 		</div>`).appendTo(this.wrapper.find(".page-content").empty());
 		this.container = this.wrapper.find(".dashboard-graph");


### PR DESCRIPTION
### Before

<img width="2940" height="912" alt="CleanShot 2025-12-09 at 13 12 43@2x" src="https://github.com/user-attachments/assets/8b1e5d01-e915-469a-9e62-5a3015f9a69c" />



### After

<img width="2940" height="796" alt="CleanShot 2025-12-09 at 13 09 24@2x" src="https://github.com/user-attachments/assets/4a2fc614-6fe8-41e8-a170-0fc7e85eeebd" />
