### PR TITLE
fix(list-view): retain selection when cancelling `Clear Assignment`

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2330,21 +2330,14 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			return {
 				label: __("Clear Assignment", null, "Button in list view actions menu"),
 				action: () => {
-					frappe.confirm(
-						__("Are you sure you want to clear the assignments?"),
-						() => {
-							this.disable_list_update = true;
-							bulk_operations.clear_assignment(this.get_checked_items(true), () => {
-								this.disable_list_update = false;
-								this.clear_checked_items();
-								this.refresh();
-							});
-						},
-						() => {
+					frappe.confirm(__("Are you sure you want to clear the assignments?"), () => {
+						this.disable_list_update = true;
+						bulk_operations.clear_assignment(this.get_checked_items(true), () => {
+							this.disable_list_update = false;
 							this.clear_checked_items();
 							this.refresh();
-						}
-					);
+						});
+					});
 				},
 				standard: true,
 			};


### PR DESCRIPTION
## Description

The Clear Assignment bulk action passes a `reject_action` to `frappe.confirm` that calls `clear_checked_items()` and `refresh()` when the user clicks No. Clicking No to back out of the action wipes the row selection and reloads the list, forcing the user to re-select everything.

Other bulk actions (Delete, Submit, Cancel) don't pass a `reject_action` and leave the selection intact on dismissal. **Better UX/Consistency** would be to drop the `reject_action` so `Clear Assignment` behaves the same way.

## Before
https://github.com/user-attachments/assets/3f92600a-357a-4468-a38f-ba46b29fd4a5

## After
https://github.com/user-attachments/assets/6ef9a992-2fcd-4c75-b774-e96b64adc6f7
