### PR TITLE
fix: wrap `get_match_cond()` in parentheses

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -809,7 +809,7 @@ def get_match_cond(doctype, as_condition=True):
 	if not as_condition:
 		return cond
 
-	return ((" and " + cond) if cond else "").replace("%", "%%")
+	return ((" and (" + cond + ")") if cond else "").replace("%", "%%")
 
 
 def build_match_conditions(doctype, user=None, as_condition=True):


### PR DESCRIPTION
Fixes #37962

---

**Reproduce**
```python
frappe.set_user("john@example.com")  # user with company User Permission
from frappe.desk.reportview import get_match_cond
print(get_match_cond("Employee"))
```

**Before**
```sql
 and IFNULL(`tabEmployee`.`company`,'')='' OR `tabEmployee`.`company` IN ('Hakuna Matata (Demo)')
 ```
---

**After**
```sql
 and (IFNULL(`tabEmployee`.`company`,'')='' OR `tabEmployee`.`company` IN ('Hakuna Matata (Demo)'))
 ```
 
so when Searching for `joh` in Employee , user only has permission on `Hakuna Matata (Demo)`:

```py
# without parentheses, Tamer Hassan leaks in, search text ignored
frappe.db.sql("""
    SELECT name, employee_name FROM `tabEmployee`
    WHERE employee_name LIKE '%joh%'
    AND IFNULL(`tabEmployee`.`company`,'')='' OR `tabEmployee`.`company` IN ('Hakuna Matata (Demo)')
""")
# (('HR-EMP-00002', 'John Doe'), ('HR-EMP-00003', 'Tamer Hassan'))

# with parentheses, only John Doe matches the search
frappe.db.sql("""
    SELECT name, employee_name FROM `tabEmployee`
    WHERE employee_name LIKE '%joh%'
    AND (IFNULL(`tabEmployee`.`company`,'')='' OR `tabEmployee`.`company` IN ('Hakuna Matata (Demo)'))
""")
# (('HR-EMP-00002', 'John Doe'),)


```