### PR TITLE
feat: autocomplete field filter support for description

### DIFF
--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -57,7 +57,8 @@ frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui
 				};
 			},
 			filter: function (item, input) {
-				let hay = item.label + item.value;
+				var d = this.get_item(item.value);
+				let hay = d.description ? d.label + d.description + d.value : d.label + d.value;
 				return Awesomplete.FILTER_CONTAINS(hay, input);
 			},
 			item: function (item) {

--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -57,8 +57,8 @@ frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui
 				};
 			},
 			filter: function (item, input) {
-				var d = this.get_item(item.value);
-				let hay = d.description ? d.label + d.description + d.value : d.label + d.value;
+				const d = this.get_item(item.value);
+				const hay = d.description ? d.label + d.description + d.value : d.label + d.value;
 				return Awesomplete.FILTER_CONTAINS(hay, input);
 			},
 			item: function (item) {


### PR DESCRIPTION
Currently,  if options have descriptions, filters on the Autocomplete field don't include descriptions. Added support for it.


<!-- no-docs -->