### PR TITLE
fix: change delete message to something more specific

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -641,7 +641,9 @@ def delete_bulk(doctype, items):
 		)
 	else:
 		frappe.msgprint(
-			_("Deleted all documents successfully"), realtime=True, title=_("Bulk Operation Successful")
+			_(f"Deleted {len(items)} records from {doctype} doctype"),
+			realtime=True,
+			title=_("Bulk Operation Successful"),
 		)
 
 


### PR DESCRIPTION
Bulk deletion message is scary message where it says deleted all the documents, any new user might be scared to know that all documents are deleted. This PR changes it to a better message

<img width="628" height="190" alt="Screenshot 2026-02-09 at 10 28 07 AM" src="https://github.com/user-attachments/assets/9e31dfed-2b22-48c0-be0a-059c490215e0" />
 