### PR TITLE
feat: sync installed_apps to site_config.json on install/uninstall

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -359,6 +359,7 @@ def add_to_installed_apps(app_name, rebuild_website=True):
 
 	frappe.get_single("Installed Applications").update_versions()
 	frappe.db.commit()
+	_sync_installed_apps_to_site_config()
 
 
 def remove_from_installed_apps(app_name):
@@ -374,6 +375,7 @@ def remove_from_installed_apps(app_name):
 		frappe.db.commit()
 		if frappe.flags.in_install:
 			post_install()
+		_sync_installed_apps_to_site_config()
 
 
 def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False):
@@ -625,6 +627,14 @@ def make_site_config(
 
 		with open(site_file, "w") as f:
 			f.write(json.dumps(site_config, indent=1, sort_keys=True))
+
+
+def _sync_installed_apps_to_site_config():
+	"""Mirror the installed-apps list into site_config.json for fast reads without a DB round-trip."""
+	try:
+		update_site_config("installed_apps", frappe.get_installed_apps())
+	except Exception:
+		pass
 
 
 def update_site_config(key, value, validate=True, site_config_path=None):

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -260,3 +260,4 @@ execute:from frappe.email.doctype.notification.notification import install_notif
 execute:frappe.db.set_value("Email Account", {}, "add_x_original_from", 1)
 execute:frappe.db.set_value("Email Account", {}, "add_reply_to_header", 1)
 frappe.patches.v16_0.set_reply_to_header
+frappe.patches.v16_0.sync_installed_apps_to_site_config

--- a/frappe/patches/v16_0/sync_installed_apps_to_site_config.py
+++ b/frappe/patches/v16_0/sync_installed_apps_to_site_config.py
@@ -1,0 +1,12 @@
+import frappe
+from frappe.installer import update_site_config
+
+
+def execute():
+	"""Backfill installed_apps into site_config.json for existing sites.
+
+	bench-cli (and other tools) can read the list without a DB round-trip by
+	checking site_config.json first.  Going forward, install_app / remove_app
+	keep this key in sync automatically.
+	"""
+	update_site_config("installed_apps", frappe.get_installed_apps())


### PR DESCRIPTION
- `add_to_installed_apps` and `remove_from_installed_apps` now mirror the installed apps list into `site_config.json` after each change
- Adds a v16 backfill patch so existing sites get the key on next `bench migrate`

This lets tools read installed apps from `site_config.json` directly (a plain file read) instead of opening a DB connection or spawning a full frappe process on every request.

`no-docs`

Backport of #39801