### PR TITLE
fix: RTL direction for login form inputs

### DIFF
--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -1,5 +1,7 @@
 {% extends "templates/web.html" %}
 
+{% set input_dir = "rtl" if is_rtl() else "ltr" %}
+
 {% macro email_login_body() -%}
 {% if not disable_user_pass_login or (ldap_settings and ldap_settings.enabled) %}
 <div class="page-card-body">
@@ -7,6 +9,7 @@
 		<label class="form-label sr-only" for="login_email">{{ login_label or _("Email")}}</label>
 		<div class="email-field">
 			<input type="text" id="login_email" class="form-control"
+				dir="{{ input_dir }}"
 				placeholder="{% if login_name_placeholder %}{{ login_name_placeholder  }}{% else %}{{ _('jane@example.com') }}{% endif %}"
 				required autofocus autocomplete="username">
 
@@ -21,6 +24,7 @@
 		<label class="form-label sr-only" for="login_password">{{ _("Password") }}</label>
 		<div class="password-field">
 			<input type="password" id="login_password" class="form-control" placeholder="•••••"
+				dir="{{ input_dir }}"
 				autocomplete="current-password" required>
 
 			<svg class="field-icon password-icon" width="16" height="16" viewBox="0 0 16 16" fill="none"
@@ -180,6 +184,7 @@
 				<div class="page-card-body">
 					<div class="email-field">
 						<input type="email" id="forgot_email" class="form-control"
+							dir="{{ input_dir }}"
 							placeholder="{{ _('Email Address') }}" required autofocus autocomplete="username">
 						<svg class="field-icon email-icon" width="20" height="20" viewBox="0 0 20 20" fill="none"
 							xmlns="http://www.w3.org/2000/svg">
@@ -212,6 +217,7 @@
 				<div class="page-card-body">
 					<div class="email-field">
 						<input type="email" id="login_with_email_link_email" class="form-control"
+							dir="{{ input_dir }}"
 							placeholder="{{ _('Email Address') }}" required autofocus autocomplete="username">
 						<svg class="field-icon email-icon" width="20" height="20" viewBox="0 0 20 20" fill="none"
 							xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
Fix Username and Password inputs remaining LTR on RTL login page.

## Related Issue
Fixes #35726

## Changes Made
- Added `input_dir` Jinja variable using `is_rtl()` 
- Applied `dir="{{ input_dir }}"` to login form inputs so the caret/text flows RTL in RTL locales
- Inputs updated: `login_email`, `login_password`, `forgot_email`, `login_with_email_link_email`

## Testing
- Tested on RTL page layout
- Inputs now correctly align to RTL direction
-


Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=105917501
