### PR TITLE
fix: remove "My Workspaces" from framework siblings

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -84,6 +84,7 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 
 	fetch_related_icons() {
 		let sibling_workspaces = [];
+		let workspaces_not_to_show = ["My Workspaces"];
 		if (frappe.current_app) {
 			let desktop_icons = [...frappe.boot.desktop_icons];
 			desktop_icons.splice(
@@ -93,27 +94,31 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 			let { folder_map, sibling_icons } = this.build_folder_map(desktop_icons);
 			sibling_icons.forEach((icon) => {
 				if (folder_map[icon.parent_icon]) return;
-				let item = {
-					name: icon.label.toLowerCase(),
-					label: icon.label,
-					url: frappe.utils.get_route_for_icon(icon),
-				};
-				if (icon.icon_type == "Folder") {
-					let nested_items = folder_map[item.label];
-					nested_items.forEach((item) => {
-						this.get_icon_for_menu_item(item, item);
-					});
-					item.items = nested_items;
+				if (!workspaces_not_to_show.includes(icon.label)) {
+					let item = {
+						name: icon.label.toLowerCase(),
+						label: icon.label,
+						url: frappe.utils.get_route_for_icon(icon),
+					};
+					if (icon.icon_type == "Folder") {
+						let nested_items = folder_map[item.label];
+						nested_items.forEach((item) => {
+							this.get_icon_for_menu_item(item, item);
+						});
+						item.items = nested_items;
+					}
+					if (
+						frappe.utils.get_desktop_icon(icon.label, frappe.boot.desktop_icon_style)
+					) {
+						item.icon_url = frappe.utils.get_desktop_icon(
+							icon.label,
+							frappe.boot.desktop_icon_style
+						);
+					} else {
+						item.icon_html = frappe.utils.desktop_icon(icon.label, "gray", "sm");
+					}
+					sibling_workspaces.push(item);
 				}
-				if (frappe.utils.get_desktop_icon(icon.label, frappe.boot.desktop_icon_style)) {
-					item.icon_url = frappe.utils.get_desktop_icon(
-						icon.label,
-						frappe.boot.desktop_icon_style
-					);
-				} else {
-					item.icon_html = frappe.utils.desktop_icon(icon.label, "gray", "sm");
-				}
-				sibling_workspaces.push(item);
 			});
 			return sibling_workspaces;
 		}


### PR DESCRIPTION
Removing the reference to my workspaces from framework app sidebars

<img width="554" height="448" alt="Screenshot 2026-01-09 at 6 14 51 PM" src="https://github.com/user-attachments/assets/352c8a63-d144-4383-88fd-7be472a2b55e" />

Maybe it can be in all app sidebars. Will re think and add back