### PR TITLE
fix: allow users to save their own private workspace without Workspace Manager role

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -342,8 +342,12 @@ def save_page(name: str, public: str | int, new_widgets: str, blocks: str):
 	public = frappe.parse_json(public)
 
 	doc = frappe.get_doc("Workspace", name)
-	if not is_workspace_manager() or (not doc.public and doc.for_user != frappe.session.user):
-		return
+	can_edit = is_workspace_manager() or (not doc.public and doc.for_user == frappe.session.user)
+	if not can_edit:
+		frappe.throw(
+			_("You need the Workspace Manager role to edit this workspace."),
+			frappe.PermissionError,
+		)
 
 	if not doc.type:
 		doc.type = "Workspace"


### PR DESCRIPTION
https://support.frappe.io/helpdesk/tickets/70755?view=VIEW-HD+Ticket-1547