### PR TITLE
feat: allow exporting modified, modified_by and idx system fields

### DIFF
--- a/frappe/core/doctype/data_export/exporter.py
+++ b/frappe/core/doctype/data_export/exporter.py
@@ -213,7 +213,7 @@ class DataExporter:
 
 		for f in frappe.db.get_table_columns_description(table_name):
 			field = meta.get_field(f.name)
-			if f.name in ["owner", "creation","modified","modified_by","idx"]:
+			if f.name in ["owner", "creation", "modified", "modified_by", "idx"]:
 				std_field = next((x for x in frappe.model.std_fields if x["fieldname"] == f.name), None)
 				if std_field:
 					field = frappe._dict(

--- a/frappe/core/doctype/data_export/exporter.py
+++ b/frappe/core/doctype/data_export/exporter.py
@@ -213,7 +213,7 @@ class DataExporter:
 
 		for f in frappe.db.get_table_columns_description(table_name):
 			field = meta.get_field(f.name)
-			if f.name in ["owner", "creation"]:
+			if f.name in ["owner", "creation","modified","modified_by","idx"]:
 				std_field = next((x for x in frappe.model.std_fields if x["fieldname"] == f.name), None)
 				if std_field:
 					field = frappe._dict(


### PR DESCRIPTION
## Description
This PR adds `modified`, `modified_by`, and `idx` to the allowed list of fields in the Data Export tool (`exporter.py`).

### Motivation
Previously, the Data Export tool was hardcoded to only allow `owner` and `creation`. This limitation prevented users from exporting critical audit trail data (Last Updated Time/User) and order index, which are standard system fields present in all DocTypes.

## Fixes
Fixes #22177

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Manual Logic Verification
> **Note to Reviewer:** I have verified the logic in `build_field_columns` to ensure `modified` and `idx` are correctly identified and appended to the allowed export list.
>
> *Constraint:* I am currently running a minimal environment and was unable to generate a UI screenshot. However, the backend logic change is isolated to the allow-list array and should safely expose these fields to the frontend without side effects.