### PR TITLE
fix: report printing fixes

### DIFF
--- a/frappe/core/doctype/report/report.js
+++ b/frappe/core/doctype/report/report.js
@@ -55,6 +55,17 @@ frappe.ui.form.on("Report", {
 				},
 			};
 		});
+
+		frm.set_query("default_print_format", () => {
+			return {
+				filters: {
+					print_format_for: "Report",
+					report: frm.doc.name,
+					print_format_type: "JS",
+					disabled: 0,
+				},
+			};
+		});
 	},
 
 	ref_doctype: function (frm) {

--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -14,6 +14,7 @@
   "column_break_4",
   "report_type",
   "letter_head",
+  "default_print_format",
   "add_total_row",
   "disabled",
   "prepared_report",
@@ -99,7 +100,7 @@
    "depends_on": "eval: doc.is_standard == \"No\"",
    "fieldname": "letter_head",
    "fieldtype": "Link",
-   "label": "Letter Head",
+   "label": "Default Letter Head",
    "options": "Letter Head"
   },
   {
@@ -202,12 +203,18 @@
    "fieldname": "add_translate_data",
    "fieldtype": "Check",
    "label": "Add Translate Data"
+  },
+  {
+   "fieldname": "default_print_format",
+   "fieldtype": "Link",
+   "label": "Default Print Format",
+   "options": "Print Format"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-28 18:28:32.510719",
+ "modified": "2026-03-31 14:42:49.829920",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Report",

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -83,10 +83,8 @@ class Report(Document):
 		if self.report_type == "Report Builder":
 			self.update_report_json()
 
-		if self.default_print_format:
-			report_name = frappe.db.get_value("Print Format", self.default_print_format, "report")
-			if not report_name or report_name != self.name:
-				frappe.throw(_("Print Format must belong to this report!"))
+		if self.default_print_format and self.has_value_changed("default_print_format"):
+			self.validate_default_print_format()
 
 	def before_insert(self):
 		self.set_doctype_roles()
@@ -413,6 +411,23 @@ class Report(Document):
 			data.append(_row)
 
 		return data
+
+	def validate_default_print_format(self):
+		pf = frappe.db.get_value(
+			"Print Format",
+			self.default_print_format,
+			["report", "print_format_for", "print_format_type", "disabled"],
+			as_dict=True,
+		)
+
+		if (
+			not pf
+			or pf.report != self.name
+			or pf.print_format_for != "Report"
+			or pf.print_format_type != "JS"
+			or pf.disabled
+		):
+			frappe.throw(_("Selected Print Format is invalid for this Report."))
 
 	@frappe.whitelist()
 	def toggle_disable(self, disable: bool):

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -32,6 +32,7 @@ class Report(Document):
 		add_total_row: DF.Check
 		add_translate_data: DF.Check
 		columns: DF.Table[ReportColumn]
+		default_print_format: DF.Link | None
 		disabled: DF.Check
 		filters: DF.Table[ReportFilter]
 		is_standard: DF.Literal["No", "Yes"]
@@ -81,6 +82,11 @@ class Report(Document):
 
 		if self.report_type == "Report Builder":
 			self.update_report_json()
+
+		if self.default_print_format:
+			report_name = frappe.db.get_value("Print Format", self.default_print_format, "report")
+			if not report_name or report_name != self.name:
+				frappe.throw(_("Print Format must belong to this report!"))
 
 	def before_insert(self):
 		self.set_doctype_roles()

--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -4,7 +4,8 @@ frappe.ui.get_print_settings = function (
 	letter_head,
 	pick_columns,
 	has_filters = false,
-	title = null
+	title = null,
+	default_print_format = null
 ) {
 	var print_settings = locals[":Print Settings"]["Print Settings"];
 
@@ -31,6 +32,10 @@ frappe.ui.get_print_settings = function (
 			fieldname: "print_format",
 			label: __("Print Format"),
 			options: "Print Format",
+			default: default_print_format,
+			description: __(
+				"If no Print Format is selected, the default template for this report will be used."
+			),
 			get_query: () => ({
 				filters: {
 					print_format_for: "Report",
@@ -43,7 +48,7 @@ frappe.ui.get_print_settings = function (
 		{
 			fieldtype: "Check",
 			fieldname: "with_letter_head",
-			label: __("With Letter head"),
+			label: __("With Letter Head"),
 		},
 		{
 			fieldtype: "Link",
@@ -60,6 +65,7 @@ frappe.ui.get_print_settings = function (
 			label: __("Include filters"),
 			fieldtype: "Check",
 			fieldname: "include_filters",
+			depends_on: "eval: !doc.print_format",
 		});
 	}
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1941,7 +1941,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 						(print_settings) => this.print_report(print_settings),
 						this.report_doc.letter_head,
 						this.get_visible_columns(),
-						true
+						true,
+						null,
+						this.report_doc.default_print_format
 					);
 					this.add_portrait_warning(dialog);
 				},


### PR DESCRIPTION
Introduced a default print format link field in the report doctype and use it to populate the print format link field in the print settings dialog.


Before:

https://github.com/user-attachments/assets/9a01f6c7-2d7a-4bc4-95a3-0b308765a113

After:

https://github.com/user-attachments/assets/7c7f4deb-afff-44da-80be-40b6ab010111


Report Doc

https://github.com/user-attachments/assets/677a5469-6b9c-4b54-ac19-898641026839

