### PR TITLE
fix: RTL direction for login form inputs

### DIFF
--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -112,6 +112,12 @@ body {
 				}
 			}
 
+			.password-field {
+				input[dir="rtl"] {
+					padding-right: 35px;
+				}
+			}
+
 			.btn-login-option {
 				@include get_textstyle("base", "medium");
 				color: var(--text-gray-700);

--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -87,7 +87,6 @@ body {
 			}
 
 			.field-icon {
-				/* rtl:ignore */
 				left: 9px;
 				top: 50%;
 				transform: translateY(-50%);
@@ -101,12 +100,10 @@ body {
 				position: relative;
 
 				input {
-					/* rtl:ignore */
 					padding-left: 35px;
 				}
 
 				.toggle-password {
-					/* rtl:ignore */
 					right: 9px;
 					top: 5px;
 					position: absolute;
@@ -119,7 +116,7 @@ body {
 			.password-field {
 				input[dir="rtl"] {
 					/* rtl:ignore */
-					padding-right: 3.5rem;
+					padding-left: 3.5rem;
 				}
 			}
 

--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -76,6 +76,7 @@ body {
 			}
 
 			.forgot-password-message {
+				/* rtl:ignore */
 				text-align: right;
 				line-height: 1;
 
@@ -86,6 +87,7 @@ body {
 			}
 
 			.field-icon {
+				/* rtl:ignore */
 				left: 9px;
 				top: 50%;
 				transform: translateY(-50%);
@@ -99,10 +101,12 @@ body {
 				position: relative;
 
 				input {
+					/* rtl:ignore */
 					padding-left: 35px;
 				}
 
 				.toggle-password {
+					/* rtl:ignore */
 					right: 9px;
 					top: 5px;
 					position: absolute;
@@ -114,7 +118,8 @@ body {
 
 			.password-field {
 				input[dir="rtl"] {
-					padding-right: 35px;
+					/* rtl:ignore */
+					padding-right: 3.5rem;
 				}
 			}
 

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -36,7 +36,7 @@
 
 	{% if not disable_user_pass_login %}
 	<p class="forgot-password-message">
-		<a href="#forgot">{{ _("Forgot Password?") }}</a>
+		<a href="#forgot" dir="auto">{{ _("Forgot Password?") }}</a>
 	</p>
 	{% endif %}
 </div>

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -1,13 +1,15 @@
 {% extends "templates/web.html" %}
 {% block navbar %}{% endblock %}
 
+{% set input_dir = "rtl" if is_rtl() else "ltr" %}
+
 {% macro email_login_body() -%}
 {% if not disable_user_pass_login or (ldap_settings and ldap_settings.enabled) %}
 <div class="page-card-body">
 	<div class="form-group">
 		<label class="form-label sr-only" for="login_email">{{ login_label or _("Email")}}</label>
 		<div class="email-field">
-			<input type="text" id="login_email" class="form-control"
+			<input type="text" id="login_email" class="form-control" dir="{{ input_dir }}"
 				placeholder="{% if login_name_placeholder %}{{ login_name_placeholder  }}{% else %}{{ _('jane@example.com') }}{% endif %}"
 				required autofocus autocomplete="username">
 
@@ -21,7 +23,7 @@
 	<div class="form-group">
 		<label class="form-label sr-only" for="login_password">{{ _("Password") }}</label>
 		<div class="password-field">
-			<input type="password" id="login_password" class="form-control" placeholder="•••••"
+			<input type="password" id="login_password" class="form-control" dir="{{ input_dir }}" placeholder="•••••"
 				autocomplete="current-password" required>
 
 			<svg class="field-icon password-icon" width="16" height="16" viewBox="0 0 16 16" fill="none"
@@ -180,7 +182,7 @@
 			<form class="form-signin form-forgot hide" role="form">
 				<div class="page-card-body">
 					<div class="email-field">
-						<input type="email" id="forgot_email" class="form-control"
+						<input type="email" id="forgot_email" class="form-control" dir="{{ input_dir }}"
 							placeholder="{{ _('Email Address') }}" required autofocus autocomplete="username">
 						<svg class="field-icon email-icon" width="16" height="16" viewBox="0 0 16 16" fill="none"
 							xmlns="http://www.w3.org/2000/svg">
@@ -207,7 +209,7 @@
 			<form class="form-signin form-login-with-email-link hide" role="form">
 				<div class="page-card-body">
 					<div class="email-field">
-						<input type="email" id="login_with_email_link_email" class="form-control"
+						<input type="email" id="login_with_email_link_email" class="form-control" dir="{{ input_dir }}"
 							placeholder="{{ _('Email Address') }}" required autofocus autocomplete="username">
 						<svg class="field-icon email-icon" width="16" height="16" viewBox="0 0 16 16" fill="none"
 							xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
Fix Username and Password inputs remaining LTR on RTL login page.

## Related Issue
Fixes #35726

## Changes Made
- Added `input_dir` Jinja variable using `is_rtl()` 
- Applied `dir="{{ input_dir }}"` to login form inputs so the caret/text flows RTL in RTL locales
- Inputs updated: `login_email`, `login_password`, `forgot_email`, `login_with_email_link_email`

## Testing
- Tested on RTL page layout
- Inputs now correctly align to RTL direction

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=105917501
