### PR TITLE
fix: prevent translation of icon class names for workflow states in select options

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -329,6 +329,9 @@ def get_messages_from_doctype(name):
 
 		if d.fieldtype == "Select" and d.options:
 			options = d.options.split("\n")
+			# for workflow state, we don't want to translate the icon(css classnames)
+			if d.fieldname == "icon" and name == "Workflow State":
+				continue
 			if "icon" not in options[0]:
 				messages.extend(options)
 		if d.fieldtype == "HTML" and d.options:


### PR DESCRIPTION
Resolves and closes #28969 

#### Problem

Workflow State is a translated doctype. Its Icon field is a Select whose options are CSS/icon class names (e.g. glass, music, star, star-empty, search), not user-facing text. They were still being extracted as translatable because the existing check used "icon" not in options[0] (first option value); for this field options starts with a newline so options[0] is "" and the condition always passed.

#### Solution

Skip adding Select options to translatable messages when the doctype is Workflow State and the field is icon, so these class names are no longer included in translation files.

Ran - `bench get-untranslated --app frappe ar ./ar-1.text` before and after the change to check that these classes are not translated after he change.

#### Screenshots

##### Before
<img width="1978" height="676" alt="CleanShot 2026-02-20 at 12 59 15@2x" src="https://github.com/user-attachments/assets/c1715306-337c-442e-9510-7619ef8347b6" />

##### After
<img width="1966" height="812" alt="CleanShot 2026-02-20 at 12 59 51@2x" src="https://github.com/user-attachments/assets/cd9611d1-c14d-4be6-87e2-071fc108afee" />