### PR TITLE
refactor: remove unnecessary deep copy in paste doc listener

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -529,7 +529,6 @@ frappe.Application = class Application {
 							newdoc.idx = null;
 							newdoc.__run_link_triggers = false;
 							newdoc.on_paste_event = true;
-							newdoc = JSON.parse(JSON.stringify(newdoc));
 							frappe.set_route("Form", newdoc.doctype, newdoc.name);
 							frappe.dom.unfreeze();
 						});


### PR DESCRIPTION
The `JSON.parse(JSON.stringify(newdoc))` deep copy in `setup_copy_doc_listener` is not needed since the `newdoc` variable is not used further.