### PR TITLE
fix: jump to field vertical scroll for readonly & other non-focusable fields

### DIFF
--- a/cypress/integration/web_form.js
+++ b/cypress/integration/web_form.js
@@ -27,7 +27,9 @@ context("Web Form", () => {
 
 		cy.wait("@save_form");
 
+		cy.get('.frappe-control[data-fieldname="route"]').scrollIntoView();
 		cy.get_field("route").should("have.value", "note");
+
 		cy.get(".title-area .indicator-pill")
 			.should("contain.text", "Published")
 			.should("have.class", "green");

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -2083,7 +2083,7 @@ frappe.ui.form.Form = class FrappeForm {
 		}
 
 		// scroll to input
-		frappe.utils.scroll_to($el, true, 15);
+		frappe.utils.scroll_to($el, true, 15, $(".main-section"));
 
 		// focus if text field
 		if (focus) {

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -328,7 +328,7 @@ Object.assign(frappe.utils, {
 			scroll_top =
 				typeof element == "number"
 					? element - cint(additional_offset)
-					: this.get_scroll_position(element, element_to_be_scrolled, additional_offset);
+					: this.get_scroll_position(element, additional_offset, element_to_be_scrolled);
 		}
 
 		if (scroll_top < 0) {
@@ -366,8 +366,8 @@ Object.assign(frappe.utils, {
 			element_to_be_scrolled.scrollTop(scroll_top);
 		}
 	},
-	get_scroll_position: function (element, element_to_be_scrolled, additional_offset) {
-		function getOffsetRelativeToContainer() {
+	get_scroll_position: function (element, additional_offset, element_to_be_scrolled) {
+		const get_offset_relative_to_container = () => {
 			let offset = 0;
 
 			let el = element instanceof HTMLElement ? element : element[0];
@@ -379,12 +379,19 @@ Object.assign(frappe.utils, {
 			}
 
 			return offset;
-		}
+		};
 
-		const navbar_height = $(".navbar").height() || 0;
-		const page_head_height = $(".page-head:visible").height() || 0;
-		const header_offset = navbar_height + page_head_height;
-		const element_offset_top = getOffsetRelativeToContainer();
+		const get_header_offset = () => {
+			const navbar_height = $(".navbar").height() || 0;
+			const page_head_height = $(".page-head:visible").height() || 0;
+			const tabs_container_height = $(".form-tabs-list:visible").height() || 0;
+
+			return navbar_height + page_head_height + tabs_container_height;
+		};
+
+		const element_offset_top = get_offset_relative_to_container();
+		const header_offset = get_header_offset();
+
 		return element_offset_top - header_offset - cint(additional_offset);
 	},
 	filter_dict: function (dict, filters) {

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -328,7 +328,7 @@ Object.assign(frappe.utils, {
 			scroll_top =
 				typeof element == "number"
 					? element - cint(additional_offset)
-					: this.get_scroll_position(element, additional_offset);
+					: this.get_scroll_position(element, element_to_be_scrolled, additional_offset);
 		}
 
 		if (scroll_top < 0) {
@@ -366,10 +366,26 @@ Object.assign(frappe.utils, {
 			element_to_be_scrolled.scrollTop(scroll_top);
 		}
 	},
-	get_scroll_position: function (element, additional_offset) {
-		let header_offset =
-			$(".navbar").height() + $(".page-head:visible").height() || $(".navbar").height();
-		return $(element).offset().top - header_offset - cint(additional_offset);
+	get_scroll_position: function (element, element_to_be_scrolled, additional_offset) {
+		function getOffsetRelativeToContainer() {
+			let offset = 0;
+
+			let el = element instanceof HTMLElement ? element : element[0];
+			const container = element_to_be_scrolled ? element_to_be_scrolled[0] : null;
+
+			while (el && el !== container && el.offsetParent) {
+				offset += el.offsetTop;
+				el = el.offsetParent;
+			}
+
+			return offset;
+		}
+
+		const navbar_height = $(".navbar").height() || 0;
+		const page_head_height = $(".page-head:visible").height() || 0;
+		const header_offset = navbar_height + page_head_height;
+		const element_offset_top = getOffsetRelativeToContainer();
+		return element_offset_top - header_offset - cint(additional_offset);
 	},
 	filter_dict: function (dict, filters) {
 		var ret = [];

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -779,7 +779,7 @@
 .data-row.row {
 	flex-wrap: nowrap;
 }
-.frappe-control[data-fieldtype="Table"].form-group:has(.column-limit-reached) {
+.frappe-control[data-fieldtype="Table"].form-group:has(.column-limit-reached):not(.highlight) {
 	overflow-x: clip;
 }
 .column-limit-reached {


### PR DESCRIPTION
### Summary
Since the scrollable container for form fields is now different (`.main-section`) instead of the body container itself, jumping to form fields that require vertical scrolling breaks. 

### Flow
- Form tries to call `scroll_to` with no explicit container div set and the function defaults to the body when no container is passed. 
- Scrolling is attempted on the wrong container.
- No scroll behaviour triggers. 
- Although vertical scroll breaks, the Jump To Field feature tries to focus on the field we scrolled to. On doing that, the default scroll behaviour is triggered for "focusable fields". The offset and it's expected position mentioned explicitly are not respected but browser default scrolling kind of takes care of at least putting the element in view.
- But any fields we can't focus on like Readonly Fields / Tables, Attach Image fields etc. don't get this benefit and vertical scroll just fails for them. 

### Fix
- Scroll using the correct scrollable container for form fields.
- Calculate the vertical offset correctly based on current scroll position.

<br>

### Before

https://github.com/user-attachments/assets/1ef20e60-64fc-41be-a672-9dd4849a1e14

<br>


### After


https://github.com/user-attachments/assets/7a9b6bcc-988c-4b46-8929-6ebd5f2567fb



-----


#### Related Fix
Highlight for grid when focused was getting clipped on the X axis so fixed that.

Before
<img width="969" height="250" alt="Screenshot 2026-02-25 at 8 23 20 PM" src="https://github.com/user-attachments/assets/b9274e8f-3c58-479e-aef7-fd50f3e19183" />

After
<img width="948" height="237" alt="Screenshot 2026-02-25 at 8 23 53 PM" src="https://github.com/user-attachments/assets/98ded5d5-0060-432d-bdb7-db04feed25b0" />


Closes #37497 
