### PR TITLE
fix(grid): show Autocomplete dropdown in editable child table rows

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1061,7 +1061,11 @@ export default class GridRow {
 			.on("focusin", function (event) {
 				if (is_focused) return;
 				is_focused = true;
-				if (df.fieldtype === "Link" || df.fieldtype === "Dynamic Link") {
+				if (
+						df.fieldtype === "Link" ||
+						df.fieldtype === "Dynamic Link" ||
+						df.fieldtype === "Autocomplete"
+					) {
 					frappe.utils.sleep(300).then(() => {
 						let $dropdown = $(this).find(".awesomplete > ul:first-of-type");
 						let $grid_field = $dropdown.closest(".grid-field");


### PR DESCRIPTION
## Summary
Fix Autocomplete suggestions being hidden in editable grid rows.

## Root cause
`GridRow` only repositions awesomplete dropdowns for `Link` and `Dynamic Link` fields. `Autocomplete` uses awesomplete too, but was excluded from that logic.

## Fix
Include `Autocomplete` in the same dropdown reposition path in `frappe/public/js/frappe/form/grid_row.js`.

## Repro
- Add an `Autocomplete` field to a child table
- Enable editable grid for that table
- Type in the field inside grid row
- Before: dropdown options are hidden/behind row
- After: dropdown renders correctly and can be selected

Fixes #37142
