### PR TITLE
fix: update link field handling in ControlLink and BulkOperations to ensure correct `link_fieldname` usage

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -412,7 +412,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			ignore_user_permissions: this.df.ignore_user_permissions,
 			reference_doctype: this.get_reference_doctype() || "",
 			page_length: cint(frappe.boot.sysdefaults?.link_field_results_limit) || 10,
-			link_fieldname: this.df.fieldname,
+			link_fieldname: this.df.link_fieldname || this.df.fieldname,
 		};
 
 		this.set_custom_query(args);

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -413,6 +413,10 @@ export default class BulkOperations {
 			delete new_df.depends_on;
 			delete new_df.is_child_field;
 			delete new_df.child_doctype;
+			// Preserve actual fieldname for Link/Dynamic Link so search_link gets correct link_fieldname
+			if (new_df.fieldtype === "Link" || new_df.fieldtype === "Dynamic Link") {
+				new_df.link_fieldname = new_df.fieldname;
+			}
 			dialogObj.replace_field("value", new_df);
 			show_help_text();
 		}


### PR DESCRIPTION
## Fix Bulk Edit: ValidationError on Link fields ("Field 'value' not found")

### Issue
1. Bulk Edit uses a single slot with fieldname: "value" and replaces it with the real field via replace_field("value", new_df).
2. That overwrites the field’s fieldname to "value".
3. The Link control sends link_fieldname: "value" to search_link, so backend validation fails (no field named value on the doctype).

### Fix
1. In Bulk Edit only: for Link/Dynamic Link fields, set new_df.link_fieldname = new_df.fieldname before replace_field (bulk_operations.js).
2. In Link control: use link_fieldname: this.df.link_fieldname || this.df.fieldname when calling search_link (link.js).