### PR TITLE
fix(setup): spacing between fields in setup wizard

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -400,9 +400,6 @@ frappe.setup.slides_settings = [
 				reqd: 1,
 			},
 			{
-				fieldtype: "Section Break",
-			},
-			{
 				fieldname: "timezone",
 				label: __("Time Zone"),
 				placeholder: __("Select Time Zone"),
@@ -415,9 +412,6 @@ frappe.setup.slides_settings = [
 				placeholder: __("Select Currency"),
 				fieldtype: "Select",
 				reqd: 1,
-			},
-			{
-				fieldtype: "Section Break",
 			},
 			{
 				fieldname: "enable_telemetry",


### PR DESCRIPTION
Spacing between Country and Time Zone fields was inconsistent. Fixed it.

<img width="2557" height="1384" alt="image" src="https://github.com/user-attachments/assets/24c246cb-d03c-4e8c-981a-abf848556f82" />
