### PR TITLE
refactor: desktop icon permissions

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -14,7 +14,6 @@ from frappe.core.doctype.installed_applications.installed_applications import (
 )
 from frappe.core.doctype.navbar_settings.navbar_settings import get_app_logo, get_navbar_settings
 from frappe.desk.doctype.changelog_feed.changelog_feed import get_changelog_feed_items
-from frappe.desk.doctype.desktop_icon.desktop_icon import get_desktop_icons
 from frappe.desk.doctype.form_tour.form_tour import get_onboarding_ui_tours
 from frappe.desk.doctype.route_history.route_history import frequently_visited_links
 from frappe.desk.form.load import get_meta_bundle
@@ -58,7 +57,6 @@ def get_bootinfo():
 	bootinfo.modules = {}
 	bootinfo.module_list = []
 	load_desktop_data(bootinfo)
-	bootinfo.desktop_icons = get_desktop_icons(bootinfo=bootinfo)
 	bootinfo.letter_heads = get_letter_heads()
 	bootinfo.active_domains = frappe.get_active_domains()
 	bootinfo.all_domains = frappe.get_all("Domain", pluck="name")
@@ -168,11 +166,11 @@ def load_desktop_data(bootinfo):
 
 	bootinfo.workspaces = get_workspace_sidebar_items()
 	allowed_pages = [d.name for d in bootinfo.workspaces.get("pages")]
-	bootinfo.workspace_sidebar_item = get_sidebar_items(allowed_pages)
+	bootinfo.allowed_workspaces = allowed_pages
 	bootinfo.module_wise_workspaces = get_controller("Workspace").get_module_wise_workspaces()
 	bootinfo.dashboards = frappe.get_all("Dashboard")
 	bootinfo.app_data = []
-
+	get_icons_and_sidebar(bootinfo)
 	Workspace = frappe.qb.DocType("Workspace")
 	Module = frappe.qb.DocType("Module Def")
 
@@ -228,6 +226,10 @@ def load_desktop_data(bootinfo):
 
 def get_allowed_pages(cache=False):
 	return get_user_pages_or_reports("Page", cache=cache)
+
+
+def get_allowed_pages_names(cache=False) -> set[str]:
+	return {cstr(page) for page in get_allowed_pages(cache).keys() if page}
 
 
 def get_allowed_reports(cache=False):
@@ -544,74 +546,64 @@ def get_sentry_dsn():
 	return os.getenv("FRAPPE_SENTRY_DSN")
 
 
-def get_sidebar_items(allowed_workspaces):
-	from frappe import _
-	from frappe.desk.doctype.workspace_sidebar.workspace_sidebar import auto_generate_sidebar_from_module
+def get_icons_and_sidebar(bootinfo):
+	bootinfo.desktop_icons = []
+	bootinfo.workspace_sidebar_item = {}
+	for sidebar in frappe.get_all("Workspace Sidebar", pluck="name"):
+		sidebar_doc = frappe.get_doc("Workspace Sidebar", sidebar)
+		allowed_items = []
+		for item in sidebar_doc.items:
+			if is_item_allowed(item.link_to, item.link_type, bootinfo):
+				allowed_items.append(item.as_dict())
+		if len(allowed_items) > 0 and not all(item.type == "Section Break" for item in allowed_items):
+			bootinfo.workspace_sidebar_item[sidebar.lower()] = sidebar_doc.as_dict()
+			bootinfo.workspace_sidebar_item[sidebar.lower()]["items"] = allowed_items
+	for icon in frappe.get_all("Desktop Icon", pluck="name"):
+		icon_doc = frappe.get_doc("Desktop Icon", icon)
+		try:
+			if icon_doc.icon_type == "Folder":
+				bootinfo.desktop_icons.append(icon_doc.as_dict())
+			if icon_doc.icon_type == "App" and check_app_permission(icon_doc):
+				bootinfo.desktop_icons.append(icon_doc.as_dict())
+			if icon_doc.link_type == "Workspace Sidebar" and bootinfo.workspace_sidebar_item[icon.lower()]:
+				bootinfo.desktop_icons.append(icon_doc.as_dict())
+		except KeyError as e:
+			print("Helo", e)
 
-	workspace_sidebars = frappe.get_all(
-		"Workspace Sidebar", fields=["name", "header_icon", "module_onboarding"]
-	)
-	module_sidebars = auto_generate_sidebar_from_module()
-	workspace_sidebars.extend(module_sidebars)
-	sidebar_items = {}
 
-	for sidebar in workspace_sidebars:
-		sidebar_title = sidebar.get("name")
-		sidebar_doc = None
-		if sidebar_title:
-			sidebar_doc = frappe.get_doc("Workspace Sidebar", sidebar_title)
-		else:
-			sidebar_title = sidebar.title
-			sidebar_doc = sidebar
-		if (
-			frappe.session.user == "Administrator"
-			or sidebar_title == "My Workspaces"
-			or not sidebar_doc.module
-			or sidebar_doc.module in sidebar_doc.user.allow_modules
-		):
-			sidebar_items[sidebar_title.lower()] = {
-				"label": sidebar_title,
-				"items": [],
-				"header_icon": sidebar.get("header_icon"),
-				"module_onboarding": sidebar.get("module_onboarding"),
-				"module": sidebar_doc.module,
-				"app": sidebar_doc.app,
-			}
-			for item in sidebar_doc.items:
-				workspace_sidebar = {
-					"label": _(item.label),
-					"link_to": item.link_to,
-					"link_type": item.link_type,
-					"type": item.type,
-					"icon": item.icon,
-					"child": item.child,
-					"collapsible": item.collapsible,
-					"indent": item.indent,
-					"keep_closed": item.keep_closed,
-					"display_depends_on": item.display_depends_on,
-					"url": item.url,
-					"show_arrow": item.show_arrow,
-					"filters": item.filters,
-					"route_options": item.route_options,
-					"tab": item.navigate_to_tab,
-					"open_in_new_tab": item.open_in_new_tab,
-				}
-				if item.link_type == "Report" and item.link_to and frappe.db.exists("Report", item.link_to):
-					report_type, ref_doctype = frappe.db.get_value(
-						"Report", item.link_to, ["report_type", "ref_doctype"]
-					)
-					workspace_sidebar["report"] = {
-						"report_type": report_type,
-						"ref_doctype": ref_doctype,
-					}
-				if (
-					"My Workspaces" in sidebar_title
-					or item.type == "Section Break"
-					or sidebar_doc.is_item_allowed(item.link_to, item.link_type, allowed_workspaces)
-				):
-					sidebar_items[sidebar_title.lower()]["items"].append(workspace_sidebar)
-	add_user_specific_sidebar(sidebar_items)
-	return sidebar_items
+def is_item_allowed(item_name, item_type, bootinfo):
+	if frappe.session.user == "Administrator":
+		return True
+	if not item_name:
+		return True
+	item_type = item_type.lower()
+	if item_type == "doctype":
+		return item_name in (bootinfo.user.can_read or []) and frappe.has_permission(item_name)
+	if item_type == "page":
+		return item_name in get_allowed_pages_names()
+	if item_type == "report":
+		return item_name in get_allowed_report_names()
+	if item_type == "dashboard":
+		return item_name in bootinfo.dashboards
+	if item_type == "url":
+		return True
+	if item_type == "workspace":
+		return item_name in bootinfo.allowed_workspaces
+
+
+def check_app_permission(icon):
+	for a in frappe.get_installed_apps():
+		if frappe.get_hooks(app_name=a)["app_title"][0] == icon.label or icon.app == a:
+			app_detail = frappe.get_hooks("add_to_apps_screen", app_name=a)
+			if len(app_detail) != 0:
+				permission_method = app_detail[0].get("has_permission", None)
+				if permission_method:
+					return frappe.call(permission_method)
+				else:
+					return True
+			else:
+				# App hooks.py doesn't have add_to_apps_screen
+				return True
 
 
 def get_desktop_icon_urls():

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -548,9 +548,16 @@ def get_sentry_dsn():
 
 def get_icons_and_sidebar(bootinfo):
 	bootinfo.desktop_icons = []
+	from frappe.desk.doctype.workspace_sidebar.workspace_sidebar import auto_generate_sidebar_from_module
+
 	bootinfo.workspace_sidebar_item = {}
-	for sidebar in frappe.get_all("Workspace Sidebar", pluck="name"):
-		sidebar_doc = frappe.get_doc("Workspace Sidebar", sidebar)
+	sidebars = frappe.get_all("Workspace Sidebar", pluck="name") + auto_generate_sidebar_from_module()
+	for sidebar in sidebars:
+		if isinstance(sidebar, str):
+			sidebar_doc = frappe.get_doc("Workspace Sidebar", sidebar)
+		else:
+			sidebar_doc = sidebar
+			sidebar = sidebar_doc.title
 		if sidebar_doc.module not in frappe.get_user().permitted_modules:
 			continue
 		allowed_items = []
@@ -560,6 +567,7 @@ def get_icons_and_sidebar(bootinfo):
 		if len(allowed_items) > 0 and not all(item.type == "Section Break" for item in allowed_items):
 			bootinfo.workspace_sidebar_item[sidebar.lower()] = sidebar_doc.as_dict()
 			bootinfo.workspace_sidebar_item[sidebar.lower()]["items"] = allowed_items
+
 	for icon in frappe.get_all("Desktop Icon", pluck="name"):
 		icon_doc = frappe.get_doc("Desktop Icon", icon)
 		try:

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -551,6 +551,8 @@ def get_icons_and_sidebar(bootinfo):
 	bootinfo.workspace_sidebar_item = {}
 	for sidebar in frappe.get_all("Workspace Sidebar", pluck="name"):
 		sidebar_doc = frappe.get_doc("Workspace Sidebar", sidebar)
+		if sidebar_doc.module not in frappe.get_user().permitted_modules:
+			continue
 		allowed_items = []
 		for item in sidebar_doc.items:
 			if is_item_allowed(item.link_to, item.link_type, bootinfo):
@@ -568,7 +570,7 @@ def get_icons_and_sidebar(bootinfo):
 			if icon_doc.link_type == "Workspace Sidebar" and bootinfo.workspace_sidebar_item[icon.lower()]:
 				bootinfo.desktop_icons.append(icon_doc.as_dict())
 		except KeyError as e:
-			print("Helo", e)
+			print(e)
 
 
 def is_item_allowed(item_name, item_type, bootinfo):

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -595,7 +595,7 @@ def is_item_allowed(item_name, item_type, bootinfo):
 
 def check_app_permission(icon):
 	for a in frappe.get_installed_apps():
-		if frappe.get_hooks(app_name=a)["app_title"][0] == icon.label or icon.app == a:
+		if frappe.get_hooks("app_title", app_name=a)[0] == icon.label or icon.app == a:
 			app_detail = frappe.get_hooks("add_to_apps_screen", app_name=a)
 			if len(app_detail) != 0:
 				permission_method = app_detail[0].get("has_permission", None)

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -14,7 +14,6 @@ from frappe.core.doctype.installed_applications.installed_applications import (
 )
 from frappe.core.doctype.navbar_settings.navbar_settings import get_app_logo, get_navbar_settings
 from frappe.desk.doctype.changelog_feed.changelog_feed import get_changelog_feed_items
-from frappe.desk.doctype.desktop_icon.desktop_icon import get_desktop_icons
 from frappe.desk.doctype.form_tour.form_tour import get_onboarding_ui_tours
 from frappe.desk.doctype.route_history.route_history import frequently_visited_links
 from frappe.desk.form.load import get_meta_bundle
@@ -57,7 +56,6 @@ def get_bootinfo():
 	bootinfo.modules = {}
 	bootinfo.module_list = []
 	load_desktop_data(bootinfo)
-	bootinfo.desktop_icons = get_desktop_icons(bootinfo=bootinfo)
 	bootinfo.letter_heads = get_letter_heads()
 	bootinfo.active_domains = frappe.get_active_domains()
 	bootinfo.all_domains = [d.get("name") for d in frappe.get_all("Domain")]
@@ -165,11 +163,11 @@ def load_desktop_data(bootinfo):
 
 	bootinfo.workspaces = get_workspace_sidebar_items()
 	allowed_pages = [d.name for d in bootinfo.workspaces.get("pages")]
-	bootinfo.workspace_sidebar_item = get_sidebar_items(allowed_pages)
+	bootinfo.allowed_workspaces = allowed_pages
 	bootinfo.module_wise_workspaces = get_controller("Workspace").get_module_wise_workspaces()
 	bootinfo.dashboards = frappe.get_all("Dashboard")
 	bootinfo.app_data = []
-
+	get_icons_and_sidebar(bootinfo)
 	Workspace = frappe.qb.DocType("Workspace")
 	Module = frappe.qb.DocType("Module Def")
 
@@ -225,6 +223,10 @@ def load_desktop_data(bootinfo):
 
 def get_allowed_pages(cache=False):
 	return get_user_pages_or_reports("Page", cache=cache)
+
+
+def get_allowed_pages_names(cache=False) -> set[str]:
+	return {cstr(page) for page in get_allowed_pages(cache).keys() if page}
 
 
 def get_allowed_reports(cache=False):
@@ -536,72 +538,64 @@ def get_sentry_dsn():
 	return os.getenv("FRAPPE_SENTRY_DSN")
 
 
-def get_sidebar_items(allowed_workspaces):
-	from frappe import _
-	from frappe.desk.doctype.workspace_sidebar.workspace_sidebar import auto_generate_sidebar_from_module
+def get_icons_and_sidebar(bootinfo):
+	bootinfo.desktop_icons = []
+	bootinfo.workspace_sidebar_item = {}
+	for sidebar in frappe.get_all("Workspace Sidebar", pluck="name"):
+		sidebar_doc = frappe.get_doc("Workspace Sidebar", sidebar)
+		allowed_items = []
+		for item in sidebar_doc.items:
+			if is_item_allowed(item.link_to, item.link_type, bootinfo):
+				allowed_items.append(item.as_dict())
+		if len(allowed_items) > 0 and not all(item.type == "Section Break" for item in allowed_items):
+			bootinfo.workspace_sidebar_item[sidebar.lower()] = sidebar_doc.as_dict()
+			bootinfo.workspace_sidebar_item[sidebar.lower()]["items"] = allowed_items
+	for icon in frappe.get_all("Desktop Icon", pluck="name"):
+		icon_doc = frappe.get_doc("Desktop Icon", icon)
+		try:
+			if icon_doc.icon_type == "Folder":
+				bootinfo.desktop_icons.append(icon_doc.as_dict())
+			if icon_doc.icon_type == "App" and check_app_permission(icon_doc):
+				bootinfo.desktop_icons.append(icon_doc.as_dict())
+			if icon_doc.link_type == "Workspace Sidebar" and bootinfo.workspace_sidebar_item[icon.lower()]:
+				bootinfo.desktop_icons.append(icon_doc.as_dict())
+		except KeyError as e:
+			print("Helo", e)
 
-	workspace_sidebars = frappe.get_all(
-		"Workspace Sidebar", fields=["name", "header_icon", "module_onboarding"]
-	)
-	module_sidebars = auto_generate_sidebar_from_module()
-	workspace_sidebars.extend(module_sidebars)
-	sidebar_items = {}
 
-	for sidebar in workspace_sidebars:
-		sidebar_title = sidebar.get("name")
-		sidebar_doc = None
-		if sidebar_title:
-			sidebar_doc = frappe.get_doc("Workspace Sidebar", sidebar_title)
-		else:
-			sidebar_title = sidebar.title
-			sidebar_doc = sidebar
-		if (
-			frappe.session.user == "Administrator"
-			or sidebar_doc.module in sidebar_doc.user.allow_modules
-			or sidebar_title == "My Workspaces"
-		):
-			sidebar_items[sidebar_title.lower()] = {
-				"label": sidebar_title,
-				"items": [],
-				"header_icon": sidebar.get("header_icon"),
-				"module_onboarding": sidebar.get("module_onboarding"),
-				"module": sidebar_doc.module,
-				"app": sidebar_doc.app,
-			}
-			for item in sidebar_doc.items:
-				workspace_sidebar = {
-					"label": _(item.label),
-					"link_to": item.link_to,
-					"link_type": item.link_type,
-					"type": item.type,
-					"icon": item.icon,
-					"child": item.child,
-					"collapsible": item.collapsible,
-					"indent": item.indent,
-					"keep_closed": item.keep_closed,
-					"display_depends_on": item.display_depends_on,
-					"url": item.url,
-					"show_arrow": item.show_arrow,
-					"filters": item.filters,
-					"route_options": item.route_options,
-					"tab": item.navigate_to_tab,
-				}
-				if item.link_type == "Report" and item.link_to and frappe.db.exists("Report", item.link_to):
-					report_type, ref_doctype = frappe.db.get_value(
-						"Report", item.link_to, ["report_type", "ref_doctype"]
-					)
-					workspace_sidebar["report"] = {
-						"report_type": report_type,
-						"ref_doctype": ref_doctype,
-					}
-				if (
-					"My Workspaces" in sidebar_title
-					or item.type == "Section Break"
-					or sidebar_doc.is_item_allowed(item.link_to, item.link_type, allowed_workspaces)
-				):
-					sidebar_items[sidebar_title.lower()]["items"].append(workspace_sidebar)
-	add_user_specific_sidebar(sidebar_items)
-	return sidebar_items
+def is_item_allowed(item_name, item_type, bootinfo):
+	if frappe.session.user == "Administrator":
+		return True
+	if not item_name:
+		return True
+	item_type = item_type.lower()
+	if item_type == "doctype":
+		return item_name in (bootinfo.user.can_read or []) and frappe.has_permission(item_name)
+	if item_type == "page":
+		return item_name in get_allowed_pages_names()
+	if item_type == "report":
+		return item_name in get_allowed_report_names()
+	if item_type == "dashboard":
+		return item_name in bootinfo.dashboards
+	if item_type == "url":
+		return True
+	if item_type == "workspace":
+		return item_name in bootinfo.allowed_workspaces
+
+
+def check_app_permission(icon):
+	for a in frappe.get_installed_apps():
+		if frappe.get_hooks(app_name=a)["app_title"][0] == icon.label or icon.app == a:
+			app_detail = frappe.get_hooks("add_to_apps_screen", app_name=a)
+			if len(app_detail) != 0:
+				permission_method = app_detail[0].get("has_permission", None)
+				if permission_method:
+					return frappe.call(permission_method)
+				else:
+					return True
+			else:
+				# App hooks.py doesn't have add_to_apps_screen
+				return True
 
 
 def get_desktop_icon_urls():

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -85,34 +85,13 @@ class DesktopIcon(Document):
 		if os.path.exists(file_path):
 			os.remove(file_path)
 
-	def is_permitted(self, bootinfo):
-		icon_module = None
-		if self.icon_type == "Link" and self.link_to:
-			icon_module = frappe.db.get_value("Workspace", self.link_to, "module")
-		# module permission check
-		if icon_module:
-			blocked_modules = frappe.get_cached_doc("User", frappe.session.user).get_blocked_modules()
-			if icon_module in blocked_modules:
-				return False
-		# perform a permission check based on roles table (desktop icons)
-		allowed_roles = [d.role for d in self.get("roles") or []]
-		if allowed_roles and not set(allowed_roles).intersection(frappe.get_roles()):
-			return False
-		if self.icon_type == "Folder":
-			return True
-		elif self.icon_type == "App":
-			return self.check_app_permission()
-		else:
-			try:
-				items = bootinfo.workspace_sidebar_item[self.label.lower()]["items"]
-
-				if len(items) and all(item["type"] == "Section Break" for item in items):
-					return False
-				if len(items) == 0:
-					return False
-				return True
-			except KeyError:
-				return False
+	# 			if len(items) and all(item["type"] == "Section Break" for item in items):
+	# 				return False
+	# 			if len(items) == 0:
+	# 				return False
+	# 			return True
+	# 		except KeyError:
+	# 			return False
 
 	def check_app_permission(self):
 		for a in frappe.get_installed_apps():
@@ -158,72 +137,6 @@ def get_workspace_names(workspaces):
 	for w in workspaces["pages"]:
 		workspace_list.append(w["name"])
 	return workspace_list
-
-
-def get_desktop_icons(user=None, bootinfo=None):
-	"""Return desktop icons for user"""
-	if not user:
-		user = frappe.session.user
-
-	user_icons = frappe.cache.hget("desktop_icons", user)
-
-	if not user_icons:
-		fields = [
-			"label",
-			"bg_color",
-			"link",
-			"link_type",
-			"app",
-			"icon_type",
-			"parent_icon",
-			"icon",
-			"link_to",
-			"idx",
-			"standard",
-			"logo_url",
-			"hidden",
-			"name",
-			"restrict_removal",
-			"icon_image",
-		]
-
-		from frappe.query_builder import DocType
-
-		DesktopIcon = DocType("Desktop Icon")
-
-		user_icons = (
-			frappe.qb.from_(DesktopIcon)
-			.select(*fields)
-			.where(
-				(DesktopIcon.standard == 1)
-				| (
-					(DesktopIcon.standard == 0)
-					& (DesktopIcon.owner.isin(["Administrator", frappe.session.user]))
-				)
-			)
-			.distinct()
-		).run(as_dict=True)
-
-		# sort by idx
-		user_icons.sort(key=lambda a: a.idx)
-
-		permitted_icons = []
-		permitted_parent_labels = set()
-		if bootinfo:
-			for s in user_icons:
-				icon = frappe.get_doc("Desktop Icon", s.name)
-				if icon.is_permitted(bootinfo):
-					permitted_icons.append(s)
-
-					if not s.parent_icon:
-						permitted_parent_labels.add(s.label)
-
-		user_icons = [
-			s for s in permitted_icons if not s.parent_icon or s.parent_icon in permitted_parent_labels
-		]
-
-		frappe.cache.hset("desktop_icons", user, user_icons)
-	return user_icons
 
 
 def clear_desktop_icons_cache(user=None):

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -84,34 +84,13 @@ class DesktopIcon(Document):
 		if os.path.exists(file_path):
 			os.remove(file_path)
 
-	def is_permitted(self, bootinfo):
-		icon_module = None
-		if self.icon_type == "Link" and self.link_to:
-			icon_module = frappe.db.get_value("Workspace", self.link_to, "module")
-		# module permission check
-		if icon_module:
-			blocked_modules = frappe.get_cached_doc("User", frappe.session.user).get_blocked_modules()
-			if icon_module in blocked_modules:
-				return False
-		# perform a permission check based on roles table (desktop icons)
-		allowed_roles = [d.role for d in self.get("roles") or []]
-		if allowed_roles and not set(allowed_roles).intersection(frappe.get_roles()):
-			return False
-		if self.icon_type == "Folder":
-			return True
-		elif self.icon_type == "App":
-			return self.check_app_permission()
-		else:
-			try:
-				items = bootinfo.workspace_sidebar_item[self.label.lower()]["items"]
-
-				if len(items) and all(item["type"] == "Section Break" for item in items):
-					return False
-				if len(items) == 0:
-					return False
-				return True
-			except KeyError:
-				return False
+	# 			if len(items) and all(item["type"] == "Section Break" for item in items):
+	# 				return False
+	# 			if len(items) == 0:
+	# 				return False
+	# 			return True
+	# 		except KeyError:
+	# 			return False
 
 	def check_app_permission(self):
 		for a in frappe.get_installed_apps():
@@ -157,72 +136,6 @@ def get_workspace_names(workspaces):
 	for w in workspaces["pages"]:
 		workspace_list.append(w["name"])
 	return workspace_list
-
-
-def get_desktop_icons(user=None, bootinfo=None):
-	"""Return desktop icons for user"""
-	if not user:
-		user = frappe.session.user
-
-	user_icons = frappe.cache.hget("desktop_icons", user)
-
-	if not user_icons:
-		fields = [
-			"label",
-			"bg_color",
-			"link",
-			"link_type",
-			"app",
-			"icon_type",
-			"parent_icon",
-			"icon",
-			"link_to",
-			"idx",
-			"standard",
-			"logo_url",
-			"hidden",
-			"name",
-			"restrict_removal",
-			"icon_image",
-		]
-
-		from frappe.query_builder import DocType
-
-		DesktopIcon = DocType("Desktop Icon")
-
-		user_icons = (
-			frappe.qb.from_(DesktopIcon)
-			.select(*fields)
-			.where(
-				(DesktopIcon.standard == 1)
-				| (
-					(DesktopIcon.standard == 0)
-					& (DesktopIcon.owner.isin(["Administrator", frappe.session.user]))
-				)
-			)
-			.distinct()
-		).run(as_dict=True)
-
-		# sort by idx
-		user_icons.sort(key=lambda a: a.idx)
-
-		permitted_icons = []
-		permitted_parent_labels = set()
-		if bootinfo:
-			for s in user_icons:
-				icon = frappe.get_doc("Desktop Icon", s.name)
-				if icon.is_permitted(bootinfo):
-					permitted_icons.append(s)
-
-					if not s.parent_icon:
-						permitted_parent_labels.add(s.label)
-
-		user_icons = [
-			s for s in permitted_icons if not s.parent_icon or s.parent_icon in permitted_parent_labels
-		]
-
-		frappe.cache.hset("desktop_icons", user, user_icons)
-	return user_icons
 
 
 def clear_desktop_icons_cache(user=None):

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -6,7 +6,6 @@ from json import loads
 
 import frappe
 from frappe import _
-from frappe.boot import get_sidebar_items
 from frappe.desk.desktop import get_workspace_sidebar_items, save_new_widget
 from frappe.desk.doctype.workspace_sidebar.workspace_sidebar import add_to_my_workspace
 from frappe.desk.utils import validate_route_conflict
@@ -332,7 +331,7 @@ def new_page(new_page: str):
 	if not doc.public:
 		add_to_my_workspace(doc)
 	workspaces = get_workspace_sidebar_items()
-	return {"workspace_pages": workspaces, "sidebar_items": get_sidebar_items(workspaces)}
+	return {"workspace_pages": workspaces}
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -6,7 +6,6 @@ from json import loads
 
 import frappe
 from frappe import _
-from frappe.boot import get_sidebar_items
 from frappe.desk.desktop import get_workspace_sidebar_items, save_new_widget
 from frappe.desk.doctype.workspace_sidebar.workspace_sidebar import add_to_my_workspace
 from frappe.desk.utils import validate_route_conflict
@@ -336,7 +335,7 @@ def new_page(new_page: str):
 	if not doc.public:
 		add_to_my_workspace(doc)
 	workspaces = get_workspace_sidebar_items()
-	return {"workspace_pages": workspaces, "sidebar_items": get_sidebar_items(workspaces)}
+	return {"workspace_pages": workspaces}
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -51,9 +51,7 @@ class WorkspaceSidebar(Document):
 			self.user.build_permissions()
 
 	def before_save(self):
-		self.export_sidebar()
-		if not self.for_user:
-			self.set_module()
+		self.set_module()
 
 	def export_sidebar(self):
 		allow_export = (
@@ -115,7 +113,7 @@ class WorkspaceSidebar(Document):
 		return value
 
 	def set_module(self):
-		if not self.module:
+		if self.standard:
 			self.module = self.get_module_from_items()
 
 	def get_module_from_items(self):

--- a/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.py
+++ b/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, Frappe Technologies and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
@@ -32,6 +32,18 @@ class WorkspaceSidebarItem(Document):
 		show_arrow: DF.Check
 		type: DF.Literal["Link", "Section Break", "Spacer", "Sidebar Item Group"]
 		url: DF.Data | None
+
 	# end: auto-generated types
+	def as_dict(self, **kwargs):
+		doc = super().as_dict()
+		if doc.get("link_type") == "Report":
+			report_type, ref_doctype = frappe.db.get_value(
+				"Report", doc.get("link_to"), ["report_type", "ref_doctype"]
+			)
+			doc["report"] = {
+				"report_type": report_type,
+				"ref_doctype": ref_doctype,
+			}
+		return doc
 
 	pass

--- a/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.py
+++ b/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, Frappe Technologies and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
@@ -31,6 +31,18 @@ class WorkspaceSidebarItem(Document):
 		show_arrow: DF.Check
 		type: DF.Literal["Link", "Section Break", "Spacer", "Sidebar Item Group"]
 		url: DF.Data | None
+
 	# end: auto-generated types
+	def as_dict(self, **kwargs):
+		doc = super().as_dict()
+		if doc.get("link_type") == "Report":
+			report_type, ref_doctype = frappe.db.get_value(
+				"Report", doc.get("link_to"), ["report_type", "ref_doctype"]
+			)
+			doc["report"] = {
+				"report_type": report_type,
+				"ref_doctype": ref_doctype,
+			}
+		return doc
 
 	pass

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -52,7 +52,7 @@ function get_route(desktop_icon) {
 	} else {
 		let sidebar = frappe.boot.workspace_sidebar_item[desktop_icon.label.toLowerCase()];
 		if (desktop_icon.link_type == "Workspace Sidebar" && sidebar) {
-			let first_link = sidebar.items.find((i) => i.type == "Link");
+			let first_link = sidebar.items.find((i) => i.type == "Link" && i.link_type != "URL");
 			if (first_link) {
 				if (first_link.link_type === "Report") {
 					let args = {

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -202,7 +202,7 @@ class DesktopPage {
 				icon_map[icon.parent_icon].child_icons.push(icon);
 			}
 
-			if (!icon.parent_icon || !icon_map[icon.parent_icon]) {
+			if (!icon.parent_icon) {
 				this.apps_icons.push(icon);
 			}
 		});

--- a/frappe/desk/page/desktop/desktop.py
+++ b/frappe/desk/page/desktop/desktop.py
@@ -1,7 +1,6 @@
 import sys
 
 import frappe
-from frappe.desk.doctype.desktop_icon.desktop_icon import get_desktop_icons
 
 
 def get_context(context):

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -545,5 +545,6 @@ add_to_apps_screen = [
 		"logo": app_logo_url,
 		"title": app_title,
 		"route": app_home,
+		"has_permission": "frappe.permissions.has_app_permission",
 	}
 ]

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -938,3 +938,7 @@ def _get_parent_and_ancestors(doctype, parent):
 	from frappe.utils.nestedset import get_ancestors_of
 
 	yield from get_ancestors_of(doctype, parent)
+
+
+def has_app_permission():
+	return frappe.session.user == "Administrator" or "System Manager" in frappe.get_roles()

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -44,11 +44,11 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 	build_sidebar_module_map() {
 		for (const [key, value] of Object.entries(frappe.boot.workspace_sidebar_item)) {
-			if (value.module && !value.label.includes("My Workspaces")) {
+			if (value.module && !value.title.includes("My Workspaces")) {
 				if (!this.sidebar_module_map[value.module]) {
 					this.sidebar_module_map[value.module] = [];
 				}
-				this.sidebar_module_map[value.module].push(value.label);
+				this.sidebar_module_map[value.module].push(value.title);
 			}
 		}
 	}
@@ -768,10 +768,10 @@ frappe.ui.Sidebar = class Sidebar {
 	get_workspace_sidebars(link_to) {
 		let sidebars = [];
 		Object.entries(this.all_sidebar_items).forEach(([name, sidebar]) => {
-			const { items, label } = sidebar;
+			const { items, title } = sidebar;
 			items.forEach((item) => {
 				if (item.link_to === link_to) {
-					sidebars.push(label || name);
+					sidebars.push(title || name);
 				}
 			});
 		});

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -44,11 +44,11 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 	build_sidebar_module_map() {
 		for (const [key, value] of Object.entries(frappe.boot.workspace_sidebar_item)) {
-			if (value.module && !value.label.includes("My Workspaces")) {
+			if (value.module && !value.title.includes("My Workspaces")) {
 				if (!this.sidebar_module_map[value.module]) {
 					this.sidebar_module_map[value.module] = [];
 				}
-				this.sidebar_module_map[value.module].push(value.label);
+				this.sidebar_module_map[value.module].push(value.title);
 			}
 		}
 	}
@@ -736,10 +736,10 @@ frappe.ui.Sidebar = class Sidebar {
 	get_workspace_sidebars(link_to) {
 		let sidebars = [];
 		Object.entries(this.all_sidebar_items).forEach(([name, sidebar]) => {
-			const { items, label } = sidebar;
+			const { items, title } = sidebar;
 			items.forEach((item) => {
 				if (item.link_to === link_to) {
-					sidebars.push(label || name);
+					sidebars.push(title || name);
 				}
 			});
 		});

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1348,7 +1348,9 @@ Object.assign(frappe.utils, {
 		} else {
 			let sidebar = frappe.boot.workspace_sidebar_item[desktop_icon.label.toLowerCase()];
 			if (desktop_icon.link_type == "Workspace Sidebar" && sidebar) {
-				let first_link = sidebar.items.find((i) => i.type == "Link");
+				let first_link = sidebar.items.find(
+					(i) => i.type == "Link" && i.link_type != "URL"
+				);
 				if (first_link) {
 					if (first_link.link_type === "Report") {
 						let args = {

--- a/frappe/tests/test_domainification.py
+++ b/frappe/tests/test_domainification.py
@@ -3,10 +3,6 @@
 import frappe
 from frappe.core.doctype.domain_settings.domain_settings import get_active_modules
 from frappe.core.page.permission_manager.permission_manager import get_roles_and_doctypes
-from frappe.desk.doctype.desktop_icon.desktop_icon import (
-	clear_desktop_icons_cache,
-	get_desktop_icons,
-)
 from frappe.tests import IntegrationTestCase
 
 

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -145,8 +145,6 @@ class UserPermissions:
 						no_list_view_link.append(dt)
 					else:
 						self.can_read.append(dt)
-						if dtp["module"] not in self.permitted_modules:
-							self.permitted_modules.append(dtp["module"])
 			if p.get("submit"):
 				self.can_submit.append(dt)
 
@@ -186,6 +184,11 @@ class UserPermissions:
 		)
 		self.can_read = list(set(self.can_read + self.shared))
 		self.all_read += self.can_read
+		# generate permitted_modules using self.all_read
+		for name in self.all_read:
+			module = self.doctype_map[name].get("module")
+			if module not in self.permitted_modules:
+				self.permitted_modules.append(module)
 
 		for dt in no_list_view_link:
 			if dt in self.can_read:


### PR DESCRIPTION
Desktop permission depend on where there the workspace sidebar item is allowed to the user or not
Icon is just a way to navigate to the first link in the sidebar
This PR refactors the code

Also closes https://github.com/frappe/frappe/issues/37929