### PR TITLE
fix(List View): hover state for list rows

### DIFF
--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -98,14 +98,14 @@
 
 	&:hover:not(.list-row-head) {
 		background-color: var(--highlight-color);
-
-		.level-right {
-			box-shadow: -5px 0px 5px var(--highlight-color);
-		}
 	}
 
 	&:hover .level-right {
 		background-color: var(--highlight-color);
+	}
+
+	&:last-child {
+		border-bottom: 0px;
 	}
 }
 
@@ -144,6 +144,12 @@
 	transition: color 0.2s;
 	-webkit-transition: color 0.2s;
 	@include get_textstyle("base", "regular");
+
+	&:hover:not(.list-row-head) {
+		.level-right {
+			box-shadow: -5px 0px 5px var(--highlight-color);
+		}
+	}
 
 	.level-left {
 		flex: 4;
@@ -235,7 +241,6 @@
 	}
 	.level-right {
 		background-color: var(--subtle-fg);
-		border-radius: var(--border-radius);
 		height: var(--list-row-height);
 		border-left: none;
 		&:hover {

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -83,7 +83,8 @@
 .list-row-container {
 	display: flex;
 	flex-direction: column;
-	border-bottom: 1px solid $border-color;
+	padding-inline: var(--padding-sm);
+	border-radius: var(--border-radius);
 
 	&:focus {
 		.list-row {
@@ -92,8 +93,19 @@
 	}
 
 	&:first-child {
-		padding-top: 0;
-		border-bottom: none;
+		padding: 0;
+	}
+
+	&:hover:not(.list-row-head) {
+		background-color: var(--highlight-color);
+
+		.level-right {
+			box-shadow: -5px 0px 5px var(--highlight-color);
+		}
+	}
+
+	&:hover .level-right {
+		background-color: var(--highlight-color);
 	}
 }
 
@@ -127,27 +139,11 @@
 }
 
 .list-row {
-	border-radius: var(--border-radius);
+	border-bottom: 1px solid var(--border-color);
 	cursor: pointer;
 	transition: color 0.2s;
 	-webkit-transition: color 0.2s;
 	@include get_textstyle("base", "regular");
-
-	&:hover:not(.list-row-head) {
-		background-color: var(--highlight-color);
-		border-radius: unset;
-		.level-right {
-			box-shadow: -5px 0px 5px var(--highlight-color);
-		}
-	}
-
-	&:hover .level-right {
-		background-color: var(--highlight-color);
-	}
-
-	&:last-child {
-		border-bottom: 0px;
-	}
 
 	.level-left {
 		flex: 4;
@@ -228,6 +224,7 @@
 	background-color: var(--subtle-fg);
 	border-radius: var(--border-radius);
 	height: var(--list-row-height);
+	padding-inline: var(--padding-sm);
 
 	.list-subject {
 		font-weight: normal;

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -96,16 +96,12 @@
 		padding: 0;
 	}
 
-	&:hover:not(.list-row-head) {
+	&:hover {
 		background-color: var(--highlight-color);
 	}
 
 	&:hover .level-right {
 		background-color: var(--highlight-color);
-	}
-
-	&:last-child {
-		border-bottom: 0px;
 	}
 }
 


### PR DESCRIPTION
Add bottom border to the list-row instead of container so hover state can show up correctly with applied border radius on list-row-container similar to our list views in other apps. 

#### Sidenote:
Encountered this bit of code while changing the CSS which kind of did nothing since the bottom border is expected to appear even for the last list row. Not sure but removed it so please point out if this breaks anything - 

```
&:last-child {
	border-bottom: 0px;
}
```

<br>

### Before

https://github.com/user-attachments/assets/90cb42e5-180e-4e07-a716-f16b07678477



### After

https://github.com/user-attachments/assets/3b6b3aa3-78fd-47be-bc1b-a273bcc11ffa




Closes https://github.com/frappe/frappe/issues/36040