### PR TITLE
fix(mobile): desktop modal design

### DIFF
--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -234,7 +234,7 @@
 }
 .modal-body .icons{
     margin-top: 0px;
-    place-self: start;
+    place-self: anchor-center;
     & .desktop-icon{
         height: 126px;
         width: 127px;
@@ -395,7 +395,9 @@
   }
 
     .desktop-modal-body {
-        width: 90vw;
+        width: calc(100vw - 20px);
+        padding-left: 0px !important;
+        padding-right: 0px !important;
         > .icons-container {
             width: 100%;
             overflow: hidden !important;
@@ -404,10 +406,8 @@
             padding: 0;
 
             > .icons {
-                position: relative;
-                right: 6%;
-                column-gap: 4px;
-                row-gap: 8px;
+                column-gap: 6px;
+                row-gap: 6px;
 
                 @media screen and (max-width: 380px) {
                 --desktop-icon-container: 100px;
@@ -463,4 +463,7 @@
 [data-theme="dark"] .desktop-edit:hover{
 	opacity: 0.8;
 	transition: opacity 0.3s;
+}
+.desktop-navbar-modal-search:hover{
+    outline: 1px solid var(--surface-gray-3);
 }


### PR DESCRIPTION
This PR fixes styles for the desktop modal on mobile

Before

<img width="357" height="674" alt="Screenshot 2026-01-16 at 2 56 47 AM" src="https://github.com/user-attachments/assets/cc78c327-8660-4ac9-ac67-9ef27d647c8f" />


After

<img width="355" height="671" alt="Screenshot 2026-01-16 at 2 55 20 AM" src="https://github.com/user-attachments/assets/0aeb6dc1-b481-4ffa-a293-3e765a6e77f1" />
