### PR TITLE
feat(experimental): listview layout per user

### DIFF
--- a/frappe/desk/doctype/user_saved_list_view/__init__.py
+++ b/frappe/desk/doctype/user_saved_list_view/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024, Frappe Technologies and contributors
+# License: MIT. See LICENSE

--- a/frappe/desk/doctype/user_saved_list_view/test_user_saved_list_view.py
+++ b/frappe/desk/doctype/user_saved_list_view/test_user_saved_list_view.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2024, Frappe Technologies and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+
+class TestUserSavedListView(IntegrationTestCase):
+	def setUp(self):
+		# Clean up any existing test views
+		frappe.db.delete("User Saved List View", {"view_name": ("like", "Test View%")})
+
+	def tearDown(self):
+		frappe.db.delete("User Saved List View", {"view_name": ("like", "Test View%")})
+
+	def test_create_private_view(self):
+		"""Test creating a private view"""
+		view = frappe.get_doc({
+			"doctype": "User Saved List View",
+			"view_name": "Test View Private",
+			"reference_doctype": "ToDo",
+			"is_public": 0,
+			"columns": '[{"fieldname": "description", "label": "Description"}]',
+			"filters": '[["ToDo", "status", "=", "Open"]]',
+			"sort_by": "creation",
+			"sort_order": "desc",
+		})
+		view.insert()
+
+		self.assertEqual(view.owner, frappe.session.user)
+		self.assertEqual(view.is_public, 0)
+
+	def test_create_public_view(self):
+		"""Test creating a public view (requires System Manager)"""
+		view = frappe.get_doc({
+			"doctype": "User Saved List View",
+			"view_name": "Test View Public",
+			"reference_doctype": "ToDo",
+			"is_public": 1,
+			"columns": '[{"fieldname": "description", "label": "Description"}]',
+		})
+		view.insert()
+
+		self.assertEqual(view.is_public, 1)
+
+	def test_duplicate_view_name(self):
+		"""Test that duplicate view names for same doctype and user are not allowed"""
+		view1 = frappe.get_doc({
+			"doctype": "User Saved List View",
+			"view_name": "Test View Duplicate",
+			"reference_doctype": "ToDo",
+		})
+		view1.insert()
+
+		view2 = frappe.get_doc({
+			"doctype": "User Saved List View",
+			"view_name": "Test View Duplicate",
+			"reference_doctype": "ToDo",
+		})
+
+		self.assertRaises(frappe.ValidationError, view2.insert)
+
+	def test_get_views(self):
+		"""Test getting views for a doctype"""
+		from frappe.desk.doctype.user_saved_list_view.user_saved_list_view import get_views
+
+		# Create private view
+		frappe.get_doc({
+			"doctype": "User Saved List View",
+			"view_name": "Test View Get 1",
+			"reference_doctype": "ToDo",
+			"is_public": 0,
+		}).insert()
+
+		# Create public view
+		frappe.get_doc({
+			"doctype": "User Saved List View",
+			"view_name": "Test View Get 2",
+			"reference_doctype": "ToDo",
+			"is_public": 1,
+		}).insert()
+
+		views = get_views("ToDo")
+
+		private_names = [v["view_name"] for v in views["private"]]
+		public_names = [v["view_name"] for v in views["public"]]
+
+		self.assertIn("Test View Get 1", private_names)
+		self.assertIn("Test View Get 2", public_names)
+
+	def test_save_view(self):
+		"""Test save_view API"""
+		from frappe.desk.doctype.user_saved_list_view.user_saved_list_view import save_view
+		import json
+
+		result = save_view(
+			doctype="ToDo",
+			view_name="Test View Save",
+			columns=json.dumps([{"fieldname": "description", "label": "Description"}]),
+			filters=json.dumps([["ToDo", "status", "=", "Open"]]),
+			sort_by="creation",
+			sort_order="desc",
+			settings=json.dumps({"disable_count": 1}),
+			is_public=0,
+		)
+
+		self.assertTrue(result.get("name"))
+
+		# Verify the view was created
+		doc = frappe.get_doc("User Saved List View", result["name"])
+		self.assertEqual(doc.view_name, "Test View Save")
+		self.assertEqual(doc.disable_count, 1)

--- a/frappe/desk/doctype/user_saved_list_view/user_saved_list_view.json
+++ b/frappe/desk/doctype/user_saved_list_view/user_saved_list_view.json
@@ -1,0 +1,206 @@
+{
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2024-02-13 10:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "view_name",
+  "reference_doctype",
+  "column_break_1",
+  "is_public",
+  "owner",
+  "section_break_columns",
+  "columns",
+  "section_break_filters",
+  "filters",
+  "section_break_sorting",
+  "sort_by",
+  "sort_order",
+  "section_break_settings",
+  "disable_count",
+  "disable_auto_refresh",
+  "disable_sidebar_stats",
+  "disable_automatic_recency_filters",
+  "column_break_settings",
+  "disable_comment_count",
+  "disable_scrolling",
+  "allow_edit",
+  "show_tags"
+ ],
+ "fields": [
+  {
+   "fieldname": "view_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "View Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Reference DocType",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "If checked, this view will be visible to all users with access to this DocType",
+   "fieldname": "is_public",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Is Public"
+  },
+  {
+   "fieldname": "owner",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Owner",
+   "options": "User"
+  },
+  {
+   "fieldname": "section_break_columns",
+   "fieldtype": "Section Break",
+   "label": "Columns"
+  },
+  {
+   "description": "JSON array of columns with fieldname, label, and width",
+   "fieldname": "columns",
+   "fieldtype": "Code",
+   "label": "Columns",
+   "options": "JSON"
+  },
+  {
+   "fieldname": "section_break_filters",
+   "fieldtype": "Section Break",
+   "label": "Filters"
+  },
+  {
+   "description": "JSON array of filters",
+   "fieldname": "filters",
+   "fieldtype": "Code",
+   "label": "Filters",
+   "options": "JSON"
+  },
+  {
+   "fieldname": "section_break_sorting",
+   "fieldtype": "Section Break",
+   "label": "Sorting"
+  },
+  {
+   "fieldname": "sort_by",
+   "fieldtype": "Data",
+   "label": "Sort By"
+  },
+  {
+   "default": "desc",
+   "fieldname": "sort_order",
+   "fieldtype": "Select",
+   "label": "Sort Order",
+   "options": "asc\ndesc"
+  },
+  {
+   "fieldname": "section_break_settings",
+   "fieldtype": "Section Break",
+   "label": "List View Settings"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_count",
+   "fieldtype": "Check",
+   "label": "Disable Count"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_auto_refresh",
+   "fieldtype": "Check",
+   "label": "Disable Auto Refresh"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_sidebar_stats",
+   "fieldtype": "Check",
+   "label": "Disable Sidebar Stats"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_automatic_recency_filters",
+   "fieldtype": "Check",
+   "label": "Disable Automatic Recency Filters"
+  },
+  {
+   "fieldname": "column_break_settings",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_comment_count",
+   "fieldtype": "Check",
+   "label": "Disable Comment Count"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_scrolling",
+   "fieldtype": "Check",
+   "label": "Disable Scrolling"
+  },
+  {
+   "default": "0",
+   "description": "Allow editing even if the doctype has a workflow set up",
+   "fieldname": "allow_edit",
+   "fieldtype": "Check",
+   "label": "Allow Bulk Editing"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_tags",
+   "fieldtype": "Check",
+   "label": "Show Tags"
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2024-02-13 10:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Desk",
+ "name": "User Saved List View",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "if_owner": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Desk User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/frappe/desk/doctype/user_saved_list_view/user_saved_list_view.py
+++ b/frappe/desk/doctype/user_saved_list_view/user_saved_list_view.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2024, Frappe Technologies and contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class UserSavedListView(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		allow_edit: DF.Check
+		columns: DF.Code | None
+		disable_auto_refresh: DF.Check
+		disable_automatic_recency_filters: DF.Check
+		disable_comment_count: DF.Check
+		disable_count: DF.Check
+		disable_scrolling: DF.Check
+		disable_sidebar_stats: DF.Check
+		filters: DF.Code | None
+		is_public: DF.Check
+		reference_doctype: DF.Link
+		show_tags: DF.Check
+		sort_by: DF.Data | None
+		sort_order: DF.Literal["asc", "desc"]
+		view_name: DF.Data
+	# end: auto-generated types
+
+	def before_insert(self):
+		# Set the owner to current user if not set
+		if not self.owner:
+			self.owner = frappe.session.user
+
+	def validate(self):
+		# Only System Manager can create public views
+		if self.is_public and "System Manager" not in frappe.get_roles():
+			frappe.throw(_("Only System Manager can create public views"))
+
+		# Check if user has permission to the reference doctype
+		if not frappe.has_permission(self.reference_doctype, "read"):
+			frappe.throw(_("You don't have permission to access {0}").format(self.reference_doctype))
+
+		# Check for duplicate view names for this doctype and user
+		existing = frappe.db.exists(
+			"User Saved List View",
+			{
+				"view_name": self.view_name,
+				"reference_doctype": self.reference_doctype,
+				"owner": self.owner,
+				"name": ("!=", self.name or ""),
+			},
+		)
+		if existing:
+			frappe.throw(_("A view with name '{0}' already exists for {1}").format(self.view_name, self.reference_doctype))
+
+	def has_permission(self, ptype, user=None):
+		"""Custom permission check for User Saved List View"""
+		user = user or frappe.session.user
+		
+		# System Manager can do anything
+		if "System Manager" in frappe.get_roles(user):
+			return True
+
+		# For read permission, allow if view is public or owned by user
+		if ptype == "read":
+			return self.is_public or self.owner == user
+
+		# For write/delete, only allow if owner
+		return self.owner == user
+
+
+@frappe.whitelist()
+def get_views(doctype):
+	"""Get all available views for a doctype (user's private views + public views)"""
+	if not frappe.has_permission(doctype, "read"):
+		frappe.throw(_("You don't have permission to access {0}").format(doctype))
+
+	# Get user's private views
+	private_views = frappe.get_all(
+		"User Saved List View",
+		filters={
+			"reference_doctype": doctype,
+			"owner": frappe.session.user,
+			"is_public": 0,
+		},
+		fields=["name", "view_name", "is_public", "owner"],
+		order_by="view_name asc",
+	)
+
+	# Get public views
+	public_views = frappe.get_all(
+		"User Saved List View",
+		filters={
+			"reference_doctype": doctype,
+			"is_public": 1,
+		},
+		fields=["name", "view_name", "is_public", "owner"],
+		order_by="view_name asc",
+	)
+
+	return {
+		"private": private_views,
+		"public": public_views,
+	}
+
+
+@frappe.whitelist()
+def get_view(name):
+	"""Get a specific view by name"""
+	doc = frappe.get_doc("User Saved List View", name)
+	
+	# Check permission
+	if not doc.has_permission("read"):
+		frappe.throw(_("You don't have permission to access this view"))
+
+	return doc.as_dict()
+
+
+@frappe.whitelist()
+def save_view(doctype, view_name, columns, filters, sort_by, sort_order, settings, is_public=0, view_id=None):
+	"""Save or update a view"""
+	if not frappe.has_permission(doctype, "read"):
+		frappe.throw(_("You don't have permission to access {0}").format(doctype))
+
+	settings = frappe.parse_json(settings) if settings else {}
+
+	if view_id:
+		# Update existing view
+		doc = frappe.get_doc("User Saved List View", view_id)
+		if not doc.has_permission("write"):
+			frappe.throw(_("You don't have permission to edit this view"))
+	else:
+		# Create new view
+		doc = frappe.new_doc("User Saved List View")
+		doc.reference_doctype = doctype
+		doc.owner = frappe.session.user
+
+	doc.view_name = view_name
+	doc.columns = columns
+	doc.filters = filters
+	doc.sort_by = sort_by
+	doc.sort_order = (sort_order or "desc").lower()
+	doc.is_public = int(is_public)
+
+	# Apply settings
+	doc.disable_count = settings.get("disable_count", 0)
+	doc.disable_auto_refresh = settings.get("disable_auto_refresh", 0)
+	doc.disable_sidebar_stats = settings.get("disable_sidebar_stats", 0)
+	doc.disable_automatic_recency_filters = settings.get("disable_automatic_recency_filters", 0)
+	doc.disable_comment_count = settings.get("disable_comment_count", 0)
+	doc.disable_scrolling = settings.get("disable_scrolling", 0)
+	doc.allow_edit = settings.get("allow_edit", 0)
+	doc.show_tags = settings.get("show_tags", 0)
+
+	doc.save()
+	frappe.db.commit()
+
+	return {"name": doc.name, "view_name": doc.view_name}
+
+
+@frappe.whitelist()
+def delete_view(name):
+	"""Delete a view"""
+	doc = frappe.get_doc("User Saved List View", name)
+	
+	if not doc.has_permission("delete"):
+		frappe.throw(_("You don't have permission to delete this view"))
+
+	doc.delete()
+	frappe.db.commit()
+
+	return {"success": True}
+
+
+@frappe.whitelist()
+def set_default_view(doctype, view_name=None):
+	"""Set a view as default for the current user"""
+	from frappe.model.utils.user_settings import update_user_settings
+
+	update_user_settings(doctype, {"default_list_view": view_name})
+	return {"success": True}
+
+
+@frappe.whitelist()
+def get_default_view(doctype):
+	"""Get the default view for the current user"""
+	import json
+
+	from frappe.model.utils.user_settings import get_user_settings
+
+	settings = json.loads(get_user_settings(doctype) or "{}")
+	return settings.get("default_list_view")

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1,5 +1,6 @@
 import BulkOperations from "./bulk_operations";
 import ListSettings from "./list_settings";
+import ListViewSelector from "./list_view_selector";
 
 frappe.provide("frappe.views");
 
@@ -335,8 +336,17 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		this.render_header();
 		this.render_skeleton();
 		this.setup_events();
+		this.setup_view_selector();
 		this.settings.onload && this.settings.onload(this);
 		this.show_restricted_list_indicator_if_applicable();
+	}
+
+	setup_view_selector() {
+		// Initialize the saved views selector
+		this.view_selector = new ListViewSelector({
+			list_view: this,
+			doctype: this.doctype,
+		});
 	}
 
 	refresh_columns(meta, list_view_settings) {

--- a/frappe/public/js/frappe/list/list_view_selector.js
+++ b/frappe/public/js/frappe/list/list_view_selector.js
@@ -1,0 +1,531 @@
+// List View Selector - Manages saved list views per user/public
+frappe.provide("frappe.views");
+
+export default class ListViewSelector {
+	constructor({ list_view, doctype }) {
+		this.list_view = list_view;
+		this.doctype = doctype;
+		this.views = { private: [], public: [] };
+		this.current_view = null;
+		this.setup();
+	}
+
+	async setup() {
+		await this.fetch_views();
+		await this.check_default_view();
+		this.render_view_selector();
+	}
+
+	async fetch_views() {
+		const response = await frappe.call({
+			method: "frappe.desk.doctype.user_saved_list_view.user_saved_list_view.get_views",
+			args: { doctype: this.doctype },
+		});
+		this.views = response.message || { private: [], public: [] };
+	}
+
+	async check_default_view() {
+		const response = await frappe.call({
+			method: "frappe.desk.doctype.user_saved_list_view.user_saved_list_view.get_default_view",
+			args: { doctype: this.doctype },
+		});
+		const default_view = response.message;
+		
+		if (default_view) {
+			// Load the default view on initial load
+			await this.apply_view(default_view, true);
+		}
+	}
+
+	render_view_selector() {
+		// Add the views dropdown to the page
+		this.$views_dropdown = this.list_view.page.add_inner_button(
+			__("Views"),
+			[],
+			__("Saved Views")
+		);
+
+		this.refresh_dropdown();
+	}
+
+	refresh_dropdown() {
+		const $menu = this.$views_dropdown.parent();
+		$menu.empty();
+
+		// Default view option
+		$menu.append(this.create_menu_item({
+			label: __("Default View"),
+			is_default: true,
+			action: () => this.reset_to_default(),
+		}));
+
+		if (this.views.private.length || this.views.public.length) {
+			$menu.append('<div class="dropdown-divider"></div>');
+		}
+
+		// Private views section
+		if (this.views.private.length) {
+			$menu.append(`<h6 class="dropdown-header">${__("My Views")}</h6>`);
+			this.views.private.forEach((view) => {
+				$menu.append(this.create_view_item(view, false));
+			});
+		}
+
+		// Public views section
+		if (this.views.public.length) {
+			$menu.append(`<h6 class="dropdown-header">${__("Public Views")}</h6>`);
+			this.views.public.forEach((view) => {
+				$menu.append(this.create_view_item(view, true));
+			});
+		}
+
+		$menu.append('<div class="dropdown-divider"></div>');
+
+		// Save current view option
+		$menu.append(this.create_menu_item({
+			label: __("Save Current View"),
+			icon: "add",
+			action: () => this.show_save_dialog(),
+		}));
+
+		// Save as new view option (if current view is selected)
+		if (this.current_view) {
+			$menu.append(this.create_menu_item({
+				label: __("Save as New View"),
+				icon: "copy",
+				action: () => this.show_save_dialog(true),
+			}));
+
+			$menu.append(this.create_menu_item({
+				label: __("Update Current View"),
+				icon: "refresh",
+				action: () => this.update_current_view(),
+			}));
+		}
+	}
+
+	create_menu_item({ label, icon, action, is_default }) {
+		const icon_html = icon ? frappe.utils.icon(icon, "sm") : "";
+		const $item = $(`
+			<a class="dropdown-item" href="#">
+				${icon_html}
+				<span class="menu-item-label">${label}</span>
+			</a>
+		`);
+		$item.on("click", (e) => {
+			e.preventDefault();
+			action();
+		});
+		return $item;
+	}
+
+	create_view_item(view, is_public) {
+		const is_current = this.current_view === view.name;
+		const can_delete = !is_public || frappe.user.has_role("System Manager");
+		const can_set_default = true;
+
+		const $item = $(`
+			<div class="dropdown-item view-item d-flex align-items-center justify-content-between ${is_current ? "active" : ""}" data-view="${view.name}">
+				<a href="#" class="view-name grow">${view.view_name}</a>
+				<span class="view-actions">
+					${can_set_default ? `<a href="#" class="set-default-btn ml-2" title="${__("Set as Default")}">
+						${frappe.utils.icon("star", "sm")}
+					</a>` : ""}
+					${can_delete ? `<a href="#" class="delete-view-btn ml-2 text-danger" title="${__("Delete")}">
+						${frappe.utils.icon("delete", "sm")}
+					</a>` : ""}
+				</span>
+			</div>
+		`);
+
+		$item.find(".view-name").on("click", (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			this.apply_view(view.name);
+		});
+
+		$item.find(".set-default-btn").on("click", (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			this.set_as_default(view.name, view.view_name);
+		});
+
+		$item.find(".delete-view-btn").on("click", (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			this.delete_view(view.name, view.view_name);
+		});
+
+		return $item;
+	}
+
+	async apply_view(view_name, silent = false) {
+		try {
+			const response = await frappe.call({
+				method: "frappe.desk.doctype.user_saved_list_view.user_saved_list_view.get_view",
+				args: { name: view_name },
+			});
+
+			const view = response.message;
+			if (!view) return;
+
+			this.current_view = view_name;
+			this.current_view_data = view;
+
+			// Apply columns - build columns array directly
+			if (view.columns) {
+				const saved_columns = JSON.parse(view.columns);
+				this.list_view.list_view_settings.fields = JSON.stringify(saved_columns);
+				
+				// Build columns array directly from saved view
+				this.apply_saved_columns(saved_columns);
+			}
+
+			// Apply filters
+			if (view.filters) {
+				const filters = JSON.parse(view.filters);
+				await this.list_view.filter_area.clear(false);
+				if (filters.length) {
+					await this.list_view.filter_area.add(filters);
+				}
+			}
+
+			// Apply sorting
+			if (view.sort_by) {
+				this.list_view.sort_by = view.sort_by;
+				this.list_view.sort_order = view.sort_order || "desc";
+				this.list_view.sort_selector?.set_value(view.sort_by, view.sort_order);
+			}
+
+			// Apply list view settings
+			const settings = {
+				disable_count: view.disable_count,
+				disable_auto_refresh: view.disable_auto_refresh,
+				disable_sidebar_stats: view.disable_sidebar_stats,
+				disable_automatic_recency_filters: view.disable_automatic_recency_filters,
+				disable_comment_count: view.disable_comment_count,
+				disable_scrolling: view.disable_scrolling,
+				allow_edit: view.allow_edit,
+				show_tags: view.show_tags,
+			};
+			Object.assign(this.list_view.list_view_settings, settings);
+
+			// Refresh the list and re-render header
+			await this.list_view.refresh(true);
+
+			// Update dropdown label
+			this.update_dropdown_label(view.view_name);
+			this.refresh_dropdown();
+
+			if (!silent) {
+				frappe.show_alert({
+					message: __("View '{0}' applied", [view.view_name]),
+					indicator: "green",
+				});
+			}
+		} catch (e) {
+			console.error("Error applying view:", e);
+			frappe.show_alert({
+				message: __("Error applying view"),
+				indicator: "red",
+			});
+		}
+	}
+
+	apply_saved_columns(saved_columns) {
+		// Build columns array directly from saved view
+		const list_view = this.list_view;
+		const get_df = frappe.meta.get_docfield.bind(null, this.doctype);
+		
+		// Start with empty columns
+		list_view.columns = [];
+		
+		// Add title field first (always first column)
+		if (list_view.meta.title_field) {
+			list_view.columns.push({
+				type: "Subject",
+				df: get_df(list_view.meta.title_field),
+			});
+		} else {
+			list_view.columns.push({
+				type: "Subject",
+				df: {
+					label: __("ID"),
+					fieldname: "name",
+				},
+			});
+		}
+		
+		// Add Tag column (normally hidden)
+		list_view.columns.push({
+			type: "Tag",
+		});
+		
+		// Add columns from saved view
+		for (const field of saved_columns) {
+			// Skip subject field (already added)
+			if (field.fieldname === list_view.meta.title_field) continue;
+			if (field.fieldname === "name" && !list_view.meta.title_field) continue;
+			
+			// Handle status field
+			if (field.fieldname === "status_field") {
+				if (frappe.has_indicator(this.doctype)) {
+					list_view.columns.push({
+						type: "Status",
+					});
+				}
+				continue;
+			}
+			
+			// Get field definition from meta
+			const df = get_df(field.fieldname);
+			if (df) {
+				list_view.columns.push({
+					type: "Field",
+					df: df,
+				});
+			} else if (field.fieldname === "name") {
+				// Handle ID field
+				list_view.columns.push({
+					type: "Field",
+					df: {
+						label: __("ID"),
+						fieldname: "name",
+					},
+				});
+			}
+		}
+		
+		// Limit columns
+		list_view.columns = list_view.columns.slice(0, list_view.max_number_of_fields);
+		
+		// Re-render header with new columns
+		list_view.render_header(true);
+	}
+
+	reset_to_default() {
+		this.current_view = null;
+		this.current_view_data = null;
+
+		// Clear filters
+		this.list_view.filter_area.clear();
+
+		// Reset sorting
+		this.list_view.sort_by = this.list_view.meta.sort_field || "creation";
+		this.list_view.sort_order = this.list_view.meta.sort_order || "desc";
+
+		// Reset columns
+		this.list_view.list_view_settings.fields = null;
+
+		// Reset list view settings to default
+		frappe.call({
+			method: "frappe.desk.listview.get_list_settings",
+			args: { doctype: this.doctype },
+		}).then((response) => {
+			this.list_view.list_view_settings = response.message || {};
+			this.list_view.setup_columns();
+			this.list_view.refresh(true);
+		});
+
+		this.update_dropdown_label(__("Saved Views"));
+		this.refresh_dropdown();
+
+		frappe.show_alert({
+			message: __("Reset to default view"),
+			indicator: "blue",
+		});
+	}
+
+	update_dropdown_label(label) {
+		const $btn = $(`.inner-group-button[data-label="${encodeURIComponent("Saved Views")}"] button`);
+		$btn.contents().first()[0].textContent = label;
+	}
+
+	show_save_dialog(save_as_new = false) {
+		const fields = [
+			{
+				fieldname: "view_name",
+				label: __("View Name"),
+				fieldtype: "Data",
+				reqd: 1,
+				default: save_as_new ? "" : (this.current_view_data?.view_name || ""),
+			},
+		];
+
+		// Add is_public option for System Managers
+		if (frappe.user.has_role("System Manager")) {
+			fields.push({
+				fieldname: "is_public",
+				label: __("Public View"),
+				fieldtype: "Check",
+				description: __("Public views are visible to all users"),
+				default: save_as_new ? 0 : (this.current_view_data?.is_public || 0),
+			});
+		}
+
+		const dialog = new frappe.ui.Dialog({
+			title: save_as_new ? __("Save as New View") : __("Save View"),
+			fields: fields,
+			primary_action_label: __("Save"),
+			primary_action: async (values) => {
+				await this.save_view(
+					values.view_name,
+					values.is_public || 0,
+					save_as_new ? null : this.current_view
+				);
+				dialog.hide();
+			},
+		});
+		dialog.show();
+	}
+
+	async save_view(view_name, is_public, view_id = null) {
+		// Gather current state
+		const columns = this.get_current_columns();
+		const filters = this.get_current_filters();
+		const sort_by = this.list_view.sort_by;
+		const sort_order = this.list_view.sort_order;
+		const settings = this.get_current_settings();
+
+		try {
+			const response = await frappe.call({
+				method: "frappe.desk.doctype.user_saved_list_view.user_saved_list_view.save_view",
+				args: {
+					doctype: this.doctype,
+					view_name: view_name,
+					columns: JSON.stringify(columns),
+					filters: JSON.stringify(filters),
+					sort_by: sort_by,
+					sort_order: sort_order,
+					settings: JSON.stringify(settings),
+					is_public: is_public,
+					view_id: view_id,
+				},
+			});
+
+			if (response.message) {
+				this.current_view = response.message.name;
+				await this.fetch_views();
+				this.refresh_dropdown();
+				this.update_dropdown_label(view_name);
+
+				frappe.show_alert({
+					message: __("View '{0}' saved", [view_name]),
+					indicator: "green",
+				});
+			}
+		} catch (e) {
+			console.error("Error saving view:", e);
+			frappe.show_alert({
+				message: __("Error saving view"),
+				indicator: "red",
+			});
+		}
+	}
+
+	async update_current_view() {
+		if (!this.current_view || !this.current_view_data) {
+			frappe.show_alert({
+				message: __("No view selected to update"),
+				indicator: "orange",
+			});
+			return;
+		}
+
+		await this.save_view(
+			this.current_view_data.view_name,
+			this.current_view_data.is_public,
+			this.current_view
+		);
+	}
+
+	get_current_columns() {
+		// Get current columns from list view
+		if (this.list_view.list_view_settings?.fields) {
+			return JSON.parse(this.list_view.list_view_settings.fields);
+		}
+
+		// Fallback to default columns from list view
+		return this.list_view.columns
+			.filter((col) => col.type === "Field" || col.type === "Subject" || col.type === "Status")
+			.map((col) => {
+				if (col.type === "Status") {
+					return { fieldname: "status_field", label: __("Status") };
+				}
+				return {
+					fieldname: col.df?.fieldname || col.fieldname,
+					label: col.df?.label || col.label,
+				};
+			});
+	}
+
+	get_current_filters() {
+		return this.list_view.filter_area?.get() || [];
+	}
+
+	get_current_settings() {
+		const settings = this.list_view.list_view_settings || {};
+		return {
+			disable_count: settings.disable_count || 0,
+			disable_auto_refresh: settings.disable_auto_refresh || 0,
+			disable_sidebar_stats: settings.disable_sidebar_stats || 0,
+			disable_automatic_recency_filters: settings.disable_automatic_recency_filters || 0,
+			disable_comment_count: settings.disable_comment_count || 0,
+			disable_scrolling: settings.disable_scrolling || 0,
+			allow_edit: settings.allow_edit || 0,
+			show_tags: settings.show_tags || 0,
+		};
+	}
+
+	async set_as_default(view_name, view_label) {
+		try {
+			await frappe.call({
+				method: "frappe.desk.doctype.user_saved_list_view.user_saved_list_view.set_default_view",
+				args: {
+					doctype: this.doctype,
+					view_name: view_name,
+				},
+			});
+
+			frappe.show_alert({
+				message: __("'{0}' set as default view", [view_label]),
+				indicator: "green",
+			});
+		} catch (e) {
+			console.error("Error setting default view:", e);
+		}
+	}
+
+	async delete_view(view_name, view_label) {
+		frappe.confirm(
+			__("Are you sure you want to delete the view '{0}'?", [view_label]),
+			async () => {
+				try {
+					await frappe.call({
+						method: "frappe.desk.doctype.user_saved_list_view.user_saved_list_view.delete_view",
+						args: { name: view_name },
+					});
+
+					// Reset to default if deleted view was current
+					if (this.current_view === view_name) {
+						this.reset_to_default();
+					}
+
+					await this.fetch_views();
+					this.refresh_dropdown();
+
+					frappe.show_alert({
+						message: __("View '{0}' deleted", [view_label]),
+						indicator: "green",
+					});
+				} catch (e) {
+					console.error("Error deleting view:", e);
+					frappe.show_alert({
+						message: __("Error deleting view"),
+						indicator: "red",
+					});
+				}
+			}
+		);
+	}
+}

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -684,3 +684,57 @@ input.list-header-checkbox {
 		}
 	}
 }
+
+// Saved Views Selector Styles
+.view-item {
+	padding: 0.5rem 1rem;
+	cursor: pointer;
+	
+	&:hover {
+		background-color: var(--bg-light-gray);
+	}
+	
+	&.active {
+		background-color: var(--bg-blue);
+		
+		.view-name {
+			font-weight: 600;
+		}
+	}
+	
+	.view-name {
+		color: var(--text-color);
+		text-decoration: none;
+		
+		&:hover {
+			color: var(--text-color);
+		}
+	}
+	
+	.view-actions {
+		display: none;
+		white-space: nowrap;
+		
+		a {
+			padding: 0.25rem;
+			border-radius: var(--border-radius-sm);
+			
+			&:hover {
+				background-color: var(--bg-light-gray);
+			}
+		}
+	}
+	
+	&:hover .view-actions {
+		display: inline-flex;
+		gap: 0.25rem;
+	}
+}
+
+.dropdown-header {
+	font-size: var(--text-xs);
+	color: var(--text-muted);
+	font-weight: 600;
+	text-transform: uppercase;
+	padding: 0.5rem 1rem;
+}


### PR DESCRIPTION
I think this could be a valuable feature.

Includes the ability to save different views, and set it as private or public.

Let's configure:

- Visible columns
- Column order
- Filters
- Data ordering
- Listview settings (disable count, disable scrolling ...)

<img width="1730" height="627" alt="image" src="https://github.com/user-attachments/assets/94929e27-dd38-41c2-b43e-05350dfafcd9" />


The movie:

https://github.com/user-attachments/assets/1e1232ce-8242-4b9e-9f38-d0f208792308

Resolves https://github.com/frappe/frappe/issues/14631

Maybe UI should align with this:
https://github.com/frappe/frappe/issues/36642


- [ ] Save ordering
- [ ] Better UI
- [ ] Refresh dropdown after creating/editing view
- [ ] Better DocType name (currently "User Saved List View")
- [ ] Mobile?
- [ ] Testing


