### PR TITLE
Fix sidebar items retrieval in workspace

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -308,7 +308,7 @@ def new_page(new_page):
 	if not doc.public:
 		add_to_my_workspace(doc)
 	workspaces = get_workspace_sidebar_items()
-	return {"workspace_pages": workspaces, "sidebar_items": get_sidebar_items(workspaces)}
+	return {"workspace_pages": workspaces, "sidebar_items": get_sidebar_items()}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
It seems that there is a mismatch between the workspace.py and the updated get_sidebar_items.

Previously required a positional argument (workspace) but no longer does. This fix resolves that issue in testing on my labs.
