### PR TITLE
fix: pass letterhead and render layout header/footer in print format

### DIFF
--- a/frappe/utils/weasyprint.py
+++ b/frappe/utils/weasyprint.py
@@ -92,9 +92,9 @@ class PrintFormatGenerator:
 
 	def get_header_footer_html(self):
 		header_html = footer_html = None
-		if self.letterhead:
+		if self.letterhead or self.layout.get("header"):
 			header_html = frappe.render_template("templates/print_format/print_header.html", self.context)
-		if self.letterhead:
+		if self.letterhead or self.layout.get("footer"):
 			footer_html = frappe.render_template("templates/print_format/print_footer.html", self.context)
 		return header_html, footer_html
 

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -76,7 +76,10 @@ def get_context(context) -> PrintContext:
 		from frappe.utils.weasyprint import get_html
 
 		body = get_html(
-			doctype=frappe.form_dict.doctype, name=frappe.form_dict.name, print_format=print_format.name
+			doctype=frappe.form_dict.doctype,
+			name=frappe.form_dict.name,
+			print_format=print_format.name,
+			letterhead=letterhead,
 		)
 		body += trigger_print_script
 	else:


### PR DESCRIPTION
Closes #37620

## Summary

- `printview.py` was calling `get_html()` for `print_format_builder_beta` formats without forwarding the `letterhead` parameter from the URL.  
  As a result, the letterhead (and its included `layout.header`) was not applied during browser print.

- `get_header_footer_html()` in `weasyprint.py` only rendered the header/footer template when a letterhead was set - 
  which caused `layout.header` / `layout.footer` to be skipped if no letterhead was configured.

## Fix

- Forward the already-computed `letterhead` variable to `get_html()` in `printview.py`.

- Extend the conditions in `get_header_footer_html()` (in `weasyprint.py`) to render header/footer when  
  `layout.header` / `layout.footer` exist - regardless of whether a letterhead is configured.
  
  
 ## Preview
 
<img width="1512" height="869" alt="Screenshot 2026-03-04 at 2 07 15 AM" src="https://github.com/user-attachments/assets/473788e3-1003-4421-aa5e-df103e2a3517" />

## PDF button

<img width="1509" height="872" alt="Screenshot 2026-03-04 at 2 07 48 AM" src="https://github.com/user-attachments/assets/d7b52e73-7fcb-4a34-a6db-64e4bfdebe05" />

## Print

<img width="1394" height="905" alt="Screenshot 2026-03-04 at 2 08 17 AM" src="https://github.com/user-attachments/assets/7ae8ad48-9dd3-41ec-ab6f-d21a0b9aa762" />

