### PR TITLE
ci: restrict review script

### DIFF
--- a/.github/workflows/review-po-prs.yml
+++ b/.github/workflows/review-po-prs.yml
@@ -3,6 +3,9 @@ name: Review translation PRs
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - develop
+      - "version-??-hotfix"
     paths:
       - "**/*.po"
 


### PR DESCRIPTION
Only run on PRs against hotfix/develop, not against main, which are typically release PRs.
