### PR TITLE
fix(grid_row): skip rendering for compound currency symbols in editable rows

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1603,7 +1603,7 @@ export default class GridRow {
 		const symbol = window.get_currency_symbol(currency);
 
 		// skip if compound symbols like in case of EGP - "£ or ج."
-		if (symbol && (symbol.includes(' or ') || symbol.length > 3)) {
+		if (symbol && (symbol.includes(" or ") || symbol.length > 3)) {
 			return;
 		}
 

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1601,6 +1601,12 @@ export default class GridRow {
 
 		const currency = frappe.meta.get_field_currency(df, this.doc);
 		const symbol = window.get_currency_symbol(currency);
+
+		// skip if compound symbols like in case of EGP - "£ or ج."
+		if (symbol && (symbol.includes(' or ') || symbol.length > 3)) {
+			return;
+		}
+
 		const show_on_right =
 			cint(frappe.model.get_value(":Currency", currency, "symbol_on_right")) === 1;
 


### PR DESCRIPTION
Didn't expect a case like this to arrive, oversight from my side, Thanks @KerollesFathy for the issue, this PR resolves #37158. Checked for possibilities for symbol in Currency table this time.

Thought of ways to solve this, but again, adding anything would have been too complicating in terms of UX significance - 
Like showing only first one from "X or Y" - inconsistent UX with non-editable row
Conditionally adding/removing class and styling it according to the symbols - too complicated for the UX improvement it provides.

Simplest and effective solution would be - 
To just skip compound symbols like such (works like before), keep it simple.