### PR TITLE
fix: show roles section when creating new user

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -432,18 +432,26 @@ frappe.ui.form.on("User Email", {
 frappe.ui.form.on("User Role Profile", {
 	role_profiles_add: function (frm) {
 		if (frm.doc.role_profiles.length > 0) {
-			frm.roles_editor.disable = 1;
+			if (frm.roles_editor) {
+				frm.roles_editor.disable = 1;
+			}
 			frm.call("populate_role_profile_roles").then(() => {
-				frm.roles_editor.show();
+				if (frm.roles_editor) {
+					frm.roles_editor.show();
+				}
 			});
-			$(".deselect-all, .select-all").prop("disabled", true);
+			if (frm.roles_editor) {
+				$(".deselect-all, .select-all").prop("disabled", true);
+			}
 		}
 	},
 	role_profiles_remove: function (frm) {
 		if (frm.doc.role_profiles.length == 0) {
-			frm.roles_editor.disable = 0;
-			frm.roles_editor.show();
-			$(".deselect-all, .select-all").prop("disabled", false);
+			if (frm.roles_editor) {
+				frm.roles_editor.disable = 0;
+				frm.roles_editor.show();
+				$(".deselect-all, .select-all").prop("disabled", false);
+			}
 		}
 	},
 });

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -121,6 +121,9 @@ frappe.ui.form.on("User", {
 		}
 
 		frm.toggle_display(["sb1", "sb3", "modules_access"], false);
+		if (frm.is_new() && has_access_to_edit_user()) {
+			frm.toggle_display(["sb1", "sb3", "modules_access"], true);
+		}
 		frm.trigger("setup_impersonation");
 
 		if (!frm.is_new()) {


### PR DESCRIPTION
## Summary
Fixes the Roles & Permissions section (including Role Profiles) being hidden when creating a new user via "Edit full form".

## Problem
- Add New User → Edit full form: Role Profile section was missing in Roles & Permissions.
- Role Profile was visible in quick entry but not in full form.
- Cause: In `User` form `refresh`, the script always hides `sb1`, `sb3`, and `modules_access`, then only shows them inside `if (!frm.is_new())`. For new users that block never ran, so the Roles section stayed hidden.

## Solution
- **frappe/core/doctype/user/user.js**: After hiding the sections, show them again when `frm.is_new() && has_access_to_edit_user()`, so the Roles section (including Role Profiles) is visible when creating a new user.
- **frappe/core/doctype/user/user.json** (optional, from earlier attempt): `sb1` `depends_on` updated to include `doc.__islocal` so the Roles section is visible for new docs at meta level.

Closes: #36556