### PR TITLE
fix: applying setter in filter for multi select dialog

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -554,7 +554,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 			}
 		} else {
 			Object.keys(this.setters).forEach(function (setter) {
-				var value = me.dialog.fields_dict[setter].get_value();
+				var value = me.dialog.fields_dict[setter].get_value() || me.setters[setter];
 				if (me.dialog.fields_dict[setter].df.fieldtype == "Data" && value) {
 					filters[setter] = ["like", "%" + value + "%"];
 				} else {


### PR DESCRIPTION
In Multi select dialog box before the change, the value set in Setter used to not apply while the data was fetched for the table below. 

Fixes: https://github.com/frappe/erpnext/issues/53510

Before: 
<img width="1440" height="721" alt="image" src="https://github.com/user-attachments/assets/6a87f25b-d47a-4a65-987b-9edb3a452539" />

After:
<img width="1434" height="810" alt="image" src="https://github.com/user-attachments/assets/47eb80fd-3f19-4b4f-aa60-f0346ee4ee34" />
