### PR TITLE
fix: add missing options for Event Notifications interval

### DIFF
--- a/frappe/desk/doctype/event_notifications/event_notifications.json
+++ b/frappe/desk/doctype/event_notifications/event_notifications.json
@@ -1,58 +1,58 @@
 {
-    "actions": [],
-    "allow_rename": 1,
-    "creation": "2025-10-01 14:19:43.271468",
-    "doctype": "DocType",
-    "editable_grid": 1,
-    "engine": "InnoDB",
-    "field_order": [
-        "type",
-        "before",
-        "interval",
-        "time"
-    ],
-    "fields": [
-        {
-            "default": "Notification",
-            "fieldname": "type",
-            "fieldtype": "Select",
-            "in_list_view": 1,
-            "label": "Type",
-            "options": "Notification\nEmail"
-        },
-        {
-            "fieldname": "before",
-            "fieldtype": "Int",
-            "in_list_view": 1,
-            "label": "Before"
-        },
-        {
-            "fieldname": "interval",
-            "fieldtype": "Select",
-            "in_list_view": 1,
-            "label": "Interval",
-            "options": "days\nweeks"
-        },
-        {
-            "fieldname": "time",
-            "fieldtype": "Time",
-            "in_list_view": 1,
-            "label": "Time"
-        }
-    ],
-    "grid_page_length": 50,
-    "index_web_pages_for_search": 1,
-    "istable": 1,
-    "links": [],
-    "modified": "2025-10-01 14:26:21.526868",
-    "modified_by": "Administrator",
-    "module": "Desk",
-    "name": "Event Notifications",
-    "owner": "Administrator",
-    "permissions": [],
-    "row_format": "Dynamic",
-    "rows_threshold_for_grid_search": 20,
-    "sort_field": "creation",
-    "sort_order": "DESC",
-    "states": []
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-10-01 14:19:43.271468",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "type",
+  "before",
+  "interval",
+  "time"
+ ],
+ "fields": [
+  {
+   "default": "Notification",
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Type",
+   "options": "Notification\nEmail"
+  },
+  {
+   "fieldname": "before",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Before"
+  },
+  {
+   "fieldname": "interval",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Interval",
+   "options": "days\nweeks"
+  },
+  {
+   "fieldname": "time",
+   "fieldtype": "Time",
+   "in_list_view": 1,
+   "label": "Time"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-10-01 14:26:21.526868",
+ "modified_by": "Administrator",
+ "module": "Desk",
+ "name": "Event Notifications",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
 }

--- a/frappe/desk/doctype/event_notifications/event_notifications.json
+++ b/frappe/desk/doctype/event_notifications/event_notifications.json
@@ -1,57 +1,58 @@
 {
- "actions": [],
- "allow_rename": 1,
- "creation": "2025-10-01 14:19:43.271468",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "type",
-  "before",
-  "interval",
-  "time"
- ],
- "fields": [
-  {
-   "default": "Notification",
-   "fieldname": "type",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Type",
-   "options": "Notification\nEmail"
-  },
-  {
-   "fieldname": "before",
-   "fieldtype": "Int",
-   "in_list_view": 1,
-   "label": "Before"
-  },
-  {
-   "fieldname": "interval",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Interval"
-  },
-  {
-   "fieldname": "time",
-   "fieldtype": "Time",
-   "in_list_view": 1,
-   "label": "Time"
-  }
- ],
- "grid_page_length": 50,
- "index_web_pages_for_search": 1,
- "istable": 1,
- "links": [],
- "modified": "2025-10-01 14:26:21.526868",
- "modified_by": "Administrator",
- "module": "Desk",
- "name": "Event Notifications",
- "owner": "Administrator",
- "permissions": [],
- "row_format": "Dynamic",
- "rows_threshold_for_grid_search": 20,
- "sort_field": "creation",
- "sort_order": "DESC",
- "states": []
+    "actions": [],
+    "allow_rename": 1,
+    "creation": "2025-10-01 14:19:43.271468",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+        "type",
+        "before",
+        "interval",
+        "time"
+    ],
+    "fields": [
+        {
+            "default": "Notification",
+            "fieldname": "type",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "label": "Type",
+            "options": "Notification\nEmail"
+        },
+        {
+            "fieldname": "before",
+            "fieldtype": "Int",
+            "in_list_view": 1,
+            "label": "Before"
+        },
+        {
+            "fieldname": "interval",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "label": "Interval",
+            "options": "days\nweeks"
+        },
+        {
+            "fieldname": "time",
+            "fieldtype": "Time",
+            "in_list_view": 1,
+            "label": "Time"
+        }
+    ],
+    "grid_page_length": 50,
+    "index_web_pages_for_search": 1,
+    "istable": 1,
+    "links": [],
+    "modified": "2025-10-01 14:26:21.526868",
+    "modified_by": "Administrator",
+    "module": "Desk",
+    "name": "Event Notifications",
+    "owner": "Administrator",
+    "permissions": [],
+    "row_format": "Dynamic",
+    "rows_threshold_for_grid_search": 20,
+    "sort_field": "creation",
+    "sort_order": "DESC",
+    "states": []
 }


### PR DESCRIPTION
The 'interval' field in 'Event Notifications' was missing options 'days' and 'weeks'. This PR adds them to allow proper selection.