### PR TITLE
fix: move logout from user avatar to sidebar dropdown

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -471,21 +471,6 @@ get_changelog_feed = "frappe.desk.doctype.changelog_feed.changelog_feed.get_feed
 
 export_python_type_annotations = True
 
-standard_navbar_items = [
-	{
-		"item_label": "User Settings",
-		"item_type": "Action",
-		"action": "frappe.ui.toolbar.route_to_user()",
-		"is_standard": 1,
-	},
-	{
-		"item_label": "Log out",
-		"item_type": "Action",
-		"action": "frappe.app.logout()",
-		"is_standard": 1,
-	},
-]
-
 standard_help_items = [
 	{
 		"item_label": "About",

--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -46,15 +46,22 @@ frappe.ui.menu = class ContextMenu {
 	make() {
 		this.template.empty();
 		this.menu_items_to_show = [];
-		this.menu_items.forEach((f) => {
-			f.condition =
-				f.condition ||
+		this.menu_items.forEach((item) => {
+			item.condition =
+				item.condition ||
 				function () {
 					return true;
 				};
-			if (f.condition()) {
-				this.add_menu_item(f);
-				this.menu_items_to_show.push(f);
+			console.log(typeof item.condition);
+			let render = false;
+			if (typeof item.condition == "function") {
+				render = item.condition();
+			} else {
+				render = frappe.utils.eval_expression(item.condition);
+			}
+			if (render) {
+				this.add_menu_item(item);
+				this.menu_items_to_show.push(item);
 			}
 		});
 

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -52,10 +52,10 @@
 		 			<span> {%= __("Collapse") %} </span>
 				</a>
 				<div class="nav-item dropdown dropdown-navbar-user dropdown-mobile mt-3">
-					<button
+					<a
 						class="align-center btn-reset flex nav-link"
 						style="width: 100%; height: 40px;"
-						data-toggle="dropdown"
+						onclick="return frappe.ui.toolbar.route_to_user()"
 						aria-label="{{ __("User Menu") }}"
 					>
 						<div> {{ avatar }} </div>
@@ -68,25 +68,7 @@
 							</span>
 						</div>
 
-					</button>
-					<div class="dropdown-menu dropdown-menu-left" id="toolbar-user" role="menu">
-						{% for item in navbar_settings.settings_dropdown %}
-							{% var condition = item.condition ? eval(item.condition) : true %}
-							{% if (condition && !item.hidden) { %}
-								{% if (item.route) { %}
-									<a class="dropdown-item" href="{{ item.route }}">
-										{%= __(item.item_label) %}
-									</a>
-								{% } else if (item.action) { %}
-									<button class="btn-reset dropdown-item" onclick="return {{ item.action }}">
-										{%= __(item.item_label) %}
-									</button>
-								{% } else { %}
-									<div class="dropdown-divider"></div>
-								{% } %}
-							{% } %}
-						{% endfor %}
-					</div>
+					</a>
 				</div>
 			</div>
 		</div>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -76,6 +76,14 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 					label: "Help",
 					icon: "info",
 					items: this.get_help_siblings(),
+				},
+				{
+					name: "logout",
+					label: "Logout",
+					icon: "logout",
+					onClick: function () {
+						return frappe.app.logout();
+					},
 				}
 			);
 		}

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -87,12 +87,18 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 				}
 			);
 		}
+		this.add_navbar_items();
 		this.make();
 		this.setup_app_switcher();
 		this.populate_dropdown_menu();
 		this.setup_select_options();
 	}
-
+	add_navbar_items() {
+		frappe.boot.navbar_settings.settings_dropdown.forEach((item) => {
+			item.label = item.item_label;
+			this.dropdown_items.push(item);
+		});
+	}
 	fetch_related_icons() {
 		let sibling_workspaces = [];
 		let workspaces_not_to_show = ["My Workspaces"];


### PR DESCRIPTION
This PR moves the logout option from user avatar to sidebar header dropdown
Customization done via standard_navbar_items will be visible here now. 


https://github.com/user-attachments/assets/a0116587-0bad-44c9-a9da-fc64df98571e

