### PR TITLE
perf: Reduce memory usage of exif stripping

### DIFF
--- a/frappe/utils/image.py
+++ b/frappe/utils/image.py
@@ -37,13 +37,8 @@ def strip_exif_data(content, content_type) -> bytes:
 	if content_type == "image/jpeg" and original_image.mode in ("RGBA", "P"):
 		original_image = original_image.convert("RGB")
 
-	new_image = Image.new(original_image.mode, original_image.size)
-	new_image.putdata(list(original_image.getdata()))
-	new_image.save(output, format=content_type.split("/")[1])
-
-	content = output.getvalue()
-
-	return content
+	original_image.save(output, format=content_type.split("/")[1], exif=b"")
+	return output.getvalue()
 
 
 def optimize_image(content, content_type, max_width=1024, max_height=768, optimize=True, quality=85):


### PR DESCRIPTION
This was at least 4x inefficient because of:

- Way too many copies of same buffers
- Serialization of binary data to python integers :woozy_face:  using `list()`


<img width="1024" height="558" alt="image" src="https://github.com/user-attachments/assets/3a680757-b03d-4c5a-8fa4-0810b794e196" />
