### PR TITLE
fix(calendar): add event time formatter

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -252,6 +252,11 @@ frappe.views.Calendar = class Calendar {
 		defaults.meridiem = "false";
 		this.cal_options = {
 			locale: frappe.boot.lang,
+			eventTimeFormat: {
+				hour: "numeric",
+				minute: "2-digit",
+				hour12: true,
+			},
 			header: {
 				left: "prev, title, next",
 				right: "today, month, agendaWeek, agendaDay",


### PR DESCRIPTION
**Ref:** [58189](https://support.frappe.io/helpdesk/tickets/58189?view=VIEW-HD+Ticket-781)

**Description:** The time format shows A or P instead of AM or PM

**Before:**

<img width="1920" height="1007" alt="image" src="https://github.com/user-attachments/assets/f220ee9f-884f-45eb-8ba3-fbe1ded04a8e" />

**After:**

<img width="1919" height="1010" alt="Screenshot from 2026-01-28 15-30-47" src="https://github.com/user-attachments/assets/006af218-8129-4647-8683-1838dd52441c" />

