### PR TITLE
fix: handle export when child table is empty

### DIFF
--- a/frappe/core/doctype/data_import/exporter.py
+++ b/frappe/core/doctype/data_import/exporter.py
@@ -124,14 +124,14 @@ class Exporter:
 				raise frappe.PermissionError(
 					_("You are not allowed to export {} doctype").format(self.doctype)
 				)
-
 		for doc in data:
 			rows = []
 			rows = self.add_data_row(self.doctype, None, doc, rows, 0)
 			if table_fields:
 				# add child table data
 				for f in table_fields:
-					for i, child_row in enumerate(doc.get(f, [])):
+					table_data = doc.get(f, []) or []
+					for i, child_row in enumerate(table_data):
 						table_df = self.meta.get_field(f)
 						child_doctype = table_df.options
 						rows = self.add_data_row(child_doctype, child_row.parentfield, child_row, rows, i)

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -1038,8 +1038,9 @@ def groupby_metric(iterable: dict[str, list], key: str):
 	"""
 	records = {}
 	for category, items in iterable.items():
-		for item in items:
-			records.setdefault(item[key], {}).setdefault(category, []).append(item)
+		if items:
+			for item in items:
+				records.setdefault(item[key], {}).setdefault(category, []).append(item)
 	return records
 
 


### PR DESCRIPTION
Closes https://support.frappe.io/helpdesk/tickets/68514

Exporting recorder data was breaking this fixes the issue 

https://github.com/user-attachments/assets/371087e0-1d7f-45fa-9486-5d5d20a3c49c

Human written :)
