### PR TITLE
fix: use secrets for random string generation

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -291,10 +291,11 @@ def is_valid_iban(iban: str) -> bool:
 
 def random_string(length: int) -> str:
 	"""generate a random string"""
+	import secrets
 	import string
-	from random import choice
 
-	return "".join(choice(string.ascii_letters + string.digits) for i in range(length))
+	alphabet = string.ascii_letters + string.digits
+	return "".join(secrets.choice(alphabet) for i in range(length))
 
 
 def has_gravatar(email: str) -> str:


### PR DESCRIPTION
Replace `random.choice()` in `random_string()` with `secrets.choice()` so generated strings use a cryptographically stronger random source.

> The secrets module is used for generating cryptographically strong random numbers suitable for managing data such as passwords, account authentication, security tokens, and related secrets.
>
> In particular, secrets should be used in preference to the default pseudo-random number generator in the [random](https://docs.python.org/3/library/random.html#module-random) module, which is designed for modelling and simulation, not security or cryptography.
> – https://docs.python.org/3/library/secrets.html

We use this method for creating User and DB passwords, among other things.