### PR TITLE
fix: indicator pill breaking UI issue

### DIFF
--- a/frappe/public/scss/common/indicator.scss
+++ b/frappe/public/scss/common/indicator.scss
@@ -5,6 +5,9 @@
 	display: inline-flex;
 	align-items: center;
 }
+.list-row-col .indicator-pill {
+  max-width: 150px;
+}
 
 .indicator::before {
 	content: "";

--- a/frappe/public/scss/common/indicator.scss
+++ b/frappe/public/scss/common/indicator.scss
@@ -6,7 +6,7 @@
 	align-items: center;
 }
 .list-row-col .indicator-pill {
-  max-width: 150px;
+	max-width: 150px;
 }
 
 .indicator::before {

--- a/frappe/public/scss/common/indicator.scss
+++ b/frappe/public/scss/common/indicator.scss
@@ -5,9 +5,6 @@
 	display: inline-flex;
 	align-items: center;
 }
-.list-row-col .indicator-pill {
-	max-width: 150px;
-}
 
 .indicator::before {
 	content: "";

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -264,6 +264,10 @@
 	}
 }
 
+.list-row-col .indicator-pill {
+	max-width: 150px;
+}
+
 $level-margin-right: 8px;
 
 .list-subject {


### PR DESCRIPTION
Indicator Pills break UI if text content is long it can be solved 
through using max-width



https://github.com/user-attachments/assets/b23cf0f6-6852-4481-be5a-8dc068cb369d


Closes #36140
