### PR TITLE
fix: specifiy version for ubuntu and frappe in ci template in boilerp…

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -659,7 +659,7 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+	runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     name: Server
@@ -728,7 +728,7 @@ jobs:
       - name: Setup
         run: |
           pip install frappe-bench
-          bench init --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
+          bench init --frappe-branch version-15 --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
           mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
           mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
 


### PR DESCRIPTION
# Update CI workflow to use Frappe 15 and Ubuntu version 22.04

> Description:

1. Use Frappe version-15 explicitly when initializing the bench.
2. Update the workflow to run on Ubuntu 22.04 for better compatibility.

> Errors : 

- if don't specify the frappe version it will take latest one  
```
   File "<unknown>", line 91
          type ConfType = _dict[str, Any]  # type: ignore[no-any-explicit]
               ^^^^^^^^
      SyntaxError: invalid syntax
```
- if don't specify the Ubuntu version to be 22.04 
```
However the following packages replace it:
  mariadb-client

E: Package 'mariadb-client-10.6' has no installation candidate
```