### PR TITLE
fix: trim preload Link header to stay under size limits

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -603,8 +603,24 @@ def add_preload_for_bundled_assets(response):
 		for svg in frappe.local.preload_assets["icons"]
 	)
 
+	# Safe limit for Link header length (~4 KB is the default max in Nginx)
+	MAX_LINK_HEADER_BYTES = 3800
 	if links:
-		response.headers["Link"] = ",".join(links)
+		final_links = []
+		current_size = 0
+
+		for link in links:
+			link_size = len(link.encode("utf-8"))
+			needed_size = link_size + (1 if final_links else 0)
+
+			if current_size + needed_size > MAX_LINK_HEADER_BYTES:
+				break
+
+			final_links.append(link)
+			current_size += needed_size
+
+		if final_links:
+			response.headers["Link"] = ",".join(final_links)
 
 
 @lru_cache

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -603,8 +603,8 @@ def add_preload_for_bundled_assets(response):
 		for svg in frappe.local.preload_assets["icons"]
 	)
 
-	# Safe limit for Link header length (~8 KB is the default max in Nginx)
-	MAX_LINK_HEADER_BYTES = 7800
+	# Safe limit for Link header length (~7 KB is the default max in Nginx)
+	MAX_LINK_HEADER_BYTES = 7000
 	if links:
 		final_links = []
 		current_size = 0

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -603,8 +603,7 @@ def add_preload_for_bundled_assets(response):
 		for svg in frappe.local.preload_assets["icons"]
 	)
 
-	# Safe limit for Link header length (~7 KB is the default max in Nginx)
-	MAX_LINK_HEADER_BYTES = 7000
+	MAX_LINK_HEADER_BYTES = 1000
 	if links:
 		trimmed = _fit_links_within_limit(links, MAX_LINK_HEADER_BYTES)
 		if trimmed:

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -603,8 +603,8 @@ def add_preload_for_bundled_assets(response):
 		for svg in frappe.local.preload_assets["icons"]
 	)
 
-	# Safe limit for Link header length (~4 KB is the default max in Nginx)
-	MAX_LINK_HEADER_BYTES = 3800
+	# Safe limit for Link header length (~8 KB is the default max in Nginx)
+	MAX_LINK_HEADER_BYTES = 7800
 	if links:
 		final_links = []
 		current_size = 0

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -606,21 +606,25 @@ def add_preload_for_bundled_assets(response):
 	# Safe limit for Link header length (~7 KB is the default max in Nginx)
 	MAX_LINK_HEADER_BYTES = 7000
 	if links:
-		final_links = []
-		current_size = 0
+		trimmed = _fit_links_within_limit(links, MAX_LINK_HEADER_BYTES)
+		if trimmed:
+			response.headers["Link"] = ",".join(trimmed)
 
-		for link in links:
-			link_size = len(link.encode("utf-8"))
-			needed_size = link_size + (1 if final_links else 0)
 
-			if current_size + needed_size > MAX_LINK_HEADER_BYTES:
-				break
+def _fit_links_within_limit(links: list[str], byte_limit: int) -> list[str]:
+	result = []
+	total = 0
 
-			final_links.append(link)
-			current_size += needed_size
+	for link in links:
+		link_size = len(link.encode("utf-8"))
+		needed_size = link_size + (1 if result else 0)
 
-		if final_links:
-			response.headers["Link"] = ",".join(final_links)
+		if total + needed_size > byte_limit:
+			break
+
+		result.append(link)
+		total += needed_size
+	return result
 
 
 @lru_cache


### PR DESCRIPTION
Limits link header to stay with in 7 Kb

ref: [https://github.com/frappe/frappe/pull/33713](https://github.com/frappe/frappe/pull/33713)

Support Ticket: [https://support.frappe.io/helpdesk/tickets/66940](https://support.frappe.io/helpdesk/tickets/66940)