### PR TITLE
fix: empty list in and not in operator behaviour in get_all filters

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -597,8 +597,8 @@ class Engine:
 					v.strip().strip("'") for v in get_between_date_filter(_value, df).split(" AND ")
 				)
 
-		# Handle empty lists for IN/NOT IN operators before conversion
-		# SQL semantics: IN () returns 0 results, NOT IN () returns all results
+		# Handle empty lists for IN/NOT IN operators - generate native SQL syntax
+		# Generate IN () / NOT IN () syntax, let database handle errors naturally
 		if _operator.lower() in ("in", "not in") and (
 			(isinstance(value, (list, tuple, set)) and len(value) == 0)
 			or (isinstance(_value, (list, tuple, set)) and len(_value) == 0)
@@ -606,11 +606,9 @@ class Engine:
 			quote_char = '"' if self.is_postgres else "`"
 			try:
 				field_sql = _field.get_sql(quote_char=quote_char, with_alias=False)
-
 			except (AttributeError, TypeError):
 				field_sql = str(_field)
 				field_sql = field_sql.replace("`", '"') if self.is_postgres else field_sql.replace('"', "`")
-				
 			operator_sql = "IN" if _operator.lower() == "in" else "NOT IN"
 			return RawCriterion(f"{field_sql} {operator_sql} ()")
 

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -597,6 +597,23 @@ class Engine:
 					v.strip().strip("'") for v in get_between_date_filter(_value, df).split(" AND ")
 				)
 
+		# Handle empty lists for IN/NOT IN operators before conversion
+		# SQL semantics: IN () returns 0 results, NOT IN () returns all results
+		if _operator.lower() in ("in", "not in") and (
+			(isinstance(value, (list, tuple, set)) and len(value) == 0)
+			or (isinstance(_value, (list, tuple, set)) and len(_value) == 0)
+		):
+			quote_char = '"' if self.is_postgres else "`"
+			try:
+				field_sql = _field.get_sql(quote_char=quote_char, with_alias=False)
+
+			except (AttributeError, TypeError):
+				field_sql = str(_field)
+				field_sql = field_sql.replace("`", '"') if self.is_postgres else field_sql.replace('"', "`")
+				
+			operator_sql = "IN" if _operator.lower() == "in" else "NOT IN"
+			return RawCriterion(f"{field_sql} {operator_sql} ()")
+
 		if not _value and isinstance(_value, list | tuple | set):
 			_value = ("",)
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -861,6 +861,16 @@ from {tables}
 			)
 
 		if f.operator.lower() in ("in", "not in"):
+			# Handle empty lists for IN/NOT IN operators
+			# SQL semantics: IN () returns 0 results, NOT IN () returns all results
+			if isinstance(f.value, (list, tuple)) and len(f.value) == 0:
+				if f.operator.lower() == "in":
+					# IN () naturally returns 0 results in SQL
+					return f"{column_name} IN ()"
+				else:  # not in
+					# NOT IN () naturally returns all results in SQL
+					return f"{column_name} NOT IN ()"
+
 			# if values contain '' or falsy values then only coalesce column
 			# for `in` query this is only required if values contain '' or values are empty.
 			# for `not in` queries we can't be sure as column values might contain null.

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -861,14 +861,12 @@ from {tables}
 			)
 
 		if f.operator.lower() in ("in", "not in"):
-			# Handle empty lists for IN/NOT IN operators
-			# SQL semantics: IN () returns 0 results, NOT IN () returns all results
+			# Handle empty lists for IN/NOT IN operators - generate native SQL syntax
+			# Generate IN () / NOT IN () syntax, let database handle errors naturally
 			if isinstance(f.value, (list, tuple)) and len(f.value) == 0:
 				if f.operator.lower() == "in":
-					# IN () naturally returns 0 results in SQL
 					return f"{column_name} IN ()"
 				else:  # not in
-					# NOT IN () naturally returns all results in SQL
 					return f"{column_name} NOT IN ()"
 
 			# if values contain '' or falsy values then only coalesce column

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1050,15 +1050,21 @@ class TestDBQuery(IntegrationTestCase):
 		self.assertNotIn("IF", frappe.get_all("User", {"first_name": ("in", ["a", "b"])}, run=0).get_sql())
 		self.assertIn("IFNULL", frappe.get_all("User", {"first_name": ("in", ["a", None])}, run=0).get_sql())
 		self.assertIn("IFNULL", frappe.get_all("User", {"first_name": ("in", ["a", ""])}, run=0).get_sql())
-		self.assertIn("IFNULL", frappe.get_all("User", {"first_name": ("in", [])}, run=0).get_sql())
+		# Empty list with IN should return IN (), not use IFNULL
+		self.assertIn("IN ()", frappe.get_all("User", {"first_name": ("in", [])}, run=0).get_sql())
+		self.assertNotIn("IFNULL", frappe.get_all("User", {"first_name": ("in", [])}, run=0).get_sql())
 		self.assertIn("IFNULL", frappe.get_all("User", {"first_name": ("not in", ["a"])}, run=0).get_sql())
-		self.assertIn("IFNULL", frappe.get_all("User", {"first_name": ("not in", [])}, run=0).get_sql())
+		# Empty list with NOT IN should return NOT IN (), not use IFNULL
+		self.assertIn("NOT IN ()", frappe.get_all("User", {"first_name": ("not in", [])}, run=0).get_sql())
+		self.assertNotIn("IFNULL", frappe.get_all("User", {"first_name": ("not in", [])}, run=0).get_sql())
 		self.assertIn("IFNULL", frappe.get_all("User", {"first_name": ("not in", [""])}, run=0).get_sql())
 
 		# primary key is never nullable
 		self.assertNotIn("IFNULL", frappe.get_all("User", {"name": ("in", ["a", None])}, run=0).get_sql())
 		self.assertNotIn("IFNULL", frappe.get_all("User", {"name": ("in", ["a", ""])}, run=0).get_sql())
 		self.assertNotIn("IFNULL", frappe.get_all("User", {"name": ("in", (""))}, run=0).get_sql())
+		# Empty tuple with IN should return IN (), not use IFNULL
+		self.assertIn("IN ()", frappe.get_all("User", {"name": ("in", ())}, run=0).get_sql())
 		self.assertNotIn("IFNULL", frappe.get_all("User", {"name": ("in", ())}, run=0).get_sql())
 
 	def test_coalesce_with_datetime_ops(self):

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1050,11 +1050,11 @@ class TestDBQuery(IntegrationTestCase):
 		self.assertNotIn("IF", frappe.get_all("User", {"first_name": ("in", ["a", "b"])}, run=0).get_sql())
 		self.assertIn("IFNULL", frappe.get_all("User", {"first_name": ("in", ["a", None])}, run=0).get_sql())
 		self.assertIn("IFNULL", frappe.get_all("User", {"first_name": ("in", ["a", ""])}, run=0).get_sql())
-		# Empty list with IN should return IN (), not use IFNULL
+		# Empty list with IN should generate native SQL IN () syntax
 		self.assertIn("IN ()", frappe.get_all("User", {"first_name": ("in", [])}, run=0).get_sql())
 		self.assertNotIn("IFNULL", frappe.get_all("User", {"first_name": ("in", [])}, run=0).get_sql())
 		self.assertIn("IFNULL", frappe.get_all("User", {"first_name": ("not in", ["a"])}, run=0).get_sql())
-		# Empty list with NOT IN should return NOT IN (), not use IFNULL
+		# Empty list with NOT IN should generate native SQL NOT IN () syntax
 		self.assertIn("NOT IN ()", frappe.get_all("User", {"first_name": ("not in", [])}, run=0).get_sql())
 		self.assertNotIn("IFNULL", frappe.get_all("User", {"first_name": ("not in", [])}, run=0).get_sql())
 		self.assertIn("IFNULL", frappe.get_all("User", {"first_name": ("not in", [""])}, run=0).get_sql())
@@ -1063,7 +1063,7 @@ class TestDBQuery(IntegrationTestCase):
 		self.assertNotIn("IFNULL", frappe.get_all("User", {"name": ("in", ["a", None])}, run=0).get_sql())
 		self.assertNotIn("IFNULL", frappe.get_all("User", {"name": ("in", ["a", ""])}, run=0).get_sql())
 		self.assertNotIn("IFNULL", frappe.get_all("User", {"name": ("in", (""))}, run=0).get_sql())
-		# Empty tuple with IN should return IN (), not use IFNULL
+		# Empty tuple with IN should generate native SQL IN () syntax
 		self.assertIn("IN ()", frappe.get_all("User", {"name": ("in", ())}, run=0).get_sql())
 		self.assertNotIn("IFNULL", frappe.get_all("User", {"name": ("in", ())}, run=0).get_sql())
 

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -410,7 +410,7 @@ class TestQuery(IntegrationTestCase):
 			"SELECT `name` FROM `tabDocType` WHERE `name` IN ('ToDo','Note')",
 		)
 
-		# Empty list with IN operator should return 0 results (IN () condition)
+		# Empty list with IN operator should generate native SQL IN () syntax
 		self.assertQueryEqual(
 			frappe.qb.get_query(
 				"DocType",
@@ -419,7 +419,7 @@ class TestQuery(IntegrationTestCase):
 			"SELECT `name` FROM `tabDocType` WHERE `name` IN ()",
 		)
 
-		# Empty list with NOT IN operator should return all results (NOT IN () condition)
+		# Empty list with NOT IN operator should generate native SQL NOT IN () syntax
 		self.assertQueryEqual(
 			frappe.qb.get_query(
 				"DocType",

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -410,12 +410,22 @@ class TestQuery(IntegrationTestCase):
 			"SELECT `name` FROM `tabDocType` WHERE `name` IN ('ToDo','Note')",
 		)
 
+		# Empty list with IN operator should return 0 results (IN () condition)
 		self.assertQueryEqual(
 			frappe.qb.get_query(
 				"DocType",
 				filters={"name": ("in", [])},
 			).get_sql(),
-			"SELECT `name` FROM `tabDocType` WHERE `name` IN ('')",
+			"SELECT `name` FROM `tabDocType` WHERE `name` IN ()",
+		)
+
+		# Empty list with NOT IN operator should return all results (NOT IN () condition)
+		self.assertQueryEqual(
+			frappe.qb.get_query(
+				"DocType",
+				filters={"name": ("not in", [])},
+			).get_sql(),
+			"SELECT `name` FROM `tabDocType` WHERE `name` NOT IN ()",
 		)
 
 		self.assertQueryEqual(


### PR DESCRIPTION
## Description

Fixes issue #18840 where empty lists in `IN` and `NOT IN` filters were incorrectly handled, causing unexpected query results.

### Problem

When using `frappe.get_all()` or query builder with `IN` or `NOT IN` operators and an empty list, the code was converting the empty list to `('')` (empty string), which caused:

- **IN with empty list**: Matched records with empty string values instead of returning 0 results
- **NOT IN with empty list**: Matched records with empty string values instead of returning all results

This violated SQL semantics where:
- `field IN ()` should return 0 results (nothing to match)
- `field NOT IN ()` should return all results (nothing to exclude)

**Example of the bug:**

**Expected: Error just like native SQL**  
**Actual: 305 results (all DocTypes with empty description)**

```python
frappe.get_all("DocType", filters={"description": ["IN", []]})
```

**Expected: Error just like native SQL**  
**Actual: Only records with empty description**

```python
frappe.get_all("DocType", filters={"description": ["NOT IN", []]})
```

### Solution

This PR generates native SQL syntax for empty lists in `IN` and `NOT IN` operators:

- **Empty list with `IN`**: Generates SQL `field IN ()` syntax (same as native SQL)
- **Empty list with `NOT IN`**: Generates SQL `field NOT IN ()` syntax (same as native SQL)
- The database will throw a syntax error if it doesn't support empty `IN ()` (e.g., MySQL/MariaDB), matching native SQL behavior

This approach:
- ✅ Generates the same SQL syntax that native SQL would produce
- ✅ Lets the database handle errors naturally (MySQL/MariaDB will throw syntax error)
- ✅ Works correctly with PostgreSQL which supports `IN ()` syntax
- ✅ Handles both query builder (`frappe.qb`) and legacy `db_query` paths

### Changes

1. **`frappe/database/query.py`**: Added handling in `_build_criterion_for_simple_filter()` to generate `IN ()` or `NOT IN ()` SQL syntax using `RawCriterion` for empty lists
2. **`frappe/model/db_query.py`**: Added handling in `prepare_filter_condition()` to generate native `IN ()` or `NOT IN ()` SQL syntax for empty lists
3. **Tests**: Updated tests to verify `IN ()` and `NOT IN ()` syntax is generated (matching native SQL)


Screenshots:

Before fix:

<img width="1266" height="750" alt="image" src="https://github.com/user-attachments/assets/72f58c4b-c623-4bbc-8490-edbedfec89a1" />



After fix:

<img width="975" height="767" alt="image" src="https://github.com/user-attachments/assets/71bb0a96-7545-4196-9b58-1af20808a0f6" />

