### PR TITLE
feat: render_safe_exec

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -244,7 +244,8 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force=False) 
 	local.valid_columns = {}
 	local.new_doc_templates = {}
 
-	local.jenv = None
+	local.jenv_restricted = None
+	local.jenv_unrestricted = None
 	local.jloader = None
 	local.cache = {}
 	local.form_dict = _dict()
@@ -646,7 +647,8 @@ def set_user(username: str):
 	local.session.sid = username
 	local.cache = {}
 	local.form_dict = _dict()
-	local.jenv = None
+	local.jenv_restricted = None
+	local.jenv_unrestricted = None
 	local.session.data = _dict()
 	local.role_permissions = {}
 	local.new_doc_templates = {}

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -401,33 +401,3 @@ result = [
 		self.assertEqual(result[-1][0], "Total")
 		self.assertEqual(result[-1][1], 200)
 		self.assertEqual(result[-1][2], 150.50)
-
-	def test_cte_in_query_report(self):
-		cte_query = textwrap.dedent(
-			"""
-            with enabled_users as (
-                select name
-                from `tabUser`
-                where enabled = 1
-            )
-            select * from enabled_users;
-        """
-		)
-
-		report = frappe.get_doc(
-			{
-				"doctype": "Report",
-				"ref_doctype": "User",
-				"report_name": "Enabled Users List",
-				"report_type": "Query Report",
-				"is_standard": "No",
-				"query": cte_query,
-			}
-		).insert()
-
-		if frappe.db.db_type == "mariadb":
-			col, rows = report.execute_query_report(filters={})
-			self.assertEqual(col[0], "name")
-			self.assertGreaterEqual(len(rows), 1)
-		elif frappe.db.db_type == "postgres":
-			self.assertRaises(frappe.PermissionError, report.execute_query_report, filters={})

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -153,7 +153,7 @@ class Meta(Document):
 
 	def as_dict(self, no_nulls=False):
 		def serialize(doc):
-			out = {}
+			out = frappe._dict()
 			for key, value in doc.__dict__.items():
 				if isinstance(value, list | tuple):
 					if not value or not isinstance(value[0], BaseDocument):

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -107,11 +107,11 @@ def patch_query_execute():
 	def prepare_query(query):
 		import inspect
 
+		from frappe.utils.safe_exec import SERVER_SCRIPT_FILE_PREFIX, check_safe_sql_query
+
 		param_collector = NamedParameterWrapper()
 		query = query.get_sql(param_wrapper=param_collector)
 		if frappe.flags.in_safe_exec:
-			from frappe.utils.safe_exec import SERVER_SCRIPT_FILE_PREFIX, check_safe_sql_query
-
 			if not check_safe_sql_query(query, throw=False):
 				callstack = inspect.stack()
 
@@ -127,6 +127,9 @@ def patch_query_execute():
 				# if frame2 is server script <serverscript> is set as the filename it shouldn't be allowed.
 				if len(callstack) >= 3 and SERVER_SCRIPT_FILE_PREFIX in callstack[2].filename:
 					raise frappe.PermissionError("Only SELECT SQL allowed in scripting")
+
+		if frappe.local.flags.get("in_render_safe_exec", False):
+			check_safe_sql_query(query, throw=True)
 
 		return query, param_collector.get_parameters()
 

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -2,6 +2,7 @@ import types
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils.jinja import get_jenv, render_template
 from frappe.utils.safe_exec import ServerScriptNotEnabled, get_safe_globals, safe_exec
 
 
@@ -9,6 +10,7 @@ class TestSafeExec(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls) -> None:
 		cls.enable_safe_exec()
+		frappe.set_user("Administrator")
 		return super().setUpClass()
 
 	def test_import_fails(self):
@@ -74,6 +76,16 @@ class TestSafeExec(FrappeTestCase):
 	def test_safe_query_builder(self):
 		self.assertRaises(frappe.PermissionError, safe_exec, """frappe.qb.from_("User").delete().run()""")
 
+	def test_safe_query_builder_in_render(self):
+		self.assertRaises(
+			frappe.PermissionError,
+			render_template,
+			""" {{ frappe.qb.from_("User").delete().run() }} """,
+		)
+
+		# Allowed read query
+		frappe.render_template(""" {{ frappe.qb.from_("User").select("*").run() }} """)
+
 	def test_call(self):
 		# call non whitelisted method
 		self.assertRaises(frappe.PermissionError, safe_exec, """frappe.call("frappe.get_user")""")
@@ -127,3 +139,35 @@ class TestSafeExec(FrappeTestCase):
 class TestNoSafeExec(FrappeTestCase):
 	def test_safe_exec_disabled_by_default(self):
 		self.assertRaises(ServerScriptNotEnabled, safe_exec, "pass")
+
+
+class TestJinjaGlobals(FrappeTestCase):
+	def test_jenv_thread_safety(self):
+		first = get_jenv()
+		# reinit to create a new local ctx, this "simulates" two request running in two diff
+		# thread.
+		frappe.init(frappe.local.site, force=True)
+		second = get_jenv()
+		self.assertIsNot(first, second)
+		self.assertIsNot(first.globals, second.globals)
+		self.assertIsNot(first.filters, second.filters)
+		self.assertIsNot(first.globals["frappe"], second.globals["frappe"])
+		self.assertIsNot(first.globals["frappe"]["form_dict"], second.globals["frappe"]["form_dict"])
+
+	def test_globals_override(self):
+		"""Test that when restrict_globals is parsed, the correct globals are injected."""
+		from frappe.utils.safe_exec import FrappeClient, safe_get_all
+
+		jenv_restricted = get_jenv(restrict_globals=True)
+		self.assertIs(jenv_restricted.globals["frappe"]["get_all"], safe_get_all)
+		with self.assertRaises(KeyError):
+			jenv_restricted.globals["FrappeClient"]
+
+		jenv_unrestricted = get_jenv(restrict_globals=False)
+		self.assertIs(jenv_unrestricted.globals["frappe"]["get_all"], frappe.get_all)
+		self.assertIs(jenv_unrestricted.globals["FrappeClient"], FrappeClient)  # test exclusivity
+
+		self.assertIsNot(jenv_restricted, jenv_unrestricted)  # globals cache check
+		self.assertIsNot(jenv_restricted.globals, jenv_unrestricted.globals)
+		self.assertIs(get_jenv(restrict_globals=True), jenv_restricted)
+		self.assertIs(get_jenv(restrict_globals=False), jenv_unrestricted)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -981,17 +981,20 @@ def print_language(language: str):
 
 	# remember original values
 	_lang = frappe.local.lang
-	_jenv = frappe.local.jenv
+	_jenv_restricted = getattr(frappe.local, "jenv_restricted", None)
+	_jenv_unrestricted = getattr(frappe.local, "jenv_unrestricted", None)
 
 	# set language, empty any existing lang_full_dict and jenv
 	frappe.local.lang = language
-	frappe.local.jenv = None
+	frappe.local.jenv_restricted = None
+	frappe.local.jenv_unrestricted = None
 
 	yield
 
 	# restore original values
 	frappe.local.lang = _lang
-	frappe.local.jenv = _jenv
+	frappe.local.jenv_restricted = _jenv_restricted
+	frappe.local.jenv_unrestricted = _jenv_unrestricted
 
 
 # Backward compatibility

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -1,13 +1,26 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-def get_jenv():
-	import frappe
+from contextlib import contextmanager
 
-	if not getattr(frappe.local, "jenv", None):
+import frappe
+
+
+def get_jenv(*, restrict_globals=None):
+	from frappe.utils.safe_exec import (
+		UNSAFE_ATTRIBUTES,
+		get_safe_globals,
+		is_render_exec_enabled,
+		render_safe_globals,
+	)
+
+	if restrict_globals is None:
+		restrict_globals = is_render_exec_enabled()
+
+	local_key = "jenv_restricted" if restrict_globals else "jenv_unrestricted"
+
+	if not getattr(frappe.local, local_key, None):
 		from jinja2 import DebugUndefined
 		from jinja2.sandbox import SandboxedEnvironment
-
-		from frappe.utils.safe_exec import UNSAFE_ATTRIBUTES, get_safe_globals
 
 		UNSAFE_ATTRIBUTES = UNSAFE_ATTRIBUTES - {"format", "format_map"}
 
@@ -22,15 +35,18 @@ def get_jenv():
 		jenv = FrappeSandboxedEnvironment(loader=get_jloader(), undefined=DebugUndefined)
 		set_filters(jenv)
 
-		jenv.globals.update(get_safe_globals())
+		if restrict_globals:
+			jenv.globals.update(render_safe_globals())
+		else:
+			jenv.globals.update(get_safe_globals())
 
 		methods, filters = get_jinja_hooks()
 		jenv.globals.update(methods or {})
 		jenv.filters.update(filters or {})
 
-		frappe.local.jenv = jenv
+		setattr(frappe.local, local_key, jenv)
 
-	return frappe.local.jenv
+	return getattr(frappe.local, local_key, None)
 
 
 def get_template(path):
@@ -54,7 +70,7 @@ def get_email_from_template(name, args):
 	return (message, text_content)
 
 
-def validate_template(html):
+def validate_template(html, restrict_globals=None):
 	"""Throws exception if there is a syntax error in the Jinja Template"""
 	from jinja2 import TemplateSyntaxError
 
@@ -62,20 +78,21 @@ def validate_template(html):
 
 	if not html:
 		return
-	jenv = get_jenv()
+	jenv = get_jenv(restrict_globals=restrict_globals)
 	try:
 		jenv.from_string(html)
 	except TemplateSyntaxError as e:
 		frappe.throw(f"Syntax error in template as line {e.lineno}: {e.message}")
 
 
-def render_template(template, context=None, is_path=None, safe_render=True):
+def render_template(template, context=None, is_path=None, safe_render=True, *, restrict_globals=None):
 	"""Render a template using Jinja
 
 	:param template: path or HTML containing the jinja template
 	:param context: dict of properties to pass to the template
 	:param is_path: (optional) assert that the `template` parameter is a path
 	:param safe_render: (optional) prevent server side scripting via jinja templating
+	:param restrict_globals: (optional) restrict globals in template rendering to render only globals.
 	"""
 
 	from jinja2 import TemplateError
@@ -94,7 +111,8 @@ def render_template(template, context=None, is_path=None, safe_render=True):
 		if safe_render and ".__" in template:
 			throw(_("Illegal template"))
 		try:
-			return get_jenv().from_string(template).render(context)
+			with safe_render_flags():
+				return get_jenv(restrict_globals=restrict_globals).from_string(template).render(context)
 		except TemplateError:
 			throw(
 				title="Jinja Template Error",
@@ -189,3 +207,17 @@ def get_jinja_hooks():
 	filter_dict = get_obj_dict_from_paths(filters)
 
 	return method_dict, filter_dict
+
+
+@contextmanager
+def safe_render_flags():
+	if frappe.flags.in_render_safe_exec is None:
+		frappe.flags.in_render_safe_exec = 0
+
+	frappe.flags.in_render_safe_exec += 1
+
+	try:
+		yield
+	finally:
+		# Always ensure that the flag is decremented
+		frappe.flags.in_render_safe_exec -= 1

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -29,7 +29,9 @@ from frappe.model.mapper import get_mapped_doc
 from frappe.model.rename_doc import rename_doc
 from frappe.modules import scrub
 from frappe.utils.background_jobs import enqueue, get_jobs
+from frappe.utils.caching import site_cache
 from frappe.utils.inplacevar import protected_inplacevar
+from frappe.utils.response import json_handler
 from frappe.website.utils import get_next_link, get_toc
 from frappe.www.printview import get_visible_columns
 
@@ -42,6 +44,8 @@ ARGUMENT_NOT_SET = object()
 
 SAFE_EXEC_CONFIG_KEY = "server_script_enabled"
 SERVER_SCRIPT_FILE_PREFIX = "<serverscript>"
+
+RENDER_EXEC_CONFIG_KEY = "disable_render_safe_exec"
 
 
 class NamespaceDict(frappe._dict):
@@ -79,6 +83,10 @@ class FrappePrintCollector(PrintCollector):
 def is_safe_exec_enabled() -> bool:
 	# server scripts can only be enabled via common_site_config.json
 	return bool(frappe.get_common_site_config().get(SAFE_EXEC_CONFIG_KEY))
+
+
+def is_render_exec_enabled() -> bool:
+	return not bool(frappe.get_common_site_config().get(RENDER_EXEC_CONFIG_KEY, 0))
 
 
 def safe_exec(
@@ -152,7 +160,7 @@ def _validate_safe_eval_syntax(code):
 
 @contextmanager
 def safe_exec_flags():
-	if not frappe.flags.in_safe_exec:
+	if frappe.flags.in_safe_exec is None:
 		frappe.flags.in_safe_exec = 0
 
 	frappe.flags.in_safe_exec += 1
@@ -164,7 +172,133 @@ def safe_exec_flags():
 		frappe.flags.in_safe_exec -= 1
 
 
-def get_safe_globals():
+def get_doc_as_dict(doctype, name):
+	assert isinstance(doctype, str)
+	assert isinstance(name, (str, int))
+	return frappe.get_doc(doctype, name).as_dict()
+
+
+def safer_get_last_doc(*args, **kwargs):
+	return frappe.get_last_doc(*args, **kwargs).as_dict()
+
+
+def safer_get_cached_doc(*args, **kwargs):
+	return frappe.get_cached_doc(*args, **kwargs).as_dict()
+
+
+def remove_unsafe_fields(fields):
+	return [f for f in fields if "(" not in f]
+
+
+def safe_get_list(*args, **kwargs):
+	if args and len(args) > 1 and isinstance(args[1], list):
+		args = list(args)
+		args[1] = remove_unsafe_fields(args[1])
+
+	kwargs["run"] = True
+	fields = kwargs.get("fields", [])
+	if fields:
+		kwargs["fields"] = remove_unsafe_fields(fields)
+
+	return frappe.db.get_list(
+		*args,
+		**kwargs,
+	)
+
+
+def safe_get_all(*args, **kwargs):
+	kwargs["ignore_permissions"] = True
+	if "limit_page_length" not in kwargs:
+		kwargs["limit_page_length"] = 0
+
+	return safe_get_list(*args, **kwargs)
+
+
+def safer_get_meta(doctype, cached=True):
+	assert isinstance(doctype, str)
+	assert isinstance(cached, bool)
+
+	doc = frappe.get_meta(doctype, cached=cached)
+	return doc.as_dict() if doc else None
+
+
+def safer_log_error(
+	title=None, message=None, reference_doctype=None, reference_name=None, *, defer_insert=False
+):
+	assert isinstance(title, (str, type(None)))
+	assert isinstance(message, (str, type(None)))
+	assert isinstance(reference_doctype, (str, type(None)))
+	assert isinstance(reference_name, (str, int, type(None)))
+	assert isinstance(defer_insert, bool)
+
+	frappe.log_error(
+		title=title,
+		message=message,
+		reference_doctype=reference_doctype,
+		reference_name=reference_name,
+		defer_insert=defer_insert,
+	)
+	return {}
+
+
+def safer_get_visible_columns(*args, **kwargs):
+	cols = get_visible_columns(*args, **kwargs)
+	if cols is None:
+		return None
+	return [c if isinstance(c, dict) else c.as_dict() for c in cols]
+
+
+def safe_get_value(*args, **kwargs):
+	kwargs["run"] = True
+	return frappe.db.get_value(*args, **kwargs)
+
+
+def safe_get_single_value(*args, **kwargs):
+	kwargs["run"] = True
+	return frappe.db.get_single_value(*args, **kwargs)
+
+
+def safe_render_template(*args, **kwargs):
+	kwargs.pop("restrict_globals", None)
+	return frappe.render_template(*args, restrict_globals=True, **kwargs)
+
+
+ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+def make_safe_get_request(url: str, **kwargs):
+	import ipaddress
+	import socket
+	from urllib.parse import urlparse
+
+	parsed = urlparse(url)
+
+	if parsed.scheme not in ALLOWED_SCHEMES:
+		frappe.throw(f"URL scheme '{parsed.scheme}' is not permitted")
+
+	hostname = parsed.hostname
+	if not hostname:
+		frappe.throw("Invalid URL: no hostname")
+
+	try:
+		addr_info = socket.getaddrinfo(hostname, None)
+	except socket.gaierror:
+		frappe.throw(f"Could not resolve host: {hostname}")
+
+	for record in addr_info:
+		try:
+			addr = ipaddress.ip_address(record[4][0])
+		except (ValueError, IndexError):
+			continue
+
+		if not addr.is_global:
+			frappe.throw("Requests to internal network addresses are not permitted")
+
+	return frappe.integrations.utils.make_get_request(url, **kwargs)
+
+
+def render_safe_globals():
+	"""Safer subset of globals for rendering ops."""
 	datautils = frappe._dict()
 
 	if frappe.db:
@@ -192,7 +326,6 @@ def get_safe_globals():
 		_dict=frappe._dict,
 		args=form_dict,
 		frappe=NamespaceDict(
-			call=call_whitelisted_function,
 			flags=frappe._dict(),
 			format=frappe.format_value,
 			format_value=frappe.format_value,
@@ -201,28 +334,21 @@ def get_safe_globals():
 			format_date=frappe.utils.data.global_date_format,
 			form_dict=form_dict,
 			bold=frappe.bold,
-			copy_doc=frappe.copy_doc,
 			errprint=frappe.errprint,
 			qb=frappe.qb,
-			get_meta=frappe.get_meta,
-			new_doc=frappe.new_doc,
-			get_doc=frappe.get_doc,
-			get_mapped_doc=get_mapped_doc,
-			get_last_doc=frappe.get_last_doc,
-			get_cached_doc=frappe.get_cached_doc,
-			get_list=frappe.get_list,
-			get_all=frappe.get_all,
+			get_meta=safer_get_meta,
+			get_doc=get_doc_as_dict,
+			get_last_doc=safer_get_last_doc,
+			get_cached_doc=safer_get_cached_doc,
+			get_list=safe_get_list,
+			get_all=safe_get_all,
+			get_hooks=get_hooks,
 			get_system_settings=frappe.get_system_settings,
-			rename_doc=rename_doc,
-			delete_doc=delete_doc,
 			utils=datautils,
 			get_url=frappe.utils.get_url,
-			render_template=frappe.render_template,
+			render_template=safe_render_template,
 			msgprint=frappe.msgprint,
 			throw=frappe.throw,
-			sendmail=frappe.sendmail,
-			get_print=frappe.get_print,
-			attach_print=frappe.attach_print,
 			user=user,
 			get_fullname=frappe.utils.get_fullname,
 			get_gravatar=frappe.utils.get_gravatar_url,
@@ -236,39 +362,32 @@ def get_safe_globals():
 				if getattr(frappe.local, "session", None) and getattr(frappe.local.session, "data", None)
 				else "",
 			),
-			make_get_request=frappe.integrations.utils.make_get_request,
-			make_post_request=frappe.integrations.utils.make_post_request,
-			make_put_request=frappe.integrations.utils.make_put_request,
-			make_patch_request=frappe.integrations.utils.make_patch_request,
-			make_delete_request=frappe.integrations.utils.make_delete_request,
+			make_get_request=make_safe_get_request,
 			socketio_port=frappe.conf.socketio_port,
-			get_hooks=get_hooks,
-			enqueue=safe_enqueue,
 			sanitize_html=frappe.utils.sanitize_html,
-			log_error=frappe.log_error,
+			log_error=safer_log_error,
 			log=frappe.log,
 			db=NamespaceDict(
-				get_list=frappe.get_list,
-				get_all=frappe.get_all,
-				get_value=frappe.db.get_value,
-				set_value=frappe.db.set_value,
-				get_single_value=frappe.db.get_single_value,
+				get_list=safe_get_list,
+				get_all=safe_get_all,
+				get_value=safe_get_value,
+				get_single_value=safe_get_single_value,
 				get_default=frappe.db.get_default,
 				exists=frappe.db.exists,
 				count=frappe.db.count,
 				escape=frappe.db.escape,
 				sql=read_sql,
-				commit=frappe.db.commit,
-				rollback=frappe.db.rollback,
-				after_commit=frappe.db.after_commit,
-				before_commit=frappe.db.before_commit,
-				after_rollback=frappe.db.after_rollback,
-				before_rollback=frappe.db.before_rollback,
-				add_index=frappe.db.add_index,
+			),
+			website=NamespaceDict(
+				abs_url=frappe.website.utils.abs_url,
+				extract_title=frappe.website.utils.extract_title,
+				get_boot_data=frappe.website.utils.get_boot_data,
+				get_home_page=frappe.website.utils.get_home_page,
+				get_html_content_based_on_type=frappe.website.utils.get_html_content_based_on_type,
 			),
 			lang=getattr(frappe.local, "lang", "en"),
+			json_handler=json_handler,
 		),
-		FrappeClient=FrappeClient,
 		style=frappe._dict(border_color="#d1d8dd"),
 		get_toc=get_toc,
 		get_next_link=get_next_link,
@@ -277,9 +396,7 @@ def get_safe_globals():
 		guess_mimetype=mimetypes.guess_type,
 		html2text=html2text,
 		dev_server=frappe.local.dev_server,
-		run_script=run_script,
-		is_job_queued=is_job_queued,
-		get_visible_columns=get_visible_columns,
+		get_visible_columns=safer_get_visible_columns,
 	)
 
 	add_module_properties(
@@ -304,9 +421,66 @@ def get_safe_globals():
 	out._iter_unpack_sequence_ = RestrictedPython.Guards.guarded_iter_unpack_sequence
 	out._inplacevar_ = protected_inplacevar
 
-	# add common python builtins
+	# add common python builtins, also remove standard builtins
 	out.update(get_python_builtins())
 
+	return out
+
+
+def exec_safe_globals():
+	"""Safer subset of globals for exec. ops."""
+	out = render_safe_globals()
+	out.frappe.update(
+		NamespaceDict(
+			call=call_whitelisted_function,
+			get_meta=frappe.get_meta,
+			copy_doc=frappe.copy_doc,
+			new_doc=frappe.new_doc,
+			get_doc=frappe.get_doc,
+			get_mapped_doc=get_mapped_doc,
+			rename_doc=rename_doc,
+			delete_doc=delete_doc,
+			sendmail=frappe.sendmail,
+			get_print=frappe.get_print,
+			attach_print=frappe.attach_print,
+			make_get_request=frappe.integrations.utils.make_get_request,
+			make_post_request=frappe.integrations.utils.make_post_request,
+			make_put_request=frappe.integrations.utils.make_put_request,
+			make_patch_request=frappe.integrations.utils.make_patch_request,
+			make_delete_request=frappe.integrations.utils.make_delete_request,
+			log_error=frappe.log_error,
+			get_list=frappe.get_list,
+			get_all=frappe.get_all,
+			get_cached_doc=frappe.get_cached_doc,
+			get_last_doc=frappe.get_last_doc,
+			render_template=frappe.render_template,
+			enqueue=safe_enqueue,
+			is_job_queued=is_job_queued,
+		)
+	)
+	out.frappe.db.update(
+		NamespaceDict(
+			get_list=frappe.get_list,
+			get_all=frappe.get_all,
+			get_value=frappe.db.get_value,
+			set_value=frappe.db.set_value,
+			get_single_value=frappe.db.get_single_value,
+			add_index=frappe.db.add_index,
+			commit=frappe.db.commit,
+			rollback=frappe.db.rollback,
+			after_commit=frappe.db.after_commit,
+			before_commit=frappe.db.before_commit,
+			after_rollback=frappe.db.after_rollback,
+			before_rollback=frappe.db.before_rollback,
+		)
+	)
+	out.update(
+		NamespaceDict(
+			run_script=run_script,
+			FrappeClient=FrappeClient,
+			get_visible_columns=get_visible_columns,
+		)
+	)
 	return out
 
 
@@ -433,7 +607,13 @@ def get_python_builtins():
 	}
 
 
-def get_hooks(hook=None, default=None, app_name=None):
+def get_hooks(hook: str | None = None, default=None, app_name: str | None = None) -> frappe._dict:
+	"""Get hooks via `app/hooks.py`
+
+	:param hook: Name of the hook. Will gather all hooks for this name and return as a list.
+	:param default: Default if no hook found.
+	:param app_name: Filter by app."""
+
 	hooks = frappe.get_hooks(hook=hook, default=default, app_name=app_name)
 	return copy.deepcopy(hooks)
 
@@ -452,7 +632,6 @@ def check_safe_sql_query(query: str, throw: bool = True) -> bool:
 
 	Safe queries:
 	        1. Read only 'select' or 'explain' queries
-	        2. CTE on mariadb where writes are not allowed.
 	"""
 
 	query = query.strip().lower()
@@ -467,14 +646,12 @@ def check_safe_sql_query(query: str, throw: bool = True) -> bool:
 			)
 		return False
 
-	if query.startswith(whitelisted_statements) or (
-		query.startswith("with") and frappe.db.db_type == "mariadb"
-	):
+	if query.startswith(whitelisted_statements):
 		return True
 
 	if throw:
 		frappe.throw(
-			_("Query must be of SELECT or read-only WITH type."),
+			_("Read-Only queries are allowed"),
 			title=_("Unsafe SQL query"),
 			exc=frappe.PermissionError,
 		)
@@ -700,6 +877,9 @@ VALID_UTILS = (
 )
 
 
+SAFE_DATA_UTILS = {key: frappe.utils.data.__dict__[key] for key in VALID_UTILS}
+
+
 WHITELISTED_SAFE_EVAL_GLOBALS = {
 	"int": int,
 	"float": float,
@@ -712,3 +892,5 @@ WHITELISTED_SAFE_EVAL_GLOBALS = {
 	"_iter_unpack_sequence_": RestrictedPython.Guards.guarded_iter_unpack_sequence,
 	"_inplacevar_": protected_inplacevar,
 }
+
+get_safe_globals = exec_safe_globals


### PR DESCRIPTION
This is a backport of pull request https://github.com/frappe/frappe/pull/37924.

Building a safer_exec :)

TODO:
- [x] Build a render_safe_globals (read)
- [x] Build a exec_safe_globals (write)
- [x] Hardening of utils/funcs.
- [x] Refactor
- [x] Integration
- [x] Audit and reviewed todo

Concerns:
1. methods, filters = get_jinja_hooks() (should we enforce here? )
https://github.com/AarDG10/frappe/blob/a28b2dfa043cb65ea59c652f2f140e4d94f0506d/frappe/utils/jinja.py#L34-L37
2. Enforce Exec. safe where it is expected (to min. breakages) instead of relying on reading frm. configs.?

**This is a test PR to chk. for breakages in v15**
(`test_login_with_email_link`) seems to be breaking likely due to changes in jinja.py?

Backported some stuff:
- CTEs are now disallowed.