### PR TITLE
fix: update mandatory dependency for aggregate function field in Number Card

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -59,7 +59,7 @@
    "fieldname": "aggregate_function_based_on",
    "fieldtype": "Select",
    "label": "Aggregate Function Based On",
-   "mandatory_depends_on": "eval: doc.function !== 'Count'"
+   "mandatory_depends_on": "eval: doc.type === 'Document Type' && doc.function !== 'Count'"
   },
   {
    "fieldname": "filters_json",
@@ -229,7 +229,7 @@
   }
  ],
  "links": [],
- "modified": "2026-05-29 02:13:20.933689",
+ "modified": "2026-05-29 19:20:37.543999",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",


### PR DESCRIPTION
Follow up for https://github.com/frappe/frappe/pull/39583

---
**Before:**

https://github.com/user-attachments/assets/1d871845-7109-4bac-90c0-934fae45394f


**After:**

https://github.com/user-attachments/assets/21325b81-a545-4f92-9748-155a03ebcdfd

