### PR TITLE
fix: args can be undefined

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -859,7 +859,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 	}
 	validate_link_and_fetch(value) {
 		const args = this.get_search_args(value);
-		if (!args.doctype) return;
+		if (!args) return;
 
 		const columns_to_fetch = Object.values(this.fetch_map);
 


### PR DESCRIPTION
when trying to set value to a dynamic link field - but the doctype is not specified in the connected link field.