### PR TITLE
fix: multiple fixes of list and form view

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -36,7 +36,6 @@ frappe.ui.form.Sidebar = class {
 		this.show_auto_repeat_status();
 		frappe.ui.form.setup_user_image_event(this.frm);
 		this.indicator = $(this.sidebar).find(".sidebar-meta-details .indicator-pill");
-		this.set_form_indicator();
 		this.setup_copy_event();
 		this.make_like();
 		this.refresh();
@@ -44,20 +43,6 @@ frappe.ui.form.Sidebar = class {
 		// setup editable title
 		let form_sidebar_text = $(this.sidebar).find(".sidebar-meta-details .form-title-text");
 		this.toolbar.setup_editable_title(form_sidebar_text);
-	}
-
-	set_form_indicator() {
-		let indicator = frappe.get_indicator(this.frm.doc);
-		if (indicator) {
-			this.set_indicator(indicator[0], indicator[1]);
-		}
-	}
-	set_indicator(label, color) {
-		this.clear_indicator().removeClass("hide").html(`<span>${label}</span>`).addClass(color);
-	}
-
-	clear_indicator() {
-		return this.indicator.addClass("indicator-pill no-indicator-dot whitespace-nowrap hide");
 	}
 
 	setup_keyboard_shortcuts() {

--- a/frappe/public/js/frappe/form/tab.js
+++ b/frappe/public/js/frappe/form/tab.js
@@ -35,7 +35,11 @@ export default class Tab {
 					type="button"
 					role="tab"
 					aria-controls="${id}">
-						${frappe.utils.icon(this.df.icon || ICON_MAP[this.label] || "list")}
+						${
+							ICON_MAP[this.label] || this.df.icon
+								? frappe.utils.icon(this.df.icon || ICON_MAP[this.label])
+								: ""
+						}
 						${__(this.label, null, this.doctype)}
 				</button>
 			</li>

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -28,13 +28,14 @@
 </div>
 <div class="sidebar-section sidebar-meta-details border-bottom">
 	<div class="form-details flex {{image_field ? "justify-center" : "justify-between"}}">
-		<span class="ellipsis mr-3 bold form-title-text pointer" title="{{__("Click to edit")}}">{%= frm.get_title() %}</span>
+		<span class="ellipsis mr-3 bold form-title-text pointer text-medium" title="{{__("Click to edit")}}">{%= frm.get_title() %}</span>
 		<span class="form-name-copy" data-copy="{{frm.get_title()}}">{%= frappe.utils.icon("copy")%}</span>
 	</div>
+	{% if frm.doc.name != frm.get_title() %}
 	<div class="form-name-container mt-2 flex {{image_field ? "justify-center" : "justify-between"}}">
 		<span class="ellipsis mr-3">{%= frm.doc.name %}</span>
-		<span class="indicator-pill whitespace-nowrap"></span>
 	</div>
+	{% endif %}
 </div>
 {% if frm.meta.beta %}
 <div class="sidebar-section border-bottom">

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -315,7 +315,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 		this.page.clear_menu();
 
 		if (frappe.boot.desk_settings.form_sidebar) {
-			this.make_navigation();
+			// this.make_navigation();
 			this.make_menu_items();
 		}
 	}

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -1,7 +1,7 @@
 <div class="page-head flex {% if frappe.boot.read_only || frappe.boot.user.impersonated_by %}show-navbar{% endif %}">
 	<div class="container">
 		<div class="row flex-nowrap align-center page-head-content justify-between">
-			<div class="col-md-5 col-sm-6 col-xs-7 page-title">
+			<div class="page-title">
 				<div class="flex fill-width title-area ellipsis">
 					{% if (!frappe.is_mobile()) { %}
 						<ul class="nav d-sm-flex navbar-breadcrumbs ellipsis"></ul>

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -131,8 +131,13 @@ frappe.breadcrumbs = {
 
 		this.append_breadcrumb_element(
 			`/desk/${frappe.router.slug(breadcrumbs.workspace)}`,
-			__(breadcrumbs.workspace)
+			__(breadcrumbs.workspace),
+			"worksapce-breadcrumb"
 		);
+
+		let worksapce_crumb = this.$breadcrumbs.find("li a.worksapce-breadcrumb");
+
+		worksapce_crumb.parent().addClass("ellipsis");
 	},
 
 	set_workspace(breadcrumbs) {
@@ -223,7 +228,6 @@ frappe.breadcrumbs = {
 		if (view === "form") {
 			let last_crumb = this.$breadcrumbs.find("li").last();
 			last_crumb.addClass("disabled");
-			last_crumb.addClass("ellipsis");
 			last_crumb.css("cursor", "copy");
 			last_crumb.click((event) => {
 				event.stopImmediatePropagation();

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -209,6 +209,9 @@ frappe.breadcrumbs = {
 			}
 			this.append_breadcrumb_element(`/desk/${route}`, __(doctype), "title-text");
 		}
+
+		let list_crumb = this.$breadcrumbs.find("li a.title-text");
+		list_crumb.parent().addClass("ellipsis");
 	},
 
 	set_form_breadcrumb(breadcrumbs, view) {

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -336,7 +336,6 @@ body[data-route^="Form"] {
 	background-color: var(--bg-color);
 	text-align: start;
 	margin-top: var(--margin-sm);
-	margin-left: var(--margin-md);
 	margin-bottom: var(--margin-sm);
 	color: var(--text-light);
 }

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -1,6 +1,7 @@
 .page-title {
 	display: flex;
 	align-items: center;
+	padding: 0 15px;
 	.sidebar-toggle-btn {
 		display: flex;
 		margin-right: var(--margin-sm);


### PR DESCRIPTION
- Remove default Icon from Tab
<img width="2452" height="1520" alt="image" src="https://github.com/user-attachments/assets/e9d52862-69e7-478f-b14e-28f307bd0ee5" />

- If ID and title are same then don't show ID again and remove indicator from sidebar
<img width="2488" height="1366" alt="image" src="https://github.com/user-attachments/assets/50b06e4b-2bd6-4634-8ec8-2b5edc256aae" />

- Truncate workspace name instead of ID
- Remove fix width of breadcrumb