### PR TITLE
fix(MultiSelectDialog): refresh results on Link field selection without requiring blur

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -361,6 +361,20 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 			});
 		});
 
+		const refresh_results = frappe.utils.debounce(() => {
+			frappe.flags.auto_scroll = false;
+			if (me.is_child_selection_enabled()) {
+				me.show_child_results();
+			} else {
+				me.empty_list();
+				me.get_results();
+			}
+		}, 300);
+
+		this.$parent
+			.find(".input-with-feedback")
+			.on("awesomplete-selectcomplete", refresh_results);
+
 		this.$parent.find(".input-with-feedback").on("change", () => {
 			frappe.flags.auto_scroll = false;
 			if (this.is_child_selection_enabled()) {


### PR DESCRIPTION
Resolve: #38842 

---

**Before:**

https://github.com/user-attachments/assets/df5b95bd-beda-48e9-9b03-6fc90b4d7c8f

**After**

https://github.com/user-attachments/assets/45f07257-ef54-4549-b71a-4b313333b14c
