### PR TITLE
fix(sentry): handle tz-aware enqueued_at from rq 2.x

### DIFF
--- a/frappe/tests/test_sentry.py
+++ b/frappe/tests/test_sentry.py
@@ -1,0 +1,43 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from frappe.tests import UnitTestCase
+from frappe.utils.sentry import set_scope
+
+
+class TestSentryScope(UnitTestCase):
+	def test_aware_enqueued_at(self):
+		enqueued_at = datetime(2026, 5, 18, 12, 0, tzinfo=UTC)
+		now = enqueued_at + timedelta(seconds=45)
+
+		self.assert_job_context(enqueued_at, now, wait=45)
+
+	def test_naive_enqueued_at(self):
+		enqueued_at = datetime(2026, 5, 18, 12, 0)
+		now = enqueued_at.replace(tzinfo=UTC) + timedelta(seconds=45)
+
+		self.assert_job_context(enqueued_at, now, wait=45)
+
+	def assert_job_context(self, enqueued_at, now, wait):
+		job = MagicMock()
+		job._kwargs = {"method": "frappe.ping"}
+		job.id = "test-job-id"
+		job.enqueued_at = enqueued_at
+
+		scope = MagicMock()
+		with (
+			patch("frappe.utils.sentry.rq.get_current_job", return_value=job),
+			patch("frappe.utils.sentry.datetime") as datetime_mock,
+		):
+			datetime_mock.now.return_value = now
+			set_scope(scope)
+
+		datetime_mock.now.assert_called_once_with(UTC)
+		scope.set_transaction_name.assert_called_once_with("frappe.ping")
+		scope.set_extra.assert_called_once()
+		self.assertEqual("job", scope.set_extra.call_args.args[0])
+
+		context = scope.set_extra.call_args.args[1]
+		self.assertEqual("test-job-id", context.uuid)
+		self.assertEqual(wait, context.wait)
+		self.assertEqual(job._kwargs, context.kwargs)

--- a/frappe/utils/sentry.py
+++ b/frappe/utils/sentry.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from datetime import datetime
+from datetime import UTC, datetime
 
 import rq
 from sentry_sdk import capture_message as sentry_capture_message
@@ -56,7 +56,10 @@ def set_scope(scope):
 			transaction_name = kwargs.get("kwargs", {}).get("job_type", "")
 			context.scheduled = True
 
-		waitdiff = datetime.utcnow() - job.enqueued_at
+		enqueued_at = job.enqueued_at
+		if enqueued_at.tzinfo is None:
+			enqueued_at = enqueued_at.replace(tzinfo=UTC)
+		waitdiff = datetime.now(UTC) - enqueued_at
 		context.uuid = job.id
 		context.wait = waitdiff.total_seconds()
 		context.kwargs = kwargs


### PR DESCRIPTION
## Bug

`set_scope` crashes for background jobs when Sentry job context hooks are enabled:

```python
waitdiff = datetime.utcnow() - job.enqueued_at
TypeError: can't subtract offset-naive and offset-aware datetimes
```

This happens when `FRAPPE_SENTRY_DSN` is set along with one of:

* `ENABLE_SENTRY_DB_MONITORING`
* `SENTRY_TRACING_SAMPLE_RATE`
* `SENTRY_PROFILING_SAMPLE_RATE`

and telemetry is enabled.

`datetime.utcnow()` returns a naive datetime, while `job.enqueued_at` is timezone-aware since RQ 2.x (`rq.utils.utcparse` sets `tzinfo=timezone.utc`).

Because the `before_job` hook runs before `method(**kwargs)` in `background_jobs.py`, the actual background job never executes when this error is raised. Sentry job context is also not recorded.

---

## Regression

Introduced by #31141, which bumped RQ from 1.x to 2.x. `frappe/utils/sentry.py` was still using naive UTC datetime arithmetic.

---

## Repro

```bash
# .env
FRAPPE_SENTRY_DSN=https://x@x.ingest.sentry.io/1
SENTRY_TRACING_SAMPLE_RATE=1
```

```bash
bench start
bench --site <site> execute frappe.utils.background_jobs.enqueue \
  --kwargs "{'method': 'frappe.ping', 'queue': 'short'}"

tail logs/worker.error.log
```

---

## Impact

Deployments with Sentry DSN plus tracing, profiling, or DB monitoring enabled can have broken scheduled and enqueued background jobs while telemetry is enabled.
