### PR TITLE
fix: handle malformed URIs in file upload via web link

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -552,7 +552,13 @@ function upload_via_web_link() {
 		close_dialog.value = true;
 		return Promise.reject();
 	}
-	file_url = decodeURI(file_url);
+	try {
+		file_url = decodeURI(file_url);
+	} catch (e) {
+		// If decodeURI fails, use the URL as-is
+		// This handles URLs with unescaped % characters
+		console.warn("Failed to decode URL, using as-is:", e);
+	}
 	close_dialog.value = true;
 	return upload_file({
 		file_url,


### PR DESCRIPTION
## Description

Fixes a UI crash when uploading files via Web Link if the URL contains unescaped percent characters (%) that are not part of valid percent-encoded sequences.

## Changes
- Wrap `decodeURI()` call in try-catch block
- If decoding fails, use the URL as-is instead of crashing
- Add console warning for debugging purposes
- Graceful degradation ensures upload continues

## Root Cause
The `upload_via_web_link()` function called `decodeURI()` without error handling. URLs like `https://example.com/file_100_%final.pdf` would throw `URIError: URI malformed` and crash the uploader dialog.

## Testing
1. Open any form with file attachment
2. Click Attach → Web Link
3. Paste URL: `https://example.com/file_100_%final.pdf`
4. Click Upload
5. **Expected:** Upload proceeds without crashing (may fail server-side, but UI stays intact)

## Behavior
- **Before:** UI crashes with `URIError: URI malformed`
- **After:** URL used as-is, upload attempt continues gracefully

Fixes #36947