### PR TITLE
refactor!: deprecate older web view links

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -29,7 +29,6 @@
   "permissions",
   "apply_strict_user_permissions",
   "column_break_21",
-  "allow_older_web_view_links",
   "show_external_link_warning",
   "security_tab",
   "security",
@@ -494,12 +493,6 @@
    "label": "Document Share Key Expiry (in Days)"
   },
   {
-   "default": "0",
-   "fieldname": "allow_older_web_view_links",
-   "fieldtype": "Check",
-   "label": "Allow Older Web View Links (Insecure)"
-  },
-  {
    "default": "20",
    "fieldname": "max_auto_email_report_per_user",
    "fieldtype": "Int",
@@ -787,7 +780,7 @@
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2025-12-01 00:12:17.823242",
+ "modified": "2025-12-10 05:27:21.774897",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -24,7 +24,6 @@ class SystemSettings(Document):
 		allow_login_after_fail: DF.Int
 		allow_login_using_mobile_number: DF.Check
 		allow_login_using_user_name: DF.Check
-		allow_older_web_view_links: DF.Check
 		allowed_file_extensions: DF.SmallText | None
 		app_name: DF.Data | None
 		apply_strict_user_permissions: DF.Check

--- a/frappe/patches/v14_0/set_document_expiry_default.py
+++ b/frappe/patches/v14_0/set_document_expiry_default.py
@@ -4,5 +4,5 @@ import frappe
 def execute():
 	frappe.db.set_single_value(
 		"System Settings",
-		{"document_share_key_expiry": 30, "allow_older_web_view_links": 1},
+		{"document_share_key_expiry": 30},
 	)

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -553,13 +553,9 @@ class TestDocumentWebView(IntegrationTestCase):
 		document_key = todo.get_document_share_key()
 
 		# with old-style signature key
-		with self.change_settings("System Settings", {"allow_older_web_view_links": True}):
-			old_document_key = todo.get_signature()
-			url = f"/ToDo/{todo.name}?key={old_document_key}"
-			self.assertEqual(self.get(url).status, "200 OK")
-
-		with self.change_settings("System Settings", {"allow_older_web_view_links": False}):
-			self.assertEqual(self.get(url).status, "403 FORBIDDEN")
+		old_document_key = todo.get_signature()
+		url = f"/ToDo/{todo.name}?key={old_document_key}"
+		self.assertEqual(self.get(url).status, "403 FORBIDDEN")
 
 		# with valid key
 		url = f"/ToDo/{todo.name}?key={document_key}"

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -415,10 +415,6 @@ def validate_key(key: str, doc: "Document") -> None:
 		else:
 			return
 
-	# TODO: Deprecate this! kept it for backward compatibility
-	if frappe.get_system_settings("allow_older_web_view_links") and key == doc.get_signature():
-		return
-
 	return False
 
 


### PR DESCRIPTION
- new links have expiry, old links are no longer being generated for anyone coming from v14 or older (support target)
- this is breaking, but due now - ignoring addition to migration guide

removed from docs: https://docs.frappe.io/erpnext/user/manual/en/system-settings?editWiki=1&wikiPagePatch=81l2bci8uh