### PR TITLE
fix: Breadcrumb breaks when document title contains HTML tags

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -235,7 +235,7 @@ frappe.breadcrumbs = {
 			let title = frappe.model.get_doc_title(doc);
 			docname_title = title || doc.name;
 			if (frappe.utils.is_html(docname_title)) {
-				docname_title = $(docname_title).text();
+				docname_title = strip_html(docname_title);
 			}
 		}
 		this.append_breadcrumb_element(form_route, docname_title, "title-text-form");


### PR DESCRIPTION
Closes #36164

### **Root Cause:**

In breadcrumbs.js, the set_form_breadcrumb function uses $(docname_title).text() to strip HTML. 
However, jQuery's $() fails when the string contains HTML but doesn't start with a tag ( it tries to interpret it as a selector).

### **Fix:**
Replace $(docname_title).text() with strip_html(docname_title).


- This is the data of **small text** field:

<img width="554" height="209" alt="Screenshot 2026-01-21 at 3 47 12 PM" src="https://github.com/user-attachments/assets/66158e6d-ac7c-44d4-92c1-99ce36b5c28c" />

- The data is shown without line break:

<img width="701" height="118" alt="Screenshot 2026-01-21 at 3 47 22 PM" src="https://github.com/user-attachments/assets/3cd07fa2-4437-42ec-a1cd-12b997a6f56a" />

- In pdf it works as line break:

<img width="807" height="271" alt="Screenshot 2026-01-21 at 3 47 32 PM" src="https://github.com/user-attachments/assets/8a62cf9a-3c95-488d-9e0e-146914f89be8" />

