### PR TITLE
fix: solves `bench start` crash when PYTHONWARNINGS is set for deprecation testing

### DIFF
--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -79,11 +79,11 @@ class V17FrappeDeprecationWarning(PendingFrappeDeprecationWarning):
 
 
 def __get_deprecation_class(graduation: str | None = None, class_name: str | None = None) -> type:
+	current_module = sys.modules[__name__]
 	if graduation:
 		# Scrub the graduation string to ensure it's a valid class name
 		cleaned_graduation = re.sub(r"\W|^(?=\d)", "_", graduation.upper())
 		class_name = f"{cleaned_graduation}FrappeDeprecationWarning"
-		current_module = sys.modules[__name__]
 	try:
 		return getattr(current_module, class_name)
 	except AttributeError:


### PR DESCRIPTION
Fixes a crash that happens when `bench` starts up with the `PYTHONWARNINGS` env variable set as described in the [Deprecations wiki](https://github.com/frappe/frappe/wiki/Deprecations).

### Replicating the Issue

Try to show deprecations that will graduate in v17:
```bash
export PYTHONWARNINGS="always::frappe.deprecation_dumpster.V17FrappeDeprecationWarning"
```

Then run:
```bash
bench start
```
The entire bench crashes immediately with:
```bash
18:47:03 watch.1       |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/deprecation_dumpster.py", line 88, in __get_deprecation_class
18:47:03 watch.1       |     return getattr(current_module, class_name)
18:47:03 watch.1       |                    ^^^^^^^^^^^^^^
18:47:03 watch.1       | UnboundLocalError: cannot access local variable 'current_module' where it is not associated with a value
```
<details>
<summary>Full Terminal Output</summary>

```bash
$ bench start
Invalid -W option ignored: invalid module name: 'frappe.deprecation_dumpster'
Invalid -W option ignored: invalid module name: 'frappe.deprecation_dumpster'
18:47:02 system        | redis_cache.1 started (pid=85841)
18:47:02 system        | redis_queue.1 started (pid=85846)
18:47:02 system        | web.1 started (pid=85850)
18:47:02 system        | socketio.1 started (pid=85852)
18:47:02 system        | watch.1 started (pid=85855)
18:47:02 system        | schedule.1 started (pid=85861)
18:47:02 redis_queue.1 | 85848:C 17 Mar 2026 18:47:02.992 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
18:47:02 redis_queue.1 | 85848:C 17 Mar 2026 18:47:02.992 # Redis version=7.0.15, bits=64, commit=00000000, modified=0, pid=85848, just started
18:47:02 redis_queue.1 | 85848:C 17 Mar 2026 18:47:02.992 # Configuration loaded
18:47:02 redis_queue.1 | 85848:M 17 Mar 2026 18:47:02.993 * monotonic clock: POSIX clock_gettime
18:47:02 redis_cache.1 | 85844:C 17 Mar 2026 18:47:02.994 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
18:47:02 redis_cache.1 | 85844:C 17 Mar 2026 18:47:02.994 # Redis version=7.0.15, bits=64, commit=00000000, modified=0, pid=85844, just started
18:47:02 system        | worker.1 started (pid=85864)
18:47:02 redis_cache.1 | 85844:C 17 Mar 2026 18:47:02.994 # Configuration loaded
18:47:02 redis_queue.1 | 85848:M 17 Mar 2026 18:47:02.996 * Running mode=standalone, port=11002.
18:47:02 redis_queue.1 | 85848:M 17 Mar 2026 18:47:02.996 # Server initialized
18:47:02 redis_queue.1 | 85848:M 17 Mar 2026 18:47:02.996 # WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
18:47:02 redis_queue.1 | 85848:M 17 Mar 2026 18:47:02.997 * Loading RDB produced by version 7.0.15
18:47:02 redis_queue.1 | 85848:M 17 Mar 2026 18:47:02.997 * RDB age 18 seconds
18:47:02 redis_queue.1 | 85848:M 17 Mar 2026 18:47:02.997 * RDB memory usage when created 1.86 Mb
18:47:02 redis_queue.1 | 85848:M 17 Mar 2026 18:47:02.998 * Done loading RDB, keys loaded: 78, keys expired: 0.
18:47:02 redis_queue.1 | 85848:M 17 Mar 2026 18:47:02.999 * DB loaded from disk: 0.001 seconds
18:47:03 redis_queue.1 | 85848:M 17 Mar 2026 18:47:03.000 * Ready to accept connections
18:47:03 web.1         | Invalid -W option ignored: invalid module name: 'frappe.deprecation_dumpster'
18:47:03 redis_cache.1 | 85844:M 17 Mar 2026 18:47:03.007 * monotonic clock: POSIX clock_gettime
18:47:03 redis_cache.1 | 85844:M 17 Mar 2026 18:47:03.008 * Running mode=standalone, port=13002.
18:47:03 redis_cache.1 | 85844:M 17 Mar 2026 18:47:03.008 # Server initialized
18:47:03 redis_cache.1 | 85844:M 17 Mar 2026 18:47:03.008 # WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
18:47:03 redis_cache.1 | 85844:M 17 Mar 2026 18:47:03.009 * Ready to accept connections
18:47:03 schedule.1    | Invalid -W option ignored: invalid module name: 'frappe.deprecation_dumpster'
18:47:03 watch.1       | Invalid -W option ignored: invalid module name: 'frappe.deprecation_dumpster'
18:47:03 watch.1       | Invalid -W option ignored: invalid module name: 'frappe.deprecation_dumpster'
18:47:03 schedule.1    | Invalid -W option ignored: invalid module name: 'frappe.deprecation_dumpster'
18:47:03 web.1         | Invalid -W option ignored: invalid module name: 'frappe.deprecation_dumpster'
18:47:03 schedule.1    | Traceback (most recent call last):
18:47:03 schedule.1    |   File "<frozen runpy>", line 189, in _run_module_as_main
18:47:03 schedule.1    |   File "<frozen runpy>", line 112, in _get_module_details
18:47:03 schedule.1    |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/__init__.py", line 37, in <module>
18:47:03 schedule.1    |     from frappe.query_builder.utils import (
18:47:03 schedule.1    |     ...<2 lines>...
18:47:03 schedule.1    |     )
18:47:03 schedule.1    |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/query_builder/__init__.py", line 6, in <module>
18:47:03 schedule.1    |     from frappe.query_builder.terms import ParameterizedFunction, ParameterizedValueWrapper
18:47:03 schedule.1    |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/query_builder/terms.py", line 10, in <module>
18:47:03 schedule.1    |     from frappe.utils.data import format_time, format_timedelta
18:47:03 schedule.1    |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/utils/__init__.py", line 27, in <module>
18:47:03 schedule.1    |     from frappe.deprecation_dumpster import gzip_compress, gzip_decompress, make_esc
18:47:03 schedule.1    |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/deprecation_dumpster.py", line 105, in <module>
18:47:03 schedule.1    |     warning_class = __get_deprecation_class(class_name=class_name)
18:47:03 schedule.1    |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/deprecation_dumpster.py", line 88, in __get_deprecation_class
18:47:03 schedule.1    |     return getattr(current_module, class_name)
18:47:03 schedule.1    |                    ^^^^^^^^^^^^^^
18:47:03 schedule.1    | UnboundLocalError: cannot access local variable 'current_module' where it is not associated with a value
18:47:03 watch.1       | Traceback (most recent call last):
18:47:03 watch.1       |   File "<frozen runpy>", line 189, in _run_module_as_main
18:47:03 watch.1       |   File "<frozen runpy>", line 112, in _get_module_details
18:47:03 watch.1       |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/__init__.py", line 37, in <module>
18:47:03 watch.1       |     from frappe.query_builder.utils import (
18:47:03 watch.1       |     ...<2 lines>...
18:47:03 watch.1       |     )
18:47:03 watch.1       |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/query_builder/__init__.py", line 6, in <module>
18:47:03 watch.1       |     from frappe.query_builder.terms import ParameterizedFunction, ParameterizedValueWrapper
18:47:03 watch.1       |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/query_builder/terms.py", line 10, in <module>
18:47:03 watch.1       |     from frappe.utils.data import format_time, format_timedelta
18:47:03 watch.1       |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/utils/__init__.py", line 27, in <module>
18:47:03 watch.1       |     from frappe.deprecation_dumpster import gzip_compress, gzip_decompress, make_esc
18:47:03 watch.1       |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/deprecation_dumpster.py", line 105, in <module>
18:47:03 watch.1       |     warning_class = __get_deprecation_class(class_name=class_name)
18:47:03 watch.1       |   File "/home/harsh/frappe-workspace/frappe-dev/apps/frappe/frappe/deprecation_dumpster.py", line 88, in __get_deprecation_class
18:47:03 watch.1       |     return getattr(current_module, class_name)
18:47:03 watch.1       |                    ^^^^^^^^^^^^^^
18:47:03 watch.1       | UnboundLocalError: cannot access local variable 'current_module' where it is not associated with a value
18:47:03 system        | worker.1 stopped (rc=1)
18:47:03 system        | sending SIGTERM to redis_cache.1 (pid 85841)
18:47:03 system        | sending SIGTERM to redis_queue.1 (pid 85846)
18:47:03 system        | sending SIGTERM to web.1 (pid 85850)
18:47:03 system        | sending SIGTERM to socketio.1 (pid 85852)
18:47:03 system        | sending SIGTERM to watch.1 (pid 85855)
18:47:03 system        | sending SIGTERM to schedule.1 (pid 85861)
18:47:03 redis_cache.1 | 85844:signal-handler (1773753423) Received SIGTERM scheduling shutdown...
18:47:03 redis_queue.1 | 85848:signal-handler (1773753423) Received SIGTERM scheduling shutdown...
18:47:03 system        | web.1 stopped (rc=-15)
18:47:03 system        | schedule.1 stopped (rc=-15)
18:47:03 system        | watch.1 stopped (rc=-15)
18:47:03 redis_queue.1 | 85848:M 17 Mar 2026 18:47:03.805 # User requested shutdown...
18:47:03 redis_queue.1 | 85848:M 17 Mar 2026 18:47:03.805 * Saving the final RDB snapshot before exiting.
18:47:03 system        | socketio.1 stopped (rc=-15)
18:47:03 redis_cache.1 | 85844:M 17 Mar 2026 18:47:03.813 # User requested shutdown...
18:47:03 redis_cache.1 | 85844:M 17 Mar 2026 18:47:03.813 * Removing the pid file.
18:47:03 redis_cache.1 | 85844:M 17 Mar 2026 18:47:03.813 # Redis is now ready to exit, bye bye...
18:47:03 redis_queue.1 | 85848:M 17 Mar 2026 18:47:03.813 * DB saved on disk
18:47:03 redis_queue.1 | 85848:M 17 Mar 2026 18:47:03.813 * Removing the pid file.
18:47:03 redis_queue.1 | 85848:M 17 Mar 2026 18:47:03.813 # Redis is now ready to exit, bye bye...
18:47:03 system        | redis_cache.1 stopped (rc=-15)
18:47:03 system        | redis_queue.1 stopped (rc=-15)
```

</details>


### How I tested the fix

> test2.py

```python
import frappe
from frappe.model.document import Document


class Test2(Document):
	def onload(self):
		from frappe.model.qb_query import DatabaseQuery

		query = DatabaseQuery('Test2')
		results = query.execute(limit_page_length=10)
		frappe.errprint(results)

```

After the fix, `bench start` runs without any crash. Deprecation warnings are correctly surfaced at runtime. For example, accessing a deprecated parameter now shows the expected warning instead of blowing up:
```bash
15:52:36 web.1         |  The 'limit_page_length' parameter is deprecated. Use 'limit' instead.
```



