### PR TITLE
fix: better button layout in report footer in windowed view

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -2267,9 +2267,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			this.page.main
 		);
 		if (this.tree_report) {
-			this.$tree_footer = $(`<div class="tree-footer col-md-3">
+			this.$tree_footer = $(`<div class="tree-footer col-md-12">
 				<div class="input-group">
-				  <input id="tree-level" type="number" class="form-control" style="width: 60px; border-right: 1px solid var(--border-color);" aria-label="Tree Level" value="2">
+				  <input id="tree-level" type="number" class="form-control" style="max-width: 120px; border-right: 1px solid var(--border-color);" aria-label="Tree Level" value="2">
 					<button class="btn btn-xs btn-secondary" style="border-top-left-radius: 0px; border-bottom-left-radius: 0px;" data-action="set_tree_level">
 						${__("Set Level")}</button>
 					<button class="btn btn-xs btn-secondary" data-action="expand_all_rows">


### PR DESCRIPTION
Before:
<img width="678" height="302" alt="Screenshot 2026-03-24 at 11 25 34 AM" src="https://github.com/user-attachments/assets/aca1a3f9-2a35-4b75-811e-ff5cc4b45c0d" />


After:

https://github.com/user-attachments/assets/ead2ab56-f42d-49b5-bffe-c8457ef137ae


