### PR TITLE
fix(ui): text color for selected rows toast

### DIFF
--- a/frappe/public/scss/desk/frappe_datatable.scss
+++ b/frappe/public/scss/desk/frappe_datatable.scss
@@ -140,7 +140,7 @@
 		border-top: 0 !important;
 	}
 
-	.dt-tree-node__toggle+a {
+	.dt-tree-node__toggle + a {
 		margin-left: 4px;
 	}
 

--- a/frappe/public/scss/desk/frappe_datatable.scss
+++ b/frappe/public/scss/desk/frappe_datatable.scss
@@ -5,7 +5,7 @@
 	--dt-light-yellow: var(--yellow-50);
 	--dt-orange: var(--orange-500);
 	--dt-text-color: var(--text-muted);
-	--dt-text-light: var(--text-light);
+	--dt-text-light: var(--neutral-white);
 	--dt-spacer-1: 0.25rem;
 	--dt-spacer-2: var(--padding-xs);
 	--dt-spacer-3: 1rem;
@@ -51,6 +51,7 @@
 		.dt-row[data-is-filter] {
 			display: flex !important;
 		}
+
 		.dt-row-header {
 			background-color: var(--subtle-fg);
 		}
@@ -139,7 +140,7 @@
 		border-top: 0 !important;
 	}
 
-	.dt-tree-node__toggle + a {
+	.dt-tree-node__toggle+a {
 		margin-left: 4px;
 	}
 
@@ -185,6 +186,7 @@ table td.dt-cell {
 	0% {
 		background-color: transparent;
 	}
+
 	// 50% {
 	// 	background-color: $extra-light-yellow;
 	// }


### PR DESCRIPTION
Closes #34157

Changed the datatable toast color to neutral-white

<img width="2306" height="1241" alt="CleanShot 2026-01-29 at 16 03 12" src="https://github.com/user-attachments/assets/93424ace-fd09-44f8-adc8-e3a259143eef" />
