### PR TITLE
fix(Email Account): create_dummy

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -492,7 +492,7 @@ class EmailAccount(Document):
 
 	@classmethod
 	def create_dummy(cls):
-		return cls.from_record({"sender": "notifications@example.com"})
+		return cls.from_record({"name": "Notifications", "email_id": "notifications@example.com"})
 
 	@classmethod
 	@cache_email_account("outgoing_email_account")


### PR DESCRIPTION
The dummy email account is used when no other **Email Account** is found. E.g. when unit test fixtures create **User** records and no email account is configured in `site_config.json`.

However, it used to set only `.sender`, a field that does not exist on email account and is used nowhere. The test setup then crashed when `.default_sender` was accessed, because `.email_id` was `None` in this case.

This PR fixes it to set `.email_id` and `.name` instead of `.sender`.