### PR TITLE
fix: reset temp file for new uploads

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -176,7 +176,7 @@ def upload_file():
 			total_chunks = 1
 
 		temp_path = Path(get_files_path(".temp-" + get_safe_file_name(filename), is_private=is_private))
-		with temp_path.open("ab") as f:
+		with temp_path.open("ab" if current_chunk > 0 else "wb") as f:
 			f.seek(offset)
 			f.write(file.stream.read())
 			if not f.tell() >= int(total_file_size) or current_chunk != total_chunks - 1:


### PR DESCRIPTION
If an chunked upload doesn't fully go through, it isn't deleted. This means that the next time the file is uploaded, data gets corrupted as chunking requires `a` mode.

This PR fixes that by wiping the file upon re-upload (when the chunk index is 0).