### PR TITLE
fix(tests): skip uninstalled doctypes in test record dependency walk

### DIFF
--- a/frappe/tests/test_test_utils.py
+++ b/frappe/tests/test_test_utils.py
@@ -1,7 +1,9 @@
+import logging
 from datetime import timedelta
 
 import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.tests.utils.generators import get_missing_records_doctypes, get_modules
 from frappe.utils.data import now_datetime
 
 
@@ -37,6 +39,30 @@ class TestTestUtils(IntegrationTestCase):
 		tomorrow = now + timedelta(days=1)
 		with self.freeze_time(tomorrow):
 			self.assertEqual(now_datetime(), tomorrow)
+
+	def test_get_modules_returns_none_for_missing_doctype(self):
+		"""DocTypes from uninstalled apps should resolve to (None, None) instead of raising."""
+		get_modules.cache_clear()
+		try:
+			module, test_module = get_modules("Definitely Not A Real DocType")
+		finally:
+			get_modules.cache_clear()
+		self.assertIsNone(module)
+		self.assertIsNone(test_module)
+
+	def test_get_missing_records_doctypes_skips_missing_doctype(self):
+		"""Missing link targets should be skipped with a warning, not crash the walk."""
+		get_modules.cache_clear()
+		try:
+			with self.assertLogs("frappe.testing.generators", level=logging.WARNING) as log_ctx:
+				result = get_missing_records_doctypes("Definitely Not A Real DocType")
+		finally:
+			get_modules.cache_clear()
+		self.assertEqual(result, [])
+		self.assertTrue(
+			any("Definitely Not A Real DocType" in line for line in log_ctx.output),
+			f"Expected warning mentioning the missing doctype, got: {log_ctx.output}",
+		)
 
 
 def tearDownModule():

--- a/frappe/tests/utils/generators.py
+++ b/frappe/tests/utils/generators.py
@@ -35,9 +35,13 @@ __all__ = [
 
 
 @cache
-def get_modules(doctype) -> tuple[str, ModuleType]:
+def get_modules(doctype) -> tuple[str | None, ModuleType | None]:
 	"""Get the modules for the specified doctype"""
 	module = frappe.db.get_value("DocType", doctype, "module")
+	if not module:
+		# DocType is not installed on this site (e.g. belongs to an uninstalled app);
+		# treat it as a dead-end leaf rather than raising DoesNotExistError.
+		return None, None
 	try:
 		test_module = load_doctype_module(doctype, module, "test_")
 		if test_module:
@@ -49,7 +53,7 @@ def get_modules(doctype) -> tuple[str, ModuleType]:
 
 
 # @cache - don't cache the recursion, code depends on its recurn value declining
-def get_missing_records_doctypes(doctype, visited=None) -> list[str]:
+def get_missing_records_doctypes(doctype, visited=None, _parent=None) -> list[str]:
 	"""Get the dependencies for the specified doctype in a depth-first manner"""
 
 	if visited is None:
@@ -62,7 +66,18 @@ def get_missing_records_doctypes(doctype, visited=None) -> list[str]:
 	# Mark as visited
 	visited.add(doctype)
 
-	_module, test_module = get_modules(doctype)
+	module, test_module = get_modules(doctype)
+	if module is None:
+		# DocType is not installed on this site; skip it instead of crashing the
+		# whole test run. This typically means a Link field points to a DocType
+		# from an optional/uninstalled app.
+		testing_logger.warning(
+			"Skipping test record generation for %r (linked from %r): DocType not installed on this site",
+			doctype,
+			_parent,
+		)
+		return []
+
 	meta = frappe.get_meta(doctype)
 	link_fields = meta.get_link_fields()
 
@@ -79,7 +94,7 @@ def get_missing_records_doctypes(doctype, visited=None) -> list[str]:
 	# Recursive depth-first traversal
 	result = []
 	for dep_doctype in unique_doctypes:
-		result.extend(get_missing_records_doctypes(dep_doctype, visited))
+		result.extend(get_missing_records_doctypes(dep_doctype, visited, _parent=doctype))
 
 	result.append(doctype)
 	return result


### PR DESCRIPTION
## Summary

Fixes #38747.

The test runner's dependency walker (`frappe.tests.utils.generators.get_missing_records_doctypes`) recursively follows `Link` fields to pre-generate test records. Previously, if any DocType in that transitive graph belonged to an app **not installed on the test site**, the walk crashed with `frappe.exceptions.DoesNotExistError: DocType <Name> not found`, aborting the entire test suite before a single test ran.

This PR treats such link targets as dead-end leaves instead of fatal errors:

- `get_modules(doctype)` now returns `(None, None)` when `frappe.db.get_value(\"DocType\", doctype, \"module\")` is empty, instead of falling through into `load_doctype_module` which raises `DoesNotExistError`.
- `get_missing_records_doctypes` checks for `module is None`, logs a warning naming the parent DocType that linked to it, and returns `[]` without descending further or appending the missing doctype to the result.
- The recursion now passes `_parent=doctype` so the warning can point users at the DocType that owned the offending link, which is otherwise hard to extract from the recursive traceback.

The targeted check (\"DocType row doesn't exist in the DocType table\") preserves the diagnostic value of the original behavior for genuinely broken cases (typos, missing dependency that was supposed to be installed) — those still surface, but as a clear log line instead of a crashing stack trace, and the test suite continues.

## Why

This situation arises any time an optional/decoupled Frappe app is `Link`-referenced from a more widely-installed one. Without this fix, downstream apps' CI is forced to know the full transitive link graph of every dependency-of-dependency, which is fragile: a new `Link` field added three apps upstream silently breaks CI for everyone downstream. The existing per-test escape hatch (`IGNORE_TEST_RECORD_DEPENDENCIES`) requires the same upstream knowledge in every test file and doesn't scale.

## Test plan

- [x] Added `test_get_modules_returns_none_for_missing_doctype` — verifies `get_modules(\"<nonexistent>\")` returns `(None, None)` instead of raising.
- [x] Added `test_get_missing_records_doctypes_skips_missing_doctype` — verifies the dependency walk returns `[]` for a nonexistent doctype and emits a warning naming it on `frappe.testing.generators`.
- [x] Existing tests in `frappe.tests.test_test_utils` still pass.

```
$ bench --site <site> run-tests --module frappe.tests.test_test_utils
Ran 6 tests in 0.982s
OK
```