### PR TITLE
fix(sidebar): correct indentation for sidebar child items

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -309,17 +309,3 @@
 		font-weight: 420;
 	}
 }
-
-.body-sidebar-container {
-	.sidebar-child-item {
-		transition: margin-inline-start 0.2s ease;
-	}
-
-	&:not(.expanded) .sidebar-child-item {
-		margin-inline-start: 0px;
-	}
-
-	&.expanded .sidebar-child-item {
-		margin-inline-start: 16px;
-	}
-}

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -309,3 +309,17 @@
 		font-weight: 420;
 	}
 }
+
+.body-sidebar-container {
+	.sidebar-child-item {
+		transition: margin-inline-start 0.2s ease;
+	}
+
+	&:not(.expanded) .sidebar-child-item {
+		margin-inline-start: 0px;
+	}
+
+	&.expanded .sidebar-child-item {
+		margin-inline-start: 16px;
+	}
+}

--- a/frappe/workspace_sidebar/integrations.json
+++ b/frappe/workspace_sidebar/integrations.json
@@ -113,7 +113,7 @@
    "type": "Link"
   },
   {
-   "child": 0,
+   "child": 1,
    "collapsible": 1,
    "icon": "settings",
    "indent": 0,
@@ -125,7 +125,7 @@
    "type": "Link"
   },
   {
-   "child": 0,
+   "child": 1,
    "collapsible": 1,
    "icon": "list",
    "indent": 0,
@@ -137,7 +137,7 @@
    "type": "Link"
   },
   {
-   "child": 0,
+   "child": 1,
    "collapsible": 1,
    "icon": "list",
    "indent": 0,
@@ -149,7 +149,7 @@
    "type": "Link"
   }
  ],
- "modified": "2025-12-18 17:22:26.558605",
+ "modified": "2025-12-29 23:46:47.024937",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Integrations",


### PR DESCRIPTION
**Closes:** #35337

---


https://github.com/user-attachments/assets/de4cfc75-7b04-4ce5-8c5b-e1838fff8756



**Before**:
<img width="324" height="321" alt="image" src="https://github.com/user-attachments/assets/5c16a5e0-fabe-490e-b538-2d6cb22e6d56" />

**After**
<img width="223" height="539" alt="image" src="https://github.com/user-attachments/assets/55c23fff-6f38-4db4-9144-2ba04bed5d79" />


---
`no-docs` 