### PR TITLE
fix: add missing currency_fraction for 20 currencies

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -212,6 +212,8 @@
  "Bahamas": {
   "code": "bs",
   "currency": "BSD",
+  "currency_fraction": "Cent",
+  "currency_fraction_units": 100,
   "currency_name": "Bahamian Dollar",
   "number_format": "#,###.##",
   "timezones": [
@@ -338,6 +340,8 @@
  "Bolivia, Plurinational State of": {
   "code": "bo",
   "currency": "BOB",
+  "currency_fraction": "Centavo",
+  "currency_fraction_units": 100,
   "currency_name": "Boliviano",
   "number_format": "#,###.##",
   "isd": "+591"
@@ -418,6 +422,8 @@
  "Brunei Darussalam": {
   "code": "bn",
   "currency": "BND",
+  "currency_fraction": "Sen",
+  "currency_fraction_units": 100,
   "currency_name": "Brunei Dollar",
   "number_format": "#,###.##",
   "timezones": [
@@ -600,6 +606,7 @@
  "China": {
   "code": "cn",
   "currency": "CNY",
+  "currency_fraction": "Fen",
   "currency_name": "Yuan Renminbi",
   "currency_fraction_units": 100,
   "smallest_currency_fraction_value": 0.01,
@@ -909,6 +916,8 @@
  "Falkland Islands (Malvinas)": {
   "code": "fk",
   "currency": "FKP",
+  "currency_fraction": "Penny",
+  "currency_fraction_units": 100,
   "currency_name": "Falkland Islands Pound",
   "number_format": "#,###.##",
   "isd": "+500"
@@ -1006,6 +1015,8 @@
  "Gambia": {
   "code": "gm",
   "currency": "GMD",
+  "currency_fraction": "Butut",
+  "currency_fraction_units": 100,
   "currency_name": "Dalasi",
   "number_format": "#,###.##",
   "timezones": [
@@ -1289,6 +1300,8 @@
  "Iran": {
   "code": "ir",
   "currency": "IRR",
+  "currency_fraction": "Dinar",
+  "currency_fraction_units": 100,
   "currency_name": "Iranian Rial",
   "currency_symbol": "\ufdfc",
   "number_format": "#,###.##",
@@ -1470,6 +1483,8 @@
  "Korea, Democratic Peoples Republic of": {
   "code": "kp",
   "currency": "KPW",
+  "currency_fraction": "Chon",
+  "currency_fraction_units": 100,
   "currency_name": "North Korean Won",
   "number_format": "#,###.##",
   "isd": "+850"
@@ -1477,6 +1492,8 @@
  "Korea, Republic of": {
   "code": "kr",
   "currency": "KRW",
+  "currency_fraction": "Jeon",
+  "currency_fraction_units": 100,
   "currency_name": "Won",
   "number_format": "#,###",
   "isd": "+82"
@@ -1510,6 +1527,8 @@
  "Lao Peoples Democratic Republic": {
   "code": "la",
   "currency": "LAK",
+  "currency_fraction": "Att",
+  "currency_fraction_units": 100,
   "currency_name": "Kip",
   "number_format": "#,###.##",
   "timezones": [
@@ -1623,6 +1642,8 @@
  "Macao": {
   "code": "mo",
   "currency": "MOP",
+  "currency_fraction": "Avo",
+  "currency_fraction_units": 100,
   "currency_name": "Pataca",
   "number_format": "#,###.##",
   "isd": "+853"
@@ -1801,6 +1822,8 @@
  "Moldova, Republic of": {
   "code": "md",
   "currency": "MDL",
+  "currency_fraction": "Ban",
+  "currency_fraction_units": 100,
   "currency_name": "Moldovan Leu",
   "number_format": "#,###.##",
   "isd": "+373"
@@ -1888,6 +1911,8 @@
  "Myanmar": {
   "code": "mm",
   "currency": "MMK",
+  "currency_fraction": "Pya",
+  "currency_fraction_units": 100,
   "currency_name": "Kyat",
   "number_format": "#,###.##",
   "timezones": [
@@ -2237,6 +2262,8 @@
  "Russian Federation": {
   "code": "ru",
   "currency": "RUB",
+  "currency_fraction": "Kopek",
+  "currency_fraction_units": 100,
   "currency_name": "Russian Ruble",
   "number_format": "#.###,##",
   "isd": "+7"
@@ -2267,6 +2294,8 @@
  "Saint Helena, Ascension and Tristan da Cunha": {
   "code": "sh",
   "currency": "SHP",
+  "currency_fraction": "Penny",
+  "currency_fraction_units": 100,
   "currency_name": "Saint Helena Pound",
   "number_format": "#,###.##",
   "isd": "+290"
@@ -2349,6 +2378,8 @@
  "Sao Tome and Principe": {
   "code": "st",
   "currency": "STD",
+  "currency_fraction": "Cêntimo",
+  "currency_fraction_units": 100,
   "currency_name": "Dobra",
   "number_format": "#,###.##",
   "isd": "+239"
@@ -2623,6 +2654,8 @@
  "Syria": {
   "code": "sy",
   "currency": "SYP",
+  "currency_fraction": "Piastre",
+  "currency_fraction_units": 100,
   "currency_name": "Syrian Pound",
   "number_format": "#,###.##",
   "isd": "+963"
@@ -2630,6 +2663,8 @@
  "Taiwan": {
   "code": "tw",
   "currency": "TWD",
+  "currency_fraction": "Fen",
+  "currency_fraction_units": 100,
   "date_format": "yyyy-mm-dd",
   "number_format": "#,###.##",
   "isd": "+886"
@@ -2648,6 +2683,8 @@
  "Tanzania": {
   "code": "tz",
   "currency": "TZS",
+  "currency_fraction": "Senti",
+  "currency_fraction_units": 100,
   "currency_name": "Tanzanian Shilling",
   "number_format": "#,###.##",
   "timezones": [
@@ -2932,6 +2969,8 @@
  "Vietnam": {
   "code": "vn",
   "currency": "VND",
+  "currency_fraction": "Hào",
+  "currency_fraction_units": 10,
   "currency_name": "Dong",
   "number_format": "#.###",
   "isd": "+84"


### PR DESCRIPTION
Adds missing `currency_fraction` values for 20 currencies in `country_info.json`. These currencies were being inserted into the database with `fraction = None`, causing a `TypeError` in `money_in_words()` when called with a decimal amount.

Fixes #37394


### Root Cause

`country_info.json` was missing the `currency_fraction` key for the following currencies, resulting in `None` being stored in the `Currency` doctype on first install/seed.

| Currency | Fraction Added |
|----------|----------------|
| VND | Hào |
| TZS | Senti |
| TWD | Fen |
| SYP | Piastre |
| STD | Cêntimo |
| SHP | Penny |
| RUB | Kopek |
| MMK | Pya |
| MDL | Ban |
| MOP | Avo |
| LAK | Att |
| KRW | Jeon |
| KPW | Chon |
| IRR | Dinar |
| GMD | Butut |
| FKP | Penny |
| CNY | Fen |
| BND | Sen |
| BOB | Centavo |
| BSD | Cent |


### Changes
- `frappe/geo/country_info.json` - added `currency_fraction` and `currency_fraction_units` for 20 currencies
