### PR TITLE
fix: enable escape_html for all text data types

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -148,11 +148,17 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		}
 		if (
 			value &&
-			["Data", "Text", "Small Text", "Long Text", "Password", "MultiSelect", "MultiSelectPills"].includes(
-				this.df.fieldtype
-			)
+			[
+				"Data",
+				"Text",
+				"Small Text",
+				"Long Text",
+				"Password",
+				"MultiSelect",
+				"MultiSelectPills",
+			].includes(this.df.fieldtype)
 		) {
-			value = frappe.utils.xss_sanitise(value);
+			value = frappe.utils.escape_html(value);
 		}
 		let doc = this.doc || (this.frm && this.frm.doc);
 		let display_value = frappe.format(value, this.df, { no_icon: true, inline: true }, doc);

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -146,8 +146,13 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		} else {
 			value = this.value || value;
 		}
-		if (this.df.fieldtype === "Data") {
-			value = frappe.utils.escape_html(value);
+		if (
+			value &&
+			["Data", "Text", "Small Text", "Long Text", "Password", "MultiSelect", "MultiSelectPills"].includes(
+				this.df.fieldtype
+			)
+		) {
+			value = frappe.utils.xss_sanitise(value);
 		}
 		let doc = this.doc || (this.frm && this.frm.doc);
 		let display_value = frappe.format(value, this.df, { no_icon: true, inline: true }, doc);


### PR DESCRIPTION
This pull request improves the sanitization of user input in form controls to enhance security and prevent XSS vulnerabilities. The main change is the expansion of input sanitization to cover more field types and the use of a more robust sanitization method.

**Security and input sanitization improvements:**

* Expanded sanitization to additional field types (`Text`, `Small Text`, `Long Text`, `Password`, `MultiSelect`, `MultiSelectPills`) and switched from `escape_html` to the more comprehensive `xss_sanitise` function for these fields in the `ControlInput` class (`frappe/public/js/frappe/form/controls/base_input.js`).<!--
