### PR TITLE
fix(grid): prevent border on adjacent empty sections in grid layout of child table in tab interface

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -637,6 +637,11 @@
 			&.show.active {
 				display: block;
 			}
+
+			// Tab Break creates a hidden empty section first; don't border the next section.
+			.empty-section + .form-section {
+				border-top: none;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Removes an extra top border on the first visible section inside tabs in the child table row editor (“Editing Row” modal).

Tab Break creates a hidden empty section before the real section; grid row form CSS was treating that as a second section and adding border-top.

before:
<img width="1276" height="445" alt="image" src="https://github.com/user-attachments/assets/85a9f594-43f2-4bfb-86fb-694884078a41" />


after:
<img width="1261" height="446" alt="image" src="https://github.com/user-attachments/assets/78d458a4-c844-46bf-9849-44e37e336ecb" />
