### PR TITLE
fix(ux): bind click events to assign, tags and share labels on form sidebar

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/assign_to.js
+++ b/frappe/public/js/frappe/form/sidebar/assign_to.js
@@ -5,6 +5,7 @@ frappe.ui.form.AssignTo = class AssignTo {
 	constructor(opts) {
 		$.extend(this, opts);
 		this.btn = this.parent.find(".add-assignment-btn").on("click", () => this.add());
+		this.parent.find(".add-assignment-label").on("click", () => this.add());
 		this.btn_wrapper = this.btn.parent();
 
 		this.refresh();

--- a/frappe/public/js/frappe/form/sidebar/share.js
+++ b/frappe/public/js/frappe/form/sidebar/share.js
@@ -18,12 +18,17 @@ frappe.ui.form.Share = class Share {
 			this.parent.find(".share-doc-btn").hide();
 		}
 
-		this.parent
-			.find(".share-doc-btn")
-			.off("click")
-			.on("click", () => {
+		const bind_share_click = ($el) => {
+			$el.off("click").on("click", () => {
 				this.frm.share_doc();
 			});
+		};
+
+		const $share_btn = this.parent.find(".share-doc-btn");
+		const $share_label = this.parent.find(".share-label");
+
+		bind_share_click($share_btn);
+		bind_share_click($share_label);
 
 		this.shares.empty();
 

--- a/frappe/public/js/frappe/ui/tags.js
+++ b/frappe/public/js/frappe/ui/tags.js
@@ -37,6 +37,11 @@ frappe.ui.Tags = class {
 			me.$input.val("");
 		};
 
+		const activate_input = () => {
+			this.activate();
+			this.$input.focus();
+		};
+
 		this.$input.keypress((e) => {
 			if (e.which == 13 || e.keyCode == 13) {
 				// Triggers event when <enter> is pressed
@@ -55,10 +60,8 @@ frappe.ui.Tags = class {
 			this.deactivate();
 		});
 
-		this.$placeholder.on("click", () => {
-			this.activate();
-			this.$input.focus(); // focus only when clicked
-		});
+		this.$placeholder.on("click", activate_input);
+		this.$ul.find(".tags-label").on("click", activate_input);
 	}
 
 	boot() {

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -407,6 +407,14 @@ body[data-route^="Form"] {
 	}
 }
 
+.add-assignment-label,
+.tags-label,
+.share-label {
+	&:hover {
+		cursor: pointer;
+	}
+}
+
 .liked-by-popover {
 	.popover-body {
 		min-height: 30px;


### PR DESCRIPTION
Resolve: #35708

---
**Before**

https://github.com/user-attachments/assets/e9c35bd8-0930-4443-87c6-b3e1ef8eccff



---
**After**

https://github.com/user-attachments/assets/f9dd30af-d1d8-462a-96f9-6066f627f1ed

