### PR TITLE
fix: rename get_sidebar_items in help_article to avoid naming conflict

### DIFF
--- a/frappe/website/doctype/help_article/help_article.py
+++ b/frappe/website/doctype/help_article/help_article.py
@@ -61,7 +61,7 @@ class HelpArticle(WebsiteGenerator):
 		context.level_class = get_level_class(self.level)
 		context.comment_list = get_comment_list(self.doctype, self.name)
 		context.show_sidebar = True
-		context.sidebar_items = get_sidebar_items()
+		context.sidebar_items = get_help_article_sidebar_items()
 		context.parents = self.get_parents(context)
 
 	def get_parents(self, context):
@@ -80,7 +80,7 @@ def get_list_context(context=None):
 		title=category or _("Knowledge Base"),
 		get_level_class=get_level_class,
 		show_sidebar=True,
-		sidebar_items=get_sidebar_items(),
+		sidebar_items=get_help_article_sidebar_items(),
 		hide_filters=True,
 		filters=filters,
 		category=frappe.local.form_dict.category,
@@ -98,7 +98,7 @@ def get_level_class(level):
 	return {"Beginner": "green", "Intermediate": "orange", "Expert": "red"}[level]
 
 
-def get_sidebar_items():
+def get_help_article_sidebar_items():
 	def _get():
 		return frappe.db.sql(
 			"""select


### PR DESCRIPTION
## Description

Fixes a TypeError that occurs when creating custom workspaces due to a function naming conflict.

## Problem

Creating a custom workspace from the UI results in the following error:

TypeError: get_sidebar_items() takes 0 positional arguments but 1 was given

### Root Cause

Two functions share the same name:

- get_sidebar_items(allowed_workspaces) in frappe/boot.py
- get_sidebar_items() in frappe/website/doctype/help_article/help_article.py

Due to Python’s module resolution, the wrong function can be imported, causing the workspace creation flow to fail when get_sidebar_items(workspaces) is called.

## Solution

Renamed the help article sidebar function to avoid the naming collision.

## Changes Made

- Renamed get_sidebar_items() to get_help_article_sidebar_items()
- Updated all references (2 occurrences)
- No changes to frappe.boot.get_sidebar_items

## Files Modified

- frappe/website/doctype/help_article/help_article.py

Closes #36210