### PR TITLE
fix: format attached_to_name file field as a link

### DIFF
--- a/frappe/core/doctype/file/file.js
+++ b/frappe/core/doctype/file/file.js
@@ -46,9 +46,9 @@ frappe.ui.form.on("File", {
 
 		if (frm.doc.attached_to_name) {
 			const field = frm.get_field("attached_to_name");
-			field.$input_wrapper.find(".control-value").html(
-				`${frappe.utils.get_form_link(frm.doctype, frm.docname, true)}`
-			);
+			field.$input_wrapper
+				.find(".control-value")
+				.html(`${frappe.utils.get_form_link(frm.doctype, frm.docname, true)}`);
 		}
 	},
 

--- a/frappe/core/doctype/file/file.js
+++ b/frappe/core/doctype/file/file.js
@@ -43,6 +43,15 @@ frappe.ui.form.on("File", {
 		if (!frappe.utils.can_upload_public_files() && frm.doc.is_private) {
 			frm.set_df_property("is_private", "read_only", 1);
 		}
+
+		if (frm.doc.attached_to_name) {
+			const field = frm.get_field("attached_to_name");
+			field.$input_wrapper.find(".control-value").html(
+				`<a href="/desk/${frm.doc.attached_to_doctype}/${frm.doc.attached_to_name}" target="_blank">
+			  ${frm.doc.attached_to_name}
+			</a>`
+			);
+		}
 	},
 
 	preview_file: function (frm) {

--- a/frappe/core/doctype/file/file.js
+++ b/frappe/core/doctype/file/file.js
@@ -47,9 +47,7 @@ frappe.ui.form.on("File", {
 		if (frm.doc.attached_to_name) {
 			const field = frm.get_field("attached_to_name");
 			field.$input_wrapper.find(".control-value").html(
-				`<a href="/desk/${frm.doc.attached_to_doctype}/${frm.doc.attached_to_name}" target="_blank">
-			  ${frm.doc.attached_to_name}
-			</a>`
+				`${frappe.utils.get_form_link(frm.doctype, frm.docname, true)}`
 			);
 		}
 	},


### PR DESCRIPTION
Closes #27297

### Screenshots
Before:
<img width="784" height="91" alt="image" src="https://github.com/user-attachments/assets/b8947675-58cb-4f7c-8578-4fe0115a1c19" />

After:
<img width="817" height="466" alt="image" src="https://github.com/user-attachments/assets/2e100f03-f5a6-4352-a44d-9305d7b81eb9" />
