### PR TITLE
docs(permissions): document delete as valid permission type

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -593,7 +593,7 @@ def has_permission(
 	Raise `frappe.PermissionError` if user isn't permitted and `throw` is truthy
 
 	:param doctype: DocType for which permission is to be check.
-	:param ptype: Permission type (`read`, `write`, `create`, `submit`, `cancel`, `amend`). Default: `read`.
+	:param ptype: Permission type (`read`, `write`, `create`, `delete`, `submit`, `cancel`, `amend`). Default: `read`.
 	:param doc: [optional] Checks User permissions for given doc.
 	:param user: [optional] Check for given user. Default: current user.
 	:param parent_doctype: Required when checking permission for a child DocType (unless doc is specified).


### PR DESCRIPTION
The `frappe.has_permission` function docstring omitted `delete` even though it is a fully supported permission type across the framework.

This change updates the docstring to reflect actual behavior and align it with Role Permissions Manager and permission checks.

Use the following code for verification:
```py
import frappe

comment = frappe.get_doc(
    "Comment",
    frappe.db.get_value("Comment", {}, "name")
)

print({
    "read": frappe.has_permission("Comment", ptype="read", doc=comment),
    "write": frappe.has_permission("Comment", ptype="write", doc=comment),
    "create": frappe.has_permission("Comment", ptype="create", doc=comment),
    "delete": frappe.has_permission("Comment", ptype="delete", doc=comment),
})
```
Output:
```
{'read': True, 'write': True, 'create': True, 'delete': True}
```
The function did not throw an error when I passed `ptype="delete"` proving its existence.


closes #35365