### PR TITLE
fix!: Only query single for single doctypes

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -628,6 +628,9 @@ class Database:
 		        # return last login of **User** `test@example.com`
 		        user = frappe.db.get_values("User", "test@example.com", "*")[0]
 		"""
+
+		from frappe.model.utils import is_single_doctype
+
 		out = None
 		if cache and isinstance(filters, str) and fieldname in self.value_cache[doctype][filters]:
 			return self.value_cache[doctype][filters][fieldname]
@@ -679,7 +682,7 @@ class Database:
 						out = None
 					else:
 						raise
-			else:
+			elif is_single_doctype(doctype):
 				fields = [fieldname] if (isinstance(fieldname, str) and fieldname != "*") else fieldname
 				out = self.get_values_from_single(
 					fields,
@@ -692,6 +695,8 @@ class Database:
 					pluck=pluck,
 					distinct=distinct,
 				)
+			else:
+				return None
 
 		if cache and isinstance(filters, str):
 			self.value_cache[doctype][filters][fieldname] = out


### PR DESCRIPTION
Right now, if `None` is passed as second arguement we automatically
query singles, in 99% cases this just results in `None` with extra
steps... But why do that?

Better to terminate query early and return nothing if `pk==null` is
requested.

```
In [1]: frappe.db.get_value("User", None, ["name"], debug=True)
SELECT `field`,`value` FROM `tabSingles` WHERE `field` IN ('name') AND `doctype`='User'
```

Closes https://github.com/frappe/frappe/issues/36506 