### PR TITLE
fix: dont make button primary

### DIFF
--- a/frappe/desk/doctype/event/event.js
+++ b/frappe/desk/doctype/event/event.js
@@ -32,8 +32,6 @@ frappe.ui.form.on("Event", {
 			});
 		}
 
-		frm.page.set_inner_btn_group_as_primary(__("Add Participants"));
-
 		frm.add_custom_button(
 			__("Add Contacts"),
 			function () {


### PR DESCRIPTION
This keeps only one primary button on the event form. This form was doing the cardinal sin of having 2 primary buttons.

Before
<img width="1440" height="900" alt="Screenshot 2026-05-12 at 1 03 33 PM" src="https://github.com/user-attachments/assets/321e4d49-e398-4758-bf13-270ae24185a6" />


After

<img width="1440" height="900" alt="Screenshot 2026-05-12 at 1 02 44 PM" src="https://github.com/user-attachments/assets/83fc9298-82f7-4fb0-867e-82ad82005b3b" />
