### PR TITLE
fix: prevent TypeError when desktop_icon_urls variant is undefined

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1336,10 +1336,8 @@ Object.assign(frappe.utils, {
 			icon_name
 		)}.svg`;
 
-		if (
-			frappe.boot.desktop_icon_urls[app_name] &&
-			frappe.boot.desktop_icon_urls[app_name][variant].includes(icon_url)
-		) {
+		const urls = frappe.boot.desktop_icon_urls?.[app_name]?.[variant] || [];
+		if (urls.includes(icon_url)) {
 			return `/${icon_url}`;
 		}
 		return exists;


### PR DESCRIPTION
**Issue :**

When loading the Desk, a browser console error appears: `TypeError: Cannot read properties of undefined (reading 'includes')
`   because of this error, the desk page becomes blank.


**Before :**

<img width="1832" height="1079" alt="Screenshot 2025-12-12 221406" src="https://github.com/user-attachments/assets/d3bb1d1d-14d8-46a7-a13a-658f9a8950b1" />


**After :**

<img width="1919" height="1019" alt="Screenshot 2025-12-12 221600" src="https://github.com/user-attachments/assets/27999388-a687-4892-abd8-a0a45b5eff97" />

