### PR TITLE
fix: preserve column width and sticky settings in grid configure dialog

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -502,16 +502,29 @@ export default class GridRow {
 
 		d.set_primary_action(__("Add"), () => {
 			let selected_fields = d.get_values().fields;
+			const existing_settings = {};
+			this.selected_columns_for_grid.forEach((col) => {
+				existing_settings[col.fieldname] = col;
+			});
+
 			this.selected_columns_for_grid = [];
 			if (selected_fields) {
 				selected_fields.forEach((selected_column) => {
-					let docfield = frappe.meta.get_docfield(this.grid.doctype, selected_column);
-					this.grid.update_default_colsize(docfield);
+					if (existing_settings[selected_column]) {
+						this.selected_columns_for_grid.push(existing_settings[selected_column]);
+					} else {
+						let docfield = frappe.meta.get_docfield(
+							this.grid.doctype,
+							selected_column
+						);
+						this.grid.update_default_colsize(docfield);
 
-					this.selected_columns_for_grid.push({
-						fieldname: selected_column,
-						columns: docfield.columns || docfield.colsize,
-					});
+						this.selected_columns_for_grid.push({
+							fieldname: selected_column,
+							columns: docfield.columns || docfield.colsize,
+							sticky: docfield.sticky,
+						});
+					}
 				});
 
 				this.render_selected_columns();
@@ -596,14 +609,14 @@ export default class GridRow {
 							<div class='col-3' style='padding-top: 2px; margin-top:-2px;' title='${__("Columns")}'>
 								<input class='form-control column-width my-1 input-xs text-right'
 								style='height: 24px; max-width: 80px; background: var(--bg-color);'
-									value='${docfield.columns || cint(d.columns)}'
+									value='${cint(d.columns) || docfield.columns}'
 									data-fieldname='${docfield.fieldname}' style='background-color: var(--modal-bg); display: inline'>
 							</div>
 							<div class='col-2' title='${__("Sticky")}'>
 								<input type='checkbox' class='form-control sticky-column'
 									style='margin-top: 8px'
-									${docfield.sticky ? "checked" : ""}
-									data-fieldname='${docfield.fieldname}' style='background-color: var(--modal-bg); display: inline'>
+									${d.sticky ? "checked" : ""}
+									data-fieldname='${d.fieldname}' style='background-color: var(--modal-bg); display: inline'>
 							</div>
 							<div class='col-1' style='padding-top: 3px;'>
 								<a class='text-muted remove-field' data-fieldname='${docfield.fieldname}'>
@@ -642,6 +655,7 @@ export default class GridRow {
 			this.selected_columns_for_grid.push({
 				fieldname: $(columns[idx]).attr("data-fieldname"),
 				columns: cint($(columns[idx]).find(".column-width").attr("value")),
+				sticky: $(columns[idx]).find(".sticky-column").is(":checked") ? 1 : 0,
 			});
 		});
 	}


### PR DESCRIPTION
When using the "Configure Columns" dialog on a grid, changing column width or sticky and then opening "Add / Remove Columns" to add another column would reset all previously modified values (before saving) back to defaults.

This is happened because the existing implementation resets the selected_columns_for_grid on adding new columns, so previous modifications to column width and sticky check are lost.

Additionally, sort_columns which is called on drag reordering was rebuilding the array without carrying over the field's corresponding sticky property causing silent data loss on save.

Changes:
- Preserve existing column settings when adding/removing columns via the dialog
- Fix render priority to use user settings over meta defaults for column width and sticky
- Read sticky checkbox state from DOM in sort_columns so drag-reorder doesn't drop
- Inherit sticky default from meta for newly added columns

Result:

https://github.com/user-attachments/assets/424b496a-960b-40fa-ac28-3bc3857e8437

