### PR TITLE
fix: prevent persistence of virtual single doctypes

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -898,6 +898,9 @@ class Document(BaseDocument):
 
 	def update_single(self, d):
 		"""Updates values for Single type Document in `tabSingles`."""
+		if self.meta.is_virtual:
+			return
+
 		frappe.db.delete("Singles", {"doctype": self.doctype})
 		for field, value in d.items():
 			if field != "doctype":


### PR DESCRIPTION
There are many single doctypes which are being used for just scripting purposes and not saving anything - for example: Employee Attendance Tool in HRMS

Even if we disable save on such doctypes using `frm.disable_save()`, there are cases where user somehow saves it(maybe using `cur_frm.save()`) and value persists for all users. Example - Ticket [65614](https://support.frappe.io/helpdesk/tickets/65614?view=VIEW-HD+Ticket-1520)
There is no server side validation for save. 
We can make all such doctypes virtual and this adds server side block for save