### PR TITLE
fix: parent table join for child tables of Single DocTypes

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1413,8 +1413,10 @@ class Engine:
 		if not self.apply_permissions:
 			return
 
-		# For child tables, join to parent table so permission conditions can reference it
-		if self.permission_doctype != self.doctype:
+		meta = frappe.get_meta(self.permission_doctype)
+
+		# For child tables, join to parent table so permission conditions can reference it (skip for Single doctypes)
+		if self.permission_doctype != self.doctype and not meta.issingle:
 			self.query = self.query.inner_join(self.permission_table).on(
 				self.table.parent == self.permission_table.name
 			)

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1406,17 +1406,22 @@ class Engine:
 
 		For child tables (when parent_doctype is specified):
 			- permissions are checked against the parent doctype
-			- a join to the parent table is added
-			- conditions reference the parent table's fields
+			- for non-single parent doctypes: a join to the parent table is added,
+		                conditions reference parent fields
+			- for single parent doctypes: all permissions are already checked by has_permission,
+		                we exit early without adding any conditions
 		"""
 
 		if not self.apply_permissions:
 			return
 
-		meta = frappe.get_meta(self.permission_doctype)
+		if self.permission_doctype != self.doctype:
+			parent_meta = frappe.get_meta(self.permission_doctype)
+			if parent_meta.issingle:
+				# Child table of single doctype
+				# permissions are already checked by has_permission
+				return
 
-		# For child tables, join to parent table so permission conditions can reference it (skip for Single doctypes)
-		if self.permission_doctype != self.doctype and not meta.issingle:
 			self.query = self.query.inner_join(self.permission_table).on(
 				self.table.parent == self.permission_table.name
 			)

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -130,6 +130,10 @@ def has_permission(
 
 	meta = frappe.get_meta(doctype)
 
+	# docname == doctype for single doctypes
+	if not doc and meta.issingle:
+		doc = meta.name
+
 	if doc:
 		if isinstance(doc, str | int):
 			# perf: Avoid loading child tables for perm checks
@@ -140,7 +144,9 @@ def has_permission(
 				"Permission check failed from role permission system. Check if user's role grant them permission to the document."
 			)
 			msg = _("User {0} does not have access to this document").format(frappe.bold(user))
-			if frappe.has_permission(doc.doctype):
+			if meta.issingle:
+				msg += f": {_(doc.doctype)}"
+			elif has_permission(doc.doctype):
 				msg += f": {_(doc.doctype)} - {doc.name}"
 			push_perm_check_log(msg, debug=debug)
 	else:


### PR DESCRIPTION
Fixes an invalid SQL join when querying child tables whose parent_doctype is a Single DocType.

**Problem**
While applying permission conditions, Frappe attempts to join the parent table for child table queries. This fails for Single DocTypes, which do not have physical tables, resulting in SQL errors. For example,

Error in query:
('SELECT `tabLogs To Clear`.`days` FROM `tabLogs To Clear` JOIN `tabLog Settings` ON `tabLogs To Clear`.`parent`=`tabLog Settings`.`name` WHERE `tabLogs To Clear`.`ref_doctype`=%(param1)s LIMIT 1', {'param1': 'Webhook Request Log'})

**Solution & Impact**
Skip the parent table join when the parent_doctype is a Single DocType, while preserving existing permission behavior for all other doctypes.

Prevents invalid joins and runtime SQL errors when permission checks involve child tables of Single DocTypes.