### PR TITLE
fix(email): validate IMAP folders using `SELECT` instead of `LIST` parsing

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -197,7 +197,8 @@ class EmailAccount(Document):
 						try:
 							self.validate_imap_folders_exist(server)
 						finally:
-							server.logout()
+							if hasattr(server, "imap") and server.imap is not None:
+								server.logout()
 
 					self.no_failed = 0
 
@@ -224,7 +225,10 @@ class EmailAccount(Document):
 			frappe_mail_client.validate()
 
 	def validate_imap_folders_exist(self, server: EmailServer) -> None:
-		"""Validate that the configured IMAP folders exist on the server."""
+		"""Validate that each configured IMAP folder exists on the server by attempting to SELECT it directly."""
+
+		if not hasattr(server, "imap") or server.imap is None:
+			server.connect()
 
 		status, mailboxes = server.imap.list()
 		if status != "OK":
@@ -232,22 +236,29 @@ class EmailAccount(Document):
 				_(
 					"Failed to retrieve the list of IMAP folders from the server. Please ensure the mailbox is accessible and the account has permission to list folders."
 				),
-				title=_("IMAP Folder Not Found"),
+				title=_("IMAP Folder Validation Failed"),
 			)
 
-		folders = []
-		for mailbox in mailboxes:
-			decoded = mailbox.decode()
-			parts = decoded.split(' "/" ')
-			if len(parts) == 2:
-				folder = parts[1].strip('"')
-				folders.append(folder)
+		if not mailboxes:
+			frappe.throw(
+				_(
+					"No IMAP folders were found on the server. Please verify the email account settings and ensure the mailbox contains folders."
+				),
+				title=_("IMAP Folder Validation Failed"),
+			)
 
-		if not folders:
-			frappe.throw(_("The server did not return any IMAP folders for this account."))
+		missing_folders = []
+		for row in self.imap_folder:
+			folder = row.folder_name.strip()
 
-		configured_folders = [f.folder_name for f in self.imap_folder]
-		missing_folders = [folder for folder in configured_folders if folder not in folders]
+			if not folder:
+				frappe.throw(_("IMAP Folder name cannot be empty."))
+
+			status, _response = server.imap.select(f'"{folder}"', readonly=True)
+
+			if status != "OK":
+				missing_folders.append(folder)
+				continue
 
 		if missing_folders:
 			missing_list = "".join(
@@ -255,10 +266,11 @@ class EmailAccount(Document):
 			)
 			frappe.throw(
 				_(
-					"The following configured IMAP folder(s) were not found on the server:<br>"
+					"The following configured IMAP folder(s) were not found or "
+					"are not accessible on the server:<br>"
 					"<ul>{0}</ul>"
 					"Please verify the folder names exactly as they appear on the server "
-					"(folder names are case-sensitive)."
+					"and ensure the account has access to them."
 				).format(missing_list),
 				title=_("IMAP Folder Not Found"),
 			)
@@ -380,7 +392,7 @@ class EmailAccount(Document):
 			frappe.throw(_("{0} is required").format("Email Server"))
 
 		if self.flags.validate_imap_pop_connection:
-			args.timeout = 15
+			args.timeout = 30
 
 		email_server = EmailServer(frappe._dict(args))
 		self.check_email_server_connection(email_server, in_receive)


### PR DESCRIPTION
Use IMAP SELECT instead of LIST parsing to validate configured folders.
Although slightly slower, but ensures reliable validation across different IMAP servers. Timeout increased to 30s.

closes: https://github.com/frappe/frappe/issues/37751