### PR TITLE
fix(boilerplate): add apt dependencies section for Frappe Cloud

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -359,9 +359,7 @@ build-backend = "flit_core.buildapi"
 
 # These apt dependencies will be installed from Ubuntu repositories when you host your app on Frappe Cloud
 [deploy.dependencies.apt]
-packages = [
-    "hello",
-]
+packages = []
 
 [tool.ruff]
 line-length = 110

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -357,6 +357,12 @@ build-backend = "flit_core.buildapi"
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"
 
+# These apt dependencies will be installed from Ubuntu repositories when you host your app on Frappe Cloud
+[deploy.dependencies.apt]
+packages = [
+    "hello",
+]
+
 [tool.ruff]
 line-length = 110
 target-version = "py314"


### PR DESCRIPTION
A common question we receive from Frappe Cloud users is how to add Ubuntu APT dependencies for their app. This change introduces a dedicated section in the `pyproject.toml` boilerplate for that purpose.