### PR TITLE
fix: restrict public workspace rename to Workspace Manager

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -112,6 +112,13 @@ class Workspace(Document):
 
 			self.app = get_module_app(self.module)
 
+	def before_rename(self, old_name, new_name, merge=False):
+		if self.public and not is_workspace_manager() and not disable_saving_as_public():
+			frappe.throw(
+				_("You need to be {0} to rename this document").format(frappe.bold("Workspace Manager")),
+				frappe.PermissionError,
+			)
+
 	def clear_cache(self):
 		super().clear_cache()
 		if self.for_user:

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -117,6 +117,7 @@ class Workspace(Document):
 			frappe.throw(
 				_("You need to be {0} to rename this document").format(frappe.bold("Workspace Manager")),
 				frappe.PermissionError,
+				title=_("Permission Error"),
 			)
 
 	def clear_cache(self):


### PR DESCRIPTION
Fixes: #38140

---


https://github.com/user-attachments/assets/969640f6-5b85-49a5-b874-b3db37660f6d



