### PR TITLE
fix: copy title functionality to handle HTML content correctly

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -28,7 +28,7 @@
 </div>
 <div class="sidebar-section sidebar-meta-details border-bottom">
 	<div class="form-details flex {{image_field ? "justify-center" : "justify-between"}}">
-		<span class="ellipsis mr-3 bold form-title-text text-medium" title="{{__("Click to edit")}}">{%= frm.get_title() %}</span>
+		<span class="ellipsis mr-3 bold form-title-text text-medium" title="{{__("Click to edit")}}">{%= frappe.utils.html2text(frm.get_title()) %}</span>
 		<span class="form-name-copy" data-copy="{{
 			frappe.utils.is_html(frm.get_title())
 			? frappe.utils.html2text(frm.get_title())

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -29,7 +29,7 @@
 <div class="sidebar-section sidebar-meta-details border-bottom">
 	<div class="form-details flex {{image_field ? "justify-center" : "justify-between"}}">
 		<span class="ellipsis mr-3 bold form-title-text text-medium" title="{{__("Click to edit")}}">{%= frm.get_title() %}</span>
-		<span class="form-name-copy" data-copy="{{frm.get_title()}}">{%= frappe.utils.icon("copy")%}</span>
+		<span class="form-name-copy" data-copy="{{frappe.utils.is_html(frm.get_title()) ? frappe.utils.html2text(frm.get_title()) : frm.get_title()}}">{%= frappe.utils.icon("copy")%}</span>
 	</div>
 	{% if frm.doc.name != frm.get_title() %}
 	<div class="form-name-container mt-2 flex {{image_field ? "justify-center" : "justify-between"}}">

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -29,7 +29,13 @@
 <div class="sidebar-section sidebar-meta-details border-bottom">
 	<div class="form-details flex {{image_field ? "justify-center" : "justify-between"}}">
 		<span class="ellipsis mr-3 bold form-title-text text-medium" title="{{__("Click to edit")}}">{%= frm.get_title() %}</span>
-		<span class="form-name-copy" data-copy="{{frappe.utils.is_html(frm.get_title()) ? frappe.utils.html2text(frm.get_title()) : frm.get_title()}}">{%= frappe.utils.icon("copy")%}</span>
+		<span class="form-name-copy" data-copy="{{
+			frappe.utils.is_html(frm.get_title())
+			? frappe.utils.html2text(frm.get_title())
+			: frm.get_title()}}"
+		>
+			{%= frappe.utils.icon("copy")%}
+		</span>
 	</div>
 	{% if frm.doc.name != frm.get_title() %}
 	<div class="form-name-container mt-2 flex {{image_field ? "justify-center" : "justify-between"}}">


### PR DESCRIPTION
**Closes:** https://github.com/frappe/frappe/issues/35337#issuecomment-3698761142

### Problem

In the **ToDo** DocType, the title field is **`description`**, which can contain HTML content due to its **Text Editor**.
When rendering the `data-copy` attribute, the value was being used directly, so the copied text included raw HTML instead of plain text.

**Before**
<img width="447" height="357" alt="image" src="https://github.com/user-attachments/assets/3e9433b1-5933-498e-ad14-9634e3a0e8aa" />

---
### Solution

This PR updates the copy logic to properly extract plain text from the title when it contains HTML.
By using `frappe.utils.is_html()` and converting HTML to text when necessary, the copied value now behaves correctly for the ToDo DocType and any other cases where the title includes HTML.

**After**
<img width="285" height="295" alt="image" src="https://github.com/user-attachments/assets/55e6c025-6a8c-4272-b4ad-6c9c359045c8" />


`no-docs`
