### PR TITLE
fix(desktop): improve edit button visibility in light/dark theme 

### DIFF
--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -446,9 +446,20 @@
     bottom: 4%;
     right: 4%;
     z-index: 100;
-    opacity: 0.1;
+    opacity: 0.5;
 }
+
 .desktop-edit:hover{
     opacity: 1;
     transition: opacity 0.3s;
+}
+
+[data-theme="dark"] .desktop-edit{
+	background-color: var(--surface-gray-3);
+	opacity: 1;
+}
+
+[data-theme="dark"] .desktop-edit:hover{
+	opacity: 0.8;
+	transition: opacity 0.3s;
 }


### PR DESCRIPTION
**Closes:** https://github.com/frappe/frappe/issues/34734#issuecomment-3705355979 , https://github.com/frappe/frappe/issues/35337#issuecomment-3708098376

---

https://github.com/user-attachments/assets/78c933ea-455e-457f-a8e7-18e88c47d1c4


`no-docs`

