### PR TITLE
fix: show app icons instead of folder

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -780,8 +780,7 @@ class DesktopIcon {
 	}
 
 	render_folder_thumbnail() {
-		let condition = this.icon_type == "App" && this.child_icons.length > 0;
-		if (this.icon_type == "Folder" || condition) {
+		if (this.icon_type == "Folder") {
 			if (!this.folder_wrapper) this.folder_wrapper = this.icon.find(".icon-container");
 			this.folder_wrapper.html("");
 			this.folder_grid = new DesktopIconGrid({


### PR DESCRIPTION
Shows app logos instead of rendering folder icons

<img width="149" height="153" alt="Screenshot 2026-01-13 at 7 37 35 PM" src="https://github.com/user-attachments/assets/bc0ec11c-e6d1-4d9f-bca2-17a9eb98d2ee" />
