### PR TITLE
fix: restore z-index for sticky grid column

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -68,6 +68,7 @@
 	.row-index {
 		position: sticky;
 		left: 0;
+		z-index: 1;
 	}
 	.row-index {
 		left: 31px;
@@ -140,6 +141,7 @@
 		position: sticky;
 		left: 0;
 		background-color: var(--fg-color);
+		z-index: 1;
 	}
 	.row-index {
 		left: 31px;

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -381,12 +381,7 @@
 			line-height: 1.3 !important;
 		}
 	}
-	.data-row {
-		div[data-fieldname="options"],
-		div[data-fieldtype="Text Editor"] {
-			height: auto;
-		}
-	}
+
 	.grid-static-col {
 		background-color: var(--fg-color);
 		&.sticky-grid-col {


### PR DESCRIPTION
fixes:
https://github.com/frappe/frappe/pull/37169#issuecomment-3925040016