### PR TITLE
fix(file-upload): add support for blocking unsupported file types in file uploader

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -284,6 +284,7 @@ const props = defineProps({
 			max_file_size: null, // 2048 -> 2KB
 			max_number_of_files: null,
 			allowed_file_types: [], // ['image/*', 'video/*', '.jpg', '.gif', '.pdf'],
+			blocked_file_types: [], // ['image/heic', 'image/tiff'],
 			crop_image_aspect_ratio: null, // 1, 16 / 9, 4 / 3, NaN (free)
 		}),
 	},
@@ -472,6 +473,7 @@ function check_restrictions(file) {
 
 	let is_correct_type = true;
 	let valid_file_size = true;
+	let is_unsupported_file_type = check_unsupported_file_type(file);
 
 	if (allowed_file_types && allowed_file_types.length) {
 		is_correct_type = allowed_file_types.some((type) => {
@@ -493,7 +495,7 @@ function check_restrictions(file) {
 		valid_file_size = file.size < max_file_size;
 	}
 
-	if (!is_correct_type) {
+	if (!is_correct_type || is_unsupported_file_type) {
 		console.warn("File skipped because of invalid file type", file);
 		frappe.show_alert({
 			message: __('File "{0}" was skipped because of invalid file type', [file.name]),
@@ -511,8 +513,22 @@ function check_restrictions(file) {
 		});
 	}
 
-	return is_correct_type && valid_file_size;
+	return is_correct_type && valid_file_size && !is_unsupported_file_type;
 }
+
+function check_unsupported_file_type(file) {
+	let { blocked_file_types = [] } = props.restrictions;
+	return blocked_file_types.some((type) => {
+		if (type.includes("/")) {
+			if (!file.type) return false;
+			return file.type.match(type);
+		}
+		if (type[0] === ".") {
+			return file.name.toLowerCase().endsWith(type.toLowerCase());
+		}
+	});
+}
+
 function upload_files(dialog) {
 	if (show_file_browser.value) {
 		return upload_via_file_browser();

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -497,10 +497,20 @@ function check_restrictions(file) {
 
 	if (!is_correct_type || is_unsupported_file_type) {
 		console.warn("File skipped because of invalid file type", file);
-		frappe.show_alert({
-			message: __('File "{0}" was skipped because of invalid file type', [file.name]),
-			indicator: "orange",
-		});
+		if (is_unsupported_file_type) {
+			frappe.show_alert({
+				message: __('File "{0}" was skipped because of unsupported file type "{1}"', [
+					file.name,
+					file.type,
+				]),
+				indicator: "orange",
+			});
+		} else {
+			frappe.show_alert({
+				message: __('File "{0}" was skipped because of invalid file type', [file.name]),
+				indicator: "orange",
+			});
+		}
 	}
 	if (!valid_file_size) {
 		console.warn("File skipped because of invalid file size", file.size, file);

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -64,16 +64,7 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 	}
 	on_attach_doc_image() {
 		this.set_upload_options();
-		this.upload_options.restrictions.allowed_file_types = [
-			"image/jpeg",
-			"image/png",
-			"image/gif",
-			"image/webp",
-			"image/svg+xml",
-			"image/avif",
-			"image/bmp",
-			"image/x-icon",
-		];
+		this.upload_options.restrictions.allowed_file_types = ["image/*"];
 		// file types like .heic/.tiff are not supported for preview directly in the browser, so we block the user from uploading them
 		this.upload_options.restrictions.blocked_file_types = [
 			"image/heic",

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -65,6 +65,8 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 	on_attach_doc_image() {
 		this.set_upload_options();
 		this.upload_options.restrictions.allowed_file_types = ["image/*"];
+		// file types like .heic/.tiff are not supported for preview directly in the browser, so we block the user from uploading them
+		this.upload_options.restrictions.blocked_file_types = ["image/heic", "image/heif", "image/tiff", "image/tif"];
 		this.file_uploader = new frappe.ui.FileUploader(this.upload_options);
 	}
 	set_upload_options() {

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -66,7 +66,12 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 		this.set_upload_options();
 		this.upload_options.restrictions.allowed_file_types = ["image/*"];
 		// file types like .heic/.tiff are not supported for preview directly in the browser, so we block the user from uploading them
-		this.upload_options.restrictions.blocked_file_types = ["image/heic", "image/heif", "image/tiff", "image/tif"];
+		this.upload_options.restrictions.blocked_file_types = [
+			"image/heic",
+			"image/heif",
+			"image/tiff",
+			"image/tif",
+		];
 		this.file_uploader = new frappe.ui.FileUploader(this.upload_options);
 	}
 	set_upload_options() {

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -64,7 +64,16 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 	}
 	on_attach_doc_image() {
 		this.set_upload_options();
-		this.upload_options.restrictions.allowed_file_types = ["image/*"];
+		this.upload_options.restrictions.allowed_file_types = [
+			"image/jpeg",
+			"image/png",
+			"image/gif",
+			"image/webp",
+			"image/svg+xml",
+			"image/avif",
+			"image/bmp",
+			"image/x-icon",
+		];
 		// file types like .heic/.tiff are not supported for preview directly in the browser, so we block the user from uploading them
 		this.upload_options.restrictions.blocked_file_types = [
 			"image/heic",

--- a/frappe/public/js/frappe/form/controls/attach_image.js
+++ b/frappe/public/js/frappe/form/controls/attach_image.js
@@ -21,5 +21,7 @@ frappe.ui.form.ControlAttachImage = class ControlAttachImage extends frappe.ui.f
 	set_upload_options() {
 		super.set_upload_options();
 		this.upload_options.restrictions.allowed_file_types = ["image/*"];
+		// file types like .heic/.tiff are not supported for preview directly in the browser, so we block the user from uploading them
+		this.upload_options.restrictions.blocked_file_types = ["image/heic", "image/heif", "image/tiff", "image/tif"];
 	}
 };

--- a/frappe/public/js/frappe/form/controls/attach_image.js
+++ b/frappe/public/js/frappe/form/controls/attach_image.js
@@ -20,7 +20,16 @@ frappe.ui.form.ControlAttachImage = class ControlAttachImage extends frappe.ui.f
 	}
 	set_upload_options() {
 		super.set_upload_options();
-		this.upload_options.restrictions.allowed_file_types = ["image/*"];
+		this.upload_options.restrictions.allowed_file_types = [
+			"image/jpeg",
+			"image/png",
+			"image/gif",
+			"image/webp",
+			"image/svg+xml",
+			"image/avif",
+			"image/bmp",
+			"image/x-icon",
+		];
 		// file types like .heic/.tiff are not supported for preview directly in the browser, so we block the user from uploading them
 		this.upload_options.restrictions.blocked_file_types = [
 			"image/heic",

--- a/frappe/public/js/frappe/form/controls/attach_image.js
+++ b/frappe/public/js/frappe/form/controls/attach_image.js
@@ -20,16 +20,7 @@ frappe.ui.form.ControlAttachImage = class ControlAttachImage extends frappe.ui.f
 	}
 	set_upload_options() {
 		super.set_upload_options();
-		this.upload_options.restrictions.allowed_file_types = [
-			"image/jpeg",
-			"image/png",
-			"image/gif",
-			"image/webp",
-			"image/svg+xml",
-			"image/avif",
-			"image/bmp",
-			"image/x-icon",
-		];
+		this.upload_options.restrictions.allowed_file_types = ["image/*"];
 		// file types like .heic/.tiff are not supported for preview directly in the browser, so we block the user from uploading them
 		this.upload_options.restrictions.blocked_file_types = [
 			"image/heic",

--- a/frappe/public/js/frappe/form/controls/attach_image.js
+++ b/frappe/public/js/frappe/form/controls/attach_image.js
@@ -22,6 +22,11 @@ frappe.ui.form.ControlAttachImage = class ControlAttachImage extends frappe.ui.f
 		super.set_upload_options();
 		this.upload_options.restrictions.allowed_file_types = ["image/*"];
 		// file types like .heic/.tiff are not supported for preview directly in the browser, so we block the user from uploading them
-		this.upload_options.restrictions.blocked_file_types = ["image/heic", "image/heif", "image/tiff", "image/tif"];
+		this.upload_options.restrictions.blocked_file_types = [
+			"image/heic",
+			"image/heif",
+			"image/tiff",
+			"image/tif",
+		];
 	}
 };


### PR DESCRIPTION
### Changes

- Introduced `blocked_file_types` prop in FileUploader.vue to specify file types that should be restricted from upload.
- Updated `check_restrictions` function to include checks for unsupported file types.
- Modified attach_image.js and attach.js to set blocked file types for image uploads, preventing unsupported formats like .heic and .tiff from being uploaded.
- Restricted selection of unsupported file type in file upload itself.

This resolves #33490

Before (Video referenced in #33490):

https://github.com/user-attachments/assets/1fcc5b5a-c831-47b5-8a02-e8eaab219977

After (updated):

https://github.com/user-attachments/assets/dcabf41e-579a-41f9-a643-c2a5b9cdbca8



