### PR TITLE
fix(sidebar): handle undefined nested_items when creating Section Break

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
@@ -199,7 +199,7 @@ export class SidebarEditor {
 					let old_index = event.oldIndex;
 					let item_label = $(event.item).data("id");
 					me.new_sidebar_items.forEach((item) => {
-						if (item.nested_items.length) {
+						if (item.nested_items && item.nested_items.length) {
 							let child = item.nested_items.find(
 								(child) => child.label === item_label
 							);

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -178,7 +178,7 @@ frappe.ui.sidebar_item.TypeSectionBreak = class SectionBreakSidebarItem extends 
 	}
 	make() {
 		super.make();
-		if (!this.item.nested_items || this.item.nested_items.length == 0) return;
+		if (!this.nested_items || this.nested_items.length == 0) return;
 		this.add_items();
 		this.toggle_on_collapse();
 		this.enable_collapsible(this.item, this.full_template);


### PR DESCRIPTION
## Summary

When creating a new Section Break sidebar item in the workspace editor, the application crashes with:

```
TypeError: can't access property "length", this.item.nested_items is undefined
```

## Root Cause

When a new Section Break is created via the dialog, the `values` object pushed to `new_sidebar_items` doesn't have `nested_items` property. While `this.nested_items` is properly initialized to `[]` in the `prepare()` method (line 160), the `make()` method incorrectly checks `this.item.nested_items` (line 181) which remains `undefined`.

## Changes

### `sidebar_item.js`
- Changed `this.item.nested_items` to `this.nested_items` in the `make()` method's guard clause
- This ensures consistency since `this.nested_items` is always properly initialized

### `sidebar_editor.js`
- Added null check before accessing `nested_items.length` in the `onEnd` handler for drag-and-drop reordering
- Prevents similar crash when reordering items

## Testing

1. Open any workspace in edit mode
2. Click "Add Item" and create a new "Section Break"
3. Verify no JavaScript error occurs and the Section Break is created successfully
4. Drag and drop items to verify reordering still works

Fixes #36042

---
This is a Gittensor contribution: [33f77537e7f32b9ddb9db247def29ada03f31fc9]