### PR TITLE
fix: hide disabled reports in sidebar and workspace links

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -596,7 +596,12 @@ def get_sidebar_items(allowed_workspaces):
 					"tab": item.navigate_to_tab,
 					"open_in_new_tab": item.open_in_new_tab,
 				}
-				if item.link_type == "Report" and item.link_to and frappe.db.exists("Report", item.link_to):
+				if (
+					item.link_type == "Report"
+					and item.link_to
+					and frappe.db.exists("Report", item.link_to)
+					and not frappe.db.get_value("Report", item.link_to, "disabled")
+				):
 					report_type, ref_doctype = frappe.db.get_value(
 						"Report", item.link_to, ["report_type", "ref_doctype"]
 					)

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -132,9 +132,6 @@ class Workspace:
 		return doc
 
 	def is_item_allowed(self, name, item_type):
-		if frappe.session.user == "Administrator":
-			return True
-
 		item_type = item_type.lower()
 
 		if item_type == "doctype":
@@ -142,7 +139,7 @@ class Workspace:
 		if item_type == "page":
 			return name in self.allowed_pages and name in self.restricted_pages
 		if item_type == "report":
-			return name in self.allowed_reports
+			return not frappe.db.get_value("Report", name, "disabled") and name in self.allowed_reports
 		if item_type == "help":
 			return True
 		if item_type == "dashboard":


### PR DESCRIPTION
If a report is disabled then it should not show up in the sidebar or the workspace links. This PR fixes that
