### PR TITLE
feat: add bulk_update and bulk_delete endpoints to /api/v2

### DIFF
--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -277,7 +277,7 @@ def bulk_delete():
 	"""Bulk delete documents across multiple doctypes.
 
 	Request body should contain:
-		documents: List of {"doctype": str, "name": str} objects
+		docs: List of {"doctype": str, "name": str} objects
 
 	Returns:
 		deleted: List of successfully deleted documents
@@ -287,15 +287,15 @@ def bulk_delete():
 		failure_count: Number of failed deletions
 	"""
 	data = frappe.form_dict
-	documents = frappe.parse_json(data.get("documents", "[]"))
+	docs = frappe.parse_json(data.get("docs", "[]"))
 
-	if not isinstance(documents, list):
-		frappe.throw(_("Request body must contain 'documents' as an array"))
+	if not isinstance(docs, list):
+		frappe.throw(_("Request body must contain 'docs' as an array"))
 
 	deleted = []
 	failed = []
 
-	for item in documents:
+	for item in docs:
 		doctype = None
 		name = None
 		try:
@@ -316,7 +316,7 @@ def bulk_delete():
 	return {
 		"deleted": deleted,
 		"failed": failed,
-		"total": len(documents),
+		"total": len(docs),
 		"success_count": len(deleted),
 		"failure_count": len(failed),
 	}
@@ -326,8 +326,8 @@ def bulk_update_docs(doctype: str):
 	"""Bulk update multiple documents of the same doctype.
 
 	Request body should contain:
-		updates: List of {"name": str, ...fields} objects where each object contains
-		         the document name and the fields to update
+		docs: List of {"name": str, ...fields} objects where each object contains
+		      the document name and the fields to update
 
 	Returns:
 		updated: List of successfully updated document names
@@ -337,15 +337,15 @@ def bulk_update_docs(doctype: str):
 		failure_count: Number of failed updates
 	"""
 	data = frappe.form_dict
-	updates = frappe.parse_json(data.get("updates", "[]"))
+	docs = frappe.parse_json(data.get("docs", "[]"))
 
-	if not isinstance(updates, list):
-		frappe.throw(_("'updates' must be an array"))
+	if not isinstance(docs, list):
+		frappe.throw(_("'docs' must be an array"))
 
 	updated = []
 	failed = []
 
-	for item in updates:
+	for item in docs:
 		name = None
 		try:
 			if not isinstance(item, dict):
@@ -372,7 +372,7 @@ def bulk_update_docs(doctype: str):
 	return {
 		"updated": updated,
 		"failed": failed,
-		"total": len(updates),
+		"total": len(docs),
 		"success_count": len(updated),
 		"failure_count": len(failed),
 	}
@@ -382,7 +382,7 @@ def bulk_update():
 	"""Bulk update documents across multiple doctypes.
 
 	Request body should contain:
-		documents: List of {"doctype": str, "name": str, ...fields} objects
+		docs: List of {"doctype": str, "name": str, ...fields} objects
 
 	Returns:
 		updated: List of successfully updated documents
@@ -392,15 +392,15 @@ def bulk_update():
 		failure_count: Number of failed updates
 	"""
 	data = frappe.form_dict
-	documents = frappe.parse_json(data.get("documents", "[]"))
+	docs = frappe.parse_json(data.get("docs", "[]"))
 
-	if not isinstance(documents, list):
-		frappe.throw(_("Request body must contain 'documents' as an array"))
+	if not isinstance(docs, list):
+		frappe.throw(_("Request body must contain 'docs' as an array"))
 
 	updated = []
 	failed = []
 
-	for item in documents:
+	for item in docs:
 		doctype = None
 		name = None
 		try:
@@ -433,7 +433,7 @@ def bulk_update():
 	return {
 		"updated": updated,
 		"failed": failed,
-		"total": len(documents),
+		"total": len(docs),
 		"success_count": len(updated),
 		"failure_count": len(failed),
 	}

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -25,6 +25,17 @@ PERMISSION_MAP = {
 }
 
 
+def get_bulk_operation_async_threshold(doctype: str | None = None) -> int:
+	conf = frappe.conf.get("bulk_operation_async_threshold", 20)
+
+	if isinstance(conf, dict):
+		value = conf.get(doctype, 20) if doctype else conf.get("*", 20)
+	else:
+		value = conf
+
+	return cint(value)
+
+
 class FrappeValueError(ValueError):
 	http_status_code = 417
 
@@ -266,7 +277,7 @@ def bulk_delete_docs(doctype: str):
 	if not isinstance(names, list):
 		raise FrappeValueError("'names' must be a list")
 
-	if len(names) > 20:
+	if len(names) > get_bulk_operation_async_threshold(doctype):
 		job = frappe.enqueue(
 			"frappe.api.v2.execute_bulk_delete_docs",
 			doctype=doctype,
@@ -327,7 +338,7 @@ def bulk_delete():
 	if not isinstance(docs, list):
 		raise FrappeValueError("'docs' must be a list")
 
-	if len(docs) > 20:
+	if len(docs) > get_bulk_operation_async_threshold():
 		job = frappe.enqueue(
 			"frappe.api.v2.execute_bulk_delete",
 			docs=docs,
@@ -398,7 +409,7 @@ def bulk_update_docs(doctype: str):
 	if not isinstance(docs, list):
 		raise FrappeValueError("'docs' must be a list")
 
-	if len(docs) > 20:
+	if len(docs) > get_bulk_operation_async_threshold(doctype):
 		job = frappe.enqueue(
 			"frappe.api.v2.execute_bulk_update_docs",
 			doctype=doctype,
@@ -472,7 +483,7 @@ def bulk_update():
 	if not isinstance(docs, list):
 		raise FrappeValueError("'docs' must be a list")
 
-	if len(docs) > 20:
+	if len(docs) > get_bulk_operation_async_threshold():
 		job = frappe.enqueue(
 			"frappe.api.v2.execute_bulk_update",
 			docs=docs,

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -362,8 +362,10 @@ def bulk_update_docs(doctype: str):
 
 			doc.update(item_copy)
 			doc.save()
+			doc.apply_fieldlevel_read_permissions()
 
 			updated.append(name)
+			frappe.response.docs.append(doc.as_dict())
 		except Exception as e:
 			failed.append({"name": name, "error": str(e)})
 
@@ -421,8 +423,10 @@ def bulk_update():
 
 			doc.update(item_copy)
 			doc.save()
+			doc.apply_fieldlevel_read_permissions()
 
 			updated.append({"doctype": doctype, "name": name})
+			frappe.response.docs.append(doc.as_dict())
 		except Exception as e:
 			failed.append({"doctype": doctype, "name": name, "error": str(e)})
 

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -330,7 +330,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		response = self.post(
 			self.method("bulk_delete"),
 			{
-				"documents": frappe.as_json(
+				"docs": frappe.as_json(
 					[
 						{"doctype": "ToDo", "name": todo.name},
 						{"doctype": "Note", "name": note.name},
@@ -354,14 +354,14 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		# Test with invalid format (not a list)
 		response = self.post(
 			self.method("bulk_delete"),
-			{"documents": frappe.as_json({"doctype": "ToDo", "name": "test"}), "sid": self.sid},
+			{"docs": frappe.as_json({"doctype": "ToDo", "name": "test"}), "sid": self.sid},
 		)
 		self.assertEqual(response.status_code, 417)
 
 		# Test with invalid document format (not dict)
 		response = self.post(
 			self.method("bulk_delete"),
-			{"documents": frappe.as_json(["invalid-item"]), "sid": self.sid},
+			{"docs": frappe.as_json(["invalid-item"]), "sid": self.sid},
 		)
 		self.assertEqual(response.status_code, 200)
 		data = response.json["data"]
@@ -378,7 +378,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 			response = self.post(
 				self.resource(self.DOCTYPE, "bulk_update"),
 				{
-					"updates": frappe.as_json(
+					"docs": frappe.as_json(
 						[
 							{"name": doc1.name, "description": "Updated description 1", "priority": "High"},
 							{"name": doc2.name, "description": "Updated description 2", "priority": "Low"},
@@ -419,7 +419,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 			response = self.post(
 				self.method("bulk_update"),
 				{
-					"documents": frappe.as_json(
+					"docs": frappe.as_json(
 						[
 							{"doctype": "ToDo", "name": todo.name, "description": "Updated ToDo"},
 							{"doctype": "Note", "name": note.name, "title": "Updated Note"},
@@ -457,7 +457,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 			response = self.post(
 				self.resource(self.DOCTYPE, "bulk_update"),
 				{
-					"updates": frappe.as_json(
+					"docs": frappe.as_json(
 						[
 							{"name": valid_doc, "description": "Updated"},
 							{"name": non_existent, "description": "Should fail"},
@@ -487,14 +487,14 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		# Test with invalid format (not a list)
 		response = self.post(
 			self.resource(self.DOCTYPE, "bulk_update"),
-			{"updates": frappe.as_json({"name": "test", "description": "test"}), "sid": self.sid},
+			{"docs": frappe.as_json({"name": "test", "description": "test"}), "sid": self.sid},
 		)
 		self.assertEqual(response.status_code, 417)
 
 		# Test with missing name field
 		response = self.post(
 			self.resource(self.DOCTYPE, "bulk_update"),
-			{"updates": frappe.as_json([{"description": "test"}]), "sid": self.sid},
+			{"docs": frappe.as_json([{"description": "test"}]), "sid": self.sid},
 		)
 		self.assertEqual(response.status_code, 200)
 		data = response.json["data"]

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -550,7 +550,7 @@ def generate_admin_keys():
 	from frappe.core.doctype.user.user import generate_keys
 
 	generate_keys("Administrator")
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep
 
 
 @whitelist_for_tests()

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -270,23 +270,6 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 
 	version = "v2"
 	DOCTYPE = "ToDo"
-	GENERATED_DOCUMENTS: typing.ClassVar[list] = []
-
-	@classmethod
-	def setUpClass(cls):
-		super().setUpClass()
-		# Create test documents
-		for i in range(10):
-			doc = frappe.get_doc({"doctype": "ToDo", "description": f"Test bulk operations {i}"}).insert()
-			cls.GENERATED_DOCUMENTS.append(doc.name)
-		frappe.db.commit()
-
-	@classmethod
-	def tearDownClass(cls):
-		frappe.db.commit()
-		for name in cls.GENERATED_DOCUMENTS:
-			frappe.delete_doc_if_exists(cls.DOCTYPE, name)
-		frappe.db.commit()
 
 	def setUp(self) -> None:
 		self.post(self.method("login"), {"sid": self.sid})
@@ -296,7 +279,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		# Create docs to delete
 		doc1 = frappe.get_doc({"doctype": self.DOCTYPE, "description": "To delete 1"}).insert()
 		doc2 = frappe.get_doc({"doctype": self.DOCTYPE, "description": "To delete 2"}).insert()
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep
 
 		# Bulk delete
 		response = self.post(
@@ -319,7 +302,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 	def test_bulk_delete_docs_partial_failure(self):
 		# Create one valid doc
 		doc = frappe.get_doc({"doctype": self.DOCTYPE, "description": "To delete"}).insert()
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep
 
 		# Try to delete valid and non-existent doc
 		non_existent = "non-existent-todo"
@@ -341,7 +324,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		# Create docs of different types
 		todo = frappe.get_doc({"doctype": "ToDo", "description": "Test"}).insert()
 		note = frappe.get_doc({"doctype": "Note", "title": "Test Note", "content": "Test"}).insert()
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep
 
 		# Bulk delete across doctypes
 		response = self.post(
@@ -388,7 +371,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		# Create fresh docs for this test
 		doc1 = frappe.get_doc({"doctype": self.DOCTYPE, "description": "Original 1"}).insert()
 		doc2 = frappe.get_doc({"doctype": self.DOCTYPE, "description": "Original 2"}).insert()
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep
 
 		try:
 			# Bulk update
@@ -423,13 +406,13 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		finally:
 			frappe.delete_doc_if_exists(self.DOCTYPE, doc1.name)
 			frappe.delete_doc_if_exists(self.DOCTYPE, doc2.name)
-			frappe.db.commit()
+			frappe.db.commit()  # nosemgrep
 
 	def test_bulk_update_cross_doctype(self):
 		# Create test documents
 		todo = frappe.get_doc({"doctype": "ToDo", "description": "Test"}).insert()
 		note = frappe.get_doc({"doctype": "Note", "title": "Test", "content": "Test"}).insert()
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep
 
 		try:
 			# Bulk update across doctypes
@@ -460,12 +443,12 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		finally:
 			frappe.delete_doc_if_exists("ToDo", todo.name)
 			frappe.delete_doc_if_exists("Note", note.name)
-			frappe.db.commit()
+			frappe.db.commit()  # nosemgrep
 
 	def test_bulk_update_partial_failure(self):
 		# Create a fresh doc for this test
 		doc = frappe.get_doc({"doctype": self.DOCTYPE, "description": "Original"}).insert()
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep
 		valid_doc = doc.name
 		non_existent = "non-existent-todo"
 
@@ -498,7 +481,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 			self.assertEqual(updated_doc.description, "Updated")
 		finally:
 			frappe.delete_doc_if_exists(self.DOCTYPE, valid_doc)
-			frappe.db.commit()
+			frappe.db.commit()  # nosemgrep
 
 	def test_bulk_update_invalid_format(self):
 		# Test with invalid format (not a list)

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -284,7 +284,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		# Bulk delete
 		response = self.post(
 			self.resource(self.DOCTYPE, "bulk_delete"),
-			{"names": frappe.as_json([doc1.name, doc2.name]), "sid": self.sid},
+			{"names": [doc1.name, doc2.name], "sid": self.sid},
 		)
 
 		self.assertEqual(response.status_code, 200)
@@ -308,7 +308,7 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		non_existent = "non-existent-todo"
 		response = self.post(
 			self.resource(self.DOCTYPE, "bulk_delete"),
-			{"names": frappe.as_json([doc.name, non_existent]), "sid": self.sid},
+			{"names": [doc.name, non_existent], "sid": self.sid},
 		)
 
 		self.assertEqual(response.status_code, 200)
@@ -330,12 +330,10 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		response = self.post(
 			self.method("bulk_delete"),
 			{
-				"docs": frappe.as_json(
-					[
-						{"doctype": "ToDo", "name": todo.name},
-						{"doctype": "Note", "name": note.name},
-					]
-				),
+				"docs": [
+					{"doctype": "ToDo", "name": todo.name},
+					{"doctype": "Note", "name": note.name},
+				],
 				"sid": self.sid,
 			},
 		)
@@ -354,18 +352,20 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		# Test with invalid format (not a list)
 		response = self.post(
 			self.method("bulk_delete"),
-			{"docs": frappe.as_json({"doctype": "ToDo", "name": "test"}), "sid": self.sid},
+			{"docs": {"doctype": "ToDo", "name": "test"}, "sid": self.sid},
 		)
 		self.assertEqual(response.status_code, 417)
+		self.assertIn("'docs' must be a list", response.json["errors"][0]["message"])
 
 		# Test with invalid document format (not dict)
 		response = self.post(
 			self.method("bulk_delete"),
-			{"docs": frappe.as_json(["invalid-item"]), "sid": self.sid},
+			{"docs": ["invalid-item"], "sid": self.sid},
 		)
 		self.assertEqual(response.status_code, 200)
 		data = response.json["data"]
 		self.assertEqual(data["failure_count"], 1)
+		self.assertIn("must be a dictionary", data["failed"][0]["error"])
 
 	def test_bulk_update_docs_single_doctype(self):
 		# Create fresh docs for this test
@@ -378,12 +378,10 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 			response = self.post(
 				self.resource(self.DOCTYPE, "bulk_update"),
 				{
-					"docs": frappe.as_json(
-						[
-							{"name": doc1.name, "description": "Updated description 1", "priority": "High"},
-							{"name": doc2.name, "description": "Updated description 2", "priority": "Low"},
-						]
-					),
+					"docs": [
+						{"name": doc1.name, "description": "Updated description 1", "priority": "High"},
+						{"name": doc2.name, "description": "Updated description 2", "priority": "Low"},
+					],
 					"sid": self.sid,
 				},
 			)
@@ -419,12 +417,10 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 			response = self.post(
 				self.method("bulk_update"),
 				{
-					"docs": frappe.as_json(
-						[
-							{"doctype": "ToDo", "name": todo.name, "description": "Updated ToDo"},
-							{"doctype": "Note", "name": note.name, "title": "Updated Note"},
-						]
-					),
+					"docs": [
+						{"doctype": "ToDo", "name": todo.name, "description": "Updated ToDo"},
+						{"doctype": "Note", "name": note.name, "title": "Updated Note"},
+					],
 					"sid": self.sid,
 				},
 			)
@@ -457,12 +453,10 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 			response = self.post(
 				self.resource(self.DOCTYPE, "bulk_update"),
 				{
-					"docs": frappe.as_json(
-						[
-							{"name": valid_doc, "description": "Updated"},
-							{"name": non_existent, "description": "Should fail"},
-						]
-					),
+					"docs": [
+						{"name": valid_doc, "description": "Updated"},
+						{"name": non_existent, "description": "Should fail"},
+					],
 					"sid": self.sid,
 				},
 			)
@@ -487,18 +481,20 @@ class TestBulkOperationsV2(FrappeAPITestCase):
 		# Test with invalid format (not a list)
 		response = self.post(
 			self.resource(self.DOCTYPE, "bulk_update"),
-			{"docs": frappe.as_json({"name": "test", "description": "test"}), "sid": self.sid},
+			{"docs": {"name": "test", "description": "test"}, "sid": self.sid},
 		)
 		self.assertEqual(response.status_code, 417)
+		self.assertIn("'docs' must be a list", response.json["errors"][0]["message"])
 
 		# Test with missing name field
 		response = self.post(
 			self.resource(self.DOCTYPE, "bulk_update"),
-			{"docs": frappe.as_json([{"description": "test"}]), "sid": self.sid},
+			{"docs": [{"description": "test"}], "sid": self.sid},
 		)
 		self.assertEqual(response.status_code, 200)
 		data = response.json["data"]
 		self.assertEqual(data["failure_count"], 1)
+		self.assertIn("'name' must be a string or integer", data["failed"][0]["error"])
 
 
 class TestDocTypeAPIV2(FrappeAPITestCase):


### PR DESCRIPTION
# Bulk Operations in API v2

## Bulk Delete

### Single DocType
**Endpoint:** `POST /api/v2/document/{doctype}/bulk_delete`

Delete multiple documents of the same doctype in a single request.

**Request Body:**
```json
{
  "names": ["doc-1", "doc-2", "doc-3"]
}
```

**Response:**
```json
{
  "deleted": ["doc-1", "doc-2"],
  "failed": [
    {
      "name": "doc-3",
      "error": "Error message"
    }
  ],
  "total": 3,
  "success_count": 2,
  "failure_count": 1
}
```

### Multiple DocTypes
**Endpoint:** `POST /api/v2/method/bulk_delete`

Delete documents across different doctypes in a single request.

**Request Body:**
```json
{
  "docs": [
    {"doctype": "ToDo", "name": "todo-1"},
    {"doctype": "Task", "name": "task-1"}
  ]
}
```

**Response:**
```json
{
  "deleted": [
    {"doctype": "ToDo", "name": "todo-1"}
  ],
  "failed": [
    {
      "doctype": "Task",
      "name": "task-1",
      "error": "Error message"
    }
  ],
  "total": 2,
  "success_count": 1,
  "failure_count": 1
}
```

## Bulk Update

### Single DocType
**Endpoint:** `POST /api/v2/document/{doctype}/bulk_update`

Update multiple documents of the same doctype in a single request.

**Request Body:**
```json
{
  "docs": [
    {
      "name": "doc-1",
      "status": "Completed",
      "priority": "High"
    },
    {
      "name": "doc-2",
      "status": "In Progress"
    }
  ]
}
```

**Response:**
```json
{
  "updated": ["doc-1", "doc-2"],
  "failed": [],
  "total": 2,
  "success_count": 2,
  "failure_count": 0
}
```

The updated documents are also available in `frappe.response.docs`.

### Multiple DocTypes
**Endpoint:** `POST /api/v2/method/bulk_update`

Update documents across different doctypes in a single request.

**Request Body:**
```json
{
  "docs": [
    {
      "doctype": "ToDo",
      "name": "todo-1",
      "status": "Closed"
    },
    {
      "doctype": "Task",
      "name": "task-1",
      "status": "Completed",
      "priority": "High"
    }
  ]
}
```

**Response:**
```json
{
  "updated": [
    {"doctype": "ToDo", "name": "todo-1"},
    {"doctype": "Task", "name": "task-1"}
  ],
  "failed": [],
  "total": 2,
  "success_count": 2,
  "failure_count": 0
}
```

The updated documents are also available in `frappe.response.docs`.

## Notes

- All bulk operations are performed individually - a failure in one document doesn't stop processing of others
- Partial success is possible - check `success_count` and `failure_count` in the response
- Permission checks are performed for each document operation
- Failed operations include error messages

For https://github.com/frappe/gameplan/issues/438

no-docs