### PR TITLE
fix(auto_email_report): attach doc to filter dialog to stop set_value loop

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -195,6 +195,9 @@ frappe.ui.form.on("Auto Email Report", {
 					reference_report.onload(frappe.query_report);
 				}
 
+				dialog.doc = dialog.doc || {};
+				dialog.fields_list.forEach((f) => (f.doc = dialog.doc));
+
 				dialog.set_values(filters);
 			});
 


### PR DESCRIPTION
Clicking the filter table on an Auto Email Report with a saved Date
filter could freeze the page. The guard that
breaks the cycle compares against `this.doc[fieldname]`, but Dialog
fields have no `this.doc` so the check never holds and the loop
never ends.

Attach an empty doc to the dialog before set_values so each value
persists and the guard can fire.

tk:67215 & 67794