### PR TITLE
feat: init frappe-ui template

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -12,7 +12,7 @@ from frappe import _
 from frappe.commands import get_site, pass_context
 from frappe.coverage import CodeCoverage
 from frappe.exceptions import SiteNotSpecifiedError
-from frappe.utils import cint, update_progress_bar
+from frappe.utils import cint, get_bench_path, update_progress_bar
 from frappe.utils.bench_helper import CliCtxObj
 
 EXTRA_ARGS_CTX = {"ignore_unknown_options": True, "allow_extra_args": True}
@@ -930,9 +930,10 @@ def create_frontend_template(info, starter_template_repo):
 		if result.returncode == 0:
 			run_boilderplate_commands(app_path, info)
 			click.secho(f"Frappe UI is setup for the app {info.app_name} ", fg="green")
+			click.secho("Next steps are:")
 			next_steps = [
-				f"Navigate to bench/apps/{info.app_name}/{template_dir}",
-				"Run `yarn install`",
+				f"Navigate using `cd {get_bench_path()}/apps/{info.app_name}/{template_dir}`",
+				"Install packages `yarn install`",
 				"Start the dev server `yarn run dev`",
 			]
 			for i, step in enumerate(next_steps):
@@ -945,7 +946,6 @@ def create_frontend_template(info, starter_template_repo):
 
 
 def run_boilderplate_commands(app_path, info):
-	print(app_path)
 	package_json_path = os.path.join(app_path, "frontend", "package.json")
 	if os.path.exists(package_json_path):
 		package_json_content = None
@@ -957,7 +957,7 @@ def run_boilderplate_commands(app_path, info):
 			click.secho("No boilerplate commands found in package.json", fg="yellow")
 			return
 		subprocess.run(
-			["node", boilerplate_script, info.app_name],
+			["node", boilerplate_script, json.dumps(info)],
 			cwd=os.path.join(app_path, "frontend"),
 		)
 		os.remove(os.path.join(app_path, "frontend", boilerplate_script))

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -901,12 +901,22 @@ def validate_if_app_is_installed(app_name):
 
 def create_frappe_ui_template(info):
 	template_url = "sokumon/frappe-ui-starter"
+	template_dir = "frontend"
 	import os
+	import shutil
 
 	try:
 		app_path = os.path.dirname(frappe.get_app_path(info.app_name))
 		os.chdir(app_path)
-		command = f"npx degit {template_url} frontend"
+		if os.path.exists(os.path.join(app_path, template_dir)):
+			if click.confirm(f"Looks like there already is a {template_dir} dir, Do you want to delete it"):
+				shutil.rmtree(os.path.join(app_path, template_dir))
+				click.echo("Restarting initializing")
+				create_frappe_ui_template(info)
+			else:
+				click.echo(f"Delete the {template_dir} in apps/{info.app_name} directory to continue")
+			return
+		command = f"npx degit {template_url} {template_dir}"
 		result = subprocess.run(
 			command,
 			shell=True,

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -881,16 +881,20 @@ def init_frappe_ui():
 		create_frappe_ui_template(info)
 
 
-def validate_if_app_is_installed(app_name):
+def get_apps_site_map():
 	from frappe.utils import get_bench_path
 
-	app_not_installed = False
 	out = subprocess.check_output(
 		["bench", "--site", "all", "list-apps", "--format", "json"],
 		stderr=open(os.devnull, "wb"),
 		cwd=get_bench_path(),
 	).decode("utf-8")
-	apps_sites_dict = json.loads(out)
+	return json.loads(out)
+
+
+def validate_if_app_is_installed(app_name):
+	app_not_installed = False
+	apps_sites_dict = get_apps_site_map()
 	for apps in apps_sites_dict.values():
 		if app_name in apps:
 			app_not_installed = True
@@ -903,7 +907,7 @@ def validate_if_app_is_installed(app_name):
 def create_frappe_ui_template(info):
 	template_url = "sokumon/frappe-ui-starter"
 	template_dir = "frontend"
-
+	info.app_publisher = frappe.get_hooks(hook="app_publisher", app_name=info.app_name)[0]
 	try:
 		app_path = os.path.dirname(frappe.get_app_path(info.app_name))
 		os.chdir(app_path)
@@ -926,6 +930,13 @@ def create_frappe_ui_template(info):
 		if result.returncode == 0:
 			make_frappe_ui_boilerplate(app_path, info)
 			click.secho(f"Frappe UI is setup for the app {info.app_name} ", fg="green")
+			next_steps = [
+				f"Navigate to bench/apps/{info.app_name}/{template_dir}",
+				"Run `yarn install`",
+				"Start the dev server `yarn run dev`",
+			]
+			for i, step in enumerate(next_steps):
+				click.secho(f"{i + 1}. {step}")
 		else:
 			click.secho("Something went wrong while fetching the template", fg="red")
 			print(result.stderr)
@@ -939,6 +950,7 @@ def make_frappe_ui_boilerplate(app_path, data):
 		"vite.config.js.tpl": os.path.join(app_path, "frontend"),
 		"router.ts.tpl": os.path.join(app_path, "frontend", "src"),
 		"package.json.tpl": app_path,
+		"Home.vue.tpl": os.path.join(app_path, "frontend", "src", "pages"),
 	}
 	if os.path.exists(boilerplate_path):
 		for file in os.listdir(boilerplate_path):
@@ -956,7 +968,9 @@ def make_boilerplate(boilerplate_path, file_name, target_directory, data):
 	with open(boilerplate_file_path) as source:
 		template_content = Template(source.read())
 
-	custom_content = template_content.substitute(app_name=data["app_name"], app_route=data["route"])
+	custom_content = template_content.substitute(
+		app_name=data["app_name"], app_route=data["route"], app_publisher=data["app_publisher"]
+	)
 	with open(target_file_path, "w") as target:
 		target.write(custom_content)
 

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -873,11 +873,30 @@ def make_app(destination, app_name, no_git=False):
 
 @click.command("init-frappe-ui")
 def init_frappe_ui():
-	click.secho("Please fill the details", fg="green")
 	from frappe.utils.boilerplate import _get_app_info
 
 	info = _get_app_info()
-	create_frappe_ui_template(info)
+	if validate_if_app_is_installed(info.app_name):
+		create_frappe_ui_template(info)
+
+
+def validate_if_app_is_installed(app_name):
+	from frappe.utils import get_bench_path
+
+	app_not_installed = False
+	out = subprocess.check_output(
+		["bench", "--site", "all", "list-apps", "--format", "json"],
+		stderr=open(os.devnull, "wb"),
+		cwd=get_bench_path(),
+	).decode("utf-8")
+	apps_sites_dict = json.loads(out)
+	for apps in apps_sites_dict.values():
+		if app_name in apps:
+			app_not_installed = True
+	if not app_not_installed:
+		click.secho(f"Cannot setup frappe-ui. Install the app {app_name} on a site", fg="red")
+		return False
+	return app_not_installed
 
 
 def create_frappe_ui_template(info):

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -925,12 +925,39 @@ def create_frappe_ui_template(info):
 			text=True,
 		)
 		if result.returncode == 0:
+			make_frappe_ui_boilerplate(app_path, info)
 			click.secho(f"Frappe UI is setup for the app {info.app_name} ", fg="green")
 		else:
 			click.secho("Something went wrong while fetching the template", fg="red")
 			print(result.stderr)
 	except ModuleNotFoundError:
 		click.secho(f"App {info.app_name} does not exist", fg="red")
+
+
+def make_frappe_ui_boilerplate(app_path, data):
+	boilerplate_path = os.path.join(app_path, "frontend", "boilerplate")
+	target_directory_map = {
+		"vite.config.js.tpl": os.path.join(app_path, "frontend"),
+		"router.ts.tpl": os.path.join(app_path, "frontend", "src"),
+	}
+	if os.path.exists(boilerplate_path):
+		for file in os.listdir(boilerplate_path):
+			make_boilerplate(boilerplate_path, file, target_directory_map[file], data)
+
+
+def make_boilerplate(boilerplate_path, file_name, target_directory, data):
+	from string import Template
+
+	target_file_name = file_name.replace(".tpl", "")
+	target_file_path = os.path.join(target_directory, target_file_name)
+	boilerplate_file_path = os.path.join(boilerplate_path, file_name)
+	template_content = None
+	with open(boilerplate_file_path) as source:
+		template_content = Template(source.read())
+
+	custom_content = template_content.substitute(app_name=data["app_name"], app_route=data["route"])
+	with open(target_file_path, "w") as target:
+		target.write(custom_content)
 
 
 @click.command("create-patch")

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -880,6 +880,26 @@ def init_frontend(starter_template_repo):
 	info = _get_app_info()
 	if validate_if_app_is_installed(info.app_name):
 		create_frontend_template(info, starter_template_repo)
+		add_files_for_production_build(info)
+
+
+def add_files_for_production_build(info):
+	app_path = frappe.get_app_path(info.app_name)
+	www_folder = os.path.join(app_path, "www")
+	context_file = os.path.join(www_folder, f"{info.app_name}.py")
+	content = """import frappe
+
+def get_context(context):
+	context.boot = get_boot()
+	return context
+
+def get_boot():
+	boot = frappe._dict()
+	boot.csrf_token = frappe.sessions.get_csrf_token()
+	return boot
+ """
+	with open(context_file, "w") as f:
+		f.write(content)
 
 
 def get_apps_site_map():

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import subprocess
 import sys
 import typing
@@ -902,8 +903,6 @@ def validate_if_app_is_installed(app_name):
 def create_frappe_ui_template(info):
 	template_url = "sokumon/frappe-ui-starter"
 	template_dir = "frontend"
-	import os
-	import shutil
 
 	try:
 		app_path = os.path.dirname(frappe.get_app_path(info.app_name))
@@ -939,10 +938,12 @@ def make_frappe_ui_boilerplate(app_path, data):
 	target_directory_map = {
 		"vite.config.js.tpl": os.path.join(app_path, "frontend"),
 		"router.ts.tpl": os.path.join(app_path, "frontend", "src"),
+		"package.json.tpl": app_path,
 	}
 	if os.path.exists(boilerplate_path):
 		for file in os.listdir(boilerplate_path):
 			make_boilerplate(boilerplate_path, file, target_directory_map[file], data)
+	shutil.rmtree(boilerplate_path)
 
 
 def make_boilerplate(boilerplate_path, file_name, target_directory, data):

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -872,13 +872,14 @@ def make_app(destination, app_name, no_git=False):
 	make_boilerplate(destination, app_name, no_git=no_git)
 
 
-@click.command("init-frappe-ui")
-def init_frappe_ui():
+@click.command("create-ui")
+@click.argument("starter_template_repo")
+def init_frontend(starter_template_repo):
 	from frappe.utils.boilerplate import _get_app_info
 
 	info = _get_app_info()
 	if validate_if_app_is_installed(info.app_name):
-		create_frappe_ui_template(info)
+		create_frontend_template(info, starter_template_repo)
 
 
 def get_apps_site_map():
@@ -904,10 +905,9 @@ def validate_if_app_is_installed(app_name):
 	return app_not_installed
 
 
-def create_frappe_ui_template(info):
-	template_url = "sokumon/frappe-ui-starter"
+def create_frontend_template(info, starter_template_repo):
+	template_url = starter_template_repo
 	template_dir = "frontend"
-	info.app_publisher = frappe.get_hooks(hook="app_publisher", app_name=info.app_name)[0]
 	try:
 		app_path = os.path.dirname(frappe.get_app_path(info.app_name))
 		os.chdir(app_path)
@@ -915,7 +915,7 @@ def create_frappe_ui_template(info):
 			if click.confirm(f"Looks like there already is a {template_dir} dir, Do you want to delete it"):
 				shutil.rmtree(os.path.join(app_path, template_dir))
 				click.echo("Restarting initializing")
-				create_frappe_ui_template(info)
+				create_frontend_template(info, starter_template_repo)
 			else:
 				click.echo(f"Delete the {template_dir} in apps/{info.app_name} directory to continue")
 			return
@@ -928,7 +928,7 @@ def create_frappe_ui_template(info):
 			text=True,
 		)
 		if result.returncode == 0:
-			make_frappe_ui_boilerplate(app_path, info)
+			run_boilderplate_commands(app_path, info)
 			click.secho(f"Frappe UI is setup for the app {info.app_name} ", fg="green")
 			next_steps = [
 				f"Navigate to bench/apps/{info.app_name}/{template_dir}",
@@ -944,35 +944,23 @@ def create_frappe_ui_template(info):
 		click.secho(f"App {info.app_name} does not exist", fg="red")
 
 
-def make_frappe_ui_boilerplate(app_path, data):
-	boilerplate_path = os.path.join(app_path, "frontend", "boilerplate")
-	target_directory_map = {
-		"vite.config.js.tpl": os.path.join(app_path, "frontend"),
-		"router.ts.tpl": os.path.join(app_path, "frontend", "src"),
-		"package.json.tpl": app_path,
-		"Home.vue.tpl": os.path.join(app_path, "frontend", "src", "pages"),
-	}
-	if os.path.exists(boilerplate_path):
-		for file in os.listdir(boilerplate_path):
-			make_boilerplate(boilerplate_path, file, target_directory_map[file], data)
-	shutil.rmtree(boilerplate_path)
-
-
-def make_boilerplate(boilerplate_path, file_name, target_directory, data):
-	from string import Template
-
-	target_file_name = file_name.replace(".tpl", "")
-	target_file_path = os.path.join(target_directory, target_file_name)
-	boilerplate_file_path = os.path.join(boilerplate_path, file_name)
-	template_content = None
-	with open(boilerplate_file_path) as source:
-		template_content = Template(source.read())
-
-	custom_content = template_content.substitute(
-		app_name=data["app_name"], app_route=data["route"], app_publisher=data["app_publisher"]
-	)
-	with open(target_file_path, "w") as target:
-		target.write(custom_content)
+def run_boilderplate_commands(app_path, info):
+	print(app_path)
+	package_json_path = os.path.join(app_path, "frontend", "package.json")
+	if os.path.exists(package_json_path):
+		package_json_content = None
+		with open(package_json_path) as f:
+			package_json_content = json.loads(f.read())
+		try:
+			boilerplate_script = package_json_content["boilerplate_script"]
+		except KeyError:
+			click.secho("No boilerplate commands found in package.json", fg="yellow")
+			return
+		subprocess.run(
+			["node", boilerplate_script, info.app_name],
+			cwd=os.path.join(app_path, "frontend"),
+		)
+		os.remove(os.path.join(app_path, "frontend", boilerplate_script))
 
 
 @click.command("create-patch")
@@ -1174,5 +1162,5 @@ commands = [
 	rebuild_global_search,
 	list_sites,
 	setup_chrome,
-	init_frappe_ui,
+	init_frontend,
 ]

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -871,6 +871,39 @@ def make_app(destination, app_name, no_git=False):
 	make_boilerplate(destination, app_name, no_git=no_git)
 
 
+@click.command("init-frappe-ui")
+def init_frappe_ui():
+	click.secho("Please fill the details", fg="green")
+	from frappe.utils.boilerplate import _get_app_info
+
+	info = _get_app_info()
+	create_frappe_ui_template(info)
+
+
+def create_frappe_ui_template(info):
+	template_url = "sokumon/frappe-ui-starter"
+	import os
+
+	try:
+		app_path = os.path.dirname(frappe.get_app_path(info.app_name))
+		os.chdir(app_path)
+		command = f"npx degit {template_url} frontend"
+		result = subprocess.run(
+			command,
+			shell=True,
+			stdout=subprocess.PIPE,
+			stderr=subprocess.DEVNULL,
+			text=True,
+		)
+		if result.returncode == 0:
+			click.secho(f"Frappe UI is setup for the app {info.app_name} ", fg="green")
+		else:
+			click.secho("Something went wrong while fetching the template", fg="red")
+			print(result.stderr)
+	except ModuleNotFoundError:
+		click.secho(f"App {info.app_name} does not exist", fg="red")
+
+
 @click.command("create-patch")
 def create_patch():
 	"Creates a new patch interactively"
@@ -1070,4 +1103,5 @@ commands = [
 	rebuild_global_search,
 	list_sites,
 	setup_chrome,
+	init_frappe_ui,
 ]

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -106,6 +106,7 @@ def _get_app_info():
 				if not validator_function(value):
 					value = None
 		hooks[property] = value
+	hooks.app_publisher = frappe.get_hooks(hook="app_publisher", app_name=hooks.app_name)[0]
 	return hooks
 
 

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -79,6 +79,36 @@ def _get_user_inputs(app_name):
 	return hooks
 
 
+def _get_app_info():
+	hooks = frappe._dict()
+	new_app_config = {
+		"app_name": {
+			"prompt": "App Name",
+			"validator": is_valid_title,
+		},
+		"route": {"prompt": "Frontend to be hosted at", "get_default": "app_name"},
+	}
+
+	for property, config in new_app_config.items():
+		value = None
+		input_type = config.get("type", str)
+
+		while value is None:
+			default_value = config.get("default")
+			if config.get("get_default"):
+				default_value = f"/{hooks[config.get('get_default')]}"
+			if input_type is bool:
+				value = click.confirm(config["prompt"], default=default_value)
+			else:
+				value = click.prompt(config["prompt"], default=default_value, type=input_type)
+
+			if validator_function := config.get("validator"):
+				if not validator_function(value):
+					value = None
+		hooks[property] = value
+	return hooks
+
+
 def is_valid_email(email) -> bool:
 	from email.headerregistry import Address
 

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -80,13 +80,21 @@ def _get_user_inputs(app_name):
 
 
 def _get_app_info():
+	import questionary
+
+	from frappe.utils import get_bench_path
+
 	hooks = frappe._dict()
+
+	def get_apps():
+		if os.path.exists(os.path.join(get_bench_path(), "sites", "apps.txt")):
+			with open(os.path.join(get_bench_path(), "sites", "apps.txt")) as f:
+				return [app.strip() for app in f.readlines() if app.strip()]
+
+	app_name = questionary.select("App Name", qmark="", choices=get_apps()).ask()
+	hooks.app_name = app_name
 	new_app_config = {
-		"app_name": {
-			"prompt": "App Name",
-			"validator": is_valid_title,
-		},
-		"route": {"prompt": "Frontend to be hosted at", "get_default": "app_name"},
+		"route": {"prompt": "Frontend to be hosted at", "default": f"/{app_name}"},
 	}
 
 	for property, config in new_app_config.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dependencies = [
     "vobject~=0.9.9",
     "pycountry~=24.6.1",
     "websockets~=15.0.1",
+    "questionary"
 ]
 
 [project.urls]


### PR DESCRIPTION
Frappe UI and Framework meet atlast :) 

Todos

- [x] Make the starter delightful, its very boring right now. 
- [x] Move starter to frappe repo
- [x] Need to create boilerplate out of router.ts, vite.config.js finding best way to do that
- [ ] Show CRUD in template
- [ ] Make UX better
- [x] Generate files for production
- [ ] Add this in new app flow

Starter Repo
https://github.com/frappe/frappe-ui-starter
Here I am using boilerplate/ folder to generate some special files customized to that app and its app publisher
This might be too complicated but its the only way to write JS files from Python. It allows me to personalize the tempalte making it delightful

New Template 
<img width="1440" height="900" alt="Screenshot 2026-01-30 at 2 09 59 PM" src="https://github.com/user-attachments/assets/37ba770a-bb75-4b07-8008-07c7b3f2d8a6" />
Will tweak the copy and some components in this. The point of this template to show off our beautiful components 

Usage
`bench create-ui frappe/frappe-ui-starter`

`no-docs` as of now will update it later