### PR TITLE
chore: mark as out of beta (backport #39619)

### DIFF
--- a/frappe/core/doctype/data_import/data_import.json
+++ b/frappe/core/doctype/data_import/data_import.json
@@ -1,7 +1,6 @@
 {
  "actions": [],
  "autoname": "format:{reference_doctype} Import on {creation}",
- "beta": 1,
  "creation": "2019-08-04 14:16:08.318714",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -171,11 +170,11 @@
  ],
  "hide_toolbar": 1,
  "links": [],
- "modified": "2024-01-30 17:08:05.566686",
+ "modified": "2026-05-30 20:50:17.543006",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Data Import",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -191,6 +190,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/desk/doctype/workspace/workspace.json
+++ b/frappe/desk/doctype/workspace/workspace.json
@@ -2,7 +2,6 @@
  "actions": [],
  "allow_rename": 1,
  "autoname": "field:label",
- "beta": 1,
  "creation": "2020-01-23 13:45:59.470592",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -219,7 +218,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2024-05-30 17:30:36.791171",
+ "modified": "2026-05-30 20:50:29.564384",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace",
@@ -251,6 +250,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/integrations/doctype/connected_app/connected_app.json
+++ b/frappe/integrations/doctype/connected_app/connected_app.json
@@ -1,6 +1,5 @@
 {
  "actions": [],
- "beta": 1,
  "creation": "2019-01-24 15:51:06.362222",
  "doctype": "DocType",
  "document_type": "Document",
@@ -133,13 +132,14 @@
    "options": "Query Parameters"
   }
  ],
+ "grid_page_length": 50,
  "links": [
   {
    "link_doctype": "Token Cache",
    "link_fieldname": "connected_app"
   }
  ],
- "modified": "2022-01-07 05:28:45.073041",
+ "modified": "2026-05-30 20:53:27.952198",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Connected App",
@@ -162,8 +162,11 @@
    "role": "All"
   }
  ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "provider_name",
  "track_changes": 1
 }

--- a/frappe/integrations/doctype/token_cache/token_cache.json
+++ b/frappe/integrations/doctype/token_cache/token_cache.json
@@ -1,7 +1,6 @@
 {
  "actions": [],
  "autoname": "format:{connected_app}-{user}",
- "beta": 1,
  "creation": "2019-01-24 16:56:55.631096",
  "doctype": "DocType",
  "document_type": "System",
@@ -86,11 +85,11 @@
   }
  ],
  "links": [],
- "modified": "2023-01-01 21:01:24.405729",
+ "modified": "2026-05-30 20:50:11.544011",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Token Cache",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -105,6 +104,7 @@
    "role": "All"
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
Remove `is_beta` mark from DocTypes that have been in use for a long time.
