### PR TITLE
fix(data import): use user_language for validations and DI BG job

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -38,7 +38,9 @@ class Importer:
 			self.data_import = frappe.get_doc(doctype="Data Import")
 			if import_type:
 				self.data_import.import_type = import_type
-
+		# set user lang for translations
+		frappe.cache.hdel("lang", frappe.session.user)
+		frappe.set_user_lang(frappe.session.user)
 		self.template_options = frappe.parse_json(self.data_import.template_options or "{}")
 		self.import_type = self.data_import.import_type
 


### PR DESCRIPTION
**fix(data import):** Since the last update of Frappe v15.91.0, the Data Import feature had the introduction of validations of columns. This worked for users who had their language set as English but failed for Non-English Users. This was fixed further, however, that fix worked only for the validations and the Background job continued to fail silently. This was primarily due to the fact that the validations occurred prior to setting user language for the system in `before_import`. This issue is related to Support Ticket [#54765](https://support.frappe.io/helpdesk/my-tickets/54765) . This PR aims to fix this bug by ensuring we set user_language early on in the process during `init`. This will ensure that the BG job runs the way it should and succeeds. Related PR: #34926 

**Before:**
<img width="1322" height="702" alt="Image" src="https://github.com/user-attachments/assets/00ae9169-a7f4-43b5-879e-56c3fba8825e" />

**After:**
<img width="2874" height="1592" alt="image" src="https://github.com/user-attachments/assets/37c57c0f-7576-4d97-879f-7342ed6fd3c6" />

fixes #35226 
fixes #35140