### PR TITLE
fix: validate path in render_include

### DIFF
--- a/frappe/model/utils/__init__.py
+++ b/frappe/model/utils/__init__.py
@@ -57,6 +57,7 @@ class InvalidIncludePath(frappe.ValidationError):
 
 def render_include(content):
 	"""render {% raw %}{% include "app/path/filename" %}{% endraw %} in js file"""
+	import os
 
 	content = cstr(content)
 
@@ -69,7 +70,13 @@ def render_include(content):
 
 			for path in paths:
 				app, app_path = path.split("/", 1)
-				with open(frappe.get_app_path(app, app_path), encoding="utf-8") as f:
+
+				resolved_path = os.path.realpath(frappe.get_app_path(app, app_path))
+				app_root = os.path.realpath(frappe.get_app_path(app))
+				if not resolved_path.startswith(app_root + os.sep):
+					frappe.throw(frappe._("Security Error: The Path provided is not safe."))
+
+				with open(resolved_path, encoding="utf-8") as f:
 					include = f.read()
 					if path.endswith(".html"):
 						include = html_to_js_template(path, include)


### PR DESCRIPTION
Validate the parsed path in render_include by canonicalizing the path

closes Ticket #61834