### PR TITLE
fix(Notification): receiver by role option silently fails on Administrator role 

### DIFF
--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -89,6 +89,10 @@ class Role(Document):
 
 def get_info_based_on_role(role, field="email", ignore_permissions=False):
 	"""Get information of all users that have been assigned this role"""
+	if role == "Administrator":
+		user = frappe.db.get_value("User", "Administrator", field)
+		return [user] if user else []
+
 	users = frappe.get_list(
 		"Has Role",
 		filters={"role": role, "parenttype": "User"},

--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -89,6 +89,8 @@ class Role(Document):
 
 def get_info_based_on_role(role, field="email", ignore_permissions=False):
 	"""Get information of all users that have been assigned this role"""
+	# Administrator is a superuser account, not a typical role with assigned users
+	# so we resolve it directly to the Administrator user
 	if role == "Administrator":
 		user = frappe.db.get_value("User", "Administrator", field)
 		return [user] if user else []


### PR DESCRIPTION
#### Bug
When **Administrator** was selected as **Receiver By Role** in the Notification Recipient child table while setting up a new Notification document, notifications were silently skipped for the Administrator role (system notifications, email and using mobile number). Not sure if there are other ways but this left users with the option to configure such notifications only using `hooks.py` and not from the UI using the Notification DocType.

#### Fix
- This happened because the recipients are resolved using the `get_info_based_on_role` utility which checks for all users in the `Has Role` that have the queried role. Since Administrator is a special role and no user document has the Administrator role assigned, this query always returns an empty list for Administrator, causing silent failure with no error or no warning. 
- Administrator appears as a selectable option in the link field for Receiver By Role in the child table so resolve it separately unlike other roles that use the Has Role table.

Closes #21505