### PR TITLE
fix(email_account): add perm. check to set_email_password

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -1135,6 +1135,7 @@ def remove_user_email_inbox(email_account):
 
 @frappe.whitelist()
 def set_email_password(email_account: str, password: str):
+	frappe.has_permission("Email Account", "write", email_account, throw=True)
 	account = frappe.get_doc("Email Account", email_account)
 	if account.awaiting_password and account.auth_method != "OAuth":
 		account.awaiting_password = 0


### PR DESCRIPTION
Adding perm. check to `set_email_password` endpoint.

closes Ticket #66726

Thanks to Ali Saifeldin (NSSYS) for flagging the issue (@nssys). 