### PR TITLE
feat: Add Text Case option for Data fields

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -1,654 +1,654 @@
 {
-    "actions": [],
-    "autoname": "hash",
-    "creation": "2013-02-22 01:27:33",
-    "doctype": "DocType",
-    "document_type": "Setup",
-    "editable_grid": 1,
-    "engine": "InnoDB",
-    "field_order": [
-        "label_and_type",
-        "label",
-        "fieldtype",
-        "fieldname",
-        "length",
-        "precision",
-        "non_negative",
-        "hide_days",
-        "hide_seconds",
-        "reqd",
-        "is_virtual",
-        "search_index",
-        "not_nullable",
-        "mask",
-        "column_break_18",
-        "options",
-        "sort_options",
-        "show_dashboard",
-        "link_filters",
-        "defaults_section",
-        "default",
-        "column_break_6",
-        "fetch_from",
-        "fetch_if_empty",
-        "visibility_section",
-        "button_color",
-        "hidden",
-        "show_on_timeline",
-        "bold",
-        "allow_in_quick_entry",
-        "translatable",
-        "print_hide",
-        "print_hide_if_no_value",
-        "report_hide",
-        "column_break_28",
-        "depends_on",
-        "collapsible",
-        "collapsible_depends_on",
-        "hide_border",
-        "list__search_settings_section",
-        "in_list_view",
-        "in_standard_filter",
-        "in_preview",
-        "sticky",
-        "column_break_35",
-        "in_filter",
-        "in_global_search",
-        "permissions",
-        "read_only",
-        "allow_on_submit",
-        "ignore_user_permissions",
-        "allow_bulk_edit",
-        "make_attachment_public",
-        "column_break_13",
-        "permlevel",
-        "ignore_xss_filter",
-        "constraints_section",
-        "unique",
-        "no_copy",
-        "set_only_once",
-        "remember_last_selected_value",
-        "column_break_38",
-        "mandatory_depends_on",
-        "read_only_depends_on",
-        "display",
-        "text_case",
-        "print_width",
-        "width",
-        "max_height",
-        "columns",
-        "column_break_22",
-        "description",
-        "documentation_url",
-        "placeholder",
-        "oldfieldname",
-        "oldfieldtype"
-    ],
-    "fields": [
-        {
-            "fieldname": "label_and_type",
-            "fieldtype": "Section Break"
-        },
-        {
-            "bold": 1,
-            "fieldname": "label",
-            "fieldtype": "Data",
-            "in_list_view": 1,
-            "label": "Label",
-            "length": 255,
-            "oldfieldname": "label",
-            "oldfieldtype": "Data",
-            "print_width": "163",
-            "search_index": 1,
-            "width": "163"
-        },
-        {
-            "bold": 1,
-            "default": "Data",
-            "fieldname": "fieldtype",
-            "fieldtype": "Select",
-            "in_list_view": 1,
-            "label": "Type",
-            "oldfieldname": "fieldtype",
-            "oldfieldtype": "Select",
-            "options": "Autocomplete\nAttach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDuration\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nIcon\nImage\nInt\nJSON\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nPhone\nRead Only\nRating\nSection Break\nSelect\nSignature\nSmall Text\nTab Break\nTable\nTable MultiSelect\nText\nText Editor\nTime",
-            "reqd": 1,
-            "search_index": 1
-        },
-        {
-            "bold": 1,
-            "fieldname": "fieldname",
-            "fieldtype": "Data",
-            "in_list_view": 1,
-            "label": "Name",
-            "oldfieldname": "fieldname",
-            "oldfieldtype": "Data",
-            "search_index": 1
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:!in_list([\"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
-            "fieldname": "reqd",
-            "fieldtype": "Check",
-            "in_list_view": 1,
-            "label": "Mandatory",
-            "oldfieldname": "reqd",
-            "oldfieldtype": "Check",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "depends_on": "eval:in_list([\"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
-            "description": "Set non-standard precision for a Float, Currency or Percent field",
-            "fieldname": "precision",
-            "fieldtype": "Select",
-            "label": "Precision",
-            "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9",
-            "print_hide": 1
-        },
-        {
-            "depends_on": "eval:in_list(['Data', 'Link', 'Dynamic Link', 'Password', 'Select', 'Read Only', 'Attach', 'Attach Image', 'Int', 'Float', 'Currency', 'Percent'], doc.fieldtype)",
-            "fieldname": "length",
-            "fieldtype": "Int",
-            "label": "Length"
-        },
-        {
-            "default": "0",
-            "fieldname": "search_index",
-            "fieldtype": "Check",
-            "label": "Index",
-            "oldfieldname": "search_index",
-            "oldfieldtype": "Check",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:!doc.is_virtual",
-            "fieldname": "in_list_view",
-            "fieldtype": "Check",
-            "label": "In List View",
-            "print_width": "70px",
-            "width": "70px"
-        },
-        {
-            "default": "0",
-            "fieldname": "in_standard_filter",
-            "fieldtype": "Check",
-            "label": "In List Filter"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:([\"Data\", \"Select\", \"Table\", \"Text\", \"Text Editor\", \"Link\", \"Small Text\", \"Long Text\", \"Read Only\", \"Heading\", \"Dynamic Link\"].indexOf(doc.fieldtype) !== -1)",
-            "fieldname": "in_global_search",
-            "fieldtype": "Check",
-            "label": "In Global Search"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
-            "fieldname": "in_preview",
-            "fieldtype": "Check",
-            "label": "In Preview"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:!in_list(['Tab Break', 'Table'], doc.fieldtype)",
-            "fieldname": "allow_in_quick_entry",
-            "fieldtype": "Check",
-            "label": "Allow in Quick Entry"
-        },
-        {
-            "default": "0",
-            "fieldname": "bold",
-            "fieldtype": "Check",
-            "label": "Bold"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:['Data', 'Select', 'Text', 'Small Text', 'Text Editor'].includes(doc.fieldtype)",
-            "fieldname": "translatable",
-            "fieldtype": "Check",
-            "label": "Translatable"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:doc.fieldtype===\"Section Break\"",
-            "fieldname": "collapsible",
-            "fieldtype": "Check",
-            "label": "Collapsible",
-            "length": 255
-        },
-        {
-            "depends_on": "eval:doc.fieldtype==\"Section Break\" && doc.collapsible",
-            "fieldname": "collapsible_depends_on",
-            "fieldtype": "Code",
-            "label": "Collapsible Depends On (JS)",
-            "max_height": "3rem",
-            "options": "JS"
-        },
-        {
-            "fieldname": "column_break_6",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "options",
-            "fieldtype": "Small Text",
-            "ignore_xss_filter": 1,
-            "in_list_view": 1,
-            "label": "Options",
-            "oldfieldname": "options",
-            "oldfieldtype": "Text"
-        },
-        {
-            "fieldname": "default",
-            "fieldtype": "Small Text",
-            "ignore_xss_filter": 1,
-            "label": "Default",
-            "max_height": "3rem",
-            "oldfieldname": "default",
-            "oldfieldtype": "Text"
-        },
-        {
-            "fieldname": "fetch_from",
-            "fieldtype": "Small Text",
-            "label": "Fetch From"
-        },
-        {
-            "default": "0",
-            "description": "If unchecked, the value will always be re-fetched on save.",
-            "fieldname": "fetch_if_empty",
-            "fieldtype": "Check",
-            "label": "Fetch on Save if Empty"
-        },
-        {
-            "fieldname": "permissions",
-            "fieldtype": "Section Break",
-            "label": "Permissions"
-        },
-        {
-            "fieldname": "depends_on",
-            "fieldtype": "Code",
-            "label": "Display Depends On (JS)",
-            "length": 255,
-            "max_height": "3rem",
-            "oldfieldname": "depends_on",
-            "oldfieldtype": "Data",
-            "options": "JS"
-        },
-        {
-            "default": "0",
-            "fieldname": "hidden",
-            "fieldtype": "Check",
-            "label": "Hidden",
-            "oldfieldname": "hidden",
-            "oldfieldtype": "Check",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "default": "0",
-            "fieldname": "read_only",
-            "fieldtype": "Check",
-            "label": "Read Only",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "default": "0",
-            "fieldname": "unique",
-            "fieldtype": "Check",
-            "label": "Unique"
-        },
-        {
-            "default": "0",
-            "fieldname": "set_only_once",
-            "fieldtype": "Check",
-            "label": "Set only once"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval: doc.fieldtype == \"Table\"",
-            "fieldname": "allow_bulk_edit",
-            "fieldtype": "Check",
-            "label": "Allow Bulk Edit"
-        },
-        {
-            "fieldname": "column_break_13",
-            "fieldtype": "Column Break"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:!in_list(['Section Break', 'Column Break', 'Tab Break'], doc.fieldtype)",
-            "fieldname": "permlevel",
-            "fieldtype": "Int",
-            "label": "Perm Level",
-            "oldfieldname": "permlevel",
-            "oldfieldtype": "Int",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:[\"Link\", \"Dynamic Link\", \"Table MultiSelect\"].includes(doc.fieldtype)",
-            "fieldname": "ignore_user_permissions",
-            "fieldtype": "Check",
-            "label": "Ignore User Permissions"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval: parent.is_submittable",
-            "fieldname": "allow_on_submit",
-            "fieldtype": "Check",
-            "label": "Allow on Submit",
-            "oldfieldname": "allow_on_submit",
-            "oldfieldtype": "Check",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "default": "0",
-            "fieldname": "report_hide",
-            "fieldtype": "Check",
-            "label": "Report Hide",
-            "oldfieldname": "report_hide",
-            "oldfieldtype": "Check",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:(doc.fieldtype == 'Link')",
-            "fieldname": "remember_last_selected_value",
-            "fieldtype": "Check",
-            "label": "Remember Last Selected Value"
-        },
-        {
-            "default": "0",
-            "description": "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",
-            "fieldname": "ignore_xss_filter",
-            "fieldtype": "Check",
-            "label": "Ignore XSS Filter"
-        },
-        {
-            "fieldname": "display",
-            "fieldtype": "Section Break",
-            "label": "Display"
-        },
-        {
-            "depends_on": "eval:in_list([\"Data\"], doc.fieldtype)",
-            "fieldname": "text_case",
-            "fieldtype": "Select",
-            "label": "Text Case",
-            "options": "\nUpperCase\nTitleCase\nLowerCase"
-        },
-        {
-            "default": "0",
-            "fieldname": "in_filter",
-            "fieldtype": "Check",
-            "label": "In Filter",
-            "oldfieldname": "in_filter",
-            "oldfieldtype": "Check",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "default": "0",
-            "fieldname": "no_copy",
-            "fieldtype": "Check",
-            "label": "No Copy",
-            "oldfieldname": "no_copy",
-            "oldfieldtype": "Check",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "default": "0",
-            "fieldname": "print_hide",
-            "fieldtype": "Check",
-            "label": "Print Hide",
-            "oldfieldname": "print_hide",
-            "oldfieldtype": "Check",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:[\"Int\", \"Float\", \"Currency\", \"Percent\"].indexOf(doc.fieldtype)!==-1",
-            "fieldname": "print_hide_if_no_value",
-            "fieldtype": "Check",
-            "label": "Print Hide If No Value"
-        },
-        {
-            "fieldname": "print_width",
-            "fieldtype": "Data",
-            "label": "Print Width",
-            "length": 10
-        },
-        {
-            "fieldname": "width",
-            "fieldtype": "Data",
-            "label": "Width",
-            "length": 10,
-            "oldfieldname": "width",
-            "oldfieldtype": "Data",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "description": "Number of columns for a field in a List View or a Grid (Total Columns should be less than 11)",
-            "fieldname": "columns",
-            "fieldtype": "Int",
-            "label": "Columns"
-        },
-        {
-            "fieldname": "column_break_22",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "description",
-            "fieldtype": "Small Text",
-            "in_list_view": 1,
-            "label": "Description",
-            "oldfieldname": "description",
-            "oldfieldtype": "Text",
-            "print_width": "300px",
-            "width": "300px"
-        },
-        {
-            "fieldname": "oldfieldname",
-            "fieldtype": "Data",
-            "hidden": 1,
-            "oldfieldname": "oldfieldname",
-            "oldfieldtype": "Data"
-        },
-        {
-            "fieldname": "oldfieldtype",
-            "fieldtype": "Data",
-            "hidden": 1,
-            "oldfieldname": "oldfieldtype",
-            "oldfieldtype": "Data"
-        },
-        {
-            "fieldname": "mandatory_depends_on",
-            "fieldtype": "Code",
-            "label": "Mandatory Depends On (JS)",
-            "max_height": "3rem",
-            "options": "JS"
-        },
-        {
-            "fieldname": "read_only_depends_on",
-            "fieldtype": "Code",
-            "label": "Read Only Depends On (JS)",
-            "max_height": "3rem",
-            "options": "JS"
-        },
-        {
-            "fieldname": "column_break_38",
-            "fieldtype": "Column Break"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:doc.fieldtype=='Duration'",
-            "fieldname": "hide_days",
-            "fieldtype": "Check",
-            "label": "Hide Days"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:doc.fieldtype=='Duration'",
-            "fieldname": "hide_seconds",
-            "fieldtype": "Check",
-            "label": "Hide Seconds"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:doc.fieldtype=='Section Break'",
-            "fieldname": "hide_border",
-            "fieldtype": "Check",
-            "label": "Hide Border"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
-            "fieldname": "non_negative",
-            "fieldtype": "Check",
-            "label": "Non Negative"
-        },
-        {
-            "fieldname": "column_break_18",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "defaults_section",
-            "fieldtype": "Section Break",
-            "label": "Defaults",
-            "max_height": "2rem"
-        },
-        {
-            "fieldname": "visibility_section",
-            "fieldtype": "Section Break",
-            "label": "Visibility"
-        },
-        {
-            "fieldname": "column_break_28",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "constraints_section",
-            "fieldtype": "Section Break",
-            "label": "Constraints"
-        },
-        {
-            "fieldname": "max_height",
-            "fieldtype": "Data",
-            "label": "Max Height",
-            "length": 10
-        },
-        {
-            "fieldname": "list__search_settings_section",
-            "fieldtype": "Section Break",
-            "label": "List / Search Settings"
-        },
-        {
-            "fieldname": "column_break_35",
-            "fieldtype": "Column Break"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:doc.fieldtype===\"Tab Break\"",
-            "fieldname": "show_dashboard",
-            "fieldtype": "Check",
-            "label": "Show Dashboard"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:doc.fieldtype !== 'Link'",
-            "fieldname": "is_virtual",
-            "fieldtype": "Check",
-            "label": "Virtual"
-        },
-        {
-            "depends_on": "eval:!in_list([\"Tab Break\", \"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
-            "fieldname": "documentation_url",
-            "fieldtype": "Data",
-            "label": "Documentation URL",
-            "options": "URL"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval: doc.fieldtype === 'Select'",
-            "fieldname": "sort_options",
-            "fieldtype": "Check",
-            "label": "Sort Options"
-        },
-        {
-            "fieldname": "link_filters",
-            "fieldtype": "JSON",
-            "label": "Link Filters"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:!in_list([\"Check\", \"Currency\", \"Float\", \"Int\", \"Percent\", \"Rating\", \"Select\", \"Table\", \"Table MultiSelect\"], doc.fieldtype)",
-            "fieldname": "not_nullable",
-            "fieldtype": "Check",
-            "label": "Not Nullable"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval: doc.hidden",
-            "fieldname": "show_on_timeline",
-            "fieldtype": "Check",
-            "label": "Show on Timeline"
-        },
-        {
-            "fieldname": "placeholder",
-            "fieldtype": "Data",
-            "label": "Placeholder"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:['Attach', 'Attach Image'].includes(doc.fieldtype)",
-            "fieldname": "make_attachment_public",
-            "fieldtype": "Check",
-            "label": "Make Attachment Public (by default)"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
-            "fieldname": "sticky",
-            "fieldtype": "Check",
-            "label": "Sticky"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:[\"Select\", \"Read Only\", \"Phone\", \"Percent\", \"Password\", \"Link\", \"Int\", \"Float\", \"Dynamic Link\", \"Duration\", \"Datetime\", \"Currency\", \"Data\", \"Date\"].includes(doc.fieldtype)",
-            "fieldname": "mask",
-            "fieldtype": "Check",
-            "label": "Mask"
-        },
-        {
-            "depends_on": "eval:doc.fieldtype===\"Button\"",
-            "fieldname": "button_color",
-            "fieldtype": "Select",
-            "label": "Button Color",
-            "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
-        }
-    ],
-    "grid_page_length": 50,
-    "idx": 1,
-    "index_web_pages_for_search": 1,
-    "istable": 1,
-    "links": [],
-    "modified": "2026-01-06 01:37:29.723265",
-    "modified_by": "Administrator",
-    "module": "Core",
-    "name": "DocField",
-    "naming_rule": "Random",
-    "owner": "Administrator",
-    "permissions": [],
-    "row_format": "Dynamic",
-    "sort_field": "creation",
-    "sort_order": "ASC",
-    "states": []
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2013-02-22 01:27:33",
+ "doctype": "DocType",
+ "document_type": "Setup",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "label_and_type",
+  "label",
+  "fieldtype",
+  "fieldname",
+  "length",
+  "precision",
+  "non_negative",
+  "hide_days",
+  "hide_seconds",
+  "reqd",
+  "is_virtual",
+  "search_index",
+  "not_nullable",
+  "mask",
+  "column_break_18",
+  "options",
+  "sort_options",
+  "show_dashboard",
+  "link_filters",
+  "defaults_section",
+  "default",
+  "column_break_6",
+  "fetch_from",
+  "fetch_if_empty",
+  "visibility_section",
+  "button_color",
+  "hidden",
+  "show_on_timeline",
+  "bold",
+  "allow_in_quick_entry",
+  "translatable",
+  "print_hide",
+  "print_hide_if_no_value",
+  "report_hide",
+  "column_break_28",
+  "depends_on",
+  "collapsible",
+  "collapsible_depends_on",
+  "hide_border",
+  "list__search_settings_section",
+  "in_list_view",
+  "in_standard_filter",
+  "in_preview",
+  "sticky",
+  "column_break_35",
+  "in_filter",
+  "in_global_search",
+  "permissions",
+  "read_only",
+  "allow_on_submit",
+  "ignore_user_permissions",
+  "allow_bulk_edit",
+  "make_attachment_public",
+  "column_break_13",
+  "permlevel",
+  "ignore_xss_filter",
+  "constraints_section",
+  "unique",
+  "no_copy",
+  "set_only_once",
+  "remember_last_selected_value",
+  "column_break_38",
+  "mandatory_depends_on",
+  "read_only_depends_on",
+  "display",
+  "text_case",
+  "print_width",
+  "width",
+  "max_height",
+  "columns",
+  "column_break_22",
+  "description",
+  "documentation_url",
+  "placeholder",
+  "oldfieldname",
+  "oldfieldtype"
+ ],
+ "fields": [
+  {
+   "fieldname": "label_and_type",
+   "fieldtype": "Section Break"
+  },
+  {
+   "bold": 1,
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Label",
+   "length": 255,
+   "oldfieldname": "label",
+   "oldfieldtype": "Data",
+   "print_width": "163",
+   "search_index": 1,
+   "width": "163"
+  },
+  {
+   "bold": 1,
+   "default": "Data",
+   "fieldname": "fieldtype",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Type",
+   "oldfieldname": "fieldtype",
+   "oldfieldtype": "Select",
+   "options": "Autocomplete\nAttach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDuration\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nIcon\nImage\nInt\nJSON\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nPhone\nRead Only\nRating\nSection Break\nSelect\nSignature\nSmall Text\nTab Break\nTable\nTable MultiSelect\nText\nText Editor\nTime",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "bold": 1,
+   "fieldname": "fieldname",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Name",
+   "oldfieldname": "fieldname",
+   "oldfieldtype": "Data",
+   "search_index": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!in_list([\"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
+   "fieldname": "reqd",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Mandatory",
+   "oldfieldname": "reqd",
+   "oldfieldtype": "Check",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "depends_on": "eval:in_list([\"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
+   "description": "Set non-standard precision for a Float, Currency or Percent field",
+   "fieldname": "precision",
+   "fieldtype": "Select",
+   "label": "Precision",
+   "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:in_list(['Data', 'Link', 'Dynamic Link', 'Password', 'Select', 'Read Only', 'Attach', 'Attach Image', 'Int', 'Float', 'Currency', 'Percent'], doc.fieldtype)",
+   "fieldname": "length",
+   "fieldtype": "Int",
+   "label": "Length"
+  },
+  {
+   "default": "0",
+   "fieldname": "search_index",
+   "fieldtype": "Check",
+   "label": "Index",
+   "oldfieldname": "search_index",
+   "oldfieldtype": "Check",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.is_virtual",
+   "fieldname": "in_list_view",
+   "fieldtype": "Check",
+   "label": "In List View",
+   "print_width": "70px",
+   "width": "70px"
+  },
+  {
+   "default": "0",
+   "fieldname": "in_standard_filter",
+   "fieldtype": "Check",
+   "label": "In List Filter"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:([\"Data\", \"Select\", \"Table\", \"Text\", \"Text Editor\", \"Link\", \"Small Text\", \"Long Text\", \"Read Only\", \"Heading\", \"Dynamic Link\"].indexOf(doc.fieldtype) !== -1)",
+   "fieldname": "in_global_search",
+   "fieldtype": "Check",
+   "label": "In Global Search"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
+   "fieldname": "in_preview",
+   "fieldtype": "Check",
+   "label": "In Preview"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!in_list(['Tab Break', 'Table'], doc.fieldtype)",
+   "fieldname": "allow_in_quick_entry",
+   "fieldtype": "Check",
+   "label": "Allow in Quick Entry"
+  },
+  {
+   "default": "0",
+   "fieldname": "bold",
+   "fieldtype": "Check",
+   "label": "Bold"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:['Data', 'Select', 'Text', 'Small Text', 'Text Editor'].includes(doc.fieldtype)",
+   "fieldname": "translatable",
+   "fieldtype": "Check",
+   "label": "Translatable"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype===\"Section Break\"",
+   "fieldname": "collapsible",
+   "fieldtype": "Check",
+   "label": "Collapsible",
+   "length": 255
+  },
+  {
+   "depends_on": "eval:doc.fieldtype==\"Section Break\" && doc.collapsible",
+   "fieldname": "collapsible_depends_on",
+   "fieldtype": "Code",
+   "label": "Collapsible Depends On (JS)",
+   "max_height": "3rem",
+   "options": "JS"
+  },
+  {
+   "fieldname": "column_break_6",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "options",
+   "fieldtype": "Small Text",
+   "ignore_xss_filter": 1,
+   "in_list_view": 1,
+   "label": "Options",
+   "oldfieldname": "options",
+   "oldfieldtype": "Text"
+  },
+  {
+   "fieldname": "default",
+   "fieldtype": "Small Text",
+   "ignore_xss_filter": 1,
+   "label": "Default",
+   "max_height": "3rem",
+   "oldfieldname": "default",
+   "oldfieldtype": "Text"
+  },
+  {
+   "fieldname": "fetch_from",
+   "fieldtype": "Small Text",
+   "label": "Fetch From"
+  },
+  {
+   "default": "0",
+   "description": "If unchecked, the value will always be re-fetched on save.",
+   "fieldname": "fetch_if_empty",
+   "fieldtype": "Check",
+   "label": "Fetch on Save if Empty"
+  },
+  {
+   "fieldname": "permissions",
+   "fieldtype": "Section Break",
+   "label": "Permissions"
+  },
+  {
+   "fieldname": "depends_on",
+   "fieldtype": "Code",
+   "label": "Display Depends On (JS)",
+   "length": 255,
+   "max_height": "3rem",
+   "oldfieldname": "depends_on",
+   "oldfieldtype": "Data",
+   "options": "JS"
+  },
+  {
+   "default": "0",
+   "fieldname": "hidden",
+   "fieldtype": "Check",
+   "label": "Hidden",
+   "oldfieldname": "hidden",
+   "oldfieldtype": "Check",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "default": "0",
+   "fieldname": "read_only",
+   "fieldtype": "Check",
+   "label": "Read Only",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "default": "0",
+   "fieldname": "unique",
+   "fieldtype": "Check",
+   "label": "Unique"
+  },
+  {
+   "default": "0",
+   "fieldname": "set_only_once",
+   "fieldtype": "Check",
+   "label": "Set only once"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.fieldtype == \"Table\"",
+   "fieldname": "allow_bulk_edit",
+   "fieldtype": "Check",
+   "label": "Allow Bulk Edit"
+  },
+  {
+   "fieldname": "column_break_13",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!in_list(['Section Break', 'Column Break', 'Tab Break'], doc.fieldtype)",
+   "fieldname": "permlevel",
+   "fieldtype": "Int",
+   "label": "Perm Level",
+   "oldfieldname": "permlevel",
+   "oldfieldtype": "Int",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:[\"Link\", \"Dynamic Link\", \"Table MultiSelect\"].includes(doc.fieldtype)",
+   "fieldname": "ignore_user_permissions",
+   "fieldtype": "Check",
+   "label": "Ignore User Permissions"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: parent.is_submittable",
+   "fieldname": "allow_on_submit",
+   "fieldtype": "Check",
+   "label": "Allow on Submit",
+   "oldfieldname": "allow_on_submit",
+   "oldfieldtype": "Check",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "default": "0",
+   "fieldname": "report_hide",
+   "fieldtype": "Check",
+   "label": "Report Hide",
+   "oldfieldname": "report_hide",
+   "oldfieldtype": "Check",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:(doc.fieldtype == 'Link')",
+   "fieldname": "remember_last_selected_value",
+   "fieldtype": "Check",
+   "label": "Remember Last Selected Value"
+  },
+  {
+   "default": "0",
+   "description": "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",
+   "fieldname": "ignore_xss_filter",
+   "fieldtype": "Check",
+   "label": "Ignore XSS Filter"
+  },
+  {
+   "fieldname": "display",
+   "fieldtype": "Section Break",
+   "label": "Display"
+  },
+  {
+   "depends_on": "eval:in_list([\"Data\"], doc.fieldtype)",
+   "fieldname": "text_case",
+   "fieldtype": "Select",
+   "label": "Text Case",
+   "options": "\nUpperCase\nTitleCase\nLowerCase"
+  },
+  {
+   "default": "0",
+   "fieldname": "in_filter",
+   "fieldtype": "Check",
+   "label": "In Filter",
+   "oldfieldname": "in_filter",
+   "oldfieldtype": "Check",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "default": "0",
+   "fieldname": "no_copy",
+   "fieldtype": "Check",
+   "label": "No Copy",
+   "oldfieldname": "no_copy",
+   "oldfieldtype": "Check",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "default": "0",
+   "fieldname": "print_hide",
+   "fieldtype": "Check",
+   "label": "Print Hide",
+   "oldfieldname": "print_hide",
+   "oldfieldtype": "Check",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:[\"Int\", \"Float\", \"Currency\", \"Percent\"].indexOf(doc.fieldtype)!==-1",
+   "fieldname": "print_hide_if_no_value",
+   "fieldtype": "Check",
+   "label": "Print Hide If No Value"
+  },
+  {
+   "fieldname": "print_width",
+   "fieldtype": "Data",
+   "label": "Print Width",
+   "length": 10
+  },
+  {
+   "fieldname": "width",
+   "fieldtype": "Data",
+   "label": "Width",
+   "length": 10,
+   "oldfieldname": "width",
+   "oldfieldtype": "Data",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "description": "Number of columns for a field in a List View or a Grid (Total Columns should be less than 11)",
+   "fieldname": "columns",
+   "fieldtype": "Int",
+   "label": "Columns"
+  },
+  {
+   "fieldname": "column_break_22",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Description",
+   "oldfieldname": "description",
+   "oldfieldtype": "Text",
+   "print_width": "300px",
+   "width": "300px"
+  },
+  {
+   "fieldname": "oldfieldname",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "oldfieldname": "oldfieldname",
+   "oldfieldtype": "Data"
+  },
+  {
+   "fieldname": "oldfieldtype",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "oldfieldname": "oldfieldtype",
+   "oldfieldtype": "Data"
+  },
+  {
+   "fieldname": "mandatory_depends_on",
+   "fieldtype": "Code",
+   "label": "Mandatory Depends On (JS)",
+   "max_height": "3rem",
+   "options": "JS"
+  },
+  {
+   "fieldname": "read_only_depends_on",
+   "fieldtype": "Code",
+   "label": "Read Only Depends On (JS)",
+   "max_height": "3rem",
+   "options": "JS"
+  },
+  {
+   "fieldname": "column_break_38",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype=='Duration'",
+   "fieldname": "hide_days",
+   "fieldtype": "Check",
+   "label": "Hide Days"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype=='Duration'",
+   "fieldname": "hide_seconds",
+   "fieldtype": "Check",
+   "label": "Hide Seconds"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype=='Section Break'",
+   "fieldname": "hide_border",
+   "fieldtype": "Check",
+   "label": "Hide Border"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
+   "fieldname": "non_negative",
+   "fieldtype": "Check",
+   "label": "Non Negative"
+  },
+  {
+   "fieldname": "column_break_18",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "defaults_section",
+   "fieldtype": "Section Break",
+   "label": "Defaults",
+   "max_height": "2rem"
+  },
+  {
+   "fieldname": "visibility_section",
+   "fieldtype": "Section Break",
+   "label": "Visibility"
+  },
+  {
+   "fieldname": "column_break_28",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "constraints_section",
+   "fieldtype": "Section Break",
+   "label": "Constraints"
+  },
+  {
+   "fieldname": "max_height",
+   "fieldtype": "Data",
+   "label": "Max Height",
+   "length": 10
+  },
+  {
+   "fieldname": "list__search_settings_section",
+   "fieldtype": "Section Break",
+   "label": "List / Search Settings"
+  },
+  {
+   "fieldname": "column_break_35",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype===\"Tab Break\"",
+   "fieldname": "show_dashboard",
+   "fieldtype": "Check",
+   "label": "Show Dashboard"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype !== 'Link'",
+   "fieldname": "is_virtual",
+   "fieldtype": "Check",
+   "label": "Virtual"
+  },
+  {
+   "depends_on": "eval:!in_list([\"Tab Break\", \"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
+   "fieldname": "documentation_url",
+   "fieldtype": "Data",
+   "label": "Documentation URL",
+   "options": "URL"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.fieldtype === 'Select'",
+   "fieldname": "sort_options",
+   "fieldtype": "Check",
+   "label": "Sort Options"
+  },
+  {
+   "fieldname": "link_filters",
+   "fieldtype": "JSON",
+   "label": "Link Filters"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!in_list([\"Check\", \"Currency\", \"Float\", \"Int\", \"Percent\", \"Rating\", \"Select\", \"Table\", \"Table MultiSelect\"], doc.fieldtype)",
+   "fieldname": "not_nullable",
+   "fieldtype": "Check",
+   "label": "Not Nullable"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.hidden",
+   "fieldname": "show_on_timeline",
+   "fieldtype": "Check",
+   "label": "Show on Timeline"
+  },
+  {
+   "fieldname": "placeholder",
+   "fieldtype": "Data",
+   "label": "Placeholder"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:['Attach', 'Attach Image'].includes(doc.fieldtype)",
+   "fieldname": "make_attachment_public",
+   "fieldtype": "Check",
+   "label": "Make Attachment Public (by default)"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
+   "fieldname": "sticky",
+   "fieldtype": "Check",
+   "label": "Sticky"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:[\"Select\", \"Read Only\", \"Phone\", \"Percent\", \"Password\", \"Link\", \"Int\", \"Float\", \"Dynamic Link\", \"Duration\", \"Datetime\", \"Currency\", \"Data\", \"Date\"].includes(doc.fieldtype)",
+   "fieldname": "mask",
+   "fieldtype": "Check",
+   "label": "Mask"
+  },
+  {
+   "depends_on": "eval:doc.fieldtype===\"Button\"",
+   "fieldname": "button_color",
+   "fieldtype": "Select",
+   "label": "Button Color",
+   "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
+  }
+ ],
+ "grid_page_length": 50,
+ "idx": 1,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-01-06 01:37:29.723265",
+ "modified_by": "Administrator",
+ "module": "Core",
+ "name": "DocField",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "ASC",
+ "states": []
 }

--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -1,646 +1,654 @@
 {
- "actions": [],
- "autoname": "hash",
- "creation": "2013-02-22 01:27:33",
- "doctype": "DocType",
- "document_type": "Setup",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "label_and_type",
-  "label",
-  "fieldtype",
-  "fieldname",
-  "length",
-  "precision",
-  "non_negative",
-  "hide_days",
-  "hide_seconds",
-  "reqd",
-  "is_virtual",
-  "search_index",
-  "not_nullable",
-  "mask",
-  "column_break_18",
-  "options",
-  "sort_options",
-  "show_dashboard",
-  "link_filters",
-  "defaults_section",
-  "default",
-  "column_break_6",
-  "fetch_from",
-  "fetch_if_empty",
-  "visibility_section",
-  "button_color",
-  "hidden",
-  "show_on_timeline",
-  "bold",
-  "allow_in_quick_entry",
-  "translatable",
-  "print_hide",
-  "print_hide_if_no_value",
-  "report_hide",
-  "column_break_28",
-  "depends_on",
-  "collapsible",
-  "collapsible_depends_on",
-  "hide_border",
-  "list__search_settings_section",
-  "in_list_view",
-  "in_standard_filter",
-  "in_preview",
-  "sticky",
-  "column_break_35",
-  "in_filter",
-  "in_global_search",
-  "permissions",
-  "read_only",
-  "allow_on_submit",
-  "ignore_user_permissions",
-  "allow_bulk_edit",
-  "make_attachment_public",
-  "column_break_13",
-  "permlevel",
-  "ignore_xss_filter",
-  "constraints_section",
-  "unique",
-  "no_copy",
-  "set_only_once",
-  "remember_last_selected_value",
-  "column_break_38",
-  "mandatory_depends_on",
-  "read_only_depends_on",
-  "display",
-  "print_width",
-  "width",
-  "max_height",
-  "columns",
-  "column_break_22",
-  "description",
-  "documentation_url",
-  "placeholder",
-  "oldfieldname",
-  "oldfieldtype"
- ],
- "fields": [
-  {
-   "fieldname": "label_and_type",
-   "fieldtype": "Section Break"
-  },
-  {
-   "bold": 1,
-   "fieldname": "label",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Label",
-   "length": 255,
-   "oldfieldname": "label",
-   "oldfieldtype": "Data",
-   "print_width": "163",
-   "search_index": 1,
-   "width": "163"
-  },
-  {
-   "bold": 1,
-   "default": "Data",
-   "fieldname": "fieldtype",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Type",
-   "oldfieldname": "fieldtype",
-   "oldfieldtype": "Select",
-   "options": "Autocomplete\nAttach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDuration\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nIcon\nImage\nInt\nJSON\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nPhone\nRead Only\nRating\nSection Break\nSelect\nSignature\nSmall Text\nTab Break\nTable\nTable MultiSelect\nText\nText Editor\nTime",
-   "reqd": 1,
-   "search_index": 1
-  },
-  {
-   "bold": 1,
-   "fieldname": "fieldname",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Name",
-   "oldfieldname": "fieldname",
-   "oldfieldtype": "Data",
-   "search_index": 1
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:!in_list([\"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
-   "fieldname": "reqd",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "label": "Mandatory",
-   "oldfieldname": "reqd",
-   "oldfieldtype": "Check",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "depends_on": "eval:in_list([\"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
-   "description": "Set non-standard precision for a Float, Currency or Percent field",
-   "fieldname": "precision",
-   "fieldtype": "Select",
-   "label": "Precision",
-   "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9",
-   "print_hide": 1
-  },
-  {
-   "depends_on": "eval:in_list(['Data', 'Link', 'Dynamic Link', 'Password', 'Select', 'Read Only', 'Attach', 'Attach Image', 'Int', 'Float', 'Currency', 'Percent'], doc.fieldtype)",
-   "fieldname": "length",
-   "fieldtype": "Int",
-   "label": "Length"
-  },
-  {
-   "default": "0",
-   "fieldname": "search_index",
-   "fieldtype": "Check",
-   "label": "Index",
-   "oldfieldname": "search_index",
-   "oldfieldtype": "Check",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:!doc.is_virtual",
-   "fieldname": "in_list_view",
-   "fieldtype": "Check",
-   "label": "In List View",
-   "print_width": "70px",
-   "width": "70px"
-  },
-  {
-   "default": "0",
-   "fieldname": "in_standard_filter",
-   "fieldtype": "Check",
-   "label": "In List Filter"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:([\"Data\", \"Select\", \"Table\", \"Text\", \"Text Editor\", \"Link\", \"Small Text\", \"Long Text\", \"Read Only\", \"Heading\", \"Dynamic Link\"].indexOf(doc.fieldtype) !== -1)",
-   "fieldname": "in_global_search",
-   "fieldtype": "Check",
-   "label": "In Global Search"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
-   "fieldname": "in_preview",
-   "fieldtype": "Check",
-   "label": "In Preview"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:!in_list(['Tab Break', 'Table'], doc.fieldtype)",
-   "fieldname": "allow_in_quick_entry",
-   "fieldtype": "Check",
-   "label": "Allow in Quick Entry"
-  },
-  {
-   "default": "0",
-   "fieldname": "bold",
-   "fieldtype": "Check",
-   "label": "Bold"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:['Data', 'Select', 'Text', 'Small Text', 'Text Editor'].includes(doc.fieldtype)",
-   "fieldname": "translatable",
-   "fieldtype": "Check",
-   "label": "Translatable"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.fieldtype===\"Section Break\"",
-   "fieldname": "collapsible",
-   "fieldtype": "Check",
-   "label": "Collapsible",
-   "length": 255
-  },
-  {
-   "depends_on": "eval:doc.fieldtype==\"Section Break\" && doc.collapsible",
-   "fieldname": "collapsible_depends_on",
-   "fieldtype": "Code",
-   "label": "Collapsible Depends On (JS)",
-   "max_height": "3rem",
-   "options": "JS"
-  },
-  {
-   "fieldname": "column_break_6",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "options",
-   "fieldtype": "Small Text",
-   "ignore_xss_filter": 1,
-   "in_list_view": 1,
-   "label": "Options",
-   "oldfieldname": "options",
-   "oldfieldtype": "Text"
-  },
-  {
-   "fieldname": "default",
-   "fieldtype": "Small Text",
-   "ignore_xss_filter": 1,
-   "label": "Default",
-   "max_height": "3rem",
-   "oldfieldname": "default",
-   "oldfieldtype": "Text"
-  },
-  {
-   "fieldname": "fetch_from",
-   "fieldtype": "Small Text",
-   "label": "Fetch From"
-  },
-  {
-   "default": "0",
-   "description": "If unchecked, the value will always be re-fetched on save.",
-   "fieldname": "fetch_if_empty",
-   "fieldtype": "Check",
-   "label": "Fetch on Save if Empty"
-  },
-  {
-   "fieldname": "permissions",
-   "fieldtype": "Section Break",
-   "label": "Permissions"
-  },
-  {
-   "fieldname": "depends_on",
-   "fieldtype": "Code",
-   "label": "Display Depends On (JS)",
-   "length": 255,
-   "max_height": "3rem",
-   "oldfieldname": "depends_on",
-   "oldfieldtype": "Data",
-   "options": "JS"
-  },
-  {
-   "default": "0",
-   "fieldname": "hidden",
-   "fieldtype": "Check",
-   "label": "Hidden",
-   "oldfieldname": "hidden",
-   "oldfieldtype": "Check",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "default": "0",
-   "fieldname": "read_only",
-   "fieldtype": "Check",
-   "label": "Read Only",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "default": "0",
-   "fieldname": "unique",
-   "fieldtype": "Check",
-   "label": "Unique"
-  },
-  {
-   "default": "0",
-   "fieldname": "set_only_once",
-   "fieldtype": "Check",
-   "label": "Set only once"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval: doc.fieldtype == \"Table\"",
-   "fieldname": "allow_bulk_edit",
-   "fieldtype": "Check",
-   "label": "Allow Bulk Edit"
-  },
-  {
-   "fieldname": "column_break_13",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:!in_list(['Section Break', 'Column Break', 'Tab Break'], doc.fieldtype)",
-   "fieldname": "permlevel",
-   "fieldtype": "Int",
-   "label": "Perm Level",
-   "oldfieldname": "permlevel",
-   "oldfieldtype": "Int",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:[\"Link\", \"Dynamic Link\", \"Table MultiSelect\"].includes(doc.fieldtype)",
-   "fieldname": "ignore_user_permissions",
-   "fieldtype": "Check",
-   "label": "Ignore User Permissions"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval: parent.is_submittable",
-   "fieldname": "allow_on_submit",
-   "fieldtype": "Check",
-   "label": "Allow on Submit",
-   "oldfieldname": "allow_on_submit",
-   "oldfieldtype": "Check",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "default": "0",
-   "fieldname": "report_hide",
-   "fieldtype": "Check",
-   "label": "Report Hide",
-   "oldfieldname": "report_hide",
-   "oldfieldtype": "Check",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:(doc.fieldtype == 'Link')",
-   "fieldname": "remember_last_selected_value",
-   "fieldtype": "Check",
-   "label": "Remember Last Selected Value"
-  },
-  {
-   "default": "0",
-   "description": "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",
-   "fieldname": "ignore_xss_filter",
-   "fieldtype": "Check",
-   "label": "Ignore XSS Filter"
-  },
-  {
-   "fieldname": "display",
-   "fieldtype": "Section Break",
-   "label": "Display"
-  },
-  {
-   "default": "0",
-   "fieldname": "in_filter",
-   "fieldtype": "Check",
-   "label": "In Filter",
-   "oldfieldname": "in_filter",
-   "oldfieldtype": "Check",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "default": "0",
-   "fieldname": "no_copy",
-   "fieldtype": "Check",
-   "label": "No Copy",
-   "oldfieldname": "no_copy",
-   "oldfieldtype": "Check",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "default": "0",
-   "fieldname": "print_hide",
-   "fieldtype": "Check",
-   "label": "Print Hide",
-   "oldfieldname": "print_hide",
-   "oldfieldtype": "Check",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:[\"Int\", \"Float\", \"Currency\", \"Percent\"].indexOf(doc.fieldtype)!==-1",
-   "fieldname": "print_hide_if_no_value",
-   "fieldtype": "Check",
-   "label": "Print Hide If No Value"
-  },
-  {
-   "fieldname": "print_width",
-   "fieldtype": "Data",
-   "label": "Print Width",
-   "length": 10
-  },
-  {
-   "fieldname": "width",
-   "fieldtype": "Data",
-   "label": "Width",
-   "length": 10,
-   "oldfieldname": "width",
-   "oldfieldtype": "Data",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "description": "Number of columns for a field in a List View or a Grid (Total Columns should be less than 11)",
-   "fieldname": "columns",
-   "fieldtype": "Int",
-   "label": "Columns"
-  },
-  {
-   "fieldname": "column_break_22",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "description",
-   "fieldtype": "Small Text",
-   "in_list_view": 1,
-   "label": "Description",
-   "oldfieldname": "description",
-   "oldfieldtype": "Text",
-   "print_width": "300px",
-   "width": "300px"
-  },
-  {
-   "fieldname": "oldfieldname",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "oldfieldname": "oldfieldname",
-   "oldfieldtype": "Data"
-  },
-  {
-   "fieldname": "oldfieldtype",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "oldfieldname": "oldfieldtype",
-   "oldfieldtype": "Data"
-  },
-  {
-   "fieldname": "mandatory_depends_on",
-   "fieldtype": "Code",
-   "label": "Mandatory Depends On (JS)",
-   "max_height": "3rem",
-   "options": "JS"
-  },
-  {
-   "fieldname": "read_only_depends_on",
-   "fieldtype": "Code",
-   "label": "Read Only Depends On (JS)",
-   "max_height": "3rem",
-   "options": "JS"
-  },
-  {
-   "fieldname": "column_break_38",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.fieldtype=='Duration'",
-   "fieldname": "hide_days",
-   "fieldtype": "Check",
-   "label": "Hide Days"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.fieldtype=='Duration'",
-   "fieldname": "hide_seconds",
-   "fieldtype": "Check",
-   "label": "Hide Seconds"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.fieldtype=='Section Break'",
-   "fieldname": "hide_border",
-   "fieldtype": "Check",
-   "label": "Hide Border"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
-   "fieldname": "non_negative",
-   "fieldtype": "Check",
-   "label": "Non Negative"
-  },
-  {
-   "fieldname": "column_break_18",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "defaults_section",
-   "fieldtype": "Section Break",
-   "label": "Defaults",
-   "max_height": "2rem"
-  },
-  {
-   "fieldname": "visibility_section",
-   "fieldtype": "Section Break",
-   "label": "Visibility"
-  },
-  {
-   "fieldname": "column_break_28",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "constraints_section",
-   "fieldtype": "Section Break",
-   "label": "Constraints"
-  },
-  {
-   "fieldname": "max_height",
-   "fieldtype": "Data",
-   "label": "Max Height",
-   "length": 10
-  },
-  {
-   "fieldname": "list__search_settings_section",
-   "fieldtype": "Section Break",
-   "label": "List / Search Settings"
-  },
-  {
-   "fieldname": "column_break_35",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.fieldtype===\"Tab Break\"",
-   "fieldname": "show_dashboard",
-   "fieldtype": "Check",
-   "label": "Show Dashboard"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.fieldtype !== 'Link'",
-   "fieldname": "is_virtual",
-   "fieldtype": "Check",
-   "label": "Virtual"
-  },
-  {
-   "depends_on": "eval:!in_list([\"Tab Break\", \"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
-   "fieldname": "documentation_url",
-   "fieldtype": "Data",
-   "label": "Documentation URL",
-   "options": "URL"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval: doc.fieldtype === 'Select'",
-   "fieldname": "sort_options",
-   "fieldtype": "Check",
-   "label": "Sort Options"
-  },
-  {
-   "fieldname": "link_filters",
-   "fieldtype": "JSON",
-   "label": "Link Filters"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:!in_list([\"Check\", \"Currency\", \"Float\", \"Int\", \"Percent\", \"Rating\", \"Select\", \"Table\", \"Table MultiSelect\"], doc.fieldtype)",
-   "fieldname": "not_nullable",
-   "fieldtype": "Check",
-   "label": "Not Nullable"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval: doc.hidden",
-   "fieldname": "show_on_timeline",
-   "fieldtype": "Check",
-   "label": "Show on Timeline"
-  },
-  {
-   "fieldname": "placeholder",
-   "fieldtype": "Data",
-   "label": "Placeholder"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:['Attach', 'Attach Image'].includes(doc.fieldtype)",
-   "fieldname": "make_attachment_public",
-   "fieldtype": "Check",
-   "label": "Make Attachment Public (by default)"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
-   "fieldname": "sticky",
-   "fieldtype": "Check",
-   "label": "Sticky"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:[\"Select\", \"Read Only\", \"Phone\", \"Percent\", \"Password\", \"Link\", \"Int\", \"Float\", \"Dynamic Link\", \"Duration\", \"Datetime\", \"Currency\", \"Data\", \"Date\"].includes(doc.fieldtype)",
-   "fieldname": "mask",
-   "fieldtype": "Check",
-   "label": "Mask"
-  },
-  {
-   "depends_on": "eval:doc.fieldtype===\"Button\"",
-   "fieldname": "button_color",
-   "fieldtype": "Select",
-   "label": "Button Color",
-   "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
-  }
- ],
- "grid_page_length": 50,
- "idx": 1,
- "index_web_pages_for_search": 1,
- "istable": 1,
- "links": [],
- "modified": "2026-01-06 01:37:29.723265",
- "modified_by": "Administrator",
- "module": "Core",
- "name": "DocField",
- "naming_rule": "Random",
- "owner": "Administrator",
- "permissions": [],
- "row_format": "Dynamic",
- "sort_field": "creation",
- "sort_order": "ASC",
- "states": []
+    "actions": [],
+    "autoname": "hash",
+    "creation": "2013-02-22 01:27:33",
+    "doctype": "DocType",
+    "document_type": "Setup",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+        "label_and_type",
+        "label",
+        "fieldtype",
+        "fieldname",
+        "length",
+        "precision",
+        "non_negative",
+        "hide_days",
+        "hide_seconds",
+        "reqd",
+        "is_virtual",
+        "search_index",
+        "not_nullable",
+        "mask",
+        "column_break_18",
+        "options",
+        "sort_options",
+        "show_dashboard",
+        "link_filters",
+        "defaults_section",
+        "default",
+        "column_break_6",
+        "fetch_from",
+        "fetch_if_empty",
+        "visibility_section",
+        "button_color",
+        "hidden",
+        "show_on_timeline",
+        "bold",
+        "allow_in_quick_entry",
+        "translatable",
+        "print_hide",
+        "print_hide_if_no_value",
+        "report_hide",
+        "column_break_28",
+        "depends_on",
+        "collapsible",
+        "collapsible_depends_on",
+        "hide_border",
+        "list__search_settings_section",
+        "in_list_view",
+        "in_standard_filter",
+        "in_preview",
+        "sticky",
+        "column_break_35",
+        "in_filter",
+        "in_global_search",
+        "permissions",
+        "read_only",
+        "allow_on_submit",
+        "ignore_user_permissions",
+        "allow_bulk_edit",
+        "make_attachment_public",
+        "column_break_13",
+        "permlevel",
+        "ignore_xss_filter",
+        "constraints_section",
+        "unique",
+        "no_copy",
+        "set_only_once",
+        "remember_last_selected_value",
+        "column_break_38",
+        "mandatory_depends_on",
+        "read_only_depends_on",
+        "display",
+        "text_case",
+        "print_width",
+        "width",
+        "max_height",
+        "columns",
+        "column_break_22",
+        "description",
+        "documentation_url",
+        "placeholder",
+        "oldfieldname",
+        "oldfieldtype"
+    ],
+    "fields": [
+        {
+            "fieldname": "label_and_type",
+            "fieldtype": "Section Break"
+        },
+        {
+            "bold": 1,
+            "fieldname": "label",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "label": "Label",
+            "length": 255,
+            "oldfieldname": "label",
+            "oldfieldtype": "Data",
+            "print_width": "163",
+            "search_index": 1,
+            "width": "163"
+        },
+        {
+            "bold": 1,
+            "default": "Data",
+            "fieldname": "fieldtype",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "label": "Type",
+            "oldfieldname": "fieldtype",
+            "oldfieldtype": "Select",
+            "options": "Autocomplete\nAttach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDuration\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nIcon\nImage\nInt\nJSON\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nPhone\nRead Only\nRating\nSection Break\nSelect\nSignature\nSmall Text\nTab Break\nTable\nTable MultiSelect\nText\nText Editor\nTime",
+            "reqd": 1,
+            "search_index": 1
+        },
+        {
+            "bold": 1,
+            "fieldname": "fieldname",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "label": "Name",
+            "oldfieldname": "fieldname",
+            "oldfieldtype": "Data",
+            "search_index": 1
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:!in_list([\"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
+            "fieldname": "reqd",
+            "fieldtype": "Check",
+            "in_list_view": 1,
+            "label": "Mandatory",
+            "oldfieldname": "reqd",
+            "oldfieldtype": "Check",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "depends_on": "eval:in_list([\"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
+            "description": "Set non-standard precision for a Float, Currency or Percent field",
+            "fieldname": "precision",
+            "fieldtype": "Select",
+            "label": "Precision",
+            "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9",
+            "print_hide": 1
+        },
+        {
+            "depends_on": "eval:in_list(['Data', 'Link', 'Dynamic Link', 'Password', 'Select', 'Read Only', 'Attach', 'Attach Image', 'Int', 'Float', 'Currency', 'Percent'], doc.fieldtype)",
+            "fieldname": "length",
+            "fieldtype": "Int",
+            "label": "Length"
+        },
+        {
+            "default": "0",
+            "fieldname": "search_index",
+            "fieldtype": "Check",
+            "label": "Index",
+            "oldfieldname": "search_index",
+            "oldfieldtype": "Check",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:!doc.is_virtual",
+            "fieldname": "in_list_view",
+            "fieldtype": "Check",
+            "label": "In List View",
+            "print_width": "70px",
+            "width": "70px"
+        },
+        {
+            "default": "0",
+            "fieldname": "in_standard_filter",
+            "fieldtype": "Check",
+            "label": "In List Filter"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:([\"Data\", \"Select\", \"Table\", \"Text\", \"Text Editor\", \"Link\", \"Small Text\", \"Long Text\", \"Read Only\", \"Heading\", \"Dynamic Link\"].indexOf(doc.fieldtype) !== -1)",
+            "fieldname": "in_global_search",
+            "fieldtype": "Check",
+            "label": "In Global Search"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
+            "fieldname": "in_preview",
+            "fieldtype": "Check",
+            "label": "In Preview"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:!in_list(['Tab Break', 'Table'], doc.fieldtype)",
+            "fieldname": "allow_in_quick_entry",
+            "fieldtype": "Check",
+            "label": "Allow in Quick Entry"
+        },
+        {
+            "default": "0",
+            "fieldname": "bold",
+            "fieldtype": "Check",
+            "label": "Bold"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:['Data', 'Select', 'Text', 'Small Text', 'Text Editor'].includes(doc.fieldtype)",
+            "fieldname": "translatable",
+            "fieldtype": "Check",
+            "label": "Translatable"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:doc.fieldtype===\"Section Break\"",
+            "fieldname": "collapsible",
+            "fieldtype": "Check",
+            "label": "Collapsible",
+            "length": 255
+        },
+        {
+            "depends_on": "eval:doc.fieldtype==\"Section Break\" && doc.collapsible",
+            "fieldname": "collapsible_depends_on",
+            "fieldtype": "Code",
+            "label": "Collapsible Depends On (JS)",
+            "max_height": "3rem",
+            "options": "JS"
+        },
+        {
+            "fieldname": "column_break_6",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "options",
+            "fieldtype": "Small Text",
+            "ignore_xss_filter": 1,
+            "in_list_view": 1,
+            "label": "Options",
+            "oldfieldname": "options",
+            "oldfieldtype": "Text"
+        },
+        {
+            "fieldname": "default",
+            "fieldtype": "Small Text",
+            "ignore_xss_filter": 1,
+            "label": "Default",
+            "max_height": "3rem",
+            "oldfieldname": "default",
+            "oldfieldtype": "Text"
+        },
+        {
+            "fieldname": "fetch_from",
+            "fieldtype": "Small Text",
+            "label": "Fetch From"
+        },
+        {
+            "default": "0",
+            "description": "If unchecked, the value will always be re-fetched on save.",
+            "fieldname": "fetch_if_empty",
+            "fieldtype": "Check",
+            "label": "Fetch on Save if Empty"
+        },
+        {
+            "fieldname": "permissions",
+            "fieldtype": "Section Break",
+            "label": "Permissions"
+        },
+        {
+            "fieldname": "depends_on",
+            "fieldtype": "Code",
+            "label": "Display Depends On (JS)",
+            "length": 255,
+            "max_height": "3rem",
+            "oldfieldname": "depends_on",
+            "oldfieldtype": "Data",
+            "options": "JS"
+        },
+        {
+            "default": "0",
+            "fieldname": "hidden",
+            "fieldtype": "Check",
+            "label": "Hidden",
+            "oldfieldname": "hidden",
+            "oldfieldtype": "Check",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "default": "0",
+            "fieldname": "read_only",
+            "fieldtype": "Check",
+            "label": "Read Only",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "default": "0",
+            "fieldname": "unique",
+            "fieldtype": "Check",
+            "label": "Unique"
+        },
+        {
+            "default": "0",
+            "fieldname": "set_only_once",
+            "fieldtype": "Check",
+            "label": "Set only once"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval: doc.fieldtype == \"Table\"",
+            "fieldname": "allow_bulk_edit",
+            "fieldtype": "Check",
+            "label": "Allow Bulk Edit"
+        },
+        {
+            "fieldname": "column_break_13",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:!in_list(['Section Break', 'Column Break', 'Tab Break'], doc.fieldtype)",
+            "fieldname": "permlevel",
+            "fieldtype": "Int",
+            "label": "Perm Level",
+            "oldfieldname": "permlevel",
+            "oldfieldtype": "Int",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:[\"Link\", \"Dynamic Link\", \"Table MultiSelect\"].includes(doc.fieldtype)",
+            "fieldname": "ignore_user_permissions",
+            "fieldtype": "Check",
+            "label": "Ignore User Permissions"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval: parent.is_submittable",
+            "fieldname": "allow_on_submit",
+            "fieldtype": "Check",
+            "label": "Allow on Submit",
+            "oldfieldname": "allow_on_submit",
+            "oldfieldtype": "Check",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "default": "0",
+            "fieldname": "report_hide",
+            "fieldtype": "Check",
+            "label": "Report Hide",
+            "oldfieldname": "report_hide",
+            "oldfieldtype": "Check",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:(doc.fieldtype == 'Link')",
+            "fieldname": "remember_last_selected_value",
+            "fieldtype": "Check",
+            "label": "Remember Last Selected Value"
+        },
+        {
+            "default": "0",
+            "description": "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",
+            "fieldname": "ignore_xss_filter",
+            "fieldtype": "Check",
+            "label": "Ignore XSS Filter"
+        },
+        {
+            "fieldname": "display",
+            "fieldtype": "Section Break",
+            "label": "Display"
+        },
+        {
+            "depends_on": "eval:in_list([\"Data\"], doc.fieldtype)",
+            "fieldname": "text_case",
+            "fieldtype": "Select",
+            "label": "Text Case",
+            "options": "\nUpperCase\nTitleCase\nLowerCase"
+        },
+        {
+            "default": "0",
+            "fieldname": "in_filter",
+            "fieldtype": "Check",
+            "label": "In Filter",
+            "oldfieldname": "in_filter",
+            "oldfieldtype": "Check",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "default": "0",
+            "fieldname": "no_copy",
+            "fieldtype": "Check",
+            "label": "No Copy",
+            "oldfieldname": "no_copy",
+            "oldfieldtype": "Check",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "default": "0",
+            "fieldname": "print_hide",
+            "fieldtype": "Check",
+            "label": "Print Hide",
+            "oldfieldname": "print_hide",
+            "oldfieldtype": "Check",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:[\"Int\", \"Float\", \"Currency\", \"Percent\"].indexOf(doc.fieldtype)!==-1",
+            "fieldname": "print_hide_if_no_value",
+            "fieldtype": "Check",
+            "label": "Print Hide If No Value"
+        },
+        {
+            "fieldname": "print_width",
+            "fieldtype": "Data",
+            "label": "Print Width",
+            "length": 10
+        },
+        {
+            "fieldname": "width",
+            "fieldtype": "Data",
+            "label": "Width",
+            "length": 10,
+            "oldfieldname": "width",
+            "oldfieldtype": "Data",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "description": "Number of columns for a field in a List View or a Grid (Total Columns should be less than 11)",
+            "fieldname": "columns",
+            "fieldtype": "Int",
+            "label": "Columns"
+        },
+        {
+            "fieldname": "column_break_22",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "description",
+            "fieldtype": "Small Text",
+            "in_list_view": 1,
+            "label": "Description",
+            "oldfieldname": "description",
+            "oldfieldtype": "Text",
+            "print_width": "300px",
+            "width": "300px"
+        },
+        {
+            "fieldname": "oldfieldname",
+            "fieldtype": "Data",
+            "hidden": 1,
+            "oldfieldname": "oldfieldname",
+            "oldfieldtype": "Data"
+        },
+        {
+            "fieldname": "oldfieldtype",
+            "fieldtype": "Data",
+            "hidden": 1,
+            "oldfieldname": "oldfieldtype",
+            "oldfieldtype": "Data"
+        },
+        {
+            "fieldname": "mandatory_depends_on",
+            "fieldtype": "Code",
+            "label": "Mandatory Depends On (JS)",
+            "max_height": "3rem",
+            "options": "JS"
+        },
+        {
+            "fieldname": "read_only_depends_on",
+            "fieldtype": "Code",
+            "label": "Read Only Depends On (JS)",
+            "max_height": "3rem",
+            "options": "JS"
+        },
+        {
+            "fieldname": "column_break_38",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:doc.fieldtype=='Duration'",
+            "fieldname": "hide_days",
+            "fieldtype": "Check",
+            "label": "Hide Days"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:doc.fieldtype=='Duration'",
+            "fieldname": "hide_seconds",
+            "fieldtype": "Check",
+            "label": "Hide Seconds"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:doc.fieldtype=='Section Break'",
+            "fieldname": "hide_border",
+            "fieldtype": "Check",
+            "label": "Hide Border"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
+            "fieldname": "non_negative",
+            "fieldtype": "Check",
+            "label": "Non Negative"
+        },
+        {
+            "fieldname": "column_break_18",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "defaults_section",
+            "fieldtype": "Section Break",
+            "label": "Defaults",
+            "max_height": "2rem"
+        },
+        {
+            "fieldname": "visibility_section",
+            "fieldtype": "Section Break",
+            "label": "Visibility"
+        },
+        {
+            "fieldname": "column_break_28",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "constraints_section",
+            "fieldtype": "Section Break",
+            "label": "Constraints"
+        },
+        {
+            "fieldname": "max_height",
+            "fieldtype": "Data",
+            "label": "Max Height",
+            "length": 10
+        },
+        {
+            "fieldname": "list__search_settings_section",
+            "fieldtype": "Section Break",
+            "label": "List / Search Settings"
+        },
+        {
+            "fieldname": "column_break_35",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:doc.fieldtype===\"Tab Break\"",
+            "fieldname": "show_dashboard",
+            "fieldtype": "Check",
+            "label": "Show Dashboard"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:doc.fieldtype !== 'Link'",
+            "fieldname": "is_virtual",
+            "fieldtype": "Check",
+            "label": "Virtual"
+        },
+        {
+            "depends_on": "eval:!in_list([\"Tab Break\", \"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
+            "fieldname": "documentation_url",
+            "fieldtype": "Data",
+            "label": "Documentation URL",
+            "options": "URL"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval: doc.fieldtype === 'Select'",
+            "fieldname": "sort_options",
+            "fieldtype": "Check",
+            "label": "Sort Options"
+        },
+        {
+            "fieldname": "link_filters",
+            "fieldtype": "JSON",
+            "label": "Link Filters"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:!in_list([\"Check\", \"Currency\", \"Float\", \"Int\", \"Percent\", \"Rating\", \"Select\", \"Table\", \"Table MultiSelect\"], doc.fieldtype)",
+            "fieldname": "not_nullable",
+            "fieldtype": "Check",
+            "label": "Not Nullable"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval: doc.hidden",
+            "fieldname": "show_on_timeline",
+            "fieldtype": "Check",
+            "label": "Show on Timeline"
+        },
+        {
+            "fieldname": "placeholder",
+            "fieldtype": "Data",
+            "label": "Placeholder"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:['Attach', 'Attach Image'].includes(doc.fieldtype)",
+            "fieldname": "make_attachment_public",
+            "fieldtype": "Check",
+            "label": "Make Attachment Public (by default)"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
+            "fieldname": "sticky",
+            "fieldtype": "Check",
+            "label": "Sticky"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:[\"Select\", \"Read Only\", \"Phone\", \"Percent\", \"Password\", \"Link\", \"Int\", \"Float\", \"Dynamic Link\", \"Duration\", \"Datetime\", \"Currency\", \"Data\", \"Date\"].includes(doc.fieldtype)",
+            "fieldname": "mask",
+            "fieldtype": "Check",
+            "label": "Mask"
+        },
+        {
+            "depends_on": "eval:doc.fieldtype===\"Button\"",
+            "fieldname": "button_color",
+            "fieldtype": "Select",
+            "label": "Button Color",
+            "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
+        }
+    ],
+    "grid_page_length": 50,
+    "idx": 1,
+    "index_web_pages_for_search": 1,
+    "istable": 1,
+    "links": [],
+    "modified": "2026-01-06 01:37:29.723265",
+    "modified_by": "Administrator",
+    "module": "Core",
+    "name": "DocField",
+    "naming_rule": "Random",
+    "owner": "Administrator",
+    "permissions": [],
+    "row_format": "Dynamic",
+    "sort_field": "creation",
+    "sort_order": "ASC",
+    "states": []
 }

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -807,6 +807,7 @@ docfield_properties = {
 	"link_filters": "JSON",
 	"placeholder": "Data",
 	"button_color": "Select",
+	"text_case": "Select",
 	"mask": "Check",
 }
 

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -1,522 +1,530 @@
 {
- "actions": [],
- "autoname": "hash",
- "creation": "2013-02-22 01:27:32",
- "doctype": "DocType",
- "document_type": "Setup",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "is_system_generated",
-  "label_and_type",
-  "label",
-  "fieldtype",
-  "fieldname",
-  "non_negative",
-  "reqd",
-  "unique",
-  "is_virtual",
-  "in_list_view",
-  "in_standard_filter",
-  "in_global_search",
-  "in_preview",
-  "bold",
-  "no_copy",
-  "allow_in_quick_entry",
-  "translatable",
-  "mask",
-  "link_filters",
-  "column_break_7",
-  "default",
-  "precision",
-  "length",
-  "options",
-  "sort_options",
-  "fetch_from",
-  "fetch_if_empty",
-  "show_dashboard",
-  "permissions",
-  "depends_on",
-  "permlevel",
-  "hidden",
-  "read_only",
-  "collapsible",
-  "allow_bulk_edit",
-  "collapsible_depends_on",
-  "column_break_14",
-  "ignore_user_permissions",
-  "allow_on_submit",
-  "report_hide",
-  "remember_last_selected_value",
-  "hide_border",
-  "ignore_xss_filter",
-  "property_depends_on_section",
-  "mandatory_depends_on",
-  "column_break_33",
-  "read_only_depends_on",
-  "display",
-  "button_color",
-  "in_filter",
-  "hide_seconds",
-  "hide_days",
-  "column_break_21",
-  "description",
-  "placeholder",
-  "print_hide",
-  "print_hide_if_no_value",
-  "print_width",
-  "columns",
-  "width",
-  "is_custom_field"
- ],
- "fields": [
-  {
-   "fieldname": "label_and_type",
-   "fieldtype": "Section Break",
-   "label": "Label and Type"
-  },
-  {
-   "fieldname": "label",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Label",
-   "length": 255,
-   "oldfieldname": "label",
-   "oldfieldtype": "Data",
-   "search_index": 1
-  },
-  {
-   "default": "Data",
-   "fieldname": "fieldtype",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Type",
-   "oldfieldname": "fieldtype",
-   "oldfieldtype": "Select",
-   "options": "Autocomplete\nAttach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDuration\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nIcon\nImage\nInt\nJSON\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nPhone\nRating\nRead Only\nSection Break\nSelect\nSignature\nSmall Text\nTab Break\nTable\nTable MultiSelect\nText\nText Editor\nTime",
-   "reqd": 1,
-   "search_index": 1,
-   "sort_options": 1
-  },
-  {
-   "fieldname": "fieldname",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Name",
-   "oldfieldname": "fieldname",
-   "oldfieldtype": "Data",
-   "read_only": 1,
-   "search_index": 1
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:!in_list([\"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
-   "fieldname": "reqd",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "label": "Mandatory",
-   "oldfieldname": "reqd",
-   "oldfieldtype": "Check",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "default": "0",
-   "fieldname": "unique",
-   "fieldtype": "Check",
-   "label": "Unique"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.fieldtype !== 'Link'",
-   "fieldname": "is_virtual",
-   "fieldtype": "Check",
-   "label": "Is Virtual"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:!doc.is_virtual",
-   "fieldname": "in_list_view",
-   "fieldtype": "Check",
-   "label": "In List View"
-  },
-  {
-   "default": "0",
-   "fieldname": "in_standard_filter",
-   "fieldtype": "Check",
-   "label": "In Standard Filter"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:([\"Data\", \"Select\", \"Table\", \"Text\", \"Text Editor\", \"Link\", \"Small Text\", \"Long Text\", \"Read Only\", \"Heading\", \"Dynamic Link\"].indexOf(doc.fieldtype) !== -1)",
-   "fieldname": "in_global_search",
-   "fieldtype": "Check",
-   "label": "In Global Search"
-  },
-  {
-   "default": "0",
-   "fieldname": "bold",
-   "fieldtype": "Check",
-   "label": "Bold"
-  },
-  {
-   "default": "1",
-   "depends_on": "eval:['Data', 'Select', 'Text', 'Small Text', 'Text Editor'].includes(doc.fieldtype)",
-   "fieldname": "translatable",
-   "fieldtype": "Check",
-   "label": "Translatable"
-  },
-  {
-   "fieldname": "column_break_7",
-   "fieldtype": "Column Break"
-  },
-  {
-   "depends_on": "eval:in_list([\"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
-   "description": "Set non-standard precision for a Float or Currency field",
-   "fieldname": "precision",
-   "fieldtype": "Select",
-   "label": "Precision",
-   "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
-  },
-  {
-   "depends_on": "eval:in_list(['Data', 'Link', 'Dynamic Link', 'Password', 'Select', 'Read Only', 'Attach', 'Attach Image'], doc.fieldtype)",
-   "fieldname": "length",
-   "fieldtype": "Int",
-   "label": "Length"
-  },
-  {
-   "fieldname": "options",
-   "fieldtype": "Small Text",
-   "in_list_view": 1,
-   "label": "Options",
-   "oldfieldname": "options",
-   "oldfieldtype": "Text"
-  },
-  {
-   "fieldname": "fetch_from",
-   "fieldtype": "Small Text",
-   "label": "Fetch From"
-  },
-  {
-   "default": "0",
-   "description": "If unchecked, the value will always be re-fetched on save.",
-   "fieldname": "fetch_if_empty",
-   "fieldtype": "Check",
-   "label": "Fetch on Save if Empty"
-  },
-  {
-   "fieldname": "permissions",
-   "fieldtype": "Section Break",
-   "label": "Permissions"
-  },
-  {
-   "description": "This field will appear only if the fieldname defined here has value OR the rules are true (examples):\nmyfield\neval:doc.myfield=='My Value'\neval:doc.age&gt;18",
-   "fieldname": "depends_on",
-   "fieldtype": "Code",
-   "label": "Depends On",
-   "oldfieldname": "depends_on",
-   "oldfieldtype": "Data",
-   "options": "JS"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:!in_list(['Section Break', 'Column Break', 'Tab Break'], doc.fieldtype)",
-   "fieldname": "permlevel",
-   "fieldtype": "Int",
-   "in_list_view": 1,
-   "label": "Perm Level",
-   "oldfieldname": "permlevel",
-   "oldfieldtype": "Int"
-  },
-  {
-   "default": "0",
-   "fieldname": "hidden",
-   "fieldtype": "Check",
-   "label": "Hidden",
-   "oldfieldname": "hidden",
-   "oldfieldtype": "Check",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "default": "0",
-   "fieldname": "read_only",
-   "fieldtype": "Check",
-   "label": "Read Only"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.fieldtype==\"Section Break\"",
-   "fieldname": "collapsible",
-   "fieldtype": "Check",
-   "label": "Collapsible"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval: doc.fieldtype == \"Table\"",
-   "fieldname": "allow_bulk_edit",
-   "fieldtype": "Check",
-   "label": "Allow Bulk Edit"
-  },
-  {
-   "depends_on": "eval:doc.fieldtype==\"Section Break\"",
-   "fieldname": "collapsible_depends_on",
-   "fieldtype": "Code",
-   "label": "Collapsible Depends On",
-   "options": "JS"
-  },
-  {
-   "fieldname": "column_break_14",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "fieldname": "ignore_user_permissions",
-   "fieldtype": "Check",
-   "label": "Ignore User Permissions"
-  },
-  {
-   "default": "0",
-   "fieldname": "allow_on_submit",
-   "fieldtype": "Check",
-   "label": "Allow on Submit",
-   "oldfieldname": "allow_on_submit",
-   "oldfieldtype": "Check"
-  },
-  {
-   "default": "0",
-   "fieldname": "report_hide",
-   "fieldtype": "Check",
-   "label": "Report Hide",
-   "oldfieldname": "report_hide",
-   "oldfieldtype": "Check"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:(doc.fieldtype == 'Link')",
-   "fieldname": "remember_last_selected_value",
-   "fieldtype": "Check",
-   "label": "Remember Last Selected Value"
-  },
-  {
-   "fieldname": "display",
-   "fieldtype": "Section Break",
-   "label": "Display"
-  },
-  {
-   "fieldname": "default",
-   "fieldtype": "Small Text",
-   "label": "Default",
-   "oldfieldname": "default",
-   "oldfieldtype": "Text"
-  },
-  {
-   "default": "0",
-   "fieldname": "in_filter",
-   "fieldtype": "Check",
-   "label": "In Filter",
-   "oldfieldname": "in_filter",
-   "oldfieldtype": "Check",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "fieldname": "column_break_21",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "description",
-   "fieldtype": "Text",
-   "label": "Description",
-   "oldfieldname": "description",
-   "oldfieldtype": "Text",
-   "print_width": "300px",
-   "width": "300px"
-  },
-  {
-   "default": "0",
-   "fieldname": "print_hide",
-   "fieldtype": "Check",
-   "label": "Print Hide",
-   "oldfieldname": "print_hide",
-   "oldfieldtype": "Check"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:[\"Int\", \"Float\", \"Currency\", \"Percent\"].indexOf(doc.fieldtype)!==-1",
-   "fieldname": "print_hide_if_no_value",
-   "fieldtype": "Check",
-   "label": "Print Hide If No Value"
-  },
-  {
-   "description": "Print Width of the field, if the field is a column in a table",
-   "fieldname": "print_width",
-   "fieldtype": "Data",
-   "label": "Print Width",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "depends_on": "eval:parent.istable",
-   "description": "Number of columns for a field in a Grid (Total Columns in a grid should be less than 11)",
-   "fieldname": "columns",
-   "fieldtype": "Int",
-   "label": "Columns"
-  },
-  {
-   "fieldname": "width",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Width",
-   "oldfieldname": "width",
-   "oldfieldtype": "Data",
-   "print_width": "50px",
-   "width": "50px"
-  },
-  {
-   "default": "0",
-   "fieldname": "is_custom_field",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "label": "Is Custom Field",
-   "read_only": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "allow_in_quick_entry",
-   "fieldtype": "Check",
-   "label": "Allow in Quick Entry"
-  },
-  {
-   "fieldname": "property_depends_on_section",
-   "fieldtype": "Section Break",
-   "label": "Property Depends On"
-  },
-  {
-   "fieldname": "mandatory_depends_on",
-   "fieldtype": "Code",
-   "label": "Mandatory Depends On",
-   "options": "JS"
-  },
-  {
-   "fieldname": "column_break_33",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "read_only_depends_on",
-   "fieldtype": "Code",
-   "label": "Read Only Depends On",
-   "options": "JS"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
-   "fieldname": "in_preview",
-   "fieldtype": "Check",
-   "label": "In Preview"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.fieldtype=='Duration'",
-   "fieldname": "hide_seconds",
-   "fieldtype": "Check",
-   "label": "Hide Seconds"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.fieldtype=='Duration'",
-   "fieldname": "hide_days",
-   "fieldtype": "Check",
-   "label": "Hide Days"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.fieldtype=='Section Break'",
-   "fieldname": "hide_border",
-   "fieldtype": "Check",
-   "label": "Hide Border"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\"], doc.fieldtype)",
-   "fieldname": "non_negative",
-   "fieldtype": "Check",
-   "label": "Non Negative"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.fieldtype=='Tab Break'",
-   "fieldname": "show_dashboard",
-   "fieldtype": "Check",
-   "label": "Show Dashboard"
-  },
-  {
-   "default": "0",
-   "fieldname": "no_copy",
-   "fieldtype": "Check",
-   "label": "No Copy"
-  },
-  {
-   "default": "0",
-   "fieldname": "is_system_generated",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "label": "Is System Generated",
-   "read_only": 1
-  },
-  {
-   "default": "0",
-   "description": "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",
-   "fieldname": "ignore_xss_filter",
-   "fieldtype": "Check",
-   "label": "Ignore XSS Filter"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval: doc.fieldtype === 'Select'",
-   "fieldname": "sort_options",
-   "fieldtype": "Check",
-   "label": "Sort Options"
-  },
-  {
-   "fieldname": "link_filters",
-   "fieldtype": "JSON",
-   "label": "Link Filters"
-  },
-  {
-   "fieldname": "placeholder",
-   "fieldtype": "Data",
-   "label": "Placeholder"
-  },
-  {
-   "depends_on": "eval:doc.fieldtype===\"Button\"",
-   "fieldname": "button_color",
-   "fieldtype": "Select",
-   "label": "Button Color",
-   "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:[\"Select\", \"Read Only\", \"Phone\", \"Percent\", \"Password\", \"Link\", \"Int\", \"Float\", \"Dynamic Link\", \"Duration\", \"Datetime\", \"Currency\", \"Data\", \"Date\"].includes(doc.fieldtype)",
-   "fieldname": "mask",
-   "fieldtype": "Check",
-   "label": "Mask"
-  }
- ],
- "grid_page_length": 50,
- "idx": 1,
- "index_web_pages_for_search": 1,
- "istable": 1,
- "links": [],
- "modified": "2025-12-23 14:17:10.458916",
- "modified_by": "Administrator",
- "module": "Custom",
- "name": "Customize Form Field",
- "naming_rule": "Random",
- "owner": "Administrator",
- "permissions": [],
- "row_format": "Dynamic",
- "sort_field": "creation",
- "sort_order": "DESC",
- "states": []
+    "actions": [],
+    "autoname": "hash",
+    "creation": "2013-02-22 01:27:32",
+    "doctype": "DocType",
+    "document_type": "Setup",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+        "is_system_generated",
+        "label_and_type",
+        "label",
+        "fieldtype",
+        "fieldname",
+        "non_negative",
+        "reqd",
+        "unique",
+        "is_virtual",
+        "in_list_view",
+        "in_standard_filter",
+        "in_global_search",
+        "in_preview",
+        "bold",
+        "no_copy",
+        "allow_in_quick_entry",
+        "translatable",
+        "mask",
+        "link_filters",
+        "column_break_7",
+        "default",
+        "precision",
+        "length",
+        "options",
+        "sort_options",
+        "fetch_from",
+        "fetch_if_empty",
+        "show_dashboard",
+        "permissions",
+        "depends_on",
+        "permlevel",
+        "hidden",
+        "read_only",
+        "collapsible",
+        "allow_bulk_edit",
+        "collapsible_depends_on",
+        "column_break_14",
+        "ignore_user_permissions",
+        "allow_on_submit",
+        "report_hide",
+        "remember_last_selected_value",
+        "hide_border",
+        "ignore_xss_filter",
+        "property_depends_on_section",
+        "mandatory_depends_on",
+        "column_break_33",
+        "read_only_depends_on",
+        "display",
+        "button_color",
+        "text_case",
+        "in_filter",
+        "hide_seconds",
+        "hide_days",
+        "column_break_21",
+        "description",
+        "placeholder",
+        "print_hide",
+        "print_hide_if_no_value",
+        "print_width",
+        "columns",
+        "width",
+        "is_custom_field"
+    ],
+    "fields": [
+        {
+            "fieldname": "label_and_type",
+            "fieldtype": "Section Break",
+            "label": "Label and Type"
+        },
+        {
+            "fieldname": "label",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "label": "Label",
+            "length": 255,
+            "oldfieldname": "label",
+            "oldfieldtype": "Data",
+            "search_index": 1
+        },
+        {
+            "default": "Data",
+            "fieldname": "fieldtype",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "label": "Type",
+            "oldfieldname": "fieldtype",
+            "oldfieldtype": "Select",
+            "options": "Autocomplete\nAttach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDuration\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nIcon\nImage\nInt\nJSON\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nPhone\nRating\nRead Only\nSection Break\nSelect\nSignature\nSmall Text\nTab Break\nTable\nTable MultiSelect\nText\nText Editor\nTime",
+            "reqd": 1,
+            "search_index": 1,
+            "sort_options": 1
+        },
+        {
+            "fieldname": "fieldname",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "label": "Name",
+            "oldfieldname": "fieldname",
+            "oldfieldtype": "Data",
+            "read_only": 1,
+            "search_index": 1
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:!in_list([\"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
+            "fieldname": "reqd",
+            "fieldtype": "Check",
+            "in_list_view": 1,
+            "label": "Mandatory",
+            "oldfieldname": "reqd",
+            "oldfieldtype": "Check",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "default": "0",
+            "fieldname": "unique",
+            "fieldtype": "Check",
+            "label": "Unique"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:doc.fieldtype !== 'Link'",
+            "fieldname": "is_virtual",
+            "fieldtype": "Check",
+            "label": "Is Virtual"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:!doc.is_virtual",
+            "fieldname": "in_list_view",
+            "fieldtype": "Check",
+            "label": "In List View"
+        },
+        {
+            "default": "0",
+            "fieldname": "in_standard_filter",
+            "fieldtype": "Check",
+            "label": "In Standard Filter"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:([\"Data\", \"Select\", \"Table\", \"Text\", \"Text Editor\", \"Link\", \"Small Text\", \"Long Text\", \"Read Only\", \"Heading\", \"Dynamic Link\"].indexOf(doc.fieldtype) !== -1)",
+            "fieldname": "in_global_search",
+            "fieldtype": "Check",
+            "label": "In Global Search"
+        },
+        {
+            "default": "0",
+            "fieldname": "bold",
+            "fieldtype": "Check",
+            "label": "Bold"
+        },
+        {
+            "default": "1",
+            "depends_on": "eval:['Data', 'Select', 'Text', 'Small Text', 'Text Editor'].includes(doc.fieldtype)",
+            "fieldname": "translatable",
+            "fieldtype": "Check",
+            "label": "Translatable"
+        },
+        {
+            "fieldname": "column_break_7",
+            "fieldtype": "Column Break"
+        },
+        {
+            "depends_on": "eval:in_list([\"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
+            "description": "Set non-standard precision for a Float or Currency field",
+            "fieldname": "precision",
+            "fieldtype": "Select",
+            "label": "Precision",
+            "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+        },
+        {
+            "depends_on": "eval:in_list(['Data', 'Link', 'Dynamic Link', 'Password', 'Select', 'Read Only', 'Attach', 'Attach Image'], doc.fieldtype)",
+            "fieldname": "length",
+            "fieldtype": "Int",
+            "label": "Length"
+        },
+        {
+            "fieldname": "options",
+            "fieldtype": "Small Text",
+            "in_list_view": 1,
+            "label": "Options",
+            "oldfieldname": "options",
+            "oldfieldtype": "Text"
+        },
+        {
+            "fieldname": "fetch_from",
+            "fieldtype": "Small Text",
+            "label": "Fetch From"
+        },
+        {
+            "default": "0",
+            "description": "If unchecked, the value will always be re-fetched on save.",
+            "fieldname": "fetch_if_empty",
+            "fieldtype": "Check",
+            "label": "Fetch on Save if Empty"
+        },
+        {
+            "fieldname": "permissions",
+            "fieldtype": "Section Break",
+            "label": "Permissions"
+        },
+        {
+            "description": "This field will appear only if the fieldname defined here has value OR the rules are true (examples):\nmyfield\neval:doc.myfield=='My Value'\neval:doc.age&gt;18",
+            "fieldname": "depends_on",
+            "fieldtype": "Code",
+            "label": "Depends On",
+            "oldfieldname": "depends_on",
+            "oldfieldtype": "Data",
+            "options": "JS"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:!in_list(['Section Break', 'Column Break', 'Tab Break'], doc.fieldtype)",
+            "fieldname": "permlevel",
+            "fieldtype": "Int",
+            "in_list_view": 1,
+            "label": "Perm Level",
+            "oldfieldname": "permlevel",
+            "oldfieldtype": "Int"
+        },
+        {
+            "default": "0",
+            "fieldname": "hidden",
+            "fieldtype": "Check",
+            "label": "Hidden",
+            "oldfieldname": "hidden",
+            "oldfieldtype": "Check",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "default": "0",
+            "fieldname": "read_only",
+            "fieldtype": "Check",
+            "label": "Read Only"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:doc.fieldtype==\"Section Break\"",
+            "fieldname": "collapsible",
+            "fieldtype": "Check",
+            "label": "Collapsible"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval: doc.fieldtype == \"Table\"",
+            "fieldname": "allow_bulk_edit",
+            "fieldtype": "Check",
+            "label": "Allow Bulk Edit"
+        },
+        {
+            "depends_on": "eval:doc.fieldtype==\"Section Break\"",
+            "fieldname": "collapsible_depends_on",
+            "fieldtype": "Code",
+            "label": "Collapsible Depends On",
+            "options": "JS"
+        },
+        {
+            "fieldname": "column_break_14",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "0",
+            "fieldname": "ignore_user_permissions",
+            "fieldtype": "Check",
+            "label": "Ignore User Permissions"
+        },
+        {
+            "default": "0",
+            "fieldname": "allow_on_submit",
+            "fieldtype": "Check",
+            "label": "Allow on Submit",
+            "oldfieldname": "allow_on_submit",
+            "oldfieldtype": "Check"
+        },
+        {
+            "default": "0",
+            "fieldname": "report_hide",
+            "fieldtype": "Check",
+            "label": "Report Hide",
+            "oldfieldname": "report_hide",
+            "oldfieldtype": "Check"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:(doc.fieldtype == 'Link')",
+            "fieldname": "remember_last_selected_value",
+            "fieldtype": "Check",
+            "label": "Remember Last Selected Value"
+        },
+        {
+            "fieldname": "display",
+            "fieldtype": "Section Break",
+            "label": "Display"
+        },
+        {
+            "fieldname": "default",
+            "fieldtype": "Small Text",
+            "label": "Default",
+            "oldfieldname": "default",
+            "oldfieldtype": "Text"
+        },
+        {
+            "default": "0",
+            "fieldname": "in_filter",
+            "fieldtype": "Check",
+            "label": "In Filter",
+            "oldfieldname": "in_filter",
+            "oldfieldtype": "Check",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "fieldname": "column_break_21",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "description",
+            "fieldtype": "Text",
+            "label": "Description",
+            "oldfieldname": "description",
+            "oldfieldtype": "Text",
+            "print_width": "300px",
+            "width": "300px"
+        },
+        {
+            "default": "0",
+            "fieldname": "print_hide",
+            "fieldtype": "Check",
+            "label": "Print Hide",
+            "oldfieldname": "print_hide",
+            "oldfieldtype": "Check"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:[\"Int\", \"Float\", \"Currency\", \"Percent\"].indexOf(doc.fieldtype)!==-1",
+            "fieldname": "print_hide_if_no_value",
+            "fieldtype": "Check",
+            "label": "Print Hide If No Value"
+        },
+        {
+            "description": "Print Width of the field, if the field is a column in a table",
+            "fieldname": "print_width",
+            "fieldtype": "Data",
+            "label": "Print Width",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "depends_on": "eval:parent.istable",
+            "description": "Number of columns for a field in a Grid (Total Columns in a grid should be less than 11)",
+            "fieldname": "columns",
+            "fieldtype": "Int",
+            "label": "Columns"
+        },
+        {
+            "fieldname": "width",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "label": "Width",
+            "oldfieldname": "width",
+            "oldfieldtype": "Data",
+            "print_width": "50px",
+            "width": "50px"
+        },
+        {
+            "default": "0",
+            "fieldname": "is_custom_field",
+            "fieldtype": "Check",
+            "hidden": 1,
+            "label": "Is Custom Field",
+            "read_only": 1
+        },
+        {
+            "default": "0",
+            "fieldname": "allow_in_quick_entry",
+            "fieldtype": "Check",
+            "label": "Allow in Quick Entry"
+        },
+        {
+            "fieldname": "property_depends_on_section",
+            "fieldtype": "Section Break",
+            "label": "Property Depends On"
+        },
+        {
+            "fieldname": "mandatory_depends_on",
+            "fieldtype": "Code",
+            "label": "Mandatory Depends On",
+            "options": "JS"
+        },
+        {
+            "fieldname": "column_break_33",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "read_only_depends_on",
+            "fieldtype": "Code",
+            "label": "Read Only Depends On",
+            "options": "JS"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
+            "fieldname": "in_preview",
+            "fieldtype": "Check",
+            "label": "In Preview"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:doc.fieldtype=='Duration'",
+            "fieldname": "hide_seconds",
+            "fieldtype": "Check",
+            "label": "Hide Seconds"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:doc.fieldtype=='Duration'",
+            "fieldname": "hide_days",
+            "fieldtype": "Check",
+            "label": "Hide Days"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:doc.fieldtype=='Section Break'",
+            "fieldname": "hide_border",
+            "fieldtype": "Check",
+            "label": "Hide Border"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\"], doc.fieldtype)",
+            "fieldname": "non_negative",
+            "fieldtype": "Check",
+            "label": "Non Negative"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:doc.fieldtype=='Tab Break'",
+            "fieldname": "show_dashboard",
+            "fieldtype": "Check",
+            "label": "Show Dashboard"
+        },
+        {
+            "default": "0",
+            "fieldname": "no_copy",
+            "fieldtype": "Check",
+            "label": "No Copy"
+        },
+        {
+            "default": "0",
+            "fieldname": "is_system_generated",
+            "fieldtype": "Check",
+            "hidden": 1,
+            "label": "Is System Generated",
+            "read_only": 1
+        },
+        {
+            "default": "0",
+            "description": "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",
+            "fieldname": "ignore_xss_filter",
+            "fieldtype": "Check",
+            "label": "Ignore XSS Filter"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval: doc.fieldtype === 'Select'",
+            "fieldname": "sort_options",
+            "fieldtype": "Check",
+            "label": "Sort Options"
+        },
+        {
+            "fieldname": "link_filters",
+            "fieldtype": "JSON",
+            "label": "Link Filters"
+        },
+        {
+            "fieldname": "placeholder",
+            "fieldtype": "Data",
+            "label": "Placeholder"
+        },
+        {
+            "depends_on": "eval:doc.fieldtype===\"Button\"",
+            "fieldname": "button_color",
+            "fieldtype": "Select",
+            "label": "Button Color",
+            "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
+        },
+        {
+            "depends_on": "eval:in_list([\"Data\"], doc.fieldtype)",
+            "fieldname": "text_case",
+            "fieldtype": "Select",
+            "label": "Text Case",
+            "options": "\nUpperCase\nTitleCase\nLowerCase"
+        },
+        {
+            "default": "0",
+            "depends_on": "eval:[\"Select\", \"Read Only\", \"Phone\", \"Percent\", \"Password\", \"Link\", \"Int\", \"Float\", \"Dynamic Link\", \"Duration\", \"Datetime\", \"Currency\", \"Data\", \"Date\"].includes(doc.fieldtype)",
+            "fieldname": "mask",
+            "fieldtype": "Check",
+            "label": "Mask"
+        }
+    ],
+    "grid_page_length": 50,
+    "idx": 1,
+    "index_web_pages_for_search": 1,
+    "istable": 1,
+    "links": [],
+    "modified": "2025-12-23 14:17:10.458916",
+    "modified_by": "Administrator",
+    "module": "Custom",
+    "name": "Customize Form Field",
+    "naming_rule": "Random",
+    "owner": "Administrator",
+    "permissions": [],
+    "row_format": "Dynamic",
+    "sort_field": "creation",
+    "sort_order": "DESC",
+    "states": []
 }

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -1,530 +1,530 @@
 {
-    "actions": [],
-    "autoname": "hash",
-    "creation": "2013-02-22 01:27:32",
-    "doctype": "DocType",
-    "document_type": "Setup",
-    "editable_grid": 1,
-    "engine": "InnoDB",
-    "field_order": [
-        "is_system_generated",
-        "label_and_type",
-        "label",
-        "fieldtype",
-        "fieldname",
-        "non_negative",
-        "reqd",
-        "unique",
-        "is_virtual",
-        "in_list_view",
-        "in_standard_filter",
-        "in_global_search",
-        "in_preview",
-        "bold",
-        "no_copy",
-        "allow_in_quick_entry",
-        "translatable",
-        "mask",
-        "link_filters",
-        "column_break_7",
-        "default",
-        "precision",
-        "length",
-        "options",
-        "sort_options",
-        "fetch_from",
-        "fetch_if_empty",
-        "show_dashboard",
-        "permissions",
-        "depends_on",
-        "permlevel",
-        "hidden",
-        "read_only",
-        "collapsible",
-        "allow_bulk_edit",
-        "collapsible_depends_on",
-        "column_break_14",
-        "ignore_user_permissions",
-        "allow_on_submit",
-        "report_hide",
-        "remember_last_selected_value",
-        "hide_border",
-        "ignore_xss_filter",
-        "property_depends_on_section",
-        "mandatory_depends_on",
-        "column_break_33",
-        "read_only_depends_on",
-        "display",
-        "button_color",
-        "text_case",
-        "in_filter",
-        "hide_seconds",
-        "hide_days",
-        "column_break_21",
-        "description",
-        "placeholder",
-        "print_hide",
-        "print_hide_if_no_value",
-        "print_width",
-        "columns",
-        "width",
-        "is_custom_field"
-    ],
-    "fields": [
-        {
-            "fieldname": "label_and_type",
-            "fieldtype": "Section Break",
-            "label": "Label and Type"
-        },
-        {
-            "fieldname": "label",
-            "fieldtype": "Data",
-            "in_list_view": 1,
-            "label": "Label",
-            "length": 255,
-            "oldfieldname": "label",
-            "oldfieldtype": "Data",
-            "search_index": 1
-        },
-        {
-            "default": "Data",
-            "fieldname": "fieldtype",
-            "fieldtype": "Select",
-            "in_list_view": 1,
-            "label": "Type",
-            "oldfieldname": "fieldtype",
-            "oldfieldtype": "Select",
-            "options": "Autocomplete\nAttach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDuration\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nIcon\nImage\nInt\nJSON\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nPhone\nRating\nRead Only\nSection Break\nSelect\nSignature\nSmall Text\nTab Break\nTable\nTable MultiSelect\nText\nText Editor\nTime",
-            "reqd": 1,
-            "search_index": 1,
-            "sort_options": 1
-        },
-        {
-            "fieldname": "fieldname",
-            "fieldtype": "Data",
-            "in_list_view": 1,
-            "label": "Name",
-            "oldfieldname": "fieldname",
-            "oldfieldtype": "Data",
-            "read_only": 1,
-            "search_index": 1
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:!in_list([\"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
-            "fieldname": "reqd",
-            "fieldtype": "Check",
-            "in_list_view": 1,
-            "label": "Mandatory",
-            "oldfieldname": "reqd",
-            "oldfieldtype": "Check",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "default": "0",
-            "fieldname": "unique",
-            "fieldtype": "Check",
-            "label": "Unique"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:doc.fieldtype !== 'Link'",
-            "fieldname": "is_virtual",
-            "fieldtype": "Check",
-            "label": "Is Virtual"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:!doc.is_virtual",
-            "fieldname": "in_list_view",
-            "fieldtype": "Check",
-            "label": "In List View"
-        },
-        {
-            "default": "0",
-            "fieldname": "in_standard_filter",
-            "fieldtype": "Check",
-            "label": "In Standard Filter"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:([\"Data\", \"Select\", \"Table\", \"Text\", \"Text Editor\", \"Link\", \"Small Text\", \"Long Text\", \"Read Only\", \"Heading\", \"Dynamic Link\"].indexOf(doc.fieldtype) !== -1)",
-            "fieldname": "in_global_search",
-            "fieldtype": "Check",
-            "label": "In Global Search"
-        },
-        {
-            "default": "0",
-            "fieldname": "bold",
-            "fieldtype": "Check",
-            "label": "Bold"
-        },
-        {
-            "default": "1",
-            "depends_on": "eval:['Data', 'Select', 'Text', 'Small Text', 'Text Editor'].includes(doc.fieldtype)",
-            "fieldname": "translatable",
-            "fieldtype": "Check",
-            "label": "Translatable"
-        },
-        {
-            "fieldname": "column_break_7",
-            "fieldtype": "Column Break"
-        },
-        {
-            "depends_on": "eval:in_list([\"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
-            "description": "Set non-standard precision for a Float or Currency field",
-            "fieldname": "precision",
-            "fieldtype": "Select",
-            "label": "Precision",
-            "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
-        },
-        {
-            "depends_on": "eval:in_list(['Data', 'Link', 'Dynamic Link', 'Password', 'Select', 'Read Only', 'Attach', 'Attach Image'], doc.fieldtype)",
-            "fieldname": "length",
-            "fieldtype": "Int",
-            "label": "Length"
-        },
-        {
-            "fieldname": "options",
-            "fieldtype": "Small Text",
-            "in_list_view": 1,
-            "label": "Options",
-            "oldfieldname": "options",
-            "oldfieldtype": "Text"
-        },
-        {
-            "fieldname": "fetch_from",
-            "fieldtype": "Small Text",
-            "label": "Fetch From"
-        },
-        {
-            "default": "0",
-            "description": "If unchecked, the value will always be re-fetched on save.",
-            "fieldname": "fetch_if_empty",
-            "fieldtype": "Check",
-            "label": "Fetch on Save if Empty"
-        },
-        {
-            "fieldname": "permissions",
-            "fieldtype": "Section Break",
-            "label": "Permissions"
-        },
-        {
-            "description": "This field will appear only if the fieldname defined here has value OR the rules are true (examples):\nmyfield\neval:doc.myfield=='My Value'\neval:doc.age&gt;18",
-            "fieldname": "depends_on",
-            "fieldtype": "Code",
-            "label": "Depends On",
-            "oldfieldname": "depends_on",
-            "oldfieldtype": "Data",
-            "options": "JS"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:!in_list(['Section Break', 'Column Break', 'Tab Break'], doc.fieldtype)",
-            "fieldname": "permlevel",
-            "fieldtype": "Int",
-            "in_list_view": 1,
-            "label": "Perm Level",
-            "oldfieldname": "permlevel",
-            "oldfieldtype": "Int"
-        },
-        {
-            "default": "0",
-            "fieldname": "hidden",
-            "fieldtype": "Check",
-            "label": "Hidden",
-            "oldfieldname": "hidden",
-            "oldfieldtype": "Check",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "default": "0",
-            "fieldname": "read_only",
-            "fieldtype": "Check",
-            "label": "Read Only"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:doc.fieldtype==\"Section Break\"",
-            "fieldname": "collapsible",
-            "fieldtype": "Check",
-            "label": "Collapsible"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval: doc.fieldtype == \"Table\"",
-            "fieldname": "allow_bulk_edit",
-            "fieldtype": "Check",
-            "label": "Allow Bulk Edit"
-        },
-        {
-            "depends_on": "eval:doc.fieldtype==\"Section Break\"",
-            "fieldname": "collapsible_depends_on",
-            "fieldtype": "Code",
-            "label": "Collapsible Depends On",
-            "options": "JS"
-        },
-        {
-            "fieldname": "column_break_14",
-            "fieldtype": "Column Break"
-        },
-        {
-            "default": "0",
-            "fieldname": "ignore_user_permissions",
-            "fieldtype": "Check",
-            "label": "Ignore User Permissions"
-        },
-        {
-            "default": "0",
-            "fieldname": "allow_on_submit",
-            "fieldtype": "Check",
-            "label": "Allow on Submit",
-            "oldfieldname": "allow_on_submit",
-            "oldfieldtype": "Check"
-        },
-        {
-            "default": "0",
-            "fieldname": "report_hide",
-            "fieldtype": "Check",
-            "label": "Report Hide",
-            "oldfieldname": "report_hide",
-            "oldfieldtype": "Check"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:(doc.fieldtype == 'Link')",
-            "fieldname": "remember_last_selected_value",
-            "fieldtype": "Check",
-            "label": "Remember Last Selected Value"
-        },
-        {
-            "fieldname": "display",
-            "fieldtype": "Section Break",
-            "label": "Display"
-        },
-        {
-            "fieldname": "default",
-            "fieldtype": "Small Text",
-            "label": "Default",
-            "oldfieldname": "default",
-            "oldfieldtype": "Text"
-        },
-        {
-            "default": "0",
-            "fieldname": "in_filter",
-            "fieldtype": "Check",
-            "label": "In Filter",
-            "oldfieldname": "in_filter",
-            "oldfieldtype": "Check",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "fieldname": "column_break_21",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "description",
-            "fieldtype": "Text",
-            "label": "Description",
-            "oldfieldname": "description",
-            "oldfieldtype": "Text",
-            "print_width": "300px",
-            "width": "300px"
-        },
-        {
-            "default": "0",
-            "fieldname": "print_hide",
-            "fieldtype": "Check",
-            "label": "Print Hide",
-            "oldfieldname": "print_hide",
-            "oldfieldtype": "Check"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:[\"Int\", \"Float\", \"Currency\", \"Percent\"].indexOf(doc.fieldtype)!==-1",
-            "fieldname": "print_hide_if_no_value",
-            "fieldtype": "Check",
-            "label": "Print Hide If No Value"
-        },
-        {
-            "description": "Print Width of the field, if the field is a column in a table",
-            "fieldname": "print_width",
-            "fieldtype": "Data",
-            "label": "Print Width",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "depends_on": "eval:parent.istable",
-            "description": "Number of columns for a field in a Grid (Total Columns in a grid should be less than 11)",
-            "fieldname": "columns",
-            "fieldtype": "Int",
-            "label": "Columns"
-        },
-        {
-            "fieldname": "width",
-            "fieldtype": "Data",
-            "in_list_view": 1,
-            "label": "Width",
-            "oldfieldname": "width",
-            "oldfieldtype": "Data",
-            "print_width": "50px",
-            "width": "50px"
-        },
-        {
-            "default": "0",
-            "fieldname": "is_custom_field",
-            "fieldtype": "Check",
-            "hidden": 1,
-            "label": "Is Custom Field",
-            "read_only": 1
-        },
-        {
-            "default": "0",
-            "fieldname": "allow_in_quick_entry",
-            "fieldtype": "Check",
-            "label": "Allow in Quick Entry"
-        },
-        {
-            "fieldname": "property_depends_on_section",
-            "fieldtype": "Section Break",
-            "label": "Property Depends On"
-        },
-        {
-            "fieldname": "mandatory_depends_on",
-            "fieldtype": "Code",
-            "label": "Mandatory Depends On",
-            "options": "JS"
-        },
-        {
-            "fieldname": "column_break_33",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "read_only_depends_on",
-            "fieldtype": "Code",
-            "label": "Read Only Depends On",
-            "options": "JS"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
-            "fieldname": "in_preview",
-            "fieldtype": "Check",
-            "label": "In Preview"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:doc.fieldtype=='Duration'",
-            "fieldname": "hide_seconds",
-            "fieldtype": "Check",
-            "label": "Hide Seconds"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:doc.fieldtype=='Duration'",
-            "fieldname": "hide_days",
-            "fieldtype": "Check",
-            "label": "Hide Days"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:doc.fieldtype=='Section Break'",
-            "fieldname": "hide_border",
-            "fieldtype": "Check",
-            "label": "Hide Border"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\"], doc.fieldtype)",
-            "fieldname": "non_negative",
-            "fieldtype": "Check",
-            "label": "Non Negative"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:doc.fieldtype=='Tab Break'",
-            "fieldname": "show_dashboard",
-            "fieldtype": "Check",
-            "label": "Show Dashboard"
-        },
-        {
-            "default": "0",
-            "fieldname": "no_copy",
-            "fieldtype": "Check",
-            "label": "No Copy"
-        },
-        {
-            "default": "0",
-            "fieldname": "is_system_generated",
-            "fieldtype": "Check",
-            "hidden": 1,
-            "label": "Is System Generated",
-            "read_only": 1
-        },
-        {
-            "default": "0",
-            "description": "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",
-            "fieldname": "ignore_xss_filter",
-            "fieldtype": "Check",
-            "label": "Ignore XSS Filter"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval: doc.fieldtype === 'Select'",
-            "fieldname": "sort_options",
-            "fieldtype": "Check",
-            "label": "Sort Options"
-        },
-        {
-            "fieldname": "link_filters",
-            "fieldtype": "JSON",
-            "label": "Link Filters"
-        },
-        {
-            "fieldname": "placeholder",
-            "fieldtype": "Data",
-            "label": "Placeholder"
-        },
-        {
-            "depends_on": "eval:doc.fieldtype===\"Button\"",
-            "fieldname": "button_color",
-            "fieldtype": "Select",
-            "label": "Button Color",
-            "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
-        },
-        {
-            "depends_on": "eval:in_list([\"Data\"], doc.fieldtype)",
-            "fieldname": "text_case",
-            "fieldtype": "Select",
-            "label": "Text Case",
-            "options": "\nUpperCase\nTitleCase\nLowerCase"
-        },
-        {
-            "default": "0",
-            "depends_on": "eval:[\"Select\", \"Read Only\", \"Phone\", \"Percent\", \"Password\", \"Link\", \"Int\", \"Float\", \"Dynamic Link\", \"Duration\", \"Datetime\", \"Currency\", \"Data\", \"Date\"].includes(doc.fieldtype)",
-            "fieldname": "mask",
-            "fieldtype": "Check",
-            "label": "Mask"
-        }
-    ],
-    "grid_page_length": 50,
-    "idx": 1,
-    "index_web_pages_for_search": 1,
-    "istable": 1,
-    "links": [],
-    "modified": "2025-12-23 14:17:10.458916",
-    "modified_by": "Administrator",
-    "module": "Custom",
-    "name": "Customize Form Field",
-    "naming_rule": "Random",
-    "owner": "Administrator",
-    "permissions": [],
-    "row_format": "Dynamic",
-    "sort_field": "creation",
-    "sort_order": "DESC",
-    "states": []
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2013-02-22 01:27:32",
+ "doctype": "DocType",
+ "document_type": "Setup",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "is_system_generated",
+  "label_and_type",
+  "label",
+  "fieldtype",
+  "fieldname",
+  "non_negative",
+  "reqd",
+  "unique",
+  "is_virtual",
+  "in_list_view",
+  "in_standard_filter",
+  "in_global_search",
+  "in_preview",
+  "bold",
+  "no_copy",
+  "allow_in_quick_entry",
+  "translatable",
+  "mask",
+  "link_filters",
+  "column_break_7",
+  "default",
+  "precision",
+  "length",
+  "options",
+  "sort_options",
+  "fetch_from",
+  "fetch_if_empty",
+  "show_dashboard",
+  "permissions",
+  "depends_on",
+  "permlevel",
+  "hidden",
+  "read_only",
+  "collapsible",
+  "allow_bulk_edit",
+  "collapsible_depends_on",
+  "column_break_14",
+  "ignore_user_permissions",
+  "allow_on_submit",
+  "report_hide",
+  "remember_last_selected_value",
+  "hide_border",
+  "ignore_xss_filter",
+  "property_depends_on_section",
+  "mandatory_depends_on",
+  "column_break_33",
+  "read_only_depends_on",
+  "display",
+  "button_color",
+  "text_case",
+  "in_filter",
+  "hide_seconds",
+  "hide_days",
+  "column_break_21",
+  "description",
+  "placeholder",
+  "print_hide",
+  "print_hide_if_no_value",
+  "print_width",
+  "columns",
+  "width",
+  "is_custom_field"
+ ],
+ "fields": [
+  {
+   "fieldname": "label_and_type",
+   "fieldtype": "Section Break",
+   "label": "Label and Type"
+  },
+  {
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Label",
+   "length": 255,
+   "oldfieldname": "label",
+   "oldfieldtype": "Data",
+   "search_index": 1
+  },
+  {
+   "default": "Data",
+   "fieldname": "fieldtype",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Type",
+   "oldfieldname": "fieldtype",
+   "oldfieldtype": "Select",
+   "options": "Autocomplete\nAttach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDuration\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nIcon\nImage\nInt\nJSON\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nPhone\nRating\nRead Only\nSection Break\nSelect\nSignature\nSmall Text\nTab Break\nTable\nTable MultiSelect\nText\nText Editor\nTime",
+   "reqd": 1,
+   "search_index": 1,
+   "sort_options": 1
+  },
+  {
+   "fieldname": "fieldname",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Name",
+   "oldfieldname": "fieldname",
+   "oldfieldtype": "Data",
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!in_list([\"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
+   "fieldname": "reqd",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Mandatory",
+   "oldfieldname": "reqd",
+   "oldfieldtype": "Check",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "default": "0",
+   "fieldname": "unique",
+   "fieldtype": "Check",
+   "label": "Unique"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype !== 'Link'",
+   "fieldname": "is_virtual",
+   "fieldtype": "Check",
+   "label": "Is Virtual"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.is_virtual",
+   "fieldname": "in_list_view",
+   "fieldtype": "Check",
+   "label": "In List View"
+  },
+  {
+   "default": "0",
+   "fieldname": "in_standard_filter",
+   "fieldtype": "Check",
+   "label": "In Standard Filter"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:([\"Data\", \"Select\", \"Table\", \"Text\", \"Text Editor\", \"Link\", \"Small Text\", \"Long Text\", \"Read Only\", \"Heading\", \"Dynamic Link\"].indexOf(doc.fieldtype) !== -1)",
+   "fieldname": "in_global_search",
+   "fieldtype": "Check",
+   "label": "In Global Search"
+  },
+  {
+   "default": "0",
+   "fieldname": "bold",
+   "fieldtype": "Check",
+   "label": "Bold"
+  },
+  {
+   "default": "1",
+   "depends_on": "eval:['Data', 'Select', 'Text', 'Small Text', 'Text Editor'].includes(doc.fieldtype)",
+   "fieldname": "translatable",
+   "fieldtype": "Check",
+   "label": "Translatable"
+  },
+  {
+   "fieldname": "column_break_7",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:in_list([\"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
+   "description": "Set non-standard precision for a Float or Currency field",
+   "fieldname": "precision",
+   "fieldtype": "Select",
+   "label": "Precision",
+   "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+  },
+  {
+   "depends_on": "eval:in_list(['Data', 'Link', 'Dynamic Link', 'Password', 'Select', 'Read Only', 'Attach', 'Attach Image'], doc.fieldtype)",
+   "fieldname": "length",
+   "fieldtype": "Int",
+   "label": "Length"
+  },
+  {
+   "fieldname": "options",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Options",
+   "oldfieldname": "options",
+   "oldfieldtype": "Text"
+  },
+  {
+   "fieldname": "fetch_from",
+   "fieldtype": "Small Text",
+   "label": "Fetch From"
+  },
+  {
+   "default": "0",
+   "description": "If unchecked, the value will always be re-fetched on save.",
+   "fieldname": "fetch_if_empty",
+   "fieldtype": "Check",
+   "label": "Fetch on Save if Empty"
+  },
+  {
+   "fieldname": "permissions",
+   "fieldtype": "Section Break",
+   "label": "Permissions"
+  },
+  {
+   "description": "This field will appear only if the fieldname defined here has value OR the rules are true (examples):\nmyfield\neval:doc.myfield=='My Value'\neval:doc.age&gt;18",
+   "fieldname": "depends_on",
+   "fieldtype": "Code",
+   "label": "Depends On",
+   "oldfieldname": "depends_on",
+   "oldfieldtype": "Data",
+   "options": "JS"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!in_list(['Section Break', 'Column Break', 'Tab Break'], doc.fieldtype)",
+   "fieldname": "permlevel",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Perm Level",
+   "oldfieldname": "permlevel",
+   "oldfieldtype": "Int"
+  },
+  {
+   "default": "0",
+   "fieldname": "hidden",
+   "fieldtype": "Check",
+   "label": "Hidden",
+   "oldfieldname": "hidden",
+   "oldfieldtype": "Check",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "default": "0",
+   "fieldname": "read_only",
+   "fieldtype": "Check",
+   "label": "Read Only"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype==\"Section Break\"",
+   "fieldname": "collapsible",
+   "fieldtype": "Check",
+   "label": "Collapsible"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.fieldtype == \"Table\"",
+   "fieldname": "allow_bulk_edit",
+   "fieldtype": "Check",
+   "label": "Allow Bulk Edit"
+  },
+  {
+   "depends_on": "eval:doc.fieldtype==\"Section Break\"",
+   "fieldname": "collapsible_depends_on",
+   "fieldtype": "Code",
+   "label": "Collapsible Depends On",
+   "options": "JS"
+  },
+  {
+   "fieldname": "column_break_14",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "ignore_user_permissions",
+   "fieldtype": "Check",
+   "label": "Ignore User Permissions"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_on_submit",
+   "fieldtype": "Check",
+   "label": "Allow on Submit",
+   "oldfieldname": "allow_on_submit",
+   "oldfieldtype": "Check"
+  },
+  {
+   "default": "0",
+   "fieldname": "report_hide",
+   "fieldtype": "Check",
+   "label": "Report Hide",
+   "oldfieldname": "report_hide",
+   "oldfieldtype": "Check"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:(doc.fieldtype == 'Link')",
+   "fieldname": "remember_last_selected_value",
+   "fieldtype": "Check",
+   "label": "Remember Last Selected Value"
+  },
+  {
+   "fieldname": "display",
+   "fieldtype": "Section Break",
+   "label": "Display"
+  },
+  {
+   "fieldname": "default",
+   "fieldtype": "Small Text",
+   "label": "Default",
+   "oldfieldname": "default",
+   "oldfieldtype": "Text"
+  },
+  {
+   "default": "0",
+   "fieldname": "in_filter",
+   "fieldtype": "Check",
+   "label": "In Filter",
+   "oldfieldname": "in_filter",
+   "oldfieldtype": "Check",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "fieldname": "column_break_21",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Text",
+   "label": "Description",
+   "oldfieldname": "description",
+   "oldfieldtype": "Text",
+   "print_width": "300px",
+   "width": "300px"
+  },
+  {
+   "default": "0",
+   "fieldname": "print_hide",
+   "fieldtype": "Check",
+   "label": "Print Hide",
+   "oldfieldname": "print_hide",
+   "oldfieldtype": "Check"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:[\"Int\", \"Float\", \"Currency\", \"Percent\"].indexOf(doc.fieldtype)!==-1",
+   "fieldname": "print_hide_if_no_value",
+   "fieldtype": "Check",
+   "label": "Print Hide If No Value"
+  },
+  {
+   "description": "Print Width of the field, if the field is a column in a table",
+   "fieldname": "print_width",
+   "fieldtype": "Data",
+   "label": "Print Width",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "depends_on": "eval:parent.istable",
+   "description": "Number of columns for a field in a Grid (Total Columns in a grid should be less than 11)",
+   "fieldname": "columns",
+   "fieldtype": "Int",
+   "label": "Columns"
+  },
+  {
+   "fieldname": "width",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Width",
+   "oldfieldname": "width",
+   "oldfieldtype": "Data",
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_custom_field",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Is Custom Field",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_in_quick_entry",
+   "fieldtype": "Check",
+   "label": "Allow in Quick Entry"
+  },
+  {
+   "fieldname": "property_depends_on_section",
+   "fieldtype": "Section Break",
+   "label": "Property Depends On"
+  },
+  {
+   "fieldname": "mandatory_depends_on",
+   "fieldtype": "Code",
+   "label": "Mandatory Depends On",
+   "options": "JS"
+  },
+  {
+   "fieldname": "column_break_33",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "read_only_depends_on",
+   "fieldtype": "Code",
+   "label": "Read Only Depends On",
+   "options": "JS"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
+   "fieldname": "in_preview",
+   "fieldtype": "Check",
+   "label": "In Preview"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype=='Duration'",
+   "fieldname": "hide_seconds",
+   "fieldtype": "Check",
+   "label": "Hide Seconds"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype=='Duration'",
+   "fieldname": "hide_days",
+   "fieldtype": "Check",
+   "label": "Hide Days"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype=='Section Break'",
+   "fieldname": "hide_border",
+   "fieldtype": "Check",
+   "label": "Hide Border"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\"], doc.fieldtype)",
+   "fieldname": "non_negative",
+   "fieldtype": "Check",
+   "label": "Non Negative"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype=='Tab Break'",
+   "fieldname": "show_dashboard",
+   "fieldtype": "Check",
+   "label": "Show Dashboard"
+  },
+  {
+   "default": "0",
+   "fieldname": "no_copy",
+   "fieldtype": "Check",
+   "label": "No Copy"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_system_generated",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Is System Generated",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "description": "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",
+   "fieldname": "ignore_xss_filter",
+   "fieldtype": "Check",
+   "label": "Ignore XSS Filter"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.fieldtype === 'Select'",
+   "fieldname": "sort_options",
+   "fieldtype": "Check",
+   "label": "Sort Options"
+  },
+  {
+   "fieldname": "link_filters",
+   "fieldtype": "JSON",
+   "label": "Link Filters"
+  },
+  {
+   "fieldname": "placeholder",
+   "fieldtype": "Data",
+   "label": "Placeholder"
+  },
+  {
+   "depends_on": "eval:doc.fieldtype===\"Button\"",
+   "fieldname": "button_color",
+   "fieldtype": "Select",
+   "label": "Button Color",
+   "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
+  },
+  {
+   "depends_on": "eval:in_list([\"Data\"], doc.fieldtype)",
+   "fieldname": "text_case",
+   "fieldtype": "Select",
+   "label": "Text Case",
+   "options": "\nUpperCase\nTitleCase\nLowerCase"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:[\"Select\", \"Read Only\", \"Phone\", \"Percent\", \"Password\", \"Link\", \"Int\", \"Float\", \"Dynamic Link\", \"Duration\", \"Datetime\", \"Currency\", \"Data\", \"Date\"].includes(doc.fieldtype)",
+   "fieldname": "mask",
+   "fieldtype": "Check",
+   "label": "Mask"
+  }
+ ],
+ "grid_page_length": 50,
+ "idx": 1,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-12-23 14:17:10.458916",
+ "modified_by": "Administrator",
+ "module": "Custom",
+ "name": "Customize Form Field",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
 }

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -170,11 +170,11 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 			// Apply text case transformation for read-only display
 			if (this.df.text_case && this.df.fieldtype === "Data") {
 				const caseMap = {
-					'UpperCase': 'uppercase',
-					'TitleCase': 'capitalize',
-					'LowerCase': 'lowercase'
+					UpperCase: "uppercase",
+					TitleCase: "capitalize",
+					LowerCase: "lowercase",
 				};
-				$(this.disp_area).css("text-transform", caseMap[this.df.text_case] || 'none');
+				$(this.disp_area).css("text-transform", caseMap[this.df.text_case] || "none");
 			}
 		}
 	}
@@ -186,7 +186,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		var icon = "";
 		this.label_span.innerHTML =
 			(icon ? '<i class="' + icon + '"></i> ' : "") +
-			__(this.df.label, null, this.df.parent) || "&nbsp;";
+				__(this.df.label, null, this.df.parent) || "&nbsp;";
 		this._label = this.df.label;
 	}
 

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -165,7 +165,18 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		let doc = this.doc || (this.frm && this.frm.doc);
 		let display_value = frappe.format(value, this.df, { no_icon: true, inline: true }, doc);
 		// This is used to display formatted output AND showing values in read only fields
-		this.disp_area && $(this.disp_area).html(display_value);
+		if (this.disp_area) {
+			$(this.disp_area).html(display_value);
+			// Apply text case transformation for read-only display
+			if (this.df.text_case && this.df.fieldtype === "Data") {
+				const caseMap = {
+					'UpperCase': 'uppercase',
+					'TitleCase': 'capitalize',
+					'LowerCase': 'lowercase'
+				};
+				$(this.disp_area).css("text-transform", caseMap[this.df.text_case] || 'none');
+			}
+		}
 	}
 	set_label(label) {
 		if (label) this.df.label = label;
@@ -175,7 +186,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		var icon = "";
 		this.label_span.innerHTML =
 			(icon ? '<i class="' + icon + '"></i> ' : "") +
-				__(this.df.label, null, this.df.parent) || "&nbsp;";
+			__(this.df.label, null, this.df.parent) || "&nbsp;";
 		this._label = this.df.label;
 	}
 

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -288,12 +288,12 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		if (value && this.df.text_case) {
 			switch (this.df.text_case) {
 				case 'UpperCase':
-					return value.toUpperCase();
+					return value.toLocaleUpperCase();
 				case 'LowerCase':
-					return value.toLowerCase();
+					return value.toLocaleLowerCase();
 				case 'TitleCase':
-					return value.replace(/\w\S*/g, (txt) =>
-						txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
+					return value.replace(/[^\s]+/g, (txt) =>
+						txt.charAt(0).toLocaleUpperCase() + txt.substr(1).toLocaleLowerCase()
 					);
 			}
 		}

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -251,6 +251,15 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		if (this.df.input_class) {
 			this.$input.addClass(this.df.input_class);
 		}
+		// Apply text case transformation if specified
+		if (this.df.text_case) {
+			const caseMap = {
+				'UpperCase': 'uppercase',
+				'TitleCase': 'capitalize',
+				'LowerCase': 'lowercase'
+			};
+			this.$input.css("text-transform", caseMap[this.df.text_case] || 'none');
+		}
 	}
 	set_input(value) {
 		this.last_value = this.value;
@@ -274,6 +283,19 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 	parse(value) {
 		if (this.df.options == "IBAN" && value) {
 			return value.replaceAll(" ", "");
+		}
+		// Transform value based on text_case setting
+		if (value && this.df.text_case) {
+			switch (this.df.text_case) {
+				case 'UpperCase':
+					return value.toUpperCase();
+				case 'LowerCase':
+					return value.toLowerCase();
+				case 'TitleCase':
+					return value.replace(/\w\S*/g, (txt) =>
+						txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
+					);
+			}
 		}
 		return value;
 	}

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -254,11 +254,11 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		// Apply text case transformation if specified
 		if (this.df.text_case) {
 			const caseMap = {
-				'UpperCase': 'uppercase',
-				'TitleCase': 'capitalize',
-				'LowerCase': 'lowercase'
+				UpperCase: "uppercase",
+				TitleCase: "capitalize",
+				LowerCase: "lowercase",
 			};
-			this.$input.css("text-transform", caseMap[this.df.text_case] || 'none');
+			this.$input.css("text-transform", caseMap[this.df.text_case] || "none");
 		}
 	}
 	set_input(value) {
@@ -287,13 +287,15 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		// Transform value based on text_case setting
 		if (value && this.df.text_case) {
 			switch (this.df.text_case) {
-				case 'UpperCase':
+				case "UpperCase":
 					return value.toLocaleUpperCase();
-				case 'LowerCase':
+				case "LowerCase":
 					return value.toLocaleLowerCase();
-				case 'TitleCase':
-					return value.replace(/[^\s]+/g, (txt) =>
-						txt.charAt(0).toLocaleUpperCase() + txt.substr(1).toLocaleLowerCase()
+				case "TitleCase":
+					return value.replace(
+						/[^\s]+/g,
+						(txt) =>
+							txt.charAt(0).toLocaleUpperCase() + txt.substr(1).toLocaleLowerCase()
 					);
 			}
 		}


### PR DESCRIPTION
## Summary
Introduces a new "Text Case" property for Data fields, similar to the alignment feature. This allows configuring text transformations (UpperCase, TitleCase, LowerCase) both visually in the UI and for actual stored values.

## Features
- **Visual Transformation**: Applies CSS `text-transform` to display text in the selected case
- **Value Transformation**: Transforms the actual value on blur (UpperCase → `toUpperCase()`, TitleCase → title case, LowerCase → `toLowerCase()`)
- **Read-only Support**: Applies text transformation in read-only/display mode

## Changes

### Backend
- **[docfield.json]**: Added `text_case` Select field with options (UpperCase, TitleCase, LowerCase) for Data fieldtype
- **[customize_form_field.json]**: Added `text_case` field for Customize Form support
- **[customize_form.py]**: Added `text_case` to `docfield_properties` for Property Setter persistence

### Frontend
- **[data.js]**: 
  - `apply_text_case_style()`: Applies CSS text-transform based on selected case
  - `parse()`: Transforms actual value based on text_case setting
- **[base_input.js]**: Applies text-transform styling in read-only display mode

Before
![frappe-text_case-1](https://github.com/user-attachments/assets/1ec5c7fb-6c28-4318-8872-9edff00514b9)

After
<img width="1818" height="826" alt="Screenshot from 2026-01-14 10-53-38" src="https://github.com/user-attachments/assets/9854c2a7-b735-42c8-be64-d5d5afb02fac" />
![frappe-text_case-2](https://github.com/user-attachments/assets/c777c106-0cfe-47ff-9ead-54dd98611f0c)
