### PR TITLE
fix(auth): return auth. error in case query fails

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -726,9 +726,13 @@ def validate_api_key_secret(api_key, api_secret, frappe_authorization_source=Non
 		raise frappe.AuthenticationError
 
 	doctype = frappe_authorization_source or "User"
-	docname = frappe.db.get_value(
-		doctype=doctype, filters={"api_key": api_key, "enabled": True}, fieldname=["name"]
-	)
+	try:
+		docname = frappe.db.get_value(
+			doctype=doctype, filters={"api_key": api_key, "enabled": True}, fieldname=["name"]
+		)
+	except Exception:
+		raise frappe.AuthenticationError
+
 	if not docname:
 		raise frappe.AuthenticationError
 	form_dict = frappe.local.form_dict


### PR DESCRIPTION
Return Auth. Error  if query fails. It's still an auth. failure so raising Auth. error.
partially closes Ticket #63321