### PR TITLE
fix: prevent focus on empty mandatory field on save

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -231,7 +231,7 @@ frappe.ui.form.check_mandatory = function (frm) {
 	}
 
 	function scroll_to(fieldname) {
-		if (frm.scroll_to_field(fieldname)) {
+		if (frm.scroll_to_field(fieldname, false)) {
 			frm.scroll_set = true;
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/37428

Prevents autofocus for all fields, not just date. Defocusing out of the warning (Mandatory fields required) dialog, would remove focus from the field as well, making the autofocus pointless anyway.