### PR TITLE
fix: redirect system users to role home page

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -204,7 +204,7 @@ class LoginManager:
 			frappe.local.cookie_manager.set_cookie("system_user", "yes", deduplicate=True)
 			if not resume:
 				frappe.local.response["message"] = "Logged In"
-				frappe.local.response["home_page"] = get_default_path() or "/desk"
+				frappe.local.response["home_page"] = get_home_page() or "/desk"
 
 		if not resume:
 			frappe.response["full_name"] = self.full_name


### PR DESCRIPTION
Role home page should apply to desk users where after logging in you should be guided to a certain path

User shown in the video has the role blogger and blogger has a home page of "/desk/blog"

It would be useful to simply navigate people of the same role to a specific place. 
Video

https://github.com/user-attachments/assets/c75b7f72-e71e-4079-80af-ea832b46de19

