### PR TITLE
fix: re-initialize awesomebar after exiting edit layout

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -246,6 +246,7 @@ class DesktopPage {
 	make() {
 		this.page.page_head.hide();
 		$(this.page.body).empty();
+		this.awesomebar_setup = false;
 		$(frappe.render_template("desktop")).appendTo(this.page.body);
 		if (this.data !== undefined) {
 			this.render();


### PR DESCRIPTION
Fixes the bug where the awesomebar (search bar) stops working after saving or cancelling "Edit Layout" on the desktop.
when Edit Layout was being used, the "this.awesomebar_setup" flag wasn't being set to false which is why setup_awesomebar() function was returning early.
The fix ensures the search bar is properly re-initialized when the page re-renders.

Before:

https://github.com/user-attachments/assets/25361c23-1270-4679-bc10-c11faa1d9820

After:

https://github.com/user-attachments/assets/84af15c7-383b-476b-b2f4-78e913481d1b

