### PR TITLE
fix: use icon_grid for Create Folder in Desk Edit layou

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -167,6 +167,7 @@ class DesktopPage {
 	constructor(page) {
 		this.page = page;
 		this.edit_mode = false;
+		this.desktop_menu_items = [];
 		this.make(this.page);
 		this.setup();
 	}
@@ -263,6 +264,7 @@ class DesktopPage {
 	}
 
 	setup() {
+		$(document).trigger("desktop_screen", { desktop: this });
 		this.setup_avatar();
 		this.setup_notifications();
 		this.setup_navbar();
@@ -441,6 +443,8 @@ class DesktopPage {
 				},
 			},
 		];
+		if (this.desktop_menu_items && this.desktop_menu_items.length)
+			menu_items = [...menu_items, ...this.desktop_menu_items];
 		frappe.ui.create_menu({
 			parent: $(".desktop-avatar"),
 			menu_items: menu_items,
@@ -448,6 +452,9 @@ class DesktopPage {
 			// if it's LTR, we want it to open on the left (true).
 			open_on_left: !frappe.utils.is_rtl(),
 		});
+	}
+	add_menu_item(item) {
+		this.desktop_menu_items.push(item);
 	}
 	setup_navbar() {
 		$(".sticky-top > .navbar").hide();

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -167,7 +167,6 @@ class DesktopPage {
 	constructor(page) {
 		this.page = page;
 		this.edit_mode = false;
-		this.desktop_menu_items = [];
 		this.make(this.page);
 		this.setup();
 	}
@@ -264,7 +263,6 @@ class DesktopPage {
 	}
 
 	setup() {
-		$(document).trigger("desktop_screen", { desktop: this });
 		this.setup_avatar();
 		this.setup_notifications();
 		this.setup_navbar();
@@ -443,8 +441,6 @@ class DesktopPage {
 				},
 			},
 		];
-		if (this.desktop_menu_items && this.desktop_menu_items.length)
-			menu_items = [...menu_items, ...this.desktop_menu_items];
 		frappe.ui.create_menu({
 			parent: $(".desktop-avatar"),
 			menu_items: menu_items,
@@ -452,9 +448,6 @@ class DesktopPage {
 			// if it's LTR, we want it to open on the left (true).
 			open_on_left: !frappe.utils.is_rtl(),
 		});
-	}
-	add_menu_item(item) {
-		this.desktop_menu_items.push(item);
 	}
 	setup_navbar() {
 		$(".sticky-top > .navbar").hide();
@@ -950,7 +943,7 @@ class DesktopIcon {
 					label: "Create Folder",
 					icon: "folder",
 					onClick: function () {
-						let folder = me.grid.add_folder();
+						let folder = me.icon_grid.add_folder();
 						add_icons_to_folder(folder.label, [icon_data.label]);
 					},
 				},


### PR DESCRIPTION
## Summary
Fixes the "Create Folder" option in the Desk Edit layout so it works when right-clicking an icon.

## Problem
- In Edit Layout, right-clicking a desktop icon and choosing "Create Folder" did nothing.
- The handler called `me.grid.add_folder()`, but `DesktopPage` only has `icon_grid`, not `grid`, so `me.grid` was undefined and the call failed.

## Solution
- Use `me.icon_grid.add_folder()` in the Create Folder menu item `onClick` in `frappe/desk/page/desktop/desktop.js`.

## Testing
1. Go to Desk.
2. Right-click the desktop → "Edit Layout".
3. Right-click any icon → "Create Folder".
4. A new folder should be created and the icon moved into it.

##Relation
Fixes #36497