### PR TITLE
fix(db): drop unique constraint on deleted fields

### DIFF
--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -70,6 +70,8 @@ class MariaDBTable(DBTable):
 		frappe.db.sql_ddl(query)
 
 	def alter(self):
+		self.drop_unique_constraints_on_deleted_fields()
+
 		for col in self.columns.values():
 			col.build_for_alter_table(self.current_columns.get(col.fieldname.lower()))
 
@@ -144,6 +146,28 @@ class MariaDBTable(DBTable):
 				)
 
 			raise
+
+	def drop_unique_constraints_on_deleted_fields(self):
+		if not self.current_columns:
+			return
+
+		keep_columns = {col.lower() for col in self.columns}
+
+		keep_columns.update({"name", "creation", "modified", "modified_by", "owner", "docstatus", "idx"})
+
+		if self.meta.istable:
+			keep_columns.update({"parent", "parenttype", "parentfield"})
+
+		existing_indexes = frappe.db.sql(f"SHOW INDEX FROM `{self.table_name}`", as_dict=True)
+		for index in existing_indexes:
+			if index.Key_name == "PRIMARY":
+				continue
+
+			# Drop the index ONLY if the column is NOT in our keep list
+			if index.Non_unique == 0 and index.Column_name.lower() not in keep_columns:
+				# MariaDB triggers an implicit commit on DDL, so we commit here for safety
+				frappe.db.commit()  # nosemgrep
+				frappe.db.sql(f"ALTER TABLE `{self.table_name}` DROP INDEX `{index.Key_name}`")
 
 	def alter_primary_key(self) -> str | None:
 		# If there are no values in table allow migrating to UUID from varchar

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -71,6 +71,8 @@ class PostgresTable(DBTable):
 			frappe.db.sql(create_index_query)
 
 	def alter(self):
+		self.drop_unique_constraints_on_deleted_fields()
+
 		for col in self.columns.values():
 			col.build_for_alter_table(self.current_columns.get(col.fieldname.lower()))
 
@@ -190,6 +192,40 @@ class PostgresTable(DBTable):
 				)
 			else:
 				raise e
+
+	def drop_unique_constraints_on_deleted_fields(self):
+		if not self.current_columns:
+			return
+
+		keep_columns = {col.lower() for col in self.columns}
+
+		keep_columns.update({"name", "creation", "modified", "modified_by", "owner", "docstatus", "idx"})
+
+		if self.meta.istable:
+			keep_columns.update({"parent", "parenttype", "parentfield"})
+
+		# Identify deleted columns
+		deleted_columns = [c for c in self.current_columns if c.lower() not in keep_columns]
+
+		if not deleted_columns:
+			return
+
+		for col_name in deleted_columns:
+			constraint_name = frappe.db.sql(
+				f"""
+				SELECT conname
+				FROM pg_constraint
+				JOIN pg_attribute ON pg_attribute.attnum = ANY(pg_constraint.conkey)
+				WHERE pg_constraint.conrelid = '"{self.table_name}"'::regclass
+				AND pg_attribute.attname = %s
+				AND pg_constraint.contype = 'u'
+				""",
+				(col_name,),
+			)
+
+			if constraint_name:
+				c_name = constraint_name[0][0]
+				frappe.db.sql(f'ALTER TABLE "{self.table_name}" DROP CONSTRAINT "{c_name}"')
 
 	def alter_primary_key(self) -> str | None:
 		# If there are no values in table allow migrating to UUID from varchar


### PR DESCRIPTION
**The Problem:**
Currently, when a user deletes a field marked as "Unique" from a DocType, Frappe performs a "soft delete" (hiding the column) but fails to drop the underlying Unique Index or Constraint in the database.

This causes a critical issue where subsequent records cannot be created. The database attempts to insert the default value (e.g., `0` or `NULL`) into the hidden column for every new record. The first insertion succeeds, but the second fails with a `Duplicate Entry` error because the unique constraint is still active on that hidden column.

**The Fix:**
I have updated `frappe/database/mariadb/schema.py` and `frappe/database/postgres/schema.py` to:
1.  Identify columns that exist in the database schema but are missing from the current DocType definition (deleted fields).
2.  Check if these specific columns still hold an active Unique Index (MariaDB) or Unique Constraint (PostgreSQL).
3.  Explicitly drop the unique constraint during schema synchronization (`bench migrate` or DocType save), allowing multiple records to exist with the same default value in the hidden column.

**Visual Proof**

https://github.com/user-attachments/assets/07e75b50-2957-4f18-a598-579c91ff7844

Fixes #36123 