### PR TITLE
fix: apply min-height only on first child

### DIFF
--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -189,9 +189,9 @@ body[data-route^="Form"] {
 
 	.frappe-list,
 	.report-wrapper {
-		.result,
+		.result:first-child,
 		.no-result,
-		.freeze {
+		.freeze:first-child {
 			min-height: 200px;
 		}
 	}


### PR DESCRIPTION
Else it leads to this because of the same class name `result`
<img width="1911" height="600" alt="image" src="https://github.com/user-attachments/assets/56cacec2-3476-4836-8294-e9433510a2ff" />
