### PR TITLE
fix: handle precision correctly when decimal string is empty

### DIFF
--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -195,7 +195,8 @@ function get_number_format_info(format) {
 	}
 
 	// get the precision from the number format
-	info.precision = format.split(info.decimal_str).slice(1)[0].length;
+	info.precision =
+		info.decimal_str == "" ? 0 : format.split(info.decimal_str).slice(1)[0].length;
 
 	return info;
 }


### PR DESCRIPTION
`get_number_format_info()` in JavaScript incorrectly calculates precision for number formats without a decimal part.
For formats such as `#,###` and `#.###`, `decimal_str` is an empty string "". The existing logic:
`format.split(info.decimal_str).slice(1)[0].length
`
```javascript
frappe.number_format_info = {
	"#,###.##": { decimal_str: ".", group_sep: "," },
	"#.###,##": { decimal_str: ",", group_sep: "." },
	"# ###.##": { decimal_str: ".", group_sep: " " },
	"# ###,##": { decimal_str: ",", group_sep: " " },
	"#'###.##": { decimal_str: ".", group_sep: "'" },
	"#, ###.##": { decimal_str: ".", group_sep: ", " },
	"#,##,###.##": { decimal_str: ".", group_sep: "," },
	"#,###.###": { decimal_str: ".", group_sep: "," },
	"#.###": { decimal_str: "", group_sep: "." },
	"#,###": { decimal_str: "", group_sep: "," },
};
```
splits the string on "", which results in an incorrect precision value of 1, even though these formats have no decimal places.

**Solution**
Explicitly handle formats with no decimal separator by returning precision 0 when decimal_str is empty.

**Alternative Solution**
I can add the precision to the object, just like in Python:
```python
# file path frappe/utils/number_format.py
NUMBER_FORMAT_MAP = {
	"#,###.##": (".", ",", 2),
	"#.###,##": (",", ".", 2),
	"# ###.##": (".", " ", 2),
	"# ###,##": (",", " ", 2),
	"#'###.##": (".", "'", 2),
	"#, ###.##": (".", ", ", 2),
	"#,##,###.##": (".", ",", 2),
	"#,###.###": (".", ",", 3),
	"#.###": ("", ".", 0),
	"#,###": ("", ",", 0),
	"#.########": (".", "", 8),
}
```
backport verion-15-hotfix
backport verion-16-beta