### PR TITLE
fix(desktop): show correct keyboard shortcut

### DIFF
--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -18,8 +18,7 @@
                     <svg class="icon icon-sm"><use href="#icon-search"></use></svg>
                     {{ _("Search") }}
                 </span>
-                <span>
-                    {{ "⌘K" if is_mac else "Ctrl+K" }}
+                <span class="desktop-keyboard-shortcut">
                 </span>
             </button>
         </div>

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -466,6 +466,12 @@ class DesktopPage {
 	}
 
 	setup_awesomebar() {
+		if (!frappe.is_mobile()) {
+			$(".desktop-keyboard-shortcut").html("Ctrl+K");
+			if (frappe.utils.is_mac()) {
+				$(".desktop-keyboard-shortcut").html("⌘K");
+			}
+		}
 		if (this.awesomebar_setup) return;
 		this.awesomebar_setup = true;
 


### PR DESCRIPTION
Shows correct keyboard shortcut
<img width="403" height="71" alt="Screenshot 2026-02-05 at 9 24 41 PM" src="https://github.com/user-attachments/assets/71639abb-68b3-4ff4-b40f-602a639d5124" />