### PR TITLE
fix: graphic label translation issue

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -568,6 +568,7 @@ export default class ChartWidget extends Widget {
 
 	async render() {
 		let setup_dashboard_chart = () => {
+			this.translate_chart_labels();
 			const chart_args = this.get_chart_args();
 
 			if (!this.dashboard_chart) {
@@ -693,6 +694,26 @@ export default class ChartWidget extends Widget {
 		}
 
 		return chart_args;
+	}
+
+	translate_chart_labels() {
+		if (this.data && Array.isArray(this.data.labels)) {
+			this.data.labels = this.data.labels.map((label) => {
+				if (label === null || label === undefined) {
+					return label;
+				}
+				return typeof label === "string" ? __(label) : label;
+			});
+		}
+
+		if (this.data && Array.isArray(this.data.datasets)) {
+			this.data.datasets = this.data.datasets.map((dataset) => {
+				if (dataset && typeof dataset.name === "string") {
+					dataset.name = __(dataset.name);
+				}
+				return dataset;
+			});
+		}
 	}
 
 	get_chart_colors() {


### PR DESCRIPTION
## Closes: #37485 

## Summary
Dashboard chart labels and dataset names now respect the active system language (e.g. Spanish) instead of always showing raw English values.

## Problem
- Chart data labels (`Open`, `Cancelled`, `Draft`, color names like `Green`, `Blue`, etc.) were rendered directly from `this.data.labels` and `this.data.datasets[].name`.
- Only fixed UI strings used `__()`, so chart labels ignored translations even when they existed in `.po` files.

## Root Cause
`chart_widget.js` never passed chart data through the translation function. Labels coming from DocTypes, reports, or hard‑coded option values stayed in the original language.

## Change
- Added `translate_chart_labels()` in `chart_widget.js`.
- Before rendering, `render()` now calls this helper, which:
  - Maps `this.data.labels` through `__()` for string values.
  - Maps `this.data.datasets[].name` through `__()` for string values.
- Non‑string labels (numbers, dates) are left unchanged; strings without translations fall back to the original text.

## Effect
- Status‑based charts and color‑slice charts display labels in the current user language, as long as translations exist in the language files.
- Behavior is backward‑compatible for labels without translations.

## Screenshot
<img width="793" height="535" alt="image" src="https://github.com/user-attachments/assets/96710631-d3ba-4bce-b873-c15ff5750c3c" />

<img width="875" height="627" alt="image" src="https://github.com/user-attachments/assets/ac122860-fd8c-4e66-ab57-a5ab4fba1a22" />

