### PR TITLE
refactor: add focus event to open multi-select list with `tab`

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -53,6 +53,13 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 			$(this).dropdown("show");
 		});
 		this.$list_wrapper.on(
+			"mousedown",
+			".selectable-item, .select-all-options, .clear-selections",
+			(e) => {
+				e.preventDefault();
+			}
+		);
+		this.$list_wrapper.on(
 			"input",
 			"input",
 			frappe.utils.debounce((e) => {

--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -49,7 +49,8 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 			let $target = $(e.currentTarget);
 			this.toggle_select_item($target);
 		});
-		// Prevent focus triggered by a mouse click from reopening the dropdown.
+
+		// open dropdown on tab focus
 		const $toggle = this.$list_wrapper.find('[data-toggle="dropdown"]');
 		let focus_triggered_by_mouse = false;
 		$toggle.on("mousedown", () => {
@@ -62,6 +63,8 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 			}
 			$toggle.dropdown("show");
 		});
+
+		// prevent input text focus loss when clicking items or buttons
 		this.$list_wrapper.on(
 			"mousedown",
 			".selectable-item, .select-all-options, .clear-selections",
@@ -69,6 +72,7 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 				e.preventDefault();
 			}
 		);
+
 		this.$list_wrapper.on(
 			"input",
 			"input",

--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -49,8 +49,18 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 			let $target = $(e.currentTarget);
 			this.toggle_select_item($target);
 		});
-		this.$list_wrapper.find('[data-toggle="dropdown"]').on("focus", function () {
-			$(this).dropdown("show");
+		// Prevent focus triggered by a mouse click from reopening the dropdown.
+		const $toggle = this.$list_wrapper.find('[data-toggle="dropdown"]');
+		let focus_triggered_by_mouse = false;
+		$toggle.on("mousedown", () => {
+			focus_triggered_by_mouse = true;
+		});
+		$toggle.on("focus", () => {
+			if (focus_triggered_by_mouse) {
+				focus_triggered_by_mouse = false;
+				return;
+			}
+			$toggle.dropdown("show");
 		});
 		this.$list_wrapper.on(
 			"mousedown",

--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -49,6 +49,9 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 			let $target = $(e.currentTarget);
 			this.toggle_select_item($target);
 		});
+		this.$list_wrapper.find('[data-toggle="dropdown"]').on("focus", function () {
+			$(this).dropdown("show");
+		});
 		this.$list_wrapper.on(
 			"input",
 			"input",


### PR DESCRIPTION
## Issue 1 — Tab key does not open MultiSelectList dropdown

### Problem
Tabbing to a `MultiSelectList` field focuses it but does not open the dropdown. The user has to press <kbd>down ↓</kbd> or click to open it. Other fields like Link open immediately on focus.

### Fix
Added a `focus` handler on the toggle element that opens the dropdown when focus arrives via keyboard. A `mousedown` flag prevents it from interfering with normal mouse clicks.

### Before

https://github.com/user-attachments/assets/ccfeff2f-9397-4690-99b3-071e51a90f34



### After

https://github.com/user-attachments/assets/ba251eb8-d857-4933-b904-b5670c7022fd

## Issue 2 — Typing stops working after clicking an item in MultiSelectList

### Problem
After clicking a selectable item, the Select All, or the Clear All button, the search input loses focus. Any typing after that is lost until the user manually clicks back into the search box.

### Fix
Added `mousedown` with `preventDefault` on those elements. This stops the browser from shifting focus away from the search input when clicked, so typing continues to work immediately after any interaction.

### Before

https://github.com/user-attachments/assets/e1a9afed-1c30-4780-9975-de3c946070f7


### After

https://github.com/user-attachments/assets/b04dba16-3ba2-4356-8058-325044f95213

> [!NOTE]
> Backport to V-16