### PR TITLE
fix(Sidebar): fix sidebar user email truncation overflow

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -77,6 +77,13 @@
 		width: 100%;
 	}
 
+	.dropdown-navbar-user {
+		.nav-link {
+			min-width: 0;
+			max-width: 100%;
+		}
+	}
+
 	.divider {
 		margin: var(--margin-xs) 0;
 		border-top: 1px solid var(--gray-300);


### PR DESCRIPTION
Resolves #35456 
<img width="2535" height="1250" alt="image" src="https://github.com/user-attachments/assets/06ac287d-df62-4163-bcc3-0e4b45a65c90" />