### PR TITLE
fix(db): support list of fields in get_value method when cache is True

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -632,6 +632,9 @@ class Database:
 		from frappe.model.utils import is_single_doctype
 
 		out = None
+		if isinstance(fieldname, list):
+			fieldname = tuple(fieldname)
+
 		if cache and isinstance(filters, str) and fieldname in self.value_cache[doctype][filters]:
 			return self.value_cache[doctype][filters][fieldname]
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -141,8 +141,9 @@ class TestDB(IntegrationTestCase):
 		# Test with list of fields and cache=True
 		result = frappe.db.get_value("User", "Administrator", ["name", "email"], cache=True)
 		self.assertEqual(result, ("Administrator", "admin@example.com"))
-		# Verify cache hit returns same result
-		cached_result = frappe.db.get_value("User", "Administrator", ["name", "email"], cache=True)
+		# Verify cache hit - second call should not execute any queries
+		with self.assertQueryCount(0):
+			cached_result = frappe.db.get_value("User", "Administrator", ["name", "email"], cache=True)
 		self.assertEqual(result, cached_result)
 
 	def test_escape(self):

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -138,6 +138,13 @@ class TestDB(IntegrationTestCase):
 			frappe.db.get_value("DocType", "DocField", order_by="creation desc, modified asc, name", run=0),
 		)
 
+		# Test with list of fields and cache=True
+		result = frappe.db.get_value("User", "Administrator", ["name", "email"], cache=True)
+		self.assertEqual(result, ("Administrator", "admin@example.com"))
+		# Verify cache hit returns same result
+		cached_result = frappe.db.get_value("User", "Administrator", ["name", "email"], cache=True)
+		self.assertEqual(result, cached_result)
+
 	def test_escape(self):
 		frappe.db.escape("香港濟生堂製藥有限公司 - IT".encode())
 


### PR DESCRIPTION
Resolves and closes - #37022 

### Root Cause:

The error TypeError: unhashable type: 'list' occurs because Python lists cannot be used as dictionary keys (they're mutable and therefore unhashable). 

### Solution:

Converting fieldname from list to tuple before `if cache` check ensures:
The cache lookup in if condition and cache setting both work well.

This can be ported to both v16 and v15 directly.