### PR TITLE
refactor: strictly type hint financial rounding functions

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1236,7 +1236,7 @@ def sbool(x: str | Any) -> bool | str | Any:
 		return x
 
 
-def rounded(num, precision=0, rounding_method=None):
+def rounded(num: NumericType, precision: int = 0, rounding_method: str | None = None) -> float:
 	"""Round according to method set in system setting, defaults to banker's rounding"""
 	precision = cint(precision)
 
@@ -1257,7 +1257,7 @@ def rounded(num, precision=0, rounding_method=None):
 		)
 
 
-def _bankers_rounding_legacy(num, precision):
+def _bankers_rounding_legacy(num: NumericType, precision: int) -> float:
 	# avoid rounding errors
 	multiplier = 10**precision
 	num = round(num * multiplier if precision else num, 8)
@@ -1276,7 +1276,7 @@ def _bankers_rounding_legacy(num, precision):
 	return (num / multiplier) if precision else num
 
 
-def _round_away_from_zero(num, precision):
+def _round_away_from_zero(num: NumericType, precision: int) -> float:
 	if num == 0:
 		return 0.0
 
@@ -1302,7 +1302,7 @@ def _round_away_from_zero(num, precision):
 	return round(num + math.copysign(epsilon, num), precision)
 
 
-def _bankers_rounding(num, precision):
+def _bankers_rounding(num: NumericType, precision: int) -> float:
 	multiplier = 10**precision
 	num = round(num * multiplier, 12)
 


### PR DESCRIPTION
## Description
Added strict type hints to `rounded` and its internal helper functions (`_bankers_rounding`, etc.) in `frappe/utils/data.py`.

### Changes
- `num`: Typed as `NumericType` to ensure consistency with file standards.
- `precision`: Typed as `int` to encourage passing integers (though `cint` handles safety).
- `return`: Explicitly typed as `-> float`.

### Why
These are critical financial functions. Explicit typing prevents subtle bugs during static analysis and improves IDE intelligence for developers working on ERPNext financial modules.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
