### PR TITLE
fix: show tooltip for long filter names

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -93,7 +93,7 @@ frappe.ui.Filter = class {
 		this.filter_edit_area = $(
 			frappe.render_template("edit_filter", {
 				conditions: this.conditions,
-			})
+			}),
 		);
 		this.parent && this.filter_edit_area.appendTo(this.parent.find(".filter-edit-area"));
 		this.make_select();
@@ -365,7 +365,7 @@ frappe.ui.Filter = class {
 	make_tag() {
 		if (!this.field) return;
 		this.$filter_tag = this.get_filter_tag_element().insertAfter(
-			this.parent.find(".active-tag-filters .clear-filters")
+			this.parent.find(".active-tag-filters .clear-filters"),
 		);
 		this.set_filter_button_text();
 		this.bind_tag();
@@ -382,13 +382,15 @@ frappe.ui.Filter = class {
 	}
 
 	set_filter_button_text() {
-		this.$filter_tag.find(".toggle-filter").html(this.get_filter_button_text());
+		let filter_text = this.get_filter_button_text();
+		let $toggle_button = this.$filter_tag.find(".toggle-filter");
+		$toggle_button.html(filter_text).attr("title", frappe.utils.escape_html(filter_text));
 	}
 
 	get_filter_button_text() {
 		let value = this.utils.get_formatted_value(
 			this.field,
-			this.get_selected_label() || this.get_selected_value()
+			this.get_selected_label() || this.get_selected_value(),
 		);
 		return `${__(this.field.df.label)} ${__(this.get_condition())} ${__(value)}`;
 	}

--- a/frappe/public/scss/desk/filters.scss
+++ b/frappe/public/scss/desk/filters.scss
@@ -127,3 +127,15 @@
 .match-type-dropdown-menu {
 	min-width: 100px;
 }
+
+.filter-tag {
+	.toggle-filter {
+		max-width: 250px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		display: inline-block;
+		vertical-align: middle;
+		cursor: pointer;
+	}
+}


### PR DESCRIPTION
## Description

Fixes #35396

When filter names are long, they get truncated with an ellipsis (`...`) but there's no way for users to see the complete filter text. Even hovering over the truncated filter name doesn't show the full text, making it difficult to understand what filter is applied.

## Problem

The issue occurs across all DocTypes when applying filters with long field names or values. Users cannot see the complete filter information, which affects usability and clarity.

## Solution

This PR adds:
1. **Tooltip functionality**: Added `title` attribute to the filter button element that displays the full filter text on hover
2. **CSS truncation**: Added proper CSS styling to ensure long filter names are truncated with ellipsis while maintaining a clean UI
3. **Security**: Used `frappe.utils.escape_html()` to properly escape HTML in tooltips to prevent XSS vulnerabilities

## Changes Made

### JavaScript (`frappe/public/js/frappe/ui/filters/filter.js`)
- Modified `set_filter_button_text()` method to add `title` attribute with full filter text
- Used `frappe.utils.escape_html()` for secure HTML escaping

### CSS (`frappe/public/scss/desk/filters.scss`)
- Added `.filter-tag .toggle-filter` styles with:
  - `max-width: 250px` - Limits filter button width
  - `text-overflow: ellipsis` - Shows ellipsis for overflow
  - `overflow: hidden` - Hides overflow text
  - `white-space: nowrap` - Prevents text wrapping
  - Proper display properties for correct rendering

## Testing

- [x] Verified tooltip appears on hover for long filter names
- [x] Tested truncation works correctly with ellipsis
- [x] Verified across different DocTypes (User, Customer, Item, etc.)
- [x] Confirmed no JavaScript errors in browser console
- [x] Tested with various filter field name lengths

## Checklist

- [x] PR targets `develop` branch
- [x] PR title follows conventional commit format
- [x] Code follows Frappe's style guidelines (Prettier formatted)
- [x] No breaking changes introduced
- [x] Changes are focused on fixing the reported issue
- [x] Includes `closes #35396` to auto-close the issue