### PR TITLE
refactor!: remove `__print_formats` from meta

### DIFF
--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -16,7 +16,6 @@ ASSET_KEYS = (
 	"__css",
 	"__list_js",
 	"__calendar_js",
-	"__print_formats",
 	"__workflow_docs",
 	"__form_grid_templates",
 	"__listview_template",
@@ -60,7 +59,6 @@ class FormMeta(Meta):
 		if not self.istable:
 			self.add_code()
 			self.add_custom_script()
-			self.load_print_formats()
 			self.load_workflows()
 			self.load_templates()
 			self.load_dashboard()
@@ -195,17 +193,6 @@ class FormMeta(Meta):
 			)
 
 		frappe.throw(msg, title=_("Missing DocType"))
-
-	def load_print_formats(self):
-		print_formats = frappe.db.sql(
-			"""select * FROM `tabPrint Format`
-			WHERE doc_type=%s AND docstatus<2 and disabled=0""",
-			(self.name,),
-			as_dict=1,
-			update={"doctype": "Print Format"},
-		)
-
-		self.set("__print_formats", print_formats)
 
 	def load_workflows(self):
 		# get active workflow

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -137,6 +137,7 @@ has_permission = {
 	"Prepared Report": "frappe.core.doctype.prepared_report.prepared_report.has_permission",
 	"Notification Settings": "frappe.desk.doctype.notification_settings.notification_settings.has_permission",
 	"User Invitation": "frappe.core.doctype.user_invitation.user_invitation.has_permission",
+	"Print Format": "frappe.printing.doctype.print_format.print_format.has_permission",
 }
 
 has_website_permission = {"Address": "frappe.contacts.doctype.address.address.has_website_permission"}

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -293,7 +293,7 @@
  "icon": "fa fa-print",
  "idx": 1,
  "links": [],
- "modified": "2026-03-26 16:27:02.559100",
+ "modified": "2026-05-06 02:26:54.457678",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",
@@ -312,8 +312,8 @@
    "write": 1
   },
   {
-   "role": "Desk User",
-   "select": 1
+   "read": 1,
+   "role": "Desk User"
   }
  ],
  "row_format": "Dynamic",

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -176,3 +176,15 @@ def make_default(name: str):
 			frappe.bold(name), frappe.bold(print_format.doc_type)
 		)
 	)
+
+
+def has_permission(doc, ptype="read", user=None):
+	if ptype in ("read", "select"):
+		if doc.print_format_for == "DocType":
+			return frappe.has_permission(doc.doc_type, "print")
+		elif doc.print_format_for == "Report":
+			from frappe.boot import get_allowed_reports
+
+			return doc.report in get_allowed_reports(cache=True)
+
+	return True

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -181,7 +181,7 @@ def make_default(name: str):
 def has_permission(doc, ptype="read", user=None):
 	if ptype in ("read", "select"):
 		if doc.print_format_for == "DocType":
-			return frappe.has_permission(doc.doc_type, "print")
+			return frappe.has_permission(doc.doc_type, "print", user=user)
 		elif doc.print_format_for == "Report":
 			from frappe.boot import get_allowed_reports
 

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -109,7 +109,7 @@ frappe.ui.form.PrintView = class {
 	setup_sidebar() {
 		this.sidebar = this.page.sidebar.addClass("print-preview-sidebar");
 
-		this.print_format_selector = this.add_sidebar_item({
+		this.print_format_field = this.add_sidebar_item({
 			fieldtype: "Link",
 			fieldname: "print_format",
 			options: "Print Format",
@@ -118,7 +118,7 @@ frappe.ui.form.PrintView = class {
 				return { filters: { doc_type: this.frm.doctype } };
 			},
 			change: () => this.refresh_print_format(),
-		}).$input;
+		});
 
 		this.language_selector = this.add_sidebar_item({
 			fieldtype: "Link",
@@ -248,8 +248,8 @@ frappe.ui.form.PrintView = class {
 		}
 	}
 
-	edit_print_format() {
-		let print_format = this.get_print_format();
+	async edit_print_format() {
+		let print_format = await this.get_print_format();
 		let is_custom_format =
 			print_format.name &&
 			(print_format.print_format_builder || print_format.print_format_builder_beta) &&
@@ -314,17 +314,28 @@ frappe.ui.form.PrintView = class {
 					beta: data.beta,
 				};
 				frappe.set_route("print-format-builder");
-				this.print_format_selector.val(data.print_format_name);
+				this.print_format_field.set_value(data.print_format_name);
 			},
 			__("New Custom Print Format"),
 			__("Start")
 		);
 	}
 
-	refresh_print_format() {
+	async refresh_print_format() {
+		await this.load_print_format();
 		this.set_default_print_language();
 		this.toggle_raw_printing();
 		this.preview();
+	}
+
+	async load_print_format(format) {
+		if (!format) {
+			format = this.selected_format();
+		}
+
+		if (format && format !== "Standard") {
+			frappe.model.with_doc("Print Format", format);
+		}
 	}
 
 	// bind_events () {
@@ -820,20 +831,17 @@ frappe.ui.form.PrintView = class {
 		}
 	}
 
-	set_default_print_format() {
-		if (
-			frappe.meta
-				.get_print_formats(this.frm.doctype)
-				.includes(this.print_format_selector.val())
-		)
+	async set_default_print_format() {
+		let print_format = this.print_format_field.get_value();
+		if (print_format && (await this.print_format_field.validate(print_format))) {
 			return;
+		}
 
-		this.print_format_selector.empty();
-		this.print_format_selector.val(this.frm.meta.default_print_format || "");
+		this.print_format_field.set_value(this.frm.meta.default_print_format || "");
 	}
 
 	selected_format() {
-		return this.print_format_selector.val() || "Standard";
+		return this.print_format_field.get_value() || "Standard";
 	}
 
 	is_raw_printing(format) {
@@ -885,13 +893,20 @@ frappe.ui.form.PrintView = class {
 						},
 						fields: [
 							{
-								fieldtype: "Select",
+								fieldtype: "Link",
 								fieldname: "print_format",
-								default: 0,
-								options: frappe.meta.get_print_formats(this.frm.doctype),
+								options: "Print Format",
 								read_only: 0,
 								in_list_view: 1,
 								label: __("Print Format"),
+								get_query: () => {
+									return {
+										filters: {
+											doc_type: this.frm.doctype,
+											disabled: 0,
+										},
+									};
+								},
 							},
 							{
 								fieldtype: "Select",

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -829,8 +829,9 @@ frappe.ui.form.PrintView = class {
 		// returns a list of "print format: printer" mapping filtered by the current print format
 		let print_format_printer_map = this.get_print_format_printer_map();
 		if (print_format_printer_map[this.frm.doctype]) {
+			let selected_format = this.selected_format();
 			return print_format_printer_map[this.frm.doctype].filter(
-				(printer_map) => printer_map.print_format == this.selected_format()
+				(printer_map) => (printer_map.print_format || "Standard") == selected_format
 			);
 		} else {
 			return [];
@@ -887,7 +888,10 @@ frappe.ui.form.PrintView = class {
 	printer_setting_dialog() {
 		// dialog for the Printer Settings
 		this.print_format_printer_map = this.get_print_format_printer_map();
-		this.data = this.print_format_printer_map[this.frm.doctype] || [];
+		this.data = (this.print_format_printer_map[this.frm.doctype] || []).map((printer_map) => ({
+			...printer_map,
+			print_format: printer_map.print_format === "Standard" ? "" : printer_map.print_format,
+		}));
 		this.printer_list = [];
 		frappe.ui.form.qz_get_printer_list().then((data) => {
 			this.printer_list = data;
@@ -933,7 +937,9 @@ frappe.ui.form.PrintView = class {
 				primary_action: () => {
 					let printer_mapping = dialog.get_values()["printer_mapping"];
 					if (printer_mapping && printer_mapping.length) {
-						let print_format_list = printer_mapping.map((a) => a.print_format);
+						let print_format_list = printer_mapping.map(
+							(printer_map) => printer_map.print_format || "Standard"
+						);
 						let has_duplicate = print_format_list.some(
 							(item, idx) => print_format_list.indexOf(item) != idx
 						);

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -115,7 +115,7 @@ frappe.ui.form.PrintView = class {
 			options: "Print Format",
 			label: __("Print Format"),
 			get_query: () => {
-				return { filters: { doc_type: this.frm.doctype } };
+				return { filters: this.get_print_format_filters() };
 			},
 			change: () => this.refresh_print_format(),
 		});
@@ -337,6 +337,20 @@ frappe.ui.form.PrintView = class {
 		if (format && format !== "Standard") {
 			await frappe.model.with_doc("Print Format", format);
 		}
+	}
+
+	get_print_format_filters() {
+		let filters = {
+			doc_type: this.frm.doctype,
+			disabled: 0,
+			print_format_type: ["!=", "JS"],
+		};
+
+		if (!cint(this.print_settings.enable_raw_printing)) {
+			filters.raw_printing = 0;
+		}
+
+		return filters;
 	}
 
 	// bind_events () {
@@ -901,12 +915,7 @@ frappe.ui.form.PrintView = class {
 								in_list_view: 1,
 								label: __("Print Format"),
 								get_query: () => {
-									return {
-										filters: {
-											doc_type: this.frm.doctype,
-											disabled: 0,
-										},
-									};
+									return { filters: this.get_print_format_filters() };
 								},
 							},
 							{

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -208,6 +208,7 @@ frappe.ui.form.PrintView = class {
 
 		let tasks = [
 			this.set_default_print_format,
+			this.load_print_format,
 			this.set_default_print_language,
 			this.set_default_letterhead,
 			this.preview,
@@ -334,7 +335,7 @@ frappe.ui.form.PrintView = class {
 		}
 
 		if (format && format !== "Standard") {
-			frappe.model.with_doc("Print Format", format);
+			await frappe.model.with_doc("Print Format", format);
 		}
 	}
 
@@ -837,7 +838,7 @@ frappe.ui.form.PrintView = class {
 			return;
 		}
 
-		this.print_format_field.set_value(this.frm.meta.default_print_format || "");
+		return this.print_format_field.set_value(this.frm.meta.default_print_format || "");
 	}
 
 	selected_format() {

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -61,11 +61,18 @@ export default class BulkOperations {
 					options: "Print Format",
 					default: frappe.get_meta(this.doctype).default_print_format,
 					get_query: () => {
+						const filters = {
+							doc_type: this.doctype,
+							disabled: 0,
+							print_format_type: ["!=", "JS"],
+						};
+
+						if (!cint(print_settings.enable_raw_printing)) {
+							filters.raw_printing = 0;
+						}
+
 						return {
-							filters: {
-								doc_type: this.doctype,
-								disabled: 0,
-							},
+							filters: filters,
 						};
 					},
 				},

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -55,11 +55,19 @@ export default class BulkOperations {
 					default: letterheads[0],
 				},
 				{
-					fieldtype: "Select",
+					fieldtype: "Link",
 					label: __("Print Format"),
 					fieldname: "print_sel",
-					options: frappe.meta.get_print_formats(this.doctype),
+					options: "Print Format",
 					default: frappe.get_meta(this.doctype).default_print_format,
+					get_query: () => {
+						return {
+							filters: {
+								doc_type: this.doctype,
+								disabled: 0,
+							},
+						};
+					},
 				},
 				{
 					fieldtype: "Select",

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -20,7 +20,6 @@ $.extend(frappe.meta, {
 			frappe.meta.add_field(df);
 		});
 
-		if (doc.__print_formats?.length) frappe.model.sync(doc.__print_formats);
 		if (doc.__workflow_docs?.length) frappe.model.sync(doc.__workflow_docs);
 	},
 
@@ -259,37 +258,6 @@ $.extend(frappe.meta, {
 			"Tabloid",
 			"Custom",
 		];
-	},
-
-	get_print_formats: function (doctype) {
-		var print_format_list = ["Standard"];
-		var default_print_format = locals.DocType[doctype].default_print_format;
-		let enable_raw_printing = frappe.model.get_doc(
-			":Print Settings",
-			"Print Settings"
-		).enable_raw_printing;
-		var print_formats = frappe
-			.get_list("Print Format", { doc_type: doctype })
-			.sort(function (a, b) {
-				return a > b ? 1 : -1;
-			});
-		$.each(print_formats, function (i, d) {
-			if (
-				!print_format_list.includes(d.name) &&
-				d.print_format_type !== "JS" &&
-				(cint(enable_raw_printing) || !d.raw_printing)
-			) {
-				print_format_list.push(d.name);
-			}
-		});
-
-		if (default_print_format && default_print_format != "Standard") {
-			var index = print_format_list.indexOf(default_print_format);
-			print_format_list.splice(index, 1).sort();
-			print_format_list.unshift(default_print_format);
-		}
-
-		return print_format_list;
 	},
 
 	get_field_currency: function (df, doc) {

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -179,8 +179,17 @@ frappe.views.CommunicationComposer = class {
 			},
 			{
 				label: __("Select Print Format"),
-				fieldtype: "Select",
+				fieldtype: "Link",
+				options: "Print Format",
 				fieldname: "select_print_format",
+				get_query: () => {
+					return {
+						filters: {
+							doc_type: me.frm.doctype,
+							disabled: 0,
+						},
+					};
+				},
 				onchange: function () {
 					me.guess_language();
 				},
@@ -605,18 +614,6 @@ frappe.views.CommunicationComposer = class {
 		);
 	}
 
-	get_print_format(format) {
-		if (!format) {
-			format = this.selected_format();
-		}
-
-		if (locals["Print Format"] && locals["Print Format"][format]) {
-			return locals["Print Format"][format];
-		} else {
-			return {};
-		}
-	}
-
 	setup_print() {
 		// print formats
 		const fields = this.dialog.fields_dict;
@@ -630,11 +627,7 @@ frappe.views.CommunicationComposer = class {
 		$(fields.select_print_format.wrapper).toggle(false);
 
 		if (this.frm) {
-			const print_formats = frappe.meta.get_print_formats(this.frm.meta.name);
-			$(fields.select_print_format.input)
-				.empty()
-				.add_options(print_formats)
-				.val(print_formats[0]);
+			fields.select_print_format.set_value(this.frm.meta.default_print_format || "");
 		} else {
 			$(fields.attach_document_print.wrapper).toggle(false);
 		}

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -201,8 +201,8 @@ frappe.views.CommunicationComposer = class {
 						filters: filters,
 					};
 				},
-				onchange: function () {
-					me.guess_language();
+				onchange: async function () {
+					await me.guess_language();
 				},
 			},
 			{
@@ -278,7 +278,7 @@ frappe.views.CommunicationComposer = class {
 		}
 	}
 
-	guess_language() {
+	async guess_language() {
 		// when attach print for print format changes try to guess language
 		// if print format has language then set that else boot lang.
 
@@ -289,18 +289,20 @@ frappe.views.CommunicationComposer = class {
 		// 4. system lang
 		// 3 and 4 are resolved already in boot
 		let document_lang = this.frm?.doc?.language;
-		let print_format = this.dialog.get_value("select_print_format");
+		let print_format = this.selected_format();
 
 		let print_format_lang;
 		if (print_format != "Standard") {
-			print_format_lang = frappe.get_doc(
-				"Print Format",
-				print_format
-			)?.default_print_language;
+			const print_format_doc = await frappe.model.with_doc("Print Format", print_format);
+			if (print_format !== this.selected_format()) {
+				return;
+			}
+
+			print_format_lang = print_format_doc.default_print_language;
 		}
 
 		let lang = document_lang || print_format_lang || frappe.boot.lang;
-		this.dialog.set_value("print_language", lang);
+		await this.dialog.set_value("print_language", lang);
 	}
 
 	async check_email_template_html(email_template) {

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -183,11 +183,22 @@ frappe.views.CommunicationComposer = class {
 				options: "Print Format",
 				fieldname: "select_print_format",
 				get_query: () => {
+					const print_settings = frappe.model.get_doc(
+						":Print Settings",
+						"Print Settings"
+					);
+					const filters = {
+						doc_type: me.frm.doctype,
+						disabled: 0,
+						print_format_type: ["!=", "JS"],
+					};
+
+					if (!cint(print_settings.enable_raw_printing)) {
+						filters.raw_printing = 0;
+					}
+
 					return {
-						filters: {
-							doc_type: me.frm.doctype,
-							disabled: 0,
-						},
+						filters: filters,
 					};
 				},
 				onchange: function () {

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -298,7 +298,7 @@ frappe.views.CommunicationComposer = class {
 				return;
 			}
 
-			print_format_lang = print_format_doc.default_print_language;
+			print_format_lang = print_format_doc?.default_print_language;
 		}
 
 		let lang = document_lang || print_format_lang || frappe.boot.lang;


### PR DESCRIPTION
Previously, all print formats for a doctype were fetched via a raw SQL query, included in doctype metadata and synced to locals. This meant unnecessary overhead and could cause incomplete data when editing Print Format itself (e.g. the SQL query didn't run `onload`, so these values could be missing).

With this refactor, we load a print format only when it's needed, where it's needed, but properly via `frappe.model.with_doc` instead of raw SQL.

This also means that permissions have to be rectified: desk user needs `"read"` perms on print formats for doctypes and reports they can print. Changed the role_perm from `"select"` to `"read"` and added a `has_permission` hook that restricts to relevant formats.

Resolves #39103

### Alternative idea

Store print formats as ":Print Format" in locals, like it's done with other boot-loaded settings. #39414