### PR TITLE
fix: prevent empty filter export in query report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -497,10 +497,9 @@ def build_xlsx_data(
 	include_hidden_columns = cint(include_hidden_columns)
 	include_indentation = cint(include_indentation)
 
-	if cint(include_filters):
+	if cint(include_filters) and data.filters:
 		filter_data = []
-		filters = data.filters
-		for filter_name, filter_value in filters.items():
+		for filter_name, filter_value in data.filters.items():
 			if not filter_value:
 				continue
 			filter_value = (


### PR DESCRIPTION
### Issue

1. Even when no filters are applied to the report, the **Include Filters** checkbox is still visible in the export dialog.

2. When no filters are available and **Include Filters** is checked during export, an empty row appears as the first row in the exported file.

### Before

#### Dialog

<img width="1352" height="424" alt="image" src="https://github.com/user-attachments/assets/800901f0-d384-4c46-a069-77d60c403856" />

####  Report

<img width="551" height="182" alt="image" src="https://github.com/user-attachments/assets/cdfec6a8-1f6b-4248-b0e4-751914528895" />


### After

#### Dialog

<img width="1322" height="475" alt="image" src="https://github.com/user-attachments/assets/4f1bf98c-6311-4f3f-85fd-fe696a746865" />


####  Report

<img width="456" height="163" alt="image" src="https://github.com/user-attachments/assets/ae70f39e-a407-47fc-b843-e80e31886ebf" />

---

> [!NOTE]
> Backport to V-15 