### PR TITLE
fix(utils): update route assignment for external desktop icons

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1310,7 +1310,7 @@ Object.assign(frappe.utils, {
 		if (!desktop_icon) return;
 		let item = {};
 		if (desktop_icon.link_type == "External" && desktop_icon.link) {
-			route = window.location.origin + desktop_icon.link;
+			route = desktop_icon.link;
 		} else {
 			let sidebar = frappe.boot.workspace_sidebar_item[desktop_icon.label.toLowerCase()];
 			if (desktop_icon.link_type == "Workspace Sidebar" && sidebar) {


### PR DESCRIPTION
Issue: "Page http: not found" error in Global Search for App Desktop Icons

Steps to Reproduce:

- Install an app that uses add_to_apps_screen hook (e.g., Lending app)
- Open the global search (Ctrl+K or click search bar)
- Type the app name (e.g., "lending")
- Locate "Open Lending" option in the results
- Press Enter to select
Shows error: "Page http: not found"


Note: Right-clicking and copying the link shows the correct URL. Clicking directly on the link also works. Only pressing Enter fails.



Before:
<img width="1077" height="280" alt="image" src="https://github.com/user-attachments/assets/1c6d8363-0736-4976-8667-ff73843b2a24" />

