### PR TITLE
style(ui): normalize left property in modal divider

### DIFF
--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -115,6 +115,7 @@
 		background-color: var(--border-color);
 		position: absolute;
 		top: 40px;
+		left: 0;
 		border-radius: 50%;
 	}
 }


### PR DESCRIPTION
### What changed
Normalized the CSS `left` property for `.modal-divider`.

### Why
The modal divider is absolutely positioned and using `left: 0;` ensures consistent edge alignment across browsers. Zero values do not require units in CSS and this matches the existing code style.

### Screenshots
<img width="616" height="257" alt="Screenshot from 2025-12-15 15-45-21" src="https://github.com/user-attachments/assets/058cc90c-0589-493e-8c37-ca09a3a0fe4b" />

