### PR TITLE
fix: show notification badge on desktop bell icon

### DIFF
--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -26,7 +26,7 @@
         <div class="flex" style="gap:16px; align-items: center;">
             <div class="desktop-notifications">
                 <div class="dropdown dropdown-notifications">
-                    <button class="btn-reset nav-link text-muted" data-toggle="dropdown" aria-label="{{ _("Notifications") }}" aria-haspopup="true">
+                    <button class="btn-reset nav-link text-muted desktop-notification-icon" data-toggle="dropdown" aria-label="{{ _("Notifications") }}" aria-haspopup="true">
                         <svg
                             class="icon icon-md" aria-hidden="true"
                         >

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -131,6 +131,19 @@ frappe.ui.Notifications = class Notifications {
 		frappe.call("frappe.desk.doctype.notification_log.notification_log.mark_all_as_read");
 	}
 
+	mark_notifications_as_seen() {
+		if ($(".notification-badge").length === 0) return;
+		$(".notification-badge").remove();
+		this.notification_settings.seen = 1;
+		frappe.call(
+			"frappe.desk.doctype.notification_settings.notification_settings.set_seen_value",
+			{ value: 1, user: frappe.session.user }
+		);
+		frappe.call(
+			"frappe.desk.doctype.notification_log.notification_log.trigger_indicator_hide"
+		);
+	}
+
 	setup_dropdown_events() {
 		const dropdown = this.dropdown;
 		const full_height = this.full_height;
@@ -143,6 +156,16 @@ frappe.ui.Notifications = class Notifications {
 		this.dropdown.on("click", (e) => {
 			$(e.currentTarget).data("closable", true);
 		});
+
+		this.dropdown.on("show.bs.dropdown", () => {
+			this.mark_notifications_as_seen();
+		});
+
+		if (this.full_height) {
+			this.wrapper.find(".sidebar-notification").on("click", () => {
+				this.mark_notifications_as_seen();
+			});
+		}
 
 		$(document).on("click", function (e) {
 			const isInsideNotificationBtn =
@@ -400,16 +423,6 @@ class NotificationsView extends BaseNotificationsView {
 		}
 	}
 
-	toggle_seen(flag) {
-		frappe.call(
-			"frappe.desk.doctype.notification_settings.notification_settings.set_seen_value",
-			{
-				value: cint(flag),
-				user: frappe.session.user,
-			}
-		);
-	}
-
 	setup_notification_listeners() {
 		frappe.realtime.on("notification", () => {
 			this.toggle_notification_icon(false);
@@ -418,16 +431,6 @@ class NotificationsView extends BaseNotificationsView {
 
 		frappe.realtime.on("indicator_hide", () => {
 			this.toggle_notification_icon(true);
-		});
-
-		$(document).on("click", ".sidebar-notification, .desktop-notification-icon", () => {
-			if ($(".notification-badge").length > 0) {
-				this.toggle_notification_icon(true);
-				this.toggle_seen(true);
-				frappe.call(
-					"frappe.desk.doctype.notification_log.notification_log.trigger_indicator_hide"
-				);
-			}
 		});
 	}
 }

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -383,8 +383,21 @@ class NotificationsView extends BaseNotificationsView {
 	}
 
 	toggle_notification_icon(seen) {
-		this.notifications_icon.find(".notifications-seen").toggle(seen);
-		this.notifications_icon.find(".notifications-unseen").toggle(!seen);
+		let sidebar_bell = $(".sidebar-notification");
+		let desktop_bell = $(".desktop-notification-icon");
+		if (seen) {
+			sidebar_bell.find(".notification-badge").remove();
+			desktop_bell.find(".notification-badge").remove();
+		} else {
+			if (sidebar_bell.find(".notification-badge").length === 0) {
+				sidebar_bell
+					.find(".sidebar-item-icon")
+					.append('<span class="notification-badge"></span>');
+			}
+			if (desktop_bell.find(".notification-badge").length === 0) {
+				desktop_bell.append('<span class="notification-badge"></span>');
+			}
+		}
 	}
 
 	toggle_seen(flag) {
@@ -407,10 +420,10 @@ class NotificationsView extends BaseNotificationsView {
 			this.toggle_notification_icon(true);
 		});
 
-		this.parent.on("show.bs.dropdown", () => {
-			this.toggle_seen(true);
-			if (this.notifications_icon.find(".notifications-unseen").is(":visible")) {
+		$(document).on("click", ".sidebar-notification, .desktop-notification-icon", () => {
+			if ($(".notification-badge").length > 0) {
 				this.toggle_notification_icon(true);
+				this.toggle_seen(true);
 				frappe.call(
 					"frappe.desk.doctype.notification_log.notification_log.trigger_indicator_hide"
 				);

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -222,11 +222,11 @@ class NotificationsView extends BaseNotificationsView {
 			.attr("title", __("Notifications"))
 			.tooltip({ delay: { show: 600, hide: 100 }, trigger: "hover" });
 
-		this.bell_icon = this.parent.find(".desktop-notification-icon use");
-		if (!this.bell_icon.length) {
-			this.bell_icon = this.parent
+		this.bell_indicator = this.parent.find(".desktop-notification-icon");
+		if (!this.bell_indicator.length) {
+			this.bell_indicator = this.parent
 				.closest(".body-sidebar")
-				?.find(".sidebar-notification use");
+				?.find(".sidebar-notification .sidebar-item-icon");
 		}
 
 		this.setup_notification_listeners();
@@ -387,7 +387,7 @@ class NotificationsView extends BaseNotificationsView {
 	}
 
 	toggle_notification_icon(seen) {
-		this.bell_icon?.attr("href", seen ? "#icon-bell" : "#icon-bell-dot");
+		this.bell_indicator?.toggleClass("indicator blue", !seen);
 	}
 
 	toggle_seen(flag) {
@@ -402,11 +402,13 @@ class NotificationsView extends BaseNotificationsView {
 
 	setup_notification_listeners() {
 		frappe.realtime.on("notification", () => {
+			this.settings.seen = 0;
 			this.toggle_notification_icon(false);
 			this.update_dropdown();
 		});
 
 		frappe.realtime.on("indicator_hide", () => {
+			this.settings.seen = 1;
 			this.toggle_notification_icon(true);
 		});
 
@@ -430,7 +432,7 @@ class NotificationsView extends BaseNotificationsView {
 			}
 
 			this.toggle_seen(true);
-			if (this.bell_icon?.attr("href") === "#icon-bell-dot") {
+			if (this.bell_indicator?.hasClass("indicator")) {
 				this.toggle_notification_icon(true);
 				frappe.call(
 					"frappe.desk.doctype.notification_log.notification_log.trigger_indicator_hide"

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -130,19 +130,6 @@ frappe.ui.Notifications = class Notifications {
 		frappe.call("frappe.desk.doctype.notification_log.notification_log.mark_all_as_read");
 	}
 
-	mark_notifications_as_seen() {
-		if ($(".notification-badge").length === 0) return;
-		$(".notification-badge").remove();
-		this.notification_settings.seen = 1;
-		frappe.call(
-			"frappe.desk.doctype.notification_settings.notification_settings.set_seen_value",
-			{ value: 1, user: frappe.session.user }
-		);
-		frappe.call(
-			"frappe.desk.doctype.notification_log.notification_log.trigger_indicator_hide"
-		);
-	}
-
 	setup_dropdown_events() {
 		const dropdown = this.dropdown;
 		const full_height = this.full_height;
@@ -155,16 +142,6 @@ frappe.ui.Notifications = class Notifications {
 		this.dropdown.on("click", (e) => {
 			$(e.currentTarget).data("closable", true);
 		});
-
-		this.dropdown.on("show.bs.dropdown", () => {
-			this.mark_notifications_as_seen();
-		});
-
-		if (this.full_height) {
-			this.wrapper.find(".sidebar-notification").on("click", () => {
-				this.mark_notifications_as_seen();
-			});
-		}
 
 		$(document).on("click", function (e) {
 			const isInsideNotificationBtn =
@@ -244,6 +221,13 @@ class NotificationsView extends BaseNotificationsView {
 		this.notifications_icon
 			.attr("title", __("Notifications"))
 			.tooltip({ delay: { show: 600, hide: 100 }, trigger: "hover" });
+
+		this.bell_icon = this.parent.find(".desktop-notification-icon use");
+		if (!this.bell_icon.length) {
+			this.bell_icon = this.parent
+				.closest(".body-sidebar")
+				?.find(".sidebar-notification use");
+		}
 
 		this.setup_notification_listeners();
 
@@ -403,21 +387,17 @@ class NotificationsView extends BaseNotificationsView {
 	}
 
 	toggle_notification_icon(seen) {
-		let sidebar_bell = $(".sidebar-notification");
-		let desktop_bell = $(".desktop-notification-icon");
-		if (seen) {
-			sidebar_bell.find(".notification-badge").remove();
-			desktop_bell.find(".notification-badge").remove();
-		} else {
-			if (sidebar_bell.find(".notification-badge").length === 0) {
-				sidebar_bell
-					.find(".sidebar-item-icon")
-					.append('<span class="notification-badge"></span>');
+		this.bell_icon?.attr("href", seen ? "#icon-bell" : "#icon-bell-dot");
+	}
+
+	toggle_seen(flag) {
+		frappe.call(
+			"frappe.desk.doctype.notification_settings.notification_settings.set_seen_value",
+			{
+				value: cint(flag),
+				user: frappe.session.user,
 			}
-			if (desktop_bell.find(".notification-badge").length === 0) {
-				desktop_bell.append('<span class="notification-badge"></span>');
-			}
-		}
+		);
 	}
 
 	setup_notification_listeners() {
@@ -447,6 +427,14 @@ class NotificationsView extends BaseNotificationsView {
 					this.render_notifications_dropdown();
 					this.notifications_fetched = true;
 				});
+			}
+
+			this.toggle_seen(true);
+			if (this.bell_icon?.attr("href") === "#icon-bell-dot") {
+				this.toggle_notification_icon(true);
+				frappe.call(
+					"frappe.desk.doctype.notification_log.notification_log.trigger_indicator_hide"
+				);
 			}
 		});
 	}

--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -49,6 +49,10 @@
 	position: relative;
 }
 
+.sidebar-notification .item-anchor {
+	overflow: visible;
+}
+
 .notification-badge {
 	position: absolute;
 	top: 4px;

--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -44,6 +44,26 @@
 	display: none;
 }
 
+.sidebar-notification .sidebar-item-icon.indicator,
+.desktop-notification-icon.indicator {
+	position: relative;
+
+	&::before {
+		position: absolute;
+		top: 0;
+		right: 0;
+		left: auto;
+		height: 6px;
+		width: 6px;
+		margin: 0;
+		z-index: 1;
+	}
+}
+
+.sidebar-notification .item-anchor {
+	overflow: visible;
+}
+
 .mark-read {
 	display: none;
 	margin-left: 10px;

--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -44,6 +44,27 @@
 	display: none;
 }
 
+.sidebar-notification .sidebar-item-icon,
+.desktop-notification-icon {
+	position: relative;
+}
+
+.notification-badge {
+	position: absolute;
+	top: 4px;
+	right: 4px;
+	width: 8px;
+	height: 8px;
+	background-color: var(--red-500);
+	border-radius: 50%;
+	pointer-events: none;
+}
+
+.desktop-notification-icon > .notification-badge {
+	top: 2px;
+	right: 0;
+}
+
 .mark-read {
 	display: none;
 	margin-left: 10px;

--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -44,31 +44,6 @@
 	display: none;
 }
 
-.sidebar-notification .sidebar-item-icon,
-.desktop-notification-icon {
-	position: relative;
-}
-
-.sidebar-notification .item-anchor {
-	overflow: visible;
-}
-
-.notification-badge {
-	position: absolute;
-	top: 4px;
-	right: 4px;
-	width: 8px;
-	height: 8px;
-	background-color: var(--red-500);
-	border-radius: 50%;
-	pointer-events: none;
-}
-
-.desktop-notification-icon > .notification-badge {
-	top: 2px;
-	right: 0;
-}
-
 .mark-read {
 	display: none;
 	margin-left: 10px;


### PR DESCRIPTION
## Description
Notification badge (red dot) was not appearing on the desktop page bell icon after notifications were moved to the sidebar in `b0cbb9b7dc`. The toggle logic only targeted sidebar DOM elements.
This PR adds a `.notification-badge` element approach for both the sidebar and desktop bell icons, along with proper click handlers to clear the badge when viewed.


## Before
Notice that the notification is received but there is no indication (such as a red badge)

https://github.com/user-attachments/assets/38bac450-3cd2-4347-80a2-3d70826463dd

The notification badge on the bell icon was broken when notifications were moved from the navbar to the sidebar in b0cbb9b7dc. The old implementation toggled between two SVG icons (`.notifications-seen` / `.notifications-unseen`), but the new sidebar bell uses a plain `#icon-bell` without any replacement badge mechanism. This also never worked on the desktop page bell icon.

---

## After

https://github.com/user-attachments/assets/0f842012-6fa0-44db-831e-79258d4c4ec2

### Fixes

#### 1. Badge display
- Added a small blue dot (`.notification-badge`) appended to the bell icon when there are unseen notifications.
- Works for both:
  - Sidebar bell
  - Desktop page bell

#### 2. Badge not clearing on click
- Bootstrap’s dropdown handler prevents click events from bubbling.
- The previous click listener never fired.
- Fixed by:
  - Listening to `show.bs.dropdown` (desktop)
  - Using a direct click handler (sidebar)

#### 3. Sidebar badge hidden
- Sidebar anchor had `overflow: hidden` (used for text truncation).
- This was clipping the badge.
- Fixed by setting `overflow: visible` on the notification item.

#### 4. Cross-instance sync
- There are two separate Notifications instances (sidebar + desktop).
- Clicking one bell now updates the client-side seen flag.
- Prevents the other instance from re-adding the badge on load.