### PR TITLE
feat: Add gunicorn companion helper for COW-shared processes

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -10,7 +10,7 @@ from werkzeug.exceptions import HTTPException, NotFound
 from werkzeug.middleware.profiler import ProfilerMiddleware
 from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.middleware.shared_data import SharedDataMiddleware
-from werkzeug.wrappers import Request, Response
+from werkzeug.wrappers import Request, Response  # nosemgrep: frappe-monkey-patching-not-allowed
 from werkzeug.wsgi import ClosingIterator
 
 import frappe
@@ -48,7 +48,11 @@ import frappe.boot
 import frappe.client
 import frappe.core.doctype.file.file
 import frappe.core.doctype.user.user
-import frappe.database.mariadb.mysqlclient  # Load database related utils
+
+# Skipped under the companion manager: the gevent socketio companion forks this
+# master and refuses to start if MySQLdb is already imported. Loaded lazily there.
+if not os.environ.get("FRAPPE_GUNICORN_COMPANION"):
+	import frappe.database.mariadb.mysqlclient  # Load database related utils
 import frappe.database.query
 import frappe.desk.desktop  # workspace
 import frappe.desk.form.save
@@ -70,7 +74,7 @@ import frappe.website.website_generator  # web page doctypes
 # better werkzeug default
 # this is necessary because frappe desk sends most requests as form data
 # and some of them can exceed werkzeug's default limit of 500kb
-Request.max_form_memory_size = None
+Request.max_form_memory_size = None  # nosemgrep: frappe-monkey-patching-not-allowed
 
 
 def after_response_wrapper(app):

--- a/frappe/gunicorn_companion.py
+++ b/frappe/gunicorn_companion.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# License: MIT. See LICENSE
+"""Companion processes for the gunicorn companion manager.
+
+Each "run_*" function below is one companion (worker, scheduler, socketio).
+They are listed in "companion_workers" in the generated "config/gunicorn.conf.py"
+as "frappe.gunicorn_companion:run_*", and take no arguments.
+
+The manager starts each one by forking the already-loaded gunicorn master, so
+the companion reuses the master's memory instead of loading its own copy.
+"""
+
+import os
+
+
+def warmup() -> None:
+	"""Load the worker code in the master before any companion is forked, so the
+	worker and scheduler companions can reuse it instead of loading their own copy.
+
+	Called from the gunicorn "on_starting" hook. Socketio is left out on purpose:
+	loading it would pull gevent into the master and break the other companions.
+	"""
+	import redis
+	import rq
+	import rq.worker
+
+	try:
+		from rq.worker_pool import WorkerPool
+	except ImportError:
+		pass  # older rq keeps the pool elsewhere; safe to skip here
+
+	import frappe.utils.background_jobs
+	import frappe.utils.scheduler
+
+
+def run_scheduler() -> None:
+	"""Run frappe scheduler"""
+	from frappe.utils.scheduler import start_scheduler
+
+	start_scheduler()
+
+
+def run_worker() -> None:
+	"""Run one rq worker. Queues come from "FRAPPE_COMPANION_QUEUE" (comma list)."""
+	from frappe.utils.background_jobs import start_worker
+
+	queue = os.environ.get("FRAPPE_COMPANION_QUEUE") or None
+	start_worker(queue=queue)
+
+
+def run_worker_pool() -> None:
+	"""Run a pool of rq workers. Queues come from "FRAPPE_COMPANION_QUEUE", and
+	the number of workers from "FRAPPE_COMPANION_NUM_WORKERS" (default 1)."""
+	from frappe.utils.background_jobs import start_worker_pool
+
+	queue = os.environ.get("FRAPPE_COMPANION_QUEUE") or None
+	num_workers = int(os.environ.get("FRAPPE_COMPANION_NUM_WORKERS") or 1)
+	start_worker_pool(queue=queue, num_workers=num_workers)
+
+
+def run_socketio() -> None:
+	"""Run the realtime (socketio) server. The backend is chosen at runtime.
+
+	If the backend is "python": run in this process. Otherwise: hand off to
+	node running "apps/frappe/socketio.js". Either way this runs from the
+	bench dir, just like "bench socketio".
+	"""
+	backend = _socketio_backend()
+
+	if backend == "python":
+		from frappe.realtime.server import serve
+
+		serve()
+		return
+
+	import shutil
+
+	node = shutil.which("node") or shutil.which("nodejs")
+	if not node:
+		raise RuntimeError(
+			f"Cannot start socketio companion: node not found and socketio_backend is "
+			f"{backend!r} (not 'python'). Install node or set socketio_backend to 'python'."
+		)
+	os.execv(node, [node, os.path.join("apps", "frappe", "socketio.js")])
+
+
+def _socketio_backend() -> str:
+	"""Read "socketio_backend" from common_site_config. Defaults to "node".
+
+	The "sites/" folder is located from the bench root (via
+	"frappe.utils.get_bench_path"), not the current directory. So this reads the
+	right file whether bench is run from the bench dir or from inside "sites/".
+	"""
+	import json
+
+	from frappe.utils import get_bench_path
+
+	path = os.path.join(get_bench_path(), "sites", "common_site_config.json")
+	try:
+		with open(path) as config_file:  # nosemgrep
+			return (json.load(config_file) or {}).get("socketio_backend", "node")
+	except OSError, ValueError:
+		return "node"

--- a/frappe/gunicorn_companion.py
+++ b/frappe/gunicorn_companion.py
@@ -81,7 +81,9 @@ def run_socketio() -> None:
 			f"Cannot start socketio companion: node not found and socketio_backend is "
 			f"{backend!r} (not 'python'). Install node or set socketio_backend to 'python'."
 		)
-	os.execv(node, [node, os.path.join("apps", "frappe", "socketio.js")])
+	from frappe.utils import get_bench_path
+
+	os.execv(node, [node, os.path.join(get_bench_path(), "apps", "frappe", "socketio.js")])
 
 
 def _socketio_backend() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.2",
-    "pypdf==6.10.2",
+    "pypdf==6.12.0",
     "PyPika @ git+https://github.com/frappe/pypika@2c50e6142b2d61d2d243e466fdd5dc03b3d918f2",
     "mysqlclient==2.2.7",
     "PyQRCode~=1.2.1",


### PR DESCRIPTION
Related https://github.com/frappe/gunicorn/pull/15

Workers (rq, scheduler, socketio) previously each cold-started their own Python interpreter, paying the full import cost independently. With the gunicorn companion manager, the preloaded master forks to spawn each companion — they inherit the master's already-imported modules via copy-on-write and never reload them.

frappe/gunicorn_companion.py provides:
- warmup(): pre-imports redis/rq/background_jobs/scheduler in the master before the first fork so COW pages are already warm for workers
- run_{scheduler,worker,worker_pool}(): companion entry points that reuse the master's memory
- run_socketio(): runs python socketio in-process via gevent monkey-patching (always in-fork; no exec fallback to preserve full COW benefit)

frappe/app.py: gate mysqlclient eager-import behind FRAPPE_GUNICORN_COMPANION so the socketio companion can safely call gevent.monkey.patch_all() — MySQLdb in the master would break gevent's SSL/socket patches.

`no-docs`