### PR TITLE
fix: remove Awesomebar help modal

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -53,7 +53,6 @@ frappe.search.AwesomeBar = class AwesomeBar {
 					<span>${__("to close")}</span>
 				</span>
 			</div>
-			<div class="pointer">${frappe.utils.icon("circle-question-mark")}</div>
 		</div>`;
 
 		search_modal.find(".modal-body").css("padding", "0").html(search_modal_body);
@@ -63,9 +62,6 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			.removeClass("hide")
 			.addClass("cool-awesomebar-modal-footer")
 			.html(search_modal_footer);
-		search_modal.find(".pointer").on("click", () => {
-			this.show_help();
-		});
 
 		$search_element.on("click", () => {
 			if ($(search_modal).hasClass("show")) {
@@ -220,23 +216,6 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			if (e.key == "Escape") {
 				$input.trigger("blur");
 			}
-		});
-	}
-
-	show_help() {
-		const help_data = [
-			[__("Create a new record"), __("new type of document")],
-			[__("List a document type"), __("document type — e.g. Customer")],
-			[__("Search in a document type"), __("text within a document type")],
-			[__("Tags"), __("tag name — e.g. #tag")],
-			[__("Open a module or tool"), __("module name")],
-			[__("Open in new tab"), frappe.utils.is_mac() ? "⌘ + Enter" : "Ctrl + Enter"],
-			[__("Calculate"), __("e.g. (55 + 434) / 4")],
-		];
-		frappe.msgprint({
-			message: help_data,
-			title: __("Search Help"),
-			as_table: true,
 		});
 	}
 

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -226,10 +226,10 @@ frappe.search.AwesomeBar = class AwesomeBar {
 	show_help() {
 		const help_data = [
 			[__("Create a new record"), __("new type of document")],
-			[__("List a document type"), __("document type..., e.g. customer")],
-			[__("Search in a document type"), __("text in document type")],
-			[__("Tags"), __("tag name..., e.g. #tag")],
-			[__("Open a module or tool"), __("module name...")],
+			[__("List a document type"), __("document type — e.g. Customer")],
+			[__("Search in a document type"), __("text within a document type")],
+			[__("Tags"), __("tag name — e.g. #tag")],
+			[__("Open a module or tool"), __("module name")],
 			[__("Open in new tab"), frappe.utils.is_mac() ? "⌘ + Enter" : "Ctrl + Enter"],
 			[__("Calculate"), __("e.g. (55 + 434) / 4")],
 		];


### PR DESCRIPTION
Removed the unwanted table help modal from the Awesome Bar.