### PR TITLE
fix(link): fallback to meta for ignore_user_permissions in Link control

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -406,11 +406,20 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		const doctype = this.get_options();
 		if (!doctype) return;
 
+		const reference_doctype = this.get_reference_doctype() || "";
+		const docfield_parent =
+			this.df?.parent || reference_doctype || (this.frm && this.frm.doctype) || "";
+		const meta_df =
+			docfield_parent && this.df?.fieldname
+				? frappe.meta.get_docfield(docfield_parent, this.df.fieldname)
+				: null;
+
 		const args = {
 			txt,
 			doctype,
-			ignore_user_permissions: this.df.ignore_user_permissions,
-			reference_doctype: this.get_reference_doctype() || "",
+			ignore_user_permissions:
+				this.df?.ignore_user_permissions || meta_df?.ignore_user_permissions,
+			reference_doctype,
 			page_length: cint(frappe.boot.sysdefaults?.link_field_results_limit) || 10,
 			link_fieldname: this.df.fieldname,
 		};


### PR DESCRIPTION
This PR fixes Link field search behavior when ignore_user_permissions is missing on the runtime df object.

  - Adds fallback to DocField metadata via frappe.meta.get_docfield(...)
  - Resolves parent doctype safely from df.parent, reference doctype, or frm.doctype
  - Uses metadata value when df.ignore_user_permissions is undefined
  - Preserves existing behavior when runtime value is present

  This ensures Link autocomplete honors ignore_user_permissions when it is configured in metadata.

## Before Fix
[Screencast from 2026-03-25 13-18-20.webm](https://github.com/user-attachments/assets/8670a434-91a5-4538-bde7-d416a9f59bd6)


## After Fix
[Screencast from 2026-03-25 13-23-13.webm](https://github.com/user-attachments/assets/74d2bb54-2307-4068-a54f-ec25a85e3b75)

