### PR TITLE
fix(core): improve deferred insert robustness

### DIFF
--- a/frappe/deferred_insert.py
+++ b/frappe/deferred_insert.py
@@ -31,7 +31,7 @@ def save_to_db():
 		record_count = 0
 		queue_key = get_key_name(key)
 		doctype = get_doctype_name(key)
-		while frappe.cache.llen(queue_key) > 0 and record_count <= 10000:
+		while frappe.cache.llen(queue_key) > 0:
 			records = frappe.cache.lpop(queue_key)
 			records = json.loads(records.decode("utf-8"))
 			if isinstance(records, dict):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -761,8 +761,10 @@ class Document(BaseDocument):
 		if self.is_new() and not (
 			frappe.flags.in_install or frappe.flags.in_patch or frappe.flags.in_migrate
 		):
-			self.creation = self.modified
-			self.owner = self.modified_by
+			if not self.creation:
+				self.creation = self.modified
+			if not self.owner:
+				self.owner = self.modified_by
 
 		for d in self.get_all_children():
 			d.modified = self.modified


### PR DESCRIPTION
This PR addresses issue #25777 by:
1. Removing the 10,000 record processing limit in deferred insert flush to prevent starvation for high-volume queues.
2. Preserving the 'creation' and 'owner' fields when inserting documents if they are already provided, preventing metadata reset.