### PR TITLE
fix: remove links from filters in report print pdf

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1722,7 +1722,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				if (docfield.fieldtype === "Check") {
 					display_value = this.boolean_labels[cint(value)];
 				} else {
-					display_value = frappe.format(value, docfield);
+					display_value = frappe.format(value, docfield, { for_print: true });
 				}
 
 				return `<div class="filter-row">


### PR DESCRIPTION
<img width="1045" height="468" alt="Screenshot 2026-03-23 at 3 01 49 PM" src="https://github.com/user-attachments/assets/bfc4c8b2-d63a-48be-b61b-864537d5ef58" />


closes frappe/erpnext#53437
