### PR TITLE
fix: avoid leaking URL in navigate errors, surface set_device_metrics failures

### DIFF
--- a/frappe/utils/pdf_generator/page.py
+++ b/frappe/utils/pdf_generator/page.py
@@ -207,7 +207,7 @@ class Page:
 		wait_start = self.wait_for_load(wait_for=wait_for or ["load", "DOMContentLoaded", "networkIdle"])
 		_result, error = self.send("Page.navigate", {"url": url})
 		if error:
-			raise RuntimeError(f"Error navigating to {url}: {error}")
+			raise RuntimeError(f"Error navigating to URL: {error}")
 		wait_start()
 
 	def evaluate(self, expression, await_promise=False):
@@ -333,10 +333,12 @@ class Page:
 
 	def set_device_metrics(self, width=1280, height=720, scale_factor=1):
 		"""Override viewport size for deterministic screenshot dimensions (default 1280x720)."""
-		self.send(
+		_result, error = self.send(
 			"Emulation.setDeviceMetricsOverride",
 			{"width": width, "height": height, "deviceScaleFactor": scale_factor, "mobile": False},
 		)
+		if error:
+			raise RuntimeError(f"Error setting device metrics: {error}")
 
 	def capture_screenshot(self, image_format="jpeg", quality=30):
 		"""Screenshot the current viewport; returns raw image bytes."""


### PR DESCRIPTION
## Summary
Follow-up to the review comments on #39911 (already merged), which introduced `frappe/utils/pdf_generator/page.py`'s bundled-Chromium preview/PDF support. Two issues were flagged after merge:

- `navigate()` interpolated the full URL into its `RuntimeError` message. If the URL contains credentials or access tokens in its path/query string, they'd be written verbatim to `frappe.log_error` and any upstream exception handler. The message no longer includes the URL.
- `set_device_metrics()` discarded the `(result, error)` return from `self.send("Emulation.setDeviceMetricsOverride", ...)`. If the CDP call fails, the screenshot would silently fall back to the browser's default viewport instead of the requested size, with no way for the caller to detect it. It now raises `RuntimeError` on error, matching the pattern used by the other `Page` methods (e.g. `navigate`, `capture_screenshot`).

The same fix has been applied to #39882 (the open `develop` PR this was backported from).

## Test plan
- [x] `bench --site builder.test run-tests --module frappe.tests.test_preview` — all 4 tests pass