### PR TITLE
fix(List View): clear selection after bulk edit to prevent stale selection

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2523,6 +2523,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					this.disable_list_update = true;
 					bulk_operations.edit(this.get_checked_items(true), field_mappings, () => {
 						this.disable_list_update = false;
+						this.clear_checked_items();
 						this.refresh();
 					});
 				},


### PR DESCRIPTION
## Problem

In the list view, every bulk action clears the row selection in its done-callback (`assign`, `add tags`, `apply assignment rule`, `delete`, `submit`, `cancel`) — except **Bulk Edit**, which only calls `refresh()` and leaves the selection intact.

Because selections are re-applied by docname after every re-render, the leftover selection persists (often scrolled out of view) into the next action. A subsequent Bulk Edit then operates on the previously-selected document instead of the one the user is looking at, while the dialog only shows a record count — so the wrong target is invisible.

We traced a production case where this silently overwrote a field on the wrong record repeatedly across a single session.

## Fix

Add `this.clear_checked_items()` to the `bulk_edit` done-callback, consistent with every other bulk action.

```js
bulk_operations.edit(this.get_checked_items(true), field_mappings, () => {
    this.disable_list_update = false;
    this.clear_checked_items();
    this.refresh();
});
```

## Steps to reproduce

1. Open any list view; tick a row near the bottom.
2. Scroll up / search so the ticked row is off-screen (header still shows "1 item selected").
3. Actions → Edit → set a field → Update.
4. Before: the selection survives and the next Bulk Edit re-targets the stale row. After: the selection clears immediately.