### PR TITLE
feat: `after_build` hook

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -108,6 +108,19 @@ def build(
 			print("Compiling translations for", app)
 			compile_translations(app, force=force)
 
+		run_after_build_hook(apps)
+
+
+def run_after_build_hook(apps):
+	from importlib import import_module
+
+	for app in apps:
+		for fn in frappe.get_hooks("after_build", app_name=app):
+			modulename = ".".join(fn.split(".")[:-1])
+			methodname = fn.split(".")[-1]
+			method = getattr(import_module(modulename), methodname)
+			method()
+
 
 @click.command("watch")
 @click.option("--apps", help="Watch assets for specific apps")

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -48,6 +48,7 @@ if typing.TYPE_CHECKING:
 	envvar="USING_CACHED",
 	help="Skips build and uses cached build artifacts (cache is set by Bench). Ignored if developer_mode enabled.",
 )
+@click.option("--skip-after-build", is_flag=True, help="Skip running after build hooks")
 def build(
 	app=None,
 	apps=None,
@@ -57,6 +58,7 @@ def build(
 	force=False,
 	save_metafiles=False,
 	using_cached=False,
+	skip_after_build=False,
 ):
 	"Compile JS and CSS source files"
 	from frappe.build import bundle, download_frappe_assets
@@ -108,7 +110,8 @@ def build(
 			print("Compiling translations for", app)
 			compile_translations(app, force=force)
 
-		run_after_build_hook(apps)
+		if not skip_after_build:
+			run_after_build_hook(apps)
 
 
 def run_after_build_hook(apps):

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -48,7 +48,6 @@ if typing.TYPE_CHECKING:
 	envvar="USING_CACHED",
 	help="Skips build and uses cached build artifacts (cache is set by Bench). Ignored if developer_mode enabled.",
 )
-@click.option("--skip-after-build", is_flag=True, help="Skip running after build hooks")
 def build(
 	app=None,
 	apps=None,
@@ -58,7 +57,6 @@ def build(
 	force=False,
 	save_metafiles=False,
 	using_cached=False,
-	skip_after_build=False,
 ):
 	"Compile JS and CSS source files"
 	from frappe.build import bundle, download_frappe_assets
@@ -110,8 +108,7 @@ def build(
 			print("Compiling translations for", app)
 			compile_translations(app, force=force)
 
-		if not skip_after_build:
-			run_after_build_hook(apps)
+		run_after_build_hook(apps)
 
 
 def run_after_build_hook(apps):

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -515,6 +515,12 @@ app_license = "{app_license}"
 # before_app_uninstall = "{app_name}.utils.before_app_uninstall"
 # after_app_uninstall = "{app_name}.utils.after_app_uninstall"
 
+# Build
+# ------------------
+# To hook into the build process
+
+# after_build = "{app_name}.build.after_build"
+
 # Desk Notifications
 # ------------------
 # See frappe.core.notifications.get_notification_config


### PR DESCRIPTION
## Why?

Adding an `after_build` hook to extend the build system. Need this for Studio to generate assets for frontends built on it. Ref here: https://github.com/frappe/studio/pull/163

The current way to do this is extending the build command in your frappe app's package.json. This is currently used in all frappe-ui based apps to hook building their frontends after their app is built. But this has to be done for every frontend.

<img width="1512" height="506" alt="image" src="https://github.com/user-attachments/assets/7cb339d8-10bf-4b37-9c4d-ad1e260c4ff8" />


Studio manages build & rendering for all apps built with it so it needs more control. Plus, I already have similar python code that calls the node process so I just want to reuse that. Using the existing build script in package.json will force me to rewrite this in node or call python from node which is too much work

## Example Usage

`studio/hooks.py`
```python
after_build = "studio.build.after_build"
```

`studio/build.py`

```python
def after_build() -> None:
	"""Hook called after `bench build`. Builds all standard studio apps"""
	click.secho("\nBuilding Studio Apps...", fg="cyan")
	build_standard_apps()
```

P.S: Not sure if a `before_build` hook makes sense.

Docs: https://docs.frappe.io/wiki/change-requests/fg9duob38f