### PR TITLE
feat: provision to configure max_writes_per_transaction in site config

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -475,6 +475,9 @@ class Database:
 
 		if query_type in WRITE_QUERY_TYPES:
 			self.transaction_writes += 1
+			if frappe.conf.get("max_writes_per_transaction"):
+				self.MAX_WRITES_PER_TRANSACTION = cint(frappe.conf.max_writes_per_transaction)
+
 			if self.transaction_writes > self.MAX_WRITES_PER_TRANSACTION:
 				if self.auto_commit_on_many_writes:
 					self.commit()


### PR DESCRIPTION
By default, the limit is 20,000. However, if a user tries to create a Purchase Receipt with a quantity of 100,000 for a serialized item, they encounter the error: "Too many changes to the database in a single action."

Added provision to configure max_writes_per_transaction in site config file

#no-docs