### PR TITLE
fix: alignment fix of like icon

### DIFF
--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -571,12 +571,14 @@ body[data-route^="Form"] {
 	}
 }
 
-.liked-by {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 28px;
-	height: 28px;
+.form-stats-likes {
+	.liked-by {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		height: 28px;
+	}
 }
 
 .liked-by-popover {


### PR DESCRIPTION
The like icon gets misaligned in the list view when liked. This fixes it. 

Existing list view with like icon:
<img width="1239" height="206" alt="image" src="https://github.com/user-attachments/assets/7b015dc5-eb6e-441f-81eb-cc3bf9d78e71" />

After the change 

<img width="1240" height="196" alt="image" src="https://github.com/user-attachments/assets/d243f9de-4b00-4776-b832-24f2cd9f287b" />
