### PR TITLE
feat: Add bulk delete utility for property setters

### DIFF
--- a/frappe/custom/doctype/property_setter/property_setter.py
+++ b/frappe/custom/doctype/property_setter/property_setter.py
@@ -114,3 +114,47 @@ def delete_property_setter(doc_type, property=None, field_name=None, row_name=No
 	property_setters = frappe.db.get_values("Property Setter", filters)
 	for ps in property_setters:
 		frappe.get_doc("Property Setter", ps).delete(ignore_permissions=True, force=True)
+
+
+def bulk_delete_property_setters(property_setters: list[dict], bypass_hooks: bool = False):
+	"""
+	Delete property setters.
+
+	:param property_setters: List of filters for Property Setter rows.
+	:param bypass_hooks: If `True`, raw delete without doc hooks.
+
+	Example of `property_setters`:
+	```
+	[
+	    {"doctype": "ToDo", "fieldname": "status", "property": "hidden"},
+	    {"doctype": "ToDo", "fieldname": "status", "property": "read_only"},
+	]
+	```
+	"""
+	field_map = {
+		"doctype": "doc_type",
+		"fieldname": "field_name",
+	}
+
+	for property_setter in property_setters:
+		filters = property_setter.copy()
+
+		for key, fieldname in field_map.items():
+			if key in filters:
+				filters[fieldname] = filters.pop(key)
+
+		if not filters:
+			continue
+
+		if bypass_hooks:
+			frappe.db.delete("Property Setter", filters)
+
+			if filters.get("doc_type"):
+				frappe.clear_cache(doctype=filters["doc_type"])
+		else:
+			property_setter_names = frappe.get_all("Property Setter", filters=filters, pluck="name")
+
+			for property_setter_name in property_setter_names:
+				frappe.get_doc("Property Setter", property_setter_name).delete(
+					ignore_permissions=True, force=True
+				)

--- a/frappe/custom/doctype/property_setter/property_setter.py
+++ b/frappe/custom/doctype/property_setter/property_setter.py
@@ -111,9 +111,7 @@ def delete_property_setter(doc_type, property=None, field_name=None, row_name=No
 	if row_name:
 		filters["row_name"] = row_name
 
-	property_setters = frappe.db.get_values("Property Setter", filters)
-	for ps in property_setters:
-		frappe.get_doc("Property Setter", ps).delete(ignore_permissions=True, force=True)
+	_delete_property_setters(filters)
 
 
 def bulk_delete_property_setters(property_setters: list[dict], bypass_hooks: bool = False):
@@ -130,11 +128,17 @@ def bulk_delete_property_setters(property_setters: list[dict], bypass_hooks: boo
 	    {"doctype": "ToDo", "fieldname": "status", "property": "read_only"},
 	]
 	```
+
+	---
+
+	Note: `doctype` and `fieldname` are mandatory.
 	"""
 	field_map = {
 		"doctype": "doc_type",
 		"fieldname": "field_name",
 	}
+
+	doctypes_to_clear = set()
 
 	for property_setter in property_setters:
 		filters = property_setter.copy()
@@ -146,15 +150,21 @@ def bulk_delete_property_setters(property_setters: list[dict], bypass_hooks: boo
 		if not filters:
 			continue
 
+		if not filters.get("doc_type") or not filters.get("field_name"):
+			frappe.throw(_("`doctype` and `fieldname` are required for deleting property setters."))
+
 		if bypass_hooks:
 			frappe.db.delete("Property Setter", filters)
-
-			if filters.get("doc_type"):
-				frappe.clear_cache(doctype=filters["doc_type"])
+			doctypes_to_clear.add(filters["doc_type"])
 		else:
-			property_setter_names = frappe.get_all("Property Setter", filters=filters, pluck="name")
+			_delete_property_setters(filters)
 
-			for property_setter_name in property_setter_names:
-				frappe.get_doc("Property Setter", property_setter_name).delete(
-					ignore_permissions=True, force=True
-				)
+	for doctype in doctypes_to_clear:
+		frappe.clear_cache(doctype=doctype)
+
+
+def _delete_property_setters(filters: dict):
+	property_setters = frappe.get_all("Property Setter", filters=filters, pluck="name")
+
+	for ps in property_setters:
+		frappe.get_doc("Property Setter", ps).delete(ignore_permissions=True, force=True)

--- a/frappe/custom/doctype/property_setter/test_property_setter.py
+++ b/frappe/custom/doctype/property_setter/test_property_setter.py
@@ -1,7 +1,48 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+import frappe
+from frappe.custom.doctype.property_setter.property_setter import (
+	bulk_delete_property_setters,
+)
 from frappe.tests import IntegrationTestCase
 
 
 class TestPropertySetter(IntegrationTestCase):
-	pass
+	def test_bulk_delete_property_setters(self):
+		doctype = "ToDo"
+		fieldname = "status"
+
+		property_1 = "hidden"
+		property_2 = "no_copy"
+		properties = [property_1, property_2]
+
+		for property_name in properties:
+			frappe.make_property_setter(
+				{
+					"doctype": doctype,
+					"fieldname": fieldname,
+					"property": property_name,
+					"value": 1,
+					"property_type": "Check",
+				}
+			)
+
+		def property_setter_exists(property_name):
+			return frappe.db.exists(
+				"Property Setter",
+				{"doc_type": doctype, "field_name": fieldname, "property": property_name},
+			)
+
+		for property_name in properties:
+			self.assertTrue(property_setter_exists(property_name))
+
+		# 1
+		bulk_delete_property_setters(
+			[{"doctype": doctype, "fieldname": fieldname, "property": property_1}],
+			bypass_hooks=True,
+		)
+		self.assertFalse(property_setter_exists(property_1))
+
+		# 2
+		bulk_delete_property_setters([{"doc_type": doctype, "field_name": fieldname, "property": property_2}])
+		self.assertFalse(property_setter_exists(property_2))


### PR DESCRIPTION
## Requirements

- In many custom apps, `Property Setters` are defined using a structure like:

```python
PROPERTY_SETTERS = [
    {
        "doctype": "Todo",
        "fieldname": "status",
        "property": "default",
        "property_type": "Data",
        "value": "Required",
    },
    ...
]
```

- While creating Property Setters, Frappe utilities can be used. However, there is no similar utility available for deleting them.

Frappe implementations for creation:

- [`frappe.make_property_setters`](https://github.com/frappe/frappe/blob/fdf74f32b9a4bded258d1be18b6c0020764158f3/frappe/__init__.py#L1177)  
- [`make_property_setter`](https://github.com/frappe/frappe/blob/fdf74f32b9a4bded258d1be18b6c0020764158f3/frappe/custom/doctype/property_setter/property_setter.py#L74) from `frappe.custom.doctype.property_setter.property_setter`

Examples:

- https://github.com/alyf-de/banking/blob/d6387254c339d166768a981a367d9f0dc12c274e/banking/uninstall.py#L36  
- https://github.com/resilient-tech/india-compliance/blob/04960d7f419480e88a65afa7e2933d612132eb31/india_compliance/gst_india/setup/__init__.py#L84  

## Solution

This PR introduces a new method to remove Property Setters using the same structure as used during creation. This keeps the API consistent and simplifies maintenance.

> [!NOTE]  
> Backport required for v16 and v15.