### PR TITLE
fix: compute desktop layout on the fly

### DIFF
--- a/frappe/desk/doctype/desktop_layout/desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.py
@@ -66,7 +66,40 @@ def get_layout():
 	try:
 		doc = frappe.get_doc("Desktop Layout", frappe.session.user)
 		if doc.layout:
-			return json.loads(doc.layout)
+			layout = json.loads(doc.layout)
+			latest_icons = frappe.get_all("Desktop Icon", fields="*")
+
+			def key(i):
+				return i.get("label") or None
+
+			latest_map = {key(i): i for i in latest_icons}
+
+			def merge_icon(item):
+				k = key(item)
+				latest = latest_map.get(k)
+				# preserve layout-specific fields
+				layout_idx = item.get("idx")
+				layout_parent = item.get("parent_icon", None)
+				layout_hidden = item.get("hidden", None)
+
+				if latest:
+					if item.get("icon_type") != latest.get("icon_type"):
+						if latest.get("icon_type") == "Folder":
+							latest["icon_image"] = None
+					item.update(latest)
+				# restore layout-specific values if present
+				if layout_idx is not None:
+					item["idx"] = layout_idx
+				if layout_hidden:
+					item["hidden"] = item.get("hidden")
+				item["parent_icon"] = layout_parent
+
+				if item.get("child_icons"):
+					item["child_icons"] = [merge_icon(c) for c in item["child_icons"]]
+				return item
+
+			layout = [merge_icon(i) for i in layout]
+		return layout
 	except frappe.DoesNotExistError:
 		frappe.clear_last_message()
 	return None

--- a/frappe/desk/doctype/desktop_layout/desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.py
@@ -65,41 +65,82 @@ def get_layout():
 	"""Return the current user's saved desktop layout. Used on desk load to avoid stale cached HTML."""
 	try:
 		doc = frappe.get_doc("Desktop Layout", frappe.session.user)
-		if doc.layout:
-			layout = json.loads(doc.layout)
-			latest_icons = frappe.get_all("Desktop Icon", fields="*")
+		if not doc.layout:
+			return None
 
-			def key(i):
-				return i.get("label") or None
+		layout = json.loads(doc.layout)
+		latest_icons = frappe.get_all("Desktop Icon", fields="*")
 
-			latest_map = {key(i): i for i in latest_icons}
+		def key(i):
+			return i.get("label") or None
 
-			def merge_icon(item):
+		latest_map = {key(i): i for i in latest_icons}
+
+		name_map = {i.get("name"): i for i in latest_icons if i.get("name")}
+
+		def merge_icon(item):
+			k = key(item)
+			latest = latest_map.get(k) or name_map.get(item.get("name"))
+			# preserve layout-specific fields
+			layout_idx = item.get("idx")
+			layout_parent = item.get("parent_icon", None)
+			layout_hidden = item.get("hidden", None)
+
+			if latest:
+				if item.get("icon_type") != latest.get("icon_type"):
+					if latest.get("icon_type") == "Folder":
+						latest["icon_image"] = None
+				item.update(latest)
+			# restore layout-specific values if present
+			if layout_idx is not None:
+				item["idx"] = layout_idx
+			if layout_hidden is not None:
+				item["hidden"] = layout_hidden
+			item["parent_icon"] = layout_parent
+
+			if item.get("child_icons"):
+				item["child_icons"] = [merge_icon(c) for c in item["child_icons"]]
+			return item
+
+		layout = [merge_icon(i) for i in layout]
+
+		def collect_labels(items):
+			labels = set()
+			for item in items:
 				k = key(item)
-				latest = latest_map.get(k)
-				# preserve layout-specific fields
-				layout_idx = item.get("idx")
-				layout_parent = item.get("parent_icon", None)
-				layout_hidden = item.get("hidden", None)
-
-				if latest:
-					if item.get("icon_type") != latest.get("icon_type"):
-						if latest.get("icon_type") == "Folder":
-							latest["icon_image"] = None
-					item.update(latest)
-				# restore layout-specific values if present
-				if layout_idx is not None:
-					item["idx"] = layout_idx
-				if layout_hidden:
-					item["hidden"] = item.get("hidden")
-				item["parent_icon"] = layout_parent
-
+				if k:
+					labels.add(k)
 				if item.get("child_icons"):
-					item["child_icons"] = [merge_icon(c) for c in item["child_icons"]]
-				return item
+					labels.update(collect_labels(item["child_icons"]))
+			return labels
 
-			layout = [merge_icon(i) for i in layout]
-		return layout
+		_icon_fields = [
+			"label",
+			"bg_color",
+			"link",
+			"link_type",
+			"app",
+			"icon_type",
+			"parent_icon",
+			"icon",
+			"link_to",
+			"idx",
+			"standard",
+			"logo_url",
+			"hidden",
+			"name",
+			"restrict_removal",
+			"icon_image",
+		]
+
+		saved_labels = collect_labels(layout)
+		new_icons = [
+			{f: i.get(f) for f in _icon_fields}
+			for k, i in latest_map.items()
+			if k and k not in saved_labels and not i.get("parent_icon")
+		]
+
+		return layout + new_icons
 	except frappe.DoesNotExistError:
 		frappe.clear_last_message()
 	return None

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -273,6 +273,8 @@
     & .icons{
         gap: 2.1px;
         margin-top: 0px;
+        grid-template-columns: repeat(2, 1fr);
+        grid-template-rows: repeat(2, 1fr);
         & .desktop-icon {
             width: fit-content;
             height: fit-content;

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -801,28 +801,35 @@ class DesktopIconGrid {
 				},
 				onEnd: function (evt) {
 					if (frappe.desktop_utils.in_folder_creation) return;
-					if (evt.oldIndex !== evt.newIndex) {
-						if (evt.to.parentElement == evt.from.parentElement) {
+					const is_same_container = evt.to.parentElement == evt.from.parentElement;
+					if (is_same_container) {
+						if (evt.oldIndex !== evt.newIndex) {
 							let reordered_icons = me.sortable.toArray();
 							let filters = {
 								parent_icon: me.parent_icon?.icon_data.label || "" || null,
 							};
 							me.reorder_icons(reordered_icons, filters);
 							me.parent_icon?.render_folder_thumbnail();
-						} else {
-							let from = $(evt.from.parentElement);
-							let to = $(evt.to.parentElement);
-							let title = $(evt.item).find(".icon-title").text();
-							let selected_icon = get_desktop_icon_by_label(title);
-							if ($(to.get(0).parentElement)) {
-								me.reorder_icons(me.sortable.toArray());
-								me.reorder_icons(
-									frappe.pages[
-										"desktop"
-									].desktop_page.icon_grid.sortable.toArray()
-								);
-								selected_icon.idx = evt.newIndex;
-								selected_icon.parent_icon = null;
+						}
+					} else {
+						let title = $(evt.item).find(".icon-title").text();
+						let selected_icon = get_desktop_icon_by_label(title);
+						let to = $(evt.to.parentElement);
+						if ($(to.get(0).parentElement)) {
+							me.reorder_icons(me.sortable.toArray());
+							me.reorder_icons(
+								frappe.pages["desktop"].desktop_page.icon_grid.sortable.toArray()
+							);
+							selected_icon.idx = evt.newIndex;
+							selected_icon.parent_icon = null;
+
+							if (me.parent_icon) {
+								me.parent_icon.icon_data.child_icons =
+									me.parent_icon.icon_data.child_icons.filter(
+										(c) => c.label !== title
+									);
+								me.parent_icon.child_icons = me.parent_icon.get_child_icons_data();
+								me.parent_icon.render_folder_thumbnail();
 							}
 						}
 					}
@@ -1072,20 +1079,16 @@ class DesktopIcon {
 	}
 
 	render_folder_thumbnail() {
-		if (this.icon_type == "Folder") {
-			if (!this.folder_wrapper) this.folder_wrapper = this.icon.find(".icon-container");
-			this.folder_wrapper.html("");
-			this.folder_grid = new DesktopIconGrid({
-				wrapper: this.folder_wrapper,
-				icons_data: this.child_icons,
-				in_folder: true,
-				in_modal: false,
-				no_dragging: true,
-			});
-			if (this.icon_type == "App") {
-				this.folder_wrapper.addClass("folder-icon");
-			}
-		}
+		if (this.icon_type != "Folder") return;
+		if (!this.folder_wrapper) this.folder_wrapper = this.icon.find(".icon-container");
+		this.folder_wrapper.html("");
+		this.folder_grid = new DesktopIconGrid({
+			wrapper: this.folder_wrapper,
+			icons_data: this.child_icons.slice(0, 4),
+			row_size: 2,
+			in_folder: true,
+			no_dragging: true,
+		});
 	}
 
 	setup_dragging() {


### PR DESCRIPTION
Desktop Layout right now is a static thing and get "updates". This PR should make sure the following things

- [x] Syncs latest updates for the icons present in layout
- [ ]  If a new icon is added we should show that
- [ ] Cache it user wise like boot


Closes https://github.com/frappe/frappe/issues/39205, https://github.com/frappe/frappe/issues/37461