### PR TITLE
fix: add perm. check to relink endpoint

### DIFF
--- a/frappe/core/doctype/communication/communication.js
+++ b/frappe/core/doctype/communication/communication.js
@@ -159,10 +159,13 @@ frappe.ui.form.on("Communication", {
 		d.set_primary_action(__("Relink"), function () {
 			var values = d.get_values();
 			if (values) {
+				let message = values["reference_name"]
+					? __("Are you sure you want to relink this communication to {0}?", [
+							values["reference_name"],
+					  ])
+					: __("Are you sure you want to relink this communication?");
 				frappe.confirm(
-					__("Are you sure you want to relink this communication to {0}?", [
-						values["reference_name"],
-					]),
+					message,
 					function () {
 						d.hide();
 						frappe.call({

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -61,7 +61,7 @@ def get_system_managers():
 
 @frappe.whitelist()
 def relink(name: str, reference_doctype: str | None = None, reference_name: str | None = None):
-	frappe.has_permission("Communication", "write", name)
+	frappe.has_permission("Communication", "write", name, throw=True)
 	frappe.db.sql(
 		"""update
 			`tabCommunication`

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -61,6 +61,7 @@ def get_system_managers():
 
 @frappe.whitelist()
 def relink(name: str, reference_doctype: str | None = None, reference_name: str | None = None):
+	frappe.has_permission("Communication", "write", name)
 	frappe.db.sql(
 		"""update
 			`tabCommunication`


### PR DESCRIPTION
Added perm. chk to `relink` endpoint and a minor UI fix (added fallback msg in case `reference_name` was not provided).

closes Ticket #66636

Thanks to Ali Saifeldin (NSSYS) for flagging the issue (@nssys).