### PR TITLE
fix: use keyset pagination for Previous/Next document navigation

### DIFF
--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -79,39 +79,50 @@ def update_comment_publicity(name: str, publish: bool):
 
 
 @frappe.whitelist()
-def get_next(doctype, value, prev, filters=None, sort_order="desc", sort_field="modified"):
+def get_next(
+	doctype: str,
+	value: str,
+	prev: str | int,
+	filters: dict | str | None = None,
+	sort_order: str = "desc",
+	sort_field: str = "modified",
+):
 	prev = int(prev)
 	if not filters:
 		filters = []
 	if isinstance(filters, str):
 		filters = json.loads(filters)
 
-	# # condition based on sort order
-	condition = ">" if sort_order.lower() == "asc" else "<"
+	table = frappe.qb.DocType(doctype)
+	sort_column = table[sort_field]
+	name_column = table.name
+	current_sort_value = frappe.db.get_value(doctype, value, sort_field)
 
-	# switch the condition
-	if prev:
-		sort_order = "asc" if sort_order.lower() == "desc" else "desc"
-		condition = "<" if condition == ">" else ">"
+	is_ascending = sort_order.lower() == "asc"
+	if prev == is_ascending:
+		composite_condition = (sort_column < current_sort_value) | (
+			(sort_column == current_sort_value) & (name_column < value)
+		)
+		order = frappe.qb.desc
+	else:
+		composite_condition = (sort_column > current_sort_value) | (
+			(sort_column == current_sort_value) & (name_column > value)
+		)
+		order = frappe.qb.asc
 
-	# # add condition for next or prev item
-	filters.append([doctype, sort_field, condition, frappe.get_value(doctype, value, sort_field)])
-
-	res = frappe.get_list(
-		doctype,
-		fields=["name"],
-		filters=filters,
-		order_by=f"`tab{doctype}`.{sort_field}" + " " + sort_order,
-		limit_start=0,
-		limit_page_length=1,
-		as_list=True,
+	query = (
+		frappe.qb.get_query(doctype, filters=filters, fields=["name"])
+		.orderby(sort_column, order=order)
+		.orderby(name_column, order=order)
+		.where(composite_condition)
+		.limit(1)
 	)
 
-	if not res:
-		frappe.msgprint(_("No further records"))
-		return None
-	else:
+	if res := query.run(as_list=True):
 		return res[0][0]
+
+	frappe.msgprint(_("No further records"))
+	return None
 
 
 def get_pdf_link(doctype, docname, print_format="Standard", no_letterhead=0):


### PR DESCRIPTION
## Summary
- Backports the composite keyset pagination fix from `develop` (PR #37080) to `version-15-hotfix`
- Replaces the old simple filter-based approach with composite conditioning on `(sort_field, name)`, which correctly handles documents with identical sort field values
- Drops the `ignore_permissions` kwarg from `get_query()` as it does not exist in the v15 query engine (was added in v16)

## Context
PR #38278 attempted this backport but broke v15 by passing `ignore_permissions=False` to `frappe.qb.get_query()`, which doesn't accept that parameter in v15. That was reverted in #38402.

This fix applies the same keyset pagination logic without the unsupported kwarg.
