### PR TITLE
fix(minor): center align sort and base filter

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -1364,7 +1364,7 @@ class FilterArea {
 	}
 
 	make_filter_list() {
-		$(`<div class="filter-selector">
+		$(`<div class="filter-selector flex align-items-center">
 			<div class="btn-group">
 				<button class="btn btn-default btn-sm filter-button">
 					<span class="filter-icon button-icon">

--- a/frappe/public/js/frappe/ui/sort_selector.html
+++ b/frappe/public/js/frappe/ui/sort_selector.html
@@ -1,4 +1,4 @@
-<div class="sort-selector">
+<div class="sort-selector flex align-items-center">
 	<div class="btn-group">
 		<button class="btn btn-default btn-sm btn-order"
 			data-value="{{ sort_order }}"


### PR DESCRIPTION

Before

<img width="1182" height="258" alt="Screenshot 2026-03-27 at 10 44 59 AM" src="https://github.com/user-attachments/assets/02597346-bf35-40f4-a1a2-cf9f3132cd14" />
After

<img width="1166" height="443" alt="Screenshot 2026-03-27 at 10 44 35 AM" src="https://github.com/user-attachments/assets/21501b1c-e404-4370-8d46-94b604e661ea" />