### PR TITLE
feat: Make link field filters human-readable (fixes #35164)

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -512,7 +512,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				if (!Array.isArray(value)) {
 					value = ["=", value];
 				}
-				filter_array.push([fieldname, ...value]); // [fieldname, operator, value]
+				filter_array.push([doctype, fieldname, ...value]); // [doctype, fieldname, operator, value]
 			}
 		} else {
 			filter_array = filters.slice(); // clone

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -534,7 +534,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				const arr = filtered.slice(0, 5).map((v) => {
 					// Strings in quotes, numbers/dates not quoted
 					if (typeof v === "string") {
-						return `"${String(__(v, null, docfield?.options))}"`;
+						return `"${String(__(v))}"`;
 					}
 					// Numbers, dates, etc. - not translated, not quoted
 					return String(v);
@@ -550,7 +550,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 
 			// Format based on type: strings in quotes, numbers/dates not quoted
 			if (typeof val === "string") {
-				return `"${String(__(val, null, docfield?.options))}"`;
+				return `"${String(__(val))}"`;
 			}
 
 			// Numbers, dates, etc. - not translated, not quoted
@@ -571,7 +571,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			const label = docfield ? docfield.label : frappe.model.unscrub(fieldname);
 			const fieldtype = docfield ? docfield.fieldtype : null;
 
-			const labelDisplay = `<i>${String(__(label))}</i>`;
+			const labelDisplay = `<i>${String(__(label, null, _doctype))}</i>`;
 			const valueDisplay = formatValueForDisplay(docfield, value);
 			const is_time_like = ["Date", "Datetime", "Time"].includes(fieldtype);
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -599,22 +599,22 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				case "not like":
 					return __("{0} does not contain {1}", [labelDisplay, valueDisplay]);
 				case ">":
-					if (fieldtype === "Date" || fieldtype === "Datetime" || fieldtype === "Time") {
+					if (["Date", "Datetime", "Time"].includes(fieldtype)) {
 						return __("{0} is after {1}", [labelDisplay, valueDisplay]);
 					}
 					return __("{0} is greater than {1}", [labelDisplay, valueDisplay]);
 				case "<":
-					if (fieldtype === "Date" || fieldtype === "Datetime" || fieldtype === "Time") {
+					if (["Date", "Datetime", "Time"].includes(fieldtype)) {
 						return __("{0} is before {1}", [labelDisplay, valueDisplay]);
 					}
 					return __("{0} is less than {1}", [labelDisplay, valueDisplay]);
 				case ">=":
-					if (fieldtype === "Date" || fieldtype === "Datetime" || fieldtype === "Time") {
+					if (["Date", "Datetime", "Time"].includes(fieldtype)) {
 						return __("{0} is on or after {1}", [labelDisplay, valueDisplay]);
 					}
 					return __("{0} is greater than or equal to {1}", [labelDisplay, valueDisplay]);
 				case "<=":
-					if (fieldtype === "Date" || fieldtype === "Datetime" || fieldtype === "Time") {
+					if (["Date", "Datetime", "Time"].includes(fieldtype)) {
 						return __("{0} is on or before {1}", [labelDisplay, valueDisplay]);
 					}
 					return __("{0} is less than or equal to {1}", [labelDisplay, valueDisplay]);

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -554,7 +554,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			}
 
 			// Numbers, dates, etc. - not translated, not quoted
-			return String(val);
+			return frappe.format(val, docfield || {});
 		}
 
 		async function describe_filter(filter) {

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -574,25 +574,21 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			const labelDisplay = `<i>${String(__(label))}</i>`;
 			const valueDisplay = formatValueForDisplay(docfield, value);
 
-			// Special handling for Check fields with =/!= - show human phrase without value
-			if (fieldtype === "Check" && (operator === "=" || operator === "!=")) {
-				if (operator === "=") {
-					return value == 1
-						? __("{0} is enabled", [labelDisplay])
-						: __("{0} is disabled", [labelDisplay]);
-				} else {
-					// operator === "!="
-					return value == 1
-						? __("{0} is disabled", [labelDisplay])
-						: __("{0} is enabled", [labelDisplay]);
-				}
-			}
-
 			// Handle all operators with translation and interpolation in one call
 			switch (operator) {
 				case "=":
+					if (fieldtype === "Check") {
+						return value == 1
+							? __("{0} is enabled", [labelDisplay])
+							: __("{0} is disabled", [labelDisplay]);
+					}
 					return __("{0} equals {1}", [labelDisplay, valueDisplay]);
 				case "!=":
+					if (fieldtype === "Check") {
+						return value == 1
+							? __("{0} is disabled", [labelDisplay])
+							: __("{0} is enabled", [labelDisplay]);
+					}
 					return __("{0} is not equal to {1}", [labelDisplay, valueDisplay]);
 				case "in":
 					return __("{0} is one of {1}", [labelDisplay, valueDisplay]);

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -579,6 +579,18 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			switch (operator) {
 				case "=":
 					if (fieldtype === "Check") {
+						if (fieldname === "enabled") {
+							return value == 1
+								? __("is enabled") // ["enabled", "=", 1]
+								: __("is disabled"); // ["enabled", "=", 0]
+						}
+
+						if (fieldname === "disabled") {
+							return value == 1
+								? __("is disabled") // ["disabled", "=", 1]
+								: __("is enabled"); // ["disabled", "=", 0]
+						}
+
 						return value == 1
 							? __("{0} is enabled", [labelDisplay])
 							: __("{0} is disabled", [labelDisplay]);
@@ -586,6 +598,18 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					return __("{0} equals {1}", [labelDisplay, valueDisplay]);
 				case "!=":
 					if (fieldtype === "Check") {
+						if (fieldname === "enabled") {
+							return value == 1
+								? __("is disabled") // ["enabled", "!=", 1]
+								: __("is enabled"); // ["enabled", "!=", 0]
+						}
+
+						if (fieldname === "disabled") {
+							return value == 1
+								? __("is enabled") // ["disabled", "!=", 1]
+								: __("is disabled"); // ["disabled", "!=", 0]
+						}
+
 						return value == 1
 							? __("{0} is disabled", [labelDisplay])
 							: __("{0} is enabled", [labelDisplay]);

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -573,6 +573,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 
 			const labelDisplay = `<i>${String(__(label))}</i>`;
 			const valueDisplay = formatValueForDisplay(docfield, value);
+			const is_time_like = ["Date", "Datetime", "Time"].includes(fieldtype);
 
 			// Handle all operators with translation and interpolation in one call
 			switch (operator) {
@@ -599,22 +600,22 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				case "not like":
 					return __("{0} does not contain {1}", [labelDisplay, valueDisplay]);
 				case ">":
-					if (["Date", "Datetime", "Time"].includes(fieldtype)) {
+					if (is_time_like) {
 						return __("{0} is after {1}", [labelDisplay, valueDisplay]);
 					}
 					return __("{0} is greater than {1}", [labelDisplay, valueDisplay]);
 				case "<":
-					if (["Date", "Datetime", "Time"].includes(fieldtype)) {
+					if (is_time_like) {
 						return __("{0} is before {1}", [labelDisplay, valueDisplay]);
 					}
 					return __("{0} is less than {1}", [labelDisplay, valueDisplay]);
 				case ">=":
-					if (["Date", "Datetime", "Time"].includes(fieldtype)) {
+					if (is_time_like) {
 						return __("{0} is on or after {1}", [labelDisplay, valueDisplay]);
 					}
 					return __("{0} is greater than or equal to {1}", [labelDisplay, valueDisplay]);
 				case "<=":
-					if (["Date", "Datetime", "Time"].includes(fieldtype)) {
+					if (is_time_like) {
 						return __("{0} is on or before {1}", [labelDisplay, valueDisplay]);
 					}
 					return __("{0} is less than or equal to {1}", [labelDisplay, valueDisplay]);

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -531,31 +531,98 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			return filter;
 		});
 
+		// Helper function to get human-readable operator
+		function get_operator_label(operator, fieldtype, value) {
+			const operator_map = {
+				"=": __("equals"),
+				"!=": __("is not equal to"),
+				">": __("greater than"),
+				"<": __("less than"),
+				">=": __("greater than or equals"),
+				"<=": __("less than or equals"),
+				in: __("is one of"),
+				"not in": __("is not one of"),
+				like: __("contains"),
+				"not like": __("does not contain"),
+				between: __("is between"),
+				is: __("is"),
+				"descendants of": __("descendants of"),
+				"ancestors of": __("ancestors of"),
+				"not descendants of": __("not descendants of"),
+				"not ancestors of": __("not ancestors of"),
+				timespan: __("is within"),
+			};
+
+			// Special handling for Check fields
+			if (fieldtype === "Check") {
+				if (operator === "=" && value == 1) {
+					return __("is enabled");
+				} else if (operator === "=" && value == 0) {
+					return __("is disabled");
+				} else if (operator === "!=") {
+					return value == 1 ? __("is disabled") : __("is enabled");
+				}
+			}
+
+			return operator_map[operator] || operator;
+		}
+
 		function get_filter_description(filter) {
-			let doctype = filter[0];
+			let filter_doctype = filter[0];
 			let fieldname = filter[1];
-			let docfield = frappe.meta.get_docfield(doctype, fieldname);
+			let operator = filter[2];
+			let value = filter[3];
+
+			// Get docfield metadata (should be cached by now)
+			let docfield = frappe.meta.get_docfield(filter_doctype, fieldname);
 			let label = docfield ? docfield.label : frappe.model.unscrub(fieldname);
+			let fieldtype = docfield ? docfield.fieldtype : null;
 
-			if (docfield && docfield.fieldtype === "Check") {
-				filter[3] = filter[3] ? __("Yes") : __("No");
+			// Detect Check field: primary check is metadata, fallback to value pattern (1/0 with =/!=)
+			let is_check_field =
+				fieldtype === "Check" ||
+				((operator === "=" || operator === "!=") && (value == 1 || value == 0));
+
+			// For Check fields with = or !=, show "is enabled"/"is disabled" without value
+			if (is_check_field && (operator === "=" || operator === "!=")) {
+				let operator_label = get_operator_label(operator, "Check", value);
+				return [__(label).bold(), operator_label].join(" ");
 			}
 
-			if (filter[3] && Array.isArray(filter[3]) && filter[3].length > 5) {
-				filter[3] = filter[3].slice(0, 5);
-				filter[3].push("...");
+			// Get operator label for non-Check fields or Check fields with other operators
+			let operator_label = get_operator_label(operator, fieldtype, value);
+
+			// For other Check field operators, show Yes/No
+			if (fieldtype === "Check") {
+				value = value ? __("Yes") : __("No");
 			}
 
-			let value;
-			if (filter[3] && Array.isArray(filter[3])) {
-				value = filter[3].map((v) => String(__(v)).bold()).join(", ");
-			} else if (filter[3] == null || filter[3] === "") {
-				value = __("empty").bold();
+			// Handle array values and truncate if needed
+			if (value && Array.isArray(value)) {
+				// Filter out null/undefined/empty values from array
+				value = value.filter((v) => v != null && v !== "");
+
+				if (value.length > 5) {
+					value = value.slice(0, 5);
+					value.push("...");
+				}
+			}
+
+			// Format value for display
+			let formatted_value;
+			if (value && Array.isArray(value)) {
+				if (value.length === 0) {
+					formatted_value = __("empty").bold();
+				} else {
+					formatted_value = value.map((v) => String(__(v)).bold()).join(", ");
+				}
+			} else if (value == null || value === "") {
+				formatted_value = __("empty").bold();
 			} else {
-				value = String(__(filter[3])).bold();
+				formatted_value = String(__(value)).bold();
 			}
 
-			return [__(label).bold(), __(filter[2]), value].join(" ");
+			return [__(label).bold(), operator_label, formatted_value].join(" ");
 		}
 
 		let filter_string = filter_array.map(get_filter_description).join(", ");

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -502,12 +502,12 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 	}
 
 	get_filter_description(filters) {
-		let doctype = this.get_options();
+		const doctype = this.get_options();
 		let filter_array = [];
-		let meta = null;
 
+		// ensure meta is loaded (keeps existing behaviour)
 		frappe.model.with_doctype(doctype, () => {
-			meta = frappe.get_meta(doctype);
+			frappe.get_meta(doctype);
 		});
 
 		// convert object style to array
@@ -517,116 +517,111 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				if (!Array.isArray(value)) {
 					value = ["=", value];
 				}
-				filter_array.push([fieldname, ...value]); // fieldname, operator, value
+				filter_array.push([fieldname, ...value]); // [fieldname, operator, value]
 			}
 		} else {
-			filter_array = filters;
+			filter_array = filters.slice(); // clone
 		}
 
-		// add doctype if missing
-		filter_array = filter_array.map((filter) => {
-			if (filter.length === 3) {
-				return [doctype, ...filter]; // doctype, fieldname, operator, value
+		// add doctype if missing: [doctype, fieldname, operator, value]
+		filter_array = filter_array.map((f) => (f.length === 3 ? [doctype, ...f] : f));
+
+		// operator templates (use {0} = label, {1} = value) -> good for i18n extraction
+		const operatorTemplates = {
+			"=": "{0} equals {1}",
+			"!=": "{0} is not equal to {1}",
+			in: "{0} is one of {1}",
+			"not in": "{0} is not one of {1}",
+			like: "{0} contains {1}",
+			"not like": "{0} does not contain {1}",
+			">": "{0} is greater than {1}",
+			"<": "{0} is less than {1}",
+			">=": "{0} is greater than or equal to {1}",
+			"<=": "{0} is less than or equal to {1}",
+			is: "{0} is {1}",
+			between: "{0} is between {1}",
+			"descendants of": "{0} is a descendant of {1}",
+			"ancestors of": "{0} is an ancestor of {1}",
+			"not descendants of": "{0} is not a descendant of {1}",
+			"not ancestors of": "{0} is not an ancestor of {1}",
+			timespan: "{0} is within {1}",
+		};
+
+		function formatValueForDisplay(docfield, val) {
+			// Check boolean fields -> show Yes/No (localized)
+			// Handles 0/1, true/false values
+			if (docfield && docfield.fieldtype === "Check") {
+				return String(__(val == 1 || val === true ? "Yes" : "No")).bold();
 			}
-			return filter;
-		});
 
-		// Helper function to get human-readable operator
-		function get_operator_label(operator, fieldtype, value) {
-			const operator_map = {
-				"=": __("equals"),
-				"!=": __("is not equal to"),
-				">": __("greater than"),
-				"<": __("less than"),
-				">=": __("greater than or equals"),
-				"<=": __("less than or equals"),
-				in: __("is one of"),
-				"not in": __("is not one of"),
-				like: __("contains"),
-				"not like": __("does not contain"),
-				between: __("is between"),
-				is: __("is"),
-				"descendants of": __("descendants of"),
-				"ancestors of": __("ancestors of"),
-				"not descendants of": __("not descendants of"),
-				"not ancestors of": __("not ancestors of"),
-				timespan: __("is within"),
-			};
+			// Array values -> truncate to first 5, append "..."
+			if (Array.isArray(val)) {
+				const filtered = val.filter((v) => v != null && v !== "");
+				const arr = filtered.slice(0, 5).map((v) => String(__(v)).bold());
+				if (filtered.length > 5) arr.push("...");
+				return arr.join(", ");
+			}
 
+			// Null / empty
+			if (val == null || val === "") {
+				return String(__("empty")).bold();
+			}
+
+			// Default scalar
+			return String(__(val)).bold();
+		}
+
+		function get_operator_template(operator, fieldtype, value) {
 			// Special handling for Check fields
 			if (fieldtype === "Check") {
 				if (operator === "=" && value == 1) {
-					return __("is enabled");
+					return "{0} is enabled";
 				} else if (operator === "=" && value == 0) {
-					return __("is disabled");
+					return "{0} is disabled";
 				} else if (operator === "!=") {
-					return value == 1 ? __("is disabled") : __("is enabled");
+					return value == 1 ? "{0} is disabled" : "{0} is enabled";
 				}
 			}
-
-			return operator_map[operator] || operator;
+			return operatorTemplates[operator] || "{0} {1} {2}";
 		}
 
 		function get_filter_description(filter) {
-			let filter_doctype = filter[0];
-			let fieldname = filter[1];
-			let operator = filter[2];
+			// expect [doctype, fieldname, operator, value]
+			const _doctype = filter[0];
+			const fieldname = filter[1];
+			const operator = filter[2];
 			let value = filter[3];
 
-			// Get docfield metadata (should be cached by now)
-			let docfield = frappe.meta.get_docfield(filter_doctype, fieldname);
-			let label = docfield ? docfield.label : frappe.model.unscrub(fieldname);
-			let fieldtype = docfield ? docfield.fieldtype : null;
+			const docfield = frappe.meta.get_docfield(_doctype, fieldname);
+			const label = docfield ? docfield.label : frappe.model.unscrub(fieldname);
+			const fieldtype = docfield ? docfield.fieldtype : null;
 
-			// Detect Check field: primary check is metadata, fallback to value pattern (1/0 with =/!=)
-			let is_check_field =
-				fieldtype === "Check" ||
-				((operator === "=" || operator === "!=") && (value == 1 || value == 0));
+			// heuristics: detect a Check field if metadata absent but value looks boolean-ish
+			const looks_like_check =
+				(operator === "=" || operator === "!=") &&
+				(value == 1 || value == 0 || value === true || value === false);
+			const is_check_field = fieldtype === "Check" || looks_like_check;
 
-			// For Check fields with = or !=, show "is enabled"/"is disabled" without value
+			// For Check fields with =/!= prefer human phrase without showing raw value
 			if (is_check_field && (operator === "=" || operator === "!=")) {
-				let operator_label = get_operator_label(operator, "Check", value);
-				return [__(label).bold(), operator_label].join(" ");
+				const template = get_operator_template(operator, "Check", value);
+				return __(template, [String(__(label)).bold()]);
 			}
 
-			// Get operator label for non-Check fields or Check fields with other operators
-			let operator_label = get_operator_label(operator, fieldtype, value);
+			const labelDisplay = String(__(label)).bold();
+			const valueDisplay = formatValueForDisplay(docfield, value);
 
-			// For other Check field operators, show Yes/No
-			if (fieldtype === "Check") {
-				value = value ? __("Yes") : __("No");
+			const template = get_operator_template(operator, fieldtype, value);
+
+			// fallback pattern expects 3 placeholders: label, operator (raw), value
+			if (template === "{0} {1} {2}") {
+				return __(template, [labelDisplay, operator, valueDisplay]);
 			}
 
-			// Handle array values and truncate if needed
-			if (value && Array.isArray(value)) {
-				// Filter out null/undefined/empty values from array
-				value = value.filter((v) => v != null && v !== "");
-
-				if (value.length > 5) {
-					value = value.slice(0, 5);
-					value.push("...");
-				}
-			}
-
-			// Format value for display
-			let formatted_value;
-			if (value && Array.isArray(value)) {
-				if (value.length === 0) {
-					formatted_value = __("empty").bold();
-				} else {
-					formatted_value = value.map((v) => String(__(v)).bold()).join(", ");
-				}
-			} else if (value == null || value === "") {
-				formatted_value = __("empty").bold();
-			} else {
-				formatted_value = String(__(value)).bold();
-			}
-
-			return [__(label).bold(), operator_label, formatted_value].join(" ");
+			return __(template, [labelDisplay, valueDisplay]);
 		}
 
-		let filter_string = filter_array.map(get_filter_description).join(", ");
-
+		const filter_string = filter_array.map(get_filter_description).join(", ");
 		return __("Filters applied for {0}", [filter_string]);
 	}
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -615,6 +615,13 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					}
 					return __("{0} is {1}", [labelDisplay, valueDisplay]);
 				case "between":
+					if (Array.isArray(value) && value.length === 2) {
+						return __("{0} is between {1} and {2}", [
+							labelDisplay,
+							formatValueForDisplay(docfield, value[0]),
+							formatValueForDisplay(docfield, value[1]),
+						]);
+					}
 					return __("{0} is between {1}", [labelDisplay, valueDisplay]);
 				case "descendants of":
 					return __("{0} is a descendant of {1}", [labelDisplay, valueDisplay]);

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -399,7 +399,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			no_spinner: true,
 			cache: use_get,
 			args: args,
-			callback: (r) => {
+			callback: async (r) => {
 				if (!window.Cypress && !this.$input.is(":focus")) {
 					return;
 				}
@@ -409,7 +409,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				let filter_string = this.df.filter_description
 					? this.df.filter_description
 					: args.filters
-					? this.get_filter_description(args.filters)
+					? await this.get_filter_description(args.filters)
 					: null;
 				if (filter_string) {
 					r.message.push({
@@ -501,14 +501,9 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		}
 	}
 
-	get_filter_description(filters) {
+	async get_filter_description(filters) {
 		const doctype = this.get_options();
 		let filter_array = [];
-
-		// ensure meta is loaded (keeps existing behaviour)
-		frappe.model.with_doctype(doctype, () => {
-			frappe.get_meta(doctype);
-		});
 
 		// convert object style to array
 		if (!Array.isArray(filters)) {
@@ -526,104 +521,119 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		// add doctype if missing: [doctype, fieldname, operator, value]
 		filter_array = filter_array.map((f) => (f.length === 3 ? [doctype, ...f] : f));
 
-		// operator templates (use {0} = label, {1} = value) -> good for i18n extraction
-		const operatorTemplates = {
-			"=": __("{0} equals {1}"),
-			"!=": __("{0} is not equal to {1}"),
-			["in"]: __("{0} is one of {1}"),
-			"not in": __("{0} is not one of {1}"),
-			["like"]: __("{0} contains {1}"),
-			"not like": __("{0} does not contain {1}"),
-			">": __("{0} is greater than {1}"),
-			"<": __("{0} is less than {1}"),
-			">=": __("{0} is greater than or equal to {1}"),
-			"<=": __("{0} is less than or equal to {1}"),
-			["is"]: __("{0} is {1}"),
-			["between"]: __("{0} is between {1}"),
-			"descendants of": __("{0} is a descendant of {1}"),
-			"ancestors of": __("{0} is an ancestor of {1}"),
-			"not descendants of": __("{0} is not a descendant of {1}"),
-			"not ancestors of": __("{0} is not an ancestor of {1}"),
-			["timespan"]: __("{0} is within {1}"),
-		};
-
 		function formatValueForDisplay(docfield, val) {
 			// Check boolean fields -> show Yes/No (localized)
 			// Handles 0/1, true/false values
 			if (docfield && docfield.fieldtype === "Check") {
-				return (val == 1 || val === true ? __("Yes") : __("No")).bold();
+				return val == 1 || val === true ? __("Yes") : __("No");
 			}
 
 			// Array values -> truncate to first 5, append "..."
 			if (Array.isArray(val)) {
 				const filtered = val.filter((v) => v != null && v !== "");
-				const arr = filtered.slice(0, 5).map((v) => String(__(v)).bold());
+				const arr = filtered.slice(0, 5).map((v) => {
+					// Strings in quotes, numbers/dates not quoted
+					if (typeof v === "string") {
+						return `"${String(__(v))}"`;
+					}
+					// Numbers, dates, etc. - not translated, not quoted
+					return String(v);
+				});
 				if (filtered.length > 5) arr.push("...");
 				return arr.join(", ");
 			}
 
 			// Null / empty
 			if (val == null || val === "") {
-				return String(__("empty")).bold();
+				return __("empty");
 			}
 
-			// Default scalar
-			return String(__(val)).bold();
-		}
-
-		function get_operator_template(operator, fieldtype, value) {
-			// Special handling for Check fields
-			if (fieldtype === "Check") {
-				if (operator === "=" && value == 1) {
-					return __("{0} is enabled");
-				} else if (operator === "=" && value == 0) {
-					return __("{0} is disabled");
-				} else if (operator === "!=") {
-					return value == 1 ? __("{0} is disabled") : __("{0} is enabled");
-				}
+			// Format based on type: strings in quotes, numbers/dates not quoted
+			if (typeof val === "string") {
+				return `"${String(__(val))}"`;
 			}
-			// Return raw placeholder pattern for unknown operators (not translatable)
-			return operatorTemplates[operator] || "{0} {1} {2}";
+
+			// Numbers, dates, etc. - not translated, not quoted
+			return String(val);
 		}
 
-		function get_filter_description(filter) {
+		async function describe_filter(filter) {
 			// expect [doctype, fieldname, operator, value]
 			const _doctype = filter[0];
 			const fieldname = filter[1];
 			const operator = filter[2];
 			let value = filter[3];
 
+			// Ensure metadata is loaded for this doctype before accessing docfield
+			await frappe.model.with_doctype(_doctype, () => {});
+
 			const docfield = frappe.meta.get_docfield(_doctype, fieldname);
 			const label = docfield ? docfield.label : frappe.model.unscrub(fieldname);
 			const fieldtype = docfield ? docfield.fieldtype : null;
 
-			// heuristics: detect a Check field if metadata absent but value looks boolean-ish
-			const looks_like_check =
-				(operator === "=" || operator === "!=") &&
-				(value == 1 || value == 0 || value === true || value === false);
-			const is_check_field = fieldtype === "Check" || looks_like_check;
-
-			// For Check fields with =/!= prefer human phrase without showing raw value
-			if (is_check_field && (operator === "=" || operator === "!=")) {
-				const template = get_operator_template(operator, "Check", value);
-				return __(template, [String(__(label)).bold()]);
-			}
-
-			const labelDisplay = String(__(label)).bold();
+			const labelDisplay = `<i>${String(__(label))}</i>`;
 			const valueDisplay = formatValueForDisplay(docfield, value);
 
-			const template = get_operator_template(operator, fieldtype, value);
-
-			// fallback pattern expects 3 placeholders: label, operator (raw), value
-			// Check if operator is not in templates (fallback case)
-			if (!operatorTemplates[operator]) {
-				return __(template, [labelDisplay, operator, valueDisplay]);
+			// Special handling for Check fields with =/!= - show human phrase without value
+			if (fieldtype === "Check" && (operator === "=" || operator === "!=")) {
+				if (operator === "=") {
+					return value == 1
+						? __("{0} is enabled", [labelDisplay])
+						: __("{0} is disabled", [labelDisplay]);
+				} else {
+					// operator === "!="
+					return value == 1
+						? __("{0} is disabled", [labelDisplay])
+						: __("{0} is enabled", [labelDisplay]);
+				}
 			}
 
-			return __(template, [labelDisplay, valueDisplay]);
+			// Handle all operators with translation and interpolation in one call
+			switch (operator) {
+				case "=":
+					return __("{0} equals {1}", [labelDisplay, valueDisplay]);
+				case "!=":
+					return __("{0} is not equal to {1}", [labelDisplay, valueDisplay]);
+				case "in":
+					return __("{0} is one of {1}", [labelDisplay, valueDisplay]);
+				case "not in":
+					return __("{0} is not one of {1}", [labelDisplay, valueDisplay]);
+				case "like":
+					return __("{0} contains {1}", [labelDisplay, valueDisplay]);
+				case "not like":
+					return __("{0} does not contain {1}", [labelDisplay, valueDisplay]);
+				case ">":
+					return __("{0} is greater than {1}", [labelDisplay, valueDisplay]);
+				case "<":
+					return __("{0} is less than {1}", [labelDisplay, valueDisplay]);
+				case ">=":
+					return __("{0} is greater than or equal to {1}", [labelDisplay, valueDisplay]);
+				case "<=":
+					return __("{0} is less than or equal to {1}", [labelDisplay, valueDisplay]);
+				case "is":
+					return __("{0} is {1}", [labelDisplay, valueDisplay]);
+				case "between":
+					return __("{0} is between {1}", [labelDisplay, valueDisplay]);
+				case "descendants of":
+					return __("{0} is a descendant of {1}", [labelDisplay, valueDisplay]);
+				case "ancestors of":
+					return __("{0} is an ancestor of {1}", [labelDisplay, valueDisplay]);
+				case "not descendants of":
+					return __("{0} is not a descendant of {1}", [labelDisplay, valueDisplay]);
+				case "not ancestors of":
+					return __("{0} is not an ancestor of {1}", [labelDisplay, valueDisplay]);
+				case "timespan":
+					return __("{0} is within {1}", [labelDisplay, valueDisplay]);
+				default:
+					// Fallback for unknown operators
+					return __("{0} {1} {2}", [labelDisplay, operator, valueDisplay]);
+			}
 		}
 
-		const filter_string = filter_array.map(get_filter_description).join(", ");
+		const descriptions = await Promise.all(
+			filter_array.map((filter) => describe_filter(filter))
+		);
+		const filter_string = frappe.utils.comma_and(descriptions);
 		return __("Filters applied for {0}", [filter_string]);
 	}
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -528,30 +528,30 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 
 		// operator templates (use {0} = label, {1} = value) -> good for i18n extraction
 		const operatorTemplates = {
-			"=": "{0} equals {1}",
-			"!=": "{0} is not equal to {1}",
-			in: "{0} is one of {1}",
-			"not in": "{0} is not one of {1}",
-			like: "{0} contains {1}",
-			"not like": "{0} does not contain {1}",
-			">": "{0} is greater than {1}",
-			"<": "{0} is less than {1}",
-			">=": "{0} is greater than or equal to {1}",
-			"<=": "{0} is less than or equal to {1}",
-			is: "{0} is {1}",
-			between: "{0} is between {1}",
-			"descendants of": "{0} is a descendant of {1}",
-			"ancestors of": "{0} is an ancestor of {1}",
-			"not descendants of": "{0} is not a descendant of {1}",
-			"not ancestors of": "{0} is not an ancestor of {1}",
-			timespan: "{0} is within {1}",
+			"=": __("{0} equals {1}"),
+			"!=": __("{0} is not equal to {1}"),
+			["in"]: __("{0} is one of {1}"),
+			"not in": __("{0} is not one of {1}"),
+			["like"]: __("{0} contains {1}"),
+			"not like": __("{0} does not contain {1}"),
+			">": __("{0} is greater than {1}"),
+			"<": __("{0} is less than {1}"),
+			">=": __("{0} is greater than or equal to {1}"),
+			"<=": __("{0} is less than or equal to {1}"),
+			["is"]: __("{0} is {1}"),
+			["between"]: __("{0} is between {1}"),
+			"descendants of": __("{0} is a descendant of {1}"),
+			"ancestors of": __("{0} is an ancestor of {1}"),
+			"not descendants of": __("{0} is not a descendant of {1}"),
+			"not ancestors of": __("{0} is not an ancestor of {1}"),
+			["timespan"]: __("{0} is within {1}"),
 		};
 
 		function formatValueForDisplay(docfield, val) {
 			// Check boolean fields -> show Yes/No (localized)
 			// Handles 0/1, true/false values
 			if (docfield && docfield.fieldtype === "Check") {
-				return String(__(val == 1 || val === true ? "Yes" : "No")).bold();
+				return (val == 1 || val === true ? __("Yes") : __("No")).bold();
 			}
 
 			// Array values -> truncate to first 5, append "..."
@@ -575,13 +575,14 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			// Special handling for Check fields
 			if (fieldtype === "Check") {
 				if (operator === "=" && value == 1) {
-					return "{0} is enabled";
+					return __("{0} is enabled");
 				} else if (operator === "=" && value == 0) {
-					return "{0} is disabled";
+					return __("{0} is disabled");
 				} else if (operator === "!=") {
-					return value == 1 ? "{0} is disabled" : "{0} is enabled";
+					return value == 1 ? __("{0} is disabled") : __("{0} is enabled");
 				}
 			}
+			// Return raw placeholder pattern for unknown operators (not translatable)
 			return operatorTemplates[operator] || "{0} {1} {2}";
 		}
 
@@ -614,7 +615,8 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			const template = get_operator_template(operator, fieldtype, value);
 
 			// fallback pattern expects 3 placeholders: label, operator (raw), value
-			if (template === "{0} {1} {2}") {
+			// Check if operator is not in templates (fallback case)
+			if (!operatorTemplates[operator]) {
 				return __(template, [labelDisplay, operator, valueDisplay]);
 			}
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -607,6 +607,12 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				case "<=":
 					return __("{0} is less than or equal to {1}", [labelDisplay, valueDisplay]);
 				case "is":
+					if (value == "set") {
+						return __("{0} is set", [labelDisplay]);
+					}
+					if (value == "not set") {
+						return __("{0} is not set", [labelDisplay]);
+					}
 					return __("{0} is {1}", [labelDisplay, valueDisplay]);
 				case "between":
 					return __("{0} is between {1}", [labelDisplay, valueDisplay]);

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -599,22 +599,22 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				case "not like":
 					return __("{0} does not contain {1}", [labelDisplay, valueDisplay]);
 				case ">":
-					if (fieldtype === "Date" || fieldtype === "Datetime") {
+					if (fieldtype === "Date" || fieldtype === "Datetime" || fieldtype === "Time") {
 						return __("{0} is after {1}", [labelDisplay, valueDisplay]);
 					}
 					return __("{0} is greater than {1}", [labelDisplay, valueDisplay]);
 				case "<":
-					if (fieldtype === "Date" || fieldtype === "Datetime") {
+					if (fieldtype === "Date" || fieldtype === "Datetime" || fieldtype === "Time") {
 						return __("{0} is before {1}", [labelDisplay, valueDisplay]);
 					}
 					return __("{0} is less than {1}", [labelDisplay, valueDisplay]);
 				case ">=":
-					if (fieldtype === "Date" || fieldtype === "Datetime") {
+					if (fieldtype === "Date" || fieldtype === "Datetime" || fieldtype === "Time") {
 						return __("{0} is on or after {1}", [labelDisplay, valueDisplay]);
 					}
 					return __("{0} is greater than or equal to {1}", [labelDisplay, valueDisplay]);
 				case "<=":
-					if (fieldtype === "Date" || fieldtype === "Datetime") {
+					if (fieldtype === "Date" || fieldtype === "Datetime" || fieldtype === "Time") {
 						return __("{0} is on or before {1}", [labelDisplay, valueDisplay]);
 					}
 					return __("{0} is less than or equal to {1}", [labelDisplay, valueDisplay]);

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -625,8 +625,8 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				case "timespan":
 					return __("{0} is within {1}", [labelDisplay, valueDisplay]);
 				default:
-					// Fallback for unknown operators
-					return __("{0} {1} {2}", [labelDisplay, operator, valueDisplay]);
+					// Fallback for unknown operators (no translatable text here)
+					return [labelDisplay, operator, valueDisplay].join(" ");
 			}
 		}
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -534,7 +534,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				const arr = filtered.slice(0, 5).map((v) => {
 					// Strings in quotes, numbers/dates not quoted
 					if (typeof v === "string") {
-						return `"${String(__(v))}"`;
+						return `"${String(__(v, null, docfield?.options))}"`;
 					}
 					// Numbers, dates, etc. - not translated, not quoted
 					return String(v);
@@ -545,12 +545,12 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 
 			// Null / empty
 			if (val == null || val === "") {
-				return __("empty");
+				return __("empty", null, "Comparison value is empty");
 			}
 
 			// Format based on type: strings in quotes, numbers/dates not quoted
 			if (typeof val === "string") {
-				return `"${String(__(val))}"`;
+				return `"${String(__(val, null, docfield?.options))}"`;
 			}
 
 			// Numbers, dates, etc. - not translated, not quoted

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -634,7 +634,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			filter_array.map((filter) => describe_filter(filter))
 		);
 		const filter_string = frappe.utils.comma_and(descriptions);
-		return __("Filters applied for {0}", [filter_string]);
+		return __("Filtered by: {0}.", [filter_string]);
 	}
 
 	set_custom_query(args) {

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -599,12 +599,24 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				case "not like":
 					return __("{0} does not contain {1}", [labelDisplay, valueDisplay]);
 				case ">":
+					if (fieldtype === "Date" || fieldtype === "Datetime") {
+						return __("{0} is after {1}", [labelDisplay, valueDisplay]);
+					}
 					return __("{0} is greater than {1}", [labelDisplay, valueDisplay]);
 				case "<":
+					if (fieldtype === "Date" || fieldtype === "Datetime") {
+						return __("{0} is before {1}", [labelDisplay, valueDisplay]);
+					}
 					return __("{0} is less than {1}", [labelDisplay, valueDisplay]);
 				case ">=":
+					if (fieldtype === "Date" || fieldtype === "Datetime") {
+						return __("{0} is on or after {1}", [labelDisplay, valueDisplay]);
+					}
 					return __("{0} is greater than or equal to {1}", [labelDisplay, valueDisplay]);
 				case "<=":
+					if (fieldtype === "Date" || fieldtype === "Datetime") {
+						return __("{0} is on or before {1}", [labelDisplay, valueDisplay]);
+					}
 					return __("{0} is less than or equal to {1}", [labelDisplay, valueDisplay]);
 				case "is":
 					if (value == "set") {


### PR DESCRIPTION
## Description
This PR addresses issue #35164 by converting technical filter operators into human-readable statements that are easier for non-technical users to understand.

## Changes Made

### 1. Human-Readable Operator Labels
- Added `get_operator_label()` helper function that maps technical operators to user-friendly labels:
  - `=` → "equals"
  - `!=` → "not equals"
  - `>` → "greater than"
  - `<` → "less than"
  - `>=` → "greater than or equals"
  - `<=` → "less than or equals"
  - `in` → "is one of"
  - `not in` → "is not one of"
  - `like` → "contains"
  - `not like` → "does not contain"
  - `between` → "is between"
  - `is` → "is"
  - `descendants of` → "descendants of"
  - `ancestors of` → "ancestors of"
  - `timespan` → "is within"
  
  Special handling for Date/Datetime fields with comparison operators:
  - ">" operator: "is after" (instead of "is greater than") for Date/Datetime/Time
  - "<" operator: "is before" (instead of "is less than") for Date/Datetime/Time  
  - ">=" operator: "is on or after" (instead of "is greater than or equal to") for Date/Datetime/Time
  - "<=" operator: "is on or before" (instead of "is less than or equal to") for Date/Datetime/Time

### 2. Special Check Field Handling
- For Check fields with `=` or `!=` operators:
  - Shows "is enabled" instead of "equals 1"
  - Shows "is disabled" instead of "equals 0"
  - Hides the numeric value for better readability
- Works even when metadata isn't loaded yet by detecting Check fields through value patterns (1/0)

### 3. Improved Value Formatting
- Filters out null/undefined/empty values from arrays before truncation
- Better handling of empty arrays and null values
- Maintains existing truncation logic (max 5 items)

## Example Output

**Before:**

<img width="1672" height="682" alt="Screenshot 2025-12-12 161302" src="https://github.com/user-attachments/assets/e70bd3c2-4476-4f62-a019-332cc395038d" />

**After:**
<img width="1378" height="674" alt="Screenshot 2025-12-12 161423" src="https://github.com/user-attachments/assets/18e3c673-f401-4fc2-ad03-46b6cc7b4ef4" />

### Documentation
Docs: https://docs.frappe.io/framework/

