### PR TITLE
fix: reduce z-index onboarding widget

### DIFF
--- a/frappe/public/js/frappe/ui/user_onboarding/user_onboarding.bundle.js
+++ b/frappe/public/js/frappe/ui/user_onboarding/user_onboarding.bundle.js
@@ -80,7 +80,7 @@ function addStyles() {
 		border-radius: 8px;
 		box-shadow: 0 12px 40px rgba(0,0,0,0.15);
 		padding: 16px;
-		z-index: 9999;
+		z-index: 1000;
 		display: flex;
 		flex-direction: column;
 	  }


### PR DESCRIPTION
Before

<img width="1258" height="722" alt="Screenshot 2026-03-23 at 2 03 46 PM" src="https://github.com/user-attachments/assets/95cabca8-06e3-423b-bc41-23e77ab01de9" />


After

<img width="1440" height="760" alt="Screenshot 2026-03-23 at 2 03 06 PM" src="https://github.com/user-attachments/assets/950e989a-69f1-48b0-bc5d-c98468088a41" />

Seeing 2 things highlighted in backdrop is wrong