### PR TITLE
Fix: Resolve JSON serialization error for Path objects

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -206,6 +206,7 @@ def _make_logs_v2():
 def json_handler(obj):
 	"""serialize non-serializable data for json"""
 	from collections.abc import Iterable
+	from pathlib import Path
 	from re import Match
 
 	if isinstance(obj, datetime.date | datetime.datetime | datetime.time):
@@ -236,6 +237,12 @@ def json_handler(obj):
 
 	elif isinstance(obj, uuid.UUID):
 		return str(obj)
+	
+	# elif isinstance(obj, Path):
+	# 	path = Path('suhail@astromingroup.com (suhail@astromingroup.com)/AMG-ACCOUNTS/2.AMG-ACC-UAE-JAFZAaz')
+	# 	data = {'path': str(os.path)}  # Convert to string
+	# 	return data
+	
 
 	else:
 		raise TypeError(f"""Object of type {type(obj)} with value of {obj!r} is not JSON serializable""")

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -238,10 +238,10 @@ def json_handler(obj):
 	elif isinstance(obj, uuid.UUID):
 		return str(obj)
 	
-	# elif isinstance(obj, Path):
-	# 	path = Path('suhail@astromingroup.com (suhail@astromingroup.com)/AMG-ACCOUNTS/2.AMG-ACC-UAE-JAFZAaz')
-	# 	data = {'path': str(os.path)}  # Convert to string
-	# 	return data
+	elif isinstance(obj, Path):
+		path = Path(obj)
+		data = {'path': str(path)}
+		return data
 	
 
 	else:


### PR DESCRIPTION
### Problem

Apps that include a `pathlib.Path` object in API responses fail during JSON serialization because `json_handler()` does not currently handle `Path` objects.  
This issue was encountered in **Frappe Drive**, where file system paths are returned as `Pathlib.Path` instances, causing response serialization errors.

---

### Solution

Updated `json_handler()` to properly serialize `pathlib.Path` objects by converting them into a JSON-compatible format.  
With this change, apps (including **Frappe Drive**) can safely return `Pathlib.Path` objects in responses without raising serialization errors.

---

### Impact

- Fixes JSON serialization errors when `Pathlib.Path` objects are included in responses  
- Improves compatibility for filesystem-related apps such as **Frappe Drive**  
- Backward compatible with existing response handling

---

### Related Apps / Use Case

- Frappe Drive