### PR TITLE
fix: increase width on icon

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -549,7 +549,11 @@ def get_sidebar_items(allowed_workspaces):
 		else:
 			sidebar_title = s.title
 			w = s
-		if w.module in w.user.permitted_modules or sidebar_title == "My Workspaces":
+		if (
+			frappe.session.user == "Administrator"
+			or w.module in w.user.permitted_modules
+			or sidebar_title == "My Workspaces"
+		):
 			sidebar_items[sidebar_title.lower()] = {
 				"label": sidebar_title,
 				"items": [],

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -141,7 +141,6 @@
     text-wrap: nowrap;
     display: flex;
     justify-content: space-between;
-    width: 120px;
     height: 35px;
     flex-direction: column;
 }
@@ -182,7 +181,6 @@
         & .modal-content {
             top: 120px;
             border-radius: var(--desktop-modal-radius);
-            align-items: center;
         }
     }
 }
@@ -196,12 +194,9 @@
     width: var(--desktop-modal-width);
     height: var(--desktop-modal-height);
     padding: 24px 23px !important;
+    width: fit-content;
     & .icons{
         gap: 0px 0px;
-    }
-    & .icons:has(.desktop-edit-mode){
-        margin-top: 4px;
-        gap: 6px 6px;
     }
     .icon-container{
         min-height: var(--desktop-icon-dimension);
@@ -278,8 +273,8 @@
                     height: 5px;
                 }
                 & img{
-                    width: var(--folder-thumbnail-icon-height);
-                    height: var(--folder-thumbnail-icon-height);
+                    width: 9px;
+                    height: 9px;
                 }
             }
 

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -141,14 +141,13 @@
     text-wrap: nowrap;
     display: flex;
     justify-content: space-between;
-    width: 95px;
+    width: 120px;
     height: 35px;
     flex-direction: column;
 }
 .icon-title{
     font-weight: var(--weight-semibold);
     font-size: var(--text-md);
-    max-width: 95px;
     overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;


### PR DESCRIPTION
Some icon titles like Manfacturing and erpnext were being cut off
Before
<img width="1440" height="900" alt="Screenshot 2026-02-02 at 11 55 58 PM" src="https://github.com/user-attachments/assets/34aa9692-6545-4153-bde9-bf4c41399b61" />

After 

<img width="1440" height="900" alt="Screenshot 2026-02-02 at 11 55 24 PM" src="https://github.com/user-attachments/assets/7f3575e5-e0b5-430b-9753-4ba6e413166f" />
