### PR TITLE
fix(module-def): add validation for rename

### DIFF
--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.modules.export_file import delete_folder
 
@@ -88,6 +89,10 @@ class ModuleDef(Document):
 			modules_txt.write_text("\n".join(modules))
 			frappe.clear_cache()
 			frappe.setup_module_map()
+
+	def before_rename(self, old, new, merge=False):
+		if not self.custom:
+			frappe.throw(_("Only Custom Modules can be renamed."))
 
 
 @frappe.whitelist()


### PR DESCRIPTION
**Issue:**
User can currently rename the core module, which results in a Module Not Found error.

<img width="1796" height="961" alt="image" src="https://github.com/user-attachments/assets/e7c3c685-c587-4336-a45b-25079e06f577" />


Backport need for v15, v16