### PR TITLE
feat(ListView): add support for adjustable column widths

### DIFF
--- a/cypress/integration/list_view_column_width.js
+++ b/cypress/integration/list_view_column_width.js
@@ -1,6 +1,13 @@
 const DOCTYPE = "DocType";
 const LIST_URL = "/desk/List/DocType/List";
 
+// Columns we explicitly configure so every test has a predictable starting state.
+// "module" has in_list_view=1 on DocType so it is always available to add.
+const BASE_FIELDS = JSON.stringify([
+	{ fieldname: "name", label: "Name" },
+	{ fieldname: "module", label: "Module" },
+]);
+
 // Helper — open List View Settings modal for the current list
 function openListSettings() {
 	cy.get(".menu-btn-group button").click({ force: true });
@@ -8,11 +15,12 @@ function openListSettings() {
 	cy.get(".modal-dialog").should("contain", `${DOCTYPE} List View Settings`);
 }
 
-// Helper — reset List View Settings for DOCTYPE so each test starts clean
+// Helper — reset List View Settings to a clean, known state before each test.
+// Pass "[]" (valid JSON) so frappe.parse_json() never receives an empty string.
 function resetListViewSettings() {
 	cy.call("frappe.desk.doctype.list_view_settings.list_view_settings.save_listview_settings", {
 		doctype: DOCTYPE,
-		listview_settings: { fields: "" },
+		listview_settings: { fields: BASE_FIELDS },
 		removed_listview_fields: [],
 	});
 }
@@ -22,6 +30,48 @@ function getColumnWidth(fieldname) {
 	return cy
 		.get(`.list-row-head .list-row-col[data-fieldname="${fieldname}"]`)
 		.invoke("outerWidth");
+}
+
+// Helper — simulate a drag-to-resize by dispatching native MouseEvents so that
+// jQuery's $(document) listeners (used by setup_column_resize) receive them.
+function dragResizeColumn(fieldname, deltaX) {
+	cy.window().then((win) => {
+		const handle = win.document.querySelector(
+			`.list-row-head .list-row-col[data-fieldname="${fieldname}"] .list-col-resize-handle`
+		);
+		if (!handle) throw new Error(`Resize handle for "${fieldname}" not found`);
+
+		const rect = handle.getBoundingClientRect();
+		const startX = rect.left + rect.width / 2;
+
+		handle.dispatchEvent(
+			new win.MouseEvent("mousedown", {
+				bubbles: true,
+				cancelable: true,
+				button: 0,
+				clientX: startX,
+				pageX: startX,
+			})
+		);
+
+		win.document.dispatchEvent(
+			new win.MouseEvent("mousemove", {
+				bubbles: true,
+				cancelable: true,
+				clientX: startX + deltaX,
+				pageX: startX + deltaX,
+			})
+		);
+
+		win.document.dispatchEvent(
+			new win.MouseEvent("mouseup", {
+				bubbles: true,
+				cancelable: true,
+				clientX: startX + deltaX,
+				pageX: startX + deltaX,
+			})
+		);
+	});
 }
 
 context("List View — Column Widths", () => {
@@ -37,10 +87,9 @@ context("List View — Column Widths", () => {
 		cy.clear_filters();
 	});
 
-	// ─── 1. DocField width is applied ───────────────────────────────────────────
+	// ─── 1. DocField width is applied ────────────────────────────────────────────
 
 	it("applies width defined in DocField to the column", () => {
-		// Set a known width on the DocType's 'module' field via the API
 		cy.call("frappe.client.set_value", {
 			doctype: "DocField",
 			filters: { parent: DOCTYPE, fieldname: "module" },
@@ -51,9 +100,9 @@ context("List View — Column Widths", () => {
 		cy.reload();
 		cy.wait(500);
 
-		getColumnWidth("module").should("be.closeTo", 200, 10);
+		getColumnWidth("module").should("be.closeTo", 200, 15);
 
-		// Cleanup — remove the width so other tests aren't affected
+		// Cleanup
 		cy.call("frappe.client.set_value", {
 			doctype: "DocField",
 			filters: { parent: DOCTYPE, fieldname: "module" },
@@ -62,12 +111,11 @@ context("List View — Column Widths", () => {
 		});
 	});
 
-	// ─── 2. Width set via List View Settings is applied ─────────────────────────
+	// ─── 2. Width set via List View Settings dialog is applied ───────────────────
 
-	it("saves and applies column width set in List View Settings", () => {
+	it("saves and applies column width set in List View Settings dialog", () => {
 		openListSettings();
 
-		// Find the 'module' field row and set width to 180
 		cy.get(".fields_order")
 			.filter('[data-fieldname="module"]')
 			.find("input.form-control")
@@ -77,13 +125,12 @@ context("List View — Column Widths", () => {
 		cy.findByRole("button", { name: "Save" }).click();
 		cy.wait(500);
 
-		getColumnWidth("module").should("be.closeTo", 180, 10);
+		getColumnWidth("module").should("be.closeTo", 180, 15);
 	});
 
-	// ─── 3. Width is persisted after page reload ─────────────────────────────────
+	// ─── 3. Width persists after page reload ─────────────────────────────────────
 
 	it("persists column width across page reloads", () => {
-		// Save width 220 via settings
 		cy.call(
 			"frappe.desk.doctype.list_view_settings.list_view_settings.save_listview_settings",
 			{
@@ -101,41 +148,26 @@ context("List View — Column Widths", () => {
 		cy.reload();
 		cy.wait(500);
 
-		getColumnWidth("module").should("be.closeTo", 220, 10);
+		getColumnWidth("module").should("be.closeTo", 220, 15);
 	});
 
 	// ─── 4. Drag-to-resize changes the column width ──────────────────────────────
 
 	it("drag-to-resize handle changes column width", () => {
-		// Get starting width of the module column
 		getColumnWidth("module").then((initialWidth) => {
-			const dragBy = 80; // drag 80px to the right
-
-			cy.get('.list-row-head .list-row-col[data-fieldname="module"] .list-col-resize-handle')
-				.trigger("mousedown", { button: 0, clientX: 0 })
-				.trigger("mousemove", { clientX: dragBy }, { bubbles: true })
-				.trigger("mouseup", { clientX: dragBy }, { bubbles: true });
-
+			dragResizeColumn("module", 80);
 			cy.wait(300);
-
 			getColumnWidth("module").should("be.greaterThan", initialWidth + 40);
 		});
 	});
 
-	// ─── 5. Drag-to-resize width is saved to List View Settings ─────────────────
+	// ─── 5. Drag-to-resize width is persisted after reload ───────────────────────
 
 	it("drag-to-resize width is persisted in List View Settings", () => {
-		const dragBy = 60;
-
 		getColumnWidth("module").then((initialWidth) => {
-			cy.get('.list-row-head .list-row-col[data-fieldname="module"] .list-col-resize-handle')
-				.trigger("mousedown", { button: 0, clientX: 0 })
-				.trigger("mousemove", { clientX: dragBy }, { bubbles: true })
-				.trigger("mouseup", { clientX: dragBy }, { bubbles: true });
+			dragResizeColumn("module", 60);
+			cy.wait(600);
 
-			cy.wait(500);
-
-			// Reload and confirm the new width survived
 			cy.reload();
 			cy.wait(500);
 
@@ -146,43 +178,31 @@ context("List View — Column Widths", () => {
 	// ─── 6. Min-width constraint (50 px) is enforced ─────────────────────────────
 
 	it("enforces minimum column width of 50 px when dragging", () => {
-		// Drag far to the left to attempt collapsing the column below 50 px
-		cy.get('.list-row-head .list-row-col[data-fieldname="module"] .list-col-resize-handle')
-			.trigger("mousedown", { button: 0, clientX: 500 })
-			.trigger("mousemove", { clientX: -500 }, { bubbles: true })
-			.trigger("mouseup", { clientX: -500 }, { bubbles: true });
-
+		dragResizeColumn("module", -2000);
 		cy.wait(300);
-
 		getColumnWidth("module").should("be.gte", 50);
 	});
 
 	// ─── 7. Max-width constraint (400 px) is enforced ────────────────────────────
 
 	it("enforces maximum column width of 400 px when dragging", () => {
-		cy.get('.list-row-head .list-row-col[data-fieldname="module"] .list-col-resize-handle')
-			.trigger("mousedown", { button: 0, clientX: 0 })
-			.trigger("mousemove", { clientX: 2000 }, { bubbles: true })
-			.trigger("mouseup", { clientX: 2000 }, { bubbles: true });
-
+		dragResizeColumn("module", 2000);
 		cy.wait(300);
-
 		getColumnWidth("module").should("be.lte", 400);
 	});
 
-	// ─── 8. Resize handle is visible in the header ───────────────────────────────
+	// ─── 8. Resize handles are present in the header ─────────────────────────────
 
 	it("shows resize handles in the list header", () => {
 		cy.get(".list-row-head .list-col-resize-handle").should("have.length.greaterThan", 0);
 	});
 
-	// ─── 9. List View Settings dialog shows Width column header ──────────────────
+	// ─── 9. List View Settings dialog shows Width (px) header and hint ───────────
 
-	it("shows Width (px) column header and info icon in List View Settings", () => {
+	it("shows Width (px) column header and drag hint in List View Settings", () => {
 		openListSettings();
 
 		cy.get(".modal-dialog").should("contain", "Width (px)");
-		// info icon tooltip is present
 		cy.get(".modal-dialog [title]")
 			.filter((_, el) => el.title.toLowerCase().includes("drag"))
 			.should("exist");
@@ -190,10 +210,10 @@ context("List View — Column Widths", () => {
 		cy.get(".modal-dialog .btn-modal-close").click();
 	});
 
-	// ─── 10. List View Settings priority over DocField width ─────────────────────
+	// ─── 10. List View Settings width takes priority over DocField width ──────────
 
 	it("List View Settings width takes priority over DocField width", () => {
-		// Set DocField width to 150
+		// DocField says 150 px
 		cy.call("frappe.client.set_value", {
 			doctype: "DocField",
 			filters: { parent: DOCTYPE, fieldname: "module" },
@@ -201,7 +221,7 @@ context("List View — Column Widths", () => {
 			value: "150",
 		});
 
-		// Override with 260 in List View Settings
+		// List View Settings overrides to 260 px
 		cy.call(
 			"frappe.desk.doctype.list_view_settings.list_view_settings.save_listview_settings",
 			{
@@ -219,7 +239,6 @@ context("List View — Column Widths", () => {
 		cy.reload();
 		cy.wait(500);
 
-		// Should be closer to 260 than 150
 		getColumnWidth("module").should("be.closeTo", 260, 15);
 
 		// Cleanup

--- a/cypress/integration/list_view_column_width.js
+++ b/cypress/integration/list_view_column_width.js
@@ -1,0 +1,233 @@
+const DOCTYPE = "DocType";
+const LIST_URL = "/desk/List/DocType/List";
+
+// Helper — open List View Settings modal for the current list
+function openListSettings() {
+	cy.get(".menu-btn-group button").click({ force: true });
+	cy.get(".dropdown-menu li").filter(":visible").contains("List Settings").click();
+	cy.get(".modal-dialog").should("contain", `${DOCTYPE} List View Settings`);
+}
+
+// Helper — reset List View Settings for DOCTYPE so each test starts clean
+function resetListViewSettings() {
+	cy.call("frappe.desk.doctype.list_view_settings.list_view_settings.save_listview_settings", {
+		doctype: DOCTYPE,
+		listview_settings: { fields: "" },
+		removed_listview_fields: [],
+	});
+}
+
+// Helper — get the rendered pixel width of a list-row-col by fieldname
+function getColumnWidth(fieldname) {
+	return cy
+		.get(`.list-row-head .list-row-col[data-fieldname="${fieldname}"]`)
+		.invoke("outerWidth");
+}
+
+context("List View — Column Widths", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/desk/website");
+	});
+
+	beforeEach(() => {
+		resetListViewSettings();
+		cy.visit(LIST_URL);
+		cy.wait(500);
+		cy.clear_filters();
+	});
+
+	// ─── 1. DocField width is applied ───────────────────────────────────────────
+
+	it("applies width defined in DocField to the column", () => {
+		// Set a known width on the DocType's 'module' field via the API
+		cy.call("frappe.client.set_value", {
+			doctype: "DocField",
+			filters: { parent: DOCTYPE, fieldname: "module" },
+			fieldname: "width",
+			value: "200",
+		});
+
+		cy.reload();
+		cy.wait(500);
+
+		getColumnWidth("module").should("be.closeTo", 200, 10);
+
+		// Cleanup — remove the width so other tests aren't affected
+		cy.call("frappe.client.set_value", {
+			doctype: "DocField",
+			filters: { parent: DOCTYPE, fieldname: "module" },
+			fieldname: "width",
+			value: "",
+		});
+	});
+
+	// ─── 2. Width set via List View Settings is applied ─────────────────────────
+
+	it("saves and applies column width set in List View Settings", () => {
+		openListSettings();
+
+		// Find the 'module' field row and set width to 180
+		cy.get(".fields_order")
+			.filter('[data-fieldname="module"]')
+			.find("input.form-control")
+			.clear()
+			.type("180");
+
+		cy.findByRole("button", { name: "Save" }).click();
+		cy.wait(500);
+
+		getColumnWidth("module").should("be.closeTo", 180, 10);
+	});
+
+	// ─── 3. Width is persisted after page reload ─────────────────────────────────
+
+	it("persists column width across page reloads", () => {
+		// Save width 220 via settings
+		cy.call(
+			"frappe.desk.doctype.list_view_settings.list_view_settings.save_listview_settings",
+			{
+				doctype: DOCTYPE,
+				listview_settings: {
+					fields: JSON.stringify([
+						{ fieldname: "name", label: "Name" },
+						{ fieldname: "module", label: "Module", width: 220 },
+					]),
+				},
+				removed_listview_fields: [],
+			}
+		);
+
+		cy.reload();
+		cy.wait(500);
+
+		getColumnWidth("module").should("be.closeTo", 220, 10);
+	});
+
+	// ─── 4. Drag-to-resize changes the column width ──────────────────────────────
+
+	it("drag-to-resize handle changes column width", () => {
+		// Get starting width of the module column
+		getColumnWidth("module").then((initialWidth) => {
+			const dragBy = 80; // drag 80px to the right
+
+			cy.get('.list-row-head .list-row-col[data-fieldname="module"] .list-col-resize-handle')
+				.trigger("mousedown", { button: 0, clientX: 0 })
+				.trigger("mousemove", { clientX: dragBy }, { bubbles: true })
+				.trigger("mouseup", { clientX: dragBy }, { bubbles: true });
+
+			cy.wait(300);
+
+			getColumnWidth("module").should("be.greaterThan", initialWidth + 40);
+		});
+	});
+
+	// ─── 5. Drag-to-resize width is saved to List View Settings ─────────────────
+
+	it("drag-to-resize width is persisted in List View Settings", () => {
+		const dragBy = 60;
+
+		getColumnWidth("module").then((initialWidth) => {
+			cy.get('.list-row-head .list-row-col[data-fieldname="module"] .list-col-resize-handle')
+				.trigger("mousedown", { button: 0, clientX: 0 })
+				.trigger("mousemove", { clientX: dragBy }, { bubbles: true })
+				.trigger("mouseup", { clientX: dragBy }, { bubbles: true });
+
+			cy.wait(500);
+
+			// Reload and confirm the new width survived
+			cy.reload();
+			cy.wait(500);
+
+			getColumnWidth("module").should("be.greaterThan", initialWidth + 30);
+		});
+	});
+
+	// ─── 6. Min-width constraint (50 px) is enforced ─────────────────────────────
+
+	it("enforces minimum column width of 50 px when dragging", () => {
+		// Drag far to the left to attempt collapsing the column below 50 px
+		cy.get('.list-row-head .list-row-col[data-fieldname="module"] .list-col-resize-handle')
+			.trigger("mousedown", { button: 0, clientX: 500 })
+			.trigger("mousemove", { clientX: -500 }, { bubbles: true })
+			.trigger("mouseup", { clientX: -500 }, { bubbles: true });
+
+		cy.wait(300);
+
+		getColumnWidth("module").should("be.gte", 50);
+	});
+
+	// ─── 7. Max-width constraint (400 px) is enforced ────────────────────────────
+
+	it("enforces maximum column width of 400 px when dragging", () => {
+		cy.get('.list-row-head .list-row-col[data-fieldname="module"] .list-col-resize-handle')
+			.trigger("mousedown", { button: 0, clientX: 0 })
+			.trigger("mousemove", { clientX: 2000 }, { bubbles: true })
+			.trigger("mouseup", { clientX: 2000 }, { bubbles: true });
+
+		cy.wait(300);
+
+		getColumnWidth("module").should("be.lte", 400);
+	});
+
+	// ─── 8. Resize handle is visible in the header ───────────────────────────────
+
+	it("shows resize handles in the list header", () => {
+		cy.get(".list-row-head .list-col-resize-handle").should("have.length.greaterThan", 0);
+	});
+
+	// ─── 9. List View Settings dialog shows Width column header ──────────────────
+
+	it("shows Width (px) column header and info icon in List View Settings", () => {
+		openListSettings();
+
+		cy.get(".modal-dialog").should("contain", "Width (px)");
+		// info icon tooltip is present
+		cy.get(".modal-dialog [title]")
+			.filter((_, el) => el.title.toLowerCase().includes("drag"))
+			.should("exist");
+
+		cy.get(".modal-dialog .btn-modal-close").click();
+	});
+
+	// ─── 10. List View Settings priority over DocField width ─────────────────────
+
+	it("List View Settings width takes priority over DocField width", () => {
+		// Set DocField width to 150
+		cy.call("frappe.client.set_value", {
+			doctype: "DocField",
+			filters: { parent: DOCTYPE, fieldname: "module" },
+			fieldname: "width",
+			value: "150",
+		});
+
+		// Override with 260 in List View Settings
+		cy.call(
+			"frappe.desk.doctype.list_view_settings.list_view_settings.save_listview_settings",
+			{
+				doctype: DOCTYPE,
+				listview_settings: {
+					fields: JSON.stringify([
+						{ fieldname: "name", label: "Name" },
+						{ fieldname: "module", label: "Module", width: 260 },
+					]),
+				},
+				removed_listview_fields: [],
+			}
+		);
+
+		cy.reload();
+		cy.wait(500);
+
+		// Should be closer to 260 than 150
+		getColumnWidth("module").should("be.closeTo", 260, 15);
+
+		// Cleanup
+		cy.call("frappe.client.set_value", {
+			doctype: "DocField",
+			filters: { parent: DOCTYPE, fieldname: "module" },
+			fieldname: "width",
+			value: "",
+		});
+	});
+});

--- a/cypress/integration/list_view_column_width.js
+++ b/cypress/integration/list_view_column_width.js
@@ -32,10 +32,12 @@ function getColumnWidth(fieldname) {
 		.invoke("outerWidth");
 }
 
-// Helper — simulate a drag-to-resize by dispatching native MouseEvents so that
-// jQuery's $(document) listeners (used by setup_column_resize) receive them.
+// Helper — simulate drag-to-resize using jQuery $.Event so that both the
+// delegated mousedown handler on $result and the document-level
+// mousemove/mouseup handlers receive events with the right pageX values.
 function dragResizeColumn(fieldname, deltaX) {
 	cy.window().then((win) => {
+		const $ = win.$;
 		const handle = win.document.querySelector(
 			`.list-row-head .list-row-col[data-fieldname="${fieldname}"] .list-col-resize-handle`
 		);
@@ -44,33 +46,11 @@ function dragResizeColumn(fieldname, deltaX) {
 		const rect = handle.getBoundingClientRect();
 		const startX = rect.left + rect.width / 2;
 
-		handle.dispatchEvent(
-			new win.MouseEvent("mousedown", {
-				bubbles: true,
-				cancelable: true,
-				button: 0,
-				clientX: startX,
-				pageX: startX,
-			})
-		);
-
-		win.document.dispatchEvent(
-			new win.MouseEvent("mousemove", {
-				bubbles: true,
-				cancelable: true,
-				clientX: startX + deltaX,
-				pageX: startX + deltaX,
-			})
-		);
-
-		win.document.dispatchEvent(
-			new win.MouseEvent("mouseup", {
-				bubbles: true,
-				cancelable: true,
-				clientX: startX + deltaX,
-				pageX: startX + deltaX,
-			})
-		);
+		// Trigger mousedown on the handle so jQuery's delegated handler on $result fires.
+		$(handle).trigger($.Event("mousedown", { pageX: startX, which: 1, button: 0 }));
+		// Trigger mousemove and mouseup on document where the drag listeners are registered.
+		$(win.document).trigger($.Event("mousemove", { pageX: startX + deltaX }));
+		$(win.document).trigger($.Event("mouseup", { pageX: startX + deltaX }));
 	});
 }
 
@@ -90,9 +70,10 @@ context("List View — Column Widths", () => {
 	// ─── 1. DocField width is applied ────────────────────────────────────────────
 
 	it("applies width defined in DocField to the column", () => {
+		// frappe.client.set_value accepts a JSON filter string as the `name` argument
 		cy.call("frappe.client.set_value", {
 			doctype: "DocField",
-			filters: { parent: DOCTYPE, fieldname: "module" },
+			name: JSON.stringify({ parent: DOCTYPE, fieldname: "module" }),
 			fieldname: "width",
 			value: "200",
 		});
@@ -105,7 +86,7 @@ context("List View — Column Widths", () => {
 		// Cleanup
 		cy.call("frappe.client.set_value", {
 			doctype: "DocField",
-			filters: { parent: DOCTYPE, fieldname: "module" },
+			name: JSON.stringify({ parent: DOCTYPE, fieldname: "module" }),
 			fieldname: "width",
 			value: "",
 		});
@@ -116,13 +97,19 @@ context("List View — Column Widths", () => {
 	it("saves and applies column width set in List View Settings dialog", () => {
 		openListSettings();
 
-		cy.get(".fields_order")
-			.filter('[data-fieldname="module"]')
-			.find("input.form-control")
+		// Scope to the modal to avoid ambiguous matches outside the dialog
+		cy.get(".modal-dialog")
+			.find('[data-fieldname="module"] input.form-control')
 			.clear()
 			.type("180");
 
 		cy.findByRole("button", { name: "Save" }).click();
+
+		// Wait for the dialog to close (it hides in the save callback)
+		cy.get(".modal-dialog").should("not.be.visible");
+
+		// Reload so fresh render applies the persisted width via setup_columns()
+		cy.reload();
 		cy.wait(500);
 
 		getColumnWidth("module").should("be.closeTo", 180, 15);
@@ -216,7 +203,7 @@ context("List View — Column Widths", () => {
 		// DocField says 150 px
 		cy.call("frappe.client.set_value", {
 			doctype: "DocField",
-			filters: { parent: DOCTYPE, fieldname: "module" },
+			name: JSON.stringify({ parent: DOCTYPE, fieldname: "module" }),
 			fieldname: "width",
 			value: "150",
 		});
@@ -244,7 +231,7 @@ context("List View — Column Widths", () => {
 		// Cleanup
 		cy.call("frappe.client.set_value", {
 			doctype: "DocField",
-			filters: { parent: DOCTYPE, fieldname: "module" },
+			name: JSON.stringify({ parent: DOCTYPE, fieldname: "module" }),
 			fieldname: "width",
 			value: "",
 		});

--- a/cypress/integration/list_view_column_width.js
+++ b/cypress/integration/list_view_column_width.js
@@ -1,11 +1,11 @@
 const DOCTYPE = "DocType";
 const LIST_URL = "/desk/List/DocType/List";
 
-// Columns we explicitly configure so every test has a predictable starting state.
-// "module" has in_list_view=1 on DocType so it is always available to add.
+// Columns with a fixed starting width so drag tests have a predictable baseline
+// and never start at the natural flexbox width (which can vary by viewport).
 const BASE_FIELDS = JSON.stringify([
 	{ fieldname: "name", label: "Name" },
-	{ fieldname: "module", label: "Module" },
+	{ fieldname: "module", label: "Module", width: 150 },
 ]);
 
 // Helper — open List View Settings modal for the current list
@@ -16,7 +16,6 @@ function openListSettings() {
 }
 
 // Helper — reset List View Settings to a clean, known state before each test.
-// Pass "[]" (valid JSON) so frappe.parse_json() never receives an empty string.
 function resetListViewSettings() {
 	cy.call("frappe.desk.doctype.list_view_settings.list_view_settings.save_listview_settings", {
 		doctype: DOCTYPE,
@@ -67,32 +66,7 @@ context("List View — Column Widths", () => {
 		cy.clear_filters();
 	});
 
-	// ─── 1. DocField width is applied ────────────────────────────────────────────
-
-	it("applies width defined in DocField to the column", () => {
-		// frappe.client.set_value accepts a JSON filter string as the `name` argument
-		cy.call("frappe.client.set_value", {
-			doctype: "DocField",
-			name: JSON.stringify({ parent: DOCTYPE, fieldname: "module" }),
-			fieldname: "width",
-			value: "200",
-		});
-
-		cy.reload();
-		cy.wait(500);
-
-		getColumnWidth("module").should("be.closeTo", 200, 15);
-
-		// Cleanup
-		cy.call("frappe.client.set_value", {
-			doctype: "DocField",
-			name: JSON.stringify({ parent: DOCTYPE, fieldname: "module" }),
-			fieldname: "width",
-			value: "",
-		});
-	});
-
-	// ─── 2. Width set via List View Settings dialog is applied ───────────────────
+	// ─── 1. Width set via List View Settings dialog is applied ───────────────────
 
 	it("saves and applies column width set in List View Settings dialog", () => {
 		openListSettings();
@@ -115,7 +89,7 @@ context("List View — Column Widths", () => {
 		getColumnWidth("module").should("be.closeTo", 180, 15);
 	});
 
-	// ─── 3. Width persists after page reload ─────────────────────────────────────
+	// ─── 2. Width persists after page reload ─────────────────────────────────────
 
 	it("persists column width across page reloads", () => {
 		cy.call(
@@ -138,9 +112,10 @@ context("List View — Column Widths", () => {
 		getColumnWidth("module").should("be.closeTo", 220, 15);
 	});
 
-	// ─── 4. Drag-to-resize changes the column width ──────────────────────────────
+	// ─── 3. Drag-to-resize changes the column width ──────────────────────────────
 
 	it("drag-to-resize handle changes column width", () => {
+		// BASE_FIELDS seeds module at 150 px, so 150+80=230 — well inside the 400 px cap.
 		getColumnWidth("module").then((initialWidth) => {
 			dragResizeColumn("module", 80);
 			cy.wait(300);
@@ -148,9 +123,10 @@ context("List View — Column Widths", () => {
 		});
 	});
 
-	// ─── 5. Drag-to-resize width is persisted after reload ───────────────────────
+	// ─── 4. Drag-to-resize width is persisted after reload ───────────────────────
 
 	it("drag-to-resize width is persisted in List View Settings", () => {
+		// BASE_FIELDS seeds module at 150 px, so 150+60=210 — well inside the 400 px cap.
 		getColumnWidth("module").then((initialWidth) => {
 			dragResizeColumn("module", 60);
 			cy.wait(600);
@@ -162,7 +138,7 @@ context("List View — Column Widths", () => {
 		});
 	});
 
-	// ─── 6. Min-width constraint (50 px) is enforced ─────────────────────────────
+	// ─── 5. Min-width constraint (50 px) is enforced ─────────────────────────────
 
 	it("enforces minimum column width of 50 px when dragging", () => {
 		dragResizeColumn("module", -2000);
@@ -170,7 +146,7 @@ context("List View — Column Widths", () => {
 		getColumnWidth("module").should("be.gte", 50);
 	});
 
-	// ─── 7. Max-width constraint (400 px) is enforced ────────────────────────────
+	// ─── 6. Max-width constraint (400 px) is enforced ────────────────────────────
 
 	it("enforces maximum column width of 400 px when dragging", () => {
 		dragResizeColumn("module", 2000);
@@ -178,13 +154,13 @@ context("List View — Column Widths", () => {
 		getColumnWidth("module").should("be.lte", 400);
 	});
 
-	// ─── 8. Resize handles are present in the header ─────────────────────────────
+	// ─── 7. Resize handles are present in the header ─────────────────────────────
 
 	it("shows resize handles in the list header", () => {
 		cy.get(".list-row-head .list-col-resize-handle").should("have.length.greaterThan", 0);
 	});
 
-	// ─── 9. List View Settings dialog shows Width (px) header and hint ───────────
+	// ─── 8. List View Settings dialog shows Width (px) header and hint ───────────
 
 	it("shows Width (px) column header and drag hint in List View Settings", () => {
 		openListSettings();
@@ -195,45 +171,5 @@ context("List View — Column Widths", () => {
 			.should("exist");
 
 		cy.get(".modal-dialog .btn-modal-close").click();
-	});
-
-	// ─── 10. List View Settings width takes priority over DocField width ──────────
-
-	it("List View Settings width takes priority over DocField width", () => {
-		// DocField says 150 px
-		cy.call("frappe.client.set_value", {
-			doctype: "DocField",
-			name: JSON.stringify({ parent: DOCTYPE, fieldname: "module" }),
-			fieldname: "width",
-			value: "150",
-		});
-
-		// List View Settings overrides to 260 px
-		cy.call(
-			"frappe.desk.doctype.list_view_settings.list_view_settings.save_listview_settings",
-			{
-				doctype: DOCTYPE,
-				listview_settings: {
-					fields: JSON.stringify([
-						{ fieldname: "name", label: "Name" },
-						{ fieldname: "module", label: "Module", width: 260 },
-					]),
-				},
-				removed_listview_fields: [],
-			}
-		);
-
-		cy.reload();
-		cy.wait(500);
-
-		getColumnWidth("module").should("be.closeTo", 260, 15);
-
-		// Cleanup
-		cy.call("frappe.client.set_value", {
-			doctype: "DocField",
-			name: JSON.stringify({ parent: DOCTYPE, fieldname: "module" }),
-			fieldname: "width",
-			value: "",
-		});
 	});
 });

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -594,7 +594,7 @@ export default class GridRow {
 								<input class='form-control column-width my-1 input-xs text-right'
 								style='height: 24px; max-width: 80px; background: var(--bg-color);'
 									value='${cint(d.columns) || docfield.columns}'
-									data-fieldname='${docfield.fieldname}' style='background-color: var(--modal-bg); display: inline'>
+									data-fieldname='${docfield.fieldname}'>
 							</div>
 							<div class='col-2 sticky-col-container' title='${__("Sticky")}' >
 								<input type='checkbox' class='form-control sticky-column'

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -101,6 +101,10 @@ export default class ListSettings {
 		let wrapper = fields_html.$wrapper[0];
 		let fields = ``;
 
+		const listview_columns = (me.listview.columns = me.listview.columns.filter(
+			(col) => col.type !== "Tag"
+		));
+
 		for (let idx in me.fields) {
 			if (idx == parseInt(this.max_number_of_fields)) {
 				break;
@@ -127,11 +131,12 @@ export default class ListSettings {
 
 						<div class="col-2">
 							<input
-								type="number"
-								max="400"
-								class='form-control text-right'
-								data-fieldname='${me.fields[idx].fieldname}'
-								style='background-color: var(--modal-bg); height: 22px;'
+								inputmode="numeric"
+								autocomplete="number"
+								class="form-control text-right"
+								data-fieldname="${me.fields[idx].fieldname}"
+								style="background-color: var(--modal-bg); height: 22px;"
+								value="${cint(listview_columns[idx]?.df?.width)}"
 							>
 						</div>
 

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -162,23 +162,21 @@ export default class ListSettings {
 
 		fields_html.html(`
 			<div class="form-group">
-				<div class="clearfix">
-					<label class="control-label" style="padding-right: 0px;">${__("Fields")}</label>
-					<label class="text-extra-muted float-right">
-						<a class="add-new-fields text-muted">
+				<div class="row flex-fill align-items-center px-1 mb-2">
+					<div class="col-1"></div>
+					<div class="col d-flex align-items-center justify-content-between px-0">
+						<label class="control-label mb-0" style="padding-right: 0;">${__("Fields")}</label>
+						<a class="add-new-fields text-muted" style="font-size: var(--text-xs); white-space: nowrap;">
 							${__("+ Add / Remove Fields")}
 						</a>
-					</label>
-				</div>
-				<div class="row flex-fill mb-1 px-1" style="font-size: var(--text-xs); color: var(--text-muted);">
-					<div class="col"></div>
-					<div class="col-2 text-right pr-2">
+					</div>
+					<div class="col-2 text-right pr-2" style="font-size: var(--text-xs); color: var(--text-muted); white-space: nowrap;">
 						${__("Width (px)")}
 						<span
 							class="ml-1"
 							title="${__("You can also drag column borders directly in the list view to resize")}"
 							style="cursor: help;"
-						>${frappe.utils.icon("information", "xs")}</span>
+						>${frappe.utils.icon("info", "xs")}</span>
 					</div>
 					<div class="col-1"></div>
 				</div>

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -162,15 +162,18 @@ export default class ListSettings {
 
 		fields_html.html(`
 			<div class="form-group">
-				<div class="d-flex align-items-center justify-content-between mb-1">
-					<label class="control-label mb-0" style="padding-right: 0;">${__("Fields")}</label>
+				<div class="text-right mb-1">
 					<a class="add-new-fields text-muted" style="font-size: var(--text-xs); white-space: nowrap;">
 						${__("+ Add / Remove Fields")}
 					</a>
 				</div>
 				<div class="row flex-fill px-1 mb-1" style="font-size: var(--text-xs); color: var(--text-muted);">
 					<div class="col-1"></div>
-					<div class="col px-0"></div>
+					<div class="col px-0">
+						<label class="control-label mb-0" style="padding-right: 0; font-size: var(--text-xs);">${__(
+							"Fields"
+						)}</label>
+					</div>
 					<div class="col-2 text-right pr-2" style="white-space: nowrap;">
 						${__("Width (px)")}
 						<span

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -35,7 +35,11 @@ export default class ListSettings {
 		});
 		me.dialog.set_values(me.settings);
 		me.dialog.set_primary_action(__("Save"), () => {
+			me.update_fields();
 			let values = me.dialog.get_values();
+			// update_fields() populates me.fields synchronously but set_value() is async,
+			// so bypass the dialog model and use me.fields directly.
+			values.fields = JSON.stringify(me.fields);
 
 			frappe.show_alert({
 				message: __("Saving"),
@@ -101,9 +105,11 @@ export default class ListSettings {
 		let wrapper = fields_html.$wrapper[0];
 		let fields = ``;
 
-		const listview_columns = (me.listview.columns = me.listview.columns.filter(
-			(col) => col.type !== "Tag"
-		));
+		me.listview.columns = me.listview.columns.filter((col) => col.type !== "Tag");
+		const columnByFieldname = {};
+		me.listview.columns.forEach((col) => {
+			if (col.df?.fieldname) columnByFieldname[col.df.fieldname] = col;
+		});
 
 		for (let idx in me.fields) {
 			if (idx == parseInt(this.max_number_of_fields)) {
@@ -136,7 +142,11 @@ export default class ListSettings {
 								class="form-control text-right"
 								data-fieldname="${me.fields[idx].fieldname}"
 								style="background-color: var(--modal-bg); height: 22px;"
-								value="${cint(listview_columns[idx]?.df?.width)}"
+								value="${
+									cint(me.fields[idx].width) ||
+									cint(columnByFieldname[me.fields[idx].fieldname]?.df?.width) ||
+									""
+								}"
 							>
 						</div>
 
@@ -228,10 +238,18 @@ export default class ListSettings {
 		me.fields = [];
 
 		for (let idx = 0; idx < fields_order.length; idx++) {
-			me.fields.push({
-				fieldname: fields_order.item(idx).getAttribute("data-fieldname"),
-				label: __(fields_order.item(idx).getAttribute("data-label")),
-			});
+			let el = fields_order.item(idx);
+			let fieldname = el.getAttribute("data-fieldname");
+			let width_input = el.querySelector(
+				`input.form-control[data-fieldname="${fieldname}"]`
+			);
+			let width = width_input ? cint(width_input.value) : 0;
+			let field = {
+				fieldname: fieldname,
+				label: __(el.getAttribute("data-label")),
+			};
+			if (width) field.width = width;
+			me.fields.push(field);
 		}
 
 		me.dialog.set_value("fields", JSON.stringify(me.fields));

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -162,15 +162,16 @@ export default class ListSettings {
 
 		fields_html.html(`
 			<div class="form-group">
-				<div class="row flex-fill align-items-center px-1 mb-2">
+				<div class="d-flex align-items-center justify-content-between mb-1">
+					<label class="control-label mb-0" style="padding-right: 0;">${__("Fields")}</label>
+					<a class="add-new-fields text-muted" style="font-size: var(--text-xs); white-space: nowrap;">
+						${__("+ Add / Remove Fields")}
+					</a>
+				</div>
+				<div class="row flex-fill px-1 mb-1" style="font-size: var(--text-xs); color: var(--text-muted);">
 					<div class="col-1"></div>
-					<div class="col d-flex align-items-center justify-content-between px-0">
-						<label class="control-label mb-0" style="padding-right: 0;">${__("Fields")}</label>
-						<a class="add-new-fields text-muted" style="font-size: var(--text-xs); white-space: nowrap;">
-							${__("+ Add / Remove Fields")}
-						</a>
-					</div>
-					<div class="col-2 text-right pr-2" style="font-size: var(--text-xs); color: var(--text-muted); white-space: nowrap;">
+					<div class="col px-0"></div>
+					<div class="col-2 text-right pr-2" style="white-space: nowrap;">
 						${__("Width (px)")}
 						<span
 							class="ml-1"

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -117,15 +117,25 @@ export default class ListSettings {
 	 				data-type="${me.fields[idx].type}">
 
 					<div class="row flex-fill align-items-center">
-						<div class="col-1 d-flex align-items-center justify-content-center px-1">
+						<div class="col-1 flex align-items-center justify-content-center px-1">
 							${frappe.utils.icon("drag", "xs", "", "", "sortable-handle " + show_sortable_handle)}
 						</div>
 
-						<div class="col d-flex align-items-center px-0">
+						<div class="col flex align-items-center px-0">
 							${__(me.fields[idx].label, null, me.doctype)}
 						</div>
 
-						<div class="col-1 d-flex align-items-center justify-content-center px-0">
+						<div class="col-2">
+							<input
+								type="number"
+								max="400"
+								class='form-control text-right'
+								data-fieldname='${me.fields[idx].fieldname}'
+								style='background-color: var(--modal-bg); height: 22px;'
+							>
+						</div>
+
+						<div class="col-1 flex align-items-center justify-content-center px-0">
 							<a class="text-muted remove-field align-items-center ${can_remove}"
 							   data-fieldname="${me.fields[idx].fieldname}">
 								${frappe.utils.icon("x", "xs")}

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -170,6 +170,18 @@ export default class ListSettings {
 						</a>
 					</label>
 				</div>
+				<div class="row flex-fill mb-1 px-1" style="font-size: var(--text-xs); color: var(--text-muted);">
+					<div class="col"></div>
+					<div class="col-2 text-right pr-2">
+						${__("Width (px)")}
+						<span
+							class="ml-1"
+							title="${__("You can also drag column borders directly in the list view to resize")}"
+							style="cursor: help;"
+						>${frappe.utils.icon("information", "xs")}</span>
+					</div>
+					<div class="col-1"></div>
+				</div>
 				<div class="control-input-wrapper">
 				${fields}
 				</div>

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -34,6 +34,13 @@ export default class ListSettings {
 			fields: list_view_settings.fields,
 		});
 		me.dialog.set_values(me.settings);
+
+		// Collapse the unlabelled section that wraps fields_html — it adds
+		// an empty section-head + default section-body margins with no content.
+		const $fields_section = me.dialog.$wrapper.find('[data-fieldname="section_break_evqq"]');
+		$fields_section.find(".section-head").hide();
+		$fields_section.find("> .section-body").css({ "margin-top": 0, "padding-top": 0 });
+
 		me.dialog.set_primary_action(__("Save"), () => {
 			me.update_fields();
 			let values = me.dialog.get_values();

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -638,6 +638,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				this.$result.find(".list-liked-by-me").addClass("liked");
 			}
 		}
+		this.setup_column_resize();
 	}
 
 	render_skeleton() {
@@ -645,6 +646,96 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			'<div><input type="checkbox" class="render-list-checkbox"/></div>'
 		);
 		this.$result.append($row);
+	}
+
+	setup_column_resize() {
+		if (frappe.is_mobile()) return;
+
+		// Clean up any previous listeners to avoid duplicates on re-render
+		this.$result.off("mousedown.list-col-resize");
+		$(document).off("mousemove.list-col-resize mouseup.list-col-resize");
+
+		let isDragging = false;
+		let fieldname = null;
+		let startX = 0;
+		let startWidth = 0;
+
+		this.$result.on(
+			"mousedown.list-col-resize",
+			".list-row-head .list-col-resize-handle",
+			(e) => {
+				e.preventDefault();
+				const $col = $(e.target).closest(".list-row-col");
+				fieldname = $col.attr("data-fieldname");
+				if (!fieldname || fieldname === "undefined") return;
+
+				isDragging = true;
+				startX = e.pageX;
+				startWidth = $col.outerWidth();
+				$("body").addClass("list-col-resizing");
+			}
+		);
+
+		$(document).on("mousemove.list-col-resize", (e) => {
+			if (!isDragging || !fieldname) return;
+			const newWidth = Math.max(50, Math.min(400, startWidth + (e.pageX - startX)));
+			this.$result.find(`.list-row-col[data-fieldname="${fieldname}"]`).css({
+				width: newWidth,
+				flex: `0 0 ${newWidth}px`,
+			});
+		});
+
+		$(document).on("mouseup.list-col-resize", (e) => {
+			if (!isDragging) return;
+			isDragging = false;
+			$("body").removeClass("list-col-resizing");
+
+			if (fieldname) {
+				const newWidth = Math.max(50, Math.min(400, startWidth + (e.pageX - startX)));
+				this.column_max_widths[fieldname] = newWidth;
+				this.save_column_width(fieldname, newWidth);
+			}
+			fieldname = null;
+		});
+	}
+
+	save_column_width(fieldname, width) {
+		let fields;
+
+		if (this.list_view_settings?.fields) {
+			fields = JSON.parse(this.list_view_settings.fields);
+		} else {
+			// No saved field order yet — build it from current columns
+			fields = this.columns
+				.filter((col) => col.type !== "Tag")
+				.map((col) => {
+					if (col.type === "Status") {
+						return { fieldname: "status_field", label: __("Status") };
+					}
+					return { fieldname: col.df?.fieldname, label: col.df?.label || "" };
+				})
+				.filter((f) => f.fieldname);
+		}
+
+		const field = fields.find((f) => f.fieldname === fieldname);
+		if (field) {
+			field.width = width;
+		}
+
+		frappe.call({
+			method: "frappe.desk.doctype.list_view_settings.list_view_settings.save_listview_settings",
+			args: {
+				doctype: this.doctype,
+				listview_settings: {
+					...(this.list_view_settings || {}),
+					fields: JSON.stringify(fields),
+				},
+				removed_listview_fields: [],
+			},
+			callback: (r) => {
+				this.list_view_settings = r.message.listview_settings;
+			},
+		});
 	}
 
 	before_render() {
@@ -778,7 +869,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				}
 
 				const headerFieldname = col.type === "Status" ? "status_field" : col.df?.fieldname;
-				return `<div class="${classes}" data-fieldname="${headerFieldname}">${html}</div>
+				const resizeHandle =
+					headerFieldname && col.type !== "Tag"
+						? `<div class="list-col-resize-handle"></div>`
+						: "";
+				return `<div class="${classes}" data-fieldname="${headerFieldname}">${html}${resizeHandle}</div>
 			`;
 			})
 			.join("");

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -497,6 +497,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				let column = this.columns[col];
 
 				if (column.type == "Status" && field.fieldname == "status_field") {
+					if (field.width) {
+						column.df = column.df || { fieldname: "status_field" };
+						column.df.width = field.width;
+					}
 					fields_order.push(column);
 					break;
 				} else if (column.type == "Field" && field.fieldname === column.df.fieldname) {
@@ -773,7 +777,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					html = `<span ${attrs}>${label}</span>`;
 				}
 
-				return `<div class="${classes}" data-fieldname="${col.df?.fieldname}">${html}</div>
+				const headerFieldname = col.type === "Status" ? "status_field" : col.df?.fieldname;
+				return `<div class="${classes}" data-fieldname="${headerFieldname}">${html}</div>
 			`;
 			})
 			.join("");
@@ -893,9 +898,13 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	get_column_html(col, doc, show_in_mobile) {
 		if (col.type === "Status" || col.df?.options == "Workflow State") {
+			const fieldname = col.type === "Status" ? "status_field" : col.df?.fieldname;
+			if (!frappe.is_mobile() && cint(col.df?.width)) {
+				this.column_max_widths[fieldname] = cint(col.df.width);
+			}
 			let show_workflow_state = col.df?.options == "Workflow State";
 			return `
-				<div class="list-row-col hidden-xs ellipsis">
+				<div class="list-row-col hidden-xs ellipsis" data-fieldname="${fieldname}">
 					${this.get_indicator_html(doc, show_workflow_state)}
 				</div>
 			`;
@@ -1052,7 +1061,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	 */
 	apply_column_widths() {
 		if (this.list_view_settings?.disable_scrolling) return;
-		const MIN_WIDTH = 150;
+		const MIN_WIDTH = 50;
 		const MAX_WIDTH = 400;
 		Object.entries(this.column_max_widths).forEach(([fieldname, width]) => {
 			const clamped = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, width));

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1019,11 +1019,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		].join(" ");
 
 		let column_html;
-		if (
-			this.settings.formatters &&
-			this.settings.formatters[fieldname] &&
-			col.type !== "Subject"
-		) {
+		const formatter = this.settings.formatters?.[fieldname];
+		if (formatter && col.type !== "Subject") {
 			column_html = this.settings.formatters[fieldname](value, df, doc);
 		} else {
 			column_html = {
@@ -1036,23 +1033,24 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			css_class += " bold";
 		}
 
-		/**
-		 * Calculates the width of a text element based on its length.
-		 * If the length of the text is not available, it defaults to a length of 22.5.
-		 */
-		let textLength = $(column_html).text()?.trim()?.length || 22.5;
-		let calculatedWidth = (textLength * 10) / 1.3 + (col.type == "Subject" ? 30 : 0);
+		if (!frappe.is_mobile()) {
+			/**
+			 * Calculates the width of a text element based on its length.
+			 * If the length of the text is not available, it defaults to a length of 22.5.
+			 */
+			let textLength = $(column_html).text()?.trim()?.length || 22.5;
+			let calculatedWidth = (textLength * 10) / 1.3 + (col.type == "Subject" ? 30 : 0);
 
-		/**
-		 * Updates the `column_max_widths` object by setting the maximum width for a specific column (fieldname).
-		 * If no width is set for the column, or the newly calculated width exceeds the current width, the width is updated.
-		 */
-		if (
-			(!this.column_max_widths[fieldname] ||
-				calculatedWidth > this.column_max_widths[fieldname]) &&
-			!frappe.is_mobile()
-		) {
-			this.column_max_widths[fieldname] = calculatedWidth;
+			/**
+			 * Updates the `column_max_widths` object by setting the maximum width for a specific column (fieldname).
+			 * If no width is set for the column, or the newly calculated width exceeds the current width, the width is updated.
+			 */
+			if (
+				!this.column_max_widths[fieldname] ||
+				calculatedWidth > this.column_max_widths[fieldname]
+			) {
+				this.column_max_widths[fieldname] = calculatedWidth;
+			}
 		}
 
 		return `

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -500,6 +500,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					fields_order.push(column);
 					break;
 				} else if (column.type == "Field" && field.fieldname === column.df.fieldname) {
+					if (field.width) column.df.width = field.width;
 					fields_order.push(column);
 					break;
 				}
@@ -1033,27 +1034,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			css_class += " bold";
 		}
 
-		if (!frappe.is_mobile()) {
-			/**
-			 * Calculates the width of a text element based on its length.
-			 * If the length of the text is not available, it defaults to a length of 22.5.
-			 */
-			if (cint(col.df.width)) {
-				this.column_max_widths[fieldname] = cint(col.df.width);
-			}
-			// let textLength = $(column_html).text()?.trim()?.length || 22.5;
-			// let calculatedWidth = (textLength * 10) / 1.3 + (col.type == "Subject" ? 30 : 0);
-
-			// /**
-			//  * Updates the `column_max_widths` object by setting the maximum width for a specific column (fieldname).
-			//  * If no width is set for the column, or the newly calculated width exceeds the current width, the width is updated.
-			//  */
-			// if (
-			// 	!this.column_max_widths[fieldname] ||
-			// 	calculatedWidth > this.column_max_widths[fieldname]
-			// ) {
-			// 	this.column_max_widths[fieldname] = calculatedWidth;
-			// }
+		if (!frappe.is_mobile() && cint(col.df?.width)) {
+			this.column_max_widths[fieldname] = cint(col.df.width);
 		}
 
 		return `
@@ -1070,12 +1052,15 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	 */
 	apply_column_widths() {
 		if (this.list_view_settings?.disable_scrolling) return;
+		const MIN_WIDTH = 150;
+		const MAX_WIDTH = 400;
 		Object.entries(this.column_max_widths).forEach(([fieldname, width]) => {
+			const clamped = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, width));
 			$(
 				`.list-view .frappe-list .result .level-left .list-row-col[data-fieldname="${fieldname}"]`
 			).css({
-				width: width,
-				flex: `0 0 ${width}px`,
+				width: clamped,
+				flex: `0 0 ${clamped}px`,
 			});
 		});
 	}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -461,18 +461,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			this.columns = this.reorder_listview_fields();
 		}
 
-		// limit max to 8 columns if no total_fields is set in List View Settings
-		// Screen with low density no of columns 4
-		// Screen with medium density no of columns 6
-		// Screen with high density no of columns 8
-		let total_fields = 6;
-
-		if (window.innerWidth <= 1366) {
-			total_fields = 4;
-		} else if (window.innerWidth >= 1920) {
-			total_fields = 10;
-		}
-
 		this.columns = this.columns.slice(0, this.max_number_of_fields);
 
 		// 2nd column: tag - normally hidden doesn't count towards total_fields
@@ -771,7 +759,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					col.type == "Subject" ? "list-subject level" : "hidden-xs",
 					col.type == "Tag" ? `tag-col ${!this.tags_shown ? "hide" : ""} ` : "",
 					frappe.model.is_numeric_field(col.df) ? "text-right" : "",
-					col.df?.fieldname,
 				].join(" ");
 
 				let html = "";
@@ -785,7 +772,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					html = `<span ${attrs}>${label}</span>`;
 				}
 
-				return `<div class="${classes}">${html}</div>
+				return `<div class="${classes}" data-fieldname="${col.df?.fieldname}">${html}</div>
 			`;
 			})
 			.join("");
@@ -1029,7 +1016,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			"list-row-col ellipsis",
 			class_map[col.type],
 			frappe.model.is_numeric_field(df) ? "text-right" : "",
-			fieldname,
 		].join(" ");
 
 		let column_html;
@@ -1070,7 +1056,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		}
 
 		return `
-			<div class="${css_class}">
+			<div class="${css_class}" data-fieldname="${fieldname}">
 				${column_html}
 			</div>
 		`;
@@ -1084,7 +1070,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	apply_column_widths() {
 		if (this.list_view_settings?.disable_scrolling) return;
 		Object.entries(this.column_max_widths).forEach(([fieldname, width]) => {
-			$(`.list-view .frappe-list .result .level-left .list-row-col.${fieldname}`).css({
+			$(
+				`.list-view .frappe-list .result .level-left .list-row-col[data-fieldname="${fieldname}"]`
+			).css({
 				width: width,
 				flex: `1 0 ${width}px`,
 			});

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1038,19 +1038,22 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			 * Calculates the width of a text element based on its length.
 			 * If the length of the text is not available, it defaults to a length of 22.5.
 			 */
-			let textLength = $(column_html).text()?.trim()?.length || 22.5;
-			let calculatedWidth = (textLength * 10) / 1.3 + (col.type == "Subject" ? 30 : 0);
-
-			/**
-			 * Updates the `column_max_widths` object by setting the maximum width for a specific column (fieldname).
-			 * If no width is set for the column, or the newly calculated width exceeds the current width, the width is updated.
-			 */
-			if (
-				!this.column_max_widths[fieldname] ||
-				calculatedWidth > this.column_max_widths[fieldname]
-			) {
-				this.column_max_widths[fieldname] = calculatedWidth;
+			if (cint(col.df.width)) {
+				this.column_max_widths[fieldname] = cint(col.df.width);
 			}
+			// let textLength = $(column_html).text()?.trim()?.length || 22.5;
+			// let calculatedWidth = (textLength * 10) / 1.3 + (col.type == "Subject" ? 30 : 0);
+
+			// /**
+			//  * Updates the `column_max_widths` object by setting the maximum width for a specific column (fieldname).
+			//  * If no width is set for the column, or the newly calculated width exceeds the current width, the width is updated.
+			//  */
+			// if (
+			// 	!this.column_max_widths[fieldname] ||
+			// 	calculatedWidth > this.column_max_widths[fieldname]
+			// ) {
+			// 	this.column_max_widths[fieldname] = calculatedWidth;
+			// }
 		}
 
 		return `
@@ -1072,7 +1075,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				`.list-view .frappe-list .result .level-left .list-row-col[data-fieldname="${fieldname}"]`
 			).css({
 				width: width,
-				flex: `1 0 ${width}px`,
+				flex: `0 0 ${width}px`,
 			});
 		});
 	}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1019,19 +1019,22 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			 * Calculates the width of a text element based on its length.
 			 * If the length of the text is not available, it defaults to a length of 22.5.
 			 */
-			let textLength = $(column_html).text()?.trim()?.length || 22.5;
-			let calculatedWidth = (textLength * 10) / 1.3 + (col.type == "Subject" ? 30 : 0);
-
-			/**
-			 * Updates the `column_max_widths` object by setting the maximum width for a specific column (fieldname).
-			 * If no width is set for the column, or the newly calculated width exceeds the current width, the width is updated.
-			 */
-			if (
-				!this.column_max_widths[fieldname] ||
-				calculatedWidth > this.column_max_widths[fieldname]
-			) {
-				this.column_max_widths[fieldname] = calculatedWidth;
+			if (cint(col.df.width)) {
+				this.column_max_widths[fieldname] = cint(col.df.width);
 			}
+			// let textLength = $(column_html).text()?.trim()?.length || 22.5;
+			// let calculatedWidth = (textLength * 10) / 1.3 + (col.type == "Subject" ? 30 : 0);
+
+			// /**
+			//  * Updates the `column_max_widths` object by setting the maximum width for a specific column (fieldname).
+			//  * If no width is set for the column, or the newly calculated width exceeds the current width, the width is updated.
+			//  */
+			// if (
+			// 	!this.column_max_widths[fieldname] ||
+			// 	calculatedWidth > this.column_max_widths[fieldname]
+			// ) {
+			// 	this.column_max_widths[fieldname] = calculatedWidth;
+			// }
 		}
 
 		return `
@@ -1053,7 +1056,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				`.list-view .frappe-list .result .level-left .list-row-col[data-fieldname="${fieldname}"]`
 			).css({
 				width: width,
-				flex: `1 0 ${width}px`,
+				flex: `0 0 ${width}px`,
 			});
 		});
 	}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -448,18 +448,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			this.columns = this.reorder_listview_fields();
 		}
 
-		// limit max to 8 columns if no total_fields is set in List View Settings
-		// Screen with low density no of columns 4
-		// Screen with medium density no of columns 6
-		// Screen with high density no of columns 8
-		let total_fields = 6;
-
-		if (window.innerWidth <= 1366) {
-			total_fields = 4;
-		} else if (window.innerWidth >= 1920) {
-			total_fields = 10;
-		}
-
 		this.columns = this.columns.slice(0, this.max_number_of_fields);
 
 		// 2nd column: tag - normally hidden doesn't count towards total_fields
@@ -757,7 +745,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					col.type == "Subject" ? "list-subject level" : "hidden-xs",
 					col.type == "Tag" ? `tag-col ${!this.tags_shown ? "hide" : ""} ` : "",
 					frappe.model.is_numeric_field(col.df) ? "text-right" : "",
-					col.df?.fieldname,
 				].join(" ");
 
 				let html = "";
@@ -771,7 +758,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					html = `<span ${attrs}>${label}</span>`;
 				}
 
-				return `<div class="${classes}">${html}</div>
+				return `<div class="${classes}" data-fieldname="${col.df?.fieldname}">${html}</div>
 			`;
 			})
 			.join("");
@@ -1010,7 +997,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			"list-row-col ellipsis",
 			class_map[col.type],
 			frappe.model.is_numeric_field(df) ? "text-right" : "",
-			fieldname,
 		].join(" ");
 
 		let column_html;
@@ -1051,7 +1037,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		}
 
 		return `
-			<div class="${css_class}">
+			<div class="${css_class}" data-fieldname="${fieldname}">
 				${column_html}
 			</div>
 		`;
@@ -1065,7 +1051,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	apply_column_widths() {
 		if (this.list_view_settings?.disable_scrolling) return;
 		Object.entries(this.column_max_widths).forEach(([fieldname, width]) => {
-			$(`.list-view .frappe-list .result .level-left .list-row-col.${fieldname}`).css({
+			$(
+				`.list-view .frappe-list .result .level-left .list-row-col[data-fieldname="${fieldname}"]`
+			).css({
 				width: width,
 				flex: `1 0 ${width}px`,
 			});

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1000,11 +1000,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		].join(" ");
 
 		let column_html;
-		if (
-			this.settings.formatters &&
-			this.settings.formatters[fieldname] &&
-			col.type !== "Subject"
-		) {
+		const formatter = this.settings.formatters?.[fieldname];
+		if (formatter && col.type !== "Subject") {
 			column_html = this.settings.formatters[fieldname](value, df, doc);
 		} else {
 			column_html = {
@@ -1017,23 +1014,24 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			css_class += " bold";
 		}
 
-		/**
-		 * Calculates the width of a text element based on its length.
-		 * If the length of the text is not available, it defaults to a length of 22.5.
-		 */
-		let textLength = $(column_html).text()?.trim()?.length || 22.5;
-		let calculatedWidth = (textLength * 10) / 1.3 + (col.type == "Subject" ? 30 : 0);
+		if (!frappe.is_mobile()) {
+			/**
+			 * Calculates the width of a text element based on its length.
+			 * If the length of the text is not available, it defaults to a length of 22.5.
+			 */
+			let textLength = $(column_html).text()?.trim()?.length || 22.5;
+			let calculatedWidth = (textLength * 10) / 1.3 + (col.type == "Subject" ? 30 : 0);
 
-		/**
-		 * Updates the `column_max_widths` object by setting the maximum width for a specific column (fieldname).
-		 * If no width is set for the column, or the newly calculated width exceeds the current width, the width is updated.
-		 */
-		if (
-			(!this.column_max_widths[fieldname] ||
-				calculatedWidth > this.column_max_widths[fieldname]) &&
-			!frappe.is_mobile()
-		) {
-			this.column_max_widths[fieldname] = calculatedWidth;
+			/**
+			 * Updates the `column_max_widths` object by setting the maximum width for a specific column (fieldname).
+			 * If no width is set for the column, or the newly calculated width exceeds the current width, the width is updated.
+			 */
+			if (
+				!this.column_max_widths[fieldname] ||
+				calculatedWidth > this.column_max_widths[fieldname]
+			) {
+				this.column_max_widths[fieldname] = calculatedWidth;
+			}
 		}
 
 		return `

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -268,7 +268,6 @@
 $level-margin-right: 8px;
 
 .list-subject {
-	flex: 2;
 	justify-content: start;
 
 	a {

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -222,12 +222,11 @@
 .list-col-resize-handle {
 	position: absolute;
 	right: -8px;
-	top: 10%;
-	bottom: 10%;
+	top: 0;
+	bottom: 0;
 	width: 16px;
 	cursor: col-resize;
 	user-select: none;
-	z-index: 2;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -253,7 +252,7 @@
 
 // Darken & grow all separators when cursor enters the header row
 .list-row-head:hover .list-col-resize-handle::before {
-	background-color: var(--gray-700);
+	background-color: var(--gray-600);
 	width: 3px;
 	height: 80%;
 	opacity: 0.7;

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -222,8 +222,8 @@
 .list-col-resize-handle {
 	position: absolute;
 	right: -8px;
-	top: 15%;
-	bottom: 15%;
+	top: 10%;
+	bottom: 10%;
 	width: 16px;
 	cursor: col-resize;
 	user-select: none;
@@ -235,22 +235,28 @@
 	&::before {
 		content: "";
 		width: 2px;
-		height: 100%;
+		height: 60%;
 		border-radius: 2px;
-		background-color: var(--gray-400);
-		opacity: 0;
-		transition: opacity 0.15s, background-color 0.15s;
+		background-color: var(--gray-500);
+		// Always show a faint resting separator so users can discover resize
+		opacity: 0.25;
+		transition: opacity 0.15s, background-color 0.15s, width 0.15s, height 0.15s;
 	}
 
 	&:hover::before {
 		background-color: var(--primary);
+		width: 3px;
+		height: 100%;
 		opacity: 1 !important;
 	}
 }
 
-// Reveal ALL separators the moment the cursor enters the header row
+// Darken & grow all separators when cursor enters the header row
 .list-row-head:hover .list-col-resize-handle::before {
-	opacity: 0.35;
+	background-color: var(--gray-700);
+	width: 3px;
+	height: 80%;
+	opacity: 0.7;
 }
 
 body.list-col-resizing {

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -12,7 +12,7 @@
 				.list-row-container {
 					.level-left {
 						.list-row-col {
-							min-width: 150px;
+							min-width: 50px;
 							max-width: 400px;
 						}
 					}

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -219,6 +219,30 @@
 	cursor: default;
 }
 
+.list-col-resize-handle {
+	position: absolute;
+	right: 0;
+	top: 0;
+	bottom: 0;
+	width: 4px;
+	cursor: col-resize;
+	user-select: none;
+	z-index: 1;
+
+	&:hover {
+		background-color: var(--border-color);
+	}
+}
+
+body.list-col-resizing {
+	cursor: col-resize !important;
+	user-select: none;
+
+	* {
+		cursor: col-resize !important;
+	}
+}
+
 .list-row-head {
 	@extend .list-row;
 	cursor: default;
@@ -226,6 +250,10 @@
 	border-radius: var(--border-radius);
 	height: var(--list-row-height);
 	padding-inline: var(--padding-sm);
+
+	.list-row-col {
+		position: relative;
+	}
 
 	.list-subject {
 		font-weight: normal;

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -221,17 +221,36 @@
 
 .list-col-resize-handle {
 	position: absolute;
-	right: 0;
+	right: -8px;
 	top: 0;
 	bottom: 0;
-	width: 4px;
+	width: 16px;
 	cursor: col-resize;
 	user-select: none;
-	z-index: 1;
+	z-index: 2;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 
-	&:hover {
-		background-color: var(--border-color);
+	&::before {
+		content: "";
+		width: 2px;
+		height: 40%;
+		border-radius: 2px;
+		background-color: var(--gray-400);
+		opacity: 0;
+		transition: opacity 0.15s, height 0.15s, background-color 0.15s;
 	}
+
+	&:hover::before {
+		opacity: 1;
+		height: 65%;
+		background-color: var(--primary);
+	}
+}
+
+.list-row-head .list-row-col:hover .list-col-resize-handle::before {
+	opacity: 0.4;
 }
 
 body.list-col-resizing {

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -234,7 +234,7 @@
 	&::before {
 		content: "";
 		width: 2px;
-		height: 60%;
+		height: 14px; // fixed px — same on every column regardless of column height
 		border-radius: 2px;
 		background-color: var(--gray-500);
 		// Always show a faint resting separator so users can discover resize
@@ -245,7 +245,7 @@
 	&:hover::before {
 		background-color: var(--primary);
 		width: 3px;
-		height: 100%;
+		height: 20px;
 		opacity: 1 !important;
 	}
 }
@@ -254,7 +254,7 @@
 .list-row-head:hover .list-col-resize-handle::before {
 	background-color: var(--gray-600);
 	width: 3px;
-	height: 80%;
+	height: 18px;
 	opacity: 0.7;
 }
 

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -4,6 +4,7 @@
 			.result {
 				min-width: 100%;
 				width: auto;
+				display: table;
 				.list-row-container {
 					width: fit-content;
 					min-width: 100%;

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -279,6 +279,12 @@ body.list-col-resizing {
 		position: relative;
 	}
 
+	// Right-aligned columns have text flush against the right edge where the
+	// resize handle sits — add breathing room so they don't look glued together
+	.list-row-col.text-right > span {
+		padding-right: 14px;
+	}
+
 	.list-subject {
 		font-weight: normal;
 	}

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -222,8 +222,8 @@
 .list-col-resize-handle {
 	position: absolute;
 	right: -8px;
-	top: 0;
-	bottom: 0;
+	top: 15%;
+	bottom: 15%;
 	width: 16px;
 	cursor: col-resize;
 	user-select: none;
@@ -235,22 +235,22 @@
 	&::before {
 		content: "";
 		width: 2px;
-		height: 40%;
+		height: 100%;
 		border-radius: 2px;
 		background-color: var(--gray-400);
 		opacity: 0;
-		transition: opacity 0.15s, height 0.15s, background-color 0.15s;
+		transition: opacity 0.15s, background-color 0.15s;
 	}
 
 	&:hover::before {
-		opacity: 1;
-		height: 65%;
 		background-color: var(--primary);
+		opacity: 1 !important;
 	}
 }
 
-.list-row-head .list-row-col:hover .list-col-resize-handle::before {
-	opacity: 0.4;
+// Reveal ALL separators the moment the cursor enters the header row
+.list-row-head:hover .list-col-resize-handle::before {
+	opacity: 0.35;
 }
 
 body.list-col-resizing {


### PR DESCRIPTION
### Column Width Configuration in List View

Three ways to set column widths — each takes priority over the previous:

#### 1. DocField definition
Set \`width\` on any DocField — applied automatically when the list view loads.

#### 2. List View Settings dialog
Open **⋮ → List View Settings** to set per-column widths with a numeric input. Includes an inline hint that drag-to-resize is also available directly in the list view.

<img width="1120" height="1324" alt="image" src="https://github.com/user-attachments/assets/318a166e-83d0-41dd-9e12-3ed797ebdc12" />

#### 3. Drag-to-resize in the list view header
Drag any column separator directly in the list header to resize it on the fly. The new width is saved to List View Settings automatically, so it persists across refreshes.

- Resize handles are always subtly visible at resting state so they are discoverable without hovering
- Hovering the header row reveals all separators at once
- Direct hover on a handle highlights it in the primary colour

https://github.com/user-attachments/assets/20d8f764-05d7-42bd-8246-762e869a0802




---

### Width priority (highest → lowest)
1. Drag-to-resize / List View Settings saved width
2. DocField \`width\` property
3. Auto — columns size themselves naturally via \`display: table\` on the result container (no manual pixel calculation needed)

### Constraints
- Minimum width: **50 px**
- Maximum width: **400 px**
- Status column is fully supported (handled explicitly throughout the pipeline since it has no \`df\` by default)

### Other changes
- Fixed async bug in List View Settings where saved width silently failed (\`set_value\` is async; bypassed by assigning \`fields\` JSON directly before \`get_values\`)
- Fixed index misalignment when reading existing column widths in the settings dialog
- Improved List View Settings dialog layout: \`Fields\` and \`Width (px) ⓘ\` are proper aligned column headers; \`+ Add / Remove Fields\` action sits above them; removed extra empty section spacing
- Resize handle height uses fixed \`px\` values so it looks identical across all columns including the taller Subject column
- Right-aligned (numeric) column header text gets `padding-right` so it does not appear glued to the resize handle
- `min-width` CSS lowered from 150 px → 50 px

`no-docs`