### PR TITLE
fix: only re-export standard sidebars

### DIFF
--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -75,8 +75,9 @@ class WorkspaceSidebar(Document):
 			frappe.throw(_("You need to be Workspace Manager to delete a public workspace."))
 
 	def after_rename(self, old, new, merge):
-		delete_file(self.app, old)
-		self.export_sidebar()
+		if self.standard:
+			delete_file(self.app, old)
+			self.export_sidebar()
 
 	def is_item_allowed(self, name, item_type, allowed_workspaces):
 		if frappe.session.user == "Administrator":


### PR DESCRIPTION
Renaming a non standard workspace sidebar breaks and it is fixed in this PR
