### PR TITLE
fix(permission): enforce role and module permissions for desktop icons

### DIFF
--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -79,6 +79,14 @@ class DesktopIcon(Document):
 			os.remove(file_path)
 
 	def is_permitted(self, bootinfo):
+		icon_module = None
+		if self.icon_type == "Link" and self.link_to:
+			icon_module = frappe.db.get_value("Workspace", self.link_to, "module")
+		# module permission check
+		if icon_module:
+			blocked_modules = frappe.get_cached_doc("User", frappe.session.user).get_blocked_modules()
+			if icon_module in blocked_modules:
+				return False
 		# perform a permission check based on roles table (desktop icons)
 		allowed_roles = [d.role for d in self.get("roles") or []]
 		if allowed_roles and not set(allowed_roles).intersection(frappe.get_roles()):

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -79,6 +79,10 @@ class DesktopIcon(Document):
 			os.remove(file_path)
 
 	def is_permitted(self, bootinfo):
+		# perform a permission check based on roles table (desktop icons)
+		allowed_roles = [d.role for d in self.get("roles") or []]
+		if allowed_roles and not set(allowed_roles).intersection(frappe.get_roles()):
+			return False
 		if self.icon_type == "Folder":
 			return True
 		elif self.icon_type == "App":


### PR DESCRIPTION
**fix(permission)**: This PR is a direct resolution to #36341 and in turn enforces strict permissions by respecting roles table in desktop icons. If user does not have a role corresponding to who can perceive that icon, then they will not be allowed to see the icon on desk. 

**Before**:
<img width="2880" height="1496" alt="image" src="https://github.com/user-attachments/assets/72e02c53-fa50-4a45-b075-18056876d5da" />


**After**:
<img width="2880" height="1488" alt="image" src="https://github.com/user-attachments/assets/79990815-fd8c-47f1-99e7-96a1990891b7" />


**Edit**:
- [x]  Also enforce block module permissions, avoid showing in UI if user is not allowed for a more consistent approach.

<img width="2132" height="1192" alt="image" src="https://github.com/user-attachments/assets/978881fc-40c3-4c6b-b1c4-e21ee10ed5dc" />

<img width="2880" height="1558" alt="image" src="https://github.com/user-attachments/assets/07e211cf-5baa-48b6-b1f5-dc1cb9fcb28b" />

(only see modules your allowed to see)

**couple more perms. needs to be checked (fresh pr)**

closes #36341 