### PR TITLE
fix: calendar view not displaying events

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -249,6 +249,8 @@ frappe.views.Calendar = class Calendar {
 	}
 	setup_options(defaults) {
 		var me = this;
+		const user_time_fmt = frappe.datetime.get_user_time_fmt();
+		const event_time_fmt = user_time_fmt.replace(/[:.]s{1,2}/g, "").trim();
 		defaults.meridiem = "false";
 		this.cal_options = {
 			locale: frappe.boot.lang,
@@ -256,11 +258,7 @@ frappe.views.Calendar = class Calendar {
 				left: "prev, title, next",
 				right: "today, month, agendaWeek, agendaDay",
 			},
-			eventTimeFormat: {
-				hour: "numeric",
-				minute: "2-digit",
-				hour12: true,
-			},
+			eventTimeFormat: event_time_fmt,
 			editable: true,
 			selectable: true,
 			selectHelper: true,


### PR DESCRIPTION
> **Please provide enough information so that others can review your pull request:**

This PR addresses a Calendar View regression observed on Frappe v15.99.0 where events fail to render and the browser console throws `key.toUpperCase is not a function`.

Introduced in #36447

---

> **Explain the details for making this change. What existing problem does the pull request solve?**

Calendar View in Frappe uses FullCalendar v3.10.2, which is Moment.js–based and expects `eventTimeFormat` to be provided as a string (e.g. `"HH:mm"` or `"LT"`).
However, the current implementation was passing an Intl-style time format object (e.g. `{ hour, minute, hour12 }`) to FullCalendar.

FullCalendar v3 forwards this value to Moment’s `localeData().longDateFormat(key)` API, which assumes `key` is a string and calls `key.toUpperCase()`. When an object is passed instead, this results in a runtime exception and prevents events from being rendered on the calendar.

This change ensures that a Moment-compatible string time format is always passed to FullCalendar by deriving it from the user’s configured time format and normalizing it before use. This restores Calendar View rendering and prevents the runtime error.

---

> **Screenshots/GIFs**

**Before**
<img width="1412" height="292" alt="image" src="https://github.com/user-attachments/assets/1eac296b-cc54-45bb-9fd3-8f6dd5b33eda" />


**After**
<img width="1056" height="350" alt="image" src="https://github.com/user-attachments/assets/d8a5641d-0e50-49c6-9a9c-fe97f0ecb185" />

---
fixes #36794 


