### PR TITLE
fix: handle prepared report if no previous completed prepared reports

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -768,9 +768,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				this.execution_time = data.execution_time || 0.1;
 
 				const check_if_report_is_stale = () => {
-					let generated_at = this.prepared_report
-						? this.prepared_report_document.report_end_time
-						: this.refreshed_at;
+					let generated_at =
+						this.prepared_report && this.prepared_report_document
+							? this.prepared_report_document.report_end_time
+							: this.refreshed_at;
 					let pretty_diff = frappe.datetime.comment_when(generated_at);
 					const days_old = frappe.datetime.get_day_diff(
 						frappe.datetime.now_datetime(),


### PR DESCRIPTION
If user doesn't have a prepared report in completed status we cant get the report_name for prepared report_name

Before

https://github.com/user-attachments/assets/9b1cefb0-adf4-4e0b-a049-c5c73b9b6a6a

Screen was becoming blank 


After


https://github.com/user-attachments/assets/b68ad9ad-8ccd-4940-9077-606c2c197fbc




