### PR TITLE
fix: sidebar cleanup and grouping

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -66,14 +66,6 @@
 
 					</a>
 				</div>
-				<div class="sidebar-bottom-actions d-flex align-items-center justify-content-between mt-2" style="padding: 0;">
-					<button class="about-sidebar-link btn btn-ghost btn-xs">
-						{%= frappe.utils.icon("info" , "sm", "", "", "text-ink-gray-7 current-color", true)%}
-					</button>
-					<button class="collapse-sidebar-link btn btn-ghost btn-xs">
-						{%= frappe.utils.icon("panel-right-open" , "sm", "", "", "text-ink-gray-7 current-color", true)%}
-					</button>
-				</div>
 			</div>
 			<div class="sidebar-resize-handle"></div>
 		</div>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -350,10 +350,6 @@ frappe.ui.Sidebar = class Sidebar {
 			this.toggle_width();
 		});
 
-		this.wrapper.find(".body-sidebar .about-sidebar-link").on("click", () => {
-			frappe.ui.toolbar.show_about();
-		});
-
 		this.wrapper.find(".overlay").on("click", () => {
 			this.close();
 		});
@@ -443,7 +439,6 @@ frappe.ui.Sidebar = class Sidebar {
 	make_sidebar() {
 		this.empty();
 		this.wrapper.find(".collapse-sidebar-link").removeClass("hidden");
-		this.wrapper.find(".about-sidebar-link").removeClass("hidden");
 		if (this.editor.edit_mode) {
 			this.create_sidebar(this.editor.new_sidebar_items);
 		} else {
@@ -472,7 +467,6 @@ frappe.ui.Sidebar = class Sidebar {
 			);
 			this.wrapper.find(".sidebar-items").append(no_items_message);
 			this.wrapper.find(".collapse-sidebar-link").addClass("hidden");
-			this.wrapper.find(".about-sidebar-link").addClass("hidden");
 		}
 		if (this.edit_mode) {
 			$(".edit-menu").removeClass("hidden");
@@ -582,7 +576,6 @@ frappe.ui.Sidebar = class Sidebar {
 			direction = is_rtl ? "left" : "right";
 			$('[data-toggle="tooltip"]').tooltip("dispose");
 			this.wrapper.find(".avatar-name-email").show();
-			this.wrapper.find(".about-sidebar-link").show();
 			this.wrapper.find(".onboarding-sidebar span").show();
 		} else {
 			this.wrapper.removeClass("expanded");
@@ -593,7 +586,6 @@ frappe.ui.Sidebar = class Sidebar {
 				trigger: "hover",
 			});
 			this.wrapper.find(".avatar-name-email").hide();
-			this.wrapper.find(".about-sidebar-link").hide();
 			this.wrapper.find(".onboarding-sidebar span").hide();
 		}
 

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -57,6 +57,12 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 			let is_dark = frappe.ui.get_current_theme() === "dark";
 			this.dropdown_items.push(
 				{
+					name: "display",
+					label: "Display",
+					icon: "monitor",
+					items: this.get_display_siblings(is_dark),
+				},
+				{
 					label: "Session Defaults",
 					action: "frappe.ui.toolbar.setup_session_defaults()",
 					is_standard: 1,
@@ -70,18 +76,6 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 					action: "frappe.ui.toolbar.clear_cache()",
 					is_standard: 1,
 					icon: "rotate-ccw",
-				},
-				{
-					label: "Toggle Full Width",
-					action: "frappe.ui.toolbar.toggle_full_width()",
-					is_standard: 1,
-					icon: "maximize",
-				},
-				{
-					label: "Toggle Theme",
-					action: "new frappe.ui.ThemeSwitcher().show()",
-					is_standard: 1,
-					icon: is_dark ? "sun" : "moon",
 				},
 				{
 					name: "help",
@@ -230,6 +224,36 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 		});
 
 		return help_dropdown_items;
+	}
+
+	get_display_siblings(is_dark) {
+		const sidebar = this.sidebar;
+		return [
+			{
+				name: "toggle-theme",
+				label: __("Toggle Theme"),
+				icon: is_dark ? "sun" : "moon",
+				onClick: function () {
+					new frappe.ui.ThemeSwitcher().show();
+				},
+			},
+			{
+				name: "toggle-full-width",
+				label: __("Toggle Full Width"),
+				icon: "maximize",
+				onClick: function () {
+					frappe.ui.toolbar.toggle_full_width();
+				},
+			},
+			{
+				name: "toggle-sidebar",
+				label: __("Toggle Sidebar"),
+				icon: "panel-right-open",
+				onClick: function () {
+					sidebar.toggle_width();
+				},
+			},
+		];
 	}
 
 	get_custom_help_links() {


### PR DESCRIPTION
The two icon buttons at the bottom of the sidebar looked out of the place. The menu below also had multiple display settings separately instead of being in a group

Before:
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/f8116f98-4e94-42bf-b357-3c6fc426e8ce" />

After:
<img width="2940" height="1672" alt="image" src="https://github.com/user-attachments/assets/c81507fa-122a-4f07-afe6-da498d851ca4" />

Removed the two icon button from the bottom.

Grouped Toggle Full Theme, Toggle Width and Toggle Theme into Display.

Closes #39168 

