### PR TITLE
fix: enforce link_filters on link fields server-side

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -465,7 +465,7 @@ def validate_link_and_fetch(
 	)
 
 	if not search_result:
-		return {}
+		return {}  # Either the record does not exist or was excluded by link_filters
 
 	values = None
 	is_virtual_dt = bool(meta.get("is_virtual"))

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -465,7 +465,7 @@ def validate_link_and_fetch(
 	)
 
 	if not search_result:
-		return {}  # does not exist or filtered out
+		return {}
 
 	values = None
 	is_virtual_dt = bool(meta.get("is_virtual"))

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -870,7 +870,6 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 	validate_link_and_fetch(value) {
 		const args = this.get_search_args(value);
 		if (!args) return;
-		const has_filters = !!(args.filters && Object.keys(args.filters).length);
 
 		const columns_to_fetch = Object.values(this.fetch_map);
 
@@ -939,6 +938,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			.then((response) => {
 				if (!response) return;
 
+				const has_filters = !!(args.filters && Object.keys(args.filters).length);
 				if (!response.name && has_filters) {
 					frappe.show_alert({
 						message: __("{0}: {1} did not match any results.", [

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -870,6 +870,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 	validate_link_and_fetch(value) {
 		const args = this.get_search_args(value);
 		if (!args) return;
+		const has_filters = !!(args.filters && Object.keys(args.filters).length);
 
 		const columns_to_fetch = Object.values(this.fetch_map);
 
@@ -937,6 +938,16 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			)
 			.then((response) => {
 				if (!response) return;
+
+				if (!response.name && has_filters) {
+					frappe.show_alert({
+						message: __("{0}: {1} did not match any results.", [
+							__(this.df.label || this.df.fieldname),
+							value,
+						]),
+						indicator: "red",
+					});
+				}
 
 				update_dependant_fields(response);
 				return response.name;


### PR DESCRIPTION
Closes #37605

After #35033, when a typed link value fails link_filters, the field silently clears with no feedback. This makes it confusing for users who don't know why their value disappeared.

`client.py`: `return __filtered_out: true` when filters are active and the value doesn't match, so the client can distinguish it from a non-existent document
`link.js`: show an alert explaining why the field cleared
