### PR TITLE
fix: depends_on condition for tab break field

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -629,7 +629,7 @@
    "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
   },
   {
-   "depends_on": "eval: doc.type == \"Tab Break\"",
+   "depends_on": "eval: doc.fieldtype == \"Tab Break\"",
    "fieldname": "icon",
    "fieldtype": "Icon",
    "label": "Icon"


### PR DESCRIPTION
Currently, icon field is not shown on form builder for tab break, because `depends_on` is not well defined. 
At least, now we can write the icon name.

Will manage proper icon selector for form builder on different PR
