### PR TITLE
fix!: Make file uploads private by default if API hasn't specified

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -149,7 +149,7 @@ def upload_file():
 		ignore_permissions = False
 
 	files = frappe.request.files
-	is_private = frappe.form_dict.is_private
+	is_private = frappe.form_dict.get("is_private", 1)
 	doctype = frappe.form_dict.doctype
 	docname = frappe.form_dict.docname
 	fieldname = frappe.form_dict.fieldname


### PR DESCRIPTION
DID fix. If any client forgets to specify public/private then we now assume private file.