### PR TITLE
fix: btn-default styles no longer override Bootstrap variant classes

### DIFF
--- a/frappe/public/scss/common/buttons.scss
+++ b/frappe/public/scss/common/buttons.scss
@@ -100,7 +100,7 @@
 	}
 }
 
-.btn.btn-default {
+.btn.btn-default:not(.btn-primary):not(.btn-success):not(.btn-danger):not(.btn-warning):not(.btn-info) {
 	background-color: var(--control-bg);
 	color: var(--text-color);
 	&:hover,


### PR DESCRIPTION
Fixes: #38958

PR raised on behalf of @marcramser 