### PR TITLE
fix(sync): Make sure child records are properly synced on save

### DIFF
--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -105,81 +105,104 @@ Object.assign(frappe.model, {
 		}
 	},
 
-	update_in_locals: function (doc) {
+	update_in_locals: function (updated_doc) {
 		// update values in the existing local doc instead of replacing
-		let local_doc = locals[doc.doctype][doc.name];
+		let local_parent_doc = locals[updated_doc.doctype][updated_doc.name];
 		let clear_keys = function (source, target) {
 			Object.keys(target).map((key) => {
 				if (source[key] == undefined) delete target[key];
 			});
 		};
 
-		for (let fieldname in doc) {
-			let df = frappe.meta.get_field(doc.doctype, fieldname);
+		for (let fieldname in updated_doc) {
+			let df = frappe.meta.get_field(updated_doc.doctype, fieldname);
 			if (df && frappe.model.table_fields.includes(df.fieldtype)) {
 				// table
-				if (!(doc[fieldname] instanceof Array)) {
-					doc[fieldname] = [];
+				if (!(updated_doc[fieldname] instanceof Array)) {
+					updated_doc[fieldname] = [];
 				}
 
-				if (!(local_doc[fieldname] instanceof Array)) {
-					local_doc[fieldname] = [];
+				if (!(local_parent_doc[fieldname] instanceof Array)) {
+					local_parent_doc[fieldname] = [];
 				}
 
 				// child table, override each row and append new rows if required
-				for (let i = 0; i < doc[fieldname].length; i++) {
-					let d = doc[fieldname][i];
-					let local_d = local_doc[fieldname][i];
-					if (local_d) {
+				for (let i = 0; i < updated_doc[fieldname].length; i++) {
+					let updated_child_doc = updated_doc[fieldname][i];
+					let local_child_doc_in_parent = local_parent_doc[fieldname][i];
+					const local_child_doc = locals[updated_child_doc.doctype]
+						? locals[updated_child_doc.doctype][updated_child_doc.name]
+						: null;
+					if (local_child_doc) {
+						// update the existing child doc in locals
+						Object.assign(local_child_doc, updated_child_doc);
+						clear_keys(updated_child_doc, local_child_doc);
+						// update parent array reference if needed
+						if (local_child_doc_in_parent !== local_child_doc) {
+							local_parent_doc[fieldname][i] = local_child_doc;
+						}
+						continue;
+					}
+					if (local_child_doc_in_parent) {
 						// deleted and added again
-						if (!locals[d.doctype]) locals[d.doctype] = {};
+						if (!locals[updated_child_doc.doctype])
+							locals[updated_child_doc.doctype] = {};
 
-						if (!d.name) {
+						if (!updated_child_doc.name) {
 							// incoming row is new, find a new name
-							d.name = frappe.model.get_new_name(doc.doctype);
+							updated_child_doc.name = frappe.model.get_new_name(
+								updated_doc.doctype
+							);
 						}
 
 						// if incoming row is not registered, register it
-						if (!locals[d.doctype][d.name]) {
+						if (!locals[updated_child_doc.doctype][updated_child_doc.name]) {
 							// detach old key
-							delete locals[d.doctype][local_d.name];
+							delete locals[updated_child_doc.doctype][
+								local_child_doc_in_parent.name
+							];
 
 							// re-attach with new name
-							locals[d.doctype][d.name] = local_d;
+							locals[updated_child_doc.doctype][updated_child_doc.name] =
+								local_child_doc_in_parent;
 						}
 
 						// row exists, just copy the values
-						Object.assign(local_d, d);
-						clear_keys(d, local_d);
+						Object.assign(local_child_doc_in_parent, updated_child_doc);
+						clear_keys(updated_child_doc, local_child_doc_in_parent);
 					} else {
-						local_doc[fieldname].push(d);
-						if (!d.parent) d.parent = doc.name;
-						frappe.model.add_to_locals(d);
+						local_parent_doc[fieldname].push(updated_child_doc);
+						if (!updated_child_doc.parent) updated_child_doc.parent = updated_doc.name;
+						frappe.model.add_to_locals(updated_child_doc);
 					}
 				}
 
 				// remove extra rows
-				if (local_doc[fieldname].length > doc[fieldname].length) {
-					for (let i = doc[fieldname].length; i < local_doc[fieldname].length; i++) {
+				if (local_parent_doc[fieldname].length > updated_doc[fieldname].length) {
+					for (
+						let i = updated_doc[fieldname].length;
+						i < local_parent_doc[fieldname].length;
+						i++
+					) {
 						// clear from local
-						let d = local_doc[fieldname][i];
+						let d = local_parent_doc[fieldname][i];
 						if (locals[d.doctype] && locals[d.doctype][d.name]) {
 							delete locals[d.doctype][d.name];
 						}
 					}
-					local_doc[fieldname].length = doc[fieldname].length;
+					local_parent_doc[fieldname].length = updated_doc[fieldname].length;
 				}
 			} else {
 				// literal
-				local_doc[fieldname] = doc[fieldname];
+				local_parent_doc[fieldname] = updated_doc[fieldname];
 			}
 		}
 
-		if (local_doc?.on_paste_event && local_doc?.__newname) {
-			doc.__newname = local_doc.__newname;
+		if (local_parent_doc?.on_paste_event && local_parent_doc?.__newname) {
+			updated_doc.__newname = local_parent_doc.__newname;
 		}
 
 		// clear keys on parent
-		clear_keys(doc, local_doc);
+		clear_keys(updated_doc, local_parent_doc);
 	},
 });


### PR DESCRIPTION
On save, individual child records were not being updated in `locals`. As a result, idx values were not synced on save and only corrected after a refresh.

Each [grid row reads its corresponding child record from `locals`](https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/form/grid_row.js#L207) on refresh. Because the data there was stale, the grid displayed an incorrect row order immediately after saving.

This change ensures child records are properly updated in `locals` on save, keeping `idx` in sync and preventing incorrect ordering.

Resolves: https://github.com/frappe/frappe/issues/21081

---

Also, renamed lot of variables for better readability. Previous ones were horrible!