### PR TITLE
fix: desktop breadcrumb style

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -575,6 +575,7 @@ def get_sidebar_items():
 				"show_arrow": si.show_arrow,
 				"filters": si.filters,
 				"route_options": si.route_options,
+				"tab": si.navigate_to_tab,
 			}
 			if si.link_type == "Report" and si.link_to and frappe.db.exists("Report", si.link_to):
 				report_type, ref_doctype = frappe.db.get_value(

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.js
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.js
@@ -16,3 +16,23 @@ frappe.ui.form.on("Workspace Sidebar", {
 		}
 	},
 });
+
+frappe.ui.form.on("Workspace Sidebar Item", {
+	form_render(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		let grid = frm.fields_dict.items.grid;
+		let link_to = row.link_to;
+		if (link_to) {
+			frappe.model.with_doctype(link_to, function () {
+				let meta = frappe.get_meta(link_to);
+				let row_obj = grid.get_grid_row(cdn);
+				let field_obj = row_obj.get_field("navigate_to_tab");
+				let tab_fieldnames = meta.fields
+					.filter((field) => field.fieldtype === "Tab Break")
+					.map((field) => field.fieldname);
+				field_obj.set_data(tab_fieldnames);
+				row_obj.refresh();
+			});
+		}
+	},
+});

--- a/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.json
+++ b/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.json
@@ -14,6 +14,7 @@
   "type",
   "link_to",
   "child",
+  "navigate_to_tab",
   "url",
   "display_section",
   "collapsible_column",
@@ -155,13 +156,19 @@
    "fieldtype": "Code",
    "label": "Route Options",
    "options": "JSON"
+  },
+  {
+   "depends_on": "eval: doc.link_type == \"DocType\" && doc.link_to",
+   "fieldname": "navigate_to_tab",
+   "fieldtype": "Autocomplete",
+   "label": "Tab"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-11-26 18:14:11.682693",
+ "modified": "2025-12-29 17:11:16.069665",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace Sidebar Item",

--- a/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.py
+++ b/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.py
@@ -23,6 +23,7 @@ class WorkspaceSidebarItem(Document):
 		label: DF.Data | None
 		link_to: DF.DynamicLink | None
 		link_type: DF.Literal["DocType", "Page", "Report", "Workspace", "Dashboard", "URL"]
+		navigate_to_tab: DF.Autocomplete | None
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -51,6 +51,7 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 				path = frappe.utils.generate_route({
 					type: this.item.link_type,
 					name: this.item.link_to,
+					tab: this.item.tab,
 				});
 			}
 		}

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -204,6 +204,7 @@ frappe.ui.sidebar_item.TypeSectionBreak = class SectionBreakSidebarItem extends 
 			} else {
 				$(me.wrapper.find(".section-break")).addClass("hidden");
 				$(me.wrapper.find(".divider")).removeClass("hidden");
+				$(me.wrapper).removeAttr("data-original-title");
 				me.old_state = me.collapsed;
 				me.open();
 				if (me.item.indent) {

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1474,6 +1474,9 @@ Object.assign(frappe.utils, {
 							route = doctype_slug;
 					}
 				}
+				if (item.tab) {
+					route += `#${item.tab}`;
+				}
 			} else if (type === "report") {
 				if (item.is_query_report) {
 					route = "query-report/" + item.name;

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -257,10 +257,7 @@ frappe.breadcrumbs = {
 
 	clear() {
 		this.$breadcrumbs = $(".navbar-breadcrumbs").empty();
-		this.append_breadcrumb_element(
-			"/desk",
-			frappe.utils.icon("monitor", { width: "18px", height: "18px" })
-		);
+		this.append_breadcrumb_element("/desk", frappe.utils.icon("monitor"));
 	},
 
 	toggle(show) {


### PR DESCRIPTION
This PR contains 3 things

1. Desktop breadcrumb height and width
2. Overlapping tooltip issue mentioned in https://github.com/frappe/frappe/issues/35337
3. Ability to sidebar item directly to form
	It fetches the tab breaks in the doctype selected in link_to field
	and generates a link

https://github.com/user-attachments/assets/56fe5cfd-ba8f-4c7e-b12c-28f8395b1cb5

