### PR TITLE
fix: allow command k trigger inside input

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -55,6 +55,18 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 			// like links, currencies, HTMLs etc.
 			this.disp_area = this.$wrapper.find(".control-value").get(0);
 		}
+		this.setup_shortcut();
+	}
+	setup_shortcut() {
+		$(this.input_area).on("keydown", function (event) {
+			if (event.originalEvent.ctrlKey || event.originalEvent.metaKey) {
+				if (event.originalEvent.key === "k" || event.originalEvent.key === "K") {
+					$("#navbar-modal-search").click();
+					event.preventDefault();
+					return false;
+				}
+			}
+		});
 	}
 	set_max_width() {
 		if (this.constructor.horizontal) {


### PR DESCRIPTION
Consider the following scenario 
You are in list view filter and then quickly want to jump to some other doctype to check something and use command K to trigger awesombar but nothing happens. This PR allows triggering only command K inside input element

This can be a user preference but keeping it on for everyone for now. Do tell me if its annoying


https://github.com/user-attachments/assets/4dc239a2-3ca0-46b3-a536-fec19ad729cd



