### PR TITLE
fix: add fallback to consider messages w/ html tags

### DIFF
--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -92,6 +92,12 @@ class TestTranslation(IntegrationTestCase):
 
 		self.assertTrue(_(source), target)
 
+	def test_html_message_translations(self):
+		"""Test fallback for messages w/ HTML Tags"""
+		message = "Hide descendant records of <b>For Value</b>."
+		translated_message = "隐藏下层节点<b>值</b>"
+		self.assertEqual(_(message, lang="zh"), translated_message)
+
 
 def get_translation_data():
 	html_source_data = """<font color="#848484" face="arial, tahoma, verdana, sans-serif">

--- a/frappe/utils/translations.py
+++ b/frappe/utils/translations.py
@@ -16,6 +16,8 @@ def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
 	if not lang:
 		lang = frappe.local.lang
 
+	all_translations = get_all_translations(lang)
+
 	non_translated_string = msg
 
 	if is_html(msg):
@@ -24,17 +26,23 @@ def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
 	# msg should always be unicode
 	msg = frappe.as_unicode(msg).strip()
 
-	translated_string = ""
+	msg_with_html = frappe.as_unicode(non_translated_string).strip()
+	msg_list = [msg, msg_with_html]
 
-	all_translations = get_all_translations(lang)
-	if context:
-		string_key = f"{msg}:{context}"
-		translated_string = all_translations.get(string_key)
+	for msg in msg_list:
+		translated_string = ""
 
-	if not translated_string:
-		translated_string = all_translations.get(msg)
+		if context:
+			string_key = f"{msg}:{context}"
+			translated_string = all_translations.get(string_key)
 
-	return translated_string or non_translated_string
+		if not translated_string:
+			translated_string = all_translations.get(msg)
+
+		if translated_string:
+			return translated_string
+
+	return non_translated_string
 
 
 def _lt(msg: str, lang: str | None = None, context: str | None = None):


### PR DESCRIPTION
closes #37948

**Before**:

```python
ubuntu@ubuntu-server-erpnext:~/frappe/frappe_bench$ bench console
Apps in this namespace:
frappe, erpnext

In [1]: from frappe.translate import get_all_translations

In [2]: from frappe import _

In [3]: all_translations = get_all_translations("zh")

In [4]: all_translations["Please enter <b>Difference Account</b> or set default <b>Stock Adjustment Account</b> for company {0}"]
Out[4]: '请输入<b>差异账户</b>或为公司{0}设置默认<b>库存调整账户</b>'

In [5]: _("Please enter <b>Difference Account</b> or set default <b>Stock Adjustment Account</b> for company {0}").format("Test Company")
Out[5]: 'Please enter <b>Difference Account</b> or set default <b>Stock Adjustment Account</b> for company Test Company'

In [6]: 
```

**After**:

<img width="1958" height="182" alt="image" src="https://github.com/user-attachments/assets/fe5ea6ba-8b24-49e6-8953-3563b9002712" />
