### PR TITLE
fix: only restrict script type reports for script manager

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -65,7 +65,7 @@ class Report(Document):
 
 		if self.is_standard == "No":
 			# allow only script manager to edit scripts
-			if self.report_type not in ["Report Builder", "Custom Report"]:
+			if self.report_type not in ("Report Builder", "Custom Report"):
 				frappe.only_for("Script Manager", True)
 
 			if frappe.db.get_value("Report", self.name, "is_standard") == "Yes":

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -65,7 +65,7 @@ class Report(Document):
 
 		if self.is_standard == "No":
 			# allow only script manager to edit scripts
-			if self.report_type != "Report Builder":
+			if self.report_type not in ["Report Builder", "Custom Report"]:
 				frappe.only_for("Script Manager", True)
 
 			if frappe.db.get_value("Report", self.name, "is_standard") == "Yes":


### PR DESCRIPTION
Earlier, if a user was given **Report Manager** role or **System Manager** role and then he tries to save it, this validation was triggered.

<img width="736" height="285" alt="Screenshot 2025-12-22 at 4 12 09 PM" src="https://github.com/user-attachments/assets/544153f3-0734-49e2-bdc6-2b3f04419871" />

But, since a new report is of type **Custom Report** this validation should not be triggered.


Support: https://support.frappe.io/helpdesk/tickets/53829