### PR TITLE
fix(workspace): show role-restricted non-public workspaces in sidebar

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -467,6 +467,8 @@ def get_workspace_sidebar_items():
 					pages.append(page)
 				elif page.for_user == frappe.session.user:
 					private_pages.append(page)
+				elif not page.public and not page.for_user:
+					pages.append(page)
 				page["label"] = _(page.get("name"))
 
 			if not page["app"] and page["module"]:

--- a/frappe/desk/doctype/workspace/test_workspace.py
+++ b/frappe/desk/doctype/workspace/test_workspace.py
@@ -46,7 +46,7 @@ class TestWorkspace(IntegrationTestCase):
 			workspace_titles = [p.title for p in result["pages"]]
 			self.assertIn("Role Test Workspace", workspace_titles)
 		finally:
-			frappe.delete_doc("Workspace", workspace.name, force=True)
+			frappe.db.delete("Workspace", {"name": workspace.name})
 
 
 def create_module(module_name):

--- a/frappe/desk/doctype/workspace/test_workspace.py
+++ b/frappe/desk/doctype/workspace/test_workspace.py
@@ -32,9 +32,12 @@ class TestWorkspace(IntegrationTestCase):
 		"""Non-public workspace with roles should be visible to users with matching role."""
 		from frappe.desk.desktop import get_workspace_sidebar_items
 
-		workspace = create_workspace(name="Role Test Workspace", label="Role Test Workspace")
+		workspace = frappe.new_doc("Workspace")
+		workspace.label = "Role Test Workspace"
 		workspace.title = "Role Test Workspace"
+		workspace.category = "Modules"
 		workspace.public = 0
+		workspace.module = "Desk"
 		workspace.append("roles", {"role": "System Manager"})
 		workspace.insert(ignore_if_duplicate=True)
 

--- a/frappe/desk/doctype/workspace/test_workspace.py
+++ b/frappe/desk/doctype/workspace/test_workspace.py
@@ -28,6 +28,23 @@ class TestWorkspace(IntegrationTestCase):
 	# 	else:
 	# 		self.assertEqual(len(cards), 1)
 
+	def test_role_restricted_non_public_workspace_visible_to_permitted_user(self):
+		"""Non-public workspace with roles should be visible to users with matching role."""
+		from frappe.desk.desktop import get_workspace_sidebar_items
+
+		workspace = create_workspace(name="Role Test Workspace", label="Role Test Workspace")
+		workspace.title = "Role Test Workspace"
+		workspace.public = 0
+		workspace.append("roles", {"role": "System Manager"})
+		workspace.insert(ignore_if_duplicate=True)
+
+		try:
+			result = get_workspace_sidebar_items()
+			workspace_titles = [p.title for p in result["pages"]]
+			self.assertIn("Role Test Workspace", workspace_titles)
+		finally:
+			frappe.delete_doc("Workspace", workspace.name, force=True)
+
 
 def create_module(module_name):
 	module = frappe.get_doc({"doctype": "Module Def", "module_name": module_name, "app_name": "frappe"})


### PR DESCRIPTION
Non-public workspaces with assigned roles were not visible to users with matching roles because the visibility logic only had two buckets: public workspaces and private (for_user) workspaces. Role-restricted non-public workspaces without a for_user value fell through both conditions and were never shown.

Fixes #36201