### PR TITLE
fix: refresh form value even if unchanged

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -214,6 +214,7 @@ frappe.ui.form.Control = class BaseControl {
 		const is_value_same = this.get_model_value() === value;
 
 		if (this.inside_change_event || (is_value_same && !force_set_value)) {
+			me.refresh();
 			return Promise.resolve();
 		}
 

--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -212,9 +212,8 @@ frappe.ui.form.Control = class BaseControl {
 	validate_and_set_in_model(value, e, force_set_value = false) {
 		const me = this;
 		const is_value_same = this.get_model_value() === value;
-
 		if (this.inside_change_event || (is_value_same && !force_set_value)) {
-			me.refresh();
+			me.set_formatted_input?.(value);
 			return Promise.resolve();
 		}
 


### PR DESCRIPTION
Closes #36575 - refreshes the field if the parsed value hasn't changed, which renders the field in the "expected" format as opposed to the format the user put in.