### PR TITLE
fix: improve which sidebar to show

### DIFF
--- a/frappe/public/js/frappe/views/pageview.js
+++ b/frappe/public/js/frappe/views/pageview.js
@@ -99,6 +99,11 @@ frappe.views.Page = class Page {
 		}
 
 		this.trigger_page_event("on_page_load");
+		frappe.breadcrumbs.add({
+			type: "Custom",
+			label: this.pagedoc.title,
+			route: frappe.get_route_str(),
+		});
 
 		// set events
 		$(this.wrapper).on("show", function () {


### PR DESCRIPTION
Improvements to the sidebar prediction algorithm.
Next steps: 
Refactor it make it more clear.

Adds the page title to breadcrumb

<img width="1438" height="784" alt="Screenshot 2026-01-11 at 4 15 17 AM" src="https://github.com/user-attachments/assets/b524b30d-bd5c-4be9-a723-652ee6083960" />
