### PR TITLE
fix: add permission conditions to where clause instead of join

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1833,13 +1833,11 @@ class LinkTableField(DynamicTableField):
 		table = frappe.qb.DocType(self.doctype)
 		main_table = frappe.qb.DocType(self.parent_doctype)
 		if not query.is_joined(table):
-			clause = table.name == getattr(main_table, self.link_fieldname)
-
+			query = query.left_join(table).on(table.name == getattr(main_table, self.link_fieldname))
 			if engine and engine.apply_permissions:
 				if condition := engine.get_permission_conditions(self.doctype, table):
-					clause &= condition
+					query = query.where(condition)
 
-			query = query.left_join(table).on(clause)
 		return query
 
 


### PR DESCRIPTION
this feels more correct. adding to join condition will give null values if permission conditions fail (even when values do exist in DB).