### PR TITLE
feat(webhook): retry failed deliveries on a backoff schedule

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -217,6 +217,7 @@ scheduler_events = {
 		"0/5 * * * *": [
 			"frappe.email.doctype.notification.notification.trigger_offset_alerts",
 			"frappe.search.sqlite_search.index_docs_in_queue",
+			"frappe.integrations.doctype.webhook.webhook.retry_failed_webhooks",
 		],
 		# 15 minutes
 		"0/15 * * * *": [

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -12,9 +12,11 @@ from frappe.integrations.doctype.webhook.webhook import (
 	enqueue_webhook,
 	get_webhook_data,
 	get_webhook_headers,
+	retry_failed_webhooks,
 )
 from frappe.tests import IntegrationTestCase
 from frappe.tests.classes.context_managers import timeout
+from frappe.utils import add_to_date, now_datetime
 
 
 @contextmanager
@@ -331,3 +333,113 @@ class TestWebhook(IntegrationTestCase):
 			doc = frappe.new_doc("Note")
 			doc.title = "Test Webhook Note"
 			enqueue_webhook(doc, wh)
+
+	def retry_webhook_config(self, url, max_retries=3, webhook_docevent="after_insert"):
+		return {
+			"doctype": "Webhook",
+			"webhook_doctype": "Note",
+			"webhook_docevent": webhook_docevent,
+			"enabled": 1,
+			"request_url": url,
+			"request_method": "POST",
+			"request_structure": "JSON",
+			"webhook_json": "{}",
+			"max_retries": max_retries,
+		}
+
+	@timeout(5, "Test webhooks should never wait, check mocked responses.")
+	def test_webhook_failure_schedules_retry(self):
+		"""A failed delivery logs a single row awaiting a scheduled retry"""
+		url = "https://httpbin.org/retry-schedule"
+		self.responses.add(responses.POST, url, status=500)
+
+		with get_test_webhook(self.retry_webhook_config(url, max_retries=3)) as wh:
+			doc = frappe.new_doc("Note")
+			doc.title = "Retry Note"
+			enqueue_webhook(doc, wh)
+
+			log = frappe.get_last_doc("Webhook Request Log", filters={"webhook": wh.name})
+			self.assertEqual(log.status, "Failed")
+			self.assertEqual(log.attempt, 1)
+			self.assertIsNotNone(log.next_retry)
+
+	@timeout(5, "Test webhooks should never wait, check mocked responses.")
+	def test_webhook_without_retries_is_exhausted(self):
+		"""With max_retries set to 0, a failed delivery is not retried"""
+		url = "https://httpbin.org/exhaust-now"
+		self.responses.add(responses.POST, url, status=500)
+
+		with get_test_webhook(self.retry_webhook_config(url, max_retries=0)) as wh:
+			doc = frappe.new_doc("Note")
+			doc.title = "No Retry Note"
+			enqueue_webhook(doc, wh)
+
+			log = frappe.get_last_doc("Webhook Request Log", filters={"webhook": wh.name})
+			self.assertEqual(log.status, "Exhausted")
+			self.assertIsNone(log.next_retry)
+
+	@timeout(5, "Test webhooks should never wait, check mocked responses.")
+	def test_sweeper_redelivers_due_webhook(self):
+		"""The sweeper re-sends a due delivery and marks it delivered on success"""
+		url = "https://httpbin.org/sweeper-success"
+		self.responses.add(responses.POST, url, status=500)
+		self.responses.add(responses.POST, url, status=200, json={})
+
+		with get_test_webhook(self.retry_webhook_config(url, max_retries=3)) as wh:
+			doc = frappe.new_doc("Note")
+			doc.title = "Sweeper Note"
+			enqueue_webhook(doc, wh)
+
+			log = frappe.get_last_doc("Webhook Request Log", filters={"webhook": wh.name})
+			self.assertEqual(log.status, "Failed")
+
+			frappe.db.set_value(
+				"Webhook Request Log", log.name, "next_retry", add_to_date(now_datetime(), seconds=-1)
+			)
+			retry_failed_webhooks()
+
+			log.reload()
+			self.assertEqual(log.status, "Delivered")
+			self.assertEqual(log.attempt, 2)
+			self.assertIsNone(log.next_retry)
+
+	@timeout(5, "Test webhooks should never wait, check mocked responses.")
+	def test_sweeper_exhausts_after_max_retries(self):
+		"""The sweeper stops retrying once max_retries is reached"""
+		url = "https://httpbin.org/sweeper-exhaust"
+		self.responses.add(responses.POST, url, status=500)
+
+		with get_test_webhook(self.retry_webhook_config(url, max_retries=1)) as wh:
+			doc = frappe.new_doc("Note")
+			doc.title = "Exhaust Note"
+			enqueue_webhook(doc, wh)
+
+			log = frappe.get_last_doc("Webhook Request Log", filters={"webhook": wh.name})
+			self.assertEqual(log.status, "Failed")
+
+			frappe.db.set_value(
+				"Webhook Request Log", log.name, "next_retry", add_to_date(now_datetime(), seconds=-1)
+			)
+			retry_failed_webhooks()
+
+			log.reload()
+			self.assertEqual(log.status, "Exhausted")
+			self.assertEqual(log.attempt, 2)
+			self.assertIsNone(log.next_retry)
+
+	@timeout(5, "Test webhooks should never wait, check mocked responses.")
+	def test_workflow_transition_failure_raises_without_scheduling(self):
+		"""A failed workflow_transition webhook raises instead of scheduling a retry"""
+		url = "https://httpbin.org/workflow-fail"
+		self.responses.add(responses.POST, url, status=500)
+
+		config = self.retry_webhook_config(url, max_retries=3, webhook_docevent="workflow_transition")
+		with get_test_webhook(config) as wh:
+			doc = frappe.new_doc("Note")
+			doc.title = "Workflow Note"
+			with self.assertRaises(Exception):
+				enqueue_webhook(doc, wh)
+
+			log = frappe.get_last_doc("Webhook Request Log", filters={"webhook": wh.name})
+			self.assertEqual(log.status, "Exhausted")
+			self.assertIsNone(log.next_retry)

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 import json
 from contextlib import contextmanager
+from unittest.mock import patch
 
 import responses
 from responses.matchers import json_params_matcher
@@ -467,6 +468,29 @@ class TestWebhook(IntegrationTestCase):
 			self.assertEqual(log.status, "Failed")
 			self.assertEqual(log.attempt, 2)
 			self.assertIsNotNone(log.next_retry)
+
+	@timeout(5, "Test webhooks should never wait, check mocked responses.")
+	def test_sweeper_skips_delivery_already_in_flight(self):
+		"""A due delivery whose retry job is still queued is not sent again"""
+		url = "https://httpbin.org/sweeper-in-flight"
+		self.responses.add(responses.POST, url, status=500)
+
+		with get_test_webhook(self.retry_webhook_config(url, max_retries=3)) as wh:
+			doc = frappe.new_doc("Note")
+			doc.title = "In Flight Note"
+			enqueue_webhook(doc, wh)
+
+			log = frappe.get_last_doc("Webhook Request Log", filters={"webhook": wh.name})
+			frappe.db.set_value(
+				"Webhook Request Log", log.name, "next_retry", add_to_date(now_datetime(), seconds=-1)
+			)
+
+			with patch("frappe.integrations.doctype.webhook.webhook.is_job_enqueued", return_value=True):
+				retry_failed_webhooks()
+
+			log.reload()
+			self.assertEqual(log.status, "Failed")
+			self.assertEqual(log.attempt, 1)
 
 	@timeout(5, "Test webhooks should never wait, check mocked responses.")
 	def test_retry_stops_when_webhook_disabled(self):

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -503,3 +503,18 @@ class TestWebhook(IntegrationTestCase):
 
 			self.assertIn(WEBHOOK_SECRET_HEADER, headers)
 			self.assertIsInstance(headers[WEBHOOK_SECRET_HEADER], str)
+
+	@timeout(5, "Test webhooks should never wait, check mocked responses.")
+	def test_unbuildable_request_is_exhausted(self):
+		"""A webhook whose dynamic URL fails to render is exhausted without a retry"""
+		config = self.retry_webhook_config("http://example.com/{{ doc.missing.attr }}")
+		config["is_dynamic_url"] = 1
+
+		with get_test_webhook(config) as wh:
+			doc = frappe.new_doc("Note")
+			doc.title = "Unbuildable Note"
+			enqueue_webhook(doc, wh)
+
+			log = frappe.get_last_doc("Webhook Request Log", filters={"webhook": wh.name})
+			self.assertEqual(log.status, "Exhausted")
+			self.assertIsNone(log.next_retry)

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -9,6 +9,7 @@ from responses.matchers import json_params_matcher
 import frappe
 from frappe.integrations.doctype.webhook import flush_webhook_execution_queue
 from frappe.integrations.doctype.webhook.webhook import (
+	WEBHOOK_SECRET_HEADER,
 	enqueue_webhook,
 	get_webhook_data,
 	get_webhook_headers,
@@ -443,3 +444,62 @@ class TestWebhook(IntegrationTestCase):
 			log = frappe.get_last_doc("Webhook Request Log", filters={"webhook": wh.name})
 			self.assertEqual(log.status, "Exhausted")
 			self.assertIsNone(log.next_retry)
+
+	@timeout(5, "Test webhooks should never wait, check mocked responses.")
+	def test_sweeper_reschedules_when_retries_remain(self):
+		"""A retry that fails with attempts left stays Failed and is scheduled again"""
+		url = "https://httpbin.org/sweeper-reschedule"
+		self.responses.add(responses.POST, url, status=500)
+		self.responses.add(responses.POST, url, status=500)
+
+		with get_test_webhook(self.retry_webhook_config(url, max_retries=2)) as wh:
+			doc = frappe.new_doc("Note")
+			doc.title = "Reschedule Note"
+			enqueue_webhook(doc, wh)
+
+			log = frappe.get_last_doc("Webhook Request Log", filters={"webhook": wh.name})
+			frappe.db.set_value(
+				"Webhook Request Log", log.name, "next_retry", add_to_date(now_datetime(), seconds=-1)
+			)
+			retry_failed_webhooks()
+
+			log.reload()
+			self.assertEqual(log.status, "Failed")
+			self.assertEqual(log.attempt, 2)
+			self.assertIsNotNone(log.next_retry)
+
+	@timeout(5, "Test webhooks should never wait, check mocked responses.")
+	def test_retry_stops_when_webhook_disabled(self):
+		"""A retry is exhausted without resending when the webhook is disabled"""
+		url = "https://httpbin.org/sweeper-disabled"
+		self.responses.add(responses.POST, url, status=500)
+
+		with get_test_webhook(self.retry_webhook_config(url, max_retries=3)) as wh:
+			doc = frappe.new_doc("Note")
+			doc.title = "Disabled Note"
+			enqueue_webhook(doc, wh)
+
+			log = frappe.get_last_doc("Webhook Request Log", filters={"webhook": wh.name})
+			frappe.db.set_value("Webhook", wh.name, "enabled", 0)
+			frappe.db.set_value(
+				"Webhook Request Log", log.name, "next_retry", add_to_date(now_datetime(), seconds=-1)
+			)
+			retry_failed_webhooks()
+
+			log.reload()
+			self.assertEqual(log.status, "Exhausted")
+			self.assertIsNone(log.next_retry)
+
+	def test_secured_webhook_signs_payload_with_string_header(self):
+		"""A secured webhook stores its signature as a string so it survives serialization and replay"""
+		config = self.retry_webhook_config("https://httpbin.org/secured")
+		config["enable_security"] = 1
+		config["webhook_secret"] = "super-secret"
+
+		with get_test_webhook(config) as wh:
+			doc = frappe.new_doc("Note")
+			doc.title = "Secured Note"
+			headers = get_webhook_headers(doc, wh, data=get_webhook_data(doc, wh))
+
+			self.assertIn(WEBHOOK_SECRET_HEADER, headers)
+			self.assertIsInstance(headers[WEBHOOK_SECRET_HEADER], str)

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -198,7 +198,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2026-04-22 15:33:54.888415",
+ "modified": "2026-07-11 19:04:55.894152",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -19,6 +19,7 @@
   "request_url",
   "is_dynamic_url",
   "timeout",
+  "max_retries",
   "background_jobs_queue",
   "cb_webhook",
   "request_method",
@@ -176,6 +177,14 @@
    "fieldname": "timeout",
    "fieldtype": "Int",
    "label": "Request Timeout"
+  },
+  {
+   "default": "3",
+   "description": "Number of retry attempts for failed requests. Set to 0 for no retries.",
+   "fieldname": "max_retries",
+   "fieldtype": "Int",
+   "label": "Max Retries",
+   "non_negative": 1
   },
   {
    "fieldname": "background_jobs_queue",

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -5,7 +5,6 @@ import base64
 import hashlib
 import hmac
 import json
-from time import sleep
 from urllib.parse import urlparse
 
 import requests
@@ -13,11 +12,14 @@ import requests
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import add_to_date, cint, now_datetime
 from frappe.utils.background_jobs import get_queues_timeout
 from frappe.utils.jinja import validate_template
 from frappe.utils.safe_exec import get_safe_globals
 
 WEBHOOK_SECRET_HEADER = "X-Frappe-Webhook-Signature"
+
+RETRY_SCHEDULE = [5 * 60, 30 * 60, 2 * 3600, 5 * 3600, 10 * 3600, 10 * 3600]
 
 
 class Webhook(Document):
@@ -38,6 +40,7 @@ class Webhook(Document):
 		enable_security: DF.Check
 		enabled: DF.Check
 		is_dynamic_url: DF.Check
+		max_retries: DF.Int
 		request_method: DF.Literal["POST", "PUT", "DELETE"]
 		request_structure: DF.Literal["", "Form URL-Encoded", "JSON"]
 		request_url: DF.SmallText
@@ -148,7 +151,7 @@ def get_context(doc):
 
 
 def enqueue_webhook(doc, webhook) -> None:
-	request_url = headers = data = r = None
+	request_url = headers = data = None
 	try:
 		if not isinstance(webhook, Document):
 			webhook: Webhook = frappe.get_doc("Webhook", webhook.get("name"))
@@ -160,35 +163,124 @@ def enqueue_webhook(doc, webhook) -> None:
 
 	except Exception as e:
 		frappe.logger().debug({"enqueue_webhook_error": e})
-		log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data)
+		log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data, status="Exhausted")
 		return
 
-	for i in range(3):
-		try:
-			r = requests.request(
-				method=webhook.request_method,
-				url=request_url,
-				data=frappe.as_json(data),
-				headers=headers,
-				timeout=webhook.timeout or 5,
+	res = None
+	try:
+		res = send_webhook_request(webhook.request_method, request_url, headers, data, webhook.timeout)
+		res.raise_for_status()
+		frappe.logger().debug({"webhook_success": res.text})
+		log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data, res, status="Delivered")
+
+	except Exception as e:
+		frappe.logger().debug({"webhook_error": e, "try": 1})
+
+		# A workflow transition needs the webhook result now, so fail it instead of deferring a retry.
+		if webhook.webhook_docevent == "workflow_transition":
+			log_request(
+				webhook.name, doc.doctype, doc.name, request_url, headers, data, res, status="Exhausted"
 			)
-			r.raise_for_status()
-			frappe.logger().debug({"webhook_success": r.text})
-			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data, r)
-			break
+			raise
 
-		except requests.exceptions.ReadTimeout as e:
-			frappe.logger().debug({"webhook_error": e, "try": i + 1})
-			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data)
+		if cint(webhook.max_retries) >= 1:
+			log_request(
+				webhook.name,
+				doc.doctype,
+				doc.name,
+				request_url,
+				headers,
+				data,
+				res,
+				status="Failed",
+				next_retry=get_next_retry(1),
+			)
+		else:
+			log_request(
+				webhook.name, doc.doctype, doc.name, request_url, headers, data, res, status="Exhausted"
+			)
 
-		except Exception as e:
-			frappe.logger().debug({"webhook_error": e, "try": i + 1})
-			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data, r)
-			if i < 2:
-				sleep(3 * i + 1)
-				continue
-			if webhook.webhook_docevent == "workflow_transition":
-				raise e
+
+def send_webhook_request(method, url, headers, data, timeout):
+	return requests.request(
+		method=method,
+		url=url,
+		data=frappe.as_json(data),
+		headers=headers,
+		timeout=timeout or 5,
+	)
+
+
+def get_next_retry(attempt: int):
+	delay = RETRY_SCHEDULE[min(attempt - 1, len(RETRY_SCHEDULE) - 1)]
+	return add_to_date(now_datetime(), seconds=delay)
+
+
+def retry_failed_webhooks():
+	"""Re-send webhook deliveries whose scheduled retry time has passed."""
+	due_logs = frappe.get_all(
+		"Webhook Request Log",
+		filters={"status": "Failed", "next_retry": ["<=", now_datetime()]},
+		order_by="next_retry asc",
+		pluck="name",
+	)
+	for log_name in due_logs:
+		retry_webhook_delivery(log_name)
+
+
+def retry_webhook_delivery(log_name: str):
+	log = frappe.get_doc("Webhook Request Log", log_name)
+	webhook = frappe.db.get_value(
+		"Webhook",
+		log.webhook,
+		["request_method", "timeout", "max_retries", "enabled"],
+		as_dict=True,
+	)
+	if not webhook or not webhook.enabled:
+		log.db_set({"status": "Exhausted", "next_retry": None})
+		return
+
+	attempt = cint(log.attempt) + 1
+	headers = json.loads(log.headers) if log.headers else {}
+	data = json.loads(log.data) if log.data else {}
+	res = None
+	try:
+		res = send_webhook_request(webhook.request_method, log.url, headers, data, webhook.timeout)
+		res.raise_for_status()
+		frappe.logger().debug({"webhook_success": res.text})
+		log.db_set(
+			{
+				"status": "Delivered",
+				"attempt": attempt,
+				"next_retry": None,
+				"response": res.text,
+				"error": None,
+			}
+		)
+
+	except Exception as e:
+		frappe.logger().debug({"webhook_retry_error": e, "attempt": attempt})
+		response = res.text if res is not None else None
+		if attempt - 1 < cint(webhook.max_retries):
+			log.db_set(
+				{
+					"status": "Failed",
+					"attempt": attempt,
+					"next_retry": get_next_retry(attempt),
+					"response": response,
+					"error": frappe.get_traceback(),
+				}
+			)
+		else:
+			log.db_set(
+				{
+					"status": "Exhausted",
+					"attempt": attempt,
+					"next_retry": None,
+					"response": response,
+					"error": frappe.get_traceback(),
+				}
+			)
 
 
 def log_request(
@@ -199,6 +291,9 @@ def log_request(
 	headers: dict,
 	data: dict,
 	res: requests.Response | None = None,
+	status: str | None = None,
+	attempt: int = 1,
+	next_retry=None,
 ):
 	request_log = frappe.get_doc(
 		{
@@ -212,6 +307,9 @@ def log_request(
 			"data": frappe.as_json(data) if data else None,
 			"response": res.text if res is not None else None,
 			"error": frappe.get_traceback(),
+			"status": status,
+			"attempt": attempt,
+			"next_retry": next_retry,
 		}
 	)
 
@@ -230,7 +328,7 @@ def get_webhook_headers(doc, webhook, data=None):
 				frappe.as_json(data).encode("utf8"),
 				hashlib.sha256,
 			).digest()
-		)
+		).decode()
 		headers[WEBHOOK_SECRET_HEADER] = signature
 
 	if webhook.webhook_headers:

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -13,13 +13,15 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import add_to_date, cint, now_datetime
-from frappe.utils.background_jobs import get_queues_timeout
+from frappe.utils.background_jobs import get_queues_timeout, is_job_enqueued
 from frappe.utils.jinja import validate_template
 from frappe.utils.safe_exec import get_safe_globals
 
 WEBHOOK_SECRET_HEADER = "X-Frappe-Webhook-Signature"
 
 RETRY_SCHEDULE = [5 * 60, 30 * 60, 2 * 3600, 5 * 3600, 10 * 3600, 10 * 3600]
+
+RETRY_BATCH_SIZE = 100
 
 
 class Webhook(Document):
@@ -217,15 +219,33 @@ def get_next_retry(attempt: int):
 
 
 def retry_failed_webhooks():
-	"""Re-send webhook deliveries whose scheduled retry time has passed."""
+	"""Enqueue a delivery job for each webhook whose scheduled retry time has passed."""
 	due_logs = frappe.get_all(
 		"Webhook Request Log",
 		filters={"status": "Failed", "next_retry": ["<=", now_datetime()]},
+		fields=["name", "webhook"],
 		order_by="next_retry asc",
-		pluck="name",
+		limit=RETRY_BATCH_SIZE,
 	)
-	for log_name in due_logs:
-		retry_webhook_delivery(log_name)
+
+	queues = {}
+	for log in due_logs:
+		job_id = f"webhook_retry::{log.name}"
+		if is_job_enqueued(job_id):
+			continue
+
+		if log.webhook not in queues:
+			queues[log.webhook] = (
+				frappe.db.get_value("Webhook", log.webhook, "background_jobs_queue") or "default"
+			)
+
+		frappe.enqueue(
+			"frappe.integrations.doctype.webhook.webhook.retry_webhook_delivery",
+			log_name=log.name,
+			job_id=job_id,
+			queue=queues[log.webhook],
+			now=frappe.in_test,
+		)
 
 
 def retry_webhook_delivery(log_name: str):

--- a/frappe/integrations/doctype/webhook_request_log/webhook_request_log.json
+++ b/frappe/integrations/doctype/webhook_request_log/webhook_request_log.json
@@ -114,7 +114,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-25 15:16:24.028963",
+ "modified": "2026-07-11 19:04:55.894152",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook Request Log",

--- a/frappe/integrations/doctype/webhook_request_log/webhook_request_log.json
+++ b/frappe/integrations/doctype/webhook_request_log/webhook_request_log.json
@@ -15,7 +15,10 @@
   "user",
   "url",
   "response",
-  "error"
+  "error",
+  "status",
+  "attempt",
+  "next_retry"
  ],
  "fields": [
   {
@@ -84,6 +87,28 @@
    "in_standard_filter": 1,
    "label": "Reference Doctype",
    "read_only": 1
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "\nDelivered\nFailed\nExhausted",
+   "read_only": 1
+  },
+  {
+   "fieldname": "attempt",
+   "fieldtype": "Int",
+   "label": "Attempt",
+   "read_only": 1
+  },
+  {
+   "fieldname": "next_retry",
+   "fieldtype": "Datetime",
+   "label": "Next Retry",
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "in_create": 1,

--- a/frappe/integrations/doctype/webhook_request_log/webhook_request_log.py
+++ b/frappe/integrations/doctype/webhook_request_log/webhook_request_log.py
@@ -16,12 +16,15 @@ class WebhookRequestLog(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		attempt: DF.Int
 		data: DF.Code | None
 		error: DF.Text | None
 		headers: DF.Code | None
+		next_retry: DF.Datetime | None
 		reference_doctype: DF.Data | None
 		reference_document: DF.Data | None
 		response: DF.Code | None
+		status: DF.Literal["", "Delivered", "Failed", "Exhausted"]
 		url: DF.Text | None
 		user: DF.Link | None
 		webhook: DF.Link | None


### PR DESCRIPTION
## What this changes

Webhook deliveries previously retried three times within the same background job, sleeping between attempts before eventually giving up. In practice, this meant a receiver that was temporarily unavailable could still miss the event, while the worker remained blocked for the duration of the retries.

This reworks the retry mechanism to use separate background jobs with an increasing backoff, similar to how production webhook services handle retries. Each delivery is now represented by a single `Webhook Request Log` row that tracks its status, attempt count, and `next_retry` timestamp. A scheduler running every 5 minutes picks up due retries and resends the payload that was captured when the event originally fired. Backoff intervals are 5 minutes → 30 minutes → 2 hours → 5 hours → 10 hours → 10 hours, after which the request is marked as `Exhausted` if it still hasn't been delivered.

Retries now reuse the stored payload instead of rebuilding it from the current document state, ensuring receivers always get the event exactly as it existed when it was generated.

`workflow_transition` webhooks continue to behave synchronously and still raise immediately on failure, since the workflow transition depends on the delivery result and cannot be deferred.

## Other changes

* Failed deliveries now update a single `Webhook Request Log` entry instead of creating a new log row for every retry attempt.
* Secured webhooks now store the HMAC signature header as a string before persisting it. Previously, the raw bytes were converted into an integer array during JSON serialization, resulting in an invalid signature when the webhook was retried.

## Testing

Verified end-to-end with a `ToDo` `after_insert` webhook pointed at a local server I could switch between failing (500) and succeeding (200):

* Server failing → delivery logged `Failed`, attempt 1, `next_retry` set 5 minutes out.
* Server recovers → scheduler resends the stored payload, log flips to `Delivered` (attempt 2).
* Server stays down → attempts step through the backoff (5m → 30m → 2h …) and the log is marked `Exhausted` once `max_retries` (3) is reached.
* Secured webhook signature stays valid after storage and replay.

`#no-docs`

---
Closes #21063.
