### PR TITLE
feat: allow to disable standard pages (backport #33756)

### DIFF
--- a/frappe/website/doctype/about_us_settings/about_us_settings.json
+++ b/frappe/website/doctype/about_us_settings/about_us_settings.json
@@ -6,6 +6,7 @@
  "document_type": "Other",
  "engine": "InnoDB",
  "field_order": [
+  "is_disabled",
   "page_title",
   "company_introduction",
   "sb0",
@@ -75,6 +76,12 @@
    "fieldname": "team_members_subtitle",
    "fieldtype": "Small Text",
    "label": "Team Members Subtitle"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_disabled",
+   "fieldtype": "Check",
+   "label": "Disabled"
   }
  ],
  "icon": "fa fa-group",
@@ -82,7 +89,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2020-10-12 13:26:20.277859",
+ "modified": "2025-08-22 15:56:33.957707",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "About Us Settings",
@@ -98,7 +105,8 @@
    "write": 1
   }
  ],
- "sort_field": "modified",
+ "row_format": "Dynamic",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "track_changes": 1
 }

--- a/frappe/website/doctype/about_us_settings/about_us_settings.py
+++ b/frappe/website/doctype/about_us_settings/about_us_settings.py
@@ -22,6 +22,7 @@ class AboutUsSettings(Document):
 		company_history_heading: DF.Data | None
 		company_introduction: DF.TextEditor | None
 		footer: DF.TextEditor | None
+		is_disabled: DF.Check
 		page_title: DF.Data | None
 		team_members: DF.Table[AboutUsTeamMember]
 		team_members_heading: DF.Data | None

--- a/frappe/website/doctype/contact_us_settings/contact_us_settings.json
+++ b/frappe/website/doctype/contact_us_settings/contact_us_settings.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "introduction_section",
+  "is_disabled",
   "forward_to_email",
   "heading",
   "introduction",
@@ -115,13 +116,19 @@
    "fieldname": "skype",
    "fieldtype": "Data",
    "label": "Skype"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_disabled",
+   "fieldtype": "Check",
+   "label": "Disabled"
   }
  ],
  "icon": "fa fa-cog",
  "idx": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-15 07:19:31.401053",
+ "modified": "2025-08-22 12:59:39.463182",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Contact Us Settings",
@@ -137,7 +144,8 @@
    "write": 1
   }
  ],
- "sort_field": "modified",
+ "row_format": "Dynamic",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "track_changes": 1
 }

--- a/frappe/website/doctype/contact_us_settings/contact_us_settings.py
+++ b/frappe/website/doctype/contact_us_settings/contact_us_settings.py
@@ -26,6 +26,7 @@ class ContactUsSettings(Document):
 		forward_to_email: DF.Data | None
 		heading: DF.Data | None
 		introduction: DF.TextEditor | None
+		is_disabled: DF.Check
 		phone: DF.Data | None
 		pincode: DF.Data | None
 		query_options: DF.SmallText | None

--- a/frappe/www/about.py
+++ b/frappe/www/about.py
@@ -8,5 +8,7 @@ sitemap = 1
 
 def get_context(context):
 	context.doc = frappe.get_cached_doc("About Us Settings")
-
+	if context.doc.is_disabled:
+		frappe.local.flags.redirect_location = "/404"
+		raise frappe.Redirect
 	return context

--- a/frappe/www/contact.py
+++ b/frappe/www/contact.py
@@ -13,6 +13,9 @@ sitemap = 1
 
 def get_context(context):
 	doc = frappe.get_doc("Contact Us Settings", "Contact Us Settings")
+	if doc.is_disabled:
+		frappe.local.flags.redirect_location = "/404"
+		raise frappe.Redirect
 
 	if doc.query_options:
 		query_options = [opt.strip() for opt in doc.query_options.replace(",", "\n").split("\n") if opt]
@@ -28,6 +31,10 @@ def get_context(context):
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=1000, seconds=60 * 60)
 def send_message(sender, message, subject="Website Query"):
+	doc = frappe.get_doc("Contact Us Settings", "Contact Us Settings")
+	if doc.is_disabled:
+		return
+
 	sender = validate_email_address(sender, throw=True)
 
 	message = escape_html(message)


### PR DESCRIPTION
**Problem:**
Standard Pages like About Us and Contact Us are always included in the frappe framework. You can not disable them. The only way to avoid them, is by using workarounds. People wish to have the possibility, to disable these sites.

examples:
https://discuss.frappe.io/t/how-to-hide-standard-pages-like-contact-about-us/127476
https://discuss.frappe.io/t/how-to-disable-or-unpublish-in-the-web-the-contact-us-page/130827

**solution:**
Include a checkbox to disable about us and contact sites. The checkbox also disables the API to prevent robots/attackers to use it.

**Addition**:
already mentioned in https://github.com/frappe/frappe/issues/25781 there was already a field "disable_contact_us" which is now replaced/used




> no-docs


---
Backport of #33756 