### PR TITLE
feat(UX): warn users that postgres is not supported for vers below 16

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -87,6 +87,14 @@ def new_site(
 
 	frappe.init(site=site, new_site=True)
 
+	if db_type == "postgres":
+		click.secho(
+			"\nNote: PostgreSQL support is limited to Frappe v16 and above. "
+			"Fixes for earlier versions will not be added.\n",
+			fg="yellow",
+			bold=True,
+		)
+
 	if site in frappe.get_all_apps():
 		click.secho(
 			f"Your bench has an app called {site}, please choose another name for the site.", fg="red"


### PR DESCRIPTION
**feat(UX)**: This PR warns users during install that PostgreSQL is not supported for Frappe versions below 16.

**Demonstration**:
<img width="1634" height="138" alt="image" src="https://github.com/user-attachments/assets/116a7d00-3b53-43db-ab45-63d5c8d61d30" />

related to #36403