### PR TITLE
fix: create minimal bench structure for esbuild in CI

### DIFF
--- a/.github/workflows/build-and-commit-assets.yml
+++ b/.github/workflows/build-and-commit-assets.yml
@@ -29,7 +29,15 @@ jobs:
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Create minimal bench structure
+        run: |
+          mkdir -p /tmp/bench/sites /tmp/bench/apps
+          echo "frappe" > /tmp/bench/sites/apps.txt
+          ln -s "$GITHUB_WORKSPACE" /tmp/bench/apps/frappe
+
       - name: Build assets (production)
+        env:
+          FRAPPE_BENCH_ROOT: /tmp/bench
         run: yarn run production
 
       - name: Package assets


### PR DESCRIPTION
- esbuild reads `sites/apps.txt` via `FRAPPE_BENCH_ROOT`; set it to a temp dir in CI

`no-docs`