### PR TITLE
ci: Tweak coverage (again)

### DIFF
--- a/.github/helper/ci.py
+++ b/.github/helper/ci.py
@@ -1,11 +1,18 @@
-# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
-# MIT License. See LICENSE
 """
-frappe.coverage
-~~~~~~~~~~~~~~~~
+Script to run Python tests while capturing accurte coverage.
 
-Coverage settings for frappe
+Enabling coverage after `frappe` is imported leaves out a lot of lines that are imported by
+default.
+
+This is essentially a copy of `frappe/coverage.py` BUT also triggers test runner with desired
+configuration.
 """
+
+import json
+import sys
+import os
+from pathlib import Path
+from coverage import Coverage
 
 STANDARD_INCLUSIONS = ["*.py"]
 
@@ -22,7 +29,7 @@ STANDARD_EXCLUSIONS = [
 	"*/node_modules/*",
 	"*/doctype/*/*_dashboard.py",
 	"*/patches/*",
-	"*/.github/*",
+	".github/*",
 ]
 
 # tested via commands' test suite
@@ -54,6 +61,11 @@ FRAPPE_EXCLUSIONS = [
 ]
 
 
+def get_bench_path():
+	"""Get the path to the bench directory."""
+	return Path(__file__).resolve().parents[4]
+
+
 class CodeCoverage:
 	"""
 	Context manager for handling code coverage.
@@ -69,12 +81,6 @@ class CodeCoverage:
 
 	def __enter__(self):
 		if self.with_coverage:
-			import os
-
-			from coverage import Coverage
-
-			from frappe.utils import get_bench_path
-
 			# Generate coverage report only for app that is being tested
 			source_path = os.path.join(get_bench_path(), "apps", self.app)
 			omit = STANDARD_EXCLUSIONS[:]
@@ -82,12 +88,9 @@ class CodeCoverage:
 			if self.app == "frappe":
 				omit.extend(FRAPPE_EXCLUSIONS)
 
-			self.coverage = Coverage(
-				source=[source_path],
-				omit=omit,
-				include=STANDARD_INCLUSIONS,
-				data_suffix=True,
-			)
+			self.coverage = Coverage(source=[source_path], omit=omit, include=STANDARD_INCLUSIONS)
+
+			assert "frappe" not in sys.modules, "frappe already imported, coverage will be inaccurate"
 			self.coverage.start()
 		return self
 
@@ -97,3 +100,20 @@ class CodeCoverage:
 			self.coverage.save()
 			self.coverage.xml_report(outfile=self.outfile)
 			print("Saved Coverage")
+
+
+if __name__ == "__main__":
+	app = "frappe"
+	site = os.environ.get("SITE") or "test_site"
+	with_coverage = json.loads(os.environ.get("CAPTURE_COVERAGE", "true").lower())
+
+	# Parse build information from environment variables
+	build_number = int(os.environ.get("BUILD_NUMBER"))
+	total_builds = int(os.environ.get("TOTAL_BUILDS"))
+
+	# Run tests with code coverage
+	with CodeCoverage(with_coverage=with_coverage, app=app):
+		from frappe.parallel_test_runner import ParallelTestRunner
+
+		runner = ParallelTestRunner(app, site=site, build_number=build_number, total_builds=total_builds)
+		runner.setup_and_run()

--- a/.github/workflows/_base-server-tests.yml
+++ b/.github/workflows/_base-server-tests.yml
@@ -107,17 +107,14 @@ jobs:
 
       - name: Run Tests
         run: |
-          bench --site test_site \
-            run-parallel-tests \
-            --with-coverage \
-            --app "${{ github.event.repository.name }}" \
-            --total-builds ${{ inputs.parallel-runs }} \
-            --build-number ${{ matrix.index }}
+          cd sites && ../env/bin/python3 ../apps/frappe/.github/helper/ci.py
 
         env:
           DB: ${{ matrix.db }}
           # consumed by bench run-parallel-tests
           CAPTURE_COVERAGE: ${{ inputs.enable-coverage }}
+          BUILD_NUMBER: ${{ matrix.index }}
+          TOTAL_BUILDS: ${{ inputs.parallel-runs }}
           FRAPPE_SENTRY_DSN: ${{ secrets.SENTRY_DSN || '' }}
 
       - name: Upload coverage data

--- a/frappe/coverage.py
+++ b/frappe/coverage.py
@@ -47,6 +47,8 @@ FRAPPE_EXCLUSIONS = [
 	"*frappe/setup.py",
 	"*/doctype/*/*_dashboard.py",
 	"*/patches/*",
+	"*/frappe/database/postgres/*",
+	"*/frappe/database/sqlite/*",
 	*TESTED_VIA_CLI,
 ]
 


### PR DESCRIPTION
Last CI refactor removed the [script](https://github.com/frappe/frappe/pull/17831/) that was responsible for accurately tracking coverage of pre-imported stuff.
