### PR TITLE
fix(BulkUpdate): Handle a case where default field is empty

### DIFF
--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -391,12 +391,14 @@ export default class BulkOperations {
 		show_help_text();
 
 		function set_value_field(dialogObj) {
-			const new_df = Object.assign({}, field_mappings[dialogObj.get_value("field")]);
+			const field_value = dialogObj.get_value("field");
+			if (!field_value || !field_mappings[field_value]) return;
+			const new_df = Object.assign({}, field_mappings[field_value]);
 			/* if the field label has status in it and
 			if it has select fieldtype with no default value then
 			set a default value from the available option. */
 			if (
-				new_df.label.match(status_regex) &&
+				new_df.label?.match(status_regex) &&
 				new_df.fieldtype === "Select" &&
 				!new_df.default
 			) {


### PR DESCRIPTION
Bulk edit modal was not showing up

**Before:**

https://github.com/user-attachments/assets/25285406-bf10-489b-b1de-0b448ab65e05


**After**

https://github.com/user-attachments/assets/850e12cd-645a-4159-9f54-b7673f59a704

