### PR TITLE
fix: custom report keeps stale columns after changing filters

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -99,8 +99,13 @@ def generate_report_result(
 	result = normalize_result(result, columns)
 
 	if report.get("custom_columns"):
-		# saved columns (with custom columns / with different column order)
-		columns = report.custom_columns
+		# keep saved columns still returned by this run, plus user-added
+		# custom columns (`link_field`); drops columns stale after a filter change
+		columns = [
+			column
+			for column in report.custom_columns
+			if column.get("link_field") or column["fieldname"] in report_column_names
+		]
 
 	# unsaved custom_columns
 	if custom_columns:


### PR DESCRIPTION
Custom Reports currently freeze the column set at save time. This breaks reports with dynamic columns, such as GST, Purchase Register, where filters like “Summary by Item” and “Summary by Invoice” return different columns.

`generate_report_result` was reusing the saved column snapshot, causing stale columns to remain visible even when the report no longer returned them.

The fix keeps a saved column only if:

* it still exists in the current report output, or
* it is a user-added custom column (`link_field` set by Desk UI).

This removes stale columns while preserving custom columns and saved column order. Static-column reports remain unaffected.

---

Ref: https://support.frappe.io/helpdesk/tickets/68573?view=VIEW-HD+Ticket-1252