### PR TITLE
chore: bump PyJWT to 2.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "GitPython~=3.1.45",
     "Jinja2~=3.1.6",
     "Pillow~=12.2.0",
-    "PyJWT~=2.12.1",
+    "PyJWT~=2.13.0",
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.2",


### PR DESCRIPTION
https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-13-0

Our usage of PyJWT is narrow (HS256 + string secrets, no JWKS client in app code). v2.13.0 is a security upgrade with no meaningful functional regression expected.

Other deps don't pin it.