### PR TITLE
fix: hide print format builder sidebar after route change

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -35,6 +35,7 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 			this.show_start();
 		} else {
 			this.page.set_title(this.print_format.name);
+			this.page.sidebar.toggle(true);
 			this.setup_print_format();
 		}
 	}
@@ -65,6 +66,7 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 		this.page.main.html(frappe.render_template("print_format_builder_start", {}));
 		this.page.clear_actions();
 		this.page.set_title(__("Print Format Builder"));
+		this.page.sidebar.toggle(false);
 		this.start_edit_print_format();
 		this.start_new_print_format();
 	}


### PR DESCRIPTION
Fixes: #37577

---

After:

https://github.com/user-attachments/assets/324036d5-3d05-48f1-b63f-739c49053561

