### PR TITLE
fix: add secondary action for amended documents with tooltip

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -735,6 +735,12 @@ frappe.ui.form.Toolbar = class Toolbar {
 					.then((is_amended) => {
 						if (is_amended) {
 							this.page.clear_actions();
+							let btn = this.page.set_secondary_action(__("Amend"), () => {});
+							btn.prop("disabled", true)
+								.wrap('<span style="display:inline-block"></span>')
+								.parent()
+								.attr("title", __("Already amended as {0}", [is_amended]))
+								.tooltip({ delay: { show: 400, hide: 100 }, trigger: "hover" });
 							return;
 						}
 						this.set_page_actions(status);


### PR DESCRIPTION
If a cancelled document is already ammended, the users are confused why amend button is not visible. We now show a disabled amend button with a tooltip.

<img width="2940" height="972" alt="CleanShot 2026-04-09 at 15 02 39@2x" src="https://github.com/user-attachments/assets/b8fbac9b-a4a2-4113-adab-a22ba58ef440" />

