### PR TITLE
fix(mobile): always bind click to trigger sidebar

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -121,6 +121,7 @@ frappe.ui.toolbar.Toolbar = class {
 			this.add_back_button();
 		} else {
 			this.navbar.html(this.menu);
+			this.bind_click();
 		}
 	}
 };


### PR DESCRIPTION
This was an annoying issue, where doing back and forth between between list and form was then not triggering the sidebar open button (three-line) menu. 


https://github.com/user-attachments/assets/c7904b73-1272-44d6-8b0c-8b2ab3cc378f

