### PR TITLE
feat: Add `primary_label` and `secondary_label` params to frappe.confirm

### DIFF
--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -26,15 +26,21 @@ frappe.throw = function (msg) {
 	throw new Error(msg.message);
 };
 
-frappe.confirm = function (message, confirm_action, reject_action) {
+frappe.confirm = function (
+	message,
+	confirm_action,
+	reject_action,
+	primary_label,
+	secondary_label
+) {
 	var d = new frappe.ui.Dialog({
 		title: __("Confirm", null, "Title of confirmation dialog"),
-		primary_action_label: __("Yes", null, "Approve confirmation dialog"),
+		primary_action_label: __(primary_label || "Yes", null, "Approve confirmation dialog"),
 		primary_action: () => {
 			confirm_action && confirm_action();
 			d.hide();
 		},
-		secondary_action_label: __("No", null, "Dismiss confirmation dialog"),
+		secondary_action_label: __(secondary_label || "No", null, "Dismiss confirmation dialog"),
 		secondary_action: () => d.hide(),
 	});
 


### PR DESCRIPTION
### Problem
`frappe.confirm` always showed hardcoded **"Yes"** / **"No"** buttons regardless of the context, forcing developers to build a full `frappe.ui.Dialog` just to change button labels.

### Change
Added two optional parameters to `frappe.confirm`:
- `primary_label` , label for the confirm button (defaults to `"Yes"`)
- `secondary_label` , label for the dismiss button (defaults to `"No"`)

---
### Usage

**Delete confirmation**
```js
frappe.confirm(
  'Are you sure you want to delete this record?',
  () => frappe.db.delete_doc('Item', item_name),
  null,
  'Delete',   // instead of "Yes"
  'Cancel'    // instead of "No"
);
```

<img width="616" height="215" alt="image" src="https://github.com/user-attachments/assets/ceadac73-2287-46c0-812c-bfb12b6716a8" />


`no-docs`