### PR TITLE
fix: explicity show the sidebar for the desktop icon

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -91,6 +91,9 @@ function get_route(desktop_icon) {
 						type: first_link.link_type,
 						name: first_link.link_to,
 						tab: first_link.tab,
+						route_options: {
+							sidebar: desktop_icon.label,
+						},
 					});
 				}
 			}
@@ -997,21 +1000,6 @@ class DesktopIcon {
 				this.icon.attr("target", "_blank");
 			}
 			this.icon.attr("href", this.icon_route);
-		}
-		if (this.icon_data.sidebar) {
-			const me = this;
-			this.icon.on("click", function () {
-				if (me.icon_data.sidebar == "My Workspaces") {
-					let sidebar_name = me.icon_data.sidebar.toLowerCase();
-					if (frappe.boot.workspace_sidebar_item[sidebar_name].items.length == 0) {
-						frappe.toast("No Private Workspaces for user");
-					} else {
-						let workspace_name =
-							frappe.boot.workspace_sidebar_item[sidebar_name].items[0]["link_to"];
-						frappe.set_route("Workspaces", "private", workspace_name);
-					}
-				}
-			});
 		}
 	}
 

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -113,7 +113,11 @@ frappe.ui.Sidebar = class Sidebar {
 	setup_events() {
 		const me = this;
 		frappe.router.on("change", function (router) {
-			frappe.app.sidebar.set_workspace_sidebar(router);
+			if (frappe.route_options.sidebar) {
+				frappe.app.sidebar.setup(frappe.route_options.sidebar);
+			} else {
+				frappe.app.sidebar.set_workspace_sidebar(router);
+			}
 		});
 		$(document).on("page-change", function () {
 			frappe.app.sidebar.toggle();

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -110,6 +110,9 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				if (d.type == "Desktop Icon") {
 					target = frappe.utils.get_route_for_icon(d.icon_data);
 					d.route = target;
+					d.route_options = {
+						sidebar: d.icon_data.label,
+					};
 				}
 				let html = `<span>${__(d.label || d.value)}</span>`;
 


### PR DESCRIPTION
Video 

https://github.com/user-attachments/assets/0140eb8e-74e3-4241-818f-a6445ce622e2

Same behaviour from awesomebar


https://github.com/user-attachments/assets/c135581c-e38a-442b-9795-7028b30c7f10



