### PR TITLE
fix: add a standard field in workspace sidebar

### DIFF
--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.json
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.json
@@ -11,7 +11,8 @@
   "app",
   "for_user",
   "items",
-  "module"
+  "module",
+  "standard"
  ],
  "fields": [
   {
@@ -49,12 +50,18 @@
    "fieldtype": "Text",
    "hidden": 1,
    "label": "Module"
+  },
+  {
+   "default": "0",
+   "fieldname": "standard",
+   "fieldtype": "Check",
+   "label": "Standard"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-12-10 20:20:26.518699",
+ "modified": "2026-01-08 14:06:28.659782",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace Sidebar",

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -29,6 +29,7 @@ class WorkspaceSidebar(Document):
 		for_user: DF.Link | None
 		items: DF.Table[WorkspaceSidebarItem]
 		module: DF.Text | None
+		standard: DF.Check
 		title: DF.Data | None
 	# end: auto-generated types
 

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -446,7 +446,8 @@
     bottom: 4%;
     right: 4%;
     z-index: 100;
-    opacity: 0.5;
+    opacity: 6%;
+    border-radius: 10px;
 }
 
 .desktop-edit:hover{

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -253,3 +253,4 @@ frappe.patches.v16_0.add_private_workspaces_to_sidebar
 frappe.core.doctype.communication_link.patches.copy_communication_date_to_link
 frappe.core.doctype.communication.patches.drop_ref_dt_dn_index
 frappe.patches.v16_0.change_link_type_to_workspace_sidebar
+frappe.patches.v16_0.add_standard_field_in_workspace_sidebar

--- a/frappe/patches/v16_0/add_standard_field_in_workspace_sidebar.py
+++ b/frappe/patches/v16_0/add_standard_field_in_workspace_sidebar.py
@@ -1,0 +1,12 @@
+import frappe
+from frappe.model.sync import check_if_record_exists
+
+
+def execute():
+	for sidebar in frappe.get_all("Workspace Sidebar", pluck="name"):
+		sidebar_doc = frappe.get_doc("Workspace Sidebar", sidebar)
+		if sidebar_doc.app and check_if_record_exists(
+			"app", frappe.get_app_path(sidebar_doc.app), "Workspace Sidebar", sidebar_doc.name
+		):
+			sidebar_doc.standard = 1
+			sidebar_doc.save()

--- a/frappe/workspace_sidebar/automation.json
+++ b/frappe/workspace_sidebar/automation.json
@@ -67,10 +67,11 @@
    "type": "Link"
   }
  ],
- "modified": "2025-11-25 10:46:09.343679",
+ "modified": "2026-01-08 14:16:38.557529",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Automation",
  "owner": "Administrator",
+ "standard": 1,
  "title": "Automation"
 }

--- a/frappe/workspace_sidebar/build.json
+++ b/frappe/workspace_sidebar/build.json
@@ -157,10 +157,11 @@
    "type": "Link"
   }
  ],
- "modified": "2025-11-25 10:46:09.743753",
+ "modified": "2026-01-08 14:16:38.951231",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Build",
  "owner": "Administrator",
+ "standard": 1,
  "title": "Build"
 }

--- a/frappe/workspace_sidebar/data.json
+++ b/frappe/workspace_sidebar/data.json
@@ -67,10 +67,11 @@
    "type": "Link"
   }
  ],
- "modified": "2025-11-25 10:46:09.376260",
+ "modified": "2026-01-08 14:16:38.613338",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Data",
  "owner": "Administrator",
+ "standard": 1,
  "title": "Data"
 }

--- a/frappe/workspace_sidebar/email.json
+++ b/frappe/workspace_sidebar/email.json
@@ -79,10 +79,11 @@
    "type": "Link"
   }
  ],
- "modified": "2025-11-25 10:46:09.687081",
+ "modified": "2026-01-08 14:16:38.914482",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email",
  "owner": "Administrator",
+ "standard": 1,
  "title": "Email"
 }

--- a/frappe/workspace_sidebar/integrations.json
+++ b/frappe/workspace_sidebar/integrations.json
@@ -149,10 +149,11 @@
    "type": "Link"
   }
  ],
- "modified": "2025-12-29 23:46:47.024937",
+ "modified": "2026-01-08 14:16:38.339024",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Integrations",
  "owner": "Administrator",
+ "standard": 1,
  "title": "Integrations"
 }

--- a/frappe/workspace_sidebar/my_workspaces.json
+++ b/frappe/workspace_sidebar/my_workspaces.json
@@ -6,9 +6,10 @@
  "header_icon": "user-round",
  "idx": 0,
  "items": [],
- "modified": "2025-11-25 10:46:09.369233",
+ "modified": "2026-01-08 14:16:38.600691",
  "modified_by": "Administrator",
  "name": "My Workspaces",
  "owner": "Administrator",
+ "standard": 1,
  "title": "My Workspaces"
 }

--- a/frappe/workspace_sidebar/printing.json
+++ b/frappe/workspace_sidebar/printing.json
@@ -55,10 +55,11 @@
    "type": "Link"
   }
  ],
- "modified": "2025-11-25 10:46:09.371604",
+ "modified": "2026-01-08 14:16:38.605839",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Printing",
  "owner": "Administrator",
+ "standard": 1,
  "title": "Printing"
 }

--- a/frappe/workspace_sidebar/productivity.json
+++ b/frappe/workspace_sidebar/productivity.json
@@ -55,10 +55,11 @@
    "type": "Link"
   }
  ],
- "modified": "2025-11-25 16:54:34.049137",
+ "modified": "2026-01-08 14:16:38.622012",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Productivity",
  "owner": "Administrator",
+ "standard": 1,
  "title": "Productivity"
 }

--- a/frappe/workspace_sidebar/system.json
+++ b/frappe/workspace_sidebar/system.json
@@ -226,10 +226,11 @@
    "type": "Link"
   }
  ],
- "modified": "2025-11-25 10:46:09.401204",
+ "modified": "2026-01-08 14:16:38.658526",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System",
  "owner": "Administrator",
+ "standard": 1,
  "title": "System"
 }

--- a/frappe/workspace_sidebar/users.json
+++ b/frappe/workspace_sidebar/users.json
@@ -135,10 +135,11 @@
    "type": "Link"
   }
  ],
- "modified": "2025-11-25 10:46:09.392824",
+ "modified": "2026-01-08 14:16:38.644051",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Users",
  "owner": "Administrator",
+ "standard": 1,
  "title": "Users"
 }

--- a/frappe/workspace_sidebar/website.json
+++ b/frappe/workspace_sidebar/website.json
@@ -101,10 +101,11 @@
    "type": "Link"
   }
  ],
- "modified": "2025-11-25 10:46:09.386543",
+ "modified": "2026-01-08 14:16:38.631875",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Website",
  "owner": "Administrator",
+ "standard": 1,
  "title": "Website"
 }


### PR DESCRIPTION
Adding a standard field in workspace sidebar 
This will help in clearing autogenerated sidebars 

This fixes the desktop edit button
<img width="1440" height="900" alt="Screenshot 2026-01-08 at 6 26 16 PM" src="https://github.com/user-attachments/assets/f162d98b-e330-422d-a371-ea9585e6b4c3" />
