### PR TITLE
fix(report): skip total row label for datetime/time first column

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -678,9 +678,6 @@ def get_xlsx_styles(metadata: XLSXMetadata, report_name: str | None = None) -> d
 	return styles
 
 
-NON_LABELABLE_FIELDTYPES = ("Currency", "Int", "Float", "Percent", "Date", "Datetime", "Time")
-
-
 def add_total_row(
 	result,
 	columns,
@@ -754,7 +751,8 @@ def add_total_row(
 	else:
 		first_col_fieldtype = columns[0].get("fieldtype")
 
-	if first_col_fieldtype not in NON_LABELABLE_FIELDTYPES:
+	unsupported_col_types = ("Currency", "Int", "Float", "Percent", "Date", "Datetime", "Time")
+	if first_col_fieldtype not in unsupported_col_types:
 		total_row[0] = _("Total")
 
 	result.append(total_row)

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -751,7 +751,7 @@ def add_total_row(
 	else:
 		first_col_fieldtype = columns[0].get("fieldtype")
 
-	if first_col_fieldtype not in ["Currency", "Int", "Float", "Percent", "Date"]:
+	if first_col_fieldtype not in ["Currency", "Int", "Float", "Percent", "Date", "Datetime", "Time"]:
 		total_row[0] = _("Total")
 
 	result.append(total_row)

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -678,6 +678,9 @@ def get_xlsx_styles(metadata: XLSXMetadata, report_name: str | None = None) -> d
 	return styles
 
 
+NON_LABELABLE_FIELDTYPES = ("Currency", "Int", "Float", "Percent", "Date", "Datetime", "Time")
+
+
 def add_total_row(
 	result,
 	columns,
@@ -751,7 +754,7 @@ def add_total_row(
 	else:
 		first_col_fieldtype = columns[0].get("fieldtype")
 
-	if first_col_fieldtype not in ["Currency", "Int", "Float", "Percent", "Date", "Datetime", "Time"]:
+	if first_col_fieldtype not in NON_LABELABLE_FIELDTYPES:
 		total_row[0] = _("Total")
 
 	result.append(total_row)


### PR DESCRIPTION
Fix Query Report export crash with `add_total_row` when first column is `Datetime` or `Time`

Added `Datetime` and `Time` to the skip-list so "Total" isn't written into those cell types. First cell remains empty, matching behavior for `Date` and numeric columns.

Fixes `ParserError: Unknown string format: Total` on export

---
Related: https://github.com/frappe/frappe/pull/38118
Ref: https://support.frappe.io/helpdesk/tickets/65561?view=VIEW-HD+Ticket-1252