### PR TITLE
fix(sidebar): remove double encoding of sidebar item filter

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -69,9 +69,7 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 				path = frappe.utils.generate_route(args);
 			}
 		}
-		if (path) {
-			return encodeURI(path);
-		}
+		return path;
 	}
 	transform_filters(filters_json) {
 		for (const [key, value] of Object.entries(filters_json)) {

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1598,7 +1598,7 @@ Object.assign(frappe.utils, {
 			route +=
 				"?" +
 				$.map(item.route_options, function (value, key) {
-					return encodeURIComponent(key) + "=" + encodeURIComponent(value);
+					return key + "=" + value;
 				}).join("&");
 		}
 

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1598,7 +1598,7 @@ Object.assign(frappe.utils, {
 			route +=
 				"?" +
 				$.map(item.route_options, function (value, key) {
-					return key + "=" + value;
+					return encodeURIComponent(key) + "=" + encodeURIComponent(value);
 				}).join("&");
 		}
 


### PR DESCRIPTION
Fixes: #37020, #37143

Remove `encodeURIComponent` from route options in `generate_route` to prevent double encoding, since `encodeURI` in `get_path` already handles the full URL encoding.

https://github.com/frappe/frappe/blob/0254f52834700e86d761d10c97a07288d275958e/frappe/public/js/frappe/ui/sidebar/sidebar_item.js#L72-L74

----

Before:

https://github.com/user-attachments/assets/f98fa270-f51f-472b-bf8d-912bbde539b3


---
After:

https://github.com/user-attachments/assets/48d5b64d-51fe-4c7c-b566-4ec6ecb81d0f

