### PR TITLE
fix(utils): restore fallback for fraction_currency in money_in_words

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -601,6 +601,7 @@
   "code": "cn",
   "currency": "CNY",
   "currency_name": "Yuan Renminbi",
+  "currency_fraction": "Fen",
   "currency_fraction_units": 100,
   "smallest_currency_fraction_value": 0.01,
   "date_format": "yyyy-mm-dd",

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -394,6 +394,26 @@ class TestMoney(IntegrationTestCase):
 		words = money_in_words("42.01", "VND")
 		self.assertEqual(words, "VND Forty Two only.")
 
+	def test_money_in_words_missing_fraction_name(self):
+		# Test currency with fraction_units but no fraction name does not crash
+		# Simulates the CNY scenario where fraction_units=100 but fraction is None
+		import frappe
+
+		# Temporarily clear fraction name to simulate the bug condition
+		original_fraction = frappe.db.get_value("Currency", "CNY", "fraction")
+		frappe.db.set_value("Currency", "CNY", "fraction", None)
+		frappe.clear_cache()
+
+		try:
+			# This should NOT raise TypeError
+			words = money_in_words(400.12, "CNY")
+			self.assertIsInstance(words, str)
+			self.assertIn("CNY", words)
+			self.assertNotIn("None", words)
+		finally:
+			frappe.db.set_value("Currency", "CNY", "fraction", original_fraction or "Fen")
+			frappe.clear_cache()
+
 
 class TestDataManipulation(IntegrationTestCase):
 	def test_scrub_urls(self):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1526,14 +1526,16 @@ def money_in_words(
 		main_currency = d.get("currency", "INR")
 
 	if not fraction_currency:
-		fraction_currency = frappe.db.get_value("Currency", main_currency, "fraction", cache=True)
+		fraction_currency = frappe.db.get_value("Currency", main_currency, "fraction", cache=True) or _(
+			"Cent"
+		)
 
 	number_format = get_number_format()
 
 	fraction_units = frappe.db.get_value("Currency", main_currency, "fraction_units", cache=True)
 	if fraction_units:
 		fraction_length = math.ceil(math.log10(fraction_units))
-	elif not fraction_units or not fraction_currency:
+	elif not fraction_units:
 		fraction_units = fraction_length = 0
 
 	n = f"%.{fraction_length}f" % number


### PR DESCRIPTION
## Problem

`money_in_words()` raises `TypeError: can only concatenate str (not "NoneType") to str` when a currency has `fraction_units` defined but no `fraction` name in the Currency doctype.

This regression was introduced in PR #33137 which removed the `or _("Cent")` fallback from the `fraction_currency` lookup. The fix in #33137 correctly handled currencies with `fraction_units=0` (e.g. VND), but inadvertently broke currencies that have `fraction_units > 0` without a `fraction` name (e.g. CNY).

**Affected currency:** CNY (Chinese Yuan) — the only default-enabled currency with this issue. CNY has `fraction_units=100` but `currency_fraction` was missing from `country_info.json`, leaving the `fraction` field as `None`.

**Traceback:**
```
File "apps/frappe/frappe/utils/data.py", line 1567, in money_in_words
    out = out + " " + _("and") + " " + fraction_in_words() + " " + fraction_currency
TypeError: can only concatenate str (not "NoneType") to str
```

## Solution

1. **Restore `or _("Cent")` fallback** on `fraction_currency` lookup in `money_in_words()` — ensures any currency with a missing fraction name gracefully falls back instead of crashing
2. **Add `"currency_fraction": "Fen"`** for China in `country_info.json` — CNY's smallest fractional unit is the Fen (1 Yuan = 100 Fen)
3. **Simplify `elif` condition** — remove redundant `not fraction_currency` check since `fraction_currency` is now guaranteed to be a string
4. **Add test** — covers the exact scenario: currency with `fraction_units=100` but no `fraction` name

## Testing

Added `test_money_in_words_missing_fraction_name` which:
- Temporarily clears the `fraction` field on CNY to simulate the bug condition
- Asserts `money_in_words(400.12, "CNY")` does not raise `TypeError`
- Asserts the output is a valid string without `"None"` in it
- Restores the original state in a `finally` block

Closes frappe/erpnext#52341