### PR TITLE
fix: handle None fraction_currency in money_in_words

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1563,7 +1563,7 @@ def money_in_words(
 			out = in_words(main, in_million).title() + " " + _("Dinars", context="Currency")
 		else:
 			out = _(main_currency, context="Currency") + " " + in_words(main, in_million).title()
-		if cint(fraction):
+		if cint(fraction) and fraction_currency:
 			out = out + " " + _("and") + " " + fraction_in_words() + " " + fraction_currency
 
 	if main_currency == "DZD":


### PR DESCRIPTION
closes #37394 

## Summary
Fix money_in_words to handle a None fraction_currency by treating it as missing and zeroing fraction units, preventing string concatenation errors.

<h2>Root Cause</h2>
<p>In <code>frappe/utils/data.py</code>, the <code>fraction_currency</code> is fetched as:</p>
<pre><code class="language-python">fraction_currency = frappe.db.get_value("Currency", main_currency, "fraction", cache=True)
</code></pre>
<p>This returns <code>None</code> for the 20 affected currencies because <code>country_info.json</code> is missing the <code>currency_fraction</code> key for them. The existing guard:</p>
<pre><code class="language-python">elif not fraction_units or not fraction_currency:
    fraction_units = fraction_length = 0
</code></pre>
<p>doesn't catch the case where <code>fraction_units</code> is set but <code>fraction_currency</code> is <code>None</code>, so <code>fraction_currency</code> remains <code>None</code> and the concatenation crashes.</p>
<hr>

<p><strong>Guard against <code>None</code> in <code>money_in_words</code></p>
<pre><code class="language-python"># Before
if cint(fraction):
    out = out + " " + _("and") + " " + fraction_in_words() + " " + fraction_currency

<code class="language-python"># After
if cint(fraction) and fraction_currency:
    out = out + " " + _("and") + " " + fraction_in_words() + " " + fraction_currency
</code></pre>