### PR TITLE
fix: remove user doctype limit validation from User Type

### DIFF
--- a/frappe/core/doctype/user_type/test_user_type.py
+++ b/frappe/core/doctype/user_type/test_user_type.py
@@ -51,9 +51,6 @@ def create_user_type(user_type):
 	if frappe.db.exists("User Type", user_type):
 		frappe.delete_doc("User Type", user_type)
 
-	user_type_limit = {frappe.scrub(user_type): 1}
-	update_site_config("user_type_doctype_limit", user_type_limit)
-
 	doc = frappe.get_doc(
 		{
 			"doctype": "User Type",

--- a/frappe/core/doctype/user_type/user_type.py
+++ b/frappe/core/doctype/user_type/user_type.py
@@ -48,7 +48,6 @@ class UserType(Document):
 		if self.is_standard:
 			return
 
-		self.validate_document_type_limit()
 		self.validate_role()
 		self.add_role_permissions_for_user_doctypes()
 		self.add_role_permissions_for_select_doctypes()
@@ -74,37 +73,6 @@ class UserType(Document):
 		self.set("user_type_modules", [])
 		for module in modules:
 			self.append("user_type_modules", {"module": module})
-
-	def validate_document_type_limit(self):
-		limit = frappe.conf.get("user_type_doctype_limit", {}).get(frappe.scrub(self.name))
-
-		if not limit and frappe.session.user != "Administrator":
-			frappe.throw(
-				_("User does not have permission to create the new {0}").format(frappe.bold(_("User Type"))),
-				title=_("Permission Error"),
-			)
-
-		if limit is None:
-			frappe.msgprint(
-				_("The limit has not set for the user type {0} in the site config file.").format(
-					frappe.bold(self.name)
-				),
-				title=_("Set Limit"),
-			)
-			return
-
-		if self.user_doctypes and len(self.user_doctypes) > limit:
-			frappe.throw(
-				_("The total number of user document types limit has been crossed."),
-				title=_("User Document Types Limit Exceeded"),
-			)
-
-		custom_doctypes = [row.document_type for row in self.user_doctypes if row.is_custom]
-		if custom_doctypes and len(custom_doctypes) > 3:
-			frappe.throw(
-				_("You can only set the 3 custom doctypes in the Document Types table."),
-				title=_("Custom Document Types Limit Exceeded"),
-			)
 
 	def validate_role(self):
 		if not self.role:


### PR DESCRIPTION
### Reason
- Site migrations fail while applying HRMS patches due to `validate_document_type_limit`.
- The limit was introduced for per user pricing-based restrictions, which are no longer applicable on desk

### Changes done
- Removed `validate_document_type_limit` from user_type
- Removed related `user_type_doctype_limit` setup in tests.