### PR TITLE
fix: translate all sidebar items

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -537,6 +537,7 @@ def get_sentry_dsn():
 
 
 def get_sidebar_items():
+	from frappe import _
 	from frappe.desk.doctype.workspace_sidebar.workspace_sidebar import auto_generate_sidebar_from_module
 
 	sidebars = frappe.get_all("Workspace Sidebar", fields=["name", "header_icon"])
@@ -560,7 +561,7 @@ def get_sidebar_items():
 		}
 		for si in w.items:
 			workspace_sidebar = {
-				"label": si.label,
+				"label": _(si.label),
 				"link_to": si.link_to,
 				"link_type": si.link_type,
 				"type": si.type,

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -222,7 +222,6 @@ frappe.ui.Sidebar = class Sidebar {
 		if (items && items.length > 0) {
 			items.forEach((w) => {
 				if (!w.display_depends_on || frappe.utils.eval(w.display_depends_on)) {
-					w.label = __(w.label);
 					this.add_item(this.$items_container, w);
 				}
 			});


### PR DESCRIPTION
<img width="1440" height="900" alt="Screenshot 2025-12-23 at 11 43 18 AM" src="https://github.com/user-attachments/assets/ae6064a5-3280-4adb-9044-e917931c9437" />

Closes https://github.com/frappe/frappe/issues/35192