### PR TITLE
fix: filter virtual fields from column picker in report view

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1021,7 +1021,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			columns: 2,
 			options: columns[this.doctype]
 				.filter((df) => {
-					return !df.hidden && df.fieldname !== "name";
+					return !df.hidden && df.fieldname !== "name" && !df.is_virtual;
 				})
 				.map((df) => ({
 					label: __(df.label, null, df.parent),


### PR DESCRIPTION
## Issue

Virtual fields are not saved in database. So they show nil values or raise error. They should ideally not show up when picking columns in report view.

Hence added them as filter

### Before

<img width="1223" height="509" alt="image" src="https://github.com/user-attachments/assets/218addb2-bc61-49cf-87ef-4a3d4b07fea7" />

<img width="1312" height="491" alt="image" src="https://github.com/user-attachments/assets/31a276aa-0a1e-41ed-98e7-efe5d7d936a5" />


### After

<img width="1076" height="456" alt="image" src="https://github.com/user-attachments/assets/0623e500-6bb1-46f6-a82e-2d23b8f130d6" />
