### PR TITLE
fix: show desktop icons instead of workspaces

### DIFF
--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -149,7 +149,14 @@ frappe.ui.menu = class ContextMenu {
 			} else if (item.items) {
 				$();
 			} else {
-				$(item_wrapper).find("a").attr("href", item.url);
+				item_wrapper.on("click", function () {
+					me.nested_menus.forEach((menu) => {
+						menu.hide();
+					});
+					me.hide();
+					me.opts.onHide && me.opts.onHide(me);
+					frappe.set_route(item.url);
+				});
 			}
 		}
 		item_wrapper.appendTo(this.template);

--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -80,12 +80,12 @@ frappe.ui.menu = class ContextMenu {
 				`<div class="dropdown-menu-item"><div class="dropdown-divider documentation-links"></div></div>`
 			);
 		} else {
-			const iconMarkup = item.icon_html
+			const iconMarkup = item.icon_url
+				? `<img class="logo" src="${item.icon_url}">`
+				: item.icon_html
 				? item.icon_html
 				: item.icon
 				? frappe.utils.icon(item.icon)
-				: item.icon_url
-				? `<img class="logo" src="${item.icon_url}">`
 				: "";
 			let chevron_direction = frappe.utils.is_rtl() ? "left " : "right";
 			item_wrapper = $(`<div class="dropdown-menu-item" onclick="${

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -99,8 +99,11 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 					url: frappe.utils.get_route_for_icon(icon),
 				};
 				if (icon.icon_type == "Folder") {
-					this.get_icon_for_menu_item(icon, item);
-					item.items = folder_map[item.label];
+					let nested_items = folder_map[item.label];
+					nested_items.forEach((item) => {
+						this.get_icon_for_menu_item(item, item);
+					});
+					item.items = nested_items;
 				}
 				if (frappe.utils.get_desktop_icon(icon.label, frappe.boot.desktop_icon_style)) {
 					item.icon_url = frappe.utils.get_desktop_icon(
@@ -129,6 +132,7 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 		const folder_map = {};
 		const sibling_icons = [];
 		if (!frappe.current_app) return;
+		this.sort_icons(desktop_icons);
 		desktop_icons.forEach((icon) => {
 			if (
 				icon.link_type != "External" &&
@@ -151,6 +155,17 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 			folder_map: folder_map,
 			sibling_icons: sibling_icons,
 		};
+	}
+	sort_icons(desktop_icons) {
+		let write = 0;
+		for (let i = 0; i < desktop_icons.length; i++) {
+			if (desktop_icons[i].icon_type === "Folder") {
+				const item = desktop_icons.splice(i, 1)[0];
+				desktop_icons.splice(write, 0, item);
+				write++;
+			}
+		}
+		return desktop_icons;
 	}
 	get_help_siblings() {
 		const navbar_settings = frappe.boot.navbar_settings;

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -5,7 +5,7 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 		this.drop_down_expanded = false;
 		this.title = this.sidebar.sidebar_title;
 		const me = this;
-		this.sibling_workspaces = this.fetch_sibling_workspaces();
+		this.sibling_workspaces = this.fetch_related_icons();
 		this.dropdown_items = [
 			{
 				name: "workspaces",
@@ -81,29 +81,32 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 		this.populate_dropdown_menu();
 		this.setup_select_options();
 	}
-	fetch_sibling_workspaces() {
+
+	fetch_related_icons() {
 		let sibling_workspaces = [];
 		if (frappe.current_app) {
-			let workspaces = [...frappe.current_app.workspaces];
-			workspaces.splice(workspaces.indexOf(this.title), 1);
+			let workspaces = [...frappe.boot.desktop_icons];
+			workspaces.splice(
+				workspaces.indexOf(frappe.utils.get_desktop_icon_by_label(this.title)),
+				1
+			);
 			workspaces.forEach((w) => {
-				let item = {
-					name: w.toLowerCase(),
-					label: w,
-					url: frappe.utils.generate_route({
-						type: "Workspace",
-						route: frappe.router.slug(w),
-					}),
-				};
-				if (frappe.utils.get_desktop_icon(w, frappe.boot.desktop_icon_style)) {
-					item.icon_url = frappe.utils.get_desktop_icon(
-						w,
-						frappe.boot.desktop_icon_style
-					);
-				} else {
-					item.icon_html = frappe.utils.desktop_icon(w, "gray", "sm");
+				if (w.app && w.app == frappe.current_app.app_name) {
+					let item = {
+						name: w.label.toLowerCase(),
+						label: w.label,
+						url: frappe.utils.get_route_for_icon(w),
+					};
+					if (frappe.utils.get_desktop_icon(w.label, frappe.boot.desktop_icon_style)) {
+						item.icon_url = frappe.utils.get_desktop_icon(
+							w.label,
+							frappe.boot.desktop_icon_style
+						);
+					} else {
+						item.icon_html = frappe.utils.desktop_icon(w.label, "gray", "sm");
+					}
+					sibling_workspaces.push(item);
 				}
-				sibling_workspaces.push(item);
 			});
 			return sibling_workspaces;
 		}

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -107,6 +107,10 @@ frappe.search.AwesomeBar = class AwesomeBar {
 						)
 					);
 				}
+				if (d.type == "Desktop Icon") {
+					target = frappe.utils.get_route_for_icon(d.icon_data);
+					d.route = target;
+				}
 				let html = `<span>${__(d.label || d.value)}</span>`;
 
 				if (d.description && d.value !== d.description) {
@@ -189,7 +193,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				if (event.ctrlKey || event.metaKey) {
 					frappe.open_in_new_tab = true;
 				}
-				if (item.route[0].startsWith("https://")) {
+				if (item.route && item.route[0].startsWith("https://")) {
 					window.open(item.route[0], "_blank");
 					return;
 				}
@@ -278,7 +282,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				frappe.search.utils.get_doctypes(txt),
 				frappe.search.utils.get_reports(txt),
 				frappe.search.utils.get_pages(txt),
-				frappe.search.utils.get_workspaces(txt),
+				frappe.search.utils.get_desktop_icons(txt),
 				frappe.search.utils.get_dashboards(txt),
 				frappe.search.utils.get_recent_pages(txt || ""),
 				frappe.search.utils.get_executables(txt),

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -328,19 +328,19 @@ frappe.search.utils = {
 		return out;
 	},
 
-	get_workspaces: function (keywords) {
+	get_desktop_icons: function (keywords) {
 		var me = this;
 		var out = [];
-		frappe.boot.allowed_workspaces.forEach(function (item) {
-			const search_result = me.fuzzy_search(keywords, item.name, true);
+		frappe.boot.desktop_icons.forEach(function (item) {
+			const search_result = me.fuzzy_search(keywords, item.label, true);
 			var level = search_result.score;
 			if (level > 0) {
 				var ret = {
-					type: "Workspace",
-					label: __("Open {0}", [search_result.marked_string || __(item.name)]),
-					value: __("Open {0}", [__(item.name)]),
+					type: "Desktop Icon",
+					label: __("Open {0}", [search_result.marked_string || __(item.label)]),
+					value: __("Open {0}", [__(item.label)]),
 					index: level,
-					route: [frappe.router.slug(item.name)],
+					icon_data: item,
 				};
 
 				out.push(ret);
@@ -568,7 +568,7 @@ frappe.search.utils = {
 				results: sort_uniques(this.get_pages(keywords)),
 			},
 			{
-				title: __("Workspace"),
+				title: __("Desktop Icon"),
 				fetch_type: "Nav",
 				results: sort_uniques(this.get_workspaces(keywords)),
 			},


### PR DESCRIPTION
This PR does 2 things
1. Show Desktop Icons in the Workspaces Header
<img width="770" height="577" alt="Screenshot 2026-01-07 at 6 10 26 AM" src="https://github.com/user-attachments/assets/9b99e3c6-e008-451b-8dcb-455f780a79bc" />

Maybe this style of nesting is a bad idea but will do some user testing
2. Search and Open Icons directly
Opening & Closing is a desktop icon. You can now go to it (open the icon) via Awesombar


https://github.com/user-attachments/assets/116d8e7d-edee-47a1-9629-2d801fc54086

