### PR TITLE
fix(communication): unify doctype sources in email relink search

### DIFF
--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -96,7 +96,9 @@ def get_communication_doctype(
 ):
 	can_read = frappe.get_user().get_can_read()
 
-	com_doctypes = frappe.db.get_values("DocType", {"issingle": 0, "istable": 0, "hide_toolbar": 0}, pluck="name")
+	com_doctypes = frappe.db.get_values(
+		"DocType", {"issingle": 0, "istable": 0, "hide_toolbar": 0}, pluck="name"
+	)
 
 	results = [[dt] for dt in list(set(com_doctypes)) if dt in can_read]
 

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -94,34 +94,11 @@ def relink(name: str, reference_doctype: str | None = None, reference_name: str 
 def get_communication_doctype(
 	doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: str | list | dict
 ):
-	user_perms = frappe.utils.user.UserPermissions(frappe.session.user)
-	user_perms.build_permissions()
-	can_read = user_perms.can_read
-	from frappe import _
-	from frappe.modules import load_doctype_module
+	can_read = frappe.get_user().get_can_read()
 
-	com_doctypes = []
-	if len(txt) < 2:
-		for name in frappe.get_hooks("communication_doctypes"):
-			try:
-				module = load_doctype_module(name, suffix="_dashboard")
-				if hasattr(module, "get_data"):
-					for i in module.get_data()["transactions"]:
-						com_doctypes += i["items"]
-			except ImportError:
-				pass
-	else:
-		com_doctypes = [
-			d[0] for d in frappe.db.get_values("DocType", {"issingle": 0, "istable": 0, "hide_toolbar": 0})
-		]
+	com_doctypes = frappe.db.get_values("DocType", {"issingle": 0, "istable": 0, "hide_toolbar": 0}, pluck="name")
 
-	results = []
-	txt_lower = txt.lower().replace("%", "")
-
-	for dt in list(set(com_doctypes)):
-		if dt in can_read:
-			if txt_lower in dt.lower() or txt_lower in _(dt).lower():
-				results.append([dt])
+	results = [[dt] for dt in list(set(com_doctypes)) if dt in can_read]
 
 	return results
 


### PR DESCRIPTION
Changes include:

- Refactored `get_communication_doctype()` in `frappe/email/__init__.py` to use `frappe.get_user().get_can_read()` and a direct `frappe.db.get_values()` query, replacing a complex manual permission-building and doctype-filtering loop
- Updated the `reference_doctype` field query filter in `communication.js` to use `hide_toolbar: 0` instead of `issingle: 0`, aligning the frontend filter with the backend query logic

---

Depends on #40201 