### PR TITLE
fix(notifications): use lucide icons and fix empty state capitalisation

### DIFF
--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -28,6 +28,25 @@ frappe.ui.Notifications = class Notifications {
 	}
 
 	setup_headers() {
+		$(`<span class="notification-settings" data-action="go_to_settings">
+			${frappe.utils.icon("settings")}
+		</span>`)
+			.on("click", (e) => {
+				e.stopImmediatePropagation();
+				frappe.set_route("Form", "Notification Settings", frappe.session.user);
+			})
+			.appendTo(this.header_actions)
+			.attr("title", __("Notification Settings"))
+			.tooltip({ delay: { show: 600, hide: 100 }, trigger: "hover" });
+
+		$(`<span class="mark-all-read" data-action="mark_all_as_read">
+			${frappe.utils.icon("check-check")}
+		</span>`)
+			.on("click", (e) => this.mark_all_as_read(e))
+			.appendTo(this.header_actions)
+			.attr("title", __("Mark all as read"))
+			.tooltip({ delay: { show: 600, hide: 100 }, trigger: "hover" });
+
 		$(`<span class="close-notification-dialogue">
 			${frappe.utils.icon("x")}
 		</span>`)

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -341,7 +341,7 @@ class NotificationsView extends BaseNotificationsView {
 						<img src="/assets/frappe/images/ui-states/notification-empty-state.svg" alt="Generic Empty State" class="null-state">
 						<div class="title">${__("No new notifications")}</div>
 						<div class="subtitle">
-							${__("Looks like you haven’t received any notifications.")}
+							${__("Looks like you haven't received any notifications.")}
 					</div></div></div>`)
 				);
 			}
@@ -566,7 +566,7 @@ class ChangelogFeedView extends BaseNotificationsView {
 			html = `<div class="notification-null-state">
 						<div class="text-center">
 							<img src="/assets/frappe/images/ui-states/notification-empty-state.svg" alt="Generic Empty State" class="null-state">
-							<div class="title">${__("Nothing New")}</div>
+							<div class="title">${__("Nothing new")}</div>
 							<div class="subtitle">
 								${__("There is nothing new to show you right now.")}
 							</div>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -416,14 +416,6 @@ frappe.ui.Sidebar = class Sidebar {
 						frappe.ui.toolbar.toggle_full_width();
 					},
 				},
-				{
-					name: "Notifications Settings",
-					label: __("Notifications Settings"),
-					icon: "bell",
-					onClick: function () {
-						frappe.set_route("Form", "Notification Settings", frappe.session.user);
-					},
-				},
 				{ is_divider: true },
 				{
 					name: "logout",


### PR DESCRIPTION
- Replace thick timeless icons (`setting-gear`, `mark-as-read`) with thinner lucide equivalents (`settings`, `check-check`)
- Remove forced `stroke-width: 2px` on close icon
- Fix capitalisation: "No New notifications" → "No new notifications", "Nothing New" → "Nothing new"

This is how it looks

<img width="362" height="115" alt="Screenshot 2026-06-02 at 12 38 04 PM" src="https://github.com/user-attachments/assets/c11e9333-b638-4c23-839e-1fcd3d48a4f4" />
