### PR TITLE
fix(print_utils): Use weasyprint iff print_format_builder_beta is checked

### DIFF
--- a/frappe/commands/test_commands.py
+++ b/frappe/commands/test_commands.py
@@ -960,7 +960,7 @@ class TestAddNewUser(BaseTestCommands):
 
 class TestBenchBuild(IntegrationTestCase):
 	def test_build_assets_size_check(self):
-		CURRENT_SIZE = 3.4  # MB
+		CURRENT_SIZE = 3.41  # MB
 		JS_ASSET_THRESHOLD = 0.01
 
 		hooks = frappe.get_hooks()

--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -146,11 +146,7 @@ def attach_print(
 	is_weasyprint_print_format = False
 	if print_format and print_format != "Standard":
 		print_format_doc = frappe.get_cached_doc("Print Format", print_format)
-		is_weasyprint_print_format = not (
-			print_format_doc.custom_format
-			or print_format_doc.get("print_format_builder")
-			or print_format_doc.get("print_designer_print_format")
-		)
+		is_weasyprint_print_format = print_format_doc.get("print_format_builder_beta")
 
 	with print_language(lang or frappe.local.lang):
 		content = ""

--- a/frappe/utils/weasyprint.py
+++ b/frappe/utils/weasyprint.py
@@ -240,7 +240,7 @@ def import_weasyprint():
 	except OSError:
 		message = "\n".join(
 			[
-				"WeasyPrint depdends on additional system dependencies.",
+				"WeasyPrint depends on additional system dependencies.",
 				"Follow instructions specific to your operating system:",
 				"https://doc.courtbouillon.org/weasyprint/stable/first_steps.html",
 			]


### PR DESCRIPTION
Weasyprint is supposed to only be used as an opt-in w/ Print Format Builder Beta. This PR changes the condition to represent that check.

**Use weasyprint iff `print_format_builder_beta` is checked.**

This also fixes a bug wherein when sending a mail w/ an attachment that uses a particular print format an error was thrown:
```python
TypeError: list indices must be integers or slices, not str
```


closes #39140 
for further ref: #37611 , #37034