### PR TITLE
fix(model): handle missing doctype argument in `with_doctype`

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -238,6 +238,11 @@ $.extend(frappe.model, {
 	},
 
 	with_doctype: function (doctype, callback, async) {
+		if (!doctype) {
+			callback && callback();
+			return Promise.resolve();
+		}
+
 		if (locals.DocType[doctype]) {
 			callback && callback();
 			return Promise.resolve();


### PR DESCRIPTION
Resolve: #35949

---
**Before:**

https://github.com/user-attachments/assets/afe7c07d-6ab1-4bb9-94ba-4219fa690fe1

---
**After**

https://github.com/user-attachments/assets/539640d3-40ac-45d7-8258-1cb5459e88ff

