### PR TITLE
fix: pass document to new_record function in address and contact rendering

### DIFF
--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -33,7 +33,7 @@ $.extend(frappe.contacts, {
 				$(field_wrapper)
 					.html(frappe.render_template(item.template, frm.doc.__onload))
 					.find(item.btn)
-					.on("click", () => new_record(item.doctype, frm));
+					.on("click", () => new_record(item.doctype, frm.doc));
 			}
 		}
 	},


### PR DESCRIPTION
Issue : 
While creating a Contact or Address from the Customer, Supplier, Company, the Contact/Address is not automatically linked to the Master DocType.

Before:

[Screencast from 2026-01-30 22-06-42.webm](https://github.com/user-attachments/assets/6f49ef99-d957-425d-b7fb-f260964ef8f7)


After:

[Screencast from 2026-01-30 22-12-04.webm](https://github.com/user-attachments/assets/04c396f6-eee0-4240-9f11-733f3c7ac066)


