### PR TITLE
fix: Signature field missing label in Standard Print Formats (fixes #…

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -14,7 +14,7 @@
 	{%- elif df.fieldtype=="Geolocation" -%}
 		{{ render_geolocation(df, doc) }}
 	{%- elif df.fieldtype=="Signature" -%}
-		{{ render_signature(df, doc) }}
+    	{{ render_field_with_label(df, doc, no_of_cols) }}
 	{%- elif df.fieldtype=="Currency" -%}
 		{%- if doc.print_templates and
 				doc.print_templates.get(df.fieldname) -%}


### PR DESCRIPTION
Problem:
Signature fields did not show their label in Standard Print Formats. All other fields use render_field_with_label, but Signature was the only one routed through a separate render_signature macro, which outputs only the image and no label.

Fix:
Updated the template to render Signature fields using render_field_with_label so they behave consistently with all other fields and their labels appear correctly.

Screenshot

After: Signature image displayed together with its label, aligned like other fields

<img width="936" height="791" alt="Screenshot 2025-12-09 at 3 20 52 PM" src="https://github.com/user-attachments/assets/6a8be803-b070-45d2-999b-279e4a5686ed" />

