### PR TITLE
fix: prevent sidebar email overflow

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -58,7 +58,7 @@
 								{{ frappe.session.user_email }}
 							</span>
 						</div>
-						
+
 					</button>
 					<div class="dropdown-menu dropdown-menu-left" id="toolbar-user" role="menu">
 						{% for item in navbar_settings.settings_dropdown %}

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -50,10 +50,15 @@
 						aria-label="{{ __("User Menu") }}"
 					>
 						<div> {{ avatar }} </div>
-						<div class="avatar-name-email ml-2 text-small">
-							<span>{{frappe.session.user_fullname}}</span>
-							<span class="text-secondary">{{frappe.session.user_email}}</span>
+						<div class="avatar-name-email ml-2 text-small overflow-hidden w-75">
+							<span class="d-block text-truncate">
+								{{ frappe.session.user_fullname }}
+							</span>
+							<span class="d-block text-secondary text-truncate">
+								{{ frappe.session.user_email }}
+							</span>
 						</div>
+						
 					</button>
 					<div class="dropdown-menu dropdown-menu-left" id="toolbar-user" role="menu">
 						{% for item in navbar_settings.settings_dropdown %}


### PR DESCRIPTION
**Branch to merge into:**
develop

**Description / Problem:**
In the user sidebar, when the logged-in user has a long email address, it overflows the container and breaks the layout. This affects the visual alignment of the user menu and makes it look messy on smaller screens.

**Solution / Changes Made:**

Updated the CSS for the sidebar user email to prevent overflow.

Added text-overflow: ellipsis; and white-space: nowrap; to ensure long emails truncate gracefully.

Ensured alignment with avatar and other sidebar elements remains intact.

**Testing Done:**

Checked in desktop and mobile views.

Verified that long email addresses no longer overflow.

No other UI elements are affected.

Before:

<img width="765" height="875" alt="Image" src="https://github.com/user-attachments/assets/4bae8f67-fa64-4f2f-914b-ca7190f689d8" />

After:

<img width="737" height="879" alt="image" src="https://github.com/user-attachments/assets/fedc6cdb-b0b9-4f94-ae71-5bf8b443dc49" />


Issue Id: Sidebar user email overflows at bottom for long email IDs #35359
