### PR TITLE
fix: check for configuration when allowing private toggle

### DIFF
--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -465,7 +465,13 @@ def run_ui_tests(
 
 	os.chdir(app_base_path)
 
-	node_bin = subprocess.getoutput("(cd ../frappe && yarn bin)")
+	node_bin = subprocess.run(
+		"(cd ../frappe && yarn bin)",
+		shell=True,
+		stdout=subprocess.PIPE,
+		stderr=subprocess.DEVNULL,
+		text=True,
+	).stdout.strip()
 	cypress_path = f"{node_bin}/cypress"
 	drag_drop_plugin_path = f"{node_bin}/../@4tw/cypress-drag-drop"
 	real_events_plugin_path = f"{node_bin}/../cypress-real-events"

--- a/frappe/public/js/frappe/file_uploader/FilePreview.vue
+++ b/frappe/public/js/frappe/file_uploader/FilePreview.vue
@@ -138,13 +138,6 @@ let allow_toggle_optimize = computed(() => {
 	);
 });
 
-let allow_toggle_private = computed(() => {
-	if (!frappe.utils.can_upload_public_files()) {
-		return false;
-	}
-	return props.allow_toggle_private;
-});
-
 let show_private_checkbox = computed(() => {
 	return !uploaded.value && !props.file.failed;
 });

--- a/frappe/public/js/frappe/file_uploader/file_uploader.bundle.js
+++ b/frappe/public/js/frappe/file_uploader/file_uploader.bundle.js
@@ -30,7 +30,14 @@ class FileUploader {
 	} = {}) {
 		frm && frm.attachments.max_reached(true);
 
-		this.can_toggle_private = frappe.utils.can_upload_public_files();
+		if (allow_toggle_private === undefined) {
+			allow_toggle_private = true;
+		}
+
+		allow_toggle_private = Boolean(
+			allow_toggle_private && frappe.utils.can_upload_public_files()
+		);
+		this.can_toggle_private = allow_toggle_private;
 
 		if (!wrapper) {
 			this.make_dialog(dialog_title);


### PR DESCRIPTION
if the "private?" checkbox is hidden the "set all private" / "set  all public" secondary button is now hidden as well. previously `allow_toggle_private` did not affect "set all private"