### PR TITLE
refactor: make RoleEditor child table fields configurable

### DIFF
--- a/frappe/public/js/frappe/roles_editor.js
+++ b/frappe/public/js/frappe/roles_editor.js
@@ -1,13 +1,19 @@
 frappe.RoleEditor = class {
-	constructor(wrapper, frm, disable) {
+	constructor(wrapper, frm, disable, table_fieldname = "roles") {
+		if (typeof disable === "string") {
+			table_fieldname = disable;
+			disable = false;
+		}
+
 		this.frm = frm;
 		this.wrapper = wrapper;
 		this.disable = disable;
-		let user_roles = this.frm.doc.roles ? this.frm.doc.roles.map((a) => a.role) : [];
+		this.table_fieldname = table_fieldname || "roles";
+		let user_roles = this.get_role_rows().map((a) => a.role);
 		this.multicheck = frappe.ui.form.make_control({
 			parent: wrapper,
 			df: {
-				fieldname: "roles",
+				fieldname: this.table_fieldname,
 				fieldtype: "MultiCheck",
 				select_all: true,
 				columns: "15rem",
@@ -130,12 +136,12 @@ frappe.RoleEditor = class {
 	}
 
 	reset() {
-		let user_roles = (this.frm.doc.roles || []).map((a) => a.role);
+		let user_roles = this.get_role_rows().map((a) => a.role);
 		this.multicheck.selected_options = user_roles;
 		this.multicheck.refresh_input();
 	}
 	set_roles_in_table() {
-		let roles = this.frm.doc.roles || [];
+		let roles = this.get_role_rows();
 		let checked_options = this.multicheck.get_checked_options();
 		roles.map((role_doc) => {
 			if (!checked_options.includes(role_doc.role)) {
@@ -144,10 +150,17 @@ frappe.RoleEditor = class {
 		});
 		checked_options.map((role) => {
 			if (!roles.find((d) => d.role === role)) {
-				let role_doc = frappe.model.add_child(this.frm.doc, "Has Role", "roles");
+				let role_doc = frappe.model.add_child(
+					this.frm.doc,
+					"Has Role",
+					this.table_fieldname
+				);
 				role_doc.role = role;
 			}
 		});
+	}
+	get_role_rows() {
+		return this.frm.doc[this.table_fieldname] || [];
 	}
 	get_roles() {
 		return {

--- a/frappe/public/js/frappe/roles_editor.js
+++ b/frappe/public/js/frappe/roles_editor.js
@@ -17,16 +17,17 @@ frappe.RoleEditor = class {
 		}
 
 		const { table_fieldname = "roles", role_fieldname = "role", child_doctype } = options;
+		const configured_child_doctype = frappe.meta.get_docfield(
+			frm.doctype,
+			table_fieldname
+		)?.options;
 
 		this.frm = frm;
 		this.wrapper = wrapper;
 		this.disable = Boolean(disable);
 		this.table_fieldname = table_fieldname;
 		this.role_fieldname = role_fieldname;
-		this.child_doctype =
-			child_doctype ||
-			this.frm.fields_dict[this.table_fieldname]?.grid?.doctype ||
-			"Has Role";
+		this.child_doctype = child_doctype || configured_child_doctype || "Has Role";
 		let user_roles = this.get_selected_roles();
 		this.multicheck = frappe.ui.form.make_control({
 			parent: wrapper,

--- a/frappe/public/js/frappe/roles_editor.js
+++ b/frappe/public/js/frappe/roles_editor.js
@@ -5,21 +5,24 @@ frappe.RoleEditor = class {
 	 * @param {HTMLElement|JQuery} wrapper Container for the MultiCheck control.
 	 * @param {frappe.ui.form.Form} frm Form whose role rows are edited.
 	 * @param {boolean} [disable=false] Disable role selection inputs.
-	 * @param {string} [table_fieldname="roles"] Child table field containing role rows.
-	 * @param {string} [role_fieldname="role"] Field in each child row that stores the role value.
+	 * @param {Object} [options] Role row configuration overrides.
+	 * @param {string} [options.table_fieldname="roles"] Child table field containing role rows.
+	 * @param {string} [options.role_fieldname="role"] Field in each child row that stores the role value.
+	 * @param {string} [options.child_doctype="Has Role"] Child DocType used when adding role rows.
 	 */
-	constructor(
-		wrapper,
-		frm,
-		disable = false,
-		table_fieldname = "roles",
-		role_fieldname = "role"
-	) {
+	constructor(wrapper, frm, disable = false, options = {}) {
+		const {
+			table_fieldname = "roles",
+			role_fieldname = "role",
+			child_doctype = "Has Role",
+		} = options || {};
+
 		this.frm = frm;
 		this.wrapper = wrapper;
 		this.disable = disable;
-		this.table_fieldname = table_fieldname || "roles";
-		this.role_fieldname = role_fieldname || "role";
+		this.table_fieldname = table_fieldname;
+		this.role_fieldname = role_fieldname;
+		this.child_doctype = child_doctype;
 		let user_roles = this.get_selected_roles();
 		this.multicheck = frappe.ui.form.make_control({
 			parent: wrapper,
@@ -163,7 +166,7 @@ frappe.RoleEditor = class {
 			if (!roles.find((d) => this.get_role_value(d) === role)) {
 				let role_doc = frappe.model.add_child(
 					this.frm.doc,
-					"Has Role",
+					this.child_doctype,
 					this.table_fieldname
 				);
 				this.set_role_value(role_doc, role);

--- a/frappe/public/js/frappe/roles_editor.js
+++ b/frappe/public/js/frappe/roles_editor.js
@@ -4,25 +4,29 @@ frappe.RoleEditor = class {
 	 *
 	 * @param {HTMLElement|JQuery} wrapper Container for the MultiCheck control.
 	 * @param {frappe.ui.form.Form} frm Form whose role rows are edited.
-	 * @param {boolean} [disable=false] Disable role selection inputs.
+	 * @param {boolean|number|Object} [disable=false] Disable role selection inputs, or pass role row configuration as the third argument.
 	 * @param {Object} [options] Role row configuration overrides.
 	 * @param {string} [options.table_fieldname="roles"] Child table field containing role rows.
 	 * @param {string} [options.role_fieldname="role"] Field in each child row that stores the role value.
-	 * @param {string} [options.child_doctype="Has Role"] Child DocType used when adding role rows.
+	 * @param {string} [options.child_doctype] Child DocType used when adding role rows. Defaults to the table field's configured child DocType or "Has Role".
 	 */
 	constructor(wrapper, frm, disable = false, options = {}) {
-		const {
-			table_fieldname = "roles",
-			role_fieldname = "role",
-			child_doctype = "Has Role",
-		} = options || {};
+		if (disable && typeof disable === "object") {
+			options = disable;
+			disable = false;
+		}
+
+		const { table_fieldname = "roles", role_fieldname = "role", child_doctype } = options;
 
 		this.frm = frm;
 		this.wrapper = wrapper;
-		this.disable = disable;
+		this.disable = Boolean(disable);
 		this.table_fieldname = table_fieldname;
 		this.role_fieldname = role_fieldname;
-		this.child_doctype = child_doctype;
+		this.child_doctype =
+			child_doctype ||
+			this.frm.fields_dict[this.table_fieldname]?.grid?.doctype ||
+			"Has Role";
 		let user_roles = this.get_selected_roles();
 		this.multicheck = frappe.ui.form.make_control({
 			parent: wrapper,
@@ -157,12 +161,12 @@ frappe.RoleEditor = class {
 	set_roles_in_table() {
 		let roles = this.get_role_rows();
 		let checked_options = this.multicheck.get_checked_options();
-		roles.map((role_doc) => {
+		roles.forEach((role_doc) => {
 			if (!checked_options.includes(this.get_role_value(role_doc))) {
 				frappe.model.clear_doc(role_doc.doctype, role_doc.name);
 			}
 		});
-		checked_options.map((role) => {
+		checked_options.forEach((role) => {
 			if (!roles.find((d) => this.get_role_value(d) === role)) {
 				let role_doc = frappe.model.add_child(
 					this.frm.doc,

--- a/frappe/public/js/frappe/roles_editor.js
+++ b/frappe/public/js/frappe/roles_editor.js
@@ -1,15 +1,17 @@
 frappe.RoleEditor = class {
-	constructor(wrapper, frm, disable, table_fieldname = "roles") {
-		if (typeof disable === "string") {
-			table_fieldname = disable;
-			disable = false;
-		}
-
+	constructor(
+		wrapper,
+		frm,
+		disable = false,
+		table_fieldname = "roles",
+		role_fieldname = "role"
+	) {
 		this.frm = frm;
 		this.wrapper = wrapper;
 		this.disable = disable;
 		this.table_fieldname = table_fieldname || "roles";
-		let user_roles = this.get_role_rows().map((a) => a.role);
+		this.role_fieldname = role_fieldname || "role";
+		let user_roles = this.get_selected_roles();
 		this.multicheck = frappe.ui.form.make_control({
 			parent: wrapper,
 			df: {
@@ -136,7 +138,7 @@ frappe.RoleEditor = class {
 	}
 
 	reset() {
-		let user_roles = this.get_role_rows().map((a) => a.role);
+		let user_roles = this.get_selected_roles();
 		this.multicheck.selected_options = user_roles;
 		this.multicheck.refresh_input();
 	}
@@ -144,23 +146,32 @@ frappe.RoleEditor = class {
 		let roles = this.get_role_rows();
 		let checked_options = this.multicheck.get_checked_options();
 		roles.map((role_doc) => {
-			if (!checked_options.includes(role_doc.role)) {
+			if (!checked_options.includes(this.get_role_value(role_doc))) {
 				frappe.model.clear_doc(role_doc.doctype, role_doc.name);
 			}
 		});
 		checked_options.map((role) => {
-			if (!roles.find((d) => d.role === role)) {
+			if (!roles.find((d) => this.get_role_value(d) === role)) {
 				let role_doc = frappe.model.add_child(
 					this.frm.doc,
 					"Has Role",
 					this.table_fieldname
 				);
-				role_doc.role = role;
+				this.set_role_value(role_doc, role);
 			}
 		});
 	}
 	get_role_rows() {
 		return this.frm.doc[this.table_fieldname] || [];
+	}
+	get_selected_roles() {
+		return this.get_role_rows().map((row) => this.get_role_value(row));
+	}
+	get_role_value(row) {
+		return row[this.role_fieldname];
+	}
+	set_role_value(row, role) {
+		row[this.role_fieldname] = role;
 	}
 	get_roles() {
 		return {

--- a/frappe/public/js/frappe/roles_editor.js
+++ b/frappe/public/js/frappe/roles_editor.js
@@ -1,4 +1,13 @@
 frappe.RoleEditor = class {
+	/**
+	 * Create a role editor for a form child table.
+	 *
+	 * @param {HTMLElement|JQuery} wrapper Container for the MultiCheck control.
+	 * @param {frappe.ui.form.Form} frm Form whose role rows are edited.
+	 * @param {boolean} [disable=false] Disable role selection inputs.
+	 * @param {string} [table_fieldname="roles"] Child table field containing role rows.
+	 * @param {string} [role_fieldname="role"] Field in each child row that stores the role value.
+	 */
 	constructor(
 		wrapper,
 		frm,


### PR DESCRIPTION
- replace hardcoded role row schema in `frappe.RoleEditor` with a configurable `options` object
- support overriding the child table fieldname, role fieldname, and child DocType used for role rows
- preserve the existing defaults of `roles`, `role`, and `Has Role` so current callers continue to work unchanged
- document the constructor parameters with JSDoc

This makes the shared role editor reusable for DocTypes that store role rows in a different table, without duplicating the component or changing existing behavior.