### PR TITLE
fix(ui): use calendar days for relative timestamp display

### DIFF
--- a/frappe/public/js/frappe/utils/pretty_date.js
+++ b/frappe/public/js/frappe/utils/pretty_date.js
@@ -11,10 +11,12 @@ function prettyDate(date, mini) {
 		);
 	}
 
-	let diff =
-		(new Date(frappe.datetime.now_datetime().replace(/-/g, "/")).getTime() - date.getTime()) /
-		1000;
-	let day_diff = Math.floor(diff / 86400);
+	let now = new Date(frappe.datetime.now_datetime().replace(/-/g, "/"));
+	let diff = (now.getTime() - date.getTime()) / 1000;
+
+	let today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+	let event_day = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+	let day_diff = Math.round((today - event_day) / 86400000);
 
 	if (isNaN(day_diff) || day_diff < 0) return "";
 

--- a/frappe/public/js/frappe/utils/pretty_date.js
+++ b/frappe/public/js/frappe/utils/pretty_date.js
@@ -16,7 +16,7 @@ function prettyDate(date, mini) {
 
 	let today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 	let event_day = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-	let day_diff = Math.round((today - event_day) / 86400000);
+	let day_diff = Math.floor((today - event_day) / 86400000);
 
 	if (isNaN(day_diff) || day_diff < 0) return "";
 


### PR DESCRIPTION
`prettyDate()` in `pretty_date.js` computes `day_diff` by dividing elapsed seconds by 86400 and flooring. This counts 24-hour periods, not calendar days.

A document edited on April 4th at 4:00 PM still shows "yesterday" when viewed on April 6th at 10:00 AM — elapsed time is ~42 hours, `Math.floor(42/24) = 1`, so the code treats it as 1 day ago.

The fix strips time from both `now` and `date` before computing `day_diff`, so "yesterday" strictly means the previous calendar date. `Math.round` is used instead of `Math.floor` to account for DST transitions where consecutive midnights can be 23 or 25 hours apart.

The seconds-based `diff` is preserved for same-day granularity (`just now`, `X minutes ago`, `X hours ago`).

---
Ref: https://support.frappe.io/helpdesk/tickets/64667?view=VIEW-HD+Ticket-1252