### PR TITLE
fix: print settings not updating when exporting PDF/Print

### DIFF
--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -88,7 +88,7 @@ frappe.ui.get_print_settings = function (
 	return frappe.prompt(
 		columns,
 		function (settings) {
-			settings = $.extend(print_settings, settings);
+			settings = $.extend({}, print_settings, settings);
 
 			if (!settings.with_letter_head) {
 				settings.letter_head = null;


### PR DESCRIPTION
**Closes:** #35866 
**Backport:**  version-16, version-15

---
`$.extend(print_settings, settings)` mutates the shared global `print_settings`, causing user choices to persist across future prints.
Replacing it with `$.extend({}, print_settings, settings)` creates a new object and prevents unintended side effects.

https://github.com/user-attachments/assets/394537c0-dcb8-4dee-8fe8-bc036d63bdf5

---
`no-docs`