### PR TITLE
fix: remove `raw_html` and `add_css` params from sendmail

### DIFF
--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -145,8 +145,6 @@ def sendmail(
 	email_read_tracker_url=None,
 	x_priority: Literal[1, 3, 5] = 3,
 	email_headers=None,
-	raw_html=False,
-	add_css=True,
 ):
 	"""Send email using user's default **Email Account** or global default **Email Account**.
 
@@ -178,8 +176,6 @@ def sendmail(
 	    :param with_container: Wraps email inside a styled container
 	    :param x_priority: 1 = HIGHEST, 3 = NORMAL, 5 = LOWEST
 	    :param email_headers: Additional headers to be added in the email, e.g. {"X-Custom-Header": "value"} or {"Custom-Header": "value"}. Automatically prepends "X-" to the header name if not present.
-	    :param raw_html: Whether to treat email template as a complete HTML file
-	    :param add_css: Whether to add CSS from hooks/email_css to the email template
 	"""
 
 	from frappe.utils.jinja import get_email_from_template
@@ -239,8 +235,6 @@ def sendmail(
 		email_read_tracker_url=email_read_tracker_url,
 		x_priority=x_priority,
 		email_headers=email_headers,
-		raw_html=raw_html,
-		add_css=add_css,
 	)
 
 	# build email queue and send the email if send_now is True.


### PR DESCRIPTION
Resolve: #38223

----
these params were partially backported by mistake from #37194 without the related logic

original PR feature is:
- #34801