### PR TITLE
fix(UI/UX): persist datetime fieldvalue on click

### DIFF
--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -10,11 +10,16 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 		} else if (value.toLowerCase() === "now") {
 			value = frappe.datetime.now_datetime();
 		}
+		const raw_value = value;
 		let should_refresh = this.last_value && this.last_value !== value;
 		value = this.format_for_input(value);
 		this.$input && this.$input.val(value);
 		if (should_refresh) {
 			this.datepicker.selectDate(frappe.datetime.user_to_obj(value));
+		} else if (value && !this.datepicker.selectedDates.length) {
+			const date_obj = frappe.datetime.str_to_obj(raw_value);
+			this.datepicker.selectedDates = [date_obj];
+			this.datepicker.viewDate = date_obj;
 		}
 	}
 


### PR DESCRIPTION
closes Ticket #61791 wherein on clicking any `datetime` field value, the value instead of persisting was clearing . This PR fixes that by persisting the value when clicked, this allows the user to have their original value untouched when the field is clicked mistakenly. 

**Before:**


https://github.com/user-attachments/assets/314daf27-980d-4501-8761-c50bef9ffd82


**After**:


https://github.com/user-attachments/assets/6d1c7ecb-0882-4164-9bec-91a69ef4633d



Edit: Test seems to be failing due to the new fix...might need to rethink...