### PR TITLE
fix(perm): permission handling for Administrator role in has_perm/get_perm JS API

### DIFF
--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -56,10 +56,16 @@ $.extend(frappe.perm, {
 
 		// Administrator should get all rights (consistent with Python has_permission/get_role_permissions)
 		if (user === "Administrator" || frappe.user_roles.includes("Administrator")) {
-			const permlevels =
-				meta && meta.permissions
-					? [...new Set([0, ...meta.permissions.map((p) => cint(p.permlevel))])].sort()
-					: [0];
+			// Default permission level
+			let permlevels = [0];
+
+			// Get all unique permission levels from the doctype's permissions
+			// Always include level 0 (default level) and sort in ascending order
+			if (meta && meta.permissions) {
+				const levels = meta.permissions.map((permission) => cint(permission.permlevel));
+				// used Set for "unique" levels
+				permlevels = [...new Set([0, ...levels])].sort();
+			}
 			const admin_perm = [];
 			permlevels.forEach((level) => {
 				const p = {

--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -62,7 +62,10 @@ $.extend(frappe.perm, {
 					: [0];
 			const admin_perm = [];
 			permlevels.forEach((level) => {
-				const p = { permlevel: level, rights_without_if_owner: new Set(frappe.perm.rights) };
+				const p = {
+					permlevel: level,
+					rights_without_if_owner: new Set(frappe.perm.rights),
+				};
 				frappe.perm.rights.forEach((right) => {
 					p[right] = 1;
 				});

--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -51,14 +51,27 @@ $.extend(frappe.perm, {
 	},
 
 	_get_perm: (doctype, doc) => {
-		let perm = [{ read: 0, permlevel: 0 }];
-
-		let meta = frappe.get_meta(doctype);
 		const user = frappe.session.user;
+		let meta = frappe.get_meta(doctype);
 
+		// Administrator should get all rights (consistent with Python has_permission/get_role_permissions)
 		if (user === "Administrator" || frappe.user_roles.includes("Administrator")) {
-			perm[0].read = 1;
+			const permlevels =
+				meta && meta.permissions
+					? [...new Set([0, ...meta.permissions.map((p) => cint(p.permlevel))])].sort()
+					: [0];
+			const admin_perm = [];
+			permlevels.forEach((level) => {
+				const p = { permlevel: level, rights_without_if_owner: new Set(frappe.perm.rights) };
+				frappe.perm.rights.forEach((right) => {
+					p[right] = 1;
+				});
+				admin_perm[level] = p;
+			});
+			return admin_perm;
 		}
+
+		let perm = [{ read: 0, permlevel: 0 }];
 
 		if (!meta) {
 			if (frappe.boot.user.can_read.includes(doctype)) {


### PR DESCRIPTION
### Fix: Administrator gets all rights in JS `get_perm` / `has_perm` APIs
This PR addresses and closes #18958 

**Problem**

For Administrator, `frappe.perm.get_perm` and `frappe.perm.has_perm` only returned read access, while the Python `has_permission` / `get_role_permissions` APIs grant full access.

**Cause**

In `_get_perm`, Administrator was only given `perm[0].read = 1`, and then `perm` was overwritten by `get_role_permissions(meta)`, which uses DocPerm. For doctypes without Administrator in DocPerm, the result was read-only or empty.

**Solution**

For Administrator, return early with full permissions before calling `get_role_permissions`:

1. Load doctype meta to determine permlevels.
2. Build a perm structure for each permlevel (0, 1, 2, …) with all rights set to 1.
3. Set `rights_without_if_owner` to all rights (no owner restriction).
4. Return this structure and skip the rest of `_get_perm`.

This aligns the JS behavior with Python’s `allow_everything()` in `get_role_permissions`.

### Screenshots

#### Permissions returned for Administrator

<img width="1404" height="780" alt="CleanShot 2026-02-03 at 14 49 15@2x" src="https://github.com/user-attachments/assets/74330e93-0c34-49e3-8c32-22d1cfa28327" />


#### Permissions returned for Non Admin User

<img width="796" height="318" alt="CleanShot 2026-02-03 at 14 50 10@2x" src="https://github.com/user-attachments/assets/6be6ff62-2b71-4a0c-83e2-c0562f468fef" />