### PR TITLE
fix(form): show edit icon when is_title_editable or can_rename

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -204,7 +204,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 	setup_editable_title(element) {
 		let me = this;
 
-		if (me.is_title_editable()) {
+		if (me.is_title_editable() || me.can_rename()) {
 			let edit_icon = this.page.add_action_icon(
 				"square-pen",
 				() => {


### PR DESCRIPTION
Resolve: #36262
Backport: v16

---

**Before**

https://github.com/user-attachments/assets/d4a1169b-c039-4a6e-b329-fbc3e498e119


**After**

https://github.com/user-attachments/assets/d766a76e-0641-4c47-bf94-ee190b6f26a7


---
`no-docs`
