### PR TITLE
fix(query): fix ifnull fallback in postgres

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1622,8 +1622,8 @@ class Engine:
 						& (columns.table_schema == current_schema)
 					)
 				).run(pluck=True)
-				db_type = res[0] if res else None
-				if db_type in ("smallint", "bigint", "int", "numeric"):  # can add as needed
+				data_type = res[0] if res else None
+				if data_type in ("smallint", "bigint", "int", "numeric"):  # can add as needed
 					return "0"
 			return "''"
 

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1607,6 +1607,24 @@ class Engine:
 			meta = frappe.get_meta(doctype)
 			df = meta.get_field(fieldname)
 		except Exception:
+			if frappe.db.db_type == "postgres":
+				"""check type and accordingly choose fallback (to avoid postgres type cast errors)"""
+				target_table = frappe.utils.get_table_name(doctype)
+				info_schema = frappe.qb.Schema("information_schema")
+				columns = info_schema.columns
+				current_schema = frappe.conf.get("db_schema", "public")
+				res = (
+					frappe.qb.from_(columns)
+					.select(columns.data_type)
+					.where(
+						(columns.table_name == target_table)
+						& (columns.column_name == fieldname)
+						& (columns.table_schema == current_schema)
+					)
+				).run(pluck=True)
+				db_type = res[0] if res else None
+				if db_type in ("smallint", "bigint", "int", "numeric"):  # can add as needed
+					return "0"
 			return "''"
 
 		if df is None:

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -2289,6 +2289,15 @@ class TestQuery(IntegrationTestCase):
 		# the filter should still apply and return no results
 		self.assertEqual(len(result), 0, "Filter should not be bypassed by shared doc OR condition")
 
+	@run_only_if(db_type_is.POSTGRES)
+	def test_ifnull_fallback_postgres(self):
+		"""Test ifnull fallback in postgres"""
+		from frappe.database.query import Engine
+
+		engine = Engine()
+		self.assertEqual(engine._get_ifnull_fallback("Patch Log", "skipped"), "0")
+		self.assertEqual(engine._get_ifnull_fallback("Patch Log", "patch"), "''")
+
 
 # This function is used as a permission query condition hook
 def test_permission_hook_condition(user):


### PR DESCRIPTION
fix(query): This PR is a direct resolution to the problem occurring in issue #36136 with regards to the `ifnull` fallback. This PR is a step forward towards resolving #21613 and completes a part of the Postgres TODO #34660 . 

**Before**:
```python
Error in query:
invalid input syntax for type smallint: ""
LINE 1: ...tch" FROM "tabPatch Log" WHERE coalesce("skipped",'')= '0' O...
                                                             ^
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type smallint: ""
```

**After**:
Correct fallback is applied by checking the column type and choosing accordingly

<img width="1712" height="252" alt="image" src="https://github.com/user-attachments/assets/0cf5f7f6-f292-45f8-a975-eeaa9b472f87" />

<img width="1712" height="252" alt="image" src="https://github.com/user-attachments/assets/fa822311-83db-4971-9848-18aaf72e4d61" />












resolves #36136 