### PR TITLE
fix(bulk operations): store the acutal fieldname for the link search …

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -412,7 +412,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			ignore_user_permissions: this.df.ignore_user_permissions,
 			reference_doctype: this.get_reference_doctype() || "",
 			page_length: cint(frappe.boot.sysdefaults?.link_field_results_limit) || 10,
-			link_fieldname: this.df.fieldname,
+			link_fieldname: this.df.target_fieldname,
 		};
 
 		this.set_custom_query(args);

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -408,6 +408,7 @@ export default class BulkOperations {
 				new_df.default = options[0] || options[1];
 			}
 			new_df.label = __("Value");
+			new_df.target_fieldname = new_df.fieldname;
 			new_df.onchange = show_help_text;
 
 			delete new_df.depends_on;


### PR DESCRIPTION
closes frappe/frappe#37894

<img with="896" height="442" alt="Screenshot 2026-02-27 at 11 28 51 AM" src="https://github.com/user-attachments/assets/55768806-e2b3-41af-a066-ff71c5ea896a" />

While bulk editing from list view, the fieldname for the new field created based on the 'Field' field had its fieldname reset to 'value' from say 'parent_accont' that it should be in order to reference that particular field from the doctype, inside the replace_field function.

So for link fields with ignore_user_permission set to 1, the field could not be retrived from the doctype metadata which lead to an error being thrown while bulk editing.

Fix: store the original fieldname as target_fieldname in the new field object and use that to refer the field in the target doctype.
