### PR TITLE
fix: return CommunicationComposer instance in email_doc method

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1400,7 +1400,7 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	email_doc(message) {
-		new frappe.views.CommunicationComposer({
+		return new frappe.views.CommunicationComposer({
 			doc: this.doc,
 			frm: this,
 			subject: __(this.meta.name) + ": " + this.docname,


### PR DESCRIPTION
This pull request makes a minor change to the `email_doc` method in the `FrappeForm` class. The method now returns the `CommunicationComposer` instance instead of just creating it, which can improve composability and allow callers to interact with the composer after it's created.

This allows customizations to use `const composer = frm.email_doc()`.