### PR TITLE
fix(filter): use JSON encoding for in filter values containing commas

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -891,7 +891,7 @@ from {tables}
 					try:
 						parsed = json.loads(values)
 						values = parsed if isinstance(parsed, list) else [parsed]
-					except (ValueError, TypeError):
+					except ValueError:
 						values = values.split(",")
 
 				fallback = "''"

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -888,7 +888,11 @@ from {tables}
 			if value is None:
 				values = f.value or ""
 				if isinstance(values, str):
-					values = values.split(",")
+					try:
+						parsed = json.loads(values)
+						values = parsed if isinstance(parsed, list) else [parsed]
+					except (ValueError, TypeError):
+						values = values.split(",")
 
 				fallback = "''"
 				value = [frappe.db.escape((cstr(v) or "").strip(), percent=False) for v in values]

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -203,7 +203,9 @@ frappe.ui.Filter = class {
 		this._filter_value_set = Promise.resolve();
 
 		if (["in", "not in"].includes(condition) && Array.isArray(value)) {
-			value = value.some((v) => String(v).includes(",")) ? JSON.stringify(value) : value.join(",");
+			value = value.some((v) => String(v).includes(","))
+				? JSON.stringify(value)
+				: value.join(",");
 		}
 
 		if (Array.isArray(value)) {

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -203,7 +203,7 @@ frappe.ui.Filter = class {
 		this._filter_value_set = Promise.resolve();
 
 		if (["in", "not in"].includes(condition) && Array.isArray(value)) {
-			value = value.join(",");
+			value = value.some((v) => String(v).includes(",")) ? JSON.stringify(value) : value.join(",");
 		}
 
 		if (Array.isArray(value)) {
@@ -485,7 +485,12 @@ frappe.ui.filter_utils = {
 			}
 		} else if (["in", "not in"].includes(condition)) {
 			if (val) {
-				val = val.split(",").map((v) => strip(v));
+				try {
+					const parsed = JSON.parse(val);
+					val = Array.isArray(parsed) ? parsed : [String(parsed)];
+				} catch {
+					val = val.split(",").map((v) => strip(v));
+				}
 			}
 		} else if (frappe.boot.additional_filters_config[condition]) {
 			val = field.value || val;

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -271,6 +271,33 @@ class TestDBQuery(IntegrationTestCase):
 				result in DatabaseQuery("DocType").execute(filters={"name": ["not in", "DocType,DocField"]})
 			)
 
+	def test_in_filter_json_encoded_values(self):
+		# JSON-encoded list string should work the same as comma-separated
+		for result in [{"name": "DocType"}, {"name": "DocField"}]:
+			self.assertTrue(
+				result
+				in DatabaseQuery("DocType").execute(filters={"name": ["in", '["DocType", "DocField"]']})
+			)
+
+		# Values containing commas must not be split
+		todo = frappe.get_doc(
+			doctype="ToDo", description="Test, With Comma", allocated_to="Administrator"
+		).insert()
+		try:
+			results = DatabaseQuery("ToDo").execute(
+				filters={"description": ["in", '["Test, With Comma"]']},
+				fields=["description"],
+			)
+			self.assertIn({"description": "Test, With Comma"}, results)
+
+			results_split = DatabaseQuery("ToDo").execute(
+				filters={"description": ["in", "Test, With Comma"]},
+				fields=["description"],
+			)
+			self.assertNotIn({"description": "Test, With Comma"}, results_split)
+		finally:
+			frappe.delete_doc("ToDo", todo.name)
+
 	def test_string_as_field(self):
 		self.assertEqual(
 			frappe.get_all("DocType", as_list=True), frappe.get_all("DocType", fields="name", as_list=True)

--- a/frappe/types/filter.py
+++ b/frappe/types/filter.py
@@ -113,7 +113,7 @@ class FilterTuple(_FilterTuple):
 			if operator in ("in", "not in") and isinstance(value, str):
 				try:
 					parsed = json.loads(value)
-					value = parsed if isinstance(parsed, list) else [parsed]
+					value = parsed if isinstance(parsed, list) else value.split(",")  # type: ignore[assignment]
 				except ValueError:
 					value = value.split(",")
 

--- a/frappe/types/filter.py
+++ b/frappe/types/filter.py
@@ -1,3 +1,4 @@
+import json
 import textwrap
 from collections import defaultdict
 from collections.abc import Generator, Iterable, Mapping, Sequence
@@ -110,7 +111,11 @@ class FilterTuple(_FilterTuple):
 
 			# soundness
 			if operator in ("in", "not in") and isinstance(value, str):
-				value = value.split(",")
+				try:
+					parsed = json.loads(value)
+					value = parsed if isinstance(parsed, list) else [parsed]
+				except ValueError:
+					value = value.split(",")
 
 			_value: Value
 			if isinstance(value, _InputValue):


### PR DESCRIPTION
## Description

`in/not` in filter splits values on commas, breaking records whose names contain commas (e.g. BOM naming series). Encode as JSON when any value contains a comma; fallback to comma-split for backward compatibility.

## Before

- notice the second image, it says `no record will be exported`
- the issue occurs with records that contain commas in their IDs, for example: 
```
      BOM-- Armoured cable 4 x 1,5mm2. PVC/PVC/SWA/PVC to BS 6346. Local-002 
      BOM-- Armoured cable 4 x 70 mm2, PVC/PVC/SWA/PVC to BS 6346, Lcl-001 
```

<img width="1512" height="678" alt="Screenshot 2026-03-19 at 5 19 07 PM" src="https://github.com/user-attachments/assets/a6de66ce-46ba-4734-b32e-2a1c17aa6637" />
<img width="712" height="785" alt="Screenshot 2026-03-19 at 5 19 16 PM" src="https://github.com/user-attachments/assets/f9305e71-ab00-4d65-82ad-84d88404618a" />

## After

<img width="1505" height="864" alt="Screenshot 2026-03-19 at 5 24 08 PM" src="https://github.com/user-attachments/assets/99adce5e-113b-4a92-8ece-d8ee95c529ec" /><br>

Ref: https://support.frappe.io/helpdesk/tickets/62854?view=VIEW-HD+Ticket-1252