### PR TITLE
feat: add hover functionality for nested submenus in context menu

### DIFF
--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -167,7 +167,22 @@ frappe.ui.menu = class ContextMenu {
 		if (item.items) {
 			let nested_menu = this.handle_nested_menu(item_wrapper, item);
 			this.nested_menus.push(nested_menu);
+			me.handle_submenu_hover(item_wrapper);
 		}
+	}
+	handle_submenu_hover(item_wrapper) {
+		const me = this;
+
+		$(item_wrapper).on("mouseenter", function (event) {
+			me.nested_menus.forEach((menu) => {
+				if (menu.parent.get(0) === this) {
+					me.current_menu = menu;
+					menu.show(event);
+				} else {
+					menu.hide();
+				}
+			});
+		});
 	}
 
 	handle_nested_menu(item_wrapper, item) {
@@ -234,6 +249,11 @@ frappe.ui.menu = class ContextMenu {
 	hide() {
 		this.template.css("display", "none");
 		this.visible = false;
+		if (this.nested_menus && this.nested_menus.length) {
+			this.nested_menus.forEach((menu) => {
+				menu.hide();
+			});
+		}
 	}
 	mouseX(evt) {
 		if (evt.pageX) {


### PR DESCRIPTION
**Issue:** Sidebar submenus currently open only on click and remain visible when navigating to other sections, resulting in multiple submenus staying open at the same time.

**Description:** The current click-based interaction makes sidebar navigation slower and allows previously opened submenus to remain visible when hovering over other sections. This creates inconsistent UI behavior.

**Feat:** Enable hover-based interaction for sidebar submenus.
When hovering over a section, its submenu should open and any previously opened submenu should close automatically, ensuring only one submenu is visible at a time.

**Before:**

[Before(sidebar).webm](https://github.com/user-attachments/assets/a5b8c5a8-ec75-4eea-8349-5125e2589aa2)


**After:**

[After(sidebar).webm](https://github.com/user-attachments/assets/44c5c7df-7061-48fe-96bb-4ae45322d8b1)


Backport needed for V16.