### PR TITLE
feat: allow to add background colors for icon

### DIFF
--- a/frappe/desk/doctype/desktop_icon/desktop_icon.json
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.json
@@ -23,6 +23,7 @@
   "link",
   "hidden",
   "restrict_removal",
+  "bg_color",
   "roles_tab",
   "roles"
  ],
@@ -141,10 +142,16 @@
    "fieldname": "restrict_removal",
    "fieldtype": "Check",
    "label": "Restrict Removal"
+  },
+  {
+   "fieldname": "bg_color",
+   "fieldtype": "Select",
+   "label": "Background Color",
+   "options": "blue\ngray"
   }
  ],
  "links": [],
- "modified": "2026-01-25 15:29:33.884930",
+ "modified": "2026-01-27 18:17:48.667070",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Desktop Icon",

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -24,6 +24,7 @@ class DesktopIcon(Document):
 		from frappe.types import DF
 
 		app: DF.Autocomplete | None
+		bg_color: DF.Literal["blue", "gray"]
 		hidden: DF.Check
 		icon_image: DF.Attach | None
 		icon_type: DF.Literal["Link", "Folder", "App"]
@@ -147,6 +148,7 @@ def get_desktop_icons(user=None, bootinfo=None):
 	if not user_icons:
 		fields = [
 			"label",
+			"bg_color",
 			"link",
 			"link_type",
 			"app",

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -279,8 +279,8 @@
                     height: 5px;
                 }
                 & img{
-                    width: 9px;
-                    height: 9px;
+                    width: var(--folder-thumbnail-icon-height);
+                    height: var(--folder-thumbnail-icon-height);
                 }
             }
 

--- a/frappe/public/js/frappe/ui/desktop_icon.html
+++ b/frappe/public/js/frappe/ui/desktop_icon.html
@@ -12,7 +12,7 @@
 
         </div>
     {% } else { %}
-            {%= frappe.utils.desktop_icon(icon.label,"gray")%}
+            {%= frappe.utils.desktop_icon(icon.label, icon.bg_color || "gray") %}
     {% } %}
     {% if (!in_folder) { %}
     <div class="icon-caption">

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1389,10 +1389,6 @@ Object.assign(frappe.utils, {
 		blue: "#0981E3",
 		gray: "#7B808A",
 	},
-	desktop_bg_color(color_name) {
-		let color_value = this.desktop_pallete[color_name];
-		color_value + "";
-	},
 	icon(
 		icon_name,
 		size = "sm",


### PR DESCRIPTION
Sometimes you want to set a background color for the icon 


`no-docs`

Fixes the icons styling issue in folder of the thumbnail

Before
<img width="392" height="323" alt="Screenshot 2026-01-27 at 6 24 23 PM" src="https://github.com/user-attachments/assets/71e9f4fc-8446-4dc1-80b9-4beeeb1df652" />

After

<img width="252" height="248" alt="Screenshot 2026-01-27 at 6 37 20 PM" src="https://github.com/user-attachments/assets/e88df52b-9203-4357-8fd4-931a9c7edb39" />
