### PR TITLE
fix(desk): add permission checks to toggle_like and mark_as_seen

### DIFF
--- a/frappe/desk/doctype/note/note.py
+++ b/frappe/desk/doctype/note/note.py
@@ -58,6 +58,7 @@ class Note(Document):
 @frappe.whitelist()
 def mark_as_seen(note: str):
 	note: Note = frappe.get_doc("Note", note)
+	note.check_permission("read")
 	note.mark_seen_by(frappe.session.user)
 	note.save(ignore_permissions=True, ignore_version=True)
 

--- a/frappe/desk/like.py
+++ b/frappe/desk/like.py
@@ -33,6 +33,8 @@ def _toggle_like(doctype, name, add, user=None):
 	if not user:
 		user = frappe.session.user
 
+	frappe.has_permission(doctype, "read", doc=name, throw=True)
+
 	try:
 		liked_by = frappe.db.get_value(doctype, name, "_liked_by")
 


### PR DESCRIPTION
- Add `frappe.has_permission(doctype, "read", ...)` in `_toggle_like` before any DB operation
- Add `note.check_permission("read")` in `mark_as_seen` before saving
