### PR TITLE
ci: replace hardcoded bundle size test with PR-base comparison

### DIFF
--- a/.github/helper/compare_default_js_bundle_size.py
+++ b/.github/helper/compare_default_js_bundle_size.py
@@ -1,35 +1,13 @@
 #!/usr/bin/env python3
-"""Compare the default Desk JS bundle size against a base build.
+"""Compare default Desk JS bundle size against a base build.
 
-Measures on-disk sizes of bundles listed in `app_include_js` (see
-`frappe/hooks.py`), using hashed paths from `sites/assets/assets.json`.
+The measured bundles come from `app_include_js` in `frappe/hooks.py` and are
+resolved through hashed paths in `sites/assets/assets.json`.
 
-Only default Desk JS bundles are built
-(`--files`), not CSS, so a full `bench build` is not required:
-
-Local usage:
-
-```bash
-BENCH_ROOT="$PWD"
-FILES=$(
-	python "$BENCH_ROOT/apps/frappe/.github/helper/compare_default_js_bundle_size.py" \\
-		--bench-path "$BENCH_ROOT" --esbuild-files
-)
-
-cd "$BENCH_ROOT/apps/frappe"
-node esbuild --production --apps frappe --files "$FILES"
-
-python "$BENCH_ROOT/apps/frappe/.github/helper/compare_default_js_bundle_size.py" \\
-	--bench-path "$BENCH_ROOT" --write-json /tmp/base-default-js-bundle-size.json
-
-# Rebuild after your changes, then compare:
-node esbuild --production --apps frappe --files "$FILES"
-
-python "$BENCH_ROOT/apps/frappe/.github/helper/compare_default_js_bundle_size.py" \\
-	--bench-path "$BENCH_ROOT" --compare-to /tmp/base-default-js-bundle-size.json
-```
-
-Optional env var `DEFAULT_JS_BUNDLE_SIZE_THRESHOLD` (default 0.01 = 1% over base).
+Use `--esbuild-files` to print the comma-separated bundle list for
+`node esbuild --files`, `--write-json` to record a base measurement, and
+`--compare-to` to fail when the current measurement exceeds the configured
+threshold.
 """
 
 from __future__ import annotations

--- a/.github/helper/compare_default_js_bundle_size.py
+++ b/.github/helper/compare_default_js_bundle_size.py
@@ -4,23 +4,29 @@
 Measures on-disk sizes of bundles listed in `app_include_js` (see
 `frappe/hooks.py`), using hashed paths from `sites/assets/assets.json`.
 
-Local usage (run from the bench root):
+Only default Desk JS bundles are built
+(`--files`), not CSS, so a full `bench build` is not required:
+
+Local usage:
 
 ```bash
-cd apps/frappe
-node esbuild --production --apps frappe
+BENCH_ROOT="$PWD"
+FILES=$(
+	python "$BENCH_ROOT/apps/frappe/.github/helper/compare_default_js_bundle_size.py" \\
+		--bench-path "$BENCH_ROOT" --esbuild-files
+)
 
-cd ../..
-python apps/frappe/.github/helper/compare_default_js_bundle_size.py \
-	--write-json /tmp/base-default-js-bundle-size.json
+cd "$BENCH_ROOT/apps/frappe"
+node esbuild --production --apps frappe --files "$FILES"
+
+python "$BENCH_ROOT/apps/frappe/.github/helper/compare_default_js_bundle_size.py" \\
+	--bench-path "$BENCH_ROOT" --write-json /tmp/base-default-js-bundle-size.json
 
 # Rebuild after your changes, then compare:
-cd apps/frappe
-node esbuild --production --apps frappe
+node esbuild --production --apps frappe --files "$FILES"
 
-cd ../..
-python apps/frappe/.github/helper/compare_default_js_bundle_size.py \
-	--compare-to /tmp/base-default-js-bundle-size.json
+python "$BENCH_ROOT/apps/frappe/.github/helper/compare_default_js_bundle_size.py" \\
+	--bench-path "$BENCH_ROOT" --compare-to /tmp/base-default-js-bundle-size.json
 ```
 
 Optional env var `DEFAULT_JS_BUNDLE_SIZE_THRESHOLD` (default 0.01 = 1% over base).
@@ -120,13 +126,22 @@ def default_threshold() -> float:
 	return DEFAULT_THRESHOLD
 
 
+def get_esbuild_files(bench_path: Path) -> str:
+	return ",".join(f"frappe/{bundle}" for bundle in get_default_js_bundles(bench_path))
+
+
 def main() -> None:
 	parser = argparse.ArgumentParser()
 	parser.add_argument("--bench-path", type=Path, default=Path.cwd())
 	parser.add_argument("--write-json", type=Path)
 	parser.add_argument("--compare-to", type=Path)
+	parser.add_argument("--esbuild-files", action="store_true")
 	parser.add_argument("--threshold", type=float, default=default_threshold())
 	args = parser.parse_args()
+
+	if args.esbuild_files:
+		print(get_esbuild_files(args.bench_path))
+		return
 
 	current = get_default_bundle_size(args.bench_path)
 

--- a/.github/helper/compare_default_js_bundle_size.py
+++ b/.github/helper/compare_default_js_bundle_size.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Compare the default Desk JS bundle size against a base build.
+
+Measures on-disk sizes of bundles listed in `app_include_js` (see
+`frappe/hooks.py`), using hashed paths from `sites/assets/assets.json`.
+
+Local usage (run from the bench root):
+
+```bash
+cd apps/frappe
+node esbuild --production --apps frappe
+
+cd ../..
+python apps/frappe/.github/helper/compare_default_js_bundle_size.py \
+	--write-json /tmp/base-default-js-bundle-size.json
+
+# Rebuild after your changes, then compare:
+cd apps/frappe
+node esbuild --production --apps frappe
+
+cd ../..
+python apps/frappe/.github/helper/compare_default_js_bundle_size.py \
+	--compare-to /tmp/base-default-js-bundle-size.json
+```
+
+Optional env var `DEFAULT_JS_BUNDLE_SIZE_THRESHOLD` (default 0.01 = 1% over base).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+from pathlib import Path
+
+DEFAULT_THRESHOLD = 0.01
+THRESHOLD_ENV_VAR = "DEFAULT_JS_BUNDLE_SIZE_THRESHOLD"
+
+
+def get_default_js_bundles(bench_path: Path) -> list[str]:
+	hooks_path = bench_path / "apps/frappe/frappe/hooks.py"
+	hooks = ast.parse(hooks_path.read_text())
+
+	for node in hooks.body:
+		if not isinstance(node, ast.Assign):
+			continue
+
+		if any(isinstance(target, ast.Name) and target.id == "app_include_js" for target in node.targets):
+			return ast.literal_eval(node.value)
+
+	raise RuntimeError("Could not find app_include_js in frappe/hooks.py")
+
+
+def get_default_bundle_size(bench_path: Path) -> dict:
+	assets_json_path = bench_path / "sites/assets/assets.json"
+	assets_json = json.loads(assets_json_path.read_text())
+
+	bundles = []
+	for bundle in get_default_js_bundles(bench_path):
+		asset_path = assets_json[bundle]
+		file_path = bench_path / "sites" / asset_path.lstrip("/")
+		size = file_path.stat().st_size
+		bundles.append({"bundle": bundle, "path": asset_path, "bytes": size})
+
+	return {
+		"total_bytes": sum(bundle["bytes"] for bundle in bundles),
+		"bundles": bundles,
+	}
+
+
+def format_size(size: float) -> str:
+	return f"{size / (1024 * 1024):.4f} MB"
+
+
+def compare_bundle_sizes(base: dict, current: dict, threshold: float) -> bool:
+	base_size = base["total_bytes"]
+	current_size = current["total_bytes"]
+	allowed_size = base_size * (1 + threshold)
+	increase = current_size - base_size
+	increase_percentage = (increase / base_size) if base_size else 0
+
+	print(f"Base default JS bundle size: {format_size(base_size)}")
+	print(f"Current default JS bundle size: {format_size(current_size)}")
+	print(f"Allowed default JS bundle size: {format_size(allowed_size)} ({threshold:.2%} over base)")
+	print(f"Size change: {format_size(increase)} ({increase_percentage:.2%})")
+
+	if current_size <= allowed_size:
+		return True
+
+	print("\nBundle size changes:")
+	base_bundles = {bundle["bundle"]: bundle for bundle in base["bundles"]}
+	current_bundles = {bundle["bundle"]: bundle for bundle in current["bundles"]}
+
+	for bundle in current["bundles"]:
+		base_bundle = base_bundles.get(bundle["bundle"])
+		if not base_bundle:
+			print(f"- {bundle['bundle']}: added ({format_size(bundle['bytes'])})")
+			continue
+
+		size_change = bundle["bytes"] - base_bundle["bytes"]
+		if not size_change:
+			continue
+
+		print(
+			f"- {bundle['bundle']}: {format_size(base_bundle['bytes'])} -> "
+			f"{format_size(bundle['bytes'])} ({format_size(size_change)})"
+		)
+
+	for bundle in base["bundles"]:
+		if bundle["bundle"] not in current_bundles:
+			print(f"- {bundle['bundle']}: removed (was {format_size(bundle['bytes'])})")
+
+	return False
+
+
+def default_threshold() -> float:
+	if THRESHOLD_ENV_VAR in os.environ:
+		return float(os.environ[THRESHOLD_ENV_VAR])
+	return DEFAULT_THRESHOLD
+
+
+def main() -> None:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--bench-path", type=Path, default=Path.cwd())
+	parser.add_argument("--write-json", type=Path)
+	parser.add_argument("--compare-to", type=Path)
+	parser.add_argument("--threshold", type=float, default=default_threshold())
+	args = parser.parse_args()
+
+	current = get_default_bundle_size(args.bench_path)
+
+	if args.write_json:
+		args.write_json.write_text(json.dumps(current, indent=2))
+		print(f"Default JS bundle size: {format_size(current['total_bytes'])}")
+
+	if args.compare_to:
+		base = json.loads(args.compare_to.read_text())
+		if not compare_bundle_sizes(base, current, args.threshold):
+			raise SystemExit(1)
+
+	if not args.write_json and not args.compare_to:
+		print(current["total_bytes"])
+
+
+if __name__ == "__main__":
+	main()

--- a/.github/helper/compare_default_js_bundle_size.py
+++ b/.github/helper/compare_default_js_bundle_size.py
@@ -64,7 +64,12 @@ def get_default_bundle_size(bench_path: Path) -> dict:
 
 	bundles = []
 	for bundle in get_default_js_bundles(bench_path):
-		asset_path = assets_json[bundle]
+		try:
+			asset_path = assets_json[bundle]
+		except KeyError:
+			raise RuntimeError(
+				f"Expected {bundle} from app_include_js, but it was not found in {assets_json_path}"
+			) from None
 		file_path = bench_path / "sites" / asset_path.lstrip("/")
 		size = file_path.stat().st_size
 		bundles.append({"bundle": bundle, "path": asset_path, "bytes": size})

--- a/.github/workflows/default-js-bundle-size.yml
+++ b/.github/workflows/default-js-bundle-size.yml
@@ -1,0 +1,98 @@
+name: Default JS Bundle Size
+
+on:
+  pull_request:
+
+concurrency:
+  group: default-js-bundle-size-${{ github.event_name }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  # Do not change this as GITHUB_TOKEN is being used by roulette
+  contents: read
+
+jobs:
+  checkrun:
+    name: Plan Check
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.check-build.outputs.build }}
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v6
+
+      - name: Check if build should be run
+        id: check-build
+        run: |
+          python "${GITHUB_WORKSPACE}/.github/helper/roulette.py"
+        env:
+          TYPE: "ui"
+          PR_NUMBER: ${{ github.event.number }}
+          REPO_NAME: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  compare:
+    name: Compare
+    runs-on: ubuntu-latest
+    if: needs.checkrun.outputs.build == 'strawberry'
+    needs: checkrun
+    env:
+      NODE_ENV: "production"
+      DEFAULT_JS_BUNDLE_SIZE_THRESHOLD: "0.01"
+    steps:
+      - name: Clone
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          path: apps/frappe
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          check-latest: true
+
+      - id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('apps/frappe/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Prepare bench layout
+        run: |
+          cp apps/frappe/.github/helper/compare_default_js_bundle_size.py /tmp/compare_default_js_bundle_size.py
+          mkdir -p sites/assets
+          echo frappe > sites/apps.txt
+
+      - name: Compare default JS bundle size
+        run: |
+          build_default_js_bundle() {
+            local ref="$1"
+
+            git -C apps/frappe checkout --force "$ref"
+            yarn --cwd apps/frappe install --frozen-lockfile
+            rm -rf sites/assets/frappe sites/assets/assets.json apps/frappe/frappe/public/dist
+            (
+              cd apps/frappe
+              CI=Yes node esbuild --production --apps frappe
+            )
+          }
+
+          build_default_js_bundle "${{ github.event.pull_request.base.sha }}"
+          python /tmp/compare_default_js_bundle_size.py \
+            --bench-path "$GITHUB_WORKSPACE" \
+            --write-json /tmp/base-default-js-bundle-size.json
+
+          build_default_js_bundle "${{ github.sha }}"
+          python /tmp/compare_default_js_bundle_size.py \
+            --bench-path "$GITHUB_WORKSPACE" \
+            --compare-to /tmp/base-default-js-bundle-size.json \
+            --threshold "$DEFAULT_JS_BUNDLE_SIZE_THRESHOLD"

--- a/.github/workflows/default-js-bundle-size.yml
+++ b/.github/workflows/default-js-bundle-size.yml
@@ -47,10 +47,6 @@ jobs:
           fetch-depth: 0
           path: apps/frappe
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -80,8 +76,7 @@ jobs:
             git -C apps/frappe checkout --force "$ref"
             yarn --cwd apps/frappe install --frozen-lockfile
             rm -rf sites/assets/frappe sites/assets/assets.json apps/frappe/frappe/public/dist
-            files=$(python /tmp/compare_default_js_bundle_size.py \
-              --bench-path "$GITHUB_WORKSPACE" --esbuild-files)
+            files=$(python /tmp/compare_default_js_bundle_size.py --esbuild-files)
             (
               cd apps/frappe
               CI=Yes node esbuild --production --apps frappe --files "$files"
@@ -90,11 +85,8 @@ jobs:
 
           build_default_js_bundle "${{ github.event.pull_request.base.sha }}"
           python /tmp/compare_default_js_bundle_size.py \
-            --bench-path "$GITHUB_WORKSPACE" \
             --write-json /tmp/base-default-js-bundle-size.json
 
           build_default_js_bundle "${{ github.sha }}"
           python /tmp/compare_default_js_bundle_size.py \
-            --bench-path "$GITHUB_WORKSPACE" \
-            --compare-to /tmp/base-default-js-bundle-size.json \
-            --threshold "$DEFAULT_JS_BUNDLE_SIZE_THRESHOLD"
+            --compare-to /tmp/base-default-js-bundle-size.json

--- a/.github/workflows/default-js-bundle-size.yml
+++ b/.github/workflows/default-js-bundle-size.yml
@@ -80,9 +80,11 @@ jobs:
             git -C apps/frappe checkout --force "$ref"
             yarn --cwd apps/frappe install --frozen-lockfile
             rm -rf sites/assets/frappe sites/assets/assets.json apps/frappe/frappe/public/dist
+            files=$(python /tmp/compare_default_js_bundle_size.py \
+              --bench-path "$GITHUB_WORKSPACE" --esbuild-files)
             (
               cd apps/frappe
-              CI=Yes node esbuild --production --apps frappe
+              CI=Yes node esbuild --production --apps frappe --files "$files"
             )
           }
 

--- a/frappe/commands/test_commands.py
+++ b/frappe/commands/test_commands.py
@@ -17,7 +17,6 @@ import unittest
 from contextlib import contextmanager
 from functools import wraps
 from glob import glob
-from pathlib import Path
 from unittest.case import skipIf
 from unittest.mock import patch
 
@@ -39,7 +38,6 @@ from frappe.tests import IntegrationTestCase, timeout
 from frappe.tests.test_query_builder import run_only_if
 from frappe.utils import add_to_date, execute_in_shell, get_bench_path, get_bench_relative_path, now
 from frappe.utils.backups import BackupGenerator, fetch_latest_backups
-from frappe.utils.jinja_globals import bundled_asset
 from frappe.utils.scheduler import enable_scheduler, is_scheduler_inactive
 
 _result: Result | None = None
@@ -956,27 +954,6 @@ class TestAddNewUser(BaseTestCommands):
 		user = frappe.get_doc("User", "test@gmail.com")
 		roles = {r.role for r in user.roles}
 		self.assertEqual({"Accounts User", "Sales User"}, roles)
-
-
-class TestBenchBuild(IntegrationTestCase):
-	def test_build_assets_size_check(self):
-		CURRENT_SIZE = 3.45  # MB
-		JS_ASSET_THRESHOLD = 0.01
-
-		hooks = frappe.get_hooks()
-		default_bundle = hooks["app_include_js"]
-
-		default_bundle_size = 0.0
-
-		for chunk in default_bundle:
-			abs_path = Path.cwd() / frappe.local.sites_path / bundled_asset(chunk)[1:]
-			default_bundle_size += abs_path.stat().st_size
-
-		self.assertLessEqual(
-			default_bundle_size / (1024 * 1024),
-			CURRENT_SIZE * (1 + JS_ASSET_THRESHOLD),
-			f"Default JS bundle size increased by {JS_ASSET_THRESHOLD:.2%} or more",
-		)
 
 
 class TestDBUtils(BaseTestCommands):


### PR DESCRIPTION
## Summary

Replace the hardcoded default JS bundle size test with a PR-relative CI check.

The new workflow builds only Frappe’s default Desk JS bundles from `app_include_js` on both the PR base and head, then fails if the combined size grows by more than 1%. On failure, it prints per-bundle changes so the regression is easier to inspect.

## Why

The previous test compared against a fixed `3.45 MB` ceiling. That caught only large drift on `develop` and required manual baseline bumps over time.

Comparing head against the PR base catches regressions introduced by the PR itself while avoiding baseline maintenance.

## Notes

- Uses the existing UI roulette, so docs-only and Python-only PRs are skipped unless forced by labels.
- Measures generated files from `sites/assets/assets.json`, matching the hashed assets produced by esbuild.
- Builds only the default JS bundles via `node esbuild --files`, not the full asset set.

## Test plan

- CI: **Default JS Bundle Size / Compare** passes on this PR.
- Verified locally that `--esbuild-files` resolves the expected default Desk bundles.