### PR TITLE
fix: attachment links with web URL fragments

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -180,8 +180,18 @@ frappe.ui.form.Attachments = class Attachments {
 				file_url = "/files/" + attachment.file_name;
 			}
 		}
+
+		const is_web_url = /^(https?:)?\/\//i.test(file_url);
+
+		file_url = encodeURI(file_url);
+
 		// hash is not escaped, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
-		return encodeURI(file_url).replace(/#/g, "%23");
+		// only encode hash if it's a local file path, not a web URL
+		if (!is_web_url) {
+			file_url = file_url.replace(/#/g, "%23");
+		}
+
+		return file_url;
 	}
 	get_file_id_from_file_url(file_url) {
 		var fid;


### PR DESCRIPTION
### Bug
Opening attachments to a document from the right sidebar breaks if a Web link is added with a hash used for fragments etc. 

### Fix
Instead of blindly replacing `#` in the file url with `%23` which is needed for local file paths, check if the url needs it. If the file url is a web link skip that step so URL fragments work as expected.

### Before

Added two attachments:
- First is a web link to: https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf#section1
- Second is a normal uploaded image with # in the name

<br>

https://github.com/user-attachments/assets/a0f4713c-470b-46a5-b139-865bf0fb5904



<br>

### After

https://github.com/user-attachments/assets/83e1c5db-0c45-4f44-95b7-faf7df370ccf


Closes #18607