### PR TITLE
fix: don't stop AJAX calls even if "offline"

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -38,8 +38,6 @@ frappe.call = function (opts) {
 			},
 			3
 		);
-		opts.always && opts.always();
-		return $.ajax();
 	}
 	if (typeof arguments[0] === "string") {
 		opts = {


### PR DESCRIPTION
> In general, connection to LAN is considered online, even though the LAN may not have Internet access. For example, the computer may be running a virtualization software that has virtual ethernet adapters that are always "connected". On Windows, the online status is determined by whether it can reach a Microsoft home server, which may be blocked by firewalls or VPNs, even if the computer has Internet access. Therefore, this property is inherently unreliable, and you should not disable features based on the online status, only provide hints when the user may seem offline.




ref: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine
ref: https://support.frappe.io/helpdesk/tickets/55436?view=VIEW-HD+Ticket-610