### PR TITLE
fix(number_card): show only cards from user's allowed modules in link picker

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -230,7 +230,7 @@ def get_cards_for_user(
 		filters=filters,
 	)
 
-	allowed_modules = [module.get("module_name") for module in get_modules_from_all_apps_for_user()]
+	allowed_modules = {module.get("module_name") for module in get_modules_from_all_apps_for_user()}
 
 	return (
 		condition_query.select(numberCard.name, numberCard.label, numberCard.document_type)

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -230,9 +230,14 @@ def get_cards_for_user(
 		filters=filters,
 	)
 
+	allowed_modules = [module.get("module_name") for module in get_modules_from_all_apps_for_user()]
+
 	return (
 		condition_query.select(numberCard.name, numberCard.label, numberCard.document_type)
 		.where((numberCard.owner == frappe.session.user) | (numberCard.is_public == 1))
+		.where(
+			numberCard.module.isin(allowed_modules) | numberCard.module.isnull() | (numberCard.module == "")
+		)
 		.where(Criterion.any(search_conditions))
 	).run()
 

--- a/frappe/desk/doctype/number_card/test_number_card.py
+++ b/frappe/desk/doctype/number_card/test_number_card.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
+from frappe.desk.doctype.number_card.number_card import get_cards_for_user
 from frappe.tests import IntegrationTestCase
 
 
@@ -56,3 +57,81 @@ class TestNumberCard(IntegrationTestCase):
 			card.name,
 			frappe.get_list("Number Card", filters={"name": card.name}, pluck="name", user=user),
 		)
+
+	def test_link_search_hides_cards_from_blocked_modules(self):
+		user = "test2@example.com"
+		blocked_module = "Contacts"
+		blocked_card_name = "Test Blocked Module Card"
+		allowed_card_name = "Test No Module Card"
+
+		frappe.set_user("Administrator")
+
+		admin_blocked = frappe.get_cached_doc("User", "Administrator").get_blocked_modules()
+		self.assertNotIn(blocked_module, admin_blocked, f"{blocked_module} globally blocked — test invalid")
+
+		for card_name in (blocked_card_name, allowed_card_name):
+			frappe.delete_doc("Number Card", card_name, ignore_missing=True, force=True)
+			self.addCleanup(
+				lambda c=card_name: frappe.delete_doc("Number Card", c, ignore_missing=True, force=True)
+			)
+
+		user_doc = frappe.get_doc("User", user)
+		if blocked_module not in {d.module for d in user_doc.block_modules}:
+			user_doc.append("block_modules", {"module": blocked_module})
+			user_doc.save(ignore_permissions=True)
+			frappe.clear_document_cache("User", user)
+
+		def restore_blocks():
+			doc = frappe.get_doc("User", user)
+			doc.block_modules = {d for d in doc.block_modules if d.module != blocked_module}
+			doc.save(ignore_permissions=True)
+			frappe.clear_document_cache("User", user)
+
+		self.addCleanup(restore_blocks)
+
+		frappe.get_doc(
+			{
+				"doctype": "Number Card",
+				"label": blocked_card_name,
+				"type": "Document Type",
+				"document_type": "ToDo",
+				"function": "Count",
+				"is_public": 1,
+				"module": blocked_module,
+			}
+		).insert(ignore_permissions=True)
+
+		frappe.get_doc(
+			{
+				"doctype": "Number Card",
+				"label": allowed_card_name,
+				"type": "Document Type",
+				"document_type": "ToDo",
+				"function": "Count",
+				"is_public": 1,
+			}
+		).insert(ignore_permissions=True)
+
+		frappe.set_user(user)
+		try:
+			blocked_results = get_cards_for_user(
+				doctype="Number Card",
+				txt=blocked_card_name,
+				searchfield="name",
+				start=0,
+				page_len=20,
+				filters={},
+			)
+			allowed_results = get_cards_for_user(
+				doctype="Number Card",
+				txt=allowed_card_name,
+				searchfield="name",
+				start=0,
+				page_len=20,
+				filters={},
+			)
+		finally:
+			frappe.set_user("Administrator")
+
+		self.assertEqual([row[0] for row in blocked_results], [])
+		self.assertEqual([row[0] for row in allowed_results], [allowed_card_name])


### PR DESCRIPTION
## Problem
Number Card link picker (Workspace → add block → Number Card) shows public cards from modules the user doesn't have access to. Same user can't see them in `/app/number-card` list view.
  
## Cause
`get_cards_for_user` builds query via `frappe.qb.get_query()` which defaults to `ignore_permissions=True`, skipping `get_permission_query_conditions` that filters by allowed modules.

## Fix
Apply allowed-modules filter directly in `get_cards_for_user`, matching list view behaviour.

### Before Fix
[Screencast from 2026-05-20 17-58-35.webm](https://github.com/user-attachments/assets/9d7da1e8-da5e-4246-9ee1-83b96287ff63)

### After Fix
[Screencast from 2026-05-20 18-03-21.webm](https://github.com/user-attachments/assets/ae5a5219-258c-4f98-9dc2-31a132e42035)
