### PR TITLE
fix: replace with nicer icon

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect_pills.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_pills.js
@@ -92,7 +92,7 @@ frappe.ui.form.ControlMultiSelectPills = class ControlMultiSelectPills extends (
 		return `
 			<button class="data-pill btn tb-selected-value" data-value="${encoded_value}">
 				<span class="btn-link-to-form">${__(label || frappe.utils.escape_html(value))}</span>
-				<span class="btn-remove">${frappe.utils.icon("close")}</span>
+				<span class="btn-remove">${frappe.utils.icon("x")}</span>
 			</button>
 		`;
 	}

--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -191,7 +191,7 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 		return `
 			<button class="data-pill btn tb-selected-value" data-value="${encoded_value}">
 				<span class="btn-link-to-form">${__(frappe.utils.escape_html(pill_name))}</span>
-				<span class="btn-remove">${frappe.utils.icon("close")}</span>
+				<span class="btn-remove">${frappe.utils.icon("x")}</span>
 			</button>
 		`;
 	}


### PR DESCRIPTION
Before
<img width="934" height="325" alt="Screenshot 2026-05-23 at 3 29 20 PM" src="https://github.com/user-attachments/assets/2d42faa9-fb4f-427d-ad71-bbf691411da5" />

After

<img width="825" height="272" alt="Screenshot 2026-05-23 at 3 26 58 PM" src="https://github.com/user-attachments/assets/c0f6ce96-12d1-46bf-9c25-db1861adc7e7" />
