### PR TITLE
chore: migrate to new docker publish workflow

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -62,4 +62,4 @@ jobs:
     - name: curl
       run: |
         apk add curl bash
-        curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.CI_PAT }}" https://api.github.com/repos/frappe/frappe_docker/actions/workflows/build_stable.yml/dispatches -d '{"ref":"main"}'
+        curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.CI_PAT }}" https://api.github.com/repos/frappe/frappe_docker/actions/workflows/core-build-stable.yml/dispatches -d '{"ref":"main"}'


### PR DESCRIPTION
Raising PR on behalf of @DanielRadlAMR

> This repository is currently using the legacy Docker publish workflow, which has been replaced with a new standardized workflow. 

This PR migrates the legacy Docker Publish Workflow to the newer std. workflow in Frappe FW.

closes #38814

