### PR TITLE
fix: onboarding tour boot defaults never applied due to comparison typo

### DIFF
--- a/frappe/public/js/onboarding_tours/onboarding_tours.js
+++ b/frappe/public/js/onboarding_tours/onboarding_tours.js
@@ -122,7 +122,7 @@ frappe.ui.OnboardingTour = class OnboardingTour {
 			popover_element,
 			modal_trigger,
 		} = step_info;
-		let element = cur_page?.page.querySelector(element_selector);
+		let element = cur_page?.page?.querySelector(element_selector);
 		!element && (element = document.querySelector(element_selector));
 		if (element && parent_element_selector) {
 			element = element.closest(parent_element_selector);
@@ -261,9 +261,9 @@ frappe.ui.init_onboarding_tour = () => {
 	// Also lot of elements are hidden on mobile so until we find a better way to do it.
 	if (!window.matchMedia("(min-device-width: 992px)").matches) return;
 
-	typeof frappe.boot.onboarding_tours == "undefined" && frappe.boot.onboarding_tours == [];
+	typeof frappe.boot.onboarding_tours == "undefined" && (frappe.boot.onboarding_tours = []);
 	typeof frappe.boot.user.onboarding_status == "undefined" &&
-		frappe.boot.user.onboarding_status == {};
+		(frappe.boot.user.onboarding_status = {});
 	let route = frappe.router.current_route;
 	if (route?.[0] === "") return;
 
@@ -337,8 +337,9 @@ frappe.ui.init_onboarding_tour = () => {
 	const tour = (frappe.ui.currentTourInstance = new frappe.ui.OnboardingTour());
 	// wait for workspace and/or data to load.
 	const wait_for_data = setInterval(() => {
-		if (cur_page?.page.querySelector(".workspace-sidebar-skeleton")) return;
-		if (cur_page?.page.querySelector(".workspace-skeleton")) return;
+		if (!cur_page?.page) return;
+		if (cur_page.page.querySelector(".workspace-sidebar-skeleton")) return;
+		if (cur_page.page.querySelector(".workspace-skeleton")) return;
 		if (document.body.getAttribute("data-ajax-state") === "complete") {
 			frappe.utils.sleep(500).then(() => {
 				tour.init({


### PR DESCRIPTION
### Fix onboarding boot defaults and strengthen page initialization guards

This PR fixes an issue in `init_onboarding_tour` where default values for `frappe.boot.onboarding_tours` and `frappe.boot.user.onboarding_status` were not being applied when those properties were undefined.

The existing implementation used comparison operators (`==`) instead of assignments (`=`):

```js
typeof frappe.boot.onboarding_tours == "undefined" &&
    frappe.boot.onboarding_tours == [];
```

As a result, the expressions only evaluated a comparison and discarded the result, leaving the properties undefined. Both statements have been updated to use assignments (wrapped in parentheses to avoid operator precedence issues with `&&`).

Additionally, this PR fixes an incomplete optional-chain guard in the same file. The code previously used:

```js
cur_page?.page.querySelector(...)
```

This still throws when `cur_page` exists but `cur_page.page` is undefined. Since these checks can run during early initialization when `cur_page` starts as `null` and page state may not yet be fully initialized, the guard has been updated to:

```js
cur_page?.page?.querySelector(...)
```

This prevents runtime errors during initialization and makes the onboarding setup logic more robust.
