### PR TITLE
fix: use ASCII-only pattern in validate_column_name

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -5,8 +5,9 @@ from frappe import _
 from frappe.utils import cint, cstr, flt
 from frappe.utils.defaults import get_not_null_defaults
 
-# This matches anything that isn't [a-zA-Z0-9_]
-SPECIAL_CHAR_PATTERN = re.compile(r"[\W]", flags=re.UNICODE)
+# Matches non-ASCII letters/digits/underscore.
+# ASCII-only so Unicode (é, ü, ñ) is caught early (not at query time).
+SPECIAL_CHAR_PATTERN = re.compile(r"[^a-zA-Z0-9_]")
 
 VARCHAR_CAST_PATTERN = re.compile(r"varchar\(([\d]+)\)")
 


### PR DESCRIPTION
## **Description:**

`SPECIAL_CHAR_PATTERN` was using `re.UNICODE`, which treats accented characters (like *é, ü, ñ*) as valid word characters. Because of that, fieldnames with diacritics were passing validation at creation time but then failing later during queries with a confusing "Invalid characters in fieldname" error.

This change switches to an ASCII-only regex, so invalid fieldnames are caught early with a clear and predictable error.

### Ref: https://github.com/frappe/erpnext/pull/53563