### PR TITLE
revert: "fix(safe-exec): Allow WITH queries"

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -484,7 +484,7 @@ def check_safe_sql_query(query: str, throw: bool = True) -> bool:
 	"""
 
 	query = query.strip().lower()
-	whitelisted_statements = ("select", "explain", "with")
+	whitelisted_statements = ("select", "explain")
 
 	if query.startswith(whitelisted_statements):
 		return True


### PR DESCRIPTION
Reverts frappe/frappe#37174

MariaDB 12.x will start allowing writes with "WITH" thats why we removed it.
-- Ankush