### PR TITLE
fix(sync): skip dunder prefixed fields while adding child docs to locals

### DIFF
--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -89,6 +89,7 @@ Object.assign(frappe.model, {
 		// add child docs to locals
 		if (!is_table) {
 			for (var i in doc) {
+				if (i.startsWith("__")) continue;
 				var value = doc[i];
 
 				if ($.isArray(value)) {


### PR DESCRIPTION
these include fields like `__print_formats`, `__workflow_docs` which do not actually contain child docs for the doctype.

caused issue #18581 where the local print format doc was being unlinked from `cur_frm` while sycing as it also synced `__print_formats`.

resolves: #18581