### PR TITLE
fix!: use `*_due_to_dependency` properties for child table dependency eval

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -65,7 +65,10 @@ frappe.ui.form.Control = class BaseControl {
 				if (explain) console.log("By Hidden Dependency: None");
 				return "None";
 			} else if (
-				cint(this.df.read_only || this.df.is_virtual || this.df.fieldtype === "Read Only")
+				cint(this.df.read_only) ||
+				this.df.read_only_due_to_dependency ||
+				this.df.is_virtual ||
+				this.df.fieldtype === "Read Only"
 			) {
 				if (explain) console.log("By Read Only: Read");
 				status = "Read";

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -247,6 +247,12 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		this.$wrapper.find(".help-box").html("");
 		this.toggle_description(false);
 	}
+	/**
+	 * Check if field is required (base reqd OR reqd_due_to_dependency).
+	 */
+	is_reqd() {
+		return this.df.reqd || this.df.reqd_due_to_dependency;
+	}
 	set_mandatory(value) {
 		// do not set has-error class on form load
 		if (this.frm && this.frm.cscript && this.frm.cscript.is_onload) return;
@@ -255,7 +261,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		// set has-error if dialog primary button is clicked
 		if (this.layout && this.layout.is_dialog && !this.layout.primary_action_fulfilled) return;
 
-		this.$wrapper.toggleClass("has-error", Boolean(this.df.reqd && is_null(value)));
+		this.$wrapper.toggleClass("has-error", Boolean(this.is_reqd() && is_null(value)));
 	}
 	set_invalid() {
 		let invalid = !!this.df.invalid;
@@ -268,14 +274,15 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		}
 	}
 	set_required() {
-		this.label_area && $(this.label_area).toggleClass("reqd", Boolean(this.df.reqd));
+		this.label_area && $(this.label_area).toggleClass("reqd", Boolean(this.is_reqd()));
 	}
 	set_bold() {
+		const is_reqd = this.is_reqd();
 		if (this.$input) {
-			this.$input.toggleClass("bold", !!(this.df.bold || this.df.reqd));
+			this.$input.toggleClass("bold", !!(this.df.bold || is_reqd));
 		}
 		if (this.disp_area) {
-			$(this.disp_area).toggleClass("bold", !!(this.df.bold || this.df.reqd));
+			$(this.disp_area).toggleClass("bold", !!(this.df.bold || is_reqd));
 		}
 	}
 };

--- a/frappe/public/js/frappe/form/controls/rating.js
+++ b/frappe/public/js/frappe/form/controls/rating.js
@@ -43,6 +43,9 @@ frappe.ui.form.ControlRating = class ControlRating extends frappe.ui.form.Contro
 	}
 
 	update_rating(ev, click) {
+		// Rating doesn't have $input, so check write status at interaction time
+		if (!this.can_write()) return;
+
 		const el = $(ev.currentTarget);
 		let star_value = el.data("rating");
 		let left_half = false;

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -8,10 +8,6 @@ export default class GridRow {
 		this.set_docfields();
 		this.columns = {};
 		this.columns_list = [];
-		this.dependent_fields = {
-			mandatory: [],
-			read_only: [],
-		};
 		this.row_check_html = '<input type="checkbox" class="grid-row-check" tabIndex="-1">';
 		this.default_rows_threshold_for_grid_search = 20;
 		this.make();
@@ -761,12 +757,13 @@ export default class GridRow {
 
 			// background color for cell
 			if (this.doc) {
-				if (df.reqd && !txt) {
+				const is_reqd = this.is_field_reqd(df);
+				if (is_reqd && !txt) {
 					column.addClass("error");
 				}
 				if (column.is_invalid) {
 					column.addClass("invalid");
-				} else if (df.reqd || df.bold) {
+				} else if (is_reqd || df.bold) {
 					column.addClass("bold");
 				}
 			}
@@ -796,33 +793,40 @@ export default class GridRow {
 	}
 
 	set_dependant_property(df) {
-		if (
-			!df.reqd &&
-			df.mandatory_depends_on &&
-			this.evaluate_depends_on_value(df.mandatory_depends_on)
-		) {
-			df.reqd = 1;
-			this.dependent_fields["mandatory"].push(df);
+		// Set *_due_to_dependency properties - keeps base df.reqd/df.read_only unchanged
+		// This is consistent with how hidden_due_to_dependency works
+		if (df.depends_on) {
+			df.hidden_due_to_dependency = !this.evaluate_depends_on_value(df.depends_on) ? 1 : 0;
 		}
 
-		if (
-			!df.read_only &&
-			df.read_only_depends_on &&
-			this.evaluate_depends_on_value(df.read_only_depends_on)
-		) {
-			df.read_only = 1;
-			this.dependent_fields["read_only"].push(df);
+		if (df.mandatory_depends_on) {
+			df.reqd_due_to_dependency = this.evaluate_depends_on_value(df.mandatory_depends_on)
+				? 1
+				: 0;
+		}
+
+		if (df.read_only_depends_on) {
+			df.read_only_due_to_dependency = this.evaluate_depends_on_value(
+				df.read_only_depends_on
+			)
+				? 1
+				: 0;
 		}
 	}
 
+	/**
+	 * Check if a field is required (base reqd OR reqd_due_to_dependency).
+	 */
+	is_field_reqd(df) {
+		return df && (df.reqd || df.reqd_due_to_dependency);
+	}
+
 	refresh_dependency() {
-		this.dependent_fields["read_only"].forEach((df) => {
-			df.read_only = 0;
-			this.set_dependant_property(df);
-		});
-		this.dependent_fields["mandatory"].forEach((df) => {
-			df.reqd = 0;
-			this.set_dependant_property(df);
+		// re-evaluate all fields that have dependency expressions
+		this.docfields.forEach((df) => {
+			if (df.depends_on || df.mandatory_depends_on || df.read_only_depends_on) {
+				this.set_dependant_property(df);
+			}
 		});
 		this.refresh();
 	}
@@ -1113,7 +1117,7 @@ export default class GridRow {
 		if (!this.doc) {
 			$col.attr("title", txt);
 		}
-		df.fieldname && $col.static_area.toggleClass("reqd", Boolean(df.reqd));
+		df.fieldname && $col.static_area.toggleClass("reqd", Boolean(this.is_field_reqd(df)));
 
 		$col.df = df;
 		$col.column_index = ci;
@@ -1554,7 +1558,7 @@ export default class GridRow {
 		let column = this.columns[fieldname];
 		if (column) {
 			column.static_area.html(txt || "");
-			if (df && df.reqd) {
+			if (this.is_field_reqd(df)) {
 				column.toggleClass("error", !!(txt === null || txt === ""));
 			}
 		}

--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -128,7 +128,12 @@ export default class GridRowForm {
 
 		field.docname = this.row.doc.name;
 		field.refresh();
-		this.layout && this.layout.refresh_dependency();
+		// Don't call refresh_dependency if we're already inside it (prevents recursion)
+		if (this.layout && !this._refreshing_dependency) {
+			this._refreshing_dependency = true;
+			this.layout.refresh_dependency();
+			this._refreshing_dependency = false;
+		}
 	}
 	set_active_tab(tab) {
 		// Store the active tab for this grid row form

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -741,24 +741,9 @@ frappe.ui.form.Layout = class Layout {
 		// show / hide based on values
 		for (let i = fields.length - 1; i >= 0; i--) {
 			let f = fields[i];
-			f.guardian_has_value = true;
+
 			if (f.df.depends_on) {
-				// evaluate guardian
-
-				f.guardian_has_value = this.evaluate_depends_on_value(f.df.depends_on);
-
-				// show / hide
-				if (f.guardian_has_value) {
-					if (f.df.hidden_due_to_dependency) {
-						f.df.hidden_due_to_dependency = false;
-						f.refresh();
-					}
-				} else {
-					if (!f.df.hidden_due_to_dependency) {
-						f.df.hidden_due_to_dependency = true;
-						f.refresh();
-					}
-				}
+				this.set_dependant_property(f.df.depends_on, f.df.fieldname, "hidden", true);
 			}
 
 			if (f.df.mandatory_depends_on) {
@@ -777,22 +762,27 @@ frappe.ui.form.Layout = class Layout {
 		this.refresh_section_count();
 	}
 
-	set_dependant_property(condition, fieldname, property) {
-		let set_property = this.evaluate_depends_on_value(condition);
-		let value = set_property ? 1 : 0;
-		let form_obj;
+	set_dependant_property(condition, fieldname, property, invert = false) {
+		// Set *_due_to_dependency property via set_df_property to maintain API compatibility
+		// This keeps df.reqd/df.read_only available for system/script use
+		// invert=true for depends_on (hidden when condition is false)
+		let condition_result = this.evaluate_depends_on_value(condition);
+		let value = cint(invert ? !condition_result : condition_result);
+		let dependency_property = property + "_due_to_dependency";
 
+		let form_obj;
 		if (this.frm) {
 			form_obj = this.frm;
 		} else if (this.is_dialog || this.doctype === "Web Form") {
 			form_obj = this;
 		}
+
 		if (form_obj) {
 			if (this.doc && this.doc.parent && this.doc.parentfield) {
 				form_obj.setting_dependency = true;
 				form_obj.set_df_property(
 					this.doc.parentfield,
-					property,
+					dependency_property,
 					value,
 					this.doc.parent,
 					fieldname,
@@ -802,7 +792,7 @@ frappe.ui.form.Layout = class Layout {
 				// refresh child fields
 				this.fields_dict[fieldname] && this.fields_dict[fieldname].refresh();
 			} else {
-				form_obj.set_df_property(fieldname, property, value);
+				form_obj.set_df_property(fieldname, dependency_property, value);
 			}
 		}
 	}

--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -258,6 +258,12 @@ $.extend(frappe.perm, {
 		}
 		if (explain) console.log("By Read Only:" + status);
 
+		// read only due to dependency
+		if (status === "Write" && cint(df.read_only_due_to_dependency)) {
+			status = "Read";
+		}
+		if (explain) console.log("By Read Only Due To Dependency:" + status);
+
 		if (status === "Write" && df.set_only_once && !doc.__islocal) {
 			status = "Read";
 		}


### PR DESCRIPTION
## Problem
Child table fields with `mandatory_depends_on`, `read_only_depends_on`, and `depends_on` were not working correctly because:
1. The original code mutated `df.reqd`/`df.read_only` directly, which conflicted with system/script-set values
2. `depends_on` for visibility was not implemented for child table fields at all

## Solution
Introduce `reqd_due_to_dependency` and `read_only_due_to_dependency` properties, consistent with existing `hidden_due_to_dependency`. This approach:
- Keeps base `df.reqd`/`df.read_only` available for system/script use
- Dependencies can only ADD restrictions, not remove them (intentional breaking change - see below)
- Adds `depends_on` support for child table field visibility

## Changes
- **grid_row.js**: Use `*_due_to_dependency` properties, add `is_field_reqd()` helper, add `depends_on` support
- **layout.js**: Simplified dependency handling, use `*_due_to_dependency` via `set_df_property`
- **base_input.js**: Add `is_reqd()` method for consistent required checking
- **base_control.js**: Check `read_only_due_to_dependency` in status calculation
- **perm.js**: Check `read_only_due_to_dependency` in `get_field_display_status`

## Breaking Change
**Dependencies can now only ADD restrictions, not remove them.**

Previously: `read_only_depends_on: eval:doc.check` would toggle `df.read_only` between 0/1, potentially making a read-only field editable.

Now: Only sets `df.read_only_due_to_dependency`. If base `df.read_only=1`, the field stays read-only regardless of the dependency condition.

This is intentional - the previous behavior was confusing and could lead to unexpected state conflicts.

## Additional fixes (separate issues)
- Rating control: check write status before updating (rating uses SVG, not $input)
- Grid row form: prevent recursive refresh_dependency calls