### PR TITLE
fix: pass name string to get_doc in desktop_icon

### DIFF
--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -192,7 +192,7 @@ def get_desktop_icons(user=None, bootinfo=None):
 		permitted_parent_labels = set()
 		if bootinfo:
 			for s in user_icons:
-				icon = frappe.get_doc("Desktop Icon", s)
+				icon = frappe.get_doc("Desktop Icon", s.name)
 				if icon.is_permitted(bootinfo):
 					permitted_icons.append(s)
 


### PR DESCRIPTION
### Description

**What existing problem does the pull request solve?**
This PR fixes a critical bug in `frappe/desk/doctype/desktop_icon/desktop_icon.py` that causes a `SessionBootFailed` error when loading the Desk.

Currently, the `get_desktop_icons` function iterates over user icons (`s`), but mistakenly passes the entire dictionary object `s` to `frappe.get_doc` instead of the document name. This results in a `DoesNotExistError` because `get_doc` expects a string for the name argument.

**Ref:** Issue #35980

**What changes did you make?**
* Explicitly passed `s.name` (string) to `frappe.get_doc` instead of the `s` object.

- [x] closes #35980