### PR TITLE
fix(form): Fix hash decoding for scrolling to IDs with accents

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1584,11 +1584,12 @@ frappe.ui.form.Form = class FrappeForm {
 				history.replaceState(null, null, url);
 			}
 		} else if (window.location.hash) {
-			if ($(window.location.hash).length) {
-				frappe.utils.scroll_to(window.location.hash, true, 200, null, null, true);
-			} else {
-				this.scroll_to_field(window.location.hash.replace("#", "")) &&
-					history.replaceState(null, null, " ");
+			const id = decodeURIComponent(window.location.hash.substring(1));
+			const element = id && document.getElementById(id);
+			if (element) {
+				frappe.utils.scroll_to(element, true, 200, null, null, true);
+			} else if (id) {
+				this.scroll_to_field(id) && history.replaceState(null, null, " ");
 			}
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/39517

On behalf of @cogk 

- Create custom field with accents in the fieldname (e.g. create a custom field with the "Détails" label, or even the "日本" label for example). This happens easily because "label" is used to generate the custom field's fieldname.
- Go to any desk URL where the hash contains an accent (e.g. `/desk/user/Administrator#custom_détails`)