### PR TITLE
fix: use inputmode="decimal" for Float, Currency, and Percent fields

### DIFF
--- a/frappe/public/js/frappe/form/controls/float.js
+++ b/frappe/public/js/frappe/form/controls/float.js
@@ -1,4 +1,5 @@
 frappe.ui.form.ControlFloat = class ControlFloat extends frappe.ui.form.ControlInt {
+	static input_mode = "decimal";
 	parse(value) {
 		value = this.eval_expression(value);
 		return isNaN(parseFloat(value)) ? null : flt(value, this.get_precision());


### PR DESCRIPTION
Raising PR on behalf of @wfhp 


ControlFloat inherits from ControlInt, which sets `inputmode="numeric"`. On mobile devices, this brings up a numeric keypad without a decimal point, making it impossible to enter decimal values (e.g. 0.16, 0.18) for Float, Currency, and Percent fields.

**Fix:** Override `input_mode` to `"decimal"` in ControlFloat. Per the HTML spec, `inputmode="decimal"` instructs mobile browsers to display a numeric keypad that includes a decimal separator. Since ControlCurrency and ControlPercent both extend ControlFloat, they automatically inherit the fix.

closes #37703