### PR TITLE
fix: truncate long breadcrumb text to prevent page action buttons fro…

### DIFF
--- a/frappe/public/scss/desk/breadcrumb.scss
+++ b/frappe/public/scss/desk/breadcrumb.scss
@@ -8,12 +8,30 @@
 	flex-wrap: nowrap;
 	align-items: center;
 	line-height: 1;
+	min-width: 0;
+
+	li {
+		min-width: 0;
+		flex-shrink: 1;
+	}
+
+	//prevent desk home icon from shrinking
+	li:first-child {
+		flex-shrink: 0;
+	}
+
 	a {
 		text-decoration: none;
 		color: var(--ink-gray-5);
 		font-weight: var(--weight-medium);
 		font-size: var(--text-lg);
 		letter-spacing: get_letterspacing("sm", "regular");
+
+		display: block;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+
 		&:hover {
 			color: var(--ink-gray-7);
 		}

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	align-items: center;
 	padding: 0 15px;
+	min-width: 0;
 	.sidebar-toggle-btn {
 		display: flex;
 		margin-right: var(--margin-sm);
@@ -36,6 +37,7 @@
 	.title-area {
 		display: inline-flex;
 		align-items: center;
+		min-width: 0;
 		.indicator-pill {
 			margin-left: var(--margin-sm);
 			.indicator-doc-html {


### PR DESCRIPTION
This pull request improves the layout and responsiveness of the desk breadcrumbs. This prevents unwanted shrinking and overflow issues, ensuring that breadcrumb items display correctly and other buttons are not overflown

Before:
<img width="1470" height="54" alt="image" src="https://github.com/user-attachments/assets/a946237a-f189-4970-9603-935607098b30" />

After:
<img width="1470" height="45" alt="image" src="https://github.com/user-attachments/assets/f26eb83b-5de5-4671-a2fe-68ad2e918991" />

