### PR TITLE
fix: unnecessary scrollbars in list view on Firefox

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -431,14 +431,16 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	setup_resize_handler() {
-		$(window).on(
-			"resize",
-			frappe.utils.debounce(() => {
-				if (this.$result?.is(":visible")) {
-					this.set_result_height();
-				}
-			}, 300)
-		);
+		$(window)
+			.off("resize.list-view")
+			.on(
+				"resize.list-view",
+				frappe.utils.debounce(() => {
+					if (cur_list?.$result?.is(":visible")) {
+						cur_list.set_result_height();
+					}
+				}, 300)
+			);
 	}
 
 	set_result_height() {

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -31,6 +31,7 @@ frappe.views.BaseList = class BaseList {
 			this.setup_main_section,
 			this.setup_view,
 			this.setup_view_menu,
+			this.setup_resize_handler,
 		].map((fn) => fn.bind(this));
 
 		this.init_promise = frappe.run_serially(tasks);
@@ -427,6 +428,17 @@ frappe.views.BaseList = class BaseList {
 			this.page_length = this.selected_page_count;
 			this.refresh();
 		});
+	}
+
+	setup_resize_handler() {
+		$(window).on(
+			"resize",
+			frappe.utils.debounce(() => {
+				if (this.$result?.is(":visible")) {
+					this.set_result_height();
+				}
+			}, 300)
+		);
 	}
 
 	set_result_height() {

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -446,12 +446,14 @@ frappe.views.BaseList = class BaseList {
 		this.$result[0].style.removeProperty("height");
 		// place it at the footer of the page
 
-		let resultContainerHeight = window.innerHeight - this.$paging_area.get(0).offsetHeight;
-		if (!frappe.is_mobile()) {
-			resultContainerHeight = resultContainerHeight - this.$result.get(0).offsetTop;
-		}
-		this.$result.parent(".result-container").css({
-			height: resultContainerHeight - (frappe.is_mobile() ? 100 : 0) + "px",
+		let $result_container = this.$result.parent(".result-container");
+		let main_rect = $(".main-section").get(0).getBoundingClientRect();
+		let result_top = $result_container.get(0).getBoundingClientRect().top - main_rect.top;
+		let resultContainerHeight = Math.floor(
+			main_rect.height - this.$paging_area.get(0).getBoundingClientRect().height - result_top
+		);
+		$result_container.css({
+			height: resultContainerHeight + "px",
 		});
 
 		this.$result[0].style.height =

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -661,6 +661,7 @@ input.list-header-checkbox {
 	.frappe-list {
 		.result-container {
 			overflow-x: auto;
+			scrollbar-gutter: stable;
 
 			.result {
 				overflow-y: hidden;

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -661,7 +661,6 @@ input.list-header-checkbox {
 	.frappe-list {
 		.result-container {
 			overflow-x: auto;
-			scrollbar-gutter: stable;
 
 			.result {
 				overflow-y: hidden;

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -79,6 +79,9 @@
 		}
 	}
 	.search-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 		background-color: var(--control-bg);
 		border-radius: 8px;
 		padding: 6px;

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -81,7 +81,6 @@
 	.search-icon {
 		display: inline-flex;
 		align-items: center;
-		justify-content: center;
 		background-color: var(--control-bg);
 		border-radius: 8px;
 		padding: 6px;


### PR DESCRIPTION
Closes #39018

## Issue

Firefox showed a second scrollbar beside the list's own scrollbar on list views, especially at non-default zoom levels and on high-DPI displays.

### Root Cause

`set_result_height` calculated the result container height using `window.innerHeight`, while the actual scroll container (`.main-section`) could be slightly smaller due to fractional pixel rounding. This caused a sub-pixel overflow that Firefox rendered as a visible scrollbar.

Additionally, the height was only recalculated after data refreshes, so window resizes could leave stale dimensions and unnecessary scrollbars.

## Fix

- Calculate height using `.main-section`'s actual height and floor the result to prevent overflow at any zoom level.
- Add a debounced resize handler to recalculate height on window resize.
- Fix the page-head search icon by changing it from an inline `<span>` to `inline-flex`, preventing layout issues at fractional zoom levels.

## For scrollbar
**Before**
<img width="1512" height="865" alt="Screenshot 2026-06-12 at 2 39 39 PM" src="https://github.com/user-attachments/assets/8f16473c-fc87-4435-a8f6-1324e26040a4" />

**After**
<img width="1512" height="867" alt="Screenshot 2026-06-12 at 2 29 36 PM" src="https://github.com/user-attachments/assets/b4f776de-d40c-40a0-a264-a5262fb8ab3c" />

## For search icon
**Chromium based browser**
<img width="246" height="73" alt="Screenshot 2026-06-12 at 1 26 41 AM" src="https://github.com/user-attachments/assets/15a1a20f-f407-409a-8df9-7f59d2c84c97" />


**Non chromium**
<img width="253" height="65" alt="Screenshot 2026-06-12 at 1 26 29 AM" src="https://github.com/user-attachments/assets/caf740ad-3180-4a32-bf79-2d960edf0b9c" />