### PR TITLE
revert: changes to dead path in file uploader

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -245,8 +245,8 @@ class File(Document):
 		if self.is_remote_file or not self.file_url:
 			return
 
-		if not self.file_url.startswith(("/files/", "/private/files/", "/api/method/")):
-			# Probably an invalid URL since it doesn't start with http and isn't an internal URL either
+		if not self.file_url.startswith(("/files/", "/private/files/")):
+			# Probably an invalid URL since it doesn't start with http either
 			frappe.throw(
 				_("URL must start with http:// or https://"),
 				title=_("Invalid URL"),


### PR DESCRIPTION
Reverts inconsequential but potentially confusing changes introduced in #33995

`self.is_remote_file` is `True` when `self.file_url.startswith("/api/method")`, so this code is never reached.