### PR TITLE
fix(minor): folder icon styles

### DIFF
--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -2,7 +2,7 @@
     --desktop-blur: blur(10.2px);
     --desktop-modal-width: 590px;
     --desktop-modal-height: 450px;
-    --folder-thumbnail-icon-height: 12px;
+    --folder-thumbnail-icon-height: 16px;
     --desktop-icon-dimension: 54px;
     --folder-icon-background-color: var(--surface-gray-1);
     --desktop-modal-radius: 30px;
@@ -368,7 +368,7 @@
   :root {
     --desktop-icon-dimension: 50px;
     --desktop-icon-container: 117px;
-    --folder-thumbnail-icon-height:17px;
+    --folder-thumbnail-icon-height:15px;
   }
 
   .desktop-container {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -1086,11 +1086,6 @@ class DesktopIcon {
 			this.folder_grid = new DesktopIconGrid({
 				wrapper: this.folder_wrapper,
 				icons_data: this.child_icons,
-				row_size: 3,
-				page_size: {
-					row: 3,
-					col: 3,
-				},
 				in_folder: true,
 				in_modal: false,
 				no_dragging: true,


### PR DESCRIPTION
Before
<img width="146" height="148" alt="Screenshot 2026-02-25 at 5 35 04 PM" src="https://github.com/user-attachments/assets/411a9cac-e66a-4b88-a226-1fc227a324cc" />



After
<img width="145" height="142" alt="Screenshot 2026-02-25 at 5 33 21 PM" src="https://github.com/user-attachments/assets/4a415762-a224-4ba6-8c97-97684eba762d" />
