### PR TITLE
fix(query report): set input field width 100% on collapsible button attach

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -641,6 +641,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		const me = this;
 		let filter_no = this.filter_row_length - 1;
 		if (this.filters[filter_no]) {
+			// set input field width 100%
+			$($(this.filters[filter_no].wrapper)[0].childNodes[0]).css("width", "100%");
+
 			this.$collapse_button = $(`<div>${frappe.utils.icon("chevron-down")}</div>`);
 			$(this.filters[filter_no].wrapper).append(this.$collapse_button);
 			$(this.filters[filter_no].wrapper).css("display", "flex");


### PR DESCRIPTION
Fixed the issue with fields that don't have the `form-control` class, like the `MultiSelectList` field, the field shrinks on attaching the Collapse Button. Now, before attaching the Collapse Button, the field width will be set to 100%.

Before:

<img width="2836" height="234" alt="image" src="https://github.com/user-attachments/assets/757c6dca-f056-48e3-89cd-3dd7e5cfe453" />


After:

<img width="2838" height="238" alt="image" src="https://github.com/user-attachments/assets/35d473fb-8f8a-4f83-b5e5-7e8db2eeaa19" />



