### PR TITLE
feat: autocreate calendar controller file

### DIFF
--- a/frappe/core/doctype/doctype/boilerplate/controller_calendar.js
+++ b/frappe/core/doctype/doctype/boilerplate/controller_calendar.js
@@ -1,0 +1,5 @@
+// Copyright (c) {year}, {app_publisher} and contributors
+// For license information, please see license.txt
+
+frappe.views.calendar["{doctype}"] = {{
+}};

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -880,6 +880,9 @@ class DocType(Document):
 		if self.is_tree:
 			make_boilerplate("controller_tree.js", self.as_dict())
 
+		if self.is_calendar_and_gantt:
+			make_boilerplate("controller_calendar.js", self.as_dict())
+
 		if self.has_web_view:
 			templates_path = frappe.get_module_path(
 				frappe.scrub(self.module), "doctype", frappe.scrub(self.name), "templates"


### PR DESCRIPTION
Closes #35580.

By default, checking the `is_calendar_and_gantt` isn't enough - the developer has to create a controller file `<doctype>_calendar.js`. This PR auto-creates that file in dev mode, making it consistent with other modes like `is_tree`.

`no-docs`