### PR TITLE
fix: remove app field from auto generated sidebar

### DIFF
--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -286,7 +286,6 @@ def auto_generate_sidebar_from_module():
 			sidebar.items = sidebar_items
 			sidebar.module = module
 			sidebar.header_icon = "hammer"
-			sidebar.app = frappe.local.module_app.get(frappe.scrub(module), None)
 			sidebars.append(sidebar)
 	return sidebars
 

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -65,6 +65,16 @@ frappe.ui.Sidebar = class Sidebar {
 				frappe.current_app = app;
 				this.app_logo_url = app.app_logo_url;
 				return;
+			} else {
+				let app_name = frappe.boot.module_app[this.workspace_title];
+				if (app_name) {
+					let app_title = frappe.boot.app_data.find((f) => {
+						return f.app_name == app_name;
+					}).app_title;
+					this.header_subtitle = app_title;
+				} else {
+					this.header_subtitle = frappe.session.user;
+				}
 			}
 		}
 


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/edfda33a-5c97-488e-95f4-1ba132c7d25b

After

https://github.com/user-attachments/assets/d24fc917-19b0-49ea-8d59-892741efdbc2



