### PR TITLE
fix(modal-list-item--head): `z-index` for modal `list-item--head`

### DIFF
--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -344,7 +344,6 @@ input.list-header-checkbox {
 .modal-body {
 	.list-item--head {
 		position: sticky !important;
-		z-index: 500;
 		top: 0;
 	}
 


### PR DESCRIPTION
<img width="1606" height="1370" alt="image" src="https://github.com/user-attachments/assets/2a90581b-efb4-444e-abc0-830acd633a9e" />

`z-index` on `list-item--head` for dialog was set to 500. However, the link field's awesomeplete has `z-index` set to 2, causing overlapping.