### PR TITLE
fix: allow desktop icon renaming for non-standard icons

### DIFF
--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -63,8 +63,9 @@ class DesktopIcon(Document):
 			clear_desktop_icons_cache(user=self.owner)
 
 	def after_rename(self, old, new, merge):
-		delete_desktop_icon_file(self.app, old)
-		self.export_desktop_icon()
+		if self.standard and self.app:
+			delete_desktop_icon_file(self.app, old)
+			self.export_desktop_icon()
 
 	def export_desktop_icon(self):
 		allow_export = (


### PR DESCRIPTION
Renaming Desktop icon was breaking for non standard icons
