### PR TITLE
fix: change password in User Doctype

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -162,6 +162,53 @@ frappe.ui.form.on("User", {
 				frm.toggle_display(["sb1", "sb3", "modules_access"], true);
 			}
 
+			if (cint(frm.doc.enabled) && frm.has_perm("write")) {
+				frm.add_custom_button(
+					__("Change Password"),
+					function () {
+						const dialog = new frappe.ui.Dialog({
+							title: __("Change Password"),
+							fields: [
+								{
+									label: __("Set New Password"),
+									fieldtype: "Password",
+									fieldname: "new_password",
+									reqd: 1,
+								},
+								{
+									label: __("Logout From All Devices After Changing Password"),
+									fieldtype: "Check",
+									fieldname: "logout_all_sessions",
+									default: 1,
+								},
+							],
+							primary_action_label: __("Change Password"),
+							primary_action: (values) => {
+								return frappe
+									.call({
+										method: "frappe.core.doctype.user.user.change_password",
+										args: {
+											user: frm.doc.name,
+											new_password: values.new_password,
+											logout_all_sessions: values.logout_all_sessions,
+										},
+									})
+									.then(() => {
+										dialog.hide();
+										frappe.show_alert({
+											message: __("Password changed"),
+											indicator: "green",
+										});
+										frm.reload_doc();
+									});
+							},
+						});
+						dialog.show();
+					},
+					__("Password")
+				);
+			}
+
 			frm.add_custom_button(
 				__("Reset Password"),
 				function () {

--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -323,11 +323,13 @@
    "depends_on": "eval:doc.enabled && (!doc.__islocal || !cint(doc.send_welcome_email))",
    "fieldname": "change_password",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Change Password"
   },
   {
    "fieldname": "new_password",
    "fieldtype": "Password",
+   "hidden": 1,
    "label": "Set New Password",
    "no_copy": 1
   },
@@ -335,6 +337,7 @@
    "default": "1",
    "fieldname": "logout_all_sessions",
    "fieldtype": "Check",
+   "hidden": 1,
    "label": "Logout From All Devices After Changing Password"
   },
   {
@@ -905,7 +908,7 @@
   }
  ],
  "make_attachments_public": 1,
- "modified": "2026-04-28 21:59:59.160099",
+ "modified": "2026-05-26 11:34:02.705214",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1200,6 +1200,15 @@ def reset_password(user: str) -> None:
 	)
 
 
+@frappe.whitelist(methods=["POST"])
+def change_password(user: str, new_password: str, logout_all_sessions: int = 1) -> None:
+	user_doc: User = frappe.get_doc("User", user)
+	user_doc.check_permission("write")
+	user_doc.new_password = new_password
+	user_doc.logout_all_sessions = logout_all_sessions
+	user_doc.save()
+
+
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def user_query(doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict[str, Any]):


### PR DESCRIPTION
Removed change password from user form and shifted it under password button. Now when clicked on password -> change pasword, a dialog appears for setting a new password. 

Demo:

https://github.com/user-attachments/assets/381c91e5-73fd-4585-afc6-9d9c623cce1e

Closes: #39002 

