### PR TITLE
Fix: Add clear (X) button for Link field in ControlLink UI

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -14,15 +14,25 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		$(`<div class="link-field ui-front" style="position: relative;">
 			<input type="text" class="input-with-feedback form-control">
 			<span class="link-btn">
-				<a class="btn-open" tabIndex='-1' style="display: inline-block;" title="${__("Open Link")}">
+			    <a class="btn-clear" tabIndex='-1' style="display: inline-block;" title="${__("Clear")}">
+                ${frappe.utils.icon("close", "xs")}
+                </a>
+			     <a class="btn-open" tabIndex='-1' style="display: inline-block;" title="${__("Open Link")}">
 					${frappe.utils.icon("arrow-right", "xs")}
 				</a>
+				
 			</span>
 		</div>`).prependTo(this.input_area);
 		this.$input_area = $(this.input_area);
 		this.$input = this.$input_area.find("input");
 		this.$link = this.$input_area.find(".link-btn");
 		this.$link_open = this.$link.find(".btn-open");
+        this.$link_clear = this.$link.find(".btn-clear");
+		this.$link_clear.on("click", () => {
+			this.set_value("");        
+			this.$input.val("");     
+		});
+
 		this.set_input_attributes();
 		this.$input.on("focus", function () {
 			if (!me.$input.val()) {

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -599,3 +599,11 @@
 	background: var(--bg-color);
 	color: var(--ink-gray-9);
 }
+
+
+.link-btn .btn-clear svg {
+  fill: var(--text-secondary);  
+  opacity: 0.6;               
+}
+
+ 


### PR DESCRIPTION
**Summary**

This PR adds the missing clear (X) button functionality to Link fields in ControlLink UI, resolving issue #36379.

**Changes Made**

- Added clear button (X) icon next to Link fields in the DOM
- Implemented click handler to clear the linked value from the input field
- Updated the UI to match the behavior present in earlier Frappe versions
- Ensured the clear button appears only when a value is present in the Link field


https://github.com/user-attachments/assets/21db10b9-649a-4fa3-8593-d8e8b668f19a



Related Issue
Fixes #36379