### PR TITLE
fix: sidebar timestamps ignores `show absolute datetime in timeline` setting

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -164,7 +164,10 @@ frappe.ui.form.Sidebar = class {
 					__("Last Edited By {0}", [get_user_link(this.frm.doc.modified_by)])
 				) +
 					" <br> " +
-					comment_when(this.frm.doc.modified)
+					(cint(frappe.boot.user.show_absolute_datetime_in_timeline) ||
+					cint(frappe.boot.sysdefaults.show_absolute_datetime_in_timeline)
+						? frappe.datetime.str_to_user(this.frm.doc.modified)
+						: comment_when(this.frm.doc.modified))
 			);
 		this.sidebar
 			.find(".created-by")
@@ -175,7 +178,10 @@ frappe.ui.form.Sidebar = class {
 					__("Created By {0}", [get_user_link(this.frm.doc.owner)])
 				) +
 					" <br> " +
-					comment_when(this.frm.doc.creation)
+					(cint(frappe.boot.user.show_absolute_datetime_in_timeline) ||
+					cint(frappe.boot.sysdefaults.show_absolute_datetime_in_timeline)
+						? frappe.datetime.str_to_user(this.frm.doc.creation)
+						: comment_when(this.frm.doc.creation))
 			);
 	}
 


### PR DESCRIPTION
## Summary
The `"Show absolute datetime in timeline"` user/system setting is respected in the form timeline, but not in the sidebar’s **Last Edited** / **Created By** timestamps, which always render using `comment_when` (relative time).

As a result, toggling the setting switches the timeline between absolute and relative formats, while the sidebar continues showing relative timestamps, causing inconsistent timestamp styles within the same form.

`form_sidebar.js#refresh_creation_modified` now mirrors the logic used in `base_timeline.js`. This applies to both modified and creation timestamps.

## Before
https://github.com/user-attachments/assets/caddc601-6f02-4422-979c-d003f121f9b5

## After
https://github.com/user-attachments/assets/7b001bbf-ac66-4d66-a47b-831b853fa21c