### PR TITLE
fix(ui): properly align notification indicator on sidebar badge

### DIFF
--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -50,8 +50,6 @@
 
 	&::before {
 		position: absolute;
-		top: 0;
-		right: 0;
 		left: auto;
 		height: 6px;
 		width: 6px;
@@ -60,7 +58,19 @@
 	}
 }
 
-.sidebar-notification .item-anchor {
+.desktop-notification-icon.indicator::before {
+	top: 0;
+	right: 0;
+}
+
+.sidebar-notification .sidebar-item-icon.indicator::before {
+	top: 3px;
+	right: 5px;
+	height: 5px;
+	width: 5px;
+}
+
+.sidebar-notification .standard-sidebar-item .item-anchor {
 	overflow: visible;
 }
 

--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -68,6 +68,11 @@
 	right: 6px;
 	height: 5.5px;
 	width: 5.5px;
+	transition: opacity 0.2s ease-in-out;
+}
+
+.sidebar-notification:hover .sidebar-item-icon.indicator::before {
+	opacity: 0;
 }
 
 .sidebar-notification .standard-sidebar-item .item-anchor {

--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -64,10 +64,10 @@
 }
 
 .sidebar-notification .sidebar-item-icon.indicator::before {
-	top: 3px;
-	right: 5px;
-	height: 5px;
-	width: 5px;
+	top: 5px;
+	right: 6px;
+	height: 5.5px;
+	width: 5.5px;
 }
 
 .sidebar-notification .standard-sidebar-item .item-anchor {


### PR DESCRIPTION
Closes #38624

<img width="661" height="863" alt="Screenshot 2026-04-16 at 6 48 43 PM" src="https://github.com/user-attachments/assets/6d1846f3-5ab9-4b99-a82a-ec2b6a875cef" />

## Note 
Added a hover effect as well

https://github.com/user-attachments/assets/69f4ed71-a1ec-4cf2-94b0-14c7741be166



