### PR TITLE
fix: navigation api for explicit sorting

### DIFF
--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -84,32 +84,36 @@ def get_next(doctype, value, prev, filters=None, sort_order="desc", sort_field="
 	if isinstance(filters, str):
 		filters = json.loads(filters)
 
-	# # condition based on sort order
-	condition = ">" if sort_order.lower() == "asc" else "<"
+	table = frappe.qb.DocType(doctype)
+	sort_column = table[sort_field]
+	name_column = table.name
+	current_sort_value = frappe.db.get_value(doctype, value, sort_field)
 
-	# switch the condition
-	if prev:
-		sort_order = "asc" if sort_order.lower() == "desc" else "desc"
-		condition = "<" if condition == ">" else ">"
+	is_ascending = sort_order.lower() == "asc"
+	if prev == is_ascending:
+		composite_condition = (sort_column < current_sort_value) | (
+			(sort_column == current_sort_value) & (name_column < value)
+		)
+		order = frappe.qb.desc
+	else:
+		composite_condition = (sort_column > current_sort_value) | (
+			(sort_column == current_sort_value) & (name_column > value)
+		)
+		order = frappe.qb.asc
 
-	# # add condition for next or prev item
-	filters.append([doctype, sort_field, condition, frappe.get_value(doctype, value, sort_field)])
-
-	res = frappe.get_list(
-		doctype,
-		fields=["name"],
-		filters=filters,
-		order_by=f"{sort_field} {sort_order}",
-		limit_start=0,
-		limit_page_length=1,
-		as_list=True,
+	query = (
+		frappe.qb.get_query(doctype, filters=filters, fields=["name"])
+		.orderby(sort_column, order=order)
+		.orderby(name_column, order=order)
+		.where(composite_condition)
+		.limit(1)
 	)
 
-	if not res:
-		frappe.msgprint(_("No further records"))
-		return None
-	else:
+	if res := query.run(as_list=True):
 		return res[0][0]
+
+	frappe.msgprint(_("No further records"))
+	return None
 
 
 def get_pdf_link(doctype, docname, print_format="Standard", no_letterhead=0):

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -109,7 +109,7 @@ def get_next(
 		order = frappe.qb.asc
 
 	query = (
-		frappe.qb.get_query(doctype, filters=filters, fields=["name"])
+		frappe.qb.get_query(doctype, filters=filters, fields=["name"], ignore_permissions=False)
 		.orderby(sort_column, order=order)
 		.orderby(name_column, order=order)
 		.where(composite_condition)

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -77,7 +77,14 @@ def update_comment_publicity(name: str, publish: bool):
 
 
 @frappe.whitelist()
-def get_next(doctype, value, prev, filters=None, sort_order="desc", sort_field="creation"):
+def get_next(
+	doctype: str,
+	value: str,
+	prev: str | int,
+	filters: dict | str | None = None,
+	sort_order: str = "desc",
+	sort_field: str = "creation",
+):
 	prev = int(prev)
 	if not filters:
 		filters = []


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/29085

https://github.com/user-attachments/assets/e8d0afb1-df0a-44af-95e5-f51c61be163c

Previously, filtering of documents was done with a simple '>' or '<' operator applied on the field to be sorted on (e.g: `[['Sales Order', 'company', '<', 'Frappe (Demo)']]`). However, if there were multiple documents with the sam value for this field, this would result in all of them being skipped.

This has been solved by using keyset pagination with composite conditioning that filters on the basis of the name field in addition to the specified sort field.