### PR TITLE
fix(search): add Autocomplete field type to search filters

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -156,6 +156,7 @@ def search_widget(
 	# build from doctype
 	if txt:
 		field_types = {
+			"Autocomplete",
 			"Data",
 			"Text",
 			"Small Text",

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -173,7 +173,9 @@ def get_list(
 			or_filters.extend(
 				[doctype, f, "like", "%" + txt + "%"]
 				for f in meta.get_search_fields()
-				if f == "name" or meta.get_field(f).fieldtype in ("Data", "Text", "Small Text", "Text Editor")
+				if f == "name"
+				or meta.get_field(f).fieldtype
+				in ("Autocomplete", "Data", "Text", "Small Text", "Text Editor")
 			)
 		else:
 			if isinstance(filters, dict):


### PR DESCRIPTION
## Fix: Autocomplete field type not searchable when used in Search Fields

### Issue

Fixes #31903

When an **Autocomplete** field is added to a doctype's **Search Fields**, searching by that field in a Link field does not work. Users expect to search and find records by the Autocomplete field value, but no results are returned.

### Steps to Reproduce

1. Create a doctype with an Autocomplete field
2. Add that field to **Search Fields** in the doctype settings
3. Create another doctype with a Link field pointing to the first doctype
4. In the Link field, search using the Autocomplete field value
5. **Expected:** Matching records appear  
   **Actual:** No results (search only works for `name` and other supported field types)

### Root Cause

Before:
<img width="1285" height="468" alt="image" src="https://github.com/user-attachments/assets/08c24806-c9c2-4f5b-820f-f75a9215355a" />


After:
<img width="1291" height="531" alt="image" src="https://github.com/user-attachments/assets/c91e5211-87b1-4901-ba26-9e3fdf78c2e6" />

