### PR TITLE
fix: section spacing for full width

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -32,7 +32,7 @@
 	padding: 0 var(--padding-md);
 	.form-section-description {
 		max-width: var(--page-max-width);
-		margin-left: 0;
+		margin: auto;
 		margin-bottom: 10px;
 		@include get_textstyle("base", "regular");
 		color: var(--text-light);
@@ -76,6 +76,12 @@
 		&:first-child {
 			margin-top: 1rem;
 		}
+	}
+}
+
+body.full-width {
+	.form-section-description {
+		margin-left: 0;
 	}
 }
 


### PR DESCRIPTION
Added conditional padding when viewed in full width.

Before:
<img width="1470" height="836" alt="Screenshot 2026-05-25 at 2 33 25 PM" src="https://github.com/user-attachments/assets/3caae390-380c-4480-9fb0-1236e9fa7c2f" />



After:
<img width="1470" height="836" alt="Screenshot 2026-05-25 at 1 19 37 PM" src="https://github.com/user-attachments/assets/1f7e4136-f6ec-49d9-a906-85b1ce3f9c99" />
