### PR TITLE
Fix pdf table header repetition

### DIFF
--- a/.github/workflows/_base-migration.yml
+++ b/.github/workflows/_base-migration.yml
@@ -117,6 +117,8 @@ jobs:
             fi
 
             echo "Setting up environment..."
+            
+            # Last python version in the array is the "default", so the 2nd parameter here is optional
             if rm -rf ${GITHUB_WORKSPACE}/env && python"$2" -m venv ${GITHUB_WORKSPACE}/env; then
                 source ${GITHUB_WORKSPACE}/env/bin/activate
                 pip install --quiet --upgrade pip
@@ -154,18 +156,12 @@ jobs:
         # Save this script into a file for later use.
         declare -f update_to_version > "$RUNNER_TEMP/migrate"
 
-    - name: Update to v14
-      run: |
-        source $RUNNER_TEMP/migrate
-        update_to_version 14 3.11
-        exit $?
-
     - name: Update to v15
       run: |
         source $RUNNER_TEMP/migrate
         update_to_version 15 3.13
         exit $?
-
+        
     - name: Update to last commit
       run: |
         source $RUNNER_TEMP/migrate

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,7 +2,7 @@ name: Generate Semantic Release
 on:
   push:
     branches:
-      - version-14-beta
+      - version-16
 permissions:
   contents: read
 

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -57,7 +57,7 @@ jobs:
     needs: checkrun
     uses: ./.github/workflows/_base-migration.yml
     with:
-      db-artifact-url: https://frappeframework.com/files/v13-frappe.sql.gz
+      db-artifact-url: https://frappe.io/files/v14-frappe.sql.gz
       python-version: '3.14'
       node-version: 24
       fake-success: ${{ needs.checkrun.outputs.build != 'strawberry' }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 {
-	"branches": ["develop", {"name": "version-14-beta", "channel": "beta", "prerelease": true}],
+	"branches": ["version-16"],
 	"plugins": [
 		"@semantic-release/commit-analyzer", {
 			"preset": "angular"

--- a/.releaserc
+++ b/.releaserc
@@ -2,18 +2,21 @@
 	"branches": ["version-16"],
 	"plugins": [
 		"@semantic-release/commit-analyzer", {
-			"preset": "angular"
+			"preset": "angular",
+			"releaseRules": [
+				{"breaking": true, "release": false}
+			]
 		},
 		"@semantic-release/release-notes-generator",
 		[
 			"@semantic-release/exec", {
-				"prepareCmd": 'sed -ir "s/[0-9]*\.[0-9]*\.[0-9]*/${nextRelease.version}/" frappe/__init__.py'
+				"prepareCmd": 'sed -ir -E "s/\"[0-9]+\.[0-9]+\.[0-9]+\"/\"${nextRelease.version}\"/" frappe/__init__.py'
 			}
 		],
 		[
 			"@semantic-release/git", {
 				"assets": ["frappe/__init__.py"],
-				"message": "chore(release): Bumped to Version ${nextRelease.version}"
+				"message": "chore(release): Bumped to Version ${nextRelease.version}\n\n${nextRelease.notes}"
 			}
 		],
 		"@semantic-release/github"

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -848,7 +848,7 @@ def get_app_source_path(app_name, *joins):
 
 	:param app: App name.
 	:param *joins: Join additional path elements using `os.path.join`."""
-	return get_app_path(app_name, "16.1.0", *joins)
+	return get_app_path(app_name, "..", *joins)
 
 
 def get_site_path(*joins):
@@ -1147,7 +1147,7 @@ def get_newargs(fn: Callable, kwargs: dict[str, Any]) -> dict[str, Any]:
 
 	Example:
 	        >>> def fn(a=1, b=2):
-	        16.1.0.     pass
+	        ...     pass
 
 	        >>> get_newargs(fn, {"a": 2, "c": 1})
 	                {"a": 2}

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -54,7 +54,7 @@ from .utils.jinja import (
 	render_template,
 )
 
-__version__ = "16.0.0-dev"
+__version__ = "16.0.0"
 __title__ = "Frappe Framework"
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -54,7 +54,7 @@ from .utils.jinja import (
 	render_template,
 )
 
-__version__ = "16.0.0"
+__version__ = "16.1.0"
 __title__ = "Frappe Framework"
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -848,7 +848,7 @@ def get_app_source_path(app_name, *joins):
 
 	:param app: App name.
 	:param *joins: Join additional path elements using `os.path.join`."""
-	return get_app_path(app_name, "..", *joins)
+	return get_app_path(app_name, "16.1.0", *joins)
 
 
 def get_site_path(*joins):
@@ -1147,7 +1147,7 @@ def get_newargs(fn: Callable, kwargs: dict[str, Any]) -> dict[str, Any]:
 
 	Example:
 	        >>> def fn(a=1, b=2):
-	        ...     pass
+	        16.1.0.     pass
 
 	        >>> get_newargs(fn, {"a": 2, "c": 1})
 	                {"a": 2}

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -54,7 +54,7 @@ from .utils.jinja import (
 	render_template,
 )
 
-__version__ = "16.1.0"
+__version__ = "16.1.1"
 __title__ = "Frappe Framework"
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -36,6 +36,10 @@ frappe.ui.form.PrintView = class {
 		this.wrapper = $(wrapper);
 		this.page = wrapper.page;
 		this.make();
+
+		this.wrapper.on("show", () => {
+			this.page.sidebar.show();
+		});
 	}
 
 	make() {
@@ -152,7 +156,6 @@ frappe.ui.form.PrintView = class {
 		this.sidebar_dynamic_section = $(`<div class="dynamic-settings"></div>`).appendTo(
 			this.sidebar
 		);
-		this.page.sidebar.show();
 	}
 
 	add_sidebar_item(df, is_dynamic) {

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -152,6 +152,7 @@ frappe.ui.form.PrintView = class {
 		this.sidebar_dynamic_section = $(`<div class="dynamic-settings"></div>`).appendTo(
 			this.sidebar
 		);
+		this.page.sidebar.show();
 	}
 
 	add_sidebar_item(df, is_dynamic) {

--- a/frappe/public/js/billing.bundle.js
+++ b/frappe/public/js/billing.bundle.js
@@ -19,9 +19,11 @@ $(document).ready(function () {
 				isFCUser = response.is_fc_user;
 
 				if (response.trial_end_date && trial_end_date > new Date()) {
-					$(".layout-main-section").before(
-						generateTrialSubscriptionBanner(response.trial_end_date)
-					);
+					if ($(".layout-main-section").closest("#page-desktop").length === 0) {
+						$(".layout-main-section").before(
+							generateTrialSubscriptionBanner(response.trial_end_date)
+						);
+					}
 				}
 				addManageBillingDropdown();
 

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -664,7 +664,6 @@ frappe.ui.form.Form = class FrappeForm {
 			this.page.$title_area
 				.parent()
 				.css("max-width", overflow ? `calc(50% - ${overflow}px)` : "50%");
-			console.log(this.page.$title_area.find("ul li.ellipsis")[0].clientWidth);
 			let breadcrumb = this.page.$title_area.find("ul li.ellipsis");
 			if (!breadcrumb[0]?.clientWidth) {
 				// if workspce sodebar is not visible

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -665,10 +665,11 @@ frappe.ui.form.Form = class FrappeForm {
 				.parent()
 				.css("max-width", overflow ? `calc(50% - ${overflow}px)` : "50%");
 			let breadcrumb = this.page.$title_area.find("ul li.ellipsis");
-			if (!breadcrumb[0]?.clientWidth) {
+
+			if (cint(breadcrumb[0]?.clientWidth) <= 30) {
 				// if workspce sodebar is not visible
 				$(breadcrumb[0]).hide();
-				if (!breadcrumb[1]?.clientWidth) {
+				if (cint(breadcrumb[1]?.clientWidth) <= 30) {
 					// if doctype sodebar is not visible
 					$(breadcrumb[1]).hide();
 

--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -88,7 +88,7 @@ frappe.ui.get_print_settings = function (
 	return frappe.prompt(
 		columns,
 		function (settings) {
-			settings = $.extend(print_settings, settings);
+			settings = $.extend({}, print_settings, settings);
 
 			if (!settings.with_letter_head) {
 				settings.letter_head = null;

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -40,11 +40,9 @@ frappe.ui.form.Sidebar = class {
 		this.indicator = $(this.sidebar).find(".sidebar-meta-details .indicator-pill");
 		this.setup_copy_event();
 		this.make_like();
+		this.setup_print();
+		this.setup_editable_title();
 		this.refresh();
-
-		// setup editable title
-		let form_sidebar_text = $(this.sidebar).find(".sidebar-meta-details .form-title-text");
-		this.toolbar.setup_editable_title(form_sidebar_text);
 	}
 
 	setup_keyboard_shortcuts() {
@@ -79,6 +77,39 @@ frappe.ui.form.Sidebar = class {
 			.on("click", (e) => {
 				frappe.utils.copy_to_clipboard($(e.currentTarget).attr("data-copy"));
 			});
+	}
+
+	setup_editable_title() {
+		// setup editable title
+		let form_sidebar_text = $(this.sidebar).find(".form-stats-likes .form-title-text");
+		this.toolbar.setup_editable_title(form_sidebar_text);
+	}
+
+	setup_print() {
+		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings");
+		const allow_print_for_draft = cint(print_settings.allow_print_for_draft);
+		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
+
+		if (
+			!frappe.model.is_submittable(this.frm.doc.doctype) ||
+			this.frm.doc.docstatus == 1 ||
+			(allow_print_for_cancelled && this.frm.doc.docstatus == 2) ||
+			(allow_print_for_draft && this.frm.doc.docstatus == 0)
+		) {
+			if (frappe.model.can_print(null, this.frm) && !this.frm.meta.issingle) {
+				let print_icon = this.page.add_action_icon(
+					"printer",
+					() => {
+						this.frm.print_doc();
+					},
+					"",
+					__("Print")
+				);
+				print_icon.css("background-color", "transparent");
+				print_icon.addClass("p-0");
+				this.sidebar.find(".form-print").append(print_icon);
+			}
+		}
 	}
 
 	make_like() {

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -15,7 +15,9 @@ frappe.ui.form.Sidebar = class {
 		var sidebar_content = frappe.render_template("form_sidebar", {
 			doctype: this.frm.doctype,
 			frm: this.frm,
-			can_write: frappe.model.can_write(this.frm.doctype, this.frm.docname),
+			can_write:
+				frappe.model.can_write(this.frm.doctype, this.frm.docname) &&
+				!this.frm.fields_dict[this.frm.meta.image_field]?.df.read_only,
 			image_field: this.frm.meta.image_field ?? false,
 		});
 

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -155,7 +155,28 @@ frappe.ui.form.Sidebar = class {
 	}
 
 	refresh_creation_modified() {
-		// remove redundant (present in the activity timeline) creation/modified info
+		this.sidebar
+			.find(".modified-by")
+			.html(
+				get_user_message(
+					this.frm.doc.modified_by,
+					__("Last Edited by You", null),
+					__("Last Edited by {0}", [get_user_link(this.frm.doc.modified_by)])
+				) +
+					" <br> " +
+					comment_when(this.frm.doc.modified)
+			);
+		this.sidebar
+			.find(".created-by")
+			.html(
+				get_user_message(
+					this.frm.doc.owner,
+					__("Created By You", null),
+					__("Created By {0}", [get_user_link(this.frm.doc.owner)])
+				) +
+					" <br> " +
+					comment_when(this.frm.doc.creation)
+			);
 	}
 
 	show_auto_repeat_status() {

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -17,7 +17,10 @@
 		</div>
 		{% endif %}
 	</div>
-	<div class="form-stats-likes">
+	{% if image_field %}
+	<div class="align-items-baseline flex form-stats-likes">
+		<div class="form-title-text"></div>
+		<div class="form-print"></div>
 		<span class="liked-by like-action d-flex align-items-center">
 			<svg class="icon icon-sm like-icon pointer">
 				<use href="#icon-heart"></use>
@@ -25,14 +28,29 @@
 			<span class="like-count ml-2"></span>
 		</span>
 	</div>
+	{% endif %}
 </div>
-<div class="sidebar-section sidebar-meta-details border-bottom">
-	<div class="form-details flex justify-between">
-		<span class="bold ellipsis form-title-text mr-3 pointer text-medium" title="{{__("Click to edit")}}">{%= frappe.utils.html2text(frm.get_title()) %}</span>
+<div class="sidebar-section sidebar-meta-details border-bottom flex justify-between">
+	<div>
+		{% if frm.doc.name != frm.get_title() %}
+		<div class="form-details flex justify-between">
+			<span class="bold ellipsis form-title-text mr-3 pointer text-medium" title="{{__("Click to edit")}}">{%= frappe.utils.html2text(frm.get_title()) %}</span>
+		</div>
+		{% endif %}
+		<div class="form-name-container mt-2 flex justify-between form-name-copy" data-copy="{{frm.doc.name}}" >
+			<span class="ellipsis mr-3">{%= frm.doc.name %}</span>
+		</div>
 	</div>
-	{% if frm.doc.name != frm.get_title() %}
-	<div class="form-name-container mt-2 flex justify-between form-name-copy" data-copy="{{frm.doc.name}}" >
-		<span class="ellipsis mr-3">{%= frm.doc.name %}</span>
+	{% if not image_field %}
+	<div class="align-items-baseline flex form-stats-likes">
+		<div class="form-title-text"></div>
+		<div class="form-print"></div>
+		<span class="liked-by like-action d-flex align-items-center">
+			<svg class="icon icon-sm like-icon pointer">
+				<use href="#icon-heart"></use>
+			</svg>
+			<span class="like-count ml-2"></span>
+		</span>
 	</div>
 	{% endif %}
 </div>
@@ -60,7 +78,7 @@
 	</div>
 	{% } %}
 </div>
-<div class="sidebar-section form-assignments border-bottom">
+<div class="sidebar-section form-assignments">
 	<div>
 		<span class="form-sidebar-items">
 			<span class="add-assignment-label form-sidebar-label">
@@ -74,7 +92,7 @@
 		<div class="assignments"></div>
 	</div>
 </div>
-<div class="sidebar-section form-attachments border-bottom">
+<div class="sidebar-section form-attachments">
 	<div class="attachments-actions">
 		<span class="form-sidebar-items">
 			<span>
@@ -94,7 +112,7 @@
 		</span>
 	</a>
 </div>
-<div class="sidebar-section form-tags border-bottom">
+<div class="sidebar-section form-tags">
 	<div>
 		<span class="form-sidebar-items">
 			<div class="form-sidebar-label">
@@ -104,7 +122,7 @@
 		</span>
 	</div>
 </div>
-<div class="sidebar-section form-shared">
+<div class="sidebar-section form-shared border-bottom">
 	<div>
 		<span class="form-sidebar-items">
 			<span class="share-label form-sidebar-label">

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -30,39 +30,42 @@
 	</div>
 	{% endif %}
 </div>
-<div class="sidebar-section sidebar-meta-details border-bottom flex justify-between">
-	<div>
-		{% if frm.doc.name != frm.get_title() %}
-		<div class="form-details flex justify-between">
-			<span class="bold ellipsis form-title-text mr-3 pointer text-medium" title="{{__("Click to edit")}}">{%= frappe.utils.html2text(frm.get_title()) %}</span>
+<div class="sidebar-section sidebar-meta-details border-bottom">
+	<div class="flex justify-between">
+		<div>
+			{% if frm.doc.name != frm.get_title() %}
+			<div class="form-details flex justify-between">
+				<span class="bold ellipsis form-title-text mr-3 pointer text-medium" title="{{__("Click to edit")}}">{%= frappe.utils.html2text(frm.get_title()) %}</span>
+			</div>
+			{% endif %}
+			<div class="form-name-container mt-2 flex justify-between form-name-copy" data-copy="{{frm.doc.name}}" >
+				<span class="ellipsis mr-3">{%= frm.doc.name %}</span>
+			</div>
+		</div>
+		{% if not image_field %}
+		<div class="align-items-baseline flex form-stats-likes">
+			<div class="form-title-text"></div>
+			<div class="form-print"></div>
+			<span class="liked-by like-action d-flex align-items-center">
+				<svg class="icon icon-sm like-icon pointer">
+					<use href="#icon-heart"></use>
+				</svg>
+				<span class="like-count ml-2"></span>
+			</span>
 		</div>
 		{% endif %}
-		<div class="form-name-container mt-2 flex justify-between form-name-copy" data-copy="{{frm.doc.name}}" >
-			<span class="ellipsis mr-3">{%= frm.doc.name %}</span>
-		</div>
 	</div>
-	{% if not image_field %}
-	<div class="align-items-baseline flex form-stats-likes">
-		<div class="form-title-text"></div>
-		<div class="form-print"></div>
-		<span class="liked-by like-action d-flex align-items-center">
-			<svg class="icon icon-sm like-icon pointer">
-				<use href="#icon-heart"></use>
-			</svg>
-			<span class="like-count ml-2"></span>
-		</span>
+	{% if frm.meta.beta %}
+	<div class="flex pt-2 justify-between">
+		<div>
+			<a class="small text-muted" href="https://github.com/frappe/{{ frappe.boot.module_app[frappe.scrub(frm.meta.module)] }}/issues/new"
+				target="_blank">
+			{{ __("Report bug") }}</a>
+		</div>
+		<label class="indicator-pill yellow mb-0" title="{{ __("This feature is brand new and still experimental") }}">{{ __("Experimental") }}</label>
 	</div>
 	{% endif %}
 </div>
-{% if frm.meta.beta %}
-<div class="sidebar-section border-bottom">
-	<p><label class="indicator-pill yellow" title="{{ __("This feature is brand new and still experimental") }}">{{ __("Experimental") }}</label></p>
-	<div><a class="small text-muted" href="https://github.com/frappe/{{ frappe.boot.module_app[frappe.scrub(frm.meta.module)] }}/issues/new"
-			target="_blank">
-		{{ __("Report bug") }}</a></div>
-
-</div>
-{% endif %}
 <div class="sidebar-section sidebar-rating hide border-bottom">
 	<div style="position: relative;">
 		<a class="strong badge-hover">

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -35,7 +35,7 @@
 		<div class="ellipsis">
 			{% if frm.doc.name != frm.get_title() %}
 			<div class="form-details flex justify-between">
-				<span class="bold ellipsis form-title-text mr-3 pointer text-medium" title="{{__("Click to edit")}}">{%= frappe.utils.html2text(frm.get_title()) %}</span>
+				<span class="bold ellipsis form-title-text mr-3 text-medium">{%= frappe.utils.html2text(frm.get_title()) %}</span>
 			</div>
 			{% endif %}
 			<div class="form-name-container mt-2 flex justify-between form-name-copy" data-copy="{{frm.doc.name}}" >

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -31,8 +31,8 @@
 	{% endif %}
 </div>
 <div class="sidebar-section sidebar-meta-details border-bottom">
-	<div class="flex justify-between">
-		<div>
+	<div class="flex justify-between overflow-hidden">
+		<div class="ellipsis">
 			{% if frm.doc.name != frm.get_title() %}
 			<div class="form-details flex justify-between">
 				<span class="bold ellipsis form-title-text mr-3 pointer text-medium" title="{{__("Click to edit")}}">{%= frappe.utils.html2text(frm.get_title()) %}</span>

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -158,9 +158,9 @@
 </div>
 <div class="sidebar-section text-muted border-top pt-3">
 	<ul class="list-unstyled sidebar-menu text-muted">
-		<li class="pageview-count"></li>
 		<li class="modified-by"></li>
 		<li class="created-by"></li>
+		<li class="pageview-count"></li>
 	</ul>
 </div>
 

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -200,17 +200,27 @@ frappe.ui.form.Toolbar = class Toolbar {
 			}
 		});
 	}
+
 	setup_editable_title(element) {
 		let me = this;
 
 		if (me.is_title_editable()) {
-			$(element).tooltip({
-				delay: { show: 100, hide: 100 },
-				trigger: "hover",
-			});
-			$(element).addClass("pointer");
+			let edit_icon = this.page.add_action_icon(
+				"square-pen",
+				() => {
+					me.setup_editable_title_click_event(element);
+				},
+				"",
+				__("Edit")
+			);
+			edit_icon.css("background-color", "transparent");
+			edit_icon.addClass("p-0");
+			element.append(edit_icon);
 		}
+	}
 
+	setup_editable_title_click_event(element) {
+		let me = this;
 		element.on("click", () => {
 			let fields = [];
 			let docname = me.frm.doc.name;
@@ -292,6 +302,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 			}
 		});
 	}
+
 	get_dropdown_menu(label) {
 		return this.page.add_dropdown(label);
 	}
@@ -351,7 +362,6 @@ frappe.ui.form.Toolbar = class Toolbar {
 	make_menu_items() {
 		// Print
 		this.add_discard();
-		this.add_print();
 		this.add_open_sidebar();
 		this.add_email();
 		this.add_rename();
@@ -385,37 +395,6 @@ frappe.ui.form.Toolbar = class Toolbar {
 				},
 				true
 			);
-		}
-	}
-
-	add_print() {
-		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings");
-		const allow_print_for_draft = cint(print_settings.allow_print_for_draft);
-		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
-
-		if (
-			!frappe.model.is_submittable(this.frm.doc.doctype) ||
-			this.frm.doc.docstatus == 1 ||
-			(allow_print_for_cancelled && this.frm.doc.docstatus == 2) ||
-			(allow_print_for_draft && this.frm.doc.docstatus == 0)
-		) {
-			if (frappe.model.can_print(null, this.frm) && !this.frm.meta.issingle) {
-				this.page.add_menu_item(
-					__("Print"),
-					() => {
-						this.frm.print_doc();
-					},
-					true
-				);
-				this.print_icon = this.page.add_action_icon(
-					"printer",
-					() => {
-						this.frm.print_doc();
-					},
-					"",
-					__("Print")
-				);
-			}
 		}
 	}
 

--- a/frappe/public/js/frappe/list/list_filter.js
+++ b/frappe/public/js/frappe/list/list_filter.js
@@ -37,7 +37,7 @@ export default class ListFilter {
 			const $item = this.filter_template(filter);
 
 			// Apply filter
-			$item.find(".filter-label").on("click", () => {
+			$item.find(".dropdown-item").on("click", () => {
 				this.apply_saved_filter(filter.name, filter.filter_name);
 			});
 

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -28,6 +28,14 @@
 				color: var(--text-light);
 			}
 		}
+		.modified-by,
+		.created-by {
+			.frappe-timestamp {
+				color: var(--text-light);
+				margin-top: 5px;
+				display: block;
+			}
+		}
 	}
 
 	.form-tags {

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -8,7 +8,10 @@
 // form sidebar
 .form-sidebar {
 	.sidebar-section {
-		padding: var(--padding-md);
+		padding: var(--padding-md) var(--padding-md) 0;
+		&.border-bottom {
+			padding-bottom: var(--padding-md);
+		}
 		.form-sidebar-items {
 			display: flex;
 			width: 100%;
@@ -88,7 +91,7 @@
 			transition: opacity 0.3s;
 			width: var(--form-sidebar-image-width);
 			height: var(--form-sidebar-image-width);
-			border-radius: var(--border-radius-lg);
+			border-radius: var(--border-radius-full);
 		}
 
 		.sidebar-image-wrapper:hover {
@@ -126,6 +129,19 @@
 	.sidebar-meta-details {
 		.form-name-copy {
 			cursor: copy;
+			font-size: 14px;
+		}
+	}
+
+	.form-stats-likes {
+		gap: 8px;
+		.form-print {
+			button:hover {
+				background: var(--btn-default-hover-bg);
+			}
+			svg {
+				margin: 0px;
+			}
 		}
 	}
 }

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -8,7 +8,6 @@ body:not([data-route^="Form"]) {
 	display: flex;
 	align-items: center;
 	padding: 0 15px;
-	max-width: 50%;
 	.sidebar-toggle-btn {
 		display: flex;
 		margin-right: var(--margin-sm);

--- a/frappe/public/scss/print.bundle.scss
+++ b/frappe/public/scss/print.bundle.scss
@@ -55,3 +55,20 @@
 .ql-editor {
 	counter-reset: none;
 }
+/* Ensure table headers repeat on every page in PDF */
+thead {
+	display: table-header-group !important;
+}
+
+tfoot {
+	display: table-footer-group !important;
+}
+
+table {
+	page-break-inside: auto;
+}
+
+tr {
+	page-break-inside: avoid !important;
+	page-break-after: auto;
+}


### PR DESCRIPTION
<!--
Summary
This PR fixes the issue where table headers do not repeat on subsequent pages when printing long tables to PDF.
Some key notes before you open a PR:
Description
Added `display: table-header-group` and `display: table-footer-group` to the print SCSS. This ensures that `thead` and `tfoot` elements are correctly repeated across page breaks in PDF generation (wkhtmltopdf).
Before:
![WhatsApp Image 2026-02-16 at 5 11 51 PM (1)](https://github.com/user-attachments/assets/c145d9be-19f7-425b-9a16-80254eacce70)


 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
