### PR TITLE
fix: misc. fixes to deleted_document

### DIFF
--- a/frappe/core/doctype/deleted_document/deleted_document.py
+++ b/frappe/core/doctype/deleted_document/deleted_document.py
@@ -46,6 +46,16 @@ def restore(name: str | int, alert: bool = True):
 		frappe.throw(_("Document {0} Already Restored").format(name), exc=frappe.DocumentAlreadyRestored)
 
 	doc = frappe.get_doc(json.loads(deleted.data))
+
+	if not frappe.has_permission(doc.doctype, "create"):
+		frappe.throw(
+			_("You do not have permission to create or restore documents of type {0}.").format(doc.doctype),
+			frappe.PermissionError,
+		)
+
+	if not frappe.has_permission(doc.doctype, "read", doc=doc):
+		frappe.throw(_("You do not have permission to restore this document."), frappe.PermissionError)
+
 	original_owner = doc.get("owner")
 	original_creation = doc.get("creation")
 	original_modified = doc.get("modified")

--- a/frappe/core/doctype/deleted_document/deleted_document.py
+++ b/frappe/core/doctype/deleted_document/deleted_document.py
@@ -39,6 +39,7 @@ class DeletedDocument(Document):
 
 @frappe.whitelist()
 def restore(name: str | int, alert: bool = True):
+	frappe.only_for("System Manager")
 	deleted = frappe.get_doc("Deleted Document", name)
 
 	if deleted.restored:
@@ -70,6 +71,7 @@ def restore(name: str | int, alert: bool = True):
 
 @frappe.whitelist()
 def bulk_restore(docnames: str | list[str]):
+	frappe.only_for("System Manager")
 	docnames = frappe.parse_json(docnames)
 	message = _("Restoring Deleted Document")
 	restored, invalid, failed = [], [], []

--- a/frappe/core/doctype/deleted_document/deleted_document.py
+++ b/frappe/core/doctype/deleted_document/deleted_document.py
@@ -46,6 +46,10 @@ def restore(name: str | int, alert: bool = True):
 		frappe.throw(_("Document {0} Already Restored").format(name), exc=frappe.DocumentAlreadyRestored)
 
 	doc = frappe.get_doc(json.loads(deleted.data))
+	original_owner = doc.get("owner")
+	original_creation = doc.get("creation")
+	original_modified = doc.get("modified")
+	original_modified_by = doc.get("modified_by")
 	doc.flags.from_restore = True
 	try:
 		doc.insert()
@@ -58,6 +62,19 @@ def restore(name: str | int, alert: bool = True):
 			if doc.get(workflow_state_fieldname):
 				doc.set(workflow_state_fieldname, None)
 		doc.insert()
+
+	# retain original metadata
+	frappe.db.set_value(
+		doc.doctype,
+		doc.name,
+		{
+			"owner": original_owner,
+			"creation": original_creation,
+			"modified": original_modified,
+			"modified_by": original_modified_by,
+		},
+		update_modified=False,
+	)
 
 	doc.add_comment("Edit", _("restored {0} as {1}").format(deleted.deleted_name, doc.name))
 

--- a/frappe/core/doctype/deleted_document/test_deleted_document.py
+++ b/frappe/core/doctype/deleted_document/test_deleted_document.py
@@ -1,7 +1,30 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
+import frappe
+from frappe.core.doctype.deleted_document.deleted_document import restore
 from frappe.tests import IntegrationTestCase
 
 
 class TestDeletedDocument(IntegrationTestCase):
-	pass
+	def test_metadata_retention(self):
+		frappe.set_user("Administrator")
+		doc = frappe.get_doc({"doctype": "Note", "title": "Test Note", "content": "Test Content"}).insert()
+		orig_owner = doc.owner
+		orig_creation = doc.creation
+		orig_modified = doc.modified
+		orig_modified_by = doc.modified_by
+
+		frappe.delete_doc("Note", doc.name, force=True)
+		self.assertFalse(frappe.db.exists("Note", doc.name))
+
+		log_name = frappe.db.get_value("Deleted Document", {"deleted_name": doc.name, "restored": 0})
+		restore(log_name, alert=False)
+
+		new_restored_name = frappe.db.get_value("Deleted Document", log_name, "new_name")
+
+		restored_doc = frappe.get_doc("Note", new_restored_name)
+
+		self.assertEqual(restored_doc.owner, orig_owner)
+		self.assertEqual(str(restored_doc.creation), str(orig_creation))
+		self.assertEqual(str(restored_doc.modified), str(orig_modified))
+		self.assertEqual(restored_doc.modified_by, orig_modified_by)


### PR DESCRIPTION
Adding a few behavioral changes and restrictions to restoring docs.

- [x] only system manager should be able to restore
- [x] check deleted document perms. in restore
- [x] restore should preserve owner and all date fields (inception meta fields).
- [x] test

closes Ticket #67385


