### PR TITLE
fix!: deprecate wide parameter in msgprint

### DIFF
--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -282,16 +282,7 @@ frappe.msgprint = function (msg, title, is_minimizable, re_route) {
 		frappe.msg_dialog.indicator.removeClass().addClass("hidden");
 	}
 
-	// width
-	if (data.wide) {
-		// msgprint should be narrower than the usual dialog
-		if (frappe.msg_dialog.wrapper.classList.contains("msgprint-dialog")) {
-			frappe.msg_dialog.wrapper.classList.remove("msgprint-dialog");
-		}
-	} else {
-		// msgprint should be narrower than the usual dialog
-		frappe.msg_dialog.wrapper.classList.add("msgprint-dialog");
-	}
+	frappe.msg_dialog.wrapper.classList.add("msgprint-dialog");
 
 	if (msg_exists) {
 		frappe.msg_dialog.msg_area.append("<hr>");

--- a/frappe/utils/messages.py
+++ b/frappe/utils/messages.py
@@ -162,14 +162,6 @@ def throw(
 	:param as_list: [optional] If `msg` is a list, render as un-ordered list.
 	:param primary_action: [optional] Bind a primary server/client side action.
 	"""
-	if wide:
-		from frappe.deprecation_dumpster import deprecation_warning
-
-		deprecation_warning(
-			marked="unknown",
-			graduation="v17",
-			msg="The `wide` parameter has no effect and is deprecated",
-		)
 	msgprint(
 		msg,
 		raise_exception=exc,

--- a/frappe/utils/messages.py
+++ b/frappe/utils/messages.py
@@ -109,7 +109,13 @@ def msgprint(
 		out.primary_action = primary_action
 
 	if wide:
-		out.wide = wide
+		from frappe.deprecation_dumpster import deprecation_warning
+
+		deprecation_warning(
+			marked="unknown",
+			graduation="v17",
+			msg="The `wide` parameter has no effect and is deprecated",
+		)
 
 	if realtime:
 		frappe.publish_realtime(event="msgprint", message=out)
@@ -156,6 +162,14 @@ def throw(
 	:param as_list: [optional] If `msg` is a list, render as un-ordered list.
 	:param primary_action: [optional] Bind a primary server/client side action.
 	"""
+	if wide:
+		from frappe.deprecation_dumpster import deprecation_warning
+
+		deprecation_warning(
+			marked="unknown",
+			graduation="v17",
+			msg="The `wide` parameter has no effect and is deprecated",
+		)
 	msgprint(
 		msg,
 		raise_exception=exc,


### PR DESCRIPTION
The `wide` parameter in `frappe.msgprint` no longer affects the dialog width in `develop`, so it is being deprecated (scheduled for removal in v17).

Note: `frappe.throw(..., wide=...)` forwards this flag to `msgprint`, so the deprecation applies to `throw` as well.

### Without `wide=True`

<img width="1799" height="965" alt="image" src="https://github.com/user-attachments/assets/ceb9a230-9a6c-4a1b-8629-02ee22327c08" />

### With `wide=True`

<img width="1799" height="965" alt="image" src="https://github.com/user-attachments/assets/63dc45ca-3cdc-46d0-bdd4-9e02ab23ed9f" />

# Alternative
We could instead re-introduce a wider-than-default msgprint dialog when `wide=True`. However, that would be a breaking change for users who currently pass `wide=True`. 