### PR TITLE
fix: onboarding panel UI issues

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -163,6 +163,10 @@ frappe.ui.Sidebar = class Sidebar {
 	remove_onboarding_wrapper() {
 		this.$onboarding.empty();
 		this.wrapper.find(".onboarding-sidebar").removeClass("hidden");
+
+		if (!this.sidebar_data?.module_onboarding) {
+			this.wrapper.find(".onboarding-sidebar").addClass("hidden");
+		}
 	}
 
 	setup_onboarding() {

--- a/frappe/public/js/frappe/ui/user_onboarding/OnboardingPanel.vue
+++ b/frappe/public/js/frappe/ui/user_onboarding/OnboardingPanel.vue
@@ -235,7 +235,7 @@ function markReset(step) {
 		<!-- Header -->
 
 		<div class="header onb-header-main">
-			<div class="text-base font-medium">Getting started</div>
+			<div class="text-base font-medium">{{ __("Getting Started") }}</div>
 			<div class="onb-header-actions">
 				<button @click="toggleCollapse" v-html="minimizeIcon"></button>
 				<button @click="close" v-html="closeIcon"></button>
@@ -249,7 +249,7 @@ function markReset(step) {
 				<div class="text-base font-medium">{{ title }}</div>
 
 				<div class="onb-title-steps">
-					{{ completedCount }}/{{ steps.length }} steps completed
+					{{ completedCount }}/{{ steps.length }} {{ __("steps completed") }}
 				</div>
 			</div>
 
@@ -297,8 +297,11 @@ function markReset(step) {
 							</div>
 
 							<div v-if="!step.is_skipped">
-								<span class="text-base onb-step-text">
-									{{ step.action_label }}
+								<span
+									class="text-base onb-step-text"
+									:class="step.is_complete ? 'text-extra-muted' : ''"
+								>
+									{{ __(step.action_label) }}
 								</span>
 							</div>
 							<div v-else>
@@ -306,7 +309,7 @@ function markReset(step) {
 									class="text-base onb-step-text"
 									style="text-decoration-line: line-through"
 								>
-									{{ step.action_label }}
+									{{ __(step.action_label) }}
 								</span>
 							</div>
 						</div>

--- a/frappe/public/js/frappe/ui/user_onboarding/user_onboarding.bundle.js
+++ b/frappe/public/js/frappe/ui/user_onboarding/user_onboarding.bundle.js
@@ -67,7 +67,7 @@ function addStyles() {
 		position: fixed;
 		right: 24px;
 		bottom: 24px;
-		width: 380px;
+		width: 310px;
 		max-height: 80vh;
 		background: #fff;
 		border-radius: 16px;


### PR DESCRIPTION
- [x] Getting Started in title case
- [x] Muted colour for completed tasks?
- [x] Hide getting started from the sidebar if it does not exist
- [x] Reduce width for the widget.

Fixed https://github.com/frappe/frappe/issues/37537