### PR TITLE
fix: remove padding from datatable-wrapper in report view

### DIFF
--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -303,8 +303,3 @@
 	display: flex;
 	flex-wrap: wrap;
 }
-
-.datatable-wrapper {
-	padding-left: var(--padding-md);
-	padding-right: var(--padding-md);
-}


### PR DESCRIPTION
**Closes:** #35739
**Backport**: v16

---
Before

<img width="1692" height="1044" alt="image" src="https://github.com/user-attachments/assets/f961d4d2-d504-450a-8e02-951e8ea5c74e" />

---
After

<img width="1849" height="298" alt="image (11)" src="https://github.com/user-attachments/assets/d1679636-84cb-433d-b7b8-b1590a214b77" />


---
`no-docs`
