### PR TITLE
fix: navigation breaks when sort field has null values

### DIFF
--- a/frappe/desk/form/test_form.py
+++ b/frappe/desk/form/test_form.py
@@ -14,7 +14,9 @@ class TestForm(IntegrationTestCase):
 		self.assertTrue("DocType" in results)
 
 	def test_sort_field_fallback(self):
-		self.assertEqual(_sort_field_fallback("Note", "public"), 0)
+		self.assertIsNone(_sort_field_fallback("Note", "name"))
+		self.assertIsNone(_sort_field_fallback("Note", "creation"))
+		self.assertIsNone(_sort_field_fallback("Note", "public"))
 		self.assertEqual(_sort_field_fallback("Note", "expire_notification_on"), "0001-01-01")
 		self.assertEqual(_sort_field_fallback("Event Notifications", "time"), "00:00:00")
 		self.assertEqual(_sort_field_fallback("Note", "title"), "")

--- a/frappe/desk/form/test_form.py
+++ b/frappe/desk/form/test_form.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.desk.form.linked_with import get_linked_docs, get_linked_doctypes
+from frappe.desk.form.utils import _sort_field_fallback, get_next
 from frappe.tests import IntegrationTestCase
 
 
@@ -11,3 +12,50 @@ class TestForm(IntegrationTestCase):
 		results = get_linked_docs("Role", "System Manager", linkinfo=get_linked_doctypes("Role"))
 		self.assertTrue("User" in results)
 		self.assertTrue("DocType" in results)
+
+	def test_sort_field_fallback(self):
+		self.assertEqual(_sort_field_fallback("Note", "public"), 0)
+		self.assertEqual(_sort_field_fallback("Note", "expire_notification_on"), "0001-01-01")
+		self.assertEqual(_sort_field_fallback("Event Notifications", "time"), "00:00:00")
+		self.assertEqual(_sort_field_fallback("Note", "title"), "")
+		self.assertEqual(_sort_field_fallback("Note", "nonexistent_field_xyz"), "")
+
+	def test_get_next_with_null_sort_field(self):
+		notes = []
+		for i, expire in enumerate([None, "2099-01-01", None]):
+			note = frappe.get_doc(
+				{
+					"doctype": "Note",
+					"title": f"test_navigate_null_{frappe.generate_hash(length=8)}_{i}",
+					"expire_notification_on": expire,
+				}
+			).insert(ignore_permissions=True)
+			notes.append(note.name)
+
+		try:
+			filters = {"name": ["in", notes]}
+
+			next_name = get_next(
+				"Note",
+				notes[0],
+				prev=0,
+				sort_field="expire_notification_on",
+				sort_order="asc",
+				filters=filters,
+			)
+			self.assertIsNotNone(next_name)
+			self.assertIn(next_name, notes)
+
+			prev_name = get_next(
+				"Note",
+				notes[1],
+				prev=1,
+				sort_field="expire_notification_on",
+				sort_order="asc",
+				filters=filters,
+			)
+			self.assertIsNotNone(prev_name)
+			self.assertIn(prev_name, [notes[0], notes[2]])
+		finally:
+			for name in notes:
+				frappe.delete_doc("Note", name, force=1, ignore_permissions=True)

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -10,6 +10,7 @@ import frappe.desk.form.meta
 from frappe import _
 from frappe.core.doctype.file.utils import extract_images_from_html
 from frappe.desk.form.document_follow import follow_document
+from frappe.query_builder.functions import IfNull
 
 if TYPE_CHECKING:
 	from frappe.core.doctype.comment.comment import Comment
@@ -92,9 +93,12 @@ def get_next(
 		filters = json.loads(filters)
 
 	table = frappe.qb.DocType(doctype)
-	sort_column = table[sort_field]
 	name_column = table.name
+	fallback = _sort_field_fallback(doctype, sort_field)
+	sort_column = IfNull(table[sort_field], fallback)
 	current_sort_value = frappe.db.get_value(doctype, value, sort_field)
+	if current_sort_value is None:
+		current_sort_value = fallback
 
 	is_ascending = sort_order.lower() == "asc"
 	if prev == is_ascending:
@@ -121,6 +125,18 @@ def get_next(
 
 	frappe.msgprint(_("No further records"))
 	return None
+
+
+def _sort_field_fallback(doctype: str, fieldname: str):
+	df = frappe.get_meta(doctype).get_field(fieldname)
+	if df:
+		if df.fieldtype in ("Float", "Int", "Currency", "Percent", "Check"):
+			return 0
+		if df.fieldtype in ("Date", "Datetime"):
+			return "0001-01-01"
+		if df.fieldtype == "Time":
+			return "00:00:00"
+	return ""
 
 
 def get_pdf_link(doctype, docname, print_format="Standard", no_letterhead=0):

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -94,11 +94,14 @@ def get_next(
 
 	table = frappe.qb.DocType(doctype)
 	name_column = table.name
-	fallback = _sort_field_fallback(doctype, sort_field)
-	sort_column = IfNull(table[sort_field], fallback)
 	current_sort_value = frappe.db.get_value(doctype, value, sort_field)
-	if current_sort_value is None:
-		current_sort_value = fallback
+	fallback = _sort_field_fallback(doctype, sort_field)
+	if fallback is not None:
+		sort_column = IfNull(table[sort_field], fallback)
+		if current_sort_value is None:
+			current_sort_value = fallback
+	else:
+		sort_column = table[sort_field]
 
 	is_ascending = sort_order.lower() == "asc"
 	if prev == is_ascending:
@@ -128,14 +131,19 @@ def get_next(
 
 
 def _sort_field_fallback(doctype: str, fieldname: str):
+	if fieldname in ("name", "modified", "creation", "modified_by", "owner", "idx", "docstatus"):
+		return None
 	df = frappe.get_meta(doctype).get_field(fieldname)
-	if df:
-		if df.fieldtype in ("Float", "Int", "Currency", "Percent", "Check"):
-			return 0
-		if df.fieldtype in ("Date", "Datetime"):
-			return "0001-01-01"
-		if df.fieldtype == "Time":
-			return "00:00:00"
+	if df is None:
+		return ""
+	if df.fieldtype in ("Check", "Float", "Int", "Currency", "Percent"):
+		return None
+	if getattr(df, "not_nullable", False):
+		return None
+	if df.fieldtype in ("Date", "Datetime"):
+		return "0001-01-01"
+	if df.fieldtype == "Time":
+		return "00:00:00"
 	return ""
 
 


### PR DESCRIPTION
## Bug

The prev/next arrows in the form stops working and show **"No further records"** even when more records exist.
This happens when the field used for sorting has empty values (`NULL`). If the current record or nearby records have empty values, the comparison fails and navigation breaks.

## Why it happens

Default fields like `name`, `creation`, etc. always have values, so this issue doesn’t show up there. But custom fields (or optional fields like Date/Link) often start as empty for existing records. If you sort using such a field, navigation stops working.

## Fix

Tried to handle empty values by replacing them with safe default values during comparison. This ensures navigation works even when fields are empty, without changing the actual data.

## Before

https://github.com/user-attachments/assets/552381ae-83a1-4bc0-9577-04b313dd9f66

## After

https://github.com/user-attachments/assets/0e822c95-fda3-4b9f-ba31-cc9870d9775a

## Note
Nothing is wrong with the field setup. It’s a normal Link field (e.g. Workflow State) without default or required, so empty values (`NULL`) are expected for both old and new records. This is standard behavior for custom fields, not a bug.

The issue is in the `get_next` logic, not in the field itself.

---
Ref: https://support.frappe.io/helpdesk/tickets/63212?view=VIEW-HD+Ticket-1252



closes #38515
