### PR TITLE
perf: skip bundle CSS when rendering PDFs via WeasyPrint

### DIFF
--- a/frappe/utils/weasyprint.py
+++ b/frappe/utils/weasyprint.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See LICENSE
 
+import re
+
 import click
 
 import frappe
@@ -106,6 +108,7 @@ class PrintFormatGenerator:
 
 		self.context.update({"header_height": self.header_height, "footer_height": self.footer_height})
 		main_html = self.get_main_html()
+		main_html = re.sub(r'<link[^>]+href="[^"]*print_format\.bundle[^"]*"[^>]*>', "", main_html)
 
 		html = HTML(string=main_html, base_url=self.base_url)
 		main_doc = html.render()


### PR DESCRIPTION
## Problem

Frappe PDFs load `print_format.bundle.css` - 229 KB of Bootstrap(in this example case, the actual size depends on content of PDF), Desk styles, dark mode, and animations; via a `<link>` tag in `print_format.html`. 
WeasyPrint fetches and parses this entire file on every render, even though PDFs only use the ~3 KB of inline `print_format.css` already in the same template.

---

## Why Not Remove from Template?

`print_format.html` is shared between two paths:

- **Browser preview** (`get_html_preview()`) - the bundle CSS is needed for screen styling
- **PDF generation** (`render_pdf()`) -  the bundle is unused

Removing it from the template would break the screen preview, so it must be stripped only in the PDF code path.

---

## Solution

Strip the `<link>` tag inside `render_pdf()` after the template renders but before
WeasyPrint sees the HTML. `get_main_html()` is left untouched so the browser preview
continues to receive the full HTML.

```python
# weasyprint.py — render_pdf()
main_html = self.get_main_html()
# Strip bundle CSS link — irrelevant for PDF rendering
main_html = re.sub(r'<link[^>]+href="[^"]*print_format\.bundle[^"]*"[^>]*>', "", main_html)
```

## Performance Impact

Measured (median of 3 runs):

- Render time: 169.5 ms → 52.6 ms (~3.2× faster)  
- CSS parsed by WeasyPrint: 229 KB → ~3 KB (~98.5% reduction)  
- Visual output: identical (page count and file size unchanged)  

---