### PR TITLE
fix(linked_with): exclude virtual Link fields from reference queries

### DIFF
--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -234,7 +234,7 @@ def get_references_across_doctypes_by_link_field(
 	:param to_doctypes: Get links to these doctypes.
 	:param limit_link_doctypes: limit links to these doctypes.
 	"""
-	filters = [["fieldtype", "=", "Link"]]
+	filters = [["fieldtype", "=", "Link"], ["is_virtual", "!=", 1]]
 
 	if to_doctypes:
 		filters += [["options", "in", tuple(to_doctypes)]]

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -185,3 +185,59 @@ class TestLinkedWith(FrappeTestCase):
 
 		second_doc.cancel()
 		linked_doc.reload().cancel()
+
+	def test_virtual_link_fields_excluded_from_references(self):
+		"""Virtual Link fields should not be included in references.
+
+		Virtual fields do not have database columns, so including them in
+		reference queries would cause database errors when the system tries
+		to filter by these non-existent columns.
+		"""
+		dt_name = "Test " + "".join(random.sample(string.ascii_lowercase, 10))
+		target_dt_name = "Test Target " + "".join(random.sample(string.ascii_lowercase, 10))
+
+		# Create a target DocType that the Link fields will reference
+		target_doctype = new_doctype(target_dt_name)
+		target_doctype.insert()
+
+		# Create a DocType with both regular and virtual Link fields
+		doctype_with_virtual = new_doctype(
+			dt_name,
+			fields=[
+				{
+					"label": "Regular Link",
+					"fieldname": "regular_link",
+					"fieldtype": "Link",
+					"options": target_dt_name,
+					"is_virtual": 0,
+				},
+				{
+					"label": "Virtual Link",
+					"fieldname": "virtual_link",
+					"fieldtype": "Link",
+					"options": target_dt_name,
+					"is_virtual": 1,
+				},
+			],
+		)
+		doctype_with_virtual.insert()
+
+		try:
+			references = linked_with.get_references_across_doctypes_by_link_field(
+				to_doctypes=[target_dt_name]
+			)
+
+			# Should only contain the regular link, not the virtual one
+			self.assertIn(target_dt_name, references)
+			fieldnames = [ref["fieldname"] for ref in references[target_dt_name]]
+
+			self.assertIn("regular_link", fieldnames)
+			self.assertNotIn(
+				"virtual_link",
+				fieldnames,
+				"Virtual Link fields should not be included in references",
+			)
+		finally:
+			frappe.delete_doc("DocType", dt_name)
+			frappe.delete_doc("DocType", target_dt_name)
+			frappe.db.commit()


### PR DESCRIPTION
## Summary

Exclude virtual Link fields when querying doctype references. Virtual fields don't have database columns, causing errors when used in filters.

## Problem

When querying for linked documents using `get_references_across_doctypes_by_link_field()`, the function would include virtual Link fields in its results. Virtual fields (`is_virtual=1`) are computed fields that don't have corresponding database columns. When the system later tries to query documents using these virtual link field references, database errors occur because the column doesn't exist.

### Error Scenario

1. DocType `A` has a virtual Link field `virtual_ref` pointing to DocType `B`
2. User opens a document of DocType `B` and clicks "Links" to see linked documents
3. System calls `get_references_across_doctypes_by_link_field()` which returns `virtual_ref`
4. System tries to query: `SELECT * FROM A WHERE virtual_ref = 'B-001'`
5. **Database Error**: Column `virtual_ref` doesn't exist

## Solution

Add a filter to exclude virtual fields from the query:

```python
# Before
filters = [["fieldtype", "=", "Link"]]

# After
filters = [["fieldtype", "=", "Link"], ["is_virtual", "!=", 1]]
```

## Testing

Added `test_virtual_link_fields_excluded_from_references` to `frappe/tests/test_linked_with.py`.

All tests pass locally.