### PR TITLE
fix(Desk): Standard Workspaces without DocTypes in Module do not show

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -233,7 +233,12 @@ def get_user_pages_or_reports(parent, cache=False):
 	).run(as_dict=True)
 
 	for p in pages_with_custom_roles:
-		has_role[p.name] = {"modified": p.modified, "title": p.title, "ref_doctype": p.ref_doctype, "module": p.module}
+		has_role[p.name] = {
+			"modified": p.modified,
+			"title": p.title,
+			"ref_doctype": p.ref_doctype,
+			"module": p.module,
+		}
 
 	subq = (
 		frappe.qb.from_(customRole)

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -210,9 +210,9 @@ def get_user_pages_or_reports(parent, cache=False):
 	is_report = parent == "Report"
 
 	if is_report:
-		columns = (report.name.as_("title"), report.ref_doctype, report.report_type)
+		columns = (report.name.as_("title"), report.ref_doctype, report.report_type, report.module)
 	else:
-		columns = (page.title.as_("title"),)
+		columns = (page.title.as_("title"), page.module)
 
 	customRole = DocType("Custom Role")
 	hasRole = DocType("Has Role")
@@ -233,7 +233,7 @@ def get_user_pages_or_reports(parent, cache=False):
 	).run(as_dict=True)
 
 	for p in pages_with_custom_roles:
-		has_role[p.name] = {"modified": p.modified, "title": p.title, "ref_doctype": p.ref_doctype}
+		has_role[p.name] = {"modified": p.modified, "title": p.title, "ref_doctype": p.ref_doctype, "module": p.module}
 
 	subq = (
 		frappe.qb.from_(customRole)
@@ -258,7 +258,7 @@ def get_user_pages_or_reports(parent, cache=False):
 
 	for p in pages_with_standard_roles:
 		if p.name not in has_role:
-			has_role[p.name] = {"modified": p.modified, "title": p.title}
+			has_role[p.name] = {"modified": p.modified, "title": p.title, "module": p.module}
 			if parent == "Report":
 				has_role[p.name].update({"ref_doctype": p.ref_doctype})
 
@@ -275,7 +275,7 @@ def get_user_pages_or_reports(parent, cache=False):
 
 	for r in rows_with_no_roles:
 		if r.name not in has_role:
-			has_role[r.name] = {"modified": r.modified, "title": r.title}
+			has_role[r.name] = {"modified": r.modified, "title": r.title, "module": r.module}
 			if is_report:
 				has_role[r.name] |= {"ref_doctype": r.ref_doctype}
 

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -38,11 +38,19 @@ class Workspace:
 		self.user = frappe.get_user()
 		self.allowed_modules = self.get_cached("user_allowed_modules", self.get_allowed_modules)
 
+		self.allowed_pages = get_allowed_pages(cache=True)
+		self.allowed_reports = get_allowed_reports(cache=True)
+		allowed_page_and_report_modules = set(
+			[d.get("module") for d in self.allowed_pages.values() if d.get("module")]
+			+ [d.get("module") for d in self.allowed_reports.values() if d.get("module")]
+		)
+
 		self.doc = frappe.get_cached_doc("Workspace", self.page_name)
 		if (
 			self.doc
 			and self.doc.module
 			and self.doc.module not in self.allowed_modules
+			and self.doc.module not in allowed_page_and_report_modules
 			and not self.workspace_manager
 		):
 			raise frappe.PermissionError


### PR DESCRIPTION
Closes #24249 

### Issue

Standard Workspaces with defined Module (Is Standard = Yes) does not show up in the user's sidebar if the Module does not have read-permitted DocTypes for the User.

Even though the Module has permitted reports or pages. Making it difficult to create custom apps with a different Module just for reports and pages.

### Solution

Along with User Permissions `allowed_modules` based on DocType read permissions, check if the module has permitted page or report

Did not update User Permissions `build_permissions`'s `allowed_modules` since that would increase the overhead of building permissions even for non-UI APIs

### Screenshots

**Before:**
"Analytics" module only has pages, no DocTypes, therefore the "Analytics" Workspace is not visible.

<img width="222" height="280" alt="image" src="https://github.com/user-attachments/assets/da2eb7f7-1bbc-44ac-ba3a-6bc68d5f93cd" />

**After:**
"Analytics" Workspace is visible because there are permitted pages in the same "Analytics" module.

<img width="417" height="280" alt="image" src="https://github.com/user-attachments/assets/c3cf508c-b94c-41f9-8469-fcce8fd26d6a" />
