### PR TITLE
fix: skip `_validate_update_after_submit()` for virtual fields

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1324,7 +1324,7 @@ class BaseDocument:
 			df = self.meta.get_field(key)
 			db_value = db_values.get(key)
 
-			if df and not df.allow_on_submit and (self.get(key) or db_value):
+			if df and not df.allow_on_submit and not df.is_virtual and (self.get(key) or db_value):
 				if df.fieldtype in table_fields:
 					# just check if the table size has changed
 					# individual fields will be checked in the loop for children


### PR DESCRIPTION
## Description

Fixes validation error when updating submitted documents with virtual fields.

## Problem

`_validate_update_after_submit()` also validates virtual fields which is not expected since virtual fields are designed to be updated dynamically and do not exist in db. The validation will always fail.

## Solution

Skip virtual fields and missing keys in the validation check. Virtual fields are computed at runtime and don't require update-after-submit validation.
