### PR TITLE
feat: set restore flag before insert

### DIFF
--- a/frappe/core/doctype/deleted_document/deleted_document.py
+++ b/frappe/core/doctype/deleted_document/deleted_document.py
@@ -45,7 +45,7 @@ def restore(name, alert=True):
 		frappe.throw(_("Document {0} Already Restored").format(name), exc=frappe.DocumentAlreadyRestored)
 
 	doc = frappe.get_doc(json.loads(deleted.data))
-
+	doc.flags.from_restore = True
 	try:
 		doc.insert()
 	except frappe.DocstatusTransitionError:


### PR DESCRIPTION
Issue:

When an invoice is created on older date and later deleted, restoring it on the current date throws a validation error.

Ref: [#55735](https://support.frappe.io/helpdesk/tickets/55735), 

Part of: [#51222](https://github.com/frappe/erpnext/pull/51222)

Deleted Document:

<img width="1792" height="1120" alt="image" src="https://github.com/user-attachments/assets/7aa84c1c-ec13-48c3-ab9b-a0fe0f9b6a56" />

