### PR TITLE
fix(Web Form): child table link fields break for guest submissions

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -456,10 +456,7 @@ def get_context(context):
 				field.fields = get_in_list_view_fields(field.options, self.name)
 
 			if field.fieldtype == "Link":
-				field.fieldtype = "Autocomplete"
-				field.options = get_link_options(
-					self.name, field.options, field.allow_read_on_all_link_options
-				)
+				process_link_field(field, self.name)
 
 		context.reference_doc = {}
 
@@ -606,6 +603,14 @@ def get_context(context):
 				permitted_attachments.append(_add_attachment(attachment))
 
 		return permitted_attachments
+
+
+def process_link_field(field, web_form_name):
+	field.fieldtype = "Autocomplete"
+	field.options = get_link_options(
+		web_form_name, field.options, getattr(field, "allow_read_on_all_link_options", False)
+	)
+	return field
 
 
 def get_web_form_module(doc):
@@ -798,10 +803,7 @@ def get_form_data(doctype: str, docname: str | None = None, web_form_name: str |
 			out.update({field.fieldname: field.fields})
 
 		if field.fieldtype == "Link":
-			field.fieldtype = "Autocomplete"
-			field.options = get_link_options(
-				web_form_name, field.options, field.allow_read_on_all_link_options
-			)
+			process_link_field(field, web_form_name)
 
 	return out
 
@@ -824,14 +826,10 @@ def get_in_list_view_fields(doctype, web_form_name=None):
 	def get_field_df(fieldname):
 		if fieldname == "name":
 			return {"label": "Name", "fieldname": "name", "fieldtype": "Data"}
+
 		df = meta.get_field(fieldname).as_dict()
 		if df.get("options") and df.get("fieldtype") == "Link":
-			df["fieldtype"] = "Autocomplete"
-			df["options"] = get_link_options(
-				web_form_name,
-				doctype=df.options,
-				allow_read_on_all_link_options=df.get("allow_read_on_all_link_options", False),
-			)
+			process_link_field(df, web_form_name)
 		return df
 
 	return [get_field_df(f) for f in fields]
@@ -853,11 +851,11 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 	if web_form.login_required and frappe.session.user == "Guest":
 		frappe.throw(_("You must be logged in to use this form."), frappe.PermissionError)
 
-		if not web_form.published or not has_link_option(web_form.web_form_fields, doctype):
-			frappe.throw(
-				_("You don't have permission to access the {0} DocType.").format(doctype),
-				frappe.PermissionError,
-			)
+	if not web_form.published or not has_link_option(web_form.web_form_fields, doctype):
+		frappe.throw(
+			_("You don't have permission to access the {0} DocType.").format(doctype),
+			frappe.PermissionError,
+		)
 
 	link_options, filters = [], {}
 	if web_form.login_required and not allow_read_on_all_link_options:

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -416,7 +416,7 @@ def get_context(context):
 
 	def load_list_data(self, context):
 		if not self.list_columns:
-			self.list_columns = get_in_list_view_fields(self.doc_type)
+			self.list_columns = get_in_list_view_fields(self.doc_type, self.name)
 			context.web_form_doc.list_columns = self.list_columns
 
 	def load_form_data(self, context):
@@ -453,7 +453,7 @@ def get_context(context):
 		# For Table fields, server-side processing for meta
 		for field in context.web_form_doc.web_form_fields:
 			if field.fieldtype == "Table":
-				field.fields = get_in_list_view_fields(field.options)
+				field.fields = get_in_list_view_fields(field.options, self.name)
 
 			if field.fieldtype == "Link":
 				field.fieldtype = "Autocomplete"
@@ -794,7 +794,7 @@ def get_form_data(doctype: str, docname: str | None = None, web_form_name: str |
 	# For Table fields, server-side processing for meta
 	for field in out.web_form.web_form_fields:
 		if field.fieldtype == "Table":
-			field.fields = get_in_list_view_fields(field.options)
+			field.fields = get_in_list_view_fields(field.options, web_form_name)
 			out.update({field.fieldname: field.fields})
 
 		if field.fieldtype == "Link":
@@ -807,7 +807,7 @@ def get_form_data(doctype: str, docname: str | None = None, web_form_name: str |
 
 
 @frappe.whitelist()
-def get_in_list_view_fields(doctype):
+def get_in_list_view_fields(doctype, web_form_name=None):
 	meta = frappe.get_meta(doctype)
 	fields = []
 
@@ -824,9 +824,27 @@ def get_in_list_view_fields(doctype):
 	def get_field_df(fieldname):
 		if fieldname == "name":
 			return {"label": "Name", "fieldname": "name", "fieldtype": "Data"}
-		return meta.get_field(fieldname).as_dict()
+		df = meta.get_field(fieldname).as_dict()
+		if df.get("options") and df.get("fieldtype") == "Link":
+			df["fieldtype"] = "Autocomplete"
+			df["options"] = get_link_options(
+				web_form_name,
+				doctype=df.options,
+				allow_read_on_all_link_options=df.get("allow_read_on_all_link_options", False),
+			)
+		return df
 
 	return [get_field_df(f) for f in fields]
+
+
+def has_link_option(fields, doctype):
+	for f in fields:
+		if f.options == doctype:
+			return True
+		if hasattr(f, "fields") and isinstance(f.fields, list):
+			if has_link_option(f.fields, doctype):
+				return True
+	return False
 
 
 def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=False):
@@ -835,10 +853,11 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 	if web_form.login_required and frappe.session.user == "Guest":
 		frappe.throw(_("You must be logged in to use this form."), frappe.PermissionError)
 
-	if not web_form.published or not any(f for f in web_form.web_form_fields if f.options == doctype):
-		frappe.throw(
-			_("You don't have permission to access the {0} DocType.").format(doctype), frappe.PermissionError
-		)
+		if not web_form.published or not has_link_option(web_form.web_form_fields, doctype):
+			frappe.throw(
+				_("You don't have permission to access the {0} DocType.").format(doctype),
+				frappe.PermissionError,
+			)
 
 	link_options, filters = [], {}
 	if web_form.login_required and not allow_read_on_all_link_options:

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -808,7 +808,6 @@ def get_form_data(doctype: str, docname: str | None = None, web_form_name: str |
 	return out
 
 
-@frappe.whitelist()
 def get_in_list_view_fields(doctype, web_form_name=None):
 	meta = frappe.get_meta(doctype)
 	fields = []


### PR DESCRIPTION
#### TL;DR 
Link fields for Guest users in Web Forms work if they are normal DocType fields but not if they are in the Child Table.

#### Context
Web Form handles link fields a bit differently which means whenever I select a Link field to be shown in a Web Form associated with a DocType, it shows them as Autocomplete fields (I'm assuming this is done since we don't really want all the extra spice that Link fields offer - showing New Doc option, filters etc.) and Autocomplete options are a good way to just display the options the user can choose from in the Web Form field and submit an entry. 

But, all this is only handled for link fields which belong to the DocType and not any link fields that are part of a Child Table in that DocType. In the child table, link fields are shown normally but as soon as we try to enter a value it breaks since it's trying to call the `search_link` method and doesn't convert them to an Autocomplete field like the parent doc fields. 

#### Before


https://github.com/user-attachments/assets/0dc3b378-b937-4122-9cdf-63736ba5c1f7

<br>

#### After 


https://github.com/user-attachments/assets/8c8517c2-3084-434d-989c-a284edf50f4f



Closes https://github.com/frappe/frappe/issues/27567

<br>

----

#### PS:
We probably don't need to whitelist the `get_in_list_view_fields` function since it's not called anywhere from the client side so got rid of that decorator. Last usage from client side was removed in https://github.com/frappe/frappe/pull/5913/changes/93fd9dfce9cc59ec77aec24f97d2dc50fb0d074e but it's still whitelisted.
