### PR TITLE
fix: Align × and right arrow icons in link field

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -14,7 +14,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		$(`<div class="link-field ui-front" style="position: relative;">
 			<input type="text" class="input-with-feedback form-control">
 			<span class="link-btn">
-				<a class="btn-clear" style="display: inline-block;" title="${__("Clear Link")}">
+				<a class="btn-clear" style="display: inline-flex;" title="${__("Clear Link")}">
 					${frappe.utils.icon("close", "xs", "es-icon")}
 				</a>
 				<a class="btn-open" style="display: inline-flex;" title="${__("Open Link")}">


### PR DESCRIPTION
Closes: #38701

PR raised on behalf of @UmakanthKaspa

---

<img width="1888" height="332" alt="image" src="https://github.com/user-attachments/assets/437de564-1045-4463-b21e-b775bd5c0548" />
