### PR TITLE
fix: make desktop page pixel perfect

### DIFF
--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -138,6 +138,7 @@ def get_desktop_icons(user=None, bootinfo=None):
 			"label",
 			"link",
 			"link_type",
+			"app",
 			"icon_type",
 			"parent_icon",
 			"icon",

--- a/frappe/desk/doctype/desktop_settings/desktop_settings.json
+++ b/frappe/desk/doctype/desktop_settings/desktop_settings.json
@@ -11,11 +11,11 @@
  ],
  "fields": [
   {
-   "default": "Subtle Reverse",
+   "default": "Subtle",
    "fieldname": "icon_style",
    "fieldtype": "Select",
    "label": "Icon Style",
-   "options": "Monochrome\nSubtle\nSubtle Reverse\nSubtle Reverse w Opacity"
+   "options": "Subtle\nSolid"
   },
   {
    "fieldname": "navbar_style",
@@ -34,7 +34,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-11-15 11:38:34.968344",
+ "modified": "2025-12-12 07:11:57.947973",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Desktop Settings",

--- a/frappe/desk/doctype/desktop_settings/desktop_settings.py
+++ b/frappe/desk/doctype/desktop_settings/desktop_settings.py
@@ -14,7 +14,7 @@ class DesktopSettings(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		icon_style: DF.Literal["Monochrome", "Subtle", "Subtle Reverse", "Subtle Reverse w Opacity"]
+		icon_style: DF.Literal["Subtle", "Solid"]
 		navbar_style: DF.Literal[
 			"Awesomebar",
 			"macOS Launchpad",

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -1,10 +1,12 @@
 :root{
     --desktop-blur: blur(10.2px);
-    --desktop-modal-width: 508px;
-    --desktop-modal-height: 448px;
+    --desktop-modal-width: 590px;
+    --desktop-modal-height: 450px;
     --folder-thumbnail-icon-height: 12px;
     --desktop-icon-dimension: 54px;
     --folder-icon-background-color: var(--surface-gray-1);
+    --desktop-modal-radius: 30px;
+    --desktop-icon-line-height: 115%;
 }
 [data-theme="dark"]{
     --folder-icon-background-color: #2b2b2b;
@@ -58,27 +60,37 @@
     align-items: center;
     justify-content: center;
     flex-direction: row;
-    margin-top: 20px;
 }
 
 .icon-stroke{
     stroke-width: 1.5px;
 }
+.icons-container{
+    margin-top: 60px;
+    padding: 20px;
+}
+.modal
+.modal-body .icons-container,.folder-icon .icons-container {
+    padding:0px;
+    margin: 0px;
+    height: 100%;
+    overflow: auto;
+}
 .icons{
-	gap: 30px;
+	gap: 16px;
 	display: grid;
 	justify-items: center;
-    margin-top: 50px;
     grid-template-columns: repeat(6, 1fr);
     grid-template-rows: repeat(3, 1fr);
 }
 .desktop-icon{
     display: flex;
-    height: 100px;
-    width: 100px;
+    height: 126px;
+    width: 127px;
     flex-direction: column;
     align-items: center;
     gap: 12px;
+    padding: 13px 16px 12px 16px;
 }
 .icon-container:has(.app-logo) {
     padding: 0;
@@ -112,16 +124,25 @@
     text-align: center;
     text-wrap: nowrap;
     display: flex;
+    justify-content: space-between;
+    width: 95px;
+    height: 35px;
     flex-direction: column;
 }
 .icon-title{
     font-weight: var(--weight-semibold);
-    font-size: var(--text-sm);
+    font-size: var(--text-md);
+    max-width: 95px;
+    overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+    line-height: var(--desktop-icon-line-height);
 }
 .icon-subtitle{
     font-weight: var(--weight-regular);
     font-size: var(--text-xs);
     color: var(--ink-gray-5);
+    line-height: var(--desktop-icon-line-height);
 }
 .timeless-style{
     width: 100vw;
@@ -144,7 +165,7 @@
     & .modal-dialog{
         & .modal-content {
             top: 120px;
-            border-radius: var(--border-radius-2xl);
+            border-radius: var(--desktop-modal-radius);
         }
     }
 }
@@ -156,7 +177,9 @@
 
 .desktop-modal-body {
     width: var(--desktop-modal-width);
-    padding: 23px 0px 23px 0px !important;
+    height: var(--desktop-modal-height);
+    padding: 24px 23px !important;
+    width: fit-content;
     & .icons{
         gap: 0px 0px;
     }
@@ -223,6 +246,7 @@
             width: fit-content;
             height: fit-content;
             pointer-events: none;
+            padding: 0px;
             & .icon-container{
                 height: var(--folder-thumbnail-icon-height);
                 width: var(--folder-thumbnail-icon-height);

--- a/frappe/desktop_icon/framework.json
+++ b/frappe/desktop_icon/framework.json
@@ -10,25 +10,10 @@
  "link": "/app/build",
  "link_type": "External",
  "logo_url": "/assets/frappe/images/frappe-framework-logo.svg",
- "modified": "2025-11-20 13:36:37.227388",
+ "modified": "2025-12-12 07:36:09.059666",
  "modified_by": "Administrator",
  "name": "Framework",
  "owner": "Administrator",
- "roles": [
-  {
-   "creation": "2025-11-20 13:36:37.227388",
-   "docstatus": 0,
-   "doctype": "Has Role",
-   "idx": 1,
-   "modified": "2025-11-20 13:36:37.227388",
-   "modified_by": "Administrator",
-   "name": "u44vqe0q4q",
-   "owner": "Administrator",
-   "parent": "Framework",
-   "parentfield": "roles",
-   "parenttype": "Desktop Icon",
-   "role": "System Manager"
-  }
- ],
+ "roles": [],
  "standard": 1
 }

--- a/frappe/public/js/frappe/ui/desktop_icon.html
+++ b/frappe/public/js/frappe/ui/desktop_icon.html
@@ -1,5 +1,9 @@
 <a class="desktop-icon" data-id="{{ icon.label}}"  data-logo="{{ icon.logo_url }}" data-icon="{{ icon.icon }}" data-type="{{ icon.type }}" style="text-decoration:none">
-    {% if (icon.logo_url) { %}
+    {% if(frappe.utils.get_desktop_icon(icon.label, frappe.boot.desktop_icon_style )) %}
+        <div class="icon-container">
+            <img class="app-icon" src="{{ frappe.utils.get_desktop_icon(icon.label, frappe.boot.desktop_icon_style) }}" alt="{{ icon.label }}" />
+        </div>
+    {% else if (icon.logo_url) { %}
         <div class="icon-container">
             <img class="app-icon" src="{{ icon.logo_url }}" alt="{{ icon.label }}" />
         </div>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -138,8 +138,12 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 	}
 	set_header_icon() {
 		let desktop_icon = this.get_desktop_icon_by_label(this.sidebar.sidebar_title);
-		if (desktop_icon && desktop_icon.logo_url) {
-			this.header_icon = this.get_desktop_icon_by_label(this.sidebar.sidebar_title).logo_url;
+		let desktop_icon_url = frappe.utils.get_desktop_icon(desktop_icon.label, "solid");
+		if (desktop_icon_url) {
+			this.header_icon = desktop_icon_url;
+			this.header_icon = `<img src=${this.header_icon}></img>`;
+		} else if (desktop_icon && desktop_icon.logo_url) {
+			this.header_icon = desktop_icon.logo_url;
 			this.header_icon = `<img src=${this.header_icon}></img>`;
 		} else if (this.sidebar.sidebar_data) {
 			this.header_icon = this.sidebar.sidebar_data.header_icon;

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1320,9 +1320,48 @@ Object.assign(frappe.utils, {
 	flag(country_code) {
 		return `<img loading="lazy" src="https://flagcdn.com/${country_code}.svg" width="20" height="15">`;
 	},
+
 	is_emoji(emoji_name) {
 		let emojiList = gemoji.map((emoji) => emoji.emoji);
 		return emojiList.includes(emoji_name);
+	},
+
+	get_desktop_icon(icon_name, variant) {
+		let exists = false;
+		let icon_data = this.get_desktop_icon_by_label(icon_name);
+		variant = variant.toLowerCase();
+		if (!icon_data?.app) return exists;
+		let app_name = icon_data.app;
+		let icon_url = `assets/${app_name}/icons/desktop_icons/${variant}/${frappe.scrub(
+			icon_name
+		)}.svg`;
+
+		if (
+			frappe.boot.desktop_icon_urls[app_name] &&
+			frappe.boot.desktop_icon_urls[app_name][variant].includes(icon_url)
+		) {
+			return `/${icon_url}`;
+		}
+		return exists;
+	},
+
+	desktop_icon_exists(app_name, url) {
+		let exists = false;
+		if (frappe.boot.desktop_icon_urls[app_name].includes(url)) exists = true;
+		return exists;
+	},
+	get_desktop_icon_by_label(title, filters) {
+		if (!filters) {
+			return frappe.boot.desktop_icons.find((f) => f.label === title && f.hidden != 1);
+		} else {
+			return frappe.boot.desktop_icons.find((f) => {
+				return (
+					f.label === title &&
+					Object.keys(filters).every((key) => f[key] === filters[key]) &&
+					f.hidden != 1
+				);
+			});
+		}
 	},
 
 	make_chart(wrapper, custom_options = {}) {


### PR DESCRIPTION
This PR implements the modified design for desktop with new icon variants

Solid and Subtle are two icon variants

<img width="1440" height="778" alt="Screenshot 2025-12-12 at 7 32 40 AM" src="https://github.com/user-attachments/assets/a0812f06-30dd-425e-93e8-b72414513de0" />
<img width="1440" height="782" alt="Screenshot 2025-12-12 at 7 33 32 AM" src="https://github.com/user-attachments/assets/89c319b2-0f05-4346-b697-1cb9933c9080" />
