### PR TITLE
fix (ui): [v16] add previous and next buttons back into form

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -318,7 +318,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 		this.page.clear_menu();
 
 		if (frappe.boot.desk_settings.form_sidebar) {
-			// this.make_navigation();
+			this.make_navigation();
 			this.make_menu_items();
 		}
 	}


### PR DESCRIPTION
A line in frappe/public/js/frappe/form/toolbar.js was commented out in https://github.com/frappe/frappe/pull/35536 but it is needed for the previous and next document navigation.  This PR adds it back in to restore those buttons.

Closes https://github.com/frappe/frappe/issues/35597

Before:
<img width="811" height="229" alt="navigation-rc2" src="https://github.com/user-attachments/assets/dfb4467e-e6f1-45bc-bb87-27283b41b746" />


After:
<img width="1002" height="294" alt="navigation-after" src="https://github.com/user-attachments/assets/7a29db30-9987-4bc1-8640-b9c4e34dfced" />

