### PR TITLE
fix(workflow): enable_action confirmation permission error

### DIFF
--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -42,6 +42,30 @@ def get_workflow_name(doctype):
 
 
 @frappe.whitelist()
+def is_enable_action_confirmation(
+	doc: Document | str | dict,
+	workflow: Workflow = None,
+) -> bool:
+	from frappe.model.document import Document
+
+	# loading doc, using same pattern as get_transitions
+	# for better compatibility
+	if not isinstance(doc, Document):
+		doc = frappe.get_doc(frappe.parse_json(doc))
+		doc.load_from_db()
+	doc.check_permission("read")
+
+	# get active workflow
+	workflow = workflow or get_workflow(doc.doctype)
+
+	if not workflow:
+		return False
+
+	# return value of `enable_action_confirmation` field
+	return workflow.enable_action_confirmation
+
+
+@frappe.whitelist()
 def get_transitions(
 	doc: Document | str | dict, workflow: Workflow = None, raise_exception: bool = False
 ) -> list[dict]:

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -42,30 +42,6 @@ def get_workflow_name(doctype):
 
 
 @frappe.whitelist()
-def get_workflow_action_confirmation(
-	doc: Document | str | dict,
-	workflow: Workflow = None,
-) -> bool:
-	from frappe.model.document import Document
-
-	# loading doc, using same pattern as `frappe.model.workflow.get_transitions` function
-	# for better compatibility
-	if not isinstance(doc, Document):
-		doc = frappe.get_doc(frappe.parse_json(doc))
-		doc.load_from_db()
-	doc.check_permission("read")
-
-	# get active workflow
-	workflow = workflow or get_workflow(doc.doctype)
-
-	if not workflow:
-		return False
-
-	# return value of `enable_action_confirmation` field
-	return workflow.enable_action_confirmation
-
-
-@frappe.whitelist()
 def get_transitions(
 	doc: Document | str | dict, workflow: Workflow = None, raise_exception: bool = False
 ) -> list[dict]:

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -42,13 +42,13 @@ def get_workflow_name(doctype):
 
 
 @frappe.whitelist()
-def is_enable_action_confirmation(
+def get_workflow_action_confirmation(
 	doc: Document | str | dict,
 	workflow: Workflow = None,
 ) -> bool:
 	from frappe.model.document import Document
 
-	# loading doc, using same pattern as get_transitions
+	# loading doc, using same pattern as `frappe.model.workflow.get_transitions` function
 	# for better compatibility
 	if not isinstance(doc, Document):
 		doc = frappe.get_doc(frappe.parse_json(doc))

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -102,18 +102,6 @@ frappe.ui.form.States = class FormStates {
 				if (frappe.user_roles.includes(d.allowed) && has_approval_access(d)) {
 					added = true;
 					me.frm.page.add_action_item(__(d.action), function () {
-						frappe
-							.xcall("frappe.model.workflow.get_workflow_action_confirmation", {
-								doc: me.frm.doc,
-							})
-							.then((r) => {
-								if (r) {
-									frappe.confirm(
-										__("Are you sure you want to {0}?", [d.action]),
-										() => me.handle_workflow_action(d)
-									);
-								} else {
-									me.handle_workflow_action(d);
 						if (frappe.workflow?.workflows?.[me.frm.doctype]?.enable_action_confirmation) {
 							frappe.confirm(
 								__("Are you sure you want to {0}?", [d.action]),
@@ -122,7 +110,6 @@ frappe.ui.form.States = class FormStates {
 						} else {
 							me.handle_workflow_action(d);
 						}
-							});
 					});
 				}
 			});

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -107,7 +107,7 @@ frappe.ui.form.States = class FormStates {
 								doc: me.frm.doc,
 							})
 							.then((r) => {
-								if (r.message) {
+								if (r) {
 									frappe.confirm(
 										__("Are you sure you want to {0}?", [d.action]),
 										() => me.handle_workflow_action(d)

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -103,8 +103,7 @@ frappe.ui.form.States = class FormStates {
 					added = true;
 					me.frm.page.add_action_item(__(d.action), function () {
 						frappe
-							.xcall(
-								"frappe.model.workflow.get_workflow_action_confirmation", {
+							.xcall("frappe.model.workflow.get_workflow_action_confirmation", {
 								doc: me.frm.doc,
 							})
 							.then((r) => {

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -102,14 +102,13 @@ frappe.ui.form.States = class FormStates {
 				if (frappe.user_roles.includes(d.allowed) && has_approval_access(d)) {
 					added = true;
 					me.frm.page.add_action_item(__(d.action), function () {
-						frappe.db
-							.get_value(
-								"Workflow",
-								{ document_type: me.frm.doctype },
-								"enable_action_confirmation"
-							)
+						frappe
+							.xcall(
+								"frappe.model.workflow.get_workflow_action_confirmation", {
+								doc: me.frm.doc,
+							})
 							.then((r) => {
-								if (r.message.enable_action_confirmation) {
+								if (r.message) {
 									frappe.confirm(
 										__("Are you sure you want to {0}?", [d.action]),
 										() => me.handle_workflow_action(d)

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -102,10 +102,12 @@ frappe.ui.form.States = class FormStates {
 				if (frappe.user_roles.includes(d.allowed) && has_approval_access(d)) {
 					added = true;
 					me.frm.page.add_action_item(__(d.action), function () {
-						if (frappe.workflow?.workflows?.[me.frm.doctype]?.enable_action_confirmation) {
-							frappe.confirm(
-								__("Are you sure you want to {0}?", [d.action]),
-								() => me.handle_workflow_action(d)
+						if (
+							frappe.workflow?.workflows?.[me.frm.doctype]
+								?.enable_action_confirmation
+						) {
+							frappe.confirm(__("Are you sure you want to {0}?", [d.action]), () =>
+								me.handle_workflow_action(d)
 							);
 						} else {
 							me.handle_workflow_action(d);

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -114,7 +114,14 @@ frappe.ui.form.States = class FormStates {
 									);
 								} else {
 									me.handle_workflow_action(d);
-								}
+						if (frappe.workflow?.workflows?.[me.frm.doctype]?.enable_action_confirmation) {
+							frappe.confirm(
+								__("Are you sure you want to {0}?", [d.action]),
+								() => me.handle_workflow_action(d)
+							);
+						} else {
+							me.handle_workflow_action(d);
+						}
 							});
 					});
 				}


### PR DESCRIPTION
Fix workflow permission error.

Currently client will call `frappe.db.get_value` to get Workflow setting value which **will** throw error for all user except System Manager which has CRUD permission to Workflow doctype.

Fix, create a method for client to call and skip permission checking

Will solve this issues https://github.com/frappe/frappe/issues/34991