### PR TITLE
fix(data import): consider fieldname if label is null for col_build

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -1153,7 +1153,8 @@ def build_fields_dict_for_column_matching(parent_doctype):
 	doctypes = [(parent_doctype, None)] + [(df.options, df) for df in parent_meta.get_table_fields()]
 
 	for doctype, table_df in doctypes:
-		translated_table_label = _(table_df.label) if table_df else None
+		table_ref = (table_df.label or table_df.fieldname) if table_df else None
+		translated_table_label = _(table_ref) if table_ref else None
 
 		# name field
 		name_df = frappe._dict(
@@ -1175,7 +1176,7 @@ def build_fields_dict_for_column_matching(parent_doctype):
 		else:
 			name_headers = (
 				f"{table_df.fieldname}.name",  # fieldname
-				f"ID ({table_df.label})",  # label
+				f"ID ({table_ref})",  # label
 				"{} ({})".format(_("ID"), translated_table_label),  # translated label
 			)
 
@@ -1229,7 +1230,7 @@ def build_fields_dict_for_column_matching(parent_doctype):
 					# fieldname
 					f"{table_df.fieldname}.{df.fieldname}",
 					# label
-					f"{label} ({table_df.label})",
+					f"{label} ({table_ref})",
 					# translated label
 					f"{translated_label} ({translated_table_label})",
 				):

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
-from frappe.core.doctype.data_import.importer import Importer
+from frappe.core.doctype.data_import.importer import Importer, build_fields_dict_for_column_matching
 from frappe.tests import IntegrationTestCase
 from frappe.tests.test_query_builder import db_type_is, unimplemented_for
 from frappe.utils import format_duration, getdate
@@ -145,6 +145,22 @@ class TestImporter(IntegrationTestCase):
 		self.assertEqual(updated_doc.table_field_1[0].name, existing_doc.table_field_1[0].name)
 		self.assertEqual(updated_doc.table_field_1[0].child_description, "child description")
 		self.assertEqual(updated_doc.table_field_1_again[0].child_title, "child title again")
+
+	def test_data_import_without_label(self):
+		"""Test fallback to fieldname when label is not set for a table."""
+
+		meta = frappe.get_meta(doctype_name)
+		table_field = meta.get_field("table_field_1")
+		original_label = table_field.label
+		table_field.label = None
+		fields_dict = build_fields_dict_for_column_matching(doctype_name)
+		expected_key = "Child Title (table_field_1)"
+		self.assertIn(
+			expected_key, fields_dict, f"Fallback failed: '{expected_key}' not found in mapping dict"
+		)
+		expected_id_key = "ID (table_field_1)"
+		self.assertIn(expected_id_key, fields_dict, "ID fallback failed")
+		table_field.label = original_label  # maintain sanity in test env
 
 	def get_importer(self, doctype, import_file, update=False, use_sniffer=False):
 		data_import = frappe.new_doc("Data Import")


### PR DESCRIPTION
**fix(data import)**: In Data Import, despite of having correct column names in CSV file, the system is not able to automatically map the columns. When using Data Import to import a ‘Serial and Batch Bundle‘, the system is not able to map the columns of the child table (entries). The columns are correctly labelled in CSV file. When tried to manually map the columns, the table is shown as `(undefined)`. This problem occurs entirely due to the fact that there is no fallback in case label is empty. This PR fixes that by adding a fallback i.e. considering fieldname as a replacement for a null label. This prevents having to manually map columns and respects the fallback process of template builder too.


fixes #35600 