### PR TITLE
feat: show error state in dashboard chart widget instead of throwing …

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -61,7 +61,7 @@ export default class ChartWidget extends Widget {
 		this.empty.hide().appendTo(this.body);
 
 		this.error_state = $(
-			`<div class="chart-loading-state text-extra-muted" style="height: ${this.height}px;"></div>`
+			`<div class="chart-loading-state text-danger" style="height: ${this.height}px;"></div>`
 		);
 		this.error_state.hide().appendTo(this.body);
 
@@ -557,7 +557,18 @@ export default class ChartWidget extends Widget {
 				heatmap_year: args && args.heatmap_year ? args.heatmap_year : null,
 			};
 		}
-		return frappe.xcall(method, args);
+		return frappe.xcall(method, args, undefined, {
+			silent: true,
+			error: (err) => {
+				const message = JSON.parse(JSON.parse(err._server_messages)[0])?.message;
+				this.chart_wrapper.hide();
+				this.loading.hide();
+				this.$summary && this.$summary.hide();
+				this.empty.hide();
+				this.error_state.text(message);
+				this.error_state.show();
+			},
+		});
 	}
 
 	async get_source_doctype() {
@@ -588,14 +599,7 @@ export default class ChartWidget extends Widget {
 			}
 		};
 
-		if (this.data && this.data.error_message) {
-			this.chart_wrapper.hide();
-			this.loading.hide();
-			this.$summary && this.$summary.hide();
-			this.empty.hide();
-			this.error_state.text(this.data.error_message);
-			this.error_state.show();
-		} else if (!this.data || !this.data.labels || !Object.keys(this.data).length) {
+		if (!this.data || !this.data.labels || !Object.keys(this.data).length) {
 			this.chart_wrapper.hide();
 			this.loading.hide();
 			this.$summary && this.$summary.hide();

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -60,6 +60,11 @@ export default class ChartWidget extends Widget {
 		);
 		this.empty.hide().appendTo(this.body);
 
+		this.error_state = $(
+			`<div class="chart-loading-state text-extra-muted" style="height: ${this.height}px;"></div>`
+		);
+		this.error_state.hide().appendTo(this.body);
+
 		this.chart_wrapper = $(`<div></div>`);
 		this.chart_wrapper.appendTo(this.body);
 
@@ -583,14 +588,23 @@ export default class ChartWidget extends Widget {
 			}
 		};
 
-		if (!this.data || !this.data.labels || !Object.keys(this.data).length) {
+		if (this.data && this.data.error_message) {
+			this.chart_wrapper.hide();
+			this.loading.hide();
+			this.$summary && this.$summary.hide();
+			this.empty.hide();
+			this.error_state.text(this.data.error_message);
+			this.error_state.show();
+		} else if (!this.data || !this.data.labels || !Object.keys(this.data).length) {
 			this.chart_wrapper.hide();
 			this.loading.hide();
 			this.$summary && this.$summary.hide();
 			this.empty.show();
+			this.error_state.hide();
 		} else {
 			this.loading.hide();
 			this.empty.hide();
+			this.error_state.hide();
 			this.chart_wrapper.show();
 			this.chart_doc.document_type = await this.get_source_doctype();
 


### PR DESCRIPTION
Add support for better error reporting for bank balance chart widget in payments dashboard.
Can be applied to other charts as well for better error reporting.

<img width="1357" height="625" alt="Screenshot 2026-03-09 at 11 48 54 AM" src="https://github.com/user-attachments/assets/775a5792-7dac-434c-9474-e2fdf1442cf4" />

<img width="1260" height="444" alt="Screenshot 2026-03-09 at 11 47 46 AM" src="https://github.com/user-attachments/assets/bb90a608-da3e-41e0-8695-aefa7e666a80" />

Required for frappe/erpnext#53223

`no-docs`