### PR TITLE
fix(file): upload to current folder from File list view when inside subfolder

### DIFF
--- a/frappe/public/js/frappe/views/file/file_view.js
+++ b/frappe/public/js/frappe/views/file/file_view.js
@@ -82,6 +82,12 @@ frappe.views.FileView = class FileView extends frappe.views.ListView {
 		});
 	}
 
+	make_new_doc() {
+		new frappe.ui.FileUploader({
+			folder: this.current_folder,
+		});
+	}
+
 	file_menu_items() {
 		return [
 			{


### PR DESCRIPTION
## Problem
Uploading a file via the "+ Add File" button inside any subfolder of the File list view always created the file in `Home` instead of the current folder.

## Root cause
1. `ListView.make_new_doc` (list_view.js) builds filter options for `frappe.new_doc`, but skips fields where `df.read_only` is true.
2. `File.folder` is read-only, so it is stripped from the options.
3. `frappe.new_doc` File branch (create_new.js) reads `opts.folder` and defaults to `"Home"` when missing → every upload lands in Home.

## Fix
Override `make_new_doc` in `FileView` to skip `frappe.new_doc` entirely and instantiate `frappe.ui.FileUploader` directly with `this.current_folder`.

### Before Fix
[Screencast from 2026-05-01 00-32-59.webm](https://github.com/user-attachments/assets/8c637f59-3f28-4de5-b426-15497376a9ea)

### After Fix
[Screencast from 2026-05-01 00-35-07.webm](https://github.com/user-attachments/assets/82bc46cc-b9d6-4ca8-a6f8-fa189532ceb1)

**Suport Ticket**: [https://support.frappe.io/helpdesk/tickets/67066](https://support.frappe.io/helpdesk/tickets/67066)
