### PR TITLE
fix: save issue with paginated grid

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -745,7 +745,7 @@ frappe.ui.form.Layout = class Layout {
 
 			if (f.df.fieldtype === "Table") {
 				for (const row of f.grid?.grid_rows || []) {
-					row?.refresh_dependency?.();
+					row?.refresh_dependency();
 				}
 			}
 		}

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -745,7 +745,7 @@ frappe.ui.form.Layout = class Layout {
 
 			if (f.df.fieldtype === "Table") {
 				for (const row of f.grid?.grid_rows || []) {
-					row.refresh_dependency();
+					row?.refresh_dependency?.();
 				}
 			}
 		}


### PR DESCRIPTION
Closes #36690

If users navigate in a grid with pagination (`max_grid_length` set), saving fails - caused by https://github.com/frappe/frappe/pull/36091/.

This is because rows are deleted if they're not being viewed right now...
<img width="489" height="167" alt="image" src="https://github.com/user-attachments/assets/d63a6db4-e4e3-4bb1-af47-c62e28d037ca" />

... but saving goes through every row and refreshes dependences. 

This PR only refreshes dependencies of the visible rows (which is how it is meant to be). 

Needs to be backported to both v15 and v16.