### PR TITLE
feat: add accessibillity to desk landing page icons

### DIFF
--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -50,8 +50,8 @@
                     </div>
                 </div>
             </div>
-            <div class="desktop-avatar">
-            </div>
+            <button class="desktop-avatar btn-reset" aria-label="{{ _('User Menu') }}">
+            </button>
             </div>
 
     </header>

--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -26,9 +26,9 @@
         <div class="flex" style="gap:16px; align-items: center;">
             <div class="desktop-notifications">
                 <div class="dropdown dropdown-notifications">
-                    <button class="btn-reset nav-link text-muted" data-toggle="dropdown" >
+                    <button class="btn-reset nav-link text-muted" data-toggle="dropdown" aria-label="{{ _("Notifications") }}" aria-haspopup="true">
                         <svg
-                            class="icon icon-md"
+                            class="icon icon-md" aria-hidden="true"
                         >
                             <use href="#icon-bell"></use>
                         </svg>

--- a/frappe/public/js/frappe/ui/desktop_icon.html
+++ b/frappe/public/js/frappe/ui/desktop_icon.html
@@ -1,4 +1,4 @@
-<a class="desktop-icon" data-id="{{ icon.label}}"  data-logo="{{ icon.logo_url }}" data-icon="{{ icon.icon }}" data-type="{{ icon.type }}" style="text-decoration:none">
+<a href="#" class="desktop-icon" data-id="{{ icon.label}}"  data-logo="{{ icon.logo_url }}" data-icon="{{ icon.icon }}" data-type="{{ icon.type }}" style="text-decoration:none">
     {% if(frappe.utils.get_desktop_icon(icon.label, frappe.boot.desktop_icon_style ) && icon.icon_type != "Folder") %}
         <div class="icon-container">
             <img class="app-icon" src="{{ frappe.utils.get_desktop_icon(icon.label, frappe.boot.desktop_icon_style) }}" alt="{{ icon.label }}" />

--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -19,12 +19,17 @@ a {
 a,
 a:hover,
 a:active,
-a:focus,
 .btn,
 .btn:hover,
-.btn:active,
-.btn:focus {
+.btn:active {
 	outline: 0;
+}
+
+a:focus-visible,
+.btn:focus-visible,
+.btn-reset:focus-visible {
+	box-shadow: var(--focus-default);
+	outline: none;
 }
 
 a.grey,


### PR DESCRIPTION
## Summary
- Added accessibillity to `/desk` landing page icons

## Change
- Added focus to all .btn, .btn-reset and a tags
- Profile icon, notification icon and desktop (framework) icon are now accessible

![Screen Recording 2026-04-07 at 2 05 54 PM](https://github.com/user-attachments/assets/833b7847-2ac1-44dd-a24f-5b1e9e20859c)


`no-docs`