### PR TITLE
fix(search): make QB DB-Aware when using Locate

### DIFF
--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -25,8 +25,21 @@ class Concat_ws(Function):
 
 
 class Locate(Function):
-	def __init__(self, *terms, **kwargs):
-		super().__init__("LOCATE", *terms, **kwargs)
+	def __init__(self, needle, haystack, **kwargs):
+		super().__init__("LOCATE", needle, haystack, **kwargs)
+
+
+class Strpos(Function):
+	def __init__(self, needle, haystack, **kwargs):
+		super().__init__("STRPOS", haystack, needle, **kwargs)
+
+
+class Instr(Function):
+	def __init__(self, needle, haystack, **kwargs):
+		super().__init__("INSTR", haystack, needle, **kwargs)
+
+
+Locate = ImportMapper({db_type_is.MARIADB: Locate, db_type_is.POSTGRES: Strpos, db_type_is.SQLITE: Instr})
 
 
 # for backward compatibility

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -1812,10 +1812,21 @@ class TestQuery(IntegrationTestCase):
 			],
 		)
 		sql = query.get_sql()
-		self.assertIn(
-			self.normalize_sql("1/NULLIF(LOCATE('test',`name`),0) `relevance`"),
-			self.normalize_sql(sql),
-		)
+		if frappe.db.db_type == "mariadb":
+			self.assertIn(
+				self.normalize_sql("1/NULLIF(LOCATE('test',`name`),0) `relevance`"),
+				self.normalize_sql(sql),
+			)
+		elif frappe.db.db_type == "postgres":
+			self.assertIn(
+				self.normalize_sql("1/NULLIF(STRPOS(`name`,'test'),0) `relevance`"),
+				self.normalize_sql(sql),
+			)
+		elif frappe.db.db_type == "sqlite":
+			self.assertIn(
+				self.normalize_sql("1/NULLIF(INSTR(`name`,'test'),0) `relevance`"),
+				self.normalize_sql(sql),
+			)
 
 		# Test multiple operators in fields
 		query = frappe.qb.get_query(


### PR DESCRIPTION
**fix(search):** This PR aims to make QB **smarter** by becoming DB-aware and accordingly choosing appropriate functions. This PR is related to resolving any search related issues in particular due to how Locate is written in `database.py` file wherein in case of Postgres a substitution is made with `STRPOS` as is required by Postgres. Through this PR, QB becomes smarter and does this substitution internally in ORM itself. This PR is also a step forward towards resolving #21613 and completes a part of the Postgres TODO #34660 . 

**Before:**
Using Locate even though DB is Postgres (0 DB awareness)

**After:**
<img width="1020" height="192" alt="image" src="https://github.com/user-attachments/assets/475de2cc-9101-44f4-b5a4-6d28e60dd98a" />


related to #34533
related to #35512