### PR TITLE
fix(kanban_view): fix routing when switching kanban board

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -28,6 +28,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 
 	show() {
 		frappe.views.KanbanView.get_kanbans(this.doctype).then((kanbans) => {
+			frappe.route_options = {};
 			if (!kanbans.length) {
 				return frappe.views.KanbanView.show_kanban_dialog(this.doctype, true);
 			} else if (kanbans.length && frappe.get_route().length !== 4) {


### PR DESCRIPTION
This PR focuses on resolving a bug in Kanban View reported in Ticket #63280.

**Fix 1**:

When switching kanban board view, filters are not cleared i.e. query params. persist when switching boards, this in turn causes the new view to look like it has unsaved changes i.e (Not Saved State). Instead query params. should be cleared on switch.

**Problem exists on both V15 and V16.**

**Before**:

https://github.com/user-attachments/assets/a1df8253-8065-4495-a9d7-614318c7107a


**After**:

https://github.com/user-attachments/assets/69e5a560-02f1-4576-a592-cb66d00e9bf8


closes Ticket #63280
