### PR TITLE
fix: validate hidden and mandatory fields without default in web form

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -161,7 +161,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		let values = frappe.utils.get_query_params();
 		delete values.new;
 		Object.assign(defaults, values);
-		this.set_values(values);
+		this.set_values(defaults);
 	}
 
 	setup_primary_action() {
@@ -226,6 +226,8 @@ export default class WebForm extends frappe.ui.FieldGroup {
 			field = this.fields_dict[fieldname];
 
 			if (field && field.get_value) {
+				if (field.df.hidden) continue;
+
 				let value = field.get_value();
 				if (
 					field.df.reqd &&

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -115,7 +115,7 @@ class WebForm(WebsiteGenerator):
 
 	def validate_hidden_and_mandatory(self):
 		for d in self.web_form_fields:
-			if d.hidden and d.reqd and not d.default and not frappe.flags.in_migrate:
+			if (d.hidden and d.reqd) and not (d.default or frappe.flags.in_migrate):
 				frappe.throw(
 					_("{0}: Field {1} in row {2} cannot be hidden and mandatory without default").format(
 						self.name, d.label, d.idx

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -114,6 +114,8 @@ class WebForm(WebsiteGenerator):
 			frappe.throw(_("Following fields are missing:") + "<br>" + "<br>".join(missing))
 
 	def validate_hidden_and_mandatory(self):
+		if self.allow_incomplete:
+			return
 		for d in self.web_form_fields:
 			if (d.hidden and d.reqd) and not (d.default or frappe.flags.in_migrate):
 				frappe.throw(

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -8,6 +8,7 @@ from typing import Any
 import frappe
 from frappe import _, scrub
 from frappe.core.api.file import get_max_file_size
+from frappe.core.doctype.doctype.doctype import HiddenAndMandatoryWithoutDefaultError
 from frappe.core.doctype.file.utils import remove_file_by_url
 from frappe.desk.form.meta import get_code_files_via_hooks
 from frappe.modules.utils import export_module_json, get_doc_module
@@ -96,6 +97,8 @@ class WebForm(WebsiteGenerator):
 		if not frappe.flags.in_import:
 			self.validate_fields()
 
+		self.validate_hidden_and_mandatory()
+
 	def validate_fields(self):
 		"""Validate all fields are present"""
 		from frappe.model import no_value_fields
@@ -109,6 +112,16 @@ class WebForm(WebsiteGenerator):
 
 		if missing:
 			frappe.throw(_("Following fields are missing:") + "<br>" + "<br>".join(missing))
+
+	def validate_hidden_and_mandatory(self):
+		for d in self.web_form_fields:
+			if d.hidden and d.reqd and not d.default and not frappe.flags.in_migrate:
+				frappe.throw(
+					_("{0}: Field {1} in row {2} cannot be hidden and mandatory without default").format(
+						self.name, d.label, d.idx
+					),
+					HiddenAndMandatoryWithoutDefaultError,
+				)
 
 	def reset_field_parent(self):
 		"""Convert link fields to select with names as options."""


### PR DESCRIPTION
## Issue
Web form fields did not enforce the same hidden + mandatory validation that DocType fields do. A field could be set to both hidden and required without a default value, which causes submission failures on the frontend since the user cannot fill in a field they cannot see.

## Behaviour after fix


https://github.com/user-attachments/assets/9dd58ee4-06bd-44fa-9cff-1c53d1ca2e7c


