### PR TITLE
Revert "fix: allow same filter multiple times in workspace shortcut"

### DIFF
--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -3,7 +3,7 @@ const jump_to_field = (field_label) => {
 		.type("{esc}") // lose focus if any
 		.type("{ctrl+j}") // jump to field
 		.type(field_label)
-		.wait(1000)
+		.wait(500)
 		.type("{enter}")
 		.wait(200)
 		.type("{enter}")

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1670,19 +1670,10 @@ Object.assign(frappe.utils, {
 				// don't remove unless patch is created to convert all existing filters from object to array
 				// backward compatibility
 				if (Array.isArray(filters_json)) {
-					let filter = filters_json.reduce((acc, filter) => {
-						const field = filter[1];
-						const value = [filter[2], filter[3]];
-
-						// if we have multiple filters for the same field,
-						// we convert it into an array
-						if (acc[field]) {
-							acc[field].push(value);
-						} else {
-							acc[field] = [value];
-						}
-						return acc;
-					}, {});
+					let filter = {};
+					filters_json.forEach((arr) => {
+						filter[arr[1]] = [arr[2], arr[3]];
+					});
 					return filter || [];
 				}
 				return filters_json || [];


### PR DESCRIPTION
Reverts backport of #35133 for v15

v15 does not support nested or multiple filter conditions per field (e.g. [[">", 10], ["<", 20]]), and its `parse_filters_from_route_options()` assumes a single [operator, value] pair. 
Introducing multi-filter structures causes route option parsing to break in v15.