### PR TITLE
fix: remove duplicate key from object

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -338,7 +338,6 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				]);
 				this.options.push({
 					label: formatted_value,
-					value: __("{0} = {1}", [txt, val]),
 					value: __("{0} = {1}", [frappe.utils.xss_sanitise(txt), val]),
 					match: val,
 					index: 80,


### PR DESCRIPTION
22:10:50 watch.1       | ▲ [WARNING] Duplicate key "value" in object literal
22:10:50 watch.1       |
22:10:50 watch.1       |     frappe/public/js/frappe/ui/toolbar/awesome_bar.js:342:5:
22:10:50 watch.1       |       342 │           value: __("{0} = {1}", [frappe.utils.xss_sanitise(txt),...
22:10:50 watch.1       |           ╵           ~~~~~
22:10:50 watch.1       |
22:10:50 watch.1       |   The original key "value" is here:
22:10:50 watch.1       |
22:10:50 watch.1       |     frappe/public/js/frappe/ui/toolbar/awesome_bar.js:341:5:
22:10:50 watch.1       |       341 │           value: __("{0} = {1}", [txt, val]),
22:10:50 watch.1       |           ╵           ~~~~~
22:10:50 watch.1       |
