### PR TITLE
fix: cropping of leg `p` in header subtitle

### DIFF
--- a/frappe/public/scss/desk/sidebar_header.scss
+++ b/frappe/public/scss/desk/sidebar_header.scss
@@ -48,5 +48,4 @@
 	color: var(--ink-gray-6);
 	font-size: var(--text-sm);
 	@include truncate();
-	margin-top: 4px;
 }

--- a/frappe/public/scss/desk/sidebar_header.scss
+++ b/frappe/public/scss/desk/sidebar_header.scss
@@ -48,6 +48,5 @@
 	color: var(--ink-gray-6);
 	font-size: var(--text-sm);
 	@include truncate();
-	line-height: 1;
 	margin-top: 4px;
 }


### PR DESCRIPTION
**Fixes**: #35337 

---

**Before:**
<img width="1150" height="388" alt="image" src="https://github.com/user-attachments/assets/87830460-a3f1-4273-858e-0337ef684fa0" />

**After**
<img width="435" height="135" alt="after-fix" src="https://github.com/user-attachments/assets/b1e5d3ea-9666-446a-b670-0e0e2b183127" />

