### PR TITLE
fix: remove "Try New Print Designer" link

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -208,13 +208,7 @@ frappe.ui.form.PrintView = class {
 
 		// print designer link
 		if (!cint(frappe.boot.sysdefaults.disable_product_suggestion)) {
-			if (Object.keys(frappe.boot.versions).includes("print_designer")) {
-				this.page.add_inner_message(`
-				<a style="line-height: 2.4" href="/desk/print-designer?doctype=${this.frm.doctype}">
-					${__("Try the new Print Designer")}
-				</a>
-				`);
-			} else {
+			if (!Object.keys(frappe.boot.versions).includes("print_designer")) {
 				this.page.add_inner_message(`
 				<a style="line-height: 2.4" href="https://frappecloud.com/marketplace/apps/print_designer?utm_source=framework-desk&utm_medium=print-view&utm_campaign=try-link">
 					${__("Try the new Print Designer")}


### PR DESCRIPTION
Frappe should only nudge users to install Print Designer, not navigate to it. This link was also triggered under a wrong "disable product suggestions" condition check

**Go to new Print Designer** will handle in `print_designer` app PR:
- https://github.com/frappe/print_designer/pull/520

Context: https://github.com/frappe/print_designer/pull/520#issuecomment-3997479343
