### PR TITLE
fix(datetime): set lastSelectedDate in datetime picker

### DIFF
--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -20,6 +20,7 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 			const date_obj = frappe.datetime.str_to_obj(raw_value);
 			this.datepicker.selectedDates = [date_obj];
 			this.datepicker.viewDate = date_obj;
+			this.datepicker.lastSelectedDate = date_obj;
 		}
 	}
 


### PR DESCRIPTION
Missed out setting `lastSelectedDate` in previous change (https://github.com/frappe/frappe/commit/74205be64285a4bccc6f9b1b2e2088e28c0b3ea4), this caused a crash when a set value was being changed via datetime picker (in particular the slider was not reflecting the changes onto UI and console was logging the crash).

**Before**:


https://github.com/user-attachments/assets/fe26c2aa-4849-40fa-8c2b-6c6fe3130fdb



**After**:


https://github.com/user-attachments/assets/74d2945a-df04-40a0-a230-6f0df646d881


closes #38775 