### PR TITLE
fix(list_view): prevent filters from populating read-only fields

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -312,7 +312,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		];
 		this.filter_area.get().forEach((f) => {
 			if (allowed_filter_types.includes(f[2]) && frappe.model.is_non_std_field(f[1])) {
-				options[f[1]] = f[3];
+				const df = frappe.meta.get_field(doctype, f[1]);
+				if (df && !df.read_only) {
+					options[f[1]] = f[3];
+				}
 			}
 		});
 		frappe.new_doc(doctype, options);


### PR DESCRIPTION
## Summary

When creating a new document from a filtered list view, the filter values were being passed to the new form regardless of whether the field was read-only. This caused read-only fields with default values to be incorrectly overwritten by filter values.

### The Bug
- A DocType has a `status` field that is **read-only** with **default value = "Draft"**
- User filters list view by `status = "Pending"`
- User clicks "Add New" button
- **Bug**: New form shows `status = "Pending"` (from filter) instead of `status = "Draft"` (default)

### The Fix
Added a check in `make_new_doc()` function to verify if the field is read-only before passing filter values to the new document form. Read-only fields now preserve their default values.

## Screenshots

### Before (Bug)
Filter by read-only field → New document gets filter value instead of default:
<img width="1915" height="612" alt="before3" src="https://github.com/user-attachments/assets/9e7f6279-ce27-4e9e-afa8-c7771c2ba0bb" />


### After (Fix)
Filter by read-only field → New document correctly shows default value:
<img width="1915" height="612" alt="after3" src="https://github.com/user-attachments/assets/77936f69-ca76-435f-9de9-970f3f8bd4b5" />

Fixes #35764