### PR TITLE
fix: change to lucide icon

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_links.html
+++ b/frappe/public/js/frappe/form/templates/form_links.html
@@ -22,7 +22,7 @@
 							<button class="btn btn-new btn-secondary btn-xs icon-btn hidden"
 								data-doctype="{{ doctype }}"
 								data-fieldname="{{ fieldname }}">
-								<svg class="icon icon-sm"><use href="#icon-add"></use></svg>
+								<svg class="icon icon-sm"><use href="#icon-plus"></use></svg>
 							</button>
 						{% endif %}
 					</div>


### PR DESCRIPTION
Before
<img width="358" height="265" alt="Screenshot 2026-06-08 at 11 06 18 AM" src="https://github.com/user-attachments/assets/c174810d-3ecf-422f-89f5-872ea0dc9e4d" />


After
<img width="381" height="300" alt="Screenshot 2026-06-08 at 11 04 05 AM" src="https://github.com/user-attachments/assets/0144b1d8-afaa-40f5-bad6-cef054f112d2" />
