### PR TITLE
fix: fix clearing of last link in role profile

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -282,6 +282,10 @@ class User(Document):
 		"""This handles old role_profile_name field if programatically set.
 
 		This behaviour will be removed in future versions."""
+		if not self.role_profiles:
+			self.role_profile_name = None
+			return
+
 		if not self.role_profile_name:
 			return
 


### PR DESCRIPTION
Clearing the last link and saving was not working, the link persisted.

**Before**:


https://github.com/user-attachments/assets/a783732a-f6a0-4c01-9568-a2d11ffd6967


**After**:


https://github.com/user-attachments/assets/e84813d6-9426-43fe-b79f-28ed3986b64d



closes Ticket #67431