### PR TITLE
fix(desktop): remove overlapping edit buttons on route change

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -223,6 +223,7 @@ class DesktopPage {
 	}
 	setup_edit_button() {
 		const me = this;
+		$(".desktop-edit").remove();
 		this.$desktop_edit_button = $(
 			"<button class='btn btn-reset desktop-edit'></button>"
 		).appendTo(document.body);
@@ -387,6 +388,10 @@ class DesktopPage {
 				me.$desktop_edit_button.remove();
 				$(".navbar").show();
 				frappe.desktop_utils.close_desktop_modal();
+				// stop edit mode if route changes and cleanup
+				me.edit_mode = false;
+				$(".desktop-icon").removeClass("edit-mode");
+				$(".desktop-wrapper").removeAttr("data-mode");
 			}
 		});
 	}


### PR DESCRIPTION
Fixes: #35772

---
**After Fix:**


https://github.com/user-attachments/assets/ce8b9e1a-bc68-4934-bcd5-18ba43446f78


---

The Desktop Edit button was getting duplicated when navigating between routes or reloading the Desktop page.
Since the button is appended directly to `document.body`, the existing instance was not always cleaned up.

<img width="806" height="146" alt="duplicated-desktop-edit-btn" src="https://github.com/user-attachments/assets/d0b2d228-d43e-447e-a755-6d17d239d0d0" />

To fix this, I removed any existing Desktop Edit button before creating a new one:

```js
$(".desktop-edit").remove();
```

---
`no-docs`