### PR TITLE
feat: Add ignore_links_on_cancel hook to skip link checks during cancellation

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -306,8 +306,14 @@ def check_if_doc_is_linked(doc, method="Delete"):
 	link_fields = get_link_fields(doc.doctype)
 	ignored_doctypes = set()
 
-	if method == "Cancel" and (doc_ignore_flags := doc.get("ignore_linked_doctypes")):
-		ignored_doctypes.update(doc_ignore_flags)
+	if method == "Cancel":
+		if doc_ignore_flags := doc.get("ignore_linked_doctypes"):
+			ignored_doctypes.update(doc_ignore_flags)
+
+		cancel_ignores = frappe.get_hooks("ignore_links_on_cancel")
+		if cancel_ignores:
+			ignored_doctypes.update(cancel_ignores.get(doc.doctype, []))
+
 	if method == "Delete":
 		ignored_doctypes.update(frappe.get_hooks("ignore_links_on_delete"))
 

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -366,11 +366,16 @@ def check_if_doc_is_dynamically_linked(doc, method="Delete"):
 	for df in get_dynamic_link_map().get(doc.doctype, []):
 		ignore_linked_doctypes = doc.get("ignore_linked_doctypes") or []
 
-		if df.parent in frappe.get_hooks("ignore_links_on_delete") or (
-			df.parent in ignore_linked_doctypes and method == "Cancel"
-		):
-			# don't check for communication and todo!
+		if method == "Delete" and df.parent in frappe.get_hooks("ignore_links_on_delete"):
 			continue
+
+		if method == "Cancel":
+			if df.parent in ignore_linked_doctypes:
+				continue
+
+			cancel_ignores = frappe.get_hooks("ignore_links_on_cancel")
+			if cancel_ignores and df.parent in cancel_ignores.get(doc.doctype, []):
+				continue
 
 		meta = frappe.get_meta(df.parent)
 		if meta.issingle:
@@ -404,11 +409,16 @@ def check_if_doc_is_dynamically_linked(doc, method="Delete"):
 					reference_doctype = refdoc.parenttype if meta.istable else df.parent
 					reference_docname = refdoc.parent if meta.istable else refdoc.name
 
-					if reference_doctype in frappe.get_hooks("ignore_links_on_delete") or (
-						reference_doctype in ignore_linked_doctypes and method == "Cancel"
-					):
-						# don't check for communication and todo!
+					if method == "Delete" and reference_doctype in frappe.get_hooks("ignore_links_on_delete"):
 						continue
+
+					if method == "Cancel":
+						if reference_doctype in ignore_linked_doctypes:
+							continue
+
+						cancel_ignores = frappe.get_hooks("ignore_links_on_cancel")
+						if cancel_ignores and reference_doctype in cancel_ignores.get(doc.doctype, []):
+							continue
 
 					at_position = f"at Row: {refdoc.idx}" if meta.istable else ""
 

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -598,13 +598,6 @@ app_license = "{app_license}"
 
 # ignore_links_on_delete = ["Communication", "ToDo"]
 
-
-# Ignore links to specified DocTypes when cancelling documents
-# -----------------------------------------------------------
-# ignore_links_on_cancel = {
-# 	"{{doctype_1}}": ["{{linked_doctype_1}}", "{{linked_doctype_2}}"],
-# }
-
 # Request Events
 # ----------------
 # before_request = ["{app_name}.utils.before_request"]

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -598,6 +598,13 @@ app_license = "{app_license}"
 
 # ignore_links_on_delete = ["Communication", "ToDo"]
 
+
+# Ignore links to specified DocTypes when cancelling documents
+# -----------------------------------------------------------
+# ignore_links_on_cancel = {
+# 	"{{doctype_1}}": ["{{linked_doctype_1}}", "{{linked_doctype_2}}"],
+# }
+
 # Request Events
 # ----------------
 # before_request = ["{app_name}.utils.before_request"]


### PR DESCRIPTION
**Issue:**

When canceling a document in ERPNext (like a Journal Entry), Frappe checks if other documents are linked to it. If links exist, it stops the cancellation to prevent data problems.

Some documents (like Loans in a lending app) need to stay linked even after cancellation for audit purposes. Currently, if a lending app wants to cancel a Journal Entry that's linked to Loan/Loan Transfer/Loan Interest Accrual documents, it cannot because the link check blocks it.

The app tries to use ignore_linked_doctypes = ["Loan", "Loan Transfer", "Loan Interest Accrual"] to skip this check, but this doesn't work. Why? Because the Journal Entry's own code (the on_cancel method) overwrites this setting with its own list of ignored doctypes. The app's setting gets lost before the link check runs.

**Fix:**
Introduces a new hook ignore_links_on_cancel. This allows multiple apps to contribute doctypes that should be ignored during cancellation link checks without interfering with each other.

Hook Format
```py
ignore_links_on_cancel = {
    "Journal Entry": ["Loan", "Loan Transfer", "Loan Interest Accrual"],
    "Sales Invoice": ["Insurance Claim", "Loan"]
}
```

- Multiple apps can add their own ignored doctypes without conflicts
- Existing ignore_linked_doctypes functionality remains unchanged
- Values come from hooks, so document's on_cancel method cannot override them

`no-docs`