### PR TITLE
feat(translate): support Template strings in translate function

### DIFF
--- a/frappe/utils/translations.py
+++ b/frappe/utils/translations.py
@@ -3,7 +3,7 @@ from string.templatelib import Interpolation, Template
 import frappe
 
 
-def _(msg, lang: str | None = None, context: str | None = None) -> str:
+def _(msg: str | Template, lang: str | None = None, context: str | None = None) -> str:
 	"""Return translated string in current lang, if exists.
 	Usage:
 	        _('Change')
@@ -68,29 +68,29 @@ def set_user_lang(user: str, user_language: str | None = None) -> None:
 
 
 def _translate_template(tpl: Template, lang: str | None = None, context: str | None = None) -> str:
-	source_string, rendered_values = _template_to_positional(tpl)
-	translated = _(source_string, lang=lang, context=context)
-	return translated.format(*rendered_values)
+	positional_string, dynamic_values = _convert_template_to_positional_string(tpl)
+	translated = _(positional_string, lang=lang, context=context)
+	return translated.format(*dynamic_values)
 
 
-def _template_to_positional(tpl: Template) -> tuple[str, tuple[str, ...]]:
-	parts = []
-	rendered_values = []
+def _convert_template_to_positional_string(tpl: Template) -> tuple[str, tuple[str, ...]]:
+	string_parts = []
+	dynamic_values = []
 
 	static_parts = tpl.strings
 	interpolations = tpl.interpolations
 
 	for i, static_part in enumerate(static_parts):
-		parts.append(static_part)
+		string_parts.append(static_part)
 
 		if i < len(interpolations):
-			parts.append(f"{{{len(rendered_values)}}}")
-			rendered_values.append(_render_interpolation(interpolations[i]))
+			string_parts.append(f"{{{len(dynamic_values)}}}")
+			dynamic_values.append(_get_interpolation(interpolations[i]))
 
-	return "".join(parts), tuple(rendered_values)
+	return "".join(string_parts), tuple(dynamic_values)
 
 
-def _render_interpolation(interp: Interpolation) -> str:
+def _get_interpolation(interp: Interpolation) -> str:
 	value = interp.value
 
 	if interp.conversion == "r":

--- a/frappe/utils/translations.py
+++ b/frappe/utils/translations.py
@@ -1,12 +1,18 @@
+from string.templatelib import Interpolation, Template
+
 import frappe
 
 
-def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
+def _(msg, lang: str | None = None, context: str | None = None) -> str:
 	"""Return translated string in current lang, if exists.
 	Usage:
 	        _('Change')
 	        _('Change', context='Coins')
 	"""
+
+	if isinstance(msg, Template):
+		return _translate_template(msg, lang=lang, context=context)
+
 	from frappe.translate import get_all_translations
 	from frappe.utils import is_html, strip_html_tags
 
@@ -59,3 +65,42 @@ def set_user_lang(user: str, user_language: str | None = None) -> None:
 	from frappe.translate import get_user_lang
 
 	frappe.local.lang = get_user_lang(user) or user_language
+
+
+def _translate_template(tpl: Template, lang: str | None = None, context: str | None = None) -> str:
+	source_string, rendered_values = _template_to_positional(tpl)
+	translated = _(source_string, lang=lang, context=context)
+	return translated.format(*rendered_values)
+
+
+def _template_to_positional(tpl: Template) -> tuple[str, tuple[str, ...]]:
+	parts = []
+	rendered_values = []
+
+	static_parts = tpl.strings
+	interpolations = tpl.interpolations
+
+	for i, static_part in enumerate(static_parts):
+		parts.append(static_part)
+
+		if i < len(interpolations):
+			parts.append(f"{{{len(rendered_values)}}}")
+			rendered_values.append(_render_interpolation(interpolations[i]))
+
+	return "".join(parts), tuple(rendered_values)
+
+
+def _render_interpolation(interp: Interpolation) -> str:
+	value = interp.value
+
+	if interp.conversion == "r":
+		value = repr(value)
+	elif interp.conversion == "s":
+		value = str(value)
+	elif interp.conversion == "a":
+		value = ascii(value)
+
+	if interp.format_spec:
+		return format(value, interp.format_spec)
+
+	return str(value)


### PR DESCRIPTION
This PR adds support for Python Template strings (`string.templatelib.Template`)
to the translation function `_()`.

* Translations currently require manual `.format()` calls with positional placeholders
* Template strings allow inline variable interpolation while preserving gettext semantics
* Removes the need for manual `.format()` calls
* Converts template interpolations to positional placeholders before translation
* Applies conversion and format specs (`!r`, `.2f`, date formats, etc.) after translation
* No changes to message extraction or existing translations

Example usage (language: `de`)

**1. Inline variable interpolation**

```python
docname = "Sales Order"

frappe.msgprint(_(t"Open {docname}"))
```

Output:

```
Sales Order öffnen
```

---

**2. Floating-point formatting**

```python
utilization = 83.21443

frappe.msgprint(
    _(t"Database Table Row Size Utilization: {utilization:.2f}%, this limits number of fields you can add.")
)
```

Output:

```
Auslastung der Datenbanktabellenzeilengröße: 83.21 %, dies begrenzt die Anzahl der Felder, die Sie hinzufügen können.
```

---

**3. Nested translations**

```python
doctype = _("User")
row = 1

frappe.msgprint(_(t"Mandatory fields required in table {doctype}, Row {row}"))
```

Output:

```
Pflichtfelder erforderlich in Tabelle Benutzer, Zeile 1
```

---

**4. Date formatting**

```python
from datetime import date

today = date(2026, 1, 21)

frappe.msgprint(_(t"Page {today:%Y} of {1}"))
```

Output:

```
Seite 2026 von 1
```

---

**5. `!r` conversion with custom `__repr__`**

```python
class DocTypeName:
    def __init__(self, name):
        self.name = name

    def __repr__(self):
        return f"DocType(name={self.name})"


doctype = DocTypeName("Sales Order")

frappe.msgprint(_(t"DocType {doctype!r} does not exist."))
```

Output:

```
DocType DocType(name=Sales Order) existiert nicht.
```
