### PR TITLE
feat(setup): better onboarding flow for Frappe Cloud

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -41,18 +41,30 @@ frappe.pages["setup-wizard"].on_page_load = function (wrapper) {
 			freeze: true,
 			callback: function (r) {
 				frappe.setup.data.lang = r.message;
+				frappe.call({
+					method: "frappe.desk.page.setup_wizard.setup_wizard.load_user_details",
+					freeze: true,
+					callback: function (r) {
+						frappe.setup.data.full_name = r.message.full_name;
+						frappe.setup.data.email = r.message.email;
 
-				frappe.setup.run_event("before_load");
-				var wizard_settings = {
-					parent: wrapper,
-					slides: frappe.setup.slides,
-					slide_class: frappe.setup.SetupWizardSlide,
-					unidirectional: 1,
-					done_state: 1,
-				};
-				frappe.wizard = new frappe.setup.SetupWizard(wizard_settings);
-				frappe.setup.run_event("after_load");
-				frappe.wizard.show_slide(cint(frappe.get_route()[1]));
+						if (r.message.full_name) {
+							frappe.setup.data.first_name = r.message.full_name.split(" ")[0];
+						}
+
+						frappe.setup.run_event("before_load");
+						var wizard_settings = {
+							parent: wrapper,
+							slides: frappe.setup.slides,
+							slide_class: frappe.setup.SetupWizardSlide,
+							unidirectional: 1,
+							done_state: 1,
+						};
+						frappe.wizard = new frappe.setup.SetupWizard(wizard_settings);
+						frappe.setup.run_event("after_load");
+						frappe.wizard.show_slide(cint(frappe.get_route()[1]));
+					},
+				});
 			},
 		});
 	});
@@ -381,7 +393,7 @@ frappe.setup.slides_settings = [
 	{
 		// Welcome (language) slide
 		name: "welcome",
-		title: __("Welcome"),
+		title: () => __("Welcome") + " " + (frappe.setup.data.first_name || ""),
 
 		fields: [
 			{
@@ -497,22 +509,19 @@ frappe.setup.slides_settings = [
 				slide.form.fields_dict.email.df.read_only = 1;
 				slide.form.fields_dict.email.refresh();
 			} else {
-				slide.form.fields_dict.email.df.reqd = 1;
-				slide.form.fields_dict.email.refresh();
 				if (!frappe.boot.is_fc_site) slide.form.fields_dict.password.df.reqd = 1;
 				slide.form.fields_dict.password.refresh();
-
-				frappe.setup.utils.load_user_details(slide, this.setup_fields);
-			}
-		},
-
-		setup_fields: function (slide) {
-			if (frappe.setup.data.full_name) {
-				slide.form.fields_dict.full_name.set_input(frappe.setup.data.full_name);
-			}
-			if (frappe.setup.data.email) {
-				let email = frappe.setup.data.email;
-				slide.form.fields_dict.email.set_input(email);
+				if (frappe.setup.data.full_name) {
+					slide.form.fields_dict.full_name.set_input(frappe.setup.data.full_name);
+					slide.form.fields_dict.full_name.df.read_only = 1;
+					slide.form.fields_dict.full_name.refresh();
+				}
+				if (frappe.setup.data.email) {
+					slide.form.fields_dict.email.set_input(frappe.setup.data.email);
+					slide.form.fields_dict.email.df.read_only = 1;
+				}
+				slide.form.fields_dict.email.df.reqd = 1;
+				slide.form.fields_dict.email.refresh();
 			}
 		},
 	},

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -420,13 +420,6 @@ frappe.setup.slides_settings = [
 				default: cint(frappe.telemetry.can_enable()),
 				depends_on: "eval:frappe.telemetry.can_enable()",
 			},
-			{
-				fieldname: "allow_recording_first_session",
-				label: __("Allow recording my first session to improve user experience"),
-				fieldtype: "Check",
-				default: 0,
-				depends_on: "eval:frappe.telemetry.can_enable()",
-			},
 		],
 
 		onload: function (slide) {

--- a/frappe/public/js/frappe/ui/slides.js
+++ b/frappe/public/js/frappe/ui/slides.js
@@ -21,9 +21,14 @@ frappe.ui.Slide = class Slide {
 
 		this.attach_toggle_theme_btn();
 
+		let title = this.title;
+		if (typeof title === "function") {
+			title = title();
+		}
+
 		this.$body = $(`<div class="slide-body">
 			<div class="content text-center">
-				<h1 class="title slide-title">${__(this.title)}</h1>
+				<h1 class="title slide-title">${__(title)}</h1>
 			</div>
 			<div class="form-wrapper">
 				<div class="form"></div>


### PR DESCRIPTION
When creating a new site from the Frappe Cloud SaaS flow, the user would now see a personalised message on the onboarding step, and the name and email fields will be read-only. We can technically skip the second step altogether since the password is already set for the given user - but for now we do not know when the onboarding is triggered via the SaaS flow.

Also removed the checkbox for session recording since we are not actively using it right now. We can add it back later when required.

When the site is an FC site with the name and email pre-filled (SaaS flow):

https://github.com/user-attachments/assets/bcbc126c-9526-4f86-a1ec-d35dc3f758e3


When the site is on FC and there's no name and email (same behaviour as earlier - password field is hidden in this case):

https://github.com/user-attachments/assets/c32a2ac1-2e38-4939-bbb2-2026834a0b38


When the site is not on FC and there's no name and email (same behaviour as earlier):

https://github.com/user-attachments/assets/50dba2e1-3502-433c-b7c5-2d3a9f4b076f