### PR TITLE
fix(geo): display geolocation map in field

### DIFF
--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -26,6 +26,7 @@ frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.f
 
 		// show again on idempotent invocations
 		$(this.disp_area).removeClass("like-disabled-input");
+		$(this.disp_area).removeClass("hide");
 		$(this.disp_area).css("display", "block");
 
 		if (this.frm) {


### PR DESCRIPTION
Previously this was being hidden, this fixes that by displaying the map regardless as it should

**Before**:

<img width="2880" height="738" alt="image" src="https://github.com/user-attachments/assets/d631985f-f983-4932-af9d-eb85dd62a4d0" />


**After**:

<img width="2880" height="1560" alt="image" src="https://github.com/user-attachments/assets/25ffd552-3d81-4039-a63d-e28b82b8c7f5" />


closes Ticket #63263