### PR TITLE
fix: autocomplete field dropdown in editable grid row

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1062,33 +1062,27 @@ export default class GridRow {
 				if (is_focused) return;
 				is_focused = true;
 				if (["Link", "Dynamic Link", "Autocomplete"].includes(df.fieldtype)) {
-					frappe.utils.sleep(300).then(() => {
-						let $dropdown = $(this).find(".awesomplete > ul:first-of-type");
-						let $grid_field = $dropdown.closest(".grid-field");
+					let $dropdown = $(this).find(".awesomplete > ul:first-of-type");
+					let $grid_field = $dropdown.closest(".grid-field");
 
-						if ($grid_field.length) {
-							let $wrapper = $grid_field.find("div.awesomplete");
-							$wrapper = $(
-								`<div class="awesomplete ${$dropdown.attr("id")}"></div>`
-							);
-							$grid_field.append($wrapper);
-							$wrapper.append($dropdown);
+					if ($grid_field.length) {
+						let $wrapper = $grid_field.find("div.awesomplete");
+						$wrapper = $(`<div class="awesomplete ${$dropdown.attr("id")}"></div>`);
+						$grid_field.append($wrapper);
+						$wrapper.append($dropdown);
 
-							let element_position = event.target.getBoundingClientRect();
+						let element_position = event.target.getBoundingClientRect();
 
-							let left_difference =
-								element_position.left - $grid_field.offset().left;
-							let top_difference =
-								element_position.top - $grid_field.offset().top + 30;
-							$wrapper.css({
-								position: "absolute",
-								top: `${top_difference + 10}px`,
-								left: `${left_difference}px`,
-								minWidth: "250px",
-								width: `${element_position.width}px`,
-							});
-						}
-					});
+						let left_difference = element_position.left - $grid_field.offset().left;
+						let top_difference = element_position.top - $grid_field.offset().top + 30;
+						$wrapper.css({
+							position: "absolute",
+							top: `${top_difference + 10}px`,
+							left: `${left_difference}px`,
+							minWidth: "250px",
+							width: `${element_position.width}px`,
+						});
+					}
 				}
 			})
 			.on("click", function (event) {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1084,7 +1084,8 @@ export default class GridRow {
 								position: "absolute",
 								top: `${top_difference + 10}px`,
 								left: `${left_difference}px`,
-								width: "250px",
+								minWidth: "250px",
+								width: `${element_position.width}px`,
 							});
 						}
 					});

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1061,7 +1061,7 @@ export default class GridRow {
 			.on("focusin", function (event) {
 				if (is_focused) return;
 				is_focused = true;
-				if (df.fieldtype === "Link" || df.fieldtype === "Dynamic Link") {
+				if (["Link", "Dynamic Link", "Autocomplete"].includes(df.fieldtype)) {
 					frappe.utils.sleep(300).then(() => {
 						let $dropdown = $(this).find(".awesomplete > ul:first-of-type");
 						let $grid_field = $dropdown.closest(".grid-field");


### PR DESCRIPTION
### Changes
For link and dynamic link fields, grid row adds the awesomeplete dropdown div not as a sibling of the input field but at the very end. So, the dropdown shows up correctly when we're editing the grid row. Doesn't happen for Autocomplete fields so the dropdown gets hidden behind the row.

Also we should probably limit the minimum width for the columns which is already set but if there's space available the dropdown can probably take up the entire space so things look more uniform? So, made a small change for that.

<br>

### Before


https://github.com/user-attachments/assets/b723c6a8-5e29-4ab8-b438-2da5834cdfb2



### After

https://github.com/user-attachments/assets/8914e316-4364-4e89-ad8d-f59838f8ae19


<br>

Closes #37142

----

#### Notes to Reviewer:

Lack context on if we can do without the .sleep here that shows the dropdown in the correct place for all 3 types of fields. If we do need it we can stick to the same approach even for Autocomplete fields.

https://github.com/frappe/frappe/blob/7e0de9a902c69c0b5bc2490338daf928aa7b11af/frappe/public/js/frappe/form/grid_row.js#L1064-L1069
