### PR TITLE
fix: drop existing gravatar URLs

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -236,6 +236,7 @@ frappe.patches.v15_0.validate_newsletter_recipients
 frappe.patches.v15_0.sanitize_workspace_titles
 frappe.patches.v15_0.migrate_role_profile_to_table_multi_select
 frappe.patches.v15_0.migrate_session_data
+frappe.patches.v15_0.drop_gravatar_images
 frappe.custom.doctype.property_setter.patches.remove_invalid_fetch_from_expressions
 frappe.patches.v16_0.switch_default_sort_order
 frappe.integrations.doctype.oauth_client.patches.set_default_allowed_role_in_oauth_client

--- a/frappe/patches/v15_0/drop_gravatar_images.py
+++ b/frappe/patches/v15_0/drop_gravatar_images.py
@@ -1,0 +1,24 @@
+from click import secho
+
+import frappe
+
+GRAVATAR_PATTERN = "%gravatar.com%"
+
+DOCTYPES = (
+	("User", "user_image"),
+	("Contact", "image"),
+)
+
+
+def execute():
+	"""Clear image fields that point to Gravatar."""
+	for doctype, fieldname in DOCTYPES:
+		filters = {fieldname: ("like", GRAVATAR_PATTERN)}
+		count = frappe.db.count(doctype, filters=filters)
+
+		if not count:
+			continue
+
+		secho(f"{doctype}: found {count} record(s) with Gravatar URL in `{fieldname}`", fg="yellow")
+		frappe.db.set_value(doctype, filters, fieldname, "", update_modified=False)
+		secho(f"  cleared {count} record(s)", fg="green")


### PR DESCRIPTION
Drop existing Gravatar URLs from image fields in **User** and **Contact** to stop requesting them on every form load.

Alternative (more code, better UX): #40018