### PR TITLE
fix: package release versioning

### DIFF
--- a/frappe/core/doctype/package_release/package_release.py
+++ b/frappe/core/doctype/package_release/package_release.py
@@ -51,6 +51,7 @@ class PackageRelease(Document):
 				or 0
 			)
 		if self.patch is None:
+			# if no patch ver from query, will be incremented to 0
 			value = (
 				frappe.qb.from_(doctype)
 				.where(doctype.package == self.package)
@@ -58,7 +59,7 @@ class PackageRelease(Document):
 				.where(doctype.minor == self.minor)
 				.select(Max(doctype.patch))
 				.run()[0][0]
-				or 0
+				or -1
 			)
 			self.patch = value + 1
 

--- a/frappe/core/doctype/package_release/package_release.py
+++ b/frappe/core/doctype/package_release/package_release.py
@@ -32,28 +32,31 @@ class PackageRelease(Document):
 	def set_version(self):
 		# set the next patch release by default
 		doctype = frappe.qb.DocType("Package Release")
-		if not self.major:
+		if self.major is None:
 			self.major = (
 				frappe.qb.from_(doctype)
 				.where(doctype.package == self.package)
-				.select(Max(doctype.minor))
+				.select(Max(doctype.major))
 				.run()[0][0]
 				or 0
 			)
 
-		if not self.minor:
+		if self.minor is None:
 			self.minor = (
 				frappe.qb.from_(doctype)
 				.where(doctype.package == self.package)
-				.select(Max("minor"))
+				.where(doctype.major == self.major)
+				.select(Max(doctype.minor))
 				.run()[0][0]
 				or 0
 			)
-		if not self.patch:
+		if self.patch is None:
 			value = (
 				frappe.qb.from_(doctype)
 				.where(doctype.package == self.package)
-				.select(Max("patch"))
+				.where(doctype.major == self.major)
+				.where(doctype.minor == self.minor)
+				.select(Max(doctype.patch))
 				.run()[0][0]
 				or 0
 			)


### PR DESCRIPTION
Currently when creating a package release, the versioning has the following issues:

1. Setting `patch` to 0 forces it to 1.
2. Setting `minor` to 0 or leaving it empty results in the literal string "minor" being used in the package release name.
3. Setting next patch release automatically does not consider if major/minor already have existing values.

Example: trying to set 1.0.0
<img width="828" height="373" alt="image" src="https://github.com/user-attachments/assets/e42496cd-8a64-406d-8d6f-03325d5eb282" />

This PR fixes those 3 issues. However, you can also see the attached file has a random suffix in its name, but I believe #36589 will fix that issue.
