### PR TITLE
fix: UI alignment for top-left context menu in RTL

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -287,7 +287,9 @@ class DesktopPage {
 		frappe.ui.create_menu({
 			parent: $(".desktop-avatar"),
 			menu_items: menu_items,
-			open_on_left: true,
+			// If it's RTL, we want it to open on the right (false); 
+			// if it's LTR, we want it to open on the left (true).
+			open_on_left: !frappe.utils.is_rtl()
 		});
 	}
 	setup_navbar() {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -287,9 +287,9 @@ class DesktopPage {
 		frappe.ui.create_menu({
 			parent: $(".desktop-avatar"),
 			menu_items: menu_items,
-			// If it's RTL, we want it to open on the right (false); 
+			// If it's RTL, we want it to open on the right (false);
 			// if it's LTR, we want it to open on the left (true).
-			open_on_left: !frappe.utils.is_rtl()
+			open_on_left: !frappe.utils.is_rtl(),
 		});
 	}
 	setup_navbar() {


### PR DESCRIPTION
## Summary
This PR fixes a layout issue where the context menu (sidebar toggle/user menu) in the top-left corner was not properly aligned or had overlapping elements when using RTL languages (e.g., Persian/Arabic).

## Verification Results
- Tested on Persian (RTL) layout.
- Verified no regression on English (LTR) layout.

## Attachment 1 (overlapped menu)
<img width="1919" height="912" alt="Screenshot 2025-12-29 165200" src="https://github.com/user-attachments/assets/b3f712f1-ead2-496e-bea9-9e44966c82e3" />

## Attachment 2 (after the fix)
<img width="1919" height="907" alt="image" src="https://github.com/user-attachments/assets/00412962-dd4e-492b-8e45-cdc93d5e7678" />

