### PR TITLE
feat(tree): add on_node_render hook for post node render extensibility

### DIFF
--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -18,6 +18,7 @@ frappe.ui.Tree = class {
 		get_label,
 		on_render,
 		on_click,
+		on_node_render,
 	}) {
 		$.extend(this, arguments[0]);
 		if (root_value == null) {
@@ -164,11 +165,13 @@ frappe.ui.Tree = class {
 					() => this.get_all_nodes(value, is_root, node.label),
 					(data_list) => this.render_children_of_all_nodes(data_list),
 					() => this.set_selected_node(node),
+					() => this.on_node_render && this.on_node_render(node, deep),
 			  ])
 			: frappe.run_serially([
 					() => this.get_nodes(value, is_root),
 					(data_set) => this.render_node_children(node, data_set),
 					() => this.set_selected_node(node),
+					() => this.on_node_render && this.on_node_render(node, deep),
 			  ]);
 	}
 

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -245,6 +245,7 @@ frappe.views.TreeView = class TreeView {
 			get_label: this.opts.get_label,
 			on_render: this.opts.onrender,
 			on_get_node: this.opts.on_get_node,
+			on_node_render: this.opts.on_node_render,
 			on_click: (node) => {
 				this.select_node(node);
 			},


### PR DESCRIPTION
The existing hook 'on_get_node' executes during node data fetch inside get_nodes and get_all_nodes methods and is not ideal for post-DOM rendering use-cases. This created timing misalignment between when nodes exist in the DOM and when balances should be rendered on the nodes.

In the Chart of Accounts, balance fetching and rendering were tightly coupled, which caused issues with rendering balances for the nodes that were just fetched and rendered on any parent node expansion.

What this PR does:
1. Adds an optional on_node_render(node, deep) hook.
2. Executes it after node fetching, rendering and selection logic.
3. Keeps it non-mandatory so that it remains backward compatible.

Required for frappe/erpnext#53044
