### PR TITLE
fix: multiselect dailog link fields change trigger not getting triggered

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -111,6 +111,9 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 
 		this.setup_results();
 		this.bind_events();
+
+		this.bind_setters_queries();
+
 		this.get_results();
 		this.dialog.show();
 	}
@@ -262,6 +265,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 					read_only:
 						(this?.read_only_setters && this.read_only_setters.includes(setter)) || 0,
 					default: this.setters[setter],
+					onchange: () => this.get_results()
 				});
 			});
 		}
@@ -661,5 +665,15 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 				order_by: "parent",
 			},
 		});
+	}
+
+	bind_setters_queries() {
+		if (this.setters_queries) {
+			for (let [fieldname, query_fn] of Object.entries(this.setters_queries)) {
+				if (this.dialog.fields_dict[fieldname]) {
+					this.dialog.fields_dict[fieldname].get_query = query_fn;
+				}
+			}
+		}
 	}
 };


### PR DESCRIPTION
This PR fix the issue where event this.$parent.find(".input-with-feedback").on("change") not trigger when fill field from emtpy but work if field already fill or from fill to emtpy.
Before:
<img width="1784" height="847" alt="Screenshot 2025-12-12 151427" src="https://github.com/user-attachments/assets/13a826b5-a99f-4166-9a23-942f4d560a50" />

After:
<img width="1726" height="861" alt="image" src="https://github.com/user-attachments/assets/2b73f3d1-9b8a-4607-82cc-ee2379437675" />
<img width="1531" height="872" alt="image" src="https://github.com/user-attachments/assets/9bf1a1f6-3dae-4377-88ea-ae9c900960ea" />

closes #33827 

