### PR TITLE
fix: remove duplicate "More articles on category" link

### DIFF
--- a/frappe/website/doctype/help_article/templates/help_article.html
+++ b/frappe/website/doctype/help_article/templates/help_article.html
@@ -27,13 +27,6 @@
 		<span class="feedback-msg small hidden">{{ _("Thank you for your feedback!") }}</span>
 	</div>
 </div>
-<div class="help-article-comments">
-	<hr>
-	<a href="/{{ category.route }}">
-		{{ _("More articles on {0}").format(category.name) }}
-	</a>
-	<hr>
-</div>
 
 <div>
 	<h5>Comments</h5>


### PR DESCRIPTION
Resolve: #32506
Backport: v15, v16

---
Before 
<img width="1474" height="926" alt="image" src="https://github.com/user-attachments/assets/795e26d1-6de8-4238-9b7a-f51a8cfff759" />

---

After
<img width="1474" height="926" alt="image" src="https://github.com/user-attachments/assets/5f7e2510-222b-43f4-acf4-d0449cd2b598" />
