### PR TITLE
fix: update user allowed reports cache after insert and trash to reflect updated report list in select report dropdown

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -85,9 +85,6 @@ class Report(Document):
 	def before_insert(self):
 		self.set_doctype_roles()
 
-	def after_insert(self):
-		self.update_report_cache()
-
 	def on_update(self):
 		self.export_doc()
 
@@ -109,8 +106,9 @@ class Report(Document):
 
 		delete_custom_role("report", self.name)
 
-	def after_delete(self):
+	def clear_cache(self):
 		self.update_report_cache()
+		return super().clear_cache()
 
 	def update_report_cache(self):
 		from frappe.boot import get_allowed_reports

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -85,6 +85,9 @@ class Report(Document):
 	def before_insert(self):
 		self.set_doctype_roles()
 
+	def after_insert(self):
+		self.update_report_cache()
+
 	def on_update(self):
 		self.export_doc()
 
@@ -105,6 +108,19 @@ class Report(Document):
 				frappe.db.after_commit(self.delete_report_folder)
 
 		delete_custom_role("report", self.name)
+
+	def after_delete(self):
+		self.update_report_cache()
+
+	def update_report_cache(self):
+		from frappe.boot import get_allowed_reports
+
+		fresh_reports = get_allowed_reports()
+
+		bootinfo = frappe.cache.hget("bootinfo", frappe.session.user)
+		if bootinfo and bootinfo.get("user"):
+			bootinfo["user"]["all_reports"] = fresh_reports
+			frappe.cache.hset("bootinfo", frappe.session.user, bootinfo)
 
 	def delete_report_folder(self):
 		from frappe.modules.export_file import delete_folder

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -111,14 +111,7 @@ class Report(Document):
 		return super().clear_cache()
 
 	def update_report_cache(self):
-		from frappe.boot import get_allowed_reports
-
-		fresh_reports = get_allowed_reports()
-
-		bootinfo = frappe.cache.hget("bootinfo", frappe.session.user)
-		if bootinfo and bootinfo.get("user"):
-			bootinfo["user"]["all_reports"] = fresh_reports
-			frappe.cache.hset("bootinfo", frappe.session.user, bootinfo)
+		frappe.cache.delete_key("bootinfo")
 
 	def delete_report_folder(self):
 		from frappe.modules.export_file import delete_folder

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -413,23 +413,20 @@ result = [
 		frappe.set_user("test@example.com")
 
 		try:
-			bootinfo = get_bootinfo()
-			frappe.cache.hset("bootinfo", frappe.session.user, bootinfo)
-
 			report_name = _save_report(
 				"Test Cache Invalidation Report",
 				"User",
 				json.dumps([{"fieldname": "email", "fieldtype": "Data", "label": "Email"}]),
 			)
 
-			cached_bootinfo = frappe.cache.hget("bootinfo", frappe.session.user)
-			self.assertIn(report_name, cached_bootinfo["user"]["all_reports"])
+			bootinfo = get_bootinfo()
+			self.assertIn(report_name, bootinfo["user"]["all_reports"])
 
 			doc = frappe.get_doc("Report", report_name)
 			delete_report(doc.name)
 
-			cached_bootinfo = frappe.cache.hget("bootinfo", frappe.session.user)
-			self.assertNotIn(report_name, cached_bootinfo["user"]["all_reports"])
+			bootinfo = get_bootinfo()
+			self.assertNotIn(report_name, bootinfo["user"]["all_reports"])
 
 		finally:
 			frappe.set_user("Administrator")

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -406,3 +406,30 @@ result = [
 		self.assertEqual(result[-1][0], "Total")
 		self.assertEqual(result[-1][1], 200)
 		self.assertEqual(result[-1][2], 150.50)
+
+	def test_report_cache_invalidation(self):
+		from frappe.boot import get_bootinfo
+
+		frappe.set_user("test@example.com")
+
+		try:
+			bootinfo = get_bootinfo()
+			frappe.cache.hset("bootinfo", frappe.session.user, bootinfo)
+
+			report_name = _save_report(
+				"Test Cache Invalidation Report",
+				"User",
+				json.dumps([{"fieldname": "email", "fieldtype": "Data", "label": "Email"}]),
+			)
+
+			cached_bootinfo = frappe.cache.hget("bootinfo", frappe.session.user)
+			self.assertIn(report_name, cached_bootinfo["user"]["all_reports"])
+
+			doc = frappe.get_doc("Report", report_name)
+			delete_report(doc.name)
+
+			cached_bootinfo = frappe.cache.hget("bootinfo", frappe.session.user)
+			self.assertNotIn(report_name, cached_bootinfo["user"]["all_reports"])
+
+		finally:
+			frappe.set_user("Administrator")

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -408,25 +408,30 @@ result = [
 		self.assertEqual(result[-1][2], 150.50)
 
 	def test_report_cache_invalidation(self):
-		from frappe.boot import get_bootinfo
+		import frappe.sessions
+		from frappe.utils import set_request
 
 		frappe.set_user("test@example.com")
+		set_request(method="GET", path="/app")
 
 		try:
+			frappe.sessions.get()
+
 			report_name = _save_report(
 				"Test Cache Invalidation Report",
 				"User",
 				json.dumps([{"fieldname": "email", "fieldtype": "Data", "label": "Email"}]),
 			)
 
-			bootinfo = get_bootinfo()
-			self.assertIn(report_name, bootinfo["user"]["all_reports"])
+			cached_bootinfo = frappe.sessions.get()
+			self.assertIn(report_name, cached_bootinfo["user"]["all_reports"])
 
 			doc = frappe.get_doc("Report", report_name)
 			delete_report(doc.name)
 
-			bootinfo = get_bootinfo()
-			self.assertNotIn(report_name, bootinfo["user"]["all_reports"])
+			cached_bootinfo = frappe.sessions.get()
+			self.assertNotIn(report_name, cached_bootinfo["user"]["all_reports"])
 
 		finally:
+			frappe.local.request = None
 			frappe.set_user("Administrator")


### PR DESCRIPTION
Report List doesn't get updated after saving a new report or deleting one because user permitted reports are cached (fetched in bootinfo) so when adding or deleting a report, the cache isn't updated and the outdated list is fetched.

When new report is created via save, it doesn't show up in dropdown:

https://github.com/user-attachments/assets/b81ae75e-733f-49e3-9ebf-5ed6f9a4f555

When a report is deleted in report list, it still shows up in dropdown:

https://github.com/user-attachments/assets/46347c05-fdfb-46b5-b04f-042175ebddba


Fixed (Only fetch user permitted reports and update them in cache):

https://github.com/user-attachments/assets/8e1858cf-0a50-4c55-9cde-8709b6c63bf5


https://github.com/user-attachments/assets/802ccfcb-333b-4463-aacb-3c1b8dff4f1d

