### PR TITLE
fix(ux): enable create log for server scripts by default

### DIFF
--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -69,7 +69,6 @@ context("Form", () => {
 		// test email validations for set_invalid controller
 		let website_input = "website.in";
 		let valid_email = "user@email.com";
-		let expectBackgroundColor = "rgb(255, 245, 245)";
 
 		cy.visit("/desk/contact/new");
 		cy.fill_field("company_name", "Test Company");

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -47,7 +47,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:[\"All\", \"Cron\"].includes(doc.frequency)",
+   "depends_on": "eval:[\"All\", \"Cron\"].includes(doc.frequency) || doc.server_script",
    "fieldname": "create_log",
    "fieldtype": "Check",
    "label": "Create Log"
@@ -117,7 +117,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2025-06-03 09:26:47.961601",
+ "modified": "2025-12-17 11:35:15.878930",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -47,7 +47,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:[\"All\", \"Cron\"].includes(doc.frequency) || doc.server_script",
+   "depends_on": "eval:([\"All\", \"Cron\"].includes(doc.frequency) || doc.server_script)",
    "fieldname": "create_log",
    "fieldtype": "Check",
    "label": "Create Log"
@@ -117,7 +117,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2025-12-17 11:35:15.878930",
+ "modified": "2025-12-17 12:02:56.228336",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -123,7 +123,9 @@ class ServerScript(Document):
 			if scheduled_script := frappe.db.get_value("Scheduled Job Type", {"server_script": self.name}):
 				return frappe.get_doc("Scheduled Job Type", scheduled_script)
 			else:
-				return frappe.get_doc({"doctype": "Scheduled Job Type", "server_script": self.name})
+				return frappe.get_doc(
+					{"doctype": "Scheduled Job Type", "server_script": self.name, "create_log": 1}
+				)
 
 		previous_script_type = self.get_value_before_save("script_type")
 		if previous_script_type != self.script_type and previous_script_type == "Scheduler Event":


### PR DESCRIPTION
This is a saner default for server scripts, even I have been confused sometimes not seeing the logs and then realising have to enable it first.

ref: https://support.frappe.io/helpdesk/tickets/55471?view=VIEW-HD+Ticket-610