### PR TITLE
fix(ux): add to desktop button on workspace

### DIFF
--- a/frappe/desk/doctype/desktop_icon/desktop_icon.json
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.json
@@ -147,11 +147,11 @@
    "fieldname": "bg_color",
    "fieldtype": "Select",
    "label": "Background Color",
-   "options": "blue\ngray"
+   "options": "gray\nblue"
   }
  ],
  "links": [],
- "modified": "2026-01-27 18:17:48.667070",
+ "modified": "2026-02-04 13:59:30.578370",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Desktop Icon",

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -24,7 +24,7 @@ class DesktopIcon(Document):
 		from frappe.types import DF
 
 		app: DF.Autocomplete | None
-		bg_color: DF.Literal["blue", "gray"]
+		bg_color: DF.Literal["gray", "blue"]
 		hidden: DF.Check
 		icon_image: DF.Attach | None
 		icon_type: DF.Literal["Link", "Folder", "App"]

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -312,3 +312,24 @@ def create_user_icons(user, data):
 			frappe.cache.hset("_user_settings", f"{'Desktop Icon'}::{user}", json.dumps(user_settings))
 			return json.dumps(user_settings)
 	return data
+
+
+@frappe.whitelist()
+def add_workspace_to_desktop(workspace):
+	sidebar = frappe.new_doc("Workspace Sidebar")
+	sidebar_item = frappe.new_doc("Workspace Sidebar Item")
+	sidebar_item.label = workspace
+	sidebar_item.type = "Link"
+	sidebar_item.link_to = workspace
+	sidebar_item.link_type = "Workspace"
+	sidebar.title = workspace
+	sidebar.append("items", sidebar_item)
+	sidebar.save()
+
+	new_icon = frappe.new_doc("Desktop Icon")
+	new_icon.label = workspace
+	new_icon.icon_type = "Link"
+	new_icon.link_to = workspace
+	new_icon.link_type = "Workspace Sidebar"
+	new_icon.insert()
+	return {"message": "Desktop Icon added successfully"}

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -332,4 +332,4 @@ def add_workspace_to_desktop(workspace):
 	new_icon.link_to = workspace
 	new_icon.link_type = "Workspace Sidebar"
 	new_icon.insert()
-	return {"message": "Desktop Icon added successfully"}
+	return {"icon": new_icon.as_dict()}

--- a/frappe/desk/doctype/workspace/workspace.js
+++ b/frappe/desk/doctype/workspace/workspace.js
@@ -8,6 +8,24 @@ frappe.ui.form.on("Workspace", {
 
 	refresh: function (frm) {
 		frm.enable_save();
+		if (frappe.app.sidebar.get_workspace_sidebars(frm.doc.title).length === 0) {
+			frm.add_custom_button(__("Add to Desktop"), function () {
+				frappe.call({
+					method: "frappe.desk.doctype.desktop_icon.desktop_icon.add_workspace_to_desktop",
+					args: {
+						workspace: frm.doc.name,
+					},
+					callback: function (r) {
+						if (r.message.status) {
+							frappe.toast({
+								message: __("Workspace added to desktop"),
+								indicator: "green",
+							});
+						}
+					},
+				});
+			});
+		}
 
 		let url = `/desk/${
 			frm.doc.public

--- a/frappe/desk/doctype/workspace/workspace.js
+++ b/frappe/desk/doctype/workspace/workspace.js
@@ -16,7 +16,8 @@ frappe.ui.form.on("Workspace", {
 						workspace: frm.doc.name,
 					},
 					callback: function (r) {
-						if (r.message.status) {
+						if (r.message) {
+							frappe.boot.desktop_icons.push(r.message.icon);
 							frappe.toast({
 								message: __("Workspace added to desktop"),
 								indicator: "green",

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -125,9 +125,18 @@ class Workspace(Document):
 			self.name = doc.name = doc.label = doc.title
 
 	def on_trash(self):
+		if not self.module:
+			self.delete_sidebar()
+			self.delete_desktop_icon()
 		if self.public and not is_workspace_manager():
 			frappe.throw(_("You need to be Workspace Manager to delete a public workspace."))
 		self.delete_from_my_workspaces()
+
+	def delete_desktop_icon(self):
+		frappe.delete_doc_if_exists("Desktop Icon", self.title)
+
+	def delete_sidebar(self):
+		frappe.delete_doc_if_exists("Workspace Sidebar", self.title)
 
 	def delete_from_my_workspaces(self):
 		if not self.public:

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -30,6 +30,9 @@ frappe.pages["desktop"].on_page_load = function (wrapper) {
 	// setup();
 };
 
+frappe.pages["desktop"].on_page_show = function (wrapper) {
+	frappe.pages["desktop"].desktop_page.update();
+};
 function get_workspaces_from_app_name(app_name) {
 	const app = frappe.boot.app_data.filter((a) => {
 		return a.app_title === app_name;


### PR DESCRIPTION
So right now people have workspaces, they want to create a icon for it. This button should will help them create an icon easliy.



<img width="1440" height="900" alt="Screenshot 2026-02-03 at 8 44 28 PM" src="https://github.com/user-attachments/assets/d4ec54b8-0e40-41dc-b8fb-415d1068de38" />

https://github.com/user-attachments/assets/6ab6c1b3-556f-46fe-848f-eba690049639


