### PR TITLE
fix: use `JSON.parse()` for filter processing

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -76,6 +76,18 @@ class Workspace(Document):
 
 		if self.public and not is_workspace_manager() and not disable_saving_as_public():
 			frappe.throw(_("You need to be Workspace Manager to edit this document"))
+
+		if (
+			not self.public
+			and self.for_user
+			and self.for_user != frappe.session.user
+			and not is_workspace_manager()
+		):
+			frappe.throw(
+				_("You are not allowed to edit this workspace"),
+				frappe.PermissionError,
+			)
+
 		if self.has_value_changed("title"):
 			validate_route_conflict(self.doctype, self.title)
 		else:

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1909,7 +1909,13 @@ Object.assign(frappe.utils, {
 
 	process_filter_expression(filter) {
 		let filters = [];
-		filters = filter ? new Function(`return ${filter}`)() : [];
+		if (filter) {
+			try {
+				filters = JSON.parse(filter);
+			} catch {
+				console.warn("Invalid JSON in filter expression", filter);
+			}
+		}
 		return this.cleanup_filters(filters);
 	},
 	cleanup_filters(filters) {


### PR DESCRIPTION
Reference: support ticket 60178

<hr>

Thanks to Sho Odagiri, GMO Cybersecurity by Ierae, Inc. for reporting this issue.