### PR TITLE
Revert "fix(postgres): Explicitly grant all perms. on schema to user in setup (backport #39150)"

### DIFF
--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -24,24 +24,6 @@ def setup_database():
 			root_conn.sql(f'ALTER DATABASE "{frappe.conf.db_name}" OWNER TO "{frappe.conf.db_name}"')
 	root_conn.close()
 
-	# On Azure Managed PostgreSQL the public schema is owned by the azure_pg_admin role.
-	# Because the schema owner is hard-coded to be azure_pg_admin by Azure,
-	# changing the database owner no longer changes the schema owner (cascade).
-	db_conn = frappe.database.get_db(
-		socket=frappe.conf.db_socket,
-		host=frappe.conf.db_host,
-		port=frappe.conf.db_port,
-		user=frappe.flags.root_login,
-		password=frappe.flags.root_password,
-		cur_db_name=frappe.conf.db_name,  # Connect to the new database to grant permissions on the public schema
-	)
-	try:
-		db_conn.commit()
-		db_conn.sql("end")
-		db_conn.sql(f'GRANT ALL ON SCHEMA {db_conn.db_schema} TO "{frappe.conf.db_user}"')
-	finally:
-		db_conn.close()
-
 
 def bootstrap_database(verbose, source_sql=None):
 	frappe.connect()


### PR DESCRIPTION
Reverts frappe/frappe#39152

Quite a few breakages in v15 wrt PostgreSQL, avoiding any hotfixes to v15 (hotfixes will be done only on v16 & develop for now, since this is experimental).
closes #39251
