### PR TITLE
feat: add hook to override headers sent in frappe.request.call

### DIFF
--- a/cypress/integration/request_headers_hook.js
+++ b/cypress/integration/request_headers_hook.js
@@ -1,0 +1,40 @@
+context("Request Headers Hook", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/desk");
+	});
+
+	it("injects custom headers via frappe.request.get_headers", () => {
+		cy.intercept("POST", "**/api/method/frappe.client.get_list").as("get_list");
+		let base_get_headers;
+
+		cy.window().then((win) => {
+			base_get_headers = win.frappe.request.get_headers;
+			win.frappe.request.get_headers = (opts) => {
+				const headers = base_get_headers(opts);
+				if (opts?.args?.doctype === "ToDo") headers["X-Test-Header-Hook"] = "enabled";
+				return headers;
+			};
+
+			win.frappe.call({
+				method: "frappe.client.get_list",
+				args: {
+					doctype: "ToDo",
+					fields: ["name"],
+					limit_page_length: 1,
+				},
+			});
+		});
+
+		cy.wait("@get_list")
+			.its("request.headers")
+			.then((headers) => {
+				expect(headers["x-test-header-hook"]).to.eq("enabled");
+				expect(headers["x-frappe-doctype"]).to.eq("ToDo");
+			});
+
+		cy.window().then((win) => {
+			win.frappe.request.get_headers = base_get_headers;
+		});
+	});
+});

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -9,6 +9,19 @@ frappe.request.url = "/";
 frappe.request.ajax_count = 0;
 frappe.request.waiting_for_ajax = [];
 frappe.request.logs = {};
+frappe.request.get_headers = function (opts) {
+	return Object.assign(
+		{
+			"X-Frappe-CSRF-Token": frappe.csrf_token,
+			Accept: "application/json",
+			"X-Frappe-CMD": (opts.args && opts.args.cmd) || "" || "",
+		},
+		opts.headers || {},
+		opts.args && opts.args.doctype
+			? { "X-Frappe-Doctype": encodeURIComponent(opts.args.doctype) }
+			: {}
+	);
+};
 
 frappe.xcall = function (method, params, type, opts = {}) {
 	return new Promise((resolve, reject) => {
@@ -263,20 +276,9 @@ frappe.request.call = function (opts) {
 		type: opts.type,
 		dataType: opts.dataType || "json",
 		async: opts.async,
-		headers: Object.assign(
-			{
-				"X-Frappe-CSRF-Token": frappe.csrf_token,
-				Accept: "application/json",
-				"X-Frappe-CMD": (opts.args && opts.args.cmd) || "" || "",
-			},
-			opts.headers
-		),
+		headers: frappe.request.get_headers(opts),
 		cache: window.dev_server ? false : opts.cache || false,
 	};
-
-	if (opts.args && opts.args.doctype) {
-		ajax_args.headers["X-Frappe-Doctype"] = encodeURIComponent(opts.args.doctype);
-	}
 
 	frappe.last_request = ajax_args.data;
 


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Provides a first-class solution for allowing customisation of request headers from frontend code. I wrote up an Issue already, https://github.com/frappe/frappe/issues/37066

> Explain the **details** for making this change. What existing problem does the pull request solve?

My use case is I have a Virtual DocType that loads from an external API (the UK Government's HMRC VAT API), and their API [requires various fraud-prevention headers](https://developer.service.hmrc.gov.uk/guides/fraud-prevention/connection-method/desktop-app-via-server/). Currently, the only way I've found to send additional headers is by monkey-patching various functions in [`frappe/request.js`](https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/request.js), which isn't pleasant. This PR provides an explicit API for modifying request headers globally (by using `app_include_js` in `hooks.py`), per doctype, or per doctype view.

A Cypress UI test is included, which shows how to implement it in client code, e.g.

```javascript
base_get_headers = frappe.request.get_headers;
frappe.request.get_headers = (opts) => {
	const headers = base_get_headers(opts);
	if (opts?.args?.doctype === "ToDo") headers["X-Test-Header-Hook"] = "enabled";
	return headers;
};
```

(Honest Disclosure: Written with GPT-5.3-Codex, over a few iterations, to keep changes concise and optimal.)

In summary, this patch allows an easy-to-document API for adding or editing headers sent by client-side javascript to Frappe backend code.