### PR TITLE
fix(sendmail): respect inline_images parameter in sendmail

### DIFF
--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -210,7 +210,18 @@ class EMail:
 
 		if has_inline_images:
 			# process inline images
-			message, _inline_images = replace_filename_with_cid(message)
+			provided_images = {}
+			if inline_images:
+				for img in inline_images:
+					if img.get("filename") and img.get("filecontent"):
+						# index by full path and basename for flexible matching
+						provided_images[img["filename"]] = img["filecontent"]
+						basename = img["filename"].rsplit("/", 1)[-1]
+						if basename not in provided_images:
+							provided_images[basename] = img["filecontent"]
+
+			# process inline images while preferring provided_images over disk reads
+			message, _inline_images = replace_filename_with_cid(message, provided_images)
 
 			# prepare parts
 			msg_related = MIMEMultipart("related", policy=policy.SMTP)
@@ -552,11 +563,22 @@ def get_footer(email_account, footer=None):
 	return footer
 
 
-def replace_filename_with_cid(message):
+def replace_filename_with_cid(message, provided_images=None):
 	"""Replaces <img embed="assets/frappe/images/filename.jpg" ...> with
 	<img src="cid:content_id" ...> and return the modified message and
 	a list of inline_images with {filename, filecontent, content_id}
+
+	Args:
+		message: The HTML message to process
+		provided_images: A dictionary of images to use instead of reading from disk
+			Example:
+			{
+				"assets/frappe/images/filename.jpg": filecontent,
+				"filename.jpg": filecontent,
+			}
 	"""
+	if provided_images is None:
+		provided_images = {}
 
 	inline_images = []
 
@@ -571,7 +593,11 @@ def replace_filename_with_cid(message):
 		img_path_escaped = frappe.utils.html_utils.unescape_html(img_path)
 		filename = img_path_escaped.rsplit("/")[-1]
 
-		filecontent = get_filecontent_from_path(img_path_escaped)
+		# check if the image is provided in the provided_images(by checking full path and basename)
+		filecontent = provided_images.get(img_path_escaped) or provided_images.get(filename)
+		if not filecontent:
+			filecontent = get_filecontent_from_path(img_path_escaped)
+
 		if not filecontent:
 			message = re.sub(f"""embed=['"]{re.escape(img_path)}['"]""", "", message)
 			continue

--- a/frappe/email/test_email_body.py
+++ b/frappe/email/test_email_body.py
@@ -137,6 +137,39 @@ w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 		""".format(inline_images[0].get("content_id"))
 		self.assertEqual(message, processed_message)
 
+	def test_sendmail_inline_images_parameter_respected(self):
+		"""Test that inline_images parameter works through sendmail."""
+
+		test_image_content = b"FAKE_PNG_BINARY_CONTENT_FOR_TESTING"
+
+		html_content = '<div><img embed="files/nonexistent_test_image.png" alt="Logo"></div>'
+
+		inline_images = [
+			{
+				"filename": "files/nonexistent_test_image.png",
+				"filecontent": test_image_content,
+			}
+		]
+
+		# Use QueueBuilder directly (what sendmail uses internally)
+		from frappe.email.doctype.email_queue.email_queue import QueueBuilder
+
+		builder = QueueBuilder(
+			recipients=["test@example.com"],
+			sender="me@example.com",
+			subject="Test Inline Images",
+			message=html_content,
+			inline_images=inline_images,
+		)
+
+		# Get the email content that would be sent
+		mail = builder.prepare_email_content()
+		email_string = mail.as_string()
+
+		# Assertions
+		self.assertIn("cid:", email_string)
+		self.assertNotIn('embed="files/nonexistent_test_image.png"', email_string)
+
 	def test_inline_styling(self):
 		html = """
 <h3>Hi John</h3>

--- a/frappe/email/test_email_body.py
+++ b/frappe/email/test_email_body.py
@@ -138,7 +138,13 @@ w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 		self.assertEqual(message, processed_message)
 
 	def test_sendmail_inline_images_parameter_respected(self):
-		"""Test that inline_images parameter works through sendmail."""
+		"""
+		Test that inline_images parameter works through sendmail.
+		Earlier this was ignored and the image was read from disk instead of using the provided content.
+		The way to check this is essentially checking if the image is embedded with cid:
+		<img src="cid:content_id" ...> -> Correct behavior
+		If the image is not embedded with cid: -> Incorrect behavior
+		"""
 
 		test_image_content = b"FAKE_PNG_BINARY_CONTENT_FOR_TESTING"
 
@@ -151,7 +157,7 @@ w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 			}
 		]
 
-		# Use QueueBuilder directly (what sendmail uses internally)
+		# use QueueBuilder to send the email (sendmail uses this internally)
 		from frappe.email.doctype.email_queue.email_queue import QueueBuilder
 
 		builder = QueueBuilder(
@@ -162,11 +168,9 @@ w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 			inline_images=inline_images,
 		)
 
-		# Get the email content that would be sent
 		mail = builder.prepare_email_content()
 		email_string = mail.as_string()
 
-		# Assertions
 		self.assertIn("cid:", email_string)
 		self.assertNotIn('embed="files/nonexistent_test_image.png"', email_string)
 


### PR DESCRIPTION
### Problem

The `inline_images` parameter in `frappe.sendmail()` is accepted but never used. When sending emails with `<img embed="...">` tags, the code always reads image content from disk via `get_filecontent_from_path()` as correctly pointed out by @Bowrna in #37186 , ignoring any pre-loaded content passed through the `inline_images` parameter.

### Solution

Modified `replace_filename_with_cid()` to accept an optional `provided_images` dict and check it before falling back to disk reads. The `set_part_html()` method now builds this lookup from the `inline_images` parameter and passes it through.

**Changes:**
- `replace_filename_with_cid(message, provided_images=None)` - checks provided images first
- `set_part_html()` - builds lookup dict from `inline_images` parameter

Backward compatible: falls back to disk read if image not in `provided_images`.

### Testing

Added `test_inline_images_parameter_respected` which:
1. Passes image content via `inline_images` for a file that doesn't exist on disk
2. Verifies `cid:` reference is present in email output

**Before fix:** No `cid:` in output - indicating the image wasn't embedded because disk read failed and provided content was ignored.

<img width="1710" height="486" alt="CleanShot 2026-02-19 at 14 46 33@2x" src="https://github.com/user-attachments/assets/9c846c9a-620d-45e5-a464-10509a0c5c48" />


**After fix:** `cid:` present and provided image content embedded correctly.

<img width="1716" height="522" alt="CleanShot 2026-02-19 at 14 58 46@2x" src="https://github.com/user-attachments/assets/76e9f00f-c077-4ab2-b0ff-cc163283b3e3" />

Additional Notes - 
This is not related to #32586, that seems like a separate issue.
Resolves and Closes #37186 