### PR TITLE
fix: business hours in popup,theme and apps for which to show

### DIFF
--- a/frappe/public/js/billing.bundle.js
+++ b/frappe/public/js/billing.bundle.js
@@ -89,13 +89,17 @@ function openFrappeCloudDashboard() {
 }
 
 function addChatBubble() {
-	if (checkBusinessHours()) {
+	const all_apps = frappe.utils.get_installed_apps();
+	const desk_apps = ["erpnext", "hrms"];
+
+	const apps_allowed = frappe.utils.is_sub_array(all_apps, desk_apps);
+	if (checkBusinessHours && apps_allowed) {
 		let chat_banner = document.createElement("script");
 		chat_banner.innerHTML =
 			'(function(d,t){var BASE_URL="https://chat.frappe.cloud";var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.src=BASE_URL+"/packs/js/sdk.js";g.async=true;s.parentNode.insertBefore(g,s);g.onload=function(){window.chatwootSDK.run({websiteToken:"LdmfJzftdJGEcFjoTqk8CrSq",baseUrl:BASE_URL})}})(document,"script");';
 		document.body.append(chat_banner);
 		const root = document.documentElement;
-		root.style.setProperty("--s-700", "var(--gray-50)");
+		root.style.setProperty("--s-700", "var(--gray-500)");
 	}
 }
 
@@ -103,5 +107,5 @@ function checkBusinessHours() {
 	let currentTime = new Date();
 	const istTime = new Date(currentTime.toLocaleString("en-US", { timeZone: "Asia/Kolkata" }));
 
-	return istTime.getHours() >= 11 && istTime.getHours() <= 18;
+	return istTime.getHours() >= 11 && istTime.getHours() < 18;
 }

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -2229,4 +2229,16 @@ Object.assign(frappe.utils, {
 		}
 		return value;
 	},
+	get_installed_apps() {
+		return frappe.boot.app_data.map((app) => {
+			return app.app_name;
+		});
+	},
+	is_sub_array(big, small) {
+		let i = 0;
+		for (let num of big) {
+			if (num === small[i]) i++;
+		}
+		return i === small.length;
+	},
 });


### PR DESCRIPTION
White fill on chat bubble was looking bad and stroke was looking more bad
So settling with this for now. Customizing this is hard as the ui is very delicate. Changing one thing breaks other things

<img width="1440" height="754" alt="Screenshot 2026-02-26 at 1 38 09 AM" src="https://github.com/user-attachments/assets/a7991a5a-68d5-4b05-a32b-def2e043c0cf" />
