### PR TITLE
feat(user): send user a mail when an impersonation session has commenced

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1462,6 +1462,19 @@ def impersonate(user: str, reason: str):
 	)
 	notification.set("type", "Alert")
 	notification.insert(ignore_permissions=True)
+	# notify user via email too
+	user_email = frappe.db.get_value("User", user, "email")
+	email_message = _(
+		"User {0} has started an impersonation session as you. <br><br><b>Reason provided:</b> {1}"
+	).format(escape_html(impersonator), escape_html(reason))
+
+	frappe.enqueue(
+		method="frappe.sendmail",
+		queue="short",
+		recipients=[user_email],
+		subject=_("Security Alert: Your account is being impersonated"),
+		content=email_message,
+	)
 	frappe.local.login_manager.impersonate(user)
 
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1468,9 +1468,7 @@ def impersonate(user: str, reason: str):
 		"User {0} has started an impersonation session as you. <br><br><b>Reason provided:</b> {1}"
 	).format(escape_html(impersonator), escape_html(reason))
 
-	frappe.enqueue(
-		method="frappe.sendmail",
-		queue="short",
+	frappe.sendmail(
 		recipients=[user_email],
 		subject=_("Security Alert: Your account is being impersonated"),
 		content=email_message,

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -308,6 +308,28 @@ class TestEmail(IntegrationTestCase):
 		if changed_flag:
 			email_account.enable_incoming = False
 
+	def test_impersonation_alert_queue(self):
+		"""Verifies that impersonation alerts are sent as mail too"""
+		from frappe.core.doctype.user.user import impersonate
+
+		target_user = "testimpersonate@example.com"
+		frappe.db.delete("Email Queue Recipient", {"recipient": target_user})  # sanity
+		if not frappe.db.exists("User", target_user):
+			frappe.get_doc({"doctype": "User", "email": target_user, "first_name": "Target"}).insert(
+				ignore_permissions=True
+			)
+		with patch("frappe.enqueue") as mocked_enqueue:
+			reason = "Testing Security Alert"
+			impersonate(user=target_user, reason=reason)
+
+			self.assertEqual(frappe.session.user, target_user)  # test if impersonation worked
+			_, kwargs = mocked_enqueue.call_args
+			self.assertEqual(kwargs.get("method"), "frappe.sendmail")  # test if email was enqueued
+			self.assertIn(target_user, kwargs.get("recipients"))
+			self.assertIn(reason, kwargs.get("content"))
+
+		frappe.db.delete("User", {"email": target_user})
+
 
 class TestVerifiedRequests(IntegrationTestCase):
 	def test_round_trip(self):

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -318,15 +318,14 @@ class TestEmail(IntegrationTestCase):
 			frappe.get_doc({"doctype": "User", "email": target_user, "first_name": "Target"}).insert(
 				ignore_permissions=True
 			)
-		with patch("frappe.enqueue") as mocked_enqueue:
-			reason = "Testing Security Alert"
-			impersonate(user=target_user, reason=reason)
-
-			self.assertEqual(frappe.session.user, target_user)  # test if impersonation worked
-			_, kwargs = mocked_enqueue.call_args
-			self.assertEqual(kwargs.get("method"), "frappe.sendmail")  # test if email was enqueued
-			self.assertIn(target_user, kwargs.get("recipients"))
-			self.assertIn(reason, kwargs.get("content"))
+		reason = "Testing Security Alert"
+		impersonate(user=target_user, reason=reason)
+		self.assertEqual(frappe.session.user, target_user)  # test if impersonation worked
+		self.assertTrue(frappe.db.exists("Activity Log", {"user": target_user, "operation": "Impersonate"}))
+		email_queued = frappe.db.exists(
+			"Email Queue Recipient", {"recipient": target_user, "status": "Not Sent"}
+		)
+		self.assertTrue(email_queued, f"Impersonation email was not queued for {target_user}")
 
 		frappe.db.delete("User", {"email": target_user})
 


### PR DESCRIPTION
**feat(user)**: This PR is a direct resolution to #36205 . The PR aims to resolve the issue by sending an email to user indicating an impersonation session has commenced.  


**Before**:
No email was sent

**After**:


<img width="2136" height="672" alt="image" src="https://github.com/user-attachments/assets/9648068f-ed49-4d61-960d-55b9cf05a78e" />

resolves #36205 
