### PR TITLE
fix(delete_doc): SyntaxError: multiple exception types must be parenthesized

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -138,7 +138,7 @@ def delete_doc(
 			):
 				try:
 					delete_controllers(name, doc.module)
-				except OSError, KeyError:
+				except (OSError, KeyError):
 					# in case a doctype doesnt have any controller code  nor any app and module
 					pass
 
@@ -148,7 +148,7 @@ def delete_doc(
 			# Lock the doc without waiting
 			try:
 				frappe.db.get_value(doctype, name, for_update=True, wait=False)
-			except frappe.QueryTimeoutError, frappe.QueryDeadlockError:
+			except (frappe.QueryTimeoutError, frappe.QueryDeadlockError):
 				frappe.throw(
 					_(
 						"This document can not be deleted right now as it's being modified by another user. Please try again after some time."


### PR DESCRIPTION
Pre-Commit Error

```
frappe/model/delete_doc.py - Could not parse ast

        Traceback (most recent call last):
          File "/Users/sumitjain/.cache/pre-commit/repowe71gj1u/py_env-python3.13/lib/python3.13/site-packages/pre_commit_hooks/debug_statement_hook.py", line 57, in check_file
            ast_obj = ast.parse(f.read(), filename=filename)
          File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/ast.py", line 54, in parse
            return compile(source, filename, mode, flags,
                           _feature_version=feature_version, optimize=optimize)
          File "frappe/model/delete_doc.py", line 141
                                        except OSError, KeyError:
                                               ^^^^^^^^^^^^^^^^^
        SyntaxError: multiple exception types must be parenthesized
```
Solving this by adding parenthesis where the multiple exception given
        