### PR TITLE
fix: retain original ref, if obj is mutable

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -20,7 +20,7 @@ import frappe
 from frappe.installer import parse_app_name
 from frappe.model.document import Document
 from frappe.tests import IntegrationTestCase, MockedRequestTestCase, UnitTestCase
-from frappe.tests.utils import toggle_test_mode
+from frappe.tests.utils import toggle_test_mode, whitelist_for_tests
 from frappe.utils import (
 	ceil,
 	dict_to_str,
@@ -1332,6 +1332,27 @@ class TestTypingValidations(IntegrationTestCase):
 			pass
 
 		func(1)  # should run without error
+
+	def test_object_reference(self):
+		@whitelist_for_tests()
+		def whitelisted_func(items: list[str] | dict[str, int]):
+			if isinstance(items, list):
+				items.append("newly_added")
+			elif isinstance(items, dict):
+				items["newly_added"] = 1
+			return items
+
+		original_list = ["original_item"]
+		original_id = id(original_list)
+
+		returned_list = whitelisted_func(original_list)
+		self.assertEqual(id(returned_list), original_id)
+
+		original_dict = {"original_key": 0}
+		original_id = id(original_dict)
+
+		returned_dict = whitelisted_func(original_dict)
+		self.assertEqual(id(returned_dict), original_id)
 
 
 class TestTBSanitization(IntegrationTestCase):

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -1343,16 +1343,14 @@ class TestTypingValidations(IntegrationTestCase):
 			return items
 
 		original_list = ["original_item"]
-		original_id = id(original_list)
-
 		returned_list = whitelisted_func(original_list)
-		self.assertEqual(id(returned_list), original_id)
+
+		self.assertIs(returned_list, original_list)
 
 		original_dict = {"original_key": 0}
-		original_id = id(original_dict)
-
 		returned_dict = whitelisted_func(original_dict)
-		self.assertEqual(id(returned_dict), original_id)
+
+		self.assertIs(returned_dict, original_dict)
 
 
 class TestTBSanitization(IntegrationTestCase):

--- a/frappe/utils/typing_validations.py
+++ b/frappe/utils/typing_validations.py
@@ -188,6 +188,15 @@ def transform_parameter_types(func: Callable, args: tuple, kwargs: dict, force_t
 		if isinstance(current_arg_value_after, EllipsisType):
 			raise_type_error(func, current_arg, current_arg_type, current_arg_value)
 
+		# if mutable, maintain original reference
+		if isinstance(current_arg_value, list) and isinstance(current_arg_value_after, list):
+			current_arg_value[:] = current_arg_value_after
+			current_arg_value_after = current_arg_value
+		elif isinstance(current_arg_value, dict) and isinstance(current_arg_value_after, dict):
+			current_arg_value.clear()
+			current_arg_value.update(current_arg_value_after)
+			current_arg_value_after = current_arg_value
+
 		# update the args and kwargs with possibly casted value
 		if current_arg in kwargs:
 			new_kwargs[current_arg] = current_arg_value_after


### PR DESCRIPTION
**Before:** 

<img width="1714" height="312" alt="image" src="https://github.com/user-attachments/assets/c8e8471f-67ac-4c90-842e-8a40ee59b949" />


**After:**

<img width="1714" height="312" alt="image" src="https://github.com/user-attachments/assets/37be1de4-abac-4161-8eed-5b6621cd3169" />




closes #37449