### PR TITLE
fix: make entire row clickable for saved filters

### DIFF
--- a/frappe/public/js/frappe/list/list_filter.js
+++ b/frappe/public/js/frappe/list/list_filter.js
@@ -37,7 +37,7 @@ export default class ListFilter {
 			const $item = this.filter_template(filter);
 
 			// Apply filter
-			$item.find(".filter-label").on("click", () => {
+			$item.find(".dropdown-item").on("click", () => {
 				this.apply_saved_filter(filter.name, filter.filter_name);
 			});
 


### PR DESCRIPTION
Currently users must click exactly on the filter text to select it. Clicking anywhere else in the row does nothing.

This changes the click handler from `.filter-label` to `.dropdown-item` so the entire row is clickable, matching standard dropdown behavior.

Fixes #35894

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=162055292