### PR TITLE
fix(grid): update dynamic docfield options after configure columns

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1323,7 +1323,9 @@ export default class Grid {
 		if (user_settings && user_settings[this.doctype] && user_settings[this.doctype].length) {
 			this.user_defined_columns = user_settings[this.doctype]
 				.map((row) => {
-					let column = frappe.meta.get_docfield(this.doctype, row.fieldname);
+					let column =
+						this.docfields?.find((d) => d.fieldname === row.fieldname) ||
+						frappe.meta.get_docfield(this.doctype, row.fieldname);
 
 					if (column) {
 						column.in_list_view = 1;


### PR DESCRIPTION
**Issue**: In a child table, Link field dropdowns display autocomplete options correctly at the default column width. However, after adjusting the column width via Configure Columns, clicking the Link field no longer shows any dropdown options.

**Before:**

[Screencast from 2026-05-08 12-44-21.webm](https://github.com/user-attachments/assets/f90d0f63-aa69-4c3a-87f2-22fce3b81f80)


**After:**

[Screencast from 2026-05-08 12-45-33.webm](https://github.com/user-attachments/assets/019654b3-e27d-4ec7-8f1a-cc2d82f5d9c0)


Backport needed for v15, v16