### PR TITLE
fix(login): only show navbar when language picker is enabled

### DIFF
--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -1,5 +1,9 @@
 {% extends "templates/web.html" %}
-
+{% block navbar %}
+{% if show_language_picker %}
+    {{ super() }}
+{% endif %}
+{% endblock %}
 {% macro email_login_body() -%}
 {% if not disable_user_pass_login or (ldap_settings and ldap_settings.enabled) %}
 <div class="page-card-body">
@@ -66,6 +70,7 @@
 {% endmacro %}
 
 {% block page_content %}
+
 <!-- {{ for_test }} -->
 <div>
 	<noscript>


### PR DESCRIPTION
Right now we show this navbar on all logins. The issue is this is really bad design wise and it looks out of place
This was added back with the Show Language Picker option for Login Screens. It should only be shown when the option is enabled. 

Before
<img width="1440" height="786" alt="Screenshot 2026-04-17 at 12 22 33 PM" src="https://github.com/user-attachments/assets/4e68a5c2-9bd1-485d-aeaf-0a884e2fd777" />

After
When its enabled
<img width="1440" height="791" alt="Screenshot 2026-04-17 at 12 26 05 PM" src="https://github.com/user-attachments/assets/d7f940e6-0558-46bf-8dec-6ae3825fed84" />




When its not which is the default case in most places
<img width="1439" height="783" alt="Screenshot 2026-04-17 at 12 25 49 PM" src="https://github.com/user-attachments/assets/e6db8afc-c9e6-4cd3-b173-9a6bc6ced9b3" />
