### PR TITLE
feat: allowing python expression in naming

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 
 NAMING_SERIES_PATTERN = re.compile(r"^[\w\- \/.#{}]+$", re.UNICODE)
-BRACED_PARAMS_PATTERN = re.compile(r"(\{[\w | #]+\})")
+BRACED_PARAMS_PATTERN = re.compile(r"(\{[\w\s\.\(\)\[\]'\"\,\:\-\#]+\})")
 
 
 # Types that can be using in naming series fields
@@ -591,7 +591,15 @@ def _format_autoname(autoname: str, doc):
 
 	def get_param_value_for_match(match):
 		param = match.group()
-		return parse_naming_series([param[1:-1]], doc=doc)
+		content = param[1:-1]
+
+		if any(char in content for char in ".()[]'\""):
+			try:
+				return str(frappe.safe_eval(content, None, {"doc": doc, **doc.as_dict()}))
+			except Exception:
+				pass
+
+		return parse_naming_series([content], doc=doc)
 
 	# Replace braced params with their parsed value
 	name = BRACED_PARAMS_PATTERN.sub(get_param_value_for_match, autoname_value)


### PR DESCRIPTION
Enhanced naming.py to allow Python expressions within curly braces {} when using the format: naming rule. Previously, the system only supported direct field lookups (e.g., {customer_name}).

With this change, developers can use Python string slicing and basic expressions directly in the naming format.

Key Changes:

Modified the parsing logic in frappe.model.naming to evaluate expressions within the format string.
Maintained backward compatibility for existing field-based naming.
Updated the evaluation context to provide access to the document's field values.
Example Usage:

Old: format:{customer_name} → "John Doe"
New: format:{customer_name[:3].upper()}-{item_code} → "JOH-ITEM001"