### PR TITLE
feat: make notification email customizable

### DIFF
--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -16,7 +16,12 @@ class CommunicationEmailMixin:
 		return self.communication_type == "Communication" and self.communication_medium == "Email"
 
 	def get_owner(self):
-		"""Get notification email address of the communication docs parent.
+		"""Get owner of the communication docs parent."""
+		parent_doc = get_parent_doc(self)
+		return parent_doc.owner if parent_doc else None
+
+	def get_notification_recipient(self):
+		"""Get notification recipient of the communication docs parent.
 
 		Calls `get_notification_email` on the parent if available; otherwise returns the owner.
 		"""
@@ -24,7 +29,8 @@ class CommunicationEmailMixin:
 		if not parent_doc:
 			return None
 
-		notification_email = parent_doc.run_method("get_notification_email")
+		get_notification_email = getattr(parent_doc, "get_notification_email", None)
+		notification_email = get_notification_email() if callable(get_notification_email) else None
 		if notification_email:
 			return notification_email
 
@@ -70,7 +76,7 @@ class CommunicationEmailMixin:
 		"""Build cc list to send an email.
 
 		* if email copy is requested by sender, then add sender to CC.
-		* If this doc is created through inbound mail, then add doc owner to cc list
+		* If this doc is created through inbound mail, then add the notification recipient to CC
 		* remove all the thread_notify disabled users.
 		* Remove standard users from email list
 		"""
@@ -87,9 +93,9 @@ class CommunicationEmailMixin:
 			cc.append(sender)
 
 		if is_inbound_mail_communcation:
-			# inform parent document owner incase communication is created through inbound mail
-			if doc_owner := self.get_owner():
-				cc.append(doc_owner)
+			# inform the configured notification recipient in case communication is created inbound
+			if notification_recipient := self.get_notification_recipient():
+				cc.append(notification_recipient)
 			cc = set(cc) - {self.sender_mailid}
 			assignees = set(self.get_assignees()) - {self.sender_mailid}
 			# Check and remove If user disabled notifications for incoming emails on assigned document.

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -16,9 +16,19 @@ class CommunicationEmailMixin:
 		return self.communication_type == "Communication" and self.communication_medium == "Email"
 
 	def get_owner(self):
-		"""Get owner of the communication docs parent."""
+		"""Get notification email address of the communication docs parent.
+
+		Calls `get_notification_email` on the parent if available; otherwise returns the owner.
+		"""
 		parent_doc = get_parent_doc(self)
-		return parent_doc.owner if parent_doc else None
+		if not parent_doc:
+			return None
+
+		notification_email = parent_doc.run_method("get_notification_email")
+		if notification_email:
+			return notification_email
+
+		return parent_doc.owner
 
 	def get_all_email_addresses(self, exclude_displayname=False):
 		"""Get all Email addresses mentioned in the doc along with display name."""

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -24,13 +24,13 @@ class CommunicationEmailMixin:
 		"""Get notification recipient of the communication docs parent.
 
 		Calls `get_notification_email` on the parent if available; otherwise returns the owner.
+		This uses `run_method` so hooks can customize recipients per app/site.
 		"""
 		parent_doc = get_parent_doc(self)
 		if not parent_doc:
 			return None
 
-		get_notification_email = getattr(parent_doc, "get_notification_email", None)
-		notification_email = get_notification_email() if callable(get_notification_email) else None
+		notification_email = parent_doc.run_method("get_notification_email")
 		if notification_email:
 			return notification_email
 


### PR DESCRIPTION
## Summary

When a `Communication` is created via inbound email, the CC list for thread notifications currently falls back to `parent_doc.owner`, which is usually the document creator.

That is a problem for DocTypes where the creator is not the person responsible for handling replies. For example, a Lead may be created by one user but managed by a different user stored in `lead_owner`.

This PR adds a separate extension point for notification recipients while keeping `get_owner()` semantics unchanged for backwards compatibility.

- `get_owner()` still returns the parent document owner
- inbound thread notifications now use `get_notification_recipient()`
- `get_notification_recipient()` calls `parent_doc.run_method("get_notification_email")` first so apps and hooks can customize the recipient per site/company
- if nothing custom is returned, it falls back to `parent_doc.owner`

This keeps existing `get_owner()` callers stable while allowing DocTypes to control who receives inbound email thread notifications.

## Example usage in ERPNext

```python
class Lead:
	# ...
	def get_notification_email(self):
		"""Lead Owner should get notified about incoming emails."""
		if self.lead_owner:
			return frappe.db.get_value("User", self.lead_owner, "email")
```

https://github.com/frappe/erpnext/pull/53959

---

Docs: https://docs.frappe.io/wiki/change-requests/bmphjb0e6u (Line 70)

Ref: VOI-73
