### PR TITLE
fix(document_follow): fix doc. follow state on refresh

### DIFF
--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -17,10 +17,12 @@ if TYPE_CHECKING:
 
 @frappe.whitelist()
 def update_follow(doctype: str, doc_name: str, following: bool):
+	following = frappe.utils.sbool(following)
 	if following:
 		return (follow_document(doctype, doc_name, frappe.session.user) and True) or False
 	else:
-		return unfollow_document(doctype, doc_name, frappe.session.user)
+		unfollow_document(doctype, doc_name, frappe.session.user)
+		return False
 
 
 @frappe.whitelist()
@@ -89,7 +91,7 @@ def unfollow_document(doctype: str, doc_name: str, user: str) -> bool:
 	if doc:
 		frappe.delete_doc("Document Follow", doc[0].name, force=True)
 		frappe.toast(_("Un-following document {0}").format(doc_name))
-		return False
+		return True
 	return False
 
 

--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -16,10 +16,11 @@ if TYPE_CHECKING:
 
 
 @frappe.whitelist()
-def update_follow(doctype: str, doc_name: str, following: bool):
+def update_follow(doctype: str, doc_name: str, following: bool | str):
 	following = frappe.utils.sbool(following)
 	if following:
-		return (follow_document(doctype, doc_name, frappe.session.user) and True) or False
+		is_following = follow_document(doctype, doc_name, frappe.session.user)
+		return bool(is_following)
 	else:
 		unfollow_document(doctype, doc_name, frappe.session.user)
 		return False

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -945,7 +945,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 	}
 
 	get_follow_text(follow) {
-		if (follow === null) {
+		if (follow == null) {
 			follow = this.frm.get_docinfo().is_document_followed;
 		}
 		return follow ? __("Unfollow") : __("Follow");


### PR DESCRIPTION
Raising PR on behalf of @wreckage0907

Re-raised since I can't push commits to wreckage's branch... (#39222)

> steps to reproduce issue

1. Enable Document Follow for a user (User > Document Follow Notifications).
2. Open any DocType that has Track Changes enabled.
3. Click the ellipsis (⋯) menu and click Follow. The menu item changes to Unfollow .
4. do a hard refresh (cmd + shift + R)
5. Click the ellipsis (⋯) menu and see


**Before**:

Follow state lost after hard refresh — after a hard refresh (Cmd+Shift+R / Ctrl+Shift+R), the ellipsis menu always shows "Follow" even when the user is already following the document. This makes it impossible to unfollow from the menu after a hard refresh.


https://github.com/user-attachments/assets/b5372fa1-74cf-4621-9397-d41655c97134


**After**:


https://github.com/user-attachments/assets/370cdd57-8f9f-4021-9eea-2cfa1edef69b

closes https://github.com/frappe/frappe/issues/39100