### PR TITLE
fix: notification panel shadow

### DIFF
--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -60,7 +60,7 @@
 	min-height: 480px;
 	position: absolute;
 	top: 0;
-	box-shadow: var(--shadow-2xl);
+	box-shadow: rgba(0, 0, 0, 0.1) 8px 0px 8px;
 	background-color: var(--bg-color);
 	height: 100vh;
 	overflow: hidden;


### PR DESCRIPTION
After
<img width="1102" height="788" alt="Screenshot 2026-02-23 at 2 19 25 PM" src="https://github.com/user-attachments/assets/72f5c7b1-6825-4538-b8db-d8c2eef38879" />
