### PR TITLE
fix!: prevent submission of non-submittable doctype

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1051,6 +1051,9 @@ class Document(BaseDocument):
 		- Submit (1) > Cancel (2)
 
 		"""
+		if self.flags.skip_docstatus_validation:
+			return
+
 		to_docstatus = self.docstatus
 		if from_docstatus == DocStatus.DRAFT:
 			if to_docstatus.is_draft():

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1056,11 +1056,7 @@ class Document(BaseDocument):
 			if to_docstatus.is_draft():
 				self._action = "save"
 			elif to_docstatus.is_submitted():
-				is_submittable = getattr(self.meta, "is_submittable", False)
-				if not is_submittable and getattr(self.meta, "istable", False) and self.parenttype:
-					is_submittable = frappe.get_meta(self.parenttype).is_submittable
-
-				if not is_submittable:
+				if not getattr(self.meta, "is_submittable", False):
 					frappe.throw(
 						_("Cannot change docstatus of non submittable doctype {0}").format(self.doctype),
 						frappe.DocstatusTransitionError,

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1051,10 +1051,28 @@ class Document(BaseDocument):
 		- Submit (1) > Cancel (2)
 
 		"""
+
 		if to_docstatus == DocStatus.DRAFT:
 			if self.docstatus.is_draft():
 				self._action = "save"
 			elif self.docstatus.is_submitted():
+				if not getattr(self.meta, "is_submittable", False):
+					# Exception: workflows can manage docstatus for non-submittable doctypes
+					workflow_name = self.meta.get_workflow()
+					if workflow_name:
+						from frappe.model.workflow import get_workflow
+
+						workflow = get_workflow(self.doctype)
+						if not (workflow and workflow.get("_update_state_docstatus")):
+							raise frappe.DocstatusTransitionError(
+								_("Cannot change docstatus of non submittable doctype {0}").format(
+									self.doctype
+								)
+							)
+					else:
+						raise frappe.DocstatusTransitionError(
+							_("Cannot change docstatus of non submittable doctype {0}").format(self.doctype)
+						)
 				self._action = "submit"
 				self.check_permission("submit")
 			elif self.docstatus.is_cancelled():

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1041,7 +1041,7 @@ class Document(BaseDocument):
 		if not self.meta.issingle and self._action != "discard":
 			self.check_docstatus_transition(previous.docstatus)
 
-	def check_docstatus_transition(self, to_docstatus):
+	def check_docstatus_transition(self, from_docstatus):
 		"""Ensures valid `docstatus` transition.
 		Valid transitions are (number in brackets is `docstatus`):
 
@@ -1051,39 +1051,40 @@ class Document(BaseDocument):
 		- Submit (1) > Cancel (2)
 
 		"""
-
-		if to_docstatus == DocStatus.DRAFT:
-			if self.docstatus.is_draft():
+		to_docstatus = self.docstatus
+		if from_docstatus == DocStatus.DRAFT:
+			if to_docstatus.is_draft():
 				self._action = "save"
-			elif self.docstatus.is_submitted():
+			elif to_docstatus.is_submitted():
 				if not getattr(self.meta, "is_submittable", False):
-					raise frappe.DocstatusTransitionError(
-						_("Cannot change docstatus of non submittable doctype {0}").format(self.doctype)
+					frappe.throw(
+						_("Cannot change docstatus of non submittable doctype {0}").format(self.doctype),
+						frappe.DocstatusTransitionError,
 					)
 				self._action = "submit"
 				self.check_permission("submit")
-			elif self.docstatus.is_cancelled():
+			elif to_docstatus.is_cancelled():
 				raise frappe.DocstatusTransitionError(
 					_("Cannot change docstatus from 0 (Draft) to 2 (Cancelled)")
 				)
 			else:
-				raise frappe.ValidationError(_("Invalid docstatus"), self.docstatus)
+				raise frappe.ValidationError(_("Invalid docstatus"), to_docstatus)
 
-		elif to_docstatus == DocStatus.SUBMITTED:
-			if self.docstatus.is_submitted():
+		elif from_docstatus == DocStatus.SUBMITTED:
+			if to_docstatus.is_submitted():
 				self._action = "update_after_submit"
 				self.check_permission("submit")
-			elif self.docstatus.is_cancelled():
+			elif to_docstatus.is_cancelled():
 				self._action = "cancel"
 				self.check_permission("cancel")
-			elif self.docstatus.is_draft():
+			elif to_docstatus.is_draft():
 				raise frappe.DocstatusTransitionError(
 					_("Cannot change docstatus from 1 (Submitted) to 0 (Draft)")
 				)
 			else:
-				raise frappe.ValidationError(_("Invalid docstatus"), self.docstatus)
+				raise frappe.ValidationError(_("Invalid docstatus"), to_docstatus)
 
-		elif to_docstatus == DocStatus.CANCELLED:
+		elif from_docstatus == DocStatus.CANCELLED:
 			raise frappe.ValidationError(_("Cannot edit cancelled document"))
 
 	def set_parent_in_children(self):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1056,7 +1056,11 @@ class Document(BaseDocument):
 			if to_docstatus.is_draft():
 				self._action = "save"
 			elif to_docstatus.is_submitted():
-				if not getattr(self.meta, "is_submittable", False):
+				is_submittable = getattr(self.meta, "is_submittable", False)
+				if not is_submittable and getattr(self.meta, "istable", False) and self.parenttype:
+					is_submittable = frappe.get_meta(self.parenttype).is_submittable
+
+				if not is_submittable:
 					frappe.throw(
 						_("Cannot change docstatus of non submittable doctype {0}").format(self.doctype),
 						frappe.DocstatusTransitionError,

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1057,22 +1057,9 @@ class Document(BaseDocument):
 				self._action = "save"
 			elif self.docstatus.is_submitted():
 				if not getattr(self.meta, "is_submittable", False):
-					# Exception: workflows can manage docstatus for non-submittable doctypes
-					workflow_name = self.meta.get_workflow()
-					if workflow_name:
-						from frappe.model.workflow import get_workflow
-
-						workflow = get_workflow(self.doctype)
-						if not (workflow and workflow.get("_update_state_docstatus")):
-							raise frappe.DocstatusTransitionError(
-								_("Cannot change docstatus of non submittable doctype {0}").format(
-									self.doctype
-								)
-							)
-					else:
-						raise frappe.DocstatusTransitionError(
-							_("Cannot change docstatus of non submittable doctype {0}").format(self.doctype)
-						)
+					raise frappe.DocstatusTransitionError(
+						_("Cannot change docstatus of non submittable doctype {0}").format(self.doctype)
+					)
 				self._action = "submit"
 				self.check_permission("submit")
 			elif self.docstatus.is_cancelled():

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -554,6 +554,23 @@ class TestDocument(IntegrationTestCase):
 		changed_val = frappe.db.get_single_value(c.doctype, key)
 		self.assertEqual(val, changed_val)
 
+	def test_non_submittable_doctype_docstatus_transition(self):
+		doc = frappe.get_doc({"doctype": "ToDo", "description": "test submit guard"}).insert()
+		doc.docstatus = 1
+
+		self.assertRaises(frappe.DocstatusTransitionError, doc.save)
+
+	def test_skip_docstatus_validation_flag(self):
+		doc = frappe.get_doc({"doctype": "ToDo", "description": "test skip flag"}).insert()
+		doc.docstatus = 1
+		self.assertRaises(frappe.DocstatusTransitionError, doc.save)
+
+		doc.reload()
+		doc.docstatus = 1
+		doc.flags.skip_docstatus_validation = True
+		doc.save()
+		self.assertEqual(frappe.db.get_value("ToDo", doc.name, "docstatus"), 1)
+
 
 class TestDocumentWebView(IntegrationTestCase):
 	def get(self, path, user="Guest"):

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -66,6 +66,22 @@ class TestDocument(IntegrationTestCase):
 		self.assertEqual(d.send_reminder, 1)
 		return d
 
+	def test_submittable_insert(self):
+		dt = frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"module": "Core",
+				"name": "Test Submittable Doctype",
+				"custom": 1,
+				"is_submittable": 1,
+				"fields": [{"label": "Field", "fieldname": "test_field", "fieldtype": "Data"}],
+				"permissions": [{"role": "System Manager", "read": 1, "write": 1, "submit": 1, "cancel": 1}],
+			}
+		).insert(ignore_if_duplicate=True)
+
+		d = frappe.get_doc({"doctype": dt.name, "test_field": "test"}).insert()
+		return d
+
 	def test_website_route_default(self):
 		default = frappe.generate_hash()
 		child_table = new_doctype(default=default, istable=1).insert().name
@@ -101,7 +117,7 @@ class TestDocument(IntegrationTestCase):
 		self.assertEqual(frappe.db.get_value(d.doctype, d.name, "subject"), "subject changed")
 
 	def test_discard_transitions(self):
-		d = self.test_insert()
+		d = self.test_submittable_insert()
 		self.assertEqual(d.docstatus, 0)
 
 		# invalid: Submit > Discard, Cancel > Discard
@@ -113,7 +129,7 @@ class TestDocument(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, d.discard)
 
 		# valid: Draft > Discard
-		d2 = self.test_insert()
+		d2 = self.test_submittable_insert()
 		d2.discard()
 		self.assertEqual(d2.docstatus, 2)
 


### PR DESCRIPTION
### Problem
Non-submittable doctypes should only ever have `docstatus=0` (Draft) since they don't support the submit/cancel workflow. However, there was no validation preventing attempts to change their `docstatus` to 1 (Submitted), which could lead to invalid states in the database.

### Solution
Enhanced the validation in `check_docstatus_transition` to strictly enforce `docstatus` rules for non-submittable doctypes. Also introduced a `skip_docstatus_validation` flag that allows bypassing this check when needed (e.g. for child table documents that inherit docstatus from a submitted parent).

### Changes Made

#### Core Logic (`frappe/model/document.py`)
- Renamed `to_docstatus` parameter to `from_docstatus` in `check_docstatus_transition` to correctly reflect that the function compares the current state (`self.docstatus`) against the starting state.
- Added a validation block to throw a `DocstatusTransitionError` if an attempt is made to transition a non-submittable doctype to `DocStatus.SUBMITTED`.
- Added `flags.skip_docstatus_validation` support in `check_docstatus_transition` — when set to `True`, the entire docstatus transition check is bypassed.

#### Document Tests (`frappe/tests/test_document.py`)
- Added `test_submittable_insert` helper to create a temporary submittable doctype for testing.
- Updated `test_discard_transitions` to use the submittable doctype.
- Added `test_non_submittable_doctype_docstatus_transition` — verifies that saving a non-submittable doctype (ToDo) with `docstatus=1` raises `DocstatusTransitionError`.
- Added `test_skip_docstatus_validation_flag` — verifies both scenarios with/without flag.

### Error Message
When an invalid transition to "Submitted" is attempted on a non-submittable doctype:
```
DocstatusTransitionError: Cannot change docstatus of non submittable doctype {doctype_name}
```
