### PR TITLE
fix(user): update private workspaces on user rename

### DIFF
--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -420,8 +420,8 @@ class TestUser(IntegrationTestCase):
 			frappe.rename_doc("User", old_name, new_name)
 
 		# Workspace Sidebar.for_user is a Link field, so it is already cascaded to new_name by
-		# the User rename itself; rename_private_sidebars must look it up by new_name (that's
-		# what the after_rename_user flag is for) to find and rename "My Workspaces-<old_name>".
+		# the User rename itself; rename_private_sidebars must look it up by new_name to find
+		# and rename "My Workspaces-<old_name>".
 		new_sidebar = f"My Workspaces-{new_name}"
 		self.assertTrue(frappe.db.exists("Workspace Sidebar", new_sidebar))
 		self.assertEqual(frappe.db.get_value("Workspace Sidebar", new_sidebar, "for_user"), new_name)

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -365,6 +365,7 @@ class TestUser(IntegrationTestCase):
 		self.assertTrue(frappe.db.exists("Workspace", new_workspace))
 		self.assertEqual(frappe.db.get_value("Workspace", new_workspace, "for_user"), new_name)
 
+		frappe.delete_doc("Workspace", new_workspace, ignore_permissions=True, force=True)
 		frappe.delete_doc("User", new_name, ignore_permissions=True, force=True)
 		frappe.delete_doc("User", actor_name, ignore_permissions=True, force=True)
 

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -314,6 +314,121 @@ class TestUser(IntegrationTestCase):
 
 		frappe.delete_doc("User", new_name)
 
+	def test_user_rename_updates_private_workspace(self):
+		old_name = "test_user_rename_ws@example.com"
+		new_name = "test_user_rename_ws_new@example.com"
+		actor_name = "test_user_rename_ws_actor@example.com"
+
+		for email in (old_name, new_name, actor_name):
+			frappe.delete_doc("User", email, ignore_permissions=True, force=True)
+		if frappe.db.exists("Workspace", "Test Rename Workspace"):
+			frappe.delete_doc("Workspace", "Test Rename Workspace", ignore_permissions=True, force=True)
+
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": old_name,
+				"enabled": 1,
+				"first_name": "_Test",
+				"new_password": "Eastern_43A1W",
+				"roles": [{"doctype": "Has Role", "parentfield": "roles", "role": "System Manager"}],
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+		# Deliberately only System Manager (no Desk User / Workspace Manager role): Workspace
+		# permissions are only granted to those two roles, so renaming a private workspace
+		# owned by someone else only succeeds if rename_private_workspaces passes
+		# ignore_permissions=True to rename_doc.
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": actor_name,
+				"enabled": 1,
+				"first_name": "_Test Actor",
+				"new_password": "Eastern_43A1W",
+				"roles": [{"doctype": "Has Role", "parentfield": "roles", "role": "System Manager"}],
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+		frappe.get_doc(
+			{
+				"doctype": "Workspace",
+				"title": "Test Rename Workspace",
+				"label": "Test Rename Workspace",
+				"type": "Workspace",
+				"for_user": old_name,
+				"public": 0,
+				"content": "[]",
+			}
+		).insert(ignore_permissions=True)
+
+		with self.set_user(actor_name):
+			frappe.rename_doc("User", old_name, new_name)
+
+		new_workspace = f"Test Rename Workspace-{new_name}"
+		self.assertTrue(frappe.db.exists("Workspace", new_workspace))
+		self.assertEqual(frappe.db.get_value("Workspace", new_workspace, "for_user"), new_name)
+
+		frappe.delete_doc("User", new_name, ignore_permissions=True, force=True)
+		frappe.delete_doc("User", actor_name, ignore_permissions=True, force=True)
+
+	def test_user_rename_updates_private_sidebar(self):
+		old_name = "test_user_rename_sb@example.com"
+		new_name = "test_user_rename_sb_new@example.com"
+		actor_name = "test_user_rename_sb_actor@example.com"
+
+		for email in (old_name, new_name, actor_name):
+			frappe.delete_doc("User", email, ignore_permissions=True, force=True)
+		if frappe.db.exists("Workspace Sidebar", f"My Workspaces-{old_name}"):
+			frappe.delete_doc(
+				"Workspace Sidebar", f"My Workspaces-{old_name}", ignore_permissions=True, force=True
+			)
+
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": old_name,
+				"enabled": 1,
+				"first_name": "_Test",
+				"new_password": "Eastern_43A1W",
+				"roles": [{"doctype": "Has Role", "parentfield": "roles", "role": "System Manager"}],
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+		# Actor has no ownership relation to the sidebar being renamed, so this only succeeds
+		# if rename_private_sidebars passes ignore_permissions=True to rename_doc.
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": actor_name,
+				"enabled": 1,
+				"first_name": "_Test Actor",
+				"new_password": "Eastern_43A1W",
+				"roles": [{"doctype": "Has Role", "parentfield": "roles", "role": "System Manager"}],
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+		frappe.get_doc(
+			{
+				"doctype": "Workspace Sidebar",
+				"title": f"My Workspaces-{old_name}",
+				"for_user": old_name,
+			}
+		).insert(ignore_permissions=True)
+
+		with self.set_user(actor_name):
+			frappe.rename_doc("User", old_name, new_name)
+
+		# Workspace Sidebar.for_user is a Link field, so it is already cascaded to new_name by
+		# the User rename itself; rename_private_sidebars must look it up by new_name (that's
+		# what the after_rename_user flag is for) to find and rename "My Workspaces-<old_name>".
+		new_sidebar = f"My Workspaces-{new_name}"
+		self.assertTrue(frappe.db.exists("Workspace Sidebar", new_sidebar))
+		self.assertEqual(frappe.db.get_value("Workspace Sidebar", new_sidebar, "for_user"), new_name)
+
+		frappe.delete_doc("User", new_name, ignore_permissions=True, force=True)
+		frappe.delete_doc("User", actor_name, ignore_permissions=True, force=True)
+
 	def test_signup(self):
 		import frappe.website.utils
 

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -335,10 +335,6 @@ class TestUser(IntegrationTestCase):
 			}
 		).insert(ignore_permissions=True, ignore_if_duplicate=True)
 
-		# Deliberately only System Manager (no Desk User / Workspace Manager role): Workspace
-		# permissions are only granted to those two roles, so renaming a private workspace
-		# owned by someone else only succeeds if rename_private_workspaces passes
-		# ignore_permissions=True to rename_doc.
 		frappe.get_doc(
 			{
 				"doctype": "User",

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -319,10 +319,11 @@ class TestUser(IntegrationTestCase):
 		new_name = "test_user_rename_ws_new@example.com"
 		actor_name = "test_user_rename_ws_actor@example.com"
 
+		old_workspace = f"Test Rename Workspace-{old_name}"
 		for email in (old_name, new_name, actor_name):
 			frappe.delete_doc("User", email, ignore_permissions=True, force=True)
-		if frappe.db.exists("Workspace", "Test Rename Workspace"):
-			frappe.delete_doc("Workspace", "Test Rename Workspace", ignore_permissions=True, force=True)
+		if frappe.db.exists("Workspace", old_workspace):
+			frappe.delete_doc("Workspace", old_workspace, ignore_permissions=True, force=True)
 
 		frappe.get_doc(
 			{
@@ -350,7 +351,7 @@ class TestUser(IntegrationTestCase):
 			{
 				"doctype": "Workspace",
 				"title": "Test Rename Workspace",
-				"label": "Test Rename Workspace",
+				"label": old_workspace,
 				"type": "Workspace",
 				"for_user": old_name,
 				"public": 0,

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -372,63 +372,6 @@ class TestUser(IntegrationTestCase):
 		frappe.delete_doc("User", new_name, ignore_permissions=True, force=True)
 		frappe.delete_doc("User", actor_name, ignore_permissions=True, force=True)
 
-	def test_user_rename_updates_private_sidebar(self):
-		old_name = "test_user_rename_sb@example.com"
-		new_name = "test_user_rename_sb_new@example.com"
-		actor_name = "test_user_rename_sb_actor@example.com"
-
-		for email in (old_name, new_name, actor_name):
-			frappe.delete_doc("User", email, ignore_permissions=True, force=True)
-		if frappe.db.exists("Workspace Sidebar", f"My Workspaces-{old_name}"):
-			frappe.delete_doc(
-				"Workspace Sidebar", f"My Workspaces-{old_name}", ignore_permissions=True, force=True
-			)
-
-		frappe.get_doc(
-			{
-				"doctype": "User",
-				"email": old_name,
-				"enabled": 1,
-				"first_name": "_Test",
-				"new_password": "Eastern_43A1W",
-				"roles": [{"doctype": "Has Role", "parentfield": "roles", "role": "System Manager"}],
-			}
-		).insert(ignore_permissions=True, ignore_if_duplicate=True)
-
-		# Actor has no ownership relation to the sidebar being renamed, so this only succeeds
-		# if rename_private_sidebars passes ignore_permissions=True to rename_doc.
-		frappe.get_doc(
-			{
-				"doctype": "User",
-				"email": actor_name,
-				"enabled": 1,
-				"first_name": "_Test Actor",
-				"new_password": "Eastern_43A1W",
-				"roles": [{"doctype": "Has Role", "parentfield": "roles", "role": "System Manager"}],
-			}
-		).insert(ignore_permissions=True, ignore_if_duplicate=True)
-
-		frappe.get_doc(
-			{
-				"doctype": "Workspace Sidebar",
-				"title": f"My Workspaces-{old_name}",
-				"for_user": old_name,
-			}
-		).insert(ignore_permissions=True)
-
-		with self.set_user(actor_name):
-			frappe.rename_doc("User", old_name, new_name)
-
-		# Workspace Sidebar.for_user is a Link field, so it is already cascaded to new_name by
-		# the User rename itself; rename_private_sidebars must look it up by new_name to find
-		# and rename "My Workspaces-<old_name>".
-		new_sidebar = f"My Workspaces-{new_name}"
-		self.assertTrue(frappe.db.exists("Workspace Sidebar", new_sidebar))
-		self.assertEqual(frappe.db.get_value("Workspace Sidebar", new_sidebar, "for_user"), new_name)
-
-		frappe.delete_doc("User", new_name, ignore_permissions=True, force=True)
-		frappe.delete_doc("User", actor_name, ignore_permissions=True, force=True)
-
 	def test_signup(self):
 		import frappe.website.utils
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -706,7 +706,6 @@ class User(Document):
 		frappe.db.set_value("User", new_name, "email", new_name)
 
 		get_controller("Workspace").rename_private_workspaces(old_name, new_name)
-		get_controller("Workspace Sidebar").rename_private_sidebars(old_name, new_name)
 
 		clear_sessions(user=old_name, force=True)
 		clear_sessions(user=new_name, force=True)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -706,6 +706,9 @@ class User(Document):
 		frappe.db.set_value("User", new_name, "email", new_name)
 
 		get_controller("Workspace").rename_private_workspaces(old_name, new_name)
+		get_controller("Workspace Sidebar").rename_private_sidebars(
+			old_name, new_name, after_rename_user=True
+		)
 
 		clear_sessions(user=old_name, force=True)
 		clear_sessions(user=new_name, force=True)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -705,8 +705,19 @@ class User(Document):
 		# set email
 		frappe.db.set_value("User", new_name, "email", new_name)
 
+		self._rename_user_workspaces(old_name, new_name)
+
 		clear_sessions(user=old_name, force=True)
 		clear_sessions(user=new_name, force=True)
+
+	def _rename_user_workspaces(self, old_name, new_name):
+		for workspace in frappe.get_all(
+			"Workspace", filters={"for_user": old_name, "type": "Workspace"}, fields=["name", "title"]
+		):
+			new_label = f"{workspace.title}-{new_name}"
+			if workspace.name != new_label:
+				frappe.rename_doc("Workspace", workspace.name, new_label, force=True, show_alert=False)
+			frappe.db.set_value("Workspace", new_label, {"for_user": new_name, "label": new_label})
 
 	def append_roles(self, *roles):
 		"""Add roles to user"""

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -706,9 +706,7 @@ class User(Document):
 		frappe.db.set_value("User", new_name, "email", new_name)
 
 		get_controller("Workspace").rename_private_workspaces(old_name, new_name)
-		get_controller("Workspace Sidebar").rename_private_sidebars(
-			old_name, new_name, after_rename_user=True
-		)
+		get_controller("Workspace Sidebar").rename_private_sidebars(old_name, new_name)
 
 		clear_sessions(user=old_name, force=True)
 		clear_sessions(user=new_name, force=True)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -20,7 +20,7 @@ from frappe.desk.doctype.notification_settings.notification_settings import (
 	toggle_notifications,
 )
 from frappe.desk.notifications import clear_notifications
-from frappe.model.document import Document
+from frappe.model.document import Document, get_controller
 from frappe.query_builder import DocType
 from frappe.rate_limiter import rate_limit
 from frappe.sessions import clear_sessions
@@ -705,19 +705,10 @@ class User(Document):
 		# set email
 		frappe.db.set_value("User", new_name, "email", new_name)
 
-		self._rename_user_workspaces(old_name, new_name)
+		get_controller("Workspace").rename_private_workspaces(old_name, new_name)
 
 		clear_sessions(user=old_name, force=True)
 		clear_sessions(user=new_name, force=True)
-
-	def _rename_user_workspaces(self, old_name, new_name):
-		for workspace in frappe.get_all(
-			"Workspace", filters={"for_user": old_name, "type": "Workspace"}, fields=["name", "title"]
-		):
-			new_label = f"{workspace.title}-{new_name}"
-			if workspace.name != new_label:
-				frappe.rename_doc("Workspace", workspace.name, new_label, force=True, show_alert=False)
-			frappe.db.set_value("Workspace", new_label, {"for_user": new_name, "label": new_label})
 
 	def append_roles(self, *roles):
 		"""Add roles to user"""

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -172,7 +172,7 @@ class Workspace(Document):
 	@staticmethod
 	def rename_private_workspaces(old_name, new_name):
 		for workspace in frappe.get_all(
-			"Workspace", filters={"for_user": old_name, "type": "Workspace"}, fields=["name", "title"]
+			"Workspace", filters={"for_user": old_name, "type": "Workspace"}, fields=["name", "title"], limit=0
 		):
 			new_label = f"{workspace.title}-{new_name}"
 			if workspace.name != new_label:

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -10,7 +10,7 @@ from frappe.boot import get_sidebar_items
 from frappe.desk.desktop import get_workspaces, save_new_widget
 from frappe.desk.doctype.workspace_sidebar.workspace_sidebar import add_to_my_workspace
 from frappe.desk.utils import validate_route_conflict
-from frappe.model.document import Document, get_controller
+from frappe.model.document import Document
 from frappe.model.rename_doc import rename_doc
 from frappe.modules.export_file import delete_folder, export_to_files
 from frappe.utils import strip_html

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -173,7 +173,7 @@ class Workspace(Document):
 	def rename_private_workspaces(old_name, new_name):
 		for workspace in frappe.get_all(
 			"Workspace",
-			filters={"for_user": old_name, "type": "Workspace"},
+			filters={"for_user": old_name},
 			fields=["name", "title"],
 			limit=0,
 		):

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -10,7 +10,7 @@ from frappe.boot import get_sidebar_items
 from frappe.desk.desktop import get_workspaces, save_new_widget
 from frappe.desk.doctype.workspace_sidebar.workspace_sidebar import add_to_my_workspace
 from frappe.desk.utils import validate_route_conflict
-from frappe.model.document import Document
+from frappe.model.document import Document, get_controller
 from frappe.model.rename_doc import rename_doc
 from frappe.modules.export_file import delete_folder, export_to_files
 from frappe.utils import strip_html
@@ -178,16 +178,6 @@ class Workspace(Document):
 			if workspace.name != new_label:
 				rename_doc("Workspace", workspace.name, new_label, force=True, show_alert=False)
 			frappe.db.set_value("Workspace", new_label, {"for_user": new_name, "label": new_label})
-
-		# rename sidebar as well
-		suffix = f"-{old_name}"
-		for sidebar in frappe.get_all("Workspace Sidebar", filters={"for_user": new_name}, fields=["name"]):
-			if not sidebar.name.endswith(suffix):
-				continue
-
-			new_title = sidebar.name.removesuffix(suffix) + f"-{new_name}"
-			rename_doc("Workspace Sidebar", sidebar.name, new_title, force=True, show_alert=False)
-			frappe.db.set_value("Workspace Sidebar", new_title, "title", new_title)
 
 	@staticmethod
 	def get_module_wise_workspaces():

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -179,7 +179,14 @@ class Workspace(Document):
 		):
 			new_label = f"{workspace.title}-{new_name}"
 			if workspace.name != new_label:
-				rename_doc("Workspace", workspace.name, new_label, force=True, show_alert=False)
+				rename_doc(
+					"Workspace",
+					workspace.name,
+					new_label,
+					force=True,
+					show_alert=False,
+					ignore_permissions=True,
+				)
 			frappe.db.set_value("Workspace", new_label, {"for_user": new_name, "label": new_label})
 
 	@staticmethod

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -170,6 +170,16 @@ class Workspace(Document):
 			delete_folder(self.module, "Workspace", self.title)
 
 	@staticmethod
+	def rename_private_workspaces(old_name, new_name):
+		for workspace in frappe.get_all(
+			"Workspace", filters={"for_user": old_name, "type": "Workspace"}, fields=["name", "title"]
+		):
+			new_label = f"{workspace.title}-{new_name}"
+			if workspace.name != new_label:
+				rename_doc("Workspace", workspace.name, new_label, force=True, show_alert=False)
+			frappe.db.set_value("Workspace", new_label, {"for_user": new_name, "label": new_label})
+
+	@staticmethod
 	def get_module_wise_workspaces():
 		workspaces = frappe.get_all(
 			"Workspace",

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -178,8 +178,9 @@ class Workspace(Document):
 			limit=0,
 		):
 			new_label = f"{workspace.title}-{new_name}"
-			workspace_name = workspace.name
-			if workspace.name != new_label and not frappe.db.exists("Workspace", new_label):
+			if workspace.name != new_label:
+				if frappe.db.exists("Workspace", new_label):
+					continue
 				rename_doc(
 					"Workspace",
 					workspace.name,
@@ -188,8 +189,7 @@ class Workspace(Document):
 					show_alert=False,
 					ignore_permissions=True,
 				)
-				workspace_name = new_label
-			frappe.db.set_value("Workspace", workspace_name, {"for_user": new_name, "label": new_label})
+			frappe.db.set_value("Workspace", new_label, {"for_user": new_name, "label": new_label})
 
 	@staticmethod
 	def get_module_wise_workspaces():

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -179,6 +179,16 @@ class Workspace(Document):
 				rename_doc("Workspace", workspace.name, new_label, force=True, show_alert=False)
 			frappe.db.set_value("Workspace", new_label, {"for_user": new_name, "label": new_label})
 
+		# rename sidebar as well
+		suffix = f"-{old_name}"
+		for sidebar in frappe.get_all("Workspace Sidebar", filters={"for_user": new_name}, fields=["name"]):
+			if not sidebar.name.endswith(suffix):
+				continue
+
+			new_title = sidebar.name.removesuffix(suffix) + f"-{new_name}"
+			rename_doc("Workspace Sidebar", sidebar.name, new_title, force=True, show_alert=False)
+			frappe.db.set_value("Workspace Sidebar", new_title, "title", new_title)
+
 	@staticmethod
 	def get_module_wise_workspaces():
 		workspaces = frappe.get_all(

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -180,6 +180,7 @@ class Workspace(Document):
 			new_label = f"{workspace.title}-{new_name}"
 			if workspace.name != new_label:
 				if frappe.db.exists("Workspace", new_label):
+					frappe.db.set_value("Workspace", workspace.name, "for_user", new_name)
 					continue
 				rename_doc(
 					"Workspace",

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -172,7 +172,10 @@ class Workspace(Document):
 	@staticmethod
 	def rename_private_workspaces(old_name, new_name):
 		for workspace in frappe.get_all(
-			"Workspace", filters={"for_user": old_name, "type": "Workspace"}, fields=["name", "title"], limit=0
+			"Workspace",
+			filters={"for_user": old_name, "type": "Workspace"},
+			fields=["name", "title"],
+			limit=0,
 		):
 			new_label = f"{workspace.title}-{new_name}"
 			if workspace.name != new_label:

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -178,7 +178,8 @@ class Workspace(Document):
 			limit=0,
 		):
 			new_label = f"{workspace.title}-{new_name}"
-			if workspace.name != new_label:
+			workspace_name = workspace.name
+			if workspace.name != new_label and not frappe.db.exists("Workspace", new_label):
 				rename_doc(
 					"Workspace",
 					workspace.name,
@@ -187,7 +188,8 @@ class Workspace(Document):
 					show_alert=False,
 					ignore_permissions=True,
 				)
-			frappe.db.set_value("Workspace", new_label, {"for_user": new_name, "label": new_label})
+				workspace_name = new_label
+			frappe.db.set_value("Workspace", workspace_name, {"for_user": new_name, "label": new_label})
 
 	@staticmethod
 	def get_module_wise_workspaces():

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -81,7 +81,9 @@ class WorkspaceSidebar(Document, DeskViews):
 
 		for_user = new_user if after_rename_user else old_user
 		suffix = f"-{old_user}"
-		for sidebar in frappe.get_all("Workspace Sidebar", filters={"for_user": for_user}, fields=["name"], limit=0):
+		for sidebar in frappe.get_all(
+			"Workspace Sidebar", filters={"for_user": for_user}, fields=["name"], limit=0
+		):
 			if not sidebar.name.endswith(suffix):
 				continue
 			new_title = sidebar.name.removesuffix(suffix) + f"-{new_user}"

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -76,13 +76,12 @@ class WorkspaceSidebar(Document, DeskViews):
 			self.export_sidebar()
 
 	@staticmethod
-	def rename_private_sidebars(old_user, new_user, after_rename_user=False):
+	def rename_private_sidebars(old_user, new_user):
 		from frappe.model.rename_doc import rename_doc
 
-		for_user = new_user if after_rename_user else old_user
 		suffix = f"-{old_user}"
 		for sidebar in frappe.get_all(
-			"Workspace Sidebar", filters={"for_user": for_user}, fields=["name"], limit=0
+			"Workspace Sidebar", filters={"for_user": new_user}, fields=["name"], limit=0
 		):
 			if not sidebar.name.endswith(suffix):
 				continue

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -87,7 +87,14 @@ class WorkspaceSidebar(Document, DeskViews):
 			if not sidebar.name.endswith(suffix):
 				continue
 			new_title = sidebar.name.removesuffix(suffix) + f"-{new_user}"
-			rename_doc("Workspace Sidebar", sidebar.name, new_title, force=True, show_alert=False)
+			rename_doc(
+				"Workspace Sidebar",
+				sidebar.name,
+				new_title,
+				force=True,
+				show_alert=False,
+				ignore_permissions=True,
+			)
 			frappe.db.set_value("Workspace Sidebar", new_title, "title", new_title)
 
 	def get_cached(self, cache_key, fallback_fn):

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -75,6 +75,19 @@ class WorkspaceSidebar(Document, DeskViews):
 			delete_file(self.app, old)
 			self.export_sidebar()
 
+	@staticmethod
+	def rename_private_sidebars(old_user, new_user, after_rename_user=False):
+		from frappe.model.rename_doc import rename_doc
+
+		for_user = new_user if after_rename_user else old_user
+		suffix = f"-{old_user}"
+		for sidebar in frappe.get_all("Workspace Sidebar", filters={"for_user": for_user}, fields=["name"]):
+			if not sidebar.name.endswith(suffix):
+				continue
+			new_title = sidebar.name.removesuffix(suffix) + f"-{new_user}"
+			rename_doc("Workspace Sidebar", sidebar.name, new_title, force=True, show_alert=False)
+			frappe.db.set_value("Workspace Sidebar", new_title, "title", new_title)
+
 	def get_cached(self, cache_key, fallback_fn):
 		value = frappe.cache.get_value(cache_key, user=frappe.session.user)
 		if value is not None:

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -81,7 +81,7 @@ class WorkspaceSidebar(Document, DeskViews):
 
 		for_user = new_user if after_rename_user else old_user
 		suffix = f"-{old_user}"
-		for sidebar in frappe.get_all("Workspace Sidebar", filters={"for_user": for_user}, fields=["name"]):
+		for sidebar in frappe.get_all("Workspace Sidebar", filters={"for_user": for_user}, fields=["name"], limit=0):
 			if not sidebar.name.endswith(suffix):
 				continue
 			new_title = sidebar.name.removesuffix(suffix) + f"-{new_user}"

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -75,27 +75,6 @@ class WorkspaceSidebar(Document, DeskViews):
 			delete_file(self.app, old)
 			self.export_sidebar()
 
-	@staticmethod
-	def rename_private_sidebars(old_user, new_user):
-		from frappe.model.rename_doc import rename_doc
-
-		suffix = f"-{old_user}"
-		for sidebar in frappe.get_all(
-			"Workspace Sidebar", filters={"for_user": new_user}, fields=["name"], limit=0
-		):
-			if not sidebar.name.endswith(suffix):
-				continue
-			new_title = sidebar.name.removesuffix(suffix) + f"-{new_user}"
-			rename_doc(
-				"Workspace Sidebar",
-				sidebar.name,
-				new_title,
-				force=True,
-				show_alert=False,
-				ignore_permissions=True,
-			)
-			frappe.db.set_value("Workspace Sidebar", new_title, "title", new_title)
-
 	def get_cached(self, cache_key, fallback_fn):
 		value = frappe.cache.get_value(cache_key, user=frappe.session.user)
 		if value is not None:


### PR DESCRIPTION
Resolve: #28385 

---
When a user's email is changed, their private Workspace documents still
referenced the old email in `for_user` and the document name, making them
inaccessible.

Adds `Workspace.rename_private_workspaces`, called from `User.after_rename`,
to rename those documents and update `for_user` to the new email.




