### PR TITLE
test: Reset mock the right way

### DIFF
--- a/frappe/tests/test_caching.py
+++ b/frappe/tests/test_caching.py
@@ -75,7 +75,7 @@ class TestCachingUtils(IntegrationTestCase):
 
 		# ensure single call if key is hashable
 		for arg in hashable_values:
-			external_service.call_count = 0
+			external_service.reset_mock()
 			for _ in range(2):
 				request_specific_api(arg, 13)
 
@@ -83,7 +83,7 @@ class TestCachingUtils(IntegrationTestCase):
 
 		# multiple calls if key cannot be generated
 		for arg in unhashable_values:
-			external_service.call_count = 0
+			external_service.reset_mock()
 			for _ in range(2):
 				request_specific_api(arg, 13)
 


### PR DESCRIPTION
python 3.14.3 has some kinda proxying, so we can't override actual value
from outside without using proper API.
