### PR TITLE
fix: add space between search shortcut on sidebar

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -248,7 +248,7 @@ frappe.ui.Sidebar = class Sidebar {
 				type: "Button",
 				id: "navbar-modal-search",
 				suffix: {
-					keyboard_shortcut: "CtrlK",
+					keyboard_shortcut: "Ctrl+K",
 				},
 				class: "navbar-search-bar hidden",
 			});

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -248,7 +248,7 @@ frappe.ui.Sidebar = class Sidebar {
 				type: "Button",
 				id: "navbar-modal-search",
 				suffix: {
-					keyboard_shortcut: "Ctrl+K",
+					keyboard_shortcut: "Ctrl K",
 				},
 				class: "navbar-search-bar hidden",
 			});

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -248,7 +248,7 @@ frappe.ui.Sidebar = class Sidebar {
 				type: "Button",
 				id: "navbar-modal-search",
 				suffix: {
-					keyboard_shortcut: "Ctrl K",
+					keyboard_shortcut: "Ctrl+K",
 				},
 				class: "navbar-search-bar hidden",
 			});

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -84,7 +84,7 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 	}
 	get_shortcut_html(shortcut) {
 		if (frappe.utils.is_mac()) {
-			shortcut = shortcut.replace("Ctrl", "⌘");
+			shortcut = shortcut.replace("Ctrl+", "⌘");
 		}
 		return `<span class="sidebar-item-suffix keyboard-shortcut">${shortcut}</span>`;
 	}


### PR DESCRIPTION
**Closes:** [Comment](https://github.com/frappe/frappe/issues/35337#:~:text=CtrlK%20should%20have%20space%20in%20between%20(try%20on%20linux/windows))


----

**Before:**
<img width="365" height="380" alt="image" src="https://github.com/user-attachments/assets/10e075a2-49c6-4be8-ba40-2019d97fe4a6" />

**After:**
<img width="215" height="143" alt="image" src="https://github.com/user-attachments/assets/4fa8fabd-a962-4a2e-9ecf-b4b9c5d4007e" />
