### PR TITLE
fix(sidebar): show "Getting Started" only when sidebar expanded

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -42,7 +42,7 @@
 				</div>
 				<div class="promotional-banners"></div>
 				<p>
-					<a class="onboarding-sidebar mx-2">
+					<a class="onboarding-sidebar px-2">
 						{%= frappe.utils.icon("user-check" , "sm", "", "", "text-ink-gray-7 current-color", true)%}
 						 <span> {%= __("Getting Started") %} </span>
 					</a>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -42,7 +42,7 @@
 				</div>
 				<div class="promotional-banners"></div>
 				<p>
-					<a class="onboarding-sidebar">
+					<a class="onboarding-sidebar mx-2">
 						{%= frappe.utils.icon("user-check" , "sm", "", "", "text-ink-gray-7 current-color", true)%}
 						 <span> {%= __("Getting Started") %} </span>
 					</a>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -582,6 +582,7 @@ frappe.ui.Sidebar = class Sidebar {
 			$('[data-toggle="tooltip"]').tooltip("dispose");
 			this.wrapper.find(".avatar-name-email").show();
 			this.wrapper.find(".about-sidebar-link").show();
+			this.wrapper.find(".onboarding-sidebar span").show();
 		} else {
 			this.wrapper.removeClass("expanded");
 			direction = "left";
@@ -592,6 +593,7 @@ frappe.ui.Sidebar = class Sidebar {
 			});
 			this.wrapper.find(".avatar-name-email").hide();
 			this.wrapper.find(".about-sidebar-link").hide();
+			this.wrapper.find(".onboarding-sidebar span").hide();
 		}
 
 		localStorage.setItem("sidebar-expanded", this.sidebar_expanded);


### PR DESCRIPTION
**Before:**

https://github.com/user-attachments/assets/28d61efc-2a01-484c-90ea-c818cb43323c


**After:**

https://github.com/user-attachments/assets/f674b2dc-df8b-4e50-82cf-9c0b3ac18683

