### PR TITLE
fix(webform): hide navbar/footer settings

### DIFF
--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -4,8 +4,17 @@
 	{% include "templates/includes/meta_block.html" %}
 {% endblock %}
 
-{% if hide_navbar %}{% block navbar %}{% endblock %}{% endif %}
-{% if hide_footer %}{% block footer %}{% endblock %}{% endif %}
+{% block navbar %}
+	{% if not hide_navbar %}
+        {% include "templates/includes/navbar/navbar.html" %}
+	{% endif %}
+{% endblock %}
+
+{% block footer %}
+	{% if not hide_footer %}
+        {% include "templates/includes/footer/footer.html" %}
+	{% endif %}
+{% endblock %}
 
 {% block breadcrumbs %}{% endblock %}
 


### PR DESCRIPTION
Resolve: #37002

---
### Problem

In `web_form.html`, the `navbar` and `footer` blocks were wrapped inside conditional statements:

```jinja
{% if hide_navbar %}{% block navbar %}{% endblock %}{% endif %}
{% if hide_footer %}{% block footer %}{% endblock %}{% endif %}
```

in Jinja, **blocks must always be defined at template parse time**

----
Before:

https://github.com/user-attachments/assets/e3cf3c6f-1420-4edf-82d1-807932570198



---
After:


https://github.com/user-attachments/assets/db8a28f4-83f1-401f-bcca-98dead1df2fa

