### PR TITLE
fix: prevent duplicate settings button in session defaults dialog

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -290,7 +290,7 @@ frappe.ui.toolbar.fetch_session_defaults = function () {
 
 frappe.ui.toolbar.setup_session_defaults = function () {
 	let perms = frappe.perm.get_perm("Session Default Settings");
-	let fields = frappe.boot.session_defaults;
+	let fields = [...frappe.boot.session_defaults];
 	//add settings button only if user is a System Manager or has permission on 'Session Default Settings'
 	if (frappe.user_roles.includes("System Manager") || perms[0].read == 1) {
 		fields[fields.length] = {


### PR DESCRIPTION
Resolve: #39285 

---
`fields` was a direct reference to `frappe.boot.session_defaults`, so
each call to `setup_session_defaults` appended another Settings button
to the shared array. Using a shallow copy ensures the original is not
mutated.

**Before:**

https://github.com/user-attachments/assets/7f36e0ed-087d-45fd-9f6f-f4eb70dee421


**After:**

https://github.com/user-attachments/assets/721b7e5c-3983-4379-b311-3b488cbc88b4

