### PR TITLE
fix: consistency of datetime field for query report while exporting

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -16,7 +16,7 @@ from frappe.model.utils import render_include
 from frappe.modules import get_module_path, scrub
 from frappe.monitor import add_data_to_monitor
 from frappe.permissions import get_role_permissions, get_roles, has_permission
-from frappe.utils import cint, cstr, flt, format_duration, get_html_format, sbool
+from frappe.utils import cint, cstr, flt, format_datetime, format_duration, formatdate, get_html_format, sbool
 from frappe.utils.caching import request_cache
 
 
@@ -469,13 +469,27 @@ def format_fields(data: frappe._dict) -> None:
 		if col.get("fieldtype") == "Duration":
 			for row in data.result:
 				index = col.get("fieldname") if isinstance(row, dict) else i
-				if row[index]:
-					row[index] = format_duration(row[index])
+				val = row.get(index) if isinstance(row, dict) else row[index]
+				if val:
+					row[index] = format_duration(val)
 		elif col.get("fieldtype") == "Currency" and col.get("precision"):
 			for row in data.result:
 				index = col.get("fieldname") if isinstance(row, dict) else i
-				if row[index]:
-					row[index] = round(row[index], col.get("precision"))
+				val = row.get(index) if isinstance(row, dict) else row[index]
+				if val:
+					row[index] = round(val, col.get("precision"))
+		elif col.get("fieldtype") == "Date":
+			for row in data.result:
+				index = col.get("fieldname") if isinstance(row, dict) else i
+				val = row.get(index) if isinstance(row, dict) else row[index]
+				if val:
+					row[index] = formatdate(val)
+		elif col.get("fieldtype") == "Datetime":
+			for row in data.result:
+				index = col.get("fieldname") if isinstance(row, dict) else i
+				val = row.get(index) if isinstance(row, dict) else row[index]
+				if val:
+					row[index] = format_datetime(val)
 
 
 def build_xlsx_data(


### PR DESCRIPTION
## Description

When exporting reports to CSV, date and datetime values were always shown in a fixed format like `YYYY-MM-DD`.  
This happened because Python automatically converts date values to this format when turning them into text.

## Fix

Now, before exporting, dates and datetimes are converted using the system’s date format settings.  
So the CSV export will match how dates appear elsewhere (like in Excel exports).

Also fixed an issue where the export could crash (KeyError) if some rows didn’t have all values (like total rows), especially for Duration and Currency fields.

## Format in report view(Notice the posting date)

<img width="1512" height="865" alt="Screenshot 2026-03-18 at 2 06 19 PM" src="https://github.com/user-attachments/assets/93e95678-0f02-4599-8276-2bcd8d858dd9" />

## Before:

<img width="1512" height="982" alt="Screenshot 2026-03-18 at 2 07 14 PM" src="https://github.com/user-attachments/assets/e4b24ce2-68d5-4707-b5d4-f72e92f33195" />

## After:

<img width="1512" height="982" alt="Screenshot 2026-03-18 at 2 07 39 PM" src="https://github.com/user-attachments/assets/40b987ed-902d-4005-b8e2-2cb39872d0cd" />


