### PR TITLE
refactor(print-format-builder): dark mode compatibility and remove inline styles

### DIFF
--- a/frappe/public/js/print_format_builder/Field.vue
+++ b/frappe/public/js/print_format_builder/Field.vue
@@ -65,8 +65,7 @@
 				</span>
 				<span
 					v-if="!df.table_columns || !df.table_columns.length"
-					class="text-muted"
-					style="font-size: var(--text-xs)"
+					class="text-muted no-columns-hint"
 				>
 					{{ __("No columns configured") }}
 				</span>
@@ -291,7 +290,7 @@ watch(
 }
 
 .field-actions .btn-icon:hover {
-	background-color: white;
+	background-color: var(--fg-color);
 }
 
 .custom-html {
@@ -327,7 +326,7 @@ watch(
 
 .table-col-chip {
 	display: inline-block;
-	background: white;
+	background: var(--fg-color);
 	border: 1px solid var(--gray-300);
 	border-radius: var(--border-radius-sm);
 	padding: 1px 6px;
@@ -354,7 +353,7 @@ watch(
 	font-size: var(--text-xs);
 	font-weight: 500;
 	color: var(--text-muted);
-	background: var(--gray-50, #f8f8f8);
+	background: var(--gray-50);
 	border: 1px solid var(--gray-200);
 	border-radius: var(--border-radius);
 	padding: 3px 8px;
@@ -373,5 +372,9 @@ watch(
 .configure-columns-btn:focus {
 	outline: none;
 	box-shadow: none;
+}
+
+.no-columns-hint {
+	font-size: var(--text-xs);
 }
 </style>

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="shouldRender" style="display: flex; width: 100%">
+	<div v-if="shouldRender" class="d-flex w-100">
 		<div style="padding: var(--padding-md)">
 			<PrintFormatControls />
 		</div>

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="shouldRender" class="d-flex w-100">
+	<div v-if="shouldRender" class="builder-root">
 		<div style="padding: var(--padding-md)">
 			<PrintFormatControls />
 		</div>
@@ -58,6 +58,11 @@ defineExpose({ toggle_preview, $store });
 </script>
 
 <style scoped>
+.builder-root {
+	display: flex;
+	width: 100%;
+}
+
 .print-format-container {
 	height: calc(100vh - 95px);
 	width: 100%;

--- a/frappe/public/js/print_format_builder/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatSection.vue
@@ -215,7 +215,7 @@ function set_column_align(column, value) {
 }
 
 .print-format-section {
-	background-color: white;
+	background-color: var(--fg-color);
 	border: 1px solid var(--dark-border-color);
 	border-radius: var(--border-radius);
 	overflow: hidden;
@@ -276,7 +276,7 @@ function set_column_align(column, value) {
 .input-section-label:focus {
 	border-color: var(--gray-400);
 	outline: none;
-	background-color: white;
+	background-color: var(--fg-color);
 }
 
 .input-section-label::placeholder {
@@ -325,10 +325,10 @@ function set_column_align(column, value) {
 }
 
 .column-btn.active {
-	background: white;
+	background: var(--fg-color);
 	color: var(--text-color);
 	font-weight: 600;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+	box-shadow: var(--shadow-xs);
 }
 
 .toolbar-btn {
@@ -406,9 +406,9 @@ function set_column_align(column, value) {
 }
 
 .col-align-btn.active {
-	background: white;
+	background: var(--fg-color);
 	color: var(--text-color);
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+	box-shadow: var(--shadow-xs);
 }
 
 .column-divider {

--- a/frappe/public/js/print_format_builder/SectionInsert.vue
+++ b/frappe/public/js/print_format_builder/SectionInsert.vue
@@ -41,7 +41,7 @@ defineEmits(["insert"]);
 	height: 18px;
 	border-radius: 50%;
 	border: 1.5px solid var(--gray-400);
-	background: white;
+	background: var(--fg-color);
 	color: var(--gray-600);
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Replace hardcoded `white` and `rgba(0,0,0,…)` values with `var(--fg-color)` and `var(--shadow-xs)` across the Print Format Builder components so they render correctly in dark mode. Also moves an inline `style` attribute and a `style="font-size"` to scoped CSS classes.