### PR TITLE
fix: apply exif orientation before stripping the tag

### DIFF
--- a/frappe/utils/image.py
+++ b/frappe/utils/image.py
@@ -3,7 +3,7 @@
 import io
 import os
 
-from PIL import Image
+from PIL import Image, ImageOps
 
 import frappe
 
@@ -32,6 +32,8 @@ def strip_exif_data(content, content_type) -> bytes:
 	"""
 
 	original_image = Image.open(io.BytesIO(content))
+	# Apply EXIF orientation to pixels before stripping the tag.
+	original_image = ImageOps.exif_transpose(original_image)
 	output = io.BytesIO()
 	# ref: https://stackoverflow.com/a/48248432
 	if content_type == "image/jpeg" and original_image.mode in ("RGBA", "P"):


### PR DESCRIPTION
When you upload images from phones, it has orientation data stored in EXIF so that the image can be viewed correctly even if the phone was not in the correct orientation while taking the photo.

Framework strips the EXIF orientation tag without first rotating the pixels to match it. So some uploaded images appear rotated (original orientation). Fix is to rotate the pixels in the image and then remove the EXIF data.
