### PR TITLE
fix: allow dangerous HTML in link exists exception

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -422,7 +422,6 @@ def raise_link_exists_exception(doc, reference_doctype, reference_docname, row="
 			_(doc.doctype), doc_link, _(reference_doctype), reference_link, row
 		),
 		frappe.LinkExistsError,
-		allow_dangerous_html=True,
 	)
 
 

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -422,6 +422,7 @@ def raise_link_exists_exception(doc, reference_doctype, reference_docname, row="
 			_(doc.doctype), doc_link, _(reference_doctype), reference_link, row
 		),
 		frappe.LinkExistsError,
+		allow_dangerous_html=True,
 	)
 
 

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -44,6 +44,7 @@ def clean_html(html):
 			"tbody",
 			"td",
 			"tr",
+			"a",
 		},
 		clean_content_tags=REMOVE_CONTENT_TAGS,
 		strip_comments=True,


### PR DESCRIPTION
Fixes: #37672

---

After the changes introduced in #37399, `allow_dangerous_html` defaults to `False` in `msgprint` and `throw`. As a result, any HTML in messages, including links .. is now sanitized and rendered as plain text, making links unclickable.

> [!NOTE]
>I think all `throw` and `msgprint` calls in Frappe and ERPNext that use `get_link_to_form()` or any anchor tags need to be updated to pass `allow_dangerous_html=True`

---
Before:

https://github.com/user-attachments/assets/d29ad32d-c2dd-4e45-a870-3b69b47b5a36


---
After:


https://github.com/user-attachments/assets/b5a0a570-43e3-448f-b684-81e941f54576

