### PR TITLE
fix: allow Tab navigation in empty text fields in grid

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1274,7 +1274,12 @@ export default class GridRow {
 
 				var move_up_down = function (base) {
 					if (ignore_fieldtypes.includes(fieldtype) && !e.altKey) {
-						return false;
+						// Allow tab navigation if field is empty
+						if (e.which === TAB && $(this).val().trim() === "") {
+							// Continue with navigation
+						} else {
+							return false;
+						}
 					}
 					if (field.autocomplete_open) {
 						return false;


### PR DESCRIPTION
## Description

This PR fixes the Tab key navigation issue in grid tables when working with text fields (Text, Small Text, Code, etc.).

### Problem
When users press Tab in an empty Description field (or any text field) in a grid table, the Tab key inserts a tab character instead of moving to the next field. This breaks the keyboard-only data entry workflow that users rely on.

### Solution
As suggested by @mihir-kandoi in #35816, this change allows Tab navigation when a text field is empty, while preserving the ability to insert tab characters in non-empty text fields.

**Behavior:**
- Empty text field + Tab → moves to next field ✓
- Non-empty text field + Tab → inserts tab character ✓
- Text field + Alt+Arrow → navigates (existing behavior) ✓

### Testing
1. Create a form with a child table containing text fields
2. Add a row and navigate with Tab key
3. Verify Tab moves through empty text fields
4. Type text in a field and verify Tab still inserts tab character

### Impact
- Restores efficient keyboard navigation for data entry
- Maintains backward compatibility for multi-line text editing
- Fixes user workflow regression from v15

Fixes #35816

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=162055292