### PR TITLE
fix(model): Postgres-compatible rename_field user settings lookup

### DIFF
--- a/frappe/model/utils/rename_field.py
+++ b/frappe/model/utils/rename_field.py
@@ -166,9 +166,9 @@ def update_user_settings(doctype, old_fieldname, new_fieldname):
 	sync_user_settings()
 
 	user_settings = frappe.db.sql(
-		''' select user, doctype, data from `__UserSettings`
-		where doctype=%s and data like "%%%s%%"''',
-		(doctype, old_fieldname),
+		""" select user, doctype, data from `__UserSettings`
+		where doctype=%s and data like %s""",
+		(doctype, f"%{old_fieldname}%"),
 		as_dict=1,
 	)
 


### PR DESCRIPTION
## Issue
Installing the HRMS app on a Postgres-backed site fails during the post-install patch that renames `stop_birthday_reminders` to `send_birthday_reminders`. The failure originates in Frappe’s `rename_field` helper when it scans user settings.

Relevant reference:
- PR link: https://github.com/frappe/hrms/pull/3890

Error observed (Postgres):
- `UndefinedColumn: column "%'stop_birthday_reminders'%" does not exist`

## Root cause
The query in `frappe.model.utils.rename_field.update_user_settings` used a
double-quoted LIKE pattern:

```
... where doctype=%s and data like "%%%s%%"
```

In Postgres, double quotes denote identifiers, so the pattern is interpreted as
a column name rather than a string literal.

### Logs

```
An error occurred while installing hrms: column "%'stop_birthday_reminders'%" does not exist
LINE 2:   where doctype='HR Settings' and data like "%'stop_birthday...
                                                    ^

Traceback with variables (most recent call last):
  File "apps/frappe/frappe/commands/site.py", line 486, in install_app
    _install_app(app, verbose=context.verbose, force=force)
      context = {'sites': ['realtimex.localhost'], 'force': False, 'verbose': False, 'profile': False}
      apps = ('hrms',)
      force = True
      _install_app = <function install_app at 0x10c4d1300>
      filelock = <function filelock at 0x10ba96660>
      exit_code = 0
      site = 'realtimex.localhost'
      app = 'hrms'
      err = UndefinedColumn('column "%\'stop_birthday_reminders\'%" does not exist\nLINE 2:   where doctype=\'HR Settings\' and data like "%\'stop_birthday...\n                                                    ^\n')
  File "apps/frappe/frappe/installer.py", line 326, in install_app
    frappe.get_attr(after_install)()
      name = 'hrms'
      verbose = False
      set_as_patched = True
      force = True
      sync_jobs = <function sync_jobs at 0x10d1a9c60>
      sync_for = <function sync_for at 0x10d1aaac0>
      sync_customizations = <function sync_customizations at 0x10bad6980>
      sync_fixtures = <function sync_fixtures at 0x10d1aae80>
      app_hooks = {'accounting_dimension_doctypes': ['Expense Claim', 'Expense Claim Detail', 'Expense Taxes and Charges', 'Payroll Entry', 'Leave Encashment'], 'add_to_apps_screen': [{'name': 'hrms', 'logo': '/assets/hrms/images/frappe-hr-logo.svg', 'title': 'Frappe HR', 'route': '/app/hr', 'has_permission': 'hrms.hr.utils.check_app_permission'}], 'advance_payment_doctypes': ['Leave Encashment', 'Gratuity', 'Employee Advance'], 'after_app_install': ['hrms.setup.after_app_install'], 'after_install': ['hrms.install.after_install'], 'after_migrate': ['hrms.setup.update_select_perm_after_install'], 'app_description': ['Modern HR and Payroll Software'], 'app_email': ['contact@frappe.io'], 'app_include_css': ['hrms.bundle.css'], 'app_include_js': ['hrms.bundle.js'], 'app_license': ['GNU General Public License (v3)'], 'app_name': ['hrms'], 'app_publisher': ['Frappe Technologies Pvt. Ltd.'], 'app_title': ['Frappe HR'], 'bank_reconciliation_doctypes': ['Expense Claim'], 'before_app_uninstall': ['hrms.setup.befo...
      installed_apps = ['frappe', 'erpnext', 'hrms']
      app = 'frappe/erpnext'
      required_app = 'erpnext'
      after_install = 'hrms.install.after_install'
  File "apps/hrms/hrms/install.py", line 21, in after_install
    raise e
      BUG_REPORT_URL = 'https://github.com/frappe/hrms/issues/new'
  File "apps/hrms/hrms/install.py", line 9, in after_install
    setup()
      BUG_REPORT_URL = 'https://github.com/frappe/hrms/issues/new'
  File "apps/hrms/hrms/setup.py", line 23, in after_install
    run_post_install_patches()
  File "apps/hrms/hrms/setup.py", line 568, in run_post_install_patches
    frappe.get_attr(f"hrms.patches.post_install.{patch_name}.execute")()
      POST_INSTALL_PATCHES = ('erpnext.patches.v13_0.move_tax_slabs_from_payroll_period_to_income_tax_slab', 'erpnext.patches.v13_0.move_doctype_reports_and_notification_from_hr_to_payroll', 'erpnext.patches.v13_0.move_payroll_setting_separately_from_hr_settings', 'erpnext.patches.v13_0.update_start_end_date_for_old_shift_assignment', 'erpnext.patches.v13_0.updates_for_multi_currency_payroll', 'erpnext.patches.v13_0.update_reason_for_resignation_in_employee', 'erpnext.patches.v13_0.set_company_in_leave_ledger_entry', 'erpnext.patches.v13_0.rename_stop_to_send_birthday_reminders', 'erpnext.patches.v13_0.set_training_event_attendance', 'erpnext.patches.v14_0.set_payroll_cost_centers', 'erpnext.patches.v13_0.update_employee_advance_status', 'erpnext.patches.v13_0.update_expense_claim_status_for_paid_advances', 'erpnext.patches.v14_0.delete_employee_transfer_property_doctype', 'erpnext.patches.v13_0.set_payroll_entry_status', 'create_country_fixtures', 'update_allocate_on_in_leave_type', 'update_performance_module_cha...
      patch = 'erpnext.patches.v13_0.rename_stop_to_send_birthday_reminders'
      patch_name = 'rename_stop_to_send_birthday_reminders'
  File "apps/hrms/hrms/patches/post_install/rename_stop_to_send_birthday_reminders.py", line 10, in execute
    rename_field("HR Settings", "stop_birthday_reminders", "send_birthday_reminders")
  File "apps/frappe/frappe/model/utils/rename_field.py", line 56, in rename_field
    update_user_settings(doctype, old_fieldname, new_fieldname)
      doctype = 'HR Settings'
      old_fieldname = 'stop_birthday_reminders'
      new_fieldname = 'send_birthday_reminders'
      validate = True
      meta = <Meta: HR Settings>
      new_field = <CheckDocField: send_birthday_reminders parent=HR Settings>
  File "apps/frappe/frappe/model/utils/rename_field.py", line 168, in update_user_settings
    user_settings = frappe.db.sql(
      doctype = 'HR Settings'
      old_fieldname = 'stop_birthday_reminders'
      new_fieldname = 'send_birthday_reminders'
  File "apps/frappe/frappe/database/postgres/database.py", line 220, in sql
    return super().sql(modify_query(query), modify_values(values), *args, **kwargs)
      self = <frappe.database.postgres.database.PostgresDatabase object at 0x10c5f84d0>
      query = ' select user, doctype, data from `__UserSettings`\n\t\twhere doctype=%s and data like "%%%s%%"'
      values = ('HR Settings', 'stop_birthday_reminders')
      args = ()
      kwargs = {'as_dict': 1}
      __class__ = <class 'frappe.database.postgres.database.PostgresDatabase'>
  File "apps/frappe/frappe/database/database.py", line 230, in sql
    self._cursor.execute(query, values)
      self = <frappe.database.postgres.database.PostgresDatabase object at 0x10c5f84d0>
      query = 'select user, doctype, data from "__UserSettings"\n\t\twhere doctype=%s and data like "%%%s%%"'
      values = ['HR Settings', 'stop_birthday_reminders']
      as_dict = 1
      as_list = 0
      debug = False
      ignore_ddl = 0
      auto_commit = 0
      update = None
      explain = False
      run = True
      pluck = False
      as_iterator = False
      trace_id = None
psycopg2.errors.UndefinedColumn: column "%'stop_birthday_reminders'%" does not exist
LINE 2:   where doctype='HR Settings' and data like "%'stop_birthday...
```

## Fix
Parameterize the LIKE pattern and pass the wildcarded value as a parameter:

```
... where doctype=%s and data like %s
values = (doctype, f"%{old_fieldname}%")
```

## Behavior impact
No intended behavior change for MySQL or Postgres. The query semantics remain
the same, but the pattern is now a proper string literal on Postgres.

## Validation
- HRMS install completes on Postgres after this change.
- No change in expected behavior on MySQL (query remains equivalent).