### PR TITLE
feat: scope email templates to a specific DocType

### DIFF
--- a/frappe/email/doctype/email_template/email_template.json
+++ b/frappe/email/doctype/email_template/email_template.json
@@ -9,6 +9,7 @@
  "engine": "InnoDB",
  "field_order": [
   "subject",
+  "reference_doctype",
   "use_html",
   "response_html",
   "response",
@@ -22,6 +23,12 @@
    "in_list_view": 1,
    "label": "Subject",
    "reqd": 1
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "label": "Reference DocType",
+   "options": "DocType"
   },
   {
    "depends_on": "eval:!doc.use_html",
@@ -57,7 +64,7 @@
  ],
  "icon": "fa fa-comment",
  "links": [],
- "modified": "2024-03-23 16:03:24.779791",
+ "modified": "2026-05-27 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Template",

--- a/frappe/email/doctype/email_template/email_template.py
+++ b/frappe/email/doctype/email_template/email_template.py
@@ -20,6 +20,7 @@ class EmailTemplate(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		reference_doctype: DF.Link | None
 		response: DF.TextEditor | None
 		response_html: DF.Code | None
 		subject: DF.Data
@@ -74,3 +75,31 @@ def get_email_template(template_name: str, doc: str | dict[str, Any], sender: st
 
 	email_template = frappe.get_doc("Email Template", template_name)
 	return email_template.get_formatted_email(doc, sender=sender)
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_email_templates(
+	doctype: str,
+	txt: str,
+	searchfield: str,
+	start: int,
+	page_len: int,
+	filters: dict,
+):
+	"""Search for Email Templates scoped to a DocType or with no DocType assigned."""
+	reference_doctype = (filters or {}).get("reference_doctype", "")
+
+	return frappe.get_all(
+		"Email Template",
+		filters={"name": ("like", f"%{txt}%")},
+		or_filters=[
+			["reference_doctype", "=", reference_doctype],
+			["reference_doctype", "is", "not set"],
+			["reference_doctype", "=", ""],
+		],
+		fields=["name", "reference_doctype"],
+		limit_start=start,
+		limit_page_length=page_len,
+		as_list=True,
+	)

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -102,6 +102,14 @@ frappe.views.CommunicationComposer = class {
 				fieldtype: "Link",
 				options: "Email Template",
 				fieldname: "email_template",
+				get_query: function () {
+					if (me.frm?.doctype) {
+						return {
+							query: "frappe.email.doctype.email_template.email_template.get_email_templates",
+							filters: { reference_doctype: me.frm.doctype },
+						};
+					}
+				},
 				onchange: async function () {
 					const email_template = this.value;
 					if (!email_template) {


### PR DESCRIPTION
Before this, when you opened the email dialog on any document, the Email Template dropdown showed every template in the system — even ones written for completely different documents with different Jinja variables.

Now you can pin a template to a specific DocType using the new Reference DocType field on the Email Template form. Once set, that template only shows up when emailing from that DocType. Templates without a Reference DocType still show everywhere, so nothing breaks for existing setups.

Demo:

https://github.com/user-attachments/assets/1d62b4a3-a779-47a6-a4b0-d3e4970f46c4

Steps:
Create three email templates:

Template A - leave Reference DocType empty
Template B - set Reference DocType to ToDo
Template C - set Reference DocType to Note
Open a ToDo document → click Email → expand More Options → click the Email Template field

Template A and Template B appear
Template C does not appear
Open a Note document → repeat

Template A and Template C appear
Template B does not appear

Closes: #39228 

`no-docs`