### PR TITLE
fix(report): adjust position and z-index for page form

### DIFF
--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -5,6 +5,9 @@
 	}
 
 	.page-form {
+		position: relative;
+		z-index: 5;
+
 		.form-group {
 			padding: 0px 16px 0px 0px;
 			margin: var(--margin-sm) 0px;


### PR DESCRIPTION
- closes: https://github.com/frappe/frappe/issues/39663#event-26176035209

### Issue

- When `collapsible_filters` is enabled, opening a Link filter's autocomplete dropdown would get visually occluded by the datatable's sticky header.

### Root Cause

- The awesomplete dropdown and datatable sticky cells both have `z-index: 4`. With no stacking context on `.page-form`.

<img width="344" height="102" alt="image" src="https://github.com/user-attachments/assets/d393c894-f32d-41d2-a4bd-dc22696b34dd" />

### Fix

https://github.com/user-attachments/assets/f92269d6-48d9-42ad-ba42-e0dc0a00b766


> [!NOTE]
> Backport to V-16