### PR TITLE
fix(print_format): update field requirements based on custom format and raw printing

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -18,6 +18,7 @@ frappe.ui.form.on("Print Format", {
 		if (frm.doc.standard === "Yes" && frappe.session.user !== "Administrator") {
 			frm.set_intro(__("Please duplicate this to make changes"));
 		}
+		frm.trigger("update_field_requirements");
 		frm.trigger("render_buttons");
 		frm.toggle_display("standard", frappe.boot.developer_mode);
 		frm.trigger("hide_absolute_value_field");
@@ -37,8 +38,6 @@ frappe.ui.form.on("Print Format", {
 						frappe.set_route("print-format-builder", frm.doc.name);
 					}
 				});
-			} else if (frm.doc.custom_format && !frm.doc.raw_printing) {
-				frm.set_df_property("html", "reqd", 1);
 			}
 			if (frappe.model.can_write("Customize Form")) {
 				frappe.model.with_doctype(frm.doc.doc_type, function () {
@@ -68,6 +67,28 @@ frappe.ui.form.on("Print Format", {
 		frm.set_value("show_section_headings", value);
 		frm.set_value("line_breaks", value);
 		frm.trigger("render_buttons");
+		frm.trigger("update_field_requirements");
+	},
+	raw_printing: function (frm) {
+		frm.trigger("update_field_requirements");
+	},
+	update_field_requirements: function (frm) {
+		// Update field requirements based on custom_format and raw_printing
+		if (frm.doc.custom_format) {
+			if (frm.doc.raw_printing) {
+				// Raw printing enabled: raw_commands required, HTML not required
+				frm.set_df_property("html", "reqd", 0);
+				frm.set_df_property("raw_commands", "reqd", 1);
+			} else {
+				// Raw printing disabled: HTML required, raw_commands not required
+				frm.set_df_property("html", "reqd", 1);
+				frm.set_df_property("raw_commands", "reqd", 0);
+			}
+		} else {
+			// Not custom format: neither field required
+			frm.set_df_property("html", "reqd", 0);
+			frm.set_df_property("raw_commands", "reqd", 0);
+		}
 	},
 	doc_type: function (frm) {
 		frm.trigger("hide_absolute_value_field");

--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -74,22 +74,12 @@ frappe.ui.form.on("Print Format", {
 	},
 	update_field_requirements: function (frm) {
 		// Update field requirements based on custom_format and raw_printing
-		if (frm.doc.custom_format) {
-			if (frm.doc.raw_printing) {
-				// Raw printing enabled: raw_commands required, HTML not required
-				frm.set_df_property("html", "reqd", 0);
-				frm.set_df_property("raw_commands", "reqd", 1);
-			} else {
-				// Raw printing disabled: HTML required, raw_commands not required
-				frm.set_df_property("html", "reqd", 1);
-				frm.set_df_property("raw_commands", "reqd", 0);
-			}
-		} else {
-			// Not custom format: neither field required
-			frm.set_df_property("html", "reqd", 0);
-			frm.set_df_property("raw_commands", "reqd", 0);
-		}
-	},
+		const is_custom = frm.doc.custom_format;
+		const is_raw_printing = frm.doc.raw_printing;
+		
+		frm.set_df_property("html", "reqd", is_custom && !is_raw_printing);
+		frm.set_df_property("raw_commands", "reqd", is_custom && is_raw_printing);
+	}
 	doc_type: function (frm) {
 		frm.trigger("hide_absolute_value_field");
 	},

--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -67,7 +67,7 @@ frappe.ui.form.on("Print Format", {
 		frm.set_value("show_section_headings", value);
 		frm.set_value("line_breaks", value);
 		frm.trigger("render_buttons");
-		frm.trigger("update_field_requirements");
+		frm.trigger("update_field_conditions");
 	},
 	raw_printing: function (frm) {
 		frm.trigger("update_field_requirements");

--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -76,10 +76,10 @@ frappe.ui.form.on("Print Format", {
 		// Update field requirements based on custom_format and raw_printing
 		const is_custom = frm.doc.custom_format;
 		const is_raw_printing = frm.doc.raw_printing;
-		
+
 		frm.set_df_property("html", "reqd", is_custom && !is_raw_printing);
 		frm.set_df_property("raw_commands", "reqd", is_custom && is_raw_printing);
-	}
+	},
 	doc_type: function (frm) {
 		frm.trigger("hide_absolute_value_field");
 	},


### PR DESCRIPTION
# Fix: Print Format Raw Printing Field Requirements

## Problem

When `custom_format` is checked, HTML field becomes mandatory. When `raw_printing` is then checked, HTML field remains mandatory and `raw_commands` field doesn't become mandatory, causing validation errors when saving.

## Solution

- Added `raw_printing` field handler to update field requirements when toggled
- Created `update_field_requirements()` function to centralize the logic:
  - `raw_printing` enabled → `raw_commands` required, HTML not required
  - `raw_printing` disabled → HTML required, `raw_commands` not required

## Files Changed
- `frappe/printing/doctype/print_format/print_format.js`
