### PR TITLE
fix: resolve text input extra line causing table break and align checkbox

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -612,9 +612,8 @@ export default class GridRow {
 									value='${cint(d.columns) || docfield.columns}'
 									data-fieldname='${docfield.fieldname}' style='background-color: var(--modal-bg); display: inline'>
 							</div>
-							<div class='col-2' title='${__("Sticky")}'>
+							<div class='col-2 sticky-col-container' title='${__("Sticky")}' >
 								<input type='checkbox' class='form-control sticky-column'
-									style='margin-top: 8px'
 									${d.sticky ? "checked" : ""}
 									data-fieldname='${d.fieldname}' style='background-color: var(--modal-bg); display: inline'>
 							</div>

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -302,7 +302,7 @@
 		}
 
 		textarea {
-			height: 39px !important;
+			height: 43px !important;
 		}
 
 		.form-control,
@@ -387,7 +387,7 @@
 	.data-row {
 		div[data-fieldname="options"],
 		div[data-fieldtype="Text Editor"] {
-			height: 40px;
+			height: auto;
 		}
 	}
 	.grid-static-col {
@@ -886,6 +886,12 @@
 
 .grid-scroll-bar-rows {
 	height: 100%;
+}
+
+.sticky-col-container {
+	display: flex;
+	justify-content: center;
+	align-items: center;
 }
 
 @media (max-width: map-get($grid-breakpoints, "md")) {


### PR DESCRIPTION
An extra line was appearing in the text input field which caused table layout misalignment in grid fields. This change removes the unintended spacing and restores proper table rendering.

Also aligns the column checkbox in the Configure Columns modal for consistent UI alignment.

---

BEFORE:
<img width="1024" height="331" alt="image240942" src="https://github.com/user-attachments/assets/8e8d1cd8-6085-4162-b0f9-750bfa5a88fa" />


<img width="981" height="768" alt="image176486" src="https://github.com/user-attachments/assets/72679286-08f8-4777-bf97-015de95b4507" />

---

AFTER:
<img width="2940" height="1428" alt="image" src="https://github.com/user-attachments/assets/e6605d14-66f2-4c06-a4bf-11a27469bdc1" />

<img width="2052" height="1082" alt="image" src="https://github.com/user-attachments/assets/d388ca30-df1d-410d-99e2-35d0ef672cc0" />




