### PR TITLE
feat(Email Account): make `X-Original-From` header configurable

### DIFF
--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -65,6 +65,7 @@
   "always_use_account_email_id_as_sender",
   "always_use_account_name_as_sender_name",
   "send_unsubscribe_message",
+  "add_x_original_from",
   "track_email_status",
   "outgoing_mail_settings",
   "use_tls",
@@ -707,13 +708,19 @@
    "fieldname": "last_received_at",
    "fieldtype": "Datetime",
    "label": "Last Received At"
+  },
+  {
+   "default": "1",
+   "fieldname": "add_x_original_from",
+   "fieldtype": "Check",
+   "label": "Add X-Original-From header"
   }
  ],
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
  "make_attachments_public": 1,
- "modified": "2025-08-20 11:35:14.540578",
+ "modified": "2026-02-04 15:50:27.898578",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -61,6 +61,7 @@ class EmailAccount(Document):
 		from frappe.types import DF
 
 		add_signature: DF.Check
+		add_x_original_from: DF.Check
 		always_bcc: DF.Data | None
 		always_use_account_email_id_as_sender: DF.Check
 		always_use_account_name_as_sender_name: DF.Check

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -276,7 +276,9 @@ class EMail:
 		validate_email_address(strip(self.sender), True)
 		self.reply_to = validate_email_address(strip(self.reply_to) or self.sender, True)
 
-		self.set_header("X-Original-From", self.sender)
+		if self.email_account.add_x_original_from:
+			self.set_header("X-Original-From", self.sender)
+
 		self.replace_sender()
 		self.replace_sender_name()
 

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -257,3 +257,4 @@ execute:frappe.db.set_single_value("Desktop Settings", "icon_style", "Solid")
 execute:frappe.delete_doc_if_exists("Workspace Sidebar", "Productivity")
 frappe.patches.v16_0.unset_standard_field_for_auto_generated_icons
 execute:from frappe.email.doctype.notification.notification import install_notification_templates; install_notification_templates()
+execute:frappe.db.set_value("Email Account", {}, "add_x_original_from", 1)


### PR DESCRIPTION
`X-Original-From` is a non-standard (non-RFC) email header, and different mail servers may handle it in different ways (for example, using it for sender rewriting or internal policies).

Removing this header entirely could be a breaking change for existing setups that rely on it. To avoid regressions while still allowing flexibility, better to make it configurable in the Email Account, with the default set to enabled to preserve the existing behaviour. This header is also currently [used to determine the From address](https://github.com/frappe/frappe/blob/cd5990bd7833e5d5575b3d78b7344dfe02e395ad/frappe/email/receive.py#L446) for incoming emails, so retaining it by default ensures backward compatibility.

<img width="2175" height="424" alt="image" src="https://github.com/user-attachments/assets/90957d39-3982-442f-a583-9b77c631a32b" />

ToDo:
- [x] ~~Make Reply-To configurable (?)~~
- [x] Patch to set `add_x_original_from` to 1 for existing Email Accounts.
- [x] Update Docs.

closes: https://github.com/frappe/frappe/issues/27920

docs: https://docs.frappe.io/wiki/change-requests/e00emd53t2