### PR TITLE
fix(print): Repeat table headers on multi-page PDF prints

### DIFF
--- a/frappe/public/scss/print.bundle.scss
+++ b/frappe/public/scss/print.bundle.scss
@@ -55,3 +55,9 @@
 .ql-editor {
 	counter-reset: none;
 }
+thead {
+	display: table-header-group !important;
+}
+tfoot {
+	display: table-footer-group !important;
+}


### PR DESCRIPTION
<!--
Summary
Fixes the issue where table headers don't repeat on subsequent pages in PDF prints.
Description
Added `display: table-header-group` to `thead` in print SCSS to ensure headers repeat across multiple pages when using wkhtmltopdf.
Before:
  

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
