### PR TITLE
fix(postgres): Explicitly grant all perms. on schema to user in setup

### DIFF
--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -25,6 +25,24 @@ def setup_database():
 			root_conn.sql(f'ALTER DATABASE "{frappe.conf.db_name}" OWNER TO "{frappe.conf.db_user}"')
 	root_conn.close()
 
+	# On Azure Managed PostgreSQL the public schema is owned by the azure_pg_admin role.
+	# Because the schema owner is hard-coded to be azure_pg_admin by Azure,
+	# changing the database owner no longer changes the schema owner (cascade).
+	db_conn = frappe.database.get_db(
+		socket=frappe.conf.db_socket,
+		host=frappe.conf.db_host,
+		port=frappe.conf.db_port,
+		user=frappe.flags.root_login,
+		password=frappe.flags.root_password,
+		cur_db_name=frappe.conf.db_name,  # Connect to the new database to grant permissions on the public schema
+	)
+	try:
+		db_conn.commit()
+		db_conn.sql("end")
+		db_conn.sql(f'GRANT ALL ON SCHEMA {db_conn.db_schema} TO "{frappe.conf.db_user}"')
+	finally:
+		db_conn.close()
+
 
 def bootstrap_database(verbose, source_sql=None):
 	frappe.connect()


### PR DESCRIPTION
Azure Managed PostgreSQL hardcodes public schema ownership to their internal azure_pg_admin role. This breaks standard PostgreSQL 15+ behavior, where the database owner would automatically inherit schema privileges (like a permission cascade). Because of this Azure-specific override, Frappe database setups fail on Azure because the newly created user lacks permission to create tables in the public schema, eventhough the user owns the database.

The commit below resolves the issue by opening a brief connection directly to the newly created database to execute GRANT ALL ON SCHEMA public TO "{db_user}". This is a cloud-agnostic command that ensures schema access on Azure without breaking the DB setup on AWS, Google Cloud, or custom/local environments (it does nothing there I guess).

Raising PR on behalf of @cogk 

closes #39145 

Edit: seems alright to backport so am backporting this to v15 and v16 albeit PG is mostly upto date on develop for fixes...