### PR TITLE
feat: @framework/ui package for shared vue components and utilities

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,87 @@
+# framework-ui
+
+Shared Vue components and utilities for Frappe apps that depend on the backend. This is an extension of frappe-ui for framework specific components that all apps need. Lives at `frappe/ui` in framework and is consumed by other apps (studio, builder, hrms, …) as a local package - **never published to npm**.
+
+Code is shipped as raw `.vue`/`.ts` source (no build step) and compiled by the consuming app's bundler, exactly like `frappe-ui`. `vue`, `vue-router` and `frappe-ui` are **peer dependencies** so the host app's single copy of each is reused — this avoids
+duplicate Vue instances and mismatched router contexts.
+
+## Consuming this package from another Frappe app
+
+Frappe apps are independent git repos sitting side by side under the bench `apps/`
+folder, so the package is linked by **relative path** using yarn's `link:` protocol
+(a symlink — not `file:`, not a registry install). Three small changes in the
+consuming frontend:
+
+### 1. Declare the dependency — `package.json`
+
+```jsonc
+{
+  "dependencies": {
+    "framework-ui": "link:../../frappe/ui"
+  }
+}
+```
+
+The path is relative to the file's own directory. From `studio/frontend` that is
+`../../frappe/ui`; adjust the `../` depth for your app. Then:
+
+```bash
+yarn install   # creates node_modules/framework-ui -> ../../frappe/ui
+```
+
+### 2. Keep a single Vue / router / frappe-ui — `vite.config.js`
+
+Through a symlink the package's bare `import 'vue'` would otherwise resolve to a second
+copy. Dedupe the singletons to the host app's copy (standard Vite, no custom plugin):
+
+```js
+resolve: {
+  dedupe: ["vue", "vue-router", "frappe-ui"],
+}
+```
+
+### 3. Resolve the import for TypeScript — `tsconfig.json`
+
+`moduleResolution: node` does not read the package `exports` map, so map the specifier
+to source (relative to `baseUrl`):
+
+```jsonc
+"paths": {
+  "framework-ui": ["../../frappe/ui/src/index.ts"],
+  "framework-ui/*": ["../../frappe/ui/src/*"]
+}
+```
+
+The `paths` key must match the package name `framework-ui` (also the key under
+`dependencies`) so the specifier resolves the same way in TypeScript and the bundler.
+
+The host app must already provide the peers (`vue`, `vue-router`, `frappe-ui`) — every
+Frappe frontend does.
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { Link } from 'framework-ui'
+</script>
+
+<template>
+  <Link doctype="User" v-model="owner" />
+</template>
+```
+
+Subpaths work too (via the `./*` export), e.g. `import { Link } from 'framework-ui/components/Link'`.
+
+## Adding to the package
+
+1. Create the component/utility under `src/`.
+2. Re-export it from [`src/index.ts`](src/index.ts) (`export { Foo } from './components/Foo'`).
+
+## Notes & troubleshooting
+
+- **"Failed to resolve import 'framework-ui'"** after a rename or fresh link: re-run
+  `yarn install` and restart the dev server so the new symlink enters Vite's module graph.
+  Also confirm the import specifier matches the package name `framework-ui`.
+- **`vue`/`vue-router`/`frappe-ui` imports inside this package** are resolved by the host
+  app (peers + `resolve.dedupe`), so the package cannot be built or type-checked in
+  isolation — work on it from within a consuming app.

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,4 +1,4 @@
-# framework-ui
+# @framework/ui
 
 Shared Vue components and utilities for Frappe apps that depend on the backend. This is an extension of frappe-ui for framework specific components that all apps need. Lives at `frappe/ui` in framework and is consumed by other apps (studio, builder, hrms, …) as a local package - **never published to npm**.
 
@@ -17,7 +17,7 @@ consuming frontend:
 ```jsonc
 {
   "dependencies": {
-    "framework-ui": "link:../../frappe/ui"
+    "@framework/ui": "link:../../frappe/ui"
   }
 }
 ```
@@ -26,7 +26,7 @@ The path is relative to the file's own directory. From `studio/frontend` that is
 `../../frappe/ui`; adjust the `../` depth for your app. Then:
 
 ```bash
-yarn install   # creates node_modules/framework-ui -> ../../frappe/ui
+yarn install   # creates node_modules/framework/ui -> ../../frappe/ui
 ```
 
 ### 2. Keep a single Vue / router / frappe-ui — `vite.config.js`
@@ -47,12 +47,12 @@ to source (relative to `baseUrl`):
 
 ```jsonc
 "paths": {
-  "framework-ui": ["../../frappe/ui/src/index.ts"],
-  "framework-ui/*": ["../../frappe/ui/src/*"]
+  "@framework/ui": ["../../frappe/ui/src/index.ts"],
+  "@framework/ui/*": ["../../frappe/ui/src/*"]
 }
 ```
 
-The `paths` key must match the package name `framework-ui` (also the key under
+The `paths` key must match the package name `@framework/ui` (also the key under
 `dependencies`) so the specifier resolves the same way in TypeScript and the bundler.
 
 The host app must already provide the peers (`vue`, `vue-router`, `frappe-ui`) — every
@@ -62,7 +62,7 @@ Frappe frontend does.
 
 ```vue
 <script setup lang="ts">
-import { Link } from 'framework-ui'
+import { Link } from '@framework/ui'
 </script>
 
 <template>
@@ -70,7 +70,7 @@ import { Link } from 'framework-ui'
 </template>
 ```
 
-Subpaths work too (via the `./*` export), e.g. `import { Link } from 'framework-ui/components/Link'`.
+Subpaths work too (via the `./*` export), e.g. `import { Link } from '@framework/ui'`.
 
 ## Adding to the package
 
@@ -79,9 +79,9 @@ Subpaths work too (via the `./*` export), e.g. `import { Link } from 'framework-
 
 ## Notes & troubleshooting
 
-- **"Failed to resolve import 'framework-ui'"** after a rename or fresh link: re-run
+- **"Failed to resolve import '@framework/ui'"** after a rename or fresh link: re-run
   `yarn install` and restart the dev server so the new symlink enters Vite's module graph.
-  Also confirm the import specifier matches the package name `framework-ui`.
+  Also confirm the import specifier matches the package name `@framework/ui`.
 - **`vue`/`vue-router`/`frappe-ui` imports inside this package** are resolved by the host
   app (peers + `resolve.dedupe`), so the package cannot be built or type-checked in
   isolation — work on it from within a consuming app.

--- a/ui/README.md
+++ b/ui/README.md
@@ -29,18 +29,7 @@ The path is relative to the file's own directory. From `studio/frontend` that is
 yarn install   # creates node_modules/framework/ui -> ../../frappe/ui
 ```
 
-### 2. Keep a single Vue / router / frappe-ui — `vite.config.js`
-
-Through a symlink the package's bare `import 'vue'` would otherwise resolve to a second
-copy. Dedupe the singletons to the host app's copy (standard Vite, no custom plugin):
-
-```js
-resolve: {
-  dedupe: ["vue", "vue-router", "frappe-ui"],
-}
-```
-
-### 3. Resolve the import for TypeScript — `tsconfig.json`
+### 2. Resolve the import for TypeScript — `tsconfig.json`
 
 `moduleResolution: node` does not read the package `exports` map, so map the specifier
 to source (relative to `baseUrl`):

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "framework-ui",
+  "name": "@framework/ui",
   "version": "0.0.0",
   "description": "Shared client components and utilities for Frappe apps",
   "type": "module",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "framework-ui",
+  "version": "0.0.0",
+  "description": "Shared client components and utilities for Frappe apps",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    },
+    "./*": {
+      "import": "./src/*"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/frappe/frappe.git"
+  },
+  "author": "Frappe Technologies Pvt. Ltd.",
+  "license": "MIT",
+  "peerDependencies": {
+    "frappe-ui": "*",
+    "vue": ">=3.3.0",
+    "vue-router": "^4.1.5"
+  }
+}

--- a/ui/src/components/Link/Link.vue
+++ b/ui/src/components/Link/Link.vue
@@ -1,58 +1,54 @@
 <template>
-	<div data-slot="link" class="contents">
-		<Combobox
-			ref="comboboxRef"
-			v-bind="$attrs"
-			v-model="model"
-			v-model:open="open"
-			class="group !gap-1"
-			:label="label"
-			:description="description"
-			:error="error"
-			:required="required"
-			:id="id"
-			:options="linkOptions"
-			:disabled="disabled"
-			:placeholder="placeholder ?? `Search ${doctype.toLowerCase()}`"
-			:loading="options.loading && !options.data"
-			@update:query="handleInputChange"
-			@focus="() => loadOptions('')"
-		>
-			<template v-for="(_, name) in forwardedSlots" #[name]="slotProps" :key="name">
-				<slot :name="name" v-bind="slotProps" />
-			</template>
+	<Combobox
+		ref="comboboxRef"
+		v-model="model"
+		v-model:open="open"
+		class="group !gap-1"
+		:label="label"
+		:description="description"
+		:error="error"
+		:required="required"
+		:options="linkOptions"
+		:disabled="disabled"
+		:placeholder="placeholder ?? `Search ${doctype.toLowerCase()}`"
+		:loading="options.loading && !options.data"
+		@update:query="handleInputChange"
+		@focus="() => loadOptions('')"
+	>
+		<template v-for="(_, name) in forwardedSlots" #[name]="slotProps" :key="name">
+			<slot :name="name" v-bind="slotProps" />
+		</template>
 
-			<template v-if="slots.suffix" #suffix="suffixProps">
-				<slot name="suffix" v-bind="suffixProps" />
-			</template>
-			<template v-else-if="showClear" #suffix>
-				<button
-					type="button"
-					aria-label="Clear"
-					data-slot="clear"
-					class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
-					@click="clearValue"
-					@pointerdown.stop
-				>
-					<span class="lucide-x size-3.5" />
-				</button>
-			</template>
+		<template v-if="slots.suffix" #suffix="suffixProps">
+			<slot name="suffix" v-bind="suffixProps" />
+		</template>
+		<template v-else-if="showClear" #suffix>
+			<button
+				type="button"
+				aria-label="Clear"
+				data-slot="clear"
+				class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+				@click="clearValue"
+				@pointerdown.stop
+			>
+				<span class="lucide-x size-3.5" />
+			</button>
+		</template>
 
-			<template v-if="slots['item-create']" #item-create="slotProps">
-				<slot name="item-create" v-bind="slotProps" />
-			</template>
-			<template v-else #item-create="{ query }">
-				<div class="flex">
-					<span class="truncate">
-						Create
-						<span v-if="query" class="font-medium text-ink-gray-8">
-							{{ query }}
-						</span>
+		<template v-if="slots['item-create']" #item-create="slotProps">
+			<slot name="item-create" v-bind="slotProps" />
+		</template>
+		<template v-else #item-create="{ query }">
+			<div class="flex">
+				<span class="truncate">
+					Create
+					<span v-if="query" class="font-medium text-ink-gray-8">
+						{{ query }}
 					</span>
-				</div>
-			</template>
-		</Combobox>
-	</div>
+				</span>
+			</div>
+		</template>
+	</Combobox>
 </template>
 
 <script setup lang="ts">
@@ -72,8 +68,6 @@ const open = defineModel<boolean>("open", { default: false });
 const comboboxRef = ref<{ focus: () => void } | null>(null);
 
 const emit = defineEmits<LinkEmits>();
-
-defineOptions({ inheritAttrs: false });
 
 const slots = useSlots();
 
@@ -117,7 +111,7 @@ const linkOptions = computed<ComboboxOption[]>(() => {
 	return _options;
 });
 
-const showClear = computed(() => !props.disabled && !!model.value && !props.required);
+const showClear = computed(() => !props.disabled && !!model.value);
 
 const loadOptions = (txt: string = "") => {
 	options.update({

--- a/ui/src/components/Link/Link.vue
+++ b/ui/src/components/Link/Link.vue
@@ -1,0 +1,148 @@
+<template>
+	<div data-slot="link" class="contents">
+		<Combobox
+			ref="comboboxRef"
+			v-bind="$attrs"
+			v-model="model"
+			v-model:open="open"
+			class="group !gap-1"
+			:label="label"
+			:description="description"
+			:error="error"
+			:required="required"
+			:id="id"
+			:options="linkOptions"
+			:disabled="disabled"
+			:placeholder="placeholder ?? `Search ${doctype.toLowerCase()}`"
+			:loading="options.loading && !options.data"
+			@update:query="handleInputChange"
+			@focus="() => loadOptions('')"
+		>
+			<template v-for="(_, name) in forwardedSlots" #[name]="slotProps" :key="name">
+				<slot :name="name" v-bind="slotProps" />
+			</template>
+
+			<template v-if="slots.suffix" #suffix="suffixProps">
+				<slot name="suffix" v-bind="suffixProps" />
+			</template>
+			<template v-else-if="showClear" #suffix>
+				<button
+					type="button"
+					aria-label="Clear"
+					data-slot="clear"
+					class="group-hover:grid group-focus:grid group-focus-within:grid hidden size-4 place-items-center rounded-sm text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+					@click="clearValue"
+					@pointerdown.stop
+				>
+					<span class="lucide-x size-3.5" />
+				</button>
+			</template>
+
+			<template v-if="slots['item-create']" #item-create="slotProps">
+				<slot name="item-create" v-bind="slotProps" />
+			</template>
+			<template v-else #item-create="{ query }">
+				<div class="flex">
+					<span class="truncate">
+						Create
+						<span v-if="query" class="font-medium text-ink-gray-8">
+							{{ query }}
+						</span>
+					</span>
+				</div>
+			</template>
+		</Combobox>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, useSlots, watch } from "vue";
+import { Combobox, createResource, frappeRequest, debounce } from "frappe-ui";
+import type { LinkEmits, LinkExposed, LinkOption, LinkProps } from "./types";
+
+const props = withDefaults(defineProps<LinkProps>(), {
+	filters: () => ({}),
+	creatable: false,
+	disabled: false,
+});
+
+const model = defineModel<string | null>({ default: null });
+const open = defineModel<boolean>("open", { default: false });
+const comboboxRef = ref<{ focus: () => void } | null>(null);
+
+const emit = defineEmits<LinkEmits>();
+
+defineOptions({ inheritAttrs: false });
+
+const slots = useSlots();
+
+const forwardedSlots = computed(() =>
+	Object.fromEntries(
+		Object.entries(slots).filter(([name]) => name !== "suffix" && name !== "item-create")
+	)
+);
+
+const options = createResource({
+	url: "frappe.desk.search.search_link",
+	params: {
+		doctype: props.doctype,
+		txt: "",
+		filters: props.filters,
+	},
+	method: "POST",
+	resourceFetcher: frappeRequest,
+	transform: (data: LinkOption[]): LinkOption[] =>
+		data.map((doc: any) => ({
+			label: doc.label || doc.value,
+			value: doc.value,
+			description: doc.description,
+		})),
+});
+
+const createNewOption: ComboboxCustomOption = {
+	type: "custom",
+	key: "create",
+	label: "Create New",
+	slot: "create",
+	condition: ({ query }: { query: string }) => Boolean(query.trim()),
+	onClick: ({ query }) => emit("create", query),
+};
+
+const linkOptions = computed<ComboboxOption[]>(() => {
+	const _options = options.data || [];
+	if (props.creatable) {
+		return [..._options, createNewOption];
+	}
+	return _options;
+});
+
+const showClear = computed(() => !props.disabled && !!model.value && !props.required);
+
+const loadOptions = (txt: string = "") => {
+	options.update({
+		params: {
+			txt,
+			doctype: props.doctype,
+			filters: props.filters,
+		},
+	});
+	options.reload();
+};
+
+const handleInputChange = debounce((value: string) => {
+	loadOptions(value || "");
+}, 300);
+
+const clearValue = () => {
+	model.value = null;
+	open.value = false;
+	comboboxRef.value?.focus();
+};
+
+watch([() => props.doctype, () => props.filters], () => loadOptions(""), {
+	immediate: true,
+	deep: true,
+});
+
+defineExpose<LinkExposed>({ reload: () => loadOptions("") });
+</script>

--- a/ui/src/components/Link/Link.vue
+++ b/ui/src/components/Link/Link.vue
@@ -58,7 +58,8 @@
 <script setup lang="ts">
 import { computed, ref, useSlots, watch } from "vue";
 import { Combobox, createResource, frappeRequest, debounce } from "frappe-ui";
-import type { LinkEmits, LinkExposed, LinkOption, LinkProps } from "./types";
+import type { ComboboxOption, ComboboxCustomOption } from "frappe-ui";
+import type { LinkExposed, LinkOption, LinkProps, LinkEmits } from "./types";
 
 const props = withDefaults(defineProps<LinkProps>(), {
 	filters: () => ({}),
@@ -105,7 +106,7 @@ const createNewOption: ComboboxCustomOption = {
 	label: "Create New",
 	slot: "create",
 	condition: ({ query }: { query: string }) => Boolean(query.trim()),
-	onClick: ({ query }) => emit("create", query),
+	onClick: ({ query }: { query: string }) => emit("create", query),
 };
 
 const linkOptions = computed<ComboboxOption[]>(() => {

--- a/ui/src/components/Link/index.ts
+++ b/ui/src/components/Link/index.ts
@@ -1,0 +1,2 @@
+export { default as Link } from './Link.vue'
+export type { LinkEmits, LinkExposed, LinkOption, LinkProps } from './types.ts'

--- a/ui/src/components/Link/types.ts
+++ b/ui/src/components/Link/types.ts
@@ -11,11 +11,10 @@ export interface LinkProps extends InputLabelingProps {
   creatable?: boolean
   disabled?: boolean
   placeholder?: string
+  id?: string
 }
 
-export interface LinkEmits {
-  'update:modelValue': [value: string | null]
-  'update:open': [value: boolean]
+export type LinkEmits = {
   create: [query: string]
 }
 

--- a/ui/src/components/Link/types.ts
+++ b/ui/src/components/Link/types.ts
@@ -1,0 +1,30 @@
+interface InputLabelingProps {
+  label?: string
+  description?: string
+  error?: string | Error
+  required?: boolean
+}
+
+export interface LinkProps extends InputLabelingProps {
+  doctype: string
+  filters?: Record<string, unknown>
+  creatable?: boolean
+  disabled?: boolean
+  placeholder?: string
+}
+
+export interface LinkEmits {
+  'update:modelValue': [value: string | null]
+  'update:open': [value: boolean]
+  create: [query: string]
+}
+
+export interface LinkExposed {
+  reload: () => void
+}
+
+export type LinkOption = {
+  label: string
+  value: string
+  description?: string
+}

--- a/ui/src/components/Link/types.ts
+++ b/ui/src/components/Link/types.ts
@@ -11,7 +11,6 @@ export interface LinkProps extends InputLabelingProps {
   creatable?: boolean
   disabled?: boolean
   placeholder?: string
-  id?: string
 }
 
 export type LinkEmits = {

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -1,0 +1,1 @@
+export * from './components/Link'


### PR DESCRIPTION
# `@framework/ui` package

Shared Vue components and utilities for Frappe apps that depend on the backend. Lives at `frappe/ui` in framework and is consumed by other apps (studio, builder, hrms, …) as a local package - **never published to npm**.

This is an extension of frappe-ui for framework specific components that all apps need

Code is shipped as raw `.vue`/`.ts` source (no build step) and compiled by the
consuming app's bundler, exactly like `frappe-ui`. `vue`, `vue-router` and `frappe-ui`
are **peer dependencies** so the host app's single copy of each is reused — this avoids
duplicate Vue instances and mismatched router contexts.

> docs: [README.md](https://github.com/frappe/frappe/pull/39730/changes#diff-6e8c08cff231f603dfa7a4d5f873a6fee6e5c730d431c113bbf5b1180c6983e4)