### PR TITLE
fix(link): respect `fetch_if_empty` during client-side link validation

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -915,6 +915,21 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			for (const [target_field, source_field] of Object.entries(this.fetch_map)) {
 				const field_value = has_value ? response[source_field] : "";
 
+				const target_df = layout_set_value
+					? this.layout.fields_dict[target_field]?.df
+					: frappe.meta.get_docfield(this.df.parent, target_field);
+
+				if (target_df?.fetch_if_empty && !field_value) {
+					let current_value;
+					if (layout_set_value) {
+						current_value = this.layout.get_value(target_field);
+					} else {
+						const doc = locals[this.df.parent]?.[this.docname];
+						current_value = doc?.[target_field];
+					}
+					if (current_value) continue;
+				}
+
 				if (layout_set_value) {
 					layout_set_value(target_field, field_value);
 				} else {

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -919,7 +919,11 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					? this.layout.fields_dict[target_field]?.df
 					: frappe.meta.get_docfield(this.df.parent, target_field);
 
-				if (target_df?.fetch_if_empty && !field_value) continue;
+				const current_value = layout_set_value
+					? this.layout.get_value(target_field)
+					: frappe.model.get_value(this.df.parent, this.docname, target_field);
+
+				if (target_df?.fetch_if_empty && current_value && !field_value) continue;
 
 				if (layout_set_value) {
 					layout_set_value(target_field, field_value);

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -919,16 +919,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					? this.layout.fields_dict[target_field]?.df
 					: frappe.meta.get_docfield(this.df.parent, target_field);
 
-				if (target_df?.fetch_if_empty && !field_value) {
-					let current_value;
-					if (layout_set_value) {
-						current_value = this.layout.get_value(target_field);
-					} else {
-						const doc = locals[this.df.parent]?.[this.docname];
-						current_value = doc?.[target_field];
-					}
-					if (current_value) continue;
-				}
+				if (target_df?.fetch_if_empty && !field_value) continue;
 
 				if (layout_set_value) {
 					layout_set_value(target_field, field_value);


### PR DESCRIPTION
## Description

When a Link field with `fetch_from` is changed `validate_link_and_fetch` overwrites dependent fields with the fetched value unconditionally, even when the source document has no value for the field. This clears out user entered data on every link change.
The `fetch_if_empty` property is already respected server side in `base_document.py`, but the client side fetch in `link.js` ignores it entirely.

## Behaviour Before

https://github.com/user-attachments/assets/9375dd97-aec4-4abb-9fa9-0a84047b313f


## Behaviour Now

https://github.com/user-attachments/assets/e434a4ab-7ef3-46ce-a243-2c188b47935f

