### PR TITLE
fix(SMTP): config to disable EHLO after AUTH

### DIFF
--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -93,7 +93,8 @@ class SMTPServer:
 					frappe.msgprint(res[1], raise_exception=frappe.OutgoingEmailError)
 
 			# Re-issue EHLO after AUTH to refresh server capabilities
-			_session.ehlo()
+			if not frappe.conf.smtp_no_ehlo_after_auth:
+				_session.ehlo()
 
 			self._session = _session
 			self._enqueue_connection_closure()


### PR DESCRIPTION
EHLO before AUTH:

```py
{
    "smtputf8": "",
    "size": "104857600",
    "requiretls": "",
    "pipelining": "",
    "no-soliciting": "",
    "enhancedstatuscodes": "",
    "chunking": "",
    "binarymime": "",
    "auth": " PLAIN LOGIN XOAUTH2 OAUTHBEARER",
    "8bitmime": "",
}
```

EHLO after AUTH:

```py
{
    "vrfy": "",
    "expn": "",
    "smtputf8": "",
    "size": "104857600",
    "requiretls": "",
    "pipelining": "",
    "no-soliciting": "",
    "mt-priority": "MIXER",
    "futurerelease": "604800 1777527456",
    "enhancedstatuscodes": "",
    "dsn": "",
    "deliverby": "1296000",
    "chunking": "",
    "binarymime": "",
    "8bitmime": "",
}
```

ESMTP capabilities can differ before and after AUTH. Some servers reset the session when EHLO is reissued, and there’s no reliable way to predict this behaviour. Additionally, certain providers (e.g., Brevo) do not allow re-AUTH after EHLO at all.

Since major providers like Gmail, Outlook, and Yahoo support reissuing EHLO, removing it entirely isn’t a viable option. However, we can make this behaviour configurable (`smtp_no_ehlo_after_auth` = 1, defaults to 0).

related: https://github.com/frappe/frappe/pull/36988