### PR TITLE
fix: apply DocType Layout to record links in list view

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1400,9 +1400,15 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			return this.settings.get_form_link(doc);
 		}
 
-		return `/desk/${encodeURIComponent(
-			frappe.router.slug(frappe.router.doctype_layout || this.doctype)
+		let link = `/desk/${encodeURIComponent(
+			frappe.router.slug(this.doctype)
 		)}/${encodeURIComponent(cstr(doc.name))}`;
+
+		if (frappe.router.doctype_layout) {
+			link += `?layout=${encodeURIComponent(frappe.router.doctype_layout)}`;
+		}
+
+		return link;
 	}
 
 	get_seen_class(doc) {


### PR DESCRIPTION
### Problem

Opening a list via a DocType Layout's **"Go to List"** button slugged the active layout name into the doctype slot of each record link (e.g. `/desk/simple-todo/TODO-0001`). That path matches no doctype route, so clicking a record threw an error, and a refresh fell back to the base doctype's default layout.

### Fix

`get_form_link()` now routes to the **base doctype** and carries the layout via the `layout` query param (`/desk/todo/TODO-0001?layout=Simple%20ToDo`) — the same mechanism the "Go to List" button and router already use. Clicking resolves correctly and the layout survives a refresh.

Same class of bug as #39832, which fixed the button but not the record links inside the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)