### PR TITLE
perf: Cache all estimated counts

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1301,9 +1301,24 @@ class Database:
 			self.value_cache[dt][cache_key] = count
 		return count
 
-	def estimate_count(self, doctype: str) -> int:
-		"""Get estimated count of total rows in a table."""
+	def _fetch_all_table_counts(self) -> dict[str, int]:
+		"""Fetch estimated row counts for all tables in the current database. Override in subclasses."""
 		raise NotImplementedError
+
+	def estimate_count(self, doctype: str) -> int:
+		"""Get estimated count of total rows in a table.
+
+		Counts for all tables are cached together in Redis with a 60-minute TTL so that
+		a single DB query populates estimates for every table at once.
+		"""
+		from frappe.utils.data import cint
+
+		table = get_table_name(doctype)
+		counts = frappe.cache.get_value("estimate_counts")
+		if counts is None:
+			counts = self._fetch_all_table_counts()
+			frappe.cache.set_value("estimate_counts", counts, expires_in_sec=60 * 60)
+		return cint(counts.get(table))
 
 	@staticmethod
 	def format_date(date):

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -562,15 +562,12 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 			self._cursor = original_cursor
 			new_cursor.close()
 
-	def estimate_count(self, doctype: str):
-		"""Get estimated count of total rows in a table."""
+	def _fetch_all_table_counts(self) -> dict[str, int]:
 		from frappe.utils.data import cint
 
-		table = get_table_name(doctype)
-
 		# Scope to current database to avoid cross-site estimates
-		count = self.sql(
-			"select table_rows from information_schema.tables where table_name = %s and table_schema = %s",
-			(table, frappe.db.cur_db_name),
+		rows = self.sql(
+			"select table_name, table_rows from information_schema.tables where table_schema = %s",
+			(frappe.db.cur_db_name,),
 		)
-		return cint(count[0][0]) if count else 0
+		return {row[0]: cint(row[1]) for row in rows}

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -589,15 +589,12 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 			self._cursor = original_cursor
 			new_cursor.close()
 
-	def estimate_count(self, doctype: str):
-		"""Get estimated count of total rows in a table."""
+	def _fetch_all_table_counts(self) -> dict[str, int]:
 		from frappe.utils.data import cint
 
-		table = get_table_name(doctype)
-
 		# Scope to current database to avoid cross-site estimates
-		count = self.sql(
-			"select table_rows from information_schema.tables where table_name = %s and table_schema = %s",
-			(table, frappe.db.cur_db_name),
+		rows = self.sql(
+			"select table_name, table_rows from information_schema.tables where table_schema = %s",
+			(frappe.db.cur_db_name,),
 		)
-		return cint(count[0][0]) if count else 0
+		return {row[0]: cint(row[1]) for row in rows}

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -486,18 +486,15 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 	def get_database_list(self):
 		return self.sql("SELECT datname FROM pg_database", pluck=True)
 
-	def estimate_count(self, doctype: str):
-		"""Get estimated count of total rows in a table."""
+	def _fetch_all_table_counts(self) -> dict[str, int]:
 		from frappe.utils.data import cint
 
-		table = get_table_name(doctype)
-
-		# Scope to current database to avoid cross-site estimates
-		count = self.sql(
-			"select c.reltuples from pg_class c join pg_namespace n on n.oid = c.relnamespace where c.relname = %s and n.nspname = %s and c.relkind = 'r'",
-			(table, self.db_schema),
+		# Scope to current schema to avoid cross-site estimates
+		rows = self.sql(
+			"select c.relname, c.reltuples from pg_class c join pg_namespace n on n.oid = c.relnamespace where n.nspname = %s and c.relkind = 'r'",
+			(self.db_schema,),
 		)
-		return cint(count[0][0]) if count else 0
+		return {row[0]: cint(row[1]) for row in rows}
 
 	@contextmanager
 	def unbuffered_cursor(self):


### PR DESCRIPTION
I don't want to hand-roll information_schema queries everywhere, but
querying information_schema 1000s of time is bad too. This change
fetches them all once and caches them for a while. Serves the purpose
for now.

Extends https://github.com/frappe/frappe/pull/39888 