### PR TITLE
fix(postgres): drop_index_if_exists uses DROP INDEX IF EXISTS

### DIFF
--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -193,10 +193,17 @@ def drop_index_if_exists(table: str, index: str):
 		return
 
 	try:
-		frappe.db.sql_ddl(f"ALTER TABLE `{table}` DROP INDEX `{index}`")
+		if frappe.db.db_type == "postgres":
+			# Postgres drops indexes with DROP INDEX, not ALTER TABLE ... DROP INDEX
+			# Escape any embedded double-quotes defensively
+			safe_index = index.replace('"', '""')
+			frappe.db.sql_ddl(f'DROP INDEX IF EXISTS "{safe_index}"')
+		else:
+			frappe.db.sql_ddl(f"ALTER TABLE `{table}` DROP INDEX `{index}`")
 	except Exception as e:
 		frappe.log_error("Failed to drop index")
 		click.secho(f"x Failed to drop index {index} from {table}\n {e!s}", fg="red")
 		return
 
 	click.echo(f"✓ dropped {index} index from {table}")
+

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -195,7 +195,6 @@ def drop_index_if_exists(table: str, index: str):
 	try:
 		if frappe.db.db_type == "postgres":
 			# Postgres drops indexes with DROP INDEX, not ALTER TABLE ... DROP INDEX
-			# Escape any embedded double-quotes defensively
 			safe_index = index.replace('"', '""')
 			frappe.db.sql_ddl(f'DROP INDEX IF EXISTS "{safe_index}"')
 		else:
@@ -206,4 +205,3 @@ def drop_index_if_exists(table: str, index: str):
 		return
 
 	click.echo(f"✓ dropped {index} index from {table}")
-


### PR DESCRIPTION
### Summary

Fix Postgres migration failure when dropping indexes.

### Context

During `bench --site <site> migrate` on Postgres, patch
`frappe.core.doctype.communication.patches.drop_ref_dt_dn_index`
calls `frappe.database.utils.drop_index_if_exists(...)`.

Current implementation uses MariaDB-only DDL:
`ALTER TABLE ... DROP INDEX ...`

Postgres expects:
`DROP INDEX [IF EXISTS] <index>`

### Change

- If `frappe.db.db_type == "postgres"`, run `DROP INDEX IF EXISTS "<index>"`
- Otherwise keep existing MariaDB behavior
- Preserve existing click output/behavior

Requesting backport to `version-15-hotfix`.
