### PR TITLE
fix: remove deprecated positional argument for get_sidebar_items

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -308,7 +308,7 @@ def new_page(new_page):
 	if not doc.public:
 		add_to_my_workspace(doc)
 	workspaces = get_workspace_sidebar_items()
-	return {"workspace_pages": workspaces, "sidebar_items": get_sidebar_items(workspaces)}
+	return {"workspace_pages": workspaces, "sidebar_items": get_sidebar_items()}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
There is a mismatch between the updated get_sidebar_items function and the workspace.py whereby workpsace.py pushes a positional argument which is no longer accepted by get_sidebar_items. This prevents the creation of Workspaces in the UI.