### PR TITLE
perf(form): speed up mandatory check, dedupe row errors

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -220,10 +220,7 @@ frappe.ui.form.check_mandatory = function (frm) {
 
 			if (rows.length === te.total_rows) {
 				lines.push(
-					__("In {0}, {1} is required in every row.", [
-						te.label,
-						field_label.bold(),
-					])
+					__("In {0}, {1} is required in every row.", [te.label, field_label.bold()])
 				);
 			} else if (rows.length === 1) {
 				lines.push(

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -123,6 +123,8 @@ frappe.ui.form.check_mandatory = function (frm) {
 
 	if (frm.doc.docstatus == 2) return true; // don't check for cancel
 
+	const ROW_LIMIT = 10;
+	const parent_errors = [];
 	const table_errors = {};
 
 	$.each(frappe.model.get_all_docs(frm.doc), function (i, doc) {
@@ -190,41 +192,79 @@ frappe.ui.form.check_mandatory = function (frm) {
 					table_errors[parentfield].fields[field_label].push(doc.idx);
 				});
 			} else {
-				const message =
-					__("Mandatory fields required in {0}", [__(doc.doctype)]) +
-					"<br><br><ul><li>" +
-					error_fields.join("</li><li>") +
-					"</ul>";
-				frappe.msgprint({
-					message: message,
-					indicator: "red",
-					title: __("Missing Fields"),
+				error_fields.forEach(function (field_label) {
+					parent_errors.push(__("{0} is required.", [field_label.bold()]));
 				});
-				frm.refresh();
 			}
 		}
 	});
 
+	const lines = [...parent_errors];
 	Object.values(table_errors).forEach(function (te) {
-		const lines = Object.entries(te.fields).map(function (entry) {
-			const rows = entry[1];
-			const display =
-				rows.length === te.total_rows
-					? __("all {0} rows", [te.total_rows])
-					: __("Row {0}", [rows.join(", ")]);
-			return entry[0] + ": " + display;
+		Object.entries(te.fields).forEach(function (entry) {
+			const field_label = entry[0];
+			const rows = entry[1].sort((a, b) => a - b);
+
+			const ranges = [];
+			let start = rows[0];
+			let prev = rows[0];
+			for (let i = 1; i < rows.length; i++) {
+				if (rows[i] === prev + 1) {
+					prev = rows[i];
+				} else {
+					ranges.push(start === prev ? `${start}` : `${start}-${prev}`);
+					start = prev = rows[i];
+				}
+			}
+			ranges.push(start === prev ? `${start}` : `${start}-${prev}`);
+
+			if (rows.length === te.total_rows) {
+				lines.push(
+					__("In {0}, {1} is required in every row.", [
+						te.label,
+						field_label.bold(),
+					])
+				);
+			} else if (rows.length === 1) {
+				lines.push(
+					__("In {0}, {1} is required in row {2}.", [
+						te.label,
+						field_label.bold(),
+						rows[0],
+					])
+				);
+			} else if (ranges.length <= ROW_LIMIT) {
+				lines.push(
+					__("In {0}, {1} is required in rows {2}.", [
+						te.label,
+						field_label.bold(),
+						frappe.utils.comma_and(ranges),
+					])
+				);
+			} else {
+				lines.push(
+					__("In {0}, {1} is required in {2} rows.", [
+						te.label,
+						field_label.bold(),
+						rows.length,
+					])
+				);
+			}
 		});
+	});
+
+	if (lines.length) {
 		frappe.msgprint({
 			message:
-				__("Mandatory fields required in table {0}", [te.label]) +
+				__("Please fill the following mandatory fields before saving:") +
 				"<br><br><ul><li>" +
 				lines.join("</li><li>") +
-				"</ul>",
+				"</li></ul>",
 			indicator: "red",
 			title: __("Missing Fields"),
 		});
 		frm.refresh();
-	});
+	}
 
 	return !has_errors;
 

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -123,25 +123,25 @@ frappe.ui.form.check_mandatory = function (frm) {
 
 	if (frm.doc.docstatus == 2) return true; // don't check for cancel
 
+	const table_errors = {};
+
 	$.each(frappe.model.get_all_docs(frm.doc), function (i, doc) {
 		var error_fields = [];
 		var folded = false;
+		const fields_dict = frappe.meta.get_docfield_copy(doc.doctype, doc.name) || {};
 
 		$.each(frappe.meta.docfield_list[doc.doctype] || [], function (i, docfield) {
 			if (docfield.fieldname) {
-				const df = frappe.meta.get_docfield(doc.doctype, docfield.fieldname, doc.name);
+				const df = fields_dict[docfield.fieldname];
+				if (!df) return;
 
-				// skip fields that don't hold data
-				if (
-					["Section Break", "Column Break", "Tab Break", "HTML", "Heading"].includes(
-						df.fieldtype
-					)
-				) {
+				if (!df.reqd && !df.mandatory_depends_on && df.fieldtype !== "Fold") {
 					return;
 				}
 
 				if (df.fieldtype === "Fold") {
 					folded = frm.layout.folded;
+					return;
 				}
 
 				if (
@@ -170,29 +170,60 @@ frappe.ui.form.check_mandatory = function (frm) {
 
 		if (error_fields.length) {
 			let meta = frappe.get_meta(doc.doctype);
-			let message;
 			if (meta.istable) {
-				const table_field = frappe.meta.docfield_map[doc.parenttype][doc.parentfield];
-
-				const table_label = __(
-					table_field.label || frappe.unscrub(table_field.fieldname)
-				).bold();
-
-				message = __("Mandatory fields required in table {0}, Row {1}", [
-					table_label,
-					doc.idx,
-				]);
+				const parentfield = doc.parentfield;
+				if (!table_errors[parentfield]) {
+					const table_field = frappe.meta.docfield_map[doc.parenttype][parentfield];
+					const table_label = __(
+						table_field.label || frappe.unscrub(table_field.fieldname)
+					).bold();
+					table_errors[parentfield] = {
+						label: table_label,
+						fields: {},
+						total_rows: (frm.doc[parentfield] || []).length,
+					};
+				}
+				error_fields.forEach(function (field_label) {
+					if (!table_errors[parentfield].fields[field_label]) {
+						table_errors[parentfield].fields[field_label] = [];
+					}
+					table_errors[parentfield].fields[field_label].push(doc.idx);
+				});
 			} else {
-				message = __("Mandatory fields required in {0}", [__(doc.doctype)]);
+				const message =
+					__("Mandatory fields required in {0}", [__(doc.doctype)]) +
+					"<br><br><ul><li>" +
+					error_fields.join("</li><li>") +
+					"</ul>";
+				frappe.msgprint({
+					message: message,
+					indicator: "red",
+					title: __("Missing Fields"),
+				});
+				frm.refresh();
 			}
-			message = message + "<br><br><ul><li>" + error_fields.join("</li><li>") + "</ul>";
-			frappe.msgprint({
-				message: message,
-				indicator: "red",
-				title: __("Missing Fields"),
-			});
-			frm.refresh();
 		}
+	});
+
+	Object.values(table_errors).forEach(function (te) {
+		const lines = Object.entries(te.fields).map(function (entry) {
+			const rows = entry[1];
+			const display =
+				rows.length === te.total_rows
+					? __("all {0} rows", [te.total_rows])
+					: __("Row {0}", [rows.join(", ")]);
+			return entry[0] + ": " + display;
+		});
+		frappe.msgprint({
+			message:
+				__("Mandatory fields required in table {0}", [te.label]) +
+				"<br><br><ul><li>" +
+				lines.join("</li><li>") +
+				"</ul>",
+			indicator: "red",
+			title: __("Missing Fields"),
+		});
+		frm.refresh();
 	});
 
 	return !has_errors;


### PR DESCRIPTION
## Behaviour

  Mandatory check on save was doing two things badly:

  1. For each row in a child table with missing fields, it popped a separate "Missing Fields" dialog. A table with 10 broken rows = 10 dialogs to click through.

  2. Inside the loop, every field went through `frappe.meta.get_docfield(...)` which builds a fresh per-row docfield copy. On big forms (lots of children, lots of fields) this got slow.

  ## Fix

  - One combined dialog. Parent-doc and all child-table errors collapse into a single msgprint, listed as sentences.
  - Pull the per-row docfield map once with `get_docfield_copy` and reuse it across the field loop.
  - Come out early on fields that aren't `reqd` / `mandatory_depends_on` / Fold, IMO there is no need to keep checking layout fieldtypes one by one.


## For reference 
https://github.com/user-attachments/assets/f68460c9-0a7e-463f-81c2-b81a8602e948

## How it looks now
 ### For all fields
 <img width="682" height="269" alt="Screenshot 2026-05-10 at 5 44 01 PM" src="https://github.com/user-attachments/assets/3caf202d-7c37-45ec-90b0-18617a9952b6" />

 ### If values are filled in-between
  <img width="629" height="264" alt="Screenshot 2026-05-10 at 5 45 59 PM" src="https://github.com/user-attachments/assets/31ad7f3c-adbb-41a8-abe7-6726730a0399" />
  <img width="605" height="241" alt="Screenshot 2026-05-10 at 5 44 14 PM" src="https://github.com/user-attachments/assets/6c278d14-da2d-4812-b26d-883c305ad15f" />

## Note
Here page could hang and become unresponsive because of browser/internet issue sometimes.