### PR TITLE
fix: number card formatting

### DIFF
--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -231,6 +231,11 @@ export default class NumberCardWidget extends Widget {
 	}
 
 	set_formatted_number(df, doc) {
+		if (this.number === null) {
+			this.formatted_number = __("N/A", null, "Number not available");
+			return;
+		}
+
 		const default_country = frappe.sys_defaults.country;
 
 		let number_parts;

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -252,15 +252,14 @@ export default class NumberCardWidget extends Widget {
 		if (this.card_doc.currency) {
 			this.formatted_number =
 				format_currency(parseFloat(number_parts[0]), this.card_doc.currency) +
-				" " +
-				symbol;
+				(symbol ? " " + symbol : "");
 			return;
 		}
 
 		number_parts[0] = window.convert_old_to_new_number_format(number_parts[0]);
 		const formatted_number = frappe.format(number_parts[0], df, null, doc);
 		this.formatted_number =
-			($(formatted_number).text() || formatted_number) + " " + __(symbol);
+			($(formatted_number).text() || formatted_number) + (symbol ? " " + symbol : "");
 	}
 
 	_generate_common_doc(rows) {

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -251,7 +251,9 @@ export default class NumberCardWidget extends Widget {
 		// done to add multicurrency support in number card
 		if (this.card_doc.currency) {
 			this.formatted_number =
-				format_currency(number_parts[0], this.card_doc.currency) + " " + symbol;
+				format_currency(parseFloat(number_parts[0]), this.card_doc.currency) +
+				" " +
+				symbol;
 			return;
 		}
 


### PR DESCRIPTION
## Summary

- Handle `null` number values gracefully by displaying "N/A" instead of throwing an error
- Fix currency formatting by parsing the number part (`parseFloat`) before passing it to `format_currency`, which previously caused wrong values for non-English number formats (e.g. the displayed number was multiplied by the number of decimals)
- Only append the unit symbol (K, M, etc.) when it is actually present, and don't translate it again (it is already)


x | Currency (`12345.67`) | Null
--|----------|-----
**Before** | <img width="453" height="96" alt="currency_before" src="https://github.com/user-attachments/assets/86f61133-1abb-4d5f-942d-a3c5ca674284" /> | <img width="336" height="94" alt="null_before" src="https://github.com/user-attachments/assets/e64c70f2-94db-4b49-9473-2fe84d24aa4a" />
**After** | <img width="453" height="96" alt="currency_after" src="https://github.com/user-attachments/assets/97d8202d-a594-4f14-ada0-e950d909b6ae" /> | <img width="336" height="94" alt="null_after" src="https://github.com/user-attachments/assets/ec664a9d-4201-48de-b5d3-95ab6b7a6da7" />


## Test plan

- [x] Create a **Number Card** with a currency and verify the formatted value is correct for non-English number formats (e.g. German `1.234,56`)
- [x] Verify that shortened numbers (K, M, B) display correctly with currency
- [x] Verify that a **Number Card** returning `null` shows "N/A" instead of crashing
- [x] Confirm no trailing space appears when the number has no unit symbol


<details>

<summary>Detailed explanation for why we need `parseFloat`</summary>

`shorten_number` always returns strings in JavaScript's native format (`.` as decimal). So for a value like `1234567.89`, `shorten_number` returns `"1.23 M"`, which gets split into `["1.23", "M"]`. The `number_parts[0]` is **always** a string with `.` as the decimal separator, regardless of system number format.

A single change on line 240:

```javascript
// current (buggy)
format_currency(number_parts[0], this.card_doc.currency)

// fixed
format_currency(parseFloat(number_parts[0]), this.card_doc.currency)
```

```11:25:apps/frappe/frappe/public/js/frappe/utils/number_format.js
	if (typeof v !== "number") {
		v = v + "";
		// ... strip currency symbol ...
		v = strip_number_groups(v, number_format);  // <-- THE BUG: only runs for strings
		v = parseFloat(v);
		if (isNaN(v)) v = 0;
	}
```

When `v` is already a `number` type (from our `parseFloat`), it **skips** `strip_number_groups` entirely. The number then flows straight into `format_number`'s formatting logic which correctly applies the system number format from scratch.

### Tracing both cases with the fix

**`show_full_number: true`**, value = `1234.5`:
1. `number_parts = ["1234.5", ""]`, `symbol = ""`
2. `parseFloat("1234.5")` = `1234.5` (number type)
3. `format_currency(1234.5, "EUR")` -> `flt` sees a number, skips parsing
4. `format_number` formats `1234.5` with German format -> `"1.234,50"`
5. Result: `"€ 1.234,50"` -- correct

**`show_full_number: false`**, value = `1234567.89`:
1. `shorten_number(1234567.89, ...)` -> `"1.23 M"`
2. `number_parts = ["1.23", "M"]`, `symbol = "M"`
3. `parseFloat("1.23")` = `1.23` (number type)
4. `format_currency(1.23, "EUR")` -> `flt` sees a number, skips parsing
5. `format_number` formats `1.23` with German format -> `"1,23"`
6. Result: `"€ 1,23 M"` -- correct, properly shortened

**`show_full_number: false`**, small value = `42`:
1. `shorten_number(42, ...)` -> `"42"` (below `min_length`, not shortened)
2. `number_parts = ["42"]`, `symbol = ""`
3. `parseFloat("42")` = `42`
4. `format_currency(42, "EUR")` -> `"42,00"`
5. Result: `"€ 42,00"` -- correct

**Edge: zero decimals**, value = `12345`:
1. `number_parts[0] = "12345"` (no dot)
2. `parseFloat("12345")` = `12345`
3. Formats correctly regardless -- no `.` to misinterpret even without the fix, but the fix is harmless here

</details>

This logic has not changed compared to v15, so should be easy and safe to backport.