### PR TITLE
fix: close button hides notification dropdown

### DIFF
--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -53,9 +53,7 @@ frappe.ui.Notifications = class Notifications {
 			${frappe.utils.icon("x")}
 		</span>`)
 			.on("click", (e) => {
-				if (!this.full_height) {
-					this.dropdown.addClass("hidden");
-				}
+				this.dropdown.addClass("hidden");
 			})
 			.appendTo(this.header_actions)
 			.attr("title", __("Close"))


### PR DESCRIPTION
The notification close (X) button did not hide the dropdown consistently.
This change ensures the dropdown always closes when clicking the close button.
Fixes #36707
