### PR TITLE
fix: title for link field in virtual docfield titles

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -337,7 +337,12 @@ def build_for_autosuggest(res: list[tuple], doctype: str) -> list[LinkSearchResu
 		for item in res:
 			item = list(item)
 			if len(item) == 1:
-				item = [item[0], item[0]]
+				title_field = meta.title_field
+				docfield = meta.get_field(title_field)
+				if docfield and docfield.is_virtual:
+					doc = frappe.get_doc(meta.name, item[0])
+					title_value = doc.get_virtual_field_value(docfield)
+				item = [item[0], title_value or item[0]]
 			label = _(item[1]) if meta.translated_doctype else item[1]
 			item[1] = item[0]
 

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -167,7 +167,9 @@ def search_widget(
 		}
 		search_fields = ["name"]
 		if meta.title_field:
-			search_fields.append(meta.title_field)
+			is_virtual_field = getattr(meta.get_field(meta.title_field), "is_virtual", False)
+			if not is_virtual_field:
+				search_fields.append(meta.title_field)
 
 		if meta.search_fields:
 			search_fields.extend(meta.get_search_fields())

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -311,16 +311,7 @@ class BaseDocument:
 	def get_db_value(self, key):
 		return frappe.db.get_value(self.doctype, self.name, key)
 
-	def get_virtual_field_value(self, df):
-		fieldname = df.fieldname
-
-		if (prop := getattr(type(self), fieldname, None)) and is_a_property(prop):
-			return getattr(self, fieldname)
-
-		elif options := getattr(df, "options", None):
-			return self._evaluate_virtual_field_options(options)
-
-	def get(self, key, filters=None, limit=None, default=None, ignore_virtual=False):
+	def get(self, key, filters=None, limit=None, default=None):
 		if isinstance(key, dict):
 			return _filter(self.get_all_children(), key, limit=limit)
 
@@ -335,15 +326,6 @@ class BaseDocument:
 
 		if limit and isinstance(value, list | tuple) and len(value) > limit:
 			value = value[:limit]
-
-		if not value:
-			df = self.meta.get_field(key)
-
-			is_virtual_field = getattr(df, "is_virtual", False)
-			ignore_virtual = ignore_virtual or key not in self.permitted_fieldnames
-
-			if is_virtual_field and not ignore_virtual:
-				value = self.get_virtual_field_value(df, ignore_virtual)
 
 		return value
 
@@ -511,6 +493,15 @@ class BaseDocument:
 			eval_globals=get_safe_globals(),
 			eval_locals={"doc": self},
 		)
+
+	def get_virtual_field_value(self, df):
+		fieldname = df.fieldname
+
+		if (prop := getattr(type(self), fieldname, None)) and is_a_property(prop):
+			return getattr(self, fieldname)
+
+		elif options := getattr(df, "options", None):
+			return self._evaluate_virtual_field_options(options)
 
 	def get_valid_dict(
 		self, sanitize=True, convert_dates_to_str=False, ignore_nulls=False, ignore_virtual=False

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -311,6 +311,15 @@ class BaseDocument:
 	def get_db_value(self, key):
 		return frappe.db.get_value(self.doctype, self.name, key)
 
+	def get_virtual_field_value(self, df):
+		fieldname = df.fieldname
+
+		if (prop := getattr(type(self), fieldname, None)) and is_a_property(prop):
+			return getattr(self, fieldname)
+
+		elif options := getattr(df, "options", None):
+			return self._evaluate_virtual_field_options(options)
+
 	def get(self, key, filters=None, limit=None, default=None, ignore_virtual=False):
 		if isinstance(key, dict):
 			return _filter(self.get_all_children(), key, limit=limit)
@@ -329,17 +338,12 @@ class BaseDocument:
 
 		if not value:
 			df = self.meta.get_field(key)
+
 			is_virtual_field = getattr(df, "is_virtual", False)
+			ignore_virtual = ignore_virtual or key not in self.permitted_fieldnames
 
-			if is_virtual_field:
-				if ignore_virtual or key not in self.permitted_fieldnames:
-					return value
-
-				if (prop := getattr(type(self), key, None)) and is_a_property(prop):
-					value = getattr(self, key)
-
-				elif options := getattr(df, "options", None):
-					value = self._evaluate_virtual_field_options(options)
+			if is_virtual_field and not ignore_virtual:
+				value = self.get_virtual_field_value(df, ignore_virtual)
 
 		return value
 
@@ -530,12 +534,7 @@ class BaseDocument:
 				if is_virtual_field:
 					if ignore_virtual or fieldname not in self.permitted_fieldnames:
 						continue
-
-					if (prop := getattr(type(self), fieldname, None)) and is_a_property(prop):
-						value = getattr(self, fieldname)
-
-					elif options := getattr(df, "options", None):
-						value = self._evaluate_virtual_field_options(options)
+					value = self.get_virtual_field_value(df)
 
 				fieldtype = df.fieldtype
 				if isinstance(value, list) and fieldtype not in table_fields:

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -311,7 +311,7 @@ class BaseDocument:
 	def get_db_value(self, key):
 		return frappe.db.get_value(self.doctype, self.name, key)
 
-	def get(self, key, filters=None, limit=None, default=None):
+	def get(self, key, filters=None, limit=None, default=None, ignore_virtual=False):
 		if isinstance(key, dict):
 			return _filter(self.get_all_children(), key, limit=limit)
 
@@ -326,6 +326,20 @@ class BaseDocument:
 
 		if limit and isinstance(value, list | tuple) and len(value) > limit:
 			value = value[:limit]
+
+		if not value:
+			df = self.meta.get_field(key)
+			is_virtual_field = getattr(df, "is_virtual", False)
+
+			if is_virtual_field:
+				if ignore_virtual or key not in self.permitted_fieldnames:
+					return value
+
+				if (prop := getattr(type(self), key, None)) and is_a_property(prop):
+					value = getattr(self, key)
+
+				elif options := getattr(df, "options", None):
+					value = self._evaluate_virtual_field_options(options)
 
 		return value
 


### PR DESCRIPTION
- When a link field doctype has title field set to a DocField but it is virtual, even with "Show Title In Link fields" enabled, the title does not appear in the dropdown for that field correctly. 

- Additionally, even when user selects a value and tries to save the doc a permission error is thrown because system tries to include the title field for the search query which breaks for virtual fields. Searching seems tightly coupled with the database query results rn and doesn't support searching through values that are calculated on-the-fly like virtual field values. We could probably add this later after considering performance and other aspects.

- Related to https://github.com/frappe/frappe/issues/27247 and only addresses part of the problem to the point where user can atleast see the title, choose and save the doc in such a scenario. Supporting virtual docfield values in `get` is more of a FR and a bigger design change requiring more thought and testing. Falls under some of the limitations highlighted here https://github.com/frappe/frappe/issues/17751 and should probably be part of that design change.
 
<br>

### Before

https://github.com/user-attachments/assets/e6137ca8-d9c4-4dac-804b-169ba4f8005a


### After

https://github.com/user-attachments/assets/99b291a6-e8c2-4753-9845-2afa38bcc507




