### PR TITLE
fix: dark mode colors for Notification form and panel

### DIFF
--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -280,38 +280,38 @@ $check-icon-dark: url("data:image/svg+xml, <svg viewBox='0 0 8 7' fill='none' xm
 	}
 
 	.hljs {
-		background: var(--gray-800) !important;
-		color: var(--gray-200) !important;
+		background: var(--gray-800);
+		color: var(--gray-200);
 	}
 
 	.hljs-keyword,
 	.hljs-selector-tag,
 	.hljs-built_in {
-		color: var(--blue-300) !important;
+		color: var(--blue-300);
 	}
 
 	.hljs-string,
 	.hljs-title {
-		color: var(--yellow-200) !important;
+		color: var(--yellow-200);
 	}
 
 	.hljs-number,
 	.hljs-literal {
-		color: var(--orange-300) !important;
+		color: var(--orange-300);
 	}
 
 	.hljs-comment {
-		color: var(--gray-500) !important;
+		color: var(--gray-500);
 	}
 
 	.hljs-meta,
 	.hljs-meta-keyword {
-		color: var(--gray-400) !important;
+		color: var(--gray-400);
 	}
 
 	.frappe-control pre,
 	.frappe-control pre code {
-		background-color: var(--gray-800) !important;
-		color: var(--gray-200) !important;
+		background-color: var(--gray-800);
+		color: var(--gray-200);
 	}
 }

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -267,4 +267,51 @@ $check-icon-dark: url("data:image/svg+xml, <svg viewBox='0 0 8 7' fill='none' xm
 			--indicator-dot-#{"" + $color}: var(--bg-#{$color});
 		}
 	}
+
+	.frappe-control .help-box {
+		color: var(--text-muted);
+
+		code {
+			background-color: var(--gray-800);
+			color: var(--gray-200);
+			border-radius: var(--border-radius-sm);
+			padding: 2px 6px;
+		}
+	}
+
+	.hljs {
+		background: var(--gray-800) !important;
+		color: var(--gray-200) !important;
+	}
+
+	.hljs-keyword,
+	.hljs-selector-tag,
+	.hljs-built_in {
+		color: var(--blue-300) !important;
+	}
+
+	.hljs-string,
+	.hljs-title {
+		color: var(--yellow-200) !important;
+	}
+
+	.hljs-number,
+	.hljs-literal {
+		color: var(--orange-300) !important;
+	}
+
+	.hljs-comment {
+		color: var(--gray-500) !important;
+	}
+
+	.hljs-meta,
+	.hljs-meta-keyword {
+		color: var(--gray-400) !important;
+	}
+
+	.frappe-control pre,
+	.frappe-control pre code {
+		background-color: var(--gray-800) !important;
+		color: var(--gray-200) !important;
+	}
 }


### PR DESCRIPTION
## Description
Fixes broken dark mode styling when using the Notification doctype and the notification panel (bell dropdown).

## Changes
- **Notification panel**: Replaced hardcoded `.collapse-indicator` color `#d1d8dd` with `var(--text-muted)` so the collapse chevron is visible in dark mode.
- **Form field descriptions**: In dark mode, `.frappe-control .help-box` text uses `var(--text-muted)` and inline `code` uses a dark background and light text (e.g. "{{ doc.name }} Delivered").
- **Condition Examples / code blocks**: Override highlight.js "tomorrow" (light) theme in dark mode so `.hljs` blocks use dark background and light, readable token colors.
- **Plain pre/code in forms**: `.frappe-control pre` and `pre code` get dark background and light text in dark mode.

Fixes #36583