### PR TITLE
fix(email): ensure CC header visibility according to email semantics

### DIFF
--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -158,35 +158,35 @@ def sendmail(
 	"""Send email using user's default **Email Account** or global default **Email Account**.
 
 
-	:param recipients: List of recipients.
-	:param sender: Email sender. Default is current user or default outgoing account.
-	:param subject: Email Subject.
-	:param message: (or `content`) Email Content.
-	:param as_markdown: Convert content markdown to HTML.
-	:param delayed: Send via scheduled email sender **Email Queue**. Don't send immediately. Default is true
-	:param send_priority: Priority for Email Queue, default 1.
-	:param reference_doctype: (or `doctype`) Append as communication to this DocType.
-	:param reference_name: (or `name`) Append as communication to this document name.
-	:param unsubscribe_method: Unsubscribe url with options email, doctype, name. e.g. `/api/method/unsubscribe`
-	:param unsubscribe_params: Unsubscribe paramaters to be loaded on the unsubscribe_method [optional] (dict).
-	:param attachments: List of attachments.
-	:param reply_to: Reply-To Email Address.
-	:param message_id: Used for threading. If a reply is received to this email, Message-Id is sent back as In-Reply-To in received email.
-	:param in_reply_to: Used to send the Message-Id of a received email back as In-Reply-To.
-	:param send_after: Send after the given datetime.
-	:param expose_recipients: Controls recipient visibility. "header" shows all TO recipients in the To header.
-    "footer" adds "This email was sent to..." text in footer. None (default) hides TO recipients from each other.
-    Note: CC header is always visible regardless of this setting (as per email semantics).
-	:param communication: Communication link to be set in Email Queue record
-	:param inline_images: List of inline images as {"filename", "filecontent"}. All src properties will be replaced with random Content-Id
-	:param template: Name of html template from templates/emails folder
-	:param args: Arguments for rendering the template
-	:param header: Append header in email
-	:param with_container: Wraps email inside a styled container
-	:param x_priority: 1 = HIGHEST, 3 = NORMAL, 5 = LOWEST
-	:param email_headers: Additional headers to be added in the email, e.g. {"X-Custom-Header": "value"} or {"Custom-Header": "value"}. Automatically prepends "X-" to the header name if not present.
-	:param raw_html: Whether to treat email template as a complete HTML file
-	:param add_css: Whether to add CSS from hooks/email_css to the email template
+	    :param recipients: List of recipients.
+	    :param sender: Email sender. Default is current user or default outgoing account.
+	    :param subject: Email Subject.
+	    :param message: (or `content`) Email Content.
+	    :param as_markdown: Convert content markdown to HTML.
+	    :param delayed: Send via scheduled email sender **Email Queue**. Don't send immediately. Default is true
+	    :param send_priority: Priority for Email Queue, default 1.
+	    :param reference_doctype: (or `doctype`) Append as communication to this DocType.
+	    :param reference_name: (or `name`) Append as communication to this document name.
+	    :param unsubscribe_method: Unsubscribe url with options email, doctype, name. e.g. `/api/method/unsubscribe`
+	    :param unsubscribe_params: Unsubscribe paramaters to be loaded on the unsubscribe_method [optional] (dict).
+	    :param attachments: List of attachments.
+	    :param reply_to: Reply-To Email Address.
+	    :param message_id: Used for threading. If a reply is received to this email, Message-Id is sent back as In-Reply-To in received email.
+	    :param in_reply_to: Used to send the Message-Id of a received email back as In-Reply-To.
+	    :param send_after: Send after the given datetime.
+	    :param expose_recipients: Controls recipient visibility. "header" shows all TO recipients in the To header.
+	"footer" adds "This email was sent to..." text in footer. None (default) hides TO recipients from each other.
+	Note: CC header is always visible regardless of this setting (as per email semantics).
+	    :param communication: Communication link to be set in Email Queue record
+	    :param inline_images: List of inline images as {"filename", "filecontent"}. All src properties will be replaced with random Content-Id
+	    :param template: Name of html template from templates/emails folder
+	    :param args: Arguments for rendering the template
+	    :param header: Append header in email
+	    :param with_container: Wraps email inside a styled container
+	    :param x_priority: 1 = HIGHEST, 3 = NORMAL, 5 = LOWEST
+	    :param email_headers: Additional headers to be added in the email, e.g. {"X-Custom-Header": "value"} or {"Custom-Header": "value"}. Automatically prepends "X-" to the header name if not present.
+	    :param raw_html: Whether to treat email template as a complete HTML file
+	    :param add_css: Whether to add CSS from hooks/email_css to the email template
 	"""
 
 	from frappe.utils.jinja import get_email_from_template

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -174,7 +174,9 @@ def sendmail(
 	:param message_id: Used for threading. If a reply is received to this email, Message-Id is sent back as In-Reply-To in received email.
 	:param in_reply_to: Used to send the Message-Id of a received email back as In-Reply-To.
 	:param send_after: Send after the given datetime.
-	:param expose_recipients: Display all recipients in the footer message - "This email was sent to"
+	:param expose_recipients: Controls recipient visibility. "header" shows all TO recipients in the To header.
+    "footer" adds "This email was sent to..." text in footer. None (default) hides TO recipients from each other.
+    Note: CC header is always visible regardless of this setting (as per email semantics).
 	:param communication: Communication link to be set in Email Queue record
 	:param inline_images: List of inline images as {"filename", "filecontent"}. All src properties will be replaced with random Content-Id
 	:param template: Name of html template from templates/emails folder

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -337,7 +337,8 @@ class EMail:
 			"To": ", ".join(self.recipients) if self.expose_recipients == "header" else "<!--recipient-->",
 			"Date": email.utils.formatdate(),
 			"Reply-To": self.reply_to if self.reply_to else None,
-			"CC": ", ".join(self.cc) if self.cc and self.expose_recipients == "header" else None,
+			# cc should always be visible - as that is the semantic meaning of cc, this should not be dependent on expose_recipients
+			"CC": ", ".join(self.cc) if self.cc else None,
 			"X-Frappe-Site": get_url(),
 		}
 

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -82,8 +82,53 @@ class TestEmail(IntegrationTestCase):
 		self.assertEqual(len(queue_recipients), 2)
 		self.assertTrue("Unsubscribe" in frappe.safe_decode(frappe.flags.sent_mail))
 
-	def test_cc_header(self):
-		# test if sending with cc's makes it into header
+	def test_cc_header_always_visible(self):
+		"""Test that CC header is always visible regardless of expose_recipients setting.
+
+		CC (Carbon Copy) should always be visible to all recipients as per email semantics.
+		This enables 'Reply All' functionality. If sender wants hidden recipients, they should use BCC.
+		"""
+		frappe.sendmail(
+			recipients=["test@example.com"],
+			cc=["test1@example.com"],
+			sender="admin@example.com",
+			reference_doctype="User",
+			reference_name="Administrator",
+			subject="Testing CC Header Visibility",
+			message="CC should be visible without expose_recipients",
+			unsubscribe_message="Unsubscribe",
+			# No expose_recipients set - CC should still be visible
+		)
+		email_queue = frappe.db.sql(
+			"""select name from `tabEmail Queue` where status='Not Sent'""", as_dict=1
+		)
+		self.assertEqual(len(email_queue), 1)
+		queue_recipients = [
+			r.recipient
+			for r in frappe.db.sql(
+				"""select recipient from `tabEmail Queue Recipient`
+			where status='Not Sent'""",
+				as_dict=1,
+			)
+		]
+		self.assertTrue("test@example.com" in queue_recipients)
+		self.assertTrue("test1@example.com" in queue_recipients)
+
+		message = frappe.db.sql(
+			"""select message from `tabEmail Queue`
+			where status='Not Sent'""",
+			as_dict=1,
+		)[0].message
+		# CC should be visible even without expose_recipients
+		self.assertTrue("CC: test1@example.com" in message)
+		# TO should use placeholder (hidden) when expose_recipients is not set
+		self.assertTrue("To: <!--recipient-->" in message)
+
+	def test_cc_header_with_expose_recipients(self):
+		"""Test CC and TO visibility when expose_recipients='header' is set.
+
+		With expose_recipients='header', both TO and CC should be visible in headers.
+		"""
 		frappe.sendmail(
 			recipients=["test@example.com"],
 			cc=["test1@example.com"],
@@ -115,6 +160,7 @@ class TestEmail(IntegrationTestCase):
 			where status='Not Sent'""",
 			as_dict=1,
 		)[0].message
+		# Both TO and CC should be visible with expose_recipients="header"
 		self.assertTrue("To: test@example.com" in message)
 		self.assertTrue("CC: test1@example.com" in message)
 


### PR DESCRIPTION
Resolves and closes #26859 

If someone uses cc=["person@x.com"], they are explicitly saying: "I want recipients to know person@x.com was copied"
If they didn't want this visibility, they would use *bcc* instead

Therefore, CC should always be visible regardless of expose_recipients.

IMO, the `expose_recipients` should only be intended for TO recipients. That's what this PR fixes.

Updated the docs as well to provide better clarity. Updated the tests as well.