### PR TITLE
feat: add activity log support

### DIFF
--- a/frappe/core/doctype/permission_log/permission_log.json
+++ b/frappe/core/doctype/permission_log/permission_log.json
@@ -118,7 +118,7 @@
    "fieldtype": "Select",
    "hidden": 1,
    "label": "Status",
-   "options": "Updated\nRemoved\nAdded"
+   "options": "Updated\nRemoved\nAdded\nReset"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -150,6 +150,10 @@
   {
    "color": "Green",
    "title": "Added"
+  },
+  {
+   "color": "Blue",
+   "title": "Reset"
   }
  ],
  "title_field": "changed_by"

--- a/frappe/core/doctype/permission_log/permission_log.py
+++ b/frappe/core/doctype/permission_log/permission_log.py
@@ -23,7 +23,7 @@ class PermissionLog(Document):
 		for_document: DF.DynamicLink
 		reference: DF.DynamicLink | None
 		reference_type: DF.Link | None
-		status: DF.Literal["Updated", "Removed", "Added"]
+		status: DF.Literal["Updated", "Removed", "Added", "Reset"]
 	# end: auto-generated types
 
 	@property

--- a/frappe/core/doctype/permission_log/permission_log.py
+++ b/frappe/core/doctype/permission_log/permission_log.py
@@ -34,6 +34,13 @@ class PermissionLog(Document):
 def make_perm_log(doc, method=None):
 	if not hasattr(doc, "get_permission_log_options"):
 		return
+	# During reset we insert a single "Reset" log; skip per-Custom-DocPerm "Removed" logs
+	if (
+		method == "after_delete"
+		and doc.doctype == "Custom DocPerm"
+		and getattr(frappe.flags, "skip_perm_log_for_doctype", None) == doc.parent
+	):
+		return
 
 	params = doc.get_permission_log_options(method) or {}
 	if not getattr(doc, "_no_perm_log", False):

--- a/frappe/core/doctype/permission_log/permission_log.py
+++ b/frappe/core/doctype/permission_log/permission_log.py
@@ -46,16 +46,24 @@ def insert_perm_log(
 	for_doctype: str | None = None,
 	for_document: str | None = None,
 	fields: list | tuple | None = None,
+	custom_changes: dict | None = None,
 ):
+	"""Log a permission change. When custom_changes is provided (e.g. for reset-to-standard),
+	it must be {"from": {...}, "to": {...}} and optionally "status"; doc is used for
+	reference/owner only."""
 	if frappe.flags.in_install or frappe.flags.in_migrate:
 		# no need to log changes when migrating or installing app/site
 		return
 
-	current, previous = get_changes(doc, doc_before_save, fields)
-	if not previous and not current:
-		return
-
-	status = "Updated" if doc_before_save else ("Added" if doc.flags.in_insert else "Removed")
+	if custom_changes is not None:
+		previous = custom_changes.get("from", {})
+		current = custom_changes.get("to", {})
+		status = custom_changes.get("status", "Updated")
+	else:
+		current, previous = get_changes(doc, doc_before_save, fields)
+		if not previous and not current:
+			return
+		status = "Updated" if doc_before_save else ("Added" if doc.flags.in_insert else "Removed")
 
 	frappe.get_doc(
 		{

--- a/frappe/core/doctype/permission_log/permission_log.py
+++ b/frappe/core/doctype/permission_log/permission_log.py
@@ -71,6 +71,16 @@ def insert_perm_log(
 		if not previous and not current:
 			return
 		status = "Updated" if doc_before_save else ("Added" if doc.flags.in_insert else "Removed")
+		# Ensure role (and parent) are always in changes for Custom DocPerm so the UI can show them
+		if doc.doctype == "Custom DocPerm":
+			previous["role"] = previous.get("role") or (
+				doc_before_save and getattr(doc_before_save, "role", None)
+			)
+			current["role"] = current.get("role") or getattr(doc, "role", None)
+			previous["parent"] = previous.get("parent") or (
+				doc_before_save and getattr(doc_before_save, "parent", None)
+			)
+			current["parent"] = current.get("parent") or getattr(doc, "parent", None)
 
 	frappe.get_doc(
 		{

--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -72,6 +72,11 @@ frappe.PermissionEngine = class PermissionEngine {
 		this.page.add_inner_button(__("Set User Permissions"), () => {
 			return frappe.set_route("List", "User Permission");
 		});
+
+		this.page.add_inner_button(__("View Activity Log"), () => {
+			this.show_activity_log();
+		});
+
 		this.set_from_route();
 	}
 
@@ -576,5 +581,119 @@ frappe.PermissionEngine = class PermissionEngine {
 			fieldtype: "Link",
 			options: ["not in", ["User", "[Select]"]],
 		});
+	}
+
+	show_activity_log() {
+		let doctype = this.get_doctype();
+		let title = doctype
+			? __("Activity Log for {0}", [__(doctype)])
+			: __("Role Permissions Activity Log");
+
+		let d = new frappe.ui.Dialog({
+			title: title,
+			size: "large",
+		});
+
+		let $body = $(d.body);
+		$body.html(`<div class="text-muted text-center p-4">${__("Loading…")}</div>`);
+
+		frappe
+			.call({
+				module: "frappe.core",
+				page: "permission_manager",
+				method: "get_permission_logs",
+				args: { doctype: doctype || null, limit: 50 },
+			})
+			.then((r) => {
+				let logs = r.message || [];
+				$body.empty();
+
+				if (!logs.length) {
+					$body.html(
+						`<div class="text-muted text-center p-4">${__(
+							"No activity recorded yet."
+						)}</div>`
+					);
+					return;
+				}
+
+				let status_color = { Added: "green", Removed: "red", Updated: "orange" };
+
+				let rows = logs
+					.map((log) => {
+						let changes_html = "";
+						try {
+							let ch = log.changes || {};
+							let from = ch.from || {};
+							let to = ch.to || {};
+							let keys = new Set([...Object.keys(from), ...Object.keys(to)]);
+							let parts = [];
+							keys.forEach((k) => {
+								let fv = from[k] !== undefined ? from[k] : "";
+								let tv = to[k] !== undefined ? to[k] : "";
+								if (fv !== tv) {
+									parts.push(
+										`<span class="text-muted">${frappe.model.unscrub(
+											k
+										)}:</span> ` +
+											`<span class="diff-remove">${fv}</span> → ` +
+											`<span class="diff-add">${tv}</span>`
+									);
+								}
+							});
+							changes_html = parts.join("<br>");
+						} catch (e) {
+							changes_html = "";
+						}
+
+						let badge_color = status_color[log.status] || "grey";
+						let dt_display = log.for_document
+							? frappe.utils.get_form_link("DocType", log.for_document, true)
+							: "";
+						let user_display = log.changed_by
+							? frappe.utils.get_form_link("User", log.changed_by, true)
+							: "";
+						let ts = frappe.datetime.str_to_user(log.changed_at);
+
+						return `<tr>
+							<td>${ts}</td>
+							<td>${user_display}</td>
+							<td>${dt_display}</td>
+							<td><span class="indicator-pill ${badge_color}">${__(log.status)}</span></td>
+							<td class="small">${changes_html}</td>
+						</tr>`;
+					})
+					.join("");
+
+				$body.html(`
+					<div style="overflow-x: auto;">
+						<table class="table table-bordered table-sm">
+							<thead>
+								<tr>
+									<th style="min-width:130px">${__("When")}</th>
+									<th style="min-width:120px">${__("Changed By")}</th>
+									<th style="min-width:120px">${__("DocType")}</th>
+									<th style="min-width:80px">${__("Action")}</th>
+									<th>${__("Changes")}</th>
+								</tr>
+							</thead>
+							<tbody>${rows}</tbody>
+						</table>
+					</div>
+					<div class="text-right mt-2">
+						<a href="${frappe.utils.generate_route({
+							type: "Doctype",
+							doctype: "Permission Log",
+							name: "Permission Log",
+							doc_view: "List",
+						})}" class="text-muted small">
+							${frappe.utils.icon("external-link", "sm", "mr-1")}
+							${__("View full log")}
+						</a>
+					</div>
+				`);
+			});
+
+		d.show();
 	}
 };

--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -603,25 +603,9 @@ frappe.PermissionEngine = class PermissionEngine {
 		];
 		const STATUS_COLOR = { Added: "green", Removed: "red", Updated: "orange", Reset: "blue" };
 
-		function format_datetime(datetime_str) {
-			if (!datetime_str) return "—";
-			let d = frappe.datetime.convert_to_user_tz(datetime_str, false);
-			if (!d || !d.isValid()) return frappe.datetime.str_to_user(datetime_str);
-			let now = moment();
-			let today = now.clone().startOf("day");
-			let log_day = d.clone().startOf("day");
-			let time_fmt = frappe.datetime.get_user_time_fmt();
-			let time_str = d.format(time_fmt);
-			if (log_day.isSame(today)) {
-				return __("Today at {0}", [time_str]);
-			}
-			if (log_day.isSame(today.clone().subtract(1, "day"))) {
-				return __("Yesterday at {0}", [time_str]);
-			}
-			return d.format("D MMM YYYY") + ", " + time_str;
-		}
-
 		let doctype = this.get_doctype();
+		let show_doctype_column = !doctype;
+
 		let title = doctype
 			? __("Activity Log for {0}", [__(doctype)])
 			: __("Role Permissions Activity Log");
@@ -661,9 +645,11 @@ frappe.PermissionEngine = class PermissionEngine {
 							(log.status === "Removed" ? from.role : to.role) || from.role || "—";
 
 						// Active permissions: for Added/Removed show the full set;
-						// for Updated show only what flipped
+						// for Updated show only what flipped; for Reset show summary
 						let changes_text = "";
-						if (log.status === "Updated") {
+						if (log.status === "Reset") {
+							changes_text = __("Restored to standard permissions");
+						} else if (log.status === "Updated") {
 							let parts = [];
 							PERM_FIELDS.forEach((f) => {
 								if (f in to && to[f] !== from[f]) {
@@ -688,29 +674,44 @@ frappe.PermissionEngine = class PermissionEngine {
 						}
 
 						let badge_color = STATUS_COLOR[log.status] || "grey";
-						let ts = format_datetime(log.changed_at);
+						let ts = frappe.datetime.comment_when(log.changed_at);
 						let user_display = log.changed_by || "—";
 
+						let doctype_cell =
+							show_doctype_column && log.for_document
+								? `<td>${frappe.utils.get_form_link(
+										"DocType",
+										log.for_document,
+										true
+								  )}</td>`
+								: "";
+
 						return `<tr>
-							<td style="white-space:nowrap">${ts}</td>
 							<td>${user_display}</td>
 							<td><span class="indicator-pill ${badge_color}">${__(log.status)}</span></td>
 							<td>${__(role)}</td>
+							${doctype_cell}
 							<td class="small">${changes_text}</td>
+							<td class="frappe-timestamp-cell">${ts}</td>
 						</tr>`;
 					})
 					.join("");
+
+				let header_doctype = show_doctype_column
+					? `<th style="min-width:120px">${__("DocType")}</th>`
+					: "";
 
 				$body.html(`
 					<div style="overflow-x: auto;">
 						<table class="table table-bordered table-sm" style="font-size:13px">
 							<thead style="background:var(--fg-color)">
 								<tr>
-									<th style="min-width:130px">${__("Date")}</th>
 									<th style="min-width:110px">${__("Modified By")}</th>
 									<th style="min-width:90px">${__("Action")}</th>
 									<th style="min-width:110px">${__("Role")}</th>
+									${header_doctype}
 									<th>${__("Changes")}</th>
+									<th style="min-width:100px">${__("Timestamp")}</th>
 								</tr>
 							</thead>
 							<tbody>${rows}</tbody>

--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -699,17 +699,21 @@ frappe.PermissionEngine = class PermissionEngine {
 						</table>
 					</div>
 					<div class="text-right mt-2">
-						<a href="${frappe.utils.generate_route({
-							type: "Doctype",
-							doctype: "Permission Log",
-							name: "Permission Log",
-							doc_view: "List",
-						})}" class="text-muted small">
+						<button class="btn btn-sm btn-default btn-view-full-log">
 							${frappe.utils.icon("external-link", "sm", "mr-1")}
 							${__("View full log")}
-						</a>
+						</button>
 					</div>
 				`);
+
+				$body.find(".btn-view-full-log").on("click", () => {
+					d.hide();
+					frappe.route_options = { for_doctype: "DocType" };
+					if (doctype) {
+						frappe.route_options.for_document = doctype;
+					}
+					frappe.set_route("List", "Permission Log");
+				});
 			});
 
 		d.show();

--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -601,7 +601,25 @@ frappe.PermissionEngine = class PermissionEngine {
 			"share",
 			"mask",
 		];
-		const STATUS_COLOR = { Added: "green", Removed: "red", Updated: "orange" };
+		const STATUS_COLOR = { Added: "green", Removed: "red", Updated: "orange", Reset: "blue" };
+
+		function format_datetime(datetime_str) {
+			if (!datetime_str) return "—";
+			let d = frappe.datetime.convert_to_user_tz(datetime_str, false);
+			if (!d || !d.isValid()) return frappe.datetime.str_to_user(datetime_str);
+			let now = moment();
+			let today = now.clone().startOf("day");
+			let log_day = d.clone().startOf("day");
+			let time_fmt = frappe.datetime.get_user_time_fmt();
+			let time_str = d.format(time_fmt);
+			if (log_day.isSame(today)) {
+				return __("Today at {0}", [time_str]);
+			}
+			if (log_day.isSame(today.clone().subtract(1, "day"))) {
+				return __("Yesterday at {0}", [time_str]);
+			}
+			return d.format("D MMM YYYY") + ", " + time_str;
+		}
 
 		let doctype = this.get_doctype();
 		let title = doctype
@@ -670,7 +688,7 @@ frappe.PermissionEngine = class PermissionEngine {
 						}
 
 						let badge_color = STATUS_COLOR[log.status] || "grey";
-						let ts = frappe.datetime.str_to_user(log.changed_at);
+						let ts = format_datetime(log.changed_at);
 						let user_display = log.changed_by || "—";
 
 						return `<tr>

--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -584,18 +584,33 @@ frappe.PermissionEngine = class PermissionEngine {
 	}
 
 	show_activity_log() {
+		const PERM_FIELDS = [
+			"select",
+			"read",
+			"write",
+			"create",
+			"delete",
+			"submit",
+			"cancel",
+			"amend",
+			"print",
+			"email",
+			"report",
+			"import",
+			"export",
+			"share",
+			"mask",
+		];
+		const STATUS_COLOR = { Added: "green", Removed: "red", Updated: "orange" };
+
 		let doctype = this.get_doctype();
 		let title = doctype
 			? __("Activity Log for {0}", [__(doctype)])
 			: __("Role Permissions Activity Log");
 
-		let d = new frappe.ui.Dialog({
-			title: title,
-			size: "large",
-		});
-
+		let d = new frappe.ui.Dialog({ title, size: "large" });
 		let $body = $(d.body);
-		$body.html(`<div class="text-muted text-center p-4">${__("Loading…")}</div>`);
+		$body.html(`<div class="text-muted text-center p-4">${__("Loading\u2026")}</div>`);
 
 		frappe
 			.call({
@@ -617,63 +632,66 @@ frappe.PermissionEngine = class PermissionEngine {
 					return;
 				}
 
-				let status_color = { Added: "green", Removed: "red", Updated: "orange" };
-
 				let rows = logs
 					.map((log) => {
-						let changes_html = "";
-						try {
-							let ch = log.changes || {};
-							let from = ch.from || {};
-							let to = ch.to || {};
-							let keys = new Set([...Object.keys(from), ...Object.keys(to)]);
+						let ch = log.changes || {};
+						let from = ch.from || {};
+						let to = ch.to || {};
+
+						// Role: prefer the side that has data
+						let role =
+							(log.status === "Removed" ? from.role : to.role) || from.role || "—";
+
+						// Active permissions: for Added/Removed show the full set;
+						// for Updated show only what flipped
+						let changes_text = "";
+						if (log.status === "Updated") {
 							let parts = [];
-							keys.forEach((k) => {
-								let fv = from[k] !== undefined ? from[k] : "";
-								let tv = to[k] !== undefined ? to[k] : "";
-								if (fv !== tv) {
+							PERM_FIELDS.forEach((f) => {
+								if (f in to && to[f] !== from[f]) {
+									let label = toTitle(frappe.unscrub(f));
 									parts.push(
-										`<span class="text-muted">${frappe.model.unscrub(
-											k
-										)}:</span> ` +
-											`<span class="diff-remove">${fv}</span> → ` +
-											`<span class="diff-add">${tv}</span>`
+										to[f]
+											? `<span class="diff-add">${__(label)}</span>`
+											: `<span class="diff-remove">${__(label)}</span>`
 									);
 								}
 							});
-							changes_html = parts.join("<br>");
-						} catch (e) {
-							changes_html = "";
+							changes_text = parts.join(", ") || "—";
+						} else {
+							// Added or Removed — list the active permission types
+							let source = log.status === "Removed" ? from : to;
+							let active = PERM_FIELDS.filter(
+								(f) => source[f] == 1 || source[f] === true
+							);
+							changes_text =
+								active.map((f) => __(toTitle(frappe.unscrub(f)))).join(", ") ||
+								"—";
 						}
 
-						let badge_color = status_color[log.status] || "grey";
-						let dt_display = log.for_document
-							? frappe.utils.get_form_link("DocType", log.for_document, true)
-							: "";
-						let user_display = log.changed_by
-							? frappe.utils.get_form_link("User", log.changed_by, true)
-							: "";
+						let badge_color = STATUS_COLOR[log.status] || "grey";
 						let ts = frappe.datetime.str_to_user(log.changed_at);
+						let user_display = log.changed_by || "—";
 
 						return `<tr>
-							<td>${ts}</td>
+							<td style="white-space:nowrap">${ts}</td>
 							<td>${user_display}</td>
-							<td>${dt_display}</td>
 							<td><span class="indicator-pill ${badge_color}">${__(log.status)}</span></td>
-							<td class="small">${changes_html}</td>
+							<td>${__(role)}</td>
+							<td class="small">${changes_text}</td>
 						</tr>`;
 					})
 					.join("");
 
 				$body.html(`
 					<div style="overflow-x: auto;">
-						<table class="table table-bordered table-sm">
-							<thead>
+						<table class="table table-bordered table-sm" style="font-size:13px">
+							<thead style="background:var(--fg-color)">
 								<tr>
-									<th style="min-width:130px">${__("When")}</th>
-									<th style="min-width:120px">${__("Changed By")}</th>
-									<th style="min-width:120px">${__("DocType")}</th>
-									<th style="min-width:80px">${__("Action")}</th>
+									<th style="min-width:130px">${__("Date")}</th>
+									<th style="min-width:110px">${__("Modified By")}</th>
+									<th style="min-width:90px">${__("Action")}</th>
+									<th style="min-width:110px">${__("Role")}</th>
 									<th>${__("Changes")}</th>
 								</tr>
 							</thead>

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -199,7 +199,7 @@ def reset(doctype: str):
 					for p in standard_perms
 				],
 			},
-			"status": "Updated",
+			"status": "Reset",
 		},
 	)
 

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -180,14 +180,17 @@ def reset(doctype: str):
 	frappe.only_for("System Manager")
 	reset_perms(doctype)
 	clear_permissions_cache(doctype)
-	_log_reset(doctype)
 
+	from frappe.core.doctype.permission_log.permission_log import insert_perm_log
 
-def _log_reset(doctype: str):
-	"""Insert a Permission Log entry to record that permissions were reset to standard defaults."""
+	doc = frappe.new_doc("DocType")
+	doc.name = doctype
 	standard_perms = frappe.get_all("DocPerm", filters={"parent": doctype}, fields="*")
-	changes = frappe.as_json(
-		{
+	insert_perm_log(
+		doc,
+		for_doctype="DocType",
+		for_document=doctype,
+		custom_changes={
 			"from": {"permissions": "custom"},
 			"to": {
 				"permissions": "standard",
@@ -196,23 +199,9 @@ def _log_reset(doctype: str):
 					for p in standard_perms
 				],
 			},
-		},
-		indent=0,
-	)
-
-	frappe.get_doc(
-		{
-			"doctype": "Permission Log",
-			"owner": frappe.session.user,
-			"changed_by": frappe.session.user,
-			"reference_type": "DocType",
-			"reference": doctype,
-			"for_doctype": "DocType",
-			"for_document": doctype,
 			"status": "Updated",
-			"changes": changes,
-		}
-	).db_insert()
+		},
+	)
 
 
 @frappe.whitelist()

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -180,6 +180,39 @@ def reset(doctype: str):
 	frappe.only_for("System Manager")
 	reset_perms(doctype)
 	clear_permissions_cache(doctype)
+	_log_reset(doctype)
+
+
+def _log_reset(doctype: str):
+	"""Insert a Permission Log entry to record that permissions were reset to standard defaults."""
+	standard_perms = frappe.get_all("DocPerm", filters={"parent": doctype}, fields="*")
+	changes = frappe.as_json(
+		{
+			"from": {"permissions": "custom"},
+			"to": {
+				"permissions": "standard",
+				"standard_rules": [
+					{"role": p.role, "permlevel": p.permlevel, "read": p.read, "write": p.write}
+					for p in standard_perms
+				],
+			},
+		},
+		indent=0,
+	)
+
+	frappe.get_doc(
+		{
+			"doctype": "Permission Log",
+			"owner": frappe.session.user,
+			"changed_by": frappe.session.user,
+			"reference_type": "DocType",
+			"reference": doctype,
+			"for_doctype": "DocType",
+			"for_document": doctype,
+			"status": "Updated",
+			"changes": changes,
+		}
+	).db_insert()
 
 
 @frappe.whitelist()
@@ -199,3 +232,35 @@ def get_standard_permissions(doctype: str):
 		# also used to setup permissions via patch
 		path = get_file_path(meta.module, "DocType", doctype)
 		return read_doc_from_file(path).get("permissions")
+
+
+@frappe.whitelist()
+def get_permission_logs(doctype: str | None = None, limit: int = 20) -> list:
+	"""Return recent Permission Log entries for the given DocType (or all if not specified).
+
+	Args:
+	        doctype: Filter logs to a specific DocType. If omitted, returns logs for all DocTypes.
+	        limit: Maximum number of log entries to return (default 20).
+	"""
+	frappe.only_for("System Manager")
+
+	filters = {"for_doctype": "DocType"}
+	if doctype:
+		filters["for_document"] = doctype
+
+	logs = frappe.get_all(
+		"Permission Log",
+		filters=filters,
+		fields=["name", "changed_by", "creation", "status", "for_document", "changes"],
+		order_by="creation desc",
+		limit=limit,
+	)
+
+	for log in logs:
+		log["changed_at"] = log.pop("creation")
+		try:
+			log["changes"] = frappe.parse_json(log["changes"])
+		except Exception:
+			pass
+
+	return logs

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -178,30 +178,35 @@ def remove(doctype: str, role: str, permlevel: int, if_owner: str | int = 0):
 @frappe.whitelist()
 def reset(doctype: str):
 	frappe.only_for("System Manager")
-	reset_perms(doctype)
-	clear_permissions_cache(doctype)
 
 	from frappe.core.doctype.permission_log.permission_log import insert_perm_log
 
-	doc = frappe.new_doc("DocType")
-	doc.name = doctype
-	standard_perms = frappe.get_all("DocPerm", filters={"parent": doctype}, fields="*")
-	insert_perm_log(
-		doc,
-		for_doctype="DocType",
-		for_document=doctype,
-		custom_changes={
-			"from": {"permissions": "custom"},
-			"to": {
-				"permissions": "standard",
-				"standard_rules": [
-					{"role": p.role, "permlevel": p.permlevel, "read": p.read, "write": p.write}
-					for p in standard_perms
-				],
+	frappe.flags.skip_perm_log_for_doctype = doctype
+	try:
+		reset_perms(doctype)
+		clear_permissions_cache(doctype)
+
+		doc = frappe.new_doc("DocType")
+		doc.name = doctype
+		standard_perms = frappe.get_all("DocPerm", filters={"parent": doctype}, fields="*")
+		insert_perm_log(
+			doc,
+			for_doctype="DocType",
+			for_document=doctype,
+			custom_changes={
+				"from": {"permissions": "custom"},
+				"to": {
+					"permissions": "standard",
+					"standard_rules": [
+						{"role": p.role, "permlevel": p.permlevel, "read": p.read, "write": p.write}
+						for p in standard_perms
+					],
+				},
+				"status": "Reset",
 			},
-			"status": "Reset",
-		},
-	)
+		)
+	finally:
+		frappe.flags.pop("skip_perm_log_for_doctype", None)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary

- Adds a "View Activity Log" button to the Role Permissions Manager page that opens an inline dialog showing recent permission changes (who changed what, when, and what the diff was) with a link to the full Permission Log list.
- Adds a `get_permission_logs` whitelisted API endpoint (System Manager only) to fetch filtered `Permission Log` entries for a given DocType.
- Adds explicit logging for the "Restore Original Permissions" (reset) action via `_log_reset()`, recording that custom permissions were replaced with standard defaults.

Closes #37572

## How it works

All `add`, `update`, and `remove` operations were already automatically logged via the existing `Permission Log` doctype and `doc_events` hooks on `Custom DocPerm`. This PR surfaces that data in the UI and fills the gap for the `reset` operation.

> no-docs