### PR TITLE
feat: add options to ignore_update_if_missing

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -60,6 +60,7 @@
   "ignore_user_permissions",
   "allow_bulk_edit",
   "make_attachment_public",
+  "ignore_update_if_missing",
   "column_break_13",
   "permlevel",
   "ignore_xss_filter",
@@ -625,6 +626,12 @@
    "fieldtype": "Select",
    "label": "Button Color",
    "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
+  },
+  {
+   "default": "0",
+   "fieldname": "ignore_update_if_missing",
+   "fieldtype": "Check",
+   "label": "Ignore Update If Missing"
   }
  ],
  "grid_page_length": 50,
@@ -632,7 +639,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-06 01:37:29.723265",
+ "modified": "2026-01-07 17:58:23.675256",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/core/doctype/docfield/docfield.py
+++ b/frappe/core/doctype/docfield/docfield.py
@@ -78,6 +78,7 @@ class DocField(Document):
 		hide_border: DF.Check
 		hide_days: DF.Check
 		hide_seconds: DF.Check
+		ignore_update_if_missing: DF.Check
 		ignore_user_permissions: DF.Check
 		ignore_xss_filter: DF.Check
 		in_filter: DF.Check

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -42,6 +42,7 @@
   "is_virtual",
   "read_only",
   "ignore_user_permissions",
+  "ignore_update_if_missing",
   "hidden",
   "print_hide",
   "print_hide_if_no_value",
@@ -476,6 +477,12 @@
    "fieldtype": "Select",
    "label": "Button Color",
    "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
+  },
+  {
+   "default": "0",
+   "fieldname": "ignore_update_if_missing",
+   "fieldtype": "Check",
+   "label": "Ignore Update If Missing"
   }
  ],
  "grid_page_length": 50,
@@ -483,7 +490,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-11-12 01:14:24.753774",
+ "modified": "2026-01-07 18:08:46.324612",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -85,6 +85,7 @@ class CustomField(Document):
 		hide_border: DF.Check
 		hide_days: DF.Check
 		hide_seconds: DF.Check
+		ignore_update_if_missing: DF.Check
 		ignore_user_permissions: DF.Check
 		ignore_xss_filter: DF.Check
 		in_global_search: DF.Check

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -273,6 +273,7 @@ class CustomizeForm(Document):
 		# docfield
 		for df in self.get("fields"):
 			meta_df = meta.get("fields", {"fieldname": df.fieldname})
+
 			if not meta_df or not is_standard_or_system_generated_field(meta_df[0]):
 				continue
 
@@ -771,6 +772,7 @@ docfield_properties = {
 	"non_negative": "Check",
 	"reqd": "Check",
 	"unique": "Check",
+	"ignore_update_if_missing": "Check",
 	"ignore_user_permissions": "Check",
 	"in_list_view": "Check",
 	"in_standard_filter": "Check",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -50,6 +50,7 @@
   "remember_last_selected_value",
   "hide_border",
   "ignore_xss_filter",
+  "ignore_update_if_missing",
   "property_depends_on_section",
   "mandatory_depends_on",
   "column_break_33",
@@ -501,6 +502,12 @@
    "fieldname": "mask",
    "fieldtype": "Check",
    "label": "Mask"
+  },
+  {
+   "default": "0",
+   "fieldname": "ignore_update_if_missing",
+   "fieldtype": "Check",
+   "label": "Ignore Update If Missing"
   }
  ],
  "grid_page_length": 50,
@@ -508,7 +515,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-12-23 14:17:10.458916",
+ "modified": "2026-01-07 17:55:54.412054",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.py
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.py
@@ -76,6 +76,7 @@ class CustomizeFormField(Document):
 		hide_border: DF.Check
 		hide_days: DF.Check
 		hide_seconds: DF.Check
+		ignore_update_if_missing: DF.Check
 		ignore_user_permissions: DF.Check
 		ignore_xss_filter: DF.Check
 		in_filter: DF.Check

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -306,7 +306,11 @@ class BaseDocument:
 				# for which you don't want to set default value
 				and key not in self.dont_update_if_missing
 			):
-				self.set(key, value)
+				if (
+					self.get(key)
+					and not frappe.get_meta(self.doctype).get_field(key).ignore_update_if_missing
+				):
+					self.set(key, value)
 
 	def get_db_value(self, key):
 		return frappe.db.get_value(self.doctype, self.name, key)


### PR DESCRIPTION
**Issue**:
Branch User Permission is implicitly applied to Journal Entry child rows, causing server-side branch validations to trigger even when the user has not selected any branch field.

**Ref:** [#56032](https://support.frappe.io/helpdesk/tickets/56032)

no-docs