### PR TITLE
fix(contact): ensure query is compatible with postgres

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -366,7 +366,7 @@ def contact_query(doctype, txt, searchfield, start, page_len, filters):
 		order by
 			if(locate(%(_txt)s, `tabContact`.full_name), locate(%(_txt)s, `tabContact`.company_name), 99999),
 			`tabContact`.idx desc, `tabContact`.full_name
-		limit %(start)s, %(page_len)s """,
+		limit %(page_len)s offset %(start)s """,
 		{
 			"txt": "%" + txt + "%",
 			"_txt": txt.replace("%", ""),


### PR DESCRIPTION
**fix(contact):** This PR fixes a query in contact that was written in a MariaDB specific style. This PR is a step forward towards resolving #21613 and completes a part of the Postgres TODO #34660 . 

**Before:**
```python
Syntax error in query:
select
tabItem.name , item_name, item_group, customer_code, if(length(tabItem.description) > '40', concat(substr(tabItem.description, 1, 40), "..."), description) as description
from "tabItem"
where tabItem.docstatus < '2'
and tabItem.disabled= '0'
and tabItem.has_variants= '0'
and (tabItem.end_of_life > %(today)s or coalesce(tabItem.end_of_life, '0000-00-00')='0000-00-00')
and (item_name like %(txt)s or description like %(txt)s or item_group like %(txt)s or customer_code like %(txt)s or name like %(txt)s or item_code like %(txt)s or tabItem.item_code IN (select parent from "tabItem Barcode" where barcode LIKE %(txt)s)
or tabItem.description LIKE %(txt)s)
and "tabItem"."is_stock_item" = '1' 
order by
if(strpos( name, %(_txt)s), strpos( name, %(_txt)s), 99999),
if(strpos( item_name, %(_txt)s), strpos( item_name, %(_txt)s), 99999),
idx desc,
name, item_name
limit %(start)s, %(page_len)s {'today': '2026-01-20', 'txt': '%', '_txt': '', 'start': '0', 'page_len': '10'}

request.js:476 Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 63, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 53, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1124, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/utils/caching.py", line 248, in inner
    ret = func(*args, **kwargs)
  File "apps/frappe/frappe/desk/search.py", line 51, in search_link
    results = search_widget(
    doctype,
    ...<7 lines>...
    link_fieldname=link_fieldname,
    )
  File "apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/desk/search.py", line 122, in search_widget
    return frappe.call(
           ~~~~~~~~~~~^
    query,
     ^^^^^^
    ...<9 lines>...
    link_fieldname=link_fieldname,
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "apps/frappe/frappe/__init__.py", line 1124, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 1551, in wrapper
    return fn(**kwargs)
  File "apps/erpnext/erpnext/controllers/queries.py", line 244, in item_query
    return frappe.db.sql(
           ~~~~~~~~~~~~~^
    """select
     ^^^^^^^^^
    ...<28 lines>...
    as_dict=as_dict,
     ^^^^^^^^^^^^^^^^
    )
    ^
  File "apps/frappe/frappe/database/postgres/database.py", line 234, in sql
    return super().sql(modify_query(query), modify_values(values), *args, **kwargs)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 272, in sql
    self.execute_query(query, values)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 372, in execute_query
    return self._cursor.execute(query, values)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
psycopg2.errors.SyntaxError: LIMIT #,# syntax is not supported
LINE 16:   limit '0', '10'
           ^
HINT:  Use separate LIMIT and OFFSET clauses
```

**After:**
Works on both DB's


related to #34660 