### PR TITLE
feat: enhance calendar UI for dark theme support and improve styling.

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -138,6 +138,7 @@ frappe.views.Calendar = class Calendar {
 			this.make();
 			this.setup_view_mode_button(defaults);
 			this.bind();
+			this.listen_for_theme_change();
 		});
 	}
 	make_page() {
@@ -203,6 +204,13 @@ frappe.views.Calendar = class Calendar {
 			me.set_localStorage_option("cal_weekends", me.cal_options.weekends);
 			me.set_css();
 			me.setup_view_mode_button(me.cal_options);
+		});
+	}
+	listen_for_theme_change() {
+		this.theme_observer = new MutationObserver(() => this.fullCalendar?.refetchEvents());
+		this.theme_observer.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ["data-theme"],
 		});
 	}
 	set_css() {
@@ -429,6 +437,9 @@ frappe.views.Calendar = class Calendar {
 		});
 	}
 	prepare_colors(d) {
+		const is_dark_theme = frappe.ui.get_current_theme() === "dark";
+		const background_shade = is_dark_theme ? "dark" : "extra-light";
+		const text_shade = is_dark_theme ? "light" : "dark";
 		let color, color_name;
 		if (this.get_css_class) {
 			color_name = this.get_css_class(d);
@@ -436,14 +447,17 @@ frappe.views.Calendar = class Calendar {
 
 			if (color_name.startsWith("#")) {
 				color_name = frappe.ui.color.validate_hex(color_name) ? color_name : "blue";
+				d.backgroundColor = color_name;
+				d.textColor = frappe.ui.color.get_contrast_color(color_name);
+				return d;
 			}
 
-			d.backgroundColor = frappe.ui.color.get(color_name, "extra-light");
-			d.textColor = frappe.ui.color.get(color_name, "dark");
+			d.backgroundColor = frappe.ui.color.get(color_name, background_shade);
+			d.textColor = frappe.ui.color.get(color_name, text_shade);
 		} else {
 			color = d.color;
 			if (!frappe.ui.color.validate_hex(color) || !color) {
-				color = frappe.ui.color.get("blue", "extra-light");
+				color = frappe.ui.color.get("blue", background_shade);
 			}
 			d.backgroundColor = color;
 			d.textColor = frappe.ui.color.get_contrast_color(color);

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -138,7 +138,6 @@ frappe.views.Calendar = class Calendar {
 			this.make();
 			this.setup_view_mode_button(defaults);
 			this.bind();
-			this.listen_for_theme_change();
 		});
 	}
 	make_page() {
@@ -206,13 +205,7 @@ frappe.views.Calendar = class Calendar {
 			me.setup_view_mode_button(me.cal_options);
 		});
 	}
-	listen_for_theme_change() {
-		this.theme_observer = new MutationObserver(() => this.fullCalendar?.refetchEvents());
-		this.theme_observer.observe(document.documentElement, {
-			attributes: true,
-			attributeFilter: ["data-theme"],
-		});
-	}
+
 	set_css() {
 		const viewButtons =
 			".fc-dayGridMonth-button, .fc-timeGridWeek-button, .fc-timeGridDay-button, .fc-today-button";
@@ -437,9 +430,6 @@ frappe.views.Calendar = class Calendar {
 		});
 	}
 	prepare_colors(d) {
-		const is_dark_theme = frappe.ui.get_current_theme() === "dark";
-		const background_shade = is_dark_theme ? "dark" : "extra-light";
-		const text_shade = is_dark_theme ? "light" : "dark";
 		let color, color_name;
 		if (this.get_css_class) {
 			color_name = this.get_css_class(d);
@@ -452,12 +442,19 @@ frappe.views.Calendar = class Calendar {
 				return d;
 			}
 
-			d.backgroundColor = frappe.ui.color.get(color_name, background_shade);
-			d.textColor = frappe.ui.color.get(color_name, text_shade);
+			if (frappe.ui.color.names().includes(color_name)) {
+				d.backgroundColor = `var(--bg-${color_name})`;
+				d.textColor = `var(--text-on-${color_name})`;
+			} else {
+				d.backgroundColor = frappe.ui.color.get(color_name, "extra-light");
+				d.textColor = frappe.ui.color.get(color_name, "dark");
+			}
 		} else {
 			color = d.color;
 			if (!frappe.ui.color.validate_hex(color) || !color) {
-				color = frappe.ui.color.get("blue", background_shade);
+				d.backgroundColor = "var(--bg-blue)";
+				d.textColor = "var(--text-on-blue)";
+				return d;
 			}
 			d.backgroundColor = color;
 			d.textColor = frappe.ui.color.get_contrast_color(color);

--- a/frappe/public/scss/desk/calendar.scss
+++ b/frappe/public/scss/desk/calendar.scss
@@ -31,12 +31,38 @@ th.fc-col-header-cell {
 }
 
 .fc-theme-standard td,
+.fc-theme-standard th,
 .fc-theme-standard hr,
 .fc-theme-standard thead,
 .fc-theme-standard tbody,
 .fc-theme-standard .fc-row,
-.fc-theme-standard .fc-popover {
-	border-color: var(--gray-300) !important;
+.fc-theme-standard .fc-popover,
+.fc-theme-standard .fc-scrollgrid,
+.fc-theme-standard .fc-scrollgrid-section > *,
+.fc-theme-standard .fc-timegrid-slot,
+.fc-theme-standard .fc-timegrid-axis {
+	border-color: var(--table-border-color) !important;
+}
+
+.fc-theme-standard .fc-scrollgrid {
+	border-radius: var(--border-radius) !important;
+	overflow: hidden;
+}
+
+.fc-theme-standard .fc-scrollgrid-section > th:first-child {
+	border-top-left-radius: var(--border-radius) !important;
+}
+
+.fc-theme-standard .fc-scrollgrid-section > th:last-child {
+	border-top-right-radius: var(--border-radius) !important;
+}
+
+.fc-theme-standard .fc-scrollgrid-section:last-child > td:first-child {
+	border-bottom-left-radius: var(--border-radius) !important;
+}
+
+.fc-theme-standard .fc-scrollgrid-section:last-child > td:last-child {
+	border-bottom-right-radius: var(--border-radius) !important;
 }
 
 .fc-theme-standard td.fc-day-sun {
@@ -182,7 +208,7 @@ th.fc-col-header-cell {
 }
 
 .fc-highlight {
-	background: var(--blue-100) !important;
+	background: var(--highlight-color) !important;
 }
 
 .fc-left {
@@ -207,7 +233,7 @@ th.fc-col-header-cell {
 }
 
 .fc-day-grid {
-	border-bottom: 1px solid var(--gray-300);
+	border-bottom: 1px solid var(--table-border-color);
 }
 
 .fc-divider {


### PR DESCRIPTION
Changes
- Fixed calendar dark mode so events now match the selected theme.
- Made theme switching update calendar event colors instantly, without reload.
- Improved calendar table styling for better border and corner appearance.

Screenshots:
Previous:
<img width="2206" height="1740" alt="image" src="https://github.com/user-attachments/assets/561f9544-03de-486e-8432-54493486af35" />

After Changes:
<img width="2206" height="1740" alt="image" src="https://github.com/user-attachments/assets/f1284cb2-3a9e-4829-82c2-c2f94f7e6723" />


`no-docs`
