### PR TITLE
fix(ui): line up pagination with list view

### DIFF
--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -307,7 +307,7 @@ $level-margin-right: 8px;
 .layout-main-list {
 	.list-paging-area,
 	.footnote-area {
-		padding: var(--padding-sm) var(--padding-md);
+		padding: var(--padding-sm) 0;
 	}
 }
 


### PR DESCRIPTION
List view pagination toolbar was not lined up with the grid above

Before:
<img width="2541" height="1383" alt="CleanShot 2026-01-29 at 18 12 27" src="https://github.com/user-attachments/assets/167c0283-db9b-479d-aa84-48efa9d2fffe" />

After:
<img width="2541" height="1383" alt="CleanShot 2026-01-29 at 18 12 48" src="https://github.com/user-attachments/assets/abd2276b-9069-484c-bbc1-5a8af32640bd" />

