### PR TITLE
fix: dont consider private sidebar while module sidebar generation

### DIFF
--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -274,8 +274,8 @@ def auto_generate_sidebar_from_module():
 	sidebars = []
 	for module in frappe.get_all("Module Def", pluck="name"):
 		if not (
-			frappe.db.exists("Workspace Sidebar", {"module": module})
-			or frappe.db.exists("Workspace Sidebar", {"name": module})
+			frappe.db.exists("Workspace Sidebar", {"module": module, "for_user": None})
+			or frappe.db.exists("Workspace Sidebar", {"name": module, "for_user": None})
 		):
 			module_info = get_module_info(module)
 			sidebar_items = create_sidebar_items(module_info)

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -51,7 +51,8 @@ class WorkspaceSidebar(Document):
 
 	def before_save(self):
 		self.export_sidebar()
-		self.set_module()
+		if not self.for_user:
+			self.set_module()
 
 	def export_sidebar(self):
 		allow_export = (


### PR DESCRIPTION
In my local setup, I was facing an issue where when I go to desktop icon it wasn't the desk sidebar wasn't loading. 
Some private sidebar aka "My Workspaces" sidebar had module = "Desk" which was causing the autogeneration to not generate sidebars for the module = "desk"