### PR TITLE
fix(sidebar_item): make open URL behavior configurable

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -585,6 +585,7 @@ def get_sidebar_items(allowed_workspaces):
 					"filters": item.filters,
 					"route_options": item.route_options,
 					"tab": item.navigate_to_tab,
+					"open_in_new_tab": item.open_in_new_tab,
 				}
 				if item.link_type == "Report" and item.link_to and frappe.db.exists("Report", item.link_to):
 					report_type, ref_doctype = frappe.db.get_value(

--- a/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.json
+++ b/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.json
@@ -16,6 +16,7 @@
   "child",
   "navigate_to_tab",
   "url",
+  "open_in_new_tab",
   "display_section",
   "collapsible_column",
   "collapsible",
@@ -168,13 +169,20 @@
    "fieldname": "filter_area",
    "fieldtype": "HTML",
    "label": "Filter Area"
+  },
+  {
+   "default": "1",
+   "depends_on": "eval:doc.link_type === \"URL\";",
+   "fieldname": "open_in_new_tab",
+   "fieldtype": "Check",
+   "label": "Open in New Tab"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-12 15:35:56.930873",
+ "modified": "2026-03-15 02:26:37.285903",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace Sidebar Item",

--- a/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.py
+++ b/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.py
@@ -24,6 +24,7 @@ class WorkspaceSidebarItem(Document):
 		link_to: DF.DynamicLink | None
 		link_type: DF.Literal["DocType", "Page", "Report", "Workspace", "Dashboard", "URL"]
 		navigate_to_tab: DF.Autocomplete | None
+		open_in_new_tab: DF.Check
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_editor.js
@@ -334,6 +334,14 @@ export class SidebarEditor {
 				label: "URL",
 			},
 			{
+				depends_on: 'eval: doc.link_type == "URL"',
+				fieldname: "open_in_new_tab",
+				fieldtype: "Check",
+				default: "1",
+				label: "Open in New Tab",
+				description: "open the URL in a new browser tab",
+			},
+			{
 				depends_on:
 					'eval: doc.type == "Link" || (doc.indent == 1 && doc.type == "Section Break")',
 				fieldname: "icon",

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.html
@@ -23,7 +23,7 @@
             <a
                 {% if (path) { %}
                     href="{{ path }}"
-                    target="{%= item.link_type === "URL" ? "_blank" : "" %}"
+                    target="{%= item.link_type === "URL" && item.open_in_new_tab ? "_blank" : "" %}"
                 {% } %}
                 class="item-anchor"
             >


### PR DESCRIPTION
Resolve: #37982

---
Added an "Open in new tab" checkbox to sidebar item settings,
giving users direct control over how URLs are opened

https://github.com/user-attachments/assets/4f17dd3b-ee6e-4daa-89b5-e21517ebcd3a


