### PR TITLE
fix(data-import): show row count in value mappings grid and row numbers in edit modal

### DIFF
--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -241,7 +241,7 @@ class TestImporter(IntegrationTestCase):
 						"source_value": "Pasiv",
 						"target_value": "Passive",
 						"row_numbers": "[3]",
-						"rows_display": "3",
+						"no_of_rows": "1",
 					}
 				],
 			}
@@ -297,6 +297,13 @@ class TestImporter(IntegrationTestCase):
 		)
 		df = frappe._dict(fieldname="status", parent="Contact")
 		self.assertEqual(resolve_import_value(" Pasiv ", df, "Contact", lookup), "Passive")
+
+	def test_no_of_rows_count_returns_row_count(self):
+		from frappe.core.doctype.data_import.value_mapping import no_of_rows_count
+
+		self.assertEqual(no_of_rows_count([]), "")
+		self.assertEqual(no_of_rows_count([3]), "1")
+		self.assertEqual(no_of_rows_count([2, 3, 4]), "3")
 
 	def test_format_row_numbers_for_warning_truncates_long_lists(self):
 		from frappe.core.doctype.data_import.importer import format_row_numbers_for_warning

--- a/frappe/core/doctype/data_import/value_mapping.py
+++ b/frappe/core/doctype/data_import/value_mapping.py
@@ -267,13 +267,11 @@ def mapping_row_key(row) -> str:
 	return f"{row.get('column')}|{row.get('fieldname')}|{row.get('parent_field') or ''}|{row.get('source_value')}"
 
 
-def rows_display(rows: list) -> str:
-	"""Compact row list for the Value Mappings grid."""
-	from frappe.core.doctype.data_import.importer import format_row_numbers_for_warning
-
+def no_of_rows_count(rows: list) -> str:
+	"""Row count for the Value Mappings grid (actual row numbers live in ``row_numbers``)."""
 	if not rows:
 		return ""
-	return format_row_numbers_for_warning(rows)
+	return cstr(len(rows))
 
 
 def child_row_from_hint(item: dict, columns: dict) -> dict:
@@ -296,7 +294,7 @@ def child_row_from_hint(item: dict, columns: dict) -> dict:
 		"source_value": item.source_value,
 		"target_value": item.target_value or "",
 		"row_numbers": json.dumps(rows),
-		"rows_display": rows_display(rows),
+		"no_of_rows": no_of_rows_count(rows),
 	}
 
 
@@ -338,7 +336,7 @@ def sync_value_mappings(doc, import_file, lookup: dict | None = None) -> bool:
 			"select_options": row.select_options,
 			"target_value": row.target_value or "",
 			"row_numbers": row.row_numbers,
-			"rows_display": row.rows_display,
+			"no_of_rows": row.no_of_rows,
 		}
 		for row in (doc.get("value_mappings") or [])
 	]

--- a/frappe/core/doctype/data_import_value_mapping/data_import_value_mapping.json
+++ b/frappe/core/doctype/data_import_value_mapping/data_import_value_mapping.json
@@ -7,15 +7,15 @@
  "field_order": [
   "column_label",
   "source_value",
-  "rows_display",
+  "no_of_rows",
+  "row_numbers",
   "target_value",
   "column",
   "fieldname",
   "parent_field",
   "fieldtype",
   "link_doctype",
-  "select_options",
-  "row_numbers"
+  "select_options"
  ],
  "fields": [
   {
@@ -34,10 +34,17 @@
    "reqd": 1
   },
   {
-   "fieldname": "rows_display",
+   "fieldname": "no_of_rows",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Rows",
+   "label": "No. of Rows",
+   "read_only": 1
+  },
+  {
+   "fieldname": "row_numbers",
+   "fieldtype": "Code",
+   "label": "Row Numbers",
+   "options": "JSON",
    "read_only": 1
   },
   {
@@ -91,12 +98,6 @@
    "fieldtype": "Small Text",
    "hidden": 1,
    "label": "Select Options"
-  },
-  {
-   "fieldname": "row_numbers",
-   "fieldtype": "Small Text",
-   "hidden": 1,
-   "label": "Row Numbers"
   }
  ],
  "istable": 1,


### PR DESCRIPTION
Value Mappings previously listed every affected sheet row in the grid (e.g. "71, 76, 81, …"), which was hard to scan when many rows shared the same invalid value.

- Rename `rows_display` → `no_of_rows` and show the count of affected rows in the grid
- Show full row numbers as JSON in the row edit modal via the `row_numbers` field
- Add `no_of_rows_count()` helper and update related tests

before:
<img width="2024" height="520" alt="image" src="https://github.com/user-attachments/assets/d5ce25aa-e9f9-4172-a515-692270c4f4c6" />


after:
<img width="1066" height="674" alt="image" src="https://github.com/user-attachments/assets/cac75812-00e6-4986-a5a7-447f3e6934b8" />
