### PR TITLE
fix: Resolve translated Party Type values in Dynamic Link field

### DIFF
--- a/frappe/public/js/frappe/form/controls/dynamic_link.js
+++ b/frappe/public/js/frappe/form/controls/dynamic_link.js
@@ -7,15 +7,25 @@ frappe.ui.form.ControlDynamicLink = class ControlDynamicLink extends frappe.ui.f
 			//for dialog box
 			options = cur_dialog.get_value(this.df.options);
 		} else if (!cur_frm) {
+			const selector = `input[data-fieldname="${this.df.options}"]`;
+			let input = null;
 			if (cur_list) {
 				// for list page
-				options = cur_list.page.fields_dict[this.df.options].get_input_value();
-			} else if (cur_page) {
-				const selector = `input[data-fieldname="${this.df.options}"]`;
-				let input = $(cur_page.page).find(selector);
-				options = input.length
-					? input.val()
-					: frappe.model.get_value(this.df.parent, this.docname, this.df.options);
+				input = cur_list.filter_area.standard_filters_wrapper.find(selector);
+			}
+			if (cur_page && !input) {
+				input = $(cur_page.page).find(selector);
+			}			
+			if (input) {
+				options = input.val();
+				// Try using Party Type translation map
+				// Map is pre-populated in link.js when party_type field initializes
+				if (options && !frappe.get_meta(options)) {
+					const map = frappe._party_type_translation_map || {};
+					if (map[options]) {
+						options = map[options];
+					}
+				}
 			}
 		} else {
 			options = frappe.model.get_value(this.df.parent, this.docname, this.df.options);

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -353,6 +353,12 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				me.$input.val("");
 			}
 		});
+		if (this.df.fieldname === "party_type") {
+			setTimeout(() => {
+				// Trigger a search with empty term to get all values and populate the map
+				this.$input.trigger("input");
+			}, 100);
+		}
 	}
 
 	/**
@@ -441,6 +447,24 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			cache: use_get,
 			args: args,
 			callback: async (r) => {
+				if (this.df.fieldname === "party_type" && Array.isArray(r.message)) {
+					frappe._party_type_translation_map = {};
+					r.message.forEach((item) => {
+						const value = item?.value;
+						if (!value) return;
+						// Map the actual displayed text (same logic used by the Link control)
+						const display_text = this.get_translated(item.label || item.value);
+						if (display_text) {
+							frappe._party_type_translation_map[display_text] = value;
+						}
+						// Map description (often module/section translation)
+						if (item?.description) {
+							frappe._party_type_translation_map[item.description] = value;
+						}
+						// Map raw label/value as fallback
+						frappe._party_type_translation_map[item.label || item.value] = value;
+					});
+				}
 				if (!window.Cypress && !this.$input.is(":focus")) {
 					return;
 				}


### PR DESCRIPTION
This fix resolves the issue where the Party field in Dynamic Link was not correctly handling translated values (e.g., کسٹمر in Urdu, العميل in Arabic).

Problem:
When a form loads with a default party_type value (e.g., 'Customer'), selecting a Party value with a translated UI causes a 403 error because the API receives the translated display text instead of the English DocType name (Customer), which fails validate_link validation.

Solution:
Implement a three-block synchronization mechanism:

BLOCK 4 (link.js): Pre-population
- When party_type field's awesomplete initializes
- Automatically triggers search with empty term after 100ms
- Builds frappe._party_type_translation_map with all Party Type options
- Maps translated display text  English DocType names

BLOCK 1 (dynamic_link.js): Value Reading
- Reads the translated value from the Party input field
- Example: reads 'کسٹمر' or 'العميل'

BLOCK 2 (dynamic_link.js): Value Resolution
- Looks up the translated value in frappe._party_type_translation_map
- Resolves to English DocType name
- Example: 'کسٹمر'  'Customer'

Benefits:
- Party field now behaves identically to Party Type field
- Correctly resolves all translated values to English DocType names
- Works with any language (Urdu, Arabic, etc.)
- Works regardless of field selection order
- Works when party_type has a default value
- Eliminates 403 errors on validate_link API calls

Files Modified:
- frappe/public/js/frappe/form/controls/dynamic_link.js Updated get_options() method with improved selector logic Added translation map resolution for cur_list and cur_page contexts Uses consistent input element handling for both page types

- frappe/public/js/frappe/form/controls/link.js Added party_type translation map building in search_link callback Maps display_text, description, and raw label/value as fallbacks Added initialization trigger for party_type field (100ms timeout)

Tested with:
- Frappe Framework v15.96.0 and v15.99.0
- Languages: Urdu, Arabic
- Payment Entry form with default party_type value

<img width="3677" height="1557" alt="image" src="https://github.com/user-attachments/assets/abb97043-2e40-4dbd-8751-790a121f2a13" />
