### PR TITLE
fix(mobile): bring back the menu icon on list view

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -105,6 +105,7 @@ frappe.ui.toolbar.Toolbar = class {
 	add_back_button() {
 		if (!frappe.is_mobile()) return;
 		this.navbar = $(".navbar-brand");
+		this.menu = this.navbar.html();
 		let doctype = frappe.get_route()[1];
 		let list_view_route = `/desk/${frappe.router.convert_from_standard_route([
 			"list",
@@ -118,6 +119,8 @@ frappe.ui.toolbar.Toolbar = class {
 		let route = frappe.get_route();
 		if (route[0] == "Form") {
 			this.add_back_button();
+		} else {
+			this.navbar.html(this.menu);
 		}
 	}
 };

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -4,7 +4,7 @@
 	border-bottom: 1px solid var(--border-color);
 	padding: 0;
 	.navbar-brand {
-		margin-right: 15px;
+		margin-right: 0px;
 	}
 
 	@include media-breakpoint-up(md) {

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -184,6 +184,7 @@
 			padding: 0px;
 			width: 0px;
 			overflow: hidden;
+			transition-property: none;
 			.standard-items-sections {
 				.dropdown-notifications {
 					.notifications-list {


### PR DESCRIPTION
When navigating the from form view to list view on mobile the back button was staying on list view due to implicit assumption in previous toolbar. This PR fixes that 

https://github.com/user-attachments/assets/c1bb5c70-6baf-49f5-9ba8-da0040e46fe4




