### PR TITLE
fix: check hidden before adding help dropdown item

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -176,6 +176,7 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 		help_dropdown_items = custom_help_links.concat(help_dropdown_items);
 
 		navbar_settings.help_dropdown.forEach((element) => {
+			if (element.hidden) return;
 			let dropdown_children = {
 				name: element.name,
 				label: element.item_label,


### PR DESCRIPTION
Hidden field value is not checked before adding a new dropdown item in the help settings. Works correctly in User Settings.

Closes https://github.com/frappe/frappe/issues/36836
