### PR TITLE
fix(form-footer): scroll-to-top button position for mobile and z-index

### DIFF
--- a/frappe/public/js/frappe/form/footer/footer.js
+++ b/frappe/public/js/frappe/form/footer/footer.js
@@ -40,6 +40,7 @@ frappe.ui.form.Footer = class FormFooter {
 		const needs_scroll = scroll_height > client_height;
 		const is_scrolled = scroll_top > 50;
 		$button.toggleClass("show", needs_scroll && is_scrolled);
+		$button.css("right", frappe.is_mobile() && needs_scroll && is_scrolled ? "20px" : "");
 	}
 	make_comment_box() {
 		this.frm.comment_box = frappe.ui.form.make_control({

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -492,7 +492,7 @@
 			position: fixed;
 			right: calc(var(--form-sidebar-width, 277px) + 20px);
 			bottom: 20px;
-			z-index: 1050;
+			z-index: 1030;
 			opacity: 1;
 			visibility: visible;
 			transform: translateY(0);


### PR DESCRIPTION
Changes include:
- Fixed the z-index of the Scroll Top Button when modals are visible.
- Fixed the Scroll Top Button's position for mobile view.

<table>
<thead>
<tr>
 <th>Before
 <th>After
<tbody>
<tr>
 <td>
<img width="2940" height="1660" alt="image" src="https://github.com/user-attachments/assets/00f86357-eeb9-4131-a030-bfcbec019ef2" />
 <td>
<img width="1806" height="1653" alt="image" src="https://github.com/user-attachments/assets/d8ea28f1-80c5-4eb4-89f8-0dd77704d621" />
<tr>
 <td>
<img width="668" height="524" alt="image" src="https://github.com/user-attachments/assets/f9b67472-1092-46b2-a5d2-133b2de1af94" />
 <td>
<img width="670" height="530" alt="image" src="https://github.com/user-attachments/assets/b19422ef-31a2-4147-af39-2ed0a4ff37b8" />
</table>