### PR TITLE
feat: improved global search

### DIFF
--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -524,16 +524,6 @@ class DesktopPage {
 			awesome_bar.setup(".desktop-search-wrapper #desktop-navbar-modal-search");
 
 			frappe.ui.keys.add_shortcut({
-				shortcut: "ctrl+g",
-				action: function (e) {
-					$(".desktop-search-wrapper #desktop-navbar-modal-search").click();
-					e.preventDefault();
-					return false;
-				},
-				description: __("Open Awesomebar"),
-				ignore_inputs: true,
-			});
-			frappe.ui.keys.add_shortcut({
 				shortcut: "ctrl+k",
 				action: function (e) {
 					$(".desktop-search-wrapper #desktop-navbar-modal-search").click();

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -211,16 +211,7 @@ frappe.ui.keys.add_shortcut({
 frappe.ui.keys.add_shortcut({
 	shortcut: "ctrl+g",
 	action: function (e) {
-		const from_bar = ($("#navbar-search").val() || "").trim();
-		const dlg = frappe.searchdialog?.search;
-		if (dlg?.open_global_search_dialog) {
-			frappe.search.hide_navbar_search_modal?.();
-			dlg.open_global_search_dialog(from_bar);
-			e.preventDefault();
-			return false;
-		}
-		e.preventDefault();
-		return false;
+		return frappe.search.open_global_search_from_navbar_shortcut?.(e);
 	},
 	description: __("Open Global Search"),
 	ignore_inputs: true,

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -211,11 +211,18 @@ frappe.ui.keys.add_shortcut({
 frappe.ui.keys.add_shortcut({
 	shortcut: "ctrl+g",
 	action: function (e) {
-		$("#navbar-modal-search").click();
+		const from_bar = ($("#navbar-search").val() || "").trim();
+		const dlg = frappe.searchdialog?.search;
+		if (dlg?.open_global_search_dialog) {
+			frappe.search.hide_navbar_search_modal?.();
+			dlg.open_global_search_dialog(from_bar);
+			e.preventDefault();
+			return false;
+		}
 		e.preventDefault();
 		return false;
 	},
-	description: __("Open Awesomebar"),
+	description: __("Open Global Search"),
 	ignore_inputs: true,
 });
 

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -200,9 +200,7 @@ frappe.ui.keys.add_shortcut({
 frappe.ui.keys.add_shortcut({
 	shortcut: "ctrl+k",
 	action: function (e) {
-		$("#navbar-modal-search").click();
-		e.preventDefault();
-		return false;
+		return frappe.search.open_awesomebar_from_global_search_shortcut?.(e);
 	},
 	description: __("Open Awesomebar"),
 	ignore_inputs: true,

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -366,23 +366,30 @@ frappe.search.AwesomeBar = class AwesomeBar {
 	}
 
 	make_search_in_current(txt) {
-		const route_options = frappe.search.prepare_search_in_current_list_route_options(txt);
-		if (!route_options) return;
 		var route = frappe.get_route();
-		this.options.push({
-			label: __("Find {0} in {1}", [
-				frappe.utils.xss_sanitise(txt).bold(),
-				__(route[1]).bold(),
-			]),
-			value: __("Find {0} in {1}", [frappe.utils.xss_sanitise(txt), __(route[1])]),
-			route_options: route_options,
-			onclick: function () {
-				cur_list.show();
-			},
-			index: 90,
-			default: "Current",
-			match: txt,
-		});
+		if (route[0] === "List" && txt.indexOf(" in") === -1) {
+			// search in title field
+			const doctype = frappe.container.page?.list_view?.doctype;
+			if (!doctype) return;
+			var meta = frappe.get_meta(doctype);
+			var search_field = meta.title_field || "name";
+			var options = {};
+			options[search_field] = ["like", "%" + txt + "%"];
+			this.options.push({
+				label: __("Find {0} in {1}", [
+					frappe.utils.xss_sanitise(txt).bold(),
+					__(route[1]).bold(),
+				]),
+				value: __("Find {0} in {1}", [frappe.utils.xss_sanitise(txt), __(route[1])]),
+				route_options: options,
+				onclick: function () {
+					cur_list.show();
+				},
+				index: 90,
+				default: "Current",
+				match: txt,
+			});
+		}
 	}
 
 	make_calculator(txt) {
@@ -438,56 +445,4 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			});
 		}
 	}
-};
-
-frappe.search.prepare_search_in_current_list_route_options = function (txt) {
-	txt = (txt || "").trim();
-	if (!txt || txt.indexOf(" in") !== -1) return null;
-	var route = frappe.get_route();
-	if (route[0] !== "List") return null;
-	const doctype = frappe.container.page?.list_view?.doctype;
-	if (!doctype) return null;
-	var meta = frappe.get_meta(doctype);
-	var search_field = meta.title_field || "name";
-	var options = {};
-	options[search_field] = ["like", "%" + txt + "%"];
-	return options;
-};
-
-frappe.search.open_search_in_current_list = function (txt) {
-	const route_options = frappe.search.prepare_search_in_current_list_route_options(txt);
-	if (!route_options || !window.cur_list) return false;
-	frappe.route_options = route_options;
-	cur_list.show();
-	return true;
-};
-
-frappe.search.get_current_list_standard_search_text = function () {
-	if (!window.cur_list || frappe.get_route()[0] !== "List") return "";
-	const meta = frappe.get_meta(cur_list.doctype);
-	const fieldname = meta.title_field || "name";
-	const field = cur_list.page?.fields_dict?.[fieldname];
-	if (!field || typeof field.get_value !== "function") return "";
-	const v = field.get_value();
-	if (v === undefined || v === null || v === "") return "";
-	return String(v).trim();
-};
-
-frappe.search.hide_navbar_search_modal = function () {
-	const $modal = $("#navbar-search").closest(".modal");
-	if ($modal.length) $modal.modal("hide");
-	$("#navbar-search").val("");
-};
-
-frappe.search.open_global_search_from_navbar_shortcut = function (e) {
-	const from_bar = ($("#navbar-search").val() || "").trim();
-	const dlg = frappe.searchdialog?.search;
-	if (dlg?.open_global_search_dialog) {
-		frappe.search.hide_navbar_search_modal?.();
-		dlg.open_global_search_dialog(from_bar);
-	}
-	if (e) {
-		e.preventDefault();
-	}
-	return false;
 };

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -220,6 +220,13 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			if (e.key == "Escape") {
 				$input.trigger("blur");
 			}
+			if ((e.ctrlKey || e.metaKey) && String(e.key).toLowerCase() === "g") {
+				e.preventDefault();
+				const txt = ($input.val() || "").trim();
+				frappe.searchdialog?.search?.open_global_search_dialog(txt);
+				search_modal.modal("hide");
+				$input.val("");
+			}
 		});
 	}
 
@@ -366,30 +373,23 @@ frappe.search.AwesomeBar = class AwesomeBar {
 	}
 
 	make_search_in_current(txt) {
+		const route_options = frappe.search.prepare_search_in_current_list_route_options(txt);
+		if (!route_options) return;
 		var route = frappe.get_route();
-		if (route[0] === "List" && txt.indexOf(" in") === -1) {
-			// search in title field
-			const doctype = frappe.container.page?.list_view?.doctype;
-			if (!doctype) return;
-			var meta = frappe.get_meta(doctype);
-			var search_field = meta.title_field || "name";
-			var options = {};
-			options[search_field] = ["like", "%" + txt + "%"];
-			this.options.push({
-				label: __("Find {0} in {1}", [
-					frappe.utils.xss_sanitise(txt).bold(),
-					__(route[1]).bold(),
-				]),
-				value: __("Find {0} in {1}", [frappe.utils.xss_sanitise(txt), __(route[1])]),
-				route_options: options,
-				onclick: function () {
-					cur_list.show();
-				},
-				index: 90,
-				default: "Current",
-				match: txt,
-			});
-		}
+		this.options.push({
+			label: __("Find {0} in {1}", [
+				frappe.utils.xss_sanitise(txt).bold(),
+				__(route[1]).bold(),
+			]),
+			value: __("Find {0} in {1}", [frappe.utils.xss_sanitise(txt), __(route[1])]),
+			route_options: route_options,
+			onclick: function () {
+				cur_list.show();
+			},
+			index: 90,
+			default: "Current",
+			match: txt,
+		});
 	}
 
 	make_calculator(txt) {
@@ -445,4 +445,43 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			});
 		}
 	}
+};
+
+frappe.search.prepare_search_in_current_list_route_options = function (txt) {
+	txt = (txt || "").trim();
+	if (!txt || txt.indexOf(" in") !== -1) return null;
+	var route = frappe.get_route();
+	if (route[0] !== "List") return null;
+	const doctype = frappe.container.page?.list_view?.doctype;
+	if (!doctype) return null;
+	var meta = frappe.get_meta(doctype);
+	var search_field = meta.title_field || "name";
+	var options = {};
+	options[search_field] = ["like", "%" + txt + "%"];
+	return options;
+};
+
+frappe.search.open_search_in_current_list = function (txt) {
+	const route_options = frappe.search.prepare_search_in_current_list_route_options(txt);
+	if (!route_options || !window.cur_list) return false;
+	frappe.route_options = route_options;
+	cur_list.show();
+	return true;
+};
+
+frappe.search.get_current_list_standard_search_text = function () {
+	if (!window.cur_list || frappe.get_route()[0] !== "List") return "";
+	const meta = frappe.get_meta(cur_list.doctype);
+	const fieldname = meta.title_field || "name";
+	const field = cur_list.page?.fields_dict?.[fieldname];
+	if (!field || typeof field.get_value !== "function") return "";
+	const v = field.get_value();
+	if (v === undefined || v === null || v === "") return "";
+	return String(v).trim();
+};
+
+frappe.search.hide_navbar_search_modal = function () {
+	const $modal = $("#navbar-search").closest(".modal");
+	if ($modal.length) $modal.modal("hide");
+	$("#navbar-search").val("");
 };

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -52,6 +52,10 @@ frappe.search.AwesomeBar = class AwesomeBar {
 					<span class="help-item help-item-escape">${frappe.utils.is_mac() ? "⌘K" : "Ctrl+K"}</span>
 					<span>${__("to close")}</span>
 				</span>
+				<span class="help-item-navigate">
+					<span class="help-item help-item-escape">${frappe.utils.is_mac() ? "⌘G" : "Ctrl+G"}</span>
+					<span>${__("to open Global Search")}</span>
+				</span>
 			</div>
 			<div class="pointer">${frappe.utils.icon("circle-question-mark")}</div>
 		</div>`;

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -220,13 +220,6 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			if (e.key == "Escape") {
 				$input.trigger("blur");
 			}
-			if ((e.ctrlKey || e.metaKey) && String(e.key).toLowerCase() === "g") {
-				e.preventDefault();
-				const txt = ($input.val() || "").trim();
-				frappe.searchdialog?.search?.open_global_search_dialog(txt);
-				search_modal.modal("hide");
-				$input.val("");
-			}
 		});
 	}
 
@@ -484,4 +477,17 @@ frappe.search.hide_navbar_search_modal = function () {
 	const $modal = $("#navbar-search").closest(".modal");
 	if ($modal.length) $modal.modal("hide");
 	$("#navbar-search").val("");
+};
+
+frappe.search.open_global_search_from_navbar_shortcut = function (e) {
+	const from_bar = ($("#navbar-search").val() || "").trim();
+	const dlg = frappe.searchdialog?.search;
+	if (dlg?.open_global_search_dialog) {
+		frappe.search.hide_navbar_search_modal?.();
+		dlg.open_global_search_dialog(from_bar);
+	}
+	if (e) {
+		e.preventDefault();
+	}
+	return false;
 };

--- a/frappe/public/js/frappe/ui/toolbar/search.html
+++ b/frappe/public/js/frappe/ui/toolbar/search.html
@@ -1,8 +1,9 @@
 <div class="search-results flex">
-	<div class="col-md-3 col-sm-3 hidden-xs layout-side-section">
+	<div class="col-md-2 col-sm-3 hidden-xs layout-side-section search-shortcuts-sidebar">
 		<ul class="overlay-sidebar list-unstyled search-sidebar"></ul>
 	</div>
-	<div class="col-md-9 col-sm-9 layout-main-section results-area">
-
+	<div class="col-md-10 col-sm-9 layout-main-section search-main-column">
+		<div class="global-search-doctype-filters hide"></div>
+		<div class="results-area"></div>
 	</div>
 </div>

--- a/frappe/public/js/frappe/ui/toolbar/search.js
+++ b/frappe/public/js/frappe/ui/toolbar/search.js
@@ -132,13 +132,18 @@ frappe.search.SearchDialog = class {
 		let $shell = $(frappe.render_template("search")).addClass("hide");
 		const tipLine =
 			__("Use ampersand to match multiple terms") + " (" + __("e.g.") + " Marie&John)";
+		const awesomebarShortcut = frappe.utils.is_mac() ? "⌘K" : "Ctrl+K";
+		const awesomebarTipLine = `<span class="global-search-shortcut-key">${frappe.utils.escape_html(
+			awesomebarShortcut
+		)}</span> ${frappe.utils.escape_html(__("to open Awesome Bar"))}`;
 		const show_ampersand_empty_tip =
 			status_text === __("Search for anything") &&
 			this.search === this.searches["global_search"];
 		const ampersandBlock = show_ampersand_empty_tip
 			? `<div class="global-search-empty-state-tip text-muted">${frappe.utils.escape_html(
 					tipLine
-			  )}</div>`
+			  )}</div>
+			  <div class="global-search-empty-state-tip text-muted">${awesomebarTipLine}</div>`
 			: "";
 		$shell.find(".results-area").html(
 			`<div class="empty-state">

--- a/frappe/public/js/frappe/ui/toolbar/search.js
+++ b/frappe/public/js/frappe/ui/toolbar/search.js
@@ -1,5 +1,14 @@
 frappe.provide("frappe.search");
 
+/** First N Global Search Settings rows used as implicit default pins. Toolbar shows every pinned DocType. */
+frappe.search.GLOBAL_SEARCH_VISIBLE_DT_LIMIT = 5;
+frappe.search.GLOBAL_SEARCH_PIN_STORAGE_KEY = "global-search-pinned-doctypes";
+
+/** “All” summary: per-doctype “Show more” at or above this count when browsing all DocTypes. */
+frappe.search.GLOBAL_SEARCH_SUMMARY_SHOW_MORE_MIN = 5;
+/** Extra field values beyond this show as “and n more”. */
+frappe.search.GLOBAL_SEARCH_FIELD_INLINE_PREVIEW_LIMIT = 3;
+
 frappe.search.SearchDialog = class {
 	constructor(opts) {
 		$.extend(this, opts);
@@ -9,13 +18,22 @@ frappe.search.SearchDialog = class {
 	make() {
 		this.search_dialog = new frappe.ui.Dialog({
 			minimizable: true,
-			size: "large",
+			size: "extra-large",
+			on_page_show: () => this.focus_global_search_input(),
 		});
 		this.set_header();
 		this.$wrapper = $(this.search_dialog.$wrapper).addClass("search-dialog");
 		this.$body = $(this.search_dialog.body);
 		this.$input = this.$wrapper.find(".search-input");
 		this.setup();
+	}
+
+	/** Header `.search-input` is outside `Dialog.fields_list`; base `focus_on_first_input` skips it. */
+	focus_global_search_input() {
+		const input = this.$input?.get?.(0);
+		if (!input) return;
+		input.focus({ preventScroll: true });
+		if ((input.value || "").length) input.select();
 	}
 
 	set_header() {
@@ -30,6 +48,31 @@ frappe.search.SearchDialog = class {
 					${frappe.utils.icon("search")}
 				</span>`
 			);
+		const $actions = this.search_dialog.$wrapper.find(".modal-actions");
+		$actions.find(".btn-open-global-search-settings").remove();
+		const $gs = this.make_global_search_settings_btn();
+		if ($gs) {
+			$actions.prepend($gs);
+		}
+	}
+
+	make_global_search_settings_btn() {
+		if (!frappe.model.can_read("Global Search Settings")) return null;
+		const label = __("Configure search settings");
+		return $(
+			`<button type="button" class="btn btn-ghost icon-btn btn-open-global-search-settings">`
+		)
+			.attr({
+				title: label,
+				"aria-label": label,
+			})
+			.append(frappe.utils.icon("settings", "sm"))
+			.on("click", (e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				this.search_dialog.hide();
+				frappe.set_route("Form", "Global Search Settings", "Global Search Settings");
+			});
 	}
 
 	setup() {
@@ -38,6 +81,8 @@ frappe.search.SearchDialog = class {
 		this.more_count = 20;
 		this.full_lists = {};
 		this.nav_lists = {};
+		this.global_doctype_filter = "";
+		this._global_search_settings_promise = null;
 		this.init_search_objects();
 		this.bind_input();
 		this.bind_events();
@@ -50,18 +95,12 @@ frappe.search.SearchDialog = class {
 				empty_state_text: __("Search for anything"),
 				no_results_status: () => __("No Results found"),
 				get_results: (keywords, callback) => {
-					let start = 0,
-						limit = 100;
-					let results = frappe.search.utils.get_nav_results(keywords);
-					frappe.search.utils.get_global_results(keywords, start, limit).then(
-						(global_results) => {
-							results = results.concat(global_results);
-							callback(results, keywords);
-						},
-						(err) => {
-							console.error(err);
-						}
-					);
+					frappe.search.utils
+						.get_global_results(keywords, 0, null, this.global_doctype_filter || "")
+						.then(
+							(global_results) => callback(global_results, keywords),
+							(err) => console.error(err)
+						);
 				},
 			},
 			tags: {
@@ -70,12 +109,8 @@ frappe.search.SearchDialog = class {
 				no_results_status: (keyword) =>
 					"<div>" + __("No documents found tagged with {0}", [keyword]) + "</div>",
 				get_results: (keywords, callback) => {
-					var results = frappe.search.utils.get_nav_results(keywords);
 					frappe.tags.utils.get_tag_results(keywords).then(
-						(global_results) => {
-							results = results.concat(global_results);
-							callback(results, keywords);
-						},
+						(global_results) => callback(global_results, keywords),
 						(err) => {
 							console.error(err);
 						}
@@ -98,37 +133,49 @@ frappe.search.SearchDialog = class {
 	}
 
 	put_placeholder(status_text) {
-		var $placeholder = $(`<div class="row search-results hide">
-			<div class="empty-state">
+		let $shell = $(frappe.render_template("search")).addClass("hide");
+		const tipLine =
+			__("Use ampersand to match multiple terms") + " (" + __("e.g.") + " Marie&John)";
+		const show_ampersand_empty_tip =
+			status_text === __("Search for anything") &&
+			this.search === this.searches["global_search"];
+		const ampersandBlock = show_ampersand_empty_tip
+			? `<div class="global-search-empty-state-tip text-muted">${frappe.utils.escape_html(
+					tipLine
+			  )}</div>`
+			: "";
+		$shell.find(".results-area").html(
+			`<div class="empty-state">
 				<div class="text-center">
 					<img src="/assets/frappe/images/ui-states/search-empty-state.svg"
 						alt="Generic Empty State"
 						class="null-state"
 					>
-					<div class="empty-state-text">${status_text}</div>
+					<div class="empty-state-text">${frappe.utils.escape_html(status_text)}</div>
+					${ampersandBlock}
 				</div>
-			</div>
-		</div>`);
-		this.update($placeholder);
+			</div>`
+		);
+		this.update($shell);
+		this.sync_global_search_filter_bar();
 	}
 
 	bind_input() {
-		this.$input.on("input", (e) => {
-			const $el = $(e.currentTarget);
-			clearTimeout($el.data("timeout"));
-			$el.data(
-				"timeout",
-				setTimeout(() => {
-					if (this.$input.val() === this.current_keyword) return;
-					let keywords = this.$input.val();
-					if (keywords.length > 1) {
-						this.get_results(keywords);
-					} else {
-						this.current_keyword = "";
-						this.put_placeholder(this.search.empty_state_text);
-					}
-				}, 300)
-			);
+		const wait_ms = 300;
+		this._debounced_search_input = frappe.utils.debounce(() => {
+			if (this.$input.val() === this.current_keyword) return;
+			const keywords = this.$input.val();
+			if (keywords.length > 1) {
+				this.get_results(keywords);
+			} else {
+				this.current_keyword = "";
+				this.global_doctype_filter = "";
+				this.put_placeholder(this.search.empty_state_text);
+			}
+		}, wait_ms);
+		this.$input.on("input", () => this._debounced_search_input());
+		this.$wrapper.on("hide.bs.modal.globalSearch", () => {
+			this._debounced_search_input?.cancel?.();
 		});
 	}
 
@@ -145,12 +192,53 @@ frappe.search.SearchDialog = class {
 
 		// Summary more links
 		this.$body.on("click", ".section-more", (e) => {
-			const $section = $(e.currentTarget);
-			const type = $section.attr("data-category");
-			this.$body
-				.find(".search-sidebar")
-				.find('*[data-category="' + type + '"]')
-				.trigger("click");
+			e.preventDefault();
+			const type = $(e.currentTarget).attr("data-category");
+			if ($(e.currentTarget).attr("data-fetch-type") === "Global") {
+				this.apply_global_doctype_filter(type || "");
+				return;
+			}
+			this.$body.find(".search-sidebar").find(`*[data-category="${type}"]`).trigger("click");
+		});
+
+		this.$body.on("click", ".global-search-filter-pill", (e) => {
+			e.stopPropagation();
+			this.apply_global_doctype_filter($(e.currentTarget).attr("data-doctype") || "");
+		});
+
+		this.$wrapper.on("click", (e) => {
+			if (!$(e.target).closest(".global-search-more-dropdown-wrap").length)
+				this.close_global_search_more_menus();
+		});
+
+		this.$body.on("click", ".global-search-more-trigger", (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			const $dd = $(e.currentTarget).siblings(".global-search-more-dropdown");
+			const opening = !$dd.hasClass("menu-open");
+			this.close_global_search_more_menus();
+			if (opening) $dd.addClass("menu-open");
+		});
+
+		this.$body.on("click", ".global-search-more-dropdown", (e) => e.stopPropagation());
+
+		this.$body.on("click", ".global-search-dd-pick-doctype", (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			this.close_global_search_more_menus();
+			this.apply_global_doctype_filter($(e.currentTarget).attr("data-doctype") || "");
+		});
+
+		this.$body.on("click", ".global-search-pin-btn", (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			const $btn = $(e.currentTarget);
+			const dt = $btn.attr("data-doctype");
+			const action = $btn.attr("data-pin-action") || "";
+			if (!dt) return;
+			if (action === "remove") this.remove_global_search_pin(dt);
+			else if (action === "add") this.add_global_search_pin(dt);
+			this.sync_global_search_filter_bar();
 		});
 
 		// Back-links (mobile-view)
@@ -161,18 +249,34 @@ frappe.search.SearchDialog = class {
 				.trigger("click");
 		});
 
-		// Full list more links
+		// Full list “More” buttons
 		this.$body.on("click", ".list-more", (e) => {
-			const $el = $(e.currentTarget);
-			const type = $el.attr("data-category");
-			const fetch_type = $el.attr("data-search");
-			var current_count = this.$body.find(".result").length;
+			e.preventDefault();
+			const $trigger = $(e.currentTarget);
+			const type = $trigger.attr("data-category");
+			const fetch_type = $trigger.attr("data-search");
+			const $panel = $trigger.closest(".global-search-table-panel");
+			const $list = $panel.find(".global-search-results-list").first();
+			var current_count = $list.length
+				? Math.max(0, $list.children(".list-row-container").length - 1)
+				: this.$body.find(".result").length;
 			if (fetch_type === "Global") {
 				frappe.search.utils
-					.get_global_results(this.current_keyword, current_count, this.more_count, type)
+					.get_global_results(
+						this.current_keyword,
+						current_count,
+						this.more_count,
+						this.global_doctype_filter || type
+					)
 					.then(
 						(doctype_results) => {
-							doctype_results.length && this.add_more_results(doctype_results);
+							doctype_results.length &&
+								this.add_more_global_table_rows(
+									type,
+									doctype_results,
+									$trigger,
+									$list
+								);
 						},
 						(err) => {
 							console.error(err);
@@ -195,13 +299,29 @@ frappe.search.SearchDialog = class {
 	}
 
 	init_search(keywords, search_type) {
+		this.global_doctype_filter = "";
 		this.search = this.searches[search_type];
 		this.$input.attr("placeholder", this.search.input_placeholder);
 		this.put_placeholder(this.search.empty_state_text);
 		this.get_results(keywords);
 		this.search_dialog.show();
 		this.$input.val(keywords);
-		setTimeout(() => this.$input.select(), 500);
+	}
+
+	/** Keyboard shortcut: open full Global Search panel (not the Awesome Bar). */
+	open_global_search_dialog(keywords) {
+		keywords = (keywords || "").trim();
+		this.global_doctype_filter = "";
+		this.search = this.searches["global_search"];
+		this.$input.attr("placeholder", this.search.input_placeholder);
+		this.search_dialog.show();
+		this.$input.val(keywords);
+		if (keywords.length > 1) {
+			this.get_results(keywords);
+		} else {
+			this.current_keyword = keywords;
+			this.put_placeholder(this.search.empty_state_text);
+		}
 	}
 
 	get_results(keywords) {
@@ -213,6 +333,7 @@ frappe.search.SearchDialog = class {
 		}
 
 		if (this.current_keyword.charAt(0) === "#") {
+			this.global_doctype_filter = "";
 			this.search = this.searches["tags"];
 		} else {
 			this.search = this.searches["global_search"];
@@ -245,9 +366,26 @@ frappe.search.SearchDialog = class {
 		};
 		this.nav_lists = {};
 
+		let global_nonempty = [];
+		let nav_nonempty = [];
 		result_sets.forEach((set) => {
+			if (set.results.length === 0) return;
+			if (set.fetch_type === "Global") {
+				global_nonempty.push(set);
+			} else {
+				nav_nonempty.push(set);
+			}
+		});
+
+		const prepend_all = global_nonempty.length >= 1 || nav_nonempty.length > 1;
+
+		if (prepend_all) {
+			$sidebar.prepend($(__(sidebar_item_html, ["All Results", __("All Results")])));
+		}
+
+		nav_nonempty.forEach((set) => {
 			$sidebar.append($(__(sidebar_item_html, [set.title, __(set.title)])));
-			this.add_section_to_summary(set.title, set.results);
+			this.add_section_to_summary(set.title, set.results, set.fetch_type);
 			this.full_lists[set.title] = this.render_full_list(
 				set.title,
 				set.results,
@@ -255,16 +393,455 @@ frappe.search.SearchDialog = class {
 			);
 		});
 
-		if (result_sets.length > 1) {
-			$sidebar.prepend($(__(sidebar_item_html, ["All Results", __("All Results")])));
+		global_nonempty.forEach((set) => {
+			this.add_section_to_summary(set.title, set.results, set.fetch_type);
+			this.full_lists[set.title] = this.render_full_list(
+				set.title,
+				set.results,
+				set.fetch_type
+			);
+		});
+
+		const show_global_filters = this.search !== this.searches["tags"];
+
+		const finish_draw = () => {
+			this.update($search_results);
+			const $pill_host = $(this.search_dialog.body).find(".global-search-doctype-filters");
+			this.toggle_global_search_filters($pill_host, show_global_filters);
+			if (show_global_filters) {
+				this.render_doctype_filter_bar_into($pill_host);
+			}
+			$(this.search_dialog.body).find(".list-link").first().trigger("click");
+		};
+
+		if (show_global_filters) {
+			this.ensure_global_search_allowed_doctypes().then(() => finish_draw());
+		} else {
+			finish_draw();
+		}
+	}
+
+	sync_global_search_filter_bar() {
+		if (this.search === this.searches["tags"]) {
+			const $pill_host = this.$body.find(".global-search-doctype-filters");
+			this.toggle_global_search_filters($pill_host, false);
+			return;
+		}
+		const redraw = () => {
+			const $pill_host = this.$body.find(".global-search-doctype-filters");
+			this.toggle_global_search_filters($pill_host, true);
+			this.render_doctype_filter_bar_into($pill_host);
+		};
+		/** Promise `.then` runs on a microtask — pin/unpin would update one frame late. */
+		if (this._cached_global_search_allowed !== undefined) {
+			redraw();
+			return;
+		}
+		this.ensure_global_search_allowed_doctypes().then(redraw);
+	}
+
+	toggle_global_search_filters($host, visible) {
+		if (visible) {
+			$host.removeClass("hide");
+		} else {
+			$host.empty().addClass("hide");
+		}
+	}
+
+	apply_global_doctype_filter(dt) {
+		this.global_doctype_filter = dt || "";
+		this.get_results(this.current_keyword);
+	}
+
+	close_global_search_more_menus() {
+		this.$wrapper.find(".global-search-more-dropdown").removeClass("menu-open");
+	}
+
+	_global_search_allowed_set() {
+		const allow = Object.create(null);
+		for (const d of this._cached_global_search_allowed || []) if (d) allow[d] = 1;
+		return allow;
+	}
+
+	ensure_global_search_allowed_doctypes() {
+		if (!this._global_search_settings_promise) {
+			this._global_search_settings_promise = new Promise((resolve) => {
+				frappe.call({
+					method: "frappe.client.get",
+					args: {
+						doctype: "Global Search Settings",
+						name: "Global Search Settings",
+					},
+					callback: (res) => {
+						if (!res.exc && res.message && res.message.allowed_in_global_search) {
+							const rows = (res.message.allowed_in_global_search || []).slice();
+							rows.sort(
+								(a, b) => (parseInt(a.idx, 10) || 0) - (parseInt(b.idx, 10) || 0)
+							);
+							this._cached_global_search_allowed = rows
+								.map((row) => row.document_type)
+								.filter(Boolean);
+						} else {
+							this._cached_global_search_allowed = [];
+						}
+						resolve(this._cached_global_search_allowed);
+					},
+					error: () => {
+						this._cached_global_search_allowed = [];
+						resolve([]);
+					},
+				});
+			});
+		}
+		return this._global_search_settings_promise;
+	}
+
+	/**
+	 * explicit=false: missing key — baseline pins from first N settings rows.
+	 * explicit=true: user JSON (including []) is authoritative.
+	 */
+	read_global_search_pin_state() {
+		const key = frappe.search.GLOBAL_SEARCH_PIN_STORAGE_KEY;
+		let raw = null;
+		try {
+			raw = localStorage.getItem(key);
+		} catch (_) {
+			raw = null;
+		}
+		if (raw === null) {
+			try {
+				const u = frappe.session && frappe.session.user ? frappe.session.user : "guest";
+				const legacy_key = "frappe_global_search_pins::" + encodeURIComponent(u);
+				const legacy_val = localStorage.getItem(legacy_key);
+				if (legacy_val !== null) {
+					localStorage.setItem(key, legacy_val);
+					localStorage.removeItem(legacy_key);
+					raw = legacy_val;
+				}
+			} catch (_) {
+				/* ignore */
+			}
+		}
+		if (raw === null) return { explicit: false, pins: [] };
+		try {
+			let arr = JSON.parse(raw);
+			if (!Array.isArray(arr)) return { explicit: true, pins: [] };
+			return { explicit: true, pins: arr.filter((d) => !!d) };
+		} catch {
+			return { explicit: true, pins: [] };
+		}
+	}
+
+	write_global_search_pins(pins) {
+		const uniq = [];
+		const seen = {};
+		(pins || []).forEach(function (dt) {
+			if (!dt || seen[dt]) return;
+			seen[dt] = 1;
+			uniq.push(dt);
+		});
+		try {
+			localStorage.setItem(
+				frappe.search.GLOBAL_SEARCH_PIN_STORAGE_KEY,
+				JSON.stringify(uniq)
+			);
+		} catch (e) {
+			/* quota or private mode */
+		}
+	}
+
+	/** First N doctypes from Global Search Settings (same order as backend). */
+	default_pinned_doctypes_from_settings() {
+		const allowed = this._cached_global_search_allowed || [];
+		const lim = frappe.search.GLOBAL_SEARCH_VISIBLE_DT_LIMIT;
+		return allowed.slice(0, Math.min(lim, allowed.length));
+	}
+
+	current_effective_pins_list() {
+		const allow = this._global_search_allowed_set();
+		const st = this.read_global_search_pin_state();
+		const base = !st.explicit ? this.default_pinned_doctypes_from_settings() : st.pins;
+		return base.filter((d) => allow[d]);
+	}
+
+	add_global_search_pin(dt) {
+		const allow = this._global_search_allowed_set();
+		if (!dt || !allow[dt]) return;
+
+		const st = this.read_global_search_pin_state();
+		let next = !st.explicit
+			? this.default_pinned_doctypes_from_settings().filter((d) => allow[d])
+			: st.pins.filter((d) => allow[d]).slice();
+		if (next.indexOf(dt) === -1) next.push(dt);
+		this.write_global_search_pins(next);
+	}
+
+	remove_global_search_pin(dt) {
+		const allow = this._global_search_allowed_set();
+		const st = this.read_global_search_pin_state();
+		const next = !st.explicit
+			? this.default_pinned_doctypes_from_settings().filter((d) => allow[d] && d !== dt)
+			: st.pins.filter((d) => allow[d] && d !== dt);
+		this.write_global_search_pins(next);
+	}
+
+	build_global_search_more_menu_dom(pinned_ordered, unpinned_ordered) {
+		const pin_icon = frappe.utils.icon("pin", "xs");
+		const unpin_icon = frappe.utils.icon("pin-off", "xs");
+		let html = "";
+		const row = (dt, label, action) => {
+			const esc = frappe.utils.escape_html(dt || "");
+			const safe_label = frappe.utils.escape_html(label || dt || "");
+			let pin_btn = "";
+			if (action === "unpin") {
+				pin_btn = `<button type="button" class="btn btn-xs btn-default global-search-pin-btn" data-pin-action="remove" data-doctype="${esc}" title="${__(
+					"Unpin"
+				)}" aria-label="${__("Unpin")}">${unpin_icon}</button>`;
+			} else if (action === "pin") {
+				pin_btn = `<button type="button" class="btn btn-xs btn-default global-search-pin-btn" data-pin-action="add" data-doctype="${esc}" title="${__(
+					"Pin"
+				)}" aria-label="${__("Pin")}">${pin_icon}</button>`;
+			}
+			return `<div class="global-search-more-row">
+				<button type="button" class="btn btn-xs btn-link global-search-dd-pick-doctype ellipsis" data-doctype="${esc}">${safe_label}</button>
+				<div class="global-search-pin-cell">${pin_btn}</div>
+			</div>`;
+		};
+
+		html += `<div class="global-search-more-group"><div class="global-search-more-group-title">${__(
+			"Pinned"
+		)}</div>`;
+		if (pinned_ordered.length) {
+			pinned_ordered.forEach((dt) => {
+				html += row(dt, __(dt), "unpin");
+			});
+		} else {
+			html += `<div class="global-search-more-empty text-muted">${__(
+				"No pinned document types."
+			)}</div>`;
+		}
+		html += `</div><div class="global-search-more-group"><div class="global-search-more-group-title">${__(
+			"Other"
+		)}</div>`;
+		if (unpinned_ordered.length) {
+			unpinned_ordered.forEach((dt) => {
+				html += row(dt, __(dt), "pin");
+			});
+		} else {
+			html += `<div class="global-search-more-empty text-muted">${__(
+				"No other document types."
+			)}</div>`;
+		}
+		html += "</div>";
+		return html;
+	}
+
+	render_doctype_filter_bar_into($host) {
+		const keep_more_dropdown_open =
+			$host.find(".global-search-more-dropdown.menu-open").length > 0;
+
+		const dt_allowed = this._cached_global_search_allowed || [];
+		let pinned_matching = this.current_effective_pins_list();
+		let unpinned_ordered = dt_allowed.filter((dt) => !pinned_matching.includes(dt));
+		/** One chip per pinned DocType (strip wraps); not capped here. */
+		let visible_doctypes = pinned_matching.slice();
+		let active_dt = this.global_doctype_filter || "";
+		/** Selected DocType must appear in the toolbar if it is not among the visible chips. */
+		let show_overflow_chip =
+			!!active_dt &&
+			dt_allowed.indexOf(active_dt) !== -1 &&
+			visible_doctypes.indexOf(active_dt) === -1;
+
+		let $toolbar = $('<div class="global-search-filter-toolbar">');
+		let $strip = $('<div class="global-search-visible-pills">');
+
+		let add_pill = (lbl, dt, extra_cls = "") =>
+			$("<button>")
+				.attr({ type: "button", "data-doctype": dt || "", title: lbl })
+				.addClass(
+					"btn btn-xs btn-default global-search-filter-pill ellipsis" +
+						(extra_cls ? " " + extra_cls : "")
+				)
+				.text(lbl)
+				.toggleClass("active", (active_dt || "") === (dt || ""));
+
+		$strip.append(add_pill(__("All"), ""));
+		visible_doctypes.forEach((dt) => {
+			$strip.append(add_pill(__(dt), dt, ""));
+		});
+
+		if (show_overflow_chip) {
+			$strip.append(
+				add_pill(__(active_dt), active_dt, "global-search-filter-overflow-pick")
+			);
 		}
 
-		this.update($search_results.clone());
-		this.$body.find(".list-link").first().trigger("click");
+		let $more_wrap = $('<div class="global-search-more-dropdown-wrap">');
+		let $more_btn = $(
+			'<button type="button" class="btn btn-xs btn-default global-search-more-trigger">'
+		)
+			.append(frappe.utils.icon("menu", "xs"))
+			.append($('<span class="global-search-more-label">').text(" " + __("More")));
+		let $dropdown = $('<div class="global-search-more-dropdown shadow rounded">').html(
+			this.build_global_search_more_menu_dom(pinned_matching, unpinned_ordered)
+		);
+
+		if (pinned_matching.length + unpinned_ordered.length > 0) {
+			$more_wrap.append($more_btn).append($dropdown);
+			$strip.append($more_wrap);
+			if (keep_more_dropdown_open) {
+				$dropdown.addClass("menu-open");
+			}
+		}
+
+		$toolbar.append($strip);
+
+		let $toolbar_row = $('<div class="global-search-toolbar-row">');
+		$toolbar_row.append($toolbar);
+		$host.empty().append($toolbar_row);
+	}
+
+	build_global_search_table_panel(doctype, results_slice, keywords, options = {}) {
+		const cols = frappe.search.utils.global_search_field_columns_for_results(results_slice);
+		const max_rows = options.max_rows == null ? results_slice.length : options.max_rows;
+		let $panel = $('<div class="global-search-table-panel">');
+		let $list = $("<div>")
+			.addClass("list-item-table global-search-results-list mb-0")
+			.attr("data-doctype", doctype || "");
+
+		const nameLabel = __("Name");
+		const name_head = frappe.utils.escape_html(nameLabel);
+		let header_cols_html = `
+			<div class="list-row-col ellipsis list-subject level global-search-grid-col global-search-list-head-subject">
+				<span class="level-item" title="${name_head}">${nameLabel}</span>
+			</div>`;
+		for (let c = 0; c < cols.length; c++) {
+			const ch = frappe.utils.escape_html(cols[c]);
+			header_cols_html += `<div class="list-row-col ellipsis global-search-grid-col"><span title="${ch}">${ch}</span></div>`;
+		}
+		$list.append(
+			`<div class="list-row-container global-search-list-header">
+				<header class="level list-row-head text-muted">
+					<div class="level-left list-header-subject global-search-level-left-multi">
+						${header_cols_html}
+					</div>
+				</header>
+			</div>`
+		);
+
+		results_slice
+			.slice(0, max_rows)
+			.forEach((r) => this.append_global_result_list_row(r, cols, keywords, doctype, $list));
+		$panel.append($list);
+		return $panel;
+	}
+
+	append_global_result_list_row(result, columns, keywords, type, $list) {
+		const utils = frappe.search.utils;
+		const fields = utils.parse_global_search_fields(result._global_raw_content || "");
+		let avatar_html = "";
+		if (result.image) {
+			avatar_html = frappe.get_avatar("avatar-small", result.label, result.image);
+		}
+		let route_url = "#";
+		if (result.route) {
+			route_url = frappe.router.make_url(result.route);
+		}
+		const $name_link = $('<a class="global-search-name-link ellipsis">')
+			.attr("href", route_url)
+			.html(utils.highlight_global_search_terms(result.label, keywords));
+
+		$name_link.attr("title", result.label);
+		$name_link.on("click", (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			if (result.route_options) {
+				frappe.route_options = result.route_options;
+			}
+			var previous_hash = window.location.hash;
+			frappe.set_route(result.route);
+			if (window.location.hash === previous_hash) {
+				frappe.router.route();
+			}
+		});
+
+		let $name_inner = $('<div class="global-search-name-cell-inner">');
+		if (avatar_html) {
+			$name_inner.append($(avatar_html));
+		}
+		$name_inner.append($name_link);
+
+		let $subject = $(
+			'<div class="list-row-col ellipsis list-subject level global-search-grid-col">'
+		);
+		$subject.attr("title", result.label);
+		$subject.append($('<span class="level-item">').append($name_inner));
+
+		const field_value_parts = (raw) => {
+			if (raw == null) return [""];
+			if (Array.isArray(raw)) return raw.map((p) => String(p));
+			return [String(raw)];
+		};
+
+		let $level_left = $('<div class="level-left global-search-level-left-multi">').append(
+			$subject
+		);
+		const row_title_bits = [result.label];
+		const previewLim = frappe.search.GLOBAL_SEARCH_FIELD_INLINE_PREVIEW_LIMIT;
+		for (let i = 0; i < columns.length; i++) {
+			const parts = field_value_parts(fields[columns[i]]);
+			const total = parts.length;
+			const plain_full = parts.join("\n");
+			row_title_bits.push(plain_full);
+
+			let innerHtml = "";
+			if (total > previewLim) {
+				const head = parts.slice(0, previewLim);
+				const moreN = total - previewLim;
+				const moreLbl = __("and {0} more", [String(moreN)]);
+				const tailHint = ` <span class="global-search-field-more-hint">${frappe.utils.escape_html(
+					moreLbl
+				)}</span>`;
+				const linesBeforeLast = head.slice(0, -1);
+				const lastPreview = head[previewLim - 1];
+				const lastLineHtml =
+					utils.highlight_global_search_terms(lastPreview, keywords) + tailHint;
+				innerHtml =
+					linesBeforeLast.length > 0
+						? linesBeforeLast
+								.map((p) => utils.highlight_global_search_terms(p, keywords))
+								.join("<br>") +
+						  "<br>" +
+						  lastLineHtml
+						: lastLineHtml;
+			} else {
+				innerHtml = parts
+					.map((p) => utils.highlight_global_search_terms(p, keywords))
+					.join("<br>");
+			}
+
+			const multiline = total > 1 || total > previewLim || plain_full.indexOf("\n") !== -1;
+			let $field_col = $(
+				'<div class="list-row-col global-search-field-col global-search-grid-col">'
+			);
+			if (multiline) {
+				$field_col.addClass("global-search-field-col--multiline");
+			} else {
+				$field_col.addClass("ellipsis");
+			}
+			$field_col.html(innerHtml).attr("title", plain_full);
+			$level_left.append($field_col);
+		}
+
+		let $row = $('<div class="level list-row">').append($level_left);
+		let $container = $('<div class="list-row-container">')
+			.attr("title", row_title_bits.filter(Boolean).join("\n"))
+			.append($row);
+		$list.append($container);
 	}
 
 	render_full_list(type, results, fetch_type) {
-		let max_length = 20;
+		let max_length = fetch_type === "Global" ? 100 : 20;
 
 		let $results_list = $(`<div class="results-summary">
 			<div class="result-section full-list ${type}-section col-sm-12">
@@ -274,35 +851,90 @@ frappe.search.SearchDialog = class {
 			</div>
 		</div>`);
 
-		results.slice(0, max_length).forEach((result) => {
-			$results_list.find(".result-body").append(this.render_result(type, result));
-		});
+		if (fetch_type === "Global") {
+			const $panel = this.build_global_search_table_panel(
+				type,
+				results,
+				this.current_keyword,
+				{
+					max_rows: max_length,
+				}
+			);
+			$results_list.find(".result-body").append($panel);
+			if (results.length > max_length) {
+				const cat_esc = frappe.utils.escape_html(type || "");
+				$(`<button type="button" class="btn btn-default btn-xs mt-2 list-more" data-search="Global" data-category="${cat_esc}">
+					${__("More")}
+				</button>`).appendTo($panel);
+			}
+		} else {
+			results.slice(0, max_length).forEach((result) => {
+				$results_list.find(".result-body").append(this.render_result(type, result));
+			});
+		}
 
 		if (results.length > 0) {
 			if (fetch_type === "Nav") this.nav_lists[type] = results;
 
-			if (results.length > max_length) {
-				$(`<a class="list-more" data-search="${fetch_type}"
-					data-category="${type}" data-count="${max_length}">
+			if (fetch_type !== "Global" && results.length > max_length) {
+				const cat_esc = frappe.utils.escape_html(type || "");
+				$(`<button type="button" class="btn btn-default btn-xs mt-2 list-more" data-search="${fetch_type}"
+					data-category="${cat_esc}" data-count="${max_length}">
 						${__("More")}
-				</a>`).appendTo($results_list.find(".result-body"));
+				</button>`).appendTo($results_list.find(".result-body"));
 			}
 		}
 		return $results_list;
 	}
 
-	add_section_to_summary(type, results) {
+	add_section_to_summary(type, results, fetch_type) {
+		if (fetch_type === "Global") {
+			let title_row = __(type) + " (" + results.length + " " + __("results") + ")";
+			let $result_section =
+				$(`<div class="col-sm-12 result-section global-summary" data-type="${type || ""}">
+				<div class="result-title">${title_row}</div>
+				<div class="result-body">
+				</div>
+			</div>`).appendTo(this.full_lists["All Results"]);
+
+			const $panel = this.build_global_search_table_panel(
+				type,
+				results,
+				this.current_keyword,
+				{}
+			);
+			$result_section.find(".result-body").append($panel);
+
+			const min_show = frappe.search.GLOBAL_SEARCH_SUMMARY_SHOW_MORE_MIN;
+			if (!this.global_doctype_filter && results.length >= min_show) {
+				const dt_esc = frappe.utils.escape_html(type || "");
+				const $btn = $("<button>", {
+					type: "button",
+					class: "btn btn-default btn-xs section-more mt-2",
+				})
+					.attr("data-fetch-type", "Global")
+					.attr("data-category", dt_esc)
+					.text(__("Show more"));
+				const $wrap = $('<div class="global-search-summary-show-more">').append($btn);
+				$result_section.find(".result-body").append($wrap);
+			}
+			return;
+		}
+
 		let section_length = 4;
 		let more_html = "";
 		let get_result_html = (result) => this.render_result(type, result);
 
 		if (results.length > section_length) {
+			const cat_esc = frappe.utils.escape_html(type || "");
 			more_html = `<div>
-				<a class="section-more" data-category="${type}">${__("More")}</a>
+				<button type="button" class="btn btn-default btn-xs section-more mt-2" data-fetch-type="Nav" data-category="${cat_esc}">${__(
+				"More"
+			)}</button>
 			</div>`;
 		}
 
-		let $result_section = $(`<div class="col-sm-12 result-section" data-type="${type}">
+		let $result_section = $(`<div class="col-sm-12 result-section" data-type="${type || ""}">
 			<div class="result-title">${__(type)}</div>
 			<div class="result-body">
 				${more_html}
@@ -376,6 +1008,43 @@ frappe.search.SearchDialog = class {
 				}
 			}
 		});
+	}
+
+	add_more_global_table_rows(doctype, results_sets, $trigger, $list) {
+		const set_entry = results_sets[0];
+		if (
+			!set_entry ||
+			!set_entry.results ||
+			!set_entry.results.length ||
+			!$list ||
+			!$list.length
+		) {
+			return;
+		}
+		const cols = [];
+		$list
+			.find(".list-row-head .list-row-col")
+			.slice(1)
+			.each(function () {
+				cols.push($(this).find("span").first().text());
+			});
+		const keywords = this.current_keyword;
+		set_entry.results.forEach((r) =>
+			this.append_global_result_list_row(
+				r,
+				cols,
+				keywords,
+				set_entry.title || doctype,
+				$list
+			)
+		);
+		if (set_entry.results.length < this.more_count) {
+			$trigger.hide();
+			let total_rows = Math.max(0, $list.children(".list-row-container").length - 1);
+			$('<div class="results-status">')
+				.text(`${total_rows} ${__("results")}`)
+				.insertAfter($trigger);
+		}
 	}
 
 	add_more_results(results_set) {

--- a/frappe/public/js/frappe/ui/toolbar/search.js
+++ b/frappe/public/js/frappe/ui/toolbar/search.js
@@ -1,13 +1,13 @@
 frappe.provide("frappe.search");
 
 /** First N Global Search Settings rows used as implicit default pins. Toolbar shows every pinned DocType. */
-frappe.search.GLOBAL_SEARCH_VISIBLE_DT_LIMIT = 5;
-frappe.search.GLOBAL_SEARCH_PIN_STORAGE_KEY = "global-search-pinned-doctypes";
+const GLOBAL_SEARCH_VISIBLE_DT_LIMIT = 5;
+const GLOBAL_SEARCH_PIN_STORAGE_KEY = "global-search-pinned-doctypes";
 
 /** “All” summary: per-doctype “Show more” at or above this count when browsing all DocTypes. */
-frappe.search.GLOBAL_SEARCH_SUMMARY_SHOW_MORE_MIN = 5;
+const GLOBAL_SEARCH_SUMMARY_SHOW_MORE_MIN = 5;
 /** Extra field values beyond this show as “and n more”. */
-frappe.search.GLOBAL_SEARCH_FIELD_INLINE_PREVIEW_LIMIT = 3;
+const GLOBAL_SEARCH_FIELD_INLINE_PREVIEW_LIMIT = 3;
 
 frappe.search.SearchDialog = class {
 	constructor(opts) {
@@ -89,6 +89,7 @@ frappe.search.SearchDialog = class {
 	}
 
 	init_search_objects() {
+		const log_err = (err) => console.error(err);
 		this.searches = {
 			global_search: {
 				input_placeholder: __("Search"),
@@ -97,10 +98,7 @@ frappe.search.SearchDialog = class {
 				get_results: (keywords, callback) => {
 					frappe.search.utils
 						.get_global_results(keywords, 0, null, this.global_doctype_filter || "")
-						.then(
-							(global_results) => callback(global_results, keywords),
-							(err) => console.error(err)
-						);
+						.then((global_results) => callback(global_results, keywords), log_err);
 				},
 			},
 			tags: {
@@ -109,12 +107,9 @@ frappe.search.SearchDialog = class {
 				no_results_status: (keyword) =>
 					"<div>" + __("No documents found tagged with {0}", [keyword]) + "</div>",
 				get_results: (keywords, callback) => {
-					frappe.tags.utils.get_tag_results(keywords).then(
-						(global_results) => callback(global_results, keywords),
-						(err) => {
-							console.error(err);
-						}
-					);
+					frappe.tags.utils
+						.get_tag_results(keywords)
+						.then((global_results) => callback(global_results, keywords), log_err);
 				},
 			},
 		};
@@ -289,7 +284,7 @@ frappe.search.SearchDialog = class {
 			}
 		});
 
-		// Switch to global search link
+		// Switch to global search link (keeps existing DocType toolbar filter).
 		this.$body.on("click", ".switch-to-global-search", () => {
 			this.search = this.searches["global_search"];
 			this.$input.attr("placeholder", this.search.input_placeholder);
@@ -299,9 +294,7 @@ frappe.search.SearchDialog = class {
 	}
 
 	init_search(keywords, search_type) {
-		this.global_doctype_filter = "";
-		this.search = this.searches[search_type];
-		this.$input.attr("placeholder", this.search.input_placeholder);
+		this._reset_global_search_modal_mode(search_type);
 		this.put_placeholder(this.search.empty_state_text);
 		this.get_results(keywords);
 		this.search_dialog.show();
@@ -311,9 +304,7 @@ frappe.search.SearchDialog = class {
 	/** Keyboard shortcut: open full Global Search panel (not the Awesome Bar). */
 	open_global_search_dialog(keywords) {
 		keywords = (keywords || "").trim();
-		this.global_doctype_filter = "";
-		this.search = this.searches["global_search"];
-		this.$input.attr("placeholder", this.search.input_placeholder);
+		this._reset_global_search_modal_mode("global_search");
 		this.search_dialog.show();
 		this.$input.val(keywords);
 		if (keywords.length > 1) {
@@ -383,24 +374,20 @@ frappe.search.SearchDialog = class {
 			$sidebar.prepend($(__(sidebar_item_html, ["All Results", __("All Results")])));
 		}
 
-		nav_nonempty.forEach((set) => {
-			$sidebar.append($(__(sidebar_item_html, [set.title, __(set.title)])));
+		const register_sidebar_section = (set, with_sidebar_entry) => {
+			if (with_sidebar_entry) {
+				$sidebar.append($(__(sidebar_item_html, [set.title, __(set.title)])));
+			}
 			this.add_section_to_summary(set.title, set.results, set.fetch_type);
 			this.full_lists[set.title] = this.render_full_list(
 				set.title,
 				set.results,
 				set.fetch_type
 			);
-		});
+		};
 
-		global_nonempty.forEach((set) => {
-			this.add_section_to_summary(set.title, set.results, set.fetch_type);
-			this.full_lists[set.title] = this.render_full_list(
-				set.title,
-				set.results,
-				set.fetch_type
-			);
-		});
+		nav_nonempty.forEach((set) => register_sidebar_section(set, true));
+		global_nonempty.forEach((set) => register_sidebar_section(set, false));
 
 		const show_global_filters = this.search !== this.searches["tags"];
 
@@ -453,6 +440,26 @@ frappe.search.SearchDialog = class {
 		this.get_results(this.current_keyword);
 	}
 
+	/** Clears DocType filter and switches modal to `global_search` or `tags` mode. */
+	_reset_global_search_modal_mode(search_type) {
+		this.global_doctype_filter = "";
+		this.search = this.searches[search_type];
+		this.$input.attr("placeholder", this.search.input_placeholder);
+	}
+
+	/** Shared navigation for list/global rows and classic result tiles (route + stale-hash reroute). */
+	_open_search_result_route(result) {
+		if (!result.route) return;
+		if (result.route_options) {
+			frappe.route_options = result.route_options;
+		}
+		const previous_hash = window.location.hash;
+		frappe.set_route(result.route);
+		if (window.location.hash === previous_hash) {
+			frappe.router.route();
+		}
+	}
+
 	close_global_search_more_menus() {
 		this.$wrapper.find(".global-search-more-dropdown").removeClass("menu-open");
 	}
@@ -501,7 +508,7 @@ frappe.search.SearchDialog = class {
 	 * explicit=true: user JSON (including []) is authoritative.
 	 */
 	read_global_search_pin_state() {
-		const key = frappe.search.GLOBAL_SEARCH_PIN_STORAGE_KEY;
+		const key = GLOBAL_SEARCH_PIN_STORAGE_KEY;
 		let raw = null;
 		try {
 			raw = localStorage.getItem(key);
@@ -541,10 +548,7 @@ frappe.search.SearchDialog = class {
 			uniq.push(dt);
 		});
 		try {
-			localStorage.setItem(
-				frappe.search.GLOBAL_SEARCH_PIN_STORAGE_KEY,
-				JSON.stringify(uniq)
-			);
+			localStorage.setItem(GLOBAL_SEARCH_PIN_STORAGE_KEY, JSON.stringify(uniq));
 		} catch (e) {
 			/* quota or private mode */
 		}
@@ -553,7 +557,7 @@ frappe.search.SearchDialog = class {
 	/** First N doctypes from Global Search Settings (same order as backend). */
 	default_pinned_doctypes_from_settings() {
 		const allowed = this._cached_global_search_allowed || [];
-		const lim = frappe.search.GLOBAL_SEARCH_VISIBLE_DT_LIMIT;
+		const lim = GLOBAL_SEARCH_VISIBLE_DT_LIMIT;
 		return allowed.slice(0, Math.min(lim, allowed.length));
 	}
 
@@ -755,14 +759,7 @@ frappe.search.SearchDialog = class {
 		$name_link.on("click", (e) => {
 			e.preventDefault();
 			e.stopPropagation();
-			if (result.route_options) {
-				frappe.route_options = result.route_options;
-			}
-			var previous_hash = window.location.hash;
-			frappe.set_route(result.route);
-			if (window.location.hash === previous_hash) {
-				frappe.router.route();
-			}
+			this._open_search_result_route(result);
 		});
 
 		let $name_inner = $('<div class="global-search-name-cell-inner">');
@@ -787,7 +784,7 @@ frappe.search.SearchDialog = class {
 			$subject
 		);
 		const row_title_bits = [result.label];
-		const previewLim = frappe.search.GLOBAL_SEARCH_FIELD_INLINE_PREVIEW_LIMIT;
+		const previewLim = GLOBAL_SEARCH_FIELD_INLINE_PREVIEW_LIMIT;
 		for (let i = 0; i < columns.length; i++) {
 			const parts = field_value_parts(fields[columns[i]]);
 			const total = parts.length;
@@ -906,7 +903,7 @@ frappe.search.SearchDialog = class {
 			);
 			$result_section.find(".result-body").append($panel);
 
-			const min_show = frappe.search.GLOBAL_SEARCH_SUMMARY_SHOW_MORE_MIN;
+			const min_show = GLOBAL_SEARCH_SUMMARY_SHOW_MORE_MIN;
 			if (!this.global_doctype_filter && results.length >= min_show) {
 				const dt_esc = frappe.utils.escape_html(type || "");
 				const $btn = $("<button>", {
@@ -952,7 +949,7 @@ frappe.search.SearchDialog = class {
 		if (result.route) {
 			link = `href="${frappe.router.make_url(result.route)}"`;
 		} else if (result.data_path) {
-			link = `data-path=${result.data_path}"`;
+			link = `data-path="${result.data_path}"`;
 		}
 		return link;
 	}
@@ -993,20 +990,11 @@ frappe.search.SearchDialog = class {
 	}
 
 	handle_result_click(result, $result) {
-		if (result.route_options) {
-			frappe.route_options = result.route_options;
-		}
 		$result.on("click", () => {
-			// this.toggle_minimize();
 			if (result.onclick) {
 				result.onclick(result.match);
 			} else {
-				var previous_hash = window.location.hash;
-				frappe.set_route(result.route);
-				// hashchange didn't fire!
-				if (window.location.hash == previous_hash) {
-					frappe.router.route();
-				}
+				this._open_search_result_route(result);
 			}
 		});
 	}
@@ -1059,7 +1047,6 @@ frappe.search.SearchDialog = class {
 		this.$body.find(".list-more").before(more_results);
 
 		if (results_set[0].results.length < this.more_count) {
-			// hide more button and add a result count
 			this.$body.find(".list-more").hide();
 			let no_of_results = this.$body.find(".result").length;
 			const cue_word = no_of_results === 1 ? __("result") : __("results");
@@ -1068,6 +1055,6 @@ frappe.search.SearchDialog = class {
 			);
 			this.$body.find(".more-results:last").append(no_of_results_cue);
 		}
-		this.$body.find(".more-results.last").slideDown(200, function () {});
+		this.$body.find(".more-results.last").slideDown(200);
 	}
 };

--- a/frappe/public/js/frappe/ui/toolbar/search.js
+++ b/frappe/public/js/frappe/ui/toolbar/search.js
@@ -17,6 +17,7 @@ frappe.search.SearchDialog = class {
 
 	make() {
 		this.search_dialog = new frappe.ui.Dialog({
+			animate: false,
 			minimizable: true,
 			size: "extra-large",
 			on_page_show: () => this.focus_global_search_input(),
@@ -298,11 +299,16 @@ frappe.search.SearchDialog = class {
 	}
 
 	init_search(keywords, search_type) {
+		keywords = (keywords || "").trim();
 		this._reset_global_search_modal_mode(search_type);
-		this.put_placeholder(this.search.empty_state_text);
-		this.get_results(keywords);
 		this.search_dialog.show();
 		this.$input.val(keywords);
+		if (keywords.length > 1) {
+			this.get_results(keywords);
+		} else {
+			this.current_keyword = keywords;
+			this.put_placeholder(this.search.empty_state_text);
+		}
 	}
 
 	/** Keyboard shortcut: open full Global Search panel (not the Awesome Bar). */

--- a/frappe/public/js/frappe/ui/toolbar/search.js
+++ b/frappe/public/js/frappe/ui/toolbar/search.js
@@ -217,10 +217,14 @@ frappe.search.SearchDialog = class {
 		this.$body.on("click", ".global-search-more-trigger", (e) => {
 			e.preventDefault();
 			e.stopPropagation();
-			const $dd = $(e.currentTarget).siblings(".global-search-more-dropdown");
+			const $trigger = $(e.currentTarget);
+			const $dd = $trigger.siblings(".global-search-more-dropdown");
 			const opening = !$dd.hasClass("menu-open");
 			this.close_global_search_more_menus();
-			if (opening) $dd.addClass("menu-open");
+			if (opening) {
+				$dd.addClass("menu-open");
+				this.align_global_search_more_dropdown($dd, $trigger);
+			}
 		});
 
 		this.$body.on("click", ".global-search-more-dropdown", (e) => e.stopPropagation());
@@ -480,7 +484,31 @@ frappe.search.SearchDialog = class {
 
 	/** Closes the “More” dropdown menus: removes the `menu-open` class from the dropdown. */
 	close_global_search_more_menus() {
-		this.$wrapper.find(".global-search-more-dropdown").removeClass("menu-open");
+		this.$wrapper.find(".global-search-more-dropdown").removeClass("menu-open align-right");
+	}
+
+	align_global_search_more_dropdown($dropdown, $trigger) {
+		const apply = () => {
+			const b = $trigger[0].getBoundingClientRect();
+			const c = this.$wrapper[0].getBoundingClientRect();
+			const left_edge = Math.max(c.left, 8);
+			const right_edge = Math.min(c.right, window.innerWidth) - 8;
+			const w =
+				$dropdown.get(0).getBoundingClientRect().width ||
+				$dropdown.outerWidth() ||
+				Math.min(384, window.innerWidth * 0.92);
+			const fits_opening_right = b.left + w <= right_edge;
+			const fits_opening_left = b.right - w >= left_edge;
+			let align_right = false;
+			if (!fits_opening_right && fits_opening_left) {
+				align_right = true;
+			} else if (!fits_opening_right && !fits_opening_left) {
+				align_right = b.right - left_edge > right_edge - b.left;
+			}
+			$dropdown.toggleClass("align-right", align_right);
+		};
+		apply();
+		requestAnimationFrame(apply);
 	}
 
 	/** Returns a set of allowed DocTypes for Global Search: based on Global Search Settings. */
@@ -724,6 +752,7 @@ frappe.search.SearchDialog = class {
 			$strip.append($more_wrap);
 			if (keep_more_dropdown_open) {
 				$dropdown.addClass("menu-open");
+				this.align_global_search_more_dropdown($dropdown, $more_btn);
 			}
 		}
 

--- a/frappe/public/js/frappe/ui/toolbar/search.js
+++ b/frappe/public/js/frappe/ui/toolbar/search.js
@@ -154,7 +154,7 @@ frappe.search.SearchDialog = class {
 		this.update($shell);
 		this.sync_global_search_filter_bar();
 	}
-
+	/** Binds input event to the search input and debounces the search input. */
 	bind_input() {
 		const wait_ms = 300;
 		this._debounced_search_input = frappe.utils.debounce(() => {
@@ -174,8 +174,9 @@ frappe.search.SearchDialog = class {
 		});
 	}
 
+	/** Click handlers for search UI: sidebar sections, DocType filters/pins, “More” / pagination, and tag→global switch. */
 	bind_events() {
-		// Sidebar
+		/** Sidebar navigation: click a section link to show its results. */
 		this.$body.on("click", ".list-link", (e) => {
 			const $link = $(e.currentTarget);
 			this.$body.find(".search-sidebar").find(".list-link").removeClass("active selected");
@@ -185,7 +186,7 @@ frappe.search.SearchDialog = class {
 			this.$body.find(".module-section-link").first().focus();
 		});
 
-		// Summary more links
+		/** “Show more” links: global search or DocType-specific “More”. */
 		this.$body.on("click", ".section-more", (e) => {
 			e.preventDefault();
 			const type = $(e.currentTarget).attr("data-category");
@@ -196,6 +197,7 @@ frappe.search.SearchDialog = class {
 			this.$body.find(".search-sidebar").find(`*[data-category="${type}"]`).trigger("click");
 		});
 
+		/** DocType filter pills: apply DocType filter and show its results. */
 		this.$body.on("click", ".global-search-filter-pill", (e) => {
 			e.stopPropagation();
 			this.apply_global_doctype_filter($(e.currentTarget).attr("data-doctype") || "");
@@ -217,6 +219,7 @@ frappe.search.SearchDialog = class {
 
 		this.$body.on("click", ".global-search-more-dropdown", (e) => e.stopPropagation());
 
+		/** DocType selection from “More” dropdown: apply DocType filter and close dropdown. */
 		this.$body.on("click", ".global-search-dd-pick-doctype", (e) => {
 			e.preventDefault();
 			e.stopPropagation();
@@ -224,6 +227,7 @@ frappe.search.SearchDialog = class {
 			this.apply_global_doctype_filter($(e.currentTarget).attr("data-doctype") || "");
 		});
 
+		/** DocType pin buttons: toggle DocType pin state and sync filter bar. */
 		this.$body.on("click", ".global-search-pin-btn", (e) => {
 			e.preventDefault();
 			e.stopPropagation();
@@ -236,7 +240,7 @@ frappe.search.SearchDialog = class {
 			this.sync_global_search_filter_bar();
 		});
 
-		// Back-links (mobile-view)
+		/** Back-links (mobile-view): click to show all results. */
 		this.$body.on("click", ".all-results-link", () => {
 			this.$body
 				.find(".search-sidebar")
@@ -244,7 +248,7 @@ frappe.search.SearchDialog = class {
 				.trigger("click");
 		});
 
-		// Full list “More” buttons
+		/** Full list “More” buttons: fetch more results from the current DocType. */
 		this.$body.on("click", ".list-more", (e) => {
 			e.preventDefault();
 			const $trigger = $(e.currentTarget);
@@ -408,6 +412,7 @@ frappe.search.SearchDialog = class {
 		}
 	}
 
+	/** Syncs DocType filter bar: shows/hides based on current search mode (global vs. per-DocType). */
 	sync_global_search_filter_bar() {
 		if (this.search === this.searches["tags"]) {
 			const $pill_host = this.$body.find(".global-search-doctype-filters");
@@ -427,6 +432,7 @@ frappe.search.SearchDialog = class {
 		this.ensure_global_search_allowed_doctypes().then(redraw);
 	}
 
+	/** Toggles visibility of the DocType filter bar: shows/hides based on current search mode (global vs. per-DocType). */
 	toggle_global_search_filters($host, visible) {
 		if (visible) {
 			$host.removeClass("hide");
@@ -435,6 +441,7 @@ frappe.search.SearchDialog = class {
 		}
 	}
 
+	/** Applies a DocType filter: updates the global_doctype_filter and fetches results. */
 	apply_global_doctype_filter(dt) {
 		this.global_doctype_filter = dt || "";
 		this.get_results(this.current_keyword);
@@ -460,19 +467,23 @@ frappe.search.SearchDialog = class {
 		}
 	}
 
+	/** Closes the “More” dropdown menus: removes the `menu-open` class from the dropdown. */
 	close_global_search_more_menus() {
 		this.$wrapper.find(".global-search-more-dropdown").removeClass("menu-open");
 	}
 
+	/** Returns a set of allowed DocTypes for Global Search: based on Global Search Settings. */
 	_global_search_allowed_set() {
 		const allow = Object.create(null);
 		for (const d of this._cached_global_search_allowed || []) if (d) allow[d] = 1;
 		return allow;
 	}
 
+	/** Ensures the Global Search Settings are loaded and cached: fetches from the server if needed. */
 	ensure_global_search_allowed_doctypes() {
 		if (!this._global_search_settings_promise) {
 			this._global_search_settings_promise = new Promise((resolve) => {
+				/** Fetches the Global Search Settings from the server and caches the results. */
 				frappe.call({
 					method: "frappe.client.get",
 					args: {
@@ -480,6 +491,7 @@ frappe.search.SearchDialog = class {
 						name: "Global Search Settings",
 					},
 					callback: (res) => {
+						/** If the Global Search Settings are loaded successfully, cache the results. */
 						if (!res.exc && res.message && res.message.allowed_in_global_search) {
 							const rows = (res.message.allowed_in_global_search || []).slice();
 							rows.sort(
@@ -504,11 +516,11 @@ frappe.search.SearchDialog = class {
 	}
 
 	/**
-	 * explicit=false: missing key — baseline pins from first N settings rows.
-	 * explicit=true: user JSON (including []) is authoritative.
+	 * Reads the global search pin state from localStorage.
 	 */
 	read_global_search_pin_state() {
 		const key = GLOBAL_SEARCH_PIN_STORAGE_KEY;
+		/** Reads the global search pin state from localStorage. */
 		let raw = null;
 		try {
 			raw = localStorage.getItem(key);
@@ -539,6 +551,7 @@ frappe.search.SearchDialog = class {
 		}
 	}
 
+	/** Writes the global search pin state to localStorage. */
 	write_global_search_pins(pins) {
 		const uniq = [];
 		const seen = {};
@@ -554,13 +567,14 @@ frappe.search.SearchDialog = class {
 		}
 	}
 
-	/** First N doctypes from Global Search Settings (same order as backend). */
+	/** Returns the default pinned DocTypes: based on Global Search Settings. */
 	default_pinned_doctypes_from_settings() {
 		const allowed = this._cached_global_search_allowed || [];
 		const lim = GLOBAL_SEARCH_VISIBLE_DT_LIMIT;
 		return allowed.slice(0, Math.min(lim, allowed.length));
 	}
 
+	/** Returns the current effective list of pinned DocTypes: based on Global Search Settings and localStorage. */
 	current_effective_pins_list() {
 		const allow = this._global_search_allowed_set();
 		const st = this.read_global_search_pin_state();
@@ -568,6 +582,7 @@ frappe.search.SearchDialog = class {
 		return base.filter((d) => allow[d]);
 	}
 
+	/** Adds a DocType to the pinned list: updates localStorage. */
 	add_global_search_pin(dt) {
 		const allow = this._global_search_allowed_set();
 		if (!dt || !allow[dt]) return;
@@ -580,6 +595,7 @@ frappe.search.SearchDialog = class {
 		this.write_global_search_pins(next);
 	}
 
+	/** Removes a DocType from the pinned list: updates localStorage. */
 	remove_global_search_pin(dt) {
 		const allow = this._global_search_allowed_set();
 		const st = this.read_global_search_pin_state();
@@ -589,6 +605,7 @@ frappe.search.SearchDialog = class {
 		this.write_global_search_pins(next);
 	}
 
+	/** Builds the DOM for the “More” dropdown menu: shows pinned and unpinned DocTypes. */
 	build_global_search_more_menu_dom(pinned_ordered, unpinned_ordered) {
 		const pin_icon = frappe.utils.icon("pin", "xs");
 		const unpin_icon = frappe.utils.icon("pin-off", "xs");
@@ -640,6 +657,7 @@ frappe.search.SearchDialog = class {
 		return html;
 	}
 
+	/** Renders the DocType filter bar into the host element: shows pinned and unpinned DocTypes. */
 	render_doctype_filter_bar_into($host) {
 		const keep_more_dropdown_open =
 			$host.find(".global-search-more-dropdown.menu-open").length > 0;
@@ -705,6 +723,7 @@ frappe.search.SearchDialog = class {
 		$host.empty().append($toolbar_row);
 	}
 
+	/** Builds the DOM for the global search table panel: shows the results in a table. */
 	build_global_search_table_panel(doctype, results_slice, keywords, options = {}) {
 		const cols = frappe.search.utils.global_search_field_columns_for_results(results_slice);
 		const max_rows = options.max_rows == null ? results_slice.length : options.max_rows;
@@ -740,6 +759,7 @@ frappe.search.SearchDialog = class {
 		return $panel;
 	}
 
+	/** Appends a row to the global search table panel: shows the result in a table. */
 	append_global_result_list_row(result, columns, keywords, type, $list) {
 		const utils = frappe.search.utils;
 		const fields = utils.parse_global_search_fields(result._global_raw_content || "");
@@ -837,6 +857,7 @@ frappe.search.SearchDialog = class {
 		$list.append($container);
 	}
 
+	/** Renders the full list: shows the results in a table. */
 	render_full_list(type, results, fetch_type) {
 		let max_length = fetch_type === "Global" ? 100 : 20;
 
@@ -884,6 +905,7 @@ frappe.search.SearchDialog = class {
 		return $results_list;
 	}
 
+	/** Adds a section to the summary: shows the results in a table. */
 	add_section_to_summary(type, results, fetch_type) {
 		if (fetch_type === "Global") {
 			const results_word = results.length === 1 ? __("result") : __("results");
@@ -944,6 +966,7 @@ frappe.search.SearchDialog = class {
 			.prepend(results.slice(0, section_length).map(get_result_html));
 	}
 
+	/** Returns the link for a result: shows the result in a table. */
 	get_link(result) {
 		let link = "";
 		if (result.route) {
@@ -999,6 +1022,7 @@ frappe.search.SearchDialog = class {
 		});
 	}
 
+	/** Adds more rows to the global search table panel: shows the results in a table. */
 	add_more_global_table_rows(doctype, results_sets, $trigger, $list) {
 		const set_entry = results_sets[0];
 		if (

--- a/frappe/public/js/frappe/ui/toolbar/search.js
+++ b/frappe/public/js/frappe/ui/toolbar/search.js
@@ -889,7 +889,8 @@ frappe.search.SearchDialog = class {
 
 	add_section_to_summary(type, results, fetch_type) {
 		if (fetch_type === "Global") {
-			let title_row = __(type) + " (" + results.length + " " + __("results") + ")";
+			const results_word = results.length === 1 ? __("result") : __("results");
+			let title_row = __(type) + " (" + results.length + " " + results_word + ")";
 			let $result_section =
 				$(`<div class="col-sm-12 result-section global-summary" data-type="${type || ""}">
 				<div class="result-title">${title_row}</div>
@@ -1041,8 +1042,9 @@ frappe.search.SearchDialog = class {
 		if (set_entry.results.length < this.more_count) {
 			$trigger.hide();
 			let total_rows = Math.max(0, $list.children(".list-row-container").length - 1);
+			const status_word = total_rows === 1 ? __("result") : __("results");
 			$('<div class="results-status">')
-				.text(`${total_rows} ${__("results")}`)
+				.text(`${total_rows} ${status_word}`)
 				.insertAfter($trigger);
 		}
 	}
@@ -1060,8 +1062,9 @@ frappe.search.SearchDialog = class {
 			// hide more button and add a result count
 			this.$body.find(".list-more").hide();
 			let no_of_results = this.$body.find(".result").length;
-			let no_of_results_cue = $(
-				'<div class="results-status">' + no_of_results + " results found</div>"
+			const cue_word = no_of_results === 1 ? __("result") : __("results");
+			let no_of_results_cue = $('<div class="results-status">').text(
+				`${no_of_results} ${cue_word} ${__("found")}`
 			);
 			this.$body.find(".more-results:last").append(no_of_results_cue);
 		}

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -519,6 +519,11 @@ frappe.search.utils = {
 		});
 	},
 
+	/**
+	 * Parses `__global_search` content into { field label - value list }.
+	 * Segments are separated by `|||`; each segment is `label : value` (or `label &&& value` as fallback).
+	 * Skips blank parts and the synthetic `name` field (the real name is shown in its own column).
+	 */
 	parse_global_search_fields: function (content) {
 		const fields = {};
 		if (!content) return fields;
@@ -541,6 +546,10 @@ frappe.search.utils = {
 		return fields;
 	},
 
+	/**
+	 * Picks table column names for Global Search hits: walks each hit’s snippet text,
+	 * finds every field label in that text, then returns each label once (first time we see it).
+	 */
 	global_search_field_columns_for_results: function (results) {
 		const cols = [];
 		const seen = Object.create(null);
@@ -556,6 +565,9 @@ frappe.search.utils = {
 		return cols;
 	},
 
+	/**
+	 * Highlights search terms in text: wraps each term in `<mark>` tags.
+	 */
 	highlight_global_search_terms: function (text, keywords) {
 		const s = text == null ? "" : String(text);
 		const terms = keywords
@@ -695,13 +707,7 @@ function hide_navbar_search_modal() {
 }
 
 /**
- * Navbar search: Ctrl/Cmd+G jumps from the Awesome Bar modal to the Global Search dialog
- * with the same text pre-filled (`frappe/ui/keyboard.js` registers this shortcut).
- *
- * Registered on `frappe.search` intentionally — keyboard loads earlier in desk.bundle.js;
- * the shortcut runs after full load, when this assignment is applied.
- *
- * @param {KeyboardEvent} [e] Optional DOM event so default browser behavior can be suppressed.
+ * Open the global search dialog from the navbar search modal if in results `Search for txt`
  */
 frappe.search.open_global_search_from_navbar_shortcut = function (e) {
 	const from_bar = ($("#navbar-search").val() || "").trim();

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -686,3 +686,32 @@ frappe.search.utils = {
 	},
 	searchable_functions: [],
 };
+
+/** Closes the navbar Awesome Bar modal and clears its input (#navbar-search). */
+function hide_navbar_search_modal() {
+	const $modal = $("#navbar-search").closest(".modal");
+	if ($modal.length) $modal.modal("hide");
+	$("#navbar-search").val("");
+}
+
+/**
+ * Navbar search: Ctrl/Cmd+G jumps from the Awesome Bar modal to the Global Search dialog
+ * with the same text pre-filled (`frappe/ui/keyboard.js` registers this shortcut).
+ *
+ * Registered on `frappe.search` intentionally — keyboard loads earlier in desk.bundle.js;
+ * the shortcut runs after full load, when this assignment is applied.
+ *
+ * @param {KeyboardEvent} [e] Optional DOM event so default browser behavior can be suppressed.
+ */
+frappe.search.open_global_search_from_navbar_shortcut = function (e) {
+	const from_bar = ($("#navbar-search").val() || "").trim();
+	const dlg = frappe.searchdialog?.search;
+	if (dlg?.open_global_search_dialog) {
+		hide_navbar_search_modal();
+		dlg.open_global_search_dialog(from_bar);
+	}
+	if (e) {
+		e.preventDefault();
+	}
+	return false;
+};

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -535,7 +535,8 @@ frappe.search.utils = {
 			const label = part.slice(0, idx).trim();
 			const value = part.slice(idx + sep.length).trim();
 			if (!label.length || /^name$/i.test(label)) continue;
-			fields[label] = fields[label] ? fields[label] + "," + value : value;
+			if (!fields[label]) fields[label] = [];
+			fields[label].push(value);
 		}
 		return fields;
 	},
@@ -577,93 +578,6 @@ frappe.search.utils = {
 		} catch (e) {
 			return frappe.utils.escape_html(s);
 		}
-	},
-
-	get_nav_results: function (keywords) {
-		function sort_uniques(array) {
-			var routes = [],
-				out = [];
-			array.forEach(function (d) {
-				if (d.route) {
-					if (d.route[0] === "List" && d.route[2]) {
-						d.route.splice(2);
-					}
-					var str_route = d.route.join("/");
-					if (routes.indexOf(str_route) === -1) {
-						routes.push(str_route);
-						out.push(d);
-					} else {
-						var old = routes.indexOf(str_route);
-						if (out[old].index > d.index) {
-							out[old] = d;
-						}
-					}
-				} else {
-					out.push(d);
-				}
-			});
-			return out.sort(function (a, b) {
-				return b.index - a.index;
-			});
-		}
-		var lists = [],
-			setup = [];
-		var all_doctypes = sort_uniques(this.get_doctypes(keywords));
-		all_doctypes.forEach(function (d) {
-			if (d.type === "") {
-				setup.push(d);
-			} else {
-				lists.push(d);
-			}
-		});
-		var in_keyword = keywords.split(" in ")[0];
-		return [
-			{
-				title: __("Recents"),
-				fetch_type: "Nav",
-				results: sort_uniques(this.get_recent_pages(keywords)),
-			},
-			{
-				title: __("Create a new ..."),
-				fetch_type: "Nav",
-				results: sort_uniques(this.get_creatables(keywords)),
-			},
-			{
-				title: __("Lists"),
-				fetch_type: "Nav",
-				results: lists,
-			},
-			{
-				title: __("Reports"),
-				fetch_type: "Nav",
-				results: sort_uniques(this.get_reports(keywords)),
-			},
-			{
-				title: __("Administration"),
-				fetch_type: "Nav",
-				results: sort_uniques(this.get_pages(keywords)),
-			},
-			{
-				title: __("Desktop Icon"),
-				fetch_type: "Nav",
-				results: sort_uniques(this.get_desktop_icons(keywords)),
-			},
-			{
-				title: __("Dashboard"),
-				fetch_type: "Nav",
-				results: sort_uniques(this.get_dashboards(keywords)),
-			},
-			{
-				title: __("Setup"),
-				fetch_type: "Nav",
-				results: setup,
-			},
-			{
-				title: __("Find '{0}' in ...", [in_keyword]),
-				fetch_type: "Nav",
-				results: sort_uniques(this.get_search_in_list(keywords)),
-			},
-		];
 	},
 
 	fuzzy_search: function (keywords = "", _item = "", return_marked_string = false) {

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -699,11 +699,10 @@ frappe.search.utils = {
 	searchable_functions: [],
 };
 
-/** Closes the navbar Awesome Bar modal and clears its input (#navbar-search). */
+/** Closes the navbar Awesome Bar modal. */
 function hide_navbar_search_modal() {
 	const $modal = $("#navbar-search").closest(".modal");
 	if ($modal.length) $modal.modal("hide");
-	$("#navbar-search").val("");
 }
 
 /**

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -706,7 +706,7 @@ function hide_navbar_search_modal() {
 }
 
 /**
- * Open the global search dialog from the navbar search modal if in results `Search for txt`
+ * Open the global search dialog from the navbar Awesome Bar (Ctrl/Cmd+G).
  */
 frappe.search.open_global_search_from_navbar_shortcut = function (e) {
 	const from_bar = ($("#navbar-search").val() || "").trim();
@@ -715,6 +715,23 @@ frappe.search.open_global_search_from_navbar_shortcut = function (e) {
 		hide_navbar_search_modal();
 		dlg.open_global_search_dialog(from_bar);
 	}
+	if (e) {
+		e.preventDefault();
+	}
+	return false;
+};
+
+/**
+ * Open the navbar Awesome Bar from Global Search (Ctrl/Cmd+K).
+ */
+frappe.search.open_awesomebar_from_global_search_shortcut = function (e) {
+	const dlg = frappe.searchdialog?.search;
+	if (dlg?.search_dialog?.is_visible) {
+		const keywords = (dlg.$input?.val() || "").trim();
+		dlg.search_dialog.hide();
+		$("#navbar-search").val(keywords);
+	}
+	$("#navbar-modal-search").click();
 	if (e) {
 		e.preventDefault();
 	}

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -472,6 +472,8 @@ frappe.search.utils = {
 					value: d.name,
 					description: make_description(d.content, d.name),
 					route: ["Form", d.doctype, d.name],
+					_global_raw_content: d.content,
+					_global_doctype: d.doctype,
 				};
 				if (d.image || d.image === null) {
 					result.image = d.image;
@@ -491,14 +493,21 @@ frappe.search.utils = {
 			return results_sets;
 		}
 		return new Promise(function (resolve, reject) {
+			var args = { text: keywords };
+			if (doctype) {
+				args.doctype = doctype;
+			}
+			var offset = parseInt(start, 10) || 0;
+			if (offset > 0) {
+				args.start = offset;
+				args.limit = parseInt(limit, 10);
+				if (!args.limit || args.limit < 1) {
+					args.limit = 20;
+				}
+			}
 			frappe.call({
 				method: "frappe.utils.global_search.search",
-				args: {
-					text: keywords,
-					start: start,
-					limit: limit,
-					doctype: doctype,
-				},
+				args: args,
 				callback: function (r) {
 					if (r.message) {
 						resolve(get_results_sets(r.message));
@@ -508,6 +517,66 @@ frappe.search.utils = {
 				},
 			});
 		});
+	},
+
+	parse_global_search_fields: function (content) {
+		const fields = {};
+		if (!content) return fields;
+		for (const raw of content.split("|||")) {
+			let part = (raw || "").trim();
+			if (!part.length) continue;
+			let sep = " : ";
+			let idx = part.indexOf(sep);
+			if (idx === -1) {
+				sep = " &&& ";
+				idx = part.indexOf(sep);
+			}
+			if (idx === -1) continue;
+			const label = part.slice(0, idx).trim();
+			const value = part.slice(idx + sep.length).trim();
+			if (!label.length || /^name$/i.test(label)) continue;
+			fields[label] = fields[label] ? fields[label] + "," + value : value;
+		}
+		return fields;
+	},
+
+	global_search_field_columns_for_results: function (results) {
+		const cols = [];
+		const seen = Object.create(null);
+		for (const r of results || []) {
+			const fields = this.parse_global_search_fields(r._global_raw_content);
+			for (const col of Object.keys(fields)) {
+				if (!seen[col]) {
+					seen[col] = 1;
+					cols.push(col);
+				}
+			}
+		}
+		return cols;
+	},
+
+	highlight_global_search_terms: function (text, keywords) {
+		const s = text == null ? "" : String(text);
+		const terms = keywords
+			.split("&")
+			.map((p) => p.trim())
+			.filter(Boolean);
+		if (!terms.length) return frappe.utils.escape_html(s);
+		const escaped = terms.map((p) => p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+		try {
+			const re = new RegExp("(" + escaped.join("|") + ")", "gi");
+			return s
+				.split(re)
+				.map((part) => {
+					const isMatch =
+						part && terms.some((t) => part.toLowerCase() === t.toLowerCase());
+					const esc = frappe.utils.escape_html(part);
+					return isMatch ? "<mark>" + esc + "</mark>" : esc;
+				})
+				.join("");
+		} catch (e) {
+			return frappe.utils.escape_html(s);
+		}
 	},
 
 	get_nav_results: function (keywords) {

--- a/frappe/public/scss/desk/global_search.scss
+++ b/frappe/public/scss/desk/global_search.scss
@@ -101,7 +101,6 @@
 						background-color: var(--subtle-fg);
 						color: var(--text-color);
 						border-color: var(--border-color);
-						box-shadow: none;
 						font-weight: var(--weight-medium);
 					}
 				}
@@ -188,20 +187,25 @@
 			min-width: 0;
 		}
 
-		.results-area .global-summary .result-title {
-			@include get_textstyle("md", "semibold");
-			margin-bottom: var(--margin-xs);
-		}
-
 		.global-search-table-panel {
 			width: 100%;
-			max-width: 100%;
 			border: none;
 			border-radius: 0;
 			overflow-x: auto;
 			overflow-y: visible;
 			background: transparent;
 			-webkit-overflow-scrolling: touch;
+		}
+
+		.list-item-table.global-search-results-list {
+			width: 100%;
+			min-width: 0;
+			border: none;
+			box-shadow: none;
+			border-radius: 0;
+			background-color: transparent;
+			display: flex;
+			flex-direction: column;
 
 			.global-search-name-cell-inner {
 				@include flex(flex, null, center, null);
@@ -212,18 +216,6 @@
 					flex-shrink: 0;
 				}
 			}
-		}
-
-		.list-item-table.global-search-results-list {
-			width: 100%;
-			max-width: 100%;
-			min-width: 0;
-			border: none;
-			box-shadow: none;
-			border-radius: 0;
-			background-color: transparent;
-			display: flex;
-			flex-direction: column;
 
 			> .list-row-container {
 				border-bottom: none;
@@ -281,10 +273,6 @@
 				/* Separator between rows only (like list rows); omit on single / last row */
 				&:not(:last-child) > .level.list-row {
 					border-bottom: 1px solid var(--border-color);
-				}
-
-				&:last-child > .level.list-row {
-					border-bottom: none;
 				}
 			}
 
@@ -427,6 +415,11 @@
 				}
 			}
 
+			.result-title {
+				color: var(--text-color);
+				@include get_textstyle("lg", "semibold");
+			}
+
 			.result-section.global-summary {
 				padding-left: 0;
 				padding-right: 0;
@@ -434,11 +427,12 @@
 				.global-search-summary-show-more {
 					padding-top: var(--padding-xs);
 				}
-			}
 
-			.result-title {
-				color: var(--text-color);
-				@include get_textstyle("lg", "semibold");
+				/* Narrower heading than other summary section titles (count lives in the same line). */
+				.result-title {
+					@include get_textstyle("md", "semibold");
+					margin-bottom: var(--margin-xs);
+				}
 			}
 
 			.result-body {

--- a/frappe/public/scss/desk/global_search.scss
+++ b/frappe/public/scss/desk/global_search.scss
@@ -32,9 +32,339 @@
 			z-index: 6;
 		}
 	}
+
 	.search-results {
+		width: 100%;
+		align-self: stretch;
 		min-height: 200px;
-		place-content: center;
+		align-items: flex-start;
+		justify-content: center;
+
+		/* Widen main pane: Bootstrap col-* max-width caps the results area; sidebar stays compact. */
+		.search-shortcuts-sidebar.layout-side-section {
+			flex: 0 0 auto;
+			width: auto;
+			max-width: 11rem;
+		}
+
+		.search-main-column.layout-main-section {
+			display: flex;
+			flex-direction: column;
+			flex: 1 1 0%;
+			min-width: 0;
+			min-height: 0;
+			width: auto;
+			max-width: none;
+			box-sizing: border-box;
+			padding-inline: var(--padding-md);
+
+			.global-search-doctype-filters {
+				flex-shrink: 0;
+				padding-bottom: var(--padding-lg);
+
+				.global-search-tip-with-settings {
+					@include flex(flex, space-between, center);
+					gap: var(--padding-sm);
+					width: 100%;
+					margin-bottom: var(--margin-xs);
+				}
+
+				.global-search-multi-term-tip {
+					font-size: var(--text-xs);
+					flex: 1 1 auto;
+					min-width: 0;
+					margin-bottom: 0;
+				}
+
+				button.btn-open-global-search-settings {
+					flex: 0 0 auto;
+					align-self: center;
+					width: auto;
+					height: var(--btn-height);
+					aspect-ratio: 1;
+					padding: 0;
+					display: inline-flex;
+					align-items: center;
+					justify-content: center;
+				}
+
+				.global-search-toolbar-row,
+				.global-search-filter-toolbar {
+					width: 100%;
+				}
+
+				.global-search-visible-pills {
+					display: flex;
+					flex-wrap: wrap;
+					gap: 6px;
+					align-items: center;
+				}
+
+				button.global-search-filter-pill,
+				button.global-search-more-trigger {
+					background-color: transparent;
+					color: var(--text-color);
+					border: 1px solid var(--border-color);
+					box-shadow: none;
+				}
+
+				button.global-search-filter-pill {
+					font-weight: var(--weight-regular);
+
+					&:hover:not(:disabled):not(.active) {
+						background-color: var(--fg-color);
+						border-color: var(--border-color);
+					}
+
+					&.active {
+						background-color: var(--subtle-fg);
+						color: var(--text-color);
+						border-color: var(--border-color);
+						box-shadow: none;
+						font-weight: var(--weight-medium);
+					}
+				}
+
+				.global-search-more-dropdown-wrap {
+					position: relative;
+					flex-shrink: 0;
+				}
+
+				button.global-search-more-trigger {
+					@include flex(inline-flex, flex-start, center);
+					gap: 4px;
+
+					&:hover:not(:disabled) {
+						background-color: var(--fg-color);
+						border-color: var(--border-color);
+					}
+				}
+
+				.global-search-more-dropdown {
+					display: none;
+					position: absolute;
+					right: 0;
+					left: auto;
+					min-width: 14rem;
+					max-width: min(24rem, 92vw);
+					max-height: 75vh;
+					overflow-x: hidden;
+					overflow-y: auto;
+					background: var(--modal-bg);
+					border: 1px solid var(--border-color);
+					padding: var(--padding-xs);
+					z-index: 1070;
+
+					&.menu-open {
+						display: block;
+					}
+				}
+
+				.global-search-more-group-title {
+					@include get_textstyle("sm", "semibold");
+					padding: var(--padding-sm) var(--padding-xs);
+					color: var(--text-muted);
+				}
+
+				.global-search-more-empty {
+					font-size: var(--text-xs);
+					padding: 0 var(--padding-xs) var(--padding-sm);
+				}
+
+				.global-search-more-row {
+					@include flex(flex, space-between, center);
+					gap: 4px;
+					min-height: 1.875rem;
+
+					button.global-search-dd-pick-doctype {
+						flex: 1 1 auto;
+						justify-content: flex-start;
+						text-align: left;
+						margin: 0;
+						min-width: 0;
+					}
+
+					.global-search-pin-cell {
+						flex-shrink: 0;
+						@include flex(inline-flex, flex-end, center);
+
+						button.global-search-pin-btn {
+							padding: 2px var(--padding-xs);
+							min-height: unset;
+							line-height: 1;
+
+							svg.es-icon {
+								font-size: 12px;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		.results-area {
+			width: 100%;
+			min-width: 0;
+		}
+
+		.results-area .global-summary .result-title {
+			@include get_textstyle("md", "semibold");
+			margin-bottom: var(--margin-xs);
+		}
+
+		.global-search-table-panel {
+			width: 100%;
+			max-width: 100%;
+			border: none;
+			border-radius: 0;
+			overflow-x: auto;
+			overflow-y: visible;
+			background: transparent;
+			-webkit-overflow-scrolling: touch;
+
+			.global-search-name-cell-inner {
+				@include flex(flex, null, center, null);
+				gap: 8px;
+				min-width: 0;
+
+				.avatar {
+					flex-shrink: 0;
+				}
+			}
+		}
+
+		.list-item-table.global-search-results-list {
+			width: 100%;
+			max-width: 100%;
+			min-width: 0;
+			border: none;
+			box-shadow: none;
+			border-radius: 0;
+			background-color: transparent;
+			display: flex;
+			flex-direction: column;
+
+			> .list-row-container {
+				border-bottom: none;
+			}
+
+			> .list-row-container .level.list-row,
+			> .list-row-container header.level.list-row-head {
+				width: 100%;
+				box-sizing: border-box;
+				justify-content: flex-start !important;
+			}
+
+			.list-row .level-left,
+			header.list-row-head .level-left {
+				flex: 1 1 auto !important;
+				min-width: 0 !important;
+				max-width: none !important;
+			}
+
+			> .list-row-container:not(.global-search-list-header) {
+				position: relative;
+				z-index: 0;
+				padding-inline: var(--padding-sm);
+				border-radius: var(--border-radius-md);
+				overflow: hidden;
+				border: 1px solid transparent;
+				background-color: transparent;
+				box-sizing: border-box;
+
+				&:hover {
+					border-color: var(--border-color);
+					background-color: var(--highlight-color);
+				}
+			}
+
+			> .global-search-list-header {
+				position: sticky;
+				top: 0;
+				z-index: 2;
+				padding-inline: 0 !important;
+				background-color: var(--modal-bg);
+				border-radius: var(--border-radius-md);
+				overflow: hidden;
+				box-sizing: border-box;
+
+				&:hover {
+					background-color: var(--highlight-color);
+				}
+
+				header.level.list-row-head {
+					border-radius: var(--border-radius-md);
+					overflow: hidden;
+				}
+			}
+
+			.global-search-level-left-multi.level-left {
+				flex: 1 1 auto !important;
+				min-width: 0 !important;
+				align-items: stretch;
+				flex-wrap: nowrap;
+				overflow: visible;
+				white-space: normal;
+				max-width: none;
+				text-overflow: clip;
+			}
+
+			.list-row-col.global-search-grid-col {
+				flex: 1 1 0;
+				min-width: 0;
+				margin-right: var(--margin-sm);
+
+				> span {
+					display: block;
+					min-width: 0;
+				}
+			}
+
+			.list-row-col.list-subject.global-search-grid-col {
+				flex: 2 1 0;
+				min-width: unquote("min(12rem, 35%)");
+			}
+
+			.global-search-field-col {
+				color: var(--text-muted);
+				@include get_textstyle("base", "regular");
+
+				a {
+					color: var(--primary);
+				}
+			}
+
+			.list-subject .level-item {
+				min-width: 0;
+				flex: 1 1 auto;
+				max-width: 100%;
+				overflow: hidden;
+			}
+
+			> .list-row-container:not(.global-search-list-header) .list-row {
+				min-height: var(--list-row-height);
+				flex-shrink: 0;
+				border-bottom: none;
+			}
+
+			a.global-search-name-link {
+				color: var(--text-color);
+				font-weight: var(--weight-medium);
+
+				&:hover {
+					text-decoration: underline;
+					text-underline-offset: 2px;
+				}
+			}
+
+			mark {
+				border-radius: 2px;
+			}
+
+			.list-row .avatar {
+				--avatar-size: var(--avatar-size-medium, 26px);
+			}
+		}
 
 		.empty-state {
 			.empty-state-text {
@@ -55,13 +385,20 @@
 		}
 
 		.results-summary {
-			padding-left: var(--padding-sm);
-
 			.result-section:not(:last-child) {
 				padding-bottom: var(--padding-md);
 
 				.result-body {
 					border-bottom: 1px solid var(--border-color);
+				}
+			}
+
+			.result-section.global-summary {
+				padding-left: 0;
+				padding-right: 0;
+
+				.global-search-summary-show-more {
+					padding-top: var(--padding-xs);
 				}
 			}
 
@@ -98,11 +435,9 @@
 				}
 			}
 
-			.list-more,
-			.section-more,
 			.results-status {
 				padding: var(--padding-sm) 0;
-				color: var(--primary);
+				color: var(--text-muted);
 				@include get_textstyle("sm", "regular");
 			}
 		}

--- a/frappe/public/scss/desk/global_search.scss
+++ b/frappe/public/scss/desk/global_search.scss
@@ -394,6 +394,14 @@
 				margin-left: auto;
 				margin-right: auto;
 				line-height: 1.45;
+
+				.global-search-shortcut-key {
+					background-color: var(--border-color);
+					padding: 2px 4px;
+					border-radius: 4px;
+					font-size: x-small;
+					display: inline-block;
+				}
 			}
 		}
 

--- a/frappe/public/scss/desk/global_search.scss
+++ b/frappe/public/scss/desk/global_search.scss
@@ -123,8 +123,9 @@
 				.global-search-more-dropdown {
 					display: none;
 					position: absolute;
-					right: 0;
-					left: auto;
+					top: calc(100% + 4px);
+					left: 0;
+					right: auto;
 					min-width: 14rem;
 					max-width: min(24rem, 92vw);
 					max-height: 75vh;
@@ -134,6 +135,11 @@
 					border: 1px solid var(--border-color);
 					padding: var(--padding-xs);
 					z-index: 1070;
+
+					&.align-right {
+						left: auto;
+						right: 0;
+					}
 
 					&.menu-open {
 						display: block;

--- a/frappe/public/scss/desk/global_search.scss
+++ b/frappe/public/scss/desk/global_search.scss
@@ -13,6 +13,13 @@
 		.modal-actions {
 			z-index: 6;
 			top: 7px;
+			align-items: center;
+			gap: 2px;
+
+			.btn-open-global-search-settings {
+				/* Match minimize / close icon buttons */
+				flex-shrink: 0;
+			}
 		}
 
 		.search-input {
@@ -61,32 +68,6 @@
 			.global-search-doctype-filters {
 				flex-shrink: 0;
 				padding-bottom: var(--padding-lg);
-
-				.global-search-tip-with-settings {
-					@include flex(flex, space-between, center);
-					gap: var(--padding-sm);
-					width: 100%;
-					margin-bottom: var(--margin-xs);
-				}
-
-				.global-search-multi-term-tip {
-					font-size: var(--text-xs);
-					flex: 1 1 auto;
-					min-width: 0;
-					margin-bottom: 0;
-				}
-
-				button.btn-open-global-search-settings {
-					flex: 0 0 auto;
-					align-self: center;
-					width: auto;
-					height: var(--btn-height);
-					aspect-ratio: 1;
-					padding: 0;
-					display: inline-flex;
-					align-items: center;
-					justify-content: center;
-				}
 
 				.global-search-toolbar-row,
 				.global-search-filter-toolbar {
@@ -263,18 +244,47 @@
 			}
 
 			> .list-row-container:not(.global-search-list-header) {
+				display: flex;
+				flex-direction: column;
 				position: relative;
 				z-index: 0;
 				padding-inline: var(--padding-sm);
-				border-radius: var(--border-radius-md);
-				overflow: hidden;
-				border: 1px solid transparent;
+				border-radius: var(--border-radius);
+				overflow: visible;
 				background-color: transparent;
 				box-sizing: border-box;
 
+				/* Same as .list-row-container:hover in desk list.scss — background only, no outline */
 				&:hover {
-					border-color: var(--border-color);
 					background-color: var(--highlight-color);
+				}
+
+				/*
+				 * list.scss applies .list-row-container:focus .list-row { highlight }. tabindex made rows
+				 * focus on click so highlight stuck after mouse left. No tabindex on rows; this resets any
+				 * mouse-driven focus so highlight matches hover (keyboard still gets :focus-visible).
+				 */
+				&:focus:not(:focus-visible) {
+					outline: none;
+
+					> .level.list-row {
+						background-color: transparent;
+					}
+				}
+
+				> .level.list-row {
+					min-height: var(--list-row-height);
+					flex-shrink: 0;
+					padding: var(--padding-xs) 0;
+				}
+
+				/* Separator between rows only (like list rows); omit on single / last row */
+				&:not(:last-child) > .level.list-row {
+					border-bottom: 1px solid var(--border-color);
+				}
+
+				&:last-child > .level.list-row {
+					border-bottom: none;
 				}
 			}
 
@@ -287,6 +297,7 @@
 				border-radius: var(--border-radius-md);
 				overflow: hidden;
 				box-sizing: border-box;
+				margin-bottom: var(--margin-xs);
 
 				&:hover {
 					background-color: var(--highlight-color);
@@ -301,7 +312,7 @@
 			.global-search-level-left-multi.level-left {
 				flex: 1 1 auto !important;
 				min-width: 0 !important;
-				align-items: stretch;
+				align-items: flex-start;
 				flex-wrap: nowrap;
 				overflow: visible;
 				white-space: normal;
@@ -314,7 +325,8 @@
 				min-width: 0;
 				margin-right: var(--margin-sm);
 
-				> span {
+				/* Do not force .global-search-field-more-hint to block — it must stay inline with the 3rd value. */
+				> span:not(.global-search-field-more-hint) {
 					display: block;
 					min-width: 0;
 				}
@@ -332,6 +344,25 @@
 				a {
 					color: var(--primary);
 				}
+
+				&.global-search-field-col--multiline {
+					white-space: normal;
+					word-break: break-word;
+					overflow: visible;
+					text-overflow: clip;
+					line-height: 1.4;
+					align-self: flex-start;
+
+					br {
+						line-height: inherit;
+					}
+				}
+
+				.global-search-field-more-hint {
+					display: inline;
+					font-weight: var(--weight-regular);
+					font-style: italic;
+				}
 			}
 
 			.list-subject .level-item {
@@ -339,12 +370,6 @@
 				flex: 1 1 auto;
 				max-width: 100%;
 				overflow: hidden;
-			}
-
-			> .list-row-container:not(.global-search-list-header) .list-row {
-				min-height: var(--list-row-height);
-				flex-shrink: 0;
-				border-bottom: none;
 			}
 
 			a.global-search-name-link {
@@ -372,6 +397,15 @@
 				color: var(--text-color);
 				margin-top: var(--margin-lg);
 				font-size: var(--text-xl);
+			}
+
+			.global-search-empty-state-tip {
+				font-size: var(--text-xs);
+				margin-top: var(--margin-md);
+				max-width: 28rem;
+				margin-left: auto;
+				margin-right: auto;
+				line-height: 1.45;
 			}
 		}
 

--- a/frappe/public/scss/desk/index.scss
+++ b/frappe/public/scss/desk/index.scss
@@ -24,7 +24,6 @@
 @import "timeline";
 @import "avatar";
 @import "notification";
-@import "global_search";
 @import "desktop";
 @import "../common/awesomeplete";
 @import "main";
@@ -33,6 +32,7 @@
 @import "form_sidebar";
 @import "filters";
 @import "list";
+@import "global_search";
 @import "report";
 @import "file_view";
 @import "frappe_datatable";


### PR DESCRIPTION
The global search UI was pretty bad earlier. All results are shown in grids now with all searchable fields visible. 
The global search dialog can be opened using the keyboard shortcut "Command + G".

Before:


https://github.com/user-attachments/assets/a5f811d1-8112-46f0-ad8a-5b665b51c7e4

After:


https://github.com/user-attachments/assets/d28d8a39-386c-411c-b4e2-2a550f2664b3

`no-docs`

