### PR TITLE
fix: Avoid duplicate setup wizard request

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -59,13 +59,7 @@ def setup_complete(args: str | dict[str, Any]):
 
 	kwargs = parse_args(sanitize_input(args))
 	stages = get_setup_stages(kwargs)
-	is_background_task = frappe.conf.get("trigger_site_setup_in_background")
-
-	if is_background_task:
-		process_setup_stages.enqueue(stages=stages, user_input=kwargs, is_background_task=True, at_front=True)
-		return {"status": "registered"}
-	else:
-		return process_setup_stages(stages, kwargs)
+	return process_setup_stages(stages, kwargs)
 
 
 @frappe.whitelist()
@@ -92,7 +86,6 @@ def initialize_system_settings_and_user(
 	create_or_update_user(user_data)
 
 
-@frappe.task()
 def process_setup_stages(stages, user_input, is_background_task=False):
 	from frappe.utils.telemetry import capture
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -12,6 +12,7 @@ from frappe.permissions import AUTOMATIC_ROLES
 from frappe.translate import send_translations, set_default_language
 from frappe.utils import cint, now, strip
 from frappe.utils.password import update_password
+from frappe.utils.synchronization import LockTimeoutError, filelock
 
 from . import install_fixtures
 
@@ -54,12 +55,17 @@ def setup_complete(args: str | dict[str, Any]):
 	and clears cache. If wizard breaks, calls `setup_wizard_exception` hook"""
 
 	# Setup complete: do not throw an exception, let the user continue to desk
-	if frappe.is_setup_complete():
-		return {"status": "ok"}
+	try:
+		with filelock("setup_wizard", timeout=0.5):
+			if frappe.is_setup_complete():
+				return {"status": "ok"}
 
-	kwargs = parse_args(sanitize_input(args))
-	stages = get_setup_stages(kwargs)
-	return process_setup_stages(stages, kwargs)
+			kwargs = parse_args(sanitize_input(args))
+			stages = get_setup_stages(kwargs)
+			return process_setup_stages(stages, kwargs)
+	except LockTimeoutError:
+		# Duplicate request
+		return {"status": "ok"}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
<img width="1283" height="322" alt="image" src="https://github.com/user-attachments/assets/8f243d6a-38c7-4301-9c4a-b95b52dcfc53" />


Not sure why it happens, but server side code should guard against it.