### PR TITLE
fix(postgres): make migration patches compatible with Postgres

### DIFF
--- a/frappe/core/doctype/communication_link/patches/copy_communication_date_to_link.py
+++ b/frappe/core/doctype/communication_link/patches/copy_communication_date_to_link.py
@@ -6,27 +6,65 @@ def execute():
 	batch_size = 10_000
 
 	while True:
-		frappe.db.sql(
-			"""
-			update `tabCommunication Link` cl
-			inner join `tabCommunication` c on cl.parent = c.name
-			set cl.communication_date = c.communication_date
-			where cl.communication_date is null
-			and c.communication_date is not null
-			limit %s
-			""",
-			(batch_size,),
-		)
+		if frappe.db.db_type == "postgres":
+			# Postgres doesn't support UPDATE..JOIN..LIMIT.
+			# Use UPDATE..FROM and limit via ctid selection.
+			frappe.db.sql(
+				"""
+				UPDATE "tabCommunication Link" cl
+				SET communication_date = c.communication_date
+				FROM "tabCommunication" c
+				WHERE cl.parent = c.name
+				  AND cl.communication_date IS NULL
+				  AND c.communication_date IS NOT NULL
+				  AND cl.ctid IN (
+						SELECT cl2.ctid
+						FROM "tabCommunication Link" cl2
+						JOIN "tabCommunication" c2 ON cl2.parent = c2.name
+						WHERE cl2.communication_date IS NULL
+						  AND c2.communication_date IS NOT NULL
+						LIMIT %s
+				  )
+				""",
+				(batch_size,),
+			)
 
-		frappe.db.commit()
+			frappe.db.commit()
 
-		if not frappe.db.sql(
-			"""
-			select 1 from `tabCommunication Link` cl
-			inner join `tabCommunication` c on cl.parent = c.name
-			where cl.communication_date is null
-			and c.communication_date is not null
-			limit 1
-			"""
-		):
-			break
+			if not frappe.db.sql(
+				"""
+				SELECT 1
+				FROM "tabCommunication Link" cl
+				JOIN "tabCommunication" c ON cl.parent = c.name
+				WHERE cl.communication_date IS NULL
+				  AND c.communication_date IS NOT NULL
+				LIMIT 1
+				"""
+			):
+				break
+
+		else:
+			frappe.db.sql(
+				"""
+				update `tabCommunication Link` cl
+				inner join `tabCommunication` c on cl.parent = c.name
+				set cl.communication_date = c.communication_date
+				where cl.communication_date is null
+				  and c.communication_date is not null
+				limit %s
+				""",
+				(batch_size,),
+			)
+
+			frappe.db.commit()
+
+			if not frappe.db.sql(
+				"""
+				select 1 from `tabCommunication Link` cl
+				inner join `tabCommunication` c on cl.parent = c.name
+				where cl.communication_date is null
+				  and c.communication_date is not null
+				limit 1
+				"""
+			):
+				break

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -109,10 +109,16 @@ def drop_index_if_exists(table: str, index: str):
 		return
 
 	try:
-		frappe.db.sql_ddl(f"ALTER TABLE `{table}` DROP INDEX `{index}`")
+		if frappe.db.db_type == "postgres":
+			# Postgres drops indexes with DROP INDEX, not ALTER TABLE ... DROP INDEX
+			safe_index = index.replace('"', '""')
+			frappe.db.sql_ddl(f'DROP INDEX IF EXISTS "{safe_index}"')
+		else:
+			frappe.db.sql_ddl(f"ALTER TABLE `{table}` DROP INDEX `{index}`")
 	except Exception as e:
 		frappe.log_error("Failed to drop index")
 		click.secho(f"x Failed to drop index {index} from {table}\n {e!s}", fg="red")
 		return
 
 	click.echo(f"✓ dropped {index} index from {table}")
+


### PR DESCRIPTION
### Summary

This PR fixes PostgreSQL-specific failures during v15 migrations.

### Changes

- Make `copy_communication_date_to_link` migration compatible with Postgres.
  - Preserves the existing batched backfill loop.
  - Uses Postgres `UPDATE ... FROM` and limits the batch using `ctid` selection.
  - Keeps the existing MariaDB `UPDATE ... JOIN ... LIMIT` logic unchanged.
- Make `drop_index_if_exists` Postgres-aware by using `DROP INDEX IF EXISTS` instead of `ALTER TABLE ... DROP INDEX`, while preserving current CLI output/behavior.

### Notes

- Changes are intentionally minimal and scoped to migrations/utilities only.
- Verified by running `bench --site <site> migrate` on PostgreSQL.
