### PR TITLE
fix: Show alert if report is empty

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -2302,12 +2302,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	toggle_print_buttons(show) {
 		const menu = this.page.menu;
-		menu.find(`a:contains("${__("Print")}")`)
-			.parent()
-			.toggle(show);
-		menu.find(`a:contains("${__("PDF")}")`)
-			.parent()
-			.toggle(show);
+		menu.find('[data-label="Print"]').parent().parent().toggle(show);
+		menu.find('[data-label="PDF"]').parent().parent().toggle(show);
 	}
 
 	get_checked_items(only_docnames) {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1856,6 +1856,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			{
 				label: __("Print"),
 				action: () => {
+					if (!this.data?.length) {
+						frappe.msgprint(__("This report is empty."));
+						return;
+					}
 					let dialog = frappe.ui.get_print_settings(
 						false,
 						(print_settings) => this.print_report(print_settings),
@@ -1871,6 +1875,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			{
 				label: __("PDF"),
 				action: () => {
+					if (!this.data?.length) {
+						frappe.msgprint(__("This report is empty."));
+						return;
+					}
 					let dialog = frappe.ui.get_print_settings(
 						false,
 						(print_settings) => this.pdf_report(print_settings),

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -812,11 +812,13 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					this.render_datatable();
 					this.add_chart_buttons_to_toolbar(true);
 					this.add_card_button_to_toolbar();
+					this.toggle_print_buttons(true);
 					this.$report.show();
 				} else {
 					this.data = [];
 					this.toggle_nothing_to_show(true);
 					this.add_chart_buttons_to_toolbar(false);
+					this.toggle_print_buttons(false);
 				}
 
 				this.show_footer_message();
@@ -1856,10 +1858,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			{
 				label: __("Print"),
 				action: () => {
-					if (!this.data?.length) {
-						frappe.msgprint(__("This report is empty."));
-						return;
-					}
 					let dialog = frappe.ui.get_print_settings(
 						false,
 						(print_settings) => this.print_report(print_settings),
@@ -1875,10 +1873,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			{
 				label: __("PDF"),
 				action: () => {
-					if (!this.data?.length) {
-						frappe.msgprint(__("This report is empty."));
-						return;
-					}
 					let dialog = frappe.ui.get_print_settings(
 						false,
 						(print_settings) => this.pdf_report(print_settings),
@@ -1886,7 +1880,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 						this.get_visible_columns(),
 						true
 					);
-
 					this.add_portrait_warning(dialog);
 				},
 				condition: () => frappe.model.can_print(this.report_doc.ref_doctype),
@@ -2305,6 +2298,16 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.$report.toggle(flag);
 		this.$chart.toggle(flag);
 		this.$summary.toggle(flag);
+	}
+
+	toggle_print_buttons(show) {
+		const menu = this.page.menu;
+		menu.find(`a:contains("${__("Print")}")`)
+			.parent()
+			.toggle(show);
+		menu.find(`a:contains("${__("PDF")}")`)
+			.parent()
+			.toggle(show);
 	}
 
 	get_checked_items(only_docnames) {


### PR DESCRIPTION
Closes #36035

FIx: Now if the report is empty, Print/PDF button is not shown.

<img width="1291" height="634" alt="Screenshot 2026-01-21 at 11 27 02 AM" src="https://github.com/user-attachments/assets/6435185a-f598-4292-9d0e-c27a617fc5d6" />


