### PR TITLE
fix: call take_backup instead of take_backups_s3 from JS to ensure async execution

### DIFF
--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.js
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.js
@@ -12,15 +12,9 @@ frappe.ui.form.on("S3 Backup Settings", {
 			frm.add_custom_button(__("Take Backup Now"), function () {
 				frm.dashboard.set_headline_alert("S3 Backup Started!");
 				frappe.call({
-					method: "frappe.integrations.doctype.s3_backup_settings.s3_backup_settings.take_backups_s3",
-					callback: function (r) {
-						if (!r.exc) {
-							frappe.msgprint(__("S3 Backup complete!"));
-							frm.dashboard.clear_headline();
-						}
-					},
+					method: "frappe.integrations.doctype.s3_backup_settings.s3_backup_settings.take_backup",
 				});
-			}).addClass("btn-primary");
+			}).addClass("btn-secondary");
 		}
 	},
 });

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.js
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.js
@@ -13,8 +13,20 @@ frappe.ui.form.on("S3 Backup Settings", {
 				frm.dashboard.set_headline_alert("S3 Backup Started!");
 				frappe.call({
 					method: "frappe.integrations.doctype.s3_backup_settings.s3_backup_settings.take_backup",
+					callback: function (r) {
+						if (!r.exc && r.message) {
+							const job_id = r.message;
+							frappe.msgprint({
+								message: __(
+									"S3 Backup has been queued. You can track the progress <a href='/app/rq-job/{0}' target='_blank'>here</a>.",
+									[job_id]
+								),
+							});
+							frm.dashboard.clear_headline();
+						}
+					},
 				});
-			}).addClass("btn-secondary");
+			});
 		}
 	},
 });

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -79,12 +79,12 @@ class S3BackupSettings(Document):
 @frappe.whitelist()
 def take_backup():
 	"""Enqueue longjob for taking backup to s3"""
-	enqueue(
+	job = enqueue(
 		"frappe.integrations.doctype.s3_backup_settings.s3_backup_settings.take_backups_s3",
 		queue="long",
 		timeout=1500,
 	)
-	frappe.msgprint(_("Queued for backup. It may take a few minutes to an hour."))
+	return job.id
 
 
 def take_backups_daily():


### PR DESCRIPTION
## Problem
The JS form was calling `take_backups_s3` directly via `frappe.call`, which runs 
the backup synchronously within the HTTP request. This causes a request timeout 
for large backups since the connection is held open until the backup completes.

## Before Fix
[Screencast from 2026-03-24 10-54-40.webm](https://github.com/user-attachments/assets/2f3b74df-143a-4f92-9fe4-f70bd5c43338)


## After Fix
[Screencast from 2026-03-24 10-49-54.webm](https://github.com/user-attachments/assets/8865983a-3617-4d47-a6a5-f2f5d2d39cb6)
