### PR TITLE
feat: let's set form control alignment

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -72,6 +72,7 @@
   "mandatory_depends_on",
   "read_only_depends_on",
   "display",
+  "alignment",
   "print_width",
   "width",
   "max_height",
@@ -474,6 +475,13 @@
    "label": "Read Only Depends On (JS)",
    "max_height": "3rem",
    "options": "JS"
+  },
+  {
+   "depends_on": "eval:in_list([\"Data\", \"Int\", \"Float\"], doc.fieldtype)",
+   "fieldname": "alignment",
+   "fieldtype": "Select",
+   "label": "Alignment",
+   "options": "\nLeft\nCenter\nRight"
   },
   {
    "fieldname": "column_break_38",

--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -477,7 +477,7 @@
    "options": "JS"
   },
   {
-   "depends_on": "eval:in_list([\"Data\", \"Int\", \"Float\"], doc.fieldtype)",
+   "depends_on": "eval:in_list([\"Data\", \"Int\", \"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
    "fieldname": "alignment",
    "fieldtype": "Select",
    "label": "Alignment",

--- a/frappe/core/doctype/docfield/docfield.py
+++ b/frappe/core/doctype/docfield/docfield.py
@@ -127,7 +127,6 @@ class DocField(Document):
 
 	def get_link_doctype(self):
 		"""Return the Link doctype for the `docfield` (if applicable).
-
 		* If fieldtype is Link: Return "options".
 		* If fieldtype is Table MultiSelect: Return "options" of the Link field in the Child Table.
 		"""

--- a/frappe/core/doctype/docfield/docfield.py
+++ b/frappe/core/doctype/docfield/docfield.py
@@ -17,6 +17,7 @@ class DocField(Document):
 		allow_bulk_edit: DF.Check
 		allow_in_quick_entry: DF.Check
 		allow_on_submit: DF.Check
+		alignment: DF.Literal["", "Left", "Center", "Right"]
 		bold: DF.Check
 		button_color: DF.Literal["", "Default", "Primary", "Info", "Success", "Warning", "Danger"]
 		collapsible: DF.Check

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -46,6 +46,7 @@
   "print_hide",
   "print_hide_if_no_value",
   "print_width",
+  "alignment",
   "no_copy",
   "allow_on_submit",
   "in_list_view",
@@ -301,6 +302,13 @@
    "label": "Print Width",
    "no_copy": 1,
    "print_hide": 1
+  },
+  {
+   "depends_on": "eval:['Data', 'Int', 'Float', 'Currency', 'Percent'].includes(doc.fieldtype)",
+   "fieldname": "alignment",
+   "fieldtype": "Select",
+   "label": "Alignment",
+   "options": "\nLeft\nCenter\nRight"
   },
   {
    "default": "0",

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -24,6 +24,7 @@ class CustomField(Document):
 
 		allow_in_quick_entry: DF.Check
 		allow_on_submit: DF.Check
+		alignment: DF.Literal["", "Left", "Center", "Right"]
 		bold: DF.Check
 		button_color: DF.Literal["", "Default", "Primary", "Info", "Success", "Warning", "Danger"]
 		collapsible: DF.Check

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -768,6 +768,7 @@ docfield_properties = {
 	"permlevel": "Int",
 	"width": "Data",
 	"print_width": "Data",
+	"alignment": "Select",
 	"non_negative": "Check",
 	"reqd": "Check",
 	"unique": "Check",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -65,6 +65,7 @@
   "print_hide",
   "print_hide_if_no_value",
   "print_width",
+  "alignment",
   "columns",
   "width",
   "is_custom_field"
@@ -355,6 +356,13 @@
    "label": "Print Width",
    "print_width": "50px",
    "width": "50px"
+  },
+  {
+   "depends_on": "eval:in_list(['Data', 'Int', 'Float', 'Currency', 'Percent'], doc.fieldtype)",
+   "fieldname": "alignment",
+   "fieldtype": "Select",
+   "label": "Alignment",
+   "options": "\nLeft\nCenter\nRight"
   },
   {
    "depends_on": "eval:parent.istable",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.py
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.py
@@ -16,6 +16,7 @@ class CustomizeFormField(Document):
 		allow_bulk_edit: DF.Check
 		allow_in_quick_entry: DF.Check
 		allow_on_submit: DF.Check
+		alignment: DF.Literal["", "Left", "Center", "Right"]
 		bold: DF.Check
 		button_color: DF.Literal["", "Default", "Primary", "Info", "Success", "Warning", "Danger"]
 		collapsible: DF.Check

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -179,8 +179,11 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		// This is used to display formatted output AND showing values in read only fields
 		if (this.disp_area) {
 			$(this.disp_area).html(display_value);
-			// Apply alignment for supported fields
-			if (this.df.alignment && ["Data", "Int", "Float", "Currency", "Percent"].includes(this.df.fieldtype)) {
+			// Apply alignment only for supported fields
+			if (
+				this.df.alignment &&
+				["Data", "Int", "Float", "Currency", "Percent"].includes(this.df.fieldtype)
+			) {
 				$(this.disp_area).css("text-align", this.df.alignment.toLowerCase());
 			}
 		}

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -165,7 +165,13 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		let doc = this.doc || (this.frm && this.frm.doc);
 		let display_value = frappe.format(value, this.df, { no_icon: true, inline: true }, doc);
 		// This is used to display formatted output AND showing values in read only fields
-		this.disp_area && $(this.disp_area).html(display_value);
+		if (this.disp_area) {
+			$(this.disp_area).html(display_value);
+			// Apply alignment for Data, Int, Float fields
+			if (this.df.alignment && ["Data", "Int", "Float"].includes(this.df.fieldtype)) {
+				$(this.disp_area).css("text-align", this.df.alignment.toLowerCase());
+			}
+		}
 	}
 	set_label(label) {
 		if (label) this.df.label = label;

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -179,8 +179,8 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		// This is used to display formatted output AND showing values in read only fields
 		if (this.disp_area) {
 			$(this.disp_area).html(display_value);
-			// Apply alignment for Data, Int, Float fields
-			if (this.df.alignment && ["Data", "Int", "Float"].includes(this.df.fieldtype)) {
+			// Apply alignment for supported fields
+			if (this.df.alignment && ["Data", "Int", "Float", "Currency", "Percent"].includes(this.df.fieldtype)) {
 				$(this.disp_area).css("text-align", this.df.alignment.toLowerCase());
 			}
 		}

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -251,8 +251,11 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		if (this.df.input_class) {
 			this.$input.addClass(this.df.input_class);
 		}
-		// Apply alignment if specified for supported field types
-		if (this.df.alignment && ["Data", "Int", "Float", "Currency", "Percent"].includes(this.df.fieldtype)) {
+		// Apply alignment for supported field types
+		if (
+			this.df.alignment &&
+			["Data", "Int", "Float", "Currency", "Percent"].includes(this.df.fieldtype)
+		) {
 			this.$input.css("text-align", this.df.alignment.toLowerCase());
 		}
 	}

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -251,8 +251,8 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		if (this.df.input_class) {
 			this.$input.addClass(this.df.input_class);
 		}
-		// Apply alignment if specified
-		if (this.df.alignment) {
+		// Apply alignment if specified for supported field types
+		if (this.df.alignment && ["Data", "Int", "Float", "Currency", "Percent"].includes(this.df.fieldtype)) {
 			this.$input.css("text-align", this.df.alignment.toLowerCase());
 		}
 	}

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -251,6 +251,10 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		if (this.df.input_class) {
 			this.$input.addClass(this.df.input_class);
 		}
+		// Apply alignment if specified
+		if (this.df.alignment) {
+			this.$input.css("text-align", this.df.alignment.toLowerCase());
+		}
 	}
 	set_input(value) {
 		this.last_value = this.value;


### PR DESCRIPTION
Currently all fields are left aligned


Before

<img width="1617" height="918" alt="image" src="https://github.com/user-attachments/assets/ddb1e2bb-6ad1-4a15-926a-38cac14edc34" />



Form builder

<img width="1885" height="854" alt="image" src="https://github.com/user-attachments/assets/df45a3f4-fd62-4ea3-a054-aedbcf857287" />



After

<img width="1597" height="908" alt="image" src="https://github.com/user-attachments/assets/0f243303-7b8a-4e16-91b9-2dcf3fddc1db" />


Avaliable for Data, Int, Float, Currency and Percent fieldtype

New property is available too on customize form.


`no-docs`