### PR TITLE
fix: show better errors when unpacking from `frappe.get_cached_value()` fails

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -176,9 +176,12 @@ class LoginManager:
 		self.set_user_info()
 
 	def get_user_info(self):
-		self.info = frappe.get_cached_value(
+		result = frappe.get_cached_value(
 			"User", self.user, ["user_type", "first_name", "last_name", "user_image"], as_dict=1
 		)
+		if result is None:
+			frappe.throw(_("User does not exist"), frappe.DoesNotExistError)
+		self.info = result
 		self.user_type = self.info.user_type
 
 	def setup_boot_cache(self):

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -12,6 +12,7 @@ from frappe.core.doctype.domain_settings.domain_settings import get_active_modul
 from frappe.permissions import AUTOMATIC_ROLES, get_rights, get_roles, get_valid_perms
 from frappe.query_builder import DocType, Order
 from frappe.query_builder.functions import Concat_ws
+from frappe.utils.translations import _
 
 if TYPE_CHECKING:
 	from frappe.core.doctype.user.user import User
@@ -295,9 +296,10 @@ def get_user_fullname(user: str) -> str:
 
 
 def get_fullname_and_avatar(user: str) -> _dict:
-	first_name, last_name, avatar, name = frappe.get_cached_value(
-		"User", user, ["first_name", "last_name", "user_image", "name"]
-	)
+	result = frappe.get_cached_value("User", user, ["first_name", "last_name", "user_image", "name"])
+	if result is None:
+		frappe.throw(_("User does not exist"), frappe.DoesNotExistError)
+	first_name, last_name, avatar, name = result
 	return _dict(
 		{
 			"fullname": " ".join(list(filter(None, [first_name, last_name]))),


### PR DESCRIPTION
**frappe.get_cached_value() returns NoneType when DoesNotExistError is thrown by get_cached_doc().**

```
def get_cached_value(doctype: str, name: str, fieldname: str = "name", as_dict: bool = False) -> Any:
  try:
    doc = get_cached_doc(doctype, name)
  except DoesNotExistError:
    clear_last_message()
    return
```


**Earlier while using frappe.get_cached_value(), there was no checking done on the return value before unpacking, if the returned value is a NoneType or not. this may cause NoneType not iterable error.**

```
@frappe.whitelist(allow_guest=True)
def get_period_date_ranges(period, fiscal_year=None, year_start_date=None):
  from dateutil.relativedelta import relativedelta

  if not year_start_date:
    year_start_date, year_end_date = frappe.get_cached_value(
      "Fiscal Year", fiscal_year, ["year_start_date", "year_end_date"]
    )

  increment = {"Monthly": 1, "Quarterly": 3, "Half-Yearly": 6, "Yearly": 12}.get(period)

```

**To solve this, checks like below are added:**

```
result = ...
if result is None:
    frappe.throw(_("Fiscal year does not exist"), frappe.DoesNotExistError)

year_start_date, year_end_date = result
```