### PR TITLE
feat: update Saudi Riyal symbol to official currency symbol (⃁) [U+20C1]

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -2359,7 +2359,7 @@
   "currency_fraction": "Halala",
   "currency_fraction_units": 100,
   "currency_name": "Saudi Riyal",
-  "currency_symbol": "\u0631.\u0633",
+  "currency_symbol": "\u20C1",
   "number_format": "#,###.##",
   "timezones": [
    "Asia/Riyadh"


### PR DESCRIPTION
Update Saudi Arabia currency symbol in [frappe/geo/country_info.json](https://github.com/frappe/frappe/blob/12e2dcd4c8a93aace909853a0e0e5af5cbcaf767/frappe/geo/country_info.json#L277) to official Unicode U+20C1 (⃁).
Replaces legacy Arabic “ر.س”.
Note: Prior PRs (e.g., #31910 backports) added font support for the old symbol; this PR updates the source data to the official symbol. No schema changes.

## Summary
- Update Saudi Arabia currency symbol in country_info.json to the official Unicode code point U+20C1 (⃁)
- Replaces legacy Arabic “ر.س”; aligns with "⃁" Unicode standard

## Rationale
- Ensures the official Saudi Riyal symbol is used everywhere Currency docs are seeded from country_info.json
- Complements earlier font-related PRs (e.g., #31910 backports) by updating the source data itself; no schema changes

## Testing
- Not run (data-only change)

## Before and After Screenshot:
<img width="1935" height="1742" alt="image" src="https://github.com/user-attachments/assets/2d8d0c01-5606-42b8-b17c-e0f944853999" />

After change:
<img width="1980" height="1775" alt="image" src="https://github.com/user-attachments/assets/26eed97d-0d88-4b45-8902-5c3d6d8ca8cd" />
