### PR TITLE
fix(ui): show correct estimated number of records on list view

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1218,7 +1218,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					count_without_children !== current_count ? count_without_children : undefined;
 
 				let count_str;
-				if (this.total_count === this.count_upper_bound) {
+				if (current_count > this.total_count) {
+					count_str = `${format_number(current_count, null, 0)}+`;
+				} else if (this.total_count === this.count_upper_bound) {
 					count_str = `${format_number(this.total_count - 1, null, 0)}+`;
 				} else if (this.total_count == null) {
 					count_str = "??";


### PR DESCRIPTION
Closes #29875

When we have more than 2500 rows loaded, the text used to say "2500 of 1000+" - this has now been fixed to use the current count if it's higher than the total count.

<img width="2262" height="1077" alt="CleanShot 2026-01-29 at 16 50 50" src="https://github.com/user-attachments/assets/dc3e04a2-4f84-4351-b030-dd0bc8e46154" />
