### PR TITLE
feat: add option to disable prepared report automation

### DIFF
--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -19,6 +19,7 @@
   "add_total_row",
   "disabled",
   "prepared_report",
+  "disable_prepared_report_automation",
   "generate_csv",
   "add_translate_data",
   "timeout",
@@ -224,12 +225,20 @@
    "ignore_user_permissions": 1,
    "label": "Default Letter Head",
    "options": "Letter Head"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.report_type === \"Script Report\"",
+   "description": "If checked, <i>Prepared Report</i> will not be enabled automatically on slow runs.",
+   "fieldname": "disable_prepared_report_automation",
+   "fieldtype": "Check",
+   "label": "Disable Prepared Report Automation"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-27 00:00:00.000000",
+ "modified": "2026-06-04 03:43:50.279111",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Report",

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -37,6 +37,7 @@ class Report(Document):
 		columns: DF.Table[ReportColumn]
 		default_letter_head: DF.Link | None
 		default_print_format: DF.Link | None
+		disable_prepared_report_automation: DF.Check
 		disabled: DF.Check
 		filters: DF.Table[ReportFilter]
 		generate_csv: DF.Check
@@ -191,7 +192,7 @@ class Report(Document):
 
 		start_time = datetime.datetime.now()
 		prepared_report_watcher = None
-		if not self.prepared_report:
+		if not self.prepared_report and not self.disable_prepared_report_automation:
 			prepared_report_watcher = threading.Timer(
 				interval=threshold,
 				function=enable_prepared_report,

--- a/frappe/patches/v15_0/copy_disable_prepared_report_to_prepared_report.py
+++ b/frappe/patches/v15_0/copy_disable_prepared_report_to_prepared_report.py
@@ -3,4 +3,6 @@ import frappe
 
 def execute():
 	table = frappe.qb.DocType("Report")
-	frappe.qb.update(table).set(table.prepared_report, 0).where(table.disable_prepared_report == 1)
+	frappe.qb.update(table).set(table.prepared_report, 0).set(
+		table.disable_prepared_report_automation, 1
+	).where(table.disable_prepared_report == 1).run()


### PR DESCRIPTION
Adds `disable_prepared_report_automation` on **Report** to opt out of the 15-second auto-enable watcher for slow script reports. Updates the existing v15 migration so reports with the legacy `disable_prepared_report` flag get `disable_prepared_report_automation = 1` (and fixes the patch to call `.run()`).

Design discussed with @ankush as preferred alternative to https://github.com/frappe/frappe/pull/38136

Docs: https://docs.frappe.io/wiki/change-requests/6hb4099tjb

Ref: LAN-895