### PR TITLE
fix: use scroll_to param in URL strictly for fields

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1574,15 +1574,10 @@ frappe.ui.form.Form = class FrappeForm {
 			var scroll_to = frappe.route_options.scroll_to;
 			delete frappe.route_options.scroll_to;
 
-			var selector = [];
-			for (var key in scroll_to) {
-				var value = scroll_to[key];
-				selector.push(repl('[data-%(key)s="%(value)s"]', { key: key, value: value }));
-			}
-
-			selector = $(selector.join(" "));
-			if (selector.length) {
-				frappe.utils.scroll_to(selector);
+			if (this.scroll_to_field(scroll_to)) {
+				const url = new URL(window.location);
+				url.searchParams.delete("scroll_to");
+				history.replaceState(null, null, url);
 			}
 		} else if (window.location.hash) {
 			if ($(window.location.hash).length) {


### PR DESCRIPTION


Although **#fieldname** in route url works rn, the **scroll_to=fieldname** is still broken. 

### Fix
- Use `scroll_to` param strictly for scrolling to fields similar to `#fieldname`.
- After scrolling to the field, remove the param from `route_options` as well as current URL.
- In order to scroll to HTML elements using their ID we already check for those while parsing the correct place to scroll to in the `window.location.hash` block.


### Before

https://github.com/user-attachments/assets/4a2b8f68-724d-4a49-91b2-ce77376e8183

<br>

### After


https://github.com/user-attachments/assets/5e636cd8-f09b-42db-85d8-14acc24e55ad





Closes https://github.com/frappe/frappe/issues/32883