### PR TITLE
fix: close open menus on route change

### DIFF
--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -113,7 +113,6 @@
 .icon-container img{
     width: var(--desktop-icon-dimension);
     height: var(--desktop-icon-dimension);
-    user-drag: none;
     -webkit-user-drag: none;
     user-select: none;
     -moz-user-select: none;
@@ -356,11 +355,6 @@
     }
 }
 
-                /* @media screen and (max-width: 320px) {
-                    .icons{
-                        grid-template-columns: repeat(2, 1fr) !important;
-                    }
-                } */
 @media screen and (max-width: 570px) {
   :root {
     --desktop-icon-dimension: 50px;
@@ -390,8 +384,13 @@
         > .desktop-icon {
           width: var(--desktop-icon-container);
           height: var(--desktop-icon-container);
+          .icon-container {
+                min-width: var(--desktop-icon-dimension);
+                min-height: var(--desktop-icon-dimension);
+          }
         }
       }
+
     }
   }
 
@@ -429,7 +428,12 @@
         > .icons {
             grid-template-columns: repeat(2, 1fr) !important;
             grid-template-rows: repeat(2, 1fr) !important;
+            > .desktop-icon {
+                .icon-container {
+                        min-width: unset;
+                        min-height: unset;
+                }
+            }
+            }
         }
-    }
-
 }

--- a/frappe/public/js/frappe/ui/desktop_icon.html
+++ b/frappe/public/js/frappe/ui/desktop_icon.html
@@ -12,7 +12,7 @@
 
         </div>
     {% } else { %}
-            {%= frappe.utils.desktop_icon(icon.label.charAt(0).toUpperCase(),"gray")%}
+            {%= frappe.utils.desktop_icon(icon.label,"gray")%}
     {% } %}
     {% if (!in_folder) { %}
     <div class="icon-caption">

--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -48,17 +48,18 @@ frappe.ui.menu = class ContextMenu {
 				`<div class="dropdown-menu-item"><div class="dropdown-divider documentation-links"></div></div>`
 			);
 		} else {
+			const iconMarkup = item.icon_html
+				? item.icon_html
+				: item.icon
+				? frappe.utils.icon(item.icon)
+				: item.icon_url
+				? `<img class="logo" src="${item.icon_url}">`
+				: "";
+
 			item_wrapper = $(`<div class="dropdown-menu-item">
 				<a>
-					<div class="menu-item-icon" ${!(item.icon || item.icon_url) ? "hidden" : ""}>
-						${
-							item.icon
-								? frappe.utils.icon(item.icon)
-								: `<img
-								class="logo"
-								src="${item.icon_url}"
-							>`
-						}
+					<div class="menu-item-icon" ${!(iconMarkup != "") ? "hidden" : ""}>
+						${iconMarkup}
 					</div>
 					<span class="menu-item-title">${__(item.label)}</span>
 					<div class="menu-item-icon" style="margin-left:auto">

--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -143,6 +143,7 @@ frappe.ui.menu = class ContextMenu {
 		}
 
 		this.visible = true;
+		frappe.visible_menus.push(this);
 	}
 	close_all_other_menu() {
 		$(".context-menu").hide();
@@ -183,6 +184,7 @@ frappe.ui.menu = class ContextMenu {
 };
 
 frappe.menu_map = {};
+frappe.visible_menus = [];
 
 frappe.ui.create_menu = function (opts) {
 	if (!opts.right_click) $(opts.parent).css("cursor", "pointer");
@@ -229,3 +231,14 @@ frappe.ui.create_menu = function (opts) {
 		}
 	});
 };
+
+function close_all_open_menus() {
+	frappe.visible_menus.forEach((menu) => {
+		menu.hide();
+	});
+	frappe.visible_menus = [];
+}
+
+frappe.router.on("change", function () {
+	close_all_open_menus();
+});

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -63,12 +63,19 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 				let item = {
 					name: w.toLowerCase(),
 					label: w,
-					icon: "wallpaper",
 					url: frappe.utils.generate_route({
 						type: "Workspace",
 						route: frappe.router.slug(w),
 					}),
 				};
+				if (frappe.utils.get_desktop_icon(w, frappe.boot.desktop_icon_style)) {
+					item.icon_url = frappe.utils.get_desktop_icon(
+						w,
+						frappe.boot.desktop_icon_style
+					);
+				} else {
+					item.icon_html = frappe.utils.desktop_icon(w, "gray", "sm");
+				}
 				sibling_workspaces.push(item);
 			});
 			return sibling_workspaces;
@@ -147,11 +154,7 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 			this.header_icon = `<img src=${this.header_icon}></img>`;
 		} else if (this.sidebar.sidebar_data) {
 			this.header_icon = this.sidebar.sidebar_data.header_icon;
-			this.header_icon = frappe.utils.desktop_icon(
-				this.sidebar.sidebar_title.charAt(0),
-				"gray",
-				"sm"
-			);
+			this.header_icon = frappe.utils.desktop_icon(this.sidebar.sidebar_title, "gray", "sm");
 		} else {
 			this.header_icon = this.get_default_icon();
 			this.header_icon = `<img src=${this.header_icon}></img>`;

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1276,7 +1276,8 @@ Object.assign(frappe.utils, {
 		},
 		image_path: "/assets/frappe/images/leaflet/",
 	},
-	desktop_icon(letter, color, size) {
+	desktop_icon(label, color, size) {
+		let letter = label.charAt(0).toUpperCase();
 		let icon_size = size ? size : "md";
 		let opacity_hex = "1A";
 		let icon_html = $(`

--- a/frappe/public/scss/desk/menu.scss
+++ b/frappe/public/scss/desk/menu.scss
@@ -1,6 +1,7 @@
 :root {
 	// can do sizes later on;
 	--menu-width: 200px;
+	--menu-icon-size: 16px;
 }
 .frappe-menu {
 	position: absolute;
@@ -29,7 +30,8 @@
 		gap: var(--margin-sm);
 		.menu-item-icon {
 			line-height: 0px;
-			.app-logo {
+			.app-logo,
+			img {
 				width: 16px;
 				height: 16px;
 			}
@@ -40,5 +42,19 @@
 		text-overflow: ellipsis;
 		text-wrap: nowrap;
 		overflow: hidden;
+	}
+}
+
+.menu-item-icon {
+	width: var(--menu-icon-size);
+	height: var(--menu-icon-size);
+	& .icon-container {
+		width: 100%;
+		height: 100%;
+		padding: unset;
+		border-radius: 4px;
+		& .desktop-alphabet {
+			padding: 4px;
+		}
 	}
 }


### PR DESCRIPTION
This PR fixes
-  Close menu on clicking the desktop icon

	https://github.com/user-attachments/assets/72f4695a-ac80-401b-ad68-18db9ed75785
	Closes an comment on https://github.com/frappe/frappe/issues/35337

-  Fixes Desktop Icon height issue on mobile

	Before
	<img width="338" height="134" alt="Screenshot 2025-12-29 at 10 46 23 PM" src="https://github.com/user-attachments/assets/f642439a-425e-41a6-993e-d6644acc6e9f" />
	
	After
	<img width="130" height="120" alt="Screenshot 2025-12-29 at 10 48 23 PM" src="https://github.com/user-attachments/assets/88af4520-edd4-468d-8939-82968ed249b8" />

-  Sub menu uses desktop icons
<img width="458" height="500" alt="Screenshot 2025-12-29 at 11 42 14 PM" src="https://github.com/user-attachments/assets/a332040b-5d89-492c-9df0-b58b1b822b04" />

