### PR TITLE
feat: Add mask checkbox in customize doctype property

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -807,6 +807,7 @@ docfield_properties = {
 	"link_filters": "JSON",
 	"placeholder": "Data",
 	"button_color": "Select",
+	"mask": "Check",
 }
 
 doctype_link_properties = {

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -24,6 +24,7 @@
   "no_copy",
   "allow_in_quick_entry",
   "translatable",
+  "mask",
   "link_filters",
   "column_break_7",
   "default",
@@ -494,6 +495,13 @@
    "fieldtype": "Select",
    "label": "Button Color",
    "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:[\"Select\", \"Read Only\", \"Phone\", \"Percent\", \"Password\", \"Link\", \"Int\", \"Float\", \"Dynamic Link\", \"Duration\", \"Datetime\", \"Currency\", \"Data\", \"Date\"].includes(doc.fieldtype)",
+   "fieldname": "mask",
+   "fieldtype": "Check",
+   "label": "Mask"
   }
  ],
  "grid_page_length": 50,
@@ -501,7 +509,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-11-12 01:13:53.053888",
+ "modified": "2025-12-23 23:04:19.800253",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.py
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.py
@@ -90,6 +90,7 @@ class CustomizeFormField(Document):
 		length: DF.Int
 		link_filters: DF.JSON | None
 		mandatory_depends_on: DF.Code | None
+		mask: DF.Check
 		no_copy: DF.Check
 		non_negative: DF.Check
 		options: DF.SmallText | None


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/35013

> Please provide enough information so that others can review your pull request:
- Add the Check Box of the mask in the customize doctype

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?
- Field mask feature was not available in the customize docytpe

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs
<img width="1625" height="815" alt="image" src="https://github.com/user-attachments/assets/3721c837-f171-4f11-91ad-87cdf138f255" />

<!-- Add images/recordings to better visualize the change: expected/current behavior -->


`no-docs`