### PR TITLE
chore: bump up datatable to 1.20.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fast-deep-equal": "^2.0.1",
     "fast-glob": "^3.2.5",
     "frappe-charts": "2.0.0-rc27",
-    "frappe-datatable": "1.20.3",
+    "frappe-datatable": "1.20.4",
     "frappe-gantt": "^1.2.1",
     "frappe-quill-image-resize": "^3.0.9",
     "highlight.js": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1463,10 +1463,10 @@ frappe-charts@2.0.0-rc27:
   resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-2.0.0-rc27.tgz#a04737d36bcce5381b25ad48896c43b02eb62852"
   integrity sha512-J4WCrHYB6oR4Dfu28aaCxlUu64C/V+qJlNE1E0xpya2/yCeqDZ8LA6pS63SBMOdV2CTP8cJ6Isk5m+rZi9gElA==
 
-frappe-datatable@1.20.3:
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.20.3.tgz#d86d1cac56298fee805efe6cc14dd6df9299ef3b"
-  integrity sha512-IApAJ0AObOO48vXA2+QhFkSrrXPbVFGEZlmztJz9pDp6KfR/DpZSiHbbfdV1xbUiweYwcbteGpINSLuSVfYHoA==
+frappe-datatable@1.20.4:
+  version "1.20.4"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.20.4.tgz#d7112e9bd89e34585de5236d60ce520931a404c5"
+  integrity sha512-ocGHCAAWkWhFMvj+L9+GX7394dhG5pxWBtDH9fkmdvOWwbIVdruyZH7GL+UdR9HiIbheE4z/3McWU42OH7dJUw==
   dependencies:
     hyperlist "^1.0.0-beta"
     lodash "^4.17.5"


### PR DESCRIPTION
This PR bumps up Datatable to use the latest version 1.20.4 (resizable serial no. columns).