### PR TITLE
fix: remove bold font weight from h3 and h4 for consistent header styles

### DIFF
--- a/frappe/public/css/bootstrap.css
+++ b/frappe/public/css/bootstrap.css
@@ -5760,10 +5760,6 @@ body {
 .list-group-item {
   padding: 8px 15px;
 }
-h3,
-h4 {
-  font-weight: bold;
-}
 ul.with-margin li,
 ol.with-margin li {
   margin: 7px auto;


### PR DESCRIPTION
fixes #35447

Before:
<img width="801" height="257" alt="Screenshot 2026-02-20 at 7 53 26 AM" src="https://github.com/user-attachments/assets/eaa607c9-4d28-4efa-ac46-896cd58b41ad" />

After:
<img width="799" height="259" alt="Screenshot 2026-02-20 at 7 54 08 AM" src="https://github.com/user-attachments/assets/19e7390d-af3b-4db4-b512-5051f71275f5" />
