### PR TITLE
fix: allow print if login required is checked

### DIFF
--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -139,6 +139,7 @@
   },
   {
    "default": "0",
+   "depends_on": "login_required",
    "fieldname": "allow_print",
    "fieldtype": "Check",
    "label": "Allow print"
@@ -429,7 +430,7 @@
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2024-12-30 17:00:05.944646",
+ "modified": "2025-12-11 16:29:35.806107",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",
@@ -445,6 +446,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -70,6 +70,7 @@ class WebForm(WebsiteGenerator):
 		web_form_fields: DF.Table[WebFormField]
 		website_sidebar: DF.Link | None
 	# end: auto-generated types
+
 	website = frappe._dict(no_cache=1)
 
 	def validate(self):


### PR DESCRIPTION
Closes #35181

When **Login Required** is not checked:
<img width="1023" height="633" alt="Screenshot 2025-12-11 at 4 37 34 PM" src="https://github.com/user-attachments/assets/4e0882c3-50f0-4bc0-91b2-c3a11c510c9d" />

When **Login Required** is checked:
<img width="1046" height="630" alt="Screenshot 2025-12-11 at 4 38 22 PM" src="https://github.com/user-attachments/assets/e945bbda-11cf-4a32-b323-5bb3b92e4c6a" />
