### PR TITLE
fix(Chart Widget): render chart legend appropriately on applying filter

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -570,7 +570,13 @@ export default class ChartWidget extends Widget {
 		let setup_dashboard_chart = () => {
 			const chart_args = this.get_chart_args();
 
+			const is_circular_chart = ["Pie", "Donut", "Percentage"].includes(this.chart_doc.type);
+
 			if (!this.dashboard_chart) {
+				this.dashboard_chart = frappe.utils.make_chart(this.chart_wrapper[0], chart_args);
+			} else if (is_circular_chart) {
+				this.chart_wrapper.empty();
+				delete this.dashboard_chart;
 				this.dashboard_chart = frappe.utils.make_chart(this.chart_wrapper[0], chart_args);
 			} else {
 				this.dashboard_chart.update(this.data);
@@ -619,6 +625,7 @@ export default class ChartWidget extends Widget {
 			colors: colors,
 			height: this.height,
 			maxSlices: this.chart_doc.number_of_groups || max_slices,
+			truncateLegends: 0,
 			axisOptions: {
 				xIsSeries: this.chart_doc.timeseries,
 				shortenYAxisNumbers: 1,


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/15898

Updates legend to match colour in chart on applying filter by recreating the chart altogether.

https://github.com/user-attachments/assets/e0d560fe-6bac-4921-bb92-ae2d88d6cca6

IMO, it makes sense for the filtered value to show at the beginning of the legend and for other values to be hidden as they are no longer in the chart.