### PR TITLE
fix(document naming): custom parser should be checked before anything

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -359,6 +359,8 @@ def parse_naming_series(
 				digits = len(e)
 				part = number_generator(name, digits)
 				series_set = True
+		elif method := has_custom_parser(e):
+			part = frappe.get_attr(method[0])(doc, e)
 		elif e == "YY":
 			part = today.strftime("%y")
 		elif e == "MM":
@@ -376,8 +378,6 @@ def parse_naming_series(
 		elif doc and (e.startswith("{") or doc.get(e, _sentinel) is not _sentinel):
 			e = e.replace("{", "").replace("}", "")
 			part = doc.get(e)
-		elif method := has_custom_parser(e):
-			part = frappe.get_attr(method[0])(doc, e)
 		else:
 			part = e
 


### PR DESCRIPTION
...else

Allows all naming series variables to be overriden by hooks

Related to https://github.com/frappe/erpnext/pull/51433
