### PR TITLE
fix: Remove background on read only cell in grid

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -343,6 +343,18 @@
 			background-color: var(--error-bg);
 		}
 
+		.col:last-child {
+			.field-area {
+				flex: 1;
+				min-width: 0;
+			}
+
+			.field-area .form-control:disabled {
+				background-color: transparent;
+				width: auto;
+			}
+		}
+
 		input[data-fieldtype="Int"],
 		input[data-fieldtype="Float"],
 		input[data-fieldtype="Currency"] {


### PR DESCRIPTION
Currently, in the grid where the column is ready only, it shows a light background colour like this: 

<img width="838" height="559" alt="Screenshot 2026-05-28 at 4 56 42 PM" src="https://github.com/user-attachments/assets/bdba5892-1826-47e1-b044-c5db6e04a394" />

After fix: 

<img width="892" height="568" alt="image" src="https://github.com/user-attachments/assets/dde36480-708b-4ecc-a38d-e34dd51e3b2d" />

