### PR TITLE
fix(letter_head): clear defaults in on_trash

### DIFF
--- a/frappe/printing/doctype/letter_head/letter_head.py
+++ b/frappe/printing/doctype/letter_head/letter_head.py
@@ -40,6 +40,13 @@ class LetterHead(Document):
 		if not frappe.flags.in_migrate and not frappe.flags.in_install:
 			self.source = "Image"
 
+	def on_trash(self):
+		from frappe.defaults import clear_default
+
+		clear_default("letter_head", self.name)
+		clear_default("default_letter_head_content", self.content)
+		frappe.clear_cache()
+
 	def validate(self):
 		self.set_image()
 		self.validate_disabled_and_default()


### PR DESCRIPTION
**Issue:**
Deleted Default Letter Head still appears in Print Settings

**Steps To Reproduce:**

1. Create a Letter Head and enable Default Letter Head on it. 
2. Create an Order or Invoice check the default Letter Head is displayed.
3. Delete the Letter Head that was created with Default Letter Head enabled, and then try creating an Order or Invoice again.
4. Check the Print Settings, you will still see the deleted Letter Head being shown.

**Ref:**[54552](https://support.frappe.io/helpdesk/tickets/54552)

**Before:**

https://github.com/user-attachments/assets/a29614f7-e2e1-4710-859f-6611ef1bb69c


**After:**

https://github.com/user-attachments/assets/f845bcab-2fda-4e36-b7a4-ebf77a2c467e

Backport needed:v15

