### PR TITLE
fix: recreate missing autoincrement sequences on migrate

### DIFF
--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -97,3 +97,50 @@ def set_next_val(
 			"mariadb": f"SELECT SETVAL(`{scrub(doctype_name + slug)}`, {next_val}, {is_val_used})",
 		}
 	)
+
+
+def _get_existing_sequences() -> set[str]:
+	if db.db_type == "postgres":
+		rows = db.sql(
+			"""SELECT sequence_name FROM information_schema.sequences
+			WHERE sequence_schema = 'public'"""
+		)
+	else:
+		rows = db.sql(
+			"""SELECT TABLE_NAME FROM information_schema.TABLES
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE = 'SEQUENCE'"""
+		)
+	return {r[0] for r in rows}
+
+
+def create_missing_sequences() -> list[str]:
+	"""Recreate sequences for autoincrement doctypes whose sequence object is missing."""
+	import frappe
+	from frappe.query_builder.functions import Max
+
+	if db.db_type == "sqlite":
+		return []
+
+	doctypes = frappe.get_all(
+		"DocType",
+		filters={"autoname": "autoincrement", "issingle": 0, "is_virtual": 0},
+		pluck="name",
+	)
+	if not doctypes:
+		return []
+
+	existing = _get_existing_sequences()
+	created = []
+
+	for doctype in doctypes:
+		if scrub(f"{doctype}_id_seq") in existing:
+			continue
+
+		# align past existing rows to avoid name collisions; empty tables fall
+		# back to the default start (1), same as normal sequence creation
+		table = frappe.qb.DocType(doctype)
+		max_name = frappe.qb.from_(table).select(Max(table["name"])).run()[0][0]
+		create_sequence(doctype, check_not_exists=True, start_value=int(max_name) + 1 if max_name else 0)
+		created.append(doctype)
+
+	return created

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -160,6 +160,12 @@ class SiteMigration:
 		"""
 		print("Syncing jobs...")
 		sync_jobs()
+
+		from frappe.database.sequence import create_missing_sequences
+
+		if recreated := create_missing_sequences():
+			print(f"Recreated missing sequences for: {', '.join(recreated)}")
+
 		if not self.skip_fixtures:
 			print("Syncing fixtures...")
 			sync_fixtures()


### PR DESCRIPTION
Fixes https://support.frappe.io/helpdesk/tickets/70745?view=VIEW-HD+Ticket-1547

A DocType using Auto Increment naming relies on a separate DB sequence object (`<doctype>_id_seq`). This object can go missing after a partial backup/restore (the sequence is a separate DB object, not part of the table dump). Once lost, every insert fails with `MySQLdb.OperationalError: (4091, "Unknown SEQUENCE")`.

On each `bench migrate`, we now scan all autoincrement DocTypes, detect any missing sequences, recreate them, and align the counter to `MAX(name)` to avoid duplicate name collisions.