### PR TITLE
fix(grid): guard grid_sortable in row-index search handler

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -292,10 +292,12 @@ export default class GridRow {
 						delete this.grid.filter["row-index"];
 					}
 
-					this.grid.grid_sortable.option(
-						"disabled",
-						Object.keys(this.grid.filter).length !== 0
-					);
+					if (this.grid.grid_sortable) {
+						this.grid.grid_sortable.option(
+							"disabled",
+							Object.keys(this.grid.filter).length !== 0
+						);
+					}
 
 					this.grid.prevent_build = true;
 					me.grid.refresh();


### PR DESCRIPTION
## Problem
Searching the No. (row-index) column of a child-table grid does nothing when the grid is read-only (e.g. submitted docs). The row-index keyup handler calls `grid_sortable.option(...)` unconditionally, but `grid_sortable`
only exists for editable grids (`make_sortable()` runs only when sortable). On a read-only grid it's undefined,
so the call throws and `grid.refresh()` never runs, the filter is set but never rendered.

The per-column search handler already guards this with if (this.grid.grid_sortable); the row-index handler was
missing the same guard. That's why other columns filter fine on read-only grids and only No. breaks.

## Fix
Wrap the `grid_sortable.option(...)` call in the row-index handler with if (`this.grid.grid_sortable`), matching the column handler. No behavior change for editable grids.

### Before Fix
[Screencast from 2026-06-04 09-45-32.webm](https://github.com/user-attachments/assets/bacbff43-8ac1-4681-b812-f0567b868772)


### After Fix
[Screencast from 2026-06-04 09-42-06.webm](https://github.com/user-attachments/assets/0ef2eacc-7a4e-48b2-a4f6-33d5f267123a)


**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/70171](https://support.frappe.io/helpdesk/tickets/70171)