### PR TITLE
fix(pdf): removal of header and footer margins

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -369,6 +369,12 @@ def prepare_header_footer(soup: BeautifulSoup):
 
 			# {"header-html": "/tmp/frappe-pdf-random.html"}
 			options[html_id] = fname
+
+			if html_id == "header-html":
+				options["margin-top"] = "25mm"
+			elif html_id == "footer-html":
+				options["margin-bottom"] = "25mm"
+
 		else:
 			if html_id == "header-html":
 				options["margin-top"] = "15mm"


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/35450

Margin was not being applied for header/footer divs with ids "header-html" and "footer-html". 

https://github.com/user-attachments/assets/85bfcf43-161d-4f0f-be2e-af448e9f3ba0

I suspect that wkhtmltopdf might be using default margins when --footer-html is specified. When you don't explicitly set margin-bottom, wkhtmltopdf might be using non-standard defaults that affect the entire page layout.