### PR TITLE
feat: skip sending mail when in developer mode for impersonation

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1463,16 +1463,17 @@ def impersonate(user: str, reason: str):
 	notification.set("type", "Alert")
 	notification.insert(ignore_permissions=True)
 	# notify user via email too
-	user_email = frappe.db.get_value("User", user, "email")
-	email_message = _(
-		"User {0} has started an impersonation session as you. <br><br><b>Reason provided:</b> {1}"
-	).format(escape_html(impersonator), escape_html(reason))
+	if not frappe.conf.get("developer_mode"):  # bypass for testing locally
+		user_email = frappe.db.get_value("User", user, "email")
+		email_message = _(
+			"User {0} has started an impersonation session as you. <br><br><b>Reason provided:</b> {1}"
+		).format(escape_html(impersonator), escape_html(reason))
 
-	frappe.sendmail(
-		recipients=[user_email],
-		subject=_("Security Alert: Your account is being impersonated"),
-		content=email_message,
-	)
+		frappe.sendmail(
+			recipients=[user_email],
+			subject=_("Security Alert: Your account is being impersonated"),
+			content=email_message,
+		)
 	frappe.local.login_manager.impersonate(user)
 
 


### PR DESCRIPTION
**feat:** allow bypassing sending mail when in developer mode (for local testing purposes) for an impersonation session. 
`no-docs`