### PR TITLE
fix: remove stale `custom_onhide` in msgprint to prevent rerouting issues

### DIFF
--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -183,6 +183,7 @@ frappe.msgprint = function (msg, title, is_minimizable, re_route) {
 			onhide: function () {
 				if (frappe.msg_dialog.custom_onhide) {
 					frappe.msg_dialog.custom_onhide();
+					delete frappe.msg_dialog.custom_onhide;
 				}
 				frappe.msg_dialog.msg_area.empty();
 			},


### PR DESCRIPTION
Fixes: #37478


----
Before:


https://github.com/user-attachments/assets/666a12a6-5353-4ef6-b8eb-1a4b64fb266c



---
After: 


https://github.com/user-attachments/assets/f66853af-e8e9-4042-9dd6-0089707b242a

