### PR TITLE
fix: show original text in warning message preview instead of lower c…

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -1039,13 +1039,14 @@ class Column:
 		if self.df.fieldtype == "Link":
 			# find all values that dont exist
 			transform = (lambda v: cstr(v).lower()) if frappe.db.db_type == "mariadb" else cstr
-			values = list({transform(v) for v in self.column_values if v})
+			original_values = {transform(v): cstr(v) for v in self.column_values if v}
+			values = list(original_values.keys())
 			exists = [
 				transform(d.name) for d in frappe.get_all(self.df.options, filters={"name": ("in", values)})
 			]
 			not_exists = list(set(values) - set(exists))
 			if not_exists:
-				missing_values = ", ".join(not_exists)
+				missing_values = ", ".join(original_values[v] for v in not_exists)
 				message = _("The following values do not exist for {0}: {1}")
 				self.warnings.append(
 					{


### PR DESCRIPTION
Raising it on behalf of @sudarsan2001 

**Ref**:  [#37938](https://github.com/frappe/frappe/issues/37938)

**Issue**: In Data Import, when a Link field column contains values that don't exist in the linked doctype, the warning message displays the values in lowercase instead of preserving the original case as entered in the uploaded Excel/CSV file.

**Before**: 
<img width="1274" height="226" alt="image" src="https://github.com/user-attachments/assets/823232b1-e9b0-4a77-b601-fa05d46514b9" />
<img width="562" height="141" alt="image" src="https://github.com/user-attachments/assets/13d88430-3434-41bd-bfe3-a30b11dbbb28" />

**After**:
<img width="562" height="141" alt="image" src="https://github.com/user-attachments/assets/70065518-05be-4a0f-b97d-4e3ed7dfbc42" />

backport needed in v15