### PR TITLE
fix: Render HTML in item descriptions instead of showing raw code

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -245,10 +245,10 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					// because it will not visible otherwise
 					(me.is_title_link() || d.value !== d.description)
 				) {
-					html +=
-						'<br><span class="small">' +
-						__(frappe.utils.escape_html(d.description)) +
-						"</span>";
+					// Sanitize description to allow HTML rendering while removing dangerous tags
+					// This fixes issue #35953 where HTML descriptions show as raw code after v16 upgrade
+					let sanitized_description = frappe.dom.remove_script_and_style(d.description);
+					html += '<br><span class="small">' + __(sanitized_description) + "</span>";
 				}
 				return $(`<div role="option">`)
 					.on("click", (event) => {


### PR DESCRIPTION
## Description

Fixes #35953 - Item descriptions containing HTML were displaying as raw code instead of rendering formatted content after upgrading from v15 to v16.

## Solution

Changed description sanitization from `escape_html()` to `remove_script_and_style()` in link field autocomplete dropdowns. This allows HTML to render properly while maintaining security by removing dangerous tags.

## Changes

- `frappe/public/js/frappe/form/controls/link.js`: Use `frappe.dom.remove_script_and_style()` instead of `frappe.utils.escape_html()` for descriptions

## Testing

1. Open a form with a link field (e.g., Item)
2. Type in the link field to see autocomplete dropdown
3. Verify HTML descriptions render correctly instead of showing raw code

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=157775043