### PR TITLE
fix(standard_macros): escape fields in standard print format template

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -392,7 +392,7 @@ def make_links(columns, data):
 def update_field_types(columns):
 	for col in columns:
 		if col.fieldtype in ("Link", "Dynamic Link", "Currency") and col.options != "Currency":
-			col.fieldtype = "HTML Editor"
+			col.fieldtype = "Data"
 			col.options = ""
 	return columns
 

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -118,7 +118,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 	{%- endif %}
 	{%- if df.fieldtype=="Code" %}
 		<pre class="value">{{ doc.get(df.fieldname)|e }}</pre>
-	{%- elif df.fieldtype in ("Text", "Long Text") -%}
+	{%- elif df.fieldtype in ("Text", "Long Text", "Small Text") -%}
 		{{ doc.get_formatted(df.fieldname, parent_doc or doc, translated=df.translatable)|e }}
 	{%- else -%}
 		{{ doc.get_formatted(df.fieldname, parent_doc or doc, translated=df.translatable) }}
@@ -171,7 +171,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 	{% elif df.fieldtype=="Data" %}
 		{%- set parent = parent_doc or doc -%}
 		{{ doc.get_formatted(df.fieldname, parent, translated=df.translatable, absolute_value=parent.absolute_value) |e }}
-	{% elif df.fieldtype in ("Text", "Long Text") %}
+	{% elif df.fieldtype in ("Text", "Long Text", "Small Text") %}
 		{%- set parent = parent_doc or doc -%}
 		{{ doc.get_formatted(df.fieldname, parent, translated=df.translatable, absolute_value=parent.absolute_value) |e }}
 	{% else %}

--- a/frappe/tests/test_formatter.py
+++ b/frappe/tests/test_formatter.py
@@ -1,7 +1,6 @@
 import frappe
 from frappe import format
 from frappe.tests import IntegrationTestCase
-from frappe.utils.formatters import format_value
 
 
 class TestFormatter(IntegrationTestCase):
@@ -18,37 +17,3 @@ class TestFormatter(IntegrationTestCase):
 		self.assertEqual(format(100000, df, doc, format="#,###.##"), "$ 100,000.00")
 
 		frappe.db.set_default("currency", None)
-
-	def test_safe_formatting(self):
-		"""Test that in certain field types, the values are escaped."""
-		payload = "<script>alert('testing')</script>"
-		sanitized_payload = "&lt;script&gt;alert(&apos;testing&apos;)&lt;/script&gt;"
-
-		data_df = frappe._dict({"fieldname": "book_name", "fieldtype": "Data"})
-		self.assertEqual(format_value(payload, data_df), sanitized_payload)
-
-		text_df = frappe._dict({"fieldname": "book_description", "fieldtype": "Text"})
-		self.assertEqual(format_value(payload, text_df), sanitized_payload)
-
-		html_df = frappe._dict({"fieldname": "book_title", "fieldtype": "HTML Editor"})
-		self.assertEqual(format_value(payload, html_df), payload)
-
-		editor_df = frappe._dict({"fieldtype": "Text Editor"})
-		formatted_editor = format_value("<b>Bold</b>", editor_df)
-		self.assertEqual(formatted_editor, "<div class='ql-snow'><b>Bold</b></div>")
-
-		ltext_df = frappe._dict({"fieldname": "book_long_description", "fieldtype": "Long Text"})
-		self.assertEqual(format_value(payload, ltext_df), sanitized_payload)
-
-		select_df = frappe._dict({"fieldtype": "Select", "parent": "Task"})
-		value = "Open"
-		self.assertEqual(format_value(value, select_df), "Open")
-		self.assertEqual(format_value(payload, select_df), sanitized_payload)
-
-		link_df = frappe._dict({"fieldtype": "Link", "options": "User"})
-		self.assertEqual(format_value(payload, link_df, doc=None), sanitized_payload)
-		doc = frappe._dict({"__link_titles": {"User::attacker@example.com": "<svg onload=alert(1)>"}})
-		formatted = format_value("attacker@example.com", link_df, doc)
-		self.assertIn("&lt;svg", formatted)
-
-		self.assertEqual(format_value(payload, df=None), sanitized_payload)

--- a/frappe/utils/formatters.py
+++ b/frappe/utils/formatters.py
@@ -60,8 +60,6 @@ def format_value(value, df=None, doc=None, currency=None, translated=False, form
 		value = frappe._(value)
 
 	if not df:
-		if isinstance(value, str):
-			return frappe.utils.escape_html(value)
 		return value
 
 	elif df.get("fieldtype") == "Date":
@@ -101,8 +99,7 @@ def format_value(value, df=None, doc=None, currency=None, translated=False, form
 
 	elif df.get("fieldtype") in ("Text", "Small Text"):
 		if not BLOCK_TAGS_PATTERN.search(value):
-			escaped_value = frappe.utils.escape_html(frappe.safe_decode(value))
-			return escaped_value.replace("\n", "<br>")
+			return frappe.safe_decode(value).replace("\n", "<br>")
 
 	elif df.get("fieldtype") == "Markdown Editor":
 		return frappe.utils.markdown(value)
@@ -127,28 +124,20 @@ def format_value(value, df=None, doc=None, currency=None, translated=False, form
 
 	elif df.get("fieldtype") in ["Link", "Dynamic Link"]:
 		if not doc or not doc.get("__link_titles") or not df.options:
-			return frappe.utils.escape_html(cstr(value))
+			return value
 
 		doctype = df.options
 		if df.get("fieldtype") == "Dynamic Link":
 			if not df.parent:
-				return frappe.utils.escape_html(cstr(value))
+				return value
 
 			meta = frappe.get_meta(df.parent)
 			_field = meta.get_field(df.options)
 			doctype = _field.options
-		link_title = doc.__link_titles.get(f"{doctype}::{value}", value)
-		return frappe.utils.escape_html(cstr(link_title))
+		return doc.__link_titles.get(f"{doctype}::{value}", value)
 
 	elif df.get("fieldtype") == "Select":
 		if isinstance(value, str):
-			translated_value = frappe._(value, context=df.parent or "")
-			return frappe.utils.escape_html(translated_value)
-
-	elif df.get("fieldtype") == "HTML Editor":
-		return value
-
-	if isinstance(value, str):
-		value = frappe.utils.escape_html(value)
+			return frappe._(value, context=df.parent or "")
 
 	return value


### PR DESCRIPTION
Escaping the fields in std print format template (this was the core issue, one of the dfs was not being considered for escape), and reverting changes made in formatters.py. (via #38835)
