### PR TITLE
fix: use subtle blue for indicator pills in dark mode

### DIFF
--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -49,8 +49,8 @@ $check-icon-dark: url("data:image/svg+xml, <svg viewBox='0 0 8 7' fill='none' xm
 	--border-primary: var(--gray-200);
 
 	// Background Text Color Pairs
-	--bg-blue: var(--blue-600);
-	--bg-light-blue: var(--blue-600);
+	--bg-blue: var(--surface-blue-1);
+	--bg-light-blue: var(--surface-blue-1);
 	--bg-dark-blue: var(--blue-900);
 	--bg-green: var(--green-900);
 	--bg-yellow: var(--yellow-700);
@@ -65,8 +65,8 @@ $check-icon-dark: url("data:image/svg+xml, <svg viewBox='0 0 8 7' fill='none' xm
 	--bg-pink: var(--pink-700);
 	--bg-cyan: var(--cyan-800);
 
-	--text-on-blue: var(--blue-50);
-	--text-on-light-blue: var(--blue-50);
+	--text-on-blue: var(--ink-blue-3);
+	--text-on-light-blue: var(--ink-blue-3);
 	--text-on-dark-blue: var(--blue-300);
 	--text-on-green: var(--green-100);
 	--text-on-yellow: var(--yellow-50);


### PR DESCRIPTION
Resolve: #39254

---
**Before**
<img width="362" height="162" alt="image" src="https://github.com/user-attachments/assets/93a4ed40-83ea-49fb-9c67-aea0bd8d39b2" />


**After**
<img width="362" height="162" alt="image" src="https://github.com/user-attachments/assets/0c8df3d2-7a5e-49a4-a514-77e5c92ca9a4" />
