### PR TITLE
fix: make translation for link field value irrespective of user permi…

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -164,6 +164,7 @@ frappe.form.formatters = {
 		return `<input type="checkbox" disabled
 			class="disabled-${value ? "selected" : "deselected"}">`;
 	},
+
 	Link: function (value, docfield, options, doc) {
 		var doctype = docfield._options || docfield.options;
 		var original_value = value;
@@ -178,7 +179,7 @@ frappe.form.formatters = {
 		}
 
 		if (options && (options.for_print || options.only_value)) {
-			return link_title || value;
+			return get_link_display_value(doctype, link_title, value);
 		}
 
 		if (frappe.form.link_formatters[doctype]) {
@@ -211,10 +212,10 @@ frappe.form.formatters = {
 				a.innerText = __((options && options.label) || link_title || value);
 				return a.outerHTML;
 			} else {
-				return link_title || value;
+				return get_link_display_value(doctype, link_title, value);
 			}
 		} else {
-			return link_title || value;
+			return get_link_display_value(doctype, link_title, value);
 		}
 	},
 	Date: function (value) {
@@ -407,6 +408,13 @@ frappe.form.formatters = {
 	AttachImage: format_attachment_url,
 };
 
+function get_link_display_value(doctype, link_title, value) {
+	let translated_doctypes = frappe.boot?.translated_doctypes || [];
+	if (translated_doctypes.includes(doctype)) {
+		return __(link_title || value);
+	}
+	return link_title || value;
+}
 function format_attachment_url(url) {
 	return url ? `<a href="${url}" target="_blank">${url}</a>` : "";
 }


### PR DESCRIPTION
**Issue:** [#35288](https://github.com/frappe/frappe/issues/35288)
 
**Description:** When Translation is applied to any link field options, then the translation doesn't apply for user other than Administrator or user with System Manager role.

<img width="1029" height="207" alt="Screenshot from 2026-01-09 18-25-37" src="https://github.com/user-attachments/assets/9215d206-a738-4be4-8e80-b93c49eb1656" />

**Before:**

<img width="1028" height="284" alt="Screenshot from 2026-01-09 18-43-48_spotlight" src="https://github.com/user-attachments/assets/1eec474e-e1ab-4711-9923-dda83bc86c5f" />

**After:**
<img width="1015" height="236" alt="Screenshot from 2026-01-09 18-57-35_spotlight" src="https://github.com/user-attachments/assets/1289e3ed-c8c6-4de9-a501-d585da82f905" />


