### PR TITLE
fix: custom parent field in tree

### DIFF
--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -42,8 +42,10 @@ def get_children(doctype, parent="", include_disabled=False, **filters):
 
 
 def _get_children(doctype, parent="", ignore_permissions=False, include_disabled=False):
-	parent_field = "parent_" + frappe.scrub(doctype)
 	meta = frappe.get_meta(doctype)
+	parent_field = meta.get("nsm_parent_field")
+	if not parent_field:
+		parent_field = "parent_" + frappe.scrub(doctype)
 
 	qb = (
 		frappe.qb.from_(doctype)

--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -43,9 +43,7 @@ def get_children(doctype, parent="", include_disabled=False, **filters):
 
 def _get_children(doctype, parent="", ignore_permissions=False, include_disabled=False):
 	meta = frappe.get_meta(doctype)
-	parent_field = meta.get("nsm_parent_field")
-	if not parent_field:
-		parent_field = "parent_" + frappe.scrub(doctype)
+	parent_field = meta.get("nsm_parent_field") or "parent_" + frappe.scrub(doctype)
 
 	qb = (
 		frappe.qb.from_(doctype)


### PR DESCRIPTION
when we set our own parent field for Tree DocTypes, the tree view throws an error.
<img width="644" height="224" alt="image" src="https://github.com/user-attachments/assets/d8252956-3013-41b2-b91b-9b20f9eb1609" />


this PR solves it.