### PR TITLE
perf(query): replace Coalesce with OR IS NULL in func_in

### DIFF
--- a/frappe/database/operator_map.py
+++ b/frappe/database/operator_map.py
@@ -8,7 +8,6 @@ import frappe
 from frappe.database.utils import NestedSetHierarchy
 from frappe.model.db_query import get_timespan_date_range
 from frappe.query_builder import Field
-from frappe.query_builder.functions import Coalesce
 from frappe.utils import cstr
 
 
@@ -51,7 +50,7 @@ def func_in(key: Field, value: list | tuple) -> frappe.qb:
 
 	value = ["" if v is None else v for v in value]
 	if "" in value:
-		return Coalesce(key, "").isin(value)
+		return key.isin(value) | key.isnull()
 	return key.isin(value)
 
 

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -520,15 +520,17 @@ class TestOperatorIn(IntegrationTestCase):
 		query = func_in(note.name, [None, "user1"])
 		sql_str = str(query).lower()
 
-		self.assertIn("coalesce", sql_str)
+		self.assertNotIn("coalesce", sql_str)
+		self.assertIn("is null", sql_str)
 		self.assertIn("''", sql_str)
 
-	def test_func_in_with_empty_string_uses_coalesce(self):
+	def test_func_in_with_empty_string_uses_or_is_null(self):
 		note = frappe.qb.DocType("Note")
 		query = func_in(note.name, ["", "user1"])
 		sql_str = str(query).lower()
 
-		self.assertIn("coalesce", sql_str)
+		self.assertNotIn("coalesce", sql_str)
+		self.assertIn("is null", sql_str)
 		self.assertIn("''", sql_str)
 
 	def test_func_in_with_mixed_none_and_values(self):
@@ -536,7 +538,8 @@ class TestOperatorIn(IntegrationTestCase):
 		query = func_in(note.name, ["val1", None, "val2"])
 		sql_str = str(query).lower()
 
-		self.assertIn("coalesce", sql_str)
+		self.assertNotIn("coalesce", sql_str)
+		self.assertIn("is null", sql_str)
 
 	def test_in_filter_matches_null_and_empty_columns(self):
 		test_doctype = new_doctype(


### PR DESCRIPTION
### Description
`func_in` was using `COALESCE(col, '') IN ('', 'user')` to handle None/empty values in IN filters. Wrapping a column in `COALESCE` prevents the query planner from using indexes, causing full table scans on large tables.

### Fix
Replaced with `col IN ('', 'user') OR col IS NULL` - both conditions can independently use indexes, same approach taken in #21822 and #32382 for `IS SET/IS NOT SET`.

Follows up on #38128.