### PR TITLE
fix: hamburger menu stops opening sidebar after navigating on mobile

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -242,7 +242,7 @@ frappe.ui.Page = class Page {
 	}
 
 	setup_main_sidebar_toggle() {
-		$(".sidebar-toggle-btn.navbar-brand").on("click", (event) => {
+		this.wrapper.find(".sidebar-toggle-btn.navbar-brand").on("click", (event) => {
 			frappe.app.sidebar.set_height();
 			frappe.app.sidebar.toggle_width();
 			frappe.app.sidebar.prevent_scroll();


### PR DESCRIPTION
[setup_main_sidebar_toggle()](cci:1://file:///workspace/development/frappe-bench/apps/frappe/frappe/public/js/frappe/ui/page.js:243:1-249:2) uses a global jQuery selector to bind click handlers to `.sidebar-toggle-btn.navbar-brand`, but is called from each Page constructor. Since Pages from different view factories (Workspaces, Form, List, etc.) coexist in the DOM, each new Page creation adds duplicate handlers to all existing hamburger buttons.

When a button accumulates an even number of handlers, [toggle_width()](cci:1://file:///workspace/development/frappe-bench/apps/frappe/frappe/public/js/frappe/ui/sidebar/sidebar_header.js:337:1-348:2) fires an even number of times — open() and close() cancel each other out, and the sidebar drawer appears unresponsive.

Scope the selector to `this.wrapper.find()` so each Page only binds to its own hamburger button.
