### PR TITLE
fix: translate table headers in multi-select dialog

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -191,7 +191,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 	get_child_datatable_columns() {
 		const parent = this.doctype;
 		return [parent, ...this.child_columns].map((d) => ({
-			name: frappe.unscrub(d),
+			name: __(frappe.unscrub(d)),
 			editable: false,
 		}));
 	}


### PR DESCRIPTION
**Closes:** #35958
**Backport:** v-16, v-15, v-14

----
Before: 
<img width="812" height="762" alt="image" src="https://github.com/user-attachments/assets/fb5c2b3a-4a17-4686-9ae9-de8ac04b0a69" />

After
<img width="812" height="762" alt="image" src="https://github.com/user-attachments/assets/88dab7c5-3b7c-434f-b433-bb718bec408f" />

---
`no-docs` 