### PR TITLE
fix(formatters): escape Text fields in formatter

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -119,7 +119,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 	{%- if df.fieldtype=="Code" %}
 		<pre class="value">{{ doc.get(df.fieldname)|e }}</pre>
 	{%- elif df.fieldtype in ("Text", "Long Text") -%}
-		{{ doc.get_formatted(df.fieldname, parent_doc or doc, translated=df.translatable)|e }}
+		{{ doc.get_formatted(df.fieldname, parent_doc or doc, translated=df.translatable) }}
 	{%- else -%}
 		{{ doc.get_formatted(df.fieldname, parent_doc or doc, translated=df.translatable) }}
 	{%- endif -%}
@@ -173,7 +173,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 		{{ doc.get_formatted(df.fieldname, parent, translated=df.translatable, absolute_value=parent.absolute_value) |e }}
 	{% elif df.fieldtype in ("Text", "Long Text") %}
 		{%- set parent = parent_doc or doc -%}
-		{{ doc.get_formatted(df.fieldname, parent, translated=df.translatable, absolute_value=parent.absolute_value) |e }}
+		{{ doc.get_formatted(df.fieldname, parent, translated=df.translatable, absolute_value=parent.absolute_value) }}
 	{% else %}
 		{%- set parent = parent_doc or doc -%}
 		{{ doc.get_formatted(df.fieldname, parent, translated=df.translatable, absolute_value=parent.absolute_value) }}

--- a/frappe/utils/formatters.py
+++ b/frappe/utils/formatters.py
@@ -97,9 +97,10 @@ def format_value(value, df=None, doc=None, currency=None, translated=False, form
 	elif df.get("fieldtype") == "Percent":
 		return f"{flt(value, 2)}%"
 
-	elif df.get("fieldtype") in ("Text", "Small Text"):
+	elif df.get("fieldtype") in ("Text", "Small Text", "Long Text"):
 		if not BLOCK_TAGS_PATTERN.search(value):
-			return frappe.safe_decode(value).replace("\n", "<br>")
+			escaped_value = frappe.utils.escape_html(frappe.safe_decode(value))
+			return escaped_value.replace("\n", "<br>")
 
 	elif df.get("fieldtype") == "Markdown Editor":
 		return frappe.utils.markdown(value)


### PR DESCRIPTION
 ## Summary

  `Text` / `Small Text` / `Long Text` fields rendered through the standard print format showed literal `<br>` text instead of line breaks.

### Before Fix
[Screencast from 2026-05-12 11-15-13.webm](https://github.com/user-attachments/assets/19d6adb0-e913-43f2-b390-8e87e79d75bd)

### After Fix
[Screencast from 2026-05-12 11-16-44.webm](https://github.com/user-attachments/assets/5bfa4ce6-600a-4985-aa72-4842b3028239)

**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/67655](https://support.frappe.io/helpdesk/tickets/67655)