### PR TITLE
fix(custom-field): persist allow_bulk_edit for custom table fields

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -58,6 +58,7 @@
   "report_hide",
   "search_index",
   "allow_in_quick_entry",
+  "allow_bulk_edit",
   "ignore_xss_filter",
   "translatable",
   "hide_border",
@@ -409,6 +410,13 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: doc.fieldtype == \"Table\"",
+   "fieldname": "allow_bulk_edit",
+   "fieldtype": "Check",
+   "label": "Allow Bulk Edit"
+  },
+  {
+   "default": "0",
    "depends_on": "eval:!in_list(['Table', 'Table MultiSelect'], doc.fieldtype);",
    "fieldname": "in_preview",
    "fieldtype": "Check",
@@ -498,7 +506,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-22 10:35:32.555267",
+ "modified": "2026-06-12 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -25,6 +25,7 @@ class CustomField(Document):
 		from frappe.types import DF
 
 		alignment: DF.Literal["", "Left", "Center", "Right"]
+		allow_bulk_edit: DF.Check
 		allow_in_quick_entry: DF.Check
 		allow_on_submit: DF.Check
 		bold: DF.Check


### PR DESCRIPTION
## Problem

When a **custom child-table field** is added to a **standard doctype** via Customize Form, the **Allow Bulk Edit** checkbox auto-unchecks on save — the property is never persisted.

## Root cause

A custom field on a standard doctype is stored as a **Custom Field** doc (not a Property Setter). The `Custom Field` doctype had **no `allow_bulk_edit` column**.

- `docfield_properties` in `customize_form.py` **includes** `allow_bulk_edit`, so `add_custom_field` / `update_in_custom_field` copy it onto the Custom Field doc via `doc.set("allow_bulk_edit", ...)`.
- With no DB column, `insert()` / `db_update()` silently discard the value.
- Custom fields are explicitly skipped in property-setter creation (`set_property_setters` → `is_standard_or_system_generated_field` guard), so it isn't saved there either.
- On reload, `meta.add_custom_fields()` selects Custom Field columns with `*` — `allow_bulk_edit` isn't among them, so it reads back as `0`.

For a *standard* field this works fine because it routes through Property Setter; the bug is specific to *custom* table fields.

## Fix

Add an `allow_bulk_edit` Check field to the `Custom Field` doctype (`depends_on: fieldtype == "Table"`, mirroring `DocField`). Because `meta.add_custom_fields()` pulls all Custom Field columns, the value now persists and propagates into the doctype meta — no other code changes needed.

## Testing

Verified end-to-end on a local site:
- DB column created on reload of the doctype
- Custom `Table` field saved with `allow_bulk_edit = 1` persists in the DB
- Value propagates into the parent doctype's meta (`meta.get_field(...).allow_bulk_edit == 1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)