### PR TITLE
feat: support jump to field inside child table row editor

### DIFF
--- a/cypress/integration/grid_row_form_tabs.js
+++ b/cypress/integration/grid_row_form_tabs.js
@@ -112,6 +112,29 @@ context("Grid Row Form Tabs", () => {
 		cy.get("@table-form2").find(".form-tabs .nav-link").first().should("have.class", "active");
 	});
 
+	it("should jump to a field inside the grid row form", () => {
+		cy.new_form(parent_doctype_name);
+		cy.fill_field("title", "Test Jump To Field");
+
+		// Add a row and open the grid row form
+		cy.get('.frappe-control[data-fieldname="items"]').as("table");
+		cy.get("@table").findByRole("button", { name: "Add row" }).click();
+		cy.get("@table").find('[data-idx="1"]').find(".btn-open-row").click();
+		cy.get(".grid-row-open").as("table-form");
+
+		// Jump to a field that lives on a different tab (Details > Notes)
+		cy.get("body").type("{esc}").type("{ctrl+j}");
+		cy.get(".modal input[type='text']").first().focus();
+		cy.get("body").type("Notes").wait(1000).type("{enter}").wait(200);
+		cy.findByRole("button", { name: "Go" }).click().wait(500);
+
+		// Grid row form stays open and the target field is focused
+		cy.get(".grid-row-open").should("exist");
+		cy.get("@table-form")
+			.find('.frappe-control[data-fieldname="notes"] input')
+			.should("be.focused");
+	});
+
 	it("should allow data entry in fields across different tabs", () => {
 		cy.new_form(parent_doctype_name);
 		cy.fill_field("title", "Test Data Entry");

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -895,7 +895,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 					reqd: 1,
 				},
 			],
-			hide_open_grid_form_on_hide: !grid_form,
+			keep_grid_form_open: !!grid_form,
 			primary_action_label: __("Go"),
 			primary_action: ({ fieldname }) => {
 				dialog.hide();

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -429,7 +429,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 				this.show_jump_to_field_dialog();
 			},
 			true,
-			"Ctrl+J"
+			{ shortcut: "Ctrl+J", ignore_inputs: true }
 		);
 	}
 
@@ -876,7 +876,11 @@ frappe.ui.form.Toolbar = class Toolbar {
 			!f.df.hidden &&
 			f.disp_status !== "None";
 
-		let fields = this.frm.fields
+		// if a child table row is open in the detail editor, search its fields instead
+		let grid_row = this.frm.open_grid_row();
+		let grid_form = grid_row?.grid_form;
+
+		let fields = (grid_form ? grid_form.layout.fields_list : this.frm.fields)
 			.filter(visible_fields_filter)
 			.map((f) => ({ label: __(f.df.label), value: f.df.fieldname }));
 
@@ -891,15 +895,64 @@ frappe.ui.form.Toolbar = class Toolbar {
 					reqd: 1,
 				},
 			],
+			hide_open_grid_form_on_hide: !grid_form,
 			primary_action_label: __("Go"),
 			primary_action: ({ fieldname }) => {
 				dialog.hide();
-				this.frm.scroll_to_field(fieldname);
+				if (grid_form) {
+					this.scroll_to_grid_field(grid_form, fieldname);
+				} else {
+					this.frm.scroll_to_field(fieldname);
+				}
 			},
 			animate: false,
 		});
 
 		dialog.show();
+	}
+
+	scroll_to_grid_field(grid_form, fieldname, focus = true) {
+		let field = grid_form.fields_dict[fieldname];
+		if (!field) return false;
+
+		let $el = field.$wrapper;
+		if (!$el || !$el.length) return false;
+
+		// set tab as active
+		if (field.tab && !field.tab.is_active()) {
+			field.tab.set_active();
+		}
+
+		// uncollapse section
+		if (field.section?.is_collapsed()) {
+			field.section.collapse(false);
+		}
+
+		// scroll to input
+		let scroll_container = grid_form.wrapper.find(".grid-form-body");
+		frappe.utils.scroll_to(
+			$el,
+			true,
+			15,
+			scroll_container.length ? scroll_container : $(".main-section")
+		);
+
+		// focus if text field
+		if (focus) {
+			setTimeout(() => {
+				$el.find("input, select, textarea").focus();
+			}, 500);
+		}
+
+		// highlight control inside field
+		let control_element = $el.closest(".frappe-control");
+		if (control_element.length) {
+			control_element.addClass("highlight");
+			setTimeout(() => {
+				control_element.removeClass("highlight");
+			}, 2000);
+		}
+		return true;
 	}
 
 	setup_sidebar_toggle(sidebar_wrapper) {

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -21,7 +21,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				size: null,
 				auto_make: true,
 				centered: false,
-				hide_open_grid_form_on_hide: true,
+				keep_grid_form_open: false,
 			},
 			opts
 		);
@@ -104,7 +104,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				me.display = false;
 				me.is_minimized = false;
 				me.hide_scrollbar(false);
-				if (me.hide_open_grid_form_on_hide) {
+				if (!me.keep_grid_form_open) {
 					// hide any grid row form if open
 					frappe.ui.form.get_open_grid_form?.()?.hide_form();
 				}

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -14,7 +14,17 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 		this.is_dialog = true;
 		this.last_focus = null;
 
-		$.extend(this, { animate: true, size: null, auto_make: true, centered: false }, opts);
+		$.extend(
+			this,
+			{
+				animate: true,
+				size: null,
+				auto_make: true,
+				centered: false,
+				hide_open_grid_form_on_hide: true,
+			},
+			opts
+		);
 		if (this.auto_make) {
 			this.make();
 		}
@@ -94,8 +104,10 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				me.display = false;
 				me.is_minimized = false;
 				me.hide_scrollbar(false);
-				// hide any grid row form if open
-				frappe.ui.form.get_open_grid_form?.()?.hide_form();
+				if (me.hide_open_grid_form_on_hide) {
+					// hide any grid row form if open
+					frappe.ui.form.get_open_grid_form?.()?.hide_form();
+				}
 
 				if (frappe.ui.open_dialogs[frappe.ui.open_dialogs.length - 1] === me) {
 					frappe.ui.open_dialogs.pop();


### PR DESCRIPTION
Closes #39755

Ctrl+J (Jump to field) only searched the parent form's fields. When a child table row is open in the detail editor, it now lists that row's fields and scrolls within the row form instead.

The shortcut is also allowed to fire while focus is inside a field, since the row editor always has an input focused.

## How it looks

https://github.com/user-attachments/assets/cdfb565f-c0d2-49de-a578-f26090459c74

#no-docs
