### PR TITLE
fix: don't clear __newname on fields refresh

### DIFF
--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -202,6 +202,10 @@ Object.assign(frappe.model, {
 			updated_doc.__newname = local_parent_doc.__newname;
 		}
 
+		if (updated_doc.__islocal && local_parent_doc.__newname) {
+			updated_doc.__newname = local_parent_doc.__newname; // preserve set by user name
+		}
+
 		// clear keys on parent
 		clear_keys(updated_doc, local_parent_doc);
 	},


### PR DESCRIPTION
> many years old bug, solved 🤣 

### Problem

So if in any DocType there was a "set by user" autoname and the user tried to set a name and then due to any scripts or triggers `refresh_fields` was called, which is called in case of `frm.call` the name field used to get empty. 

### Solution

Preserve the `__newname` when syncing with `docs` returned from backend during `frm.call` or something else.


