### PR TITLE
fix(print-format-builder): fix crash when opening new print formats

### DIFF
--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -1,6 +1,6 @@
 <template>
 	<div v-if="shouldRender" class="builder-root">
-		<PrintFormatControls />
+		<PrintFormatControls v-if="!show_preview" />
 		<div class="canvas-area">
 			<!-- Sidebar-open hint -->
 			<div v-if="sidebar_open && !hint_dismissed" class="pfb-sidebar-hint">
@@ -263,7 +263,7 @@ onUnmounted(() => {
 	sidebar_observer_ref?.disconnect();
 });
 
-defineExpose({ toggle_preview, $store });
+defineExpose({ toggle_preview, show_preview, $store });
 </script>
 
 <style scoped>

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -1,5 +1,9 @@
 <template>
-	<div v-if="shouldRender" class="builder-root">
+	<div
+		v-if="shouldRender"
+		class="builder-root"
+		:class="{ 'builder-root--preview': show_preview }"
+	>
 		<PrintFormatControls v-if="!show_preview" />
 		<div class="canvas-area">
 			<!-- Sidebar-open hint -->
@@ -13,8 +17,8 @@
 				</button>
 			</div>
 
-			<!-- Canvas toolbar: sample data picker -->
-			<div class="canvas-toolbar">
+			<!-- Canvas toolbar: sample data picker (hidden in preview mode) -->
+			<div v-if="!show_preview" class="canvas-toolbar">
 				<div class="canvas-toolbar-left">
 					<span class="canvas-toolbar-eyebrow">{{ __("PREVIEW DATA") }}</span>
 				</div>
@@ -278,6 +282,10 @@ defineExpose({ toggle_preview, show_preview, $store });
 	display: flex;
 	flex-direction: column;
 	height: calc(100vh - 95px);
+}
+
+.builder-root--preview .canvas-area {
+	padding-left: 1.5rem;
 }
 
 /* ── Sidebar hint ────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -286,6 +286,7 @@ defineExpose({ toggle_preview, show_preview, $store });
 
 .builder-root--preview .canvas-area {
 	padding-left: 1.5rem;
+	padding-right: 1.5rem;
 }
 
 /* ── Sidebar hint ────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -28,7 +28,7 @@ export function getStore(print_format_name) {
 				frappe.model.with_doctype(_print_format.doc_type, () => {
 					meta.value = frappe.get_meta(_print_format.doc_type);
 					print_format.value = _print_format;
-					layout.value = get_layout();
+					layout.value = get_layout() || get_default_layout();
 					// Migrate legacy string header/footer to section objects
 					layout.value.header = migrate_to_section(layout.value.header);
 					layout.value.footer = migrate_to_section(layout.value.footer);
@@ -186,9 +186,13 @@ export function getStore(print_format_name) {
 		});
 	}
 	function get_layout() {
-		if (print_format.value) {
+		if (print_format.value && print_format.value.format_data) {
 			if (typeof print_format.value.format_data == "string") {
-				return JSON.parse(print_format.value.format_data);
+				try {
+					return JSON.parse(print_format.value.format_data);
+				} catch {
+					return null;
+				}
 			}
 			return print_format.value.format_data;
 		}


### PR DESCRIPTION
- Fix crash when opening new print formats (missing `format_data`)
- Hide sidebar, inspector, and canvas toolbar in preview mode
- Button label toggles between Show Preview / Hide Preview
- Add left/right padding in preview mode