### PR TITLE
fix(assignment_rule): add a default option in due date based on

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.js
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.js
@@ -67,8 +67,11 @@ frappe.ui.form.on("Assignment Rule", {
 			[{ label: "Owner", value: "owner" }]
 		);
 		if (doctype) {
-			frm.set_fields_as_options("due_date_based_on", doctype, (df) =>
-				["Date", "Datetime"].includes(df.fieldtype)
+			frm.set_fields_as_options(
+				"due_date_based_on",
+				doctype,
+				(df) => ["Date", "Datetime"].includes(df.fieldtype),
+				[{ value: " ", label: " " }]
 			).then((options) =>
 				frm.set_df_property("due_date_based_on", "hidden", !options.length)
 			);


### PR DESCRIPTION
This PR adds a default empty option in the select field on assignment rule form
<img width="468" height="238" alt="Screenshot 2025-12-24 at 11 40 37 AM" src="https://github.com/user-attachments/assets/ddcf950c-2b74-4d7e-a5ce-e1c528a11885" />


Ref ticket https://support.frappe.io/helpdesk/tickets/56012