### PR TITLE
fix: remove orphan entites before creating new assets

### DIFF
--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -200,8 +200,8 @@ def remove_orphan_doctypes():
 	print()
 
 
-def remove_orphan_entities():
-	entites = ["Workspace", "Dashboard", "Page", "Report", "Notification"]
+def remove_orphan_entities(entity_types=None):
+	entities = ["Workspace", "Dashboard", "Page", "Report", "Notification"]
 	app_level_entities = ["Workspace Sidebar", "Desktop Icon"]
 	entity_filter_map = {
 		"Workspace": [{"public": 1, "module": ["is", "set"], "app": ["is", "set"]}],
@@ -212,9 +212,14 @@ def remove_orphan_entities():
 		"Desktop Icon": {"standard": True},
 		"Notification": {"is_standard": True},
 	}
-	entity_file_map = create_entity_file_map(entites)
+	entity_file_map = create_entity_file_map(entities)
+	if entity_types:
+		if isinstance(entity_types, list):
+			entities = entity_types
+		else:
+			entities = [entity_types]
 
-	for entity in entites:
+	for entity in entities:
 		print(f"Removing orphan {entity}s")
 		all_enitities = frappe.get_all(
 			entity, filters=entity_filter_map.get(entity), fields=["name", "module"]
@@ -235,6 +240,8 @@ def remove_orphan_entities():
 		# save the deleted icons
 		frappe.db.commit()  # nosemgrep
 	#  Remove app level entities
+	if entity_types and not set(entity_types).issubset(set(app_level_entities)):
+		return
 	for app_entity in app_level_entities:
 		print(f"Removing orphan {app_entity}s")
 		all_enitities = frappe.get_all(

--- a/frappe/patches/v16_0/auto_generate_desktop_icon_and_sidebar.py
+++ b/frappe/patches/v16_0/auto_generate_desktop_icon_and_sidebar.py
@@ -4,5 +4,5 @@ from frappe.utils.install import auto_generate_icons_and_sidebar
 
 def execute():
 	"""Auto Create desktop icons and workspace sidebars."""
-	remove_orphan_entities()
+	remove_orphan_entities("Workspace")
 	auto_generate_icons_and_sidebar()

--- a/frappe/patches/v16_0/auto_generate_desktop_icon_and_sidebar.py
+++ b/frappe/patches/v16_0/auto_generate_desktop_icon_and_sidebar.py
@@ -1,6 +1,8 @@
+from frappe.model.sync import remove_orphan_entities
 from frappe.utils.install import auto_generate_icons_and_sidebar
 
 
 def execute():
 	"""Auto Create desktop icons and workspace sidebars."""
+	remove_orphan_entities()
 	auto_generate_icons_and_sidebar()


### PR DESCRIPTION
When a site is being migrated from v15 to v16. Old workspaces like Accounting still remain and assets as in (Desktop Icon and Workspace Sidebar) are created for orphan entities. This causes issues and creates orphan workspace sidebar and breaks Account screen 
