### PR TITLE
fix: increase page-head-height from 45px to 48px

### DIFF
--- a/frappe/public/scss/desk/css_variables.scss
+++ b/frappe/public/scss/desk/css_variables.scss
@@ -20,7 +20,7 @@
 	--error-border: var(--red-400);
 
 	// page
-	--page-head-height: 45px;
+	--page-head-height: 48px;
 	--page-bottom-margin: 60px;
 
 	// checkbox


### PR DESCRIPTION
Fixes: #39118 

---
**Before:**
<img width="1002" height="55" alt="image" src="https://github.com/user-attachments/assets/2176bae0-288d-4cde-9ee1-2c509890283d" />

**After:**
<img width="1002" height="55" alt="image" src="https://github.com/user-attachments/assets/afc0dcfd-8f5b-4582-b49b-4d217ad04564" />
