### PR TITLE
fix: grid layout issue after save

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -381,12 +381,7 @@
 			line-height: 1.3 !important;
 		}
 	}
-	.data-row {
-		div[data-fieldname="options"],
-		div[data-fieldtype="Text Editor"] {
-			height: auto;
-		}
-	}
+
 	.grid-static-col {
 		background-color: var(--fg-color);
 		&.sticky-grid-col {


### PR DESCRIPTION
Removed the height override that was causing layout issues after save.

Before:
<img width="961" height="357" alt="Screenshot 2026-02-19 at 12 38 24 PM" src="https://github.com/user-attachments/assets/c3c42d95-2399-47b6-98ae-bb25ff67b850" />

After:
<img width="2408" height="770" alt="image" src="https://github.com/user-attachments/assets/e3ee0aaa-c4a0-45c3-a98e-b419f375db8a" />
