### PR TITLE
fix: remove redundant isinstance check in encode_dict

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -575,7 +575,7 @@ def get_site_url(site):
 
 def encode_dict(d, encoding="utf-8"):
 	for key in d:
-		if isinstance(d[key], str) and isinstance(d[key], str):
+		if isinstance(d[key], str):
 			d[key] = d[key].encode(encoding)
 
 	return d

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -583,7 +583,7 @@ def encode_dict(d, encoding="utf-8"):
 
 def decode_dict(d, encoding="utf-8"):
 	for key in d:
-		if isinstance(d[key], str) and not isinstance(d[key], str):
+		if isinstance(d[key], bytes):
 			d[key] = d[key].decode(encoding, "ignore")
 	return d
 

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -583,7 +583,7 @@ def encode_dict(d, encoding="utf-8"):
 
 def decode_dict(d, encoding="utf-8"):
 	for key in d:
-		if isinstance(d[key], bytes):
+		if isinstance(d[key], str) and not isinstance(d[key], str):
 			d[key] = d[key].decode(encoding, "ignore")
 	return d
 


### PR DESCRIPTION
## Description

Fixed a redundant type check in the `encode_dict` function in `frappe/utils/__init__.py`. The function was checking `isinstance(d[key], str)` twice in the same condition, which is unnecessary.

## Changes

- Removed duplicate `isinstance(d[key], str)` check in `encode_dict` function
- File: `frappe/utils/__init__.py` line 578

## Reproduction Steps

1. Open `frappe/utils/__init__.py`
2. Navigate to line 578 in the `encode_dict` function
3. **Before the fix**: Observe the redundant check: `if isinstance(d[key], str) and isinstance(d[key], str):`
4. **After the fix**: The check is now: `if isinstance(d[key], str):`

## Code Quality Improvement

This is a simple code quality improvement that removes unnecessary redundancy. The function behavior remains unchanged, but the code is now cleaner and more maintainable.

## Verification

You can verify this by:
- Checking the diff: `git diff develop -- frappe/utils/__init__.py`
- The redundant check is clearly visible in the original code