### PR TITLE
feat: add documentation URL field to reports

### DIFF
--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -11,6 +11,7 @@
   "reference_report",
   "is_standard",
   "module",
+  "documentation_url",
   "column_break_4",
   "report_type",
   "default_letter_head",
@@ -72,6 +73,12 @@
    "fieldtype": "Link",
    "label": "Module",
    "options": "Module Def"
+  },
+  {
+   "fieldname": "documentation_url",
+   "fieldtype": "Data",
+   "label": "Documentation URL",
+   "options": "URL"
   },
   {
    "default": "0",
@@ -222,7 +229,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-23 14:53:54.321496",
+ "modified": "2026-05-27 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Report",

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -153,14 +153,19 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			// so refresh report again
 			this.refresh_report(route_options);
 		} else {
-			// same report
-			// don't do anything to preserve state
-			// like filters and datatable column widths
+			// same report — preserve filters/column widths but refresh
+			// report_doc so menu items (e.g. Documentation link) stay in sync
+			this.get_report_doc().then(() => {
+				this.page.clear_menu();
+				this.menu_items = this.get_menu_items();
+				this.set_menu_items();
+			});
 		}
 	}
 
 	load_report(route_options) {
 		this.page.clear_inner_toolbar();
+		this.page.clear_menu();
 		this.route = frappe.get_route();
 		this.page_name = frappe.get_route_str();
 		this.report_name = this.route[1];
@@ -1934,6 +1939,12 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				label: __("Edit"),
 				action: () => frappe.set_route("Form", "Report", this.report_name),
 				condition: () => frappe.user.is_report_manager(),
+				standard: true,
+			},
+			{
+				label: __("Documentation"),
+				action: () => window.open(this.report_doc.documentation_url),
+				condition: () => !!this.report_doc?.documentation_url,
 				standard: true,
 			},
 			{

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1815,6 +1815,14 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			});
 		}
 
+		if (this.report_doc && this.report_doc.documentation_url) {
+			items.push({
+				label: __("Documentation"),
+				action: () => window.open(this.report_doc.documentation_url),
+				standard: true,
+			});
+		}
+
 		items.push({
 			label: __("Setup Auto Email"),
 			action: () => {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1815,14 +1815,6 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			});
 		}
 
-		if (this.report_doc && this.report_doc.documentation_url) {
-			items.push({
-				label: __("Documentation"),
-				action: () => window.open(this.report_doc.documentation_url),
-				standard: true,
-			});
-		}
-
 		items.push({
 			label: __("Setup Auto Email"),
 			action: () => {


### PR DESCRIPTION
Currently there's no way to link documentation to a report from the report view itself. This adds a "Documentation URL" field on the Report form, when filled, a "Documentation" option shows up in the report's kebab menu that takes you directly to the docs.

Demo:

https://github.com/user-attachments/assets/302b7dae-625f-4881-9cda-19fea7ed2b9a

`no-docs`

