### PR TITLE
fix: capture input in Android v14+

### DIFF
--- a/frappe/public/js/frappe/ui/capture.js
+++ b/frappe/public/js/frappe/ui/capture.js
@@ -30,6 +30,7 @@ function get_file_input() {
 	input.setAttribute("type", "file");
 	input.setAttribute("accept", "image/*");
 	input.setAttribute("multiple", "");
+	input.setAttribute("capture", "");
 
 	// Make sure that the input exists in the DOM
 	input.classList.add("visually-hidden");


### PR DESCRIPTION
Camera input in upload dialog does not open camera instead it only allowed users to upload from device (Android 14+). This PR fixes that.

## Before

https://github.com/user-attachments/assets/9540f655-7f19-425f-afa5-f1f1eb7a2995


## After

https://github.com/user-attachments/assets/78bb52bc-5829-45c6-8846-3e51abd83e06

