### PR TITLE
fix: defer DocType exports until after save response

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -550,10 +550,19 @@ class DocType(Document):
 			and (frappe.conf.developer_mode or frappe.flags.allow_doctype_export)
 		)
 		if allow_doctype_export:
-			self.export_doc()
-			self.make_controller_template()
-			self.set_base_class_for_controller()
-			self.export_types_to_controller()
+
+			def export_doctype_files():
+				self.export_doc()
+				self.make_controller_template()
+				self.set_base_class_for_controller()
+				self.export_types_to_controller()
+
+			request = getattr(frappe.local, "request", None)
+			# Defer file writes until after the response so the client can sync the saved doc first.
+			if request and hasattr(request, "after_response"):
+				request.after_response.add(export_doctype_files)
+			else:
+				export_doctype_files()
 
 		# update index
 		if not self.custom:


### PR DESCRIPTION
Defer standard **DocType** file export and controller generation until after the save response is sent.
This allows the client form to receive the updated document payload before dev-mode file writes trigger a web reload, and prevents follow-up `TimestampMismatchError` on consecutive **DocType** saves without forcing a full page reload.

## Before
- Saving a **DocType** in developer mode ran export and controller generation immediately inside `DocType.on_update()`.
- Those file writes touched the **DocType** files during the same save request.
-`bench watch` could restart before the save response fully reached the browser.
- When that happened, the form sometimes did not receive the updated document payload, including the new `modified` timestamp.
- A second save from the still-open form then sent stale document state and failed with `TimestampMismatchError`.

## After
- Export and controller generation are now deferred until `request.after_response`.
- The browser receives the successful save response first, including the fresh document state and updated `modified` timestamp.
- Only after the response is sent do the **DocType** files get written and the dev server reloads, if needed.
- Consecutive saves now work without `TimestampMismatchError`, and the form stays in sync without requiring an explicit page reload.

### Backports

When backporting, also pick the follow-up fix from https://github.com/frappe/frappe/pull/39130