### PR TITLE
fix: cast `Read Only` field values to string in `get_valid_dict`

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -590,6 +590,9 @@ class BaseDocument:
 				elif fieldtype in float_like_fields and not isinstance(value, float):
 					value = flt(value)
 
+				elif fieldtype == "Read Only" and not isinstance(value, str):
+					value = cstr(value)
+
 				elif (fieldtype in datetime_fields and value == "") or (
 					getattr(df, "unique", False) and cstr(value).strip() == ""
 				):


### PR DESCRIPTION
Resolve: #39189

---

**Problem**

`_validate_update_after_submit` was throwing a false "Not allowed to change after submission" error for `Read Only` fields holding numeric values (e.g. `quantity_difference`) in Stock Reconciliation Doctype

The root cause is a type mismatch: `self.get_value()` returns the value as `int`, while `frappe.get_doc().as_dict()` ,`get_valid_dict()` returns it as `str`.

**Debugging log (before fix):**
```
self_value=10  db_value=10  type(self_value)=<class 'int'>  type(db_value)=<class 'str'>
 10 != "10"  throws UpdateAfterSubmitError 
```

https://github.com/user-attachments/assets/03e5751d-ef42-44d7-9607-f5df162ba939



**Fix**

Added type normalization for `Read Only` fields in `get_valid_dict`:

```python
elif fieldtype == "Read Only" and not isinstance(value, str):
    value = cstr(value)
```

**After fix:**
```python
self_value=10  db_value=10  type(self_value)=<class 'str'>  type(db_value)=<class 'str'>
"10" == "10" # no error 
```

https://github.com/user-attachments/assets/f0cc2ade-ef15-4a96-9ebb-640aade945b5




`no-docs`