### PR TITLE
fix: disable chat popup

### DIFF
--- a/frappe/public/js/billing.bundle.js
+++ b/frappe/public/js/billing.bundle.js
@@ -32,9 +32,6 @@ $(document).ready(function () {
 			!!frappe.boot.setup_complete &&
 			!frappe.is_mobile() &&
 			frappe.user.has_role("System Manager");
-		if (visiblity_condition && isFCUser) {
-			addChatBubble();
-		}
 		if (isFCUser) {
 			$.extend(card_args, {
 				primary_action_label: "Upgrade",


### PR DESCRIPTION
Onboarding widget and chat popup interfere and lead to more confusion for the end user. 
Disable chat widget for now