### PR TITLE
fix(user): sanitize all html tags in name fields in User Doctype

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -359,7 +359,7 @@ class User(Document):
 	def clean_name(self):
 		for field in ("first_name", "middle_name", "last_name"):
 			if field_value := self.get(field):
-				self.set(field, sanitize_html(field_value, always_sanitize=True))
+				self.set(field, sanitize_html(field_value, always_sanitize=True, disallowed_tags="*"))
 
 	def set_full_name(self):
 		self.full_name = " ".join(p for p in [self.first_name, self.middle_name, self.last_name] if p)

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -170,7 +170,10 @@ def sanitize_html(html, linkify=False, always_sanitize=False, disallowed_tags=No
 
 	# Allow caller to explicitly disallow some tags
 	if disallowed_tags:
-		tags.difference_update(disallowed_tags)
+		if disallowed_tags == "*":
+			tags = set()
+		else:
+			tags.difference_update(disallowed_tags)
 
 	attributes = {"*": acceptable_attributes, "svg": svg_attributes}
 


### PR DESCRIPTION
Ideally name fields should not contain html tags. This PR sanitizes `html` tags in name fields in `User` Doctype.

Edit: escaping breaks valid names w/ apostrophe etc.. too :( . Decided to introduce a wildcard sanitization of HTML tags instead and make use of that.