### PR TITLE
fix: duplicate last quoted message

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -5,6 +5,8 @@ import localforage from "localforage";
 
 frappe.last_edited_communication = {};
 const separator_element = "<div>---</div>";
+// Quill uses <p>---</p>; match both when stripping quoted content
+const separator_regex = /<(?:div|p)(?:\s[^>]*)?>---<\/(?:div|p)>/i;
 
 frappe.views.CommunicationComposer = class {
 	constructor(opts) {
@@ -566,6 +568,18 @@ frappe.views.CommunicationComposer = class {
 		const last_edited = this.get_last_edited_communication();
 		if (!last_edited.content && !last_edited.html_content) return;
 
+		// For replies: strip duplicate quoted content (Quill uses <p>---</p>)
+		if (this.is_a_reply) {
+			const reply_block = this.get_earlier_reply();
+			for (const field of ["content", "html_content"]) {
+				if (last_edited[field]) {
+					last_edited[field] =
+						(last_edited[field].split(separator_regex)[0] || "").trimEnd() +
+						reply_block;
+				}
+			}
+		}
+
 		// prevent re-triggering of email template
 		if (last_edited.email_template) {
 			const template_field = this.dialog.fields_dict.email_template;
@@ -789,7 +803,7 @@ frappe.views.CommunicationComposer = class {
 	save_as_draft() {
 		if (this.dialog && this.frm) {
 			let message = this.get_email_content();
-			message = message.split(separator_element)[0];
+			message = message.split(separator_regex)[0];
 			this.save_item_in_local_forage(this.frm.doctype + this.frm.docname, message);
 			this.save_item_in_local_forage(
 				this.frm.doctype + this.frm.docname + "_use_html",
@@ -950,7 +964,7 @@ frappe.views.CommunicationComposer = class {
 		}
 
 		if (this.is_a_reply && !this.reply_set) {
-			message += this.get_earlier_reply();
+			message = message.split(separator_regex)[0] + this.get_earlier_reply();
 		}
 
 		await this.set_email_content(message);


### PR DESCRIPTION
## Fix duplicate quoted content in email reply composer

### Fixes
[#32605](https://github.com/frappe/frappe/issues/32605) - When hitting reply to same email, and the draft is loaded, sometimes the last communication will be appended multiple times

### Problem
In the Communication composer, when replying to an email and then refreshing and replying again, the quoted last message was appended multiple times instead of once.

### Root Cause
1. The code only matched the separator `<div>---</div>` when stripping quoted content
2. The Quill editor stores the separator as `<p>---</p>`, so the split never matched and quoted blocks were never removed
3. Duplicates could come from both localforage (after refresh) and `last_edited_communication` (same session)

### Solution
- Added a regex that matches both `<div>---</div>` and `<p>---</p>`
- Strip any existing quoted content before appending a new quoted block in:
  - `set_content()` - when loading from localforage or composing a new reply
  - `set_values_from_last_edited_communication()` - when loading from same-session draft
- Updated `save_as_draft()` to use the same regex so drafts are saved correctly

Screenshots:
Before:
<img width="1024" height="665" alt="image" src="https://github.com/user-attachments/assets/83de9619-08d8-487a-aac5-961eaabc6dd2" />

After:
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/915b1799-17da-4674-8ac2-552f21f2816d" />
