### PR TITLE
fix: prevent incompatible field type changes when DocType has data

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -224,11 +224,62 @@ class DocType(Document):
 			self.before_update = frappe.get_doc("DocType", self.name)
 			self.setup_fields_to_fetch()
 			self.validate_field_name_conflicts()
+			self.validate_fieldtype_change()
 
 		check_email_append_to(self)
 
 		if self.default_print_format and not self.custom:
 			frappe.throw(_("Standard DocType cannot have default print format, use Customize Form"))
+
+	def validate_fieldtype_change(self):
+		# Validate that field type changes are allowed
+		if self.issingle or self.is_virtual:
+			return
+
+		old_fields = {df.fieldname: df for df in self.before_update.fields}
+		string_types = frozenset(("varchar", "text", "longtext"))
+		numeric_types = frozenset(("int", "bigint", "decimal", "tinyint"))
+
+		for new_df in self.fields:
+			old_df = old_fields.get(new_df.fieldname)
+			if not old_df or old_df.fieldtype == new_df.fieldtype:
+				continue
+
+			old_db_type = frappe.db.type_map.get(old_df.fieldtype)
+			new_db_type = frappe.db.type_map.get(new_df.fieldtype)
+
+			if not old_db_type or not new_db_type:
+				continue
+
+			old_col = old_db_type[0]
+			new_col = new_db_type[0]
+
+			if old_col == new_col:
+				continue
+
+			# Allow conversions within the same type family
+			if (old_col in numeric_types and new_col in numeric_types) or (
+				old_col in string_types and new_col in string_types
+			):
+				continue
+
+			# Any type -> string is safe
+			if new_col in string_types:
+				continue
+
+			# All other cross family conversions with data are unsafe
+			if frappe.db.count(self.name):
+				frappe.throw(
+					_(
+						"Cannot change field '{0}' from {1} to {2} because the DocType '{3}' has existing data."
+					).format(
+						new_df.label or new_df.fieldname,
+						old_df.fieldtype,
+						new_df.fieldtype,
+						self.name,
+					),
+					title=_("Cannot Change Field Type"),
+				)
 
 	def validate_field_name_conflicts(self):
 		"""Check if field names dont conflict with controller properties and methods"""

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -289,7 +289,7 @@ class TestPermissions(IntegrationTestCase):
 		doctype_meta.get_field("fields").set_only_once = 1
 		doc = frappe.get_doc("DocType", "Test Blog Post")
 		# change one property from the child table
-		doc.fields[-3].fieldtype = "Check"
+		doc.fields[-3].fieldtype = "Small Text"
 		self.assertRaises(frappe.CannotChangeConstantError, doc.save)
 		frappe.clear_cache(doctype="DocType")
 


### PR DESCRIPTION
> On behalf of @imgullu786
### Problem
Changing field type from Data to Int/Datetime/etc on a DocType with existing data throws an ALTER TABLE error, but the metadata change is still saved.

### Issue Screenshot
<img width="1280" height="510" alt="image" src="https://github.com/user-attachments/assets/9ea0b66e-d024-44b8-b6bc-6c43c1673065" />


### Fix
Added `validate_fieldtype_change()` in validation when doctype is not new. 
The validation logic:

Skips if
- same column type (exmple, Data -> Link, both varchar)
- same type family (eg, Int -> Float, both numeric)
- Any type -> string conversions (eg., Int -> Data, Date -> Text, etc)

And blocks cross family conversions when the table has existing data.

closes #38366