### PR TITLE
fix: Changed label from "Enabled" to "Enabled System Notification" in notification settings

### DIFF
--- a/frappe/desk/doctype/notification_settings/notification_settings.json
+++ b/frappe/desk/doctype/notification_settings/notification_settings.json
@@ -23,7 +23,7 @@
    "default": "1",
    "fieldname": "enabled",
    "fieldtype": "Check",
-   "label": "Enabled"
+   "label": "Enabled System Notification"
   },
   {
    "fieldname": "subscribed_documents",
@@ -98,7 +98,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-16 17:15:25.641232",
+ "modified": "2026-02-17 13:39:35.159083",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Settings",


### PR DESCRIPTION

Renamed "Enabled" to "Enabled System Notification" in Notification Settings so users understand the checkbox only controls system notifications, not email notifications.

<img width="1025" height="363" alt="image" src="https://github.com/user-attachments/assets/38986166-a1f1-4ca4-9525-14eab2e00d58" />
