### PR TITLE
feat: support `bulk_upsert` of records

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -14,6 +14,7 @@ from time import time
 from typing import TYPE_CHECKING, Any, Literal
 
 from pypika.queries import QueryBuilder, Table
+from pypika.terms import Values
 
 import frappe
 import frappe.defaults
@@ -1505,6 +1506,47 @@ class Database:
 		value_iterator = iter(values)
 		while value_chunk := tuple(itertools.islice(value_iterator, chunk_size)):
 			query.insert(*value_chunk).run()
+
+	def bulk_upsert(
+		self,
+		doctype: str,
+		fields: list[str],
+		values: Iterable[Sequence[Any]],
+		conflict_fields: list[str],
+		update_fields: list[str],
+		*,
+		chunk_size: int = 10_000,
+	):
+		"""
+		Insert multiple records, updating specified fields on conflict.
+
+		Uses INSERT ... ON DUPLICATE KEY UPDATE for MariaDB and
+		INSERT ... ON CONFLICT ... DO UPDATE for PostgreSQL and SQLite.
+
+		:param doctype: Doctype name
+		:param fields: list of all column names being inserted
+		:param values: iterable of value tuples matching fields
+		:param conflict_fields: columns that form the unique constraint
+		:param update_fields: columns to update when a conflict occurs
+		:param chunk_size: number of rows per INSERT statement
+		"""
+
+		table = frappe.qb.DocType(doctype)
+
+		value_iterator = iter(values)
+		while value_chunk := tuple(itertools.islice(value_iterator, chunk_size)):
+			query = frappe.qb.into(table).columns(fields).insert(*value_chunk)
+
+			if frappe.conf.db_type in ("postgres", "sqlite"):
+				query = query.on_conflict(*[table[f] for f in conflict_fields])
+
+			for field in update_fields:
+				if frappe.conf.db_type == "mariadb":
+					query = query.on_duplicate_key_update(table[field], Values(field))
+				elif frappe.conf.db_type in ("postgres", "sqlite"):
+					query = query.do_update(table[field])
+
+			query.run()
 
 	def create_sequence(self, *args, **kwargs):
 		from frappe.database.sequence import create_sequence

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -649,6 +649,60 @@ class TestDB(IntegrationTestCase):
 		# cleanup
 		frappe.db.delete("ToDo", {"name": ("in", record_names)})
 
+	def test_bulk_upsert(self):
+		test_body = f"test_bulk_upsert - {random_string(10)}"
+
+		frappe.db.bulk_insert(
+			"ToDo",
+			["name", "description", "status"],
+			[[f"ToDo Test Bulk Upsert {i}", test_body, "Open"] for i in range(20)],
+			ignore_duplicates=True,
+		)
+
+		record_names = frappe.get_all("ToDo", filters={"description": test_body}, pluck="name")
+
+		upsert_values = []
+		updated_descriptions = {}
+
+		for name in record_names:
+			updated_description = f"{test_body} - updated - {random_string(10)}"
+			updated_descriptions[name] = updated_description
+			upsert_values.append((name, updated_description, "Closed"))
+
+		new_name = f"ToDo Test Bulk Upsert New {random_string(8)}"
+		upsert_values.append((new_name, f"{test_body} - inserted", "Open"))
+
+		frappe.db.bulk_upsert(
+			"ToDo",
+			["name", "description", "status"],
+			upsert_values,
+			conflict_fields=["name"],
+			update_fields=["description", "status"],
+		)
+
+		updated_records = dict(
+			frappe.get_all(
+				"ToDo", filters={"name": ("in", record_names)}, fields=["name", "description"], as_list=True
+			)
+		)
+		self.assertDictEqual(updated_descriptions, updated_records)
+
+		statuses = dict(
+			frappe.get_all(
+				"ToDo", filters={"name": ("in", record_names)}, fields=["name", "status"], as_list=True
+			)
+		)
+		self.assertTrue(all(status == "Closed" for status in statuses.values()))
+
+		inserted_description, inserted_status = frappe.db.get_value(
+			"ToDo", new_name, ["description", "status"]
+		)
+		self.assertEqual(inserted_description, f"{test_body} - inserted")
+		self.assertEqual(inserted_status, "Open")
+
+		# cleanup
+		frappe.db.delete("ToDo", {"name": ("in", [*record_names, new_name])})
+
 	def test_count(self):
 		frappe.db.delete("Note")
 


### PR DESCRIPTION
## Usecase

- At times we have to create or update records, where we first check if records exist, and then use `bulk_update` or `bulk_insert`. It may be efficient to just use bulk_upsert here.
- When processing in parallel, you may still want to upsert records instead of `bulk_insert` with `ignore_duplicates = true`
