### PR TITLE
fix(print_format): update required property for HTML field based on custom format and raw printing status

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -38,7 +38,10 @@ frappe.ui.form.on("Print Format", {
 					}
 				});
 			} else if (frm.doc.custom_format && !frm.doc.raw_printing) {
-				frm.set_df_property("html", "reqd", 1);
+				frm.toggle_reqd("html", 1);
+			}
+			if (frm.doc.raw_printing || !frm.doc.custom_format) {
+				frm.toggle_reqd("html", 0);
 			}
 			if (frappe.model.can_write("Customize Form")) {
 				frappe.model.with_doctype(frm.doc.doc_type, function () {


### PR DESCRIPTION
**Issue:**
While editing **Print Format** docs, Unchecking the already checked custom format checkbox does not allow to save the document if the `html` field is empty.

**Fix:**
update required property for HTML field based on custom format and raw printing status in js.
update 
Fixes: https://github.com/frappe/frappe/issues/36824

**Before:**

[Screencast from 06-02-26 10:48:08 AM IST.webm](https://github.com/user-attachments/assets/e6f33b65-333a-4c44-af2c-5b4bf5a29747)

**After:**

[Screencast from 06-02-26 12:09:20 PM IST.webm](https://github.com/user-attachments/assets/f45d39a3-0b68-4127-9741-1b6c0984f98d)

Backport needed for: v15, v16