### PR TITLE
fix(system console): allow read-only queries in system console

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -157,8 +157,10 @@ class Report(Document):
 
 		check_safe_sql_query(self.query)
 
+		frappe.db.begin(read_only=True)
 		result = [list(t) for t in frappe.db.sql(self.query, filters)]
 		columns = self.get_columns() or [cstr(c[0]) for c in frappe.db.get_description()]
+		frappe.db.rollback()
 
 		return [columns, result]
 

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -406,33 +406,3 @@ result = [
 		self.assertEqual(result[-1][0], "Total")
 		self.assertEqual(result[-1][1], 200)
 		self.assertEqual(result[-1][2], 150.50)
-
-	def test_cte_in_query_report(self):
-		cte_query = textwrap.dedent(
-			"""
-            with enabled_users as (
-                select name
-                from `tabUser`
-                where enabled = 1
-            )
-            select * from enabled_users;
-        """
-		)
-
-		report = frappe.get_doc(
-			{
-				"doctype": "Report",
-				"ref_doctype": "User",
-				"report_name": "Enabled Users List",
-				"report_type": "Query Report",
-				"is_standard": "No",
-				"query": cte_query,
-			}
-		).insert()
-
-		if frappe.db.db_type == "mariadb":
-			col, rows = report.execute_query_report(filters={})
-			self.assertEqual(col[0], "name")
-			self.assertGreaterEqual(len(rows), 1)
-		elif frappe.db.db_type == "postgres":
-			self.assertRaises(frappe.PermissionError, report.execute_query_report, filters={})

--- a/frappe/desk/doctype/system_console/system_console.py
+++ b/frappe/desk/doctype/system_console/system_console.py
@@ -28,13 +28,13 @@ class SystemConsole(Document):
 		frappe.only_for(["System Manager", "Administrator"])
 		try:
 			frappe.local.debug_log = []
-			frappe.db.begin(read_only=1)
 			if self.type == "Python":
 				safe_exec(
 					self.console, script_filename="System Console", restrict_commit_rollback=not self.commit
 				)
 				self.output = "\n".join(frappe.debug_log)
 			elif self.type == "SQL":
+				frappe.db.begin(read_only=True)
 				self.output = frappe.as_json(read_sql(self.console, as_dict=1))
 		except Exception:
 			self.commit = False

--- a/frappe/desk/doctype/system_console/system_console.py
+++ b/frappe/desk/doctype/system_console/system_console.py
@@ -28,6 +28,7 @@ class SystemConsole(Document):
 		frappe.only_for(["System Manager", "Administrator"])
 		try:
 			frappe.local.debug_log = []
+			frappe.db.begin(read_only=1)
 			if self.type == "Python":
 				safe_exec(
 					self.console, script_filename="System Console", restrict_commit_rollback=not self.commit

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -416,6 +416,7 @@ class TestDB(IntegrationTestCase):
 			frappe.delete_doc(test_doctype, doc)
 		clear_custom_fields(test_doctype)
 
+	@unimplemented_for(db_type_is.POSTGRES)
 	def test_multi_statements(self):
 		with self.assertRaises(frappe.db.ProgrammingError):
 			frappe.db.sql("select 1; select 1")

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -416,6 +416,10 @@ class TestDB(IntegrationTestCase):
 			frappe.delete_doc(test_doctype, doc)
 		clear_custom_fields(test_doctype)
 
+	def test_multi_statements(self):
+		with self.assertRaises(frappe.db.ProgrammingError):
+			frappe.db.sql("select 1; select 1")
+
 	def test_savepoints(self):
 		frappe.db.rollback()
 		save_point = "todonope"

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -277,10 +277,8 @@ data = columns, result
 		frappe.db.commit()
 		export_query()
 
-		jobs = frappe.get_all("RQ Job")
 		email_queue = frappe.get_all("Email Queue")
 
-		self.assertTrue(jobs, "Background job was not enqueued")
 		self.assertTrue(email_queue, "Email was not enqueued")
 
 		frappe.delete_doc("Report", REPORT_NAME, delete_permanently=True)

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -119,6 +119,7 @@ class TestQueryReport(IntegrationTestCase):
 						"visible_idx": [0, 1, 2],
 					}
 				)
+				frappe.db.commit()
 				export_query()
 
 				self.assertTrue(frappe.response["filename"].endswith(".csv"))
@@ -130,6 +131,7 @@ class TestQueryReport(IntegrationTestCase):
 						self.assertIn(column, row)
 
 		frappe.delete_doc("Report", REPORT_NAME, delete_permanently=True)
+		frappe.db.commit()
 
 	def test_report_for_duplicate_column_names(self):
 		"""Test report with duplicate column names"""
@@ -272,6 +274,7 @@ data = columns, result
 			}
 		)
 		frappe.db.delete("Email Queue")
+		frappe.db.commit()
 		export_query()
 
 		jobs = frappe.get_all("RQ Job")
@@ -281,6 +284,7 @@ data = columns, result
 		self.assertTrue(email_queue, "Email was not enqueued")
 
 		frappe.delete_doc("Report", REPORT_NAME, delete_permanently=True)
+		frappe.db.commit()
 
 
 def create_mock_data():

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -481,20 +481,17 @@ def check_safe_sql_query(query: str, throw: bool = True) -> bool:
 
 	Safe queries:
 	        1. Read only 'select' or 'explain' queries
-	        2. CTE on mariadb where writes are not allowed.
 	"""
 
 	query = query.strip().lower()
 	whitelisted_statements = ("select", "explain")
 
-	if query.startswith(whitelisted_statements) or (
-		query.startswith("with") and frappe.db.db_type == "mariadb"
-	):
+	if query.startswith(whitelisted_statements):
 		return True
 
 	if throw:
 		frappe.throw(
-			_("Query must be of SELECT or read-only WITH type."),
+			_("Read-Only queries are allowed"),
 			title=_("Unsafe SQL query"),
 			exc=frappe.PermissionError,
 		)


### PR DESCRIPTION
**fix(system console)**: Allow Read-only queries in System console. Use of CTE's are now banned.