### PR TITLE
fix: remove `padding-block` from select to fix descender clipping

### DIFF
--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -49,7 +49,6 @@ select.form-control {
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	appearance: none;
-	padding-block: 0;
 }
 
 /* table multiselect */


### PR DESCRIPTION
Resolve: #39232 

---
**Before [Firefox]:**

<img width="252" height="40" alt="image" src="https://github.com/user-attachments/assets/4892d7aa-210c-4b94-8599-a72c27cef985" />
<img width="252" height="40" alt="image" src="https://github.com/user-attachments/assets/cbb8c9ba-e57a-4d74-bec1-d058e60f2e88" />
<img width="252" height="40" alt="image" src="https://github.com/user-attachments/assets/47b24eb9-1df4-4ad4-ac68-6acd97eb81f0" />

---
**After [Firefox]**

<img width="252" height="40" alt="image" src="https://github.com/user-attachments/assets/fc85c500-0ff2-4759-8e5e-e7e139cda5c6" />
<img width="252" height="40" alt="image" src="https://github.com/user-attachments/assets/c1b2dee0-c571-45b2-b9d6-936991ce63a1" />
<img width="252" height="40" alt="image" src="https://github.com/user-attachments/assets/67c436b1-e263-48c3-9da8-ff5e79f9c102" />


