### PR TITLE
fix: role-perm validation

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1850,9 +1850,9 @@ def validate_permissions(doctype, for_remove=False, alert=False):
 					"{0}: The 'Submit', 'Cancel', and 'Amend' permissions cannot be granted without the 'Write' permission."
 				).format(get_txt(d))
 			)
-		if d.amend and not d.write:
+		if d.amend and not d.create:
 			frappe.throw(
-				_("{0}: The 'Amend' permission cannot be granted without the 'Cancel' permission.").format(
+				_("{0}: The 'Amend' permission cannot be granted without the 'Create' permission.").format(
 					get_txt(d)
 				)
 			)

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1838,34 +1838,84 @@ def validate_permissions(doctype, for_remove=False, alert=False):
 
 	def check_permission_dependency(d):
 		if d.cancel and not d.submit:
-			frappe.throw(_("{0}: Cannot set Cancel without Submit").format(get_txt(d)))
+			frappe.throw(
+				_("{0}: The 'Cancel' permission cannot be granted without the 'Submit' permission.").format(
+					get_txt(d)
+				)
+			)
 
 		if (d.submit or d.cancel or d.amend) and not d.write:
-			frappe.throw(_("{0}: Cannot set Submit, Cancel, Amend without Write").format(get_txt(d)))
+			frappe.throw(
+				_(
+					"{0}: The 'Submit', 'Cancel', and 'Amend' permissions cannot be granted without the 'Write' permission."
+				).format(get_txt(d))
+			)
 		if d.amend and not d.write:
-			frappe.throw(_("{0}: Cannot set Amend without Cancel").format(get_txt(d)))
+			frappe.throw(
+				_("{0}: The 'Amend' permission cannot be granted without the 'Cancel' permission.").format(
+					get_txt(d)
+				)
+			)
 		if d.get("import") and not d.create:
-			frappe.throw(_("{0}: Cannot set Import without Create").format(get_txt(d)))
+			frappe.throw(
+				_("{0}: The 'Import' permission cannot be granted without the 'Create' permission.").format(
+					get_txt(d)
+				)
+			)
 
 	def remove_rights_for_single(d):
 		if not issingle:
 			return
 
-		if d.report:
-			frappe.msgprint(_("Report cannot be set for Single types"))
-			d.report = 0
+		if d.get("report"):
+			d.set("report", 0)
+			frappe.msgprint(
+				_(
+					"{0}: The 'Report' permission was removed because it cannot be granted for a 'single' DocType."
+				).format(get_txt(d))
+			)
+
+		if d.get("import"):
 			d.set("import", 0)
+			frappe.msgprint(
+				_(
+					"{0}: The 'Import' permission was removed because it cannot be granted for a 'single' DocType."
+				).format(get_txt(d))
+			)
+
+		if d.get("export"):
 			d.set("export", 0)
+			frappe.msgprint(
+				_(
+					"{0}: The 'Export' permission was removed because it cannot be granted for a 'single' DocType."
+				).format(get_txt(d))
+			)
 
 	def check_if_submittable(d):
-		if d.submit and not issubmittable:
-			frappe.throw(_("{0}: Cannot set Assign Submit if not Submittable").format(get_txt(d)))
-		elif d.amend and not issubmittable:
-			frappe.throw(_("{0}: Cannot set Assign Amend if not Submittable").format(get_txt(d)))
+		if issubmittable:
+			return
+
+		if d.submit:
+			frappe.throw(
+				_("{0}: The 'Submit' permission cannot be granted for a non-submittable DocType.").format(
+					get_txt(d)
+				)
+			)
+
+		if d.amend:
+			frappe.throw(
+				_("{0}: The 'Amend' permission cannot be granted for a non-submittable DocType.").format(
+					get_txt(d)
+				)
+			)
 
 	def check_if_importable(d):
 		if d.get("import") and not isimportable:
-			frappe.throw(_("{0}: Cannot set import as {1} is not importable").format(get_txt(d), doctype))
+			frappe.throw(
+				_("{0}: The 'Import' permission cannot be granted for a non-importable DocType.").format(
+					get_txt(d)
+				)
+			)
 
 	def validate_permission_for_all_role(d):
 		if frappe.session.user == "Administrator":
@@ -1875,7 +1925,7 @@ def validate_permissions(doctype, for_remove=False, alert=False):
 			if d.role in AUTOMATIC_ROLES:
 				frappe.throw(
 					_(
-						"Row # {0}: Non administrator user can not set the role {1} to the custom doctype"
+						"Row # {0}: Non-administrator users cannot add the role {1} to a custom DocType."
 					).format(d.idx, frappe.bold(_(d.role))),
 					title=_("Permissions Error"),
 				)
@@ -1885,7 +1935,7 @@ def validate_permissions(doctype, for_remove=False, alert=False):
 			if d.role in roles:
 				frappe.throw(
 					_(
-						"Row # {0}: Non administrator user can not set the role {1} to the custom doctype"
+						"Row # {0}: Non-administrator users cannot add the role {1} to a custom DocType."
 					).format(d.idx, frappe.bold(_(d.role))),
 					title=_("Permissions Error"),
 				)


### PR DESCRIPTION
This pull request focuses on improving the clarity and user-friendliness of permission validation messages in the `frappe/core/doctype/doctype/doctype.py` file. The changes include rewriting error and info messages for better guidance, ensuring consistency, and providing more detailed feedback when permissions are set incorrectly or automatically adjusted.

**Logic change**:

```diff
- if d.amend and not d.write:
-	frappe.throw(_("{0}: Cannot set Amend without Cancel").format(get_txt(d)))

+ if d.amend and not d.create:
+	frappe.throw(
+		_("{0}: The 'Amend' permission cannot be granted without the 'Create' permission.").format(
+			get_txt(d)
+		)
+	)
```

The previous code made no sense because it checked for 'write' but complained about 'cancel' perms. Changing the message to 'write' also did not make sense because it would duplicate the preceding check. Logically, the only missing check was that 'amend' implicitly requires 'create' perms.