### PR TITLE
fix: include all fields of a doctype in doctype field map

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1935,12 +1935,15 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 								fieldtype: df.fieldtype,
 								label: df.label,
 								insert_after_index: insert_after_index,
-								link_field: this.doctype_field_map[values.doctype],
+								link_field: {
+									fieldname: values.fieldname,
+									names: this.doctype_field_map[values.doctype][values.fieldname]
+										.names,
+								},
 								doctype: values.doctype,
 								options: df.options,
 								width: 100,
 							});
-
 							this.custom_columns = this.custom_columns.concat(custom_columns);
 							frappe.call({
 								method: "frappe.desk.query_report.get_data_for_custom_field",
@@ -1948,7 +1951,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 									field: values.field,
 									doctype: values.doctype,
 									names: Array.from(
-										this.doctype_field_map[values.doctype].names
+										this.doctype_field_map[values.doctype][values.fieldname]
+											.names
 									),
 								},
 								callback: (r) => {
@@ -2094,12 +2098,15 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		);
 
 		doctypes.forEach((doc) => {
-			this.doctype_field_map[doc.doctype] = { fieldname: doc.fieldname, names: new Set() };
+			if (!this.doctype_field_map[doc.doctype]) {
+				this.doctype_field_map[doc.doctype] = {};
+			}
+			this.doctype_field_map[doc.doctype][doc.fieldname] = {};
+			this.doctype_field_map[doc.doctype][doc.fieldname] = { names: new Set() };
 		});
-
 		this.data.forEach((row) => {
 			doctypes.forEach((doc) => {
-				this.doctype_field_map[doc.doctype].names.add(row[doc.fieldname]);
+				this.doctype_field_map[doc.doctype][doc.fieldname].names.add(row[doc.fieldname]);
 			});
 		});
 


### PR DESCRIPTION
This resolves an issue in exporting of query report. 

Added a custom column in General Report  From doctype Journal Entry and field voucher_no. When exporting it used to reference other field against_voucher as the map stored only stored the latest key. 


https://github.com/user-attachments/assets/3296ab88-e27d-46b0-96d9-07d522fe8daa

Export Before
<img width="1435" height="700" alt="Screenshot 2025-12-23 at 11 30 45 AM" src="https://github.com/user-attachments/assets/b18f6967-d594-4927-8ea1-fd55e444d962" />

Export After
<img width="1431" height="701" alt="Screenshot 2025-12-23 at 11 30 29 AM" src="https://github.com/user-attachments/assets/4878ad4a-1116-4e99-b3d4-68fdc27e7a42" />



Ref ticket: https://support.frappe.io/helpdesk/tickets/51210
