### PR TITLE
fix: support route_options for DocType links in sidebar

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -65,6 +65,9 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 						args.doc_view = "List";
 						args.route_options = filters_json;
 					}
+				} else if (this.item.route_options && this.item.link_type == "DocType") {
+					args.doc_view = "List";
+					args.route_options = JSON.parse(this.item.route_options);
 				}
 				path = frappe.utils.generate_route(args);
 			}


### PR DESCRIPTION
## Summary

- Adds support for `route_options` field on sidebar DocType link items
- When `route_options` is set (as a JSON string), it is parsed and used to build the list URL directly, bypassing the `filters` path
- This fixes incorrect URL encoding that occurs when `filters` with `["=", value]` arrays produce broken URLs

## Root Cause

When a sidebar item uses the `filters` field with a format like `[["Sales Invoice","is_return","=",1]]`, the code path via `get_filter_as_json` + `generate_route` produces `["=", 1]` as the route option value. Calling `.toString()` on this array yields `"=,1"`, which gets URL-encoded to `%3D%2C1`, breaking the filter.

Using `route_options` with a plain JSON object like `{"is_return": 1}` sidesteps this entirely.

## Related

Fixes https://github.com/frappe/erpnext/issues/55018 (in combination with erpnext-side fix)