### PR TITLE
fix: link_filters customization should take precedence over programmatic get_query

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -855,7 +855,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 
 		const query_filters = this.get_query?.()?.filters || {};
 		if (query_filters) {
-			filters = { ...filters, ...query_filters };
+			filters = { ...query_filters, ...filters };
 		}
 
 		this.get_query = function () {


### PR DESCRIPTION
When a field has both a Customize Form `link_filters` and a programmatic `get_query`, a key collision (e.g. `status`) caused `get_query` to silently overwrite the admin's customization.

Reverse the spread order so `link_filters` wins on collision while non-conflicting `get_query` filters (e.g. `customer`) are still applied.

Closes #39231 regression.