### PR TITLE
fix: hide "Edit Layout" context menu option when already in edit mode

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -296,6 +296,9 @@ class DesktopPage {
 			{
 				label: "Edit Layout",
 				icon: "edit",
+				condition: function () {
+					return !me.edit_mode;
+				},
 				onClick: function () {
 					me.$desktop_edit_button.hide();
 					frappe.new_desktop_icons = JSON.parse(JSON.stringify(frappe.desktop_icons));


### PR DESCRIPTION
In desk, clicking edit layout, when already in edit mode was causing duplicate edit grids to render.
This change adds a condition to hide edit layout option when the user is already in edit mode.

Before:

https://github.com/user-attachments/assets/77722ee0-6b23-4597-80bb-21fc172ba9a7

After:

https://github.com/user-attachments/assets/13be7d24-841a-4139-a33f-b03164b85be6
