### PR TITLE
fix: icon for form field description and documentation

### DIFF
--- a/frappe/public/js/form_builder/components/Field.vue
+++ b/frappe/public/js/form_builder/components/Field.vue
@@ -214,12 +214,12 @@ onMounted(() => selected.value && label_input.value.focus_on_label());
 						:empty_label="`${__('No Label')} (${field.df.fieldtype})`"
 						v-model="field.df.label"
 					/>
-					<div class="reqd-asterisk" v-if="field.df.reqd">*</div>
 					<div
 						class="help-icon"
 						v-if="field.df.documentation_url"
-						v-html="frappe.utils.icon('help', 'sm')"
+						v-html="frappe.utils.icon('info', 'xs')"
 					/>
+					<div class="reqd-asterisk" v-if="field.df.reqd">*</div>
 				</div>
 			</template>
 			<template #actions>
@@ -306,6 +306,13 @@ onMounted(() => selected.value && label_input.value.focus_on_label());
 				margin-left: 3px;
 				color: var(--text-muted);
 				cursor: pointer;
+				display: flex;
+				align-items: center;
+				height: 1em;
+				:deep(svg) {
+					width: 10px;
+					height: 10px;
+				}
 			}
 		}
 

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -203,8 +203,8 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 	}
 	show_description_on_click() {
 		const me = this;
-		if (this.df.show_description_on_click) {
-			let info_card = new InfoCard({
+		if (this.df.show_description_on_click && !this._doc_url_info_card) {
+			new InfoCard({
 				label_area: this.label_area,
 				label_span: this.label_span,
 				df: this.df,
@@ -223,16 +223,13 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		)
 			return;
 
-		let $help = this.$wrapper.find("span.help");
-		$help.empty();
-
-		$(`<a
-			href="${frappe.utils.escape_html(this.df.documentation_url)}"
-			target="_blank"
-			title="${frappe.utils.escape_html(__("Documentation"))}"
-		>
-			${frappe.utils.icon("help", "sm")}
-		</a>`).appendTo($help);
+		if (!this._doc_url_info_card) {
+			this._doc_url_info_card = new InfoCard({
+				label_area: this.label_area,
+				label_span: this.label_span,
+				df: this.df,
+			});
+		}
 	}
 
 	set_description(description) {

--- a/frappe/public/js/frappe/form/info_card.js
+++ b/frappe/public/js/frappe/form/info_card.js
@@ -29,7 +29,6 @@ export class InfoCard {
 	make_card() {
 		const me = this;
 		this.$info_card = $("<div class='info-card'></div>").appendTo(this.label_span);
-		this.$sidebar_card = this.$info_card.find(".sidebar-card");
 		let card_args = {
 			title: "",
 			message: this.df.show_description_on_click ? this.df.description || "" : "",

--- a/frappe/public/js/frappe/form/info_card.js
+++ b/frappe/public/js/frappe/form/info_card.js
@@ -11,11 +11,11 @@ export class InfoCard {
 	make_toggle_button() {
 		$(
 			`${frappe.utils.icon(
-				"message-circle-question-mark",
-				"sm",
+				"info",
+				"xs",
 				"",
 				"",
-				"cursor-pointer m-0 info-trigger"
+				"cursor-pointer m-0 info-trigger card-icons"
 			)}`
 		).appendTo($(this.label_span));
 		$(this.label_span).find("svg").attr("role", "button");
@@ -29,25 +29,24 @@ export class InfoCard {
 	make_card() {
 		const me = this;
 		this.$info_card = $("<div class='info-card'></div>").appendTo(this.label_span);
+		this.$sidebar_card = this.$info_card.find(".sidebar-card");
 		let card_args = {
-			message: this.df.description,
+			title: "",
+			message: this.df.show_description_on_click ? this.df.description || "" : "",
 			parent: this.$info_card,
 			trigger: $(this.label_span).find("svg").get(0),
 			close_button: true,
 			popper: true,
-			primary_button_width: "full",
+			hide_icon: true,
+			custom_class: "py-1 px-1",
 		};
 		if (this.df.documentation_url) {
-			card_args.primary_action_label = "Read More";
-			card_args.primary_action_suffix_icon = "square-arrow-out-up-right";
-			card_args.primary_action = function () {
-				window.open(me.df.documentation_url);
-			};
-			card_args.styles = {
-				"sidebar-card-button-bg-color": "var(--surface-gray-2)",
-				"sidebar-card-button-color": "var(--ink-gray-7)",
-				"sidebar-card-button-outline": "var(--ink-gray-7)",
-			};
+			if (this.df.description && this.df.show_description_on_click) {
+				card_args.message += "<br>";
+			}
+			card_args.message += `<a style="display: inline-block; text-underline-offset: 2px;" class="py-1" href="${
+				this.df.documentation_url
+			}" target="_blank">${__("View Documentation")}</a>`;
 		}
 		this.card = new frappe.ui.SidebarCard(card_args);
 	}

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -160,8 +160,8 @@ frappe.ui.form.Sidebar = class {
 			.html(
 				get_user_message(
 					this.frm.doc.modified_by,
-					__("Last Edited by You", null),
-					__("Last Edited by {0}", [get_user_link(this.frm.doc.modified_by)])
+					__("Last Edited By You", null),
+					__("Last Edited By {0}", [get_user_link(this.frm.doc.modified_by)])
 				) +
 					" <br> " +
 					comment_when(this.frm.doc.modified)

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.html
@@ -9,7 +9,9 @@
     </div>
     {% } else { %}
         <div class="card-title-container card-close-button">
-            {%= frappe.utils.icon(card.icon, "sm", "", "", "card-icon") %}
+            {% if !card.hide_icon %}
+                {%= frappe.utils.icon(card.icon, "sm", "", "", "card-icon") %}
+            {% endif %}
             <span class="flex flex-column w-100">
                 <div class="sidebar-card-title">{{ card.title }}</div>
                 <div class="sidebar-card-description">{{ card.message }}</div>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_card.js
@@ -1,6 +1,24 @@
 import { createPopper } from "@popperjs/core";
 frappe.provide("frappe.ui");
-// icon, title, message, condition, primary_action_label, primary_action
+/**
+ * Sidebar Card is used to render a card with a close button. It is used to show cards in the sidebar, tooltip on form descriptions and billing banners etc.
+ *
+ * @param {string} title - Title of the card
+ * @param {string} message - Message to be shown in the card
+ * @param {HTMLElement} parent - Parent element to which the card will be appended
+ * @param {HTMLElement} trigger - Element on which the card will be triggered
+ * @param {string} [icon="info"] - Icon to be shown in the card
+ * @param {boolean} [hide_icon] - If true, does not show the icon in the card
+ * @param {boolean} [close_button] - Whether to show the close button or not
+ * @param {boolean} [popper] - Whether to use popper for positioning the card
+ * @param {boolean} [outline] - Whether to show the card with outline or not
+ * @param {string} [primary_action_label] - Label for the primary action button
+ * @param {Function} [primary_action] - Function to be called when the primary action button is clicked
+ * @param {string} [primary_button_alignment] - Alignment for the primary action button (left or right)
+ * @param {string} [dismiss_it_for] - If set, it will dismiss the card for the specified duration (minute, hour, day, week) when the close button is clicked
+ * @param {string} [dismiss_key="card_next_show_time"] - Key to be used in localStorage for storing the dismiss time
+ * @param {Object} [styles] - Custom styles to be applied to the card, passed as an object with CSS variable names as keys and their values as values
+ */
 frappe.ui.SidebarCard = class SidebarCard {
 	constructor(opts) {
 		Object.assign(this, opts);

--- a/frappe/public/scss/desk/sidebar_card.scss
+++ b/frappe/public/scss/desk/sidebar_card.scss
@@ -28,6 +28,7 @@
 	background-color: var(--surface-modal);
 	box-shadow: var(--shadow-sm);
 	border-radius: 12px;
+	padding: 16px;
 }
 .sidebar-card-description {
 	@include get_textstyle("sm", "regular");


### PR DESCRIPTION
Before:

<img width="1920" height="526" alt="image" src="https://github.com/user-attachments/assets/949d83f7-c39b-4817-af64-9003f5137370" />


This had three different tooltip icons and it looked visually inconsistent, and the info card also contained an extra unnecessary icon. The link was also shown inside a button instead of being displayed as a normal text link.



After:

<img width="1920" height="526" alt="image" src="https://github.com/user-attachments/assets/751e7d49-0999-416b-9769-0334190bcc26" />


This change standardizes all tooltip icons to use the same “i” icon and removes the redundant icon from the info card.

The documentation link is now displayed as a normal text link inside the info card instead of being rendered as a button. It is also shown in the info card even when “Show Description On Click” is disabled.


