### PR TITLE
fix!: Swap old style naming with new one

### DIFF
--- a/cypress/integration/customize_form.js
+++ b/cypress/integration/customize_form.js
@@ -10,8 +10,8 @@ context("Customize Form", () => {
 		const naming_rule_default_autoname_map = {
 			"Set by user": "prompt",
 			"By fieldname": "field:",
-			Expression: "format:",
-			"Expression (old style)": "",
+			Expression: "",
+			"Expression (old style)": "format:",
 			Random: "hash",
 			"By script": "",
 		};

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -455,6 +455,7 @@ class DocType(Document):
 		# We swapped naming_rule field old/new to discourage use of "format:"
 		if self.autoname and self.autoname.startswith("format:"):
 			self.naming_rule = "Expression (old style)"
+			frappe.toast(_("Warning: Usage of 'format:' is discouraged."), indicator="yellow")
 
 		if self.naming_rule == "Expression (old style)" and not self.autoname.startswith("format:"):
 			self.naming_rule = "Expression"

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -216,6 +216,7 @@ class DocType(Document):
 		self.validate_website()
 		self.validate_virtual_doctype_methods()
 		self.ensure_minimum_max_attachment_limit()
+		self.patch_old_naming_expressions()
 		validate_links_table_fieldnames(self)
 
 		if not self.is_new():
@@ -446,6 +447,17 @@ class DocType(Document):
 				title=_("Insufficient attachment limit"),
 				alert=True,
 			)
+
+	def patch_old_naming_expressions(self):
+		if not self.autoname:
+			return
+
+		# We swapped naming_rule field old/new to discourage use of "format:"
+		if self.autoname and self.autoname.startswith("format:"):
+			self.naming_rule = "Expression (old style)"
+
+		if self.naming_rule == "Expression (old style)" and not self.autoname.startswith("format:"):
+			self.naming_rule = "Expression"
 
 	def change_modified_of_parent(self):
 		"""Change the timestamp of parent DocType if the current one is a child to clear caches."""

--- a/frappe/public/js/frappe/doctype/index.js
+++ b/frappe/public/js/frappe/doctype/index.js
@@ -75,8 +75,8 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 				"Set by user": "prompt",
 				"By fieldname": "field:",
 				'By "Naming Series" field': "naming_series:",
-				Expression: "format:",
-				"Expression (sld style)": "",
+				Expression: "",
+				"Expression (old style)": "format:",
 				Random: "hash",
 				UUID: "UUID",
 				"By script": "",
@@ -99,9 +99,9 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 			"By fieldname": "Format: <code>field:[fieldname]</code>. Valid fieldname must exist",
 			'By "Naming Series" field':
 				"Format: <code>naming_series:[fieldname]</code>. Default fieldname is <code>naming_series</code>",
-			Expression:
-				"Format: <code>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</code> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.",
 			"Expression (old style)":
+				"Format: <code>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</code> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.",
+			Expression:
 				"Format: <code>EXAMPLE-.#####</code> Series by prefix (separated by a dot)",
 			Random: "",
 			"By script": "",
@@ -129,9 +129,9 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 			else if (autoname.startsWith("naming_series:"))
 				this.frm.set_value("naming_rule", 'By "Naming Series" field');
 			else if (autoname.startsWith("format:"))
-				this.frm.set_value("naming_rule", "Expression");
+				this.frm.set_value("naming_rule", "Expression (old style)");
 			else if (autoname === "hash") this.frm.set_value("naming_rule", "Random");
-			else this.frm.set_value("naming_rule", "Expression (old style)");
+			else this.frm.set_value("naming_rule", "Expression");
 
 			setTimeout(() => (this.frm.__from_autoname = false), 500);
 		}

--- a/frappe/public/js/frappe/doctype/index.js
+++ b/frappe/public/js/frappe/doctype/index.js
@@ -24,6 +24,7 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 
 	refresh() {
 		this.show_db_utilization();
+		this.remove_old_style_naming_option();
 	}
 
 	show_db_utilization() {
@@ -43,6 +44,12 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 					)
 				);
 			});
+	}
+
+	remove_old_style_naming_option() {
+		let df = this.frm.get_docfield("naming_rule");
+		df.options = df.options.replace("Expression (old style)\n", "");
+		this.frm.refresh_field("naming_rule");
 	}
 
 	max_attachments() {


### PR DESCRIPTION
"new" style of naming uses `format:` which is broken and unfixable. This
commit discourages use of the new style.

What was referred to as "old style" already works just fine and supports
all the same things.

ref https://github.com/frappe/frappe/issues/21212
