### PR TITLE
fix: text muted for skipped steps

### DIFF
--- a/frappe/public/js/frappe/ui/user_onboarding/OnboardingPanel.vue
+++ b/frappe/public/js/frappe/ui/user_onboarding/OnboardingPanel.vue
@@ -306,7 +306,7 @@ function markReset(step) {
 							</div>
 							<div v-else>
 								<span
-									class="text-base onb-step-text"
+									class="text-base onb-step-text text-extra-muted"
 									style="text-decoration-line: line-through"
 								>
 									{{ __(step.action_label) }}


### PR DESCRIPTION
<img width="370" height="453" alt="Screenshot 2026-02-26 at 1 58 23 PM" src="https://github.com/user-attachments/assets/e4dfbf6d-f7e9-4aa1-ab94-55c67f1de075" />
