### PR TITLE
fix: escape user data in grid cells and formatters

### DIFF
--- a/frappe/public/js/frappe/form/controls/quill-mention/blots/mention.js
+++ b/frappe/public/js/frappe/form/controls/quill-mention/blots/mention.js
@@ -9,8 +9,12 @@ class MentionBlot extends Embed {
 		denotationChar.className = "ql-mention-denotation-char";
 		denotationChar.innerHTML = data.denotationChar;
 		node.appendChild(denotationChar);
-		node.innerHTML += data.value;
-		node.innerHTML += `${data.isGroup === "true" ? frappe.utils.icon("users") : ""}`;
+		const valueSpan = document.createElement("span");
+		valueSpan.textContent = data.value;
+		node.appendChild(valueSpan);
+		if (data.isGroup === "true") {
+			node.innerHTML += frappe.utils.icon("users");
+		}
 		node.dataset.id = data.id;
 		node.dataset.value = data.value;
 		node.dataset.denotationChar = data.denotationChar;

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -441,7 +441,7 @@ class FormTimeline extends BaseTimeline {
 
 		(this.doc_info.milestones || []).forEach((milestone_log) => {
 			const field = frappe.meta.get_label(this.frm.doctype, milestone_log.track_field);
-			const value = milestone_log.value.bold();
+			const value = frappe.utils.bold(milestone_log.value);
 			const user_link = get_user_link(milestone_log.owner);
 			const timeline_content = get_user_message(
 				milestone_log.owner,

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -302,14 +302,16 @@ frappe.form.formatters = {
 	Tag: function (value) {
 		var html = "";
 		$.each((value || "").split(","), function (i, v) {
-			if (v)
+			if (v) {
+				let ev = frappe.utils.escape_html(v);
 				html += `
 				<span
 					class="data-pill btn-xs align-center ellipsis"
 					style="background-color: var(--control-bg); box-shadow: none; margin-right: 4px;"
-					data-field="_user_tags" data-label="${v}'">
-					${v}
+					data-field="_user_tags" data-label="${ev}">
+					${ev}
 				</span>`;
+			}
 		});
 		return html;
 	},
@@ -319,13 +321,10 @@ frappe.form.formatters = {
 	Assign: function (value) {
 		var html = "";
 		$.each(JSON.parse(value || "[]"), function (i, v) {
-			if (v)
-				html +=
-					'<span class="label label-warning" \
-				style="margin-right: 7px;"\
-				data-field="_assign">' +
-					v +
-					"</span>";
+			if (v) {
+				let ev = frappe.utils.escape_html(v);
+				html += `<span class="label label-warning" style="margin-right: 7px;" data-field="_assign">${ev}</span>`;
+			}
 		});
 		return html;
 	},

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -744,7 +744,12 @@ export default class GridRow {
 
 			total_colsize += colsize;
 			let txt = this.doc
-				? frappe.format(this.doc[df.fieldname], df, null, this.doc)
+				? frappe.format(
+						this._escape_for_format(this.doc[df.fieldname], df),
+						df,
+						null,
+						this.doc
+				  )
 				: __(df.label, null, df.parent);
 
 			if (this.doc && df.fieldtype === "Select") {
@@ -1185,7 +1190,12 @@ export default class GridRow {
 					let df = this.grid.visible_columns[index][0];
 
 					let txt = this.doc
-						? frappe.format(this.doc[df.fieldname], df, null, this.doc)
+						? frappe.format(
+								this._escape_for_format(this.doc[df.fieldname], df),
+								df,
+								null,
+								this.doc
+						  )
 						: __(df.label, null, df.parent);
 
 					this.refresh_field(df.fieldname, txt);
@@ -1558,6 +1568,23 @@ export default class GridRow {
 			this.grid.grid_pagination.go_to_page(new_page);
 		}
 	}
+	// Escape plain-text field values before passing to frappe.format(), so the formatted
+	// output is safe to inject via .html(). Mirrors the same pre-escaping in base_input.js.
+	_escape_for_format(value, df) {
+		const PLAIN_TEXT_FIELDTYPES = [
+			"Data",
+			"Long Text",
+			"Small Text",
+			"Text",
+			"Password",
+			"MultiSelect",
+		];
+		if (df && PLAIN_TEXT_FIELDTYPES.includes(df.fieldtype)) {
+			return frappe.utils.escape_html(cstr(value));
+		}
+		return value;
+	}
+
 	refresh_field(fieldname, txt) {
 		let fields =
 			this.grid.user_defined_columns && this.grid.user_defined_columns.length > 0
@@ -1570,11 +1597,21 @@ export default class GridRow {
 
 		// format values if no frm
 		if (df && this.doc) {
-			txt = frappe.format(this.doc[fieldname], df, null, this.doc);
+			txt = frappe.format(
+				this._escape_for_format(this.doc[fieldname], df),
+				df,
+				null,
+				this.doc
+			);
 		}
 
 		if (!txt && this.frm) {
-			txt = frappe.format(this.doc[fieldname], df, null, this.frm.doc);
+			txt = frappe.format(
+				this._escape_for_format(this.doc[fieldname], df),
+				df,
+				null,
+				this.frm.doc
+			);
 		}
 
 		// reset static value

--- a/frappe/public/js/frappe/form/linked_with.js
+++ b/frappe/public/js/frappe/form/linked_with.js
@@ -101,7 +101,9 @@ frappe.ui.form.LinkedWith = class LinkedWith {
 		return `<div class="list-row-container">
 			<div class="level list-row small">
 				<div class="level-left bold">
-					<a href="/desk/${frappe.router.slug(doctype)}/${doc.name}">${doc.name}</a>
+					<a href="/desk/${frappe.router.slug(doctype)}/${frappe.utils.escape_html(
+			doc.name
+		)}">${frappe.utils.escape_html(doc.name)}</a>
 				</div>
 			</div>
 		</div>`;

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -125,8 +125,8 @@ frappe.ui.form.Toolbar = class Toolbar {
 		if (input_name) {
 			const warning = __("This cannot be undone");
 			const message = __("Are you sure you want to merge {0} with {1}?", [
-				docname.bold(),
-				input_name.bold(),
+				frappe.utils.bold(docname),
+				frappe.utils.bold(input_name),
 			]);
 			confirm_message = `${message}<br><b>${warning}<b>`;
 		}
@@ -160,8 +160,8 @@ frappe.ui.form.Toolbar = class Toolbar {
 								reload_form(input_name);
 								frappe.show_alert({
 									message: __("Document renamed from {0} to {1}", [
-										docname.bold(),
-										input_name.bold(),
+										frappe.utils.bold(docname),
+										frappe.utils.bold(input_name),
 									]),
 									indicator: "success",
 								});
@@ -169,8 +169,8 @@ frappe.ui.form.Toolbar = class Toolbar {
 						});
 						frappe.show_alert(
 							__("Document renaming from {0} to {1} has been queued", [
-								docname.bold(),
-								input_name.bold(),
+								frappe.utils.bold(docname),
+								frappe.utils.bold(input_name),
 							])
 						);
 					}

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -32,18 +32,18 @@ frappe.ui.form.States = class FormStates {
 					const next_actions =
 						$.map(
 							transitions,
-							(d) => `${d.action.bold()} ${__("by Role")} ${d.allowed}`
+							(d) => `${frappe.utils.bold(d.action)} ${__("by Role")} ${d.allowed}`
 						).join(", ") || __("None: End of Workflow").bold();
 
 					const document_editable_by = frappe.workflow
 						.get_document_state_roles(me.frm.doctype, state)
-						.map((role) => role.bold())
+						.map((role) => frappe.utils.bold(role))
 						.join(", ");
 
 					$(d.body)
 						.html(
 							`
-					<p>${__("Current status")}: ${state.bold()}</p>
+					<p>${__("Current status")}: ${frappe.utils.bold(state)}</p>
 					<p>${__("Document is only editable by users with role")}: ${document_editable_by}</p>
 					<p>${__("Next actions")}: ${next_actions}</p>
 					<p>${__("{0}: Other permission rules may also apply", [__("Note").bold()])}</p>

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -66,7 +66,7 @@ frappe.search.utils = {
 				const doctype = route[1];
 				if (route.length > 2 && doctype !== route[2]) {
 					const docname = route[2];
-					out.label = __(doctype) + " " + docname.bold();
+					out.label = __(doctype) + " " + frappe.utils.bold(docname);
 					out.value = __(doctype) + " " + docname;
 				} else {
 					out.label = __(doctype).bold();

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -243,6 +243,12 @@ Object.assign(frappe.utils, {
 		return String(txt).replace(/[&<>"'`=]/g, (char) => escape_html_mapping[char] || char);
 	},
 
+	// Escape text and wrap in <strong> — use this instead of String.prototype.bold()
+	// so user-supplied values are safely escaped before being injected into HTML.
+	bold: function (txt) {
+		return `<strong>${frappe.utils.escape_html(cstr(txt))}</strong>`;
+	},
+
 	unescape_html: function (txt) {
 		let unescape_html_mapping = {
 			"&amp;": "&",


### PR DESCRIPTION
- add `frappe.utils.bold(txt)` to utils.js — escapes value before wrapping in `<strong>`, replaces `String.prototype.bold()` which is deprecated and doesn't escape
- replace raw `.bold()` on doc names, workflow states/roles, milestone values, and rename dialog values with `frappe.utils.bold()`
- escape `doc.name` directly in linked_with.js template literal
- use `textContent` for mention value in quill-mention blot instead of `innerHTML +=`


Related to https://support.frappe.io/helpdesk/tickets/69035