### PR TITLE
fix(user): clear roles when role profile is cleared

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -206,6 +206,8 @@ class User(Document):
 			role_profile = frappe.get_doc("Role Profile", self.role_profile_name)
 			self.set("roles", [])
 			self.append_roles(*[role.role for role in role_profile.roles])
+		elif self.has_value_changed("role_profile_name"):
+			self.set("roles", [])
 
 	@deprecated
 	def validate_roles(self):


### PR DESCRIPTION
Previously, on clearing role profiles, roles used to persist. This fixes that by considering the fact that when role profile is cleared, roles also should be cleared.

**Before**:


https://github.com/user-attachments/assets/bd48ae80-8b7b-4c64-88a3-9a5ecf4333fb



**After**:

https://github.com/user-attachments/assets/ac1bad70-6e01-4f0f-acd5-865356626224

**edit:** expected behavior, so closing this.