### PR TITLE
fix(Contact): don't go to last doc on validation errors

### DIFF
--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -114,6 +114,10 @@ frappe.ui.form.on("Contact", {
 		}
 	},
 	after_save: function (frm) {
+		if (frm.is_dirty()) {
+			return;
+		}
+
 		frappe.run_serially([
 			() => frappe.timeout(1),
 			() => {


### PR DESCRIPTION
When an error happens during validation of a **Contact**, we used to discard the form and move back to the previous doc (the one we wanted to add the contact to).

Now the **Contact** form stays open so that the user can correct any errors and try saving again. We only move back to the previous doc after a successful save.