### PR TITLE
fix: migrate child row `docfield_copy` on rename in `update_in_locals`

### DIFF
--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -157,14 +157,21 @@ Object.assign(frappe.model, {
 
 						// if incoming row is not registered, register it
 						if (!locals[updated_child_doc.doctype][updated_child_doc.name]) {
+							const old_name = local_child_doc_in_parent.name;
+
 							// detach old key
-							delete locals[updated_child_doc.doctype][
-								local_child_doc_in_parent.name
-							];
+							delete locals[updated_child_doc.doctype][old_name];
 
 							// re-attach with new name
 							locals[updated_child_doc.doctype][updated_child_doc.name] =
 								local_child_doc_in_parent;
+
+							// migrate per-row docfield overrides to new name
+							const dc = frappe.meta.docfield_copy[updated_child_doc.doctype];
+							if (dc?.[old_name]) {
+								dc[updated_child_doc.name] = dc[old_name];
+								delete dc[old_name];
+							}
 						}
 
 						// row exists, just copy the values


### PR DESCRIPTION
## Problem

When a child row is re-keyed in `update_in_locals` (local name → server-assigned name), only the `locals` entry is migrated. The corresponding `frappe.meta.docfield_copy` entry stays under the old local name.

Any per-row field overrides — `hidden`, `reqd`, `read_only` from `depends_on` evaluation, formatters set via `grid.update_docfield_property()`, or direct `frappe.meta.get_docfield()` mutations in client scripts — are lost on the next lookup using the new name, which lazily creates a fresh copy from base definitions.

## Fix

Migrate `docfield_copy[doctype][old_name]` → `docfield_copy[doctype][new_name]` alongside the `locals` re-keying.

This is the child-table equivalent of what `rename_notify` in `form.js` already does for parent docs.