### PR TITLE
fix: Prevent input fields from being cleared while typing in dialogs

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -49,12 +49,17 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 			$(this.wrapper)
 				.find("input, select")
 				.on(
-					"change input awesomplete-selectcomplete",
+					"change awesomplete-selectcomplete",
 					frappe.utils.debounce(() => {
 						this.dirty = true;
 						me.refresh_dependency();
 					}, 100)
-				);
+				)
+				.on("input", () => {
+					if (!this.dirty) {
+						this.dirty = true;
+					}
+				});
 		}
 	}
 


### PR DESCRIPTION
Closes [#36241](https://github.com/frappe/frappe/issues/36241)

## Description
This PR addresses an issue where input fields in dialogs (such as the DocType creation dialog) are cleared or reset while typing. The problem was caused by calling `refresh_dependency()` on every `input` event in `frappe.ui.FieldGroup`, which aggressively re-evaluated dependencies and reset field values.


Also need to backport
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->
