### PR TITLE
fix: report dashboard charts drop dynamic filters stored as object

### DIFF
--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -207,8 +207,24 @@ frappe.dashboard_utils = {
 			? JSON.parse(doc.dynamic_filters_json)
 			: null;
 
-		if (!dynamic_filters?.length) {
+		const has_dynamic_filters = Array.isArray(dynamic_filters)
+			? dynamic_filters.length
+			: dynamic_filters && Object.keys(dynamic_filters).length;
+
+		if (!has_dynamic_filters) {
 			return filters;
+		}
+
+		if (!Array.isArray(dynamic_filters)) {
+			Object.keys(dynamic_filters).forEach((key) => {
+				try {
+					dynamic_filters[key] = eval(dynamic_filters[key]);
+				} catch (e) {
+					frappe.throw(__("Invalid expression set in filter {0}", [key]));
+				}
+			});
+
+			return filters ? Object.assign(filters, dynamic_filters) : dynamic_filters;
 		}
 
 		dynamic_filters.forEach((f) => {


### PR DESCRIPTION
Commit https://github.com/frappe/frappe/commit/4956e34 reverted dashboard dynamic filters to the array format: `[doctype, fieldname, operator, expression]` and removed support for the object format: `{fieldname: expression}`

However, report-type dashboard charts still store `dynamic_filters_json` as objects; including shipped fixtures like “Top Customers” and “Item-wise Annual Sales”, as well as existing site data.

`get_all_filters` checks `!dynamic_filters?.length`; since objects have no `length`, all dynamic filters are silently skipped, including `company`.

As a result, reports run without required filters and ERPNext reports depending on `company` fail.
for example, Item-wise Sales History crashes with: `TypeError: cannot unpack non-iterable NoneType object`

<img width="1505" height="863" alt="Screenshot 2026-05-21 at 12 42 39 PM" src="https://github.com/user-attachments/assets/fcf3cb0b-48a2-439a-8490-57325ce7d15b" />

The fix restores object-format handling in `get_all_filters` by:

* detecting arrays via `length`
* detecting objects via key count
* evaluating and merging both formats into static filters

The existing array flow remains unchanged, so document-type charts are unaffected.

---
Ref: https://support.frappe.io/helpdesk/tickets/68692?view=VIEW-HD+Ticket-1252
