### PR TITLE
refactor: remove ignored params from call

### DIFF
--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -274,11 +274,7 @@ data = columns, result
 		frappe.db.delete("Email Queue")
 		export_query()
 
-		jobs = frappe.get_all(
-			"RQ Job",
-			filters={"job_name": "frappe.desk.query_report.run_export_query_job"},
-			fields=["name", "status"],
-		)
+		jobs = frappe.get_all("RQ Job")
 		email_queue = frappe.get_all("Email Queue")
 
 		self.assertTrue(jobs, "Background job was not enqueued")


### PR DESCRIPTION
Actual behavior (before and after this PR):

- Returns all jobs (for the current site, across all queues and statuses)
- The job_name filter is ignored
- The fields restriction is ignored (all fields are returned)

Not attempting to fix this, just removing parameters that have no effect, so we don't mislead future readers into thinking this works.

Introduced in https://github.com/frappe/frappe/pull/33861