### PR TITLE
fix: report view crash when removing group by after toggling chart

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -502,6 +502,11 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		// show chart if saved via report or user settings
 		if (!this.chart) {
 			if (this.chart_args) {
+				if (!this.chart_axes_valid(this.chart_args)) {
+					this.reset_chart_state();
+					return;
+				}
+
 				this.build_chart_args(
 					this.chart_args.x_axis,
 					this.chart_args.y_axes,
@@ -643,10 +648,28 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 	refresh_charts() {
 		if (!this.chart || !this.chart_args) return;
+
+		if (!this.chart_axes_valid(this.chart_args)) {
+			this.reset_chart_state();
+			return;
+		}
+
 		this.$charts_wrapper.removeClass("hidden");
 		const { x_axis, y_axes, chart_type } = this.chart_args;
 		this.build_chart_args(x_axis, y_axes, chart_type);
 		this.chart.update(this.chart_args);
+	}
+
+	chart_axes_valid(chart_args) {
+		const { x_axis, y_axes } = chart_args;
+		return this.columns_map[x_axis] && y_axes.every((y_axis) => this.columns_map[y_axis]);
+	}
+
+	reset_chart_state() {
+		this.chart = null;
+		this.chart_args = null;
+		this.$charts_wrapper.addClass("hidden");
+		this.save_view_user_settings({ chart_args: null });
 	}
 
 	get_editing_object(colIndex, rowIndex, value, parent) {


### PR DESCRIPTION
## Summary                                                                                                                                                       
                                                                  
  - Fixes Report View crash when removing Group By after configuring a chart                                                                                       
  - Adds `chart_axes_valid()` to validate chart axes exist in current columns before refresh
  - Adds `reset_chart_state()` to gracefully clear chart, hide wrapper, and purge saved settings                                                                   
  - Guards both `refresh_charts()` (runtime removal) and `init_chart()` (stale settings on page reload) 

## Before Fix
[Screencast from 2026-03-24 19-03-34.webm](https://github.com/user-attachments/assets/bae3c61c-c61c-4cc7-9fd2-80ff8bb3ce46)

## After Fix
[Screencast from 2026-03-24 19-17-33.webm](https://github.com/user-attachments/assets/84032e03-5456-4cc7-a94a-179828f5ac5b)

**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/63141](https://support.frappe.io/helpdesk/tickets/63141)