### PR TITLE
fix: remove misleading wildcard hint from link field advanced search

### DIFF
--- a/frappe/public/js/frappe/form/link_selector.js
+++ b/frappe/public/js/frappe/form/link_selector.js
@@ -27,7 +27,6 @@ frappe.ui.form.LinkSelector = class LinkSelector {
 					fieldtype: "Data",
 					fieldname: "txt",
 					label: __("Beginning with"),
-					description: __("You can use wildcard %"),
 				},
 				{
 					fieldtype: "HTML",


### PR DESCRIPTION
## Summary
  - Removes misleading "You can use wildcard %" hint from link field advanced search dialog
  - The search already wraps user input in `%..%` automatically, so typing `test` does a `LIKE '%test%'` query
  - Adding `%` explicitly breaks search for translated doctypes (Item Group, Country, Territory, etc.) where post-query Python regex filtering treats `%` as a
  literal character

  ## Fix
Removed the `description: __("You can use wildcard %")` from the search field in `link_selector.js`. The wildcard behavior is built-in, users just need to type their search term.

Supersedes #38568