### PR TITLE
fix: pin python version requirement to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     { name = "Frappe Technologies Pvt Ltd", email = "developers@frappe.io"}
 ]
 description = "Metadata driven, full-stack low code web framework"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.11"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [


### PR DESCRIPTION
While doing new deploys on FC, installation of v14 was breaking. 
