### PR TITLE
fix: Workspace routing

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.js
+++ b/frappe/desk/doctype/workspace/workspace.js
@@ -9,7 +9,7 @@ frappe.ui.form.on("Workspace", {
 	refresh: function (frm) {
 		frm.enable_save();
 
-		let url = `/app/${
+		let url = `/desk#workspace/${
 			frm.doc.public
 				? frappe.router.slug(frm.doc.title)
 				: "private/" + frappe.router.slug(frm.doc.title)

--- a/frappe/desk/doctype/workspace/workspace.js
+++ b/frappe/desk/doctype/workspace/workspace.js
@@ -9,7 +9,7 @@ frappe.ui.form.on("Workspace", {
 	refresh: function (frm) {
 		frm.enable_save();
 
-		let url = `/desk/${
+		let url = `/app/${
 			frm.doc.public
 				? frappe.router.slug(frm.doc.title)
 				: "private/" + frappe.router.slug(frm.doc.title)


### PR DESCRIPTION
Problem:
Workspace sidebar link was using legacy desk/hash routing. Direct /desk/<slug> route fails in v16.
<img width="1363" height="467" alt="image" src="https://github.com/user-attachments/assets/6a8cfceb-5db4-488c-bb6d-6c08a7b260b9" />
Solution:
Updated workspace link to use correct v16 app routing (/desk#workspace/).
<img width="1360" height="463" alt="image" src="https://github.com/user-attachments/assets/88ca9993-1874-4cf4-9951-5b53a84a1688" />

Tested:
- Workspace opens correctly via /desk#workspace/
- No 404
- bench build successful
