### PR TITLE
fix the (confirm dialog message) overflow issue

### DIFF
--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -15,6 +15,7 @@ body.modal-open[style^="padding-right"] {
 .modal {
 	// Same scrollbar as body
 	scrollbar-width: auto;
+
 	&::-webkit-scrollbar {
 		width: 12px;
 		height: 12px;
@@ -23,6 +24,7 @@ body.modal-open[style^="padding-right"] {
 	// Hide scrollbar on touch devices
 	@media (max-width: 991px) {
 		scrollbar-width: none;
+
 		&::-webkit-scrollbar {
 			width: 0;
 			height: 0;
@@ -32,6 +34,7 @@ body.modal-open[style^="padding-right"] {
 	.modal-content {
 		border-color: var(--border-color);
 	}
+
 	.modal-header {
 		position: sticky;
 		top: 0;
@@ -59,6 +62,7 @@ body.modal-open[style^="padding-right"] {
 				.icon {
 					width: 14px;
 					height: 14px;
+
 					use {
 						stroke: var(--gray-500);
 					}
@@ -69,16 +73,18 @@ body.modal-open[style^="padding-right"] {
 
 	.modal-body {
 		padding: var(--padding-md) var(--padding-lg);
-		.form-layout:first-child > .form-page {
+
+		.form-layout:first-child>.form-page {
 			.visible-section:first-child {
 				padding-top: 0;
+
 				.section-body {
 					margin-top: 0;
 				}
 			}
 		}
 
-		.form-layout:last-child > .form-page {
+		.form-layout:last-child>.form-page {
 			.visible-section:last-child {
 				padding-bottom: 0;
 			}
@@ -108,7 +114,7 @@ body.modal-open[style^="padding-right"] {
 			}
 		}
 
-		& > * {
+		&>* {
 			margin: 0;
 		}
 	}
@@ -129,6 +135,7 @@ body.modal-open[style^="padding-right"] {
 			&:first-child {
 				padding-left: 0;
 			}
+
 			&:last-child {
 				padding-right: 0;
 			}
@@ -182,6 +189,7 @@ body.modal-open[style^="padding-right"] {
 		bottom: 0;
 		margin: 0;
 		min-width: 400px;
+
 		.modal-header {
 			padding-top: var(--padding-sm);
 			padding-bottom: var(--padding-xs);
@@ -240,12 +248,15 @@ body.modal-open[style^="padding-right"] {
 			}
 
 			flex: 1;
+
 			.control-input-wrapper {
 				width: 60%;
 			}
 		}
+
 		.frappe-control:last-child {
 			margin-left: 10px;
+
 			button {
 				// same as form-control input
 				height: calc(1.5em + 0.7rem);
@@ -263,6 +274,7 @@ body.modal-open[style^="padding-right"] {
 			&[data-fieldname="email_template"] {
 				margin-right: 10px;
 			}
+
 			flex: 1;
 
 			.control-input-wrapper {
@@ -287,10 +299,13 @@ body.modal-open[style^="padding-right"] {
 	padding: 5px 15px;
 	border-radius: var(--border-radius-md);
 	color: var(--text-color);
+
 	&:not(:last-child) {
 		margin-bottom: 5px;
 	}
+
 	@extend .row;
+
 	.btn-group {
 		opacity: 0;
 		transition: opacity 0.3s ease-in-out;
@@ -300,15 +315,18 @@ body.modal-open[style^="padding-right"] {
 			align-items: center;
 		}
 	}
+
 	.assignee {
 		flex: 1;
 	}
+
 	&:hover {
 		.btn-group {
 			opacity: 1;
 			transition: opacity 0.1s ease-in-out;
 		}
 	}
+
 	.avatar {
 		margin-right: var(--margin-md);
 	}
@@ -316,18 +334,22 @@ body.modal-open[style^="padding-right"] {
 
 // Stack minimized modals
 @for $i from 1 through 5 {
+
 	// 5n + 1, 5n + 2, ...
-	body > .modal:nth-child(5n + #{$i} of .show.modal-minimize) {
+	body>.modal:nth-child(5n + #{$i} of .show.modal-minimize) {
 		--minimized-modal-index: #{$i};
 	}
 }
-.modal-minimize ~ .modal-minimize {
+
+.modal-minimize~.modal-minimize {
 	.modal-dialog {
 		bottom: calc(44px * (var(--minimized-modal-index) - 1));
 	}
+
 	.modal-header {
 		border-bottom: 0px;
 	}
+
 	.modal-content {
 		// Rounded chip style
 		border-radius: var(--border-radius-md);
@@ -345,13 +367,25 @@ body.modal-open[style^="padding-right"] {
 		}
 	}
 }
+
 .modal-dialog-centered {
 	display: flex;
 	align-items: center;
 	min-height: calc(100% - 1rem);
 }
+
 @media (min-width: 576px) {
 	.modal-dialog-centered {
 		min-height: calc(100% - 3.5rem);
 	}
+}
+
+/* confirm dialog message */
+.frappe-confirm-message {
+	line-height: 1.6;
+	margin: 0;
+	padding: 0;
+	max-width: 100%;
+	word-break: break-word;
+	white-space: normal;
 }


### PR DESCRIPTION

> Please provide enough information so that others can review your pull request:

## Description

This PR fixes the text wrapping issue in dialog box modals where long text was not wrapping properly and was overflowing the modal boundaries.

## Problem

When displaying long text content in dialog boxes, the text would overflow horizontally instead of wrapping to the next line, making the content unreadable and breaking the UI layout. This affected user experience when viewing modals with lengthy content.

## Solution

Modified the `frappe/public/scss/common/modal.scss` file to add proper text wrapping styles to modal content. This ensures that text content wraps appropriately within the modal boundaries regardless of the content length.

## Changes Made

- Updated CSS styles in `modal.scss` to enable proper text wrapping
- Ensures better responsive behavior for modal content
- Improves readability and user experience

## Testing

- Tested with various lengths of text content in dialog boxes
- Verified that text wraps correctly without overflow
- Confirmed modal layout remains intact

Fixes #36355

> Screenshots/GIFs

bug :

<img width="701" height="301" alt="Screenshot 2026-01-27 132031" src="https://github.com/user-attachments/assets/4229ca56-0501-4746-bfc2-1e97adb8a36a" />

fix :

<img width="1916" height="830" alt="Screenshot 2026-01-27 125421" src="https://github.com/user-attachments/assets/c4ea2b30-690c-4068-a672-50087ee7c835" />

