### PR TITLE
feat: show description on click

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -82,7 +82,8 @@
   "documentation_url",
   "placeholder",
   "oldfieldname",
-  "oldfieldtype"
+  "oldfieldtype",
+  "show_description_on_click"
  ],
  "fields": [
   {
@@ -633,6 +634,12 @@
    "fieldtype": "Select",
    "label": "Button Color",
    "options": "\nDefault\nPrimary\nInfo\nSuccess\nWarning\nDanger"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_description_on_click",
+   "fieldtype": "Check",
+   "label": "Show Description on Click"
   }
  ],
  "grid_page_length": 50,
@@ -640,7 +647,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-06 01:37:29.723265",
+ "modified": "2026-02-06 15:13:03.688027",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/core/doctype/docfield/docfield.py
+++ b/frappe/core/doctype/docfield/docfield.py
@@ -14,10 +14,10 @@ class DocField(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		alignment: DF.Literal["", "Left", "Center", "Right"]
 		allow_bulk_edit: DF.Check
 		allow_in_quick_entry: DF.Check
 		allow_on_submit: DF.Check
-		alignment: DF.Literal["", "Left", "Center", "Right"]
 		bold: DF.Check
 		button_color: DF.Literal["", "Default", "Primary", "Info", "Success", "Warning", "Danger"]
 		collapsible: DF.Check
@@ -117,6 +117,7 @@ class DocField(Document):
 		search_index: DF.Check
 		set_only_once: DF.Check
 		show_dashboard: DF.Check
+		show_description_on_click: DF.Check
 		show_on_timeline: DF.Check
 		sort_options: DF.Check
 		sticky: DF.Check

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -230,16 +230,24 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 				.on("click", (event) => {
 					event.preventDefault();
 					me.$info_card.html("");
-					let card = new frappe.ui.SidebarCard({
-						// title: "Trial ends in 3 days",
-						// icon: "info",
+					let card_args = {
 						message: me.df.description,
 						parent: me.$info_card,
-						// primary_action_icon: "zap",
-						// primary_action_label: "Upgrade",
 						close_button: true,
-						// primary_action: () => {},
-					});
+					};
+					if (me.df.documentation_url) {
+						card_args.primary_action_label = "Read More";
+						card_args.primary_action_suffix_icon = "square-arrow-out-up-right";
+						card_args.primary_action = function () {
+							window.open(me.df.documentation_url);
+						};
+						$(":root").css({
+							"--sidebar-card-button-bg-color": "var(--surface-gray-2)",
+							"--sidebar-card-button-color": "var(--ink-gray-7)",
+							"--sidebar-card-button-outline": "var(--ink-gray-7)",
+						});
+					}
+					let card = new frappe.ui.SidebarCard(card_args);
 					if (me.info_card_display) {
 						me.info_card_display = false;
 						me.$info_card.removeAttr("data-show");

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -1,3 +1,4 @@
+import { createPopper } from "@popperjs/core";
 frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control {
 	static horizontal = true;
 	make() {
@@ -7,7 +8,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 
 		// set description
 		this.set_max_width();
-
+		this.info_card_display = false;
 		// set initial value if set
 		if (this.df.initial_value) {
 			this.set_value(this.df.initial_value);
@@ -147,6 +148,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 			me.set_description();
 			me.set_label();
 			me.set_doc_url();
+			// me.set_info_url();
 			me.set_mandatory(me.value);
 			me.set_bold();
 			me.set_required();
@@ -189,6 +191,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		}
 	}
 	set_label(label) {
+		const me = this;
 		if (label) this.df.label = label;
 
 		if (this.only_input || this.df.label == this._label) return;
@@ -197,14 +200,64 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		this.label_span.innerHTML =
 			(icon ? '<i class="' + icon + '"></i> ' : "") +
 				__(this.df.label, null, this.df.parent) || "&nbsp;";
+		if (this.df.show_description_on_click) {
+			$(`<a>${frappe.utils.icon("message-circle-question-mark", "sm")}</a>`).appendTo(
+				$(this.label_span)
+			);
+			this.$info_card = $("<div class='info-card'></div>").appendTo(this.label_span);
+			$(this.label_area).css({
+				display: "flex",
+				gap: "6px",
+				"align-items": "center",
+				"white-space": "nowrap",
+			});
+			let popper = createPopper(
+				$(this.label_span).find("a").get(0),
+				this.$info_card.get(0),
+				{
+					modifiers: [
+						{
+							name: "offset",
+							options: {
+								offset: [0, 8],
+							},
+						},
+					],
+				}
+			);
+			$(this.label_span)
+				.find("a")
+				.on("click", (event) => {
+					event.preventDefault();
+					me.$info_card.html("");
+					let card = new frappe.ui.SidebarCard({
+						// title: "Trial ends in 3 days",
+						// icon: "info",
+						message: me.df.description,
+						parent: me.$info_card,
+						// primary_action_icon: "zap",
+						// primary_action_label: "Upgrade",
+						close_button: true,
+						// primary_action: () => {},
+					});
+					if (me.info_card_display) {
+						me.info_card_display = false;
+						me.$info_card.removeAttr("data-show");
+					} else {
+						me.info_card_display = true;
+						me.$info_card.attr("data-show", "");
+						popper.update();
+					}
+				});
+		}
 		this._label = this.df.label;
 	}
 
 	set_doc_url() {
+		if (this.df.show_description_on_click) return;
 		let unsupported_fieldtypes = frappe.model.no_value_type.filter(
 			(x) => frappe.model.table_fields.indexOf(x) === -1
 		);
-
 		if (
 			!this.df.label ||
 			!this.df?.documentation_url ||
@@ -214,6 +267,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 
 		let $help = this.$wrapper.find("span.help");
 		$help.empty();
+
 		$(`<a
 			href="${frappe.utils.escape_html(this.df.documentation_url)}"
 			target="_blank"
@@ -224,6 +278,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 	}
 
 	set_description(description) {
+		if (this.df.show_description_on_click) return;
 		if (description !== undefined) {
 			this.df.description = description;
 		}

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -201,9 +201,16 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 			(icon ? '<i class="' + icon + '"></i> ' : "") +
 				__(this.df.label, null, this.df.parent) || "&nbsp;";
 		if (this.df.show_description_on_click) {
-			$(`<a>${frappe.utils.icon("message-circle-question-mark", "sm")}</a>`).appendTo(
-				$(this.label_span)
-			);
+			$(
+				`${frappe.utils.icon(
+					"message-circle-question-mark",
+					"sm",
+					"",
+					"",
+					"cursor-pointer"
+				)}`
+			).appendTo($(this.label_span));
+			$(this.label_span).find("svg").attr("role", "button");
 			this.$info_card = $("<div class='info-card'></div>").appendTo(this.label_span);
 			$(this.label_area).css({
 				display: "flex",
@@ -212,7 +219,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 				"white-space": "nowrap",
 			});
 			let popper = createPopper(
-				$(this.label_span).find("a").get(0),
+				$(this.label_span).find("svg").get(0),
 				this.$info_card.get(0),
 				{
 					modifiers: [
@@ -226,7 +233,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 				}
 			);
 			$(this.label_span)
-				.find("a")
+				.find("svg")
 				.on("click", (event) => {
 					event.preventDefault();
 					me.$info_card.html("");
@@ -241,11 +248,11 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 						card_args.primary_action = function () {
 							window.open(me.df.documentation_url);
 						};
-						$(":root").css({
-							"--sidebar-card-button-bg-color": "var(--surface-gray-2)",
-							"--sidebar-card-button-color": "var(--ink-gray-7)",
-							"--sidebar-card-button-outline": "var(--ink-gray-7)",
-						});
+						card_args.styles = {
+							"sidebar-card-button-bg-color": "var(--surface-gray-2)",
+							"sidebar-card-button-color": "var(--ink-gray-7)",
+							"sidebar-card-button-outline": "var(--ink-gray-7)",
+						};
 					}
 					let card = new frappe.ui.SidebarCard(card_args);
 					if (me.info_card_display) {
@@ -257,10 +264,9 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 						popper.update();
 					}
 				});
+			this._label = this.df.label;
 		}
-		this._label = this.df.label;
 	}
-
 	set_doc_url() {
 		if (this.df.show_description_on_click) return;
 		let unsupported_fieldtypes = frappe.model.no_value_type.filter(

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -147,7 +147,6 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 			me.set_description();
 			me.set_label();
 			me.set_doc_url();
-			// me.set_info_url();
 			me.set_mandatory(me.value);
 			me.set_bold();
 			me.set_required();

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -1,4 +1,4 @@
-import { createPopper } from "@popperjs/core";
+import { InfoCard } from "../info_card";
 frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control {
 	static horizontal = true;
 	make() {
@@ -8,7 +8,6 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 
 		// set description
 		this.set_max_width();
-		this.info_card_display = false;
 		// set initial value if set
 		if (this.df.initial_value) {
 			this.set_value(this.df.initial_value);
@@ -200,71 +199,17 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		this.label_span.innerHTML =
 			(icon ? '<i class="' + icon + '"></i> ' : "") +
 				__(this.df.label, null, this.df.parent) || "&nbsp;";
+		this.show_description_on_click();
+		this._label = this.df.label;
+	}
+	show_description_on_click() {
+		const me = this;
 		if (this.df.show_description_on_click) {
-			$(
-				`${frappe.utils.icon(
-					"message-circle-question-mark",
-					"sm",
-					"",
-					"",
-					"cursor-pointer"
-				)}`
-			).appendTo($(this.label_span));
-			$(this.label_span).find("svg").attr("role", "button");
-			this.$info_card = $("<div class='info-card'></div>").appendTo(this.label_span);
-			$(this.label_area).css({
-				display: "flex",
-				gap: "6px",
-				"align-items": "center",
-				"white-space": "nowrap",
+			let info_card = new InfoCard({
+				label_area: this.label_area,
+				label_span: this.label_span,
+				df: this.df,
 			});
-			let popper = createPopper(
-				$(this.label_span).find("svg").get(0),
-				this.$info_card.get(0),
-				{
-					modifiers: [
-						{
-							name: "offset",
-							options: {
-								offset: [0, 8],
-							},
-						},
-					],
-				}
-			);
-			$(this.label_span)
-				.find("svg")
-				.on("click", (event) => {
-					event.preventDefault();
-					me.$info_card.html("");
-					let card_args = {
-						message: me.df.description,
-						parent: me.$info_card,
-						close_button: true,
-					};
-					if (me.df.documentation_url) {
-						card_args.primary_action_label = "Read More";
-						card_args.primary_action_suffix_icon = "square-arrow-out-up-right";
-						card_args.primary_action = function () {
-							window.open(me.df.documentation_url);
-						};
-						card_args.styles = {
-							"sidebar-card-button-bg-color": "var(--surface-gray-2)",
-							"sidebar-card-button-color": "var(--ink-gray-7)",
-							"sidebar-card-button-outline": "var(--ink-gray-7)",
-						};
-					}
-					let card = new frappe.ui.SidebarCard(card_args);
-					if (me.info_card_display) {
-						me.info_card_display = false;
-						me.$info_card.removeAttr("data-show");
-					} else {
-						me.info_card_display = true;
-						me.$info_card.attr("data-show", "");
-						popper.update();
-					}
-				});
-			this._label = this.df.label;
 		}
 	}
 	set_doc_url() {

--- a/frappe/public/js/frappe/form/info_card.js
+++ b/frappe/public/js/frappe/form/info_card.js
@@ -10,7 +10,13 @@ export class InfoCard {
 	}
 	make_toggle_button() {
 		$(
-			`${frappe.utils.icon("message-circle-question-mark", "sm", "", "", "cursor-pointer")}`
+			`${frappe.utils.icon(
+				"message-circle-question-mark",
+				"sm",
+				"",
+				"",
+				"cursor-pointer m-0"
+			)}`
 		).appendTo($(this.label_span));
 		$(this.label_span).find("svg").attr("role", "button");
 		$(this.label_area).css({

--- a/frappe/public/js/frappe/form/info_card.js
+++ b/frappe/public/js/frappe/form/info_card.js
@@ -1,0 +1,56 @@
+export class InfoCard {
+	constructor(opts) {
+		Object.assign(this, opts);
+		this.make();
+		this.setup_click();
+	}
+	make() {
+		this.make_toggle_button();
+		this.make_card();
+	}
+	make_toggle_button() {
+		$(
+			`${frappe.utils.icon("message-circle-question-mark", "sm", "", "", "cursor-pointer")}`
+		).appendTo($(this.label_span));
+		$(this.label_span).find("svg").attr("role", "button");
+		$(this.label_area).css({
+			display: "flex",
+			gap: "6px",
+			"align-items": "center",
+			"white-space": "nowrap",
+		});
+	}
+	make_card() {
+		const me = this;
+		this.$info_card = $("<div class='info-card'></div>").appendTo(this.label_span);
+		let card_args = {
+			message: this.df.description,
+			parent: this.$info_card,
+			trigger: $(this.label_span).find("svg").get(0),
+			close_button: true,
+			popper: true,
+		};
+		if (this.df.documentation_url) {
+			card_args.primary_action_label = "Read More";
+			card_args.primary_action_suffix_icon = "square-arrow-out-up-right";
+			card_args.primary_action = function () {
+				window.open(me.df.documentation_url);
+			};
+			card_args.styles = {
+				"sidebar-card-button-bg-color": "var(--surface-gray-2)",
+				"sidebar-card-button-color": "var(--ink-gray-7)",
+				"sidebar-card-button-outline": "var(--ink-gray-7)",
+			};
+		}
+		this.card = new frappe.ui.SidebarCard(card_args);
+	}
+	setup_click() {
+		const me = this;
+		$(this.label_span)
+			.find("svg")
+			.on("click", (event) => {
+				event.preventDefault();
+				me.card.toggle();
+			});
+	}
+}

--- a/frappe/public/js/frappe/form/info_card.js
+++ b/frappe/public/js/frappe/form/info_card.js
@@ -52,5 +52,10 @@ export class InfoCard {
 				event.preventDefault();
 				me.card.toggle();
 			});
+		$(document).on("click", function (e) {
+			if (!e.originalEvent.composedPath().includes(me.label_area)) {
+				me.card.hide();
+			}
+		});
 	}
 }

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
@@ -18,6 +18,14 @@
          </div>
     {% } %}
     {% if(card.primary_action_label) { %}
-    <button class="sidebar-card-button btn">{{ frappe.utils.icon(card.primary_action_icon, "sm", "", "", "", true) }}{{ card.primary_action_label }}</button>
+    <button class="sidebar-card-button btn">
+        {% if (card.primary_action_icon) %}
+            {{ frappe.utils.icon(card.primary_action_icon, "sm", "", "", "", true) }}
+        {% } %}
+        {{ card.primary_action_label }}
+        {% if card.primary_action_suffix_icon %}
+            {{ frappe.utils.icon(card.primary_action_suffix_icon, "sm", "", "", "", true) }}
+        {% endif %}
+    </button>
     {% } %}
 </div>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
@@ -1,4 +1,5 @@
 <div class="sidebar-card d-inline-flex flex-column px-2 py-2">
+    {% if(!card.close_button) { %}
     <div>
         <div class="card-title-container">
             {%= frappe.utils.icon(card.icon, "sm", "", "", "card-icon") %}
@@ -6,5 +7,17 @@
         </div>
         <div class="sidebar-card-description">{{ card.message }}</div>
     </div>
+    {% } else { %}
+        <div class="card-title-container card-close-button">
+            {%= frappe.utils.icon(card.icon, "sm", "", "", "card-icon") %}
+            <span class="flex flex-column">
+                <div class="sidebar-card-title">{{ card.title }}</div>
+                <div class="sidebar-card-description">{{ card.message }}</div>
+            </span>
+            {%= frappe.utils.icon("x","sm", "", "", "card-icon") %}
+         </div>
+    {% } %}
+    {% if(card.primary_action_label) { %}
     <button class="sidebar-card-button btn">{{ frappe.utils.icon(card.primary_action_icon, "sm", "", "", "", true) }}{{ card.primary_action_label }}</button>
+    {% } %}
 </div>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
@@ -14,7 +14,7 @@
                 <div class="sidebar-card-title">{{ card.title }}</div>
                 <div class="sidebar-card-description">{{ card.message }}</div>
             </span>
-            {%= frappe.utils.icon("x","sm", "", "", "card-icon") %}
+        {%= frappe.utils.icon("x","sm", "", "", "card-icon cursor-pointer") %}
          </div>
     {% } %}
     {% if(card.primary_action_label) { %}

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
@@ -38,13 +38,19 @@ frappe.ui.SidebarCard = class SidebarCard {
 	}
 	toggle() {
 		if (this.display) {
-			this.display = false;
-			this.parent.removeAttr("data-show");
+			this.hide();
 		} else {
-			this.display = true;
-			this.parent.attr("data-show", "");
-			this.popper.update();
+			this.show();
 		}
+	}
+	hide() {
+		this.display = false;
+		this.parent.removeAttr("data-show");
+	}
+	show() {
+		this.display = true;
+		this.parent.attr("data-show", "");
+		this.popper.update();
 	}
 	setup_primary_action() {
 		const me = this;

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
@@ -60,9 +60,11 @@ frappe.ui.SidebarCard = class SidebarCard {
 		});
 	}
 	set_styles() {
-		const $root = $(":root");
-		for (const [variable, value] of Object.entries(this.styles)) {
-			$root.css(`--${variable}`, value);
+		if (this.styles) {
+			const $root = $(":root");
+			for (const [variable, value] of Object.entries(this.styles)) {
+				$root.css(`--${variable}`, value);
+			}
 		}
 	}
 };

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
@@ -1,3 +1,4 @@
+import { createPopper } from "@popperjs/core";
 frappe.provide("frappe.ui");
 
 // icon, title, message, condition, primary_action_label, primary_action
@@ -6,6 +7,7 @@ frappe.ui.SidebarCard = class SidebarCard {
 		Object.assign(this, opts);
 		this.make(opts);
 		this.setup();
+		this.display = false;
 		this.set_styles();
 	}
 	make() {
@@ -17,11 +19,32 @@ frappe.ui.SidebarCard = class SidebarCard {
 				card: this,
 			})
 		);
-
+		if (this.popper) {
+			this.popper = createPopper($(this.trigger).get(0), $(this.parent).get(0), {
+				modifiers: [
+					{
+						name: "offset",
+						options: {
+							offset: [0, 8],
+						},
+					},
+				],
+			});
+		}
 		this.card.prependTo(this.parent);
 	}
 	setup() {
 		this.setup_primary_action();
+	}
+	toggle() {
+		if (this.display) {
+			this.display = false;
+			this.parent.removeAttr("data-show");
+		} else {
+			this.display = true;
+			this.parent.attr("data-show", "");
+			this.popper.update();
+		}
 	}
 	setup_primary_action() {
 		const me = this;

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
@@ -6,6 +6,7 @@ frappe.ui.SidebarCard = class SidebarCard {
 		Object.assign(this, opts);
 		this.make(opts);
 		this.setup();
+		this.set_styles();
 	}
 	make() {
 		if (!this.icon) {
@@ -28,5 +29,11 @@ frappe.ui.SidebarCard = class SidebarCard {
 			event.preventDefault();
 			me.primary_action(event);
 		});
+	}
+	set_styles() {
+		const $root = $(":root");
+		for (const [variable, value] of Object.entries(this.styles)) {
+			$root.css(`--${variable}`, value);
+		}
 	}
 };

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
@@ -8,6 +8,9 @@ frappe.ui.SidebarCard = class SidebarCard {
 		this.setup();
 	}
 	make() {
+		if (!this.icon) {
+			this.icon = "info";
+		}
 		this.card = $(
 			frappe.render_template("sidebar_card", {
 				card: this,

--- a/frappe/public/scss/common/global.scss
+++ b/frappe/public/scss/common/global.scss
@@ -174,3 +174,15 @@ body {
 .margin-right {
 	margin-right: var(--margin-sm);
 }
+.info-card {
+	display: none;
+}
+
+.info-card[data-show] {
+	display: block;
+	z-index: 1;
+	.sidebar-card {
+		box-shadow: 0px 18px 22px -6px rgba(0, 0, 0, 0.1), 0px 0px 6px 3px rgba(0, 0, 0, 0.03),
+			0px 0px 1.5px 0px rgba(0, 0, 0, 0.18);
+	}
+}

--- a/frappe/public/scss/desk/sidebar_card.scss
+++ b/frappe/public/scss/desk/sidebar_card.scss
@@ -1,3 +1,8 @@
+:root {
+	--sidebar-card-button-outline: var(--surface-blue-3);
+	--sidebar-card-button-bg-color: var(var(--surface-blue-2));
+	--sidebar-card-button-color: var(--ink-blue-3);
+}
 .card-title-container {
 	display: flex;
 	align-items: center;
@@ -33,16 +38,16 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background-color: var(--surface-blue-2);
-	color: var(--ink-blue-3);
+	background-color: var(--sidebar-card-button-bg-color);
+	color: var(--sidebar-card-button-color);
 	gap: 4px;
 	svg {
-		stroke: var(--ink-blue-3);
+		stroke: var(--sidebar-card-button-color);
 		margin: 0px;
 	}
 }
 .sidebar-card-button:hover,
 .sidebar-card-button:focus {
-	outline: 1px solid var(--surface-blue-3);
-	color: var(--ink-blue-3);
+	outline: 1px solid var(--sidebar-card-button-outline);
+	color: var(--sidebar-card-button-color);
 }

--- a/frappe/public/scss/desk/sidebar_card.scss
+++ b/frappe/public/scss/desk/sidebar_card.scss
@@ -10,6 +10,14 @@
 		@include get_textstyle("base", "medium");
 	}
 }
+.card-close-button {
+	align-items: normal;
+	.card-icon {
+		flex-shrink: 0;
+		margin-top: 2px;
+		margin-bottom: 2px;
+	}
+}
 .sidebar-card {
 	width: 100%;
 	background-color: var(--surface-modal);
@@ -19,6 +27,7 @@
 }
 .sidebar-card-description {
 	@include get_textstyle("sm", "regular");
+	white-space: wrap;
 }
 .sidebar-card-button {
 	display: flex;

--- a/frappe/public/scss/desk/sidebar_card.scss
+++ b/frappe/public/scss/desk/sidebar_card.scss
@@ -51,3 +51,6 @@
 	outline: 1px solid var(--sidebar-card-button-outline);
 	color: var(--sidebar-card-button-color);
 }
+.cursor-pointer {
+	cursor: pointer;
+}


### PR DESCRIPTION
A lot of fields in ERPNext need some more context as to what they would do if the information is entered.
Reading docs is an helpful way but it needs the user to go outside the system and lose focus.
Descriptions are an awesome solve for this issue. But for pro users the forms become messier. 

This PR fixes that by creating a info card which reveals the card with the description

Video with 2 examples


https://github.com/user-attachments/assets/7a01610a-db05-4dd0-ac9c-f41541e4dd5f



`no-docs`
