### PR TITLE
chore: update datatble to 1.20.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fast-deep-equal": "^2.0.1",
     "fast-glob": "^3.2.5",
     "frappe-charts": "2.0.0-rc27",
-    "frappe-datatable": "1.20.2",
+    "frappe-datatable": "1.20.3",
     "frappe-gantt": "^1.2.1",
     "frappe-quill-image-resize": "^3.0.9",
     "gemoji": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1433,10 +1433,10 @@ frappe-charts@2.0.0-rc27:
   resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-2.0.0-rc27.tgz#a04737d36bcce5381b25ad48896c43b02eb62852"
   integrity sha512-J4WCrHYB6oR4Dfu28aaCxlUu64C/V+qJlNE1E0xpya2/yCeqDZ8LA6pS63SBMOdV2CTP8cJ6Isk5m+rZi9gElA==
 
-frappe-datatable@1.20.2:
-  version "1.20.2"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.20.2.tgz#5cea64425bf35855ec5f14d916ff4ec2b4ca2bbf"
-  integrity sha512-XaN96/woV/VyRsWQgnbRmi1XV3lrnZkUWRP9ANNRkJSmniYddJVQKt7K9w6Ilq+vclNvJX96iQc7B6m77w1xXg==
+frappe-datatable@1.20.3:
+  version "1.20.3"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.20.3.tgz#d86d1cac56298fee805efe6cc14dd6df9299ef3b"
+  integrity sha512-IApAJ0AObOO48vXA2+QhFkSrrXPbVFGEZlmztJz9pDp6KfR/DpZSiHbbfdV1xbUiweYwcbteGpINSLuSVfYHoA==
   dependencies:
     hyperlist "^1.0.0-beta"
     lodash "^4.17.5"


### PR DESCRIPTION
In this version of the DataTable, the label ‘Unstick from left’ has been changed to ‘Unfreeze’ to maintain consistency.