### PR TITLE
fix: use system number format for currency precision

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -915,7 +915,7 @@ def get_precision_from_currency_format(currency: str) -> int:
 	from frappe.utils.number_format import NumberFormat
 
 	use_format_from_currency = frappe.get_system_settings("use_number_format_from_currency")
-	number_format = NumberFormat.from_string(frappe.db.get_default("number_format") or "#,###.##")
+	number_format = NumberFormat.from_string(frappe.db.get_default("number_format"))
 	if use_format_from_currency:
 		currency_format = frappe.db.get_value("Currency", currency, "number_format", cache=True)
 		number_format = NumberFormat.from_string(currency_format) if currency_format else number_format

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -912,11 +912,10 @@ def get_field_precision(df, doc=None, currency=None):
 
 def get_precision_from_currency_format(currency: str) -> int:
 	"""Get precision from currency format string if applicable."""
-	from frappe.locale import get_number_format
 	from frappe.utils.number_format import NumberFormat
 
 	use_format_from_currency = frappe.get_system_settings("use_number_format_from_currency")
-	number_format = get_number_format()
+	number_format = NumberFormat.from_string(frappe.db.get_default("number_format") or "#,###.##")
 	if use_format_from_currency:
 		currency_format = frappe.db.get_value("Currency", currency, "number_format", cache=True)
 		number_format = NumberFormat.from_string(currency_format) if currency_format else number_format


### PR DESCRIPTION
Closes #35950.

https://github.com/frappe/frappe/commit/b91cacdd180b50d075a6663d4186a729322d25f0 changed the currency precision to fallback on the `locale`'s time format instead of the system's. 

This PR reverts that.