### PR TITLE
fix(mobile): align timeline dot again

### DIFF
--- a/frappe/public/scss/desk/timeline.scss
+++ b/frappe/public/scss/desk/timeline.scss
@@ -22,11 +22,6 @@ $threshold: 34;
 	position: relative;
 	padding-top: var(--padding-lg);
 
-	@include media-breakpoint-down(xs) {
-		.timeline-dot {
-			margin-left: -2px;
-		}
-	}
 	&:before {
 		content: " ";
 		top: 90px; // TODO: get top and bottom programmatically


### PR DESCRIPTION
Before
<img width="344" height="251" alt="Screenshot 2026-02-09 at 2 09 46 AM" src="https://github.com/user-attachments/assets/89dbbbd7-ee05-422a-b652-df8b4063bf1d" />

After
<img width="361" height="259" alt="Screenshot 2026-02-09 at 2 10 29 AM" src="https://github.com/user-attachments/assets/ada2fd95-2579-49de-8527-fa7997f4db1a" />

