### PR TITLE
fix: route conflict not detected when workspace matches existing doctype

### DIFF
--- a/frappe/desk/doctype/workspace/test_workspace.py
+++ b/frappe/desk/doctype/workspace/test_workspace.py
@@ -13,6 +13,15 @@ class TestWorkspace(IntegrationTestCase):
 		frappe.db.delete("DocType", {"module": "Test Module"})
 		frappe.delete_doc("Module Def", "Test Module")
 
+	def test_workspace_conflicts_with_existing_doctype(self):
+		"""Workspace name should not conflict with existing DocType names."""
+
+		create_doctype("Test", "Test Module")
+		workspace = create_workspace(name="Test", label="Test", public=1, title="Test")
+
+		with self.assertRaises(frappe.NameError):
+			workspace.insert()
+
 	# TODO: FIX ME - flaky test!!!
 	# def test_workspace_with_cards_specific_to_a_country(self):
 	# 	workspace = create_workspace()
@@ -65,6 +74,8 @@ def create_workspace(**args):
 	workspace.category = args.category or "Modules"
 	workspace.is_standard = args.is_standard or 1
 	workspace.module = "Test Module"
+	workspace.public = args.public or 0
+	workspace.title = args.title or "Test Workspace"
 
 	return workspace
 

--- a/frappe/desk/utils.py
+++ b/frappe/desk/utils.py
@@ -17,7 +17,11 @@ def validate_route_conflict(doctype, name):
 	all_names = []
 	for _doctype in ["Page", "Workspace", "DocType"]:
 		all_names.extend(
-			[slug(d) for d in frappe.get_all(_doctype, pluck="name") if (doctype != _doctype and d != name)]
+			[
+				slug(d)
+				for d in frappe.get_all(_doctype, pluck="name")
+				if not (doctype == _doctype and d == name)
+			]
 		)
 
 	if slug(name) in all_names:


### PR DESCRIPTION
Fixes: #37900

---

#### Problem
when a workspace or page is created with the same name as an existing DocType,
no conflict error is raised and the document is saved successfully

The condition `doctype != _doctype and d != name` incorrectly excludes
same-named documents from other doctypes from the conflict check.

---

#### Fix
changed the condition to 
```py 
not (doctype == _doctype and d == name)
```
which only excludes the current document itself, allowing same-named
documents across different doctypes to be detected correctly.

https://github.com/user-attachments/assets/0d3f162b-5324-4f70-bad8-c99a28a04ae5


