### PR TITLE
fix: Refactor communication date copy logic for DB compatibility

### DIFF
--- a/frappe/core/doctype/communication_link/patches/copy_communication_date_to_link.py
+++ b/frappe/core/doctype/communication_link/patches/copy_communication_date_to_link.py
@@ -1,56 +1,33 @@
 import frappe
+from frappe.query_builder import DocType
 
-
-  # copy communication_date from Communication to Communication Link
-  def execute():
-      batch_size = 10_000
-
-      while True:
-          # Update communication_date in batches
-          frappe.db.multisql(
-              {
-                  "postgres": """
-                      UPDATE "tabCommunication Link" cl
-                      SET communication_date = c.communication_date
-                      FROM "tabCommunication" c
-                      WHERE cl.parent = c.name
-                      AND cl.communication_date IS NULL
-                      AND c.communication_date IS NOT NULL
-                      LIMIT %s
-                  """,
-                  "mariadb": """
-                      UPDATE `tabCommunication Link` cl
-                      INNER JOIN `tabCommunication` c ON cl.parent = c.name
-                      SET cl.communication_date = c.communication_date
-                      WHERE cl.communication_date IS NULL
-                      AND c.communication_date IS NOT NULL
-                      LIMIT %s
-                  """,
-              },
-              values=(batch_size,),
-          )
-
-          frappe.db.commit()
-
-          # Check if more rows need updating
-          check = frappe.db.multisql(
-              {
-                  "postgres": """
-                      SELECT 1 FROM "tabCommunication Link" cl
-                      INNER JOIN "tabCommunication" c ON cl.parent = c.name
-                      WHERE cl.communication_date IS NULL
-                      AND c.communication_date IS NOT NULL
-                      LIMIT 1
-                  """,
-                  "mariadb": """
-                      SELECT 1 FROM `tabCommunication Link` cl
-                      INNER JOIN `tabCommunication` c ON cl.parent = c.name
-                      WHERE cl.communication_date IS NULL
-                      AND c.communication_date IS NOT NULL
-                      LIMIT 1
-                  """,
-              }
-          )
-
-          if not check:
-              break
+# copy communication_date from Communication to Communication Link
+def execute():
+	batch_size = 10_000
+	
+	CommunicationLink = DocType("Communication Link")
+	Communication = DocType("Communication")
+	while True:
+		# Fetch records that need updating with their communication_date
+		records = (
+			frappe.qb.from_(CommunicationLink)
+			.join(Communication)
+			.on(CommunicationLink.parent == Communication.name)
+			.select(CommunicationLink.name, Communication.communication_date)
+			.where(CommunicationLink.communication_date.isnull())
+			.where(Communication.communication_date.isnotnull())
+			.limit(batch_size)
+		).run(as_dict=True)
+		
+		if not records:
+			break
+			
+		# Update records in batch
+		for record in records:
+			(
+				frappe.qb.update(CommunicationLink)
+				.set(CommunicationLink.communication_date, record.communication_date)
+				.where(CommunicationLink.name == record.name)
+			).run()
+		
+		frappe.db.commit()

--- a/frappe/core/doctype/communication_link/patches/copy_communication_date_to_link.py
+++ b/frappe/core/doctype/communication_link/patches/copy_communication_date_to_link.py
@@ -1,12 +1,14 @@
 import frappe
 from frappe.query_builder import DocType
 
+
 # copy communication_date from Communication to Communication Link
 def execute():
 	batch_size = 10_000
-	
+
 	CommunicationLink = DocType("Communication Link")
 	Communication = DocType("Communication")
+
 	while True:
 		# Fetch records that need updating with their communication_date
 		records = (
@@ -18,10 +20,10 @@ def execute():
 			.where(Communication.communication_date.isnotnull())
 			.limit(batch_size)
 		).run(as_dict=True)
-		
+
 		if not records:
 			break
-			
+
 		# Update records in batch
 		for record in records:
 			(
@@ -29,5 +31,5 @@ def execute():
 				.set(CommunicationLink.communication_date, record.communication_date)
 				.where(CommunicationLink.name == record.name)
 			).run()
-		
+
 		frappe.db.commit()

--- a/frappe/core/doctype/communication_link/patches/copy_communication_date_to_link.py
+++ b/frappe/core/doctype/communication_link/patches/copy_communication_date_to_link.py
@@ -1,32 +1,65 @@
 import frappe
 
 
-# copy communication_date from Communication to Communication Link
-def execute():
-	batch_size = 10_000
+  # copy communication_date from Communication to Communication Link
+  def execute():
+      batch_size = 10_000
 
-	while True:
-		frappe.db.sql(
-			"""
-			update `tabCommunication Link` cl
-			inner join `tabCommunication` c on cl.parent = c.name
-			set cl.communication_date = c.communication_date
-			where cl.communication_date is null
-			and c.communication_date is not null
-			limit %s
-			""",
-			(batch_size,),
-		)
+      # Check if using PostgreSQL
+      is_postgres = frappe.db.db_type == "postgres"
 
-		frappe.db.commit()
+      while True:
+          if is_postgres:
+              # PostgreSQL syntax
+              frappe.db.sql(
+                  """
+                  update "tabCommunication Link" cl
+                  set communication_date = c.communication_date
+                  from "tabCommunication" c
+                  where cl.parent = c.name
+                  and cl.communication_date is null
+                  and c.communication_date is not null
+                  limit %s
+                  """,
+                  (batch_size,),
+              )
+          else:
+              # MySQL/MariaDB syntax
+              frappe.db.sql(
+                  """
+                  update `tabCommunication Link` cl
+                  inner join `tabCommunication` c on cl.parent = c.name
+                  set cl.communication_date = c.communication_date
+                  where cl.communication_date is null
+                  and c.communication_date is not null
+                  limit %s
+                  """,
+                  (batch_size,),
+              )
 
-		if not frappe.db.sql(
-			"""
-			select 1 from `tabCommunication Link` cl
-			inner join `tabCommunication` c on cl.parent = c.name
-			where cl.communication_date is null
-			and c.communication_date is not null
-			limit 1
-			"""
-		):
-			break
+          frappe.db.commit()
+
+          # Check if more rows need updating
+          if is_postgres:
+              check = frappe.db.sql(
+                  """
+                  select 1 from "tabCommunication Link" cl
+                  inner join "tabCommunication" c on cl.parent = c.name
+                  where cl.communication_date is null
+                  and c.communication_date is not null
+                  limit 1
+                  """
+              )
+          else:
+              check = frappe.db.sql(
+                  """
+                  select 1 from `tabCommunication Link` cl
+                  inner join `tabCommunication` c on cl.parent = c.name
+                  where cl.communication_date is null
+                  and c.communication_date is not null
+                  limit 1
+                  """
+              )
+
+          if not check:
+              break

--- a/frappe/core/doctype/communication_link/patches/copy_communication_date_to_link.py
+++ b/frappe/core/doctype/communication_link/patches/copy_communication_date_to_link.py
@@ -5,61 +5,52 @@ import frappe
   def execute():
       batch_size = 10_000
 
-      # Check if using PostgreSQL
-      is_postgres = frappe.db.db_type == "postgres"
-
       while True:
-          if is_postgres:
-              # PostgreSQL syntax
-              frappe.db.sql(
-                  """
-                  update "tabCommunication Link" cl
-                  set communication_date = c.communication_date
-                  from "tabCommunication" c
-                  where cl.parent = c.name
-                  and cl.communication_date is null
-                  and c.communication_date is not null
-                  limit %s
+          # Update communication_date in batches
+          frappe.db.multisql(
+              {
+                  "postgres": """
+                      UPDATE "tabCommunication Link" cl
+                      SET communication_date = c.communication_date
+                      FROM "tabCommunication" c
+                      WHERE cl.parent = c.name
+                      AND cl.communication_date IS NULL
+                      AND c.communication_date IS NOT NULL
+                      LIMIT %s
                   """,
-                  (batch_size,),
-              )
-          else:
-              # MySQL/MariaDB syntax
-              frappe.db.sql(
-                  """
-                  update `tabCommunication Link` cl
-                  inner join `tabCommunication` c on cl.parent = c.name
-                  set cl.communication_date = c.communication_date
-                  where cl.communication_date is null
-                  and c.communication_date is not null
-                  limit %s
+                  "mariadb": """
+                      UPDATE `tabCommunication Link` cl
+                      INNER JOIN `tabCommunication` c ON cl.parent = c.name
+                      SET cl.communication_date = c.communication_date
+                      WHERE cl.communication_date IS NULL
+                      AND c.communication_date IS NOT NULL
+                      LIMIT %s
                   """,
-                  (batch_size,),
-              )
+              },
+              values=(batch_size,),
+          )
 
           frappe.db.commit()
 
           # Check if more rows need updating
-          if is_postgres:
-              check = frappe.db.sql(
-                  """
-                  select 1 from "tabCommunication Link" cl
-                  inner join "tabCommunication" c on cl.parent = c.name
-                  where cl.communication_date is null
-                  and c.communication_date is not null
-                  limit 1
-                  """
-              )
-          else:
-              check = frappe.db.sql(
-                  """
-                  select 1 from `tabCommunication Link` cl
-                  inner join `tabCommunication` c on cl.parent = c.name
-                  where cl.communication_date is null
-                  and c.communication_date is not null
-                  limit 1
-                  """
-              )
+          check = frappe.db.multisql(
+              {
+                  "postgres": """
+                      SELECT 1 FROM "tabCommunication Link" cl
+                      INNER JOIN "tabCommunication" c ON cl.parent = c.name
+                      WHERE cl.communication_date IS NULL
+                      AND c.communication_date IS NOT NULL
+                      LIMIT 1
+                  """,
+                  "mariadb": """
+                      SELECT 1 FROM `tabCommunication Link` cl
+                      INNER JOIN `tabCommunication` c ON cl.parent = c.name
+                      WHERE cl.communication_date IS NULL
+                      AND c.communication_date IS NOT NULL
+                      LIMIT 1
+                  """,
+              }
+          )
 
           if not check:
               break


### PR DESCRIPTION
Updated the execute function to handle PostgreSQL and MySQL/MariaDB syntax for copying communication dates.

The current version 15 is throwing errors upon migrate commands
<img width="1727" height="945" alt="Screenshot 2025-12-16 at 16 21 17" src="https://github.com/user-attachments/assets/7573911b-4ea7-47d2-9ae6-b945e01ee8a3" />

I request you to add this to the new version of frappe as soon as possible.


Closes https://github.com/frappe/frappe/issues/35281