### PR TITLE
fix: resolve desktop icon reordering issue in edit mode

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -587,44 +587,89 @@ class DesktopIconGrid {
 				},
 				onEnd: function (evt) {
 					if (frappe.desktop_utils.in_folder_creation) return;
-					if (evt.oldIndex !== evt.newIndex) {
-						if (evt.to.parentElement == evt.from.parentElement) {
-							let reordered_icons = me.sortable.toArray();
+					
+					let title = $(evt.item).find(".icon-title").text();
+					let selected_icon = get_desktop_icon_by_label(title);
+					
+					if (!selected_icon) return;
+					
+					// Handle icon movement within the same grid or between grids
+					if (evt.to.parentElement == evt.from.parentElement) {
+						// Same grid - just reorder
+						let reordered_icons = me.sortable.toArray();
+						let filters = {
+							parent_icon: me.parent_icon?.icon_data.label || null,
+						};
+						me.reorder_icons(reordered_icons, filters);
+						me.parent_icon?.render_folder_thumbnail();
+					} else {
+						// Different grids - update parent and reorder both grids
+						let from_grid = $(evt.from.parentElement);
+						let to_grid = $(evt.to.parentElement);
+						
+						// Update the icon's parent
+						selected_icon.parent_icon = me.parent_icon?.icon_data.label || null;
+						selected_icon.idx = evt.newIndex;
+						
+						// Reorder the target grid
+						if (me.sortable) {
+							let to_reordered_icons = me.sortable.toArray();
 							let filters = {
-								parent_icon: me.parent_icon?.icon_data.label || "" || null,
+								parent_icon: me.parent_icon?.icon_data.label || null,
 							};
-							me.reorder_icons(reordered_icons, filters);
-							me.parent_icon?.render_folder_thumbnail();
-						} else {
-							let from = $(evt.from.parentElement);
-							let to = $(evt.to.parentElement);
-							let title = $(evt.item).find(".icon-title").text();
-							let selected_icon = get_desktop_icon_by_label(title);
-							if ($(to.get(0).parentElement)) {
-								me.reorder_icons(me.sortable.toArray());
-								me.reorder_icons(
-									frappe.pages[
-										"desktop"
-									].desktop_page.icon_grid.sortable.toArray()
-								);
-								selected_icon.idx = evt.newIndex;
-								selected_icon.parent_icon = null;
-							}
+							me.reorder_icons(to_reordered_icons, filters);
 						}
+						
+						// Reorder the main desktop grid if moving from folder to main
+						if (frappe.pages["desktop"] && 
+							frappe.pages["desktop"].desktop_page && 
+							frappe.pages["desktop"].desktop_page.icon_grid && 
+							frappe.pages["desktop"].desktop_page.icon_grid.sortable) {
+							let main_reordered = frappe.pages[
+								"desktop"
+							].desktop_page.icon_grid.sortable.toArray();
+							frappe.pages["desktop"].desktop_page.icon_grid.reorder_icons(main_reordered);
+						}
+						
+						// Re-render folder thumbnails
+						me.parent_icon?.render_folder_thumbnail();
 					}
-					// save_desktop();
 				},
 			});
 		}
 	}
 	reorder_icons(reordered_icons, filters) {
-		reordered_icons.forEach((d, idx) => {
-			let icon = get_desktop_icon_by_label(d);
+		if (!reordered_icons || reordered_icons.length === 0) return;
+		
+		// Get the correct icons array based on edit mode
+		let icons_array = frappe.pages["desktop"].desktop_page.edit_mode 
+			? frappe.new_desktop_icons 
+			: frappe.desktop_icons;
+		
+		// Update indices for reordered icons
+		reordered_icons.forEach((label, idx) => {
+			let icon = get_desktop_icon_by_label(label);
 			if (icon) {
 				icon.idx = idx;
+				
+				// Apply filters if provided (e.g., parent_icon)
+				if (filters) {
+					Object.keys(filters).forEach(key => {
+						if (filters[key] !== undefined) {
+							icon[key] = filters[key];
+						}
+					});
+				}
 			}
 		});
-		frappe.desktop_icons.sort((a, b) => a.idx - b.idx);
+		
+		// Sort the entire icons array by idx
+		icons_array.sort((a, b) => {
+			if (a.idx === b.idx) {
+				return a.label.localeCompare(b.label);
+			}
+			return a.idx - b.idx;
+		});
 	}
 	add_to_main_screen(title) {
 		let icon = get_desktop_icon_by_label(title);

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -62,7 +62,7 @@ function get_route(desktop_icon) {
 
 function get_desktop_icon_by_label(title, filters) {
 	let icons = frappe.desktop_icons;
-	if (frappe.pages["desktop"].desktop_page.edit_mode) {
+	if (frappe.pages["desktop"]?.desktop_page?.edit_mode) {
 		icons = frappe.new_desktop_icons;
 	}
 	if (!filters) {
@@ -598,40 +598,39 @@ class DesktopIconGrid {
 						// Same grid - just reorder
 						let reordered_icons = me.sortable.toArray();
 						let filters = {
-							parent_icon: me.parent_icon?.icon_data.label || null,
+							parent_icon: me.parent_icon?.icon_data.label ?? null,
 						};
 						me.reorder_icons(reordered_icons, filters);
 						me.parent_icon?.render_folder_thumbnail();
 					} else {
-						// Different grids - update parent and reorder both grids
-						let from_grid = $(evt.from.parentElement);
-						let to_grid = $(evt.to.parentElement);
+						// Different grids - update parent and reorder both source and target
 						
-						// Update the icon's parent
-						selected_icon.parent_icon = me.parent_icon?.icon_data.label || null;
-						selected_icon.idx = evt.newIndex;
+						// Find the source grid instance
+						let source_grid = frappe.desktop_grids.find(grid => 
+							grid.grids.some(g => g.get(0) === evt.from.parentElement)
+						);
 						
-						// Reorder the target grid
-						if (me.sortable) {
-							let to_reordered_icons = me.sortable.toArray();
-							let filters = {
-								parent_icon: me.parent_icon?.icon_data.label || null,
+						// Update the icon's parent (idx will be set by reorder_icons)
+						selected_icon.parent_icon = me.parent_icon?.icon_data.label ?? null;
+						
+						// Reorder the target grid (where icon landed)
+						let to_reordered_icons = me.sortable.toArray();
+						let target_filters = {
+							parent_icon: me.parent_icon?.icon_data.label ?? null,
+						};
+						me.reorder_icons(to_reordered_icons, target_filters);
+						
+						// Reorder the source grid (where icon came from) to fix sequential indices
+						if (source_grid && source_grid.sortable) {
+							let from_reordered_icons = source_grid.sortable.toArray();
+							let source_filters = {
+								parent_icon: source_grid.parent_icon?.icon_data.label ?? null,
 							};
-							me.reorder_icons(to_reordered_icons, filters);
+							source_grid.reorder_icons(from_reordered_icons, source_filters);
+							source_grid.parent_icon?.render_folder_thumbnail();
 						}
 						
-						// Reorder the main desktop grid if moving from folder to main
-						if (frappe.pages["desktop"] && 
-							frappe.pages["desktop"].desktop_page && 
-							frappe.pages["desktop"].desktop_page.icon_grid && 
-							frappe.pages["desktop"].desktop_page.icon_grid.sortable) {
-							let main_reordered = frappe.pages[
-								"desktop"
-							].desktop_page.icon_grid.sortable.toArray();
-							frappe.pages["desktop"].desktop_page.icon_grid.reorder_icons(main_reordered);
-						}
-						
-						// Re-render folder thumbnails
+						// Re-render target folder thumbnail
 						me.parent_icon?.render_folder_thumbnail();
 					}
 				},
@@ -642,9 +641,12 @@ class DesktopIconGrid {
 		if (!reordered_icons || reordered_icons.length === 0) return;
 		
 		// Get the correct icons array based on edit mode
-		let icons_array = frappe.pages["desktop"].desktop_page.edit_mode 
+		let icons_array = frappe.pages["desktop"]?.desktop_page?.edit_mode 
 			? frappe.new_desktop_icons 
 			: frappe.desktop_icons;
+		
+		// Determine the parent context for this reordering operation
+		let parent_context = filters?.parent_icon ?? null;
 		
 		// Update indices for reordered icons
 		reordered_icons.forEach((label, idx) => {
@@ -663,12 +665,31 @@ class DesktopIconGrid {
 			}
 		});
 		
-		// Sort the entire icons array by idx
-		icons_array.sort((a, b) => {
-			if (a.idx === b.idx) {
-				return a.label.localeCompare(b.label);
+		// Sort only icons with the same parent to avoid mixing different grids
+		// Group by parent_icon and sort each group separately
+		let icons_by_parent = {};
+		icons_array.forEach(icon => {
+			let parent_key = icon.parent_icon ?? null;
+			if (!icons_by_parent[parent_key]) {
+				icons_by_parent[parent_key] = [];
 			}
-			return a.idx - b.idx;
+			icons_by_parent[parent_key].push(icon);
+		});
+		
+		// Sort each group by idx
+		Object.keys(icons_by_parent).forEach(parent_key => {
+			icons_by_parent[parent_key].sort((a, b) => {
+				if (a.idx === b.idx) {
+					return a.label.localeCompare(b.label);
+				}
+				return a.idx - b.idx;
+			});
+		});
+		
+		// Reconstruct the icons_array maintaining parent grouping
+		icons_array.length = 0;
+		Object.keys(icons_by_parent).forEach(parent_key => {
+			icons_array.push(...icons_by_parent[parent_key]);
 		});
 	}
 	add_to_main_screen(title) {
@@ -787,7 +808,7 @@ class DesktopIcon {
 	}
 
 	setup_dragging() {
-		if (!frappe.pages["desktop"].desktop_page.edit_mode) return;
+		if (!frappe.pages["desktop"]?.desktop_page?.edit_mode) return;
 		this.icon.on("drag", (event) => {
 			const mouse_x = event.clientX;
 			const mouse_y = event.clientY;


### PR DESCRIPTION
## Description
Fixes issue where desktop icons behave strangely when moving them during layout editing.

## Issue
Closes #35556

## Steps to Reproduce the Issue
1. Log in and switch to Desk
2. Right Click to "Edit Layout"
3. Move icons around
4. Icons show strange/unpredictable behavior

## Changes Made
- Fixed `reorder_icons` method to properly handle icon movements between grids
- Added null checks to prevent errors when icons are undefined
- Improved handling of icons array selection based on edit mode (new vs current icons)
- Enhanced `onEnd` handler in Sortable to correctly update parent_icon and indices
- Added proper sorting of icons after reordering operations

## Testing
The fix improves the reordering logic by:
- Ensuring the correct icons array is used during edit mode
- Properly updating icon indices when moved within the same grid
- Correctly handling parent_icon updates when moving between different grids
- Maintaining icon order consistency after drag-and-drop operations

## Video Reference
https://youtu.be/qKd6dPLoxIY