### PR TITLE
fix(multi_select_dialog): apply array setter default on initial search

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -562,7 +562,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 		if ($.isArray(this.setters)) {
 			for (let df of this.setters) {
 				filters[df.fieldname] =
-					me.dialog.fields_dict[df.fieldname].get_value() || undefined;
+					me.dialog.fields_dict[df.fieldname].get_value() || df.default || undefined;
 				me.args[df.fieldname] = filters[df.fieldname];
 				filter_fields.push(df.fieldname);
 			}


### PR DESCRIPTION
## Summary
Array-form setters ignored default on first search. 
E.g. Sales Invoice → Get Items From → Quotation pre-filled Customer but listed all customers until re-select.

Fix: fallback to df.default.

### Before Fix
[Screencast from 2026-05-21 11-55-22.webm](https://github.com/user-attachments/assets/185e8c0d-4747-4785-8af2-699567103bbe)

### After Fix
[Screencast from 2026-05-21 11-56-32.webm](https://github.com/user-attachments/assets/387616d6-6e9d-4107-825f-1ffe70203bea)

**Support Ticket**:[https://support.frappe.io/helpdesk/tickets/68795](https://support.frappe.io/helpdesk/tickets/68795)