### PR TITLE
fix: use lucide icon for password control

### DIFF
--- a/frappe/public/js/frappe/form/controls/password.js
+++ b/frappe/public/js/frappe/form/controls/password.js
@@ -35,17 +35,17 @@ frappe.ui.form.ControlPassword = class ControlPassword extends frappe.ui.form.Co
 
 		this.toggle_password = $(`
 			<div class="toggle-password hidden">
-				${frappe.utils.icon("unhide", "sm")}
+				${frappe.utils.icon("eye", "sm")}
 			</div>
 		`).insertAfter(this.$input);
 
 		this.toggle_password.on("click", () => {
 			if (this.$input.attr("type") === "password") {
 				this.$input.attr("type", "text");
-				this.toggle_password.html(frappe.utils.icon("hide", "sm"));
+				this.toggle_password.html(frappe.utils.icon("eye-off", "sm"));
 			} else {
 				this.$input.attr("type", "password");
-				this.toggle_password.html(frappe.utils.icon("unhide", "sm"));
+				this.toggle_password.html(frappe.utils.icon("eye", "sm"));
 			}
 		});
 


### PR DESCRIPTION


Before
<img width="502" height="73" alt="Screenshot 2026-04-14 at 4 26 24 PM" src="https://github.com/user-attachments/assets/c84ea445-fad5-4973-b2a7-2785e3811daf" />

After
<img width="502" height="73" alt="Screenshot 2026-04-14 at 4 28 00 PM" src="https://github.com/user-attachments/assets/c68d4bdd-6663-4354-8089-0ef97bc6caf1" />

We use outline icons almost everywhere, I guess password control didn't get the memo