### PR TITLE
fix(ux): create workspace 

### DIFF
--- a/frappe/desk/doctype/desktop_icon/desktop_icon.json
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.json
@@ -147,11 +147,11 @@
    "fieldname": "bg_color",
    "fieldtype": "Select",
    "label": "Background Color",
-   "options": "blue\ngray"
+   "options": "gray\nblue"
   }
  ],
  "links": [],
- "modified": "2026-01-27 18:17:48.667070",
+ "modified": "2026-02-04 13:59:30.578370",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Desktop Icon",

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -322,7 +322,6 @@ def create_user_icons(user, data):
 	return data
 
 
-@frappe.whitelist()
 def add_workspace_to_desktop(workspace):
 	sidebar = frappe.new_doc("Workspace Sidebar")
 	sidebar_item = frappe.new_doc("Workspace Sidebar Item")

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -322,7 +322,8 @@ def create_user_icons(user, data):
 	return data
 
 
-def add_workspace_to_desktop(workspace):
+@frappe.whitelist()
+def add_workspace_to_desktop(workspace: str):
 	sidebar = frappe.new_doc("Workspace Sidebar")
 	sidebar_item = frappe.new_doc("Workspace Sidebar Item")
 	sidebar_item.label = workspace

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -24,7 +24,7 @@ class DesktopIcon(Document):
 		from frappe.types import DF
 
 		app: DF.Autocomplete | None
-		bg_color: DF.Literal["blue", "gray"]
+		bg_color: DF.Literal["gray", "blue"]
 		hidden: DF.Check
 		icon_image: DF.Attach | None
 		icon_type: DF.Literal["Link", "Folder", "App"]

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -320,3 +320,24 @@ def create_user_icons(user, data):
 			frappe.cache.hset("_user_settings", f"{'Desktop Icon'}::{user}", json.dumps(user_settings))
 			return json.dumps(user_settings)
 	return data
+
+
+@frappe.whitelist()
+def add_workspace_to_desktop(workspace):
+	sidebar = frappe.new_doc("Workspace Sidebar")
+	sidebar_item = frappe.new_doc("Workspace Sidebar Item")
+	sidebar_item.label = workspace
+	sidebar_item.type = "Link"
+	sidebar_item.link_to = workspace
+	sidebar_item.link_type = "Workspace"
+	sidebar.title = workspace
+	sidebar.append("items", sidebar_item)
+	sidebar.save()
+
+	new_icon = frappe.new_doc("Desktop Icon")
+	new_icon.label = workspace
+	new_icon.icon_type = "Link"
+	new_icon.link_to = workspace
+	new_icon.link_type = "Workspace Sidebar"
+	new_icon.insert()
+	return {"message": "Desktop Icon added successfully"}

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -340,4 +340,4 @@ def add_workspace_to_desktop(workspace):
 	new_icon.link_to = workspace
 	new_icon.link_type = "Workspace Sidebar"
 	new_icon.insert()
-	return {"message": "Desktop Icon added successfully"}
+	return {"icon": new_icon.as_dict()}

--- a/frappe/desk/doctype/desktop_layout/desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.py
@@ -25,7 +25,7 @@ class DesktopLayout(Document):
 
 
 @frappe.whitelist()
-def save_layout(user, layout, new_icons):
+def save_layout(user: str, layout: str, new_icons: str):
 	if not user:
 		user = frappe.session.user
 	layout = json.loads(layout)

--- a/frappe/desk/doctype/desktop_layout/desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.py
@@ -4,6 +4,7 @@
 import json
 
 import frappe
+from frappe.desk.doctype.desktop_icon.desktop_icon import add_workspace_to_desktop
 from frappe.model.document import Document
 
 
@@ -42,6 +43,13 @@ def save_layout(user, layout, new_icons):
 		desktop_layout.save()
 
 	for icon in new_icons:
+		workspace = icon.get("workspace")
+		if workspace:
+			new_workspace = frappe.new_doc("Workspace")
+			new_workspace.update(workspace)
+			new_workspace.title = new_workspace.label
+			new_workspace.save()
+			return add_workspace_to_desktop(new_workspace.name)
 		desktop_icon = frappe.new_doc("Desktop Icon")
 		desktop_icon.update(icon)
 		desktop_icon.owner = frappe.session.user

--- a/frappe/desk/doctype/workspace/workspace.js
+++ b/frappe/desk/doctype/workspace/workspace.js
@@ -8,6 +8,24 @@ frappe.ui.form.on("Workspace", {
 
 	refresh: function (frm) {
 		frm.enable_save();
+		if (frappe.app.sidebar.get_workspace_sidebars(frm.doc.title).length === 0) {
+			frm.add_custom_button(__("Add to Desktop"), function () {
+				frappe.call({
+					method: "frappe.desk.doctype.desktop_icon.desktop_icon.add_workspace_to_desktop",
+					args: {
+						workspace: frm.doc.name,
+					},
+					callback: function (r) {
+						if (r.message.status) {
+							frappe.toast({
+								message: __("Workspace added to desktop"),
+								indicator: "green",
+							});
+						}
+					},
+				});
+			});
+		}
 
 		let url = `/desk/${
 			frm.doc.public

--- a/frappe/desk/doctype/workspace/workspace.js
+++ b/frappe/desk/doctype/workspace/workspace.js
@@ -16,7 +16,8 @@ frappe.ui.form.on("Workspace", {
 						workspace: frm.doc.name,
 					},
 					callback: function (r) {
-						if (r.message.status) {
+						if (r.message) {
+							frappe.boot.desktop_icons.push(r.message.icon);
 							frappe.toast({
 								message: __("Workspace added to desktop"),
 								indicator: "green",

--- a/frappe/desk/doctype/workspace/workspace.js
+++ b/frappe/desk/doctype/workspace/workspace.js
@@ -8,25 +8,6 @@ frappe.ui.form.on("Workspace", {
 
 	refresh: function (frm) {
 		frm.enable_save();
-		if (frappe.app.sidebar.get_workspace_sidebars(frm.doc.title).length === 0) {
-			frm.add_custom_button(__("Add to Desktop"), function () {
-				frappe.call({
-					method: "frappe.desk.doctype.desktop_icon.desktop_icon.add_workspace_to_desktop",
-					args: {
-						workspace: frm.doc.name,
-					},
-					callback: function (r) {
-						if (r.message) {
-							frappe.boot.desktop_icons.push(r.message.icon);
-							frappe.toast({
-								message: __("Workspace added to desktop"),
-								indicator: "green",
-							});
-						}
-					},
-				});
-			});
-		}
 
 		let url = `/desk/${
 			frm.doc.public

--- a/frappe/desk/doctype/workspace/workspace.js
+++ b/frappe/desk/doctype/workspace/workspace.js
@@ -8,7 +8,7 @@ frappe.ui.form.on("Workspace", {
 
 	refresh: function (frm) {
 		frm.enable_save();
-
+		frm.trigger("add_to_desktop");
 		let url = `/desk/${
 			frm.doc.public
 				? frappe.router.slug(frm.doc.title)
@@ -44,6 +44,26 @@ frappe.ui.form.on("Workspace", {
 		frm.layout.show_message(message);
 	},
 
+	add_to_desktop: function (frm) {
+		if (frappe.app.sidebar.get_workspace_sidebars(frm.doc.title).length === 0) {
+			frm.add_custom_button(__("Add to Desktop"), function () {
+				frappe.call({
+					method: "frappe.desk.doctype.desktop_icon.desktop_icon.add_workspace_to_desktop",
+					args: {
+						workspace: frm.doc.name,
+					},
+					callback: function (r) {
+						if (r.message.status) {
+							frappe.toast({
+								message: __("Workspace added to desktop"),
+								indicator: "green",
+							});
+						}
+					},
+				});
+			});
+		}
+	},
 	disable_form: function (frm) {
 		frm.fields
 			.filter((field) => field.has_input)

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -125,9 +125,18 @@ class Workspace(Document):
 			self.name = doc.name = doc.label = doc.title
 
 	def on_trash(self):
+		if not self.module:
+			self.delete_sidebar()
+			self.delete_desktop_icon()
 		if self.public and not is_workspace_manager():
 			frappe.throw(_("You need to be Workspace Manager to delete a public workspace."))
 		self.delete_from_my_workspaces()
+
+	def delete_desktop_icon(self):
+		frappe.delete_doc_if_exists("Desktop Icon", self.title)
+
+	def delete_sidebar(self):
+		frappe.delete_doc_if_exists("Workspace Sidebar", self.title)
 
 	def delete_from_my_workspaces(self):
 		if self.public:

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -364,23 +364,53 @@ class DesktopPage {
 		let grid = $($(".desktop-container .icons").get(0));
 		this.add_new_icon = `<div class="desktop-icon desktop-edit-mode add-new-icon" title="Add New Icon">
 		 ${frappe.utils.icon("plus", "lg")}
-		 New Icon
+		  <div>Workspace</div>
 		 </div>`;
 		grid.append(this.add_new_icon);
 		$(".add-new-icon").on("click", function () {
-			frappe.ui.form.make_quick_entry(
-				"Desktop Icon",
-				function (icon) {
+			let d = new frappe.ui.Dialog({
+				title: "New Workspace",
+				fields: [
+					{
+						label: "Label",
+						fieldname: "label",
+						fieldtype: "Data",
+					},
+					{
+						label: "Public",
+						fieldname: "public",
+						fieldtype: "Check",
+					},
+				],
+				primary_action_label: "Create",
+				primary_action: function (values) {
+					let icon = frappe.model.get_new_doc("Desktop Icon");
+					icon.workspace = {
+						label: values.label,
+						public: values.public,
+					};
+					icon.link_type = "Workspace Sidebar";
+					icon.label = values.label;
 					frappe.new_desktop_icons.push(icon);
 					frappe.new_icons.push(icon);
 					frappe.pages["desktop"].desktop_page.update();
+					d.hide();
 				},
-				"",
-				"",
-				null,
-				true,
-				true
-			);
+			});
+			d.show();
+			// frappe.ui.form.make_quick_entry(
+			// 	"Desktop Icon",
+			// 	function (icon) {
+			// 		frappe.new_desktop_icons.push(icon);
+			// 		frappe.new_icons.push(icon);
+			// 		frappe.pages["desktop"].desktop_page.update();
+			// 	},
+			// 	"",
+			// 	"",
+			// 	null,
+			// 	true,
+			// 	true
+			// );
 		});
 	}
 	setup_edit_buttons() {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -30,6 +30,9 @@ frappe.pages["desktop"].on_page_load = function (wrapper) {
 	// setup();
 };
 
+frappe.pages["desktop"].on_page_show = function (wrapper) {
+	frappe.pages["desktop"].desktop_page.update();
+};
 function get_workspaces_from_app_name(app_name) {
 	const app = frappe.boot.app_data.filter((a) => {
 		return a.app_title === app_name;

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -245,16 +245,6 @@ frappe.views.Workspace = class Workspace {
 									return current_page.is_editable;
 								},
 							},
-							{
-								label: "New",
-								icon: "plus",
-								onClick: function () {
-									me.initialize_new_page(true);
-								},
-								condition: () => {
-									return me.has_create_access;
-								},
-							},
 						],
 					});
 					this.add_workspace_controls = true;

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -245,6 +245,16 @@ frappe.views.Workspace = class Workspace {
 									return current_page.is_editable;
 								},
 							},
+							{
+								label: "New",
+								icon: "plus",
+								onClick: function () {
+									me.initialize_new_page(true);
+								},
+								condition: () => {
+									return me.has_create_access;
+								},
+							},
 						],
 					});
 					this.add_workspace_controls = true;


### PR DESCRIPTION
Workspace creation right now started from the three dots menu on another workspace. This PR fixes that.
You can create a workspace from the desktop itself.

This PR also adds one more improvement where it adds a button on workspace form called "Add To Desktop"

Add to Desktop

https://github.com/user-attachments/assets/670770ed-c182-4cc7-948a-660c6276357f


Workspace Creation

https://github.com/user-attachments/assets/0f14b38d-8499-4f64-b72a-55677f4e9baf


The UX will be improved in a follow up PR
