### PR TITLE
fix: prevent portal list pages from being cached

### DIFF
--- a/frappe/website/page_renderers/list_renderer.py
+++ b/frappe/website/page_renderers/list_renderer.py
@@ -26,5 +26,6 @@ class ListPage(TemplatePage):
 
 	def render(self):
 		frappe.form_dict.doctype = self.path
+		frappe.local.no_cache = 1
 		self.set_standard_path("portal")
 		return super().render()


### PR DESCRIPTION
## Problem: 

All portal list pages (/rfq, /supplier-quotations, etc.) shared the Redis cache key `website_page::portal`, causing one user's list to be served to another. Additionally, responses were sent with `Cache-Control: private,max-age=300,stale-while-revalidate=10800` even though these pages are user-specific and dynamic.

## Fix: 
`Set frappe.local.no_cache = 1` in `ListPage.render()` before the render chain runs. `can_cache()` already gates on this flag, so it blocks both the cache hit path (stale data served from Redis) and the miss path (write to Redis + aggressive headers). No changes to `cache_html` or` portal.py` needed.