### PR TITLE
fix: scope `resize_all_columns` to direct section children only

### DIFF
--- a/frappe/public/js/frappe/form/column.js
+++ b/frappe/public/js/frappe/form/column.js
@@ -38,7 +38,7 @@ export default class Column {
 
 	resize_all_columns() {
 		// distribute visible columns equally, scoped to this section's direct children only
-		let all_columns = this.section.wrapper.find("> .section-body > .form-column");
+		let all_columns = this.section.body.find("> .form-column");
 		let visible_columns = all_columns.filter(":not(.hide-control)");
 		let columns = visible_columns.length || all_columns.length;
 		let colspan = cint(12 / columns);

--- a/frappe/public/js/frappe/form/column.js
+++ b/frappe/public/js/frappe/form/column.js
@@ -37,8 +37,8 @@ export default class Column {
 	}
 
 	resize_all_columns() {
-		// distribute visible columns equally
-		let all_columns = this.section.wrapper.find(".form-column");
+		// distribute visible columns equally, scoped to this section's direct children only
+		let all_columns = this.section.wrapper.find("> .section-body > .form-column");
 		let visible_columns = all_columns.filter(":not(.hide-control)");
 		let columns = visible_columns.length || all_columns.length;
 		let colspan = cint(12 / columns);

--- a/frappe/public/js/frappe/form/column.js
+++ b/frappe/public/js/frappe/form/column.js
@@ -38,7 +38,7 @@ export default class Column {
 
 	resize_all_columns() {
 		// distribute visible columns equally, scoped to this section's direct children only
-		let all_columns = this.section.body.find("> .form-column");
+		let all_columns = this.section.body.children(".form-column");
 		let visible_columns = all_columns.filter(":not(.hide-control)");
 		let columns = visible_columns.length || all_columns.length;
 		let colspan = cint(12 / columns);


### PR DESCRIPTION
- Closes https://github.com/resilient-tech/india-compliance/issues/4050

PR #37618 introduced dynamic column resizing when a **Column Break** field is toggled via `display_depends_on`. This resizing is triggered through `column.refresh()` -> `resize_all_columns()`, which counts columns using:

```js
this.section.wrapper.find(".form-column")  // deep search — traverses the entire DOM subtree
```

Any `.form-column` existing anywhere inside the section's subtree — from a nested `FieldGroup`, an expanded grid row, or any dynamically embedded layout — is incorrectly counted alongside real sibling columns. This inflates the count and collapses columns to a fraction of their correct width.

### Affected Scenarios

| Trigger | What gets double-counted |
|---|---|
| `FieldGroup` rendered inside an `HTML` field | Each tab/section of the inner layout adds `.form-column` |
| Child table with an inline-expanded grid row | `GridRow.Layout` creates its own `.form-column` elements |

### Resolution

A deep `find(".form-column")` is incorrect in this context; any column deeper than `> .section-body > .form-column` belongs to a separate, isolated layout context. 

The direct-child selector finds exactly the same columns in all normal layouts (as siblings are always direct children of `.section-body`) while correctly ignoring columns from nested layouts. All functionality from PR #37618 is preserved.
