### PR TITLE
fix(task_queue): use processed `method_name`

### DIFF
--- a/frappe/utils/task_queue.py
+++ b/frappe/utils/task_queue.py
@@ -90,7 +90,7 @@ def enqueue_task(
 			at_front_when_starved=at_front_when_starved,
 			retry=rq_retry,
 			task_id=task_id,
-			target_method=method,
+			target_method=method_name,
 			task_user=user,
 			task_on_success=on_success_path,
 			task_on_failure=on_failure_path,


### PR DESCRIPTION
Enqueue failed if we passed a function directly.

`enqueue_task` already computes the dotted-path `method_name` (and stores it on the Background Task doc), but then passed the raw callable to RQ as `target_method`. RQ pickles job kwargs, and pickling a function serializes it *by reference* (`module.qualname`) - which fails for anything not cleanly importable, e.g. a function defined in `bench console`:

```
PicklingError: Can't pickle <function bg_task at 0x...>: it's not found as frappe.commands.utils.bg_task
when serializing dict item 'target_method'
```