### PR TITLE
feat: enhance CSV import by applying delimiter settings and using CSV sniffer

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -187,8 +187,14 @@ def stop_data_import(doc_name: str):
 def start_import(data_import):
 	"""This method runs in background job"""
 	data_import = frappe.get_doc("Data Import", data_import)
+	# Apply same delimiter/sniffer settings as preview so CSV is parsed correctly (e.g. EU ";" delimiter)
+	data_import.set_delimiters_flag()
 	try:
-		i = Importer(data_import.reference_doctype, data_import=data_import)
+		i = Importer(
+			data_import.reference_doctype,
+			data_import=data_import,
+			use_sniffer=data_import.use_csv_sniffer,
+		)
 		i.import_data()
 	except JobTimeoutException:
 		frappe.db.rollback()


### PR DESCRIPTION
## Fix: Data Import fails with custom delimiter (e.g. EU semicolon CSV)

## Issue
With a custom delimiter (e.g. `;` for EU CSV), the preview and mapping work in the UI, but the background import fails and reports errors for every row.

## Cause
`frappe.flags.delimiter_options` was set only in the request that runs the UI. The import runs in a separate worker, so the delimiter was never applied there and the CSV was parsed with the default comma.

## Fix
Call `data_import.set_delimiters_flag()` at the start of `start_import()` so the background job uses the same delimiter as the preview.

Fixes #37706


`no-docs`