### PR TITLE
fix(minor): open link button overflows in grid row

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -14,7 +14,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		$(`<div class="link-field ui-front" style="position: relative;">
 			<input type="text" class="input-with-feedback form-control">
 			<span class="link-btn">
-				<a class="btn-open" tabIndex='-1' style="display: inline-block;" title="${__("Open Link")}">
+				<a class="btn-open" tabIndex='-1' style="display: inline-flex;" title="${__("Open Link")}">
 					${frappe.utils.icon("arrow-right", "xs")}
 				</a>
 			</span>

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -315,7 +315,6 @@
 		}
 
 		.link-btn {
-			top: 5px;
 			background-color: var(--bg-color);
 		}
 


### PR DESCRIPTION
Due to `link-btn` [now taking up full height](https://github.com/frappe/frappe/pull/36570/changes/39e5e9f0c6085d59c3ba35a439d3d952f8c88a34) and it's child anchor tag taking up full height, the open button in grid row overflows the row height. Use `inline-flex` instead of `inline-block` to center the anchor tag vertically.

### Before

https://github.com/user-attachments/assets/21e4c01e-bb1f-4c70-9432-8b1df6f2afa4

<br>

### After

https://github.com/user-attachments/assets/ef205588-1b1a-4295-92eb-9e575723fddb

<br>

Closes #37155 
