### PR TITLE
fix(DX): Allow db.commit from drop-down console

### DIFF
--- a/frappe/desk/doctype/system_console/system_console.py
+++ b/frappe/desk/doctype/system_console/system_console.py
@@ -29,9 +29,7 @@ class SystemConsole(Document):
 		try:
 			frappe.local.debug_log = []
 			if self.type == "Python":
-				safe_exec(
-					self.console, script_filename="System Console", restrict_commit_rollback=not self.commit
-				)
+				safe_exec(self.console, script_filename="System Console")
 				self.output = "\n".join(frappe.debug_log)
 			elif self.type == "SQL":
 				frappe.db.begin(read_only=True)


### PR DESCRIPTION
This is anyways allowed, it's just extra friction at this point.

After using it for a while I feel we should allow it from drop-down
console too now.

It's risky, but hey, you're literally executing arbitrary code you just
wrote so I am trusting you.
