### PR TITLE
fix(RolesEditor): enable/disable buttons in roles editor based on state

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -440,9 +440,6 @@ frappe.ui.form.on("User Role Profile", {
 					frm.roles_editor.show();
 				}
 			});
-			if (frm.roles_editor) {
-				$(".deselect-all, .select-all").prop("disabled", true);
-			}
 		}
 	},
 	role_profiles_remove: function (frm) {
@@ -450,7 +447,6 @@ frappe.ui.form.on("User Role Profile", {
 			if (frm.roles_editor) {
 				frm.roles_editor.disable = 0;
 				frm.roles_editor.show();
-				$(".deselect-all, .select-all").prop("disabled", false);
 			}
 		}
 	},

--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -130,7 +130,15 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 	}
 
 	select_all(deselect = false) {
-		$(this.wrapper).find(`:checkbox`).prop("checked", deselect).trigger("click");
+		$(this.wrapper)
+			.find(`:checkbox`)
+			.prop("checked", function () {
+				if (this.disabled) {
+					return this.checked;
+				}
+				return deselect;
+			})
+			.trigger("click");
 	}
 
 	select_options(selected_options) {

--- a/frappe/public/js/frappe/roles_editor.js
+++ b/frappe/public/js/frappe/roles_editor.js
@@ -47,6 +47,9 @@ frappe.RoleEditor = class {
 		$(this.wrapper)
 			.find('input[type="checkbox"]')
 			.attr("disabled", this.disable ? true : false);
+		$(this.wrapper)
+			.find("button")
+			.attr("disabled", this.disable ? true : false);
 	}
 	show_permissions(role) {
 		// show permissions for a role


### PR DESCRIPTION
fixes #31662

fixed `select_all` logic where disabled checkboxes did not trigger clicks and stayed in the opposite checked state.

although now it is not possible to trigger `select_all` if `RolesEditor` is disabled as the buttons to make that function call are also disabled, but this logic acts as a failsafe.

after fix:

https://github.com/user-attachments/assets/7da1ba9e-6759-45c6-ad15-a0ce23ef221d

