### PR TITLE
fix: keyboard shortcut labels and section padding

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -95,7 +95,7 @@ frappe.Application = class Application {
 	setup_theme() {
 		frappe.ui.keys.add_shortcut({
 			shortcut: "shift+ctrl+g",
-			description: __("Switch Theme"),
+			description: __("Switch theme"),
 			action: () => {
 				if (frappe.theme_switcher && frappe.theme_switcher.dialog.is_visible) {
 					frappe.theme_switcher.hide();

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -90,22 +90,33 @@ frappe.ui.keys.show_keyboard_shortcut_dialog = () => {
 		if (!shortcuts.length) {
 			return "";
 		}
-		let html = shortcuts
+		let deduped = [];
+		let seen = {};
+		shortcuts
 			.filter((s) => (s.condition ? s.condition() : true))
 			.filter((s) => !!s.description)
-			.map((shortcut) => {
-				let shortcut_label = shortcut.shortcut
-					.split("+")
-					.map(frappe.utils.to_title_case)
-					.join("+");
-				if (frappe.utils.is_mac()) {
-					shortcut_label = shortcut_label.replace("Ctrl", "⌘").replace("Alt", "⌥");
+			.forEach((shortcut) => {
+				if (seen[shortcut.description] !== undefined) {
+					deduped[seen[shortcut.description]].keys.push(shortcut.shortcut);
+				} else {
+					seen[shortcut.description] = deduped.length;
+					deduped.push({ ...shortcut, keys: [shortcut.shortcut] });
 				}
-
-				shortcut_label = shortcut_label.replace("Shift", "⇧");
-
+			});
+		let html = deduped
+			.map((shortcut) => {
+				let shortcut_label = shortcut.keys
+					.map((k) => {
+						let label = k.split("+").map(frappe.utils.to_title_case).join("+");
+						if (frappe.utils.is_mac()) {
+							label = label.replace("Ctrl", "⌘").replace("Alt", "⌥");
+						}
+						label = label.replace("Shift", "⇧");
+						return `<kbd>${label}</kbd>`;
+					})
+					.join(" / ");
 				return `<tr>
-					<td width="40%"><kbd>${shortcut_label}</kbd></td>
+					<td width="40%">${shortcut_label}</td>
 					<td width="60%">${shortcut.description || ""}</td>
 				</tr>`;
 			})
@@ -193,7 +204,7 @@ frappe.ui.keys.add_shortcut({
 		e.preventDefault();
 		return false;
 	},
-	description: __("Trigger Primary Action"),
+	description: __("Trigger primary action"),
 	ignore_inputs: true,
 });
 
@@ -220,29 +231,11 @@ frappe.ui.keys.add_shortcut({
 });
 
 frappe.ui.keys.add_shortcut({
-	shortcut: "alt+s",
-	action: function (e) {
-		e.preventDefault();
-		$(".dropdown-navbar-user button").eq(0).click();
-	},
-	description: __("Open Settings"),
-});
-
-frappe.ui.keys.add_shortcut({
 	shortcut: "shift+/",
 	action: function () {
 		frappe.ui.keys.show_keyboard_shortcut_dialog();
 	},
-	description: __("Show Keyboard Shortcuts"),
-});
-
-frappe.ui.keys.add_shortcut({
-	shortcut: "alt+h",
-	action: function (e) {
-		e.preventDefault();
-		$(".dropdown-help button").eq(0).click();
-	},
-	description: __("Open Help"),
+	description: __("Show keyboard shortcuts"),
 });
 
 frappe.ui.keys.on("escape", function (e) {
@@ -286,7 +279,7 @@ frappe.ui.keys.add_shortcut({
 	action: function () {
 		frappe.ui.toolbar.clear_cache();
 	},
-	description: __("Clear Cache and Reload"),
+	description: __("Clear cache and reload"),
 });
 
 frappe.ui.keys.key_map = {

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -32,7 +32,7 @@
 	padding: 0 var(--padding-md);
 	.form-section-description {
 		max-width: var(--page-max-width);
-		margin: auto;
+		margin-left: 0;
 		margin-bottom: 10px;
 		@include get_textstyle("base", "regular");
 		color: var(--text-light);


### PR DESCRIPTION
Before:
<img width="576" height="840" alt="Screenshot 2026-05-15 at 3 07 58 PM" src="https://github.com/user-attachments/assets/a00654ce-76ae-44a1-ad04-678b4f9d61b8" />

After:
<img width="1160" height="1616" alt="image" src="https://github.com/user-attachments/assets/936d4182-0312-4c96-8115-2647565938b4" />
