### PR TITLE
build: bump PyJWT to ~=2.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "GitPython~=3.1.45",
     "Jinja2~=3.1.6",
     "Pillow~=12.1.1",
-    "PyJWT~=2.10.1",
+    "PyJWT~=2.12.1",
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.2",


### PR DESCRIPTION
Bump PyJWT from ~=2.10.1 to ~=2.12.1.

### Notable changes

- **Security:** Validate `crit` (Critical) header parameter per RFC 7515 §4.1.11 (CVE-2026-32597, GHSA-752w-5fwx-jx9f)
- **Stricter `iss` type checking:** `iss` claim must be a string (per RFC 7519 §4.1.1) — both in `encode()` and `decode()`
- **Key type validation:** RSA/EC/OKP algorithms now reject mismatched key types early
- Adds `typing_extensions` dependency for Python < 3.11

None of these changes affect Frappe's current JWT usage — Frappe only issues HS256 tokens without `crit` headers, and `iss` is already a string when set.