### PR TITLE
fix: Page not found error when saving public workspace with multi word name

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -758,9 +758,13 @@ frappe.views.Workspace = class Workspace {
 								indicator: "green",
 							});
 							if (page.public) {
-								frappe.set_route("desk", page.title.toLowerCase());
+								frappe.set_route("desk", frappe.router.slug(page.title));
 							} else {
-								frappe.set_route("desk", "private", page.title.toLowerCase());
+								frappe.set_route(
+									"desk",
+									"private",
+									frappe.router.slug(page.title)
+								);
 							}
 						}
 					},


### PR DESCRIPTION
### Description:

Fixes a bug where saving a public workspace having a multi word name (eg. "Test Workspace") cause 404 Not Found error.

### Cause:
In `save_page()`, the redirect after saving was using `.toLowerCase()` to change the route.

But, the workspace slug was set by `frappe.router.slug()`