### PR TITLE
fix: Autofocus on search bar of multiselect list

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -105,6 +105,7 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 					.concat(this._options)
 					.uniqBy((opt) => opt.value);
 				this.set_selectable_items(this._options);
+				this.$filter_input.trigger("focus");
 			});
 		});
 


### PR DESCRIPTION
Earlier in the search bar of a multiselect list, it was not highlighted when the filter was clicked; this resolves it 

Refs: https://github.com/frappe/erpnext/issues/53962

https://github.com/user-attachments/assets/b268876f-7051-4280-baaa-c76a0b14ac6b