### PR TITLE
fix(desk): fix desktop right-click context menu issu

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -302,11 +302,15 @@ class DesktopPage {
 				},
 			},
 		];
-		frappe.ui.create_menu({
-			parent: this.wrapper,
-			menu_items: menu_items,
-			right_click: true,
-		});
+
+		if (this.wrapper && this.wrapper.length > 0 && !this.context_menu_created) {
+			frappe.ui.create_menu({
+				parent: this.wrapper,
+				menu_items: menu_items,
+				right_click: true,
+			});
+			this.context_menu_created = true;
+		}
 	}
 	stop_editing_layout(action) {
 		this.edit_mode = false;
@@ -1166,7 +1170,7 @@ class IconsPane {
 }
 
 class InlineEditor {
-	constructor(container, initialValue = "", onRename = () => {}) {
+	constructor(container, initialValue = "", onRename = () => { }) {
 		this.container = container;
 		this.initialValue = initialValue;
 		this.onRename = onRename;


### PR DESCRIPTION
## Description
Fixes an issue where the desktop right-click context menu (containing "Edit Layout" and "Reset Layout") was not accessible or functional. The [setup_context_menu](cci:1://file:///home/oswinalex/Desktop/frappe/frappe/frappe/desk/page/desktop/desktop.js:283:1-313:2) function was attempting to initialize the menu without verifying if the container wrapper existed, and purely relying on the function call order.
## Changes
- Modified [frappe/desk/page/desktop/desktop.js](cci:7://file:///home/oswinalex/Desktop/frappe/frappe/frappe/desk/page/desktop/desktop.js:0:0-0:0):
    - Added validation for `this.wrapper` in [setup_context_menu](cci:1://file:///home/oswinalex/Desktop/frappe/frappe/frappe/desk/page/desktop/desktop.js:283:1-313:2) to ensure the container exists before attaching the menu.
    - Introduced a `context_menu_created` flag to prevent duplicate context menu creation on the same instance.
## Testing
1. Go to the Desktop.
2. Right-click on the background.
3. Verify that the context menu appears with "Edit Layout" and "Reset Layout".
4. Verify functionality of both options.