### PR TITLE
fix: report wrapper padding and report datatable border radius

### DIFF
--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -88,9 +88,10 @@
 	overflow: auto;
 	padding-left: 15px;
 	padding-right: 15px;
+	padding-bottom: 15px;
 
 	.datatable {
-		border-radius: var(--border-radius);
+		border-radius: var(--border-radius) var(--border-radius) 0 0;
 	}
 }
 


### PR DESCRIPTION
1. Added padding to the report wrapper at the bottom the way it has on the left and right
2. Removed the bottom border radius from the report datatable because it cuts into the last row border

### Before
<img width="1002" height="355" alt="Screenshot From 2026-05-08 15-50-19" src="https://github.com/user-attachments/assets/e2781742-cc51-435b-b6a4-81e9bef72400" />
<img width="1588" height="1001" alt="Screenshot From 2026-05-08 13-49-47" src="https://github.com/user-attachments/assets/4e86179e-3c49-4939-a069-459e585814da" />

### After

<img width="1408" height="900" alt="Screenshot From 2026-05-08 16-02-18" src="https://github.com/user-attachments/assets/0ac00c43-ab9b-407d-bcf6-37ac97ed143a" />
