### PR TITLE
perf: lazy-load leaflet bundle

### DIFF
--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -29,19 +29,28 @@ frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.f
 		$(this.disp_area).removeClass("hide");
 		$(this.disp_area).css("display", "block");
 
-		if (this.frm) {
-			this.make_map();
-			if (value) {
-				this.bind_leaflet_data(value);
-			}
-		} else {
-			$(document).on("frappe.ui.Dialog:shown", () => {
+		this.load_lib().then(() => {
+			if (this.frm) {
 				this.make_map();
 				if (value) {
 					this.bind_leaflet_data(value);
 				}
-			});
-		}
+			} else {
+				$(document).on("frappe.ui.Dialog:shown", () => {
+					this.make_map();
+					if (value) {
+						this.bind_leaflet_data(value);
+					}
+				});
+			}
+		});
+	}
+
+	load_lib() {
+		return Promise.all([
+			frappe.require("leaflet.bundle.js"),
+			frappe.require("leaflet.bundle.css"),
+		]);
 	}
 
 	make_map(value) {

--- a/frappe/public/js/frappe/views/map/map_view.js
+++ b/frappe/public/js/frappe/views/map/map_view.js
@@ -34,6 +34,17 @@ frappe.views.MapView = class MapView extends frappe.views.ListView {
 	}
 
 	setup_view() {
+		return this.load_lib().then(() => this.setup_map());
+	}
+
+	load_lib() {
+		return Promise.all([
+			frappe.require("leaflet.bundle.js"),
+			frappe.require("leaflet.bundle.css"),
+		]);
+	}
+
+	setup_map() {
 		this.map_id = frappe.dom.get_unique_id();
 		this.$result.html(`<div id="${this.map_id}" class="map-view-container"></div>`);
 

--- a/frappe/public/js/leaflet.bundle.js
+++ b/frappe/public/js/leaflet.bundle.js
@@ -1,0 +1,4 @@
+import "../js/lib/leaflet/leaflet.js";
+import "../js/lib/leaflet_easy_button/easy-button.js";
+import "../js/lib/leaflet_draw/leaflet.draw.js";
+import "../js/lib/leaflet_control_locate/L.Control.Locate.js";

--- a/frappe/public/js/libs.bundle.js
+++ b/frappe/public/js/libs.bundle.js
@@ -1,9 +1,5 @@
 import "./jquery-bootstrap";
 import "./lib/moment";
-import "../js/lib/leaflet/leaflet.js";
-import "../js/lib/leaflet_easy_button/easy-button.js";
-import "../js/lib/leaflet_draw/leaflet.draw.js";
-import "../js/lib/leaflet_control_locate/L.Control.Locate.js";
 import Sortable from "sortablejs";
 import { gemoji } from "gemoji";
 

--- a/frappe/public/scss/desk.bundle.scss
+++ b/frappe/public/scss/desk.bundle.scss
@@ -5,8 +5,4 @@
 @import "~plyr/dist/plyr";
 @import "./desk/index";
 
-@import "frappe/public/js/lib/leaflet/leaflet.css";
-@import "frappe/public/js/lib/leaflet_easy_button/easy-button.css";
-@import "frappe/public/js/lib/leaflet_control_locate/L.Control.Locate.css";
-@import "frappe/public/js/lib/leaflet_draw/leaflet.draw.css";
 @import "frappe/public/node_modules/highlight.js/styles/tomorrow.css";

--- a/frappe/public/scss/leaflet.bundle.scss
+++ b/frappe/public/scss/leaflet.bundle.scss
@@ -1,0 +1,4 @@
+@import "frappe/public/js/lib/leaflet/leaflet.css";
+@import "frappe/public/js/lib/leaflet_easy_button/easy-button.css";
+@import "frappe/public/js/lib/leaflet_control_locate/L.Control.Locate.css";
+@import "frappe/public/js/lib/leaflet_draw/leaflet.draw.css";


### PR DESCRIPTION
Leaflet is only used by Geolocation fields and the Map view, so loading
it eagerly in libs/desk bundles bloats every page. Move it into its own
bundle and require it on demand, mirroring the scanner lib pattern.


<img width="822" height="196" alt="image" src="https://github.com/user-attachments/assets/8986e673-ff0f-4b66-af78-99a7ebf7d846" />


This was one-shotted with Claude code. :woozy_face: 

"In 2026, there are only intent problems"