### PR TITLE
feat: expose hide_toolbar in Customize Form

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -61,13 +61,18 @@ frappe.ui.form.on("Customize Form", {
 					if (r) {
 						if (r._server_messages && r._server_messages.length) {
 							frm.set_value("doc_type", "");
+							localStorage.removeItem("customize_doctype");
 						} else {
+							localStorage["customize_doctype"] = frm.doc.doc_type;
 							frm.refresh();
 							frm.trigger("add_customize_child_table_button");
 							frm.trigger("setup_default_views");
 						}
 					}
-					localStorage["customize_doctype"] = frm.doc.doc_type;
+				},
+				error: function () {
+					frm.set_value("doc_type", "");
+					localStorage.removeItem("customize_doctype");
 				},
 			});
 		} else {
@@ -96,69 +101,75 @@ frappe.ui.form.on("Customize Form", {
 		frm.page.clear_icons();
 
 		if (frm.doc.doc_type) {
-			frappe.model.with_doctype(frm.doc.doc_type).then(() => {
-				frm.page.set_title(__("Customize Form - {0}", [__(frm.doc.doc_type)]));
-				frappe.customize_form.set_primary_action(frm);
+			frappe.model.with_doctype(frm.doc.doc_type).then(
+				() => {
+					frm.page.set_title(__("Customize Form - {0}", [__(frm.doc.doc_type)]));
+					frappe.customize_form.set_primary_action(frm);
 
-				frm.add_custom_button(
-					__("Go to {0} List", [__(frm.doc.doc_type)]),
-					function () {
-						frappe.set_route("List", frm.doc.doc_type);
-					},
-					__("Actions")
-				);
+					frm.add_custom_button(
+						__("Go to {0} List", [__(frm.doc.doc_type)]),
+						function () {
+							frappe.set_route("List", frm.doc.doc_type);
+						},
+						__("Actions")
+					);
 
-				frm.add_custom_button(
-					__("Set Permissions"),
-					function () {
-						frappe.set_route("permission-manager", frm.doc.doc_type);
-					},
-					__("Actions")
-				);
+					frm.add_custom_button(
+						__("Set Permissions"),
+						function () {
+							frappe.set_route("permission-manager", frm.doc.doc_type);
+						},
+						__("Actions")
+					);
 
-				frm.add_custom_button(
-					__("Reload"),
-					function () {
-						frm.script_manager.trigger("doc_type");
-					},
-					__("Actions")
-				);
+					frm.add_custom_button(
+						__("Reload"),
+						function () {
+							frm.script_manager.trigger("doc_type");
+						},
+						__("Actions")
+					);
 
-				frm.add_custom_button(
-					__("Reset Layout"),
-					() => {
-						frm.trigger("reset_layout");
-					},
-					__("Actions")
-				);
+					frm.add_custom_button(
+						__("Reset Layout"),
+						() => {
+							frm.trigger("reset_layout");
+						},
+						__("Actions")
+					);
 
-				frm.add_custom_button(
-					__("Reset All Customizations"),
-					function () {
-						frappe.customize_form.confirm(__("Remove all customizations?"), frm);
-					},
-					__("Actions")
-				);
+					frm.add_custom_button(
+						__("Reset All Customizations"),
+						function () {
+							frappe.customize_form.confirm(__("Remove all customizations?"), frm);
+						},
+						__("Actions")
+					);
 
-				frm.add_custom_button(
-					__("Trim Table"),
-					function () {
-						frm.trigger("trim_table");
-					},
-					__("Actions")
-				);
+					frm.add_custom_button(
+						__("Trim Table"),
+						function () {
+							frm.trigger("trim_table");
+						},
+						__("Actions")
+					);
 
-				const is_autoname_autoincrement = frm.doc.autoname === "autoincrement";
-				frm.set_df_property("naming_rule", "hidden", is_autoname_autoincrement);
-				frm.set_df_property("autoname", "read_only", is_autoname_autoincrement);
-				frm.toggle_display(
-					["queue_in_background"],
-					frappe.get_meta(frm.doc.doc_type).is_submittable || 0
-				);
+					const is_autoname_autoincrement = frm.doc.autoname === "autoincrement";
+					frm.set_df_property("naming_rule", "hidden", is_autoname_autoincrement);
+					frm.set_df_property("autoname", "read_only", is_autoname_autoincrement);
+					frm.toggle_display(
+						["queue_in_background"],
+						frappe.get_meta(frm.doc.doc_type).is_submittable || 0
+					);
 
-				render_form_builder(frm);
-				frm.get_field("form_builder").tab.set_active();
-			});
+					render_form_builder(frm);
+					frm.get_field("form_builder").tab.set_active();
+				},
+				() => {
+					frm.set_value("doc_type", "");
+					localStorage.removeItem("customize_doctype");
+				}
+			);
 		}
 
 		frm.events.setup_export(frm);

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -101,8 +101,9 @@ frappe.ui.form.on("Customize Form", {
 		frm.page.clear_icons();
 
 		if (frm.doc.doc_type) {
-			frappe.model.with_doctype(frm.doc.doc_type).then(
-				() => {
+			frappe.model
+				.with_doctype(frm.doc.doc_type)
+				.then(() => {
 					frm.page.set_title(__("Customize Form - {0}", [__(frm.doc.doc_type)]));
 					frappe.customize_form.set_primary_action(frm);
 
@@ -164,12 +165,11 @@ frappe.ui.form.on("Customize Form", {
 
 					render_form_builder(frm);
 					frm.get_field("form_builder").tab.set_active();
-				},
-				() => {
+				})
+				.catch(() => {
 					frm.set_value("doc_type", "");
 					localStorage.removeItem("customize_doctype");
-				}
-			);
+				});
 		}
 
 		frm.events.setup_export(frm);

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -32,6 +32,7 @@
   "image_field",
   "max_attachments",
   "column_break_21",
+  "hide_toolbar",
   "allow_copy",
   "make_attachments_public",
   "protect_attached_files",
@@ -104,6 +105,12 @@
    "fieldname": "max_attachments",
    "fieldtype": "Int",
    "label": "Max Attachments"
+  },
+  {
+   "default": "0",
+   "fieldname": "hide_toolbar",
+   "fieldtype": "Check",
+   "label": "Hide Sidebar, Menu, and Comments"
   },
   {
    "default": "0",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -727,6 +727,7 @@ doctype_properties = {
 	"sort_field": "Data",
 	"sort_order": "Data",
 	"default_print_format": "Data",
+	"hide_toolbar": "Check",
 	"allow_copy": "Check",
 	"istable": "Check",
 	"quick_entry": "Check",


### PR DESCRIPTION
Closes #37619

This is a basic configuration which should be present in Customise Form.

### Screenshot :

<img width="1507" height="868" alt="Screenshot 2026-03-03 at 8 05 52 PM" src="https://github.com/user-attachments/assets/d81e5241-11fd-4d0d-b2a9-5ce733f5c413" />

### The sidebar is visible if the hide_toolbar checkbox is unchecked 

<img width="1512" height="865" alt="Screenshot 2026-03-03 at 8 49 34 PM" src="https://github.com/user-attachments/assets/d2ee0e23-69b2-4e3b-a020-7f7ee61786b2" />


# This fixes another small issue

### Ref video 

https://github.com/user-attachments/assets/0cf16507-4f78-4662-9d1d-289f83ac6b37

Below block of always ran regardless of if/else above it

```if (r._server_messages && r._server_messages.length) {
    frm.set_value("doc_type", "");
} else {
    frm.refresh();
    frm.trigger("add_customize_child_table_button");
    frm.trigger("setup_default_views");
}
localStorage["customize_doctype"] = frm.doc.doc_type;
```

When the server returns an error while loading a doctype in Customize Form, the doctype was still being saved to localStorage, causing it to reload the broken doctype on every subsequent visit.

Fixed by moving the localStorage set inside the success branch and clearing it in the error callback.

#no-docs