### PR TITLE
fix: cast dates in print preview

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -342,7 +342,8 @@ def get_html_and_style(
 	if isinstance(name, str):
 		document = frappe.get_lazy_doc(doc, name, check_permission=True)
 	else:
-		document = frappe.get_doc(json.loads(doc), check_permission=True)
+		details = json.loads(doc)
+		document = frappe.get_cached_doc(details["doctype"], details["name"], check_permission=True)
 
 	print_format = get_print_format_doc(print_format, meta=document.meta)
 	set_link_titles(document)


### PR DESCRIPTION
Closes #17606.

When `get_doc` receives a dictionary like (`{{'name': 'SAL-ORD-2026-00001', 'doctype': 'Sales Order', ..., 'owner': 'Administrator', 'creation': '2026-02-24 15:57:10.782070', 'modified': '2026-02-24 15:57:10.782070'}`, it doesn't cast types. 

In the print preview, `get_doc(doc_details)` was used instead of `get_doc(doctype, name)`.

### Screenshots
Before:
<img width="1460" height="877" alt="image" src="https://github.com/user-attachments/assets/7751cdb6-a33d-4791-a564-a7661d5e8f3c" />

After:
<img width="1111" height="877" alt="image" src="https://github.com/user-attachments/assets/460bd4d6-9d8c-479a-b467-543237a42b2d" />
