### PR TITLE
fix(sidebar): prevent header icon from shifting in expanded state

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -173,6 +173,8 @@
 			&:hover {
 				@include hover-mixin();
 			}
+		}
+
 		.sidebar-header {
 			padding: 0px !important;
 		}

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -173,6 +173,8 @@
 			&:hover {
 				@include hover-mixin();
 			}
+		.sidebar-header {
+			padding: 0px !important;
 		}
 	}
 


### PR DESCRIPTION
**Closes:** https://github.com/frappe/frappe/issues/34734#issuecomment-3707969607

---

https://github.com/user-attachments/assets/f4a5633f-6c31-47fe-a9e4-037aa95af1bf



---

`no-docs`