### PR TITLE
feat: support redirect-to parameter in magic link login

### DIFF
--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -161,6 +161,30 @@ class TestAuth(IntegrationTestCase):
 		else:
 			self.fail("Rate limting not working")
 
+	def test_login_with_email_link_redirect(self):
+		"""Login via magic link should redirect to the given path."""
+		user = self.test_user_email
+		redirect_to = "/app/todo"
+
+		link = _generate_temporary_login_link(user, 10, redirect_to=redirect_to)
+		self.assertIn("redirect-to", link)
+
+		res = requests.get(link, allow_redirects=False)
+		self.assertEqual(res.status_code, 302)
+		self.assertTrue(res.headers.get("Location", "").endswith(redirect_to))
+		self.assertNotEqual(res.cookies.get("sid"), "Guest")
+
+	def test_login_with_email_link_ignores_external_redirect(self):
+		"""Login via magic link should not redirect to an external URL."""
+		user = self.test_user_email
+
+		link = _generate_temporary_login_link(user, 10, redirect_to="https://evil.com/steal")
+		res = requests.get(link, allow_redirects=False)
+		# Should still log in successfully but not redirect to the external URL
+		self.assertNotEqual(res.cookies.get("sid"), "Guest")
+		location = res.headers.get("Location", "")
+		self.assertNotIn("evil.com", location)
+
 	def test_correct_cookie_expiry_set(self):
 		client = FrappeClient(self.HOST_NAME, self.test_user_email, self.test_user_password)
 

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -136,7 +136,7 @@ class TestAuth(IntegrationTestCase):
 		with self.assertRaises(Exception):
 			FrappeClient(self.HOST_NAME, self.test_user_email, self.test_user_password).get_list("ToDo")
 
-	def test_login_with_email_link(self):
+	def test_login_with_email_link_with_rate_limiting(self):
 		user = self.test_user_email
 
 		# Logs in

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -166,6 +166,7 @@ class TestAuth(IntegrationTestCase):
 		user = self.test_user_email
 		redirect_to = "/app/todo"
 
+		frappe.local.request = Request(EnvironBuilder(base_url=self.HOST_NAME).get_environ())
 		link = _generate_temporary_login_link(user, 10, redirect_to=redirect_to)
 		self.assertIn("redirect-to", link)
 
@@ -178,6 +179,7 @@ class TestAuth(IntegrationTestCase):
 		"""Login via magic link should not redirect to an external URL."""
 		user = self.test_user_email
 
+		frappe.local.request = Request(EnvironBuilder(base_url=self.HOST_NAME).get_environ())
 		link = _generate_temporary_login_link(user, 10, redirect_to="https://evil.com/steal")
 		res = requests.get(link, allow_redirects=False)
 		# Should still log in successfully but not redirect to the external URL

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -163,3 +163,25 @@ def is_rtl(rtl=None):
 	if rtl is None:
 		return local.lang in ["ar", "he", "fa", "ps"]
 	return rtl
+
+
+def get_magic_link(email, redirect_to=None):
+	"""Generate a magic login link for the given email address.
+
+	Optionally accepts a redirect_to path so the user lands on a specific page
+	after authenticating via the magic link.
+
+	Usage in Jinja templates::
+
+	    {{ get_magic_link("user@example.com") }}
+	    {{ get_magic_link("user@example.com", "/app/todo") }}
+	"""
+	import frappe
+
+	if not frappe.get_system_settings("login_with_email_link"):
+		return ""
+
+	from frappe.www.login import _generate_temporary_login_link
+
+	expiry = frappe.get_system_settings("login_with_email_link_expiry") or 10
+	return _generate_temporary_login_link(email, expiry, redirect_to=redirect_to)

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -171,10 +171,9 @@ def get_magic_link(email, redirect_to=None):
 	Optionally accepts a redirect_to path so the user lands on a specific page
 	after authenticating via the magic link.
 
-	Usage in Jinja templates::
-
-	    {{ get_magic_link("user@example.com") }}
-	    {{ get_magic_link("user@example.com", "/app/todo") }}
+	Usage in Jinja templates:
+		{{get_magic_link("user@example.com")}}
+		{{get_magic_link("user@example.com", "/desk/todo")}}
 	"""
 	import frappe
 

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -164,7 +164,7 @@ def send_login_link(email: str):
 	)
 
 
-def _generate_temporary_login_link(email: str, expiry: int):
+def _generate_temporary_login_link(email: str, expiry: int, redirect_to: str | None = None):
 	assert isinstance(email, str)
 
 	if not frappe.db.exists("User", email):
@@ -172,7 +172,14 @@ def _generate_temporary_login_link(email: str, expiry: int):
 	key = frappe.generate_hash()
 	frappe.cache.set_value(f"one_time_login_key:{key}", email, expires_in_sec=expiry * 60)
 
-	return get_url(f"/api/method/frappe.www.login.login_via_key?key={key}")
+	link = get_url(f"/api/method/frappe.www.login.login_via_key?key={key}")
+
+	if redirect_to:
+		from urllib.parse import quote
+
+		link += f"&redirect-to={quote(redirect_to)}"
+
+	return link
 
 
 @frappe.whitelist(allow_guest=True, methods=["GET"])
@@ -184,6 +191,14 @@ def login_via_key(key: str):
 	if email:
 		frappe.cache.delete_value(cache_key)
 		frappe.local.login_manager.login_as(email)
+
+		redirect_to = frappe.form_dict.get("redirect-to")
+		if redirect_to:
+			redirect_to = sanitize_redirect(redirect_to)
+			if redirect_to:
+				frappe.local.response["type"] = "redirect"
+				frappe.local.response["location"] = redirect_to
+				return
 
 		redirect_post_login(
 			desk_user=frappe.db.get_value("User", frappe.session.user, "user_type") == "System User"

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -177,6 +177,7 @@ def _generate_temporary_login_link(email: str, expiry: int, redirect_to: str | N
 	if redirect_to:
 		from urllib.parse import quote
 
+		redirect_to = sanitize_redirect(redirect_to) or "/"
 		link += f"&redirect-to={quote(redirect_to)}"
 
 	return link


### PR DESCRIPTION
Add `get_magic_link` Jinja global for generating magic login links in email templates,

Summary
Adds a new Jinja global function `get_magic_link(email, redirect_to=None)` that allows generating magic (email-based) login links directly within Jinja templates.