### PR TITLE
feat(frappe-client): enhance post_api method to send payloads in data/json

### DIFF
--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -343,12 +343,19 @@ class FrappeClient:
 		)
 		return self.post_process(res)
 
-	def post_api(self, method, params=None):
+	def post_api(self, method, params=None, *, as_json=False):
 		if params is None:
 			params = {}
-		res = self.session.post(
-			f"{self.url}/api/method/{method}", params=params, verify=self.verify, headers=self.headers
-		)
+
+		if as_json:
+			res = self.session.post(
+				f"{self.url}/api/method/{method}", json=params, verify=self.verify, headers=self.headers
+			)
+		else:
+			data = self.preprocess(params)
+			res = self.session.post(
+				f"{self.url}/api/method/{method}", data=data, verify=self.verify, headers=self.headers
+			)
 		return self.post_process(res)
 
 	def get_request(self, params):

--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -343,18 +343,15 @@ class FrappeClient:
 		)
 		return self.post_process(res)
 
-	def post_api(self, method, params=None, *, as_json=False):
-		if params is None:
-			params = {}
+	def post_api(self, method, params=None, json=None):
+		url = f"{self.url}/api/method/{method}"
 
-		if as_json:
-			res = self.session.post(
-				f"{self.url}/api/method/{method}", json=params, verify=self.verify, headers=self.headers
-			)
+		if json is not None:
+			headers = {**self.headers, "content-type": "application/json"}
+			res = self.session.post(url, json=json, verify=self.verify, headers=headers)
 		else:
-			data = self.preprocess(params)
 			res = self.session.post(
-				f"{self.url}/api/method/{method}", data=data, verify=self.verify, headers=self.headers
+				url, data=self.preprocess(params or {}), verify=self.verify, headers=self.headers
 			)
 		return self.post_process(res)
 


### PR DESCRIPTION
Frappe Client has `post_api` method which sent data in params before this fix. That is incorrect behaviour for POST requests. POST requests generally have large payloads, and sending those in URL via params is not the correct way to handle those.
We should instead send them either in data or in json args.

Added json key to allow sending directly in json as well. Else, just sends in data. Adjusts headers accordingly.
`no-docs`