### PR TITLE
fix: remove null values from "not in" filter 

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -493,6 +493,7 @@ frappe.ui.filter_utils = {
 				} catch {
 					val = val.split(",").map((v) => strip(v));
 				}
+				val = val.filter((v) => v != null && v !== ""); // remove empty values
 			}
 		} else if (frappe.boot.additional_filters_config[condition]) {
 			val = field.value || val;

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -491,9 +491,11 @@ frappe.ui.filter_utils = {
 					const parsed = JSON.parse(val);
 					val = Array.isArray(parsed) ? parsed : [String(parsed)];
 				} catch {
-					val = val.split(",").map((v) => strip(v));
+					val = val
+						.split(",")
+						.map((v) => strip(v))
+						.filter((v) => v != null && v !== "");
 				}
-				val = val.filter((v) => v != null && v !== ""); // remove empty values
 			}
 		} else if (frappe.boot.additional_filters_config[condition]) {
 			val = field.value || val;


### PR DESCRIPTION
Resolve: #38319

When splitting a `not in` filter value, trailing commas from the default `, ` separator produce empty/null entries (e.g. `"Draft,"` => `["Draft", ""]`), which corrupt the generated SQL query and cause the filter to return zero results.

---

**Before:**

https://github.com/user-attachments/assets/82077dfd-a962-4d4e-b14b-97b2f8cffc08



**After:**

https://github.com/user-attachments/assets/610ba9d7-918e-4579-85d8-e2158c0c0166

