### PR TITLE
fix: file permission checks doesn't use DocShare

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -885,6 +885,16 @@ def has_permission(doc, ptype=None, user=None, debug=False):
 
 	if user != "Guest" and doc.owner == user:
 		return True
+	if (
+		user != "Guest"
+		and ptype in ("read", "write", "submit", "share")
+		and frappe.db.get_all(
+			"DocShare",
+			filters={"share_doctype": "File", "share_name": doc.name, ptype: 1},
+			or_filters={"user": user, "everyone": 1},
+		)
+	):
+		return True
 
 	if doc.attached_to_doctype and doc.attached_to_name:
 		attached_to_doctype = doc.attached_to_doctype

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -888,7 +888,7 @@ def has_permission(doc, ptype=None, user=None, debug=False):
 	if (
 		user != "Guest"
 		and ptype
-		and frappe.share.get_shared("File", filters=[["share_name", "=", doc.name]], rights=[ptype])
+		and frappe.share.get_shared("File", filters=[["share_name", "=", doc.name]], rights=[ptype], user=user)
 	):
 		return True
 

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -887,12 +887,8 @@ def has_permission(doc, ptype=None, user=None, debug=False):
 		return True
 	if (
 		user != "Guest"
-		and ptype in ("read", "write", "submit", "share")
-		and frappe.db.get_all(
-			"DocShare",
-			filters={"share_doctype": "File", "share_name": doc.name, ptype: 1},
-			or_filters={"user": user, "everyone": 1},
-		)
+		and ptype
+		and frappe.share.get_shared("File", filters=[["share_name", "=", doc.name]], rights=[ptype])
 	):
 		return True
 

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -887,8 +887,10 @@ def has_permission(doc, ptype=None, user=None, debug=False):
 		return True
 	if (
 		user != "Guest"
-		and ptype
-		and frappe.share.get_shared("File", filters=[["share_name", "=", doc.name]], rights=[ptype], user=user)
+		and ptype in ["read", "write", "share", "submit"]
+		and frappe.share.get_shared(
+			"File", filters=[["share_name", "=", doc.name]], rights=[ptype], user=user
+		)
 	):
 		return True
 


### PR DESCRIPTION
Allow users to access private files if they are shared with them, even when they don’t have access to the attached doc.

**Issue:**
<img width="1867" height="1124" alt="image" src="https://github.com/user-attachments/assets/58dc89f1-a328-466f-aac1-6a587b484dde" />
I have a Private File shared with a user. But the user can't able to access the file.

**Before:**
<img width="1867" height="1124" alt="image" src="https://github.com/user-attachments/assets/7dc5c201-d497-4c0e-9d30-7a74a78bb4fb" />
<img width="1867" height="1124" alt="image" src="https://github.com/user-attachments/assets/055c75bf-86e4-4129-8089-9cfcdcf2ab79" />

**After:**
<img width="1867" height="1124" alt="image" src="https://github.com/user-attachments/assets/5a0a6f30-7743-4307-a8e0-ab58fcf6e227" />
<img width="1867" height="1124" alt="image" src="https://github.com/user-attachments/assets/cbff918e-dde1-4474-a90e-aa4605f99ea5" />

closes: https://github.com/frappe/frappe/issues/32913
