### PR TITLE
fix: limit config should not be mandatory

### DIFF
--- a/frappe/core/doctype/user_type/user_type.py
+++ b/frappe/core/doctype/user_type/user_type.py
@@ -84,13 +84,14 @@ class UserType(Document):
 				title=_("Permission Error"),
 			)
 
-		if not limit:
-			frappe.throw(
+		if limit is None:
+			frappe.msgprint(
 				_("The limit has not set for the user type {0} in the site config file.").format(
 					frappe.bold(self.name)
 				),
 				title=_("Set Limit"),
 			)
+			return
 
 		if self.user_doctypes and len(self.user_doctypes) > limit:
 			frappe.throw(


### PR DESCRIPTION
Things should not fail when I didn't configure restrictions for **User Type**.

Currently, e.g. this patch fails when the site config does not have `user_type_doctype_limit` specified.

https://github.com/frappe/hrms/blob/1d75c3107919f1cf56848087d29399850871c080/hrms/patches/v15_0/add_leave_type_permission_for_ess.py


```
Executing hrms.patches.v15_0.add_leave_type_permission_for_ess in my-site (_f0e0b0a7809b99f3)

Queued rebuilding of search index for my-site

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 114, in <module>
    main()
  File "frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/env/lib/python3.11/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/apps/frappe/frappe/commands/site.py", line 694, in migrate
    ).run(site=site)
      ^^^^^^^^^^^^^^
  File "frappe-bench/apps/frappe/frappe/migrate.py", line 193, in run
    self.run_schema_updates()
  File "frappe-bench/apps/frappe/frappe/migrate.py", line 54, in wrapper
    raise e
  File "frappe-bench/apps/frappe/frappe/migrate.py", line 46, in wrapper
    ret = method(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/apps/frappe/frappe/migrate.py", line 124, in run_schema_updates
    frappe.modules.patch_handler.run_all(
  File "frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 76, in run_all
    run_patch(patch)
  File "frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 62, in run_patch
    if not run_single(patchmodule=patch):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 152, in run_single
    return execute_patch(patchmodule, method, methodargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 188, in execute_patch
    _patch()
  File "frappe-bench/apps/hrms/hrms/patches/v15_0/add_leave_type_permission_for_ess.py", line 18, in execute
    doc.save()
  File "frappe-bench/apps/frappe/frappe/model/document.py", line 378, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/apps/frappe/frappe/model/document.py", line 431, in _save
    self.run_post_save_methods()
  File "frappe-bench/apps/frappe/frappe/model/document.py", line 1177, in run_post_save_methods
    self.run_method("on_update")
  File "frappe-bench/apps/frappe/frappe/model/document.py", line 1011, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/apps/frappe/frappe/model/document.py", line 1371, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/apps/frappe/frappe/model/document.py", line 1353, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/apps/frappe/frappe/model/document.py", line 1008, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "frappe-bench/apps/frappe/frappe/core/doctype/user_type/user_type.py", line 50, in on_update
    self.validate_document_type_limit()
  File "frappe-bench/apps/frappe/frappe/core/doctype/user_type/user_type.py", line 87, in validate_document_type_limit
    frappe.throw(
  File "frappe-bench/apps/frappe/frappe/__init__.py", line 609, in throw
    msgprint(
  File "frappe-bench/apps/frappe/frappe/__init__.py", line 574, in msgprint
    _raise_exception()
  File "frappe-bench/apps/frappe/frappe/__init__.py", line 525, in _raise_exception
    raise exc
frappe.exceptions.ValidationError: The limit has not set for the user type Employee Self Service in the site config file.
```