### PR TITLE
fix: Don't `set_status` to 'Closed' when status is already "Closed"

### DIFF
--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -155,7 +155,7 @@ def close_all_assignments(doctype, name, ignore_permissions=False):
 	assignments = frappe.get_all(
 		"ToDo",
 		fields=["allocated_to", "name"],
-		filters=dict(reference_type=doctype, reference_name=name, status=("!=", "Cancelled")),
+		filters=dict(reference_type=doctype, reference_name=name, status=("not in", ["Cancelled", "Closed"])),
 	)
 	if not assignments:
 		return False


### PR DESCRIPTION
Fixes #35618 (Duplicate Email notifications for removed task assignments)

When a Task is marked as completed, the `close_all_assignments` method is ran twice:
- Once when validating the status:
<img width="303" height="370" alt="image" src="https://github.com/user-attachments/assets/67579b08-f65b-4b43-b270-89b181b4ce69" />

- Once when unassigning the ToDo:
<img width="298" height="372" alt="image" src="https://github.com/user-attachments/assets/a99cc7aa-f261-4bf0-a74b-cad62cf2b7c1" />


In [`close_all_assignments`](https://github.com/frappe/frappe/blob/dbb7de17d5d9e2f20b0856c1acb106187c0fe839/frappe/desk/form/assign_to.py#L154) we should not call `set_status` to "Close" the ToDo if the ToDo is already `Closed`.

This change updates the filter in the `frappe.get_all` call to filter out ToDos that already have the status of `Closed`.

I've tested this locally and it fixes the duplicate email issue.
