### PR TITLE
fix: update Content-Disposition header for binary as attachment

### DIFF
--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -483,7 +483,9 @@ class TestAPIResponse(FrappeAPITestCase):
 		self.assertEqual(response.status_code, 200)
 		self.assertEqual(response.headers["content-type"], "application/octet-stream")
 		self.assertGreater(cint(response.headers["content-length"]), 0)
-		self.assertEqual(response.headers["content-disposition"], f'filename="{encoded_filename}"')
+		self.assertEqual(
+			response.headers["content-disposition"], f'attachment; filename="{encoded_filename}"'
+		)
 
 	def test_download_private_file_with_unique_url(self):
 		test_content = frappe.generate_hash()

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -159,7 +159,7 @@ def as_pdf():
 	response = Response()
 	response.mimetype = "application/pdf"
 	filename = frappe.response["filename"].encode("utf-8").decode("unicode-escape", "ignore")
-	response.headers.add("Content-Disposition", None, filename=filename)
+	response.headers.add("Content-Disposition", "inline", filename=filename)
 	response.data = frappe.response["filecontent"]
 	return response
 

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -169,7 +169,7 @@ def as_binary():
 	response.mimetype = "application/octet-stream"
 	filename = frappe.response["filename"]
 	filename = filename.encode("utf-8").decode("unicode-escape", "ignore")
-	response.headers.add("Content-Disposition", None, filename=filename)
+	response.headers.add("Content-Disposition", "attachment", filename=filename)
 	response.data = frappe.response["filecontent"]
 	return response
 


### PR DESCRIPTION
Issue: When downloading reports (Excel/CSV) in Firefox-based browsers (including Zen browser), files are saved without extension instead of the correct extension (.xlsx, .csv). This works correctly in Chromium-based browsers.

closes: https://github.com/resilient-tech/india-compliance/issues/3917
