### PR TITLE
fix(query): unique aliasing for linked field joins

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -2079,8 +2079,7 @@ class LinkTableField(DynamicTableField):
 
 	def _get_joined_table(self):
 		table = frappe.qb.DocType(self.doctype)
-		if self.doctype == self.parent_doctype:
-			table = table.as_(f"tab{self.doctype}_{self.link_fieldname}")
+		table = table.as_(f"tab{self.doctype}_{self.link_fieldname}")
 		return table
 
 	def apply_select(self, query: QueryBuilder, engine: "Engine" = None) -> QueryBuilder:

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1238,8 +1238,14 @@ class TestDBQuery(IntegrationTestCase):
 			fields=fields,
 		).get_sql()
 
-		self.assertIn("LEFT JOIN `tabSelf Linked DocType` `tabSelf Linked DocType_parent_ref`", query)
-		self.assertIn("LEFT JOIN `tabSelf Linked DocType` `tabSelf Linked DocType_sibling_ref`", query)
+		self.assertIn(
+			self.normalize_sql("LEFT JOIN `tabSelf Linked DocType` `tabSelf Linked DocType_parent_ref`"),
+			self.normalize_sql(query),
+		)
+		self.assertIn(
+			self.normalize_sql("LEFT JOIN `tabSelf Linked DocType` `tabSelf Linked DocType_sibling_ref`"),
+			self.normalize_sql(query),
+		)
 
 	def test_select_star_expansion(self):
 		count = frappe.get_list("Language", [{"SUM": 1}, {"COUNT": "*"}], as_list=1, order_by=None)[0]

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -371,10 +371,10 @@ class TestQuery(IntegrationTestCase):
 				fields=["name"],
 				filters={"module.app_name": "frappe"},
 			).get_sql(),
-			"SELECT `tabDocType`.`name` FROM `tabDocType` LEFT JOIN `tabModule Def` ON `tabModule Def`.`name`=`tabDocType`.`module` WHERE `tabModule Def`.`app_name`='frappe'",
+			"SELECT `tabDocType`.`name` FROM `tabDocType` LEFT JOIN `tabModule Def` `tabModule Def_module` ON `tabModule Def_module`.`name`=`tabDocType`.`module` WHERE `tabModule Def_module`.`app_name`='frappe'",
 		)
 
-		query = "SELECT `tabDocType`.`name` FROM `tabDocType` LEFT JOIN `tabModule Def` ON `tabModule Def`.`name`=`tabDocType`.`module` WHERE `tabModule Def`.`app_name` LIKE 'frap%'"
+		query = "SELECT `tabDocType`.`name` FROM `tabDocType` LEFT JOIN `tabModule Def` `tabModule Def_module` ON `tabModule Def_module`.`name`=`tabDocType`.`module` WHERE `tabModule Def_module`.`app_name` LIKE 'frap%'"
 		query = query.replace("LIKE", "ILIKE" if frappe.db.db_type == "postgres" else "LIKE")
 		self.assertQueryEqual(
 			frappe.qb.get_query(
@@ -756,7 +756,7 @@ class TestQuery(IntegrationTestCase):
 				"DocType",
 				fields=["name", "module.app_name as app_name"],
 			).get_sql(),
-			"SELECT `tabDocType`.`name`,`tabModule Def`.`app_name` `app_name` FROM `tabDocType` LEFT JOIN `tabModule Def` ON `tabModule Def`.`name`=`tabDocType`.`module`",
+			"SELECT `tabDocType`.`name`,`tabModule Def_module`.`app_name` `app_name` FROM `tabDocType` LEFT JOIN `tabModule Def` `tabModule Def_module` ON `tabModule Def_module`.`name`=`tabDocType`.`module`",
 		)
 
 	# fields now has strict validation, so this test is not valid anymore


### PR DESCRIPTION
> When a DocType contains multiple Link fields pointing to the same target DocType, and that target DocType has a Title Field defined, the List View displays incorrect values.

This PR fixes a problem in List View wherein the values displayed were wrong. This was because of an incorrect query generation that has now been fixed.

**Before**:

ref: https://github.com/user-attachments/assets/e592952d-1563-4b92-92c6-aa4e95e2c4b7


<img width="2874" height="654" alt="image" src="https://github.com/user-attachments/assets/dac89963-4281-459b-b87f-934a4818e825" />


**After**:

<img width="2874" height="654" alt="image" src="https://github.com/user-attachments/assets/94db76f1-d8da-497d-bdb1-1f6074f000b1" />




closes #38920
