### PR TITLE
feat: show sidebar as description in awesomebar

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -1067,9 +1067,17 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 };
 
 if (Awesomplete) {
+	Awesomplete.prototype._itemCursor = 0;
 	Awesomplete.prototype.get_item = function (value) {
-		return this._list.find(function (item) {
+		var matches = this._list.filter(function (item) {
 			return item.value === value;
 		});
+
+		if (matches.length === 0) return null;
+
+		var item = matches[this._itemCursor % matches.length];
+		this._itemCursor++;
+
+		return item;
 	};
 }

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -108,6 +108,11 @@ frappe.search.AwesomeBar = class AwesomeBar {
 						)
 					);
 				}
+				if (d.type == "sidebar") {
+					d.route_options = {
+						sidebar: d.description,
+					};
+				}
 				if (d.type == "Desktop Icon") {
 					target = frappe.utils.get_route_for_icon(d.icon_data);
 					d.route = target;
@@ -160,8 +165,10 @@ frappe.search.AwesomeBar = class AwesomeBar {
 					);
 					me.options = me.options.concat(frappe.search.utils.get_frequent_links());
 				}
-
-				awesomplete.list = me.deduplicate(me.options);
+				let options = me.deduplicate(me.options);
+				awesomplete.options_with_desc = me.create_options_with_descriptions(options);
+				Awesomplete.prototype._itemCursor = 0;
+				awesomplete.list = options;
 			}, 50)
 		);
 
@@ -217,6 +224,18 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				$input.trigger("blur");
 			}
 		});
+	}
+	create_options_with_descriptions(options) {
+		let options_with_desc = {};
+		options.forEach((opt) => {
+			if (opt.description) {
+				if (!options_with_desc[opt.value]) {
+					options_with_desc[opt.value] = [];
+				}
+				options_with_desc[opt.value].push(opt);
+			}
+		});
+		return options_with_desc;
 	}
 
 	set_specifics(txt, end_txt) {
@@ -274,7 +293,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 
 				var str_route =
 					typeof option.route === "string" ? option.route : option.route.join("/");
-				if (routes.indexOf(str_route) === -1) {
+				if (option.description || routes.indexOf(str_route) === -1) {
 					out.push(option);
 					routes.push(str_route);
 				} else {

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -234,15 +234,27 @@ frappe.search.utils = {
 							},
 						});
 					}
-
 					const isTree = (frappe.boot.tree_view_doctypes || []).includes(item);
-					out.push(
-						option(
-							isTree ? "Tree" : "List",
-							isTree ? ["Tree", item] : ["List", item],
-							0.05
-						)
+					let option_data = option(
+						isTree ? "Tree" : "List",
+						isTree ? ["Tree", item] : ["List", item],
+						0.05
 					);
+					let sidebars = frappe.app.sidebar.get_workspace_sidebars(item);
+					if (sidebars.length > 1) {
+						sidebars.forEach((sidebar) => {
+							let sidebar_option = option(
+								isTree ? "Tree" : "List",
+								isTree ? ["Tree", item] : ["List", item],
+								0.05
+							);
+							sidebar_option.description = `${sidebar}`;
+							sidebar_option.type = "sidebar";
+							out.push(sidebar_option);
+						});
+					} else {
+						out.push(option_data);
+					}
 					if (frappe.model.can_get_report(item)) {
 						out.push(option("Report", ["List", item, "Report"], 0.04));
 					}


### PR DESCRIPTION
When you are searching for something via Awesombar, you don't have any idea what sidebar will the system show. This unpredictability is not good.It can take you to some random sidebar you don't want to go to

<img width="791" height="316" alt="Screenshot 2026-04-29 at 1 47 10 PM" src="https://github.com/user-attachments/assets/3c177f0d-abcc-4a80-a44a-5078a5ede250" />

`no-docs`