### PR TITLE
fix: prevent submission of non-submittable doctype

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1050,6 +1050,8 @@ class Document(BaseDocument):
 		- Submit (1) > Cancel (2)
 
 		"""
+		if not self.meta.is_submittable:
+			raise frappe.DocstatusTransitionError(_("Cannot change docstatus of non submittable doctype {0}").format(self.doctype))
 		if to_docstatus == DocStatus.DRAFT:
 			if self.docstatus.is_draft():
 				self._action = "save"


### PR DESCRIPTION
Description
This adds a validation check to ensure that a document cannot be submitted if its DocType is not marked as is_submittable. 

