### PR TITLE
fix: prevent child row identity corruption on sync after reorder

### DIFF
--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -127,6 +127,7 @@ Object.assign(frappe.model, {
 				}
 
 				// child table, override each row and append new rows if required
+				const incoming_names = new Set(updated_doc[fieldname].map((d) => d.name));
 				for (let i = 0; i < updated_doc[fieldname].length; i++) {
 					let updated_child_doc = updated_doc[fieldname][i];
 					let local_child_doc_in_parent = local_parent_doc[fieldname][i];
@@ -143,8 +144,12 @@ Object.assign(frappe.model, {
 						}
 						continue;
 					}
-					if (local_child_doc_in_parent) {
-						// deleted and added again
+					if (
+						local_child_doc_in_parent &&
+						!incoming_names.has(local_child_doc_in_parent.name)
+					) {
+						// row at this position is truly deleted/replaced — safe to
+						// reuse the object for the incoming row
 						if (!locals[updated_child_doc.doctype])
 							locals[updated_child_doc.doctype] = {};
 
@@ -178,7 +183,9 @@ Object.assign(frappe.model, {
 						Object.assign(local_child_doc_in_parent, updated_child_doc);
 						clear_keys(updated_child_doc, local_child_doc_in_parent);
 					} else {
-						local_parent_doc[fieldname].push(updated_child_doc);
+						// row at this position is needed at a different index
+						// (or no row here) — create a fresh local entry
+						local_parent_doc[fieldname][i] = updated_child_doc;
 						if (!updated_child_doc.parent) updated_child_doc.parent = updated_doc.name;
 						frappe.model.add_to_locals(updated_child_doc);
 					}


### PR DESCRIPTION
## Problem

When the backend modifies a child table (reorder, delete+insert), `update_in_locals` can corrupt object identity.

The second branch (`if (local_child_doc_in_parent)`) assumes the doc at position `i` is "deleted and added again" — it re-keys the local object and overwrites it with incoming data. But if the backend reordered rows, that doc may still be present at a different index in the incoming data.

Example — local: `[A(a), B(b), C(c)]`, server returns: `[D(d), B(b), A(a)]`:

1. i=0: D not in locals. `parent[0]=A`. Branch assumes A is deleted → re-keys A from "a" to "d", overwrites with D's data. **`locals["a"]` is gone.**
2. i=2: incoming A(a). `locals["a"]` is null (destroyed at i=0) → creates fresh object instead of reusing A.

A's original object now holds D's data. Any references to the old A object (grid rows, event handlers) point to wrong data.

## Fix

Build `incoming_names` — a Set of all names the server sent for the child table. Before re-keying a local doc, check `!incoming_names.has(local_child_doc_in_parent.name)`. If the doc at position `i` is expected at another index, skip the reuse branch and create a fresh local entry. The existing doc will be matched by name when its correct index is processed.

Also fixes the else branch: `push()` → direct index assignment (`parent[i] = ...`), since we're iterating by index and the array may already have entries at that position.