### PR TITLE
refactor: move gravatar to deprecation dumpster and offer get_identicon as replacement

### DIFF
--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -1014,3 +1014,35 @@ def boilerplate_modules_txt(dest, app_name, app_title):
 
 	with open(os.path.join(dest, app_name, app_name, "modules.txt"), "w") as f:
 		f.write(frappe.as_unicode(app_title))
+
+
+@deprecated(
+	"frappe.utils.has_gravatar",
+	"2026-06-13",
+	"v17",
+	"Gravatar integration has been removed. Always returns empty string.",
+)
+def has_gravatar(email: str) -> str:
+	return ""
+
+
+@deprecated(
+	"frappe.utils.get_gravatar_url",
+	"2026-06-13",
+	"v17",
+	"Gravatar integration has been removed. Always returns empty string. Use get_identicon instead.",
+)
+def get_gravatar_url(email: str, default: str = "mm") -> str:
+	return ""
+
+
+@deprecated(
+	"frappe.utils.get_gravatar",
+	"2026-06-13",
+	"v17",
+	"Gravatar integration has been removed. Now always returns an identicon. Use get_identicon instead.",
+)
+def get_gravatar(email: str) -> str:
+	from frappe.utils import get_identicon
+
+	return get_identicon(email)

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -29,7 +29,7 @@ from frappe.utils import (
 	format_timedelta,
 	get_bench_path,
 	get_file_timestamp,
-	get_gravatar,
+	get_identicon,
 	get_link_to_report,
 	get_safe_filters,
 	get_site_info,
@@ -1204,15 +1204,14 @@ class TestLazyLoader(IntegrationTestCase):
 
 
 class TestIdenticon(IntegrationTestCase):
-	def test_get_gravatar(self):
-		# get_gravatar now always returns an identicon (base64 string)
-		gravatar_url = get_gravatar("developers@frappe.io")
-		self.assertIsInstance(gravatar_url, str)
-		self.assertTrue(gravatar_url.startswith("data:image/png;base64,"))
+	def test_get_identicon(self):
+		identicon_url = get_identicon("developers@frappe.io")
+		self.assertIsInstance(identicon_url, str)
+		self.assertTrue(identicon_url.startswith("data:image/png;base64,"))
 
-		gravatar_url = get_gravatar(f"developers{random_string(6)}@frappe.io")
-		self.assertIsInstance(gravatar_url, str)
-		self.assertTrue(gravatar_url.startswith("data:image/png;base64,"))
+		identicon_url = get_identicon(f"developers{random_string(6)}@frappe.io")
+		self.assertIsInstance(identicon_url, str)
+		self.assertTrue(identicon_url.startswith("data:image/png;base64,"))
 
 	def test_generate_identicon(self):
 		identicon = Identicon(random_string(6))

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -307,6 +307,13 @@ def random_string(length: int) -> str:
 	return "".join(secrets.choice(alphabet) for i in range(length))
 
 
+def get_identicon(email: str) -> str:
+	"""Return an identicon image (base64) for the given email."""
+	from frappe.utils.identicon import Identicon
+
+	return Identicon(email).base64()
+
+
 def get_traceback(with_context: bool = False) -> str:
 	"""Return the traceback of the Exception."""
 	from traceback_with_variables import iter_exc_lines

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -26,7 +26,14 @@ from typing import Any, Generic, TypeAlias, TypedDict
 import orjson
 from werkzeug.test import Client
 
-from frappe.deprecation_dumpster import gzip_compress, gzip_decompress, make_esc
+from frappe.deprecation_dumpster import (
+	get_gravatar,
+	get_gravatar_url,
+	gzip_compress,
+	gzip_decompress,
+	has_gravatar,
+	make_esc,
+)
 
 # utility functions like cint, int, flt, etc.
 from frappe.utils.data import *
@@ -298,23 +305,6 @@ def random_string(length: int) -> str:
 
 	alphabet = string.ascii_letters + string.digits
 	return "".join(secrets.choice(alphabet) for i in range(length))
-
-
-def has_gravatar(email: str) -> str:
-	"""Deprecated: Gravatar integration has been removed. Always returns empty string."""
-	return ""
-
-
-def get_gravatar_url(email: str, default: str = "mm") -> str:
-	"""Deprecated: Gravatar integration has been removed. Always returns empty string."""
-	return ""
-
-
-def get_gravatar(email: str) -> str:
-	"""Return an identicon image (base64) for the given email."""
-	from frappe.utils.identicon import Identicon
-
-	return Identicon(email).base64()
 
 
 def get_traceback(with_context: bool = False) -> str:

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -354,6 +354,7 @@ def render_safe_globals():
 			user=user,
 			get_fullname=frappe.utils.get_fullname,
 			get_gravatar=frappe.utils.get_gravatar_url,
+			get_identicon=frappe.utils.get_identicon,
 			full_name=frappe.local.session.data.full_name
 			if getattr(frappe.local, "session", None) and getattr(frappe.local.session, "data", None)
 			else "Guest",


### PR DESCRIPTION
- Deprecates Gravatar helpers and moves them into the deprecation path.
- Adds `get_identicon` as the replacement utility, exposes it to safe exec, and updates tests accordingly.