### PR TITLE
chore: Add get_traceback_msg function to get exception message

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -336,6 +336,18 @@ def get_gravatar(email: str) -> str:
 	return has_gravatar(email) or Identicon(email).base64()
 
 
+def get_traceback_msg() -> str:
+	"""Return only the message of the current exception, without traceback."""
+	from frappe.utils import strip_html
+
+	exc_type, exc_value, exc_tb = sys.exc_info()
+
+	if not exc_value:
+		return ""
+
+	return strip_html(str(exc_value))
+
+
 def get_traceback(with_context: bool = False) -> str:
 	"""Return the traceback of the Exception."""
 	from traceback_with_variables import iter_exc_lines

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -340,7 +340,7 @@ def get_traceback_msg() -> str:
 	"""Return only the message of the current exception, without traceback."""
 	from frappe.utils import strip_html
 
-	exc_type, exc_value, exc_tb = sys.exc_info()
+	_exc_type, exc_value, _exc_tb = sys.exc_info()
 
 	if not exc_value:
 		return ""


### PR DESCRIPTION
Add a function to retrieve the message of the current exception without traceback.

`no-docs`
