### PR TITLE
fix(prepared_report): commit prepared report before enqueueing csv conversion

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -140,10 +140,20 @@ def generate_report(prepared_report):
 
 		create_json_gz_file(result, instance.doctype, instance.name, instance.report_name)
 
-		if report.generate_csv:
-			enqueue_json_to_csv_conversion(prepared_report)
+		peak_mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+		report_end = frappe.utils.now()
+		instance.db_set(
+			{
+				"status": "Completed",
+				"report_end_time": report_end,
+				"peak_memory_usage": peak_mem,
+			},
+			update_modified=False,
+			commit=True,
+		)
 
-		instance.status = "Completed"
+		if report.get("generate_csv"):
+			enqueue_json_to_csv_conversion(prepared_report)
 
 		frappe.get_doc(
 			{
@@ -161,12 +171,7 @@ def generate_report(prepared_report):
 		_save_error(instance, error=frappe.get_traceback(with_context=True))
 		return
 
-	instance.reload()
-	instance.status = "Completed"
-	instance.report_end_time = frappe.utils.now()
-	instance.peak_memory_usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-	add_data_to_monitor(peak_memory_usage=instance.peak_memory_usage)
-	instance.save(ignore_permissions=True)
+	add_data_to_monitor(peak_memory_usage=peak_mem)
 
 	frappe.publish_realtime(
 		"report_generated",

--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -187,6 +187,7 @@ class TestRQJob(IntegrationTestCase):
 		self.assertLessEqual(rss, LAST_MEASURED_USAGE * 1.05, msg)
 
 	def test_clear_failed_jobs(self):
+		remove_failed_jobs()  # sanitize prior to test
 		limit = 10
 		update_site_config("rq_failed_jobs_limit", limit)
 


### PR DESCRIPTION
This PR fixes an issue in Postgres wherein prepared report was timing out (this was because the status was not committed) so we commit prepared report before enqueueing csv conversion.