### PR TITLE
fix: update pagination count to reflect inline filter scope in Report…

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -334,7 +334,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			translations: frappe.utils.datatable.get_translations(),
 			checkboxColumn: true,
 			inlineFilters: true,
-			noDataMessage: "No data in current page",
+			noDataMessage: "No matching entries in the current results",
 			cellHeight: 35,
 			direction: frappe.utils.is_rtl() ? "rtl" : "ltr",
 			events: {
@@ -453,7 +453,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			const current_page_count = this.data.length;
 
 			$count.html(
-				`<span>${__("{0} of {1} filtered (current page only)", [
+				`<span>${__("{0} of {1} records match (filtered on visible rows only)", [
 					filtered_count,
 					current_page_count,
 				])}</span>`

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -334,6 +334,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			translations: frappe.utils.datatable.get_translations(),
 			checkboxColumn: true,
 			inlineFilters: true,
+			noDataMessage: "No data in current page",
 			cellHeight: 35,
 			direction: frappe.utils.is_rtl() ? "rtl" : "ltr",
 			events: {
@@ -424,6 +425,43 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				},
 			],
 		});
+
+		this.setup_inline_filter_observer();
+	}
+
+	setup_inline_filter_observer() {
+		this.$datatable_wrapper.on(
+			"keyup",
+			".dt-filter",
+			frappe.utils.debounce(() => {
+				this.update_count_for_inline_filter();
+			}, 350)
+		);
+	}
+
+	update_count_for_inline_filter() {
+		if (!this.datatable) return;
+
+		const has_active_filters = this.datatable.columnmanager
+			? Object.keys(this.datatable.columnmanager.getAppliedFilters()).length > 0
+			: false;
+
+		const $count = this.get_count_element();
+
+		if (has_active_filters) {
+			const filtered_count = this.datatable.datamanager.getFilteredRowIndices().length;
+			const current_page_count = this.data.length;
+
+			$count.html(
+				`<span>${__("{0} of {1} filtered (current page only)", [
+					filtered_count,
+					current_page_count,
+				])}</span>`
+			);
+		} else {
+			// Restore the normal count
+			this.render_count();
+		}
 	}
 
 	toggle_charts() {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -334,7 +334,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			translations: frappe.utils.datatable.get_translations(),
 			checkboxColumn: true,
 			inlineFilters: true,
-			noDataMessage: "No matching entries in the current results",
+			noDataMessage: __("No matching entries in the current results"),
 			cellHeight: 35,
 			direction: frappe.utils.is_rtl() ? "rtl" : "ltr",
 			events: {

--- a/frappe/public/scss/desk/frappe_datatable.scss
+++ b/frappe/public/scss/desk/frappe_datatable.scss
@@ -164,6 +164,11 @@
 	.dt-cell--focus .dt-cell__content {
 		border-color: var(--gray-200);
 	}
+
+	.dt-scrollable__no-data .no-data-message {
+		left: 50%;
+		transform: translateX(-50%);
+	}
 }
 
 table td.dt-cell {

--- a/frappe/public/scss/desk/frappe_datatable.scss
+++ b/frappe/public/scss/desk/frappe_datatable.scss
@@ -14,6 +14,7 @@
 	--dt-border-color: var(--table-border-color);
 	--dt-header-cell-bg: var(--subtle-fg);
 	--dt-selection-highlight-color: var(--highlight-color);
+	--dt-no-data-message-width: max-content;
 
 	background-color: var(--bg-color);
 	margin-left: -1px;


### PR DESCRIPTION
The dt_filter in any doctype's report view searches only within the data in the current page and not the entire database unlike proper filters. So data which might be on another page will not be shown when searched using dt_filters. So user might get the misconception that the data is not present anywhere. The list count at the bottom (Example: 20 of 34) also gives an idea that the search is being executed within all 34 records, when it isn't:

<img width="1470" height="833" alt="image" src="https://github.com/user-attachments/assets/a88b967a-0ee7-4d4f-9570-fcdf4e66bc8f" />



This PR changes the no data message to an appropriate one: "No data in current page".
<img width="1470" height="834" alt="image" src="https://github.com/user-attachments/assets/74ffe689-e919-4c15-8f6b-31b507f4d10c" />

Also changes list count message being displayed at the bottom to give a better idea to the user:
<img width="1251" height="834" alt="image" src="https://github.com/user-attachments/assets/db60d14b-383d-42b1-837f-ff2404e868f8" />


