### PR TITLE
fix: Allow recreate orphan field with same name but different type

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -84,6 +84,63 @@ class CannotCreateStandardDoctypeError(frappe.ValidationError):
 
 form_grid_templates = {"fields": "templates/form_grid/fields.html"}
 
+FIELDTYPE_CAST_FAMILIES = {
+	# Numeric Family
+	"Int": "Numeric",
+	"Long Int": "Numeric",
+	"Float": "Numeric",
+	"Currency": "Numeric",
+	"Percent": "Numeric",
+	"Duration": "Numeric",
+	"Rating": "Numeric",
+	"Check": "Numeric",
+	# Date Family
+	"Date": "Date",
+	"Datetime": "Date",
+	# Time Family
+	"Time": "Time",
+	# String Family
+	"Data": "String",
+	"Select": "String",
+	"Read Only": "String",
+	"Color": "String",
+	"Icon": "String",
+	"Phone": "String",
+	"Autocomplete": "String",
+	"Link": "String",
+	"Dynamic Link": "String",
+	"Password": "String",
+	"Text": "String",
+	"Small Text": "String",
+	"Attach": "String",
+	"Attach Image": "String",
+	"Long Text": "String",
+	"Code": "String",
+	"Text Editor": "String",
+	"Markdown Editor": "String",
+	"HTML Editor": "String",
+	"Signature": "String",
+	"Barcode": "String",
+	"Geolocation": "String",
+	"JSON": "String",
+}
+
+
+def get_db_type_family(db_type):
+	"""Convert a MariaDB SQL type like 'varchar(140)' or 'int(11)' into High Level Families"""
+	db_type = str(db_type).lower()
+
+	if db_type.startswith(("int", "bigint", "tinyint", "decimal", "float", "double")):
+		return "Numeric"
+	elif db_type.startswith("datetime"):
+		return "Date"
+	elif db_type.startswith("date"):
+		return "Date"
+	elif db_type.startswith("time"):
+		return "Time"
+	else:
+		return "String"
+
 
 class DocType(Document):
 	# begin: auto-generated types
@@ -532,6 +589,9 @@ class DocType(Document):
 		if self.get("can_change_name_type"):
 			self.setup_autoincrement_and_sequence()
 
+		# Clean up any orphaned columns having the same name but different type as the new fields
+		self.drop_recreated_orphaned_columns()
+
 		try:
 			frappe.db.updatedb(self.name, Meta(self))
 		except Exception as e:
@@ -572,6 +632,32 @@ class DocType(Document):
 			self.sync_global_search()
 
 		clear_linked_doctype_cache()
+
+	def drop_recreated_orphaned_columns(self):
+		if self.is_new():
+			return
+
+		doc_before_save = self.get_doc_before_save()
+		if not doc_before_save:
+			return
+		old_fields = {df.fieldname for df in doc_before_save.get("fields") if df.fieldname}
+
+		for df in self.get("fields"):
+			# Only care about fields that didn't exist in the previous version
+			if not df.fieldname or df.fieldname in old_fields:
+				continue
+
+			if df.fieldname in (*frappe.db.OPTIONAL_COLUMNS, *frappe.db.DEFAULT_COLUMNS, "_seen"):
+				continue
+
+			if frappe.db.has_column(self.name, df.fieldname):
+				current_sql_type = frappe.db.get_column_type(self.name, df.fieldname)
+				old_type_family = get_db_type_family(current_sql_type)
+				new_type_family = FIELDTYPE_CAST_FAMILIES.get(df.fieldtype, "String")
+
+				is_safe = (old_type_family == new_type_family) or (new_type_family == "String")
+				if not is_safe:
+					frappe.db.sql_ddl(f"ALTER TABLE `tab{self.name}` DROP COLUMN `{df.fieldname}`")
 
 	@savepoint(catch=Exception)
 	def sync_doctype_layouts(self):

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -880,7 +880,7 @@ class TestDocType(IntegrationTestCase):
 		with self.assertRaises(frappe.DoesNotExistError):
 			frappe.get_meta(dt.name)
 
-	def test_orphaned_column_type_change(self):
+	def test_orphaned_column_add_with_different_type(self):
 		dt = new_doctype(
 			"Test Orphaned Column Validation",
 			fields=[{"fieldname": "some_field", "fieldtype": "Data", "label": "Some Field"}],

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -880,6 +880,42 @@ class TestDocType(IntegrationTestCase):
 		with self.assertRaises(frappe.DoesNotExistError):
 			frappe.get_meta(dt.name)
 
+	def test_orphaned_column_type_change(self):
+		dt = new_doctype(
+			"Test Orphaned Column Validation",
+			fields=[{"fieldname": "some_field", "fieldtype": "Data", "label": "Some Field"}],
+		).insert()
+
+		doc = frappe.get_doc({"doctype": dt.name, "some_field": "test data"}).insert()
+
+		# make the field orphan
+		dt.fields = []
+		dt.save()
+		frappe.db.commit()
+
+		# recreate orphaned column with different type
+		dt.append("fields", {"fieldname": "some_field", "fieldtype": "Int", "label": "Some Field"})
+		dt.save()
+
+		self.assertIn("int", frappe.db.get_column_type(dt.name, "some_field").lower())
+		doc.reload()
+		self.assertEqual(doc.some_field, 0)
+
+		doc.some_field = 42
+		doc.save()
+
+		dt.fields = []
+		dt.save()
+		frappe.db.commit()
+
+		# recreate orphaned column with compatible type (int -> varchar)
+		# old column data is preserved but with typecast
+		dt.append("fields", {"fieldname": "some_field", "fieldtype": "Data", "label": "Some Field"})
+		dt.save()
+
+		doc.reload()
+		self.assertEqual(doc.some_field, "42")
+
 
 def new_doctype(
 	name: str | None = None,

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -891,7 +891,6 @@ class TestDocType(IntegrationTestCase):
 		# make the field orphan
 		dt.fields = []
 		dt.save()
-		frappe.db.commit()
 
 		# recreate orphaned column with different type
 		dt.append("fields", {"fieldname": "some_field", "fieldtype": "Int", "label": "Some Field"})
@@ -906,7 +905,6 @@ class TestDocType(IntegrationTestCase):
 
 		dt.fields = []
 		dt.save()
-		frappe.db.commit()
 
 		# recreate orphaned column with compatible type (int -> varchar)
 		# old column data is preserved but with typecast


### PR DESCRIPTION
Removing a docfield with some pre existing data and then adding a docfield with same name but different type causes errors like:
<img width="576" height="176" alt="image" src="https://github.com/user-attachments/assets/8a84d545-168b-41b8-b045-bb51610f12ac" />

This happens as current implementation just tries to alter type directly. So if orphaned column has some data of type "Data", then ALTER query will fail when changing to types like float/int/etc

This PR fixes it:
- It drops the orphan column if type cast is incompatible
- If type cast is compatible (same data type or string type like data/text/etc.), then dropping is skipped and the orphaned column data is ALTERED handled in scheme.py