### PR TITLE
fix: notification panel not visible in mobile view

### DIFF
--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -362,7 +362,6 @@
 	.dropdown-notifications {
 		.notifications-list {
 			position: fixed;
-			z-index: 1300;
 			max-height: 100vh;
 			min-width: 100vw;
 			width: calc(90vw - 60px);

--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -362,7 +362,6 @@
 	.dropdown-notifications {
 		.notifications-list {
 			position: fixed;
-			left: 0;
 			z-index: 1300;
 			max-height: 100vh;
 			min-width: 100vw;

--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -361,6 +361,9 @@
 @include media-breakpoint-down(sm) {
 	.dropdown-notifications {
 		.notifications-list {
+			position: fixed;
+			left: 0;
+			z-index: 1300;
 			max-height: 100vh;
 			min-width: 100vw;
 			width: calc(90vw - 60px);


### PR DESCRIPTION
## Description
On mobile, tapping the bell collapses the sidebar via `removeClass("expanded")`. The notification panel markup lives inside `.body-sidebar`, which becomes `width: 0; overflow: hidden` once collapsed. The panel uses `position: absolute`, so its containing block is `.body-sidebar`, it gets clipped to zero and never appears.

 ## Current

https://github.com/user-attachments/assets/fa9bdab5-4403-4081-8998-9caffb979abb

 ## After
 
https://github.com/user-attachments/assets/aeceb09c-c344-4776-bd84-5a4bd296b50a

