### PR TITLE
fix: add forgot password link on login page

### DIFF
--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -303,6 +303,17 @@ frappe.ready(function () {
 	}
 
 	$(".form-signup, .form-forgot, .form-login-with-email-link").removeClass("hide");
+
+        if ($(".for-login").length && !$(".forgot-password-link").length) {
+  $(".for-login").append(`
+    <div class="text-center mt-3 forgot-password-link">
+      <a href="#forgot" class="text-muted">
+        ${__("Forgot Password?")}
+      </a>
+    </div>
+  `);
+}
+
 	$(document).trigger('login_rendered');
 });
 


### PR DESCRIPTION
## Problem
The login page does not provide a visible way for users to reset their password.

## Solution
Adds a visible **Forgot Password?** link on the login page that routes to the existing
password reset flow without introducing new logic.

Closes #3715
