### PR TITLE
feat(setup-wizard): toggle theme button

### DIFF
--- a/frappe/public/js/frappe/ui/slides.js
+++ b/frappe/public/js/frappe/ui/slides.js
@@ -19,6 +19,8 @@ frappe.ui.Slide = class Slide {
 	make() {
 		if (this.before_load) this.before_load(this);
 
+		this.attach_toggle_theme_btn();
+
 		this.$body = $(`<div class="slide-body">
 			<div class="content text-center">
 				<h1 class="title slide-title">${__(this.title)}</h1>
@@ -46,6 +48,18 @@ frappe.ui.Slide = class Slide {
 
 		this.refresh();
 		this.made = true;
+	}
+
+	attach_toggle_theme_btn() {
+		const toggle_icon = frappe.ui.get_current_theme() == "dark" ? "sun" : "moon";
+		this.$toggle_theme_btn =
+			$(`<button class="toggle-theme-btn btn btn-default btn-secondary btn-sm" data-label="Toggle Theme">
+				${frappe.utils.icon(toggle_icon, "sm")}
+			</button>`).appendTo(this.$wrapper);
+
+		this.$toggle_theme_btn.on("click", () => {
+			new frappe.ui.ThemeSwitcher().show();
+		});
 	}
 
 	refresh() {

--- a/frappe/public/scss/desk/slides.scss
+++ b/frappe/public/scss/desk/slides.scss
@@ -134,3 +134,9 @@
 		margin-bottom: var(--margin-lg);
 	}
 }
+
+.toggle-theme-btn {
+	position: absolute;
+	top: var(--margin-lg);
+	right: var(--margin-lg);
+}


### PR DESCRIPTION
Added a button to Toggle Theme on the Setup Wizard.

<img width="1654" height="1668" alt="image" src="https://github.com/user-attachments/assets/437a03cf-0eb1-496b-917a-af1b97f48130" />

<!-- no-docs -->
