### PR TITLE
fix: show calendar events for users in a different timezone than the system

### DIFF
--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -339,12 +339,14 @@ def send_event_digest():
 @frappe.whitelist()
 @http_cache(max_age=5 * 60, stale_while_revalidate=60 * 60)
 def get_events(
-	start: date,
-	end: date,
+	start: str | date,
+	end: str | date,
 	user: str | None = None,
 	for_reminder: bool = False,
 	filters: str | list | dict[str, Any] | None = None,
 ) -> list[frappe._dict]:
+	start, end = getdate(start), getdate(end)
+
 	caller = frappe.session.user
 	target_user = user or caller
 

--- a/frappe/desk/doctype/event/test_event.py
+++ b/frappe/desk/doctype/event/test_event.py
@@ -8,7 +8,7 @@ import frappe
 from frappe.core.utils import find
 from frappe.desk.doctype.event.event import get_events
 from frappe.tests import IntegrationTestCase
-from frappe.tests.utils import make_test_objects
+from frappe.tests.utils import make_test_objects, toggle_test_mode
 
 
 class TestEvent(IntegrationTestCase):
@@ -49,6 +49,26 @@ class TestEvent(IntegrationTestCase):
 		self.assertTrue("_Test Event 1" in subjects)
 		self.assertFalse("_Test Event 3" in subjects)
 		self.assertFalse("_Test Event 2" in subjects)
+
+	def test_get_events_for_different_timezone(self):
+		frappe.set_user("Administrator")
+		frappe.get_doc(
+			{
+				"doctype": "Event",
+				"subject": "_Test Event Different Timezone",
+				"event_type": "Public",
+				"starts_on": "2025-05-10 10:00:00",
+			}
+		).insert()
+
+		original_in_test = frappe.in_test
+		toggle_test_mode(True)
+		try:
+			events = get_events(start="2025-04-30 23:00:00", end="2025-06-10 23:00:00", user="Administrator")
+		finally:
+			toggle_test_mode(original_in_test)
+
+		self.assertIn("_Test Event Different Timezone", [event.subject for event in events])
 
 	def test_revert_logic(self):
 		ev = frappe.get_doc(self.globalTestRecords["Event"][0]).insert()


### PR DESCRIPTION
## Problem
Calendar shows no events for users whose timezone differs from the system timezone. It works fine for users on the same timezone (like Administrator).

## Cause
The calendar sends the date range converted to the system timezone. For an off-timezone user that value isn't midnight, and `get_events` only accepted exact dates, so the request throw error and nothing loaded.

## Fix
`get_events` now accepts the datetime value as string and converts it to a date, so the calendar loads for everyone regardless of timezone.

### Before Fix
[Screencast from 2026-06-07 09-21-02.webm](https://github.com/user-attachments/assets/f82590d1-d4c4-4a11-b35c-d00cb7e435a6)

### After Fix
[Screencast from 2026-06-07 09-09-09.webm](https://github.com/user-attachments/assets/550116fd-bd74-4a68-a113-7e4f0761f72a)

**Support Ticket**: [70384](https://support.frappe.io/helpdesk/tickets/70384)