### PR TITLE
fix: copy releaserc from version-15

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,19 +1,22 @@
 {
-	"branches": ["develop", {"name": "version-14-beta", "channel": "beta", "prerelease": true}],
+	"branches": ["version-17"],
 	"plugins": [
 		"@semantic-release/commit-analyzer", {
-			"preset": "angular"
+			"preset": "angular",
+			"releaseRules": [
+				{"breaking": true, "release": false}
+			]
 		},
 		"@semantic-release/release-notes-generator",
 		[
 			"@semantic-release/exec", {
-				"prepareCmd": 'sed -ir "s/[0-9]*\.[0-9]*\.[0-9]*/${nextRelease.version}/" frappe/__init__.py'
+				"prepareCmd": 'sed -ir -E "s/\"[0-9]+\.[0-9]+\.[0-9]+\"/\"${nextRelease.version}\"/" frappe/__init__.py'
 			}
 		],
 		[
 			"@semantic-release/git", {
 				"assets": ["frappe/__init__.py"],
-				"message": "chore(release): Bumped to Version ${nextRelease.version}"
+				"message": "chore(release): Bumped to Version ${nextRelease.version}\n\n${nextRelease.notes}"
 			}
 		],
 		"@semantic-release/github"


### PR DESCRIPTION
Also fix "branch" for future ease

(cherry picked from commit ac4d4691849407a1018dbf26a1623fedf741e69b)

<hr>

Otherwise, this happens: https://github.com/frappe/frappe/compare/v16.1.0...v16.1.1
