### PR TITLE
fix: restore custom_buttons tracking in add_custom_button

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1481,10 +1481,6 @@ frappe.ui.form.Form = class FrappeForm {
 
 		let btn = this.page.add_inner_button(label, fn, group);
 		if (btn) {
-			let menu_item_label = group ? `${group} > ${label}` : label;
-			let menu_item = this.page.add_menu_item(menu_item_label, fn, false);
-			menu_item.parent().addClass("hidden-xl");
-
 			this.custom_buttons[label] = btn;
 		}
 		return btn;

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1209,9 +1209,9 @@ frappe.ui.form.Form = class FrappeForm {
 				this.dashboard.clear_headline();
 				this.dashboard.set_headline_alert(
 					__("This form has been modified after you have loaded it") +
-						'<button class="btn btn-xs btn-primary pull-right" onclick="cur_frm.reload_doc()">' +
-						__("Refresh") +
-						"</button>",
+					'<button class="btn btn-xs btn-primary pull-right" onclick="cur_frm.reload_doc()">' +
+					__("Refresh") +
+					"</button>",
 					"alert-warning"
 				);
 			} else {
@@ -1246,7 +1246,7 @@ frappe.ui.form.Form = class FrappeForm {
 	add_web_link(path, label) {
 		label = __(label) || __("See on Website");
 		this.web_link = this.sidebar
-			.add_user_action(__(label), function () {})
+			.add_user_action(__(label), function () { })
 			.attr("href", path || this.doc.route)
 			.attr("target", "_blank");
 	}
@@ -1480,7 +1480,13 @@ frappe.ui.form.Form = class FrappeForm {
 		if (group && group.indexOf("fa fa-") !== -1) group = null;
 
 		let btn = this.page.add_inner_button(label, fn, group);
+		if (btn) {
+			let menu_item_label = group ? `${group} > ${label}` : label;
+			let menu_item = this.page.add_menu_item(menu_item_label, fn, false);
+			menu_item.parent().addClass("hidden-xl");
 
+			this.custom_buttons[label] = btn;
+		}
 		return btn;
 	}
 
@@ -2238,8 +2244,8 @@ frappe.ui.form.Form = class FrappeForm {
 						</div>
 						<div class="col-md-6">
 							<a href='/app/submission-queue?ref_doctype=${encodeURIComponent(
-								this.doctype
-							)}&ref_docname=${encodeURIComponent(this.docname)}'>${__(
+							this.doctype
+						)}&ref_docname=${encodeURIComponent(this.docname)}'>${__(
 							"All Submissions"
 						)}</a>
 						`;

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1209,9 +1209,9 @@ frappe.ui.form.Form = class FrappeForm {
 				this.dashboard.clear_headline();
 				this.dashboard.set_headline_alert(
 					__("This form has been modified after you have loaded it") +
-					'<button class="btn btn-xs btn-primary pull-right" onclick="cur_frm.reload_doc()">' +
-					__("Refresh") +
-					"</button>",
+						'<button class="btn btn-xs btn-primary pull-right" onclick="cur_frm.reload_doc()">' +
+						__("Refresh") +
+						"</button>",
 					"alert-warning"
 				);
 			} else {
@@ -1246,7 +1246,7 @@ frappe.ui.form.Form = class FrappeForm {
 	add_web_link(path, label) {
 		label = __(label) || __("See on Website");
 		this.web_link = this.sidebar
-			.add_user_action(__(label), function () { })
+			.add_user_action(__(label), function () {})
 			.attr("href", path || this.doc.route)
 			.attr("target", "_blank");
 	}
@@ -2244,8 +2244,8 @@ frappe.ui.form.Form = class FrappeForm {
 						</div>
 						<div class="col-md-6">
 							<a href='/app/submission-queue?ref_doctype=${encodeURIComponent(
-							this.doctype
-						)}&ref_docname=${encodeURIComponent(this.docname)}'>${__(
+								this.doctype
+							)}&ref_docname=${encodeURIComponent(this.docname)}'>${__(
 							"All Submissions"
 						)}</a>
 						`;


### PR DESCRIPTION
## Description
Fixes #34920 - Custom buttons not appearing in `frm.custom_buttons` in Frappe v16

## Problem
In Frappe v16, the `add_custom_button` method was refactored but accidentally removed the assignment to `frm.custom_buttons`. This causes:

1. **`frm.custom_buttons` is always empty** - Breaking any code that checks button existence
2. **`can_create()` method fails** - Always returns `false` when checking for custom make buttons
3. **`remove_custom_button()` incomplete** - Tries to delete from empty object

## Solution
Added conditional block to:
- Populate `frm.custom_buttons` when button is successfully created
- Add mobile menu support for custom buttons
- Guard against null button references with `if (btn)` check

## Changes Made
- Modified `add_custom_button()` method in `frappe/public/js/frappe/form/form.js`
- Added `if (btn)` guard before populating `custom_buttons`
- Maintained mobile menu functionality added in v16

## Testing Done
Tested with this client script:
```javascript
frappe.ui.form.on("Test", {
    refresh(frm) {
        frm.add_custom_button("Apply Supplier Rate", () => {
            console.log("Clicked");
        });
        console.log(frm.custom_buttons);
    }
});
```

**Results:**
-  `frm.custom_buttons` now correctly populated
-  `can_create()` method works as expected
-  `remove_custom_button()` properly removes buttons
-  Buttons render correctly on UI
-  Click handlers work as expected
-  Mobile menu items created properly
-  No breaking changes to existing functionality

## Related Methods Still Using `custom_buttons`
Evidence this is needed (not an intentional removal):
```javascript
clear_custom_buttons() {
    this.page.clear_inner_toolbar();
    this.page.clear_user_actions();
    this.custom_buttons = {};  // ← Still using it in version 16 also
}

remove_custom_button(label, group) {
    this.page.remove_inner_button(label, group);
    delete this.custom_buttons[label]; // ← Still using it in version 16 also
}

can_create(doctype) {
    if (this.custom_make_buttons && this.custom_make_buttons[doctype]) {
        const key = __(this.custom_make_buttons[doctype]);
        return !!this.custom_buttons[key]; // ← Still using it in version 16 also
    }
}
```

<img width="958" height="267" alt="Screenshot 2025-12-13 175431" src="https://github.com/user-attachments/assets/689b2d36-0741-4bf7-9602-255c73595af8" />
