### PR TITLE
fix: exclude print_format_builder print formats from weasyprint processing in email-attached PDFs

### DIFF
--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -139,7 +139,7 @@ def attach_print(
 		print_format_doc = frappe.get_cached_doc("Print Format", print_format)
 		is_weasyprint_print_format = not (
 			print_format_doc.custom_format
-			or print_format_doc.print_format_builder
+			or print_format_doc.get("print_format_builder")
 			or print_format_doc.get("print_designer_print_format")
 		)
 

--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -138,7 +138,9 @@ def attach_print(
 	if print_format and print_format != "Standard":
 		print_format_doc = frappe.get_cached_doc("Print Format", print_format)
 		is_weasyprint_print_format = not (
-			print_format_doc.custom_format or print_format_doc.get("print_designer_print_format")
+			print_format_doc.custom_format
+			or print_format_doc.print_format_builder
+			or print_format_doc.get("print_designer_print_format")
 		)
 
 	with print_language(lang or frappe.local.lang):


### PR DESCRIPTION
- fix: exclude print_format_builder print formats from weasyprint processing in email-attached PDFs
- refactor: safer property access

<hr>

After #35525, attached PDFs sent in an email throw an error if the print format is print_format_builder. This change has already been backported to version-16 in #36908 and there is an open PR #37004 to manually backport it into version-15.

This PR is a proposed fix, excluding print_formats created in Print Format Builder from weasyprint.py processing. It "works for me". But it raises the question- are there any print format types left that will actually trigger the logic added in 35525? @Rl0007, can you tell me your thoughts? Is this the right direction or does something in weasyprint.py need to be fixed?

Closes #37034
