### PR TITLE
fix(grid): bulk paste broken on pages beyond first

### DIFF
--- a/frappe/public/js/frappe/form/controls/table.js
+++ b/frappe/public/js/frappe/form/controls/table.js
@@ -52,7 +52,8 @@ frappe.ui.form.ControlTable = class ControlTable extends frappe.ui.form.Control 
 				data.shift();
 			} else {
 				// no column header, map to the existing visible columns
-				const visible_columns = grid_rows[0].get_visible_columns();
+				const visible_columns =
+					grid.grid_rows_by_docname[row_docname].get_visible_columns();
 				let target_column_matched = false;
 				visible_columns.forEach((column) => {
 					// consider all columns after the target column.


### PR DESCRIPTION
## Problem
Bulk-pasting values into a child table grid fails on page 2+.  
Instead of expanding into multiple rows, the entire clipboard string lands in a single cell.

## Root Cause
The paste handler in `controls/table.js` reads visible columns using:
```js
const visible_columns = grid_rows[0].get_visible_columns();
```
`grid.refresh()` clears `grid_rows` slots outside the current page.  
As a result, on page ≥ 2, `grid_rows[0]` is `undefined`, leading to:

```js
TypeError: Cannot read properties of undefined (reading 'get_visible_columns')
```
## Fix
Use the row actually being pasted into (already known via `row_docname`):

```js
const visible_columns = grid.grid_rows_by_docname[row_docname].get_visible_columns();
```
### Before Fix
[Screencast from 2026-04-29 15-45-12.webm](https://github.com/user-attachments/assets/f860acc7-7b30-484d-ab44-245f3066bd9f)

### After Fix
[Screencast from 2026-04-29 15-48-43.webm](https://github.com/user-attachments/assets/4fbcca67-8b62-4eba-87c8-047f26d70360)

**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/65975](https://support.frappe.io/helpdesk/tickets/65975)