### PR TITLE
fix(User): show impersonate button based on permission instead of hardcoded Administrator check

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -378,8 +378,8 @@ frappe.ui.form.on("User", {
 	},
 	setup_impersonation: function (frm) {
 		if (
-			frappe.session.user === "Administrator" &&
-			frm.doc.name != "Administrator" &&
+			(frappe.session.user === "Administrator" || frm.has_perm("impersonate")) &&
+			frm.doc.name !== frappe.session.user &&
 			!frm.is_new()
 		) {
 			frm.add_custom_button(__("Impersonate"), () => {


### PR DESCRIPTION
Resolve: #39027 

---
- replace hardcoded `frappe.session.user === "Administrator"` with `frm.has_perm("impersonate")` to respect the new impersonate permission type
- keep Administrator bypassing the permission check as the top authority
- prevent self-impersonation for all users by comparing `frm.doc.name !== frappe.session.user`


https://github.com/user-attachments/assets/e122a4a3-0b2f-46aa-8095-2ea02d230c11

