### PR TITLE
fix: save error message for prepared report in `code` field

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.json
+++ b/frappe/core/doctype/prepared_report/prepared_report.json
@@ -58,7 +58,7 @@
   },
   {
    "fieldname": "error_message",
-   "fieldtype": "Text",
+   "fieldtype": "Code",
    "label": "Error Message",
    "no_copy": 1,
    "print_hide": 1,


### PR DESCRIPTION
## Error

```
pymysql.err.DataError: (1406, "Data too long for column 'error_message' at row 1")
```

Ref: https://github.com/frappe/frappe/blob/cd41c054a6260e04e16282a0e6db60dc0011d275/frappe/core/doctype/prepared_report/prepared_report.py#L130

## Fix

Save error message in code field