### PR TITLE
fix: desk folder title edit persists and inline editor ui

### DIFF
--- a/frappe/desk/doctype/desktop_layout/desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.py
@@ -5,6 +5,7 @@ import json
 
 import frappe
 from frappe.desk.doctype.desktop_icon.desktop_icon import add_workspace_to_desktop
+from frappe.desk.doctype.desktop_icon.desktop_icon import clear_desktop_icons_cache
 from frappe.model.document import Document
 
 
@@ -38,6 +39,8 @@ def save_layout(user: str, layout: str, new_icons: str):
 		desktop_layout = frappe.new_doc("Desktop Layout")
 		desktop_layout.user = frappe.session.user
 
+	_sync_icon_renames(layout)
+
 	if layout:
 		desktop_layout.layout = json.dumps(layout)
 		desktop_layout.save()
@@ -56,6 +59,41 @@ def save_layout(user: str, layout: str, new_icons: str):
 		desktop_icon.save()
 
 	return {"layout": layout}
+
+
+def _sync_icon_renames(layout):
+	"""Apply label renames from layout to Desktop Icon docs so they persist across refresh."""
+	if not layout or not isinstance(layout, list):
+		return
+	for icon in layout:
+		old_name = icon.get("name")
+		new_label = icon.get("label")
+		if not old_name or not new_label or old_name == new_label:
+			continue
+		if not frappe.db.exists("Desktop Icon", old_name):
+			continue
+		# Update children's parent_icon first, then rename the doc
+		frappe.db.sql(
+			"update `tabDesktop Icon` set parent_icon = %(new)s where parent_icon = %(old)s",
+			{"new": new_label, "old": old_name},
+		)
+		doc = frappe.get_doc("Desktop Icon", old_name)
+		doc.label = new_label
+		doc.save()
+		icon["name"] = new_label
+		clear_desktop_icons_cache()
+
+
+@frappe.whitelist()
+def get_layout():
+	"""Return the current user's saved desktop layout. Used on desk load to avoid stale cached HTML."""
+	try:
+		doc = frappe.get_doc("Desktop Layout", frappe.session.user)
+		if doc.layout:
+			return json.loads(doc.layout)
+	except frappe.DoesNotExistError:
+		frappe.clear_last_message()
+	return None
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/desktop_layout/desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.py
@@ -5,7 +5,6 @@ import json
 
 import frappe
 from frappe.desk.doctype.desktop_icon.desktop_icon import add_workspace_to_desktop
-from frappe.desk.doctype.desktop_icon.desktop_icon import clear_desktop_icons_cache
 from frappe.model.document import Document
 
 

--- a/frappe/desk/doctype/desktop_layout/desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.py
@@ -39,8 +39,6 @@ def save_layout(user: str, layout: str, new_icons: str):
 		desktop_layout = frappe.new_doc("Desktop Layout")
 		desktop_layout.user = frappe.session.user
 
-	_sync_icon_renames(layout)
-
 	if layout:
 		desktop_layout.layout = json.dumps(layout)
 		desktop_layout.save()
@@ -59,29 +57,6 @@ def save_layout(user: str, layout: str, new_icons: str):
 		desktop_icon.save()
 
 	return {"layout": layout}
-
-
-def _sync_icon_renames(layout):
-	"""Apply label renames from layout to Desktop Icon docs so they persist across refresh."""
-	if not layout or not isinstance(layout, list):
-		return
-	for icon in layout:
-		old_name = icon.get("name")
-		new_label = icon.get("label")
-		if not old_name or not new_label or old_name == new_label:
-			continue
-		if not frappe.db.exists("Desktop Icon", old_name):
-			continue
-		# Update children's parent_icon first, then rename the doc
-		frappe.db.sql(
-			"update `tabDesktop Icon` set parent_icon = %(new)s where parent_icon = %(old)s",
-			{"new": new_label, "old": old_name},
-		)
-		doc = frappe.get_doc("Desktop Icon", old_name)
-		doc.label = new_label
-		doc.save()
-		icon["name"] = new_label
-		clear_desktop_icons_cache()
 
 
 @frappe.whitelist()

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -509,8 +509,16 @@
     position: relative;
 }
 
-.title-widget:hover .title-input-label {
+.title-widget--read-only {
+    cursor: default;
+}
+
+.title-widget--editable:hover .title-input-label {
     opacity: 0.9;
+}
+
+.desktop-modal-heading .title-widget--read-only .title-input-label:hover {
+    background-color: transparent;
 }
 
 .desktop-modal-heading .title-widget .title-input-label {
@@ -522,7 +530,7 @@
     transition: background-color 0.15s ease;
 }
 
-.desktop-modal-heading .title-widget:hover .title-input-label {
+.desktop-modal-heading .title-widget--editable:hover .title-input-label {
     background-color: rgba(255, 255, 255, 0.08);
 }
 

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -500,31 +500,64 @@
     justify-content: center;
 }
 
-.title-widget{
-    display: inline-block;
+.title-widget {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 1.5rem;
+    cursor: text;
     position: relative;
 }
 
-.title-input-label{
-  position: absolute;
-  top: 0px;
-  color: var(--neutral-white);
-  line-height: 22px;
-  z-index: 1;
-  pointers-events: none;
-  width: 100%;
-    text-align: center;
-}
-.title-input-wrapper{
-    position: relative;
-    display: inline-block;
-
+.title-widget:hover .title-input-label {
+    opacity: 0.9;
 }
 
-.title-input-wrapper input{
-  border: 1px solid transparent;
-  width: 100%;
-  height: 100%;
-  background: none;
+.desktop-modal-heading .title-widget .title-input-label {
     color: var(--neutral-white);
+    font-size: var(--text-2xl);
+    line-height: 1.3;
+    padding: 2px 4px;
+    border-radius: 4px;
+    transition: background-color 0.15s ease;
+}
+
+.desktop-modal-heading .title-widget:hover .title-input-label {
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+.title-input-wrapper {
+    display: inline-block;
+    min-width: 80px;
+}
+
+.desktop-modal-heading .title-input-wrapper .title-input {
+    color: var(--neutral-white);
+    font-size: var(--text-2xl);
+    line-height: 1.3;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 4px;
+    padding: 2px 8px;
+    outline: none;
+    min-width: 80px;
+    box-sizing: border-box;
+}
+
+.desktop-modal-heading .title-input-wrapper .title-input::placeholder {
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.desktop-modal-heading .title-input-wrapper .title-input:focus {
+    border-color: rgba(255, 255, 255, 0.5);
+    background-color: rgba(255, 255, 255, 0.12);
+}
+
+.title-input-mirror {
+    position: absolute;
+    visibility: hidden;
+    white-space: pre;
+    font-size: var(--text-2xl);
+    font-family: inherit;
+    padding: 0 4px;
 }

--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -65,5 +65,5 @@
                 {{ _("Save") }}
             </button>
     </div>
-    <div class="hidden" id="desktop-layout">{{ desktop_layout }}</pre>
+    <div class="hidden" id="desktop-layout">{{ desktop_layout | safe }}</div>
 </div>

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -220,7 +220,7 @@ class DesktopPage {
 		let saved_layout = JSON.parse(localStorage.getItem(`${frappe.session.user}:desktop`));
 		if (!this.data && saved_layout) {
 			this.save_layout(saved_layout);
-		} else if (Object.keys(this.data).length != 0) {
+		} else if (this.data && Array.isArray(this.data) && this.data.length > 0) {
 			frappe.desktop_icons = this.data;
 		} else {
 			frappe.desktop_icons = frappe.boot.desktop_icons;
@@ -247,9 +247,21 @@ class DesktopPage {
 		this.page.page_head.hide();
 		$(this.page.body).empty();
 		$(frappe.render_template("desktop")).appendTo(this.page.body);
-		if (!this.data) {
-			this.data = JSON.parse($("#desktop-layout").text());
+		if (this.data !== undefined) {
+			this._continue_make();
+		} else {
+			const me = this;
+			frappe.call({
+				method: "frappe.desk.doctype.desktop_layout.desktop_layout.get_layout",
+				callback: function (r) {
+					me.data = r.message;
+					me._continue_make();
+				},
+			});
 		}
+	}
+
+	_continue_make() {
 		this.sync_layout();
 		this.prepare();
 		this.wrapper = this.page.body.find(".desktop-container");
@@ -1038,6 +1050,13 @@ class DesktopIcon {
 					add_icons_to_folder(new_value, folder_icons);
 
 					frappe.pages["desktop"].desktop_page.update();
+
+					let desktop_page = frappe.pages["desktop"].desktop_page;
+					if (desktop_page.edit_mode) {
+						save_desktop(frappe.new_desktop_icons);
+					} else {
+						desktop_page.save_layout(frappe.desktop_icons, []);
+					}
 				});
 				modal.show();
 			});
@@ -1228,8 +1247,9 @@ class IconsPane {
 class InlineEditor {
 	constructor(container, initialValue = "", onRename = () => {}) {
 		this.container = container;
-		this.initialValue = initialValue;
+		this.currentValue = initialValue;
 		this.onRename = onRename;
+		this.isEditing = false;
 
 		this.render();
 		this.bindEvents();
@@ -1237,41 +1257,87 @@ class InlineEditor {
 
 	render() {
 		this.container.html(`
-			<div class="title-widget">
-				<div class="title-input-label">
-					<span>${__(this.initialValue)}</span>
-				</div>
-				<div class="title-input-wrapper">
-					<input class="title-input">
+			<div class="title-widget" title="${__("Click to edit")}">
+				<span class="title-input-label">${__(this.currentValue)}</span>
+				<div class="title-input-wrapper" style="display: none;">
+					<input type="text" class="title-input" />
 				</div>
 			</div>
 		`);
 
+		this.$widget = this.container.find(".title-widget");
 		this.input = this.container.find(".title-input");
 		this.label = this.container.find(".title-input-label");
+		this.wrapper = this.container.find(".title-input-wrapper");
 	}
 
 	bindEvents() {
-		this.container.on("click", () => {
-			if (frappe.pages["desktop"].desktop_page.edit_mode) {
-				this.label.css("visibility", "hidden");
-				this.input.focus().select();
-			}
+		this.label.on("click", (e) => {
+			e.stopPropagation();
+			this.startEditing();
 		});
 
-		this.input.on("keydown", (event) => {
-			if (event.key === "Enter") {
-				const newValue = this.input.val().trim();
-				this.input.css("display", "none");
-				this.label.css("visibility", "visible");
-				this.label.find("span").text(newValue);
-
-				this.onRename(this.initialValue, newValue, this);
+		this.input.on("keydown", (e) => {
+			if (e.key === "Enter") {
+				e.preventDefault();
+				this.commit();
+			} else if (e.key === "Escape") {
+				e.preventDefault();
+				this.cancel();
 			}
 		});
 
 		this.input.on("blur", () => {
-			this.label.css("visibility", "visible");
+			this.commit();
 		});
+
+		this.input.on("input", () => {
+			this.resizeInput();
+		});
+	}
+
+	startEditing() {
+		if (this.isEditing) return;
+		this.isEditing = true;
+		this.initialValue = this.currentValue;
+		this.label.hide();
+		this.wrapper.show();
+		this.input.val(this.currentValue);
+		this.input.css("width", "4px");
+		this.resizeInput();
+		this.input.focus().select();
+	}
+
+	commit() {
+		if (!this.isEditing) return;
+		this.isEditing = false;
+		const newValue = this.input.val().trim();
+		const effective = newValue || this.initialValue;
+		this.label.text(effective).show();
+		this.wrapper.hide();
+		this.input.val(effective);
+		this.currentValue = effective;
+		if (effective !== this.initialValue) {
+			this.onRename(this.initialValue, effective, this);
+		}
+	}
+
+	cancel() {
+		if (!this.isEditing) return;
+		this.isEditing = false;
+		this.label.text(this.initialValue).show();
+		this.wrapper.hide();
+		this.input.val(this.currentValue);
+		this.input.blur();
+	}
+
+	resizeInput() {
+		const mirror = $("<span>")
+			.addClass("title-input-mirror")
+			.text(this.input.val() || "");
+		this.$widget.append(mirror);
+		const textWidth = mirror.get(0).offsetWidth;
+		mirror.remove();
+		this.input.css("width", Math.max(80, textWidth + 20) + "px");
 	}
 }

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -1038,7 +1038,8 @@ class DesktopIcon {
 				let modal = frappe.desktop_utils.create_desktop_modal(me);
 				modal.setup(me.icon_title, me.child_icons, 4);
 				let $title = modal.modal.find(".modal-title");
-				let title = new InlineEditor($title, this.icon_data.label, function (
+				const edit_mode = frappe.pages["desktop"].desktop_page.edit_mode;
+				let title = new InlineEditor($title, this.icon_data.label, edit_mode, function (
 					old_value,
 					new_value
 				) {
@@ -1051,11 +1052,8 @@ class DesktopIcon {
 
 					frappe.pages["desktop"].desktop_page.update();
 
-					let desktop_page = frappe.pages["desktop"].desktop_page;
-					if (desktop_page.edit_mode) {
-						save_desktop(frappe.new_desktop_icons);
-					} else {
-						desktop_page.save_layout(frappe.desktop_icons, []);
+					if (!frappe.pages["desktop"].desktop_page.edit_mode) {
+						frappe.pages["desktop"].desktop_page.save_layout(frappe.desktop_icons, []);
 					}
 				});
 				modal.show();
@@ -1245,10 +1243,14 @@ class IconsPane {
 }
 
 class InlineEditor {
-	constructor(container, initialValue = "", onRename = () => {}) {
+	constructor(container, initialValue = "", editMode = false, onRename = () => {}) {
 		this.container = container;
 		this.currentValue = initialValue;
-		this.onRename = onRename;
+		this.editMode = editMode;
+		this.onRename = typeof editMode === "function" ? editMode : onRename;
+		if (typeof editMode === "function") {
+			this.editMode = false;
+		}
 		this.isEditing = false;
 
 		this.render();
@@ -1256,8 +1258,10 @@ class InlineEditor {
 	}
 
 	render() {
+		const tooltip = this.editMode ? __("Click to edit") : "";
+		const editableClass = this.editMode ? "title-widget--editable" : "title-widget--read-only";
 		this.container.html(`
-			<div class="title-widget" title="${__("Click to edit")}">
+			<div class="title-widget ${editableClass}" title="${tooltip}">
 				<span class="title-input-label">${__(this.currentValue)}</span>
 				<div class="title-input-wrapper" style="display: none;">
 					<input type="text" class="title-input" />
@@ -1274,6 +1278,7 @@ class InlineEditor {
 	bindEvents() {
 		this.label.on("click", (e) => {
 			e.stopPropagation();
+			if (!frappe.pages["desktop"].desktop_page.edit_mode) return;
 			this.startEditing();
 		});
 

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -248,20 +248,20 @@ class DesktopPage {
 		$(this.page.body).empty();
 		$(frappe.render_template("desktop")).appendTo(this.page.body);
 		if (this.data !== undefined) {
-			this._continue_make();
+			this.render();
 		} else {
 			const me = this;
 			frappe.call({
 				method: "frappe.desk.doctype.desktop_layout.desktop_layout.get_layout",
 				callback: function (r) {
 					me.data = r.message;
-					me._continue_make();
+					me.render();
 				},
 			});
 		}
 	}
 
-	_continue_make() {
+	render() {
 		this.sync_layout();
 		this.prepare();
 		this.wrapper = this.page.body.find(".desktop-container");

--- a/frappe/desk/page/desktop/desktop.py
+++ b/frappe/desk/page/desktop/desktop.py
@@ -14,7 +14,8 @@ def get_context(context):
 		brand_logo = frappe.get_hooks("app_logo_url", app_name="frappe")[0]
 	context.brand_logo = brand_logo
 	try:
-		context.desktop_layout = frappe.get_doc("Desktop Layout", frappe.session.user).layout or {}
+		layout = frappe.get_doc("Desktop Layout", frappe.session.user).layout
+		context.desktop_layout = layout if layout else "[]"
 	except frappe.DoesNotExistError:
 		frappe.clear_last_message()
 		context.desktop_layout = {}


### PR DESCRIPTION
Fixes #36664

## Changes

### Persistence
- **Immediate save on rename:** Renaming the title in the modal (and pressing Enter or blur) now calls `save_layout` so the change is saved even when not in "Edit Layout" mode.
- **Backend rename sync:** `save_layout` runs `_sync_icon_renames(layout)`: renames the Desktop Icon doc when `label` changes, updates children’s `parent_icon`, and clears desktop icons cache so sidebar/boot stay in sync.
- **Template/context:** Fixed desktop template closing tag (`</pre>` → `</div>`), output layout with `|safe` so JSON isn’t HTML-escaped, and ensure Python always passes a JSON string for layout (or `"[]"` when empty).

### Refresh / cache
- **Fresh layout on load:** Added `get_layout()` API and use it in desk `make()` when `this.data` isn’t already set. Layout is loaded from the server on each desk load so the first refresh after a rename shows the new title instead of cached HTML.
- **sync_layout:** Handles `this.data` being `null` and uses array check for saved layout so boot fallback works when there is no saved layout.

### Inline editor UX
- **Always editable:** Modal title can be edited without entering "Edit Layout"; edit-mode check removed.
- **Single inline state:** One visible state (label or input), no overlapping layers; click label to show input with current value and selection.
- **Blur / Escape / Enter:** Blur commits (save if changed, restore if empty); Escape cancels; Enter commits.
- **Sizing:** Input width is derived from text (mirror span) so it doesn’t look cramped.
- **CSS:** Hover state on title, focus styling for input, `cursor: text`, and proper layout so the title feels like one editable field.
- **Tooltip:** "Click to edit" on the title widget.

### Result

https://github.com/user-attachments/assets/eea8fa69-ecf9-4c76-abb3-8d8cb13d5828

