### PR TITLE
fix(permissions): apply validation on selecting submit amend without write/create

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -454,7 +454,6 @@ frappe.PermissionEngine = class PermissionEngine {
 		});
 
 		this.body.on("click", "input[type='checkbox']", function () {
-			frappe.dom.freeze();
 			let chk = $(this);
 			let args = {
 				role: chk.attr("data-role"),
@@ -469,8 +468,8 @@ frappe.PermissionEngine = class PermissionEngine {
 				page: "permission_manager",
 				method: "update",
 				args: args,
+				freeze: true,
 				callback: (r) => {
-					frappe.dom.unfreeze();
 					if (r.exc) {
 						// exception: reverse
 						chk.prop("checked", !chk.prop("checked"));
@@ -485,6 +484,10 @@ frappe.PermissionEngine = class PermissionEngine {
 						}
 					}
 				},
+				error: () => {
+					// Revert checkbox when server returns 417/5xx (e.g. validation error)
+					chk.prop("checked", !chk.prop("checked"));
+				}
 			});
 		});
 	}

--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -487,7 +487,7 @@ frappe.PermissionEngine = class PermissionEngine {
 				error: () => {
 					// Revert checkbox when server returns 417/5xx (e.g. validation error)
 					chk.prop("checked", !chk.prop("checked"));
-				}
+				},
 			});
 		});
 	}

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -119,7 +119,9 @@ def add(parent, role, permlevel):
 
 
 @frappe.whitelist()
-def update(doctype: str, role: str, permlevel: int, ptype: str, value=None, if_owner=0) -> str | None:
+def update(
+	doctype: str, role: str, permlevel: int, ptype: str, value: str | None = None, if_owner: str | None = None
+) -> str | None:
 	"""Update role permission params.
 
 	Args:
@@ -127,7 +129,8 @@ def update(doctype: str, role: str, permlevel: int, ptype: str, value=None, if_o
 	        role (str): Role to be updated for, eg "Website Manager".
 	        permlevel (int): perm level the provided rule applies to
 	        ptype (str): permission type, example "read", "delete", etc.
-	        value (None, optional): value for ptype, None indicates False
+	        value (str, optional): value for ptype, None indicates False (0 for False, 1 for True)
+			if_owner (str, optional): if_owner flag, None indicates False (0 for False, 1 for True)
 
 	Return:
 	        str: Refresh flag if permission is updated successfully

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -144,19 +144,29 @@ def update(doctype: str, role: str, permlevel: int, ptype: str, value=None, if_o
 	# Submit -> Write permission must be set
 	# Amend -> Write and Create permission must be set
 	if ptype in ["submit", "amend"] and value == "1":
-		has_write, has_create = frappe.db.get_value("Custom DocPerm", {"role": role}, ["write", "create"], order_by="modified desc")
+		has_write, has_create = frappe.db.get_value(
+			"Custom DocPerm", {"role": role}, ["write", "create"], order_by="modified desc"
+		)
 		if ptype == "submit" and not has_write:
 			frappe.throw(_(f"Cannot set {ptype.capitalize()} permission without setting Write permission"))
 		if ptype == "amend" and not (has_create and has_write):
-			frappe.throw(_(f"Cannot set {ptype.capitalize()} permission without setting Create or Write permission"))
+			frappe.throw(
+				_(f"Cannot set {ptype.capitalize()} permission without setting Create or Write permission")
+			)
 
 	if ptype in ["write", "create"] and value == "0":
 		# cannot remove write and create permission without removing submit and amend permissions
-		has_submit, has_amend = frappe.db.get_value("Custom DocPerm", {"role": role}, ["submit", "amend"], order_by="modified desc")
+		has_submit, has_amend = frappe.db.get_value(
+			"Custom DocPerm", {"role": role}, ["submit", "amend"], order_by="modified desc"
+		)
 		if ptype == "write" and has_submit:
-			frappe.throw(_(f"Cannot remove {ptype.capitalize()} permission without removing Submit permission"))
+			frappe.throw(
+				_(f"Cannot remove {ptype.capitalize()} permission without removing Submit permission")
+			)
 		if (ptype == "create" or ptype == "write") and has_amend:
-			frappe.throw(_(f"Cannot remove {ptype.capitalize()} permission without removing Amend permission"))
+			frappe.throw(
+				_(f"Cannot remove {ptype.capitalize()} permission without removing Amend permission")
+			)
 
 	out = update_permission_property(doctype, role, permlevel, ptype, value, if_owner=if_owner)
 

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -141,6 +141,23 @@ def update(doctype: str, role: str, permlevel: int, ptype: str, value=None, if_o
 	if ptype == "report" and value == "1" and if_owner == "1":
 		frappe.throw(_("Cannot set 'Report' permission if 'Only If Creator' permission is set"))
 
+	# Submit -> Write permission must be set
+	# Amend -> Write and Create permission must be set
+	if ptype in ["submit", "amend"] and value == "1":
+		has_write, has_create = frappe.db.get_value("Custom DocPerm", {"role": role}, ["write", "create"], order_by="modified desc")
+		if ptype == "submit" and not has_write:
+			frappe.throw(_(f"Cannot set {ptype.capitalize()} permission without setting Write permission"))
+		if ptype == "amend" and not (has_create and has_write):
+			frappe.throw(_(f"Cannot set {ptype.capitalize()} permission without setting Create or Write permission"))
+
+	if ptype in ["write", "create"] and value == "0":
+		# cannot remove write and create permission without removing submit and amend permissions
+		has_submit, has_amend = frappe.db.get_value("Custom DocPerm", {"role": role}, ["submit", "amend"], order_by="modified desc")
+		if ptype == "write" and has_submit:
+			frappe.throw(_(f"Cannot remove {ptype.capitalize()} permission without removing Submit permission"))
+		if (ptype == "create" or ptype == "write") and has_amend:
+			frappe.throw(_(f"Cannot remove {ptype.capitalize()} permission without removing Amend permission"))
+
 	out = update_permission_property(doctype, role, permlevel, ptype, value, if_owner=if_owner)
 
 	if ptype == "if_owner" and value == "1":


### PR DESCRIPTION
### Problem

As the issue #36004 explains - 
- Submit -> check if Write perm is set
- Amend -> check if Write and Create perm are set

These validations are required as not having them leads to user being allowed to set incorrect system behaviour which can lead to issues down the line.

### Solution

Apply basic validation checks in `update` function in `permission_manager`. Also checked for removing the ptype and trying to set again.
Added `freeze` property in `permission.js` instead of manually calling freeze unfreeze to fix the incorrect behavior which was leading to page being frozen incase of an error.
Also need to apply this change in v15.

### Video

https://github.com/user-attachments/assets/d1ee508a-37ac-4929-8091-cd005c2b8f8d