### PR TITLE
fix: shadow inset introduces extra spacing for grid icons

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -313,6 +313,8 @@
 
 		.link-btn {
 			background-color: var(--bg-color);
+			height: calc(100% - 4px);
+			margin-top: 2px;
 		}
 
 		.form-control:focus {


### PR DESCRIPTION
After removing unnecessary padding from grid column open link button in https://github.com/frappe/frappe/pull/37156, the overflow issue still happened in develop. After pulling in latest changes that were probably happening in parallel 😅 realised that we have recently introduced a box shadow to highlight the grid fields when they are focused - [ref](https://github.com/frappe/frappe/pull/37169/changes#diff-d6acb72fec5a6da6a8def3b2a3112d02796a0624b6af893e156c221bd241d1d6R321).

If we want to use an inset in the parent div like this we'll have to compensate for it when using full height in buttons inside the grid inputs explicitly which doesn't seem like a very clean solution but box-shadows with inset require us to offset children somehow either by using padding on parent div or by using margin on child div. If there's a better way please lmk?

<br>


### Before

https://github.com/user-attachments/assets/90b3a0f0-c9ec-464f-a280-b730429430d0


<br>


### After

https://github.com/user-attachments/assets/1215dfeb-7dcc-44b2-b751-112df518f20f

