### PR TITLE
feat: Show color for  depends on fields for data import

### DIFF
--- a/frappe/public/js/frappe/data_import/data_exporter.js
+++ b/frappe/public/js/frappe/data_import/data_exporter.js
@@ -287,6 +287,19 @@ frappe.data_import.DataExporter = class DataExporter {
 			return false;
 		};
 
+		let is_field_depends_on = (df) => {
+			if (df.depends_on && this.exporting_for == "Insert New Records") {
+				return true;
+			}
+			if (autoname_field && df.fieldname == autoname_field.fieldname) {
+				return true;
+			}
+			if (df.fieldname === "name") {
+				return true;
+			}
+			return false;
+		};
+
 		return fields
 			.filter((df) => {
 				if (autoname_field && df.fieldname === "name") {
@@ -299,6 +312,7 @@ frappe.data_import.DataExporter = class DataExporter {
 					label: __(df.label, null, df.parent),
 					value: df.fieldname,
 					danger: is_field_mandatory(df),
+					warning: is_field_depends_on(df),
 					checked: false,
 					description: `${df.fieldname} ${df.reqd ? __("(Mandatory)") : ""}`,
 				};

--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -85,6 +85,10 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 			if (option.danger) {
 				checkbox.find(".label-area").addClass("text-danger");
 			}
+			if (option.warning) {
+				checkbox.find(".label-area").addClass("text-warning");
+			}
+
 			option.$checkbox = checkbox;
 		});
 		if (this.df.select_all) {


### PR DESCRIPTION
This allows the user to see the _depends on_ fields highlighted as well in the data import, during the download template option. 
Currently, the user can only see mandatory fields, but there are times at which there are validations present on depends on fields which than lead to error in the process of data import. 

Post the change it would look something like this: 

<img width="629" height="781" alt="image" src="https://github.com/user-attachments/assets/3a4dcbf9-4728-4851-8ad4-84904981070c" />

`no-docs`