### PR TITLE
fix(table): fix bulk paste in child tables

### DIFF
--- a/frappe/public/js/frappe/form/controls/table.js
+++ b/frappe/public/js/frappe/form/controls/table.js
@@ -16,7 +16,7 @@ frappe.ui.form.ControlTable = class ControlTable extends frappe.ui.form.Control 
 			this.frm.grids[this.frm.grids.length] = this;
 		}
 		const me = this;
-		this.$wrapper.on("paste", ":text", (e) => {
+		this.$wrapper.on("paste", ":text", async (e) => {
 			const table_field = this.df.fieldname;
 			const grid = this.grid;
 			const grid_pagination = grid.grid_pagination;
@@ -70,47 +70,40 @@ frappe.ui.form.ControlTable = class ControlTable extends frappe.ui.form.Control 
 
 			let row_idx = locals[doctype][row_docname].idx;
 			let data_length = data.length;
-			data.forEach((row, i) => {
-				setTimeout(() => {
-					let blank_row = !row.filter(Boolean).length;
-					if (!blank_row) {
-						if (row_idx > this.frm.doc[table_field].length) {
-							this.grid.add_new_row();
-						}
+			const total_rows_needed = row_idx - 1 + data.length;
+			while (this.frm.doc[table_field].length < total_rows_needed) {
+				this.grid.add_new_row();
+			}
+			for (let i = 0; i < data_length; i++) {
+				const row = data[i];
+				if (!row.filter(Boolean).length) {
+					row_idx++;
+					continue;
+				}
 
-						if (row_idx > 1 && (row_idx - 1) % grid_pagination.page_length === 0) {
-							grid_pagination.go_to_page(grid_pagination.page_index + 1);
+				const doc = this.frm.doc[table_field][row_idx - 1];
+				if (doc) {
+					let row_values = {};
+					row.forEach((value, data_index) => {
+						if (fieldnames[data_index]) {
+							row_values[fieldnames[data_index]] = value_formatter_map[
+								fieldtypes[data_index]
+							]
+								? value_formatter_map[fieldtypes[data_index]](value)
+								: value;
 						}
+					});
 
-						const row_name = grid_rows[row_idx - 1].doc.name;
-						row.forEach((value, data_index) => {
-							if (fieldnames[data_index]) {
-								// format value before setting
-								value = value_formatter_map[fieldtypes[data_index]]
-									? value_formatter_map[fieldtypes[data_index]](value)
-									: value;
-								frappe.model.set_value(
-									doctype,
-									row_name,
-									fieldnames[data_index],
-									value
-								);
-							}
-						});
-						row_idx++;
-						if (data_length >= 10) {
-							let progress = i + 1;
-							frappe.show_progress(
-								__("Processing"),
-								progress,
-								data_length,
-								null,
-								true
-							);
-						}
+					await frappe.model.set_value(doctype, doc.name, row_values);
+
+					if (data_length >= 10) {
+						frappe.show_progress(__("Processing"), i + 1, data_length, null, true);
+						await new Promise((resolve) => setTimeout(resolve, 10));
 					}
-				}, 0);
-			});
+				}
+				row_idx++;
+			}
+			this.grid.refresh();
 			return false; // Prevent the default handler from running.
 		});
 	}


### PR DESCRIPTION
Noticed plenty of issues w/ bulk paste in child tables. This PR resolves them by fixing/refactoring some of the code.

**Before**:

**Firefox**:

https://github.com/user-attachments/assets/2479edd0-254c-43fd-8d22-d980a6520f59

Row counts just don't match, row data is not fully filled, quite a few of the records stay empty.

**Chrome**:

https://github.com/user-attachments/assets/8ef3a8ae-ae25-4153-ab0f-48b2dd3604d4

Row data is not fully filled.

**After**:


https://github.com/user-attachments/assets/91f2d338-8e3c-4c2e-b211-37020fec24b7


Closes Ticket #65677
