### PR TITLE
feat: added setup key support in 2fa login

### DIFF
--- a/frappe/tests/test_twofactor.py
+++ b/frappe/tests/test_twofactor.py
@@ -134,6 +134,27 @@ class TestTwoFactor(IntegrationTestCase):
 		token = int(pyotp.TOTP(otp_secret).now())
 		self.assertTrue(get_verification_obj(self.user, token, otp_secret))
 
+	def test_get_user_svg_from_cache_returns_otp_secret_in_tuple(self):
+		"""get_user_svg_from_cache should return a 3-tuple including otp_secret (line 41 in qrcode.py)."""
+		from frappe.www.qrcode import get_user_svg_from_cache
+
+		key = frappe.generate_hash(length=20)
+		otp_secret = get_otpsecret_for_(self.user)
+		totp_uri = pyotp.TOTP(otp_secret).provisioning_uri(self.user, issuer_name="Frappe")
+
+		frappe.cache.set_value(f"{key}_uri", totp_uri)
+		frappe.cache.set_value(f"{key}_user", self.user)
+		frappe.cache.set_value(f"{key}_secret", otp_secret)
+
+		set_request(method="GET", path="/qrcode", query_string=f"k={key}")
+		result = get_user_svg_from_cache()
+
+		self.assertEqual(len(result), 3)
+		user_doc, svg, returned_secret = result
+		self.assertEqual(user_doc.name, self.user)
+		self.assertIsInstance(svg, str)
+		self.assertEqual(returned_secret, otp_secret)
+
 	def test_render_string_template(self):
 		"""String template renders as expected with variables."""
 		args = {"issuer_name": "Frappe Technologies"}

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -290,7 +290,6 @@ def get_email_body_for_qr_code(kwargs_dict):
 	return frappe.render_template(body_template, kwargs_dict, restrict_globals=True)
 
 
-#  check this
 def get_link_for_qrcode(user, totp_uri, otp_secret=None):
 	"""Get link to temporary page showing QRCode."""
 	key = frappe.generate_hash(length=20)
@@ -375,7 +374,6 @@ def send_token_via_email(user, token, otp_secret, otp_issuer, subject=None, mess
 	return True
 
 
-# check this
 def get_qr_svg_code(totp_uri):
 	"""Get SVG code to display Qrcode for OTP."""
 	from pyqrcode import create as qrcreate

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -228,7 +228,6 @@ def process_2fa_for_otp_app(user, otp_secret, otp_issuer):
 	return {"method": "OTP App", "setup": otp_setup_completed}
 
 
-# check this
 def process_2fa_for_email(user, token, otp_secret, otp_issuer, method="Email"):
 	"""Process Email method for 2fa."""
 	subject = None

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -228,6 +228,7 @@ def process_2fa_for_otp_app(user, otp_secret, otp_issuer):
 	return {"method": "OTP App", "setup": otp_setup_completed}
 
 
+# check this
 def process_2fa_for_email(user, token, otp_secret, otp_issuer, method="Email"):
 	"""Process Email method for 2fa."""
 	subject = None
@@ -237,7 +238,7 @@ def process_2fa_for_email(user, token, otp_secret, otp_issuer, method="Email"):
 	if method == "OTP App" and not get_default(user + "_otplogin"):
 		"""Sending one-time email for OTP App"""
 		totp_uri = pyotp.TOTP(otp_secret).provisioning_uri(user, issuer_name=otp_issuer)
-		qrcode_link = get_link_for_qrcode(user, totp_uri)
+		qrcode_link = get_link_for_qrcode(user, totp_uri, otp_secret)
 		message = get_email_body_for_qr_code({"qrcode_link": qrcode_link})
 		subject = get_email_subject_for_qr_code({"qrcode_link": qrcode_link})
 		prompt = _(
@@ -289,14 +290,18 @@ def get_email_body_for_qr_code(kwargs_dict):
 	return frappe.render_template(body_template, kwargs_dict, restrict_globals=True)
 
 
-def get_link_for_qrcode(user, totp_uri):
+#  check this
+def get_link_for_qrcode(user, totp_uri, otp_secret=None):
 	"""Get link to temporary page showing QRCode."""
 	key = frappe.generate_hash(length=20)
 	key_user = f"{key}_user"
 	key_uri = f"{key}_uri"
+	key_secret = f"{key}_secret"
 	lifespan = int(frappe.get_system_settings("lifespan_qrcode_image")) or 240
 	frappe.cache.set_value(key_uri, totp_uri, expires_in_sec=lifespan)
 	frappe.cache.set_value(key_user, user, expires_in_sec=lifespan)
+	if otp_secret:
+		frappe.cache.set_value(key_secret, otp_secret, expires_in_sec=lifespan)
 	return get_url(f"/qrcode?k={key}")
 
 
@@ -370,6 +375,7 @@ def send_token_via_email(user, token, otp_secret, otp_issuer, subject=None, mess
 	return True
 
 
+# check this
 def get_qr_svg_code(totp_uri):
 	"""Get SVG code to display Qrcode for OTP."""
 	from pyqrcode import create as qrcreate

--- a/frappe/www/qrcode.html
+++ b/frappe/www/qrcode.html
@@ -39,18 +39,6 @@
 		padding: 6px 12px;
 		flex-shrink: 0;
 	}
-
-	.check-icon {
-		display: none;
-	}
-
-	.check-icon.visible {
-		display: inline;
-	}
-
-	.copy-icon.hidden {
-		display: none;
-	}
 </style>
 
 <h1>{{ _("QR Code for Login Verification") }}</h1>
@@ -93,11 +81,11 @@
 					class='btn btn-default btn-sm copy-secret-btn'
 					title='{{ _("Copy to clipboard") }}'
 				>
-					<svg id='copy-icon' class='copy-icon' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>
+					<svg id='copy-icon' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>
 						<rect x='9' y='9' width='13' height='13' rx='2' ry='2'></rect>
 						<path d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'></path>
 					</svg>
-					<svg id='check-icon' class='check-icon' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='#10b981' stroke-width='2.5'>
+					<svg id='check-icon' style='display:none' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='#10b981' stroke-width='2.5'>
 						<polyline points='20 6 9 17 4 12'></polyline>
 					</svg>
 				</button>
@@ -119,28 +107,33 @@ function copySecret() {
     input.select();
     input.setSelectionRange(0, 99999);
 
+    function showCopied() {
+        copyIcon.style.display = 'none';
+        checkIcon.style.display = 'inline';
+        setTimeout(function() {
+            copyIcon.style.display = 'inline';
+            checkIcon.style.display = 'none';
+        }, 2000);
+    }
+
+    function cleanup() {
+        input.blur();
+        window.getSelection().removeAllRanges();
+    }
+
     try {
         navigator.clipboard.writeText(input.value).then(function() {
-            copyIcon.style.display = 'none';
-            checkIcon.style.display = 'inline';
-            setTimeout(function() {
-                copyIcon.style.display = 'inline';
-                checkIcon.style.display = 'none';
-            }, 2000);
+            showCopied();
+            cleanup();
         }).catch(function() {
             document.execCommand('copy');
-            copyIcon.style.display = 'none';
-            checkIcon.style.display = 'inline';
-            setTimeout(function() {
-                copyIcon.style.display = 'inline';
-                checkIcon.style.display = 'none';
-            }, 2000);
+            showCopied();
+            cleanup();
         });
     } catch (err) {
         console.error('Copy failed:', err);
+        cleanup();
     }
-    input.blur();
-    window.getSelection().removeAllRanges();
 }
 </script>
 {% endblock %}

--- a/frappe/www/qrcode.html
+++ b/frappe/www/qrcode.html
@@ -22,6 +22,74 @@
 	</div>
 	<div class='col-sm-6' style='padding-top: 15px;'>
 		<img src="data:image/svg+xml;base64,{{qrcode_svg}}">
+
+        {% if otp_secret %}
+        <div style='margin-top: 20px;'>
+            <p style='margin-bottom: 0px;'><strong>{{ _("Can't scan the code?") }}</strong></p>
+            <p style='font-size: 13px; color: #636e72; margin-bottom: 4px;'>{{ _("Enter this setup key manually:") }}</p>
+
+            <div style='display: flex; gap: 8px;'>
+                <input
+                    type='text'
+                    id='otp-secret-input'
+                    value='{{ otp_secret }}'
+                    readonly
+                    onclick='this.select()'
+                    class='form-control'
+                    style='flex: 1; max-width:40%; font-family: monospace; letter-spacing: 1px;padding: 10px 12px; font-size: 14px; width: 35%; height:100% '
+                />
+                <button
+                    id='copy-secret-btn'
+                    onclick='copySecret()'
+                    class='btn btn-default btn-sm'
+                    style='padding: 6px 12px; flex-shrink: 0;'
+                    title='{{ _("Copy to clipboard") }}'
+                >
+                    <svg id='copy-icon' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>
+                        <rect x='9' y='9' width='13' height='13' rx='2' ry='2'></rect>
+                        <path d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'></path>
+                    </svg>
+                    <svg id='check-icon' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='#10b981' stroke-width='2.5' style='display: none;'>
+                        <polyline points='20 6 9 17 4 12'></polyline>
+                    </svg>
+                </button>
+            </div>
+        </div>
+        {% endif %}
 	</div>
 </div>
+
+<script>
+function copySecret() {
+    const input = document.getElementById('otp-secret-input');
+    const copyIcon = document.getElementById('copy-icon');
+    const checkIcon = document.getElementById('check-icon');
+
+    input.select();
+    input.setSelectionRange(0, 99999);
+
+    try {
+        navigator.clipboard.writeText(input.value).then(function() {
+            copyIcon.style.display = 'none';
+            checkIcon.style.display = 'inline';
+            setTimeout(function() {
+                copyIcon.style.display = 'inline';
+                checkIcon.style.display = 'none';
+            }, 2000);
+        }).catch(function() {
+            document.execCommand('copy');
+            copyIcon.style.display = 'none';
+            checkIcon.style.display = 'inline';
+            setTimeout(function() {
+                copyIcon.style.display = 'inline';
+                checkIcon.style.display = 'none';
+            }, 2000);
+        });
+    } catch (err) {
+        console.error('Copy failed:', err);
+    }
+    input.blur();
+    window.getSelection().removeAllRanges();
+}
+</script>
 {% endblock %}

--- a/frappe/www/qrcode.html
+++ b/frappe/www/qrcode.html
@@ -3,6 +3,56 @@
 {% block title %}{{ _("QR Code") }}{% endblock %}
 
 {% block page_content %}
+<style>
+	.otp-manual-section {
+		margin-top: 20px;
+	}
+
+	.otp-manual-section .manual-entry-title {
+		margin-bottom: 0px;
+	}
+
+	.otp-manual-section .manual-entry-hint {
+		font-size: 13px;
+		color: #636e72;
+		margin-bottom: 4px;
+	}
+
+	.otp-input-group {
+		display: flex;
+		gap: 8px;
+		margin-bottom: 20px;
+	}
+
+	.otp-secret-input {
+		flex: 1;
+		max-width: 40%;
+		font-family: monospace;
+		letter-spacing: 1px;
+		padding: 10px 12px;
+		font-size: 14px;
+		width: 35%;
+		height: 100%;
+	}
+
+	.copy-secret-btn {
+		padding: 6px 12px;
+		flex-shrink: 0;
+	}
+
+	.check-icon {
+		display: none;
+	}
+
+	.check-icon.visible {
+		display: inline;
+	}
+
+	.copy-icon.hidden {
+		display: none;
+	}
+</style>
+
 <h1>{{ _("QR Code for Login Verification") }}</h1>
 <div class='row'>
 	<div class='col-sm-6'>
@@ -23,42 +73,43 @@
 	<div class='col-sm-6' style='padding-top: 15px;'>
 		<img src="data:image/svg+xml;base64,{{qrcode_svg}}">
 
-        {% if otp_secret %}
-        <div style='margin-top: 20px;'>
-            <p style='margin-bottom: 0px;'><strong>{{ _("Can't scan the code?") }}</strong></p>
-            <p style='font-size: 13px; color: #636e72; margin-bottom: 4px;'>{{ _("Enter this setup key manually:") }}</p>
+		{% if otp_secret %}
+		<div class='otp-manual-section'>
+			<p class='manual-entry-title'><strong>{{ _("Can't scan the code?") }}</strong></p>
+			<p class='manual-entry-hint'>{{ _("Enter this setup key manually:") }}</p>
 
-            <div style='display: flex; gap: 8px;'>
-                <input
-                    type='text'
-                    id='otp-secret-input'
-                    value='{{ otp_secret }}'
-                    readonly
-                    onclick='this.select()'
-                    class='form-control'
-                    style='flex: 1; max-width:40%; font-family: monospace; letter-spacing: 1px;padding: 10px 12px; font-size: 14px; width: 35%; height:100% '
-                />
-                <button
-                    id='copy-secret-btn'
-                    onclick='copySecret()'
-                    class='btn btn-default btn-sm'
-                    style='padding: 6px 12px; flex-shrink: 0;'
-                    title='{{ _("Copy to clipboard") }}'
-                >
-                    <svg id='copy-icon' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>
-                        <rect x='9' y='9' width='13' height='13' rx='2' ry='2'></rect>
-                        <path d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'></path>
-                    </svg>
-                    <svg id='check-icon' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='#10b981' stroke-width='2.5' style='display: none;'>
-                        <polyline points='20 6 9 17 4 12'></polyline>
-                    </svg>
-                </button>
-            </div>
-        </div>
-        {% endif %}
+			<div class='otp-input-group'>
+				<input
+					type='text'
+					id='otp-secret-input'
+					value='{{ otp_secret }}'
+					readonly
+					onclick='this.select()'
+					class='form-control otp-secret-input'
+				/>
+				<button
+					id='copy-secret-btn'
+					onclick='copySecret()'
+					class='btn btn-default btn-sm copy-secret-btn'
+					title='{{ _("Copy to clipboard") }}'
+				>
+					<svg id='copy-icon' class='copy-icon' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>
+						<rect x='9' y='9' width='13' height='13' rx='2' ry='2'></rect>
+						<path d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'></path>
+					</svg>
+					<svg id='check-icon' class='check-icon' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='#10b981' stroke-width='2.5'>
+						<polyline points='20 6 9 17 4 12'></polyline>
+					</svg>
+				</button>
+			</div>
+		</div>
+		{% endif %}
 	</div>
 </div>
 
+{% endblock %}
+
+{% block script %}
 <script>
 function copySecret() {
     const input = document.getElementById('otp-secret-input');

--- a/frappe/www/qrcode.py
+++ b/frappe/www/qrcode.py
@@ -10,7 +10,7 @@ from frappe.twofactor import get_qr_svg_code
 
 def get_context(context):
 	context.no_cache = 1
-	context.qr_code_user, context.qrcode_svg = get_user_svg_from_cache()
+	context.qr_code_user, context.qrcode_svg, context.otp_secret = get_user_svg_from_cache()
 
 
 def get_query_key():
@@ -31,10 +31,11 @@ def get_user_svg_from_cache():
 	key = get_query_key()
 	totp_uri = frappe.cache.get_value(f"{key}_uri")
 	user = frappe.cache.get_value(f"{key}_user")
+	otp_secret = frappe.cache.get_value(f"{key}_secret")
 	if not totp_uri or not user:
 		frappe.throw(_("Page has expired!"), frappe.PermissionError)
 	if not frappe.db.exists("User", user):
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
 	user = frappe.get_doc("User", user)
 	svg = get_qr_svg_code(totp_uri)
-	return (user, svg.decode())
+	return (user, svg.decode(), otp_secret)


### PR DESCRIPTION
for @harshp4114 


pls consider adding him as a collaborator

---
Closes #39057 

### Before 
When users set up two-factor authentication using the **OTP App** method, they previously had to scan a QR code to register their authenticator app. This was the only option available.

<img width="2936" height="1594" alt="image" src="https://github.com/user-attachments/assets/8cdaeb5a-6386-4a2a-ab9f-f3fd5c19dc86" />


### After

Users can now **either scan the QR code or manually enter the setup key** into their authenticator app, giving them full flexibility during 2FA registration.

<img width="1349" height="636" alt="image" src="https://github.com/user-attachments/assets/74642f50-83f0-4dbf-af6e-33e85d8db24c" />

- `no-docs`