### PR TITLE
fix(ui): sidebar not displayed when doctype belongs to different app

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -538,8 +538,8 @@ def get_sidebar_items(allowed_workspaces):
 	from frappe.desk.doctype.workspace_sidebar.workspace_sidebar import auto_generate_sidebar_from_module
 
 	sidebars = frappe.get_all("Workspace Sidebar", fields=["name", "header_icon"])
-	module_sidebars = auto_generate_sidebar_from_module()
-	sidebars.extend(module_sidebars)
+	# module_sidebars = auto_generate_sidebar_from_module()
+	# sidebars.extend(module_sidebars)
 	sidebar_items = {}
 
 	for s in sidebars:

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -461,17 +461,23 @@ frappe.ui.Sidebar = class Sidebar {
 					entity_name = route[1];
 			}
 			let sidebars = this.get_workspace_sidebars(entity_name);
+			let original_sidebars = [...sidebars]; // Keep original list before filtering
 			this.preffered_sidebars = sidebars;
 			let module = router?.meta?.module;
 			if (this.sidebar_title && sidebars.includes(this.sidebar_title)) {
 				this.set_active_workspace_item();
 				return;
 			}
-			if (module) {
-				sidebars = this.filter_sidebars_from_app(
+			// Only filter when there are multiple sidebars
+			if (module && sidebars.length > 1) {
+				let filtered = this.filter_sidebars_from_app(
 					sidebars,
 					frappe.boot.module_app[module.toLowerCase()]
 				);
+				// Only use filtered result if there are sidebars left
+				if (filtered.length > 0) {
+					sidebars = filtered;
+				}
 			}
 			if (sidebars.length == 1) {
 				frappe.app.sidebar.setup(sidebars[0]);
@@ -480,8 +486,11 @@ frappe.ui.Sidebar = class Sidebar {
 				if (sidebars.includes(this.get_workspace_for_module(module))) {
 					frappe.app.sidebar.setup(sidebar);
 				} else {
-					frappe.app.sidebar.setup(module);
+					frappe.app.sidebar.setup(sidebars[0]);
 				}
+			} else if (original_sidebars.length > 0) {
+				// If filter removed all but we had sidebars originally, use first one
+				frappe.app.sidebar.setup(original_sidebars[0]);
 			} else if (module) {
 				this.show_sidebar_for_module(module);
 			}


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:
🐞 Fix: Custom Workspace Sidebar not displayed for DocTypes from other apps
Problem

When creating a custom Workspace Sidebar in a custom app for DocTypes that belong to another app (e.g. erpnext), the sidebar is not displayed when navigating to the DocType.

Example scenario

DocType: Supplier Quotation

Module: Buying

App: erpnext

Steps to reproduce:

Delete the default Buying workspace sidebar from erpnext

Create a new Workspace Sidebar in a custom app (e.g. my_custom_app)

Add Supplier Quotation to the new sidebar

Navigate to Supplier Quotation → List View

Reload the page

❌ Result: No workspace sidebar is displayed
✅ Expected: The custom sidebar should be shown

Root Cause

In set_workspace_sidebar(), sidebars are filtered by app using the module → app mapping:

if (module) {
    sidebars = this.filter_sidebars_from_app(
        sidebars,
        frappe.boot.module_app[module.toLowerCase()]
    );
}


Since:

Supplier Quotation belongs to module Buying

module_app["buying"] = "erpnext"

The custom sidebar belongs to my_custom_app

→ filter_sidebars_from_app() removes the custom sidebar, resulting in no sidebar being rendered.

Solution

This PR adjusts the sidebar selection logic to:

Only filter sidebars by app when multiple sidebars contain the same DocType

Preserve the original sidebar list before filtering

Fall back to the first matching sidebar if app-based filtering removes all results

This ensures custom sidebars from other apps continue to work as expected.

Screenshots
Custom Workspace Sidebar
<img src="https://github.com/user-attachments/assets/d7217daf-52d9-47d6-8888-53250daa71b3" width="900" /> <img src="https://github.com/user-attachments/assets/0c347b16-944c-42ce-a9f0-4139e4c524f2" width="900" />
Before Fix
<img src="https://github.com/user-attachments/assets/c3487a4e-d7c6-4d4b-86c3-4b4a462a7f67" width="900" />
After Fix
<img src="https://github.com/user-attachments/assets/a250adbb-ceb9-44a8-9edf-47ac7387a55d" width="900" />
Impact

Enables fully custom workspace sidebars across apps

Prevents silent sidebar disappearance

Backward-compatible with existing behavior when multiple sidebars exist

