### PR TITLE
fix: make file size param optional

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -165,7 +165,6 @@ def upload_file():
 		file = files["file"]
 		filename = file.filename
 
-		total_file_size = frappe.form_dict.total_file_size
 		if frappe.form_dict.chunk_index:
 			current_chunk = int(frappe.form_dict.chunk_index)
 			total_chunks = int(frappe.form_dict.total_chunk_count)
@@ -177,6 +176,7 @@ def upload_file():
 
 		temp_path = Path(get_files_path(".temp-" + get_safe_file_name(filename), is_private=is_private))
 		with temp_path.open("ab" if current_chunk > 0 else "wb") as f:
+			total_file_size = frappe.form_dict.total_file_size or 0
 			f.seek(offset)
 			f.write(file.stream.read())
 			if not f.tell() >= int(total_file_size) or current_chunk != total_chunks - 1:


### PR DESCRIPTION
This is an optional param but wasn't treated like that. Needs to be backported with #37888 