### PR TITLE
fix: link dropdown repositioning on child table horizontal scroll

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -126,6 +126,19 @@ export default class Grid {
 		frappe.utils.bind_actions_with_object(this.wrapper, this);
 
 		this.form_grid = this.wrapper.find(".form-grid");
+
+		this.form_grid.on("scroll", (e) => {
+			if ($(e.currentTarget).scrollLeft() > 0) {
+				this.grid_rows.forEach((grid_row) => {
+					grid_row.on_grid_fields.forEach((field) => {
+						if (field.df.fieldtype === "Link" && field.awesomplete) {
+							field.awesomplete.close();
+						}
+					});
+				});
+			}
+		});
+
 		this.setup_add_row();
 
 		this.setup_grid_pagination();


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/33292

As of v16, the link field dropdown does stick to the input on vertical scroll.

As for horizontal scroll, having the dropdown stick to the input would lead it to being cut off by the table's edges, making it an unviable solution. In this PR, scrolling horizontally in a child table forces all link dropdowns to close, so there's no floating dropdown detached from its input field.


https://github.com/user-attachments/assets/60948f2b-450f-4ccf-99ba-a141f731aff7

