### PR TITLE
fix: render checkbox values correctly in PDF reports

### DIFF
--- a/frappe/public/js/frappe/views/reports/print_grid.html
+++ b/frappe/public/js/frappe/views/reports/print_grid.html
@@ -48,6 +48,8 @@
 							{% format_data = row.is_total_row && ["Currency", "Float"].includes(col.fieldtype) ? data[0] : row %}
 							{% if (row.is_total_row && col._index == 0) { %}
 								{{ __("Total") }}
+							{% } else if (col.fieldtype == "Check") { %}
+								{{ value == 1 ? "✓" : "✗" }}
 							{% } else { %}
 								{{
 									col.formatter


### PR DESCRIPTION
Resolve: #36347 
Backport: v16

---
**Before**
<img width="1350" height="872" alt="image" src="https://github.com/user-attachments/assets/24e7f6fc-1ebb-4349-a008-0ad76aa1755d" />


**After**
<img width="1350" height="872" alt="image" src="https://github.com/user-attachments/assets/b2398257-bbf6-4ce4-90b1-942a626d844f" />

`no-docs`

