### PR TITLE
fix: list settings UI

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -195,7 +195,12 @@ export default class Grid {
 	}
 
 	setup_check() {
-		this.wrapper.on("click", ".grid-row-check", (e) => {
+		this.wrapper.on("click touchend", ".grid-row-check", (e) => {
+			if (e.type === "touchend") {
+				e.stopPropagation();
+				return;
+			}
+
 			const $check = $(e.currentTarget);
 			const checked = $check.prop("checked");
 			const is_select_all = $check.parents(".grid-heading-row:first").length !== 0;

--- a/frappe/public/js/frappe/views/kanban/kanban_settings.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_settings.js
@@ -87,19 +87,20 @@ export default class KanbanSettings {
 
 			fields += `
 				<div class="control-input flex align-center form-control fields_order sortable"
-					style="display: block; margin-bottom: 5px;"
+					style="display: block; margin-bottom: 5px; padding-top:2.5px;"
 					data-fieldname="${field.fieldname}"
 					data-label="${field.label}"
 					data-type="${field.type}">
 
 					<div class="row">
-						<div class="col-md-1">
+						<div class="col-md-1" style="display:flex; align-items:center;">
 							${frappe.utils.icon("drag", "xs", "", "", "sortable-handle")}
 						</div>
-						<div class="col-md-10" style="padding-left:0px;">
+						<div class="col-md-10" style="padding-left:0px; display:flex; align-items:center;">
 							${__(field.label, null, field.parent)}
 						</div>
-						<div class="col-md-1">
+						<div class="col-md-1"  style="display:flex; align-items:center; justify-content:center">
+
 							<a class="text-muted remove-field" data-fieldname="${field.fieldname}">
 								${frappe.utils.icon("delete", "xs")}
 							</a>

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -493,7 +493,7 @@ input.list-header-checkbox {
 
 	.filter-section {
 		display: flex;
-		padding: 0 var(--padding-xs);
+		padding: 0;
 	}
 
 	.filter-selector .btn-group {

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -228,6 +228,6 @@ body[data-route^="Form"] {
 
 .frappe-control {
 	.form-control.fields_order {
-		padding-top: 1.5px;
+		padding-top: 2.5px;
 	}
 }


### PR DESCRIPTION
### **Filter in list view alignment:**
**before:**
![filter-before](https://github.com/user-attachments/assets/6dee87c4-62d7-4b0a-95cc-daf125284277)


**after:**
![after-filter](https://github.com/user-attachments/assets/f2da97e2-68c2-499e-aacf-fbb50dc8e37f)

In this the Sorting filter button is not aligned correctly with the above and below elements.


### **List Settings fields pill vertical alignment:**
**before:**
![before-list](https://github.com/user-attachments/assets/6b841389-dfbb-48a6-94bd-5f85ef0ae4ce)


**after:**
![after-list](https://github.com/user-attachments/assets/7b29a80c-2120-4b92-9c96-1f62a15fd762)

in the list settings, the drag icon, field name and the delete button in the grey capsules are not vertically aligned.
