### PR TITLE
fix(ui): add padding and border radius to sidebar user link

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -53,8 +53,8 @@
 				</a>
 				<div class="nav-item dropdown dropdown-navbar-user dropdown-mobile mt-3">
 					<a
-						class="align-center btn-reset flex nav-link"
-						style="width: 100%; height: 40px;"
+						class="align-center btn-reset flex nav-link sidebar-user-button"
+						style="width: 100%; min-height: 40px;"
 						onclick="return frappe.ui.toolbar.route_to_user()"
 						aria-label="{{ __("User Menu") }}"
 					>

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -199,7 +199,7 @@
 
 			.sidebar-user-button {
 				padding: 6px 8px;
-				border-radius: 8px;
+				border-radius: var(--border-radius-sm);
 			}
 		}
 	}

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -196,6 +196,11 @@
 			&:hover {
 				@include hover-mixin();
 			}
+
+			.sidebar-user-button {
+				padding: 6px 8px;
+				border-radius: 8px;
+			}
 		}
 	}
 

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -198,7 +198,7 @@
 			}
 
 			.sidebar-user-button {
-				padding: 6px 8px;
+				padding: var(--padding-sm);
 				border-radius: var(--border-radius-sm);
 			}
 		}


### PR DESCRIPTION
Before: 
<img width="220" height="106" alt="image" src="https://github.com/user-attachments/assets/91a518be-5db0-4162-a117-90ae5a5b27d9" />

After:
<img width="218" height="112" alt="image" src="https://github.com/user-attachments/assets/6c3cea0e-d1b1-4048-ab40-60d6cde95c70" />
