### PR TITLE
perf: memoize functions constructed for eval

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -6,6 +6,8 @@ import number_systems from "./number_systems";
 
 frappe.provide("frappe.utils");
 
+const eval_function_cache = new Map();
+
 // Array de duplicate
 if (!Array.prototype.uniqBy) {
 	Object.defineProperty(Array.prototype, "uniqBy", {
@@ -1116,14 +1118,35 @@ Object.assign(frappe.utils, {
 		if (code.substr(0, 5) == "eval:") {
 			code = code.substr(5);
 		}
+
 		let variable_names = Object.keys(context);
 		let variables = Object.values(context);
-		code = `let out = ${code}; return out`;
+
+		// only cache expressions under 500 chars
+		const should_cache = code.length < 500;
+		const cache_key = should_cache ? code + "|" + variable_names.join(",") : null;
+
+		let expression_function = cache_key && eval_function_cache.get(cache_key);
+
+		if (!expression_function) {
+			const function_code = `let out = ${code}; return out`;
+			try {
+				expression_function = new Function(...variable_names, function_code);
+			} catch (error) {
+				console.log("Error evaluating the following expression:");
+				console.error(function_code);
+				throw error;
+			}
+
+			if (cache_key) {
+				eval_function_cache.set(cache_key, expression_function);
+			}
+		}
+
 		try {
-			let expression_function = new Function(...variable_names, code);
 			return expression_function(...variables);
 		} catch (error) {
-			console.log("Error evaluating the following expression:");
+			console.log("Error executing the following expression:");
 			console.error(code);
 			throw error;
 		}


### PR DESCRIPTION
## Benchmarks

iterations per test: 10,000


### Before

<details>

```
test: simple arithmetic
code: a + b * 2
  total: 180.00ms
  per call: 18.000μs
  ops/sec: 55,556

test: conditional
code: status === 'active' ? 1 : 0
  total: 221.00ms
  per call: 22.100μs
  ops/sec: 45,249

test: complex expression
code: items.filter(i => i.qty > 0).reduce((sum, i) => sum + i.qty * i.rate, 0)
  total: 404.00ms
  per call: 40.400μs
  ops/sec: 24,752

test: string manipulation
code: name.toUpperCase() + ' - ' + (age * 2).toString()
  total: 276.00ms
  per call: 27.600μs
  ops/sec: 36,232
```
</details>


### After

<details>

```
test: simple arithmetic
code: a + b * 2
  total: 3.00ms
  per call: 0.300μs
  ops/sec: 33,33,333

test: conditional
code: status === 'active' ? 1 : 0
  total: 3.00ms
  per call: 0.300μs
  ops/sec: 33,33,333

test: complex expression
code: items.filter(i => i.qty > 0).reduce((sum, i) => sum + i.qty * i.rate, 0)
  total: 4.00ms
  per call: 0.400μs
  ops/sec: 25,00,000

test: string manipulation
code: name.toUpperCase() + ' - ' + (age * 2).toString()
  total: 6.00ms
  per call: 0.600μs
  ops/sec: 16,66,667

```
</details>