### PR TITLE
fix: stale cache when creating new doc using link field

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -35,7 +35,7 @@ class LinkSearchResults(TypedDict):
 
 # this is called by the Link Field
 @frappe.whitelist()
-@http_cache(max_age=60 * 5, stale_while_revalidate=60 * 5)
+@http_cache(max_age=60, stale_while_revalidate=5 * 60)
 def search_link(
 	doctype: str,
 	txt: str,

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -165,6 +165,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		return false;
 	}
 	new_doc() {
+		this.$input._created_new_doc = true; // This is used to disable HTTP cache on this link field
 		var doctype = this.get_options();
 		var me = this;
 
@@ -425,7 +426,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		}
 
 		const filters = args.filters;
-		let use_get = !term;
+		let use_get = !term && !this.$input._created_new_doc;
 		if (use_get) {
 			const [are_filters_large, filters_str] = this.are_filters_large(filters);
 			use_get = !are_filters_large;


### PR DESCRIPTION
Steps:
1. Create a new doc using link field
2. Come back to original doc, empty the field and you won't see the doc
   you just created.

Fix: Disable cache when creating a new doc, also lower HTTP cache
timing.

If this still causes confusion with users, it'd be better to remove it.

Closes https://github.com/frappe/frappe/issues/35853
