### PR TITLE
ci: fix po review workflow

### DIFF
--- a/.github/workflows/review-po-prs.yml
+++ b/.github/workflows/review-po-prs.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/review-po-prs.yml
+++ b/.github/workflows/review-po-prs.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
     branches:
       - develop
-      - "version-[0-9][0-9]-hotfix"
     paths:
       - "**/*.po"
 


### PR DESCRIPTION
- run on `develop` branch only

    The helper script does not exist on other branches, but workflows from develop still run on all branches unless restricted.

- change permission to "pull-requests: write"

    This is apparently needed to be able to comment on PRs. Should resolve this error: https://github.com/frappe/frappe/actions/runs/23537955711/job/68517880302?pr=38246
