### PR TITLE
fix(grid): saving of values on navigation using arrow keys

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1283,11 +1283,14 @@ export default class GridRow {
 						return false;
 					}
 
-					base.toggle_editable_row();
-					var input = base.columns[fieldname].field.$input;
-					if (input) {
-						input.focus();
-					}
+					field.parse_validate_and_set_in_model(field.get_input_value()).then(() => {
+						base.toggle_editable_row();
+						const input = base.columns[fieldname].field.$input;
+						if (input) {
+							input.focus();
+						}
+					});
+
 					return true;
 				};
 


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/16145

When using arrow keys to navigate between grid rows, the current field's value wasn't being saved before switching rows, causing `toggle_editable_row(false)` to refresh the field from the old doc value.

Adding `field.parse_validate_and_set_in_model(field.get_input_value())` grabs the raw value currently inside the input field  and triggers the standard process to update the underlying document model.

https://github.com/user-attachments/assets/c59c719c-ca15-4583-9868-94c5cb238b32

