### PR TITLE
fix: virtual childtable docfields value not in pdf childtable

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1390,7 +1390,10 @@ class BaseDocument:
 		):
 			currency = frappe.db.get_value("Currency", currency_value, cache=True)
 
-		val = self.get(fieldname)
+		if fieldname and (prop := getattr(type(self), fieldname, None)) and is_a_property(prop):
+			val = getattr(self, fieldname)
+		else:
+			val = self.get(fieldname)
 
 		if translated:
 			val = _(val)


### PR DESCRIPTION
There seems to be a bug when printing childtables with the standard layout if that childtable document has virtual docfields (properties). 

For me they were not printed in the pdf file.

I was confused, as in the preview it seems to work.


### Steps to reproduce:

1. Create a doctype with a childtable.
2. On the Childtable doctype create a virtual field
3. implement the calculation of the virtual docfields value
4. create a sample doc with at least one childtable entry
5. click the print button
6. click the PDF button, to actually generate the pdf
=> The value should be the default value (0.00 for floats in my case)

This fixes this problem.

Much love,

stephen