### PR TITLE
fix(ui): render checkbox label in pick columns correctly

### DIFF
--- a/frappe/public/scss/desk/role_editor.scss
+++ b/frappe/public/scss/desk/role_editor.scss
@@ -43,6 +43,7 @@ table.user-perm {
 			text-decoration: underline;
 		}
 	}
+	break-inside: avoid;
 }
 
 .module-block-list .checkbox {


### PR DESCRIPTION
Checkboxes with multiline labels in pick columns modal in report view of DocTypes wasn't being rendered correctly in Mozilla Firefox:

<img width="1470" height="838" alt="image" src="https://github.com/user-attachments/assets/92267e1c-4d85-4058-8bff-8eba9b4e342b" />

Firefox tends to treat multiline labels in a column layout as multiple separate columns depending on the content. This PR avoid that:

<img width="1470" height="838" alt="image" src="https://github.com/user-attachments/assets/83f44080-828e-4598-906f-2c4c630b05d6" />
 