### PR TITLE
fix: make the desktop editing easy to discover

### DIFF
--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -437,3 +437,18 @@
             }
         }
 }
+
+.desktop-edit{
+    width: 36px;
+    height: 36px;
+    background-color: var(--surface-gray-7);
+    position: absolute;
+    bottom: 4%;
+    right: 4%;
+    z-index: 100;
+    opacity: 0.1;
+}
+.desktop-edit:hover{
+    opacity: 1;
+    transition: opacity 0.3s;
+}

--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -36,5 +36,5 @@
             <button class="save btn btn-primary ellipsis">
                 {{ _("Save") }}
             </button>
-    </div>`
+    </div>
 </div>

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -179,6 +179,20 @@ class DesktopPage {
 		this.setup_editing_mode();
 		this.handle_route_change();
 		this.setup_events();
+		this.setup_edit_button();
+	}
+	setup_edit_button() {
+		const me = this;
+		this.$desktop_edit_button = $(
+			"<button class='btn btn-reset desktop-edit'></button>"
+		).appendTo(document.body);
+		this.$desktop_edit_button.html(
+			frappe.utils.icon("square-pen", "md", "", "", "", "", "white")
+		);
+		this.$desktop_edit_button.on("click", () => {
+			me.start_editing_layout();
+			me.$desktop_edit_button.hide();
+		});
 	}
 	setup_editing_mode() {
 		const me = this;


### PR DESCRIPTION
Desktop Editing can be started via right clicking the on the desktop screen. This action however cool and real-desktop esque is hard to discover.  This PR fixes that

Closes a comment on https://github.com/frappe/frappe/issues/35337

<img width="1440" height="900" alt="Screenshot 2025-12-30 at 2 50 36 PM" src="https://github.com/user-attachments/assets/004d8f64-6bfc-4bae-8ace-b3ede9f56950" />




https://github.com/user-attachments/assets/0e2de65a-e1bd-48a2-8e55-4d36039a2aa3



Took some inspiration from Frappe Builder :) 