### PR TITLE
fix: remove is_wkhtmltopdf_valid check when pdf generator is set to chrome

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -706,7 +706,10 @@ frappe.ui.form.PrintView = class {
 				return;
 			}
 		} else {
-			this.is_wkhtmltopdf_valid();
+			let pdf_generator = this.get_pdf_generator(print_format?.pdf_generator);
+			if (pdf_generator === "wkhtmltopdf") {
+				this.is_wkhtmltopdf_valid();
+			}
 			this.render_page(
 				"/api/method/frappe.utils.print_format.download_pdf?",
 				false,


### PR DESCRIPTION
Before: 

https://github.com/user-attachments/assets/4697863d-1341-4906-bca5-42ee0a5aedfd

After:

https://github.com/user-attachments/assets/bb894f4b-890e-4221-b1e2-cf5fff097e48

