### PR TITLE
fix(customize form): prevent setting standard fields as virtual

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -401,6 +401,10 @@ class CustomizeForm(Document):
 		elif prop == "in_global_search" and df.in_global_search != meta_df[0].get("in_global_search"):
 			self.flags.rebuild_doctype_for_global_search = True
 
+		elif prop == "is_virtual" and meta_df[0].get("is_virtual") == 0 and df.get("is_virtual") == 1:
+			frappe.msgprint(_("You can't set standard field {0} as virtual").format(frappe.bold(df.label)))
+			return False
+
 		return True
 
 	def set_property_setters_for_actions_and_links(self, meta):


### PR DESCRIPTION
Setting standard fields as virtual cause breakage in standard form rendering and in save->submit state transition, especially, if they have 'options' value set.

ref: [65388](https://support.frappe.io/helpdesk/tickets/65388)