### PR TITLE
fix: release chromium browser when pdf generation raises

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -176,10 +176,15 @@ def get_chrome_pdf(print_format, html, options, output, pdf_generator=None):
 	# scrubbing url to expand url is not required as we have set url.
 	# also, planning to remove network requests anyway 🤞
 	generator = ChromePDFGenerator()
-	browser = Browser(generator, print_format, html, options)
-	transformer = PDFTransformer(browser)
-	# transforms and merges header, footer into body pdf and returns merged pdf
-	return transformer.transform_pdf(output=output)
+	browser = None
+	try:
+		browser = Browser(generator, print_format, html, options)
+		transformer = PDFTransformer(browser)
+		# transforms and merges header, footer into body pdf and returns merged pdf
+		return transformer.transform_pdf(output=output)
+	finally:
+		if browser is not None:
+			generator.remove_browser(browser.browserID)
 
 
 def get_file_data_from_writer(writer_obj):

--- a/frappe/utils/pdf_generator/browser.py
+++ b/frappe/utils/pdf_generator/browser.py
@@ -14,49 +14,54 @@ class Browser:
 		self.debug_mode = frappe.conf.developer_mode and bool(frappe.form_dict.get("pdf_debug"))
 		self.browserID = frappe.utils.random_string(10)
 		generator.add_browser(self.browserID)
-		# sets soup from html
-		self.set_html(html)
-		# sets wkhtmltopdf options
-		self.set_options(options)
-		# start cdp connection and create browser context ( kind of like new window / incognito mode)
-		self.open(generator)
-		# opens header and footer pages and sets content ( not waiting for it to load)
-		self.prepare_header_footer()
-		# opens body page and sets content and waits for it to finshing load
-		self.setup_body_page()
-		# prepare options as per chrome for pdf
-		self.prepare_options_for_pdf()
-		# generate header and footer pages if they are not dynamic ( first, odd, even, last)
-		self.update_header_footer_page_pd()
-		# if header and footer are not dynamic start generating pdf for them (non-blocking)
-		self.try_async_header_footer_pdf()
-		# now wait for page to load as we need DOM to generate pdf
-		self.body_page.wait_for_set_content()
-		self.body_pdf = self.body_page.generate_pdf(raw=not self.header_page and not self.footer_page)
-		if not self.debug_mode:
-			self.body_page.close()
-		self.update_header_footer_page()
-
-		if self.header_page:
-			if not self.is_header_dynamic:
-				self.header_pdf = self.header_page.get_pdf_from_stream(self.header_page.get_pdf_stream_id())
-			else:
-				self.header_pdf = self.header_page.generate_pdf()
+		try:
+			# sets soup from html
+			self.set_html(html)
+			# sets wkhtmltopdf options
+			self.set_options(options)
+			# start cdp connection and create browser context ( kind of like new window / incognito mode)
+			self.open(generator)
+			# opens header and footer pages and sets content ( not waiting for it to load)
+			self.prepare_header_footer()
+			# opens body page and sets content and waits for it to finshing load
+			self.setup_body_page()
+			# prepare options as per chrome for pdf
+			self.prepare_options_for_pdf()
+			# generate header and footer pages if they are not dynamic ( first, odd, even, last)
+			self.update_header_footer_page_pd()
+			# if header and footer are not dynamic start generating pdf for them (non-blocking)
+			self.try_async_header_footer_pdf()
+			# now wait for page to load as we need DOM to generate pdf
+			self.body_page.wait_for_set_content()
+			self.body_pdf = self.body_page.generate_pdf(raw=not self.header_page and not self.footer_page)
 			if not self.debug_mode:
-				self.header_page.close()
+				self.body_page.close()
+			self.update_header_footer_page()
 
-		if self.footer_page:
-			if not self.is_footer_dynamic:
-				self.footer_pdf = self.footer_page.get_pdf_from_stream(self.footer_page.get_pdf_stream_id())
-			else:
-				self.footer_pdf = self.footer_page.generate_pdf()
+			if self.header_page:
+				if not self.is_header_dynamic:
+					self.header_pdf = self.header_page.get_pdf_from_stream(
+						self.header_page.get_pdf_stream_id()
+					)
+				else:
+					self.header_pdf = self.header_page.generate_pdf()
+				if not self.debug_mode:
+					self.header_page.close()
+
+			if self.footer_page:
+				if not self.is_footer_dynamic:
+					self.footer_pdf = self.footer_page.get_pdf_from_stream(
+						self.footer_page.get_pdf_stream_id()
+					)
+				else:
+					self.footer_pdf = self.footer_page.generate_pdf()
+				if not self.debug_mode:
+					self.footer_page.close()
+
 			if not self.debug_mode:
-				self.footer_page.close()
-
-		if not self.debug_mode:
-			self.close()
-
-		generator.remove_browser(self.browserID)
+				self.close()
+		finally:
+			generator.remove_browser(self.browserID)
 		if self.debug_mode:
 			generator.detach_debug_browser()
 

--- a/frappe/utils/pdf_generator/chrome_pdf_generator.py
+++ b/frappe/utils/pdf_generator/chrome_pdf_generator.py
@@ -24,7 +24,8 @@ class ChromePDFGenerator:
 		self._browsers.append(browser)
 
 	def remove_browser(self, browser):
-		self._browsers.remove(browser)
+		if browser in self._browsers:
+			self._browsers.remove(browser)
 
 	def __new__(cls):
 		# if instance or _chromium_process is not available create object else return current instance stored in cls._instance


### PR DESCRIPTION
## Summary

Fixes a Chromium cleanup issue where failed PDF renders could leave orphaned browser instances and Chromium subprocesses running after the request finished.

`Browser.__init__` registers a browser ID with `add_browser` at the beginning of initialization, but `remove_browser` only ran if the entire setup flow completed successfully. Any exception during page setup or rendering; including CDP socket failures, template rendering errors, navigation timeouts, or downstream PDF transformation crashes; could leave stale IDs in `_browsers`.

When that happened, `_close_browser` refused to shut Chromium down and logged:

```text
Cannot close Chromium as there are active browser instances.
```

This caused Chromium processes to outlive the worker and eventually accumulate over time.

## Changes

* Wrapped the body of `Browser.__init__` in `try/finally` so `remove_browser` always executes
* Wrapped `get_chrome_pdf` in `try/finally` so cleanup still happens if `PDFTransformer.transform_pdf` fails after `Browser.__init__` returns
* Made `remove_browser` idempotent so duplicate cleanup calls are safe