### PR TITLE
feat: add option to export SQL output

### DIFF
--- a/frappe/desk/doctype/system_console/system_console.js
+++ b/frappe/desk/doctype/system_console/system_console.js
@@ -40,6 +40,29 @@ frappe.ui.form.on("System Console", {
 		frm.page.add_inner_message(
 			`${__("Tip: Try the new dropdown console using")} <kbd>⇧+T</kbd>`
 		);
+
+		if (
+			frm.doc.type == "SQL" &&
+			frm.doc.output &&
+			!frm.doc.output.startsWith("Traceback") &&
+			!frm.doc.output.includes("0 rows")
+		) {
+			frm.add_custom_button(__("Export Output"), () => {
+				let query = frm.doc.console;
+
+				if (!query) {
+					frappe.msgprint(__("Please set the query"));
+					return;
+				}
+
+				open_url_post(
+					"/api/method/frappe.desk.doctype.system_console.system_console.export_output",
+					{
+						query: query,
+					}
+				);
+			});
+		}
 	},
 
 	type: function (frm) {

--- a/frappe/desk/doctype/system_console/system_console.py
+++ b/frappe/desk/doctype/system_console/system_console.py
@@ -4,8 +4,11 @@
 import json
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
+from frappe.utils.data import now
 from frappe.utils.safe_exec import read_sql, safe_exec
+from frappe.utils.xlsxutils import make_xlsx
 
 
 class SystemConsole(Document):
@@ -60,6 +63,28 @@ def execute_code(doc):
 def show_processlist():
 	frappe.only_for("System Manager")
 	return _show_processlist()
+
+
+@frappe.whitelist()
+def export_output(query):
+	result = read_sql(query, as_dict=1)
+
+	if not result:
+		frappe.throw(_("No data to export"))
+
+	headers = list(result[0].keys())
+	rows = [headers]
+
+	for row in result:
+		rows.append([row.get(h) for h in headers])
+
+	xlsx_file = make_xlsx(rows, "System Console")
+
+	timestamp = now()[:19]  # remove milliseconds
+
+	frappe.response["filename"] = f"system_console_{timestamp}.xlsx"
+	frappe.response["filecontent"] = xlsx_file.getvalue()
+	frappe.response["type"] = "binary"
 
 
 def _show_processlist():


### PR DESCRIPTION
Added an Excel export option for SQL query results in the System Console.

Previously, users could view SQL output in the UI but had no way to download the results for offline analysis purposes. 

**Why this change is needed**
- Enables administrators to retain query results
- Improves usability for debugging and reporting



**Backport Needed: Version-15**