### PR TITLE
fix: check only select perm instead of read or select

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -472,7 +472,7 @@ def validate_link_and_fetch(
 	if is_virtual_dt:
 		try:
 			doc = frappe.get_doc(doctype, docname)
-			doc.check_permission("select" if frappe.only_has_select_perm(doctype) else "read")
+			doc.check_permission("select")
 			values = {"name": doc.name}
 
 		except frappe.DoesNotExistError:

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -274,7 +274,7 @@ class Engine:
 			self.table = qb.DocType(table)
 
 		if self.apply_permissions:
-			self.check_read_permission()
+			self.check_select_permission()
 			self.permission_doctype = parent_doctype or self.doctype
 			self.permission_table = (
 				qb.DocType(self.permission_doctype) if self.permission_doctype != self.doctype else self.table
@@ -1404,18 +1404,11 @@ class Engine:
 
 		return parsed_order_fields
 
-	def check_read_permission(self):
-		"""Check if user has select permission on the doctype"""
-
-		def has_permission(ptype):
-			return frappe.has_permission(
-				self.doctype,
-				ptype,
-				user=self.user,
-				parent_doctype=self.parent_doctype,
-			)
-
-		if not has_permission("select"):
+	def check_select_permission(self):
+		"""Check if user has select (or read) permission on the doctype"""
+		if not frappe.has_permission(
+			self.doctype, "select", user=self.user, parent_doctype=self.parent_doctype
+		):
 			self._raise_permission_error()
 
 	def _raise_permission_error(self, doctype=None):

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1405,7 +1405,7 @@ class Engine:
 		return parsed_order_fields
 
 	def check_read_permission(self):
-		"""Check if user has read permission on the doctype"""
+		"""Check if user has select permission on the doctype"""
 
 		def has_permission(ptype):
 			return frappe.has_permission(
@@ -1415,7 +1415,7 @@ class Engine:
 				parent_doctype=self.parent_doctype,
 			)
 
-		if not has_permission("select") and not has_permission("read"):
+		if not has_permission("select"):
 			self._raise_permission_error()
 
 	def _raise_permission_error(self, doctype=None):


### PR DESCRIPTION
With reference to https://github.com/frappe/frappe/pull/38041, check only select perms where read or select perm is being checked