### PR TITLE
fix: simpler permissions for desktop icons

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -451,57 +451,61 @@ def get_sidebar_items(allowed_workspaces):
 		else:
 			sidebar_title = sidebar.title
 			sidebar_doc = sidebar
-		if (
-			frappe.session.user == "Administrator"
-			or sidebar_title == "My Workspaces"
-			or not sidebar_doc.module
-			or sidebar_doc.module in sidebar_doc.user.allow_modules
-		):
-			sidebar_items[sidebar_title.lower()] = {
-				"label": sidebar_title,
-				"items": [],
-				"header_icon": sidebar.get("header_icon"),
-				"module_onboarding": sidebar.get("module_onboarding"),
-				"module": sidebar_doc.module,
-				"app": sidebar_doc.app,
+		is_my_workspaces = "My Workspaces" in sidebar_title
+		items = []
+		for item in sidebar_doc.items:
+			workspace_sidebar = {
+				"label": _(item.label),
+				"link_to": item.link_to,
+				"link_type": item.link_type,
+				"type": item.type,
+				"icon": item.icon,
+				"child": item.child,
+				"collapsible": item.collapsible,
+				"indent": item.indent,
+				"keep_closed": item.keep_closed,
+				"url": item.url,
+				"show_arrow": item.show_arrow,
+				"filters": item.filters,
+				"route_options": item.route_options,
+				"tab": item.navigate_to_tab,
+				"open_in_new_tab": item.open_in_new_tab,
 			}
-			for item in sidebar_doc.items:
-				workspace_sidebar = {
-					"label": _(item.label),
-					"link_to": item.link_to,
-					"link_type": item.link_type,
-					"type": item.type,
-					"icon": item.icon,
-					"child": item.child,
-					"collapsible": item.collapsible,
-					"indent": item.indent,
-					"keep_closed": item.keep_closed,
-					"url": item.url,
-					"show_arrow": item.show_arrow,
-					"filters": item.filters,
-					"route_options": item.route_options,
-					"tab": item.navigate_to_tab,
-					"open_in_new_tab": item.open_in_new_tab,
+			if (
+				item.link_type == "Report"
+				and item.link_to
+				and frappe.db.exists("Report", item.link_to)
+				and not frappe.db.get_value("Report", item.link_to, "disabled")
+			):
+				report_type, ref_doctype = frappe.db.get_value(
+					"Report", item.link_to, ["report_type", "ref_doctype"]
+				)
+				workspace_sidebar["report"] = {
+					"report_type": report_type,
+					"ref_doctype": ref_doctype,
 				}
-				if (
-					item.link_type == "Report"
-					and item.link_to
-					and frappe.db.exists("Report", item.link_to)
-					and not frappe.db.get_value("Report", item.link_to, "disabled")
-				):
-					report_type, ref_doctype = frappe.db.get_value(
-						"Report", item.link_to, ["report_type", "ref_doctype"]
-					)
-					workspace_sidebar["report"] = {
-						"report_type": report_type,
-						"ref_doctype": ref_doctype,
-					}
-				if (
-					"My Workspaces" in sidebar_title
-					or item.type == "Section Break"
-					or sidebar_doc.is_item_allowed(item.link_to, item.link_type, allowed_workspaces)
-				):
-					sidebar_items[sidebar_title.lower()]["items"].append(workspace_sidebar)
+			if (
+				is_my_workspaces
+				or item.type == "Section Break"
+				or sidebar_doc.is_item_allowed(item.link_to, item.link_type, allowed_workspaces)
+			):
+				items.append(workspace_sidebar)
+
+		# A sidebar (and its desktop icon) is shown only if the user can see at least one
+		# real item in it, i.e. a non-Section-Break item survived the per-item filter above.
+		# This is the single source of truth for sidebar permissions and mirrors
+		# Desktop Icon.is_permitted. "My Workspaces" is always shown.
+		if not is_my_workspaces and not any(item["type"] != "Section Break" for item in items):
+			continue
+
+		sidebar_items[sidebar_title.lower()] = {
+			"label": sidebar_title,
+			"items": items,
+			"header_icon": sidebar.get("header_icon"),
+			"module_onboarding": sidebar.get("module_onboarding"),
+			"module": sidebar_doc.module,
+			"app": sidebar_doc.app,
+		}
 	add_user_specific_sidebar(sidebar_items)
 	return sidebar_items
 

--- a/frappe/core/page/dashboard_view/dashboard_view.js
+++ b/frappe/core/page/dashboard_view/dashboard_view.js
@@ -88,10 +88,7 @@ class Dashboard {
 			"frappe.desk.doctype.dashboard.dashboard.get_permitted_charts"
 		).then((charts) => {
 			if (!charts.length) {
-				frappe.msgprint(
-					__("No Permitted Charts on this Dashboard"),
-					__("No Permitted Charts")
-				);
+				return;
 			}
 
 			frappe.dashboard_utils.get_dashboard_settings().then((settings) => {

--- a/frappe/desk/desk_views.py
+++ b/frappe/desk/desk_views.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+from functools import cached_property
+
 import frappe
 from frappe.permissions import has_permission
 from frappe.query_builder import DocType
@@ -35,6 +37,63 @@ class DeskViews:
 		bootinfo.allowed_reports = self.reports
 		bootinfo.workspaces = self.workspaces
 		bootinfo.dashboards = self.dashboards
+
+	# The properties below are the per-user view-permission data read by `is_item_allowed`.
+	# They load lazily and cache on the instance, so consumers don't need to populate them.
+
+	@cached_property
+	def allowed_pages(self):
+		return self.get_allowed_pages(cache=True)
+
+	@cached_property
+	def allowed_reports(self):
+		return self.get_allowed_reports(cache=True)
+
+	@cached_property
+	def allowed_dashboards(self):
+		return {d["name"] for d in self.get_allowed_dashboards(cache=True)}
+
+	@cached_property
+	def restricted_doctypes(self):
+		from frappe.cache_manager import build_domain_restricted_doctype_cache
+
+		return frappe.cache.get_value("domain_restricted_doctypes") or build_domain_restricted_doctype_cache()
+
+	@cached_property
+	def restricted_pages(self):
+		from frappe.cache_manager import build_domain_restricted_page_cache
+
+		return frappe.cache.get_value("domain_restricted_pages") or build_domain_restricted_page_cache()
+
+	def is_item_allowed(self, name, item_type, allowed_workspaces=None):
+		"""Return whether the user may see a sidebar/workspace item.
+
+		Relies on the consumer setting `can_read`, `allowed_pages`, `allowed_reports`,
+		`allowed_dashboards`, `restricted_doctypes` and `restricted_pages` on the instance.
+		"""
+		if frappe.session.user == "Administrator":
+			return True
+
+		item_type = item_type.lower()
+
+		if item_type == "doctype":
+			return (
+				name in (self.can_read or [])
+				and name in (self.restricted_doctypes or [])
+				and frappe.has_permission(name)
+			)
+		if item_type == "page":
+			return name in self.allowed_pages and name in self.restricted_pages
+		if item_type == "report":
+			return not frappe.db.get_value("Report", name, "disabled") and name in self.allowed_reports
+		if item_type == "dashboard":
+			return name in (self.allowed_dashboards or [])
+		if item_type in ("help", "url"):
+			return True
+		if item_type == "workspace":
+			return name in (allowed_workspaces or [])
+
+		return False
 
 	@classmethod
 	def get_allowed_pages(cls, cache=False, user: str | None = None):
@@ -195,5 +254,16 @@ class DeskViews:
 			non_permitted_reports = set(has_role.keys()) - {r.name for r in reports}
 			for r in non_permitted_reports:
 				has_role.pop(r, None)
+
+			# a report is accessible only if the user can read its reference doctype
+			ref_doctype_access = {}
+			for name, report in list(has_role.items()):
+				ref_doctype = report.get("ref_doctype")
+				if not ref_doctype:
+					continue
+				if ref_doctype not in ref_doctype_access:
+					ref_doctype_access[ref_doctype] = has_permission(ref_doctype, user=user, print_logs=False)
+				if not ref_doctype_access[ref_doctype]:
+					has_role.pop(name, None)
 
 		return has_role

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -7,11 +7,7 @@ from json import JSONDecodeError, dumps, loads
 
 import frappe
 from frappe import DoesNotExistError, ValidationError, _, _dict
-from frappe.cache_manager import (
-	build_domain_restricted_doctype_cache,
-	build_domain_restricted_page_cache,
-	build_table_count_cache,
-)
+from frappe.cache_manager import build_table_count_cache
 from frappe.core.doctype.custom_role.custom_role import get_custom_allowed_roles
 from frappe.desk.desk_views import DeskViews
 
@@ -28,7 +24,7 @@ def handle_not_exist(fn):
 	return wrapper
 
 
-class Workspace:
+class Workspace(DeskViews):
 	def __init__(self, page, minimal=False):
 		self.page_name = page.get("name")
 		self.page_title = page.get("title")
@@ -49,9 +45,6 @@ class Workspace:
 
 		self.can_read = self.get_cached("user_perm_can_read", self.get_can_read_items)
 
-		self.allowed_pages = DeskViews.get_allowed_pages(cache=True)
-		self.allowed_reports = DeskViews.get_allowed_reports(cache=True)
-
 		if not minimal:
 			if self.doc.content:
 				self.onboarding_list = [
@@ -59,12 +52,6 @@ class Workspace:
 				]
 
 			self.table_counts = get_table_with_counts()
-		self.restricted_doctypes = (
-			frappe.cache.get_value("domain_restricted_doctypes") or build_domain_restricted_doctype_cache()
-		)
-		self.restricted_pages = (
-			frappe.cache.get_value("domain_restricted_pages") or build_domain_restricted_page_cache()
-		)
 
 	def is_permitted(self):
 		"""Return true if `Has Role` is not set or the user is allowed."""
@@ -130,24 +117,6 @@ class Workspace:
 			return None
 
 		return doc
-
-	def is_item_allowed(self, name, item_type):
-		item_type = item_type.lower()
-
-		if item_type == "doctype":
-			return name in (self.can_read or []) and name in (self.restricted_doctypes or [])
-		if item_type == "page":
-			return name in self.allowed_pages and name in self.restricted_pages
-		if item_type == "report":
-			return not frappe.db.get_value("Report", name, "disabled") and name in self.allowed_reports
-		if item_type == "help":
-			return True
-		if item_type == "dashboard":
-			return True
-		if item_type == "url":
-			return True
-
-		return False
 
 	def build_workspace(self):
 		self.cards = {"items": self.get_links()}

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -87,63 +87,6 @@ class DesktopIcon(Document):
 		if os.path.exists(file_path):
 			os.remove(file_path)
 
-	def is_permitted(self, bootinfo):
-		icon_module = None
-		if self.icon_type == "Link" and self.link_to:
-			icon_module = frappe.db.get_value("Workspace", self.link_to, "module")
-		# module permission check
-		if icon_module:
-			blocked_modules = frappe.get_cached_doc("User", frappe.session.user).get_blocked_modules()
-			if icon_module in blocked_modules:
-				return False
-		# perform a permission check based on roles table (desktop icons)
-		allowed_roles = [d.role for d in self.get("roles") or []]
-		if allowed_roles and not set(allowed_roles).intersection(frappe.get_roles()):
-			return False
-		if self.icon_type == "Folder":
-			return True
-		elif self.icon_type == "App":
-			return self.check_app_permission()
-		else:
-			try:
-				items = bootinfo.workspace_sidebar_item[self.label.lower()]["items"]
-
-				if len(items) and all(item["type"] == "Section Break" for item in items):
-					return False
-				if len(items) == 0:
-					return False
-				return True
-			except KeyError:
-				return False
-
-	def check_app_permission(self):
-		for a in frappe.get_installed_apps():
-			if frappe.get_hooks(app_name=a)["app_title"][0] == self.label or self.app == a:
-				app_detail = frappe.get_hooks("add_to_apps_screen", app_name=a)
-				if len(app_detail) != 0:
-					permission_method = app_detail[0].get("has_permission", None)
-					if permission_method:
-						return frappe.call(permission_method)
-					else:
-						return True
-				else:
-					# App hooks.py doesn't have add_to_apps_screen
-					return True
-
-	# def is_permitted(self):
-	# 	"""Return True if `Has Role` is not set or the user is allowed."""
-	# 	from frappe.utils import has_common
-
-	# 	allowed = [d.role for d in frappe.get_all("Has Role", fields=["role"], filters={"parent": self.name})]
-
-	# 	if not allowed:
-	# 		return True
-
-	# 	roles = frappe.get_roles()
-
-	# 	if has_common(roles, allowed):
-	# 		return True
-
 	def after_insert(self):
 		clear_desktop_icons_cache()
 
@@ -160,6 +103,21 @@ def get_workspace_names(workspaces):
 	for w in workspaces["pages"]:
 		workspace_list.append(w["name"])
 	return workspace_list
+
+
+def check_app_permission(label, app):
+	for a in frappe.get_installed_apps():
+		if frappe.get_hooks(app_name=a)["app_title"][0] == label or app == a:
+			app_detail = frappe.get_hooks("add_to_apps_screen", app_name=a)
+			if len(app_detail) != 0:
+				permission_method = app_detail[0].get("has_permission", None)
+				if permission_method:
+					return frappe.call(permission_method)
+				else:
+					return True
+			else:
+				# App hooks.py doesn't have add_to_apps_screen
+				return True
 
 
 def get_desktop_icons(user=None, bootinfo=None):
@@ -213,8 +171,17 @@ def get_desktop_icons(user=None, bootinfo=None):
 		permitted_parent_labels = set()
 		if bootinfo:
 			for s in user_icons:
-				icon = frappe.get_doc("Desktop Icon", s.name)
-				if icon.is_permitted(bootinfo):
+				if s.icon_type == "Folder":
+					permitted = True
+				elif s.icon_type == "App":
+					permitted = check_app_permission(s.label, s.app)
+				else:
+					# Workspace Sidebar link: present in the boot map ⇒ user can see at least
+					# one item in it (get_sidebar_items already enforces this).
+					sidebar = bootinfo.workspace_sidebar_item.get(s.label.lower())
+					permitted = bool(sidebar and sidebar["items"])
+
+				if permitted:
 					permitted_icons.append(s)
 
 					if not s.parent_icon:

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -241,10 +241,7 @@ def auto_generate_sidebar_from_module():
 	"""Auto generate sidebar from module"""
 	sidebars = []
 	for module in frappe.get_all("Module Def", pluck="name"):
-		if not (
-			frappe.db.exists("Workspace Sidebar", {"module": module, "for_user": None})
-			or frappe.db.exists("Workspace Sidebar", {"name": module, "for_user": None})
-		):
+		if not (frappe.db.exists("Workspace Sidebar", {"name": module, "for_user": None})):
 			module_info = get_module_info(module)
 			sidebar_items = create_sidebar_items(module_info)
 			sidebar = frappe.new_doc("Workspace Sidebar")

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -15,7 +15,7 @@ from frappe.modules.utils import create_directory_on_app_path
 from frappe.utils.caching import site_cache
 
 
-class WorkspaceSidebar(Document):
+class WorkspaceSidebar(Document, DeskViews):
 	_DOCTYPE_NAME = "Workspace Sidebar"
 
 	# begin: auto-generated types
@@ -41,12 +41,6 @@ class WorkspaceSidebar(Document):
 		if not frappe.flags.in_migrate:
 			self.user = frappe.get_user()
 			self.can_read = self.get_cached("user_perm_can_read", self.get_can_read_items)
-			self.allowed_modules = self.get_cached("user_allowed_modules", self.get_allowed_modules)
-
-		self.allowed_pages = DeskViews.get_allowed_pages(cache=True)
-		self.allowed_reports = DeskViews.get_allowed_reports(cache=True)
-		self.restricted_doctypes = frappe.cache.get_value("domain_restricted_doctypes")
-		self.restricted_pages = frappe.cache.get_value("domain_restricted_pages")
 
 	def get_can_read_items(self):
 		if not self.user.can_read:
@@ -81,31 +75,6 @@ class WorkspaceSidebar(Document):
 			delete_file(self.app, old)
 			self.export_sidebar()
 
-	def is_item_allowed(self, name, item_type, allowed_workspaces):
-		if frappe.session.user == "Administrator":
-			return True
-
-		item_type = item_type.lower()
-
-		if item_type == "doctype":
-			return (
-				name in (self.can_read or [])
-				and name in (self.restricted_doctypes or [])
-				and frappe.has_permission(name)
-			)
-		if item_type == "page":
-			return name in self.allowed_pages and name in self.restricted_pages
-		if item_type == "report":
-			return name in self.allowed_reports
-		if item_type == "help":
-			return True
-		if item_type == "dashboard":
-			return True
-		if item_type == "url":
-			return True
-		if item_type == "workspace":
-			return name in allowed_workspaces
-
 	def get_cached(self, cache_key, fallback_fn):
 		value = frappe.cache.get_value(cache_key, user=frappe.session.user)
 		if value is not None:
@@ -135,12 +104,6 @@ class WorkspaceSidebar(Document):
 		counts = Counter(all_modules_in_sidebars)
 		if counts and counts.most_common(1)[0]:
 			return counts.most_common(1)[0][0]
-
-	def get_allowed_modules(self):
-		if not self.user.allow_modules:
-			self.user.build_permissions()
-
-		return self.user.allow_modules
 
 
 def delete_file(app, title):

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -541,5 +541,6 @@ add_to_apps_screen = [
 		"logo": app_logo_url,
 		"title": app_title,
 		"route": app_home,
+		"has_permission": "frappe.permissions.check_app_permission",
 	}
 ]

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -938,3 +938,10 @@ def _get_parent_and_ancestors(doctype, parent):
 	from frappe.utils.nestedset import get_ancestors_of
 
 	yield from get_ancestors_of(doctype, parent)
+
+
+def check_app_permission():
+	is_system_manager = "System Manager" in frappe.get_roles(frappe.session.user)
+	if is_system_user() and is_system_manager:
+		return True
+	return False


### PR DESCRIPTION
Workspace sidebar had 2 level filtering, one filter based on workspace sidebar item and if the item is permitted and after this one more filtering based on computed module. Computed module is calculated based on module field in workspace sidebar item. It was done to do 2 things. One prevent excessive item filtering and help in settling the sidebar resolution. This PR removes it. 

This PR fixes the following things.
We now use only item level filtering for the sidebar.  And desktop icon is visible if there is at least one entity in the visible in the sidebar. 
Framework icon is shown to a system manager. 
Dashboards perms are now better filtered using Desk Entity