### PR TITLE
fix(utils): safely handle null/NaN/empty in shorten_number

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1450,18 +1450,12 @@ Object.assign(frappe.utils, {
 		 */
 
 		// return empty for null, undefined, or empty string
-		if (number == null || number === "") {
+		if (!number || isNaN(number)) {
 			return "";
 		}
 
-		// extract digits from the number
-		const digits = String(number).match(/\d/g);
-		if (!digits) {
-			return "";
-		}
-
-		// return number if total digits are less than min_length
-		const len = digits.length;
+		// return number if total digits is lesser than min_length
+		const len = String(number).match(/\d/g)?.length || 0;
 		if (len < min_length) {
 			return number.toString();
 		}

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1449,8 +1449,19 @@ Object.assign(frappe.utils, {
 		 *	max_no_of_decimals - max number of decimals of the shortened number
 		 */
 
-		// return number if total digits is lesser than min_length
-		const len = String(number).match(/\d/g).length;
+		// return empty for null, undefined, or empty string
+		if (number == null || number === "") {
+			return "";
+		}
+
+		// extract digits from the number
+		const digits = String(number).match(/\d/g);
+		if (!digits) {
+			return "";
+		}
+
+		// return number if total digits are less than min_length
+		const len = digits.length;
 		if (len < min_length) {
 			return number.toString();
 		}


### PR DESCRIPTION
## Problem
Number cards using **Report** type with aggregate functions (`Average`) crash with:

Uncaught TypeError: Cannot read properties of null (reading 'length')
at Object.shorten_number 

In the UI this appears as the number card staying in a perpetual “Loading…” state and never showing a value.

**Root cause**: Report cards filter out `0` values (`col[field] && acc.push()`), 
`Average([])` → `NaN` → `shorten_number(NaN)` crashes.



## Fix
Guard `shorten_number` before string ops:
- `null`/`undefined`/`""` → `""`
- `NaN`/`non-numeric` → `String(NaN).match(/\d/g)`=null → `""`
- Valid numbers (incl. `0`) → unchanged

**Before**: `shorten_number(NaN)` → crash  
**After**: `shorten_number(NaN)` → `""` (safe blank)

[Before screenshot: broken card + console error]
<img width="2658" height="546" alt="image" src="https://github.com/user-attachments/assets/5624ccc0-88ee-4ff5-85d0-b9cb416bdfc2" />


[After screenshot: working card showing 0 safely]
<img width="2658" height="272" alt="image" src="https://github.com/user-attachments/assets/620630da-22c0-45bd-a5a4-23a2240a29e2" />
