### PR TITLE
fix: events not appearing with timezone difference

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -285,7 +285,7 @@ frappe.views.Calendar = class Calendar {
 					},
 				});
 			},
-			timezone: 'local',
+			timezone: "local",
 			displayEventEnd: true,
 			eventRender: function (event, element) {
 				element.attr("title", event.tooltip);

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -285,6 +285,7 @@ frappe.views.Calendar = class Calendar {
 					},
 				});
 			},
+			timezone: 'local',
 			displayEventEnd: true,
 			eventRender: function (event, element) {
 				element.attr("title", event.tooltip);
@@ -355,8 +356,8 @@ frappe.views.Calendar = class Calendar {
 	get_args(start, end) {
 		var args = {
 			doctype: this.doctype,
-			start: this.get_system_datetime(start),
-			end: this.get_system_datetime(end),
+			start: start.format(),
+			end: end.format(),
 			fields: this.fields,
 			filters: this.list_view.filter_area.get(),
 			field_map: this.field_map,


### PR DESCRIPTION
Closes #34444 

Formats start and end to be date strings instead of the datetime strings that came with TZ formatting.