### PR TITLE
fix(link): prevent stale dropdown selection on fast input (barcode scanner)

### DIFF
--- a/cypress/integration/control_link.js
+++ b/cypress/integration/control_link.js
@@ -332,6 +332,31 @@ context("Control Link", () => {
 		});
 	});
 
+	it("should not select stale dropdown item on fast input followed by Tab", () => {
+		// Simulates barcode scanner behavior: rapid input + immediate Tab
+		// Before the fix, the Tab key would select a stale item from the initial
+		// dropdown (loaded on focus) because the debounced search hadn't fired yet.
+		get_dialog_with_link().as("dialog");
+
+		cy.intercept("/api/method/frappe.client.validate_link_and_fetch*").as("validate_link");
+
+		cy.get(".frappe-control[data-fieldname=link] input").focus().as("input");
+		// Wait for initial dropdown to appear (stale results for empty search)
+		cy.get("@input").parent().findByRole("listbox").should("be.visible");
+
+		// Type a non-existent value very fast (no delay) to simulate barcode scanner,
+		// then immediately Tab out — before the 500ms debounced search can fire.
+		cy.get("@input").type("NONEXISTENT-BARCODE-12345{tab}", { delay: 0 });
+
+		cy.wait("@validate_link");
+		// The input should be empty (invalid value cleared by validate_link),
+		// NOT set to the first item from the stale dropdown.
+		cy.get("@dialog").then((dialog) => {
+			let value = dialog.get_value("link");
+			expect(value).to.not.contain("todo");
+		});
+	});
+
 	it("show custom link option", () => {
 		cy.window()
 			.its("frappe")

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -206,7 +206,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		this.$input.cache = {};
 
 		this.awesomplete = new Awesomplete(me.input, {
-			tabSelect: true,
+			tabSelect: false,
 			minChars: 0,
 			maxItems: 99,
 			autoFirst: true,
@@ -264,6 +264,42 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 
 		this._debounced_input_handler = frappe.utils.debounce(this.on_input.bind(this), 500);
 		this.$input.on("input", this._debounced_input_handler);
+
+		// Track which search term the current dropdown results correspond to.
+		// When null, results are stale (user typed but search hasn't completed).
+		this._results_loaded_for_term = null;
+
+		// Mark results as stale immediately when user types (before debounce fires)
+		this.$input.on("input", () => {
+			this._results_loaded_for_term = null;
+		});
+
+		// Re-implement tab-select behavior with freshness check.
+		// This prevents barcode scanners from selecting stale dropdown items
+		// when the Tab key arrives before the debounced search completes.
+		this.$input.on("keydown", (e) => {
+			if (e.key !== "Tab") return;
+			if (!me.awesomplete.opened) return;
+			if (me.awesomplete.index === -1) return;
+
+			const current_input = me.get_label_value();
+
+			// If results are stale (search hasn't returned for current input),
+			// close dropdown and let the blur handler validate the typed value.
+			if (this._results_loaded_for_term !== current_input) {
+				me.awesomplete.close();
+				return;
+			}
+
+			// Results are fresh — safe to select highlighted item if it matches.
+			const item = me.awesomplete.get_item(
+				me.awesomplete.suggestions[me.awesomplete.index]?.value
+			);
+			if (item && me.input_matches_item(current_input.toLowerCase(), item)) {
+				me.selected = true;
+				me.awesomplete.select(undefined, undefined, e.originalEvent);
+			}
+		});
 
 		this.$input.on("blur", function () {
 			if (me.selected) {
@@ -433,6 +469,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		if (cache[doctype][term] != null) {
 			// immediately show from cache
 			this.awesomplete.list = cache[doctype][term];
+			this._results_loaded_for_term = term;
 		}
 
 		const filters = args.filters;
@@ -511,6 +548,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				}
 				cache[doctype][term] = r.message;
 				this.awesomplete.list = cache[doctype][term];
+				this._results_loaded_for_term = term;
 				this.toggle_href(doctype);
 				r.message.forEach((item) => {
 					frappe.utils.add_link_title(doctype, item.value, item.label);


### PR DESCRIPTION
## Summary
- Disable Awesomplete's native `tabSelect` in Link fields to prevent barcode scanners from selecting stale dropdown items
- Track search result freshness via `_results_loaded_for_term` flag — set to `null` on input, stamped with the search term when results arrive
- Re-implement Tab-select manually: only select the highlighted item when results are current for the typed input; otherwise close dropdown and let the blur handler validate normally

## Root Cause
When a barcode scanner sends rapid input followed by Tab, the Tab key arrives before the 500ms debounced search completes. Awesomplete's `tabSelect: true` (introduced in PR #22636) then selects the first item from the **stale** initial dropdown (populated on focus with an empty search), overwriting the scanned value.

**Race condition sequence:**
1. Focus → `on_input("")` fires immediately → dropdown opens with all items, first item highlighted (`autoFirst: true`)
2. Scanner types "01234" rapidly → debounced, actual search delayed 500ms
3. Scanner sends Tab → Awesomplete's `tabSelect` selects highlighted stale item
4. Existing `input_matches_item` guard uses substring check → passes when barcode is contained in stale item's label

## Fix Approach
Following the approach recommended by @cogk in #26846:
1. Set `tabSelect: false` to disable Awesomplete's native Tab-select
2. Add `_results_loaded_for_term` to track which search term the current dropdown results correspond to
3. On each `input` event, immediately mark results as stale (`_results_loaded_for_term = null`)
4. When search callback returns (or cache hits), stamp `_results_loaded_for_term = term`
5. Custom `keydown` handler for Tab: if results are stale, close dropdown and let blur handler validate; if fresh and item matches, select it

This preserves normal Tab-to-select behavior for manual users while preventing the race condition for barcode scanners.

## Test plan
- [x] Added Cypress test: fast input + immediate Tab should not select stale dropdown item
- [ ] Manual test: barcode scanner on Link field in child table (e.g., Item field in Sales Invoice items)
- [ ] Manual test: normal Tab-to-select still works when typing slowly and waiting for results
- [ ] Verify existing Cypress tests pass (`cypress/integration/control_link.js`)

Fixes #26846