### PR TITLE
chore: ignore weasyprint vuln

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           pip install pip-audit
           cd ${GITHUB_WORKSPACE}
-          pip-audit --desc on --ignore-vuln PYSEC-2023-312 .
+          pip-audit --desc on --ignore-vuln PYSEC-2023-312 --ignore-vuln CVE-2025-68616 .
 
   precommit:
     name: 'Pre-Commit'


### PR DESCRIPTION
One more attempt to make the CI green again
This is an temporary fix cause bleach and weasyprint use a package called tinycss2 and after updating weasyprint to a version where the vulnerablity is fixed they cant agree on a tinycss2. Waiting for bleach team to do it right :) 

Correct fix : https://github.com/frappe/frappe/pull/36203