### PR TITLE
fix(ui): text overflow in reset permission dialog

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -138,11 +138,12 @@ frappe.PermissionEngine = class PermissionEngine {
 				.concat(custom_rights)
 				.map((r) => {
 					return __(toTitle(frappe.unscrub(r)));
-				});
+				})
+				.join(", ");
 
 			$wrapper.append(`<div class="row">\
 				<div class="col-xs-5"><b>${__(d.role)}</b>, ${__("Level")} ${d.permlevel || 0}</div>\
-				<div class="col-xs-7">${d.rights}</div>\
+				<div class="col-xs-7 text-break">${d.rights}</div>\
 			</div><br>`);
 		});
 	}


### PR DESCRIPTION
closes #36355


Before :
<img width="1319" height="810" alt="Screenshot from 2026-01-27 12-36-29" src="https://github.com/user-attachments/assets/3889690b-bf30-4287-a8cc-c8258e3001ec" />

After :
<img width="1202" height="903" alt="Screenshot from 2026-01-27 12-58-29" src="https://github.com/user-attachments/assets/386ad01f-e5f8-4309-83ff-ebdb44e3026a" />

