### PR TITLE
fix: guard against empty image_field in get_preview_data

### DIFF
--- a/frappe/desk/link_preview.py
+++ b/frappe/desk/link_preview.py
@@ -28,7 +28,8 @@ def get_preview_data(doctype: str, docname: str | int):
 	image_field = meta.image_field
 
 	preview_fields.append(title_field)
-	preview_fields.append(image_field)
+	if image_field:
+		preview_fields.append(image_field)
 	preview_fields.append("name")
 
 	preview_data = frappe.get_list(doctype, filters={"name": docname}, fields=preview_fields, limit=1)


### PR DESCRIPTION
> On behalf of @vishwajeet-13 

## Problem
When a DocType has Show Preview Popup enabled but no image_field set, meta.image_field returns "" (empty string) this happens when an image field was previously set and then cleared via the form UI (the form sends ""
instead of NULL for cleared fields, and check_image_field skips validation for falsy values).

The empty string gets unconditionally appended to preview_fields, which then fails the _validate_select_field security validation introduced in the query builder:

  frappe.PermissionError: Invalid field format for SELECT: . Field names must be
  simple, backticked, table-qualified, aliased, or '*'.

### Before Fix
https://github.com/user-attachments/assets/fa6d6118-c722-48bb-8961-5760d41835b1


### After Fix
https://github.com/user-attachments/assets/52354b11-d09d-4a65-95de-4998ba7b1d69



**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/66578](https://support.frappe.io/helpdesk/tickets/66578)