### PR TITLE
fix: prevent delete icon from going out of view

### DIFF
--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -121,7 +121,7 @@ export default class ListSettings {
 						<div class="col-10" style="padding-left:0px;">
 							${__(me.fields[idx].label, null, me.doctype)}
 						</div>
-						<div class="col-1 ${can_remove}">
+						<div class="col-1 ${can_remove} pl-0 pl-sm-3">
 							<a class="text-muted remove-field" data-fieldname="${me.fields[idx].fieldname}">
 								${frappe.utils.icon("trash", "xs")}
 							</a>


### PR DESCRIPTION
- Before
<img width="848" height="438" alt="image" src="https://github.com/user-attachments/assets/bdd25334-2670-4a16-89c3-58706337eb2a" />

- After
<img width="792" height="462" alt="image" src="https://github.com/user-attachments/assets/de816fa3-2dd7-4bab-884a-0a7356f7348c" />
