### PR TITLE
fix(child_table): fix grid row selection banner and button visibility

### DIFF
--- a/cypress/integration/grid.js
+++ b/cypress/integration/grid.js
@@ -183,4 +183,66 @@ context("Grid", () => {
 				});
 			});
 	});
+
+	it("hides add-row and add-multiple-rows buttons when rows are selected", () => {
+		cy.visit("/desk/contact/Test Contact");
+		cy.get('.frappe-control[data-fieldname="phone_nos"]').as("table");
+
+		cy.get("@table").find('.grid-row[data-idx="1"] .grid-row-check').click({ force: true });
+
+		cy.get("@table").find(".grid-add-row").should("have.class", "hidden");
+		cy.get("@table").find(".grid-add-multiple-rows").should("have.class", "hidden");
+
+		cy.get("@table").find('.grid-row[data-idx="1"] .grid-row-check').click({ force: true });
+
+		cy.get("@table").find(".grid-add-row").should("not.have.class", "hidden");
+	});
+
+	it("keeps selection count unchanged after duplicate_rows", () => {
+		cy.visit("/desk/contact/Test Contact");
+		cy.get('.frappe-control[data-fieldname="phone_nos"]').as("table");
+
+		cy.get("@table").find('.grid-row[data-idx="1"] .grid-row-check').click({ force: true });
+		cy.get("@table").find('.grid-row[data-idx="2"] .grid-row-check').click({ force: true });
+		cy.get("@table").find('.grid-row[data-idx="3"] .grid-row-check').click({ force: true });
+		cy.get("@table").find(".grid-selection-toast").should("be.visible");
+		cy.get("@table")
+			.find(".grid-selection-toast__message")
+			.should("contain", "3 row(s) selected");
+
+		// duplicate_rows unchecks the original row — banner should show 1 row(s) selected.
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				frm.get_field("phone_nos").grid.duplicate_rows();
+			});
+
+		cy.get("@table")
+			.find(".grid-selection-toast__message")
+			.should("contain", "3 row(s) selected");
+	});
+
+	it("hides selection banner after deleting selected rows", () => {
+		cy.visit("/desk/contact/Test Contact");
+		cy.get('.frappe-control[data-fieldname="phone_nos"]').as("table");
+
+		cy.get("@table").find('.grid-row[data-idx="1"] .grid-row-check').click({ force: true });
+		cy.get("@table").find(".grid-selection-toast").should("be.visible");
+
+		// Click the delete button in the UI so Cypress waits for DOM changes
+		cy.get("@table").find(".grid-remove-rows").click({ force: true });
+
+		cy.get("@table").find(".grid-selection-toast").should("not.be.visible");
+	});
+
+	it("shows and hides selection banner on selecting and unselecting a row", () => {
+		cy.visit("/desk/contact/Test Contact");
+		cy.get('.frappe-control[data-fieldname="phone_nos"]').as("table");
+
+		cy.get("@table").find('.grid-row[data-idx="1"] .grid-row-check').click({ force: true });
+		cy.get("@table").find(".grid-selection-toast").should("be.visible");
+
+		cy.get("@table").find('.grid-row[data-idx="1"] .grid-row-check').click({ force: true });
+		cy.get("@table").find(".grid-selection-toast").should("not.be.visible");
+	});
 });

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -269,20 +269,24 @@ export default class Grid {
 			this.refresh_remove_rows_button();
 			this.refresh_edit_rows_button();
 			this.refresh_duplicate_rows_button();
-			this.update_selection_banner(num_selected_rows);
+			this.update_selection_banner();
 		});
 	}
 
-	update_selection_banner(count) {
+	update_selection_banner() {
+		const num_selected_rows = this.get_selected_children().length;
+
 		let $container = this.wrapper.find(".form-grid-container");
 		let $toast = this.wrapper.find("> .grid-selection-toast");
-		if (count > 0) {
+		if (num_selected_rows > 0) {
 			if (!$toast.length) {
 				$toast = $(
 					`<div class="grid-selection-toast"><span class="grid-selection-toast__message"></span></div>`
 				).insertAfter($container);
 			}
-			$toast.find(".grid-selection-toast__message").text(__("{0} rows selected", [count]));
+			$toast
+				.find(".grid-selection-toast__message")
+				.text(__("{0} row(s) selected", [num_selected_rows]));
 			$toast.show();
 		} else if ($toast.length) {
 			$toast.hide();
@@ -315,6 +319,7 @@ export default class Grid {
 			this.add_new_row(null, null, false, doc, false);
 			this.check_range(doc.name, doc.name, false);
 		});
+		this.update_selection_banner();
 	}
 
 	delete_rows() {
@@ -582,6 +587,7 @@ export default class Grid {
 		this.refresh_duplicate_rows_button();
 
 		this.wrapper.trigger("change");
+		this.update_selection_banner();
 	}
 
 	render_result_rows($rows) {

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -247,7 +247,7 @@ export default class Grid {
 
 			// toggle "Add row" button
 			this.wrapper
-				.find(".grid-add-row")
+				.find(".grid-add-row, .grid-add-multiple-rows")
 				.toggleClass(
 					"hidden",
 					num_selected_rows > 0 ||


### PR DESCRIPTION
## Summary

- **Hide `Add Multiple Rows` button when rows are selected** — the selector for toggling the add-row button only covered `.grid-add-row`; `.grid-add-multiple-rows` was left visible when any rows were checked.
- **Fix selection banner not updating after `duplicate_rows`** — `duplicate_rows()` was not calling `update_selection_banner()` after unchecking the original row and checking the duplicate, leaving the banner showing a stale count.
- **Fix selection banner not updating after row deletion via `refresh()`** — `refresh()` (called after delete and other mutations) did not call `update_selection_banner()`, so the banner persisted with an outdated count after rows were removed.
- **Refactor `update_selection_banner`** — removed the `count` parameter; the method now derives the selected row count internally via `get_selected_children()`, eliminating the possibility of the caller passing a stale value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related to https://github.com/frappe/frappe/pull/38761/