### PR TITLE
fix: link filters UX

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -315,6 +315,11 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				return false;
 			}
 
+			if (item.value === "filter_description__link_option") {
+				e.preventDefault();
+				return false;
+			}
+
 			if (item.action) {
 				item.value = "";
 				item.label = "";
@@ -384,8 +389,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				if (filter_string) {
 					r.message.push({
 						html: `<span class="text-muted" style="line-height: 1.5">${filter_string}</span>`,
-						value: "",
-						action: () => {},
+						value: "filter_description__link_option",
 					});
 				}
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -390,6 +390,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					r.message.push({
 						html: `<span class="text-muted" style="line-height: 1.5">${filter_string}</span>`,
 						value: "filter_description__link_option",
+						action: () => {},
 					});
 				}
 

--- a/frappe/public/scss/common/awesomeplete.scss
+++ b/frappe/public/scss/common/awesomeplete.scss
@@ -37,6 +37,9 @@
 
 		& > li,
 		& > [role="option"] {
+			&:has(p[title="filter_description__link_option"]) {
+				cursor: default;
+			}
 			cursor: pointer;
 			@include get_textstyle("sm", "regular");
 			padding: var(--padding-sm);


### PR DESCRIPTION
<img width="440" height="189" alt="Bildschirmfoto 2025-12-09 um 14 37 28" src="https://github.com/user-attachments/assets/d97f319a-be52-4f18-b836-0685559be422" />

Marked above is the part of the link field dropdown showing the applied filters.

Before, this element behaved like a normal option: it showed a "pointer" cursor and closed the dropdown on click.
With this PR, it's read-only nature becomes more obvious: it shows a default cursor and doesn't close the dropdown on click.
