### PR TITLE
refactor: add title param to get_print_settings

### DIFF
--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -3,7 +3,8 @@ frappe.ui.get_print_settings = function (
 	callback,
 	letter_head,
 	pick_columns,
-	has_filters = false
+	has_filters = false,
+	title = null
 ) {
 	var print_settings = locals[":Print Settings"]["Print Settings"];
 
@@ -115,7 +116,7 @@ frappe.ui.get_print_settings = function (
 				settings.print_format = null;
 			}
 		},
-		__("Print Settings")
+		title ? __(title) : __("Print Settings")
 	);
 };
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1915,7 +1915,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 						(print_settings) => this.pdf_report(print_settings),
 						this.report_doc.letter_head,
 						this.get_visible_columns(),
-						true
+						true,
+						"PDF Settings"
 					);
 					this.add_portrait_warning(dialog);
 				},


### PR DESCRIPTION
When a user clicks **PDF** or **Print** on reports, the **Print Settings** dialog is shown with the same fields for both actions. This causes confusion, as it is unclear what action will be performed after submitting the dialog.

To resolve this, I added a new parameter, `title`, to the `get_print_settings` function so the dialog can clearly indicate the intended action.

---

**Before when click on PDF/Print**:
<img width="839" height="502" alt="image" src="https://github.com/user-attachments/assets/bf0dd4eb-84b3-4285-92e9-9a32af7ea656" />

---
**After when click on PDF**
<img width="839" height="502" alt="image" src="https://github.com/user-attachments/assets/b6668944-ebda-44c0-8262-9959c06c73fc" />

---

**After when click on Print**:
<img width="839" height="502" alt="image" src="https://github.com/user-attachments/assets/7154a376-65ff-4c30-9e0d-d60a4e7ddf3d" />



