### PR TITLE
fix: sidebar editor fixes

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
@@ -84,6 +84,7 @@ export class SidebarEditor {
 	}
 	prepare_data() {
 		this.new_sidebar_items.forEach((item) => {
+			if (!item.nested_items) return;
 			item.nested_items.forEach((nested_item) => {
 				if (nested_item.parent) {
 					delete nested_item.parent;

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
@@ -84,13 +84,11 @@ export class SidebarEditor {
 	}
 	prepare_data() {
 		this.new_sidebar_items.forEach((item) => {
-			if (item.nested_items) {
-				item.nested_items.forEach((nested_item) => {
-					if (nested_item.parent) {
-						delete nested_item.parent;
-					}
-				});
-			}
+			item.nested_items.forEach((nested_item) => {
+				if (nested_item.parent) {
+					delete nested_item.parent;
+				}
+			});
 		});
 	}
 	setup_sorting() {

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
@@ -84,11 +84,13 @@ export class SidebarEditor {
 	}
 	prepare_data() {
 		this.new_sidebar_items.forEach((item) => {
-			item.nested_items.forEach((nested_item) => {
-				if (nested_item.parent) {
-					delete nested_item.parent;
-				}
-			});
+			if (item.nested_items) {
+				item.nested_items.forEach((nested_item) => {
+					if (nested_item.parent) {
+						delete nested_item.parent;
+					}
+				});
+			}
 		});
 	}
 	setup_sorting() {

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -75,7 +75,11 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 	prepare() {}
 	make() {
 		this.path = this.get_path();
-		if (!this.path && !this.item.standard && this.item.type != "Section Break") {
+		if (
+			!this.path &&
+			!this.item.standard &&
+			this.item.type in ("Section Break", "Sidebar Item Group") === false
+		) {
 			return;
 		}
 		this.set_suffix();
@@ -177,8 +181,8 @@ frappe.ui.sidebar_item.TypeSectionBreak = class SectionBreakSidebarItem extends 
 		this.full_template = $(this.wrapper);
 	}
 	make() {
-		if (this.item.nested_items.length == 0) return;
 		super.make();
+		if (!this.item.nested_items || this.item.nested_items.length == 0) return;
 		this.add_items();
 		this.toggle_on_collapse();
 		this.enable_collapsible(this.item, this.full_template);

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -75,11 +75,7 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 	prepare() {}
 	make() {
 		this.path = this.get_path();
-		if (
-			!this.path &&
-			!this.item.standard &&
-			this.item.type in ("Section Break", "Sidebar Item Group") === false
-		) {
+		if (!this.path && !this.item.standard && this.item.type != "Section Break") {
 			return;
 		}
 		this.set_suffix();

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -252,7 +252,6 @@
 	display: none;
 }
 .section-break {
-	flex: 0 0 auto !important;
 	color: var(--ink-gray-5) !important;
 	margin-left: 7px;
 	gap: 0px !important;
@@ -270,6 +269,7 @@
 	.standard-sidebar-item:hover {
 		& .sidebar-item-edit-controls {
 			visibility: visible;
+			width: auto;
 		}
 	}
 	.collapse-sidebar-link {
@@ -283,6 +283,7 @@
 	visibility: hidden;
 	display: flex;
 	gap: 6px;
+	width: 0;
 }
 .standard-sidebar-item[data-name="add-sidebar-item"] {
 	margin-top: 5px;

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -270,8 +270,6 @@
 	.standard-sidebar-item:hover {
 		& .sidebar-item-edit-controls {
 			visibility: visible;
-			display: flex;
-			gap: 6px;
 		}
 	}
 	.collapse-sidebar-link {
@@ -283,6 +281,8 @@
 }
 .sidebar-item-edit-controls {
 	visibility: hidden;
+	display: flex;
+	gap: 6px;
 }
 .standard-sidebar-item[data-name="add-sidebar-item"] {
 	margin-top: 5px;


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

In `SectionBreakSidebarItem`, the `make` method overrides its parent class's `SidebarItem.make`. It then returns early before the parent method's `SidebarItem.make` can be called. So, new (and therefore empty) Sidebar Section Breaks aren't "made":-

<img width="777" height="806" alt="Screenshot 2026-01-15 at 11 26 18" src="https://github.com/user-attachments/assets/fb51e9c3-3893-43f3-8e43-e79dc92973c6" />

Javascript console traceback:-

```
sidebar_item.js:180 Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at SectionBreakSidebarItem.make (sidebar_item.js:180:30)
    at new SidebarItem (sidebar_item.js:12:8)
    at new SectionBreakSidebarItem (sidebar_item.js:155:43)
    at Sidebar.make_sidebar_item (sidebar.js:349:10)
    at Sidebar.add_item (sidebar.js:340:9)
    at sidebar.js:258:11
    at Array.forEach (<anonymous>)
    at Sidebar.create_sidebar (sidebar.js:256:10)
    at Dialog.primary_action (sidebar_editor.js:469:16)
    at HTMLButtonElement.<anonymous> (dialog.js:210:20)
```


> Explain the **details** for making this change. What existing problem does the pull request solve?

Fixes https://github.com/frappe/frappe/issues/35881
Might also fix: https://github.com/frappe/frappe/issues/35873

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

I've also made some minor CSS fixes which improve the `:hover` effect on Section Breaks:

| Before | After |
| --- | --- |
|  <img width="221" height="404" alt="Screenshot 2026-01-15 at 11 20 52" src="https://github.com/user-attachments/assets/b37fdfaa-e5da-4c2d-a0be-386b075331c4" /> | <img width="222" height="381" alt="Screenshot 2026-01-15 at 11 24 15" src="https://github.com/user-attachments/assets/38327fc7-053c-42bc-abbb-95b626ecd9f3" /> |


