### PR TITLE
fix: unsaved value in quick entry dialog due to missing blur event

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -81,7 +81,7 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 				if (e.which == 13) {
 					if (me.has_primary_action) {
 						e.preventDefault();
-						me.get_primary_btn().trigger("click");
+						frappe.app.trigger_primary_action();
 					}
 				}
 			});


### PR DESCRIPTION
### Context
When an input field is in editable state for quick entry dialog, the "Enter" shortcut does not save it's value before submitting the form. This works correctly on the other shortcut that is cmd + s which calls the `trigger_primary_action` function from desk utils. This function already takes care of checking any active input fields, blurring them and putting a slight delay for it to save correctly so re-use the same logic here instead of explicitly calling `get_primary_btn().trigger("click")`.

### Before

https://github.com/user-attachments/assets/f22ce537-3ade-4c32-8f4e-b710997b088a

<br>

### After

https://github.com/user-attachments/assets/da0a394d-81d1-4c51-9ddf-b7d693fcc3c8


Closes https://github.com/frappe/frappe/issues/36609
