### PR TITLE
fix: misc sidebar editor issues

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
@@ -271,7 +271,11 @@ export class SidebarEditor {
 							break;
 					}
 
-					if (d.get_value("type") == "Link" && d.get_value("link_type") !== "URL") {
+					if (
+						!d.get_value("link_to") &&
+						d.get_value("type") == "Link" &&
+						d.get_value("link_type") !== "URL"
+					) {
 						d.set_value("link_to", label);
 					}
 

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
@@ -141,15 +141,15 @@ export class SidebarEditor {
 				me.sorting = true;
 			},
 			onEnd: function (event) {
+				if (event.from !== event.to) return; // onAdd handles this case
+
 				if (me.new_sidebar_items.length == 0) {
 					me.new_sidebar_items = Array.from(me.workspace_sidebar_items);
 				}
 				let old_index = event.oldIndex;
 				let new_index = event.newIndex;
-				me.new_sidebar_items[old_index];
-				let b = me.new_sidebar_items[old_index];
-				me.new_sidebar_items[old_index] = me.new_sidebar_items[new_index];
-				me.new_sidebar_items[new_index] = b;
+				let [item] = me.new_sidebar_items.splice(old_index, 1);
+				me.new_sidebar_items.splice(new_index, 0, item);
 			},
 		});
 
@@ -198,21 +198,16 @@ export class SidebarEditor {
 					);
 				},
 				onEnd: function (event) {
+					if (event.from !== event.to) return; // onAdd handles this case
+
 					let new_index = event.newIndex;
 					let old_index = event.oldIndex;
-					let item_label = $(event.item).data("id");
-					me.new_sidebar_items.forEach((item) => {
-						if (item.nested_items.length) {
-							let child = item.nested_items.find(
-								(child) => child.label === item_label
-							);
-							if (child) {
-								let b = item.nested_items[old_index];
-								item.nested_items[old_index] = item.nested_items[new_index];
-								item.nested_items[new_index] = b;
-							}
-						}
-					});
+					let section_name = $(event.to).parent().attr("item-name");
+					let section_data = me.get_item_data(section_name);
+					if (section_data && section_data.nested_items) {
+						let [item] = section_data.nested_items.splice(old_index, 1);
+						section_data.nested_items.splice(new_index, 0, item);
+					}
 				},
 			});
 		});

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
@@ -84,6 +84,9 @@ export class SidebarEditor {
 	}
 	prepare_data() {
 		this.new_sidebar_items.forEach((item) => {
+			if (item.parent) {
+				delete item.parent;
+			}
 			if (!item.nested_items) return;
 			item.nested_items.forEach((nested_item) => {
 				if (nested_item.parent) {

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -185,7 +185,7 @@ frappe.ui.sidebar_item.TypeSectionBreak = class SectionBreakSidebarItem extends 
 		this.full_template = $(this.wrapper);
 	}
 	make() {
-		if (this.nested_items.length == 0) {
+		if (this.nested_items.length == 0 && !frappe.app.sidebar.editor.edit_mode) {
 			return;
 		}
 		super.make();

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -306,6 +306,7 @@
 	display: flex;
 	gap: 6px;
 	width: 0;
+	overflow: hidden;
 }
 .standard-sidebar-item[data-name="add-sidebar-item"] {
 	margin-top: 5px;

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -83,6 +83,7 @@
 
 	.standard-sidebar-item {
 		display: flex;
+		position: relative;
 		@include transition(all, 0.3s, cubic-bezier(0.4, 0, 0.2, 1));
 
 		margin-bottom: 1px;
@@ -292,7 +293,6 @@
 	.standard-sidebar-item:hover {
 		& .sidebar-item-edit-controls {
 			visibility: visible;
-			width: auto;
 		}
 	}
 	.promotional-banners,
@@ -303,10 +303,10 @@
 }
 .sidebar-item-edit-controls {
 	visibility: hidden;
+	position: absolute;
+	right: 0;
 	display: flex;
 	gap: 6px;
-	width: 0;
-	overflow: hidden;
 }
 .standard-sidebar-item[data-name="add-sidebar-item"] {
 	margin-top: 5px;


### PR DESCRIPTION
1. `Link To` was getting overwritten on label change -> now it is only set if empty
2. Empty Section Breaks breaks did not show up even in edit mode -> now they show up in edit mode
3. A horizontal overflow kicked in at edit mode (reason: flex items has by default min-width `auto`)

<img width="489" height="459" alt="issue" src="https://github.com/user-attachments/assets/450f9d12-2a19-44d8-816e-abdb3be435fa" />

4. Active state of edit control buttons gets cut off. Take the controls out of normal flow (fixes 3 too)

<img width="1024" height="768" alt="ya-fix" src="https://github.com/user-attachments/assets/ef4b1cb1-befa-49d5-a146-6ce061b16793" />

5. Clean up parent from top-level sidebar items
6. Re-order breaks due to swapping after indices become stale
