### PR TITLE
fix: escape HTML in child table formatters and link field descriptions

### DIFF
--- a/cypress/integration/formatters.js
+++ b/cypress/integration/formatters.js
@@ -1,0 +1,130 @@
+const PARENT = "Fmt Parent";
+const CHILD = "Fmt Child";
+
+function newDoc(name) {
+	cy.new_form(PARENT);
+	cy.fill_field("name1", name, "Data");
+	cy.save();
+	cy.location("pathname").should("not.contain", "/new-");
+}
+
+function addRow(fields) {
+	cy.get('.frappe-control[data-fieldname="items"]').as("tbl");
+	cy.get("@tbl").find(".grid-add-row").click();
+	cy.get("@tbl").find('[data-idx="1"] .btn-open-row').click();
+	Object.entries(fields).forEach(([fn, [val, ft]]) =>
+		cy.fill_table_field("items", 1, fn, val, ft)
+	);
+	cy.get("@tbl").find('[data-idx="1"] .form-in-grid .grid-collapse-row').click();
+	cy.save();
+}
+
+function cell(fieldname) {
+	return cy
+		.get('.frappe-control[data-fieldname="items"]')
+		.find(`.grid-row[data-idx="1"] [data-fieldname="${fieldname}"] .static-area`);
+}
+
+context("Formatters - Child Table", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/desk");
+		cy.window()
+			.its("frappe")
+			.then((f) =>
+				f
+					.xcall("frappe.tests.ui_test_helpers.create_child_doctype", {
+						name: CHILD,
+						fields: [
+							{
+								label: "Title",
+								fieldname: "title",
+								fieldtype: "Data",
+								in_list_view: 1,
+							},
+							{
+								label: "Subtitle",
+								fieldname: "subtitle",
+								fieldtype: "Data",
+								in_list_view: 1,
+							},
+							{
+								label: "Description",
+								fieldname: "description",
+								fieldtype: "Small Text",
+								in_list_view: 1,
+							},
+							{
+								label: "Notes",
+								fieldname: "notes",
+								fieldtype: "Small Text",
+								in_list_view: 1,
+							},
+						],
+					})
+					.then(() =>
+						f.xcall("frappe.tests.ui_test_helpers.create_doctype", {
+							name: PARENT,
+							fields: [
+								{ label: "Name", fieldname: "name1", fieldtype: "Data", reqd: 1 },
+								{
+									label: "Items",
+									fieldname: "items",
+									fieldtype: "Table",
+									options: CHILD,
+								},
+							],
+						})
+					)
+			);
+	});
+
+	beforeEach(() => {
+		cy.login();
+		cy.visit("/desk");
+	});
+
+	// <b> is in acceptable_elements so it survives sanitize_html; Data formatter must escape it.
+	it("escapes <b> in Data cell", () => {
+		newDoc("Bold Tag");
+		addRow({ title: ["<b>bold</b>", "Data"] });
+		cell("title").should("have.text", "<b>bold</b>");
+		cell("title").find("b").should("not.exist");
+	});
+
+	// <img> survives sanitize_html; Data formatter must not render an img element.
+	it("escapes <img> in Data cell", () => {
+		newDoc("Img Tag");
+		addRow({ subtitle: ["<img src=x>", "Data"] });
+		cell("subtitle").find("img").should("not.exist");
+		cell("subtitle").should("contain.text", "<img");
+	});
+
+	// <b> survives sanitize_html for Small Text; Text formatter must escape it.
+	it("escapes <b> in Small Text cell", () => {
+		newDoc("SmallText Bold");
+		addRow({ title: ["row1", "Data"], description: ["<b>hello</b>", "Small Text"] });
+		cell("description").should("have.text", "<b>hello</b>");
+		cell("description").find("b").should("not.exist");
+	});
+
+	// Newlines must render as <br> elements, not escaped text.
+	it("renders newlines as <br> in Small Text cell", () => {
+		newDoc("Newlines");
+		addRow({ title: ["row1", "Data"], notes: ["line1{enter}line2", "Small Text"] });
+		cell("notes").find("br").should("exist");
+		cell("notes").should("contain.text", "line1").and("contain.text", "line2");
+	});
+
+	after(() => {
+		cy.go_to_list(PARENT);
+		cy.get("body").then(($body) => {
+			if ($body.find(".list-row-checkbox").length) {
+				cy.get(".list-row-checkbox").each(($el) => cy.wrap($el).click({ force: true }));
+				cy.get(".actions-btn-group > .btn").contains("Actions").click();
+				cy.get('.actions-btn-group > .dropdown-menu [data-label="Delete"]').click();
+				cy.click_modal_primary_button("Yes");
+			}
+		});
+	});
+});

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -31,6 +31,7 @@ class LinkSearchResults(TypedDict):
 	value: str
 	description: str
 	label: NotRequired[str]
+	description_html: NotRequired[bool]
 
 
 # this is called by the Link Field
@@ -354,6 +355,9 @@ def build_for_autosuggest(res: list[tuple], doctype: str) -> list[LinkSearchResu
 	meta = frappe.get_meta(doctype)
 	if meta.show_title_field_in_link:
 		for item in res:
+			if isinstance(item, dict):
+				results.append(item)
+				continue
 			item = list(item)
 			if len(item) == 1:
 				title_field = meta.title_field
@@ -376,6 +380,9 @@ def build_for_autosuggest(res: list[tuple], doctype: str) -> list[LinkSearchResu
 			results.append(autosuggest_row)
 	else:
 		for item in res:
+			if isinstance(item, dict):
+				results.append(item)
+				continue
 			label = _(item[0]) if meta.translated_doctype else item[0]
 			results.append({"value": item[0], "description": to_string(item[1:]), "label": label})
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -256,10 +256,13 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					// because it will not visible otherwise
 					(me.is_title_link() || d.value !== d.description)
 				) {
-					html +=
-						'<br><span class="small">' +
-						__(frappe.utils.html2text(frappe.utils.escape_html(d.description))) +
-						"</span>";
+					// description_html: true signals that the caller deliberately put HTML in
+					// the description (e.g. a custom query that highlights matches). Render it
+					// directly. Otherwise treat it as plain text and escape it.
+					const desc = d.description_html
+						? __(frappe.utils.html2text(frappe.utils.escape_html(d.description)))
+						: __(frappe.utils.escape_html(d.description));
+					html += '<br><span class="small">' + desc + "</span>";
 				}
 				return $(`<div role="option">`)
 					.on("click", (event) => {

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -36,13 +36,14 @@ frappe.form.formatters = {
 	Data: function (value, df) {
 		if (df && df.options == "URL") {
 			if (!value) return "";
-			return `<a href="${value}" title="Open Link" target="_blank">${value}</a>`;
+			let escaped_url = frappe.utils.escape_html(value);
+			return `<a href="${escaped_url}" title="Open Link" target="_blank">${escaped_url}</a>`;
 		}
 		if (df && df.options == "IBAN") {
 			if (!value) return "";
 			return frappe.utils.get_formatted_iban(value);
 		}
-		value = value == null ? "" : value;
+		value = value == null ? "" : frappe.utils.escape_html(value);
 
 		return frappe.form.formatters._apply_custom_formatter(value, df);
 	},
@@ -259,23 +260,18 @@ frappe.form.formatters = {
 		}
 	},
 	Text: function (value, df) {
-		if (value) {
-			var tags = ["<p", "<div", "<br", "<table"];
-			var match = false;
-
-			for (var i = 0; i < tags.length; i++) {
-				if (value.match(tags[i])) {
-					match = true;
-					break;
-				}
-			}
-
-			if (!match) {
-				value = frappe.utils.replace_newlines(value);
-			}
+		if (!value) return "";
+		// Fields with ignore_xss_filter store intentional HTML sanitized by the backend;
+		// render it directly. All other Text/SmallText fields are plain text and must be escaped.
+		if (df && df.ignore_xss_filter) {
+			return frappe.form.formatters._apply_custom_formatter(value, df);
 		}
-
-		return frappe.form.formatters.Data(value, df);
+		// Escape first so <br> tags added by replace_newlines are not double-escaped
+		const escaped = frappe.utils.escape_html(value);
+		return frappe.form.formatters._apply_custom_formatter(
+			frappe.utils.replace_newlines(escaped),
+			df
+		);
 	},
 	Time: function (value) {
 		if (value) {
@@ -302,14 +298,16 @@ frappe.form.formatters = {
 	Tag: function (value) {
 		var html = "";
 		$.each((value || "").split(","), function (i, v) {
-			if (v)
+			if (v) {
+				let ev = frappe.utils.escape_html(v);
 				html += `
 				<span
 					class="data-pill btn-xs align-center ellipsis"
 					style="background-color: var(--control-bg); box-shadow: none; margin-right: 4px;"
-					data-field="_user_tags" data-label="${v}'">
-					${v}
+					data-field="_user_tags" data-label="${ev}">
+					${ev}
 				</span>`;
+			}
 		});
 		return html;
 	},
@@ -319,13 +317,10 @@ frappe.form.formatters = {
 	Assign: function (value) {
 		var html = "";
 		$.each(JSON.parse(value || "[]"), function (i, v) {
-			if (v)
-				html +=
-					'<span class="label label-warning" \
-				style="margin-right: 7px;"\
-				data-field="_assign">' +
-					v +
-					"</span>";
+			if (v) {
+				let ev = frappe.utils.escape_html(v);
+				html += `<span class="label label-warning" style="margin-right: 7px;" data-field="_assign">${ev}</span>`;
+			}
 		});
 		return html;
 	},
@@ -333,8 +328,10 @@ frappe.form.formatters = {
 		return frappe.form.formatters.Text(value);
 	},
 	TextEditor: function (value) {
-		let formatted_value = frappe.form.formatters.Text(value);
-		// to use ql-editor styles
+		if (!value) return "";
+		// value is backend-sanitized HTML; render it directly without chaining
+		// through the Data formatter, which would escape the HTML content
+		let formatted_value = value;
 		try {
 			if (
 				!$(formatted_value).find(".ql-editor").length &&

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
-from frappe.desk.search import get_names_for_mentions, search_link, search_widget
+from frappe.desk.search import build_for_autosuggest, get_names_for_mentions, search_link, search_widget
 from frappe.permissions import add_user_permission
 from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import whitelist_for_tests
@@ -404,10 +404,61 @@ class TestSearch(IntegrationTestCase):
 			link_fieldname="value",
 		)
 
+	def test_build_for_autosuggest_dict_passthrough(self):
+		"""Dicts in custom query results bypass tuple processing in both meta branches."""
+		from unittest.mock import MagicMock, patch
+
+		items = [
+			{"value": "DOC-001", "description": "<strong>Bold</strong>", "description_html": True},
+			{"value": "DOC-002", "description": "plain"},
+		]
+		for show_title_field in (False, True):
+			mock_meta = MagicMock()
+			mock_meta.show_title_field_in_link = show_title_field
+			mock_meta.translated_doctype = False
+			with patch("frappe.get_meta", return_value=mock_meta):
+				results = build_for_autosuggest(items, doctype="DocType")
+			self.assertEqual(len(results), 2)
+			self.assertDictEqual(results[0], items[0])
+			self.assertDictEqual(results[1], items[1])
+
+	def test_search_link_custom_query_dict_passthrough(self):
+		"""search_link preserves description_html flag when a custom query returns dicts."""
+		results = search_link(
+			doctype="User",
+			txt="",
+			query="frappe.tests.test_search.query_returning_html_description",
+			filters=None,
+			page_length=10,
+		)
+		self.assertEqual(len(results), 1)
+		self.assertEqual(results[0]["value"], "test-item")
+		self.assertTrue(results[0].get("description_html"))
+		self.assertEqual(results[0]["description"], "<strong>Bold:</strong> value")
+
 
 @frappe.validate_and_sanitize_search_inputs
 def get_data(doctype, txt, searchfield, start, page_len, filters):
 	return [doctype, txt, searchfield, start, page_len, filters]
+
+
+@whitelist_for_tests()
+def query_returning_html_description(
+	doctype: str,
+	txt: str,
+	searchfield: str,
+	start: int,
+	page_len: int,
+	filters: str | list | dict,
+	**kwargs,
+):
+	return [
+		{
+			"value": "test-item",
+			"description": "<strong>Bold:</strong> value",
+			"description_html": True,
+		}
+	]
 
 
 @whitelist_for_tests()


### PR DESCRIPTION
## Summary

- Escape HTML in Data, Text, Tag, and Assign formatters so raw tags are never rendered in child table grid cells
- Add `description_html: True` opt-in flag to `LinkSearchResults` so custom link queries that intentionally return HTML markup can signal this; all other descriptions are plain-text escaped in the awesomplete dropdown
- Pass dict results from custom queries through `build_for_autosuggest` unchanged, preserving the flag