### PR TITLE
fix(minor): child table height in form builder

### DIFF
--- a/frappe/public/js/form_builder/components/controls/TableControl.vue
+++ b/frappe/public/js/form_builder/components/controls/TableControl.vue
@@ -47,7 +47,7 @@ function open_new_child_doctype_dialog() {
 				</div>
 			</div>
 		</div>
-		<div class="grid-empty text-center">
+		<div class="grid-empty text-center" style="height: unset">
 			<img
 				src="/assets/frappe/images/ui-states/grid-empty-state.svg"
 				:alt="__('Grid Empty State')"


### PR DESCRIPTION
In a recent change child table empty styles have changed, unsetting that change on form builder component
Before

<img width="915" height="255" alt="Screenshot 2026-01-11 at 8 33 46 PM" src="https://github.com/user-attachments/assets/519b0527-f711-4f30-9b21-1ffc9d10b964" />

After
<img width="913" height="335" alt="Screenshot 2026-01-11 at 8 32 42 PM" src="https://github.com/user-attachments/assets/07fe18b8-2714-480a-8312-48725fa0f098" />
