### PR TITLE
fix: replace icon-close with icon-x

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -504,7 +504,7 @@ frappe.ui.form.on("Number Card", {
 					<td class="text-center">
 						<a class="remove-filter text-muted" style="cursor: pointer;">
 							<svg class="icon icon-sm">
-								<use href="#icon-close" class="close"></use>
+								<use href="#icon-x" class="close"></use>
 							</svg>
 						</a>
 					</td>

--- a/frappe/public/js/frappe/ui/group_by/group_by.html
+++ b/frappe/public/js/frappe/ui/group_by/group_by.html
@@ -38,7 +38,7 @@
 		<div class="groupby-actions pull-left col-sm-1 hidden-xs">
 			<span class="remove-group-by">
 				<svg class="icon icon-sm">
-					<use href="#icon-close"></use>
+					<use href="#icon-x"></use>
 				</svg>
 			</span>
 		</div>

--- a/frappe/public/js/print_format_builder/ConfigureColumns.vue
+++ b/frappe/public/js/print_format_builder/ConfigureColumns.vue
@@ -49,7 +49,7 @@
 						/>
 						<button class="ml-2 btn btn-xs btn-icon" @click="remove_column(column)">
 							<svg class="icon icon-sm">
-								<use href="#icon-close"></use>
+								<use href="#icon-x"></use>
 							</svg>
 						</button>
 					</div>

--- a/frappe/public/js/print_format_builder/Field.vue
+++ b/frappe/public/js/print_format_builder/Field.vue
@@ -42,7 +42,7 @@
 				</button>
 				<button class="btn btn-xs btn-icon" @click="df['remove'] = true">
 					<svg class="icon icon-sm">
-						<use href="#icon-close"></use>
+						<use href="#icon-x"></use>
 					</svg>
 				</button>
 			</div>


### PR DESCRIPTION
Icon-close looks horrible replacing it with icon-x



Before
<img width="601" height="177" alt="Screenshot 2026-04-21 at 5 03 02 PM" src="https://github.com/user-attachments/assets/b7351ddc-701d-4d60-aa4f-d4113bd625f4" />


After
<img width="558" height="127" alt="Screenshot 2026-04-21 at 5 01 00 PM" src="https://github.com/user-attachments/assets/e1bc873d-0e08-4829-beda-f02620d269a7" />