### PR TITLE
fix(query): check hooks for custom_operator definition

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -540,7 +540,7 @@ class Engine:
 
 			resolved = get_additional_filter_field(additional_filters_config, f, value)
 			operator = resolved.get("operator")
-			value = resolved.get("value") or resolved.get("query_value")
+			value = resolved.get("value", value)
 
 		_field = self._validate_and_prepare_filter_field(field, doctype)
 

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -567,8 +567,17 @@ class Engine:
 			_value = _apply_date_field_filter_conversion(_value, _operator, doctype or self.doctype, field)
 
 		# For Datetime fields with date values and 'between' operator, convert to datetime range to match db_query
-		if _operator.lower() == "between" and isinstance(_value, list | tuple) and len(_value) == 2:
-			_value = _apply_datetime_field_filter_conversion(_value, doctype or self.doctype, field)
+		if _operator.lower() == "between":
+			if isinstance(_value, list | tuple) and len(_value) == 2:
+				_value = _apply_datetime_field_filter_conversion(_value, doctype or self.doctype, field)
+			elif isinstance(_value, str):
+				from frappe.model.db_query import get_between_date_filter
+
+				target_meta = frappe.get_meta(doctype or self.doctype)
+				df = target_meta.get_field(field)
+				_value = tuple(
+					v.strip().strip("'") for v in get_between_date_filter(_value, df).split(" AND ")
+				)
 
 		if not _value and isinstance(_value, list | tuple | set):
 			_value = ("",)


### PR DESCRIPTION
**fix(query)**: Prior to this PR, `custom_operators` were not functioning properly in filters i.e. they were not being recognized and hence were throwing an error. This PR aims to fix this bug in `query.py` wherein `custom_operators` like `Fiscal Year` were just not working. 


**Before**:
<img width="1106" height="394" alt="image" src="https://github.com/user-attachments/assets/4bf683a3-852b-4dc7-96cc-f0c56ed5bb03" />


**After**:

https://github.com/user-attachments/assets/0aba14ec-673b-42f0-84ea-b3bb3b5fab5e


Initially spotted in [Ticket #56824](https://support.frappe.io/helpdesk/tickets/56824?view=VIEW-HD+Ticket-003)