### PR TITLE
fix: grid selection toast text invisible in dark mode and extra top margin

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -781,14 +781,14 @@
 	width: fit-content;
 	margin-left: auto;
 	margin-right: auto;
-	margin-top: calc(var(--padding-xl) * -1);
+	margin-top: calc(var(--padding-md) * -1);
 	z-index: 2;
 	display: none;
 
 	&__message {
 		display: inline-block;
 		background-color: rgba(0, 0, 0, 0.8);
-		color: var(--bg-color);
+		color: var(--gray-50);
 		border-radius: var(--border-radius-sm);
 		padding: var(--padding-xs) var(--padding-md);
 	}


### PR DESCRIPTION
Resolve:  #39570

---

**Before**

<img width="1397" height="183" alt="image" src="https://github.com/user-attachments/assets/cd13bd7c-f9a9-4def-bea1-15011567552b" />


**After**

<img width="1399" height="195" alt="image" src="https://github.com/user-attachments/assets/9b984611-7981-4ca8-8707-2fe950fc4f14" />
