### PR TITLE
fix(perm): ensure rights_without_if_owner is always present in get_perm result

### DIFF
--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -80,7 +80,7 @@ $.extend(frappe.perm, {
 			return admin_perm;
 		}
 
-		let perm = [{ read: 0, permlevel: 0 }];
+		let perm = [{ read: 0, permlevel: 0, rights_without_if_owner: new Set() }];
 
 		if (!meta) {
 			if (frappe.boot.user.can_read.includes(doctype)) {
@@ -147,15 +147,12 @@ $.extend(frappe.perm, {
 		}
 		*/
 
-		let perm = [{ read: 0, permlevel: 0 }];
+		let perm = [{ read: 0, permlevel: 0, rights_without_if_owner: new Set() }];
 
 		(meta.permissions || []).forEach((p) => {
 			const permlevel = cint(p.permlevel);
 			const current_perm = (perm[permlevel] ??= { permlevel });
 
-			if (permlevel === 0) {
-				current_perm.rights_without_if_owner ??= new Set();
-			}
 
 			// if user has this role
 			if (frappe.user_roles.includes(p.role)) {

--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -153,7 +153,6 @@ $.extend(frappe.perm, {
 			const permlevel = cint(p.permlevel);
 			const current_perm = (perm[permlevel] ??= { permlevel });
 
-
 			// if user has this role
 			if (frappe.user_roles.includes(p.role)) {
 				frappe.perm.rights.forEach((right) => {


### PR DESCRIPTION
Resolves issue #39129 

### Problem 
`rights_without_if_owner` was initialized conditionally inside the `forEach` loop only when `permlevel === 0` (see `get_role_permission` in `perm.js`) . If the loop never ran (no permissions with permlevel 0), the property would be `undefined` on `perm[0]`, causing downstream code that reads it to silently fail or throw.

### Solution 
Initialize `rights_without_if_owner: new Set()` for permlevel = 0 before the forEach loop. 
