### PR TITLE
fix(postgres): make migration patches compatible with Postgres

### DIFF
--- a/frappe/core/doctype/communication_link/patches/copy_communication_date_to_link.py
+++ b/frappe/core/doctype/communication_link/patches/copy_communication_date_to_link.py
@@ -3,11 +3,20 @@ import frappe
 
 # copy communication_date from Communication to Communication Link
 def execute():
-	frappe.db.sql(
-		"""
-        update `tabCommunication Link` cl
-        inner join `tabCommunication` c on cl.parent = c.name
-        set cl.communication_date = c.communication_date
-        where c.communication_date is not null
-    """
+	frappe.db.multisql(
+		{
+			"mariadb": """
+				UPDATE `tabCommunication Link` cl
+				INNER JOIN `tabCommunication` c ON cl.parent = c.name
+				SET cl.communication_date = c.communication_date
+				WHERE c.communication_date IS NOT NULL
+			""",
+			"postgres": """
+				UPDATE "tabCommunication Link" cl
+				SET communication_date = c.communication_date
+				FROM "tabCommunication" c
+				WHERE cl.parent = c.name
+				  AND c.communication_date IS NOT NULL
+			""",
+		}
 	)

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -109,10 +109,16 @@ def drop_index_if_exists(table: str, index: str):
 		return
 
 	try:
-		frappe.db.sql_ddl(f"ALTER TABLE `{table}` DROP INDEX `{index}`")
+		if frappe.db.db_type == "postgres":
+			# Postgres drops indexes with DROP INDEX, not ALTER TABLE ... DROP INDEX
+			safe_index = index.replace('"', '""')
+			frappe.db.sql_ddl(f'DROP INDEX IF EXISTS "{safe_index}"')
+		else:
+			frappe.db.sql_ddl(f"ALTER TABLE `{table}` DROP INDEX `{index}`")
 	except Exception as e:
 		frappe.log_error("Failed to drop index")
 		click.secho(f"x Failed to drop index {index} from {table}\n {e!s}", fg="red")
 		return
 
 	click.echo(f"✓ dropped {index} index from {table}")
+


### PR DESCRIPTION
### Summary

This PR fixes two migration-time issues when running Frappe on PostgreSQL:

1. `copy_communication_date_to_link` used MariaDB-style `UPDATE ... JOIN`, which is not supported on Postgres.
2. `drop_index_if_exists` attempted `ALTER TABLE ... DROP INDEX`, which is also MariaDB-specific.

### Changes

- Rewrite the communication link migration using `frappe.db.multisql`, with:
  - MariaDB: `UPDATE ... JOIN`
  - Postgres: `UPDATE ... SET ... FROM`
- Make `drop_index_if_exists` Postgres-aware by using `DROP INDEX IF EXISTS` while preserving the existing CLI output and behavior.

### Notes

- Changes are intentionally minimal and scoped to migrations/utilities only.
- Existing MariaDB behavior is unchanged.
- Verified by running `bench --site <site> migrate` on PostgreSQL.

This unblocks migrations on Postgres without altering runtime query behavior.
