### PR TITLE
fix(Number Card): remove restriction on Currency based aggregation

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -124,11 +124,6 @@ frappe.ui.form.on("Number Card", {
 			frappe.model.with_doctype(doctype, () => {
 				frappe.get_meta(doctype).fields.map((df) => {
 					if (frappe.model.numeric_fieldtypes.includes(df.fieldtype)) {
-						if (df.fieldtype == "Currency") {
-							if (!df.options || df.options !== "Company:company:default_currency") {
-								return;
-							}
-						}
 						aggregate_based_on_fields.push({ label: df.label, value: df.fieldname });
 					}
 				});


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/18611

Probably makes sense to go ahead with the '[easy solution](https://github.com/frappe/frappe/issues/18611#issuecomment-1527434098)'. If users need exchange rate conversion, they can:
- Apply appropriate filters (e.g., filter to one currency)
- Handle conversion in their app logic before aggregation
