### PR TITLE
fix: apply rights filter to `custom_rights` in permission manager

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -139,8 +139,8 @@ frappe.PermissionEngine = class PermissionEngine {
 		data.message.forEach((d) => {
 			let custom_rights = this.options.doctype_ptype_map[doctype] || [];
 			d.rights = this.rights
-				.filter((r) => d[r])
 				.concat(custom_rights)
+				.filter((r) => d[r])
 				.map((r) => {
 					return __(toTitle(frappe.unscrub(r)));
 				})


### PR DESCRIPTION
Custom rights were being concatenated after the filter, so they always appeared in the displayed permissions regardless of whether the role actually had them in `DocPerm`. Moving `.concat(custom_rights)` before `.filter((r) => d[r])` ensures custom rights are subject to the same check as standard rights.