### PR TITLE
fix: align checkbox with label in field properties sidebar

### DIFF
--- a/frappe/public/js/form_builder/components/controls/CheckControl.vue
+++ b/frappe/public/js/form_builder/components/controls/CheckControl.vue
@@ -47,6 +47,11 @@ input {
 	cursor: pointer;
 }
 
+label {
+	display: flex;
+	align-items: center;
+}
+
 label .checkbox {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
- Checkbox and label text were not vertically aligned in Form Builder field properties sidebar.
- Added flexbox alignment to label element.

**before**
<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/16909730-a55b-4e7e-b3e1-334a56f537f4" />

**After**
<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/6acccf6e-2d83-493c-be81-d16e8f7de4cf" />
