### PR TITLE
fix: add translations to the desktop

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -988,9 +988,8 @@ class DesktopIcon {
 				modal.show();
 			});
 			if (this.icon_type == "App") {
-				$($(this.icon_caption_area).children()[1]).html(
-					__(`${this.child_icons.length} Workspaces`)
-				);
+				let content = `${this.child_icons.length} Workspaces`;
+				$($(this.icon_caption_area).children()[1]).html(__(content));
 			}
 		} else {
 			if (this.icon_route && this.icon_route.startsWith("http")) {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -989,7 +989,7 @@ class DesktopIcon {
 			});
 			if (this.icon_type == "App") {
 				$($(this.icon_caption_area).children()[1]).html(
-					`${this.child_icons.length} Workspaces`
+					__(`${this.child_icons.length} Workspaces`)
 				);
 			}
 		} else {
@@ -1174,7 +1174,7 @@ class InlineEditor {
 		this.container.html(`
 			<div class="title-widget">
 				<div class="title-input-label">
-					<span>${this.initialValue}</span>
+					<span>${__(this.initialValue)}</span>
 				</div>
 				<div class="title-input-wrapper">
 					<input class="title-input">

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.html
@@ -8,11 +8,7 @@
 <div class="title-container">
 
     <div class="sidebar-item-label header-title" data-name-style="{%=frappe.boot.app_name_style%}">
-        {% if (frappe.boot.app_name_style == "Title") { %}
-            {%= frappe.app.sidebar.app_name %}
-        {% } else { %}
-            {%= workspace_title %}
-        {% }  %}
+            {%= __(workspace_title) %}
     </div>
     <div class="sidebar-item-label header-subtitle">
         {%= frappe.app.sidebar.header_subtitle %}

--- a/frappe/public/js/frappe/views/pageview.js
+++ b/frappe/public/js/frappe/views/pageview.js
@@ -101,7 +101,7 @@ frappe.views.Page = class Page {
 		this.trigger_page_event("on_page_load");
 		frappe.breadcrumbs.add({
 			type: "Custom",
-			label: this.pagedoc.title,
+			label: __(this.pagedoc.title),
 			route: frappe.get_route_str(),
 		});
 


### PR DESCRIPTION
<img width="909" height="672" alt="Screenshot 2026-01-22 at 10 17 37 PM" src="https://github.com/user-attachments/assets/3199159b-2bdc-4c26-a178-adc05ae5e0ac" />

Fixes some issues in https://github.com/frappe/frappe/issues/36237