### PR TITLE
fix(desktop): right-click context menu positioning

### DIFF
--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -179,9 +179,23 @@ frappe.ui.menu = class ContextMenu {
 
 	show(event) {
 		this.make();
-		const parent_rect = this.parent.get(0).getBoundingClientRect();
 		this.gap = 4;
+
+		if (this.opts.right_click && event) {
+			this.template.css({
+				display: "block",
+				position: "fixed",
+				left: `${event.clientX}px`,
+				top: `${event.clientY}px`,
+			});
+			this.visible = true;
+			frappe.visible_menus.push(this);
+			return;
+		}
+
+		const parent_rect = this.parent.get(0).getBoundingClientRect();
 		let top, left;
+
 		if (this.opts.nested && this.opts.parent_menu) {
 			let parent_menu_el = frappe.menu_map[this.opts.parent_menu].template;
 			let parent_menu_rect = parent_menu_el.get(0).getBoundingClientRect();
@@ -200,13 +214,6 @@ frappe.ui.menu = class ContextMenu {
 		}
 
 		if (left < 0) left = 10;
-
-		if (this.opts.right_click) {
-			this.template.css({
-				left: `${event.clientX}px`,
-				top: `${event.clientY}px`,
-			});
-		}
 
 		this.template.css({
 			display: "block",


### PR DESCRIPTION
**Before**:

https://github.com/user-attachments/assets/306aad2b-58f2-41c6-9a7b-6953e704fe3e

---
**After**


https://github.com/user-attachments/assets/d9805d2d-bdb3-4417-a4da-19ea82b93049

---
After the menu refactor in #36079, the final block in `show()` was overriding the cursor-based position set for `right_click` menus.

<img width="724" height="434" alt="image" src="https://github.com/user-attachments/assets/a2463d7f-3308-49b6-91d0-d487f81808ec" />

This caused desktop context menus to open at an incorrect position.

