### PR TITLE
fix: misc bug fixes

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -456,12 +456,10 @@ if sentry_dsn := os.getenv("FRAPPE_SENTRY_DSN"):
 		ArgvIntegration(),
 	]
 
-	experiments = {}
 	kwargs = {}
 
 	if os.getenv("ENABLE_SENTRY_DB_MONITORING"):
 		integrations.append(FrappeIntegration())
-		experiments["record_sql_params"] = True
 
 	if tracing_sample_rate := os.getenv("SENTRY_TRACING_SAMPLE_RATE"):
 		kwargs["traces_sample_rate"] = float(tracing_sample_rate)
@@ -478,7 +476,6 @@ if sentry_dsn := os.getenv("FRAPPE_SENTRY_DSN"):
 		auto_enabling_integrations=False,
 		default_integrations=False,
 		integrations=integrations,
-		_experiments=experiments,
 		**kwargs,
 	)
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -478,7 +478,6 @@ if sentry_dsn := os.getenv("FRAPPE_SENTRY_DSN"):
 		auto_enabling_integrations=False,
 		default_integrations=False,
 		integrations=integrations,
-		include_local_variables=False,
 		_experiments=experiments,
 		**kwargs,
 	)

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -478,6 +478,7 @@ if sentry_dsn := os.getenv("FRAPPE_SENTRY_DSN"):
 		auto_enabling_integrations=False,
 		default_integrations=False,
 		integrations=integrations,
+		include_local_variables=False,
 		_experiments=experiments,
 		**kwargs,
 	)

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -1044,11 +1044,18 @@ class Column:
 		if self.df.fieldtype == "Link":
 			# find all values that dont exist
 			transform = (lambda v: cstr(v).lower()) if frappe.db.db_type == "mariadb" else cstr
-			values = list({transform(v) for v in self.column_values if v})
-			exists = [
+			# preserve the first-seen original case for each normalized value
+			original_by_key = {}
+			for v in self.column_values:
+				if not v:
+					continue
+				key = transform(v)
+				original_by_key.setdefault(key, cstr(v))
+			values = list(original_by_key)
+			exists = {
 				transform(d.name) for d in frappe.get_all(self.df.options, filters={"name": ("in", values)})
-			]
-			not_exists = list(set(values) - set(exists))
+			}
+			not_exists = [original_by_key[k] for k in values if k not in exists]
 			if not_exists:
 				missing_values = ", ".join(escape_html(v) for v in not_exists)
 				message = _("The following values do not exist for {0}: {1}")

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -1044,13 +1044,14 @@ class Column:
 		if self.df.fieldtype == "Link":
 			# find all values that dont exist
 			transform = (lambda v: cstr(v).lower()) if frappe.db.db_type == "mariadb" else cstr
-			values = list({transform(v) for v in self.column_values if v})
+			original_values = {transform(v): cstr(v) for v in self.column_values if v}
+			values = list(original_values.keys())
 			exists = [
 				transform(d.name) for d in frappe.get_all(self.df.options, filters={"name": ("in", values)})
 			]
 			not_exists = list(set(values) - set(exists))
 			if not_exists:
-				missing_values = ", ".join(escape_html(v) for v in not_exists)
+				missing_values = ", ".join(escape_html(original_values[v]) for v in not_exists)
 				message = _("The following values do not exist for {0}: {1}")
 				self.warnings.append(
 					{

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -1044,18 +1044,11 @@ class Column:
 		if self.df.fieldtype == "Link":
 			# find all values that dont exist
 			transform = (lambda v: cstr(v).lower()) if frappe.db.db_type == "mariadb" else cstr
-			# preserve the first-seen original case for each normalized value
-			original_by_key = {}
-			for v in self.column_values:
-				if not v:
-					continue
-				key = transform(v)
-				original_by_key.setdefault(key, cstr(v))
-			values = list(original_by_key)
-			exists = {
+			values = list({transform(v) for v in self.column_values if v})
+			exists = [
 				transform(d.name) for d in frappe.get_all(self.df.options, filters={"name": ("in", values)})
-			}
-			not_exists = [original_by_key[k] for k in values if k not in exists]
+			]
+			not_exists = list(set(values) - set(exists))
 			if not_exists:
 				missing_values = ", ".join(escape_html(v) for v in not_exists)
 				message = _("The following values do not exist for {0}: {1}")

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1814,7 +1814,6 @@ def validate_fields(meta: Meta):
 
 def get_fields_not_allowed_in_list_view(meta) -> list[str]:
 	not_allowed_in_list_view = list(copy.copy(no_value_fields))
-	not_allowed_in_list_view.append("Attach Image")
 	if meta.istable:
 		not_allowed_in_list_view.remove("Button")
 		not_allowed_in_list_view.remove("HTML")

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -827,10 +827,9 @@ class TestDocType(IntegrationTestCase):
 		doctype = new_doctype(
 			fields=[
 				{
-					"fieldname": "cover_image",
-					"fieldtype": "Attach Image",
-					"label": "Cover Image",
-					"reqd": 1,  # mandatory
+					"fieldname": "btn",
+					"fieldtype": "Button",
+					"label": "Btn",
 				},
 				{
 					"fieldname": "book_name",

--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -151,6 +151,10 @@ def send_request(gateway_url, params, headers=None, use_post=False, use_json=Fal
 # Create SMS Log
 # =========================================================
 def create_sms_log(args, sent_to):
+	# SMS Log doctype was removed; skip silently if it isn't available
+	# (apps that still ship it will continue to log).
+	if not frappe.db.exists("DocType", "SMS Log"):
+		return
 	sl = frappe.new_doc("SMS Log")
 	sl.sent_on = nowdate()
 	sl.message = args["message"].decode("utf-8")

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -26,19 +26,19 @@ class MariaDBExceptionUtil:
 	@staticmethod
 	def is_deadlocked(e: pymysql.Error) -> bool:
 		# Snapshot isolation is also treated as deadlock from User POV
-		return e.args[0] in (ER.LOCK_DEADLOCK, ER.CHECKREAD)
+		return bool(e.args) and e.args[0] in (ER.LOCK_DEADLOCK, ER.CHECKREAD)
 
 	@staticmethod
 	def is_timedout(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.LOCK_WAIT_TIMEOUT
+		return bool(e.args) and e.args[0] == ER.LOCK_WAIT_TIMEOUT
 
 	@staticmethod
 	def is_read_only_mode_error(e: pymysql.Error) -> bool:
-		return e.args[0] == 1792
+		return bool(e.args) and e.args[0] == 1792
 
 	@staticmethod
 	def is_table_missing(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.NO_SUCH_TABLE
+		return bool(e.args) and e.args[0] == ER.NO_SUCH_TABLE
 
 	@staticmethod
 	def is_missing_table(e: pymysql.Error) -> bool:
@@ -46,39 +46,39 @@ class MariaDBExceptionUtil:
 
 	@staticmethod
 	def is_missing_column(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.BAD_FIELD_ERROR
+		return bool(e.args) and e.args[0] == ER.BAD_FIELD_ERROR
 
 	@staticmethod
 	def is_duplicate_fieldname(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.DUP_FIELDNAME
+		return bool(e.args) and e.args[0] == ER.DUP_FIELDNAME
 
 	@staticmethod
 	def is_duplicate_entry(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.DUP_ENTRY
+		return bool(e.args) and e.args[0] == ER.DUP_ENTRY
 
 	@staticmethod
 	def is_access_denied(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.ACCESS_DENIED_ERROR
+		return bool(e.args) and e.args[0] == ER.ACCESS_DENIED_ERROR
 
 	@staticmethod
 	def cant_drop_field_or_key(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.CANT_DROP_FIELD_OR_KEY
+		return bool(e.args) and e.args[0] == ER.CANT_DROP_FIELD_OR_KEY
 
 	@staticmethod
 	def is_syntax_error(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.PARSE_ERROR
+		return bool(e.args) and e.args[0] == ER.PARSE_ERROR
 
 	@staticmethod
 	def is_statement_timeout(e: pymysql.Error) -> bool:
-		return e.args[0] == 1969
+		return bool(e.args) and e.args[0] == 1969
 
 	@staticmethod
 	def is_data_too_long(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.DATA_TOO_LONG
+		return bool(e.args) and e.args[0] == ER.DATA_TOO_LONG
 
 	@staticmethod
 	def is_db_table_size_limit(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.TOO_BIG_ROWSIZE
+		return bool(e.args) and e.args[0] == ER.TOO_BIG_ROWSIZE
 
 	@staticmethod
 	def is_primary_key_violation(e: pymysql.Error) -> bool:

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -26,19 +26,19 @@ class MariaDBExceptionUtil:
 	@staticmethod
 	def is_deadlocked(e: pymysql.Error) -> bool:
 		# Snapshot isolation is also treated as deadlock from User POV
-		return bool(e.args) and e.args[0] in (ER.LOCK_DEADLOCK, ER.CHECKREAD)
+		return e.args and e.args[0] in (ER.LOCK_DEADLOCK, ER.CHECKREAD)
 
 	@staticmethod
 	def is_timedout(e: pymysql.Error) -> bool:
-		return bool(e.args) and e.args[0] == ER.LOCK_WAIT_TIMEOUT
+		return e.args and e.args[0] == ER.LOCK_WAIT_TIMEOUT
 
 	@staticmethod
 	def is_read_only_mode_error(e: pymysql.Error) -> bool:
-		return bool(e.args) and e.args[0] == 1792
+		return e.args and e.args[0] == 1792
 
 	@staticmethod
 	def is_table_missing(e: pymysql.Error) -> bool:
-		return bool(e.args) and e.args[0] == ER.NO_SUCH_TABLE
+		return e.args and e.args[0] == ER.NO_SUCH_TABLE
 
 	@staticmethod
 	def is_missing_table(e: pymysql.Error) -> bool:
@@ -46,39 +46,39 @@ class MariaDBExceptionUtil:
 
 	@staticmethod
 	def is_missing_column(e: pymysql.Error) -> bool:
-		return bool(e.args) and e.args[0] == ER.BAD_FIELD_ERROR
+		return e.args and e.args[0] == ER.BAD_FIELD_ERROR
 
 	@staticmethod
 	def is_duplicate_fieldname(e: pymysql.Error) -> bool:
-		return bool(e.args) and e.args[0] == ER.DUP_FIELDNAME
+		return e.args and e.args[0] == ER.DUP_FIELDNAME
 
 	@staticmethod
 	def is_duplicate_entry(e: pymysql.Error) -> bool:
-		return bool(e.args) and e.args[0] == ER.DUP_ENTRY
+		return e.args and e.args[0] == ER.DUP_ENTRY
 
 	@staticmethod
 	def is_access_denied(e: pymysql.Error) -> bool:
-		return bool(e.args) and e.args[0] == ER.ACCESS_DENIED_ERROR
+		return e.args and e.args[0] == ER.ACCESS_DENIED_ERROR
 
 	@staticmethod
 	def cant_drop_field_or_key(e: pymysql.Error) -> bool:
-		return bool(e.args) and e.args[0] == ER.CANT_DROP_FIELD_OR_KEY
+		return e.args and e.args[0] == ER.CANT_DROP_FIELD_OR_KEY
 
 	@staticmethod
 	def is_syntax_error(e: pymysql.Error) -> bool:
-		return bool(e.args) and e.args[0] == ER.PARSE_ERROR
+		return e.args and e.args[0] == ER.PARSE_ERROR
 
 	@staticmethod
 	def is_statement_timeout(e: pymysql.Error) -> bool:
-		return bool(e.args) and e.args[0] == 1969
+		return e.args and e.args[0] == 1969
 
 	@staticmethod
 	def is_data_too_long(e: pymysql.Error) -> bool:
-		return bool(e.args) and e.args[0] == ER.DATA_TOO_LONG
+		return e.args and e.args[0] == ER.DATA_TOO_LONG
 
 	@staticmethod
 	def is_db_table_size_limit(e: pymysql.Error) -> bool:
-		return bool(e.args) and e.args[0] == ER.TOO_BIG_ROWSIZE
+		return e.args and e.args[0] == ER.TOO_BIG_ROWSIZE
 
 	@staticmethod
 	def is_primary_key_violation(e: pymysql.Error) -> bool:

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -29,19 +29,19 @@ class MariaDBExceptionUtil:
 	@staticmethod
 	def is_deadlocked(e: MySQLdb.Error) -> bool:
 		# Snapshot isolation is also treated as deadlock from User POV
-		return e.args[0] in (ER.LOCK_DEADLOCK, ER.CHECKREAD)
+		return e.args and e.args[0] in (ER.LOCK_DEADLOCK, ER.CHECKREAD)
 
 	@staticmethod
 	def is_timedout(e: MySQLdb.Error) -> bool:
-		return e.args[0] == ER.LOCK_WAIT_TIMEOUT
+		return e.args and e.args[0] == ER.LOCK_WAIT_TIMEOUT
 
 	@staticmethod
 	def is_read_only_mode_error(e: MySQLdb.Error) -> bool:
-		return e.args[0] == ER.CANT_EXECUTE_IN_READ_ONLY_TRANSACTION
+		return e.args and e.args[0] == ER.CANT_EXECUTE_IN_READ_ONLY_TRANSACTION
 
 	@staticmethod
 	def is_table_missing(e: MySQLdb.Error) -> bool:
-		return e.args[0] == ER.NO_SUCH_TABLE
+		return e.args and e.args[0] == ER.NO_SUCH_TABLE
 
 	@staticmethod
 	def is_missing_table(e: MySQLdb.Error) -> bool:
@@ -49,39 +49,39 @@ class MariaDBExceptionUtil:
 
 	@staticmethod
 	def is_missing_column(e: MySQLdb.Error) -> bool:
-		return e.args[0] == ER.BAD_FIELD_ERROR
+		return e.args and e.args[0] == ER.BAD_FIELD_ERROR
 
 	@staticmethod
 	def is_duplicate_fieldname(e: MySQLdb.Error) -> bool:
-		return e.args[0] == ER.DUP_FIELDNAME
+		return e.args and e.args[0] == ER.DUP_FIELDNAME
 
 	@staticmethod
 	def is_duplicate_entry(e: MySQLdb.Error) -> bool:
-		return e.args[0] == ER.DUP_ENTRY
+		return e.args and e.args[0] == ER.DUP_ENTRY
 
 	@staticmethod
 	def is_access_denied(e: MySQLdb.Error) -> bool:
-		return e.args[0] == ER.ACCESS_DENIED_ERROR
+		return e.args and e.args[0] == ER.ACCESS_DENIED_ERROR
 
 	@staticmethod
 	def cant_drop_field_or_key(e: MySQLdb.Error) -> bool:
-		return e.args[0] == ER.CANT_DROP_FIELD_OR_KEY
+		return e.args and e.args[0] == ER.CANT_DROP_FIELD_OR_KEY
 
 	@staticmethod
 	def is_syntax_error(e: MySQLdb.Error) -> bool:
-		return e.args[0] == ER.PARSE_ERROR
+		return e.args and e.args[0] == ER.PARSE_ERROR
 
 	@staticmethod
 	def is_statement_timeout(e: MySQLdb.Error) -> bool:
-		return e.args[0] == ER_STATEMENT_TIMEOUT
+		return e.args and e.args[0] == ER_STATEMENT_TIMEOUT
 
 	@staticmethod
 	def is_data_too_long(e: MySQLdb.Error) -> bool:
-		return e.args[0] == ER.DATA_TOO_LONG
+		return e.args and e.args[0] == ER.DATA_TOO_LONG
 
 	@staticmethod
 	def is_db_table_size_limit(e: MySQLdb.Error) -> bool:
-		return e.args[0] == ER.TOO_BIG_ROWSIZE
+		return e.args and e.args[0] == ER.TOO_BIG_ROWSIZE
 
 	@staticmethod
 	def is_primary_key_violation(e: MySQLdb.Error) -> bool:

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -636,15 +636,17 @@ class Engine:
 			# If _field is from a dynamic field, its name might be just the target fieldname.
 			# We need the original string ('link.target') or the fieldname from the main doctype.
 			original_field_name = field if isinstance(field, str) else _field.name
-			# Check if the original field name exists in the *main* doctype meta
-			main_meta = frappe.get_meta(self.doctype)
-			if main_meta.has_field(original_field_name):
-				_df = main_meta.get_field(original_field_name)
-				ref_doctype = _df.options if _df else self.doctype
+			# When the filter targets a child table, resolve the field against
+			# the child doctype rather than the parent.
+			lookup_doctype = doctype or self.doctype
+			lookup_meta = frappe.get_meta(lookup_doctype)
+			if lookup_meta.has_field(original_field_name):
+				_df = lookup_meta.get_field(original_field_name)
+				ref_doctype = _df.options if _df else lookup_doctype
 			else:
-				# If not in main doctype, assume it's a standard field like 'name' or refers to the main doctype itself
+				# If not in lookup doctype, assume it's a standard field like 'name' or refers to the lookup doctype itself
 				# This part might need refinement if nested set operators are used with dynamic fields.
-				ref_doctype = self.doctype
+				ref_doctype = lookup_doctype
 
 			nodes = get_nested_set_hierarchy_result(ref_doctype, docname, hierarchy)
 			operator_fn = (

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -146,7 +146,7 @@ class DBTable:
 					# case when the field is no longer a varchar
 					continue
 				current_length = current_length[0]
-				if cint(current_length) != cint(new_length):
+				if cint(current_length) > cint(new_length):
 					try:
 						# check for truncation
 						max_length = frappe.db.sql(

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -293,7 +293,7 @@ def get_group_by_chart_config(chart, filters) -> dict | None:
 
 	if data:
 		return {
-			"labels": [item.get("name", "Not Specified") for item in data],
+			"labels": [_(item.get("name", "Not Specified")) for item in data],
 			"datasets": [{"name": _(chart.name), "values": [item["count"] for item in data]}],
 		}
 	return None

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -286,14 +286,16 @@ def get_group_by_chart_config(chart, filters) -> dict | None:
 	)  # get info about @group_by_field
 
 	if data and group_by_field_field.fieldtype == "Link":  # if @group_by_field is link
-		title_field = frappe.get_meta(group_by_field_field.options)  # get title field
-		if title_field.title_field:  # if has title_field
-			for item in data:  # replace chart labels from name to title value
-				item.name = frappe.get_value(group_by_field_field.options, item.name, title_field.title_field)
+		meta = frappe.get_meta(group_by_field_field.options)  # get title field
+		for item in data:  # replace chart labels from name to title value
+			if meta.title_field:
+				item.name = frappe.get_value(group_by_field_field.options, item.name, meta.title_field)
+			elif meta.translated_doctype:
+				item.name = _(item.get("name", "Not Specified"))
 
 	if data:
 		return {
-			"labels": [_(item.get("name", "Not Specified")) for item in data],
+			"labels": [item.name for item in data],
 			"datasets": [{"name": _(chart.name), "values": [item["count"] for item in data]}],
 		}
 	return None

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -325,15 +325,23 @@ def create_user_icons(user, data):
 
 @frappe.whitelist()
 def add_workspace_to_desktop(workspace: str):
-	sidebar = frappe.new_doc("Workspace Sidebar")
-	sidebar_item = frappe.new_doc("Workspace Sidebar Item")
-	sidebar_item.label = workspace
-	sidebar_item.type = "Link"
-	sidebar_item.link_to = workspace
-	sidebar_item.link_type = "Workspace"
-	sidebar.title = workspace
-	sidebar.append("items", sidebar_item)
-	sidebar.save()
+	if frappe.db.exists("Workspace Sidebar", workspace):
+		sidebar = frappe.get_doc("Workspace Sidebar", workspace)
+	else:
+		sidebar = frappe.new_doc("Workspace Sidebar")
+		sidebar.title = workspace
+
+	if not any(item.link_to == workspace for item in sidebar.get("items", [])):
+		sidebar_item = frappe.new_doc("Workspace Sidebar Item")
+		sidebar_item.label = workspace
+		sidebar_item.type = "Link"
+		sidebar_item.link_to = workspace
+		sidebar_item.link_type = "Workspace"
+		sidebar.append("items", sidebar_item)
+		sidebar.save()
+
+	if frappe.db.exists("Desktop Icon", workspace):
+		return {"icon": frappe.get_doc("Desktop Icon", workspace).as_dict()}
 
 	new_icon = frappe.new_doc("Desktop Icon")
 	new_icon.label = workspace

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -110,7 +110,7 @@ def add(args: dict[str, Any] | None = None, *, ignore_permissions: bool | int = 
 					)
 					frappe.throw(msg, title=_("Missing Permission"))
 				else:
-					frappe.share.add(doc.doctype, doc.name, assign_to)
+					frappe.share.add(doc.doctype, str(doc.name), assign_to)
 					shared_with_users.append(assign_to)
 
 			# make this document followed by assigned user

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -581,7 +581,8 @@ class Email:
 		if not fcontent:
 			return
 
-		attachment_limit = cint(self.email_account.attachment_limit)
+		email_account = getattr(self, "email_account", None)
+		attachment_limit = cint(email_account.attachment_limit) if email_account else 0
 		if attachment_limit and len(fcontent) > attachment_limit * 1024 * 1024:
 			return  # skip attachments that are larger than the specified limit
 

--- a/frappe/integrations/doctype/token_cache/token_cache.py
+++ b/frappe/integrations/doctype/token_cache/token_cache.py
@@ -44,7 +44,7 @@ class TokenCache(Document):
 		Params:
 		data - Dict with access_token, refresh_token, expires_in and scope.
 		"""
-		token_type = cstr(data.get("token_type", "")).lower()
+		token_type = cstr(data.get("token_type", "bearer")).lower()
 		if token_type not in ["bearer", "mac"]:
 			frappe.throw(_("Received an invalid token type."))
 		# 'Bearer' or 'MAC'

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -182,12 +182,11 @@ def enqueue_webhook(doc, webhook) -> None:
 		except Exception as e:
 			frappe.logger().debug({"webhook_error": e, "try": i + 1})
 			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data, r)
-			sleep(3 * i + 1)
-			if i != 2:
+			if i < 2:
+				sleep(3 * i + 1)
 				continue
-			else:
-				if webhook.webhook_docevent == "workflow_transition":
-					raise e
+			if webhook.webhook_docevent == "workflow_transition":
+				raise e
 
 
 def log_request(

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -153,8 +153,8 @@ def enqueue_webhook(doc, webhook) -> None:
 		request_url = webhook.request_url
 		if webhook.is_dynamic_url:
 			request_url = frappe.render_template(webhook.request_url, get_context(doc))
-		headers = get_webhook_headers(doc, webhook)
 		data = get_webhook_data(doc, webhook)
+		headers = get_webhook_headers(doc, webhook, data=data)
 
 	except Exception as e:
 		frappe.logger().debug({"enqueue_webhook_error": e})
@@ -216,15 +216,16 @@ def log_request(
 	request_log.save(ignore_permissions=True)
 
 
-def get_webhook_headers(doc, webhook):
+def get_webhook_headers(doc, webhook, data=None):
 	headers = {}
 
 	if webhook.enable_security:
-		data = get_webhook_data(doc, webhook)
+		if data is None:
+			data = get_webhook_data(doc, webhook)
 		signature = base64.b64encode(
 			hmac.new(
 				webhook.get_password("webhook_secret").encode("utf8"),
-				json.dumps(data).encode("utf8"),
+				json.dumps(data, default=str).encode("utf8"),
 				hashlib.sha256,
 			).digest()
 		)

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -166,7 +166,7 @@ def enqueue_webhook(doc, webhook) -> None:
 			r = requests.request(
 				method=webhook.request_method,
 				url=request_url,
-				data=json.dumps(data, default=str),
+				data=frappe.as_json(data),
 				headers=headers,
 				timeout=webhook.timeout or 5,
 			)
@@ -225,7 +225,7 @@ def get_webhook_headers(doc, webhook, data=None):
 		signature = base64.b64encode(
 			hmac.new(
 				webhook.get_password("webhook_secret").encode("utf8"),
-				json.dumps(data, default=str).encode("utf8"),
+				frappe.as_json(data).encode("utf8"),
 				hashlib.sha256,
 			).digest()
 		)

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -659,7 +659,7 @@ class BaseDocument:
 		return valid_columns_cache[self.doctype]
 
 	def is_new(self) -> bool:
-		return self.get("__islocal")
+		return bool(self.get("__islocal"))
 
 	@property
 	def docstatus(self) -> DocStatus:

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1643,7 +1643,9 @@ def _filter(data, filters, limit=None):
 	return out
 
 
-CACHED_PROPERTIES = (prop for prop, value in vars(BaseDocument).items() if isinstance(value, cached_property))
+CACHED_PROPERTIES = tuple(
+	prop for prop, value in vars(BaseDocument).items() if isinstance(value, cached_property)
+)
 
 UNPICKLABLE_KEYS = frozenset(
 	(

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -86,7 +86,16 @@ def update_document_title(
 				save_point=True,
 			)
 
-			doc.queue_action("rename", name=transformed_name, merge=merge, queue=queue, timeout=36000)
+			# validate_rename above already ran before_rename + validations;
+			# skip them in the background job to avoid double-execution.
+			doc.queue_action(
+				"rename",
+				name=transformed_name,
+				merge=merge,
+				validate_rename=False,
+				queue=queue,
+				timeout=36000,
+			)
 		else:
 			doc.rename(updated_name, merge=merge)
 

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -75,17 +75,6 @@ def update_document_title(
 				transformed_name = transformed_name.get("new")
 			transformed_name = transformed_name or updated_name
 
-			# run rename validations before queueing
-			# use savepoints to avoid partial renames / commits
-			validate_rename(
-				doctype=doctype,
-				old=current_name,
-				new=transformed_name,
-				meta=doc.meta,
-				merge=merge,
-				save_point=True,
-			)
-
 			doc.queue_action("rename", name=transformed_name, merge=merge, queue=queue, timeout=36000)
 		else:
 			doc.rename(updated_name, merge=merge)

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -86,16 +86,7 @@ def update_document_title(
 				save_point=True,
 			)
 
-			# validate_rename above already ran before_rename + validations;
-			# skip them in the background job to avoid double-execution.
-			doc.queue_action(
-				"rename",
-				name=transformed_name,
-				merge=merge,
-				validate_rename=False,
-				queue=queue,
-				timeout=36000,
-			)
+			doc.queue_action("rename", name=transformed_name, merge=merge, queue=queue, timeout=36000)
 		else:
 			doc.rename(updated_name, merge=merge)
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1521,3 +1521,29 @@ class TestDbConnectWithEnvCredentials(IntegrationTestCase):
 		frappe.init(self.current_site, force=True)
 		frappe.connect()
 		frappe.db.connect()
+
+
+class TestMariaDBExceptionUtil(IntegrationTestCase):
+	@run_only_if(db_type_is.MARIADB)
+	def test_exception_utils_handle_empty_args(self):
+		"""Exception utility methods should not raise IndexError when e.args is empty."""
+		import pymysql
+
+		from frappe.database.mariadb.database import MariaDBExceptionUtil
+
+		e = pymysql.Error()  # no args
+
+		# None of these should raise; all should return False
+		self.assertFalse(MariaDBExceptionUtil.is_deadlocked(e))
+		self.assertFalse(MariaDBExceptionUtil.is_timedout(e))
+		self.assertFalse(MariaDBExceptionUtil.is_read_only_mode_error(e))
+		self.assertFalse(MariaDBExceptionUtil.is_table_missing(e))
+		self.assertFalse(MariaDBExceptionUtil.is_missing_column(e))
+		self.assertFalse(MariaDBExceptionUtil.is_duplicate_fieldname(e))
+		self.assertFalse(MariaDBExceptionUtil.is_duplicate_entry(e))
+		self.assertFalse(MariaDBExceptionUtil.is_access_denied(e))
+		self.assertFalse(MariaDBExceptionUtil.cant_drop_field_or_key(e))
+		self.assertFalse(MariaDBExceptionUtil.is_syntax_error(e))
+		self.assertFalse(MariaDBExceptionUtil.is_statement_timeout(e))
+		self.assertFalse(MariaDBExceptionUtil.is_data_too_long(e))
+		self.assertFalse(MariaDBExceptionUtil.is_db_table_size_limit(e))

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -827,6 +827,82 @@ class TestQuery(IntegrationTestCase):
 		frappe.db.sql("delete from `tabDocType` where `name` = 'Test Tree DocType'")
 		frappe.db.sql_ddl("drop table if exists `tabTest Tree DocType`")
 
+	def test_nestedset_on_child_table_field(self):
+		"""Nested-set operator on a child-table link field should resolve the field
+		against the child doctype, not the parent (issue #38776)."""
+		tree_dt = child_dt = parent_dt = None
+		try:
+			tree_dt = new_doctype(is_tree=True, autoname="field:some_fieldname").insert()
+			parent_field = "parent_" + tree_dt.name.lower().replace(" ", "_")
+
+			for record in [
+				{"some_fieldname": "Root Node", parent_field: None, "is_group": 1},
+				{"some_fieldname": "Parent 1", parent_field: "Root Node", "is_group": 1},
+				{"some_fieldname": "Parent 2", parent_field: "Root Node", "is_group": 1},
+				{"some_fieldname": "Child 1", parent_field: "Parent 1", "is_group": 0},
+				{"some_fieldname": "Child 2", parent_field: "Parent 1", "is_group": 0},
+				{"some_fieldname": "Child 3", parent_field: "Parent 2", "is_group": 0},
+			]:
+				d = frappe.new_doc(tree_dt.name)
+				d.update(record)
+				d.insert()
+
+			child_dt = new_doctype(
+				istable=1,
+				fields=[
+					{
+						"fieldname": "tree_link",
+						"fieldtype": "Link",
+						"options": tree_dt.name,
+						"label": "Tree Link",
+					}
+				],
+			).insert()
+			parent_dt = new_doctype(
+				fields=[
+					{
+						"fieldname": "rows",
+						"fieldtype": "Table",
+						"options": child_dt.name,
+						"label": "Rows",
+					}
+				],
+			).insert()
+
+			p1 = frappe.get_doc(
+				doctype=parent_dt.name,
+				rows=[{"tree_link": "Child 1"}, {"tree_link": "Child 2"}],
+			).insert()
+			p2 = frappe.get_doc(
+				doctype=parent_dt.name,
+				rows=[{"tree_link": "Child 3"}],
+			).insert()
+
+			# Before the fix, the field was looked up on the parent doctype meta
+			# and ref_doctype fell back to the parent — producing
+			# "Unknown column 'lft'" against the parent table.
+			result = frappe.get_all(
+				parent_dt.name,
+				filters=[[child_dt.name, "tree_link", "descendants of", "Parent 1"]],
+				pluck="name",
+			)
+			self.assertIn(p1.name, result)
+			self.assertNotIn(p2.name, result)
+
+			# Also exercise the qb path directly.
+			rows = frappe.qb.get_query(
+				parent_dt.name,
+				fields=["name"],
+				filters=[[child_dt.name, "tree_link", "descendants of", "Parent 1"]],
+			).run(as_dict=1)
+			names = {r.name for r in rows}
+			self.assertIn(p1.name, names)
+			self.assertNotIn(p2.name, names)
+		finally:
+			for dt in filter(None, [parent_dt, child_dt, tree_dt]):
+				frappe.db.sql("delete from `tabDocType` where `name` = %s", dt.name)
+				frappe.db.sql_ddl(f"drop table if exists `tab{dt.name}`")
+
 	def test_child_field_syntax(self):
 		note1 = frappe.get_doc(doctype="Note", title="Note 1", seen_by=[{"user": "Administrator"}]).insert()
 		note2 = frappe.get_doc(

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -788,6 +788,7 @@ def _start_sentry():
 		auto_enabling_integrations=False,
 		default_integrations=False,
 		integrations=integrations,
+		include_local_variables=False,
 		_experiments=experiments,
 		**kwargs,
 	)

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -788,7 +788,6 @@ def _start_sentry():
 		auto_enabling_integrations=False,
 		default_integrations=False,
 		integrations=integrations,
-		include_local_variables=False,
 		_experiments=experiments,
 		**kwargs,
 	)

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -767,12 +767,10 @@ def _start_sentry():
 		ArgvIntegration(),
 	]
 
-	experiments = {}
 	kwargs = {}
 
 	if os.getenv("ENABLE_SENTRY_DB_MONITORING"):
 		integrations.append(FrappeIntegration())
-		experiments["record_sql_params"] = True
 
 	if tracing_sample_rate := os.getenv("SENTRY_TRACING_SAMPLE_RATE"):
 		kwargs["traces_sample_rate"] = float(tracing_sample_rate)
@@ -788,6 +786,5 @@ def _start_sentry():
 		auto_enabling_integrations=False,
 		default_integrations=False,
 		integrations=integrations,
-		_experiments=experiments,
 		**kwargs,
 	)

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -648,7 +648,7 @@ def new_backup(
 	return odb
 
 
-def delete_temp_backups(older_than=24):
+def delete_temp_backups(older_than=23):
 	"""
 	Cleans up the backup_link_path directory by deleting older files
 	"""

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -107,7 +107,7 @@ def include_script(path, preload=True):
 
 		frappe.local.preload_assets["script"].append(path)
 
-	return f'<script type="text/javascript" src="{path}" defer></script>'
+	return f'<script type="text/javascript" src="{path}"></script>'
 
 
 def include_icons(path, preload=True):

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -107,7 +107,7 @@ def include_script(path, preload=True):
 
 		frappe.local.preload_assets["script"].append(path)
 
-	return f'<script type="text/javascript" src="{path}"></script>'
+	return f'<script type="text/javascript" src="{path}" defer></script>'
 
 
 def include_icons(path, preload=True):

--- a/frappe/utils/password.py
+++ b/frappe/utils/password.py
@@ -250,4 +250,8 @@ def get_encryption_key():
 
 
 def get_password_reset_limit():
+	# Signed-in users (e.g. admins triggering reset for others) should not
+	# share the same rate-limit bucket used to throttle anonymous abuse.
+	if getattr(frappe.session, "user", "Guest") != "Guest":
+		return 99999
 	return frappe.get_system_settings("password_reset_limit") or 3

--- a/frappe/utils/password.py
+++ b/frappe/utils/password.py
@@ -252,6 +252,6 @@ def get_encryption_key():
 def get_password_reset_limit():
 	# Signed-in users (e.g. admins triggering reset for others) should not
 	# share the same rate-limit bucket used to throttle anonymous abuse.
-	if getattr(frappe.session, "user", "Guest") != "Guest":
-		return 99999
+	if "System Manager" in frappe.get_roles():
+		return 1000
 	return frappe.get_system_settings("password_reset_limit") or 3

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -408,7 +408,7 @@ def get_sentinel_connection(
 	)
 
 
-class _TrackedConnection(redis.Connection):
+class _ClientTrackingMixin:
 	def __init__(self, *args, **kwargs):
 		self._invalidator_id = kwargs.pop("_invalidator_id")
 		super().__init__(*args, **kwargs)
@@ -428,6 +428,14 @@ class _TrackedConnection(redis.Connection):
 				raise Exception("Redis version is not supported, upgrade to Redis 6.0 or higher.")
 			else:
 				raise
+
+
+class _TrackedConnection(_ClientTrackingMixin, redis.Connection):
+	pass
+
+
+class _TrackedUnixDomainSocketConnection(_ClientTrackingMixin, redis.UnixDomainSocketConnection):
+	pass
 
 
 CachedValue = namedtuple("CachedValue", ["value", "expiry"])
@@ -495,9 +503,13 @@ class ClientCache:
 		if not self.invalidator_id:
 			return
 
+		redis_url = frappe.conf.get("redis_cache") or ""
+		connection_class = (
+			_TrackedUnixDomainSocketConnection if redis_url.startswith("unix://") else _TrackedConnection
+		)
 		self.redis: RedisWrapper = RedisWrapper.from_url(
-			frappe.conf.get("redis_cache"),
-			connection_class=_TrackedConnection,
+			redis_url,
+			connection_class=connection_class,
 			_invalidator_id=self.invalidator_id,
 			protocol=2,
 		)

--- a/frappe/utils/sentry.py
+++ b/frappe/utils/sentry.py
@@ -3,8 +3,7 @@ import sys
 from datetime import UTC, datetime
 
 import rq
-from sentry_sdk import capture_message as sentry_capture_message
-from sentry_sdk.hub import Hub
+import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations.wsgi import _make_wsgi_event_processor
 from sentry_sdk.tracing import SOURCE_FOR_STYLE
@@ -25,22 +24,17 @@ class FrappeIntegration(Integration):
 		real_sql = Database.sql
 
 		def sql(self, query, values=None, *args, **kwargs):
-			hub = Hub.current
-
 			if not self._conn:
 				self.connect()
 
-			with record_sql_queries(
-				hub, self._cursor, query, values, paramstyle="pyformat", executemany=False
-			):
+			with record_sql_queries(self._cursor, query, values, paramstyle="pyformat", executemany=False):
 				return real_sql(self, query, values or EmptyQueryValues, *args, **kwargs)
 
 		def connect(self):
-			hub = Hub.current
 			with capture_internal_exceptions():
-				hub.add_breadcrumb(message="connect", category="query")
+				sentry_sdk.add_breadcrumb(message="connect", category="query")
 
-			with hub.start_span(op="db", description="connect"):
+			with sentry_sdk.start_span(op="db", name="connect"):
 				return real_connect(self)
 
 		Database.connect = connect
@@ -89,9 +83,7 @@ def set_sentry_context():
 	if not frappe.get_system_settings("enable_telemetry"):
 		return
 
-	hub = Hub.current
-	with hub.configure_scope() as scope:
-		set_scope(scope)
+	set_scope(sentry_sdk.get_current_scope())
 
 
 def before_send(event, hint):
@@ -110,8 +102,7 @@ def capture_exception(message: str | None = None) -> None:
 	if not frappe.get_system_settings("enable_telemetry"):
 		return
 	try:
-		hub = Hub.current
-		with hub.configure_scope() as scope:
+		with sentry_sdk.new_scope() as scope:
 			if (
 				os.getenv("ENABLE_SENTRY_DB_MONITORING") is None
 				or os.getenv("SENTRY_TRACING_SAMPLE_RATE") is None
@@ -126,21 +117,22 @@ def capture_exception(message: str | None = None) -> None:
 				elif frappe.request.form:
 					scope.set_context("Form Data", frappe.request.form)
 
-		if client := hub.client:
-			exc_info = sys.exc_info()
-			if any(exc_info):
-				# Don't report errors which we can't "fix" in code
-				if isinstance(exc_info[1], frappe.ValidationError | frappe.PermissionError):
-					return
+			client = sentry_sdk.get_client()
+			if client.is_active():
+				exc_info = sys.exc_info()
+				if any(exc_info):
+					# Don't report errors which we can't "fix" in code
+					if isinstance(exc_info[1], frappe.ValidationError | frappe.PermissionError):
+						return
 
-				event, hint = event_from_exception(
-					exc_info,
-					client_options=client.options,
-					mechanism={"type": "wsgi", "handled": False},
-				)
-				hub.capture_event(event, hint=hint)
-			elif message:
-				sentry_capture_message(message, level="error")
+					event, hint = event_from_exception(
+						exc_info,
+						client_options=client.options,
+						mechanism={"type": "wsgi", "handled": False},
+					)
+					sentry_sdk.capture_event(event, hint=hint)
+				elif message:
+					sentry_sdk.capture_message(message, level="error")
 
 	except Exception:
 		frappe.logger().error("Failed to capture exception", exc_info=True)

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -460,9 +460,7 @@ def get_context(context):
 		)
 
 		if context.success_message:
-			context.success_message = frappe.db.escape(context.success_message.replace("\n", "<br>")).strip(
-				"'"
-			)
+			context.success_message = context.success_message.replace("\n", "<br>")
 
 		if not context.max_attachment_size:
 			context.max_attachment_size = get_max_file_size() / 1024 / 1024

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -16,6 +16,7 @@ from frappe.permissions import check_doctype_permission
 from frappe.rate_limiter import rate_limit
 from frappe.utils import dict_with_keys, strip_html
 from frappe.utils.caching import redis_cache
+from frappe.utils.data import escape_html
 from frappe.website.utils import get_boot_data, get_comment_list, get_sidebar_items
 from frappe.website.website_generator import WebsiteGenerator
 
@@ -460,7 +461,7 @@ def get_context(context):
 		)
 
 		if context.success_message:
-			context.success_message = context.success_message.replace("\n", "<br>")
+			context.success_message = escape_html(context.success_message).replace("\n", "<br>")
 
 		if not context.max_attachment_size:
 			context.max_attachment_size = get_max_file_size() / 1024 / 1024

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     "rq==2.6.1",
     "rsa~=4.9.1",
     "semantic-version~=2.10.0",
-    "sentry-sdk~=1.45.1",
+    "sentry-sdk~=2.20",
     "sqlparse~=0.5.5",
     "sql_metadata~=2.19.0",
     "tenacity~=9.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     "rq==2.6.1",
     "rsa~=4.9.1",
     "semantic-version~=2.10.0",
-    "sentry-sdk~=2.20",
+    "sentry-sdk~=2.60.0",
     "sqlparse~=0.5.5",
     "sql_metadata~=2.19.0",
     "tenacity~=9.1.2",


### PR DESCRIPTION
An experiment to see where LLM capabilities are these days and how well they work with Frappe codebase.

Commits with Claude as the co-author are all vibed by claude with only issue description as prompt.


My rework summary:

1. Removed unnecessary use of `bool`, python has truthy stuff, no need. https://github.com/frappe/frappe/pull/39397/commits/05baf61c2f5d403f3af1dc2eafa2a87b018c7a91 Can be avoided by specifying some taste.md
2. pymysql fix wasn't applied to mariadb, copied https://github.com/frappe/frappe/pull/39397/changes/7b89d5096deee57524941a4978e59cff49dc58e5 can be fixed by some skills.md? 
3. Fix for https://github.com/frappe/frappe/issues/39324 was invalid by 3 different people: reporter, our co-maintainer and claude. We shouldn't just translate everything, only doctypes that are supposed to be translated should be translated else it will end up getting double translations. Holy edge case :smile: Can be fixed by documenting nuances of translation system implementation in framework. 
4. Sentry fix was just a hack, reverted https://github.com/frappe/frappe/pull/39397/commits/c000c6f946ca0769763a29538a211f28fc868f7b 
5. Rate limit was bypassed for all users, should be limited to trusted users only for DID. https://github.com/frappe/frappe/pull/39397/commits/cbf401dfbe79cffbdae2ff1ceaff1648ba328979 
6. Reverted a fix that removed validations on rename as per bug report. This is a bad idea because if those stateful changes were required they won't persist in actual rename job. https://github.com/frappe/frappe/pull/39397/commits/d861b1100fae696de0dc79abcf6ac5422d1a15b2 
7. Instead of casting everything to string, use `frappe.as_json` for better serialization of data: https://github.com/frappe/frappe/pull/39397/changes/50f5d0face7ea1d5125c34f7cbebdf78c175ba20 
8. Reverted verbose https://github.com/frappe/frappe/pull/39397/changes/72dbc7940230f2790bb4edba4a48394ab746f6ad in favor of simpler https://github.com/frappe/frappe/pull/37940 
9. Claude removed invalid `db.escape` where HTML was being escaped but then didn't escape it at all. https://github.com/frappe/frappe/pull/39397/commits/8243afeb9deddb03569d4ad0a18575b0e4f5098f
10. Claude applied suggested fix which is potentially breaking: https://github.com/frappe/frappe/pull/39397/commits/65970901b8ad099c495b3c063ee6a8b6360aa336 The fix was only useful for automated testing anyway, so risks don't justify it.
11. Removed ~4-5 fixes for which I didn't have enough context/time to fix.