### PR TITLE
fix(query): handle none in IN filter value list via Coalesce

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -3,7 +3,7 @@ frappe.ui.form.on("User", {
 		frm.set_query("default_workspace", () => {
 			return {
 				filters: {
-					for_user: ["in", [null, frappe.session.user]],
+					for_user: ["in", ["", frappe.session.user]],
 					title: ["!=", "Welcome Workspace"],
 				},
 			};

--- a/frappe/database/operator_map.py
+++ b/frappe/database/operator_map.py
@@ -48,6 +48,10 @@ def func_in(key: Field, value: list | tuple) -> frappe.qb:
 	"""
 	if isinstance(value, str):
 		value = value.split(",")
+
+	value = ["" if v is None else v for v in value]
+	if "" in value:
+		return Coalesce(key, "").isin(value)
 	return key.isin(value)
 
 

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -552,9 +552,6 @@ class TestOperatorIn(IntegrationTestCase):
 		self.test_doctype_name = test_doctype.name
 		self.addCleanup(frappe.delete_doc, "DocType", self.test_doctype_name)
 
-		frappe.db.sql(f"DELETE FROM `tab{self.test_doctype_name}`")
-		frappe.db.commit()
-
 		doc_null = frappe.get_doc({"doctype": self.test_doctype_name, "test_field": None})
 		doc_null.insert()
 		doc_empty = frappe.get_doc({"doctype": self.test_doctype_name, "test_field": ""})

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -4,6 +4,7 @@ from datetime import time
 
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
+from frappe.database.operator_map import func_in
 from frappe.query_builder import Case
 from frappe.query_builder.builder import Function
 from frappe.query_builder.custom import ConstantColumn
@@ -503,3 +504,70 @@ class TestMisc(IntegrationTestCase):
 		roles = frappe.qb.from_(role).select(role.name)
 
 		self.assertEqual(set(users.run() + roles.run()), set((users + roles).run()))
+
+
+class TestOperatorIn(IntegrationTestCase):
+	def test_func_in_without_empty_values(self):
+		note = frappe.qb.DocType("Note")
+		query = func_in(note.name, ["n1", "n2", "n3"])
+		sql_str = str(query).lower()
+
+		self.assertIn("in", sql_str)
+		self.assertNotIn("coalesce", sql_str)
+
+	def test_func_in_with_none_converts_to_empty_string(self):
+		note = frappe.qb.DocType("Note")
+		query = func_in(note.name, [None, "user1"])
+		sql_str = str(query).lower()
+
+		self.assertIn("coalesce", sql_str)
+		self.assertIn("''", sql_str)
+
+	def test_func_in_with_empty_string_uses_coalesce(self):
+		note = frappe.qb.DocType("Note")
+		query = func_in(note.name, ["", "user1"])
+		sql_str = str(query).lower()
+
+		self.assertIn("coalesce", sql_str)
+		self.assertIn("''", sql_str)
+
+	def test_func_in_with_mixed_none_and_values(self):
+		note = frappe.qb.DocType("Note")
+		query = func_in(note.name, ["val1", None, "val2"])
+		sql_str = str(query).lower()
+
+		self.assertIn("coalesce", sql_str)
+
+	def test_in_filter_matches_null_and_empty_columns(self):
+		test_doctype = new_doctype(
+			fields=[
+				{
+					"fieldname": "test_field",
+					"fieldtype": "Data",
+					"label": "Test Field",
+				},
+			],
+		)
+		test_doctype.insert()
+		self.test_doctype_name = test_doctype.name
+		self.addCleanup(frappe.delete_doc, "DocType", self.test_doctype_name)
+
+		frappe.db.sql(f"DELETE FROM `tab{self.test_doctype_name}`")
+		frappe.db.commit()
+
+		doc_null = frappe.get_doc({"doctype": self.test_doctype_name, "test_field": None})
+		doc_null.insert()
+		doc_empty = frappe.get_doc({"doctype": self.test_doctype_name, "test_field": ""})
+		doc_empty.insert()
+		doc_user = frappe.get_doc({"doctype": self.test_doctype_name, "test_field": "user1"})
+		doc_user.insert()
+
+		results = frappe.get_all(
+			self.test_doctype_name,
+			filters={"test_field": ["in", [None, "user1"]]},
+			pluck="test_field",
+		)
+
+		self.assertIn(None, results)
+		self.assertIn("", results)
+		self.assertIn("user1", results)


### PR DESCRIPTION
## Description

In V16, `frappe.get_list` uses the new query builder which passed `None` in an `IN` filter, producing `col IN (NULL, 'x')`.
This never matches rows where `col = ''` (public workspaces), so the Default Workspace link field returned no results.

## Fix 

`func_in` in `operator_map.py` to convert `None → ""` and wrap the column with `COALESCE` when empty values are present, matching the `IFNULL` behavior of the legacy `db_query.py` path.

## Note : 
Convert None to "" to match db_query behavior: None in an IN filter means "match empty/null values". 
Use Coalesce so NULL columns are also matched.
e.g. for_user IN (None, 'user') → COALESCE(for_user, '') IN ('', 'user')


## Before

<img width="1020" height="866" alt="Screenshot 2026-03-18 at 5 10 54 PM" src="https://github.com/user-attachments/assets/025f11b7-2fa4-40d5-8294-bfe351f315d4" />

## After

<img width="1012" height="697" alt="Screenshot 2026-03-18 at 5 00 35 PM" src="https://github.com/user-attachments/assets/c80d5309-291f-44fd-93b3-de344b0dabfd" /> <br>
---
Ref: https://support.frappe.io/helpdesk/tickets/62871?view=VIEW-HD+Ticket-1252