### PR TITLE
feat: configure global search fields directly in global search settings

### DIFF
--- a/cypress/integration/global_search_settings.js
+++ b/cypress/integration/global_search_settings.js
@@ -121,9 +121,11 @@ context("Global Search Settings — configure search fields", () => {
 			expect(response.body.message?.success).to.eq(true);
 		});
 
-		cy.get("#alert-container .desk-alert .alert-message", { timeout: 15000 }).should(
+		// Success path closes the configure modal before showing the toast.
+		cy.get(".modal.show", { timeout: 15000 }).should("not.exist");
+		cy.get('[role="alert"].desk-alert .alert-message', { timeout: 15000 }).should(
 			"contain",
-			"Global Search Fields Updated"
+			"Search fields updated."
 		);
 	});
 });

--- a/cypress/integration/global_search_settings.js
+++ b/cypress/integration/global_search_settings.js
@@ -70,9 +70,8 @@ context("Global Search Settings — configure search fields", () => {
 
 		cy.get("@row").find('[data-fieldname="configure"] button').click();
 
-		cy.get_open_dialog()
-			.find(".modal-title")
-			.should("contain", "Configure search fields of ToDo");
+		cy.get_open_dialog().find(".modal-title").should("contain", "Configure search fields");
+		cy.get_open_dialog().should("contain", "ToDo");
 		cy.get_open_dialog()
 			.find('.checkbox-options input[type="checkbox"][data-unit="name"]')
 			.should("exist");

--- a/cypress/integration/global_search_settings.js
+++ b/cypress/integration/global_search_settings.js
@@ -121,9 +121,7 @@ context("Global Search Settings — configure search fields", () => {
 			expect(response.body.message?.success).to.eq(true);
 		});
 
-		// Success path closes the configure modal before showing the toast.
-		cy.get(".modal.show", { timeout: 15000 }).should("not.exist");
-		cy.get('[role="alert"].desk-alert .alert-message', { timeout: 15000 }).should(
+		cy.get('[role="alert"].desk-alert .alert-message', { timeout: 25000 }).should(
 			"contain",
 			"Search fields updated."
 		);

--- a/cypress/integration/global_search_settings.js
+++ b/cypress/integration/global_search_settings.js
@@ -1,0 +1,130 @@
+context("Global Search Settings — configure search fields", () => {
+	const GS_GRID = '.frappe-control[data-fieldname="allowed_in_global_search"]';
+
+	/** Editable-grid Link fields only mount after the row is active (toggle_editable_row → make_control). */
+	function ensure_first_priority_row() {
+		cy.get(`${GS_GRID} .grid-body`).then(($body) => {
+			if ($body.find(".grid-row").length === 0) {
+				cy.get(`${GS_GRID} .grid-add-row`).click();
+			}
+		});
+		cy.get(`${GS_GRID} .grid-body .grid-row[data-idx="1"]`).should("exist");
+	}
+
+	function activate_document_type_cell(rowAlias = "@row") {
+		cy.get(rowAlias).find('[data-fieldname="document_type"]').click();
+		cy.get(rowAlias).find('[data-fieldname="document_type"] input').should("exist");
+	}
+
+	/** Awesomplete dropdown is attached via `aria-owns` (often outside the row); items are `div[role="option"]`, not `li`. */
+	function select_document_type_link(rowAlias, label) {
+		cy.get(rowAlias).find('[data-fieldname="document_type"] input').as("docTypeInput");
+		cy.get("@docTypeInput").clear().focus().type(label, { delay: 100 });
+		cy.get("@docTypeInput").invoke("attr", "aria-owns").should("match", /\w+/);
+		cy.get("@docTypeInput")
+			.invoke("attr", "aria-owns")
+			.then((ownsId) => {
+				const sel = `#${CSS.escape(ownsId)}`;
+				cy.get(sel).should("be.visible");
+				cy.get(sel)
+					.find('[role="option"]')
+					.filter((_, el) => {
+						const $el = Cypress.$(el);
+						const primary =
+							$el.find("strong").first().text().trim() ||
+							$el.text().trim().split("\n")[0];
+						return primary === label;
+					})
+					.should("have.length", 1)
+					.scrollIntoView()
+					.click({ force: true });
+			});
+		cy.get("@docTypeInput").blur();
+		cy.get("@docTypeInput").should("have.value", label);
+	}
+
+	beforeEach(() => {
+		cy.login("Administrator", Cypress.env("adminPassword") || "admin");
+		cy.visit("/desk/global-search-settings");
+		cy.get("body").should("have.attr", "data-ajax-state", "complete");
+		cy.get(`${GS_GRID}`).should("exist");
+	});
+
+	it("shows a message when Configure is clicked without Document Type", () => {
+		cy.get('.frappe-control[data-fieldname="allowed_in_global_search"]')
+			.find(".grid-add-row")
+			.click();
+		cy.get(
+			'.frappe-control[data-fieldname="allowed_in_global_search"] .grid-body .grid-row:last'
+		)
+			.find('[data-fieldname="configure"] button')
+			.click();
+		cy.get(".msgprint").should("contain", "Please select Document Type first");
+	});
+
+	it("opens configure dialog with MultiCheck field options and filter search", () => {
+		ensure_first_priority_row();
+		cy.get(`${GS_GRID} .grid-body .grid-row[data-idx="1"]`).as("row");
+		activate_document_type_cell();
+		select_document_type_link("@row", "ToDo");
+
+		cy.get("@row").find('[data-fieldname="configure"] button').click();
+
+		cy.get_open_dialog()
+			.find(".modal-title")
+			.should("contain", "Configure search fields of ToDo");
+		cy.get_open_dialog()
+			.find('.checkbox-options input[type="checkbox"][data-unit="name"]')
+			.should("exist");
+
+		const unlikely = "xyz-nonmatching-global-search-filter-12345";
+		cy.get_open_dialog().find('[data-element="search"]').clear().type(unlikely);
+		cy.get_open_dialog()
+			.find(".checkbox-options .unit-checkbox:visible")
+			.should("have.length", 0);
+		cy.get_open_dialog().find('[data-element="search"]').clear();
+		cy.get_open_dialog()
+			.find(".checkbox-options .unit-checkbox:visible")
+			.should((els) => {
+				expect(els.length).to.be.greaterThan(0);
+			});
+
+		cy.get_open_dialog().find(".btn-modal-close").click();
+		cy.get(".modal:visible").should("not.exist");
+	});
+
+	it("saves selected fields and shows success toast", () => {
+		cy.intercept(
+			"POST",
+			"/api/method/frappe.desk.doctype.global_search_settings.global_search_settings.update_global_search_fields"
+		).as("update_global_search_fields");
+
+		ensure_first_priority_row();
+		cy.get(`${GS_GRID} .grid-body .grid-row[data-idx="1"]`).as("row");
+		activate_document_type_cell();
+		// Must not be a Core module DocType — API rejects those (no toast; server error).
+		select_document_type_link("@row", "ToDo");
+
+		cy.get("@row").find('[data-fieldname="configure"] button').click();
+
+		cy.get_open_dialog()
+			.find('.checkbox-options input[type="checkbox"][data-unit="name"]')
+			.should("exist");
+
+		cy.get_open_dialog()
+			.find(".modal-footer .standard-actions .btn-primary")
+			.contains("Save")
+			.click({ force: true });
+
+		cy.wait("@update_global_search_fields").then(({ response }) => {
+			expect(response.statusCode).to.eq(200);
+			expect(response.body.exc, JSON.stringify(response.body)).to.be.undefined;
+			expect(response.body.message?.success).to.eq(true);
+		});
+
+		cy.get("#alert-container .desk-alert .alert-message", { timeout: 15000 }).should(
+			"contain",
+			"Global Search Fields Updated"
+		);
+	});
+});

--- a/frappe/desk/doctype/global_search_doctype/global_search_doctype.json
+++ b/frappe/desk/doctype/global_search_doctype/global_search_doctype.json
@@ -1,11 +1,13 @@
 {
  "actions": [],
+ "allow_bulk_edit": 0,
  "creation": "2019-09-13 21:33:55.551941",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "document_type"
+  "document_type",
+  "configure"
  ],
  "fields": [
   {
@@ -14,17 +16,24 @@
    "in_list_view": 1,
    "label": "Document Type",
    "options": "DocType"
+  },
+  {
+   "fieldname": "configure",
+   "fieldtype": "Button",
+   "in_list_view": 1,
+   "label": "Configure"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-23 16:03:26.489242",
+ "modified": "2026-04-27 21:41:43.954439",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Global Search DocType",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.js
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.js
@@ -91,7 +91,7 @@ frappe.global_search_settings.show_configure_search_fields_dialog = function (do
 							} else {
 								dialog.hide();
 								frappe.show_alert({
-									message: __("Global Search Fields Updated."),
+									message: __("Search fields updated."),
 									indicator: "green",
 								});
 								if (frm) {

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.js
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.js
@@ -30,3 +30,99 @@ frappe.ui.form.on("Global Search Settings", {
 		});
 	},
 });
+
+frappe.ui.form.on("Global Search DocType", {
+	configure: function (frm, cdt, cdn) {
+		const row = frappe.get_doc(cdt, cdn);
+		if (!row.document_type) {
+			frappe.msgprint(__("Please select Document Type first."));
+			return;
+		}
+		frappe.model.with_doctype(row.document_type, () => {
+			frappe.global_search_settings.show_configure_search_fields_dialog(
+				row.document_type,
+				frm
+			);
+		});
+	},
+});
+
+frappe.provide("frappe.global_search_settings");
+
+frappe.global_search_settings.show_configure_search_fields_dialog = function (doctype, frm) {
+	frappe.call({
+		method: "frappe.desk.doctype.global_search_settings.global_search_settings.get_global_search_field_options",
+		args: { doctype },
+		callback(r) {
+			const options = r.message?.options || [];
+			const default_global_search_fields = r.message?.default_global_search_fields || [];
+
+			const dialog = new frappe.ui.Dialog({
+				title: __("Configure search fields of {0}", [__(doctype)]),
+				fields: [
+					{
+						fieldtype: "HTML",
+						fieldname: "search_bar",
+					},
+					{
+						label: __(doctype),
+						fieldname: "search_fields",
+						fieldtype: "MultiCheck",
+						columns: 2,
+						sort_options: false,
+						options,
+					},
+				],
+
+				primary_action_label: __("Save"),
+				primary_action() {
+					const checked = dialog.get_field("search_fields").get_checked_options();
+					frappe.call({
+						method: "frappe.desk.doctype.global_search_settings.global_search_settings.update_global_search_fields",
+						args: { doctype, fields: checked },
+						freeze: true,
+						freeze_message: __("Updating search index"),
+						callback: function (r) {
+							if (r.exc) {
+								console.log("r", r);
+								frappe.msgprint(r.exc);
+							} else {
+								dialog.hide();
+								frappe.show_alert({
+									message: __("Global Search Fields Updated."),
+									indicator: "green",
+								});
+								frm.refresh();
+							}
+						},
+					});
+				},
+
+				secondary_action_label: __("Reset"),
+				secondary_action() {
+					const field = dialog.get_field("search_fields");
+					const defaults = new Set(default_global_search_fields);
+					field.selected_options = field.options
+						.filter((o) => defaults.has(o.value))
+						.map((o) => o.value);
+					field.select_options(field.selected_options);
+				},
+			});
+
+			dialog.get_field("search_bar").$wrapper.html(`
+				<div class="filters-search mb-3">
+					<input
+						type="text"
+						placeholder="${__("Search")}"
+						data-element="search"
+						class="form-control input-xs"
+					>
+				</div>
+			`);
+
+			dialog.show();
+
+			frappe.utils.setup_search(dialog.$body, ".unit-checkbox", ".label-area");
+		},
+	});
+};

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.js
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.js
@@ -84,7 +84,6 @@ frappe.global_search_settings.show_configure_search_fields_dialog = function (do
 						freeze_message: __("Updating search index"),
 						callback: function (r) {
 							if (r.exc) {
-								console.log("r", r);
 								frappe.msgprint(r.exc);
 							} else {
 								dialog.hide();
@@ -92,7 +91,9 @@ frappe.global_search_settings.show_configure_search_fields_dialog = function (do
 									message: __("Global Search Fields Updated."),
 									indicator: "green",
 								});
-								frm.refresh();
+								if (frm) {
+									frm.refresh();
+								}
 							}
 						},
 					});

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.js
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.js
@@ -58,14 +58,17 @@ frappe.global_search_settings.show_configure_search_fields_dialog = function (do
 			const default_global_search_fields = r.message?.default_global_search_fields || [];
 
 			const dialog = new frappe.ui.Dialog({
-				title: __("Configure search fields of {0}", [__(doctype)]),
+				title: __("Configure search fields"),
 				fields: [
+					{
+						fieldtype: "HTML",
+						fieldname: "doctype_heading",
+					},
 					{
 						fieldtype: "HTML",
 						fieldname: "search_bar",
 					},
 					{
-						label: __(doctype),
 						fieldname: "search_fields",
 						fieldtype: "MultiCheck",
 						columns: 2,
@@ -109,6 +112,10 @@ frappe.global_search_settings.show_configure_search_fields_dialog = function (do
 					field.select_options(field.selected_options);
 				},
 			});
+
+			dialog.get_field("doctype_heading").$wrapper.html(`
+				<div class="mb-3 font-weight-bold">${frappe.utils.escape_html(__(doctype))}</div>
+			`);
 
 			dialog.get_field("search_bar").$wrapper.html(`
 				<div class="filters-search mb-3">

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.js
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.js
@@ -1,61 +1,12 @@
 // Copyright (c) 2019, Frappe Technologies and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on("Global Search Settings", {
-	refresh: function (frm) {
-		frappe.realtime.on("global_search_settings", (data) => {
-			if (data.progress) {
-				frm.dashboard.show_progress(
-					"Setting up Global Search",
-					(data.progress / data.total) * 100,
-					data.msg
-				);
-				if (data.progress === data.total) {
-					frm.dashboard.hide_progress("Setting up Global Search");
-				}
-			}
-		});
-
-		frm.add_custom_button(__("Reset"), function () {
-			frappe.call({
-				method: "frappe.desk.doctype.global_search_settings.global_search_settings.reset_global_search_settings_doctypes",
-				callback: function () {
-					frappe.show_alert({
-						message: __("Global Search Document Types Reset."),
-						indicator: "green",
-					});
-					frm.refresh();
-				},
-			});
-		});
-	},
-});
-
-frappe.ui.form.on("Global Search DocType", {
-	configure: function (frm, cdt, cdn) {
-		const row = frappe.get_doc(cdt, cdn);
-		if (!row.document_type) {
-			frappe.msgprint(__("Please select Document Type first."));
-			return;
-		}
-		frappe.model.with_doctype(row.document_type, () => {
-			frappe.global_search_settings.show_configure_search_fields_dialog(
-				row.document_type,
-				frm
-			);
-		});
-	},
-});
-
-frappe.provide("frappe.global_search_settings");
-
-frappe.global_search_settings.show_configure_search_fields_dialog = function (doctype, frm) {
+function show_configure_search_fields_dialog(doctype, frm) {
 	frappe.call({
 		method: "frappe.desk.doctype.global_search_settings.global_search_settings.get_global_search_field_options",
 		args: { doctype },
 		callback(r) {
-			const options = r.message?.options || [];
-			const default_global_search_fields = r.message?.default_global_search_fields || [];
+			const options = r.message || [];
 
 			const dialog = new frappe.ui.Dialog({
 				title: __("Configure search fields"),
@@ -101,16 +52,6 @@ frappe.global_search_settings.show_configure_search_fields_dialog = function (do
 						},
 					});
 				},
-
-				secondary_action_label: __("Reset"),
-				secondary_action() {
-					const field = dialog.get_field("search_fields");
-					const defaults = new Set(default_global_search_fields);
-					field.selected_options = field.options
-						.filter((o) => defaults.has(o.value))
-						.map((o) => o.value);
-					field.select_options(field.selected_options);
-				},
 			});
 
 			dialog.get_field("doctype_heading").$wrapper.html(`
@@ -133,4 +74,47 @@ frappe.global_search_settings.show_configure_search_fields_dialog = function (do
 			frappe.utils.setup_search(dialog.$body, ".unit-checkbox", ".label-area");
 		},
 	});
-};
+}
+
+frappe.ui.form.on("Global Search Settings", {
+	refresh: function (frm) {
+		frappe.realtime.on("global_search_settings", (data) => {
+			if (data.progress) {
+				frm.dashboard.show_progress(
+					"Setting up Global Search",
+					(data.progress / data.total) * 100,
+					data.msg
+				);
+				if (data.progress === data.total) {
+					frm.dashboard.hide_progress("Setting up Global Search");
+				}
+			}
+		});
+
+		frm.add_custom_button(__("Reset"), function () {
+			frappe.call({
+				method: "frappe.desk.doctype.global_search_settings.global_search_settings.reset_global_search_settings_doctypes",
+				callback: function () {
+					frappe.show_alert({
+						message: __("Global Search Document Types Reset."),
+						indicator: "green",
+					});
+					frm.refresh();
+				},
+			});
+		});
+	},
+});
+
+frappe.ui.form.on("Global Search DocType", {
+	configure: function (frm, cdt, cdn) {
+		const row = frappe.get_doc(cdt, cdn);
+		if (!row.document_type) {
+			frappe.msgprint(__("Please select Document Type first."));
+			return;
+		}
+		frappe.model.with_doctype(row.document_type, () => {
+			show_configure_search_fields_dialog(row.document_type, frm);
+		});
+	},
+});

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.py
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.py
@@ -3,7 +3,10 @@
 
 import frappe
 from frappe import _
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+from frappe.model import NO_VALUE_FIELDS
 from frappe.model.document import Document
+from frappe.utils import cint
 
 
 class GlobalSearchSettings(Document):
@@ -101,3 +104,233 @@ def show_message(progress, msg):
 		{"progress": progress, "total": 3, "msg": msg},
 		user=frappe.session.user,
 	)
+
+
+def _eligible_global_search_docfields(meta):
+	for df in sorted(meta.fields, key=lambda x: x.idx or 0):
+		if df.fieldtype in NO_VALUE_FIELDS:
+			continue
+		if getattr(df, "hidden", False):
+			continue
+		if getattr(df, "is_virtual", False):
+			continue
+		yield df
+
+
+@frappe.whitelist()
+def get_global_search_field_options(doctype: str | None = None):
+	if not doctype:
+		frappe.throw(_("Document Type is required"))
+
+	frappe.only_for("System Manager")
+
+	meta = frappe.get_meta(doctype)
+
+	options = [
+		{
+			"label": _("Document Name (ID)"),
+			"value": "name",
+			"checked": bool(getattr(meta, "show_name_in_global_search", False)),
+			"is_system_generated": bool(getattr(meta, "show_name_in_global_search", False)),
+		}
+	]
+
+	for df in _eligible_global_search_docfields(meta):
+		is_system_generated = check_is_system_generated_property_setter(df)
+
+		options.append(
+			{
+				"label": _(df.label, context=df.parent),
+				"value": df.fieldname,
+				"checked": bool(df.in_global_search),
+				"is_system_generated": is_system_generated,
+			}
+		)
+
+	# get default global search fields
+	default_global_search_fields = get_all_default_global_search_fields(doctype)
+
+	return {"options": options, "default_global_search_fields": default_global_search_fields}
+
+
+def get_all_default_global_search_fields(doctype: str) -> list[str]:
+	"""Which fields would search-index by **schema + system PS only** (ignore Customize Form / non-system PS)."""
+	meta = frappe.get_meta(doctype)
+	cf = frappe.new_doc("Customize Form")
+	cf.doc_type = doctype
+
+	# Layer 1: shipped DocField / DocType / Custom Field rows (Customize Form does not rewrite these).
+	field_on = {
+		df.fieldname: cint(cf.get_existing_property_value("in_global_search", df.fieldname) or 0)
+		for df in (frappe.get_doc("DocType", doctype).fields or [])
+	}
+	for row in frappe.get_all(
+		"Custom Field",
+		filters={"dt": doctype},
+		fields=["fieldname", "in_global_search"],
+	):
+		field_on[row.fieldname] = cint(row.in_global_search)
+
+	include_name = cint(cf.get_existing_property_value("show_name_in_global_search") or 0)
+
+	# Layer 2: app/system patches only (`is_system_generated` PS).
+	for ps in frappe.get_all(
+		"Property Setter",
+		filters={
+			"doc_type": doctype,
+			"property": ("in", ("in_global_search", "show_name_in_global_search")),
+			"is_system_generated": 1,
+		},
+		fields=["doctype_or_field", "field_name", "property", "value"],
+		order_by="modified asc",
+	):
+		val = cint(ps.value)
+		if ps.doctype_or_field == "DocType" and ps.property == "show_name_in_global_search":
+			include_name = val
+		elif ps.doctype_or_field == "DocField" and ps.property == "in_global_search" and ps.field_name:
+			field_on[ps.field_name] = val
+
+	out = ["name"] if include_name else []
+	out.extend(df.fieldname for df in _eligible_global_search_docfields(meta) if field_on.get(df.fieldname))
+	return out
+
+
+def check_is_system_generated_property_setter(df):
+	# Check if df.in_global_search is true or not if false directly return false
+	# If True is that exist in property setter as is_system_generated is False and value is 1 then return False else True
+	# Why is_system_generated False we are checking the point is few fields which are true are directly the doctype property those will not be in property setter as it is system generated
+
+	if not df.in_global_search:
+		return False
+
+	property_setter = frappe.db.exists(
+		"Property Setter",
+		{
+			"doc_type": df.parent,
+			"field_name": df.fieldname,
+			"property": "in_global_search",
+			"is_system_generated": False,
+			"value": 1,
+		},
+	)
+	return False if property_setter else True
+
+
+@frappe.whitelist()
+def update_global_search_fields(doctype: str, fields: str):
+	fields = frappe.parse_json(fields)
+	meta = frappe.get_meta(doctype)
+
+	all_global_search_fields = [
+		df.fieldname for df in _eligible_global_search_docfields(meta) if df.in_global_search
+	]
+	all_global_search_fields.append("name") if bool(
+		getattr(meta, "show_name_in_global_search", False)
+	) else None
+
+	# Fields to add are those fields which are in fields but not in all_global_search_fields
+	fields_to_add = [field for field in fields if field not in all_global_search_fields]
+	# Fields to remove are those fields which are in all_global_search_fields but not in fields
+	fields_to_remove = [field for field in all_global_search_fields if field not in fields]
+
+	# Property Setter to add are those fields which are in fields_to_add but not in all_global_search_fields
+
+	for field in fields_to_add:
+		# Check if property setter exists for the field, the reason is let say user initially marked unchecked to system generated fields,
+		# then again trying to add right instead of creating new property setter delete the existing property setter
+		if field == "name":
+			handle_name_field_in_global_search(doctype, True)
+		else:
+			property_setter = frappe.db.exists(
+				"Property Setter",
+				{
+					"doc_type": doctype,
+					"field_name": field,
+					"property": "in_global_search",
+					"is_system_generated": False,
+					"value": "0",
+				},
+			)
+			if not property_setter:
+				make_property_setter(
+					doctype, field, "in_global_search", 1, "Check", is_system_generated=False
+				)
+
+			else:
+				frappe.delete_doc("Property Setter", property_setter)
+
+	for field in fields_to_remove:
+		if field == "name":
+			handle_name_field_in_global_search(doctype, False)
+		else:
+			property_setter = frappe.db.exists(
+				"Property Setter",
+				{
+					"doc_type": doctype,
+					"field_name": field,
+					"property": "in_global_search",
+					"is_system_generated": False,
+					"value": "1",
+				},
+			)
+
+			if not property_setter:
+				make_property_setter(
+					doctype, field, "in_global_search", 0, "Check", is_system_generated=False
+				)
+
+			else:
+				frappe.delete_doc("Property Setter", property_setter)
+
+	return {"success": True}
+
+
+def handle_name_field_in_global_search(doctype: str, add: bool = True):
+	"""Toggle DocType ``show_name_in_global_search`` via Property Setter (DocType-level, not DocField ``name``)."""
+	if add:
+		# Turning ON: drop user PS that forced 0, or add PS with 1 if base DocType row is 0.
+		property_setter = frappe.db.exists(
+			"Property Setter",
+			{
+				"doc_type": doctype,
+				"doctype_or_field": "DocType",
+				"property": "show_name_in_global_search",
+				"is_system_generated": False,
+				"value": "0",
+			},
+		)
+		if property_setter:
+			frappe.delete_doc("Property Setter", property_setter)
+		else:
+			make_property_setter(
+				doctype,
+				None,
+				"show_name_in_global_search",
+				1,
+				"Check",
+				for_doctype=True,
+				is_system_generated=False,
+			)
+	else:
+		property_setter = frappe.db.exists(
+			"Property Setter",
+			{
+				"doc_type": doctype,
+				"doctype_or_field": "DocType",
+				"property": "show_name_in_global_search",
+				"is_system_generated": False,
+				"value": "1",
+			},
+		)
+		if property_setter:
+			frappe.delete_doc("Property Setter", property_setter)
+		else:
+			make_property_setter(
+				doctype,
+				None,
+				"show_name_in_global_search",
+				0,
+				"Check",
+				for_doctype=True,
+				is_system_generated=False,
+			)

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.py
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe import _
-from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+from frappe.custom.doctype.customize_form.customize_form import CustomizeForm
 from frappe.model import NO_VALUE_FIELDS
 from frappe.model.document import Document
 from frappe.utils import cint
@@ -153,11 +153,17 @@ def get_global_search_field_options(doctype: str | None = None):
 	return {"options": options, "default_global_search_fields": default_global_search_fields}
 
 
+def _customize_form_stub(doctype: str) -> CustomizeForm:
+	"""In-memory Customize Form — same PS helpers as desk Customize Form."""
+	cf = frappe.new_doc("Customize Form")
+	cf.doc_type = doctype
+	return cf
+
+
 def get_all_default_global_search_fields(doctype: str) -> list[str]:
 	"""Which fields would search-index by **schema + system PS only** (ignore Customize Form / non-system PS)."""
 	meta = frappe.get_meta(doctype)
-	cf = frappe.new_doc("Customize Form")
-	cf.doc_type = doctype
+	cf = _customize_form_stub(doctype)
 
 	# Layer 1: shipped DocField / DocType / Custom Field rows (Customize Form does not rewrite these).
 	field_on = {
@@ -218,119 +224,42 @@ def check_is_system_generated_property_setter(df):
 
 @frappe.whitelist()
 def update_global_search_fields(doctype: str, fields: str):
+	"""Apply global-search field selection via the same Property Setter path as Customize Form."""
+	frappe.only_for("System Manager")
+	if not doctype:
+		frappe.throw(_("Document Type is required"))
+	if frappe.get_meta(doctype).module == "Core":
+		frappe.throw(_("Cannot configure Core DocTypes for Global Search."))
+
 	fields = frappe.parse_json(fields)
 	meta = frappe.get_meta(doctype)
 
 	all_global_search_fields = [
 		df.fieldname for df in _eligible_global_search_docfields(meta) if df.in_global_search
 	]
-	all_global_search_fields.append("name") if bool(
-		getattr(meta, "show_name_in_global_search", False)
-	) else None
+	if bool(getattr(meta, "show_name_in_global_search", False)):
+		all_global_search_fields.append("name")
 
-	# Fields to add are those fields which are in fields but not in all_global_search_fields
 	fields_to_add = [field for field in fields if field not in all_global_search_fields]
-	# Fields to remove are those fields which are in all_global_search_fields but not in fields
 	fields_to_remove = [field for field in all_global_search_fields if field not in fields]
 
-	# Property Setter to add are those fields which are in fields_to_add but not in all_global_search_fields
-
+	cf = _customize_form_stub(doctype)
 	for field in fields_to_add:
-		# Check if property setter exists for the field, the reason is let say user initially marked unchecked to system generated fields,
-		# then again trying to add right instead of creating new property setter delete the existing property setter
 		if field == "name":
-			handle_name_field_in_global_search(doctype, True)
+			cf.make_property_setter("show_name_in_global_search", 1, "Check")
 		else:
-			property_setter = frappe.db.exists(
-				"Property Setter",
-				{
-					"doc_type": doctype,
-					"field_name": field,
-					"property": "in_global_search",
-					"is_system_generated": False,
-					"value": "0",
-				},
-			)
-			if not property_setter:
-				make_property_setter(
-					doctype, field, "in_global_search", 1, "Check", is_system_generated=False
-				)
-
-			else:
-				frappe.delete_doc("Property Setter", property_setter)
-
+			cf.make_property_setter("in_global_search", 1, "Check", fieldname=field)
 	for field in fields_to_remove:
 		if field == "name":
-			handle_name_field_in_global_search(doctype, False)
+			cf.make_property_setter("show_name_in_global_search", 0, "Check")
 		else:
-			property_setter = frappe.db.exists(
-				"Property Setter",
-				{
-					"doc_type": doctype,
-					"field_name": field,
-					"property": "in_global_search",
-					"is_system_generated": False,
-					"value": "1",
-				},
-			)
+			cf.make_property_setter("in_global_search", 0, "Check", fieldname=field)
 
-			if not property_setter:
-				make_property_setter(
-					doctype, field, "in_global_search", 0, "Check", is_system_generated=False
-				)
-
-			else:
-				frappe.delete_doc("Property Setter", property_setter)
+	frappe.clear_cache(doctype=doctype)
+	frappe.enqueue(
+		"frappe.utils.global_search.rebuild_for_doctype",
+		doctype=doctype,
+		enqueue_after_commit=True,
+	)
 
 	return {"success": True}
-
-
-def handle_name_field_in_global_search(doctype: str, add: bool = True):
-	"""Toggle DocType ``show_name_in_global_search`` via Property Setter (DocType-level, not DocField ``name``)."""
-	if add:
-		# Turning ON: drop user PS that forced 0, or add PS with 1 if base DocType row is 0.
-		property_setter = frappe.db.exists(
-			"Property Setter",
-			{
-				"doc_type": doctype,
-				"doctype_or_field": "DocType",
-				"property": "show_name_in_global_search",
-				"is_system_generated": False,
-				"value": "0",
-			},
-		)
-		if property_setter:
-			frappe.delete_doc("Property Setter", property_setter)
-		else:
-			make_property_setter(
-				doctype,
-				None,
-				"show_name_in_global_search",
-				1,
-				"Check",
-				for_doctype=True,
-				is_system_generated=False,
-			)
-	else:
-		property_setter = frappe.db.exists(
-			"Property Setter",
-			{
-				"doc_type": doctype,
-				"doctype_or_field": "DocType",
-				"property": "show_name_in_global_search",
-				"is_system_generated": False,
-				"value": "1",
-			},
-		)
-		if property_setter:
-			frappe.delete_doc("Property Setter", property_setter)
-		else:
-			make_property_setter(
-				doctype,
-				None,
-				"show_name_in_global_search",
-				0,
-				"Check",
-				for_doctype=True,
-				is_system_generated=False,
-			)

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.py
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.py
@@ -119,6 +119,10 @@ def _eligible_global_search_docfields(meta):
 
 @frappe.whitelist()
 def get_global_search_field_options(doctype: str | None = None):
+	"""
+	Get the global search field options which is list of fields with checked status if that field is in global search
+	and name is also included if show_name_in_global_search is set
+	"""
 	if not doctype:
 		frappe.throw(_("Document Type is required"))
 
@@ -131,26 +135,19 @@ def get_global_search_field_options(doctype: str | None = None):
 			"label": _("Document Name (ID)"),
 			"value": "name",
 			"checked": bool(getattr(meta, "show_name_in_global_search", False)),
-			"is_system_generated": bool(getattr(meta, "show_name_in_global_search", False)),
 		}
 	]
 
 	for df in _eligible_global_search_docfields(meta):
-		is_system_generated = check_is_system_generated_property_setter(df)
-
 		options.append(
 			{
 				"label": _(df.label, context=df.parent),
 				"value": df.fieldname,
 				"checked": bool(df.in_global_search),
-				"is_system_generated": is_system_generated,
 			}
 		)
 
-	# get default global search fields
-	default_global_search_fields = get_all_default_global_search_fields(doctype)
-
-	return {"options": options, "default_global_search_fields": default_global_search_fields}
+	return options
 
 
 def _customize_form_stub(doctype: str) -> CustomizeForm:
@@ -160,71 +157,19 @@ def _customize_form_stub(doctype: str) -> CustomizeForm:
 	return cf
 
 
-def get_all_default_global_search_fields(doctype: str) -> list[str]:
-	"""Which fields would search-index by **schema + system PS only** (ignore Customize Form / non-system PS)."""
-	meta = frappe.get_meta(doctype)
-	cf = _customize_form_stub(doctype)
-
-	# Layer 1: shipped DocField / DocType / Custom Field rows (Customize Form does not rewrite these).
-	field_on = {
-		df.fieldname: cint(cf.get_existing_property_value("in_global_search", df.fieldname) or 0)
-		for df in (frappe.get_doc("DocType", doctype).fields or [])
-	}
-	for row in frappe.get_all(
-		"Custom Field",
-		filters={"dt": doctype},
-		fields=["fieldname", "in_global_search"],
-	):
-		field_on[row.fieldname] = cint(row.in_global_search)
-
-	include_name = cint(cf.get_existing_property_value("show_name_in_global_search") or 0)
-
-	# Layer 2: app/system patches only (`is_system_generated` PS).
-	for ps in frappe.get_all(
-		"Property Setter",
-		filters={
-			"doc_type": doctype,
-			"property": ("in", ("in_global_search", "show_name_in_global_search")),
-			"is_system_generated": 1,
-		},
-		fields=["doctype_or_field", "field_name", "property", "value"],
-		order_by="modified asc",
-	):
-		val = cint(ps.value)
-		if ps.doctype_or_field == "DocType" and ps.property == "show_name_in_global_search":
-			include_name = val
-		elif ps.doctype_or_field == "DocField" and ps.property == "in_global_search" and ps.field_name:
-			field_on[ps.field_name] = val
-
-	out = ["name"] if include_name else []
-	out.extend(df.fieldname for df in _eligible_global_search_docfields(meta) if field_on.get(df.fieldname))
-	return out
-
-
-def check_is_system_generated_property_setter(df):
-	# Check if df.in_global_search is true or not if false directly return false
-	# If True is that exist in property setter as is_system_generated is False and value is 1 then return False else True
-	# Why is_system_generated False we are checking the point is few fields which are true are directly the doctype property those will not be in property setter as it is system generated
-
-	if not df.in_global_search:
-		return False
-
-	property_setter = frappe.db.exists(
-		"Property Setter",
-		{
-			"doc_type": df.parent,
-			"field_name": df.fieldname,
-			"property": "in_global_search",
-			"is_system_generated": False,
-			"value": 1,
-		},
-	)
-	return False if property_setter else True
+def _set_global_search_property_setter(cf: CustomizeForm, fieldname: str, enabled: bool) -> None:
+	"""Toggle DocType / DocField flags via `CustomizeForm.make_property_setter` (same as Customize Form desk save)."""
+	val = 1 if enabled else 0
+	if fieldname == "name":
+		cf.make_property_setter("show_name_in_global_search", val, "Check")
+	else:
+		cf.make_property_setter("in_global_search", val, "Check", fieldname=fieldname)
 
 
 @frappe.whitelist()
 def update_global_search_fields(doctype: str, fields: str):
 	"""Apply global-search field selection via the same Property Setter path as Customize Form."""
+
 	frappe.only_for("System Manager")
 	if not doctype:
 		frappe.throw(_("Document Type is required"))
@@ -234,27 +179,29 @@ def update_global_search_fields(doctype: str, fields: str):
 	fields = frappe.parse_json(fields)
 	meta = frappe.get_meta(doctype)
 
-	all_global_search_fields = [
-		df.fieldname for df in _eligible_global_search_docfields(meta) if df.in_global_search
-	]
+	# Current set of global search fields which are in the database
+	current = {df.fieldname for df in _eligible_global_search_docfields(meta) if df.in_global_search}
 	if bool(getattr(meta, "show_name_in_global_search", False)):
-		all_global_search_fields.append("name")
+		current.add("name")
 
-	fields_to_add = [field for field in fields if field not in all_global_search_fields]
-	fields_to_remove = [field for field in all_global_search_fields if field not in fields]
+	# Desired set of global search fields which are in the request
+	desired = set(fields)
 
+	# So basically we need to add the fields that are in the request and are not in the database
+	# and remove the fields that are in the database and are not in the request
+
+	# Create a Customize Form stub to apply property setters
 	cf = _customize_form_stub(doctype)
-	for field in fields_to_add:
-		if field == "name":
-			cf.make_property_setter("show_name_in_global_search", 1, "Check")
-		else:
-			cf.make_property_setter("in_global_search", 1, "Check", fieldname=field)
-	for field in fields_to_remove:
-		if field == "name":
-			cf.make_property_setter("show_name_in_global_search", 0, "Check")
-		else:
-			cf.make_property_setter("in_global_search", 0, "Check", fieldname=field)
 
+	# Add the fields that are in the request and are not in the database
+	for fieldname in desired - current:
+		_set_global_search_property_setter(cf, fieldname, True)
+
+	# Remove the fields that are in the database and are not in the request
+	for fieldname in current - desired:
+		_set_global_search_property_setter(cf, fieldname, False)
+
+	# Clear the cache and enqueue the rebuild for the doctype
 	frappe.clear_cache(doctype=doctype)
 	frappe.enqueue(
 		"frappe.utils.global_search.rebuild_for_doctype",

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.py
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.py
@@ -6,7 +6,6 @@ from frappe import _
 from frappe.custom.doctype.customize_form.customize_form import CustomizeForm
 from frappe.model import NO_VALUE_FIELDS
 from frappe.model.document import Document
-from frappe.utils import cint
 
 
 class GlobalSearchSettings(Document):

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -880,8 +880,17 @@ export default class Grid {
 
 							//Show the static area and hide field area if it is not the editable row
 							if (row != frappe.ui.form.editable_row) {
-								column.static_area.show();
-								column.field_area && column.field_area.toggle(false);
+								if (
+									row.should_show_button_in_idle_grid_cell &&
+									row.should_show_button_in_idle_grid_cell(column)
+								) {
+									row.make_control(column);
+									column.static_area.hide();
+									column.field_area && column.field_area.toggle(true);
+								} else {
+									column.static_area.show();
+									column.field_area && column.field_area.toggle(false);
+								}
 							}
 							//Hide the static area and show field area if it is the editable row
 							else {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -790,6 +790,30 @@ export default class GridRow {
 			// last empty column
 			$(`<div class="col grid-static-col search"></div>`).appendTo(this.row);
 		}
+
+		// Button has no stored value; static_area stays empty while field_area is hidden until the row
+		// becomes "editable". Keep the control visible for Button columns in editable grids.
+		this.columns_list.forEach((column) => {
+			if (this.should_show_button_in_idle_grid_cell(column)) {
+				this.make_control(column);
+				column.static_area.toggle(false);
+				column.field_area.toggle(true);
+			}
+		});
+	}
+
+	/**
+	 * Button fields only: show the real control even when this row is not the active editable row.
+	 * Scope is intentionally narrow to avoid changing behaviour of value fields.
+	 */
+	should_show_button_in_idle_grid_cell(column) {
+		return (
+			column.df.fieldtype === "Button" &&
+			this.grid.allow_on_grid_editing() &&
+			this.grid.is_editable() &&
+			this.doc &&
+			!column.df.hidden
+		);
 	}
 
 	set_dependant_property(df) {
@@ -1165,11 +1189,17 @@ export default class GridRow {
 					this.refresh_field(df.fieldname, txt);
 				}
 
-				if (!column.df.hidden) {
-					column.static_area.toggle(true);
-				}
+				if (this.should_show_button_in_idle_grid_cell(column)) {
+					this.make_control(column);
+					column.static_area.toggle(false);
+					column.field_area.toggle(true);
+				} else {
+					if (!column.df.hidden) {
+						column.static_area.toggle(true);
+					}
 
-				column.field_area && column.field_area.toggle(false);
+					column.field_area && column.field_area.toggle(false);
+				}
 			});
 			frappe.ui.form.editable_row = null;
 		}

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -291,6 +291,12 @@
 			padding: var(--grid-padding) !important;
 		}
 
+		// Button: same cell padding as idle rows — .grid-static-col padding is 0 above for editable rows,
+		// which shifts Button controls up versus the Document Type column.
+		.grid-static-col[data-fieldtype="Button"] {
+			padding: var(--grid-padding) !important;
+		}
+
 		.frappe-control[data-fieldtype="Select"].form-group .select-icon {
 			top: 9px;
 		}
@@ -342,12 +348,19 @@
 		}
 	}
 
-	.grid-static-col[data-fieldtype="Button"] .field-area {
-		margin-top: var(--margin-xs);
-		margin-left: var(--margin-xs);
+	.grid-static-col[data-fieldtype="Button"] {
+		display: flex;
+		align-items: center;
 
-		button {
-			height: 24px;
+		.field-area {
+			margin-top: 0;
+			margin-left: var(--margin-xs);
+			display: flex;
+			align-items: center;
+
+			button {
+				height: 24px;
+			}
 		}
 	}
 

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -295,6 +295,8 @@
 		// which shifts Button controls up versus the Document Type column.
 		.grid-static-col[data-fieldtype="Button"] {
 			padding: var(--grid-padding) !important;
+			// editable-row sets --control-bg to neutral (white); keep btn-default gray like idle rows.
+			--control-bg: var(--btn-default-bg);
 		}
 
 		.frappe-control[data-fieldtype="Select"].form-group .select-icon {
@@ -357,10 +359,6 @@
 			margin-left: var(--margin-xs);
 			display: flex;
 			align-items: center;
-
-			button {
-				height: 24px;
-			}
 		}
 	}
 


### PR DESCRIPTION
Allow user to configure Global Search fields of Doctype from Global Search Setting Doctype itself

Note: fixing the button visibility in grid as well

1. Added Configure Button in grid for each child table document of Global Search Setting
<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/97950b10-6363-4297-9dea-585f44d9ced3" />


2. By Clicking on Configure Button user Can Select the fields for global search settings
<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/4f315be7-1476-48a2-9565-f9b7b7089f4d" />


3. Those fields will be marked as `in_global_search`
<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/f7ddee77-c737-4aca-96ba-6bebe9482de5" />

`no-docs`

