### PR TITLE
fix: skip sending mail if account does not exist

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1459,7 +1459,8 @@ def impersonate(user: str, reason: str):
 	notification.set("type", "Alert")
 	notification.insert(ignore_permissions=True)
 	# notify user via email too
-	if not frappe.conf.get("developer_mode"):  # bypass for testing locally
+	email_exists = frappe.db.exists("Email Account", {"default_outgoing": 1, "awaiting_password": 0})
+	if email_exists:
 		user_email = frappe.db.get_value("User", user, "email")
 		email_message = _(
 			"User {0} has started an impersonation session as you. <br><br><b>Reason provided:</b> {1}"

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1459,8 +1459,8 @@ def impersonate(user: str, reason: str):
 	notification.set("type", "Alert")
 	notification.insert(ignore_permissions=True)
 	# notify user via email too
-	email_exists = frappe.db.exists("Email Account", {"default_outgoing": 1, "awaiting_password": 0})
-	if email_exists:
+	outgoing_email_exists = frappe.db.exists("Email Account", {"default_outgoing": 1, "awaiting_password": 0})
+	if outgoing_email_exists:
 		user_email = frappe.db.get_value("User", user, "email")
 		email_message = _(
 			"User {0} has started an impersonation session as you. <br><br><b>Reason provided:</b> {1}"

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -369,14 +369,15 @@ class TestEmail(IntegrationTestCase):
 			patch("frappe.sendmail") as mocked_sendmail,
 			patch("frappe.local.login_manager", create=True) as mocked_lm,
 		):
-			reason = "Testing Security Alert"
-			impersonate(user=target_user, reason=reason)
+			with patch("frappe.db.exists", return_value=True):
+				reason = "Testing Security Alert"
+				impersonate(user=target_user, reason=reason)
 
-			self.assertTrue(mocked_sendmail.called)
-			_, kwargs = mocked_sendmail.call_args
-			self.assertIn(target_user, kwargs.get("recipients"))
-			self.assertIn(reason, kwargs.get("content"))
-			mocked_lm.impersonate.assert_called_with(target_user)
+				self.assertTrue(mocked_sendmail.called)
+				_, kwargs = mocked_sendmail.call_args
+				self.assertIn(target_user, kwargs.get("recipients"))
+				self.assertIn(reason, kwargs.get("content"))
+				mocked_lm.impersonate.assert_called_with(target_user)
 
 		# Cleanup
 		frappe.db.delete("User", {"email": target_user})


### PR DESCRIPTION
**fix:** Skip sending mail if an account is not configured. Skips the whole mess where you have to configure an email to impersonate.