### PR TITLE
fix: use parent doctype for DocShare check on child table field permissions

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -705,7 +705,7 @@ class Meta(Document):
 		)
 
 		if 0 not in permlevel_access and permission_type in ("read", "select"):
-			share_doctype = parenttype if self.istable and parenttype else self.name
+			share_doctype = parenttype if (self.istable and parenttype) else self.name
 			if frappe.share.get_shared(share_doctype, user, rights=["read"], limit=1):
 				permlevel_access.add(0)
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -705,7 +705,8 @@ class Meta(Document):
 		)
 
 		if 0 not in permlevel_access and permission_type in ("read", "select"):
-			if frappe.share.get_shared(self.name, user, rights=["read"], limit=1):
+			share_doctype = parenttype if self.istable and parenttype else self.name
+			if frappe.share.get_shared(share_doctype, user, rights=["read"], limit=1):
 				permlevel_access.add(0)
 
 		permitted_fieldnames.extend(

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -705,7 +705,7 @@ class Meta(Document):
 		)
 
 		if 0 not in permlevel_access and permission_type in ("read", "select"):
-			share_doctype = parenttype if (self.istable and parenttype) else self.name
+			share_doctype = parenttype if self.istable else self.name
 			if frappe.share.get_shared(share_doctype, user, rights=["read"], limit=1):
 				permlevel_access.add(0)
 

--- a/frappe/tests/test_model_utils.py
+++ b/frappe/tests/test_model_utils.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from random import choice
 
 import frappe
+import frappe.share
 from frappe.model import core_doctypes_list, get_permitted_fields, is_default_field
 from frappe.model.utils import get_fetch_values
 from frappe.tests import IntegrationTestCase
@@ -62,6 +63,50 @@ class TestModelUtils(IntegrationTestCase):
 			self.assertNotIn(
 				"app_name", get_permitted_fields("Installed Application", parenttype="Installed Applications")
 			)
+
+	def test_get_permitted_fields_for_child_table_via_docshare(self):
+		user = "test@example.com"
+
+		doc = frappe.get_doc(
+			{
+				"doctype": "Web Page",
+				"title": "test child table share",
+				"page_blocks": [{"web_template": "Hero with Right Image"}],
+			}
+		).insert()
+
+		try:
+			# user without Website Manager role has no access to child table fields
+			with set_user(user):
+				child_fields = get_permitted_fields(
+					"Web Page Block", parenttype="Web Page", permission_type="read"
+				)
+				self.assertNotIn("web_template", child_fields)
+
+			frappe.share.add("Web Page", doc.name, user)
+
+			# sharing parent grants access to child table fields
+			with set_user(user):
+				child_fields = get_permitted_fields(
+					"Web Page Block", parenttype="Web Page", permission_type="read"
+				)
+				self.assertIn("web_template", child_fields)
+				self.assertIn("css_class", child_fields)
+
+			# child table fields are also accessible via get_list
+			with set_user(user):
+				result = frappe.get_list(
+					"Web Page",
+					fields=["name", "`tabWeb Page Block`.web_template"],
+					limit=5,
+				)
+				matched = [r for r in result if r.get("name") == doc.name]
+				self.assertTrue(matched)
+				self.assertEqual(matched[0].get("web_template"), "Hero with Right Image")
+		finally:
+			frappe.set_user("Administrator")
+			frappe.share.remove("Web Page", doc.name, user)
+			doc.delete(ignore_permissions=True)
 
 	def test_is_default_field(self):
 		self.assertTrue(is_default_field("doctype"))

--- a/frappe/tests/test_model_utils.py
+++ b/frappe/tests/test_model_utils.py
@@ -65,7 +65,7 @@ class TestModelUtils(IntegrationTestCase):
 			)
 
 	def test_get_permitted_fields_for_child_table_via_docshare(self):
-		user = "test@example.com"
+		user = "test2@example.com"
 
 		doc = frappe.get_doc(
 			{


### PR DESCRIPTION
## Summary                                                                                                                                                       
                                                                                                                                                                   
  - Fix DocShare permission check in `get_permitted_fieldnames()` to use the parent doctype
    when resolving field permissions for child tables                                                                                                              
  - When `self.istable` is true and `parenttype` is provided, look up sharing on the parent
    doctype instead of the child doctype name                                                                                                                      
  - Without this fix, users who access documents via DocShare (without role-based read) see                                                                        
    blank child table columns in Report View                                                                                                                       
                                                                                                                                                                   
  ## Related                                                                                                                                                       
                                                                                                                                                                   
  - Complements PR #32192 which fixed the `pop()` during `enumerate()` iteration bug in
    `db_query.py` (merged to develop, not backported to v15)                                                                                                       
  - That fix prevented data leakage but exposed this underlying issue: child table fields
    are now correctly stripped but incorrectly — sharing is never recognized for child tables                                                                                                                                                                                   

## Before Fix
<img width="2476" height="571" alt="image" src="https://github.com/user-attachments/assets/076e7c5c-8a4d-4a8d-b4cd-e557b20fbc01" />

## After Fix
<img width="2476" height="571" alt="image" src="https://github.com/user-attachments/assets/8bb84d07-8a59-4a80-8f7c-fdf87aacc0d6" />
