### PR TITLE
fix(pulse): capture session user from backend if not found in frontend

### DIFF
--- a/frappe/public/js/telemetry/pulse.js
+++ b/frappe/public/js/telemetry/pulse.js
@@ -34,7 +34,7 @@ class PulseProvider {
 			event_name: event,
 			app: app,
 			properties: props,
-			user: frappe.session.user,
+			user: frappe.session?.user,
 			captured_at: new Date().toISOString(),
 		});
 	}

--- a/frappe/utils/telemetry/pulse/client.py
+++ b/frappe/utils/telemetry/pulse/client.py
@@ -57,7 +57,7 @@ def bulk_capture(events):
 			event.get("event_name"),
 			site=event.get("site"),
 			app=event.get("app"),
-			user=event.get("user"),
+			user=event.get("user") or frappe.session.user,
 			captured_at=event.get("captured_at"),
 			properties=event.get("properties"),
 			interval=event.get("interval"),


### PR DESCRIPTION
When the Pulse capture event was triggered from the frontend of a Frappe UI based app, frappe.session was undefined. This was breaking the app flow.

<img width="1470" height="396" alt="Screenshot 2026-01-19 at 4 32 43 PM" src="https://github.com/user-attachments/assets/5dfe556b-8304-4b31-8400-24ebc599dbb4" />
