### PR TITLE
fix(share): use `has_permission` instead of `get_role_permissions`

### DIFF
--- a/frappe/share.py
+++ b/frappe/share.py
@@ -233,15 +233,10 @@ def check_share_permission(doctype, name, permissions=None, custom_perms=None):
 		custom_perms = get_doctype_ptype_map().get(doctype, [])
 	restricted_permissions.extend(custom_perms)
 
-	from frappe.permissions import get_role_permissions
-
 	doc = frappe.get_doc(doctype, name)
-	is_owner = (doc.get("owner") or "").lower() == frappe.session.user.lower()
-
-	user_perms = get_role_permissions(doc.meta, user=frappe.session.user, is_owner=is_owner)
 
 	for ptype in restricted_permissions:
-		if cint(permissions.get(ptype)) and not user_perms.get(ptype):
+		if cint(permissions.get(ptype)) and not frappe.has_permission(doctype, ptype, doc=doc):
 			frappe.throw(
 				_("You cannot share `{0}` on {1} `{2}` as you do not have `{0}` permission on `{1}`").format(
 					_(ptype), _(doctype), name


### PR DESCRIPTION
It handles is_owner checks as well

Resolves #36661
