### PR TITLE
fix: bump dropbox to 12.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
 
     # integration dependencies
     "boto3~=1.34.143",
-    "dropbox~=11.36.2",
+    "dropbox~=12.0.2",
     "google-api-python-client~=2.188.0",
     "google-auth-oauthlib~=1.2.4",
     "google-auth~=2.48.0",


### PR DESCRIPTION
The newer dropbox no longer depends on `pkg_resources`, eliminating the following error:

```
Installing frappe...
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/utils.py", line 282, in load_doctype_module
    doctype_python_modules[key] = frappe.get_module(module_name)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 1454, in get_module
    return importlib.import_module(modulename)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/runner/frappe-bench/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 7, in <module>
    import dropbox
  File "/home/runner/frappe-bench/env/lib/python3.11/site-packages/dropbox/__init__.py", line 3, in <module>
    from dropbox.dropbox_client import (  # noqa: F401 # pylint: disable=unused-import
  File "/home/runner/frappe-bench/env/lib/python3.11/site-packages/dropbox/dropbox_client.py", line 43, in <module>
    from dropbox.session import (
  File "/home/runner/frappe-bench/env/lib/python3.11/site-packages/dropbox/session.py", line 1, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

I've checked the release notes, the changes seem non-breaking for us. The breaking change was the one removing the dependency on `pkg_resources`:

> The SDK no longer provides its own CA bundle to verify TLS connections. It will continue to verify connections through the `requests` library, which makes use of [`certifi`](https://github.com/certifi/python-certifi).