### PR TITLE
fix: find app locally in the correct folder when resolving required apps

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -252,7 +252,7 @@ def parse_app_name(name: str) -> str:
 	:rtype: str
 	"""
 	name = name.rstrip("/")
-	if os.path.exists(name):
+	if os.path.exists(os.path.join("..", "apps", name)):
 		repo = os.path.split(name)[-1]
 	elif is_git_url(name):
 		if name.startswith("git@") or name.startswith("ssh://"):


### PR DESCRIPTION
facing a lot of rate limit errors when we find apps in frappe/erpnext org using github apis causing installation faliures

if the apps already exist in bench we should not be hitting any api imo

apparently when I did `os.getcwd` in one of the site commands like `install-apps` ..we seem to be executing from the `sites` dir rather than the `apps` dir so that seems to be the root of this faliure