### PR TITLE
fix: skip self-follow on User doc in add_docshare

### DIFF
--- a/frappe/share.py
+++ b/frappe/share.py
@@ -82,7 +82,9 @@ def add_docshare(
 	doc.save(ignore_permissions=True)
 	notify_assignment(user, doctype, name, everyone, notify=notify)
 
-	if frappe.get_cached_value("User", user, "follow_shared_documents"):
+	if (user != name or doctype != "User") and frappe.get_cached_value(
+		"User", user, "follow_shared_documents"
+	):
 		follow_document(doctype, name, user)
 
 	return doc


### PR DESCRIPTION
## Problem
 Password reset throws `403 PermissionError: You can only follow documents for yourself.` for any user with `follow_shared_documents = 1`. The password update transaction rolls back, leaving the user stuck on `/update-password`. 
  
## Root cause
Flow during `update_password`:

1. `update_password` → `reset_user_data(user)`
2. `reset_user_data` → `user_doc.save(ignore_permissions=True)`
3. Save fires `User.on_update` → `share_with_self()`
4. `share_with_self` → `frappe.share.add_docshare("User", self.name, self.name, ...)`
5. `add_docshare` → `if follow_shared_documents: follow_document("User", name, user)`
6. `follow_document` checks `user != frappe.session.user` - session is still `Guest`; 
`login_manager.login_as(user)` runs after `reset_user_data`. Guest has no `Document Follow` write perm → **throws**.

The perm check in `follow_document` was added by #38942 to prevent cross-user follow injection. It cannot be relaxed.

## Fix
In `add_docshare`, skip the auto-follow when the share is a User doc shared with itself. Self-following one's own User document creates no useful sense.

### Before Fix
[Screencast from 2026-05-14 10-23-57.webm](https://github.com/user-attachments/assets/9f5f9b06-965a-4788-857f-9c88613071b9)

### After Fix
<img width="2879" height="1661" alt="image" src="https://github.com/user-attachments/assets/e1751240-b0e4-492e-89c8-1e0e8b622ab9" />

**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/68100](https://support.frappe.io/helpdesk/tickets/68100)