### PR TITLE
fix: support translated_doctypes in search_widget custom queries

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -110,15 +110,21 @@ def search_widget(
 		filters = {}
 
 	if query:  # Query = custom search query i.e. python function
+		meta = frappe.get_meta(doctype)
+		# For translated doctypes, pass empty txt and a large page_length so the custom query
+		# returns all records without SQL-level text filtering; Python-level filtering against
+		# translated values is applied below.
+		query_txt = "" if meta.translated_doctype else txt
+		query_page_length = PAGE_LENGTH_FOR_LINK_VALIDATION if meta.translated_doctype else page_length
 		try:
 			is_whitelisted(frappe.get_attr(query))
-			return frappe.call(
+			values = frappe.call(
 				query,
 				doctype,
-				txt,
+				query_txt,
 				searchfield,
 				start,
-				page_length,
+				query_page_length,
 				filters,
 				as_dict=as_dict,
 				reference_doctype=reference_doctype,
@@ -136,6 +142,14 @@ def search_widget(
 					http_status_code=404,
 				)
 				return []
+
+		if not for_link_validation:
+			if meta.translated_doctype:
+				values = filter_translated(values, txt, as_dict)
+				values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
+				values = values[:page_length]
+
+		return values
 
 	meta = frappe.get_meta(doctype)
 
@@ -227,15 +241,7 @@ def search_widget(
 
 	if not for_link_validation:
 		if meta.translated_doctype:
-			# Filtering the values array so that query is included in very element
-			values = (
-				result
-				for result in values
-				if any(
-					re.search(f"{re.escape(txt)}.*", _(cstr(value)) or "", re.IGNORECASE)
-					for value in (result.values() if as_dict else result)
-				)
-			)
+			values = filter_translated(values, txt, as_dict)
 
 		# Sorting the values array so that relevant results always come first
 		# This will first bring elements on top in which query is a prefix of element
@@ -387,6 +393,18 @@ def scrub_custom_query(query, key, txt):
 def relevance_sorter(key, query, as_dict):
 	value = _(key.name if as_dict else key[0])
 	return (cstr(value).casefold().startswith(query.casefold()) is not True, value)
+
+
+def filter_translated(values, txt: str, as_dict: bool) -> list:
+	"""Return only those results where txt matches any translated field value."""
+	return [
+		result
+		for result in values
+		if any(
+			re.search(f"{re.escape(txt)}.*", _(cstr(value)) or "", re.IGNORECASE)
+			for value in (result.values() if as_dict else result)
+		)
+	]
 
 
 @frappe.whitelist()


### PR DESCRIPTION
When a custom `query` function is used on a translated doctype, the previous code returned immediately from `frappe.call(query, ...)`, bypassing all translated doctype handling.

For translated doctypes with a custom query:
- Pass `txt=""` so the custom query returns all records without SQL-level LIKE filtering (the DB stores original names, not translated ones)
- Pass `PAGE_LENGTH_FOR_LINK_VALIDATION` as page_length so pagination does not cut off records that sort late alphabetically
- Apply the same Python-level regex filter against translated values and relevance sort that the standard (no-query) path uses
- Trim results back to the requested page_length after filtering

---
Fixes https://github.com/frappe/erpnext/issues/54996

