### PR TITLE
feat: add extractors

### DIFF
--- a/babel_extractors.csv
+++ b/babel_extractors.csv
@@ -1,10 +1,7 @@
 **/hooks.py,frappe.gettext.extractors.navbar.extract
 **/doctype/*/*.json,frappe.gettext.extractors.doctype.extract
 **/desktop_icon/*.json,frappe.gettext.extractors.desktop_icon.extract
-<<<<<<< Updated upstream
 **/workspace_sidebar/*.json,frappe.gettext.extractors.workspace_sidebar.extract
-=======
->>>>>>> Stashed changes
 **/workspace/*/*.json,frappe.gettext.extractors.workspace.extract
 **/web_form/*/*.json,frappe.gettext.extractors.web_form.extract
 **/onboarding_step/*/*.json,frappe.gettext.extractors.onboarding_step.extract

--- a/babel_extractors.csv
+++ b/babel_extractors.csv
@@ -1,7 +1,10 @@
 **/hooks.py,frappe.gettext.extractors.navbar.extract
 **/doctype/*/*.json,frappe.gettext.extractors.doctype.extract
 **/desktop_icon/*.json,frappe.gettext.extractors.desktop_icon.extract
+<<<<<<< Updated upstream
 **/workspace_sidebar/*.json,frappe.gettext.extractors.workspace_sidebar.extract
+=======
+>>>>>>> Stashed changes
 **/workspace/*/*.json,frappe.gettext.extractors.workspace.extract
 **/web_form/*/*.json,frappe.gettext.extractors.web_form.extract
 **/onboarding_step/*/*.json,frappe.gettext.extractors.onboarding_step.extract

--- a/babel_extractors.csv
+++ b/babel_extractors.csv
@@ -1,6 +1,7 @@
 **/hooks.py,frappe.gettext.extractors.navbar.extract
 **/doctype/*/*.json,frappe.gettext.extractors.doctype.extract
 **/desktop_icon/*.json,frappe.gettext.extractors.desktop_icon.extract
+**/workspace_sidebar/*.json,frappe.gettext.extractors.workspace_sidebar.extract
 **/workspace/*/*.json,frappe.gettext.extractors.workspace.extract
 **/web_form/*/*.json,frappe.gettext.extractors.web_form.extract
 **/onboarding_step/*/*.json,frappe.gettext.extractors.onboarding_step.extract

--- a/babel_extractors.csv
+++ b/babel_extractors.csv
@@ -1,5 +1,6 @@
 **/hooks.py,frappe.gettext.extractors.navbar.extract
 **/doctype/*/*.json,frappe.gettext.extractors.doctype.extract
+**/desktop_icon/*.json,frappe.gettext.extractors.desktop_icon.extract
 **/workspace/*/*.json,frappe.gettext.extractors.workspace.extract
 **/web_form/*/*.json,frappe.gettext.extractors.web_form.extract
 **/onboarding_step/*/*.json,frappe.gettext.extractors.onboarding_step.extract

--- a/frappe/gettext/extractors/desktop_icon.py
+++ b/frappe/gettext/extractors/desktop_icon.py
@@ -1,0 +1,18 @@
+import json
+
+
+def extract(fileobj, *args, **kwargs):
+	"""
+	Extract messages from Desktop Icon JSON files. To be used to babel extractor
+	:param fileobj: the file-like object the messages should be extracted from
+	:rtype: `iterator`
+	"""
+	data = json.load(fileobj)
+
+	if isinstance(data, list):
+		return
+
+	# Extract the label field (main translatable field for Desktop Icons)
+	label = data.get("label")
+	if label:
+		yield None, "_", label, ["Label of a Desktop Icon"]

--- a/frappe/gettext/extractors/desktop_icon.py
+++ b/frappe/gettext/extractors/desktop_icon.py
@@ -2,8 +2,8 @@ import json
 
 
 def extract(fileobj, *args, **kwargs):
-	"""
-	Extract messages from Desktop Icon JSON files. To be used to babel extractor
+	"""Extract messages from Desktop Icon JSON files. To be used by babel extractor.
+
 	:param fileobj: the file-like object the messages should be extracted from
 	:rtype: `iterator`
 	"""

--- a/frappe/gettext/extractors/workspace_sidebar.py
+++ b/frappe/gettext/extractors/workspace_sidebar.py
@@ -2,8 +2,8 @@ import json
 
 
 def extract(fileobj, *args, **kwargs):
-	"""
-	Extract messages from Workspace Sidebar JSON files. To be used to babel extractor
+	"""Extract messages from Workspace Sidebar JSON files. To be used by babel extractor.
+
 	:param fileobj: the file-like object the messages should be extracted from
 	:rtype: `iterator`
 	"""

--- a/frappe/gettext/extractors/workspace_sidebar.py
+++ b/frappe/gettext/extractors/workspace_sidebar.py
@@ -1,0 +1,26 @@
+import json
+
+
+def extract(fileobj, *args, **kwargs):
+	"""
+	Extract messages from Workspace Sidebar JSON files. To be used to babel extractor
+	:param fileobj: the file-like object the messages should be extracted from
+	:rtype: `iterator`
+	"""
+	data = json.load(fileobj)
+
+	if isinstance(data, list):
+		return
+
+	# Extract the title field (main translatable field for Workspace Sidebar)
+	title = data.get("title")
+	if title:
+		yield None, "_", title, ["Title of a Workspace Sidebar"]
+
+	# Extract labels from items list
+	items = data.get("items", [])
+	if isinstance(items, list):
+		for item in items:
+			label = item.get("label")
+			if label:
+				yield None, "_", label, ["Label of a Workspace Sidebar Item"]


### PR DESCRIPTION
This pull request adds support for extracting translatable strings from `desktop_icon` and `workspace_sidebar` JSON files for internationalization purposes. It introduces new Babel extractors and updates the extractor configuration to include these new file types.

New Babel extractors:

* Added a new extractor for `desktop_icon` JSON files that extracts the `label` field for translation. (`frappe/gettext/extractors/desktop_icon.py`)
* Added a new extractor for `workspace_sidebar` JSON files that extracts the `title` field and the `label` fields from items for translation. (`frappe/gettext/extractors/workspace_sidebar.py`)

close #37082

no-docs
