### PR TITLE
fix(form): reset attachment preview on document switch

### DIFF
--- a/frappe/public/js/frappe/views/formview.js
+++ b/frappe/public/js/frappe/views/formview.js
@@ -72,6 +72,8 @@ frappe.views.FormFactory = class FormFactory extends frappe.views.Factory {
 	}
 
 	show_doc(route) {
+		this.clear_attachment_preview_state();
+
 		var doctype = route[1],
 			doctype_layout = frappe.router.doctype_layout || doctype,
 			name = route.slice(2).join("/");
@@ -123,7 +125,17 @@ frappe.views.FormFactory = class FormFactory extends frappe.views.Factory {
 	}
 
 	render(doctype_layout, name) {
+		this.clear_attachment_preview_state();
 		frappe.container.change_to(doctype_layout);
 		frappe.views.formview[doctype_layout].frm.refresh(name);
+	}
+
+	clear_attachment_preview_state() {
+		$(".attachment-preview-open, .attachment-preview-resizing")
+			.removeClass("attachment-preview-open attachment-preview-resizing")
+			.each((_, el) => el.style.removeProperty("--attachment-preview-width"));
+		$(".attachment-preview").remove();
+		$(document).off("keydown.attachment_preview");
+		$(document).off(".attachment_preview_resize");
 	}
 };

--- a/frappe/public/scss/desk/form_sidebar.scss
+++ b/frappe/public/scss/desk/form_sidebar.scss
@@ -293,7 +293,7 @@ body[data-route^="Form"] {
 		}
 	}
 
-	.attachment-preview-open {
+	.layout-main:has(.layout-side-section .attachment-preview:not(.hidden)) {
 		.layout-main-section-wrapper {
 			flex: 1 1 calc(100% - var(--attachment-preview-width));
 			width: calc(100% - var(--attachment-preview-width));


### PR DESCRIPTION
## Summary

This fixes stale attachment preview split-pane state when navigating between form documents.

The attachment preview pane adds split-view state to the reused form page. When switching to another document without closing the preview, the next form could inherit the split layout and show an empty right-hand pane.

This PR:
- clears attachment preview state before rendering a form route
- removes stale preview nodes and document-level preview listeners
- makes split-pane CSS depend on an actual visible preview element instead of only a state class

## Testing

- Built assets with npm run build
- Verified locally on prm.localhost:8000:
  1. Opened a Customer with an attachment
  2. Opened attachment preview
  3. Navigated to another Customer without closing preview
  4. Confirmed the new form shows the normal sidebar and no empty RHS pane