### PR TITLE
fix(print): Re-assert chromium executable bit when binary already exists

### DIFF
--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -219,6 +219,8 @@ def find_or_download_chromium_executable():
 	if not exec_path.exists():
 		click.echo("Chromium is not available. downloading...")
 		download_chromium()
+	else:
+		make_chromium_executable(str(exec_path))
 
 	if not exec_path.exists():
 		click.echo("Error while downloading chrome")


### PR DESCRIPTION
`find_or_download_chromium_executable()` only checks whether the bench-level chromium binary exists, not whether it is executable. `download_chromium()` chmods `0o755` only on a fresh extract, so once the +x bit is dropped — e.g. when the bench is copied, restored, or rsynced without preserving modes — the lookup returns the path as-is, chrome fails to launch, and printing stays broken until someone manually runs chmod +x.

`Call make_chromium_executable()` when the binary already exists so the bit is re-asserted on every lookup. It is idempotent (no-ops via the `os.access` `X_OK` guard when already executable), so printing self-heals instead of requiring manual intervention.