### PR TITLE
fix: remove underline on attachment hover

### DIFF
--- a/=0.38.1
+++ b/=0.38.1
@@ -1,0 +1,8 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: wheel in /usr/lib/python3/dist-packages (0.37.1)
+Collecting wheel
+  Using cached wheel-0.46.3-py3-none-any.whl.metadata (2.4 kB)
+Requirement already satisfied: packaging>=24.0 in /usr/local/lib/python3.10/dist-packages (from wheel) (25.0)
+Using cached wheel-0.46.3-py3-none-any.whl (30 kB)
+Installing collected packages: wheel
+Successfully installed wheel-0.46.3

--- a/=0.9.6
+++ b/=0.9.6
@@ -1,0 +1,8 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: uv in /usr/local/lib/python3.10/dist-packages (0.9.2)
+Collecting uv
+  Downloading uv-0.9.26-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (11 kB)
+Downloading uv-0.9.26-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (23.3 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 23.3/23.3 MB 10.6 MB/s  0:00:02
+Installing collected packages: uv
+Successfully installed uv-0.9.26

--- a/=12.2.0
+++ b/=12.2.0
@@ -1,0 +1,12 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: ansible in /usr/local/lib/python3.10/dist-packages (10.7.0)
+Requirement already satisfied: ansible-core~=2.17.7 in /usr/local/lib/python3.10/dist-packages (from ansible) (2.17.14)
+Requirement already satisfied: jinja2>=3.0.0 in /usr/local/lib/python3.10/dist-packages (from ansible-core~=2.17.7->ansible) (3.1.6)
+Requirement already satisfied: PyYAML>=5.1 in /usr/lib/python3/dist-packages (from ansible-core~=2.17.7->ansible) (5.4.1)
+Requirement already satisfied: cryptography in /home/tridots055/.local/lib/python3.10/site-packages (from ansible-core~=2.17.7->ansible) (46.0.3)
+Requirement already satisfied: packaging in /usr/local/lib/python3.10/dist-packages (from ansible-core~=2.17.7->ansible) (25.0)
+Requirement already satisfied: resolvelib<1.1.0,>=0.5.3 in /usr/local/lib/python3.10/dist-packages (from ansible-core~=2.17.7->ansible) (1.0.1)
+Requirement already satisfied: MarkupSafe>=2.0 in /home/tridots055/.local/lib/python3.10/site-packages (from jinja2>=3.0.0->ansible-core~=2.17.7->ansible) (3.0.3)
+Requirement already satisfied: cffi>=2.0.0 in /home/tridots055/.local/lib/python3.10/site-packages (from cryptography->ansible-core~=2.17.7->ansible) (2.0.0)
+Requirement already satisfied: typing-extensions>=4.13.2 in /home/tridots055/.local/lib/python3.10/site-packages (from cryptography->ansible-core~=2.17.7->ansible) (4.15.0)
+Requirement already satisfied: pycparser in /home/tridots055/.local/lib/python3.10/site-packages (from cffi>=2.0.0->cryptography->ansible-core~=2.17.7->ansible) (3.0)

--- a/=2.2.2
+++ b/=2.2.2
@@ -1,0 +1,7 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: urllib3 in /usr/lib/python3/dist-packages (1.26.5)
+Collecting urllib3
+  Using cached urllib3-2.6.3-py3-none-any.whl.metadata (6.9 kB)
+Using cached urllib3-2.6.3-py3-none-any.whl (131 kB)
+Installing collected packages: urllib3
+Successfully installed urllib3-2.6.3

--- a/=2.4.0
+++ b/=2.4.0
@@ -1,0 +1,7 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: pyjwt in /usr/lib/python3/dist-packages (2.3.0)
+Collecting pyjwt
+  Using cached PyJWT-2.10.1-py3-none-any.whl.metadata (4.0 kB)
+Using cached PyJWT-2.10.1-py3-none-any.whl (22 kB)
+Installing collected packages: pyjwt
+Successfully installed pyjwt-2.10.1

--- a/=2.9.1
+++ b/=2.9.1
@@ -1,0 +1,6 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: babel in /usr/lib/python3/dist-packages (2.8.0)
+Collecting babel
+  Using cached babel-2.17.0-py3-none-any.whl (10.2 MB)
+Installing collected packages: babel
+Successfully installed babel-2.17.0

--- a/=2023.7.22
+++ b/=2023.7.22
@@ -1,0 +1,6 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: certifi in /usr/lib/python3/dist-packages (2020.6.20)
+Collecting certifi
+  Using cached certifi-2026.1.4-py3-none-any.whl (152 kB)
+Installing collected packages: certifi
+Successfully installed certifi-2026.1.4

--- a/=24.7.0
+++ b/=24.7.0
@@ -1,0 +1,24 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: twisted in /usr/lib/python3/dist-packages (22.1.0)
+Collecting twisted
+  Downloading twisted-25.5.0-py3-none-any.whl.metadata (22 kB)
+Collecting attrs>=22.2.0 (from twisted)
+  Using cached attrs-25.4.0-py3-none-any.whl.metadata (10 kB)
+Collecting automat>=24.8.0 (from twisted)
+  Downloading automat-25.4.16-py3-none-any.whl.metadata (8.4 kB)
+Requirement already satisfied: constantly>=15.1 in /usr/lib/python3/dist-packages (from twisted) (15.1.0)
+Requirement already satisfied: hyperlink>=17.1.1 in /usr/lib/python3/dist-packages (from twisted) (21.0.0)
+Collecting incremental>=24.7.0 (from twisted)
+  Downloading incremental-24.11.0-py3-none-any.whl.metadata (9.5 kB)
+Requirement already satisfied: typing-extensions>=4.2.0 in /home/tridots055/.local/lib/python3.10/site-packages (from twisted) (4.15.0)
+Requirement already satisfied: zope-interface>=5 in /usr/lib/python3/dist-packages (from twisted) (5.4.0)
+Requirement already satisfied: packaging>=17.0 in /usr/local/lib/python3.10/dist-packages (from incremental>=24.7.0->twisted) (25.0)
+Requirement already satisfied: tomli in /usr/local/lib/python3.10/dist-packages (from incremental>=24.7.0->twisted) (2.3.0)
+Downloading twisted-25.5.0-py3-none-any.whl (3.2 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.2/3.2 MB 8.9 MB/s  0:00:00
+Using cached attrs-25.4.0-py3-none-any.whl (67 kB)
+Downloading automat-25.4.16-py3-none-any.whl (42 kB)
+Downloading incremental-24.11.0-py3-none-any.whl (21 kB)
+Installing collected packages: incremental, automat, attrs, twisted
+
+Successfully installed attrs-25.4.0 automat-25.4.16 incremental-24.11.0 twisted-25.5.0

--- a/=25.3
+++ b/=25.3
@@ -1,0 +1,6 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: pip in /usr/lib/python3/dist-packages (22.0.2)
+Collecting pip
+  Using cached pip-25.3-py3-none-any.whl (1.8 MB)
+Installing collected packages: pip
+Successfully installed pip-25.3

--- a/=3.1.5
+++ b/=3.1.5
@@ -1,0 +1,12 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: werkzeug in /home/tridots055/.local/lib/python3.10/site-packages (3.1.3)
+Collecting werkzeug
+  Using cached werkzeug-3.1.5-py3-none-any.whl.metadata (4.0 kB)
+Requirement already satisfied: markupsafe>=2.1.1 in /home/tridots055/.local/lib/python3.10/site-packages (from werkzeug) (3.0.3)
+Using cached werkzeug-3.1.5-py3-none-any.whl (225 kB)
+Installing collected packages: werkzeug
+  Attempting uninstall: werkzeug
+    Found existing installation: Werkzeug 3.1.3
+    Uninstalling Werkzeug-3.1.3:
+      Successfully uninstalled Werkzeug-3.1.3
+Successfully installed werkzeug-3.1.5

--- a/=3.19.1
+++ b/=3.19.1
@@ -1,0 +1,7 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: zipp in /usr/lib/python3/dist-packages (1.0.0)
+Collecting zipp
+  Downloading zipp-3.23.0-py3-none-any.whl.metadata (3.6 kB)
+Downloading zipp-3.23.0-py3-none-any.whl (10 kB)
+Installing collected packages: zipp
+Successfully installed zipp-3.23.0

--- a/=3.2.1
+++ b/=3.2.1
@@ -1,0 +1,6 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: oauthlib in /usr/lib/python3/dist-packages (3.2.0)
+Collecting oauthlib
+  Using cached oauthlib-3.3.1-py3-none-any.whl (160 kB)
+Installing collected packages: oauthlib
+Successfully installed oauthlib-3.3.1

--- a/=3.7
+++ b/=3.7
@@ -1,0 +1,6 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: idna in /usr/lib/python3/dist-packages (3.3)
+Collecting idna
+  Using cached idna-3.11-py3-none-any.whl (71 kB)
+Installing collected packages: idna
+Successfully installed idna-3.11

--- a/=42.0.2
+++ b/=42.0.2
@@ -1,0 +1,12 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: cryptography in /usr/lib/python3/dist-packages (3.4.8)
+Collecting cryptography
+  Using cached cryptography-46.0.3-cp38-abi3-manylinux_2_34_x86_64.whl (4.5 MB)
+Requirement already satisfied: typing-extensions>=4.13.2 in /home/tridots055/.local/lib/python3.10/site-packages (from cryptography) (4.15.0)
+Collecting cffi>=2.0.0
+  Using cached cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (216 kB)
+Collecting pycparser
+  Downloading pycparser-3.0-py3-none-any.whl (48 kB)
+     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.2/48.2 KB 1.1 MB/s eta 0:00:00
+Installing collected packages: pycparser, cffi, cryptography
+Successfully installed cffi-2.0.0 cryptography-46.0.3 pycparser-3.0

--- a/=5.0.9
+++ b/=5.0.9
@@ -1,0 +1,6 @@
+Defaulting to user installation because normal site-packages is not writeable
+Requirement already satisfied: configobj in /usr/lib/python3/dist-packages (5.0.6)
+Collecting configobj
+  Using cached configobj-5.0.9-py2.py3-none-any.whl (35 kB)
+Installing collected packages: configobj
+Successfully installed configobj-5.0.9

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -77,11 +77,9 @@
 <div class="sidebar-section form-attachments border-bottom">
 	<div class="attachments-actions">
 		<span class="form-sidebar-items">
-			<span>
-				<a class="pill-label ellipsis form-sidebar-label explore-link">
-					{%= frappe.utils.icon("paperclip") %}
-					{%= __("Attachments") %}
-				</a>
+			<span class="add-assignment-label form-sidebar-label">
+				{%= frappe.utils.icon("paperclip") %}
+				<span class="ellipsis">{%= __("Attachments") %}</span>
 			</span>
 			<button class="add-attachment-btn btn btn-link icon-btn">
 				<svg class="es-icon icon-sm"><use href="#es-line-add"></use></svg>

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -77,7 +77,7 @@
 <div class="sidebar-section form-attachments border-bottom">
 	<div class="attachments-actions">
 		<span class="form-sidebar-items">
-			<span class="add-assignment-label form-sidebar-label">
+			<span class="form-sidebar-label">
 				{%= frappe.utils.icon("paperclip") %}
 				<span class="ellipsis">{%= __("Attachments") %}</span>
 			</span>


### PR DESCRIPTION
## Description
Fixed the underline appearing on attachment label during hover state in the form sidebar.

## Changes Made
```
			<span class="add-assignment-label form-sidebar-label">
				{%= frappe.utils.icon("paperclip") %}
				<span class="ellipsis">{%= __("Attachments") %}</span>
			</span>
```
- This prevents the default link underline behavior on hover

## Screenshots

### Before
<img width="527" height="513" alt="before" src="https://github.com/user-attachments/assets/d6716b3c-9c22-4813-81fa-e8124a450629" />

### After  
<img width="393" height="506" alt="after" src="https://github.com/user-attachments/assets/eae5fbef-ee1e-48c5-b868-de3d1a9117b0" />

## Related Issue
Fixes #36265

## Checklist
- [x] Code follows Frappe coding standards
- [x] Tested locally
- [x] Screenshots added