### PR TITLE
feat(File): add helper to copy attachment to different doc

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -157,6 +157,7 @@ class File(Document):
 				"attached_to_field": attached_to_field,
 			}
 		)
+		attachment.folder = None
 		attachment.flags.copy_from_existing_file = True
 		return attachment.insert(ignore_permissions=ignore_permissions)
 

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -115,6 +115,16 @@ class File(Document):
 		if self.is_folder:
 			return
 
+		if self.flags.copy_from_existing_file:
+			# Preserve the normal insert lifecycle for hooks and validations, but skip
+			# reprocessing an existing blob that is already referenced by `file_url`.
+			if not self.file_url:
+				frappe.throw(
+					_("File URL is required when copying an existing attachment."),
+					exc=frappe.MandatoryError,
+				)
+			return
+
 		if self.is_remote_file:
 			self.validate_remote_file()
 		else:
@@ -127,6 +137,28 @@ class File(Document):
 	def after_insert(self):
 		if not self.is_folder:
 			self.create_attachment_record()
+
+	def create_attachment_copy(
+		self,
+		attached_to_doctype: str,
+		attached_to_name: str,
+		attached_to_field: str | None = None,
+		ignore_permissions: bool = False,
+	):
+		"""Efficiently copy an attachment from one document to another by reusing `file_url`."""
+		if self.is_folder:
+			frappe.throw(_("Cannot attach a folder to a document"))
+
+		attachment = frappe.copy_doc(self)
+		attachment.update(
+			{
+				"attached_to_doctype": attached_to_doctype,
+				"attached_to_name": attached_to_name,
+				"attached_to_field": attached_to_field,
+			}
+		)
+		attachment.flags.copy_from_existing_file = True
+		return attachment.insert(ignore_permissions=ignore_permissions)
 
 	def validate(self):
 		if self.is_folder:

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -276,6 +276,10 @@ class TestSameContent(IntegrationTestCase):
 		self.assertEqual(copied_file.file_url, source_file.file_url)
 		self.assertEqual(copied_file.attached_to_doctype, doctype)
 		self.assertEqual(copied_file.attached_to_name, docname)
+		self.assertEqual(
+			copied_file.folder,
+			frappe.db.get_value("File", {"is_attachments_folder": 1}),
+		)
 		self.assertEqual(comment_count_after, comment_count_before + 1)
 
 	def test_create_attachment_copy_respects_attachment_limit(self):

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -254,6 +254,62 @@ class TestSameContent(IntegrationTestCase):
 		limit_property.delete()
 		frappe.clear_cache(doctype="ToDo")
 
+	def test_create_attachment_copy(self):
+		doctype, docname = make_test_doc()
+		source_file = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": f"existing-file-{frappe.generate_hash(length=8)}.txt",
+				"content": "Existing attachment content",
+			}
+		).insert()
+		comment_count_before = frappe.db.count(
+			"Comment", {"reference_doctype": doctype, "reference_name": docname}
+		)
+
+		copied_file = source_file.create_attachment_copy(doctype, docname)
+		comment_count_after = frappe.db.count(
+			"Comment", {"reference_doctype": doctype, "reference_name": docname}
+		)
+
+		self.assertNotEqual(copied_file.name, source_file.name)
+		self.assertEqual(copied_file.file_url, source_file.file_url)
+		self.assertEqual(copied_file.attached_to_doctype, doctype)
+		self.assertEqual(copied_file.attached_to_name, docname)
+		self.assertEqual(comment_count_after, comment_count_before + 1)
+
+	def test_create_attachment_copy_respects_attachment_limit(self):
+		doctype, docname = make_test_doc()
+		from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+
+		limit_property = make_property_setter("ToDo", None, "max_attachments", 1, "int", for_doctype=True)
+		source_file_1 = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": f"existing-limit-file-{frappe.generate_hash(length=8)}.txt",
+				"content": "Existing attachment content 1",
+			}
+		).insert()
+		source_file_2 = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": f"existing-limit-file-{frappe.generate_hash(length=8)}.txt",
+				"content": "Existing attachment content 2",
+			}
+		).insert()
+
+		try:
+			source_file_1.create_attachment_copy(doctype, docname)
+			self.assertRaises(
+				frappe.exceptions.AttachmentLimitReached,
+				source_file_2.create_attachment_copy,
+				doctype,
+				docname,
+			)
+		finally:
+			limit_property.delete()
+			frappe.clear_cache(doctype="ToDo")
+
 	def test_utf8_bom_content_decoding(self):
 		utf8_bom_content = test_content1.encode("utf-8-sig")
 		_file: frappe.Document = frappe.get_doc(


### PR DESCRIPTION
## Summary
- add `create_attachment_copy()` on **File** to efficiently copy an attachment from one document to another by reusing the existing `file_url`
- preserve the normal **File** insert lifecycle so ecosystem hooks and document events still run for copied attachments
- skip blob reprocessing for existing files while keeping target-document checks like attachment-limit validation in place

## Why
Sometimes we want to copy an attachment from one doc to a different doc. A raw database insert is efficient, but it bypasses the extension points and validations that apps in the ecosystem rely on when **File** records are inserted. A normal **File** insert, on the other hand, treats the copy like a brand new upload and unnecessarily reprocesses the underlying file.

This helper provides a middle path: create a new **File** entry for another document while reusing the existing file reference, without giving up the standard **File** insert flow.

## Test plan
- add coverage for `create_attachment_copy()` in `frappe/core/doctype/file/test_file.py`
- verify copied attachments create a new **File** record while reusing the same `file_url`
- verify attachment limits are still enforced on the target document