### PR TITLE
feat: allow use of chrome pdf generator for standard print format

### DIFF
--- a/frappe/printing/doctype/print_settings/print_settings.json
+++ b/frappe/printing/doctype/print_settings/print_settings.json
@@ -8,7 +8,7 @@
   "pdf_settings",
   "send_print_as_pdf",
   "repeat_header_footer",
-  "pdf_generator_for_standard_format",
+  "pdf_generator",
   "column_break_4",
   "pdf_page_size",
   "pdf_page_height",
@@ -174,9 +174,9 @@
   },
   {
    "default": "wkhtmltopdf",
-   "fieldname": "pdf_generator_for_standard_format",
+   "fieldname": "pdf_generator",
    "fieldtype": "Select",
-   "label": "PDF Generator for Standard Format",
+   "label": "PDF Generator",
    "options": "wkhtmltopdf\nchrome"
   }
  ],
@@ -184,7 +184,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-10 11:08:14.847391",
+ "modified": "2026-01-10 11:54:14.176810",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Settings",

--- a/frappe/printing/doctype/print_settings/print_settings.json
+++ b/frappe/printing/doctype/print_settings/print_settings.json
@@ -8,7 +8,7 @@
   "pdf_settings",
   "send_print_as_pdf",
   "repeat_header_footer",
-  "use_chrome_for_standard_format",
+  "pdf_generator_for_standard_format",
   "column_break_4",
   "pdf_page_size",
   "pdf_page_height",
@@ -173,17 +173,18 @@
    "label": "PDF Page Width (in mm)"
   },
   {
-   "default": "0",
-   "fieldname": "use_chrome_for_standard_format",
-   "fieldtype": "Check",
-   "label": "Use Chrome for Standard Format"
+   "default": "wkhtmltopdf",
+   "fieldname": "pdf_generator_for_standard_format",
+   "fieldtype": "Select",
+   "label": "PDF Generator for Standard Format",
+   "options": "wkhtmltopdf\nchrome"
   }
  ],
  "icon": "fa fa-cog",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-10 08:47:37.915137",
+ "modified": "2026-01-10 11:08:14.847391",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Settings",
@@ -198,6 +199,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/printing/doctype/print_settings/print_settings.json
+++ b/frappe/printing/doctype/print_settings/print_settings.json
@@ -8,6 +8,7 @@
   "pdf_settings",
   "send_print_as_pdf",
   "repeat_header_footer",
+  "use_chrome_for_standard_format",
   "column_break_4",
   "pdf_page_size",
   "pdf_page_height",
@@ -170,13 +171,19 @@
    "fieldname": "pdf_page_width",
    "fieldtype": "Float",
    "label": "PDF Page Width (in mm)"
+  },
+  {
+   "default": "0",
+   "fieldname": "use_chrome_for_standard_format",
+   "fieldtype": "Check",
+   "label": "Use Chrome for Standard Format"
   }
  ],
  "icon": "fa fa-cog",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-23 16:03:35.392721",
+ "modified": "2026-01-10 08:47:37.915137",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Settings",

--- a/frappe/printing/doctype/print_settings/print_settings.py
+++ b/frappe/printing/doctype/print_settings/print_settings.py
@@ -24,7 +24,7 @@ class PrintSettings(Document):
 		enable_raw_printing: DF.Check
 		font: DF.Literal["Default", "Helvetica Neue", "Arial", "Helvetica", "Inter", "Verdana", "Monospace"]
 		font_size: DF.Float
-		pdf_generator_for_standard_format: DF.Literal["wkhtmltopdf", "chrome"]
+		pdf_generator: DF.Literal["wkhtmltopdf", "chrome"]
 		pdf_page_height: DF.Float
 		pdf_page_size: DF.Literal[
 			"A0",

--- a/frappe/printing/doctype/print_settings/print_settings.py
+++ b/frappe/printing/doctype/print_settings/print_settings.py
@@ -24,6 +24,7 @@ class PrintSettings(Document):
 		enable_raw_printing: DF.Check
 		font: DF.Literal["Default", "Helvetica Neue", "Arial", "Helvetica", "Inter", "Verdana", "Monospace"]
 		font_size: DF.Float
+		pdf_generator_for_standard_format: DF.Literal["wkhtmltopdf", "chrome"]
 		pdf_page_height: DF.Float
 		pdf_page_size: DF.Literal[
 			"A0",
@@ -62,7 +63,6 @@ class PrintSettings(Document):
 		print_style: DF.Link | None
 		repeat_header_footer: DF.Check
 		send_print_as_pdf: DF.Check
-		use_chrome_for_standard_format: DF.Check
 		with_letterhead: DF.Check
 	# end: auto-generated types
 

--- a/frappe/printing/doctype/print_settings/print_settings.py
+++ b/frappe/printing/doctype/print_settings/print_settings.py
@@ -62,6 +62,7 @@ class PrintSettings(Document):
 		print_style: DF.Link | None
 		repeat_header_footer: DF.Check
 		send_print_as_pdf: DF.Check
+		use_chrome_for_standard_format: DF.Check
 		with_letterhead: DF.Check
 	# end: auto-generated types
 

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -712,7 +712,7 @@ frappe.ui.form.PrintView = class {
 	}
 	get_pdf_generator(pdf_generator) {
 		if (!pdf_generator) {
-			pdf_generator = this.print_settings.pdf_generator_for_standard_format || "wkhtmltopdf";
+			pdf_generator = this.print_settings.pdf_generator || "wkhtmltopdf";
 		}
 		return pdf_generator;
 	}

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -710,8 +710,16 @@ frappe.ui.form.PrintView = class {
 			);
 		}
 	}
-
-	render_page(method, printit = false, pdf_generator = "wkhtmltopdf") {
+	get_pdf_generator(pdf_generator) {
+		if (!pdf_generator) {
+			pdf_generator = cint(this.print_settings.use_chrome_for_standard_format)
+				? "chrome"
+				: "wkhtmltopdf";
+		}
+		return pdf_generator;
+	}
+	render_page(method, printit = false, pdf_generator) {
+		pdf_generator = this.get_pdf_generator(pdf_generator);
 		let w = window.open(
 			frappe.urllib.get_full_url(
 				method +

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -712,9 +712,7 @@ frappe.ui.form.PrintView = class {
 	}
 	get_pdf_generator(pdf_generator) {
 		if (!pdf_generator) {
-			pdf_generator = cint(this.print_settings.use_chrome_for_standard_format)
-				? "chrome"
-				: "wkhtmltopdf";
+			pdf_generator = this.print_settings.pdf_generator_for_standard_format || "wkhtmltopdf";
 		}
 		return pdf_generator;
 	}

--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -175,7 +175,7 @@ def find_or_download_chromium_executable():
 	import shutil
 	from pathlib import Path
 
-	if chromium_path := shutil.which(frappe.get_common_site_config().chromium_path):
+	if chromium_path := shutil.which(frappe.get_common_site_config().get("chromium_path", "")):
 		return chromium_path
 
 	bench_path = frappe.utils.get_bench_path()


### PR DESCRIPTION
There was no way for users to toggle between chrome based pdf generator and wkthmltopdf. This PR fixes it.


## Print Settings

<img width="1470" height="799" alt="Print Settings" src="https://github.com/user-attachments/assets/5b78b6ac-2006-42ba-902c-ac7ae9b7fb2e" />


## Before

<img width="1469" height="879" alt="before" src="https://github.com/user-attachments/assets/19491b07-8846-4787-80bc-343401695a94" />


## After

<img width="1469" height="878" alt="after" src="https://github.com/user-attachments/assets/0c0f1ab1-c189-4c67-a3ed-4358a959ef93" />

`no docs`

Support: https://support.frappe.io/helpdesk/tickets/55977