### PR TITLE
fix: respect cannot_add_rows when toggling Add Row button visibility

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -223,7 +223,14 @@ export default class Grid {
 			const num_selected_rows = this.get_selected_children().length;
 
 			// toggle "Add row" button
-			this.wrapper.find(".grid-add-row").toggleClass("hidden", num_selected_rows > 0);
+			this.wrapper
+				.find(".grid-add-row")
+				.toggleClass(
+					"hidden",
+					num_selected_rows > 0 ||
+						this.cannot_add_rows ||
+						(this.df && this.df.cannot_add_rows)
+				);
 
 			// update "Delete" and "Duplicate" button labels
 			if (num_selected_rows == 1) {


### PR DESCRIPTION
Fixes #36095

When cannot_add_rows is set, the Add Row button was reappearing after deselecting a row checkbox. Added the missing cannot_add_rows check in setup_check() method.


**Before**

https://github.com/user-attachments/assets/155e0c61-45ff-4fe7-a4ad-3ff228632e7d


**After**

https://github.com/user-attachments/assets/c60ec21e-1c3d-4384-9f83-dd7b5cee9db8

