### PR TITLE
fix: skip get_number_format during `parse` for `ControlRating`

### DIFF
--- a/frappe/public/js/frappe/form/controls/float.js
+++ b/frappe/public/js/frappe/form/controls/float.js
@@ -17,10 +17,14 @@ frappe.ui.form.ControlFloat = class ControlFloat extends frappe.ui.form.ControlI
 	}
 
 	get_number_format() {
-		if (this.df.fieldtype === "Rating" || (this.df.fieldtype === "Float" && !this.df.options?.trim())) return;
-
-		const currency = frappe.meta.get_field_currency(this.df, this.get_doc());
-		return get_number_format(currency);
+		if (
+			this.df.fieldtype === "Rating" ||
+			(this.df.fieldtype === "Float" && !this.df.options?.trim())
+		)
+			return;
+ 
+ 		const currency = frappe.meta.get_field_currency(this.df, this.get_doc());
+ 		return get_number_format(currency);
 	}
 
 	get_precision() {

--- a/frappe/public/js/frappe/form/controls/float.js
+++ b/frappe/public/js/frappe/form/controls/float.js
@@ -22,9 +22,9 @@ frappe.ui.form.ControlFloat = class ControlFloat extends frappe.ui.form.ControlI
 			(this.df.fieldtype === "Float" && !this.df.options?.trim())
 		)
 			return;
- 
- 		const currency = frappe.meta.get_field_currency(this.df, this.get_doc());
- 		return get_number_format(currency);
+
+		const currency = frappe.meta.get_field_currency(this.df, this.get_doc());
+		return get_number_format(currency);
 	}
 
 	get_precision() {

--- a/frappe/public/js/frappe/form/controls/float.js
+++ b/frappe/public/js/frappe/form/controls/float.js
@@ -17,7 +17,7 @@ frappe.ui.form.ControlFloat = class ControlFloat extends frappe.ui.form.ControlI
 	}
 
 	get_number_format() {
-		if (this.df.fieldtype === "Float" && !this.df.options?.trim()) return;
+		if (this.df.fieldtype === "Rating" || (this.df.fieldtype === "Float" && !this.df.options?.trim())) return;
 
 		const currency = frappe.meta.get_field_currency(this.df, this.get_doc());
 		return get_number_format(currency);


### PR DESCRIPTION
CI tests failed as Rating fields have no currency associated with them and after #36859 parsing value checks for number_format which is associated with a currency.