### PR TITLE
fix(formatters): apply cint to Int fieldtype in format_value

### DIFF
--- a/frappe/utils/formatters.py
+++ b/frappe/utils/formatters.py
@@ -94,6 +94,9 @@ def format_value(value, df=None, doc=None, currency=None, translated=False, form
 
 		return fmt_money(value, precision=precision, currency=currency)
 
+	elif df.get("fieldtype") == "Int":
+		return "" if value == "" else cint(value)
+
 	elif df.get("fieldtype") == "Percent":
 		return f"{flt(value, 2)}%"
 

--- a/frappe/utils/formatters.py
+++ b/frappe/utils/formatters.py
@@ -95,7 +95,7 @@ def format_value(value, df=None, doc=None, currency=None, translated=False, form
 		return fmt_money(value, precision=precision, currency=currency)
 
 	elif df.get("fieldtype") == "Int":
-		return "" if value == "" else cint(value)
+		return "" if value == "" else cstr(cint(value))
 
 	elif df.get("fieldtype") == "Percent":
 		return f"{flt(value, 2)}%"


### PR DESCRIPTION
### Problem
`format_value` (server-side) has no `Int` branch value falls through and renders raw. 
Query Reports return floats for Int columns (e.g. `ROUND(x/100000, 0)`), so HTML/PDF/Auto Email Report show `2489.0` while the browser shows `2489`. 
The JS formatter (`formatters.js` `Int`) already applies `cint`. the Python side did not, so the two
render paths disagree.

### Fix
Add an `Int` branch to `format_value` that applies `cint`, matching the client formatter.
Empty string preserved as blank.

### Before Fix
[Screencast from 2026-06-02 16-59-54.webm](https://github.com/user-attachments/assets/96d68a2c-3505-49ed-8886-7f493de1de42)

### After Fix
[Screencast from 2026-06-02 17-05-17.webm](https://github.com/user-attachments/assets/a4408ad8-bcf4-4064-988d-86db0da8f50c)
