### PR TITLE
fix(email): don't mark server mails \Seen during IMAP sync

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -335,8 +335,6 @@ class EmailServer:
 		with suppress(Exception):
 			if not cint(self.settings.use_imap):
 				self.pop.dele(msg_num)
-			elif self.settings.email_sync_rule == "UNSEEN":
-				self.imap.uid("STORE", uid, "+FLAGS", "(\\SEEN)")
 
 	def is_temporary_system_problem(self, e):
 		messages = (


### PR DESCRIPTION
## Problem
Incoming emails get marked **read** on the mail server (e.g. Gmail) during IMAP sync, even though no user opened them. Read-state should reflect what the user actually opened not Frappe's background polling.

## Root cause
`EmailServer._post_retrieve_cleanup` (`frappe/email/receive.py`).
The fetch itself is safe, it uses `BODY.PEEK[]`, which does not set `\Seen`. But when **Email Sync Option = UNSEEN**, the cleanup step after each fetch explicitly does `STORE +FLAGS (\Seen)` on the server, so the next poll (which re-searches `UNSEEN`) skips already-synced mail. 
Side effect: the user's mailbox shows the mail as read.

Under **Sync Option = ALL** the rule is a `UID x:y` range, so the `== "UNSEEN"` branch never runs and the flag is never touched.

## Fix
Remove the `STORE +FLAGS (\Seen)` from `_post_retrieve_cleanup`. Server read-state is no longer changed by sync under any sync option.

### Before fix
[Screencast from 2026-06-11 16-25-59.webm](https://github.com/user-attachments/assets/dddb4903-fda8-4131-9365-7a63bc066414)

### After fix
[Screencast from 2026-06-11 16-51-17.webm](https://github.com/user-attachments/assets/fabc83ab-749f-4fad-9fff-95009a37bc9b)

**Support Ticket**: [67563](https://support.frappe.io/helpdesk/tickets/67563)