### PR TITLE
fix: append existing link filters instead of overwriting

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -853,9 +853,9 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		let filters = this.parse_filters(JSON.parse(this.df.link_filters));
 		// take filters from the link field and add to the query
 
-		const existing_filters = this.get_query?.()?.filters || {};
-		if (existing_filters) {
-			filters = { ...filters, ...existing_filters };
+		const query_filters = this.get_query?.()?.filters || {};
+		if (query_filters) {
+			filters = { ...filters, ...query_filters };
 		}
 
 		this.get_query = function () {

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -850,9 +850,14 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 	}
 
 	apply_link_field_filters() {
-		let link_filters = JSON.parse(this.df.link_filters);
-		let filters = this.parse_filters(link_filters);
+		let filters = this.parse_filters(JSON.parse(this.df.link_filters));
 		// take filters from the link field and add to the query
+
+		const existing_filters = this.get_query?.()?.filters || {};
+		if (existing_filters) {
+			filters = { ...filters, ...existing_filters };
+		}
+
 		this.get_query = function () {
 			return {
 				filters,


### PR DESCRIPTION
if you set link filters through the DocType and then use `frm.set_query` in the js controller of the DocType, the js config is ignored and only the link filters set in the DocType config is applied