### PR TITLE
fix: empty grid height

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -387,7 +387,7 @@ export default class GridRow {
 		if (this.configure_columns && this.frm) {
 			this.configure_columns_button = $(`
 				<div class="col grid-static-col pointer">
-					<a>${frappe.utils.icon("setting-gear", "sm", "", "filter: opacity(0.5)")}</a>
+					<a>${frappe.utils.icon("settings", "sm", "", "filter: opacity(0.5)")}</a>
 				</div>
 			`)
 				.appendTo(this.row)

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -6,7 +6,7 @@
 	border: 1px solid var(--table-border-color);
 	border-radius: var(--border-radius-md);
 	color: var(--text-color);
-	min-height: 150px;
+	min-height: 75px;
 	background-color: var(--subtle-accent);
 }
 
@@ -157,7 +157,7 @@
 }
 
 .grid-empty {
-	height: 110px;
+	height: 43px;
 	background-color: var(--subtle-accent);
 	display: flex;
 	vertical-align: middle;
@@ -242,6 +242,7 @@
 		min-width: 0;
 		display: flex;
 		justify-content: center;
+		align-items: center;
 	}
 
 	.col {
@@ -811,6 +812,7 @@
 			position: sticky;
 			right: 0;
 			z-index: 1;
+			line-height: 1;
 		}
 		.grid-row > .row .col:nth-child(2),
 		.grid-row > .dialog-assignment-row .col:nth-child(2) {


### PR DESCRIPTION
Attempt to reduce the gray empty space when there's only one row. The hardcoded height (hence empty space) was set to avoid layout shift when a row was added. 

Now, we set the empty space to just a single row height to avoid gray empty space after a row is added.

#### Before


https://github.com/user-attachments/assets/a94d5be7-e372-4c8d-8e94-6d29d94bbbd8


#### After

https://github.com/user-attachments/assets/6c4a956f-5332-497a-9c9d-619856638b58


