### PR TITLE
fix(test): maintain sanity to avoid unexpected test failures in postgres

### DIFF
--- a/frappe/tests/test_sqlite_search.py
+++ b/frappe/tests/test_sqlite_search.py
@@ -47,6 +47,8 @@ class TestSQLiteSearchAPI(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
+		frappe.db.delete("Note")
+		frappe.db.delete("ToDo")
 		cls.search = TestSQLiteSearch()
 		# Clean up any existing test database
 		cls.search.drop_index()


### PR DESCRIPTION
**fix(test)**: This PR fixes the unexpected/flaky test failures in the `test_sqlite_search` Test Suite in Postgres. The test failure was occurring due to contamination in the test suite so we start with a clean slate now and maintain sanity.  This PR is in particular aims to fix the problem that was first noticed in PR #35488 .

**Before**:
```python
 FAIL  test_advanced_scoring_and_ranking (frappe.tests.test_sqlite_search.TestSQLiteSearchAPI.test_advanced_scoring_and_ranking)
Test scoring pipeline, ranking, and result ordering.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/frappe/frappe/apps/frappe/frappe/tests/test_sqlite_search.py", line 286, in test_advanced_scoring_and_ranking
    self.assertGreater(result["score"], 1.0)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
    doc = <sqlite3.Row object at 0x7f1239b7ba60>
    expected_count = 7
    i = 2
    result = {'id': 'Note:1tqau7p5sg', 'score': 0.9689501661767508, 'original_rank': 1, 'bm25_score': -4.160224100821225, 'title': 'Python <mark>Programming</mark> Guide', 'content': 'Learn Python basics and advanced concepts', 'doctype': 'Note', 'name': '1tqau7p5sg', 'author': 'Administrator', 'modified': 1767402500.279039, 'modified_rank': 1}
    results = {'results': [{'id': 'Note:1tqau7p5sg', 'score': 0.9689501661767508, 'original_rank': 1, 'bm25_score': -4.160224100821225, 'title': 'Python <mark>Programming</mark> Guide', 'content': 'Learn Python basics and advanced concepts', 'doctype': 'Note', 'name': '1tqau7p5sg', 'author': 'Administrator', 'modified': 1767402500.279039, 'modified_rank': 1}], 'summary': {'duration': 0.001, 'total_matches': 1, 'returned_matches': 1, 'corrected_words': {'Programming': 'programming'}, 'corrected_query': 'programming', 'title_only': False, 'filtered_matches': 1, 'applied_filters': {}}}
    scores = [1.0156519010037899, 0.9580870408271318, 0.2461334113123132]
    self = <frappe.tests.test_sqlite_search.TestSQLiteSearchAPI testMethod=test_advanced_scoring_and_ranking>
    title_match_found = True
    total_indexed = 63
AssertionError: 0.9689501661767508 not greater than 1.0
```

**After**:
Successfully passes on every run (No more flakiness).

related to #34660 