### PR TITLE
fix: make header sticky even when scrolling is disabled

### DIFF
--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -2,7 +2,6 @@
 	.frappe-list {
 		.result-container {
 			.result {
-				display: table;
 				min-width: 100%;
 				width: auto;
 				.list-row-container {
@@ -596,6 +595,8 @@ input.list-header-checkbox {
 			overflow-x: auto;
 			.result {
 				overflow-y: hidden;
+				display: table;
+				width: 100%;
 			}
 		}
 	}


### PR DESCRIPTION
Follow-up of https://github.com/frappe/frappe/pull/38282