### PR TITLE
fix: reduce z-index on sticky-top

### DIFF
--- a/frappe/public/scss/desk/main.scss
+++ b/frappe/public/scss/desk/main.scss
@@ -42,3 +42,6 @@ body {
 	overflow-y: visible;
 	scrollbar-gutter: stable;
 }
+.sticky-top {
+	z-index: 1019;
+}


### PR DESCRIPTION
Fixes this issue on mobile

<img width="308" height="497" alt="Screenshot 2026-01-09 at 7 21 53 PM" src="https://github.com/user-attachments/assets/7b2ed3ef-6fc5-46ad-80a3-60250cb28f86" />
