### PR TITLE
feat(UX): warn users during install that multi-db support (pg/sqlite) is in testing

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -91,6 +91,19 @@ def new_site(
 
 	frappe.init(site, new_site=True)
 
+	if db_type == "postgres":
+		click.secho(
+			"\nKindly Note: PostgreSQL support is currently in development and considered experimental.",
+			fg="yellow",
+			bold=True,
+		)
+		click.secho(
+			"We are actively fixing schema and performance issues. If you encounter any bugs,\n"
+			"please feel free to report them with a full traceback at:\n"
+			"https://github.com/frappe/frappe/issues\n",
+			fg="cyan",
+		)
+
 	if site in frappe.get_all_apps():
 		click.secho(
 			f"Your bench has an app called {site}, please choose another name for the site.", fg="red"

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -104,6 +104,19 @@ def new_site(
 			fg="cyan",
 		)
 
+	if db_type == "sqlite":
+		click.secho(
+			"\nKindly Note: SQLite support is currently in development and considered experimental.",
+			fg="yellow",
+			bold=True,
+		)
+		click.secho(
+			"We are actively fixing schema and performance issues. If you encounter any bugs,\n"
+			"please feel free to report them with a full traceback at:\n"
+			"https://github.com/frappe/frappe/issues\n",
+			fg="cyan",
+		)
+
 	if site in frappe.get_all_apps():
 		click.secho(
 			f"Your bench has an app called {site}, please choose another name for the site.", fg="red"

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -90,30 +90,18 @@ def new_site(
 	from frappe.installer import _new_site
 
 	frappe.init(site, new_site=True)
-
-	if db_type == "postgres":
+	db_labels = {
+		"postgres": "PostgreSQL",
+		"sqlite": "SQLite",
+	}
+	if db_type in db_labels:
 		click.secho(
-			"\nKindly Note: PostgreSQL support is currently in development and considered experimental.",
+			f"\nNote: {db_labels[db_type]} support is currently in development and considered experimental.",
 			fg="yellow",
 			bold=True,
 		)
 		click.secho(
-			"We are actively fixing schema and performance issues. If you encounter any bugs,\n"
-			"please feel free to report them with a full traceback at:\n"
-			"https://github.com/frappe/frappe/issues\n",
-			fg="cyan",
-		)
-
-	if db_type == "sqlite":
-		click.secho(
-			"\nKindly Note: SQLite support is currently in development and considered experimental.",
-			fg="yellow",
-			bold=True,
-		)
-		click.secho(
-			"We are actively fixing schema and performance issues. If you encounter any bugs,\n"
-			"please feel free to report them with a full traceback at:\n"
-			"https://github.com/frappe/frappe/issues\n",
+			"Please report issues with a full traceback here:\nhttps://github.com/frappe/frappe/issues\n",
 			fg="cyan",
 		)
 


### PR DESCRIPTION
**feat(UX)**: This PR warns users during install that postgres + sqlite is in testing and also provides info. on where they can report bugs to. This is part of a long term strategy to have **multi-db capabilities** in Frappe especially for (MariaDB, PostgreSQL and SQLite). Part of #34660 .



**Output**:

**PostgreSQL**
<img width="1886" height="510" alt="image" src="https://github.com/user-attachments/assets/a6943843-5d4f-4a34-89ef-6e8020d1885e" />


**SQLite**
<img width="1886" height="260" alt="image" src="https://github.com/user-attachments/assets/a1cc5c06-0082-4580-8db3-9bacf9b21cb8" />
