### PR TITLE
feat: data import tool to skip rows or create missing items during import

### DIFF
--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -379,15 +379,31 @@ frappe.ui.form.on("Data Import", {
 			.map((row_number) => {
 				let message = warnings_by_row[row_number]
 					.map((w) => {
+						let extra_action = "";
+
+						if (w.type === "warning" && w.link_doctype && w.missing_value) {
+							extra_action = `
+								<button
+									class="btn btn-xs btn-secondary create-missing-link"
+									data-doctype="${w.link_doctype}"
+									data-name="${w.missing_value}"
+									style="margin-left: 10px;">
+									${__("Create")} ${w.link_doctype}
+								</button>
+
+							`;
+						}
+
 						if (w.field) {
 							let label =
 								w.field.label +
 								(w.field.parent !== frm.doc.reference_doctype
 									? ` (${w.field.parent})`
 									: "");
-							return `<li>${label}: ${w.message}</li>`;
+							return `<li>${label}: ${w.message} ${extra_action}</li>`;
 						}
-						return `<li>${w.message}</li>`;
+
+						return `<li>${w.message} ${extra_action}</li>`;
 					})
 					.join("");
 				return `
@@ -422,6 +438,11 @@ frappe.ui.form.on("Data Import", {
 				<div class="col-sm-10 warnings">${html}</div>
 			</div>
 		`);
+		frm.get_field("import_warnings")
+			.$wrapper.find(".create-missing-link")
+			.on("click", function () {
+				frappe.new_doc($(this).data("doctype"), { name: $(this).data("name") });
+			});
 	},
 
 	show_failed_logs(frm) {

--- a/frappe/core/doctype/data_import/data_import.json
+++ b/frappe/core/doctype/data_import/data_import.json
@@ -22,6 +22,7 @@
   "status",
   "submit_after_import",
   "mute_emails",
+  "skip_rows_with_missing_linked_records",
   "template_options",
   "import_warnings_section",
   "template_warnings",
@@ -170,6 +171,13 @@
    "hidden": 1,
    "label": "Payload Count",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "skip_rows_with_missing_linked_records",
+   "fieldtype": "Check",
+   "label": "Skip rows with missing linked records",
+   "set_only_once": 1
   },
   {
    "default": ",;\\t|",

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -39,6 +39,7 @@ class DataImport(Document):
 		payload_count: DF.Int
 		reference_doctype: DF.Link
 		show_failed_logs: DF.Check
+		skip_rows_with_missing_linked_records: DF.Check
 		status: DF.Literal["Pending", "Success", "Partial Success", "Error", "Timed Out"]
 		submit_after_import: DF.Check
 		template_options: DF.Code | None

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -10,6 +10,7 @@ from datetime import date, datetime, time
 import frappe
 from frappe import _
 from frappe.core.doctype.version.version import get_diff
+from frappe.exceptions import LinkValidationError
 from frappe.model import no_value_fields
 from frappe.utils import cint, cstr, duration_to_seconds, flt, update_progress_bar
 from frappe.utils.csvutils import get_csv_content_from_google_sheets, read_csv_content
@@ -83,14 +84,41 @@ class Importer:
 
 		# dont import if there are non-ignorable warnings
 		warnings = self.import_file.get_warnings()
-		warnings = [w for w in warnings if w.get("type") != "info"]
+
+		processed_warnings = []
+		has_blocking_error = False
+
+		for w in warnings:
+			# Skip info warnings always
+			if w.get("type") == "info":
+				continue
+
+			# Handle missing link warnings
+			if w.get("is_missing_link"):
+				if self.data_import.skip_rows_with_missing_linked_records:
+					# skip this warning completely
+					continue
+				else:
+					# convert missing link to error
+					w["type"] = "error"
+
+			# Track blocking errors
+			if w.get("type") == "error":
+				has_blocking_error = True
+
+			processed_warnings.append(w)
+
+		warnings = processed_warnings
 
 		if warnings:
 			if self.console:
 				self.print_grouped_warnings(warnings)
 			else:
 				self.data_import.db_set("template_warnings", json.dumps(warnings))
-			return
+
+			# Only stop import if there is a blocking error
+			if has_blocking_error:
+				return
 
 		# setup import log
 		import_log = (
@@ -189,13 +217,38 @@ class Importer:
 					# commit after every successful import
 					frappe.db.commit()
 
-				except Exception:
-					messages = frappe.local.message_log
+				except Exception as e:
+					messages = frappe.local.message_log or []
 					frappe.clear_messages()
 
 					# rollback if exception
 					frappe.db.rollback()
 
+					# Skip row if option is enabled and it's a link error
+					if self.data_import.skip_rows_with_missing_linked_records and isinstance(
+						e, LinkValidationError
+					):
+						create_import_log(
+							self.data_import.name,
+							log_index,
+							{
+								"success": False,
+								"messages": [
+									{
+										"title": _("Row Skipped"),
+										"message": _(
+											"One or more linked records were missing. Row was skipped."
+										),
+									}
+								],
+								"row_indexes": row_indexes,
+							},
+						)
+						log_index += 1
+						frappe.db.commit()  # Commit the skip log
+						continue
+
+					# default strict behavior - create error log
 					create_import_log(
 						self.data_import.name,
 						log_index,
@@ -206,7 +259,6 @@ class Importer:
 							"row_indexes": row_indexes,
 						},
 					)
-
 					log_index += 1
 
 		# Logs are db inserted directly so will have to be fetched again
@@ -728,7 +780,11 @@ class Row:
 					{
 						"row": self.row_number,
 						"field": df_as_json(df),
+						"missing_value": value,
+						"link_doctype": df.options,
 						"message": msg,
+						"type": "warning",
+						"is_missing_link": True,
 					}
 				)
 				return
@@ -1048,8 +1104,10 @@ class Column:
 						"col": self.column_number,
 						"message": message.format(self.df.options, missing_values),
 						"type": "warning",
+						"link_doctype": self.df.options,
 					}
 				)
+
 		elif self.df.fieldtype in ("Date", "Time", "Datetime"):
 			# guess date/time format
 			# TODO: add possibility for user, to define the date format explicitly in the Data Import UI


### PR DESCRIPTION
This PR enhances the Data Import Tool by allowing imports to continue even when some rows reference missing linked records (e.g., Items), instead of failing the entire import.

It introduces configurable behavior and an inline UI action to handle missing links more gracefully, especially for large transactional imports such as Sales Orders.

**Issues** 

- https://github.com/frappe/frappe/issues/35430
- https://support.frappe.io/helpdesk/my-tickets/55418

 
 **Solution**-
 This PR introduces a flexible and user-friendly approach to handling missing linked records during import.
The following changes were made:

- Added support to skip rows with missing linked records and continue importing valid rows.
- Introduced a configurable import option to control this behavior.
- Added an inline action in the import warnings view to:
  - Identify missing linked records
  - Quickly create missing records directly from the import flow using pre-filled forms
- Ensured that the existing blocking behavior remains unchanged when the option is disabled.

**Before Fix**

https://github.com/user-attachments/assets/419b3a35-dd18-4afb-aecd-b8199b5b6d5d

**After Fix** 

https://github.com/user-attachments/assets/d85057af-dd7b-433d-9ed4-0627fc6e1cc7

## Documentation

### Data Import: Handling Missing Linked Records

The Data Import tool now provides improved handling for rows that reference missing linked records (for example, Items in Sales Orders).

#### New Option
A new import option **“Skip Rows with Missing Linked Records”** has been added.

- When **enabled**, rows that contain missing linked records are skipped.
- Valid rows continue to be imported successfully.
- Warnings are shown for skipped rows.

#### Inline Action for Missing Records
In the import warnings view, users can now:
- Identify missing linked records directly
- Create missing records (such as Items) inline using pre-filled forms
- Retry the import after resolving missing links

#### Default Behavior
- When the option is **disabled**, the Data Import tool retains its existing behavior and stops the import if missing linked records are detected.

This enhancement is especially useful for large transactional imports where partial data issues should not block the entire import process.


