### PR TITLE
fix: ensure import log is only used for persisted Data Import records

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -93,15 +93,19 @@ class Importer:
 			return
 
 		# setup import log
-		import_log = (
-			frappe.get_all(
-				"Data Import Log",
-				fields=["row_indexes", "success", "log_index"],
-				filters={"data_import": self.data_import.name},
-				order_by="log_index",
+		# Only use import log for retry/resume when Data Import is persisted in DB.
+		# For bench data-import (CLI), the doc is never inserted, so we must not reuse logs
+		import_log = []
+		if self.data_import.name and frappe.db.exists("Data Import", self.data_import.name):
+			import_log = (
+				frappe.get_all(
+					"Data Import Log",
+					fields=["row_indexes", "success", "log_index"],
+					filters={"data_import": self.data_import.name},
+					order_by="log_index",
+				)
+				or []
 			)
-			or []
-		)
 
 		log_index = 0
 


### PR DESCRIPTION
## Issue

`bench data-import` works for the first CSV, but later imports skip all rows until the Data Import Log table is manually truncated.

**Reference:** [frappe/frappe#33407](https://github.com/frappe/frappe/issues/33407)

## Root Cause

For CLI imports, the Data Import doc is never saved. Import logs from earlier runs are reused via `data_import = NULL`, so row indices (2, 3, 4) from different files are wrongly treated as already imported.

## Fix

Only use the Data Import Log when the Data Import document exists in the database. For CLI imports, the doc is not persisted, so previous logs are ignored.

---

## Testing Steps

### Prerequisites

- DocType `Test` with fields `description` and `full_name`, **Allow Import** enabled

### Sample CSVs

**import1.csv:**
```csv
description,full_name
First batch item A,Alice Adams
First batch item B,Bob Brown
First batch item C,Carol Clark
```

**import2.csv:**
```csv
description,full_name
Second batch item D,David Davis
Second batch item E,Eve Evans
Second batch item F,Frank Ford
```

### Steps

1. Clear old log entries (one-time, if needed):
   ```bash
   bench --site [site] mariadb
   ```
   ```sql
   TRUNCATE `tabData Import Log`;
   exit
   ```

2. First import:
   ```bash
   bench --site [site] data-import --file /path/to/import1.csv --doctype "Test" --type insert
   ```

3. Second import:
   ```bash
   bench --site [site] data-import --file /path/to/import2.csv --doctype "Test" --type insert
   ```

### Expected Result (After Fix)

- Both imports succeed
- Test list shows all 6 records (A–F)

### Old Behaviour (Before Fix)

**First import:**
```
Importing Test: 3 records        : [========================================] 100%
Successfully imported 3 records out of 3
```

**Second import (bug):**
```
Skipping imported rows [2]
Skipping imported rows [3]
Skipping imported rows [4]

Successfully imported 3 records out of 3
```

- Second import falsely reports success but adds no new records
- Only 3 records (A, B, C) exist; D, E, F are never imported
