### PR TITLE
fix: show correct view label in awesomebar for tree-view doctypes

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -68,6 +68,7 @@ def get_bootinfo():
 	bootinfo.nested_set_doctypes = [
 		d.parent for d in frappe.get_all("DocField", {"fieldname": "lft"}, ["parent"])
 	]
+	bootinfo.tree_view_doctypes = [d.name for d in frappe.get_all("DocType", {"default_view": "Tree"})]
 	add_home_page(bootinfo, doclist)
 	bootinfo.page_info = get_allowed_pages()
 	load_translations(bootinfo)

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -26,6 +26,7 @@ from frappe.query_builder import DocType
 from frappe.query_builder.functions import Count
 from frappe.query_builder.terms import ParameterizedValueWrapper, SubQuery
 from frappe.utils import add_user_info, cstr, get_system_timezone
+from frappe.utils.caching import redis_cache
 from frappe.utils.change_log import get_versions
 from frappe.utils.frappecloud import on_frappecloud
 from frappe.website.doctype.web_page_view.web_page_view import is_tracking_enabled
@@ -65,10 +66,8 @@ def get_bootinfo():
 
 	bootinfo.module_app = frappe.local.module_app
 	bootinfo.single_types = [d.name for d in frappe.get_all("DocType", {"issingle": 1})]
-	bootinfo.nested_set_doctypes = [
-		d.parent for d in frappe.get_all("DocField", {"fieldname": "lft"}, ["parent"])
-	]
-	bootinfo.tree_view_doctypes = [d.name for d in frappe.get_all("DocType", {"default_view": "Tree"})]
+	bootinfo.nested_set_doctypes = frappe.get_all("DocField", {"fieldname": "lft"}, pluck="parent")
+	bootinfo.tree_view_doctypes = get_tree_view_doctypes()
 	add_home_page(bootinfo, doclist)
 	bootinfo.page_info = get_allowed_pages()
 	load_translations(bootinfo)
@@ -521,6 +520,11 @@ def get_marketplace_apps():
 		frappe.cache.set_value(cache_key, apps, shared=True, expires_in_sec=24 * 60 * 60)
 
 	return apps
+
+
+@redis_cache
+def get_tree_view_doctypes():
+	return frappe.get_all("DocType", {"default_view": "Tree"}, pluck="name")
 
 
 def add_subscription_conf():

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -61,11 +61,11 @@ def get_bootinfo():
 	bootinfo.desktop_icons = get_desktop_icons(bootinfo=bootinfo)
 	bootinfo.letter_heads = get_letter_heads()
 	bootinfo.active_domains = frappe.get_active_domains()
-	bootinfo.all_domains = [d.get("name") for d in frappe.get_all("Domain")]
+	bootinfo.all_domains = frappe.get_all("Domain", pluck="name")
 	add_layouts(bootinfo)
 
 	bootinfo.module_app = frappe.local.module_app
-	bootinfo.single_types = [d.name for d in frappe.get_all("DocType", {"issingle": 1})]
+	bootinfo.single_types = frappe.get_all("DocType", {"issingle": 1}, pluck="name")
 	bootinfo.nested_set_doctypes = frappe.get_all("DocField", {"fieldname": "lft"}, pluck="parent")
 	bootinfo.tree_view_doctypes = get_tree_view_doctypes()
 	add_home_page(bootinfo, doclist)
@@ -217,7 +217,7 @@ def load_desktop_data(bootinfo):
 				app_logo_url=app_info.get("logo")
 				or frappe.get_hooks("app_logo_url", app_name=app_name)
 				or frappe.get_hooks("app_logo_url", app_name="frappe"),
-				modules=[m.name for m in frappe.get_all("Module Def", dict(app_name=app_name))],
+				modules=frappe.get_all("Module Def", dict(app_name=app_name), pluck="name"),
 				workspaces=workspaces,
 			)
 		)
@@ -409,7 +409,7 @@ def get_success_action():
 def get_link_preview_doctypes():
 	from frappe.utils import cint
 
-	link_preview_doctypes = [d.name for d in frappe.get_all("DocType", {"show_preview_popup": 1})]
+	link_preview_doctypes = frappe.get_all("DocType", {"show_preview_popup": 1}, pluck="name")
 	customizations = frappe.get_all(
 		"Property Setter", fields=["doc_type", "value"], filters={"property": "show_preview_popup"}
 	)

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -235,7 +235,14 @@ frappe.search.utils = {
 						});
 					}
 
-					out.push(option("List", ["List", item], 0.05));
+					const isTree = (frappe.boot.tree_view_doctypes || []).includes(item);
+					out.push(
+						option(
+							isTree ? "Tree" : "List",
+							isTree ? ["Tree", item] : ["List", item],
+							0.05
+						)
+					);
 					if (frappe.model.can_get_report(item)) {
 						out.push(option("Report", ["List", item, "Report"], 0.04));
 					}


### PR DESCRIPTION
## Problem                                                      
                                                                                                                                                                   
  After [erpnext#45365](https://github.com/frappe/erpnext/pull/45365) set `default_view: "Tree"` on doctypes like Account,                                                                                         
  Warehouse, Item Group etc., the awesomebar still showed "Account List"
  instead of "Account Tree" in its dropdown.                                                                                                                       
                                                                  
  Root cause: `search_utils.js` (`get_doctypes()`) hardcodes `"List"` as                                                                                           
  the label and route type for all non-single doctypes, without checking
  `default_view`.                                                                                                                                                  
                                                                  
  Note: navigation itself was unaffected — `["List", "Account"]` resolves                                                                                          
  to URL `/account`, which the router correctly re-routes to Tree view.
  The issue was purely cosmetic.                                                                                                                                   
                                                                  
  ## Solution                                                                                                                                                      
                                                                  
  - **`frappe/boot.py`**: expose `tree_view_doctypes` in `frappe.boot` —                                                                                           
    a list of all doctypes with `default_view: "Tree"`
  - **`search_utils.js`**: check `frappe.boot.tree_view_doctypes` when                                                                                             
    building the awesomebar option, and use `"Tree"` route/label for
    matching doctypes                                                                                                                                              
                                                                                                                                                                   
  ## Before / After                                                                                                                                                
                                                                                                                                                                   
  | Search term | Before | After |                                                                                                                                 
  |---|---|---|                                                   
  | Account | Account List | Account Tree |                                                                                                                        
  | Warehouse | Warehouse List | Warehouse Tree |                                                                                                                  
  | Item Group | Item Group | Item Group Tree |

## Screenshorts
### Before
<img width="2879" height="917" alt="Screenshot from 2026-03-18 15-46-12" src="https://github.com/user-attachments/assets/30168d95-1b7b-4f08-8c79-2230319d9ffc" />

### After
<img width="2879" height="917" alt="Screenshot from 2026-03-18 15-49-28" src="https://github.com/user-attachments/assets/144e9685-1487-4222-ab07-540e191e2206" />

**Support Ticket** : [https://support.frappe.io/helpdesk/tickets/62238](https://support.frappe.io/helpdesk/tickets/62238)
