### PR TITLE
fix(rounding): improve Banker's rounding implementation for negative numbers

### DIFF
--- a/cypress/integration/rounding.js
+++ b/cypress/integration/rounding.js
@@ -99,6 +99,17 @@ context("Rounding behaviour", () => {
 				expect(flt(-1.15, 1, null, rounding_method)).eq(-1.2);
 				expect(flt(-2.25, 1, null, rounding_method)).eq(-2.2);
 				expect(flt(-3.35, 1, null, rounding_method)).eq(-3.4);
+
+				// Sign-symmetry regression
+				for (const [value, expected] of [
+					[647.325, 647.32],
+					[647.315, 647.32],
+					[0.125, 0.12],
+					[0.135, 0.14],
+				]) {
+					expect(flt(value, 2, null, rounding_method)).eq(expected);
+					expect(flt(-value, 2, null, rounding_method)).eq(-expected);
+				}
 			});
 	});
 });

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -1518,6 +1518,16 @@ class TestRounding(IntegrationTestCase):
 		self.assertEqual(flt(-2.25, 1, rounding_method=rounding_method), -2.2)
 		self.assertEqual(flt(-3.35, 1, rounding_method=rounding_method), -3.4)
 
+		# Sign-symmetry regression.
+		for value, expected in [
+			(647.325, 647.32),
+			(647.315, 647.32),
+			(0.125, 0.12),
+			(0.135, 0.14),
+		]:
+			self.assertEqual(flt(value, 2, rounding_method=rounding_method), expected)
+			self.assertEqual(flt(-value, 2, rounding_method=rounding_method), -expected)
+
 	@IntegrationTestCase.change_settings("System Settings", {"rounding_method": "Banker's Rounding"})
 	@given(
 		st.decimals(min_value=-1e8, max_value=1e8),

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1303,22 +1303,26 @@ def _round_away_from_zero(num, precision):
 
 
 def _bankers_rounding(num, precision):
+	if num == 0:
+		return 0.0
+
+	sign = -1 if num < 0 else 1
 	multiplier = 10**precision
-	num = round(num * multiplier, 12)
+	num = round(abs(num) * multiplier, 12)
 
 	if num == 0:
 		return 0.0
 
-	floor_num = math.floor(num) if num > 0 else math.ceil(num)
+	floor_num = math.floor(num)
 	decimal_part = num - floor_num
 
-	epsilon = 2.0 ** (math.log(abs(num), 2) - 52.0)
+	epsilon = 2.0 ** (math.log(num, 2) - 52.0)
 	if abs(decimal_part - 0.5) < epsilon:
-		num = floor_num if (floor_num % 2 == 0) else floor_num + 1 if num > 0 else floor_num - 1
+		num = floor_num if (floor_num % 2 == 0) else floor_num + 1
 	else:
 		num = round(num)
 
-	return num / multiplier
+	return sign * num / multiplier
 
 
 def remainder(numerator: NumericType, denominator: NumericType, precision: int = 2) -> NumericType:


### PR DESCRIPTION
Issue: PR #36242 patched the odd-floor branch but left the tie-detection test `abs(decimal_part - 0.5) < epsilon` sign-blind, so negative values failed the tie check at typical magnitudes and fell through to round() — yielding -647.33 for input -647.325 while +647.325 correctly rounded to 647.32.

Note: Frontend is already correct.


Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/69141?view=VIEW-HD+Ticket-771