### PR TITLE
fix: Don't switch user on developer install

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -186,7 +186,7 @@ def run_setup_success(args):  # nosemgrep
 	for hook in frappe.get_hooks("setup_wizard_success"):
 		frappe.get_attr(hook)(args)
 	install_fixtures.install()
-	if not frappe.conf.developer_mode:
+	if not frappe.conf.developer_mode and not frappe._dev_server:
 		login_as_first_user(args)
 
 


### PR DESCRIPTION
Developers might forget to enable dev mode, we should still guess it
if request was handled by development server.
