### PR TITLE
fix: make percent precision dynamic

### DIFF
--- a/frappe/public/js/frappe/form/controls/control.js
+++ b/frappe/public/js/frappe/form/controls/control.js
@@ -3,6 +3,7 @@ import "./base_input";
 import "./data";
 import "./int";
 import "./float";
+import "./percent";
 import "./currency";
 import "./date";
 import "./time";

--- a/frappe/public/js/frappe/form/controls/float.js
+++ b/frappe/public/js/frappe/form/controls/float.js
@@ -29,4 +29,16 @@ frappe.ui.form.ControlFloat = class ControlFloat extends frappe.ui.form.ControlI
 	}
 };
 
-frappe.ui.form.ControlPercent = frappe.ui.form.ControlFloat;
+frappe.ui.form.ControlPercent = class ControlPercent extends frappe.ui.form.ControlFloat {
+	format_for_input(value) {
+		if (value === null || value === undefined || isNaN(Number(value))) {
+			return "";
+		}
+		const precision = value.toString().split(".")[1]?.length || 0;
+		return format_number(
+			value,
+			this.get_number_format(),
+			Math.min(this.get_precision(), precision)
+		);
+	}
+};

--- a/frappe/public/js/frappe/form/controls/float.js
+++ b/frappe/public/js/frappe/form/controls/float.js
@@ -28,17 +28,3 @@ frappe.ui.form.ControlFloat = class ControlFloat extends frappe.ui.form.ControlI
 		return this.df.precision || cint(frappe.boot.sysdefaults.float_precision, null);
 	}
 };
-
-frappe.ui.form.ControlPercent = class ControlPercent extends frappe.ui.form.ControlFloat {
-	format_for_input(value) {
-		if (value === null || value === undefined || isNaN(Number(value))) {
-			return "";
-		}
-		const precision = value.toString().split(".")[1]?.length || 0;
-		return format_number(
-			value,
-			this.get_number_format(),
-			Math.min(this.get_precision(), precision)
-		);
-	}
-};

--- a/frappe/public/js/frappe/form/controls/percent.js
+++ b/frappe/public/js/frappe/form/controls/percent.js
@@ -1,0 +1,13 @@
+frappe.ui.form.ControlPercent = class ControlPercent extends frappe.ui.form.ControlFloat {
+	format_for_input(value) {
+		if (value === null || value === undefined || isNaN(Number(value))) {
+			return "";
+		}
+		const precision = value.toString().split(".")[1]?.length || 0;
+		return format_number(
+			value,
+			this.get_number_format(),
+			Math.min(this.get_precision(), precision)
+		);
+	}
+};

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -94,12 +94,15 @@ frappe.form.formatters = {
 		if (value === null) {
 			return "";
 		}
-
+		const valuePrecision = value.toString().split(".")[1]?.length || 0;
 		const precision =
 			docfield.precision ||
 			cint(frappe.boot.sysdefaults && frappe.boot.sysdefaults.float_precision) ||
 			2;
-		return frappe.form.formatters._right(format_number(value, null, precision) + "%", options);
+		return frappe.form.formatters._right(
+			format_number(value, null, Math.min(precision, valuePrecision)) + "%",
+			options
+		);
 	},
 	Rating: function (value, docfield) {
 		let rating_html = "";


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/14629

Uses the least precision possible.

```
49 --> 49
49.00 -> 49
49.01 -> 49.01
49.0001 -> 49 # assuming float precision is set to 3
```

Also probably need to show percent sign? 