### PR TITLE
fix(docshare): use has_permission to validate share permissions

### DIFF
--- a/frappe/core/doctype/docshare/test_docshare.py
+++ b/frappe/core/doctype/docshare/test_docshare.py
@@ -247,3 +247,13 @@ class TestDocShare(IntegrationTestCase):
 			frappe.share.add("Communication", doc.name, "test1@example.com")
 		finally:
 			doc.delete()
+
+	def test_owner_can_share_write_with_if_owner_permission(self):
+		"""Test that document owner can share write permission when if_owner grants write."""
+		frappe.share.add("Event", self.event.name, self.user, write=1, share=1)
+
+		frappe.set_user(self.user)
+
+		# user is not the owner, but has write+share via docshare
+		# should be able to share write with another user
+		frappe.share.add("Event", self.event.name, "test1@example.com", write=1)

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -228,20 +228,8 @@ def check_share_permission(doctype, name, permissions=None, custom_perms=None):
 	# Validate user has the permissions they're trying to grant
 	restricted_permissions = ["read", "write", "submit"]
 
-	# Append custom permissions
-	if custom_perms is None:
-		custom_perms = get_doctype_ptype_map().get(doctype, [])
-	restricted_permissions.extend(custom_perms)
-
-	from frappe.permissions import get_role_permissions
-
-	doc = frappe.get_doc(doctype, name)
-	is_owner = (doc.get("owner") or "").lower() == frappe.session.user.lower()
-
-	user_perms = get_role_permissions(doc.meta, user=frappe.session.user, is_owner=is_owner)
-
 	for ptype in restricted_permissions:
-		if cint(permissions.get(ptype)) and not user_perms.get(ptype):
+		if cint(permissions.get(ptype)) and not frappe.has_permission(doctype, ptype=ptype, doc=name):
 			frappe.throw(
 				_("You cannot share `{0}` on {1} `{2}` as you do not have `{0}` permission on `{1}`").format(
 					_(ptype), _(doctype), name


### PR DESCRIPTION
`get_role_permissions` does not account for `if_owner` permissions, causing document owners to be denied sharing write permissions even when they have write access through `if_owner` rules.

Replace `get_role_permissions` with `frappe.has_permission` which correctly evaluates all permission sources including `if_owner`, document shares, and user permissions.

Fixes #36661
