### PR TITLE
fix(report-view): label handling in pick columns dialog fields

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1038,9 +1038,10 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 		table_fields.forEach((df) => {
 			const cdt = df.options;
+			const label = df.label || frappe.unscrub(df.fieldname);
 
 			dialog_fields.push({
-				label: __(df.label, null, df.parent) + ` (${__(cdt)})`,
+				label: __(label) + ` (${__(cdt)})`,
 				fieldname: df.options,
 				fieldtype: "MultiCheck",
 				columns: 2,


### PR DESCRIPTION
**Problem**
When a Child Table field has no `label`, the Report view -> Pick Columns header renders as
`undefined (Child Table)`  e.g. `undefined (Work Order Item)`.

**Fix**
If `label` is missing, fall back to an unscrubbed `fieldname` before rendering.
Example: `required_items` → **Required Items (Work Order Item)**.

---

Before:
<img width="824" height="960" alt="image" src="https://github.com/user-attachments/assets/81fd4b6e-d21a-4d05-92b1-81980a62b365" />

---
After

https://github.com/user-attachments/assets/4b241707-f78f-4a25-9eaf-b68969ad6650

