### PR TITLE
fix: exclude fields with default when validatng mandatory import columns

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -507,7 +507,7 @@ class ImportFile:
 		mandatory_fields = []
 
 		for df in meta.fields:
-			if df.reqd and df.fieldtype not in no_value_fields:
+			if df.reqd and df.fieldtype not in no_value_fields and not df.default:
 				mandatory_fields.append(df.label)
 
 		return mandatory_fields


### PR DESCRIPTION
When validating mandatory columns, fields with default value will now be skipped