### PR TITLE
[WIP] fix(link): correctly merge Customize Form link_filters with controller get_query

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -850,19 +850,43 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 	}
 
 	apply_link_field_filters() {
-		let filters = this.parse_filters(JSON.parse(this.df.link_filters));
-		// take filters from the link field and add to the query
-
-		const query_filters = this.get_query?.()?.filters || {};
-		if (query_filters) {
-			filters = { ...filters, ...query_filters };
+		// Already wrapped on a previous search; nothing to do.
+		if (this.get_query && this.get_query.__has_link_filters) {
+			return;
 		}
 
-		this.get_query = function () {
-			return {
-				filters,
-			};
+		const link_filters = this.parse_filters(JSON.parse(this.df.link_filters));
+		const controller_get_query = this.get_query;
+
+		// Wrap (instead of replacing) any controller-defined get_query so that the
+		// link field filters set via Customize Form are merged with it. The wrapper
+		// is invoked later by set_custom_query with the standard (doc, doctype,
+		// docname) arguments, so controller queries that rely on those arguments
+		// keep working (e.g. a get_query that reads `doc.customer`).
+		const get_query = (...args) => {
+			const result = { filters: { ...link_filters } };
+
+			let controller_result = controller_get_query;
+			if (typeof controller_get_query === "function") {
+				controller_result = controller_get_query.apply(this, args);
+			}
+
+			if (typeof controller_result === "string") {
+				// controller returned a server-side query method path
+				result.query = controller_result;
+			} else if (controller_result) {
+				if (controller_result.query) {
+					result.query = controller_result.query;
+				}
+				// Controller filters take precedence over link field filters on
+				// conflicting keys (they often enforce data integrity, e.g. company).
+				Object.assign(result.filters, controller_result.filters);
+			}
+
+			return result;
 		};
+		get_query.__has_link_filters = true;
+		this.get_query = get_query;
 	}
 
 	parse_filters(link_filters) {


### PR DESCRIPTION
## Problem

When a Link field has **both** a filter added via Customize Form (`link_filters`) **and** a `get_query` defined by the doctype controller, the user's filter is not applied correctly — and in some cases the field shows completely unfiltered results.

`apply_link_field_filters` eagerly called `this.get_query()` with **no arguments** and kept only its `.filters`:

```js
const query_filters = this.get_query?.()?.filters || {};
```

Two issues result:

1. **Controller queries that use their arguments crash.** A controller `get_query` written as `function(doc, cdt, cdn)` that reads, say, `doc.customer` (e.g. ERPNext's Timesheet `project` field) throws a `TypeError` when invoked with no args. The throw is unguarded (`get_search_args` → `set_custom_query`), so filter setup aborts and the link field falls back to showing everything.
2. **Server-side `query` methods are discarded.** Only `.filters` was preserved, so a controller returning `{ query: \"path.to.method\", filters: {...} }` lost its query method.

## Reproduction (ERPNext)

1. Customize Form on **Timesheet** → add a filter to the **Project** field (`link_filters`).
2. On a Timesheet, the controller already defines a `get_query` for `project` (filters by `company`; and by `customer` once a customer is set).
3. The Customize Form filter is dropped; with a customer set, the field shows unfiltered Projects.

## Fix

Wrap the controller's `get_query` instead of replacing it. The wrapper is invoked later by `set_custom_query` with the standard `(doc, doctype, docname)` arguments, so argument-dependent controller queries keep working. Both filter sets are merged (controller wins on conflicting keys, preserving integrity filters like `company`), and a server-side `query` method is preserved. A guard flag avoids re-wrapping on subsequent searches.

## Testing

Verified the merge logic for:
- user filter + controller `company` filter → both applied
- controller function reading `doc.customer` → no longer crashes, both applied
- controller returning a server-side `query` method → preserved alongside merged filters
- link_filters only (no controller query) → applied as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)