### PR TITLE
fix: translate desktop icons correctly

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -515,7 +515,6 @@ class DesktopIconGrid {
 class DesktopIcon {
 	constructor(icon, in_folder) {
 		this.icon_data = icon;
-		this.icon_data.label = __(this.icon_data.label);
 		this.icon_title = this.icon_data.label;
 		this.icon_subtitle = "";
 		this.icon_type = this.icon_data.icon_type;
@@ -666,7 +665,7 @@ class DesktopModal {
 	}
 	make_modal(icon_title) {
 		if ($(".desktop-modal").length == 0) {
-			this.modal = new frappe.get_modal(icon_title, "");
+			this.modal = new frappe.get_modal(__(icon_title), "");
 			this.modal.find(".modal-header").addClass("desktop-modal-heading");
 			this.modal.addClass("desktop-modal");
 			this.modal.find(".modal-dialog").attr("id", "desktop-modal");

--- a/frappe/public/js/frappe/ui/desktop_icon.html
+++ b/frappe/public/js/frappe/ui/desktop_icon.html
@@ -18,7 +18,7 @@
     {% } %}
     {% if (!in_folder) { %}
     <div class="icon-caption">
-        <div class="icon-title">{{ icon.label }}</div>
+        <div class="icon-title">{{ __(icon.label) }}</div>
         <div class="icon-subtitle"></div>
     </div>
     {% } %}


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/35468

After
<img width="687" height="594" alt="Screenshot 2025-12-30 at 2 06 53 AM" src="https://github.com/user-attachments/assets/a766a1c7-b740-4c4b-b632-9a0ec87e70e4" />
