### PR TITLE
fix: add a command resync icons

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -1583,31 +1583,34 @@ def bypass_patch(context: CliCtxObj, patch_name: str, yes: bool):
 			frappe.destroy()
 
 
-@click.command("create-desktop-icons-and-sidebar")
+@click.command("sync-desktop-icons")
 @pass_context
-def create_icons_and_sidebar(context: CliCtxObj):
-	"""Create desktop icons and workspace sidebars."""
-	from frappe.desk.doctype.desktop_icon.desktop_icon import create_desktop_icons
-	from frappe.desk.doctype.workspace_sidebar.workspace_sidebar import (
-		create_workspace_sidebar_for_workspaces,
-	)
+def sync_desktop_icons(context: CliCtxObj):
+	from frappe.model.sync import import_file_by_path
+	from frappe.modules.utils import get_app_level_directory_path
+	from frappe.utils import update_progress_bar
 
-	if not context.sites:
-		raise SiteNotSpecifiedError
+	files = []
+	app_level_folders = ["desktop_icon"]
 	for site in context.sites:
+		print("Sycning icons for " + site)
 		frappe.init(site)
 		frappe.connect()
-		try:
-			print("Creating Desktop Icons")
-			create_desktop_icons()
-			print("Creating Workspace Sidebars")
-			create_workspace_sidebar_for_workspaces()
-			# Saving it in a command need it
-			frappe.db.commit()  # nosemgrep
-		except Exception as e:
-			print(f"Error creating icons {site}: {e}")
-		finally:
-			frappe.destroy()
+		for app_name in frappe.get_installed_apps():
+			for folder_name in app_level_folders:
+				directory_path = get_app_level_directory_path(folder_name, app_name)
+				if os.path.exists(directory_path):
+					icon_files = [
+						os.path.join(directory_path, filename) for filename in os.listdir(directory_path)
+					]
+					for doc_path in icon_files:
+						files.append(doc_path)
+		for i, doc_path in enumerate(files):
+			imported = import_file_by_path(doc_path, force=True, ignore_version=True)
+			if imported:
+				frappe.db.commit(chain=True)
+
+			update_progress_bar("Updating Desktop Icons", i, len(files))
 
 
 commands = [
@@ -1646,5 +1649,5 @@ commands = [
 	trim_database,
 	clear_log_table,
 	bypass_patch,
-	create_icons_and_sidebar,
+	sync_desktop_icons,
 ]


### PR DESCRIPTION
Consider this followiing scenario

You want to edit desktop icons. You are on branch `edit-standard-icon-layout` where you make a layout. To validate if the navigation as actually improved you want to go back to develop where the original layout for the app is. When you migrate nothing happens cause no timestamp has changed

So introducing this command so icons can be synced on demand. This is temporary in nature. Investigating problems with migrate. 


Command usage
`bench --site erpnext.site sync-desktop-icons`