### PR TITLE
feat(dx): bench stop command

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -818,6 +818,7 @@ def serve(
 @click.option("--signal", default="SIGTERM", help="Signal to send to processes (SIGTERM, SIGKILL)")
 def stop(signal="SIGTERM"):
 	"Stop Frappe development processes started with 'bench start'"
+	import json
 	import signal as sig
 	from datetime import datetime
 
@@ -844,23 +845,64 @@ def stop(signal="SIGTERM"):
 	if os.path.exists(os.path.join(bench_path, "site_config.json")):
 		bench_path = os.path.dirname(os.path.dirname(bench_path))
 
-	procfile_path = os.path.join(bench_path, "Procfile")
+	# Load port configuration from common_site_config.json
+	common_site_config_path = os.path.join(bench_path, "sites", "common_site_config.json")
 
-	if not os.path.exists(procfile_path):
-		click.secho(f"Procfile not found at {procfile_path}. Are you in a bench directory?", fg="red")
+	if not os.path.exists(common_site_config_path):
+		click.secho(
+			f"Config file not found at {common_site_config_path}. Are you in a bench directory?", fg="red"
+		)
 		return
 
-	# Parse Procfile to get process commands
-	processes_to_stop = []
-	with open(procfile_path) as f:
-		for line in f:
-			line = line.strip()
-			if line and not line.startswith("#") and ":" in line:
-				name, cmd = line.split(":", 1)
-				processes_to_stop.append((name.strip(), cmd.strip()))
+	try:
+		with open(common_site_config_path) as f:
+			config = json.load(f)
+	except Exception as e:
+		click.secho(f"Error reading config: {e}", fg="red")
+		return
+
+	# Define processes to stop based on common_site_config.json
+	processes_to_stop = {}
+
+	# Web server
+	if "webserver_port" in config:
+		processes_to_stop["web"] = {
+			"port": config["webserver_port"],
+			"name_hints": ["frappe serve", "bench serve"],
+		}
+
+	# SocketIO server
+	if "socketio_port" in config:
+		processes_to_stop["socketio"] = {
+			"port": config["socketio_port"],
+			"name_hints": ["socketio.js", "node"],
+		}
+
+	# Redis cache
+	redis_cache = config.get("redis_cache", "")
+	if ":" in redis_cache:
+		redis_cache_port = int(redis_cache.split(":")[-1])
+		processes_to_stop["redis_cache"] = {
+			"port": redis_cache_port,
+			"name_hints": ["redis-server", "redis_cache.conf"],
+		}
+
+	# Redis queue
+	redis_queue = config.get("redis_queue", "")
+	if ":" in redis_queue:
+		redis_queue_port = int(redis_queue.split(":")[-1])
+		processes_to_stop["redis_queue"] = {
+			"port": redis_queue_port,
+			"name_hints": ["redis-server", "redis_queue.conf"],
+		}
+
+	# Worker, scheduler, watch processes (no ports, match by command)
+	processes_to_stop["worker"] = {"port": None, "name_hints": ["bench worker"]}
+	processes_to_stop["schedule"] = {"port": None, "name_hints": ["bench schedule"]}
+	processes_to_stop["watch"] = {"port": None, "name_hints": ["bench watch"]}
 
 	if not processes_to_stop:
-		log_message("system", "No processes found in Procfile", "yellow")
+		log_message("system", "No processes configured to stop", "yellow")
 		return
 
 	log_message("system", "Stopping Frappe development processes...", "cyan")
@@ -902,64 +944,65 @@ def stop(signal="SIGTERM"):
 			pass
 		return False
 
-	for proc_name, proc_cmd in processes_to_stop:
-		# Extract the main command from the process
-		cmd_parts = proc_cmd.split()
-		if not cmd_parts:
-			continue
+	def get_listening_ports(proc):
+		"""Get all ports a process is listening on"""
+		try:
+			connections = proc.connections(kind="inet")
+			return {conn.laddr.port for conn in connections if conn.status == "LISTEN"}
+		except (psutil.NoSuchProcess, psutil.AccessDenied):
+			return set()
 
-		# Get the base command (e.g., 'bench', 'redis-server', 'node')
-		base_cmd = os.path.basename(cmd_parts[0])
+	# Iterate through each process type we want to stop
+	for proc_name, proc_info in processes_to_stop.items():
+		expected_port = proc_info["port"]
+		name_hints = proc_info["name_hints"]
 
 		# Find matching processes
 		for proc in psutil.process_iter(["pid", "name", "cmdline", "cwd"]):
 			try:
-				# Check if process is running in this bench directory
+				# Check if process is running in this bench directory (or a subdirectory)
 				proc_cwd = proc.info.get("cwd")
-				if proc_cwd and not proc_cwd.startswith(bench_path):
-					continue
+				if proc_cwd:
+					# Normalize paths for comparison
+					try:
+						proc_cwd_real = os.path.realpath(proc_cwd)
+						bench_path_real = os.path.realpath(bench_path)
+						if not proc_cwd_real.startswith(bench_path_real):
+							continue
+					except (OSError, ValueError):
+						continue
 
 				cmdline = proc.info.get("cmdline", [])
 				if not cmdline:
 					continue
 
-				# Check if this process matches what's in Procfile
 				cmdline_str = " ".join(cmdline)
 
-				# Match based on key parts of the command
-				if base_cmd in cmdline_str or proc_name in cmdline_str:
-					# Additional checks to ensure we match the right process
-					if "redis-server" in base_cmd and proc_name in ["redis_cache", "redis_queue"]:
-						# For redis, check config file path
-						if proc_name == "redis_cache" and "redis_cache.conf" in cmdline_str:
-							log_message(
-								f"{proc_name}.1",
-								f"Sending SIGTERM to process (PID: {proc.info['pid']})",
-								"white",
-							)
-							if kill_process_tree(proc, sig_num):
-								stopped_count += 1
-						elif proc_name == "redis_queue" and "redis_queue.conf" in cmdline_str:
-							log_message(
-								f"{proc_name}.1",
-								f"Sending SIGTERM to process (PID: {proc.info['pid']})",
-								"white",
-							)
-							if kill_process_tree(proc, sig_num):
-								stopped_count += 1
-					elif "bench" in base_cmd and any(arg in cmdline for arg in cmd_parts[1:]):
-						# For bench commands, match the subcommand
-						log_message(
-							f"{proc_name}.1", f"Sending SIGTERM to process (PID: {proc.info['pid']})", "white"
-						)
-						if kill_process_tree(proc, sig_num):
-							stopped_count += 1
-					elif "node" in base_cmd and "socketio.js" in cmdline_str and proc_name == "socketio":
-						log_message(
-							f"{proc_name}.1", f"Sending SIGTERM to process (PID: {proc.info['pid']})", "white"
-						)
-						if kill_process_tree(proc, sig_num):
-							stopped_count += 1
+				# Get ports this process is listening on
+				listening_ports = get_listening_ports(proc)
+
+				# Check if this process matches
+				matched = False
+
+				# If we have an expected port, check if process is listening on it
+				if expected_port and expected_port in listening_ports:
+					# Verify it's the right type of process by checking name hints
+					if any(hint in cmdline_str for hint in name_hints):
+						matched = True
+				# If no port (worker, schedule, watch), match by command hints
+				elif expected_port is None:
+					if any(hint in cmdline_str for hint in name_hints):
+						matched = True
+
+				if matched:
+					port_info = f", port {expected_port}" if expected_port else ""
+					log_message(
+						f"{proc_name}.1",
+						f"Sending {signal.upper()} to process (PID: {proc.info['pid']}{port_info})",
+						"white",
+					)
+					if kill_process_tree(proc, sig_num):
+						stopped_count += 1
 
 			except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
 				continue

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -884,7 +884,7 @@ def stop(signal="SIGTERM"):
 		redis_cache_port = int(redis_cache.split(":")[-1])
 		processes_to_stop["redis_cache"] = {
 			"port": redis_cache_port,
-			"name_hints": ["redis-server", "redis_cache.conf"],
+			"name_hints": ["redis-server"],
 		}
 
 	# Redis queue
@@ -893,13 +893,13 @@ def stop(signal="SIGTERM"):
 		redis_queue_port = int(redis_queue.split(":")[-1])
 		processes_to_stop["redis_queue"] = {
 			"port": redis_queue_port,
-			"name_hints": ["redis-server", "redis_queue.conf"],
+			"name_hints": ["redis-server"],
 		}
 
 	# Worker, scheduler, watch processes (no ports, match by command)
-	processes_to_stop["worker"] = {"port": None, "name_hints": ["bench worker"]}
-	processes_to_stop["schedule"] = {"port": None, "name_hints": ["bench schedule"]}
-	processes_to_stop["watch"] = {"port": None, "name_hints": ["bench watch"]}
+	processes_to_stop["worker"] = {"port": None, "name_hints": ["frappe worker", "bench worker"]}
+	processes_to_stop["schedule"] = {"port": None, "name_hints": ["frappe schedule", "bench schedule"]}
+	processes_to_stop["watch"] = {"port": None, "name_hints": ["frappe watch", "bench watch"]}
 
 	if not processes_to_stop:
 		log_message("system", "No processes configured to stop", "yellow")
@@ -962,15 +962,19 @@ def stop(signal="SIGTERM"):
 			try:
 				# Check if process is running in this bench directory (or a subdirectory)
 				proc_cwd = proc.info.get("cwd")
-				if proc_cwd:
-					# Normalize paths for comparison
-					try:
-						proc_cwd_real = os.path.realpath(proc_cwd)
-						bench_path_real = os.path.realpath(bench_path)
-						if not proc_cwd_real.startswith(bench_path_real):
-							continue
-					except (OSError, ValueError):
+				if not proc_cwd:
+					# Skip processes without accessible working directory
+					continue
+
+				# Normalize paths for comparison
+				try:
+					proc_cwd_real = os.path.realpath(proc_cwd)
+					bench_path_real = os.path.realpath(bench_path)
+					if not proc_cwd_real.startswith(bench_path_real):
 						continue
+				except (OSError, ValueError):
+					# Skip if we can't verify the path
+					continue
 
 				cmdline = proc.info.get("cmdline", [])
 				if not cmdline:
@@ -1003,6 +1007,8 @@ def stop(signal="SIGTERM"):
 					)
 					if kill_process_tree(proc, sig_num):
 						stopped_count += 1
+					# Break after finding the first match for this process type
+					break
 
 			except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
 				continue

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -814,6 +814,162 @@ def serve(
 		)
 
 
+@click.command("stop")
+@click.option("--signal", default="SIGTERM", help="Signal to send to processes (SIGTERM, SIGKILL)")
+def stop(signal="SIGTERM"):
+	"Stop Frappe development processes started with 'bench start'"
+	import signal as sig
+	from datetime import datetime
+
+	import psutil
+
+	def log_message(proc_name, message, color="white"):
+		"""Print formatted log message with timestamp"""
+		timestamp = datetime.now().strftime("%H:%M:%S")
+		proc_label = f"{proc_name:<15}"
+		click.secho(f"{timestamp} ", fg="cyan", nl=False)
+		click.secho(f"{proc_label}", fg="yellow", nl=False)
+		click.secho(f"| {message}", fg=color)
+
+	# Get the bench root directory (parent of sites directory)
+	bench_path = os.getcwd()
+
+	# If we're in the sites directory, go up one level
+	if os.path.basename(bench_path) == "sites" or os.path.exists(
+		os.path.join(bench_path, "site_config.json")
+	):
+		bench_path = os.path.dirname(bench_path)
+
+	# If current directory is a site directory, go up to sites, then to bench root
+	if os.path.exists(os.path.join(bench_path, "site_config.json")):
+		bench_path = os.path.dirname(os.path.dirname(bench_path))
+
+	procfile_path = os.path.join(bench_path, "Procfile")
+
+	if not os.path.exists(procfile_path):
+		click.secho(f"Procfile not found at {procfile_path}. Are you in a bench directory?", fg="red")
+		return
+
+	# Parse Procfile to get process commands
+	processes_to_stop = []
+	with open(procfile_path) as f:
+		for line in f:
+			line = line.strip()
+			if line and not line.startswith("#") and ":" in line:
+				name, cmd = line.split(":", 1)
+				processes_to_stop.append((name.strip(), cmd.strip()))
+
+	if not processes_to_stop:
+		log_message("system", "No processes found in Procfile", "yellow")
+		return
+
+	log_message("system", "Stopping Frappe development processes...", "cyan")
+
+	# Map signal name to signal number
+	signal_map = {
+		"SIGTERM": sig.SIGTERM,
+		"SIGKILL": sig.SIGKILL,
+		"SIGINT": sig.SIGINT,
+	}
+
+	sig_num = signal_map.get(signal.upper(), sig.SIGTERM)
+
+	# Find and kill processes (including their children)
+	stopped_count = 0
+	stopped_pids = set()
+
+	def kill_process_tree(proc, sig_num):
+		"""Kill a process and all its children"""
+		try:
+			# Get all children before killing parent
+			children = proc.children(recursive=True)
+
+			# Kill children first
+			for child in children:
+				try:
+					if child.pid not in stopped_pids:
+						child.send_signal(sig_num)
+						stopped_pids.add(child.pid)
+				except (psutil.NoSuchProcess, psutil.AccessDenied):
+					pass
+
+			# Kill parent
+			if proc.pid not in stopped_pids:
+				proc.send_signal(sig_num)
+				stopped_pids.add(proc.pid)
+				return True
+		except (psutil.NoSuchProcess, psutil.AccessDenied):
+			pass
+		return False
+
+	for proc_name, proc_cmd in processes_to_stop:
+		# Extract the main command from the process
+		cmd_parts = proc_cmd.split()
+		if not cmd_parts:
+			continue
+
+		# Get the base command (e.g., 'bench', 'redis-server', 'node')
+		base_cmd = os.path.basename(cmd_parts[0])
+
+		# Find matching processes
+		for proc in psutil.process_iter(["pid", "name", "cmdline", "cwd"]):
+			try:
+				# Check if process is running in this bench directory
+				proc_cwd = proc.info.get("cwd")
+				if proc_cwd and not proc_cwd.startswith(bench_path):
+					continue
+
+				cmdline = proc.info.get("cmdline", [])
+				if not cmdline:
+					continue
+
+				# Check if this process matches what's in Procfile
+				cmdline_str = " ".join(cmdline)
+
+				# Match based on key parts of the command
+				if base_cmd in cmdline_str or proc_name in cmdline_str:
+					# Additional checks to ensure we match the right process
+					if "redis-server" in base_cmd and proc_name in ["redis_cache", "redis_queue"]:
+						# For redis, check config file path
+						if proc_name == "redis_cache" and "redis_cache.conf" in cmdline_str:
+							log_message(
+								f"{proc_name}.1",
+								f"Sending SIGTERM to process (PID: {proc.info['pid']})",
+								"white",
+							)
+							if kill_process_tree(proc, sig_num):
+								stopped_count += 1
+						elif proc_name == "redis_queue" and "redis_queue.conf" in cmdline_str:
+							log_message(
+								f"{proc_name}.1",
+								f"Sending SIGTERM to process (PID: {proc.info['pid']})",
+								"white",
+							)
+							if kill_process_tree(proc, sig_num):
+								stopped_count += 1
+					elif "bench" in base_cmd and any(arg in cmdline for arg in cmd_parts[1:]):
+						# For bench commands, match the subcommand
+						log_message(
+							f"{proc_name}.1", f"Sending SIGTERM to process (PID: {proc.info['pid']})", "white"
+						)
+						if kill_process_tree(proc, sig_num):
+							stopped_count += 1
+					elif "node" in base_cmd and "socketio.js" in cmdline_str and proc_name == "socketio":
+						log_message(
+							f"{proc_name}.1", f"Sending SIGTERM to process (PID: {proc.info['pid']})", "white"
+						)
+						if kill_process_tree(proc, sig_num):
+							stopped_count += 1
+
+			except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+				continue
+
+	if stopped_count > 0:
+		log_message("system", f"Successfully stopped {stopped_count} process(es)", "green")
+	else:
+		log_message("system", "No running bench processes found", "yellow")
+
+
 @click.command("request")
 @click.option("--args", help="arguments like `?cmd=test&key=value` or `/api/request/method?..`")
 @click.option("--path", help="path to request JSON")
@@ -1062,6 +1218,7 @@ commands = [
 	request,
 	reset_perms,
 	serve,
+	stop,
 	set_config,
 	show_config,
 	watch,


### PR DESCRIPTION
In some cases, stop the bench processes needs to manually kill it from system. Despite you can use Ctrl/Cmd + C to stop in terminal, sometimes terminal where bench is running was closed.

So, this command let's stop based on `Procfile` procceses and `common_site_config` ports 

<img width="608" height="231" alt="image" src="https://github.com/user-attachments/assets/6ac1015b-2ecc-4b2b-814e-a1f5acd66b2a" />

