### PR TITLE
fix(desktop): show framework icon only for admins

### DIFF
--- a/frappe/desktop_icon/framework.json
+++ b/frappe/desktop_icon/framework.json
@@ -10,10 +10,18 @@
  "link": "/desk/build",
  "link_type": "External",
  "logo_url": "/assets/frappe/images/frappe-framework-logo.svg",
- "modified": "2025-12-12 07:36:09.059666",
+ "modified": "2026-03-29 13:53:49.960436",
  "modified_by": "Administrator",
  "name": "Framework",
  "owner": "Administrator",
- "roles": [],
+ "restrict_removal": 0,
+ "roles": [
+  {
+   "role": "Administrator"
+  },
+  {
+   "role": "System Manager"
+  }
+ ],
  "standard": 1
 }


### PR DESCRIPTION
Resolve: #37929

----

**Normal User View Before Fix**

<img width="1840" height="967" alt="image" src="https://github.com/user-attachments/assets/c860e897-2a39-4ee5-88d0-bb538113ab11" />

---

**Administrator and System Manager view:**

<img width="1847" height="957" alt="image" src="https://github.com/user-attachments/assets/3cc6e21a-1e0f-4fb5-b78e-77947dd7b77d" />

---

**Normal User After Fix**

<img width="1847" height="957" alt="image" src="https://github.com/user-attachments/assets/245b642f-186f-4405-bd2b-417d391bd7ec" />

