### PR TITLE
feat: allow export of all standard fields in Data Export

### DIFF
--- a/frappe/core/doctype/data_export/exporter.py
+++ b/frappe/core/doctype/data_export/exporter.py
@@ -213,7 +213,8 @@ class DataExporter:
 
 		for f in frappe.db.get_table_columns_description(table_name):
 			field = meta.get_field(f.name)
-			if f.name in ["owner", "creation"]:
+			# Check if this is a standard field (not in meta but exists in table)
+			if not field:
 				std_field = next((x for x in frappe.model.std_fields if x["fieldname"] == f.name), None)
 				if std_field:
 					field = frappe._dict(


### PR DESCRIPTION
## Description

Enables export of ALL standard fields in Data Export, not just `owner` and `creation`. Users can now export metadata fields like `modified`, `modified_by`, `_user_tags`, `_liked_by`, `_comments`, `_assign`, `docstatus`, and `idx`.

## Changes
- Changed field check from hardcoded `["owner", "creation"]` to generic `std_fields` lookup
- Now checks if field is missing from meta, then looks up in standard fields
- Provides complete metadata export capability

## Root Cause
The code previously only checked for `f.name in ["owner", "creation"]` instead of checking all standard fields defined in `frappe.model.std_fields`.

## Testing
1. Go to any DocType list view
2. Click dropdown → Export
3. Select fields
4. Verify standard fields (modified, modified_by, etc.) appear in field list
5. Export and verify these fields appear in CSV/Excel output

## Backward Compatibility
✅ No breaking changes - only makes additional fields available for selection

Fixes #22177