### PR TITLE
fix(dynamic_link): resolve translated option values using control's get_input_value

### DIFF
--- a/frappe/public/js/frappe/form/controls/dynamic_link.js
+++ b/frappe/public/js/frappe/form/controls/dynamic_link.js
@@ -13,11 +13,19 @@ frappe.ui.form.ControlDynamicLink = class ControlDynamicLink extends frappe.ui.f
 				// for list page
 				input = cur_list.filter_area.standard_filters_wrapper.find(selector);
 			}
-			if (cur_page) {
+			if (cur_page && !input) {
 				input = $(cur_page.page).find(selector);
 			}
 			if (input) {
-				options = input.val();
+				// Use the control instance's get_input_value() to resolve
+				// translated display text back to the actual value via title_value_map
+				let control = cur_list?.page?.fields_dict?.[this.df.options]
+					|| cur_page?.page?.fields_dict?.[this.df.options];
+				if (control && typeof control.get_input_value === "function") {
+					options = control.get_input_value();
+				} else {
+					options = input.val();
+				}
 			}
 		} else {
 			options = frappe.model.get_value(this.df.parent, this.docname, this.df.options);


### PR DESCRIPTION
When a Dynamic Link field reads its options from a sibling Link field (e.g., on list pages), it uses input.val() to get the raw DOM value. If the Link field displays a translated DocType name (e.g., Customer in Urdu, or Arabic), input.val() returns this translated text instead of the actual DocType name.

This causes a 403 FORBIDDEN error because the translated text is sent to search_link/validate_link APIs as the doctype parameter, which is not a valid DocType.

The Link control already has get_input_value() which resolves translated display text back to the actual value via its title_value_map. This fix uses the control instance's get_input_value() instead of reading input.val() directly from the DOM.

Also fixes a minor issue where cur_page lookup could override a valid input already found via cur_list.