### PR TITLE
fix(sidebar): notification panel and icon hover state

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -111,7 +111,7 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 		if (frappe.utils.is_mac()) {
 			shortcut = shortcut.replace("Ctrl+", "⌘");
 		}
-		return `<span class="sidebar-item-suffix keyboard-shortcut">${shortcut}</span>`;
+		return `<span class="keyboard-shortcut">${shortcut}</span>`;
 	}
 	setup_editing_controls() {
 		this.menu_items = this.get_menu_items();

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -159,7 +159,7 @@
 	.standard-items-sections {
 		.dropdown-notifications {
 			.notifications-list {
-				left: 3.4%;
+				left: 100%;
 			}
 		}
 	}
@@ -170,11 +170,6 @@
 		// make it an overlay on hover
 		position: absolute;
 		width: var(--sidebar-width);
-		.dropdown-notifications {
-			.notifications-list {
-				left: 100%;
-			}
-		}
 
 		.collapse-sidebar-link {
 			text-decoration: none;

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -359,6 +359,7 @@
 }
 .sidebar-item-suffix {
 	margin-left: auto;
+	padding: 7px;
 	.keyboard-shortcut {
 		color: var(--ink-gray-4, #999999);
 		font-size: var(--text-sm);


### PR DESCRIPTION
### Before
<img width="1164" height="918" alt="image" src="https://github.com/user-attachments/assets/5633fb54-434b-4724-96d1-6b474080fc35" />

### After
<img width="1296" height="826" alt="image" src="https://github.com/user-attachments/assets/5dec1fcc-7f98-4574-bc85-c8866eac7239" />


### Before
<img width="718" height="920" alt="image" src="https://github.com/user-attachments/assets/e9ff68e2-7e95-4313-8ea9-9689a66447b9" />

### After
<img width="822" height="914" alt="image" src="https://github.com/user-attachments/assets/059c87ff-5f35-4012-bd08-ce4e17589051" />
