### PR TITLE
fix(ListView): apply saved width to subject/title column on render

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -487,8 +487,13 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		let fields_order = [];
 		let fields = JSON.parse(this.list_view_settings.fields);
 
-		// title field is fixed
-		fields_order.push(this.columns[0]);
+		// title field is fixed — but still honour any saved width from settings
+		const subjectCol = this.columns[0];
+		const subjectSettings = fields.find((f) => f.fieldname === subjectCol.df?.fieldname);
+		if (subjectSettings?.width) {
+			subjectCol.df.width = subjectSettings.width;
+		}
+		fields_order.push(subjectCol);
 		this.columns.splice(0, 1);
 
 		for (let fld in fields) {


### PR DESCRIPTION
## Summary

- In `reorder_listview_fields()`, the subject (title) column was pushed to `fields_order` before the loop that applies saved widths from `list_view_settings.fields`. This meant any width saved for the title column — via the List View Settings dialog or drag-to-resize — was never applied to `col.df.width`, so `apply_column_widths()` never set the inline `width`/`flex` style on it.
- Fix: look up the subject column's fieldname in the saved `fields` array and apply `col.df.width` before pushing, identical to how other column types are handled in the loop.

## Root cause

```js
// Before — width from settings silently ignored for the title column
fields_order.push(this.columns[0]);

// After — width applied before push
const subjectCol = this.columns[0];
const subjectSettings = fields.find((f) => f.fieldname === subjectCol.df?.fieldname);
if (subjectSettings?.width) subjectCol.df.width = subjectSettings.width;
fields_order.push(subjectCol);
```

## Test plan

- [x] Open any List View, drag-resize the first (title) column → width changes visually
- [x] Reload the page → title column retains the resized width
- [x] Open List View Settings, set a width for the title column, save → title column renders at that width after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Follow up PR: https://github.com/frappe/frappe/pull/37980