### PR TITLE
fix: overlapping css in desktop

### DIFF
--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -7,7 +7,7 @@
     --folder-icon-background-color: var(--surface-gray-1);
     --desktop-modal-radius: 30px;
     --desktop-icon-line-height: 115%;
-    --navbar-height: 52px;
+    --desktop-navbar-height: 52px;
 }
 [data-theme="dark"]{
     --folder-icon-background-color: #2b2b2b;
@@ -28,7 +28,7 @@
     width: 100%;
     padding: 10px 20px 10px 20px;
     box-sizing: border-box;
-    height: var(--navbar-height);
+    height: var(--desktop-navbar-height);
     position: sticky;
     top: 0px;
     z-index: 1030;
@@ -468,7 +468,7 @@
 }
 .desktop-pane{
     position: absolute;
-    top: var(--navbar-height);
+    top: var(--desktop-navbar-height);
     right: 0px;
     width: 300px;
     border-left: 1px solid var(--border-color);

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -35,6 +35,7 @@
 
 	.title-area {
 		display: inline-flex;
+		align-items: center;
 		.indicator-pill {
 			margin-left: var(--margin-sm);
 		}


### PR DESCRIPTION
- Overlapping css in desktop
- Sidebar open icon & list title vertical alignment