### PR TITLE
fix: add ellipsis to tag labels

### DIFF
--- a/frappe/public/js/frappe/dom.js
+++ b/frappe/public/js/frappe/dom.js
@@ -318,7 +318,7 @@ frappe.get_data_pill = (
 		<button class="data-pill btn" style="${style}">
 			<div class="flex align-center ellipsis">
 				${image ? image : ""}
-				<span class="pill-label">${label} </span>
+				<span class="pill-label ellipsis">${label} </span>
 			</div>
 		</button>
 	`);

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -327,6 +327,7 @@ body[data-route^="Form"] {
 	margin-right: var(--margin-xs);
 	.data-pill {
 		background-color: var(--subtle-fg);
+		min-width: 0;
 	}
 	display: inline-flex;
 }

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -327,7 +327,7 @@ body[data-route^="Form"] {
 	margin-right: var(--margin-xs);
 	.data-pill {
 		background-color: var(--subtle-fg);
-		min-width: 0;
+		max-width: 250px;
 	}
 	display: inline-flex;
 }

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -327,7 +327,7 @@ body[data-route^="Form"] {
 	margin-right: var(--margin-xs);
 	.data-pill {
 		background-color: var(--subtle-fg);
-		max-width: 250px;
+		max-width: 150px;
 	}
 	display: inline-flex;
 }


### PR DESCRIPTION
**Fix:** https://github.com/frappe/frappe/issues/35337#issuecomment-3698765682

**Before**
<img width="580" height="236" alt="image" src="https://github.com/user-attachments/assets/323069c5-914f-4bd6-a8fe-3c4188cfeec0" />

----
**After**
<img width="291" height="99" alt="image" src="https://github.com/user-attachments/assets/36c8e319-5b84-4824-94ad-37765db51863" />

`no-docs`
