### PR TITLE
Single doctype - client script redirect fix

### DIFF
--- a/frappe/custom/doctype/client_script/client_script.js
+++ b/frappe/custom/doctype/client_script/client_script.js
@@ -8,24 +8,19 @@ frappe.ui.form.on("Client Script", {
 		frappe.utils.highlight_pre(sample_field.$wrapper);
 	},
 	refresh(frm) {
-    if (frm.doc.dt && frm.doc.script) {
-        frm.add_custom_button(__("Go to {0}", [frm.doc.dt]), () => {
-            frappe.db.get_value(
-                "DocType",
-                frm.doc.dt,
-                "issingle"
-            ).then(r => {
-                if (r && r.message && r.message.issingle) {
-                    frappe.set_route("Form", frm.doc.dt);
-                } else {
-                    frappe.set_route("List", frm.doc.dt);
-                }
-            });
+		if (frm.doc.dt && frm.doc.script) {
+			frm.add_custom_button(__("Go to {0}", [frm.doc.dt]), () => {
+				frappe.db.get_value("DocType", frm.doc.dt, "issingle").then((r) => {
+					if (r && r.message && r.message.issingle) {
+						frappe.set_route("Form", frm.doc.dt);
+					} else {
+						frappe.set_route("List", frm.doc.dt);
+					}
+				});
+			});
+		}
 
-        });
-    }
-
-if (frm.doc.view == "Form") {
+		if (frm.doc.view == "Form") {
 			frm.add_custom_button(__("Add script for Child Table"), () => {
 				frappe.model.with_doctype(frm.doc.dt, () => {
 					const child_tables = frappe.meta

--- a/frappe/custom/doctype/client_script/client_script.js
+++ b/frappe/custom/doctype/client_script/client_script.js
@@ -8,13 +8,24 @@ frappe.ui.form.on("Client Script", {
 		frappe.utils.highlight_pre(sample_field.$wrapper);
 	},
 	refresh(frm) {
-		if (frm.doc.dt && frm.doc.script) {
-			frm.add_custom_button(__("Go to {0}", [frm.doc.dt]), () =>
-				frappe.set_route("List", frm.doc.dt, "List")
-			);
-		}
+    if (frm.doc.dt && frm.doc.script) {
+        frm.add_custom_button(__("Go to {0}", [frm.doc.dt]), () => {
+            frappe.db.get_value(
+                "DocType",
+                frm.doc.dt,
+                "issingle"
+            ).then(r => {
+                if (r && r.message && r.message.issingle) {
+                    frappe.set_route("Form", frm.doc.dt);
+                } else {
+                    frappe.set_route("List", frm.doc.dt);
+                }
+            });
 
-		if (frm.doc.view == "Form") {
+        });
+    }
+
+if (frm.doc.view == "Form") {
 			frm.add_custom_button(__("Add script for Child Table"), () => {
 				frappe.model.with_doctype(frm.doc.dt, () => {
 					const child_tables = frappe.meta

--- a/frappe/custom/doctype/client_script/client_script.js
+++ b/frappe/custom/doctype/client_script/client_script.js
@@ -10,13 +10,11 @@ frappe.ui.form.on("Client Script", {
 	refresh(frm) {
 		if (frm.doc.dt && frm.doc.script) {
 			frm.add_custom_button(__("Go to {0}", [frm.doc.dt]), () => {
-				frappe.db.get_value("DocType", frm.doc.dt, "issingle").then((r) => {
-					if (r && r.message && r.message.issingle) {
-						frappe.set_route("Form", frm.doc.dt);
-					} else {
-						frappe.set_route("List", frm.doc.dt);
-					}
-				});
+				if (frappe.model.is_single(frm.doc.dt)) {
+					frappe.set_route("Form", frm.doc.dt);
+				} else {
+					frappe.set_route("List", frm.doc.dt);
+				}
 			});
 		}
 


### PR DESCRIPTION
Fixed an issue where clicking the **'Go to'** button in Client Script for Single Doctype failed to redirect properly.

The code has been updated to ensure that client-side redirects function as expected for these specific document types.

**Before (Issue):**

<img width="1846" height="992" alt="Before fix" src="https://github.com/user-attachments/assets/d57ea811-ca95-4aa3-9ec8-d03c9e10ac1a" />

> *Observation: The redirection fails or does not trigger on the Single Doctype.*

**After (Fixed):**

<img width="1846" height="992" alt="After fix" src="https://github.com/user-attachments/assets/e6e3456c-6562-4a82-9aa5-03fd6aff336a" />

> *Observation: The redirection now works smoothly.*