### PR TITLE
fix(gantt): make bottom time span bar move with page scroll

### DIFF
--- a/frappe/public/js/frappe/views/gantt/gantt_view.js
+++ b/frappe/public/js/frappe/views/gantt/gantt_view.js
@@ -166,7 +166,7 @@ frappe.views.GanttView = class GanttView extends frappe.views.ListView {
 
 		const view_modes = this.gantt.options.view_modes || [];
 		const active_class = (view_mode) => (this.gantt.view_is(view_mode) ? "btn-info" : "");
-		const html = `<div class="btn-group gantt-view-mode">
+		const html = `<div class="btn-group gantt-view-mode mx-2">
 				${view_modes
 					.map(
 						(value) => `<button type="button"

--- a/frappe/public/scss/desk/frappe_gantt.scss
+++ b/frappe/public/scss/desk/frappe_gantt.scss
@@ -80,3 +80,12 @@
 		height: 15px;
 	}
 }
+
+.gantt-modern {
+	height: calc(100vh - 240px);
+	overflow-y: auto;
+
+	.gantt-container {
+		position: relative;
+	}
+}


### PR DESCRIPTION
Resolve: #36826 

> And add space between button group
---
Before



https://github.com/user-attachments/assets/853af56b-e828-4a2a-b6f6-3d730406b151



---
After

https://github.com/user-attachments/assets/848e8b7b-5d96-4fb8-a5bc-f11aafe96991

