### PR TITLE
fix: improve scroll-to-top button

### DIFF
--- a/frappe/public/js/frappe/form/footer/footer.js
+++ b/frappe/public/js/frappe/form/footer/footer.js
@@ -22,52 +22,24 @@ frappe.ui.form.Footer = class FormFooter {
 	setup_scroll_to_top() {
 		const $scroll_to_top_btn = this.wrapper.find(".scroll-to-top");
 		const $scroll_container = $(".main-section");
-
-		if (!$scroll_to_top_btn.length || !$scroll_container.length) {
-			return;
-		}
-
-		this.toggle_scroll_to_top_button($scroll_to_top_btn, $scroll_container);
-
-		$scroll_container.on(
-			"scroll.form-footer",
-			frappe.utils.throttle(() => {
-				this.toggle_scroll_to_top_button($scroll_to_top_btn, $scroll_container);
-			}, 100)
-		);
-
-		$(window).on(
-			"resize.form-footer",
-			frappe.utils.throttle(() => {
-				this.toggle_scroll_to_top_button($scroll_to_top_btn, $scroll_container);
-			}, 100)
-		);
-
-		setTimeout(() => {
+		if (!$scroll_to_top_btn.length || !$scroll_container.length) return;
+		const update = () =>
 			this.toggle_scroll_to_top_button($scroll_to_top_btn, $scroll_container);
-		}, 500);
+		const throttled_update = frappe.utils.throttle(update, 100);
+		$scroll_container.off("scroll.form-footer").on("scroll.form-footer", throttled_update);
+		$(window).off("resize.form-footer").on("resize.form-footer", throttled_update);
+		setTimeout(update, 500);
 	}
 	toggle_scroll_to_top_button($button, $container) {
-		if (!$button.length || !$container.length) {
-			return;
-		}
-
+		if (!$button.length || !$container.length) return;
 		const container_element = $container[0];
-		if (!container_element) {
-			return;
-		}
-
+		if (!container_element) return;
 		const scroll_top = $container.scrollTop();
 		const scroll_height = container_element.scrollHeight || 0;
 		const client_height = container_element.clientHeight || 0;
 		const needs_scroll = scroll_height > client_height;
 		const is_scrolled = scroll_top > 50;
-
-		if (needs_scroll && is_scrolled) {
-			$button.addClass("show");
-		} else {
-			$button.removeClass("show");
-		}
+		$button.toggleClass("show", needs_scroll && is_scrolled);
 	}
 	make_comment_box() {
 		this.frm.comment_box = frappe.ui.form.make_control({

--- a/frappe/public/js/frappe/form/footer/footer.js
+++ b/frappe/public/js/frappe/form/footer/footer.js
@@ -17,6 +17,57 @@ frappe.ui.form.Footer = class FormFooter {
 		this.wrapper.find(".btn-save").click(() => {
 			this.frm.save("Save", null, this);
 		});
+		this.setup_scroll_to_top();
+	}
+	setup_scroll_to_top() {
+		const $scroll_to_top_btn = this.wrapper.find(".scroll-to-top");
+		const $scroll_container = $(".main-section");
+
+		if (!$scroll_to_top_btn.length || !$scroll_container.length) {
+			return;
+		}
+
+		this.toggle_scroll_to_top_button($scroll_to_top_btn, $scroll_container);
+
+		$scroll_container.on(
+			"scroll.form-footer",
+			frappe.utils.throttle(() => {
+				this.toggle_scroll_to_top_button($scroll_to_top_btn, $scroll_container);
+			}, 100)
+		);
+
+		$(window).on(
+			"resize.form-footer",
+			frappe.utils.throttle(() => {
+				this.toggle_scroll_to_top_button($scroll_to_top_btn, $scroll_container);
+			}, 100)
+		);
+
+		setTimeout(() => {
+			this.toggle_scroll_to_top_button($scroll_to_top_btn, $scroll_container);
+		}, 500);
+	}
+	toggle_scroll_to_top_button($button, $container) {
+		if (!$button.length || !$container.length) {
+			return;
+		}
+
+		const container_element = $container[0];
+		if (!container_element) {
+			return;
+		}
+
+		const scroll_top = $container.scrollTop();
+		const scroll_height = container_element.scrollHeight || 0;
+		const client_height = container_element.clientHeight || 0;
+		const needs_scroll = scroll_height > client_height;
+		const is_scrolled = scroll_top > 50;
+
+		if (needs_scroll && is_scrolled) {
+			$button.addClass("show");
+		} else {
+			$button.removeClass("show");
+		}
 	}
 	make_comment_box() {
 		this.frm.comment_box = frappe.ui.form.make_control({

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -301,7 +301,7 @@ Object.assign(frappe.utils, {
 		$container.animate(
 			{ scrollTop: 0 },
 			{
-				duration: 500,
+				duration: 300,
 				easing: "swing",
 				complete: function () {
 					// Ensure we're at the top

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -297,7 +297,18 @@ Object.assign(frappe.utils, {
 		return content.html();
 	},
 	scroll_page_to_top() {
-		$(".main-section").scrollTop(0);
+		const $container = $(".main-section");
+		$container.animate(
+			{ scrollTop: 0 },
+			{
+				duration: 500,
+				easing: "swing",
+				complete: function () {
+					// Ensure we're at the top
+					$container.scrollTop(0);
+				},
+			}
+		);
 	},
 	scroll_to: function (
 		element,

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -458,17 +458,27 @@
 	}
 	margin: auto;
 	padding: 0 15px;
+	position: relative;
+	display: flex;
+	align-items: flex-end;
+	gap: 15px;
 
 	h5 {
 		margin: 15px 0px;
 		font-weight: bold;
 	}
-	position: relative;
+
+	.after-save {
+		flex: 1;
+		min-width: 0;
+	}
+
 	.scroll-to-top {
 		position: absolute;
-		height: 28px;
 		right: 15px;
 		bottom: 15px;
+		height: 28px;
+		flex-shrink: 0;
 		opacity: 0;
 		visibility: hidden;
 		transform: translateY(10px);
@@ -476,6 +486,10 @@
 		pointer-events: none;
 
 		&.show {
+			position: fixed;
+			right: calc(var(--form-sidebar-width, 277px) + 20px);
+			bottom: 20px;
+			z-index: 1050;
 			opacity: 1;
 			visibility: visible;
 			transform: translateY(0);

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -469,6 +469,18 @@
 		height: 28px;
 		right: 15px;
 		bottom: 15px;
+		opacity: 0;
+		visibility: hidden;
+		transform: translateY(10px);
+		transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.3s ease;
+		pointer-events: none;
+
+		&.show {
+			opacity: 1;
+			visibility: visible;
+			transform: translateY(0);
+			pointer-events: auto;
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

## Changes Made

### JavaScript (`frappe/public/js/frappe/form/footer/footer.js`)
- Added `setup_scroll_to_top()` method to initialize scroll handling
- Added `toggle_scroll_to_top_button()` to show/hide button based on:
  - Whether scrolling is needed (content height > container height)
  - Whether user has scrolled more than 50px
- Added scroll and resize event handlers with throttling
- Added delayed check for dynamic content loading

### Scroll Animation (`frappe/public/js/frappe/utils/utils.js`)
- Updated `scroll_page_to_top()` to use smooth jQuery animation
- 500ms duration with swing easing
- Ensures final position is at top

### Styles (`frappe/public/scss/desk/form.scss`)
- Button hidden by default (opacity: 0, visibility: hidden)
- Smooth fade-in/out transition (0.3s)
- Slide-up animation (translateY)
- Only visible when `.show` class is present

## Related Issues
Fixes #36266