### PR TITLE
fix(link_selector): add margin above "More" button for better spacing

### DIFF
--- a/frappe/public/js/frappe/form/link_selector.js
+++ b/frappe/public/js/frappe/form/link_selector.js
@@ -156,6 +156,7 @@ frappe.ui.form.LinkSelector = class LinkSelector {
 						});
 				}
 
+				parent.append('<div style="margin-bottom: 15px;"></div>');
 				var more_btn = me.dialog.fields_dict.more.$wrapper;
 				if (results.length < me.page_length) {
 					more_btn.hide();


### PR DESCRIPTION
**Before:**

<img width="948" height="735" alt="ScreenShot Tool -20260104182636" src="https://github.com/user-attachments/assets/fdf2adcb-9eb3-4398-b7f3-cc9a620c8261" />

---
**After**
<img width="1325" height="733" alt="ScreenShot Tool -20260104183238" src="https://github.com/user-attachments/assets/bdd7178a-19f6-44e8-9faa-ace3fbdfd7d3" />
