### PR TITLE
fix(print_utils): fix pdf rendering via chrome by considering bytes

### DIFF
--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -95,6 +95,15 @@ def get_print(
 			)
 			# if hook returns a value, assume it was the correct pdf_generator and return it
 			if pdf:
+				if output and isinstance(pdf, bytes):
+					from io import BytesIO
+
+					from pypdf import PdfReader
+
+					reader = PdfReader(BytesIO(pdf))
+					for page in reader.pages:
+						output.add_page(page)
+					return output
 				return pdf
 
 	for hook in frappe.get_hooks("on_print_pdf"):


### PR DESCRIPTION
Issue has been caught w/ chrome pdf generator, it returns bytes. This fixes that by considering bytes and then turning it into a `PdfWriter` obj. 