### PR TITLE
fix: invalid default app

### DIFF
--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -53,6 +53,8 @@ def get_apps():
 
 
 def get_route(app_name):
+	if app_name not in frappe.get_installed_apps():
+		return "/apps"  # Invalid defaults
 	apps = frappe.get_hooks("add_to_apps_screen", app_name=app_name)
 	app = next((app for app in apps if app.get("name") == app_name), None)
 	return app.get("route") if app and app.get("route") else "/apps"
@@ -89,6 +91,9 @@ def get_default_path():
 
 @frappe.whitelist()
 def set_app_as_default(app_name: str):
+	if app_name not in frappe.get_installed_apps():
+		frappe.throw(_("App {} is not installed").format(frappe.bold(app_name)))
+
 	if frappe.db.get_value("User", frappe.session.user, "default_app") == app_name:
 		frappe.db.set_value("User", frappe.session.user, "default_app", "")
 	else:

--- a/frappe/core/doctype/system_settings/system_settings.js
+++ b/frappe/core/doctype/system_settings/system_settings.js
@@ -19,7 +19,7 @@ frappe.ui.form.on("System Settings", {
 
 		frappe.xcall("frappe.apps.get_apps").then((r) => {
 			let apps = r?.map((r) => r.name) || [];
-			frm.set_df_property("default_app", "options", [" ", ...apps]);
+			frm.set_df_property("default_app", "options", ["", ...apps]);
 		});
 
 		frm.trigger("set_rounding_method_options");

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -466,6 +466,21 @@ class TestUser(IntegrationTestCase):
 			sorted(m.get("module_name") for m in get_modules_from_all_apps()),
 		)
 
+	def test_default_app(self):
+		from frappe.apps import get_default_path
+
+		with test_user(roles=["System Manager"]) as user:
+			user.default_app = "next_erp"
+			user.save()
+			self.assertFalse(user.default_app)
+
+			frappe.set_user(user.name)
+			user.db_set("default_app", "next_erp")
+			user.reload()
+			self.assertTrue(user.default_app)
+
+			get_default_path()  # defaults will also trigger hooks logic
+
 	@IntegrationTestCase.change_settings("System Settings", reset_password_link_expiry_duration=1)
 	def test_reset_password_link_expiry(self):
 		new_password = "new_password"

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -105,7 +105,7 @@ frappe.ui.form.on("User", {
 
 		frappe.xcall("frappe.apps.get_apps").then((r) => {
 			let apps = r?.map((r) => r.name) || [];
-			frm.set_df_property("default_app", "options", [" ", ...apps]);
+			frm.set_df_property("default_app", "options", ["", ...apps]);
 		});
 
 		if (frm.is_new()) {

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -248,6 +248,9 @@ class User(Document):
 		if self.language == "Loading...":
 			self.language = None
 
+		if self.default_app and self.default_app not in frappe.get_installed_apps():
+			self.default_app = ""
+
 		if (self.name not in ["Administrator", "Guest"]) and (not self.get_social_login_userid("frappe")):
 			self.set_social_login_userid("frappe", frappe.generate_hash(length=39))
 

--- a/frappe/core/doctype/user/user_list.js
+++ b/frappe/core/doctype/user/user_list.js
@@ -23,7 +23,7 @@ frappe.listview_settings["User"] = {
 
 		frappe.xcall("frappe.apps.get_apps").then((r) => {
 			let apps = r?.map((r) => r.name) || [];
-			default_app_field.options = [" ", ...apps].join("\n");
+			default_app_field.options = ["", ...apps].join("\n");
 		});
 	},
 };


### PR DESCRIPTION
Bad defaults were causing this error for new users.

closes https://github.com/frappe/frappe/issues/39028 
This was broken since day this feature was added, but it only started affecting users after https://github.com/frappe/frappe/pull/38805 

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/caching.py", line 65, in wrapper
    return _cache[func][args_key]
           ~~~~~~~~~~~~^^^^^^^^^^
KeyError: (' ',)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/frappe/frappe-bench/env/lib/python3.14/site-packages/gunicorn/workers/gthread.py", line 300, in handle
    keepalive = self.handle_request(req, conn)
  File "/home/frappe/frappe-bench/env/lib/python3.14/site-packages/gunicorn/workers/gthread.py", line 352, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 84, in application
    app(environ, start_response),
    ~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.14/site-packages/werkzeug/wrappers/request.py", line 193, in application
    resp = f(*args[:-2] + (request,))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 145, in application
    response = e.get_response(request.environ) if isinstance(e, HTTPException) else handle_exception(e)
                                                                                    ~~~~~~~~~~~~~~~~^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/permissions.py", line 930, in wrapper
    return fn(e, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 406, in handle_exception
    ).render()
      ~~~~~~^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/page_renderers/template_page.py", line 84, in render
    html = self.get_html()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/utils.py", line 545, in cache_html_decorator
    html = func(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/page_renderers/template_page.py", line 92, in get_html
    self.init_context()
    ~~~~~~~~~~~~~~~~~^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/page_renderers/error_page.py", line 17, in init_context
    super().init_context()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/page_renderers/base_template_page.py", line 15, in init_context
    self.context.update(get_website_settings())
                        ~~~~~~~~~~~~~~~~~~~~^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/doctype/website_settings/website_settings.py", line 263, in get_website_settings
    context.boot = get_boot_data()
                   ~~~~~~~~~~~~~^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/utils.py", line 185, in get_boot_data
    "default_path": get_default_path() or "",
                    ~~~~~~~~~~~~~~~~^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/apps.py", line 81, in get_default_path
    return get_route(user_default_app)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/apps.py", line 56, in get_route
    apps = frappe.get_hooks("add_to_apps_screen", app_name=app_name)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 984, in get_hooks
    hooks = _request_cached_load_app_hooks(app_name)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/caching.py", line 71, in wrapper
    return_val = func(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 952, in _load_app_hooks
    app_hooks = get_module(f"{app}.hooks")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 819, in get_module
    return importlib.import_module(modulename)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/lib/python3.14/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1406, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1314, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 491, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1406, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1335, in _find_and_load_unlocked
ModuleNotFoundError: No module named ' '
```
