### PR TITLE
fix(DocType Layout): re-render form builder when switching records without reload

### DIFF
--- a/cypress/integration/doctype_layout.js
+++ b/cypress/integration/doctype_layout.js
@@ -12,6 +12,7 @@ context("DocType Layout", () => {
 		// Wipe any layouts from a previous run so field rows are deterministic
 		cy.remove_doc("DocType Layout", "Compact", true);
 		cy.remove_doc("DocType Layout", "Special", true);
+		cy.remove_doc("DocType Layout", "Todo Layout", true);
 
 		cy.insert_doc("DocType Layout", {
 			title: "Compact",
@@ -34,6 +35,12 @@ context("DocType Layout", () => {
 				{ fieldname: "is_special" },
 				{ fieldname: "description", label: "Special Notes" },
 			],
+		});
+
+		cy.insert_doc("DocType Layout", {
+			title: "Todo Layout",
+			document_type: "ToDo",
+			fields: [{ fieldname: "description", label: "Todo Notes" }],
 		});
 
 		// Reload so frappe.boot.doctype_layouts includes the newly created layouts
@@ -68,6 +75,34 @@ context("DocType Layout", () => {
 		// cy.window().its("frappe").its("layout_builder").should("exist");
 		cy.findByRole("tab", { name: "Parent Layout" }).click();
 		cy.get(".form-builder-container").should("exist");
+	});
+
+	it("Form Builder re-renders when switching layout records without a reload", () => {
+		cy.visit("/desk/doctype-layout/Compact");
+		cy.get("body").should("have.attr", "data-ajax-state", "complete");
+		cy.findByRole("tab", { name: "Parent Layout" }).click({ force: true });
+		cy.get(".form-builder-container").should("contain.text", "Compact Data 1");
+
+		// In-app navigation to another record of the same target doctype
+		cy.window().then((win) => win.frappe.set_route("Form", "DocType Layout", "Special"));
+		cy.get("body").should("have.attr", "data-ajax-state", "complete");
+		cy.findByRole("tab", { name: "Parent Layout" }).click({ force: true });
+		cy.get(".form-builder-container").should("contain.text", "Special Notes");
+		cy.get(".form-builder-container").should("not.contain.text", "Compact Data 1");
+
+		// Switch to a layout whose target is a different doctype
+		cy.window().then((win) => win.frappe.set_route("Form", "DocType Layout", "Todo Layout"));
+		cy.get("body").should("have.attr", "data-ajax-state", "complete");
+		cy.findByRole("tab", { name: "Parent Layout" }).click({ force: true });
+		cy.get(".form-builder-container").should("contain.text", "Todo Notes");
+		cy.get(".form-builder-container").should("not.contain.text", "Special Notes");
+
+		// Revisit an already-opened record — no onload events fire on this path
+		cy.window().then((win) => win.frappe.set_route("Form", "DocType Layout", "Compact"));
+		cy.get("body").should("have.attr", "data-ajax-state", "complete");
+		cy.findByRole("tab", { name: "Parent Layout" }).click({ force: true });
+		cy.get(".form-builder-container").should("contain.text", "Compact Data 1");
+		cy.get(".form-builder-container").should("not.contain.text", "Todo Notes");
 	});
 
 	it("Condition auto-switches the layout after a matching value is saved", () => {

--- a/frappe/core/doctype/doctype_layout/doctype_layout.js
+++ b/frappe/core/doctype/doctype_layout/doctype_layout.js
@@ -18,10 +18,6 @@ frappe.ui.form.on("DocType Layout", {
 		}
 	},
 
-	onload_post_render(frm) {
-		frm.events.render_builder(frm);
-	},
-
 	tab_break_form(frm) {
 		frm.events.render_builder(frm);
 	},
@@ -51,6 +47,7 @@ frappe.ui.form.on("DocType Layout", {
 			frm.disable_save();
 		}
 		frm.events.add_buttons(frm);
+		frm.events.render_builder(frm);
 	},
 
 	async document_type(frm) {
@@ -107,23 +104,39 @@ frappe.ui.form.on("DocType Layout", {
 		if (!frm.doc.document_type) return;
 
 		const wrapper = $(frm.fields_dict["form_builder"].wrapper).closest(".tab-pane");
+		const builder = frappe.layout_builder;
 
-		if (frappe.layout_builder?.store && frappe.layout_builder.frm === frm) {
-			frappe.layout_builder.setup_page_actions();
-			frappe.layout_builder.store.fetch();
+		if (builder?.store && builder.frm === frm) {
+			// frm (and the mounted Vue app) is reused across records of this DocType.
+			// Re-fetch only when the record or its target doctype changed, so plain
+			// refreshes don't wipe in-progress edits in the builder.
+			if (builder.docname === frm.doc.name && builder.doctype === frm.doc.document_type) {
+				return;
+			}
+			builder.docname = frm.doc.name;
+			builder.doctype = frm.doc.document_type;
+			builder.update_store();
+			builder.setup_page_actions();
+			builder.store.fetch();
 			return;
 		}
 
-		if (frappe.layout_builder) {
-			frappe.layout_builder.$wrapper = wrapper;
-			frappe.layout_builder.frm = frm;
-			frappe.layout_builder.page = frm.page;
-			frappe.layout_builder.doctype = frm.doc.document_type;
-			frappe.layout_builder.is_layout = true;
-			frappe.layout_builder.init(true);
-			frappe.layout_builder.store.fetch();
+		if (builder) {
+			builder.$wrapper = wrapper;
+			builder.frm = frm;
+			builder.page = frm.page;
+			builder.docname = frm.doc.name;
+			builder.doctype = frm.doc.document_type;
+			builder.is_layout = true;
+			builder.init(true);
+			builder.store.fetch();
 			return;
 		}
+
+		// `refresh` can fire more than once before the bundle loads — guard so
+		// only one FormBuilder instance is ever mounted.
+		if (frm._layout_builder_loading) return;
+		frm._layout_builder_loading = true;
 
 		frappe.require("form_builder.bundle.js").then(() => {
 			frappe.layout_builder = new frappe.ui.FormBuilder({
@@ -133,6 +146,8 @@ frappe.ui.form.on("DocType Layout", {
 				customize: false,
 				is_layout: true,
 			});
+			frappe.layout_builder.docname = frm.doc.name;
+			frm._layout_builder_loading = false;
 
 			// tab.refresh() is invoked by refresh_tabs() on every layout.refresh() and
 			// frm.refresh_field() call. It hides the tab when all its sections appear


### PR DESCRIPTION
## Problem

Follow-up to #38679. Opening a first DocType Layout record renders its customization correctly under the **Parent Layout** tab, but opening a second record without refreshing the browser (or revisiting an already-opened record) keeps showing the previous record's layout.

Two causes:

1. `render_builder` was triggered only from `onload_post_render`, which fires just **once per docname per session** (`trigger_onload` skips it for docnames already in `opendocs`). Revisiting a record never re-rendered the builder.
2. On the builder-reuse path, the Pinia store retained the first record's `document_type`, so a record targeting a different doctype merged its field rows against the wrong source meta — rows were filtered out and the layout rendered wrong/empty.

## Fix

- Drive `render_builder` from the `refresh` event, which fires on every doc load including revisits.
- Track `docname`/`doctype` on the builder and re-fetch only when they change, so plain refreshes don't wipe in-progress edits in the builder.
- Sync the store (`update_store()`) before fetching on the reuse path.
- Guard the `frappe.require` path so double-firing events can't mount two Vue apps.

## How to test

1. Create two DocType Layout records — one targeting e.g. ToDo, another targeting Note — each with some field overrides (e.g. a custom label).
2. Open the first record → **Parent Layout** tab shows its customization.
3. From the list (without refreshing the browser), open the second record → **Parent Layout** tab now shows the second record's customization instead of the first one's.
4. Navigate back to the first record → its own layout renders again.

Covered by the new Cypress test **"Form Builder re-renders when switching layout records without a reload"** in `cypress/integration/doctype_layout.js` (same-doctype switch, cross-doctype switch, and revisit of an already-opened record).