### PR TITLE
feat: python socket.io server

### DIFF
--- a/cypress/integration/realtime_backend.js
+++ b/cypress/integration/realtime_backend.js
@@ -1,0 +1,29 @@
+context("Realtime Backend Switcher", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/app");
+	});
+
+	it("defaults to the node backend", () => {
+		cy.window().then((win) => {
+			win.localStorage.removeItem("frappe_socketio_backend");
+			expect(win.frappe.realtime.get_backend()).to.equal("node");
+		});
+	});
+
+	it("rejects invalid backend names without persisting or reloading", () => {
+		cy.window().then((win) => {
+			win.frappe.realtime.set_backend("deno");
+			expect(win.localStorage.getItem("frappe_socketio_backend")).to.equal(null);
+			expect(win.frappe.realtime.get_backend()).to.equal("node");
+		});
+	});
+
+	it("reads the configured backend from localStorage", () => {
+		cy.window().then((win) => {
+			win.localStorage.setItem("frappe_socketio_backend", "python");
+			expect(win.frappe.realtime.get_backend()).to.equal("python");
+			win.localStorage.removeItem("frappe_socketio_backend");
+		});
+	});
+});

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -158,7 +158,12 @@ def load_conf_settings(bootinfo):
 
 	bootinfo.max_file_size = get_max_file_size()
 	bootinfo.file_chunk_size = get_file_chunk_size()
-	for key in ("developer_mode", "socketio_port", "file_watcher_port"):
+	for key in (
+		"developer_mode",
+		"socketio_port",
+		"socketio_python_port",
+		"file_watcher_port",
+	):
 		if key in frappe.conf:
 			bootinfo[key] = frappe.conf.get(key)
 

--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -121,13 +121,32 @@ class RealTimeClient {
 		let host = window.location.origin;
 		if (window.dev_server) {
 			let parts = host.split(":");
-			port = frappe.boot.socketio_port || port.toString() || "9000";
+			const backend = localStorage.getItem("frappe_socketio_backend") || "node";
+			if (backend === "python") {
+				port = frappe.boot.socketio_python_port || "9001";
+			} else {
+				port = frappe.boot.socketio_port || port.toString() || "9000";
+			}
 			if (parts.length > 2) {
 				host = parts[0] + ":" + parts[1];
 			}
 			host = host + ":" + port;
 		}
 		return host + `/${frappe.boot.sitename}`;
+	}
+
+	set_backend(name) {
+		if (!["node", "python"].includes(name)) {
+			console.warn(`backend must be "node" or "python", got: ${name}`);
+			return;
+		}
+		localStorage.setItem("frappe_socketio_backend", name);
+		console.log(`socketio backend set to ${name} — reloading…`);
+		window.location.reload();
+	}
+
+	get_backend() {
+		return localStorage.getItem("frappe_socketio_backend") || "node";
 	}
 
 	subscribe(task_id, opts) {
@@ -224,3 +243,28 @@ frappe.realtime = new RealTimeClient();
 
 // backward compatibility
 frappe.socketio = frappe.realtime;
+
+// Dev-mode backend switcher (node ↔ python). Shows a small indicator in the
+// bottom-right corner; click to toggle and reload. No-op outside dev_server.
+$(document).on("toolbar_setup", function () {
+	if (!window.dev_server || !frappe.boot.developer_mode) return;
+	if (document.getElementById("socketio-backend-switcher")) return;
+
+	const backend = frappe.realtime.get_backend();
+	const $el = $(`
+		<div id="socketio-backend-switcher"
+		     style="position:fixed;bottom:8px;right:8px;z-index:9999;
+		            font:11px/1.4 var(--font-stack);padding:4px 8px;
+		            background:var(--bg-color);border:1px solid var(--border-color);
+		            border-radius:6px;cursor:pointer;user-select:none;
+		            box-shadow:var(--shadow-sm);opacity:0.85;"
+		     title="Click to switch socket.io backend">
+			socket.io: <b>${backend}</b>
+		</div>
+	`);
+	$el.on("click", () => {
+		const next = frappe.realtime.get_backend() === "node" ? "python" : "node";
+		frappe.realtime.set_backend(next);
+	});
+	$("body").append($el);
+});

--- a/frappe/socketio_server/README.md
+++ b/frappe/socketio_server/README.md
@@ -1,43 +1,191 @@
-# socketio_server (prototype)
+# Python socket.io server
 
-Drop-in replacement sketch for `apps/frappe/socketio.js`, in Python via
-`python-socketio` + `uvicorn`. Not wired into bench yet.
+A Python implementation of Frappe's realtime server, wire-compatible with the
+Node implementation (`apps/frappe/socketio.js` + `apps/frappe/realtime/`).
+Built on [python-socketio](https://python-socketio.readthedocs.io/) and
+uvicorn. Browsers keep using the same `socket.io-client` library and the same
+events — no frontend changes are required to switch backends.
 
-## To try it
+```
+┌───────────┐  socket.io (ws/polling)  ┌──────────────────────┐
+│  Browser   │ ───────────────────────▶ │  this server          │
+│ (Desk/SPA) │ ◀─────────────────────── │  (uvicorn, port 9001) │
+└───────────┘                          └──────────┬───────────┘
+                                          ▲        │ HTTP callback (auth/permissions)
+              redis_queue pub/sub         │        ▼
+┌───────────┐  "events" channel   ┌───────┴──────┐
+│ web/worker │ ──────────────────▶ │ redis_queue  │◀── socketio_auth_secret
+│ processes  │  emit_via_redis     └──────────────┘
+└───────────┘
+```
 
-1. Install deps in the frappe venv:
-   ```
-   uv pip install "python-socketio[asyncio]" uvicorn redis
-   ```
+## How it works
 
-2. Stop the existing node socketio (`mprocs` → kill `socketio`), then:
-   ```
-   uvicorn frappe.socketio_server.server:asgi_app --host 0.0.0.0 --port 9000
-   ```
+### Multitenancy (dynamic namespaces)
 
-3. Replace the Procfile line:
-   ```
-   # before
-   socketio: node apps/frappe/socketio.js
-   # after
-   socketio: .venv/bin/uvicorn frappe.socketio_server.server:asgi_app --host 0.0.0.0 --port 9000
-   ```
+Clients connect to `io(origin + "/" + sitename)` — one socket.io *namespace*
+per site. The Node implementation uses `io.of(/^\/.*$/)`; python-socketio has
+no regex-namespace equivalent, so `DynamicServer` (server.py) registers all
+Frappe event handlers for a namespace the first time any client connects to
+it. Invalid sites are rejected by authentication, which requires the
+namespace to match the site derived from the request headers.
 
-## Wire compatibility
+### Authentication (auth.py)
 
-- `socket.io-client` (browser) connects unchanged: `io(origin + "/" + site)`.
-- Redis `events` channel contract unchanged — `frappe.realtime.emit_via_redis`
-  publishes the same JSON shape; `consume_events()` in `server.py` fans it out.
-- Per-app handler discovery moves from `apps/{app}/realtime/handlers.js` (filesystem)
-  to `hooks.py` (`realtime_handlers = "myapp.realtime.setup"`). Apps that depend
-  on the JS version need to declare the hook.
+A direct port of `realtime/middlewares/authenticate.js`:
 
-## Known gaps / TODOs
+1. The namespace must match the site resolved from `X-Frappe-Site-Name` /
+   `Host` / `Origin` headers (`default_site` for localhost in dev).
+2. `Host` and `Origin` hostnames must match.
+3. The client must present a `sid` cookie or an `Authorization` header
+   (token or Bearer — anything `frappe.api` accepts).
+4. The credentials are verified by an HTTP callback to the Frappe web server:
+   `GET /api/method/frappe.realtime.get_user_info`, forwarding the client's
+   credentials plus the shared `socketio_auth_secret` that web workers store
+   in redis_queue. The first call after a cold start can race the secret's
+   generation, so it is retried once (same as Node).
 
-- `DynamicServer._handle_connect` is the namespace workaround. If python-socketio
-  ever adds regex namespaces, drop the subclass.
-- `auth.py` reuses `frappe.init/connect/destroy` per connect — fine for low
-  concurrency, needs a session-pool wrapper for production.
-- `_check_permission` is sync inside an async handler — wrap in
-  `asyncio.to_thread()` once we benchmark.
-- No tests yet. First test should round-trip an `emit_via_redis` → browser.
+The resolved identity (`user`, `user_type`, `installed_apps`) is stored in
+the socket session. System Users join the `all` room; everyone joins
+`website` and their own `user:{name}` room.
+
+### Event handlers (handlers.py)
+
+Port of `realtime/handlers.js`: `ping`, `doctype_subscribe/unsubscribe`,
+`task_subscribe/unsubscribe`, `progress_subscribe`,
+`doc_subscribe/unsubscribe`, `doc_open/doc_close` (with `doc_viewers`
+presence notifications), `open_in_editor`. `doctype_subscribe`,
+`doc_subscribe` and `doc_open` check permissions through an HTTP callback to
+`frappe.realtime.has_permission` using the connection's stored credentials.
+
+### Event fan-out (server.py)
+
+`frappe.realtime.publish_realtime` → `emit_via_redis` publishes
+`{event, message, room, namespace}` JSON on the redis_queue `events` channel
+— unchanged. `consume_events()` subscribes to that channel and emits into
+the right room/namespace. Publishes without a room (e.g. the esbuild
+`build` event in dev) are broadcast to every connected namespace. The
+subscriber reconnects with backoff if redis drops.
+
+An `AsyncRedisManager` is configured as the client manager, so multiple
+server processes can be run behind a load balancer and emits reach clients
+connected to any instance (the Node implementation is single-process).
+
+### Per-app handlers
+
+The Node server loads `apps/{app}/realtime/handlers.js` from the filesystem.
+The Python equivalent is import-based: an app opts in by shipping a
+`{app}/realtime_handlers.py` module with a `register(sio, namespace)`
+callable, invoked once per site namespace (not per socket — keep
+per-connection state in the socket session via `sio.get_session`/
+`save_session`). Apps with JS handlers need this (small) port to work with
+the Python backend.
+
+## Running it
+
+```sh
+# deps are part of frappe's pyproject (python-socketio, uvicorn)
+python -m frappe.socketio_server
+```
+
+Listens on `socketio_uds` (if set) or `socketio_python_port` (default 9001)
+from `common_site_config.json`. Environment overrides: `FRAPPE_BENCH_ROOT`,
+`FRAPPE_SITE`, `FRAPPE_REDIS_QUEUE`, `FRAPPE_SOCKETIO_PORT`,
+`FRAPPE_SOCKETIO_UDS`.
+
+### Switching backends in development
+
+Both servers can run side by side (Node on 9000, Python on 9001). In a dev
+bench (`developer_mode` + dev server), a small indicator appears in the
+bottom-right corner showing the active backend — click it to toggle and
+reload. Programmatically:
+
+```js
+frappe.realtime.get_backend(); // "node" | "python"
+frappe.realtime.set_backend("python"); // persists in localStorage, reloads
+```
+
+The selection only affects the dev-server connection URL
+(`socketio_client.js`); production setups route through nginx and are
+controlled by the proxy upstream instead.
+
+### Tests
+
+- `frappe/tests/test_socketio_server.py` — unit tests for config/auth plus
+  end-to-end integration tests that boot the real ASGI server and exercise
+  auth, permissions and redis fan-out with the python socket.io client
+  (`bench --site {site} run-tests --module frappe.tests.test_socketio_server`).
+- `cypress/integration/realtime_backend.js` — client-side backend switcher.
+
+## What's needed to run this in production
+
+The server itself is production-shaped (multi-instance capable via the redis
+client manager, reconnecting subscriber, UDS support). The pieces below live
+outside this repo.
+
+### bench
+
+- **Procfile** (`bench setup procfile`): either replace the Node entry or add
+  the Python one alongside:
+
+  ```yaml
+  # replace
+  socketio: {bench}/env/bin/python -m frappe.socketio_server
+  # or run side by side (Node stays on socketio_port 9000)
+  socketio_python: {bench}/env/bin/python -m frappe.socketio_server
+  ```
+
+- **Supervisor** (`bench setup supervisor`): a `frappe-bench-python-socketio`
+  program mirroring the existing node-socketio program, using
+  `env/bin/python -m frappe.socketio_server`.
+
+- **nginx** (`bench setup nginx`): the generated config proxies
+  `/socket.io/` to `socketio_port`. To cut over, point that upstream at
+  `socketio_python_port` (or the UDS path) instead — the HTTP path and
+  protocol are identical, so nothing else changes. For a gradual rollout,
+  nginx `split_clients` can route a percentage of traffic per backend.
+
+- `bench update`/`bench restart` already restart supervisor programs, so no
+  further integration is needed once the program definition exists.
+
+### Frappe Cloud / press
+
+- **Bench image**: no extra system packages — the server is pure Python and
+  the dependencies install with frappe. Benches on older frappe versions
+  simply don't have the module; press should gate the feature on the app
+  version.
+- **Supervisor/agent**: press generates supervisor and nginx configs through
+  the agent; it needs the same program + upstream changes as plain bench
+  (above). Port allocation: either reuse the bench's existing socketio port
+  after cutover, or allocate `socketio_python_port` per bench for
+  side-by-side operation.
+- **Health checks**: the agent's socketio health check can hit
+  `GET /socket.io/?EIO=4&transport=polling` — identical for both backends. A
+  plain connect to the default namespace also succeeds without auth and is
+  used only for health checking.
+- **Scaling**: unlike Node, multiple instances can be run behind the same
+  nginx upstream (sticky sessions required for long-polling — use
+  `ip_hash` or cookie-based stickiness; pure-websocket clients don't need
+  it). Emits propagate across instances via the redis client manager.
+
+### Rollout strategy
+
+1. Ship the server in frappe (this directory) — inert until something runs it.
+2. bench/press add the supervisor program behind a config flag
+   (e.g. `use_python_socketio`), running side by side on 9001.
+3. Cut the nginx upstream over per-bench; the Node process keeps serving
+   existing connections until drained, clients reconnect to the new backend
+   on their next (re)connect.
+4. Once stable, drop the Node program and `socketio.js`.
+
+## Known gaps / non-goals
+
+- Apps that ship `realtime/handlers.js` must port them to the Python
+  convention (`{app}/realtime_handlers.py`) to keep their custom events when
+  a bench switches backends.
+- Dynamically-registered namespaces are never garbage-collected (Node sets
+  `cleanupEmptyChildNamespaces`). One namespace per site is negligible;
+  revisit for very large multitenant benches.
+- Auth/permission callbacks run `requests` in a thread per call (mirroring
+  Node's per-connect fetch). If connect storms become a bottleneck, switch to
+  a shared aiohttp session.

--- a/frappe/socketio_server/README.md
+++ b/frappe/socketio_server/README.md
@@ -1,0 +1,43 @@
+# socketio_server (prototype)
+
+Drop-in replacement sketch for `apps/frappe/socketio.js`, in Python via
+`python-socketio` + `uvicorn`. Not wired into bench yet.
+
+## To try it
+
+1. Install deps in the frappe venv:
+   ```
+   uv pip install "python-socketio[asyncio]" uvicorn redis
+   ```
+
+2. Stop the existing node socketio (`mprocs` → kill `socketio`), then:
+   ```
+   uvicorn frappe.socketio_server.server:asgi_app --host 0.0.0.0 --port 9000
+   ```
+
+3. Replace the Procfile line:
+   ```
+   # before
+   socketio: node apps/frappe/socketio.js
+   # after
+   socketio: .venv/bin/uvicorn frappe.socketio_server.server:asgi_app --host 0.0.0.0 --port 9000
+   ```
+
+## Wire compatibility
+
+- `socket.io-client` (browser) connects unchanged: `io(origin + "/" + site)`.
+- Redis `events` channel contract unchanged — `frappe.realtime.emit_via_redis`
+  publishes the same JSON shape; `consume_events()` in `server.py` fans it out.
+- Per-app handler discovery moves from `apps/{app}/realtime/handlers.js` (filesystem)
+  to `hooks.py` (`realtime_handlers = "myapp.realtime.setup"`). Apps that depend
+  on the JS version need to declare the hook.
+
+## Known gaps / TODOs
+
+- `DynamicServer._handle_connect` is the namespace workaround. If python-socketio
+  ever adds regex namespaces, drop the subclass.
+- `auth.py` reuses `frappe.init/connect/destroy` per connect — fine for low
+  concurrency, needs a session-pool wrapper for production.
+- `_check_permission` is sync inside an async handler — wrap in
+  `asyncio.to_thread()` once we benchmark.
+- No tests yet. First test should round-trip an `emit_via_redis` → browser.

--- a/frappe/socketio_server/README.md
+++ b/frappe/socketio_server/README.md
@@ -49,6 +49,33 @@ The resolved identity (`user`, `user_type`, `installed_apps`) is stored in
 the socket session. System Users join the `all` room; everyone joins
 `website` and their own `user:{name}` room.
 
+#### Session fast path
+
+Something the Node implementation could never do: for `sid`-cookie
+connections, the server first tries to resolve the session **directly from
+the redis session cache** (the `{db_name}|session` hash that
+`frappe.sessions.Session` maintains), skipping the HTTP callback entirely.
+The fast path is strictly conservative — it only answers when the answer is
+provably right, and falls back to the canonical HTTP path otherwise:
+
+- cache miss, unparseable entry, or missing user/user_type → HTTP
+- session freshness is validated locally against `last_updated` +
+  `session_expiry`, with a 26-hour slack: `last_updated` is written in the
+  *site's* timezone (a DB setting this server doesn't read), so only
+  sessions that would be valid under any timezone interpretation qualify.
+  Anything ambiguous — including all sites with short session expiries —
+  goes to the web server for canonical validation. The fast path never
+  rejects on its own.
+- `installed_apps` lives only in the site DB, so the first connect per site
+  (per process) always uses the HTTP callback and primes a per-site cache
+  (10 min TTL) that subsequent fast-path connects reuse.
+- cached sessions are unpickled with a restricted unpickler that only
+  constructs plain dicts and datetime values — the realtime server never
+  executes arbitrary pickle from the cache and never imports the framework.
+
+`Authorization`-header connections (API key/secret, OAuth bearer) always use
+the HTTP callback — token verification belongs to `frappe.auth`.
+
 ### Event handlers (handlers.py)
 
 Port of `realtime/handlers.js`: `ping`, `doctype_subscribe/unsubscribe`,
@@ -187,5 +214,10 @@ outside this repo.
   `cleanupEmptyChildNamespaces`). One namespace per site is negligible;
   revisit for very large multitenant benches.
 - Auth/permission callbacks run `requests` in a thread per call (mirroring
-  Node's per-connect fetch). If connect storms become a bottleneck, switch to
-  a shared aiohttp session.
+  Node's per-connect fetch). The session fast path removes the callback for
+  the common case (sid cookie, long expiry); if the remaining HTTP traffic
+  (token auth, permission checks) ever becomes a bottleneck, switch to a
+  shared aiohttp session.
+- The fast path reads each site's `db_name` from `site_config.json`, so the
+  realtime server needs filesystem access to the sites directory (it already
+  reads `common_site_config.json`). It never reads DB credentials.

--- a/frappe/socketio_server/__init__.py
+++ b/frappe/socketio_server/__init__.py
@@ -1,11 +1,7 @@
 """Python implementation of Frappe's realtime (socket.io) server.
 
-Drop-in replacement for ``apps/frappe/socketio.js`` built on python-socketio
-and uvicorn. Run with::
-
-	python -m frappe.socketio_server
-
-See README.md in this directory for architecture and production notes.
+Drop-in replacement for apps/frappe/socketio.js. See README.md for
+architecture and production notes.
 """
 
 import json
@@ -14,12 +10,8 @@ from pathlib import Path
 
 
 def find_bench_root() -> Path:
-	"""Locate the bench root (the directory containing sites/common_site_config.json).
-
-	Resolution order: FRAPPE_BENCH_ROOT env var, then cwd and its parents
-	(covers running from bench root, sites dir, or an app dir), then the
-	location of this file (apps/frappe/frappe/socketio_server).
-	"""
+	"""Locate the directory containing sites/common_site_config.json —
+	FRAPPE_BENCH_ROOT, then cwd and its parents, then this file's location."""
 	if env_root := os.environ.get("FRAPPE_BENCH_ROOT"):
 		return Path(env_root)
 	for candidate in (Path.cwd(), *Path.cwd().parents):
@@ -31,12 +23,8 @@ def find_bench_root() -> Path:
 
 
 def bench_conf() -> dict:
-	"""Read sites/common_site_config.json directly — mirrors node_utils.get_conf.
-
-	We deliberately do NOT call frappe.get_conf() because it triggers
-	frappe.init_site → setup_module_map → reads apps.txt from cwd, which is
-	the wrong dependency at server-startup / per-connect time.
-	"""
+	"""Read common_site_config.json directly — frappe.get_conf() would pull in
+	site init, the wrong dependency at server startup."""
 	conf: dict = {"socketio_port": 9000, "socketio_python_port": 9001}
 	conf_path = find_bench_root() / "sites" / "common_site_config.json"
 	if conf_path.exists():
@@ -53,6 +41,5 @@ def bench_conf() -> dict:
 
 
 def redis_url() -> str:
-	"""URL of the redis_queue instance — carries the `events` pub/sub channel
-	and the socketio_auth_secret key, same as the Node implementation."""
+	"""redis_queue URL — carries the events channel and the auth secret."""
 	return bench_conf().get("redis_queue") or "redis://127.0.0.1:11000"

--- a/frappe/socketio_server/__init__.py
+++ b/frappe/socketio_server/__init__.py
@@ -1,8 +1,33 @@
-"""Shared helpers for the prototype python-socketio server."""
+"""Python implementation of Frappe's realtime (socket.io) server.
+
+Drop-in replacement for ``apps/frappe/socketio.js`` built on python-socketio
+and uvicorn. Run with::
+
+	python -m frappe.socketio_server
+
+See README.md in this directory for architecture and production notes.
+"""
 
 import json
 import os
 from pathlib import Path
+
+
+def find_bench_root() -> Path:
+	"""Locate the bench root (the directory containing sites/common_site_config.json).
+
+	Resolution order: FRAPPE_BENCH_ROOT env var, then cwd and its parents
+	(covers running from bench root, sites dir, or an app dir), then the
+	location of this file (apps/frappe/frappe/socketio_server).
+	"""
+	if env_root := os.environ.get("FRAPPE_BENCH_ROOT"):
+		return Path(env_root)
+	for candidate in (Path.cwd(), *Path.cwd().parents):
+		if (candidate / "sites" / "common_site_config.json").exists():
+			return candidate
+		if candidate.name == "sites" and (candidate / "common_site_config.json").exists():
+			return candidate.parent
+	return Path(__file__).resolve().parents[4]
 
 
 def bench_conf() -> dict:
@@ -12,16 +37,22 @@ def bench_conf() -> dict:
 	frappe.init_site → setup_module_map → reads apps.txt from cwd, which is
 	the wrong dependency at server-startup / per-connect time.
 	"""
-	bench_root = Path(os.environ.get("FRAPPE_BENCH_ROOT", Path.cwd()))
-	conf_path = bench_root / "sites" / "common_site_config.json"
 	conf: dict = {"socketio_port": 9000, "socketio_python_port": 9001}
+	conf_path = find_bench_root() / "sites" / "common_site_config.json"
 	if conf_path.exists():
 		conf.update(json.loads(conf_path.read_text()))
 	for env_key, conf_key in [
 		("FRAPPE_SITE", "default_site"),
 		("FRAPPE_REDIS_QUEUE", "redis_queue"),
 		("FRAPPE_SOCKETIO_PORT", "socketio_python_port"),
+		("FRAPPE_SOCKETIO_UDS", "socketio_uds"),
 	]:
 		if env_key in os.environ:
 			conf[conf_key] = os.environ[env_key]
 	return conf
+
+
+def redis_url() -> str:
+	"""URL of the redis_queue instance — carries the `events` pub/sub channel
+	and the socketio_auth_secret key, same as the Node implementation."""
+	return bench_conf().get("redis_queue") or "redis://127.0.0.1:11000"

--- a/frappe/socketio_server/__init__.py
+++ b/frappe/socketio_server/__init__.py
@@ -1,0 +1,27 @@
+"""Shared helpers for the prototype python-socketio server."""
+
+import json
+import os
+from pathlib import Path
+
+
+def bench_conf() -> dict:
+	"""Read sites/common_site_config.json directly — mirrors node_utils.get_conf.
+
+	We deliberately do NOT call frappe.get_conf() because it triggers
+	frappe.init_site → setup_module_map → reads apps.txt from cwd, which is
+	the wrong dependency at server-startup / per-connect time.
+	"""
+	bench_root = Path(os.environ.get("FRAPPE_BENCH_ROOT", Path.cwd()))
+	conf_path = bench_root / "sites" / "common_site_config.json"
+	conf: dict = {"socketio_port": 9000, "socketio_python_port": 9001}
+	if conf_path.exists():
+		conf.update(json.loads(conf_path.read_text()))
+	for env_key, conf_key in [
+		("FRAPPE_SITE", "default_site"),
+		("FRAPPE_REDIS_QUEUE", "redis_queue"),
+		("FRAPPE_SOCKETIO_PORT", "socketio_python_port"),
+	]:
+		if env_key in os.environ:
+			conf[conf_key] = os.environ[env_key]
+	return conf

--- a/frappe/socketio_server/__main__.py
+++ b/frappe/socketio_server/__main__.py
@@ -1,0 +1,25 @@
+"""Entrypoint: python -m frappe.socketio_server
+
+Listens on socketio_uds (if set) or socketio_python_port (default 9001) from
+common_site_config.json. Environment overrides: FRAPPE_SOCKETIO_UDS,
+FRAPPE_SOCKETIO_PORT.
+"""
+
+import uvicorn
+
+from frappe.socketio_server import bench_conf
+
+
+def main():
+	conf = bench_conf()
+	kwargs = {"lifespan": "on"}
+	if uds := conf.get("socketio_uds"):
+		kwargs["uds"] = uds
+	else:
+		kwargs["host"] = "0.0.0.0"
+		kwargs["port"] = int(conf.get("socketio_python_port") or 9001)
+	uvicorn.run("frappe.socketio_server.server:asgi_app", **kwargs)
+
+
+if __name__ == "__main__":
+	main()

--- a/frappe/socketio_server/__main__.py
+++ b/frappe/socketio_server/__main__.py
@@ -1,8 +1,6 @@
 """Entrypoint: python -m frappe.socketio_server
 
-Listens on socketio_uds (if set) or socketio_python_port (default 9001) from
-common_site_config.json. Environment overrides: FRAPPE_SOCKETIO_UDS,
-FRAPPE_SOCKETIO_PORT.
+Listens on socketio_uds (if set) or socketio_python_port (default 9001).
 """
 
 import uvicorn

--- a/frappe/socketio_server/auth.py
+++ b/frappe/socketio_server/auth.py
@@ -1,32 +1,34 @@
-"""
-PROTOTYPE: connect-time authentication for the python-socketio server.
+"""Connect-time authentication for the python-socketio realtime server.
 
-Direct port of realtime/middlewares/authenticate.js. Two important caveats:
+Port of realtime/middlewares/authenticate.js. Session resolution works the
+same way as the Node implementation: an HTTP callback to the Frappe web
+server (`frappe.realtime.get_user_info`), authenticated by forwarding the
+client's `sid` cookie or Authorization header plus the shared
+`socketio_auth_secret` that web workers store in redis_queue.
 
-1. The JS version makes an HTTP callback to Frappe for session/user info.
-   The right Python equivalent is NOT `frappe.init/connect/destroy` per
-   connect — that's blocking, cwd-dependent, and slow. The real impl needs
-   either (a) a session-resolver subprocess we talk to via redis/UDS, or
-   (b) running the auth path in a thread executor with a properly-bound
-   site context, or (c) keeping the HTTP callback for now.
-
-2. To unblock smoke-testing of the dynamic-namespace mechanism, this module
-   honours FRAPPE_SOCKETIO_DEBUG_SKIP_AUTH=1 — when set, it accepts any
-   connection as Guest with installed_apps=["frappe"].
+The callback is synchronous (requests) and runs in a worker thread via
+asyncio.to_thread — one call per connect, same cost profile as the Node
+implementation's fetch().
 """
 
-import os
+import asyncio
 from http.cookies import SimpleCookie
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
-from frappe.socketio_server import bench_conf
+import redis
+import requests
+
+from frappe.socketio_server import bench_conf, redis_url
+
+SOCKETIO_SECRET_KEY = "socketio_auth_secret"
+CALLBACK_TIMEOUT = 10
 
 
 def _hostname(url_or_host: str | None) -> str | None:
 	if not url_or_host:
 		return None
 	if "://" in url_or_host:
-		url_or_host = urlparse(url_or_host).netloc
+		url_or_host = urlsplit(url_or_host).netloc
 	return url_or_host.split(":")[0]
 
 
@@ -42,27 +44,74 @@ def _site_from_environ(environ: dict, conf: dict) -> str | None:
 	return _hostname(environ.get("HTTP_ORIGIN")) or host
 
 
-async def authenticate(environ: dict, namespace: str) -> tuple[bool, dict | str]:
-	"""Returns (ok, ctx_or_error_message).
+def _base_url(environ: dict, conf: dict) -> str:
+	"""URL of the Frappe web server to make auth callbacks against.
 
-	ctx on success: {"site", "user", "user_type", "installed_apps"}
+	Mirrors realtime/utils.js get_url: use the request origin; in
+	developer_mode rewrite the port to webserver_port because the browser
+	origin points at the dev asset server, not the gunicorn worker.
+	"""
+	origin = environ.get("HTTP_ORIGIN") or f"http://{environ.get('HTTP_HOST', 'localhost')}"
+	if conf.get("developer_mode") and conf.get("webserver_port"):
+		parts = urlsplit(origin)
+		origin = f"{parts.scheme}://{parts.hostname}:{conf['webserver_port']}"
+	return origin
+
+
+def _get_socket_secret() -> str | None:
+	"""The shared secret get_user_info requires — generated and stored in
+	redis_queue by the web worker (frappe.realtime.get_socketio_secret)."""
+	client = redis.Redis.from_url(redis_url())
+	try:
+		secret = client.get(SOCKETIO_SECRET_KEY)
+	finally:
+		client.close()
+	return secret.decode() if secret else None
+
+
+def _frappe_request(
+	base_url: str,
+	path: str,
+	*,
+	sid: str | None = None,
+	authorization_header: str | None = None,
+	params: dict | None = None,
+) -> dict:
+	"""Synchronous HTTP callback to the Frappe web server (run via
+	asyncio.to_thread). Returns the decoded JSON body, or {} on any failure —
+	callers treat a missing "message" key as denial."""
+	headers = {"Accept": "application/json"}
+	if authorization_header:
+		headers["Authorization"] = authorization_header
+	elif sid:
+		headers["Cookie"] = f"sid={sid}"
+	if secret := _get_socket_secret():
+		headers["X-Frappe-Socket-Secret"] = secret
+	try:
+		response = requests.get(
+			f"{base_url}{path}", params=params or {}, headers=headers, timeout=CALLBACK_TIMEOUT
+		)
+		if response.ok:
+			return response.json()
+	except (requests.RequestException, ValueError):
+		pass
+	return {}
+
+
+async def authenticate(environ: dict, namespace: str) -> tuple[bool, dict | str]:
+	"""Validate a connection attempt against the namespace's site.
+
+	Returns (True, ctx) on success where ctx becomes the socket session:
+	{"site", "user", "user_type", "installed_apps", "sid",
+	 "authorization_header", "base_url", "open_docs"},
+	or (False, error_message) on rejection.
 	"""
 	conf = bench_conf()
 	site = _site_from_environ(environ, conf)
 	ns_site = namespace.lstrip("/")
 
-	# DEV escape hatch: bypass session resolution to exercise dynamic-namespace
-	# registration and event fan-out without a real cookie.
-	if os.environ.get("FRAPPE_SOCKETIO_DEBUG_SKIP_AUTH") == "1":
-		return True, {
-			"site": ns_site or site or "debug",
-			"user": "Guest",
-			"user_type": "Guest",
-			"installed_apps": ["frappe"],
-		}
-
 	if ns_site != site:
-		return False, f"Invalid namespace: {ns_site!r} != site {site!r}"
+		return False, f"Invalid namespace {ns_site!r} for site {site!r}"
 
 	host = _hostname(environ.get("HTTP_HOST"))
 	origin = _hostname(environ.get("HTTP_ORIGIN"))
@@ -70,29 +119,65 @@ async def authenticate(environ: dict, namespace: str) -> tuple[bool, dict | str]
 		return False, "Invalid origin"
 
 	cookie_header = environ.get("HTTP_COOKIE", "")
-	auth_header = environ.get("HTTP_AUTHORIZATION")
-	if not cookie_header and not auth_header:
-		return False, "Missing cookie and authorization header"
+	authorization_header = environ.get("HTTP_AUTHORIZATION")
+	if not cookie_header and not authorization_header:
+		return False, "Missing cookie and authorization header. Either one needed for authentication."
 
 	sid = None
 	if cookie_header:
 		jar = SimpleCookie()
 		jar.load(cookie_header)
-		sid = jar["sid"].value if "sid" in jar else None
-	if not sid and not auth_header:
-		return False, "No authentication method used"
+		if "sid" in jar:
+			sid = jar["sid"].value
+	if not sid and not authorization_header:
+		return False, "No authentication method used. Use cookie or authorization header."
 
-	# Resolve session — placeholder. See module docstring.
-	return await _resolve_session(site, sid, auth_header)
+	base_url = _base_url(environ, conf)
+	user_info = await _get_user_info(base_url, sid, authorization_header)
+	if not user_info.get("user"):
+		return False, "Unauthorized: could not resolve session"
+
+	return True, {
+		"site": site,
+		"user": user_info["user"],
+		"user_type": user_info.get("user_type"),
+		"installed_apps": user_info.get("installed_apps") or [],
+		"sid": sid,
+		"authorization_header": authorization_header,
+		"base_url": base_url,
+		"open_docs": [],
+	}
 
 
-async def _resolve_session(site, sid, auth_header):
-	"""TODO: real session resolution. Options:
-	  a) HTTP callback (like the JS version)
-	  b) thread-pool wrapper around frappe.sessions.Session(sid=...)
-	  c) dedicated session-resolver daemon
+async def _get_user_info(base_url: str, sid: str | None, authorization_header: str | None) -> dict:
+	async def call() -> dict:
+		response = await asyncio.to_thread(
+			_frappe_request,
+			base_url,
+			"/api/method/frappe.realtime.get_user_info",
+			sid=sid,
+			authorization_header=authorization_header,
+		)
+		return response.get("message") or {}
 
-	For now this is a stub so the smoke test fails clearly rather than
-	silently letting Guest through.
-	"""
-	return False, "Session resolution not yet implemented (set FRAPPE_SOCKETIO_DEBUG_SKIP_AUTH=1)"
+	message = await call()
+	# get_user_info returns {} until a web worker has generated the shared
+	# secret (the first call itself generates it) — retry once, like the
+	# Node implementation.
+	if not message.get("installed_apps"):
+		message = await call() or message
+	return message
+
+
+async def check_permission(ctx: dict, doctype: str, docname: str | None = None) -> bool:
+	"""frappe.realtime.has_permission HTTP callback using the connection's
+	stored credentials. Deny on any failure."""
+	response = await asyncio.to_thread(
+		_frappe_request,
+		ctx["base_url"],
+		"/api/method/frappe.realtime.has_permission",
+		sid=ctx.get("sid"),
+		authorization_header=ctx.get("authorization_header"),
+		params={"doctype": doctype, "name": docname or ""},
+	)
+	return bool(response.get("message"))

--- a/frappe/socketio_server/auth.py
+++ b/frappe/socketio_server/auth.py
@@ -1,14 +1,7 @@
-"""Connect-time authentication for the python-socketio realtime server.
+"""Connect-time authentication — port of realtime/middlewares/authenticate.js.
 
-Port of realtime/middlewares/authenticate.js. Session resolution works the
-same way as the Node implementation: an HTTP callback to the Frappe web
-server (`frappe.realtime.get_user_info`), authenticated by forwarding the
-client's `sid` cookie or Authorization header plus the shared
-`socketio_auth_secret` that web workers store in redis_queue.
-
-The callback is synchronous (requests) and runs in a worker thread via
-asyncio.to_thread — one call per connect, same cost profile as the Node
-implementation's fetch().
+Sessions are resolved from the redis session cache when possible, falling
+back to an HTTP callback to frappe.realtime.get_user_info (the Node way).
 """
 
 import asyncio
@@ -28,12 +21,8 @@ from frappe.socketio_server import bench_conf, find_bench_root, redis_url
 SOCKETIO_SECRET_KEY = "socketio_auth_secret"
 CALLBACK_TIMEOUT = 10
 
-# Session fast path: sessions whose remaining validity is smaller than this
-# slack fall back to the HTTP callback instead of being judged locally.
-# frappe.utils.now() writes last_updated in the *site's* timezone (a DB
-# setting this server can't read), so local freshness math can be off by up
-# to the largest possible tz offset — only trust it when the session would
-# be fresh under any timezone interpretation.
+# last_updated is written in the site's timezone (a DB setting we can't
+# read), so only trust sessions fresh under any timezone interpretation
 TZ_SLACK_SECONDS = 26 * 3600
 INSTALLED_APPS_TTL = 600
 
@@ -62,12 +51,8 @@ def _site_from_environ(environ: dict, conf: dict) -> str | None:
 
 
 def _base_url(environ: dict, conf: dict) -> str:
-	"""URL of the Frappe web server to make auth callbacks against.
-
-	Mirrors realtime/utils.js get_url: use the request origin; in
-	developer_mode rewrite the port to webserver_port because the browser
-	origin points at the dev asset server, not the gunicorn worker.
-	"""
+	"""Web server URL for auth callbacks. In developer_mode the browser origin
+	points at the dev asset server, so rewrite the port to webserver_port."""
 	origin = environ.get("HTTP_ORIGIN") or f"http://{environ.get('HTTP_HOST', 'localhost')}"
 	if conf.get("developer_mode") and conf.get("webserver_port"):
 		parts = urlsplit(origin)
@@ -76,20 +61,16 @@ def _base_url(environ: dict, conf: dict) -> str:
 
 
 # --- Session fast path --------------------------------------------------------
-# Resolve sid cookies straight from the redis session cache (the same hash
-# frappe.sessions.Session writes), skipping the HTTP callback. Strictly
-# conservative: any miss, parse failure, staleness ambiguity, or unknown
-# installed_apps falls back to the canonical HTTP path.
+# Read sid sessions straight from the redis session cache; anything uncertain
+# falls back to the HTTP callback.
 
 
 class _session_dict(dict):
-	"""Stand-in for frappe._dict when unpickling session data — a plain dict
-	subclass so pickle's BUILD opcode (which sets instance state) works."""
+	"""Stand-in for frappe._dict (a subclass, so pickle's BUILD opcode works)."""
 
 
 class _SessionUnpickler(pickle.Unpickler):
-	"""Unpickle frappe's cached session without importing the framework, and
-	refuse to construct anything beyond the types session data contains."""
+	"""Only constructs dicts and datetime values — never arbitrary classes."""
 
 	def find_class(self, module, name):
 		if module in ("frappe", "frappe.types.frappedict") and name == "_dict":
@@ -100,8 +81,7 @@ class _SessionUnpickler(pickle.Unpickler):
 
 
 def _site_db_name(site: str) -> str | None:
-	"""Sessions are cached under "{db_name}|session" — db_name comes from the
-	site's site_config.json (filesystem only, never changes for a site)."""
+	"""Sessions are cached under "{db_name}|session"; db_name never changes."""
 	if site not in _site_db_names:
 		db_name = None
 		config_path = find_bench_root() / "sites" / site / "site_config.json"
@@ -114,9 +94,7 @@ def _site_db_name(site: str) -> str | None:
 
 
 def _session_comfortably_fresh(session_data: dict) -> bool:
-	"""Would this session be unexpired under ANY timezone interpretation of
-	last_updated? Mirrors Session.get_session_data_from_cache validation,
-	minus the site-timezone knowledge we don't have (see TZ_SLACK_SECONDS)."""
+	"""Unexpired under any timezone interpretation of last_updated?"""
 	if session_data.get("session_end"):
 		# bounded sessions are rare — let the web server judge them
 		return False
@@ -146,13 +124,9 @@ def _remember_installed_apps(site: str, apps: list[str]):
 
 
 def _resolve_session_fast(site: str, sid: str) -> dict | None:
-	"""sid → user info straight from the redis session cache. Returns the
-	get_user_info shape, or None to fall back to the HTTP callback.
-
-	installed_apps lives only in the site DB, so the fast path requires a
-	cached value from an earlier HTTP callback — the first connect per site
-	(per process) always goes over HTTP and primes it.
-	"""
+	"""sid → user info from the redis session cache, or None to fall back."""
+	# installed_apps lives only in the site DB — the first connect per site
+	# goes over HTTP and primes it
 	apps = _cached_installed_apps(site)
 	if apps is None:
 		return None
@@ -187,8 +161,7 @@ def _resolve_session_fast(site: str, sid: str) -> dict | None:
 
 # --- HTTP callback path ---------------------------------------------------------
 def _get_socket_secret() -> str | None:
-	"""The shared secret get_user_info requires — generated and stored in
-	redis_queue by the web worker (frappe.realtime.get_socketio_secret)."""
+	"""Shared secret that get_user_info requires; web workers store it in redis."""
 	client = redis.Redis.from_url(redis_url())
 	try:
 		secret = client.get(SOCKETIO_SECRET_KEY)
@@ -205,9 +178,7 @@ def _frappe_request(
 	authorization_header: str | None = None,
 	params: dict | None = None,
 ) -> dict:
-	"""Synchronous HTTP callback to the Frappe web server (run via
-	asyncio.to_thread). Returns the decoded JSON body, or {} on any failure —
-	callers treat a missing "message" key as denial."""
+	"""HTTP callback to the Frappe web server. Returns {} on any failure."""
 	headers = {"Accept": "application/json"}
 	if authorization_header:
 		headers["Authorization"] = authorization_header
@@ -227,13 +198,8 @@ def _frappe_request(
 
 
 async def authenticate(environ: dict, namespace: str) -> tuple[bool, dict | str]:
-	"""Validate a connection attempt against the namespace's site.
-
-	Returns (True, ctx) on success where ctx becomes the socket session:
-	{"site", "user", "user_type", "installed_apps", "sid",
-	 "authorization_header", "base_url", "open_docs"},
-	or (False, error_message) on rejection.
-	"""
+	"""Validate a connection attempt. Returns (True, session ctx) or
+	(False, error message)."""
 	conf = bench_conf()
 	site = _site_from_environ(environ, conf)
 	ns_site = namespace.lstrip("/")
@@ -295,17 +261,14 @@ async def _get_user_info(base_url: str, sid: str | None, authorization_header: s
 		return response.get("message") or {}
 
 	message = await call()
-	# get_user_info returns {} until a web worker has generated the shared
-	# secret (the first call itself generates it) — retry once, like the
-	# Node implementation.
+	# the first call generates the shared secret — retry once, like Node
 	if not message.get("installed_apps"):
 		message = await call() or message
 	return message
 
 
 async def check_permission(ctx: dict, doctype: str, docname: str | None = None) -> bool:
-	"""frappe.realtime.has_permission HTTP callback using the connection's
-	stored credentials. Deny on any failure."""
+	"""Check frappe.realtime.has_permission with the connection's credentials."""
 	response = await asyncio.to_thread(
 		_frappe_request,
 		ctx["base_url"],

--- a/frappe/socketio_server/auth.py
+++ b/frappe/socketio_server/auth.py
@@ -1,0 +1,98 @@
+"""
+PROTOTYPE: connect-time authentication for the python-socketio server.
+
+Direct port of realtime/middlewares/authenticate.js. Two important caveats:
+
+1. The JS version makes an HTTP callback to Frappe for session/user info.
+   The right Python equivalent is NOT `frappe.init/connect/destroy` per
+   connect — that's blocking, cwd-dependent, and slow. The real impl needs
+   either (a) a session-resolver subprocess we talk to via redis/UDS, or
+   (b) running the auth path in a thread executor with a properly-bound
+   site context, or (c) keeping the HTTP callback for now.
+
+2. To unblock smoke-testing of the dynamic-namespace mechanism, this module
+   honours FRAPPE_SOCKETIO_DEBUG_SKIP_AUTH=1 — when set, it accepts any
+   connection as Guest with installed_apps=["frappe"].
+"""
+
+import os
+from http.cookies import SimpleCookie
+from urllib.parse import urlparse
+
+from frappe.socketio_server import bench_conf
+
+
+def _hostname(url_or_host: str | None) -> str | None:
+	if not url_or_host:
+		return None
+	if "://" in url_or_host:
+		url_or_host = urlparse(url_or_host).netloc
+	return url_or_host.split(":")[0]
+
+
+def _site_from_environ(environ: dict, conf: dict) -> str | None:
+	explicit = environ.get("HTTP_X_FRAPPE_SITE_NAME")
+	if explicit:
+		return _hostname(explicit)
+
+	host = _hostname(environ.get("HTTP_HOST"))
+	if conf.get("default_site") and host in ("localhost", "127.0.0.1"):
+		return conf["default_site"]
+
+	return _hostname(environ.get("HTTP_ORIGIN")) or host
+
+
+async def authenticate(environ: dict, namespace: str) -> tuple[bool, dict | str]:
+	"""Returns (ok, ctx_or_error_message).
+
+	ctx on success: {"site", "user", "user_type", "installed_apps"}
+	"""
+	conf = bench_conf()
+	site = _site_from_environ(environ, conf)
+	ns_site = namespace.lstrip("/")
+
+	# DEV escape hatch: bypass session resolution to exercise dynamic-namespace
+	# registration and event fan-out without a real cookie.
+	if os.environ.get("FRAPPE_SOCKETIO_DEBUG_SKIP_AUTH") == "1":
+		return True, {
+			"site": ns_site or site or "debug",
+			"user": "Guest",
+			"user_type": "Guest",
+			"installed_apps": ["frappe"],
+		}
+
+	if ns_site != site:
+		return False, f"Invalid namespace: {ns_site!r} != site {site!r}"
+
+	host = _hostname(environ.get("HTTP_HOST"))
+	origin = _hostname(environ.get("HTTP_ORIGIN"))
+	if host != origin:
+		return False, "Invalid origin"
+
+	cookie_header = environ.get("HTTP_COOKIE", "")
+	auth_header = environ.get("HTTP_AUTHORIZATION")
+	if not cookie_header and not auth_header:
+		return False, "Missing cookie and authorization header"
+
+	sid = None
+	if cookie_header:
+		jar = SimpleCookie()
+		jar.load(cookie_header)
+		sid = jar["sid"].value if "sid" in jar else None
+	if not sid and not auth_header:
+		return False, "No authentication method used"
+
+	# Resolve session — placeholder. See module docstring.
+	return await _resolve_session(site, sid, auth_header)
+
+
+async def _resolve_session(site, sid, auth_header):
+	"""TODO: real session resolution. Options:
+	  a) HTTP callback (like the JS version)
+	  b) thread-pool wrapper around frappe.sessions.Session(sid=...)
+	  c) dedicated session-resolver daemon
+
+	For now this is a stub so the smoke test fails clearly rather than
+	silently letting Guest through.
+	"""
+	return False, "Session resolution not yet implemented (set FRAPPE_SOCKETIO_DEBUG_SKIP_AUTH=1)"

--- a/frappe/socketio_server/auth.py
+++ b/frappe/socketio_server/auth.py
@@ -12,16 +12,33 @@ implementation's fetch().
 """
 
 import asyncio
+import datetime
+import io
+import json
+import pickle
+import time
 from http.cookies import SimpleCookie
 from urllib.parse import urlsplit
 
 import redis
 import requests
 
-from frappe.socketio_server import bench_conf, redis_url
+from frappe.socketio_server import bench_conf, find_bench_root, redis_url
 
 SOCKETIO_SECRET_KEY = "socketio_auth_secret"
 CALLBACK_TIMEOUT = 10
+
+# Session fast path: sessions whose remaining validity is smaller than this
+# slack fall back to the HTTP callback instead of being judged locally.
+# frappe.utils.now() writes last_updated in the *site's* timezone (a DB
+# setting this server can't read), so local freshness math can be off by up
+# to the largest possible tz offset — only trust it when the session would
+# be fresh under any timezone interpretation.
+TZ_SLACK_SECONDS = 26 * 3600
+INSTALLED_APPS_TTL = 600
+
+_site_db_names: dict[str, str | None] = {}
+_installed_apps_cache: dict[str, tuple[list[str], float]] = {}
 
 
 def _hostname(url_or_host: str | None) -> str | None:
@@ -58,6 +75,117 @@ def _base_url(environ: dict, conf: dict) -> str:
 	return origin
 
 
+# --- Session fast path --------------------------------------------------------
+# Resolve sid cookies straight from the redis session cache (the same hash
+# frappe.sessions.Session writes), skipping the HTTP callback. Strictly
+# conservative: any miss, parse failure, staleness ambiguity, or unknown
+# installed_apps falls back to the canonical HTTP path.
+
+
+class _session_dict(dict):
+	"""Stand-in for frappe._dict when unpickling session data — a plain dict
+	subclass so pickle's BUILD opcode (which sets instance state) works."""
+
+
+class _SessionUnpickler(pickle.Unpickler):
+	"""Unpickle frappe's cached session without importing the framework, and
+	refuse to construct anything beyond the types session data contains."""
+
+	def find_class(self, module, name):
+		if module in ("frappe", "frappe.types.frappedict") and name == "_dict":
+			return _session_dict
+		if module == "datetime" and name in ("datetime", "date", "time", "timedelta"):
+			return getattr(datetime, name)
+		raise pickle.UnpicklingError(f"refusing to unpickle {module}.{name} from session cache")
+
+
+def _site_db_name(site: str) -> str | None:
+	"""Sessions are cached under "{db_name}|session" — db_name comes from the
+	site's site_config.json (filesystem only, never changes for a site)."""
+	if site not in _site_db_names:
+		db_name = None
+		config_path = find_bench_root() / "sites" / site / "site_config.json"
+		try:
+			db_name = json.loads(config_path.read_text()).get("db_name")
+		except (OSError, json.JSONDecodeError):
+			pass
+		_site_db_names[site] = db_name
+	return _site_db_names[site]
+
+
+def _session_comfortably_fresh(session_data: dict) -> bool:
+	"""Would this session be unexpired under ANY timezone interpretation of
+	last_updated? Mirrors Session.get_session_data_from_cache validation,
+	minus the site-timezone knowledge we don't have (see TZ_SLACK_SECONDS)."""
+	if session_data.get("session_end"):
+		# bounded sessions are rare — let the web server judge them
+		return False
+	last_updated = session_data.get("last_updated")
+	expiry = session_data.get("session_expiry")
+	if not last_updated or not expiry:
+		return False
+	try:
+		last = datetime.datetime.fromisoformat(str(last_updated))
+		parts = [int(p) for p in str(expiry).split(":")]
+		expiry_seconds = parts[0] * 3600 + parts[1] * 60 + (parts[2] if len(parts) > 2 else 0)
+	except ValueError:
+		return False
+	age = (datetime.datetime.now() - last).total_seconds()
+	return age + TZ_SLACK_SECONDS < expiry_seconds
+
+
+def _cached_installed_apps(site: str) -> list[str] | None:
+	entry = _installed_apps_cache.get(site)
+	if entry and time.monotonic() - entry[1] < INSTALLED_APPS_TTL:
+		return entry[0]
+	return None
+
+
+def _remember_installed_apps(site: str, apps: list[str]):
+	_installed_apps_cache[site] = (apps, time.monotonic())
+
+
+def _resolve_session_fast(site: str, sid: str) -> dict | None:
+	"""sid → user info straight from the redis session cache. Returns the
+	get_user_info shape, or None to fall back to the HTTP callback.
+
+	installed_apps lives only in the site DB, so the fast path requires a
+	cached value from an earlier HTTP callback — the first connect per site
+	(per process) always goes over HTTP and primes it.
+	"""
+	apps = _cached_installed_apps(site)
+	if apps is None:
+		return None
+	db_name = _site_db_name(site)
+	if not db_name:
+		return None
+
+	conf = bench_conf()
+	client = redis.Redis.from_url(conf.get("redis_cache") or "redis://127.0.0.1:13000")
+	try:
+		raw = client.hget(f"{db_name}|session", sid)
+	except redis.RedisError:
+		return None
+	finally:
+		client.close()
+	if not raw:
+		return None
+
+	try:
+		data = _SessionUnpickler(io.BytesIO(raw)).load()
+	except Exception:
+		return None
+
+	session_data = data.get("data") or {}
+	if not _session_comfortably_fresh(session_data):
+		return None
+	user, user_type = session_data.get("user"), session_data.get("user_type")
+	if not user or not user_type:
+		return None
+	return {"user": user, "user_type": user_type, "installed_apps": apps}
+
+
+# --- HTTP callback path ---------------------------------------------------------
 def _get_socket_secret() -> str | None:
 	"""The shared secret get_user_info requires — generated and stored in
 	redis_queue by the web worker (frappe.realtime.get_socketio_secret)."""
@@ -133,7 +261,13 @@ async def authenticate(environ: dict, namespace: str) -> tuple[bool, dict | str]
 		return False, "No authentication method used. Use cookie or authorization header."
 
 	base_url = _base_url(environ, conf)
-	user_info = await _get_user_info(base_url, sid, authorization_header)
+	user_info = None
+	if sid:
+		user_info = await asyncio.to_thread(_resolve_session_fast, site, sid)
+	if user_info is None:
+		user_info = await _get_user_info(base_url, sid, authorization_header)
+		if user_info.get("user"):
+			_remember_installed_apps(site, user_info.get("installed_apps") or [])
 	if not user_info.get("user"):
 		return False, "Unauthorized: could not resolve session"
 

--- a/frappe/socketio_server/handlers.py
+++ b/frappe/socketio_server/handlers.py
@@ -1,8 +1,7 @@
-"""Per-namespace event handlers — port of apps/frappe/realtime/handlers.js.
+"""Event handlers — port of apps/frappe/realtime/handlers.js.
 
-python-socketio registers handlers per *namespace* (one per site), not per
-socket like the Node implementation, so per-connection state (user, open
-docs, credentials) lives in the socket session saved at connect time.
+Handlers are registered per namespace (one per site), not per socket like
+Node, so per-connection state lives in the socket session.
 """
 
 import importlib
@@ -47,10 +46,7 @@ def _task_room(task_id):
 
 
 def register_frappe_handlers(sio, namespace: str):
-	"""Attach all Frappe event handlers to a dynamically-created namespace.
-
-	Called once per site, the first time a client connects to /{site}.
-	"""
+	"""Attach all Frappe event handlers to a namespace (once per site)."""
 
 	@sio.on("connect", namespace=namespace)
 	async def _connect(sid, environ, auth=None):
@@ -127,23 +123,15 @@ def register_frappe_handlers(sio, namespace: str):
 
 	@sio.on("disconnect", namespace=namespace)
 	async def _disconnect(sid, reason=None):
-		# The socket is still in its rooms here (removed after this handler
-		# runs) — exclude it explicitly to mirror the Node implementation,
-		# where "disconnect" fires after rooms are left.
+		# the socket is still in its rooms here — exclude it explicitly
 		ctx = await sio.get_session(sid, namespace=namespace)
 		for doctype, docname in ctx.get("open_docs", []):
 			await _notify_viewers(sio, namespace, doctype, docname, current_user=ctx["user"], exclude_sid=sid)
 
 
 def _register_app_handlers(sio, namespace: str, installed_apps: list[str]):
-	"""Per-app realtime handlers, discovered by import instead of the Node
-	implementation's filesystem walk over apps/{app}/realtime/handlers.js.
-
-	An app opts in by shipping a `{app}.realtime_handlers` module with a
-	`register(sio, namespace)` callable. Unlike the Node version it is invoked
-	once per namespace (site), not once per socket — per-connection state
-	belongs in the socket session.
-	"""
+	"""Register handlers from apps that ship a `{app}.realtime_handlers`
+	module with a `register(sio, namespace)` callable — once per namespace."""
 	for app in installed_apps:
 		if app == "frappe" or (app, namespace) in _registered_apps:
 			continue
@@ -167,7 +155,7 @@ async def _publish_to_redis(channel: str, data):
 
 
 async def _notify_viewers(sio, namespace, doctype, docname, current_user, exclude_sid=None):
-	"""Tell everyone with this document open who is currently viewing it."""
+	"""Tell everyone with this document open who is viewing it."""
 	room = _open_doc_room(doctype, docname)
 	users = []
 	for member_sid, _ in sio.manager.get_participants(namespace, room):

--- a/frappe/socketio_server/handlers.py
+++ b/frappe/socketio_server/handlers.py
@@ -1,16 +1,29 @@
-"""
-PROTOTYPE: port of apps/frappe/realtime/handlers.js to python-socketio.
+"""Per-namespace event handlers — port of apps/frappe/realtime/handlers.js.
 
-In a real impl `_check_permission` is a direct frappe.has_permission call —
-but that needs a properly-bound site/session context which we don't have in
-this prototype's async path (see auth.py). For now permission checks are
-permissive when FRAPPE_SOCKETIO_DEBUG_SKIP_AUTH=1.
+python-socketio registers handlers per *namespace* (one per site), not per
+socket like the Node implementation, so per-connection state (user, open
+docs, credentials) lives in the socket session saved at connect time.
 """
 
-import os
+import importlib
+import importlib.util
+import json
+import logging
+
+import redis.asyncio as aioredis
+import socketio
+
+from frappe.socketio_server import redis_url
+from frappe.socketio_server.auth import authenticate, check_permission
+
+logger = logging.getLogger("frappe.socketio")
 
 WEBSITE_ROOM = "website"
 SITE_ROOM = "all"
+
+# (app, namespace) pairs whose realtime handlers are already registered
+_registered_apps: set[tuple[str, str]] = set()
+_redis_publisher: aioredis.Redis | None = None
 
 
 def _doc_room(doctype, docname):
@@ -40,18 +53,18 @@ def register_frappe_handlers(sio, namespace: str):
 	"""
 
 	@sio.on("connect", namespace=namespace)
-	async def _connect(sid, environ, auth):
-		# Auth + room setup is driven from server.on_site_connect; this is
-		# just here so the namespace exists. server.py calls authenticate()
-		# then enters the per-user rooms below via _post_auth_join.
-		from frappe.socketio_server.server import on_site_connect
+	async def _connect(sid, environ, auth=None):
+		ok, ctx = await authenticate(environ, namespace)
+		if not ok:
+			raise socketio.exceptions.ConnectionRefusedError(ctx)  # ctx is the error message
 
-		await on_site_connect(sid, environ, auth, namespace)
-		session = await sio.get_session(sid, namespace=namespace)
-		await sio.enter_room(sid, _user_room(session["user"]), namespace=namespace)
+		await sio.save_session(sid, ctx, namespace=namespace)
+		await sio.enter_room(sid, _user_room(ctx["user"]), namespace=namespace)
 		await sio.enter_room(sid, WEBSITE_ROOM, namespace=namespace)
-		if session.get("user_type") == "System User":
+		if ctx.get("user_type") == "System User":
 			await sio.enter_room(sid, SITE_ROOM, namespace=namespace)
+
+		_register_app_handlers(sio, namespace, ctx["installed_apps"])
 
 	@sio.on("ping", namespace=namespace)
 	async def _ping(sid):
@@ -59,7 +72,8 @@ def register_frappe_handlers(sio, namespace: str):
 
 	@sio.on("doctype_subscribe", namespace=namespace)
 	async def _doctype_subscribe(sid, doctype):
-		if await _check_permission(sid, namespace, doctype):
+		ctx = await sio.get_session(sid, namespace=namespace)
+		if await check_permission(ctx, doctype):
 			await sio.enter_room(sid, _doctype_room(doctype), namespace=namespace)
 
 	@sio.on("doctype_unsubscribe", namespace=namespace)
@@ -80,7 +94,8 @@ def register_frappe_handlers(sio, namespace: str):
 
 	@sio.on("doc_subscribe", namespace=namespace)
 	async def _doc_subscribe(sid, doctype, docname):
-		if await _check_permission(sid, namespace, doctype, docname):
+		ctx = await sio.get_session(sid, namespace=namespace)
+		if await check_permission(ctx, doctype, docname):
 			await sio.enter_room(sid, _doc_room(doctype, docname), namespace=namespace)
 
 	@sio.on("doc_unsubscribe", namespace=namespace)
@@ -89,56 +104,85 @@ def register_frappe_handlers(sio, namespace: str):
 
 	@sio.on("doc_open", namespace=namespace)
 	async def _doc_open(sid, doctype, docname):
-		if not await _check_permission(sid, namespace, doctype, docname):
+		ctx = await sio.get_session(sid, namespace=namespace)
+		if not await check_permission(ctx, doctype, docname):
 			return
-		room = _open_doc_room(doctype, docname)
-		await sio.enter_room(sid, room, namespace=namespace)
-		session = await sio.get_session(sid, namespace=namespace)
-		session.setdefault("open_docs", []).append((doctype, docname))
-		await sio.save_session(sid, session, namespace=namespace)
-		await _notify_viewers(sio, namespace, doctype, docname)
+		await sio.enter_room(sid, _open_doc_room(doctype, docname), namespace=namespace)
+		ctx.setdefault("open_docs", []).append((doctype, docname))
+		await sio.save_session(sid, ctx, namespace=namespace)
+		await _notify_viewers(sio, namespace, doctype, docname, current_user=ctx["user"])
 
 	@sio.on("doc_close", namespace=namespace)
 	async def _doc_close(sid, doctype, docname):
-		room = _open_doc_room(doctype, docname)
-		await sio.leave_room(sid, room, namespace=namespace)
-		session = await sio.get_session(sid, namespace=namespace)
-		session["open_docs"] = [t for t in session.get("open_docs", []) if t != (doctype, docname)]
-		await sio.save_session(sid, session, namespace=namespace)
-		await _notify_viewers(sio, namespace, doctype, docname)
+		await sio.leave_room(sid, _open_doc_room(doctype, docname), namespace=namespace)
+		ctx = await sio.get_session(sid, namespace=namespace)
+		ctx["open_docs"] = [entry for entry in ctx.get("open_docs", []) if entry != (doctype, docname)]
+		await sio.save_session(sid, ctx, namespace=namespace)
+		await _notify_viewers(sio, namespace, doctype, docname, current_user=ctx["user"])
+
+	@sio.on("open_in_editor", namespace=namespace)
+	async def _open_in_editor(sid, data):
+		# Republish for the esbuild watcher ("open in editor" on build error)
+		await _publish_to_redis("open_in_editor", data)
 
 	@sio.on("disconnect", namespace=namespace)
-	async def _disconnect(sid):
-		session = await sio.get_session(sid, namespace=namespace)
-		for doctype, docname in session.get("open_docs", []):
-			await _notify_viewers(sio, namespace, doctype, docname, exclude_sid=sid)
+	async def _disconnect(sid, reason=None):
+		# The socket is still in its rooms here (removed after this handler
+		# runs) — exclude it explicitly to mirror the Node implementation,
+		# where "disconnect" fires after rooms are left.
+		ctx = await sio.get_session(sid, namespace=namespace)
+		for doctype, docname in ctx.get("open_docs", []):
+			await _notify_viewers(sio, namespace, doctype, docname, current_user=ctx["user"], exclude_sid=sid)
 
 
-# --- helpers ----------------------------------------------------------------
-async def _check_permission(sio, namespace, doctype, docname=None) -> bool:
-	"""TODO: route through a thread-pool wrapper of frappe.has_permission with
-	a properly-bound site/user context, or fall back to an HTTP callback like
-	the JS version. Permissive in debug-skip-auth mode for smoke testing."""
-	if os.environ.get("FRAPPE_SOCKETIO_DEBUG_SKIP_AUTH") == "1":
-		return True
-	return False
+def _register_app_handlers(sio, namespace: str, installed_apps: list[str]):
+	"""Per-app realtime handlers, discovered by import instead of the Node
+	implementation's filesystem walk over apps/{app}/realtime/handlers.js.
 
-
-async def _notify_viewers(sio, namespace, doctype, docname, exclude_sid=None):
-	room = _open_doc_room(doctype, docname)
-	members = sio.manager.get_participants(namespace, room)
-	users = []
-	for sid, _ in members:
-		if sid == exclude_sid:
+	An app opts in by shipping a `{app}.realtime_handlers` module with a
+	`register(sio, namespace)` callable. Unlike the Node version it is invoked
+	once per namespace (site), not once per socket — per-connection state
+	belongs in the socket session.
+	"""
+	for app in installed_apps:
+		if app == "frappe" or (app, namespace) in _registered_apps:
 			continue
-		session = await sio.get_session(sid, namespace=namespace)
+		_registered_apps.add((app, namespace))
+		try:
+			if importlib.util.find_spec(f"{app}.realtime_handlers") is None:
+				continue
+			module = importlib.import_module(f"{app}.realtime_handlers")
+			register = getattr(module, "register", None)
+			if register:
+				register(sio, namespace)
+		except Exception:
+			logger.warning("failed to setup realtime handlers from %s", app, exc_info=True)
+
+
+async def _publish_to_redis(channel: str, data):
+	global _redis_publisher
+	if _redis_publisher is None:
+		_redis_publisher = aioredis.from_url(redis_url())
+	await _redis_publisher.publish(channel, json.dumps(data))
+
+
+async def _notify_viewers(sio, namespace, doctype, docname, current_user, exclude_sid=None):
+	"""Tell everyone with this document open who is currently viewing it."""
+	room = _open_doc_room(doctype, docname)
+	users = []
+	for member_sid, _ in sio.manager.get_participants(namespace, room):
+		if member_sid == exclude_sid:
+			continue
+		session = await sio.get_session(member_sid, namespace=namespace)
 		users.append(session["user"])
-	users = sorted(set(users))
-	if len(users) <= 1:
+
+	# don't send update to self. meaningless.
+	if len(users) == 1 and users[0] == current_user:
 		return
+
 	await sio.emit(
 		"doc_viewers",
-		{"doctype": doctype, "docname": docname, "users": users},
+		{"doctype": doctype, "docname": docname, "users": sorted(set(users))},
 		room=room,
 		namespace=namespace,
 	)

--- a/frappe/socketio_server/handlers.py
+++ b/frappe/socketio_server/handlers.py
@@ -1,0 +1,144 @@
+"""
+PROTOTYPE: port of apps/frappe/realtime/handlers.js to python-socketio.
+
+In a real impl `_check_permission` is a direct frappe.has_permission call —
+but that needs a properly-bound site/session context which we don't have in
+this prototype's async path (see auth.py). For now permission checks are
+permissive when FRAPPE_SOCKETIO_DEBUG_SKIP_AUTH=1.
+"""
+
+import os
+
+WEBSITE_ROOM = "website"
+SITE_ROOM = "all"
+
+
+def _doc_room(doctype, docname):
+	return f"doc:{doctype}/{docname}"
+
+
+def _open_doc_room(doctype, docname):
+	return f"open_doc:{doctype}/{docname}"
+
+
+def _user_room(user):
+	return f"user:{user}"
+
+
+def _doctype_room(doctype):
+	return f"doctype:{doctype}"
+
+
+def _task_room(task_id):
+	return f"task_progress:{task_id}"
+
+
+def register_frappe_handlers(sio, namespace: str):
+	"""Attach all Frappe event handlers to a dynamically-created namespace.
+
+	Called once per site, the first time a client connects to /{site}.
+	"""
+
+	@sio.on("connect", namespace=namespace)
+	async def _connect(sid, environ, auth):
+		# Auth + room setup is driven from server.on_site_connect; this is
+		# just here so the namespace exists. server.py calls authenticate()
+		# then enters the per-user rooms below via _post_auth_join.
+		from frappe.socketio_server.server import on_site_connect
+
+		await on_site_connect(sid, environ, auth, namespace)
+		session = await sio.get_session(sid, namespace=namespace)
+		await sio.enter_room(sid, _user_room(session["user"]), namespace=namespace)
+		await sio.enter_room(sid, WEBSITE_ROOM, namespace=namespace)
+		if session.get("user_type") == "System User":
+			await sio.enter_room(sid, SITE_ROOM, namespace=namespace)
+
+	@sio.on("ping", namespace=namespace)
+	async def _ping(sid):
+		await sio.emit("pong", to=sid, namespace=namespace)
+
+	@sio.on("doctype_subscribe", namespace=namespace)
+	async def _doctype_subscribe(sid, doctype):
+		if await _check_permission(sid, namespace, doctype):
+			await sio.enter_room(sid, _doctype_room(doctype), namespace=namespace)
+
+	@sio.on("doctype_unsubscribe", namespace=namespace)
+	async def _doctype_unsubscribe(sid, doctype):
+		await sio.leave_room(sid, _doctype_room(doctype), namespace=namespace)
+
+	@sio.on("task_subscribe", namespace=namespace)
+	async def _task_subscribe(sid, task_id):
+		await sio.enter_room(sid, _task_room(task_id), namespace=namespace)
+
+	@sio.on("task_unsubscribe", namespace=namespace)
+	async def _task_unsubscribe(sid, task_id):
+		await sio.leave_room(sid, _task_room(task_id), namespace=namespace)
+
+	@sio.on("progress_subscribe", namespace=namespace)
+	async def _progress_subscribe(sid, task_id):
+		await sio.enter_room(sid, _task_room(task_id), namespace=namespace)
+
+	@sio.on("doc_subscribe", namespace=namespace)
+	async def _doc_subscribe(sid, doctype, docname):
+		if await _check_permission(sid, namespace, doctype, docname):
+			await sio.enter_room(sid, _doc_room(doctype, docname), namespace=namespace)
+
+	@sio.on("doc_unsubscribe", namespace=namespace)
+	async def _doc_unsubscribe(sid, doctype, docname):
+		await sio.leave_room(sid, _doc_room(doctype, docname), namespace=namespace)
+
+	@sio.on("doc_open", namespace=namespace)
+	async def _doc_open(sid, doctype, docname):
+		if not await _check_permission(sid, namespace, doctype, docname):
+			return
+		room = _open_doc_room(doctype, docname)
+		await sio.enter_room(sid, room, namespace=namespace)
+		session = await sio.get_session(sid, namespace=namespace)
+		session.setdefault("open_docs", []).append((doctype, docname))
+		await sio.save_session(sid, session, namespace=namespace)
+		await _notify_viewers(sio, namespace, doctype, docname)
+
+	@sio.on("doc_close", namespace=namespace)
+	async def _doc_close(sid, doctype, docname):
+		room = _open_doc_room(doctype, docname)
+		await sio.leave_room(sid, room, namespace=namespace)
+		session = await sio.get_session(sid, namespace=namespace)
+		session["open_docs"] = [t for t in session.get("open_docs", []) if t != (doctype, docname)]
+		await sio.save_session(sid, session, namespace=namespace)
+		await _notify_viewers(sio, namespace, doctype, docname)
+
+	@sio.on("disconnect", namespace=namespace)
+	async def _disconnect(sid):
+		session = await sio.get_session(sid, namespace=namespace)
+		for doctype, docname in session.get("open_docs", []):
+			await _notify_viewers(sio, namespace, doctype, docname, exclude_sid=sid)
+
+
+# --- helpers ----------------------------------------------------------------
+async def _check_permission(sio, namespace, doctype, docname=None) -> bool:
+	"""TODO: route through a thread-pool wrapper of frappe.has_permission with
+	a properly-bound site/user context, or fall back to an HTTP callback like
+	the JS version. Permissive in debug-skip-auth mode for smoke testing."""
+	if os.environ.get("FRAPPE_SOCKETIO_DEBUG_SKIP_AUTH") == "1":
+		return True
+	return False
+
+
+async def _notify_viewers(sio, namespace, doctype, docname, exclude_sid=None):
+	room = _open_doc_room(doctype, docname)
+	members = sio.manager.get_participants(namespace, room)
+	users = []
+	for sid, _ in members:
+		if sid == exclude_sid:
+			continue
+		session = await sio.get_session(sid, namespace=namespace)
+		users.append(session["user"])
+	users = sorted(set(users))
+	if len(users) <= 1:
+		return
+	await sio.emit(
+		"doc_viewers",
+		{"doctype": doctype, "docname": docname, "users": users},
+		room=room,
+		namespace=namespace,
+	)

--- a/frappe/socketio_server/server.py
+++ b/frappe/socketio_server/server.py
@@ -1,0 +1,135 @@
+"""
+PROTOTYPE: python-socketio replacement for apps/frappe/socketio.js
+
+Run with:
+    uvicorn frappe.socketio_server.server:asgi_app --host 0.0.0.0 --port 9000
+
+Wire-compat with the existing socket.io-client browser library: the JS
+frontend connects to `io(origin + "/" + site)` and that keeps working
+because we accept any namespace dynamically (see DynamicServer below).
+"""
+
+import asyncio
+import json
+
+import redis.asyncio as aioredis
+import socketio
+
+from frappe.socketio_server import bench_conf
+from frappe.socketio_server.auth import authenticate
+from frappe.socketio_server.handlers import register_frappe_handlers
+
+
+# --- Dynamic namespace support ----------------------------------------------
+# python-socketio has no native equivalent of socket.io's `io.of(/regex/)`.
+# We subclass AsyncServer to auto-register a namespace the first time a
+# client tries to connect to it. Authentication still rejects unknown sites.
+class DynamicServer(socketio.AsyncServer):
+	async def _handle_connect(self, eio_sid, namespace, data):
+		# python-socketio tracks function-style handlers in self.handlers and
+		# class-style ones in self.namespace_handlers. Check both.
+		known = namespace in self.handlers or namespace in self.namespace_handlers
+		if not known and namespace != "/":
+			register_frappe_handlers(self, namespace)
+		return await super()._handle_connect(eio_sid, namespace, data)
+
+
+# --- Server setup -----------------------------------------------------------
+conf = bench_conf()
+redis_url = conf.get("redis_queue") or "redis://127.0.0.1:11311"
+
+sio = DynamicServer(
+	async_mode="asgi",
+	cors_allowed_origins="*",  # mirrored to request origin by CORSReflectMiddleware below
+	cors_credentials=True,
+	client_manager=socketio.AsyncRedisManager(redis_url),
+)
+
+
+@sio.event
+async def connect(sid, environ, auth):
+	"""Default-namespace connect — used only for health checks; real
+	traffic lands on per-site namespaces handled by register_frappe_handlers."""
+	return True
+
+
+# Register an on_connect for *every* dynamically-attached namespace.
+# This is what DynamicServer wires up on first connect to a site.
+async def on_site_connect(sid, environ, auth, namespace):
+	ok, ctx = await authenticate(environ, namespace)
+	if not ok:
+		raise socketio.exceptions.ConnectionRefusedError(ctx)  # ctx is err msg
+
+	await sio.save_session(sid, ctx, namespace=namespace)
+	# Per-app handler discovery via hooks instead of filesystem walk.
+	# Each app declares `realtime_handlers = "myapp.realtime.handlers.setup"`
+	# in its hooks.py; we call them with (sio, sid, namespace, session).
+	# Per-app handler discovery via hooks (frappe.get_hooks) — disabled
+	# in this prototype because it requires a full frappe.init() per
+	# connect. The base frappe handlers in handlers.py cover the common
+	# rooms. Real impl: cache hook lookups at server startup keyed by site.
+
+
+# --- Redis pub/sub fan-out --------------------------------------------------
+async def consume_events():
+	"""Bridge Python publishers (frappe.realtime.emit_via_redis) into socket.io."""
+	r = aioredis.from_url(redis_url, decode_responses=True)
+	pubsub = r.pubsub()
+	await pubsub.subscribe("events")
+	async for msg in pubsub.listen():
+		if msg["type"] != "message":
+			continue
+		try:
+			payload = json.loads(msg["data"])
+		except json.JSONDecodeError:
+			continue
+		namespace = "/" + payload["namespace"]
+		if payload.get("room"):
+			await sio.emit(
+				payload["event"],
+				payload["message"],
+				room=payload["room"],
+				namespace=namespace,
+			)
+		else:
+			# Site-less broadcast (e.g. esbuild "build" event).
+			await sio.emit(payload["event"], payload["message"])
+
+
+# --- ASGI entrypoint --------------------------------------------------------
+class CORSReflectMiddleware:
+	"""Reflect the request Origin header into Access-Control-Allow-Origin,
+	matching the Node socket.io `cors: { origin: true, credentials: true }`
+	behaviour. Required because browsers reject `*` with credentials."""
+
+	def __init__(self, app):
+		self.app = app
+
+	async def __call__(self, scope, receive, send):
+		if scope["type"] not in ("http", "websocket"):
+			return await self.app(scope, receive, send)
+
+		origin = b""
+		for k, v in scope.get("headers", []):
+			if k == b"origin":
+				origin = v
+				break
+
+		async def send_wrapper(message):
+			if message["type"] == "http.response.start" and origin:
+				headers = [
+					(k, v)
+					for k, v in message.get("headers", [])
+					if k.lower() not in (b"access-control-allow-origin", b"access-control-allow-credentials")
+				]
+				headers.append((b"access-control-allow-origin", origin))
+				headers.append((b"access-control-allow-credentials", b"true"))
+				message["headers"] = headers
+			await send(message)
+
+		await self.app(scope, receive, send_wrapper)
+
+
+asgi_app = CORSReflectMiddleware(
+	socketio.ASGIApp(sio, on_startup=lambda: asyncio.create_task(consume_events()))
+)

--- a/frappe/socketio_server/server.py
+++ b/frappe/socketio_server/server.py
@@ -1,30 +1,33 @@
-"""
-PROTOTYPE: python-socketio replacement for apps/frappe/socketio.js
+"""python-socketio replacement for apps/frappe/socketio.js.
 
-Run with:
-    uvicorn frappe.socketio_server.server:asgi_app --host 0.0.0.0 --port 9000
+Run with::
 
-Wire-compat with the existing socket.io-client browser library: the JS
-frontend connects to `io(origin + "/" + site)` and that keeps working
-because we accept any namespace dynamically (see DynamicServer below).
+	python -m frappe.socketio_server
+
+Wire-compatible with the socket.io-client browser library: the JS frontend
+connects to `io(origin + "/" + site)` and that keeps working because we
+accept any namespace dynamically (see DynamicServer below).
 """
 
 import asyncio
 import json
+import logging
 
 import redis.asyncio as aioredis
 import socketio
 
-from frappe.socketio_server import bench_conf
-from frappe.socketio_server.auth import authenticate
+from frappe.socketio_server import redis_url
 from frappe.socketio_server.handlers import register_frappe_handlers
 
+logger = logging.getLogger("frappe.socketio")
 
-# --- Dynamic namespace support ----------------------------------------------
-# python-socketio has no native equivalent of socket.io's `io.of(/regex/)`.
-# We subclass AsyncServer to auto-register a namespace the first time a
-# client tries to connect to it. Authentication still rejects unknown sites.
+
 class DynamicServer(socketio.AsyncServer):
+	"""python-socketio has no native equivalent of socket.io's `io.of(/regex/)`
+	multitenant namespaces — auto-register handlers for a namespace the first
+	time a client tries to connect to it. authenticate() still rejects
+	namespaces that don't match a valid site."""
+
 	async def _handle_connect(self, eio_sid, namespace, data):
 		# python-socketio tracks function-style handlers in self.handlers and
 		# class-style ones in self.namespace_handlers. Check both.
@@ -33,70 +36,63 @@ class DynamicServer(socketio.AsyncServer):
 			register_frappe_handlers(self, namespace)
 		return await super()._handle_connect(eio_sid, namespace, data)
 
+	def site_namespaces(self) -> set[str]:
+		return (set(self.handlers) | set(self.namespace_handlers)) - {"/"}
 
-# --- Server setup -----------------------------------------------------------
-conf = bench_conf()
-redis_url = conf.get("redis_queue") or "redis://127.0.0.1:11311"
 
 sio = DynamicServer(
 	async_mode="asgi",
 	cors_allowed_origins="*",  # mirrored to request origin by CORSReflectMiddleware below
 	cors_credentials=True,
-	client_manager=socketio.AsyncRedisManager(redis_url),
+	client_manager=socketio.AsyncRedisManager(redis_url()),
 )
 
 
 @sio.event
-async def connect(sid, environ, auth):
-	"""Default-namespace connect — used only for health checks; real
-	traffic lands on per-site namespaces handled by register_frappe_handlers."""
+async def connect(sid, environ, auth=None):
+	"""Default-namespace connect — used only for health checks; real traffic
+	lands on per-site namespaces handled by register_frappe_handlers."""
 	return True
 
 
-# Register an on_connect for *every* dynamically-attached namespace.
-# This is what DynamicServer wires up on first connect to a site.
-async def on_site_connect(sid, environ, auth, namespace):
-	ok, ctx = await authenticate(environ, namespace)
-	if not ok:
-		raise socketio.exceptions.ConnectionRefusedError(ctx)  # ctx is err msg
-
-	await sio.save_session(sid, ctx, namespace=namespace)
-	# Per-app handler discovery via hooks instead of filesystem walk.
-	# Each app declares `realtime_handlers = "myapp.realtime.handlers.setup"`
-	# in its hooks.py; we call them with (sio, sid, namespace, session).
-	# Per-app handler discovery via hooks (frappe.get_hooks) — disabled
-	# in this prototype because it requires a full frappe.init() per
-	# connect. The base frappe handlers in handlers.py cover the common
-	# rooms. Real impl: cache hook lookups at server startup keyed by site.
-
-
-# --- Redis pub/sub fan-out --------------------------------------------------
+# --- Redis pub/sub fan-out ---------------------------------------------------
 async def consume_events():
-	"""Bridge Python publishers (frappe.realtime.emit_via_redis) into socket.io."""
-	r = aioredis.from_url(redis_url, decode_responses=True)
-	pubsub = r.pubsub()
-	await pubsub.subscribe("events")
-	async for msg in pubsub.listen():
-		if msg["type"] != "message":
-			continue
+	"""Bridge Python publishers (frappe.realtime.emit_via_redis) into
+	socket.io. Reconnects with backoff if redis drops."""
+	delay = 1
+	while True:
 		try:
-			payload = json.loads(msg["data"])
-		except json.JSONDecodeError:
-			continue
-		namespace = "/" + payload["namespace"]
-		if payload.get("room"):
-			await sio.emit(
-				payload["event"],
-				payload["message"],
-				room=payload["room"],
-				namespace=namespace,
-			)
-		else:
-			# Site-less broadcast (e.g. esbuild "build" event).
-			await sio.emit(payload["event"], payload["message"])
+			client = aioredis.from_url(redis_url(), decode_responses=True)
+			pubsub = client.pubsub()
+			await pubsub.subscribe("events")
+			delay = 1
+			async for msg in pubsub.listen():
+				if msg["type"] != "message":
+					continue
+				try:
+					payload = json.loads(msg["data"])
+					await _dispatch(payload)
+				except Exception:
+					logger.warning("failed to dispatch realtime event: %r", msg["data"], exc_info=True)
+		except (aioredis.RedisError, OSError):
+			logger.warning("events subscriber lost redis, retrying in %ss", delay, exc_info=True)
+			await asyncio.sleep(delay)
+			delay = min(delay * 2, 30)
 
 
-# --- ASGI entrypoint --------------------------------------------------------
+async def _dispatch(payload: dict):
+	event, message = payload["event"], payload.get("message")
+	if payload.get("room"):
+		await sio.emit(event, message, room=payload["room"], namespace="/" + payload["namespace"])
+	else:
+		# Site-less broadcast (e.g. esbuild "build" event in dev). The Node
+		# implementation emits on the catch-all namespace, which reaches every
+		# connected client — emit on every registered site namespace.
+		for namespace in sio.site_namespaces():
+			await sio.emit(event, message, namespace=namespace)
+
+
+# --- ASGI entrypoint ----------------------------------------------------------
 class CORSReflectMiddleware:
 	"""Reflect the request Origin header into Access-Control-Allow-Origin,
 	matching the Node socket.io `cors: { origin: true, credentials: true }`
@@ -130,6 +126,12 @@ class CORSReflectMiddleware:
 		await self.app(scope, receive, send_wrapper)
 
 
-asgi_app = CORSReflectMiddleware(
-	socketio.ASGIApp(sio, on_startup=lambda: asyncio.create_task(consume_events()))
-)
+_consumer_task = None
+
+
+async def _start_event_consumer():
+	global _consumer_task
+	_consumer_task = asyncio.create_task(consume_events())
+
+
+asgi_app = CORSReflectMiddleware(socketio.ASGIApp(sio, on_startup=_start_event_consumer))

--- a/frappe/socketio_server/server.py
+++ b/frappe/socketio_server/server.py
@@ -1,12 +1,6 @@
 """python-socketio replacement for apps/frappe/socketio.js.
 
-Run with::
-
-	python -m frappe.socketio_server
-
-Wire-compatible with the socket.io-client browser library: the JS frontend
-connects to `io(origin + "/" + site)` and that keeps working because we
-accept any namespace dynamically (see DynamicServer below).
+Run with: python -m frappe.socketio_server
 """
 
 import asyncio
@@ -23,14 +17,11 @@ logger = logging.getLogger("frappe.socketio")
 
 
 class DynamicServer(socketio.AsyncServer):
-	"""python-socketio has no native equivalent of socket.io's `io.of(/regex/)`
-	multitenant namespaces — auto-register handlers for a namespace the first
-	time a client tries to connect to it. authenticate() still rejects
-	namespaces that don't match a valid site."""
+	"""python-socketio has no equivalent of socket.io's `io.of(/regex/)`
+	namespaces, so register handlers on first connect to a namespace.
+	authenticate() still rejects namespaces that don't match a valid site."""
 
 	async def _handle_connect(self, eio_sid, namespace, data):
-		# python-socketio tracks function-style handlers in self.handlers and
-		# class-style ones in self.namespace_handlers. Check both.
 		known = namespace in self.handlers or namespace in self.namespace_handlers
 		if not known and namespace != "/":
 			register_frappe_handlers(self, namespace)
@@ -50,15 +41,14 @@ sio = DynamicServer(
 
 @sio.event
 async def connect(sid, environ, auth=None):
-	"""Default-namespace connect — used only for health checks; real traffic
-	lands on per-site namespaces handled by register_frappe_handlers."""
+	"""Default-namespace connect — only used for health checks."""
 	return True
 
 
 # --- Redis pub/sub fan-out ---------------------------------------------------
 async def consume_events():
-	"""Bridge Python publishers (frappe.realtime.emit_via_redis) into
-	socket.io. Reconnects with backoff if redis drops."""
+	"""Bridge frappe.realtime.emit_via_redis publishes into socket.io.
+	Reconnects with backoff if redis drops."""
 	delay = 1
 	while True:
 		try:
@@ -85,18 +75,15 @@ async def _dispatch(payload: dict):
 	if payload.get("room"):
 		await sio.emit(event, message, room=payload["room"], namespace="/" + payload["namespace"])
 	else:
-		# Site-less broadcast (e.g. esbuild "build" event in dev). The Node
-		# implementation emits on the catch-all namespace, which reaches every
-		# connected client — emit on every registered site namespace.
+		# site-less broadcast (e.g. esbuild build event) goes to every namespace
 		for namespace in sio.site_namespaces():
 			await sio.emit(event, message, namespace=namespace)
 
 
 # --- ASGI entrypoint ----------------------------------------------------------
 class CORSReflectMiddleware:
-	"""Reflect the request Origin header into Access-Control-Allow-Origin,
-	matching the Node socket.io `cors: { origin: true, credentials: true }`
-	behaviour. Required because browsers reject `*` with credentials."""
+	"""Reflect the request Origin into Access-Control-Allow-Origin —
+	browsers reject `*` with credentials."""
 
 	def __init__(self, app):
 		self.app = app

--- a/frappe/tests/test_socketio_server.py
+++ b/frappe/tests/test_socketio_server.py
@@ -1,0 +1,381 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+"""Tests for the python-socketio realtime server (frappe/socketio_server).
+
+The integration tests boot the actual ASGI server on a free port (uvicorn in
+a background thread) and talk to it with the python socket.io client over
+real TCP, with the HTTP auth callback to the Frappe web server mocked out.
+They need a reachable redis_queue and are skipped if there is none.
+"""
+
+import asyncio
+import json
+import os
+import socket
+import threading
+import unittest
+from unittest import mock
+
+import redis
+
+from frappe.socketio_server import bench_conf, redis_url
+from frappe.socketio_server.auth import (
+	_base_url,
+	_hostname,
+	_site_from_environ,
+	authenticate,
+	check_permission,
+)
+from frappe.tests import IntegrationTestCase, UnitTestCase
+
+TEST_SITE = "sio-test-site"
+TEST_USER = "socket@example.com"
+VALID_SID = "valid-test-sid"
+AUTH_CALLBACK_PATH = "frappe.socketio_server.auth._frappe_request"
+
+USER_INFO = {
+	"user": TEST_USER,
+	"user_type": "System User",
+	"installed_apps": ["frappe"],
+}
+
+
+def fake_frappe_request(base_url, path, *, sid=None, authorization_header=None, params=None):
+	"""Stand-in for the HTTP callback to the Frappe web server."""
+	if path.endswith("get_user_info"):
+		if sid == VALID_SID or authorization_header:
+			return {"message": USER_INFO}
+		return {}
+	if path.endswith("has_permission"):
+		return {"message": params.get("doctype") != "Forbidden DocType"}
+	return {}
+
+
+def redis_available() -> bool:
+	try:
+		client = redis.Redis.from_url(redis_url())
+		client.ping()
+		client.close()
+		return True
+	except redis.RedisError:
+		return False
+
+
+class TestBenchConf(UnitTestCase):
+	def test_defaults_and_env_overrides(self):
+		conf = bench_conf()
+		self.assertIn("socketio_port", conf)
+		self.assertIn("socketio_python_port", conf)
+
+		with mock.patch.dict(os.environ, {"FRAPPE_SOCKETIO_PORT": "9999", "FRAPPE_SITE": "envsite"}):
+			conf = bench_conf()
+			self.assertEqual(conf["socketio_python_port"], "9999")
+			self.assertEqual(conf["default_site"], "envsite")
+
+
+class TestAuthHelpers(UnitTestCase):
+	def test_hostname(self):
+		self.assertIsNone(_hostname(None))
+		self.assertEqual(_hostname("mysite.localhost:8000"), "mysite.localhost")
+		self.assertEqual(_hostname("https://mysite.com:443"), "mysite.com")
+		self.assertEqual(_hostname("mysite.com"), "mysite.com")
+
+	def test_site_from_environ(self):
+		conf = {"default_site": "defsite.localhost"}
+		# explicit header wins
+		environ = {"HTTP_X_FRAPPE_SITE_NAME": "explicit.localhost:8000"}
+		self.assertEqual(_site_from_environ(environ, conf), "explicit.localhost")
+		# localhost host falls back to default_site
+		environ = {"HTTP_HOST": "localhost:8000"}
+		self.assertEqual(_site_from_environ(environ, conf), "defsite.localhost")
+		# otherwise origin, then host
+		environ = {"HTTP_HOST": "a.com:8000", "HTTP_ORIGIN": "http://b.com:8000"}
+		self.assertEqual(_site_from_environ(environ, conf), "b.com")
+		environ = {"HTTP_HOST": "a.com:8000"}
+		self.assertEqual(_site_from_environ(environ, conf), "a.com")
+
+	def test_base_url(self):
+		environ = {"HTTP_ORIGIN": "http://mysite.localhost:8080"}
+		self.assertEqual(_base_url(environ, {}), "http://mysite.localhost:8080")
+		# developer_mode rewrites the port to the gunicorn worker's port
+		conf = {"developer_mode": 1, "webserver_port": 8000}
+		self.assertEqual(_base_url(environ, conf), "http://mysite.localhost:8000")
+		# no origin: fall back to host
+		environ = {"HTTP_HOST": "mysite.localhost:8000"}
+		self.assertEqual(_base_url(environ, {}), "http://mysite.localhost:8000")
+
+
+class TestAuthenticate(UnitTestCase):
+	"""authenticate() validation and session resolution, HTTP callback mocked."""
+
+	def _environ(self, **overrides):
+		environ = {
+			"HTTP_HOST": "mysite.localhost:8000",
+			"HTTP_ORIGIN": "http://mysite.localhost:8000",
+			"HTTP_COOKIE": f"sid={VALID_SID}",
+		}
+		environ.update(overrides)
+		return environ
+
+	def test_rejects_namespace_site_mismatch(self):
+		ok, error = asyncio.run(authenticate(self._environ(), "/othersite.localhost"))
+		self.assertFalse(ok)
+		self.assertIn("Invalid namespace", error)
+
+	def test_rejects_origin_host_mismatch(self):
+		environ = self._environ(HTTP_ORIGIN="http://evil.com:8000")
+		# origin determines the site, so pin it via the explicit header
+		environ["HTTP_X_FRAPPE_SITE_NAME"] = "mysite.localhost"
+		ok, error = asyncio.run(authenticate(environ, "/mysite.localhost"))
+		self.assertFalse(ok)
+		self.assertEqual(error, "Invalid origin")
+
+	def test_rejects_missing_credentials(self):
+		environ = self._environ()
+		del environ["HTTP_COOKIE"]
+		ok, error = asyncio.run(authenticate(environ, "/mysite.localhost"))
+		self.assertFalse(ok)
+		self.assertIn("Missing cookie", error)
+
+	def test_rejects_cookie_without_sid(self):
+		environ = self._environ(HTTP_COOKIE="other=value")
+		ok, error = asyncio.run(authenticate(environ, "/mysite.localhost"))
+		self.assertFalse(ok)
+		self.assertIn("No authentication method", error)
+
+	def test_rejects_unresolved_session(self):
+		with mock.patch(AUTH_CALLBACK_PATH, return_value={}):
+			ok, error = asyncio.run(authenticate(self._environ(), "/mysite.localhost"))
+		self.assertFalse(ok)
+		self.assertIn("Unauthorized", error)
+
+	def test_accepts_valid_session(self):
+		with mock.patch(AUTH_CALLBACK_PATH, return_value={"message": USER_INFO}) as callback:
+			ok, ctx = asyncio.run(authenticate(self._environ(), "/mysite.localhost"))
+		self.assertTrue(ok)
+		self.assertEqual(ctx["user"], TEST_USER)
+		self.assertEqual(ctx["user_type"], "System User")
+		self.assertEqual(ctx["installed_apps"], ["frappe"])
+		self.assertEqual(ctx["site"], "mysite.localhost")
+		self.assertEqual(ctx["sid"], VALID_SID)
+		callback.assert_called_once()
+
+	def test_retries_user_info_once_for_secret_bootstrap(self):
+		# first call returns {} (web worker just generated the shared secret),
+		# the retry succeeds — mirrors the Node implementation
+		with mock.patch(AUTH_CALLBACK_PATH, side_effect=[{}, {"message": USER_INFO}]) as callback:
+			ok, ctx = asyncio.run(authenticate(self._environ(), "/mysite.localhost"))
+		self.assertTrue(ok)
+		self.assertEqual(ctx["user"], TEST_USER)
+		self.assertEqual(callback.call_count, 2)
+
+	def test_check_permission(self):
+		ctx = {"base_url": "http://mysite.localhost:8000", "sid": VALID_SID}
+		with mock.patch(AUTH_CALLBACK_PATH, return_value={"message": True}):
+			self.assertTrue(asyncio.run(check_permission(ctx, "ToDo", "TODO-001")))
+		with mock.patch(AUTH_CALLBACK_PATH, return_value={}):
+			self.assertFalse(asyncio.run(check_permission(ctx, "ToDo", "TODO-001")))
+
+
+@unittest.skipUnless(redis_available(), "redis_queue not reachable")
+class TestSocketioServerIntegration(IntegrationTestCase):
+	"""End-to-end: real uvicorn server, real socket.io client, real redis."""
+
+	port: int
+	_patcher = None
+	_server = None
+	_thread = None
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		import uvicorn
+
+		from frappe.socketio_server.server import asgi_app
+
+		cls._patcher = mock.patch(AUTH_CALLBACK_PATH, new=fake_frappe_request)
+		cls._patcher.start()
+
+		with socket.socket() as sock:
+			sock.bind(("127.0.0.1", 0))
+			cls.port = sock.getsockname()[1]
+
+		config = uvicorn.Config(asgi_app, host="127.0.0.1", port=cls.port, lifespan="on", log_level="warning")
+		cls._server = uvicorn.Server(config)
+		cls._thread = threading.Thread(target=cls._server.run, daemon=True)
+		cls._thread.start()
+
+		for _ in range(100):
+			if cls._server.started:
+				break
+			threading.Event().wait(0.1)
+		else:
+			raise RuntimeError("uvicorn did not start within 10s")
+
+	@classmethod
+	def tearDownClass(cls):
+		cls._server.should_exit = True
+		cls._thread.join(timeout=10)
+		cls._patcher.stop()
+		super().tearDownClass()
+
+	@property
+	def namespace(self):
+		return f"/{TEST_SITE}"
+
+	async def _connect(self, cookie=f"sid={VALID_SID}"):
+		import socketio
+
+		client = socketio.AsyncClient(reconnection=False)
+		headers = {
+			"Origin": f"http://127.0.0.1:{self.port}",
+			"X-Frappe-Site-Name": TEST_SITE,
+		}
+		if cookie:
+			headers["Cookie"] = cookie
+		await client.connect(
+			f"http://127.0.0.1:{self.port}",
+			headers=headers,
+			namespaces=[self.namespace],
+			wait_timeout=10,
+		)
+		return client
+
+	async def _publish_until(self, payload: dict, received: asyncio.Event, attempts=40):
+		"""Publish to the `events` channel until the client sees it — absorbs
+		subscriber startup latency in consume_events and the redis manager."""
+		client = redis.Redis.from_url(redis_url())
+		try:
+			for _ in range(attempts):
+				client.publish("events", json.dumps(payload))
+				try:
+					await asyncio.wait_for(received.wait(), timeout=0.5)
+					return
+				except TimeoutError:
+					continue
+			raise AssertionError(f"event never reached the client: {payload}")
+		finally:
+			client.close()
+
+	def test_connect_and_ping(self):
+		async def scenario():
+			client = await self._connect()
+			try:
+				pong = asyncio.Event()
+				client.on("pong", lambda *args: pong.set(), namespace=self.namespace)
+				await client.emit("ping", namespace=self.namespace)
+				await asyncio.wait_for(pong.wait(), timeout=10)
+			finally:
+				await client.disconnect()
+
+		asyncio.run(scenario())
+
+	def test_rejects_unauthenticated_connection(self):
+		import socketio
+
+		async def scenario():
+			with self.assertRaises(socketio.exceptions.ConnectionError):
+				await self._connect(cookie=None)
+
+		asyncio.run(scenario())
+
+	def test_rejects_invalid_session(self):
+		import socketio
+
+		async def scenario():
+			with self.assertRaises(socketio.exceptions.ConnectionError):
+				await self._connect(cookie="sid=bogus-sid")
+
+		asyncio.run(scenario())
+
+	def test_user_room_event_roundtrip(self):
+		"""emit_via_redis-shaped publish reaches the user's auto-joined room."""
+
+		async def scenario():
+			client = await self._connect()
+			try:
+				received = asyncio.Event()
+				client.on("user_event", lambda data: received.set(), namespace=self.namespace)
+				await self._publish_until(
+					{
+						"event": "user_event",
+						"message": {"hello": "world"},
+						"room": f"user:{TEST_USER}",
+						"namespace": TEST_SITE,
+					},
+					received,
+				)
+			finally:
+				await client.disconnect()
+
+		asyncio.run(scenario())
+
+	def test_siteless_broadcast_reaches_namespaced_clients(self):
+		"""A publish without a room (e.g. esbuild build event) must reach
+		clients connected to site namespaces."""
+
+		async def scenario():
+			client = await self._connect()
+			try:
+				received = asyncio.Event()
+				client.on("build_event", lambda data: received.set(), namespace=self.namespace)
+				await self._publish_until(
+					{
+						"event": "build_event",
+						"message": {"changed": "app.js"},
+						"room": None,
+						"namespace": TEST_SITE,
+					},
+					received,
+				)
+			finally:
+				await client.disconnect()
+
+		asyncio.run(scenario())
+
+	def test_doctype_subscribe_respects_permissions(self):
+		async def scenario():
+			client = await self._connect()
+			try:
+				allowed = asyncio.Event()
+				forbidden = asyncio.Event()
+				client.on("allowed_event", lambda data: allowed.set(), namespace=self.namespace)
+				client.on("forbidden_event", lambda data: forbidden.set(), namespace=self.namespace)
+
+				await client.emit("doctype_subscribe", "ToDo", namespace=self.namespace)
+				await client.emit("doctype_subscribe", "Forbidden DocType", namespace=self.namespace)
+
+				# permitted doctype: event arrives
+				await self._publish_until(
+					{
+						"event": "allowed_event",
+						"message": {},
+						"room": "doctype:ToDo",
+						"namespace": TEST_SITE,
+					},
+					allowed,
+				)
+
+				# forbidden doctype: the join was denied, so the room is empty
+				publisher = redis.Redis.from_url(redis_url())
+				try:
+					for _ in range(5):
+						publisher.publish(
+							"events",
+							json.dumps(
+								{
+									"event": "forbidden_event",
+									"message": {},
+									"room": "doctype:Forbidden DocType",
+									"namespace": TEST_SITE,
+								}
+							),
+						)
+						await asyncio.sleep(0.2)
+				finally:
+					publisher.close()
+				self.assertFalse(forbidden.is_set())
+			finally:
+				await client.disconnect()
+
+		asyncio.run(scenario())

--- a/frappe/tests/test_socketio_server.py
+++ b/frappe/tests/test_socketio_server.py
@@ -2,10 +2,8 @@
 # License: MIT. See LICENSE
 """Tests for the python-socketio realtime server (frappe/socketio_server).
 
-The integration tests boot the actual ASGI server on a free port (uvicorn in
-a background thread) and talk to it with the python socket.io client over
-real TCP, with the HTTP auth callback to the Frappe web server mocked out.
-They need a reachable redis_queue and are skipped if there is none.
+Integration tests boot the real ASGI server and talk to it over TCP with
+the HTTP auth callback mocked; they skip without a reachable redis_queue.
 """
 
 import asyncio
@@ -182,8 +180,7 @@ class TestAuthenticate(UnitTestCase):
 
 
 class TestSessionFreshness(UnitTestCase):
-	"""_session_comfortably_fresh: only sessions valid under ANY timezone
-	interpretation may skip the canonical HTTP validation."""
+	"""Only sessions valid under any timezone interpretation skip HTTP."""
 
 	def _session(self, age_seconds=0, expiry="240:00:00", **extra):
 		last = datetime.datetime.now() - datetime.timedelta(seconds=age_seconds)
@@ -193,8 +190,7 @@ class TestSessionFreshness(UnitTestCase):
 		self.assertTrue(_session_comfortably_fresh(self._session()))
 
 	def test_session_inside_tz_slack_window_falls_back(self):
-		# 239h old with 240h expiry — valid locally, but not provably valid
-		# under every timezone interpretation
+		# 239h old with 240h expiry — valid locally but inside the slack window
 		self.assertFalse(_session_comfortably_fresh(self._session(age_seconds=239 * 3600)))
 
 	def test_clearly_expired_session_fails(self):
@@ -216,8 +212,7 @@ class TestSessionFreshness(UnitTestCase):
 
 @unittest.skipUnless(redis_available(), "redis_queue not reachable")
 class TestSessionCacheFastPath(IntegrationTestCase):
-	"""Fast path against the real redis session cache, in the exact format
-	frappe.sessions.Session writes (pickled frappe._dict via frappe.cache)."""
+	"""Fast path against the real redis session cache via frappe.cache."""
 
 	def setUp(self):
 		super().setUp()
@@ -281,8 +276,7 @@ class TestSessionCacheFastPath(IntegrationTestCase):
 		self.assertEqual(callback.call_count, 1)
 
 	def test_stale_session_falls_back_to_http(self):
-		# 20 days old with a 10-day expiry: expired everywhere — never
-		# rejected locally, always delegated to canonical validation
+		# expired sessions are delegated to the web server, never rejected locally
 		last = str(datetime.datetime.now() - datetime.timedelta(days=20))
 		self._put_session(last_updated=last)
 		sio_auth._remember_installed_apps(self.site, ["frappe"])
@@ -369,8 +363,7 @@ class TestSocketioServerIntegration(IntegrationTestCase):
 		return client
 
 	async def _publish_until(self, payload: dict, received: asyncio.Event, attempts=40):
-		"""Publish to the `events` channel until the client sees it — absorbs
-		subscriber startup latency in consume_events and the redis manager."""
+		"""Publish to the events channel until the client sees it."""
 		client = redis.Redis.from_url(redis_url())
 		try:
 			for _ in range(attempts):

--- a/frappe/tests/test_socketio_server.py
+++ b/frappe/tests/test_socketio_server.py
@@ -9,6 +9,7 @@ They need a reachable redis_queue and are skipped if there is none.
 """
 
 import asyncio
+import datetime
 import json
 import os
 import socket
@@ -18,10 +19,13 @@ from unittest import mock
 
 import redis
 
+import frappe
+from frappe.socketio_server import auth as sio_auth
 from frappe.socketio_server import bench_conf, redis_url
 from frappe.socketio_server.auth import (
 	_base_url,
 	_hostname,
+	_session_comfortably_fresh,
 	_site_from_environ,
 	authenticate,
 	check_permission,
@@ -175,6 +179,129 @@ class TestAuthenticate(UnitTestCase):
 			self.assertTrue(asyncio.run(check_permission(ctx, "ToDo", "TODO-001")))
 		with mock.patch(AUTH_CALLBACK_PATH, return_value={}):
 			self.assertFalse(asyncio.run(check_permission(ctx, "ToDo", "TODO-001")))
+
+
+class TestSessionFreshness(UnitTestCase):
+	"""_session_comfortably_fresh: only sessions valid under ANY timezone
+	interpretation may skip the canonical HTTP validation."""
+
+	def _session(self, age_seconds=0, expiry="240:00:00", **extra):
+		last = datetime.datetime.now() - datetime.timedelta(seconds=age_seconds)
+		return {"last_updated": str(last), "session_expiry": expiry, **extra}
+
+	def test_fresh_session_passes(self):
+		self.assertTrue(_session_comfortably_fresh(self._session()))
+
+	def test_session_inside_tz_slack_window_falls_back(self):
+		# 239h old with 240h expiry — valid locally, but not provably valid
+		# under every timezone interpretation
+		self.assertFalse(_session_comfortably_fresh(self._session(age_seconds=239 * 3600)))
+
+	def test_clearly_expired_session_fails(self):
+		self.assertFalse(_session_comfortably_fresh(self._session(age_seconds=480 * 3600)))
+
+	def test_short_expiry_never_takes_fast_path(self):
+		self.assertFalse(_session_comfortably_fresh(self._session(expiry="06:00:00")))
+
+	def test_bounded_session_falls_back(self):
+		self.assertFalse(_session_comfortably_fresh(self._session(session_end="2030-01-01 00:00:00+00:00")))
+
+	def test_garbage_falls_back(self):
+		self.assertFalse(_session_comfortably_fresh({}))
+		self.assertFalse(_session_comfortably_fresh(self._session(expiry="soon")))
+		self.assertFalse(
+			_session_comfortably_fresh({"last_updated": "not a date", "session_expiry": "240:00:00"})
+		)
+
+
+@unittest.skipUnless(redis_available(), "redis_queue not reachable")
+class TestSessionCacheFastPath(IntegrationTestCase):
+	"""Fast path against the real redis session cache, in the exact format
+	frappe.sessions.Session writes (pickled frappe._dict via frappe.cache)."""
+
+	def setUp(self):
+		super().setUp()
+		self.site = frappe.local.site
+		self.sid = frappe.generate_hash(length=32)
+		sio_auth._installed_apps_cache.clear()
+		sio_auth._site_db_names.clear()
+
+	def tearDown(self):
+		frappe.cache.hdel("session", self.sid)
+		sio_auth._installed_apps_cache.clear()
+		sio_auth._site_db_names.clear()
+		super().tearDown()
+
+	def _put_session(self, last_updated=None, session_expiry="240:00:00", session_end=None):
+		data = frappe._dict(
+			{
+				"user": TEST_USER,
+				"sid": self.sid,
+				"data": frappe._dict(
+					{
+						"user": TEST_USER,
+						"user_type": "System User",
+						"full_name": "Socket Test",
+						"last_updated": last_updated or str(datetime.datetime.now()),
+						"session_expiry": session_expiry,
+					}
+				),
+			}
+		)
+		if session_end:
+			data["data"]["session_end"] = session_end
+		frappe.cache.hset("session", self.sid, data)
+
+	def _environ(self):
+		return {
+			"HTTP_HOST": f"{self.site}:8000",
+			"HTTP_ORIGIN": f"http://{self.site}:8000",
+			"HTTP_COOKIE": f"sid={self.sid}",
+		}
+
+	def _authenticate(self):
+		return asyncio.run(authenticate(self._environ(), f"/{self.site}"))
+
+	def test_fresh_session_resolves_without_http(self):
+		self._put_session()
+		sio_auth._remember_installed_apps(self.site, ["frappe"])
+		boom = mock.MagicMock(side_effect=AssertionError("HTTP callback must not be called"))
+		with mock.patch(AUTH_CALLBACK_PATH, new=boom):
+			ok, ctx = self._authenticate()
+		self.assertTrue(ok)
+		self.assertEqual(ctx["user"], TEST_USER)
+		self.assertEqual(ctx["user_type"], "System User")
+		self.assertEqual(ctx["installed_apps"], ["frappe"])
+
+	def test_cache_miss_falls_back_to_http(self):
+		sio_auth._remember_installed_apps(self.site, ["frappe"])
+		with mock.patch(AUTH_CALLBACK_PATH, return_value={"message": USER_INFO}) as callback:
+			ok, _ctx = self._authenticate()
+		self.assertTrue(ok)
+		self.assertEqual(callback.call_count, 1)
+
+	def test_stale_session_falls_back_to_http(self):
+		# 20 days old with a 10-day expiry: expired everywhere — never
+		# rejected locally, always delegated to canonical validation
+		last = str(datetime.datetime.now() - datetime.timedelta(days=20))
+		self._put_session(last_updated=last)
+		sio_auth._remember_installed_apps(self.site, ["frappe"])
+		with mock.patch(AUTH_CALLBACK_PATH, return_value={}) as callback:
+			ok, error = self._authenticate()
+		self.assertFalse(ok)
+		self.assertIn("Unauthorized", error)
+		self.assertGreaterEqual(callback.call_count, 1)
+
+	def test_http_resolution_primes_fast_path(self):
+		self._put_session()
+		with mock.patch(AUTH_CALLBACK_PATH, return_value={"message": USER_INFO}) as callback:
+			ok, _ = self._authenticate()  # installed_apps unknown -> HTTP, primes cache
+			self.assertTrue(ok)
+			self.assertEqual(callback.call_count, 1)
+			ok, ctx = self._authenticate()  # now served from redis only
+			self.assertTrue(ok)
+			self.assertEqual(callback.call_count, 1)
+		self.assertEqual(ctx["installed_apps"], USER_INFO["installed_apps"])
 
 
 @unittest.skipUnless(redis_available(), "redis_queue not reachable")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ dependencies = [
     "xlrd~=2.0.2",
     "zxcvbn~=4.5.0",
     "markdownify~=1.2.2",
+    # realtime (python socket.io server, frappe/socketio_server)
+    "python-socketio~=5.16.1",
+    "uvicorn~=0.47.0",
     # integration dependencies
     "google-api-python-client~=2.188.0",
     "google-auth-oauthlib~=1.2.4",
@@ -128,6 +131,8 @@ dev = [
     "pypika-stubs",  # contributed
 ]
 test = [
+    # async socket.io client for frappe/tests/test_socketio_server.py
+    "aiohttp~=3.13.4",
     "unittest-xml-reporting~=3.2.0",
     "coverage~=7.13.5",
     "hypothesis~=6.77.0",


### PR DESCRIPTION
## Summary

A Python implementation of the realtime server (`python-socketio` + uvicorn), wire-compatible with `socketio.js` — the browser client and the `emit_via_redis` contract are unchanged. Run with `python -m frappe.socketio_server` (port 9001 by default), or switch backends in a dev bench via `frappe.realtime.set_backend("python")`.

Details in [`frappe/socketio_server/README.md`](https://github.com/netchampfaris/frappe/blob/socketio-python-server/frappe/socketio_server/README.md): architecture, auth flow, and what bench / Frappe Cloud need to run it in production.

## Why

- one less runtime to ship and supervise in production
- can run multiple instances behind one upstream (redis client manager), unlike the single-process Node server
- realtime logic and per-app handlers in the same language as the framework

## How it works

- **Auth**: sid-cookie sessions are resolved directly from the redis session cache (something the Node server can't do); anything uncertain — token/Bearer auth, stale or missing sessions — falls back to the same HTTP callback the Node server uses (`get_user_info` + socket secret)
- **Permissions**: `doctype_subscribe` / `doc_subscribe` / `doc_open` check `frappe.realtime.has_permission` with the connection's credentials
- **Multitenancy**: namespaces are registered dynamically per site (python-socketio has no regex namespaces)
- **Per-app handlers**: apps ship `{app}/realtime_handlers.py` with `register(sio, namespace)` instead of `realtime/handlers.js`

## Tests

- unit + end-to-end integration tests (real uvicorn server, real redis, python socket.io client): `bench --site {site} run-tests --module frappe.tests.test_socketio_server`
- cypress spec for the client-side backend switcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)