### PR TITLE
fix: better validation message for data too long error

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -3,6 +3,7 @@
 import datetime
 import json
 import keyword
+import re
 import weakref
 from types import MappingProxyType
 from typing import TYPE_CHECKING, TypeVar
@@ -801,7 +802,21 @@ class BaseDocument:
 				),
 				[*list(d.values()), name],
 			)
+
 		except Exception as e:
+			if frappe.db.is_data_too_long(e):
+				column = re.search(r"column\s+'([^']+)'", e.args[1])
+				if column:
+					label = self.get_label_from_fieldname(column.group(1))
+
+					# data too long for column
+					frappe.throw(
+						_(
+							"The value of the field {0} is too long in the {1} document. To resolve this issue, please reduce the value length or change the {0} field Type to Long Text using customize form, and then try again."
+						).format(frappe.bold(label), frappe.bold(self.doctype)),
+						title=_("Value Too Long"),
+					)
+
 			if frappe.db.is_unique_key_violation(e):
 				self.show_unique_validation_message(e)
 			else:


### PR DESCRIPTION
### **Before Change**
<img width="1025" height="374" alt="Screenshot 2026-01-05 at 9 15 21 PM" src="https://github.com/user-attachments/assets/9b21d8dc-f85b-4973-a43b-ad2939ae5a7a" />


### **After Change**
<img width="715" height="268" alt="image" src="https://github.com/user-attachments/assets/0c7ecb9d-0d1e-4e28-9036-d99b62c7d504" />



