### PR TITLE
fix(calendar): add time format

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -255,6 +255,11 @@ frappe.views.Calendar = class Calendar {
 			plugins: frappe.FullCalendar.Plugins,
 			initialView: defaults.initialView || "dayGridMonth",
 			locale: frappe.boot.lang,
+			eventTimeFormat: {
+				hour: "numeric",
+				minute: "2-digit",
+				hour12: true,
+			},
 			firstDay: 1,
 			headerToolbar: {
 				left: "prev,title,next",


### PR DESCRIPTION
**Ref:** [58189](https://support.frappe.io/helpdesk/tickets/58189?view=VIEW-HD+Ticket-781)

**Description:** The time format shows A or P instead of AM or PM

**Before:**

<img width="1920" height="1007" alt="image" src="https://github.com/user-attachments/assets/f220ee9f-884f-45eb-8ba3-fbe1ded04a8e" />

**After:**

<img width="1919" height="1010" alt="Screenshot from 2026-01-28 15-30-47" src="https://github.com/user-attachments/assets/006af218-8129-4647-8683-1838dd52441c" />


Backport needed for v-15, v-16