### PR TITLE
fix: show workspace sidebar with no module to all users

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -562,8 +562,9 @@ def get_sidebar_items(allowed_workspaces):
 			sidebar_doc = sidebar
 		if (
 			frappe.session.user == "Administrator"
-			or sidebar_doc.module in sidebar_doc.user.allow_modules
 			or sidebar_title == "My Workspaces"
+			or not sidebar_doc.module
+			or sidebar_doc.module in sidebar_doc.user.allow_modules
 		):
 			sidebar_items[sidebar_title.lower()] = {
 				"label": sidebar_title,


### PR DESCRIPTION
## Description
When a Workspace Sidebar has no module set (common for custom workspaces created by users), the visibility check in `get_sidebar_items()` evaluates `None` in `user.allow_modules` which returns False, hiding the sidebar from all non-admin users.

This adds an early not `sidebar_doc.module` guard, consistent with how Workspace.__init__ already handles the same case in desktop.py:42-44.
 
 ## Before
 
<img width="1508" height="860" alt="Screenshot 2026-04-14 at 6 58 10 PM" src="https://github.com/user-attachments/assets/c6668ddd-6970-4d8f-8ad9-94d7d89241ee" />

 ## After
 
 <img width="1512" height="867" alt="Screenshot 2026-04-14 at 6 58 27 PM" src="https://github.com/user-attachments/assets/10b7f903-017c-4296-a4c3-ca39364bb203" />
 
 ## Note
 Clearing cache does not solves the issue.
 
## Closes #37836


https://github.com/user-attachments/assets/2c1f5edd-7de4-45de-b0f4-8c9f08a102cd

