### PR TITLE
fix: Use valid column details for building report

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -374,28 +374,55 @@ class Report(Document):
 		return order_by, group_by, group_by_args
 
 	def build_standard_report_columns(self, columns, group_by_args):
-		_columns = []
+		from frappe.model.meta import get_default_df
+
+		report_columns = []
 
 		for fieldname, doctype in columns:
 			meta = frappe.get_meta(doctype)
 
-			if meta.get_field(fieldname):
-				field = meta.get_field(fieldname)
+			meta_df = meta.get_field(fieldname)
+			df = meta_df or get_default_df(fieldname)
+
+			if df:
+				column = frappe._dict(
+					{
+						"fieldname": df.fieldname,
+						"label": _(df.label or "") if meta_df else meta.get_label(df.fieldname),
+						"fieldtype": df.fieldtype,
+						"options": df.options,
+						"translatable": df.translatable or False,
+						"hidden": df.hidden or False,
+					}
+				)
+
+				if (
+					column.fieldtype == "Link"
+					and column.options
+					and frappe.get_meta(column.options).translated_doctype
+				):
+					column.translatable = True
 			else:
-				if fieldname == "_aggregate_column":
-					label = get_group_by_column_label(group_by_args, meta)
-				else:
-					label = meta.get_label(fieldname)
+				label = (
+					get_group_by_column_label(group_by_args, meta)
+					if fieldname == "_aggregate_column"
+					else meta.get_label(fieldname)
+				)
 
-				field = frappe._dict(fieldname=fieldname, label=label)
+				column = frappe._dict(
+					{
+						"fieldname": fieldname,
+						"label": label,
+						"fieldtype": "Link" if fieldname == "name" else "Data",
+						"options": doctype if fieldname == "name" else None,
+						"translatable": False,
+						"hidden": False,
+					}
+				)
 
-				# since name is the primary key for a document, it will always be a Link datatype
-				if fieldname == "name":
-					field.fieldtype = "Link"
-					field.options = doctype
+			report_columns.append(column)
 
-			_columns.append(field)
-		return _columns
+		return report_columns
 
 	def build_data_dict(self, result, columns):
 		data = []

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -381,27 +381,13 @@ class Report(Document):
 		for fieldname, doctype in columns:
 			meta = frappe.get_meta(doctype)
 
-			meta_df = meta.get_field(fieldname)
-			df = meta_df or get_default_df(fieldname)
+			if meta_df := meta.get_field(fieldname):
+				column = meta_df.as_dict()
+			elif default_df := get_default_df(fieldname):
+				column = default_df.copy()
 
-			if df:
-				column = frappe._dict(
-					{
-						"fieldname": df.fieldname,
-						"label": _(df.label or "") if meta_df else meta.get_label(df.fieldname),
-						"fieldtype": df.fieldtype,
-						"options": df.options,
-						"translatable": df.translatable or False,
-						"hidden": df.hidden or False,
-					}
-				)
-
-				if (
-					column.fieldtype == "Link"
-					and column.options
-					and frappe.get_meta(column.options).translated_doctype
-				):
-					column.translatable = True
+				if not column.get("label"):
+					column.label = meta.get_label(fieldname)
 			else:
 				label = (
 					get_group_by_column_label(group_by_args, meta)
@@ -415,8 +401,6 @@ class Report(Document):
 						"label": label,
 						"fieldtype": "Link" if fieldname == "name" else "Data",
 						"options": doctype if fieldname == "name" else None,
-						"translatable": False,
-						"hidden": False,
 					}
 				)
 

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -109,8 +109,9 @@ class XLSXStyleBuilder:
 		self.metadata = metadata
 
 		# column fieldname -> index mapping
+		# !NOTE: use .get() — columns may be DocField objects
 		self.field_index_map = {
-			col["fieldname"]: idx for idx, col in self.metadata.column_map.items() if col.get("fieldname")
+			col.get("fieldname"): idx for idx, col in self.metadata.column_map.items() if col.get("fieldname")
 		}
 
 		self.styles: list[dict] = []


### PR DESCRIPTION
- Closes: https://github.com/frappe/frappe/issues/39233

## Fixes

### 1. Fix the actual issue

- Use `.get()` instead of `[ ]` while creating `index_dict` for columns, because a column can be a `DocField` object when called via an external API.

### 2. Standardize report column objects

- While building standard report columns, ensure all columns are converted to `frappe._dict` instead of having a mix of `dict` and `DocField` objects.

### 3. Add fieldtypes for default fields

- Add `fieldtype` for default fields like `creation`, `modified`, etc. Without a `fieldtype`, Excel export formatting is not applied correctly.

> [!NOTE]
> Backport to V-16