### PR TITLE
fix: Demarcate comments/timeline section from form

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -165,7 +165,12 @@
 
 .comment-box {
 	margin-top: var(--margin-lg);
-	padding: 0;
+	padding: var(--padding-lg);
+	padding-bottom: var(--padding-xl);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	background-color: var(--card-bg);
+	margin-bottom: var(--margin-lg);
 	.comment-input-header {
 		display: flex;
 		justify-content: space-between;

--- a/frappe/public/scss/desk/timeline.scss
+++ b/frappe/public/scss/desk/timeline.scss
@@ -20,7 +20,11 @@ $threshold: 34;
 
 .new-timeline {
 	position: relative;
+	padding: var(--padding-lg);
 	padding-top: var(--padding-lg);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	background-color: var(--card-bg);
 
 	@include media-breakpoint-down(xs) {
 		padding-left: calc(var(--padding-sm) + var(--timeline-item-icon-size) / 2);
@@ -31,7 +35,7 @@ $threshold: 34;
 	&:before {
 		content: " ";
 		top: 90px; // TODO: get top and bottom programmatically
-		left: calc(var(--timeline-item-icon-size) / 2);
+		left: calc(var(--timeline-item-icon-size) / 2 + var(--padding-lg));
 		position: absolute;
 		border-left: 1px solid var(--dark-border-color);
 		bottom: calc(-1 * var(--timeline-item-bottom-margin) + 25px);


### PR DESCRIPTION
# Visual Demarcation of Comments and Timeline Sections

Closes #35736 

## Overview
Added clear visual separation between the comment input section and the activity timeline section in form views to improve UI clarity and user experience.

## Changes Made

### 1. Comment Box Styling (`frappe/public/scss/desk/form.scss`)
- Added border with rounded corners to create a distinct card appearance
- Added padding around the entire comment section for better spacing
- Added background color for visual distinction
- Added bottom margin to create separation from the timeline section

### 2. Timeline Styling (`frappe/public/scss/desk/timeline.scss`)
- Added border with rounded corners to match the comment box styling
- Added padding around the timeline section
- Added background color for consistency
- Adjusted the timeline vertical line position to account for the new padding

## Visual Impact
- Both sections now appear as distinct, bordered cards
- Clear boundaries make it easier to distinguish between commenting and viewing activity
- Consistent styling maintains design system coherence
- Responsive design preserved with proper mobile breakpoints

## Technical Details
- Uses existing CSS variables for theming (supports light/dark mode)
- Maintains existing functionality without breaking changes
- No JavaScript changes required

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=147358252