### PR TITLE
Fix(desk): Add Item Below not working in Sidebar Editor

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
@@ -566,7 +566,7 @@ export class SidebarEditor {
 				this.delete_item(item_data);
 				break;
 			case "add_item_below":
-				this.edit_item(item_data);
+				this.add_below(item_data);
 				break;
 			case "duplicate":
 				this.duplicate_item(item_data);

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
@@ -565,7 +565,7 @@ export class SidebarEditor {
 			case "delete":
 				this.delete_item(item_data);
 				break;
-			case "add_item_below":
+			case "add_below":
 				this.add_below(item_data);
 				break;
 			case "duplicate":

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -128,7 +128,6 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 				label: "Add Item Below",
 				icon: "add",
 				onClick: () => {
-					console.log("Moving");
 					frappe.app.sidebar.editor.perform_action("add_item_below", me.item);
 				},
 			},
@@ -143,7 +142,6 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 				label: "Delete",
 				icon: "trash-2",
 				onClick: () => {
-					console.log(me.item);
 					frappe.app.sidebar.editor.perform_action("delete", me.item);
 				},
 			},

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -128,7 +128,7 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 				label: "Add Item Below",
 				icon: "add",
 				onClick: () => {
-					frappe.app.sidebar.editor.perform_action("add_item_below", me.item);
+					frappe.app.sidebar.editor.perform_action("add_below", me.item);
 				},
 			},
 			{
@@ -142,6 +142,7 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 				label: "Delete",
 				icon: "trash-2",
 				onClick: () => {
+					console.log(me.item);
 					frappe.app.sidebar.editor.perform_action("delete", me.item);
 				},
 			},

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -128,7 +128,8 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 				label: "Add Item Below",
 				icon: "add",
 				onClick: () => {
-					frappe.app.sidebar.editor.perform_action("add_below", me.item);
+					console.log("Moving");
+					frappe.app.sidebar.editor.perform_action("add_item_below", me.item);
 				},
 			},
 			{


### PR DESCRIPTION
## Description

The "Add Item Below" option in the Sidebar Editor was not functioning.

Root Cause:
- There was a mismatch in action naming between `sidebar_item.js` and `sidebar_editor.js`.
- The editor was handling `add_item_below` while the sidebar was triggering `add_below`.
- Additionally, the handler incorrectly called `edit_item()` instead of inserting a new item below.

Fix:
- Standardized the action name to `add_below` for consistency.
- Updated the perform_action switch case to call `add_below(item_data)` instead of `edit_item(item_data)`.
- Now clicking `Add Item Below` correctly inserts a new sidebar item below the selected item.

Before:

https://github.com/user-attachments/assets/d3e9b98c-efd5-4ff7-b72b-4b79400730e6

After

https://github.com/user-attachments/assets/04c7bad4-aa66-43f1-b773-7b3c459abf48


Closes #36950
