### PR TITLE
feat: init playwright tests

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -1,0 +1,80 @@
+name: Playwright
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+concurrency:
+  group: playwright-${{ github.event_name }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      NODE_ENV: production
+      DB_ROOT_PASSWORD: db_root
+
+    services:
+      mariadb:
+        image: mariadb:11.8
+        ports:
+          - 3306:3306
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3
+        env:
+          MARIADB_ROOT_PASSWORD: db_root
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup
+        name: Environment Setup
+        with:
+          build-assets: true
+          db-root-password: ${{ env.DB_ROOT_PASSWORD }}
+
+      - name: Install Playwright
+        run: |
+          cd ${GITHUB_WORKSPACE}/apps/${{ github.event.repository.name }}
+          yarn add @playwright/test --no-lockfile
+          npx playwright install chromium --with-deps
+
+      - name: Site Setup
+        run: |
+          source ${GITHUB_WORKSPACE}/env/bin/activate
+          bench --site test_site execute frappe.utils.install.complete_setup_wizard
+          bench --site test_site execute frappe.tests.ui_test_helpers.create_test_user
+
+      - name: Run Playwright Tests
+        id: tests
+        run: |
+          source ${GITHUB_WORKSPACE}/env/bin/activate
+          bench --site test_site run-ui-tests ${{ github.event.repository.name }} --playwright --headless
+
+      - name: Upload Playwright Report
+        uses: actions/upload-artifact@v6
+        if: ${{ always() && steps.tests.outcome != 'skipped' }}
+        with:
+          name: playwright-report
+          path: ./apps/${{ github.event.repository.name }}/playwright-report/
+          retention-days: 30
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v6
+        if: ${{ failure() && steps.tests.outcome == 'failure' }}
+        with:
+          name: playwright-test-results
+          path: ./apps/${{ github.event.repository.name }}/test-results/
+          retention-days: 30
+
+      - name: Show bench output
+        if: ${{ always() }}
+        run: cat bench_start.log || true

--- a/.gitignore
+++ b/.gitignore
@@ -198,5 +198,5 @@ cypress/videos
 .helix/
 # Aider AI Chat
 .aider*
-playwright.config.js
-test-results/*
+test-results/
+playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,5 @@ cypress/videos
 .helix/
 # Aider AI Chat
 .aider*
+playwright.config.js
+test-results/*

--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -439,6 +439,7 @@ def run_parallel_tests(
 @click.option("--browser", default="chrome", help="Browser to run tests in")
 @click.option("--spec", help="Spec file to run")
 @click.option("--ci-build-id")
+@click.option("--playwright", is_flag=True, help="Use Playwright instead of Cypress")
 @pass_context
 def run_ui_tests(
 	context: CliCtxObj,
@@ -450,6 +451,7 @@ def run_ui_tests(
 	ci_build_id=None,
 	cypressargs=None,
 	spec=None,
+	playwright=False,
 ):
 	"Run UI tests"
 	site = get_site(context)
@@ -457,6 +459,17 @@ def run_ui_tests(
 	app_base_path = frappe.get_app_source_path(app)
 	site_url = frappe.utils.get_site_url(site)
 	admin_password = frappe.get_conf().admin_password
+
+	if playwright:
+		_run_playwright_tests(
+			app_base_path=app_base_path,
+			site_url=site_url,
+			admin_password=admin_password,
+			headless=headless,
+			browser=browser,
+			spec=spec,
+		)
+		return
 
 	# override baseUrl using env variable
 	site_env = f"CYPRESS_baseUrl={site_url}"
@@ -532,6 +545,61 @@ def run_ui_tests(
 		frappe.commands.popen(formatted_command, cwd=app_base_path, raise_err=True)
 	except subprocess.CalledProcessError as e:
 		click.secho("Cypress tests failed", fg="red")
+		raise click.exceptions.Exit(1) from e
+
+
+def _run_playwright_tests(app_base_path, site_url, admin_password, headless, browser, spec):
+	"""Run Playwright-based UI tests."""
+	frappe_path = frappe.get_app_source_path("frappe")
+	node_bin = subprocess.run(
+		"(cd ../frappe && yarn bin)",
+		shell=True,
+		stdout=subprocess.PIPE,
+		stderr=subprocess.DEVNULL,
+		text=True,
+		cwd=app_base_path,
+	).stdout.strip()
+	playwright_path = f"{node_bin}/playwright"
+
+	# Install @playwright/test if not present
+	if not os.path.exists(playwright_path):
+		click.secho("Installing Playwright...", fg="yellow")
+		package_json_path = os.path.join(frappe_path, "package.json")
+		with open(package_json_path) as f:
+			package_json_contents = f.read()
+
+		frappe.commands.popen("(cd ../frappe && yarn add @playwright/test --no-lockfile)")
+
+		with open(package_json_path, "w") as f:
+			f.write(package_json_contents)
+
+		# Install browser binaries
+		click.secho("Installing Playwright browsers...", fg="yellow")
+		frappe.commands.popen(f"{playwright_path} install chromium")
+
+	# Build environment variables
+	env = {"PLAYWRIGHT_baseURL": site_url}
+	if admin_password:
+		env["ADMIN_PASSWORD"] = admin_password
+
+	# Build command
+	cmd = [playwright_path, "test"]
+
+	if headless:
+		cmd.append("--reporter=list")
+
+	browser_map = {"chrome": "chromium", "chromium": "chromium", "firefox": "firefox", "webkit": "webkit"}
+	pw_browser = browser_map.get(browser, "chromium")
+	cmd.extend(["--project", pw_browser])
+
+	if spec:
+		cmd.append(spec)
+
+	click.secho("Running Playwright...", fg="yellow")
+	try:
+		frappe.commands.popen(" ".join(cmd), cwd=app_base_path, raise_err=True, env=env)
+	except subprocess.CalledProcessError as e:
+		click.secho("Playwright tests failed", fg="red")
 		raise click.exceptions.Exit(1) from e
 
 

--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -440,6 +440,7 @@ def run_parallel_tests(
 @click.option("--spec", help="Spec file to run")
 @click.option("--ci-build-id")
 @click.option("--playwright", is_flag=True, help="Use Playwright instead of Cypress")
+@click.option("--ui", is_flag=True, help="Run Playwright in UI mode (interactive)")
 @pass_context
 def run_ui_tests(
 	context: CliCtxObj,
@@ -452,6 +453,7 @@ def run_ui_tests(
 	cypressargs=None,
 	spec=None,
 	playwright=False,
+	ui=False,
 ):
 	"Run UI tests"
 	site = get_site(context)
@@ -468,6 +470,7 @@ def run_ui_tests(
 			headless=headless,
 			browser=browser,
 			spec=spec,
+			ui=ui,
 		)
 		return
 
@@ -548,16 +551,16 @@ def run_ui_tests(
 		raise click.exceptions.Exit(1) from e
 
 
-def _run_playwright_tests(app_base_path, site_url, admin_password, headless, browser, spec):
+def _run_playwright_tests(app_base_path, site_url, admin_password, headless, browser, spec, ui=False):
 	"""Run Playwright-based UI tests."""
 	frappe_path = frappe.get_app_source_path("frappe")
 	node_bin = subprocess.run(
-		"(cd ../frappe && yarn bin)",
+		"yarn bin",
 		shell=True,
 		stdout=subprocess.PIPE,
 		stderr=subprocess.DEVNULL,
 		text=True,
-		cwd=app_base_path,
+		cwd=frappe_path,
 	).stdout.strip()
 	playwright_path = f"{node_bin}/playwright"
 
@@ -568,7 +571,7 @@ def _run_playwright_tests(app_base_path, site_url, admin_password, headless, bro
 		with open(package_json_path) as f:
 			package_json_contents = f.read()
 
-		frappe.commands.popen("(cd ../frappe && yarn add @playwright/test --no-lockfile)")
+		frappe.commands.popen("yarn add @playwright/test --no-lockfile", cwd=frappe_path)
 
 		with open(package_json_path, "w") as f:
 			f.write(package_json_contents)
@@ -583,14 +586,23 @@ def _run_playwright_tests(app_base_path, site_url, admin_password, headless, bro
 		env["ADMIN_PASSWORD"] = admin_password
 
 	# Build command
-	cmd = [playwright_path, "test"]
+	cmd = [playwright_path]
 
-	if headless:
-		cmd.append("--reporter=list")
+	if ui:
+		# UI mode provides an interactive interface
+		cmd.append("test")
+		cmd.append("--ui")
+	else:
+		cmd.append("test")
+		if headless:
+			cmd.append("--reporter=list")
+		else:
+			cmd.append("--headed")
+			cmd.append("--workers=1")
 
-	browser_map = {"chrome": "chromium", "chromium": "chromium", "firefox": "firefox", "webkit": "webkit"}
-	pw_browser = browser_map.get(browser, "chromium")
-	cmd.extend(["--project", pw_browser])
+		browser_map = {"chrome": "chromium", "chromium": "chromium", "firefox": "firefox", "webkit": "webkit"}
+		pw_browser = browser_map.get(browser, "chromium")
+		cmd.extend(["--project", pw_browser])
 
 	if spec:
 		cmd.append(spec)

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,59 @@
+const { defineConfig, devices } = require("@playwright/test");
+
+/**
+ * Read environment variables
+ */
+const baseURL = process.env.PLAYWRIGHT_baseURL || "http://localhost:8000";
+const adminPassword = process.env.ADMIN_PASSWORD || "admin";
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+module.exports = defineConfig({
+	testDir: "./playwright/tests",
+	/* Run tests in files in parallel */
+	fullyParallel: true,
+	/* Fail the build on CI if you accidentally left test.only in the source code. */
+	forbidOnly: !!process.env.CI,
+	/* Retry on CI only */
+	retries: process.env.CI ? 2 : 0,
+	/* Opt out of parallel tests on CI. */
+	workers: process.env.CI ? 1 : undefined,
+	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
+	reporter: "html",
+	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+	use: {
+		/* Base URL to use in actions like `await page.goto('/')`. */
+		baseURL: baseURL,
+		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+		trace: "on-first-retry",
+		/* Screenshot on failure */
+		screenshot: "only-on-failure",
+		/* Video on failure */
+		video: "retain-on-failure",
+	},
+
+	/* Configure projects for major browsers */
+	projects: [
+		{
+			name: "chromium",
+			use: {
+				...devices["Desktop Chrome"],
+				/* Reuse browser context to avoid opening multiple windows */
+				launchOptions: {
+					args: ["--disable-dev-shm-usage"],
+				},
+			},
+		},
+
+		{
+			name: "firefox",
+			use: { ...devices["Desktop Firefox"] },
+		},
+
+		{
+			name: "webkit",
+			use: { ...devices["Desktop Safari"] },
+		},
+	],
+});

--- a/playwright/tests/list_paging.spec.js
+++ b/playwright/tests/list_paging.spec.js
@@ -1,0 +1,78 @@
+const { test, expect } = require("@playwright/test");
+const { login, frappeCall } = require("../utils");
+
+test.describe("List Paging", () => {
+	test.beforeAll(async ({ browser }) => {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+		await login(page);
+		await page.goto("/desk/website");
+
+		// Create multiple todo records for testing pagination
+		await frappeCall(page, "frappe.tests.ui_test_helpers.create_multiple_todo_records");
+
+		await context.close();
+	});
+
+	test.beforeEach(async ({ page }) => {
+		await login(page);
+	});
+
+	test("test load more with count selection buttons", async ({ page }) => {
+		await page.goto("/desk/todo/view/report");
+
+		// Clear any existing filters
+		const clearFiltersBtn = page.locator(".filter-section .btn-secondary");
+		if (await clearFiltersBtn.isVisible()) {
+			await clearFiltersBtn.click();
+			await page.waitForTimeout(500);
+		}
+
+		// Check initial count (20 records)
+		await expect(page.locator(".list-paging-area .list-count")).toContainText("20 of", {
+			timeout: 10000,
+		});
+
+		// Load more - should show 40
+		await page.locator(".list-paging-area .btn-more").click();
+		await page.waitForTimeout(500);
+		await expect(page.locator(".list-paging-area .list-count")).toContainText("40 of");
+
+		// Load more - should show 60
+		await page.locator(".list-paging-area .btn-more").click();
+		await page.waitForTimeout(500);
+		await expect(page.locator(".list-paging-area .list-count")).toContainText("60 of");
+
+		// Select 100 per page
+		await page.locator('.list-paging-area .btn-group .btn-paging[data-value="100"]').click();
+		await page.waitForTimeout(500);
+		await expect(page.locator(".list-paging-area .list-count")).toContainText("100 of");
+
+		// Load more - should show 200
+		await page.locator(".list-paging-area .btn-more").click();
+		await page.waitForTimeout(500);
+		await expect(page.locator(".list-paging-area .list-count")).toContainText("200 of");
+
+		// Load more - should show 300
+		await page.locator(".list-paging-area .btn-more").click();
+		await page.waitForTimeout(500);
+		await expect(page.locator(".list-paging-area .list-count")).toContainText("300 of");
+
+		// Check if refresh works after load more
+		await page
+			.locator('.page-head .standard-actions [data-original-title="Reload List"]')
+			.click();
+		await page.waitForTimeout(500);
+		await expect(page.locator(".list-paging-area .list-count")).toContainText("300 of");
+
+		// Select 500 per page
+		await page.locator('.list-paging-area .btn-group .btn-paging[data-value="500"]').click();
+		await page.waitForTimeout(500);
+		await expect(page.locator(".list-paging-area .list-count")).toContainText("500 of");
+
+		// Load more - should show 1,000
+		await page.locator(".list-paging-area .btn-more").click();
+		await page.waitForTimeout(1000);
+		await expect(page.locator(".list-paging-area .list-count")).toContainText("1,000 of");
+	});
+});

--- a/playwright/tests/list_paging.spec.js
+++ b/playwright/tests/list_paging.spec.js
@@ -73,6 +73,6 @@ test.describe("List Paging", () => {
 		// Load more - should show 1,000
 		await page.locator(".list-paging-area .btn-more").click();
 		await page.waitForTimeout(1000);
-		await expect(page.locator(".list-paging-area .list-count")).toContainText("1,000 of");
+		await expect(page.locator(".list-paging-area .list-count")).toContainText("of 1,000");
 	});
 });

--- a/playwright/tests/login.spec.js
+++ b/playwright/tests/login.spec.js
@@ -1,0 +1,77 @@
+const { test, expect } = require("@playwright/test");
+const { login, logout } = require("../utils");
+
+const adminPassword = process.env.ADMIN_PASSWORD || "admin";
+
+test.describe("Login", () => {
+	test.beforeEach(async ({ page }) => {
+		// ensure logged-in so we can call logout via API
+		await login(page);
+		await page.goto("/");
+		await logout(page);
+		await page.goto("/login");
+		await expect(page).toHaveURL(/\/login/);
+	});
+
+	test("greets with login screen", async ({ page }) => {
+		await expect(page.locator(".page-card-head").first()).toContainText("Login");
+	});
+
+	test("validates password", async ({ page }) => {
+		await page.locator("#login_email").fill("Administrator");
+		await page.getByRole("button", { name: "Login" }).click();
+		await expect(page).toHaveURL(/\/login/);
+	});
+
+	test("validates email", async ({ page }) => {
+		await page.locator("#login_password").fill("qwe");
+		await page.getByRole("button", { name: "Login" }).click();
+		await expect(page).toHaveURL(/\/login/);
+	});
+
+	test("shows invalid login if incorrect credentials", async ({ page }) => {
+		await page.locator("#login_email").fill("Administrator");
+		await page.locator("#login_password").fill("qwer");
+
+		await page.getByRole("button", { name: "Login" }).click();
+		await expect(
+			page.getByRole("button", { name: "Invalid Login. Try again." })
+		).toBeVisible();
+		await expect(page).toHaveURL(/\/login/);
+	});
+
+	test("logs in using correct credentials", async ({ page }) => {
+		await page.locator("#login_email").fill("Administrator");
+		await page.locator("#login_password").fill(adminPassword);
+
+		await page.getByRole("button", { name: "Login" }).click();
+		await expect(page).toHaveURL(/\/desk/);
+
+		const user = await page.evaluate(() => window.frappe.session.user);
+		expect(user).toBe("Administrator");
+	});
+
+	test("check redirect after login", async ({ page }) => {
+		const payload = new URLSearchParams({
+			uuid: "6fed1519-cfd8-4a2d-84a6-9a1799c7c741",
+			encoded_string: "hello all",
+			encoded_url: "http://test.localhost/callback",
+			base64_string: "aGVsbG8gYWxs",
+		});
+
+		await logout(page);
+
+		const redirectTo = "/me?" + payload.toString().replace(/\+/g, " ");
+		await page.goto("/login?redirect-to=" + encodeURIComponent(redirectTo));
+
+		await page.locator("#login_email").fill("Administrator");
+		await page.locator("#login_password").fill(adminPassword);
+
+		await page.getByRole("button", { name: "Login" }).click();
+
+		const expectedFragment = "/me?" + payload.toString().replace(/\+/g, "%20");
+		await expect(page).toHaveURL(
+			new RegExp(expectedFragment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+		);
+	});
+});

--- a/playwright/tests/routing.spec.js
+++ b/playwright/tests/routing.spec.js
@@ -1,0 +1,48 @@
+const { test, expect } = require("@playwright/test");
+const { login } = require("../utils");
+
+const list_view = "/desk/todo";
+
+// test round trip with filter types
+const test_queries = [
+	"?status=Open",
+	`?date=%5B"Between"%2C%5B"2022-06-01"%2C"2022-06-30"%5D%5D`,
+	`?date=%5B">"%2C"2022-06-01"%5D`,
+	`?name=%5B"like"%2C"%2542%25"%5D`,
+	`?status=%5B"not%20in"%2C%5B"Open"%2C"Closed"%5D%5D`,
+	`?status=%5B%22%21%3D%22%2C%22Closed%22%5D&status=%5B%22%21%3D%22%2C%22Cancelled%22%5D`,
+];
+
+test.describe("SPA Routing", () => {
+	test.beforeAll(async ({ browser }) => {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+		await login(page);
+		await page.goto("/desk/todo");
+		await context.close();
+	});
+
+	test.beforeEach(async ({ page }) => {
+		await login(page);
+	});
+
+	test("should apply filter on list view from route", async ({ page }) => {
+		for (const query of test_queries) {
+			const full_url = `${list_view}${query}`;
+			await page.goto(full_url);
+
+			// Wait for the page title to be visible
+			await expect(page.getByTitle("To Do")).toBeVisible({ timeout: 5000 });
+
+			const expected = new URLSearchParams(query);
+			const actual_url = new URL(page.url());
+			const actual = new URLSearchParams(actual_url.search);
+
+			// This might appear like a dumb test checking visited URL to itself
+			// but it's actually doing a round trip
+			// URL with params -> parsed filters -> new URL
+			// if it's same that means everything worked in between.
+			expect(actual.toString()).toBe(expected.toString());
+		}
+	});
+});

--- a/playwright/utils.js
+++ b/playwright/utils.js
@@ -1,0 +1,56 @@
+/**
+ * Frappe Playwright test utilities.
+ * Mirrors the most-used custom Cypress commands in cypress/support/commands.js.
+ */
+
+/**
+ * Log into Frappe via the REST API and return the authenticated context.
+ * Call this in a beforeAll / beforeEach to get an already-logged-in page.
+ */
+async function login(page, email, password) {
+	email = email || process.env.ADMIN_USER || "Administrator";
+	password = password || process.env.ADMIN_PASSWORD || "admin";
+
+	await page.request.post("/api/method/login", {
+		data: { usr: email, pwd: password },
+	});
+}
+
+/**
+ * Log out the current user by calling the logout whitelisted method.
+ * Uses the CSRF token from the current page context.
+ */
+async function logout(page) {
+	const csrfToken = await page.evaluate(() => window.frappe?.csrf_token);
+	if (csrfToken) {
+		await page.request.post("/api/method/logout", {
+			headers: {
+				"X-Frappe-CSRF-Token": csrfToken,
+			},
+		});
+	} else {
+		// Fallback: just hit logout without CSRF (works for GET logout too)
+		await page.request.post("/api/method/logout");
+	}
+}
+
+/**
+ * Call a Frappe whitelisted method. Retrieves the CSRF token from the page.
+ */
+async function frappeCall(page, method, args) {
+	const csrfToken = await page.evaluate(() => window.frappe?.csrf_token);
+	const headers = {
+		Accept: "application/json",
+		"Content-Type": "application/json",
+	};
+	if (csrfToken) {
+		headers["X-Frappe-CSRF-Token"] = csrfToken;
+	}
+	const response = await page.request.post(`/api/method/${method}`, {
+		data: args || {},
+		headers,
+	});
+	return response.json();
+}
+
+module.exports = { login, logout, frappeCall };


### PR DESCRIPTION
WIP

```
MacBook-Air-8:frappe saqibansari$  PLAYWRIGHT_baseURL=http://test.insights.localhost:8000 ADMIN_PASSWORD=admin npx playwright test playwright/tests/login.spec.js --reporter=list --grep "greets|validates|invalid" 2>&1

Running 4 tests using 1 worker

  ✓  1 …right/tests/login.spec.js:16:2 › Login › greets with login screen (3.3s)
  ✓  2 … playwright/tests/login.spec.js:20:2 › Login › validates password (1.7s)
  ✓  3 …] › playwright/tests/login.spec.js:26:2 › Login › validates email (1.7s)
  ✓  4 …ec.js:32:2 › Login › shows invalid login if incorrect credentials (1.8s)

  4 passed (10.3s)
```

> Co-authored by Claude Opus 4.6