### PR TITLE
refactor: add type hints to document follow API

### DIFF
--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-from typing import TYPE_CHECKING, List, Dict, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import frappe
 import frappe.utils
 from frappe import _
@@ -11,6 +14,7 @@ from frappe.utils import get_url_to_form
 if TYPE_CHECKING:
 	from frappe.model.document import Document
 
+
 @frappe.whitelist()
 def update_follow(doctype: str, doc_name: str, following: bool):
 	if following:
@@ -20,7 +24,7 @@ def update_follow(doctype: str, doc_name: str, following: bool):
 
 
 @frappe.whitelist()
-def follow_document(doctype: str, doc_name: str, user: str) -> Union["Document", bool]:
+def follow_document(doctype: str, doc_name: str, user: str) -> Document | bool:
 	"""
 	param:
 	Doctype name

--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-
+from typing import TYPE_CHECKING, List, Dict, Union
 import frappe
 import frappe.utils
 from frappe import _
@@ -8,6 +8,8 @@ from frappe.model import log_types
 from frappe.query_builder import DocType
 from frappe.utils import get_url_to_form
 
+if TYPE_CHECKING:
+	from frappe.model.document import Document
 
 @frappe.whitelist()
 def update_follow(doctype: str, doc_name: str, following: bool):
@@ -18,7 +20,7 @@ def update_follow(doctype: str, doc_name: str, following: bool):
 
 
 @frappe.whitelist()
-def follow_document(doctype, doc_name, user):
+def follow_document(doctype: str, doc_name: str, user: str) -> Union["Document", bool]:
 	"""
 	param:
 	Doctype name
@@ -67,7 +69,7 @@ def follow_document(doctype, doc_name, user):
 
 
 @frappe.whitelist()
-def unfollow_document(doctype, doc_name, user):
+def unfollow_document(doctype: str, doc_name: str, user: str) -> bool:
 	doc = frappe.get_all(
 		"Document Follow",
 		filters={"ref_doctype": doctype, "ref_docname": doc_name, "user": user},


### PR DESCRIPTION
Description: This PR adds static type hints to the follow_document function in frappe/desk/form/document_follow.py. This improves code readability and enables better IDE support (autocomplete/error checking) for developers working with this API.

Changes:

Added type annotations (str, bool) to function arguments and return types.

Organized imports using TYPE_CHECKING to prevent circular dependencies and clean up runtime imports.

Ensured imports are sorted according to project linting standards.