### PR TITLE
perf: scope grid container selector to grid wrapper

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -777,9 +777,7 @@ export default class GridRow {
 			}
 		});
 
-		let current_grid = $(
-			`div[data-fieldname="${this.grid.df.fieldname}"] .form-grid-container`
-		);
+		let current_grid = this.grid.wrapper.find(".form-grid-container");
 		if (total_colsize > 10) {
 			current_grid.addClass("column-limit-reached");
 		} else if (current_grid.hasClass("column-limit-reached")) {


### PR DESCRIPTION
## Problem

In `GridRow.setup_columns()`, the grid container element is found using a global attribute selector:

```js
$(`div[data-fieldname="${this.grid.df.fieldname}"] .form-grid-container`)
```

This scans the entire DOM tree on every `setup_columns()` call — which runs per row, per refresh.

## Fix

Use the already-available `this.grid.wrapper` to scope the lookup:

```js
this.grid.wrapper.find(".form-grid-container")
```

Functionally identical, avoids a full-DOM scan.