### PR TITLE
fix: move dropdown options to sidebar dropdown

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -341,6 +341,7 @@ class DesktopPage {
 			if (frappe.get_route()[0] == "desktop" || frappe.get_route()[0] == "")
 				me.setup_navbar();
 			else {
+				me.$desktop_edit_button.remove();
 				$(".navbar").show();
 				frappe.desktop_utils.close_desktop_modal();
 			}

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -476,53 +476,6 @@ standard_navbar_items = [
 		"is_standard": 1,
 	},
 	{
-		"item_label": "Workspace Settings",
-		"item_type": "Action",
-		"action": "frappe.quick_edit('Workspace Settings')",
-		"is_standard": 1,
-	},
-	{
-		"item_label": "Session Defaults",
-		"item_type": "Action",
-		"action": "frappe.ui.toolbar.setup_session_defaults()",
-		"is_standard": 1,
-	},
-	{
-		"item_label": "Reload",
-		"item_type": "Action",
-		"action": "frappe.ui.toolbar.clear_cache()",
-		"is_standard": 1,
-	},
-	{
-		"item_label": "View Website",
-		"item_type": "Action",
-		"action": "frappe.ui.toolbar.view_website()",
-		"is_standard": 1,
-	},
-	{
-		"item_label": "Apps",
-		"item_type": "Route",
-		"route": "/apps",
-		"is_standard": 1,
-	},
-	{
-		"item_label": "Toggle Full Width",
-		"item_type": "Action",
-		"action": "frappe.ui.toolbar.toggle_full_width()",
-		"is_standard": 1,
-	},
-	{
-		"item_label": "Toggle Theme",
-		"item_type": "Action",
-		"action": "new frappe.ui.ThemeSwitcher().show()",
-		"is_standard": 1,
-	},
-	{
-		"item_type": "Separator",
-		"is_standard": 1,
-		"item_label": "",
-	},
-	{
 		"item_label": "Log out",
 		"item_type": "Action",
 		"action": "frappe.app.logout()",

--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -56,7 +56,9 @@ frappe.ui.menu = class ContextMenu {
 				? `<img class="logo" src="${item.icon_url}">`
 				: "";
 
-			item_wrapper = $(`<div class="dropdown-menu-item">
+			item_wrapper = $(`<div class="dropdown-menu-item" onclick="${
+				item.action ? `return ${item.action}` : ""
+			}">
 				<a>
 					<div class="menu-item-icon" ${!(iconMarkup != "") ? "hidden" : ""}>
 						${iconMarkup}

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -42,12 +42,39 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 			},
 		];
 		if (frappe.boot.desk_settings.notifications) {
-			this.dropdown_items.push({
-				name: "help",
-				label: "Help",
-				icon: "info",
-				items: this.get_help_siblings(),
-			});
+			let is_dark = frappe.ui.get_current_theme() === "dark";
+			this.dropdown_items.push(
+				{
+					name: "help",
+					label: "Help",
+					icon: "info",
+					items: this.get_help_siblings(),
+				},
+				{
+					label: "Session Defaults",
+					action: "frappe.ui.toolbar.setup_session_defaults()",
+					is_standard: 1,
+					icon: "sliders-horizontal",
+				},
+				{
+					label: "Reload",
+					action: "frappe.ui.toolbar.clear_cache()",
+					is_standard: 1,
+					icon: "rotate-ccw",
+				},
+				{
+					label: "Toggle Full Width",
+					action: "frappe.ui.toolbar.toggle_full_width()",
+					is_standard: 1,
+					icon: "maximize",
+				},
+				{
+					label: "Toggle Theme",
+					action: "new frappe.ui.ThemeSwitcher().show()",
+					is_standard: 1,
+					icon: is_dark ? "sun" : "moon",
+				}
+			);
 		}
 		this.make();
 		this.setup_app_switcher();

--- a/frappe/public/js/frappe/ui/theme_switcher.js
+++ b/frappe/public/js/frappe/ui/theme_switcher.js
@@ -161,3 +161,7 @@ frappe.ui.set_theme = (theme) => {
 	}
 	root.setAttribute("data-theme", theme || theme_mode);
 };
+
+frappe.ui.get_current_theme = () => {
+	return document.documentElement.getAttribute("data-theme");
+};


### PR DESCRIPTION
This PR moves the dropdown items which were attached to the avatar to the sidebar dropdown.
Also adds the ability to pass function name as action in menu


<img width="723" height="900" alt="Screenshot 2025-12-30 at 5 59 21 PM" src="https://github.com/user-attachments/assets/33fb6e68-6a85-469f-a491-70fdc26a7cb4" />

Closes a comment in https://github.com/frappe/frappe/issues/35337

The sidebar dropdown has now become very crowded