### PR TITLE
fix: avoid shell in changelog git calls

### DIFF
--- a/frappe/utils/change_log.py
+++ b/frappe/utils/change_log.py
@@ -136,8 +136,8 @@ def get_app_branch(app):
 	try:
 		with open(os.devnull, "wb") as null_stream:
 			result = subprocess.check_output(
-				f"cd ../apps/{app} && git rev-parse --abbrev-ref HEAD",
-				shell=True,
+				["git", "-C", f"../apps/{app}", "rev-parse", "--abbrev-ref", "HEAD"],
+				shell=False,
 				stdin=null_stream,
 				stderr=null_stream,
 			)
@@ -152,8 +152,8 @@ def get_app_last_commit_ref(app):
 	try:
 		with open(os.devnull, "wb") as null_stream:
 			result = subprocess.check_output(
-				f"git -C ../apps/{app} rev-parse --short=7 HEAD",
-				shell=True,
+				["git", "-C", f"../apps/{app}", "rev-parse", "--short=7", "HEAD"],
+				shell=False,
 				stdin=null_stream,
 				stderr=null_stream,
 			)


### PR DESCRIPTION
Resovle #35476: Remove shell injection risk in changelog git calls

Changed git invocations from shell=True to shell=False with argument lists, eliminating command injection vulnerability while maintaining functionality.