### PR TITLE
fix: use inline formatting for link filter values

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -600,7 +600,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			}
 
 			// Numbers, dates, etc. - not translated, not quoted
-			return frappe.format(val, docfield || {});
+			return frappe.format(val, docfield || {}, { inline: true });
 		}
 
 		async function describe_filter(filter) {


### PR DESCRIPTION
Resolves #36120
