### PR TITLE
refactor!: Remove UUID Utils library

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -6,10 +6,8 @@ import datetime
 import re
 import time
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Optional
-from uuid import UUID
-
-import uuid_utils
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid7
 
 import frappe
 from frappe import _
@@ -166,8 +164,8 @@ def set_new_name(doc):
 
 	if meta.autoname == "UUID":
 		if not doc.name:
-			doc.name = str(uuid_utils.uuid7())
-		elif isinstance(doc.name, UUID | uuid_utils.UUID):
+			doc.name = str(uuid7())
+		elif isinstance(doc.name, UUID):
 			doc.name = str(doc.name)
 		elif isinstance(doc.name, str):  # validate
 			try:

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -2,9 +2,9 @@
 # License: MIT. See LICENSE
 
 import time
+import uuid
 from uuid import UUID
 
-import uuid_utils
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_full_jitter
 
 import frappe
@@ -430,12 +430,12 @@ class TestNaming(IntegrationTestCase):
 		self.assertEqual(uid.version, 7)  # Default version
 
 		# Applications can specify UUID themselves, useful for APIs to set name themselves.
-		for uid in (uuid_utils.uuid4(), uuid_utils.uuid7()):
+		for uid in (uuid.uuid4(), uuid.uuid7()):
 			doc = frappe.new_doc(uuid_doctype, name=uid).insert()
 			self.assertEqual(doc.name, str(uid))
 
 		# Can specify valid UUID strings too
-		for uid in (uuid_utils.uuid4(), uuid_utils.uuid7()):
+		for uid in (uuid.uuid4(), uuid.uuid7()):
 			doc = frappe.new_doc(uuid_doctype, name=str(uid)).insert()
 			self.assertEqual(doc.name, str(uid))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ dependencies = [
     "terminaltables~=3.1.10",
     "traceback-with-variables~=2.2.1",
     "typing_extensions>=4.15.0,<5",
-    "uuid-utils~=0.12.0",
     "xlrd~=2.0.2",
     "zxcvbn~=4.5.0",
     "markdownify~=1.2.2",


### PR DESCRIPTION
potentially minor breaking change - removal of a default dependency.

py3.14 adds support for uuidv7, so we no longer need third party lib.
