### PR TITLE
fix: set default icon style to solid

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -206,7 +206,6 @@ class DesktopPage {
 				col: 3,
 			},
 		});
-		this.setup_editing_mode();
 		if (this.edit_mode) {
 			this.start_editing_layout();
 		}
@@ -217,10 +216,8 @@ class DesktopPage {
 		this.setup_notifications();
 		this.setup_navbar();
 		this.setup_awesomebar();
-		this.setup_editing_mode();
 		this.handle_route_change();
 		this.setup_events();
-		this.setup_edit_button();
 	}
 	setup_edit_button() {
 		const me = this;

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -254,3 +254,4 @@ frappe.core.doctype.communication_link.patches.copy_communication_date_to_link
 frappe.core.doctype.communication.patches.drop_ref_dt_dn_index
 frappe.patches.v16_0.change_link_type_to_workspace_sidebar
 frappe.patches.v16_0.add_standard_field_in_workspace_sidebar
+execute:frappe.db.set_single_value("Desktop Settings", "icon_style", "Solid")


### PR DESCRIPTION
Setting default icon to solid and disabling the editing 