### PR TITLE
fix(minor): center breadcrumb

### DIFF
--- a/frappe/public/scss/desk/breadcrumb.scss
+++ b/frappe/public/scss/desk/breadcrumb.scss
@@ -7,13 +7,14 @@
 .navbar-breadcrumbs {
 	flex-wrap: nowrap;
 	align-items: center;
-	line-height: 1;
 	a {
 		text-decoration: none;
 		color: var(--ink-gray-5);
 		font-weight: var(--weight-medium);
 		font-size: var(--text-lg);
 		letter-spacing: get_letterspacing("sm", "regular");
+		display: flex;
+		align-items: center;
 		&:hover {
 			color: var(--ink-gray-7);
 		}


### PR DESCRIPTION
Before
<img width="610" height="162" alt="Screenshot 2026-04-16 at 12 53 14 PM" src="https://github.com/user-attachments/assets/e11ab43d-06a3-4a2d-a17a-387ef27688f6" />

After
<img width="517" height="152" alt="Screenshot 2026-04-16 at 12 52 08 PM" src="https://github.com/user-attachments/assets/d3f27e2e-c2b8-4541-919b-16b1b68a404e" />


Slightly better than before
