### PR TITLE
feat: add attachment preview pane

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -225,7 +225,7 @@ frappe.ui.form.Attachments = class Attachments {
 					<button class="btn btn-link icon-btn attachment-preview-close" type="button" title="${__(
 						"Close"
 					)}">
-						${frappe.utils.icon("close", "sm")}
+						${frappe.utils.icon("es-line-close", "sm")}
 					</button>
 				</div>
 				<div class="attachment-preview-body">

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -228,7 +228,6 @@ frappe.ui.form.Attachments = class Attachments {
 						>
 							${frappe.utils.icon("es-line-copy", "sm")}
 						</button>
-						<span class="attachment-preview-title-divider"></span>
 						<button class="btn btn-link icon-btn attachment-preview-close" type="button" title="${__(
 							"Close"
 						)}">

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -198,13 +198,7 @@ frappe.ui.form.Attachments = class Attachments {
 				"Loading preview..."
 			)}</div>`;
 		} else {
-			preview_html = `<div class="attachment-preview-unavailable">
-				<div class="text-muted">${__("Preview not available for this file type.")}</div>
-				<a class="btn btn-default btn-sm" href="${escaped_file_url}" target="_blank" rel="noopener noreferrer">
-					<span>${__("Open file")}</span>
-					${frappe.utils.icon("es-line-arrow-up-right", "xs", "", "", "ml-1")}
-				</a>
-			</div>`;
+			preview_html = this.get_unsupported_preview_html(escaped_file_url);
 		}
 
 		this.current_attachment_preview_type = preview_type;
@@ -256,9 +250,12 @@ frappe.ui.form.Attachments = class Attachments {
 		$(document)
 			.off("keydown.attachment_preview")
 			.on("keydown.attachment_preview", (event) => {
-				if (event.key === "Escape") {
-					this.hide_attachment_preview();
+				if (event.key !== "Escape") return;
+				if (!document.body.contains(this.attachment_preview?.[0])) {
+					$(document).off("keydown.attachment_preview");
+					return;
 				}
+				this.hide_attachment_preview();
 			});
 
 		this.attachment_preview
@@ -317,7 +314,7 @@ frappe.ui.form.Attachments = class Attachments {
 	async render_csv_preview(attachment, file_url, escaped_file_url, preview_request_id) {
 		try {
 			let file_size = Number(attachment.file_size);
-			if (file_size && file_size > this.max_csv_preview_size) {
+			if (file_size > this.max_csv_preview_size) {
 				throw this.get_csv_size_error();
 			}
 
@@ -367,22 +364,28 @@ frappe.ui.form.Attachments = class Attachments {
 
 	async get_csv_response_text(response) {
 		if (!response.body?.getReader) {
-			return await response.text();
+			let text = await response.text();
+			if (text.length > this.max_csv_preview_size) {
+				throw this.get_csv_size_error();
+			}
+			return text;
 		}
 
 		let reader = response.body.getReader();
 		let decoder = new TextDecoder();
 		let csv_text = "";
-		let is_done = false;
+		let bytes_read = 0;
+		let { done, value } = await reader.read();
 
-		while (!is_done) {
-			let { done, value } = await reader.read();
-			is_done = done;
-			if (done) {
-				break;
+		while (!done) {
+			bytes_read += value.byteLength;
+			if (bytes_read > this.max_csv_preview_size) {
+				reader.cancel();
+				throw this.get_csv_size_error();
 			}
 
 			csv_text += decoder.decode(value, { stream: true });
+			({ done, value } = await reader.read());
 		}
 
 		return csv_text + decoder.decode();
@@ -545,7 +548,14 @@ frappe.ui.form.Attachments = class Attachments {
 		this.frm.page.wrapper.addClass("attachment-preview-resizing");
 
 		if (this.current_attachment_preview_type === "pdf") {
-			this.attachment_preview.addClass("attachment-preview-resizing-pdf");
+			this.attachment_preview
+				.addClass("attachment-preview-resizing-pdf")
+				.find(".attachment-preview-body")
+				.append(
+					`<div class="attachment-preview-resize-overlay">${__(
+						"Resizing preview..."
+					)}</div>`
+				);
 		}
 
 		$(document)
@@ -580,7 +590,10 @@ frappe.ui.form.Attachments = class Attachments {
 
 		this.is_resizing_attachment_preview = false;
 		this.frm.page.wrapper.removeClass("attachment-preview-resizing");
-		this.attachment_preview?.removeClass("attachment-preview-resizing-pdf");
+		this.attachment_preview
+			?.removeClass("attachment-preview-resizing-pdf")
+			.find(".attachment-preview-resize-overlay")
+			.remove();
 		$(document).off(".attachment_preview_resize");
 		this.save_preview_width();
 	}

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -539,6 +539,11 @@ frappe.ui.form.Attachments = class Attachments {
 		this.frm.page.wrapper.removeClass("attachment-preview-open");
 		this.attachment_preview_request_id = (this.attachment_preview_request_id || 0) + 1;
 		$(document).off("keydown.attachment_preview");
+		if (this.is_resizing_attachment_preview) {
+			this.is_resizing_attachment_preview = false;
+			this.frm.page.wrapper.removeClass("attachment-preview-resizing");
+			$(document).off(".attachment_preview_resize");
+		}
 	}
 
 	start_preview_resize(event) {

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -190,6 +190,10 @@ frappe.ui.form.Attachments = class Attachments {
 			preview_html = `<iframe src="${escaped_file_url}" title="${escaped_file_name}"></iframe>`;
 		} else if (preview_type === "image") {
 			preview_html = `<img src="${escaped_file_url}" alt="${escaped_file_name}" loading="lazy">`;
+		} else if (preview_type === "csv") {
+			preview_html = `<div class="text-muted attachment-preview-loading">${__(
+				"Loading preview..."
+			)}</div>`;
 		} else {
 			preview_html = `<div class="attachment-preview-unavailable">
 				<div class="text-muted">${__("Preview not available for this file type.")}</div>
@@ -201,13 +205,23 @@ frappe.ui.form.Attachments = class Attachments {
 		}
 
 		this.current_attachment_preview_type = preview_type;
+		this.attachment_preview_request_id = (this.attachment_preview_request_id || 0) + 1;
+		let preview_request_id = this.attachment_preview_request_id;
 		this.set_preview_width(this.attachment_preview_width);
 		this.frm.page.wrapper.addClass("attachment-preview-open");
 
 		this.attachment_preview.removeClass("hidden").html(
 			`<div class="attachment-preview-resize-handle"></div>
 				<div class="attachment-preview-header">
-					<div class="ellipsis" title="${escaped_file_name}">${escaped_file_name}</div>
+					<div class="attachment-preview-title">
+						<div class="ellipsis" title="${escaped_file_name}">${escaped_file_name}</div>
+						<a class="btn btn-link icon-btn attachment-preview-open"
+							href="${escaped_file_url}" target="_blank" rel="noopener noreferrer"
+							title="${__("Open in new tab")}"
+						>
+							${frappe.utils.icon("es-line-arrow-up-right", "sm")}
+						</a>
+					</div>
 					<button class="btn btn-link icon-btn attachment-preview-close" type="button" title="${__(
 						"Close"
 					)}">
@@ -232,6 +246,10 @@ frappe.ui.form.Attachments = class Attachments {
 
 				this.start_preview_resize(event);
 			});
+
+		if (preview_type === "csv") {
+			this.render_csv_preview(file_url, escaped_file_url, preview_request_id);
+		}
 	}
 
 	get_preview_type(attachment, file_url) {
@@ -242,6 +260,10 @@ frappe.ui.form.Attachments = class Attachments {
 
 		if (file_type.includes("pdf") || extension === "pdf") {
 			return "pdf";
+		}
+
+		if (extension === "csv") {
+			return "csv";
 		}
 
 		if (
@@ -255,9 +277,186 @@ frappe.ui.form.Attachments = class Attachments {
 		return "unsupported";
 	}
 
+	get_unsupported_preview_html(file_url) {
+		return `<div class="attachment-preview-unavailable">
+			<div class="text-muted">${__("Preview not available for this file type.")}</div>
+			<a class="btn btn-default btn-sm" href="${file_url}" target="_blank" rel="noopener noreferrer">
+				<span>${__("Open file")}</span>
+				${frappe.utils.icon("es-line-arrow-up-right", "xs", "", "", "ml-1")}
+			</a>
+		</div>`;
+	}
+
+	async render_csv_preview(file_url, escaped_file_url, preview_request_id) {
+		try {
+			let response = await fetch(file_url);
+			if (!response.ok) {
+				throw new Error("Unable to fetch CSV");
+			}
+
+			let csv_text = await response.text();
+			let rows = this.parse_csv(csv_text);
+			if (!rows.length) {
+				throw new Error("Empty CSV");
+			}
+
+			if (
+				preview_request_id !== this.attachment_preview_request_id ||
+				this.current_attachment_preview_type !== "csv"
+			) {
+				return;
+			}
+
+			this.attachment_preview
+				.find(".attachment-preview-body")
+				.html(this.get_csv_preview_html(rows));
+		} catch (error) {
+			if (
+				preview_request_id !== this.attachment_preview_request_id ||
+				this.current_attachment_preview_type !== "csv"
+			) {
+				return;
+			}
+
+			this.attachment_preview
+				.find(".attachment-preview-body")
+				.html(this.get_unsupported_preview_html(escaped_file_url));
+		}
+	}
+
+	parse_csv(csv_text) {
+		let rows = [];
+		let row = [];
+		let value = "";
+		let in_quotes = false;
+
+		let push_value = () => {
+			row.push(value);
+			value = "";
+		};
+
+		let push_row = () => {
+			push_value();
+			rows.push(row);
+			row = [];
+		};
+
+		for (let i = 0; i < csv_text.length; i++) {
+			let character = csv_text[i];
+
+			if (in_quotes) {
+				if (character === '"') {
+					if (csv_text[i + 1] === '"') {
+						value += '"';
+						i++;
+					} else {
+						in_quotes = false;
+					}
+				} else {
+					value += character;
+				}
+				continue;
+			}
+
+			if (character === '"') {
+				in_quotes = true;
+			} else if (character === ",") {
+				push_value();
+			} else if (character === "\n") {
+				push_row();
+			} else if (character === "\r") {
+				if (csv_text[i + 1] === "\n") {
+					i++;
+				}
+				push_row();
+			} else {
+				value += character;
+			}
+		}
+
+		if (in_quotes) {
+			throw new Error("Unclosed quoted field");
+		}
+
+		if (value.length || row.length) {
+			push_row();
+		}
+
+		return rows;
+	}
+
+	get_csv_preview_html(rows) {
+		let max_rows = 100;
+		let max_columns = 20;
+		let visible_rows = rows.slice(0, max_rows);
+		let total_rows = rows.length;
+		let total_columns = rows.reduce((max, row) => Math.max(max, row.length), 0);
+		let visible_column_count = Math.min(total_columns, max_columns);
+		let visible_row_count = visible_rows.length;
+		let is_row_truncated = total_rows > max_rows;
+		let is_column_truncated = total_columns > max_columns;
+
+		let get_cell_html = (value = "") => {
+			let cell_value = String(value);
+			let max_cell_length = 200;
+			let max_title_length = 1000;
+			let is_cell_truncated = cell_value.length > max_cell_length;
+			let display_value = is_cell_truncated
+				? cell_value.slice(0, max_cell_length) + "…"
+				: cell_value;
+			let title =
+				cell_value.length && cell_value.length <= max_title_length
+					? ` title="${frappe.utils.escape_html(cell_value)}"`
+					: "";
+
+			return `<td${title}>${frappe.utils.escape_html(display_value)}</td>`;
+		};
+
+		let table_rows = visible_rows
+			.map((row) => {
+				let cells = [];
+				for (let i = 0; i < visible_column_count; i++) {
+					cells.push(get_cell_html(row[i] || ""));
+				}
+				return `<tr>${cells.join("")}</tr>`;
+			})
+			.join("");
+
+		let format_count = (count) => format_number(count, null, 0);
+		let note = "";
+		if (is_row_truncated && is_column_truncated) {
+			note = __("Showing {0} of {1} rows and {2} of {3} columns.", [
+				format_count(visible_row_count),
+				format_count(total_rows),
+				format_count(visible_column_count),
+				format_count(total_columns),
+			]);
+		} else if (is_row_truncated) {
+			note = __("Showing {0} of {1} rows.", [
+				format_count(visible_row_count),
+				format_count(total_rows),
+			]);
+		} else if (is_column_truncated) {
+			note = __("Showing {0} of {1} columns.", [
+				format_count(visible_column_count),
+				format_count(total_columns),
+			]);
+		}
+
+		return `<div class="attachment-preview-csv">
+			<div class="attachment-preview-csv-table">
+				<table class="table table-bordered">
+					<tbody>${table_rows}</tbody>
+				</table>
+			</div>
+			${note ? `<div class="text-muted attachment-preview-note">${note}</div>` : ""}
+		</div>`;
+	}
+
 	hide_attachment_preview() {
 		this.attachment_preview?.addClass("hidden").empty();
 		this.frm.page.wrapper.removeClass("attachment-preview-open");
+		this.attachment_preview_request_id = (this.attachment_preview_request_id || 0) + 1;
 	}
 
 	start_preview_resize(event) {

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -6,6 +6,7 @@ frappe.ui.form.Attachments = class Attachments {
 
 		this.attachments_page_length = 10; // show n attachments initially
 		this.show_all_attachments = false;
+		this.attachment_preview_width = 40;
 
 		this.make();
 	}
@@ -26,6 +27,7 @@ frappe.ui.form.Attachments = class Attachments {
 
 		this.add_attachment_wrapper = this.parent.find(".attachments-actions");
 		this.attachments_label = this.parent.find(".attachments-label");
+		this.setup_preview_area();
 	}
 	max_reached(raise_exception = false) {
 		const attachment_count = Object.keys(this.get_attachments()).length;
@@ -151,9 +153,168 @@ frappe.ui.form.Attachments = class Attachments {
 				${frappe.utils.icon(attachment.is_private ? "es-line-lock" : "es-line-unlock", "sm ml-0")}
 			</a>`;
 
-		$(`<div class="attachment-row"></div>`)
+		let $attachment_row = $(`<div class="attachment-row"></div>`)
 			.append(frappe.get_data_pill(file_label, fileid, remove_action, icon))
 			.insertAfter(this.add_attachment_wrapper);
+
+		$attachment_row.find(".attachment-file-label").on("click", (event) => {
+			if (event.metaKey || event.ctrlKey || event.shiftKey || event.which !== 1) {
+				return;
+			}
+
+			event.preventDefault();
+			this.show_attachment_preview(attachment, file_url);
+		});
+	}
+
+	setup_preview_area() {
+		if (this.attachment_preview) {
+			return;
+		}
+
+		this.attachment_preview = $(`<div class="attachment-preview hidden"></div>`).appendTo(
+			this.frm.page.sidebar
+		);
+	}
+
+	show_attachment_preview(attachment, file_url) {
+		this.setup_preview_area();
+
+		let file_name = attachment.file_name || file_url;
+		let preview_type = this.get_preview_type(attachment, file_url);
+		let escaped_file_name = frappe.utils.escape_html(file_name);
+		let escaped_file_url = frappe.utils.escape_html(file_url);
+		let preview_html = "";
+
+		if (preview_type === "pdf") {
+			preview_html = `<iframe src="${escaped_file_url}" title="${escaped_file_name}"></iframe>`;
+		} else if (preview_type === "image") {
+			preview_html = `<img src="${escaped_file_url}" alt="${escaped_file_name}" loading="lazy">`;
+		} else {
+			preview_html = `<div class="attachment-preview-unavailable">
+				<div class="text-muted">${__("Preview not available for this file type.")}</div>
+				<a class="btn btn-default btn-sm" href="${escaped_file_url}" target="_blank" rel="noopener noreferrer">
+					<span>${__("Open file")}</span>
+					${frappe.utils.icon("es-line-arrow-up-right", "xs", "", "", "ml-1")}
+				</a>
+			</div>`;
+		}
+
+		this.current_attachment_preview_type = preview_type;
+		this.set_preview_width(this.attachment_preview_width);
+		this.frm.page.wrapper.addClass("attachment-preview-open");
+
+		this.attachment_preview.removeClass("hidden").html(
+			`<div class="attachment-preview-resize-handle"></div>
+				<div class="attachment-preview-header">
+					<div class="ellipsis" title="${escaped_file_name}">${escaped_file_name}</div>
+					<button class="btn btn-link icon-btn attachment-preview-close" type="button" title="${__(
+						"Close"
+					)}">
+						${frappe.utils.icon("close", "sm")}
+					</button>
+				</div>
+				<div class="attachment-preview-body">
+					${preview_html}
+				</div>`
+		);
+
+		this.attachment_preview.find(".attachment-preview-close").on("click", () => {
+			this.hide_attachment_preview();
+		});
+
+		this.attachment_preview
+			.find(".attachment-preview-resize-handle")
+			.on("mousedown", (event) => {
+				if (event.target !== event.currentTarget) {
+					return;
+				}
+
+				this.start_preview_resize(event);
+			});
+	}
+
+	get_preview_type(attachment, file_url) {
+		let file_type = (attachment.file_type || "").toLowerCase();
+		let file_name = (attachment.file_name || file_url || "").split("?")[0].toLowerCase();
+		let image_extensions = ["jpg", "jpeg", "png", "gif", "webp", "svg", "avif", "bmp", "ico"];
+		let extension = file_name.includes(".") ? file_name.split(".").pop() : "";
+
+		if (file_type.includes("pdf") || extension === "pdf") {
+			return "pdf";
+		}
+
+		if (
+			file_type.includes("image") ||
+			image_extensions.includes(file_type) ||
+			image_extensions.includes(extension)
+		) {
+			return "image";
+		}
+
+		return "unsupported";
+	}
+
+	hide_attachment_preview() {
+		this.attachment_preview?.addClass("hidden").empty();
+		this.frm.page.wrapper.removeClass("attachment-preview-open");
+	}
+
+	start_preview_resize(event) {
+		event.preventDefault();
+
+		this.is_resizing_attachment_preview = true;
+		this.frm.page.wrapper.addClass("attachment-preview-resizing");
+
+		if (this.current_attachment_preview_type === "pdf") {
+			this.attachment_preview.addClass("attachment-preview-resizing-pdf");
+		}
+
+		$(document)
+			.on("mousemove.attachment_preview", (event) => {
+				this.resize_preview(event);
+			})
+			.on("mouseup.attachment_preview", () => {
+				this.stop_preview_resize();
+			});
+	}
+
+	resize_preview(event) {
+		if (!this.is_resizing_attachment_preview) {
+			return;
+		}
+
+		let layout = this.frm.page.wrapper.find(".layout-main").get(0);
+		if (!layout) {
+			return;
+		}
+
+		let layout_rect = layout.getBoundingClientRect();
+		let preview_width = ((layout_rect.right - event.clientX) / layout_rect.width) * 100;
+
+		this.set_preview_width(preview_width);
+	}
+
+	stop_preview_resize() {
+		if (!this.is_resizing_attachment_preview) {
+			return;
+		}
+
+		this.is_resizing_attachment_preview = false;
+		this.frm.page.wrapper.removeClass("attachment-preview-resizing");
+		this.attachment_preview?.removeClass("attachment-preview-resizing-pdf");
+		$(document).off(".attachment_preview");
+	}
+
+	set_preview_width(width) {
+		let min_preview_width = 25;
+		let max_preview_width = 60; // Keeps the form at a minimum width of 40%.
+		let preview_width = Math.min(Math.max(width, min_preview_width), max_preview_width);
+
+		this.attachment_preview_width = preview_width;
+		this.frm.page.wrapper
+			.get(0)
+			?.style.setProperty("--attachment-preview-width", `${preview_width}%`);
 	}
 
 	can_delete_attachment() {

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -256,7 +256,7 @@ frappe.ui.form.Attachments = class Attachments {
 			});
 
 		if (preview_type === "csv") {
-			this.render_csv_preview(file_url, escaped_file_url, preview_request_id);
+			this.render_csv_preview(attachment, file_url, escaped_file_url, preview_request_id);
 		}
 	}
 
@@ -298,8 +298,13 @@ frappe.ui.form.Attachments = class Attachments {
 		</div>`;
 	}
 
-	async render_csv_preview(file_url, escaped_file_url, preview_request_id) {
+	async render_csv_preview(attachment, file_url, escaped_file_url, preview_request_id) {
 		try {
+			let file_size = Number(attachment.file_size);
+			if (file_size && file_size > this.max_csv_preview_size) {
+				throw this.get_csv_size_error();
+			}
+
 			let response = await fetch(file_url);
 			if (!response.ok) {
 				throw new Error("Unable to fetch CSV");
@@ -335,7 +340,9 @@ frappe.ui.form.Attachments = class Attachments {
 					this.get_unsupported_preview_html(
 						escaped_file_url,
 						error.code === "CSV_PREVIEW_TOO_LARGE"
-							? __("File is too large to preview.")
+							? __("Only files up to {0} MB are supported for preview.", [
+									this.max_csv_preview_size / (1024 * 1024),
+							  ])
 							: __("Preview not available for this file type.")
 					)
 				);
@@ -343,22 +350,12 @@ frappe.ui.form.Attachments = class Attachments {
 	}
 
 	async get_csv_response_text(response) {
-		let content_length = Number(response.headers.get("content-length"));
-		if (content_length && content_length > this.max_csv_preview_size) {
-			throw this.get_csv_size_error();
-		}
-
 		if (!response.body?.getReader) {
-			let csv_text = await response.text();
-			if (new TextEncoder().encode(csv_text).length > this.max_csv_preview_size) {
-				throw this.get_csv_size_error();
-			}
-			return csv_text;
+			return await response.text();
 		}
 
 		let reader = response.body.getReader();
 		let decoder = new TextDecoder();
-		let received_length = 0;
 		let csv_text = "";
 		let is_done = false;
 
@@ -369,11 +366,6 @@ frappe.ui.form.Attachments = class Attachments {
 				break;
 			}
 
-			received_length += value.length;
-			if (received_length > this.max_csv_preview_size) {
-				await reader.cancel();
-				throw this.get_csv_size_error();
-			}
 			csv_text += decoder.decode(value, { stream: true });
 		}
 

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -334,7 +334,7 @@ frappe.ui.form.Attachments = class Attachments {
 				throw this.get_csv_size_error();
 			}
 
-			let rows = this.parse_csv(csv_text);
+			let rows = frappe.utils.csv_to_array(csv_text);
 			if (!rows.length) {
 				throw new Error("Empty CSV");
 			}
@@ -376,45 +376,6 @@ frappe.ui.form.Attachments = class Attachments {
 		let error = new Error("CSV exceeds preview size limit");
 		error.code = "CSV_PREVIEW_TOO_LARGE";
 		return error;
-	}
-
-	parse_csv(csv_text) {
-		let rows = [[]];
-		let field = "";
-		let in_quotes = false;
-
-		for (let i = 0; i < csv_text.length; i++) {
-			let ch = csv_text[i];
-
-			if (in_quotes) {
-				if (ch === '"' && csv_text[i + 1] === '"') {
-					field += '"';
-					i++;
-				} else if (ch === '"') {
-					in_quotes = false;
-				} else {
-					field += ch;
-				}
-			} else if (ch === '"') {
-				in_quotes = true;
-			} else if (ch === ",") {
-				rows[rows.length - 1].push(field);
-				field = "";
-			} else if (ch === "\r" || ch === "\n") {
-				if (ch === "\r" && csv_text[i + 1] === "\n") i++;
-				rows[rows.length - 1].push(field);
-				field = "";
-				rows.push([]);
-			} else {
-				field += ch;
-			}
-		}
-
-		if (field.length || rows[rows.length - 1].length) {
-			rows[rows.length - 1].push(field);
-		}
-
-		return rows.filter((row) => row.some((cell) => cell.length));
 	}
 
 	get_csv_preview_html(rows) {

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -212,13 +212,14 @@ frappe.ui.form.Attachments = class Attachments {
 				<div class="attachment-preview-header">
 					<div class="attachment-preview-title">
 						<div class="ellipsis" title="${escaped_file_name}">${escaped_file_name}</div>
+					</div>
+					<div class="attachment-preview-actions">
 						<a class="btn btn-link icon-btn attachment-preview-open-link"
 							href="${escaped_file_url}" target="_blank" rel="noopener noreferrer"
 							title="${__("Open file in new tab")}"
 						>
 							${frappe.utils.icon("es-line-arrow-up-right", "sm")}
 						</a>
-						<span class="attachment-preview-title-divider"></span>
 						<button class="btn btn-link icon-btn attachment-preview-copy-link"
 							type="button"
 							data-file-url="${escaped_absolute_file_url}"
@@ -227,12 +228,13 @@ frappe.ui.form.Attachments = class Attachments {
 						>
 							${frappe.utils.icon("es-line-copy", "sm")}
 						</button>
+						<span class="attachment-preview-title-divider"></span>
+						<button class="btn btn-link icon-btn attachment-preview-close" type="button" title="${__(
+							"Close"
+						)}">
+							${frappe.utils.icon("es-line-close", "sm")}
+						</button>
 					</div>
-					<button class="btn btn-link icon-btn attachment-preview-close" type="button" title="${__(
-						"Close"
-					)}">
-						${frappe.utils.icon("es-line-close", "sm")}
-					</button>
 				</div>
 				<div class="attachment-preview-body">
 					${preview_html}

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -379,10 +379,42 @@ frappe.ui.form.Attachments = class Attachments {
 	}
 
 	parse_csv(csv_text) {
-		return csv_text
-			.split(/\r?\n/)
-			.filter((line) => line.length)
-			.map((line) => line.split(","));
+		let rows = [[]];
+		let field = "";
+		let in_quotes = false;
+
+		for (let i = 0; i < csv_text.length; i++) {
+			let ch = csv_text[i];
+
+			if (in_quotes) {
+				if (ch === '"' && csv_text[i + 1] === '"') {
+					field += '"';
+					i++;
+				} else if (ch === '"') {
+					in_quotes = false;
+				} else {
+					field += ch;
+				}
+			} else if (ch === '"') {
+				in_quotes = true;
+			} else if (ch === ",") {
+				rows[rows.length - 1].push(field);
+				field = "";
+			} else if (ch === "\r" || ch === "\n") {
+				if (ch === "\r" && csv_text[i + 1] === "\n") i++;
+				rows[rows.length - 1].push(field);
+				field = "";
+				rows.push([]);
+			} else {
+				field += ch;
+			}
+		}
+
+		if (field.length || rows[rows.length - 1].length) {
+			rows[rows.length - 1].push(field);
+		}
+
+		return rows.filter((row) => row.some((cell) => cell.length));
 	}
 
 	get_csv_preview_html(rows) {

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -6,7 +6,9 @@ frappe.ui.form.Attachments = class Attachments {
 
 		this.attachments_page_length = 10; // show n attachments initially
 		this.show_all_attachments = false;
-		this.attachment_preview_width = 40;
+		this.attachment_preview_width_key = "form_attachment_preview_width";
+		this.max_csv_preview_size = 5 * 1024 * 1024;
+		this.attachment_preview_width = this.get_stored_preview_width();
 
 		this.make();
 	}
@@ -158,7 +160,7 @@ frappe.ui.form.Attachments = class Attachments {
 			.insertAfter(this.add_attachment_wrapper);
 
 		$attachment_row.find(".attachment-file-label").on("click", (event) => {
-			if (event.metaKey || event.ctrlKey || event.shiftKey || event.which !== 1) {
+			if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0) {
 				return;
 			}
 
@@ -178,8 +180,6 @@ frappe.ui.form.Attachments = class Attachments {
 	}
 
 	show_attachment_preview(attachment, file_url) {
-		this.setup_preview_area();
-
 		let file_name = attachment.file_name || file_url;
 		let preview_type = this.get_preview_type(attachment, file_url);
 		let escaped_file_name = frappe.utils.escape_html(file_name);
@@ -215,7 +215,7 @@ frappe.ui.form.Attachments = class Attachments {
 				<div class="attachment-preview-header">
 					<div class="attachment-preview-title">
 						<div class="ellipsis" title="${escaped_file_name}">${escaped_file_name}</div>
-						<a class="btn btn-link icon-btn attachment-preview-open"
+						<a class="btn btn-link icon-btn attachment-preview-open-link"
 							href="${escaped_file_url}" target="_blank" rel="noopener noreferrer"
 							title="${__("Open in new tab")}"
 						>
@@ -236,6 +236,14 @@ frappe.ui.form.Attachments = class Attachments {
 		this.attachment_preview.find(".attachment-preview-close").on("click", () => {
 			this.hide_attachment_preview();
 		});
+
+		$(document)
+			.off("keydown.attachment_preview")
+			.on("keydown.attachment_preview", (event) => {
+				if (event.key === "Escape") {
+					this.hide_attachment_preview();
+				}
+			});
 
 		this.attachment_preview
 			.find(".attachment-preview-resize-handle")
@@ -277,9 +285,12 @@ frappe.ui.form.Attachments = class Attachments {
 		return "unsupported";
 	}
 
-	get_unsupported_preview_html(file_url) {
+	get_unsupported_preview_html(
+		file_url,
+		message = __("Preview not available for this file type.")
+	) {
 		return `<div class="attachment-preview-unavailable">
-			<div class="text-muted">${__("Preview not available for this file type.")}</div>
+			<div class="text-muted">${frappe.utils.escape_html(message)}</div>
 			<a class="btn btn-default btn-sm" href="${file_url}" target="_blank" rel="noopener noreferrer">
 				<span>${__("Open file")}</span>
 				${frappe.utils.icon("es-line-arrow-up-right", "xs", "", "", "ml-1")}
@@ -294,7 +305,7 @@ frappe.ui.form.Attachments = class Attachments {
 				throw new Error("Unable to fetch CSV");
 			}
 
-			let csv_text = await response.text();
+			let csv_text = await this.get_csv_response_text(response);
 			let rows = this.parse_csv(csv_text);
 			if (!rows.length) {
 				throw new Error("Empty CSV");
@@ -320,8 +331,59 @@ frappe.ui.form.Attachments = class Attachments {
 
 			this.attachment_preview
 				.find(".attachment-preview-body")
-				.html(this.get_unsupported_preview_html(escaped_file_url));
+				.html(
+					this.get_unsupported_preview_html(
+						escaped_file_url,
+						error.code === "CSV_PREVIEW_TOO_LARGE"
+							? __("File is too large to preview.")
+							: __("Preview not available for this file type.")
+					)
+				);
 		}
+	}
+
+	async get_csv_response_text(response) {
+		let content_length = Number(response.headers.get("content-length"));
+		if (content_length && content_length > this.max_csv_preview_size) {
+			throw this.get_csv_size_error();
+		}
+
+		if (!response.body?.getReader) {
+			let csv_text = await response.text();
+			if (new TextEncoder().encode(csv_text).length > this.max_csv_preview_size) {
+				throw this.get_csv_size_error();
+			}
+			return csv_text;
+		}
+
+		let reader = response.body.getReader();
+		let decoder = new TextDecoder();
+		let received_length = 0;
+		let csv_text = "";
+		let is_done = false;
+
+		while (!is_done) {
+			let { done, value } = await reader.read();
+			is_done = done;
+			if (done) {
+				break;
+			}
+
+			received_length += value.length;
+			if (received_length > this.max_csv_preview_size) {
+				await reader.cancel();
+				throw this.get_csv_size_error();
+			}
+			csv_text += decoder.decode(value, { stream: true });
+		}
+
+		return csv_text + decoder.decode();
+	}
+
+	get_csv_size_error() {
+		let error = new Error("CSV exceeds preview size limit");
+		error.code = "CSV_PREVIEW_TOO_LARGE";
+		return error;
 	}
 
 	parse_csv(csv_text) {
@@ -388,15 +450,17 @@ frappe.ui.form.Attachments = class Attachments {
 	get_csv_preview_html(rows) {
 		let max_rows = 100;
 		let max_columns = 20;
-		let visible_rows = rows.slice(0, max_rows);
-		let total_rows = rows.length;
+		let header_row = rows[0];
+		let data_rows = rows.slice(1);
+		let visible_rows = data_rows.slice(0, max_rows);
+		let total_rows = data_rows.length;
 		let total_columns = rows.reduce((max, row) => Math.max(max, row.length), 0);
 		let visible_column_count = Math.min(total_columns, max_columns);
 		let visible_row_count = visible_rows.length;
 		let is_row_truncated = total_rows > max_rows;
 		let is_column_truncated = total_columns > max_columns;
 
-		let get_cell_html = (value = "") => {
+		let get_cell_html = (value = "", tag = "td") => {
 			let cell_value = String(value);
 			let max_cell_length = 200;
 			let max_title_length = 1000;
@@ -409,8 +473,13 @@ frappe.ui.form.Attachments = class Attachments {
 					? ` title="${frappe.utils.escape_html(cell_value)}"`
 					: "";
 
-			return `<td${title}>${frappe.utils.escape_html(display_value)}</td>`;
+			return `<${tag}${title}>${frappe.utils.escape_html(display_value)}</${tag}>`;
 		};
+
+		let table_headers = [];
+		for (let i = 0; i < visible_column_count; i++) {
+			table_headers.push(get_cell_html(header_row[i] || "", "th"));
+		}
 
 		let table_rows = visible_rows
 			.map((row) => {
@@ -446,6 +515,7 @@ frappe.ui.form.Attachments = class Attachments {
 		return `<div class="attachment-preview-csv">
 			<div class="attachment-preview-csv-table">
 				<table class="table table-bordered">
+					<thead><tr>${table_headers.join("")}</tr></thead>
 					<tbody>${table_rows}</tbody>
 				</table>
 			</div>
@@ -457,6 +527,7 @@ frappe.ui.form.Attachments = class Attachments {
 		this.attachment_preview?.addClass("hidden").empty();
 		this.frm.page.wrapper.removeClass("attachment-preview-open");
 		this.attachment_preview_request_id = (this.attachment_preview_request_id || 0) + 1;
+		$(document).off("keydown.attachment_preview");
 	}
 
 	start_preview_resize(event) {
@@ -470,10 +541,10 @@ frappe.ui.form.Attachments = class Attachments {
 		}
 
 		$(document)
-			.on("mousemove.attachment_preview", (event) => {
+			.on("mousemove.attachment_preview_resize", (event) => {
 				this.resize_preview(event);
 			})
-			.on("mouseup.attachment_preview", () => {
+			.on("mouseup.attachment_preview_resize", () => {
 				this.stop_preview_resize();
 			});
 	}
@@ -502,18 +573,40 @@ frappe.ui.form.Attachments = class Attachments {
 		this.is_resizing_attachment_preview = false;
 		this.frm.page.wrapper.removeClass("attachment-preview-resizing");
 		this.attachment_preview?.removeClass("attachment-preview-resizing-pdf");
-		$(document).off(".attachment_preview");
+		$(document).off(".attachment_preview_resize");
+		this.save_preview_width();
 	}
 
 	set_preview_width(width) {
-		let min_preview_width = 25;
-		let max_preview_width = 60; // Keeps the form at a minimum width of 40%.
-		let preview_width = Math.min(Math.max(width, min_preview_width), max_preview_width);
+		let preview_width = this.clamp_preview_width(width);
 
 		this.attachment_preview_width = preview_width;
 		this.frm.page.wrapper
 			.get(0)
 			?.style.setProperty("--attachment-preview-width", `${preview_width}%`);
+	}
+
+	clamp_preview_width(width) {
+		let min_preview_width = 25;
+		let max_preview_width = 60; // Keeps the form at a minimum width of 40%.
+		return Math.min(Math.max(width, min_preview_width), max_preview_width);
+	}
+
+	get_stored_preview_width() {
+		try {
+			let stored_width = Number(localStorage.getItem(this.attachment_preview_width_key));
+			return this.clamp_preview_width(stored_width || 40);
+		} catch {
+			return 40;
+		}
+	}
+
+	save_preview_width() {
+		try {
+			localStorage.setItem(this.attachment_preview_width_key, this.attachment_preview_width);
+		} catch {
+			// localStorage can be unavailable in restricted browser contexts.
+		}
 	}
 
 	can_delete_attachment() {

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -184,6 +184,9 @@ frappe.ui.form.Attachments = class Attachments {
 		let preview_type = this.get_preview_type(attachment, file_url);
 		let escaped_file_name = frappe.utils.escape_html(file_name);
 		let escaped_file_url = frappe.utils.escape_html(file_url);
+		let escaped_absolute_file_url = frappe.utils.escape_html(
+			this.get_absolute_file_url(file_url)
+		);
 		let preview_html = "";
 
 		if (preview_type === "pdf") {
@@ -217,10 +220,19 @@ frappe.ui.form.Attachments = class Attachments {
 						<div class="ellipsis" title="${escaped_file_name}">${escaped_file_name}</div>
 						<a class="btn btn-link icon-btn attachment-preview-open-link"
 							href="${escaped_file_url}" target="_blank" rel="noopener noreferrer"
-							title="${__("Open in new tab")}"
+							title="${__("Open file in new tab")}"
 						>
 							${frappe.utils.icon("es-line-arrow-up-right", "sm")}
 						</a>
+						<span class="attachment-preview-title-divider"></span>
+						<button class="btn btn-link icon-btn attachment-preview-copy-link"
+							type="button"
+							data-file-url="${escaped_absolute_file_url}"
+							title="${__("Copy file URL to clipboard")}"
+							aria-label="${__("Copy file URL to clipboard")}"
+						>
+							${frappe.utils.icon("es-line-copy", "sm")}
+						</button>
 					</div>
 					<button class="btn btn-link icon-btn attachment-preview-close" type="button" title="${__(
 						"Close"
@@ -235,6 +247,10 @@ frappe.ui.form.Attachments = class Attachments {
 
 		this.attachment_preview.find(".attachment-preview-close").on("click", () => {
 			this.hide_attachment_preview();
+		});
+
+		this.attachment_preview.find(".attachment-preview-copy-link").on("click", (event) => {
+			frappe.utils.copy_to_clipboard(event.currentTarget.dataset.fileUrl);
 		});
 
 		$(document)
@@ -638,6 +654,15 @@ frappe.ui.form.Attachments = class Attachments {
 
 		return file_url;
 	}
+
+	get_absolute_file_url(file_url) {
+		try {
+			return new URL(file_url, window.location.origin).href;
+		} catch {
+			return file_url;
+		}
+	}
+
 	get_file_id_from_file_url(file_url) {
 		var fid;
 		$.each(this.get_attachments(), function (i, attachment) {

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -324,7 +324,16 @@ frappe.ui.form.Attachments = class Attachments {
 				throw new Error("Unable to fetch CSV");
 			}
 
-			let csv_text = await this.get_csv_response_text(response);
+			let content_length = Number(response.headers.get("Content-Length"));
+			if (content_length > this.max_csv_preview_size) {
+				throw this.get_csv_size_error();
+			}
+
+			let csv_text = await response.text();
+			if (csv_text.length > this.max_csv_preview_size) {
+				throw this.get_csv_size_error();
+			}
+
 			let rows = this.parse_csv(csv_text);
 			if (!rows.length) {
 				throw new Error("Empty CSV");
@@ -363,35 +372,6 @@ frappe.ui.form.Attachments = class Attachments {
 		}
 	}
 
-	async get_csv_response_text(response) {
-		if (!response.body?.getReader) {
-			let text = await response.text();
-			if (text.length > this.max_csv_preview_size) {
-				throw this.get_csv_size_error();
-			}
-			return text;
-		}
-
-		let reader = response.body.getReader();
-		let decoder = new TextDecoder();
-		let csv_text = "";
-		let bytes_read = 0;
-		let { done, value } = await reader.read();
-
-		while (!done) {
-			bytes_read += value.byteLength;
-			if (bytes_read > this.max_csv_preview_size) {
-				reader.cancel();
-				throw this.get_csv_size_error();
-			}
-
-			csv_text += decoder.decode(value, { stream: true });
-			({ done, value } = await reader.read());
-		}
-
-		return csv_text + decoder.decode();
-	}
-
 	get_csv_size_error() {
 		let error = new Error("CSV exceeds preview size limit");
 		error.code = "CSV_PREVIEW_TOO_LARGE";
@@ -399,64 +379,10 @@ frappe.ui.form.Attachments = class Attachments {
 	}
 
 	parse_csv(csv_text) {
-		let rows = [];
-		let row = [];
-		let value = "";
-		let in_quotes = false;
-
-		let push_value = () => {
-			row.push(value);
-			value = "";
-		};
-
-		let push_row = () => {
-			push_value();
-			rows.push(row);
-			row = [];
-		};
-
-		for (let i = 0; i < csv_text.length; i++) {
-			let character = csv_text[i];
-
-			if (in_quotes) {
-				if (character === '"') {
-					if (csv_text[i + 1] === '"') {
-						value += '"';
-						i++;
-					} else {
-						in_quotes = false;
-					}
-				} else {
-					value += character;
-				}
-				continue;
-			}
-
-			if (character === '"') {
-				in_quotes = true;
-			} else if (character === ",") {
-				push_value();
-			} else if (character === "\n") {
-				push_row();
-			} else if (character === "\r") {
-				if (csv_text[i + 1] === "\n") {
-					i++;
-				}
-				push_row();
-			} else {
-				value += character;
-			}
-		}
-
-		if (in_quotes) {
-			throw new Error("Unclosed quoted field");
-		}
-
-		if (value.length || row.length) {
-			push_row();
-		}
-
-		return rows;
+		return csv_text
+			.split(/\r?\n/)
+			.filter((line) => line.length)
+			.map((line) => line.split(","));
 	}
 
 	get_csv_preview_html(rows) {

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -573,6 +573,12 @@ body[data-route^="Form"] .attachment-preview {
 		min-width: 0;
 	}
 
+	.attachment-preview-title-divider {
+		width: 1px;
+		height: 16px;
+		background-color: var(--border-color);
+	}
+
 	.attachment-preview-body {
 		position: relative;
 		height: calc(100% - 41px);

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -566,6 +566,13 @@ body[data-route^="Form"] .attachment-preview {
 		border-bottom: 1px solid var(--border-color);
 	}
 
+	.attachment-preview-title {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		min-width: 0;
+	}
+
 	.attachment-preview-body {
 		position: relative;
 		height: calc(100% - 41px);
@@ -584,6 +591,36 @@ body[data-route^="Form"] .attachment-preview {
 		img {
 			object-fit: contain;
 		}
+	}
+
+	.attachment-preview-loading {
+		padding: var(--padding-md);
+	}
+
+	.attachment-preview-csv {
+		width: 100%;
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.attachment-preview-csv-table {
+		flex: 1;
+		overflow: auto;
+
+		table {
+			margin: 0;
+			background-color: var(--fg-color);
+		}
+
+		td {
+			white-space: nowrap;
+		}
+	}
+
+	.attachment-preview-note {
+		padding: var(--padding-sm) var(--padding-md);
+		border-top: 1px solid var(--border-color);
 	}
 
 	.attachment-preview-unavailable {

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -555,9 +555,12 @@ body[data-route^="Form"] {
 body[data-route^="Form"] .attachment-preview {
 	overflow: hidden;
 	position: relative;
+	display: flex;
+	flex-direction: column;
 	background-color: var(--fg-color);
 
 	.attachment-preview-header {
+		flex-shrink: 0;
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
@@ -581,7 +584,8 @@ body[data-route^="Form"] .attachment-preview {
 
 	.attachment-preview-body {
 		position: relative;
-		height: calc(100% - 41px);
+		flex: 1;
+		min-height: 0;
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -643,19 +647,19 @@ body[data-route^="Form"] .attachment-preview {
 		iframe {
 			visibility: hidden;
 		}
+	}
 
-		.attachment-preview-body::after {
-			content: "Resizing preview...";
-			position: absolute;
-			top: 50%;
-			left: 50%;
-			transform: translate(-50%, -50%);
-			color: var(--text-muted);
-			background-color: var(--bg-color);
-			padding: var(--padding-sm) var(--padding-md);
-			border: 1px solid var(--border-color);
-			border-radius: var(--border-radius);
-		}
+	.attachment-preview-resize-overlay {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		color: var(--text-muted);
+		background-color: var(--bg-color);
+		padding: var(--padding-sm) var(--padding-md);
+		border: 1px solid var(--border-color);
+		border-radius: var(--border-radius);
+		pointer-events: none;
 	}
 
 	.attachment-preview-resize-handle {

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -558,6 +558,7 @@ body[data-route^="Form"] .attachment-preview {
 	display: flex;
 	flex-direction: column;
 	background-color: var(--fg-color);
+	border-left: 1px solid var(--border-color);
 
 	.attachment-preview-header {
 		flex-shrink: 0;
@@ -566,6 +567,7 @@ body[data-route^="Form"] .attachment-preview {
 		justify-content: space-between;
 		gap: 8px;
 		padding: 6px 8px;
+		background-color: var(--subtle-fg);
 		border-bottom: 1px solid var(--border-color);
 	}
 
@@ -589,17 +591,22 @@ body[data-route^="Form"] .attachment-preview {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		background-color: var(--bg-color);
+		background-color: var(--subtle-fg);
 
-		iframe,
-		img {
+		iframe {
 			width: 100%;
 			height: 100%;
 			border: 0;
 		}
 
 		img {
-			object-fit: contain;
+			max-width: calc(100% - 32px);
+			max-height: calc(100% - 32px);
+			width: auto;
+			height: auto;
+			border: 0;
+			border-radius: var(--border-radius-sm);
+			box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
 		}
 	}
 
@@ -612,6 +619,7 @@ body[data-route^="Form"] .attachment-preview {
 		height: 100%;
 		display: flex;
 		flex-direction: column;
+		background-color: var(--fg-color);
 	}
 
 	.attachment-preview-csv-table {

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -287,6 +287,10 @@ body[data-route^="Form"] {
 		.attachment-preview {
 			height: 100%;
 		}
+
+		&:focus {
+			outline: none;
+		}
 	}
 
 	.attachment-preview-open {
@@ -559,6 +563,7 @@ body[data-route^="Form"] .attachment-preview {
 	flex-direction: column;
 	background-color: var(--fg-color);
 	border-left: 1px solid var(--border-color);
+	outline: none;
 
 	.attachment-preview-header {
 		flex-shrink: 0;
@@ -585,13 +590,17 @@ body[data-route^="Form"] .attachment-preview {
 		align-items: center;
 		gap: 2px;
 		flex-shrink: 0;
-	}
 
-	.attachment-preview-title-divider {
-		width: 1px;
-		height: 16px;
-		margin: 0 4px;
-		background-color: var(--border-color);
+		.btn-link {
+			text-decoration: none;
+
+			&:hover,
+			&:focus {
+				text-decoration: none;
+				outline: none;
+				box-shadow: none;
+			}
+		}
 	}
 
 	.attachment-preview-body {

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -613,6 +613,7 @@ body[data-route^="Form"] .attachment-preview {
 			background-color: var(--fg-color);
 		}
 
+		th,
 		td {
 			white-space: nowrap;
 		}

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -566,21 +566,31 @@ body[data-route^="Form"] .attachment-preview {
 		align-items: center;
 		justify-content: space-between;
 		gap: 8px;
-		padding: 6px 8px;
+		padding: 0 8px 0 12px;
+		height: 40px;
 		background-color: var(--subtle-fg);
 		border-bottom: 1px solid var(--border-color);
 	}
 
 	.attachment-preview-title {
+		flex: 1;
+		min-width: 0;
+		font-size: var(--text-sm);
+		font-weight: 500;
+		color: var(--text-color);
+	}
+
+	.attachment-preview-actions {
 		display: flex;
 		align-items: center;
-		gap: 4px;
-		min-width: 0;
+		gap: 2px;
+		flex-shrink: 0;
 	}
 
 	.attachment-preview-title-divider {
 		width: 1px;
 		height: 16px;
+		margin: 0 4px;
 		background-color: var(--border-color);
 	}
 
@@ -597,6 +607,7 @@ body[data-route^="Form"] .attachment-preview {
 			width: 100%;
 			height: 100%;
 			border: 0;
+			outline: none;
 		}
 
 		img {

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -283,6 +283,32 @@ body[data-route^="Form"] {
 		@media (max-width: 991px) {
 			position: relative;
 		}
+
+		.attachment-preview {
+			height: 100%;
+		}
+	}
+
+	.attachment-preview-open {
+		.layout-main-section-wrapper {
+			flex: 1 1 calc(100% - var(--attachment-preview-width));
+			width: calc(100% - var(--attachment-preview-width));
+			min-width: 0;
+		}
+
+		.layout-side-section {
+			flex: 0 0 var(--attachment-preview-width);
+			width: var(--attachment-preview-width);
+			min-width: var(--attachment-preview-width);
+		}
+
+		.form-sidebar {
+			display: none !important;
+		}
+	}
+
+	.attachment-preview-resizing {
+		cursor: col-resize;
 	}
 }
 
@@ -523,6 +549,85 @@ body[data-route^="Form"] {
 	// without affecting empty state
 	.attachments-actions + .attachment-row {
 		margin-top: 8px;
+	}
+}
+
+body[data-route^="Form"] .attachment-preview {
+	overflow: hidden;
+	position: relative;
+	background-color: var(--fg-color);
+
+	.attachment-preview-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		padding: 6px 8px;
+		border-bottom: 1px solid var(--border-color);
+	}
+
+	.attachment-preview-body {
+		position: relative;
+		height: calc(100% - 41px);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background-color: var(--bg-color);
+
+		iframe,
+		img {
+			width: 100%;
+			height: 100%;
+			border: 0;
+		}
+
+		img {
+			object-fit: contain;
+		}
+	}
+
+	.attachment-preview-unavailable {
+		padding: var(--padding-md);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--margin-sm);
+		text-align: center;
+	}
+
+	&.attachment-preview-resizing-pdf {
+		iframe {
+			visibility: hidden;
+		}
+
+		.attachment-preview-body::after {
+			content: "Resizing preview...";
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			transform: translate(-50%, -50%);
+			color: var(--text-muted);
+			background-color: var(--bg-color);
+			padding: var(--padding-sm) var(--padding-md);
+			border: 1px solid var(--border-color);
+			border-radius: var(--border-radius);
+		}
+	}
+
+	.attachment-preview-resize-handle {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 3px;
+		height: 100%;
+		cursor: col-resize;
+		z-index: 1;
+		background-color: var(--border-color);
+		transition: background-color 120ms ease;
+
+		&:hover {
+			background-color: var(--primary-color);
+		}
 	}
 }
 

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -702,7 +702,7 @@ body[data-route^="Form"] .attachment-preview {
 		transition: background-color 120ms ease;
 
 		&:hover {
-			background-color: var(--primary-color);
+			background-color: var(--gray-400);
 		}
 	}
 }


### PR DESCRIPTION
## What changed

Adds an attachment preview pane in the form sidebar for image and PDF attachments. Clicking an attachment opens a resizable preview area with a close control, while unsupported attachment types show an unavailable state with a direct open-file action.

## Why

This lets users inspect common attachment types directly from the form without navigating away from the document.

## Validation

- Ran `git diff --check -- frappe/public/js/frappe/form/sidebar/attachments.js frappe/public/scss/desk/form_sidebar.scss`.


https://github.com/user-attachments/assets/68962e03-e744-4f60-94d9-fbe381275934



`no-docs`