### PR TITLE
fix(List View): respect link filters in quick filter section

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -1214,6 +1214,7 @@ class FilterArea {
 						onchange: () => this.debounced_refresh_list_view(),
 						ignore_link_validation: fieldtype === "Dynamic Link",
 						is_filter: 1,
+						link_filters: df.link_filters,
 					};
 				})
 		);


### PR DESCRIPTION
List View quick filter section creates Link Controls by passing a temporary `df`-like structure and not the actual DocField object. Link Control in turn tries to check the `link_filters` key in that object and fails to find any so it doesn't respect the added link filters. This works as expected in the Filter Popover on the right-hand side section because that passes the link filters correctly.

Assuming we add this filter [["User", "enabled", "=", 1]] for the User Link field in the DocType.

### Before

https://github.com/user-attachments/assets/1345735c-746d-45bc-8af5-7f5bbfda3c6d


### After


https://github.com/user-attachments/assets/3deeda3f-3882-4cfc-bdbb-fea838c11149


Closes https://github.com/frappe/frappe/issues/34257 