### PR TITLE
fix(datatable): left border visibility

### DIFF
--- a/frappe/public/scss/desk/frappe_datatable.scss
+++ b/frappe/public/scss/desk/frappe_datatable.scss
@@ -17,7 +17,6 @@
 	--dt-no-data-message-width: max-content;
 
 	background-color: var(--bg-color);
-	margin-left: -1px;
 	margin-top: 0px;
 	border-radius: var(--dt-border-radius);
 	@include get_textstyle("base", "regular");


### PR DESCRIPTION
### Before
<img width="1926" height="1504" alt="image" src="https://github.com/user-attachments/assets/a0199671-7921-4ad0-8e4e-5a1dbc647b90" />

### After
<img width="2046" height="1530" alt="image" src="https://github.com/user-attachments/assets/0ca45091-5c80-4cc6-b107-9daa89cf4fcf" />
