### PR TITLE
fix(invitation): add **kwargs param to invite_user API to add app specific fields

### DIFF
--- a/frappe/core/api/user_invitation.py
+++ b/frappe/core/api/user_invitation.py
@@ -6,7 +6,7 @@ from frappe.core.doctype.user_invitation.user_invitation import UserInvitation
 
 @frappe.whitelist(methods=["POST"])
 def invite_by_email(
-	emails: str, roles: list[str], redirect_to_path: str, app_name: str = "frappe"
+	emails: str, roles: list[str], redirect_to_path: str, app_name: str = "frappe", **args
 ) -> dict[str, list[str]]:
 	UserInvitation.validate_role(app_name)
 
@@ -49,6 +49,7 @@ def invite_by_email(
 			roles=[dict(role=role) for role in roles],
 			app_name=app_name,
 			redirect_to_path=redirect_to_path,
+			**args,
 		).insert(ignore_permissions=True)
 
 	return {

--- a/frappe/core/api/user_invitation.py
+++ b/frappe/core/api/user_invitation.py
@@ -66,9 +66,10 @@ def invite_by_email(
 def get_allowed_invite_params(app_name: str, kwargs: dict) -> dict:
 	# get extra args based on app_name
 	allowed_params = frappe._dict()
-	extra_invite_params = frappe.get_hooks("user_invitation", app_name=app_name).get(
-		"extra_invite_params", []
-	)
+	user_invitation_hook = frappe.get_hooks("user_invitation", app_name=app_name)
+	if not isinstance(user_invitation_hook, dict):
+		return {}
+	extra_invite_params = user_invitation_hook.get("extra_invite_params", [])
 	for param in extra_invite_params:
 		if param in kwargs:
 			allowed_params[param] = kwargs[param]

--- a/frappe/core/api/user_invitation.py
+++ b/frappe/core/api/user_invitation.py
@@ -6,7 +6,7 @@ from frappe.core.doctype.user_invitation.user_invitation import UserInvitation
 
 @frappe.whitelist(methods=["POST"])
 def invite_by_email(
-	emails: str, roles: list[str], redirect_to_path: str, app_name: str = "frappe", **args
+	emails: str, roles: list[str], redirect_to_path: str, app_name: str = "frappe", **kwargs
 ) -> dict[str, list[str]]:
 	UserInvitation.validate_role(app_name)
 
@@ -42,6 +42,9 @@ def invite_by_email(
 	to_invite = list(
 		set(email_list) - set(disabled_user_emails) - set(accepted_invite_emails) - set(pending_invite_emails)
 	)
+
+	extra_args = get_allowed_invite_params(app_name, kwargs)
+
 	for email in to_invite:
 		frappe.get_doc(
 			doctype="User Invitation",
@@ -49,7 +52,7 @@ def invite_by_email(
 			roles=[dict(role=role) for role in roles],
 			app_name=app_name,
 			redirect_to_path=redirect_to_path,
-			**args,
+			**extra_args,
 		).insert(ignore_permissions=True)
 
 	return {
@@ -58,6 +61,18 @@ def invite_by_email(
 		"pending_invite_emails": pending_invite_emails,
 		"invited_emails": to_invite,
 	}
+
+
+def get_allowed_invite_params(app_name: str, kwargs: dict) -> dict:
+	# get extra args based on app_name
+	allowed_params = frappe._dict()
+	extra_invite_params = frappe.get_hooks("user_invitation", app_name=app_name).get(
+		"extra_invite_params", []
+	)
+	for param in extra_invite_params:
+		if param in kwargs:
+			allowed_params[param] = kwargs[param]
+	return allowed_params
 
 
 @frappe.whitelist(allow_guest=True, methods=["GET"])

--- a/frappe/core/doctype/user_invitation/internal_doc/index.md
+++ b/frappe/core/doctype/user_invitation/internal_doc/index.md
@@ -28,6 +28,10 @@ Define user invitation hooks in your app's `hooks.py` file. An example is shown 
 
   A map of `only_for` roles to a list of roles that are allowed to be invited to your app.
 
+- `extra_invite_params`
+
+  A list of additional parameters that can be passed when creating a user invitation. Optional parameter.
+
 - `after_accept`
 
   Dot path of the function to execute after the user accepts the invitation.


### PR DESCRIPTION
**Issue:**
We have an api called `invite_by_email`, which accepts only four params.

But the User Invitation doctype can have some App specific fields.
We need a way to store the data in additional fields while inviting a user.


**Solution:**

add **kargs in the api to store data in custom fields created by the app.

By hooks get `extra_invite_params` from "user_invitation_hook", which will filter out the **kwargs
