### PR TITLE
fix: update the regex to allow foreign chars.

### DIFF
--- a/frappe/public/js/frappe/form/controls/quill-mention/quill.mention.js
+++ b/frappe/public/js/frappe/form/controls/quill-mention/quill.mention.js
@@ -19,7 +19,7 @@ class Mention {
 				return `${item.value}`;
 			},
 			mentionDenotationChars: ["@"],
-			allowedChars: /^[a-zA-Z0-9_]*$/,
+			allowedChars: /^[\p{L}0-9_]*$/u,
 			minChars: 0,
 			maxChars: 31,
 			offsetTop: 2,

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -254,7 +254,7 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 		let me = this;
 
 		return {
-			allowedChars: /^[A-Za-z0-9_]*$/,
+			allowedChars: /^[\p{L}0-9_]*$/u,
 			mentionDenotationChars: ["@"],
 			isolateCharacter: true,
 


### PR DESCRIPTION
This PR fixes the issue wherein it's impossible to mention a user, when writing a comment or CRM Note if the user has non-latin letters in their name.
Letters like ä, ö, ü, ß, ā, ē, ī, ū, ķ, ģ, ļ, ņ, š, ž, č, etc. were not supported. This is fixed in this PR.
(Description taken from issue #25534)

**Before**:

<img width="2880" height="1642" alt="image" src="https://github.com/user-attachments/assets/d9b46962-f3f8-4e5b-954f-d7bfbd07b5e1" />



**After**:

<img width="2880" height="1642" alt="image" src="https://github.com/user-attachments/assets/c8a21746-3287-424b-aa1a-26ab947c88f6" />


closes #25534 