### PR TITLE
fix: permission indicator spacing in list view

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -182,18 +182,12 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		const match_rules_list = frappe.perm.get_match_rules(this.doctype);
 		if (match_rules_list.length) {
 			this.restricted_list = $(
-				`<button class="btn btn-xs restricted-button flex align-center ${
-					frappe.is_mobile() ? "ml-2" : ""
-				}">
+				`<button class="btn btn-xs restricted-button flex align-center">
 					${frappe.utils.icon("restriction", "xs")}
 				</button>`
 			)
 				.click(() => this.show_restrictions(match_rules_list))
-				.appendTo(
-					frappe.is_mobile()
-						? this.page.page_form.find(".filter-section")
-						: this.page.page_form
-				);
+				.appendTo(this.page.page_form.find(".filter-section"));
 		}
 	}
 

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -546,8 +546,8 @@ input.list-header-checkbox {
 }
 
 .restricted-button {
-	margin-top: var(--margin-xs);
-	height: var(--margin-xl);
+	margin: var(--margin-xs) 0 0 var(--margin-sm);
+	height: 29px;
 
 	.icon {
 		width: 14px;
@@ -560,13 +560,6 @@ input.list-header-checkbox {
 	&.btn {
 		@include button-variant($background: $light-yellow, $border: darken($light-yellow, 5%));
 		box-shadow: none;
-	}
-}
-
-.frappe-rtl {
-	.restricted-button {
-		margin: auto auto auto 5px;
-		direction: ltr;
 	}
 }
 


### PR DESCRIPTION
Height of the restriction button was not matching the other filters. Spacing was incorrect.

### Before:

**LTR - Desktop**
<img width="1166" height="494" alt="CleanShot 2026-03-13 at 13 46 40@2x" src="https://github.com/user-attachments/assets/7b4b3b08-dd50-452e-89fa-c92a491b382c" />


**LTR - Mobile**
<img width="1108" height="676" alt="CleanShot 2026-03-13 at 13 47 01@2x" src="https://github.com/user-attachments/assets/ce7a6236-02bf-4186-a251-495c4fa95352" />

**RTL - Desktop**
<img width="1666" height="796" alt="CleanShot 2026-03-13 at 13 48 05@2x" src="https://github.com/user-attachments/assets/96a31a3f-e0f2-4aa1-bf20-409c6d0039ba" />

**RTL - Mobile**
<img width="1106" height="706" alt="CleanShot 2026-03-13 at 13 47 28@2x" src="https://github.com/user-attachments/assets/62110d5b-68cb-4b29-8888-12a13fa93761" />


### After:

**LTR - Desktop**
<img width="3058" height="1246" alt="CleanShot 2026-03-13 at 13 39 34@2x" src="https://github.com/user-attachments/assets/4c08315b-28f8-4ce1-a89c-0cd03a684122" />

**LTR - Mobile**
<img width="1098" height="1590" alt="CleanShot 2026-03-13 at 13 39 56@2x" src="https://github.com/user-attachments/assets/3c2b19e8-659a-41a6-b47e-f9d57dd11cb7" />


**RTL - Desktop**
<img width="2656" height="716" alt="CleanShot 2026-03-13 at 13 58 00@2x" src="https://github.com/user-attachments/assets/18241fc3-1bbf-40c4-b70c-0c5fe05e6869" />


**RTL - Mobile**
<img width="1104" height="1598" alt="CleanShot 2026-03-13 at 13 42 15@2x" src="https://github.com/user-attachments/assets/5849f745-17ef-444f-800f-6492c44d75b7" />




**Without user permission**
<img width="2800" height="712" alt="CleanShot 2026-03-13 at 13 43 00@2x" src="https://github.com/user-attachments/assets/d394164b-be2d-4a3f-a9d9-8a7aaac050b2" />
