### PR TITLE
fix(desktop-modal): close modal when clicking outside the title

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -1163,6 +1163,11 @@ class DesktopModal {
 			this.modal.find(".modal-dialog").attr("id", "desktop-modal");
 			this.modal.find(".modal-body").addClass("desktop-modal-body");
 			this.$child_icons_wrapper = this.modal.find(".desktop-modal-body");
+			this.modal.find(".desktop-modal-heading").on("click", (e) => {
+				if (!$(e.target).closest(".modal-title").length) {
+					this.hide();
+				}
+			});
 		} else {
 			this.modal.find(".modal-title").text(icon_title);
 			$(this.modal.find(".modal-body")).empty();


### PR DESCRIPTION
Resolve: #38324

---

**Before:**

https://github.com/user-attachments/assets/81139ff6-52b9-405d-aeef-158d38064e31

**After**

https://github.com/user-attachments/assets/263b0956-7aa7-4809-b88b-f3ed8c0e10f5

