### PR TITLE
fix(client): add proper checks to client.py endpoints.

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -189,10 +189,8 @@ def set_value(doctype: str, name: str | int, fieldname: str | dict[str, Any], va
 	:param fieldname: fieldname string or JSON / dict with key value pair
 	:param value: value if fieldname is JSON / dict"""
 
-	if fieldname in (frappe.model.default_fields + frappe.model.child_table_fields):
-		frappe.throw(_("Cannot edit standard fields"))
-
-	if not value:
+	values = {}
+	if value is None:
 		values = fieldname
 		if isinstance(fieldname, str):
 			try:
@@ -201,6 +199,11 @@ def set_value(doctype: str, name: str | int, fieldname: str | dict[str, Any], va
 				values = {fieldname: ""}
 	else:
 		values = {fieldname: value}
+
+	forbidden = set(frappe.model.default_fields + frappe.model.child_table_fields)
+	for field in values:
+		if field in forbidden:
+			frappe.throw(_("Cannot edit standard fields"))
 
 	# check for child table doctype
 	if not frappe.get_meta(doctype).istable:


### PR DESCRIPTION
Adding proper checks to client.py endpoints.
- [x] `save` (after discussion w/ team, can be ignored...)
- [x] `set_value`

Added proper parsing for dicts. because prev. dicts. were bypassing checks.

related to #38815