### PR TITLE
fix(cache_manager): reset valid_columns when doctype cache is cleared

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -122,6 +122,11 @@ def clear_doctype_cache(doctype=None):
 	clear_controller_cache(doctype)
 	frappe.client_cache.erase_persistent_caches(doctype=doctype)
 
+	if doctype:
+		frappe.local.valid_columns.pop(doctype, None)
+	else:
+		frappe.local.valid_columns = {}
+
 	_clear_doctype_cache_from_redis(doctype)
 	if hasattr(frappe.db, "after_commit"):
 		frappe.db.after_commit.add(lambda: _clear_doctype_cache_from_redis(doctype))
@@ -297,6 +302,7 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 
 		reset_metadata_version()
 		frappe.local.cache = {}
+		frappe.local.valid_columns = {}
 		frappe.local.new_doc_templates = {}
 
 		for fn in frappe.get_hooks("clear_cache"):

--- a/frappe/tests/test_caching.py
+++ b/frappe/tests/test_caching.py
@@ -371,3 +371,26 @@ class TestHttpCache(FrappeAPITestCase):
 		)
 		self.assertEqual(resp.cache_control.max_age, 600)
 		self.assertTrue(resp.cache_control.private)
+
+
+class TestValidColumnsCache(IntegrationTestCase):
+	def test_clear_doctype_cache(self):
+		from frappe.cache_manager import clear_doctype_cache
+
+		frappe.get_single("System Settings")
+		clear_doctype_cache("System Settings")
+		self.assertNotIn("System Settings", frappe.local.valid_columns)
+
+		frappe.get_single("System Settings")
+		self.assertIn("System Settings", frappe.local.valid_columns)
+		self.assertIsInstance(frappe.local.valid_columns["System Settings"], list)
+
+	def test_clear_cache(self):
+		from frappe.cache_manager import clear_cache
+
+		frappe.get_single("System Settings")
+		self.assertIn("System Settings", frappe.local.valid_columns)
+		self.assertIsInstance(frappe.local.valid_columns["System Settings"], list)
+
+		clear_cache()
+		self.assertEqual(frappe.local.valid_columns, {})


### PR DESCRIPTION
## Problem

`frappe.local.valid_columns` is a per‑process cache of `Meta.get_valid_columns()`, populated on first access inside `BaseDocument.get_valid_columns()` and consumed by `BaseDocument.init_valid_columns()` to seed `self.__dict__` with every valid field of the doctype.

It is only initialized once per request (in `frappe/__init__.py`) and was **never invalidated** afterwards — neither `clear_cache()` nor `clear_doctype_cache()` touched it, even though both wipe `local.cache` and the Redis-backed `doctype_meta` hash it is derived from.

In any long-lived process that mutates a DocType and then calls `clear_cache()` (`bench migrate`, background workers, `bench execute`, tests that reload a DocType, Customize Form flows), subsequent document loads end up with a `Meta` object that knows about the new field, but a document whose `__dict__` does not — because `init_valid_columns` reads from the stale `local.valid_columns` list.

The visible symptom is an `AttributeError` on a field that is clearly defined in the DocType JSON, e.g. during post-model-sync migration patches that edit a Single whose JSON was just extended in the same migrate pass:

```
AttributeError: 'SystemSettings' object has no attribute 'allowed_file_extensions'.
```

## Root cause

`frappe.clear_cache()` clears `local.cache`, `local.new_doc_templates`, `local.role_permissions`, `local.request_cache`, `local.system_settings`, `local.website_settings` — but leaves `local.valid_columns` alone. Same for `clear_doctype_cache(doctype)`. So the per-doctype field list silently outlives the `Meta` it was derived from.

## Fix

Invalidate `local.valid_columns` everywhere the meta cache is invalidated:

- `clear_doctype_cache(doctype)`: pop the single entry, or `clear()` when no doctype is given.
- `clear_cache()` (global `else` branch): reset the dict alongside the other `local.*` caches it already resets.

This also transitively fixes narrower flows: `DocType.on_update` already calls `frappe.clear_cache(doctype=self.name)`, so a resynced DocType now invalidates its own `valid_columns` entry immediately during `sync_all()`, not just at the final global sweep.

## Reproduction (pre-fix)

```python
import frappe

doc = frappe.get_doc("System Settings")          # primes local.valid_columns

# simulate the meta gaining a field while the local cache stays hot:
frappe.local.valid_columns["System Settings"] = [
    c for c in frappe.local.valid_columns["System Settings"] if c != "<any field>"
]

frappe.clear_cache()                              # pre-fix: valid_columns NOT reset
frappe.get_doc("System Settings").save()          # AttributeError on <any field>
```

With this patch, `frappe.clear_cache()` clears `local.valid_columns` too, and the final `save()` succeeds.