### PR TITLE
fix(optimized): KanbanView field fetching by limiting to required fields and board configurations

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -163,8 +163,30 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 	}
 
 	set_fields() {
-		super.set_fields();
+		// Fetch only required + Kanban Board configured fields (optimization: avoid fetching all doctype fields)
+		this.fields = [];
+		// Core: identity and column
+		this._add_field("name");
+		this._add_field("creation");
+		this._add_field(this.board.field_name, this.board.reference_doctype);
 		this._add_field(this.card_meta.title_field);
+		// Card UI: assignments, tags, like, comment count
+		this._add_field("_assign");
+		this._add_field("_user_tags");
+		this._add_field("_liked_by");
+		this._add_field("_comments");
+		this._add_field("owner");
+		// Kanban Board document's configured fields (card body content)
+		if (this.board.fields && Array.isArray(this.board.fields)) {
+			this.board.fields.forEach((field_spec) => {
+				const fieldname =
+					typeof field_spec === "string" ? field_spec : field_spec?.fieldname;
+				if (fieldname) this._add_field(fieldname);
+			});
+		}
+		// Optional: image and color if doctype has them
+		if (this.meta.image_field) this._add_field(this.meta.image_field);
+		if (frappe.meta.has_field(this.doctype, "color")) this._add_field("color");
 	}
 
 	before_render() {
@@ -208,7 +230,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 	}
 
 	get_fields() {
-		this.fields.push([this.board.field_name, this.board.reference_doctype]);
+		// board.field_name already added in set_fields(); just return built field list
 		return super.get_fields();
 	}
 


### PR DESCRIPTION
## Kanban view: fetch only required + board-configured fields

### Problem
Kanban used the same field set as list view and requested all list-view fields, even when the Kanban Board was configured to show only a few.

### Change
Kanban now requests only:
- **Core:** `name`, `creation`, column field, title field
- **Card UI:** `_assign`, `_user_tags`, `_liked_by`, `_comments`, `owner`
- **Board fields:** fields defined on the Kanban Board doc (card body)
- **Optional:** image field and `color` when present on the doctype

Reduces payload and server work when doctypes have many fields but the board shows only a subset.

before:

https://github.com/user-attachments/assets/e10a6cef-4b0d-4a67-9c73-89d0acc7ed0b

payload:
```
{
  "doctype": "Test",
  "fields": [
    "`tabTest`.`name`",
    "`tabTest`.`owner`",
    "`tabTest`.`creation`",
    "`tabTest`.`modified`",
    "`tabTest`.`modified_by`",
    "`tabTest`.`_user_tags`",
    "`tabTest`.`_comments`",
    "`tabTest`.`_assign`",
    "`tabTest`.`_liked_by`",
    "`tabTest`.`docstatus`",
    "`tabTest`.`idx`",
    "`tabTest`.`description`",
    "`tabTest`.`status`",
    "`tabTest`.`enabled`",
    "`tabTest`.`status`",
    "`tabTest`.`status`"
  ],
  "filters": [],
  "start": 0,
  "page_length": 0,
  "view": "List",
  "group_by": null,
  "with_comment_count": 1
}
```

after:

https://github.com/user-attachments/assets/07028787-6a00-491c-b33b-c848ab8a2e11

payload:

```
{
  "doctype": "Test",
  "fields": [
    "`tabTest`.`name`",
    "`tabTest`.`creation`",
    "`tabTest`.`status`",
    "`tabTest`.`description`",
    "`tabTest`.`_assign`",
    "`tabTest`.`_user_tags`",
    "`tabTest`.`_liked_by`",
    "`tabTest`.`_comments`",
    "`tabTest`.`owner`"
  ],
  "filters": [],
  "start": 0,
  "page_length": 0,
  "view": "List",
  "group_by": null,
  "with_comment_count": 1
}
```

### My Test Doctype have 10,046 Documents, In after it is still slow because kanban fetches all, this is just small optimization but we need Pagination on kanban