### PR TITLE
perf: setup routes only once

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -285,7 +285,6 @@ frappe.Application = class Application {
 
 			frappe.boot.setup_complete = frappe.boot.sysdefaults["setup_complete"];
 			frappe.user.name = frappe.boot.user.name;
-			frappe.router.setup();
 		} else {
 			this.set_as_guest();
 		}


### PR DESCRIPTION
We were setting up routes twice which is not needed. Once is enough
<img width="626" height="375" alt="Screenshot 2026-04-16 at 2 42 00 PM" src="https://github.com/user-attachments/assets/fed4c6c3-cd29-43a6-a91e-adf5f772d46b" />
