### PR TITLE
fix: keyboard shortcuts for prev/next record

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -139,7 +139,7 @@ frappe.ui.form.Form = class FrappeForm {
 	add_form_keyboard_shortcuts() {
 		// Navigate to next record
 		frappe.ui.keys.add_shortcut({
-			shortcut: "shift+ctrl+>",
+			shortcut: "shift+ctrl+right",
 			action: () => this.navigate_records(0),
 			page: this.page,
 			description: __("Go to next record"),
@@ -149,7 +149,7 @@ frappe.ui.form.Form = class FrappeForm {
 
 		// Navigate to previous record
 		frappe.ui.keys.add_shortcut({
-			shortcut: "shift+ctrl+<",
+			shortcut: "shift+ctrl+left",
 			action: () => this.navigate_records(1),
 			page: this.page,
 			description: __("Go to previous record"),


### PR DESCRIPTION
Frappe v16 removed the next/previous buttons from the form view. This leaves only keyboard shortcuts to accomplish this. The existing shortcut was using the <kbd><</kbd> and <kbd>></kbd> keys. However, there are many keyboard layouts where these characters are on the same physical key, rendering the existing shortcut useless. E.g. German, Swiss, Norwegian, Swedish, Finnish, Estonian, Lithuanian, Italian, etc. This PR replaces them with the <kbd>←</kbd> and <kbd>→</kbd> keys, which should be present on most keyboards.