### PR TITLE
fix: search sidebar item style

### DIFF
--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -95,13 +95,15 @@ frappe.ui.menu = class ContextMenu {
 		this.left_offset = 0;
 		this.gap = 4;
 		if (this.opts.nested && this.opts.parent_menu) {
+			let top =
+				parent.getBoundingClientRect().bottom - parent.getBoundingClientRect().height;
 			let dropdown = frappe.menu_map[this.opts.parent_menu].template;
 			let width = dropdown.outerWidth();
 			let offset = $(dropdown).offset();
 			this.template.css({
 				display: "block",
 				position: "absolute",
-				top: offset.top + "px",
+				top: top + "px",
 				left: offset.left + width + this.gap + "px",
 			});
 		} else {

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -155,15 +155,6 @@
 
 	.standard-items-sections {
 		margin-top: 14px;
-		.navbar-search-bar {
-			background-color: var(--control-bg-on-gray);
-			border-radius: var(--border-radius);
-			padding-right: 7px;
-			.standard-sidebar-item a:hover {
-				background-color: var(--control-bg-on-gray);
-				border-radius: var(--border-radius);
-			}
-		}
 		.dropdown-notifications {
 			.notifications-list {
 				left: 3.4%;


### PR DESCRIPTION
Reverting the style for search bar for now. It looks like its in persistent hover state reverting to default one

<img width="221" height="778" alt="Screenshot 2025-12-09 at 7 36 35 PM" src="https://github.com/user-attachments/assets/206fbba2-4442-4238-9fa0-74dbb7fc9a12" />


Aligining help menu item correctly
<img width="421" height="770" alt="Screenshot 2025-12-09 at 11 48 34 PM" src="https://github.com/user-attachments/assets/120001c0-aa17-4fa7-9db7-55b90caa1021" />

