### PR TITLE
fix: add missing translation for "Next Actions" label

### DIFF
--- a/frappe/core/doctype/success_action/success_action.js
+++ b/frappe/core/doctype/success_action/success_action.js
@@ -41,7 +41,7 @@ frappe.ui.form.on("Success Action", {
 		frm.action_multicheck = frappe.ui.form.make_control({
 			parent: next_actions_wrapper,
 			df: {
-				label: "Next Actions",
+				label: __("Next Actions"),
 				fieldname: "next_actions_multicheck",
 				fieldtype: "MultiCheck",
 				options: action_multicheck_options,


### PR DESCRIPTION
in **Success Action** DocType

### Before
<img width="816" height="247" alt="before" src="https://github.com/user-attachments/assets/09b3193b-d580-4f13-8809-1212eaea8feb" />

### After
<img width="935" height="250" alt="image" src="https://github.com/user-attachments/assets/e0d5b474-76d5-469a-85dd-a3c61ddc2d8b" />


