### PR TITLE
fix(form sidebar): remove double border

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -157,7 +157,7 @@
 <div class="sidebar-section hidden">
 	<a><li class="indicator blue auto-repeat-status" style="display: none;"></li></a>
 </div>
-<div class="sidebar-section text-muted border-top pt-3">
+<div class="sidebar-section text-muted pt-3">
 	<ul class="list-unstyled sidebar-menu text-muted">
 		<li class="modified-by"></li>
 		<li class="created-by"></li>


### PR DESCRIPTION
Before
<img width="282" height="535" alt="Screenshot 2026-02-12 at 11 21 21 AM" src="https://github.com/user-attachments/assets/a2cd5cc1-50c4-458b-9704-2adbcae74773" />

After
<img width="282" height="577" alt="Screenshot 2026-02-12 at 11 23 44 AM" src="https://github.com/user-attachments/assets/1e9f34a6-b32d-4d5b-a4d7-d2604ddf7c69" />
