### PR TITLE
fix(calendar): update first day of the week to use dynamic configuration

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -261,7 +261,7 @@ frappe.views.Calendar = class Calendar {
 				minute: "2-digit",
 				hour12: true,
 			},
-			firstDay: 1,
+			firstDay: frappe.datetime.get_first_day_of_the_week_index(),
 			eventDisplay: "block",
 			headerToolbar: {
 				left: "prev,title,next",


### PR DESCRIPTION
## Fix: Use first day of week from System Settings in Calendar

Use `first_day_of_the_week` from System Settings instead of the hardcoded `firstDay: 1` in the calendar view.

<img width="528" height="124" alt="image" src="https://github.com/user-attachments/assets/dda414ef-dc09-432d-9f3b-cffd9b40483a" />
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/27c956a4-af81-48f2-8f09-671a80b558a8" />
