### PR TITLE
fix: add translation context for fraction currency

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1556,7 +1556,7 @@ def money_in_words(
 	if main == "0" and fraction in ["0", "00", "000"]:
 		out = _(main_currency, context="Currency") + " " + _("Zero")
 	elif main == "0":
-		out = f"{fraction_in_words()} {fraction_currency}"
+		out = f"{fraction_in_words()} {_(fraction_currency, context='Currency')}"
 	else:
 		if main_currency == "DZD":
 			# Use Dinars for Algerian Compliance
@@ -1564,7 +1564,15 @@ def money_in_words(
 		else:
 			out = _(main_currency, context="Currency") + " " + in_words(main, in_million).title()
 		if cint(fraction):
-			out = out + " " + _("and") + " " + fraction_in_words() + " " + fraction_currency
+			out = (
+				out
+				+ " "
+				+ _("and")
+				+ " "
+				+ fraction_in_words()
+				+ " "
+				+ _(fraction_currency, context="Currency")
+			)
 
 	if main_currency == "DZD":
 		return _("{0}.", context="Money in words").format(out)


### PR DESCRIPTION
Resolve: #38623

---
Before:
<img width="417" height="243" alt="image" src="https://github.com/user-attachments/assets/5e403b35-5e8c-4c74-bebe-cee029f85df4" />

After:
<img width="417" height="243" alt="image" src="https://github.com/user-attachments/assets/11b082be-9776-4cc2-880c-453c6a3a7065" />

