### PR TITLE
fix: improve UI spacing in MultiSelectDialog results

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -142,7 +142,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 	setup_results() {
 		this.$parent = $(this.dialog.body);
 		this.$wrapper = this.dialog.fields_dict.results_area.$wrapper
-			.append(`<div class="results my-3"
+			.append(`<div class="results mt-1 mb-3"
 			style="border: 1px solid #d1d8dd; border-radius: 3px; height: 300px; overflow: auto;"></div>`);
 
 		this.$results = this.$wrapper.find(".results");
@@ -477,7 +477,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 			</div>`;
 		});
 
-		let $row = $(`<div class="list-item">
+		let $row = $(`<div class="list-item py-2 px-2 border-bottom">
 			<div class="list-item__content" style="flex: 0 0 10px;">
 				<input type="checkbox" class="list-row-check" data-item-name="${result.name}" ${
 			result.checked ? "checked" : ""
@@ -489,7 +489,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 		head
 			? $row.addClass("list-item--head")
 			: ($row = $(
-					`<div class="list-item-container" data-item-name="${result.name}"></div>`
+					`<div class="list-item-container m-0" data-item-name="${result.name}"></div>`
 			  ).append($row));
 
 		return $row;

--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -142,7 +142,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 	setup_results() {
 		this.$parent = $(this.dialog.body);
 		this.$wrapper = this.dialog.fields_dict.results_area.$wrapper
-			.append(`<div class="results mt-1 mb-3"
+			.append(`<div class="results mt-2 mb-3"
 			style="border: 1px solid #d1d8dd; border-radius: 3px; height: 300px; overflow: auto;"></div>`);
 
 		this.$results = this.$wrapper.find(".results");


### PR DESCRIPTION
**Closes:** #36064 
**Backport:** v-16

---
Before:
<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/3890b469-9d6a-426d-a271-71e433fc603d" />

---

After:
<img width="859" height="719" alt="image" src="https://github.com/user-attachments/assets/d9b180a1-d1a0-4827-8572-684807136f98" />


---
`no-docs`
