### PR TITLE
fix: dont show session defaults they are empty

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -287,6 +287,7 @@ frappe.Application = class Application {
 		} else {
 			this.set_as_guest();
 		}
+		frappe.ui.toolbar.fetch_session_defaults();
 	}
 
 	setup_workspaces() {
@@ -377,17 +378,15 @@ frappe.Application = class Application {
 	logout() {
 		var me = this;
 		me.logged_out = true;
-		frappe.confirm(__("Are you sure you want to log out?"), function () {
-			return frappe.call({
-				method: "logout",
-				callback: function (r) {
-					if (r.exc) {
-						return;
-					}
+		return frappe.call({
+			method: "logout",
+			callback: function (r) {
+				if (r.exc) {
+					return;
+				}
 
-					me.redirect_to_login();
-				},
-			});
+				me.redirect_to_login();
+			},
 		});
 	}
 	handle_session_expired() {

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -60,6 +60,9 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 					label: "Session Defaults",
 					action: "frappe.ui.toolbar.setup_session_defaults()",
 					is_standard: 1,
+					condition: function () {
+						return frappe.boot.session_defaults.length != 0;
+					},
 					icon: "sliders-horizontal",
 				},
 				{

--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -279,63 +279,60 @@ frappe.ui.toolbar.view_website = function () {
 	website_tab.location = "/index";
 };
 
-frappe.ui.toolbar.setup_session_defaults = function () {
-	let fields = [];
+frappe.ui.toolbar.fetch_session_defaults = function () {
 	frappe.call({
 		method: "frappe.core.doctype.session_default_settings.session_default_settings.get_session_default_values",
 		callback: function (data) {
-			fields = JSON.parse(data.message);
-			let perms = frappe.perm.get_perm("Session Default Settings");
-			//add settings button only if user is a System Manager or has permission on 'Session Default Settings'
-			if (frappe.user_roles.includes("System Manager") || perms[0].read == 1) {
-				fields[fields.length] = {
-					fieldname: "settings",
-					fieldtype: "Button",
-					label: __("Settings"),
-					click: () => {
-						frappe.set_route(
-							"Form",
-							"Session Default Settings",
-							"Session Default Settings"
-						);
-					},
-				};
-			}
-			frappe.prompt(
-				fields,
-				function (values) {
-					//if default is not set for a particular field in prompt
-					fields.forEach(function (d) {
-						if (!values[d.fieldname]) {
-							values[d.fieldname] = "";
-						}
-					});
-					frappe.call({
-						method: "frappe.core.doctype.session_default_settings.session_default_settings.set_session_default_values",
-						args: {
-							default_values: values,
-						},
-						callback: function (data) {
-							if (data.message == "success") {
-								frappe.show_alert({
-									message: __("Session Defaults Saved"),
-									indicator: "green",
-								});
-								frappe.ui.toolbar.clear_cache();
-							} else {
-								frappe.show_alert({
-									message: __(
-										"An error occurred while setting Session Defaults"
-									),
-									indicator: "red",
-								});
-							}
-						},
-					});
-				},
-				__("Session Defaults"),
-				__("Save")
-			);
+			frappe.boot.session_defaults = JSON.parse(data.message);
 		},
 	});
+};
+
+frappe.ui.toolbar.setup_session_defaults = function () {
+	let perms = frappe.perm.get_perm("Session Default Settings");
+	let fields = frappe.boot.session_defaults;
+	//add settings button only if user is a System Manager or has permission on 'Session Default Settings'
+	if (frappe.user_roles.includes("System Manager") || perms[0].read == 1) {
+		fields[fields.length] = {
+			fieldname: "settings",
+			fieldtype: "Button",
+			label: __("Settings"),
+			click: () => {
+				frappe.set_route("Form", "Session Default Settings", "Session Default Settings");
+			},
+		};
+	}
+	frappe.prompt(
+		fields,
+		function (values) {
+			//if default is not set for a particular field in prompt
+			fields.forEach(function (d) {
+				if (!values[d.fieldname]) {
+					values[d.fieldname] = "";
+				}
+			});
+			frappe.call({
+				method: "frappe.core.doctype.session_default_settings.session_default_settings.set_session_default_values",
+				args: {
+					default_values: values,
+				},
+				callback: function (data) {
+					if (data.message == "success") {
+						frappe.show_alert({
+							message: __("Session Defaults Saved"),
+							indicator: "green",
+						});
+						frappe.ui.toolbar.clear_cache();
+					} else {
+						frappe.show_alert({
+							message: __("An error occurred while setting Session Defaults"),
+							indicator: "red",
+						});
+					}
+				},
+			});
+		},
+		__("Session Defaults"),
+		__("Save")
+	);
 };


### PR DESCRIPTION
On a site if only framework is installed, session defaults are empty by default and we need to hide them.
This PR does that. It first checks if session defaults fields exist and then shows the option in men

When only framework is installed
<img width="244" height="388" alt="Screenshot 2026-03-24 at 1 22 47 AM" src="https://github.com/user-attachments/assets/8fca4c1b-019a-495c-aadc-9f0758eb7fd3" />

When ERPNext is also installed

https://github.com/user-attachments/assets/0d45c948-1fe9-4c09-9238-a29010578bca

