### PR TITLE
feat: property to include fields in default import template

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -41,7 +41,7 @@
   "print_hide",
   "print_hide_if_no_value",
   "report_hide",
-  "include_in_import_template",
+  "in_import_template",
   "column_break_28",
   "depends_on",
   "collapsible",
@@ -645,7 +645,7 @@
   {
    "default": "0",
    "description": "Enable this option to include the field in the data import template",
-   "fieldname": "include_in_import_template",
+   "fieldname": "in_import_template",
    "fieldtype": "Check",
    "label": "Include in Import Template"
   }
@@ -655,7 +655,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-04-07 15:23:18.264098",
+ "modified": "2026-04-24 13:21:02.590853",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -41,6 +41,7 @@
   "print_hide",
   "print_hide_if_no_value",
   "report_hide",
+  "include_in_import_template",
   "column_break_28",
   "depends_on",
   "collapsible",
@@ -640,6 +641,13 @@
    "fieldname": "show_description_on_click",
    "fieldtype": "Check",
    "label": "Show Description on Click"
+  },
+  {
+   "default": "0",
+   "description": "Enable this option to include the field in the data import template",
+   "fieldname": "include_in_import_template",
+   "fieldtype": "Check",
+   "label": "Include in Import Template"
   }
  ],
  "grid_page_length": 50,
@@ -647,7 +655,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-10 21:39:58.400441",
+ "modified": "2026-04-07 15:23:18.264098",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/core/doctype/docfield/docfield.py
+++ b/frappe/core/doctype/docfield/docfield.py
@@ -83,10 +83,10 @@ class DocField(Document):
 		ignore_xss_filter: DF.Check
 		in_filter: DF.Check
 		in_global_search: DF.Check
+		in_import_template: DF.Check
 		in_list_view: DF.Check
 		in_preview: DF.Check
 		in_standard_filter: DF.Check
-		include_in_import_template: DF.Check
 		is_virtual: DF.Check
 		label: DF.Data | None
 		length: DF.Int

--- a/frappe/core/doctype/docfield/docfield.py
+++ b/frappe/core/doctype/docfield/docfield.py
@@ -86,6 +86,7 @@ class DocField(Document):
 		in_list_view: DF.Check
 		in_preview: DF.Check
 		in_standard_filter: DF.Check
+		include_in_import_template: DF.Check
 		is_virtual: DF.Check
 		label: DF.Data | None
 		length: DF.Int

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -787,6 +787,7 @@ docfield_properties = {
 	"print_hide": "Check",
 	"print_hide_if_no_value": "Check",
 	"report_hide": "Check",
+	"in_import_template": "Check",
 	"allow_on_submit": "Check",
 	"translatable": "Check",
 	"mandatory_depends_on": "Data",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -48,6 +48,7 @@
   "ignore_user_permissions",
   "allow_on_submit",
   "report_hide",
+  "in_import_template",
   "remember_last_selected_value",
   "hide_border",
   "ignore_xss_filter",
@@ -295,6 +296,13 @@
   },
   {
    "default": "0",
+   "description": "Enable this option to include the field in the data import template",
+   "fieldname": "in_import_template",
+   "fieldtype": "Check",
+   "label": "Include in Import Template"
+  },
+  {
+   "default": "0",
    "depends_on": "eval:(doc.fieldtype == 'Link')",
    "fieldname": "remember_last_selected_value",
    "fieldtype": "Check",
@@ -523,7 +531,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-22 10:36:12.968197",
+ "modified": "2026-04-27 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.py
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.py
@@ -81,6 +81,7 @@ class CustomizeFormField(Document):
 		ignore_xss_filter: DF.Check
 		in_filter: DF.Check
 		in_global_search: DF.Check
+		in_import_template: DF.Check
 		in_list_view: DF.Check
 		in_preview: DF.Check
 		in_standard_filter: DF.Check

--- a/frappe/public/js/frappe/data_import/data_exporter.js
+++ b/frappe/public/js/frappe/data_import/data_exporter.js
@@ -309,10 +309,16 @@ frappe.data_import.DataExporter = class DataExporter {
 			if (autoname_field && df.fieldname == autoname_field.fieldname) {
 				return true;
 			}
-			if (df.fieldname === "name") {
-				return true;
-			}
 			return false;
+		};
+		let get_info_title = (df) => {
+			if (df.depends_on) {
+				return __("Depends on: {0}", [df.depends_on]);
+			}
+			if (autoname_field && df.fieldname == autoname_field.fieldname) {
+				return __("Autoname: {0}", [autoname_field.label]);
+			}
+			return "";
 		};
 
 		return fields
@@ -332,6 +338,7 @@ frappe.data_import.DataExporter = class DataExporter {
 					value: df.fieldname,
 					danger: is_field_mandatory(df),
 					warning: is_field_depends_on(df),
+					warning_title: get_info_title(df),
 					include_in_import_template: !!df.include_in_import_template,
 					checked: false,
 					description: `${df.fieldname} ${df.reqd ? __("(Mandatory)") : ""}`,

--- a/frappe/public/js/frappe/data_import/data_exporter.js
+++ b/frappe/public/js/frappe/data_import/data_exporter.js
@@ -1,9 +1,10 @@
 frappe.provide("frappe.data_import");
 
 frappe.data_import.DataExporter = class DataExporter {
-	constructor(doctype, exporting_for, filetype = "CSV") {
+	constructor(doctype, exporting_for, filetype = "CSV", hide_blank_template = false) {
 		this.doctype = doctype;
 		this.exporting_for = exporting_for;
+		this.hide_blank_template = hide_blank_template;
 		frappe.model.with_doctype(doctype, () => {
 			this.make_dialog(filetype);
 		});
@@ -37,13 +38,20 @@ frappe.data_import.DataExporter = class DataExporter {
 							label: __("5 Records"),
 							value: "5_records",
 						},
-						{
-							label: __("Blank Template"),
-							value: "blank_template",
-						},
-					],
+					].concat(
+						this.hide_blank_template
+							? []
+							: [
+									{
+										label: __("Blank Template"),
+										value: "blank_template",
+									},
+							  ]
+					),
 					default:
-						this.exporting_for === "Insert New Records" ? "blank_template" : "all",
+						this.exporting_for === "Insert New Records" && !this.hide_blank_template
+							? "blank_template"
+							: "all",
 					change: () => {
 						this.update_record_count_message();
 					},
@@ -189,7 +197,7 @@ frappe.data_import.DataExporter = class DataExporter {
 			...multicheck_fields.map((fieldname) => {
 				let field = this.dialog.get_field(fieldname);
 				return field.options
-					.filter((option) => option.danger)
+					.filter((option) => option.danger || option.include_in_import_template)
 					.map((option) => option.$checkbox.find("input").get(0));
 			})
 		);
@@ -274,6 +282,10 @@ frappe.data_import.DataExporter = class DataExporter {
 			let fieldname = meta.autoname.slice("field:".length);
 			autoname_field = frappe.meta.get_field(doctype, fieldname);
 		}
+		const hide_name_for_insert_when_not_set_by_user =
+			this.exporting_for === "Insert New Records" &&
+			!this.hide_blank_template &&
+			!["Prompt", "prompt"].includes(meta.autoname);
 
 		let fields = child_fieldname ? this.column_map[child_fieldname] : this.column_map[doctype];
 
@@ -305,7 +317,11 @@ frappe.data_import.DataExporter = class DataExporter {
 
 		return fields
 			.filter((df) => {
-				if (autoname_field && df.fieldname === "name") {
+				if (
+					this.exporting_for === "Insert New Records" &&
+					(autoname_field || hide_name_for_insert_when_not_set_by_user) &&
+					df.fieldname === "name"
+				) {
 					return false;
 				}
 				return true;
@@ -316,6 +332,7 @@ frappe.data_import.DataExporter = class DataExporter {
 					value: df.fieldname,
 					danger: is_field_mandatory(df),
 					warning: is_field_depends_on(df),
+					include_in_import_template: !!df.include_in_import_template,
 					checked: false,
 					description: `${df.fieldname} ${df.reqd ? __("(Mandatory)") : ""}`,
 				};

--- a/frappe/public/js/frappe/data_import/data_exporter.js
+++ b/frappe/public/js/frappe/data_import/data_exporter.js
@@ -197,7 +197,7 @@ frappe.data_import.DataExporter = class DataExporter {
 			...multicheck_fields.map((fieldname) => {
 				let field = this.dialog.get_field(fieldname);
 				return field.options
-					.filter((option) => option.danger || option.include_in_import_template)
+					.filter((option) => option.danger || option.in_import_template)
 					.map((option) => option.$checkbox.find("input").get(0));
 			})
 		);
@@ -282,7 +282,7 @@ frappe.data_import.DataExporter = class DataExporter {
 			let fieldname = meta.autoname.slice("field:".length);
 			autoname_field = frappe.meta.get_field(doctype, fieldname);
 		}
-		const hide_name_for_insert_when_not_set_by_user =
+		const hide_name_for_autoname =
 			this.exporting_for === "Insert New Records" &&
 			!this.hide_blank_template &&
 			!["Prompt", "prompt"].includes(meta.autoname);
@@ -325,7 +325,7 @@ frappe.data_import.DataExporter = class DataExporter {
 			.filter((df) => {
 				if (
 					this.exporting_for === "Insert New Records" &&
-					(autoname_field || hide_name_for_insert_when_not_set_by_user) &&
+					(autoname_field || hide_name_for_autoname) &&
 					df.fieldname === "name"
 				) {
 					return false;
@@ -339,7 +339,7 @@ frappe.data_import.DataExporter = class DataExporter {
 					danger: is_field_mandatory(df),
 					warning: is_field_depends_on(df),
 					warning_title: get_info_title(df),
-					include_in_import_template: !!df.include_in_import_template,
+					in_import_template: !!df.in_import_template,
 					checked: false,
 					description: `${df.fieldname} ${df.reqd ? __("(Mandatory)") : ""}`,
 				};

--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -82,10 +82,7 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 		}
 		this.options.forEach((option) => {
 			let checkbox = this.get_checkbox_element(option).appendTo(this.$checkbox_area);
-			checkbox.find('[data-toggle="tooltip"]').tooltip({
-				delay: { show: 600, hide: 100 },
-				trigger: "hover",
-			});
+			checkbox.find('[data-toggle="tooltip"]').tooltip();
 
 			option.$checkbox = checkbox;
 		});

--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -167,7 +167,7 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 			option.warning_title || __("Condition based field")
 		);
 		const warning_icon = option.warning
-			? `<span class="text-muted" style="margin-left: 4px; display: inline-flex; align-items: center; vertical-align: middle; line-height: 1;" data-toggle="tooltip" title="${warning_title}">${frappe.utils.icon(
+			? `<span class="text-muted multicheck-warning-icon" data-toggle="tooltip" title="${warning_title}">${frappe.utils.icon(
 					"info",
 					"xs"
 			  )}</span>`

--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -82,12 +82,10 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 		}
 		this.options.forEach((option) => {
 			let checkbox = this.get_checkbox_element(option).appendTo(this.$checkbox_area);
-			if (option.danger) {
-				checkbox.find(".label-area").addClass("text-danger");
-			}
-			if (option.warning) {
-				checkbox.find(".label-area").addClass("text-warning");
-			}
+			checkbox.find('[data-toggle="tooltip"]').tooltip({
+				delay: { show: 600, hide: 100 },
+				trigger: "hover",
+			});
 
 			option.$checkbox = checkbox;
 		});
@@ -165,11 +163,25 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 	}
 
 	get_checkbox_element(option) {
+		const mandatory_marker = option.danger
+			? `<span class="text-danger" style="margin-left: 4px;">*</span>`
+			: "";
+		const warning_title = frappe.utils.escape_html(
+			option.warning_title || __("Condition based field")
+		);
+		const warning_icon = option.warning
+			? `<span class="text-muted" style="margin-left: 4px; display: inline-flex; align-items: center; vertical-align: middle; line-height: 1;" data-toggle="tooltip" title="${warning_title}">${frappe.utils.icon(
+					"info",
+					"xs"
+			  )}</span>`
+			: "";
 		return $(`
 			<div class="checkbox unit-checkbox">
 				<label title="${option.description || ""}" style="display: flex; align-items: center;">
 					<input type="checkbox" data-unit="${option.value}" style="flex-shrink: 0;">
-					<span class="label-area" data-unit="${option.value}">${option.label}</span>
+					<span class="label-area" data-unit="${option.value}">${
+			option.label
+		}${mandatory_marker}${warning_icon}</span>
 				</label>
 			</div>
 		`);

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -476,7 +476,9 @@ export default class BulkOperations {
 		frappe.require("data_import_tools.bundle.js", () => {
 			const data_exporter = new frappe.data_import.DataExporter(
 				doctype,
-				"Insert New Records"
+				"Insert New Records",
+				"CSV",
+				true
 			);
 			data_exporter.dialog.set_value("export_records", "by_filter");
 			data_exporter.filter_group.add_filters_to_filter_group([

--- a/frappe/public/scss/element/checkbox.scss
+++ b/frappe/public/scss/element/checkbox.scss
@@ -56,6 +56,14 @@ input[type="checkbox"] {
 	}
 }
 
+.checkbox .multicheck-warning-icon {
+	margin-left: 4px !important;
+	display: inline-flex;
+	align-items: center;
+	vertical-align: middle;
+	line-height: 1;
+}
+
 /* The switch - the box around the slider */
 .switch {
 	position: relative;


### PR DESCRIPTION
1. Added a new DocField property: Include in Import Template (`include_in_import_template`), by checking this field will be checked in export data modal by default
<img width="1450" height="633" alt="image" src="https://github.com/user-attachments/assets/0355df82-cd75-4d6a-ba1b-dd5c0327b7db" />
<img width="753" height="607" alt="image" src="https://github.com/user-attachments/assets/9a80f385-21d0-4f5f-9d36-0c82c642f5bf" />

2. Another Issue was Data import's Template Download and Export Data Modal are same Component, so Issue is For Downloading Template and It is `Insert a new Record` and ID is not `Set by User` then no need to show `ID` field actually , so fixing that as well and removed option of Export Type as `Blank Template` if it is exporting the data
<img width="1463" height="860" alt="image" src="https://github.com/user-attachments/assets/64c15d5d-907f-4104-9fca-19012dedfc30" />
Note: no `ID` field

3. There was weird convention for show mandatory field as red text, fixed that to have asterisk
before:

<img width="1449" height="860" alt="image" src="https://github.com/user-attachments/assets/f9a42f6d-7e09-4897-9673-c49501942a79" />


after:
<img width="1463" height="860" alt="image" src="https://github.com/user-attachments/assets/8cfc7de5-ba7f-4aa6-a838-0e33d938e0c7" />

4. Also there was weird convention to show `depends_on` field to show in yellow text, User dont understand what exactly it is fixing that and adding the tooltip on it

before:
<img width="1462" height="862" alt="image" src="https://github.com/user-attachments/assets/7cfa86f3-5f1a-43ae-bb56-0a637556bfaf" />

after:
<img width="929" height="860" alt="image" src="https://github.com/user-attachments/assets/2fc10103-a48c-4191-84be-9ad52dae0923" />


Any Suggestion to show this depends_on or mandatory in much better way are welcome.

docs link: https://docs.frappe.io/erpnext/data-import