### PR TITLE
fix: remove link for Print Designer

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -206,16 +206,6 @@ frappe.ui.form.PrintView = class {
 		this.set_breadcrumbs();
 		this.setup_customize_dialog();
 
-		// print designer link
-		if (!cint(frappe.boot.sysdefaults.disable_product_suggestion)) {
-			if (!Object.keys(frappe.boot.versions).includes("print_designer")) {
-				this.page.add_inner_message(`
-				<a style="line-height: 2.4" href="https://frappecloud.com/marketplace/apps/print_designer?utm_source=framework-desk&utm_medium=print-view&utm_campaign=try-link">
-					${__("Try the new Print Designer")}
-				</a>
-				`);
-			}
-		}
 		let tasks = [
 			this.set_default_print_format,
 			this.set_default_print_language,


### PR DESCRIPTION
Print Designer promotional link is not needed on the page. Long term goal is to make a better printing experience on Framework anyway. Keeping this PR as a draft for now.

Related to https://github.com/frappe/erpnext/issues/53319