### PR TITLE
feat: render_safe_exec

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -212,7 +212,6 @@ runs:
         --verbose
       bench --site test_site set-config allow_tests 1 --parse
       bench --site test_site set-config server_script_enabled 1 --parse
-      bench set-config -g disable_render_safe_exec 1 --parse
       bench --site test_site set-config host_name "http://test_site:8000"
       bench --site test_site set-config auto_email_id "test@example.com"
       bench --site test_site set-config mail_server localhost

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -212,6 +212,7 @@ runs:
         --verbose
       bench --site test_site set-config allow_tests 1 --parse
       bench --site test_site set-config server_script_enabled 1 --parse
+      bench set-config -g disable_render_safe_exec 1 --parse
       bench --site test_site set-config host_name "http://test_site:8000"
       bench --site test_site set-config auto_email_id "test@example.com"
       bench --site test_site set-config mail_server localhost

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -190,7 +190,8 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force: bool =
 	local.new_doc_templates = {}
 
 	local.request_cache = defaultdict(dict)
-	local.jenv = None
+	local.jenv_restricted = None
+	local.jenv_unrestricted = None
 	local.jloader = None
 	local.cache = {}
 	local.form_dict = _dict()
@@ -365,7 +366,8 @@ def set_user(username: str):
 	local.session.sid = username
 	local.cache = {}
 	local.form_dict = _dict()
-	local.jenv = None
+	local.jenv_restricted = None
+	local.jenv_unrestricted = None
 	local.session.data = _dict()
 	local.role_permissions = {}
 	local.new_doc_templates = {}

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -1031,7 +1031,7 @@ CACHE_PROPERTIES = frozenset(prop for prop, value in vars(Meta).items() if isins
 
 
 def _serialize(doc, no_nulls=False, *, is_child=False):
-	out = {}
+	out = frappe._dict()
 	for key, value in doc.__dict__.items():
 		if not is_child:
 			if key in CACHE_PROPERTIES:

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -158,11 +158,11 @@ def execute_child_queries(queries, result):
 
 
 def prepare_query(query):
+	from frappe.utils.safe_exec import SERVER_SCRIPT_FILE_PREFIX, check_safe_sql_query
+
 	param_collector = NamedParameterWrapper()
 	query = query.get_sql(param_wrapper=param_collector)
 	if frappe.local.flags.get("in_safe_exec", False):
-		from frappe.utils.safe_exec import SERVER_SCRIPT_FILE_PREFIX, check_safe_sql_query
-
 		if not check_safe_sql_query(query, throw=False):
 			callstack = inspect.stack()
 
@@ -178,6 +178,9 @@ def prepare_query(query):
 			# if frame2 is server script <serverscript> is set as the filename it shouldn't be allowed.
 			if len(callstack) >= 3 and SERVER_SCRIPT_FILE_PREFIX in callstack[2].filename:
 				raise frappe.PermissionError("Only SELECT SQL allowed in scripting")
+
+	if frappe.local.flags.get("in_render_safe_exec", False):
+		check_safe_sql_query(query, throw=True)
 
 	return query, param_collector.parameters
 

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -142,3 +142,16 @@ class TestJinjaGlobals(IntegrationTestCase):
 		self.assertIsNot(first.filters, second.filters)
 		self.assertIsNot(first.globals["frappe"], second.globals["frappe"])
 		self.assertIsNot(first.globals["frappe"]["form_dict"], second.globals["frappe"]["form_dict"])
+
+	def test_globals_override(self):
+		"""Test that when restrict_globals is parsed, the correct globals are injected."""
+		from frappe.utils.safe_exec import FrappeClient, safe_get_all
+
+		jenv_restricted = get_jenv(restrict_globals=True)
+		self.assertIs(jenv_restricted.globals["frappe"]["get_all"], safe_get_all)
+		with self.assertRaises(KeyError):
+			jenv_restricted.globals["FrappeClient"]
+
+		jenv_unrestricted = get_jenv(restrict_globals=False)
+		self.assertIs(jenv_unrestricted.globals["frappe"]["get_all"], frappe.get_all)
+		self.assertIs(jenv_unrestricted.globals["FrappeClient"], FrappeClient)  # test exclusivity

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -2,7 +2,7 @@ import types
 
 import frappe
 from frappe.tests import IntegrationTestCase
-from frappe.utils.jinja import get_jenv
+from frappe.utils.jinja import get_jenv, render_template
 from frappe.utils.safe_exec import ServerScriptNotEnabled, get_safe_globals, safe_exec
 
 
@@ -74,6 +74,16 @@ class TestSafeExec(IntegrationTestCase):
 
 	def test_safe_query_builder(self):
 		self.assertRaises(frappe.PermissionError, safe_exec, """frappe.qb.from_("User").delete().run()""")
+
+	def test_safe_query_builder_in_render(self):
+		self.assertRaises(
+			frappe.PermissionError,
+			render_template,
+			""" {{ frappe.qb.from_("User").delete().run() }} """,
+		)
+
+		# Allowed read query
+		frappe.render_template(""" {{ frappe.qb.from_("User").select("*").run() }} """)
 
 	def test_call(self):
 		# call non whitelisted method

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -155,3 +155,8 @@ class TestJinjaGlobals(IntegrationTestCase):
 		jenv_unrestricted = get_jenv(restrict_globals=False)
 		self.assertIs(jenv_unrestricted.globals["frappe"]["get_all"], frappe.get_all)
 		self.assertIs(jenv_unrestricted.globals["FrappeClient"], FrappeClient)  # test exclusivity
+
+		self.assertIsNot(jenv_restricted, jenv_unrestricted)  # globals cache check
+		self.assertIsNot(jenv_restricted.globals, jenv_unrestricted.globals)
+		self.assertIs(get_jenv(restrict_globals=True), jenv_restricted)
+		self.assertIs(get_jenv(restrict_globals=False), jenv_unrestricted)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -991,17 +991,20 @@ def print_language(language: str):
 
 	# remember original values
 	_lang = frappe.local.lang
-	_jenv = frappe.local.jenv
+	_jenv_restricted = getattr(frappe.local, "jenv_restricted", None)
+	_jenv_unrestricted = getattr(frappe.local, "jenv_unrestricted", None)
 
 	# set language, empty any existing lang_full_dict and jenv
 	frappe.local.lang = language
-	frappe.local.jenv = None
+	frappe.local.jenv_restricted = None
+	frappe.local.jenv_unrestricted = None
 
 	yield
 
 	# restore original values
 	frappe.local.lang = _lang
-	frappe.local.jenv = _jenv
+	frappe.local.jenv_restricted = _jenv_restricted
+	frappe.local.jenv_unrestricted = _jenv_unrestricted
 
 
 # Backward compatibility

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -6,7 +6,7 @@ import frappe
 from frappe.utils.caching import site_cache
 
 
-def get_jenv(restrict_globals=None):
+def get_jenv(*, restrict_globals=None):
 	import frappe
 	from frappe.utils.safe_exec import get_safe_globals, is_render_exec_enabled, render_safe_globals
 
@@ -101,7 +101,7 @@ def validate_template(html, restrict_globals=None):
 
 	if not html:
 		return
-	jenv = get_jenv(restrict_globals)
+	jenv = get_jenv(restrict_globals=restrict_globals)
 	try:
 		jenv.from_string(html)
 	except TemplateSyntaxError as e:
@@ -133,7 +133,7 @@ def render_template(template, context=None, is_path=None, safe_render=True, *, r
 			is_path = True
 			compiled_template = get_template(template)
 		else:
-			jenv: SandboxedEnvironment = get_jenv(restrict_globals)
+			jenv: SandboxedEnvironment = get_jenv(restrict_globals=restrict_globals)
 			if safe_render and ".__" in template:
 				throw(_("Illegal template"))
 			compiled_template = jenv.from_string(template)

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+from contextlib import contextmanager
+
 import frappe
 from frappe.utils.caching import site_cache
 
@@ -150,7 +152,8 @@ def render_template(template, context=None, is_path=None, safe_render=True, *, r
 	logger = get_logger("render-template")
 	try:
 		start_time = time.monotonic()
-		return compiled_template.render(context)
+		with safe_render_flags():
+			return compiled_template.render(context)
 	except Exception as e:
 		import html
 
@@ -251,3 +254,17 @@ def get_jinja_hooks():
 	filter_dict = get_obj_dict_from_paths(filters)
 
 	return method_dict, filter_dict
+
+
+@contextmanager
+def safe_render_flags():
+	if frappe.flags.in_render_safe_exec is None:
+		frappe.flags.in_render_safe_exec = 0
+
+	frappe.flags.in_render_safe_exec += 1
+
+	try:
+		yield
+	finally:
+		# Always ensure that the flag is decremented
+		frappe.flags.in_render_safe_exec -= 1

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -4,11 +4,15 @@ import frappe
 from frappe.utils.caching import site_cache
 
 
-def get_jenv():
+def get_jenv(restrict_globals=None):
 	import frappe
-	from frappe.utils.safe_exec import get_safe_globals
+	from frappe.utils.safe_exec import get_safe_globals, is_render_exec_enabled, render_safe_globals
 
-	if jenv := getattr(frappe.local, "jenv", None):
+	if restrict_globals is None:
+		restrict_globals = is_render_exec_enabled()
+
+	local_key = "jenv_restricted" if restrict_globals else "jenv_unrestricted"
+	if jenv := getattr(frappe.local, local_key, None):
 		return jenv
 
 	default_jenv = _get_jenv()
@@ -22,12 +26,17 @@ def get_jenv():
 	jenv.globals = default_jenv.globals.copy()
 	jenv.filters = default_jenv.filters.copy()
 
-	jenv.globals.update(get_safe_globals())
-	methods, filters = get_jinja_hooks()
-	jenv.globals.update(methods or {})
-	jenv.filters.update(filters or {})
+	if restrict_globals:
+		jenv.globals.update(render_safe_globals())
+	else:
+		jenv.globals.update(get_safe_globals())
 
-	frappe.local.jenv = jenv
+	if not restrict_globals:
+		methods, filters = get_jinja_hooks()
+		jenv.globals.update(methods or {})
+		jenv.filters.update(filters or {})
+
+	setattr(frappe.local, local_key, jenv)
 
 	return jenv
 
@@ -83,7 +92,7 @@ def get_email_from_template(name, args):
 	return (message, text_content)
 
 
-def validate_template(html):
+def validate_template(html, restrict_globals=None):
 	"""Throws exception if there is a syntax error in the Jinja Template"""
 	from jinja2 import TemplateSyntaxError
 
@@ -91,7 +100,7 @@ def validate_template(html):
 
 	if not html:
 		return
-	jenv = get_jenv()
+	jenv = get_jenv(restrict_globals)
 	try:
 		jenv.from_string(html)
 	except TemplateSyntaxError as e:
@@ -114,26 +123,19 @@ def render_template(template, context=None, is_path=None, safe_render=True, *, r
 	from jinja2.sandbox import SandboxedEnvironment
 
 	from frappe import _, get_traceback, throw
-	from frappe.utils.safe_exec import is_render_exec_enabled, render_safe_globals
 
 	if context is None:
 		context = {}
-
-	if restrict_globals is None:
-		restrict_globals = is_render_exec_enabled()
 
 	try:
 		if is_path or guess_is_path(template):
 			is_path = True
 			compiled_template = get_template(template)
 		else:
-			jenv: SandboxedEnvironment = get_jenv()
+			jenv: SandboxedEnvironment = get_jenv(restrict_globals)
 			if safe_render and ".__" in template:
 				throw(_("Illegal template"))
-			if restrict_globals:
-				compiled_template = jenv.from_string(template, globals=render_safe_globals())
-			else:
-				compiled_template = jenv.from_string(template)
+			compiled_template = jenv.from_string(template)
 	except TemplateError:
 		import html
 

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -98,7 +98,7 @@ def validate_template(html):
 		frappe.throw(f"Syntax error in template as line {e.lineno}: {e.message}")
 
 
-def render_template(template, context=None, is_path=None, safe_render=True, restrict_globals=None):
+def render_template(template, context=None, is_path=None, safe_render=True, *, restrict_globals=None):
 	"""Render a template using Jinja
 
 	:param template: path or HTML containing the jinja template

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -31,10 +31,9 @@ def get_jenv(restrict_globals=None):
 	else:
 		jenv.globals.update(get_safe_globals())
 
-	if not restrict_globals:
-		methods, filters = get_jinja_hooks()
-		jenv.globals.update(methods or {})
-		jenv.filters.update(filters or {})
+	methods, filters = get_jinja_hooks()
+	jenv.globals.update(methods or {})
+	jenv.filters.update(filters or {})
 
 	setattr(frappe.local, local_key, jenv)
 

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -98,13 +98,14 @@ def validate_template(html):
 		frappe.throw(f"Syntax error in template as line {e.lineno}: {e.message}")
 
 
-def render_template(template, context=None, is_path=None, safe_render=True):
+def render_template(template, context=None, is_path=None, safe_render=True, restrict_globals=None):
 	"""Render a template using Jinja
 
 	:param template: path or HTML containing the jinja template
 	:param context: dict of properties to pass to the template
 	:param is_path: (optional) assert that the `template` parameter is a path
 	:param safe_render: (optional) prevent server side scripting via jinja templating
+	:param restrict_globals: (optional) restrict globals in template rendering to render only globals.
 	"""
 	if not template:
 		return ""
@@ -113,9 +114,13 @@ def render_template(template, context=None, is_path=None, safe_render=True):
 	from jinja2.sandbox import SandboxedEnvironment
 
 	from frappe import _, get_traceback, throw
+	from frappe.utils.safe_exec import is_render_exec_enabled, render_safe_globals
 
 	if context is None:
 		context = {}
+
+	if restrict_globals is None:
+		restrict_globals = is_render_exec_enabled()
 
 	try:
 		if is_path or guess_is_path(template):
@@ -125,8 +130,10 @@ def render_template(template, context=None, is_path=None, safe_render=True):
 			jenv: SandboxedEnvironment = get_jenv()
 			if safe_render and ".__" in template:
 				throw(_("Illegal template"))
-
-			compiled_template = jenv.from_string(template)
+			if restrict_globals:
+				compiled_template = jenv.from_string(template, globals=render_safe_globals())
+			else:
+				compiled_template = jenv.from_string(template)
 	except TemplateError:
 		import html
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -648,6 +648,52 @@ def render_safe_globals():
 	return out
 
 
+def exec_safe_globals():
+	"""Safer subset of globals for read+write ops."""
+	out = render_safe_globals()
+	out.frappe.update(
+		NamespaceDict(
+			call=call_whitelisted_function,
+			get_meta=frappe.get_meta,
+			copy_doc=frappe.copy_doc,
+			new_doc=frappe.new_doc,
+			get_doc=frappe.get_doc,
+			get_mapped_doc=get_mapped_doc,
+			rename_doc=rename_doc,
+			delete_doc=delete_doc,
+			sendmail=frappe.sendmail,
+			get_print=frappe.get_print,
+			attach_print=frappe.attach_print,
+			make_post_request=frappe.integrations.utils.make_post_request,
+			make_put_request=frappe.integrations.utils.make_put_request,
+			make_patch_request=frappe.integrations.utils.make_patch_request,
+			make_delete_request=frappe.integrations.utils.make_delete_request,
+			get_hooks=get_hooks,
+			log_error=frappe.log_error,
+			get_list=frappe.get_list,
+			get_all=frappe.get_all,
+			get_cached_doc=frappe.get_cached_doc,
+			get_last_doc=frappe.get_last_doc,
+		)
+	)
+	out.frappe.db.update(
+		NamespaceDict(
+			get_list=frappe.get_list,
+			get_all=frappe.get_all,
+			get_value=frappe.db.get_value,
+			set_value=frappe.db.set_value,
+			get_single_value=frappe.db.get_single_value,
+			commit=frappe.db.commit,
+			rollback=frappe.db.rollback,
+			after_commit=frappe.db.after_commit,
+			before_commit=frappe.db.before_commit,
+			after_rollback=frappe.db.after_rollback,
+			before_rollback=frappe.db.before_rollback,
+		)
+	)
+	return out
+
+
 def get_safer_globals():
 	"""Safer subset of globals"""
 	out = get_safe_globals()

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -189,6 +189,34 @@ def safer_get_cached_doc(*args, **kwargs):
 	return frappe.get_cached_doc(*args, **kwargs).as_dict()
 
 
+def remove_unsafe_fields(fields):
+	return [f for f in fields if "(" not in f]
+
+
+def safe_get_list(*args, **kwargs):
+	if args and len(args) > 1 and isinstance(args[1], list):
+		args = list(args)
+		args[1] = remove_unsafe_fields(args[1])
+
+	kwargs["run"] = True
+	fields = kwargs.get("fields", [])
+	if fields:
+		kwargs["fields"] = remove_unsafe_fields(fields)
+
+	return frappe.db.get_list(
+		*args,
+		**kwargs,
+	)
+
+
+def safe_get_all(*args, **kwargs):
+	kwargs["ignore_permissions"] = True
+	if "limit_page_length" not in kwargs:
+		kwargs["limit_page_length"] = 0
+
+	return safe_get_list(*args, **kwargs)
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -346,6 +346,7 @@ def render_safe_globals():
 			get_cached_doc=safer_get_cached_doc,
 			get_list=safe_get_list,
 			get_all=safe_get_all,
+			get_hooks=get_hooks,
 			get_system_settings=frappe.get_system_settings,
 			utils=datautils,
 			get_url=frappe.utils.get_url,
@@ -367,7 +368,6 @@ def render_safe_globals():
 			),
 			make_get_request=make_safe_get_request,
 			socketio_port=frappe.conf.socketio_port,
-			enqueue=safe_enqueue,
 			sanitize_html=frappe.utils.sanitize_html,
 			log_error=safer_log_error,
 			log=frappe.log,
@@ -400,7 +400,6 @@ def render_safe_globals():
 		guess_mimetype=mimetypes.guess_type,
 		html2text=html2text,
 		dev_server=frappe._dev_server,
-		is_job_queued=is_job_queued,
 		get_visible_columns=safer_get_visible_columns,
 	)
 
@@ -451,13 +450,14 @@ def exec_safe_globals():
 			make_put_request=frappe.integrations.utils.make_put_request,
 			make_patch_request=frappe.integrations.utils.make_patch_request,
 			make_delete_request=frappe.integrations.utils.make_delete_request,
-			get_hooks=get_hooks,
 			log_error=frappe.log_error,
 			get_list=frappe.get_list,
 			get_all=frappe.get_all,
 			get_cached_doc=frappe.get_cached_doc,
 			get_last_doc=frappe.get_last_doc,
 			render_template=frappe.render_template,
+			enqueue=safe_enqueue,
+			is_job_queued=is_job_queued,
 		)
 	)
 	out.frappe.db.update(

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -175,6 +175,12 @@ def safer_copy_doc(doc, ignore_no_copy=True):
 	return copied_obj.as_dict()
 
 
+def get_doc_as_dict(doctype, name):
+	assert isinstance(doctype, str)
+	assert isinstance(name, (str, int))
+	return frappe.get_doc(doctype, name).as_dict()
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -290,162 +290,6 @@ def make_safe_get_request(url: str, **kwargs):
 	return frappe.integrations.utils.make_get_request(url, **kwargs)
 
 
-def get_safe_globals():
-	datautils = frappe._dict()
-
-	if frappe.db:
-		date_format = get_date_format()
-		time_format = get_time_format()
-		number_format = get_number_format()
-	else:
-		date_format = "yyyy-mm-dd"
-		time_format = "HH:mm:ss"
-		number_format = NumberFormat.from_string("#,###.##")
-
-	datautils.update(SAFE_DATA_UTILS)
-
-	form_dict = getattr(frappe.local, "form_dict", frappe._dict())
-
-	if "_" in form_dict:
-		del frappe.local.form_dict["_"]
-
-	user = (getattr(frappe.local, "session", None) and frappe.local.session.user) or "Guest"
-
-	out = NamespaceDict(
-		# make available limited methods of frappe
-		json=NamespaceDict(loads=json.loads, dumps=json.dumps),
-		orjson=SAFE_ORJSON,
-		as_json=frappe.as_json,
-		dict=dict,
-		log=frappe.log,
-		_dict=frappe._dict,
-		args=form_dict,
-		frappe=NamespaceDict(
-			call=call_whitelisted_function,
-			flags=frappe._dict(),
-			format=frappe.format_value,
-			format_value=frappe.format_value,
-			date_format=date_format,
-			time_format=time_format,
-			number_format=number_format,
-			format_date=frappe.utils.data.global_date_format,
-			form_dict=form_dict,
-			bold=frappe.bold,
-			copy_doc=frappe.copy_doc,
-			errprint=frappe.errprint,
-			qb=frappe.qb,
-			get_meta=frappe.get_meta,
-			new_doc=frappe.new_doc,
-			get_doc=frappe.get_doc,
-			get_mapped_doc=get_mapped_doc,
-			get_last_doc=frappe.get_last_doc,
-			get_cached_doc=frappe.get_cached_doc,
-			get_list=frappe.get_list,
-			get_all=frappe.get_all,
-			get_system_settings=frappe.get_system_settings,
-			rename_doc=rename_doc,
-			delete_doc=delete_doc,
-			utils=datautils,
-			get_url=frappe.utils.get_url,
-			render_template=frappe.render_template,
-			msgprint=frappe.msgprint,
-			throw=frappe.throw,
-			sendmail=frappe.sendmail,
-			get_print=frappe.get_print,
-			attach_print=frappe.attach_print,
-			user=user,
-			get_fullname=frappe.utils.get_fullname,
-			get_gravatar=frappe.utils.get_gravatar_url,
-			full_name=frappe.local.session.data.full_name
-			if getattr(frappe.local, "session", None) and getattr(frappe.local.session, "data", None)
-			else "Guest",
-			request=getattr(frappe.local, "request", {}),
-			session=frappe._dict(
-				user=user,
-				csrf_token=frappe.local.session.data.csrf_token
-				if getattr(frappe.local, "session", None) and getattr(frappe.local.session, "data", None)
-				else "",
-			),
-			make_get_request=frappe.integrations.utils.make_get_request,
-			make_post_request=frappe.integrations.utils.make_post_request,
-			make_put_request=frappe.integrations.utils.make_put_request,
-			make_patch_request=frappe.integrations.utils.make_patch_request,
-			make_delete_request=frappe.integrations.utils.make_delete_request,
-			socketio_port=frappe.conf.socketio_port,
-			get_hooks=get_hooks,
-			enqueue=safe_enqueue,
-			sanitize_html=frappe.utils.sanitize_html,
-			log_error=frappe.log_error,
-			log=frappe.log,
-			db=NamespaceDict(
-				get_list=frappe.get_list,
-				get_all=frappe.get_all,
-				get_value=frappe.db.get_value,
-				set_value=frappe.db.set_value,
-				get_single_value=frappe.db.get_single_value,
-				get_default=frappe.db.get_default,
-				exists=frappe.db.exists,
-				count=frappe.db.count,
-				escape=frappe.db.escape,
-				sql=read_sql,
-				commit=frappe.db.commit,
-				rollback=frappe.db.rollback,
-				after_commit=frappe.db.after_commit,
-				before_commit=frappe.db.before_commit,
-				after_rollback=frappe.db.after_rollback,
-				before_rollback=frappe.db.before_rollback,
-				add_index=frappe.db.add_index,
-			),
-			website=NamespaceDict(
-				abs_url=frappe.website.utils.abs_url,
-				extract_title=frappe.website.utils.extract_title,
-				get_boot_data=frappe.website.utils.get_boot_data,
-				get_home_page=frappe.website.utils.get_home_page,
-				get_html_content_based_on_type=frappe.website.utils.get_html_content_based_on_type,
-			),
-			lang=getattr(frappe.local, "lang", "en"),
-			json_handler=json_handler,
-		),
-		FrappeClient=FrappeClient,
-		style=frappe._dict(border_color="#d1d8dd"),
-		get_toc=get_toc,
-		get_next_link=get_next_link,
-		_=frappe._,
-		scrub=scrub,
-		guess_mimetype=mimetypes.guess_type,
-		html2text=html2text,
-		dev_server=frappe._dev_server,
-		run_script=run_script,
-		is_job_queued=is_job_queued,
-		get_visible_columns=get_visible_columns,
-	)
-
-	out.frappe.update(SAFE_EXCEPTIONS)
-
-	if frappe.response:
-		out.frappe.response = frappe.response
-
-	out.update(safe_globals)
-
-	# default writer allows write access
-	out._write_ = _write
-	out._getitem_ = _getitem
-	out._getattr_ = _getattr_for_safe_exec
-
-	# Allow using `print()` calls with `safe_exec()`
-	out._print_ = FrappePrintCollector
-
-	# allow iterators and list comprehension
-	out._getiter_ = iter
-	out._iter_unpack_sequence_ = RestrictedPython.Guards.guarded_iter_unpack_sequence
-	out._inplacevar_ = protected_inplacevar
-
-	# add common python builtins
-	out.update(get_python_builtins())
-
-	return out
-
-
 def render_safe_globals():
 	"""Safer subset of globals for rendering ops."""
 	datautils = frappe._dict()
@@ -573,7 +417,7 @@ def render_safe_globals():
 	out._iter_unpack_sequence_ = RestrictedPython.Guards.guarded_iter_unpack_sequence
 	out._inplacevar_ = protected_inplacevar
 
-	# add common python builtins
+	# add common python builtins, also remove standard builtins
 	out.update(get_python_builtins())
 
 	return out
@@ -1054,3 +898,6 @@ for key, val in vars(orjson).items():
 SAFE_EXCEPTIONS = get_module_properties(
 	frappe.exceptions, lambda obj: inspect.isclass(obj) and issubclass(obj, Exception)
 )
+
+
+get_safe_globals = exec_safe_globals

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -509,6 +509,7 @@ def get_safer_globals():
 	out.frappe.pop("delete_doc", None)
 	out.frappe.pop("render_template", None)
 	out.pop("FrappeClient", None)
+	out.frappe.pop("db", None)
 	out.frappe.update(
 		{
 			"copy_doc": safer_copy_doc,
@@ -526,12 +527,6 @@ def get_safer_globals():
 			"enqueue": safer_enqueue,
 			"log_error": safer_log_error,
 			"get_visible_columns": safer_get_visible_columns,
-		}
-	)
-	out.frappe.db.update(
-		{
-			"get_list": safe_get_list,
-			"get_all": safe_get_all,
 		}
 	)
 	return out

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -48,7 +48,7 @@ ARGUMENT_NOT_SET = object()
 SAFE_EXEC_CONFIG_KEY = "server_script_enabled"
 SERVER_SCRIPT_FILE_PREFIX = "<serverscript>"
 
-SAFER_EXEC_CONFIG_KEY = "safer_server_script_enabled"
+RENDER_EXEC_CONFIG_KEY = "render_exec_enabled"
 
 
 class NamespaceDict(frappe._dict):
@@ -88,11 +88,6 @@ def is_safe_exec_enabled() -> bool:
 	return bool(frappe.get_common_site_config(cached=True).get(SAFE_EXEC_CONFIG_KEY))
 
 
-def is_safer_exec_enabled() -> bool:
-	# safer execution of server scripts can only be enabled via common_site_config.json
-	return bool(frappe.get_common_site_config(cached=True).get(SAFER_EXEC_CONFIG_KEY))
-
-
 def safe_exec(
 	script: str,
 	_globals: dict | None = None,
@@ -106,9 +101,6 @@ def safe_exec(
 		docs_cta = _("Read the documentation to know more")
 		msg += f"<br><a href='https://frappeframework.com/docs/user/en/desk/scripting/server-script' target='_blank' rel='noopener noreferrer'>{docs_cta}</a>"
 		frappe.throw(msg, ServerScriptNotEnabled, title="Server Scripts Disabled")
-
-	if is_safer_exec_enabled():
-		return safer_exec(script, None, _locals, script_filename=script_filename)
 
 	# build globals
 	exec_globals = get_safe_globals()
@@ -127,35 +119,6 @@ def safe_exec(
 
 	with safe_exec_flags():
 		# execute script compiled by RestrictedPython
-		exec(_compile_code(script, filename=filename), exec_globals, _locals)
-
-	return exec_globals, _locals
-
-
-def safer_exec(
-	script: str,
-	_globals: dict | None = None,
-	_locals: dict | None = None,
-	*,
-	restrict_commit_rollback: bool = True,
-	script_filename: str | None = None,
-):
-	exec_globals = get_safer_globals()
-	if _globals:
-		exec_globals.update(_globals)
-
-	if restrict_commit_rollback:
-		# prevent user from using these in docevents
-		exec_globals.frappe.db.pop("commit", None)
-		exec_globals.frappe.db.pop("rollback", None)
-		exec_globals.frappe.db.pop("add_index", None)
-
-	filename = SERVER_SCRIPT_FILE_PREFIX
-
-	if script_filename:
-		filename += f": {frappe.scrub(script_filename)}"
-
-	with safe_exec_flags():
 		exec(_compile_code(script, filename=filename), exec_globals, _locals)
 
 	return exec_globals, _locals
@@ -728,37 +691,6 @@ def exec_safe_globals():
 			run_script=run_script,
 			FrappeClient=FrappeClient,
 		)
-	)
-	return out
-
-
-def get_safer_globals():
-	"""Safer subset of globals"""
-	out = get_safe_globals()
-
-	out.frappe.pop("qb", None)
-	out.frappe.pop("delete_doc", None)
-	out.frappe.pop("render_template", None)
-	out.pop("FrappeClient", None)
-	out.frappe.pop("db", None)
-	out.frappe.update(
-		{
-			"copy_doc": safer_copy_doc,
-			"get_meta": safer_get_meta,
-			"new_doc": safer_new_doc,
-			"get_doc": get_doc_as_dict,
-			"get_mapped_doc": safer_get_mapped_doc,
-			"get_last_doc": safer_get_last_doc,
-			"get_cached_doc": safer_get_cached_doc,
-			"get_list": safe_get_list,
-			"get_all": safe_get_all,
-			"sendmail": safer_sendmail,
-			"get_print": safer_get_print,
-			"attach_print": safer_attach_print,
-			"enqueue": safer_enqueue,
-			"log_error": safer_log_error,
-			"get_visible_columns": safer_get_visible_columns,
-		}
 	)
 	return out
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -166,6 +166,15 @@ def safe_exec_flags():
 		frappe.flags.in_safe_exec -= 1
 
 
+def safer_copy_doc(doc, ignore_no_copy=True):
+	from frappe.model.document import Document
+
+	assert isinstance(doc, (dict, Document))
+	assert isinstance(ignore_no_copy, bool)
+	copied_obj = frappe.copy_doc(doc, ignore_no_copy=ignore_no_copy)
+	return copied_obj.as_dict()
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -172,13 +172,6 @@ def safe_exec_flags():
 		frappe.flags.in_safe_exec -= 1
 
 
-def safer_copy_doc(doc, ignore_no_copy=True):
-	assert isinstance(doc, dict)
-	assert isinstance(ignore_no_copy, bool)
-	copied_obj = frappe.copy_doc(doc, ignore_no_copy=ignore_no_copy)
-	return copied_obj.as_dict()
-
-
 def get_doc_as_dict(doctype, name):
 	assert isinstance(doctype, str)
 	assert isinstance(name, (str, int))
@@ -229,51 +222,6 @@ def safer_get_meta(doctype, cached=True):
 	return doc.as_dict() if doc else None
 
 
-def safer_get_mapped_doc(
-	from_doctype,
-	from_docname,
-	table_maps,
-	target_doc=None,
-	postprocess=None,
-	ignore_permissions=False,
-	ignore_child_tables=False,
-	cached=False,
-):
-	assert isinstance(from_doctype, str)
-	assert isinstance(from_docname, (str, int))
-	assert isinstance(table_maps, dict)
-	assert isinstance(target_doc, (str, type(None)))
-	assert isinstance(ignore_permissions, bool)
-	assert isinstance(ignore_child_tables, bool)
-	assert isinstance(cached, bool)
-
-	doc = get_mapped_doc(
-		from_doctype,
-		from_docname,
-		table_maps,
-		target_doc=target_doc,
-		postprocess=postprocess,
-		ignore_permissions=ignore_permissions,
-		ignore_child_tables=ignore_child_tables,
-		cached=cached,
-	)
-	return doc.as_dict() if doc else None
-
-
-def safer_new_doc(*args, **kwargs):
-	return frappe.new_doc(*args, **kwargs).as_dict()
-
-
-def safer_sendmail(*args, **kwargs):
-	q = frappe.sendmail(*args, **kwargs)
-	return q.name if q else None
-
-
-def safer_enqueue(function, **kwargs):
-	job = safe_enqueue(function, **kwargs)
-	return job.id if hasattr(job, "id") else None
-
-
 def safer_log_error(
 	title=None, message=None, reference_doctype=None, reference_name=None, *, defer_insert=False
 ):
@@ -296,20 +244,6 @@ def safer_log_error(
 def safer_get_visible_columns(*args, **kwargs):
 	cols = get_visible_columns(*args, **kwargs)
 	return [c.as_dict() for c in cols] if cols is not None else None
-
-
-def safer_get_print(*args, **kwargs):
-	print_obj = frappe.get_print(*args, **kwargs)
-	return print_obj if isinstance(print_obj, (str, bytes)) else None
-
-
-def safer_attach_print(*args, **kwargs):
-	print_obj = frappe.attach_print(*args, **kwargs)
-	fname = print_obj.get("fname")
-	fcontent = print_obj.get("fcontent")
-	if isinstance(fname, str) and isinstance(fcontent, (str, bytes)):
-		return print_obj
-	return None
 
 
 def safe_get_value(*args, **kwargs):
@@ -616,7 +550,7 @@ def render_safe_globals():
 		html2text=html2text,
 		dev_server=frappe._dev_server,
 		is_job_queued=is_job_queued,
-		get_visible_columns=get_visible_columns,
+		get_visible_columns=safer_get_visible_columns,
 	)
 
 	out.frappe.update(SAFE_EXCEPTIONS)
@@ -694,6 +628,7 @@ def exec_safe_globals():
 		NamespaceDict(
 			run_script=run_script,
 			FrappeClient=FrappeClient,
+			get_visible_columns=get_visible_columns,
 		)
 	)
 	return out

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -272,7 +272,7 @@ def safer_get_mapped_doc(
 	assert isinstance(from_doctype, str)
 	assert isinstance(from_docname, (str, int))
 	assert isinstance(table_maps, dict)
-	assert isinstance(target_doc, (str, None))
+	assert isinstance(target_doc, (str, type(None)))
 	assert isinstance(ignore_permissions, bool)
 	assert isinstance(ignore_child_tables, bool)
 	assert isinstance(cached, bool)
@@ -307,10 +307,10 @@ def safer_enqueue(function, **kwargs):
 def safer_log_error(
 	title=None, message=None, reference_doctype=None, reference_name=None, *, defer_insert=False
 ):
-	assert isinstance(title, (str, None))
-	assert isinstance(message, (str, None))
-	assert isinstance(reference_doctype, (str, None))
-	assert isinstance(reference_name, (str, int, None))
+	assert isinstance(title, (str, type(None)))
+	assert isinstance(message, (str, type(None)))
+	assert isinstance(reference_doctype, (str, type(None)))
+	assert isinstance(reference_name, (str, int, type(None)))
 	assert isinstance(defer_insert, bool)
 
 	log_doc = frappe.log_error(

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -181,6 +181,10 @@ def get_doc_as_dict(doctype, name):
 	return frappe.get_doc(doctype, name).as_dict()
 
 
+def safer_get_last_doc(*args, **kwargs):
+	return frappe.get_last_doc(*args, **kwargs).as_dict()
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -258,6 +258,11 @@ def safer_new_doc(*args, **kwargs):
 	return frappe.new_doc(*args, **kwargs).as_dict()
 
 
+def safer_sendmail(*args, **kwargs):
+	q = frappe.sendmail(*args, **kwargs)
+	return q.name if q else None
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -355,6 +355,18 @@ def safe_get_single_value(*args, **kwargs):
 	return frappe.db.get_single_value(*args, **kwargs)
 
 
+def make_safe_get_request(url, **kwargs):
+	import socket
+	from urllib.parse import urlparse
+
+	parsed = urlparse(url)
+	parsed_ip = socket.gethostbyname(parsed.hostname)
+	if parsed_ip.startswith(("127", "10", "192", "172")):
+		return
+
+	return frappe.integrations.utils.make_get_request(url, **kwargs)
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 
@@ -579,7 +591,7 @@ def render_safe_globals():
 				if getattr(frappe.local, "session", None) and getattr(frappe.local.session, "data", None)
 				else "",
 			),
-			make_get_request=frappe.integrations.utils.make_get_request,
+			make_get_request=make_safe_get_request,
 			socketio_port=frappe.conf.socketio_port,
 			enqueue=safe_enqueue,
 			sanitize_html=frappe.utils.sanitize_html,
@@ -664,6 +676,7 @@ def exec_safe_globals():
 			sendmail=frappe.sendmail,
 			get_print=frappe.get_print,
 			attach_print=frappe.attach_print,
+			make_get_request=frappe.integrations.utils.make_get_request,
 			make_post_request=frappe.integrations.utils.make_post_request,
 			make_put_request=frappe.integrations.utils.make_put_request,
 			make_patch_request=frappe.integrations.utils.make_patch_request,

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -231,14 +231,14 @@ def safer_log_error(
 	assert isinstance(reference_name, (str, int, type(None)))
 	assert isinstance(defer_insert, bool)
 
-	log_doc = frappe.log_error(
+	frappe.log_error(
 		title=title,
 		message=message,
 		reference_doctype=reference_doctype,
 		reference_name=reference_name,
 		defer_insert=defer_insert,
 	)
-	return log_doc.as_dict() if log_doc else None
+	return {}
 
 
 def safer_get_visible_columns(*args, **kwargs):
@@ -286,7 +286,7 @@ def make_safe_get_request(url: str, **kwargs):
 	for record in addr_info:
 		try:
 			addr = ipaddress.ip_address(record[4][0])
-		except ValueError, IndexError:
+		except (ValueError, IndexError):
 			continue
 
 		if not addr.is_global:

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -219,7 +219,39 @@ def safer_get_meta(doctype, cached=True):
 	assert isinstance(doctype, str)
 	assert isinstance(cached, bool)
 
-	return frappe.get_meta(doctype, cached).as_dict()
+	doc = frappe.get_meta(doctype, cached=cached)
+	return doc.as_dict() if doc else None
+
+
+def safer_get_mapped_doc(
+	from_doctype,
+	from_docname,
+	table_maps,
+	target_doc=None,
+	postprocess=None,
+	ignore_permissions=False,
+	ignore_child_tables=False,
+	cached=False,
+):
+	assert isinstance(from_doctype, str)
+	assert isinstance(from_docname, str | int)
+	assert isinstance(table_maps, dict)
+	assert isinstance(target_doc, (str, None))
+	assert isinstance(ignore_permissions, bool)
+	assert isinstance(ignore_child_tables, bool)
+	assert isinstance(cached, bool)
+
+	doc = get_mapped_doc(
+		from_doctype,
+		from_docname,
+		table_maps,
+		target_doc=target_doc,
+		postprocess=postprocess,
+		ignore_permissions=ignore_permissions,
+		ignore_child_tables=ignore_child_tables,
+		cached=cached,
+	)
+	return doc.as_dict() if doc else None
 
 
 def get_safe_globals():

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -217,6 +217,15 @@ def safe_get_all(*args, **kwargs):
 	return safe_get_list(*args, **kwargs)
 
 
+def safer_get_meta(doctype, cached=True):
+	from frappe.model.document import Document
+
+	assert isinstance(doctype, (str, Document))
+	assert isinstance(cached, bool)
+
+	return frappe.get_meta(doctype, cached).as_dict()
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -462,6 +462,41 @@ def get_safe_globals():
 	return out
 
 
+def get_safer_globals():
+	"""Safer subset of globals"""
+	out = get_safe_globals()
+
+	out.frappe.pop("qb", None)
+	out.frappe.pop("delete_doc", None)
+	out.frappe.pop("render_template", None)
+	out.frappe.update(
+		{
+			"copy_doc": safer_copy_doc,
+			"get_meta": safer_get_meta,
+			"new_doc": safer_new_doc,
+			"get_doc": get_doc_as_dict,
+			"get_mapped_doc": safer_get_mapped_doc,
+			"get_last_doc": safer_get_last_doc,
+			"get_cached_doc": safer_get_cached_doc,
+			"get_list": safe_get_list,
+			"get_all": safe_get_all,
+			"sendmail": safer_sendmail,
+			"get_print": safer_get_print,
+			"attach_print": safer_attach_print,
+			"enqueue": safer_enqueue,
+			"log_error": safer_log_error,
+			"get_visible_columns": safer_get_visible_columns,
+		}
+	)
+	out.frappe.db.update(
+		{
+			"get_list": safe_get_list,
+			"get_all": safe_get_all,
+		}
+	)
+	return out
+
+
 def get_keys_for_autocomplete(
 	key: str,
 	value: Any,

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -107,6 +107,9 @@ def safe_exec(
 		msg += f"<br><a href='https://frappeframework.com/docs/user/en/desk/scripting/server-script' target='_blank' rel='noopener noreferrer'>{docs_cta}</a>"
 		frappe.throw(msg, ServerScriptNotEnabled, title="Server Scripts Disabled")
 
+	if is_safer_exec_enabled():
+		return safer_exec(script, None, _locals, script_filename=script_filename)
+
 	# build globals
 	exec_globals = get_safe_globals()
 	if _globals:

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -601,14 +601,12 @@ def render_safe_globals():
 				get_list=safe_get_list,
 				get_all=safe_get_all,
 				get_value=safe_get_value,
-				set_value=frappe.db.set_value,
 				get_single_value=safe_get_single_value,
 				get_default=frappe.db.get_default,
 				exists=frappe.db.exists,
 				count=frappe.db.count,
 				escape=frappe.db.escape,
 				sql=read_sql,
-				add_index=frappe.db.add_index,
 			),
 			website=NamespaceDict(
 				abs_url=frappe.website.utils.abs_url,
@@ -620,7 +618,6 @@ def render_safe_globals():
 			lang=getattr(frappe.local, "lang", "en"),
 			json_handler=json_handler,
 		),
-		FrappeClient=FrappeClient,
 		style=frappe._dict(border_color="#d1d8dd"),
 		get_toc=get_toc,
 		get_next_link=get_next_link,
@@ -629,7 +626,6 @@ def render_safe_globals():
 		guess_mimetype=mimetypes.guess_type,
 		html2text=html2text,
 		dev_server=frappe._dev_server,
-		run_script=run_script,
 		is_job_queued=is_job_queued,
 		get_visible_columns=get_visible_columns,
 	)
@@ -661,7 +657,7 @@ def render_safe_globals():
 
 
 def exec_safe_globals():
-	"""Safer subset of globals for read+write ops."""
+	"""Safer subset of globals for exec. ops."""
 	out = render_safe_globals()
 	out.frappe.update(
 		NamespaceDict(
@@ -696,12 +692,19 @@ def exec_safe_globals():
 			get_value=frappe.db.get_value,
 			set_value=frappe.db.set_value,
 			get_single_value=frappe.db.get_single_value,
+			add_index=frappe.db.add_index,
 			commit=frappe.db.commit,
 			rollback=frappe.db.rollback,
 			after_commit=frappe.db.after_commit,
 			before_commit=frappe.db.before_commit,
 			after_rollback=frappe.db.after_rollback,
 			before_rollback=frappe.db.before_rollback,
+		)
+	)
+	out.update(
+		NamespaceDict(
+			run_script=run_script,
+			FrappeClient=FrappeClient,
 		)
 	)
 	return out

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -287,6 +287,11 @@ def safer_log_error(
 	return log_doc.as_dict() if log_doc else None
 
 
+def safer_get_visible_columns(*args, **kwargs):
+	cols = get_visible_columns(*args, **kwargs)
+	return [c.as_dict() for c in cols] if cols is not None else None
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -185,6 +185,10 @@ def safer_get_last_doc(*args, **kwargs):
 	return frappe.get_last_doc(*args, **kwargs).as_dict()
 
 
+def safer_get_cached_doc(*args, **kwargs):
+	return frappe.get_cached_doc(*args, **kwargs).as_dict()
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -254,6 +254,10 @@ def safer_get_mapped_doc(
 	return doc.as_dict() if doc else None
 
 
+def safer_new_doc(*args, **kwargs):
+	return frappe.new_doc(*args, **kwargs).as_dict()
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -88,6 +88,10 @@ def is_safe_exec_enabled() -> bool:
 	return bool(frappe.get_common_site_config(cached=True).get(SAFE_EXEC_CONFIG_KEY))
 
 
+def is_render_exec_enabled() -> bool:
+	return bool(frappe.get_common_site_config(cached=True).get(RENDER_EXEC_CONFIG_KEY))
+
+
 def safe_exec(
 	script: str,
 	_globals: dict | None = None,

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -234,7 +234,7 @@ def safer_get_mapped_doc(
 	cached=False,
 ):
 	assert isinstance(from_doctype, str)
-	assert isinstance(from_docname, str | int)
+	assert isinstance(from_docname, (str, int))
 	assert isinstance(table_maps, dict)
 	assert isinstance(target_doc, (str, None))
 	assert isinstance(ignore_permissions, bool)
@@ -266,6 +266,25 @@ def safer_sendmail(*args, **kwargs):
 def safer_enqueue(function, **kwargs):
 	job = safe_enqueue(function, **kwargs)
 	return job.id if hasattr(job, "id") else None
+
+
+def safer_log_error(
+	title=None, message=None, reference_doctype=None, reference_name=None, *, defer_insert=False
+):
+	assert isinstance(title, (str, None))
+	assert isinstance(message, (str, None))
+	assert isinstance(reference_doctype, (str, None))
+	assert isinstance(reference_name, (str, int, None))
+	assert isinstance(defer_insert, bool)
+
+	log_doc = frappe.log_error(
+		title=title,
+		message=message,
+		reference_doctype=reference_doctype,
+		reference_name=reference_name,
+		defer_insert=defer_insert,
+	)
+	return log_doc.as_dict() if log_doc else None
 
 
 def get_safe_globals():

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -256,6 +256,11 @@ def safe_get_single_value(*args, **kwargs):
 	return frappe.db.get_single_value(*args, **kwargs)
 
 
+def safe_render_template(*args, **kwargs):
+	kwargs.pop("restrict_globals", None)
+	return frappe.render_template(*args, restrict_globals=True, **kwargs)
+
+
 ALLOWED_SCHEMES = frozenset({"http", "https"})
 
 
@@ -342,7 +347,7 @@ def render_safe_globals():
 			get_system_settings=frappe.get_system_settings,
 			utils=datautils,
 			get_url=frappe.utils.get_url,
-			render_template=frappe.render_template,
+			render_template=safe_render_template,
 			msgprint=frappe.msgprint,
 			throw=frappe.throw,
 			user=user,
@@ -450,6 +455,7 @@ def exec_safe_globals():
 			get_all=frappe.get_all,
 			get_cached_doc=frappe.get_cached_doc,
 			get_last_doc=frappe.get_last_doc,
+			render_template=frappe.render_template,
 		)
 	)
 	out.frappe.db.update(

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -355,14 +355,36 @@ def safe_get_single_value(*args, **kwargs):
 	return frappe.db.get_single_value(*args, **kwargs)
 
 
-def make_safe_get_request(url, **kwargs):
+ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+def make_safe_get_request(url: str, **kwargs):
+	import ipaddress
 	import socket
 	from urllib.parse import urlparse
 
 	parsed = urlparse(url)
-	parsed_ip = socket.gethostbyname(parsed.hostname)
-	if parsed_ip.startswith(("127", "10", "192", "172")):
-		return
+
+	if parsed.scheme not in ALLOWED_SCHEMES:
+		frappe.throw(f"URL scheme '{parsed.scheme}' is not permitted")
+
+	hostname = parsed.hostname
+	if not hostname:
+		frappe.throw("Invalid URL: no hostname")
+
+	try:
+		addr_info = socket.getaddrinfo(hostname, None)
+	except socket.gaierror:
+		frappe.throw(f"Could not resolve host: {hostname}")
+
+	for record in addr_info:
+		try:
+			addr = ipaddress.ip_address(record[4][0])
+		except (ValueError, IndexError):
+			continue
+
+		if not addr.is_global:
+			frappe.throw("Requests to internal network addresses are not permitted")
 
 	return frappe.integrations.utils.make_get_request(url, **kwargs)
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -48,6 +48,8 @@ ARGUMENT_NOT_SET = object()
 SAFE_EXEC_CONFIG_KEY = "server_script_enabled"
 SERVER_SCRIPT_FILE_PREFIX = "<serverscript>"
 
+SAFER_EXEC_CONFIG_KEY = "safer_server_script_enabled"
+
 
 class NamespaceDict(frappe._dict):
 	"""Raise AttributeError if function not found in namespace"""
@@ -86,6 +88,11 @@ def is_safe_exec_enabled() -> bool:
 	return bool(frappe.get_common_site_config(cached=True).get(SAFE_EXEC_CONFIG_KEY))
 
 
+def is_safer_exec_enabled() -> bool:
+	# safer execution of server scripts can only be enabled via common_site_config.json
+	return bool(frappe.get_common_site_config(cached=True).get(SAFER_EXEC_CONFIG_KEY))
+
+
 def safe_exec(
 	script: str,
 	_globals: dict | None = None,
@@ -117,6 +124,35 @@ def safe_exec(
 
 	with safe_exec_flags():
 		# execute script compiled by RestrictedPython
+		exec(_compile_code(script, filename=filename), exec_globals, _locals)
+
+	return exec_globals, _locals
+
+
+def safer_exec(
+	script: str,
+	_globals: dict | None = None,
+	_locals: dict | None = None,
+	*,
+	restrict_commit_rollback: bool = True,
+	script_filename: str | None = None,
+):
+	exec_globals = get_safer_globals()
+	if _globals:
+		exec_globals.update(_globals)
+
+	if restrict_commit_rollback:
+		# prevent user from using these in docevents
+		exec_globals.frappe.db.pop("commit", None)
+		exec_globals.frappe.db.pop("rollback", None)
+		exec_globals.frappe.db.pop("add_index", None)
+
+	filename = SERVER_SCRIPT_FILE_PREFIX
+
+	if script_filename:
+		filename += f": {frappe.scrub(script_filename)}"
+
+	with safe_exec_flags(), patched_qb():
 		exec(_compile_code(script, filename=filename), exec_globals, _locals)
 
 	return exec_globals, _locals
@@ -469,6 +505,7 @@ def get_safer_globals():
 	out.frappe.pop("qb", None)
 	out.frappe.pop("delete_doc", None)
 	out.frappe.pop("render_template", None)
+	out.pop("FrappeClient", None)
 	out.frappe.update(
 		{
 			"copy_doc": safer_copy_doc,

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -263,6 +263,11 @@ def safer_sendmail(*args, **kwargs):
 	return q.name if q else None
 
 
+def safer_enqueue(function, **kwargs):
+	job = safe_enqueue(function, **kwargs)
+	return job.id if hasattr(job, "id") else None
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -345,6 +345,16 @@ def safer_attach_print(*args, **kwargs):
 	return None
 
 
+def safe_get_value(*args, **kwargs):
+	kwargs["run"] = True
+	return frappe.db.get_value(*args, **kwargs)
+
+
+def safe_get_single_value(*args, **kwargs):
+	kwargs["run"] = True
+	return frappe.db.get_single_value(*args, **kwargs)
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 
@@ -449,6 +459,143 @@ def get_safe_globals():
 				before_commit=frappe.db.before_commit,
 				after_rollback=frappe.db.after_rollback,
 				before_rollback=frappe.db.before_rollback,
+				add_index=frappe.db.add_index,
+			),
+			website=NamespaceDict(
+				abs_url=frappe.website.utils.abs_url,
+				extract_title=frappe.website.utils.extract_title,
+				get_boot_data=frappe.website.utils.get_boot_data,
+				get_home_page=frappe.website.utils.get_home_page,
+				get_html_content_based_on_type=frappe.website.utils.get_html_content_based_on_type,
+			),
+			lang=getattr(frappe.local, "lang", "en"),
+			json_handler=json_handler,
+		),
+		FrappeClient=FrappeClient,
+		style=frappe._dict(border_color="#d1d8dd"),
+		get_toc=get_toc,
+		get_next_link=get_next_link,
+		_=frappe._,
+		scrub=scrub,
+		guess_mimetype=mimetypes.guess_type,
+		html2text=html2text,
+		dev_server=frappe._dev_server,
+		run_script=run_script,
+		is_job_queued=is_job_queued,
+		get_visible_columns=get_visible_columns,
+	)
+
+	out.frappe.update(SAFE_EXCEPTIONS)
+
+	if frappe.response:
+		out.frappe.response = frappe.response
+
+	out.update(safe_globals)
+
+	# default writer allows write access
+	out._write_ = _write
+	out._getitem_ = _getitem
+	out._getattr_ = _getattr_for_safe_exec
+
+	# Allow using `print()` calls with `safe_exec()`
+	out._print_ = FrappePrintCollector
+
+	# allow iterators and list comprehension
+	out._getiter_ = iter
+	out._iter_unpack_sequence_ = RestrictedPython.Guards.guarded_iter_unpack_sequence
+	out._inplacevar_ = protected_inplacevar
+
+	# add common python builtins
+	out.update(get_python_builtins())
+
+	return out
+
+
+def render_safe_globals():
+	"""Safer subset of globals for rendering ops."""
+	datautils = frappe._dict()
+
+	if frappe.db:
+		date_format = get_date_format()
+		time_format = get_time_format()
+		number_format = get_number_format()
+	else:
+		date_format = "yyyy-mm-dd"
+		time_format = "HH:mm:ss"
+		number_format = NumberFormat.from_string("#,###.##")
+
+	datautils.update(SAFE_DATA_UTILS)
+
+	form_dict = getattr(frappe.local, "form_dict", frappe._dict())
+
+	if "_" in form_dict:
+		del frappe.local.form_dict["_"]
+
+	user = (getattr(frappe.local, "session", None) and frappe.local.session.user) or "Guest"
+
+	out = NamespaceDict(
+		# make available limited methods of frappe
+		json=NamespaceDict(loads=json.loads, dumps=json.dumps),
+		orjson=SAFE_ORJSON,
+		as_json=frappe.as_json,
+		dict=dict,
+		log=frappe.log,
+		_dict=frappe._dict,
+		args=form_dict,
+		frappe=NamespaceDict(
+			flags=frappe._dict(),
+			format=frappe.format_value,
+			format_value=frappe.format_value,
+			date_format=date_format,
+			time_format=time_format,
+			number_format=number_format,
+			format_date=frappe.utils.data.global_date_format,
+			form_dict=form_dict,
+			bold=frappe.bold,
+			errprint=frappe.errprint,
+			qb=frappe.qb,
+			get_meta=safer_get_meta,
+			get_doc=get_doc_as_dict,
+			get_last_doc=safer_get_last_doc,
+			get_cached_doc=safer_get_cached_doc,
+			get_list=safe_get_list,
+			get_all=safe_get_all,
+			get_system_settings=frappe.get_system_settings,
+			utils=datautils,
+			get_url=frappe.utils.get_url,
+			render_template=frappe.render_template,
+			msgprint=frappe.msgprint,
+			throw=frappe.throw,
+			user=user,
+			get_fullname=frappe.utils.get_fullname,
+			get_gravatar=frappe.utils.get_gravatar_url,
+			full_name=frappe.local.session.data.full_name
+			if getattr(frappe.local, "session", None) and getattr(frappe.local.session, "data", None)
+			else "Guest",
+			request=getattr(frappe.local, "request", {}),
+			session=frappe._dict(
+				user=user,
+				csrf_token=frappe.local.session.data.csrf_token
+				if getattr(frappe.local, "session", None) and getattr(frappe.local.session, "data", None)
+				else "",
+			),
+			make_get_request=frappe.integrations.utils.make_get_request,
+			socketio_port=frappe.conf.socketio_port,
+			enqueue=safe_enqueue,
+			sanitize_html=frappe.utils.sanitize_html,
+			log_error=safer_log_error,
+			log=frappe.log,
+			db=NamespaceDict(
+				get_list=safe_get_list,
+				get_all=safe_get_all,
+				get_value=safe_get_value,
+				set_value=frappe.db.set_value,
+				get_single_value=safe_get_single_value,
+				get_default=frappe.db.get_default,
+				exists=frappe.db.exists,
+				count=frappe.db.count,
+				escape=frappe.db.escape,
+				sql=read_sql,
 				add_index=frappe.db.add_index,
 			),
 			website=NamespaceDict(

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -167,9 +167,7 @@ def safe_exec_flags():
 
 
 def safer_copy_doc(doc, ignore_no_copy=True):
-	from frappe.model.document import Document
-
-	assert isinstance(doc, (dict, Document))
+	assert isinstance(doc, dict)
 	assert isinstance(ignore_no_copy, bool)
 	copied_obj = frappe.copy_doc(doc, ignore_no_copy=ignore_no_copy)
 	return copied_obj.as_dict()
@@ -218,9 +216,7 @@ def safe_get_all(*args, **kwargs):
 
 
 def safer_get_meta(doctype, cached=True):
-	from frappe.model.document import Document
-
-	assert isinstance(doctype, (str, Document))
+	assert isinstance(doctype, str)
 	assert isinstance(cached, bool)
 
 	return frappe.get_meta(doctype, cached).as_dict()

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -243,7 +243,9 @@ def safer_log_error(
 
 def safer_get_visible_columns(*args, **kwargs):
 	cols = get_visible_columns(*args, **kwargs)
-	return [c.as_dict() for c in cols] if cols is not None else None
+	if cols is None:
+		return None
+	return [c if isinstance(c, dict) else c.as_dict() for c in cols]
 
 
 def safe_get_value(*args, **kwargs):
@@ -286,7 +288,7 @@ def make_safe_get_request(url: str, **kwargs):
 	for record in addr_info:
 		try:
 			addr = ipaddress.ip_address(record[4][0])
-		except (ValueError, IndexError):
+		except ValueError, IndexError:
 			continue
 
 		if not addr.is_global:

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -48,7 +48,7 @@ ARGUMENT_NOT_SET = object()
 SAFE_EXEC_CONFIG_KEY = "server_script_enabled"
 SERVER_SCRIPT_FILE_PREFIX = "<serverscript>"
 
-RENDER_EXEC_CONFIG_KEY = "render_exec_enabled"
+RENDER_EXEC_CONFIG_KEY = "disable_render_safe_exec"
 
 
 class NamespaceDict(frappe._dict):
@@ -89,7 +89,7 @@ def is_safe_exec_enabled() -> bool:
 
 
 def is_render_exec_enabled() -> bool:
-	return bool(frappe.get_common_site_config(cached=True).get(RENDER_EXEC_CONFIG_KEY))
+	return not bool(frappe.get_common_site_config(cached=True).get(RENDER_EXEC_CONFIG_KEY, 0))
 
 
 def safe_exec(
@@ -281,7 +281,7 @@ def make_safe_get_request(url: str, **kwargs):
 	for record in addr_info:
 		try:
 			addr = ipaddress.ip_address(record[4][0])
-		except (ValueError, IndexError):
+		except ValueError, IndexError:
 			continue
 
 		if not addr.is_global:

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -292,6 +292,20 @@ def safer_get_visible_columns(*args, **kwargs):
 	return [c.as_dict() for c in cols] if cols is not None else None
 
 
+def safer_get_print(*args, **kwargs):
+	print_obj = frappe.get_print(*args, **kwargs)
+	return print_obj if isinstance(print_obj, (str, bytes)) else None
+
+
+def safer_attach_print(*args, **kwargs):
+	print_obj = frappe.attach_print(*args, **kwargs)
+	fname = print_obj.get("fname")
+	fcontent = print_obj.get("fcontent")
+	if isinstance(fname, str) and isinstance(fcontent, (str, bytes)):
+		return print_obj
+	return None
+
+
 def get_safe_globals():
 	datautils = frappe._dict()
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -155,7 +155,7 @@ def safer_exec(
 	if script_filename:
 		filename += f": {frappe.scrub(script_filename)}"
 
-	with safe_exec_flags(), patched_qb():
+	with safe_exec_flags():
 		exec(_compile_code(script, filename=filename), exec_globals, _locals)
 
 	return exec_globals, _locals


### PR DESCRIPTION
Building a safer_exec :)

TODO:
- [x] Build a render_safe_globals (read)
- [x] Build a exec_safe_globals (write)
- [x] Hardening of utils/funcs.
- [x] Refactor
- [x] Integration
- [x] Audit and reviewed todo

Concerns:
1. methods, filters = get_jinja_hooks() (should we enforce here? )
https://github.com/AarDG10/frappe/blob/a28b2dfa043cb65ea59c652f2f140e4d94f0506d/frappe/utils/jinja.py#L34-L37
2. Enforce Exec. safe where it is expected (to min. breakages) instead of relying on reading frm. configs.?