### PR TITLE
feat: add sidebar hover-expand with lock toggle

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -39,10 +39,17 @@
 						Save
 					</button>
 				</div>
-				<a class="collapse-sidebar-link">
-					{%= frappe.utils.icon("panel-right-open" , "sm", "", "", "text-ink-gray-7 current-color", true)%}
-		 			<span> {%= __("Collapse") %} </span>
-				</a>
+				<div class="sidebar-controls">
+					<a class="collapse-sidebar-link">
+						{%= frappe.utils.icon("panel-right-open" , "sm", "", "", "text-ink-gray-7 current-color", true)%}
+						<span class="sidebar-link-label"> {%= __("Collapse") %} </span>
+					</a>
+					<button class="btn-reset hover-expand-toggle"
+						title="{%= __('Lock sidebar') %}"
+						aria-label="{%= __('Lock sidebar') %}">
+						{%= frappe.utils.icon("lock-open", "sm", "", "", "text-ink-gray-7 current-color", true, "lucide")%}
+					</button>
+				</div>
 				<div class="nav-item dropdown dropdown-navbar-user dropdown-mobile mt-3">
 					<button
 						class="align-center btn-reset flex nav-link"

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -56,16 +56,16 @@ frappe.ui.Sidebar = class Sidebar {
 			this.update_hover_expand_toggle_icon();
 
 			if (this.hover_expand_enabled && this.sidebar_expanded) {
-				// Convert to hover-expanded when unlocking - will collapse on mouse leave
+				// Unlocking while expanded: switch to hover mode
 				this.sidebar_expanded = false;
-				this.wrapper.addClass("hover-expanded").removeClass("expanded");
 				localStorage.setItem("sidebar-expanded", false);
+				this.wrapper.addClass("hover-expanded").removeClass("expanded");
 			} else if (!this.hover_expand_enabled && this.wrapper.hasClass("hover-expanded")) {
-				// Keep expanded when locking while hover-expanded
-				this.wrapper.addClass("expanded").removeClass("hover-expanded");
+				// Locking while hover-expanded: keep it expanded
 				this.sidebar_expanded = true;
-				this.wrapper.find(".avatar-name-email").show();
 				localStorage.setItem("sidebar-expanded", true);
+				this.wrapper.addClass("expanded").removeClass("hover-expanded");
+				this.wrapper.find(".avatar-name-email").show();
 			}
 		});
 	}
@@ -82,13 +82,6 @@ frappe.ui.Sidebar = class Sidebar {
 		$toggle.find("use").attr("href", `#icon-${icon}`);
 		$toggle.attr("title", is_locked ? __("Unlock sidebar") : __("Lock sidebar"));
 		$toggle.attr("aria-label", is_locked ? __("Unlock sidebar") : __("Lock sidebar"));
-	}
-
-	update_collapse_icon(direction) {
-		this.wrapper
-			.find(".body-sidebar .collapse-sidebar-link")
-			.find("use")
-			.attr("href", `#icon-panel-${direction}-open`);
 	}
 
 	prepare() {

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -1,5 +1,6 @@
 import "./sidebar_item";
 import { SidebarEditor } from "./sidebar_editor";
+
 frappe.ui.Sidebar = class Sidebar {
 	constructor() {
 		if (!frappe.boot.setup_complete) {
@@ -10,7 +11,7 @@ frappe.ui.Sidebar = class Sidebar {
 		// states
 		this.editor = new SidebarEditor(this);
 		this.edit_mode = this.editor.edit_mode;
-		this.sidebar_expanded = false;
+		// sidebar_expanded is set by load_sidebar_state() in make_dom()
 		this.all_sidebar_items = frappe.boot.workspace_sidebar_item;
 		this.$items = [];
 		this.fields_for_dialog = [];
@@ -23,6 +24,71 @@ frappe.ui.Sidebar = class Sidebar {
 		this.sidebar_module_map = {};
 		this.build_sidebar_module_map();
 		this.standard_items_setup = false;
+
+		this.setup_hover_expand();
+	}
+
+	setup_hover_expand() {
+		const stored = localStorage.getItem("sidebar-hover-expand");
+		if (stored !== null) {
+			this.hover_expand_enabled = stored !== "false";
+		} else {
+			// First-time user: default to locked if sidebar is expanded (consistent state)
+			this.hover_expand_enabled = !this.sidebar_expanded;
+		}
+		this.update_hover_expand_toggle_icon();
+
+		this.wrapper.on("mouseenter", ".body-sidebar", () => {
+			if (this.should_hover_expand()) {
+				this.wrapper.addClass("hover-expanded");
+			}
+		});
+
+		this.wrapper.on("mouseleave", ".body-sidebar", () => {
+			if (this.should_hover_expand()) {
+				this.wrapper.removeClass("hover-expanded");
+			}
+		});
+
+		this.wrapper.on("click", ".hover-expand-toggle", () => {
+			this.hover_expand_enabled = !this.hover_expand_enabled;
+			localStorage.setItem("sidebar-hover-expand", this.hover_expand_enabled);
+			this.update_hover_expand_toggle_icon();
+
+			if (this.hover_expand_enabled && this.sidebar_expanded) {
+				// Convert to hover-expanded when unlocking - will collapse on mouse leave
+				this.sidebar_expanded = false;
+				this.wrapper.addClass("hover-expanded").removeClass("expanded");
+				localStorage.setItem("sidebar-expanded", false);
+			} else if (!this.hover_expand_enabled && this.wrapper.hasClass("hover-expanded")) {
+				// Keep expanded when locking while hover-expanded
+				this.wrapper.addClass("expanded").removeClass("hover-expanded");
+				this.sidebar_expanded = true;
+				this.wrapper.find(".avatar-name-email").show();
+				localStorage.setItem("sidebar-expanded", true);
+			}
+		});
+	}
+
+	should_hover_expand() {
+		return !this.sidebar_expanded && !frappe.is_mobile() && this.hover_expand_enabled;
+	}
+
+	update_hover_expand_toggle_icon() {
+		const $toggle = this.wrapper.find(".hover-expand-toggle");
+		const is_locked = !this.hover_expand_enabled;
+		const icon = is_locked ? "lock" : "lock-open";
+
+		$toggle.find("use").attr("href", `#icon-${icon}`);
+		$toggle.attr("title", is_locked ? __("Unlock sidebar") : __("Lock sidebar"));
+		$toggle.attr("aria-label", is_locked ? __("Unlock sidebar") : __("Lock sidebar"));
+	}
+
+	update_collapse_icon(direction) {
+		this.wrapper
+			.find(".body-sidebar .collapse-sidebar-link")
+			.find("use")
+			.attr("href", `#icon-panel-${direction}-open`);
 	}
 
 	prepare() {
@@ -365,17 +431,12 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 
 	expand_sidebar() {
-		let direction;
 		if (this.sidebar_expanded) {
-			this.wrapper.addClass("expanded");
-			// this.sidebar_expanded = false
-			direction = "right";
+			this.wrapper.addClass("expanded").removeClass("hover-expanded");
 			$('[data-toggle="tooltip"]').tooltip("dispose");
 			this.wrapper.find(".avatar-name-email").show();
 		} else {
-			this.wrapper.removeClass("expanded");
-			// this.sidebar_expanded = true
-			direction = "left";
+			this.wrapper.removeClass("expanded hover-expanded");
 			$('[data-toggle="tooltip"]').tooltip({
 				boundary: "window",
 				container: "body",
@@ -385,10 +446,6 @@ frappe.ui.Sidebar = class Sidebar {
 		}
 
 		localStorage.setItem("sidebar-expanded", this.sidebar_expanded);
-		this.wrapper
-			.find(".body-sidebar .collapse-sidebar-link")
-			.find("use")
-			.attr("href", `#icon-panel-${direction}-open`);
 		this.sidebar_header.toggle_width(this.sidebar_expanded);
 		$(document).trigger("sidebar-expand", {
 			sidebar_expand: this.sidebar_expanded,

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -41,12 +41,20 @@ frappe.ui.Sidebar = class Sidebar {
 		this.wrapper.on("mouseenter", ".body-sidebar", () => {
 			if (this.should_hover_expand()) {
 				this.wrapper.addClass("hover-expanded");
+				// Restore section visibility based on collapsed state
+				this.items.forEach((item) => {
+					if (item.$nested_items && !item.collapsed) {
+						item.$nested_items.removeClass("hidden");
+					}
+				});
 			}
 		});
 
 		this.wrapper.on("mouseleave", ".body-sidebar", () => {
 			if (this.should_hover_expand()) {
 				this.wrapper.removeClass("hover-expanded");
+				// Hide all nested sections
+				this.wrapper.find(".nested-container").addClass("hidden");
 			}
 		});
 

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -317,7 +317,7 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 	}
 
 	setup_hover() {
-		$(".sidebar-header").on("mouseover", function (event) {
+		$(".sidebar-header").on("mouseover", function () {
 			if ($(this).parent().hasClass("active-sidebar")) return;
 			$(this).addClass("hover");
 		});

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -281,7 +281,10 @@ frappe.ui.sidebar_item.TypeSectionBreak = class SectionBreakSidebarItem extends 
 			if (e.originalEvent.isTrusted) {
 				me.save_section_break_state();
 			}
-			if (!frappe.app.sidebar.sidebar_expanded) {
+			if (
+				!frappe.app.sidebar.sidebar_expanded &&
+				!frappe.app.sidebar.wrapper.hasClass("hover-expanded")
+			) {
 				frappe.app.sidebar.open();
 				this.open();
 			}

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -249,6 +249,11 @@
 				}
 			}
 		}
+
+		// Hide hover-expand toggle on mobile (hover doesn't apply)
+		.hover-expand-toggle {
+			display: none !important;
+		}
 	}
 
 	// expands when navbar-brand is clicked

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -1,4 +1,3 @@
-// clean-this-file
 :root {
 	--sidebar-hover-color: #f3f3f3;
 	--sidebar-active-color: rgba(255, 255, 255, 1);
@@ -37,10 +36,8 @@
 	width: 50px;
 	background: var(--surface-menu-bar);
 	border-right: 1px solid var(--sidebar-border-color);
-	transition-property: all;
-	transition-duration: 0.3s;
-	transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-	// @include transition(all, 0.3s ,cubic-bezier(0.4, 0, 0.2, 1));
+	transition: width 0.2s ease-out;
+	will-change: width;
 
 	display: flex;
 	flex-direction: column;
@@ -62,11 +59,8 @@
 		overflow-y: auto;
 		position: static;
 		font-size: var(--text-base);
-		@include transition(all, 0.3s, cubic-bezier(0.4, 0, 0.2, 1));
-		// transition: width 200ms;
 		.sidebar-items {
 			width: 100%;
-			@include transition(all, 0.3s, cubic-bezier(0.4, 0, 0.2, 1));
 		}
 	}
 
@@ -83,7 +77,7 @@
 
 	.standard-sidebar-item {
 		display: flex;
-		@include transition(all, 0.3s, cubic-bezier(0.4, 0, 0.2, 1));
+		transition: background-color 0.15s ease;
 
 		margin-bottom: 1px;
 		.sidebar-item-control {
@@ -104,7 +98,6 @@
 			display: block;
 			flex: 1 1 auto;
 			align-items: center;
-			@include transition(all, 0.3s, cubic-bezier(0.4, 0, 0.2, 1));
 			cursor: pointer;
 		}
 		.item-anchor {
@@ -117,7 +110,6 @@
 			height: 30px;
 			color: var(--ink-gray-8);
 			text-decoration: none;
-			@include transition(all, 0.3s, cubic-bezier(0.4, 0, 0.2, 1));
 			.sidebar-item-icon {
 				padding: 7px;
 				display: flex;
@@ -127,20 +119,50 @@
 		}
 	}
 
+	.sidebar-controls {
+		display: flex;
+		align-items: center;
+		height: 24px;
+	}
+
 	.collapse-sidebar-link {
 		text-decoration: none;
 		font-size: var(--text-sm);
 		display: flex;
 		align-items: center;
+		flex: 1;
+		cursor: pointer;
+
 		svg {
 			margin: 0px;
 			flex: 0 0 auto;
 		}
-		span {
+
+		.sidebar-link-label {
+			display: none;
 			margin-left: 10px;
 			@include truncate();
 		}
-		@include transition(all, 0.3s, cubic-bezier(0.4, 0, 0.2, 1));
+	}
+
+	.hover-expand-toggle {
+		display: none;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		padding: 7px;
+		border-radius: 4px;
+		cursor: pointer;
+		color: var(--ink-gray-7);
+
+		&:hover {
+			background-color: var(--sidebar-hover-color);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--primary);
+			outline-offset: 2px;
+		}
 	}
 	.nav-item {
 		margin-left: -5px;
@@ -183,8 +205,32 @@
 	}
 }
 
-.body-sidebar-container.expanded {
+// Shared styles for both expanded states
+.body-sidebar-container.expanded,
+.body-sidebar-container.hover-expanded {
 	@include body-sidebar-expanded();
+
+	.collapse-sidebar-link {
+		.sidebar-link-label {
+			display: block;
+		}
+
+		// Flip the icon to point left when expanded
+		> svg {
+			transform: scaleX(-1);
+		}
+	}
+
+	.hover-expand-toggle {
+		display: flex;
+	}
+}
+
+// Hover-expanded specific overrides
+.body-sidebar-container.hover-expanded {
+	.avatar-name-email {
+		display: block !important;
+	}
 }
 
 @include media-breakpoint-down(sm) {

--- a/frappe/public/scss/desk/sidebar_header.scss
+++ b/frappe/public/scss/desk/sidebar_header.scss
@@ -9,6 +9,18 @@
 		@include truncate();
 	}
 }
+
+// Override JS inline styles for consistent header padding
+.body-sidebar-container.expanded .sidebar-header,
+.body-sidebar-container.hover-expanded .sidebar-header {
+	padding-left: 8px !important;
+	padding-right: 8px !important;
+}
+
+.body-sidebar-container:not(.expanded):not(.hover-expanded) .sidebar-header {
+	padding-left: 0px !important;
+	padding-right: 0px !important;
+}
 .header-logo-container {
 	border-radius: 8px;
 	background-color: var(--surface-gray-3);


### PR DESCRIPTION
### Description

Adds an optional hover-to-expand behavior for the sidebar. When unlocked, the sidebar automatically expands when the mouse enters and collapses when it leaves, giving users more screen real estate while keeping navigation accessible.

A lock/unlock toggle button appears next to the collapse link when the sidebar is expanded, allowing users to switch between:
- **Locked (default)**: Current behavior - sidebar stays expanded/collapsed until manually toggled
- **Unlocked**: Sidebar expands on hover and collapses on mouse leave

### Features

- Hover-expand state persists via localStorage
- Nested sections properly collapse/restore when hovering in/out
- Hidden on mobile (hover doesn't apply to touch devices)
- First-time users default to locked if sidebar is already expanded (consistent UX)

### Screenshots/GIFs
![frappe-sidebar](https://github.com/user-attachments/assets/6ffb6804-0e31-4af8-b44c-dc890eccfb59)
