### PR TITLE
fix: remove the 5th param everywhere

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1839,9 +1839,15 @@ Object.assign(frappe.utils, {
 	},
 
 	process_filter_expression(filter) {
-		return new Function(`return ${filter}`)();
+		return this.cleanup_filters(new Function(`return ${filter}`)());
 	},
-
+	cleanup_filters(filters) {
+		if (filters.length && filters[0].length == 5) {
+			filters.pop();
+			return filters;
+		}
+		return filters;
+	},
 	get_filter_from_json(filter_json, doctype) {
 		// convert json to filter array
 		if (filter_json) {


### PR DESCRIPTION
This PR should remove these popups. I had earlier fixed this for dashboard, thinking it would work everywhere where filters are mentioned

Before:
<img width="1440" height="896" alt="Screenshot 2026-01-10 at 8 33 52 PM" src="https://github.com/user-attachments/assets/c47a189a-82a5-4cb6-a6c7-12ab56476780" />


After
<img width="1440" height="898" alt="Screenshot 2026-01-10 at 8 34 01 PM" src="https://github.com/user-attachments/assets/45205874-1a16-49a9-937c-606223d139ea" />
