### PR TITLE
fix(email): allow password reset when global unsubscribe enabled

### DIFF
--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -141,7 +141,9 @@ def is_ci(file):
 
 def is_frontend_code(file):
 	"""Check if the file is frontend code."""
-	return file.lower().endswith((".css", ".scss", ".less", ".sass", ".styl", ".js", ".ts", ".vue", ".html", ".svg"))
+	return file.lower().endswith(
+		(".css", ".scss", ".less", ".sass", ".styl", ".js", ".ts", ".vue", ".html", ".svg")
+	)
 
 
 def is_docs(file):

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -571,6 +571,7 @@ class User(Document):
 			header=[subject, "green"],
 			delayed=(not now) if now is not None else self.flags.delay_emails,
 			retry=3,
+			ignore_unsubscribed=True
 		)
 
 	def on_trash(self):

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -571,7 +571,7 @@ class User(Document):
 			header=[subject, "green"],
 			delayed=(not now) if now is not None else self.flags.delay_emails,
 			retry=3,
-			ignore_unsubscribed=True
+			ignore_unsubscribed=True,
 		)
 
 	def on_trash(self):

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -152,6 +152,7 @@ def sendmail(
 	email_headers=None,
 	raw_html=False,
 	add_css=True,
+	ignore_unsubscribed=False
 ) -> EmailQueue | None:
 	"""Send email using user's default **Email Account** or global default **Email Account**.
 
@@ -183,6 +184,7 @@ def sendmail(
 	:param email_headers: Additional headers to be added in the email, e.g. {"X-Custom-Header": "value"} or {"Custom-Header": "value"}. Automatically prepends "X-" to the header name if not present.
 	:param raw_html: Whether to treat email template as a complete HTML file
 	:param add_css: Whether to add CSS from hooks/email_css to the email template
+	:param ignore_unsubscribed: Whether to sent email for all the users if they unsubscribed to the event
 	"""
 
 	from frappe.utils.jinja import get_email_from_template
@@ -244,6 +246,7 @@ def sendmail(
 		email_headers=email_headers,
 		raw_html=raw_html,
 		add_css=add_css,
+		ignore_unsubscribed=ignore_unsubscribed
 	)
 
 	# build email queue and send the email if send_now is True.

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -152,7 +152,7 @@ def sendmail(
 	email_headers=None,
 	raw_html=False,
 	add_css=True,
-	ignore_unsubscribed=False
+	ignore_unsubscribed=False,
 ) -> EmailQueue | None:
 	"""Send email using user's default **Email Account** or global default **Email Account**.
 
@@ -246,7 +246,7 @@ def sendmail(
 		email_headers=email_headers,
 		raw_html=raw_html,
 		add_css=add_css,
-		ignore_unsubscribed=ignore_unsubscribed
+		ignore_unsubscribed=ignore_unsubscribed,
 	)
 
 	# build email queue and send the email if send_now is True.

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -521,7 +521,7 @@ class QueueBuilder:
 		email_headers=None,
 		raw_html=False,
 		add_css=True,
-		ignore_unsubscribed=False
+		ignore_unsubscribed=False,
 	):
 		"""Add email to sending queue (Email Queue)
 

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -675,7 +675,7 @@ class QueueBuilder:
 	def get_unsubscribed_user_emails(self, email_ids):
 		if self._unsubscribed_user_emails is not None:
 			return self._unsubscribed_user_emails
-		if self.ignore_unsubscribed == True:
+		if self.ignore_unsubscribed:
 			return []
 		all_ids = list(set(email_ids))
 

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -521,6 +521,7 @@ class QueueBuilder:
 		email_headers=None,
 		raw_html=False,
 		add_css=True,
+		ignore_unsubscribed=False
 	):
 		"""Add email to sending queue (Email Queue)
 
@@ -550,6 +551,7 @@ class QueueBuilder:
 		:param email_headers: Additional headers to be added in the email, e.g. {"X-Custom-Header": "value"} or {"Custom-Header": "value"}. Automatically prepends "X-" to the header name if not present.
 		:param raw_html: Whether to treat email template as a complete HTML file
 		:param add_css: Add default CSS from hooks/email_css to the email template (default True)
+		:param ignore_unsubscribed: Whether to sent email for all the users if they unsubscribed to the event
 		"""
 
 		self._unsubscribe_method = unsubscribe_method
@@ -589,6 +591,7 @@ class QueueBuilder:
 		self.email_headers = email_headers
 		self.raw_html = raw_html
 		self.add_css = add_css
+		self.ignore_unsubscribed = ignore_unsubscribed
 
 	@property
 	def unsubscribe_method(self):
@@ -669,11 +672,12 @@ class QueueBuilder:
 		)
 		return self._email_account
 
-	def get_unsubscribed_user_emails(self):
+	def get_unsubscribed_user_emails(self, email_ids):
 		if self._unsubscribed_user_emails is not None:
 			return self._unsubscribed_user_emails
-
-		all_ids = list(set(self.recipients + self.cc + self.bcc))
+		if self.ignore_unsubscribed == True:
+			return []
+		all_ids = list(set(email_ids))
 
 		EmailUnsubscribe = DocType("Email Unsubscribe")
 
@@ -700,15 +704,15 @@ class QueueBuilder:
 		return self._unsubscribed_user_emails
 
 	def final_recipients(self):
-		unsubscribed_emails = self.get_unsubscribed_user_emails()
+		unsubscribed_emails = self.get_unsubscribed_user_emails(self.recipients)
 		return [mail_id for mail_id in self.recipients if mail_id not in unsubscribed_emails]
 
 	def final_cc(self):
-		unsubscribed_emails = self.get_unsubscribed_user_emails()
+		unsubscribed_emails = self.get_unsubscribed_user_emails(self.cc)
 		return [mail_id for mail_id in self.cc if mail_id not in unsubscribed_emails]
 
 	def final_bcc(self):
-		unsubscribed_emails = self.get_unsubscribed_user_emails()
+		unsubscribed_emails = self.get_unsubscribed_user_emails(self.bcc)
 		return [mail_id for mail_id in self.bcc if mail_id not in unsubscribed_emails]
 
 	def get_attachments(self):


### PR DESCRIPTION
Closes #36069

## Problem
When `global_unsubscribed` is enabled, transactional emails such as password reset and welcome emails are blocked. This prevents users from resetting their passwords or receiving onboarding emails.

## Solution
Added `ignore_unsubscribed=True` to `frappe.sendmail` calls used for password reset and welcome emails. This ensures that transactional emails are delivered regardless of the global unsubscribe setting.

## Optimization
Previously, recipient resolution for `_final_recipients`, `_final_cc`, and `_final_bcc` queried the database for all email addresses each time.

This has been optimized to query only the relevant recipient type (recipient / cc / bcc), reducing unnecessary database queries and improving performance.
