### PR TITLE
fix(report): prevent standard report creation when developer mode is off

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -74,10 +74,7 @@ class Report(Document):
 				frappe.throw(_("Cannot edit a standard report. Please duplicate and create a new report"))
 
 		if self.is_standard == "Yes":
-			if frappe.session.user != "Administrator":
-				frappe.throw(_("Only Administrator can save a standard report. Please rename and save."))
-
-			self.validate_standard_report_developer_mode()
+			self.validate_standard_report()
 
 		if self.report_type == "Report Builder":
 			self.update_report_json()
@@ -414,7 +411,10 @@ class Report(Document):
 
 		return data
 
-	def validate_standard_report_developer_mode(self):
+	def validate_standard_report(self):
+		if frappe.session.user != "Administrator":
+			frappe.throw(_("Only Administrator can save a standard report. Please rename and save."))
+
 		if not cint(frappe.conf.developer_mode):
 			frappe.throw(_("Standard reports can only be created in developer mode."))
 

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -77,8 +77,7 @@ class Report(Document):
 			if frappe.session.user != "Administrator":
 				frappe.throw(_("Only Administrator can save a standard report. Please rename and save."))
 
-			if not cint(getattr(frappe.local.conf, "developer_mode", 0)):
-				frappe.throw(_("Standard reports can only be created in developer mode."))
+			self.validate_standard_report_developer_mode()
 
 		if self.report_type == "Report Builder":
 			self.update_report_json()
@@ -414,6 +413,10 @@ class Report(Document):
 			data.append(_row)
 
 		return data
+
+	def validate_standard_report_developer_mode(self):
+		if not cint(frappe.conf.developer_mode):
+			frappe.throw(_("Standard reports can only be created in developer mode."))
 
 	def validate_default_print_format(self):
 		pf = frappe.db.get_value(

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -77,6 +77,9 @@ class Report(Document):
 			if frappe.session.user != "Administrator":
 				frappe.throw(_("Only Administrator can save a standard report. Please rename and save."))
 
+			if not cint(getattr(frappe.local.conf, "developer_mode", 0)):
+				frappe.throw(_("Standard reports can only be created in developer mode."))
+
 		if self.report_type == "Report Builder":
 			self.update_report_json()
 


### PR DESCRIPTION
Resolve: #28049

---

 ```json
 "developer_mode": false
 ```
 

https://github.com/user-attachments/assets/344b247c-5a6a-453a-94ee-cfe86aee8f88

`no-docs`
 