### PR TITLE
fix: percent precision when value is undefined

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -94,7 +94,9 @@ frappe.form.formatters = {
 		if (value === null) {
 			return "";
 		}
-		const valuePrecision = value.toString().split(".")[1]?.length || 0;
+
+		const valuePrecision = value?.toString().split(".")[1]?.length || 0;
+
 		const precision =
 			docfield.precision ||
 			cint(frappe.boot.sysdefaults && frappe.boot.sysdefaults.float_precision) ||


### PR DESCRIPTION
In formatter, if the value is undefined for percent precision, it breaks; this fixes that issue. 


https://github.com/user-attachments/assets/35b6d517-2c13-4460-80bd-c581ea79fdcb

