### PR TITLE
revert: keep validation on client side only

### DIFF
--- a/frappe/public/js/frappe/microtemplate.js
+++ b/frappe/public/js/frappe/microtemplate.js
@@ -187,9 +187,6 @@ frappe.render_pdf = function (html, opts = {}) {
 
 	//Push the HTML content into an element
 	formData.append("html", html);
-	if (opts.doctype) {
-		formData.append("doctype", opts.doctype);
-	}
 	if (opts.orientation) {
 		formData.append("orientation", opts.orientation);
 	}

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -253,9 +253,7 @@ def download_pdf(
 
 
 @frappe.whitelist()
-def report_to_pdf(html, orientation="Landscape", doctype=None):
-	if doctype:
-		frappe.has_permission(doctype, "print", throw=True)
+def report_to_pdf(html, orientation="Landscape"):
 	make_access_log(file_type="PDF", method="PDF", page=html)
 	frappe.local.response.filename = "report.pdf"
 	frappe.local.response.filecontent = get_pdf(html, {"orientation": orientation})


### PR DESCRIPTION
**Problem:**
**revert:** Perform validations only on client side since the permission was not enforced on client side (grid rendering).



**Before**:
<img width="1320" height="680" alt="image" src="https://github.com/user-attachments/assets/37c919b4-aba1-4e9b-a3d8-6ddf25546608" />

**After**:
<img width="2880" height="1662" alt="image" src="https://github.com/user-attachments/assets/6e4fd428-8886-4eeb-b279-068213203726" />

https://github.com/user-attachments/assets/f7175782-0a0a-49bb-9e38-6a4f882d0f62


fixes #35551 