### PR TITLE
fix: added 'autoname' to reserved keywords

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1278,9 +1278,20 @@ def validate_fields(meta: Meta):
 		validate_column_name(fieldname)
 
 	def check_invalid_fieldnames(docname, fieldname):
+		INVALID_DOCFIELD_NAMES = frozenset(("autoname",))
+
 		if fieldname in RESERVED_KEYWORDS:
 			frappe.throw(
 				_("{0}: fieldname cannot be set to reserved keyword {1}").format(
+					frappe.bold(docname),
+					frappe.bold(fieldname),
+				),
+				title=_("Invalid Fieldname"),
+			)
+
+		if fieldname in INVALID_DOCFIELD_NAMES:
+			frappe.throw(
+				_("{0}: fieldname cannot be set to special DocType attribute {1}").format(
 					frappe.bold(docname),
 					frappe.bold(fieldname),
 				),

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1278,7 +1278,7 @@ def validate_fields(meta: Meta):
 		validate_column_name(fieldname)
 
 	def check_invalid_fieldnames(docname, fieldname):
-		INVALID_DOCFIELD_NAMES = frozenset(("autoname",))
+		RESERVED_DOCFIELD_NAMES = frozenset(("autoname",))
 
 		if fieldname in RESERVED_KEYWORDS:
 			frappe.throw(
@@ -1289,9 +1289,9 @@ def validate_fields(meta: Meta):
 				title=_("Invalid Fieldname"),
 			)
 
-		if fieldname in INVALID_DOCFIELD_NAMES:
+		if fieldname in RESERVED_DOCFIELD_NAMES and docname != "DocType":
 			frappe.throw(
-				_("{0}: fieldname cannot be set to special DocType attribute {1}").format(
+				_("{0}: fieldname cannot be set to reserved field {1} in DocType").format(
 					frappe.bold(docname),
 					frappe.bold(fieldname),
 				),

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 import datetime
 import json
+import keyword
 import weakref
 from types import MappingProxyType
 from typing import TYPE_CHECKING, TypeVar
@@ -1555,6 +1556,8 @@ UNPICKLABLE_KEYS = frozenset(
 	)
 )
 
+PYTHON_KEYWORDS = frozenset(keyword.kwlist)
+
 RESERVED_KEYWORDS = frozenset(
 	(
 		"doctype",
@@ -1563,6 +1566,7 @@ RESERVED_KEYWORDS = frozenset(
 		"_parent_doc",
 		"_doc_before_save",
 		"dont_update_if_missing",
+		*PYTHON_KEYWORDS,
 		*CACHED_PROPERTIES,
 	)
 )

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1561,7 +1561,6 @@ PYTHON_KEYWORDS = frozenset(keyword.kwlist)
 RESERVED_KEYWORDS = frozenset(
 	(
 		"doctype",
-		"autoname",
 		"flags",
 		"_parent_doc",
 		"_doc_before_save",

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1558,6 +1558,7 @@ UNPICKLABLE_KEYS = frozenset(
 RESERVED_KEYWORDS = frozenset(
 	(
 		"doctype",
+		"autoname",
 		"flags",
 		"_parent_doc",
 		"_doc_before_save",

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1556,8 +1556,6 @@ UNPICKLABLE_KEYS = frozenset(
 	)
 )
 
-PYTHON_KEYWORDS = frozenset(keyword.kwlist)
-
 RESERVED_KEYWORDS = frozenset(
 	(
 		"doctype",
@@ -1565,7 +1563,6 @@ RESERVED_KEYWORDS = frozenset(
 		"_parent_doc",
 		"_doc_before_save",
 		"dont_update_if_missing",
-		*PYTHON_KEYWORDS,
 		*CACHED_PROPERTIES,
 	)
 )


### PR DESCRIPTION
Added autoname to reserved keywords to prevent breaking when used as a fieldname.

Before:
![ScreencastFrom2025-12-2614-55-14-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/1cb97765-0f58-42b5-8a8d-c4e56f34cac0)

After:
<img width="2404" height="1069" alt="Screenshot From 2s025-12-26 14-58-11" src="https://github.com/user-attachments/assets/b8bccdf5-96df-43b0-adce-5a4c1a40b910" />