### PR TITLE
feat: more desktop customization 

### DIFF
--- a/frappe/desk/doctype/desktop_icon/desktop_icon.json
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.json
@@ -139,12 +139,6 @@
    "fieldname": "restrict_removal",
    "fieldtype": "Check",
    "label": "Restrict Removal"
-  },
-  {
-   "allow_in_quick_entry": 1,
-   "fieldname": "icon_image",
-   "fieldtype": "Attach",
-   "label": "Icon Image"
   }
  ],
  "links": [],

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.json
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.json
@@ -139,6 +139,12 @@
    "fieldname": "restrict_removal",
    "fieldtype": "Check",
    "label": "Restrict Removal"
+  },
+  {
+   "allow_in_quick_entry": 1,
+   "fieldname": "icon_image",
+   "fieldtype": "Attach",
+   "label": "Icon Image"
   }
  ],
  "links": [],

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -156,6 +156,7 @@ def get_desktop_icons(user=None, bootinfo=None):
 			"hidden",
 			"name",
 			"restrict_removal",
+			"icon_image",
 		]
 
 		standard_icons = frappe.get_all("Desktop Icon", fields=fields, filters={"standard": 1})

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -221,7 +221,6 @@ def create_desktop_icons_from_workspace():
 		icon.link_type = "Workspace Sidebar"
 		icon.label = w.name
 		icon.icon_type = "Link"
-		icon.standard = 1
 		icon.link_to = w.name
 		icon.icon = w.icon
 		if w.module:
@@ -267,7 +266,6 @@ def create_desktop_icons_from_installed_apps():
 				icon = frappe.new_doc("Desktop Icon")
 				icon.label = app_title
 				icon.link_type = "External"
-				icon.standard = 1
 				icon.idx = index
 				icon.icon_type = "App"
 				icon.app = a
@@ -281,3 +279,7 @@ def create_desktop_icons_from_installed_apps():
 def create_desktop_icons():
 	create_desktop_icons_from_installed_apps()
 	create_desktop_icons_from_workspace()
+
+
+def create_user_icons(user, data):
+	print("Hello")

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -282,4 +282,20 @@ def create_desktop_icons():
 
 
 def create_user_icons(user, data):
-	print("Hello")
+	user_settings = json.loads(data)
+	new_icons = user_settings.get("icons_to_create")
+	if new_icons:
+		new_icons = json.loads(user_settings.get("icons_to_create"))
+		if new_icons:
+			for icon in new_icons:
+				try:
+					desktop_icon = frappe.new_doc("Desktop Icon")
+					desktop_icon.update(icon)
+					desktop_icon.owner = user
+					desktop_icon.save()
+				except Exception as e:
+					frappe.log_error("Error in syncing icons", e)
+			user_settings.pop("icons_to_create", None)
+			frappe.cache.hset("_user_settings", f"{'Desktop Icon'}::{user}", json.dumps(user_settings))
+			return json.dumps(user_settings)
+	return data

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -158,79 +158,34 @@ def get_desktop_icons(user=None, bootinfo=None):
 			"restrict_removal",
 		]
 
-		active_domains = frappe.get_active_domains()
-
-		DocType = frappe.qb.DocType("DocType")
-		if active_domains:
-			blocked_condition = (
-				(DocType.restrict_to_domain.isnull())
-				| (DocType.restrict_to_domain == "")
-				| (DocType.restrict_to_domain.notin(active_domains))
-			)
-		else:
-			blocked_condition = (DocType.restrict_to_domain.isnull()) | (DocType.restrict_to_domain == "")
-		blocked_doctypes = [
-			d.get("name")
-			for d in frappe.qb.from_(DocType).select(DocType.name).where(blocked_condition).run(as_dict=True)
-		]
-
 		standard_icons = frappe.get_all("Desktop Icon", fields=fields, filters={"standard": 1})
 
-		standard_map = {}
-
-		for icon in standard_icons:
-			if icon._doctype in blocked_doctypes:
-				icon.blocked = 1
-			standard_map[icon.module_name] = icon
-
 		user_icons = frappe.get_all("Desktop Icon", fields=fields, filters={"standard": 0, "owner": user})
+		user_icons = user_icons + standard_icons
+		# for icon in user_icons:
+		# 	standard_icon = standard_map.get(icon.module_name, None)
 
-		# update hidden property
-		for icon in user_icons:
-			standard_icon = standard_map.get(icon.module_name, None)
+		# 	# override properties from standard icon
+		# 	if standard_icon:
+		# 		for key in ("route", "label", "color", "icon", "link"):
+		# 			if standard_icon.get(key):
+		# 				icon[key] = standard_icon.get(key)
 
-			if icon._doctype in blocked_doctypes:
-				icon.blocked = 1
+		# 		if standard_icon.blocked:
+		# 			icon.hidden = 1
 
-			# override properties from standard icon
-			if standard_icon:
-				for key in ("route", "label", "color", "icon", "link"):
-					if standard_icon.get(key):
-						icon[key] = standard_icon.get(key)
+		# 			# flag for modules_select dialog
+		# 			icon.hidden_in_standard = 1
 
-				if standard_icon.blocked:
-					icon.hidden = 1
-
-					# flag for modules_select dialog
-					icon.hidden_in_standard = 1
-
-				elif standard_icon.force_show:
-					icon.hidden = 0
-
-		# add missing standard icons (added via new install apps?)
-		user_icon_names = [icon.module_name for icon in user_icons]
-		for standard_icon in standard_icons:
-			if standard_icon.module_name not in user_icon_names:
-				# if blocked, hidden too!
-				if standard_icon.blocked:
-					standard_icon.hidden = 1
-					standard_icon.hidden_in_standard = 1
-
-				user_icons.append(standard_icon)
-
-		user_blocked_modules = frappe.get_lazy_doc("User", user).get_blocked_modules()
-		for icon in user_icons:
-			if icon.module_name in user_blocked_modules:
-				icon.hidden = 1
+		# 		elif standard_icon.force_show:
+		# 			icon.hidden = 0
 
 		# sort by idx
+		for icon in user_icons:
+			print(icon.label)
+			print(icon.idx)
 		user_icons.sort(key=lambda a: a.idx)
 
-		# translate
-		# for d in user_icons:
-		# 	if d.label:
-		# 		d.label = _(d.label, context=d.parent)
-		# includes
 		permitted_icons = []
 		permitted_parent_labels = set()
 

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -181,9 +181,6 @@ def get_desktop_icons(user=None, bootinfo=None):
 		# 			icon.hidden = 0
 
 		# sort by idx
-		for icon in user_icons:
-			print(icon.label)
-			print(icon.idx)
 		user_icons.sort(key=lambda a: a.idx)
 
 		permitted_icons = []

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -46,7 +46,6 @@ class DesktopIcon(Document):
 
 	def on_trash(self):
 		clear_desktop_icons_cache()
-		self.check_for_restrict_removal()
 		if frappe.conf.developer_mode and self.standard and self.app:
 			self.delete_desktop_icon_file()
 

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -46,8 +46,13 @@ class DesktopIcon(Document):
 
 	def on_trash(self):
 		clear_desktop_icons_cache()
+		self.check_for_restrict_removal()
 		if frappe.conf.developer_mode and self.standard and self.app:
 			self.delete_desktop_icon_file()
+
+	def check_for_restrict_removal(self):
+		if self.restrict_removal:
+			frappe.throw(_("Cannot delete Desktop Icon '{0}' as it is restricted").format(self.label))
 
 	def on_update(self):
 		allow_export = (
@@ -150,7 +155,7 @@ def get_desktop_icons(user=None, bootinfo=None):
 			"logo_url",
 			"hidden",
 			"name",
-			"sidebar",
+			"restrict_removal",
 		]
 
 		active_domains = frappe.get_active_domains()

--- a/frappe/desk/doctype/desktop_layout/desktop_layout.js
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Desktop Layout", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe/desk/doctype/desktop_layout/desktop_layout.json
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.json
@@ -1,0 +1,55 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:user",
+ "creation": "2026-01-18 02:17:17.304705",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "user",
+  "layout"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "User",
+   "options": "User",
+   "unique": 1
+  },
+  {
+   "fieldname": "layout",
+   "fieldtype": "Code",
+   "label": "Layout",
+   "options": "JSON"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-01-18 02:45:37.287424",
+ "modified_by": "Administrator",
+ "module": "Desk",
+ "name": "Desktop Layout",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/desk/doctype/desktop_layout/desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+import json
+
+import frappe
+from frappe.model.document import Document
+
+
+class DesktopLayout(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		layout: DF.Code | None
+		user: DF.Link | None
+	# end: auto-generated types
+
+	pass
+
+
+@frappe.whitelist()
+def save_layout(user, layout, new_icons):
+	if not user:
+		user = frappe.session.user
+	layout = json.loads(layout)
+	new_icons = json.loads(new_icons)
+	desktop_layout = None
+	try:
+		desktop_layout = frappe.get_doc("Desktop Layout", frappe.session.user)
+	except frappe.DoesNotExistError:
+		frappe.clear_last_message()
+		desktop_layout = frappe.new_doc("Desktop Layout")
+		desktop_layout.user = frappe.session.user
+
+	if layout:
+		desktop_layout.layout = json.dumps(layout)
+		desktop_layout.save()
+
+	for icon in new_icons:
+		desktop_icon = frappe.new_doc("Desktop Icon")
+		desktop_icon.update(icon)
+		desktop_icon.owner = frappe.session.user
+		desktop_icon.save()
+
+	return {"layout": layout}

--- a/frappe/desk/doctype/desktop_layout/test_desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/test_desktop_layout.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestDesktopLayout(IntegrationTestCase):
+	"""
+	Integration tests for DesktopLayout.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -495,3 +495,9 @@
         overflow: scroll;
     }
 }
+
+.add-new-icon{
+    cursor: pointer;
+    gap: 0px;
+    justify-content: center;
+}

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -7,6 +7,7 @@
     --folder-icon-background-color: var(--surface-gray-1);
     --desktop-modal-radius: 30px;
     --desktop-icon-line-height: 115%;
+    --navbar-height: 52px;
 }
 [data-theme="dark"]{
     --folder-icon-background-color: #2b2b2b;
@@ -27,7 +28,7 @@
     width: 100%;
     padding: 10px 20px 10px 20px;
     box-sizing: border-box;
-    height: 52px;
+    height: var(--navbar-height);
     position: sticky;
     top: 0px;
     z-index: 1030;
@@ -103,7 +104,7 @@
     padding: 13px 16px 12px 16px;
     position: relative;
 }
-.desktop-icon.edit-mode .hide-button {
+.desktop-icon.desktop-edit-mode .hide-button {
     display: flex;
 }
 .icon-container:has(.app-logo) {
@@ -337,7 +338,7 @@
     left: 108px;
 }
 
-.edit-mode{
+.desktop-edit-mode{
     border: 1px dashed var(--outline-gray-2);
     border-radius: 20px;
 }
@@ -466,4 +467,32 @@
 }
 .desktop-navbar-modal-search:hover{
     outline: 1px solid var(--surface-gray-3);
+}
+.desktop-pane{
+    position: absolute;
+    top: var(--navbar-height);
+    right: 0px;
+    width: 300px;
+    border-left: 1px solid var(--border-color);
+    background-color: rgba(255,255,255, 1);
+    height: 100vh;
+}
+.pane-header{
+    display: flex;
+    font-size: var(--text-lg);
+    padding: var(--padding-md);
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--border-color);
+}
+.pane-icons-area{
+    height: 100%;
+    .icons-container {
+        height: 100%;
+        margin-top: 0px;
+    }
+    .icons{
+        height: 100%;
+        overflow: scroll;
+    }
 }

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -486,7 +486,6 @@
     border-bottom: 1px solid var(--border-color);
 }
 .pane-icons-area{
-    height: 100%;
     .icons-container {
         height: 100%;
         margin-top: 0px;

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -501,3 +501,32 @@
     gap: 0px;
     justify-content: center;
 }
+
+.title-widget{
+    display: inline-block;
+    position: relative;
+}
+
+.title-input-label{
+  position: absolute;
+  top: 0px;
+  color: var(--neutral-white);
+  line-height: 22px;
+  z-index: 1;
+  pointers-events: none;
+  width: 100%;
+    text-align: center;
+}
+.title-input-wrapper{
+    position: relative;
+    display: inline-block;
+
+}
+
+.title-input-wrapper input{
+  border: 1px solid transparent;
+  width: 100%;
+  height: 100%;
+  background: none;
+    color: var(--neutral-white);
+}

--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -66,11 +66,4 @@
                 {{ _("Save") }}
             </button>
     </div>
-    <div class="desktop-pane hidden">
-        <div class="pane-header">
-            Icons
-            <svg class="close-button icon  icon-sm" style="margin: 0px;cursor: pointer;" aria-hidden="true"><use class="" href="#icon-x"> </use></svg>
-        </div>
-        <div class="pane-icons-area"></div>
-    </div>
 </div>

--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -66,4 +66,11 @@
                 {{ _("Save") }}
             </button>
     </div>
+    <div class="desktop-pane hidden">
+        <div class="pane-header">
+            Icons
+            <svg class="close-button icon  icon-sm" style="margin: 0px;cursor: pointer;" aria-hidden="true"><use class="" href="#icon-x"> </use></svg>
+        </div>
+        <div class="pane-icons-area"></div>
+    </div>
 </div>

--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -65,4 +65,5 @@
                 {{ _("Save") }}
             </button>
     </div>
+    <div class="hidden" id="desktop-layout">{{ desktop_layout }}</pre>
 </div>

--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -53,7 +53,6 @@
             <div class="desktop-avatar">
             </div>
             </div>
-        </div>
 
     </header>
     <div class="desktop-container">

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -331,79 +331,9 @@ class DesktopPage {
 	start_editing_layout() {
 		this.edit_mode = true;
 		const me = this;
-		$(".desktop-icon").not(".folder-icon .desktop-icon").addClass("desktop-edit-mode");
-		$(".desktop-icon")
-			.not(".folder-icon .desktop-icon")
-			.each(function (index, icon) {
-				let icon_data = get_desktop_icon_by_label(icon.dataset.id, null, true);
-				frappe.ui.create_menu({
-					parent: icon,
-					right_click: true,
-					menu_items: [
-						{
-							label: "Edit",
-							icon: "edit",
-							condition: function () {
-								return icon_data.standard != 1;
-							},
-							onClick: function () {
-								frappe.ui.form.make_quick_entry(
-									"Desktop Icon",
-									function (icon) {
-										let old_index = frappe.new_desktop_icons.findIndex(
-											(d_icon) => d_icon.label == icon.label
-										);
-										if (old_index !== -1) {
-											frappe.new_desktop_icons.splice(old_index, 1);
-										}
-										frappe.new_desktop_icons.push(icon);
-										frappe.new_icons.push(icon.name);
-										frappe.pages["desktop"].desktop_page.update();
-									},
-									function (dialog) {
-										dialog.set_df_property("label", "read_only", 1);
-										dialog.fields.forEach((field) => {
-											field.default = icon_data[field.fieldname];
-										});
-										dialog.script_manager.trigger("refresh");
-									},
-									icon_data,
-									null
-								);
-							},
-						},
-						{
-							label: "Create Folder",
-							icon: "folder",
-							onClick: function () {
-								let current_grid;
-								frappe.desktop_grids.forEach((grid) => {
-									if (grid.wrapper.get(0).contains(icon)) {
-										current_grid = grid;
-									}
-								});
-								let folder = current_grid.add_folder();
-								add_icons_to_folder(folder.label, [icon_data.label]);
-							},
-						},
-						{
-							label: "Add To Folder",
-							icon: "folder-open",
-							condition: function () {
-								return me.folders.length > 0;
-							},
-							items: me.folders.map((name) => {
-								return {
-									label: name,
-									onClick: function () {
-										add_icons_to_folder(this.label, [icon_data.label]);
-									},
-								};
-							}),
-						},
-					],
-				});
-			});
+		frappe.desktop_icons_objects.forEach((icon) => {
+			icon.edit_mode = true;
+		});
 		$(".desktop-wrapper").attr("data-mode", "Edit");
 		frappe.desktop_grids.forEach((desktop_grid) => {
 			if (!desktop_grid.no_dragging) {
@@ -411,9 +341,6 @@ class DesktopPage {
 					desktop_grid.setup_reordering(grid);
 				});
 			}
-		});
-		frappe.desktop_icons_objects.forEach((icon_object) => {
-			icon_object.setup_dragging();
 		});
 		this.add_new_icons_to_grid();
 		if (this.edit_mode) {
@@ -777,7 +704,7 @@ class DesktopIconGrid {
 	}
 	make_icons(icons_data, grid) {
 		icons_data.forEach((icon) => {
-			let icon_obj = new DesktopIcon(icon, this.in_folder);
+			let icon_obj = new DesktopIcon(icon, this.in_folder, this);
 			let icon_html = icon_obj.get_desktop_icon_html();
 			this.icons.push(icon_obj);
 			this.icons_html.push(icon_html);
@@ -789,6 +716,9 @@ class DesktopIconGrid {
 		$('[data-toggle="tooltip"]').tooltip({
 			placement: "bottom",
 		});
+	}
+	remove_label_tooltip() {
+		$('[data-toggle="tooltip"]').tooltip("dispose");
 	}
 	setup_reordering(grid) {
 		const me = this;
@@ -879,7 +809,7 @@ class DesktopIconGrid {
 	}
 }
 class DesktopIcon {
-	constructor(icon, in_folder) {
+	constructor(icon, in_folder, grid_obj) {
 		this.icon_data = icon;
 		this.icon_title = this.icon_data.label;
 		this.icon_subtitle = "";
@@ -887,6 +817,7 @@ class DesktopIcon {
 		this.in_folder = in_folder;
 		this.icon_data.in_folder = in_folder;
 		this.link_type = this.icon_data.link_type;
+		this._edit_mode = false;
 		if (this.icon_type != "Folder" && !this.icon_data.sidebar) {
 			this.icon_route = get_route(this.icon_data);
 		}
@@ -905,6 +836,29 @@ class DesktopIcon {
 			this.parent_icon = this.icon_data.icon;
 			this.setup_click();
 			this.render_folder_thumbnail();
+			this.grid = grid_obj;
+			Object.defineProperty(this, "edit_mode", {
+				get: function () {
+					return this._edit_mode;
+				},
+				set: function (value) {
+					if (value) {
+						if (!this.in_folder) {
+							this.icon.addClass("desktop-edit-mode");
+						}
+
+						this.grid.remove_label_tooltip();
+						this.setup_dragging();
+						this.setup_edit_menu();
+						this.icon.removeAttr("href");
+					} else {
+						this.icon.addClass("desktop-edit-mode");
+						this.icon.setup_click();
+					}
+					this._edit_mode = value;
+				},
+			});
+
 			frappe.desktop_icons_objects.push(this);
 		}
 
@@ -931,12 +885,83 @@ class DesktopIcon {
 	get_desktop_icon_html() {
 		return this.icon;
 	}
+	setup_edit_menu() {
+		const me = frappe.pages["desktop"].desktop_page;
+		let icon_data = this.icon_data;
+		const icon = this;
+		frappe.ui.create_menu({
+			parent: this.icon,
+			right_click: true,
+			menu_items: [
+				{
+					label: "Edit",
+					icon: "edit",
+					condition: function () {
+						return icon_data.standard != 1;
+					},
+					onClick: function () {
+						frappe.ui.form.make_quick_entry(
+							"Desktop Icon",
+							function (icon) {
+								let old_index = frappe.new_desktop_icons.findIndex(
+									(d_icon) => d_icon.label == icon.label
+								);
+								if (old_index !== -1) {
+									frappe.new_desktop_icons.splice(old_index, 1);
+								}
+								frappe.new_desktop_icons.push(icon);
+								frappe.new_icons.push(icon.name);
+								frappe.pages["desktop"].desktop_page.update();
+							},
+							function (dialog) {
+								dialog.set_df_property("label", "read_only", 1);
+								dialog.fields.forEach((field) => {
+									field.default = icon_data[field.fieldname];
+								});
+								dialog.script_manager.trigger("refresh");
+							},
+							icon_data,
+							null
+						);
+					},
+				},
+				{
+					label: "Create Folder",
+					icon: "folder",
+					onClick: function () {
+						let folder = me.grid.add_folder();
+						add_icons_to_folder(folder.label, [icon_data.label]);
+					},
+				},
+				{
+					label: "Add To Folder",
+					icon: "folder-open",
+					condition: function () {
+						return me.folders.length > 0;
+					},
+					items: me.folders.map((name) => {
+						return {
+							label: name,
+							onClick: function () {
+								add_icons_to_folder(this.label, [icon_data.label]);
+							},
+						};
+					}),
+				},
+			],
+		});
+	}
+
 	setup_click() {
 		const me = this;
 		if (this.child_icons?.length && (this.icon_type == "App" || this.icon_type == "Folder")) {
 			$(this.icon).on("click", () => {
 				let modal = frappe.desktop_utils.create_desktop_modal(me);
 				modal.setup(me.icon_title, me.child_icons, 4);
+				let $title = modal.modal.find(".modal-title");
+				let title = new InlineEditor($title, this.icon_data.label, function (newValue) {
+					console.log("Init rename");
+				});
 				modal.show();
 			});
 			if (this.icon_type == "App") {
@@ -1110,6 +1135,55 @@ class DesktopPane {
 		const me = this;
 		this.wrapper.find(".close-button").on("click", function () {
 			me.hide();
+		});
+	}
+}
+
+class InlineEditor {
+	constructor(container, initialValue = "", onRename = () => {}) {
+		this.container = container;
+		this.initialValue = initialValue;
+		this.onRename = onRename;
+
+		this.render();
+		this.bindEvents();
+	}
+
+	render() {
+		this.container.html(`
+			<div class="title-widget">
+				<div class="title-input-label">
+					<span>${this.initialValue}</span>
+				</div>
+				<div class="title-input-wrapper">
+					<input class="title-input">
+				</div>
+			</div>
+		`);
+
+		this.input = this.container.find(".title-input");
+		this.label = this.container.find(".title-input-label");
+	}
+
+	bindEvents() {
+		this.container.on("click", () => {
+			this.label.css("visibility", "hidden");
+			this.input.focus().select();
+		});
+
+		this.input.on("keydown", (event) => {
+			if (event.key === "Enter") {
+				const newValue = this.input.val().trim();
+
+				this.label.css("visibility", "visible");
+				this.label.find("span").text(newValue);
+
+				this.onRename(newValue, this);
+			}
+		});
+
+		this.input.on("blur", () => {
+			this.label.css("visibility", "visible");
 		});
 	}
 }

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -599,6 +599,7 @@ class DesktopIconGrid {
 		$.extend(this, opts);
 		this.init();
 	}
+	static folder_count = 0;
 	init() {
 		this.icons = [];
 		this.icons_html = [];
@@ -613,13 +614,12 @@ class DesktopIconGrid {
 		this.prepare();
 		this.make();
 		frappe.desktop_grids.push(this);
-		this.folder_count = 0;
 	}
 	add_folder() {
-		this.folder_count++;
+		DesktopIconGrid.folder_count++;
 		let icon = frappe.model.get_new_doc("Desktop Icon");
 		icon.icon_type = "Folder";
-		icon.label = `Untitled ${this.folder_count}`;
+		icon.label = `Untitled ${DesktopIconGrid.folder_count}`;
 		icon.idx = 100000;
 		frappe.new_desktop_icons.push(icon);
 		frappe.new_icons.push(icon);

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -271,6 +271,7 @@ class DesktopPage {
 		this.setup_awesomebar();
 		this.handle_route_change();
 		this.setup_events();
+		this.setup_edit_button();
 	}
 	setup_edit_button() {
 		if (this.edit_mode || frappe.is_mobile()) return;
@@ -334,6 +335,7 @@ class DesktopPage {
 		const me = this;
 		this.desktop_pane = new IconsPane();
 		$(".desktop-wrapper").attr("data-mode", "Edit");
+		$(".desktop-edit").remove();
 		frappe.desktop_icons_objects.forEach((icon) => {
 			icon.edit_mode = true;
 		});

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -320,12 +320,13 @@ class DesktopPage {
 		this.edit_mode = false;
 		$(".desktop-icon").not(".folder-icon .desktop-icon").removeClass("desktop-edit-mode");
 		$(".desktop-wrapper").removeAttr("data-mode");
+		$(".add-new-icon").remove();
+		this.desktop_pane.hide();
 		if (action === "cancel") {
 			frappe.new_desktop_icons = null;
 			this.sync_layout();
 			return;
 		}
-
 		// submit
 		save_desktop(frappe.new_desktop_icons);
 	}

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -275,7 +275,7 @@ class DesktopPage {
 		this.setup_events();
 	}
 	setup_edit_button() {
-		if (this.edit_mode) return;
+		if (this.edit_mode || frappe.is_mobile()) return;
 		const me = this;
 		$(".desktop-edit").remove();
 		this.$desktop_edit_button = $(

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -95,9 +95,10 @@ function get_route(desktop_icon) {
 	return route;
 }
 
-function get_desktop_icon_by_label(title, filters) {
+function get_desktop_icon_by_label(title, filters, force) {
+	if (force === undefined) force = false;
 	let icons = frappe.desktop_icons;
-	if (frappe.pages["desktop"].desktop_page.edit_mode) {
+	if (!force && frappe.pages["desktop"].desktop_page.edit_mode) {
 		icons = frappe.new_desktop_icons;
 	}
 	if (!filters) {
@@ -155,7 +156,7 @@ class DesktopPage {
 
 	prepare() {
 		this.apps_icons = [];
-
+		this.hidden_icons = [];
 		const icon_map = {};
 		frappe.desktop_icons = this.get_saved_layout() || frappe.boot.desktop_icons;
 		let icons = this.edit_mode ? frappe.new_desktop_icons : frappe.desktop_icons;
@@ -164,6 +165,8 @@ class DesktopPage {
 				icon.child_icons = [];
 				icon_map[icon.label] = icon;
 				return true;
+			} else {
+				this.hidden_icons.push(icon);
 			}
 			return false;
 		});
@@ -185,6 +188,7 @@ class DesktopPage {
 		return JSON.parse(localStorage.getItem(`${frappe.session.user}:desktop`));
 	}
 	setup_events() {
+		const me = this;
 		this.wrapper.find(".hide-button").on("click", function (event) {
 			event.preventDefault();
 			event.stopImmediatePropagation();
@@ -221,6 +225,7 @@ class DesktopPage {
 		this.setup_events();
 	}
 	setup_edit_button() {
+		if (this.edit_mode) return;
 		const me = this;
 		$(".desktop-edit").remove();
 		this.$desktop_edit_button = $(
@@ -241,15 +246,18 @@ class DesktopPage {
 				label: "Edit Layout",
 				icon: "edit",
 				onClick: function () {
+					me.$desktop_edit_button.hide();
 					frappe.new_desktop_icons = JSON.parse(JSON.stringify(frappe.desktop_icons));
 					me.start_editing_layout();
 				},
 			},
 			{
-				label: "Add Desktop Item",
+				label: "Restore Icons",
 				icon: "plus",
 				condition: function () {
-					return me.edit_mode;
+					return (
+						me.edit_mode && frappe.pages.desktop.desktop_page.hidden_icons.length > 0
+					);
 				},
 				onClick: function () {
 					me.desktop_pane.show();
@@ -449,6 +457,9 @@ class DesktopPage {
 class DesktopIconGrid {
 	constructor(opts) {
 		$.extend(this, opts);
+		this.init();
+	}
+	init() {
 		this.icons = [];
 		this.icons_html = [];
 		// this.page_size = {
@@ -463,7 +474,6 @@ class DesktopIconGrid {
 		this.make();
 		frappe.desktop_grids.push(this);
 	}
-
 	prepare() {
 		this.total_pages = 1;
 		this.icons_data = this.icons_data.sort((a, b) => {
@@ -641,9 +651,21 @@ class DesktopIconGrid {
 				sort: true, // keep sorting normally
 				dragoverBubble: true,
 				group: {
-					name: "desktop",
+					name: this.name || "desktop",
 					put: true,
 					pull: true,
+				},
+				onAdd(evt) {
+					if (Sortable.get(evt.from).option("group").name == "hidden-icons-grid") {
+						let icon_name = $(evt.item).attr("data-id");
+						let icon = get_desktop_icon_by_label(icon_name, {}, true);
+						icon.index = evt.newIndex;
+						icon.hidden = 0;
+						frappe.new_desktop_icons.push(icon);
+						let hidden_icons = frappe.pages.desktop.desktop_page.hidden_icons;
+						let added_icon_index = hidden_icons.findIndex((d) => d.label == icon_name);
+						hidden_icons.splice(added_icon_index, 1);
+					}
 				},
 				onStart(evt) {
 					frappe.desktop_utils.dragged_item = evt.item;
@@ -686,6 +708,10 @@ class DesktopIconGrid {
 				},
 			});
 		}
+	}
+	update_grid(icons) {
+		this.wrapper.empty();
+		this.init();
 	}
 	reorder_icons(reordered_icons, filters) {
 		reordered_icons.forEach((d, idx) => {
@@ -829,51 +855,6 @@ class DesktopIcon {
 				}
 			}
 		});
-		// this.icon.on("dragstart", function (event) {
-		// 	frappe.desktop_utils.dragged_item = event.target;
-		// });
-		// this.icon.on("dragover", function (event) {
-		// 	console.log(event.target);
-		// 	if (frappe.desktop_utils.dragged_item == event.target.parentElement) return;
-		// 	if (
-		// 		event.target == frappe.desktop_utils.dragged_item ||
-		// 		frappe.desktop_utils.dragged_item.contains(event.target)
-		// 	) {
-		// 		return;
-		// 	}
-		// 	if (event.target.parentElement.classList.contains("icon-container")) {
-		// 		frappe.desktop_utils.allow_move = false;
-		// 		frappe.desktop_utils.in_folder_creation = true;
-
-		// 		let icon_list = [];
-		// 		icon_list.push(
-		// 			get_desktop_icon_by_label(event.target.parentElement.parentElement.dataset.id)
-		// 		);
-		// 		icon_list.push(
-		// 			get_desktop_icon_by_label(frappe.desktop_utils.dragged_item.dataset.id)
-		// 		);
-
-		// 		let icon = {
-		// 			label: "Untitled Folder",
-		// 			icon_type: "Folder",
-		// 			child_icons: icon_list,
-		// 		};
-		// 		let modal = frappe.desktop_utils.create_desktop_modal(icon);
-		// 		modal.setup(icon.label, icon_list, 4);
-		// 		$(event.target.parentElement).addClass("folder-icon");
-		// 		$(event.target.parentElement).empty();
-		// 		modal.show();
-		// 		frappe.boot.desktop_icons.push(icon);
-		// 		icon_list.forEach((icon) => {
-		// 			let desktop_icon = frappe.utils.get_desktop_icon_by_label(icon.label);
-		// 			desktop_icon.parent_icon = "Untitled Folder";
-		// 			frappe.new_desktop_icons.splice(frappe.boot.desktop_icons.indexOf(icon), 1);
-		// 			frappe.new_desktop_icons.push(desktop_icon);
-		// 		});
-		// 	} else {
-		// 		frappe.desktop_utils.allow_move = true;
-		// 	}
-		// });
 	}
 }
 
@@ -944,18 +925,25 @@ class DesktopModal {
 }
 
 class DesktopPane {
-	constructor() {
-		this.wrapper = $(".desktop-wrapper").find(".desktop-pane");
+	constructor() {}
+	get wrapper() {
+		return $(".desktop-wrapper .desktop-pane");
 	}
 	show() {
 		this.wrapper.removeClass("hidden");
-
-		new DesktopIconGrid({
-			wrapper: $(".desktop-wrapper").find(".desktop-pane").find(".pane-icons-area"),
-			icons_data: frappe.desktop_icons,
+		if (this.grid) {
+			this.grid.icons_data = frappe.pages.desktop.desktop_page.hidden_icons;
+			this.grid.update_grid();
+			return;
+		}
+		this.grid = new DesktopIconGrid({
+			name: "hidden-icons-grid",
+			wrapper: this.wrapper.find(".pane-icons-area"),
+			icons_data: frappe.pages.desktop.desktop_page.hidden_icons,
 			row_size: 2,
 			edit_mode: true,
 		});
+
 		this.setup();
 	}
 	hide() {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -145,6 +145,15 @@ function toggle_icons(icons) {
 	});
 }
 
+function add_icons_to_folder(folder_name, items) {
+	let folder = get_desktop_icon_by_label(folder_name);
+	items.forEach((item) => {
+		let icon = get_desktop_icon_by_label(item);
+		icon.parent_icon = folder.label;
+	});
+	frappe.pages["desktop"].desktop_page.update();
+}
+
 class DesktopPage {
 	constructor(page) {
 		this.page = page;
@@ -158,6 +167,7 @@ class DesktopPage {
 	prepare() {
 		this.apps_icons = [];
 		this.hidden_icons = [];
+		this.folders = [];
 		const icon_map = {};
 		frappe.desktop_icons = this.get_saved_layout() || frappe.boot.desktop_icons;
 		let icons = this.edit_mode ? frappe.new_desktop_icons : frappe.desktop_icons;
@@ -165,6 +175,9 @@ class DesktopPage {
 			if (icon.hidden != 1) {
 				icon.child_icons = [];
 				icon_map[icon.label] = icon;
+				if (icon.icon_type == "Folder") {
+					this.folders.push(icon.label);
+				}
 				return true;
 			} else {
 				this.hidden_icons.push(icon);
@@ -317,6 +330,7 @@ class DesktopPage {
 
 	start_editing_layout() {
 		this.edit_mode = true;
+		const me = this;
 		$(".desktop-icon").not(".folder-icon .desktop-icon").addClass("desktop-edit-mode");
 		$(".desktop-icon")
 			.not(".folder-icon .desktop-icon")
@@ -357,6 +371,35 @@ class DesktopPage {
 									null
 								);
 							},
+						},
+						{
+							label: "Create Folder",
+							icon: "folder",
+							onClick: function () {
+								let current_grid;
+								frappe.desktop_grids.forEach((grid) => {
+									if (grid.wrapper.get(0).contains(icon)) {
+										current_grid = grid;
+									}
+								});
+								let folder = current_grid.add_folder();
+								add_icons_to_folder(folder.label, [icon_data.label]);
+							},
+						},
+						{
+							label: "Add To Folder",
+							icon: "folder-open",
+							condition: function () {
+								return me.folders.length > 0;
+							},
+							items: me.folders.map((name) => {
+								return {
+									label: name,
+									onClick: function () {
+										add_icons_to_folder(this.label, [icon_data.label]);
+									},
+								};
+							}),
 						},
 					],
 				});
@@ -570,6 +613,17 @@ class DesktopIconGrid {
 		this.prepare();
 		this.make();
 		frappe.desktop_grids.push(this);
+		this.folder_count = 0;
+	}
+	add_folder() {
+		this.folder_count++;
+		let icon = frappe.model.get_new_doc("Desktop Icon");
+		icon.icon_type = "Folder";
+		icon.label = `Untitled ${this.folder_count}`;
+		icon.idx = 100000;
+		frappe.new_desktop_icons.push(icon);
+		frappe.new_icons.push(icon);
+		return icon;
 	}
 	prepare() {
 		this.total_pages = 1;
@@ -891,7 +945,7 @@ class DesktopIcon {
 				);
 			}
 		} else {
-			if (this.icon_route.startsWith("http")) {
+			if (this.icon_route && this.icon_route.startsWith("http")) {
 				this.icon.attr("target", "_blank");
 			}
 			this.icon.attr("href", this.icon_route);

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -122,24 +122,7 @@ function get_desktop_icon_by_idx(idx, parent_icon) {
 
 function save_desktop(icons) {
 	// saving in localStorage;
-	frappe.model.user_settings
-		.save("Desktop Icon", "desktop_layout", JSON.stringify(icons))
-		.then((r) => {
-			if (frappe.new_icons.length) {
-				frappe.model.user_settings.get("Desktop Icon").then((user_settings) => {
-					frappe.model.user_settings
-						.save("Desktop Icon", "icons_to_create", JSON.stringify(frappe.new_icons))
-						.then((r) => {
-							frappe.pages["desktop"].desktop_page.sync_layout();
-							frappe.toast("Desktop Saved");
-							frappe.pages["desktop"].desktop_page.sync_layout();
-						});
-				});
-			} else {
-				frappe.toast("Desktop Saved");
-				frappe.pages["desktop"].desktop_page.sync_layout();
-			}
-		});
+	frappe.pages["desktop"].desktop_page.save_layout(icons, frappe.new_icons);
 }
 
 function reset_to_default() {
@@ -180,17 +163,18 @@ class DesktopPage {
 	constructor(page) {
 		this.page = page;
 		this.edit_mode = false;
-		this.sync_layout();
+		this.make(this.page);
+		this.setup();
 	}
 	update() {
-		this.sync_layout();
+		this.make(this.page);
+		this.setup();
 	}
 	prepare() {
 		this.apps_icons = [];
 		this.hidden_icons = [];
 		this.folders = [];
 		const icon_map = {};
-		frappe.desktop_icons = frappe.desktop_icons || frappe.boot.desktop_icons;
 		let icons = this.edit_mode ? frappe.new_desktop_icons : frappe.desktop_icons;
 		const all_icons = icons.filter((icon) => {
 			if (icon.hidden != 1) {
@@ -225,30 +209,40 @@ class DesktopPage {
 	sync_layout() {
 		const me = this;
 		let saved_layout = JSON.parse(localStorage.getItem(`${frappe.session.user}:desktop`));
-		frappe.model.user_settings.get("Desktop Icon").then((user_settings) => {
-			if (!user_settings.desktop_layout && saved_layout) {
-				frappe.model.user_settings.save(
-					"Desktop Icon",
-					"desktop_layout",
-					JSON.stringify(saved_layout)
-				);
-			} else if (user_settings.desktop_layout) {
-				frappe.desktop_icons = JSON.parse(user_settings.desktop_layout);
-			} else {
-				frappe.desktop_icons = frappe.boot.desktop_icons;
-			}
-			me.prepare();
-			me.make(me.page);
-			me.setup();
-		});
+		if (!this.data && saved_layout) {
+			this.save_layout(saved_layout);
+		} else if (Object.keys(this.data).length != 0) {
+			frappe.desktop_icons = this.data;
+		} else {
+			frappe.desktop_icons = frappe.boot.desktop_icons;
+		}
 	}
-	setup_events() {
+	save_layout(layout, new_icons) {
 		const me = this;
+		frappe.call({
+			method: "frappe.desk.doctype.desktop_layout.desktop_layout.save_layout",
+			args: {
+				user: frappe.session.user,
+				layout: JSON.stringify(layout),
+				new_icons: JSON.stringify(new_icons),
+			},
+			callback: function (r) {
+				me.data = r.message.layout;
+				me.make(me.page);
+				me.setup();
+				frappe.new_icons = [];
+			},
+		});
 	}
 	make() {
 		this.page.page_head.hide();
 		$(this.page.body).empty();
 		$(frappe.render_template("desktop")).appendTo(this.page.body);
+		if (!this.data) {
+			this.data = JSON.parse($("#desktop-layout").text());
+		}
+		this.sync_layout();
+		this.prepare();
 		this.wrapper = this.page.body.find(".desktop-container");
 		this.icon_grid = new DesktopIconGrid({
 			wrapper: this.wrapper,
@@ -270,7 +264,6 @@ class DesktopPage {
 		this.setup_navbar();
 		this.setup_awesomebar();
 		this.handle_route_change();
-		this.setup_events();
 		this.setup_edit_button();
 	}
 	setup_edit_button() {
@@ -498,33 +491,6 @@ class DesktopPage {
 			}
 		});
 	}
-
-	// setup_icon_search() {
-	// 	let all_icons = $(".icon-title");
-	// 	let icons_to_show = [];
-	// 	$(".desktop-container .icons").append(
-	// 		"<div class='no-apps-message hidden'> No apps found </div>"
-	// 	);
-	// 	$(".desktop-search-wrapper > #navbar-search").on("input", function (e) {
-	// 		let search_query = $(e.target).val().toLowerCase();
-	// 		console.log(search_query);
-	// 		icons_to_show = [];
-	// 		all_icons.each(function (index, element) {
-	// 			$(element).parent().parent().hide();
-	// 			let label = $(element).text().toLowerCase();
-	// 			if (label.includes(search_query)) {
-	// 				icons_to_show.push(element);
-	// 			}
-	// 		});
-
-	// 		if (icons_to_show.length == 0) {
-	// 			$(".desktop-container .icons").find(".no-apps-message").removeClass("hidden");
-	// 		} else {
-	// 			$(".desktop-container .icons").find(".no-apps-message").addClass("hidden");
-	// 		}
-	// 		toggle_icons(icons_to_show);
-	// 	});
-	// }
 }
 
 class DesktopIconGrid {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -106,13 +106,11 @@ function get_desktop_icon_by_label(title, filters, force) {
 		icons = frappe.new_desktop_icons;
 	}
 	if (!filters) {
-		return icons.find((f) => f.label === title && f.hidden != 1);
+		return icons.find((f) => f.label === title);
 	} else {
 		return icons.find((f) => {
 			return (
-				f.label === title &&
-				Object.keys(filters).every((key) => f[key] === filters[key]) &&
-				f.hidden != 1
+				f.label === title && Object.keys(filters).every((key) => f[key] === filters[key])
 			);
 		});
 	}
@@ -177,7 +175,6 @@ class DesktopPage {
 	update() {
 		this.sync_layout();
 	}
-
 	prepare() {
 		this.apps_icons = [];
 		this.hidden_icons = [];
@@ -233,19 +230,10 @@ class DesktopPage {
 			me.prepare();
 			me.make(me.page);
 			me.setup();
-			me.desktop_pane = new DesktopPane();
 		});
 	}
 	setup_events() {
 		const me = this;
-		this.wrapper.find(".hide-button").on("click", function (event) {
-			event.preventDefault();
-			event.stopImmediatePropagation();
-			let desktop_label = event.currentTarget.parentElement.dataset.id;
-			let desktop_icon = get_desktop_icon_by_label(desktop_label);
-			desktop_icon.hidden = 1;
-			frappe.pages["desktop"].desktop_page.update();
-		});
 	}
 	make() {
 		this.page.page_head.hide();
@@ -302,18 +290,6 @@ class DesktopPage {
 				},
 			},
 			{
-				label: "Restore Icons",
-				icon: "plus",
-				condition: function () {
-					return (
-						me.edit_mode && frappe.pages.desktop.desktop_page.hidden_icons.length > 0
-					);
-				},
-				onClick: function () {
-					me.desktop_pane.show();
-				},
-			},
-			{
 				label: "Reset Layout",
 				icon: "rotate-ccw",
 				onClick: function () {
@@ -345,10 +321,11 @@ class DesktopPage {
 	start_editing_layout() {
 		this.edit_mode = true;
 		const me = this;
+		this.desktop_pane = new IconsPane();
+		$(".desktop-wrapper").attr("data-mode", "Edit");
 		frappe.desktop_icons_objects.forEach((icon) => {
 			icon.edit_mode = true;
 		});
-		$(".desktop-wrapper").attr("data-mode", "Edit");
 		frappe.desktop_grids.forEach((desktop_grid) => {
 			if (!desktop_grid.no_dragging) {
 				desktop_grid.grids.forEach((grid) => {
@@ -359,6 +336,7 @@ class DesktopPage {
 		this.add_new_icons_to_grid();
 		if (this.edit_mode) {
 			this.setup_edit_buttons();
+			this.desktop_pane.show();
 		}
 	}
 	add_new_icons_to_grid() {
@@ -580,6 +558,9 @@ class DesktopIconGrid {
 	make() {
 		const me = this;
 		this.icons_container = $(`<div class="icons-container"></div>`).appendTo(this.wrapper);
+		if (this.compact) {
+			this.icons_container.css("margin-top", "0px");
+		}
 		for (let i = 0; i < this.total_pages; i++) {
 			let template = `<div class="icons"></div>`;
 
@@ -722,9 +703,18 @@ class DesktopIconGrid {
 			let icon_html = icon_obj.get_desktop_icon_html();
 			this.icons.push(icon_obj);
 			this.icons_html.push(icon_html);
+			this.setup_actions_on_icon(icon_obj);
 			grid.append(icon_html);
 		});
 		this.setup_tooltip();
+	}
+	setup_actions_on_icon(icon) {
+		if (this.edit_mode) {
+			icon.edit_mode = true;
+		}
+		if (this.is_pane) {
+			icon.in_pane = true;
+		}
 	}
 	setup_tooltip() {
 		$('[data-toggle="tooltip"]').tooltip({
@@ -832,6 +822,7 @@ class DesktopIcon {
 		this.icon_data.in_folder = in_folder;
 		this.link_type = this.icon_data.link_type;
 		this._edit_mode = false;
+		this.in_pane = false;
 		if (this.icon_type != "Folder" && !this.icon_data.sidebar) {
 			this.icon_route = get_route(this.icon_data);
 		}
@@ -857,27 +848,57 @@ class DesktopIcon {
 				},
 				set: function (value) {
 					if (value) {
-						if (!this.in_folder) {
-							this.icon.addClass("desktop-edit-mode");
+						this.icon.addClass("desktop-edit-mode");
+						if (this.in_folder) {
+							this.icon.removeClass("desktop-edit-mode");
 						}
-
 						this.grid.remove_label_tooltip();
 						this.setup_dragging();
 						this.setup_edit_menu();
+						this.setup_hide_button();
 						this.icon.removeAttr("href");
 					} else {
 						this.icon.addClass("desktop-edit-mode");
-						this.icon.setup_click();
+						this.setup_click();
 					}
 					this._edit_mode = value;
 				},
 			});
-
+			Object.defineProperty(this, "in_pane", {
+				get: function () {
+					return this._in_pane;
+				},
+				set: function (value) {
+					this._in_pane = value;
+					if (value) {
+						this.icon.find(".hide-button").html(frappe.utils.icon("plus"));
+						this.icon.find(".hide-button").attr("data-mode", "add");
+						this.setup_hide_button();
+					} else {
+						this.icon.find(".hide-button").html(frappe.utils.icon("x"));
+						this.icon.find(".hide-button").attr("data-mode", "hide");
+					}
+				},
+			});
 			frappe.desktop_icons_objects.push(this);
 		}
 
 		// this.child_icons = this.get_desktop_icon(this.icon_title).child_icons;
 		// this.child_icons_data = this.get_child_icons_data();
+	}
+	setup_hide_button() {
+		this.icon.find(".hide-button").on("click", function (event) {
+			event.preventDefault();
+			event.stopImmediatePropagation();
+			let desktop_label = event.currentTarget.parentElement.dataset.id;
+			let desktop_icon = get_desktop_icon_by_label(desktop_label);
+			if (event.target.parentElement.dataset.mode == "hide") {
+				desktop_icon.hidden = 1;
+			} else {
+				desktop_icon.hidden = 0;
+			}
+			frappe.pages["desktop"].desktop_page.update();
+		});
 	}
 	validate_icon() {
 		// validate if my workspaces are empty
@@ -1127,10 +1148,9 @@ class DesktopModal {
 	}
 }
 
-class DesktopPane {
-	constructor() {}
-	get wrapper() {
-		return $(".desktop-wrapper .desktop-pane");
+class IconsPane {
+	constructor() {
+		this.wrapper = $($(".desktop-container .icons-container").get(0));
 	}
 	show() {
 		this.wrapper.removeClass("hidden");
@@ -1139,14 +1159,18 @@ class DesktopPane {
 			this.grid.update_grid();
 			return;
 		}
+		this.wrapper.append(
+			"<span style='margin-top: 10px; margin-bottom: 20px'>Removed Icons</span>"
+		);
 		this.grid = new DesktopIconGrid({
 			name: "hidden-icons-grid",
-			wrapper: this.wrapper.find(".pane-icons-area"),
+			wrapper: this.wrapper,
 			icons_data: frappe.pages.desktop.desktop_page.hidden_icons,
-			row_size: 2,
+			row_size: 6,
 			edit_mode: true,
+			compact: true,
+			is_pane: true,
 		});
-
 		this.setup();
 	}
 	hide() {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -188,6 +188,27 @@ class DesktopPage {
 		}
 		return JSON.parse(localStorage.getItem(`${frappe.session.user}:desktop`));
 	}
+	sync_layout() {
+		const me = this;
+		let saved_layout = JSON.parse(localStorage.getItem(`${frappe.session.user}:desktop`));
+		frappe.model.user_settings.get("Desktop Icon").then((user_settings) => {
+			if (!user_settings.desktop_layout && saved_layout) {
+				frappe.model.user_settings.save(
+					"Desktop Icon",
+					"desktop_layout",
+					JSON.stringify(saved_layout)
+				);
+			} else if (user_settings.desktop_layout) {
+				frappe.desktop_icons = JSON.parse(user_settings.desktop_layout);
+			} else {
+				frappe.desktop_icons = frappe.boot.desktop_icons;
+			}
+			me.prepare();
+			me.make(me.page);
+			me.setup();
+			me.desktop_pane = new DesktopPane();
+		});
+	}
 	setup_events() {
 		const me = this;
 		this.wrapper.find(".hide-button").on("click", function (event) {
@@ -282,11 +303,11 @@ class DesktopPage {
 	}
 	stop_editing_layout(action) {
 		this.edit_mode = false;
-		$(".desktop-icon").removeClass("edit-mode");
+		$(".desktop-icon").not(".folder-icon .desktop-icon").removeClass("desktop-edit-mode");
 		$(".desktop-wrapper").removeAttr("data-mode");
 		if (action === "cancel") {
 			frappe.new_desktop_icons = null;
-			this.update();
+			this.sync_layout();
 			return;
 		}
 
@@ -296,7 +317,50 @@ class DesktopPage {
 
 	start_editing_layout() {
 		this.edit_mode = true;
-		$(".desktop-icon").addClass("desktop-edit-mode");
+		$(".desktop-icon").not(".folder-icon .desktop-icon").addClass("desktop-edit-mode");
+		$(".desktop-icon")
+			.not(".folder-icon .desktop-icon")
+			.each(function (index, icon) {
+				let icon_data = get_desktop_icon_by_label(icon.dataset.id, null, true);
+				frappe.ui.create_menu({
+					parent: icon,
+					right_click: true,
+					menu_items: [
+						{
+							label: "Edit",
+							icon: "edit",
+							condition: function () {
+								return icon_data.standard != 1;
+							},
+							onClick: function () {
+								frappe.ui.form.make_quick_entry(
+									"Desktop Icon",
+									function (icon) {
+										let old_index = frappe.new_desktop_icons.findIndex(
+											(d_icon) => d_icon.label == icon.label
+										);
+										if (old_index !== -1) {
+											frappe.new_desktop_icons.splice(old_index, 1);
+										}
+										frappe.new_desktop_icons.push(icon);
+										frappe.new_icons.push(icon.name);
+										frappe.pages["desktop"].desktop_page.update();
+									},
+									function (dialog) {
+										dialog.set_df_property("label", "read_only", 1);
+										dialog.fields.forEach((field) => {
+											field.default = icon_data[field.fieldname];
+										});
+										dialog.script_manager.trigger("refresh");
+									},
+									icon_data,
+									null
+								);
+							},
+						},
+					],
+				});
+			});
 		$(".desktop-wrapper").attr("data-mode", "Edit");
 		frappe.desktop_grids.forEach((desktop_grid) => {
 			if (!desktop_grid.no_dragging) {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -124,18 +124,20 @@ function get_desktop_icon_by_idx(idx, parent_icon) {
 
 function save_desktop(icons) {
 	// saving in localStorage;
-	localStorage.setItem(`${frappe.session.user}:desktop`, JSON.stringify(icons));
-	frappe.toast("Desktop Saved");
-	frappe.pages["desktop"].desktop_page.update();
+	frappe.model.user_settings.save(
+		"Desktop Icon",
+		"desktop_layout",
+		JSON.stringify(icons),
+		(r) => {
+			frappe.toast("Desktop Saved");
+			frappe.pages["desktop"].desktop_page.sync_layout();
+		}
+	);
 }
 
 function reset_to_default() {
-	localStorage.setItem(`${frappe.session.user}:desktop`, null);
+	frappe.model.user_settings.save("Desktop Icon", "desktop_layout", "");
 }
-
-frappe.pages["desktop"].on_page_show = function () {
-	frappe.pages["desktop"].desktop_page.setup();
-};
 
 function toggle_icons(icons) {
 	icons.forEach((i) => {
@@ -147,15 +149,10 @@ class DesktopPage {
 	constructor(page) {
 		this.page = page;
 		this.edit_mode = false;
-		this.prepare();
-		this.make(page);
-		this.setup_events();
-		this.desktop_pane = new DesktopPane();
+		this.sync_layout();
 	}
 	update() {
-		this.prepare();
-		this.make();
-		this.setup();
+		this.sync_layout();
 	}
 
 	prepare() {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -552,9 +552,6 @@ class DesktopIconGrid {
 			}
 			this.grids.push($(template).appendTo(this.icons_container));
 			this.make_icons(this.icons_data_by_page, this.grids[i]);
-			if (this.edit_mode || !this.no_dragging) {
-				this.setup_reordering(this.grids[i]);
-			}
 		}
 		if (!this.in_folder && this.total_pages > 1) {
 			this.add_page_indicators();

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -145,6 +145,20 @@ function toggle_icons(icons) {
 	});
 }
 
+frappe.desktop_utils.get_folder_icons = function (folder_name) {
+	let icons_in_folder = [];
+	let icons = frappe.desktop_icons;
+	if (frappe.pages["desktop"].desktop_page.edit_mode) {
+		icons = frappe.new_desktop_icons;
+	}
+	icons.forEach((icon) => {
+		if (icon.parent_icon == folder_name) {
+			icons_in_folder.push(icon.label);
+		}
+	});
+	return icons_in_folder;
+};
+
 function add_icons_to_folder(folder_name, items) {
 	let folder = get_desktop_icon_by_label(folder_name);
 	items.forEach((item) => {
@@ -959,8 +973,18 @@ class DesktopIcon {
 				let modal = frappe.desktop_utils.create_desktop_modal(me);
 				modal.setup(me.icon_title, me.child_icons, 4);
 				let $title = modal.modal.find(".modal-title");
-				let title = new InlineEditor($title, this.icon_data.label, function (newValue) {
-					console.log("Init rename");
+				let title = new InlineEditor($title, this.icon_data.label, function (
+					old_value,
+					new_value
+				) {
+					let icon = get_desktop_icon_by_label(old_value);
+					let folder_icons = frappe.desktop_utils.get_folder_icons(old_value);
+					if (icon) {
+						icon.label = new_value;
+					}
+					add_icons_to_folder(new_value, folder_icons);
+
+					frappe.pages["desktop"].desktop_page.update();
 				});
 				modal.show();
 			});
@@ -1174,11 +1198,11 @@ class InlineEditor {
 		this.input.on("keydown", (event) => {
 			if (event.key === "Enter") {
 				const newValue = this.input.val().trim();
-
+				this.input.css("display", "none");
 				this.label.css("visibility", "visible");
 				this.label.find("span").text(newValue);
 
-				this.onRename(newValue, this);
+				this.onRename(this.initialValue, newValue, this);
 			}
 		});
 

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -700,7 +700,7 @@ class DesktopIconGrid {
 		});
 	}
 	remove_label_tooltip() {
-		$('[data-toggle="tooltip"]').tooltip("dispose");
+		$('[data-toggle="tooltip"]').tooltip("disable");
 	}
 	setup_reordering(grid) {
 		const me = this;

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -145,6 +145,7 @@ class DesktopPage {
 		this.prepare();
 		this.make(page);
 		this.setup_events();
+		this.desktop_pane = new DesktopPane();
 	}
 	update() {
 		this.prepare();
@@ -245,6 +246,16 @@ class DesktopPage {
 				},
 			},
 			{
+				label: "Add Desktop Item",
+				icon: "plus",
+				condition: function () {
+					return me.edit_mode;
+				},
+				onClick: function () {
+					me.desktop_pane.show();
+				},
+			},
+			{
 				label: "Reset Layout",
 				icon: "rotate-ccw",
 				onClick: function () {
@@ -276,7 +287,7 @@ class DesktopPage {
 
 	start_editing_layout() {
 		this.edit_mode = true;
-		$(".desktop-icon").addClass("edit-mode");
+		$(".desktop-icon").addClass("desktop-edit-mode");
 		$(".desktop-wrapper").attr("data-mode", "Edit");
 		frappe.desktop_grids.forEach((desktop_grid) => {
 			if (!desktop_grid.no_dragging) {
@@ -478,9 +489,9 @@ class DesktopIconGrid {
 			}
 			this.grids.push($(template).appendTo(this.icons_container));
 			this.make_icons(this.icons_data_by_page, this.grids[i]);
-			// if (!this.no_dragging) {
-			// 	this.setup_reordering(this.grids[i]);
-			// }
+			if (this.edit_mode || !this.no_dragging) {
+				this.setup_reordering(this.grids[i]);
+			}
 		}
 		if (!this.in_folder && this.total_pages > 1) {
 			this.add_page_indicators();
@@ -643,9 +654,6 @@ class DesktopIconGrid {
 						return d.icon_title === title;
 					});
 					dataTransfer.setData("text/plain", JSON.stringify(icon.icon_data)); // `dataTransfer` object of HTML5 DragEvent
-				},
-				onMove() {
-					return frappe.desktop_utils.allow_move || false;
 				},
 				onEnd: function (evt) {
 					if (frappe.desktop_utils.in_folder_creation) return;
@@ -821,51 +829,51 @@ class DesktopIcon {
 				}
 			}
 		});
-		this.icon.on("dragstart", function (event) {
-			frappe.desktop_utils.dragged_item = event.target;
-		});
-		this.icon.on("dragover", function (event) {
-			console.log(event.target);
-			if (frappe.desktop_utils.dragged_item == event.target.parentElement) return;
-			if (
-				event.target == frappe.desktop_utils.dragged_item ||
-				frappe.desktop_utils.dragged_item.contains(event.target)
-			) {
-				return;
-			}
-			if (event.target.parentElement.classList.contains("icon-container")) {
-				frappe.desktop_utils.allow_move = false;
-				frappe.desktop_utils.in_folder_creation = true;
+		// this.icon.on("dragstart", function (event) {
+		// 	frappe.desktop_utils.dragged_item = event.target;
+		// });
+		// this.icon.on("dragover", function (event) {
+		// 	console.log(event.target);
+		// 	if (frappe.desktop_utils.dragged_item == event.target.parentElement) return;
+		// 	if (
+		// 		event.target == frappe.desktop_utils.dragged_item ||
+		// 		frappe.desktop_utils.dragged_item.contains(event.target)
+		// 	) {
+		// 		return;
+		// 	}
+		// 	if (event.target.parentElement.classList.contains("icon-container")) {
+		// 		frappe.desktop_utils.allow_move = false;
+		// 		frappe.desktop_utils.in_folder_creation = true;
 
-				let icon_list = [];
-				icon_list.push(
-					get_desktop_icon_by_label(event.target.parentElement.parentElement.dataset.id)
-				);
-				icon_list.push(
-					get_desktop_icon_by_label(frappe.desktop_utils.dragged_item.dataset.id)
-				);
+		// 		let icon_list = [];
+		// 		icon_list.push(
+		// 			get_desktop_icon_by_label(event.target.parentElement.parentElement.dataset.id)
+		// 		);
+		// 		icon_list.push(
+		// 			get_desktop_icon_by_label(frappe.desktop_utils.dragged_item.dataset.id)
+		// 		);
 
-				let icon = {
-					label: "Untitled Folder",
-					icon_type: "Folder",
-					child_icons: icon_list,
-				};
-				let modal = frappe.desktop_utils.create_desktop_modal(icon);
-				modal.setup(icon.label, icon_list, 4);
-				$(event.target.parentElement).addClass("folder-icon");
-				$(event.target.parentElement).empty();
-				modal.show();
-				frappe.boot.desktop_icons.push(icon);
-				icon_list.forEach((icon) => {
-					let desktop_icon = frappe.utils.get_desktop_icon_by_label(icon.label);
-					desktop_icon.parent_icon = "Untitled Folder";
-					frappe.new_desktop_icons.splice(frappe.boot.desktop_icons.indexOf(icon), 1);
-					frappe.new_desktop_icons.push(desktop_icon);
-				});
-			} else {
-				frappe.desktop_utils.allow_move = true;
-			}
-		});
+		// 		let icon = {
+		// 			label: "Untitled Folder",
+		// 			icon_type: "Folder",
+		// 			child_icons: icon_list,
+		// 		};
+		// 		let modal = frappe.desktop_utils.create_desktop_modal(icon);
+		// 		modal.setup(icon.label, icon_list, 4);
+		// 		$(event.target.parentElement).addClass("folder-icon");
+		// 		$(event.target.parentElement).empty();
+		// 		modal.show();
+		// 		frappe.boot.desktop_icons.push(icon);
+		// 		icon_list.forEach((icon) => {
+		// 			let desktop_icon = frappe.utils.get_desktop_icon_by_label(icon.label);
+		// 			desktop_icon.parent_icon = "Untitled Folder";
+		// 			frappe.new_desktop_icons.splice(frappe.boot.desktop_icons.indexOf(icon), 1);
+		// 			frappe.new_desktop_icons.push(desktop_icon);
+		// 		});
+		// 	} else {
+		// 		frappe.desktop_utils.allow_move = true;
+		// 	}
+		// });
 	}
 }
 
@@ -932,5 +940,34 @@ class DesktopModal {
 	}
 	hide() {
 		this.modal.modal("hide");
+	}
+}
+
+class DesktopPane {
+	constructor() {
+		this.wrapper = $(".desktop-wrapper").find(".desktop-pane");
+	}
+	show() {
+		this.wrapper.removeClass("hidden");
+
+		new DesktopIconGrid({
+			wrapper: $(".desktop-wrapper").find(".desktop-pane").find(".pane-icons-area"),
+			icons_data: frappe.desktop_icons,
+			row_size: 2,
+			edit_mode: true,
+		});
+		this.setup();
+	}
+	hide() {
+		this.wrapper.addClass("hidden");
+	}
+	setup() {
+		this.setup_close_button();
+	}
+	setup_close_button() {
+		const me = this;
+		this.wrapper.find(".close-button").on("click", function () {
+			me.hide();
+		});
 	}
 }

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -488,6 +488,7 @@ class DesktopPage {
 				me.edit_mode = false;
 				$(".desktop-icon").removeClass("edit-mode");
 				$(".desktop-wrapper").removeAttr("data-mode");
+				$(".desktop-edit").remove();
 			}
 		});
 	}

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -1,6 +1,7 @@
 frappe.desktop_utils = {};
 frappe.desktop_grids = [];
 frappe.desktop_icons_objects = [];
+frappe.new_icons = [];
 $.extend(frappe.desktop_utils, {
 	modal: null,
 	modal_stack: [],
@@ -211,6 +212,7 @@ class DesktopPage {
 				col: 3,
 			},
 		});
+		this.setup_context_menu();
 		if (this.edit_mode) {
 			this.start_editing_layout();
 		}
@@ -239,7 +241,7 @@ class DesktopPage {
 			me.start_editing_layout();
 		});
 	}
-	setup_editing_mode() {
+	setup_context_menu() {
 		const me = this;
 		let menu_items = [
 			{
@@ -280,7 +282,6 @@ class DesktopPage {
 	}
 	stop_editing_layout(action) {
 		this.edit_mode = false;
-
 		$(".desktop-icon").removeClass("edit-mode");
 		$(".desktop-wrapper").removeAttr("data-mode");
 		if (action === "cancel") {
@@ -307,13 +308,39 @@ class DesktopPage {
 		frappe.desktop_icons_objects.forEach((icon_object) => {
 			icon_object.setup_dragging();
 		});
-		if (this.edit_mode) this.setup_edit_buttons();
+		this.add_new_icons_to_grid();
+		if (this.edit_mode) {
+			this.setup_edit_buttons();
+		}
+	}
+	add_new_icons_to_grid() {
+		let grid = $($(".desktop-container .icons").get(0));
+		let desktop_icon = `<div class="desktop-icon desktop-edit-mode add-new-icon" title="Add New Icon">
+		 ${frappe.utils.icon("plus", "lg")}
+		 New Icon
+		 </div>`;
+		grid.append(desktop_icon);
+		$(".add-new-icon").on("click", function () {
+			frappe.ui.form.make_quick_entry(
+				"Desktop Icon",
+				function (icon) {
+					frappe.new_desktop_icons.push(icon);
+					frappe.new_icons.push(icon.name);
+					frappe.pages["desktop"].desktop_page.update();
+				},
+				"",
+				"",
+				null,
+				true
+			);
+		});
 	}
 	setup_edit_buttons() {
 		const me = this;
 		this.$edit_button = $(".edit-mode-buttons");
 		this.$edit_button.find(".discard").on("click", function () {
 			me.stop_editing_layout("cancel");
+			me.delete_new_icons();
 		});
 		this.$edit_button.find(".save").on("click", function () {
 			me.stop_editing_layout("submit");
@@ -325,6 +352,12 @@ class DesktopPage {
 			full_height: false,
 		});
 	}
+
+	delete_new_icons() {
+		const bulk_operations = new frappe.ui.BulkOperations({ doctype: "Desktop Icon" });
+		bulk_operations.delete(frappe.new_icons);
+	}
+
 	setup_avatar() {
 		$(".desktop-avatar").html(frappe.avatar(frappe.session.user, "avatar-medium"));
 		let is_dark = document.documentElement.getAttribute("data-theme") === "dark";

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -43,6 +43,9 @@ function get_route(desktop_icon) {
 	let item = {};
 	if (desktop_icon.link_type == "External" && desktop_icon.link) {
 		route = window.location.origin + desktop_icon.link;
+		if (desktop_icon.link.startsWith("http") || desktop_icon.link.startsWith("https")) {
+			route = desktop_icon.link;
+		}
 	} else {
 		let sidebar = frappe.boot.workspace_sidebar_item[desktop_icon.label.toLowerCase()];
 		if (desktop_icon.link_type == "Workspace Sidebar" && sidebar) {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -122,31 +122,29 @@ function get_desktop_icon_by_idx(idx, parent_icon) {
 
 function save_desktop(icons) {
 	// saving in localStorage;
-	frappe.model.user_settings.save(
-		"Desktop Icon",
-		"desktop_layout",
-		JSON.stringify(icons),
-		(r) => {
-			frappe.toast("Desktop Saved");
-			frappe.pages["desktop"].desktop_page.sync_layout();
-		}
-	);
-	if (frappe.new_icons.length) {
-		frappe.model.user_settings.get("Desktop Icon").then((user_settings) => {
-			frappe.model.user_settings.save(
-				"Desktop Icon",
-				"icons_to_create",
-				JSON.stringify(frappe.new_icons),
-				(r) => {
-					frappe.pages["desktop"].desktop_page.sync_layout();
-				}
-			);
+	frappe.model.user_settings
+		.save("Desktop Icon", "desktop_layout", JSON.stringify(icons))
+		.then((r) => {
+			if (frappe.new_icons.length) {
+				frappe.model.user_settings.get("Desktop Icon").then((user_settings) => {
+					frappe.model.user_settings
+						.save("Desktop Icon", "icons_to_create", JSON.stringify(frappe.new_icons))
+						.then((r) => {
+							frappe.pages["desktop"].desktop_page.sync_layout();
+							frappe.toast("Desktop Saved");
+							frappe.pages["desktop"].desktop_page.sync_layout();
+						});
+				});
+			} else {
+				frappe.toast("Desktop Saved");
+				frappe.pages["desktop"].desktop_page.sync_layout();
+			}
 		});
-	}
 }
 
 function reset_to_default() {
-	frappe.model.user_settings.save("Desktop Icon", "desktop_layout", "");
+	frappe.model.user_settings.save("Desktop Icon", "icons_to_create", null);
+	frappe.model.user_settings.save("Desktop Icon", "desktop_layout", null);
 }
 
 function toggle_icons(icons) {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -891,6 +891,9 @@ class DesktopIcon {
 				);
 			}
 		} else {
+			if (this.icon_route.startsWith("http")) {
+				this.icon.attr("target", "_blank");
+			}
 			this.icon.attr("href", this.icon_route);
 		}
 		if (this.icon_data.sidebar) {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -316,7 +316,7 @@ class DesktopPage {
 		this.desktop_pane.hide();
 		if (action === "cancel") {
 			frappe.new_desktop_icons = null;
-			this.sync_layout();
+			this.update();
 			return;
 		}
 		// submit

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -131,6 +131,18 @@ function save_desktop(icons) {
 			frappe.pages["desktop"].desktop_page.sync_layout();
 		}
 	);
+	if (frappe.new_icons.length) {
+		frappe.model.user_settings.get("Desktop Icon").then((user_settings) => {
+			frappe.model.user_settings.save(
+				"Desktop Icon",
+				"icons_to_create",
+				JSON.stringify(frappe.new_icons),
+				(r) => {
+					frappe.pages["desktop"].desktop_page.sync_layout();
+				}
+			);
+		});
+	}
 }
 
 function reset_to_default() {
@@ -180,7 +192,7 @@ class DesktopPage {
 		this.hidden_icons = [];
 		this.folders = [];
 		const icon_map = {};
-		frappe.desktop_icons = this.get_saved_layout() || frappe.boot.desktop_icons;
+		frappe.desktop_icons = frappe.desktop_icons || frappe.boot.desktop_icons;
 		let icons = this.edit_mode ? frappe.new_desktop_icons : frappe.desktop_icons;
 		const all_icons = icons.filter((icon) => {
 			if (icon.hidden != 1) {
@@ -341,22 +353,23 @@ class DesktopPage {
 	}
 	add_new_icons_to_grid() {
 		let grid = $($(".desktop-container .icons").get(0));
-		let desktop_icon = `<div class="desktop-icon desktop-edit-mode add-new-icon" title="Add New Icon">
+		this.add_new_icon = `<div class="desktop-icon desktop-edit-mode add-new-icon" title="Add New Icon">
 		 ${frappe.utils.icon("plus", "lg")}
 		 New Icon
 		 </div>`;
-		grid.append(desktop_icon);
+		grid.append(this.add_new_icon);
 		$(".add-new-icon").on("click", function () {
 			frappe.ui.form.make_quick_entry(
 				"Desktop Icon",
 				function (icon) {
 					frappe.new_desktop_icons.push(icon);
-					frappe.new_icons.push(icon.name);
+					frappe.new_icons.push(icon);
 					frappe.pages["desktop"].desktop_page.update();
 				},
 				"",
 				"",
 				null,
+				true,
 				true
 			);
 		});
@@ -367,6 +380,7 @@ class DesktopPage {
 		this.$edit_button.find(".discard").on("click", function () {
 			me.stop_editing_layout("cancel");
 			me.delete_new_icons();
+			$($(".desktop-container .icons").get(0)).find(".add-new-icon").remove();
 		});
 		this.$edit_button.find(".save").on("click", function () {
 			me.stop_editing_layout("submit");
@@ -380,8 +394,7 @@ class DesktopPage {
 	}
 
 	delete_new_icons() {
-		const bulk_operations = new frappe.ui.BulkOperations({ doctype: "Desktop Icon" });
-		bulk_operations.delete(frappe.new_icons);
+		frappe.new_icons = [];
 	}
 
 	setup_avatar() {

--- a/frappe/desk/page/desktop/desktop.py
+++ b/frappe/desk/page/desktop/desktop.py
@@ -13,8 +13,9 @@ def get_context(context):
 	if not brand_logo:
 		brand_logo = frappe.get_hooks("app_logo_url", app_name="frappe")[0]
 	context.brand_logo = brand_logo
-	context.desktop_icons = get_desktop_icons()
-	context.current_user = frappe.session.user
-	# check if system is mac or not
-	context.is_mac = sys.platform == "darwin"
+	try:
+		context.desktop_layout = frappe.get_doc("Desktop Layout", frappe.session.user).layout or {}
+	except frappe.DoesNotExistError:
+		frappe.clear_last_message()
+		context.desktop_layout = {}
 	return context

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -554,3 +554,5 @@ add_to_apps_screen = [
 		"route": app_home,
 	}
 ]
+
+sync_user_settings = {"Desktop Icon": "frappe.desk.doctype.desktop_icon.desktop_icon.create_user_icons"}

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -554,5 +554,3 @@ add_to_apps_screen = [
 		"route": app_home,
 	}
 ]
-
-sync_user_settings = {"Desktop Icon": "frappe.desk.doctype.desktop_icon.desktop_icon.create_user_icons"}

--- a/frappe/model/utils/user_settings.py
+++ b/frappe/model/utils/user_settings.py
@@ -48,13 +48,6 @@ def sync_user_settings():
 	for key, data in frappe.cache.hgetall("_user_settings").items():
 		key = safe_decode(key)
 		doctype, user = key.split("::")  # WTF?
-		hooks = frappe.get_hooks("sync_user_settings")
-
-		methods = hooks.get(doctype, [])
-		for method in methods:
-			updated_data = frappe.call(method, user=user, data=data)
-			data = updated_data
-
 		frappe.db.multisql(
 			{
 				"mariadb": """INSERT INTO `__UserSettings`(`user`, `doctype`, `data`)

--- a/frappe/model/utils/user_settings.py
+++ b/frappe/model/utils/user_settings.py
@@ -40,7 +40,6 @@ def update_user_settings(doctype, user_settings, for_update=False):
 			current = {}
 
 		current.update(user_settings)
-
 	frappe.cache.hset("_user_settings", f"{doctype}::{frappe.session.user}", json.dumps(current))
 
 
@@ -49,6 +48,13 @@ def sync_user_settings():
 	for key, data in frappe.cache.hgetall("_user_settings").items():
 		key = safe_decode(key)
 		doctype, user = key.split("::")  # WTF?
+		hooks = frappe.get_hooks("sync_user_settings")
+
+		methods = hooks.get(doctype, [])
+		for method in methods:
+			updated_data = frappe.call(method, user=user, data=data)
+			data = updated_data
+
 		frappe.db.multisql(
 			{
 				"mariadb": """INSERT INTO `__UserSettings`(`user`, `doctype`, `data`)

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -256,3 +256,4 @@ frappe.patches.v16_0.change_link_type_to_workspace_sidebar
 frappe.patches.v16_0.add_standard_field_in_workspace_sidebar
 execute:frappe.db.set_single_value("Desktop Settings", "icon_style", "Solid")
 execute:frappe.delete_doc_if_exists("Workspace Sidebar", "Productivity")
+frappe.patches.v16_0.unset_standard_field_for_auto_generated_icons

--- a/frappe/patches/v16_0/unset_standard_field_for_auto_generated_icons.py
+++ b/frappe/patches/v16_0/unset_standard_field_for_auto_generated_icons.py
@@ -1,0 +1,18 @@
+import frappe
+from frappe.model.sync import check_if_record_exists
+
+
+def execute():
+	for icon in frappe.get_all("Desktop Icon"):
+		icon_doc = frappe.get_doc("Desktop Icon", icon.name)
+		if (icon_doc.standard and icon_doc.app) and not check_if_record_exists(
+			"app",
+			frappe.get_app_path(icon_doc.app),
+			"Desktop Icon",
+			icon_doc.name,
+		):
+			try:
+				icon_doc.standard = 0
+				icon_doc.save()
+			except Exception as e:
+				print("Error in unsetting standard field", e)

--- a/frappe/public/js/frappe/form/controls/dynamic_link.js
+++ b/frappe/public/js/frappe/form/controls/dynamic_link.js
@@ -13,7 +13,9 @@ frappe.ui.form.ControlDynamicLink = class ControlDynamicLink extends frappe.ui.f
 			} else if (cur_page) {
 				const selector = `input[data-fieldname="${this.df.options}"]`;
 				let input = $(cur_page.page).find(selector);
-				options = input.length ? input.val() : null;
+				options = input.length
+					? input.val()
+					: frappe.model.get_value(this.df.parent, this.docname, this.df.options);
 			}
 		} else {
 			options = frappe.model.get_value(this.df.parent, this.docname, this.df.options);

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -7,7 +7,14 @@ frappe.quick_edit = function (doctype, name) {
 	});
 };
 
-frappe.ui.form.make_quick_entry = (doctype, after_insert, init_callback, doc, force) => {
+frappe.ui.form.make_quick_entry = (
+	doctype,
+	after_insert,
+	init_callback,
+	doc,
+	force,
+	skip_insert
+) => {
 	var trimmed_doctype = doctype.replace(/ /g, "");
 	var controller_name = "QuickEntryForm";
 
@@ -20,19 +27,23 @@ frappe.ui.form.make_quick_entry = (doctype, after_insert, init_callback, doc, fo
 		after_insert,
 		init_callback,
 		doc,
-		force
+		force,
+		skip_insert
 	);
 	return frappe.quick_entry.setup();
 };
 
 frappe.ui.form.QuickEntryForm = class QuickEntryForm extends frappe.ui.Dialog {
-	constructor(doctype, after_insert, init_callback, doc, force) {
-		super({ auto_make: false });
+	constructor(doctype, after_insert, init_callback, doc, force, skip_insert) {
+		super({
+			auto_make: false,
+		});
 		this.doctype = doctype;
 		this.after_insert = after_insert;
 		this.init_callback = init_callback;
 		this.doc = doc;
 		this.force = force ? force : false;
+		this.skip_insert = skip_insert ? skip_insert : false;
 		this.dialog = this; // for backward compatibility
 		this.layout = this;
 	}
@@ -42,6 +53,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm extends frappe.ui.Dialog {
 			frappe.model.with_doctype(this.doctype, () => {
 				this.check_quick_entry_doc();
 				this.set_meta_and_mandatory_fields();
+
 				if (this.is_quick_entry() || this.force) {
 					this.setup_script_manager();
 					this.render_dialog();
@@ -149,18 +161,16 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm extends frappe.ui.Dialog {
 
 	render_dialog() {
 		var me = this;
-
 		this.fields = this.docfields;
 		this.title = this.get_title();
-
 		super.make();
 		this.register_primary_action();
 		this.render_edit_in_full_page_link();
 		this.setup_cmd_enter_for_save();
 
 		this.onhide = () => (frappe.quick_entry = null);
-		this.show();
 
+		this.show();
 		this.refresh_dependency();
 		this.set_defaults();
 
@@ -192,17 +202,49 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm extends frappe.ui.Dialog {
 			if (data) {
 				me.dialog.working = true;
 				me.script_manager.trigger("validate").then(() => {
-					me.insert().then(() => {
-						let messagetxt = __("{1} saved", [__(me.doctype), this.doc.name.bold()]);
+					if (me.skip_insert) {
+						// Skip insert mode - just update the doc and trigger callbacks
+						me.update_doc();
 						me.dialog.animation_speed = "slow";
 						me.dialog.hide();
-						setTimeout(function () {
-							frappe.show_alert({ message: messagetxt, indicator: "green" }, 3);
-						}, 500);
-					});
+
+						// Trigger after_save event
+						if (me.script_manager.has_handler("after_save")) {
+							me.script_manager.trigger("after_save").then(() => {
+								me.handle_after_callbacks();
+							});
+						} else {
+							me.handle_after_callbacks();
+						}
+					} else {
+						// Normal insert mode
+						me.insert().then(() => {
+							let messagetxt = __("{1} saved", [__(me.doctype), me.doc.name.bold()]);
+							me.dialog.animation_speed = "slow";
+							me.dialog.hide();
+							setTimeout(function () {
+								frappe.show_alert(
+									{
+										message: messagetxt,
+										indicator: "green",
+									},
+									3
+								);
+							}, 500);
+						});
+					}
 				});
 			}
 		});
+	}
+
+	handle_after_callbacks() {
+		// Handle callbacks when skip_insert is true
+		if (frappe._from_link) {
+			frappe.ui.form.update_calling_link(this.doc);
+		} else if (this.after_insert) {
+			this.after_insert(this.doc);
+		}
 	}
 
 	insert() {
@@ -291,6 +333,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm extends frappe.ui.Dialog {
 
 	open_form_if_not_list() {
 		if (this.meta.issingle) return;
+
 		let route = frappe.get_route();
 		let doc = this.doc;
 		if (route && !(route[0] === "List" && route[1] === doc.doctype)) {

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -485,3 +485,5 @@ export default class BulkOperations {
 		});
 	}
 }
+
+frappe.ui.BulkOperations = BulkOperations;

--- a/frappe/public/js/frappe/ui/desktop_icon.html
+++ b/frappe/public/js/frappe/ui/desktop_icon.html
@@ -21,7 +21,7 @@
     </div>
     {% } %}
     {% if(!icon.in_folder && !icon.restrict_removal) { %}
-    <div class="hide-button">
+    <div class="hide-button" data-mode="hide">
         {%= frappe.utils.icon("x") %}
     </div>
     {% } %}

--- a/frappe/public/js/frappe/ui/desktop_icon.html
+++ b/frappe/public/js/frappe/ui/desktop_icon.html
@@ -3,9 +3,9 @@
         <div class="icon-container">
             <img class="app-icon" src="{{ frappe.utils.get_desktop_icon(icon.label, frappe.boot.desktop_icon_style) }}" alt="{{ icon.label }}" />
         </div>
-    {% else if (icon.logo_url) { %}
+    {% else if (icon.logo_url || icon.icon_image) { %}
         <div class="icon-container">
-            <img class="app-icon" src="{{ icon.logo_url }}" alt="{{ icon.label }}" />
+            <img class="app-icon" src="{{ icon.logo_url || icon.icon_image }}" alt="{{ icon.label }}" />
         </div>
     {% } else if (icon.icon_type == "Folder") { %}
         <div class="icon-container folder-icon">

--- a/frappe/public/js/frappe/ui/desktop_icon.html
+++ b/frappe/public/js/frappe/ui/desktop_icon.html
@@ -20,7 +20,7 @@
         <div class="icon-subtitle"></div>
     </div>
     {% } %}
-    {% if(!icon.in_folder) { %}
+    {% if(!icon.in_folder && !icon.restrict_removal) { %}
     <div class="hide-button">
         {%= frappe.utils.icon("x") %}
     </div>

--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -139,19 +139,7 @@ frappe.ui.menu = class ContextMenu {
 								me.current_menu.show();
 							}
 						}
-
-						// debugger
-						// if(!current_menu.visible){
-						// 	current_menu.show(event)
-						// }
-						// me.nested_menus.forEach(menu => {
-						// 	if(current_menu == menu) return;
-						// 	menu.hide()
-						// })
 					}
-					// me.nested_menus.forEach((menu) => {
-					// 	menu.hide();
-					// });
 				});
 			} else if (item.items) {
 				$();

--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -45,6 +45,7 @@ frappe.ui.menu = class ContextMenu {
 	}
 	make() {
 		this.template.empty();
+		this.menu_items_to_show = [];
 		this.menu_items.forEach((f) => {
 			f.condition =
 				f.condition ||
@@ -53,13 +54,19 @@ frappe.ui.menu = class ContextMenu {
 				};
 			if (f.condition()) {
 				this.add_menu_item(f);
+				this.menu_items_to_show.push(f);
 			}
 		});
 
 		// if (!$.contains(document.body, this.template[0])) {
 		// 	$(document.body).append(this.template);
 		// }
-		$(document.body).append(this.template);
+
+		// only append if there are items to show
+		if (this.menu_items_to_show.length > 0) {
+			$(document.body).append(this.template);
+		}
+
 		this.set_styles();
 	}
 	set_styles() {

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -17,14 +17,6 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 				items: this.sibling_workspaces,
 			},
 			{
-				name: "desktop",
-				label: __("Desktop"),
-				icon: "layout-grid",
-				onClick: function (el) {
-					frappe.set_route("/desk");
-				},
-			},
-			{
 				name: "edit-sidebar",
 				label: __("Edit Sidebar"),
 				icon: "edit",


### PR DESCRIPTION
Right now, Desktop Customization is limited, The end user is allowed to do the following things

- [x] Reorder Icons
- [x] Hide unwanted icons

In my view this isn't enough you need ability to 

- [x] Create custom icons
- [x] Add a user friendly way to create folders
- [x] Add icons the back to the page which are deleted 

Add Icons back to page/Restore

https://github.com/user-attachments/assets/93e6873c-805e-4cd3-b3d9-38c2398dc02b

Create Custom Icons 
Closes https://github.com/frappe/frappe/issues/35475


https://github.com/user-attachments/assets/3ffa374b-6070-4f29-8f47-928c247bce14

Add your image for icons


https://github.com/user-attachments/assets/f6cb63cc-728c-4b1f-a5f9-8b14726f2892



Refactoring Ideas

1. Use Proxy in JS to have some sort of reactivity 
2. Maybe Split the code in files.


`no-docs`
