### PR TITLE
fix: translate breadcrumb titles

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -233,7 +233,7 @@ frappe.breadcrumbs = {
 			is_new_doc = true;
 		} else {
 			let title = frappe.model.get_doc_title(doc);
-			docname_title = title || doc.name;
+			docname_title = __(title) || __(doc.name);
 			if (frappe.utils.is_html(docname_title)) {
 				docname_title = strip_html(docname_title);
 			}


### PR DESCRIPTION
This PR fixes the issue where breadcrumb titles were not being translated.


**Before**:

<img width="2880" height="1642" alt="image" src="https://github.com/user-attachments/assets/3385488a-443f-479f-aab0-a0e1e4a510ca" />




**After**:

<img width="2880" height="1642" alt="image" src="https://github.com/user-attachments/assets/1d21fb8b-7d90-4d71-9d07-a7ec26b6fc6d" />

closes #37477 