### PR TITLE
fix: Report shortcut error in Workspace

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1839,7 +1839,9 @@ Object.assign(frappe.utils, {
 	},
 
 	process_filter_expression(filter) {
-		return this.cleanup_filters(new Function(`return ${filter}`)());
+		let filters = [];
+		filters = filter ? new Function(`return ${filter}`)() : [];
+		return this.cleanup_filters(filters);
 	},
 	cleanup_filters(filters) {
 		if (filters.length && filters[0].length == 5) {


### PR DESCRIPTION
### Issue
Workspace shortcuts in Report view display "The block can not be displayed correctly." message 

Ref: [#35830](https://github.com/frappe/frappe/issues/35830)

Before: 

[Screencast from 2026-01-11 16-07-20.webm](https://github.com/user-attachments/assets/59ec1a4a-77a7-4d66-9d16-55685b883105)

After

[Screencast from 2026-01-11 17-18-49.webm](https://github.com/user-attachments/assets/a95a46bf-9a77-48d2-bf26-aed17faa786c)
