### PR TITLE
feat: add Brazilian Portuguese

### DIFF
--- a/frappe/geo/languages.csv
+++ b/frappe/geo/languages.csv
@@ -59,6 +59,7 @@ no,Norsk,0
 pl,Polski,0
 ps,پښتو,0
 pt,Português,0
+pt-BR,Português Brasileiro,0
 ro,Română,0
 ru,Русский,0
 rw,Kinyarwanda,0


### PR DESCRIPTION
This is a manual backport of  #38048 (adding Brazilian Portuguese into `languages.csv`)
