### PR TITLE
fix: reload Prepared Report before save to avoid TimestampMismatchError

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -141,7 +141,10 @@ def generate_report(prepared_report):
 	except Exception:
 		# we need to ensure that error gets stored
 		_save_error(instance, error=frappe.get_traceback(with_context=True))
+		return
 
+	instance.reload()
+	instance.status = "Completed"
 	instance.report_end_time = frappe.utils.now()
 	instance.peak_memory_usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
 	add_data_to_monitor(peak_memory_usage=instance.peak_memory_usage)


### PR DESCRIPTION
`generate_report` fails with `TimestampMismatchError` when saving the completed report.

**Root cause:**

`update_job_id()` updates the Prepared Report's `job_id` and `status` via `db.set_value()` + `commit()`, which updates the `modified` timestamp in DB. The subsequent `frappe.get_doc()` loads the doc, but can pick up a slightly different `modified` value (~50ms drift under load). When the report finishes and `instance.save()` is called, `check_if_latest()` detects the mismatch and raises `TimestampMismatchError`.

The report data is generated successfully but the save that updates status to "Completed" fails — leaving the report stuck in "Started" forever.

This is especially likely on sites with large datasets or concurrent users, where report generation takes minutes and the timing window is wider.

**Fix:**

1. Add `instance.reload()` before the success-path save to pick up the latest `modified` timestamp — mirroring what `_save_error` already does.
2. Add `return` after `_save_error()` to prevent falling through to a second `instance.save()` on the error path.

Ref: https://support.frappe.io/helpdesk/tickets/63479?view=VIEW-HD+Ticket-1252