### PR TITLE
fix: respect Enable Onboarding setting in sidebar onboarding panel

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -682,6 +682,9 @@ def get_onboarding_data(module: str):
 	Return:
 	        dict: onboarding data
 	"""
+	if not frappe.get_system_settings("enable_onboarding"):
+		return []
+
 	onboardings = []
 	onboarding_doc = frappe.get_doc("Module Onboarding", module)
 	if onboarding_doc.is_complete:


### PR DESCRIPTION
## Summary                                                                                                                                                       
                                                                                                                                                                   
  - The sidebar "Getting Started" onboarding panel ignores the "Enable Onboarding"
    checkbox in System Settings, showing on every module workspace regardless                                                                                      
  - Root cause: `get_onboarding_data()` in `desk/desktop.py` was missing the 
    `enable_onboarding` check that `get_onboarding_doc()` already has                                                                                              
  - Added the same `frappe.get_system_settings("enable_onboarding")` guard to                                                                                      
    `get_onboarding_data()`                                                                                                                                        
                                                                                                                                                                   
  Fixes the issue where disabling onboarding via System Settings > Enable Onboarding                                                                               
  had no effect on the sidebar onboarding widget.

**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/64389](https://support.frappe.io/helpdesk/tickets/64389)