### PR TITLE
fix: Exclude virtual fields from List Settings column selector

### DIFF
--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -364,7 +364,7 @@ export default class ListSettings {
 		let multiselect_fields = [];
 
 		meta.fields.forEach((field) => {
-			if (!frappe.model.no_value_type.includes(field.fieldtype)) {
+			if (!frappe.model.no_value_type.includes(field.fieldtype) && !field.is_virtual) {
 				multiselect_fields.push({
 					label: __(field.label, null, field.doctype),
 					value: field.fieldname,


### PR DESCRIPTION
On a doctype's list view, I can select which columns are visible via the List Settings. The fields that appear here include virtual fields, which will not appear in the list view even if they are selected.

Within frappe/frappe/public/js/frappe/list/list_settings.js, the ListSettings.column_selector method calls get_doctype_fields to obtain the fields selectable as options. This method does not filter out virtual fields. Yet within the ListView.setup_columns method, virtual fields are explicitly filtered out (line 414), altogether explaining why the fields are selectable, but then not included.

It is not feasible for virtual fields to be included in the list view as their values would have to be determined in situ and this could be impractical given the calculations involved and the number of objects involved.

To improve the user experience and reduce potential confusion, virtual fields should not be included in the List Settings column selector options.