### PR TITLE
fix(db_query): unique alias on self-referential Link joins

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -2074,16 +2074,22 @@ class LinkTableField(DynamicTableField):
 	) -> None:
 		super().__init__(doctype, fieldname, parent_doctype, alias=alias)
 		self.link_fieldname = link_fieldname
-		self.table = frappe.qb.DocType(self.doctype)
+		self.table = self._get_joined_table()
 		self.field = self.table[self.fieldname]
 
-	def apply_select(self, query: QueryBuilder, engine: "Engine" = None) -> QueryBuilder:
+	def _get_joined_table(self):
 		table = frappe.qb.DocType(self.doctype)
+		if self.doctype == self.parent_doctype:
+			table = table.as_(f"tab{self.doctype}_{self.link_fieldname}")
+		return table
+
+	def apply_select(self, query: QueryBuilder, engine: "Engine" = None) -> QueryBuilder:
+		table = self._get_joined_table()
 		query = self.apply_join(query, engine=engine)
 		return query.select(getattr(table, self.fieldname).as_(self.alias or None))
 
 	def apply_join(self, query: QueryBuilder, engine: "Engine" = None) -> QueryBuilder:
-		table = frappe.qb.DocType(self.doctype)
+		table = self._get_joined_table()
 		main_table = frappe.qb.DocType(self.parent_doctype)
 		if not query.is_joined(table):
 			query = query.left_join(table).on(table.name == getattr(main_table, self.link_fieldname))

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1179,6 +1179,66 @@ class TestDBQuery(IntegrationTestCase):
 		data = get()
 		self.assertEqual(len(data["values"]), 1)
 
+	def test_self_referential_link_joins(self):
+		from frappe.desk.reportview import get
+
+		if not frappe.db.exists("DocType", "Self Linked DocType"):
+			frappe.get_doc(
+				{
+					"doctype": "DocType",
+					"custom": 1,
+					"module": "Custom",
+					"name": "Self Linked DocType",
+					"naming_rule": "Random",
+					"autoname": "hash",
+					"fields": [
+						{
+							"label": "Title",
+							"fieldname": "title",
+							"fieldtype": "Data",
+						},
+						{
+							"label": "Parent Ref",
+							"fieldname": "parent_ref",
+							"fieldtype": "Link",
+							"options": "Self Linked DocType",
+						},
+						{
+							"label": "Sibling Ref",
+							"fieldname": "sibling_ref",
+							"fieldtype": "Link",
+							"options": "Self Linked DocType",
+						},
+					],
+				}
+			).insert()
+		else:
+			frappe.db.delete("Self Linked DocType")
+
+		root = frappe.get_doc({"doctype": "Self Linked DocType", "title": "Root"}).insert()
+		sibling = frappe.get_doc({"doctype": "Self Linked DocType", "title": "Sibling"}).insert()
+		frappe.get_doc(
+			{
+				"doctype": "Self Linked DocType",
+				"title": "Child",
+				"parent_ref": root.name,
+				"sibling_ref": sibling.name,
+			}
+		).insert()
+
+		frappe.form_dict.doctype = "Self Linked DocType"
+		frappe.form_dict.fields = [
+			"`tabSelf Linked DocType`.`name`",
+			"`tabSelf Linked DocType`.`parent_ref`",
+			"`tabSelf Linked DocType`.`sibling_ref`",
+			"parent_ref.title as parent_title",
+			"sibling_ref.title as sibling_title",
+		]
+
+		# Shouldn't raise pymysql.err.OperationalError: (1066, "Not unique table/alias: 'tabSelf Linked DocType2'")
+		data = get()
+		self.assertEqual(len(data["values"]), 3)
+
 	def test_select_star_expansion(self):
 		count = frappe.get_list("Language", [{"SUM": 1}, {"COUNT": "*"}], as_list=1, order_by=None)[0]
 		self.assertEqual(count[0], frappe.db.count("Language"))


### PR DESCRIPTION
When a DocType has two or more Link fields pointing back to itself and list view tries to join them, pypika auto-aliased both joins with the same '<table>2' suffix, producing a MySQL 1066 'Not unique table/alias' error.

Alias each self-referential join with 'tab<doctype>_<link_fieldname>' so every join gets a unique alias, and use the same aliased table in apply_select so SELECT references resolve correctly.

Raising PR on behalf of @vijayanrxbb

closes #38851
