### PR TITLE
ci: don't run greptile on PRs labeled "conflicts"

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,5 @@
+{
+    "disabledLabels": [
+        "conflicts"
+    ]
+}


### PR DESCRIPTION
Mergify backports often contain conflicts, automated PR review will invariably request changes, this is wasted compute.

Ref: https://www.greptile.com/docs/code-review/greptile-json-reference#pr-filters