### PR TITLE
fix: Remove newlines from filename in email attachment

### DIFF
--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -241,7 +241,8 @@ class EMail:
 		part = MIMEText(message, _subtype=subtype, policy=policy.SMTP)
 
 		if as_attachment:
-			part.add_header("Content-Disposition", "attachment", filename=filename)
+			clean_filename = re.sub("[\r\n]", "", str(filename))
+			part.add_header("Content-Disposition", "attachment", filename=clean_filename)
 
 		self.msg_root.attach(part)
 
@@ -476,7 +477,8 @@ def add_attachment(fname, fcontent, content_type=None, parent=None, content_id=N
 	# Set the filename parameter
 	if fname:
 		attachment_type = "inline" if inline else "attachment"
-		part.add_header("Content-Disposition", attachment_type, filename=str(fname))
+		clean_filename = re.sub("[\r\n]", "", str(fname))
+		part.add_header("Content-Disposition", attachment_type, filename=clean_filename)
 	if content_id:
 		part.add_header("Content-ID", f"<{content_id}>")
 


### PR DESCRIPTION
**email.errors.HeaderWriteError: folded header contains newline**

Happens when Frappe forwards an email (for instance when a help ticket is created) sent originally from Outlook.

```
Traceback (most recent call last):
  File "apps/frappe/frappe/email/doctype/email_queue/email_queue.py", line 179, in send
    message = ctx.build_message(recipient.recipient)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/email/doctype/email_queue/email_queue.py", line 323, in build_message
    message = self.include_attachments(message)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/email/doctype/email_queue/email_queue.py", line 405, in include_attachments
    return safe_encode(message_obj.as_string())
                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/email/message.py", line 996, in as_string
    return super().as_string(unixfrom, maxheaderlen, policy)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/email/message.py", line 188, in as_string
    g.flatten(self, unixfrom=unixfrom)
  File "/usr/lib/python3.11/email/generator.py", line 117, in flatten
    self._write(msg)
  File "/usr/lib/python3.11/email/generator.py", line 182, in _write
    self._dispatch(msg)
  File "/usr/lib/python3.11/email/generator.py", line 219, in _dispatch
    meth(msg)
  File "/usr/lib/python3.11/email/generator.py", line 286, in _handle_multipart
    g.flatten(part, unixfrom=False, linesep=self._NL)
  File "/usr/lib/python3.11/email/generator.py", line 117, in flatten
    self._write(msg)
  File "/usr/lib/python3.11/email/generator.py", line 200, in _write
    self._write_headers(msg)
  File "/usr/lib/python3.11/email/generator.py", line 234, in _write_headers
    raise HeaderWriteError(
email.errors.HeaderWriteError: folded header contains newline: 'Content-Disposition: attachment; filename="Outlook-Icon\r\n\r\nDesc.png"\r\n'
```