### PR TITLE
fix: hide Submit button on non-submittable doctypes

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -670,6 +670,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 	}
 	can_submit() {
 		return (
+			frappe.model.is_submittable(this.frm.doc.doctype) &&
 			this.get_docstatus() === 0 &&
 			!this.frm.doc.__islocal &&
 			!this.frm.doc.__unsaved &&


### PR DESCRIPTION
`can_submit()` in `toolbar.js` checked `docstatus`, permissions, and workflow state but never verified the doctype is actually submittable. Since all documents start at `docstatus 0`, any non-submittable doctype showed a Submit button when the user had submit permission (e.g. System Manager).

Added a `frappe.model.is_submittable()` check, consistent with how `add_discard()` and `show_submit_message()` already guard against this in the same codebase.
