### PR TITLE
fix: set valid parent for `mandatory_depends_on` evaluation

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -201,7 +201,7 @@ frappe.ui.form.check_mandatory = function (frm) {
 		if (df.mandatory_depends_on && doc) {
 			let out = null;
 			let expression = df.mandatory_depends_on;
-			let parent = frappe.get_meta(df.parent);
+			let parent = frm.doc;
 
 			if (typeof expression === "boolean") {
 				out = expression;


### PR DESCRIPTION
In `check_mandatory`'s `is_docfield_mandatory`, the `parent` variable used for evaluating `mandatory_depends_on` expressions was set to `frappe.get_meta(df.parent)` — the DocType definition object.

For child table fields whose `mandatory_depends_on` expressions reference `parent` (to check parent document field values like `eval: parent.status == 'Draft'`), this is wrong — meta has properties like `fields`, `permissions`, etc., not the actual document's field values.

Fix: use `frm.doc` so `parent` refers to the actual parent document, consistent with how other `depends_on` evaluations work.