### PR TITLE
fix(like-btn): dark theme color issue

### DIFF
--- a/frappe/public/scss/common/icons.scss
+++ b/frappe/public/scss/common/icons.scss
@@ -22,7 +22,7 @@
 use.like-icon {
 	--icon-stroke: transparent;
 	cursor: pointer;
-	stroke: var(--gray-800);
+	stroke: var(--text-muted);
 }
 
 #icon-file-large {


### PR DESCRIPTION
- Made it same as the color in v16. Resolves - #31815

### Before:

#### Dark
<img width="360" height="418" alt="CleanShot 2026-02-05 at 14 58 56@2x" src="https://github.com/user-attachments/assets/e1ef665b-3c75-4752-a29f-2d202afc7ee5" />

#### Light
<img width="314" height="426" alt="CleanShot 2026-02-05 at 14 59 47@2x" src="https://github.com/user-attachments/assets/590a70c9-6ecc-44fd-b763-42105b565232" />


### After

#### Dark
<img width="232" height="360" alt="CleanShot 2026-02-05 at 15 00 07@2x" src="https://github.com/user-attachments/assets/8b211788-d07b-4953-8ffe-98991bc2e5b9" />

<img width="204" height="318" alt="CleanShot 2026-02-05 at 15 00 33@2x" src="https://github.com/user-attachments/assets/27ddccf9-cd3d-465a-87d1-1e93e7dfca44" />
