### PR TITLE
fix: render barcodes in print view

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -499,7 +499,16 @@ frappe.ui.form.PrintView = class {
 		this.$print_format_body
 			.find("body")
 			.html(`<div class="print-format print-format-preview">${out.html}</div>`);
-
+		const iframeDoc = this.$print_format_body[0];
+		const script = iframeDoc.createElement("script");
+		script.src = "https://cdn.jsdelivr.net/npm/jsbarcode@3/dist/JsBarcode.all.min.js";
+		script.onload = () => {
+			iframeDoc.querySelectorAll("svg[data-barcode-value]").forEach((el) => {
+				JsBarcode(el, el.dataset.barcodeValue, { width: 3, height: 50, fontSize: 16 });
+				el.setAttribute("width", "100%");
+			});
+		};
+		iframeDoc.head.appendChild(script);
 		this.show_footer();
 
 		this.$print_format_body.find(".print-format").css({

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -504,7 +504,6 @@ frappe.ui.form.PrintView = class {
 			const get_options = frappe.ui.form.ControlBarcode.prototype.get_options.bind({
 				df: { options: el.dataset.options },
 			});
-			console.log(get_options(el.dataset.barcodeValue));
 			JsBarcode(el, el.dataset.barcodeValue, get_options(el.dataset.barcodeValue));
 			el.setAttribute("width", "100%");
 		});

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -500,15 +500,14 @@ frappe.ui.form.PrintView = class {
 			.find("body")
 			.html(`<div class="print-format print-format-preview">${out.html}</div>`);
 		const iframeDoc = this.$print_format_body[0];
-		const script = iframeDoc.createElement("script");
-		script.src = "https://cdn.jsdelivr.net/npm/jsbarcode@3/dist/JsBarcode.all.min.js";
-		script.onload = () => {
-			iframeDoc.querySelectorAll("svg[data-barcode-value]").forEach((el) => {
-				JsBarcode(el, el.dataset.barcodeValue, { width: 3, height: 50, fontSize: 16 });
-				el.setAttribute("width", "100%");
+		iframeDoc.querySelectorAll("svg[data-barcode-value]").forEach((el) => {
+			const get_options = frappe.ui.form.ControlBarcode.prototype.get_options.bind({
+				df: { options: el.dataset.options },
 			});
-		};
-		iframeDoc.head.appendChild(script);
+			console.log(get_options(el.dataset.barcodeValue));
+			JsBarcode(el, el.dataset.barcodeValue, get_options(el.dataset.barcodeValue));
+			el.setAttribute("width", "100%");
+		});
 		this.show_footer();
 
 		this.$print_format_body.find(".print-format").css({

--- a/frappe/public/js/frappe/form/controls/barcode.js
+++ b/frappe/public/js/frappe/form/controls/barcode.js
@@ -64,7 +64,7 @@ frappe.ui.form.ControlBarcode = class ControlBarcode extends frappe.ui.form.Cont
 		options.height = "50";
 
 		if (frappe.utils.is_json(this.df.options)) {
-			options = JSON.parse(this.df.options);
+			Object.assign(options, JSON.parse(this.df.options));
 			if (options.format && options.format === "EAN") {
 				options.format = value.length == 8 ? "EAN8" : "EAN13";
 			}

--- a/frappe/public/js/print.bundle.js
+++ b/frappe/public/js/print.bundle.js
@@ -1,0 +1,25 @@
+import JsBarcode from "jsbarcode";
+
+function get_options(value, df_options = null) {
+	let options = {};
+	options.fontSize = "16";
+	options.width = "3";
+	options.height = "50";
+	if (df_options) {
+		Object.assign(options, JSON.parse(df_options));
+		if (options.format && options.format === "EAN") {
+			options.format = value.length == 8 ? "EAN8" : "EAN13";
+		}
+	}
+	return options;
+}
+
+window.render_barcode = (el) => {
+	const value = el.dataset.barcodeValue;
+	try {
+		JsBarcode(el, value, get_options(value, el.dataset.options));
+		el.setAttribute("width", "100%");
+	} catch (e) {
+		console.log(e);
+	}
+};

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -157,6 +157,9 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 	{% elif df.fieldtype=="Signature" %}
 		<img src="{{ doc[df.fieldname] }}" class="signature-img img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
+	{% elif df.fieldtype=="Barcode" %}
+		<svg data-barcode-value="{{ doc[df.fieldname] }}" height="80"></svg>
+	 	<script>get_barcode_html("{{ doc[df.fieldname] }}");</script>
 	{% elif df.fieldtype in ("Attach", "Attach Image") and frappe.utils.is_image(doc[df.fieldname]) %}
 		<img src="{{ doc[df.fieldname] }}" class="img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -158,8 +158,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 		<img src="{{ doc[df.fieldname] }}" class="signature-img img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
 	{% elif df.fieldtype=="Barcode" %}
-		<svg data-barcode-value="{{ doc[df.fieldname] }}" height="80"></svg>
-	 	<script>get_barcode_html("{{ doc[df.fieldname] }}");</script>
+		<svg data-barcode-value="{{ doc[df.fieldname] }}" height="80" data-options='{{ df.options }}'></svg>
 	{% elif df.fieldtype in ("Attach", "Attach Image") and frappe.utils.is_image(doc[df.fieldname]) %}
 		<img src="{{ doc[df.fieldname] }}" class="img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -157,7 +157,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 	{% elif df.fieldtype=="Signature" %}
 		<img src="{{ doc[df.fieldname] }}" class="signature-img img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
-	{% elif df.fieldtype=="Barcode" %}
+	{% elif df.fieldtype=="Barcode" and not doc[df.fieldname].startswith("<svg") %}
 		<svg data-barcode-value="{{ doc[df.fieldname] }}" height="80" data-options='{{ df.options }}'></svg>
 	{% elif df.fieldtype in ("Attach", "Attach Image") and frappe.utils.is_image(doc[df.fieldname]) %}
 		<img src="{{ doc[df.fieldname] }}" class="img-responsive"

--- a/frappe/www/printview.html
+++ b/frappe/www/printview.html
@@ -6,6 +6,41 @@
 	<title>{{ title }}</title>
 	<meta name="generator" content="frappe">
 	{{ include_style('print.bundle.css') }}
+	<script src="https://cdn.jsdelivr.net/npm/jsbarcode@3/dist/JsBarcode.all.min.js"></script>
+	<script>
+
+	function get_options(value) {
+		// get JsBarcode options
+		let options = {};
+		options.fontSize = "16";
+		options.width = "3";
+		options.height = "50";
+		// options.format = value.length == 8 ? "EAN8" : "EAN13";
+
+		// if (frappe.utils.is_json(this.df.options)) {
+		// 	options = JSON.parse(this.df.options);
+		// 	if (options.format && options.format === "EAN") {
+		// 		options.format = value.length == 8 ? "EAN8" : "EAN13";
+		// 	}
+
+		// }
+		return options;
+	}
+	function get_barcode_html(value) {
+		if (value) {
+			// Get svg
+			const svg = document.querySelector(`[data-barcode-value="${value}"]`);
+			try {
+				JsBarcode(svg, value, get_options(value));
+				$(svg).attr("width", "100%");
+				return  'hey';
+			} catch (e) {
+				console.log(e)
+			}
+		}
+	}
+
+	</script>
 	{% if print_style %}
 		<style>
 		{{ print_style }}

--- a/frappe/www/printview.html
+++ b/frappe/www/printview.html
@@ -6,41 +6,7 @@
 	<title>{{ title }}</title>
 	<meta name="generator" content="frappe">
 	{{ include_style('print.bundle.css') }}
-	<script src="https://cdn.jsdelivr.net/npm/jsbarcode@3/dist/JsBarcode.all.min.js"></script>
-	<script>
-
-	function get_options(value) {
-		// get JsBarcode options
-		let options = {};
-		options.fontSize = "16";
-		options.width = "3";
-		options.height = "50";
-		// options.format = value.length == 8 ? "EAN8" : "EAN13";
-
-		// if (frappe.utils.is_json(this.df.options)) {
-		// 	options = JSON.parse(this.df.options);
-		// 	if (options.format && options.format === "EAN") {
-		// 		options.format = value.length == 8 ? "EAN8" : "EAN13";
-		// 	}
-
-		// }
-		return options;
-	}
-	function get_barcode_html(value) {
-		if (value) {
-			// Get svg
-			const svg = document.querySelector(`[data-barcode-value="${value}"]`);
-			try {
-				JsBarcode(svg, value, get_options(value));
-				$(svg).attr("width", "100%");
-				return  'hey';
-			} catch (e) {
-				console.log(e)
-			}
-		}
-	}
-
-	</script>
+	{{ include_script('print.bundle.js') }}
 	{% if print_style %}
 		<style>
 		{{ print_style }}
@@ -78,6 +44,7 @@
 				footer_html.style.order = 1;
 				footer_html.style.marginTop = '20px';
 			}
+			document.querySelectorAll("svg[data-barcode-value]").forEach(render_barcode)
 		});
 	</script>
 </body>


### PR DESCRIPTION
Closes #32104

Barcodes are stored inconsistently:
<img width="936" height="253" alt="image" src="https://github.com/user-attachments/assets/31763648-6c7b-4c45-aacf-47a0f08fd4e1" />

When a barcode is not stored as an SVG (like when the field is `read_only`) it shows up in the print preview and download as just a number. This PR fixes that

(We should not be storing the SVG in DB in any case, but that's a separate issue.)

### Screenshots/GIFs

This is tested on a barcode with option `{"format": "EAN"}` and `read_only` turned on.

Existing rendering in form:

<img width="1127" height="824" alt="image" src="https://github.com/user-attachments/assets/2c976a83-46b5-4b16-96a0-dab17a537519" />


In print preview:

<img width="1132" height="877" alt="image" src="https://github.com/user-attachments/assets/1d53d701-8394-4d7a-9869-814a4ba69fda" />


In print:

<img width="1127" height="824" alt="image" src="https://github.com/user-attachments/assets/cd5aa47b-a723-4b86-8aae-1f7b43a5c4f3" />

### Notes
We're adding a new bundle (`62.78 kB`) for the barcode JS.