### PR TITLE
fix: auto email report sql function validation error

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -416,9 +416,10 @@ def get_report_module_dotted_path(module, report_name):
 
 def get_group_by_field(args, doctype):
 	if args["aggregate_function"] == "count":
-		group_by_field = "count(*) as _aggregate_column"
+		group_by_field = {"COUNT": "*", "as": "_aggregate_column"}
 	else:
-		group_by_field = f"{args.aggregate_function}({args.aggregate_on}) as _aggregate_column"
+		func_name = args["aggregate_function"].upper()
+		group_by_field = {func_name: args["aggregate_on"], "as": "_aggregate_column"}
 
 	return group_by_field
 


### PR DESCRIPTION
### Problem

When attempting to download or execute reports with aggregate functions in Frappe, a ValidationError was being raised. The error occurred because the query builder was generating SQL aggregate functions using raw string syntax (e.g., "count(*) as _aggregate_column"), which doesn't comply with Frappe's current validation requirements that mandate dictionary-based syntax for SQL functions.

Ref : https://github.com/frappe/frappe/blob/5cf98a548275def2edd568ae7e0057450be801dc/frappe/database/query.py#L1955


### Preview of the bug:

**Before :**


https://github.com/user-attachments/assets/62e5879c-6905-400b-aaae-542b64b1c7ab



**After :**





https://github.com/user-attachments/assets/39c4d4f4-70b7-4791-9abc-6d50ed259035

