### PR TITLE
feat: sidebar card

### DIFF
--- a/frappe/public/js/desk.bundle.js
+++ b/frappe/public/js/desk.bundle.js
@@ -14,6 +14,8 @@ import "./frappe/ui/sidebar/sidebar_header.html";
 import "./frappe/ui/sidebar/sidebar.html";
 import "./frappe/ui/sidebar/sidebar_item.html";
 import "./frappe/ui/sidebar/sidebar.js";
+import "./frappe/ui/sidebar/sidebar_card.html";
+import "./frappe/ui/sidebar/sidebar_card.js";
 import "./frappe/ui/link_preview.js";
 
 import "./frappe/request.js";

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -30,6 +30,7 @@
 					</a>
 				</div>
 			</div>
+			<div class="body-sidebar-cards"></div>
 			<div class="body-sidebar-bottom">
 				<div class="edit-mode bottom-edit-controls hidden">
 					<button class="btn-outline btn-sm discard-button">

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -106,7 +106,20 @@ frappe.ui.Sidebar = class Sidebar {
 		this.$sidebar.attr("data-title", this.sidebar_title);
 		this.sidebar_header = new frappe.ui.SidebarHeader(this);
 		this.make_sidebar();
+		this.add_sidebar_card();
 	}
+	add_sidebar_card() {
+		let card = new frappe.ui.SidebarCard({
+			title: "Trial ends in 3 days",
+			icon: "zap",
+			message: "Upgrade to Pro to unlock more features",
+			parent: this.wrapper.find(".body-sidebar-bottom"),
+			primary_action_icon: "zap",
+			primary_action_label: "Upgrade",
+			primary_action: () => {},
+		});
+	}
+
 	check_for_private_workspace(workspace_title) {
 		if (workspace_title == "private" || workspace_title == "Personal") {
 			this.sidebar_title = "My Workspaces";

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -111,9 +111,9 @@ frappe.ui.Sidebar = class Sidebar {
 	add_sidebar_card() {
 		let card = new frappe.ui.SidebarCard({
 			title: "Trial ends in 3 days",
-			icon: "zap",
+			icon: "info",
 			message: "Upgrade to Pro to unlock more features",
-			parent: this.wrapper.find(".body-sidebar-bottom"),
+			parent: this.wrapper.find(".body-sidebar-cards"),
 			primary_action_icon: "zap",
 			primary_action_label: "Upgrade",
 			primary_action: () => {},

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -19,6 +19,7 @@ frappe.ui.Sidebar = class Sidebar {
 		this.$standard_items_sections = this.wrapper.find(".standard-items-sections");
 		this.$sidebar = this.wrapper.find(".body-sidebar");
 		this.items = [];
+		this.cards = [];
 		this.setup_events();
 		this.sidebar_module_map = {};
 		this.build_sidebar_module_map();
@@ -106,17 +107,21 @@ frappe.ui.Sidebar = class Sidebar {
 		this.$sidebar.attr("data-title", this.sidebar_title);
 		this.sidebar_header = new frappe.ui.SidebarHeader(this);
 		this.make_sidebar();
-		this.add_sidebar_card();
+		this.add_sidebar_cards();
 	}
-	add_sidebar_card() {
-		let card = new frappe.ui.SidebarCard({
-			title: "Trial ends in 3 days",
-			icon: "info",
-			message: "Upgrade to Pro to unlock more features",
-			parent: this.wrapper.find(".body-sidebar-cards"),
-			primary_action_icon: "zap",
-			primary_action_label: "Upgrade",
-			primary_action: () => {},
+	add_card(card) {
+		if (
+			this.desktop_menu_items &&
+			this.desktop_menu_items.find((i) => i.to_title_case === card.title)
+		)
+			return;
+		this.cards.push(card);
+	}
+	add_sidebar_cards() {
+		this.wrapper.find(".body-sidebar-cards").html("");
+		this.cards.forEach((card) => {
+			let card_obj = new frappe.ui.SidebarCard(card);
+			card.obj = card_obj;
 		});
 	}
 

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
@@ -1,0 +1,8 @@
+<div class="d-inline-flex flex-column px-2 py-2" style="background-color: var(--surface-modal); box-shadow: var(--shadow-sm); gap: 12px; border-radius: 12px;">
+    <div class="flex">
+        {%= frappe.utils.icon(card.icon) %}
+        <div class="sidebar-card-title">{{ card.title }}</div>
+    </div>
+    <div class="sidebar-card-description">{{ card.message }}</div>
+    <button class="btn btn-info">{{ card.primary_action_label }}</button>
+</div>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
@@ -1,4 +1,4 @@
-<div class="sidebar-card d-inline-flex flex-column px-2 py-2" style="background-color: var(--surface-modal); box-shadow: var(--shadow-sm); gap: 12px; border-radius: 12px;">
+<div class="sidebar-card d-inline-flex flex-column px-2 py-2">
     <div>
         <div class="card-title-container">
             {%= frappe.utils.icon(card.icon, "sm", "", "", "card-icon") %}

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
@@ -1,8 +1,10 @@
-<div class="d-inline-flex flex-column px-2 py-2" style="background-color: var(--surface-modal); box-shadow: var(--shadow-sm); gap: 12px; border-radius: 12px;">
-    <div class="flex">
-        {%= frappe.utils.icon(card.icon) %}
-        <div class="sidebar-card-title">{{ card.title }}</div>
+<div class="sidebar-card d-inline-flex flex-column px-2 py-2" style="background-color: var(--surface-modal); box-shadow: var(--shadow-sm); gap: 12px; border-radius: 12px;">
+    <div>
+        <div class="card-title-container">
+            {%= frappe.utils.icon(card.icon, "sm", "", "", "card-icon") %}
+            <div class="sidebar-card-title">{{ card.title }}</div>
+        </div>
+        <div class="sidebar-card-description">{{ card.message }}</div>
     </div>
-    <div class="sidebar-card-description">{{ card.message }}</div>
-    <button class="btn btn-info">{{ card.primary_action_label }}</button>
+    <button class="sidebar-card-button btn">{{ frappe.utils.icon(card.primary_action_icon, "sm", "", "", "", true) }}{{ card.primary_action_label }}</button>
 </div>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
@@ -1,0 +1,18 @@
+frappe.provide("frappe.ui");
+
+// icon, title, message, condition, primary_action_label, primary_action
+frappe.ui.SidebarCard = class SidebarCard {
+	constructor(opts) {
+		Object.assign(this, opts);
+		this.make(opts);
+	}
+	make() {
+		this.card = $(
+			frappe.render_template("sidebar_card", {
+				card: this,
+			})
+		);
+
+		this.card.prependTo(this.parent);
+	}
+};

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
@@ -5,6 +5,7 @@ frappe.ui.SidebarCard = class SidebarCard {
 	constructor(opts) {
 		Object.assign(this, opts);
 		this.make(opts);
+		this.setup();
 	}
 	make() {
 		this.card = $(
@@ -14,5 +15,15 @@ frappe.ui.SidebarCard = class SidebarCard {
 		);
 
 		this.card.prependTo(this.parent);
+	}
+	setup() {
+		this.setup_primary_action();
+	}
+	setup_primary_action() {
+		const me = this;
+		this.card.find(".sidebar-card-button").on("click", function (event) {
+			event.preventDefault();
+			me.primary_action(event);
+		});
 	}
 };

--- a/frappe/public/scss/desk/index.scss
+++ b/frappe/public/scss/desk/index.scss
@@ -54,3 +54,4 @@
 @import "version";
 @import "menu";
 @import "sidebar_header";
+@import "sidebar_card";

--- a/frappe/public/scss/desk/sidebar_card.scss
+++ b/frappe/public/scss/desk/sidebar_card.scss
@@ -10,6 +10,13 @@
 		@include get_textstyle("base", "medium");
 	}
 }
+.sidebar-card {
+	width: 100%;
+	background-color: var(--surface-modal);
+	box-shadow: var(--shadow-sm);
+	gap: 12px;
+	border-radius: 12px;
+}
 .sidebar-card-description {
 	@include get_textstyle("sm", "regular");
 }
@@ -25,6 +32,8 @@
 		margin: 0px;
 	}
 }
-.sidebar-card-button:hover {
+.sidebar-card-button:hover,
+.sidebar-card-button:focus {
 	outline: 1px solid var(--surface-blue-3);
+	color: var(--ink-blue-3);
 }

--- a/frappe/public/scss/desk/sidebar_card.scss
+++ b/frappe/public/scss/desk/sidebar_card.scss
@@ -1,0 +1,30 @@
+.card-title-container {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	color: var(--ink-gray-9);
+	.card-icon {
+		margin: 0;
+	}
+	.sidebar-card-title {
+		@include get_textstyle("base", "medium");
+	}
+}
+.sidebar-card-description {
+	@include get_textstyle("sm", "regular");
+}
+.sidebar-card-button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: var(--surface-blue-2);
+	color: var(--ink-blue-3);
+	gap: 4px;
+	svg {
+		stroke: var(--ink-blue-3);
+		margin: 0px;
+	}
+}
+.sidebar-card-button:hover {
+	outline: 1px solid var(--surface-blue-3);
+}


### PR DESCRIPTION
Desk based apps like ERPNext, HRMS are missing a component to show trial banner. The old trail banner will be removed in favor of this

<img width="1440" height="900" alt="Screenshot 2026-02-06 at 11 23 23 AM" src="https://github.com/user-attachments/assets/28098f69-a500-42a9-8c11-950bb612eb24" />

Example usage
```
frappe.app.sidebar.add_card({
	title: "Trial ends in 3 days",
	icon: "info",
	message: "Upgrade to Pro to unlock more features",
	parent: this.wrapper.find(".body-sidebar-cards"),
	primary_action_icon: "zap",
	primary_action_label: "Upgrade",
	primary_action: () => {},
}))
```

`no-docs`