### PR TITLE
fix: pass user to allowed report/doctype permission helpers

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -226,25 +226,28 @@ def load_desktop_data(bootinfo):
 		)
 
 
-def get_allowed_pages(cache=False):
-	return get_user_pages_or_reports("Page", cache=cache)
+def get_allowed_pages(cache=False, user: str | None = None):
+	return get_user_pages_or_reports("Page", cache=cache, user=user)
 
 
-def get_allowed_reports(cache=False):
-	return get_user_pages_or_reports("Report", cache=cache)
+def get_allowed_reports(cache=False, user: str | None = None):
+	return get_user_pages_or_reports("Report", cache=cache, user=user)
 
 
-def get_allowed_report_names(cache=False) -> set[str]:
-	return {cstr(report) for report in get_allowed_reports(cache).keys() if report}
+def get_allowed_report_names(cache=False, user: str | None = None) -> set[str]:
+	return {cstr(report) for report in get_allowed_reports(cache=cache, user=user).keys() if report}
 
 
-def get_user_pages_or_reports(parent, cache=False):
+def get_user_pages_or_reports(parent, cache=False, user: str | None = None):
+	if user is None:
+		user = frappe.session.user
+
 	if cache:
-		has_role = frappe.cache.get_value("has_role:" + parent, user=frappe.session.user)
+		has_role = frappe.cache.get_value("has_role:" + parent, user=user)
 		if has_role:
 			return has_role
 
-	roles = frappe.get_roles()
+	roles = frappe.get_roles(user)
 	has_role = {}
 
 	page = DocType("Page")
@@ -323,7 +326,7 @@ def get_user_pages_or_reports(parent, cache=False):
 				has_role[r.name] |= {"ref_doctype": r.ref_doctype}
 
 	if is_report:
-		if not has_permission("Report", print_logs=False):
+		if not has_permission("Report", user=user, print_logs=False):
 			return {}
 
 		reports = frappe.get_list(
@@ -331,6 +334,7 @@ def get_user_pages_or_reports(parent, cache=False):
 			fields=["name", "report_type"],
 			filters={"name": ("in", has_role.keys())},
 			ignore_ifnull=True,
+			user=user,
 		)
 		for report in reports:
 			has_role[report.name]["report_type"] = report.report_type
@@ -340,7 +344,7 @@ def get_user_pages_or_reports(parent, cache=False):
 			has_role.pop(r, None)
 
 	# Expire every six hours
-	frappe.cache.set_value("has_role:" + parent, has_role, frappe.session.user, 21600)
+	frappe.cache.set_value("has_role:" + parent, has_role, user, 21600)
 	return has_role
 
 

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -11,6 +11,7 @@ from frappe.boot import get_allowed_report_names
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 from frappe.modules.export_file import export_to_files
+from frappe.permissions import get_doctypes_with_read
 from frappe.utils import cint, flt, get_datetime, getdate, has_common, now_datetime, nowdate
 from frappe.utils.dashboard import cache_source
 from frappe.utils.data import format_date
@@ -38,10 +39,10 @@ def get_permission_query_conditions(user):
 	report_condition = False
 	module_condition = False
 
-	allowed_doctypes = [frappe.db.escape(doctype) for doctype in frappe.permissions.get_doctypes_with_read()]
-	allowed_reports = [frappe.db.escape(report) for report in get_allowed_report_names()]
+	allowed_doctypes = [frappe.db.escape(doctype) for doctype in get_doctypes_with_read(user)]
+	allowed_reports = [frappe.db.escape(report) for report in get_allowed_report_names(user=user)]
 	allowed_modules = [
-		frappe.db.escape(module.get("module_name")) for module in get_modules_from_all_apps_for_user()
+		frappe.db.escape(module.get("module_name")) for module in get_modules_from_all_apps_for_user(user)
 	]
 
 	if allowed_doctypes:
@@ -77,10 +78,10 @@ def has_permission(doc, ptype, user):
 		if has_common(roles, allowed):
 			return True
 	elif doc.chart_type == "Report":
-		if doc.report_name in get_allowed_report_names():
+		if doc.report_name in get_allowed_report_names(user=user):
 			return True
 	else:
-		allowed_doctypes = frappe.permissions.get_doctypes_with_read()
+		allowed_doctypes = get_doctypes_with_read(user)
 		if doc.document_type in allowed_doctypes:
 			return True
 

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -82,16 +82,15 @@ class NumberCard(Document):
 
 
 def get_permission_query_conditions(user=None):
-	# The user param is ignored because `get_allowed_report_names` and `get_doctypes_with_read` don't support it.
-	if frappe.session.user == "Administrator":
+	if not user:
+		user = frappe.session.user
+
+	if user == "Administrator" or "System Manager" in frappe.get_roles(user):
 		return
 
-	if "System Manager" in frappe.get_roles():
-		return
-
-	allowed_reports = get_allowed_report_names()
-	allowed_doctypes = get_doctypes_with_read()
-	allowed_modules = [module.get("module_name") for module in get_modules_from_all_apps_for_user()]
+	allowed_reports = get_allowed_report_names(user=user)
+	allowed_doctypes = get_doctypes_with_read(user)
+	allowed_modules = [module.get("module_name") for module in get_modules_from_all_apps_for_user(user)]
 
 	nc = frappe.qb.DocType("Number Card")
 	conditions = (
@@ -104,20 +103,19 @@ def get_permission_query_conditions(user=None):
 
 
 def has_permission(doc, ptype, user):
-	# The user param is ignored because `get_allowed_report_names` and `get_doctypes_with_read` don't support it.
-	if frappe.session.user == "Administrator":
+	if not user:
+		user = frappe.session.user
+
+	if user == "Administrator" or "System Manager" in frappe.get_roles(user):
 		return True
 
-	if "System Manager" in frappe.get_roles():
+	if doc.type == "Report" and doc.report_name in get_allowed_report_names(user=user):
 		return True
 
-	if doc.type == "Report" and doc.report_name in get_allowed_report_names():
+	if doc.type == "Custom" and doc.document_type in get_doctypes_with_read(user):
 		return True
 
-	if doc.type == "Custom" and doc.document_type in get_doctypes_with_read():
-		return True
-
-	if doc.type == "Document Type" and doc.document_type in get_doctypes_with_read():
+	if doc.type == "Document Type" and doc.document_type in get_doctypes_with_read(user):
 		return True
 
 	return False

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -97,7 +97,7 @@ def get_permission_query_conditions(user=None):
 		((nc.type == "Report") & nc.report_name.isin(allowed_reports))
 		| ((nc.type == "Custom") & nc.document_type.isin(allowed_doctypes))
 		| ((nc.type == "Document Type") & nc.document_type.isin(allowed_doctypes))
-	) & (nc.module.isin(allowed_modules) | nc.module.isnull() | nc.module == "")
+	) & (nc.module.isin(allowed_modules) | nc.module.isnull() | (nc.module == ""))
 
 	return conditions.get_sql(quote_char="`")
 

--- a/frappe/desk/doctype/number_card/test_number_card.py
+++ b/frappe/desk/doctype/number_card/test_number_card.py
@@ -1,8 +1,58 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-# import frappe
+import frappe
 from frappe.tests import IntegrationTestCase
 
 
 class TestNumberCard(IntegrationTestCase):
-	pass
+	def test_report_card_hidden_when_report_is_not_allowed(self):
+		user = "test2@example.com"
+		report_name = "Test Restricted Number Card Report"
+		card_name = "Test Restricted Report Number Card"
+		baseline_role = "Desk User"
+		exclusive_role = "System Manager"
+
+		frappe.set_user("Administrator")
+		frappe.delete_doc("Number Card", card_name, ignore_missing=True, force=True)
+		frappe.delete_doc("Report", report_name, ignore_missing=True, force=True)
+		self.addCleanup(lambda: frappe.delete_doc("Number Card", card_name, ignore_missing=True, force=True))
+		self.addCleanup(lambda: frappe.delete_doc("Report", report_name, ignore_missing=True, force=True))
+
+		user_doc = frappe.get_doc("User", user)
+		had_baseline_role = baseline_role in frappe.get_roles(user)
+		if not had_baseline_role:
+			user_doc.add_roles(baseline_role)
+			self.addCleanup(lambda: user_doc.remove_roles(baseline_role))
+
+		had_exclusive_role = exclusive_role in frappe.get_roles(user)
+		if had_exclusive_role:
+			user_doc.remove_roles(exclusive_role)
+			self.addCleanup(lambda: user_doc.add_roles(exclusive_role))
+
+		report = frappe.get_doc(
+			{
+				"doctype": "Report",
+				"report_name": report_name,
+				"ref_doctype": "ToDo",
+				"report_type": "Report Builder",
+				"is_standard": "No",
+				"roles": [{"role": exclusive_role}],
+			}
+		).insert(ignore_permissions=True)
+
+		card = frappe.get_doc(
+			{
+				"doctype": "Number Card",
+				"label": card_name,
+				"type": "Report",
+				"report_name": report.name,
+				"function": "Count",
+				"report_field": "name",
+			}
+		).insert(ignore_permissions=True)
+
+		self.assertFalse(frappe.has_permission("Number Card", doc=card, user=user))
+		self.assertNotIn(
+			card.name,
+			frappe.get_list("Number Card", filters={"name": card.name}, pluck="name", user=user),
+		)

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -498,8 +498,8 @@ def has_controller_permissions(doc, ptype, user=None, debug=False) -> bool:
 	return True
 
 
-def get_doctypes_with_read():
-	return list({cstr(p.parent) for p in get_valid_perms() if p.parent and p.read})
+def get_doctypes_with_read(user: str | None = None):
+	return list({cstr(p.parent) for p in get_valid_perms(user=user) if p.parent and p.read})
 
 
 def get_valid_perms(doctype=None, user=None):


### PR DESCRIPTION
## Summary

Permission hooks for **Number Card** and **Dashboard Chart** receive a `user` argument from the framework, but their helpers always used `frappe.session.user`. That could grant or deny access incorrectly when permissions are evaluated for a specific user (e.g. `has_permission(doc, ptype, user)`).

This PR threads an optional `user` through the boot helpers and related permission utilities:

- `get_allowed_pages`, `get_allowed_reports`, `get_allowed_report_names`, and `get_user_pages_or_reports` now accept `user` (default: session user).
- Role lookup, cache keys, `has_permission("Report")`, and `frappe.get_list("Report")` all use that user when resolving allowed reports.
- `get_doctypes_with_read` accepts `user` and forwards it to `get_valid_perms`.
- **Number Card** and **Dashboard Chart** permission hooks pass `user` into `get_allowed_report_names`, `get_doctypes_with_read`, and `get_modules_from_all_apps_for_user`.
- **Number Card** Administrator / System Manager bypass now checks the target `user`, consistent with **Dashboard Chart**.
- List perm query for **Number Card** had a bug due to operator binding that is fixed here.

Existing call sites that omit `user` are unchanged.

## Test plan

- [x] As a non–System Manager user, open **Number Card** list and confirm only cards for allowed reports/doctypes/modules are visible.
- [x] As a non–System Manager user, open **Dashboard Chart** list and confirm the same for report- and doctype-based charts.
- [x] Create a **Number Card** linked to a report the user cannot access; confirm it does not appear in the list and `has_permission` returns false.
- [x] Repeat for a **Dashboard Chart** with `chart_type` = "Report".
- [x] As **System Manager** / **Administrator**, confirm both lists still show all relevant records (no over-restrictive filter).
- [x] Smoke-test desk boot (workspace sidebar / allowed reports in UI) to ensure default session-user behavior is unchanged.
- [x] `bench --site <site> run-tests --app frappe --module frappe.tests.test_boot` (covers report permission-query behavior in `get_user_pages_or_reports`)
