### PR TITLE
feat: set label dynamically for the section

### DIFF
--- a/frappe/public/js/frappe/form/section.js
+++ b/frappe/public/js/frappe/form/section.js
@@ -139,6 +139,10 @@ export default class Section {
 		this.indicator && this.indicator.html(frappe.utils.icon(indicator_icon, "sm", "mb-1"));
 	}
 
+	set_label(label) {
+		this.wrapper.find(".section-head").html(label);
+	}
+
 	is_collapsed() {
 		return this.body.hasClass("hide");
 	}


### PR DESCRIPTION
Before
<img width="930" height="515" alt="Screenshot 2026-02-03 at 10 43 36 PM" src="https://github.com/user-attachments/assets/971a6770-5a20-4531-a13e-ce9ec87546dd" />


After
<img width="943" height="528" alt="Screenshot 2026-02-03 at 10 30 31 PM" src="https://github.com/user-attachments/assets/33ffe5c9-bad5-459b-aca1-d514d0c83621" />


no-docs