### PR TITLE
fix: add optional chaining to prevent errors when accessing `docinfo` properties

### DIFF
--- a/frappe/public/js/frappe/form/footer/footer.js
+++ b/frappe/public/js/frappe/form/footer/footer.js
@@ -67,7 +67,7 @@ frappe.ui.form.Footer = class FormFooter {
 	}
 
 	refresh_comments_count() {
-		let count = (this.frm.get_docinfo().comments || []).length;
+		let count = (this.frm.get_docinfo()?.comments || []).length;
 		this.wrapper.find(".comment-count")?.html(count ? `(${count})` : "");
 	}
 };

--- a/frappe/public/js/frappe/form/sidebar/assign_to.js
+++ b/frappe/public/js/frappe/form/sidebar/assign_to.js
@@ -14,6 +14,13 @@ frappe.ui.form.AssignTo = class AssignTo {
 			this.parent.toggle(false);
 			return;
 		}
+
+		let docinfo = this.frm.get_docinfo?.();
+		if (!docinfo || !docinfo.assignments) {
+			this.parent.toggle(false);
+			return;
+		}
+
 		this.parent.toggle(true);
 		this.render(this.frm.get_docinfo().assignments);
 	}

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -80,7 +80,7 @@ frappe.ui.form.Attachments = class Attachments {
 	}
 
 	get_attachments() {
-		return this.frm.get_docinfo().attachments || [];
+		return this.frm.get_docinfo()?.attachments || [];
 	}
 
 	render_attachments(attachments) {

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -61,7 +61,7 @@ frappe.ui.form.Sidebar = class {
 			this.frm.attachments.refresh();
 			this.frm.shared.refresh();
 
-			this.frm.tags && this.frm.tags.refresh(this.frm.get_docinfo().tags);
+			this.frm.tags && this.frm.tags.refresh(this.frm.get_docinfo()?.tags);
 
 			this.refresh_web_view_count();
 			this.refresh_creation_modified();

--- a/frappe/public/js/frappe/form/sidebar/share.js
+++ b/frappe/public/js/frappe/form/sidebar/share.js
@@ -10,7 +10,7 @@ frappe.ui.form.Share = class Share {
 		this.render_sidebar();
 	}
 	render_sidebar() {
-		const shared = this.shared || this.frm.get_docinfo().shared;
+		const shared = this.shared || this.frm.get_docinfo()?.shared || [];
 		const has_everyone = shared.some((s) => s && s.everyone);
 		const shared_users = shared.filter((s) => s && s.user && !s.everyone).map((s) => s.user);
 


### PR DESCRIPTION
Resolve: #36558

----
**Before**

https://github.com/user-attachments/assets/96c501b2-2205-4b91-8bbb-749d34616b5e

---
**After**


https://github.com/user-attachments/assets/518f1b43-496b-4c78-a777-6ec2f0dd758c

