### PR TITLE
feat: Add `Insert or Update` import type option to data import tool

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -406,9 +406,9 @@ def import_doc(context: CliCtxObj, path, force=False):
 @click.option(
 	"--type",
 	"import_type",
-	type=click.Choice(["Insert", "Update"], case_sensitive=False),
+	type=click.Choice(["Insert", "Update", "Upsert"], case_sensitive=False),
 	default="Insert",
-	help="Insert New Records or Update Existing Records",
+	help="Insert New Records, Update Existing Records, or Insert or Update Records",
 )
 @click.option("--submit-after-import", default=False, is_flag=True, help="Submit document after importing it")
 @click.option("--mute-emails", default=True, is_flag=True, help="Mute emails during import")

--- a/frappe/core/doctype/data_import/data_import.css
+++ b/frappe/core/doctype/data_import/data_import.css
@@ -21,6 +21,7 @@
 /* Collapsible section headers with (count) before chevron. */
 .data-import-warnings-section .section-head.collapsible,
 .data-import-value-mappings-section .section-head.collapsible,
+.data-import-tree-preview-section .section-head.collapsible,
 .data-import-preview-section .section-head.collapsible {
 	display: flex;
 	align-items: center;
@@ -28,10 +29,26 @@
 
 .data-import-warnings-section .section-head .import-warnings-count,
 .data-import-value-mappings-section .section-head .value-mappings-count,
+.data-import-tree-preview-section .section-head .import-tree-preview-count,
 .data-import-preview-section .section-head .import-preview-count {
 	margin-left: auto;
 	margin-right: 6px;
 }
+
+.data-import-tree-preview-section .section-body {
+	display: block;
+	width: 100%;
+}
+
+.data-import-tree-preview-section .section-body .form-column {
+	width: 100%;
+	max-width: 100%;
+}
+
+[data-fieldname="import_tree_preview"] > .form-group .control-label {
+	display: none;
+}
+
 
 /* Preview section: full-width layout for datatable and import log. */
 .data-import-preview-section .section-body {

--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -55,6 +55,19 @@ function get_preview_row_count(preview_data) {
 	return preview_data.total_number_of_rows ?? preview_data.data?.length ?? 0;
 }
 
+function get_tree_preview_node_count(preview_data) {
+	if (!preview_data?.tree_preview) return 0;
+	return preview_data.tree_preview.total_nodes ?? preview_data.tree_preview.nodes?.length ?? 0;
+}
+
+/** Keep Tree Preview collapsed by default (unlike Preview, which expands when a file is attached). */
+function collapse_import_tree_section(frm, hide = true) {
+	const section = frm.layout?.sections_dict?.section_import_tree_preview;
+	if (section) {
+		section.collapse(hide);
+	}
+}
+
 /** Docfield for Map To: Link/Select per mapping row (child meta defaults to Data). */
 function get_mapping_target_df(grid_row) {
 	const doc = grid_row.doc;
@@ -382,14 +395,18 @@ frappe.ui.form.on("Data Import", {
 
 	reset_import_ui_state(frm) {
 		frm.import_preview = null;
+		frm.import_tree_preview = null;
 		frm.events.toggle_import_issues_ui(frm, false, false);
 		frm.events.toggle_import_log_ui(frm, false);
+		frm.toggle_display("section_import_tree_preview", false);
 		frm.toggle_display("section_import_preview", false);
+		frm.get_field("import_tree_preview")?.$wrapper.empty();
 		frm.get_field("import_preview")?.$wrapper.empty();
 		frm.get_field("import_warnings")?.$wrapper.html("");
 		frm.get_field("import_log_preview")?.$wrapper.empty();
 		update_section_count(frm, "import_warnings_section", 0, "import-warnings-count");
 		update_section_count(frm, "value_mappings_section", 0, "value-mappings-count");
+		update_section_count(frm, "section_import_tree_preview", 0, "import-tree-preview-count");
 		update_section_count(frm, "section_import_preview", 0, "import-preview-count");
 	},
 
@@ -556,9 +573,66 @@ frappe.ui.form.on("Data Import", {
 			},
 		}).then((r) => {
 			let preview_data = r.message;
+			frm.events.show_import_tree_preview(frm, preview_data);
 			frm.events.show_import_preview(frm, preview_data);
 			frm.events.show_import_warnings(frm, preview_data);
 		});
+	},
+
+	show_import_tree_preview(frm, preview_data) {
+		const show_tree = Boolean(preview_data?.tree_preview);
+		frm.toggle_display("section_import_tree_preview", show_tree);
+		frm.toggle_display("import_tree_preview", show_tree);
+
+		if (!show_tree) {
+			frm.import_tree_preview = null;
+			frm.get_field("import_tree_preview")?.$wrapper.empty();
+			update_section_count(
+				frm,
+				"section_import_tree_preview",
+				0,
+				"import-tree-preview-count"
+			);
+			return;
+		}
+
+		update_section_count(
+			frm,
+			"section_import_tree_preview",
+			get_tree_preview_node_count(preview_data),
+			"import-tree-preview-count"
+		);
+
+		const render_tree_preview = () => {
+			const wrapper = frm.get_field("import_tree_preview").$wrapper;
+			const on_row_click = (row_number) => {
+				frm.layout?.sections_dict?.section_import_preview?.collapse(false);
+				frm.import_preview?.highlight_table_row(row_number);
+			};
+
+			if (
+				frm.doc.name &&
+				frm.import_tree_preview &&
+				frm.import_tree_preview.data_import_name === frm.doc.name
+			) {
+				frm.import_tree_preview.preview_data = preview_data;
+				frm.import_tree_preview.on_row_click = on_row_click;
+				frm.import_tree_preview.refresh();
+			} else {
+				frm.import_tree_preview = new frappe.data_import.ImportTreePreview({
+					wrapper,
+					doctype: frm.doc.reference_doctype,
+					preview_data,
+					on_row_click,
+				});
+				frm.import_tree_preview.data_import_name = frm.doc.name;
+			}
+
+			// After layout refresh_section_collapse (Preview uses depends_on to expand).
+			setTimeout(() => collapse_import_tree_section(frm, true), 0);
+		};
+
+		frappe.require("data_import_tools.bundle.js", render_tree_preview);
 	},
 
 	show_import_preview(frm, preview_data) {

--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -1,6 +1,54 @@
 // Copyright (c) 2019, Frappe Technologies and contributors
 // For license information, please see license.txt
 
+const UPSERT_IMPORT_TYPE = "Insert or Update Records";
+const UPDATE_IMPORT_TYPE = "Update Existing Records";
+const IMPORT_ACTION_UPDATE = "Update";
+
+function is_upsert_import_type(import_type) {
+	return import_type === UPSERT_IMPORT_TYPE;
+}
+
+/** Progress headline shown while an import job is running. */
+function get_import_progress_message(import_type, current, total, eta_message) {
+	const args = [current, total, eta_message];
+	if (import_type === UPDATE_IMPORT_TYPE) {
+		return __("Updating {0} of {1}, {2}", args);
+	}
+	if (is_upsert_import_type(import_type)) {
+		return __("Importing or updating {0} of {1}, {2}", args);
+	}
+	return __("Importing {0} of {1}, {2}", args);
+}
+
+/** Summary headline after import completes. */
+function get_import_status_message(import_type, inserted, updated, total) {
+	if (import_type === UPDATE_IMPORT_TYPE) {
+		return __("Successfully updated {0} out of {1} records.", [inserted, total]);
+	}
+	if (is_upsert_import_type(import_type)) {
+		return __("Successfully inserted {0} and updated {1} out of {2} records.", [
+			inserted,
+			updated,
+			total,
+		]);
+	}
+	return __("Successfully imported {0} out of {1} records.", [inserted, total]);
+}
+
+/** Success message for a single import log row. */
+function get_import_log_html(import_type, import_action, doc_link) {
+	if (is_upsert_import_type(import_type)) {
+		return import_action === IMPORT_ACTION_UPDATE
+			? __("Successfully updated {0}", [doc_link])
+			: __("Successfully inserted {0}", [doc_link]);
+	}
+	if (import_type === UPDATE_IMPORT_TYPE) {
+		return __("Successfully updated {0}", [doc_link]);
+	}
+	return __("Successfully imported {0}", [doc_link]);
+}
+
 /** Deduplicate template + preview warnings: one per column (longer message wins, often has row numbers). */
 function dedupe_import_warnings(warnings) {
 	const by_col = {};
@@ -145,11 +193,12 @@ frappe.ui.form.on("Data Import", {
 
 			let message;
 			if (data.success) {
-				let message_args = [data.current, data.total, eta_message];
-				message =
-					frm.doc.import_type === "Insert New Records"
-						? __("Importing {0} of {1}, {2}", message_args)
-						: __("Updating {0} of {1}, {2}", message_args);
+				message = get_import_progress_message(
+					frm.doc.import_type,
+					data.current,
+					data.total,
+					eta_message
+				);
 			}
 			if (data.skipping) {
 				message = __("Skipping {0} of {1}, {2}", [data.current, data.total, eta_message]);
@@ -277,18 +326,13 @@ frappe.ui.form.on("Data Import", {
 					return;
 				}
 
-				let message;
-				if (frm.doc.import_type === "Insert New Records") {
-					message = __("Successfully imported {0} out of {1} records.", [
-						successful_records,
-						total_records,
-					]);
-				} else {
-					message = __("Successfully updated {0} out of {1} records.", [
-						successful_records,
-						total_records,
-					]);
-				}
+				const is_upsert = is_upsert_import_type(frm.doc.import_type);
+				let message = get_import_status_message(
+					frm.doc.import_type,
+					is_upsert ? cint(r.message.inserted) : successful_records,
+					is_upsert ? cint(r.message.updated) : 0,
+					total_records
+				);
 
 				if (failed_records > 0) {
 					message +=
@@ -927,27 +971,28 @@ frappe.ui.form.on("Data Import", {
 
 				frm.events.toggle_import_log_ui(frm, true);
 
+				const is_upsert = is_upsert_import_type(frm.doc.import_type);
+				let inserted_count = 0;
+				let updated_count = 0;
+
 				let rows = logs
 					.map((log) => {
 						let html = "";
 						if (log.success) {
-							if (frm.doc.import_type === "Insert New Records") {
-								html = __("Successfully imported {0}", [
-									`<span class="underline">${frappe.utils.get_form_link(
-										frm.doc.reference_doctype,
-										log.docname,
-										true
-									)}<span>`,
-								]);
-							} else {
-								html = __("Successfully updated {0}", [
-									`<span class="underline">${frappe.utils.get_form_link(
-										frm.doc.reference_doctype,
-										log.docname,
-										true
-									)}<span>`,
-								]);
+							if (is_upsert) {
+								if (log.import_action === IMPORT_ACTION_UPDATE) updated_count++;
+								else inserted_count++;
 							}
+							const doc_link = `<span class="underline">${frappe.utils.get_form_link(
+								frm.doc.reference_doctype,
+								log.docname,
+								true
+							)}<span>`;
+							html = get_import_log_html(
+								frm.doc.import_type,
+								log.import_action,
+								doc_link
+							);
 						} else {
 							let messages = JSON.parse(log.messages || "[]")
 								.map((m) => {
@@ -992,7 +1037,16 @@ frappe.ui.form.on("Data Import", {
 					</td></tr>`;
 				}
 
+				let upsert_summary = "";
+				if (is_upsert) {
+					upsert_summary = `<div class="text-muted small mb-2">${__(
+						"Inserted {0}, Updated {1}",
+						[inserted_count, updated_count]
+					)}</div>`;
+				}
+
 				frm.get_field("import_log_preview").$wrapper.html(`
+					${upsert_summary}
 					<table class="table table-bordered">
 						<tr class="text-muted">
 							<th width="10%">${__("Row Number")}</th>

--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -60,6 +60,27 @@ function get_tree_preview_node_count(preview_data) {
 	return preview_data.tree_preview.total_nodes ?? preview_data.tree_preview.nodes?.length ?? 0;
 }
 
+/** Hide tree structure warnings after a finished import; keep the tree for reference. */
+function strip_tree_preview_warnings(preview_data) {
+	if (!preview_data?.tree_preview) {
+		return preview_data;
+	}
+
+	const nodes = (preview_data.tree_preview.nodes || []).map((node) => ({
+		...node,
+		warnings: [],
+	}));
+
+	return {
+		...preview_data,
+		tree_preview: {
+			...preview_data.tree_preview,
+			tree_warnings: [],
+			nodes,
+		},
+	};
+}
+
 /** Keep Tree Preview collapsed by default (unlike Preview, which expands when a file is attached). */
 function collapse_import_tree_section(frm, hide = true) {
 	const section = frm.layout?.sections_dict?.section_import_tree_preview;
@@ -578,6 +599,10 @@ frappe.ui.form.on("Data Import", {
 	},
 
 	show_import_tree_preview(frm, preview_data) {
+		if (["Success", "Partial Success"].includes(frm.doc.status)) {
+			preview_data = strip_tree_preview_warnings(preview_data);
+		}
+
 		const show_tree = Boolean(preview_data?.tree_preview);
 		frm.toggle_display("section_import_tree_preview", show_tree);
 		frm.toggle_display("import_tree_preview", show_tree);

--- a/frappe/core/doctype/data_import/data_import.json
+++ b/frappe/core/doctype/data_import/data_import.json
@@ -30,6 +30,8 @@
   "value_mappings",
   "skipped_rows_section",
   "skipped_rows",
+  "section_import_tree_preview",
+  "import_tree_preview",
   "section_import_preview",
   "import_preview",
   "import_log_heading",
@@ -62,6 +64,20 @@
    "in_list_view": 1,
    "label": "Import File",
    "read_only_depends_on": "eval: ['Success', 'Partial Success'].includes(doc.status)"
+  },
+  {
+   "collapsible": 1,
+   "css_class": "data-import-tree-preview-section",
+   "fieldname": "section_import_tree_preview",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Tree Preview"
+  },
+  {
+   "fieldname": "import_tree_preview",
+   "fieldtype": "HTML",
+   "hide_label": 1,
+   "label": "Tree Preview"
   },
   {
    "fieldname": "import_preview",

--- a/frappe/core/doctype/data_import/data_import.json
+++ b/frappe/core/doctype/data_import/data_import.json
@@ -53,7 +53,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Import Type",
-   "options": "\nInsert New Records\nUpdate Existing Records",
+   "options": "\nInsert New Records\nUpdate Existing Records\nInsert or Update Records",
    "reqd": 1,
    "set_only_once": 1
   },

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -11,7 +11,7 @@ from rq.timeouts import JobTimeoutException
 import frappe
 from frappe import _
 from frappe.core.doctype.data_import.exporter import Exporter
-from frappe.core.doctype.data_import.importer import Importer
+from frappe.core.doctype.data_import.importer import UPSERT, Importer
 from frappe.model import CORE_DOCTYPES
 from frappe.model.document import Document
 from frappe.modules.import_file import import_file_by_path
@@ -37,7 +37,9 @@ class DataImport(Document):
 		delimiter_options: DF.Data | None
 		google_sheets_url: DF.Data | None
 		import_file: DF.Attach | None
-		import_type: DF.Literal["", "Insert New Records", "Update Existing Records"]
+		import_type: DF.Literal[
+			"", "Insert New Records", "Update Existing Records", "Insert or Update Records"
+		]
 		mute_emails: DF.Check
 		payload_count: DF.Int
 		reference_doctype: DF.Link
@@ -294,26 +296,41 @@ def download_import_log(data_import_name: str):
 
 @frappe.whitelist()
 def get_import_status(data_import_name: str):
+	from frappe.core.doctype.data_import.importer import ACTION_INSERT, ACTION_UPDATE
+
 	data_import: DataImport = frappe.get_doc("Data Import", data_import_name)
 	data_import.check_permission("read")
 
-	import_status = {"status": data_import.status}
-	logs = frappe.get_all(
+	import_status = {
+		"status": data_import.status,
+		"total_records": data_import.payload_count,
+	}
+	is_upsert = data_import.import_type == UPSERT
+	group_by = "success, import_action" if is_upsert else "success"
+	log_fields = [{"COUNT": "*", "as": "count"}, "success"]
+	if is_upsert:
+		log_fields.append("import_action")
+
+	for log in frappe.get_all(
 		"Data Import Log",
-		fields=[{"COUNT": "*", "as": "count"}, "success"],
+		fields=log_fields,
 		filters={"data_import": data_import_name},
-		group_by="success",
-	)
-
-	total_payload_count = data_import.payload_count
-
-	for log in logs:
+		group_by=group_by,
+	):
+		count = log.get("count")
 		if log.get("success"):
-			import_status["success"] = log.get("count")
+			import_status["success"] = import_status.get("success", 0) + count
+			if is_upsert:
+				if log.get("import_action") == ACTION_INSERT:
+					import_status["inserted"] = count
+				elif log.get("import_action") == ACTION_UPDATE:
+					import_status["updated"] = count
 		else:
-			import_status["failed"] = log.get("count")
+			import_status["failed"] = count
 
-	import_status["total_records"] = total_payload_count
+	if is_upsert:
+		import_status.setdefault("inserted", 0)
+		import_status.setdefault("updated", 0)
 
 	return import_status
 
@@ -325,7 +342,7 @@ def get_import_logs(data_import: str):
 
 	return frappe.get_all(
 		"Data Import Log",
-		fields=["success", "docname", "messages", "exception", "row_indexes"],
+		fields=["success", "docname", "messages", "exception", "row_indexes", "import_action"],
 		filters={"data_import": data_import},
 		limit_page_length=5000,
 		order_by="log_index",
@@ -338,18 +355,21 @@ def import_file(doctype, file_path, import_type, submit_after_import=False, cons
 
 	:param doctype: DocType to import
 	:param file_path: Path to .csv, .xls, or .xlsx file to import
-	:param import_type: One of "Insert" or "Update"
+	:param import_type: One of "Insert", "Update", or "Upsert"
 	:param submit_after_import: Whether to submit documents after import
 	:param console: Set to true if this is to be used from command line. Will print errors or progress to stdout.
 	"""
 
+	import_type_map = {
+		"insert": "Insert New Records",
+		"update": "Update Existing Records",
+		"upsert": "Insert or Update Records",
+	}
 	data_import = frappe.new_doc("Data Import")
 	data_import.reference_doctype = doctype
 	data_import.import_file = file_path
 	data_import.submit_after_import = submit_after_import
-	data_import.import_type = (
-		"Insert New Records" if import_type.lower() == "insert" else "Update Existing Records"
-	)
+	data_import.import_type = import_type_map.get(import_type.lower(), "Insert New Records")
 
 	i = Importer(doctype=doctype, file_path=file_path, data_import=data_import, console=console)
 	data_import.set_payload_count(i)

--- a/frappe/core/doctype/data_import/data_import_list.js
+++ b/frappe/core/doctype/data_import/data_import_list.js
@@ -34,6 +34,7 @@ frappe.listview_settings["Data Import"] = {
 			return {
 				"Insert New Records": __("Insert"),
 				"Update Existing Records": __("Update"),
+				"Insert or Update Records": __("Insert or Update"),
 			}[value];
 		},
 	},

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -23,6 +23,9 @@ INVALID_VALUES = ("", None)
 MAX_ROWS_IN_PREVIEW = 10
 INSERT = "Insert New Records"
 UPDATE = "Update Existing Records"
+UPSERT = "Insert or Update Records"
+ACTION_INSERT = "Insert"
+ACTION_UPDATE = "Update"
 DURATION_PATTERN = re.compile(r"^(?:(\d+d)?((^|\s)\d+h)?((^|\s)\d+m)?((^|\s)\d+s)?)$")
 
 
@@ -207,11 +210,15 @@ class Importer:
 							user=frappe.session.user,
 						)
 
-					create_import_log(
-						self.data_import.name,
-						log_index,
-						{"success": True, "docname": doc.name, "row_indexes": row_indexes},
-					)
+					log_details = {
+						"success": True,
+						"docname": doc.name,
+						"row_indexes": row_indexes,
+					}
+					if self.import_type == UPSERT:
+						log_details["import_action"] = doc.flags.import_action
+
+					create_import_log(self.data_import.name, log_index, log_details)
 
 					log_index += 1
 
@@ -301,6 +308,20 @@ class Importer:
 			return self.insert_record(doc)
 		elif self.import_type == UPDATE:
 			return self.update_record(doc)
+		elif self.import_type == UPSERT:
+			return self.upsert_record(doc)
+
+	def upsert_record(self, doc):
+		"""Update the record when it exists, otherwise insert it."""
+		id_field = get_id_field(self.doctype)
+		id_value = doc.get(id_field.fieldname)
+		if id_value and frappe.db.exists(self.doctype, id_value):
+			result = self.update_record(doc, raise_if_no_changes=False)
+			result.flags.import_action = ACTION_UPDATE
+		else:
+			result = self.insert_record(doc)
+			result.flags.import_action = ACTION_INSERT
+		return result
 
 	def insert_record(self, doc):
 		meta = frappe.get_meta(self.doctype)
@@ -351,7 +372,7 @@ class Importer:
 		if id_value not in INVALID_VALUES:
 			self._inserted_name_map[cstr(id_value).strip()] = new_doc.name
 
-	def update_record(self, doc):
+	def update_record(self, doc, raise_if_no_changes=True):
 		id_field = get_id_field(self.doctype)
 		existing_doc = frappe.get_doc(self.doctype, doc.get(id_field.fieldname))
 
@@ -368,9 +389,10 @@ class Importer:
 			}
 			updated_doc.save()
 			return updated_doc
-		else:
-			# throw if no changes
+
+		if raise_if_no_changes:
 			frappe.throw(_("No changes to update"))
+		return updated_doc
 
 	def get_eta(self, current, total, processing_time):
 		self.last_eta = getattr(self, "last_eta", 0)
@@ -966,7 +988,7 @@ def build_tree_preview(import_file: "ImportFile") -> frappe._dict | None:
 			continue
 
 		parent_exists = frappe.db.exists(import_file.doctype, parent_id)
-		if import_file.import_type == UPDATE or parent_exists:
+		if import_file.import_type in (UPDATE, UPSERT) or parent_exists:
 			continue
 
 		message = _("Parent {0} not found in file").format(frappe.bold(parent_id))
@@ -1037,7 +1059,7 @@ def _has_parent_cycle(node_id: str, nodes_by_id: dict) -> bool:
 def sort_tree_payloads(payloads: list, doctype: str, import_type: str | None) -> list:
 	"""Return payloads in parent-before-child order for nested-set inserts."""
 	meta = frappe.get_meta(doctype)
-	if import_type != INSERT or not meta.is_nested_set() or not payloads:
+	if import_type not in (INSERT, UPSERT) or not meta.is_nested_set() or not payloads:
 		return payloads
 
 	parent_field = meta.nsm_parent_field or f"parent_{frappe.scrub(doctype)}"
@@ -1167,7 +1189,7 @@ class Row:
 
 	def _parse_doc(self, doctype, columns, values, parent_doc=None, table_df=None):
 		doc = frappe._dict()
-		if self.import_type == INSERT:
+		if self.import_type in (INSERT, UPSERT):
 			# new_doc returns a dict with default values set
 			doc = frappe.new_doc(
 				doctype,
@@ -1192,7 +1214,7 @@ class Row:
 				doc[df.fieldname] = self.parse_value(value, col)
 
 		is_table = frappe.get_meta(doctype).istable
-		is_update = self.import_type == UPDATE
+		is_update = self.import_type in (UPDATE, UPSERT)
 		if is_table and is_update:
 			# check if the row already exists
 			# if yes, fetch the original doc so that it is not updated
@@ -1840,6 +1862,7 @@ def create_import_log(data_import, log_index, log_details):
 			"data_import": data_import,
 			"row_indexes": json.dumps(log_details.get("row_indexes")),
 			"docname": log_details.get("docname"),
+			"import_action": log_details.get("import_action"),
 			"messages": json.dumps(log_details.get("messages", "[]")),
 			"exception": log_details.get("exception"),
 		}

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -86,6 +86,13 @@ class Importer:
 		frappe.flags.mute_emails = self.data_import.mute_emails
 
 		self.data_import.db_set("template_warnings", "")
+		self._inserted_name_map = {}
+		meta = frappe.get_meta(self.doctype)
+		self._tree_parent_field = meta.nsm_parent_field if meta.is_nested_set() else None
+		header = getattr(self.import_file, "header", None)
+		self._tree_alias_field = getattr(header, "tree_alias_field", None)
+		self._id_fieldname = getattr(header, "id_fieldname", None) or get_id_field(self.doctype).fieldname
+		self._uses_tree_aliases = bool(self._tree_alias_field)
 
 	def import_data(self):
 		self.before_import()
@@ -99,7 +106,9 @@ class Importer:
 			get_skipped_row_numbers,
 		)
 
-		warnings = get_blocking_warnings(self.import_file.get_warnings(), self.import_file, self.data_import)
+		warnings = get_blocking_warnings(
+			self.import_file.get_all_warnings(), self.import_file, self.data_import
+		)
 
 		if warnings:
 			if self.console:
@@ -302,6 +311,11 @@ class Importer:
 			# name can only be set directly if autoname is prompt
 			new_doc.set("name", None)
 
+		if self._uses_tree_aliases and self._tree_parent_field:
+			self._resolve_tree_parent_link(doc)
+
+		new_doc.update(doc)
+
 		new_doc.flags.updater_reference = {
 			"doctype": self.data_import.doctype,
 			"docname": self.data_import.name,
@@ -309,9 +323,33 @@ class Importer:
 		}
 
 		new_doc.insert()
+		if self._uses_tree_aliases:
+			self._register_inserted_name(doc, new_doc)
 		if meta.is_submittable and self.data_import.submit_after_import:
 			new_doc.submit()
 		return new_doc
+
+	def _resolve_tree_parent_link(self, doc):
+		"""Swap parent link aliases from the file with inserted document names."""
+		parent = doc.get(self._tree_parent_field)
+		if parent in INVALID_VALUES:
+			return
+
+		parent = cstr(parent).strip()
+		resolved = self._inserted_name_map.get(parent)
+		if resolved:
+			doc[self._tree_parent_field] = resolved
+
+	def _register_inserted_name(self, doc, new_doc):
+		"""Track alias/id values from the file against the generated document name."""
+		if self._tree_alias_field:
+			alias = new_doc.get(self._tree_alias_field) or doc.get(self._tree_alias_field)
+			if alias not in INVALID_VALUES:
+				self._inserted_name_map[cstr(alias).strip()] = new_doc.name
+
+		id_value = doc.get(self._id_fieldname)
+		if id_value not in INVALID_VALUES:
+			self._inserted_name_map[cstr(id_value).strip()] = new_doc.name
 
 	def update_record(self, doc):
 		id_field = get_id_field(self.doctype)
@@ -551,7 +589,13 @@ class ImportFile:
 		self.header = header
 		self.columns = self.header.columns
 		self.data = data
-		self.header.import_ids = _build_import_id_set(self)
+		meta = frappe.get_meta(self.doctype)
+		self.header.id_fieldname = _get_id_fieldname_from_meta(meta)
+		self.header.tree_alias_field = _get_tree_alias_field_from_meta(meta)
+		self.header.import_ids, self.header.import_aliases = _build_import_reference_sets(
+			self, self.header.id_fieldname, self.header.tree_alias_field
+		)
+		self.header.import_refs = self.header.import_ids | self.header.import_aliases
 		self._refresh_self_referential_link_validation()
 
 		if len(data) < 1:
@@ -570,7 +614,7 @@ class ImportFile:
 			if col.df.options != self.doctype:
 				continue
 
-			col.import_ids = self.header.import_ids
+			col.import_refs = self.header.import_refs
 			col.invalid_value_items = None
 			col.warnings = [w for w in col.warnings if w.get("type") != "value_mapping"]
 			warn_invalid_link_select_values(col)
@@ -596,12 +640,15 @@ class ImportFile:
 
 		data = [[row.row_number, *row.as_list()] for row in self.data]
 
-		warnings = self.get_warnings()
+		tree_preview = build_tree_preview(self)
 
 		out = frappe._dict()
 		out.data = data
 		out.columns = columns
-		out.warnings = warnings
+		out.warnings = self.get_warnings()
+		if tree_preview:
+			out.tree_preview = tree_preview
+			out.warnings += tree_preview.tree_warnings
 		total_number_of_rows = len(out.data)
 		out.total_number_of_rows = total_number_of_rows
 		if total_number_of_rows > MAX_ROWS_IN_PREVIEW:
@@ -611,11 +658,6 @@ class ImportFile:
 		from frappe.core.doctype.data_import.value_mapping import get_mapping_hints
 
 		out.mapping_hints = get_mapping_hints(self, self.reference_doctype, self.value_lookup)
-
-		tree_preview = build_tree_preview(self)
-		if tree_preview:
-			out.tree_preview = tree_preview
-			out.warnings += tree_preview.tree_warnings
 
 		return out
 
@@ -689,6 +731,14 @@ class ImportFile:
 
 		return warnings
 
+	def get_all_warnings(self):
+		"""Row/column warnings plus tree-structure warnings used to block import."""
+		warnings = self.get_warnings()
+		tree_preview = build_tree_preview(self)
+		if tree_preview:
+			warnings += tree_preview.tree_warnings
+		return warnings
+
 	######
 
 	def read_file(self, file_path: str):
@@ -747,26 +797,89 @@ def format_row_numbers_for_warning(rows: list, max_shown: int = 6) -> str:
 	return f"{', '.join(str(r) for r in rows[:max_shown])}, ... {rows[-1]}"
 
 
-def _build_import_id_set(import_file: "ImportFile") -> set[str]:
-	"""IDs present in the template (used to validate self-referential tree parent links)."""
-	id_field = get_id_field(import_file.doctype)
-	id_column = next(
-		(
-			col
-			for col in import_file.header.columns
-			if col.df and col.df.fieldname == id_field.fieldname and not col.skip_import
-		),
+def _get_id_fieldname_from_meta(meta) -> str:
+	if meta.autoname and meta.autoname.startswith("field:"):
+		return meta.autoname[6:]
+	return "name"
+
+
+def _get_tree_alias_field_from_meta(meta) -> str | None:
+	"""Title field for parent-by-alias tree imports; None when names come from a ``field:`` autoname."""
+	if (
+		not meta.is_nested_set()
+		or (meta.autoname and meta.autoname.startswith("field:"))
+		or not meta.title_field
+	):
+		return None
+
+	if meta.title_field == _get_id_fieldname_from_meta(meta):
+		return None
+
+	return meta.title_field
+
+
+def get_tree_alias_fieldname(doctype):
+	"""Title field for parent-by-alias tree imports; None when names come from a ``field:`` autoname."""
+	return _get_tree_alias_field_from_meta(frappe.get_meta(doctype))
+
+
+def uses_tree_alias_references(doctype):
+	"""Whether tree parent links may use title-field values instead of generated names."""
+	return bool(get_tree_alias_fieldname(doctype))
+
+
+def _get_tree_node_key(doc, id_fieldname, alias_field=None):
+	"""Stable row identity for tree sorting/preview: explicit id, else title-field alias."""
+	node_id = doc.get(id_fieldname)
+	if node_id not in INVALID_VALUES:
+		return cstr(node_id).strip()
+
+	if alias_field:
+		alias = doc.get(alias_field)
+		if alias not in INVALID_VALUES:
+			return cstr(alias).strip()
+
+	return None
+
+
+def _is_same_file_tree_reference(value, header) -> bool:
+	"""Whether a self-referential link value exists elsewhere in the import file."""
+	import_refs = getattr(header, "import_refs", None)
+	return bool(import_refs and cstr(value).strip() in import_refs)
+
+
+def _get_import_column_index(columns, fieldname):
+	column = next(
+		(col for col in columns if col.df and col.df.fieldname == fieldname and not col.skip_import),
 		None,
 	)
-	if not id_column:
-		return set()
+	return column.index if column else None
+
+
+def _build_import_reference_sets(
+	import_file: "ImportFile", id_fieldname: str, alias_field: str | None
+) -> tuple[set[str], set[str]]:
+	"""Collect id and alias values from the template in a single pass."""
+	columns = import_file.header.columns
+	id_index = _get_import_column_index(columns, id_fieldname)
+	alias_index = _get_import_column_index(columns, alias_field) if alias_field else None
+
+	if id_index is None and alias_index is None:
+		return set(), set()
 
 	ids = set()
+	aliases = set()
 	for row in import_file.data:
-		value = row.get(id_column.index)
-		if value not in INVALID_VALUES:
-			ids.add(cstr(value).strip())
-	return ids
+		if id_index is not None:
+			value = row.get(id_index)
+			if value not in INVALID_VALUES:
+				ids.add(cstr(value).strip())
+		if alias_index is not None:
+			value = row.get(alias_index)
+			if value not in INVALID_VALUES:
+				aliases.add(cstr(value).strip())
+
+	return ids, aliases
 
 
 def build_tree_preview(import_file: "ImportFile") -> frappe._dict | None:
@@ -776,8 +889,8 @@ def build_tree_preview(import_file: "ImportFile") -> frappe._dict | None:
 		return None
 
 	parent_field = meta.nsm_parent_field or f"parent_{frappe.scrub(import_file.doctype)}"
-	id_field = get_id_field(import_file.doctype)
-	id_fieldname = id_field.fieldname
+	id_fieldname = getattr(import_file.header, "id_fieldname", None) or _get_id_fieldname_from_meta(meta)
+	alias_field = getattr(import_file.header, "tree_alias_field", None)
 	label_fieldname = meta.title_field or id_fieldname
 	is_group_field = "is_group" if meta.has_field("is_group") else None
 	parent_column = next(
@@ -797,11 +910,10 @@ def build_tree_preview(import_file: "ImportFile") -> frappe._dict | None:
 		if not doc:
 			continue
 
-		node_id = doc.get(id_fieldname)
-		if node_id in INVALID_VALUES:
+		node_id = _get_tree_node_key(doc, id_fieldname, alias_field)
+		if not node_id:
 			continue
 
-		node_id = cstr(node_id).strip()
 		parent = _get_tree_parent_value(row, parent_column, doc, parent_field)
 
 		label = doc.get(label_fieldname) or node_id
@@ -823,7 +935,7 @@ def build_tree_preview(import_file: "ImportFile") -> frappe._dict | None:
 
 	tree_warnings = []
 	nodes_by_id = {node.id: node for node in nodes}
-	import_ids = getattr(import_file.header, "import_ids", None) or set()
+	duplicate_messages = {}
 
 	for node_id, row_numbers in id_to_rows.items():
 		if len(row_numbers) > 1:
@@ -831,9 +943,11 @@ def build_tree_preview(import_file: "ImportFile") -> frappe._dict | None:
 				frappe.bold(node_id), format_row_numbers_for_warning(row_numbers)
 			)
 			tree_warnings.append({"message": message})
-			for node in nodes:
-				if node.id == node_id:
-					node.warnings.append(message)
+			duplicate_messages[node_id] = message
+
+	for node in nodes:
+		if message := duplicate_messages.get(node.id):
+			node.warnings.append(message)
 
 	for node in nodes:
 		parent_id = node.parent
@@ -848,7 +962,7 @@ def build_tree_preview(import_file: "ImportFile") -> frappe._dict | None:
 					tree_warnings.append({"row": node.row_number, "message": message})
 			continue
 
-		if parent_id in import_ids:
+		if _is_same_file_tree_reference(parent_id, import_file.header):
 			continue
 
 		parent_exists = frappe.db.exists(import_file.doctype, parent_id)
@@ -859,6 +973,9 @@ def build_tree_preview(import_file: "ImportFile") -> frappe._dict | None:
 		node.warnings.append(message)
 		tree_warnings.append({"row": node.row_number, "message": message})
 
+	if is_group_field:
+		_append_non_group_parent_warnings(nodes, nodes_by_id, tree_warnings, is_group_field)
+
 	display_nodes = _order_tree_preview_nodes(nodes)
 
 	return frappe._dict(
@@ -866,6 +983,30 @@ def build_tree_preview(import_file: "ImportFile") -> frappe._dict | None:
 		tree_warnings=tree_warnings,
 		total_nodes=len(nodes),
 	)
+
+
+def _append_non_group_parent_warnings(
+	nodes: list, nodes_by_id: dict, tree_warnings: list, is_group_field: str
+):
+	"""Warn when a node is used as a parent in the file but Is Group is unchecked."""
+	children_by_parent: dict[str, list] = {}
+	for node in nodes:
+		if node.parent and node.parent in nodes_by_id:
+			children_by_parent.setdefault(node.parent, []).append(node)
+
+	for parent_id, _children in children_by_parent.items():
+		parent = nodes_by_id.get(parent_id)
+		if not parent or parent.is_group:
+			continue
+
+		display_name = parent.label or parent.id
+		message = _("{0} has children but Is Group is 0 — parent must be a group node").format(
+			frappe.bold(display_name)
+		)
+		if message not in parent.warnings:
+			parent.warnings.append(message)
+		if not any(w.get("message") == message for w in tree_warnings):
+			tree_warnings.append({"row": parent.row_number, "message": message})
 
 
 def _get_tree_parent_value(row: "Row", parent_column, doc: frappe._dict, parent_field: str):
@@ -900,30 +1041,24 @@ def sort_tree_payloads(payloads: list, doctype: str, import_type: str | None) ->
 		return payloads
 
 	parent_field = meta.nsm_parent_field or f"parent_{frappe.scrub(doctype)}"
-	id_fieldname = get_id_field(doctype).fieldname
+	id_fieldname = _get_id_fieldname_from_meta(meta)
+	alias_field = _get_tree_alias_field_from_meta(meta)
 
-	def get_payload_id(payload):
-		value = payload.doc.get(id_fieldname)
-		if value in INVALID_VALUES:
-			return None
-		return cstr(value).strip()
+	payload_keys = []
+	for payload in payloads:
+		node_id = _get_tree_node_key(payload.doc, id_fieldname, alias_field)
+		parent = payload.doc.get(parent_field)
+		parent = cstr(parent).strip() if parent not in INVALID_VALUES else None
+		payload_keys.append((payload, node_id, parent))
 
-	def get_payload_parent(payload):
-		value = payload.doc.get(parent_field)
-		if value in INVALID_VALUES:
-			return None
-		return cstr(value).strip()
-
-	payload_by_id = {node_id: payload for payload in payloads if (node_id := get_payload_id(payload))}
+	payload_by_id = {node_id: payload for payload, node_id, _parent in payload_keys if node_id}
 
 	children_by_parent: dict[str, list] = {}
 	roots = []
 
-	for payload in payloads:
-		node_id = get_payload_id(payload)
+	for payload, node_id, parent in payload_keys:
 		if not node_id:
 			continue
-		parent = get_payload_parent(payload)
 		if parent and parent in payload_by_id:
 			children_by_parent.setdefault(parent, []).append(payload)
 		else:
@@ -935,10 +1070,11 @@ def sort_tree_payloads(payloads: list, doctype: str, import_type: str | None) ->
 
 	ordered = []
 	seen = set()
+	payload_id_by_payload = {id(payload): node_id for payload, node_id, _parent in payload_keys}
 
 	def walk(parent_id):
 		for child in children_by_parent.get(parent_id, []):
-			node_id = get_payload_id(child)
+			node_id = payload_id_by_payload[id(child)]
 			if not node_id or node_id in seen:
 				continue
 			seen.add(node_id)
@@ -946,19 +1082,15 @@ def sort_tree_payloads(payloads: list, doctype: str, import_type: str | None) ->
 			walk(node_id)
 
 	for root in roots:
-		node_id = get_payload_id(root)
+		node_id = payload_id_by_payload[id(root)]
 		if not node_id or node_id in seen:
 			continue
 		seen.add(node_id)
 		ordered.append(root)
 		walk(node_id)
 
-	for payload in payloads:
-		node_id = get_payload_id(payload)
-		if node_id:
-			if node_id not in seen:
-				ordered.append(payload)
-		else:
+	for payload, node_id, _parent in payload_keys:
+		if not node_id or node_id not in seen:
 			ordered.append(payload)
 
 	return ordered
@@ -1106,11 +1238,7 @@ class Row:
 				return
 
 		elif df.fieldtype == "Link":
-			if (
-				df.options == self.doctype
-				and getattr(self.header, "import_ids", None)
-				and cstr(value).strip() in self.header.import_ids
-			):
+			if df.options == self.doctype and _is_same_file_tree_reference(value, self.header):
 				return value
 
 			exists = self.link_exists(value, df)

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -551,12 +551,29 @@ class ImportFile:
 		self.header = header
 		self.columns = self.header.columns
 		self.data = data
+		self.header.import_ids = _build_import_id_set(self)
+		self._refresh_self_referential_link_validation()
 
 		if len(data) < 1:
 			frappe.throw(
 				_("Import template should contain a Header and atleast one row."),
 				title=_("Template Error"),
 			)
+
+	def _refresh_self_referential_link_validation(self):
+		"""Re-validate parent Link columns after IDs from the file are known."""
+		from frappe.core.doctype.data_import.value_mapping import warn_invalid_link_select_values
+
+		for col in self.header.columns:
+			if not col.df or col.skip_import or col.df.fieldtype != "Link":
+				continue
+			if col.df.options != self.doctype:
+				continue
+
+			col.import_ids = self.header.import_ids
+			col.invalid_value_items = None
+			col.warnings = [w for w in col.warnings if w.get("type") != "value_mapping"]
+			warn_invalid_link_select_values(col)
 
 	def get_data_for_import_preview(self):
 		"""Adds a serial number column as the first column"""
@@ -594,6 +611,12 @@ class ImportFile:
 		from frappe.core.doctype.data_import.value_mapping import get_mapping_hints
 
 		out.mapping_hints = get_mapping_hints(self, self.reference_doctype, self.value_lookup)
+
+		tree_preview = build_tree_preview(self)
+		if tree_preview:
+			out.tree_preview = tree_preview
+			out.warnings += tree_preview.tree_warnings
+
 		return out
 
 	def get_payloads_for_import(self):
@@ -603,7 +626,7 @@ class ImportFile:
 		while data:
 			doc, rows, data = self.parse_next_row_for_import(data)
 			payloads.append(frappe._dict(doc=doc, rows=rows))
-		return payloads
+		return sort_tree_payloads(payloads, self.doctype, self.import_type)
 
 	def parse_next_row_for_import(self, data):
 		"""
@@ -724,6 +747,253 @@ def format_row_numbers_for_warning(rows: list, max_shown: int = 6) -> str:
 	return f"{', '.join(str(r) for r in rows[:max_shown])}, ... {rows[-1]}"
 
 
+def _build_import_id_set(import_file: "ImportFile") -> set[str]:
+	"""IDs present in the template (used to validate self-referential tree parent links)."""
+	id_field = get_id_field(import_file.doctype)
+	id_column = next(
+		(
+			col
+			for col in import_file.header.columns
+			if col.df and col.df.fieldname == id_field.fieldname and not col.skip_import
+		),
+		None,
+	)
+	if not id_column:
+		return set()
+
+	ids = set()
+	for row in import_file.data:
+		value = row.get(id_column.index)
+		if value not in INVALID_VALUES:
+			ids.add(cstr(value).strip())
+	return ids
+
+
+def build_tree_preview(import_file: "ImportFile") -> frappe._dict | None:
+	"""Build a flat, depth-ordered node list for tree DocType import preview."""
+	meta = frappe.get_meta(import_file.doctype)
+	if not meta.is_nested_set():
+		return None
+
+	parent_field = meta.nsm_parent_field or f"parent_{frappe.scrub(import_file.doctype)}"
+	id_field = get_id_field(import_file.doctype)
+	id_fieldname = id_field.fieldname
+	label_fieldname = meta.title_field or id_fieldname
+	is_group_field = "is_group" if meta.has_field("is_group") else None
+	parent_column = next(
+		(
+			col
+			for col in import_file.header.columns
+			if col.df and col.df.fieldname == parent_field and not col.skip_import
+		),
+		None,
+	)
+
+	nodes = []
+	id_to_rows: dict[str, list[int]] = {}
+
+	for row in import_file.data:
+		doc = row.parse_doc(import_file.doctype)
+		if not doc:
+			continue
+
+		node_id = doc.get(id_fieldname)
+		if node_id in INVALID_VALUES:
+			continue
+
+		node_id = cstr(node_id).strip()
+		parent = _get_tree_parent_value(row, parent_column, doc, parent_field)
+
+		label = doc.get(label_fieldname) or node_id
+		label = cstr(label).strip() if label not in INVALID_VALUES else node_id
+
+		is_group = cint(doc.get(is_group_field)) if is_group_field else 0
+
+		id_to_rows.setdefault(node_id, []).append(row.row_number)
+		nodes.append(
+			frappe._dict(
+				id=node_id,
+				label=label,
+				parent=parent,
+				row_number=row.row_number,
+				is_group=is_group,
+				warnings=[],
+			)
+		)
+
+	tree_warnings = []
+	nodes_by_id = {node.id: node for node in nodes}
+
+	for node_id, row_numbers in id_to_rows.items():
+		if len(row_numbers) > 1:
+			message = _("Duplicate ID {0} in rows {1}").format(
+				frappe.bold(node_id), format_row_numbers_for_warning(row_numbers)
+			)
+			tree_warnings.append({"message": message})
+			for node in nodes:
+				if node.id == node_id:
+					node.warnings.append(message)
+
+	for node in nodes:
+		parent_id = node.parent
+		if not parent_id:
+			continue
+
+		if parent_id in nodes_by_id:
+			if _has_parent_cycle(node.id, nodes_by_id):
+				message = _("Circular parent reference for {0}").format(frappe.bold(node.id))
+				node.warnings.append(message)
+				if not any(w.get("message") == message for w in tree_warnings):
+					tree_warnings.append({"row": node.row_number, "message": message})
+			continue
+
+		parent_exists = frappe.db.exists(import_file.doctype, parent_id)
+		if import_file.import_type == UPDATE or parent_exists:
+			continue
+
+		message = _("Parent {0} not found in file").format(frappe.bold(parent_id))
+		node.warnings.append(message)
+		tree_warnings.append({"row": node.row_number, "message": message})
+
+	display_nodes = _order_tree_preview_nodes(nodes)
+
+	return frappe._dict(
+		nodes=display_nodes,
+		tree_warnings=tree_warnings,
+		total_nodes=len(nodes),
+	)
+
+
+def _get_tree_parent_value(row: "Row", parent_column, doc: frappe._dict, parent_field: str):
+	"""Parent link values are often unset in preview because targets are not in DB yet."""
+	if parent_column:
+		value = row.get(parent_column.index)
+		if value not in INVALID_VALUES:
+			return cstr(value).strip()
+
+	value = doc.get(parent_field)
+	return cstr(value).strip() if value not in INVALID_VALUES else None
+
+
+def _has_parent_cycle(node_id: str, nodes_by_id: dict) -> bool:
+	seen = set()
+	current = node_id
+	while current:
+		if current in seen:
+			return True
+		seen.add(current)
+		node = nodes_by_id.get(current)
+		if not node or not node.parent or node.parent not in nodes_by_id:
+			return False
+		current = node.parent
+	return False
+
+
+def sort_tree_payloads(payloads: list, doctype: str, import_type: str | None) -> list:
+	"""Return payloads in parent-before-child order for nested-set inserts."""
+	meta = frappe.get_meta(doctype)
+	if import_type != INSERT or not meta.is_nested_set() or not payloads:
+		return payloads
+
+	parent_field = meta.nsm_parent_field or f"parent_{frappe.scrub(doctype)}"
+	id_fieldname = get_id_field(doctype).fieldname
+
+	def get_payload_id(payload):
+		value = payload.doc.get(id_fieldname)
+		if value in INVALID_VALUES:
+			return None
+		return cstr(value).strip()
+
+	def get_payload_parent(payload):
+		value = payload.doc.get(parent_field)
+		if value in INVALID_VALUES:
+			return None
+		return cstr(value).strip()
+
+	payload_by_id = {node_id: payload for payload in payloads if (node_id := get_payload_id(payload))}
+
+	children_by_parent: dict[str, list] = {}
+	roots = []
+
+	for payload in payloads:
+		node_id = get_payload_id(payload)
+		if not node_id:
+			continue
+		parent = get_payload_parent(payload)
+		if parent and parent in payload_by_id:
+			children_by_parent.setdefault(parent, []).append(payload)
+		else:
+			roots.append(payload)
+
+	for children in children_by_parent.values():
+		children.sort(key=lambda payload: payload.rows[0].row_number)
+	roots.sort(key=lambda payload: payload.rows[0].row_number)
+
+	ordered = []
+	seen = set()
+
+	def walk(parent_id):
+		for child in children_by_parent.get(parent_id, []):
+			node_id = get_payload_id(child)
+			if not node_id or node_id in seen:
+				continue
+			seen.add(node_id)
+			ordered.append(child)
+			walk(node_id)
+
+	for root in roots:
+		node_id = get_payload_id(root)
+		if not node_id or node_id in seen:
+			continue
+		seen.add(node_id)
+		ordered.append(root)
+		walk(node_id)
+
+	for payload in payloads:
+		node_id = get_payload_id(payload)
+		if node_id:
+			if node_id not in seen:
+				ordered.append(payload)
+		else:
+			ordered.append(payload)
+
+	return ordered
+
+
+def _order_tree_preview_nodes(nodes: list) -> list:
+	children_by_parent: dict[str | None, list] = {}
+	nodes_by_id = {}
+
+	for node in nodes:
+		nodes_by_id[node.id] = node
+		children_by_parent.setdefault(node.parent or None, []).append(node)
+
+	for children in children_by_parent.values():
+		children.sort(key=lambda n: n.row_number)
+
+	ordered = []
+	seen = set()
+
+	def walk(parent_id, depth):
+		for child in children_by_parent.get(parent_id, []):
+			if child.id in seen:
+				continue
+			seen.add(child.id)
+			child.depth = depth
+			ordered.append(child)
+			walk(child.id, depth + 1)
+
+	walk(None, 0)
+
+	for node in nodes:
+		if node.id not in seen:
+			node.depth = 0
+			node.orphan = True
+			ordered.append(node)
+
+	return ordered
+
+
 class Row:
 	def __init__(self, index, row, doctype, header, import_type):
 		self.index = index
@@ -834,6 +1104,13 @@ class Row:
 				return
 
 		elif df.fieldtype == "Link":
+			if (
+				df.options == self.doctype
+				and getattr(self.header, "import_ids", None)
+				and cstr(value).strip() in self.header.import_ids
+			):
+				return value
+
 			exists = self.link_exists(value, df)
 			if not exists:
 				msg = _('"{0}" is not a valid {1}').format(

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -823,6 +823,7 @@ def build_tree_preview(import_file: "ImportFile") -> frappe._dict | None:
 
 	tree_warnings = []
 	nodes_by_id = {node.id: node for node in nodes}
+	import_ids = getattr(import_file.header, "import_ids", None) or set()
 
 	for node_id, row_numbers in id_to_rows.items():
 		if len(row_numbers) > 1:
@@ -845,6 +846,9 @@ def build_tree_preview(import_file: "ImportFile") -> frappe._dict | None:
 				node.warnings.append(message)
 				if not any(w.get("message") == message for w in tree_warnings):
 					tree_warnings.append({"row": node.row_number, "message": message})
+			continue
+
+		if parent_id in import_ids:
 			continue
 
 		parent_exists = frappe.db.exists(import_file.doctype, parent_id)
@@ -962,10 +966,8 @@ def sort_tree_payloads(payloads: list, doctype: str, import_type: str | None) ->
 
 def _order_tree_preview_nodes(nodes: list) -> list:
 	children_by_parent: dict[str | None, list] = {}
-	nodes_by_id = {}
 
 	for node in nodes:
-		nodes_by_id[node.id] = node
 		children_by_parent.setdefault(node.parent or None, []).append(node)
 
 	for children in children_by_parent.values():

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -2,7 +2,10 @@
 # License: MIT. See LICENSE
 import frappe
 from frappe.core.doctype.data_import.importer import (
+	ACTION_INSERT,
+	ACTION_UPDATE,
 	INSERT,
+	UPSERT,
 	Column,
 	Importer,
 	_get_tree_node_key,
@@ -15,6 +18,38 @@ from frappe.tests.test_query_builder import db_type_is, unimplemented_for
 from frappe.utils import format_duration, getdate
 
 doctype_name = "DocType for Import"
+SAMPLE_IMPORT_DOC_NAMES = ("Test", "Test 2", "Test 3")
+
+
+def _delete_data_import(data_import_name):
+	"""Remove a persisted Data Import and its logs after integration tests."""
+	if not data_import_name or not frappe.db.exists("Data Import", data_import_name):
+		return
+	frappe.db.delete("Data Import Log", {"data_import": data_import_name})
+	frappe.delete_doc("Data Import", data_import_name, force=1, ignore_permissions=True)
+	frappe.db.commit()  # nosemgrep
+
+
+def _delete_file(file_name):
+	if not file_name or not frappe.db.exists("File", file_name):
+		return
+	frappe.delete_doc("File", file_name, force=1, ignore_permissions=True)
+	frappe.db.commit()  # nosemgrep
+
+
+def _delete_doctype_records(doctype, names):
+	for name in names:
+		if name:
+			frappe.delete_doc_if_exists(doctype, name, force=1)
+	frappe.db.commit()  # nosemgrep
+
+
+def _register_data_import_cleanup(test_case, data_import):
+	test_case.addCleanup(_delete_data_import, data_import.name)
+
+
+def _register_file_cleanup(test_case, file_doc):
+	test_case.addCleanup(_delete_file, file_doc.name)
 
 
 class TestImporter(IntegrationTestCase):
@@ -26,6 +61,7 @@ class TestImporter(IntegrationTestCase):
 		)
 
 	def test_data_import_from_file(self):
+		self.addCleanup(_delete_doctype_records, doctype_name, SAMPLE_IMPORT_DOC_NAMES)
 		import_file = get_import_file("sample_import_file")
 		data_import = self.get_importer(doctype_name, import_file)
 		data_import.start_import()
@@ -59,7 +95,8 @@ class TestImporter(IntegrationTestCase):
 		self.assertEqual(format_duration(doc3.duration), "5d 5h 45m")
 
 	def test_skip_rows_during_import(self):
-		for name in ("Test", "Test 2", "Test 3"):
+		self.addCleanup(_delete_doctype_records, doctype_name, ("Test 2", "Test 3"))
+		for name in SAMPLE_IMPORT_DOC_NAMES:
 			frappe.delete_doc_if_exists(doctype_name, name)
 		frappe.db.commit()  # ensure deletions are flushed to DB before import; # nosemgrep
 
@@ -158,6 +195,7 @@ class TestImporter(IntegrationTestCase):
 		)
 		existing_doc.save()
 		frappe.db.commit()  # ensure saved document is visible to other DB connections; # nosemgrep
+		self.addCleanup(_delete_doctype_records, doctype_name, [existing_doc.name])
 
 		import_file = get_import_file("sample_import_file_for_update")
 		data_import = self.get_importer(doctype_name, import_file, update=True)
@@ -182,6 +220,65 @@ class TestImporter(IntegrationTestCase):
 		self.assertEqual(updated_doc.table_field_1[0].name, existing_doc.table_field_1[0].name)
 		self.assertEqual(updated_doc.table_field_1[0].child_description, "child description")
 		self.assertEqual(updated_doc.table_field_1_again[0].child_title, "child title again")
+
+	def test_data_import_upsert(self):
+		existing_doc = frappe.get_doc(
+			doctype=doctype_name,
+			title=frappe.generate_hash(length=8),
+			description="old description",
+		)
+		existing_doc.insert()
+		frappe.db.commit()  # nosemgrep
+
+		new_title = frappe.generate_hash(length=8)
+		self.addCleanup(_delete_doctype_records, doctype_name, [existing_doc.name, new_title])
+
+		import_file = get_import_file("sample_import_file_for_update")
+		data_import = self.get_importer(doctype_name, import_file, import_type=UPSERT)
+		i = Importer(data_import.reference_doctype, data_import=data_import)
+		if frappe.db.db_type == "mariadb":
+			i.import_file.raw_data[1][0] = existing_doc.name.upper()
+		else:
+			i.import_file.raw_data[1][0] = existing_doc.name
+		i.import_file.raw_data.append(
+			[
+				new_title,
+				"new description",
+				1,
+				2,
+				"",
+				"child title",
+				"child description",
+				"child title",
+				"14-08-2019",
+				4,
+				"child title again",
+				"22-09-2020",
+				5,
+				7,
+			]
+		)
+		i.import_file.parse_data_from_template()
+		i.import_data()
+
+		updated_doc = frappe.get_doc(doctype_name, existing_doc.name)
+		self.assertEqual(existing_doc.title, updated_doc.title)
+		self.assertEqual(updated_doc.description, "test description")
+
+		self.assertTrue(frappe.db.exists(doctype_name, new_title))
+		new_doc = frappe.get_doc(doctype_name, new_title)
+		self.assertEqual(new_doc.description, "new description")
+
+		import_logs = frappe.get_all(
+			"Data Import Log",
+			fields=["import_action", "docname", "success"],
+			filters={"data_import": data_import.name, "success": 1},
+			order_by="log_index",
+		)
+		self.assertEqual(len(import_logs), 2)
+		actions_by_docname = {log.docname: log.import_action for log in import_logs}
+		self.assertEqual(actions_by_docname[existing_doc.name], ACTION_UPDATE)
+		self.assertEqual(actions_by_docname[new_title], ACTION_INSERT)
 
 	def test_mapped_select_still_shows_warning_but_unmapped_blocks_import(self):
 		from frappe.core.doctype.data_import.value_mapping import (
@@ -277,6 +374,8 @@ class TestImporter(IntegrationTestCase):
 			}
 		)
 		data_import.insert()
+		_register_data_import_cleanup(self, data_import)
+		_register_file_cleanup(self, import_file)
 
 		self.assertEqual(len(data_import.value_mappings), 1)
 		self.assertEqual(data_import.value_mappings[0].fieldname, "status")
@@ -389,14 +488,18 @@ class TestImporter(IntegrationTestCase):
 		self.assertIn(expected_id_key, fields_dict, "ID fallback failed")
 		table_field.label = original_label  # maintain sanity in test env
 
-	def get_importer(self, doctype, import_file, update=False, use_sniffer=False):
+	def get_importer(self, doctype, import_file, update=False, use_sniffer=False, import_type=None):
 		data_import = frappe.new_doc("Data Import")
-		data_import.import_type = "Insert New Records" if not update else "Update Existing Records"
+		if import_type:
+			data_import.import_type = import_type
+		else:
+			data_import.import_type = "Insert New Records" if not update else "Update Existing Records"
 		data_import.reference_doctype = doctype
 		data_import.import_file = import_file.file_url
 		data_import.use_csv_sniffer = use_sniffer
 		data_import.insert()
 		frappe.db.commit()  # Commit so that the first import failure does not rollback the Data Import insert.  # nosemgrep
+		_register_data_import_cleanup(self, data_import)
 
 		return data_import
 
@@ -410,6 +513,7 @@ class TestImporter(IntegrationTestCase):
 		data_import.delimiter_options = ","
 		data_import.insert()
 		frappe.db.commit()  # nosemgrep
+		_register_data_import_cleanup(self, data_import)
 
 		return data_import
 
@@ -580,6 +684,8 @@ class TestTreeDataImport(IntegrationTestCase):
 		data_import.import_file = file_doc.file_url
 		data_import.insert()
 		frappe.db.commit()  # Ensure Data Import insert is persisted before subsequent operations; # nosemgrep
+		_register_data_import_cleanup(self, data_import)
+		_register_file_cleanup(self, file_doc)
 		return data_import
 
 	def test_tree_preview_and_payload_order(self):
@@ -603,8 +709,11 @@ class TestTreeDataImport(IntegrationTestCase):
 	def test_tree_import(self):
 		meta = frappe.get_meta(self.doctype_name)
 		parent_field = meta.nsm_parent_field
+		tree_doc_names = ("Root", "Division", "Leaf")
 
-		for name in ("Root", "Division", "Leaf"):
+		# Delete children before parents for nested-set doctypes.
+		self.addCleanup(_delete_doctype_records, self.doctype_name, tuple(reversed(tree_doc_names)))
+		for name in reversed(tree_doc_names):
 			frappe.delete_doc_if_exists(self.doctype_name, name)
 		frappe.db.commit()  # ensure deletions are flushed to DB before import; # nosemgrep
 
@@ -687,10 +796,12 @@ class TestTreeAliasDataImport(IntegrationTestCase):
 		data_import.import_file = file_doc.file_url
 		data_import.insert()
 		frappe.db.commit()  # Ensure Data Import insert is persisted before subsequent operations; # nosemgrep
+		_register_data_import_cleanup(self, data_import)
+		_register_file_cleanup(self, file_doc)
 		return data_import
 
 	def _cleanup_docs(self, labels):
-		for label in labels:
+		for label in reversed(labels):
 			name = frappe.db.get_value(self.doctype_name, {"node_label": label})
 			if name:
 				frappe.delete_doc(self.doctype_name, name, force=1)
@@ -726,6 +837,7 @@ class TestTreeAliasDataImport(IntegrationTestCase):
 		parent_field = meta.nsm_parent_field
 		labels = ("Root Node", "Child Node")
 		self._cleanup_docs(labels)
+		self.addCleanup(self._cleanup_docs, labels)
 
 		rows = [
 			("Child Node", "0", "Root Node"),

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -519,3 +519,92 @@ def get_import_file(csv_file_name, force=False):
 
 def get_csv_file_path(file_name):
 	return frappe.get_app_path("frappe", "core", "doctype", "data_import", "fixtures", file_name)
+
+
+class TestTreeDataImport(IntegrationTestCase):
+	doctype_name = "Test Tree Data Import"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls._ensure_tree_doctype()
+
+	@classmethod
+	def _ensure_tree_doctype(cls):
+		if frappe.db.exists("DocType", cls.doctype_name):
+			return
+
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		dt = new_doctype(
+			cls.doctype_name,
+			is_tree=True,
+			autoname="field:node_name",
+			fields=[{"label": "Node Name", "fieldname": "node_name", "fieldtype": "Data", "reqd": 1}],
+		)
+		dt.allow_import = 1
+		dt.insert()
+
+	def _parent_label(self):
+		meta = frappe.get_meta(self.doctype_name)
+		parent_field = meta.nsm_parent_field
+		return meta.get_field(parent_field).label
+
+	def _make_csv_file(self, rows):
+		parent_label = self._parent_label()
+		lines = [f"Node Name,Is Group,{parent_label}"] + [",".join(row) for row in rows]
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": f"{frappe.generate_hash(length=10)}.csv",
+				"content": "\n".join(lines),
+				"is_private": 1,
+			}
+		)
+		file_doc.save(ignore_permissions=True)
+		return file_doc
+
+	def _get_importer(self, file_doc):
+		data_import = frappe.new_doc("Data Import")
+		data_import.import_type = "Insert New Records"
+		data_import.reference_doctype = self.doctype_name
+		data_import.import_file = file_doc.file_url
+		data_import.insert()
+		frappe.db.commit()
+		return data_import
+
+	def test_tree_preview_and_payload_order(self):
+		rows = [
+			("Leaf", "0", "Division"),
+			("Division", "1", "Root"),
+			("Root", "1", ""),
+		]
+		data_import = self._get_importer(self._make_csv_file(rows))
+		preview = data_import.get_preview_from_template()
+
+		self.assertIsNotNone(preview.tree_preview)
+		self.assertEqual(preview.tree_preview.total_nodes, 3)
+		node_ids = [node.id for node in preview.tree_preview.nodes]
+		self.assertEqual(node_ids, ["Root", "Division", "Leaf"])
+
+		imp = Importer(self.doctype_name, data_import=data_import)
+		payload_ids = [p.doc.node_name for p in imp.import_file.get_payloads_for_import()]
+		self.assertEqual(payload_ids, ["Root", "Division", "Leaf"])
+
+	def test_tree_import(self):
+		meta = frappe.get_meta(self.doctype_name)
+		parent_field = meta.nsm_parent_field
+
+		for name in ("Root", "Division", "Leaf"):
+			frappe.delete_doc_if_exists(self.doctype_name, name)
+		frappe.db.commit()
+
+		rows = [
+			("Root", "1", ""),
+			("Division", "1", "Root"),
+			("Leaf", "0", "Division"),
+		]
+		data_import = self._get_importer(self._make_csv_file(rows))
+		Importer(self.doctype_name, data_import=data_import).import_data()
+
+		self.assertEqual(frappe.db.get_value(self.doctype_name, "Leaf", parent_field), "Division")

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -5,7 +5,10 @@ from frappe.core.doctype.data_import.importer import (
 	INSERT,
 	Column,
 	Importer,
+	_get_tree_node_key,
 	build_fields_dict_for_column_matching,
+	get_tree_alias_fieldname,
+	uses_tree_alias_references,
 )
 from frappe.tests import IntegrationTestCase
 from frappe.tests.test_query_builder import db_type_is, unimplemented_for
@@ -608,3 +611,125 @@ class TestTreeDataImport(IntegrationTestCase):
 		Importer(self.doctype_name, data_import=data_import).import_data()
 
 		self.assertEqual(frappe.db.get_value(self.doctype_name, "Leaf", parent_field), "Division")
+
+	def test_field_autoname_tree_skips_alias_mode(self):
+		self.assertFalse(uses_tree_alias_references(self.doctype_name))
+		self.assertIsNone(get_tree_alias_fieldname(self.doctype_name))
+
+	def test_tree_preview_warns_non_group_parent(self):
+		rows = [
+			("Grandchild", "0", "Division"),
+			("Division", "0", "Root"),
+			("Root", "1", ""),
+		]
+		data_import = self._get_importer(self._make_csv_file(rows))
+		preview = data_import.get_preview_from_template()
+
+		division = next(node for node in preview.tree_preview.nodes if node.id == "Division")
+		self.assertTrue(division.warnings)
+		self.assertIn("Is Group is 0", division.warnings[0])
+
+
+class TestTreeAliasDataImport(IntegrationTestCase):
+	doctype_name = "Test Tree Alias Import"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls._ensure_tree_doctype()
+
+	@classmethod
+	def _ensure_tree_doctype(cls):
+		if frappe.db.exists("DocType", cls.doctype_name):
+			return
+
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		dt = new_doctype(
+			cls.doctype_name,
+			is_tree=True,
+			autoname="TAL-.#####",
+			title_field="node_label",
+			fields=[{"label": "Node Label", "fieldname": "node_label", "fieldtype": "Data", "reqd": 1}],
+		)
+		dt.allow_import = 1
+		dt.insert()
+
+	def _parent_label(self):
+		meta = frappe.get_meta(self.doctype_name)
+		parent_field = meta.nsm_parent_field
+		return meta.get_field(parent_field).label
+
+	def _make_csv_file(self, rows):
+		parent_label = self._parent_label()
+		lines = [f"Node Label,Is Group,{parent_label}"] + [",".join(row) for row in rows]
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": f"{frappe.generate_hash(length=10)}.csv",
+				"content": "\n".join(lines),
+				"is_private": 1,
+			}
+		)
+		file_doc.save(ignore_permissions=True)
+		return file_doc
+
+	def _get_importer(self, file_doc):
+		data_import = frappe.new_doc("Data Import")
+		data_import.import_type = "Insert New Records"
+		data_import.reference_doctype = self.doctype_name
+		data_import.import_file = file_doc.file_url
+		data_import.insert()
+		frappe.db.commit()
+		return data_import
+
+	def _cleanup_docs(self, labels):
+		for label in labels:
+			name = frappe.db.get_value(self.doctype_name, {"node_label": label})
+			if name:
+				frappe.delete_doc(self.doctype_name, name, force=1)
+		frappe.db.commit()
+
+	def test_series_autoname_tree_uses_alias_mode(self):
+		self.assertTrue(uses_tree_alias_references(self.doctype_name))
+		self.assertEqual(get_tree_alias_fieldname(self.doctype_name), "node_label")
+
+	def test_tree_alias_preview_and_payload_order(self):
+		rows = [
+			("Child Node", "0", "Root Node"),
+			("Root Node", "1", ""),
+		]
+		data_import = self._get_importer(self._make_csv_file(rows))
+		preview = data_import.get_preview_from_template()
+
+		self.assertIsNotNone(preview.tree_preview)
+		self.assertEqual(preview.tree_preview.total_nodes, 2)
+		node_ids = [node.id for node in preview.tree_preview.nodes]
+		self.assertEqual(node_ids, ["Root Node", "Child Node"])
+
+		imp = Importer(self.doctype_name, data_import=data_import)
+		header = imp.import_file.header
+		payload_keys = [
+			_get_tree_node_key(p.doc, header.id_fieldname, header.tree_alias_field)
+			for p in imp.import_file.get_payloads_for_import()
+		]
+		self.assertEqual(payload_keys, ["Root Node", "Child Node"])
+
+	def test_tree_alias_import(self):
+		meta = frappe.get_meta(self.doctype_name)
+		parent_field = meta.nsm_parent_field
+		labels = ("Root Node", "Child Node")
+		self._cleanup_docs(labels)
+
+		rows = [
+			("Child Node", "0", "Root Node"),
+			("Root Node", "1", ""),
+		]
+		data_import = self._get_importer(self._make_csv_file(rows))
+		Importer(self.doctype_name, data_import=data_import).import_data()
+
+		root_name = frappe.db.get_value(self.doctype_name, {"node_label": "Root Node"})
+		child_name = frappe.db.get_value(self.doctype_name, {"node_label": "Child Node"})
+		self.assertTrue(root_name)
+		self.assertTrue(child_name)
+		self.assertEqual(frappe.db.get_value(self.doctype_name, child_name, parent_field), root_name)

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -61,7 +61,7 @@ class TestImporter(IntegrationTestCase):
 	def test_skip_rows_during_import(self):
 		for name in ("Test", "Test 2", "Test 3"):
 			frappe.delete_doc_if_exists(doctype_name, name)
-		frappe.db.commit()
+		frappe.db.commit()  # ensure deletions are flushed to DB before import; # nosemgrep
 
 		import_file = get_import_file("sample_import_file")
 		data_import = self.get_importer(doctype_name, import_file)
@@ -157,7 +157,7 @@ class TestImporter(IntegrationTestCase):
 			table_field_1=[{"child_title": "child title to update"}],
 		)
 		existing_doc.save()
-		frappe.db.commit()
+		frappe.db.commit()  # ensure saved document is visible to other DB connections; # nosemgrep
 
 		import_file = get_import_file("sample_import_file_for_update")
 		data_import = self.get_importer(doctype_name, import_file, update=True)
@@ -389,8 +389,7 @@ class TestImporter(IntegrationTestCase):
 		data_import.import_file = import_file.file_url
 		data_import.use_csv_sniffer = use_sniffer
 		data_import.insert()
-		# Commit so that the first import failure does not rollback the Data Import insert.
-		frappe.db.commit()
+		frappe.db.commit()  # Commit so that the first import failure does not rollback the Data Import insert.  # nosemgrep
 
 		return data_import
 
@@ -573,7 +572,7 @@ class TestTreeDataImport(IntegrationTestCase):
 		data_import.reference_doctype = self.doctype_name
 		data_import.import_file = file_doc.file_url
 		data_import.insert()
-		frappe.db.commit()
+		frappe.db.commit()  # Ensure Data Import insert is persisted before subsequent operations; # nosemgrep
 		return data_import
 
 	def test_tree_preview_and_payload_order(self):
@@ -600,7 +599,7 @@ class TestTreeDataImport(IntegrationTestCase):
 
 		for name in ("Root", "Division", "Leaf"):
 			frappe.delete_doc_if_exists(self.doctype_name, name)
-		frappe.db.commit()
+		frappe.db.commit()  # ensure deletions are flushed to DB before import; # nosemgrep
 
 		rows = [
 			("Root", "1", ""),
@@ -680,7 +679,7 @@ class TestTreeAliasDataImport(IntegrationTestCase):
 		data_import.reference_doctype = self.doctype_name
 		data_import.import_file = file_doc.file_url
 		data_import.insert()
-		frappe.db.commit()
+		frappe.db.commit()  # Ensure Data Import insert is persisted before subsequent operations; # nosemgrep
 		return data_import
 
 	def _cleanup_docs(self, labels):
@@ -688,7 +687,7 @@ class TestTreeAliasDataImport(IntegrationTestCase):
 			name = frappe.db.get_value(self.doctype_name, {"node_label": label})
 			if name:
 				frappe.delete_doc(self.doctype_name, name, force=1)
-		frappe.db.commit()
+		frappe.db.commit()  # Ensure deletions are flushed to DB before continuing; # nosemgrep
 
 	def test_series_autoname_tree_uses_alias_mode(self):
 		self.assertTrue(uses_tree_alias_references(self.doctype_name))

--- a/frappe/core/doctype/data_import/value_mapping.py
+++ b/frappe/core/doctype/data_import/value_mapping.py
@@ -132,7 +132,15 @@ def get_invalid_link_select_items(col) -> list[dict]:
 				col.df.options, filters={"name": ("in", list({transform(k) for k in value_rows}))}
 			)
 		}
-		invalid_keys = [k for k in value_rows if transform(k) not in exists]
+		import_ids = getattr(col, "import_ids", None) or set()
+		allow_same_file_parents = col.df.options == col.doctype and import_ids
+		invalid_keys = []
+		for key in value_rows:
+			if transform(key) in exists:
+				continue
+			if allow_same_file_parents and normalize_source_value(key) in import_ids:
+				continue
+			invalid_keys.append(key)
 	elif col.df.fieldtype == "Select":
 		options = get_select_options(col.df)
 		if not options:

--- a/frappe/core/doctype/data_import/value_mapping.py
+++ b/frappe/core/doctype/data_import/value_mapping.py
@@ -133,13 +133,14 @@ def get_invalid_link_select_items(col) -> list[dict]:
 				col.df.options, filters={"name": ("in", list({transform(k) for k in value_rows}))}
 			)
 		}
-		import_ids = getattr(col, "import_ids", None) or set()
-		allow_same_file_parents = col.df.options == col.doctype and import_ids
+		import_refs = getattr(col, "import_refs", None)
+		allow_same_file_parents = col.df.options == col.doctype and import_refs
 		invalid_keys = []
 		for key in value_rows:
 			if transform(key) in exists:
 				continue
-			if allow_same_file_parents and normalize_source_value(key) in import_ids:
+			normalized_key = normalize_source_value(key)
+			if allow_same_file_parents and normalized_key in import_refs:
 				continue
 			invalid_keys.append(key)
 	elif col.df.fieldtype == "Select":

--- a/frappe/core/doctype/data_import_log/data_import_log.json
+++ b/frappe/core/doctype/data_import_log/data_import_log.json
@@ -4,10 +4,11 @@
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "MyISAM",
- "field_order": [
+  "field_order": [
   "data_import",
   "row_indexes",
   "success",
+  "import_action",
   "docname",
   "messages",
   "exception",
@@ -43,6 +44,12 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Success"
+  },
+  {
+   "fieldname": "import_action",
+   "fieldtype": "Select",
+   "label": "Import Action",
+   "options": "\nInsert\nUpdate"
   },
   {
    "fieldname": "log_index",

--- a/frappe/public/js/frappe/data_import/data_exporter.js
+++ b/frappe/public/js/frappe/data_import/data_exporter.js
@@ -1,5 +1,13 @@
 frappe.provide("frappe.data_import");
 
+function is_insert_import_type(import_type) {
+	return import_type === "Insert New Records";
+}
+
+function is_update_import_type(import_type) {
+	return import_type === "Update Existing Records" || import_type === "Insert or Update Records";
+}
+
 frappe.data_import.DataExporter = class DataExporter {
 	constructor(doctype, exporting_for, filetype = "CSV", hide_blank_template = false) {
 		this.doctype = doctype;
@@ -49,7 +57,7 @@ frappe.data_import.DataExporter = class DataExporter {
 							  ]
 					),
 					default:
-						this.exporting_for === "Insert New Records" && !this.hide_blank_template
+						is_insert_import_type(this.exporting_for) && !this.hide_blank_template
 							? "blank_template"
 							: "all",
 					change: () => {
@@ -151,7 +159,7 @@ frappe.data_import.DataExporter = class DataExporter {
 	}
 
 	make_select_all_buttons() {
-		let for_insert = this.exporting_for === "Insert New Records";
+		let for_insert = is_insert_import_type(this.exporting_for);
 		let section_title = for_insert
 			? __("Select Fields To Insert")
 			: __("Select Fields To Update");
@@ -207,8 +215,7 @@ frappe.data_import.DataExporter = class DataExporter {
 	}
 
 	unselect_all() {
-		let update_existing_records =
-			this.dialog.get_value("exporting_for") == "Update Existing Records";
+		let update_existing_records = is_update_import_type(this.exporting_for);
 		this.dialog.$wrapper
 			.find(`:checkbox${update_existing_records ? ":not([data-unit=name])" : ""}`)
 			.prop("checked", false)
@@ -283,14 +290,14 @@ frappe.data_import.DataExporter = class DataExporter {
 			autoname_field = frappe.meta.get_field(doctype, fieldname);
 		}
 		const hide_name_for_autoname =
-			this.exporting_for === "Insert New Records" &&
+			is_insert_import_type(this.exporting_for) &&
 			!this.hide_blank_template &&
 			!["Prompt", "prompt"].includes(meta.autoname);
 
 		let fields = child_fieldname ? this.column_map[child_fieldname] : this.column_map[doctype];
 
 		let is_field_mandatory = (df) => {
-			if (df.reqd && this.exporting_for == "Insert New Records") {
+			if (df.reqd && is_insert_import_type(this.exporting_for)) {
 				return true;
 			}
 			if (autoname_field && df.fieldname == autoname_field.fieldname) {
@@ -303,7 +310,7 @@ frappe.data_import.DataExporter = class DataExporter {
 		};
 
 		let is_field_depends_on = (df) => {
-			if (df.depends_on && this.exporting_for == "Insert New Records") {
+			if (df.depends_on && is_insert_import_type(this.exporting_for)) {
 				return true;
 			}
 			if (autoname_field && df.fieldname == autoname_field.fieldname) {
@@ -324,7 +331,7 @@ frappe.data_import.DataExporter = class DataExporter {
 		return fields
 			.filter((df) => {
 				if (
-					this.exporting_for === "Insert New Records" &&
+					is_insert_import_type(this.exporting_for) &&
 					(autoname_field || hide_name_for_autoname) &&
 					df.fieldname === "name"
 				) {

--- a/frappe/public/js/frappe/data_import/import_preview.js
+++ b/frappe/public/js/frappe/data_import/import_preview.js
@@ -162,6 +162,18 @@ frappe.data_import.ImportPreview = class ImportPreview {
 		});
 	}
 
+	/** Scroll to and highlight a sheet row in the table preview. */
+	highlight_table_row(row_number) {
+		const row_index = this.data.findIndex((row) => cint(row[0]) === cint(row_number));
+		if (row_index < 0 || !this.datatable) {
+			return;
+		}
+		this.datatable.style.setStyle(`.dt-row-${row_index} .dt-cell`, {
+			backgroundColor: frappe.ui.color.get_color_shade("yellow", "extra-light"),
+		});
+		frappe.utils.scroll_to(this.$table_preview.find(`.dt-row-${row_index}`), true, 30);
+	}
+
 	/** Row count below the preview table (always shown when data exists). */
 	render_table_message() {
 		const $message = this.wrapper.find(".table-message");

--- a/frappe/public/js/frappe/data_import/import_tree_preview.js
+++ b/frappe/public/js/frappe/data_import/import_tree_preview.js
@@ -17,15 +17,21 @@ frappe.data_import.ImportTreePreview = class ImportTreePreview {
 
 	refresh() {
 		const tree_preview = this.preview_data?.tree_preview;
-		if (!tree_preview?.nodes?.length) {
+		if (!tree_preview) {
 			this.wrapper.empty();
 			return;
 		}
 
-		const { roots, children_by_parent } = this._build_tree(tree_preview.nodes);
-		const total_nodes = tree_preview.total_nodes || tree_preview.nodes.length;
+		const nodes = tree_preview.nodes || [];
+		if (!nodes.length) {
+			this.wrapper.html(this.get_status_banner_html(tree_preview));
+			return;
+		}
+
+		const total_nodes = tree_preview.total_nodes ?? nodes.length;
 		const footer =
 			total_nodes === 1 ? __("1 node") : __("Tree preview of {0} nodes", [total_nodes]);
+		const { roots, children_by_parent } = this._build_tree(nodes);
 		const root_label = __("{0} Tree", [__(this.doctype)]);
 		const root_icon = roots.length
 			? `<span class="node-parent">${this.icon_set.open}</span>`
@@ -33,23 +39,22 @@ frappe.data_import.ImportTreePreview = class ImportTreePreview {
 
 		this.wrapper.html(`
 			<div class="import-tree-preview-panel">
-				<div class="import-tree-container">
-					<div class="import-tree-header">
-						<div class="import-tree-title">
-							${root_icon}
-							<span class="import-tree-doctype-label">${frappe.utils.escape_html(root_label)}</span>
-						</div>
-						<div class="btn-group import-tree-preview-toolbar">
-							<button type="button" class="btn btn-default btn-xs" data-action="expand_all">
-								${__("Expand All")}
-							</button>
-							<button type="button" class="btn btn-default btn-xs" data-action="collapse_all">
-								${__("Collapse All")}
-							</button>
-						</div>
+				${this.get_status_banner_html(tree_preview)}
+				<div class="import-tree-header">
+					<div class="import-tree-title">
+						${root_icon}
+						<span class="import-tree-doctype-label">${frappe.utils.escape_html(root_label)}</span>
 					</div>
-					<div class="import-tree-body"></div>
+					<div class="btn-group">
+						<button type="button" class="btn btn-default btn-xs" data-action="expand_all">
+							${__("Expand All")}
+						</button>
+						<button type="button" class="btn btn-default btn-xs" data-action="collapse_all">
+							${__("Collapse All")}
+						</button>
+					</div>
 				</div>
+				<div class="import-tree-body"></div>
 				<div class="text-muted margin-top text-medium">${footer}</div>
 			</div>
 		`);
@@ -61,6 +66,39 @@ frappe.data_import.ImportTreePreview = class ImportTreePreview {
 		roots.forEach((node) => this.render_node(node, $root_children, children_by_parent));
 
 		frappe.utils.bind_actions_with_object(this.wrapper, this);
+	}
+
+	/** Issue banner only (empty nodes or tree structure warnings). */
+	get_status_banner_html(tree_preview) {
+		const nodes = tree_preview.nodes || [];
+		const warning_count = tree_preview.tree_warnings?.length || 0;
+
+		if (!nodes.length) {
+			return this.get_form_message_html(
+				__("No valid tree nodes found in the import file."),
+				"yellow"
+			);
+		}
+
+		if (!warning_count) {
+			return "";
+		}
+
+		const warning_label =
+			warning_count === 1
+				? __("1 tree structure warning found.")
+				: __("{0} tree structure warnings found.", [warning_count]);
+
+		return this.get_form_message_html(
+			`${warning_label}<br/>${__(
+				"See warning icons on nodes below or check the Warnings section."
+			)}`,
+			"yellow"
+		);
+	}
+
+	get_form_message_html(message, color) {
+		return `<div class="form-message ${color} import-tree-status-alert"><div>${message}</div></div>`;
 	}
 
 	_build_tree(nodes) {
@@ -165,6 +203,7 @@ frappe.data_import.ImportTreePreview = class ImportTreePreview {
 		$tree.find(".tree-node, .tree").addClass("opened");
 		$tree.find(".tree-children").show();
 		$tree.find(".node-parent").html(this.icon_set.open);
+		this._set_header_folder_icon(true);
 	}
 
 	collapse_all() {
@@ -173,6 +212,13 @@ frappe.data_import.ImportTreePreview = class ImportTreePreview {
 		$tree.find(".tree-children").hide();
 		$tree.find(".node-parent").html(this.icon_set.closed);
 		$tree.children(".tree-children").show();
-		this.wrapper.find(".import-tree-header .node-parent").html(this.icon_set.closed);
+		this._set_header_folder_icon(false);
+	}
+
+	_set_header_folder_icon(open) {
+		const $icon = this.wrapper.find(".import-tree-header .node-parent");
+		if ($icon.length) {
+			$icon.html(open ? this.icon_set.open : this.icon_set.closed);
+		}
 	}
 };

--- a/frappe/public/js/frappe/data_import/import_tree_preview.js
+++ b/frappe/public/js/frappe/data_import/import_tree_preview.js
@@ -1,0 +1,178 @@
+frappe.provide("frappe.data_import");
+
+/** Static tree preview using the same markup and styles as desk Tree View. */
+frappe.data_import.ImportTreePreview = class ImportTreePreview {
+	constructor({ wrapper, doctype, preview_data, on_row_click }) {
+		this.wrapper = wrapper;
+		this.doctype = doctype;
+		this.preview_data = preview_data;
+		this.on_row_click = on_row_click;
+		this.icon_set = {
+			open: frappe.utils.icon("folder-open", "md"),
+			closed: frappe.utils.icon("folder-normal", "md"),
+			leaf: frappe.utils.icon("primitive-dot", "xs"),
+		};
+		this.refresh();
+	}
+
+	refresh() {
+		const tree_preview = this.preview_data?.tree_preview;
+		if (!tree_preview?.nodes?.length) {
+			this.wrapper.empty();
+			return;
+		}
+
+		const { roots, children_by_parent } = this._build_tree(tree_preview.nodes);
+		const total_nodes = tree_preview.total_nodes || tree_preview.nodes.length;
+		const footer =
+			total_nodes === 1 ? __("1 node") : __("Tree preview of {0} nodes", [total_nodes]);
+		const root_label = __("{0} Tree", [__(this.doctype)]);
+		const root_icon = roots.length
+			? `<span class="node-parent">${this.icon_set.open}</span>`
+			: "";
+
+		this.wrapper.html(`
+			<div class="import-tree-preview-panel">
+				<div class="import-tree-container">
+					<div class="import-tree-header">
+						<div class="import-tree-title">
+							${root_icon}
+							<span class="import-tree-doctype-label">${frappe.utils.escape_html(root_label)}</span>
+						</div>
+						<div class="btn-group import-tree-preview-toolbar">
+							<button type="button" class="btn btn-default btn-xs" data-action="expand_all">
+								${__("Expand All")}
+							</button>
+							<button type="button" class="btn btn-default btn-xs" data-action="collapse_all">
+								${__("Collapse All")}
+							</button>
+						</div>
+					</div>
+					<div class="import-tree-body"></div>
+				</div>
+				<div class="text-muted margin-top text-medium">${footer}</div>
+			</div>
+		`);
+
+		const $tree = $('<div class="tree with-skeleton">').appendTo(
+			this.wrapper.find(".import-tree-body")
+		);
+		const $root_children = $('<ul class="tree-children">').appendTo($tree);
+		roots.forEach((node) => this.render_node(node, $root_children, children_by_parent));
+
+		frappe.utils.bind_actions_with_object(this.wrapper, this);
+	}
+
+	_build_tree(nodes) {
+		const nodes_by_id = {};
+		nodes.forEach((node) => {
+			nodes_by_id[node.id] = node;
+		});
+
+		const children_by_parent = {};
+		const roots = [];
+
+		for (const node of nodes) {
+			const parent_id = node.parent;
+			if (node.orphan || (parent_id && !nodes_by_id[parent_id])) {
+				roots.push(node);
+			} else if (!parent_id) {
+				roots.push(node);
+			} else {
+				children_by_parent[parent_id] = children_by_parent[parent_id] || [];
+				children_by_parent[parent_id].push(node);
+			}
+		}
+
+		return { roots, children_by_parent };
+	}
+
+	render_node(node, $parent, children_by_parent) {
+		const children = children_by_parent[node.id] || [];
+		const expandable = cint(node.is_group) || children.length > 0;
+		const $li = $('<li class="tree-node">').appendTo($parent);
+
+		if (expandable && children.length) {
+			$li.addClass("opened");
+		}
+
+		const $link = $('<span class="tree-link">').appendTo($li);
+		const icon_html = expandable
+			? `<span class="node-parent">${
+					children.length ? this.icon_set.open : this.icon_set.closed
+			  }</span>`
+			: `<span>${this.icon_set.leaf}</span>`;
+		$(icon_html).appendTo($link);
+
+		$(`<a class="tree-label" data-name="${frappe.utils.escape_html(node.id)}">`)
+			.html(this.get_node_label_html(node))
+			.appendTo($link);
+
+		const $children = $('<ul class="tree-children">').appendTo($li);
+		children.forEach((child) => this.render_node(child, $children, children_by_parent));
+
+		if (!expandable || !children.length) {
+			$children.hide();
+		}
+
+		$link.on("click", (e) => {
+			e.preventDefault();
+			if (expandable && children.length) {
+				this.toggle_children($li, $link, $children);
+			}
+			frappe.dom.activate($link.closest(".tree"), $link, "tree-link");
+			this.on_row_click?.(node.row_number);
+		});
+
+		$link.hover(
+			() => $li.addClass("hover-active"),
+			() => $li.removeClass("hover-active")
+		);
+
+		if (node.orphan) {
+			$li.addClass("import-tree-node-orphan");
+		}
+	}
+
+	get_node_label_html(node) {
+		let label = frappe.utils.escape_html(node.label);
+		if (node.warnings?.length) {
+			const title = frappe.utils.escape_html(node.warnings.join(" "));
+			label += ` <span class="text-warning" title="${title}">${frappe.utils.icon(
+				"warning-sign",
+				"sm"
+			)}</span>`;
+		}
+		if (node.orphan) {
+			label += ` <span class="text-muted">(${__("unlinked")})</span>`;
+		}
+		label += ` <span class="text-muted import-tree-row-number">#${node.row_number}</span>`;
+		return label;
+	}
+
+	toggle_children($parent, $link, $children) {
+		const is_open = $parent.hasClass("opened");
+		$parent.toggleClass("opened", !is_open);
+		$children.toggle(!is_open);
+		const $icon_parent = $link.find(".node-parent");
+		if ($icon_parent.length) {
+			$icon_parent.html(!is_open ? this.icon_set.open : this.icon_set.closed);
+		}
+	}
+
+	expand_all() {
+		const $tree = this.wrapper.find(".tree");
+		$tree.find(".tree-node, .tree").addClass("opened");
+		$tree.find(".tree-children").show();
+		$tree.find(".node-parent").html(this.icon_set.open);
+	}
+
+	collapse_all() {
+		const $tree = this.wrapper.find(".tree");
+		$tree.find(".tree-node").removeClass("opened");
+		$tree.find(".tree-children").hide();
+		$tree.find(".node-parent").html(this.icon_set.closed);
+		$tree.children(".tree-children").show();
+		this.wrapper.find(".import-tree-header .node-parent").html(this.icon_set.closed);
+	}
+};

--- a/frappe/public/js/frappe/data_import/index.js
+++ b/frappe/public/js/frappe/data_import/index.js
@@ -1,2 +1,3 @@
 import "./import_preview";
+import "./import_tree_preview";
 import "./data_exporter";

--- a/frappe/public/scss/desk/data_import.scss
+++ b/frappe/public/scss/desk/data_import.scss
@@ -35,21 +35,17 @@
 	}
 }
 
-.import-tree-preview-panel {
-	.import-tree-container {
-		border: 1px solid var(--border-color);
-		border-radius: var(--border-radius);
-		background-color: var(--card-bg);
-		overflow: hidden;
-	}
+.import-tree-status-alert {
+	margin-bottom: var(--margin-sm);
+}
 
+.import-tree-preview-panel {
 	.import-tree-header {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		gap: var(--margin-md);
-		padding: var(--padding-sm) var(--padding-md);
-		border-bottom: 1px solid var(--border-color);
+		margin-bottom: var(--margin-xs);
 	}
 
 	.import-tree-title {

--- a/frappe/public/scss/desk/data_import.scss
+++ b/frappe/public/scss/desk/data_import.scss
@@ -34,3 +34,52 @@
 		background-color: unset;
 	}
 }
+
+.import-tree-preview-panel {
+	.import-tree-container {
+		border: 1px solid var(--border-color);
+		border-radius: var(--border-radius);
+		background-color: var(--card-bg);
+		overflow: hidden;
+	}
+
+	.import-tree-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--margin-md);
+		padding: var(--padding-sm) var(--padding-md);
+		border-bottom: 1px solid var(--border-color);
+	}
+
+	.import-tree-title {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--margin-sm);
+		min-width: 0;
+	}
+
+	.import-tree-doctype-label {
+		font-size: var(--text-lg);
+		font-weight: 600;
+		color: var(--text-color);
+		line-height: 1.4;
+	}
+
+	.import-tree-body {
+		max-height: 380px;
+		overflow: auto;
+
+		.tree {
+			padding: var(--padding-sm);
+		}
+	}
+
+	.import-tree-row-number {
+		font-weight: normal;
+	}
+
+	.import-tree-node-orphan > .tree-link .tree-label {
+		color: var(--orange-600);
+	}
+}


### PR DESCRIPTION

Closes [#33450](https://github.com/frappe/frappe/issues/33450).

Note: Please merge this https://github.com/frappe/frappe/pull/39833 before reviewing this PR.

1. Adds an upsert import type to Data Import: update existing records by ID/autoname field, insert when missing. Unchanged existing rows succeed without error.

2. New import type: Insert or Update Records (UI, CLI --type Upsert, template export)
import_action on Data Import Log (Insert / Update) with per-row and summary counts in the UI

Screenshots:
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/a4130acd-ff2b-4c6b-9416-78dd26f130c4" />
<img width="1148" height="368" alt="image" src="https://github.com/user-attachments/assets/71ad91a8-fd60-4f0e-8e93-f5d6e32f119e" />

Maintaining the log how many inserted and how many updated

`no-docs`