### PR TITLE
fix(link): match popup width with grid column width

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -289,6 +289,17 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			}
 
 			const dropdown = this.awesomplete.ul;
+			if (this.$input.closest(".grid-row").length) {
+				const column = this.$input.closest(".grid-static-col")[0];
+				const width = column
+					? column.getBoundingClientRect().width
+					: this.$input[0].getBoundingClientRect().width;
+
+				dropdown.style.width = width + "px";
+				dropdown.style.minWidth = width + "px";
+				dropdown.style.maxWidth = width + "px";
+			}
+
 			const dropdownRect = dropdown.getBoundingClientRect();
 			const viewportWidth = window.innerWidth;
 


### PR DESCRIPTION
**Ref :** #36559 

**Issue :** When the column width is adjusted in tables like Items (Quotation / Sales Order / Sales Invoice):
      **1**.Narrow column → dropdown becomes wider than the column and overlaps adjacent columns.
      **2**.Wide column → dropdown remains smaller than the column, causing content truncation.
This results in inconsistent UI behavior and poor user experience.

**Before:**

[Screencast from 16-02-26 03:08:08 AM IST.webm](https://github.com/user-attachments/assets/e8710c88-4576-46da-b509-2d02cf90b175)

**After:**

[Screencast from 16-02-26 03:09:42 AM IST.webm](https://github.com/user-attachments/assets/03aba987-8448-496c-954e-11d9c75279c9)


**Bacport needed :** V16
