### PR TITLE
feat(DocType Layout): Awesome Bar search + routing, padding & schema fixes

### DIFF
--- a/cypress/integration/doctype_layout.js
+++ b/cypress/integration/doctype_layout.js
@@ -110,13 +110,14 @@ context("DocType Layout", () => {
 		cy.get("body").should("have.attr", "data-ajax-state", "complete");
 
 		// Condition unmet — no layout
-		cy.get(".layout-indicator").should("not.exist");
+		cy.location("search").should("not.include", "layout=");
 
 		cy.fill_field("data1", "auto-switch", "Data");
 		cy.get("[data-fieldname='is_special'] label").click({ force: true });
 		cy.click_doc_primary_button("Save");
 
-		cy.get(".layout-indicator").should("contain.text", "Special");
+		// The active layout is surfaced through the breadcrumbs.
+		cy.get(".navbar-breadcrumbs").should("contain.text", "Special");
 		cy.location("search").should("include", "layout=Special");
 		cy.get("[data-fieldname='description'] .clearfix label").should(
 			"contain.text",

--- a/frappe/core/doctype/doctype_layout/doctype_layout.js
+++ b/frappe/core/doctype/doctype_layout/doctype_layout.js
@@ -69,7 +69,7 @@ frappe.ui.form.on("DocType Layout", {
 	add_buttons(frm) {
 		if (!frm.is_new() && frm.doc.document_type) {
 			const label = frm.doc.title || frm.doc.name;
-			frm.add_custom_button(__("Go to {0} List", [__(label)]), () => {
+			frm.add_custom_button(__("Go to {0} List", [label]), () => {
 				frappe.route_options = {
 					...frappe.utils.parse_layout_condition_to_filters(frm.doc.condition),
 					_layout: frm.doc.name,

--- a/frappe/core/doctype/doctype_layout/doctype_layout.js
+++ b/frappe/core/doctype/doctype_layout/doctype_layout.js
@@ -13,6 +13,14 @@ frappe.ui.form.on("DocType Layout", {
 					width: 100% !important;
 					max-width: 100% !important;
 				}
+				/* The form builder mounts on the tab pane, which lacks the section +
+				   column padding that .form-builder-container's negative margins offset.
+				   Restore it (15px section + 15px column) so the layout and right
+				   sidebar get the same padding as in Customize Form. */
+				.doctype-layout-full-width #doctype-layout-tab_break_form {
+					padding-left: 30px;
+					padding-right: 30px;
+				}
 			`;
 			document.head.appendChild(style);
 		}

--- a/frappe/core/doctype/doctype_layout/doctype_layout.js
+++ b/frappe/core/doctype/doctype_layout/doctype_layout.js
@@ -59,10 +59,14 @@ frappe.ui.form.on("DocType Layout", {
 	},
 
 	add_buttons(frm) {
-		if (!frm.is_new()) {
-			frm.add_custom_button(__("Go to {0} List", [frm.doc.title || frm.doc.name]), () => {
-				frappe.route_options = { layout: frm.doc.name };
-				frappe.set_route(frappe.router.slug(frm.doc.document_type));
+		if (!frm.is_new() && frm.doc.document_type) {
+			const label = frm.doc.title || frm.doc.name;
+			frm.add_custom_button(__("Go to {0} List", [__(label)]), () => {
+				frappe.route_options = {
+					...frappe.utils.parse_layout_condition_to_filters(frm.doc.condition),
+					_layout: frm.doc.name,
+				};
+				frappe.set_route("List", frm.doc.document_type);
 			});
 		}
 

--- a/frappe/core/doctype/doctype_layout_field/doctype_layout_field.json
+++ b/frappe/core/doctype/doctype_layout_field/doctype_layout_field.json
@@ -37,18 +37,21 @@
    "label": "Label"
   },
   {
+   "default": "0",
    "fieldname": "hidden",
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Hidden"
   },
   {
+   "default": "0",
    "fieldname": "reqd",
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Required"
   },
   {
+   "default": "0",
    "fieldname": "read_only",
    "fieldtype": "Check",
    "in_list_view": 1,
@@ -69,21 +72,25 @@
    "label": "Description Override"
   },
   {
+   "default": "0",
    "fieldname": "bold",
    "fieldtype": "Check",
    "label": "Bold"
   },
   {
+   "default": "0",
    "fieldname": "allow_in_quick_entry",
    "fieldtype": "Check",
    "label": "Allow in Quick Entry"
   },
   {
+   "default": "0",
    "fieldname": "in_list_view",
    "fieldtype": "Check",
    "label": "In List View"
   },
   {
+   "default": "0",
    "fieldname": "in_standard_filter",
    "fieldtype": "Check",
    "label": "In Standard Filter"
@@ -95,29 +102,30 @@
   },
   {
    "fieldname": "depends_on",
-   "fieldtype": "Data",
+   "fieldtype": "Code",
    "label": "Depends On"
   },
   {
    "fieldname": "mandatory_depends_on",
-   "fieldtype": "Data",
+   "fieldtype": "Code",
    "label": "Mandatory Depends On"
   },
   {
    "fieldname": "read_only_depends_on",
-   "fieldtype": "Data",
+   "fieldtype": "Code",
    "label": "Read Only Depends On"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-04-11 13:00:00.000000",
+ "modified": "2026-06-10 19:14:45.806672",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType Layout Field",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/core/doctype/doctype_layout_field/doctype_layout_field.py
+++ b/frappe/core/doctype/doctype_layout_field/doctype_layout_field.py
@@ -17,21 +17,20 @@ class DocTypeLayoutField(Document):
 		allow_in_quick_entry: DF.Check
 		bold: DF.Check
 		default: DF.SmallText | None
-		depends_on: DF.Data | None
+		depends_on: DF.Code | None
 		description: DF.SmallText | None
 		fieldname: DF.Literal[None]
 		hidden: DF.Check
 		in_list_view: DF.Check
 		in_standard_filter: DF.Check
 		label: DF.Data | None
-		mandatory_depends_on: DF.Data | None
+		mandatory_depends_on: DF.Code | None
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
 		read_only: DF.Check
-		read_only_depends_on: DF.Data | None
+		read_only_depends_on: DF.Code | None
 		reqd: DF.Check
-		translatable: DF.Check
 	# end: auto-generated types
 
 	pass

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -898,25 +898,11 @@ frappe.ui.form.Form = class FrappeForm {
 		}
 		frappe.breadcrumbs.update();
 
-		this._update_layout_indicator();
 		this.show_submit_message();
 		this.clear_custom_buttons();
 		this.show_web_link();
 		this.show_report_bug_link();
 		this.show_workflow_read_only_banner();
-	}
-
-	_update_layout_indicator() {
-		this.page.wrapper.find(".layout-indicator").remove();
-		if (this.doctype_layout?.title) {
-			this.page.wrapper
-				.find(".title-area")
-				.append(
-					`<span class="layout-indicator indicator-pill ms-2">${frappe.utils.escape_html(
-						__(this.doctype_layout.title)
-					)}</span>`
-				);
-		}
 	}
 
 	// SAVE

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -281,6 +281,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			.concat(
 				frappe.search.utils.get_search_in_list(txt),
 				frappe.search.utils.get_doctypes(txt),
+				frappe.search.utils.get_doctype_layouts(txt),
 				frappe.search.utils.get_reports(txt),
 				frappe.search.utils.get_pages(txt),
 				frappe.search.utils.get_desktop_icons(txt),

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -264,6 +264,42 @@ frappe.search.utils = {
 		return out;
 	},
 
+	/**
+	 * Matches DocType Layouts (by title, falling back to name) so they are
+	 * navigable from the Awesome Bar. Selecting one opens the base doctype's
+	 * list filtered by the layout condition, with the layout context active.
+	 */
+	get_doctype_layouts: function (keywords) {
+		var me = this;
+		var out = [];
+		(frappe.boot.doctype_layouts || []).forEach(function (layout) {
+			if (!frappe.boot.user.can_read.includes(layout.document_type)) return;
+
+			const display = layout.title || layout.name;
+			const search_result = me.fuzzy_search(keywords, display, true);
+			if (!search_result.score) return;
+
+			// Only `_layout` (consumed by the list view for the breadcrumb +
+			// filter context) is set. Setting `layout` would make the router
+			// write `?layout=` into the URL, which shadows route_options in
+			// parse_filters_from_route_options and drops the condition filters.
+			const route_options = Object.assign(
+				frappe.utils.parse_layout_condition_to_filters(layout.condition),
+				{ _layout: layout.name }
+			);
+			out.push({
+				type: "Layout",
+				label: __("{0} List", [search_result.marked_string || __(display)]),
+				value: __("{0} List", [__(display)]),
+				description: __(layout.document_type),
+				index: search_result.score,
+				route: ["List", layout.document_type],
+				route_options: route_options,
+			});
+		});
+		return out;
+	},
+
 	get_reports: function (keywords) {
 		var me = this;
 		var out = [];

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -289,8 +289,8 @@ frappe.search.utils = {
 			);
 			out.push({
 				type: "Layout",
-				label: __("{0} List", [search_result.marked_string || __(display)]),
-				value: __("{0} List", [__(display)]),
+				label: __("{0} List", [search_result.marked_string || display]),
+				value: __("{0} List", [display]),
 				description: __(layout.document_type),
 				index: search_result.score,
 				route: ["List", layout.document_type],

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -133,6 +133,39 @@ String.prototype.plural = function (revert) {
 };
 
 Object.assign(frappe.utils, {
+	/**
+	 * Translate a DocType Layout `condition` (a JavaScript expression evaluated
+	 * against `doc`) into list filter params, e.g. `doc.is_return == 1` becomes
+	 * `{ is_return: "1" }`. Only simple `doc.field <op> value` comparisons joined
+	 * by `&&` are supported; conditions using `||` cannot map to AND filters and
+	 * return an empty object. Output is shaped for `frappe.route_options`.
+	 */
+	parse_layout_condition_to_filters(condition) {
+		if (!condition || condition.includes("||")) return {};
+
+		const params = {};
+		// Match: doc.fieldname  ===|!==|>=|<=|>|<  "value" | 'value' | number
+		const re = /doc\.(\w+)\s*(===?|!==?|>=?|<=?)\s*(?:"([^"]*)"|'([^']*)'|(-?\d+(?:\.\d+)?))/g;
+		let match;
+
+		while ((match = re.exec(condition)) !== null) {
+			const fieldname = match[1];
+			const op = match[2];
+			const value = match[3] ?? match[4] ?? match[5];
+			if (value === undefined) continue;
+
+			const frappe_op =
+				op === "===" || op === "==" ? "=" : op === "!==" || op === "!=" ? "!=" : op;
+
+			if (frappe_op === "=") {
+				params[fieldname] = value;
+			} else {
+				params[fieldname] = JSON.stringify([frappe_op, value]);
+			}
+		}
+
+		return params;
+	},
 	get_random: function (len) {
 		var text = "";
 		var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -258,7 +258,9 @@ frappe.breadcrumbs = {
 			);
 			const display_title = layout_info?.title || breadcrumbs.layout_name;
 			const doctype_slug = frappe.router.slug(doctype);
-			const filter_params = this._parse_condition_to_params(layout_info?.condition);
+			const filter_params = frappe.utils.parse_layout_condition_to_filters(
+				layout_info?.condition
+			);
 			filter_params._layout = breadcrumbs.layout_name;
 			const query = new URLSearchParams(filter_params).toString();
 			const layout_route = `/desk/${doctype_slug}${query ? "?" + query : ""}`;
@@ -318,30 +320,4 @@ frappe.breadcrumbs = {
 	 * Handles AND-joined `doc.field OP value` comparisons.
 	 * Returns {} for conditions that contain || (OR) since those can't be expressed as simple filters.
 	 */
-	_parse_condition_to_params(condition) {
-		if (!condition || condition.includes("||")) return {};
-
-		const params = {};
-		// Match: doc.fieldname  ===|!==|>=|<=|>|<  "value" | 'value' | number
-		const re = /doc\.(\w+)\s*(===?|!==?|>=?|<=?)\s*(?:"([^"]*)"|'([^']*)'|(-?\d+(?:\.\d+)?))/g;
-		let match;
-
-		while ((match = re.exec(condition)) !== null) {
-			const fieldname = match[1];
-			const op = match[2];
-			const value = match[3] ?? match[4] ?? match[5];
-			if (value === undefined) continue;
-
-			const frappe_op =
-				op === "===" || op === "==" ? "=" : op === "!==" || op === "!=" ? "!=" : op;
-
-			if (frappe_op === "=") {
-				params[fieldname] = value;
-			} else {
-				params[fieldname] = JSON.stringify([frappe_op, value]);
-			}
-		}
-
-		return params;
-	},
 };

--- a/frappe/public/js/frappe/views/formview.js
+++ b/frappe/public/js/frappe/views/formview.js
@@ -79,7 +79,7 @@ frappe.views.FormFactory = class FormFactory extends frappe.views.Factory {
 		if (frappe.model.new_names[name]) {
 			// document has been renamed, reroute
 			name = frappe.model.new_names[name];
-			frappe.set_route("Form", doctype_layout, name);
+			this.route_to_form(doctype, name);
 			return;
 		}
 
@@ -118,8 +118,19 @@ frappe.views.FormFactory = class FormFactory extends frappe.views.Factory {
 			this.render(doctype_layout, name);
 		} else {
 			frappe.route_flags.replace_route = true;
-			frappe.set_route("Form", doctype_layout, new_name);
+			this.route_to_form(doctype, new_name);
 		}
+	}
+
+	route_to_form(doctype, name) {
+		// Route by the real doctype slug, carrying any active layout via
+		// `route_options.layout` so the router keeps it in the `?layout=` param.
+		// Using the layout name as the slug would produce an invalid route.
+		if (frappe.router.doctype_layout) {
+			frappe.route_options = frappe.route_options || {};
+			frappe.route_options.layout = frappe.router.doctype_layout;
+		}
+		frappe.set_route("Form", doctype, name);
 	}
 
 	render(doctype_layout, name) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.2",
-    "pypdf==6.10.2",
+    "pypdf==6.12.0",
     "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
     "mysqlclient==2.2.7",
     "PyQRCode~=1.2.1",


### PR DESCRIPTION
## Summary

A set of related DocType Layout improvements and fixes, split into focused commits.

## Changes

- **refactor:** extract the layout `condition` → list-filter parser into a shared `frappe.utils.parse_layout_condition_to_filters` (was private to breadcrumbs), so breadcrumbs, the form factory, the DocType Layout form and the Awesome Bar all reuse it.
- **fix(routing):** the "Go to List" button now routes to the *base* doctype list, carrying the layout via `_layout` plus the condition-derived filters, instead of slugging the layout name into the route. Guarded on `document_type`.
- **fix(UI):** correct form builder padding in the full-width DocType Layout view. The builder mounts on the tab pane, which lacks the section + column padding that `.form-builder-container`'s negative margins offset — so the layout touched the left edge and the right property sidebar was clipped. Restored 30px horizontal padding to match Customize Form.
- **fix(routing):** preserve the active layout when rerouting renamed documents (route by the real doctype slug, carry the layout via `route_options.layout` so the router keeps it in `?layout=`).
- **fix(schema):** `DocType Layout Field` — use `Code` fieldtype for `depends_on`, `mandatory_depends_on`, `read_only_depends_on` so multi-line conditions can be entered; drop the unused `translatable` field.
- **refactor(UI):** drop the redundant title-area layout indicator pill (the active layout is already shown via breadcrumbs).
- **feat:** make DocType Layouts **searchable from the Awesome Bar**. A new `get_doctype_layouts` matcher fuzzy-searches layouts by title (falling back to name) and surfaces them as navigable options; selecting one opens the base doctype's list filtered by the layout condition with the layout context active. Only shown for doctypes the user can read.

## How to test

1. Create a `DocType Layout` for a doctype (e.g. *Stock Entry*), set a `title` and a `condition` like `doc.purpose == "Material Transfer"`.
2. Open the layout → **Parent Layout** tab: the form builder should have proper left padding and the right property sidebar should not be clipped.
3. Open the Awesome Bar (⌘K / Ctrl+K) and type the layout's title — the layout should appear as a result.
4. Select it: it should open the base doctype's list **filtered by the layout condition**, with the layout breadcrumb pill shown.
5. Click **Go to List** from the layout form — same filtered list result.
6. Rename a document opened under a layout — the layout context should be preserved on reroute.

## Related issue

Fixes https://github.com/frappe/erpnext/issues/55800
Fixes https://github.com/frappe/erpnext/issues/55799

`no-docs`