### PR TITLE
fix(Link): re-evaluate link_filters on every search so they refresh on dependency change

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -781,11 +781,6 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			return obj;
 		};
 
-		// apply link field filters
-		if (this.df.link_filters && !!this.df.link_filters.length) {
-			this.apply_link_field_filters();
-		}
-
 		if (this.get_query || this.df.get_query) {
 			var get_query = this.get_query || this.df.get_query;
 			if ($.isPlainObject(get_query)) {
@@ -847,22 +842,15 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			if (!args.filters) args.filters = {};
 			$.extend(args.filters, this.df.filters);
 		}
+
+		if (this.df.link_filters && !!this.df.link_filters.length) {
+			args.filters = { ...this.apply_link_field_filters(), ...(args.filters || {}) };
+		}
 	}
 
+	// apply link field filters
 	apply_link_field_filters() {
-		let filters = this.parse_filters(JSON.parse(this.df.link_filters));
-		// take filters from the link field and add to the query
-
-		const query_filters = this.get_query?.()?.filters || {};
-		if (query_filters) {
-			filters = { ...filters, ...query_filters };
-		}
-
-		this.get_query = function () {
-			return {
-				filters,
-			};
-		};
+		return this.parse_filters(JSON.parse(this.df.link_filters));
 	}
 
 	parse_filters(link_filters) {


### PR DESCRIPTION
### Problem
A Link field with DocType **Link Filters** using `eval:` (e.g. filter Task by `doc.custom_proj`) stops refreshing after the first dropdown open. Change the dependency field and reopen, it still shows results for the old value until the form is reloaded.

### Cause
`apply_link_field_filters()` permanently overwrote `this.get_query` with a frozen `{ filters }` closure, then on the next search read back its own stale output and merged it over the freshly evaluated filter, so the old value won every time. Introduced in #39231.

### Fix
Stop mutating `this.get_query`. `apply_link_field_filters()` is now pure (returns the parsed filters), and `set_custom_query()` merges them into `args.filters` on every search as the base, with `get_query` / `df.filters` taking precedence. Since `set_custom_query` runs on each search, `eval:` filters are re-evaluated fresh.

### Before Fix
[Screencast from 2026-06-13 12-08-55.webm](https://github.com/user-attachments/assets/178cbf0b-95ed-4d01-aa8d-509ff93c0a72)


### After Fix
[Screencast from 2026-06-13 12-03-41.webm](https://github.com/user-attachments/assets/238f3738-3a86-4d0c-9c41-d39c08f06b40)

**Support Tickets**: [71149](https://support.frappe.io/helpdesk/tickets/71149), [70846](https://support.frappe.io/helpdesk/tickets/70846)
Fixes #39797