### PR TITLE
fix(ui): pagination controls overlap content in image view

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -438,25 +438,12 @@ frappe.views.BaseList = class BaseList {
 		if (!frappe.is_mobile()) {
 			resultContainerHeight = resultContainerHeight - this.$result.get(0).offsetTop;
 		}
+		this.$result.parent(".result-container").css({
+			height: resultContainerHeight - (frappe.is_mobile() ? 100 : 0) + "px",
+		});
 
-		if (this.view_name === "Image") {
-			// use minHeight in case of image view to ensure that the result container takes up almost the full height of the page
-			// and the pagination stays at the bottom
-			this.$result.parent(".result-container").css({
-				minHeight: resultContainerHeight - (frappe.is_mobile() ? 100 : 0) + "px",
-			});
-
-			this.$result[0].style.minHeight =
-				Math.max(this.$result[0].offsetHeight, resultContainerHeight) + "px";
-		} else {
-			this.$result.parent(".result-container").css({
-				height: resultContainerHeight - (frappe.is_mobile() ? 100 : 0) + "px",
-			});
-
-			this.$result[0].style.height =
-				Math.max(this.$result[0].offsetHeight, resultContainerHeight) + "px";
-		}
-
+		this.$result[0].style.height =
+			Math.max(this.$result[0].offsetHeight, resultContainerHeight) + "px";
 		this.$no_result.css({
 			height: window.innerHeight - this.$no_result.get(0).offsetTop + "px",
 		});

--- a/frappe/public/js/frappe/views/image/image_view.js
+++ b/frappe/public/js/frappe/views/image/image_view.js
@@ -67,6 +67,28 @@ frappe.views.ImageView = class ImageView extends frappe.views.ListView {
 		this.render_count();
 	}
 
+	// override set_result_height of base list to use minHeight instead of height
+	set_result_height() {
+		// remove any previously set height
+		this.$result[0].style.removeProperty("height");
+		this.$result[0].style.removeProperty("minHeight");
+
+		let resultContainerHeight = window.innerHeight - this.$paging_area.get(0).offsetHeight;
+		if (!frappe.is_mobile()) {
+			resultContainerHeight = resultContainerHeight - this.$result.get(0).offsetTop;
+		}
+
+		// use minHeight in case of image view to ensure that the result container takes up almost the full height of the page
+		// and the pagination stays at the bottom
+		this.$result[0].style.minHeight =
+			Math.max(this.$result[0].offsetHeight, resultContainerHeight) + "px";
+
+		// set minHeight on no_result area
+		this.$no_result.css({
+			minHeight: window.innerHeight - this.$no_result.get(0).offsetTop + "px",
+		});
+	}
+
 	item_details_html(item) {
 		// TODO: Image view field in DocType
 		let info_fields = this.get_fields_in_list_view().map((el) => el.fieldname) || [];


### PR DESCRIPTION
Resolves and closes - #34436 , refactored PR - #36971

### Before:

<img width="1526" height="995" alt="image" src="https://github.com/user-attachments/assets/593bf5cd-00e5-479c-8af8-5363258ed683" />


### After:

#### Mobile/Responsive View -

<img width="1432" height="1716" alt="CleanShot 2026-02-11 at 16 37 16@2x" src="https://github.com/user-attachments/assets/29840b64-dbe0-4f02-86d1-af360607ffed" />

#### Normal View-

<img width="3020" height="1720" alt="CleanShot 2026-02-11 at 16 36 49@2x" src="https://github.com/user-attachments/assets/ab124180-502b-495c-bb6f-0ce2353481c8" />
