### PR TITLE
fix: add wrapper on the run() method in query_report.py for dashboard charts to support user friendly error reporting

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -204,6 +204,41 @@ def get_reference_report(report):
 
 @frappe.whitelist()
 @frappe.read_only()
+def run_for_chart(
+	report_name: str,
+	filters: str | dict | None = None,
+	user: str | None = None,
+	ignore_prepared_report: bool = False,
+	custom_columns: str | list | None = None,
+	is_tree: bool = False,
+	parent_field: str | None = None,
+	are_default_filters: bool = True,
+	js_filters: str | list | None = None,
+	skip_total_calculation: bool = False,
+) -> dict:
+	try:
+		return run(
+			report_name=report_name,
+			filters=filters,
+			user=user,
+			ignore_prepared_report=ignore_prepared_report,
+			custom_columns=custom_columns,
+			is_tree=is_tree,
+			parent_field=parent_field,
+			are_default_filters=are_default_filters,
+			js_filters=js_filters,
+			skip_total_calculation=skip_total_calculation,
+		)
+	except frappe.ValidationError:
+		raise
+	except Exception:
+		frappe.throw(
+			_("Unable to generate chart data for this report. Please check the filters or try again.")
+		)
+
+
+@frappe.whitelist()
+@frappe.read_only()
 def run(
 	report_name: str,
 	filters: str | dict | None = None,

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -232,9 +232,8 @@ def run_for_chart(
 	except frappe.ValidationError:
 		raise
 	except Exception:
-		frappe.throw(
-			_("Unable to generate chart data for this report. Please check the filters or try again.")
-		)
+		frappe.log_error(frappe.get_traceback(), f"Dashboard Chart Error: {report_name}")
+		frappe.throw(_("Unable to generate chart data. Check Error Log for details."))
 
 
 @frappe.whitelist()

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -858,7 +858,7 @@ export default class ChartWidget extends Widget {
 					}
 				} else if (this.chart_doc.chart_type == "Report") {
 					this.settings = {
-						method: "frappe.desk.query_report.run",
+						method: "frappe.desk.query_report.run_for_chart",
 					};
 					return Promise.resolve();
 				} else {

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -560,12 +560,19 @@ export default class ChartWidget extends Widget {
 		return frappe.xcall(method, args, undefined, {
 			silent: true,
 			error: (err) => {
-				const message = JSON.parse(JSON.parse(err._server_messages)[0])?.message;
+				let message;
+				try {
+					message = JSON.parse(JSON.parse(err._server_messages)[0])?.message;
+				} catch (_) {
+					// 500 or malformed response
+				}
 				this.chart_wrapper.hide();
 				this.loading.hide();
 				this.$summary && this.$summary.hide();
 				this.empty.hide();
-				this.error_state.text(message);
+				this.error_state.text(
+					message || __("Unable to generate chart data. Check Error Log for details.")
+				);
 				this.error_state.show();
 			},
 		});


### PR DESCRIPTION
Before:
<img width="1440" height="900" alt="Screenshot 2026-03-11 at 2 57 59 PM" src="https://github.com/user-attachments/assets/ebe1bfc5-12b8-4b58-8480-805596d1fdc6" />


After:
<img width="1440" height="900" alt="Screenshot 2026-03-11 at 3 00 23 PM" src="https://github.com/user-attachments/assets/1e923559-554a-483d-8437-6a9a356fd7af" />

closes frappe/erpnext#53202
ref frappe/erpnext#53306
ref frappe/erpnext#53307
