### PR TITLE
fix: nested set child table filter

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -628,15 +628,17 @@ class Engine:
 			# If _field is from a dynamic field, its name might be just the target fieldname.
 			# We need the original string ('link.target') or the fieldname from the main doctype.
 			original_field_name = field if isinstance(field, str) else _field.name
-			# Check if the original field name exists in the *main* doctype meta
-			main_meta = frappe.get_meta(self.doctype)
-			if main_meta.has_field(original_field_name):
-				_df = main_meta.get_field(original_field_name)
-				ref_doctype = _df.options if _df else self.doctype
+			# Resolve against the filter's doctype (child table for child-field filters),
+			# falling back to the main queried doctype.
+			target_doctype = doctype or self.doctype
+			target_meta = frappe.get_meta(target_doctype)
+			if target_meta.has_field(original_field_name):
+				_df = target_meta.get_field(original_field_name)
+				ref_doctype = _df.options if _df else target_doctype
 			else:
-				# If not in main doctype, assume it's a standard field like 'name' or refers to the main doctype itself
+				# If not in target doctype, assume it's a standard field like 'name' or refers to the doctype itself
 				# This part might need refinement if nested set operators are used with dynamic fields.
-				ref_doctype = self.doctype
+				ref_doctype = target_doctype
 
 			nodes = get_nested_set_hierarchy_result(ref_doctype, docname, hierarchy)
 			operator_fn = (

--- a/frappe/tests/test_nestedset.py
+++ b/frappe/tests/test_nestedset.py
@@ -297,6 +297,44 @@ class TestNestedSet(IntegrationTestCase):
 		self.assertNotIn(record, str(frappe.qb.get_query(table=linked_doctype, filters=exclusive_link)))
 		self.assertIn(record, str(frappe.qb.get_query(table=linked_doctype, filters=inclusive_link)))
 
+	def test_desc_filters_on_child_table_field(self):
+		"""Nested-set operator on a child-table field should resolve ref_doctype
+		against the child table, not the parent queried doctype."""
+		child_doctype = (
+			new_doctype(
+				istable=1,
+				fields=[
+					{
+						"fieldname": "link_field",
+						"fieldtype": "Link",
+						"options": TEST_DOCTYPE,
+					}
+				],
+			)
+			.insert()
+			.name
+		)
+		parent_doctype = (
+			new_doctype(
+				fields=[
+					{
+						"fieldname": "child_table",
+						"fieldtype": "Table",
+						"options": child_doctype,
+					}
+				],
+			)
+			.insert()
+			.name
+		)
+
+		record = "Child 1"
+		child_filter = [[child_doctype, "link_field", "descendants of (inclusive)", record]]
+
+		# Must not raise pymysql/MySQLdb OperationalError 1054 ("Unknown column 'lft'")
+		frappe.get_all(parent_doctype, filters=child_filter, fields=["name"])
+		frappe.qb.get_query(parent_doctype, filters=child_filter).run()
+
 	def test_disabled_records_in_treeview(self):
 		"""
 		Tests the `get_children` util for showing / skipping disabled records in treeview


### PR DESCRIPTION
In _build_criterion_for_simple_filter ([query.py#L631-L639](https://github.com/frappe/frappe/blob/develop/frappe/database/query.py#L631-L639)) ref_doctype is resolved against self.doctype only, ignoring the doctype argument passed through _apply_filter. For child-table filters, the parent doctype has no such field, so ref_doctype falls through to the parent and get_nested_set_hierarchy_result runs SELECT lft, rgt FROM tab<parent>.

Affects develop and version-15.

Raising PR on Behalf of @maasanto 