### PR TITLE
fix(dynamic_link): resolve translated option values using control's get_input_value

### DIFF
--- a/frappe/public/js/frappe/form/controls/dynamic_link.js
+++ b/frappe/public/js/frappe/form/controls/dynamic_link.js
@@ -13,11 +13,19 @@ frappe.ui.form.ControlDynamicLink = class ControlDynamicLink extends frappe.ui.f
 				// for list page
 				input = cur_list.filter_area.standard_filters_wrapper.find(selector);
 			}
-			if (cur_page) {
+			if (cur_page && !input) {
 				input = $(cur_page.page).find(selector);
 			}
 			if (input) {
-				options = input.val();
+				// Use the control instance's get_input_value() to resolve
+				// translated display text back to the actual value via title_value_map
+				let control = cur_list?.page?.fields_dict?.[this.df.options]
+					|| cur_page?.page?.fields_dict?.[this.df.options];
+				if (control && typeof control.get_input_value === "function") {
+					options = control.get_input_value();
+				} else {
+					options = input.val();
+				}
 			}
 		} else {
 			options = frappe.model.get_value(this.df.parent, this.docname, this.df.options);


### PR DESCRIPTION
This fix resolves the issue where Dynamic Link fields were not correctly handling translated option values (e.g., کسٹمر in Urdu, العميل in Arabic).

Supersedes #36808  (closed — reworked to be fully generic with no hardcoded field names, per reviewer feedback).

## Problem

When a page loads with a translated UI, Dynamic Link fields read the raw DOM value from their sibling Link field using `input.val()`. If the Link field displays a translated DocType name (e.g., 'کسٹمر' for Customer in Urdu, or 'العميل' in Arabic), this translated text is sent to `search_link`/`validate_link` APIs as the `doctype` parameter, which fails with a **403 FORBIDDEN** error because the translated text is not a valid DocType.

## Root Cause

`ControlDynamicLink.get_options()` bypasses the Link control's built-in translation resolution mechanism by reading `input.val()` directly from the DOM instead of using the control instance's `get_input_value()` method.

## Solution

Use the Link control's existing `get_input_value()` method which resolves translated display text back to the actual value via its `title_value_map`, instead of reading raw DOM values.

- Access the control instance via `page.fields_dict[fieldname]` (same pattern used in `base_list.js` for standard filters)
- Call `control.get_input_value()` which maps translated text → actual DocType name
- Fall back to `input.val()` if no control instance is found (backward compatibility)
- Add `&& !input` guard to prevent `cur_page` from overriding a valid input already found via `cur_list`

## Benefits

- Correctly resolves all translated values to English DocType names
- Works with any language (Urdu, Arabic, etc.)
- Works regardless of field selection order
- Works when the options field has a default value
- Eliminates 403 errors on `search_link`/`validate_link` API calls
- Fully generic — no hardcoded field names, works for ANY Dynamic Link + translated Link field combination
- Uses the framework's own existing translation resolution mechanism

## Files Modified

- `frappe/public/js/frappe/form/controls/dynamic_link.js`
  - Updated `get_options()` to use control instance's `get_input_value()` instead of raw `input.val()`
  - Added `&& !input` guard on `cur_page` lookup to prevent overriding `cur_list` result
  - Falls back to `input.val()` when control instance is unavailable

## Tested with

- Frappe Framework v15.96.0 and v15.99.0
- Languages: Urdu, Arabic, English
- Payment Entry list page with default party_type value
- Selecting Party directly without changing Party Type first
- Changing Party Type first, then selecting Party

<img width="3677" height="1557" alt="image" src="https://github.com/user-attachments/assets/dc803db6-f405-48e4-af1c-55d248871be4" />
