### PR TITLE
fix(ListView): content overlow in small screens

### DIFF
--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -644,6 +644,7 @@ input.list-header-checkbox {
 	.layout-main-section .frappe-list .result-container {
 		.result {
 			overflow: hidden;
+			display: block;
 			input.list-row-checkbox,
 			input.list-header-checkbox {
 				width: 15px !important;


### PR DESCRIPTION
### Before
<img width="818" height="1402" alt="image" src="https://github.com/user-attachments/assets/c1afa517-1e19-46fd-b690-50706bffabcb" />
### After
<img width="778" height="1396" alt="image" src="https://github.com/user-attachments/assets/d0a4e143-6aae-438f-ad10-7a109deaac31" />
