### PR TITLE
fix: defer DocType module hooks until controller export completes

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -550,6 +550,15 @@ class DocType(Document):
 			and not frappe.flags.in_import
 			and (frappe.conf.developer_mode or frappe.flags.allow_doctype_export)
 		)
+		request = getattr(frappe.local, "request", None)
+		defer_doctype_export = request and hasattr(request, "after_response")
+		defer_module_methods = allow_doctype_export and defer_doctype_export
+
+		def run_doctype_module_methods():
+			self.run_module_method("on_doctype_update")
+			if self.flags.in_insert:
+				self.run_module_method("after_doctype_insert")
+
 		if allow_doctype_export:
 
 			def export_doctype_files():
@@ -557,19 +566,18 @@ class DocType(Document):
 				self.make_controller_template()
 				self.set_base_class_for_controller()
 				self.export_types_to_controller()
+				if defer_module_methods:
+					run_doctype_module_methods()
 
-			request = getattr(frappe.local, "request", None)
 			# Defer file writes until after the response so the client can sync the saved doc first.
-			if request and hasattr(request, "after_response"):
+			if defer_doctype_export:
 				request.after_response.add(export_doctype_files)
 			else:
 				export_doctype_files()
 
 		# update index
-		if not self.custom:
-			self.run_module_method("on_doctype_update")
-			if self.flags.in_insert:
-				self.run_module_method("after_doctype_insert")
+		if not self.custom and not defer_module_methods:
+			run_doctype_module_methods()
 
 		self.sync_doctype_layouts()
 		delete_notification_count_for(doctype=self.name)

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -554,9 +554,12 @@ class DocType(Document):
 		defer_doctype_export = request and hasattr(request, "after_response")
 		defer_module_methods = allow_doctype_export and defer_doctype_export
 
+		# Snapshot insert intent: flags.in_insert is cleared before request.after_response runs.
+		needs_after_doctype_insert = bool(self.flags.in_insert)
+
 		def run_doctype_module_methods():
 			self.run_module_method("on_doctype_update")
-			if self.flags.in_insert:
+			if needs_after_doctype_insert:
 				self.run_module_method("after_doctype_insert")
 
 		if allow_doctype_export:

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -671,6 +671,39 @@ class TestDocType(IntegrationTestCase):
 		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
 	)
 	@patch.dict(frappe.conf, {"developer_mode": 1})
+	def test_standard_doctype_insert_with_deferred_export(self):
+		import shutil
+
+		from frappe.utils import CallbackManager
+
+		previous_request = getattr(frappe.local, "request", None)
+		frappe.local.request = frappe._dict(after_response=CallbackManager())
+		doctype = None
+		controller_folder = None
+
+		try:
+			doctype = new_doctype(custom=0).insert()
+			frappe.local.request.after_response.run()
+
+			controller_folder = frappe.get_module_path(doctype.module, "doctype", frappe.scrub(doctype.name))
+			controller_path = frappe.get_module_path(
+				doctype.module, "doctype", frappe.scrub(doctype.name), f"{frappe.scrub(doctype.name)}.py"
+			)
+			self.assertTrue(os.path.exists(controller_path))
+		finally:
+			try:
+				if doctype and frappe.db.exists("DocType", doctype.name):
+					doctype.delete()
+					frappe.db.commit()
+			finally:
+				if controller_folder:
+					shutil.rmtree(controller_folder, ignore_errors=True)
+				frappe.local.request = previous_request
+
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
+	@patch.dict(frappe.conf, {"developer_mode": 1})
 	def test_export_types(self):
 		"""Export python types."""
 		import ast

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -680,10 +680,22 @@ class TestDocType(IntegrationTestCase):
 		frappe.local.request = frappe._dict(after_response=CallbackManager())
 		doctype = None
 		controller_folder = None
+		method_calls = []
+
+		original_run_module_method = DocType.run_module_method
+
+		def spy(self, method):
+			method_calls.append(method)
+			return original_run_module_method(self, method)
 
 		try:
-			doctype = new_doctype(custom=0).insert()
-			frappe.local.request.after_response.run()
+			with patch.object(DocType, "run_module_method", spy):
+				doctype = new_doctype(custom=0).insert()
+				# Module hooks must be deferred until after the controller file exists.
+				self.assertEqual(method_calls, [])
+
+				frappe.local.request.after_response.run()
+				self.assertEqual(method_calls, ["on_doctype_update", "after_doctype_insert"])
 
 			controller_folder = frappe.get_module_path(doctype.module, "doctype", frappe.scrub(doctype.name))
 			controller_path = frappe.get_module_path(


### PR DESCRIPTION
- Fix creating a new standard **DocType** from a web request when controller file export is deferred until `after_response`.
- Run `on_doctype_update` and `after_doctype_insert` after deferred controller generation so the module exists before import.
- Add regression coverage for standard **DocType** insert with deferred export.

Resolves https://github.com/frappe/frappe/pull/38393#issuecomment-4387494081

Note: there can still be race conditions between werkzeug reloading and frontend requests during doctype creation and deletion, but the clear import-before-exists error should be resolved. Use the `--noreload` flag on `bench serve` to avoid this.