### PR TITLE
fix(navbar): add spacing between buttons in desktop screens

### DIFF
--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -31,7 +31,7 @@
 				<div class="standard-actions flex">
 					<span class="page-icon-group hide hidden-xs hidden-sm"></span>
 					<div class="menu-btn-group hide">
-						<button type="button" class="btn btn-default icon-btn ml-0" data-toggle="dropdown" aria-expanded="false" aria-label="{{ __("Menu") }}">
+						<button type="button" class="btn btn-default icon-btn menu-more-button" data-toggle="dropdown" aria-expanded="false" aria-label="{{ __("Menu") }}">
 							<span>
 								<span class="menu-btn-group-label">
 									<svg class="icon icon-sm">

--- a/frappe/public/scss/desk/mobile.scss
+++ b/frappe/public/scss/desk/mobile.scss
@@ -336,6 +336,13 @@ body {
 				}
 			}
 		}
+		.page-actions {
+			.standard-actions {
+				.menu-btn-group .menu-more-button {
+					margin-left: 0;
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
- Before
<img width="2928" height="900" alt="image" src="https://github.com/user-attachments/assets/bbf951a9-092a-4eba-a05b-3be8ddcbe951" />

- After
<img width="2940" height="1360" alt="image" src="https://github.com/user-attachments/assets/d3e8f29f-cab6-4b6d-bd8c-cbcaf47bc78c" />
