### PR TITLE
fix: add flex-shrink to prevent indicator dot from being compressed

### DIFF
--- a/frappe/public/scss/common/indicator.scss
+++ b/frappe/public/scss/common/indicator.scss
@@ -37,6 +37,7 @@
 	width: 6px;
 	border-radius: 50%;
 	margin-right: 6px;
+	flex-shrink: 0;
 }
 
 .indicator-pill.no-margin::before,


### PR DESCRIPTION
Dot rendered using before property was being shrunk when due to indicator-pill flex property

Before:
<img width="1249" height="379" alt="image" src="https://github.com/user-attachments/assets/0aa4f4ef-1135-4a21-ad20-09e44c7f5c89" />

After:
<img width="1251" height="383" alt="image" src="https://github.com/user-attachments/assets/a04038f1-9dc9-4c8b-af6d-0b50e897b928" />
