### PR TITLE
fix: choosing which sidebar to load

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -24,6 +24,8 @@ frappe.pages["print"].on_page_load = function (wrapper) {
 				? frappe.route_options.frm
 				: frappe.route_options.frm.frm;
 			frappe.route_options.frm = null;
+			let meta = print_view.frm.meta;
+			meta.module && frappe.app.sidebar.show_sidebar_for_module(meta.module);
 			print_view.show(print_view.frm);
 		}
 	});

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -425,6 +425,12 @@ frappe.ui.Sidebar = class Sidebar {
 
 			if (sidebars.length == 1) {
 				frappe.app.sidebar.setup(sidebars[0]);
+			} else if (sidebars.length > 1) {
+				if (sidebars.includes(this.sidebar_module_map[module])) {
+					frappe.app.sidebar.setup(this.sidebar_module_map[module]);
+				} else {
+					frappe.app.sidebar.setup(sidebars[0]);
+				}
 			} else if (module) {
 				this.show_sidebar_for_module(module);
 			}
@@ -441,7 +447,6 @@ frappe.ui.Sidebar = class Sidebar {
 				return a.localeCompare(b);
 			});
 		if (sidebars && sidebars.length) {
-			if (this.sidebar_title) return;
 			frappe.app.sidebar.setup(sidebars[0]);
 		}
 	}

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -417,6 +417,7 @@ frappe.ui.Sidebar = class Sidebar {
 			}
 
 			let sidebars = this.get_correct_workspace_sidebars(entity_name);
+			this.preffered_sidebars = sidebars;
 			let module = router?.meta?.module;
 			if (this.sidebar_title && sidebars.includes(this.sidebar_title)) {
 				this.set_active_workspace_item();
@@ -441,6 +442,7 @@ frappe.ui.Sidebar = class Sidebar {
 		this.set_active_workspace_item();
 	}
 	show_sidebar_for_module(module) {
+		if (this.sidebar_title != module) return;
 		let sidebars =
 			this.sidebar_module_map[module] &&
 			this.sidebar_module_map[module].sort((a, b) => {

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -128,12 +128,13 @@ frappe.breadcrumbs = {
 		) {
 			return;
 		}
-
-		this.append_breadcrumb_element(
-			`/desk/${frappe.router.slug(breadcrumbs.workspace)}`,
-			__(breadcrumbs.workspace),
-			"worksapce-breadcrumb"
-		);
+		if (frappe.app.sidebar.sidebar_title) {
+			let icon = frappe.utils.get_desktop_icon_by_label(frappe.app.sidebar.sidebar_title);
+			let url = frappe.utils.get_route_for_icon(icon);
+			if (url) {
+				this.append_breadcrumb_element(url, __(icon.label), "worksapce-breadcrumb");
+			}
+		}
 
 		let worksapce_crumb = this.$breadcrumbs.find("li a.worksapce-breadcrumb");
 

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -12,6 +12,7 @@
 
 .form-grid.error {
 	border-color: var(--error-border);
+	overflow: hidden;
 }
 
 .grid-heading-row {

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -35,7 +35,6 @@
 
 	.title-area {
 		display: inline-flex;
-		align-items: baseline;
 		.indicator-pill {
 			margin-left: var(--margin-sm);
 		}


### PR DESCRIPTION
This PR fixes
1.  Shows the correct breadcrumb
2. Fixes the grid issue and fixes the other issue 
3. Fixes sidebar choosing issue
<img width="1440" height="900" alt="Screenshot 2026-01-07 at 6 35 40 PM" src="https://github.com/user-attachments/assets/66823186-90f6-4459-85ea-070bb1e3d3ca" />

4. Show semantically correct sidebar for print view as in for printview for sales order show selling not printing sidebar


5. Fixes the workspace not showing issue for users who should have access
Closes https://github.com/frappe/frappe/issues/35734
Before
<img width="482" height="894" alt="Screenshot 2026-01-08 at 10 15 19 AM" src="https://github.com/user-attachments/assets/044dc836-9566-4160-aa74-32ed05972897" />
After

<img width="405" height="900" alt="Screenshot 2026-01-08 at 10 15 29 AM" src="https://github.com/user-attachments/assets/74c36622-e7d4-4e72-afbb-72580b1aefa1" />
