### PR TITLE
chore(language): enabled language pt-BR by default

### DIFF
--- a/frappe/geo/languages.csv
+++ b/frappe/geo/languages.csv
@@ -59,7 +59,7 @@ no,Norsk,0
 pl,Polski,0
 ps,پښتو,0
 pt,Português,0
-pt-BR,Português Brasileiro,0
+pt-BR,Português Brasileiro,1
 ro,Română,0
 ru,Русский,0
 rw,Kinyarwanda,0


### PR DESCRIPTION
Enabled language pt-BR by default, so that it shows up in the language selection during Setup.

Closes https://github.com/frappe/erpnext/issues/53821