### PR TITLE
fix: remove hover tooltip from mentions

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -393,7 +393,7 @@ def get_names_for_mentions(search_term: str):
 			continue
 
 		mention_data["link"] = frappe.utils.get_url_to_form(
-			"User Group" if mention_data.get("is_group") else "User Profile", mention_data["id"]
+			"User Group" if mention_data.get("is_group") else "User", mention_data["id"]
 		)
 
 		filtered_mentions.append(mention_data)

--- a/frappe/public/js/frappe/form/controls/quill-mention/quill.mention.js
+++ b/frappe/public/js/frappe/form/controls/quill-mention/quill.mention.js
@@ -158,7 +158,7 @@ class Mention {
 		return {
 			id: this.mentionList.childNodes[this.itemIndex].dataset.id,
 			value: itemLink
-				? `<a href="${itemLink}" target="_blank">${
+				? `<a class="mention-link" href="${itemLink}" target="_blank">${
 						this.mentionList.childNodes[this.itemIndex].dataset.value
 				  }`
 				: this.mentionList.childNodes[this.itemIndex].dataset.value,

--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -346,3 +346,7 @@
 .ql-bubble .ql-editor img {
 	max-width: 500px !important;
 }
+.mention-link::after,
+.mention-link::before {
+	display: none;
+}


### PR DESCRIPTION
Mentions in the comments had broken tooltip. Tooltip is not needed cause it just a link to the user directly which is pretty self explanatory.
Also it used to point to user profile form. in v15 changed it to just user

Video


https://github.com/user-attachments/assets/2ef4d2cd-420b-405c-97d4-8ef22345a342



