### PR TITLE
fix: add border-radius to report datatable

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -80,7 +80,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	setup_result_area() {
 		super.setup_result_area();
 		this.setup_charts_area();
-		this.$datatable_wrapper = $('<div class="datatable-wrapper">');
+		this.$datatable_wrapper = $('<div class="datatable-wrapper rounded"></div>');
 		this.$result.append(this.$datatable_wrapper);
 		this.settings.onload && this.settings.onload(this);
 	}

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -80,7 +80,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	setup_result_area() {
 		super.setup_result_area();
 		this.setup_charts_area();
-		this.$datatable_wrapper = $('<div class="datatable-wrapper"></div>');
+		this.$datatable_wrapper = $('<div class="datatable-wrapper">');
 		this.$result.append(this.$datatable_wrapper);
 		this.settings.onload && this.settings.onload(this);
 	}

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -80,7 +80,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	setup_result_area() {
 		super.setup_result_area();
 		this.setup_charts_area();
-		this.$datatable_wrapper = $('<div class="datatable-wrapper rounded"></div>');
+		this.$datatable_wrapper = $('<div class="datatable-wrapper"></div>');
 		this.$result.append(this.$datatable_wrapper);
 		this.settings.onload && this.settings.onload(this);
 	}

--- a/frappe/public/scss/desk/frappe_datatable.scss
+++ b/frappe/public/scss/desk/frappe_datatable.scss
@@ -12,13 +12,13 @@
 	--dt-border-radius: var(--border-radius);
 	--dt-cell-bg: var(--fg-color);
 	--dt-border-color: var(--table-border-color);
-	--dt-border-radius: var(--border-radius);
 	--dt-header-cell-bg: var(--subtle-fg);
 	--dt-selection-highlight-color: var(--highlight-color);
 
 	background-color: var(--bg-color);
 	margin-left: -1px;
 	margin-top: 0px;
+	border-radius: var(--dt-border-radius);
 	@include get_textstyle("base", "regular");
 
 	.dt-cell {

--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -88,6 +88,10 @@
 	overflow: auto;
 	padding-left: 15px;
 	padding-right: 15px;
+
+	.datatable {
+		border-radius: var(--border-radius);
+	}
 }
 @include media-breakpoint-up(sm) {
 	.report-view {


### PR DESCRIPTION
**Before**
<img width="838" height="211" alt="image" src="https://github.com/user-attachments/assets/d357ac98-490f-4adc-ae37-96868b83267d" />

---
**After**
<img width="838" height="211" alt="image" src="https://github.com/user-attachments/assets/04175965-4398-4011-917c-8a0e06fa0a97" />
