### PR TITLE
feat: add ability to extend the desktop menu items

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -441,6 +441,8 @@ class DesktopPage {
 				},
 			},
 		];
+		if (frappe.ui.desktop_menu_items && frappe.ui.desktop_menu_items.length)
+			menu_items = [...menu_items, ...frappe.ui.desktop_menu_items];
 		frappe.ui.create_menu({
 			parent: $(".desktop-avatar"),
 			menu_items: menu_items,

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -167,6 +167,7 @@ class DesktopPage {
 	constructor(page) {
 		this.page = page;
 		this.edit_mode = false;
+		this.desktop_menu_items = [];
 		this.make(this.page);
 		this.setup();
 	}
@@ -263,6 +264,7 @@ class DesktopPage {
 	}
 
 	setup() {
+		$(document).trigger("desktop_screen", { desktop: this });
 		this.setup_avatar();
 		this.setup_notifications();
 		this.setup_navbar();
@@ -441,8 +443,8 @@ class DesktopPage {
 				},
 			},
 		];
-		if (frappe.ui.desktop_menu_items && frappe.ui.desktop_menu_items.length)
-			menu_items = [...menu_items, ...frappe.ui.desktop_menu_items];
+		if (this.desktop_menu_items && this.desktop_menu_items.length)
+			menu_items = [...menu_items, ...this.desktop_menu_items];
 		frappe.ui.create_menu({
 			parent: $(".desktop-avatar"),
 			menu_items: menu_items,
@@ -450,6 +452,9 @@ class DesktopPage {
 			// if it's LTR, we want it to open on the left (true).
 			open_on_left: !frappe.utils.is_rtl(),
 		});
+	}
+	add_menu_item(item) {
+		this.desktop_menu_items.push(item);
 	}
 	setup_navbar() {
 		$(".sticky-top > .navbar").hide();


### PR DESCRIPTION
<img width="264" height="278" alt="Screenshot 2026-01-28 at 5 33 42 AM" src="https://github.com/user-attachments/assets/e29645fd-4a60-4240-ac51-0e1e71f020a5" />

`no-docs`