### PR TITLE
fix(ui): correct next/prev arrow direction in RTL

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -341,7 +341,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 		// Navigate
 		if (!this.frm.is_new() && !this.frm.meta.issingle) {
 			this.page.add_action_icon(
-				"es-line-left-chevron",
+				frappe.utils.is_rtl() ? "es-line-right-chevron" : "es-line-left-chevron",
 				() => {
 					this.frm.navigate_records(1);
 				},
@@ -349,7 +349,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 				__("Previous Document")
 			);
 			this.page.add_action_icon(
-				"es-line-right-chevron",
+				frappe.utils.is_rtl() ? "es-line-left-chevron" : "es-line-right-chevron",
 				() => {
 					this.frm.navigate_records(0);
 				},


### PR DESCRIPTION
**Before - in RTL view**
<img width="441" height="133" alt="image (14)" src="https://github.com/user-attachments/assets/ca810256-65a6-4f8c-8a29-df07fc9c208d" />


---
**After - in RTL view**
<img width="441" height="133" alt="image (13)" src="https://github.com/user-attachments/assets/f474279c-a79c-463f-aa35-03c4f9472774" />
