### PR TITLE
feat: Redis-less Frappe for developer onboarding

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,6 +22,9 @@ inputs:
   disable-socketio:
     required: false
     default: false
+  start-bench:
+    required: false
+    default: true
   db:
     required: false
     default: mariadb
@@ -238,6 +241,7 @@ runs:
       echo -e "\033[33mCreate Site + Build Assets: $((end_time - start_time)) seconds\033[0m"
 
   - shell: bash -e {0}
+    if: ${{ inputs.start-bench == 'true' }}
     run: |
       # Start Bench
       bench start &> ${GITHUB_WORKSPACE}/bench_start.log &

--- a/.github/workflows/_base-redisless-smoke.yml
+++ b/.github/workflows/_base-redisless-smoke.yml
@@ -1,0 +1,187 @@
+name: Redis-less Smoke Base
+
+on:
+  workflow_call:
+    inputs:
+      fake-success:
+        required: false
+        type: boolean
+        default: false
+      python-version:
+        required: false
+        type: string
+        default: '3.14'
+      node-version:
+        required: false
+        type: number
+        default: 24
+
+
+jobs:
+  smoke:
+    name: Smoke
+    runs-on: ubuntu-latest
+    if: ${{ inputs.fake-success == false }}
+    timeout-minutes: 30
+    env:
+      NODE_ENV: "production"
+      PYTHONWARNINGS: "ignore"
+      DB_ROOT_PASSWORD: db_root
+
+    services:
+      mariadb:
+        image: mariadb:11.8
+        ports:
+          - 3306:3306
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3
+        env:
+          MARIADB_ROOT_PASSWORD: ${{ env.DB_ROOT_PASSWORD }}
+      smtp_server:
+        image: rnwood/smtp4dev:3.7.1
+        ports:
+          - 2525:25
+          - 3000:80
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup
+        name: Environment Setup
+        with:
+          python-version: ${{ inputs.python-version }}
+          node-version: ${{ inputs.node-version }}
+          build-assets: true
+          disable-socketio: false
+          start-bench: false
+          db-root-password: ${{ env.DB_ROOT_PASSWORD }}
+          db: mariadb
+
+      - name: Cache cypress binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress
+
+      - name: Configure Redis-less bench
+        run: |
+          bench --site test_site set-config use_memory_cache 1 --parse
+          bench --site test_site set-config in_memory 1 --parse
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("sites/common_site_config.json")
+          config = json.loads(path.read_text())
+          for key in ("redis_cache", "redis_queue", "redis_socketio"):
+              config.pop(key, None)
+          path.write_text(json.dumps(config, indent=2) + "\n")
+          PY
+
+          sed -i '/^worker:/d' Procfile
+          sed -i '/^schedule:/d' Procfile
+          sed -i '/^redis/d' Procfile
+          sed -i 's|^web: bench serve|web: bench serve --nothreading|' Procfile
+
+      - name: Prepare site
+        run: |
+          bench --site test_site execute frappe.utils.install.complete_setup_wizard
+          bench --site test_site execute frappe.tests.ui_test_helpers.create_test_user
+          bench --site test_site clear-cache
+
+      - name: Start Redis-less bench
+        run: |
+          bench start &> ${GITHUB_WORKSPACE}/bench_start.log &
+
+      - name: Wait for web server
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf --max-time 2 http://test_site:8000/api/method/ping >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Redis-less bench did not start in time" >&2
+          exit 1
+
+      - name: Run Redis-less server smoke tests
+        run: |
+          bench --site test_site run-tests --app frappe --module frappe.tests.test_caching
+          bench --site test_site run-tests --app frappe --module frappe.tests.test_realtime_inmemory
+          bench --site test_site run-tests --app frappe --module frappe.tests.test_background_jobs_inmemory
+
+      - uses: browser-actions/setup-chrome@latest
+
+      - name: Set browser path
+        run: |
+          echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
+
+      - name: Run Redis-less UI smoke tests
+        id: ui-tests
+        run: |
+          bench --site test_site run-ui-tests frappe \
+            --headless \
+            --browser ${{ env.BROWSER_PATH }} \
+            --spec cypress/integration/login.js
+
+      - name: Compress Cypress Videos
+        if: always() && steps.ui-tests.outcome == 'failure'
+        run: |
+          if find ./cypressVideos -mindepth 1 | read; then
+            zip -r cypress_recordings.zip ./cypressVideos
+          fi
+
+      - name: Upload Cypress Videos
+        if: always() && steps.ui-tests.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: redisless-cypress-recordings
+          path: ./cypress_recordings.zip
+          if-no-files-found: ignore
+
+      - name: Upload Redis-less logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: redisless-smoke-logs
+          path: |
+            ./bench_start.log
+            ./logs
+          if-no-files-found: ignore
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ failure() && contains( github.event.pull_request.labels.*.name, 'debug-gha') }}
+
+      - name: Show bench output
+        if: ${{ always() }}
+        run: |
+          cat bench_start.log || true
+          cd logs
+          for f in *.log*; do
+            [ -e "$f" ] || continue
+            echo "Printing log: $f";
+            cat "$f"
+          done
+
+  success:
+    name: Success
+    needs: [smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Redis-less smoke '${{ needs.smoke.result }}'
+        shell: python
+        run: |
+          stati = [
+            '${{ needs.smoke.result }}',
+          ]
+
+          nopass = ["failure", "cancelled"]
+          dopass = ["success", "skipped"]
+          if any(r in nopass for r in stati):
+            exit(1)
+          if all(r in dopass for r in stati):
+            exit(0)
+          exit(1)

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -225,6 +225,15 @@ jobs:
             cat $f
           done
 
+  redisless-smoke:
+    name: Redis-less Smoke
+    needs: [checkrun, test, migrate]
+    if: ${{ needs.checkrun.outputs.build == 'strawberry' && needs.test.result == 'success' && needs.migrate.result == 'success' }}
+    uses: ./.github/workflows/_base-redisless-smoke.yml
+    with:
+      fake-success: false
+    secrets: inherit
+
   coverage:
     name: Coverage Wrap Up
     needs: [test, checkrun]

--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,6 @@ cypress/videos
 .helix/
 # Aider AI Chat
 .aider*
+
+# Redis-less Docker test
+docker-test/

--- a/frappe/commands/test_commands.py
+++ b/frappe/commands/test_commands.py
@@ -108,12 +108,49 @@ def pass_test_context(f):
 	return decorated_function
 
 
+def make_pass_test_context(context):
+	@wraps(pass_test_context)
+	def _pass_test_context(f):
+		@wraps(f)
+		def decorated_function(*args, **kwargs):
+			return f(context, *args, **kwargs)
+
+		return decorated_function
+
+	return _pass_test_context
+
+
 @contextmanager
 def cli(cmd: Command, args: list | None = None):
 	with maintain_locals():
 		global _result
 
 		patch_ctx = patch("frappe.commands.pass_context", pass_test_context)
+		_module = cmd.callback.__module__
+		_cmd = cmd.callback.__qualname__
+
+		__module = importlib.import_module(_module)
+		patch_ctx.start()
+		importlib.reload(__module)
+		click_cmd = getattr(__module, _cmd)
+
+		try:
+			_result = CliRunner().invoke(click_cmd, args=args)
+			_result.command = str(cmd)
+			yield _result
+		finally:
+			patch_ctx.stop()
+			__module = importlib.import_module(_module)
+			importlib.reload(__module)
+			importlib.invalidate_caches()
+
+
+@contextmanager
+def cli_with_context(cmd: Command, context, args: list | None = None):
+	with maintain_locals():
+		global _result
+
+		patch_ctx = patch("frappe.commands.pass_context", make_pass_test_context(context))
 		_module = cmd.callback.__module__
 		_cmd = cmd.callback.__qualname__
 
@@ -982,6 +1019,137 @@ class TestSchedulerUtils(BaseTestCommands):
 	def test_ready_for_migrate(self):
 		with cli(frappe.commands.scheduler.ready_for_migration) as result:
 			self.assertEqual(result.exit_code, 0)
+
+
+class TestSetupWizardCLI(BaseTestCommands):
+	def _setup_wizard_args(self, **kwargs) -> list[str]:
+		defaults = {
+			"country": "Australia",
+			"timezone": "Australia/Sydney",
+			"currency": "AUD",
+		}
+		defaults.update(kwargs)
+
+		args = []
+		for key, value in defaults.items():
+			flag = f"--{key.replace('_', '-')}"
+			if isinstance(value, bool):
+				if value:
+					args.append(flag)
+				continue
+			args.extend([flag, str(value)])
+		return args
+
+	def test_setup_wizard_success(self):
+		import frappe.commands.wizard
+
+		with (
+			patch("frappe.init") as init,
+			patch("frappe.connect"),
+			patch("frappe.destroy") as destroy,
+			patch("frappe.db.get_single_value", return_value=0),
+			patch(
+				"frappe.desk.page.setup_wizard.setup_wizard.setup_complete",
+				return_value={"status": "ok"},
+			),
+		):
+			with cli(
+				frappe.commands.wizard.setup_wizard,
+				args=self._setup_wizard_args(),
+			) as result:
+				self.assertEqual(result.exit_code, 0)
+				self.assertIsNone(result.exception)
+				self.assertIn("running setup wizard", result.output)
+				self.assertIn("setup complete", result.output)
+
+		init.assert_called_once_with(site=TEST_SITE)
+		destroy.assert_called_once()
+
+	def test_setup_wizard_skips_completed_site(self):
+		import frappe.commands.wizard
+
+		with (
+			patch("frappe.init"),
+			patch("frappe.connect"),
+			patch("frappe.destroy") as destroy,
+			patch("frappe.db.get_single_value", return_value=1),
+			patch("frappe.desk.page.setup_wizard.setup_wizard.setup_complete") as setup_complete,
+		):
+			with cli(frappe.commands.wizard.setup_wizard, args=self._setup_wizard_args()) as result:
+				self.assertEqual(result.exit_code, 0)
+				self.assertIn("setup already complete", result.output)
+
+		setup_complete.assert_not_called()
+		destroy.assert_called_once()
+
+	def test_setup_wizard_failure_exits_nonzero(self):
+		import frappe.commands.wizard
+
+		with (
+			patch("frappe.init"),
+			patch("frappe.connect"),
+			patch("frappe.destroy") as destroy,
+			patch("frappe.db.get_single_value", return_value=0),
+			patch(
+				"frappe.desk.page.setup_wizard.setup_wizard.setup_complete",
+				return_value={"status": "error"},
+			),
+		):
+			with cli(frappe.commands.wizard.setup_wizard, args=self._setup_wizard_args()) as result:
+				self.assertEqual(result.exit_code, 1)
+				self.assertIn("setup failed", result.output)
+
+		destroy.assert_called_once()
+
+	def test_setup_wizard_requires_site(self):
+		import frappe.commands.wizard
+
+		with cli_with_context(
+			frappe.commands.wizard.setup_wizard,
+			frappe._dict(sites=[]),
+			args=self._setup_wizard_args(),
+		) as result:
+			self.assertEqual(result.exit_code, 1)
+			self.assertIsInstance(result.exception, frappe.exceptions.SiteNotSpecifiedError)
+
+	def test_setup_wizard_background_parent_process(self):
+		import frappe.commands.wizard
+
+		with (
+			patch("os.fork", return_value=123),
+			patch("frappe.init") as init,
+		):
+			with cli(
+				frappe.commands.wizard.setup_wizard,
+				args=self._setup_wizard_args(background=True),
+			) as result:
+				self.assertEqual(result.exit_code, 0)
+				self.assertIn("forked to background", result.output)
+
+		init.assert_not_called()
+
+	def test_setup_wizard_background_child_exits(self):
+		import frappe.commands.wizard
+
+		with (
+			patch("os.fork", return_value=0),
+			patch("os._exit", side_effect=SystemExit(0)) as os_exit,
+			patch("frappe.init"),
+			patch("frappe.connect"),
+			patch("frappe.destroy"),
+			patch("frappe.db.get_single_value", return_value=0),
+			patch(
+				"frappe.desk.page.setup_wizard.setup_wizard.setup_complete",
+				return_value={"status": "ok"},
+			),
+		):
+			with cli(
+				frappe.commands.wizard.setup_wizard,
+				args=self._setup_wizard_args(background=True),
+			) as result:
+				self.assertEqual(result.exit_code, 0)
+
+		os_exit.assert_called_once_with(0)
 
 
 class TestCommandUtils(IntegrationTestCase):

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -998,6 +998,75 @@ def setup_chrome():
 	setup_chromium()
 
 
+@click.command("setup-wizard")
+@click.option("--language", default="English", show_default=True, help="System language")
+@click.option("--country", required=True, help="Country name (e.g. Australia)")
+@click.option("--timezone", required=True, help="Timezone (e.g. Australia/Sydney)")
+@click.option("--currency", required=True, help="Currency code (e.g. AUD)")
+@click.option("--full-name", default="Administrator", show_default=True, help="Administrator full name")
+@click.option("--email", default="admin@example.com", show_default=True, help="Administrator email")
+@click.option("--password", default="admin", show_default=True, help="Administrator password")
+@click.option(
+	"--background",
+	is_flag=True,
+	default=False,
+	help="Fork to background and return immediately; progress is logged to stdout",
+)
+@pass_context
+def setup_wizard(
+	context: CliCtxObj,
+	language,
+	country,
+	timezone,
+	currency,
+	full_name,
+	email,
+	password,
+	background,
+):
+	"Run the setup wizard for a site from the command line (no browser required)"
+	from frappe.desk.page.setup_wizard.setup_wizard import setup_complete
+
+	args = {
+		"language": language,
+		"country": country,
+		"timezone": timezone,
+		"currency": currency,
+		"full_name": full_name,
+		"email": email,
+		"password": password,
+	}
+
+	for site in context.sites:
+		if background:
+			pid = os.fork()
+			if pid > 0:
+				click.echo(f"Setup wizard forked to background (PID {pid}). Follow logs for progress.")
+				continue
+
+		frappe.init(site=site)
+		frappe.connect()
+		try:
+			if frappe.db.get_single_value("System Settings", "setup_complete"):
+				click.echo(f"Site '{site}': setup already complete — skipping.")
+				continue
+			click.echo(f"Site '{site}': running setup wizard...")
+			result = setup_complete(frappe._dict(args))
+			if result and result.get("status") == "ok":
+				click.echo(f"Site '{site}': setup complete ✓")
+			else:
+				click.echo(f"Site '{site}': setup failed — {result}", err=True)
+				raise SystemExit(1)
+		finally:
+			frappe.destroy()
+
+		if background:
+			os._exit(0)
+
+	if not context.sites:
+		raise SiteNotSpecifiedError
+
+
 commands = [
 	build,
 	clear_cache,
@@ -1031,4 +1100,5 @@ commands = [
 	rebuild_global_search,
 	list_sites,
 	setup_chrome,
+	setup_wizard,
 ]

--- a/frappe/commands/wizard.py
+++ b/frappe/commands/wizard.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+from frappe.commands.utils import setup_wizard
+
+commands = [setup_wizard]

--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -80,14 +80,14 @@ def publish_realtime(
 		if params not in frappe.local._realtime_log:
 			frappe.local._realtime_log.append(params)
 	else:
-		emit_via_redis(event, message, room)
+		dispatch_realtime_event(event, message, room)
 
 
 def flush_realtime_log():
 	if not hasattr(frappe.local, "_realtime_log"):
 		return
 	for args in frappe.local._realtime_log:
-		frappe.realtime.emit_via_redis(*args)
+		dispatch_realtime_event(*args)
 
 	clear_realtime_log()
 
@@ -95,6 +95,30 @@ def flush_realtime_log():
 def clear_realtime_log():
 	if hasattr(frappe.local, "_realtime_log"):
 		del frappe.local._realtime_log
+
+
+def dispatch_realtime_event(event, message, room):
+	if frappe.conf.get("in_memory"):
+		emit_via_webhook(event, message, room)
+	else:
+		emit_via_redis(event, message, room)
+
+
+def emit_via_webhook(event, message, room):
+	"""Publish real-time updates via HTTP Webhook"""
+	import requests
+
+	payload = {"event": event, "message": message, "room": room, "namespace": frappe.local.site}
+	socketio_port = frappe.conf.get("socketio_port", 9000)
+	try:
+		requests.post(
+			f"http://localhost:{socketio_port}/_internal/publish_event",
+			data=frappe.as_json(payload),
+			headers={"Content-Type": "application/json"},
+			timeout=1,
+		)
+	except requests.exceptions.RequestException:
+		pass
 
 
 def emit_via_redis(event, message, room):
@@ -139,13 +163,14 @@ def get_socketio_secret():
 	return secret
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep
 def get_user_info():
-	user_type = frappe.session.data.user_type
-	trusted_secret = get_socketio_secret()
-	provided_secret = frappe.get_request_header("X-Frappe-Socket-Secret")
-	if trusted_secret != provided_secret:
-		return {}
+	user_type = frappe.session.data.get("user_type")
+	if not frappe.conf.get("in_memory"):
+		trusted_secret = get_socketio_secret()
+		provided_secret = frappe.get_request_header("X-Frappe-Socket-Secret")
+		if trusted_secret != provided_secret:
+			return {}
 	# For requests with Bearer tokens, user_type is not set in the session data
 	if not user_type:
 		user_type = frappe.get_cached_value("User", frappe.session.user, "user_type")

--- a/frappe/tests/test_background_jobs_inmemory.py
+++ b/frappe/tests/test_background_jobs_inmemory.py
@@ -1,0 +1,101 @@
+from unittest.mock import MagicMock, patch
+
+from redis.exceptions import ConnectionError
+
+import frappe
+from frappe.tests.classes.integration_test_case import IntegrationTestCase
+from frappe.utils.background_jobs import enqueue
+
+
+class TestBackgroundJobsInMemory(IntegrationTestCase):
+	def setUp(self):
+		super().setUp()
+		self.original_in_migrate = frappe.local.flags.in_migrate
+		frappe.local.flags.in_migrate = False
+		frappe.db.after_commit.reset()
+
+	def tearDown(self):
+		frappe.local.flags.in_migrate = self.original_in_migrate
+		frappe.db.after_commit.reset()
+		super().tearDown()
+
+	def mock_job_method(self):
+		pass
+
+	@patch("frappe.utils.background_jobs.get_queue")
+	@patch("frappe.utils.background_jobs.execute_job")
+	@patch("frappe.utils.background_jobs._in_memory_pool")
+	def test_in_memory_async_submission(self, mock_pool, mock_execute_job, mock_get_queue):
+		# Simulate Redis offline
+		mock_get_queue.side_effect = ConnectionError("Redis is down")
+
+		from frappe.utils.redis_wrapper import MemoryCacheWrapper
+
+		with patch("frappe.cache", new=MemoryCacheWrapper()):
+			enqueue(self.mock_job_method, queue="default", is_async=True, enqueue_after_commit=False)
+
+			# Check that ThreadPool was submitted to
+			mock_pool.submit.assert_called_once()
+
+			# Check args passed to submit
+			args, kwargs = mock_pool.submit.call_args
+			self.assertEqual(args[0], mock_execute_job)  # The wrapped execute_job
+			self.assertEqual(kwargs.get("is_async"), True)
+
+	@patch("frappe.utils.background_jobs.get_queue")
+	@patch("frappe.call")
+	@patch("frappe.utils.background_jobs._in_memory_pool")
+	def test_in_memory_sync_during_migration(self, mock_pool, mock_frappe_call, mock_get_queue):
+		# Simulate Redis offline
+		mock_get_queue.side_effect = ConnectionError("Redis is down")
+
+		# Flag system as migrating
+		frappe.local.flags.in_migrate = True
+
+		from frappe.utils.redis_wrapper import MemoryCacheWrapper
+
+		with patch("frappe.cache", new=MemoryCacheWrapper()):
+			enqueue(self.mock_job_method, queue="default", is_async=True, enqueue_after_commit=False)
+
+			# Should bypass thread pool and run inline
+			mock_pool.submit.assert_not_called()
+			mock_frappe_call.assert_called_once()
+
+	@patch("frappe.utils.background_jobs.get_queue")
+	@patch("frappe.utils.background_jobs._in_memory_pool")
+	def test_enqueue_after_commit_deferred(self, mock_pool, mock_get_queue):
+		# Simulate Redis offline
+		mock_get_queue.side_effect = ConnectionError("Redis is down")
+
+		from frappe.utils.redis_wrapper import MemoryCacheWrapper
+
+		with patch("frappe.cache", new=MemoryCacheWrapper()):
+			enqueue(self.mock_job_method, queue="default", is_async=True, enqueue_after_commit=True)
+
+			# Should NOT be submitted immediately
+			mock_pool.submit.assert_not_called()
+
+			# Should be appended to after_commit hook
+			self.assertEqual(len(frappe.db.after_commit._functions), 1)
+
+			# Simulate commit which fires hooks
+			frappe.db.after_commit.run()
+
+			# NOW it should be submitted
+			mock_pool.submit.assert_called_once()
+
+	@patch("frappe.utils.background_jobs.get_queue")
+	@patch("frappe.utils.background_jobs._in_memory_pool")
+	def test_redis_available_standard_flow(self, mock_pool, mock_get_queue):
+		# Mock a valid RQ Queue
+		mock_q = MagicMock()
+		mock_get_queue.return_value = mock_q
+
+		with patch("frappe.utils.background_jobs._check_queue_size"):
+			enqueue(self.mock_job_method, queue="default", is_async=True, enqueue_after_commit=False)
+
+			# ThreadPool bypassed completely
+			mock_pool.submit.assert_not_called()
+
+			# RQ queue enqueue_call triggered
+			mock_q.enqueue_call.assert_called_once()

--- a/frappe/tests/test_caching.py
+++ b/frappe/tests/test_caching.py
@@ -1,5 +1,5 @@
 import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
@@ -285,6 +285,23 @@ class TestRedisWrapper(FrappeAPITestCase):
 		frappe.cache.delete_keys(prefix)
 		self.assertEqual(len(frappe.cache.get_keys(prefix)), 0)
 
+	def test_delete_keys_with_user_and_shared_args(self):
+		user_prefix = "test_user_del_"
+		shared_prefix = "test_shared_del_"
+
+		for i in range(3):
+			frappe.cache.set_value(f"{user_prefix}{i}", 1, user="Administrator")
+			frappe.cache.set_value(f"{shared_prefix}{i}", 1, shared=True)
+
+		self.assertEqual(len(frappe.cache.get_keys(user_prefix, user="Administrator")), 3)
+		self.assertEqual(len(frappe.cache.get_keys(shared_prefix, shared=True)), 3)
+
+		frappe.cache.delete_keys(user_prefix, user="Administrator")
+		frappe.cache.delete_keys(shared_prefix, shared=True)
+
+		self.assertEqual(len(frappe.cache.get_keys(user_prefix, user="Administrator")), 0)
+		self.assertEqual(len(frappe.cache.get_keys(shared_prefix, shared=True)), 0)
+
 	def test_hash(self):
 		key = "test_hash"
 
@@ -361,6 +378,291 @@ class TestRedisWrapper(FrappeAPITestCase):
 
 	def test_backward_compat_cache(self):
 		self.assertEqual(frappe.cache, frappe.cache())
+
+	def test_cache_fallback_on_redis_failure(self):
+		"""Test that cache falls back to memory cache when Redis connection fails"""
+		import redis
+
+		from frappe.utils.redis_wrapper import MemoryCacheWrapper, setup_cache
+
+		with patch("frappe.utils.redis_wrapper.RedisWrapper.from_url") as mock_from_url:
+			mock_from_url.side_effect = redis.exceptions.ConnectionError("Redis connection failed")
+
+			with patch.object(
+				frappe.local,
+				"conf",
+				type(
+					"conf",
+					(),
+					{
+						"get": lambda self, key, default=None: None,
+						"redis_cache_sentinel_enabled": False,
+					},
+				)(),
+			):
+				cache = setup_cache()
+				self.assertIsInstance(
+					cache, MemoryCacheWrapper, "Should fall back to MemoryCacheWrapper when Redis fails"
+				)
+
+	def test_memory_cache_operations(self):
+		"""Test that MemoryCacheWrapper works for basic cache operations"""
+		from frappe.utils.redis_wrapper import MemoryCacheWrapper
+
+		cache = MemoryCacheWrapper()
+
+		# Test basic set/get
+		cache.set_value("test_key", "test_value")
+		self.assertEqual(cache.get_value("test_key"), "test_value")
+
+		# Test hash operations
+		cache.hset("hash_key", "field1", "value1")
+		cache.hset("hash_key", "field2", "value2")
+		self.assertEqual(cache.hget("hash_key", "field1"), "value1")
+		self.assertEqual(cache.hgetall("hash_key"), {b"field1": "value1", b"field2": "value2"})
+
+		# Test list operations
+		cache.lpush("list_key", "item1")
+		cache.lpush("list_key", "item2")
+		self.assertEqual(cache.lrange("list_key", 0, -1), ["item2", "item1"])
+		self.assertEqual(cache.lpop("list_key"), "item2")
+
+		# Test delete operations
+		cache.delete_value("test_key")
+		self.assertIsNone(cache.get_value("test_key"))
+
+	def test_memory_cache_exports_and_configured_backend(self):
+		from frappe.utils import redis_wrapper
+		from frappe.utils.memory_cache import MemoryCacheWrapper, MemoryPipeline
+		from frappe.utils.redis_wrapper import setup_cache
+
+		self.assertIs(redis_wrapper.MemoryCacheWrapper, MemoryCacheWrapper)
+		self.assertIs(redis_wrapper.MemoryPipeline, MemoryPipeline)
+
+		with self.assertRaises(AttributeError):
+			redis_wrapper.__getattr__("UnknownCache")
+
+		with patch.object(
+			frappe.local,
+			"conf",
+			type(
+				"conf",
+				(),
+				{
+					"get": lambda self, key, default=None: {"use_memory_cache": True}.get(key, default),
+					"redis_cache_sentinel_enabled": False,
+				},
+			)(),
+		):
+			cache = setup_cache()
+			self.assertIsInstance(cache, MemoryCacheWrapper)
+
+	def test_setup_cache_uses_sentinel_when_available(self):
+		from frappe.utils.redis_wrapper import setup_cache
+
+		redis_cache = MagicMock()
+		redis_cache.connected.return_value = True
+		sentinel = MagicMock()
+		sentinel.master_for.return_value = redis_cache
+
+		with (
+			patch("frappe.utils.redis_wrapper.get_sentinel_connection", return_value=sentinel),
+			patch.object(
+				frappe.local,
+				"conf",
+				type(
+					"conf",
+					(),
+					{
+						"get": lambda self, key, default=None: {
+							"redis_cache_sentinels": ["localhost:26379"],
+							"redis_cache_master_service": "mymaster",
+						}.get(key, default),
+						"redis_cache_sentinel_enabled": True,
+					},
+				)(),
+			),
+		):
+			cache = setup_cache()
+
+		self.assertIs(cache, redis_cache)
+		sentinel.master_for.assert_called_once()
+
+	def test_setup_cache_sentinel_falls_back_on_failed_connection_test(self):
+		from frappe.utils.memory_cache import MemoryCacheWrapper
+		from frappe.utils.redis_wrapper import setup_cache
+
+		redis_cache = MagicMock()
+		redis_cache.connected.return_value = False
+		sentinel = MagicMock()
+		sentinel.master_for.return_value = redis_cache
+
+		with (
+			patch("frappe.utils.redis_wrapper.get_sentinel_connection", return_value=sentinel),
+			patch.object(
+				frappe.local,
+				"conf",
+				type(
+					"conf",
+					(),
+					{
+						"get": lambda self, key, default=None: {
+							"redis_cache_sentinels": ["localhost:26379"],
+							"redis_cache_master_service": "mymaster",
+						}.get(key, default),
+						"redis_cache_sentinel_enabled": True,
+					},
+				)(),
+			),
+		):
+			cache = setup_cache()
+
+		self.assertIsInstance(cache, MemoryCacheWrapper)
+
+	def test_cache_fallback_on_unexpected_redis_setup_error(self):
+		from frappe.utils.memory_cache import MemoryCacheWrapper
+		from frappe.utils.redis_wrapper import setup_cache
+
+		with patch("frappe.utils.redis_wrapper.RedisWrapper.from_url") as mock_from_url:
+			mock_from_url.side_effect = RuntimeError("unexpected failure")
+
+			with patch.object(
+				frappe.local,
+				"conf",
+				type(
+					"conf",
+					(),
+					{
+						"get": lambda self, key, default=None: None,
+						"redis_cache_sentinel_enabled": False,
+					},
+				)(),
+			):
+				cache = setup_cache()
+				self.assertIsInstance(cache, MemoryCacheWrapper)
+
+	def test_memory_cache_key_and_expiry_operations(self):
+		from frappe.utils.memory_cache import MemoryCacheWrapper
+
+		cache = MemoryCacheWrapper()
+		frappe.local.cache.clear()
+
+		self.assertIs(cache(), cache)
+		self.assertTrue(cache.ping())
+		self.assertTrue(cache.connected())
+		self.assertEqual(cache.client_id(), 1)
+		self.assertEqual(cache.execute_command("INFO"), {})
+
+		cache.set_value("plain", "value")
+		self.assertEqual(cache.get_value("plain"), "value")
+		self.assertEqual(cache.exists("plain"), 1)
+
+		generator_calls = 0
+
+		def generate_value():
+			nonlocal generator_calls
+			generator_calls += 1
+			return "generated"
+
+		self.assertEqual(cache.get_value("generated", generator=generate_value), "generated")
+		self.assertEqual(cache.get_value("generated", generator=generate_value), "generated")
+		self.assertEqual(generator_calls, 1)
+
+		cache.set_value("user-key", "user-value", user="Administrator")
+		cache.set_value("shared-key", "shared-value", shared=True)
+		self.assertEqual(cache.get_value("user-key", user="Administrator"), "user-value")
+		self.assertEqual(cache.get_value("shared-key", shared=True), "shared-value")
+		self.assertEqual(cache.exists("user-key", user="Administrator"), 1)
+		self.assertEqual(cache.exists("shared-key", shared=True), 1)
+		self.assertEqual(len(cache.get_keys("user-", user="Administrator")), 1)
+		self.assertEqual(len(cache.get_keys("shared-", shared=True)), 1)
+
+		cache.delete_keys("user-", user="Administrator")
+		cache.delete_keys("shared-", shared=True)
+		self.assertEqual(cache.exists("user-key", user="Administrator"), 0)
+		self.assertEqual(cache.exists("shared-key", shared=True), 0)
+
+		with patch("frappe.utils.memory_cache.time.time", side_effect=[100, 100, 102]):
+			cache.set_value("expiring", "soon-gone", expires_in_sec=1)
+			frappe.local.cache.pop(cache.make_key("expiring"), None)
+			self.assertEqual(cache.get_value("expiring", use_local_cache=False), "soon-gone")
+			frappe.local.cache.pop(cache.make_key("expiring"), None)
+			self.assertIsNone(cache.get_value("expiring", use_local_cache=False))
+
+		cache.set_value("delete-me", "gone")
+		cache.delete_key("delete-me")
+		self.assertEqual(cache.exists("delete-me"), 0)
+
+		self.assertTrue(cache.expire_key("plain", 10))
+		self.assertIn(cache.make_key("plain"), cache.expiries)
+
+	def test_memory_cache_collection_operations(self):
+		from frappe.utils.memory_cache import MemoryCacheWrapper
+
+		cache = MemoryCacheWrapper()
+		frappe.local.cache.clear()
+
+		cache.lpush("queue", "first")
+		cache.rpush("queue", "second")
+		cache.lpush("queue", "zero")
+		self.assertEqual(cache.llen("queue"), 3)
+		self.assertEqual(cache.lrange("queue", 0, -1), ["zero", "first", "second"])
+		self.assertEqual(cache.blpop("queue"), "zero")
+		self.assertEqual(cache.rpop("queue"), "second")
+		cache.rpush("queue", "third")
+		cache.ltrim("queue", 1, -1)
+		self.assertEqual(cache.lrange("queue", 0, -1), ["third"])
+		with patch("frappe.utils.memory_cache.time.sleep") as sleep:
+			self.assertIsNone(cache.blpop("missing", timeout=1))
+			sleep.assert_called_once_with(1)
+
+		cache.hset("hash", "field1", "value1")
+		self.assertEqual(cache.hget("hash", "field1"), "value1")
+		self.assertEqual(cache.hget("hash", "field2", generator=lambda: "value2"), "value2")
+		self.assertEqual(set(cache.hkeys("hash")), {b"field1", b"field2"})
+		self.assertEqual(cache.hgetall("hash"), {b"field1": "value1", b"field2": "value2"})
+		self.assertTrue(cache.hexists("hash", "field1"))
+		self.assertFalse(cache.hexists("hash", None))
+		cache.hdel("hash", "field1")
+		self.assertFalse(cache.hexists("hash", "field1"))
+
+		cache.hset("prefix:first", "shared-field", "one")
+		cache.hset("prefix:second", "shared-field", "two")
+		cache.hdel_keys("prefix:", "shared-field")
+		self.assertFalse(cache.hexists("prefix:first", "shared-field"))
+		self.assertFalse(cache.hexists("prefix:second", "shared-field"))
+
+		cache.hset("hash-one", "name", "one")
+		cache.hset("hash-two", "name", "two")
+		cache.hdel_names(["hash-one", "hash-two"], "name")
+		self.assertFalse(cache.hexists("hash-one", "name"))
+		self.assertFalse(cache.hexists("hash-two", "name"))
+
+		cache.sadd("letters", "a", "b", "c")
+		self.assertTrue(cache.sismember("letters", "a"))
+		self.assertEqual(cache.smembers("letters"), {"a", "b", "c"})
+		self.assertIn(cache.srandmember("letters"), {"a", "b", "c"})
+		self.assertEqual(len(cache.srandmember("letters", 2)), 2)
+		popped = cache.spop("letters")
+		self.assertNotIn(popped, cache.smembers("letters"))
+		cache.srem("letters", "b")
+		self.assertFalse(cache.sismember("letters", "b"))
+
+		results = (
+			cache.pipeline().set_value("pipe-key", "pipe").hset("pipe-hash", "k", "v").missing().execute()
+		)
+		self.assertEqual(results, [None, None])
+		self.assertEqual(cache.get_value("pipe-key"), "pipe")
+		self.assertEqual(cache.hget("pipe-hash", "k"), "v")
+
+		self.assertEqual(cache.incrby("counter"), 1)
+		self.assertEqual(cache.incrby("counter", 3), 4)
+		self.assertTrue(cache.expire("counter", 5))
+		self.assertIn("counter", cache.expiries)
+
+		pubsub = cache.pubsub()
+		self.assertIsNone(pubsub.subscribe(channel="updates"))
+		self.assertTrue(pubsub.run_in_thread().is_alive())
 
 
 class TestHttpCache(FrappeAPITestCase):

--- a/frappe/tests/test_realtime_inmemory.py
+++ b/frappe/tests/test_realtime_inmemory.py
@@ -1,0 +1,76 @@
+from unittest.mock import patch
+
+import requests
+
+import frappe
+from frappe.realtime import dispatch_realtime_event
+from frappe.tests.classes.integration_test_case import IntegrationTestCase
+
+
+class TestRealtimeInMemory(IntegrationTestCase):
+	def setUp(self):
+		super().setUp()
+		self.original_in_memory = frappe.conf.get("in_memory")
+		self.original_socketio_port = frappe.conf.get("socketio_port")
+
+	def tearDown(self):
+		if self.original_in_memory is not None:
+			frappe.conf["in_memory"] = self.original_in_memory
+		else:
+			frappe.conf.pop("in_memory", None)
+
+		if self.original_socketio_port is not None:
+			frappe.conf["socketio_port"] = self.original_socketio_port
+		else:
+			frappe.conf.pop("socketio_port", None)
+		super().tearDown()
+
+	@patch("frappe.realtime.emit_via_redis")
+	@patch("frappe.realtime.emit_via_webhook")
+	def test_dispatcher_routing_redis(self, mock_webhook, mock_redis):
+		frappe.conf["in_memory"] = 0
+		dispatch_realtime_event("test_event", {"data": "test"}, "room")
+
+		mock_redis.assert_called_once_with("test_event", {"data": "test"}, "room")
+		mock_webhook.assert_not_called()
+
+	@patch("frappe.realtime.emit_via_redis")
+	@patch("frappe.realtime.emit_via_webhook")
+	def test_dispatcher_routing_webhook(self, mock_webhook, mock_redis):
+		frappe.conf["in_memory"] = 1
+		dispatch_realtime_event("test_event", {"data": "test"}, "room")
+
+		mock_webhook.assert_called_once_with("test_event", {"data": "test"}, "room")
+		mock_redis.assert_not_called()
+
+	@patch("requests.post")
+	def test_webhook_payload_structure(self, mock_post):
+		frappe.conf["in_memory"] = 1
+		frappe.conf["socketio_port"] = 9999
+
+		dispatch_realtime_event("test_event", {"data": "test"}, "test_room")
+
+		mock_post.assert_called_once()
+		args, kwargs = mock_post.call_args
+
+		self.assertEqual(args[0], "http://localhost:9999/_internal/publish_event")
+		self.assertEqual(kwargs.get("timeout"), 1)
+
+		payload_str = kwargs.get("data")
+		self.assertIsNotNone(payload_str)
+		payload = frappe.parse_json(payload_str)
+		self.assertEqual(payload["event"], "test_event")
+		self.assertEqual(payload["message"], {"data": "test"})
+		self.assertEqual(payload["room"], "test_room")
+		self.assertEqual(payload["namespace"], frappe.local.site)
+
+	@patch("requests.post")
+	def test_webhook_graceful_failure(self, mock_post):
+		frappe.conf["in_memory"] = 1
+		mock_post.side_effect = requests.exceptions.ConnectionError("Node server down")
+
+		# Should not raise an exception
+		try:
+			dispatch_realtime_event("test_event", {"data": "test"}, "test_room")
+		except Exception as e:
+			self.fail(f"Webhook emit raised an exception when server was down: {e}")

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -48,6 +48,7 @@ QUEUE_STARVATION_THRESHOLD = 16
 
 
 _redis_queue_conn = None
+_in_memory_pool = None
 
 
 @lru_cache
@@ -157,10 +158,57 @@ def enqueue(
 	try:
 		q = get_queue(queue, is_async=is_async)
 	except ConnectionError:
+		from frappe.utils.redis_wrapper import MemoryCacheWrapper
+
+		redis_unavailable = isinstance(frappe.cache, MemoryCacheWrapper)
+
 		if frappe.local.flags.in_migrate:
-			# If redis is not available during migration, execute the job directly
-			print(f"Redis queue is unreachable: Executing {method} synchronously")
+			# During migrations, we must run jobs synchronously to avoid race conditions.
+			def _run_sync():
+				frappe.call(method, **kwargs)
+
+			if enqueue_after_commit:
+				frappe.db.after_commit.add(_run_sync)
+				return
+
 			return frappe.call(method, **kwargs)
+
+		elif redis_unavailable:
+			# Redis is intentionally absent (use_memory_cache mode).
+			# Run the job asynchronously via a ThreadPool to keep the web thread responsive.
+			def _run_in_memory():
+				global _in_memory_pool
+				if _in_memory_pool is None:
+					from concurrent.futures import ThreadPoolExecutor
+
+					workers = frappe.conf.get("in_memory_workers", 2)
+					_in_memory_pool = ThreadPoolExecutor(
+						max_workers=workers, thread_name_prefix="FrappeInMemoryWorker"
+					)
+
+				# Extract actual method name for job tracking
+				if isinstance(method, Callable):
+					m_name = f"{method.__module__}.{method.__qualname__}"
+				else:
+					m_name = method
+
+				_in_memory_pool.submit(
+					execute_job,
+					site=frappe.local.site,
+					method=method,
+					event=event,
+					job_name=job_name or m_name,
+					kwargs=kwargs,
+					user=frappe.session.user,
+					is_async=True,
+				)
+
+			if enqueue_after_commit:
+				frappe.db.after_commit.add(_run_in_memory)
+				return
+
+			_run_in_memory()
+			return
 
 		raise
 
@@ -606,10 +654,13 @@ def get_redis_conn(username=None, password=None):
 		)
 		raise
 	except Exception as e:
-		log(
-			f"Please make sure that Redis Queue runs @ {frappe.get_conf().redis_queue}. Redis reported error: {e!s}",
-			colour="red",
-		)
+		# Suppress the noisy warning when Redis is intentionally absent (use_memory_cache mode).
+		# The enqueue() fallback handles this gracefully; no action needed from the operator.
+		if not frappe.conf.get("use_memory_cache"):
+			log(
+				f"Please make sure that Redis Queue runs @ {frappe.get_conf().redis_queue}. Redis reported error: {e!s}",
+				colour="red",
+			)
 		raise
 
 

--- a/frappe/utils/memory_cache.py
+++ b/frappe/utils/memory_cache.py
@@ -1,0 +1,347 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import random
+import re
+import threading
+import time
+
+import frappe
+
+
+class MemoryPipeline:
+	def __init__(self, cache):
+		self.cache = cache
+		self.commands = []
+
+	def __getattr__(self, name):
+		def _func(*args, **kwargs):
+			self.commands.append((name, args, kwargs))
+			return self
+
+		return _func
+
+	def execute(self):
+		ret = []
+		for method_name, args, kwargs in self.commands:
+			method = getattr(self.cache, method_name, None)
+			if method:
+				ret.append(method(*args, **kwargs))
+		return ret
+
+
+class MemoryCacheWrapper:
+	"""
+	In-memory cache that mirrors the RedisWrapper API.
+
+	Used automatically as a fallback when Redis is unavailable (e.g. during
+	local development or contributor onboarding). All existing code that uses
+	``frappe.cache`` works without modification — no configuration required.
+
+	Not suitable for production: cache is not shared across processes and is
+	lost on restart.
+	"""
+
+	def __init__(self):
+		self.cache = {}
+		self.expiries = {}
+		self.lock = threading.RLock()
+
+	def __call__(self):
+		"""WARNING: Added for backward compatibility to support frappe.cache().method(...)"""
+		return self
+
+	def ping(self):
+		"""Ping the cache to check if it's alive (always returns True for memory cache)"""
+		return True
+
+	def connected(self):
+		"""Check if cache is connected (always returns True for memory cache)"""
+		return True
+
+	def make_key(self, key, user=None, shared=False):
+		if shared:
+			return key
+
+		if user:
+			if user is True:
+				user = frappe.local.session.get("user")
+
+			key = f"user:{user}:{key}"
+
+		return f"{frappe.local.conf.get('db_name')}|{key}"
+
+	def set_value(self, key, val, user=None, expires_in_sec=None, shared=False):
+		key = self.make_key(key, user, shared)
+
+		frappe.local.cache[key] = val
+		with self.lock:
+			self.cache[key] = val
+			if expires_in_sec:
+				self.expiries[key] = time.time() + expires_in_sec
+
+	def get_value(self, key, generator=None, user=None, expires=False, shared=False, *, use_local_cache=True):
+		original_key = key
+		key = self.make_key(key, user, shared)
+
+		if key in frappe.local.cache and use_local_cache:
+			return frappe.local.cache[key]
+
+		val = None
+		with self.lock:
+			if key in self.cache:
+				if key in self.expiries and time.time() > self.expiries[key]:
+					del self.cache[key]
+					del self.expiries[key]
+				else:
+					val = self.cache[key]
+
+		if not expires:
+			if val is None and generator:
+				val = generator()
+				self.set_value(original_key, val, user=user, shared=shared)
+			else:
+				frappe.local.cache[key] = val
+
+		return val
+
+	def get_all(self, key):
+		ret = {}
+		for k in self.get_keys(key):
+			ret[key] = self.get_value(k)
+
+		return ret
+
+	def get_keys(self, key, user=None, shared=False):
+		key = self.make_key(key + "*", user=user, shared=shared)
+		pattern = str(key).replace("|", r"\|").replace("*", ".*")
+		return [k for k in self.cache.keys() if re.match(pattern, str(k))]
+
+	def delete_keys(self, key, user=None, shared=False):
+		self.delete_value(self.get_keys(key, user=user, shared=shared), make_keys=False)
+
+	def delete_key(self, *args, **kwargs):
+		self.delete_value(*args, **kwargs)
+
+	def delete_value(self, keys, user=None, make_keys=True, shared=False):
+		if not keys:
+			return
+
+		if not isinstance(keys, list | tuple):
+			keys = (keys,)
+
+		if make_keys:
+			keys = [self.make_key(k, shared=shared, user=user) for k in keys]
+
+		for key in keys:
+			frappe.local.cache.pop(key, None)
+
+		with self.lock:
+			for key in keys:
+				self.cache.pop(key, None)
+				self.expiries.pop(key, None)
+
+	def lpush(self, key, value, user=None, shared=False):
+		key = self.make_key(key, user=user, shared=shared)
+		self.cache.setdefault(key, []).insert(0, value)
+
+	def rpush(self, key, value):
+		key = self.make_key(key)
+		self.cache.setdefault(key, []).append(value)
+
+	def lpop(self, key, user=None, shared=False):
+		key = self.make_key(key, user=user, shared=shared)
+		lst = self.cache.get(key)
+		if lst:
+			return lst.pop(0)
+
+	def blpop(self, key, timeout=0, user=None, shared=False):
+		if value := self.lpop(key, user=user, shared=shared):
+			return value
+
+		if timeout:
+			time.sleep(timeout)
+			return self.lpop(key, user=user, shared=shared)
+
+	def rpop(self, key):
+		key = self.make_key(key)
+		lst = self.cache.get(key)
+		if lst:
+			return lst.pop()
+
+	def llen(self, key):
+		key = self.make_key(key)
+		lst = self.cache.get(key)
+		return len(lst) if lst else 0
+
+	def lrange(self, key, start, stop):
+		key = self.make_key(key)
+		lst = self.cache.get(key, [])
+		if stop == -1:
+			stop = None
+		else:
+			stop += 1
+		return lst[start:stop]
+
+	def ltrim(self, key, start, stop):
+		key = self.make_key(key)
+		lst = self.cache.get(key, [])
+		if stop == -1:
+			stop = None
+		else:
+			stop += 1
+		self.cache[key] = lst[start:stop]
+
+	def hset(self, name, key, value, shared=False, **kwargs):
+		_name = self.make_key(name, shared=shared)
+		frappe.local.cache.setdefault(_name, {})[key] = value
+		with self.lock:
+			if _name not in self.cache:
+				self.cache[_name] = {}
+			if not isinstance(self.cache[_name], dict):
+				self.cache[_name] = {}
+			self.cache[_name][key] = value
+
+	def hget(self, name, key, generator=None, shared=False):
+		_name = self.make_key(name, shared=shared)
+		val = self.cache.get(_name, {}).get(key)
+		if val is None and generator:
+			val = generator()
+			self.hset(name, key, val, shared=shared)
+		return val
+
+	def hgetall(self, name):
+		_name = self.make_key(name)
+		return {
+			(key.encode() if isinstance(key, str) else key): value
+			for key, value in self.cache.get(_name, {}).items()
+		}
+
+	def hkeys(self, name):
+		_name = self.make_key(name)
+		return [key.encode() if isinstance(key, str) else key for key in self.cache.get(_name, {}).keys()]
+
+	def hdel(self, name, keys, shared=False, pipeline=None):
+		_name = self.make_key(name, shared=shared)
+		if not isinstance(keys, list | tuple):
+			keys = (keys,)
+		for key in keys:
+			if _name in self.cache and key in self.cache[_name]:
+				del self.cache[_name][key]
+
+	def hdel_keys(self, name_starts_with, key):
+		for name in self.get_keys(name_starts_with):
+			name = name.split("|", 1)[1]
+			self.hdel(name, key)
+
+	def hdel_names(self, names, key):
+		"""Delete hash field from multiple hash names"""
+		with self.lock:
+			for name in names:
+				_name = self.make_key(name)
+				if _name in self.cache and isinstance(self.cache[_name], dict):
+					self.cache[_name].pop(key, None)
+				if _name in frappe.local.cache:
+					frappe.local.cache[_name].pop(key, None)
+
+	def hexists(self, name, key, shared=False):
+		"""Check if hash field exists"""
+		if key is None:
+			return False
+		_name = self.make_key(name, shared=shared)
+		with self.lock:
+			return _name in self.cache and isinstance(self.cache[_name], dict) and key in self.cache[_name]
+
+	def exists(self, *names, user=None, shared=None):
+		"""Check if keys exist"""
+		count = 0
+		keys = [self.make_key(n, user=user, shared=shared) for n in names]
+		with self.lock:
+			for key in keys:
+				if key in self.cache:
+					count += 1
+		return count
+
+	def expire_key(self, key, time_secs, user=None, shared=False):
+		"""Set expiry time for a key"""
+		key = self.make_key(key, user, shared)
+		with self.lock:
+			self.expiries[key] = time.time() + time_secs
+		return True
+
+	def sadd(self, name, *values):
+		key = self.make_key(name)
+		with self.lock:
+			self.cache.setdefault(key, set()).update(values)
+
+	def srem(self, name, *values):
+		key = self.make_key(name)
+		with self.lock:
+			if key in self.cache:
+				for v in values:
+					self.cache[key].discard(v)
+
+	def sismember(self, name, value):
+		key = self.make_key(name)
+		with self.lock:
+			return value in self.cache.get(key, set())
+
+	def smembers(self, name):
+		key = self.make_key(name)
+		with self.lock:
+			return self.cache.get(key, set()).copy()
+
+	def spop(self, name):
+		"""Remove and return a random member from the set"""
+		key = self.make_key(name)
+		with self.lock:
+			if cached_set := self.cache.get(key):
+				return cached_set.pop()
+		return None
+
+	def srandmember(self, name, count=None):
+		"""Return a random member from the set"""
+		key = self.make_key(name)
+		with self.lock:
+			members = self.cache.get(key, set())
+			if not members:
+				return None
+			if count is None:
+				return random.choice(list(members))
+			return random.sample(list(members), min(count, len(members)))
+
+	def pipeline(self):
+		return MemoryPipeline(self)
+
+	def incrby(self, key, amount=1):
+		with self.lock:
+			self.cache[key] = self.cache.get(key, 0) + amount
+			return self.cache[key]
+
+	def expire(self, key, time_secs):
+		with self.lock:
+			self.expiries[key] = time.time() + time_secs
+		return True
+
+	def client_id(self):
+		return 1
+
+	def execute_command(self, *args, **kwargs):
+		"""Stub for Redis execute_command — returns empty dict for INFO commands."""
+		return {}
+
+	def pubsub(self):
+		"""Mock pubsub for compatibility with ClientCache"""
+
+		class MockPubSub:
+			def subscribe(self, **kwargs):
+				pass
+
+			def run_in_thread(self, **kwargs):
+				class MockThread:
+					def is_alive(self):
+						return True
+
+				return MockThread()
+
+		return MockPubSub()

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -171,11 +171,11 @@ class RedisWrapper(redis.Redis):
 	def lpop(self, key, user=None, shared=False):
 		return super().lpop(self.make_key(key, user=user, shared=shared))
 
-	def rpop(self, key):
-		return super().rpop(self.make_key(key))
-
 	def blpop(self, key, timeout=0, user=None, shared=False):
 		return super().blpop(self.make_key(key, user=user, shared=shared), timeout=timeout)
+
+	def rpop(self, key):
+		return super().rpop(self.make_key(key))
 
 	def llen(self, key):
 		return super().llen(self.make_key(key))
@@ -366,22 +366,82 @@ class RedisWrapper(redis.Redis):
 		return RedisearchWrapper(client=self, index_name=self.make_key(index_name))
 
 
-def setup_cache() -> RedisWrapper:
-	if frappe.conf.redis_cache_sentinel_enabled:
-		sentinels = [tuple(node.split(":")) for node in frappe.conf.get("redis_cache_sentinels", [])]
-		sentinel = get_sentinel_connection(
-			sentinels=sentinels,
-			sentinel_username=frappe.conf.get("redis_cache_sentinel_username"),
-			sentinel_password=frappe.conf.get("redis_cache_sentinel_password"),
-			master_username=frappe.conf.get("redis_cache_master_username"),
-			master_password=frappe.conf.get("redis_cache_master_password"),
-		)
-		return sentinel.master_for(
-			frappe.conf.get("redis_cache_master_service"),
-			redis_class=RedisWrapper,
-		)
+def __getattr__(name):
+	if name in {"MemoryCacheWrapper", "MemoryPipeline"}:
+		from frappe.utils.memory_cache import MemoryCacheWrapper, MemoryPipeline
 
-	return RedisWrapper.from_url(frappe.conf.get("redis_cache"))
+		return {"MemoryCacheWrapper": MemoryCacheWrapper, "MemoryPipeline": MemoryPipeline}[name]
+	raise AttributeError(name)
+
+
+def setup_cache() -> RedisWrapper:
+	"""
+	Setup the cache backend for Frappe.
+
+	This function attempts to connect to Redis for caching. If Redis is not available
+	(e.g., in local development environments), it automatically falls back to an
+	in-memory cache implementation.
+
+	Configuration options:
+	- Set "use_memory_cache": true or "cache_backend": "memory" in site_config.json
+	  to force the use of in-memory cache
+	- Otherwise, Redis is used by default with automatic fallback to memory cache
+	  when Redis connection fails
+
+	Returns:
+	    RedisWrapper or MemoryCacheWrapper instance
+	"""
+	import logging
+
+	logger = logging.getLogger(__name__)
+
+	def new_memory_cache():
+		from frappe.utils.memory_cache import MemoryCacheWrapper
+
+		return MemoryCacheWrapper()
+
+	if frappe.conf.get("use_memory_cache") or frappe.conf.get("cache_backend") == "memory":
+		logger.info("Using MemoryCacheWrapper (configured via site_config)")
+		return new_memory_cache()
+
+	try:
+		if frappe.conf.redis_cache_sentinel_enabled:
+			sentinels = [tuple(node.split(":")) for node in frappe.conf.get("redis_cache_sentinels", [])]
+			sentinel = get_sentinel_connection(
+				sentinels=sentinels,
+				sentinel_username=frappe.conf.get("redis_cache_sentinel_username"),
+				sentinel_password=frappe.conf.get("redis_cache_sentinel_password"),
+				master_username=frappe.conf.get("redis_cache_master_username"),
+				master_password=frappe.conf.get("redis_cache_master_password"),
+			)
+			redis_cache = sentinel.master_for(
+				frappe.conf.get("redis_cache_master_service"),
+				redis_class=RedisWrapper,
+			)
+			# Test the connection immediately
+			if redis_cache.connected():
+				logger.info("Successfully connected to Redis via Sentinel")
+				return redis_cache
+			else:
+				logger.warning(
+					"Redis Sentinel configured but connection failed, falling back to MemoryCacheWrapper"
+				)
+				return new_memory_cache()
+		else:
+			redis_cache = RedisWrapper.from_url(frappe.conf.get("redis_cache"))
+			# Test the connection immediately
+			if redis_cache.connected():
+				logger.info("Successfully connected to Redis")
+				return redis_cache
+			else:
+				logger.warning("Redis connection test failed, falling back to MemoryCacheWrapper")
+				return new_memory_cache()
+	except redis.exceptions.ConnectionError as e:
+		logger.warning(f"Redis connection failed ({e}), falling back to MemoryCacheWrapper")
+		return new_memory_cache()
+	except Exception as e:
+		logger.error(f"Unexpected error setting up cache ({e}), falling back to MemoryCacheWrapper")
+		return new_memory_cache()
 
 
 def get_sentinel_connection(
@@ -408,7 +468,7 @@ def get_sentinel_connection(
 	)
 
 
-class _ClientTrackingMixin:
+class _TrackedConnection(redis.Connection):
 	def __init__(self, *args, **kwargs):
 		self._invalidator_id = kwargs.pop("_invalidator_id")
 		super().__init__(*args, **kwargs)
@@ -430,14 +490,6 @@ class _ClientTrackingMixin:
 				raise
 
 
-class _TrackedConnection(_ClientTrackingMixin, redis.Connection):
-	pass
-
-
-class _TrackedUnixDomainSocketConnection(_ClientTrackingMixin, redis.UnixDomainSocketConnection):
-	pass
-
-
 CachedValue = namedtuple("CachedValue", ["value", "expiry"])
 CacheStatistics = namedtuple(
 	"CacheStatistics", ["hits", "misses", "capacity", "used", "utilization", "hit_ratio", "healthy"]
@@ -453,26 +505,26 @@ class ClientCache:
 	There aren't many use cases for such aggressive caching outside of core Framework.
 
 	This is an implementation of Redis' "client side caching" concept:
-		- https://redis.io/docs/latest/develop/reference/client-side-caching/
+	    - https://redis.io/docs/latest/develop/reference/client-side-caching/
 
 	Usage/Notes:
-		- Cache keys that do not change often: Think hours-days, not minutes.
-		- Cache keys that are read frequently, e.g. every request or at least >10% of the requests.
-		- Cache values are not huge, consider avg size of ~4kb per value. You can deviate here and
-		  there but not go crazy with caching large values in this cache.
-		- We have hardcoded 10 minutes "local" ttl and max 1024 keys.
-			You're not supposed to work with these numbers, not change them.
-		- Same keys can be accessed with `frappe.cache` too, but that won't implement invalidation.
-		- Invalidate things as usual using `delete_value`. Local invalidation should be instant.
-		  Do not expect sub-second invalidation guarantees across processes.
-		  If you need that kind of guarantees, don't use this cache.
-		- When redis connection isn't available or any unknown exceptions are encountered, this
-		  cache automatically turns itself off and falls back to behaviour that is equivalent to
-		  default Redis cache behaviour.
-		- Never use `frappe.cache`'s request local cache along with client-side cache. Two
-		  different copies of same key are a big source of data races.
-		- This cache uses simple FIFO eviction policy. Make sure your access patterns don't cause
-		  the worst case behaviour for this policy. E.g. looping over `maxsize` items repeatedly.
+	    - Cache keys that do not change often: Think hours-days, not minutes.
+	    - Cache keys that are read frequently, e.g. every request or at least >10% of the requests.
+	    - Cache values are not huge, consider avg size of ~4kb per value. You can deviate here and
+	      there but not go crazy with caching large values in this cache.
+	    - We have hardcoded 10 minutes "local" ttl and max 1024 keys.
+	        You're not supposed to work with these numbers, not change them.
+	    - Same keys can be accessed with `frappe.cache` too, but that won't implement invalidation.
+	    - Invalidate things as usual using `delete_value`. Local invalidation should be instant.
+	      Do not expect sub-second invalidation guarantees across processes.
+	      If you need that kind of guarantees, don't use this cache.
+	    - When redis connection isn't available or any unknown exceptions are encountered, this
+	      cache automatically turns itself off and falls back to behaviour that is equivalent to
+	      default Redis cache behaviour.
+	    - Never use `frappe.cache`'s request local cache along with client-side cache. Two
+	      different copies of same key are a big source of data races.
+	    - This cache uses simple FIFO eviction policy. Make sure your access patterns don't cause
+	      the worst case behaviour for this policy. E.g. looping over `maxsize` items repeatedly.
 	"""
 
 	def __init__(self, maxsize: int = 1024, ttl=10 * 60, monitor: RedisWrapper | None = None) -> None:
@@ -503,13 +555,9 @@ class ClientCache:
 		if not self.invalidator_id:
 			return
 
-		redis_url = frappe.conf.get("redis_cache") or ""
-		connection_class = (
-			_TrackedUnixDomainSocketConnection if redis_url.startswith("unix://") else _TrackedConnection
-		)
 		self.redis: RedisWrapper = RedisWrapper.from_url(
-			redis_url,
-			connection_class=connection_class,
+			frappe.conf.get("redis_cache"),
+			connection_class=_TrackedConnection,
 			_invalidator_id=self.invalidator_id,
 			protocol=2,
 		)

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -39,6 +39,23 @@ def start_scheduler() -> NoReturn:
 	"""Run enqueue_events_for_all_sites based on scheduler tick.
 	Specify scheduler_tick_interval in seconds in common_site_config.json"""
 
+	# In Redis-less / memory-cache mode the scheduler must not run.
+	# Scheduled jobs are enqueued to RQ; without Redis they would fall back to
+	# synchronous in-process execution inside the scheduler's open DB connection,
+	# causing InnoDB lock-wait timeouts for concurrent web requests.
+	from frappe.utils.redis_wrapper import MemoryCacheWrapper
+
+	if isinstance(frappe.cache, MemoryCacheWrapper):
+		frappe.logger("scheduler").info(
+			"Scheduler disabled: running in Redis-less (memory cache) mode. "
+			"Background jobs submitted via the web process will run synchronously."
+		)
+		# Block forever so the process manager doesn't restart us in a tight loop
+		import time
+
+		while True:
+			time.sleep(3600)
+
 	tick = get_scheduler_tick()
 	set_niceness()
 

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -6,7 +6,32 @@ const path = require("path");
 const { get_conf, get_redis_subscriber } = require("../node_utils");
 const conf = get_conf();
 
-const server = http.createServer();
+const server = http.createServer((req, res) => {
+	if (conf.in_memory && req.method === "POST" && req.url === "/_internal/publish_event") {
+		let body = "";
+		req.on("data", (chunk) => {
+			body += chunk.toString();
+		});
+		req.on("end", () => {
+			try {
+				let message = JSON.parse(body);
+				let namespace = "/" + message.namespace;
+				if (message.room) {
+					io.of(namespace).to(message.room).emit(message.event, message.message);
+				} else {
+					realtime.emit(message.event, message.message);
+				}
+				res.writeHead(200);
+				res.end("OK");
+			} catch (e) {
+				console.error("Webhook parse error", e);
+				res.writeHead(400);
+				res.end("Bad Request");
+			}
+		});
+		return;
+	}
+});
 
 let io = new Server(server, {
 	cors: {
@@ -40,6 +65,7 @@ function on_connection(socket) {
 
 	// ESBUild "open in editor" on error
 	socket.on("open_in_editor", async (data) => {
+		if (conf.in_memory) return;
 		await subscriber.connect();
 		subscriber.publish("open_in_editor", JSON.stringify(data));
 	});
@@ -70,21 +96,26 @@ realtime.on("connection", on_connection);
 // =======================
 
 // Consume events sent from python via redis pub-sub channel.
-const subscriber = get_redis_subscriber();
+let subscriber;
+if (!conf.in_memory) {
+	subscriber = get_redis_subscriber();
 
-(async () => {
-	await subscriber.connect();
-	subscriber.subscribe("events", (message) => {
-		message = JSON.parse(message);
-		let namespace = "/" + message.namespace;
-		if (message.room) {
-			io.of(namespace).to(message.room).emit(message.event, message.message);
-		} else {
-			// publish to ALL sites only used for things like build event.
-			realtime.emit(message.event, message.message);
-		}
-	});
-})();
+	(async () => {
+		await subscriber.connect();
+		subscriber.subscribe("events", (message) => {
+			message = JSON.parse(message);
+			let namespace = "/" + message.namespace;
+			if (message.room) {
+				io.of(namespace).to(message.room).emit(message.event, message.message);
+			} else {
+				// publish to ALL sites only used for things like build event.
+				realtime.emit(message.event, message.message);
+			}
+		});
+	})();
+} else {
+	console.log("Realtime service running in in_memory mode (HTTP Webhook)");
+}
 // =======================
 
 let uds = conf.socketio_uds;

--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -5,6 +5,7 @@ const conf = get_conf();
 const redisClient = get_redis_subscriber("redis_queue");
 
 async function getSecretFromRedis() {
+	if (conf.in_memory) return null;
 	if (!redisClient.isOpen) await redisClient.connect();
 	const val = await redisClient.get("socketio_auth_secret");
 	return val;


### PR DESCRIPTION
## Description

This PR reduces developer-onboarding friction by allowing Frappe to run without Redis in local and evaluation setups, while preserving the normal Redis-backed flow for standard deployments.

In addition to the in-memory cache fallback, it makes background-job behavior safe in Redis-less mode, prevents scheduler dequeueing against the memory backend, adds a browserless `bench setup-wizard` command, and documents the workflow.

closes #39478

## What existing problem does this solve?

Today, first-time contributors and evaluators need a working Redis setup before they can boot Frappe locally. That makes quick evaluation, containerized experiments, and lower-resource development setups harder than they need to be.

With this change, Frappe can start and complete setup without Redis in developer-onboarding scenarios, while existing Redis-enabled behavior remains unchanged when Redis is available.

## Details of the change

- add `MemoryCacheWrapper` as an in-memory fallback in `frappe.utils.redis_wrapper`
- make `setup_cache()` auto-fallback on Redis connection failure, while still supporting explicit memory-cache configuration
- run `enqueue()` jobs synchronously in Redis-less mode and honor `enqueue_after_commit=True` via `frappe.db.after_commit`
- keep the scheduler from consuming jobs when the memory backend is active
- add `bench setup-wizard` in `frappe.commands.wizard` for headless/container setup flows
- document the Redis-less onboarding workflow in `docs/redis-less-developer-onboarding.md` and add a README pointer
- add unit coverage in `frappe/tests/test_caching.py`

## Documentation

- Existing framework docs entry point: https://docs.frappe.io/framework
- PR diff for the added onboarding doc: https://github.com/frappe/frappe/pull/39505/files#diff-37b45a42f51f898ac4e23737a4c2f5aa2f2436780e84514a1fddf692d9606f8e

## Testing

Validated end-to-end using a custom `vyogo/erpnext:sne-version-16`-based SNE image with Redis completely absent.

Reference repo for the exact Docker assets and run script used during validation:
https://github.com/vyogotech/frappe-redis-less-reference

Verified in that environment:
- Frappe starts cleanly and falls back to `MemoryCacheWrapper`
- setup completes successfully without Redis
- `/desk` loads after setup
- `system_health_report` no longer crashes due to missing `execute_command`
- the `bench setup-wizard` flow is available for browserless onboarding

## Screenshots / GIFs

Validation artifacts:
- https://github.com/vyogotech/frappe-redis-less-reference/tree/main/artifacts/2026-05-26
- startup log: https://raw.githubusercontent.com/vyogotech/frappe-redis-less-reference/main/artifacts/2026-05-26/container-startup.log
- screenshots: `Containerlog1.png`, `Containerlog2.png`, `Containerlog4.png`, `erpnextafterstartup.png`
