### PR TITLE
fix: add ellipsis on sidebar items

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -103,7 +103,8 @@
 		.sidebar-item-label {
 			@include truncate();
 			font-size: var(--text-sm);
-			display: flex;
+			display: block;
+			flex: 1 1 auto;
 			align-items: center;
 			@include transition(all, 0.3s, cubic-bezier(0.4, 0, 0.2, 1));
 			cursor: pointer;


### PR DESCRIPTION
**Fix:** https://github.com/frappe/frappe/issues/35337#issuecomment-3698538656

**Before:**

<img width="266" height="260" alt="image" src="https://github.com/user-attachments/assets/1482d0c2-09d4-4f7a-b177-fa7a77c77de3" />

----
**After**
<img width="209" height="152" alt="image" src="https://github.com/user-attachments/assets/69d7adc7-9979-43d8-b607-80285c5cf8b3" />




`no-docs`
