### PR TITLE
fix: move user actions to sidebar user button dropdown

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -484,12 +484,6 @@ standard_help_items = [
 		"is_standard": 1,
 	},
 	{
-		"item_label": "Keyboard Shortcuts",
-		"item_type": "Action",
-		"action": "frappe.ui.toolbar.show_shortcuts(event)",
-		"is_standard": 1,
-	},
-	{
 		"item_label": "System Health",
 		"item_type": "Route",
 		"route": "/desk/system-health-report",

--- a/frappe/public/js/frappe/ui/menu.js
+++ b/frappe/public/js/frappe/ui/menu.js
@@ -63,10 +63,6 @@ frappe.ui.menu = class ContextMenu {
 			}
 		});
 
-		// if (!$.contains(document.body, this.template[0])) {
-		// 	$(document.body).append(this.template);
-		// }
-
 		// only append if there are items to show
 		if (this.menu_items_to_show.length > 0) {
 			$(document.body).append(this.template);
@@ -84,9 +80,7 @@ frappe.ui.menu = class ContextMenu {
 	add_menu_item(item) {
 		const me = this;
 		item.nested_menus = [];
-		let item_wrapper = $(
-			`<div class="dropdown-menu-item"><div class="dropdown-divider documentation-links"></div></div>`
-		);
+		let item_wrapper;
 		if (item?.is_divider) {
 			item_wrapper = $(
 				`<div class="dropdown-menu-item"><div class="dropdown-divider documentation-links"></div></div>`

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -359,9 +359,24 @@ frappe.ui.Sidebar = class Sidebar {
 	setup_user_menu() {
 		const me = this;
 		const $btn = this.wrapper.find(".sidebar-user-button");
+		const $container = this.wrapper.find(".dropdown-navbar-user");
+
+		const theme_item = {
+			name: "toggle-theme",
+			label: __("Theme"),
+			icon: frappe.ui.get_current_theme() === "dark" ? "sun" : "moon",
+			shortcut: "Shift+Ctrl+G",
+			onClick: function () {
+				new frappe.ui.ThemeSwitcher().show();
+			},
+		};
+
+		$container.on("click", function () {
+			theme_item.icon = frappe.ui.get_current_theme() === "dark" ? "sun" : "moon";
+		});
 
 		frappe.ui.create_menu({
-			parent: $btn,
+			parent: $container,
 			open_on_top: true,
 			menu_items: [
 				{
@@ -373,27 +388,32 @@ frappe.ui.Sidebar = class Sidebar {
 					},
 				},
 				{
-					name: "toggle-theme",
-					label: __("Toggle Theme"),
-					icon: frappe.ui.get_current_theme() === "dark" ? "sun" : "moon",
+					name: "session-defaults",
+					label: __("Session Defaults"),
+					icon: "sliders-horizontal",
+					condition: function () {
+						return frappe.boot.session_defaults.length != 0;
+					},
 					onClick: function () {
-						new frappe.ui.ThemeSwitcher().show();
+						frappe.ui.toolbar.setup_session_defaults();
 					},
 				},
+				{
+					name: "keyboard-shortcuts",
+					label: __("Keyboard Shortcuts"),
+					icon: "keyboard",
+					shortcut: "Shift+/",
+					onClick: function () {
+						frappe.ui.keys.show_keyboard_shortcut_dialog();
+					},
+				},
+				theme_item,
 				{
 					name: "toggle-full-width",
 					label: __("Toggle Full Width"),
 					icon: "maximize",
 					onClick: function () {
 						frappe.ui.toolbar.toggle_full_width();
-					},
-				},
-				{
-					name: "toggle-sidebar",
-					label: __("Toggle Sidebar"),
-					icon: "panel-right-open",
-					onClick: function () {
-						me.toggle_width();
 					},
 				},
 				{ is_divider: true },

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_header.js
@@ -56,15 +56,6 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 		if (frappe.boot.desk_settings.notifications) {
 			this.dropdown_items.push(
 				{
-					label: "Session Defaults",
-					action: "frappe.ui.toolbar.setup_session_defaults()",
-					is_standard: 1,
-					condition: function () {
-						return frappe.boot.session_defaults.length != 0;
-					},
-					icon: "sliders-horizontal",
-				},
-				{
 					label: "Reload",
 					action: "frappe.ui.toolbar.clear_cache()",
 					is_standard: 1,
@@ -191,14 +182,12 @@ frappe.ui.SidebarHeader = class SidebarHeader {
 
 		navbar_settings.help_dropdown.forEach((element) => {
 			if (element.hidden) return;
+			if (element.action?.includes("frappe.ui.toolbar.show_shortcuts")) return;
 			if (element.condition && !frappe.utils.eval(element.condition)) return;
 			let dropdown_children = {
 				name: element.name,
 				label: element.item_label,
 			};
-			if (element.action?.includes("frappe.ui.toolbar.show_shortcuts")) {
-				dropdown_children.shortcut = "Shift+/";
-			}
 			if (element.item_type === "Route") {
 				dropdown_children.url = element.route;
 			}

--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -291,24 +291,12 @@ frappe.ui.toolbar.fetch_session_defaults = function () {
 frappe.ui.toolbar.setup_session_defaults = function () {
 	let perms = frappe.perm.get_perm("Session Default Settings");
 	let fields = [...frappe.boot.session_defaults];
-	//add settings button only if user is a System Manager or has permission on 'Session Default Settings'
-	if (frappe.user_roles.includes("System Manager") || perms[0].read == 1) {
-		fields[fields.length] = {
-			fieldname: "settings",
-			fieldtype: "Button",
-			label: __("Settings"),
-			click: () => {
-				frappe.set_route("Form", "Session Default Settings", "Session Default Settings");
-			},
-		};
-	}
-	frappe.prompt(
+	let d = frappe.prompt(
 		fields,
 		function (values) {
-			//if default is not set for a particular field in prompt
-			fields.forEach(function (d) {
-				if (!values[d.fieldname]) {
-					values[d.fieldname] = "";
+			fields.forEach(function (field) {
+				if (!values[field.fieldname]) {
+					values[field.fieldname] = "";
 				}
 			});
 			frappe.call({
@@ -335,4 +323,10 @@ frappe.ui.toolbar.setup_session_defaults = function () {
 		__("Session Defaults"),
 		__("Save")
 	);
+	if (frappe.user_roles.includes("System Manager") || perms[0].read == 1) {
+		d.add_custom_action(__("Configure"), () => {
+			d.hide();
+			frappe.set_route("Form", "Session Default Settings", "Session Default Settings");
+		});
+	}
 };

--- a/frappe/public/scss/desk/menu.scss
+++ b/frappe/public/scss/desk/menu.scss
@@ -5,9 +5,7 @@
 }
 .frappe-menu {
 	position: absolute;
-	width: max-content;
-	min-width: var(--menu-width);
-	max-width: min(320px, calc(100vw - 16px));
+	width: var(--menu-width);
 	padding: 6px;
 	border-radius: var(--border-radius-lg);
 	background: var(--surface-modal);
@@ -26,10 +24,10 @@
 		height: 28px;
 		padding: 6px 8px 6px 8px;
 		gap: 8px;
-		min-width: var(--menu-width);
 		text-decoration: none;
 		display: flex;
 		align-items: center;
+		overflow: hidden;
 		gap: var(--margin-sm);
 		.menu-item-icon {
 			line-height: 0px;
@@ -41,8 +39,8 @@
 		}
 	}
 	.dropdown-divider {
-		margin-right: calc(var(--margin-xs) + 3px);
-		margin-left: calc(var(--margin-xs) + 3px);
+		margin-right: 0;
+		margin-left: 0;
 	}
 	.menu-item-title {
 		text-overflow: ellipsis;
@@ -50,9 +48,10 @@
 		white-space: nowrap;
 		overflow: hidden;
 		flex: 1;
+		min-width: 0;
 	}
 	.menu-item-shortcut {
-		margin-left: var(--margin-lg);
+		margin-left: var(--margin-xxs);
 		color: var(--ink-gray-4, #999999);
 		font-size: var(--text-sm);
 		font-weight: 420;


### PR DESCRIPTION
Clicking the user button at the bottom of the sidebar now shows Session Defaults and Keyboard Shortcuts options. The theme icon updates dynamically — sun in light mode, moon in dark mode.

<img width="2932" height="1666" alt="image" src="https://github.com/user-attachments/assets/750dba03-beb8-43df-b6e4-490de4b28007" />
<img width="2932" height="1666" alt="image" src="https://github.com/user-attachments/assets/2d751825-1280-4729-8c55-e55f1d9fd7be" />

Closes: #39255 