### PR TITLE
fix: export the `name` field in Python type annotations (#35315)

### DIFF
--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -685,6 +685,9 @@ class TestDocType(IntegrationTestCase):
 		self.assertIn(fieldname, new_field_code)
 		self.assertIn("Int", new_field_code)
 
+		# Verify that the "name" field is exported (fix for #35315)
+		self.assertIn("name: DF.Data", new_field_code)
+
 		doctype.delete()
 		frappe.db.commit()
 

--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -110,6 +110,8 @@ class TypeExporter:
 
 		if self.doc.autoname == "autoincrement":
 			self.field_types["name"] = "DF.Int | None"
+		else:
+			self.field_types["name"] = "DF.Data | None"
 
 		fields_code_block = self._create_fields_code_block()
 		imports = self._create_imports_block()


### PR DESCRIPTION
## Summary
- Fixed the `name` field not being exported in Python type annotations
- Previously, `name` was only exported for DocTypes with `autoname="autoincrement"`
- Now `name` is exported for all DocTypes as `DF.Data | None`

## Screenshot
<img width="1170" height="993" alt="Screenshot 2025-12-18 135119" src="https://github.com/user-attachments/assets/e3a04728-c49f-476a-b460-d5f053124533" />

## Test Plan
- [x] Added test assertion in `test_export_types`
- [x] Ran existing tests - all passing

Fixes #35315
