### PR TITLE
fix: report and notification folder deletion on deletion from ui

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -105,7 +105,8 @@ class Report(Document):
 	def after_delete(self):
 		from frappe.modules.export_file import delete_folder
 
-		delete_folder(self.module, "Report", self.name)
+		if not frappe.flags.in_test and frappe.conf.developer_mode:
+			delete_folder(self.module, "Report", self.name)
 
 	def get_permission_log_options(self, event=None):
 		return {"fields": ["roles"]}

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -102,6 +102,11 @@ class Report(Document):
 			frappe.throw(_("You are not allowed to delete Standard Report"))
 		delete_custom_role("report", self.name)
 
+	def after_delete(self):
+		from frappe.modules.export_file import delete_folder
+
+		delete_folder(self.module, "Report", self.name)
+
 	def get_permission_log_options(self, event=None):
 		return {"fields": ["roles"]}
 

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -724,7 +724,7 @@ def get_context(context):
 		# Prevent deletion of standard notifications outside developer mode to avoid restoration during migration
 		if (
 			self.is_standard
-			and not cint(getattr(frappe.local.conf, "developer_mode", 0))
+			and not frappe.conf.developer_mode
 			and not frappe.flags.in_migrate
 			and not frappe.flags.in_patch
 		):

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -723,6 +723,11 @@ def get_context(context):
 	def on_trash(self):
 		clear_notification_cache()
 
+	def after_delete(self):
+		from frappe.modules.export_file import delete_folder
+
+		delete_folder(self.module, "Notification", self.name)
+
 
 def clear_notification_cache():
 	frappe.client_cache.delete_keys("notifications::")

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -721,19 +721,23 @@ def get_context(context):
 		self.message = self.get_template(md_as_html=True)
 
 	def on_trash(self):
+		# Prevent deletion of standard notifications outside developer mode to avoid restoration during migration
 		if (
 			self.is_standard
 			and not cint(getattr(frappe.local.conf, "developer_mode", 0))
 			and not frappe.flags.in_migrate
 			and not frappe.flags.in_patch
 		):
-			frappe.throw(_("You are not allowed to delete Standard Notification"))
+			frappe.throw(
+				_("You are not allowed to delete a standard Notification. You can disable it instead.")
+			)
 		clear_notification_cache()
 
 	def after_delete(self):
 		from frappe.modules.export_file import delete_folder
 
-		delete_folder(self.module, "Notification", self.name)
+		if not frappe.flags.in_test and frappe.conf.developer_mode:
+			delete_folder(self.module, "Notification", self.name)
 
 
 def clear_notification_cache():

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -14,7 +14,7 @@ from frappe.desk.doctype.notification_log.notification_log import enqueue_create
 from frappe.integrations.doctype.slack_webhook_url.slack_webhook_url import send_slack_message
 from frappe.model.document import Document
 from frappe.modules.utils import export_module_json, get_doc_module
-from frappe.utils import add_to_date, cast, now_datetime, nowdate, validate_email_address
+from frappe.utils import add_to_date, cast, cint, now_datetime, nowdate, validate_email_address
 from frappe.utils.data import evaluate_filters
 from frappe.utils.jinja import validate_template
 from frappe.utils.safe_exec import get_safe_globals
@@ -721,6 +721,13 @@ def get_context(context):
 		self.message = self.get_template(md_as_html=True)
 
 	def on_trash(self):
+		if (
+			self.is_standard
+			and not cint(getattr(frappe.local.conf, "developer_mode", 0))
+			and not frappe.flags.in_migrate
+			and not frappe.flags.in_patch
+		):
+			frappe.throw(_("You are not allowed to delete Standard Notification"))
 		clear_notification_cache()
 
 	def after_delete(self):


### PR DESCRIPTION
- **Closes: #37188**

# Description

This PR addresses two things:

1) Folder deletion when deleted from ui as mentioned in #37188 
2) Allow standard notifications to be deleted only when one is in developer mode. This check was missing and is added now.