### PR TITLE
fix: Don't bother resolving installed app

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -260,6 +260,8 @@ def parse_app_name(name: str) -> str:
 		else:
 			_repo = name.rsplit("/", 2)[2]
 		repo = _repo.split(".", 1)[0]
+	elif name in frappe.get_all_apps():
+		return name
 	else:
 		_, repo, _ = fetch_details_from_tag(name)
 	return repo


### PR DESCRIPTION
If only app name is specified and it already exists on bench, don't
bother resolving using github APIs which can be flaky sometimes.

closes https://github.com/frappe/frappe/issues/21686