### PR TITLE
fix: show search filter on portals and fix layout

### DIFF
--- a/frappe/templates/includes/list/filters.html
+++ b/frappe/templates/includes/list/filters.html
@@ -1,22 +1,24 @@
-<div class="website-list-filters">
+<div class="website-list-filters my-4">
 	<div class="row">
 		<div class="col-6">
 			<form class="form-inline form-search" action="/{{ pathname }}">
 				<div class="input-group">
 					<input class="form-control" doctype="text" name="txt"
 						placeholder="Search..." value="{{ txt or '' }}">
-					<span class="input-group-btn">
+					<div class="input-group-append">
 						<button class="btn btn-light" type="submit">
-							<i class="fa fa-search"></i></button>
-					</span>
+						<span class="desktop-search-icon">
+							<svg class="icon icon-xs"><use href="#icon-search"></use></svg>
+						</span>
+						</button>
+					</div>
 				</div>
 			</form>
 		</div>
 	</div>
 	{% if txt %}
-	<div>
-		<div class="filter-message small text-muted">Results filtered by <b>{{ txt }}</b>.
-			<a href="/{{ pathname }}" class="text-muted">( <span class="close-inline">&times;</span> {{ _("clear") }} )</a></div>
-	</div>
+		<div class="filter-message small text-muted">
+			Results filtered by <b>{{ txt }}</b>.
+		</div>
 	{% endif %}
 </div>

--- a/frappe/templates/includes/list/list.html
+++ b/frappe/templates/includes/list/list.html
@@ -1,7 +1,12 @@
 {% if sub_title %}
 <h4 class="text-muted">{{ sub_title }}</h4>
 {% endif %}
-{% if not result -%}
+
+{% if (not hide_filters) and (result or txt) %}
+	{% include "templates/includes/list/filters.html" %}
+{% endif %}
+
+{% if not result %}
 	<div class="empty-apps-state">
 		<svg class="icon icon-xl" style="stroke: var(--text-light);">
 			<use href="#icon-small-file"></use>
@@ -11,9 +16,6 @@
 {% else %}
 	<div class="website-list" data-doctype="{{ doctype }}"
 		data-txt="{{ (txt or '')|e }}">
-		<!-- {% if not hide_filters -%}
-			{% include "templates/includes/list/filters.html" %}
-		{%- endif %} -->
 		{% if result_heading_template %}{% include result_heading_template %}{% endif %}
 
 		<div class="result">

--- a/frappe/www/portal.py
+++ b/frappe/www/portal.py
@@ -52,7 +52,7 @@ def get(
 	list_context = frappe.flags.list_context
 
 	if not raw_result:
-		return {"result": []}
+		return {"result": [], "txt": txt}
 
 	if txt:
 		list_context.default_subtitle = _('Filtered by "{0}"').format(txt)
@@ -84,4 +84,5 @@ def get(
 		"result": result,
 		"show_more": show_more,
 		"next_start": limit_start + limit,
+		"txt": txt,
 	}


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/32071

- Show search for portals
- Fix layout to search even when there are no results (because how else is a user supposed to clear their query?)

<img width="1440" height="812" alt="image" src="https://github.com/user-attachments/assets/43989b07-3f3e-40db-ae67-cae374796b55" />
