### PR TITLE
fix: skip db changes while renaming virtual doctype

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -680,7 +680,7 @@ class DocType(Document):
 				where doctype=%s and field='name' and value = %s""",
 				(new, new, old),
 			)
-		else:
+		elif not self.is_virtual:
 			frappe.db.rename_table(old, new)
 			frappe.db.commit()
 

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -649,6 +649,9 @@ def update_parenttype_values(old: str, new: str):
 	child_doctypes = set(list(d["options"] for d in child_doctypes) + property_setter_child_doctypes)
 
 	for doctype in child_doctypes:
+		if frappe.get_meta(doctype).is_virtual:
+			continue
+
 		table = frappe.qb.DocType(doctype)
 		frappe.qb.update(table).set(table.parenttype, new).where(table.parenttype == old).run()
 


### PR DESCRIPTION
While renaming a virtual DocType (the doctype definition, not a record), framework tries to update the record's DB table name and the child table row's `parenttype` via a db query. This fails because these tables don't exist.

This PR fixes that by skipping these db changes for virtual DocTypes and virtual child tables.

Resolves #27286