### PR TITLE
fix: use newer format for data export tool

### DIFF
--- a/frappe/core/doctype/data_export/data_export.js
+++ b/frappe/core/doctype/data_export/data_export.js
@@ -27,9 +27,6 @@ frappe.ui.form.on("Data Export", {
 			reset_filter_and_field(frm);
 		}
 	},
-	export_without_main_header: (frm) => {
-		frm.refresh();
-	},
 });
 
 const can_export = (frm) => {
@@ -61,9 +58,6 @@ const export_data = (frm) => {
 			select_columns: JSON.stringify(columns),
 			filters: frm.filter_list.get_filters().map((filter) => filter.slice(1, 4)),
 			file_type: frm.doc.file_type,
-			template: !frm.doc.export_without_main_header,
-			with_data: 1,
-			export_without_column_meta: frm.doc.export_without_main_header ? true : false,
 		};
 	};
 

--- a/frappe/core/doctype/data_export/data_export.js
+++ b/frappe/core/doctype/data_export/data_export.js
@@ -46,7 +46,8 @@ const can_export = (frm) => {
 };
 
 const export_data = (frm) => {
-	let get_template_url = "/api/method/frappe.core.doctype.data_export.exporter.export_data";
+	let get_template_url =
+		"/api/method/frappe.core.doctype.data_import.data_import.download_template";
 	var export_params = () => {
 		let columns = {};
 		Object.keys(frm.fields_multicheck).forEach((dt) => {
@@ -55,8 +56,9 @@ const export_data = (frm) => {
 		});
 		return {
 			doctype: frm.doc.reference_doctype,
-			select_columns: JSON.stringify(columns),
-			filters: frm.filter_list.get_filters().map((filter) => filter.slice(1, 4)),
+			export_fields: JSON.stringify(columns),
+			export_records: "by_filter",
+			export_filters: frm.filter_list.get_filters().map((filter) => filter.slice(1, 4)),
 			file_type: frm.doc.file_type,
 		};
 	};
@@ -93,7 +95,10 @@ const set_field_options = (frm) => {
 
 	frm.fields_multicheck = {};
 	related_doctypes.forEach((dt) => {
-		frm.fields_multicheck[dt] = add_doctype_field_multicheck_control(dt, parent_wrapper);
+		frm.fields_multicheck[dt.fieldname] = add_doctype_field_multicheck_control(
+			dt.label,
+			parent_wrapper
+		);
 	});
 
 	frm.refresh();
@@ -133,7 +138,12 @@ const make_multiselect_buttons = (parent_wrapper) => {
 };
 
 const get_doctypes = (parentdt) => {
-	return [parentdt].concat(frappe.meta.get_table_fields(parentdt).map((df) => df.options));
+	return [{ fieldname: parentdt, label: parentdt }].concat(
+		frappe.meta.get_table_fields(parentdt).map((df) => ({
+			fieldname: df.fieldname,
+			label: df.options,
+		}))
+	);
 };
 
 const add_doctype_field_multicheck_control = (doctype, parent_wrapper) => {

--- a/frappe/core/doctype/data_export/data_export.json
+++ b/frappe/core/doctype/data_export/data_export.json
@@ -6,7 +6,6 @@
  "engine": "InnoDB",
  "field_order": [
   "reference_doctype",
-  "export_without_main_header",
   "column_break_2",
   "file_type",
   "section_break",
@@ -48,19 +47,12 @@
    "fieldname": "fields_multicheck",
    "fieldtype": "HTML",
    "label": "Fields Multicheck"
-  },
-  {
-   "default": "0",
-   "description": "Export the data without any header notes and column descriptions",
-   "fieldname": "export_without_main_header",
-   "fieldtype": "Check",
-   "label": "Export without main header"
   }
  ],
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-23 16:02:16.856404",
+ "modified": "2026-02-26 18:44:16.099496",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Data Export",
@@ -78,6 +70,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/frappe/core/doctype/data_export/data_export.py
+++ b/frappe/core/doctype/data_export/data_export.py
@@ -13,7 +13,6 @@ class DataExport(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		export_without_main_header: DF.Check
 		file_type: DF.Literal["Excel", "CSV"]
 		reference_doctype: DF.Link
 	# end: auto-generated types

--- a/frappe/core/doctype/data_export/test_data_export.py
+++ b/frappe/core/doctype/data_export/test_data_export.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestDataExport(IntegrationTestCase):
+	"""
+	Integration tests for DataExport.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass


### PR DESCRIPTION
Data Export Tool uses the older template from version 12 meanwhile Data Import and List View Export both use the newer format for the exported file. Keep a single API for all of these formats to use.

Tasks:

- [x] Rely on same API for Data Export tool as importer.
- [x] Disable Export button if no filtered records are available to export.
- [ ] Make `export-csv` command also use same format.
- [ ] Check usage of different format in tests and fix tests.

Closes #13404
Closes #20603


