### PR TITLE
chore: mark as out of beta

### DIFF
--- a/frappe/core/doctype/data_import/data_import.json
+++ b/frappe/core/doctype/data_import/data_import.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "autoname": "format:{reference_doctype} Import on {creation}",
- "beta": 1,
  "creation": "2019-08-04 14:16:08.318714",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -195,11 +195,11 @@
  ],
  "hide_toolbar": 1,
  "links": [],
- "modified": "2025-01-14 17:36:22.389195",
+ "modified": "2026-05-30 23:17:40.195392",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Data Import",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -215,6 +215,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/core/doctype/permission_inspector/permission_inspector.json
+++ b/frappe/core/doctype/permission_inspector/permission_inspector.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_rename": 1,
- "beta": 1,
  "creation": "2024-01-03 17:43:27.257317",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -72,7 +72,7 @@
  "is_virtual": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-23 16:03:34.140177",
+ "modified": "2026-05-30 23:16:00.919759",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Permission Inspector",
@@ -84,6 +84,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/frappe/desk/doctype/workspace/workspace.json
+++ b/frappe/desk/doctype/workspace/workspace.json
@@ -1,8 +1,8 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_rename": 1,
  "autoname": "field:label",
- "beta": 1,
  "creation": "2020-01-23 13:45:59.470592",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -262,7 +262,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2024-09-26 15:47:24.710881",
+ "modified": "2026-05-30 23:29:46.848382",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace",
@@ -294,6 +294,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/integrations/doctype/connected_app/connected_app.json
+++ b/frappe/integrations/doctype/connected_app/connected_app.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "beta": 1,
+ "allow_bulk_edit": 1,
  "creation": "2019-01-24 15:51:06.362222",
  "doctype": "DocType",
  "document_type": "Document",
@@ -139,7 +139,7 @@
    "link_fieldname": "connected_app"
   }
  ],
- "modified": "2024-07-05 08:24:50.182706",
+ "modified": "2026-05-30 23:25:41.508707",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Connected App",
@@ -162,6 +162,7 @@
    "role": "All"
   }
  ],
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
+++ b/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_rename": 1,
- "beta": 1,
  "creation": "2024-01-04 11:36:08.013039",
  "description": "Enabling this will register your site on a central relay server to send push notifications for all installed apps through Firebase Cloud Messaging. This server only stores user tokens and error logs, and no messages are saved.",
  "doctype": "DocType",
@@ -46,7 +46,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-23 16:03:35.768559",
+ "modified": "2026-05-30 23:05:07.179037",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Push Notification Settings",
@@ -63,6 +63,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/frappe/integrations/doctype/token_cache/token_cache.json
+++ b/frappe/integrations/doctype/token_cache/token_cache.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "autoname": "format:{connected_app}-{user}",
- "beta": 1,
  "creation": "2019-01-24 16:56:55.631096",
  "doctype": "DocType",
  "document_type": "System",
@@ -86,11 +86,11 @@
   }
  ],
  "links": [],
- "modified": "2024-03-23 16:03:58.980060",
+ "modified": "2026-05-30 23:26:46.860235",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Token Cache",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -105,6 +105,7 @@
    "role": "All"
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
Remove the `beta` mark from DocTypes that have been in use for a long time.
