### PR TITLE
feat(sidebar): add hover-reveal toggle button

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -67,6 +67,13 @@
 					</a>
 				</div>
 			</div>
+			<button
+				class="collapse-sidebar-link sidebar-toggle-btn"
+				aria-label="{%= __('Toggle Sidebar') %}"
+				data-placement="right"
+			>
+				{%= frappe.utils.icon(expanded ? "chevron-left" : "chevron-right", "sm", "", "", "", true) %}
+			</button>
 			<div class="sidebar-resize-handle"></div>
 		</div>
 		<div class="overlay" style="z-index: 1021;"></div>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -567,18 +567,15 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 
 	expand_sidebar() {
-		let direction;
 		const is_rtl = frappe.utils.is_rtl();
 		if (this.sidebar_expanded) {
 			this.wrapper.addClass("expanded");
-			direction = is_rtl ? "left" : "right";
 			$('[data-toggle="tooltip"]').tooltip("dispose");
 			this.wrapper.find(".avatar-name-email").show();
 			this.wrapper.find(".onboarding-sidebar span").show();
 			this.wrapper.find(".promotional-banner-title").show();
 		} else {
 			this.wrapper.removeClass("expanded");
-			direction = is_rtl ? "right" : "left";
 			$('[data-toggle="tooltip"]').tooltip({
 				boundary: "window",
 				container: "body",
@@ -590,10 +587,17 @@ frappe.ui.Sidebar = class Sidebar {
 		}
 
 		localStorage.setItem("sidebar-expanded", this.sidebar_expanded);
+		const chevron_icon = this.sidebar_expanded
+			? is_rtl
+				? "chevron-right"
+				: "chevron-left"
+			: is_rtl
+			? "chevron-left"
+			: "chevron-right";
 		this.wrapper
 			.find(".body-sidebar .collapse-sidebar-link")
 			.find("use")
-			.attr("href", `#icon-panel-${direction}-open`);
+			.attr("href", `#icon-${chevron_icon}`);
 		this.sidebar_header.toggle_width(this.sidebar_expanded);
 		$(document).trigger("sidebar-expand", {
 			sidebar_expand: this.sidebar_expanded,

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -281,6 +281,41 @@
 	display: none;
 }
 
+.sidebar-toggle-btn {
+	position: absolute;
+	right: -12px;
+	bottom: 80px;
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	border: 1px solid var(--sidebar-border-color);
+	background: var(--surface-menu-bar);
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	padding: 0;
+	opacity: 0;
+	visibility: hidden;
+	transition: opacity 0.15s ease, visibility 0.15s ease;
+	z-index: 1023;
+
+	svg {
+		width: 12px;
+		height: 12px;
+	}
+
+	&:hover {
+		background: var(--sidebar-hover-color);
+	}
+}
+
+.body-sidebar:hover .sidebar-toggle-btn {
+	opacity: 1;
+	visibility: visible;
+}
+
 .sidebar-resize-handle {
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
Adds a circular toggle button on the sidebar that appears only on hover and hides when the mouse leaves.

- Button hidden by default, revealed on `.body-sidebar:hover`
- Uses chevron icons (`‹` / `›`) that update on expand/collapse
- Positioned at the right edge of the sidebar (`right: -12px`)


https://github.com/user-attachments/assets/88811562-2f83-4388-be40-3f34bba88b9a


`no-docs`