### PR TITLE
fix: barcode height now scales proportionally in print formats

### DIFF
--- a/frappe/public/js/frappe/form/controls/barcode.js
+++ b/frappe/public/js/frappe/form/controls/barcode.js
@@ -48,6 +48,13 @@ frappe.ui.form.ControlBarcode = class ControlBarcode extends frappe.ui.form.Cont
 			try {
 				JsBarcode(svg, value, this.get_options(value));
 				$(svg).attr("data-barcode-value", value);
+				// Add viewBox for proper scaling in print formats
+				const width = svg.getAttribute("width");
+				const height = svg.getAttribute("height");
+				if (width && height) {
+					svg.setAttribute("viewBox", `0 0 ${parseFloat(width)} ${parseFloat(height)}`);
+					svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
+				}
 				$(svg).attr("width", "100%");
 				return this.barcode_area.html();
 			} catch (e) {

--- a/frappe/templates/styles/standard.css
+++ b/frappe/templates/styles/standard.css
@@ -189,3 +189,9 @@ table td div {
 .print-format-preview [data-fieldtype="Table"] {
 	overflow: auto;
 }
+
+.barcode-wrapper svg,
+svg[data-barcode-value] {
+	height: auto;
+	display: block;
+}


### PR DESCRIPTION
Fixes #36021

## Problem
When a barcode field is displayed in a print format and the user applies CSS to reduce its width (e.g., `width: 20%`), only the width scales down while the height remains constant. This creates unintended whitespace above and below the barcode.

## Root Cause
JsBarcode generates SVG elements with fixed `width` and `height` attributes but without `viewBox` and `preserveAspectRatio` attributes. Without these attributes, the SVG cannot scale proportionally when CSS dimensions are applied.

## Solution
This PR adds two fixes:

### 1. JavaScript fix (`frappe/public/js/frappe/form/controls/barcode.js`)
After JsBarcode generates the SVG, we now:
- Add a `viewBox` attribute matching the SVG's natural dimensions
- Add `preserveAspectRatio="xMidYMid meet"` to ensure proportional scaling

### 2. CSS fix (`frappe/templates/styles/standard.css`)
Added CSS rules to ensure barcode SVGs scale properly with `height: auto`.

## Testing
1. Create a doctype with a Barcode field
2. Create a print format with the barcode styled at different widths
3. Generate PDF and verify all barcodes maintain proper proportions

## Compatibility
- No breaking changes
- Backward compatible with existing barcode implementations