### PR TITLE
fix: address password strength serialization and Office 365 email validation

### DIFF
--- a/frappe/tests/test_password_strength.py
+++ b/frappe/tests/test_password_strength.py
@@ -3,9 +3,10 @@ from string import printable
 from time import time
 from unittest import TestCase
 
+import orjson
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
-from frappe.utils.password_strength import test_password_strength
+from frappe.utils.password_strength import _clamp_large_ints, test_password_strength
 
 
 class TestPasswordStrength(TestCase):
@@ -24,3 +25,29 @@ class TestPasswordStrength(TestCase):
 
 		self.assertLess(end_second - start_second, 10)
 		self.assertIn("feedback", result)
+
+	def test_result_is_orjson_serializable(self):
+		"""zxcvbn can return integers exceeding 64-bit range which orjson cannot serialize."""
+		result = test_password_strength("Eastern_43A1W")
+		# should not raise TypeError: Integer exceeds 64-bit range
+		orjson.dumps(result)
+
+	def test_clamp_large_ints(self):
+		INT64_MAX = 2**63 - 1
+		data = {
+			"guesses": 10**100,
+			"score": 4,
+			"flag": True,
+			"nested": {"big": 2**64, "ok": 42},
+			"items": [10**100, 1, False],
+		}
+		_clamp_large_ints(data)
+
+		self.assertEqual(data["guesses"], INT64_MAX)
+		self.assertEqual(data["score"], 4)
+		self.assertIs(data["flag"], True)
+		self.assertEqual(data["nested"]["big"], INT64_MAX)
+		self.assertEqual(data["nested"]["ok"], 42)
+		self.assertEqual(data["items"][0], INT64_MAX)
+		self.assertEqual(data["items"][1], 1)
+		self.assertIs(data["items"][2], False)

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -188,7 +188,7 @@ def get_info_via_oauth(provider: str, code: str, decoder: Callable | None = None
 			email_dict = next(filter(lambda x: x.get("primary"), emails))
 			info["email"] = email_dict.get("email")
 
-	if not (info.get("email_verified") or info.get("email")):
+	if not (info.get("email_verified") or get_email(info)):
 		frappe.throw(_("Email not verified with {0}").format(provider.title()))
 
 	return info

--- a/frappe/utils/password_strength.py
+++ b/frappe/utils/password_strength.py
@@ -27,7 +27,35 @@ def test_password_strength(password: str, user_inputs: "Iterable[object] | None"
 
 	result = zxcvbn(password, user_inputs, max_length=128)
 	result["feedback"] = get_feedback(result.get("score"), result.get("sequence"))
+	_clamp_large_ints(result)
 	return result
+
+
+_INT64_MAX = 2**63 - 1
+_INT64_MIN = -(2**63)
+
+
+def _clamp_large_ints(obj):
+	"""Clamp integers exceeding 64-bit range in-place.
+
+	orjson cannot serialize integers outside the signed 64-bit range.
+	zxcvbn can produce astronomically large guess counts for strong passwords.
+	"""
+	if isinstance(obj, dict):
+		items = obj.items()
+	elif isinstance(obj, list):
+		items = enumerate(obj)
+	else:
+		return
+
+	for key, value in items:
+		if isinstance(value, (dict, list)):
+			_clamp_large_ints(value)
+		elif isinstance(value, int) and not isinstance(value, bool):
+			if value > _INT64_MAX:
+				obj[key] = _INT64_MAX
+			elif value < _INT64_MIN:
+				obj[key] = _INT64_MIN
 
 
 # NOTE: code modified for frappe translations


### PR DESCRIPTION
## Summary
This PR fixes two small issues discovered during O365 Social Login usage:

1. Password strength API serialization error
2. Office 365 OAuth email claim handling

This issue also affects version-16 not sure how far it goes back.

---

## 1) Password strength serialization error

### Problem
`zxcvbn` can produce guess counts that exceed the 64-bit integer range supported by `orjson`. This caused a `TypeError` and a 500 response from the `test_password_strength` endpoint.

### Solution
Clamp the large integer values before serialization so `orjson` can handle them safely.

---

## 2) Office 365 OAuth email validation

### Problem
Email validation only checked the `"email"` claim, but Microsoft Entra ID tokens may instead use `"upn"` or `"unique_name"`. This caused valid Office 365 logins to fail.

### Solution
Use the existing `get_email()` helper, which already supports multiple claim formats.

---

## Testing
### Password strength
1. Call `test_password_strength` with a very strong password
2. Confirm a valid JSON response is returned

### OAuth
1. Log in using Office 365 OAuth
2. Verify email is extracted correctly
4. Confirm login succeeds
