### PR TITLE
fix: adjust padding and layout for knowledge base

### DIFF
--- a/frappe/website/doctype/help_article/templates/help_article_list.html
+++ b/frappe/website/doctype/help_article/templates/help_article_list.html
@@ -4,7 +4,7 @@
 
 {% block page_content %}
 
-<div class="row py-8">
+<div class="row py-4">
 	<div class="col-md-8">
 		<div class="hero">
 			<div class="hero-content">
@@ -21,13 +21,13 @@
 			{{ no_result_message or _("Nothing to show") }}
 		</div>
 		{% else %}
-		<div id="blog-list" class="blog-list result row">
+		<div id="blog-list" class="blog-list result col">
 			{% for item in result %}
 			{{ item }}
 			{% endfor %}
 		</div>
 		{% endif %}
-		<button class="btn btn-light btn-more btn {% if not show_more -%} hidden {%- endif %}">{{ _("Load More") }}</button>
+		<button class="btn btn-light btn-more my-4 {% if not show_more -%} hidden {%- endif %}">{{ _("Load More") }}</button>
 	</div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Resolve: #36918 

---
Before

<img width="1474" height="926" alt="image" src="https://github.com/user-attachments/assets/deb4ddd1-090f-49c9-a72a-98f686c77af5" />

---
After
<img width="1348" height="907" alt="image" src="https://github.com/user-attachments/assets/866fd80e-2ae5-4a09-9595-7f3ee81971cd" />
