### PR TITLE
fix(estimate_count): scope to site db

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -570,5 +570,9 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 
 		table = get_table_name(doctype)
 
-		count = self.sql("select table_rows from information_schema.tables where table_name = %s", table)
+		# Scope to current database to avoid cross-site estimates
+		count = self.sql(
+			"select table_rows from information_schema.tables where table_name = %s and table_schema = %s",
+			(table, frappe.db.cur_db_name),
+		)
 		return cint(count[0][0]) if count else 0

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -596,5 +596,9 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 
 		table = get_table_name(doctype)
 
-		count = self.sql("select table_rows from information_schema.tables where table_name = %s", table)
+		# Scope to current database to avoid cross-site estimates
+		count = self.sql(
+			"select table_rows from information_schema.tables where table_name = %s and table_schema = %s",
+			(table, frappe.db.cur_db_name),
+		)
 		return cint(count[0][0]) if count else 0

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -489,7 +489,12 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		from frappe.utils.data import cint
 
 		table = get_table_name(doctype)
-		count = self.sql("select reltuples from pg_class where relname = %s", table)
+
+		# Scope to current database to avoid cross-site estimates
+		count = self.sql(
+			"select c.reltuples from pg_class c join pg_namespace n on n.oid = c.relnamespace where c.relname = %s and n.nspname = %s and c.relkind = 'r'",
+			(table, self.db_schema),
+		)
 		return cint(count[0][0]) if count else 0
 
 	@contextmanager

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -502,7 +502,9 @@ class Meta(Document):
 			recent_change = frappe.db.sql(
 				f"SELECT `creation` FROM `tab{self.name}` ORDER BY `creation` DESC LIMIT 1"
 			)  # nosemgrep
-			if get_datetime(recent_change[0][0]) > add_to_date(None, days=-1 * LARGE_TABLE_RECENCY_THRESHOLD):
+			if recent_change and get_datetime(recent_change[0][0]) > add_to_date(
+				None, days=-1 * LARGE_TABLE_RECENCY_THRESHOLD
+			):
 				self.is_large_table = True
 
 	@cached_property


### PR DESCRIPTION
## Summary
System Health crashes on multi-site benches with an IndexError when fetching “Unhandled Email” stats. The large-table heuristic mis-detects the table as large because estimate_count reads information_schema without scoping the schema, and then dereferences recent_change[0][0] even when the table is empty.

## Fix
- Scope estimate_count to the current database schema (`table_schema = frappe.db.cur_db_name`).
- Guard the recency check in check_if_large_table to skip when no rows are returned.

## Issue
Closes #35480

## Notes
No UI changes; server-side only. All tests pass locally.
