### PR TITLE
perf: Custom query report optimization

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -246,7 +246,7 @@ def add_custom_column_data(custom_columns, result):
 	doctype_names_from_custom_field = []
 	for column in custom_columns:
 		if len(column["fieldname"].split("-")) > 1:
-			# length greater than 1, means that the column is a custom field with confilicting fieldname
+			# length greater than 1, means that the column is a custom field with conflicting fieldname
 			doctype_name = frappe.unscrub(column["fieldname"].split("-")[1])
 			doctype_names_from_custom_field.append(doctype_name)
 		column["fieldname"] = column["fieldname"].split("-")[0]
@@ -259,7 +259,7 @@ def add_custom_column_data(custom_columns, result):
 			for row in result:
 				link_field = column.get("link_field")
 
-				# backwards compatibile `link_field`
+				# backwards compatible `link_field`
 				# old custom reports which use `str` should not break.
 				if isinstance(link_field, str):
 					link_field = frappe._dict({"fieldname": link_field, "names": []})
@@ -643,7 +643,7 @@ def get_data_for_custom_report(columns, result):
 
 	for column in columns:
 		if link_field := column.get("link_field"):
-			# backwards compatibile `link_field`
+			# backwards compatible `link_field`
 			# old custom reports which use `str` should not break
 			if isinstance(link_field, str):
 				link_field = frappe._dict({"fieldname": link_field, "names": []})
@@ -658,7 +658,10 @@ def get_data_for_custom_report(columns, result):
 					names.append(row.get(row_key))
 			names = list(set(names))
 
-			doc_field_value_map[(doctype, fieldname)] = get_data_for_custom_field(doctype, fieldname, names)
+			if names:
+				doc_field_value_map[(doctype, fieldname)] = get_data_for_custom_field(
+					doctype, fieldname, names
+				)
 	return doc_field_value_map
 
 


### PR DESCRIPTION
Custom column data should only be fetched based on names.
If there are no `names` present, it means that no custom data needs to be fetched.

Currently, even if no name is present, it does a full table scan of the custom column doctype. For large data volume tables this could take a lot of time in fetching the data unnecessarily

<img width="1916" height="186" alt="image" src="https://github.com/user-attachments/assets/b785abc9-c515-4673-b602-2e5bd2c0b504" />

<img width="2856" height="182" alt="image" src="https://github.com/user-attachments/assets/aa8b9f8e-a8c6-4ba7-904c-7beba3182a60" />
