### PR TITLE
fix(Print Format): don't create __init__.py

### DIFF
--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -25,7 +25,9 @@ if TYPE_CHECKING:
 doctype_python_modules = {}
 
 
-def export_module_json(doc: "Document", is_standard: bool, module: str) -> str | None:
+def export_module_json(
+	doc: "Document", is_standard: bool, module: str, *, create_init: bool | None = None
+) -> str | None:
 	"""Make a folder for the given doc and add its json file (make it a standard object that will be synced).
 
 	Return the absolute file_path without the extension.
@@ -35,8 +37,18 @@ def export_module_json(doc: "Document", is_standard: bool, module: str) -> str |
 	if not frappe.flags.in_import and is_standard and frappe.conf.developer_mode:
 		from frappe.modules.export_file import export_to_files
 
+		if create_init is None:
+			# fall back to old default behavior if new parameter is not provided
+			_create_init = is_standard
+		else:
+			_create_init = create_init
+
 		# json
-		export_to_files(record_list=[[doc.doctype, doc.name]], record_module=module, create_init=is_standard)
+		export_to_files(
+			record_list=[[doc.doctype, doc.name]],
+			record_module=module,
+			create_init=_create_init,
+		)
 
 		return os.path.join(
 			frappe.get_module_path(module), scrub(doc.doctype), scrub(doc.name), scrub(doc.name)

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -143,7 +143,7 @@ class PrintFormat(Document):
 	def export_doc(self):
 		from frappe.modules.utils import export_module_json
 
-		return export_module_json(self, self.standard == "Yes", self.module)
+		return export_module_json(self, self.standard == "Yes", self.module, create_init=False)
 
 	def on_trash(self):
 		if self.doc_type:

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -51,6 +51,7 @@ class TestPrintFormat(IntegrationTestCase):
 		doc_dict = doc.as_dict(no_nulls=True, convert_dates_to_str=True)
 
 		self.assertTrue(os.path.exists(exported_doc_path))
+		self.assertFalse(os.path.exists(os.path.join(os.path.dirname(exported_doc_path), "__init__.py")))
 
 		with open(exported_doc_path) as f:
 			exported_doc = frappe.parse_json(f.read())


### PR DESCRIPTION
Exporting a standard print format used to create an `__init__.py` file, which caused the print format dir to be treated as a python module and the watcher (in development mode) to reload the server before the answer reaches the client. Same problem as described in #38393

`frappe/model/sync.py` discovers standard document JSON files by directory listing and file path, not by Python package import, so missing `__init__.py` should not prevent Print Format restore on migrate.

What I tested:

- Remove `__init__.py` from a standard print format
- Delete the standard print format from DB
- Run `bench migrate` and verify it's restored and functional