### PR TITLE
feat(api/v2): route `frappe.call` doc calls to `execute_doc_method`, supporting both api/v1 and api/v2

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -456,47 +456,6 @@ frappe.call = function (opts) {
 		return { should_skip: is_fresh };
 	}
 
-	/**
-	 * Assembles the final configuration object for frappe.request.call.
-	 * @param {{
-	 *   type: string,
-	 *   payload: object,
-	 *   url: string,
-	 *   success_handler: function,
-	 *   error_callback: function|undefined,
-	 *   always_callback: function|undefined,
-	 *   btn: HTMLElement|undefined,
-	 *   freeze: boolean,
-	 *   freeze_message: string,
-	 *   headers: object,
-	 *   error_handlers: object,
-	 *   async: boolean|undefined,
-	 *   silent: boolean|undefined,
-	 *   api_version: string|undefined,
-	 *   cache: boolean|undefined
-	 * }} config
-	 * @returns {object} Configuration for frappe.request.call
-	 */
-	function assemble_request_config(config) {
-		return {
-			type: config.type || "POST",
-			args: config.payload,
-			success: config.success_handler,
-			error: config.error_callback,
-			always: config.always_callback,
-			btn: config.btn,
-			freeze: config.freeze,
-			freeze_message: config.freeze_message,
-			headers: config.headers || {},
-			error_handlers: config.error_handlers || {},
-			async: config.async,
-			silent: config.silent,
-			api_version: config.api_version,
-			url: config.url,
-			cache: config.cache,
-		};
-	}
-
 	// ============================================================================
 	// MAIN EXECUTION FLOW
 	// ============================================================================
@@ -599,28 +558,24 @@ frappe.call = function (opts) {
 		realtime_opts: realtime_opts,
 	});
 
-	// Assemble request configuration
-	// TODO: Consider passing properties directly to frappe.request.call instead of an intermediate method
-	var request_config = assemble_request_config({
-		type: options.type,
-		payload: payload_result.payload,
-		url: url_result.url,
-		success_handler: success_handler,
-		error_callback: options.error,
-		always_callback: options.always,
+	// Dispatch request
+	return frappe.request.call({
+		type: options.type || "POST",
+		args: payload_result.payload,
+		success: success_handler,
+		error: options.error,
+		always: options.always,
 		btn: options.btn,
 		freeze: resolved_params.freeze,
 		freeze_message: resolved_params.freeze_message,
-		headers: options.headers,
-		error_handlers: options.error_handlers,
+		headers: options.headers || {},
+		error_handlers: options.error_handlers || {},
 		async: options.async,
 		silent: options.silent,
 		api_version: effective_api_version,
+		url: url_result.url,
 		cache: options.cache,
 	});
-
-	// Dispatch request
-	return frappe.request.call(request_config);
 };
 
 frappe.request.call = function (opts) {

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -345,38 +345,38 @@ frappe.call = function (opts) {
 	}
 
 	/**
-	 * Builds URL for database origin document method calls (v1 API).
-	 * v1: POST to /api/v1/resource/<doctype>/<name>/ with run_method in form data
-	 * @param {{ doctype: string, name: string }} config
+	 * Builds URL for database origin document method calls.
+	 * Supports both v1 and v2 API versions:
+	 * - v1: POST to /api/v1/resource/<doctype>/<name>/ with run_method in form data
+	 * - v2: method is part of the URL path /api/v2/document/<doctype>/<name>/method/<method>/
+	 * @param {{ api_version: string, doctype: string, name: string, method?: string }} config
 	 * @returns {{ url: string }}
 	 */
-	function build_doc_database_url_v1(config) {
-		// TODO: Merge with build_doc_database_url_v2
-		var { doctype, name } = config;
+	function build_doc_db_origin_url(config) {
+		var { api_version, doctype, name, method } = config;
 
-		var url =
-			`/api/v1/resource/` +
-			`${encodeURIComponent(doctype)}/` +
-			`${encodeURIComponent(name)}/`;
-		return { url: url };
-	}
+		var identifier = `${encodeURIComponent(doctype)}/${encodeURIComponent(name)}`;
+		var version = api_version || "v1";
+		var method_name = null;
+		var route;
 
-	/**
-	 * Builds URL for database origin document method calls (v2 API).
-	 * v2: method is part of the URL path
-	 * @param {{ doctype: string, name: string, method: string }} config
-	 * @returns {{ url: string }}
-	 */
-	function build_doc_database_url_v2(config) {
-		// TODO: Merge with build_doc_database_url_v1
-		var { doctype, name, method } = config;
-
-		var url =
-			`/api/v2/document/` +
-			`${encodeURIComponent(doctype)}/` +
-			`${encodeURIComponent(name)}/` +
-			`method/${encodeURIComponent(method)}/`;
-		return { url: url };
+		switch (version) {
+			case "v2":
+				method_name = `method/${encodeURIComponent(method)}`;
+				route = "document";
+				break;
+			
+			case "v1":
+			default:
+				method_name = ""; // method is passed via form data in v1, not in URL
+				route = "resource";
+				break;
+		}
+		
+		var url = `/api/${version}/${route}/${identifier}`;
+		if (method_name) url += `/${method_name}`;
+		
+		return { url };
 	}
 
 	/**
@@ -433,20 +433,13 @@ frappe.call = function (opts) {
 				return { url: null, error: validation.error };
 			}
 
-			if (api_version === "v1") {
-				var v1_url = build_doc_database_url_v1({
-					doctype: doc.doctype,
-					name: doc.name,
-				});
-				url = v1_url.url;
-			} else if (api_version === "v2") {
-				var v2_url = build_doc_database_url_v2({
-					doctype: doc.doctype,
-					name: doc.name,
-					method: method,
-				});
-				url = v2_url.url;
-			}
+			var doc_url = build_doc_db_origin_url({
+				api_version: api_version,
+				doctype: doc.doctype,
+				name: doc.name,
+				method: method,
+			});
+			url = doc_url.url;
 		} else {
 			// Standard method URL
 			var std_url = build_standard_method_url({

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -201,120 +201,71 @@ frappe.call = function (opts) {
 	}
 
 	/**
-	 * Builds the command string for page methods.
-	 * @param {{ module: string, page: string, method: string }} config
-	 * @returns {{ cmd: string }}
-	 */
-	function build_page_method_command(config) {
-		var { module, page, method } = config;
-
-		return {
-			cmd: `${module}.page.${page}.${page}.${method}`,
-		};
-	}
-
-	/**
-	 * Builds the payload for document method calls with memory origin.
-	 * Uses run_doc_method, sends full in-memory document to server.
-	 * @param {{ doctype: string, name: string, method: string, args: object }} config
-	 * @returns {{ payload: object, cmd: string }}
-	 */
-	function build_doc_memory_payload(config) {
-		var { doctype, name, method, args } = config;
-
-		return {
-			payload: {
-				cmd: "run_doc_method",
-				docs: frappe.get_doc(doctype, name),
-				method: method,
-				args: args,
-			},
-			cmd: "run_doc_method",
-		};
-	}
-
-	/**
-	 * Builds the payload for document method calls with database origin.
-	 * Server loads document from DB (lighter payload).
-	 * @param {{ api_version: string, method: string, args: object }} config
-	 * @returns {{ payload: object, cmd: string|undefined }}
-	 */
-	function build_doc_database_payload(config) {
-		var { api_version, method, args } = config;
-
-		var payload = {};
-
-		// For v1: method is passed via run_method in form data
-		// For v2: method is in URL path, no need to add inside payload
-		if (api_version === "v1") {
-			payload.run_method = method;
-		}
-
-		// Pass any method arguments
-		if (args) {
-			payload = $.extend({}, args, payload);
-		}
-
-		return {
-			payload: payload,
-			cmd: undefined, // database origin doesn't use cmd in payload
-		};
-	}
-
-	/**
-	 * Builds the server payload based on call type (page, doc memory, doc database, or direct method).
-	 * @param {{ method: string, args: object, doc: object|undefined, doc_origin: string|undefined, api_version: string|undefined, module: string|undefined, page: string|undefined }} config
+	 * Builds and prepares the server payload
+	 * Determinates the appropriate cmd and payload structure based on call type and doc_origin.
+	 * @param {{ method: string, args: object, doc: object|undefined, doc_origin: string|undefined, api_version: string|undefined, module: string|undefined, page: string|undefined, has_custom_url: boolean }} config
 	 * @returns {{ payload: object, cmd: string|undefined }}
 	 */
 	function build_server_payload(config) {
-		var { method, args, doc, doc_origin, api_version, module, page } = config;
+		var { method, args, doc, doc_origin, api_version, module, page, has_custom_url } = config;
 
-		// Page method call
+		var base_payload;
+		var cmd_value;
+
 		if (module && page) {
-			var page_cmd = build_page_method_command({
-				module: module,
-				page: page,
-				method: method,
-			});
-			var page_payload = $.extend({}, args);
-			page_payload.cmd = page_cmd.cmd;
-			return {
-				payload: page_payload,
-				cmd: page_cmd.cmd,
+			// Page method call
+			base_payload = $.extend({}, args);
+			cmd_value = `${module}.page.${page}.${page}.${method}`
+			
+			// Add cmd to payload if custom URL
+			if (has_custom_url) {
+				base_payload.cmd = cmd_value;
+			}
+		} else if (doc && doc_origin === "memory") {
+			// Document method call with memory origin
+			cmd_value = "run_doc_method";
+
+			const { doctype, name } = doc;
+			// Retrieve full document
+			// from in-memory cache if available, or from server if not in cache
+			const docs = frappe.get_doc(doctype, name);
+
+			base_payload = {
+				docs,
+				method,
+				args,
 			};
+			
+			// Add cmd to payload if custom URL
+			if (has_custom_url) {
+				base_payload.cmd = cmd_value;
+			}
+		} else if (doc && doc_origin === "database") {
+			// Document method call with database origin
+			// Server loads document from DB (lighter payload).
+			cmd_value = undefined; // database origin doesn't use cmd
+			base_payload = $.extend({}, args);
+
+			// For v1: method is passed via run_method in form data
+			// For v2: method is in URL path, no need to add inside payload
+			if (api_version === "v1") {
+				base_payload.run_method = method;
+			}
+		} else if (method) {
+			// Direct method call
+			cmd_value = method;
+			base_payload = $.extend({}, args);
+			
+			// Add cmd to payload if custom URL
+			if (has_custom_url) {
+				base_payload.cmd = cmd_value;
+			}
 		}
 
-		// Document method call with memory origin
-		if (doc && doc_origin === "memory") {
-			return build_doc_memory_payload({
-				doctype: doc.doctype,
-				name: doc.name,
-				method: method,
-				args: args,
-			});
-		}
-
-		// Document method call with database origin
-		if (doc && doc_origin === "database") {
-			return build_doc_database_payload({
-				api_version: api_version,
-				method: method,
-				args: args,
-			});
-		}
-
-		// Direct method call
-		if (method) {
-			var direct_payload = $.extend({}, args);
-			direct_payload.cmd = method;
-			return {
-				payload: direct_payload,
-				cmd: method,
-			};
-		}
-
-		// This should never be reached, previous validations should catch invalid configurations
-		throw new Error("frappe.call: unable to build server payload due to unknown call type");
+		return {
+			payload: base_payload,
+			cmd: cmd_value,
+		};
 	}
 
 	/**
@@ -455,24 +406,6 @@ frappe.call = function (opts) {
 		}
 
 		return { url: url, error: null };
-	}
-
-	/**
-	 * Removes cmd from payload when URL is built (not custom).
-	 * Prevents sending cmd twice (as path and POST data).
-	 * @param {object} payload
-	 * @param {boolean} has_custom_url
-	 * @returns {{ payload: object }}
-	 */
-	function prepare_final_payload(payload, has_custom_url) {
-		// TODO: Maybe this method can be unified with build_server_payload?
-		if (has_custom_url) {
-			return { payload: payload };
-		}
-		// Create new object without cmd
-		var final_payload = $.extend({}, payload);
-		delete final_payload.cmd;
-		return { payload: final_payload };
 	}
 
 	/**
@@ -625,6 +558,7 @@ frappe.call = function (opts) {
 		api_version: effective_api_version,
 		module: options.module,
 		page: options.page,
+		has_custom_url: !!options.url,
 	});
 
 	// Build request URL
@@ -641,15 +575,11 @@ frappe.call = function (opts) {
 		throw url_result.error;
 	}
 
-	// Prepare final payload (remove cmd if URL was built)
-	var final_payload_result = prepare_final_payload(payload_result.payload, !!options.url);
-	var final_payload = final_payload_result.payload;
-
 	// Check debounce status
 	var debounce_check = check_debounce_status({
 		debounce: options.debounce,
 		cmd: payload_result.cmd,
-		payload: final_payload,
+		payload: payload_result.payload,
 	});
 
 	if (debounce_check.should_skip) {
@@ -661,7 +591,7 @@ frappe.call = function (opts) {
 		freeze: resolved_params.freeze,
 		freeze_message: resolved_params.freeze_message,
 		api_version: effective_api_version,
-		args: final_payload,
+		args: payload_result.payload,
 	});
 	var success_handler = create_success_handler({
 		callback: options.callback,
@@ -673,7 +603,7 @@ frappe.call = function (opts) {
 	// TODO: Consider passing properties directly to frappe.request.call instead of an intermediate method
 	var request_config = assemble_request_config({
 		type: options.type,
-		payload: final_payload,
+		payload: payload_result.payload,
 		url: url_result.url,
 		success_handler: success_handler,
 		error_callback: options.error,

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -39,28 +39,18 @@ frappe.call = function (opts) {
 	var options = parsed.opts;
 
 	// Validate API version and doc_origin
-	var api_validation = helpers.validate_api_version(options.api_version);
-	if (!api_validation.is_valid) {
-		throw api_validation.error;
-	}
-
-	var doc_origin_validation = helpers.validate_doc_origin(options.doc_origin);
-	if (!doc_origin_validation.is_valid) {
-		throw doc_origin_validation.error;
-	}
+	helpers.validate_api_version(options.api_version);
+	helpers.validate_doc_origin(options.doc_origin);
 
 	// Validate call type ONLY if no custom URL is provided
 	// When using custom URL, method/doc/page are optional since URL is already specified
 	if (!options.url) {
-		var call_type_validation = helpers.validate_call_type({
+		helpers.validate_call_type({
 			method: options.method,
 			doc: options.doc,
 			module: options.module,
 			page: options.page,
 		});
-		if (!call_type_validation.is_valid) {
-			throw call_type_validation.error;
-		}
 	}
 
 	// Resolve parameters precedence
@@ -99,10 +89,6 @@ frappe.call = function (opts) {
 		method: options.method,
 	});
 
-	if (url_result.error) {
-		throw url_result.error;
-	}
-
 	// Check debounce status
 	var debounce_check = helpers.check_debounce_status({
 		debounce: options.debounce,
@@ -121,7 +107,7 @@ frappe.call = function (opts) {
 		api_version: doc_origin_resolution.api_version,
 		args: payload_result.payload,
 	});
-	var success_handler = helpers.create_success_handler({
+	var success_wrapper = helpers.route_success_callback({
 		callback: options.callback,
 		queued: options.queued,
 		realtime_opts: realtime_opts,
@@ -131,7 +117,7 @@ frappe.call = function (opts) {
 	return frappe.request.call({
 		type: options.type || "POST",
 		args: payload_result.payload,
-		success: success_handler,
+		success: success_wrapper.handler,
 		error: options.error,
 		always: options.always,
 		btn: options.btn,
@@ -166,7 +152,7 @@ frappe.call._helpers = {
 				3 // Display time in seconds
 			);
 		}
-		return { is_online: is_online };
+		return { is_online };
 	},
 
 	/**
@@ -211,48 +197,46 @@ frappe.call._helpers = {
 
 	/**
 	 * Validates API version parameter.
+	 * Throws if the provided version is not supported.
 	 * @param {string|undefined} api_version
-	 * @returns {{ is_valid: boolean, error: Error|null }}
+	 * @returns {{ is_valid: boolean }}
 	 */
 	validate_api_version(api_version) {
 		var valid_versions = ["v1", "v2"];
-		// No api_version is also valid (defaults to legacy behavior)
-		if (api_version && !valid_versions.includes(api_version)) {
+		let is_valid = !api_version || valid_versions.includes(api_version);
+		if (!is_valid) {
 			console.error("frappe.call unsupported api_version");
-			return {
-				is_valid: false,
-				error: new Error(
-					`frappe.call: api_version '${api_version}' is not supported. Use one of: ${valid_versions.join(", ")}`
-				),
-			};
+			throw new Error(
+				`frappe.call: api_version '${api_version}' is not supported. Use one of: ${valid_versions.join(", ")}`
+			);
 		}
-		return { is_valid: true, error: null };
+		return { is_valid };
 	},
 
 	/**
 	 * Validates doc_origin parameter.
+	 * Throws if the provided origin is not supported.
 	 * @param {string|undefined} doc_origin
-	 * @returns {{ is_valid: boolean, error: Error|null }}
+	 * @returns {{ is_valid: boolean }}
 	 */
 	validate_doc_origin(doc_origin) {
 		var valid_origins = ["memory", "database"];
-		if (doc_origin && !valid_origins.includes(doc_origin)) {
+		let is_valid = !doc_origin || valid_origins.includes(doc_origin);
+		if (!is_valid) {
 			console.error("frappe.call unsupported doc_origin");
-			return {
-				is_valid: false,
-				error: new Error(
-					`frappe.call: doc_origin '${doc_origin}' is not supported. Use one of: ${valid_origins.join(", ")}`
-				),
-			};
+			throw new Error(
+				`frappe.call: doc_origin '${doc_origin}' is not supported. Use one of: ${valid_origins.join(", ")}`
+			);
 		}
-		return { is_valid: true, error: null };
+		return { is_valid };
 	},
 
 	/**
 	 * Validates that at least one valid call type is specified.
 	 * Valid call types are: page method (module + page), document method (doc), or direct method (method).
+	 * Throws if none of the valid call types is specified.
 	 * @param {{ method: string|undefined, doc: object|undefined, module: string|undefined, page: string|undefined }} config
-	 * @returns {{ is_valid: boolean, error: Error|null }}
+	 * @returns {{ is_valid: boolean }}
 	 */
 	validate_call_type(config) {
 		var { method, doc, module, page } = config;
@@ -261,8 +245,9 @@ frappe.call._helpers = {
 		var has_doc_call = doc != null;
 		var has_method_call = method != null;
 
-		if (has_page_call || has_doc_call || has_method_call) {
-			return { is_valid: true, error: null };
+		let is_valid = has_page_call || has_doc_call || has_method_call;
+		if (is_valid) {
+			return { is_valid };
 		}
 
 		var missing_options = [
@@ -272,12 +257,9 @@ frappe.call._helpers = {
 		].filter(Boolean);
 
 		console.error("frappe.call invalid call configuration");
-		return {
-			is_valid: false,
-			error: new Error(
-				`frappe.call: invalid call configuration. Must provide one of: ${missing_options.join(", ")}`
-			),
-		};
+		throw new Error(
+			`frappe.call: invalid call configuration. Must provide one of: ${missing_options.join(", ")}`
+		);
 	},
 
 	/**
@@ -390,28 +372,34 @@ frappe.call._helpers = {
 
 	/**
 	 * Validates required parameters for database origin document method calls.
+	 * Throws if any required parameter is missing.
 	 * @param {{ doctype: string|undefined, name: string|undefined, method: string|undefined }} config
-	 * @returns {{ is_valid: boolean, error: Error|null }}
+	 * @returns {{ is_valid: boolean }}
 	 */
 	validate_document_method_params(config) {
 		var { doctype, name, method } = config;
+		
+		var has_doctype = doctype != null;
+		var has_name = name != null;
+		var has_method = method != null;
 
-		var missing = [
-			!doctype && "doc.doctype",
-			!name && "doc.name",
-			!method && "method",
-		].filter(Boolean);
+		var is_valid = has_doctype && has_name && has_method;
+		if (!is_valid) {
+			var missing = [
+				!has_doctype && "doc.doctype (document doctype)",
+				!has_name && "doc.name (document name)",
+				!has_method && "method (method name to run on the document)",
+			].filter(Boolean);
 
-		if (missing.length) {
-			console.error("frappe.call missing parameters");
-			return {
-				is_valid: false,
-				error: new Error(
+			if (missing.length) {
+				console.error("frappe.call missing parameters");
+				throw new Error(
 					`frappe.call: missing '${missing.join("', '")}' required for database origin document method calls`
-				),
-			};
+				);
+			}
 		}
-		return { is_valid: true, error: null };
+
+		return { is_valid };
 	},
 
 	/**
@@ -473,35 +461,33 @@ frappe.call._helpers = {
 	apply_cordova_host(url) {
 		var host = frappe.request.url;
 		host = host.slice(0, host.length - 1);
-		return { url: host + url };
+		return { url: `${host}${url}` };
 	},
 
 	/**
 	 * Builds the complete request URL if needed.
+	 * Throws (via validate_document_method_params) if required params are missing for database origin calls.
 	 * @param {{ custom_url: string|undefined, doc: object|undefined, doc_origin: string|undefined, api_version: string|undefined, cmd: string|undefined, method: string|undefined }} config
-	 * @returns {{ url: string, error: Error|null }}
+	 * @returns {{ url: string }}
 	 */
 	build_request_url(config) {
 		var { custom_url, doc, doc_origin, api_version, cmd, method } = config;
 
 		// Use custom URL if provided
 		if (custom_url) {
-			return { url: custom_url, error: null };
+			return { url: custom_url };
 		}
 
 		var url;
 
 		// Database origin document method URL
 		if (doc && doc_origin === "database") {
-			// Validate required params for database origin
-			var validation = this.validate_document_method_params({
+			// Validate required params for database origin — throws if missing
+			this.validate_document_method_params({
 				doctype: doc.doctype,
 				name: doc.name,
 				method: method,
 			});
-			if (!validation.is_valid) {
-				return { url: null, error: validation.error };
-			}
 
 			var doc_url = this.build_doc_db_origin_url({
 				api_version: api_version,
@@ -525,7 +511,7 @@ frappe.call._helpers = {
 			url = cordova_url.url;
 		}
 
-		return { url: url, error: null };
+		return { url };
 	},
 
 	/**
@@ -535,10 +521,10 @@ frappe.call._helpers = {
 	 * @param {{ callback: function|undefined, queued: function|undefined, realtime_opts: object }} config
 	 * @returns {function}
 	 */
-	create_success_handler(config) {
+	route_success_callback(config) {
 		var { callback, queued, realtime_opts } = config;
 
-		const success_handler = (data, response_text) => {
+		const handler = (data, response_text) => {
 			// Async task: subscribe to realtime updates
 			if (data.task_id) {
 				frappe.realtime.subscribe(data.task_id, realtime_opts);
@@ -554,7 +540,8 @@ frappe.call._helpers = {
 				return callback(data, response_text);
 			}
 		};
-		return success_handler;
+
+		return { handler };
 	},
 
 	/**
@@ -571,8 +558,8 @@ frappe.call._helpers = {
 
 		// Build args object with cmd for is_fresh check
 		var args_with_cmd = $.extend({}, payload, { cmd: cmd });
-		// TODO: Check if it is correct implementation to skip the request when not fresh
 		var is_fresh = frappe.request.is_fresh(args_with_cmd, debounce);
+
 		return { should_skip: is_fresh };
 	},
 };

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -48,7 +48,7 @@ frappe.call = function (opts) {
 					message: __("Connection Lost"),
 					subtitle: __("You are not connected to Internet. Retry after sometime."),
 				},
-				3
+				3 // Display time in seconds
 			);
 		}
 		return { is_online: is_online };
@@ -80,13 +80,13 @@ frappe.call = function (opts) {
 	 * Resolves parameter precedence between top-level opts and args.
 	 * Top-level options take precedence over args options.
 	 * @param {{ opts: object, args: object }} config
-	 * @returns {{ freeze: boolean, freeze_message: string }}
+	 * @returns {{ freeze: boolean, freeze_message: string|undefined }}
 	 */
 	function resolve_parameter_precedence(config) {
 		var { opts, args } = config;
 
 		var resolved_freeze = opts.freeze || args.freeze || false;
-		var resolved_freeze_message = opts.freeze_message || args.freeze_message || "";
+		var resolved_freeze_message = opts.freeze_message || args.freeze_message;
 
 		return {
 			freeze: resolved_freeze,
@@ -141,10 +141,10 @@ frappe.call = function (opts) {
 	 */
 	function validate_call_type(config) {
 		var { method, doc, module, page } = config;
-
-		var has_page_call = module && page;
-		var has_doc_call = !!doc;
-		var has_method_call = !!method;
+		
+		var has_page_call = module != null && page != null;
+		var has_doc_call = doc != null;
+		var has_method_call = method != null;
 
 		if (has_page_call || has_doc_call || has_method_call) {
 			return { is_valid: true, error: null };
@@ -260,6 +260,11 @@ frappe.call = function (opts) {
 			if (has_custom_url) {
 				base_payload.cmd = cmd_value;
 			}
+		} else {
+			// No call pattern specified (custom URL case)
+			// Just use args as-is, no cmd
+			cmd_value = undefined;
+			base_payload = $.extend({}, args);
 		}
 
 		return {
@@ -480,15 +485,18 @@ frappe.call = function (opts) {
 		throw doc_origin_validation.error;
 	}
 
-	// Validate call type
-	var call_type_validation = validate_call_type({
-		method: options.method,
-		doc: options.doc,
-		module: options.module,
-		page: options.page,
-	});
-	if (!call_type_validation.is_valid) {
-		throw call_type_validation.error;
+	// Validate call type ONLY if no custom URL is provided
+	// When using custom URL, method/doc/page are optional since URL is already specified
+	if (!options.url) {
+		var call_type_validation = validate_call_type({
+			method: options.method,
+			doc: options.doc,
+			module: options.module,
+			page: options.page,
+		});
+		if (!call_type_validation.is_valid) {
+			throw call_type_validation.error;
+		}
 	}
 
 	// Resolve parameters precedence
@@ -505,16 +513,13 @@ frappe.call = function (opts) {
 		has_doc: !!options.doc,
 	});
 
-	var effective_doc_origin = doc_origin_resolution.doc_origin;
-	var effective_api_version = doc_origin_resolution.api_version;
-
 	// Build server payload
 	var payload_result = build_server_payload({
 		method: options.method,
 		args: input_args,
 		doc: options.doc,
-		doc_origin: effective_doc_origin,
-		api_version: effective_api_version,
+		doc_origin: doc_origin_resolution.doc_origin,
+		api_version: doc_origin_resolution.api_version,
 		module: options.module,
 		page: options.page,
 		has_custom_url: !!options.url,
@@ -524,8 +529,8 @@ frappe.call = function (opts) {
 	var url_result = build_request_url({
 		custom_url: options.url,
 		doc: options.doc,
-		doc_origin: effective_doc_origin,
-		api_version: effective_api_version,
+		doc_origin: doc_origin_resolution.doc_origin,
+		api_version: doc_origin_resolution.api_version,
 		cmd: payload_result.cmd,
 		method: options.method,
 	});
@@ -549,7 +554,7 @@ frappe.call = function (opts) {
 	var realtime_opts = $.extend({}, options, {
 		freeze: resolved_params.freeze,
 		freeze_message: resolved_params.freeze_message,
-		api_version: effective_api_version,
+		api_version: doc_origin_resolution.api_version,
 		args: payload_result.payload,
 	});
 	var success_handler = create_success_handler({
@@ -572,7 +577,7 @@ frappe.call = function (opts) {
 		error_handlers: options.error_handlers || {},
 		async: options.async,
 		silent: options.silent,
-		api_version: effective_api_version,
+		api_version: doc_origin_resolution.api_version,
 		url: url_result.url,
 		cache: options.cache,
 	});

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -174,7 +174,8 @@ frappe.call._helpers = {
 				},
 			};
 		}
-		return { opts: first_arg };
+		
+		return { opts: { ...first_arg } };
 	},
 
 	/**
@@ -330,7 +331,7 @@ frappe.call._helpers = {
 			base_payload = {
 				docs,
 				method,
-				args,
+				args: { ...args },
 			};
 			
 			// Add cmd to payload if custom URL

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -78,19 +78,20 @@ frappe.call = function (opts) {
 	}
 
 	/**
-	 * Derives UI-related options from various sources.
-	 * @param {{ freeze: boolean, freeze_message: string, args_freeze: boolean, args_freeze_message: string }} config
+	 * Resolves parameter precedence between top-level opts and args.
+	 * Top-level options take precedence over args options.
+	 * @param {{ opts: { freeze: boolean, freeze_message: string }, args: { freeze: boolean, freeze_message: string } }} config
 	 * @returns {{ freeze: boolean, freeze_message: string }}
 	 */
-	function derive_ui_options(config) {
-		var { freeze, freeze_message, args_freeze, args_freeze_message } = config;
+	function resolve_parameter_precedence(config) {
+		var { opts, args } = config;
 
-		var derived_freeze = freeze || args_freeze || false;
-		var derived_freeze_message = freeze_message || args_freeze_message || "";
+		var resolved_freeze = opts.freeze || args.freeze || false;
+		var resolved_freeze_message = opts.freeze_message || args.freeze_message || "";
 
 		return {
-			freeze: derived_freeze,
-			freeze_message: derived_freeze_message,
+			freeze: resolved_freeze,
+			freeze_message: resolved_freeze_message,
 		};
 	}
 
@@ -567,13 +568,11 @@ frappe.call = function (opts) {
 		throw doc_origin_validation.error;
 	}
 
-	// Derive UI options (freeze, spinner settings)
+	// Resolve parameter precedence (freeze, spinner settings)
 	var input_args = options.args || {};
-	var ui_options = derive_ui_options({
-		freeze: options.freeze,
-		freeze_message: options.freeze_message,
-		args_freeze: input_args.freeze,
-		args_freeze_message: input_args.freeze_message,
+	var resolved_params = resolve_parameter_precedence({
+		opts: { freeze: options.freeze, freeze_message: options.freeze_message },
+		args: { freeze: input_args.freeze, freeze_message: input_args.freeze_message },
 	});
 
 	// Resolve effective doc_origin and api_version
@@ -628,8 +627,8 @@ frappe.call = function (opts) {
 
 	// Create success handler
 	var realtime_opts = $.extend({}, options, {
-		freeze: ui_options.freeze,
-		freeze_message: ui_options.freeze_message,
+		freeze: resolved_params.freeze,
+		freeze_message: resolved_params.freeze_message,
 		api_version: effective_api_version,
 		args: final_payload,
 	});
@@ -649,8 +648,8 @@ frappe.call = function (opts) {
 		error_callback: options.error,
 		always_callback: options.always,
 		btn: options.btn,
-		freeze: ui_options.freeze,
-		freeze_message: ui_options.freeze_message,
+		freeze: resolved_params.freeze,
+		freeze_message: resolved_params.freeze_message,
 		headers: options.headers,
 		error_handlers: options.error_handlers,
 		async: options.async,

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -98,24 +98,17 @@ frappe.call = function (opts) {
 			return;
 		}
 
-		// For API v1 or undefined: only 'memory' (run_doc_method) is available
-		// If doc_origin is specified as 'database', warn and ignore
-		if (!opts.api_version || opts.api_version === "v1") {
-			if (opts.doc_origin === "database") {
-				console.warn(
-					"frappe.call: doc_origin='database' is ignored for API v1. " +
-					"Database document origin is only available in API v2."
-				);
-			}
-			opts.doc_origin = "memory";
-			return;
+		// Both API v1 and v2 support both origins:
+		// - 'memory' (default): Uses run_doc_method, sends full in-memory document to server
+		// - 'database': Server loads document from DB (lighter payload)
+		//
+		// For undefined api_version: default to 'memory' for backward compatibility
+		// When api_version is not specified and doc_origin='database' is requested,
+		// we default to v1 for the database origin endpoint
+		if (opts.doc_origin === "database" && !opts.api_version) {
+			opts.api_version = "v1";
 		}
 
-		// For API v2: default to 'memory' (run_doc_method) for backward compatibility
-		// with original behavior. Use doc_origin='database' to opt-in to RESTful endpoint.
-		// 
-		// 'memory' (default): Uses run_doc_method, sends full in-memory document to server
-		// 'database': Uses RESTful endpoint, server loads document from DB (lighter payload)
 		opts.doc_origin = opts.doc_origin || "memory";
 	}
 
@@ -132,8 +125,18 @@ frappe.call = function (opts) {
 					method: opts.method,
 					args: opts.args,
 				});
+			} else if (opts.doc_origin === "database") {
+				// Database origin: server loads document from DB
+				// For v1: method is passed via run_method in form data
+				// For v2: method is in URL path, no need to add to args
+				if (opts.api_version === "v1") {
+					args.run_method = opts.method;
+				}
+				// Pass any method arguments
+				if (opts.args) {
+					$.extend(args, opts.args);
+				}
 			}
-			// For 'database' origin, no cmd is set here - URL will be built differently
 		} else if (opts.method) {
 			// Direct method call
 			args.cmd = opts.method;
@@ -168,8 +171,18 @@ frappe.call = function (opts) {
 		var method = opts.method;
 
 		validateDocumentMethodParams(doctype, name, method);
+
+		var prefix = `/api/${opts.api_version || "v1"}`;
+
+		if (opts.api_version === "v1") {
+			// v1: POST to /api/v1/resource/<doctype>/<name>/ with run_method in form data
+			return `${prefix}/resource/${encodeURIComponent(doctype)}/${encodeURIComponent(name)}/`;
+		}
 		
-		return `/api/${opts.api_version}/document/${encodeURIComponent(doctype)}/${encodeURIComponent(name)}/method/${encodeURIComponent(method)}/`;
+		if (opts.api_version === "v2") {
+			// v2: method is part of the URL path
+			return `${prefix}/document/${encodeURIComponent(doctype)}/${encodeURIComponent(name)}/method/${encodeURIComponent(method)}/`;
+		}
 	}
 
 	function validateDocumentMethodParams(doctype, name, method) {

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -56,12 +56,11 @@ frappe.call = function (opts) {
 
 	/**
 	 * Handles legacy calling convention: frappe.call(method, args, callback, headers)
-	 * @param {IArguments} caller_arguments - The arguments object from frappe.call
+	 * @param {string|object} first_arg - The first argument passed to frappe.call
+	 * @param {IArguments} caller_arguments - The full arguments object from frappe.call
 	 * @returns {{ opts: object }}
 	 */
-	function parse_caller_arguments(caller_arguments) {
-		var [ first_arg ] = caller_arguments;
-
+	function parse_caller_arguments(first_arg, caller_arguments) {
 		if (typeof first_arg === "string") {
 			var [ method, args, callback, headers ] = caller_arguments;
 
@@ -80,7 +79,7 @@ frappe.call = function (opts) {
 	/**
 	 * Resolves parameter precedence between top-level opts and args.
 	 * Top-level options take precedence over args options.
-	 * @param {{ opts: { freeze: boolean, freeze_message: string }, args: { freeze: boolean, freeze_message: string } }} config
+	 * @param {{ opts: object, args: object }} config
 	 * @returns {{ freeze: boolean, freeze_message: string }}
 	 */
 	function resolve_parameter_precedence(config) {
@@ -575,7 +574,7 @@ frappe.call = function (opts) {
 	check_connectivity();
 
 	// Parse caller arguments (handle legacy calling convention)
-	var parsed = parse_caller_arguments(arguments);
+	var parsed = parse_caller_arguments(opts, arguments);
 	var options = parsed.opts;
 
 	// Validate API version and doc_origin
@@ -600,7 +599,7 @@ frappe.call = function (opts) {
 		throw call_type_validation.error;
 	}
 
-	// Resolve parameter precedence (freeze, spinner settings)
+	// Resolve parameters precedence
 	var input_args = options.args || {};
 	var resolved_params = resolve_parameter_precedence({
 		opts: { freeze: options.freeze, freeze_message: options.freeze_message },

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -56,19 +56,21 @@ frappe.call = function (opts) {
 
 	/**
 	 * Handles legacy calling convention: frappe.call(method, args, callback, headers)
-	 * @param {string|object} first_arg - First argument passed to frappe.call
 	 * @param {IArguments} caller_arguments - The arguments object from frappe.call
 	 * @returns {{ opts: object }}
 	 */
-	function parse_caller_arguments(first_arg, caller_arguments) {
-		// TODO: This could be simplified by handling just the arguments object directly passed from frappe.call
+	function parse_caller_arguments(caller_arguments) {
+		var [ first_arg ] = caller_arguments;
+
 		if (typeof first_arg === "string") {
+			var [ method, args, callback, headers ] = caller_arguments;
+
 			return {
 				opts: {
-					method: caller_arguments[0],
-					args: caller_arguments[1],
-					callback: caller_arguments[2],
-					headers: caller_arguments[3],
+					method,
+					args,
+					callback,
+					headers,
 				},
 			};
 		}
@@ -551,7 +553,7 @@ frappe.call = function (opts) {
 	check_connectivity();
 
 	// Parse caller arguments (handle legacy calling convention)
-	var parsed = parse_caller_arguments(opts, arguments);
+	var parsed = parse_caller_arguments(arguments);
 	var options = parsed.opts;
 
 	// Validate API version and doc_origin

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -29,17 +29,132 @@ frappe.xcall = function (method, params, type, opts = {}) {
 
 // generic server call (call page, object)
 frappe.call = function (opts) {
-	// ============================================================================
-	// PURE HELPER FUNCTIONS
-	// ============================================================================
-	
+	const helpers = frappe.call._helpers;
+
+	// Check connectivity (side effect, but informational)
+	helpers.check_connectivity();
+
+	// Parse caller arguments (handle legacy calling convention)
+	var parsed = helpers.parse_caller_arguments(opts, arguments);
+	var options = parsed.opts;
+
+	// Validate API version and doc_origin
+	var api_validation = helpers.validate_api_version(options.api_version);
+	if (!api_validation.is_valid) {
+		throw api_validation.error;
+	}
+
+	var doc_origin_validation = helpers.validate_doc_origin(options.doc_origin);
+	if (!doc_origin_validation.is_valid) {
+		throw doc_origin_validation.error;
+	}
+
+	// Validate call type ONLY if no custom URL is provided
+	// When using custom URL, method/doc/page are optional since URL is already specified
+	if (!options.url) {
+		var call_type_validation = helpers.validate_call_type({
+			method: options.method,
+			doc: options.doc,
+			module: options.module,
+			page: options.page,
+		});
+		if (!call_type_validation.is_valid) {
+			throw call_type_validation.error;
+		}
+	}
+
+	// Resolve parameters precedence
+	var input_args = options.args || {};
+	var resolved_params = helpers.resolve_parameter_precedence({
+		opts: { freeze: options.freeze, freeze_message: options.freeze_message },
+		args: { freeze: input_args.freeze, freeze_message: input_args.freeze_message },
+	});
+
+	// Resolve effective doc_origin and api_version
+	var doc_origin_resolution = helpers.resolve_doc_origin_and_api_version({
+		api_version: options.api_version,
+		doc_origin: options.doc_origin,
+		has_doc: !!options.doc,
+	});
+
+	// Build server payload
+	var payload_result = helpers.build_server_payload({
+		method: options.method,
+		args: input_args,
+		doc: options.doc,
+		doc_origin: doc_origin_resolution.doc_origin,
+		api_version: doc_origin_resolution.api_version,
+		module: options.module,
+		page: options.page,
+		has_custom_url: !!options.url,
+	});
+
+	// Build request URL
+	var url_result = helpers.build_request_url({
+		custom_url: options.url,
+		doc: options.doc,
+		doc_origin: doc_origin_resolution.doc_origin,
+		api_version: doc_origin_resolution.api_version,
+		cmd: payload_result.cmd,
+		method: options.method,
+	});
+
+	if (url_result.error) {
+		throw url_result.error;
+	}
+
+	// Check debounce status
+	var debounce_check = helpers.check_debounce_status({
+		debounce: options.debounce,
+		cmd: payload_result.cmd,
+		payload: payload_result.payload,
+	});
+
+	if (debounce_check.should_skip) {
+		return Promise.resolve();
+	}
+
+	// Create success handler
+	var realtime_opts = $.extend({}, options, {
+		freeze: resolved_params.freeze,
+		freeze_message: resolved_params.freeze_message,
+		api_version: doc_origin_resolution.api_version,
+		args: payload_result.payload,
+	});
+	var success_handler = helpers.create_success_handler({
+		callback: options.callback,
+		queued: options.queued,
+		realtime_opts: realtime_opts,
+	});
+
+	// Dispatch request
+	return frappe.request.call({
+		type: options.type || "POST",
+		args: payload_result.payload,
+		success: success_handler,
+		error: options.error,
+		always: options.always,
+		btn: options.btn,
+		freeze: resolved_params.freeze,
+		freeze_message: resolved_params.freeze_message,
+		headers: options.headers || {},
+		error_handlers: options.error_handlers || {},
+		async: options.async,
+		silent: options.silent,
+		api_version: doc_origin_resolution.api_version,
+		url: url_result.url,
+		cache: options.cache,
+	});
+};
+
+frappe.call._helpers = {
 	// Methods here are defined here to keep them encapsulated, without exposing them globally
 
 	/**
 	 * Shows connectivity warning if offline.
 	 * @returns {{ is_online: boolean }}
 	 */
-	function check_connectivity() {
+	check_connectivity() {
 		var is_online = frappe.is_online();
 		if (!is_online) {
 			frappe.show_alert(
@@ -52,7 +167,7 @@ frappe.call = function (opts) {
 			);
 		}
 		return { is_online: is_online };
-	}
+	},
 
 	/**
 	 * Handles legacy calling convention: frappe.call(method, args, callback, headers)
@@ -60,7 +175,7 @@ frappe.call = function (opts) {
 	 * @param {IArguments} caller_arguments - The full arguments object from frappe.call
 	 * @returns {{ opts: object }}
 	 */
-	function parse_caller_arguments(first_arg, caller_arguments) {
+	parse_caller_arguments(first_arg, caller_arguments) {
 		if (typeof first_arg === "string") {
 			var [ method, args, callback, headers ] = caller_arguments;
 
@@ -74,7 +189,7 @@ frappe.call = function (opts) {
 			};
 		}
 		return { opts: first_arg };
-	}
+	},
 
 	/**
 	 * Resolves parameter precedence between top-level opts and args.
@@ -82,7 +197,7 @@ frappe.call = function (opts) {
 	 * @param {{ opts: object, args: object }} config
 	 * @returns {{ freeze: boolean, freeze_message: string|undefined }}
 	 */
-	function resolve_parameter_precedence(config) {
+	resolve_parameter_precedence(config) {
 		var { opts, args } = config;
 
 		var resolved_freeze = opts.freeze || args.freeze || false;
@@ -92,14 +207,14 @@ frappe.call = function (opts) {
 			freeze: resolved_freeze,
 			freeze_message: resolved_freeze_message,
 		};
-	}
+	},
 
 	/**
 	 * Validates API version parameter.
 	 * @param {string|undefined} api_version
 	 * @returns {{ is_valid: boolean, error: Error|null }}
 	 */
-	function validate_api_version(api_version) {
+	validate_api_version(api_version) {
 		var valid_versions = ["v1", "v2"];
 		// No api_version is also valid (defaults to legacy behavior)
 		if (api_version && !valid_versions.includes(api_version)) {
@@ -112,14 +227,14 @@ frappe.call = function (opts) {
 			};
 		}
 		return { is_valid: true, error: null };
-	}
+	},
 
 	/**
 	 * Validates doc_origin parameter.
 	 * @param {string|undefined} doc_origin
 	 * @returns {{ is_valid: boolean, error: Error|null }}
 	 */
-	function validate_doc_origin(doc_origin) {
+	validate_doc_origin(doc_origin) {
 		var valid_origins = ["memory", "database"];
 		if (doc_origin && !valid_origins.includes(doc_origin)) {
 			console.error("frappe.call unsupported doc_origin");
@@ -131,7 +246,7 @@ frappe.call = function (opts) {
 			};
 		}
 		return { is_valid: true, error: null };
-	}
+	},
 
 	/**
 	 * Validates that at least one valid call type is specified.
@@ -139,7 +254,7 @@ frappe.call = function (opts) {
 	 * @param {{ method: string|undefined, doc: object|undefined, module: string|undefined, page: string|undefined }} config
 	 * @returns {{ is_valid: boolean, error: Error|null }}
 	 */
-	function validate_call_type(config) {
+	validate_call_type(config) {
 		var { method, doc, module, page } = config;
 		
 		var has_page_call = module != null && page != null;
@@ -163,7 +278,7 @@ frappe.call = function (opts) {
 				`frappe.call: invalid call configuration. Must provide one of: ${missing_options.join(", ")}`
 			),
 		};
-	}
+	},
 
 	/**
 	 * Resolves the effective doc_origin and api_version based on provided options.
@@ -174,7 +289,7 @@ frappe.call = function (opts) {
 	 * @param {{ api_version: string|undefined, doc_origin: string|undefined, has_doc: boolean }} config
 	 * @returns {{ api_version: string|undefined, doc_origin: string|undefined }}
 	 */
-	function resolve_doc_origin_and_api_version(config) {
+	resolve_doc_origin_and_api_version(config) {
 		var { api_version, doc_origin, has_doc } = config;
 
 		// doc_origin is only relevant when doc is provided
@@ -198,7 +313,7 @@ frappe.call = function (opts) {
 			api_version: resolved_api_version,
 			doc_origin: resolved_doc_origin,
 		};
-	}
+	},
 
 	/**
 	 * Builds and prepares the server payload
@@ -206,7 +321,7 @@ frappe.call = function (opts) {
 	 * @param {{ method: string, args: object, doc: object|undefined, doc_origin: string|undefined, api_version: string|undefined, module: string|undefined, page: string|undefined, has_custom_url: boolean }} config
 	 * @returns {{ payload: object, cmd: string|undefined }}
 	 */
-	function build_server_payload(config) {
+	build_server_payload(config) {
 		var { method, args, doc, doc_origin, api_version, module, page, has_custom_url } = config;
 
 		var base_payload;
@@ -271,14 +386,14 @@ frappe.call = function (opts) {
 			payload: base_payload,
 			cmd: cmd_value,
 		};
-	}
+	},
 
 	/**
 	 * Validates required parameters for database origin document method calls.
 	 * @param {{ doctype: string|undefined, name: string|undefined, method: string|undefined }} config
 	 * @returns {{ is_valid: boolean, error: Error|null }}
 	 */
-	function validate_document_method_params(config) {
+	validate_document_method_params(config) {
 		var { doctype, name, method } = config;
 
 		var missing = [
@@ -297,7 +412,7 @@ frappe.call = function (opts) {
 			};
 		}
 		return { is_valid: true, error: null };
-	}
+	},
 
 	/**
 	 * Builds URL for database origin document method calls.
@@ -307,7 +422,7 @@ frappe.call = function (opts) {
 	 * @param {{ api_version: string, doctype: string, name: string, method?: string }} config
 	 * @returns {{ url: string }}
 	 */
-	function build_doc_db_origin_url(config) {
+	build_doc_db_origin_url(config) {
 		var { api_version, doctype, name, method } = config;
 
 		var identifier = `${encodeURIComponent(doctype)}/${encodeURIComponent(name)}`;
@@ -332,14 +447,14 @@ frappe.call = function (opts) {
 		if (method_name) url += `/${method_name}`;
 		
 		return { url };
-	}
+	},
 
 	/**
 	 * Builds URL for standard method calls.
 	 * @param {{ api_version: string|undefined, cmd: string }} config
 	 * @returns {{ url: string }}
 	 */
-	function build_standard_method_url(config) {
+	build_standard_method_url(config) {
 		var { api_version, cmd } = config;
 
 		var prefix = "/api/method";
@@ -348,25 +463,25 @@ frappe.call = function (opts) {
 			prefix = `/api/${api_version}/method`;
 		}
 		return { url: `${prefix}/${cmd}` };
-	}
+	},
 
 	/**
 	 * Applies Cordova host prefix to URL.
 	 * @param {string} url
 	 * @returns {{ url: string }}
 	 */
-	function apply_cordova_host(url) {
+	apply_cordova_host(url) {
 		var host = frappe.request.url;
 		host = host.slice(0, host.length - 1);
 		return { url: host + url };
-	}
+	},
 
 	/**
 	 * Builds the complete request URL if needed.
 	 * @param {{ custom_url: string|undefined, doc: object|undefined, doc_origin: string|undefined, api_version: string|undefined, cmd: string|undefined, method: string|undefined }} config
 	 * @returns {{ url: string, error: Error|null }}
 	 */
-	function build_request_url(config) {
+	build_request_url(config) {
 		var { custom_url, doc, doc_origin, api_version, cmd, method } = config;
 
 		// Use custom URL if provided
@@ -379,7 +494,7 @@ frappe.call = function (opts) {
 		// Database origin document method URL
 		if (doc && doc_origin === "database") {
 			// Validate required params for database origin
-			var validation = validate_document_method_params({
+			var validation = this.validate_document_method_params({
 				doctype: doc.doctype,
 				name: doc.name,
 				method: method,
@@ -388,7 +503,7 @@ frappe.call = function (opts) {
 				return { url: null, error: validation.error };
 			}
 
-			var doc_url = build_doc_db_origin_url({
+			var doc_url = this.build_doc_db_origin_url({
 				api_version: api_version,
 				doctype: doc.doctype,
 				name: doc.name,
@@ -397,7 +512,7 @@ frappe.call = function (opts) {
 			url = doc_url.url;
 		} else {
 			// Standard method URL
-			var std_url = build_standard_method_url({
+			var std_url = this.build_standard_method_url({
 				api_version: api_version,
 				cmd: cmd,
 			});
@@ -406,12 +521,12 @@ frappe.call = function (opts) {
 
 		// Apply Cordova host if needed
 		if (window.cordova) {
-			var cordova_url = apply_cordova_host(url);
+			var cordova_url = this.apply_cordova_host(url);
 			url = cordova_url.url;
 		}
 
 		return { url: url, error: null };
-	}
+	},
 
 	/**
 	 * Creates the success callback handler.
@@ -420,7 +535,7 @@ frappe.call = function (opts) {
 	 * @param {{ callback: function|undefined, queued: function|undefined, realtime_opts: object }} config
 	 * @returns {function}
 	 */
-	function create_success_handler(config) {
+	create_success_handler(config) {
 		var { callback, queued, realtime_opts } = config;
 
 		const success_handler = (data, response_text) => {
@@ -440,14 +555,14 @@ frappe.call = function (opts) {
 			}
 		};
 		return success_handler;
-	}
+	},
 
 	/**
 	 * Checks if request should be debounced (skipped due to recent identical request).
 	 * @param {{ debounce: number|undefined, cmd: string, payload: object }} config
 	 * @returns {{ should_skip: boolean }}
 	 */
-	function check_debounce_status(config) {
+	check_debounce_status(config) {
 		var { debounce, cmd, payload } = config;
 
 		if (!debounce) {
@@ -459,128 +574,7 @@ frappe.call = function (opts) {
 		// TODO: Check if it is correct implementation to skip the request when not fresh
 		var is_fresh = frappe.request.is_fresh(args_with_cmd, debounce);
 		return { should_skip: is_fresh };
-	}
-
-	// ============================================================================
-	// MAIN EXECUTION FLOW
-	// ============================================================================
-	
-	// Perform execution through unidirectionally and clearly defined steps
-
-	// Check connectivity (side effect, but informational)
-	check_connectivity();
-
-	// Parse caller arguments (handle legacy calling convention)
-	var parsed = parse_caller_arguments(opts, arguments);
-	var options = parsed.opts;
-
-	// Validate API version and doc_origin
-	var api_validation = validate_api_version(options.api_version);
-	if (!api_validation.is_valid) {
-		throw api_validation.error;
-	}
-
-	var doc_origin_validation = validate_doc_origin(options.doc_origin);
-	if (!doc_origin_validation.is_valid) {
-		throw doc_origin_validation.error;
-	}
-
-	// Validate call type ONLY if no custom URL is provided
-	// When using custom URL, method/doc/page are optional since URL is already specified
-	if (!options.url) {
-		var call_type_validation = validate_call_type({
-			method: options.method,
-			doc: options.doc,
-			module: options.module,
-			page: options.page,
-		});
-		if (!call_type_validation.is_valid) {
-			throw call_type_validation.error;
-		}
-	}
-
-	// Resolve parameters precedence
-	var input_args = options.args || {};
-	var resolved_params = resolve_parameter_precedence({
-		opts: { freeze: options.freeze, freeze_message: options.freeze_message },
-		args: { freeze: input_args.freeze, freeze_message: input_args.freeze_message },
-	});
-
-	// Resolve effective doc_origin and api_version
-	var doc_origin_resolution = resolve_doc_origin_and_api_version({
-		api_version: options.api_version,
-		doc_origin: options.doc_origin,
-		has_doc: !!options.doc,
-	});
-
-	// Build server payload
-	var payload_result = build_server_payload({
-		method: options.method,
-		args: input_args,
-		doc: options.doc,
-		doc_origin: doc_origin_resolution.doc_origin,
-		api_version: doc_origin_resolution.api_version,
-		module: options.module,
-		page: options.page,
-		has_custom_url: !!options.url,
-	});
-
-	// Build request URL
-	var url_result = build_request_url({
-		custom_url: options.url,
-		doc: options.doc,
-		doc_origin: doc_origin_resolution.doc_origin,
-		api_version: doc_origin_resolution.api_version,
-		cmd: payload_result.cmd,
-		method: options.method,
-	});
-
-	if (url_result.error) {
-		throw url_result.error;
-	}
-
-	// Check debounce status
-	var debounce_check = check_debounce_status({
-		debounce: options.debounce,
-		cmd: payload_result.cmd,
-		payload: payload_result.payload,
-	});
-
-	if (debounce_check.should_skip) {
-		return Promise.resolve();
-	}
-
-	// Create success handler
-	var realtime_opts = $.extend({}, options, {
-		freeze: resolved_params.freeze,
-		freeze_message: resolved_params.freeze_message,
-		api_version: doc_origin_resolution.api_version,
-		args: payload_result.payload,
-	});
-	var success_handler = create_success_handler({
-		callback: options.callback,
-		queued: options.queued,
-		realtime_opts: realtime_opts,
-	});
-
-	// Dispatch request
-	return frappe.request.call({
-		type: options.type || "POST",
-		args: payload_result.payload,
-		success: success_handler,
-		error: options.error,
-		always: options.always,
-		btn: options.btn,
-		freeze: resolved_params.freeze,
-		freeze_message: resolved_params.freeze_message,
-		headers: options.headers || {},
-		error_handlers: options.error_handlers || {},
-		async: options.async,
-		silent: options.silent,
-		api_version: doc_origin_resolution.api_version,
-		url: url_result.url,
-		cache: options.cache,
-	});
+	},
 };
 
 frappe.request.call = function (opts) {

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -59,8 +59,8 @@ frappe.call = function (opts) {
 		args: { freeze: options.args?.freeze, freeze_message: options.args?.freeze_message },
 	});
 
-	// Resolve effective doc_origin and api_version
-	var doc_origin_resolution = helpers.resolve_doc_origin_and_api_version({
+	// Normalize effective doc_origin and api_version
+	var doc_call_context = helpers.normalize_doc_call_context({
 		api_version: options.api_version,
 		doc_origin: options.doc_origin,
 		has_doc: !!options.doc,
@@ -71,8 +71,8 @@ frappe.call = function (opts) {
 		method: options.method,
 		args: options.args,
 		doc: options.doc,
-		doc_origin: doc_origin_resolution.doc_origin,
-		api_version: doc_origin_resolution.api_version,
+		doc_origin: doc_call_context.doc_origin,
+		api_version: doc_call_context.api_version,
 		module: options.module,
 		page: options.page,
 		has_custom_url: !!options.url,
@@ -82,8 +82,8 @@ frappe.call = function (opts) {
 	var url_result = helpers.build_request_url({
 		custom_url: options.url,
 		doc: options.doc,
-		doc_origin: doc_origin_resolution.doc_origin,
-		api_version: doc_origin_resolution.api_version,
+		doc_origin: doc_call_context.doc_origin,
+		api_version: doc_call_context.api_version,
 		cmd: payload_result.cmd,
 		method: options.method,
 	});
@@ -103,7 +103,7 @@ frappe.call = function (opts) {
 	var realtime_opts = $.extend({}, options, {
 		freeze: resolved_params.freeze,
 		freeze_message: resolved_params.freeze_message,
-		api_version: doc_origin_resolution.api_version,
+		api_version: doc_call_context.api_version,
 		args: payload_result.payload,
 	});
 	var success_wrapper = helpers.route_success_callback({
@@ -126,7 +126,7 @@ frappe.call = function (opts) {
 		error_handlers: options.error_handlers || {},
 		async: options.async,
 		silent: options.silent,
-		api_version: doc_origin_resolution.api_version,
+		api_version: doc_call_context.api_version,
 		url: url_result.url,
 		cache: options.cache,
 	});
@@ -266,7 +266,7 @@ frappe.call._helpers = {
 	},
 
 	/**
-	 * Resolves the effective doc_origin and api_version based on provided options.
+	 * Normalizes doc_origin and api_version by applying defaults based on provided options.
 	 * Both API v1 and v2 support both origins:
 	 * - 'memory' (default): Uses run_doc_method, sends full in-memory document to server
 	 * - 'database': Server loads document from DB (lighter payload)
@@ -274,7 +274,7 @@ frappe.call._helpers = {
 	 * @param {{ api_version: string|undefined, doc_origin: string|undefined, has_doc: boolean }} config
 	 * @returns {{ api_version: string|undefined, doc_origin: string|undefined }}
 	 */
-	resolve_doc_origin_and_api_version(config) {
+	normalize_doc_call_context(config) {
 		var { api_version, doc_origin, has_doc } = config;
 
 		// doc_origin is only relevant when doc is provided

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -29,12 +29,19 @@ frappe.xcall = function (method, params, type, opts = {}) {
 
 // generic server call (call page, object)
 frappe.call = function (opts) {
-	// Helpers separates responsibilities for better readability and maintainability
-	// Keep helpers inside frappe.call to avoid polluting global namespace
-	// Below this helper functions, the main execution flow is outlined
+	// ============================================================================
+	// PURE HELPER FUNCTIONS
+	// ============================================================================
+	
+	// Methods here are defined here to keep them encapsulated, without exposing them globally
 
-	function checkConnectivity() {
-		if (!frappe.is_online()) {
+	/**
+	 * Shows connectivity warning if offline.
+	 * @returns {{ is_online: boolean }}
+	 */
+	function check_connectivity() {
+		var is_online = frappe.is_online();
+		if (!is_online) {
 			frappe.show_alert(
 				{
 					indicator: "orange",
@@ -44,148 +51,250 @@ frappe.call = function (opts) {
 				3
 			);
 		}
+		return { is_online: is_online };
 	}
 
-	function normalizeArguments(originalOpts, originalArguments) {
-		// Handle legacy calling convention: frappe.call(method, args, callback, headers)
-		if (typeof originalOpts === "string") {
+	/**
+	 * Handles legacy calling convention: frappe.call(method, args, callback, headers)
+	 * @param {string|object} first_arg - First argument passed to frappe.call
+	 * @param {IArguments} caller_arguments - The arguments object from frappe.call
+	 * @returns {{ opts: object }}
+	 */
+	function parse_caller_arguments(first_arg, caller_arguments) {
+		// TODO: This could be simplified by handling just the arguments object directly passed from frappe.call
+		if (typeof first_arg === "string") {
 			return {
-				method: originalArguments[0],
-				args: originalArguments[1],
-				callback: originalArguments[2],
-				headers: originalArguments[3],
+				opts: {
+					method: caller_arguments[0],
+					args: caller_arguments[1],
+					callback: caller_arguments[2],
+					headers: caller_arguments[3],
+				},
 			};
 		}
-		return originalOpts;
+		return { opts: first_arg };
 	}
 
-	function normalizeOptions(opts) {
-		var args = $.extend({}, opts.args);
+	/**
+	 * Derives UI-related options from various sources.
+	 * @param {{ freeze: boolean, freeze_message: string, args_freeze: boolean, args_freeze_message: string }} config
+	 * @returns {{ freeze: boolean, freeze_message: string }}
+	 */
+	function derive_ui_options(config) {
+		var { freeze, freeze_message, args_freeze, args_freeze_message } = config;
 
-		// quiet mode implies no_spinner
-		if (opts.quiet) {
-			opts.no_spinner = true;
-		}
+		var derived_freeze = freeze || args_freeze || false;
+		var derived_freeze_message = freeze_message || args_freeze_message || "";
 
-		// freeze can come from args
-		if (args.freeze) {
-			opts.freeze = opts.freeze || args.freeze;
-			opts.freeze_message = opts.freeze_message || args.freeze_message;
-		}
-
-		return args;
+		return {
+			freeze: derived_freeze,
+			freeze_message: derived_freeze_message,
+		};
 	}
 
-	function validateApiVersion(api_version) {
-		const valid_versions = ["v1", "v2"];
+	/**
+	 * Validates API version parameter.
+	 * @param {string|undefined} api_version
+	 * @returns {{ is_valid: boolean, error: Error|null }}
+	 */
+	function validate_api_version(api_version) {
+		var valid_versions = ["v1", "v2"];
+		// No api_version is also valid (defaults to legacy behavior)
 		if (api_version && !valid_versions.includes(api_version)) {
 			console.error("frappe.call unsupported api_version");
-			throw new Error(`frappe.call: api_version '${api_version}' is not supported. Use one of: ${valid_versions.join(", ")}`);
+			return {
+				is_valid: false,
+				error: new Error(
+					`frappe.call: api_version '${api_version}' is not supported. Use one of: ${valid_versions.join(", ")}`
+				),
+			};
 		}
+		return { is_valid: true, error: null };
 	}
 
-	function validateDocOrigin(doc_origin) {
-		const valid_origins = ["memory", "database"];
+	/**
+	 * Validates doc_origin parameter.
+	 * @param {string|undefined} doc_origin
+	 * @returns {{ is_valid: boolean, error: Error|null }}
+	 */
+	function validate_doc_origin(doc_origin) {
+		var valid_origins = ["memory", "database"];
 		if (doc_origin && !valid_origins.includes(doc_origin)) {
 			console.error("frappe.call unsupported doc_origin");
-			throw new Error(`frappe.call: doc_origin '${doc_origin}' is not supported. Use one of: ${valid_origins.join(", ")}`);
+			return {
+				is_valid: false,
+				error: new Error(
+					`frappe.call: doc_origin '${doc_origin}' is not supported. Use one of: ${valid_origins.join(", ")}`
+				),
+			};
 		}
+		return { is_valid: true, error: null };
 	}
 
-	function resolveDocOrigin(opts) {
-		// doc_origin is only relevant when opts.doc is provided
-		if (!opts.doc) {
-			return;
+	/**
+	 * Resolves the effective doc_origin and api_version based on provided options.
+	 * Both API v1 and v2 support both origins:
+	 * - 'memory' (default): Uses run_doc_method, sends full in-memory document to server
+	 * - 'database': Server loads document from DB (lighter payload)
+	 *
+	 * @param {{ api_version: string|undefined, doc_origin: string|undefined, has_doc: boolean }} config
+	 * @returns {{ api_version: string|undefined, doc_origin: string|undefined }}
+	 */
+	function resolve_doc_origin_and_api_version(config) {
+		var { api_version, doc_origin, has_doc } = config;
+
+		// doc_origin is only relevant when doc is provided
+		if (!has_doc) {
+			return {
+				api_version: api_version,
+				doc_origin: undefined,
+			};
 		}
 
-		// Both API v1 and v2 support both origins:
-		// - 'memory' (default): Uses run_doc_method, sends full in-memory document to server
-		// - 'database': Server loads document from DB (lighter payload)
-		//
-		// For undefined api_version: default to 'memory' for backward compatibility
+		var resolved_api_version = api_version;
+		var resolved_doc_origin = doc_origin || "memory";
+
 		// When api_version is not specified and doc_origin='database' is requested,
 		// we default to v1 for the database origin endpoint
-		if (opts.doc_origin === "database" && !opts.api_version) {
-			opts.api_version = "v1";
+		if (resolved_doc_origin === "database" && !resolved_api_version) {
+			resolved_api_version = "v1";
 		}
 
-		opts.doc_origin = opts.doc_origin || "memory";
+		return {
+			api_version: resolved_api_version,
+			doc_origin: resolved_doc_origin,
+		};
 	}
 
-	function buildCommand(opts, args) {
-		if (opts.module && opts.page) {
-			// Page method
-			args.cmd = `${opts.module}.page.${opts.page}.${opts.page}.${opts.method}`;
-		} else if (opts.doc) {
-			if (opts.doc_origin === "memory") {
-				// Memory origin: sends full in-memory document to server via run_doc_method
-				$.extend(args, {
-					cmd: "run_doc_method",
-					docs: frappe.get_doc(opts.doc.doctype, opts.doc.name),
-					method: opts.method,
-					args: opts.args,
-				});
-			} else if (opts.doc_origin === "database") {
-				// Database origin: server loads document from DB
-				// For v1: method is passed via run_method in form data
-				// For v2: method is in URL path, no need to add to args
-				if (opts.api_version === "v1") {
-					args.run_method = opts.method;
-				}
-				// Pass any method arguments
-				if (opts.args) {
-					$.extend(args, opts.args);
-				}
-			}
-		} else if (opts.method) {
-			// Direct method call
-			args.cmd = opts.method;
-		}
+	/**
+	 * Builds the command string for page methods.
+	 * @param {{ module: string, page: string, method: string }} config
+	 * @returns {{ cmd: string }}
+	 */
+	function build_page_method_command(config) {
+		var { module, page, method } = config;
+
+		return {
+			cmd: `${module}.page.${page}.${page}.${method}`,
+		};
 	}
 
-	function buildUrl(opts, args) {
-		if (opts.url) {
-			return opts.url;
-		}
+	/**
+	 * Builds the payload for document method calls with memory origin.
+	 * Uses run_doc_method, sends full in-memory document to server.
+	 * @param {{ doctype: string, name: string, method: string, args: object }} config
+	 * @returns {{ payload: object, cmd: string }}
+	 */
+	function build_doc_memory_payload(config) {
+		var { doctype, name, method, args } = config;
 
-		var url;
-
-		if (opts.doc && opts.doc_origin === "database") {
-			// Database origin: server loads document from DB (lighter payload)
-			url = buildDocumentMethodUrl(opts);
-		} else {
-			// Memory origin: /api/method/<cmd> or /api/<version>/method/<cmd>
-			url = buildStandardMethodUrl(opts, args);
-		}
-
-		if (window.cordova) {
-			url = applyCordovaHost(url);
-		}
-
-		return url;
+		return {
+			payload: {
+				cmd: "run_doc_method",
+				docs: frappe.get_doc(doctype, name),
+				method: method,
+				args: args,
+			},
+			cmd: "run_doc_method",
+		};
 	}
 
-	function buildDocumentMethodUrl(opts) {
-		// Database origin: RESTful endpoint, server loads document from DB (lighter payload)
-		var { doctype, name } = opts.doc;
-		var method = opts.method;
+	/**
+	 * Builds the payload for document method calls with database origin.
+	 * Server loads document from DB (lighter payload).
+	 * @param {{ api_version: string, method: string, args: object }} config
+	 * @returns {{ payload: object, cmd: string|undefined }}
+	 */
+	function build_doc_database_payload(config) {
+		var { api_version, method, args } = config;
 
-		validateDocumentMethodParams(doctype, name, method);
+		var payload = {};
 
-		var prefix = `/api/${opts.api_version || "v1"}`;
-
-		if (opts.api_version === "v1") {
-			// v1: POST to /api/v1/resource/<doctype>/<name>/ with run_method in form data
-			return `${prefix}/resource/${encodeURIComponent(doctype)}/${encodeURIComponent(name)}/`;
+		// For v1: method is passed via run_method in form data
+		// For v2: method is in URL path, no need to add inside payload
+		if (api_version === "v1") {
+			payload.run_method = method;
 		}
-		
-		if (opts.api_version === "v2") {
-			// v2: method is part of the URL path
-			return `${prefix}/document/${encodeURIComponent(doctype)}/${encodeURIComponent(name)}/method/${encodeURIComponent(method)}/`;
+
+		// Pass any method arguments
+		if (args) {
+			payload = $.extend({}, args, payload);
 		}
+
+		return {
+			payload: payload,
+			cmd: undefined, // database origin doesn't use cmd in payload
+		};
 	}
 
-	function validateDocumentMethodParams(doctype, name, method) {
+	/**
+	 * Builds the server payload based on call type (page, doc memory, doc database, or direct method).
+	 * @param {{ method: string, args: object, doc: object|undefined, doc_origin: string|undefined, api_version: string|undefined, module: string|undefined, page: string|undefined }} config
+	 * @returns {{ payload: object, cmd: string|undefined }}
+	 */
+	function build_server_payload(config) {
+		var { method, args, doc, doc_origin, api_version, module, page } = config;
+
+		// Page method call
+		if (module && page) {
+			var page_cmd = build_page_method_command({
+				module: module,
+				page: page,
+				method: method,
+			});
+			var page_payload = $.extend({}, args);
+			page_payload.cmd = page_cmd.cmd;
+			return {
+				payload: page_payload,
+				cmd: page_cmd.cmd,
+			};
+		}
+
+		// Document method call with memory origin
+		if (doc && doc_origin === "memory") {
+			return build_doc_memory_payload({
+				doctype: doc.doctype,
+				name: doc.name,
+				method: method,
+				args: args,
+			});
+		}
+
+		// Document method call with database origin
+		if (doc && doc_origin === "database") {
+			return build_doc_database_payload({
+				api_version: api_version,
+				method: method,
+				args: args,
+			});
+		}
+
+		// Direct method call
+		if (method) {
+			var direct_payload = $.extend({}, args);
+			direct_payload.cmd = method;
+			return {
+				payload: direct_payload,
+				cmd: method,
+			};
+		}
+
+		// No recognized call type
+		// TODO: What should happen here? Throw error?
+		return {
+			payload: $.extend({}, args),
+			cmd: undefined,
+		};
+	}
+
+	/**
+	 * Validates required parameters for database origin document method calls.
+	 * @param {{ doctype: string|undefined, name: string|undefined, method: string|undefined }} config
+	 * @returns {{ is_valid: boolean, error: Error|null }}
+	 */
+	function validate_document_method_params(config) {
+		var { doctype, name, method } = config;
+
 		var missing = [
 			!doctype && "doc.doctype",
 			!name && "doc.name",
@@ -194,99 +303,362 @@ frappe.call = function (opts) {
 
 		if (missing.length) {
 			console.error("frappe.call missing parameters");
-			throw new Error(
-				`frappe.call: missing '${missing.join("', '")}' required for database origin document method calls`
-			);
+			return {
+				is_valid: false,
+				error: new Error(
+					`frappe.call: missing '${missing.join("', '")}' required for database origin document method calls`
+				),
+			};
 		}
+		return { is_valid: true, error: null };
 	}
 
-	function buildStandardMethodUrl(opts, args) {
-		var prefix = "/api/method/";
-		if (opts.api_version) {
-			// Both 'v1' and 'v2' use same prefix for non-doc calls
-			prefix = `/api/${opts.api_version}/method/`;
-		}
-		return prefix + args.cmd;
+	/**
+	 * Builds URL for database origin document method calls (v1 API).
+	 * v1: POST to /api/v1/resource/<doctype>/<name>/ with run_method in form data
+	 * @param {{ doctype: string, name: string }} config
+	 * @returns {{ url: string }}
+	 */
+	function build_doc_database_url_v1(config) {
+		// TODO: Merge with build_doc_database_url_v2
+		var { doctype, name } = config;
+
+		var url =
+			`/api/v1/resource/` +
+			`${encodeURIComponent(doctype)}/` +
+			`${encodeURIComponent(name)}/`;
+		return { url: url };
 	}
-	
-	function applyCordovaHost(url) {
+
+	/**
+	 * Builds URL for database origin document method calls (v2 API).
+	 * v2: method is part of the URL path
+	 * @param {{ doctype: string, name: string, method: string }} config
+	 * @returns {{ url: string }}
+	 */
+	function build_doc_database_url_v2(config) {
+		// TODO: Merge with build_doc_database_url_v1
+		var { doctype, name, method } = config;
+
+		var url =
+			`/api/v2/document/` +
+			`${encodeURIComponent(doctype)}/` +
+			`${encodeURIComponent(name)}/` +
+			`method/${encodeURIComponent(method)}/`;
+		return { url: url };
+	}
+
+	/**
+	 * Builds URL for standard method calls.
+	 * @param {{ api_version: string|undefined, cmd: string }} config
+	 * @returns {{ url: string }}
+	 */
+	function build_standard_method_url(config) {
+		var { api_version, cmd } = config;
+
+		var prefix = "/api/method";
+		if (api_version) {
+			// Both 'v1' and 'v2' use same prefix for non-doc calls
+			prefix = `/api/${api_version}/method`;
+		}
+		return { url: `${prefix}/${cmd}` };
+	}
+
+	/**
+	 * Applies Cordova host prefix to URL.
+	 * @param {string} url
+	 * @returns {{ url: string }}
+	 */
+	function apply_cordova_host(url) {
 		var host = frappe.request.url;
 		host = host.slice(0, host.length - 1);
-		return host + url;
+		return { url: host + url };
 	}
 
-	function createSuccessCallback(opts) {
-		const successCallback = function (data, response_text) {
+	/**
+	 * Builds the complete request URL if needed.
+	 * @param {{ custom_url: string|undefined, doc: object|undefined, doc_origin: string|undefined, api_version: string|undefined, cmd: string|undefined, method: string|undefined }} config
+	 * @returns {{ url: string, error: Error|null }}
+	 */
+	function build_request_url(config) {
+		var { custom_url, doc, doc_origin, api_version, cmd, method } = config;
+
+		// Use custom URL if provided
+		if (custom_url) {
+			return { url: custom_url, error: null };
+		}
+
+		var url;
+
+		// Database origin document method URL
+		if (doc && doc_origin === "database") {
+			// Validate required params for database origin
+			var validation = validate_document_method_params({
+				doctype: doc.doctype,
+				name: doc.name,
+				method: method,
+			});
+			if (!validation.is_valid) {
+				return { url: null, error: validation.error };
+			}
+
+			if (api_version === "v1") {
+				var v1_url = build_doc_database_url_v1({
+					doctype: doc.doctype,
+					name: doc.name,
+				});
+				url = v1_url.url;
+			} else if (api_version === "v2") {
+				var v2_url = build_doc_database_url_v2({
+					doctype: doc.doctype,
+					name: doc.name,
+					method: method,
+				});
+				url = v2_url.url;
+			}
+		} else {
+			// Standard method URL
+			var std_url = build_standard_method_url({
+				api_version: api_version,
+				cmd: cmd,
+			});
+			url = std_url.url;
+		}
+
+		// Apply Cordova host if needed
+		if (window.cordova) {
+			var cordova_url = apply_cordova_host(url);
+			url = cordova_url.url;
+		}
+
+		return { url: url, error: null };
+	}
+
+	/**
+	 * Removes cmd from payload when URL is built (not custom).
+	 * Prevents sending cmd twice (as path and POST data).
+	 * @param {object} payload
+	 * @param {boolean} has_custom_url
+	 * @returns {{ payload: object }}
+	 */
+	function prepare_final_payload(payload, has_custom_url) {
+		// TODO: Maybe this method can be unified with build_server_payload?
+		if (has_custom_url) {
+			return { payload: payload };
+		}
+		// Create new object without cmd
+		var final_payload = $.extend({}, payload);
+		delete final_payload.cmd;
+		return { payload: final_payload };
+	}
+
+	/**
+	 * Creates the success callback handler.
+	 * For async tasks, the realtime_opts object is passed to frappe.realtime.subscribe
+	 * which requires the full set of callback and cleanup options.
+	 * @param {{ callback: function|undefined, queued: function|undefined, realtime_opts: object }} config
+	 * @returns {function}
+	 */
+	function create_success_handler(config) {
+		var { callback, queued, realtime_opts } = config;
+
+		const success_handler = (data, response_text) => {
 			// Async task: subscribe to realtime updates
 			if (data.task_id) {
-				frappe.realtime.subscribe(data.task_id, opts);
+				frappe.realtime.subscribe(data.task_id, realtime_opts);
 
-				if (opts.queued) {
-					opts.queued(data);
+				if (queued) {
+					queued(data);
 				}
-
 				return;
 			}
 
 			// Regular callback
-			if (opts.callback) {
-				return opts.callback(data, response_text);
+			if (callback) {
+				return callback(data, response_text);
 			}
 		};
-		return successCallback;
+		return success_handler;
 	}
 
-	function shouldDebounce(opts, args) {
-		return opts.debounce && frappe.request.is_fresh(args, opts.debounce);
+	/**
+	 * Checks if request should be debounced (skipped due to recent identical request).
+	 * @param {{ debounce: number|undefined, cmd: string, payload: object }} config
+	 * @returns {{ should_skip: boolean }}
+	 */
+	function check_debounce_status(config) {
+		var { debounce, cmd, payload } = config;
+
+		if (!debounce) {
+			return { should_skip: false };
+		}
+
+		// Build args object with cmd for is_fresh check
+		var args_with_cmd = $.extend({}, payload, { cmd: cmd });
+		// TODO: Check if it is correct implementation to skip the request when not fresh
+		var is_fresh = frappe.request.is_fresh(args_with_cmd, debounce);
+		return { should_skip: is_fresh };
 	}
 
-	function dispatchRequest(opts, args, url) {
-		return frappe.request.call({
-			type: opts.type || "POST",
-			args: args,
-			success: createSuccessCallback(opts),
-			error: opts.error,
-			always: opts.always,
-			btn: opts.btn,
-			freeze: opts.freeze,
-			freeze_message: opts.freeze_message,
-			headers: opts.headers || {},
-			error_handlers: opts.error_handlers || {},
-			async: opts.async,
-			silent: opts.silent,
-			api_version: opts.api_version,
-			url: url,
-			cache: opts.cache,
-		});
+	/**
+	 * Assembles the final configuration object for frappe.request.call.
+	 * @param {{
+	 *   type: string,
+	 *   payload: object,
+	 *   url: string,
+	 *   success_handler: function,
+	 *   error_callback: function|undefined,
+	 *   always_callback: function|undefined,
+	 *   btn: HTMLElement|undefined,
+	 *   freeze: boolean,
+	 *   freeze_message: string,
+	 *   headers: object,
+	 *   error_handlers: object,
+	 *   async: boolean|undefined,
+	 *   silent: boolean|undefined,
+	 *   api_version: string|undefined,
+	 *   cache: boolean|undefined
+	 * }} config
+	 * @returns {object} Configuration for frappe.request.call
+	 */
+	function assemble_request_config(config) {
+		return {
+			type: config.type || "POST",
+			args: config.payload,
+			success: config.success_handler,
+			error: config.error_callback,
+			always: config.always_callback,
+			btn: config.btn,
+			freeze: config.freeze,
+			freeze_message: config.freeze_message,
+			headers: config.headers || {},
+			error_handlers: config.error_handlers || {},
+			async: config.async,
+			silent: config.silent,
+			api_version: config.api_version,
+			url: config.url,
+			cache: config.cache,
+		};
 	}
 
-	// Main execution flow
+	// ============================================================================
+	// MAIN EXECUTION FLOW
+	// ============================================================================
+	
+	// Perform execution through unidirectionally and clearly defined steps
 
-	checkConnectivity();
+	// Check connectivity (side effect, but informational)
+	check_connectivity();
 
-	opts = normalizeArguments(opts, arguments);
+	// Parse caller arguments (handle legacy calling convention)
+	var parsed = parse_caller_arguments(opts, arguments);
+	var options = parsed.opts;
 
-	var args = normalizeOptions(opts);
-
-	validateApiVersion(opts.api_version);
-	validateDocOrigin(opts.doc_origin);
-	resolveDocOrigin(opts);
-
-	buildCommand(opts, args);
-
-	var url = buildUrl(opts, args);
-
-	if (!opts.url) {
-		// When URL is built (not provided via opts.url), cmd is embedded in URL path
-		// Remove from args to avoid sending it twice (as path and as POST data)
-		delete args.cmd;
+	// Validate API version and doc_origin
+	var api_validation = validate_api_version(options.api_version);
+	if (!api_validation.is_valid) {
+		throw api_validation.error;
 	}
 
-	if (shouldDebounce(opts, args)) {
+	var doc_origin_validation = validate_doc_origin(options.doc_origin);
+	if (!doc_origin_validation.is_valid) {
+		throw doc_origin_validation.error;
+	}
+
+	// Derive UI options (freeze, spinner settings)
+	var input_args = options.args || {};
+	var ui_options = derive_ui_options({
+		freeze: options.freeze,
+		freeze_message: options.freeze_message,
+		args_freeze: input_args.freeze,
+		args_freeze_message: input_args.freeze_message,
+	});
+
+	// Resolve effective doc_origin and api_version
+	var doc_origin_resolution = resolve_doc_origin_and_api_version({
+		api_version: options.api_version,
+		doc_origin: options.doc_origin,
+		has_doc: !!options.doc,
+	});
+
+	var effective_doc_origin = doc_origin_resolution.doc_origin;
+	var effective_api_version = doc_origin_resolution.api_version;
+
+	// Build server payload
+	var payload_result = build_server_payload({
+		method: options.method,
+		args: input_args,
+		doc: options.doc,
+		doc_origin: effective_doc_origin,
+		api_version: effective_api_version,
+		module: options.module,
+		page: options.page,
+	});
+
+	// Build request URL
+	var url_result = build_request_url({
+		custom_url: options.url,
+		doc: options.doc,
+		doc_origin: effective_doc_origin,
+		api_version: effective_api_version,
+		cmd: payload_result.cmd,
+		method: options.method,
+	});
+
+	if (url_result.error) {
+		throw url_result.error;
+	}
+
+	// Prepare final payload (remove cmd if URL was built)
+	var final_payload_result = prepare_final_payload(payload_result.payload, !!options.url);
+	var final_payload = final_payload_result.payload;
+
+	// Check debounce status
+	var debounce_check = check_debounce_status({
+		debounce: options.debounce,
+		cmd: payload_result.cmd,
+		payload: final_payload,
+	});
+
+	if (debounce_check.should_skip) {
 		return Promise.resolve();
 	}
 
-	return dispatchRequest(opts, args, url);
+	// Create success handler
+	var realtime_opts = $.extend({}, options, {
+		freeze: ui_options.freeze,
+		freeze_message: ui_options.freeze_message,
+		api_version: effective_api_version,
+		args: final_payload,
+	});
+	var success_handler = create_success_handler({
+		callback: options.callback,
+		queued: options.queued,
+		realtime_opts: realtime_opts,
+	});
+
+	// Assemble request configuration
+	// TODO: Consider passing properties directly to frappe.request.call instead of an intermediate method
+	var request_config = assemble_request_config({
+		type: options.type,
+		payload: final_payload,
+		url: url_result.url,
+		success_handler: success_handler,
+		error_callback: options.error,
+		always_callback: options.always,
+		btn: options.btn,
+		freeze: ui_options.freeze,
+		freeze_message: ui_options.freeze_message,
+		headers: options.headers,
+		error_handlers: options.error_handlers,
+		async: options.async,
+		silent: options.silent,
+		api_version: effective_api_version,
+		cache: options.cache,
+	});
+
+	// Dispatch request
+	return frappe.request.call(request_config);
 };
 
 frappe.request.call = function (opts) {

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -58,12 +58,15 @@ frappe.call = function (opts) {
 		opts.freeze_message = opts.freeze_message || args.freeze_message;
 	}
 
+	if (opts.api_version && !["v1", "v2"].includes(opts.api_version)) {
+		console.error("frappe.call unsupported api_version");
+		throw new Error(`frappe.call: api_version '${opts.api_version}' is not supported.`);
+	}
+	
 	// cmd
 	if (opts.module && opts.page) {
 		args.cmd = opts.module + ".page." + opts.page + "." + opts.page + "." + opts.method;
 	} else if (opts.doc) {
-		// API v2 (api_version='v2'): RESTful endpoint, loads document from DB (lighter payload)
-		// API v1 (default): RPC run_doc_method, sends full document to server
 		if (!opts.api_version || opts.api_version === "v1") {
 			$.extend(args, {
 				cmd: "run_doc_method",
@@ -71,9 +74,6 @@ frappe.call = function (opts) {
 				method: opts.method,
 				args: opts.args,
 			});
-		} else if (opts.api_version !== "v2") {
-			console.warn(`Unsupported api_version "${opts.api_version}" for doc method call, falling back to "v2".`);
-			opts.api_version = "v2"; // Fallback to v2
 		}
 	} else if (opts.method) {
 		args.cmd = opts.method;
@@ -95,6 +95,8 @@ frappe.call = function (opts) {
 
 	let url = opts.url;
 	if (!url) {
+		// API v2 (api_version='v2'): RESTful endpoint, loads document from DB (lighter payload)
+		// API v1 (default): RPC run_doc_method, sends full document to server
 		if (opts.doc && opts.api_version === "v2") {
 			// RESTful document method endpoint for API v2
 			const { doctype, name } = opts.doc;
@@ -111,7 +113,7 @@ frappe.call = function (opts) {
 				throw new Error(`frappe.call: missing '${missing.join("', '")}' required for API v2 document method calls`);
 			}
 
-			url = `/api/v2/document/${encodeURIComponent(doctype)}/${encodeURIComponent(name)}/method/${encodeURIComponent(method)}/`;
+			url = `/api/${opts.api_version}/document/${encodeURIComponent(doctype)}/${encodeURIComponent(name)}/method/${encodeURIComponent(method)}/`;
 		} else {
 			let prefix = "/api/method/";
 			if (opts.api_version) { // Both 'v1' and 'v2' use same prefix for non-doc calls

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -29,128 +29,251 @@ frappe.xcall = function (method, params, type, opts = {}) {
 
 // generic server call (call page, object)
 frappe.call = function (opts) {
-	if (!frappe.is_online()) {
-		frappe.show_alert(
-			{
-				indicator: "orange",
-				message: __("Connection Lost"),
-				subtitle: __("You are not connected to Internet. Retry after sometime."),
-			},
-			3
-		);
-	}
-	if (typeof arguments[0] === "string") {
-		opts = {
-			method: arguments[0],
-			args: arguments[1],
-			callback: arguments[2],
-			headers: arguments[3],
-		};
+	// Helpers separates responsibilities for better readability and maintainability
+	// Keep helpers inside frappe.call to avoid polluting global namespace
+	// Below this helper functions, the main execution flow is outlined
+
+	function checkConnectivity() {
+		if (!frappe.is_online()) {
+			frappe.show_alert(
+				{
+					indicator: "orange",
+					message: __("Connection Lost"),
+					subtitle: __("You are not connected to Internet. Retry after sometime."),
+				},
+				3
+			);
+		}
 	}
 
-	if (opts.quiet) {
-		opts.no_spinner = true;
+	function normalizeArguments(originalOpts, originalArguments) {
+		// Handle legacy calling convention: frappe.call(method, args, callback, headers)
+		if (typeof originalOpts === "string") {
+			return {
+				method: originalArguments[0],
+				args: originalArguments[1],
+				callback: originalArguments[2],
+				headers: originalArguments[3],
+			};
+		}
+		return originalOpts;
 	}
-	var args = $.extend({}, opts.args);
 
-	if (args.freeze) {
-		opts.freeze = opts.freeze || args.freeze;
-		opts.freeze_message = opts.freeze_message || args.freeze_message;
+	function normalizeOptions(opts) {
+		var args = $.extend({}, opts.args);
+
+		// quiet mode implies no_spinner
+		if (opts.quiet) {
+			opts.no_spinner = true;
+		}
+
+		// freeze can come from args
+		if (args.freeze) {
+			opts.freeze = opts.freeze || args.freeze;
+			opts.freeze_message = opts.freeze_message || args.freeze_message;
+		}
+
+		return args;
 	}
 
-	if (opts.api_version && !["v1", "v2"].includes(opts.api_version)) {
-		console.error("frappe.call unsupported api_version");
-		throw new Error(`frappe.call: api_version '${opts.api_version}' is not supported.`);
+	function validateApiVersion(api_version) {
+		const valid_versions = ["v1", "v2"];
+		if (api_version && !valid_versions.includes(api_version)) {
+			console.error("frappe.call unsupported api_version");
+			throw new Error(`frappe.call: api_version '${api_version}' is not supported. Use one of: ${valid_versions.join(", ")}`);
+		}
+	}
+
+	function validateDocOrigin(doc_origin) {
+		const valid_origins = ["memory", "database"];
+		if (doc_origin && !valid_origins.includes(doc_origin)) {
+			console.error("frappe.call unsupported doc_origin");
+			throw new Error(`frappe.call: doc_origin '${doc_origin}' is not supported. Use one of: ${valid_origins.join(", ")}`);
+		}
+	}
+
+	function resolveDocOrigin(opts) {
+		// doc_origin is only relevant when opts.doc is provided
+		if (!opts.doc) {
+			return;
+		}
+
+		// For API v1 or undefined: only 'memory' (run_doc_method) is available
+		// If doc_origin is specified as 'database', warn and ignore
+		if (!opts.api_version || opts.api_version === "v1") {
+			if (opts.doc_origin === "database") {
+				console.warn(
+					"frappe.call: doc_origin='database' is ignored for API v1. " +
+					"Database document origin is only available in API v2."
+				);
+			}
+			opts.doc_origin = "memory";
+			return;
+		}
+
+		// For API v2: default to 'memory' (run_doc_method) for backward compatibility
+		// with original behavior. Use doc_origin='database' to opt-in to RESTful endpoint.
+		// 
+		// 'memory' (default): Uses run_doc_method, sends full in-memory document to server
+		// 'database': Uses RESTful endpoint, server loads document from DB (lighter payload)
+		opts.doc_origin = opts.doc_origin || "memory";
+	}
+
+	function buildCommand(opts, args) {
+		if (opts.module && opts.page) {
+			// Page method
+			args.cmd = `${opts.module}.page.${opts.page}.${opts.page}.${opts.method}`;
+		} else if (opts.doc) {
+			if (opts.doc_origin === "memory") {
+				// Memory origin: sends full in-memory document to server via run_doc_method
+				$.extend(args, {
+					cmd: "run_doc_method",
+					docs: frappe.get_doc(opts.doc.doctype, opts.doc.name),
+					method: opts.method,
+					args: opts.args,
+				});
+			}
+			// For 'database' origin, no cmd is set here - URL will be built differently
+		} else if (opts.method) {
+			// Direct method call
+			args.cmd = opts.method;
+		}
+	}
+
+	function buildUrl(opts, args) {
+		if (opts.url) {
+			return opts.url;
+		}
+
+		var url;
+
+		if (opts.doc && opts.doc_origin === "database") {
+			// Database origin: server loads document from DB (lighter payload)
+			url = buildDocumentMethodUrl(opts);
+		} else {
+			// Memory origin: /api/method/<cmd> or /api/<version>/method/<cmd>
+			url = buildStandardMethodUrl(opts, args);
+		}
+
+		if (window.cordova) {
+			url = applyCordovaHost(url);
+		}
+
+		return url;
+	}
+
+	function buildDocumentMethodUrl(opts) {
+		// Database origin: RESTful endpoint, server loads document from DB (lighter payload)
+		var { doctype, name } = opts.doc;
+		var method = opts.method;
+
+		validateDocumentMethodParams(doctype, name, method);
+		
+		return `/api/${opts.api_version}/document/${encodeURIComponent(doctype)}/${encodeURIComponent(name)}/method/${encodeURIComponent(method)}/`;
+	}
+
+	function validateDocumentMethodParams(doctype, name, method) {
+		var missing = [
+			!doctype && "doc.doctype",
+			!name && "doc.name",
+			!method && "method",
+		].filter(Boolean);
+
+		if (missing.length) {
+			console.error("frappe.call missing parameters");
+			throw new Error(
+				`frappe.call: missing '${missing.join("', '")}' required for database origin document method calls`
+			);
+		}
+	}
+
+	function buildStandardMethodUrl(opts, args) {
+		var prefix = "/api/method/";
+		if (opts.api_version) {
+			// Both 'v1' and 'v2' use same prefix for non-doc calls
+			prefix = `/api/${opts.api_version}/method/`;
+		}
+		return prefix + args.cmd;
 	}
 	
-	// cmd
-	if (opts.module && opts.page) {
-		args.cmd = opts.module + ".page." + opts.page + "." + opts.page + "." + opts.method;
-	} else if (opts.doc) {
-		if (!opts.api_version || opts.api_version === "v1") {
-			$.extend(args, {
-				cmd: "run_doc_method",
-				docs: frappe.get_doc(opts.doc.doctype, opts.doc.name),
-				method: opts.method,
-				args: opts.args,
-			});
-		}
-	} else if (opts.method) {
-		args.cmd = opts.method;
+	function applyCordovaHost(url) {
+		var host = frappe.request.url;
+		host = host.slice(0, host.length - 1);
+		return host + url;
 	}
 
-	var callback = function (data, response_text) {
-		if (data.task_id) {
-			// async call, subscribe
-			frappe.realtime.subscribe(data.task_id, opts);
+	function createSuccessCallback(opts) {
+		const successCallback = function (data, response_text) {
+			// Async task: subscribe to realtime updates
+			if (data.task_id) {
+				frappe.realtime.subscribe(data.task_id, opts);
 
-			if (opts.queued) {
-				opts.queued(data);
-			}
-		} else if (opts.callback) {
-			// ajax
-			return opts.callback(data, response_text);
-		}
-	};
+				if (opts.queued) {
+					opts.queued(data);
+				}
 
-	let url = opts.url;
-	if (!url) {
-		// API v2 (api_version='v2'): RESTful endpoint, loads document from DB (lighter payload)
-		// API v1 (default): RPC run_doc_method, sends full document to server
-		if (opts.doc && opts.api_version === "v2") {
-			// RESTful document method endpoint for API v2
-			const { doctype, name } = opts.doc;
-			const method = opts.method;
-
-			// Validate required parameters for API v2 document method calls
-			const missing = [
-				!doctype && "doc.doctype",
-				!name && "doc.name",
-				!method && "method",
-			].filter(Boolean);
-			if (missing.length) {
-				console.error("frappe.call missing parameters");
-				throw new Error(`frappe.call: missing '${missing.join("', '")}' required for API v2 document method calls`);
+				return;
 			}
 
-			url = `/api/${opts.api_version}/document/${encodeURIComponent(doctype)}/${encodeURIComponent(name)}/method/${encodeURIComponent(method)}/`;
-		} else {
-			let prefix = "/api/method/";
-			if (opts.api_version) { // Both 'v1' and 'v2' use same prefix for non-doc calls
-				prefix = `/api/${opts.api_version}/method/`;
+			// Regular callback
+			if (opts.callback) {
+				return opts.callback(data, response_text);
 			}
-			url = prefix + args.cmd;
-		}
-		if (window.cordova) {
-			let host = frappe.request.url;
-			host = host.slice(0, host.length - 1);
-			url = host + url;
-		}
+		};
+		return successCallback;
+	}
+
+	function shouldDebounce(opts, args) {
+		return opts.debounce && frappe.request.is_fresh(args, opts.debounce);
+	}
+
+	function dispatchRequest(opts, args, url) {
+		return frappe.request.call({
+			type: opts.type || "POST",
+			args: args,
+			success: createSuccessCallback(opts),
+			error: opts.error,
+			always: opts.always,
+			btn: opts.btn,
+			freeze: opts.freeze,
+			freeze_message: opts.freeze_message,
+			headers: opts.headers || {},
+			error_handlers: opts.error_handlers || {},
+			async: opts.async,
+			silent: opts.silent,
+			api_version: opts.api_version,
+			url: url,
+			cache: opts.cache,
+		});
+	}
+
+	// Main execution flow
+
+	checkConnectivity();
+
+	opts = normalizeArguments(opts, arguments);
+
+	var args = normalizeOptions(opts);
+
+	validateApiVersion(opts.api_version);
+	validateDocOrigin(opts.doc_origin);
+	resolveDocOrigin(opts);
+
+	buildCommand(opts, args);
+
+	var url = buildUrl(opts, args);
+
+	if (!opts.url) {
+		// When URL is built (not provided via opts.url), cmd is embedded in URL path
+		// Remove from args to avoid sending it twice (as path and as POST data)
 		delete args.cmd;
 	}
 
-	// debouce if required
-	if (opts.debounce && frappe.request.is_fresh(args, opts.debounce)) {
+	if (shouldDebounce(opts, args)) {
 		return Promise.resolve();
 	}
 
-	return frappe.request.call({
-		type: opts.type || "POST",
-		args: args,
-		success: callback,
-		error: opts.error,
-		always: opts.always,
-		btn: opts.btn,
-		freeze: opts.freeze,
-		freeze_message: opts.freeze_message,
-		headers: opts.headers || {},
-		error_handlers: opts.error_handlers || {},
-		async: opts.async,
-		silent: opts.silent,
-		api_version: opts.api_version,
-		url,
-		cache: opts.cache,
-	});
+	return dispatchRequest(opts, args, url);
 };
 
 frappe.request.call = function (opts) {

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -135,6 +135,38 @@ frappe.call = function (opts) {
 	}
 
 	/**
+	 * Validates that at least one valid call type is specified.
+	 * Valid call types are: page method (module + page), document method (doc), or direct method (method).
+	 * @param {{ method: string|undefined, doc: object|undefined, module: string|undefined, page: string|undefined }} config
+	 * @returns {{ is_valid: boolean, error: Error|null }}
+	 */
+	function validate_call_type(config) {
+		var { method, doc, module, page } = config;
+
+		var has_page_call = module && page;
+		var has_doc_call = !!doc;
+		var has_method_call = !!method;
+
+		if (has_page_call || has_doc_call || has_method_call) {
+			return { is_valid: true, error: null };
+		}
+
+		var missing_options = [
+			!has_method_call && "'method' (direct method call)",
+			!has_doc_call && "'doc' (document method call)",
+			!has_page_call && "'module' and 'page' (page method call)",
+		].filter(Boolean);
+
+		console.error("frappe.call invalid call configuration");
+		return {
+			is_valid: false,
+			error: new Error(
+				`frappe.call: invalid call configuration. Must provide one of: ${missing_options.join(", ")}`
+			),
+		};
+	}
+
+	/**
 	 * Resolves the effective doc_origin and api_version based on provided options.
 	 * Both API v1 and v2 support both origins:
 	 * - 'memory' (default): Uses run_doc_method, sends full in-memory document to server
@@ -282,12 +314,8 @@ frappe.call = function (opts) {
 			};
 		}
 
-		// No recognized call type
-		// TODO: What should happen here? Throw error?
-		return {
-			payload: $.extend({}, args),
-			cmd: undefined,
-		};
+		// This should never be reached, previous validations should catch invalid configurations
+		throw new Error("frappe.call: unable to build server payload due to unknown call type");
 	}
 
 	/**
@@ -566,6 +594,17 @@ frappe.call = function (opts) {
 	var doc_origin_validation = validate_doc_origin(options.doc_origin);
 	if (!doc_origin_validation.is_valid) {
 		throw doc_origin_validation.error;
+	}
+
+	// Validate call type
+	var call_type_validation = validate_call_type({
+		method: options.method,
+		doc: options.doc,
+		module: options.module,
+		page: options.page,
+	});
+	if (!call_type_validation.is_valid) {
+		throw call_type_validation.error;
 	}
 
 	// Resolve parameter precedence (freeze, spinner settings)

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -53,11 +53,10 @@ frappe.call = function (opts) {
 		});
 	}
 
-	// Resolve parameters precedence
-	var input_args = options.args || {};
+	// Resolve parameters precedence between top-level options and args
 	var resolved_params = helpers.resolve_parameter_precedence({
 		opts: { freeze: options.freeze, freeze_message: options.freeze_message },
-		args: { freeze: input_args.freeze, freeze_message: input_args.freeze_message },
+		args: { freeze: options.args?.freeze, freeze_message: options.args?.freeze_message },
 	});
 
 	// Resolve effective doc_origin and api_version
@@ -70,7 +69,7 @@ frappe.call = function (opts) {
 	// Build server payload
 	var payload_result = helpers.build_server_payload({
 		method: options.method,
-		args: input_args,
+		args: options.args,
 		doc: options.doc,
 		doc_origin: doc_origin_resolution.doc_origin,
 		api_version: doc_origin_resolution.api_version,
@@ -168,14 +167,17 @@ frappe.call._helpers = {
 			return {
 				opts: {
 					method,
-					args,
+					args: args || {},
 					callback,
 					headers,
 				},
 			};
 		}
+
+		var opts = first_arg;
+		opts.args = opts.args || {};
 		
-		return { opts: { ...first_arg } };
+		return { opts };
 	},
 
 	/**

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -62,12 +62,19 @@ frappe.call = function (opts) {
 	if (opts.module && opts.page) {
 		args.cmd = opts.module + ".page." + opts.page + "." + opts.page + "." + opts.method;
 	} else if (opts.doc) {
-		$.extend(args, {
-			cmd: "run_doc_method",
-			docs: frappe.get_doc(opts.doc.doctype, opts.doc.name),
-			method: opts.method,
-			args: opts.args,
-		});
+		// API v2 (api_version='v2'): RESTful endpoint, loads document from DB (lighter payload)
+		// API v1 (default): RPC run_doc_method, sends full document to server
+		if (!opts.api_version || opts.api_version === "v1") {
+			$.extend(args, {
+				cmd: "run_doc_method",
+				docs: frappe.get_doc(opts.doc.doctype, opts.doc.name),
+				method: opts.method,
+				args: opts.args,
+			});
+		} else if (opts.api_version !== "v2") {
+			console.warn(`Unsupported api_version "${opts.api_version}" for doc method call, falling back to "v2".`);
+			opts.api_version = "v2"; // Fallback to v2
+		}
 	} else if (opts.method) {
 		args.cmd = opts.method;
 	}
@@ -88,11 +95,19 @@ frappe.call = function (opts) {
 
 	let url = opts.url;
 	if (!url) {
-		let prefix = "/api/method/";
-		if (opts.api_version) {
-			prefix = `/api/${opts.api_version}/method/`;
+		if (opts.doc && opts.api_version === "v2") {
+			// RESTful document method endpoint for API v2
+			const { doctype, name } = opts.doc;
+			const method = opts.method;
+
+			url = `/api/v2/document/${encodeURIComponent(doctype)}/${encodeURIComponent(name)}/method/${encodeURIComponent(method)}/`;
+		} else {
+			let prefix = "/api/method/";
+			if (opts.api_version) { // Both 'v1' and 'v2' use same prefix for non-doc calls
+				prefix = `/api/${opts.api_version}/method/`;
+			}
+			url = prefix + args.cmd;
 		}
-		url = prefix + args.cmd;
 		if (window.cordova) {
 			let host = frappe.request.url;
 			host = host.slice(0, host.length - 1);

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -100,6 +100,17 @@ frappe.call = function (opts) {
 			const { doctype, name } = opts.doc;
 			const method = opts.method;
 
+			// Validate required parameters for API v2 document method calls
+			const missing = [
+				!doctype && "doc.doctype",
+				!name && "doc.name",
+				!method && "method",
+			].filter(Boolean);
+			if (missing.length) {
+				console.error("frappe.call missing parameters");
+				throw new Error(`frappe.call: missing '${missing.join("', '")}' required for API v2 document method calls`);
+			}
+
 			url = `/api/v2/document/${encodeURIComponent(doctype)}/${encodeURIComponent(name)}/method/${encodeURIComponent(method)}/`;
 		} else {
 			let prefix = "/api/method/";


### PR DESCRIPTION
## Summary

This PR fixes a gap in the JavaScript client's `frappe.call` function where document instance method calls using the `doc` option were not routed to the correct API v2 RESTful endpoint (`execute_doc_method`), even when `api_version: 'v2'` was explicitly provided.

Closes: #36607 
- frappe.call with `doc` and `api_version: 'v2'` options doesn't really support API v2 RESTful document method endpoint

**Related issue:** #22762 - API v2 stabilization (includes "FrappeClient rewrite" in the checklist)

---

## Explain the **details** for making this change. What existing problem does the pull request solve?

### Problem

When calling `frappe.call` with both a `doc` object and `api_version: 'v2'`, the request was always dispatched to the RPC-style endpoint `run_doc_method` (serializing and sending the entire in-memory document in the request body) regardless of the `api_version` flag:

```javascript
// Before: always calls POST /api/v2/method/run_doc_method (full doc in body)
frappe.call({
    doc: frm.doc,
    method: 'my_custom_method',
    api_version: 'v2',
    callback: (r) => { /* r.message ... */ }
});
```

The `api_version: 'v2'` flag only changed the URL prefix (affecting response format), but did not switch to the RESTful `execute_doc_method` endpoint that API v2 introduced specifically for document instance method calls. The backend had the endpoint, but the frontend client never leveraged it.

### Solution

The `frappe.call` function now supports a `doc_origin` parameter that makes the document source explicit:

- **`doc_origin: 'memory'`** (default, backward compatible): Uses `run_doc_method`. The full in-memory document is serialized and sent with the request. Suitable for unsaved documents or in-memory manipulation.
- **`doc_origin: 'database'`**: Server loads the document from the database. Lightweight payload (only `doctype`, `name`, method args). Suitable for saved documents.

When `doc_origin: 'database'` is used together with `api_version: 'v2'`, the request is routed to the RESTful endpoint:
```
POST /api/v2/document/<doctype>/<name>/method/<method>/
```

When `doc_origin: 'database'` is used without an explicit `api_version` (or with `v1`), the request is routed to the v1 resource endpoint:
```
POST /api/v1/resource/<doctype>/<name>/
```
with `run_method` passed in the form data.

**Usage examples:**

```javascript
// memory origin (explicit) full in-memory doc sent to server via run_doc_method.
// Useful for unsaved documents or when the server needs the current form state
// (e.g. running validations before the document is saved).
frappe.call({
    doc: frm.doc,
    method: 'calculate_totals',
    doc_origin: 'memory',        // explicit, same as omitting doc_origin entirely
    callback: (r) => { /* r.message ... */ }
});
// POST /api/method/run_doc_method (full doc serialized in body)

// memory origin (implicit default) backward-compatible, behavior unchanged
frappe.call({
    doc: frm.doc,
    method: 'calculate_totals',
    callback: (r) => { /* r.message ... */ }
});
// POST /api/method/run_doc_method (full doc serialized in body)

// database origin + v2 server loads the document from DB, lightweight payload.
// Suitable for actions on already-saved documents (submit, cancel, workflow triggers, etc.).
frappe.call({
    doc: frm.doc,
    method: 'submit',
    doc_origin: 'database',
    api_version: 'v2',
    callback: (r) => { /* r.data ... */ }
});
// POST /api/v2/document/Sales%20Order/SO-0001/method/submit/

// database origin + v1 same lightweight payload, v1 resource endpoint
frappe.call({
    doc: frm.doc,
    method: 'submit',
    doc_origin: 'database',
    callback: (r) => { /* r.message ... */ }
});
// POST /api/v1/resource/Sales%20Order/SO-0001/ (run_method in form data)
```

### Refactoring

Beyond the core fix, `frappe.call` was significantly refactored to improve maintainability and correctness:

- All logic is decomposed into small, focused pure helper functions grouped under `frappe.call._helpers`, keeping them encapsulated and testable without polluting the global `frappe` namespace.
- Input validation is now explicit and early: `api_version`, `doc_origin`, and call type (method / doc / page) are validated upfront with descriptive error messages.
- URL construction and payload building are separated into dedicated helpers (`build_request_url`, `build_server_payload`, `build_doc_db_origin_url`, `build_standard_method_url`), making the routing logic transparent.
- Caller argument mutation is prevented: `opts` and `args` are no longer mutated in place; copies are used throughout.
- Legacy calling convention (`frappe.call(method, args, callback, headers)`) is preserved via `parse_caller_arguments`.
- Debounce, Cordova host injection, freeze parameter precedence, and realtime/queued callback routing are all handled in isolated helpers.

### Backward Compatibility

This change is fully backward compatible:

| Scenario | Behavior |
|---|---|
| `frappe.call({ doc, method })` | Unchanged — uses `run_doc_method` (memory origin) |
| `frappe.call({ doc, method, api_version: 'v2' })` | Unchanged — still uses `run_doc_method` (memory origin), v2 response format |
| `frappe.call({ doc, method, doc_origin: 'database' })` | **New** — uses v1 resource endpoint |
| `frappe.call({ doc, method, doc_origin: 'database', api_version: 'v2' })` | **New** — uses v2 RESTful document method endpoint |
| `frappe.call({ method, api_version: 'v2' })` | Unchanged — already worked correctly |

No existing calls are broken. The `doc_origin` parameter is opt-in.

---

Happy to receive any feedback on this PR. I'm open to discussing design decisions or alternative approaches to any part of the implementation. I'm also committed to following up on any issues or concerns identified during review and will make time to address them promptly.