### PR TITLE
fix: wildcard search broken for translated doctypes

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -224,13 +224,16 @@ def search_widget(
 	)
 
 	if not for_link_validation:
+		# Strip SQL wildcards for use in Python regex/string matching
+		_stripped_txt = txt.replace("%", "") if txt else txt
+
 		if meta.translated_doctype:
 			# Filtering the values array so that query is included in very element
 			values = (
 				result
 				for result in values
 				if any(
-					re.search(f"{re.escape(txt)}.*", _(cstr(value)) or "", re.IGNORECASE)
+					re.search(f"{re.escape(_stripped_txt)}.*", _(cstr(value)) or "", re.IGNORECASE)
 					for value in (result.values() if as_dict else result)
 				)
 			)
@@ -238,7 +241,7 @@ def search_widget(
 		# Sorting the values array so that relevant results always come first
 		# This will first bring elements on top in which query is a prefix of element
 		# Then it will bring the rest of the elements and sort them in lexicographical order
-		values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
+		values = sorted(values, key=lambda x: relevance_sorter(x, _stripped_txt, as_dict))
 
 		# remove _relevance from results
 		if not meta.translated_doctype:


### PR DESCRIPTION
## Summary                                                      
  - Fixes wildcard `%` search returning "No Results" in link field advanced search for translated doctypes (Item Group, Country, Territory, UOM, etc.)
  - Root cause: `re.escape(txt)` converts `%` to `\%`, producing a regex that looks for literal `%` characters instead of treating them as wildcards  
  - Strips `%` from search text before Python regex filtering and relevance sorting — the SQL LIKE path (non-translated doctypes) was already working correctly

## Before Fix
[Screencast from 2026-04-13 23-35-17.webm](https://github.com/user-attachments/assets/ad71585d-af51-4a01-bd97-528b211b9b93)

## After Fix
[Screencast from 2026-04-13 23-41-34.webm](https://github.com/user-attachments/assets/08936bea-d134-4db6-aaf4-3a5cc3f20b5d)


**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/64179](https://support.frappe.io/helpdesk/tickets/64179)