### PR TITLE
fix: deterministic list sorting on version-15

### DIFF
--- a/frappe/public/js/frappe/ui/sort_selector.js
+++ b/frappe/public/js/frappe/ui/sort_selector.js
@@ -196,7 +196,14 @@ frappe.ui.SortSelector = class SortSelector {
 		}
 	}
 	get_sql_string() {
-		// build string like `tabTask`.`subject` desc
-		return "`tab" + this.doctype + "`.`" + this.sort_by + "` " + this.sort_order;
+		// build string like: `tabSales Invoice`.`subject`, `tabSales Invoice`.`name` desc
+		const table_name = "`tab" + this.doctype + "`";
+		const sort_by = `${table_name}.\`${this.sort_by}\``;
+		if (!["name", "creation", "modified"].includes(this.sort_by)) {
+			// add name column for deterministic ordering
+			return `${sort_by} ${this.sort_order}, ${table_name}.\`name\` ${this.sort_order}`;
+		} else {
+			return `${sort_by} ${this.sort_order}`;
+		}
 	}
 };


### PR DESCRIPTION
Form prev/next navigation can skip records when multiple rows share the same sort value. The issue occurs because `get_next` uses `name` as a secondary sort key, while the list view does not, resulting in inconsistent ordering.

<img width="635" height="363" alt="Screenshot 2026-06-02 at 2 57 45 PM" src="https://github.com/user-attachments/assets/1c5fdbdf-aec4-47c4-9012-a995cdcf7f10" />

This ports the `sort_selector` change from develop (#25278), adding `name` as a secondary sort key in the list view so its ordering matches navigation. The fix is already present in version-16 and was only missing from version-15.

Related: https://github.com/frappe/frappe/pull/38901