### PR TITLE
fix: miscellaneous fixes in print format

### DIFF
--- a/frappe/public/js/print_format_builder/components/Autocomplete.vue
+++ b/frappe/public/js/print_format_builder/components/Autocomplete.vue
@@ -9,6 +9,7 @@
 				:placeholder="placeholder || __('Search...')"
 				v-model="query"
 				@focus="open = true"
+				@input="open = true"
 				@blur="on_blur"
 				@keydown.escape="open = false"
 				@keydown.enter.prevent="confirm_highlight"

--- a/frappe/public/js/print_format_builder/components/Autocomplete.vue
+++ b/frappe/public/js/print_format_builder/components/Autocomplete.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="pfb-autocomplete" ref="wrap">
-		<div class="pfb-autocomplete-input-wrap" :class="{ focused: open }">
+	<div class="pfb-autocomplete">
+		<div class="pfb-autocomplete-input-wrap" :class="{ focused }">
 			<span class="pfb-autocomplete-icon" v-html="frappe.utils.icon('search', 'xs')"></span>
 			<input
 				ref="input_el"
@@ -8,16 +8,15 @@
 				type="text"
 				:placeholder="placeholder || __('Search...')"
 				v-model="query"
-				@focus="open = true"
-				@input="open = true"
-				@blur="on_blur"
-				@keydown.escape="open = false"
+				@focus="focused = true"
+				@blur="setTimeout(() => (focused = false), 100)"
+				@keydown.escape="input_el.blur()"
 				@keydown.enter.prevent="confirm_highlight"
 				@keydown.down.prevent="highlight = Math.min(highlight + 1, filtered.length - 1)"
 				@keydown.up.prevent="highlight = Math.max(highlight - 1, 0)"
 			/>
 		</div>
-		<div v-if="open" class="pfb-autocomplete-dropdown">
+		<div v-if="focused" class="pfb-autocomplete-dropdown">
 			<template v-if="filtered.length">
 				<button
 					v-for="(opt, i) in filtered"
@@ -47,10 +46,9 @@ const props = defineProps({
 
 const emit = defineEmits(["select"]);
 
-const wrap = ref(null);
 const input_el = ref(null);
 const query = ref("");
-const open = ref(false);
+const focused = ref(false);
 const highlight = ref(0);
 
 const filtered = computed(() => {
@@ -68,14 +66,9 @@ watch(filtered, () => {
 	highlight.value = 0;
 });
 
-function on_blur() {
-	setTimeout(() => (open.value = false), 100);
-}
-
 function select(opt) {
 	emit("select", opt);
 	query.value = "";
-	open.value = false;
 	highlight.value = 0;
 }
 

--- a/frappe/public/js/print_format_builder/components/Autocomplete.vue
+++ b/frappe/public/js/print_format_builder/components/Autocomplete.vue
@@ -1,0 +1,188 @@
+<template>
+	<div class="pfb-autocomplete" ref="wrap">
+		<div class="pfb-autocomplete-input-wrap" :class="{ focused: open }">
+			<span class="pfb-autocomplete-icon" v-html="frappe.utils.icon('search', 'xs')"></span>
+			<input
+				ref="input_el"
+				class="pfb-autocomplete-input"
+				type="text"
+				:placeholder="placeholder || __('Search...')"
+				v-model="query"
+				@focus="open = true"
+				@blur="on_blur"
+				@keydown.escape="open = false"
+				@keydown.enter.prevent="confirm_highlight"
+				@keydown.down.prevent="highlight = Math.min(highlight + 1, filtered.length - 1)"
+				@keydown.up.prevent="highlight = Math.max(highlight - 1, 0)"
+			/>
+		</div>
+		<div v-if="open" class="pfb-autocomplete-dropdown">
+			<template v-if="filtered.length">
+				<button
+					v-for="(opt, i) in filtered"
+					:key="opt.value"
+					class="pfb-autocomplete-option"
+					:class="{ highlighted: highlight === i }"
+					@mousedown.prevent="select(opt)"
+				>
+					<span class="pfb-autocomplete-option-label">{{ opt.label }}</span>
+					<span v-if="opt.badge" class="pfb-autocomplete-option-badge">{{
+						opt.badge
+					}}</span>
+				</button>
+			</template>
+			<div v-else class="pfb-autocomplete-empty">{{ __("No results") }}</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from "vue";
+
+const props = defineProps({
+	options: { type: Array, default: () => [] },
+	placeholder: { type: String, default: "" },
+});
+
+const emit = defineEmits(["select"]);
+
+const wrap = ref(null);
+const input_el = ref(null);
+const query = ref("");
+const open = ref(false);
+const highlight = ref(0);
+
+const filtered = computed(() => {
+	const q = query.value.toLowerCase();
+	if (!q) return props.options;
+	return props.options.filter(
+		(o) =>
+			(o.label || "").toLowerCase().includes(q) ||
+			(o.value || "").toLowerCase().includes(q) ||
+			(o.badge || "").toLowerCase().includes(q)
+	);
+});
+
+watch(filtered, () => {
+	highlight.value = 0;
+});
+
+function on_blur() {
+	setTimeout(() => (open.value = false), 100);
+}
+
+function select(opt) {
+	emit("select", opt);
+	query.value = "";
+	open.value = false;
+	highlight.value = 0;
+}
+
+function confirm_highlight() {
+	if (!filtered.value.length) return;
+	select(filtered.value[highlight.value] ?? filtered.value[0]);
+}
+
+defineExpose({ focus: () => input_el.value?.focus() });
+</script>
+
+<style scoped>
+.pfb-autocomplete {
+	position: relative;
+}
+
+.pfb-autocomplete-input-wrap {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 5px 8px;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	background: var(--control-bg);
+	transition: border-color 0.1s, background 0.1s;
+}
+
+.pfb-autocomplete-input-wrap.focused {
+	border-color: var(--gray-500);
+	background: var(--fg-color);
+}
+
+.pfb-autocomplete-icon {
+	display: flex;
+	align-items: center;
+	color: var(--gray-400);
+	flex-shrink: 0;
+}
+
+.pfb-autocomplete-input {
+	flex: 1;
+	border: none;
+	background: transparent;
+	outline: none;
+	font-size: var(--text-sm);
+	color: var(--text-color);
+	min-width: 0;
+}
+
+.pfb-autocomplete-input::placeholder {
+	color: var(--gray-400);
+}
+
+.pfb-autocomplete-dropdown {
+	position: absolute;
+	top: calc(100% + 3px);
+	left: 0;
+	right: 0;
+	background: var(--fg-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	box-shadow: var(--shadow-sm);
+	z-index: 100;
+	max-height: 200px;
+	overflow-y: auto;
+}
+
+.pfb-autocomplete-option {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+	padding: 6px 10px;
+	border: none;
+	background: transparent;
+	text-align: left;
+	cursor: pointer;
+	gap: 8px;
+	font-size: var(--text-sm);
+}
+
+.pfb-autocomplete-option:hover,
+.pfb-autocomplete-option.highlighted {
+	background: var(--gray-100);
+}
+
+.pfb-autocomplete-option-label {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.pfb-autocomplete-option-badge {
+	font-size: var(--text-tiny);
+	color: var(--gray-500);
+	background: var(--gray-100);
+	border: 1px solid var(--gray-200);
+	border-radius: var(--border-radius-sm);
+	padding: 1px 5px;
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+.pfb-autocomplete-empty {
+	padding: 10px 12px;
+	font-size: var(--text-sm);
+	color: var(--text-muted);
+	text-align: center;
+}
+</style>

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -375,6 +375,8 @@ function select_section(section) {
 	store.scroll_to_section.value = section;
 	store.selected_section.value = section;
 	store.selected_field.value = null;
+	store.selected_letterhead.value = false;
+	store.selected_lh_footer.value = false;
 }
 
 function clone_as_section() {

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -548,8 +548,8 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	color: var(--text-muted);
 	cursor: pointer;
 	transition: color 0.12s, background 0.12s;
-	font-size: 10px;
-	font-weight: 500;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-medium);
 	position: relative;
 }
 
@@ -627,7 +627,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 .pfb-search-kbd {
 	flex-shrink: 0;
 	font-family: inherit;
-	font-size: 10px;
+	font-size: var(--text-tiny);
 	color: var(--gray-400);
 	background: var(--gray-100);
 	border: 1px solid var(--gray-300);
@@ -646,8 +646,8 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 .pfb-fields-header-title {
-	font-size: 10px;
-	font-weight: 600;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-semibold);
 	letter-spacing: 0.06em;
 	color: var(--text-muted);
 }
@@ -659,8 +659,8 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 
 /* ── Group label ─────────────────────────────────────────── */
 .pfb-group-label {
-	font-size: 10px;
-	font-weight: 600;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-semibold);
 	text-transform: uppercase;
 	letter-spacing: 0.06em;
 	color: var(--text-muted);
@@ -711,7 +711,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 .pfb-field-type {
-	font-size: 10px;
+	font-size: var(--text-tiny);
 	color: var(--gray-500);
 	background: var(--gray-100);
 	border: 1px solid var(--gray-200);
@@ -774,7 +774,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 .pfb-block-desc {
-	font-size: 10px;
+	font-size: var(--text-tiny);
 	margin-top: 1px;
 }
 
@@ -821,7 +821,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 .pfb-template-field {
-	font-size: 10px;
+	font-size: var(--text-tiny);
 	margin-top: 1px;
 }
 
@@ -833,13 +833,13 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 .pfb-templates-hint {
-	font-size: 11px;
+	font-size: var(--text-tiny);
 	line-height: 1.5;
 	margin-top: 6px;
 }
 
 .pfb-manage-link {
-	font-size: 10px;
+	font-size: var(--text-tiny);
 	font-weight: 400;
 	text-transform: none;
 	letter-spacing: 0;
@@ -868,7 +868,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 .pfb-outline-idx {
-	font-size: 10px;
+	font-size: var(--text-tiny);
 	font-variant-numeric: tabular-nums;
 	min-width: 18px;
 	text-align: right;
@@ -896,7 +896,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 .pfb-margin-label {
-	font-size: 10px;
+	font-size: var(--text-tiny);
 }
 
 /* ── Empty state ─────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -98,13 +98,12 @@
 					</div>
 				</div>
 			</div>
-			<!-- Left-edge drag handle — appears on hover -->
-			<div
-				class="drag-handle field-drag-handle field-drag-left"
-				v-html="frappe.utils.icon('drag', 'xs')"
-			></div>
-			<!-- Right actions: remove only -->
+			<!-- Top-right actions pill: drag + remove -->
 			<div class="field-preview-actions">
+				<div
+					class="drag-handle field-drag-handle"
+					v-html="frappe.utils.icon('drag', 'xs')"
+				></div>
 				<button
 					class="btn btn-xs btn-icon field-remove-btn"
 					@click.stop="df['remove'] = true"
@@ -669,34 +668,13 @@ watch(
 	margin: 4px 0;
 }
 
-/* Left-edge drag handle — hidden until hover/selected */
-.field-drag-left {
-	display: none;
-	position: absolute;
-	top: 2px;
-	left: 2px;
-	color: var(--gray-400);
-	cursor: grab;
-	z-index: 2;
-	padding: 1px 2px;
-	background: var(--fg-color);
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius-sm);
-	box-shadow: var(--shadow-xs);
-}
-
-.field--preview:hover .field-drag-left,
-.field--preview.field--selected .field-drag-left {
-	display: flex;
-	align-items: center;
-}
-
-/* Right actions — remove only, hidden until hover/selected */
+/* Top-right actions pill: drag + remove — hidden until hover/selected */
 .field-preview-actions {
 	display: none;
 	position: absolute;
 	top: 2px;
 	right: 2px;
+	z-index: 2;
 	gap: 2px;
 	background: var(--fg-color);
 	border: 1px solid var(--border-color);
@@ -714,6 +692,18 @@ watch(
 .field-preview-actions .btn-icon {
 	box-shadow: none;
 	padding: 2px;
+}
+
+.field-preview-actions .field-drag-handle {
+	cursor: grab;
+	color: var(--gray-400);
+	display: flex;
+	align-items: center;
+	padding: 2px;
+}
+
+.field-preview-actions .field-drag-handle:hover {
+	color: var(--gray-600);
 }
 
 /* Preview table — exact PDF print_format.css child-table style */

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -408,7 +408,7 @@ function validate_table_columns() {
 }
 
 watch(editing, (value) => {
-	if (value) nextTick(() => label_input.value.focus());
+	if (value) nextTick(() => label_input.value?.focus());
 });
 watch(
 	() => props.df.table_columns,

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -98,12 +98,13 @@
 					</div>
 				</div>
 			</div>
-			<!-- Drag + remove — top-right corner on hover; remove button hidden in clean-preview -->
+			<!-- Left-edge drag handle — appears on hover -->
+			<div
+				class="drag-handle field-drag-handle field-drag-left"
+				v-html="frappe.utils.icon('drag', 'xs')"
+			></div>
+			<!-- Right actions: remove only -->
 			<div class="field-preview-actions">
-				<div
-					class="drag-handle field-drag-handle"
-					v-html="frappe.utils.icon('drag', 'xs')"
-				></div>
 				<button
 					class="btn btn-xs btn-icon field-remove-btn"
 					@click.stop="df['remove'] = true"
@@ -668,7 +669,29 @@ watch(
 	margin: 4px 0;
 }
 
-/* Preview actions — drag + remove — hidden until hover/selected */
+/* Left-edge drag handle — hidden until hover/selected */
+.field-drag-left {
+	display: none;
+	position: absolute;
+	top: 2px;
+	left: 2px;
+	color: var(--gray-400);
+	cursor: grab;
+	z-index: 2;
+	padding: 1px 2px;
+	background: var(--fg-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-sm);
+	box-shadow: var(--shadow-xs);
+}
+
+.field--preview:hover .field-drag-left,
+.field--preview.field--selected .field-drag-left {
+	display: flex;
+	align-items: center;
+}
+
+/* Right actions — remove only, hidden until hover/selected */
 .field-preview-actions {
 	display: none;
 	position: absolute;

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -488,9 +488,9 @@ watch(
 }
 
 .fieldtype-badge {
-	font-size: 10px;
+	font-size: var(--text-tiny);
 	color: var(--text-muted);
-	background: var(--gray-100);
+	background: var(--control-bg);
 	border: 1px solid var(--gray-300);
 	border-radius: var(--border-radius-sm);
 	padding: 1px 4px;
@@ -628,8 +628,8 @@ watch(
 }
 
 .field-preview-label {
-	font-size: 0.72em;
-	font-weight: 600;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-semibold);
 	color: var(--gray-500);
 	margin-bottom: 1px;
 }
@@ -714,7 +714,7 @@ watch(
 
 .field-preview-table > .field-preview-label {
 	font-size: 0.8em;
-	font-weight: 600;
+	font-weight: var(--weight-semibold);
 	color: var(--text-muted);
 	margin-bottom: 0.4rem;
 }
@@ -722,15 +722,15 @@ watch(
 .preview-table {
 	width: 100%;
 	border-collapse: collapse;
-	font-size: 0.9em;
+	font-size: var(--text-sm);
 }
 
 /* ── Default: bordered + styled header (matches PDF) ─── */
 .preview-table th {
 	background-color: var(--gray-100);
 	color: var(--text-color);
-	font-weight: 600;
-	font-size: 0.85em;
+	font-weight: var(--weight-semibold);
+	font-size: var(--text-tiny);
 	padding: 0.45rem 0.6rem;
 	border: 1px solid var(--gray-200);
 	text-align: left;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -284,14 +284,14 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 /* Section drag handle in clean-preview: show on hover */
-.pfb-clean-preview :deep(.section-preview-drag) {
+.pfb-clean-preview :deep(.section-preview-actions) {
 	display: flex;
 }
 
-.pfb-clean-preview :deep(.print-format-section-container:hover .section-preview-drag),
-.pfb-clean-preview :deep(.print-format-section.section--selected ~ .section-preview-drag),
+.pfb-clean-preview :deep(.print-format-section-container:hover .section-preview-actions),
+.pfb-clean-preview :deep(.print-format-section.section--selected ~ .section-preview-actions),
 .pfb-clean-preview
-	:deep(.print-format-section-container:has(.section--selected) .section-preview-drag) {
+	:deep(.print-format-section-container:has(.section--selected) .section-preview-actions) {
 	opacity: 1;
 }
 

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -233,11 +233,6 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	display: none !important;
 }
 
-/* In clean-preview: keep the drag handle but hide only the remove button */
-.pfb-clean-preview :deep(.field-remove-btn) {
-	display: none !important;
-}
-
 /* Section hover/selected states in clean-preview */
 .pfb-clean-preview :deep(.print-format-section) {
 	border: 1px solid transparent;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -192,8 +192,8 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 .zone-divider-label {
-	font-size: 10px;
-	font-weight: 700;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-bold);
 	text-transform: uppercase;
 	letter-spacing: 0.08em;
 	white-space: nowrap;
@@ -301,8 +301,8 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	padding: 0 0 0.3rem;
 	margin-bottom: 0.4rem;
 	border-bottom: 1.5px solid var(--border-color);
-	font-size: 1rem;
-	font-weight: 700;
+	font-size: var(--text-lg);
+	font-weight: var(--weight-bold);
 	color: var(--text-color);
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -211,7 +211,7 @@ function set_column_align(column, value) {
 	justify-content: space-between;
 	align-items: center;
 	padding: 0.4rem 0.6rem;
-	background: var(--gray-50);
+	background: var(--subtle-accent);
 	border-bottom: 1px solid var(--border-color);
 	gap: 0.5rem;
 }
@@ -244,8 +244,8 @@ function set_column_align(column, value) {
 }
 
 .zone-badge {
-	font-size: 10px;
-	font-weight: 700;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-bold);
 	text-transform: uppercase;
 	letter-spacing: 0.07em;
 	color: var(--text-muted);
@@ -261,7 +261,7 @@ function set_column_align(column, value) {
 	border: 1px solid transparent;
 	border-radius: var(--border-radius);
 	font-size: var(--text-sm);
-	font-weight: 600;
+	font-weight: var(--weight-semibold);
 	background: transparent;
 	padding: 2px 4px;
 	flex: 1;
@@ -310,7 +310,7 @@ function set_column_align(column, value) {
 .section-title-display {
 	display: none;
 	font-size: var(--text-sm);
-	font-weight: 600;
+	font-weight: var(--weight-semibold);
 	color: var(--text-muted);
 	padding: 0;
 }

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -409,7 +409,7 @@ function set_column_align(column, value) {
 	display: none; /* hidden by default; shown via .pfb-clean-preview :deep() override */
 	position: absolute;
 	top: 4px;
-	right: 4px;
+	left: 4px;
 	z-index: 2;
 	padding: 3px 4px;
 	background: var(--fg-color);

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -1,11 +1,18 @@
 <template>
 	<div class="print-format-section-container" v-if="!section.remove" data-pfb-section>
-		<!-- Section drag handle shown on hover in clean-preview (toolbar is hidden) -->
-		<div
-			v-if="!is_header"
-			class="drag-handle section-drag-handle section-preview-drag"
-			v-html="frappe.utils.icon('drag', 'sm')"
-		></div>
+		<!-- Top-left actions pill shown on hover in clean-preview (toolbar is hidden) -->
+		<div v-if="!is_header" class="section-preview-actions">
+			<div
+				class="drag-handle section-drag-handle"
+				v-html="frappe.utils.icon('drag', 'xs')"
+			></div>
+			<button
+				class="btn btn-xs btn-icon"
+				:title="__('Remove section')"
+				@click.stop="section['remove'] = true"
+				v-html="frappe.utils.icon('x', 'xs')"
+			></button>
+		</div>
 		<div
 			class="print-format-section"
 			:class="{
@@ -404,22 +411,45 @@ function set_column_align(column, value) {
 	color: var(--red-500);
 }
 
-/* ── Section preview drag handle (only visible in clean-preview, hidden in edit) ── */
-.section-preview-drag {
-	display: none; /* hidden by default; shown via .pfb-clean-preview :deep() override */
+/* ── Section preview actions pill (only visible in clean-preview, hidden in edit) ── */
+.section-preview-actions {
+	display: none; /* shown via .pfb-clean-preview :deep() override */
 	position: absolute;
 	top: 4px;
 	left: 4px;
 	z-index: 2;
-	padding: 3px 4px;
+	gap: 2px;
+	padding: 1px 2px;
 	background: var(--fg-color);
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius-sm);
 	box-shadow: var(--shadow-xs);
-	color: var(--gray-400);
-	cursor: grab;
+	align-items: center;
 	opacity: 0;
 	transition: opacity 0.12s;
+}
+
+.section-preview-actions .section-drag-handle {
+	cursor: grab;
+	color: var(--gray-400);
+	display: flex;
+	align-items: center;
+	padding: 2px;
+}
+
+.section-preview-actions .section-drag-handle:hover {
+	color: var(--gray-600);
+}
+
+.section-preview-actions .btn-icon {
+	box-shadow: none;
+	padding: 2px;
+	color: var(--text-muted);
+}
+
+.section-preview-actions .btn-icon:hover {
+	background: var(--red-50);
+	color: var(--red-500);
 }
 
 /* ── Label case: uppercase (mirrors print_format.css rules for builder canvas) */

--- a/frappe/public/js/print_format_builder/components/inspector/ConfigureColumns.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/ConfigureColumns.vue
@@ -109,7 +109,7 @@ let total_width = computed(() => {
 }
 .total-badge {
 	font-size: var(--text-sm);
-	font-weight: 600;
+	font-weight: var(--weight-semibold);
 	padding: 1px 8px;
 	border-radius: var(--border-radius-sm);
 }
@@ -124,13 +124,13 @@ let total_width = computed(() => {
 .total-bar-track {
 	height: 6px;
 	background: var(--gray-200);
-	border-radius: 99px;
+	border-radius: var(--border-radius-full);
 	overflow: hidden;
 }
 .total-bar-fill {
 	height: 100%;
 	background: var(--green-400);
-	border-radius: 99px;
+	border-radius: var(--border-radius-full);
 	transition: width 0.2s ease, background 0.2s ease;
 }
 .total-bar-fill--over {
@@ -188,7 +188,7 @@ let total_width = computed(() => {
 	align-items: center;
 	border: 1px solid var(--gray-300);
 	border-radius: var(--border-radius);
-	background: white;
+	background: var(--fg-color);
 	overflow: hidden;
 	flex: 1;
 }

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -65,19 +65,7 @@
 
 		<!-- ── Table field inspector ───────────────────────────────── -->
 		<template v-else-if="selected_field && is_table_field">
-			<div class="pfb-insp-tabs">
-				<button
-					v-for="tab in field_tabs"
-					:key="tab.id"
-					class="pfb-insp-tab"
-					:class="{ active: active_tab === tab.id }"
-					@click="active_tab = tab.id"
-				>
-					{{ tab.label }}
-				</button>
-			</div>
-
-			<div v-if="active_tab === 'properties'" class="pfb-insp-body">
+			<div class="pfb-insp-body">
 				<!-- TABLE section -->
 				<div class="pfb-insp-section">
 					<div class="pfb-insp-section-head" @click="toggle('t_table')">
@@ -243,21 +231,6 @@
 					</div>
 				</div>
 
-				<!-- BEHAVIOR section -->
-				<div class="pfb-insp-section">
-					<div class="pfb-insp-section-head" @click="toggle('t_behavior')">
-						<span class="pfb-insp-section-label">{{ __("Behavior") }}</span>
-						<span
-							class="pfb-insp-chevron"
-							:class="{ collapsed: !open.t_behavior }"
-							v-html="frappe.utils.icon('chevron-down', 'xs')"
-						></span>
-					</div>
-					<div v-show="open.t_behavior" class="pfb-insp-section-body">
-						<p class="pfb-insp-hint text-muted">{{ __("Coming soon.") }}</p>
-					</div>
-				</div>
-
 				<div class="pfb-insp-actions">
 					<button class="btn btn-xs btn-danger-subtle" @click="remove_field">
 						<span v-html="frappe.utils.icon('x', 'xs')"></span>
@@ -265,27 +238,11 @@
 					</button>
 				</div>
 			</div>
-
-			<div v-else class="pfb-insp-body pfb-insp-placeholder">
-				<p class="text-muted">{{ __("Coming soon.") }}</p>
-			</div>
 		</template>
 
 		<!-- ── Field inspector ─────────────────────────────────── -->
 		<template v-else-if="selected_field">
-			<div class="pfb-insp-tabs">
-				<button
-					v-for="tab in field_tabs"
-					:key="tab.id"
-					class="pfb-insp-tab"
-					:class="{ active: active_tab === tab.id }"
-					@click="active_tab = tab.id"
-				>
-					{{ tab.label }}
-				</button>
-			</div>
-
-			<div v-if="active_tab === 'properties'" class="pfb-insp-body">
+			<div class="pfb-insp-body">
 				<div class="pfb-insp-section">
 					<div class="pfb-insp-section-head" @click="toggle('f_field')">
 						<span class="pfb-insp-section-label">{{ __("Field") }}</span>
@@ -359,22 +316,6 @@
 								</div>
 							</div>
 						</template>
-					</div>
-				</div>
-
-				<div class="pfb-insp-section">
-					<div class="pfb-insp-section-head" @click="toggle('f_format')">
-						<span class="pfb-insp-section-label">{{ __("Format") }}</span>
-						<span
-							class="pfb-insp-chevron"
-							:class="{ collapsed: !open.f_format }"
-							v-html="frappe.utils.icon('chevron-down', 'xs')"
-						></span>
-					</div>
-					<div v-show="open.f_format" class="pfb-insp-section-body">
-						<p class="pfb-insp-hint text-muted">
-							{{ __("Additional formatting options coming soon.") }}
-						</p>
 					</div>
 				</div>
 
@@ -636,16 +577,8 @@ let selected_section = computed(() => store.selected_section.value);
 let selected_letterhead = computed(() => store.selected_letterhead.value);
 let selected_lh_footer = computed(() => store.selected_lh_footer.value);
 
-let active_tab = ref("properties");
-
-const field_tabs = [
-	{ id: "properties", label: __("Properties") },
-	{ id: "style", label: __("Style") },
-];
-
 const open = ref({
 	f_field: true,
-	f_format: false,
 	f_visibility: false,
 	s_section: true,
 	s_bg: true,
@@ -653,7 +586,6 @@ const open = ref({
 	s_visibility: false,
 	t_table: true,
 	t_columns: true,
-	t_behavior: false,
 });
 
 function toggle(key) {
@@ -1002,7 +934,7 @@ function set_padding(side, value) {
 .pfb-breadcrumb {
 	padding: 4px 10px;
 	border-bottom: 1px solid var(--border-color);
-	background: var(--gray-50);
+	background: var(--fg-color);
 }
 
 .pfb-breadcrumb-btn {
@@ -1046,50 +978,6 @@ function set_padding(side, value) {
 	padding: 24px;
 	text-align: center;
 	font-size: var(--text-sm);
-}
-
-/* ── Tabs ────────────────────────────────────────────────── */
-.pfb-insp-tabs {
-	display: flex;
-	padding: 8px 10px 0;
-	gap: 2px;
-	border-bottom: 1px solid var(--border-color);
-	flex-shrink: 0;
-	background: var(--gray-50);
-}
-
-.pfb-insp-tab {
-	flex: 1;
-	padding: 6px 4px 8px;
-	font-size: var(--text-sm);
-	font-weight: 500;
-	border: none;
-	background: transparent;
-	color: var(--text-muted);
-	cursor: pointer;
-	border-radius: var(--border-radius) var(--border-radius) 0 0;
-	position: relative;
-	transition: color 0.12s;
-}
-
-.pfb-insp-tab:hover {
-	color: var(--text-color);
-}
-
-.pfb-insp-tab.active {
-	color: var(--text-color);
-	font-weight: 600;
-}
-
-.pfb-insp-tab.active::after {
-	content: "";
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	right: 0;
-	height: 2px;
-	background: var(--gray-700);
-	border-radius: 2px 2px 0 0;
 }
 
 /* ── Body ────────────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -203,60 +203,11 @@
 						</draggable>
 						<!-- Add column picker -->
 						<div class="pfb-col-add-row" v-if="available_columns.length">
-							<div class="pfb-col-add-combobox">
-								<div class="pfb-col-add-input-wrap">
-									<span
-										class="pfb-col-add-icon"
-										v-html="frappe.utils.icon('search', 'xs')"
-									></span>
-									<input
-										class="pfb-col-add-input"
-										type="text"
-										:placeholder="__('Add column...')"
-										v-model="col_search"
-										@focus="col_open = true"
-										@blur="setTimeout(() => (col_open = false), 100)"
-										@keydown.escape="col_open = false"
-										@keydown.enter.prevent="add_filtered_column"
-										@keydown.down.prevent="
-											col_highlight = Math.min(
-												col_highlight + 1,
-												filtered_add_columns.length - 1
-											)
-										"
-										@keydown.up.prevent="
-											col_highlight = Math.max(col_highlight - 1, 0)
-										"
-									/>
-								</div>
-								<div
-									v-if="col_open && filtered_add_columns.length"
-									class="pfb-col-add-dropdown"
-								>
-									<button
-										v-for="(col, i) in filtered_add_columns"
-										:key="col.fieldname"
-										class="pfb-col-add-option"
-										:class="{ highlighted: col_highlight === i }"
-										@mousedown.prevent="pick_column(col)"
-									>
-										<span class="pfb-col-add-option-label">{{
-											col.label || col.fieldname
-										}}</span>
-										<span class="pfb-col-add-option-type">{{
-											col.fieldtype
-										}}</span>
-									</button>
-								</div>
-								<div
-									v-if="col_open && !filtered_add_columns.length"
-									class="pfb-col-add-dropdown"
-								>
-									<div class="pfb-col-add-empty">
-										{{ __("No matching columns") }}
-									</div>
-								</div>
-							</div>
+							<Autocomplete
+								:options="available_column_opts"
+								:placeholder="__('Add column...')"
+								@select="pick_column"
+							/>
 						</div>
 						<div
 							v-else
@@ -605,6 +556,7 @@ import { computed, inject, ref } from "vue";
 import draggable from "vuedraggable";
 import { useStore } from "../../stores";
 import LetterHeadZoneInspector from "./LetterHeadZoneInspector.vue";
+import Autocomplete from "../Autocomplete.vue";
 
 let store = inject("$store");
 let { letterhead, layout } = useStore();
@@ -827,28 +779,21 @@ let available_columns = computed(() => {
 		.filter((f) => !existing.has(f.fieldname));
 });
 
-let col_search = ref("");
-let col_open = ref(false);
-let col_highlight = ref(0);
+let available_column_opts = computed(() =>
+	available_columns.value.map((c) => ({
+		label: c.label || c.fieldname,
+		value: c.fieldname,
+		badge: c.fieldtype,
+	}))
+);
 
-let filtered_add_columns = computed(() => {
-	const q = col_search.value.toLowerCase();
-	if (!q) return available_columns.value;
-	return available_columns.value.filter(
-		(c) =>
-			(c.label || "").toLowerCase().includes(q) ||
-			c.fieldname.toLowerCase().includes(q) ||
-			(c.fieldtype || "").toLowerCase().includes(q)
-	);
-});
-
-function pick_column(col) {
+function pick_column(opt) {
 	const meta = frappe.get_meta(selected_field.value.options);
 	let entry;
-	if (col.fieldname === "idx") {
+	if (opt.value === "idx") {
 		entry = { label: __("Sr No."), fieldname: "idx", fieldtype: "Data", width: 10 };
 	} else {
-		const df = meta?.fields.find((f) => f.fieldname === col.fieldname);
+		const df = meta?.fields.find((f) => f.fieldname === opt.value);
 		if (!df) return;
 		entry = {
 			label: df.label,
@@ -860,19 +805,6 @@ function pick_column(col) {
 	}
 	if (!selected_field.value.table_columns) selected_field.value.table_columns = [];
 	selected_field.value.table_columns = [...selected_field.value.table_columns, entry];
-	col_search.value = "";
-	col_open.value = false;
-	col_highlight.value = 0;
-}
-
-function add_filtered_column() {
-	const cols = filtered_add_columns.value;
-	if (!cols.length) return;
-	pick_column(cols[col_highlight.value] || cols[0]);
-}
-
-function add_table_column() {
-	add_filtered_column();
 }
 
 function remove_table_column(idx) {
@@ -1448,105 +1380,6 @@ function set_padding(side, value) {
 .pfb-col-add-row {
 	padding: 6px 14px 10px;
 	border-top: 1px solid var(--gray-100);
-}
-
-.pfb-col-add-combobox {
-	position: relative;
-}
-
-.pfb-col-add-input-wrap {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	padding: 5px 8px;
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius);
-	background: var(--control-bg);
-	transition: border-color 0.1s;
-}
-
-.pfb-col-add-input-wrap:focus-within {
-	border-color: var(--gray-500);
-	background: var(--fg-color);
-}
-
-.pfb-col-add-icon {
-	display: flex;
-	align-items: center;
-	color: var(--gray-400);
-	flex-shrink: 0;
-}
-
-.pfb-col-add-input {
-	flex: 1;
-	border: none;
-	background: transparent;
-	outline: none;
-	font-size: var(--text-sm);
-	color: var(--text-color);
-	min-width: 0;
-}
-
-.pfb-col-add-input::placeholder {
-	color: var(--gray-400);
-}
-
-.pfb-col-add-dropdown {
-	position: absolute;
-	top: calc(100% + 3px);
-	left: 0;
-	right: 0;
-	background: var(--fg-color);
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius);
-	box-shadow: var(--shadow-sm);
-	z-index: 100;
-	max-height: 200px;
-	overflow-y: auto;
-}
-
-.pfb-col-add-option {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	width: 100%;
-	padding: 6px 10px;
-	border: none;
-	background: transparent;
-	text-align: left;
-	cursor: pointer;
-	gap: 8px;
-	font-size: var(--text-sm);
-}
-
-.pfb-col-add-option:hover,
-.pfb-col-add-option.highlighted {
-	background: var(--gray-100);
-}
-
-.pfb-col-add-option-label {
-	flex: 1;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.pfb-col-add-option-type {
-	font-size: var(--text-tiny);
-	color: var(--gray-500);
-	background: var(--gray-100);
-	border: 1px solid var(--gray-200);
-	border-radius: var(--border-radius-sm);
-	padding: 1px 5px;
-	white-space: nowrap;
-	flex-shrink: 0;
-}
-
-.pfb-col-add-empty {
-	padding: 10px 12px;
-	font-size: var(--text-sm);
-	color: var(--text-muted);
-	text-align: center;
 }
 
 .pfb-insp-col-count {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -2,7 +2,6 @@
 	<div class="pfb-inspector" @click.stop>
 		<!-- Header -->
 		<div class="pfb-inspector-head">
-			<div class="pfb-inspector-eyebrow">{{ __("Inspector") }}</div>
 			<div class="pfb-inspector-title">
 				<span class="pfb-inspector-kind">{{ inspector_kind }}</span>
 				<span
@@ -16,6 +15,7 @@
 				>
 					{{ inspector_subtitle }}
 				</span>
+				<span v-else class="pfb-inspector-eyebrow-inline">{{ __("Inspector") }}</span>
 			</div>
 		</div>
 
@@ -896,37 +896,46 @@ function set_padding(side, value) {
 
 /* ── Header ─────────────────────────────────────────────── */
 .pfb-inspector-head {
-	padding: 12px 14px 10px;
+	padding: 8px 12px;
 	border-bottom: 1px solid var(--border-color);
 	flex-shrink: 0;
-}
-
-.pfb-inspector-eyebrow {
-	font-size: var(--text-tiny);
-	font-weight: var(--weight-semibold);
-	text-transform: uppercase;
-	letter-spacing: 0.08em;
-	color: var(--text-muted);
-	margin-bottom: 3px;
+	min-height: 0;
 }
 
 .pfb-inspector-title {
 	display: flex;
-	align-items: baseline;
+	align-items: center;
 	gap: 6px;
+	min-width: 0;
 }
 
 .pfb-inspector-kind {
-	font-size: var(--text-lg);
-	font-weight: var(--weight-bold);
+	font-size: var(--text-sm);
+	font-weight: var(--weight-semibold);
+	white-space: nowrap;
+	flex-shrink: 0;
 }
 
 .pfb-inspector-name {
-	font-size: var(--text-base);
+	font-size: var(--text-sm);
 	color: var(--text-muted);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	flex: 1;
+	min-width: 0;
+}
+
+.pfb-inspector-name::before {
+	content: "·";
+	margin-right: 6px;
+	opacity: 0.4;
+}
+
+.pfb-inspector-eyebrow-inline {
+	font-size: var(--text-sm);
+	font-weight: var(--weight-medium);
+	color: var(--text-muted);
 }
 
 /* ── Breadcrumb ──────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -203,22 +203,60 @@
 						</draggable>
 						<!-- Add column picker -->
 						<div class="pfb-col-add-row" v-if="available_columns.length">
-							<select class="pfb-col-add-select" v-model="add_col_select">
-								<option value="" disabled>{{ __("+ Add column...") }}</option>
-								<option
-									v-for="col in available_columns"
-									:key="col.fieldname"
-									:value="col.fieldname"
+							<div class="pfb-col-add-combobox">
+								<div class="pfb-col-add-input-wrap">
+									<span
+										class="pfb-col-add-icon"
+										v-html="frappe.utils.icon('search', 'xs')"
+									></span>
+									<input
+										class="pfb-col-add-input"
+										type="text"
+										:placeholder="__('Add column...')"
+										v-model="col_search"
+										@focus="col_open = true"
+										@blur="setTimeout(() => (col_open = false), 100)"
+										@keydown.escape="col_open = false"
+										@keydown.enter.prevent="add_filtered_column"
+										@keydown.down.prevent="
+											col_highlight = Math.min(
+												col_highlight + 1,
+												filtered_add_columns.length - 1
+											)
+										"
+										@keydown.up.prevent="
+											col_highlight = Math.max(col_highlight - 1, 0)
+										"
+									/>
+								</div>
+								<div
+									v-if="col_open && filtered_add_columns.length"
+									class="pfb-col-add-dropdown"
 								>
-									{{ col.label || col.fieldname }}
-								</option>
-							</select>
-							<button
-								class="pfb-col-add-btn"
-								@click="add_table_column"
-								:disabled="!add_col_select"
-								v-html="frappe.utils.icon('plus', 'xs')"
-							></button>
+									<button
+										v-for="(col, i) in filtered_add_columns"
+										:key="col.fieldname"
+										class="pfb-col-add-option"
+										:class="{ highlighted: col_highlight === i }"
+										@mousedown.prevent="pick_column(col)"
+									>
+										<span class="pfb-col-add-option-label">{{
+											col.label || col.fieldname
+										}}</span>
+										<span class="pfb-col-add-option-type">{{
+											col.fieldtype
+										}}</span>
+									</button>
+								</div>
+								<div
+									v-if="col_open && !filtered_add_columns.length"
+									class="pfb-col-add-dropdown"
+								>
+									<div class="pfb-col-add-empty">
+										{{ __("No matching columns") }}
+									</div>
+								</div>
+							</div>
 						</div>
 						<div
 							v-else
@@ -789,19 +827,30 @@ let available_columns = computed(() => {
 		.filter((f) => !existing.has(f.fieldname));
 });
 
-let add_col_select = ref("");
+let col_search = ref("");
+let col_open = ref(false);
+let col_highlight = ref(0);
 
-function add_table_column() {
-	if (!add_col_select.value) return;
-	const fieldname = add_col_select.value;
+let filtered_add_columns = computed(() => {
+	const q = col_search.value.toLowerCase();
+	if (!q) return available_columns.value;
+	return available_columns.value.filter(
+		(c) =>
+			(c.label || "").toLowerCase().includes(q) ||
+			c.fieldname.toLowerCase().includes(q) ||
+			(c.fieldtype || "").toLowerCase().includes(q)
+	);
+});
+
+function pick_column(col) {
 	const meta = frappe.get_meta(selected_field.value.options);
-	let col;
-	if (fieldname === "idx") {
-		col = { label: __("Sr No."), fieldname: "idx", fieldtype: "Data", width: 10 };
+	let entry;
+	if (col.fieldname === "idx") {
+		entry = { label: __("Sr No."), fieldname: "idx", fieldtype: "Data", width: 10 };
 	} else {
-		const df = meta?.fields.find((f) => f.fieldname === fieldname);
+		const df = meta?.fields.find((f) => f.fieldname === col.fieldname);
 		if (!df) return;
-		col = {
+		entry = {
 			label: df.label,
 			fieldname: df.fieldname,
 			fieldtype: df.fieldtype,
@@ -810,10 +859,20 @@ function add_table_column() {
 		};
 	}
 	if (!selected_field.value.table_columns) selected_field.value.table_columns = [];
-	selected_field.value.table_columns.push(col);
-	add_col_select.value = "";
-	// trigger reactivity
-	selected_field.value.table_columns = [...selected_field.value.table_columns];
+	selected_field.value.table_columns = [...selected_field.value.table_columns, entry];
+	col_search.value = "";
+	col_open.value = false;
+	col_highlight.value = 0;
+}
+
+function add_filtered_column() {
+	const cols = filtered_add_columns.value;
+	if (!cols.length) return;
+	pick_column(cols[col_highlight.value] || cols[0]);
+}
+
+function add_table_column() {
+	add_filtered_column();
 }
 
 function remove_table_column(idx) {
@@ -1387,52 +1446,107 @@ function set_padding(side, value) {
 }
 
 .pfb-col-add-row {
-	display: flex;
-	align-items: center;
-	gap: 6px;
 	padding: 6px 14px 10px;
 	border-top: 1px solid var(--gray-100);
 }
 
-.pfb-col-add-select {
-	flex: 1;
-	font-size: var(--text-sm);
-	padding: 4px 6px;
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius);
-	background: var(--fg-color);
-	color: var(--text-color);
-	outline: none;
-	min-width: 0;
+.pfb-col-add-combobox {
+	position: relative;
 }
 
-.pfb-col-add-select:focus {
-	border-color: var(--gray-500);
-}
-
-.pfb-col-add-btn {
+.pfb-col-add-input-wrap {
 	display: flex;
 	align-items: center;
-	justify-content: center;
-	width: 26px;
-	height: 26px;
+	gap: 6px;
+	padding: 5px 8px;
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius);
-	background: var(--gray-50);
-	cursor: pointer;
-	color: var(--text-muted);
+	background: var(--control-bg);
+	transition: border-color 0.1s;
+}
+
+.pfb-col-add-input-wrap:focus-within {
+	border-color: var(--gray-500);
+	background: var(--fg-color);
+}
+
+.pfb-col-add-icon {
+	display: flex;
+	align-items: center;
+	color: var(--gray-400);
 	flex-shrink: 0;
 }
 
-.pfb-col-add-btn:hover:not(:disabled) {
-	background: var(--gray-100);
+.pfb-col-add-input {
+	flex: 1;
+	border: none;
+	background: transparent;
+	outline: none;
+	font-size: var(--text-sm);
 	color: var(--text-color);
-	border-color: var(--gray-400);
+	min-width: 0;
 }
 
-.pfb-col-add-btn:disabled {
-	opacity: 0.4;
-	cursor: not-allowed;
+.pfb-col-add-input::placeholder {
+	color: var(--gray-400);
+}
+
+.pfb-col-add-dropdown {
+	position: absolute;
+	top: calc(100% + 3px);
+	left: 0;
+	right: 0;
+	background: var(--fg-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	box-shadow: var(--shadow-sm);
+	z-index: 100;
+	max-height: 200px;
+	overflow-y: auto;
+}
+
+.pfb-col-add-option {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+	padding: 6px 10px;
+	border: none;
+	background: transparent;
+	text-align: left;
+	cursor: pointer;
+	gap: 8px;
+	font-size: var(--text-sm);
+}
+
+.pfb-col-add-option:hover,
+.pfb-col-add-option.highlighted {
+	background: var(--gray-100);
+}
+
+.pfb-col-add-option-label {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.pfb-col-add-option-type {
+	font-size: var(--text-tiny);
+	color: var(--gray-500);
+	background: var(--gray-100);
+	border: 1px solid var(--gray-200);
+	border-radius: var(--border-radius-sm);
+	padding: 1px 5px;
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+.pfb-col-add-empty {
+	padding: 10px 12px;
+	font-size: var(--text-sm);
+	color: var(--text-muted);
+	text-align: center;
 }
 
 .pfb-insp-col-count {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -556,7 +556,7 @@ import { computed, inject, ref } from "vue";
 import draggable from "vuedraggable";
 import { useStore } from "../../stores";
 import LetterHeadZoneInspector from "./LetterHeadZoneInspector.vue";
-import Autocomplete from "../../../../vue-components/Autocomplete.vue";
+import Autocomplete from "../../../vue-components/Autocomplete.vue";
 
 let store = inject("$store");
 let { letterhead, layout } = useStore();

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -1067,6 +1067,8 @@ function set_padding(side, value) {
 	border-radius: var(--border-radius);
 	background: var(--gray-50);
 	gap: 6px;
+	min-width: 0;
+	overflow: hidden;
 }
 
 .pfb-source-name {
@@ -1074,6 +1076,7 @@ function set_padding(side, value) {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	min-width: 0;
 }
 
 .pfb-type-badge {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -556,7 +556,7 @@ import { computed, inject, ref } from "vue";
 import draggable from "vuedraggable";
 import { useStore } from "../../stores";
 import LetterHeadZoneInspector from "./LetterHeadZoneInspector.vue";
-import Autocomplete from "../Autocomplete.vue";
+import Autocomplete from "../../../../vue-components/Autocomplete.vue";
 
 let store = inject("$store");
 let { letterhead, layout } = useStore();

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -902,8 +902,8 @@ function set_padding(side, value) {
 }
 
 .pfb-inspector-eyebrow {
-	font-size: 10px;
-	font-weight: 600;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-semibold);
 	text-transform: uppercase;
 	letter-spacing: 0.08em;
 	color: var(--text-muted);
@@ -918,7 +918,7 @@ function set_padding(side, value) {
 
 .pfb-inspector-kind {
 	font-size: var(--text-lg);
-	font-weight: 700;
+	font-weight: var(--weight-bold);
 }
 
 .pfb-inspector-name {
@@ -1009,12 +1009,12 @@ function set_padding(side, value) {
 }
 
 .pfb-insp-section-head:hover {
-	background: var(--gray-50);
+	background: var(--subtle-accent);
 }
 
 .pfb-insp-section-label {
-	font-size: 10px;
-	font-weight: 700;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-bold);
 	text-transform: uppercase;
 	letter-spacing: 0.08em;
 	color: var(--text-muted);
@@ -1064,7 +1064,7 @@ function set_padding(side, value) {
 	padding: 5px 8px;
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius);
-	background: var(--gray-50);
+	background: var(--control-bg);
 	gap: 6px;
 	min-width: 0;
 	overflow: hidden;
@@ -1079,7 +1079,7 @@ function set_padding(side, value) {
 }
 
 .pfb-type-badge {
-	font-size: 10px;
+	font-size: var(--text-tiny);
 	color: var(--text-muted);
 	background: var(--gray-100);
 	border: 1px solid var(--gray-300);
@@ -1109,7 +1109,7 @@ function set_padding(side, value) {
 /* ── Segmented control ───────────────────────────────────── */
 .pfb-seg {
 	display: inline-flex;
-	background: var(--gray-100);
+	background: var(--control-bg);
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius);
 	overflow: hidden;
@@ -1119,8 +1119,8 @@ function set_padding(side, value) {
 .pfb-seg button {
 	flex: 1;
 	padding: 5px 6px;
-	font-size: 11px;
-	font-weight: 500;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-medium);
 	border: none;
 	border-radius: 0;
 	background: transparent;
@@ -1154,7 +1154,7 @@ function set_padding(side, value) {
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius);
 	overflow: hidden;
-	background: var(--gray-50);
+	background: var(--subtle-accent);
 	width: 100%;
 }
 
@@ -1211,7 +1211,7 @@ function set_padding(side, value) {
 }
 
 .pfb-stepper-unit {
-	font-size: 10px;
+	font-size: var(--text-tiny);
 	color: var(--text-muted);
 	padding: 0 6px 0 2px;
 }
@@ -1260,7 +1260,7 @@ function set_padding(side, value) {
 }
 
 .pfb-padding-label {
-	font-size: 10px;
+	font-size: var(--text-tiny);
 	color: var(--text-muted);
 	text-align: center;
 }
@@ -1336,7 +1336,7 @@ function set_padding(side, value) {
 .pfb-col-width-input {
 	width: 40px;
 	padding: 2px 4px;
-	font-size: 11px;
+	font-size: var(--text-tiny);
 	text-align: right;
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius-sm);
@@ -1356,7 +1356,7 @@ function set_padding(side, value) {
 }
 
 .pfb-col-width-unit {
-	font-size: 10px;
+	font-size: var(--text-tiny);
 	color: var(--text-muted);
 	flex-shrink: 0;
 }
@@ -1428,7 +1428,7 @@ function set_padding(side, value) {
 }
 
 .pfb-insp-col-count {
-	font-size: 11px;
+	font-size: var(--text-tiny);
 }
 
 /* ── Letter Head inspector ───────────────────────────────── */
@@ -1436,8 +1436,8 @@ function set_padding(side, value) {
 	display: flex;
 	align-items: center;
 	gap: 6px;
-	font-size: 11px;
-	font-weight: 600;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-semibold);
 	text-transform: uppercase;
 	letter-spacing: 0.06em;
 	color: var(--blue-500);
@@ -1480,10 +1480,10 @@ function set_padding(side, value) {
 	display: flex;
 	align-items: center;
 	gap: 6px;
-	font-size: 11px;
-	color: var(--yellow-800, #854d0e);
-	background: var(--yellow-50, #fefce8);
-	border-bottom: 1px solid var(--yellow-200, #fde68a);
+	font-size: var(--text-tiny);
+	color: var(--yellow-800);
+	background: var(--yellow-50);
+	border-bottom: 1px solid var(--yellow-200);
 	padding: 7px 14px;
 	flex-shrink: 0;
 	line-height: 1.4;
@@ -1528,8 +1528,8 @@ function set_padding(side, value) {
 }
 
 .pfb-html-split-label {
-	font-size: 10px;
-	font-weight: 700;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-bold);
 	text-transform: uppercase;
 	letter-spacing: 0.08em;
 	color: var(--text-muted);

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -36,7 +36,6 @@
 
 		<!-- Letter Head notice — shown whenever the letterhead is selected -->
 		<div v-if="selected_letterhead || selected_lh_footer" class="pfb-lh-notice">
-			<span v-html="frappe.utils.icon('alert-circle', 'xs')"></span>
 			{{ __("Edits here update the Letter Head document directly.") }}
 		</div>
 

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -668,7 +668,6 @@ let current_align = computed(() => selected_field.value?.align ?? "left");
 const show_label_opts = [
 	{ value: "show", label: __("Show") },
 	{ value: "hide", label: __("Hide") },
-	{ value: "inline", label: __("Inline") },
 ];
 
 const align_icons = {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -401,27 +401,11 @@
 					</button>
 				</div>
 			</div>
-
-			<div v-else class="pfb-insp-body pfb-insp-placeholder">
-				<p class="text-muted">{{ __("Coming soon.") }}</p>
-			</div>
 		</template>
 
 		<!-- ── Section inspector ───────────────────────────────── -->
 		<template v-else-if="selected_section">
-			<div class="pfb-insp-tabs">
-				<button
-					v-for="tab in section_tabs"
-					:key="tab.id"
-					class="pfb-insp-tab"
-					:class="{ active: active_tab === tab.id }"
-					@click="active_tab = tab.id"
-				>
-					{{ tab.label }}
-				</button>
-			</div>
-
-			<div v-if="active_tab === 'properties'" class="pfb-insp-body">
+			<div class="pfb-insp-body">
 				<!-- SECTION properties -->
 				<div class="pfb-insp-section">
 					<div class="pfb-insp-section-head" @click="toggle('s_section')">
@@ -541,40 +525,7 @@
 					</div>
 				</div>
 
-				<!-- VISIBILITY -->
-				<div class="pfb-insp-section">
-					<div class="pfb-insp-section-head" @click="toggle('s_visibility')">
-						<span class="pfb-insp-section-label">{{ __("Visibility") }}</span>
-						<span
-							class="pfb-insp-chevron"
-							:class="{ collapsed: !open.s_visibility }"
-							v-html="frappe.utils.icon('chevron-down', 'xs')"
-						></span>
-					</div>
-					<div v-show="open.s_visibility" class="pfb-insp-section-body">
-						<p class="pfb-insp-hint text-muted">
-							{{ __("Conditional visibility coming soon.") }}
-						</p>
-					</div>
-				</div>
-
-				<div class="pfb-insp-actions">
-					<button
-						class="btn btn-xs btn-danger-subtle"
-						@click="
-							selected_section.remove = true;
-							store.selected_section.value = null;
-						"
-					>
-						<span v-html="frappe.utils.icon('x', 'xs')"></span>
-						{{ __("Remove section") }}
-					</button>
-				</div>
-			</div>
-
-			<!-- ── Style tab ───────────────────────────────────────── -->
-			<div v-else-if="active_tab === 'style'" class="pfb-insp-body">
-				<!-- Background -->
+				<!-- BACKGROUND -->
 				<div class="pfb-insp-section">
 					<div class="pfb-insp-section-head" @click="toggle('s_bg')">
 						<span class="pfb-insp-section-label">{{ __("Background") }}</span>
@@ -599,7 +550,7 @@
 					</div>
 				</div>
 
-				<!-- Padding -->
+				<!-- PADDING -->
 				<div class="pfb-insp-section">
 					<div class="pfb-insp-section-head" @click="toggle('s_padding')">
 						<span class="pfb-insp-section-label">{{ __("Padding") }}</span>
@@ -636,10 +587,36 @@
 						</div>
 					</div>
 				</div>
-			</div>
 
-			<div v-else class="pfb-insp-body pfb-insp-placeholder">
-				<p class="text-muted">{{ __("Coming soon.") }}</p>
+				<!-- VISIBILITY -->
+				<div class="pfb-insp-section">
+					<div class="pfb-insp-section-head" @click="toggle('s_visibility')">
+						<span class="pfb-insp-section-label">{{ __("Visibility") }}</span>
+						<span
+							class="pfb-insp-chevron"
+							:class="{ collapsed: !open.s_visibility }"
+							v-html="frappe.utils.icon('chevron-down', 'xs')"
+						></span>
+					</div>
+					<div v-show="open.s_visibility" class="pfb-insp-section-body">
+						<p class="pfb-insp-hint text-muted">
+							{{ __("Conditional visibility coming soon.") }}
+						</p>
+					</div>
+				</div>
+
+				<div class="pfb-insp-actions">
+					<button
+						class="btn btn-xs btn-danger-subtle"
+						@click="
+							selected_section.remove = true;
+							store.selected_section.value = null;
+						"
+					>
+						<span v-html="frappe.utils.icon('x', 'xs')"></span>
+						{{ __("Remove section") }}
+					</button>
+				</div>
 			</div>
 		</template>
 	</div>
@@ -664,12 +641,6 @@ let active_tab = ref("properties");
 const field_tabs = [
 	{ id: "properties", label: __("Properties") },
 	{ id: "style", label: __("Style") },
-	{ id: "logic", label: __("Logic") },
-];
-const section_tabs = [
-	{ id: "properties", label: __("Properties") },
-	{ id: "style", label: __("Style") },
-	{ id: "logic", label: __("Logic") },
 ];
 
 const open = ref({

--- a/frappe/public/js/print_format_builder/components/inspector/LetterHeadZoneInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/LetterHeadZoneInspector.vue
@@ -14,13 +14,13 @@
 					<div class="pfb-seg">
 						<button
 							:class="{ active: zone_source === 'Image' }"
-							@click="letterhead && (letterhead[source_field] = 'Image')"
+							@click="set_source('Image')"
 						>
 							{{ __("Image") }}
 						</button>
 						<button
 							:class="{ active: zone_source === 'HTML' }"
-							@click="letterhead && (letterhead[source_field] = 'HTML')"
+							@click="set_source('HTML')"
 						>
 							{{ __("HTML") }}
 						</button>
@@ -101,7 +101,7 @@
 								v-for="dir in ['Left', 'Center', 'Right']"
 								:key="dir"
 								:class="{ active: zone_align === dir }"
-								@click="letterhead[align_field] = dir"
+								@click="set_align(dir)"
 							>
 								{{ __(dir) }}
 							</button>
@@ -190,6 +190,18 @@ const zone_size_max = computed(() => {
 	return rf === width_field.value ? 700 : 500;
 });
 
+function set_source(val) {
+	if (!letterhead.value) return;
+	letterhead.value[source_field.value] = val;
+	letterhead.value._dirty = true;
+}
+
+function set_align(val) {
+	if (!letterhead.value) return;
+	letterhead.value[align_field.value] = val;
+	letterhead.value._dirty = true;
+}
+
 function set_size(val) {
 	if (!letterhead.value || !range_field.value) return;
 	const v = parseFloat(val);
@@ -199,6 +211,7 @@ function set_size(val) {
 		const other = is_width ? height_field.value : width_field.value;
 		letterhead.value[other] = is_width ? v / aspect_ratio.value : aspect_ratio.value * v;
 	}
+	letterhead.value._dirty = true;
 }
 
 function upload_image() {
@@ -220,8 +233,8 @@ function upload_image() {
 				letterhead.value[height_field.value] = new_height;
 				if (props.zone === "footer") {
 					letterhead.value[source_field.value] = "Image";
-					letterhead.value._dirty = true;
 				}
+				letterhead.value._dirty = true;
 			});
 		},
 	});

--- a/frappe/public/js/print_format_builder/components/inspector/LetterHeadZoneInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/LetterHeadZoneInspector.vue
@@ -378,8 +378,8 @@ function lh_create_letterhead() {
 }
 
 .pfb-insp-section-label {
-	font-size: 10px;
-	font-weight: 700;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-bold);
 	text-transform: uppercase;
 	letter-spacing: 0.08em;
 	color: var(--text-muted);
@@ -432,8 +432,8 @@ function lh_create_letterhead() {
 .pfb-seg button {
 	flex: 1;
 	padding: 5px 6px;
-	font-size: 11px;
-	font-weight: 500;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-medium);
 	border: none;
 	border-radius: 0;
 	background: transparent;
@@ -469,8 +469,8 @@ function lh_create_letterhead() {
 	display: flex;
 	align-items: center;
 	gap: 6px;
-	font-size: 11px;
-	font-weight: 600;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-semibold);
 	text-transform: uppercase;
 	letter-spacing: 0.06em;
 	color: var(--blue-500);

--- a/frappe/public/js/vue-components/Autocomplete.vue
+++ b/frappe/public/js/vue-components/Autocomplete.vue
@@ -1,10 +1,37 @@
+<!--
+  Autocomplete — searchable combobox for add-more workflows (no headlessui required)
+
+  Props:
+    options     Array<{ label, value, badge? }>   List of options to search through
+    placeholder string                            Input placeholder (default: "Search...")
+
+  Events:
+    @select(opt)   Fired when user picks an option. `opt` is the full option object.
+                   Input clears automatically; dropdown stays open for the next pick.
+
+  Exposes:
+    focus()   Programmatically focus the input
+
+  Usage:
+    <Autocomplete
+      :options="[{ label: 'Item Name', value: 'item_name', badge: 'Data' }]"
+      placeholder="Add column..."
+      @select="(opt) => add_column(opt.value)"
+    />
+
+  Import:
+    import Autocomplete from "../../../vue-components/Autocomplete.vue";
+-->
 <template>
-	<div class="pfb-autocomplete">
-		<div class="pfb-autocomplete-input-wrap" :class="{ focused }">
-			<span class="pfb-autocomplete-icon" v-html="frappe.utils.icon('search', 'xs')"></span>
+	<div class="frappe-autocomplete">
+		<div class="frappe-autocomplete-input-wrap" :class="{ focused }">
+			<span
+				class="frappe-autocomplete-icon"
+				v-html="frappe.utils.icon('search', 'xs')"
+			></span>
 			<input
 				ref="input_el"
-				class="pfb-autocomplete-input"
+				class="frappe-autocomplete-input"
 				type="text"
 				:placeholder="placeholder || __('Search...')"
 				v-model="query"
@@ -16,22 +43,22 @@
 				@keydown.up.prevent="highlight = Math.max(highlight - 1, 0)"
 			/>
 		</div>
-		<div v-if="focused" class="pfb-autocomplete-dropdown">
+		<div v-if="focused" class="frappe-autocomplete-dropdown">
 			<template v-if="filtered.length">
 				<button
 					v-for="(opt, i) in filtered"
 					:key="opt.value"
-					class="pfb-autocomplete-option"
+					class="frappe-autocomplete-option"
 					:class="{ highlighted: highlight === i }"
 					@mousedown.prevent="select(opt)"
 				>
-					<span class="pfb-autocomplete-option-label">{{ opt.label }}</span>
-					<span v-if="opt.badge" class="pfb-autocomplete-option-badge">{{
+					<span class="frappe-autocomplete-option-label">{{ opt.label }}</span>
+					<span v-if="opt.badge" class="frappe-autocomplete-option-badge">{{
 						opt.badge
 					}}</span>
 				</button>
 			</template>
-			<div v-else class="pfb-autocomplete-empty">{{ __("No results") }}</div>
+			<div v-else class="frappe-autocomplete-empty">{{ __("No results") }}</div>
 		</div>
 	</div>
 </template>
@@ -81,11 +108,11 @@ defineExpose({ focus: () => input_el.value?.focus() });
 </script>
 
 <style scoped>
-.pfb-autocomplete {
+.frappe-autocomplete {
 	position: relative;
 }
 
-.pfb-autocomplete-input-wrap {
+.frappe-autocomplete-input-wrap {
 	display: flex;
 	align-items: center;
 	gap: 6px;
@@ -96,19 +123,19 @@ defineExpose({ focus: () => input_el.value?.focus() });
 	transition: border-color 0.1s, background 0.1s;
 }
 
-.pfb-autocomplete-input-wrap.focused {
+.frappe-autocomplete-input-wrap.focused {
 	border-color: var(--gray-500);
 	background: var(--fg-color);
 }
 
-.pfb-autocomplete-icon {
+.frappe-autocomplete-icon {
 	display: flex;
 	align-items: center;
 	color: var(--gray-400);
 	flex-shrink: 0;
 }
 
-.pfb-autocomplete-input {
+.frappe-autocomplete-input {
 	flex: 1;
 	border: none;
 	background: transparent;
@@ -118,11 +145,11 @@ defineExpose({ focus: () => input_el.value?.focus() });
 	min-width: 0;
 }
 
-.pfb-autocomplete-input::placeholder {
+.frappe-autocomplete-input::placeholder {
 	color: var(--gray-400);
 }
 
-.pfb-autocomplete-dropdown {
+.frappe-autocomplete-dropdown {
 	position: absolute;
 	top: calc(100% + 3px);
 	left: 0;
@@ -136,7 +163,7 @@ defineExpose({ focus: () => input_el.value?.focus() });
 	overflow-y: auto;
 }
 
-.pfb-autocomplete-option {
+.frappe-autocomplete-option {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
@@ -150,19 +177,19 @@ defineExpose({ focus: () => input_el.value?.focus() });
 	font-size: var(--text-sm);
 }
 
-.pfb-autocomplete-option:hover,
-.pfb-autocomplete-option.highlighted {
+.frappe-autocomplete-option:hover,
+.frappe-autocomplete-option.highlighted {
 	background: var(--gray-100);
 }
 
-.pfb-autocomplete-option-label {
+.frappe-autocomplete-option-label {
 	flex: 1;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
-.pfb-autocomplete-option-badge {
+.frappe-autocomplete-option-badge {
 	font-size: var(--text-tiny);
 	color: var(--gray-500);
 	background: var(--gray-100);
@@ -173,7 +200,7 @@ defineExpose({ focus: () => input_el.value?.focus() });
 	flex-shrink: 0;
 }
 
-.pfb-autocomplete-empty {
+.frappe-autocomplete-empty {
 	padding: 10px 12px;
 	font-size: var(--text-sm);
 	color: var(--text-muted);

--- a/frappe/public/js/vue-components/Autocomplete.vue
+++ b/frappe/public/js/vue-components/Autocomplete.vue
@@ -36,8 +36,8 @@
 				:placeholder="placeholder || __('Search...')"
 				v-model="query"
 				@focus="focused = true"
-				@blur="setTimeout(() => (focused = false), 100)"
-				@keydown.escape="input_el.blur()"
+				@blur="on_blur"
+				@keydown.escape="on_escape"
 				@keydown.enter.prevent="confirm_highlight"
 				@keydown.down.prevent="highlight = Math.min(highlight + 1, filtered.length - 1)"
 				@keydown.up.prevent="highlight = Math.max(highlight - 1, 0)"
@@ -92,6 +92,14 @@ const filtered = computed(() => {
 watch(filtered, () => {
 	highlight.value = 0;
 });
+
+function on_blur() {
+	setTimeout(() => (focused.value = false), 100);
+}
+
+function on_escape() {
+	input_el.value?.blur();
+}
 
 function select(opt) {
 	emit("select", opt);


### PR DESCRIPTION
## Fixed
- Letter head changes (width, alignment, source, image upload) not saving — inspector mutations never set \`_dirty\` flag
- Drag handle and remove button overlapping in preview mode — unified into corner action pills
- Outline panel not updating inspector when letter head was selected
- Source display text overflowing inspector panel
- Broken \`alert-circle\` icon leaving empty space in letter head notice
- All-caps INSPECTOR eyebrow and wasted vertical space in inspector header
- Add-column dropdown not reopening after selection via keyboard

## Refactored
- Section inspector: merged Style tab into Properties, removed non-functional Logic tab
- Field inspector: removed tabs, removed placeholder Format/Behavior sections, removed non-functional Inline label option
- Inspector header: removed eyebrow label, compacted kind + name into single row
- Add-column \`<select>\` replaced with searchable autocomplete combobox

## Added
- Reusable \`Autocomplete.vue\` at \`frappe/public/js/vue-components/\` (no headlessui dependency)

## Chore
- Applied Espresso design tokens across all print format builder components (font sizes, weights, border radii, backgrounds)