### PR TITLE
fix(grid): include cross-page selections in get_selected()

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -408,13 +408,7 @@ export default class Grid {
 	);
 
 	get_selected() {
-		return (this.grid_rows || [])
-			.map((row) => {
-				return row.doc.__checked ? row.doc.name : null;
-			})
-			.filter((d) => {
-				return d;
-			});
+		return (this.data || []).filter((doc) => doc.__checked).map((doc) => doc.name);
 	}
 
 	get_selected_children() {

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -261,7 +261,24 @@ export default class Grid {
 
 			this.refresh_remove_rows_button();
 			this.refresh_duplicate_rows_button();
+			this.update_selection_banner(num_selected_rows);
 		});
+	}
+
+	update_selection_banner(count) {
+		let $container = this.wrapper.find(".form-grid-container");
+		let $toast = this.wrapper.find("> .grid-selection-toast");
+		if (count > 0) {
+			if (!$toast.length) {
+				$toast = $(
+					`<div class="grid-selection-toast"><span class="grid-selection-toast__message"></span></div>`
+				).insertAfter($container);
+			}
+			$toast.find(".grid-selection-toast__message").text(__("{0} rows selected", [count]));
+			$toast.show();
+		} else if ($toast.length) {
+			$toast.hide();
+		}
 	}
 
 	/**

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -772,16 +772,14 @@
 	margin-right: auto;
 	margin-top: calc(var(--padding-xl) * -1);
 	z-index: 2;
-	pointer-events: none;
 	display: none;
 
 	&__message {
 		display: inline-block;
 		background-color: rgba(0, 0, 0, 0.8);
 		color: var(--bg-color);
-		border-radius: var(--border-radius-md);
-		padding: var(--padding-xs) var(--padding-sm);
-		font-size: var(--text-sm);
+		border-radius: var(--border-radius-sm);
+		padding: var(--padding-xs) var(--padding-md);
 	}
 }
 

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -764,6 +764,27 @@
 	width: 100%;
 }
 
+.grid-selection-toast {
+	position: sticky;
+	bottom: var(--padding-md);
+	width: fit-content;
+	margin-left: auto;
+	margin-right: auto;
+	margin-top: calc(var(--padding-xl) * -1);
+	z-index: 2;
+	pointer-events: none;
+	display: none;
+
+	&__message {
+		display: inline-block;
+		background-color: rgba(0, 0, 0, 0.8);
+		color: var(--bg-color);
+		border-radius: var(--border-radius-md);
+		padding: var(--padding-xs) var(--padding-sm);
+		font-size: var(--text-sm);
+	}
+}
+
 .form-grid-container:has(.grid-row.grid-row-open) {
 	overflow-x: clip;
 	white-space: normal;


### PR DESCRIPTION
## Summary
Fix child-table grid `get_selected()` to return selected rows across all pagination pages, not just the currently rendered page.

### Before Fix
[Screencast from 2026-04-21 16-11-30.webm](https://github.com/user-attachments/assets/3bc6206c-3789-4d34-8ebd-b6eeff3adab6)

### After Fix
[Screencast from 2026-04-21 16-13-09.webm](https://github.com/user-attachments/assets/71b77c99-1a14-403c-99d7-e25113877706)

**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/65893](https://support.frappe.io/helpdesk/tickets/65893)