### PR TITLE
fix(ux): show workspace ellipsis menu after discarding customization

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -387,6 +387,7 @@ frappe.views.Workspace = class Workspace {
 			});
 		}
 		$(this.workspace_actions_button).remove();
+		this.add_workspace_controls = false;
 	}
 
 	make_blocks_sortable() {


### PR DESCRIPTION
**Before Fix**


https://github.com/user-attachments/assets/d36bd80b-bb60-4e39-a049-4b6244a7d311



**After Fix**

https://github.com/user-attachments/assets/2c111b45-3d2b-4a05-94d0-a44167ac9b6b

