### PR TITLE
fix: convert description to plain text after escaping

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -242,7 +242,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				) {
 					html +=
 						'<br><span class="small">' +
-						__(frappe.utils.escape_html(frappe.utils.html2text(d.description))) +
+						__(frappe.utils.html2text(frappe.utils.escape_html(d.description))) +
 						"</span>";
 				}
 				return $(`<div role="option">`)


### PR DESCRIPTION
Resolve: https://github.com/frappe/frappe/issues/36121#issuecomment-4152502097

**Before**

<img width="429" height="352" alt="image (12)" src="https://github.com/user-attachments/assets/f3adfee3-d5fe-416e-8e5e-7467d723165e" />


----

**After**
<img width="429" height="352" alt="image" src="https://github.com/user-attachments/assets/8df4c5fa-2f22-4b03-bc54-2b3bdb5c930b" />
