### PR TITLE
fix: escape html for letterhead footer and header

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -138,7 +138,7 @@ def get_icon_style():
 
 
 def get_letter_heads():
-	from frappe.utils.data import escape_html
+	from frappe.utils.html_utils import clean_html
 
 	letter_heads = {}
 
@@ -147,7 +147,10 @@ def get_letter_heads():
 	for letter_head in frappe.get_list("Letter Head", fields=["name", "content", "footer"]):
 		letter_heads.setdefault(
 			letter_head.name,
-			{"header": escape_html(letter_head.content), "footer": escape_html(letter_head.footer)},
+			{
+				"header": clean_html(letter_head.content, tags_allowed={"style"}, content_tags={"script"}),
+				"footer": clean_html(letter_head.footer, tags_allowed={"style"}, content_tags={"script"}),
+			},
 		)
 
 	return letter_heads

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -138,13 +138,16 @@ def get_icon_style():
 
 
 def get_letter_heads():
+	from frappe.utils.data import escape_html
+
 	letter_heads = {}
 
 	if not frappe.has_permission("Letter Head"):
 		return letter_heads
 	for letter_head in frappe.get_list("Letter Head", fields=["name", "content", "footer"]):
 		letter_heads.setdefault(
-			letter_head.name, {"header": letter_head.content, "footer": letter_head.footer}
+			letter_head.name,
+			{"header": escape_html(letter_head.content), "footer": escape_html(letter_head.footer)},
 		)
 
 	return letter_heads

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -21,32 +21,37 @@ EMOJI_PATTERN = re.compile(
 REMOVE_CONTENT_TAGS = {"script", "style"}
 
 
-def clean_html(html):
+def clean_html(html, tags_allowed=None, content_tags=None):
 	if not isinstance(html, str):
 		return html
-
+	allowed_tags = {
+		"div",
+		"p",
+		"br",
+		"ul",
+		"ol",
+		"li",
+		"strong",
+		"b",
+		"em",
+		"i",
+		"u",
+		"table",
+		"thead",
+		"tbody",
+		"td",
+		"tr",
+		"a",
+	}
+	remove_content_tags = REMOVE_CONTENT_TAGS
+	if content_tags:
+		remove_content_tags = content_tags
+	if tags_allowed and isinstance(tags_allowed, set):
+		allowed_tags = allowed_tags.union(tags_allowed)
 	return nh3.clean(
 		html,
-		tags={
-			"div",
-			"p",
-			"br",
-			"ul",
-			"ol",
-			"li",
-			"strong",
-			"b",
-			"em",
-			"i",
-			"u",
-			"table",
-			"thead",
-			"tbody",
-			"td",
-			"tr",
-			"a",
-		},
-		clean_content_tags=REMOVE_CONTENT_TAGS,
+		tags=allowed_tags,
+		clean_content_tags=remove_content_tags,
 		strip_comments=True,
 	)
 


### PR DESCRIPTION
Adding a script tag in letter head was breaking desk
