### PR TITLE
fix: simplify notification header actions

### DIFF
--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -28,27 +28,7 @@ frappe.ui.Notifications = class Notifications {
 	}
 
 	setup_headers() {
-		// Add header actions
-		$(`<span class="notification-settings" data-action="go_to_settings">
-			${frappe.utils.icon("setting-gear")}
-		</span>`)
-			.on("click", (e) => {
-				e.stopImmediatePropagation();
-				frappe.set_route("Form", "Notification Settings", frappe.session.user);
-			})
-			.appendTo(this.header_actions)
-			.attr("title", __("Notification Settings"))
-			.tooltip({ delay: { show: 600, hide: 100 }, trigger: "hover" });
-
-		$(`<span class="mark-all-read" data-action="mark_all_as_read">
-			${frappe.utils.icon("mark-as-read")}
-		</span>`)
-			.on("click", (e) => this.mark_all_as_read(e))
-			.appendTo(this.header_actions)
-			.attr("title", __("Mark all as read"))
-			.tooltip({ delay: { show: 600, hide: 100 }, trigger: "hover" });
-
-		$(`<span class="close-notification-dialogue pull-right">
+		$(`<span class="close-notification-dialogue">
 			${frappe.utils.icon("x")}
 		</span>`)
 			.on("click", (e) => {
@@ -359,7 +339,7 @@ class NotificationsView extends BaseNotificationsView {
 					$(`<div class="notification-null-state">
 					<div class="text-center">
 						<img src="/assets/frappe/images/ui-states/notification-empty-state.svg" alt="Generic Empty State" class="null-state">
-						<div class="title">${__("No New notifications")}</div>
+						<div class="title">${__("No new notifications")}</div>
 						<div class="subtitle">
 							${__("Looks like you haven’t received any notifications.")}
 					</div></div></div>`)

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -416,6 +416,14 @@ frappe.ui.Sidebar = class Sidebar {
 						frappe.ui.toolbar.toggle_full_width();
 					},
 				},
+				{
+					name: "Notifications Settings",
+					label: __("Notifications Settings"),
+					icon: "bell",
+					onClick: function () {
+						frappe.set_route("Form", "Notification Settings", frappe.session.user);
+					},
+				},
 				{ is_divider: true },
 				{
 					name: "logout",

--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -12,17 +12,8 @@
 	cursor: pointer;
 }
 
-.mark-all-read {
-	margin-top: 2px;
-	margin-right: 4px;
-	cursor: pointer;
-}
-
 .close-notification-dialogue {
 	cursor: pointer;
-	.icon {
-		stroke-width: 2px;
-	}
 }
 
 .notification-settings {


### PR DESCRIPTION
Notifications header actions are too tight and overwhelming to look at. The actions are also not that used

Notification Settings is moved to user dropdown as the functionality is user related

Before
<img width="380" height="62" alt="Screenshot 2026-06-02 at 10 42 30 AM" src="https://github.com/user-attachments/assets/981c8417-b3fa-4210-a8fa-993b0249c6c9" />


After
<img width="369" height="57" alt="Screenshot 2026-06-02 at 10 49 10 AM" src="https://github.com/user-attachments/assets/6971c751-5f4d-42e2-8331-760904062b0b" />

