### PR TITLE
fix(doctype): disable allow_auto_repeat during duplication

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -3,8 +3,11 @@
 
 frappe.ui.form.on("DocType", {
 	onload: function (frm) {
-		if (frm.is_new() && !frm.doc?.fields) {
-			frappe.listview_settings["DocType"].new_doctype_dialog();
+		if (frm.is_new()) {
+			frm.set_value("allow_auto_repeat", 0);
+			if (!frm.doc?.fields) {
+				frappe.listview_settings["DocType"].new_doctype_dialog();
+			}
 		}
 		frm.call("check_pending_migration");
 	},


### PR DESCRIPTION
**issue:** Duplicating a DocType with Allow Auto Repeat enabled triggers a validation error because the new DocType is not yet created/registered during the duplication process.

**fix:** Automatically disable Allow Auto Repeat while duplicating the DocType to prevent premature validation errors.

**closes:** [#36737](https://github.com/frappe/frappe/issues/36737)

**before:**

[befor_issue.webm](https://github.com/user-attachments/assets/f89b801c-7982-4908-a558-72221e7df074)

**after:**

[Screencast from 06-02-26 02_08_31 PM IST.webm](https://github.com/user-attachments/assets/ddd665c5-8fc9-4ffe-a94a-929e6ddf821d)

  **Backport needed: v15 , v16**