### PR TITLE
chore: using `Whoosh-Reloaded` instead of `Whoosh`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "WeasyPrint==68.0",
     "pydyf==0.12.1",
     "Werkzeug==3.1.6",
-    "Whoosh~=2.7.4",
+    "Whoosh-Reloaded~=2.7.5",
     "beautifulsoup4~=4.13.5",
     "bleach-allowlist~=1.0.3",
     "chardet~=5.2.0",


### PR DESCRIPTION
Got the following error, while starting a new bench.

```zsh
20:24:04 web.1         | /home/dptnlsh/bench16/env/lib64/python3.14/site-packages/whoosh/analysis/filters.py:56: SyntaxWarning: "\w" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\w"? A raw string is also an option.
20:24:04 web.1         |   \w+([:.]?\w+)*         # word characters, with opt. internal colons/dots
20:24:04 web.1         | /home/dptnlsh/bench16/env/lib64/python3.14/site-packages/whoosh/analysis/filters.py:158: SyntaxWarning: "\S" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\S"? A raw string is also an option.
20:24:04 web.1         |   >>> ana = RegexTokenizer(r"\S+") | TeeFilter(f1, f2)
20:24:04 web.1         | /home/dptnlsh/bench16/env/lib64/python3.14/site-packages/whoosh/analysis/intraword.py:49: SyntaxWarning: "\S" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\S"? A raw string is also an option.
20:24:04 web.1         |   >>> analyzer = RegexTokenizer(r"\S+") | cwf
20:24:04 web.1         | /home/dptnlsh/bench16/env/lib64/python3.14/site-packages/whoosh/analysis/intraword.py:275: SyntaxWarning: "\S" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\S"? A raw string is also an option.
20:24:04 web.1         |   >>> analyzer = RegexTokenizer(r"\S+") | iwf | LowercaseFilter()
20:24:04 web.1         | /home/dptnlsh/bench16/env/lib64/python3.14/site-packages/whoosh/analysis/intraword.py:285: SyntaxWarning: "\|" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\|"? A raw string is also an option.
20:24:04 web.1         |   def __init__(self, delims=u("-_'\"()!@#$%^&*[]{}<>\|;:,./?`~=+"),
```

As mentioned in [Python 3.12 Release Notes](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes), backslash-character pair that is not a valid escape sequence now generates `SyntaxWarning` instead of `DeprecationWarning`.

Replaced [whoosh](https://github.com/mchaput/whoosh) with [whoosh-reloaded](https://github.com/Sygil-Dev/whoosh-reloaded) which is kind of compatible with Python 3.14, though it is also not maintained.