### PR TITLE
fix(doctype): show Permissions tab only when doctype is not a child table

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -665,6 +665,7 @@
    "label": "Sender Name Field"
   },
   {
+   "depends_on": "eval:!doc.istable",
    "fieldname": "permissions_tab",
    "fieldtype": "Tab Break",
    "label": "Permissions"
@@ -792,7 +793,7 @@
    "link_fieldname": "document_type"
   }
  ],
- "modified": "2025-09-23 06:48:13.555017",
+ "modified": "2026-04-20 16:06:57.212832",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",
@@ -823,6 +824,7 @@
  ],
  "route": "doctype",
  "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "search_fields": "module",
  "show_name_in_global_search": 1,
  "sort_field": "creation",


### PR DESCRIPTION
Fixes: #38446 

---

**Before:**

<img width="632" height="129" alt="image" src="https://github.com/user-attachments/assets/102b3fdc-6fd1-4f73-9a29-77e438f4e15e" />

----

**After:**
<img width="632" height="129" alt="image" src="https://github.com/user-attachments/assets/75e8bcce-1226-48a7-b6d6-5c69085b3fb9" />
