### PR TITLE
fix: fix image overflow by restricting width to 100% of column

### DIFF
--- a/frappe/public/js/frappe/form/controls/image.js
+++ b/frappe/public/js/frappe/form/controls/image.js
@@ -10,9 +10,9 @@ frappe.ui.form.ControlImage = class ControlImage extends frappe.ui.form.Control 
 
 		var doc = this.get_doc();
 		if (doc && this.df.options && doc[this.df.options]) {
-			this.$img = $(
-				"<img src='" + doc[this.df.options] + "' class='img-responsive'>"
-			).appendTo(this.$body);
+			this.$img = $("<img src='" + doc[this.df.options] + "' class='img-responsive'>")
+				.appendTo(this.$body)
+				.css({ "max-width": "100%" });
 		} else {
 			this.$buffer = $(
 				`<div class='missing-image'>${frappe.utils.icon("restriction", "md")}</div>`


### PR DESCRIPTION
Image was overflowing onto the right sidebar. This was due to the width not being bounded, added max-width to fix this.

**Before**:

<img width="2866" height="1296" alt="image" src="https://github.com/user-attachments/assets/cb424f06-2a66-4cf9-855c-0c3af06ead06" />



**After**:

<img width="2866" height="1430" alt="image" src="https://github.com/user-attachments/assets/89af88ed-f57f-4655-97b5-136df907baed" />


closes Ticket #66222
(backport to v16)