### PR TITLE
fix: replace bare raise statement with AuthenticationError in oauth.py

### DIFF
--- a/frappe/email/oauth.py
+++ b/frappe/email/oauth.py
@@ -65,6 +65,12 @@ class Oauth:
 		)
 
 		if not res.startswith(b"+OK"):
+			frappe.log_error(
+				title="POP3 OAuth Authentication Failed",
+				message=f"Response: {res}",
+				reference_doctype="Email Account",
+				reference_name=self.email_account,
+			)
 			frappe.throw(
 				frappe._("POP3 OAuth authentication failed for Email Account {0}").format(self.email_account),
 				frappe.AuthenticationError,

--- a/frappe/email/oauth.py
+++ b/frappe/email/oauth.py
@@ -65,7 +65,10 @@ class Oauth:
 		)
 
 		if not res.startswith(b"+OK"):
-			raise
+			frappe.throw(
+				frappe._("POP3 OAuth authentication failed for Email Account {0}").format(self.email_account),
+				frappe.AuthenticationError,
+			)
 
 	def _connect_imap(self) -> None:
 		self._conn.authenticate(self._mechanism, lambda x: self._auth_string)


### PR DESCRIPTION
Closes #36728


## Summary
- Fixed bare `raise` statement in `_connect_pop()` that caused `RuntimeError: No active exception to reraise`
- Added proper error handling with `frappe.AuthenticationError` and message