### PR TITLE
fix(Web Form): incorrect child link field comparison and failing UI tests

### DIFF
--- a/cypress/integration/web_form.js
+++ b/cypress/integration/web_form.js
@@ -72,10 +72,8 @@ context("Web Form", () => {
 
 		cy.call("logout");
 
-		cy.visit("/note");
-		cy.get_open_dialog()
-			.get(".modal-message")
-			.contains("You are not permitted to access this page without login.");
+		cy.visit("/note", { failOnStatusCode: false });
+		cy.contains("You must be logged in to use this form.");
 	});
 
 	it("Show List", () => {

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -126,8 +126,8 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 					.attr("href", dataurl || this.value);
 			}
 		} else {
-			this.$input.toggle(true);
-			this.$value.toggle(false);
+			this.$input?.toggle(true);
+			this.$value?.toggle(false);
 		}
 	}
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -839,9 +839,17 @@ def has_link_option(fields, doctype):
 	for f in fields:
 		if f.options == doctype:
 			return True
-		if hasattr(f, "fields") and isinstance(f.fields, list):
-			if has_link_option(f.fields, doctype):
-				return True
+		if f.fieldtype == "Table" and f.options:
+			child_doctype = f.options
+			if not isinstance(child_doctype, str) or not child_doctype.strip():
+				continue
+			try:
+				child_table_fields = frappe.get_meta(child_doctype).fields
+			except Exception:
+				continue
+			for child_field in child_table_fields:
+				if getattr(child_field, "options", None) == doctype:
+					return True
 	return False
 
 


### PR DESCRIPTION
- Correct the way Child Table DocTypes are checked while calling `get_link_options` in web forms that have links in child table.
- Fixed failing Web Form UI Tests.