### PR TITLE
fix: remove reload file button

### DIFF
--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -19,7 +19,6 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 					<a class="attached-file-link" target="_blank"></a>
 				</div>
 				<div class="flex" style="align-items: center">
-					<a class="btn btn-xs btn-default" data-action="reload_attachment">${__("Reload File")}</a>
 					<a class="btn btn-xs btn-default" data-action="clear_attachment">${__("Clear")}</a>
 				</div>
 			</div>`
@@ -31,7 +30,6 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 		this.has_input = true;
 
 		frappe.utils.bind_actions_with_object(this.$value, this);
-		this.toggle_reload_button();
 	}
 	clear_attachment() {
 		let me = this;
@@ -52,11 +50,6 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 				me.refresh();
 			}
 		});
-	}
-	reload_attachment() {
-		if (this.file_uploader) {
-			this.file_uploader.uploader.upload_files();
-		}
 	}
 	on_attach_click() {
 		this.set_upload_options();
@@ -81,7 +74,6 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 			allow_multiple: false,
 			on_success: (file) => {
 				this.on_upload_complete(file);
-				this.toggle_reload_button();
 			},
 			restrictions: {},
 		};
@@ -150,11 +142,5 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 			this.frm.doc.docstatus == 1 ? this.frm.save("Update") : this.frm.save();
 		}
 		this.set_value(attachment.file_url);
-	}
-
-	toggle_reload_button() {
-		this.$value
-			.find('[data-action="reload_attachment"]')
-			.toggle(this.file_uploader && this.file_uploader.uploader.files.length > 0);
 	}
 };


### PR DESCRIPTION
Was added in https://github.com/frappe/frappe/commit/1cccb33bada07b6d58e3f563a2fc9972ce020623#diff-046b65a20286ccfeaaf368023321facf56397947a3a6c3978ca6dd32ed5a5a56

The feature doesn't work. browser throws `ERR_UPLOAD_FILE_CHANGED` if a re-upload is attempted with a changed file.

Also causes duplication issues - closes #26923 