### PR TITLE
fix: add quick way to go back to desktop

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -88,7 +88,7 @@ frappe.breadcrumbs = {
 		if (css_classes) {
 			a.classList.add(css_classes);
 		}
-		a.innerText = label;
+		a.innerHTML = label;
 		el.appendChild(a);
 		this.$breadcrumbs.append(el);
 	},
@@ -244,6 +244,7 @@ frappe.breadcrumbs = {
 
 	clear() {
 		this.$breadcrumbs = $(".navbar-breadcrumbs").empty();
+		this.append_breadcrumb_element("/desk", frappe.utils.icon("monitor"));
 	},
 
 	toggle(show) {


### PR DESCRIPTION
Desktop Button is hidden inside the dropdown, but there needs to be a way to get there quickly. Will polish it later

<img width="1440" height="778" alt="Screenshot 2025-12-17 at 2 47 18 PM" src="https://github.com/user-attachments/assets/17587479-4d74-4d7c-9a4b-fdd97097aadf" />
