### PR TITLE
fix: Skip nulls in `client.get`

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -114,7 +114,7 @@ def get(
 	doc.check_permission()
 	doc.apply_fieldlevel_read_permissions()
 
-	return doc.as_dict()
+	return doc.as_dict(no_nulls=True)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
This makes it consistent with `load.getdoc`

Could be mildly breaking, maybe port it after some time?
