### PR TITLE
fix: check that row link_type is DocType before call with_doctype

### DIFF
--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.js
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.js
@@ -28,7 +28,7 @@ frappe.ui.form.on("Workspace Sidebar Item", {
 		let grid = frm.fields_dict.items.grid;
 		let link_to = row.link_to;
 		let row_obj = grid.get_grid_row(cdn);
-		if (link_to) {
+		if (link_to && row.link_type === "DocType" && row_obj) {
 			frappe.model.with_doctype(link_to, function () {
 				let meta = frappe.get_meta(link_to);
 				let field_obj = row_obj.get_field("navigate_to_tab");


### PR DESCRIPTION
Resolves: https://github.com/orgs/frappe/projects/148/views/1?pane=issue&itemId=148191890

---
**Before:**

https://github.com/user-attachments/assets/0afc69b8-c9ce-42da-a2c9-287e34f79acb



**After**

https://github.com/user-attachments/assets/8f8cbfdc-efdb-4a91-a285-496b4e0cd193


---
`no-docs`