### PR TITLE
fix: add text-nowrap class to sort selector button

### DIFF
--- a/frappe/public/js/frappe/ui/sort_selector.html
+++ b/frappe/public/js/frappe/ui/sort_selector.html
@@ -9,7 +9,7 @@
 				</svg>
 			</span>
 		</button>
-		<button type="button" class="btn btn-default btn-sm sort-selector-button" data-toggle="dropdown">
+		<button type="button" class="btn btn-default btn-sm sort-selector-button text-nowrap" data-toggle="dropdown">
 			<span class="dropdown-text">{{ __(sort_by_label) }}</span>
 			<ul class="dropdown-menu dropdown-menu-right">
 				{% for value in options %}


### PR DESCRIPTION
**Fixes:** #35740

---
**Before:**

https://github.com/user-attachments/assets/601c7160-22b1-4f74-aeb4-ffde4c3cc4b6

**After**

https://github.com/user-attachments/assets/0770479e-6d25-45c8-952b-00718caf61f6

`no-docs`

