### PR TITLE
fix: filter alignment

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -1364,7 +1364,7 @@ class FilterArea {
 	}
 
 	make_filter_list() {
-		$(`<div class="filter-selector flex align-items-center">
+		$(`<div class="filter-selector">
 			<div class="btn-group">
 				<button class="btn btn-default btn-sm filter-button">
 					<span class="filter-icon button-icon">

--- a/frappe/public/js/frappe/ui/sort_selector.html
+++ b/frappe/public/js/frappe/ui/sort_selector.html
@@ -1,4 +1,4 @@
-<div class="sort-selector flex align-items-center">
+<div class="sort-selector">
 	<div class="btn-group">
 		<button class="btn btn-default btn-sm btn-order"
 			data-value="{{ sort_order }}"

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -513,6 +513,7 @@ input.list-header-checkbox {
 	.filter-section {
 		display: flex;
 		padding: 0;
+		margin-top: 3px;
 	}
 
 	.filter-selector .btn-group {


### PR DESCRIPTION
After
<img width="1420" height="796" alt="Screenshot 2026-03-31 at 12 06 18 PM" src="https://github.com/user-attachments/assets/f4edcc86-c3e6-4166-8847-8ba3bda73a98" />

This method is nicer and doesnt break when standard filters spillover to the next line
