### PR TITLE
fix(ui): tree level input spacing in reports

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -2264,8 +2264,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		if (this.tree_report) {
 			this.$tree_footer = $(`<div class="tree-footer col-md-3">
 				<div class="input-group">
-				  <input id="tree-level" type="number" class="form-control" aria-label="Tree Level" value="2">
-					<button class="btn btn-xs btn-secondary" data-action="set_tree_level">
+				  <input id="tree-level" type="number" class="form-control" style="width: 60px; border-right: 1px solid var(--border-color);" aria-label="Tree Level" value="2">
+					<button class="btn btn-xs btn-secondary" style="border-top-left-radius: 0px; border-bottom-left-radius: 0px;" data-action="set_tree_level">
 						${__("Set Level")}</button>
 					<button class="btn btn-xs btn-secondary" data-action="expand_all_rows">
 						${__("Expand All")}</button>


### PR DESCRIPTION
I am assuming the input and button were supposed to stick together - had to use inline styles since `form-control` and `input-group` are used in a lot of places.

Before:
<img width="1426" height="720" alt="CleanShot 2026-03-12 at 14 39 35@2x" src="https://github.com/user-attachments/assets/4b90c1f7-f1f5-4453-9d47-30e3c3c70928" />


After:

<img width="1426" height="720" alt="CleanShot 2026-03-12 at 14 39 03@2x" src="https://github.com/user-attachments/assets/857a79ba-4bfe-4c99-84c2-73e3c01cc9d9" />

