### PR TITLE
feat: toggle HTML editor in send email dialog

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -1017,8 +1017,8 @@ frappe.views.CommunicationComposer = class {
 	on_use_html_toggle() {
 		const use_html = this.dialog.get_value("use_html");
 
-		this.dialog.set_df_property("content", "hidden", use_html ? 1 : 0);
-		this.dialog.set_df_property("content_html", "hidden", !use_html ? 1 : 0);
+		this.dialog.set_df_property("content", "hidden", use_html);
+		this.dialog.set_df_property("content_html", "hidden", !use_html);
 
 		this.dialog.set_value("email_template", "");
 	}

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -894,10 +894,9 @@ frappe.views.CommunicationComposer = class {
 		let message = this.message || "";
 		if (!message && this.frm) {
 			const { doctype, docname } = this.frm;
-
+			message = (await localforage.getItem(doctype + docname)) || "";
 			const use_html = (await localforage.getItem(doctype + docname + "_use_html")) || 0;
-			this.dialog.set_value("use_html", use_html);
-			this.on_use_html_toggle();
+			await this.dialog.set_value("use_html", use_html);
 		}
 
 		if (message) {


### PR DESCRIPTION
We have two types of Email templates
1. HTML
2. Text Editor

they are distinguished by **use_html** check in the Email Template DocType.

Now, when we send an email and try to use HTML based email template, it is imported in the **Text Editor** in the send email dialog which breaks the HTML structure.

To fix this I have added a **use_html** check in the dialog which toggles between **Text Editor** input and **HTML Editor** input.

This PR also makes the following changes:
When Use HTML is checked
1. Only fetch email templates where use_html is checked
2. Convert Text Editor input to HTML Editor


## Before

https://github.com/user-attachments/assets/2ad98db6-f3fc-4420-a769-5dd46480fd99


### Email

<img width="2048" height="2732" alt="mail google com_mail_u_0_(iPad Pro)" src="https://github.com/user-attachments/assets/d1a0c83a-a648-4987-9e1b-d0e4a520c50a" />
<img width="4096" height="5464" alt="mail google com_mail_u_0_(iPad Pro) (1)" src="https://github.com/user-attachments/assets/c062c10b-ea07-46ce-8bb3-3051a627728f" />

## After

https://github.com/user-attachments/assets/adc944cf-bba2-4249-9fda-bd3110dd936a

## Email
<img width="2048" height="2732" alt="mail google com_mail_u_0_(iPad Pro) (2)" src="https://github.com/user-attachments/assets/2c3b5a10-2708-4e0d-a9f6-19cdf2b442a1" />
<img width="2048" height="2732" alt="mail google com_mail_u_0_(iPad Pro) (3)" src="https://github.com/user-attachments/assets/8e44534d-9cd7-463a-a5df-950215aeefc6" />


Support: https://support.frappe.io/helpdesk/tickets/55645

>no-docs