### PR TITLE
fix(docfield): word break for description

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -420,6 +420,7 @@
 	margin-top: 4px;
 	margin-bottom: 8px;
 	line-height: 1.6;
+	word-break: break-word;
 }
 
 .form-heatmap {


### PR DESCRIPTION
Fixed the issue where the long URLs overflow in the DocField Description.

Before:

<img width="1242" height="134" alt="image" src="https://github.com/user-attachments/assets/2a7892ee-c0f8-40cf-b4a6-0b6b21bb7018" />


After:

<img width="922" height="370" alt="image" src="https://github.com/user-attachments/assets/eb0cb698-698e-455c-8bea-457443ef2c42" />
