### PR TITLE
fix: Fixed permission issue while login using Office 365

### DIFF
--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -191,6 +191,8 @@ def get_info_via_oauth(provider: str, code: str, decoder: Callable | None = None
 	if not (info.get("email_verified") or info.get("email")):
 		frappe.throw(_("Email not verified with {0}").format(provider.title()))
 
+	info["email"] = info.get("email", "").lower()
+	info["upn"] = info.get("upn", "").lower()
 	return info
 
 


### PR DESCRIPTION
### Fix

1. Issue: Getting permissions issue while using Office 365 login method
2. Resolution: System did not lower the important data getting from the Social Login Provider such as email, upn by which session data are not getting properly prepared after login

**Session data before =**` {'data': {'user': 'Test.SSO@*******.com', 'session_ip': '127.0.0.1', 'last_updated': '2025-09-01 14:20:28.527069', 'session_expiry': '06:00:00', 'creation': '2025-09-01 14:20:28.527328', 'full_name': 'Guest', 'user_type': 'System User', 'device': 'desktop'}, 'user': 'Test.SSO@*******.com', 'sid': '******************************************'}`

**Session data after =** `{'data': {'user': 'test.ssp@*******.com', 'session_ip': '127.0.0.1', 'last_updated': '2025-09-01 14:20:28.527069', 'session_expiry': '06:00:00', 'creation': '2025-09-01 14:20:28.527328', 'full_name': 'Guest', 'user_type': 'System User', 'device': 'desktop'}, 'user': 'test.sso@*******.com', 'sid': '******************************************'}`

For the instance check the below issue
<img width="1083" height="617" alt="image" src="https://github.com/user-attachments/assets/b4d20b2b-26f7-4975-abf5-80bc5c58a55e" />

In the image user have the right to edit also action on draft state but still he does not able to do.
<img width="1165" height="628" alt="image" src="https://github.com/user-attachments/assets/b0c1f1a9-5e86-4a74-bfcc-d121b673b2b5" />
After the fix employee can edit and send the doc to next state