### PR TITLE
fix: bring awesomebar on toolbar again

### DIFF
--- a/cypress/integration/awesome_bar.js
+++ b/cypress/integration/awesome_bar.js
@@ -12,7 +12,7 @@ context("Awesome Bar", () => {
 	beforeEach(() => {
 		cy.get("body").type("{esc}");
 		cy.wait(300);
-		cy.get("#navbar-modal-search").as("awesome_bar_search");
+		cy.get("#full-search-button").as("awesome_bar_search");
 		cy.get("@awesome_bar_search").click();
 		cy.get("#navbar-search").as("awesome_bar");
 		cy.get("#navbar-search").type("{selectall}");

--- a/frappe/desk/page/desktop/desktop.css
+++ b/frappe/desk/page/desktop/desktop.css
@@ -34,30 +34,8 @@
     z-index: 1030;
 }
 
-.desktop-search-wrapper{
-    flex: 1;
-    position: relative;
-}
-
-.desktop-search-wrapper span {
-    color: var(--text-light);
-}
-
-.desktop-navbar-modal-search {
-    background-color: var(--control-bg);
-    border-radius: var(--border-radius-sm);
-    height: 32px;
-    padding: 0px 10px;
-    display: flex;
-    align-items: center;
-    width: 100%;
-    margin-right: 0px;
-}
 #brand-logo{
     width: auto;
-}
-.desktop-search-icon > svg {
-    stroke: var(--text-light);
 }
 
 .desktop-container{
@@ -482,9 +460,6 @@
 [data-theme="dark"] .desktop-edit:hover{
 	opacity: 0.8;
 	transition: opacity 0.3s;
-}
-.desktop-navbar-modal-search:hover{
-    outline: 1px solid var(--surface-gray-3);
 }
 .desktop-pane{
     position: absolute;

--- a/frappe/desk/page/desktop/desktop.html
+++ b/frappe/desk/page/desktop/desktop.html
@@ -9,16 +9,16 @@
             >
         </div>
         {% if (show_search_bar) %}
-            <div class="desktop-search-wrapper input-group search-bar">
-                <button id="desktop-navbar-modal-search" class="btn-reset flex justify-between desktop-navbar-modal-search"
+            <div class="search-widget-wrapper input-group search-bar">
+                <button id="search-widget-button" class="btn-reset search-widget-button"
                     title="Search">
-                    <span class="desktop-search-icon">
+                    <span class="search-widget-icon">
                         <svg class="icon icon-sm">
                             <use href="#icon-search"></use>
                         </svg>
                         {{ _("Search") }}
                     </span>
-                    <span class="desktop-keyboard-shortcut">
+                    <span class="search-widget-shortcut">
                     </span>
                 </button>
             </div>

--- a/frappe/desk/page/desktop/desktop.js
+++ b/frappe/desk/page/desktop/desktop.js
@@ -511,9 +511,9 @@ class DesktopPage {
 
 	setup_awesomebar() {
 		if (!frappe.is_mobile()) {
-			$(".desktop-keyboard-shortcut").html("Ctrl+K");
+			$(".search-widget-shortcut").html("Ctrl+K");
 			if (frappe.utils.is_mac()) {
-				$(".desktop-keyboard-shortcut").html("⌘K");
+				$(".search-widget-shortcut").html("⌘K");
 			}
 		}
 		if (this.awesomebar_setup) return;
@@ -521,12 +521,12 @@ class DesktopPage {
 
 		if (frappe.boot.desk_settings.search_bar) {
 			let awesome_bar = new frappe.search.AwesomeBar();
-			awesome_bar.setup(".desktop-search-wrapper #desktop-navbar-modal-search");
+			awesome_bar.setup(".search-widget-wrapper #search-widget-button");
 
 			frappe.ui.keys.add_shortcut({
 				shortcut: "ctrl+k",
 				action: function (e) {
-					$(".desktop-search-wrapper #desktop-navbar-modal-search").click();
+					$(".search-widget-wrapper #search-widget-button").click();
 					e.preventDefault();
 					return false;
 				},

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -36,20 +36,20 @@
 					</div>
 				</div>
 				{% if(!frappe.is_mobile()) { %}
-				<button id="full-search-button" class="btn btn-default btn-sm navbar-modal-search-mobile hidden justify-between" aria-label="{{ __("Search") }}">
-					<div class="flex align-items-center">
+				<button id="full-search-button" class="btn-reset navbar-modal-search-mobile search-widget-button hidden" aria-label="{{ __("Search") }}">
+					<span class="search-widget-icon">
 						<svg class="icon icon-sm">
 							<use href="#icon-search"></use>
 						</svg>
-						<span class="ml-2">{%= __("Search") %}</span>
-					</div>
-					<span class="desktop-keyboard-shortcut">
+						{%= __("Search") %}
+					</span>
+					<span class="search-widget-shortcut">
 					{% if(frappe.utils.is_mac()) { %}
 						⌘K
 					{% } else { %}
 						Ctrl+K
 					{% } %}
-                    </span>
+					</span>
 				</button>
 
 				{% } %}

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -36,12 +36,22 @@
 					</div>
 				</div>
 				{% if(!frappe.is_mobile()) { %}
-				<button id="full-search-button" class="btn btn-default btn-sm navbar-modal-search-mobile hidden" aria-label="{{ __("Search") }}">
-					<svg class="icon icon-sm">
-						<use href="#icon-search"></use>
-					</svg>
-					<span class="ml-2">{%= __("Search") %}</span>
+				<button id="full-search-button" class="btn btn-default btn-sm navbar-modal-search-mobile hidden justify-between" aria-label="{{ __("Search") }}">
+					<div class="flex align-items-center">
+						<svg class="icon icon-sm">
+							<use href="#icon-search"></use>
+						</svg>
+						<span class="ml-2">{%= __("Search") %}</span>
+					</div>
+					<span class="desktop-keyboard-shortcut">
+					{% if(frappe.utils.is_mac()) { %}
+						⌘K
+					{% } else { %}
+						Ctrl+K
+					{% } %}
+                    </span>
 				</button>
+
 				{% } %}
 				<div class="flex col page-actions justify-content-end {% if frappe.is_mobile() %} pl-0 {% endif %}">
 					<!-- buttons -->

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -35,14 +35,14 @@
 						</span>
 					</div>
 				</div>
-				<!-- Big Search Button (hidden) -->
+				{% if(!frappe.is_mobile()) { %}
 				<button id="full-search-button" class="btn btn-default btn-sm navbar-modal-search-mobile hidden" aria-label="{{ __("Search") }}">
 					<svg class="icon icon-sm">
 						<use href="#icon-search"></use>
 					</svg>
 					<span class="ml-2">{%= __("Search") %}</span>
 				</button>
-
+				{% } %}
 				<div class="flex col page-actions justify-content-end {% if frappe.is_mobile() %} pl-0 {% endif %}">
 					<!-- buttons -->
 					{% if (frappe.boot.read_only) { %}

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -25,18 +25,24 @@
 				</div>
 			</div>
 			<div class="align-center flex standard-items-section">
-				{% if frappe.is_mobile() %}
-					<div class="search-bar text-muted hidden">
-						<div
-							class="navbar-modal-search-mobile"
-							placeholder="Search for type a command"
-						>
-							<span class="search-icon">
-								<svg class="icon icon-sm"><use href="#icon-search"></use></svg>
-							</span>
-						</div>
+				<div id="small-search-button" class="search-bar text-muted hidden">
+					<div
+						class="navbar-modal-search-mobile"
+						placeholder="Search for type a command"
+					>
+						<span class="search-icon">
+							<svg class="icon icon-sm"><use href="#icon-search"></use></svg>
+						</span>
 					</div>
-				{% endif %}
+				</div>
+				<!-- Big Search Button (hidden) -->
+				<button id="full-search-button" class="btn btn-default btn-sm navbar-modal-search-mobile hidden" aria-label="{{ __("Search") }}">
+					<svg class="icon icon-sm">
+						<use href="#icon-search"></use>
+					</svg>
+					<span class="ml-2">{%= __("Search") %}</span>
+				</button>
+
 				<div class="flex col page-actions justify-content-end {% if frappe.is_mobile() %} pl-0 {% endif %}">
 					<!-- buttons -->
 					{% if (frappe.boot.read_only) { %}

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -49,7 +49,7 @@ frappe.ui.Page = class Page {
 	}
 
 	setup_mobile_awesomebar() {
-		if (frappe.boot.desk_settings.search_bar && frappe.is_mobile()) {
+		if (frappe.boot.desk_settings.search_bar) {
 			let awesome_bar = new frappe.search.AwesomeBar();
 			awesome_bar.setup(".navbar-modal-search-mobile");
 		}

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -45,13 +45,23 @@ frappe.ui.Page = class Page {
 		this.add_main_section();
 		this.setup_scroll_handler();
 		this.setup_main_sidebar_toggle();
-		this.setup_mobile_awesomebar();
+		this.setup_awesomebar();
 	}
 
-	setup_mobile_awesomebar() {
+	setup_awesomebar() {
 		if (frappe.boot.desk_settings.search_bar) {
 			let awesome_bar = new frappe.search.AwesomeBar();
 			awesome_bar.setup(".navbar-modal-search-mobile");
+			frappe.app.awesome_bar = awesome_bar;
+			frappe.search.utils.make_function_searchable(
+				frappe.utils.generate_tracking_url,
+				__("Generate Tracking URL")
+			);
+			if (frappe.model.can_read("RQ Job")) {
+				frappe.search.utils.make_function_searchable(function () {
+					frappe.set_route("List", "RQ Job");
+				}, __("Background Jobs"));
+			}
 		}
 	}
 

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -557,19 +557,6 @@ frappe.ui.Sidebar = class Sidebar {
 	add_standard_items(items) {
 		if (this.standard_items_setup) return;
 		this.standard_items = [];
-		if (!frappe.is_mobile()) {
-			this.standard_items.push({
-				label: __("Search"),
-				icon: "search",
-				standard: true,
-				type: "Button",
-				id: "navbar-modal-search",
-				suffix: {
-					keyboard_shortcut: "Ctrl+K",
-				},
-				class: "navbar-search-bar hidden",
-			});
-		}
 		this.standard_items.push({
 			label: __("Notification"),
 			icon: "bell",

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -593,7 +593,6 @@ frappe.ui.Sidebar = class Sidebar {
 		this.standard_items.forEach((w) => {
 			this.add_item(this.$standard_items_sections, w);
 		});
-		this.setup_awesomebar();
 		this.setup_notifications();
 		this.setup_background_tasks();
 		this.standard_items_setup = true;
@@ -603,22 +602,6 @@ frappe.ui.Sidebar = class Sidebar {
 			const workspace = frappe.boot.workspaces.pages[i];
 			if (workspace.module == module && !workspace.parent_page) {
 				return workspace.name;
-			}
-		}
-	}
-	setup_awesomebar() {
-		if (frappe.boot.desk_settings.search_bar) {
-			let awesome_bar = new frappe.search.AwesomeBar();
-			awesome_bar.setup("#navbar-modal-search");
-
-			frappe.search.utils.make_function_searchable(
-				frappe.utils.generate_tracking_url,
-				__("Generate Tracking URL")
-			);
-			if (frappe.model.can_read("RQ Job")) {
-				frappe.search.utils.make_function_searchable(function () {
-					frappe.set_route("List", "RQ Job");
-				}, __("Background Jobs"));
 			}
 		}
 	}

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -5,7 +5,7 @@ frappe.provide("frappe.tags");
 
 frappe.search.AwesomeBar = class AwesomeBar {
 	setup(element) {
-		$(".search-bar, .navbar-search-bar").removeClass("hidden");
+		$(".navbar-search-bar").removeClass("hidden");
 
 		this.options = [];
 		this.global_results = [];
@@ -13,6 +13,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 		this.setup_search_modal(element);
 
 		frappe.search.utils.setup_recent();
+		this.setup_page_change_event();
 	}
 
 	setup_search_modal(element) {
@@ -446,5 +447,24 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				},
 			});
 		}
+	}
+
+	setup_correct_button(wrapper) {
+		let small_button = $(wrapper).find("#small-search-button");
+		let full_button = $(wrapper).find("#full-search-button");
+		let route = frappe.get_route();
+		if (route[0] == "Workspaces") {
+			small_button.addClass("hidden");
+			full_button.removeClass("hidden");
+		} else {
+			full_button.addClass("hidden");
+			small_button.removeClass("hidden");
+		}
+	}
+	setup_page_change_event() {
+		const me = this;
+		$(document).on("page-change", function (event, data) {
+			me.setup_correct_button(data);
+		});
 	}
 };

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -21,7 +21,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 		let $search_element = $(element);
 
 		let search_modal = new frappe.get_modal("Search", "");
-
+		this.search_modal = search_modal;
 		search_modal.removeClass("fade");
 		search_modal.on("shown.bs.modal", () => {
 			const input = search_modal.find("#navbar-search").get(0);
@@ -80,6 +80,13 @@ frappe.search.AwesomeBar = class AwesomeBar {
 
 			this.setup_event_listeners(search_modal);
 		});
+	}
+
+	open(search_modal) {
+		const modal = search_modal || this.search_modal;
+		if (!modal) return;
+		modal.modal("show");
+		this.setup_event_listeners(modal);
 	}
 
 	setup_event_listeners(search_modal) {

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -471,5 +471,9 @@ frappe.search.AwesomeBar = class AwesomeBar {
 		$(document).on("page-change", function (event, data) {
 			me.setup_correct_button(data);
 		});
+
+		$(document).on("form-refresh", function (event, data) {
+			me.setup_correct_button(data.wrapper);
+		});
 	}
 };

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -453,7 +453,12 @@ frappe.search.AwesomeBar = class AwesomeBar {
 		let small_button = $(wrapper).find("#small-search-button");
 		let full_button = $(wrapper).find("#full-search-button");
 		let route = frappe.get_route();
-		if (route[0] == "Workspaces") {
+		if (frappe.is_mobile()) {
+			small_button.removeClass("hidden");
+			full_button.addClass("hidden");
+			return;
+		}
+		if (route[0] == "Workspaces" || frappe.is_mobile()) {
 			small_button.addClass("hidden");
 			full_button.removeClass("hidden");
 		} else {

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -743,7 +743,7 @@ frappe.search.open_awesomebar_from_global_search_shortcut = function (e) {
 		dlg.search_dialog.hide();
 		$("#navbar-search").val(keywords);
 	}
-	$("#navbar-modal-search").click();
+	frappe.app.awesome_bar.open();
 	if (e) {
 		e.preventDefault();
 	}

--- a/frappe/public/js/frappe/views/container.js
+++ b/frappe/public/js/frappe/views/container.js
@@ -75,8 +75,7 @@ frappe.views.Container = class Container {
 			$(this.page).show();
 		}
 
-		$(document).trigger("page-change");
-
+		$(document).trigger("page-change", this.page);
 		this.page._route = frappe.router.get_sub_path();
 		$(this.page).trigger("show");
 		!this.page.disable_scroll_to_top && frappe.utils.scroll_to(0);

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -346,6 +346,7 @@ frappe.views.Workspace = class Workspace {
 		this.body.addClass("edit-mode");
 		this.initialize_editorjs_undo();
 		this.clear_page_actions();
+		$("#full-search-button").addClass("hidden");
 
 		// switch headers
 		this.wrapper.find(".page-head").removeClass("hidden");
@@ -357,6 +358,7 @@ frappe.views.Workspace = class Workspace {
 				() => {
 					this.clear_page_actions();
 					this.body.removeClass("edit-mode");
+					$("#full-search-button").removeClass("hidden");
 					this.save_page(page).then((saved) => {
 						if (!saved) return;
 						this.undo.readOnly = true;
@@ -371,6 +373,7 @@ frappe.views.Workspace = class Workspace {
 		this.page.set_secondary_action(__("Discard"), async () => {
 			this.body.removeClass("edit-mode");
 			this.clear_page_actions();
+			$("#full-search-button").removeClass("hidden");
 			await this.editor.readOnly.toggle();
 			this.is_read_only = true;
 			frappe.boot.workspaces = this.cached_pages;

--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -733,3 +733,11 @@ details > summary:focus {
 .desktop-alphabet {
 	stroke: none;
 }
+#full-search-button {
+	width: 200px;
+	display: flex;
+	align-items: center;
+	svg {
+		margin: 0px;
+	}
+}

--- a/frappe/public/scss/desk/index.scss
+++ b/frappe/public/scss/desk/index.scss
@@ -14,6 +14,7 @@
 @import "print_preview";
 @import "scrollbar";
 @import "navbar";
+@import "search_widget";
 @import "../common/modal";
 @import "slides";
 @import "toast";

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -61,6 +61,7 @@
 
 .page-actions {
 	align-items: center;
+	padding-left: 0px;
 	.btn {
 		height: var(--btn-height);
 		margin-left: var(--margin-sm, 8px);

--- a/frappe/public/scss/desk/search_widget.scss
+++ b/frappe/public/scss/desk/search_widget.scss
@@ -1,0 +1,34 @@
+.search-widget-wrapper {
+	flex: 1;
+	position: relative;
+}
+
+.search-widget-button {
+	background-color: var(--control-bg);
+	border-radius: var(--border-radius-sm);
+	height: 32px;
+	padding: 0 10px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+	margin-right: 0;
+
+	span {
+		color: var(--text-light);
+	}
+
+	.search-widget-icon {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+
+		> svg {
+			stroke: var(--text-light);
+		}
+	}
+
+	&:hover {
+		outline: 1px solid var(--surface-gray-3);
+	}
+}


### PR DESCRIPTION
Brings awesombar on top. 

Workspace has more space in the toolbar so it gets the full search bar, other views have a crowded toolbar so they get a small icon
I have removed awesomebar from sidebar

<img width="1440" height="900" alt="Screenshot 2026-05-20 at 1 31 52 PM" src="https://github.com/user-attachments/assets/ab0a4211-91b7-40ca-9632-c9a3bbb1e05e" />


Some more UI polish is required
