### PR TITLE
fix: sort fields to move checkboxes to the end in filter area

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -1219,6 +1219,17 @@ class FilterArea {
 				})
 		);
 
+		// sort fields to move checkboxes at the end
+		fields.sort((a, b) => {
+			if (a.fieldtype === "Check" && b.fieldtype !== "Check") {
+				return 1;
+			} else if (a.fieldtype !== "Check" && b.fieldtype === "Check") {
+				return -1;
+			} else {
+				return 0;
+			}
+		});
+
 		fields.map((df) => {
 			this.list_view.page.add_field(df, this.standard_filters_wrapper);
 


### PR DESCRIPTION
### Before:

<img width="2932" height="704" alt="CleanShot 2025-12-24 at 15 21 19@2x" src="https://github.com/user-attachments/assets/8eacb7fe-d535-4268-af14-14df0cb57c29" />

### After:

<img width="2934" height="750" alt="CleanShot 2025-12-24 at 15 22 06@2x" src="https://github.com/user-attachments/assets/8c397758-f5d0-4ec0-8a6e-391e54645036" />
