### PR TITLE
feat(search): add search back to the navbar

### DIFF
--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -25,9 +25,9 @@ frappe.ui.keys.standard_shortcuts = standard_shortcuts;
 frappe.ui.keys.get_shortcut_label = function (shortcut) {
 	let label = shortcut.split("+").map(frappe.utils.to_title_case).join("+");
 	if (frappe.utils.is_mac()) {
-		label = label.replace("Ctrl+", "⌘").replace("Alt+", "⌥");
+		label = label.replace("Ctrl+", "⌘").replace("Alt+", "⌥").replace("Shift+", "⇧");
 	}
-	return label.replace("Shift+", "⇧");
+	return label;
 };
 frappe.ui.keys.add_shortcut = ({
 	shortcut,

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -25,9 +25,9 @@ frappe.ui.keys.standard_shortcuts = standard_shortcuts;
 frappe.ui.keys.get_shortcut_label = function (shortcut) {
 	let label = shortcut.split("+").map(frappe.utils.to_title_case).join("+");
 	if (frappe.utils.is_mac()) {
-		label = label.replace("Ctrl", "⌘").replace("Alt", "⌥");
+		label = label.replace("Ctrl+", "⌘").replace("Alt+", "⌥");
 	}
-	return label.replace("Shift", "⇧");
+	return label.replace("Shift+", "⇧");
 };
 frappe.ui.keys.add_shortcut = ({
 	shortcut,

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -31,11 +31,9 @@
 					</span>
 				</button>
 				{% if(!frappe.is_mobile()) { %}
-				<button id="full-search-button" class="btn-reset navbar-modal-search-mobile search-widget-button hidden" aria-label="{{ __("Search") }}">
+				<button id="full-search-button" class="btn btn-default navbar-modal-search-mobile search-widget-button hidden" aria-label="{{ __("Search") }}">
 					<span class="search-widget-icon">
-						<svg class="icon icon-xs">
-							<use href="#icon-search"></use>
-						</svg>
+						{{ frappe.utils.icon("search") }}
 					</span>
 					<span class="search-widget-label">{%= __("Search") %}</span>
 					<span class="search-widget-shortcut">

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -40,7 +40,7 @@
 					<span class="search-widget-label">{%= __("Search") %}</span>
 					<span class="search-widget-shortcut">
 					{% if(frappe.utils.is_mac()) { %}
-						{%= frappe.utils.icon("command", "xs") %}K
+						⌘K
 					{% } else { %}
 						Ctrl K
 					{% } %}

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -25,18 +25,13 @@
 				</div>
 			</div>
 			<div class="align-center flex standard-items-section">
-				<div id="small-search-button" class="search-bar text-muted hidden">
-					<div
-						class="navbar-modal-search-mobile"
-						placeholder="Search for type a command"
-					>
-						<span class="search-icon">
-							<svg class="icon icon-sm"><use href="#icon-search"></use></svg>
-						</span>
-					</div>
-				</div>
+				<button id="small-search-button" class="btn-reset search-bar navbar-modal-search-mobile hidden" aria-label="{{ __("Search") }}">
+					<span class="search-icon">
+						<svg class="icon icon-sm"><use href="#icon-search"></use></svg>
+					</span>
+				</button>
 				{% if(!frappe.is_mobile()) { %}
-				<button id="full-search-button" class="btn-reset navbar-modal-search-mobile search-widget-button hidden" aria-label="{{ __("Search") }}">
+				<button id="full-search-button" class="btn btn-default btn-sm navbar-modal-search-mobile search-widget-button hidden" aria-label="{{ __("Search") }}">
 					<span class="search-widget-icon">
 						<svg class="icon icon-sm">
 							<use href="#icon-search"></use>

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -40,7 +40,7 @@
 					{% if(frappe.utils.is_mac()) { %}
 						⌘K
 					{% } else { %}
-						Ctrl K
+						Ctrl+K
 					{% } %}
 					</span>
 				</button>

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -40,9 +40,9 @@
 					</span>
 					<span class="search-widget-shortcut">
 					{% if(frappe.utils.is_mac()) { %}
-						⌘K
+						{%= frappe.utils.icon("command", "xs") %}K
 					{% } else { %}
-						Ctrl+K
+						Ctrl K
 					{% } %}
 					</span>
 				</button>

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -31,13 +31,13 @@
 					</span>
 				</button>
 				{% if(!frappe.is_mobile()) { %}
-				<button id="full-search-button" class="btn btn-default btn-sm navbar-modal-search-mobile search-widget-button hidden" aria-label="{{ __("Search") }}">
+				<button id="full-search-button" class="btn-reset navbar-modal-search-mobile search-widget-button hidden" aria-label="{{ __("Search") }}">
 					<span class="search-widget-icon">
 						<svg class="icon icon-sm">
 							<use href="#icon-search"></use>
 						</svg>
-						{%= __("Search") %}
 					</span>
+					<span class="search-widget-label">{%= __("Search") %}</span>
 					<span class="search-widget-shortcut">
 					{% if(frappe.utils.is_mac()) { %}
 						{%= frappe.utils.icon("command", "xs") %}K

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -33,7 +33,7 @@
 				{% if(!frappe.is_mobile()) { %}
 				<button id="full-search-button" class="btn-reset navbar-modal-search-mobile search-widget-button hidden" aria-label="{{ __("Search") }}">
 					<span class="search-widget-icon">
-						<svg class="icon icon-sm">
+						<svg class="icon icon-xs">
 							<use href="#icon-search"></use>
 						</svg>
 					</span>

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -573,21 +573,6 @@ frappe.ui.Sidebar = class Sidebar {
 	add_standard_items(items) {
 		if (this.standard_items_setup) return;
 		this.standard_items = [];
-		if (!frappe.is_mobile() && frappe.boot.desk_settings.search_bar) {
-			this.standard_items.push({
-				label: __("Search"),
-				icon: "search",
-				standard: true,
-				type: "Button",
-				class: "navbar-search-bar",
-				suffix: {
-					keyboard_shortcut: "Ctrl+K",
-				},
-				onClick: () => {
-					frappe.app.awesome_bar && frappe.app.awesome_bar.open();
-				},
-			});
-		}
 		this.standard_items.push({
 			label: __("Notification"),
 			icon: "bell",

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -573,6 +573,21 @@ frappe.ui.Sidebar = class Sidebar {
 	add_standard_items(items) {
 		if (this.standard_items_setup) return;
 		this.standard_items = [];
+		if (!frappe.is_mobile() && frappe.boot.desk_settings.search_bar) {
+			this.standard_items.push({
+				label: __("Search"),
+				icon: "search",
+				standard: true,
+				type: "Button",
+				class: "navbar-search-bar",
+				suffix: {
+					keyboard_shortcut: "Ctrl+K",
+				},
+				onClick: () => {
+					frappe.app.awesome_bar && frappe.app.awesome_bar.open();
+				},
+			});
+		}
 		this.standard_items.push({
 			label: __("Notification"),
 			icon: "bell",

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -467,19 +467,13 @@ frappe.search.AwesomeBar = class AwesomeBar {
 	setup_correct_button(wrapper) {
 		let small_button = $(wrapper).find("#small-search-button");
 		let full_button = $(wrapper).find("#full-search-button");
-		let route = frappe.get_route();
 		if (frappe.is_mobile()) {
 			small_button.removeClass("hidden");
 			full_button.addClass("hidden");
 			return;
 		}
-		if (route[0] == "Workspaces" || frappe.is_mobile()) {
-			small_button.addClass("hidden");
-			full_button.removeClass("hidden");
-		} else {
-			full_button.addClass("hidden");
-			small_button.removeClass("hidden");
-		}
+		small_button.addClass("hidden");
+		full_button.removeClass("hidden");
 	}
 	setup_page_change_event() {
 		const me = this;

--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -755,10 +755,6 @@ details > summary:focus {
 }
 
 #full-search-button {
-	width: 200px;
-	display: flex;
-	align-items: center;
-
 	svg {
 		margin: 0px;
 	}

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -49,6 +49,7 @@
 
 .search-bar {
 	max-width: 300px;
+	height: 100%;
 	svg {
 		stroke: var(--icon-stroke);
 		margin-bottom: 2px;

--- a/frappe/public/scss/desk/search_widget.scss
+++ b/frappe/public/scss/desk/search_widget.scss
@@ -4,31 +4,31 @@
 }
 
 .search-widget-button {
-	background-color: var(--control-bg);
-	border-radius: var(--border-radius-sm);
-	height: 32px;
-	padding: 0 10px;
-	display: flex;
+	display: inline-flex;
 	align-items: center;
 	justify-content: space-between;
-	width: 100%;
-	margin-right: 0;
-
-	span {
-		color: var(--text-light);
-	}
+	gap: 8px;
 
 	.search-widget-icon {
 		display: flex;
 		align-items: center;
 		gap: 6px;
+		color: var(--text-light);
 
 		> svg {
 			stroke: var(--text-light);
+			flex-shrink: 0;
 		}
 	}
 
-	&:hover {
-		outline: 1px solid var(--surface-gray-3);
+	.search-widget-shortcut {
+		background-color: var(--control-bg);
+		border: 1px solid var(--border-color);
+		border-radius: var(--border-radius-tiny);
+		padding: 1px 5px;
+		font-size: var(--text-xs);
+		color: var(--text-muted);
+		white-space: nowrap;
+		line-height: 1.4;
 	}
 }

--- a/frappe/public/scss/desk/search_widget.scss
+++ b/frappe/public/scss/desk/search_widget.scss
@@ -13,6 +13,7 @@
 	border-radius: var(--border-radius-full);
 	cursor: pointer;
 	transition: background-color 0.15s ease;
+	white-space: nowrap;
 
 	&:hover {
 		background-color: var(--control-bg-on-gray);
@@ -29,23 +30,12 @@
 	}
 
 	.search-widget-label {
-		@include get_textstyle("base", "regular");
+		@include get_textstyle("sm", "regular");
 		color: var(--text-light);
-		white-space: nowrap;
 	}
 
 	.search-widget-shortcut {
-		display: flex;
-		align-items: center;
-		gap: 3px;
-		margin-left: 4px;
-		font-size: var(--text-xs);
+		@include get_textstyle("sm", "regular");
 		color: var(--text-muted);
-		white-space: nowrap;
-
-		svg {
-			stroke: var(--text-muted);
-			flex-shrink: 0;
-		}
 	}
 }

--- a/frappe/public/scss/desk/search_widget.scss
+++ b/frappe/public/scss/desk/search_widget.scss
@@ -3,35 +3,39 @@
 	position: relative;
 }
 
+#full-search-button {
+	height: 28px;
+}
+
 .search-widget-button {
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
-	height: 28px;
 	padding: 0 10px;
 	background-color: var(--control-bg);
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius-sm);
-	cursor: pointer;
-	white-space: nowrap;
-	transition: background-color 0.1s ease;
+	width: 100%;
+	justify-content: space-between;
+	color: var(--text-light);
 
 	&:hover {
 		background-color: var(--control-bg-on-gray);
 	}
 
-	.search-widget-icon svg {
-		stroke: var(--text-muted);
+	.search-widget-icon {
+		margin-bottom: 1px;
+		svg {
+			stroke: var(--text-muted);
+		}
 	}
 
 	.search-widget-label {
 		font-size: var(--text-sm);
-		color: var(--text-muted);
 	}
 
 	.search-widget-shortcut {
-		font-size: var(--text-xs);
+		font-size: var(--text-sm);
 		color: var(--text-light);
-		letter-spacing: 0.01em;
 	}
 }

--- a/frappe/public/scss/desk/search_widget.scss
+++ b/frappe/public/scss/desk/search_widget.scss
@@ -8,6 +8,7 @@
 	align-items: center;
 	justify-content: space-between;
 	gap: 8px;
+	padding: var(--padding-xs) 10px;
 
 	.search-widget-icon {
 		display: flex;
@@ -22,9 +23,16 @@
 	}
 
 	.search-widget-shortcut {
+		display: flex;
+		align-items: center;
+		gap: 4px;
 		font-size: var(--text-xs);
 		color: var(--text-muted);
 		white-space: nowrap;
-		letter-spacing: 0.02em;
+
+		svg {
+			stroke: var(--text-muted);
+			flex-shrink: 0;
+		}
 	}
 }

--- a/frappe/public/scss/desk/search_widget.scss
+++ b/frappe/public/scss/desk/search_widget.scss
@@ -22,13 +22,9 @@
 	}
 
 	.search-widget-shortcut {
-		background-color: var(--control-bg);
-		border: 1px solid var(--border-color);
-		border-radius: var(--border-radius-tiny);
-		padding: 1px 5px;
 		font-size: var(--text-xs);
 		color: var(--text-muted);
 		white-space: nowrap;
-		line-height: 1.4;
+		letter-spacing: 0.02em;
 	}
 }

--- a/frappe/public/scss/desk/search_widget.scss
+++ b/frappe/public/scss/desk/search_widget.scss
@@ -11,7 +11,7 @@
 	padding: 0 10px;
 	background-color: var(--control-bg);
 	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius-full);
+	border-radius: var(--border-radius-sm);
 	cursor: pointer;
 	white-space: nowrap;
 	transition: background-color 0.1s ease;

--- a/frappe/public/scss/desk/search_widget.scss
+++ b/frappe/public/scss/desk/search_widget.scss
@@ -7,35 +7,31 @@
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
-	padding: 5px 12px;
+	height: 28px;
+	padding: 0 10px;
 	background-color: var(--control-bg);
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius-full);
 	cursor: pointer;
-	transition: background-color 0.15s ease;
 	white-space: nowrap;
+	transition: background-color 0.1s ease;
 
 	&:hover {
 		background-color: var(--control-bg-on-gray);
 	}
 
-	.search-widget-icon {
-		display: flex;
-		align-items: center;
-		flex-shrink: 0;
-
-		> svg {
-			stroke: var(--text-light);
-		}
+	.search-widget-icon svg {
+		stroke: var(--text-muted);
 	}
 
 	.search-widget-label {
-		@include get_textstyle("sm", "regular");
-		color: var(--text-light);
+		font-size: var(--text-sm);
+		color: var(--text-muted);
 	}
 
 	.search-widget-shortcut {
-		@include get_textstyle("sm", "regular");
-		color: var(--text-muted);
+		font-size: var(--text-xs);
+		color: var(--text-light);
+		letter-spacing: 0.01em;
 	}
 }

--- a/frappe/public/scss/desk/search_widget.scss
+++ b/frappe/public/scss/desk/search_widget.scss
@@ -6,26 +6,39 @@
 .search-widget-button {
 	display: inline-flex;
 	align-items: center;
-	justify-content: space-between;
-	gap: 8px;
-	padding: var(--padding-xs) 10px;
+	gap: 6px;
+	padding: 5px 12px;
+	background-color: var(--control-bg);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-full);
+	cursor: pointer;
+	transition: background-color 0.15s ease;
+
+	&:hover {
+		background-color: var(--control-bg-on-gray);
+	}
 
 	.search-widget-icon {
 		display: flex;
 		align-items: center;
-		gap: 6px;
-		color: var(--text-light);
+		flex-shrink: 0;
 
 		> svg {
 			stroke: var(--text-light);
-			flex-shrink: 0;
 		}
+	}
+
+	.search-widget-label {
+		@include get_textstyle("base", "regular");
+		color: var(--text-light);
+		white-space: nowrap;
 	}
 
 	.search-widget-shortcut {
 		display: flex;
 		align-items: center;
-		gap: 4px;
+		gap: 3px;
+		margin-left: 4px;
 		font-size: var(--text-xs);
 		color: var(--text-muted);
 		white-space: nowrap;


### PR DESCRIPTION
- Fix desktop search button: \`btn-reset\` → \`btn btn-default btn-sm\` for consistent padding and border-radius
- Fix mobile search trigger: inner div → proper \`<button>\` element
- Rework \`search_widget.scss\`: remove hardcoded height/padding (now inherited from btn-sm), add keyboard shortcut pill style

<img width="2932" height="1590" alt="image" src="https://github.com/user-attachments/assets/38a8e921-9534-402d-b530-2917ca827598" />



`no-docs`