### PR TITLE
fix(oauth): add another fallback for first name

### DIFF
--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -331,7 +331,7 @@ def update_oauth_user(user: str, data: dict, provider: str):
 
 
 def get_first_name(data: dict) -> str:
-	return data.get("first_name") or data.get("given_name") or data.get("name")
+	return data.get("first_name") or data.get("given_name") or data.get("name") or data.get("login")
 
 
 def get_last_name(data: dict) -> str:


### PR DESCRIPTION
Github doesn't mandate a first name, but frappe does, so fallback to username.

<hr>

Resolves #37742
