### PR TITLE
fix(mobile): avoid list view crash when standard filters are not initialized

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -649,7 +649,7 @@ class FilterArea {
 	setup_mobile(list_view) {
 		const me = this;
 		this.standard_filters_visible = false;
-		this.standard_filters_wrapper.hide();
+		this.standard_filters_wrapper?.hide();
 		this.list_view.page.page_form.css("justify-content", "flex-end");
 		$(`<button class="filter-toggle btn btn-default btn-sm filter-button">
 					<span class="filter-icon button-icon">


### PR DESCRIPTION
Resolve: #36706


----
**Before:** 

https://github.com/user-attachments/assets/8f030e5d-e6c2-4aa6-940b-aa0c3f810bb9


----
**After:**

https://github.com/user-attachments/assets/8ba15883-0dc0-4d82-8405-4dd4462bf145

