### PR TITLE
feat(email_queue): log suspend/resume actions in activity log

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -514,7 +514,18 @@ def send_now(name: str | int, force_send: bool = False):
 @frappe.whitelist()
 def toggle_sending(enable: bool | int | str):
 	frappe.only_for("System Manager")
-	frappe.db.set_default("suspend_email_queue", 0 if sbool(enable) else 1)
+	suspend_value = 0 if sbool(enable) else 1
+	frappe.db.set_default("suspend_email_queue", suspend_value)
+
+	action = "Resumed" if suspend_value == 0 else "Suspended"
+	frappe.get_doc(
+		{
+			"doctype": "Activity Log",
+			"user": frappe.session.user,
+			"status": "Success",
+			"subject": f"Email Queue sending {action.lower()}",
+		}
+	).insert(ignore_permissions=True, ignore_links=True)
 
 
 def on_doctype_update():


### PR DESCRIPTION
Reference: support ticket 60890
<hr>
<img width="995" height="208" alt="image" src="https://github.com/user-attachments/assets/5d667c83-abfb-4e83-b084-391ee2162444" />
<img width="1660" height="623" alt="image" src="https://github.com/user-attachments/assets/4b921436-df58-443e-8d15-335e43a002f2" />
