### PR TITLE
fix(ux): remove duplicate DocType entries in AwesomeBar search results

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -241,17 +241,15 @@ frappe.search.utils = {
 						0.05
 					);
 					let sidebars = frappe.app.sidebar.get_workspace_sidebars(item);
-					if (sidebars.length > 1) {
-						sidebars.forEach((sidebar) => {
-							let sidebar_option = option(
-								isTree ? "Tree" : "List",
-								isTree ? ["Tree", item] : ["List", item],
-								0.05
-							);
-							sidebar_option.description = `${sidebar}`;
-							sidebar_option.type = "sidebar";
-							out.push(sidebar_option);
-						});
+					if (sidebars.length === 1) {
+						let sidebar_option = option(
+							isTree ? "Tree" : "List",
+							isTree ? ["Tree", item] : ["List", item],
+							0.05
+						);
+						sidebar_option.description = sidebars[0];
+						sidebar_option.type = "sidebar";
+						out.push(sidebar_option);
 					} else {
 						out.push(option_data);
 					}


### PR DESCRIPTION
Resolve: #39431 

---
**After fix behavior:**

- 0 sidebars: one plain entry (unchanged behaviour)
- 1 sidebar: one entry with that workspace name as description (helpful context, no duplication)
- 2+ sidebars: one plain entry, deduplication works correctly, no confusing repetition

https://github.com/user-attachments/assets/82ea3c5f-b504-4044-9b85-5717faf36e35


