### PR TITLE
fix: flickering issue on attach image

### DIFF
--- a/frappe/public/js/frappe/form/controls/attach_image.js
+++ b/frappe/public/js/frappe/form/controls/attach_image.js
@@ -3,9 +3,10 @@ frappe.ui.form.ControlAttachImage = class ControlAttachImage extends frappe.ui.f
 		super.make_input();
 
 		let $file_link = this.$value.find(".attached-file-link");
+		// Changing placement from top to bottom to avoid flickering. Fix with better solution
 		$file_link.popover({
 			trigger: "hover",
-			placement: "top",
+			placement: "bottom",
 			content: () => {
 				return `<div>
 					<img src="${this.get_value()}"


### PR DESCRIPTION
Fixes the flickering issue on hover. Come up with a better solution
Video 

https://github.com/user-attachments/assets/5456b696-a708-4d3f-984b-6a52cd55e047

Closes an comment in https://github.com/frappe/frappe/issues/34734
