### PR TITLE
fix(form): fix calling of parent( ) on a boolean value

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1418,12 +1418,11 @@ frappe.ui.form.Form = class FrappeForm {
 		// Remove actions from menu
 		delete this.custom_buttons[label];
 		let menu_item_label = group ? `${group} > ${label}` : label;
-		let $linkBody = this.page
-			.is_in_group_button_dropdown(
-				this.page.menu,
-				"li > a.grey-link > span",
-				menu_item_label
-			);
+		let $linkBody = this.page.is_in_group_button_dropdown(
+			this.page.menu,
+			"li > a.grey-link > span",
+			menu_item_label
+		);
 
 		if ($linkBody && $linkBody.parent()?.parent()) {
 			$linkBody = $linkBody.parent().parent();

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1423,11 +1423,10 @@ frappe.ui.form.Form = class FrappeForm {
 				this.page.menu,
 				"li > a.grey-link > span",
 				menu_item_label
-			)
-			.parent()
-			.parent();
+			);
 
-		if ($linkBody) {
+		if ($linkBody && $linkBody.parent()?.parent()) {
+			$linkBody = $linkBody.parent().parent();
 			// If last button, remove divider too
 			let $divider = $linkBody.next(".dropdown-divider");
 			if ($divider) $divider.remove();


### PR DESCRIPTION
1. This should be merged into the stable version-15 branch **ASAP**, and whichever have the changes in #24199 merged in them.
2. This closes #35590.

The original change by @safwansamsudeen was very reckless and short-sighted. This code attempts to call the `parent()` method on the result of `is_in_group_button_dropdown()`. While the design of the `is_in_group_button_dropdown()` method itself, which inconsistently returns a `bool` and `object` in `false` and `true` cases respectively, is a debate by itself, not even assuming that the result of the method could be `undefined` is amusing, to put it mildly.

Getting an error this stupid after running `bench update` on the **STABLE** branch is incredibly frustrating.

<img width="963" height="41" alt="Image" src="https://github.com/user-attachments/assets/7e026c54-fc55-4576-af89-d070f41fac49" />