### PR TITLE
feat: Add Select All/Unselect All buttons to Table Columns dialog in Print Format Builder

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -709,8 +709,8 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 				$body.find("input[type='checkbox']").each(function () {
 					if (!$(this).prop("checked")) {
 						$(this).prop("checked", true);
-						var fieldname = $(this).attr("data-fieldname");
-						var input = get_width_input(fieldname);
+						const fieldname = $(this).attr("data-fieldname");
+						const input = get_width_input(fieldname);
 						input.prop("disabled", false);
 					}
 				});
@@ -722,8 +722,8 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 				$body.find("input[type='checkbox']").each(function () {
 					if ($(this).prop("checked")) {
 						$(this).prop("checked", false);
-						var fieldname = $(this).attr("data-fieldname");
-						var input = get_width_input(fieldname);
+						const fieldname = $(this).attr("data-fieldname");
+						const input = get_width_input(fieldname);
 						input.prop("disabled", true);
 						input.val("");
 					}

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -704,6 +704,33 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 				update_column_count_message();
 			});
 
+			// Select All functionality
+			$body.on("click", ".select-all-btn", function () {
+				$body.find("input[type='checkbox']").each(function () {
+					if (!$(this).prop("checked")) {
+						$(this).prop("checked", true);
+						var fieldname = $(this).attr("data-fieldname");
+						var input = get_width_input(fieldname);
+						input.prop("disabled", false);
+					}
+				});
+				update_column_count_message();
+			});
+
+			// Unselect All functionality
+			$body.on("click", ".unselect-all-btn", function () {
+				$body.find("input[type='checkbox']").each(function () {
+					if ($(this).prop("checked")) {
+						$(this).prop("checked", false);
+						var fieldname = $(this).attr("data-fieldname");
+						var input = get_width_input(fieldname);
+						input.prop("disabled", true);
+						input.val("");
+					}
+				});
+				update_column_count_message();
+			});
+
 			d.show();
 
 			return false;

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -704,31 +704,36 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 				update_column_count_message();
 			});
 
-			// Select All functionality
-			$body.on("click", ".select-all-btn", function () {
-				$body.find("input[type='checkbox']").each(function () {
-					if (!$(this).prop("checked")) {
-						$(this).prop("checked", true);
-						const fieldname = $(this).attr("data-fieldname");
+			// Toggle all checkboxes in column selector
+			const toggle_all_checkboxes = function (should_check, should_clear_value) {
+				// Scope to column selector list checkboxes only
+				$body.find(".column-selector-list input[type='checkbox'][data-fieldname]").each(function () {
+					const $checkbox = $(this);
+					const is_checked = $checkbox.prop("checked");
+					
+					// Only process checkboxes that need to be changed
+					if ((should_check && !is_checked) || (!should_check && is_checked)) {
+						$checkbox.prop("checked", should_check);
+						const fieldname = $checkbox.attr("data-fieldname");
 						const input = get_width_input(fieldname);
-						input.prop("disabled", false);
+						input.prop("disabled", !should_check);
+						
+						if (should_clear_value) {
+							input.val("");
+						}
 					}
 				});
 				update_column_count_message();
+			};
+
+			// Select All functionality
+			$body.on("click", ".select-all-btn", function () {
+				toggle_all_checkboxes(true, false);
 			});
 
 			// Unselect All functionality
 			$body.on("click", ".unselect-all-btn", function () {
-				$body.find("input[type='checkbox']").each(function () {
-					if ($(this).prop("checked")) {
-						$(this).prop("checked", false);
-						const fieldname = $(this).attr("data-fieldname");
-						const input = get_width_input(fieldname);
-						input.prop("disabled", true);
-						input.val("");
-					}
-				});
-				update_column_count_message();
+				toggle_all_checkboxes(false, true);
 			});
 
 			d.show();

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -707,22 +707,24 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 			// Toggle all checkboxes in column selector
 			const toggle_all_checkboxes = function (should_check, should_clear_value) {
 				// Scope to column selector list checkboxes only
-				$body.find(".column-selector-list input[type='checkbox'][data-fieldname]").each(function () {
-					const $checkbox = $(this);
-					const is_checked = $checkbox.prop("checked");
-					
-					// Only process checkboxes that need to be changed
-					if ((should_check && !is_checked) || (!should_check && is_checked)) {
-						$checkbox.prop("checked", should_check);
-						const fieldname = $checkbox.attr("data-fieldname");
-						const input = get_width_input(fieldname);
-						input.prop("disabled", !should_check);
-						
-						if (should_clear_value) {
-							input.val("");
+				$body
+					.find(".column-selector-list input[type='checkbox'][data-fieldname]")
+					.each(function () {
+						const $checkbox = $(this);
+						const is_checked = $checkbox.prop("checked");
+
+						// Only process checkboxes that need to be changed
+						if ((should_check && !is_checked) || (!should_check && is_checked)) {
+							$checkbox.prop("checked", should_check);
+							const fieldname = $checkbox.attr("data-fieldname");
+							const input = get_width_input(fieldname);
+							input.prop("disabled", !should_check);
+
+							if (should_clear_value) {
+								input.val("");
+							}
 						}
-					}
-				});
+					});
 				update_column_count_message();
 			};
 

--- a/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html
@@ -3,6 +3,12 @@
 <p class="help-message alert alert-warning">
 	{{ __("Some columns might get cut off when printing to PDF. Try to keep number of columns under 10.") }}
 </p>
+<div class="row" style="margin-bottom: 15px;">
+	<div class="col-sm-12">
+		<button class="btn btn-xs btn-default select-all-btn" type="button">{{ __("Select All") }}</button>
+		<button class="btn btn-xs btn-default unselect-all-btn" type="button" style="margin-left: 5px;">{{ __("Unselect All") }}</button>
+	</div>
+</div>
 <div class="row">
 	<div class="col-sm-6"><p class="bold">{{ __("Column") }}</p></div>
 	<div class="col-sm-6 text-right"><p class="bold">{{ __("Width") }}</p></div>


### PR DESCRIPTION
### Description
Adds "Select All" and "Unselect All" buttons to the "Select Table Columns" dialog in Print Format Builder to improve UX when selecting multiple columns.

no-docs

### Changes
- Added "Select All" and "Unselect All" buttons to the column selector dialog
- Implemented functionality to select/deselect all checkboxes at once
- Automatically enables/disables width inputs based on selection state
- Updates column count warning message when using Select All/Unselect All

### Related Issue
Fixes #36066

### Testing
- Tested Select All functionality - selects all columns and enables width inputs
- Tested Unselect All functionality - deselects all columns and clears width inputs
- Verified column count warning updates correctly

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=5625555