### PR TITLE
fix(Doctype): prevent DocType fieldnames from using Python keywords

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 import datetime
 import json
+import keyword
 import weakref
 from types import MappingProxyType
 from typing import TYPE_CHECKING, TypeVar
@@ -1563,5 +1564,6 @@ RESERVED_KEYWORDS = frozenset(
 		"_doc_before_save",
 		"dont_update_if_missing",
 		*CACHED_PROPERTIES,
+		*keyword.kwlist,
 	)
 )


### PR DESCRIPTION
Resolves #35313 

Add Python keywords to RESERVED_KEYWORDS so DocType fieldnames cannot use them, preventing controller syntax errors.