### PR TITLE
fix(desk): guard owner/modified_by access in update_user_info

### DIFF
--- a/frappe/desk/doctype/system_health_report/test_system_health_report.py
+++ b/frappe/desk/doctype/system_health_report/test_system_health_report.py
@@ -2,9 +2,10 @@
 # See license.txt
 
 import frappe
+from frappe.desk.form.load import getdoc
 from frappe.tests import IntegrationTestCase
 
 
 class TestSystemHealthReport(IntegrationTestCase):
 	def test_it_works(self):
-		frappe.get_doc("System Health Report")
+		getdoc("System Health Report", "System Health Report")

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -481,8 +481,9 @@ def update_user_info(docinfo, doc=None):
 	users = set()
 
 	if doc:
-		users.add(doc.owner)
-		users.add(doc.modified_by)
+		for field in ("owner", "modified_by"):
+			if getattr(doc, field, None):
+				users.add(getattr(doc, field))
 
 	users.update(d.sender for d in docinfo.communications)
 	users.update(d.user for d in docinfo.shared)

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -482,9 +482,8 @@ def update_user_info(docinfo, doc=None):
 
 	if doc:
 		for field in ("owner", "modified_by"):
-			get_doc_val = getattr(doc, field, None)
-			if get_doc_val:
-				users.add(get_doc_val)
+			if user := doc.get(field):
+				users.add(user)
 
 	users.update(d.sender for d in docinfo.communications)
 	users.update(d.user for d in docinfo.shared)

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -482,8 +482,9 @@ def update_user_info(docinfo, doc=None):
 
 	if doc:
 		for field in ("owner", "modified_by"):
-			if getattr(doc, field, None):
-				users.add(getattr(doc, field))
+			get_doc_val = getattr(doc, field, None)
+			if get_doc_val:
+				users.add(get_doc_val)
 
 	users.update(d.sender for d in docinfo.communications)
 	users.update(d.user for d in docinfo.shared)


### PR DESCRIPTION
Fixes a regression introduced by #35557

This updates the code to safely check for the presence of those fields using `getattr` before adding them to the user list. This preserves the intended upstream behavior while avoiding runtime errors for virtual/single/transient documents.