### PR TITLE
feat(core) : send email when user is impersonated

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -3,6 +3,7 @@
 
 from collections.abc import Iterable
 from datetime import timedelta
+from functools import cached_property
 
 import frappe
 import frappe.defaults
@@ -33,7 +34,6 @@ from frappe.utils import (
 	today,
 )
 from frappe.utils.data import sha256_hash
-from frappe.utils.deprecations import deprecated
 from frappe.utils.html_utils import sanitize_html
 from frappe.utils.password import check_password, get_password_reset_limit
 from frappe.utils.password import update_password as _update_password
@@ -48,6 +48,7 @@ desk_properties = (
 	"bulk_actions",
 	"view_switcher",
 	"form_sidebar",
+	"form_navigation_buttons",
 	"timeline",
 	"dashboard",
 )
@@ -64,9 +65,12 @@ class User(Document):
 		from frappe.core.doctype.defaultvalue.defaultvalue import DefaultValue
 		from frappe.core.doctype.has_role.has_role import HasRole
 		from frappe.core.doctype.user_email.user_email import UserEmail
+		from frappe.core.doctype.user_role_profile.user_role_profile import UserRoleProfile
+		from frappe.core.doctype.user_session_display.user_session_display import UserSessionDisplay
 		from frappe.core.doctype.user_social_login.user_social_login import UserSocialLogin
 		from frappe.types import DF
 
+		active_sessions: DF.Table[UserSessionDisplay]
 		allowed_in_mentions: DF.Check
 		api_key: DF.Data | None
 		api_secret: DF.Password | None
@@ -76,6 +80,7 @@ class User(Document):
 		block_modules: DF.Table[BlockModule]
 		bulk_actions: DF.Check
 		bypass_restrict_ip_check_if_2fa_enabled: DF.Check
+		code_editor_type: DF.Literal["vscode", "vim", "emacs"]
 		dashboard: DF.Check
 		default_app: DF.Literal[None]
 		default_workspace: DF.Link | None
@@ -84,7 +89,7 @@ class User(Document):
 		document_follow_frequency: DF.Literal["Hourly", "Daily", "Weekly"]
 		document_follow_notify: DF.Check
 		email: DF.Data
-		email_signature: DF.SmallText | None
+		email_signature: DF.TextEditor | None
 		enabled: DF.Check
 		first_name: DF.Data
 		follow_assigned_documents: DF.Check
@@ -92,6 +97,7 @@ class User(Document):
 		follow_created_documents: DF.Check
 		follow_liked_documents: DF.Check
 		follow_shared_documents: DF.Check
+		form_navigation_buttons: DF.Check
 		form_sidebar: DF.Check
 		full_name: DF.Data | None
 		gender: DF.Link | None
@@ -122,10 +128,12 @@ class User(Document):
 		reset_password_key: DF.Data | None
 		restrict_ip: DF.SmallText | None
 		role_profile_name: DF.Link | None
+		role_profiles: DF.TableMultiSelect[UserRoleProfile]
 		roles: DF.Table[HasRole]
 		search_bar: DF.Check
 		send_me_a_copy: DF.Check
 		send_welcome_email: DF.Check
+		show_absolute_datetime_in_timeline: DF.Check
 		simultaneous_sessions: DF.Int
 		social_logins: DF.Table[UserSocialLogin]
 		thread_notify: DF.Check
@@ -138,7 +146,43 @@ class User(Document):
 		username: DF.Data | None
 		view_switcher: DF.Check
 	# end: auto-generated types
+
 	__new_password = None
+
+	@cached_property
+	def active_sessions(self):
+		sessions = frappe.qb.DocType("Sessions")
+		if self.name != frappe.session.user:
+			# sec: only allow users to see their sessions.
+			return []
+
+		sessions_data = (
+			frappe.qb.from_(sessions)
+			.select(sessions.user, sessions.sessiondata, sessions.sid)
+			.where(sessions.user == self.name)
+		).run(as_dict=True)
+
+		def mask(sid: str):
+			return sid[:4] + "*" * 10
+
+		session_docs = []
+		for session in sessions_data:
+			data = frappe.parse_json(session.sessiondata)
+			sid_hash = sha256_hash(session.sid)
+			session_docs.append(
+				{
+					"name": sid_hash,
+					"id": mask(sid_hash),
+					"owner": session.user,
+					"modified_by": session.user,
+					"ip_address": data.session_ip,
+					"last_updated": data.last_updated,
+					"is_current": session.sid == frappe.session.sid,
+					"session_created": data.creation,
+					"user_agent": data.user_agent,
+				}
+			)
+		return session_docs
 
 	def __setup__(self):
 		# because it is handled separately
@@ -153,7 +197,7 @@ class User(Document):
 			self.name = self.email
 
 	def onload(self):
-		from frappe.config import get_modules_from_all_apps
+		from frappe.utils.modules import get_modules_from_all_apps
 
 		self.set_onload("all_modules", sorted(m.get("module_name") for m in get_modules_from_all_apps()))
 
@@ -171,13 +215,14 @@ class User(Document):
 		self.__new_password = self.new_password
 		self.new_password = ""
 
-		if not frappe.flags.in_test:
+		if not frappe.in_test:
 			self.password_strength_test()
 
 		if self.name not in STANDARD_USERS:
 			self.email = self.name
 			self.validate_email_type(self.name)
 
+		self.move_role_profile_name_to_role_profiles()
 		self.populate_role_profile_roles()
 		self.check_roles_added()
 		self.set_system_user()
@@ -185,14 +230,18 @@ class User(Document):
 		self.set_full_name()
 		self.check_enable_disable()
 		self.ensure_unique_roles()
+		self.ensure_unique_role_profiles()
 		self.remove_all_roles_for_guest()
 		self.validate_username()
 		self.remove_disabled_roles()
 		self.validate_user_email_inbox()
-		ask_pass_update()
+		if self.user_emails:
+			ask_pass_update()
 		self.validate_allowed_modules()
 		self.validate_user_image()
 		self.set_time_zone()
+		if self.restrict_ip:
+			self.validate_ip_addr()
 
 		if self.language == "Loading...":
 			self.language = None
@@ -200,15 +249,51 @@ class User(Document):
 		if (self.name not in ["Administrator", "Guest"]) and (not self.get_social_login_userid("frappe")):
 			self.set_social_login_userid("frappe", frappe.generate_hash(length=39))
 
-	def populate_role_profile_roles(self):
-		if self.role_profile_name:
-			role_profile = frappe.get_doc("Role Profile", self.role_profile_name)
-			self.set("roles", [])
-			self.append_roles(*[role.role for role in role_profile.roles])
+	def disable_email_fields_if_user_disabled(self):
+		if not self.enabled:
+			self.thread_notify = 0
+			self.send_me_a_copy = 0
+			self.allowed_in_mentions = 0
 
-	@deprecated
-	def validate_roles(self):
-		self.populate_role_profile_roles()
+	@frappe.whitelist()
+	def populate_role_profile_roles(self):
+		if not self.role_profiles:
+			return
+
+		if self.name in STANDARD_USERS:
+			self.role_profiles = []
+			return
+
+		new_roles = set()
+		for role_profile in self.role_profiles:
+			role_profile = frappe.get_cached_doc("Role Profile", role_profile.role_profile)
+			new_roles.update(role.role for role in role_profile.roles)
+
+		# Remove invalid roles and add new ones
+		self.roles = [r for r in self.roles if r.role in new_roles]
+		self.append_roles(*new_roles)
+
+	def move_role_profile_name_to_role_profiles(self):
+		"""This handles old role_profile_name field if programatically set.
+
+		This behaviour will be remoed in future versions."""
+		if not self.role_profile_name:
+			return
+
+		current_role_profiles = [r.role_profile for r in self.role_profiles]
+		if self.role_profile_name in current_role_profiles:
+			self.role_profile_name = None
+			return
+
+		from frappe.deprecation_dumpster import deprecation_warning
+
+		deprecation_warning(
+			"unknown",
+			"v16",
+			"The field `role_profile_name` is deprecated and will be removed in v16, use `role_profiles` child table instead.",
+		)
+		self.append("role_profiles", {"role_profile": self.role_profile_name})
+		self.role_profile_name = None
 
 	def validate_allowed_modules(self):
 		if self.module_profile:
@@ -226,7 +311,7 @@ class User(Document):
 		self.share_with_self()
 		clear_notifications(user=self.name)
 		frappe.clear_cache(user=self.name)
-		now = frappe.flags.in_test or frappe.flags.in_install
+		now = frappe.in_test or frappe.flags.in_install
 		self.send_password_notification(self.__new_password)
 		frappe.enqueue(
 			"frappe.core.doctype.user.user.create_contact",
@@ -248,6 +333,18 @@ class User(Document):
 		if self.time_zone:
 			frappe.defaults.set_default("time_zone", self.time_zone, self.name)
 
+		if self.has_value_changed("language"):
+			locale_keys = ("date_format", "time_format", "number_format", "first_day_of_the_week")
+			if self.language:
+				language = frappe.get_doc("Language", self.language)
+				for key in locale_keys:
+					value = language.get(key)
+					if value:
+						frappe.defaults.set_default(key, value, self.name)
+			else:
+				for key in locale_keys:
+					frappe.defaults.clear_default(key, parent=self.name)
+
 		if self.has_value_changed("enabled"):
 			frappe.cache.delete_key("users_for_mentions")
 			frappe.cache.delete_key("enabled_users")
@@ -255,7 +352,7 @@ class User(Document):
 			frappe.cache.delete_key("users_for_mentions")
 
 	def has_website_permission(self, ptype, user, verbose=False):
-		"""Returns true if current user is the session user"""
+		"""Return True if current user is the session user."""
 		return self.name == frappe.session.user
 
 	def clean_name(self):
@@ -276,7 +373,8 @@ class User(Document):
 			frappe.local.login_manager.logout(user=self.name)
 
 		# toggle notifications based on the user's status
-		toggle_notifications(self.name, enable=cint(self.enabled))
+		toggle_notifications(self.name, enable=cint(self.enabled), ignore_permissions=True)
+		self.disable_email_fields_if_user_disabled()
 
 	def email_new_password(self, new_password=None):
 		if new_password and not self.flags.in_insert:
@@ -459,7 +557,7 @@ class User(Document):
 		if custom_template:
 			from frappe.email.doctype.email_template.email_template import get_email_template
 
-			email_template = get_email_template(custom_template, args)
+			email_template = get_email_template(custom_template, args, sender=sender)
 			subject = email_template.get("subject")
 			content = email_template.get("message")
 
@@ -499,17 +597,6 @@ class User(Document):
 
 		# delete shares
 		frappe.db.delete("DocShare", {"user": self.name})
-		# delete messages
-		table = DocType("Communication")
-		frappe.db.delete(
-			table,
-			filters=(
-				(table.communication_type.isin(["Chat", "Notification"]))
-				& (table.reference_doctype == "User")
-				& ((table.reference_name == self.name) | table.owner == self.name)
-			),
-			run=False,
-		)
 		# unlink contact
 		table = DocType("Contact")
 		frappe.qb.update(table).where(table.user == self.name).set(table.user, None).run()
@@ -528,9 +615,6 @@ class User(Document):
 		# Delete OAuth data
 		frappe.db.delete("OAuth Authorization Code", {"user": self.name})
 		frappe.db.delete("Token Cache", {"user": self.name})
-
-		# Delete EPS data
-		frappe.db.delete("Energy Point Log", {"user": self.name})
 
 		# Remove user link from Workflow Action
 		frappe.db.set_value("Workflow Action", {"user": self.name}, "user", None)
@@ -598,7 +682,7 @@ class User(Document):
 
 	def append_roles(self, *roles):
 		"""Add roles to user"""
-		current_roles = [d.role for d in self.get("roles")]
+		current_roles = {d.role for d in self.get("roles")}
 		for role in roles:
 			if role in current_roles:
 				continue
@@ -607,6 +691,7 @@ class User(Document):
 	def add_roles(self, *roles):
 		"""Add roles to user and save"""
 		self.append_roles(*roles)
+		# test_user_permission.create_user depends on this
 		self.save()
 
 	def remove_roles(self, *roles):
@@ -628,12 +713,18 @@ class User(Document):
 				self.get("roles").remove(role)
 
 	def ensure_unique_roles(self):
-		exists = []
-		for d in self.get("roles"):
+		exists = set()
+		for d in list(self.roles):
 			if (not d.role) or (d.role in exists):
-				self.get("roles").remove(d)
-			else:
-				exists.append(d.role)
+				self.roles.remove(d)
+			exists.add(d.role)
+
+	def ensure_unique_role_profiles(self):
+		seen = set()
+		for rp in list(self.role_profiles):
+			if rp.role_profile in seen:
+				self.role_profiles.remove(rp)
+			seen.add(rp.role_profile)
 
 	def validate_username(self):
 		if not self.username and self.is_new() and self.first_name:
@@ -688,7 +779,7 @@ class User(Document):
 		return frappe.db.get_value("User", {"username": username or self.username, "name": ("!=", self.name)})
 
 	def get_blocked_modules(self):
-		"""Returns list of modules blocked for that user"""
+		"""Return list of modules blocked for that user."""
 		return [d.module for d in self.block_modules] if self.block_modules else []
 
 	def validate_user_email_inbox(self):
@@ -727,12 +818,8 @@ class User(Document):
 		3. If allow_login_using_user_name is set, you can use username while finding the user.
 		"""
 
-		login_with_mobile = cint(
-			frappe.db.get_single_value("System Settings", "allow_login_using_mobile_number")
-		)
-		login_with_username = cint(
-			frappe.db.get_single_value("System Settings", "allow_login_using_user_name")
-		)
+		login_with_mobile = cint(frappe.get_system_settings("allow_login_using_mobile_number"))
+		login_with_username = cint(frappe.get_system_settings("allow_login_using_user_name"))
 
 		or_filters = [{"name": user_name}]
 		if login_with_mobile:
@@ -758,6 +845,9 @@ class User(Document):
 		if not self.time_zone:
 			self.time_zone = get_system_timezone()
 
+	def get_permission_log_options(self, event=None):
+		return {"fields": ("role_profile_name", "roles", "module_profile", "block_modules")}
+
 	def check_roles_added(self):
 		if self.user_type != "System User" or self.roles or not self.is_new():
 			return
@@ -773,12 +863,15 @@ class User(Document):
 			},
 		)
 
+	def validate_ip_addr(self):
+		self.restrict_ip = ",".join(self.get_restricted_ip_list())
+
 
 @frappe.whitelist()
 def get_timezones():
-	import pytz
+	import zoneinfo
 
-	return {"timezones": pytz.all_timezones}
+	return {"timezones": zoneinfo.available_timezones()}
 
 
 @frappe.whitelist()
@@ -786,14 +879,20 @@ def get_all_roles():
 	"""return all roles"""
 	active_domains = frappe.get_active_domains()
 
-	roles = frappe.get_all(
-		"Role",
-		filters={
-			"name": ("not in", frappe.permissions.AUTOMATIC_ROLES),
-			"disabled": 0,
-		},
-		or_filters={"ifnull(restrict_to_domain, '')": "", "restrict_to_domain": ("in", active_domains)},
-		order_by="name",
+	Role = frappe.qb.DocType("Role")
+
+	domain_condition = (Role.restrict_to_domain.isnull()) | (Role.restrict_to_domain == "")
+	if active_domains:
+		domain_condition = domain_condition | Role.restrict_to_domain.isin(active_domains)
+
+	roles = (
+		frappe.qb.from_(Role)
+		.select(Role.name)
+		.where(
+			(Role.name.notin(frappe.permissions.AUTOMATIC_ROLES)) & (Role.disabled == 0) & domain_condition
+		)
+		.orderby(Role.name)
+		.run(as_dict=True)
 	)
 
 	return sorted([role.get("name") for role in roles])
@@ -802,7 +901,7 @@ def get_all_roles():
 @frappe.whitelist()
 def get_roles(arg=None):
 	"""get roles for a user"""
-	return frappe.get_roles(frappe.form_dict["uid"])
+	return frappe.get_roles(frappe.form_dict.get("uid", frappe.session.user))
 
 
 @frappe.whitelist()
@@ -820,10 +919,10 @@ def update_password(
 	"""Update password for the current user.
 
 	Args:
-	        new_password (str): New password.
-	        logout_all_sessions (int, optional): If set to 1, all other sessions will be logged out. Defaults to 0.
-	        key (str, optional): Password reset key. Defaults to None.
-	        old_password (str, optional): Old password. Defaults to None.
+	    new_password (str): New password.
+	    logout_all_sessions (int, optional): If set to 1, all other sessions will be logged out. Defaults to 0.
+	    key (str, optional): Password reset key. Defaults to None.
+	    old_password (str, optional): Old password. Defaults to None.
 	"""
 
 	if len(new_password) > MAX_PASSWORD_SIZE:
@@ -842,9 +941,7 @@ def update_password(
 	else:
 		user = res["user"]
 
-	logout_all_sessions = cint(logout_all_sessions) or frappe.db.get_single_value(
-		"System Settings", "logout_on_password_reset"
-	)
+	logout_all_sessions = cint(logout_all_sessions) or frappe.get_system_settings("logout_on_password_reset")
 	_update_password(user, new_password, logout_all_sessions=cint(logout_all_sessions))
 
 	user_doc, redirect_url = reset_user_data(user)
@@ -863,22 +960,25 @@ def update_password(
 	frappe.db.set_value("User", user, "reset_password_key", "")
 
 	if user_doc.user_type == "System User":
-		return get_default_path() or "/app"
+		return get_default_path() or "/desk"
 	else:
 		return redirect_url or get_default_path() or get_home_page()
 
 
 @frappe.whitelist(allow_guest=True)
 def test_password_strength(new_password: str, key=None, old_password=None, user_data: tuple | None = None):
-	from frappe.utils.deprecations import deprecation_warning
 	from frappe.utils.password_strength import test_password_strength as _test_password_strength
 
 	if key is not None or old_password is not None:
+		from frappe.deprecation_dumpster import deprecation_warning
+
 		deprecation_warning(
-			"Arguments `key` and `old_password` are deprecated in function `test_password_strength`."
+			"unknown",
+			"v17",
+			"Arguments `key` and `old_password` are deprecated in function `test_password_strength`.",
 		)
 
-	enable_password_policy = frappe.get_system_settings("enable_password_policy") or 0
+	enable_password_policy = frappe.get_system_settings("enable_password_policy")
 
 	if not enable_password_policy:
 		return {}
@@ -891,7 +991,7 @@ def test_password_strength(new_password: str, key=None, old_password=None, user_
 	if new_password:
 		result = _test_password_strength(new_password, user_inputs=user_data)
 		password_policy_validation_passed = False
-		minimum_password_score = cint(frappe.get_system_settings("minimum_password_score")) or 0
+		minimum_password_score = cint(frappe.get_system_settings("minimum_password_score"))
 
 		# score should be greater than 0 and minimum_password_score
 		if result.get("score") and result.get("score") >= minimum_password_score:
@@ -921,7 +1021,10 @@ def ask_pass_update():
 	from frappe.utils import set_default
 
 	password_list = frappe.get_all(
-		"User Email", filters={"awaiting_password": 1, "used_oauth": 0}, pluck="parent", distinct=True
+		"User Email",
+		filters={"awaiting_password": 1, "used_oauth": 0},
+		pluck="parent",
+		distinct=True,
 	)
 	set_default("email_user_password", ",".join(password_list))
 
@@ -937,7 +1040,7 @@ def _get_user_for_update_password(key, old_password):
 		result.user, last_reset_password_key_generated_on = user or (None, None)
 		if result.user:
 			reset_password_link_expiry = cint(
-				frappe.db.get_single_value("System Settings", "reset_password_link_expiry_duration")
+				frappe.get_system_settings("reset_password_link_expiry_duration")
 			)
 			if (
 				reset_password_link_expiry
@@ -1037,7 +1140,7 @@ def reset_password(user: str) -> str:
 		user.reset_password(send_email=True)
 
 		return frappe.msgprint(
-			msg=_("Password reset instructions have been sent to your email"),
+			msg=_("Password reset instructions have been sent to {}'s email").format(user.full_name),
 			title=_("Password Email Sent"),
 		)
 	except frappe.DoesNotExistError:
@@ -1081,7 +1184,7 @@ def user_query(doctype, txt, searchfield, start, page_len, filters):
 
 
 def get_total_users():
-	"""Returns total no. of system users"""
+	"""Return total number of system users."""
 	return flt(
 		frappe.db.sql(
 			"""SELECT SUM(`simultaneous_sessions`)
@@ -1114,7 +1217,7 @@ def get_system_users(exclude_users: Iterable[str] | str | None = None, limit: in
 
 
 def get_active_users():
-	"""Returns No. of system users who logged in, in the last 3 days"""
+	"""Return number of system users who logged in, in the last 3 days."""
 	return frappe.db.sql(
 		"""select count(*) from `tabUser`
 		where enabled = 1 and user_type != 'Website User'
@@ -1125,16 +1228,16 @@ def get_active_users():
 
 
 def get_website_users():
-	"""Returns total no. of website users"""
+	"""Return total number of website users."""
 	return frappe.db.count("User", filters={"enabled": True, "user_type": "Website User"})
 
 
 def get_active_website_users():
-	"""Returns No. of website users who logged in, in the last 3 days"""
+	"""Return number of website users who logged in, in the last 3 days."""
 	return frappe.db.sql(
 		"""select count(*) from `tabUser`
-		where enabled = 1 and user_type = 'Website User'
-		and hour(timediff(now(), last_active)) < 72"""
+        where enabled = 1 and user_type = 'Website User'
+        and hour(timediff(now(), last_active)) < 72"""
 	)[0][0]
 
 
@@ -1151,6 +1254,7 @@ def has_permission(doc, user):
 	if (user != "Administrator") and (doc.name in STANDARD_USERS):
 		# dont allow non Administrator user to view / edit Administrator user
 		return False
+	return True
 
 
 def notify_admin_access_to_system_manager(login_manager=None):
@@ -1219,11 +1323,6 @@ def throttle_user_creation():
 
 	if frappe.db.get_creation_count("User", 60) > frappe.local.conf.get("throttle_user_limit", 60):
 		frappe.throw(_("Throttled"))
-
-
-@frappe.whitelist()
-def get_role_profile(role_profile: str):
-	return frappe.get_doc("Role Profile", {"role_profile": role_profile}).roles
 
 
 @frappe.whitelist()
@@ -1303,7 +1402,7 @@ def get_restricted_ip_list(user):
 	if not user.restrict_ip:
 		return
 
-	return [i.strip() for i in user.restrict_ip.split(",")]
+	return [i.strip() for i in user.restrict_ip.strip().split(",")]
 
 
 @frappe.whitelist(methods=["POST"])
@@ -1341,10 +1440,8 @@ def get_enabled_users():
 
 
 @frappe.whitelist(methods=["POST"])
-def impersonate(user: str, reason: str = "No reason provided"):
-	# Note: For now we only allow admins, we MIGHT allow system manager in future.
-	# All the impersonation code doesn't assume anything about user.
-    if not frappe.has_permission("User", "write"):
+def impersonate(user: str, reason: str):
+	if not frappe.has_permission("User", "write"):
         frappe.throw(_("No permission to impersonate"))
 
     impersonator = frappe.session.user
@@ -1389,3 +1486,20 @@ def impersonate(user: str, reason: str = "No reason provided"):
     )
 
     frappe.local.login_manager.impersonate(user)
+
+
+@frappe.whitelist()
+@rate_limit(limit=10, seconds=60 * 60, methods="POST")
+def clear_session(sid_hash: str):
+	from frappe.sessions import delete_session
+
+	sessions = frappe.qb.DocType("Sessions")
+	sessions_data = (
+		frappe.qb.from_(sessions).select(sessions.sid).where(sessions.user == frappe.session.user)
+	).run(pluck=True)
+
+	for session in sessions_data:
+		if sha256_hash(session) == sid_hash:
+			delete_session(sid=session, reason="Force Logged out by the user", user=frappe.session.user)
+			frappe.toast(_("Successfully signed out"))
+			return

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -3,7 +3,6 @@
 
 from collections.abc import Iterable
 from datetime import timedelta
-from functools import cached_property
 
 import frappe
 import frappe.defaults
@@ -34,6 +33,7 @@ from frappe.utils import (
 	today,
 )
 from frappe.utils.data import sha256_hash
+from frappe.utils.deprecations import deprecated
 from frappe.utils.html_utils import sanitize_html
 from frappe.utils.password import check_password, get_password_reset_limit
 from frappe.utils.password import update_password as _update_password
@@ -48,7 +48,6 @@ desk_properties = (
 	"bulk_actions",
 	"view_switcher",
 	"form_sidebar",
-	"form_navigation_buttons",
 	"timeline",
 	"dashboard",
 )
@@ -65,12 +64,9 @@ class User(Document):
 		from frappe.core.doctype.defaultvalue.defaultvalue import DefaultValue
 		from frappe.core.doctype.has_role.has_role import HasRole
 		from frappe.core.doctype.user_email.user_email import UserEmail
-		from frappe.core.doctype.user_role_profile.user_role_profile import UserRoleProfile
-		from frappe.core.doctype.user_session_display.user_session_display import UserSessionDisplay
 		from frappe.core.doctype.user_social_login.user_social_login import UserSocialLogin
 		from frappe.types import DF
 
-		active_sessions: DF.Table[UserSessionDisplay]
 		allowed_in_mentions: DF.Check
 		api_key: DF.Data | None
 		api_secret: DF.Password | None
@@ -80,7 +76,6 @@ class User(Document):
 		block_modules: DF.Table[BlockModule]
 		bulk_actions: DF.Check
 		bypass_restrict_ip_check_if_2fa_enabled: DF.Check
-		code_editor_type: DF.Literal["vscode", "vim", "emacs"]
 		dashboard: DF.Check
 		default_app: DF.Literal[None]
 		default_workspace: DF.Link | None
@@ -89,7 +84,7 @@ class User(Document):
 		document_follow_frequency: DF.Literal["Hourly", "Daily", "Weekly"]
 		document_follow_notify: DF.Check
 		email: DF.Data
-		email_signature: DF.TextEditor | None
+		email_signature: DF.SmallText | None
 		enabled: DF.Check
 		first_name: DF.Data
 		follow_assigned_documents: DF.Check
@@ -97,7 +92,6 @@ class User(Document):
 		follow_created_documents: DF.Check
 		follow_liked_documents: DF.Check
 		follow_shared_documents: DF.Check
-		form_navigation_buttons: DF.Check
 		form_sidebar: DF.Check
 		full_name: DF.Data | None
 		gender: DF.Link | None
@@ -128,12 +122,10 @@ class User(Document):
 		reset_password_key: DF.Data | None
 		restrict_ip: DF.SmallText | None
 		role_profile_name: DF.Link | None
-		role_profiles: DF.TableMultiSelect[UserRoleProfile]
 		roles: DF.Table[HasRole]
 		search_bar: DF.Check
 		send_me_a_copy: DF.Check
 		send_welcome_email: DF.Check
-		show_absolute_datetime_in_timeline: DF.Check
 		simultaneous_sessions: DF.Int
 		social_logins: DF.Table[UserSocialLogin]
 		thread_notify: DF.Check
@@ -146,43 +138,7 @@ class User(Document):
 		username: DF.Data | None
 		view_switcher: DF.Check
 	# end: auto-generated types
-
 	__new_password = None
-
-	@cached_property
-	def active_sessions(self):
-		sessions = frappe.qb.DocType("Sessions")
-		if self.name != frappe.session.user:
-			# sec: only allow users to see their sessions.
-			return []
-
-		sessions_data = (
-			frappe.qb.from_(sessions)
-			.select(sessions.user, sessions.sessiondata, sessions.sid)
-			.where(sessions.user == self.name)
-		).run(as_dict=True)
-
-		def mask(sid: str):
-			return sid[:4] + "*" * 10
-
-		session_docs = []
-		for session in sessions_data:
-			data = frappe.parse_json(session.sessiondata)
-			sid_hash = sha256_hash(session.sid)
-			session_docs.append(
-				{
-					"name": sid_hash,
-					"id": mask(sid_hash),
-					"owner": session.user,
-					"modified_by": session.user,
-					"ip_address": data.session_ip,
-					"last_updated": data.last_updated,
-					"is_current": session.sid == frappe.session.sid,
-					"session_created": data.creation,
-					"user_agent": data.user_agent,
-				}
-			)
-		return session_docs
 
 	def __setup__(self):
 		# because it is handled separately
@@ -197,7 +153,7 @@ class User(Document):
 			self.name = self.email
 
 	def onload(self):
-		from frappe.utils.modules import get_modules_from_all_apps
+		from frappe.config import get_modules_from_all_apps
 
 		self.set_onload("all_modules", sorted(m.get("module_name") for m in get_modules_from_all_apps()))
 
@@ -215,14 +171,13 @@ class User(Document):
 		self.__new_password = self.new_password
 		self.new_password = ""
 
-		if not frappe.in_test:
+		if not frappe.flags.in_test:
 			self.password_strength_test()
 
 		if self.name not in STANDARD_USERS:
 			self.email = self.name
 			self.validate_email_type(self.name)
 
-		self.move_role_profile_name_to_role_profiles()
 		self.populate_role_profile_roles()
 		self.check_roles_added()
 		self.set_system_user()
@@ -230,18 +185,14 @@ class User(Document):
 		self.set_full_name()
 		self.check_enable_disable()
 		self.ensure_unique_roles()
-		self.ensure_unique_role_profiles()
 		self.remove_all_roles_for_guest()
 		self.validate_username()
 		self.remove_disabled_roles()
 		self.validate_user_email_inbox()
-		if self.user_emails:
-			ask_pass_update()
+		ask_pass_update()
 		self.validate_allowed_modules()
 		self.validate_user_image()
 		self.set_time_zone()
-		if self.restrict_ip:
-			self.validate_ip_addr()
 
 		if self.language == "Loading...":
 			self.language = None
@@ -249,51 +200,15 @@ class User(Document):
 		if (self.name not in ["Administrator", "Guest"]) and (not self.get_social_login_userid("frappe")):
 			self.set_social_login_userid("frappe", frappe.generate_hash(length=39))
 
-	def disable_email_fields_if_user_disabled(self):
-		if not self.enabled:
-			self.thread_notify = 0
-			self.send_me_a_copy = 0
-			self.allowed_in_mentions = 0
-
-	@frappe.whitelist()
 	def populate_role_profile_roles(self):
-		if not self.role_profiles:
-			return
+		if self.role_profile_name:
+			role_profile = frappe.get_doc("Role Profile", self.role_profile_name)
+			self.set("roles", [])
+			self.append_roles(*[role.role for role in role_profile.roles])
 
-		if self.name in STANDARD_USERS:
-			self.role_profiles = []
-			return
-
-		new_roles = set()
-		for role_profile in self.role_profiles:
-			role_profile = frappe.get_cached_doc("Role Profile", role_profile.role_profile)
-			new_roles.update(role.role for role in role_profile.roles)
-
-		# Remove invalid roles and add new ones
-		self.roles = [r for r in self.roles if r.role in new_roles]
-		self.append_roles(*new_roles)
-
-	def move_role_profile_name_to_role_profiles(self):
-		"""This handles old role_profile_name field if programatically set.
-
-		This behaviour will be remoed in future versions."""
-		if not self.role_profile_name:
-			return
-
-		current_role_profiles = [r.role_profile for r in self.role_profiles]
-		if self.role_profile_name in current_role_profiles:
-			self.role_profile_name = None
-			return
-
-		from frappe.deprecation_dumpster import deprecation_warning
-
-		deprecation_warning(
-			"unknown",
-			"v16",
-			"The field `role_profile_name` is deprecated and will be removed in v16, use `role_profiles` child table instead.",
-		)
-		self.append("role_profiles", {"role_profile": self.role_profile_name})
-		self.role_profile_name = None
+	@deprecated
+	def validate_roles(self):
+		self.populate_role_profile_roles()
 
 	def validate_allowed_modules(self):
 		if self.module_profile:
@@ -311,7 +226,7 @@ class User(Document):
 		self.share_with_self()
 		clear_notifications(user=self.name)
 		frappe.clear_cache(user=self.name)
-		now = frappe.in_test or frappe.flags.in_install
+		now = frappe.flags.in_test or frappe.flags.in_install
 		self.send_password_notification(self.__new_password)
 		frappe.enqueue(
 			"frappe.core.doctype.user.user.create_contact",
@@ -333,18 +248,6 @@ class User(Document):
 		if self.time_zone:
 			frappe.defaults.set_default("time_zone", self.time_zone, self.name)
 
-		if self.has_value_changed("language"):
-			locale_keys = ("date_format", "time_format", "number_format", "first_day_of_the_week")
-			if self.language:
-				language = frappe.get_doc("Language", self.language)
-				for key in locale_keys:
-					value = language.get(key)
-					if value:
-						frappe.defaults.set_default(key, value, self.name)
-			else:
-				for key in locale_keys:
-					frappe.defaults.clear_default(key, parent=self.name)
-
 		if self.has_value_changed("enabled"):
 			frappe.cache.delete_key("users_for_mentions")
 			frappe.cache.delete_key("enabled_users")
@@ -352,7 +255,7 @@ class User(Document):
 			frappe.cache.delete_key("users_for_mentions")
 
 	def has_website_permission(self, ptype, user, verbose=False):
-		"""Return True if current user is the session user."""
+		"""Returns true if current user is the session user"""
 		return self.name == frappe.session.user
 
 	def clean_name(self):
@@ -373,8 +276,7 @@ class User(Document):
 			frappe.local.login_manager.logout(user=self.name)
 
 		# toggle notifications based on the user's status
-		toggle_notifications(self.name, enable=cint(self.enabled), ignore_permissions=True)
-		self.disable_email_fields_if_user_disabled()
+		toggle_notifications(self.name, enable=cint(self.enabled))
 
 	def email_new_password(self, new_password=None):
 		if new_password and not self.flags.in_insert:
@@ -557,7 +459,7 @@ class User(Document):
 		if custom_template:
 			from frappe.email.doctype.email_template.email_template import get_email_template
 
-			email_template = get_email_template(custom_template, args, sender=sender)
+			email_template = get_email_template(custom_template, args)
 			subject = email_template.get("subject")
 			content = email_template.get("message")
 
@@ -597,6 +499,17 @@ class User(Document):
 
 		# delete shares
 		frappe.db.delete("DocShare", {"user": self.name})
+		# delete messages
+		table = DocType("Communication")
+		frappe.db.delete(
+			table,
+			filters=(
+				(table.communication_type.isin(["Chat", "Notification"]))
+				& (table.reference_doctype == "User")
+				& ((table.reference_name == self.name) | table.owner == self.name)
+			),
+			run=False,
+		)
 		# unlink contact
 		table = DocType("Contact")
 		frappe.qb.update(table).where(table.user == self.name).set(table.user, None).run()
@@ -615,6 +528,9 @@ class User(Document):
 		# Delete OAuth data
 		frappe.db.delete("OAuth Authorization Code", {"user": self.name})
 		frappe.db.delete("Token Cache", {"user": self.name})
+
+		# Delete EPS data
+		frappe.db.delete("Energy Point Log", {"user": self.name})
 
 		# Remove user link from Workflow Action
 		frappe.db.set_value("Workflow Action", {"user": self.name}, "user", None)
@@ -682,7 +598,7 @@ class User(Document):
 
 	def append_roles(self, *roles):
 		"""Add roles to user"""
-		current_roles = {d.role for d in self.get("roles")}
+		current_roles = [d.role for d in self.get("roles")]
 		for role in roles:
 			if role in current_roles:
 				continue
@@ -691,7 +607,6 @@ class User(Document):
 	def add_roles(self, *roles):
 		"""Add roles to user and save"""
 		self.append_roles(*roles)
-		# test_user_permission.create_user depends on this
 		self.save()
 
 	def remove_roles(self, *roles):
@@ -713,18 +628,12 @@ class User(Document):
 				self.get("roles").remove(role)
 
 	def ensure_unique_roles(self):
-		exists = set()
-		for d in list(self.roles):
+		exists = []
+		for d in self.get("roles"):
 			if (not d.role) or (d.role in exists):
-				self.roles.remove(d)
-			exists.add(d.role)
-
-	def ensure_unique_role_profiles(self):
-		seen = set()
-		for rp in list(self.role_profiles):
-			if rp.role_profile in seen:
-				self.role_profiles.remove(rp)
-			seen.add(rp.role_profile)
+				self.get("roles").remove(d)
+			else:
+				exists.append(d.role)
 
 	def validate_username(self):
 		if not self.username and self.is_new() and self.first_name:
@@ -779,7 +688,7 @@ class User(Document):
 		return frappe.db.get_value("User", {"username": username or self.username, "name": ("!=", self.name)})
 
 	def get_blocked_modules(self):
-		"""Return list of modules blocked for that user."""
+		"""Returns list of modules blocked for that user"""
 		return [d.module for d in self.block_modules] if self.block_modules else []
 
 	def validate_user_email_inbox(self):
@@ -818,8 +727,12 @@ class User(Document):
 		3. If allow_login_using_user_name is set, you can use username while finding the user.
 		"""
 
-		login_with_mobile = cint(frappe.get_system_settings("allow_login_using_mobile_number"))
-		login_with_username = cint(frappe.get_system_settings("allow_login_using_user_name"))
+		login_with_mobile = cint(
+			frappe.db.get_single_value("System Settings", "allow_login_using_mobile_number")
+		)
+		login_with_username = cint(
+			frappe.db.get_single_value("System Settings", "allow_login_using_user_name")
+		)
 
 		or_filters = [{"name": user_name}]
 		if login_with_mobile:
@@ -845,9 +758,6 @@ class User(Document):
 		if not self.time_zone:
 			self.time_zone = get_system_timezone()
 
-	def get_permission_log_options(self, event=None):
-		return {"fields": ("role_profile_name", "roles", "module_profile", "block_modules")}
-
 	def check_roles_added(self):
 		if self.user_type != "System User" or self.roles or not self.is_new():
 			return
@@ -863,15 +773,12 @@ class User(Document):
 			},
 		)
 
-	def validate_ip_addr(self):
-		self.restrict_ip = ",".join(self.get_restricted_ip_list())
-
 
 @frappe.whitelist()
 def get_timezones():
-	import zoneinfo
+	import pytz
 
-	return {"timezones": zoneinfo.available_timezones()}
+	return {"timezones": pytz.all_timezones}
 
 
 @frappe.whitelist()
@@ -879,20 +786,14 @@ def get_all_roles():
 	"""return all roles"""
 	active_domains = frappe.get_active_domains()
 
-	Role = frappe.qb.DocType("Role")
-
-	domain_condition = (Role.restrict_to_domain.isnull()) | (Role.restrict_to_domain == "")
-	if active_domains:
-		domain_condition = domain_condition | Role.restrict_to_domain.isin(active_domains)
-
-	roles = (
-		frappe.qb.from_(Role)
-		.select(Role.name)
-		.where(
-			(Role.name.notin(frappe.permissions.AUTOMATIC_ROLES)) & (Role.disabled == 0) & domain_condition
-		)
-		.orderby(Role.name)
-		.run(as_dict=True)
+	roles = frappe.get_all(
+		"Role",
+		filters={
+			"name": ("not in", frappe.permissions.AUTOMATIC_ROLES),
+			"disabled": 0,
+		},
+		or_filters={"ifnull(restrict_to_domain, '')": "", "restrict_to_domain": ("in", active_domains)},
+		order_by="name",
 	)
 
 	return sorted([role.get("name") for role in roles])
@@ -901,7 +802,7 @@ def get_all_roles():
 @frappe.whitelist()
 def get_roles(arg=None):
 	"""get roles for a user"""
-	return frappe.get_roles(frappe.form_dict.get("uid", frappe.session.user))
+	return frappe.get_roles(frappe.form_dict["uid"])
 
 
 @frappe.whitelist()
@@ -919,10 +820,10 @@ def update_password(
 	"""Update password for the current user.
 
 	Args:
-	    new_password (str): New password.
-	    logout_all_sessions (int, optional): If set to 1, all other sessions will be logged out. Defaults to 0.
-	    key (str, optional): Password reset key. Defaults to None.
-	    old_password (str, optional): Old password. Defaults to None.
+	        new_password (str): New password.
+	        logout_all_sessions (int, optional): If set to 1, all other sessions will be logged out. Defaults to 0.
+	        key (str, optional): Password reset key. Defaults to None.
+	        old_password (str, optional): Old password. Defaults to None.
 	"""
 
 	if len(new_password) > MAX_PASSWORD_SIZE:
@@ -941,7 +842,9 @@ def update_password(
 	else:
 		user = res["user"]
 
-	logout_all_sessions = cint(logout_all_sessions) or frappe.get_system_settings("logout_on_password_reset")
+	logout_all_sessions = cint(logout_all_sessions) or frappe.db.get_single_value(
+		"System Settings", "logout_on_password_reset"
+	)
 	_update_password(user, new_password, logout_all_sessions=cint(logout_all_sessions))
 
 	user_doc, redirect_url = reset_user_data(user)
@@ -960,25 +863,22 @@ def update_password(
 	frappe.db.set_value("User", user, "reset_password_key", "")
 
 	if user_doc.user_type == "System User":
-		return get_default_path() or "/desk"
+		return get_default_path() or "/app"
 	else:
 		return redirect_url or get_default_path() or get_home_page()
 
 
 @frappe.whitelist(allow_guest=True)
 def test_password_strength(new_password: str, key=None, old_password=None, user_data: tuple | None = None):
+	from frappe.utils.deprecations import deprecation_warning
 	from frappe.utils.password_strength import test_password_strength as _test_password_strength
 
 	if key is not None or old_password is not None:
-		from frappe.deprecation_dumpster import deprecation_warning
-
 		deprecation_warning(
-			"unknown",
-			"v17",
-			"Arguments `key` and `old_password` are deprecated in function `test_password_strength`.",
+			"Arguments `key` and `old_password` are deprecated in function `test_password_strength`."
 		)
 
-	enable_password_policy = frappe.get_system_settings("enable_password_policy")
+	enable_password_policy = frappe.get_system_settings("enable_password_policy") or 0
 
 	if not enable_password_policy:
 		return {}
@@ -991,7 +891,7 @@ def test_password_strength(new_password: str, key=None, old_password=None, user_
 	if new_password:
 		result = _test_password_strength(new_password, user_inputs=user_data)
 		password_policy_validation_passed = False
-		minimum_password_score = cint(frappe.get_system_settings("minimum_password_score"))
+		minimum_password_score = cint(frappe.get_system_settings("minimum_password_score")) or 0
 
 		# score should be greater than 0 and minimum_password_score
 		if result.get("score") and result.get("score") >= minimum_password_score:
@@ -1021,10 +921,7 @@ def ask_pass_update():
 	from frappe.utils import set_default
 
 	password_list = frappe.get_all(
-		"User Email",
-		filters={"awaiting_password": 1, "used_oauth": 0},
-		pluck="parent",
-		distinct=True,
+		"User Email", filters={"awaiting_password": 1, "used_oauth": 0}, pluck="parent", distinct=True
 	)
 	set_default("email_user_password", ",".join(password_list))
 
@@ -1040,7 +937,7 @@ def _get_user_for_update_password(key, old_password):
 		result.user, last_reset_password_key_generated_on = user or (None, None)
 		if result.user:
 			reset_password_link_expiry = cint(
-				frappe.get_system_settings("reset_password_link_expiry_duration")
+				frappe.db.get_single_value("System Settings", "reset_password_link_expiry_duration")
 			)
 			if (
 				reset_password_link_expiry
@@ -1140,7 +1037,7 @@ def reset_password(user: str) -> str:
 		user.reset_password(send_email=True)
 
 		return frappe.msgprint(
-			msg=_("Password reset instructions have been sent to {}'s email").format(user.full_name),
+			msg=_("Password reset instructions have been sent to your email"),
 			title=_("Password Email Sent"),
 		)
 	except frappe.DoesNotExistError:
@@ -1184,7 +1081,7 @@ def user_query(doctype, txt, searchfield, start, page_len, filters):
 
 
 def get_total_users():
-	"""Return total number of system users."""
+	"""Returns total no. of system users"""
 	return flt(
 		frappe.db.sql(
 			"""SELECT SUM(`simultaneous_sessions`)
@@ -1217,7 +1114,7 @@ def get_system_users(exclude_users: Iterable[str] | str | None = None, limit: in
 
 
 def get_active_users():
-	"""Return number of system users who logged in, in the last 3 days."""
+	"""Returns No. of system users who logged in, in the last 3 days"""
 	return frappe.db.sql(
 		"""select count(*) from `tabUser`
 		where enabled = 1 and user_type != 'Website User'
@@ -1228,16 +1125,16 @@ def get_active_users():
 
 
 def get_website_users():
-	"""Return total number of website users."""
+	"""Returns total no. of website users"""
 	return frappe.db.count("User", filters={"enabled": True, "user_type": "Website User"})
 
 
 def get_active_website_users():
-	"""Return number of website users who logged in, in the last 3 days."""
+	"""Returns No. of website users who logged in, in the last 3 days"""
 	return frappe.db.sql(
 		"""select count(*) from `tabUser`
-        where enabled = 1 and user_type = 'Website User'
-        and hour(timediff(now(), last_active)) < 72"""
+		where enabled = 1 and user_type = 'Website User'
+		and hour(timediff(now(), last_active)) < 72"""
 	)[0][0]
 
 
@@ -1254,7 +1151,6 @@ def has_permission(doc, user):
 	if (user != "Administrator") and (doc.name in STANDARD_USERS):
 		# dont allow non Administrator user to view / edit Administrator user
 		return False
-	return True
 
 
 def notify_admin_access_to_system_manager(login_manager=None):
@@ -1323,6 +1219,11 @@ def throttle_user_creation():
 
 	if frappe.db.get_creation_count("User", 60) > frappe.local.conf.get("throttle_user_limit", 60):
 		frappe.throw(_("Throttled"))
+
+
+@frappe.whitelist()
+def get_role_profile(role_profile: str):
+	return frappe.get_doc("Role Profile", {"role_profile": role_profile}).roles
 
 
 @frappe.whitelist()
@@ -1402,7 +1303,7 @@ def get_restricted_ip_list(user):
 	if not user.restrict_ip:
 		return
 
-	return [i.strip() for i in user.restrict_ip.strip().split(",")]
+	return [i.strip() for i in user.restrict_ip.split(",")]
 
 
 @frappe.whitelist(methods=["POST"])
@@ -1440,43 +1341,51 @@ def get_enabled_users():
 
 
 @frappe.whitelist(methods=["POST"])
-def impersonate(user: str, reason: str):
-	frappe.has_permission("User", "impersonate")
+def impersonate(user: str, reason: str = "No reason provided"):
+	# Note: For now we only allow admins, we MIGHT allow system manager in future.
+	# All the impersonation code doesn't assume anything about user.
+    if not frappe.has_permission("User", "write"):
+        frappe.throw(_("No permission to impersonate"))
 
-	impersonator = frappe.session.user
-	frappe.get_doc(
-		{
-			"doctype": "Activity Log",
-			"user": user,
-			"status": "Success",
-			"subject": _("User {0} impersonated as {1}").format(impersonator, user),
-			"operation": "Impersonate",
-		}
-	).insert(ignore_permissions=True, ignore_links=True)
+    impersonator = frappe.session.user
 
-	notification = frappe.new_doc(
-		"Notification Log",
-		for_user=user,
-		from_user=frappe.session.user,
-		subject=_("{0} just impersonated as you. They gave this reason: {1}").format(impersonator, reason),
-	)
-	notification.set("type", "Alert")
-	notification.insert(ignore_permissions=True)
-	frappe.local.login_manager.impersonate(user)
+    frappe.get_doc(
+        {
+            "doctype": "Activity Log",
+            "user": user,
+            "status": "Success",
+            "subject": _("User {0} impersonated as {1}").format(impersonator, user),
+            "operation": "Impersonate",
+        }
+    ).insert(ignore_permissions=True, ignore_links=True)
 
+    notification = frappe.new_doc(
+        "Notification Log",
+        for_user=user,
+        from_user=frappe.session.user,
+        subject=_("{0} just impersonated as you. Reason: {1}").format(impersonator, reason),
+    )
+    notification.set("type", "Alert")
+    notification.insert(ignore_permissions=True)
 
-@frappe.whitelist()
-@rate_limit(limit=10, seconds=60 * 60, methods="POST")
-def clear_session(sid_hash: str):
-	from frappe.sessions import delete_session
+    
+    email_subject = _("Security Alert: Your account was impersonated by {0}").format(impersonator)
+    email_message = _("""
+        <div style="font-family: sans-serif; padding: 10px;">
+            <h3>Security Alert</h3>
+            <p>Hello,</p>
+            <p>User <b>{0}</b> has just signed in to your account using the <b>Impersonate</b> feature.</p>
+            <p><b>Reason:</b> {1}</p>
+            <p><b>Time:</b> {2}</p>
+        </div>
+    """).format(impersonator, reason, frappe.utils.format_datetime(frappe.utils.now(), "medium"))
 
-	sessions = frappe.qb.DocType("Sessions")
-	sessions_data = (
-		frappe.qb.from_(sessions).select(sessions.sid).where(sessions.user == frappe.session.user)
-	).run(pluck=True)
+    frappe.sendmail(
+        recipients=user,
+        subject=email_subject,
+        message=email_message,
+        header=[_("Security Alert"), "orange"],
+        now=True 
+    )
 
-	for session in sessions_data:
-		if sha256_hash(session) == sid_hash:
-			delete_session(sid=session, reason="Force Logged out by the user", user=frappe.session.user)
-			frappe.toast(_("Successfully signed out"))
-			return
+    frappe.local.login_manager.impersonate(user)

--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -8,6 +8,11 @@ from frappe.model import log_types
 from frappe.query_builder import DocType
 from frappe.utils import get_url_to_form
 
+from typing import TYPE_CHECKING, List, Dict, Union
+
+if TYPE_CHECKING:
+	from frappe.model.document import Document
+
 
 @frappe.whitelist()
 def update_follow(doctype: str, doc_name: str, following: bool):
@@ -18,7 +23,7 @@ def update_follow(doctype: str, doc_name: str, following: bool):
 
 
 @frappe.whitelist()
-def follow_document(doctype, doc_name, user):
+def follow_document(doctype: str, doc_name: str, user: str) -> Union["Document", bool]:
 	"""
 	param:
 	Doctype name
@@ -67,7 +72,7 @@ def follow_document(doctype, doc_name, user):
 
 
 @frappe.whitelist()
-def unfollow_document(doctype, doc_name, user):
+def unfollow_document(doctype: str, doc_name: str, user: str) -> bool:
 	doc = frappe.get_all(
 		"Document Follow",
 		filters={"ref_doctype": doctype, "ref_docname": doc_name, "user": user},
@@ -77,7 +82,7 @@ def unfollow_document(doctype, doc_name, user):
 	if doc:
 		frappe.delete_doc("Document Follow", doc[0].name, force=True)
 		frappe.toast(_("Un-following document {0}").format(doc_name))
-		return False
+		return True
 	return False
 
 
@@ -240,7 +245,7 @@ def is_document_followed(doctype, doc_name, user):
 
 
 @frappe.whitelist()
-def get_follow_users(doctype, doc_name):
+def get_follow_users(doctype: str, doc_name: str) -> List[Dict]:
 	return frappe.get_all(
 		"Document Follow", filters={"ref_doctype": doctype, "ref_docname": doc_name}, fields=["user"]
 	)

--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -8,11 +8,6 @@ from frappe.model import log_types
 from frappe.query_builder import DocType
 from frappe.utils import get_url_to_form
 
-from typing import TYPE_CHECKING, List, Dict, Union
-
-if TYPE_CHECKING:
-	from frappe.model.document import Document
-
 
 @frappe.whitelist()
 def update_follow(doctype: str, doc_name: str, following: bool):
@@ -23,7 +18,7 @@ def update_follow(doctype: str, doc_name: str, following: bool):
 
 
 @frappe.whitelist()
-def follow_document(doctype: str, doc_name: str, user: str) -> Union["Document", bool]:
+def follow_document(doctype, doc_name, user):
 	"""
 	param:
 	Doctype name
@@ -72,7 +67,7 @@ def follow_document(doctype: str, doc_name: str, user: str) -> Union["Document",
 
 
 @frappe.whitelist()
-def unfollow_document(doctype: str, doc_name: str, user: str) -> bool:
+def unfollow_document(doctype, doc_name, user):
 	doc = frappe.get_all(
 		"Document Follow",
 		filters={"ref_doctype": doctype, "ref_docname": doc_name, "user": user},
@@ -82,7 +77,7 @@ def unfollow_document(doctype: str, doc_name: str, user: str) -> bool:
 	if doc:
 		frappe.delete_doc("Document Follow", doc[0].name, force=True)
 		frappe.toast(_("Un-following document {0}").format(doc_name))
-		return True
+		return False
 	return False
 
 
@@ -245,7 +240,7 @@ def is_document_followed(doctype, doc_name, user):
 
 
 @frappe.whitelist()
-def get_follow_users(doctype: str, doc_name: str) -> List[Dict]:
+def get_follow_users(doctype, doc_name):
 	return frappe.get_all(
 		"Document Follow", filters={"ref_doctype": doctype, "ref_docname": doc_name}, fields=["user"]
 	)


### PR DESCRIPTION
Description: This PR adds a security feature that triggers an immediate email notification to a user whenever their account is accessed by an Administrator using the Impersonate feature. This addresses the security concern raised in Issue #36205, ensuring users are aware of administrative access to their accounts.

Changes:

Modified impersonate method in frappe/core/doctype/user/user.py.

Added frappe.sendmail logic with now=True to ensure the alert is sent immediately before the session switches.

The email includes the Impersonator's Name, Time of Access, and the Reason (if provided).

Added a "Security Alert" header to the email for better visibility.

Fixes: Fixes #36205


https://github.com/user-attachments/assets/2f283786-fe38-42d7-93e6-4ca1420a7bf3

