### PR TITLE
fix(sidebar): add hover state to user avatar

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -168,6 +168,12 @@
 		.nav-item {
 			margin-left: -5px;
 		}
+
+		.dropdown-navbar-user {
+			&:hover {
+				@include hover-mixin();
+			}
+		}
 	}
 
 	// show placeholder so that main section remains static


### PR DESCRIPTION
**Resolve:** https://github.com/frappe/frappe/issues/35337#issuecomment-3698544787

> This PR adds a hover state for the user avatar similar to the sidebar header.
---

<img width="229" height="71" alt="image" src="https://github.com/user-attachments/assets/a6a07e13-3200-4ea5-ab91-2b1a2af50264" />

<img width="228" height="94" alt="image" src="https://github.com/user-attachments/assets/790fbde3-0c10-454e-b503-1cd79622b422" />
