### PR TITLE
feat: add keyboard shortcuts to the sidebar menu items

### DIFF
--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -22,6 +22,13 @@ frappe.ui.keys.setup = function () {
 
 let standard_shortcuts = [];
 frappe.ui.keys.standard_shortcuts = standard_shortcuts;
+frappe.ui.keys.get_shortcut_label = function (shortcut) {
+	let label = shortcut.split("+").map(frappe.utils.to_title_case).join("+");
+	if (frappe.utils.is_mac()) {
+		label = label.replace("Ctrl", "⌘").replace("Alt", "⌥");
+	}
+	return label.replace("Shift", "⇧");
+};
 frappe.ui.keys.add_shortcut = ({
 	shortcut,
 	action,
@@ -107,11 +114,7 @@ frappe.ui.keys.show_keyboard_shortcut_dialog = () => {
 			.map((shortcut) => {
 				let shortcut_label = shortcut.keys
 					.map((k) => {
-						let label = k.split("+").map(frappe.utils.to_title_case).join("+");
-						if (frappe.utils.is_mac()) {
-							label = label.replace("Ctrl", "⌘").replace("Alt", "⌥");
-						}
-						label = label.replace("Shift", "⇧");
+						let label = frappe.ui.keys.get_shortcut_label(k);
 						return `<kbd>${label}</kbd>`;
 					})
 					.join(" / ");

--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -108,6 +108,13 @@ frappe.ui.menu = class ContextMenu {
 					</div>
 					<span class="menu-item-title">${__(item.label)}</span>
 					${
+						item.shortcut
+							? `<span class="menu-item-shortcut">${frappe.ui.keys.get_shortcut_label(
+									item.shortcut
+							  )}</span>`
+							: ""
+					}
+					${
 						item.items && item.items.length
 							? `<div class="menu-item-icon" style="margin-left:auto">
 						${frappe.utils.icon(`chevron-${chevron_direction}`)}

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -459,9 +459,7 @@ frappe.ui.Page = class Page {
 					<a class="grey-link dropdown-item" href="#" onClick="return false;">
 						${$icon}
 						<span class="menu-item-label">${label}</span>
-						<kbd class="pull-right">
-							<span>${shortcut_obj.shortcut_label}</span>
-						</kbd>
+						<span class="menu-item-shortcut">${shortcut_obj.shortcut_label}</span>
 					</a>
 				</li>
 			`);
@@ -514,16 +512,7 @@ frappe.ui.Page = class Page {
 		} else {
 			shortcut_obj = shortcut;
 		}
-		// label
-		if (frappe.utils.is_mac()) {
-			shortcut_obj.shortcut_label = shortcut_obj.shortcut
-				.replace("Ctrl", "⌘")
-				.replace("Alt", "⌥");
-		} else {
-			shortcut_obj.shortcut_label = shortcut_obj.shortcut;
-		}
-
-		shortcut_obj.shortcut_label = shortcut_obj.shortcut_label.replace("Shift", "⇧");
+		shortcut_obj.shortcut_label = frappe.ui.keys.get_shortcut_label(shortcut_obj.shortcut);
 
 		// actual shortcut string
 		shortcut_obj.shortcut = shortcut_obj.shortcut.toLowerCase();

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -76,6 +76,7 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 					action: "frappe.ui.toolbar.clear_cache()",
 					is_standard: 1,
 					icon: "rotate-ccw",
+					shortcut: "Shift+Ctrl+R",
 				},
 				{
 					name: "help",
@@ -213,6 +214,9 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 				name: element.name,
 				label: element.item_label,
 			};
+			if (element.action?.includes("frappe.ui.toolbar.show_shortcuts")) {
+				dropdown_children.shortcut = "Shift+/";
+			}
 			if (element.item_type === "Route") {
 				dropdown_children.url = element.route;
 			}
@@ -234,6 +238,7 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 				name: "toggle-theme",
 				label: __("Toggle Theme"),
 				icon: is_dark ? "sun" : "moon",
+				shortcut: "Shift+Ctrl+G",
 				onClick: function () {
 					new frappe.ui.ThemeSwitcher().show();
 				},
@@ -250,6 +255,7 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 				name: "toggle-sidebar",
 				label: __("Toggle Sidebar"),
 				icon: "panel-right-open",
+				shortcut: "Ctrl+/",
 				onClick: function () {
 					sidebar.toggle_width();
 				},
@@ -357,6 +363,13 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 					}
 				</div>
 				<span class="menu-item-title">${item.label}</span>
+				${
+					item.shortcut
+						? `<span class="menu-item-shortcut">${frappe.ui.keys.get_shortcut_label(
+								item.shortcut
+						  )}</span>`
+						: ""
+				}
 			</a>
 		</div>`).appendTo(this.dropdown_menu);
 	}

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -111,9 +111,7 @@ frappe.ui.sidebar_item.TypeLink = class SidebarItem {
 		}
 	}
 	get_shortcut_html(shortcut) {
-		if (frappe.utils.is_mac()) {
-			shortcut = shortcut.replace("Ctrl+", "⌘");
-		}
+		shortcut = frappe.ui.keys.get_shortcut_label(shortcut);
 		return `<span class="keyboard-shortcut">${shortcut}</span>`;
 	}
 	setup_editing_controls() {

--- a/frappe/public/scss/desk/menu.scss
+++ b/frappe/public/scss/desk/menu.scss
@@ -5,7 +5,9 @@
 }
 .frappe-menu {
 	position: absolute;
-	width: var(--menu-width);
+	width: max-content;
+	min-width: var(--menu-width);
+	max-width: min(320px, calc(100vw - 16px));
 	padding: 6px;
 	border-radius: var(--border-radius-lg);
 	background: var(--surface-modal);
@@ -24,6 +26,7 @@
 		height: 28px;
 		padding: 6px 8px 6px 8px;
 		gap: 8px;
+		min-width: var(--menu-width);
 		text-decoration: none;
 		display: flex;
 		align-items: center;
@@ -44,7 +47,18 @@
 	.menu-item-title {
 		text-overflow: ellipsis;
 		text-wrap: nowrap;
+		white-space: nowrap;
 		overflow: hidden;
+		flex: 1;
+	}
+	.menu-item-shortcut {
+		margin-left: var(--margin-lg);
+		color: var(--ink-gray-4, #999999);
+		font-size: var(--text-sm);
+		font-weight: 420;
+		line-height: 1.15;
+		letter-spacing: 0.02em;
+		white-space: nowrap;
 	}
 }
 

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -164,14 +164,29 @@ body[data-route^="Form"] {
 
 .menu-btn-group,
 .custom-btn-group,
+.actions-btn-group,
 .page-icon-group {
 	display: flex;
 	.dropdown-menu {
 		width: max-content;
 	}
+	.dropdown-item {
+		display: flex;
+		align-items: center;
+	}
 
 	.menu-item-label {
 		margin-right: var(--margin-md);
+	}
+
+	.menu-item-shortcut {
+		margin-left: auto;
+		color: var(--ink-gray-4, #999999);
+		font-size: var(--text-sm);
+		font-weight: 420;
+		line-height: 1.15;
+		letter-spacing: 0.02em;
+		white-space: nowrap;
 	}
 
 	.menu-item-icon {


### PR DESCRIPTION
Added keyboard shortcuts in the sidebar menu items for things which has a keyboard shortcut.

Before:
<img width="1122" height="1036" alt="image" src="https://github.com/user-attachments/assets/33d3a52e-6e17-4ac6-b370-b086b200037a" />
<img width="986" height="988" alt="image" src="https://github.com/user-attachments/assets/3cffb1f9-bb6f-4605-b6ce-4d59e46b543a" />


After:
<img width="986" height="1028" alt="image" src="https://github.com/user-attachments/assets/3e82ea00-466d-4fee-8556-b6d4a627c87c" />
<img width="986" height="988" alt="image" src="https://github.com/user-attachments/assets/4133cd15-8f8b-4cb6-bc45-7a1b6114ac50" />

