### PR TITLE
fix: improve quick entry link field handling

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -199,8 +199,8 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		// reference to calling link
 		frappe._from_link = {
 			field_obj: this,
-			from_doctype: this.doctype,
-			from_docname: this.doc?.name,
+			doc: this.doc,
+			set_route_args: ["Form", this.frm?.doctype, this.frm?.docname],
 			scrollY: $(document).scrollTop(),
 		};
 

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -247,12 +247,10 @@ frappe.ui.form.remove_old_form_route = () => {
 frappe.ui.form.update_calling_link = async (newdoc) => {
 	if (!frappe._from_link) return;
 
-	const { field_obj, from_doctype, from_docname, scrollY } = frappe._from_link;
+	const { field_obj, doc, set_route_args, scrollY } = frappe._from_link;
 	const df = field_obj.df;
 
 	if (!["Link", "Dynamic Link", "Table MultiSelect"].includes(df.fieldtype)) return;
-
-	const doc = frappe.get_doc(from_doctype, from_docname);
 
 	const is_valid_doctype = () => {
 		switch (df.fieldtype) {
@@ -270,7 +268,7 @@ frappe.ui.form.update_calling_link = async (newdoc) => {
 	// switch back to the original doc first,
 	// this is necessary in case from_link.doctype === newdoc.doctype
 	if (field_obj.frm) {
-		await frappe.set_route("Form", from_doctype, from_docname);
+		await frappe.set_route(...set_route_args);
 		frappe.utils.scroll_to(scrollY);
 	}
 
@@ -286,15 +284,10 @@ frappe.ui.form.update_calling_link = async (newdoc) => {
 
 	// set value
 	if (doc && doc.parentfield) {
-		//update values for child table
-		$.each(
-			field_obj.frm.fields_dict[doc.parentfield].grid.grid_rows,
-			function (_index, field) {
-				if (field.doc && field.doc.name === from_docname) {
-					field_obj.set_value(newdoc.name);
-				}
-			}
+		const row_exists = field_obj.frm.fields_dict[doc.parentfield].grid.grid_rows.find(
+			(row) => row.doc.name === doc.name
 		);
+		if (row_exists) field_obj.set_value(newdoc.name);
 	} else {
 		// parsing is needed for table multiselect to convert string to array
 		field_obj.parse_validate_and_set_in_model(newdoc.name);


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/35778

## Description
Improves the handling of link fields after quick entry creation by refactoring how the calling context is tracked and restored.

## Changes
- Store doc reference directly in `frappe._from_link` instead of separate doctype/docname properties
- Use flexible `set_route_args` array for routing back to source form (supports child tables)
- Simplify child table row lookup using `.find()` instead of `$.each`
- Add row existence check before setting value to prevent errors
