### PR TITLE
fix: remove `max-width` for section content in non-form contexts like dialogs

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -78,12 +78,15 @@
 		}
 	}
 }
-.section-head,
-.section-body {
-	margin: auto !important;
 
-	body:not(.full-width) & {
-		max-width: var(--page-max-width);
+.std-form-layout {
+	.section-head,
+	.section-body {
+		margin: auto !important;
+
+		body:not(.full-width) & {
+			max-width: var(--page-max-width);
+		}
 	}
 }
 


### PR DESCRIPTION
- **Closes: https://github.com/frappe/erpnext/issues/52327**  

# Description of fix

After v16 UI changes, the ledger preview dialogs are not looking good, need an update and alignment fixes. The standard form layout restricts width (via `--page-max-width`).

 The whole point of having a size parameter on frappe.ui.Dialog is to have wider content but having max-width defeats that purpose. So we just to exclude non-form contexts (dialogs, fieldgroup instances, etc.) from that rule.

<img width="1907" height="875" alt="image" src="https://github.com/user-attachments/assets/c332ae17-37e8-42d2-a8cc-5c8cf9ad321c" />



# Screenshots

### Before:
<img width="1921" height="1014" alt="before" src="https://github.com/user-attachments/assets/c96e70c8-b0d1-4219-97ec-fd736fd30544" />

### After:
<img width="1921" height="1014" alt="after" src="https://github.com/user-attachments/assets/592325df-f85d-4a05-90da-f5878b3ac9f1" />
