### PR TITLE
chore: add exclude-newer option for uv tool in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,9 @@ nixpkgs-deps = [
     "python312",
 ]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.mypy]
 strict = false
 pretty = true


### PR DESCRIPTION
https://docs.astral.sh/uv/concepts/resolution/#reproducible-resolutions

Add configuration for `uv` to ignore releases of dependencies that are less than a week old. This allows maintainers time to identify supply-chain attacks and withdraw affected releases before we install them.