### PR TITLE
fix: bypass size limit check for requesting personal information

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -767,7 +767,7 @@ class File(Document):
 		max_file_size = get_max_file_size()
 		file_size = len(self._content or b"")
 
-		if file_size > max_file_size:
+		if self.attached_to_doctype != "Personal Data Download Request" and file_size > max_file_size:
 			msg = _("File size exceeded the maximum allowed size of {0} MB").format(max_file_size / 1048576)
 			if frappe.has_permission("System Settings", "write"):
 				msg += ".<br>" + _("You can increase the limit from System Settings.")

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -767,7 +767,7 @@ class File(Document):
 		max_file_size = get_max_file_size()
 		file_size = len(self._content or b"")
 
-		if not self.flags.skip_max_file_size_check and file_size > max_file_size:
+		if not self.flags.skip_file_size_check and file_size > max_file_size:
 			msg = _("File size exceeded the maximum allowed size of {0} MB").format(max_file_size / 1048576)
 			if frappe.has_permission("System Settings", "write"):
 				msg += ".<br>" + _("You can increase the limit from System Settings.")

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -767,7 +767,7 @@ class File(Document):
 		max_file_size = get_max_file_size()
 		file_size = len(self._content or b"")
 
-		if self.attached_to_doctype != "Personal Data Download Request" and file_size > max_file_size:
+		if not self.flags.skip_max_file_size_check and file_size > max_file_size:
 			msg = _("File size exceeded the maximum allowed size of {0} MB").format(max_file_size / 1048576)
 			if frappe.has_permission("System Settings", "write"):
 				msg += ".<br>" + _("You can increase the limit from System Settings.")

--- a/frappe/website/doctype/personal_data_download_request/personal_data_download_request.py
+++ b/frappe/website/doctype/personal_data_download_request/personal_data_download_request.py
@@ -48,7 +48,7 @@ class PersonalDataDownloadRequest(Document):
 				"is_private": 1,
 			}
 		)
-		f.flags.skip_max_file_size_check = True
+		f.flags.skip_file_size_check = True
 		f.save(ignore_permissions=True)
 
 		file_link = (

--- a/frappe/website/doctype/personal_data_download_request/personal_data_download_request.py
+++ b/frappe/website/doctype/personal_data_download_request/personal_data_download_request.py
@@ -48,6 +48,7 @@ class PersonalDataDownloadRequest(Document):
 				"is_private": 1,
 			}
 		)
+		f.flags.skip_max_file_size_check = True
 		f.save(ignore_permissions=True)
 
 		file_link = (

--- a/frappe/website/doctype/personal_data_download_request/test_personal_data_download_request.py
+++ b/frappe/website/doctype/personal_data_download_request/test_personal_data_download_request.py
@@ -50,27 +50,35 @@ class TestRequestPersonalData(IntegrationTestCase):
 		frappe.db.delete("Email Queue")
 
 	def test_large_file_request(self):
-		import frappe
+		from unittest.mock import patch
 
-		original_sendmail = frappe.sendmail
-		frappe.sendmail = lambda *args, **kwargs: None
+		frappe.db.delete("File")
+		frappe.db.delete("Email Queue")
 
 		frappe.set_user("test_privacy@example.com")
 
-		file = frappe.new_doc("Personal Data Download Request")
-		file.user = "test_privacy@example.com"
-		file.save(ignore_permissions=True)
+		with patch("frappe.sendmail"):
+			req = frappe.new_doc("Personal Data Download Request")
+			req.user = "test_privacy@example.com"
+			req.insert(ignore_permissions=True)
 
-		file_count = frappe.db.count(
+			req.generate_file_and_send_mail(
+				{
+					"data": "x" * (60 * 1024 * 1024)  # 60MB
+				}
+			)
+
+		files = frappe.get_all(
 			"File",
-			{
+			filters={
 				"attached_to_doctype": "Personal Data Download Request",
-				"attached_to_name": file.name,
+				"attached_to_name": req.name,
 			},
+			fields=["file_size"],
 		)
-		self.assertEqual(file_count, 1)
 
-		frappe.sendmail = original_sendmail
+		large_files = [f for f in files if f.file_size >= 60 * 1024 * 1024]
+		self.assertEqual(len(large_files), 1)
 
 
 def create_user_if_not_exists(email, first_name=None):

--- a/frappe/website/doctype/personal_data_download_request/test_personal_data_download_request.py
+++ b/frappe/website/doctype/personal_data_download_request/test_personal_data_download_request.py
@@ -13,10 +13,12 @@ from frappe.website.doctype.personal_data_download_request.personal_data_downloa
 
 class TestRequestPersonalData(IntegrationTestCase):
 	def setUp(self):
+		frappe.set_user("Administrator")
 		create_user_if_not_exists(email="test_privacy@example.com")
 
 	def tearDown(self):
 		frappe.db.delete("Personal Data Download Request")
+		frappe.set_user("Administrator")
 
 	def test_user_data_creation(self):
 		user_data = json.loads(get_user_data("test_privacy@example.com"))

--- a/frappe/website/doctype/personal_data_download_request/test_personal_data_download_request.py
+++ b/frappe/website/doctype/personal_data_download_request/test_personal_data_download_request.py
@@ -49,6 +49,29 @@ class TestRequestPersonalData(IntegrationTestCase):
 
 		frappe.db.delete("Email Queue")
 
+	def test_large_file_request(self):
+		import frappe
+
+		original_sendmail = frappe.sendmail
+		frappe.sendmail = lambda *args, **kwargs: None
+
+		frappe.set_user("test_privacy@example.com")
+
+		file = frappe.new_doc("Personal Data Download Request")
+		file.user = "test_privacy@example.com"
+		file.save(ignore_permissions=True)
+
+		file_count = frappe.db.count(
+			"File",
+			{
+				"attached_to_doctype": "Personal Data Download Request",
+				"attached_to_name": file.name,
+			},
+		)
+		self.assertEqual(file_count, 1)
+
+		frappe.sendmail = original_sendmail
+
 
 def create_user_if_not_exists(email, first_name=None):
 	frappe.delete_doc_if_exists("User", email)


### PR DESCRIPTION
Existing implementation for requesting personal information via: Personal Data Download Request fails if file size is greater than 25MB.

This PR - removes the file_size check if the request is attached to Personal Data Download Request doctype.