### PR TITLE
fix: validate `doc_status` for non-submittable doctypes in workflow

### DIFF
--- a/frappe/public/js/workflow_builder/components/Properties.vue
+++ b/frappe/public/js/workflow_builder/components/Properties.vue
@@ -8,12 +8,10 @@ let title = ref("Workflow Details");
 
 watch(
 	() => store.workflow_doc?.document_type,
-	async (newDocType, oldDocType) => {
+	async (newDocType) => {
 		if (!newDocType) return;
 		await store.update_is_submittable();
-		if (newDocType !== oldDocType) {
-			store.reset_non_submittable_states();
-		}
+		store.reset_non_submittable_states();
 	}
 );
 

--- a/frappe/public/js/workflow_builder/components/Properties.vue
+++ b/frappe/public/js/workflow_builder/components/Properties.vue
@@ -4,6 +4,11 @@ import { useStore } from "../store";
 
 let store = useStore();
 
+const is_doc_status_readonly = computed(() => {
+	if (!store.workflow.selected || !("state" in store.workflow.selected.data)) return false;
+	return !store.is_submittable();
+});
+
 let title = ref("Workflow Details");
 
 let doc = computed(() => {
@@ -29,6 +34,13 @@ let properties = computed(() => {
 			(df) => !["allow_edit", "workflow_builder_id"].includes(df.fieldname)
 		);
 		store.statefields.splice(2, 0, allow_edit);
+
+		const submittable = store.is_submittable();
+
+		// Auto-reset doc_status to "Draft" for non-submittable doctypes
+		if (!submittable && store.workflow.selected.data.doc_status !== "Draft") {
+			store.workflow.selected.data.doc_status = "Draft";
+		}
 
 		return store.statefields.filter((df) => {
 			if (df.fieldname == "doc_status") {
@@ -61,6 +73,7 @@ let properties = computed(() => {
 						v-model="doc[df.fieldname]"
 						:data-fieldname="df.fieldname"
 						:data-fieldtype="df.fieldtype"
+						:read_only="df.fieldname === 'doc_status' ? is_doc_status_readonly : false"
 					/>
 				</div>
 			</div>

--- a/frappe/public/js/workflow_builder/components/Properties.vue
+++ b/frappe/public/js/workflow_builder/components/Properties.vue
@@ -5,7 +5,7 @@ import { useStore } from "../store";
 let store = useStore();
 
 const is_doc_status_readonly = computed(() => {
-	if (!store.workflow.selected || !("state" in store.workflow.selected.data)) return false;
+	if (!store.workflow.selected || !(store.workflow.selected.type === "state")) return false;
 	return !store.is_submittable();
 });
 
@@ -37,7 +37,6 @@ let properties = computed(() => {
 
 		const submittable = store.is_submittable();
 
-		// Auto-reset doc_status to "Draft" for non-submittable doctypes
 		if (!submittable && store.workflow.selected.data.doc_status !== "Draft") {
 			store.workflow.selected.data.doc_status = "Draft";
 		}

--- a/frappe/public/js/workflow_builder/components/Properties.vue
+++ b/frappe/public/js/workflow_builder/components/Properties.vue
@@ -9,8 +9,9 @@ let title = ref("Workflow Details");
 watch(
 	() => store.workflow_doc?.document_type,
 	async (newDocType, oldDocType) => {
-		if (newDocType && oldDocType && newDocType !== oldDocType) {
-			await store.update_is_submittable();
+		if (!newDocType) return;
+		await store.update_is_submittable();
+		if (newDocType !== oldDocType) {
 			store.reset_non_submittable_states();
 		}
 	}

--- a/frappe/public/js/workflow_builder/components/Properties.vue
+++ b/frappe/public/js/workflow_builder/components/Properties.vue
@@ -1,15 +1,20 @@
 <script setup>
-import { ref, computed, nextTick } from "vue";
+import { ref, computed, nextTick, watch } from "vue";
 import { useStore } from "../store";
 
 let store = useStore();
 
-const is_doc_status_readonly = computed(() => {
-	if (!store.workflow.selected || !(store.workflow.selected.type === "state")) return false;
-	return !store.is_submittable();
-});
-
 let title = ref("Workflow Details");
+
+watch(
+	() => store.workflow_doc?.document_type,
+	async (newDocType, oldDocType) => {
+		if (newDocType && oldDocType && newDocType !== oldDocType) {
+			await store.update_is_submittable();
+			store.reset_non_submittable_states();
+		}
+	}
+);
 
 let doc = computed(() => {
 	return store.workflow.selected ? store.workflow.selected.data : store.workflow_doc;
@@ -34,12 +39,6 @@ let properties = computed(() => {
 			(df) => !["allow_edit", "workflow_builder_id"].includes(df.fieldname)
 		);
 		store.statefields.splice(2, 0, allow_edit);
-
-		const submittable = store.is_submittable();
-
-		if (!submittable && store.workflow.selected.data.doc_status !== "Draft") {
-			store.workflow.selected.data.doc_status = "Draft";
-		}
 
 		return store.statefields.filter((df) => {
 			if (df.fieldname == "doc_status") {
@@ -72,7 +71,7 @@ let properties = computed(() => {
 						v-model="doc[df.fieldname]"
 						:data-fieldname="df.fieldname"
 						:data-fieldtype="df.fieldtype"
-						:read_only="df.fieldname === 'doc_status' ? is_doc_status_readonly : false"
+						:read_only="df.fieldname === 'doc_status' ? !store.is_submittable : false"
 					/>
 				</div>
 			</div>

--- a/frappe/public/js/workflow_builder/store.js
+++ b/frappe/public/js/workflow_builder/store.js
@@ -135,13 +135,18 @@ export const useStore = defineStore("workflow-builder-store", () => {
 		frappe.breadcrumbs.$breadcrumbs.append(breadcrumbs);
 	}
 
+	function is_submittable() {
+		if (!workflow_doc.value?.document_type) return true;
+		return frappe.get_meta(workflow_doc.value.document_type)?.is_submittable;
+	}
+
 	function get_state_df(data) {
 		let doc_status_map = {
 			Draft: 0,
 			Submitted: 1,
 			Cancelled: 2,
 		};
-		data.doc_status = doc_status_map[data.doc_status];
+		data.doc_status = is_submittable() ? doc_status_map[data.doc_status] : 0;
 		return data;
 	}
 
@@ -234,5 +239,6 @@ export const useStore = defineStore("workflow-builder-store", () => {
 		reset_changes,
 		save_changes,
 		setup_undo_redo,
+		is_submittable,
 	};
 });

--- a/frappe/public/js/workflow_builder/store.js
+++ b/frappe/public/js/workflow_builder/store.js
@@ -155,7 +155,7 @@ export const useStore = defineStore("workflow-builder-store", () => {
 		let affected_states = [];
 		workflow.value.elements.forEach((el) => {
 			if (el.type === "state" && el.data.doc_status && el.data.doc_status !== "Draft") {
-				affected_states.push(el.data.state || __("No Label State"));
+				affected_states.push(el.data.state);
 				el.data.doc_status = "Draft";
 			}
 		});
@@ -164,8 +164,8 @@ export const useStore = defineStore("workflow-builder-store", () => {
 			frappe.msgprint({
 				title: __("Doc Status Reset"),
 				message: __(
-					"The <b>Doc Status</b> for the following states has been reset to <b>Draft</b> because the <b>{0}</b> is not submittable: <b>{1}</b>",
-					[workflow_doc.value.document_type, affected_states.join(", ")]
+					"The <strong>Doc Status</strong> for all states has been reset to <strong>Draft</strong> because <strong>{0}</strong> is not submittable",
+					[workflow_doc.value.document_type]
 				),
 				indicator: "orange",
 			});

--- a/frappe/public/js/workflow_builder/store.js
+++ b/frappe/public/js/workflow_builder/store.js
@@ -152,15 +152,15 @@ export const useStore = defineStore("workflow-builder-store", () => {
 	function reset_non_submittable_states() {
 		if (is_submittable.value) return;
 
-		let affected_states = [];
+		let has_affected_states = false;
 		workflow.value.elements.forEach((el) => {
 			if (el.type === "state" && el.data.doc_status && el.data.doc_status !== "Draft") {
-				affected_states.push(el.data.state);
+				has_affected_states = true;
 				el.data.doc_status = "Draft";
 			}
 		});
 
-		if (affected_states.length) {
+		if (has_affected_states) {
 			frappe.msgprint({
 				title: __("Doc Status Reset"),
 				message: __(

--- a/frappe/public/js/workflow_builder/store.js
+++ b/frappe/public/js/workflow_builder/store.js
@@ -12,6 +12,7 @@ export const useStore = defineStore("workflow-builder-store", () => {
 	let statefields = ref([]);
 	let transitionfields = ref([]);
 	let ref_history = ref(null);
+	let is_submittable = ref(true);
 
 	async function fetch() {
 		await frappe.model.clear_doc("Workflow", workflow_name.value);
@@ -60,6 +61,9 @@ export const useStore = defineStore("workflow-builder-store", () => {
 			[];
 
 		workflow.value.elements = get_workflow_elements(workflow_doc.value, workflow_data);
+
+		await update_is_submittable();
+		reset_non_submittable_states();
 
 		setup_undo_redo();
 		setup_breadcrumbs();
@@ -135,9 +139,37 @@ export const useStore = defineStore("workflow-builder-store", () => {
 		frappe.breadcrumbs.$breadcrumbs.append(breadcrumbs);
 	}
 
-	function is_submittable() {
-		if (!workflow_doc.value?.document_type) return true;
-		return frappe.get_meta(workflow_doc.value.document_type)?.is_submittable;
+	async function update_is_submittable() {
+		if (!workflow_doc.value?.document_type) {
+			is_submittable.value = true;
+			return;
+		}
+		await frappe.model.with_doctype(workflow_doc.value.document_type);
+		is_submittable.value =
+			frappe.get_meta(workflow_doc.value.document_type)?.is_submittable || false;
+	}
+
+	function reset_non_submittable_states() {
+		if (is_submittable.value) return;
+
+		let affected_states = [];
+		workflow.value.elements.forEach((el) => {
+			if (el.type === "state" && el.data.doc_status && el.data.doc_status !== "Draft") {
+				affected_states.push(el.data.state || __("Unnamed State"));
+				el.data.doc_status = "Draft";
+			}
+		});
+
+		if (affected_states.length) {
+			frappe.msgprint({
+				title: __("Doc Status Reset"),
+				message: __(
+					"The <b>Doc Status</b> for the following states has been reset to <b>Draft</b> because the selected DocType is not submittable: <b>{0}</b>",
+					[affected_states.join(", ")]
+				),
+				indicator: "orange",
+			});
+		}
 	}
 
 	function get_state_df(data) {
@@ -146,7 +178,7 @@ export const useStore = defineStore("workflow-builder-store", () => {
 			Submitted: 1,
 			Cancelled: 2,
 		};
-		data.doc_status = is_submittable() ? doc_status_map[data.doc_status] : 0;
+		data.doc_status = is_submittable.value ? doc_status_map[data.doc_status] : 0;
 		return data;
 	}
 
@@ -240,5 +272,7 @@ export const useStore = defineStore("workflow-builder-store", () => {
 		save_changes,
 		setup_undo_redo,
 		is_submittable,
+		update_is_submittable,
+		reset_non_submittable_states,
 	};
 });

--- a/frappe/public/js/workflow_builder/store.js
+++ b/frappe/public/js/workflow_builder/store.js
@@ -155,7 +155,7 @@ export const useStore = defineStore("workflow-builder-store", () => {
 		let affected_states = [];
 		workflow.value.elements.forEach((el) => {
 			if (el.type === "state" && el.data.doc_status && el.data.doc_status !== "Draft") {
-				affected_states.push(el.data.state || __("Unnamed State"));
+				affected_states.push(el.data.state || __("No Label State"));
 				el.data.doc_status = "Draft";
 			}
 		});
@@ -164,8 +164,8 @@ export const useStore = defineStore("workflow-builder-store", () => {
 			frappe.msgprint({
 				title: __("Doc Status Reset"),
 				message: __(
-					"The <b>Doc Status</b> for the following states has been reset to <b>Draft</b> because the selected DocType is not submittable: <b>{0}</b>",
-					[affected_states.join(", ")]
+					"The <b>Doc Status</b> for the following states has been reset to <b>Draft</b> because the <b>{0}</b> is not submittable: <b>{1}</b>",
+					[workflow_doc.value.document_type, affected_states.join(", ")]
 				),
 				indicator: "orange",
 			});

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -108,14 +108,15 @@ class TestWorkflow(IntegrationTestCase):
 		self.assertEqual(workflow_actions[0].status, "Completed")
 
 	def test_if_workflow_set_on_action(self):
+		self.workflow, doc = create_new_submittable_doctype_with_workflow()
 		self.workflow._update_state_docstatus = True
 		self.workflow.states[1].doc_status = 1
 		self.workflow.save()
-		todo = create_new_todo()
-		self.assertEqual(todo.docstatus, 0)
-		todo.submit()
-		self.assertEqual(todo.docstatus, 1)
-		self.assertEqual(todo.workflow_state, "Approved")
+
+		self.assertEqual(doc.docstatus, 0)
+		doc.submit()
+		self.assertEqual(doc.docstatus, 1)
+		self.assertEqual(doc.workflow_state, "Approved")
 
 		self.workflow.states[1].doc_status = 0
 		self.workflow.save()
@@ -348,6 +349,57 @@ def create_domain_workflow():
 
 def create_new_todo():
 	return frappe.get_doc(doctype="ToDo", description="workflow " + random_string(10)).insert()
+
+
+def create_new_submittable_doctype_with_workflow():
+	submittable_dt = frappe.get_doc(
+		{
+			"doctype": "DocType",
+			"module": "Core",
+			"name": "Test Submittable Doc",
+			"custom": 1,
+			"is_submittable": 1,
+			"fields": [
+				{"label": "Field", "fieldname": "test_field", "fieldtype": "Data"},
+				{
+					"label": "Workflow State",
+					"fieldname": "workflow_state",
+					"fieldtype": "Link",
+					"options": "Workflow State",
+				},
+			],
+			"permissions": [{"role": "System Manager", "read": 1, "write": 1, "submit": 1, "cancel": 1}],
+		}
+	).insert(ignore_if_duplicate=True)
+
+	workflow = None
+	if not frappe.db.exists("Workflow", "Submittable Workflow"):
+		workflow = frappe.new_doc("Workflow")
+		workflow.workflow_name = "Submittable Workflow"
+		workflow.document_type = submittable_dt.name
+		workflow.workflow_state_field = "workflow_state"
+		workflow.is_active = 1
+		workflow.append("states", dict(state="Pending", allow_edit="All"))
+		workflow.append(
+			"states",
+			dict(state="Approved", allow_edit="System Manager", doc_status=0),
+		)
+		workflow.append(
+			"transitions",
+			dict(
+				state="Pending",
+				action="Approve",
+				next_state="Approved",
+				allowed="System Manager",
+				allow_self_approval=1,
+			),
+		)
+		workflow.insert(ignore_permissions=True)
+	else:
+		workflow = frappe.get_doc("Workflow", "Submittable Workflow")
+
+	doc = frappe.get_doc({"doctype": submittable_dt.name, "test_field": "test"}).insert()
+	return workflow, doc
 
 
 def create_new_note(doc):

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -108,18 +108,21 @@ class TestWorkflow(IntegrationTestCase):
 		self.assertEqual(workflow_actions[0].status, "Completed")
 
 	def test_if_workflow_set_on_action(self):
-		self.workflow, doc = create_new_submittable_doctype_with_workflow()
-		self.workflow._update_state_docstatus = True
-		self.workflow.states[1].doc_status = 1
-		self.workflow.save()
+		dt = create_new_submittable_doctype()
+		workflow = create_submittable_workflow(dt.name)
+		doc = frappe.get_doc({"doctype": dt.name, "test_field": "test"}).insert()
+
+		workflow._update_state_docstatus = True
+		workflow.states[1].doc_status = 1
+		workflow.save()
 
 		self.assertEqual(doc.docstatus, 0)
 		doc.submit()
 		self.assertEqual(doc.docstatus, 1)
 		self.assertEqual(doc.workflow_state, "Approved")
 
-		self.workflow.states[1].doc_status = 0
-		self.workflow.save()
+		workflow.states[1].doc_status = 0
+		workflow.save()
 
 	def test_syntax_error_in_transition_rule(self):
 		self.workflow.transitions[0].condition = 'doc.status =! "Closed"'
@@ -351,8 +354,8 @@ def create_new_todo():
 	return frappe.get_doc(doctype="ToDo", description="workflow " + random_string(10)).insert()
 
 
-def create_new_submittable_doctype_with_workflow():
-	submittable_dt = frappe.get_doc(
+def create_new_submittable_doctype():
+	return frappe.get_doc(
 		{
 			"doctype": "DocType",
 			"module": "Core",
@@ -372,34 +375,32 @@ def create_new_submittable_doctype_with_workflow():
 		}
 	).insert(ignore_if_duplicate=True)
 
-	workflow = None
-	if not frappe.db.exists("Workflow", "Submittable Workflow"):
-		workflow = frappe.new_doc("Workflow")
-		workflow.workflow_name = "Submittable Workflow"
-		workflow.document_type = submittable_dt.name
-		workflow.workflow_state_field = "workflow_state"
-		workflow.is_active = 1
-		workflow.append("states", dict(state="Pending", allow_edit="All"))
-		workflow.append(
-			"states",
-			dict(state="Approved", allow_edit="System Manager", doc_status=0),
-		)
-		workflow.append(
-			"transitions",
-			dict(
-				state="Pending",
-				action="Approve",
-				next_state="Approved",
-				allowed="System Manager",
-				allow_self_approval=1,
-			),
-		)
-		workflow.insert(ignore_permissions=True)
-	else:
-		workflow = frappe.get_doc("Workflow", "Submittable Workflow")
 
-	doc = frappe.get_doc({"doctype": submittable_dt.name, "test_field": "test"}).insert()
-	return workflow, doc
+def create_submittable_workflow(doctype):
+	workflow = frappe.get_doc(
+		{
+			"doctype": "Workflow",
+			"workflow_name": "Submittable Workflow",
+			"document_type": doctype,
+			"workflow_state_field": "workflow_state",
+			"is_active": 1,
+			"states": [
+				{"state": "Pending", "allow_edit": "All"},
+				{"state": "Approved", "allow_edit": "System Manager", "doc_status": 0},
+			],
+			"transitions": [
+				{
+					"state": "Pending",
+					"action": "Approve",
+					"next_state": "Approved",
+					"allowed": "System Manager",
+					"allow_self_approval": 1,
+				}
+			],
+		}
+	).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+	return workflow
 
 
 def create_new_note(doc):

--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -128,14 +128,24 @@ frappe.ui.form.on("Workflow", {
 			);
 
 			if (!is_submittable) {
-				let changed = false;
+				let affected_states = [];
 				frm.doc.states.forEach((row) => {
 					if (parseInt(row.doc_status || 0) !== 0) {
+						affected_states.push(row.state || __("Unnamed State"));
 						row.doc_status = "0";
-						changed = true;
 					}
 				});
-				if (changed) frm.refresh_field("states");
+				if (affected_states.length) {
+					frm.refresh_field("states");
+					frappe.msgprint({
+						title: __("Doc Status Reset"),
+						message: __(
+							"The <b>Doc Status</b> for the following states has been reset to <b>Draft</b> because the selected DocType is not submittable: <b>{0}</b>",
+							[affected_states.join(", ")]
+						),
+						indicator: "orange",
+					});
+				}
 			}
 		});
 	},

--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -131,7 +131,7 @@ frappe.ui.form.on("Workflow", {
 				let affected_states = [];
 				frm.doc.states.forEach((row) => {
 					if (parseInt(row.doc_status || 0) !== 0) {
-						affected_states.push(row.state || __("Unnamed State"));
+						affected_states.push(row.state || __("No Label State"));
 						row.doc_status = "0";
 					}
 				});
@@ -140,8 +140,8 @@ frappe.ui.form.on("Workflow", {
 					frappe.msgprint({
 						title: __("Doc Status Reset"),
 						message: __(
-							"The <b>Doc Status</b> for the following states has been reset to <b>Draft</b> because the selected DocType is not submittable: <b>{0}</b>",
-							[affected_states.join(", ")]
+							"The <b>Doc Status</b> for the following states has been reset to <b>Draft</b> because the <b>{0}</b> is not submittable: <b>{1}</b>",
+							[frm.doc.document_type, affected_states.join(", ")]
 						),
 						indicator: "orange",
 					});

--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -109,9 +109,10 @@ frappe.ui.form.on("Workflow", {
 			return;
 		}
 		frappe.model.with_doctype(doc.document_type, () => {
-			const fieldnames = frappe
-				.get_meta(doc.document_type)
-				.fields.filter((field) => !frappe.model.no_value_type.includes(field.fieldtype))
+			const meta = frappe.get_meta(doc.document_type);
+			const is_submittable = meta.is_submittable;
+			const fieldnames = meta.fields
+				.filter((field) => !frappe.model.no_value_type.includes(field.fieldtype))
 				.map((field) => field.fieldname);
 
 			frm.fields_dict.states.grid.update_docfield_property(
@@ -119,6 +120,23 @@ frappe.ui.form.on("Workflow", {
 				"options",
 				[""].concat(fieldnames)
 			);
+
+			frm.fields_dict.states.grid.update_docfield_property(
+				"doc_status",
+				"read_only",
+				!is_submittable
+			);
+
+			if (!is_submittable) {
+				let changed = false;
+				frm.doc.states.forEach((row) => {
+					if (parseInt(row.doc_status || 0) !== 0) {
+						row.doc_status = "0";
+						changed = true;
+					}
+				});
+				if (changed) frm.refresh_field("states");
+			}
 		});
 	},
 	create_warning_dialog: function (frm) {

--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -128,14 +128,14 @@ frappe.ui.form.on("Workflow", {
 			);
 
 			if (!is_submittable) {
-				let affected_states = [];
+				let has_affected_states = false;
 				frm.doc.states.forEach((row) => {
 					if (parseInt(row.doc_status || 0) !== 0) {
-						affected_states.push(row.state);
+						has_affected_states = true;
 						row.doc_status = "0";
 					}
 				});
-				if (affected_states.length) {
+				if (has_affected_states) {
 					frm.refresh_field("states");
 					frappe.msgprint({
 						title: __("Doc Status Reset"),

--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -131,7 +131,7 @@ frappe.ui.form.on("Workflow", {
 				let affected_states = [];
 				frm.doc.states.forEach((row) => {
 					if (parseInt(row.doc_status || 0) !== 0) {
-						affected_states.push(row.state || __("No Label State"));
+						affected_states.push(row.state);
 						row.doc_status = "0";
 					}
 				});
@@ -140,8 +140,8 @@ frappe.ui.form.on("Workflow", {
 					frappe.msgprint({
 						title: __("Doc Status Reset"),
 						message: __(
-							"The <b>Doc Status</b> for the following states has been reset to <b>Draft</b> because the <b>{0}</b> is not submittable: <b>{1}</b>",
-							[frm.doc.document_type, affected_states.join(", ")]
+							"The <strong>Doc Status</strong> for all states has been reset to <strong>0</strong> because <strong>{0}</strong> is not submittable",
+							[frm.doc.document_type]
 						),
 						indicator: "orange",
 					});

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -95,7 +95,7 @@ class Workflow(Document):
 
 		if not is_submittable:
 			for state in self.states:
-				if cint(state.doc_status or 0) != 0:
+				if cint(state.doc_status) != 0:
 					frappe.throw(
 						frappe._(
 							"Workflow State '{0}' has Document Status {1}, but DocType '{2}' is not submittable. "
@@ -106,8 +106,8 @@ class Workflow(Document):
 		for t in self.transitions:
 			state = get_state(t.state)
 			next_state = get_state(t.next_state)
-			state_docstatus = cint(state.doc_status or 0)
-			next_state_docstatus = cint(next_state.doc_status or 0)
+			state_docstatus = cint(state.doc_status)
+			next_state_docstatus = cint(next_state.doc_status)
 
 			if state_docstatus == 2:
 				frappe.throw(

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -90,11 +90,9 @@ class Workflow(Document):
 
 			frappe.throw(frappe._("{0} not a valid State").format(state))
 
-		# Check if doctype is submittable
 		meta = frappe.get_meta(self.document_type)
 		is_submittable = meta.is_submittable
 
-		# Validate that non-submittable doctypes only have doc_status 0
 		if not is_submittable:
 			for state in self.states:
 				if cint(state.doc_status or 0) != 0:

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -90,23 +90,40 @@ class Workflow(Document):
 
 			frappe.throw(frappe._("{0} not a valid State").format(state))
 
+		# Check if doctype is submittable
+		meta = frappe.get_meta(self.document_type)
+		is_submittable = meta.is_submittable
+
+		# Validate that non-submittable doctypes only have doc_status 0
+		if not is_submittable:
+			for state in self.states:
+				if cint(state.doc_status or 0) != 0:
+					frappe.throw(
+						frappe._(
+							"Workflow State '{0}' has Document Status {1}, but DocType '{2}' is not submittable. "
+							"Only Document Status 0 (Draft) is allowed for non-submittable DocTypes."
+						).format(state.state, state.doc_status, self.document_type)
+					)
+
 		for t in self.transitions:
 			state = get_state(t.state)
 			next_state = get_state(t.next_state)
+			state_docstatus = cint(state.doc_status or 0)
+			next_state_docstatus = cint(next_state.doc_status or 0)
 
-			if state.doc_status == "2":
+			if state_docstatus == 2:
 				frappe.throw(
 					frappe._("Cannot change state of Cancelled Document. Transition row {0}").format(t.idx)
 				)
 
-			if state.doc_status == "1" and next_state.doc_status == "0":
+			if state_docstatus == 1 and next_state_docstatus == 0:
 				frappe.throw(
 					frappe._(
 						"Submitted Document cannot be converted back to draft. Transition row {0}"
 					).format(t.idx)
 				)
 
-			if state.doc_status == "0" and next_state.doc_status == "2":
+			if state_docstatus == 0 and next_state_docstatus == 2:
 				frappe.throw(frappe._("Cannot cancel before submitting. See Transition {0}").format(t.idx))
 
 	def set_active(self):


### PR DESCRIPTION
- Closes #37178

The fix implements multi-layered enforcement across the backend, frontend, and Workflow Builder.

## Root Cause
- `workflow.py` lacked server-side validation to check if the [document_type](file:///Users/shubh/Desktop/Resillient/frappe/frappe/workflow/doctype/workflow/workflow.js#103-106) was submittable before allowing non-zero `doc_status` values.
- The UI (both standard form view and Workflow Builder) did not lock or hide the `doc_status` field based on the DocType's submittability.

## Changes

### 1. Backend Validation (`workflow.py`)
- Added a strict check in `validate_docstatus`: if a DocType is not submittable, all its Workflow States **must** have a `doc_status` of `0` (Draft).
- Throws a descriptive `frappe.ValidationError` if an invalid status is detected.

### 2. Frontend Enforcement ([workflow.js](file:///Users/shubh/Desktop/Resillient/frappe/frappe/workflow/doctype/workflow/workflow.js))
- The `doc_status` field in the states table is now automatically set to `read_only` if the selected DocType is not submittable.
- Added a "Reset" logic: if a user selects a non-submittable DocType, any existing states with invalid statuses are automatically reset to `0`, and a prompt is displayed to the user.

### 3. Workflow Builder ([store.js](file:///Users/shubh/Desktop/Resillient/frappe/frappe/public/js/workflow_builder/store.js) & [Properties.vue](file:///Users/shubh/Desktop/Resillient/frappe/frappe/public/js/workflow_builder/components/Properties.vue))
- Added [is_submittable](file:///Users/shubh/Desktop/Resillient/frappe/frappe/public/js/workflow_builder/store.js#142-151) tracking to the Workflow Builder store.
- The Properties sidebar now renders the `docStatus` field as read-only for non-submittable types.
- Implemented automatic state reset in the builder when a DocType is changed.
- Improved error messaging to include the DocType name and handle states without labels ("No Label State").

### 4. Testing (`test_workflow.py`)
- Refactored `test_if_workflow_set_on_action` to correctly use a dynamically created submittable DocType using helper functions `create_new_submittable_doctype` and `create_submittable_workflow`.