### PR TITLE
fix(UX): add fallback for better error message delivery

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -636,10 +636,13 @@ function upload_file(file, i) {
 						: __("File upload failed.");
 				} else {
 					file.failed = true;
+					let detail =
+						xhr.statusText ||
+						__("Server error during upload. The file might be corrupted.");
 					file.error_message =
 						xhr.status === 0
 							? __("XMLHttpRequest Error")
-							: `${xhr.status} : ${xhr.statusText}`;
+							: `${xhr.status} : ${detail}`;
 
 					let error = null;
 					try {


### PR DESCRIPTION
**fix(UX):** This PR is a resolution to a UX problem with file uploads in particular image uploads as seen in #36012 . This PR adds a fallback for a better UX since `xhr.statusText` at times might be empty and would end up just throwing a status code onto the client which in turn might make the user clueless as to what the problem might have been.


**Before**:
<img width="927" height="441" alt="image" src="https://github.com/user-attachments/assets/68a66d0c-577b-448f-b7f4-c5fdebc0ebb9" />


**After**:
Better fallback applied to client


fixes #36012 