### PR TITLE
fix(grid): prevent mandatory_depends_on leaking across child table rows

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -2,7 +2,6 @@ import GridRowForm from "./grid_row_form";
 
 const DEPENDENCY_PROPERTIES = [
 	{ expr: "depends_on", prop: "hidden_due_to_dependency", negate: true },
-	{ expr: "mandatory_depends_on", prop: "reqd", negate: false },
 	{ expr: "read_only_depends_on", prop: "read_only", negate: false },
 ];
 
@@ -740,7 +739,7 @@ export default class GridRow {
 			let df = fields.find((field) => field?.fieldname === col[0].fieldname);
 
 			this.set_dependant_property(df);
-
+			this.set_row_mandatory(df);
 			let colsize = col[1];
 
 			total_colsize += colsize;
@@ -1676,5 +1675,11 @@ export default class GridRow {
 	}
 	toggle_editable(fieldname, editable) {
 		this.set_field_property(fieldname, "read_only", editable ? 0 : 1);
+	}
+	set_row_mandatory(df) {
+		if (!df.mandatory_depends_on) return;
+
+		const is_mandatory = !!this.evaluate_depends_on_value(df.mandatory_depends_on);
+		this.toggle_reqd(df.fieldname, is_mandatory);
 	}
 }


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->
closes #36921 
> Please provide enough information so that others can review your pull request:

Fixes incorrect mandatory validation in child table rows when `mandatory_depends_on` is used and rows are deleted or reordered.

---

> Explain the **details** for making this change. What existing problem does the pull request solve?

`mandatory_depends_on` was previously handled by mutating `df.reqd` in `grid_row.js`.Since `df` is shared across all rows of a child table, this caused the mandatory state to leak between rows, resulting in validation errors for rows where the field should not be mandatory.

This PR stops mutating shared DocField metadata for `mandatory_depends_on` and instead evaluates mandatory state per row, applying it only at the UI level. Save-time validation already re-evaluates the condition per row and continues to work correctly.

The setup was done as describe [here](https://github.com/frappe/frappe/issues/36921#issue-3919930086)

---
> Screenshot / GIFs 

**before** : 

https://github.com/user-attachments/assets/1855e727-cb63-46e7-9800-00adad30ffc9



**after**:


https://github.com/user-attachments/assets/b30eb7f1-10bb-4889-962d-ba1c907a17e9

