### PR TITLE
Fix: ShortcutWidget throws TableMissingError for Single DocTypes

### DIFF
--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -82,7 +82,12 @@ export default class ShortcutWidget extends Widget {
 
 		let filters = frappe.utils.process_filter_expression(this.stats_filter);
 
-		if (this.type == "DocType" && this.doc_view != "New" && filters) {
+		if (
+			this.type == "DocType" &&
+			this.doc_view != "New" &&
+			filters &&
+			!frappe.boot.single_types.includes(this.link_to)
+		) {
 			frappe.db
 				.count(this.link_to, {
 					filters: filters,


### PR DESCRIPTION
## Problem

When a workspace shortcut links to a Single DocType, `ShortcutWidget.set_actions()` was calling
`frappe.db.count()` on it. Single DocTypes don't have their own database table, so this triggered
`get_table_columns()` → `TableMissingError` on the backend.

<img width="1038" height="427" alt="image" src="https://github.com/user-attachments/assets/919deb37-4e37-4afc-9cac-dee9231fc7f3" />

## Fix

Added a guard in `set_actions()` to exclude Single DocTypes from the count query:
```js
&& !frappe.boot.single_types.includes(this.link_to)
```

This is consistent with the existing guards (`doc_view != "New"`, filters check) that already
prevent unnecessary or invalid count queries.

## Testing

- Add a shortcut to a Single DocType (e.g. `System Settings`) on a workspace — no error should appear.
- Shortcuts to regular DocTypes should still show the document count pill as expected.