### PR TITLE
fix: populate link title in link field

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -447,11 +447,19 @@ class Communication(Document, CommunicationEmailMixin):
 			self.add_link(doctype, name)
 
 	def add_link(self, link_doctype, link_name, autosave=False):
+		title_field = frappe.get_meta(link_doctype).get_title_field()
+		link_title = (
+			frappe.db.get_value(link_doctype, link_name, title_field, cache=True, order_by=None)
+			if title_field != "name"
+			else None
+		)
+
 		self.append(
 			"timeline_links",
 			{
 				"link_doctype": link_doctype,
 				"link_name": link_name,
+				"link_title": link_title or link_name,
 				"communication_date": self.communication_date,
 			},
 		)


### PR DESCRIPTION
ref ticket https://support.frappe.io/helpdesk/tickets/69201

This is now populated
<img width="982" height="225" alt="Screenshot 2026-05-22 at 2 47 34 PM" src="https://github.com/user-attachments/assets/ae20c984-8974-4f31-b383-b1f2b28e1d35" />
