### PR TITLE
fix(db_query): handle filters as strings or dictionaries in query prepartion

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -677,8 +677,14 @@ from {tables}
 		if ignore_permissions is not None:
 			self.flags.ignore_permissions = ignore_permissions
 
+		if isinstance(filters, dict):
+			filters = [filters]
+
 		for f in filters:
-			conditions.append(self.prepare_filter_condition(f))
+			if isinstance(f, str):
+				conditions.append(f)
+			else:
+				conditions.append(self.prepare_filter_condition(f))
 
 	def remove_field(self, idx: int):
 		if self.as_list:


### PR DESCRIPTION
Fixes #31866

We used to support two things in `build_filter_conditions`: (1) passing a raw SQL condition as a string and having it appended as-is, and (2) passing a single dict and having it turned into a one-item list. Both got dropped in the backports of [#31576](https://github.com/frappe/frappe/pull/31576).

The original PR only touched `frappe/utils/data.py`. When it was backported in [#31580](https://github.com/frappe/frappe/pull/31580) (commit `996c85240`) and [#31579](https://github.com/frappe/frappe/pull/31579) (commit `ddea0b5b5`), the backport commits said things like "revert str filters" and "These are not used anywhere", so the string/dict handling in `build_filter_conditions` was removed to simplify the backport. Turns out people do use it when they mix normal filters with a raw SQL condition (e.g. "my ToDos modified in last 7 days"), so this PR brings that behaviour back.

**What changed:** In `frappe/model/db_query.py`, we again normalise a single dict to a list, and when a filter item is a string we append it to `conditions` instead of calling `prepare_filter_condition()` on it (which expects a dict-like structure and breaks on a string).

**Quick check in console:**

```python
import frappe
from frappe.types import Filters
from frappe.model.db_query import DatabaseQuery

filters = list(Filters([["owner", "=", frappe.session.user]], doctype="ToDo"))
filters.append("`tabToDo`.`modified` > DATE_SUB(NOW(), INTERVAL 7 DAY)")

query = DatabaseQuery("ToDo")
conditions = []
query.build_filter_conditions(filters, conditions, ignore_permissions=True)

where = " and ".join(conditions)
result = frappe.db.sql("select name, modified from `tabToDo` where " + where + " limit 5", as_dict=1)
print(len(result), "rows")
for r in result:
    print(r)
```

**Before this fix:** This blows up inside `build_filter_conditions` (e.g. `AttributeError: 'str' object has no attribute 'doctype'`) because the string gets passed to `prepare_filter_condition`.

**After this fix:** It runs fine. You get the owner condition plus the raw date condition, and the query returns rows.