### PR TITLE
fix: redirect to login if user is logged out

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -145,7 +145,14 @@ frappe.request.call = function (opts) {
 			opts.error_callback && opts.error_callback();
 		},
 		403: function (xhr) {
-			if (frappe.session.user === "Guest" && frappe.session.logged_in_user !== "Guest") {
+			const user_id = document.cookie
+				.split(";")
+				.find((c) => c.trim().startsWith("user_id="))
+				?.split("=")[1];
+			if (
+				user_id === "Guest" ||
+				(frappe.session.user === "Guest" && frappe.session.logged_in_user !== "Guest")
+			) {
 				// session expired
 				frappe.app.handle_session_expired();
 			} else if (xhr.responseJSON && xhr.responseJSON._error_message) {


### PR DESCRIPTION
Closes #35091

Checks document cookie to see if user is logged out when a 403 occurs; if so redirect them to `/login`.