### PR TITLE
fix: remove cleanup_filters that pops last chart filter

### DIFF
--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -208,7 +208,7 @@ frappe.dashboard_utils = {
 			: null;
 
 		if (!dynamic_filters || !Object.keys(dynamic_filters).length) {
-			return this.cleanup_filters(filters);
+			return filters;
 		}
 
 		if (Array.isArray(dynamic_filters)) {
@@ -232,13 +232,6 @@ frappe.dashboard_utils = {
 			Object.assign(filters, dynamic_filters);
 		}
 
-		return this.cleanup_filters(filters);
-	},
-	cleanup_filters(filters) {
-		if (filters.length && filters[0].length == 5) {
-			filters.pop();
-			return filters;
-		}
 		return filters;
 	},
 	get_dashboard_link_field() {


### PR DESCRIPTION
Closes #36959

### Summary
Remove the cleanup_filters() function and its call in dashboard_utils.js
This function was introduced in commit 50c67025aa (PR #34777) to strip the deprecated 5th element from filter arrays, but it incorrectly calls filters.pop() which removes the entire last filter instead of the 5th element from each filter

### Root Cause
The 5th element (this.hidden) in filter arrays was already properly removed at the
source in commit 632e65e6d9 (filter.js: get_value() no longer returns it). This makes
cleanup_filters() buggy.