### PR TITLE
fix: handle translations in MultiSelect filters

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect.js
+++ b/frappe/public/js/frappe/form/controls/multiselect.js
@@ -35,16 +35,6 @@ frappe.ui.form.ControlMultiSelect = class ControlMultiSelect extends (
 		});
 	}
 
-	parse_options() {
-		let options = this.df.options;
-		if (typeof options === "string") {
-			options = options.split("\n").map((option) => {
-				return { label: __(option), value: option };
-			});
-		}
-		return options;
-	}
-
 	get_value() {
 		let data = super.get_value();
 		let options = this.parse_options();
@@ -80,6 +70,16 @@ frappe.ui.form.ControlMultiSelect = class ControlMultiSelect extends (
 				.join(", ");
 		}
 		super.set_formatted_input(value);
+	}
+
+	parse_options() {
+		let options = this.df.options;
+		if (typeof options === "string") {
+			options = options.split("\n").map((option) => {
+				return { label: __(option), value: option };
+			});
+		}
+		return options;
 	}
 
 	get_values() {

--- a/frappe/public/js/frappe/form/controls/multiselect.js
+++ b/frappe/public/js/frappe/form/controls/multiselect.js
@@ -50,7 +50,7 @@ frappe.ui.form.ControlMultiSelect = class ControlMultiSelect extends (
 		let options = this.parse_options();
 
 		// find value of label from option list and return actual value string
-		if (options && options.length && options[0].label != null) {
+		if (options && options.length && options[0].label != undefined) {
 			data = data.split(",").map((op) => op.trim());
 			data = data
 				.map((val) => {
@@ -68,7 +68,7 @@ frappe.ui.form.ControlMultiSelect = class ControlMultiSelect extends (
 		let options = this.parse_options();
 
 		// find label of value from option list and set from it as input
-		if (options && options.length && options[0].label != null) {
+		if (options && options.length && options[0].label != undefined) {
 			value = value
 				.split(",")
 				.map((d) => d.trim())

--- a/frappe/public/js/frappe/form/controls/multiselect.js
+++ b/frappe/public/js/frappe/form/controls/multiselect.js
@@ -37,12 +37,20 @@ frappe.ui.form.ControlMultiSelect = class ControlMultiSelect extends (
 
 	get_value() {
 		let data = super.get_value();
+
+		let options = this.df.options;
+		if (typeof options === "string") {
+			options = options.split("\n").map((option) => {
+				return { label: __(option), value: option };
+			});
+		}
+
 		// find value of label from option list and return actual value string
-		if (this.df.options && this.df.options.length && this.df.options[0].label) {
+		if (options && options.length && options[1].label) {
 			data = data.split(",").map((op) => op.trim());
 			data = data
 				.map((val) => {
-					let option = this.df.options.find((op) => op.label === val);
+					let option = options.find((op) => op.label === val);
 					return option ? option.value : null;
 				})
 				.filter((n) => n != null)
@@ -53,13 +61,21 @@ frappe.ui.form.ControlMultiSelect = class ControlMultiSelect extends (
 
 	set_formatted_input(value) {
 		if (!value) return;
+
+		let options = this.df.options;
+		if (typeof options === "string") {
+			options = options.split("\n").map((option) => {
+				return { label: __(option), value: option };
+			});
+		}
+
 		// find label of value from option list and set from it as input
-		if (this.df.options && this.df.options.length && this.df.options[0].label) {
+		if (options && options.length && options[1].label) {
 			value = value
 				.split(",")
 				.map((d) => d.trim())
 				.map((val) => {
-					let option = this.df.options.find((op) => op.value === val);
+					let option = options.find((op) => op.value === val);
 					return option ? option.label : val;
 				})
 				.filter((n) => n != null)

--- a/frappe/public/js/frappe/form/controls/multiselect.js
+++ b/frappe/public/js/frappe/form/controls/multiselect.js
@@ -37,7 +37,7 @@ frappe.ui.form.ControlMultiSelect = class ControlMultiSelect extends (
 
 	get_value() {
 		let data = super.get_value();
-		let options = this.parse_options();
+		let options = this.get_parsed_options();
 
 		// find value of label from option list and return actual value string
 		if (options && options.length && options[0].label != undefined) {
@@ -55,7 +55,7 @@ frappe.ui.form.ControlMultiSelect = class ControlMultiSelect extends (
 
 	set_formatted_input(value) {
 		if (!value) return;
-		let options = this.parse_options();
+		let options = this.get_parsed_options();
 
 		// find label of value from option list and set from it as input
 		if (options && options.length && options[0].label != undefined) {
@@ -72,7 +72,7 @@ frappe.ui.form.ControlMultiSelect = class ControlMultiSelect extends (
 		super.set_formatted_input(value);
 	}
 
-	parse_options() {
+	get_parsed_options() {
 		let options = this.df.options;
 		if (typeof options === "string") {
 			options = options.split("\n").map((option) => {

--- a/frappe/public/js/frappe/form/controls/multiselect.js
+++ b/frappe/public/js/frappe/form/controls/multiselect.js
@@ -35,18 +35,22 @@ frappe.ui.form.ControlMultiSelect = class ControlMultiSelect extends (
 		});
 	}
 
-	get_value() {
-		let data = super.get_value();
-
+	parse_options() {
 		let options = this.df.options;
 		if (typeof options === "string") {
 			options = options.split("\n").map((option) => {
 				return { label: __(option), value: option };
 			});
 		}
+		return options;
+	}
+
+	get_value() {
+		let data = super.get_value();
+		let options = this.parse_options();
 
 		// find value of label from option list and return actual value string
-		if (options && options.length && options[1].label) {
+		if (options && options.length && options[0].label != null) {
 			data = data.split(",").map((op) => op.trim());
 			data = data
 				.map((val) => {
@@ -61,16 +65,10 @@ frappe.ui.form.ControlMultiSelect = class ControlMultiSelect extends (
 
 	set_formatted_input(value) {
 		if (!value) return;
-
-		let options = this.df.options;
-		if (typeof options === "string") {
-			options = options.split("\n").map((option) => {
-				return { label: __(option), value: option };
-			});
-		}
+		let options = this.parse_options();
 
 		// find label of value from option list and set from it as input
-		if (options && options.length && options[1].label) {
+		if (options && options.length && options[0].label != null) {
 			value = value
 				.split(",")
 				.map((d) => d.trim())


### PR DESCRIPTION

### Problem:
1. Translation Failure: MultiSelect controls (used in "In" filters) did not support translated options. They displayed raw database values (e.g., "Draft") instead of labels (e.g., "Entwurf") because df.options remained a raw string.
2. Filter Vanishing on Refresh: When refreshing a page with an "In" filter active.

### Solution
In File : `frappe/public/js/frappe/form/controls/multiselect.js`
1. `get_value`: Added logic to parse string options into objects, enabling the label-to-value translation when filtering.

2. `set_formatted_input`: Added logic to parse raw string options into {label, value} objects immediately, ensuring the value-to-label translation works on page load.

### Screenshots

- Issue
<img width="1102" height="553" alt="1" src="https://github.com/user-attachments/assets/bdb9e5ce-9a00-4210-b6ce-54c58b06635f" />

- Fixed
<img width="2430" height="942" alt="2" src="https://github.com/user-attachments/assets/da0959d4-3b33-4d3d-95ba-8de2d0a3d924" />

closes #35385
