### PR TITLE
fix(text editor): grid row tab action

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -392,7 +392,7 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 	}
 
 	get_keyboard_bindings() {
-		let bindings = {
+		const bindings = {
 			"table enter": {
 				key: "Enter",
 				formats: ["table"],
@@ -419,6 +419,14 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 				},
 			},
 		};
+
+		if (this.grid_row) {
+			bindings["tab"] = {
+				key: "Tab",
+				handler: () => true, // call default handler
+			};
+		}
+
 		return bindings;
 	}
 };


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/36685

Overrides default text editor 'tab' key behaviour in grid row to allow going to next cell

https://github.com/user-attachments/assets/bb577ebf-ed27-44ee-9a2e-c7b2bef5b8d8

