### PR TITLE
fix: auto-expand parent Section Break when nested item is active

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -180,7 +180,11 @@ frappe.ui.Sidebar = class Sidebar {
 
 		// Find the SectionBreakSidebarItem instance
 		for (let item of this.items) {
-			if (item.item && item.item.type === "Section Break" && item.item.label === section_label) {
+			if (
+				item.item &&
+				item.item.type === "Section Break" &&
+				item.item.label === section_label
+			) {
 				// Expand the section break if it's collapsed
 				if (item.collapsed) {
 					item.open();

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -155,6 +155,38 @@ frappe.ui.Sidebar = class Sidebar {
 	set_active_workspace_item() {
 		if (this.is_route_in_sidebar()) {
 			this.active_item.addClass("active-sidebar");
+			this.expand_parent_section_if_needed();
+		}
+	}
+
+	expand_parent_section_if_needed() {
+		if (!this.active_item) return;
+
+		// Check if the active item is inside a nested container (child of a Section Break)
+		// active_item is .standard-sidebar-item, we need to check its container
+		const $item_container = this.active_item.closest(".sidebar-item-container");
+		if ($item_container.length === 0) return;
+
+		const $nested_container = $item_container.parent(".nested-container");
+		if ($nested_container.length === 0) return;
+
+		// Find the parent Section Break container
+		const $section_break_container = $nested_container.closest(".section-item");
+		if ($section_break_container.length === 0) return;
+
+		// Find the Section Break item instance that contains this nested item
+		const section_label = $section_break_container.attr("item-name");
+		if (!section_label) return;
+
+		// Find the SectionBreakSidebarItem instance
+		for (let item of this.items) {
+			if (item.item && item.item.type === "Section Break" && item.item.label === section_label) {
+				// Expand the section break if it's collapsed
+				if (item.collapsed) {
+					item.open();
+				}
+				break;
+			}
 		}
 	}
 

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -155,41 +155,33 @@ frappe.ui.Sidebar = class Sidebar {
 	set_active_workspace_item() {
 		if (this.is_route_in_sidebar()) {
 			this.active_item.addClass("active-sidebar");
-			this.expand_parent_section_if_needed();
+			this.expand_parent_section();
 		}
 	}
 
-	expand_parent_section_if_needed() {
+	expand_parent_section() {
 		if (!this.active_item) return;
+		let active_section;
+		$(".section-item").each((index, element) => {
+			if (element.contains(this.active_item.get(0))) {
+				active_section = element.dataset.id;
+			}
+		});
 
-		// Check if the active item is inside a nested container (child of a Section Break)
-		// active_item is .standard-sidebar-item, we need to check its container
-		const $item_container = this.active_item.closest(".sidebar-item-container");
-		if ($item_container.length === 0) return;
-
-		const $nested_container = $item_container.parent(".nested-container");
-		if ($nested_container.length === 0) return;
-
-		// Find the parent Section Break container
-		const $section_break_container = $nested_container.closest(".section-item");
-		if ($section_break_container.length === 0) return;
-
-		// Find the Section Break item instance that contains this nested item
-		const section_label = $section_break_container.attr("item-name");
-		if (!section_label) return;
-
-		// Find the SectionBreakSidebarItem instance
-		for (let item of this.items) {
-			if (
-				item.item &&
-				item.item.type === "Section Break" &&
-				item.item.label === section_label
-			) {
-				// Expand the section break if it's collapsed
-				if (item.collapsed) {
-					item.open();
+		if (active_section) {
+			let section = this.get_item(active_section);
+			if (section) {
+				if (section.collapsed) {
+					section.open();
 				}
-				break;
+			}
+		}
+	}
+
+	get_item(name) {
+		for (let item of this.items) {
+			if (item.item.label === name) {
+				return item;
 			}
 		}
 	}


### PR DESCRIPTION
When navigating to a nested sidebar item (child of a collapsible Section Break),
the parent section was not automatically expanded, making the active item
invisible if the section was collapsed.

- Added expand_parent_section_if_needed() method to detect and expand parent
  Section Break when a nested child item is active
- Modified set_active_workspace_item() to call the expansion method after
  setting the active item
- Ensures nested items are visible when they become active

Fixes #35742 

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=118192227