### PR TITLE
fix: javascript parse_template_string algorithm

### DIFF
--- a/frappe/gettext/extractors/javascript.py
+++ b/frappe/gettext/extractors/javascript.py
@@ -204,8 +204,17 @@ def parse_template_string(
 		if level > 0:
 			if not inside_str and character in ('"', "'", "`"):
 				inside_str = character
-			elif inside_str == character and prev_character != "\\":
-				inside_str = False
+			elif inside_str == character:
+				# Count consecutive backslashes before the quote
+				# The quote is escaped only if there's an odd number of backslashes
+				num_backslashes = 0
+				check_pos = len(expression_contents) - 1
+				while check_pos >= 0 and expression_contents[check_pos] == "\\":
+					num_backslashes += 1
+					check_pos -= 1
+				# If even number of backslashes (including 0), the quote is not escaped
+				if num_backslashes % 2 == 0:
+					inside_str = False
 
 		if level:
 			expression_contents += character

--- a/frappe/gettext/extractors/javascript.py
+++ b/frappe/gettext/extractors/javascript.py
@@ -72,13 +72,14 @@ def extract_javascript(code, keywords=None, options=None, lineno=1):
 	closing_operators = {"]", "}"}
 	all_container_operators = opening_operators.union(closing_operators)
 	dotted = any("." in kw for kw in keywords)
+	# Offset for line numbers
+	line_offset = lineno - 1
 
 	for token in tokenize(
 		code,
 		jsx=True,
 		dotted=dotted,
 		template_string=options.get("template_string", True),
-		lineno=lineno,
 	):
 		if (  # Turn keyword`foo` expressions into keyword("foo") calls:
 			funcname
@@ -86,18 +87,18 @@ def extract_javascript(code, keywords=None, options=None, lineno=1):
 			and token.type  # we've seen nothing after the keyword...
 			== "template_string"  # this is a template string
 		):
-			message_lineno = token.lineno
+			message_lineno = token.lineno + line_offset
 			messages = [unquote_string(token.value)]
 			call_stack = 0
 			tree_level = 0
 			token = Token("operator", ")", token.lineno)
 
 		if not funcname and token.type == "template_string":
-			yield from parse_template_string(token.value, keywords, options, token.lineno)
+			yield from parse_template_string(token.value, keywords, options, token.lineno + line_offset)
 
 		if token.type == "operator" and token.value == "(":
 			if funcname:
-				message_lineno = token.lineno
+				message_lineno = token.lineno + line_offset
 				call_stack += 1
 
 		elif call_stack >= 0 and token.type == "operator" and token.value in all_container_operators:
@@ -191,9 +192,12 @@ def parse_template_string(
 	level = 0
 	inside_str = False
 	expression_contents = ""
+	expression_start_lineno = lineno
+
 	for character in template_string[1:-1]:
-		# Track newlines to maintain correct line numbers
-		if character == "\n":
+		# Track newlines outside of ${...} expressions to maintain correct line numbers.
+		# Newlines inside expressions are accounted for separately via line_re on expression_contents.
+		if character == "\n" and level == 0:
 			lineno += 1
 
 		# Only track strings when we're inside an expression
@@ -208,11 +212,14 @@ def parse_template_string(
 		if not inside_str:
 			if character == "{" and prev_character == "$":
 				level += 1
+				expression_start_lineno = lineno
 			elif level and character == "}":
 				level -= 1
 				if level == 0 and expression_contents:
 					expression_contents = expression_contents[:-1]
-					yield from extract_javascript(expression_contents, keywords, options, lineno)
+					yield from extract_javascript(
+						expression_contents, keywords, options, expression_start_lineno
+					)
 					lineno += len(line_re.findall(expression_contents))
 					expression_contents = ""
 		prev_character = character

--- a/frappe/gettext/extractors/javascript.py
+++ b/frappe/gettext/extractors/javascript.py
@@ -192,10 +192,17 @@ def parse_template_string(
 	inside_str = False
 	expression_contents = ""
 	for character in template_string[1:-1]:
-		if not inside_str and character in ('"', "'", "`"):
-			inside_str = character
-		elif inside_str == character and prev_character != r"\\":
-			inside_str = False
+		# Track newlines to maintain correct line numbers
+		if character == "\n":
+			lineno += 1
+
+		# Only track strings when we're inside an expression
+		if level > 0:
+			if not inside_str and character in ('"', "'", "`"):
+				inside_str = character
+			elif inside_str == character and prev_character != "\\":
+				inside_str = False
+
 		if level:
 			expression_contents += character
 		if not inside_str:

--- a/frappe/gettext/extractors/tests/test_javascript.py
+++ b/frappe/gettext/extractors/tests/test_javascript.py
@@ -15,3 +15,66 @@ class TestJavaScript(IntegrationTestCase):
 			next(extract_javascript(code)),
 			(1, "__", ("Test", None, "Context")),
 		)
+
+	def test_html_attribute_inside_template_literal(self):
+		"""Test extraction from HTML attributes within template literals (Issue #36496)"""
+		# Single line with HTML attribute
+		code = '`<input placeholder="${__("Search or type a command")}" />`'
+		result = next(extract_javascript(code))
+		self.assertEqual(result[2], "Search or type a command")
+
+		# Multiple attributes
+		code = '`<input type="text" placeholder="${__("Enter name")}" value="${__("Default")}" />`'
+		results = list(extract_javascript(code))
+		self.assertEqual(len(results), 2)
+		self.assertEqual(results[0][2], "Enter name")
+		self.assertEqual(results[1][2], "Default")
+
+	def test_multiline_template_literal_lineno(self):
+		"""Test correct line numbers for multi-line template literals"""
+		code = """let html = `<div class="test">
+    <input placeholder="${__("Enter text")}" />
+    <button>${__("Submit")}</button>
+</div>`;"""
+		results = list(extract_javascript(code))
+		self.assertEqual(len(results), 2)
+		# First message on line 2, second on line 3
+		self.assertEqual(results[0][0], 2)
+		self.assertEqual(results[1][0], 3)
+
+	def test_multiline_expression_lineno(self):
+		"""Test correct line numbers for multi-line ${...} expressions (barredterra's case)"""
+		code = """let x = `
+<input
+placeholder="${
+	__("Search or type a command")
+}"
+/>`;"""
+		results = list(extract_javascript(code))
+		self.assertEqual(len(results), 1)
+		# Message should be reported on line 4 where __() appears
+		self.assertEqual(results[0][0], 4)
+
+	def test_lineno_offset(self):
+		"""Test that lineno parameter correctly offsets line numbers"""
+		code = """
+let x = "not important";
+let html = `<div>
+    ${__("Message")}
+</div>`;
+"""
+		results = list(extract_javascript(code, lineno=100))
+		# Message is on line 4 of the code, + 100 offset - 1 = line 103
+		self.assertEqual(results[0][0], 103)
+
+	def test_backslash_escape_handling(self):
+		"""Test correct handling of backslash escapes in strings"""
+		# Double backslash (literal backslash)
+		code = r'`${__("Test with \\ backslash")}`'
+		result = next(extract_javascript(code))
+		self.assertIn("backslash", result[2])
+
+		# Escaped quote
+		code = r'`${__("Test with \" quote")}`'
+		result = next(extract_javascript(code))
+		self.assertIn("quote", result[2])


### PR DESCRIPTION
This pull request updates the JavaScript template string parser to improve line number tracking and fix a bug in string delimiter handling. 

close #36496

This applies to v15 and v16, so I recommend backporting.