### PR TITLE
fix: use linked doc title field if document has title field of link type

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -614,7 +614,12 @@ $.extend(frappe.model, {
 		}
 		let meta = frappe.get_meta(doc.doctype);
 		if (meta.title_field) {
-			return doc[meta.title_field];
+			let df = meta.fields.find((df) => df.fieldname === meta.title_field);
+			let title_value = doc[meta.title_field];
+			if (df && df.fieldtype === "Link") {
+				title_value = frappe.utils.get_link_title(df.options, title_value) ?? title_value;
+			}
+			return title_value;
 		} else {
 			return String(doc.name);
 		}

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -606,6 +606,17 @@ $.extend(frappe.model, {
 		}
 	},
 
+	get_title_from_title_field: function (doc, meta) {
+		let df = meta.fields.find((df) => df.fieldname === meta.title_field);
+		let title_value = doc[meta.title_field];
+
+		if (df && df.fieldtype === "Link") {
+			title_value = frappe.utils.get_link_title(df.options, title_value) ?? title_value;
+		}
+
+		return title_value;
+	},
+
 	get_doc_title(doc) {
 		if (typeof doc.name == "string") {
 			if (doc.name.startsWith("new-" + doc.doctype.toLowerCase().replace(/ /g, "-"))) {
@@ -614,12 +625,7 @@ $.extend(frappe.model, {
 		}
 		let meta = frappe.get_meta(doc.doctype);
 		if (meta.title_field) {
-			let df = meta.fields.find((df) => df.fieldname === meta.title_field);
-			let title_value = doc[meta.title_field];
-			if (df && df.fieldtype === "Link") {
-				title_value = frappe.utils.get_link_title(df.options, title_value) ?? title_value;
-			}
-			return title_value;
+			return this.get_title_from_title_field(doc, meta);
 		} else {
 			return String(doc.name);
 		}

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -610,8 +610,9 @@ $.extend(frappe.model, {
 		let df = meta.fields.find((df) => df.fieldname === meta.title_field);
 		let title_value = doc[meta.title_field];
 
-		if (df && df.fieldtype === "Link") {
-			title_value = frappe.utils.get_link_title(df.options, title_value) ?? title_value;
+		if (df?.fieldtype && ["Link", "Dynamic Link"].includes(df.fieldtype)) {
+			const doctype = df.fieldtype === "Dynamic Link" ? doc[df.options] : df.options;
+			title_value = frappe.utils.get_link_title(doctype, title_value) ?? title_value;
 		}
 
 		return title_value;


### PR DESCRIPTION
Document title breaks when title field of a doctype is a link with it's own title field set. It currently shows the name of the linked document instead of it's corresponding title.

### Before

https://github.com/user-attachments/assets/672b09ef-945d-44b7-9a95-3e647ff3155c

<br>

### After

https://github.com/user-attachments/assets/d9106651-5260-4dcf-8622-c74a6fc471d2


Closes [#25743](https://github.com/frappe/frappe/issues/25743)

---

#### Todo

- [x] Need to test and accommodate condition for similar case with dynamic link field type. Would break there as well ig?

