### PR TITLE
fix(ui): desktop search

### DIFF
--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -56,9 +56,8 @@
 #brand-logo{
     width: auto;
 }
-.desktop-search-icon > .icon {
-    stroke-width: 1px;
-    margin-bottom: 2px;
+.desktop-search-icon > svg {
+    stroke: var(--text-light);
 }
 
 .desktop-container{


### PR DESCRIPTION
Before

<img width="950" height="219" alt="Screenshot 2026-05-07 at 7 18 58 PM" src="https://github.com/user-attachments/assets/441dd817-f6be-4360-b913-4aa2a3a64d08" />

After

<img width="756" height="181" alt="Screenshot 2026-05-07 at 7 26 57 PM" src="https://github.com/user-attachments/assets/c1b7fd91-ed54-480f-a946-1ed778387829" />


Closes https://github.com/frappe/frappe/issues/39078
