### PR TITLE
fix: reroute when page not found

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -145,6 +145,7 @@ frappe.request.call = function (opts) {
 				title: __("Not found"),
 				indicator: "red",
 				message: __("The resource you are looking for is not available"),
+				re_route: true,
 			});
 			opts.error_callback && opts.error_callback();
 		},


### PR DESCRIPTION
Payables was my favourite workspace, but now that it is deleted it shows not found, but closing that dialog leaves me on white screen 

https://github.com/user-attachments/assets/1f97c374-d5ba-44c6-93e3-078c8b39ddf3

