### PR TITLE
fix: Remove DNT based check

### DIFF
--- a/frappe/public/js/telemetry/index.js
+++ b/frappe/public/js/telemetry/index.js
@@ -42,9 +42,6 @@ class TelemetryManager {
 	}
 
 	can_enable() {
-		if (cint(navigator.doNotTrack)) {
-			return false;
-		}
 		let posthog_available = Boolean(this.telemetry_host && this.project_id);
 		let sentry_available = Boolean(frappe.boot.sentry_dsn);
 		return posthog_available || sentry_available;


### PR DESCRIPTION
Firefox has stopped supporting this checkbox, it has no meaning anymore.

<img width="732" height="240" alt="image" src="https://github.com/user-attachments/assets/b9f0fb70-431c-4443-8456-e1a003961730" />

https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature?as=u&utm_source=inproduct 