### PR TITLE
fix: enforce nested set module updates(update_nsm function) when on_update is used for nsm without explicit super().on_update() call

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1371,9 +1371,15 @@ class Document(BaseDocument):
 		- `on_cancel` for **Cancel**
 		- `update_after_submit` for **Update after Submit**"""
 
+		from frappe.utils.nestedset import update_nsm
+
 		if self._action == "save":
+			if getattr(self.meta, "is_tree", False):
+				update_nsm(self)
 			self.run_method("on_update")
 		elif self._action == "submit":
+			if getattr(self.meta, "is_tree", False):
+				update_nsm(self)
 			self.run_method("on_update")
 			self.run_method("on_submit")
 		elif self._action == "cancel":

--- a/frappe/tests/test_nestedset.py
+++ b/frappe/tests/test_nestedset.py
@@ -336,3 +336,59 @@ class TestNestedSet(IntegrationTestCase):
 		# Check if disabled records are skipped is set to False
 		# Children of disabled records are automatically skipped in recursion
 		self.assertEqual(len(get_children(doctype)), 1)
+
+	def test_tree_with_overridden_on_update(self):
+		"""
+		Ensure Nested Set logic runs even if controller overrides on_update
+		without calling super()
+		"""
+
+		doctype = new_doctype(
+			name="Test Tree Override",
+			is_tree=True,
+			autoname="field:some_fieldname",
+		).insert()
+
+		controller = frappe.model.base_document.get_controller(doctype.name)
+
+		def broken_on_update(self):
+			pass
+
+		controller.on_update = broken_on_update
+
+		# Insert tree records
+		root = frappe.new_doc(doctype.name)
+		root.some_fieldname = "Root"
+		root.is_group = 1
+		root.insert()
+
+		child = frappe.new_doc(doctype.name)
+		child.some_fieldname = "Child"
+		parent_field = "parent_" + doctype.name.lower().replace(" ", "_")
+		setattr(child, parent_field, "Root")
+
+		child.is_group = 0
+		child.insert()
+
+		root_lft, root_rgt = frappe.db.get_value(doctype.name, "Root", ["lft", "rgt"])
+		child_lft, child_rgt = frappe.db.get_value(doctype.name, "Child", ["lft", "rgt"])
+
+		self.assertTrue(root_lft < child_lft < child_rgt < root_rgt)
+
+		# Detach child and make it a root node
+		child = frappe.get_doc(doctype.name, "Child")
+		setattr(child, parent_field, "")
+		child.save()
+
+		root_lft, root_rgt = frappe.db.get_value(doctype.name, "Root", ["lft", "rgt"])
+		child_lft, child_rgt = frappe.db.get_value(doctype.name, "Child", ["lft", "rgt"])
+
+		# After detaching child, both should be separate roots
+		self.assertTrue(root_lft < root_rgt)
+		self.assertTrue(child_lft < child_rgt)
+
+		# Child must not be nested under root
+		self.assertFalse(root_lft < child_lft < child_rgt < root_rgt)
+
+		# Root should now be a leaf node
+		self.assertEqual(root_rgt - root_lft, 1)

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -275,7 +275,6 @@ class NestedSet(Document):
 			frappe.cache.hdel("user_permissions", frappe.session.user)
 
 	def on_update(self):
-		update_nsm(self)
 		self.validate_ledger()
 
 	def on_trash(self, allow_root_deletion=False):


### PR DESCRIPTION
Nested set updates for tree DocTypes currently rely on NestedSet.on_update() being executed. If a controller overrides on_update() without calling super(), nested set maintenance is skipped, which can leave lft / rgt values in an inconsistent state.

This change moves nested set maintenance into the document save flow so it runs reliably for all tree DocTypes, regardless of controller overrides.

closes https://github.com/frappe/frappe/issues/32670 