### PR TITLE
fix: disable render safe globals by default

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -86,7 +86,7 @@ def is_safe_exec_enabled() -> bool:
 
 
 def is_render_exec_enabled() -> bool:
-	return not bool(frappe.get_common_site_config().get(RENDER_EXEC_CONFIG_KEY, 0))
+	return not bool(frappe.get_common_site_config().get(RENDER_EXEC_CONFIG_KEY, 1))
 
 
 def safe_exec(


### PR DESCRIPTION
Can be enabled later, but observing for breakages on develop for now.