### PR TITLE
fix: restore missing doctypes in Communication relink dialog

### DIFF
--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -85,10 +85,11 @@ def get_communication_doctype(
 	user_perms.build_permissions()
 	can_read = user_perms.can_read
 	from frappe import _
+	from frappe.desk.search import PAGE_LENGTH_FOR_LINK_VALIDATION
 	from frappe.modules import load_doctype_module
 
 	com_doctypes = []
-	if len(txt) < 2:
+	if len(txt) < 2 and page_len < PAGE_LENGTH_FOR_LINK_VALIDATION:
 		for name in frappe.get_hooks("communication_doctypes"):
 			try:
 				module = load_doctype_module(name, suffix="_dashboard")
@@ -97,7 +98,8 @@ def get_communication_doctype(
 						com_doctypes += i["items"]
 			except ImportError:
 				pass
-	else:
+
+	if not com_doctypes:
 		com_doctypes = [
 			d[0] for d in frappe.db.get_values("DocType", {"issingle": 0, "istable": 0, "hide_toolbar": 0})
 		]


### PR DESCRIPTION
Resolve: #39446 

---
**Problem**

Searching for "Timesheet" (or any doctype not in the communication_doctypes hook) in the Relink Communication dialog returns no results in v16.18.3.

https://github.com/user-attachments/assets/c7957874-c770-4d57-8786-97e00334c4fc


**Root Cause**

PR #39366 made search_widget pass txt="" and page_len=PAGE_LENGTH_FOR_LINK_VALIDATION to custom queries when the target doctype has translated_doctype=1. Since DocType has translated_doctype=1, txt is always empty when get_communication_doctype is called from the relink dialog.

get_communication_doctype uses len(txt) < 2 to decide what to return. With txt always empty, it always returned only the hook-based curated list (Customer/Supplier dashboards), which does not include Timesheet or most other doctypes.

**After Fix**

Add page_len < PAGE_LENGTH_FOR_LINK_VALIDATION to the condition. When search_widget is in translation mode it sends PAGE_LENGTH_FOR_LINK_VALIDATION as page_len, which is a reliable signal that txt was cleared by the framework. In that case the function falls through to query all doctypes from the DB.

https://github.com/user-attachments/assets/ac79410b-0906-43db-a33a-d1311cd7500b

`no-docs`

