### PR TITLE
fix(sidebar): correct collapse sidebar icon direction in RTL

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -576,16 +576,17 @@ frappe.ui.Sidebar = class Sidebar {
 
 	expand_sidebar() {
 		let direction;
+		const is_rtl = frappe.utils.is_rtl();
 		if (this.sidebar_expanded) {
 			this.wrapper.addClass("expanded");
-			direction = "right";
+			direction = is_rtl ? "left" : "right";
 			$('[data-toggle="tooltip"]').tooltip("dispose");
 			this.wrapper.find(".avatar-name-email").show();
 			this.wrapper.find(".about-sidebar-link").show();
 			this.wrapper.find(".onboarding-sidebar span").show();
 		} else {
 			this.wrapper.removeClass("expanded");
-			direction = "left";
+			direction = is_rtl ? "right" : "left";
 			$('[data-toggle="tooltip"]').tooltip({
 				boundary: "window",
 				container: "body",


### PR DESCRIPTION
**Before (RTL view):**


https://github.com/user-attachments/assets/dea96c69-c358-42a6-9333-b4a2aea0e7d7



**After (RTL view):**



https://github.com/user-attachments/assets/63279bbc-4726-42a7-a3e2-a1855bbd3583

