### PR TITLE
fix: missing arguements while creating a private workspace and improve UX

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -778,7 +778,7 @@ frappe.views.Workspace = class Workspace {
 								message: __("Saved"),
 								indicator: "green",
 							});
-							frappe.set_route("desk","private",page.title)
+							frappe.set_route("desk", "private", page.title);
 						}
 					},
 				});

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -778,6 +778,7 @@ frappe.views.Workspace = class Workspace {
 								message: __("Saved"),
 								indicator: "green",
 							});
+							frappe.set_route("desk","private",page.title)
 						}
 					},
 				});

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -532,9 +532,6 @@ frappe.views.Workspace = class Workspace {
 			primary_action: (values) => {
 				values.title = strip_html(values.title);
 				d.hide();
-				if (values.type === "Workspace") {
-					this.setup_customization_buttons({ is_editable: true });
-				}
 
 				let name = values.title + (values.is_public ? "" : "-" + frappe.session.user);
 				let blocks = [
@@ -562,6 +559,10 @@ frappe.views.Workspace = class Workspace {
 					link_to: values.link_to,
 					external_link: values.external_link,
 				};
+
+				if (values.type === "Workspace") {
+					this.setup_customization_buttons(new_page);
+				}
 
 				if (new_page.type !== "Workspace") {
 					this.create_page(new_page);


### PR DESCRIPTION
### **Problem:**
While creating a new private Workspace, saving the Workspace triggers an HTTP 500 error.

### **Root Cause**
In workspace.js, inside initialize_new_page(), the framework enters customization mode by calling setup_customization_buttons() with a partial page object:

`{ is_editable: true }`

setup_customization_buttons() internally creates the Save primary action using a closure reference to this page object. When Save is clicked, save_page(page) is called, which expects a complete page descriptor containing name and public fields.

The backend whitelisted method requires the following parameters:

`def save_page(name, public, new_widgets, blocks)`

Since the frontend passes only { is_editable: true }, the API call is executed with missing required arguments, causing a TypeError and resulting in an HTTP 500 error.

This issue specifically affects newly created private Workspaces.

### **Fix:**
Instead of passing a partial object, the full newly constructed page descriptor is now passed into setup_customization_buttons():

`this.setup_customization_buttons(new_page)`

This ensures that the Save primary action always holds a valid page object containing name, public, and other required fields, preventing backend crashes.

### **Result:**

Prevents HTTP 500 when saving newly created private Workspaces

Ensures save_page() always receives valid arguments

No behavioral change to existing Workspace editing flow

### **Scope:**

Affected file: frappe/frappe/public/js/frappe/views/workspace/workspace.js
Area: Workspace creation flow

### **Preview of the bug:**

**Before Fix:**

https://github.com/user-attachments/assets/44eef40a-931e-4f38-902b-03654c686889

**After Fix:**

https://github.com/user-attachments/assets/844c06e1-3951-4f9a-b1ee-ec03e600b862
