### PR TITLE
fix(testing): use XMLTestRunner when junit_xml_output is wanted

### DIFF
--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -159,11 +159,14 @@ def main(
 			discover_all_tests(apps, runner)
 
 		results = []
+		global unittest_runner
 		for app, category, suite in runner.iterRun():
 			click.secho(
 				f"\nRunning {suite.countTestCases()} {category} tests for {app}", fg="cyan", bold=True
 			)
-			results.append([app, category, runner.run(suite)])
+			main_runner = unittest_runner if junit_xml_output and unittest_runner else runner
+			res = main_runner.run(suite)
+			results.append([app, category, res])
 
 		success = all(r.wasSuccessful() for _, _, r in results)
 		if not success:


### PR DESCRIPTION
This PR fixes a regression in v16 where XMLTestRunner was not being used where it should, thus resulting in an empty file.

**Before**:

Just an empty file.


**After**:

<img width="2290" height="350" alt="image" src="https://github.com/user-attachments/assets/ce968bbf-68b5-4837-a7f2-adf0066dcff2" />


closes #38465