### PR TITLE
fix: use string representation of exceptions in translated strings

### DIFF
--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -58,7 +58,7 @@ def handle_rpc_call(method: str, doctype: str | None = None):
 	try:
 		method = frappe.get_attr(method)
 	except Exception as e:
-		frappe.throw(_("Failed to get method {0} with {1}").format(method, e))
+		frappe.throw(_("Failed to get method {0} with {1}").format(method, str(e)))
 
 	is_whitelisted(method)
 	is_valid_http_method(method)

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -453,7 +453,7 @@ class Engine:
 							self.query = self.query.where(combined_criterion)
 				except Exception as e:
 					# Log the original filters list for better debugging context
-					frappe.throw(_("Error parsing nested filters: {0}. {1}").format(filters, e), exc=e)
+					frappe.throw(_("Error parsing nested filters: {0}. {1}").format(filters, str(e)), exc=e)
 
 			else:  # Not a nested structure, assume it's a list of simple filters (implicitly ANDed)
 				for filter_item in filters:

--- a/frappe/desk/doctype/dashboard/dashboard.py
+++ b/frappe/desk/doctype/dashboard/dashboard.py
@@ -64,7 +64,7 @@ class Dashboard(Document):
 			try:
 				json.loads(self.chart_options)
 			except ValueError as error:
-				frappe.throw(_("Invalid json added in the custom options: {0}").format(error))
+				frappe.throw(_("Invalid json added in the custom options: {0}").format(str(error)))
 
 
 def get_permission_query_conditions(user):

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -424,7 +424,7 @@ class DashboardChart(Document):
 			try:
 				json.loads(self.custom_options)
 			except ValueError as error:
-				frappe.throw(_("Invalid json added in the custom options: {0}").format(error))
+				frappe.throw(_("Invalid json added in the custom options: {0}").format(str(error)))
 
 
 @frappe.whitelist()

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -103,7 +103,7 @@ class Notification(Document):
 				return _("Yes") if evaluate_filters(doc, json.loads(self.filters)) else _("No")
 		except Exception as e:
 			frappe.local.message_log = []
-			return _("Failed to evaluate conditions: {}").format(e)
+			return _("Failed to evaluate conditions: {}").format(str(e))
 
 	@frappe.whitelist()
 	def preview_message(self, preview_document: str):
@@ -120,7 +120,7 @@ class Notification(Document):
 				return frappe.utils.strip_html_tags(msg)
 			return msg
 		except Exception as e:
-			return _("Failed to render message: {}").format(e)
+			return _("Failed to render message: {}").format(str(e))
 
 	@frappe.whitelist()
 	def preview_subject(self, preview_document: str):
@@ -138,7 +138,7 @@ class Notification(Document):
 				return frappe.render_template(self.subject, context)
 			return self.subject
 		except Exception as e:
-			return _("Failed to render subject: {}").format(e)
+			return _("Failed to render subject: {}").format(str(e))
 
 	# END: PreviewRenderer API
 

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -74,7 +74,7 @@ def execute_cmd(cmd, from_async=False):
 	try:
 		method = get_attr(cmd)
 	except Exception as e:
-		frappe.throw(_("Failed to get method for command {0} with {1}").format(cmd, e))
+		frappe.throw(_("Failed to get method for command {0} with {1}").format(cmd, str(e)))
 
 	if from_async:
 		method = method.queue

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -99,7 +99,7 @@ class LDAPSettings(Document):
 
 				except LDAPAttributeError as ex:
 					frappe.throw(
-						_("LDAP settings incorrect. validation response was: {0}").format(ex),
+						_("LDAP settings incorrect. validation response was: {0}").format(str(ex)),
 						title=_("Misconfigured"),
 					)
 

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -88,7 +88,7 @@ class Webhook(Document):
 			try:
 				frappe.safe_eval(self.condition, eval_locals=get_context(temp_doc))
 			except Exception as e:
-				frappe.throw(_("Invalid Condition: {}").format(e))
+				frappe.throw(_("Invalid Condition: {}").format(str(e)))
 
 	def validate_request_url(self):
 		try:
@@ -128,7 +128,7 @@ class Webhook(Document):
 			met_condition = frappe.safe_eval(self.condition, eval_locals=get_context(doc))
 		except Exception as e:
 			frappe.local.message_log = []
-			return _("Failed to evaluate conditions: {}").format(e)
+			return _("Failed to evaluate conditions: {}").format(str(e))
 		return _("Yes") if met_condition else _("No")
 
 	@frappe.whitelist()
@@ -138,7 +138,7 @@ class Webhook(Document):
 			return frappe.as_json(get_webhook_data(doc, self))
 		except Exception as e:
 			frappe.local.message_log = []
-			return _("Failed to compute request body: {}").format(e)
+			return _("Failed to compute request body: {}").format(str(e))
 
 
 def get_context(doc):

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -109,7 +109,7 @@ def evaluate_workflow_value(value, evaluate_as_expression, doc):
 			return frappe.safe_eval(value, get_workflow_safe_globals(), dict(doc=doc.as_dict()))
 		except Exception as e:
 			frappe.throw(
-				_("Invalid expression in Workflow Update Value: {0}").format(e),
+				_("Invalid expression in Workflow Update Value: {0}").format(str(e)),
 				title=_("Workflow Evaluation Error"),
 			)
 	else:

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -58,7 +58,7 @@ def pdf_body_html(template, args, **kwargs):
 		# Guess line number ?
 		frappe.throw(
 			_("Error in print format on line {0}: {1}").format(
-				_guess_template_error_line_number(template), e
+				_guess_template_error_line_number(template), str(e)
 			),
 			exc=frappe.PrintFormatError,
 			title=_("Print Format Error"),


### PR DESCRIPTION
Reference: support ticket 61295
