### PR TITLE
fix(tabs): remove jitter while navigating via forms

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -545,10 +545,10 @@
 	margin-top: var(--margin-sm);
 }
 .form-tabs-sticky-up {
-	top: calc(var(--navbar-height) - 1px);
+	top: calc(var(--navbar-height));
 }
 .form-tabs-sticky-down {
-	top: calc(var(--navbar-height) - 2px);
+	top: calc(var(--navbar-height));
 	&.show-navbar {
 		top: calc(var(--navbar-height) + var(--page-head-height) - 1px);
 	}


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/717e9400-f781-452b-9614-3a930d2db227

Notice the squished tabs while scrolling down


After

https://github.com/user-attachments/assets/d409df08-26a0-4257-a5bc-3eb5500807a7

The switching between tabs is now smoother than before

