### PR TITLE
fix(CustomizeForm): don't show view list button for Child tables

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -107,13 +107,15 @@ frappe.ui.form.on("Customize Form", {
 					frm.page.set_title(__("Customize Form - {0}", [__(frm.doc.doc_type)]));
 					frappe.customize_form.set_primary_action(frm);
 
-					frm.add_custom_button(
-						__("Go to {0} List", [__(frm.doc.doc_type)]),
-						function () {
-							frappe.set_route("List", frm.doc.doc_type);
-						},
-						__("Actions")
-					);
+					if (!frappe.get_meta(frm.doc.doc_type).istable) {
+						frm.add_custom_button(
+							__("Go to {0} List", [__(frm.doc.doc_type)]),
+							() => {
+								frappe.set_route("List", frm.doc.doc_type);
+							},
+							__("Actions")
+						);
+					}
 
 					frm.add_custom_button(
 						__("Set Permissions"),


### PR DESCRIPTION
Customize form used to show "Go to [X] list view" for child tables as well, which then threw an error. 

Before:

<img width="748" height="744" alt="CleanShot 2026-03-19 at 11 46 27@2x" src="https://github.com/user-attachments/assets/25eb94d9-1909-4ebb-ac1c-fdbd2559f3ed" />


<img width="1874" height="632" alt="CleanShot 2026-03-19 at 11 46 31@2x" src="https://github.com/user-attachments/assets/7d7805cf-981f-4b33-b2f1-de2aa428e055" />




After:

<img width="690" height="696" alt="CleanShot 2026-03-19 at 11 43 54@2x" src="https://github.com/user-attachments/assets/467e774e-609e-4e14-8123-d1e1f1e96a7f" />
