### PR TITLE
feat: add torch/flashlight support to QR code scanner

### DIFF
--- a/frappe/public/js/frappe/scanner/index.js
+++ b/frappe/public/js/frappe/scanner/index.js
@@ -6,6 +6,7 @@ frappe.ui.Scanner = class Scanner {
 		this.handler = null;
 		this.options = options;
 		this.is_alive = false;
+		this.torch_enabled = false;
 
 		if (!("multiple" in this.options)) {
 			this.options.multiple = false;
@@ -49,6 +50,10 @@ frappe.ui.Scanner = class Scanner {
 					// parse error, ignore it.
 				}
 			)
+			.then(() => {
+				// Check if torch is supported after camera starts
+				this.check_torch_support();
+			})
 			.catch((err) => {
 				this.is_alive = false;
 				this.hide_dialog();
@@ -57,10 +62,74 @@ frappe.ui.Scanner = class Scanner {
 		this.is_alive = true;
 	}
 
+	check_torch_support() {
+		try {
+			const capabilities = this.handler.getRunningTrackCameraCapabilities();
+			if (capabilities.torchFeature && capabilities.torchFeature().isSupported()) {
+				this.show_torch_button();
+			}
+		} catch (error) {
+			// Torch not supported, silently ignore
+			console.debug("Torch feature not supported on this device");
+		}
+	}
+
+	show_torch_button() {
+		if (!this.$torch_button) {
+			this.$torch_button = $(`
+				<button class="btn btn-default torch-button" 
+					style="position: absolute; bottom: 20px; right: 20px; z-index: 1000;">
+					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<path d="M9 2h6l3 7H6l3-7z"/>
+						<path d="M12 9v13"/>
+						<path d="M8 22h8"/>
+					</svg>
+					${__("Torch")}
+				</button>
+			`);
+
+			this.$torch_button.on("click", () => {
+				this.toggle_torch();
+			});
+
+			this.$scan_area.css("position", "relative");
+			this.$scan_area.append(this.$torch_button);
+		}
+	}
+
+	toggle_torch() {
+		if (!this.handler || !this.is_alive) {
+			return;
+		}
+
+		this.torch_enabled = !this.torch_enabled;
+
+		this.handler
+			.applyVideoConstraints({
+				advanced: [{ torch: this.torch_enabled }],
+			})
+			.then(() => {
+				// Update button state
+				this.$torch_button.toggleClass("btn-primary", this.torch_enabled);
+				this.$torch_button.toggleClass("btn-default", !this.torch_enabled);
+			})
+			.catch((error) => {
+				console.error("Failed to toggle torch:", error);
+				frappe.msgprint({
+					title: __("Torch Error"),
+					indicator: "red",
+					message: __("Unable to control torch on this device"),
+				});
+				// Revert state on failure
+				this.torch_enabled = !this.torch_enabled;
+			});
+	}
+
 	stop_scan() {
 		if (this.handler && this.is_alive) {
 			this.handler.stop().then(() => {
 				this.is_alive = false;
+				this.torch_enabled = false;
 				this.$scan_area.empty();
 				this.hide_dialog();
 			});

--- a/frappe/public/js/frappe/scanner/index.js
+++ b/frappe/public/js/frappe/scanner/index.js
@@ -79,11 +79,7 @@ frappe.ui.Scanner = class Scanner {
 			this.$torch_button = $(`
 				<button class="btn btn-default torch-button" 
 					style="position: absolute; bottom: 20px; right: 20px; z-index: 1000;">
-					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-						<path d="M9 2h6l3 7H6l3-7z"/>
-						<path d="M12 9v13"/>
-						<path d="M8 22h8"/>
-					</svg>
+					${frappe.utils.icon("flashlight", "sm")}
 					${__("Torch")}
 				</button>
 			`);


### PR DESCRIPTION
## Description

Adds torch/flashlight toggle button to the QR code scanner for improved usability in low-light environments.

## Changes
- Add torch toggle button to `frappe.ui.Scanner`
- Check device torch capability after camera starts using `getRunningTrackCameraCapabilities()`
- Use html5-qrcode `applyVideoConstraints()` API for torch control
- Button only appears when torch is supported on device
- Visual feedback with button state changes (primary/default)
- Graceful error handling for unsupported devices

## Use Case
Manufacturing shopfloors, cold rooms, storage areas, and other low-light environments where barcode scanning is required.

## Testing
Tested on mobile devices with camera and torch support.

Fixes #20984