### PR TITLE
feat(doctype): generate controller_tree.js boilerplate for tree doctypes

### DIFF
--- a/frappe/core/doctype/doctype/boilerplate/controller_tree.js
+++ b/frappe/core/doctype/doctype/boilerplate/controller_tree.js
@@ -1,0 +1,5 @@
+// Copyright (c) {year}, {app_publisher} and contributors
+// For license information, please see license.txt
+
+// frappe.treeview_settings["{doctype}"] = {{
+// }};

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -877,6 +877,9 @@ class DocType(Document):
 			make_boilerplate("controller.js", self.as_dict())
 			# make_boilerplate("controller_list.js", self.as_dict())
 
+		if self.is_tree:
+			make_boilerplate("controller_tree.js", self.as_dict())
+
 		if self.has_web_view:
 			templates_path = frappe.get_module_path(
 				frappe.scrub(self.module), "doctype", frappe.scrub(self.name), "templates"

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -345,7 +345,6 @@ def get_app_publisher(module: str) -> str:
 
 
 def make_boilerplate(template: str, doc: "Document" | "frappe._dict", opts: dict | "frappe._dict" = None):
-	# print(template, "template_file_path \n\n\n")
 	target_path = get_doc_path(doc.module, doc.doctype, doc.name)
 	template_name = template.replace("controller", scrub(doc.name))
 	if template_name.endswith("._py"):
@@ -354,8 +353,6 @@ def make_boilerplate(template: str, doc: "Document" | "frappe._dict", opts: dict
 	template_file_path = os.path.join(
 		get_module_path("core"), "doctype", scrub(doc.doctype), "boilerplate", template
 	)
-
-	
 
 	if os.path.exists(target_file_path):
 		print(f"{target_file_path} already exists, skipping...")
@@ -403,7 +400,7 @@ def make_boilerplate(template: str, doc: "Document" | "frappe._dict", opts: dict
 			"""
 
 		controller_body = indent(dedent(controller_body), "\t")
-	# print(source, "source \n\n\n")
+
 	with open(target_file_path, "w") as target, open(template_file_path) as source:
 		template = source.read()
 		controller_file_content = cstr(template).format(
@@ -417,7 +414,6 @@ def make_boilerplate(template: str, doc: "Document" | "frappe._dict", opts: dict
 			custom_controller=controller_body,
 		)
 		print("template_file_path \n\n\n", controller_file_content)
-		# print(controller_file_content)
 		target.write(frappe.as_unicode(controller_file_content))
 
 

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -345,6 +345,7 @@ def get_app_publisher(module: str) -> str:
 
 
 def make_boilerplate(template: str, doc: "Document" | "frappe._dict", opts: dict | "frappe._dict" = None):
+	# print(template, "template_file_path \n\n\n")
 	target_path = get_doc_path(doc.module, doc.doctype, doc.name)
 	template_name = template.replace("controller", scrub(doc.name))
 	if template_name.endswith("._py"):
@@ -353,6 +354,8 @@ def make_boilerplate(template: str, doc: "Document" | "frappe._dict", opts: dict
 	template_file_path = os.path.join(
 		get_module_path("core"), "doctype", scrub(doc.doctype), "boilerplate", template
 	)
+
+	
 
 	if os.path.exists(target_file_path):
 		print(f"{target_file_path} already exists, skipping...")
@@ -400,7 +403,7 @@ def make_boilerplate(template: str, doc: "Document" | "frappe._dict", opts: dict
 			"""
 
 		controller_body = indent(dedent(controller_body), "\t")
-
+	# print(source, "source \n\n\n")
 	with open(target_file_path, "w") as target, open(template_file_path) as source:
 		template = source.read()
 		controller_file_content = cstr(template).format(
@@ -413,6 +416,8 @@ def make_boilerplate(template: str, doc: "Document" | "frappe._dict", opts: dict
 			**opts,
 			custom_controller=controller_body,
 		)
+		print("template_file_path \n\n\n", controller_file_content)
+		# print(controller_file_content)
 		target.write(frappe.as_unicode(controller_file_content))
 
 

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -413,7 +413,6 @@ def make_boilerplate(template: str, doc: "Document" | "frappe._dict", opts: dict
 			**opts,
 			custom_controller=controller_body,
 		)
-		print("template_file_path \n\n\n", controller_file_content)
 		target.write(frappe.as_unicode(controller_file_content))
 
 


### PR DESCRIPTION
`no-docs`