### PR TITLE
fix: get_desk_link function

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1481,12 +1481,12 @@ def get_desk_link(doctype, name, show_title_with_name=False, open_in_new_tab=Fal
 	encoded_name = quote(name)
 
 	if show_title_with_name and name != title:
-		html = '<a href="/desk/Form/{doctype}/{encoded_name}"{target} style="font-weight: bold;">{doctype_local} {name}: {title_local}</a>'
+		html = '<a href="/desk/{doctype}/{encoded_name}"{target} style="font-weight: bold;">{doctype_local} {name}: {title_local}</a>'
 	else:
-		html = '<a href="/desk/Form/{doctype}/{encoded_name}"{target} style="font-weight: bold;">{doctype_local} {title_local}</a>'
+		html = '<a href="/desk/{doctype}/{encoded_name}"{target} style="font-weight: bold;">{doctype_local} {title_local}</a>'
 
 	return html.format(
-		doctype=doctype,
+		doctype=frappe.scrub(doctype),
 		name=name,
 		encoded_name=encoded_name,
 		doctype_local=_(doctype),


### PR DESCRIPTION
With the change in v16, using `Form` inside the URL is no longer valid. Also needed to scrub the DocType name.

![CleanShot 2026-02-05 at 11 25 10](https://github.com/user-attachments/assets/31bdd1d9-9ead-452f-819a-8f7ce6031c64)
