### PR TITLE
fix: isolate website ready handlers and guard assets_json lookup

### DIFF
--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -23,7 +23,7 @@ $.extend(frappe, {
 			if (path.endsWith(".css") && is_rtl) {
 				path = `rtl_${path}`;
 			}
-			path = frappe.boot.assets_json[path] || path;
+			path = frappe.boot?.assets_json?.[path] || path;
 			return path;
 		}
 		return path;
@@ -291,7 +291,11 @@ $.extend(frappe, {
 
 	trigger_ready: function () {
 		frappe.ready_events.forEach(function (fn) {
-			fn();
+			try {
+				fn();
+			} catch (e) {
+				console.error(e);
+			}
 		});
 	},
 

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -290,11 +290,11 @@ $.extend(frappe, {
 	},
 
 	trigger_ready: function () {
-		frappe.ready_events.forEach(function (fn) {
+		frappe.ready_events.forEach(function (fn, i) {
 			try {
 				fn();
 			} catch (e) {
-				console.error(e);
+				console.error(`frappe.ready handler #${i} failed:`, fn, e);
 			}
 		});
 	},


### PR DESCRIPTION
## Bug

Reported in #39778: on some Webshop product pages, enquiry forms stop working because a JavaScript error prevents later `frappe.ready` handlers from running.

```js
TypeError: Cannot read properties of undefined (reading 'file_uploader.bundle.js')
```

## Root Cause

`bundled_asset()` accesses `frappe.boot.assets_json[path]` without checking whether `assets_json` exists. On pages where the inline boot script is missing, this throws during `trigger_ready()`. Since ready handlers are executed without error isolation, one exception prevents all subsequent handlers (including form submit bindings) from running.

## Fix

* Guard access to `frappe.boot.assets_json` and fall back to the raw path.
* Wrap each ready handler in `trigger_ready()` with `try/catch` so one failure cannot block the rest.

Closes #39778.
