### PR TITLE
fix(filter): restrict the hidden fields in filter

### DIFF
--- a/frappe/public/js/frappe/ui/filters/field_select.js
+++ b/frappe/public/js/frappe/ui/filters/field_select.js
@@ -179,6 +179,7 @@ frappe.ui.FieldSelect = class FieldSelect {
 
 		if (
 			frappe.model.no_value_type.indexOf(df.fieldtype) == -1 &&
+			!df.hidden &&
 			!(me.fields_by_name[df.parent] && me.fields_by_name[df.parent][df.fieldname])
 		) {
 			this.options.push({


### PR DESCRIPTION
**Issue:** In the filter list, the fields are showing even if it is a hidden.

**Before:**

[Screencast from 2026-04-24 13-19-12.webm](https://github.com/user-attachments/assets/4fa1b1e6-05ab-43cb-8861-2ebde271faf0)


**After:**

[Screencast from 2026-04-24 13-18-29.webm](https://github.com/user-attachments/assets/310f94b3-fe07-442c-9956-dcee01236944)


Backport needed for  v15, v16