### PR TITLE
fix: child table field filter throws false permission error

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -934,7 +934,7 @@ class Engine:
 
 				if (
 					meta
-					and not doctype
+					and (not doctype or doctype == self.doctype)
 					and target_fieldname not in default_fields + optional_fields + child_table_fields
 					and not meta.has_field(target_fieldname)
 				):


### PR DESCRIPTION
Resolve: #39175 

----
when dict filters are passed through `search_widget`, they are converted 
to 4-tuples via `make_filter_tuple(doctype, key, value)`, setting the
doctype explicitly to the parent. This caused the child-table auto-detect
block (guarded by `not doctype`) to be skipped, falling through to a
permission check on the parent doctype where the field doesn't exist.

The fix: widen the guard to 
```py 
not doctype or doctype == self.doctype
```
---

**Before:**

https://github.com/user-attachments/assets/908615aa-88dc-453d-ab1a-653b5da79b0a



**After:**

https://github.com/user-attachments/assets/7c373743-63b4-4417-86a4-dc0b7e02a1ba

