### PR TITLE
fix: don't close context menu when clicking items inside it

### DIFF
--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -303,8 +303,11 @@ frappe.ui.create_menu = function (opts) {
 
 	document.addEventListener(
 		"click",
-		function () {
-			if (frappe.menu_map[context_menu.name].visible) {
+		function (e) {
+			if (
+				frappe.menu_map[context_menu.name].visible &&
+				!context_menu.template[0].contains(e.target)
+			) {
 				frappe.menu_map[context_menu.name].hide();
 				opts.onHide && opts.onHide(opts.parent);
 			}


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/55005

## Problem

On mobile, tapping "Workspaces" in the sidebar header dropdown closes the parent menu before the nested sub-menu can position itself. This happens because `frappe.ui.create_menu` registers a document-level listener in the **capture phase** (third argument `true`), which fires before the click target's own handlers.

The sequence on mobile was:
1. Tap "Workspaces" (a nested sub-menu trigger)
2. Capture listener fires → hides parent menu (`display:none`)
3. Click handler tries to position nested sub-menu via `getBoundingClientRect()` on an element inside the now-hidden parent → returns all zeros
4. Sub-menu appears at `(0, 4)px` — top-left corner, off-screen on mobile

On desktop this didn't occur because the sub-menu is shown via `mouseenter` while the parent is still visible.

## Fix

Add a `!context_menu.template[0].contains(e.target)` check so the capture listener only hides the menu for clicks genuinely outside it — not for clicks on items within the menu itself.