### PR TITLE
fix: disable tab selection in awesomplete settings

### DIFF
--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -40,7 +40,7 @@ frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui
 	get_awesomplete_settings() {
 		var me = this;
 		return {
-			tabSelect: true,
+			tabSelect: false,
 			minChars: 0,
 			maxItems: this.df.max_items || 99,
 			autoFirst: true,


### PR DESCRIPTION
- closes: https://github.com/frappe/frappe/issues/39648

## Fixes

https://github.com/user-attachments/assets/b802c8f6-3824-4cb7-b017-2033ed6da3a4


> [!NOTE]
> Backport to V-16