### PR TITLE
fix(Auto Email Report): missing dynamic filters

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -188,6 +188,15 @@ frappe.ui.form.on("Auto Email Report", {
 					},
 				});
 				dialog.show();
+
+				// add filters defined in onload event of report
+				if (reference_report.onload) {
+					frappe.query_report = new frappe.views.QueryReport({
+						filters: dialog.fields_list,
+					});
+					reference_report.onload(frappe.query_report);
+				}
+
 				dialog.set_values(filters);
 			});
 


### PR DESCRIPTION
## Reason
While setting up an Auto Email Report setup for Monthly Attendance Sheet in Frappe HR, the 'year' filter is not populated with data as per attendance report filter

<img width="800" height="226" alt="image" src="https://github.com/user-attachments/assets/a3811ada-02f0-41e0-8cf4-594ad6bf3fea" />

<img width="636" height="326" alt="image" src="https://github.com/user-attachments/assets/7d094c75-9c7d-4031-85a8-b7516c446b9a" />

## Changes done
- Call the report's onload event when opening filter table to set dynamic filters as defined
 
fix:

<img width="636" height="326" alt="image" src="https://github.com/user-attachments/assets/9dc6785d-7802-4b52-b107-8c94d8d1ca15" />

closes: https://github.com/frappe/hrms/issues/112