### PR TITLE
fix: dark theme support for onboarding panel

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -43,7 +43,7 @@
 				<p>
 					<a class="onboarding-sidebar">
 						{%= frappe.utils.icon("user-check" , "sm", "", "", "text-ink-gray-7 current-color", true)%}
-						 <span> {%= __("Getting started") %} </span>
+						 <span> {%= __("Getting Started") %} </span>
 					</a>
 				</p>
 				<a class="collapse-sidebar-link">

--- a/frappe/public/js/frappe/ui/user_onboarding/OnboardingPanel.vue
+++ b/frappe/public/js/frappe/ui/user_onboarding/OnboardingPanel.vue
@@ -264,10 +264,10 @@ function markReset(step) {
 				</div>
 
 				<div v-if="skippAll">
-					<span class="onb-skip" @click="resetAll(steps)"> {{ __("Reset all") }}</span>
+					<span class="onb-skip" @click="resetAll(steps)"> {{ __("Reset All") }}</span>
 				</div>
 				<div v-else>
-					<span class="onb-skip" @click="skipAll(steps)">Skip all</span>
+					<span class="onb-skip" @click="skipAll(steps)">{{ __("Skip All") }}</span>
 				</div>
 			</div>
 

--- a/frappe/public/js/frappe/ui/user_onboarding/user_onboarding.bundle.js
+++ b/frappe/public/js/frappe/ui/user_onboarding/user_onboarding.bundle.js
@@ -215,6 +215,46 @@ function addStyles() {
 		color: #6b7280;
 		font-size: 14px;
 	}
+
+	[data-theme="dark"] .onb-panel {
+		background-color: #232323;
+		color: #e5e7eb;
+		box-shadow: 0 12px 40px rgba(0,0,0,0.6);
+	}
+
+	[data-theme="dark"] .text-base {
+		color: #e5e7eb;
+	}
+
+	[data-theme="dark"] .onb-skip {
+		color: #9ca3af;
+	}
+
+	[data-theme="dark"] .onb-skip:hover {
+		color: #f3f4f6;
+	}
+
+	[data-theme="dark"] .onb-title-steps,
+	[data-theme="dark"] .onb-progress-text {
+		color: #9ca3af;
+	}
+
+	[data-theme="dark"] .onb-group:hover {
+		background: #374151;
+		color: #f3f4f6;
+	}
+
+	[data-theme="dark"] .onb-progress-badge {
+		background: rgba(245,158,11,0.15);
+		color: #fbbf24;
+	}
+
+	[data-theme="dark"] .onb-progress-badge-complete {
+		background: rgba(16,185,129,0.15);
+		color: #34d399;
+	}
+
+
 	`;
 
 	document.head.appendChild(style);


### PR DESCRIPTION
<img width="1066" height="642" alt="image" src="https://github.com/user-attachments/assets/3584a0cc-5659-473d-a0ff-906f04dd8459" />
