### PR TITLE
fix: child doc getting parent name as link format

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1544,10 +1544,6 @@ export default class GridRow {
 			txt = frappe.format(this.doc[fieldname], df, null, this.doc);
 		}
 
-		if (!txt && this.frm) {
-			txt = frappe.format(this.doc[fieldname], df, null, this.frm.doc);
-		}
-
 		// reset static value
 		let column = this.columns[fieldname];
 		if (column) {


### PR DESCRIPTION
Please check https://github.com/frappe/erpnext/issues/51193 as to why I made this PR I am too tired to explain this took me 3 hours to find AND my sanity

TLDR is the second if condition is assuming that `this.doc` is null and then passes `this.doc` inside the same condition 😭 
Atleast thats my assumption for that assumption. It may be wrong, lets hope cypress catches any error (if any)