### PR TITLE
fix(google_calendar): check cancelled event exists before update it

### DIFF
--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -352,21 +352,22 @@ def sync_events_from_google_calendar(g_calendar, method=None):
 					"google_calendar_event_id": event.get("id"),
 				},
 			)
-			frappe.db.set_value(
-				"Event",
-				event_name,
-				"status",
-				"Closed",
-			)
-			frappe.get_doc(
-				{
-					"doctype": "Comment",
-					"comment_type": "Info",
-					"reference_doctype": "Event",
-					"reference_name": event_name,
-					"content": " - Event deleted from Google Calendar.",
-				}
-			).insert(ignore_permissions=True)
+			if event_name:
+				frappe.db.set_value(
+					"Event",
+					event_name,
+					"status",
+					"Closed",
+				)
+				frappe.get_doc(
+					{
+						"doctype": "Comment",
+						"comment_type": "Info",
+						"reference_doctype": "Event",
+						"reference_name": event_name,
+						"content": " - Event deleted from Google Calendar.",
+					}
+				).insert(ignore_permissions=True)
 
 	if not results:
 		return _("No Google Calendar Event to sync.")


### PR DESCRIPTION
Fixes: #37010 

---
Add existence check before updating cancelled events to prevent `DoesNotExistError`

