### PR TITLE
fix: inconsistent link title in report view

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -147,16 +147,36 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	}
 
 	set_link_title_field_value() {
+		let rows = this.datatable?.datamanager?.rows;
+		let link_col_indices = this.datatable?.datamanager?.columns
+			?.filter((c) => c.docfield?.fieldtype === "Link")
+			.map((c) => c.colIndex);
+
 		Object.keys(this.link_title_doctype_fields).forEach(async (key) => {
 			let link_title = await this.get_link_title_field_value(
 				this.link_title_doctype_fields[key],
 				key
 			);
 
-			if (link_title !== undefined) {
-				document.querySelectorAll(`a[data-name="${key}"]`).forEach((el) => {
-					el.innerHTML = link_title;
-				});
+			if (link_title === undefined) return;
+
+			// update visible DOM elements and cell tooltip
+			document.querySelectorAll(`a[data-name="${key}"]`).forEach((el) => {
+				if (el.innerHTML === link_title) return;
+				el.innerHTML = link_title;
+
+				$(el).closest(".dt-cell__content").attr("title", link_title);
+			});
+
+			if (rows?.length && link_col_indices?.length) {
+				for (let row of rows) {
+					for (let ci of link_col_indices) {
+						let cell = row[ci];
+						if (cell?.content === key && cell.html) {
+							cell.html = null;
+						}
+					}
+				}
 			}
 		});
 	}


### PR DESCRIPTION
 ## Summary 
- When "Load More" is clicked in Report View, newly loaded rows (with show title in link fields) display raw link names instead of resolved titles in both the cell text and tooltip.
- The link formatter runs synchronously during render and relies on a title cache (`frappe._link_titles`) that hasn't been populated yet for new rows. The async post-render patch (`set_link_title_field_value`) updates the `<a>` innerHTML but doesn't update the cell tooltip or invalidate the datatable's internal HTML cache, causing stale content on virtual scroll.

### Fix updates `set_link_title_field_value()` to:
1. Update the `.dt-cell__content` title attribute when patching link text.
2. Nullify `cell.html` in the datatable's datamanager rows for matching link cells, forcing the format function to re-run with the now-cached title.

### Before
[Screencast from 2026-04-04 10-01-42.webm](https://github.com/user-attachments/assets/ffcf0e57-6cae-41ce-8729-91c2667f2208)

### After
[Screencast from 2026-04-06 08-38-46.webm](https://github.com/user-attachments/assets/0c6727d4-40a8-4257-8a65-b171998c1451)

**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/63239](https://support.frappe.io/helpdesk/tickets/63239)