### PR TITLE
fix: stock level indicator bar invisible in dark mode

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -325,7 +325,7 @@ body.full-width {
 			border-radius: 0px 3px 3px 0px;
 		}
 		.inline-graph-bar-inner.dark {
-			background-color: var(--primary-color);
+			background-color: var(--text-color);
 		}
 	}
 	.inline-graph-half:first-child {


### PR DESCRIPTION
## Description 

The filled segment of the Item Dashboard stock-level bar used var(--primary-color), which resolves to --gray-900 (#171717). In dark mode the page background is also --gray-900, so the bar matched its background and was invisible. Switched to var(--text-color) so the bar flips per theme and stays visible in both light and dark.

## Before 
<img width="903" height="221" alt="Screenshot 2026-06-12 at 12 14 55 AM" src="https://github.com/user-attachments/assets/0c39d295-8098-45b6-8ffc-852b4d380504" />

## After 
<img width="931" height="214" alt="Screenshot 2026-06-12 at 12 14 17 AM" src="https://github.com/user-attachments/assets/e8fde7f3-30e7-488d-8c97-6f0b1d8e6103" />

---
Ref: https://support.frappe.io/helpdesk/tickets/70479?view=VIEW-HD+Ticket-1252