### PR TITLE
fix(Workspace Sidebar Item): clear link to field

### DIFF
--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.js
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.js
@@ -15,4 +15,9 @@ frappe.ui.form.on("Workspace Sidebar", {
 			});
 		}
 	},
+	link_type: function (frm) {
+		if (frm.doc.link_type == "URL") {
+			frm.set_value("link_to", "");
+		}
+	},
 });


### PR DESCRIPTION
If link type is changed to URL, link to field still holds a value which it tries to validate for resulting in the following error

<img width="2189" height="881" alt="image" src="https://github.com/user-attachments/assets/10eeead6-ccc0-464b-ad94-1eae1c8ee365" />
