### PR TITLE
fix: swap email first before swapping full name

### DIFF
--- a/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
@@ -241,9 +241,10 @@ class PersonalDataDeletionRequest(Document):
 		filter_by_meta = meta.get_field(filter_by)
 
 		if filter_by_meta and filter_by_meta.fieldtype != "Link":
-			if self.email in doc[filter_by]:
-				value = re.sub(self.full_name_regex, self.anonymization_value_map["Data"], doc[filter_by])
+			value = doc[filter_by]
+			if self.email in value:
 				value = re.sub(self.email_regex, self.anon, value)
+				value = re.sub(self.full_name_regex, self.anonymization_value_map["Data"], value)
 				self.anonymize_fields_dict[filter_by] = value
 
 		frappe.db.set_value(


### PR DESCRIPTION
email may contain full name. so to avoid full name swap from preventing email swap, email should be swapped first.