### PR TITLE
feat: add ability to duplicate standard workspaces

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.js
+++ b/frappe/desk/doctype/workspace/workspace.js
@@ -20,6 +20,16 @@ frappe.ui.form.on("Workspace", {
 			.attr("target", "_blank");
 
 		frm.layout.message.empty();
+		if (frm.doc.app && frm.doc.module && !frappe.boot.developer_mode) {
+			frm.trigger("disable_form");
+			frm.layout.show_message(
+				__(
+					"This is a standard workspace and cannot be edited. Please duplicate it to make changes."
+				)
+			);
+			return;
+		}
+
 		let message = __("Please click Edit on the Workspace for best results");
 
 		if (

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -338,6 +338,57 @@ def new_page(new_page: str):
 
 
 @frappe.whitelist()
+def duplicate_page(source_name: str, title: str, public: str | int):
+	public = frappe.parse_json(public)
+
+	if public and not is_workspace_manager():
+		frappe.throw(_("Only Workspace Manager can create public workspaces"), frappe.PermissionError)
+
+	if not frappe.has_permission(doctype="Workspace", ptype="create"):
+		frappe.flags.error_message = _("User {0} does not have the permission to create a Workspace.").format(
+			frappe.bold(frappe.session.user)
+		)
+		raise frappe.PermissionError
+
+	source = frappe.get_doc("Workspace", source_name)
+	doc = frappe.copy_doc(source)
+	doc.title = title
+	doc.label = title if public else f"{title}-{frappe.session.user}"
+	doc.parent_page = ""
+	doc.for_user = "" if public else frappe.session.user
+	doc.public = public
+	doc.app = None
+	doc.module = None
+	doc.sequence_id = last_sequence_id(doc) + 1
+	doc.save(ignore_permissions=True)
+
+	if not doc.public:
+		add_to_my_workspace(doc)
+	else:
+		create_sidebar_for_duplicate(doc)
+
+	workspaces = get_workspace_sidebar_items()
+	return {"workspace_pages": workspaces, "sidebar_items": get_sidebar_items(workspaces), "name": doc.name}
+
+
+def create_sidebar_for_duplicate(workspace):
+	sidebar = frappe.new_doc("Workspace Sidebar")
+	sidebar.title = workspace.title
+	sidebar.header_icon = workspace.icon
+	sidebar.append(
+		"items",
+		{
+			"label": workspace.title,
+			"type": "Link",
+			"link_to": workspace.name,
+			"link_type": "Workspace",
+			"idx": 1,
+		},
+	)
+	sidebar.insert(ignore_permissions=True)
+
+
+@frappe.whitelist()
 def save_page(name: str, public: str | int, new_widgets: str, blocks: str):
 	public = frappe.parse_json(public)
 

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -387,6 +387,22 @@ def create_sidebar_for_duplicate(workspace):
 	)
 	sidebar.insert(ignore_permissions=True)
 
+	create_desktop_icon_for_duplicate(workspace, sidebar)
+
+
+def create_desktop_icon_for_duplicate(workspace, sidebar):
+	if frappe.db.exists("Desktop Icon", workspace.title):
+		return
+
+	icon = frappe.new_doc("Desktop Icon")
+	icon.label = workspace.title
+	icon.icon_type = "Link"
+	icon.link_type = "Workspace Sidebar"
+	icon.link_to = workspace.name
+	icon.icon = workspace.icon
+	icon.sidebar = sidebar.name
+	icon.insert(ignore_permissions=True)
+
 
 @frappe.whitelist()
 def save_page(name: str, public: str | int, new_widgets: str, blocks: str):

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -203,7 +203,18 @@ frappe.views.Workspace = class Workspace {
 								});
 							},
 							condition: () => {
-								return current_page.is_editable;
+								const is_standard = !!(this._page?.app && this._page?.module);
+								return is_standard
+									? frappe.boot.developer_mode
+									: this._page?.is_editable;
+							},
+						},
+						{
+							label: "Duplicate",
+							icon: "copy",
+							onClick: () => this.duplicate_page(),
+							condition: () => {
+								return !!(this._page?.app && this._page?.module);
 							},
 						},
 						{
@@ -548,6 +559,58 @@ frappe.views.Workspace = class Workspace {
 							});
 						});
 				}
+			},
+		});
+		d.show();
+	}
+
+	duplicate_page() {
+		const page = this._page;
+		const d = new frappe.ui.Dialog({
+			title: __("Duplicate Workspace"),
+			fields: [
+				{
+					label: __("Title"),
+					fieldtype: "Data",
+					fieldname: "title",
+					reqd: 1,
+					default: __("Copy of {0}", [page.title]),
+				},
+			],
+			primary_action_label: __("Duplicate"),
+			primary_action: (values) => {
+				values.title = strip_html(values.title);
+				d.hide();
+
+				frappe.call({
+					method: "frappe.desk.doctype.workspace.workspace.duplicate_page",
+					args: {
+						source_name: page.name,
+						title: values.title,
+						public: page.public || 0,
+					},
+					callback: (r) => {
+						if (!r.message) return;
+						frappe.boot.workspaces = r.message.workspace_pages;
+						this.workspaces = frappe.boot.workspaces.pages;
+						this.setup_pages(frappe.boot.workspaces.pages);
+						frappe.boot.workspace_sidebar_item = r.message.sidebar_items;
+
+						if (!page.public) {
+							frappe.app.sidebar.setup("private");
+						}
+
+						let route = frappe.router.slug(
+							page.public ? r.message.name : "private/" + r.message.name
+						);
+						frappe.set_route(route);
+
+						frappe.show_alert({
+							message: __("Workspace {0} duplicated", [values.title.bold()]),
+							indicator: "green",
+						});
+					},
+				});
 			},
 		});
 		d.show();


### PR DESCRIPTION
Duplicating standard workspaces was disabled in some version but people want to clone an existing workspace

This creates a copy of Workspace and its content and a new Workspace Sidebar which has the Sidebar Item
