### PR TITLE
fix(new_user): escape name

### DIFF
--- a/frappe/templates/emails/new_user.html
+++ b/frappe/templates/emails/new_user.html
@@ -1,5 +1,5 @@
 <p>
-	{{_("Hello")}} {{ first_name }}{% if last_name %} {{ last_name}}{% endif %},
+	{{_("Hello")}} {{ first_name | e }}{% if last_name %} {{ last_name | e }}{% endif %},
 </p>
 {% set site_link = "<a href='" + site_url + "'>" + site_url + "</a>" %}
 <p>{{_("A new account has been created for you at {0}").format(site_link)}}.</p>


### PR DESCRIPTION
People can enter any name, including HTML, which would get rendered as the value was being used in jinja directly

Reference: support ticket 56343
