### PR TITLE
feat(boilerplate): add Vue frontend scaffold for Frappe apps

### DIFF
--- a/frappe/commands/test_commands.py
+++ b/frappe/commands/test_commands.py
@@ -220,6 +220,63 @@ class BaseTestCommands(IntegrationTestCase):
 
 
 class TestCommands(BaseTestCommands):
+	def test_make_app_forwards_cli_options(self):
+		with (
+			patch("frappe.commands.utils.get_sites", return_value=[]),
+			patch("frappe.utils.boilerplate.make_boilerplate") as make_boilerplate,
+		):
+			result = CliRunner().invoke(
+				frappe.commands.utils.make_app,
+				[
+					"apps",
+					"test_app",
+					"--no-git",
+					"--title",
+					"Test App",
+					"--description",
+					"Test app description",
+					"--publisher",
+					"Test Publisher",
+					"--email",
+					"example@example.org",
+					"--license",
+					"mit",
+					"--github-workflow",
+					"--frontend",
+					"--route",
+					"t",
+					"--branch",
+					"main",
+				],
+			)
+
+		self.assertEqual(result.exit_code, 0)
+		make_boilerplate.assert_called_once_with(
+			"apps",
+			"test_app",
+			no_git=True,
+			options={
+				"app_title": "Test App",
+				"app_description": "Test app description",
+				"app_publisher": "Test Publisher",
+				"app_email": "example@example.org",
+				"app_license": "mit",
+				"create_github_workflow": True,
+				"create_frontend": True,
+				"frontend_route": "t",
+				"branch_name": "main",
+			},
+		)
+
+	def test_make_app_frontend_route_requires_frontend(self):
+		result = CliRunner().invoke(
+			frappe.commands.utils.make_app,
+			["apps", "test_app", "--no-frontend", "--route", "t"],
+		)
+
+		self.assertEqual(result.exit_code, 2)
+		self.assertIn("--route cannot be used with --no-frontend", result.output)
+
 	def test_execute(self):
 		# test 1: execute a command expecting a numeric output
 		self.execute("bench --site {site} execute frappe.db.get_database_size")

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -11,7 +11,7 @@ from frappe import _
 from frappe.commands import get_site, pass_context
 from frappe.coverage import CodeCoverage
 from frappe.exceptions import SiteNotSpecifiedError
-from frappe.utils import cint, update_progress_bar
+from frappe.utils import cint, get_sites, get_sites_for_app, update_progress_bar
 from frappe.utils.bench_helper import CliCtxObj
 
 EXTRA_ARGS_CTX = {"ignore_unknown_options": True, "allow_extra_args": True}
@@ -804,19 +804,109 @@ def request(context: CliCtxObj, args=None, path=None):
 @click.argument("destination")
 @click.argument("app_name")
 @click.option("--no-git", is_flag=True, default=False, help="Do not initialize git repository for the app")
-def make_app(destination, app_name, no_git=False):
+@click.option("--title", "app_title", help="App title")
+@click.option("--description", "app_description", help="App description")
+@click.option("--publisher", "app_publisher", help="App publisher")
+@click.option("--email", "app_email", help="App email")
+@click.option("--license", "app_license", help="App license")
+@click.option(
+	"--github-workflow/--no-github-workflow",
+	"github_workflow",
+	default=None,
+	help="Create GitHub Workflow action for unittests",
+)
+@click.option(
+	"--frontend/--no-frontend",
+	"frontend",
+	default=None,
+	help="Create frappe-ui frontend",
+)
+@click.option("--route", help="Frontend route for SPA when creating a frontend")
+@click.option("--branch", "branch_name", help="Initial git branch name")
+def make_app(
+	destination,
+	app_name,
+	no_git=False,
+	app_title=None,
+	app_description=None,
+	app_publisher=None,
+	app_email=None,
+	app_license=None,
+	github_workflow=None,
+	frontend=None,
+	route=None,
+	branch_name=None,
+):
 	"Creates a boilerplate app"
-	from frappe.utils import get_sites
-
 	if app_name in get_sites():
 		click.secho(
 			f"Your bench has a site called {app_name}, please choose another name for the app.", fg="red"
 		)
 		sys.exit(1)
 
+	if route:
+		if frontend is False:
+			raise click.UsageError("--route cannot be used with --no-frontend")
+		if frontend is None:
+			frontend = True
+
 	from frappe.utils.boilerplate import make_boilerplate
 
-	make_boilerplate(destination, app_name, no_git=no_git)
+	make_boilerplate(
+		destination,
+		app_name,
+		no_git=no_git,
+		options={
+			"app_title": app_title,
+			"app_description": app_description,
+			"app_publisher": app_publisher,
+			"app_email": app_email,
+			"app_license": app_license,
+			"create_github_workflow": github_workflow,
+			"create_frontend": frontend,
+			"frontend_route": route,
+			"branch_name": branch_name,
+		},
+	)
+
+
+@click.command("add-frontend")
+@click.argument("app_name")
+@click.option("--framework", default="vue", help="Frontend framework to use (vue)")
+@click.option("--frontend-route", default=None, help="Frontend route for SPA")
+def add_frontend(app_name, framework="vue", frontend_route=None):
+	"Add frontend boilerplate to an existing app"
+
+	import os
+	import re
+	import sys
+	from frappe.utils.boilerplate import make_frontend_boilerplate
+
+	if not frontend_route:
+		default_route = app_name[0]
+		frontend_route = click.prompt("Frontend Route", default=default_route)
+
+	app_directory = os.path.join("..", "apps", app_name)
+	if not os.path.exists(app_directory):
+		click.secho(f"App {app_name} not found in apps directory", fg="red")
+		sys.exit(1)
+
+	app_title = app_name.replace("_", " ").title()
+	hooks_path = os.path.join(app_directory, app_name, "hooks.py")
+	if os.path.exists(hooks_path):
+		with open(hooks_path) as f:
+			content = f.read()
+			match = re.search(r'app_title\s*=\s*["\'](.*?)["\']', content)
+			if match:
+				app_title = match.group(1)
+
+	make_frontend_boilerplate(
+		app_directory=app_directory,
+		app_name=app_name,
+		app_title=app_title,
+		frontend_route=frontend_route,
+		framework=framework,
+	)
 
 
 @click.command("create-patch")
@@ -978,6 +1068,27 @@ def list_sites(context: CliCtxObj, output_json=False):
 		click.echo("No sites found")
 
 
+@click.command("list-app-sites")
+@click.argument("app_name")
+@click.option("--format", "output_format", type=click.Choice(["text", "json"]), default="text")
+@pass_context
+def list_app_sites(context: CliCtxObj, app_name: str, output_format: str):
+	"List sites in current bench where an app is installed."
+	sites = get_sites_for_app(app_name)
+
+	if output_format == "json":
+		click.echo(json.dumps(sites))
+		return
+
+	if not sites:
+		click.echo(f"No sites found with app '{app_name}' installed")
+		return
+
+	click.echo(f"Sites with app '{app_name}' installed:")
+	for site in sites:
+		click.echo(site)
+
+
 @click.command("setup-chrome")
 def setup_chrome():
 	from frappe.utils.print_utils import setup_chromium
@@ -1003,6 +1114,7 @@ commands = [
 	data_import,
 	import_doc,
 	make_app,
+	add_frontend,
 	create_patch,
 	mariadb,
 	sqlite,
@@ -1017,5 +1129,6 @@ commands = [
 	add_to_email_queue,
 	rebuild_global_search,
 	list_sites,
+	list_app_sites,
 	setup_chrome,
 ]

--- a/frappe/tests/test_boilerplate.py
+++ b/frappe/tests/test_boilerplate.py
@@ -8,6 +8,7 @@ import unittest
 from io import StringIO
 from unittest.mock import patch
 
+import click
 import git
 import yaml
 
@@ -33,8 +34,9 @@ class TestBoilerPlate(unittest.TestCase):
 				"app_publisher": "Test Publisher",
 				"app_email": "example@example.org",
 				"app_license": "mit",
-				"branch_name": "develop",
 				"create_github_workflow": False,
+				"create_frontend": False,
+				"branch_name": "develop",
 			}
 		)
 
@@ -45,6 +47,7 @@ class TestBoilerPlate(unittest.TestCase):
 			"example@example.org",  # email
 			"",  # license (accept default)
 			"",  # create github workflow (accept default)
+			"",  # create frontend (accept default)
 			"develop",  # branch name
 		]
 
@@ -110,6 +113,50 @@ class TestBoilerPlate(unittest.TestCase):
 
 	def test_valid_ci_yaml(self):
 		yaml.safe_load(github_workflow_template.format(**self.default_hooks))
+
+	def test_provided_values_skip_prompts(self):
+		provided_values = {
+			"app_title": self.default_hooks.app_title,
+			"app_description": self.default_hooks.app_description,
+			"app_publisher": self.default_hooks.app_publisher,
+			"app_email": self.default_hooks.app_email,
+			"app_license": self.default_hooks.app_license,
+			"create_github_workflow": self.default_hooks.create_github_workflow,
+			"create_frontend": self.default_hooks.create_frontend,
+			"branch_name": self.default_hooks.branch_name,
+		}
+
+		with patch("click.prompt") as prompt, patch("click.confirm") as confirm:
+			hooks = _get_user_inputs(self.default_hooks.app_name, provided_values=provided_values)
+
+		self.assertDictEqual(hooks, self.default_hooks)
+		prompt.assert_not_called()
+		confirm.assert_not_called()
+
+	def test_provided_frontend_values_skip_prompts(self):
+		provided_values = {
+			"app_title": self.default_hooks.app_title,
+			"app_description": self.default_hooks.app_description,
+			"app_publisher": self.default_hooks.app_publisher,
+			"app_email": self.default_hooks.app_email,
+			"app_license": self.default_hooks.app_license,
+			"create_github_workflow": self.default_hooks.create_github_workflow,
+			"create_frontend": True,
+			"frontend_route": "t",
+			"branch_name": self.default_hooks.branch_name,
+		}
+
+		with patch("click.prompt") as prompt, patch("click.confirm") as confirm:
+			hooks = _get_user_inputs(self.default_hooks.app_name, provided_values=provided_values)
+
+		self.assertTrue(hooks.create_frontend)
+		self.assertEqual(hooks.frontend_route, "t")
+		prompt.assert_not_called()
+		confirm.assert_not_called()
+
+	def test_invalid_provided_values_raise(self):
+		with self.assertRaises(click.BadParameter):
+			_get_user_inputs(self.default_hooks.app_name, provided_values={"app_email": "not-an-email"})
 
 	@unittest.skipUnless(
 		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -720,6 +720,35 @@ def get_sites(sites_path=None):
 	return sorted(sites)
 
 
+def get_sites_for_app(app_name: str) -> list[str]:
+	import frappe
+
+	bench_path = get_bench_path()
+	sites_path = os.path.join(bench_path, "sites")
+	matching_sites = []
+
+	for site in get_sites(sites_path=sites_path):
+		try:
+			frappe.init(site, sites_path=sites_path)
+			frappe.connect()
+
+			try:
+				installed_applications = frappe.get_single("Installed Applications").get("installed_applications") or []
+				installed_apps = [app.get("app_name") for app in installed_applications if app.get("app_name")]
+			except Exception:
+				installed_apps = frappe.get_installed_apps()
+
+			if app_name in installed_apps:
+				matching_sites.append(site)
+		except Exception:
+			continue
+		finally:
+			if getattr(frappe.local, "site", None):
+				frappe.destroy()
+
+	return matching_sites
+
+
 def get_request_session(max_retries=5):
 	import requests
 	from requests.adapters import HTTPAdapter, Retry

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -20,20 +20,21 @@ from frappe.utils.change_log import get_app_branch
 APP_TITLE_PATTERN = re.compile(r"^(?![\W])[^\d_\s][\w -]+$", flags=re.UNICODE)
 
 
-def make_boilerplate(dest, app_name, no_git=False):
+def make_boilerplate(dest, app_name, no_git=False, options=None):
 	if not os.path.exists(dest):
 		print("Destination directory does not exist")
 		return
 
 	# app_name should be in snake_case
 	app_name = frappe.scrub(app_name)
-	hooks = _get_user_inputs(app_name)
+	hooks = _get_user_inputs(app_name, provided_values=options)
 	_create_app_boilerplate(dest, hooks, no_git=no_git)
 
 
-def _get_user_inputs(app_name):
+def _get_user_inputs(app_name, provided_values=None):
 	"""Prompt user for various inputs related to new app and return config."""
 	app_name = frappe.scrub(app_name)
+	provided_values = provided_values or {}
 
 	hooks = frappe._dict()
 	hooks.app_name = app_name
@@ -58,10 +59,19 @@ def _get_user_inputs(app_name):
 			"default": False,
 			"type": bool,
 		},
+		"create_frontend": {
+			"prompt": "Create frappe-ui frontend",
+			"default": False,
+			"type": bool,
+		},
 		"branch_name": {"prompt": "Branch Name", "default": get_app_branch("frappe")},
 	}
 
 	for property, config in new_app_config.items():
+		if provided_values.get(property) is not None:
+			hooks[property] = _validate_input(property, provided_values[property], config)
+			continue
+
 		value = None
 		input_type = config.get("type", str)
 
@@ -76,7 +86,27 @@ def _get_user_inputs(app_name):
 					value = None
 		hooks[property] = value
 
+	if hooks.create_frontend:
+		frontend_route = provided_values.get("frontend_route")
+		if frontend_route is None:
+			default_route = hooks.app_name[0]
+			frontend_route = click.prompt("Frontend Route", default=default_route)
+		hooks.frontend_route = frontend_route
+
 	return hooks
+
+
+def _validate_input(property, value, config):
+	input_type = config.get("type", str)
+
+	if isinstance(input_type, click.ParamType):
+		value = input_type.convert(value, param=None, ctx=None)
+
+	if validator_function := config.get("validator"):
+		if not validator_function(value):
+			raise click.BadParameter(f"Invalid value for {property.replace('_', ' ')}")
+
+	return value
 
 
 def is_valid_email(email) -> bool:
@@ -201,9 +231,20 @@ def _create_app_boilerplate(dest, hooks, no_git=False):
 	with open(os.path.join(dest, hooks.app_name, "README.md"), "w") as f:
 		f.write(frappe.as_unicode(readme_template.format(**hooks)))
 
+	if hooks.get("create_frontend"):
+		make_frontend_boilerplate(
+			app_directory=app_directory,
+			app_name=hooks.app_name,
+			app_title=hooks.app_title,
+			frontend_route=hooks.frontend_route,
+		)
+
 	if not no_git:
 		with open(os.path.join(dest, hooks.app_name, ".gitignore"), "w") as f:
 			f.write(frappe.as_unicode(gitignore_template.format(app_name=hooks.app_name)))
+
+		if hooks.get("create_frontend"):
+			_append_frontend_gitignore(app_directory, hooks.app_name, hooks.frontend_route)
 
 		# initialize git repository
 		app_repo = git.Repo.init(app_directory, initial_branch=hooks.branch_name)
@@ -211,6 +252,143 @@ def _create_app_boilerplate(dest, hooks, no_git=False):
 		app_repo.index.commit("feat: Initialize App")
 
 	print(f"'{hooks.app_name}' created at {app_directory}")
+
+
+def make_frontend_boilerplate(app_directory, app_name, app_title, frontend_route, framework="vue"):
+	"""Generate a frappe-ui frontend scaffold for a Frappe app.
+
+	Creates a `frontend/` directory with Vue 3 + Vite + TailwindCSS + frappe-ui + TypeScript,
+	a sidebar layout, and working ToDo CRUD operations.
+
+	Args:
+	        app_directory: Absolute path to the app root (e.g., /path/to/apps/my_app)
+	        app_name: Snake-case app name (e.g., my_app)
+	        app_title: Human-readable app title (e.g., My App)
+	        frontend_route: URL route for the SPA (e.g., 'm')
+	        framework: UI framework to use ('vue' for now, 'react'/'solid' in future)
+	"""
+	if framework != "vue":
+		click.echo(f"Framework '{framework}' is not yet supported. Only 'vue' is available.")
+		return
+
+	frontend_dir = os.path.join(app_directory, "frontend")
+
+	try:
+		res = requests.get("https://registry.npmjs.org/frappe-ui/latest", timeout=5)
+		frappe_ui_version = res.json().get("version", "latest")
+	except Exception:
+		frappe_ui_version = "latest"
+
+	template_vars = {
+		"app_name": app_name,
+		"app_title": app_title,
+		"frontend_route": frontend_route,
+		"frappe_ui_version": frappe_ui_version,
+	}
+
+	boilerplate_dir = os.path.join(os.path.dirname(__file__), "frontend_boilerplate", framework)
+	if not os.path.exists(boilerplate_dir):
+		click.echo(f"Framework '{framework}' boilerplate not found.")
+		return
+
+	for root, dirs, files in os.walk(boilerplate_dir):
+		for d in dirs:
+			relative_dir = os.path.relpath(os.path.join(root, d), boilerplate_dir)
+			if relative_dir.startswith("www"):
+				target_dir = os.path.join(app_directory, app_name, "www")
+			else:
+				target_dir = os.path.join(frontend_dir, relative_dir)
+			frappe.create_folder(target_dir)
+
+		for f in files:
+			src_path = os.path.join(root, f)
+			relative_path = os.path.relpath(src_path, boilerplate_dir)
+
+			if relative_path.startswith("www" + os.sep) or relative_path.startswith("www/"):
+				file_name = f.replace("frontend_route", frontend_route)
+				target_path = os.path.join(app_directory, app_name, "www", file_name)
+			elif relative_path == "root_package.json":
+				target_path = os.path.join(app_directory, "package.json")
+			else:
+				target_path = os.path.join(frontend_dir, relative_path)
+
+			if not os.path.exists(os.path.dirname(target_path)):
+				frappe.create_folder(os.path.dirname(target_path))
+
+			with open(src_path) as src_file:
+				content = src_file.read()
+
+			import jinja2
+			rendered_content = jinja2.Template(content).render(template_vars)
+
+			with open(target_path, "w") as target_file:
+				target_file.write(rendered_content)
+
+	# --- Update hooks.py and .gitignore ---
+	_append_website_route_rules(app_directory, app_name, frontend_route)
+	_append_frontend_gitignore(app_directory, app_name, frontend_route)
+
+	display_cwd = os.path.abspath(os.environ.get("PWD") or os.getcwd())
+	frontend_dir_display = os.path.relpath(os.path.abspath(frontend_dir), display_cwd)
+
+	click.echo()
+	click.secho("Frontend scaffold ready", fg="green")
+	click.echo(f"  Path: {frontend_dir_display}")
+	click.echo("  Next steps:")
+	click.echo(f"    cd {frontend_dir_display}")
+	click.echo("    yarn install")
+	click.echo("    yarn dev")
+
+
+def _append_website_route_rules(app_directory, app_name, frontend_route):
+	"""Append website_route_rules to the app's hooks.py for SPA routing."""
+	hooks_path = os.path.join(app_directory, app_name, "hooks.py")
+	with open(hooks_path) as f:
+		content = f.read()
+
+	route_rule = f'{{"from_route": "/{frontend_route}/<path:app_path>", "to_route": "{frontend_route}"}}'
+
+	if "website_route_rules" not in content:
+		route_rules_block = f"\nwebsite_route_rules = [\n\t{route_rule},\n]\n"
+		with open(hooks_path, "a") as f:
+			f.write(route_rules_block)
+	else:
+		if route_rule in content:
+			click.echo(f"Route rule for /{frontend_route} already exists in hooks.py, skipping...")
+			return
+
+		import re
+
+		match = re.search(r"website_route_rules\s*=\s*\[", content)
+		if match:
+			content = content[:match.end()] + f"\n\t{route_rule}," + content[match.end():]
+			with open(hooks_path, "w") as f:
+				f.write(content)
+			click.echo(f"Added route rule for /{frontend_route} to existing website_route_rules in hooks.py")
+		else:
+			click.secho("Could not properly parse existing website_route_rules list. Please add the route manually.", fg="yellow")
+
+
+def _append_frontend_gitignore(app_directory, app_name, frontend_route):
+	"""Append frontend build output patterns to the app's .gitignore."""
+	gitignore_path = os.path.join(app_directory, ".gitignore")
+
+	entries = [
+		f"\n# Frontend build outputs",
+		f"{app_name}/public/frontend/",
+		f"{app_name}/www/{frontend_route}.html",
+	]
+
+	if os.path.exists(gitignore_path):
+		with open(gitignore_path) as f:
+			content = f.read()
+		new_entries = [e for e in entries if e not in content]
+		if new_entries:
+			with open(gitignore_path, "a") as f:
+				f.write("\n".join(new_entries) + "\n")
+	else:
+		with open(gitignore_path, "w") as f:
+			f.write("\n".join(entries) + "\n")
 
 
 def _create_github_workflow_files(dest, hooks):

--- a/frappe/utils/frontend_boilerplate/vue/.gitignore
+++ b/frappe/utils/frontend_boilerplate/vue/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/frappe/utils/frontend_boilerplate/vue/.prettierrc.json
+++ b/frappe/utils/frontend_boilerplate/vue/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/frappe/utils/frontend_boilerplate/vue/index.html
+++ b/frappe/utils/frontend_boilerplate/vue/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html class="h-full" lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <title>{{ app_title }}</title>
+  </head>
+  <body class="h-full">
+    <div id="app" class="h-full"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frappe/utils/frontend_boilerplate/vue/package.json
+++ b/frappe/utils/frontend_boilerplate/vue/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "{{ app_name }}-ui",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "frappe-ui": "^{{ frappe_ui_version }}",
+    "vue": "^3.5.13",
+    "vue-router": "^4.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.19.4",
+    "@vitejs/plugin-vue": "^6.0.5",
+    "autoprefixer": "^10.4.2",
+    "postcss": "^8.4.5",
+    "prettier": "^3.3.3",
+    "prettier-plugin-tailwindcss": "^0.6.8",
+    "tailwindcss": "^3.4.15",
+    "typescript": "^5.8.3",
+    "vite": "^8.0.1"
+  }
+}

--- a/frappe/utils/frontend_boilerplate/vue/postcss.config.js
+++ b/frappe/utils/frontend_boilerplate/vue/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frappe/utils/frontend_boilerplate/vue/root_package.json
+++ b/frappe/utils/frontend_boilerplate/vue/root_package.json
@@ -1,0 +1,12 @@
+{
+  "name": "{{ app_name }}",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "frontend:install": "cd frontend && yarn",
+    "postinstall": "npm run frontend:install",
+    "dev": "cd frontend && yarn dev",
+    "build": "cd frontend && yarn build",
+    "upgrade-frappeui": "cd frontend && yarn upgrade frappe-ui@latest"
+  }
+}

--- a/frappe/utils/frontend_boilerplate/vue/src/App.vue
+++ b/frappe/utils/frontend_boilerplate/vue/src/App.vue
@@ -1,0 +1,15 @@
+<template>
+  <FrappeUIProvider>
+    <router-view v-if="$route.name === 'Login'" />
+    <AppLayout v-else-if="session.isLoggedIn">
+      <router-view />
+    </AppLayout>
+    <router-view v-else />
+  </FrappeUIProvider>
+</template>
+
+<script setup lang="ts">
+import { FrappeUIProvider } from 'frappe-ui'
+import AppLayout from '@/components/AppLayout.vue'
+import { session } from '@/data/session'
+</script>

--- a/frappe/utils/frontend_boilerplate/vue/src/components/AppLayout.vue
+++ b/frappe/utils/frontend_boilerplate/vue/src/components/AppLayout.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="flex h-full">
+    <AppSidebar />
+    <main class="flex-1 overflow-auto bg-surface-white">
+      <slot />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import AppSidebar from './AppSidebar.vue'
+</script>

--- a/frappe/utils/frontend_boilerplate/vue/src/components/AppSidebar.vue
+++ b/frappe/utils/frontend_boilerplate/vue/src/components/AppSidebar.vue
@@ -1,0 +1,53 @@
+<template>
+  <nav class="flex h-full w-56 flex-shrink-0 flex-col border-r bg-surface-menu-bar">
+    <div class="flex items-center px-4 py-3">
+      <h1 class="text-lg font-semibold text-ink-gray-9">{{ app_title }}</h1>
+    </div>
+    <div class="flex-1 space-y-0.5 px-2">
+      <router-link
+        v-for="link in navigation"
+        :key="link.name"
+        :to="link.route"
+        class="flex items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition"
+        :class="[
+          isActive(link.activeRegex)
+            ? 'bg-surface-selected text-ink-gray-9 shadow-sm'
+            : 'text-ink-gray-7 hover:bg-surface-gray-2',
+        ]"
+      >
+        <component :is="link.icon" class="h-4 w-4 text-ink-gray-6" />
+        {% raw %}{{ link.name }}{% endraw %}
+      </router-link>
+    </div>
+    <div class="border-t px-3 py-3">
+      <div class="flex items-center justify-between">
+        <span class="truncate text-sm text-ink-gray-7">
+          {% raw %}{{ session.user }}{% endraw %}
+        </span>
+        <Button variant="ghost" size="sm" @click="session.logout.submit()">
+          <LucideLogOut class="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import { useRoute } from 'vue-router'
+import { session } from '@/data/session'
+
+const route = useRoute()
+
+const navigation = [
+  {
+    name: 'Home',
+    route: { name: 'Home' },
+    icon: 'LucideHome',
+    activeRegex: /Home/,
+  },
+]
+
+function isActive(regex: RegExp) {
+  return route.name ? regex.test(route.name.toString()) : false
+}
+</script>

--- a/frappe/utils/frontend_boilerplate/vue/src/data/session.ts
+++ b/frappe/utils/frontend_boilerplate/vue/src/data/session.ts
@@ -1,0 +1,37 @@
+import { computed, reactive, ref } from 'vue'
+import { useCall } from 'frappe-ui'
+import router from '@/router'
+
+export const sessionUser = ref<string | null>(getSessionUserFromCookie())
+
+export const session = reactive({
+  login: useCall({
+    url: '/api/v2/method/login',
+    immediate: false,
+    onSuccess(data: any) {
+      sessionUser.value = getSessionUserFromCookie()
+      session.login.reset()
+      router.replace(data.default_route || '/')
+    },
+  }),
+  logout: useCall({
+    url: '/api/v2/method/logout',
+    method: 'POST',
+    immediate: false,
+    onSuccess() {
+      sessionUser.value = getSessionUserFromCookie()
+      window.location.href = '/login'
+    },
+  }),
+  user: sessionUser,
+  isLoggedIn: computed(() => sessionUser.value != null),
+})
+
+function getSessionUserFromCookie(): string | null {
+  const cookies = new URLSearchParams(document.cookie.split('; ').join('&'))
+  let user = cookies.get('user_id')
+  if (user === 'Guest') {
+    user = null
+  }
+  return user
+}

--- a/frappe/utils/frontend_boilerplate/vue/src/data/todos.ts
+++ b/frappe/utils/frontend_boilerplate/vue/src/data/todos.ts
@@ -1,0 +1,24 @@
+import { useList, useDoc } from 'frappe-ui'
+import type { ToDo } from '@/types'
+
+export function useTodoList() {
+  return useList<ToDo>({
+    doctype: 'ToDo',
+    fields: ['name', 'description', 'status', 'priority', 'date', 'modified'],
+    orderBy: 'modified desc',
+    limit: 20,
+    immediate: true,
+  })
+}
+
+const todoCache: Record<string, ReturnType<typeof useDoc>> = {}
+
+export function useTodo(name: string) {
+  if (!todoCache[name]) {
+    todoCache[name] = useDoc<ToDo>({
+      doctype: 'ToDo',
+      name,
+    })
+  }
+  return todoCache[name] as ReturnType<typeof useDoc<ToDo>>
+}

--- a/frappe/utils/frontend_boilerplate/vue/src/index.css
+++ b/frappe/utils/frontend_boilerplate/vue/src/index.css
@@ -1,0 +1,5 @@
+@import 'frappe-ui/style.css';
+
+body {
+  -webkit-tap-highlight-color: transparent;
+}

--- a/frappe/utils/frontend_boilerplate/vue/src/main.ts
+++ b/frappe/utils/frontend_boilerplate/vue/src/main.ts
@@ -1,0 +1,56 @@
+import { createApp } from 'vue'
+import {
+  Button,
+  Input,
+  TextInput,
+  FormControl,
+  ErrorMessage,
+  Dialog,
+  Alert,
+  Badge,
+  frappeRequest,
+  setConfig,
+  pageMetaPlugin,
+  resourcesPlugin,
+  useCall,
+} from 'frappe-ui'
+import router from './router'
+import App from './App.vue'
+import './index.css'
+
+const globalComponents: Record<string, any> = {
+  Button,
+  TextInput,
+  Input,
+  FormControl,
+  ErrorMessage,
+  Dialog,
+  Alert,
+  Badge,
+}
+
+const app = createApp(App)
+
+setConfig('resourceFetcher', frappeRequest)
+app.use(resourcesPlugin)
+app.use(pageMetaPlugin)
+app.use(router)
+
+for (const key in globalComponents) {
+  app.component(key, globalComponents[key])
+}
+
+if (import.meta.env.DEV) {
+  useCall({
+    url: '/api/v2/method/{{ app_name }}.www.{{ frontend_route }}.get_context_for_dev',
+    method: 'POST',
+    onSuccess(values: Record<string, any>) {
+      for (const key in values) {
+        ;(window as any)[key] = values[key]
+      }
+      app.mount('#app')
+    },
+  })
+} else {
+  app.mount('#app')
+}

--- a/frappe/utils/frontend_boilerplate/vue/src/pages/Home.vue
+++ b/frappe/utils/frontend_boilerplate/vue/src/pages/Home.vue
@@ -1,0 +1,155 @@
+<template>
+  <div class="mx-auto max-w-3xl px-6 py-8">
+    <div class="mb-6 flex items-center justify-between">
+      <h1 class="text-2xl font-semibold text-ink-gray-9">ToDos</h1>
+      <Button variant="solid" @click="showNewDialog = true">
+        <template #prefix>
+          <LucidePlus class="h-4 w-4" />
+        </template>
+        New ToDo
+      </Button>
+    </div>
+
+    <div v-if="todos.data?.length" class="space-y-2">
+      <router-link
+        v-for="todo in todos.data"
+        :key="todo.name"
+        :to="{ name: 'TodoDetail', params: { id: todo.name } }"
+        class="flex items-center justify-between rounded-lg border bg-surface-white px-4 py-3 transition hover:bg-surface-gray-1"
+      >
+        <div class="flex items-center gap-3">
+          <button
+            class="flex h-5 w-5 items-center justify-center rounded border transition"
+            :class="[
+              todo.status === 'Closed'
+                ? 'border-green-600 bg-green-600'
+                : 'border-outline-gray-3 hover:border-outline-gray-5',
+            ]"
+            @click.prevent="toggleStatus(todo)"
+          >
+            <LucideCheck v-if="todo.status === 'Closed'" class="h-3.5 w-3.5 text-white" />
+          </button>
+          <span
+            class="text-sm"
+            :class="[
+              todo.status === 'Closed'
+                ? 'text-ink-gray-5 line-through'
+                : 'text-ink-gray-9',
+            ]"
+          >
+            {% raw %}{{ todo.description || 'Untitled' }}{% endraw %}
+          </span>
+        </div>
+        <div class="flex items-center gap-2">
+          <Badge
+            v-if="todo.priority"
+            :variant="'subtle'"
+            :theme="priorityColor(todo.priority)"
+            size="sm"
+          >
+            {% raw %}{{ todo.priority }}{% endraw %}
+          </Badge>
+          <button
+            class="rounded p-1 text-ink-gray-5 transition hover:bg-surface-gray-2 hover:text-ink-red-7"
+            @click.prevent="deleteTodo(todo.name)"
+          >
+            <LucideTrash2 class="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </router-link>
+    </div>
+
+    <div
+      v-else-if="!todos.loading"
+      class="flex flex-col items-center justify-center rounded-lg border border-dashed py-12 text-ink-gray-5"
+    >
+      <LucideListTodo class="mb-3 h-10 w-10 text-ink-gray-4" />
+      <p class="text-sm">No ToDos yet. Create one to get started.</p>
+    </div>
+
+    <Dialog v-model="showNewDialog" :options="{ title: 'New ToDo' }">
+      <template #body-content>
+        <div class="space-y-4">
+          <FormControl
+            label="Description"
+            v-model="newTodo.description"
+            type="textarea"
+            placeholder="What needs to be done?"
+          />
+          <FormControl
+            label="Priority"
+            v-model="newTodo.priority"
+            type="select"
+            :options="['Low', 'Medium', 'High']"
+          />
+        </div>
+      </template>
+      <template #actions>
+        <Button
+          variant="solid"
+          class="w-full"
+          @click="createTodo"
+          :loading="creating"
+        >
+          Create
+        </Button>
+      </template>
+    </Dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive } from 'vue'
+import { useTodoList } from '@/data/todos'
+
+const todos = useTodoList()
+const showNewDialog = ref(false)
+const creating = ref(false)
+
+const newTodo = reactive({
+  description: '',
+  priority: 'Medium',
+})
+
+function priorityColor(priority: string) {
+  switch (priority) {
+    case 'High':
+      return 'red'
+    case 'Medium':
+      return 'orange'
+    case 'Low':
+      return 'blue'
+    default:
+      return 'gray'
+  }
+}
+
+async function createTodo() {
+  creating.value = true
+  try {
+    await todos.insert.submit({
+      description: newTodo.description,
+      priority: newTodo.priority,
+      status: 'Open',
+    })
+    showNewDialog.value = false
+    newTodo.description = ''
+    newTodo.priority = 'Medium'
+    todos.reload()
+  } finally {
+    creating.value = false
+  }
+}
+
+async function toggleStatus(todo: any) {
+  const newStatus = todo.status === 'Closed' ? 'Open' : 'Closed'
+  todo.status = newStatus
+  await todos.setValue.submit({ name: todo.name, status: newStatus })
+  todos.reload()
+}
+
+async function deleteTodo(name: string) {
+  await todos.delete.submit({ name })
+  todos.reload()
+}
+</script>

--- a/frappe/utils/frontend_boilerplate/vue/src/pages/TodoDetail.vue
+++ b/frappe/utils/frontend_boilerplate/vue/src/pages/TodoDetail.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="mx-auto max-w-3xl px-6 py-8">
+    <div class="mb-6">
+      <router-link
+        :to="{ name: 'Home' }"
+        class="inline-flex items-center gap-1 text-sm text-ink-gray-5 transition hover:text-ink-gray-8"
+      >
+        <LucideArrowLeft class="h-4 w-4" />
+        Back to ToDos
+      </router-link>
+    </div>
+
+    <div v-if="todo.doc" class="space-y-6">
+      <div class="flex items-start justify-between">
+        <h1 class="text-2xl font-semibold text-ink-gray-9">
+          {% raw %}{{ todo.doc.description || 'Untitled ToDo' }}{% endraw %}
+        </h1>
+        <div class="flex items-center gap-2">
+          <Badge
+            :variant="'subtle'"
+            :theme="todo.doc.status === 'Closed' ? 'green' : 'orange'"
+            size="md"
+          >
+            {% raw %}{{ todo.doc.status }}{% endraw %}
+          </Badge>
+          <Button variant="ghost" theme="red" @click="onDelete">
+            <LucideTrash2 class="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div class="rounded-lg border bg-surface-white p-6">
+        <div class="space-y-4">
+          <FormControl
+            label="Description"
+            type="textarea"
+            :modelValue="todo.doc.description"
+            @update:modelValue="(val: string) => todo.setValue.submit({ description: val })"
+          />
+          <div class="grid grid-cols-2 gap-4">
+            <FormControl
+              label="Status"
+              type="select"
+              :options="['Open', 'Closed', 'Cancelled']"
+              :modelValue="todo.doc.status"
+              @update:modelValue="(val: string) => todo.setValue.submit({ status: val })"
+            />
+            <FormControl
+              label="Priority"
+              type="select"
+              :options="['Low', 'Medium', 'High']"
+              :modelValue="todo.doc.priority"
+              @update:modelValue="(val: string) => todo.setValue.submit({ priority: val })"
+            />
+          </div>
+          <FormControl
+            label="Due Date"
+            type="date"
+            :modelValue="todo.doc.date"
+            @update:modelValue="(val: string) => todo.setValue.submit({ date: val })"
+          />
+        </div>
+      </div>
+
+      <div class="text-xs text-ink-gray-5">
+        Last modified: {% raw %}{{ todo.doc.modified }}{% endraw %}
+      </div>
+    </div>
+
+    <div v-else-if="todo.loading" class="flex items-center justify-center py-12">
+      <div class="text-sm text-ink-gray-5">Loading...</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import { useTodo } from '@/data/todos'
+
+const props = defineProps<{
+  id: string
+}>()
+
+const router = useRouter()
+const todo = useTodo(props.id)
+
+async function onDelete() {
+  await todo.delete.submit()
+  router.push({ name: 'Home' })
+}
+</script>

--- a/frappe/utils/frontend_boilerplate/vue/src/router.ts
+++ b/frappe/utils/frontend_boilerplate/vue/src/router.ts
@@ -1,0 +1,32 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import { session } from './data/session'
+
+const router = createRouter({
+  history: createWebHistory(__FRONTEND_ROUTE__ + '/'),
+  routes: [
+    {
+      path: '/',
+      redirect: '/home',
+    },
+    {
+      path: '/home',
+      name: 'Home',
+      component: () => import('@/pages/Home.vue'),
+    },
+    {
+      path: '/todos/:id',
+      name: 'TodoDetail',
+      component: () => import('@/pages/TodoDetail.vue'),
+      props: true,
+    },
+  ],
+})
+
+router.beforeEach((to, from) => {
+  if (to.name !== 'Login' && !session.isLoggedIn) {
+    window.location.href = '/login'
+    return false
+  }
+})
+
+export default router

--- a/frappe/utils/frontend_boilerplate/vue/src/types/index.ts
+++ b/frappe/utils/frontend_boilerplate/vue/src/types/index.ts
@@ -1,0 +1,17 @@
+export interface ToDo {
+  name: string
+  description: string
+  status: 'Open' | 'Closed' | 'Cancelled'
+  priority: 'Low' | 'Medium' | 'High'
+  date: string | null
+  modified: string
+  owner: string
+}
+
+declare global {
+  interface Window {
+    csrf_token: string
+    site_name: string
+    frappe_version: string
+  }
+}

--- a/frappe/utils/frontend_boilerplate/vue/tailwind.config.js
+++ b/frappe/utils/frontend_boilerplate/vue/tailwind.config.js
@@ -1,0 +1,12 @@
+import frappeUIPreset from 'frappe-ui/tailwind'
+
+export default {
+  presets: [frappeUIPreset],
+  content: [
+    './index.html',
+    './src/**/*.{vue,js,ts,jsx,tsx}',
+    './node_modules/frappe-ui/src/components/**/*.{vue,js,ts,jsx,tsx}',
+    '../node_modules/frappe-ui/src/components/**/*.{vue,js,ts,jsx,tsx}',
+    '../frappe-ui/src/components/**/*.{vue,js,ts,jsx,tsx}',
+  ],
+}

--- a/frappe/utils/frontend_boilerplate/vue/tsconfig.json
+++ b/frappe/utils/frontend_boilerplate/vue/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "frappe-ui/tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["./src/**/*", "vite/client", "./vite.config.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
+}

--- a/frappe/utils/frontend_boilerplate/vue/vite.config.ts
+++ b/frappe/utils/frontend_boilerplate/vue/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import { resolve } from 'node:path'
+import frappeui from 'frappe-ui/vite'
+
+export default defineConfig({
+  plugins: [
+    frappeui({
+      frontendRoute: '/{{ frontend_route }}',
+      frappeTypes: {
+        input: {
+          frappe: ['todo'],
+        },
+      },
+    }),
+    vue(),
+  ],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+      'tailwind.config.js': resolve(__dirname, 'tailwind.config.js'),
+    },
+  },
+  optimizeDeps: {
+    include: ['tailwind.config.js'],
+  },
+})

--- a/frappe/utils/frontend_boilerplate/vue/www/frontend_route.html
+++ b/frappe/utils/frontend_boilerplate/vue/www/frontend_route.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html class="h-full" lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <title>{{ app_title }}</title>
+  </head>
+  <body class="h-full">
+    <div id="app" class="h-full"></div>
+    {% raw %}{%- for key in boot %}
+    <script>
+      window["{{ key }}"] = {{ boot[key] | tojson }};
+    </script>
+    {%- endfor %}{% endraw %}
+  </body>
+</html>

--- a/frappe/utils/frontend_boilerplate/vue/www/frontend_route.py
+++ b/frappe/utils/frontend_boilerplate/vue/www/frontend_route.py
@@ -1,0 +1,30 @@
+import frappe
+from frappe.utils import get_system_timezone
+
+no_cache = 1
+
+
+def get_context():
+	csrf_token = frappe.sessions.get_csrf_token()
+	frappe.db.commit()
+	context = frappe._dict()
+	context.boot = get_boot()
+	context.boot.csrf_token = csrf_token
+	return context
+
+
+@frappe.whitelist(methods=["POST"], allow_guest=True)
+def get_context_for_dev():
+	if not frappe.conf.developer_mode:
+		frappe.throw("This method is only meant for developer mode")
+	return get_boot()
+
+
+def get_boot():
+	return frappe._dict(
+		{
+			"frappe_version": frappe.__version__,
+			"site_name": frappe.local.site,
+			"system_timezone": get_system_timezone(),
+		}
+	)


### PR DESCRIPTION
Adds a Vue 3 + frappe-ui frontend scaffold for Frappe apps.

## Usage

### Create a new app with frontend
```bash
bench new-app my_app --frontend --route m
```

### Add frontend to an existing app
```bash
bench add-frontend my_app
```

Both commands generate a `frontend/` directory with Vite + Vue 3 + TypeScript + TailwindCSS + frappe-ui, session management, sidebar layout, Vue Router, and example ToDo CRUD pages using `useList` / `useDoc`. The app's `hooks.py` and `.gitignore` are updated automatically.

After scaffolding:
```bash
cd apps/my_app/frontend
yarn install
yarn dev
```

### List sites where an app is installed
```bash
bench list-app-sites my_app
```

## Related
bench PR: https://github.com/frappe/bench/pull/1706
