### PR TITLE
revert: "fix: '\n' in translation CSV not handled as new line, causing translations to fail (backport #33855)"

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -202,8 +202,6 @@ def get_translation_dict_from_file(path, lang, app, throw=False) -> dict[str, st
 		csv_content = read_csv_file(path)
 
 		for item in csv_content:
-			item[0] = item[0].replace("\\n", "\n")
-			item[1] = item[1].replace("\\n", "\n")
 			if len(item) == 3 and item[2]:
 				key = item[0] + ":" + item[2]
 				translation_map[key] = strip(item[1])


### PR DESCRIPTION
Reverts frappe/frappe#35376