### PR TITLE
fix(report_view): enforce print permission for reports

### DIFF
--- a/frappe/public/js/frappe/microtemplate.js
+++ b/frappe/public/js/frappe/microtemplate.js
@@ -187,6 +187,9 @@ frappe.render_pdf = function (html, opts = {}) {
 
 	//Push the HTML content into an element
 	formData.append("html", html);
+	if (opts.doctype) {
+		formData.append("doctype", opts.doctype);
+	}
 	if (opts.orientation) {
 		formData.append("orientation", opts.orientation);
 	}

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1531,6 +1531,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			},
 			{
 				label: __("Print"),
+				condition: () => frappe.model.can_print(this.doctype),
 				action: () => {
 					// prepare rows in their current state, sorted and filtered
 					const rows_in_order = this.datatable.datamanager.rowViewOrder

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -253,7 +253,9 @@ def download_pdf(
 
 
 @frappe.whitelist()
-def report_to_pdf(html, orientation="Landscape"):
+def report_to_pdf(html, orientation="Landscape", doctype=None):
+	if doctype:
+		frappe.has_permission(doctype, "print", throw=True)
 	make_access_log(file_type="PDF", method="PDF", page=html)
 	frappe.local.response.filename = "report.pdf"
 	frappe.local.response.filecontent = get_pdf(html, {"orientation": orientation})


### PR DESCRIPTION
**Problem:**
**fix(Report View):** This PR is a resolution to [Ticket #56128](https://support.frappe.io/helpdesk/tickets/56128?view=VIEW-HD+Ticket-003) and the issue pertains to the fact that in Report View print permissions are not being enforced even though they are enforced on an individual doc level but not at the report level. This creates a security and permission control gap where report-level printing is not respecting the document-level print permissions configured for the role. This PR resolves such inconsistent behavior. This PR fixes #35550 . 

**Before**:
<img width="1320" height="680" alt="image" src="https://github.com/user-attachments/assets/37c919b4-aba1-4e9b-a3d8-6ddf25546608" />

**After**:
<img width="2880" height="1662" alt="image" src="https://github.com/user-attachments/assets/6e4fd428-8886-4eeb-b279-068213203726" />

https://github.com/user-attachments/assets/f7175782-0a0a-49bb-9e38-6a4f882d0f62


fixes #35550 