### PR TITLE
fix: `get_list` calls fail sometimes due to permlevel TypeError

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -672,7 +672,7 @@ class Meta(Document):
 
 	@cached_property
 	def high_permlevel_fields(self):
-		return [df for df in self.fields if df.permlevel > 0]
+		return [df for df in self.fields if (df.permlevel or 0) > 0]
 
 	def get_permitted_fieldnames(
 		self,


### PR DESCRIPTION
`get_list` calls fail when checking permlevel

<img width="1327" height="443" alt="error" src="https://github.com/user-attachments/assets/bd2f8cc8-54d3-4af1-9cb5-bdc3a527704c" />

<details>
<summary>Traceback</summary>

```python
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 60, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 52, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1127, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/client.py", line 66, in get_list
    validate_args(args)
  File "apps/frappe/frappe/desk/reportview.py", line 113, in validate_args
    validate_fields(data)
  File "apps/frappe/frappe/desk/reportview.py", line 148, in validate_fields
    if df.fieldname in [_df.fieldname for _df in meta.get_high_permlevel_fields()]:
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/meta.py", line 626, in get_high_permlevel_fields
    return self.high_permlevel_fields
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/__init__.py", line 1239, in __get__
    value = self.func(instance)
            ^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/meta.py", line 630, in high_permlevel_fields
    return [df for df in self.fields if df.permlevel > 0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/meta.py", line 630, in <listcomp>
    return [df for df in self.fields if df.permlevel > 0]
                                        ^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

</details>


permlevel for standard fields like "name" is None

<img width="953" height="318" alt="image" src="https://github.com/user-attachments/assets/9a549304-ce4e-4c78-9d48-5b500e055f96" />