### PR TITLE
fix(Number Card): dynamic filters

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -202,7 +202,6 @@ frappe.ui.form.on("Number Card", {
 	render_filters_table: function (frm) {
 		frm.set_df_property("filters_section", "hidden", 0);
 		let is_document_type = frm.doc.type == "Document Type";
-		let is_dynamic_filter = (f) => ["Date", "DateRange"].includes(f.fieldtype) && f.default;
 
 		let wrapper = $(frm.get_field("filters_json").wrapper).empty();
 		let table = $(`<table class="table table-bordered" style="cursor:${
@@ -226,18 +225,6 @@ frappe.ui.form.on("Number Card", {
 
 		let filters = JSON.parse(frm.doc.filters_json || "[]");
 		let filters_set = false;
-
-		// Set dynamic filters for reports
-		if (frm.doc.type == "Report") {
-			let set_filters = false;
-			frm.filters.forEach((f) => {
-				if (is_dynamic_filter(f)) {
-					filters[f.fieldname] = f.default;
-					set_filters = true;
-				}
-			});
-			set_filters && frm.set_value("filters_json", JSON.stringify(filters));
-		}
 
 		let fields = [];
 		if (is_document_type) {
@@ -292,7 +279,7 @@ frappe.ui.form.on("Number Card", {
 			}
 			let dialog = new frappe.ui.Dialog({
 				title: __("Set Filters"),
-				fields: fields.filter((f) => !is_dynamic_filter(f)),
+				fields,
 				primary_action: function () {
 					let values = this.get_values();
 					if (values) {
@@ -406,11 +393,6 @@ frappe.ui.form.on("Number Card", {
 	},
 
 	show_doctype_dynamic_filter_dialog: function (frm) {
-		const dynamic_filters =
-			frm.doc.dynamic_filters_json?.length > 2
-				? JSON.parse(frm.doc.dynamic_filters_json)
-				: [];
-
 		const meta = frappe.get_meta(frm.doc.document_type);
 		const field_options = meta.fields
 			.filter((df) => df.fieldname && !frappe.model.no_value_type.includes(df.fieldtype))
@@ -420,57 +402,22 @@ frappe.ui.form.on("Number Card", {
 			field_options.push({ label: df.label, value: df.fieldname });
 		});
 
-		const dialog = new frappe.ui.Dialog({
-			title: __("Set Dynamic Filters"),
-			fields: [
-				{
-					fieldtype: "HTML",
-					fieldname: "help_text",
-					options: frm.events.get_dynamic_filter_help_text(),
-				},
-				{ fieldtype: "HTML", fieldname: "filter_area" },
-			],
-			size: "large",
-			primary_action: () => {
-				const filters = [];
-				dialog.$wrapper.find(".dynamic-filter-row").each(function () {
-					const field = $(this).find(".filter-field").val();
-					const expression = $(this).find(".filter-expression").val();
-					if (field && expression) {
-						filters.push([frm.doc.document_type, field, "=", expression]);
-					}
-				});
-				dialog.hide();
-				frm.set_value("dynamic_filters_json", JSON.stringify(filters));
-				frm.trigger("set_dynamic_filters_in_table");
-			},
-			primary_action_label: __("Update"),
-		});
-
-		const add_filter_row = frm.events.build_dynamic_filter_interface(
-			dialog.fields_dict.filter_area.$wrapper,
-			field_options,
-			"Field"
-		);
-
-		if (dynamic_filters?.length) {
-			dynamic_filters.forEach((filter) => add_filter_row(filter[1], filter[3]));
-		} else {
-			add_filter_row();
-		}
-
-		dialog.show();
+		frm.events.show_dynamic_filter_dialog_common(frm, field_options);
 	},
 
 	show_report_dynamic_filter_dialog: function (frm) {
+		const field_options = frm.filters
+			.filter((f) => f.fieldname)
+			.map((f) => ({ label: f.label || f.fieldname, value: f.fieldname }));
+
+		frm.events.show_dynamic_filter_dialog_common(frm, field_options);
+	},
+
+	show_dynamic_filter_dialog_common: function (frm, field_options) {
 		const dynamic_filters =
 			frm.doc.dynamic_filters_json?.length > 2
 				? JSON.parse(frm.doc.dynamic_filters_json)
 				: {};
-
-		const field_options = frm.filters
-			.filter((f) => f.fieldname)
-			.map((f) => ({ label: f.label || f.fieldname, value: f.fieldname }));
 
 		const dialog = new frappe.ui.Dialog({
 			title: __("Set Dynamic Filters"),
@@ -501,8 +448,7 @@ frappe.ui.form.on("Number Card", {
 
 		const add_filter_row = frm.events.build_dynamic_filter_interface(
 			dialog.fields_dict.filter_area.$wrapper,
-			field_options,
-			"Filter"
+			field_options
 		);
 
 		if (dynamic_filters && Object.keys(dynamic_filters).length) {
@@ -524,13 +470,13 @@ frappe.ui.form.on("Number Card", {
 		</p>`;
 	},
 
-	build_dynamic_filter_interface: function ($filter_area, field_options, field_label) {
+	build_dynamic_filter_interface: function ($filter_area, field_options) {
 		const filter_html = `
 			<div>
 				<table class="table table-bordered" style="margin-bottom: 12px;">
 					<thead>
 						<tr>
-							<th style="width: 35%">${__(field_label)}</th>
+							<th style="width: 35%">${__("Field")}</th>
 							<th style="width: 60%">${__("Expression")}</th>
 							<th style="width: 5%"></th>
 						</tr>
@@ -595,7 +541,7 @@ frappe.ui.form.on("Number Card", {
 
 	set_dynamic_filters_in_table: function (frm) {
 		frm.dynamic_filters =
-			frm.doc.dynamic_filters_json && frm.doc.dynamic_filters_json.length > 2
+			frm.doc.dynamic_filters_json?.length > 2
 				? JSON.parse(frm.doc.dynamic_filters_json)
 				: null;
 
@@ -605,20 +551,11 @@ frappe.ui.form.on("Number Card", {
 			frm.dynamic_filter_table.find("tbody").html(filter_row);
 		} else {
 			let filter_rows = "";
-			if ($.isArray(frm.dynamic_filters)) {
-				frm.dynamic_filters.forEach((filter) => {
-					filter_rows += `<tr>
-							<td>${filter[1]}</td>
-							<td><code>${filter[3]}</code></td>
-						</tr>`;
-				});
-			} else {
-				for (let [key, val] of Object.entries(frm.dynamic_filters)) {
-					filter_rows += `<tr>
-							<td>${key}</td>
-							<td><code>${val || ""}</code></td>
-						</tr>`;
-				}
+			for (let [key, val] of Object.entries(frm.dynamic_filters)) {
+				filter_rows += `<tr>
+						<td>${key}</td>
+						<td><code>${val || ""}</code></td>
+					</tr>`;
 			}
 
 			frm.dynamic_filter_table.find("tbody").html(filter_rows);

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -349,11 +349,6 @@ frappe.ui.form.on("Number Card", {
 			);
 		}
 
-		frm.dynamic_filters =
-			frm.doc.dynamic_filters_json && frm.doc.dynamic_filters_json.length > 2
-				? JSON.parse(frm.doc.dynamic_filters_json)
-				: null;
-
 		frm.trigger("set_dynamic_filters_in_table");
 
 		frm.dynamic_filter_table.on("click", () => {
@@ -413,11 +408,27 @@ frappe.ui.form.on("Number Card", {
 		frm.events.show_dynamic_filter_dialog_common(frm, field_options);
 	},
 
+	convert_legacy_dynamic_filters: function (dynamic_filters) {
+		if (Array.isArray(dynamic_filters)) {
+			const converted = {};
+			dynamic_filters.forEach((filter) => {
+				if (filter.length >= 4) {
+					// Old format: [doctype, fieldname, operator, expression]
+					converted[filter[1]] = filter[3];
+				}
+			});
+			return converted;
+		}
+		return dynamic_filters;
+	},
+
 	show_dynamic_filter_dialog_common: function (frm, field_options) {
-		const dynamic_filters =
+		let dynamic_filters =
 			frm.doc.dynamic_filters_json?.length > 2
 				? JSON.parse(frm.doc.dynamic_filters_json)
 				: {};
+
+		dynamic_filters = frm.events.convert_legacy_dynamic_filters(dynamic_filters);
 
 		const dialog = new frappe.ui.Dialog({
 			title: __("Set Dynamic Filters"),
@@ -511,8 +522,7 @@ frappe.ui.form.on("Number Card", {
 						</select>
 					</td>
 					<td>
-						<input type="text" class="form-control input-xs filter-expression"
-							value="${expression}">
+						<input type="text" class="form-control input-xs filter-expression">
 					</td>
 					<td class="text-center">
 						<a class="remove-filter text-muted" style="cursor: pointer;">
@@ -524,7 +534,9 @@ frappe.ui.form.on("Number Card", {
 				</tr>
 			`;
 
-			$filter_area.find(".filter-rows").append(row_html);
+			const $row = $(row_html);
+			$row.find(".filter-expression").val(expression);
+			$filter_area.find(".filter-rows").append($row);
 		};
 
 		$filter_area.on("click", ".add-filter", () => add_filter_row());
@@ -540,18 +552,20 @@ frappe.ui.form.on("Number Card", {
 	},
 
 	set_dynamic_filters_in_table: function (frm) {
-		frm.dynamic_filters =
+		let dynamic_filters =
 			frm.doc.dynamic_filters_json?.length > 2
 				? JSON.parse(frm.doc.dynamic_filters_json)
 				: null;
 
-		if (!frm.dynamic_filters || Object.keys(frm.dynamic_filters).length === 0) {
+		dynamic_filters = frm.events.convert_legacy_dynamic_filters(dynamic_filters);
+
+		if (!dynamic_filters || Object.keys(dynamic_filters).length === 0) {
 			const filter_row = $(`<tr><td colspan="2" class="text-muted text-center">
 				${__("Click to Set Dynamic Filters")}</td></tr>`);
 			frm.dynamic_filter_table.find("tbody").html(filter_row);
 		} else {
 			let filter_rows = "";
-			for (let [key, val] of Object.entries(frm.dynamic_filters)) {
+			for (let [key, val] of Object.entries(dynamic_filters)) {
 				filter_rows += `<tr>
 						<td>${key}</td>
 						<td><code>${val || ""}</code></td>

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -219,7 +219,9 @@ frappe.ui.form.on("Number Card", {
 		</table>`).appendTo(wrapper);
 
 		if (frm.has_perm("write")) {
-			$(`<p class="text-muted small">${__("Click table to edit")}</p>`).appendTo(wrapper);
+			$(`<p class="text-muted small mt-2">${__("Click table to edit")}</p>`).appendTo(
+				wrapper
+			);
 		}
 
 		let filters = JSON.parse(frm.doc.filters_json || "[]");
@@ -304,7 +306,7 @@ frappe.ui.form.on("Number Card", {
 						frm.trigger("render_filters_table");
 					}
 				},
-				primary_action_label: __("Set"),
+				primary_action_label: __("Update"),
 			});
 
 			if (is_document_type) {
@@ -340,8 +342,6 @@ frappe.ui.form.on("Number Card", {
 
 		frm.set_df_property("dynamic_filters_section", "hidden", 0);
 
-		let is_document_type = frm.doc.type == "Document Type";
-
 		let wrapper = $(frm.get_field("dynamic_filters_json").wrapper).empty();
 
 		frm.dynamic_filter_table = $(`<table class="table table-bordered" style="cursor:${
@@ -349,13 +349,18 @@ frappe.ui.form.on("Number Card", {
 		}; margin:0px;">
 			<thead>
 				<tr>
-					<th style="width: 20%">${__("Filter")}</th>
-					<th style="width: 20%">${__("Condition")}</th>
-					<th>${__("Value")}</th>
+					<th style="width: 30%">${__("Filter")}</th>
+					<th>${__("Expression")}</th>
 				</tr>
 			</thead>
 			<tbody></tbody>
 		</table>`).appendTo(wrapper);
+
+		if (frm.has_perm("write")) {
+			$(`<p class="text-muted small mt-2">${__("Click table to edit")}</p>`).appendTo(
+				wrapper
+			);
+		}
 
 		frm.dynamic_filters =
 			frm.doc.dynamic_filters_json && frm.doc.dynamic_filters_json.length > 2
@@ -363,14 +368,6 @@ frappe.ui.form.on("Number Card", {
 				: null;
 
 		frm.trigger("set_dynamic_filters_in_table");
-
-		let filters = JSON.parse(frm.doc.filters_json || "[]");
-
-		let fields = frappe.dashboard_utils.get_fields_for_dynamic_filter_dialog(
-			is_document_type,
-			filters,
-			frm.dynamic_filters
-		);
 
 		frm.dynamic_filter_table.on("click", () => {
 			if (!frm.has_perm("write")) {
@@ -380,33 +377,220 @@ frappe.ui.form.on("Number Card", {
 			if (!frappe.boot.developer_mode && frm.doc.is_standard) {
 				frappe.throw(__("Cannot edit filters for standard number cards"));
 			}
-			let dialog = new frappe.ui.Dialog({
-				title: __("Set Dynamic Filters"),
-				fields: fields,
-				primary_action: () => {
-					let values = dialog.get_values();
-					dialog.hide();
-					let dynamic_filters = [];
-					for (let key of Object.keys(values)) {
-						if (is_document_type) {
-							let [doctype, fieldname] = key.split(":");
-							dynamic_filters.push([doctype, fieldname, "=", values[key]]);
-						}
-					}
 
-					if (is_document_type) {
-						frm.set_value("dynamic_filters_json", JSON.stringify(dynamic_filters));
-					} else {
-						frm.set_value("dynamic_filters_json", JSON.stringify(values));
-					}
-					frm.trigger("set_dynamic_filters_in_table");
+			frm.trigger("show_dynamic_filter_dialog");
+		});
+	},
+
+	show_dynamic_filter_dialog: function (frm) {
+		if (frm.doc.type === "Document Type") {
+			if (!frm.doc.document_type) {
+				frappe.msgprint(__("Please select a Document Type first"));
+				return;
+			}
+			frappe.model.with_doctype(frm.doc.document_type, () => {
+				frm.trigger("show_doctype_dynamic_filter_dialog");
+			});
+			return;
+		}
+
+		if (!frm.doc.report_name) {
+			frappe.msgprint(__("Please select a Report first"));
+			return;
+		}
+		if (!frm.filters?.length) {
+			frappe.msgprint(__("No filters available for this report"));
+			return;
+		}
+		frm.trigger("show_report_dynamic_filter_dialog");
+	},
+
+	show_doctype_dynamic_filter_dialog: function (frm) {
+		const dynamic_filters =
+			frm.doc.dynamic_filters_json?.length > 2
+				? JSON.parse(frm.doc.dynamic_filters_json)
+				: [];
+
+		const meta = frappe.get_meta(frm.doc.document_type);
+		const field_options = meta.fields
+			.filter((df) => df.fieldname && !frappe.model.no_value_type.includes(df.fieldtype))
+			.map((df) => ({ label: df.label || df.fieldname, value: df.fieldname }));
+
+		frappe.model.std_fields.forEach((df) => {
+			field_options.push({ label: df.label, value: df.fieldname });
+		});
+
+		const dialog = new frappe.ui.Dialog({
+			title: __("Set Dynamic Filters"),
+			fields: [
+				{
+					fieldtype: "HTML",
+					fieldname: "help_text",
+					options: frm.events.get_dynamic_filter_help_text(),
 				},
-				primary_action_label: __("Set"),
+				{ fieldtype: "HTML", fieldname: "filter_area" },
+			],
+			size: "large",
+			primary_action: () => {
+				const filters = [];
+				dialog.$wrapper.find(".dynamic-filter-row").each(function () {
+					const field = $(this).find(".filter-field").val();
+					const expression = $(this).find(".filter-expression").val();
+					if (field && expression) {
+						filters.push([frm.doc.document_type, field, "=", expression]);
+					}
+				});
+				dialog.hide();
+				frm.set_value("dynamic_filters_json", JSON.stringify(filters));
+				frm.trigger("set_dynamic_filters_in_table");
+			},
+			primary_action_label: __("Update"),
+		});
+
+		const add_filter_row = frm.events.build_dynamic_filter_interface(
+			dialog.fields_dict.filter_area.$wrapper,
+			field_options,
+			"Field"
+		);
+
+		if (dynamic_filters?.length) {
+			dynamic_filters.forEach((filter) => add_filter_row(filter[1], filter[3]));
+		} else {
+			add_filter_row();
+		}
+
+		dialog.show();
+	},
+
+	show_report_dynamic_filter_dialog: function (frm) {
+		const dynamic_filters =
+			frm.doc.dynamic_filters_json?.length > 2
+				? JSON.parse(frm.doc.dynamic_filters_json)
+				: {};
+
+		const field_options = frm.filters
+			.filter((f) => f.fieldname)
+			.map((f) => ({ label: f.label || f.fieldname, value: f.fieldname }));
+
+		const dialog = new frappe.ui.Dialog({
+			title: __("Set Dynamic Filters"),
+			fields: [
+				{
+					fieldtype: "HTML",
+					fieldname: "help_text",
+					options: frm.events.get_dynamic_filter_help_text(),
+				},
+				{ fieldtype: "HTML", fieldname: "filter_area" },
+			],
+			size: "large",
+			primary_action: () => {
+				const filters = {};
+				dialog.$wrapper.find(".dynamic-filter-row").each(function () {
+					const field = $(this).find(".filter-field").val();
+					const expression = $(this).find(".filter-expression").val();
+					if (field && expression) {
+						filters[field] = expression;
+					}
+				});
+				dialog.hide();
+				frm.set_value("dynamic_filters_json", JSON.stringify(filters));
+				frm.trigger("set_dynamic_filters_in_table");
+			},
+			primary_action_label: __("Update"),
+		});
+
+		const add_filter_row = frm.events.build_dynamic_filter_interface(
+			dialog.fields_dict.filter_area.$wrapper,
+			field_options,
+			"Filter"
+		);
+
+		if (dynamic_filters && Object.keys(dynamic_filters).length) {
+			Object.entries(dynamic_filters).forEach(([field, expression]) =>
+				add_filter_row(field, expression)
+			);
+		} else {
+			add_filter_row();
+		}
+
+		dialog.show();
+	},
+
+	get_dynamic_filter_help_text: function () {
+		return `<p class="text-muted small">
+			${__("Enter expressions that will be evaluated when the card is displayed. For example:")}<br>
+			<code>frappe.defaults.get_user_default("Company")</code><br>
+			<code>frappe.datetime.get_today()</code><br>
+		</p>`;
+	},
+
+	build_dynamic_filter_interface: function ($filter_area, field_options, field_label) {
+		const filter_html = `
+			<div>
+				<table class="table table-bordered" style="margin-bottom: 12px;">
+					<thead>
+						<tr>
+							<th style="width: 35%">${__(field_label)}</th>
+							<th style="width: 60%">${__("Expression")}</th>
+							<th style="width: 5%"></th>
+						</tr>
+					</thead>
+					<tbody class="filter-rows"></tbody>
+				</table>
+				<div style="display: flex; justify-content: space-between; align-items: center;">
+					<button class="text-muted add-filter btn btn-xs">
+						+ ${__("Add Filter")}
+					</button>
+					<button class="btn btn-secondary btn-xs clear-filters">
+						${__("Clear Filters")}
+					</button>
+				</div>
+			</div>
+		`;
+
+		$filter_area.html(filter_html);
+
+		const add_filter_row = (field = "", expression = "") => {
+			let options_html = '<option value=""></option>';
+			field_options.forEach((opt) => {
+				const selected = opt.value === field ? "selected" : "";
+				options_html += `<option value="${opt.value}" ${selected}>${opt.label}</option>`;
 			});
 
-			dialog.show();
-			dialog.set_values(frm.dynamic_filters);
+			const row_html = `
+				<tr class="dynamic-filter-row">
+					<td>
+						<select class="form-control input-xs filter-field">
+							${options_html}
+						</select>
+					</td>
+					<td>
+						<input type="text" class="form-control input-xs filter-expression"
+							value="${expression}">
+					</td>
+					<td class="text-center">
+						<a class="remove-filter text-muted" style="cursor: pointer;">
+							<svg class="icon icon-sm">
+								<use href="#icon-close" class="close"></use>
+							</svg>
+						</a>
+					</td>
+				</tr>
+			`;
+
+			$filter_area.find(".filter-rows").append(row_html);
+		};
+
+		$filter_area.on("click", ".add-filter", () => add_filter_row());
+		$filter_area.on("click", ".remove-filter", function () {
+			$(this).closest("tr").remove();
 		});
+		$filter_area.on("click", ".clear-filters", () => {
+			$filter_area.find(".filter-rows").empty();
+			add_filter_row();
+		});
+
+		return add_filter_row;
 	},
 
 	set_dynamic_filters_in_table: function (frm) {
@@ -415,8 +599,8 @@ frappe.ui.form.on("Number Card", {
 				? JSON.parse(frm.doc.dynamic_filters_json)
 				: null;
 
-		if (!frm.dynamic_filters) {
-			const filter_row = $(`<tr><td colspan="3" class="text-muted text-center">
+		if (!frm.dynamic_filters || Object.keys(frm.dynamic_filters).length === 0) {
+			const filter_row = $(`<tr><td colspan="2" class="text-muted text-center">
 				${__("Click to Set Dynamic Filters")}</td></tr>`);
 			frm.dynamic_filter_table.find("tbody").html(filter_row);
 		} else {
@@ -425,17 +609,14 @@ frappe.ui.form.on("Number Card", {
 				frm.dynamic_filters.forEach((filter) => {
 					filter_rows += `<tr>
 							<td>${filter[1]}</td>
-							<td>${filter[2] || ""}</td>
-							<td>${filter[3]}</td>
+							<td><code>${filter[3]}</code></td>
 						</tr>`;
 				});
 			} else {
-				let condition = "=";
 				for (let [key, val] of Object.entries(frm.dynamic_filters)) {
 					filter_rows += `<tr>
 							<td>${key}</td>
-							<td>${condition}</td>
-							<td>${val || ""}</td>
+							<td><code>${val || ""}</code></td>
 						</tr>`;
 				}
 			}

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -428,10 +428,11 @@ frappe.ui.form.on("Number Card", {
 			primary_action: () => {
 				const filters = [];
 				dialog.$wrapper.find(".dynamic-filter-row").each(function () {
-					const field = $(this).find(".filter-field").val();
-					const expression = $(this).find(".filter-expression").val();
-					if (field && expression) {
-						filters.push([doctype_or_report, field, "=", expression]);
+					const $row = $(this);
+					const fieldname = $row.data("selected_fieldname");
+					const expression = $row.find(".filter-expression").val();
+					if (fieldname && expression) {
+						filters.push([doctype_or_report, fieldname, "=", expression]);
 					}
 				});
 				dialog.hide();
@@ -443,7 +444,8 @@ frappe.ui.form.on("Number Card", {
 
 		const add_filter_row = frm.events.build_dynamic_filter_interface(
 			dialog.fields_dict.filter_area.$wrapper,
-			field_options
+			field_options,
+			doctype_or_report
 		);
 
 		if (dynamic_filters?.length) {
@@ -465,7 +467,7 @@ frappe.ui.form.on("Number Card", {
 		</p>`;
 	},
 
-	build_dynamic_filter_interface: function ($filter_area, field_options) {
+	build_dynamic_filter_interface: function ($filter_area, field_options, doctype_or_report) {
 		const filter_html = `
 			<div>
 				<table class="table table-bordered" style="margin-bottom: 12px;">
@@ -491,20 +493,16 @@ frappe.ui.form.on("Number Card", {
 
 		$filter_area.html(filter_html);
 
-		const add_filter_row = (field = "", expression = "") => {
-			let options_html = '<option value=""></option>';
-			field_options.forEach((opt) => {
-				const selected = opt.value === field ? "selected" : "";
-				options_html += `<option value="${opt.value}" ${selected}>${opt.label}</option>`;
-			});
+		const filter_fields = field_options.map((opt) => ({
+			fieldname: opt.value,
+			label: opt.label,
+			parent: doctype_or_report,
+		}));
 
+		const add_filter_row = (fieldname = "", expression = "") => {
 			const row_html = `
 				<tr class="dynamic-filter-row">
-					<td>
-						<select class="form-control input-xs filter-field">
-							${options_html}
-						</select>
-					</td>
+					<td class="fieldname-select-area"></td>
 					<td>
 						<input type="text" class="form-control input-xs filter-expression">
 					</td>
@@ -519,7 +517,24 @@ frappe.ui.form.on("Number Card", {
 			`;
 
 			const $row = $(row_html);
+
+			const field_select = new frappe.ui.FieldSelect({
+				parent: $row.find(".fieldname-select-area"),
+				doctype: doctype_or_report,
+				filter_fields: filter_fields,
+				input_class: "input-xs",
+				select: (_, selected_fieldname) => {
+					$row.data("selected_fieldname", selected_fieldname);
+				},
+			});
+
+			if (fieldname) {
+				field_select.set_value(doctype_or_report, fieldname);
+				$row.data("selected_fieldname", fieldname);
+			}
+
 			$row.find(".filter-expression").val(expression);
+			$row.data("field_select", field_select);
 			$filter_area.find(".filter-rows").append($row);
 		};
 

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -397,7 +397,7 @@ frappe.ui.form.on("Number Card", {
 			field_options.push({ label: df.label, value: df.fieldname });
 		});
 
-		frm.events.show_dynamic_filter_dialog_common(frm, field_options);
+		frm.events.show_dynamic_filter_dialog_common(frm, field_options, frm.doc.document_type);
 	},
 
 	show_report_dynamic_filter_dialog: function (frm) {
@@ -405,30 +405,14 @@ frappe.ui.form.on("Number Card", {
 			.filter((f) => f.fieldname)
 			.map((f) => ({ label: f.label || f.fieldname, value: f.fieldname }));
 
-		frm.events.show_dynamic_filter_dialog_common(frm, field_options);
+		frm.events.show_dynamic_filter_dialog_common(frm, field_options, frm.doc.report_name);
 	},
 
-	convert_legacy_dynamic_filters: function (dynamic_filters) {
-		if (Array.isArray(dynamic_filters)) {
-			const converted = {};
-			dynamic_filters.forEach((filter) => {
-				if (filter.length >= 4) {
-					// Old format: [doctype, fieldname, operator, expression]
-					converted[filter[1]] = filter[3];
-				}
-			});
-			return converted;
-		}
-		return dynamic_filters;
-	},
-
-	show_dynamic_filter_dialog_common: function (frm, field_options) {
+	show_dynamic_filter_dialog_common: function (frm, field_options, doctype_or_report) {
 		let dynamic_filters =
 			frm.doc.dynamic_filters_json?.length > 2
 				? JSON.parse(frm.doc.dynamic_filters_json)
-				: {};
-
-		dynamic_filters = frm.events.convert_legacy_dynamic_filters(dynamic_filters);
+				: [];
 
 		const dialog = new frappe.ui.Dialog({
 			title: __("Set Dynamic Filters"),
@@ -442,12 +426,12 @@ frappe.ui.form.on("Number Card", {
 			],
 			size: "large",
 			primary_action: () => {
-				const filters = {};
+				const filters = [];
 				dialog.$wrapper.find(".dynamic-filter-row").each(function () {
 					const field = $(this).find(".filter-field").val();
 					const expression = $(this).find(".filter-expression").val();
 					if (field && expression) {
-						filters[field] = expression;
+						filters.push([doctype_or_report, field, "=", expression]);
 					}
 				});
 				dialog.hide();
@@ -462,10 +446,10 @@ frappe.ui.form.on("Number Card", {
 			field_options
 		);
 
-		if (dynamic_filters && Object.keys(dynamic_filters).length) {
-			Object.entries(dynamic_filters).forEach(([field, expression]) =>
-				add_filter_row(field, expression)
-			);
+		if (dynamic_filters?.length) {
+			dynamic_filters.forEach((filter) => {
+				add_filter_row(filter[1], filter[3]);
+			});
 		} else {
 			add_filter_row();
 		}
@@ -555,22 +539,20 @@ frappe.ui.form.on("Number Card", {
 		let dynamic_filters =
 			frm.doc.dynamic_filters_json?.length > 2
 				? JSON.parse(frm.doc.dynamic_filters_json)
-				: null;
+				: [];
 
-		dynamic_filters = frm.events.convert_legacy_dynamic_filters(dynamic_filters);
-
-		if (!dynamic_filters || Object.keys(dynamic_filters).length === 0) {
+		if (!dynamic_filters?.length) {
 			const filter_row = $(`<tr><td colspan="2" class="text-muted text-center">
 				${__("Click to Set Dynamic Filters")}</td></tr>`);
 			frm.dynamic_filter_table.find("tbody").html(filter_row);
 		} else {
 			let filter_rows = "";
-			for (let [key, val] of Object.entries(dynamic_filters)) {
+			dynamic_filters.forEach((filter) => {
 				filter_rows += `<tr>
-						<td>${key}</td>
-						<td><code>${val || ""}</code></td>
+						<td>${filter[1]}</td>
+						<td><code>${filter[3] || ""}</code></td>
 					</tr>`;
-			}
+			});
 
 			frm.dynamic_filter_table.find("tbody").html(filter_rows);
 		}

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "field:label",
  "creation": "2020-04-15 18:06:39.444683",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -72,7 +73,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Label",
-   "reqd": 1
+   "reqd": 1,
+   "unique": 1
   },
   {
    "fieldname": "color",
@@ -229,10 +231,11 @@
   }
  ],
  "links": [],
- "modified": "2025-09-17 21:00:11.351605",
+ "modified": "2026-02-25 16:33:09.032056",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -132,18 +132,27 @@ frappe.dashboard_utils = {
 
 	remove_common_static_filter_values(static_filters, dynamic_filters) {
 		if (dynamic_filters) {
-			if ($.isArray(static_filters)) {
-				static_filters = static_filters.filter((static_filter) => {
-					for (let dynamic_filter of dynamic_filters) {
-						if (
-							static_filter[0] == dynamic_filter[0] &&
-							static_filter[1] == dynamic_filter[1]
-						) {
-							return false;
+			if (Array.isArray(static_filters)) {
+				if (Array.isArray(dynamic_filters)) {
+					static_filters = static_filters.filter((static_filter) => {
+						for (let dynamic_filter of dynamic_filters) {
+							if (
+								static_filter[0] == dynamic_filter[0] &&
+								static_filter[1] == dynamic_filter[1]
+							) {
+								return false;
+							}
 						}
-					}
-					return true;
-				});
+						return true;
+					});
+				} else {
+					static_filters = static_filters.filter((static_filter) => {
+						return !Object.prototype.hasOwnProperty.call(
+							dynamic_filters,
+							static_filter[1]
+						);
+					});
+				}
 			} else {
 				for (let key of Object.keys(dynamic_filters)) {
 					delete static_filters[key];

--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -133,26 +133,17 @@ frappe.dashboard_utils = {
 	remove_common_static_filter_values(static_filters, dynamic_filters) {
 		if (dynamic_filters) {
 			if (Array.isArray(static_filters)) {
-				if (Array.isArray(dynamic_filters)) {
-					static_filters = static_filters.filter((static_filter) => {
-						for (let dynamic_filter of dynamic_filters) {
-							if (
-								static_filter[0] == dynamic_filter[0] &&
-								static_filter[1] == dynamic_filter[1]
-							) {
-								return false;
-							}
+				static_filters = static_filters.filter((static_filter) => {
+					for (let dynamic_filter of dynamic_filters) {
+						if (
+							static_filter[0] == dynamic_filter[0] &&
+							static_filter[1] == dynamic_filter[1]
+						) {
+							return false;
 						}
-						return true;
-					});
-				} else {
-					static_filters = static_filters.filter((static_filter) => {
-						return !Object.prototype.hasOwnProperty.call(
-							dynamic_filters,
-							static_filter[1]
-						);
-					});
-				}
+					}
+					return true;
+				});
 			} else {
 				for (let key of Object.keys(dynamic_filters)) {
 					delete static_filters[key];
@@ -216,29 +207,26 @@ frappe.dashboard_utils = {
 			? JSON.parse(doc.dynamic_filters_json)
 			: null;
 
-		if (!dynamic_filters || !Object.keys(dynamic_filters).length) {
+		if (!dynamic_filters?.length) {
 			return filters;
 		}
 
-		if (Array.isArray(dynamic_filters)) {
-			dynamic_filters.forEach((f) => {
-				try {
-					f[3] = eval(f[3]);
-				} catch (e) {
-					frappe.throw(__("Invalid expression set in filter {0} ({1})", [f[1], f[0]]));
-				}
-			});
+		dynamic_filters.forEach((f) => {
+			try {
+				f[3] = eval(f[3]);
+			} catch (e) {
+				frappe.throw(__("Invalid expression set in filter {0} ({1})", [f[1], f[0]]));
+			}
+		});
+
+		if (!filters) {
+			filters = dynamic_filters;
+		} else if (Array.isArray(filters)) {
 			filters = [...filters, ...dynamic_filters];
 		} else {
-			for (let key of Object.keys(dynamic_filters)) {
-				try {
-					const val = eval(dynamic_filters[key]);
-					dynamic_filters[key] = val;
-				} catch (e) {
-					frappe.throw(__("Invalid expression set in filter {0}", [key]));
-				}
-			}
-			Object.assign(filters, dynamic_filters);
+			dynamic_filters.forEach((f) => {
+				filters[f[1]] = f[3];
+			});
 		}
 
 		return filters;


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/28169; Closes https://github.com/frappe/frappe/issues/37351; Closes https://github.com/frappe/frappe/issues/35161; Closes https://github.com/frappe/frappe/issues/23558

https://github.com/user-attachments/assets/e8c6956f-d2cf-470b-a48b-8d13ba0c78c1

Previously, only those fields entered in the static filters table were available for configuring in dynamic filters. 

This PR introduces a new interface for entering dynamic filters for any field independently of the ones in static filters. I've avoided merging the two tables as they are different fields in the schema (`filters_json` and `dynamic_filters_json`), and because there is no need for dynamic filters to have a condition field ('Equals', 'Not Equals', 'Like', etc.)