### PR TITLE
fix(data): fix currency in words for Algerian compliance

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -27,7 +27,7 @@
  "Algeria": {
   "code": "dz",
   "currency": "DZD",
-  "currency_fraction": "Santeem",
+  "currency_fraction": "Centime",
   "currency_fraction_units": 100,
   "currency_name": "Algerian Dinar",
   "currency_symbol": "\u062f.\u062c",

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1558,10 +1558,16 @@ def money_in_words(
 	elif main == "0":
 		out = f"{fraction_in_words()} {fraction_currency}"
 	else:
-		out = _(main_currency, context="Currency") + " " + in_words(main, in_million).title()
+		if main_currency == "DZD":
+			# Use Dinars for Algerian Compliance
+			out = in_words(main, in_million).title() + " " + _("Dinars", context="Currency")
+		else:
+			out = _(main_currency, context="Currency") + " " + in_words(main, in_million).title()
 		if cint(fraction):
 			out = out + " " + _("and") + " " + fraction_in_words() + " " + fraction_currency
 
+	if main_currency == "DZD":
+		return _("{0}.", context="Money in words").format(out)
 	return _("{0} only.", context="Money in words").format(out)
 
 


### PR DESCRIPTION
**fix(data):** enhance money_in_words formatting for Algerian Dinar (DZD) compliance.

In Algeria, financial regulations and banking standards require a specific syntax for writing amounts in words on checks, invoices, and legal documents. The current implementation of money_in_words follows a generic pattern that is not legally compliant in the Algerian context.
Key Changes

Currency Positioning: For DZD, the currency name ("Dinars") must follow the amount rather than prefixing it.

Terminology: Replaced the ISO code "DZD" with the formal term "Dinars" in the output string.

Removal of "Only": In Algerian legal French/Arabic formatting, the suffix "only" (e.g., "Dinars only") is not used; instead, the sentence is closed with a full stop or a specific prefix.

Formatting Logic: Added a specific condition to handle main_currency == "DZD" to ensure these changes do not affect other global currencies.

Why this is necessary

Standard Algerian banking practices (and the Algerian Accounting System - SCF) require amounts to be written as:

Current generic format: "DZD One Hundred and Fifty Centimes"

Required format: "One Hundred Dinars and Fifty Centimes."

This change ensures that ERPNext is "out-of-the-box" compliant for the Algerian market without requiring custom scripts for every print format.

**Before**:
<img width="1372" height="206" alt="image" src="https://github.com/user-attachments/assets/b24dc4ee-fa9b-4d83-b5aa-ae9006687171" />



**After**:
<img width="1372" height="106" alt="image" src="https://github.com/user-attachments/assets/d5095d17-eb7d-48b0-aef0-ab24c241d7bc" />

**Picked from PR #36083**