### PR TITLE
refactor: user actions in sidebar with optional icons

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1271,10 +1271,10 @@ frappe.ui.form.Form = class FrappeForm {
 		}
 	}
 
-	add_web_link(path, label) {
+	add_web_link(path, label, icon) {
 		label = __(label) || __("See on Website");
 		this.web_link = this.sidebar
-			.add_user_action(__(label), function () {})
+			.add_user_action(__(label), function () {}, icon || "external-link")
 			.attr("href", path || this.doc.route)
 			.attr("target", "_blank");
 	}

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -190,15 +190,17 @@ frappe.ui.form.Sidebar = class {
 		});
 	}
 
-	add_user_action(label, click) {
-		return $("<a>")
-			.html(label)
-			.appendTo(
-				$('<div class="user-action-row"></div>').appendTo(
-					this.user_actions.removeClass("hidden")
-				)
-			)
-			.on("click", click);
+	add_user_action(label, click, icon) {
+		const $row = $('<div class="user-action-row"></div>').appendTo(
+			this.user_actions.removeClass("hidden")
+		);
+		const $link = $("<a>").html(label).appendTo($row).on("click", click);
+
+		if (icon) {
+			$link.append(frappe.utils.icon(icon, "sm", "", "", "m-1"));
+		}
+
+		return $link;
 	}
 
 	clear_user_actions() {


### PR DESCRIPTION
**Closes**: #35735

----
**Before:**
<img width="552" height="232" alt="image" src="https://github.com/user-attachments/assets/f9927e91-3c5a-40ac-bbfb-f7d93767230d" />

**After**
<img width="362" height="194" alt="image" src="https://github.com/user-attachments/assets/4053bab2-aaa6-4a1c-9edf-0e9b7b2582f6" />

---
`no-docs`