### PR TITLE
refactor: streamline address and contact rendering logic

### DIFF
--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -2,27 +2,42 @@ frappe.provide("frappe.contacts");
 
 $.extend(frappe.contacts, {
 	clear_address_and_contact: function (frm) {
-		$(frm.fields_dict["address_html"].wrapper).html("");
-		frm.fields_dict["contact_html"] && $(frm.fields_dict["contact_html"].wrapper).html("");
+		for (const field of ["address_html", "contact_html"]) {
+			$(frm.fields_dict[field]?.wrapper)?.html("");
+		}
 	},
 
 	render_address_and_contact: function (frm) {
-		// render address
-		if (frm.fields_dict["address_html"] && "addr_list" in frm.doc.__onload) {
-			$(frm.fields_dict["address_html"].wrapper)
-				.html(frappe.render_template("address_list", frm.doc.__onload))
-				.find(".btn-address")
-				.on("click", () => new_record("Address", frm));
-		}
+		const items = [
+			{
+				field: "address_html",
+				data: "addr_list",
+				template: "address_list",
+				btn: ".btn-address",
+				doctype: "Address",
+			},
+			{
+				field: "contact_html",
+				data: "contact_list",
+				template: "contact_list",
+				btn: ".btn-contact",
+				doctype: "Contact",
+			},
+		];
 
-		// render contact
-		if (frm.fields_dict["contact_html"] && "contact_list" in frm.doc.__onload) {
-			$(frm.fields_dict["contact_html"].wrapper)
-				.html(frappe.render_template("contact_list", frm.doc.__onload))
-				.find(".btn-contact")
-				.on("click", () => new_record("Contact", frm));
+		for (const item of items) {
+			// render address or contact
+			const field_wrapper = frm.fields_dict[item.field]?.wrapper;
+
+			if (field_wrapper && frm.doc.__onload && item.data in frm.doc.__onload) {
+				$(field_wrapper)
+					.html(frappe.render_template(item.template, frm.doc.__onload))
+					.find(item.btn)
+					.on("click", () => new_record(item.doctype, frm));
+			}
 		}
 	},
+
 	get_last_doc: function (frm) {
 		const reverse_routes = frappe.route_history.slice().reverse();
 		const last_route = reverse_routes.find((route) => {
@@ -38,6 +53,7 @@ $.extend(frappe.contacts, {
 			docname,
 		};
 	},
+
 	get_address_display: function (frm, address_field, display_field) {
 		if (frm.updating_party_details) {
 			return;


### PR DESCRIPTION
### Traceback

```js
Uncaught (in promise) TypeError: frm.fields_dict.address_html is undefined
    clear_address_and_contact address_and_contact.js:5
    refresh bank__js:18
    _handler script_manager.js:30
    runner script_manager.js:109
    trigger script_manager.js:127
    promise callback*frappe.run_serially/< dom.js:273
    run_serially dom.js:271
    trigger script_manager.js:141
    render_dialog quick_entry.js:167
    setup quick_entry.js:47
    with_doctype model.js:217
    setup quick_entry.js:42
    setup quick_entry.js:41
    make_quick_entry quick_entry.js:25
    new_doc create_new.js:380
    with_doctype model.js:217
    new_doc create_new.js:375
    new_doc create_new.js:371
    make_new_doc list_view.js:318
    set_primary_action list_view.js:294
    set_action page.js:274
    jQuery 8
    set_action page.js:273
    set_primary_action page.js:288
    set_primary_action list_view.js:288
    toggle_actions_menu_button list_view.js:591
    toggle_result_area list_view.js:580
    refresh base_list.js:527
    jQuery 12
    call request.js:282
    call request.js:109
    refresh base_list.js:524
    refresh list_view.js:340
    throttle utils.js:877
    show base_list.js:17
address_and_contact.js:5:4

```


https://github.com/user-attachments/assets/520d1530-ede7-49e8-b0fc-9d3132ffc36e


> [!NOTE]
> Backport to V-16 and V-15
