### PR TITLE
fix: broken delete account link

### DIFF
--- a/frappe/www/me.html
+++ b/frappe/www/me.html
@@ -57,16 +57,16 @@
 				</a>
 			</span>
 		</div>
-		<!-- {% if frappe.db.get_single_value("Website Settings", "show_account_deletion_link") %} -->
-		<div class="d-flex justify-content-between align-items-center">
+		{% if frappe.db.get_single_value("Website Settings", "show_account_deletion_link") %}
+		<div class="portal-section">
 			<span class="my-account-item-link">
 				<a href="/request-for-account-deletion?new=1">
-					<svg class="right-icon es-icon icon-md"><use href="#icon-delete"></use></svg>
+					<svg class="icon icon-md"><use href="#icon-trash"></use></svg>
 					<span class="item-link-text">{{_("Delete Account") }}</span>
 				</a>
 			</span>
 		</div>
-		<!-- {% endif %} -->
+		{% endif %}
 	</div>
 </div>
 


### PR DESCRIPTION
Before
<img width="815" height="617" alt="Screenshot 2026-03-18 at 12 31 22 PM" src="https://github.com/user-attachments/assets/3c836687-2ead-4ac7-94a3-108512a45917" />


After
<img width="833" height="592" alt="Screenshot 2026-03-18 at 12 27 57 PM" src="https://github.com/user-attachments/assets/cdead540-4780-42a8-a1dc-950c8039b9ef" />

Respect showing account deleting setting in Website Settings