### PR TITLE
ci(docs): fix broken links in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ Welcome to the Frappe Framework issue tracker! Before creating an issue, please 
 
 1. This tracker should only be used to report bugs and request features / enhancements to Frappe
     - For questions and general support, use https://stackoverflow.com/questions/tagged/frappe
-    - For documentation issues, refer to https://frappeframework.com/docs/user/en or the developer cheetsheet https://github.com/frappe/frappe/wiki/Developer-Cheatsheet
+    - For documentation issues, refer to https://docs.frappe.io/framework/user/en/introduction or the developer cheatsheet https://github.com/frappe/frappe/wiki/Developer-Cheatsheet
 2. Use the search function before creating a new issue. Duplicates will be closed and directed to
    the original discussion.
 3. When making a bug report, make sure you provide all required information. The easier it is for

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,7 @@ Welcome to the Frappe Framework issue tracker! Before creating an issue, please 
 
 1. This tracker should only be used to report bugs and request features / enhancements to Frappe
     - For questions and general support, refer to https://stackoverflow.com/questions/tagged/frappe
-    - For documentation issues, use https://frappeframework.com/docs/user/en or the developer cheetsheet https://frappeframework.com/docs/user/en/bench/resources/bench-commands-cheatsheet
+    - For documentation issues, use https://docs.frappe.io/framework/user/en/introduction or the developer cheatsheet https://frappeframework.com/docs/user/en/bench/resources/bench-commands-cheatsheet
 2. Use the search function before creating a new issue. Duplicates will be closed and directed to
    the original discussion.
 3. When making a feature request, make sure to be as verbose as possible. The better you convey your message, the     greater the drive to make it happen.


### PR DESCRIPTION
**ci(docs)**: While raising issues, noticed a few minor bugs with relation to broken links. This PR fixes those broken links and a few minor text corrections. 

`no-docs`