### PR TITLE
fix: ensure Create button is shown in Role list view (fixes #36503)

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -347,6 +347,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			this.update_url_with_filters();
 			this.setup_realtime_updates();
 			this.apply_styles_basedon_dropdown();
+			this.set_primary_action();
 		});
 	}
 


### PR DESCRIPTION
## Description

The Create Role button was missing in the Role list view in Frappe v16.

## Changes

- Added `set_primary_action()` call in the `refresh()` method to ensure the Create button is always displayed after list view refresh

## Issue

Fixes #36503

## Testing

- Navigate to Role list view
- Verify that the Create Role button is visible
- Refresh the list view and verify the button remains visible