### PR TITLE
Fix: query report pdf backend generation

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1592,13 +1592,52 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	async pdf_report(print_settings) {
+		const custom_format = await this.get_custom_format(print_settings);
+
+		if (custom_format) {
+			await this.render_report_letterhead(print_settings);
+			return this.render_pdf_client_side(print_settings, custom_format);
+		}
+
+		const filters = this.get_filter_values();
+		if (this.prepared_report_name) {
+			filters.prepared_report_name = this.prepared_report_name;
+		}
+
+		const selected_columns = print_settings.columns?.length
+			? this.get_visible_columns()
+					.filter((col) => print_settings.columns.includes(col.fieldname))
+					.map((col) => col.fieldname)
+			: null;
+
+		const js_filters = (this.filters || [])
+			.filter((filter) => filter.fieldtype === "Link" && filters[filter.fieldname] !== "")
+			.map(({ fieldname, fieldtype, options }) => ({ fieldname, fieldtype, options }));
+
+		open_url_post("/api/method/frappe.utils.print_format.download_report_pdf", {
+			report_name: this.report_name,
+			filters: JSON.stringify(filters),
+			print_settings: JSON.stringify({
+				columns: selected_columns,
+				with_letter_head: print_settings.with_letter_head || 0,
+				letter_head_name: print_settings.letter_head_name || "",
+				include_filters: print_settings.include_filters || 0,
+				repeat_header_footer: print_settings.repeat_header_footer || 0,
+			}),
+			orientation: print_settings.orientation || "Landscape",
+			ignore_prepared_report: this.ignore_prepared_report || 0,
+			is_tree: this.report_settings.tree || 0,
+			parent_field: this.report_settings.parent_field || "",
+			are_default_filters: 0,
+			js_filters: JSON.stringify(js_filters),
+			custom_columns: JSON.stringify(this.custom_columns?.length ? this.custom_columns : []),
+		});
+	}
+
+	render_pdf_client_side(print_settings, custom_format) {
 		const base_url = frappe.urllib.get_base_url();
 		const print_css = frappe.boot.print_css;
 		const landscape = print_settings.orientation == "Landscape";
-
-		const custom_format = await this.get_custom_format(print_settings);
-
-		await this.render_report_letterhead(print_settings);
 
 		const columns = this.get_columns_for_print(print_settings, custom_format);
 		const data = this.get_data_for_print();
@@ -1616,7 +1655,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			print_settings: print_settings,
 		});
 
-		// Render Report in HTML
 		const html = frappe.render_template("print_template", {
 			title: __(this.report_name),
 			content: content,
@@ -1630,10 +1668,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			can_use_smaller_font: this.report_doc.is_standard === "Yes" && custom_format ? 0 : 1,
 		});
 
-		let filter_values = [],
-			name_len = 0;
-		for (var key of Object.keys(applied_filters)) {
-			name_len = name_len + applied_filters[key].toString().length;
+		let filter_values = [];
+		let name_len = 0;
+		for (let key of Object.keys(applied_filters)) {
+			name_len += applied_filters[key].toString().length;
 			if (name_len > 200) break;
 			filter_values.push(applied_filters[key]);
 		}

--- a/frappe/templates/report/print_grid.html
+++ b/frappe/templates/report/print_grid.html
@@ -1,0 +1,46 @@
+{%- if title %}
+<h2 class="text-center">{{ title }}</h2>
+<hr>
+{%- endif %}
+
+{%- if subtitle %}
+{{ subtitle }}
+<hr>
+{%- endif %}
+
+<table class="table table-bordered">
+	<thead>
+		<tr>
+			<th>#</th>
+			{%- for col in columns %}
+			{%- if col.label and col.fieldname != "_check" %}
+			<th
+				{%- if col.width %} style="min-width: {{ col.width }}px"{% endif %}
+				{%- if col.fieldtype in numeric_fieldtypes %} class="text-right"{% endif %}
+			>{{ col.label }}</th>
+			{%- endif %}
+			{%- endfor %}
+		</tr>
+	</thead>
+	<tbody>
+		{%- for row in data %}
+		{%- set bold = row.bold == 1 or row.get("_is_total_row") %}
+		<tr style="height: 30px">
+			<td{% if bold %} style="font-weight: bold"{% endif %}>
+				{{ loop.index }}
+			</td>
+			{%- for col in columns %}
+			{%- if col.label and col.fieldname != "_check" %}
+			{%- set value = row.get(col.fieldname, "") %}
+			{%- set longest_word = (value | string).split(" ") | map("length") | max if value else 0 %}
+			<td{% if bold %} style="font-weight: bold"{% endif %}{% if longest_word > 45 %} class="overflow-wrap-anywhere"{% endif %}>
+				<span{%- if loop.index0 == 0 and row.indent %} style="padding-left: {{ (row.indent | int) * 2 }}em"{% endif %}>
+					{{ value }}
+				</span>
+			</td>
+			{%- endif %}
+			{%- endfor %}
+		</tr>
+		{%- endfor %}
+	</tbody>
+</table>

--- a/frappe/templates/report/print_template.html
+++ b/frappe/templates/report/print_template.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="{{ lang }}" dir="{{ layout_direction }}">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>{{ title }}</title>
+	<style>
+		{{ print_css }}
+	</style>
+</head>
+<body>
+	<div class="print-format-gutter">
+		<div class="print-format {% if landscape %}landscape{% endif %}"
+			{%- if columns | length > 20 and can_use_smaller_font %}
+				style="font-size: 4.0pt"
+			{%- endif %}
+		>
+			{%- if letter_head and letter_head.header %}
+			<div{% if repeat_header_footer %} id="header-html" class="hidden-pdf"{% endif %}>
+				<div class="letter-head">{{ letter_head.header }}</div>
+			</div>
+			{%- endif %}
+			{{ content }}
+			{%- if repeat_header_footer %}
+			<div id="footer-html" class="visible-pdf">
+				{%- if letter_head and letter_head.footer %}
+				<div class="letter-head-footer">
+					{{ letter_head.footer }}
+				</div>
+				{%- endif %}
+				<p class="text-center small page-number visible-pdf">
+					Page <span class="page"></span> of <span class="topage"></span>
+				</p>
+			</div>
+			{%- endif %}
+		</div>
+	</div>
+</body>
+</html>

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -1,9 +1,13 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import json
+from typing import ClassVar
+
 import frappe
 from frappe.desk.query_report import build_xlsx_data, export_query, run
 from frappe.tests import IntegrationTestCase
+from frappe.utils.print_format import build_report_pdf_html, download_report_pdf
 from frappe.utils.xlsxutils import XLSXMetadata, XLSXStyleBuilder, make_xlsx
 
 
@@ -352,6 +356,225 @@ data = columns, result
 
 		frappe.delete_doc("Report", REPORT_NAME, delete_permanently=True)
 		frappe.db.commit()
+
+
+class TestDownloadReportPDF(IntegrationTestCase):
+	REPORT_NAME = "Test PDF Report"
+	ESCAPE_REPORT_NAME = "Test PDF Escape Report"
+	TOTAL_REPORT_NAME = "Test PDF Total Report"
+	RICH_REPORT_NAME = "Test PDF Rich Report"
+	CHECK_REPORT_NAME = "Test PDF Check Report"
+	EDITOR_REPORT_NAME = "Test PDF Editor Report"
+
+	# report_name -> extra fields merged into the default Query Report definition
+	REPORTS: ClassVar[dict] = {
+		REPORT_NAME: {"query": "SELECT name, module, issingle FROM tabDocType LIMIT 10"},
+		ESCAPE_REPORT_NAME: {"query": "SELECT '<b>x</b>' AS label"},
+		TOTAL_REPORT_NAME: {
+			"add_total_row": 1,
+			"query": "SELECT 'A' AS item, 10 AS amount UNION SELECT 'B', 20",
+		},
+		# Code/Text columns (via the "Label:Fieldtype" hint) must be escaped, not trusted
+		RICH_REPORT_NAME: {
+			"query": (
+				"SELECT '<b>x</b>' AS \"Snippet:Code:200\", "
+				"CONCAT('a<i>y</i>', CHAR(10), 'z') AS \"Note:Text:200\""
+			),
+		},
+		CHECK_REPORT_NAME: {"query": 'SELECT 1 AS "Active:Check:80" UNION SELECT 0'},
+		# Text Editor holds backend-sanitized HTML and must render as-is
+		EDITOR_REPORT_NAME: {"query": "SELECT '<b>x</b>' AS \"Body:Text Editor:200\""},
+	}
+
+	@classmethod
+	def setUpClass(cls) -> None:
+		super().setUpClass()
+
+		for report_name, overrides in cls.REPORTS.items():
+			if not frappe.db.exists("Report", report_name):
+				frappe.get_doc(
+					{
+						"doctype": "Report",
+						"report_name": report_name,
+						"ref_doctype": "DocType",
+						"report_type": "Query Report",
+						"is_standard": "No",
+						"letter_head": "",
+						**overrides,
+					}
+				).insert(ignore_permissions=True)
+		# reports must be committed: run() opens a read-only transaction that both needs
+		# to see them and refuses to start while uncommitted writes are pending
+		frappe.db.commit()  # nosemgrep
+
+	@classmethod
+	def tearDownClass(cls) -> None:
+		for report_name in cls.REPORTS:
+			frappe.delete_doc("Report", report_name, delete_permanently=True)
+		# persist the fixture cleanup above
+		frappe.db.commit()  # nosemgrep
+		super().tearDownClass()
+
+	def tearDown(self) -> None:
+		# download_report_pdf writes an access log (direct insert in test mode); drop it so
+		# the next test's read-only report run does not trip ImplicitCommitError
+		frappe.db.rollback()
+		super().tearDown()
+
+	def test_basic_pdf_generation(self):
+		download_report_pdf(report_name=self.REPORT_NAME)
+
+		self.assertEqual(frappe.local.response.type, "pdf")
+		self.assertTrue(frappe.local.response.filecontent)
+		self.assertIn(self.REPORT_NAME.replace(" ", "-"), frappe.local.response.filename)
+
+	def test_selected_columns(self):
+		download_report_pdf(
+			report_name=self.REPORT_NAME,
+			print_settings=json.dumps({"columns": ["name", "module"]}),
+		)
+
+		self.assertEqual(frappe.local.response.type, "pdf")
+		self.assertTrue(frappe.local.response.filecontent)
+
+	def test_selected_non_prefix_columns_keep_alignment(self):
+		"""Dropping a middle column must not leak its values under a kept later column."""
+		html, _ = build_report_pdf_html(
+			self.REPORT_NAME,
+			print_settings={"columns": ["name", "issingle"]},
+		)
+
+		self.assertIn("issingle", html)
+		self.assertNotIn(">Module<", html)
+		self.assertNotIn("Core", html)
+
+	def test_orientation_portrait(self):
+		download_report_pdf(report_name=self.REPORT_NAME, orientation="Portrait")
+
+		self.assertEqual(frappe.local.response.type, "pdf")
+		self.assertTrue(frappe.local.response.filecontent)
+
+	def test_with_letterhead(self):
+		letterhead_name = frappe.db.get_value("Letter Head", {"is_default": 1})
+		if not letterhead_name:
+			self.skipTest("No default Letter Head configured")
+
+		download_report_pdf(
+			report_name=self.REPORT_NAME,
+			print_settings=json.dumps(
+				{
+					"with_letter_head": 1,
+					"letter_head_name": letterhead_name,
+				}
+			),
+		)
+
+		self.assertEqual(frappe.local.response.type, "pdf")
+		self.assertTrue(frappe.local.response.filecontent)
+
+	def test_with_filters_in_filename(self):
+		download_report_pdf(
+			report_name=self.REPORT_NAME,
+			filters=json.dumps({"module": "Core"}),
+		)
+
+		self.assertEqual(frappe.local.response.type, "pdf")
+		self.assertIn("Core", frappe.local.response.filename)
+
+	def test_permission_denied_for_guest(self):
+		frappe.set_user("Guest")
+		try:
+			self.assertRaises(frappe.PermissionError, download_report_pdf, report_name=self.REPORT_NAME)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_list_rows_converted_to_dict(self):
+		result = run(self.REPORT_NAME)
+		fieldnames = [c["fieldname"] for c in result["columns"]]
+		row = result["result"][0]
+		values = row if isinstance(row, list) else [row[f] for f in fieldnames]
+		name, module = values[0], values[1]
+
+		html, _ = build_report_pdf_html(self.REPORT_NAME)
+
+		self.assertIn(name, html)
+		self.assertIn(module, html)
+
+	def test_check_field_formatting(self):
+		download_report_pdf(report_name=self.REPORT_NAME)
+
+		content = frappe.local.response.filecontent
+		self.assertIsInstance(content, bytes)
+		self.assertTrue(len(content) > 0)
+
+	def test_are_default_filters_false(self):
+		download_report_pdf(
+			report_name=self.REPORT_NAME,
+			filters=json.dumps({}),
+			are_default_filters=False,
+		)
+
+		self.assertEqual(frappe.local.response.type, "pdf")
+		self.assertTrue(frappe.local.response.filecontent)
+
+	def test_js_filters_passed(self):
+		js_filters = [{"fieldname": "module", "fieldtype": "Link", "options": "Module Def"}]
+		download_report_pdf(
+			report_name=self.REPORT_NAME,
+			filters=json.dumps({"module": "Core"}),
+			js_filters=json.dumps(js_filters),
+		)
+
+		self.assertEqual(frappe.local.response.type, "pdf")
+		self.assertTrue(frappe.local.response.filecontent)
+
+	def test_html_in_cell_values_is_escaped(self):
+		html, _ = build_report_pdf_html(self.ESCAPE_REPORT_NAME)
+
+		self.assertIn("&lt;b&gt;x&lt;/b&gt;", html)
+		self.assertNotIn("<b>x</b>", html)
+
+	def test_code_field_value_is_escaped_in_pre(self):
+		html, _ = build_report_pdf_html(self.RICH_REPORT_NAME)
+
+		self.assertIn("<pre>&lt;b&gt;x&lt;/b&gt;</pre>", html)
+		self.assertNotIn("<b>x</b>", html)
+
+	def test_text_field_value_is_escaped_with_newlines(self):
+		html, _ = build_report_pdf_html(self.RICH_REPORT_NAME)
+
+		self.assertIn("a&lt;i&gt;y&lt;/i&gt;<br>z", html)
+		self.assertNotIn("<i>y</i>", html)
+
+	def test_check_field_rendering(self):
+		html, _ = build_report_pdf_html(self.CHECK_REPORT_NAME)
+
+		self.assertIn("✓", html)
+		self.assertIn("✗", html)
+
+	def test_text_editor_value_rendered_raw(self):
+		# Text Editor holds backend-sanitized HTML and is rendered without escaping
+		html, _ = build_report_pdf_html(self.EDITOR_REPORT_NAME)
+
+		self.assertIn("<b>x</b>", html)
+
+	def test_filters_rendered_and_escaped(self):
+		html, _ = build_report_pdf_html(
+			self.REPORT_NAME,
+			filters={"module": "<b>Core</b>"},
+			print_settings={"include_filters": 1},
+		)
+
+		self.assertIn("&lt;b&gt;Core&lt;/b&gt;", html)
+		self.assertNotIn("<b>Core</b>", html)
+
+	def test_total_row_is_bold(self):
+		self.assertTrue(run(self.TOTAL_REPORT_NAME).get("add_total_row"))
+
+		html, _ = build_report_pdf_html(self.TOTAL_REPORT_NAME)
+
+		self.assertIn("font-weight: bold", html)
+		self.assertIn("30", html)
 
 
 def create_mock_data():

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -282,6 +282,195 @@ def report_to_pdf(html: str, orientation: str = "Landscape"):
 
 
 @frappe.whitelist()
+def download_report_pdf(
+	report_name: str,
+	filters: str | dict | None = None,
+	print_settings: str | dict | None = None,
+	orientation: str = "Landscape",
+	ignore_prepared_report: bool = False,
+	custom_columns: str | list | None = None,
+	is_tree: bool = False,
+	parent_field: str | None = None,
+	are_default_filters: bool = True,
+	js_filters: str | list | None = None,
+):
+	html, filename = build_report_pdf_html(
+		report_name,
+		filters=filters,
+		print_settings=print_settings,
+		orientation=orientation,
+		ignore_prepared_report=ignore_prepared_report,
+		custom_columns=custom_columns,
+		is_tree=is_tree,
+		parent_field=parent_field,
+		are_default_filters=are_default_filters,
+		js_filters=js_filters,
+	)
+
+	make_access_log(file_type="PDF", method="PDF", page=report_name)
+	frappe.local.response.filename = f"{filename}.pdf"
+	frappe.local.response.filecontent = get_pdf(
+		html,
+		{
+			"orientation": orientation,
+			"proxy": "http://0.0.0.0:0",
+			"bypass-proxy-for": urlparse(frappe.utils.get_url(allow_header_override=False)).hostname,
+			"load-error-handling": "ignore",
+		},
+	)
+	frappe.local.response.type = "pdf"
+
+
+def build_report_pdf_html(
+	report_name: str,
+	filters: str | dict | None = None,
+	print_settings: str | dict | None = None,
+	orientation: str = "Landscape",
+	ignore_prepared_report: bool = False,
+	custom_columns: str | list | None = None,
+	is_tree: bool = False,
+	parent_field: str | None = None,
+	are_default_filters: bool = True,
+	js_filters: str | list | None = None,
+) -> tuple[str, str]:
+	"""Re-run a report on the backend and render it to print HTML.
+
+	Returns the rendered HTML and the suggested download filename (without extension).
+	"""
+	from frappe.desk.query_report import run
+	from frappe.model import numeric_fieldtypes
+	from frappe.utils import cstr, escape_html
+	from frappe.utils.formatters import format_value
+	from frappe.utils.jinja_globals import is_rtl
+	from frappe.www.printview import get_print_style
+
+	if isinstance(filters, str):
+		filters = json.loads(filters)
+
+	if isinstance(print_settings, str):
+		print_settings = json.loads(print_settings)
+
+	if isinstance(js_filters, str):
+		js_filters = json.loads(js_filters)
+
+	if isinstance(custom_columns, str):
+		custom_columns = json.loads(custom_columns)
+
+	print_settings = frappe._dict(print_settings or {})
+
+	result = run(
+		report_name,
+		filters,
+		ignore_prepared_report=ignore_prepared_report,
+		custom_columns=custom_columns or None,
+		is_tree=is_tree,
+		parent_field=parent_field,
+		are_default_filters=are_default_filters,
+		js_filters=js_filters,
+	)
+	report = frappe.get_doc("Report", report_name)
+	columns = result.get("columns", [])
+	data = result.get("result", [])
+
+	# map against the full column list before any column filtering, else values
+	# zip against the wrong fieldnames
+	all_fieldnames = [col["fieldname"] for col in columns]
+	for i, row in enumerate(data):
+		if isinstance(row, list):
+			data[i] = dict(zip(all_fieldnames, row, strict=False))
+
+	# flag the appended total row so the template can bold it, like the client grid
+	if result.get("add_total_row") and data:
+		data[-1]["_is_total_row"] = True
+
+	if print_settings.get("columns"):
+		columns = [col for col in columns if col["fieldname"] in print_settings.columns]
+
+	# Jinja autoescape is off here: escape every value except these intentionally-HTML
+	# fieldtypes. Text/Small Text and Code mirror the client grid formatters below.
+	html_fieldtypes = ("Text Editor", "Markdown Editor", "HTML")
+
+	for row in data:
+		for col in columns:
+			fieldname = col["fieldname"]
+			value = row.get(fieldname)
+			fieldtype = col.get("fieldtype")
+			if value is None or value == "":
+				row[fieldname] = ""
+			elif fieldtype == "Check":
+				row[fieldname] = "✓" if value == 1 else "✗"
+			elif fieldtype == "Code":
+				row[fieldname] = f"<pre>{escape_html(cstr(value))}</pre>"
+			elif fieldtype in ("Text", "Small Text"):
+				if col.get("ignore_xss_filter"):
+					row[fieldname] = format_value(value, col, row)
+				else:
+					row[fieldname] = escape_html(cstr(value)).replace("\n", "<br>")
+			else:
+				formatted = format_value(value, col, row)
+				if fieldtype not in html_fieldtypes:
+					formatted = escape_html(formatted)
+				row[fieldname] = formatted
+
+	letter_head = None
+	if print_settings.get("with_letter_head") and print_settings.get("letter_head_name"):
+		letter_head = render_letterhead_for_print(print_settings.letter_head_name)
+
+	filters_html = ""
+	if print_settings.get("include_filters") and isinstance(filters, dict):
+		filter_fields = {f.fieldname: f for f in (report.filters or [])}
+		for fieldname, value in filters.items():
+			if not value:
+				continue
+			df = filter_fields.get(fieldname)
+			label = escape_html(_(df.label) if df else fieldname)
+			filters_html += (
+				f'<div class="filter-row"><strong>{label}:</strong> {escape_html(cstr(value))}</div>'
+			)
+
+	content = frappe.get_template("templates/report/print_grid.html").render(
+		{
+			"title": _(report_name),
+			"subtitle": filters_html or None,
+			"columns": columns,
+			"data": data,
+			"numeric_fieldtypes": numeric_fieldtypes,
+		}
+	)
+
+	print_css = get_print_style()
+
+	html = frappe.get_template("templates/report/print_template.html").render(
+		{
+			"title": _(report_name),
+			"content": content,
+			"print_css": print_css,
+			"landscape": orientation == "Landscape",
+			"columns": columns,
+			"lang": frappe.local.lang,
+			"layout_direction": "rtl" if is_rtl() else "ltr",
+			"can_use_smaller_font": report.is_standard == "Yes",
+			"letter_head": letter_head,
+			"repeat_header_footer": print_settings.get("repeat_header_footer"),
+		}
+	)
+
+	filename = report_name.replace(" ", "-").replace("/", "-")
+	if isinstance(filters, dict):
+		parts = []
+		length = 0
+		for value in filters.values():
+			length += len(str(value))
+			if length > 200:
+				break
+			parts.append(str(value))
+		if parts:
+			filename += "_" + "_".join(parts)
+
+	return html, filename
+
+
+@frappe.whitelist()
 def render_letterhead_for_print(letterhead: str | None = None, doc: dict | str | None = None) -> dict:
 	"""Render letterhead HTML (header/footer) with Jinja for report printing."""
 


### PR DESCRIPTION
Closes #38151

Downloading a query report as PDF previously rendered the report grid in the browser and sent the generated HTML to the PDF endpoint. For large reports with many rows or wide columns, the payload could exceed `request.max_content_length` (25 MB by default), causing the request to fail with HTTP 413 before PDF generation started.

This change moves report rendering to the server. The client now sends only the report name, applied filters, and print settings to a new `download_report_pdf` endpoint. The endpoint re-runs the report using `frappe.desk.query_report.run()`, generates the grid HTML from server-side templates, and returns the PDF. As a result, request payload size remains small regardless of report size.

To preserve existing output, cell values are escaped using the same rules as the client-side grid formatters, ensuring columns such as Code, Text, Check, and Text Editor render consistently in both the report view and the exported PDF.

Custom print formats continue to use the existing client-side flow, as they may rely on report-specific print scripts. Only the default grid-based PDF export has been moved to the backend.
