### PR TITLE
fix: prevent docfield copy contamination across grid rows on deletion/reorder

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -574,7 +574,7 @@ export default class Grid {
 			let grid_row;
 			if (this.grid_rows[ri] && !append_row) {
 				grid_row = this.grid_rows[ri];
-				grid_row.doc = d;
+				grid_row.update_doc(d);
 				grid_row.refresh();
 			} else {
 				grid_row = new GridRow({

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -53,25 +53,14 @@ export default class GridRow {
 		this.wrapper.appendTo(this.parent);
 	}
 
-	set_docfields(update = false) {
+	set_docfields() {
 		if (this.doc && this.parent_df.options) {
-			frappe.meta.make_docfield_copy_for(
+			this.docfields = frappe.meta.get_docfields(
 				this.parent_df.options,
 				this.doc.name,
-				this.docfields
+				null,
+				this.grid.docfields
 			);
-			const docfields = frappe.meta.get_docfields(this.parent_df.options, this.doc.name);
-			if (update) {
-				// to maintain references
-				this.docfields.forEach((df) => {
-					Object.assign(
-						df,
-						docfields.find((d) => d.fieldname === df.fieldname)
-					);
-				});
-			} else {
-				this.docfields = docfields;
-			}
 		}
 	}
 
@@ -198,10 +187,7 @@ export default class GridRow {
 		);
 	}
 	refresh() {
-		// update docfields for new record
-		if (this.frm && this.doc && this.doc.__islocal) {
-			this.set_docfields(true);
-		}
+		this.set_docfields();
 
 		if (this.frm && this.doc) {
 			this.doc = locals[this.doc.doctype][this.doc.name];

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -53,6 +53,12 @@ export default class GridRow {
 		this.wrapper.appendTo(this.parent);
 	}
 
+	update_doc(doc) {
+		const changed = !this.doc || this.doc !== doc;
+		this.doc = doc;
+		if (changed) this.set_docfields();
+	}
+
 	set_docfields() {
 		if (this.doc && this.parent_df.options) {
 			this.docfields = frappe.meta.get_docfields(
@@ -187,8 +193,6 @@ export default class GridRow {
 		);
 	}
 	refresh() {
-		this.set_docfields();
-
 		if (this.frm && this.doc) {
 			this.doc = locals[this.doc.doctype][this.doc.name];
 		}

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -91,8 +91,8 @@ $.extend(frappe.meta, {
 		};
 	},
 
-	get_docfields: function (doctype, name, filters) {
-		var docfield_map = frappe.meta.get_docfield_copy(doctype, name);
+	get_docfields: function (doctype, name, filters, docfield_list = null) {
+		var docfield_map = frappe.meta.get_docfield_copy(doctype, name, docfield_list);
 
 		var docfields = frappe.meta.sort_docfields(docfield_map);
 
@@ -125,11 +125,11 @@ $.extend(frappe.meta, {
 		});
 	},
 
-	get_docfield_copy: function (doctype, name) {
+	get_docfield_copy: function (doctype, name, docfield_list = null) {
 		if (!name) return frappe.meta.docfield_map[doctype];
 
 		if (!(frappe.meta.docfield_copy[doctype] && frappe.meta.docfield_copy[doctype][name])) {
-			frappe.meta.make_docfield_copy_for(doctype, name);
+			frappe.meta.make_docfield_copy_for(doctype, name, docfield_list);
 		}
 
 		return frappe.meta.docfield_copy[doctype][name];


### PR DESCRIPTION
Closes #36921. Supersedes #36930.

## Problem

`set_docfields` called `make_docfield_copy_for(doctype, name, this.docfields)`, using the row's current docfields as the copy source. These docfields have mutated properties from `set_dependant_property` (e.g. `reqd=1` from `mandatory_depends_on`). When a row gets positionally reused for a different doc after deletion/reorder, these stale values contaminate the new doc's entry in `frappe.meta.docfield_copy`. At save time, `is_docfield_mandatory` short-circuits on the stale `df.reqd` without evaluating the expression against the actual doc.

The same contamination affects `read_only` and `hidden_due_to_dependency`.

## Fix

- **Remove `make_docfield_copy_for` from `set_docfields`** — the copy store already seeds itself lazily from clean originals in `get_docfield_copy`
- **Call `set_docfields()` when updating doc** — ensures rows pick up the correct copy-store entries when doc identity changes at a position (previously only ran for `__islocal` docs)
- **Thread `grid.docfields` through meta.js** — so new copy-store entries for unseen docnames include grid-level customizations (`frm.set_df_property` on child fields)