### PR TITLE
fix: retry background jobs on QueryDeadlockError and QueryTimeoutError

### DIFF
--- a/frappe/tests/test_background_jobs.py
+++ b/frappe/tests/test_background_jobs.py
@@ -54,6 +54,64 @@ class TestBackgroundJobs(IntegrationTestCase):
 		# lesser is earlier
 		self.assertTrue(high_priority_job.get_position() < low_priority_job.get_position())
 
+	def test_query_deadlock_error_retries_job(self):
+		"""QueryDeadlockError raised by frappe.db.sql should trigger job retry."""
+		call_count = 0
+
+		def deadlock_once(**kwargs):
+			nonlocal call_count
+			call_count += 1
+			if call_count == 1:
+				raise frappe.QueryDeadlockError(1020, "Record has changed since last read in table 'tabContact'")
+			return "success"
+
+		with (
+			freeze_local() as locals,
+			frappe.init_site(locals.site),
+			patch("time.sleep"),
+		):
+			frappe.connect()
+			result = execute_job(
+				site=frappe.local.site,
+				user="Administrator",
+				method=deadlock_once,
+				event=None,
+				job_name="test_deadlock",
+				is_async=True,
+				kwargs={},
+			)
+			self.assertEqual(result, "success")
+			self.assertEqual(call_count, 2)
+
+	def test_query_timeout_error_retries_job(self):
+		"""QueryTimeoutError raised by frappe.db.sql should trigger job retry."""
+		call_count = 0
+
+		def timeout_once(**kwargs):
+			nonlocal call_count
+			call_count += 1
+			if call_count == 1:
+				raise frappe.QueryTimeoutError(1205, "Lock wait timeout exceeded")
+			return "success"
+
+		with (
+			freeze_local() as locals,
+			frappe.init_site(locals.site),
+			patch("time.sleep"),
+		):
+			frappe.connect()
+			result = execute_job(
+				site=frappe.local.site,
+				user="Administrator",
+				method=timeout_once,
+				event=None,
+				job_name="test_timeout",
+				is_async=True,
+				kwargs={},
+			)
+			self.assertEqual(result, "success")
+			self.assertEqual(call_count, 2)
+
 	def test_job_hooks(self):
 		self.addCleanup(lambda: _test_JOB_HOOK.clear())
 		with (

--- a/frappe/tests/test_background_jobs.py
+++ b/frappe/tests/test_background_jobs.py
@@ -155,8 +155,10 @@ def after_job(*args, **kwargs):
 def freeze_local():
 	locals = frappe.local
 	frappe.local = Local()
-	yield locals
-	frappe.local = locals
+	try:
+		yield locals
+	finally:
+		frappe.local = locals
 
 
 def patch_job_hooks(event: str):

--- a/frappe/tests/test_background_jobs.py
+++ b/frappe/tests/test_background_jobs.py
@@ -62,7 +62,9 @@ class TestBackgroundJobs(IntegrationTestCase):
 			nonlocal call_count
 			call_count += 1
 			if call_count == 1:
-				raise frappe.QueryDeadlockError(1020, "Record has changed since last read in table 'tabContact'")
+				raise frappe.QueryDeadlockError(
+					1020, "Record has changed since last read in table 'tabContact'"
+				)
 			return "success"
 
 		with (

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -272,16 +272,22 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 	try:
 		retval = method(**kwargs)
 
-	except (frappe.db.InternalError, frappe.RetryBackgroundJobError) as e:
+	except (
+		frappe.db.InternalError,
+		frappe.RetryBackgroundJobError,
+		frappe.QueryDeadlockError,
+		frappe.QueryTimeoutError,
+	) as e:
 		frappe.db.rollback(chain=True)
 
 		if retry < 5 and (
-			isinstance(e, frappe.RetryBackgroundJobError)
+			isinstance(e, (frappe.RetryBackgroundJobError, frappe.QueryDeadlockError, frappe.QueryTimeoutError))
 			or (frappe.db.is_deadlocked(e) or frappe.db.is_timedout(e))
 		):
 			# retry the job if
 			# 1213 = deadlock
 			# 1205 = lock wait timeout
+			# 1020 = snapshot conflict (record changed since last read)
 			# or RetryBackgroundJobError is explicitly raised
 			frappe.job.after_job.reset()
 			frappe.destroy()

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -319,7 +319,8 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 			frappe.connect()
 		for after_job_task in frappe.get_hooks("after_job"):
 			frappe.call(after_job_task, method=method_name, kwargs=kwargs, result=retval)
-		frappe.local.job.after_job.run()
+		if hasattr(frappe.local, "job"):
+			frappe.local.job.after_job.run()
 
 		if is_async:
 			frappe.destroy()

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -281,7 +281,9 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 		frappe.db.rollback(chain=True)
 
 		if retry < 5 and (
-			isinstance(e, (frappe.RetryBackgroundJobError, frappe.QueryDeadlockError, frappe.QueryTimeoutError))
+			isinstance(
+				e, (frappe.RetryBackgroundJobError, frappe.QueryDeadlockError, frappe.QueryTimeoutError)
+			)
 			or (frappe.db.is_deadlocked(e) or frappe.db.is_timedout(e))
 		):
 			# retry the job if

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -291,7 +291,8 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 			# 1205 = lock wait timeout
 			# 1020 = snapshot conflict (record changed since last read)
 			# or RetryBackgroundJobError is explicitly raised
-			frappe.job.after_job.reset()
+			if hasattr(frappe.local, "job"):
+				frappe.local.job.after_job.reset()
 			frappe.destroy()
 			time.sleep(retry + 1)
 


### PR DESCRIPTION
`frappe.db.sql()` transforms raw DB deadlocks (error 1020/1213) and timeouts (error 1205) into `QueryDeadlockError` and `QueryTimeoutError` respectively. However, `execute_job` only caught `frappe.db.InternalError` for retry logic, so these transformed exceptions fell through to the generic error handler and caused permanent job failure instead of retry.

This caused `create_contact` to crash with `QueryDeadlockError` during concurrent app installations (e.g. ERPNext + Insights) when multiple background jobs tried to insert the same Contact record simultaneously.

Fixes #37707

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
