### PR TITLE
feat: use Autocomplete for searching DocType fields

### DIFF
--- a/cypress/integration/query_report.js
+++ b/cypress/integration/query_report.js
@@ -39,8 +39,17 @@ context("Query Report", () => {
 					.click({ force: true });
 				cy.get_open_dialog().get(".modal-title").should("contain", "Add Column");
 				cy.get('select[data-fieldname="doctype"]').select("Role (Name)", { force: true });
-				cy.get('select[data-fieldname="field"]').select("Role Name", { force: true });
-				cy.get('select[data-fieldname="insert_after"]').select("Name", { force: true });
+				cy.wait(500);
+				cy.get_open_dialog()
+					.find('.control-input > .awesomplete > input[data-fieldname="field"]')
+					.should("be.visible")
+					.clear({ force: true })
+					.type("Role Name{enter}", { delay: 150, force: true });
+				cy.get_open_dialog()
+					.find('.control-input > .awesomplete > input[data-fieldname="insert_after"]')
+					.should("be.visible")
+					.clear({ force: true })
+					.type("Name{enter}", { delay: 150, force: true });
 				cy.get_open_dialog()
 					.findByRole("button", { name: "Submit" })
 					.click({ force: true });

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1113,6 +1113,10 @@ export default class Grid {
 		const field_options = Object.keys(field_mappings).sort((a, b) =>
 			__(cstr(field_mappings[a].label)).localeCompare(cstr(__(field_mappings[b].label)))
 		);
+		const field_autocomplete_options = field_options.map((key) => ({
+			label: __(cstr(field_mappings[key].label)),
+			value: key,
+		}));
 		const status_regex = /status/i;
 		const default_field =
 			field_options.find((value) => status_regex.test(value)) ||
@@ -1131,8 +1135,9 @@ export default class Grid {
 			}),
 			fields: [
 				{
-					fieldtype: "Select",
-					options: field_options,
+					fieldtype: "Autocomplete",
+					options: field_autocomplete_options,
+					max_items: Infinity,
 					default: default_field,
 					label: __("Field"),
 					fieldname: "field",

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -308,21 +308,30 @@ export default class BulkOperations {
 	}
 
 	edit(docnames, field_mappings, done) {
-		let field_options = Object.keys(field_mappings).sort(function (a, b) {
+		const field_options = Object.keys(field_mappings).sort(function (a, b) {
 			return __(cstr(field_mappings[a].label)).localeCompare(
 				cstr(__(field_mappings[b].label))
 			);
 		});
+		// Same strings as legacy Select (`options`: sorted mapping keys)—parent `Label (Doctype)`,
+		// child `Child Label (Table column)`, so labels stay distinguishable after Autocomplete swap.
+		const field_autocomplete_options = field_options.map((key) => ({
+			label: __(cstr(key)),
+			value: key,
+		}));
 		const status_regex = /status/i;
 
-		const default_field = field_options.find((value) => status_regex.test(value));
+		const default_field =
+			field_options.find((value) => status_regex.test(value)) ||
+			field_options.find((value) => field_mappings[value]?.fieldtype === "Select");
 
 		const dialog = new frappe.ui.Dialog({
 			title: __("Bulk Edit"),
 			fields: [
 				{
-					fieldtype: "Select",
-					options: field_options,
+					fieldtype: "Autocomplete",
+					options: field_autocomplete_options,
+					max_items: Infinity,
 					default: default_field,
 					label: __("Field"),
 					fieldname: "field",

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -2007,33 +2007,36 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 												value: df.fieldname,
 											}));
 
-										d.set_df_property(
-											"field",
-											"options",
-											options.sort(function (a, b) {
-												if (a.label < b.label) {
-													return -1;
-												}
-												if (a.label > b.label) {
-													return 1;
-												}
-												return 0;
-											})
-										);
+										options = options.sort(function (a, b) {
+											if (a.label < b.label) {
+												return -1;
+											}
+											if (a.label > b.label) {
+												return 1;
+											}
+											return 0;
+										});
+
+										d.set_df_property("field", "options", options);
+										d.get_field("field")?.set_data(options);
+										d.set_value("field", "");
 									});
 								},
 							},
 							{
-								fieldtype: "Select",
+								fieldtype: "Autocomplete",
 								label: __("Field"),
 								fieldname: "field",
 								options: [],
 							},
 							{
-								fieldtype: "Select",
+								fieldtype: "Autocomplete",
 								label: __("Insert After"),
 								fieldname: "insert_after",
-								options: this.columns.map((df) => df.label),
+								options: this.columns.map((col) => ({
+									label: col.name || col.label,
+									value: col.fieldname,
+								})),
 							},
 						],
 						primary_action: (values) => {
@@ -2042,7 +2045,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 							Object.assign(values, { doctype, fieldname });
 							let df = frappe.meta.get_docfield(values.doctype, values.field);
 							const insert_after_index = this.columns.findIndex(
-								(column) => column.label === values.insert_after
+								(column) => column.fieldname === values.insert_after
 							);
 
 							custom_columns.push({


### PR DESCRIPTION
Existing select field becomes too long for certain DocTypes and it's hard to search for a field there. Autocomplete solves this.


List View:
<img width="1510" height="859" alt="image" src="https://github.com/user-attachments/assets/6303cfd3-7291-448d-935c-5b2a9622b9f9" />

Child table bulk edit:
<img width="1508" height="858" alt="image" src="https://github.com/user-attachments/assets/303d24a6-fc91-4c83-b48d-612ffe2c74e8" />

Report Add Column:
<img width="1492" height="852" alt="image" src="https://github.com/user-attachments/assets/ac1517b6-203d-458f-bb82-98af60a2f17f" />

