### PR TITLE
fix(ui): resolve sidebar workspace for Page routes

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -459,7 +459,7 @@ frappe.ui.Sidebar = class Sidebar {
 			switch (route.length) {
 				case 1:
 					view = "Page";
-					entity_name = route[1];
+					entity_name = route[0];
 					break;
 				case 2:
 					view = route[0];


### PR DESCRIPTION
### Summary
Fix an indexing bug in frappe.ui.Sidebar#set_workspace_sidebar() for single-segment Desk Page routes.

### Problem
When the current route is a single-segment Page route (e.g. ["my-page"]), route[1] is always undefined.
set_workspace_sidebar() uses that value as entity_name, which can prevent resolving workspace sidebars linked to that page and may leave the sidebar stuck on the previously selected workspace depending on navigation history.

### Root Cause
In frappe.ui.Sidebar#set_workspace_sidebar(), case 1 uses entity_name = route[1].

### Fix
Use route[0] as entity_name for route.length === 1.

### Notes
set_sidebar_for_page() already uses route[0] for single-segment routes, so this aligns the behavior between the two code paths.

### How to reproduce
1. Create a Desk Page (e.g. my-page).
2. Add a Workspace Sidebar item with link_to = my-page.
3. Navigate to /desk/my-page from another Desk route.

### Testing
Manual navigation on v16: confirmed the sidebar resolves as expected for /desk/<page> routes.
