### PR TITLE
fix: filters is expected to be a list

### DIFF
--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -131,7 +131,7 @@ def has_unseen_error_log():
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_log_doctypes(doctype, txt, searchfield, start, page_len, filters):
-	filters = filters or {}
+	filters = filters or []
 
 	filters.extend(
 		[


### PR DESCRIPTION
* check the next line, `extend` is being called
