### PR TITLE
fix: Add translation for labels in print format templates

### DIFF
--- a/frappe/templates/print_format/macros/AttachImage.html
+++ b/frappe/templates/print_format/macros/AttachImage.html
@@ -2,6 +2,6 @@
 
 {%- block value -%}
 <div class="value">
-    <img class="w-100" src="{{ value }}" alt="{{ df.label }}">
+    <img class="w-100" src="{{ value }}" alt="{{ _(df.label) }}">
 </div>
 {%- endblock -%}

--- a/frappe/templates/print_format/macros/Data.html
+++ b/frappe/templates/print_format/macros/Data.html
@@ -1,7 +1,7 @@
 {% if value %}
 <div class="field {{ df.section.field_orientation or '' }}" {{ field_attributes(df) }}>
 	{%- block label -%}
-	<div class="label">{{ df.label }}</div>
+	<div class="label">{{ _(df.label) }}</div>
 	{%- endblock -%}
 	{%- block value -%}
 	<div class="value">{{ doc.get_formatted(df.fieldname) }}</div>

--- a/frappe/templates/print_format/macros/Signature.html
+++ b/frappe/templates/print_format/macros/Signature.html
@@ -2,6 +2,6 @@
 
 {%- block value -%}
 <div class="value">
-    <img src="{{ value }}" alt="{{ df.label }}">
+    <img src="{{ value }}" alt="{{ _(df.label) }}">
 </div>
 {%- endblock -%}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -1,7 +1,7 @@
 {% if doc.get(df.fieldname) %}
 <div class="child-table" {{ field_attributes(df) }}>
 	<div class="label">
-		{{ df.label }}
+		{{ _(df.label) }}
 	</div>
 	<table class="table table-bordered">
 		{% set columns = df.table_columns %}
@@ -9,7 +9,7 @@
 			<tr class="table-row">
 				{% for column in columns %}
 				<th class="column-header" width="{{ column.width }}%" {{ field_attributes(column) }}>
-					{{ column.label }}
+					{{ _(column.label) }}
 				</th>
 				{% endfor %}
 			</tr>

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -21,7 +21,7 @@
 	{% for section in layout.sections %}
 	<div class="section {{ resolve_class({'page-break': section.page_break}) }}">
 		{% if section.label %}
-		<div class="section-label">{{ section.label }}</div>
+		<div class="section-label">{{ _(section.label) }}</div>
 		{% endif %}
 
 		<div class="section-columns row">


### PR DESCRIPTION
## Fix: Child table titles not translating in notification print attachments

**Issue:** When using a custom/WeasyPrint print format in a specific language, child table section titles and column headers were not translated in notification email attachments (e.g. PDF), while they were correct when printing from the UI ([#27880](https://github.com/frappe/frappe/issues/27880)).

**Cause:** Print format templates (`print_format/macros/Table.html`, `Data.html`, `print_format.html`, etc.) output labels as `{{ df.label }}` / `{{ column.label }}` / `{{ section.label }}` without the translation function, so they were never passed through `_()` even when `print_language(lang)` was set for notifications.

**Fix:** Wrap these labels with the translation function (`_(df.label)`, `_(column.label)`, `_(section.label)`) in the affected templates so notification attachments respect the notification/document print language.

Screenshots :

before:
[TestUser-TranslationTest3-00001.pdf](https://github.com/user-attachments/files/25549567/TestUser-TranslationTest3-00001.pdf)

after:
[TestUser-TranslationTest2-00001.pdf](https://github.com/user-attachments/files/25549568/TestUser-TranslationTest2-00001.pdf)
