### PR TITLE
fix: prevent report message from being overwritten by stale report message

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -827,7 +827,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					this.render_summary(data.report_summary);
 				}
 
-				if (data.message && !data.prepared_report) this.show_status(data.message);
+				if (data.message && !data.prepared_report) this.show_report_message(data.message);
 
 				this.toggle_message(false);
 				if (data.result && data.result.length) {
@@ -2242,7 +2242,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.$status = $(`<div class="form-message text-muted small"></div>`)
 			.hide()
 			.insertAfter(page_form);
-
+		this.$report_message = $(`<div class="form-message text-muted small"></div>`)
+			.hide()
+			.insertAfter(this.$status);
 		this.$summary = $(`<div class="report-summary"></div>`).hide().appendTo(this.page.main);
 
 		this.$chart = $('<div class="chart-wrapper">').hide().appendTo(this.page.main);
@@ -2255,7 +2257,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	show_status(status_message) {
 		this.$status.html(status_message).show();
 	}
-
+	show_report_message(message) {
+		this.$report_message.html(message).show();
+	}
 	hide_status() {
 		this.$status.hide();
 	}


### PR DESCRIPTION
Both stale report messages and report message are shown in the same element, so the former overwrites the latter which is unwanted for most of the reports and harmless for the rest.
Added another jQuery element for the report message with the same styling as the status div inserted after the status.

### Before
https://github.com/user-attachments/assets/a82436cd-1681-43d3-a4bf-bda496fc31c0

### After
<img width="2828" height="1746" alt="Screenshot From 2026-05-06 17-05-43" src="https://github.com/user-attachments/assets/fcc86d27-99fe-4646-9be7-3f9614270024" />
