### PR TITLE
fix: use parent doctype for DocShare check on child table field permissions

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -618,7 +618,7 @@ class Meta(Document):
 
 		if 0 not in permlevel_access and permission_type in ("read", "select"):
 			check_doctype = parenttype if self.istable and parenttype else self.name
-			if frappe.share.get_shared(check_doctype, user, rights=[permission_type], limit=1):
+			if frappe.share.get_shared(check_doctype, user, rights=["read"], limit=1):
 				permlevel_access.add(0)
 
 		permitted_fieldnames.extend(

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -617,7 +617,8 @@ class Meta(Document):
 		)
 
 		if 0 not in permlevel_access and permission_type in ("read", "select"):
-			if frappe.share.get_shared(self.name, user, rights=[permission_type], limit=1):
+			check_doctype = parenttype if self.istable and parenttype else self.name
+			if frappe.share.get_shared(check_doctype, user, rights=[permission_type], limit=1):
 				permlevel_access.add(0)
 
 		permitted_fieldnames.extend(


### PR DESCRIPTION
## Summary
- When checking DocShare permissions for child table fields, use the parent doctype instead of the child table's name
- This ensures shared document permissions are correctly applied to child table field access

Backport of https://github.com/frappe/frappe/pull/37903