### PR TITLE
fix: login as first user after setup wizard completes

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -186,6 +186,13 @@ def run_setup_success(args):  # nosemgrep
 	for hook in frappe.get_hooks("setup_wizard_success"):
 		frappe.get_attr(hook)(args)
 	install_fixtures.install()
+	if not frappe.conf.developer_mode:
+		login_as_first_user(args)
+
+
+def login_as_first_user(args):
+	if args.get("email") and hasattr(frappe.local, "login_manager"):
+		frappe.local.login_manager.login_as(args.get("email"))
 
 
 def get_stages_hooks(args):  # nosemgrep


### PR DESCRIPTION
During the setup wizard, we ask for Full Name and Email to create the first user. But then we proceed to log in as Administrator, which defeats the purpose of asking this information.

So now, after the setup wizard completes successfully, we log in as the first user to give users the right experience.