### PR TITLE
fix: add support for number format in awesomebar calculator

### DIFF
--- a/cypress/integration/awesome_bar.js
+++ b/cypress/integration/awesome_bar.js
@@ -88,4 +88,17 @@ context("Awesome Bar", () => {
 		cy.get(".modal-title").should("contain", "Result");
 		cy.get(".msgprint").should("contain", "55 + 32 = 87");
 	});
+
+	it("math expressions support number formats", () => {
+		cy.window()
+			.its("frappe")
+			.then((frappe) => {
+				frappe.boot.sysdefaults.number_format = "#.###,##";
+			});
+		cy.get("@awesome_bar").type("1.500,2 + 1.500,2");
+		cy.wait(150); // Wait a bit before hitting enter
+		cy.get("@awesome_bar").type("{downarrow}{enter}");
+		cy.get(".modal-title").should("contain", "Result");
+		cy.get(".msgprint").should("contain", "1.500,2 + 1.500,2 = 3.000,4");
+	});
 });

--- a/frappe/public/js/frappe/form/controls/int.js
+++ b/frappe/public/js/frappe/form/controls/int.js
@@ -15,27 +15,7 @@ frappe.ui.form.ControlInt = class ControlInt extends frappe.ui.form.ControlData 
 		return this.parse(value);
 	}
 	eval_expression(value) {
-		if (typeof value === "string") {
-			const parsed_components = value.match(/[^\d.,]+|[\d.,]+/g);
-			var parsed_value = value;
-			if (parsed_components !== null) {
-				parsed_value = parsed_components
-					.map((v) => {
-						return isNaN(parseFloat(v)) ? v : flt(v);
-					})
-					.join("");
-			}
-			if (parsed_value.match(/^[0-9+\-/*.() ]+$/)) {
-				// If it is a string containing operators
-				try {
-					return eval(parsed_value);
-				} catch (e) {
-					// bad expression
-					return value;
-				}
-			}
-		}
-		return value;
+		return typeof value === "string" ? frappe.utils.eval_expression(value) : value;
 	}
 	parse(value) {
 		return cint(this.eval_expression(value), null);

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -413,44 +413,35 @@ frappe.search.AwesomeBar = class AwesomeBar {
 	}
 
 	make_calculator(txt) {
-		function getDecimalPlaces(num) {
-			if (Math.floor(num) === num) return 0;
-			return num.toString().split(".")[1].length || 0;
-		}
-
+		const decimalStr = get_number_format_info().decimal_str;
 		var first = txt.substr(0, 1);
+
 		if (first == parseInt(first) || first === "(" || first === "=") {
 			if (first === "=") {
 				txt = txt.substr(1);
 			}
 			try {
-				var val = eval(txt);
-
 				// Split the input to find the numbers and their decimal places
-				var numbers = txt.match(/[+-]?([0-9]*[.])?[0-9]+/g);
+				var numbers = txt.match(/[+-]?([0-9]*[.,])?[0-9]+/g);
+
 				var maxDecimalPlaces = 0;
 				if (numbers) {
 					maxDecimalPlaces = Math.max(
-						...numbers.map((num) => getDecimalPlaces(parseFloat(num)))
+						...numbers.map((num) => num.split(decimalStr)[1]?.length || 0)
 					);
 				}
 
-				// Use a default precision of 2 decimal places if no decimal places are found
-				if (maxDecimalPlaces === 0) {
-					maxDecimalPlaces = 2;
-				}
-
-				// Adjust the result to the maximum number of decimal places found or default precision
-				var rounded_val = parseFloat(val.toFixed(maxDecimalPlaces));
-
+				// Find the result to the appropriate number of decimal
+				var val = frappe.utils.eval_expression(txt);
+				var result = format_number(val, null, maxDecimalPlaces);
 				var formatted_value = __("{0} = {1}", [
 					frappe.utils.xss_sanitise(txt),
-					(rounded_val + "").bold(),
+					result.bold(),
 				]);
 				this.options.push({
 					label: formatted_value,
-					value: __("{0} = {1}", [frappe.utils.xss_sanitise(txt), rounded_val]),
-					match: rounded_val,
+					value: __("{0} = {1}", [frappe.utils.xss_sanitise(txt), result]),
+					match: result,
 					index: 80,
 					default: "Calculator",
 					onclick: function () {

--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -188,6 +188,7 @@ function get_number_format(currency) {
 }
 
 function get_number_format_info(format) {
+	if (!format) format = get_number_format();
 	var info = frappe.number_format_info[format];
 
 	if (!info) {
@@ -313,6 +314,7 @@ function fmt_money(v, format) {
 	// for backward compatibility
 	return format_currency(v, format);
 }
+
 
 Object.assign(window, {
 	flt,

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -285,15 +285,11 @@ Object.assign(frappe.utils, {
 		if (!txt) return txt;
 
 		var content = $("<div></div>").html(txt);
-		content
-			.find("blockquote")
-			.parent("blockquote")
-			.addClass("hidden")
-			.before(
-				'<p><a class="text-muted btn btn-default toggle-blockquote" style="padding: 2px 7px 0px; line-height: 1;"> \
+		content.find("blockquote").parent("blockquote").addClass("hidden").before(
+			'<p><a class="text-muted btn btn-default toggle-blockquote" style="padding: 2px 7px 0px; line-height: 1;"> \
 					• • • \
 				</a></p>'
-			);
+		);
 		return content.html();
 	},
 	scroll_page_to_top() {
@@ -2182,5 +2178,28 @@ Object.assign(frappe.utils, {
 			links.push({ is_divider: true });
 		}
 		return links;
+	},
+	eval_expression(value) {
+		if (typeof value === "string") {
+			const parsed_components = value.match(/[^\d.,]+|[\d.,]+/g);
+			var parsed_value = value;
+			if (parsed_components !== null) {
+				parsed_value = parsed_components
+					.map((v) => {
+						return isNaN(parseFloat(v)) ? v : flt(v);
+					})
+					.join("");
+			}
+			if (parsed_value.match(/^[0-9+\-/*.() ]+$/)) {
+				// If it is a string containing operators
+				try {
+					return eval(parsed_value);
+				} catch (e) {
+					// bad expression
+					return value;
+				}
+			}
+		}
+		return value;
 	},
 });


### PR DESCRIPTION
Closes #22219 - adds support for site's number format to be used in the Awesomebar calculator. 

Also formats the result accordingly.

<img width="591" height="199" alt="image" src="https://github.com/user-attachments/assets/bcbdfa89-e0e5-4f10-82cf-5d0e4ac5b101" />



