### PR TITLE
fix(grid): styling of focus grid control

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -68,7 +68,6 @@
 	.row-index {
 		position: sticky;
 		left: 0;
-		z-index: 1;
 	}
 	.row-index {
 		left: 31px;
@@ -141,7 +140,6 @@
 		position: sticky;
 		left: 0;
 		background-color: var(--fg-color);
-		z-index: 1;
 	}
 	.row-index {
 		left: 31px;
@@ -270,7 +268,6 @@
 
 	.col:last-child {
 		border: none;
-		background-color: var(--fg-color);
 	}
 
 	.btn-open-row {
@@ -310,7 +307,7 @@
 			border-radius: 0px;
 			border: 0px;
 			padding-top: 10px;
-			padding-bottom: 10px;
+			padding-bottom: calc(var(--padding-md) - 3px);
 			height: auto;
 		}
 
@@ -321,6 +318,7 @@
 
 		.form-control:focus {
 			border-color: $text-muted;
+			box-shadow: inset 0px 0px 0 2px rgba(124, 124, 124, 0.25);
 		}
 
 		.has-error .form-control {


### PR DESCRIPTION
First of real "polish work" for me

Before
<img width="485" height="410" alt="Screenshot 2026-02-18 at 4 07 05 AM" src="https://github.com/user-attachments/assets/375c3297-601c-46df-9006-f16957c808de" />


After 
<img width="522" height="380" alt="Screenshot 2026-02-18 at 4 02 32 AM" src="https://github.com/user-attachments/assets/4d7bf655-7638-49c1-8cdf-0dd6defb8d0b" />

