### PR TITLE
fix: hide previous nested menu when switching to another

### DIFF
--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -133,7 +133,9 @@ frappe.ui.menu = class ContextMenu {
 								me.current_menu = null;
 							} else {
 								// this ensures the other nested item would close before opening the next one
+								me.current_menu.nested_menus.forEach((m) => m.hide());
 								me.current_menu.hide();
+								me.current_menu = null;
 								me.nested_menus.forEach((menu) => {
 									if (menu.parent.get(0) == this) {
 										me.current_menu = menu;


### PR DESCRIPTION
Fixes: #37698

---
Before:


https://github.com/user-attachments/assets/bc3802c1-df4a-4b47-bd25-92cfed47d2b9

---
After

https://github.com/user-attachments/assets/3d4ca7ce-9802-4015-8c1e-9b4f64da8053

