### PR TITLE
fix: Add boolean label for check type filters in export report 

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1626,7 +1626,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				let display_value = value;
 
 				if (docfield.fieldtype === "Check") {
-					display_value = this.boolean_labels[value];
+					display_value = this.boolean_labels[cint(value)];
 				} else {
 					display_value = frappe.format(value, docfield);
 				}
@@ -1748,7 +1748,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			const df = frappe.query_report.get_filter(key).df;
 			if (!df.hidden_due_to_dependency) {
 				applied_filters[df.label] =
-					df.fieldtype === "Check" ? this.boolean_labels[value] : value;
+					df.fieldtype === "Check" ? this.boolean_labels[cint(value)] : value;
 			}
 		}
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1649,13 +1649,15 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		}
 
 		if (this.report_settings.export_hidden_cols) {
-			const hidden_fields = [];
+			const hidden_fields = new Set();
+
 			this.columns.forEach((column) => {
 				if (column.hidden) {
-					hidden_fields.push(column.label);
+					hidden_fields.add(column.label);
 				}
 			});
-			if (hidden_fields.length) {
+
+			if (hidden_fields.size) {
 				extra_fields.push(
 					{
 						fieldname: "column_break_1",
@@ -1664,13 +1666,14 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					{
 						label: __("Include hidden columns"),
 						fieldname: "include_hidden_columns",
-						description: __("Hidden columns include: {0}", [hidden_fields.join(", ")]),
 						fieldtype: "Check",
+						description: __("Hidden columns include: <br> {0}", [
+							frappe.utils.comma_and(Array.from(hidden_fields)),
+						]),
 					}
 				);
 			}
 		}
-
 		this.export_dialog = frappe.report_utils.get_export_dialog(
 			__(this.report_name),
 			extra_fields,


### PR DESCRIPTION
- Closes: https://github.com/frappe/frappe/issues/35384

## 1. Duplicate labels

#### Before

<img width="773" height="488" alt="image" src="https://github.com/user-attachments/assets/4e33d27e-31dc-4582-b1e1-1745d7cbb2ca" />

#### After

<img width="718" height="419" alt="image" src="https://github.com/user-attachments/assets/3d20cad7-c13e-43c0-a91a-e9f857d1c5c8" />


## 2. Check filters value

#### Before

<img width="1202" height="407" alt="image" src="https://github.com/user-attachments/assets/c0042272-5040-4902-81a3-cc4e657e3a34" />


#### After

<img width="1191" height="397" alt="image" src="https://github.com/user-attachments/assets/01cd7a28-4338-411e-a2c5-d6b1a5a0d808" />

