### PR TITLE
fix: progress bar not rendering in list view for Percent fields

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -984,6 +984,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				html = `<span class="ellipsis">
 					${_value}
 				</span>`;
+			} else if (df.fieldtype === "Percent") {
+				return `<div style="width: 100%;"
+					title="${__(label)}: ${frappe.utils.escape_html(_value)}">
+					${format()}
+				</div>`;
 			} else {
 				html = `<a class="${filterable} ellipsis"
 					data-filter="${fieldname},=,${frappe.utils.escape_html(value)}">


### PR DESCRIPTION
## Summary                                                                                                                                                       
  - Fixes progress bar not displaying in list view for `Percent` field types                                                                                       
  - Regression from #38282 (sticky header on list view) — `display: table` on
    `.result` container causes nested `span.ellipsis` to collapse to `0px` width,                                                                                  
    making all progress bars invisible regardless of actual percentage value                                                                                       
  - Adds a dedicated rendering branch for `Percent` fields in `list_view.js` that                                                                                  
    uses a `div` wrapper with `width: 100%` instead of the `span.ellipsis` +                                                                                       
    `a.ellipsis` chain

## Before Fix
<img width="2476" height="706" alt="image" src="https://github.com/user-attachments/assets/8ca2e44c-eb6a-47c2-9fd3-4a7dbe04b6b7" />

## After Fix
<img width="2476" height="706" alt="image" src="https://github.com/user-attachments/assets/edb79bba-8560-4a1e-90da-13d9147296d6" />

**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/62930](https://support.frappe.io/helpdesk/tickets/62930)
