### PR TITLE
fix: timeline comment and email timestamps ignore show absolute datetime setting

### DIFF
--- a/frappe/public/js/frappe/form/templates/timeline_message_box.html
+++ b/frappe/public/js/frappe/form/templates/timeline_message_box.html
@@ -24,7 +24,7 @@
 					{% } %}
 
 					<div class="text-extra-muted">
-						{{ comment_when(doc.communication_date || doc.creation) }}
+						{{ cint(frappe.boot.user.show_absolute_datetime_in_timeline) || cint(frappe.boot.sysdefaults.show_absolute_datetime_in_timeline) ? frappe.datetime.str_to_user(doc.communication_date || doc.creation) : comment_when(doc.communication_date || doc.creation) }}
 					</div>
 				</span>
 			{% } else if (doc.comment_type && doc.comment_type == "Comment") { %}
@@ -34,7 +34,7 @@
 						<span class="text-extra-muted">{{ __("commented") }}</span>
 						<span> · </span>
 						<span class="text-extra-muted">
-							{{ comment_when(doc.communication_date || doc.creation, is_mini) }}
+							{{ cint(frappe.boot.user.show_absolute_datetime_in_timeline) || cint(frappe.boot.sysdefaults.show_absolute_datetime_in_timeline) ? frappe.datetime.str_to_user(doc.communication_date || doc.creation) : comment_when(doc.communication_date || doc.creation, is_mini) }}
 						</span>
 					{% if (doc.published) { %}
 						<span> · </span>
@@ -52,7 +52,7 @@
 						<span> . </span>
 
 						<span class="text-muted">
-							{{ comment_when(doc.communication_date || doc.creation, is_mini) }}
+							{{ cint(frappe.boot.user.show_absolute_datetime_in_timeline) || cint(frappe.boot.sysdefaults.show_absolute_datetime_in_timeline) ? frappe.datetime.str_to_user(doc.communication_date || doc.creation) : comment_when(doc.communication_date || doc.creation, is_mini) }}
 						</span>
 						{% if (doc.subject) { %}
 							<div class="text-muted my-1">{{doc.subject}}</div>

--- a/frappe/public/js/frappe/form/templates/timeline_message_box.html
+++ b/frappe/public/js/frappe/form/templates/timeline_message_box.html
@@ -1,5 +1,6 @@
 <div class="timeline-message-box" data-communication-type="{{ doc.communication_type }}">
 	{% is_mini = frappe.is_mobile() ? true : false %}
+	{% var show_absolute_datetime = cint(frappe.boot.user.show_absolute_datetime_in_timeline) || cint(frappe.boot.sysdefaults.show_absolute_datetime_in_timeline) %}
 	<span class="flex justify-between m-1 mb-3">
 		<span class="text-color flex">
 			{% if (doc.communication_type && doc.communication_type == "Automated Message") { %}
@@ -24,7 +25,7 @@
 					{% } %}
 
 					<div class="text-extra-muted">
-						{{ cint(frappe.boot.user.show_absolute_datetime_in_timeline) || cint(frappe.boot.sysdefaults.show_absolute_datetime_in_timeline) ? frappe.datetime.str_to_user(doc.communication_date || doc.creation) : comment_when(doc.communication_date || doc.creation) }}
+						{{ show_absolute_datetime ? frappe.datetime.str_to_user(doc.communication_date || doc.creation) : comment_when(doc.communication_date || doc.creation) }}
 					</div>
 				</span>
 			{% } else if (doc.comment_type && doc.comment_type == "Comment") { %}
@@ -34,7 +35,7 @@
 						<span class="text-extra-muted">{{ __("commented") }}</span>
 						<span> · </span>
 						<span class="text-extra-muted">
-							{{ cint(frappe.boot.user.show_absolute_datetime_in_timeline) || cint(frappe.boot.sysdefaults.show_absolute_datetime_in_timeline) ? frappe.datetime.str_to_user(doc.communication_date || doc.creation) : comment_when(doc.communication_date || doc.creation, is_mini) }}
+							{{ show_absolute_datetime ? frappe.datetime.str_to_user(doc.communication_date || doc.creation) : comment_when(doc.communication_date || doc.creation, is_mini) }}
 						</span>
 					{% if (doc.published) { %}
 						<span> · </span>
@@ -52,7 +53,7 @@
 						<span> . </span>
 
 						<span class="text-muted">
-							{{ cint(frappe.boot.user.show_absolute_datetime_in_timeline) || cint(frappe.boot.sysdefaults.show_absolute_datetime_in_timeline) ? frappe.datetime.str_to_user(doc.communication_date || doc.creation) : comment_when(doc.communication_date || doc.creation, is_mini) }}
+							{{ show_absolute_datetime ? frappe.datetime.str_to_user(doc.communication_date || doc.creation) : comment_when(doc.communication_date || doc.creation, is_mini) }}
 						</span>
 						{% if (doc.subject) { %}
 							<div class="text-muted my-1">{{doc.subject}}</div>


### PR DESCRIPTION
Follow-up to the sidebar fix (063d3000d5). 

The `Show absolute datetime in timeline` setting is honored by plain timeline entries (state changes, version logs) but not by the comment, email, and automated-message boxes rendered through `timeline_message_box.html`.
All three function calls use `comment_when` by default, which relies on `prettyDate`.

## Before 
https://github.com/user-attachments/assets/f0731940-cc77-498d-a405-db37c3e57d09

## After

<img width="1015" height="576" alt="Screenshot 2026-05-16 at 7 33 26 PM" src="https://github.com/user-attachments/assets/f1aeab3d-7d40-42c0-9a62-f98224acb59c" />