### PR TITLE
fix[ui]: add form navigation buttons back

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -59,6 +59,7 @@
   "view_switcher",
   "form_settings_section",
   "form_sidebar",
+  "form_navigation_buttons",
   "timeline",
   "dashboard",
   "show_absolute_datetime_in_timeline",
@@ -850,6 +851,12 @@
    "is_virtual": 1,
    "label": "Active Sessions",
    "options": "User Session Display"
+  },
+  {
+   "default": "1",
+   "fieldname": "form_navigation_buttons",
+   "fieldtype": "Check",
+   "label": "Navigation Buttons"
   }
  ],
  "icon": "fa fa-user",
@@ -903,7 +910,7 @@
   }
  ],
  "make_attachments_public": 1,
- "modified": "2025-12-13 12:53:46.486021",
+ "modified": "2026-01-02 15:31:01.863695",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -48,6 +48,7 @@ desk_properties = (
 	"bulk_actions",
 	"view_switcher",
 	"form_sidebar",
+	"form_navigation_buttons",
 	"timeline",
 	"dashboard",
 )
@@ -96,6 +97,7 @@ class User(Document):
 		follow_created_documents: DF.Check
 		follow_liked_documents: DF.Check
 		follow_shared_documents: DF.Check
+		form_navigation_buttons: DF.Check
 		form_sidebar: DF.Check
 		full_name: DF.Data | None
 		gender: DF.Link | None

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -318,8 +318,11 @@ frappe.ui.form.Toolbar = class Toolbar {
 		this.page.clear_menu();
 
 		if (frappe.boot.desk_settings.form_sidebar) {
-			// this.make_navigation();
 			this.make_menu_items();
+		}
+
+		if (frappe.boot.desk_settings.form_navigation_buttons) {
+			this.make_navigation();
 		}
 	}
 


### PR DESCRIPTION
A line in frappe/public/js/frappe/form/toolbar.js was commented out in https://github.com/frappe/frappe/pull/35536 but it is needed for the previous and next document navigation. This PR adds it back in to restore those buttons.

As requested by @iamejaaz, the option to disable the buttons was added into the User's form settings.

Closes https://github.com/frappe/frappe/issues/35597

New user setting:
<img width="1472" height="1016" alt="image" src="https://github.com/user-attachments/assets/2190c6a4-ae20-485b-bda9-ceab83a14d38" />

Before:
<img width="811" height="229" alt="531577937-ccc7555b-9e6c-4591-b299-e27b2175fb66" src="https://github.com/user-attachments/assets/45932ba6-171c-4fd3-8576-7246ee932a9c" />

After:
<img width="1002" height="294" alt="531577957-a327c7e3-6c83-47f6-82db-7617a487e9cb" src="https://github.com/user-attachments/assets/9571c51d-bfd5-4097-9787-cc13b0346637" />
