### PR TITLE
fix(setup-wizard): display enabled languages on language field in setup wizard with `language_code`

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -391,16 +391,34 @@ def load_messages(language):
 
 @frappe.whitelist()
 def load_languages():
-	language_codes = frappe.db.sql(
-		"select language_code, language_name from tabLanguage order by name", as_dict=True
+	Language = frappe.qb.DocType("Language")
+	language_codes = (
+		frappe.qb.from_(Language)
+		.select(Language.language_code, Language.language_name)
+		.where(Language.enabled == 1)
+		.orderby(Language.language_code)
+		.run(as_dict=1)
+	)
+
+	language_opts = (
+		frappe.qb.from_(Language)
+		.select(
+			Language.language_name.as_("value"),
+			Language.language_name.as_("label"),
+			Language.language_code.as_("description"),
+		)
+		.where(Language.enabled == 1)
+		.orderby(Language.language_code)
+		.run(as_dict=1)
 	)
 	codes_to_names = {}
 	for d in language_codes:
 		codes_to_names[d.language_code] = d.language_name
+
 	return {
 		"default_language": frappe.db.get_value("Language", frappe.local.lang, "language_name")
 		or frappe.local.lang,
-		"languages": sorted(frappe.db.sql_list("select language_name from tabLanguage order by name")),
+		"languages": language_opts,
 		"codes_to_names": codes_to_names,
 	}
 


### PR DESCRIPTION
Depends on https://github.com/frappe/frappe/pull/36981

Earlier, users could filter out the language only if they had the language input of the language, or they had to scroll and find out which language they wanted to use. 

Now, it will allow users to put the `language_code` or the actual `language_name` to filter out the language with the help of the added description (`language_code`) on the options. Changed the query on the server-side to include `language_code` as description.


Before:


https://github.com/user-attachments/assets/dfcf03ab-ea77-438b-a219-32ba5d75183f



After:

https://github.com/user-attachments/assets/f20d1594-a4ac-4714-9e59-80b56e0ae06c

