### PR TITLE
fix(UI): reportview configurations

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -538,6 +538,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 		let filter_area = this.page.page_form;
 		this.filters = [];
+		this.check_filter_area = filter_area;
 		if (this.report_settings.seperate_check_filters) this.setup_check_filter_area();
 		this.filters = filters
 			.map((df, index) => {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -538,7 +538,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 		let filter_area = this.page.page_form;
 		this.filters = [];
-		this.check_filter_area = filter_area;
 		if (this.report_settings.seperate_check_filters) this.setup_check_filter_area();
 		this.filters = filters
 			.map((df, index) => {
@@ -624,7 +623,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			for (let i = this.filter_row_length; i < this.filters.length; i++) {
 				$(this.filters[i].wrapper).addClass("hidden");
 			}
-			this.check_filter_area.css("display", "none");
+			this.check_filter_area && this.check_filter_area.css("display", "none");
 			this.filters_hidden = false;
 			icon_name = "chevron-down";
 		} else {
@@ -642,15 +641,23 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		const me = this;
 		let filter_no = this.filter_row_length - 1;
 		if (this.filters[filter_no]) {
-			this.$collapse_button = $(`<div>${frappe.utils.icon("chevron-down")}</div>`);
+			this.$collapse_button = $(
+				`<div class='btn btn-xs btn-secondary collapsible-filters'>${frappe.utils.icon(
+					"chevron-down"
+				)}</div>`
+			);
 			$(this.filters[filter_no].wrapper).append(this.$collapse_button);
 			$(this.filters[filter_no].wrapper).css("display", "flex");
 			$(this.filters[filter_no].wrapper).css("align-items", "center");
 			$(this.filters[filter_no].wrapper).css("gap", "16px");
-
-			this.$collapse_button.addClass("btn");
-			this.$collapse_button.addClass("btn-xs");
-			this.$collapse_button.addClass("btn-secondary");
+			if ($(this.filters[filter_no].wrapper).find("select")) {
+				$(this.filters[filter_no].wrapper)
+					.find(".select-icon")
+					.css(
+						"left",
+						$(this.filters[filter_no].wrapper).find("select").width() + 18 + "px"
+					);
+			}
 			this.$collapse_button.on("click", function () {
 				me.toggle_filter_visiblity();
 			});

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -545,7 +545,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				let f;
 				if (df.fieldtype === "Check" && this.check_filter_area) {
 					f = this.page.add_field(df, this.check_filter_area);
-					// $(f.wrapper).removeClass("col-md-2");
 				} else {
 					f = this.page.add_field(df, filter_area);
 				}
@@ -651,17 +650,19 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			$(this.filters[filter_no].wrapper).css("display", "flex");
 			$(this.filters[filter_no].wrapper).css("align-items", "center");
 			$(this.filters[filter_no].wrapper).css("gap", "16px");
-			if ($(this.filters[filter_no].wrapper).find("select")) {
-				$(this.filters[filter_no].wrapper)
-					.find(".select-icon")
-					.css(
-						"left",
-						$(this.filters[filter_no].wrapper).find("select").width() + 18 + "px"
-					);
-			}
+			this.handle_filter_styles($(this.filters[filter_no].wrapper));
 			this.$collapse_button.on("click", function () {
 				me.toggle_filter_visiblity();
 			});
+		}
+	}
+	handle_filter_styles(wrapper) {
+		if (wrapper.find("select")) {
+			wrapper.find(".select-icon").css("left", wrapper.find("select").width() + 18 + "px");
+		}
+
+		if (wrapper.find(".multiselect-list")) {
+			wrapper.find(".multiselect-list").css("flex", "1 0");
 		}
 	}
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -538,13 +538,14 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 		let filter_area = this.page.page_form;
 		this.filters = [];
-		if (this.report_settings.seperate_check_filters) this.setup_check_filter_area();
+		if (this.report_settings.separate_check_filters) this.setup_check_filter_area();
 		this.filters = filters
 			.map((df, index) => {
 				if (df.fieldtype === "Break") return;
 				let f;
 				if (df.fieldtype === "Check" && this.check_filter_area) {
 					f = this.page.add_field(df, this.check_filter_area);
+					// $(f.wrapper).removeClass("col-md-2");
 				} else {
 					f = this.page.add_field(df, filter_area);
 				}
@@ -582,7 +583,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				return f;
 			})
 			.filter(Boolean);
-		if (this.report_settings.seperate_check_filters) this.move_check_filter_area();
+		if (this.report_settings.separate_check_filters) this.move_check_filter_area();
 		if (this.report_settings.collapsible_filters) {
 			this.filters_hidden = true;
 			this.filter_row_length = this.get_filter_row_length();

--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -302,4 +302,7 @@
 .check-filter-area {
 	display: flex;
 	flex-wrap: wrap;
+	// Find a better fix
+	text-wrap: nowrap;
+	gap: 85px;
 }

--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -302,7 +302,5 @@
 .check-filter-area {
 	display: flex;
 	flex-wrap: wrap;
-	// Find a better fix
-	text-wrap: nowrap;
-	gap: 85px;
+	width: 100%;
 }


### PR DESCRIPTION
Report View Configurations `separate-check-fields` and `collapisible_filters` help make the filters section of the report slightly user friendly

<img width="1440" height="900" alt="Screenshot 2026-01-20 at 2 39 39 AM" src="https://github.com/user-attachments/assets/5c2f2039-6730-4f24-ad87-d7d8f4002a7d" />


Works with https://github.com/frappe/erpnext/pull/51798