### PR TITLE
fix(query): use default limit when offset is used in MariaDB and SQLite w/o limit

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -172,6 +172,9 @@ BACKTICK_FIELD_PARSE_REGEX = re.compile(r"^`tab([\w\s-]+)`\.(`?)(\w+)\2$")
 # Group 3: Fieldname
 CHILD_TABLE_FIELD_PATTERN = re.compile(r'^[`"]?tab([\w\s]+)[`"]?\.([`"]?)(\w+)\2$')
 
+# Maximum value of an unsigned 64-bit integer
+MAX_LIMIT = 18446744073709551615
+
 # Direct mapping from uppercase function names to pypika function classes
 FUNCTION_MAPPING = {
 	"COUNT": functions.Count,
@@ -299,6 +302,11 @@ class Engine:
 		if offset:
 			if not isinstance(offset, int) or offset < 0:
 				frappe.throw(_("Offset must be a non-negative integer"), TypeError)
+
+			# In MariaDB and SQLite, offset requires limit
+			if not self.is_postgres and not limit:
+				self.query = self.query.limit(MAX_LIMIT)
+
 			self.query = self.query.offset(offset)
 
 		if distinct:

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -2625,6 +2625,19 @@ class TestQuery(IntegrationTestCase):
 		)
 		self.assertFalse(index_exists)
 
+	def test_limit_offset_query(self):
+		"""Test if query builder correctly uses limit with offset in MariaDB and SQLite when limit is omitted."""
+		from frappe.database.query import MAX_LIMIT
+
+		query = frappe.qb.get_query("Doctype", offset=10).get_sql()
+		if frappe.db.db_type != "postgres":
+			self.assertIn(f"LIMIT {MAX_LIMIT} OFFSET 10", query)
+			query = frappe.qb.get_query("Doctype", limit=10, offset=10).get_sql()
+			self.assertIn("LIMIT 10 OFFSET 10", query)
+		else:
+			self.assertNotIn("LIMIT", query)
+			self.assertIn("OFFSET 10", query)
+
 
 # This function is used as a permission query condition hook
 def test_permission_hook_condition(user):


### PR DESCRIPTION
MariaDB and SQLite don't allow use of `offset` as a standalone, **`limit` is a must**, enforcing that in QB via this PR. PostgreSQL allows use of offset w/o limit clause. Have used the Maximum value of an unsigned 64-bit integer as the default, however this can be changed when and if needed.

**Doc:** https://www.postgresql.org/docs/current/queries-limit.html

**Before**:


https://github.com/user-attachments/assets/4efd7939-ab91-4ad0-866a-db28486df88c



**After**:


https://github.com/user-attachments/assets/18a5b1d6-9eb1-428d-b790-5469f3033261





closes #38692