### PR TITLE
fix: Limit storage usage report to current schema

### DIFF
--- a/frappe/core/report/database_storage_usage_by_tables/database_storage_usage_by_tables.py
+++ b/frappe/core/report/database_storage_usage_by_tables/database_storage_usage_by_tables.py
@@ -22,6 +22,7 @@ def execute(filters=None):
 						round((data_length / 1024 / 1024), 2) as data_size,
 						round((index_length / 1024 / 1024), 2) as index_size
 				FROM information_schema.TABLES
+				WHERE table_schema = DATABASE()
 				ORDER BY (data_length + index_length) DESC;
 			""",
 			"postgres": """


### PR DESCRIPTION
For deployments where permissions somehow allow reading other schemas.


https://github.com/frappe/frappe/issues/37585