### PR TITLE
fix: validate import columns only if type is insert

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -647,7 +647,8 @@ class ImportFile:
 		elif extension == "xls":
 			data = read_xls_file_from_attached_file(content)
 
-		self.validate_columns_of_import_file(data)
+		if self.import_type == INSERT:
+			self.validate_columns_of_import_file(data)
 		return data
 
 


### PR DESCRIPTION
When importing data where existing records are being updated, skip validating columns of the import file