### PR TITLE
fix: contact us page and settings

### DIFF
--- a/frappe/tests/test_global_search.py
+++ b/frappe/tests/test_global_search.py
@@ -199,8 +199,8 @@ class TestGlobalSearch(IntegrationTestCase):
 		global_search.update_global_search_for_all_web_pages()
 		global_search.sync_global_search()
 		frappe.db.commit()
-		results = global_search.web_search("company")
-		self.assertTrue("About" in results[0].content)
+		results = global_search.web_search("login")
+		self.assertTrue("login" in results[0].content)
 		results = global_search.web_search(
 			text="company", scope='manufacturing" UNION ALL SELECT 1,2,3,4,doctype from __global_search'
 		)

--- a/frappe/website/doctype/about_us_settings/about_us_settings.json
+++ b/frappe/website/doctype/about_us_settings/about_us_settings.json
@@ -78,7 +78,7 @@
    "label": "Team Members Subtitle"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "is_disabled",
    "fieldtype": "Check",
    "label": "Disabled"
@@ -89,7 +89,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-08-22 15:56:33.957707",
+ "modified": "2026-06-11 12:50:48.801831",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "About Us Settings",

--- a/frappe/website/doctype/contact_us_settings/contact_us_settings.json
+++ b/frappe/website/doctype/contact_us_settings/contact_us_settings.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "creation": "2013-02-21 20:12:42",
  "description": "Settings for Contact Us Page",
  "doctype": "DocType",
@@ -118,7 +119,7 @@
    "label": "Skype"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "is_disabled",
    "fieldtype": "Check",
    "label": "Disabled"
@@ -128,7 +129,7 @@
  "idx": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-08-22 12:59:39.463182",
+ "modified": "2026-06-11 12:21:07.918283",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Contact Us Settings",

--- a/frappe/website/doctype/contact_us_settings/contact_us_settings.py
+++ b/frappe/website/doctype/contact_us_settings/contact_us_settings.py
@@ -23,7 +23,6 @@ class ContactUsSettings(Document):
 		address_title: DF.Data | None
 		city: DF.Data | None
 		country: DF.Data | None
-		disable_contact_us: DF.Check
 		email_id: DF.Data | None
 		forward_to_email: DF.Data | None
 		heading: DF.Data | None

--- a/frappe/website/doctype/contact_us_settings/test_contact_us_settings.py
+++ b/frappe/website/doctype/contact_us_settings/test_contact_us_settings.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestContactUsSettings(IntegrationTestCase):
+	"""
+	Integration tests for ContactUsSettings.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/frappe/www/contact.html
+++ b/frappe/www/contact.html
@@ -21,10 +21,10 @@
 				style="display: none;">&nbsp;</p>
 			<div class="form-group">
 				<select name="subject" class="form-control">
-				{% if query_options -%}
-					{% for option in query_options.split("\n") -%}
+				{% if query_options %}
+					{% for option in query_options %}
 					<option value="{{ option }}">{{ _(option) }}</option>
-					{%- endfor %}
+					{% endfor %}
 				{% else %}
 					<option value="General">{{ _("General") }}</option>
 				{% endif %}

--- a/frappe/www/contact.py
+++ b/frappe/www/contact.py
@@ -22,8 +22,9 @@ def get_context(context):
 	else:
 		query_options = ["Sales", "Support", "General"]
 
-	out = {"query_options": query_options, "parents": [{"name": _("Home"), "route": "/"}]}
+	out = {}
 	out.update(doc.as_dict())
+	out.update({"query_options": query_options, "parents": [{"name": _("Home"), "route": "/"}]})
 
 	return out
 


### PR DESCRIPTION
- Fixed the Subject Options on the Contact Us Page.
- Disabled the Contact Us page by default.
- Disabled the About Us page by default.