### PR TITLE
refactor: Add permission error message title

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1417,8 +1417,9 @@ class Engine:
 
 	def _raise_permission_error(self, doctype=None):
 		frappe.throw(
-			_("Insufficient Permission for {0}").format(frappe.bold(doctype or self.doctype)),
-			frappe.PermissionError,
+			title=_("Permission Error"),
+			msg=_("Insufficient Permission for {0}").format(frappe.bold(doctype or self.doctype)),
+			exc=frappe.PermissionError,
 		)
 
 	def apply_field_permissions(self):


### PR DESCRIPTION
## Reason for Only Changing This

- This error message will mostly appear to users due to permission issues.

### Before

<img width="746" height="198" alt="image" src="https://github.com/user-attachments/assets/ae0f7d35-692c-4dc7-a0cf-eebf2bf6f859" />

### After

<img width="751" height="207" alt="image" src="https://github.com/user-attachments/assets/7bc58a49-abff-41cf-889b-e8e6c3c1861f" />

---

> [!NOTE]
> Backport to V-16