### PR TITLE
fix(module_profile): run update_all_users synchronously during migration

### DIFF
--- a/frappe/core/doctype/module_profile/module_profile.py
+++ b/frappe/core/doctype/module_profile/module_profile.py
@@ -31,9 +31,17 @@ class ModuleProfile(Document):
 
 	def on_update(self):
 		self.clear_cache()
+		# Run synchronously during maintenance operations to avoid stale locks
+		# if migration fails after lock creation but before job completes
+		run_now = (
+			frappe.flags.in_test
+			or frappe.flags.in_install
+			or frappe.flags.in_migrate
+			or frappe.flags.in_fixtures
+		)
 		self.queue_action(
 			"update_all_users",
-			now=frappe.flags.in_test or frappe.flags.in_install,
+			now=run_now,
 			enqueue_after_commit=True,
 		)
 


### PR DESCRIPTION
## Summary

- Add `in_migrate` and `in_fixtures` flags to the synchronous execution condition
- Prevents stale document locks when migration fails during fixture import

Fixes #36368

## Problem

When Module Profile fixtures are imported during `bench migrate`, the `on_update` hook queues `update_all_users` asynchronously because it only checks `in_test` and `in_install` flags. The `in_migrate` and `in_fixtures` flags (which are set during migration) are not checked.

The `queue_action()` method creates a document lock BEFORE enqueueing the job. If migration fails after lock creation but before the job runs, the lock file persists and blocks subsequent migration attempts with `DocumentLockedError`.

## Solution

Add `in_migrate` and `in_fixtures` to the condition determining whether to run synchronously:

```python
run_now = (
    frappe.flags.in_test
    or frappe.flags.in_install
    or frappe.flags.in_migrate
    or frappe.flags.in_fixtures
)
```

## Test plan

- [ ] Run `bench migrate` with a Module Profile fixture
- [ ] Verify update_all_users runs synchronously (no lock file created)
- [ ] Force migration failure and verify retry succeeds