### PR TITLE
fix: virtual childtable docfields value not in pdf childtable

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -322,6 +322,9 @@ class BaseDocument:
 
 		value = self.__dict__.get(key, default)
 
+		if value == default and key and (prop := getattr(type(self), key, None)) and is_a_property(prop):
+			value = getattr(self, key)
+
 		if limit and isinstance(value, list | tuple) and len(value) > limit:
 			value = value[:limit]
 


### PR DESCRIPTION
There seems to be a bug when printing childtables with the standard layout if that childtable document has virtual docfields (properties). For me they were not printed in the pdf file. 

I was confused, as in the preview it seems to work.
Anyway, when looking at the code, it seems quite clear, that props will not be calculated because of the access via `__dict__` in this line in `base_document.py` in the `get` methoddefinition:

```python
		value = self.__dict__.get(key, default)
```


Steps to reproduce:
1. Create a doctype with a childtable.
2. On the Childtable doctype create a virtual field
3. implement the calculation of the virtual docfields value
4. create a sample doc with at least one childtable entry
5. click the print button
6. click the `PDF` button, to actually generate the pdf
7. => The value should be the default value (0.00 for floats in my case)

This fixes this problem.

Much love,

stephen



