### PR TITLE
fix: preserve __new_password across nested save()

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -212,8 +212,8 @@ class User(Document):
 		frappe.cache.delete_key("enabled_users")
 
 	def validate(self):
-		# clear new password
-		self.__new_password = self.new_password
+		if self.new_password:
+			self.__new_password = self.new_password
 		self.new_password = ""
 
 		if not frappe.in_test:


### PR DESCRIPTION
## Summary
- Nested `save()` on user insertion re-runs validate which would reset the __new_password with empty string breaking the user login via password.

## Example
- Auto-assigning role on user creation would trigger this (doc_event)
```python
def after_insert(doc, method):
	doc.add_roles("LMS Student")
```