### PR TITLE
fix(ux): prevent browser search bar from opening on `ctrl+k` in form view

### DIFF
--- a/frappe/public/js/frappe/form/info_card.js
+++ b/frappe/public/js/frappe/form/info_card.js
@@ -58,7 +58,8 @@ export class InfoCard {
 				me.card.toggle();
 			});
 		$(document).on("click", function (e) {
-			if (!e.originalEvent.composedPath().includes(me.label_area)) {
+			const path = e.originalEvent?.composedPath();
+			if (!path || !path.includes(me.label_area)) {
 				me.card.hide();
 			}
 		});


### PR DESCRIPTION
Resolve: #39392

---

**Debugging Result:**
There is an error related to `info_card.setup_click()` |

```js
assets.js:94 localStorage cleared
assets.js:55 Cleared App Cache.
assets.js:94 localStorage cleared
info_card.js:61 Uncaught TypeError: Cannot read properties of undefined (reading 'composedPath')
    at HTMLDocument.<anonymous> (info_card.js:61:25)
    at HTMLDocument.dispatch (jquery.js:5135:27)
    at elemData.handle (jquery.js:4939:28)
    at Object.trigger (jquery.js:8619:12)
    at HTMLDivElement.<anonymous> (jquery.js:8697:17)
    at jQuery2.each (jquery.js:383:19)
    at jQuery2.fn.init.each (jquery.js:205:17)
    at jQuery2.fn.init.trigger (jquery.js:8696:15)
    at jQuery2.fn.<computed> [as click] (jquery.js:10567:10)
    at frappe.search.open_awesomebar_from_global_search_shortcut (search_utils.js:746:28)
```
**Before Fix**

https://github.com/user-attachments/assets/1fd7b284-d95e-44e6-a884-3861c11d29a8

---

**After Fix**

https://github.com/user-attachments/assets/44549042-4e9b-45ef-a7b3-8b642d28be8e

