### PR TITLE
fix: ignore unsupported filter when querying dynamic link doctypes

### DIFF
--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -116,6 +116,7 @@ def filter_dynamic_link_doctypes(
 
 	txt = txt or ""
 	filters = filters or {}
+	filters.pop("name", None)  # ignore unsupported "name" filter - passed by validate_link_and_fetch
 
 	_doctypes_from_df = frappe.get_all(
 		"DocField",


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/36013

this is a rare case - doctype being passed isn't the doctype being queried. so ignoring the filter.
I will look at other cases as well. if this is seen happening more often, I will try to design something systemic for this.