### PR TITLE
fix: complete optional chaining on table control null guards

### DIFF
--- a/frappe/public/js/frappe/form/controls/table.js
+++ b/frappe/public/js/frappe/form/controls/table.js
@@ -111,7 +111,7 @@ frappe.ui.form.ControlTable = class ControlTable extends frappe.ui.form.Control 
 	get_field(field_name) {
 		let fieldname;
 		field_name = field_name.toLowerCase();
-		this.grid?.meta?.fields.some((field) => {
+		this.grid?.meta?.fields?.some((field) => {
 			if (frappe.model.no_value_type.includes(field.fieldtype)) {
 				return false;
 			}


### PR DESCRIPTION
### Summary

Fix incomplete optional chaining in `ControlTable.get_field`.

Previously, the code used:

```js
this.grid?.meta?.fields.some(...)
```

If `meta` was `null` or `undefined`, the optional chain would short-circuit and return `undefined`, but `.some()` would still be invoked on that result, causing a `TypeError`.

This change extends the guard to:

```js
this.grid?.meta?.fields?.some(...)
```

### Why

`fields` can be nullish in some scenarios. Since the result of `.some()` is not used (the callback only sets `fieldname` as a side effect), there is no need to execute `.some()` when `fields` is unavailable.

### Behavior Change

* When `meta.fields` exists: behavior remains unchanged.
* When `meta.fields` is `null` or `undefined`: the method no longer throws and simply proceeds without finding a match.

### Impact

Prevents a potential runtime `TypeError` while preserving existing behavior for valid table metadata.
