### PR TITLE
fix(form-sidebar): render title only when title field has a value

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -33,11 +33,12 @@
 <div class="sidebar-section sidebar-meta-details border-bottom">
 	<div class="flex justify-between overflow-hidden">
 		<div class="ellipsis">
-			{% if frm.doc.name != frm.get_title() %}
+			{% let title = frm.get_title(); %}
+			{% if (title && title !== frm.doc.name) { %}
 			<div class="form-details flex justify-between">
-				<span class="bold ellipsis form-title-text mr-3 text-medium">{%= frappe.utils.html2text(frm.get_title()) %}</span>
+				<span class="bold ellipsis form-title-text mr-3 text-medium">{%= frappe.utils.html2text(title) %}</span>
 			</div>
-			{% endif %}
+			{% } %}
 			<div class="form-name-container mt-2 flex justify-between form-name-copy" data-copy="{{frm.doc.name}}" >
 				<span class="ellipsis mr-3">{%= frm.doc.name %}</span>
 			</div>


### PR DESCRIPTION
**Issue :** 

On document creation, if the Title field is empty, `undefined` is shown in the sidebar.

**Ref :** #36261 


**Before :**

![Before](https://github.com/user-attachments/assets/f1305445-be34-425c-a22c-97475410e982)


**After :**

<img width="1920" height="1080" alt="After" src="https://github.com/user-attachments/assets/8353bdd1-eff1-4dba-bed3-8d8aa09de3b9" />
