### PR TITLE
fix(input): has-error class respects both invalid and mandatory together

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -277,7 +277,9 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		// set has-error if dialog primary button is clicked
 		if (this.layout && this.layout.is_dialog && !this.layout.primary_action_fulfilled) return;
 
-		this.$wrapper.toggleClass("has-error", Boolean(this.df.reqd && is_null(value)));
+		const is_invalid = this.$wrapper.hasClass("has-error-invalid");
+		this.$wrapper.toggleClass("has-error-mandatory", Boolean(this.df.reqd && is_null(value)));
+		this.$wrapper.toggleClass("has-error", is_invalid || Boolean(this.df.reqd && is_null(value)));
 	}
 	set_invalid() {
 		let invalid = !!this.df.invalid;
@@ -286,7 +288,9 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 			this.$input?.toggleClass("invalid", invalid);
 			this.grid_row.columns[this.df.fieldname].is_invalid = invalid;
 		} else {
-			this.$wrapper.toggleClass("has-error", invalid);
+			const is_mandatory_and_empty = this.$wrapper.hasClass("has-error-mandatory");
+			this.$wrapper.toggleClass("has-error-invalid", invalid);
+			this.$wrapper.toggleClass("has-error", is_mandatory_and_empty || invalid);
 		}
 	}
 	set_required() {

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -279,7 +279,10 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 
 		const is_invalid = this.$wrapper.hasClass("has-error-invalid");
 		this.$wrapper.toggleClass("has-error-mandatory", Boolean(this.df.reqd && is_null(value)));
-		this.$wrapper.toggleClass("has-error", is_invalid || Boolean(this.df.reqd && is_null(value)));
+		this.$wrapper.toggleClass(
+			"has-error",
+			is_invalid || Boolean(this.df.reqd && is_null(value))
+		);
 	}
 	set_invalid() {
 		let invalid = !!this.df.invalid;


### PR DESCRIPTION
[previously](https://github.com/frappe/frappe/issues/35789#issuecomment-3843158717) set_invalid would remove `has-error` class which was set by set_mandatory if the field had no invalid input.

fixes #35789

after:

https://github.com/user-attachments/assets/17d2c21a-9eb8-4216-b45a-b049cb2e7d26

