### PR TITLE
fix(ux): add escape key handling to prevent closing dialog with awesomplete dropdown

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -128,6 +128,14 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				) {
 					$input.blur();
 				}
+			})
+			.on("keydown", function (e) {
+				if (e.key === "Escape" || e.keyCode === 27) {
+					// when dialog is open and contains an awesomplete dropdown - do not close the dialog on escape key press
+					if (me.display && me.$wrapper.find(".awesomplete").length) {
+						e.stopImmediatePropagation();
+					}
+				}
 			});
 	}
 


### PR DESCRIPTION
It retains focus in the combobox but closes the expanded list, just like it was asked in #23391
Closes #23391.

### Video

Note that I pressed Esc key to close the combobox.

https://github.com/user-attachments/assets/d7c6147c-6861-41ec-a774-c7e272da3ef5

