### PR TITLE
fix: importing packages with scripts that have "." in the script name

### DIFF
--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -248,7 +248,7 @@ def load_code_properties(doc, path):
 		if hasattr(doc, "get_code_fields"):
 			dirname, filename = os.path.split(path)
 			for key, extn in doc.get_code_fields().items():
-				codefile = os.path.join(dirname, filename[:filename.rfind(".")] + "." + extn)
+				codefile = os.path.join(dirname, filename[: filename.rfind(".")] + "." + extn)
 				if os.path.exists(codefile):
 					with open(codefile) as txtfile:
 						doc.set(key, txtfile.read())

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -248,7 +248,7 @@ def load_code_properties(doc, path):
 		if hasattr(doc, "get_code_fields"):
 			dirname, filename = os.path.split(path)
 			for key, extn in doc.get_code_fields().items():
-				codefile = os.path.join(dirname, filename.split(".", 1)[0] + "." + extn)
+				codefile = os.path.join(dirname, filename[:filename.rfind(".")] + "." + extn)
 				if os.path.exists(codefile):
 					with open(codefile) as txtfile:
 						doc.set(key, txtfile.read())


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

### Problem
If a Package contains Server Scripts that have any `.` in the script's name, then during package import those scripts will be imported with empty script bodies.

### Solution
Change the code that finds the script file during import to check for the last `.` in the filename instead of just splitting and taking the first part.
