### PR TITLE
fix: remove `depends_on` hack for child tables

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -338,7 +338,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval: parent.is_submittable",
+   "depends_on": "eval: parent.is_submittable || parent.istable",
    "fieldname": "allow_on_submit",
    "fieldtype": "Check",
    "label": "Allow on Submit",
@@ -647,7 +647,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-06 15:13:03.688027",
+ "modified": "2026-03-10 21:39:58.400441",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/public/js/form_builder/utils.js
+++ b/frappe/public/js/form_builder/utils.js
@@ -214,9 +214,6 @@ export function evaluate_depends_on_value(expression, doc) {
 	} else if (expression.substr(0, 5) == "eval:") {
 		try {
 			out = frappe.utils.eval(expression.substr(5), { doc, parent });
-			if (parent && parent.istable && expression.includes("is_submittable")) {
-				out = true;
-			}
 		} catch (e) {
 			frappe.throw(__('Invalid "depends_on" expression'));
 		}

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -836,9 +836,6 @@ export default class GridRow {
 		} else if (expression.substr(0, 5) == "eval:") {
 			try {
 				out = frappe.utils.eval(expression.substr(5), { doc, parent });
-				if (parent && parent.istable && expression.includes("is_submittable")) {
-					out = true;
-				}
 			} catch (e) {
 				frappe.throw(__('Invalid "depends_on" expression'));
 			}

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -802,9 +802,6 @@ frappe.ui.form.Layout = class Layout {
 		} else if (expression.substr(0, 5) == "eval:") {
 			try {
 				out = frappe.utils.eval(expression.substr(5), { doc, parent });
-				if (parent && parent.istable && expression.includes("is_submittable")) {
-					out = true;
-				}
 			} catch (e) {
 				frappe.throw(__('Invalid "depends_on" expression'));
 			}

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -210,9 +210,6 @@ frappe.ui.form.check_mandatory = function (frm) {
 			} else if (expression.substr(0, 5) == "eval:") {
 				try {
 					out = frappe.utils.eval(expression.substr(5), { doc, parent });
-					if (parent && parent.istable && expression.includes("is_submittable")) {
-						out = true;
-					}
 				} catch (e) {
 					frappe.throw(__('Invalid "mandatory_depends_on" expression'));
 				}

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -763,9 +763,6 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		} else if (expression.substr(0, 5) == "eval:") {
 			try {
 				out = frappe.utils.eval(expression.substr(5), { doc: data });
-				if (parent && parent.istable && expression.includes("is_submittable")) {
-					out = true;
-				}
 			} catch (e) {
 				frappe.throw(__('Invalid "depends_on" expression'));
 			}


### PR DESCRIPTION
Commit 94d048967414f66c0798e45b412cebb3082a4bc0 added a hack to `evaluate_depends_on_value` in `layout.js` (which was copied later in multiple places) — after evaluating the expression, if the parent doctype is a child table and the expression contains `is_submittable`, the result is force-overridden to `true`. This was done to make fields like "Allow on Submit" visible when editing child table doctypes. This is fragile and wrong because:
- It patches the general-purpose expression evaluator with a special case
- It matches on string content (`expression.includes("is_submittable")`) rather than semantic meaning — any depends_on expression mentioning `is_submittable` gets overridden, even if the intent is different
- The actual fix is trivial: update the `depends_on` expression on the `allow_on_submit` field in DocField to `eval: parent.is_submittable || parent.istable`

This PR removes the hack and applies the proper fix to `docfield.json`.