### PR TITLE
fix(email): validate message size only when SIZE limit is greater than 0

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -188,16 +188,18 @@ class EmailQueue(Document):
 				if ctx.smtp_server.session.has_extn("SIZE"):
 					if max_size := ctx.smtp_server.session.esmtp_features.get("size"):
 						max_size = int(max_size)
-						msg_size = len(msg)
 
-						if msg_size > max_size:
-							msg_size_mb = msg_size / (1024 * 1024)
-							max_size_mb = max_size / (1024 * 1024)
-							frappe.throw(
-								_(
-									"Email size {0:.2f} MB exceeds the maximum allowed size of {1:.2f} MB"
-								).format(msg_size_mb, max_size_mb)
-							)
+						if max_size > 0:
+							msg_size = len(msg)
+
+							if msg_size > max_size:
+								msg_size_mb = msg_size / (1024 * 1024)
+								max_size_mb = max_size / (1024 * 1024)
+								frappe.throw(
+									_(
+										"Email size {0:.2f} MB exceeds the maximum allowed size of {1:.2f} MB"
+									).format(msg_size_mb, max_size_mb)
+								)
 
 				return msg
 


### PR DESCRIPTION
closes: https://github.com/frappe/frappe/issues/38429