### PR TITLE
perf: avoid layout thrashing in grid `setup_toolbar`

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -593,8 +593,9 @@ export default class Grid {
 	}
 
 	setup_toolbar() {
-		if (this.is_editable()) {
-			this.wrapper.find(".grid-footer").toggle(true);
+		const is_editable = this.is_editable();
+		if (is_editable) {
+			this.wrapper.find(".grid-footer").removeClass("hidden");
 
 			const num_selected_rows = this.get_selected_children().length;
 			// show, hide buttons to add rows
@@ -619,12 +620,12 @@ export default class Grid {
 			this.grid_rows.length < this.grid_pagination.page_length &&
 			!this.df.allow_bulk_edit
 		) {
-			this.wrapper.find(".grid-footer").toggle(false);
+			this.wrapper.find(".grid-footer").addClass("hidden");
 		}
 
 		this.wrapper
 			.find(".grid-add-row, .grid-add-multiple-rows, .grid-upload")
-			.toggle(this.is_editable());
+			.toggleClass("hidden", !is_editable);
 	}
 
 	truncate_rows() {


### PR DESCRIPTION
## Problem

`setup_toolbar()` uses jQuery's `.toggle(bool)` to show/hide the grid footer and toolbar buttons. `.toggle()` internally calls `isHiddenWithinTree()` → `curCSS()`, which **reads computed styles and forces the browser to recalculate layout** before it can answer.

This runs on every `grid.refresh()` cycle. On forms with child tables, each refresh forces a style recalc on 800–2000 elements, taking ~7ms per call.

## Fix

Replace `.toggle(bool)` with class-based visibility:
- `.toggle(true)` → `.removeClass("hidden")`
- `.toggle(false)` → `.addClass("hidden")`
- `.toggle(this.is_editable())` → `.toggleClass("hidden", !is_editable)`

Class mutations don't read computed styles, so no forced layout.