### PR TITLE
fix: don't show is virtual property for link field 

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -556,6 +556,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.fieldtype !== 'Link'",
    "fieldname": "is_virtual",
    "fieldtype": "Check",
    "label": "Virtual"

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -255,6 +255,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.fieldtype !== 'Link'",
    "fieldname": "is_virtual",
    "fieldtype": "Check",
    "label": "Is Virtual"

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -127,6 +127,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.fieldtype !== 'Link'",
    "fieldname": "is_virtual",
    "fieldtype": "Check",
    "label": "Is Virtual"

--- a/frappe/public/js/form_builder/components/FieldProperties.vue
+++ b/frappe/public/js/form_builder/components/FieldProperties.vue
@@ -36,6 +36,10 @@ let docfield_df = computed(() => {
 			return false;
 		}
 
+		if (df.fieldname === "is_virtual" && store.form.selected_field.fieldtype === "Link") {
+			return false;
+		}
+
 		if (df.fieldname === "options") {
 			df.fieldtype = "Small Text";
 			df.options = "";

--- a/frappe/public/js/form_builder/components/FieldProperties.vue
+++ b/frappe/public/js/form_builder/components/FieldProperties.vue
@@ -36,10 +36,6 @@ let docfield_df = computed(() => {
 			return false;
 		}
 
-		if (df.fieldname === "is_virtual" && store.form.selected_field.fieldtype === "Link") {
-			return false;
-		}
-
 		if (df.fieldname === "options") {
 			df.fieldtype = "Small Text";
 			df.options = "";


### PR DESCRIPTION
Closes #34948

Before: Link field has a property **virtual**

<img width="1295" height="800" alt="Screenshot 2025-12-12 at 4 24 46 PM" src="https://github.com/user-attachments/assets/aa8065c5-d472-4eb9-97a9-4ddd14182406" />


Fix: 

<img width="1284" height="772" alt="Screenshot 2025-12-12 at 4 24 07 PM" src="https://github.com/user-attachments/assets/a8386fd8-a6bf-4434-bf32-8bdce7d0c6d2" />
