### PR TITLE
fix: Check column type and df before accessing fieldname in get_left_html

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -797,7 +797,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	get_left_html(doc) {
 		let left_html = "";
 		const mobile_field_columns = this.columns.filter(
-			col => col.type === "Field" && col.df?.fieldname
+			(col) => col.type === "Field" && col.df?.fieldname
 		);
 		let has_value_in_second_column = true;
 		if (mobile_field_columns.length > 1) {

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -800,7 +800,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		for (let i = 0; i < this.columns.length; i++) {
 			let col = this.columns[i];
 
-			if (i == 4 && !doc[col.df.fieldname] && doc[col.df.fieldname] != 0) {
+			if (i == 4 && col.type == "Field" && col.df?.fieldname && !doc[col.df.fieldname] && doc[col.df.fieldname] != 0) {
 				has_value_in_second_column = false;
 			}
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -796,13 +796,18 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	get_left_html(doc) {
 		let left_html = "";
+		const mobile_field_columns = this.columns.filter(
+			col => col.type === "Field" && col.df?.fieldname
+		);
 		let has_value_in_second_column = true;
-		for (let i = 0; i < this.columns.length; i++) {
-			let col = this.columns[i];
-
-			if (i == 4 && col.type == "Field" && col.df?.fieldname && !doc[col.df.fieldname] && doc[col.df.fieldname] != 0) {
+		if (mobile_field_columns.length > 1) {
+			const fieldname = mobile_field_columns[1].df.fieldname;
+			if (!doc[fieldname] && doc[fieldname] != 0) {
 				has_value_in_second_column = false;
 			}
+		}
+		for (let i = 0; i < this.columns.length; i++) {
+			let col = this.columns[i];
 
 			if (frappe.is_mobile() && col.type == "Field" && [3, 4].includes(i)) {
 				left_html += `<div class="mobile-layout ${


### PR DESCRIPTION
## Description

Refactors `ListView.get_left_html()` to use filtered field columns instead of hardcoded index checks. This fixes a crash when non-Field columns (Status/Tag) are present and makes the code more robust by not relying on specific column positions.

## Changes

- Filter `mobile_field_columns` first to get only Field-type columns with fieldnames
- Use the second field column from the filtered array (`mobile_field_columns[1]`) instead of hardcoded index `i == 4`
- Removes index-based assumption, making the code adapt to different column configurations
- Prevents `TypeError: Cannot read properties of undefined (reading 'fieldname')` when non-Field columns appear at index 4

## Related Issue

Fixes #36002

## Testing

- Verified that ListView renders correctly when Status/Tag columns appear at different positions
- Code now uses actual field columns rather than assuming specific index positions
- No linting errors introduced
---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=5625555