### PR TITLE
fix: Translate dashboard chart labels (fixes #35941)

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -218,7 +218,7 @@ def get_chart_config(chart, filters, timespan, timegrain, from_date, to_date):
 			else get_period(r[0], timegrain)
 			for r in result
 		],
-		"datasets": [{"name": chart.name, "values": [r[1] for r in result]}],
+		"datasets": [{"name": _(chart.name), "values": [r[1] for r in result]}],
 	}
 
 
@@ -292,7 +292,7 @@ def get_group_by_chart_config(chart, filters) -> dict | None:
 	if data:
 		return {
 			"labels": [item.get("name", "Not Specified") for item in data],
-			"datasets": [{"name": chart.name, "values": [item["count"] for item in data]}],
+			"datasets": [{"name": _(chart.name), "values": [item["count"] for item in data]}],
 		}
 	return None
 

--- a/frappe/public/js/frappe/views/dashboard/dashboard_view.js
+++ b/frappe/public/js/frappe/views/dashboard/dashboard_view.js
@@ -124,7 +124,7 @@ frappe.views.DashboardView = class DashboardView extends frappe.views.ListView {
 				? JSON.parse(settings.chart_config)
 				: {};
 			this.charts.map((chart) => {
-				chart.label = chart.chart_name;
+				chart.label = __(chart.chart_name);
 				chart.chart_settings = this.dashboard_chart_settings[chart.chart_name] || {};
 			});
 			this.render_dashboard_charts();
@@ -464,7 +464,7 @@ frappe.views.DashboardView = class DashboardView extends frappe.views.ListView {
 				} else {
 					this.chart_group.new_widget.on_create({
 						chart_name: chart.chart,
-						label: chart.chart,
+						label: __(chart.chart),
 						name: chart.chart,
 					});
 				}

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -147,7 +147,7 @@ class ChartDialog extends WidgetDialog {
 	}
 
 	process_data(data) {
-		data.label = data.label ? data.label : data.chart_name;
+		data.label = data.label ? data.label : __(data.chart_name);
 		return data;
 	}
 }


### PR DESCRIPTION
Fixes #35941

Ensures dashboard chart labels are properly translated in both frontend (widget labels) and backend (dataset names used in chart legends/tooltips).

**Changes:**
- Frontend: Translate `chart.chart_name` when setting widget labels
- Backend: Translate `chart.name` when used as dataset names in chart configs

**Files changed:**
- `frappe/public/js/frappe/views/dashboard/dashboard_view.js`
- `frappe/public/js/frappe/widgets/widget_dialog.js`
- `frappe/desk/doctype/dashboard_chart/dashboard_chart.py`

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=158349177