### PR TITLE
fix: report print letterhead footer not rendering

### DIFF
--- a/frappe/public/html/print_template.html
+++ b/frappe/public/html/print_template.html
@@ -14,19 +14,6 @@
 </head>
 <body>
 	<div class="print-format-gutter">
-		{% if print_settings.repeat_header_footer %}
-			<div id="footer-html" class="visible-pdf">
-				{% if print_settings.letter_head && print_settings.letter_head.footer %}
-					<div class="letter-head-footer">
-						{{ print_settings.letter_head.footer }}
-					</div>
-				{% endif %}
-				<p class="text-center small page-number visible-pdf">
-					{{ __("Page {0} of {1}", [`<span class="page"></span>`, `<span class="topage"></span>`]) }}
-				</p>
-			</div>
-		{% endif %}
-
 		<div class="print-format {% if landscape %}landscape{% endif %}"
 				{% if columns.length > 20 %}
 					{% if can_use_smaller_font %}
@@ -40,6 +27,18 @@
 			</div>
 			{% endif %}
 			{{ content }}
+			{% if print_settings.repeat_header_footer %}
+			<div id="footer-html" class="visible-pdf">
+				{% if print_settings.letter_head && print_settings.letter_head.footer %}
+					<div class="letter-head-footer">
+						{{ print_settings.letter_head.footer }}
+					</div>
+				{% endif %}
+				<p class="text-center small page-number visible-pdf">
+					{{ __("Page {0} of {1}", [`<span class="page"></span>`, `<span class="topage"></span>`]) }}
+				</p>
+			</div>
+			{% endif %}
 		</div>
 	</div>
 </body>

--- a/frappe/public/js/frappe/microtemplate.js
+++ b/frappe/public/js/frappe/microtemplate.js
@@ -163,6 +163,21 @@ frappe.render_template = function (name, data) {
 	}
 
 	w.document.write(html);
+
+	// show footer on print
+	const footer = w.document.getElementById("footer-html");
+	if (footer) {
+		footer.classList.remove("visible-pdf");
+		footer.style.marginTop = "auto";
+
+		const print_format = w.document.querySelector(".print-format");
+		if (print_format) {
+			print_format.style.display = "flex";
+			print_format.style.flexDirection = "column";
+			print_format.style.minHeight = "100vh";
+		}
+	}
+
 	w.document.close();
 }),
 	(frappe.render_tree = function (opts) {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1676,7 +1676,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	async render_report_letterhead(print_settings) {
 		if (!print_settings.with_letter_head || !print_settings.letter_head_name) return;
-		if (print_settings.__letter_head_rendered) return;
 
 		const filters = this.get_filter_values ? this.get_filter_values() : {};
 		const doc_context = Object.assign({}, filters);
@@ -1692,7 +1691,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			});
 			if (r.message) {
 				print_settings.letter_head = r.message;
-				print_settings.__letter_head_rendered = true;
 			}
 		} catch (e) {
 			// fall back silently if rendering fails


### PR DESCRIPTION
## Summary

Fixes two issues with letterhead rendering when printing reports (e.g. General Ledger) from the browser.

### Issue 1: Footer not visible in browser print

The letterhead footer was only appearing in PDF export, not in the browser print popup.

**Root cause:** The `#footer-html` div was positioned before the report content in `print_template.html` and had the `visible-pdf` class (`display: none !important`). While wkhtmltopdf overrides this for PDF generation, the browser print popup had no equivalent — so the footer was always hidden.

**Fix:**
- Move `#footer-html` inside `.print-format` after `{{ content }}` so it renders below the report data. PDF is unaffected since wkhtmltopdf extracts `#footer-html` by ID regardless of DOM position.
- Remove `visible-pdf` class in the browser popup (mirroring `toggle_visible_pdf()` on the PDF path) and use flexbox with `margin-top: auto` to pin footer to page bottom.

### Issue 2: Jinja in letterhead renders as raw text on second print

The first print correctly renders Jinja expressions, but subsequent prints show raw Jinja tags as literal text.

**Root cause:** The `__letter_head_rendered` cache flag persists on the global `print_settings` object via `$.extend()`. On the second print:
1. `print_utils.js` overwrites `letter_head` with **raw Jinja** from `frappe.boot.letter_heads`
2. `render_report_letterhead()` returns early because `__letter_head_rendered` is still `true`
3. The server-side Jinja rendering is skipped, so raw template tags appear in the output

**Fix:** Remove the `__letter_head_rendered` flag so the letterhead is always rendered server-side via `render_letterhead_for_print`.

## Screenshorts
### Before Fix (footer was hidden)
<img width="2879" height="1668" alt="image" src="https://github.com/user-attachments/assets/4667dda6-d55b-42f5-90e6-940d50f2a49f" />

### After Fix (showing footer)
<img width="2879" height="1668" alt="image" src="https://github.com/user-attachments/assets/0b55ffa5-c4af-40a9-b562-909c2b01ea48" />

## Video
### Before Fix(showing raw jinja on subsequent prints)
[Screencast from 2026-03-19 22-28-34.webm](https://github.com/user-attachments/assets/6d816ee8-c5dd-49d4-a378-c621d7bf2c55)

### After Fix(showing rendered jinja on subsequent prints)
[Screencast from 2026-03-19 22-33-21.webm](https://github.com/user-attachments/assets/c967d047-edb0-42fd-a64c-68fcc94ec552)

**Support Ticket** : [https://support.frappe.io/helpdesk/tickets/60847](https://support.frappe.io/helpdesk/tickets/60847)
