### PR TITLE
fix(webhook): include on_update_after_submit in event list

### DIFF
--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -49,8 +49,7 @@ def run_webhooks(doc, method):
 	if not webhooks_for_doc:
 		# no webhooks, quit
 		return
-
-	event_list = ["on_update", "after_insert", "on_submit", "on_cancel", "on_trash"]
+	event_list = ["on_update", "after_insert", "on_submit", "on_cancel", "on_trash", "on_update_after_submit"]
 
 	if not doc.flags.in_insert:
 		# value change is not applicable in insert


### PR DESCRIPTION
On update after submit was included in supported events but was not included in the list

Ref ticket https://support.frappe.io/helpdesk/tickets/66822 