### PR TITLE
fix: improve `fetch_if_empty` label and description

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -258,10 +258,10 @@
   },
   {
    "default": "0",
-   "description": "If unchecked, the value will always be re-fetched on save.",
+   "description": "If checked, the field won't be overwritten by fetch on save.",
    "fieldname": "fetch_if_empty",
    "fieldtype": "Check",
-   "label": "Fetch on Save if Empty"
+   "label": "Skip fetch on save if set"
   },
   {
    "fieldname": "permissions",
@@ -655,7 +655,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-04-24 13:21:02.590853",
+ "modified": "2026-04-24 13:21:03.590853",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -161,10 +161,10 @@
   },
   {
    "default": "0",
-   "description": "If unchecked, the value will always be re-fetched on save.",
+   "description": "If checked, the field won't be overwritten by fetch on save.",
    "fieldname": "fetch_if_empty",
    "fieldtype": "Check",
-   "label": "Fetch on Save if Empty"
+   "label": "Skip fetch on save if set"
   },
   {
    "fieldname": "options_help",
@@ -498,7 +498,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-22 10:35:32.555267",
+ "modified": "2026-03-22 10:35:33.555267",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",


### PR DESCRIPTION
The label `Fetch on Save if Empty` doesn't clearly convey what the checkbox does. 
Renamed to `Don't re-fetch on save if already set` to match the actual behavior;  the field prevents re-fetching on save when a value is already present.

Updated in both DocField and Custom Field.
Ref: https://github.com/frappe/frappe/pull/38808#issuecomment-4321185346