### PR TITLE
fix(workspace): add check for public ws. too

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -358,9 +358,11 @@ def update_page(name: str, title: str, icon: str, indicator_color: str, parent: 
 	public = frappe.parse_json(public)
 	doc = frappe.get_doc("Workspace", name)
 
-	if not doc.get("public") and doc.get("for_user") != frappe.session.user and not is_workspace_manager():
+	if doc.get("public") and not is_workspace_manager():
+		frappe.throw(_("Need Workspace Manager role to edit public workspaces."))
+	elif not doc.get("public") and doc.get("for_user") != frappe.session.user and not is_workspace_manager():
 		frappe.throw(
-			_("Need Workspace Manager role to edit private workspace of other users"),
+			_("Need Workspace Manager role to edit private workspace of other users."),
 			frappe.PermissionError,
 		)
 


### PR DESCRIPTION
Public workspaces should ideally be editable only by Workspace Managers.

related to closing Ticket #69000
