### PR TITLE
fix: route DocType Layout 'Go to List' button to the base doctype list

### DIFF
--- a/frappe/core/doctype/doctype_layout/doctype_layout.js
+++ b/frappe/core/doctype/doctype_layout/doctype_layout.js
@@ -61,8 +61,6 @@ frappe.ui.form.on("DocType Layout", {
 	add_buttons(frm) {
 		if (!frm.is_new()) {
 			frm.add_custom_button(__("Go to {0} List", [frm.doc.title || frm.doc.name]), () => {
-				// A DocType Layout has no route of its own — it is applied to its base
-				// doctype's list via the `layout` route option (see router.js).
 				frappe.route_options = { layout: frm.doc.name };
 				frappe.set_route(frappe.router.slug(frm.doc.document_type));
 			});

--- a/frappe/core/doctype/doctype_layout/doctype_layout.js
+++ b/frappe/core/doctype/doctype_layout/doctype_layout.js
@@ -61,7 +61,10 @@ frappe.ui.form.on("DocType Layout", {
 	add_buttons(frm) {
 		if (!frm.is_new()) {
 			frm.add_custom_button(__("Go to {0} List", [frm.doc.title || frm.doc.name]), () => {
-				frappe.set_route(frappe.router.slug(frm.doc.name));
+				// A DocType Layout has no route of its own — it is applied to its base
+				// doctype's list via the `layout` route option (see router.js).
+				frappe.route_options = { layout: frm.doc.name };
+				frappe.set_route(frappe.router.slug(frm.doc.document_type));
 			});
 		}
 


### PR DESCRIPTION
Fixes the DocType Layout "Go to List" button, which opened a non-existent page instead of the base doctype's list with the layout applied.