### PR TITLE
fix!: Sendmail shouldn't implicitly commit transaction

### DIFF
--- a/frappe/core/doctype/user_invitation/test_user_invitation.py
+++ b/frappe/core/doctype/user_invitation/test_user_invitation.py
@@ -78,6 +78,7 @@ class IntegrationTestUserInvitation(IntegrationTestCase):
 		invitation = self.get_dummy_invitation()
 		self.assertEqual(len(self.get_email_names()), 0)
 		invitation.insert()
+		frappe.db.commit()
 		self.assertEqual(invitation.invited_by, frappe.session.user)
 		self.assertEqual(invitation.status, "Pending")
 		self.assertIsInstance(invitation.email_sent_at, str)
@@ -90,8 +91,10 @@ class IntegrationTestUserInvitation(IntegrationTestCase):
 	def test_update_invitation_status_to_expired(self):
 		invitation = self.get_dummy_invitation()
 		invitation.insert()
+		frappe.db.commit()
 		self.assertEqual(len(self.get_email_names()), 1)
 		invitation.expire()
+		frappe.db.commit()
 		emails = self.get_email_messages(False)
 		self.assertEqual(len(emails), 2)
 		self.assertIn("expired", emails[0].message.lower())
@@ -252,15 +255,21 @@ class IntegrationTestUserInvitation(IntegrationTestCase):
 	def test_cancel_invitation_api(self):
 		invitation = self.get_dummy_invitation()
 		invitation.insert()
+		frappe.db.commit()
+
 		invitation.reload()
 		self.assertEqual(invitation.status, "Pending")
 		self.assertEqual(len(self.get_email_names()), 1)
 		res = cancel_invitation(invitation.name, "frappe")
+		frappe.db.commit()
+
 		self.assertTrue(res["cancelled_now"])
 		invitation.reload()
 		self.assertEqual(invitation.status, "Cancelled")
 		self.assertEqual(len(self.get_email_names()), 2)
 		res = cancel_invitation(invitation.name, "frappe")
+		frappe.db.commit()
+
 		self.assertFalse(res["cancelled_now"])
 		self.assertEqual(len(self.get_email_names()), 2)
 

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -239,4 +239,8 @@ def sendmail(
 	)
 
 	# build email queue and send the email if send_now is True.
-	return builder.process(send_now=now)
+
+	q = builder.process(send_now=False)
+	if now:
+		frappe.db.after_commit.add(q.send)
+	return q

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -183,8 +183,9 @@ class TestEmailAccount(IntegrationTestCase):
 			recipients="test_recipient@example.com",
 			content="test mail 001",
 			subject="test-mail-001",
-			delayed=False,
+			now=True,
 		)
+		frappe.db.commit()  # now=True requires commit
 
 		sent_mail = email.message_from_string(frappe.safe_decode(frappe.flags.sent_mail))
 		self.assertTrue("test-mail-001" in sent_mail.get("Subject"))

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -112,6 +112,7 @@ class TestWebhook(IntegrationTestCase):
 		self.test_user.email = "user1@integration.webhooks.test.com"
 		self.test_user.first_name = "user1"
 		self.test_user.send_welcome_email = False
+		frappe.db.commit()
 
 	def tearDown(self) -> None:
 		self.user.delete()

--- a/frappe/search/sqlite_search.py
+++ b/frappe/search/sqlite_search.py
@@ -522,7 +522,6 @@ class SQLiteSearch(ABC):
                 ORDER BY bm25_score
                 LIMIT ?
             """
-			print(sql)
 			return self.sql(sql, params, read_only=True)
 
 	def _process_search_results(self, raw_results, query):

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -355,13 +355,7 @@ class TestEmailIntegrationTest(IntegrationTestCase):
 		subject = "checking if email works"
 		content = "is email working?"
 
-		email = frappe.sendmail(
-			sender=sender, recipients=recipients, subject=subject, content=content, now=True
-		)
-		email.reload()
-		self.assertEqual(email.sender, sender)
-		self.assertEqual(len(email.recipients), 2)
-		self.assertEqual(email.status, "Sent")
+		frappe.sendmail(sender=sender, recipients=recipients, subject=subject, content=content, now=True)
 
 		sent_mails = self.get_last_sent_emails()
 		self.assertEqual(len(sent_mails), 2)

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -132,6 +132,7 @@ class TestEmail(IntegrationTestCase):
 			expose_recipients="footer",
 			now=True,
 		)
+		frappe.db.commit()
 		email_queue = frappe.db.sql("""select name from `tabEmail Queue` where status='Sent'""", as_dict=1)
 		self.assertEqual(len(email_queue), 1)
 		queue_recipients = [
@@ -165,6 +166,7 @@ class TestEmail(IntegrationTestCase):
 			unsubscribe_message="Unsubscribe",
 			now=True,
 		)
+		frappe.db.commit()
 		email_queue = frappe.db.sql("""select name from `tabEmail Queue` where status='Sent'""", as_dict=1)
 		self.assertEqual(len(email_queue), 1)
 		queue_recipients = [
@@ -210,6 +212,7 @@ class TestEmail(IntegrationTestCase):
 					message="This mail is queued!",
 					now=True,
 				)
+				frappe.db.commit()
 				email_queue_sender = frappe.db.get_value("Email Queue", {"status": "Sent"}, "sender")
 				self.assertEqual(email_queue_sender, assertion)
 
@@ -355,7 +358,14 @@ class TestEmailIntegrationTest(IntegrationTestCase):
 		subject = "checking if email works"
 		content = "is email working?"
 
-		frappe.sendmail(sender=sender, recipients=recipients, subject=subject, content=content, now=True)
+		email = frappe.sendmail(
+			sender=sender, recipients=recipients, subject=subject, content=content, now=True
+		)
+		frappe.db.commit()
+		email.reload()
+		self.assertEqual(email.sender, sender)
+		self.assertEqual(len(email.recipients), 2)
+		self.assertEqual(email.status, "Sent")
 
 		sent_mails = self.get_last_sent_emails()
 		self.assertEqual(len(sent_mails), 2)
@@ -381,6 +391,7 @@ class TestEmailIntegrationTest(IntegrationTestCase):
 			send_email=True,
 			now=True,
 		).get("name")
+		frappe.db.commit()
 
 		communication = frappe.get_doc("Communication", name)
 


### PR DESCRIPTION
- fix(UX): Add description for password strength levels
- fix!: sendmail `now=True` after current transaction is committed


BREAKING CHANGE:
- Your tests will break if they were working assuming email queue commits something, framework had 20+ unrelated failures because of this change.
- If your code assumes email queue is sent synchronously then it will start failing. Emails are now sent after request/job completes. 