### PR TITLE
fix: Resolve JSON serialization error for Path objects

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -9,12 +9,15 @@ import os
 import sys
 import uuid
 from typing import TYPE_CHECKING
-from urllib.parse import quote
+from urllib.parse import quote 
+import pathlib
 
 import werkzeug.utils
 from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.local import LocalProxy
 from werkzeug.wrappers import Response
+
+
 
 import frappe
 import frappe.model.document
@@ -59,9 +62,10 @@ def report_error(status_code):
 def is_traceback_allowed():
 	return (
 		frappe.db
+
 		and frappe.get_system_settings("allow_error_traceback")
 		and (not frappe.local.flags.disable_traceback or frappe._dev_server)
-	)
+	)																																																																																															
 
 
 def _link_error_with_message_log(error_log, exception, message_logs):
@@ -206,7 +210,9 @@ def _make_logs_v2():
 def json_handler(obj):
 	"""serialize non-serializable data for json"""
 	from collections.abc import Iterable
+	from pathlib import Path
 	from re import Match
+
 
 	if isinstance(obj, datetime.date | datetime.datetime | datetime.time):
 		return str(obj)
@@ -236,6 +242,12 @@ def json_handler(obj):
 
 	elif isinstance(obj, uuid.UUID):
 		return str(obj)
+	
+	elif isinstance(obj, Path):
+		path = Path(obj)
+		data = {'path': str(path)}
+		return data
+	
 
 	else:
 		raise TypeError(f"""Object of type {type(obj)} with value of {obj!r} is not JSON serializable""")

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -8,16 +8,14 @@ import mimetypes
 import os
 import sys
 import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import quote 
-import pathlib
+from urllib.parse import quote
 
 import werkzeug.utils
 from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.local import LocalProxy
 from werkzeug.wrappers import Response
-
-
 
 import frappe
 import frappe.model.document
@@ -62,10 +60,9 @@ def report_error(status_code):
 def is_traceback_allowed():
 	return (
 		frappe.db
-
 		and frappe.get_system_settings("allow_error_traceback")
 		and (not frappe.local.flags.disable_traceback or frappe._dev_server)
-	)																																																																																															
+	)
 
 
 def _link_error_with_message_log(error_log, exception, message_logs):
@@ -210,9 +207,7 @@ def _make_logs_v2():
 def json_handler(obj):
 	"""serialize non-serializable data for json"""
 	from collections.abc import Iterable
-	from pathlib import Path
 	from re import Match
-
 
 	if isinstance(obj, datetime.date | datetime.datetime | datetime.time):
 		return str(obj)
@@ -242,12 +237,9 @@ def json_handler(obj):
 
 	elif isinstance(obj, uuid.UUID):
 		return str(obj)
-	
+
 	elif isinstance(obj, Path):
-		path = Path(obj)
-		data = {'path': str(path)}
-		return data
-	
+		return str(obj)
 
 	else:
 		raise TypeError(f"""Object of type {type(obj)} with value of {obj!r} is not JSON serializable""")


### PR DESCRIPTION
### Problem

Apps that include a `pathlib.Path` object in API responses fail during JSON serialization because `json_handler()` does not currently handle `Path` objects.  
This issue was encountered in **Frappe Drive**, where file system paths are returned as `Pathlib.Path` instances, causing response serialization errors.

---

### Solution

Updated `json_handler()` to properly serialize `pathlib.Path` objects by converting them into a JSON-compatible format.  
With this change, apps (including **Frappe Drive**) can safely return `Pathlib.Path` objects in responses without raising serialization errors.

---

### Impact

- Fixes JSON serialization errors when `Pathlib.Path` objects are included in responses  
- Improves compatibility for filesystem-related apps such as **Frappe Drive**  
- Backward compatible with existing response handling

---

### Note

- This fix is intended for v15 only. 
- Since v16 introduces significant internal changes, the PR is based on version-15-hotfix as recommended.

---

### Related Apps / Use Case

- Frappe Drive