### PR TITLE
ci: autolabel postgres based on touched files

### DIFF
--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -144,6 +144,14 @@ def is_frontend_code(file):
 	return file.lower().endswith((".css", ".scss", ".less", ".sass", ".styl", ".js", ".ts", ".vue", ".html", ".svg"))
 
 
+def matches_postgres_filenames(files_list):
+    """Check if any changed files suggest database involvement."""
+    db_keywords = ["database", "query", "schema", "postgres"]
+    return any(
+        any(word in f.lower() for word in db_keywords) 
+        for f in files_list
+    )
+
 def is_docs(file):
 	"""Check if the file is documentation or image."""
 	regex = re.compile(r"\.(md|png|jpg|jpeg|csv|svg)$|^.github|LICENSE")
@@ -174,6 +182,10 @@ if __name__ == "__main__":
 	only_frontend_code_changed = len(list(filter(is_frontend_code, files_list))) == len(files_list)
 	updated_py_file_count = len(list(filter(is_server_side_code, files_list)))
 	only_py_changed = updated_py_file_count == len(files_list)
+	run_postgres = (
+        has_label(pr_number, "postgres", repo) or 
+        matches_postgres_filenames(files_list)
+    )
 
 	# Check for Skip CI label and other conditions
 	if has_skip_ci_label(pr_number, repo):
@@ -202,3 +214,4 @@ if __name__ == "__main__":
 
 	# If we reach here, run the build
 	os.system('echo "build=strawberry" >> $GITHUB_OUTPUT')
+	os.system(f'echo "run_postgres={"true" if run_postgres else "false"}" >> $GITHUB_OUTPUT')

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -28,6 +28,7 @@ jobs:
     needs: typecheck
     outputs:
       build: ${{ steps.check-build.outputs.build }}
+      run_postgres: ${{ steps.check-build.outputs.run_postgres }}
     steps:
       - name: Clone
         uses: actions/checkout@v6
@@ -44,7 +45,7 @@ jobs:
     name: Tests
     uses: ./.github/workflows/_base-server-tests.yml
     with:
-      enable-postgres: ${{ contains(github.event.pull_request.labels.*.name, 'postgres') }} # This enables PostgreSQL to run tests
+      enable-postgres: ${{ needs.checkrun.outputs.run_postgres == 'true' }} # This enables PostgreSQL to run tests
       enable-sqlite: false  # This will test against both MariaDB and SQLite if enabled
       parallel-runs: 2
       enable-coverage: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
**CI**: Currently Postgres Label is added manually to run the Postgres CI suite but this is just not feasible since this can be overlooked at times. This can cause unwanted regressions due to certain PR changes / queries that might be written in a very specific style (MariaDB) that may go unnoticed. The PR aims to automate this although not 100% effective, this does autolabel when certain files are touched that might indicate a change to core schema / ORM / queries. Could possibly look into diff. in the near future to autolabel but for the time being this should do the job just fine. This is part of a long term strategy to focus on **multi-db support** and ensure Postgres CI remains stable as is currently, thus avoiding unnecessary future CI cleanup for the same.


**Before**:
Manual Labelling

**After**:
Manual + Autolabel if relevant files are touched

related to #34660 