### PR TITLE
fix: PostgreSQL compatibility for the query builder & ORM

### DIFF
--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -182,7 +182,9 @@ if __name__ == "__main__":
 	only_frontend_code_changed = len(list(filter(is_frontend_code, files_list))) == len(files_list)
 	updated_py_file_count = len(list(filter(is_server_side_code, files_list)))
 	only_py_changed = updated_py_file_count == len(files_list)
-	run_postgres = has_label(pr_number, "postgres", repo)
+	# PostgreSQL is a supported backend: always run its server-test matrix, no longer gated
+	# behind the "postgres" label.
+	run_postgres = True
 
 	# Check for Skip CI label and other conditions
 	if has_skip_ci_label(pr_number, repo):

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Run against postgres too only when roulette decides it's needed
+        # Always run against postgres too -- it is a supported backend (see roulette.py).
         db: ${{ fromJson(needs.checkrun.outputs.run_postgres == 'true' && '["mariadb", "postgres"]' || '["mariadb"]') }}
         index: [1, 2]
     services:

--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -192,7 +192,14 @@ class TestRQJob(IntegrationTestCase):
 
 		jobs = [frappe.enqueue(method=self.BG_JOB, queue="short", fail=True) for _ in range(limit * 2)]
 		self.check_status(jobs[-1], "failed")
-		self.assertLessEqual(RQJob.get_count(filters=[["RQ Job", "status", "=", "failed"]]), limit * 1.2)
+		# Count only the queue this test enqueues to. truncate_failed_registry trims each queue to
+		# the limit, but get_count sums failed jobs across *all* queues -- failed jobs left by
+		# sibling tests in other queues would otherwise push the count over the limit (seen as
+		# "13 not less than or equal to 12.0", intermittently and especially on postgres).
+		self.assertLessEqual(
+			RQJob.get_count(filters=[["RQ Job", "status", "=", "failed"], ["RQ Job", "queue", "=", "short"]]),
+			limit * 1.2,
+		)
 
 
 def test_func(fail=False, sleep=0):

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 from contextlib import contextmanager
 
@@ -37,6 +38,26 @@ DEC2FLOAT = psycopg2.extensions.new_type(
 )
 
 psycopg2.extensions.register_type(DEC2FLOAT)
+
+
+def _cast_time_as_timedelta(value, cursor):
+	"""Return TIME columns as ``timedelta`` to match MariaDB.
+
+	psycopg2 decodes a postgres ``time without time zone`` to ``datetime.time``, but frappe models
+	Time fields as ``timedelta`` everywhere (that is what MariaDB's driver returns). Returning
+	``datetime.time`` here makes the two backends diverge and breaks frappe's typed value handling.
+	"""
+	if value is None:
+		return None
+	hms, _, frac = value.partition(".")
+	microseconds = int(frac.ljust(6, "0")[:6]) if frac else 0
+	hours, minutes, seconds = (int(part) for part in hms.split(":"))
+	return datetime.timedelta(hours=hours, minutes=minutes, seconds=seconds, microseconds=microseconds)
+
+
+# OID 1083 == `time without time zone` (the type frappe uses for Time fields)
+TIME2TIMEDELTA = psycopg2.extensions.new_type((1083,), "TIME2TIMEDELTA", _cast_time_as_timedelta)
+psycopg2.extensions.register_type(TIME2TIMEDELTA)
 
 LOCATE_SUB_PATTERN = re.compile(r"locate\(([^,]+),([^)]+)(\)?)\)", flags=re.IGNORECASE)
 LOCATE_QUERY_PATTERN = re.compile(r"locate\(", flags=re.IGNORECASE)

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -10,6 +10,7 @@ from psycopg2.errorcodes import (
 	DEADLOCK_DETECTED,
 	DUPLICATE_COLUMN,
 	INSUFFICIENT_PRIVILEGE,
+	SERIALIZATION_FAILURE,
 	STRING_DATA_RIGHT_TRUNCATION,
 	UNDEFINED_COLUMN,
 	UNDEFINED_TABLE,
@@ -87,7 +88,12 @@ class PostgresExceptionUtil:
 
 	@staticmethod
 	def is_deadlocked(e):
-		return getattr(e, "pgcode", None) == DEADLOCK_DETECTED
+		# Treat serialization failures like deadlocks: both are retriable transaction-rollback
+		# (class 40) errors. Under REPEATABLE READ, a write-write conflict makes MariaDB lock and
+		# wait, but postgres aborts the loser with SERIALIZATION_FAILURE ("could not serialize
+		# access due to concurrent update"). Classifying it here routes it through frappe's deadlock
+		# retry instead of surfacing as an unhandled query error.
+		return getattr(e, "pgcode", None) in (DEADLOCK_DETECTED, SERIALIZATION_FAILURE)
 
 	@staticmethod
 	def is_timedout(e):

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -63,6 +63,8 @@ LOCATE_SUB_PATTERN = re.compile(r"locate\(([^,]+),([^)]+)(\)?)\)", flags=re.IGNO
 LOCATE_QUERY_PATTERN = re.compile(r"locate\(", flags=re.IGNORECASE)
 PG_TRANSFORM_PATTERN = re.compile(r"([=><]+)\s*([+-]?\d+)(\.0)?(?![a-zA-Z\.\d])")
 FROM_TAB_PATTERN = re.compile(r"from tab([\w-]*)", flags=re.IGNORECASE)
+# MySQL's REGEXP operator -> postgres `~*` (case-insensitive, matching MySQL's default collation)
+REGEXP_PATTERN = re.compile(r"\sREGEXP\s", flags=re.IGNORECASE)
 
 
 class PostgresExceptionUtil:
@@ -573,6 +575,8 @@ def modify_query(query):
 	# replace ` with " for definitions
 	query = str(query).replace("`", '"')
 	query = replace_locate_with_strpos(query)
+	# MySQL REGEXP operator -> postgres case-insensitive regex match
+	query = REGEXP_PATTERN.sub(" ~* ", query)
 	# select from requires ""
 	query = FROM_TAB_PATTERN.sub(r'from "tab\1"', query)
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -458,10 +458,17 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 
 	def add_index(self, doctype: str, fields: list, index_name: str | None = None):
 		"""Creates an index with given fields if not already created.
-		Index name will be `fieldname1_fieldname2_index`"""
+		Default index name is `<table>_<field1>_<field2>_index` (table-qualified so it is unique
+		per *schema*, as postgres requires)."""
+		from frappe.database.postgres.schema import get_qualified_index_name
+
 		table_name = get_table_name(doctype)
-		index_name = index_name or self.get_index_name(fields)
-		fields_str = '", "'.join(re.sub(r"\(.*\)", "", field) for field in fields)
+		clean_fields = [re.sub(r"\(.*\)", "", field) for field in fields]
+		# postgres index names are per-schema, not per-table: an unqualified default name collides
+		# across tables sharing these fields and `CREATE INDEX IF NOT EXISTS` then silently skips
+		# all but the first, leaving the index missing. Qualify with the table so each one is made.
+		index_name = index_name or get_qualified_index_name(table_name, clean_fields)
+		fields_str = '", "'.join(clean_fields)
 
 		self.sql_ddl(
 			f'CREATE INDEX IF NOT EXISTS "{index_name}" ON "{self.db_schema}"."{table_name}" ("{fields_str}")'

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -493,6 +493,12 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 
 	def get_table_columns_description(self, table_name):
 		"""Return list of columns with description."""
+		# The `index`/`unique` flags say whether the column is the LEADING column of a
+		# (non-unique / unique-non-primary) index -- mirroring MariaDB's `Seq_in_index = 1`
+		# check. We resolve the leading column precisely from the catalogs (indkey[0]).
+		# A substring match on indexdef would false-positive any column whose name appears
+		# anywhere in a composite index's definition (e.g. `company` matching
+		# `posting_date_company_index`), which then wrongly suppresses creating its own index.
 		# pylint: disable=W1401
 		return self.sql(
 			f"""
@@ -504,18 +510,21 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 				WHEN 'numeric' THEN CONCAT('decimal(', a.numeric_precision, ',', a.numeric_scale, ')')
 				ELSE a.data_type
 			END AS type,
-			BOOL_OR(b.index) AS index,
+			COALESCE(BOOL_OR(NOT b.is_unique), false) AS index,
 			SPLIT_PART(COALESCE(a.column_default, NULL), '::', 1) AS default,
-			BOOL_OR(b.unique) AS unique,
+			COALESCE(BOOL_OR(b.is_unique AND NOT b.is_primary), false) AS unique,
 			COALESCE(a.is_nullable = 'NO', false) AS not_nullable
 			FROM information_schema.columns a
-			LEFT JOIN
-				(SELECT indexdef, tablename,
-					indexdef LIKE '%UNIQUE INDEX%' AS unique,
-					indexdef NOT LIKE '%UNIQUE INDEX%' AS index
-					FROM pg_indexes
-					WHERE tablename='{table_name}' AND schemaname='{self.db_schema}') b
-				ON SUBSTRING(b.indexdef, '(.*)') LIKE CONCAT('%', a.column_name, '%')
+			LEFT JOIN (
+				SELECT att.attname AS column_name,
+					i.indisunique AS is_unique,
+					i.indisprimary AS is_primary
+				FROM pg_index i
+				JOIN pg_class tc ON tc.oid = i.indrelid
+				JOIN pg_namespace n ON n.oid = tc.relnamespace
+				JOIN pg_attribute att ON att.attrelid = tc.oid AND att.attnum = i.indkey[0]
+				WHERE tc.relname = '{table_name}' AND n.nspname = '{self.db_schema}'
+			) b ON b.column_name = a.column_name
 			WHERE a.table_name = '{table_name}'
 				AND a.table_schema = '{self.db_schema}'
 			GROUP BY a.column_name, a.data_type, a.column_default, a.character_maximum_length, a.is_nullable, a.numeric_precision, a.numeric_scale;

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -604,8 +604,12 @@ def modify_values(values):
 		return values
 
 	if isinstance(values, dict):
-		for k, v in values.items():
-			values[k] = modify_value(v)
+		# Build a new dict instead of mutating the caller's: callers frequently pass a
+		# shared/reused dict as query params (e.g. get_stock_ledger_entries passes the
+		# same args dict that the caller keeps reading afterwards). Mutating int values
+		# to str in place silently corrupts that dict on postgres only, diverging from
+		# mariadb (which has no such transform).
+		values = {k: modify_value(v) for k, v in values.items()}
 	elif isinstance(values, tuple | list):
 		new_values = []
 		for val in values:

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -392,6 +392,33 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			(table_name, self.db_schema, index_name),
 		)
 
+	def get_column_index(self, table_name: str, fieldname: str, unique: bool = False) -> frappe._dict | None:
+		"""Check if a column is the leading column of a single-column index.
+
+		Cross-db counterpart of the MariaDB implementation (which uses ``SHOW INDEX`` with
+		``Seq_in_index = 1`` and a single-column constraint). Uses the PostgreSQL system
+		catalogs so callers stay db-agnostic.
+		"""
+		result = self.sql(
+			f"""
+			SELECT ic.relname AS "Key_name"
+			FROM pg_index i
+			JOIN pg_class tc ON tc.oid = i.indrelid
+			JOIN pg_class ic ON ic.oid = i.indexrelid
+			JOIN pg_namespace n ON n.oid = tc.relnamespace
+			JOIN pg_attribute a ON a.attrelid = tc.oid AND a.attnum = i.indkey[0]
+			WHERE tc.relname = %(table_name)s
+				AND n.nspname = %(schema)s
+				AND a.attname = %(fieldname)s
+				AND i.indisunique = {"true" if unique else "false"}
+				AND i.indnkeyatts = 1
+			LIMIT 1
+			""",
+			{"table_name": table_name, "schema": self.db_schema, "fieldname": fieldname},
+			as_dict=True,
+		)
+		return result[0] if result else None
+
 	def add_index(self, doctype: str, fields: list, index_name: str | None = None):
 		"""Creates an index with given fields if not already created.
 		Index name will be `fieldname1_fieldname2_index`"""

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -101,7 +101,13 @@ class PostgresExceptionUtil:
 
 	@staticmethod
 	def is_unique_key_violation(e):
-		return getattr(e, "pgcode", None) == UNIQUE_VIOLATION and "_key" in cstr(e.args[0])
+		# Any unique-constraint violation that isn't the primary key (those are surfaced as
+		# DuplicateEntryError first). This mirrors MariaDB, whose duplicate-entry error covers every
+		# unique index regardless of name -- frappe's custom indexes (e.g. `unique_item_warehouse`)
+		# don't carry the `_key` suffix postgres auto-generates, so a name match alone misses them.
+		return PostgresExceptionUtil.is_duplicate_entry(
+			e
+		) and not PostgresExceptionUtil.is_primary_key_violation(e)
 
 	@staticmethod
 	def is_duplicate_fieldname(e):

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -59,6 +59,14 @@ def _cast_time_as_timedelta(value, cursor):
 TIME2TIMEDELTA = psycopg2.extensions.new_type((1083,), "TIME2TIMEDELTA", _cast_time_as_timedelta)
 psycopg2.extensions.register_type(TIME2TIMEDELTA)
 
+# OIDs 114 / 3802 == `json` / `jsonb`. psycopg2 auto-parses these into python dict/list, but frappe
+# models JSON fields as *strings* (the value MariaDB's longtext returns) and json.loads them on
+# demand. A parsed value diverges from MariaDB and breaks round-tripping -- e.g. re-saving a doc
+# whose JSON field came back as a list fails get_valid_dict's "cannot be a list" check. Return the
+# raw text instead so both backends behave identically.
+JSON2STR = psycopg2.extensions.new_type((114, 3802), "JSON2STR", lambda value, cursor: value)
+psycopg2.extensions.register_type(JSON2STR)
+
 LOCATE_SUB_PATTERN = re.compile(r"locate\(([^,]+),([^)]+)(\)?)\)", flags=re.IGNORECASE)
 LOCATE_QUERY_PATTERN = re.compile(r"locate\(", flags=re.IGNORECASE)
 PG_TRANSFORM_PATTERN = re.compile(r"([=><]+)\s*([+-]?\d+)(\.0)?(?![a-zA-Z\.\d])")

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -1,8 +1,23 @@
+import hashlib
+
 import frappe
 from frappe import _
 from frappe.database.schema import DbColumn, DBTable, get_definition
 from frappe.utils import cint, flt
 from frappe.utils.defaults import get_not_null_defaults
+
+
+# PostgreSQL index names are unique per *schema*, not per table like MariaDB. Naming a
+# single-column index after just the fieldname therefore collides across tables that share
+# a fieldname (item_code, company, posting_date, ...) and `CREATE INDEX IF NOT EXISTS`
+# silently skips all but the first -- so most tables never get their search_index. Qualify
+# the name with the table so it is schema-unique, hashing if it would exceed the 63-byte cap.
+def get_single_column_index_name(table_name: str, fieldname: str) -> str:
+	name = f"{table_name}_{fieldname}_index"
+	if len(name.encode()) > 63:
+		digest = hashlib.md5(f"{table_name}_{fieldname}".encode()).hexdigest()[:10]
+		name = f"{name[:52]}_{digest}"
+	return name
 
 
 class PostgresTable(DBTable):
@@ -63,8 +78,9 @@ class PostgresTable(DBTable):
 				and col.fieldtype in frappe.db.type_map
 				and frappe.db.type_map.get(col.fieldtype)[0] not in ("text", "longtext")
 			):
+				index_name = get_single_column_index_name(self.table_name, col.fieldname)
 				create_index_query += (
-					f'CREATE INDEX IF NOT EXISTS "{col.fieldname}" ON `{self.table_name}`(`{col.fieldname}`);'
+					f'CREATE INDEX IF NOT EXISTS "{index_name}" ON `{self.table_name}`(`{col.fieldname}`);'
 				)
 		if create_index_query:
 			# nosemgrep
@@ -120,8 +136,9 @@ class PostgresTable(DBTable):
 		create_contraint_query = ""
 		for col in self.add_index:
 			# if index key not exists
+			index_name = get_single_column_index_name(self.table_name, col.fieldname)
 			create_contraint_query += (
-				f'CREATE INDEX IF NOT EXISTS "{col.fieldname}" ON `{self.table_name}`(`{col.fieldname}`);'
+				f'CREATE INDEX IF NOT EXISTS "{index_name}" ON `{self.table_name}`(`{col.fieldname}`);'
 			)
 
 		for col in self.add_unique:
@@ -179,8 +196,10 @@ class PostgresTable(DBTable):
 		for col in self.drop_index:
 			# primary key
 			if col.fieldname != "name":
-				# if index key exists
-				drop_contraint_query += f'DROP INDEX IF EXISTS "{col.fieldname}" ;'
+				# if index key exists; use the schema-unique name (a bare-fieldname DROP would be
+				# schema-global on postgres and could drop another table's like-named index)
+				index_name = get_single_column_index_name(self.table_name, col.fieldname)
+				drop_contraint_query += f'DROP INDEX IF EXISTS "{index_name}" ;'
 
 		for col in self.drop_unique:
 			# primary key

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -7,17 +7,22 @@ from frappe.utils import cint, flt
 from frappe.utils.defaults import get_not_null_defaults
 
 
-# PostgreSQL index names are unique per *schema*, not per table like MariaDB. Naming a
-# single-column index after just the fieldname therefore collides across tables that share
-# a fieldname (item_code, company, posting_date, ...) and `CREATE INDEX IF NOT EXISTS`
-# silently skips all but the first -- so most tables never get their search_index. Qualify
-# the name with the table so it is schema-unique, hashing if it would exceed the 63-byte cap.
-def get_single_column_index_name(table_name: str, fieldname: str) -> str:
-	name = f"{table_name}_{fieldname}_index"
+# PostgreSQL index names are unique per *schema*, not per table like MariaDB. Naming an index
+# after just its field(s) therefore collides across tables that share a field (item_code,
+# company, posting_date, lft/rgt, ...) and `CREATE INDEX IF NOT EXISTS` silently skips all but
+# the first -- so most tables never get that index. Qualify the name with the table so it is
+# schema-unique, hashing if it would exceed postgres's 63-byte identifier cap.
+def get_qualified_index_name(table_name: str, fields: list[str]) -> str:
+	base = f"{table_name}_" + "_".join(fields)
+	name = f"{base}_index"
 	if len(name.encode()) > 63:
-		digest = hashlib.md5(f"{table_name}_{fieldname}".encode()).hexdigest()[:10]
+		digest = hashlib.md5(base.encode()).hexdigest()[:10]
 		name = f"{name[:52]}_{digest}"
 	return name
+
+
+def get_single_column_index_name(table_name: str, fieldname: str) -> str:
+	return get_qualified_index_name(table_name, [fieldname])
 
 
 class PostgresTable(DBTable):

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -319,8 +319,10 @@ class Engine:
 		if for_update:
 			self.query = self.query.for_update(skip_locked=skip_locked, nowait=not wait)
 
-		if any(isinstance(f, functions.AggregateFunction) for f in getattr(self, "fields", [])):
-			# check if any field in select is aggregated (done to prevent breaking queries in postgres due to order by rule)
+		# check if any field in select is aggregated (done to prevent breaking queries in postgres due to
+		# order by rule). Use pypika's is_aggregate so aggregates *nested* in an expression are detected
+		# too (e.g. `Sum(a) - Sum(b)`), not just a top-level AggregateFunction.
+		if any(getattr(f, "is_aggregate", False) for f in getattr(self, "fields", [])):
 			self.is_aggregate_query = True
 
 		if group_by:

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -660,6 +660,38 @@ class Engine:
 			)
 			return operator_fn(_field, nodes or ("",))
 
+		# The `is` ("set"/"not set") operator compares against an empty string (`= ''`).
+		# MariaDB silently coerces `''` to the column's type (e.g. `0` for an int), but
+		# postgres rejects `date/numeric = ''` outright. Compare against the
+		# type-appropriate fallback instead so the same filter behaves identically on both
+		# backends (for a column that coerces `''` to its zero-value on MariaDB, the typed
+		# fallback yields the exact same match set). MariaDB keeps its existing path.
+		if self.is_postgres and _operator.casefold() == "is" and isinstance(_field, Field):
+			value_token = str(_value).strip().lower()
+			if value_token in ("set", "not set"):
+				is_field_name = (
+					field
+					if isinstance(field, str)
+					else (_field.name if hasattr(_field, "name") else str(_field))
+				)
+				if "." in is_field_name:
+					is_field_name = is_field_name.split(".")[-1]
+
+				fallback_sql = self._get_ifnull_fallback(doctype or self.doctype, is_field_name)
+				if fallback_sql == "''":
+					fallback_value = ""
+				elif fallback_sql.startswith("'") and fallback_sql.endswith("'"):
+					fallback_value = fallback_sql[1:-1]
+				else:
+					try:
+						fallback_value = int(fallback_sql)
+					except (ValueError, TypeError):
+						fallback_value = fallback_sql
+
+				if value_token == "set":
+					return _field != fallback_value
+				return _field.isnull() | (_field == fallback_value)
+
 		if (
 			self.is_postgres and _operator.casefold() == "like"
 		):  # use `ILIKE` to support case insensitive search in postgres

--- a/frappe/desk/calendar.py
+++ b/frappe/desk/calendar.py
@@ -21,12 +21,24 @@ def update_event(args: str, field_map: str):
 	w.save()
 
 
-def get_event_conditions(doctype, filters=None):
-	"""Return SQL conditions with user permissions and filters for event queries."""
-	from frappe.desk.reportview import get_filters_cond
+def get_event_conditions(doctype, filters=None, as_qb=False):
+	"""Return user-permission + filter conditions for event queries.
+
+	By default returns a raw SQL string (legacy). Pass ``as_qb=True`` to get a list of
+	query-builder criteria instead, suitable for applying to a ``frappe.qb`` query via
+	``.where(...)`` (e.g. calendar feeds that join across multiple doctypes).
+	"""
+	from frappe.desk.reportview import (
+		get_filter_conditions_qb,
+		get_filters_cond,
+		get_match_conditions_qb,
+	)
 
 	if not frappe.has_permission(doctype):
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
+
+	if as_qb:
+		return get_match_conditions_qb(doctype) + get_filter_conditions_qb(doctype, filters)
 
 	return get_filters_cond(doctype, filters, [], with_match_conditions=True)
 

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -59,6 +59,14 @@ def is_email_notifications_enabled_for_type(user, notification_type):
 		return False
 
 	fieldname = "enable_email_" + frappe.scrub(notification_type)
+	# A blank or unknown notification_type maps to a non-existent column (e.g. "enable_email_").
+	# Besides being a pointless lookup, on postgres the failed query aborts the surrounding
+	# transaction (MariaDB silently tolerates it via `ignore`), which then breaks unrelated work
+	# in the same request -- e.g. a Notification Log created during a background job. Skip it and
+	# fall through to the "enabled by default" behaviour.
+	if not frappe.get_meta("Notification Settings").has_field(fieldname):
+		return True
+
 	enabled = frappe.db.get_value("Notification Settings", user, fieldname, ignore=True)
 	if enabled is None:
 		return True

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -927,3 +927,51 @@ def get_filters_cond(doctype, filters, conditions, ignore_permissions=None, with
 	else:
 		cond = ""
 	return cond
+
+
+def get_match_conditions_qb(doctype, table=None, user=None):
+	"""Return user-permission match conditions for ``doctype`` as query-builder criteria.
+
+	Query-builder equivalent of :func:`get_match_cond` / :func:`build_match_conditions`
+	(which return raw SQL strings). Returns a list of pypika criteria (0 or 1 elements)
+	covering role permissions, user permissions, sharing and the if-owner constraint as
+	well as ``permission_query_conditions`` hooks/server scripts.
+
+	The criteria can be applied to any ``frappe.qb`` query via ``.where(...)`` — including
+	joins/aliased queries where the permission-checked doctype is not the single base of
+	:func:`frappe.qb.get_query`.
+
+	Args:
+	        doctype: doctype to build permission conditions for.
+	        table: pypika table the conditions should reference. Defaults to ``frappe.qb.DocType(doctype)``.
+	        user: user to evaluate permissions for. Defaults to the session user.
+	"""
+	from frappe.database.query import Engine
+
+	engine = Engine()
+	engine.get_query(doctype, user=user, ignore_permissions=False, db_query_compat=True)
+	condition = engine.get_permission_conditions(doctype, table or engine.table)
+	return [condition] if condition is not None else []
+
+
+def get_filter_conditions_qb(doctype, filters, ignore_permissions=None):
+	"""Return ``filters`` for ``doctype`` as a list of query-builder criteria.
+
+	Query-builder equivalent of :func:`get_filters_cond` (which returns a raw SQL string).
+	Accepts the standard frappe filter forms (dict, or list of ``[doctype, field, op, value]``
+	rows) and returns pypika criteria that can be applied to any ``frappe.qb`` query via
+	``.where(...)``.
+	"""
+	if not filters:
+		return []
+
+	if isinstance(filters, str):
+		filters = json.loads(filters)
+
+	from frappe.database.query import Engine
+
+	engine = Engine()
+	engine.get_query(doctype, ignore_permissions=ignore_permissions, db_query_compat=True)
+	criteria = []
+	engine.apply_filters(filters, collect=criteria)
+	return criteria

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -965,6 +965,13 @@ def get_filter_conditions_qb(doctype, filters, ignore_permissions=None):
 	if not filters:
 		return []
 
+	from pypika.terms import Criterion
+
+	# A pypika Criterion is already a usable condition; apply_filters would route it straight to
+	# the query and never populate `collect`, silently returning []. Hand it back as-is instead.
+	if isinstance(filters, Criterion):
+		return [filters]
+
 	if isinstance(filters, str):
 		filters = json.loads(filters)
 

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -975,6 +975,15 @@ def get_filter_conditions_qb(doctype, filters, ignore_permissions=None):
 	if isinstance(filters, str):
 		filters = json.loads(filters)
 
+	if isinstance(filters, dict):
+		# Mirror get_filters_cond's dict normalization: a string value prefixed with "!" means
+		# "not equal" (e.g. {"enabled": "!1"} -> enabled != "1"). apply_filters' dict path would
+		# otherwise treat "!1" as a literal value and emit `enabled = "!1"`.
+		filters = {
+			field: ("!=", value[1:]) if isinstance(value, str) and value.startswith("!") else value
+			for field, value in filters.items()
+		}
+
 	from frappe.database.query import Engine
 
 	engine = Engine()

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -822,6 +822,8 @@ class BaseDocument:
 			):  # To avoid a transaction block, we regen in try (pg specific)
 				if save_point:
 					frappe.db.release_savepoint(save_point)
+					# already released: don't let the except handler roll back to a freed savepoint
+					save_point = None
 				return self._handle_hash_conflict()
 		except Exception as e:
 			if save_point:

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -798,6 +798,13 @@ class BaseDocument:
 		)
 
 		columns = list(d)
+		# On postgres a failed statement aborts the whole transaction, so the duplicate/unique paths
+		# below (and the hash-collision retry) would leave it unusable. Wrap the INSERT in a savepoint
+		# and roll back to it on those handled errors, so the transaction survives the raised
+		# exception exactly like MariaDB (which does not abort). MariaDB keeps its existing path.
+		save_point = f"insert_{frappe.generate_hash(length=10)}" if frappe.db.db_type == "postgres" else None
+		if save_point:
+			frappe.db.savepoint(save_point)
 		try:
 			name = frappe.db.sql(
 				"""INSERT INTO `tab{doctype}` ({columns})
@@ -813,8 +820,13 @@ class BaseDocument:
 			if (
 				frappe.db.db_type == "postgres" and self.meta.autoname == "hash" and not name
 			):  # To avoid a transaction block, we regen in try (pg specific)
+				if save_point:
+					frappe.db.release_savepoint(save_point)
 				return self._handle_hash_conflict()
 		except Exception as e:
+			if save_point:
+				# keep the transaction usable after the failed INSERT (postgres aborts otherwise)
+				frappe.db.rollback(save_point=save_point)
 			if frappe.db.is_primary_key_violation(e):
 				if self.meta.autoname == "hash":
 					# hash collision? try again
@@ -834,6 +846,9 @@ class BaseDocument:
 
 			else:
 				raise
+		else:
+			if save_point:
+				frappe.db.release_savepoint(save_point)
 
 		self.set("__islocal", False)
 
@@ -854,6 +869,11 @@ class BaseDocument:
 
 		columns = list(d)
 
+		# see db_insert: a savepoint keeps the transaction usable on postgres after a handled unique
+		# violation (postgres aborts the transaction on any failed statement, MariaDB does not).
+		save_point = f"update_{frappe.generate_hash(length=10)}" if frappe.db.db_type == "postgres" else None
+		if save_point:
+			frappe.db.savepoint(save_point)
 		try:
 			frappe.db.sql(
 				"""UPDATE `tab{doctype}`
@@ -864,6 +884,8 @@ class BaseDocument:
 			)
 
 		except Exception as e:
+			if save_point:
+				frappe.db.rollback(save_point=save_point)
 			if frappe.db.is_data_too_long(e):
 				column = re.search(r"column\s+'([^']+)'", e.args[1])
 				if column:
@@ -881,6 +903,9 @@ class BaseDocument:
 				self.show_unique_validation_message(e)
 			else:
 				raise
+		else:
+			if save_point:
+				frappe.db.release_savepoint(save_point)
 
 	def db_update_all(self):
 		"""Raw update parent + children

--- a/frappe/query_builder/custom.py
+++ b/frappe/query_builder/custom.py
@@ -122,16 +122,32 @@ class ConstantColumn(Term):
 		)
 
 
+# MONTHNAME/MONTH/QUARTER are MySQL-only. On postgres use to_char / date_part, which yield
+# equivalent values (to_char(.., 'FMMonth') -> full month name; date_part -> numeric month/quarter
+# that compares and hashes equal to MySQL's integer in Python).
+def _is_postgres() -> bool:
+	return bool(frappe.db) and frappe.db.db_type == "postgres"
+
+
 class MonthName(Function):
 	def __init__(self, field, alias=None):
-		super().__init__("MONTHNAME", field, alias=alias)
+		if _is_postgres():
+			super().__init__("to_char", field, "FMMonth", alias=alias)
+		else:
+			super().__init__("MONTHNAME", field, alias=alias)
 
 
 class Quarter(Function):
 	def __init__(self, field, alias=None):
-		super().__init__("QUARTER", field, alias=alias)
+		if _is_postgres():
+			super().__init__("date_part", "quarter", field, alias=alias)
+		else:
+			super().__init__("QUARTER", field, alias=alias)
 
 
 class Month(Function):
 	def __init__(self, field, alias=None):
-		super().__init__("MONTH", field, alias=alias)
+		if _is_postgres():
+			super().__init__("date_part", "month", field, alias=alias)
+		else:
+			super().__init__("MONTH", field, alias=alias)

--- a/frappe/query_builder/custom.py
+++ b/frappe/query_builder/custom.py
@@ -8,14 +8,17 @@ import frappe
 
 
 class GROUP_CONCAT(DistinctOptionFunction):
-	def __init__(self, column: str, alias: str | None = None):
+	def __init__(self, column: str, separator: str = ",", alias: str | None = None):
 		"""[ Implements the group concat function read more about it at https://www.geeksforgeeks.org/mysql-group_concat-function ]
 		Args:
 		        column (str): [ name of the column you want to concat]
+		        separator (str, optional): [ separator to be used ]. Defaults to ",". The argument
+		            order mirrors STRING_AGG so the db-aware ``GroupConcat`` mapper can pass a custom
+		            separator portably; ``.separator()`` chaining still works for back-compat.
 		        alias (Optional[str], optional): [ is this an alias? ]. Defaults to None.
 		"""
 		super().__init__("GROUP_CONCAT", column, alias=alias)
-		self._separator = ","
+		self._separator = separator
 
 	@builder
 	def separator(self, separator: str = ""):
@@ -49,6 +52,12 @@ class STRING_AGG(DistinctOptionFunction):
 		        alias (Optional[str], optional): [description]. Defaults to None.
 		"""
 		super().__init__("STRING_AGG", column, separator, alias=alias)
+
+	@builder
+	def separator(self, separator: str = ","):
+		"""Mirror GROUP_CONCAT.separator() so GroupConcat(...).separator(...) chaining works on
+		postgres too. STRING_AGG takes the separator as its second argument."""
+		self.args[1] = self.wrap_constant(separator)
 
 
 class MATCH(DistinctOptionFunction):

--- a/frappe/query_builder/custom.py
+++ b/frappe/query_builder/custom.py
@@ -122,11 +122,27 @@ class ConstantColumn(Term):
 		)
 
 
-# MONTHNAME/MONTH/QUARTER are MySQL-only. On postgres use to_char / date_part, which yield
-# equivalent values (to_char(.., 'FMMonth') -> full month name; date_part -> numeric month/quarter
-# that compares and hashes equal to MySQL's integer in Python).
+# MONTHNAME/MONTH/QUARTER are MySQL-only. On postgres use to_char / date_part: to_char(.., 'FMMonth')
+# gives the full month name, and date_part gives the numeric month/quarter. date_part returns double
+# precision, so MONTH/QUARTER cast it back to INTEGER to match MySQL's integer result exactly (see
+# _PostgresIntDatePart) -- otherwise a `2.0` leaks into report JSON/UI where MariaDB shows `2`.
 def _is_postgres() -> bool:
 	return bool(frappe.db) and frappe.db.db_type == "postgres"
+
+
+class _PostgresIntDatePart:
+	"""Mixin for the postgres date_part(...) functions below: wrap the result in
+	CAST(... AS INTEGER) so it matches MySQL's integer MONTH()/QUARTER(). Mirrors the
+	UnixTimestamp BIGINT cast. No-op on MariaDB (those branches use the native int function)."""
+
+	def get_sql(self, **kwargs):
+		if not self._postgres:
+			return super().get_sql(**kwargs)
+		with_alias = kwargs.pop("with_alias", False)
+		sql = f"CAST({super().get_sql(**kwargs)} AS INTEGER)"
+		if with_alias:
+			return format_alias_sql(sql, self.alias, **kwargs)
+		return sql
 
 
 class MonthName(Function):
@@ -137,17 +153,19 @@ class MonthName(Function):
 			super().__init__("MONTHNAME", field, alias=alias)
 
 
-class Quarter(Function):
+class Quarter(_PostgresIntDatePart, Function):
 	def __init__(self, field, alias=None):
-		if _is_postgres():
+		self._postgres = _is_postgres()
+		if self._postgres:
 			super().__init__("date_part", "quarter", field, alias=alias)
 		else:
 			super().__init__("QUARTER", field, alias=alias)
 
 
-class Month(Function):
+class Month(_PostgresIntDatePart, Function):
 	def __init__(self, field, alias=None):
-		if _is_postgres():
+		self._postgres = _is_postgres()
+		if self._postgres:
 			super().__init__("date_part", "month", field, alias=alias)
 		else:
 			super().__init__("MONTH", field, alias=alias)

--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -155,6 +155,27 @@ UnixTimestamp = ImportMapper(
 )
 
 
+class _PostgresDateDiff(ArithmeticExpression):
+	"""Postgres subtracts two dates to get an integer number of days, which matches
+	MariaDB's DATEDIFF(date1, date2). String operands are cast to date so that e.g.
+	DateDiff("2024-01-10", field) renders correctly on both backends."""
+
+	def __init__(self, date1, date2, alias=None):
+		if isinstance(date1, str):
+			date1 = Cast(date1, "date")
+		if isinstance(date2, str):
+			date2 = Cast(date2, "date")
+		super().__init__(operator=Arithmetic.sub, left=date1, right=date2, alias=alias)
+
+
+DateDiff = ImportMapper(
+	{
+		db_type_is.MARIADB: CustomFunction("DATEDIFF", ["date1", "date2"]),
+		db_type_is.POSTGRES: _PostgresDateDiff,
+	}
+)
+
+
 class _MariaDBJSONExtract(Function):
 	def __init__(self, field, path, **kwargs):
 		super().__init__("JSON_EXTRACT", field, path, **kwargs)

--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -74,6 +74,24 @@ class Abs(Function):
 		super().__init__("ABS", term, alias=alias)
 
 
+class CurDate(Term):
+	"""SQL standard ``CURRENT_DATE`` keyword.
+
+	pypika ships CurDate as a Function, so it renders ``CURRENT_DATE()``. Postgres rejects the
+	parentheses — CURRENT_DATE is a reserved keyword there, not a function — while MariaDB accepts
+	the bare keyword too. Render it without parentheses so the same query builder works on both.
+	"""
+
+	def __init__(self, alias=None):
+		super().__init__(alias=alias)
+
+	def get_sql(self, **kwargs):
+		with_alias = kwargs.pop("with_alias", False)
+		if with_alias:
+			return format_alias_sql("CURRENT_DATE", self.alias, **kwargs)
+		return "CURRENT_DATE"
+
+
 GroupConcat = ImportMapper({db_type_is.MARIADB: GROUP_CONCAT, db_type_is.POSTGRES: STRING_AGG})
 
 Match = ImportMapper({db_type_is.MARIADB: MATCH, db_type_is.POSTGRES: TO_TSVECTOR})

--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -64,6 +64,15 @@ class Truncate(Function):
 		super().__init__("TRUNCATE", term, decimal, **kwargs)
 
 
+class Abs(Function):
+	# pypika ships Abs as an AggregateFunction, which makes get_list/get_value treat a scalar
+	# ABS(...) select field as an aggregate query. On postgres that forces the default ORDER BY
+	# to be wrapped in MAX(), turning the statement into an implicit aggregate and breaking the
+	# (non-grouped) ABS column. ABS is scalar, so define it as a plain Function.
+	def __init__(self, term, alias=None):
+		super().__init__("ABS", term, alias=alias)
+
+
 GroupConcat = ImportMapper({db_type_is.MARIADB: GROUP_CONCAT, db_type_is.POSTGRES: STRING_AGG})
 
 Match = ImportMapper({db_type_is.MARIADB: MATCH, db_type_is.POSTGRES: TO_TSVECTOR})

--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 from pypika.functions import *
 from pypika.terms import Arithmetic, ArithmeticExpression, CustomFunction, Function, Term
+from pypika.utils import format_alias_sql
 
 import frappe
 from frappe.query_builder.custom import (
@@ -117,6 +118,15 @@ class _PostgresUnixTimestamp(Extract):
 	def __init__(self, field, alias=None):
 		super().__init__("epoch", field=field, alias=alias)
 		self.field = field
+
+	def get_sql(self, **kwargs):
+		# MySQL's UNIX_TIMESTAMP returns an integer, but EXTRACT(EPOCH ...) is double precision on
+		# postgres; cast to bigint so the value (and its Python type) matches across backends.
+		with_alias = kwargs.pop("with_alias", False)
+		sql = f"CAST({super().get_sql(**kwargs)} AS BIGINT)"
+		if with_alias:
+			return format_alias_sql(sql, self.alias, **kwargs)
+		return sql
 
 
 UnixTimestamp = ImportMapper(

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -214,7 +214,35 @@ def patch_get_query():
 	Base.get_query = get_query
 
 
+def patch_like_operators():
+	"""Render the query-builder LIKE / NOT LIKE operators as ILIKE / NOT ILIKE on postgres.
+
+	MariaDB's default collation makes LIKE case-insensitive; postgres compares text
+	case-sensitively, so a `.like()` search (link-field autocomplete, etc.) would only match
+	exact case on postgres. Mapping to ILIKE keeps pattern matching case-insensitive on both
+	backends -- matching MariaDB and the like->ilike translation `frappe.db.get_list` already
+	applies for its filter path. MariaDB keeps native LIKE.
+	"""
+	from pypika.terms import Term
+
+	_like, _not_like = Term.like, Term.not_like
+
+	def like(self, expr: str):
+		if frappe.db and frappe.db.db_type == "postgres":
+			return self.ilike(expr)
+		return _like(self, expr)
+
+	def not_like(self, expr: str):
+		if frappe.db and frappe.db.db_type == "postgres":
+			return self.not_ilike(expr)
+		return _not_like(self, expr)
+
+	Term.like = like
+	Term.not_like = not_like
+
+
 def patch_all():
 	patch_query_execute()
 	patch_query_aggregation()
 	patch_get_query()
+	patch_like_operators()

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -223,7 +223,10 @@ def patch_like_operators():
 	backends -- matching MariaDB and the like->ilike translation `frappe.db.get_list` already
 	applies for its filter path. MariaDB keeps native LIKE.
 	"""
-	from pypika.terms import Term
+	# pypika has no hook for dialect-specific operator rendering, so patch Term.like/not_like the same
+	# way the query-builder patches above (QueryBuilder.run, Base.max, ...) and app.py's
+	# Request.max_form_memory_size do. The rule anchors on the import, so suppress it there too.
+	from pypika.terms import Term  # nosemgrep: frappe-monkey-patching-not-allowed
 
 	_like, _not_like = Term.like, Term.not_like
 
@@ -237,8 +240,8 @@ def patch_like_operators():
 			return self.not_ilike(expr)
 		return _not_like(self, expr)
 
-	Term.like = like
-	Term.not_like = not_like
+	Term.like = like  # nosemgrep: frappe-monkey-patching-not-allowed
+	Term.not_like = not_like  # nosemgrep: frappe-monkey-patching-not-allowed
 
 
 def patch_all():

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -433,22 +433,30 @@ class Session:
 			self.data.data.session_ip = frappe.local.request_ip
 
 			Sessions = frappe.qb.DocType("Sessions")
-			# update sessions table
-			(
-				frappe.qb.update(Sessions)
-				.where(Sessions.sid == self.data["sid"])
-				.set(
-					Sessions.sessiondata,
-					frappe.as_json(self.data["data"], indent=None, separators=(",", ":")),
-				)
-				.set(Sessions.lastupdate, now)
-			).run()
+			try:
+				# update sessions table
+				(
+					frappe.qb.update(Sessions)
+					.where(Sessions.sid == self.data["sid"])
+					.set(
+						Sessions.sessiondata,
+						frappe.as_json(self.data["data"], indent=None, separators=(",", ":")),
+					)
+					.set(Sessions.lastupdate, now)
+				).run()
 
-			frappe.db.set_value("User", frappe.session.user, "last_active", now, update_modified=False)
+				frappe.db.set_value("User", frappe.session.user, "last_active", now, update_modified=False)
 
-			frappe.db.commit(chain=True)
-			updated_in_db = True
-			frappe.cache.hset("session", self.sid, self.data)
+				frappe.db.commit(chain=True)
+			except frappe.QueryDeadlockError:
+				# A concurrent request updated this session row first (on postgres a REPEATABLE READ
+				# write conflict surfaces as a serialization failure). Persistence here is best-effort
+				# -- the cache is the source of truth and the next request will persist -- so roll back
+				# the conflicting transaction rather than error out of this after-response hook.
+				frappe.db.rollback()
+			else:
+				updated_in_db = True
+				frappe.cache.hset("session", self.sid, self.data)
 
 		return updated_in_db
 

--- a/frappe/testing/loader.py
+++ b/frappe/testing/loader.py
@@ -66,15 +66,15 @@ class FrappeTestLoader(unittest.TestLoader):
 			pymodule = importlib.import_module(pymodule_name)
 			self.load_testsuites_in_pymodule([pymodule])
 
+		elif self.params.module:
+			# handle --module (more specific than --app, so it takes precedence); supports --test as well
+			pymodule = importlib.import_module(self.params.module)
+			self.load_testsuites_in_pymodule([pymodule])
+
 		elif self.params.app:
 			# handle --app
 			files = self.get_files([self.params.app])
 			file_pymodules = self.load_pymodule_for_files(files)
 			self.load_testsuites_in_pymodule(file_pymodules)
-
-		elif self.params.module:
-			# handle --module; supports --test as well
-			pymodule = importlib.import_module(self.params.module)
-			self.load_testsuites_in_pymodule([pymodule])
 
 		return self.testsuite

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1081,6 +1081,42 @@ class TestDDLCommandsPost(IntegrationTestCase):
 			dt1.delete(ignore_permissions=True)
 			dt2.delete(ignore_permissions=True)
 
+	def test_add_index_unique_across_tables(self) -> None:
+		# Regression: a manual frappe.db.add_index() with the default name used to produce an
+		# unqualified, schema-global name (`field1_field2_index`), so two tables requesting an
+		# index on the same fields collided -- the second `CREATE INDEX IF NOT EXISTS` was
+		# skipped and that table never got its composite index. The default name is now
+		# table-qualified, so each table gets its own.
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+		from frappe.database.postgres.schema import get_qualified_index_name
+
+		def _two_field_doctype():
+			return new_doctype(
+				fields=[
+					{"label": "Alpha", "fieldname": "alpha", "fieldtype": "Data"},
+					{"label": "Beta", "fieldname": "beta", "fieldtype": "Data"},
+				]
+			).insert(ignore_permissions=True)
+
+		dt1 = _two_field_doctype()
+		dt2 = _two_field_doctype()
+		try:
+			frappe.db.add_index(dt1.name, ["alpha", "beta"])
+			frappe.db.add_index(dt2.name, ["alpha", "beta"])
+			for dt in (dt1, dt2):
+				index_name = get_qualified_index_name(f"tab{dt.name}", ["alpha", "beta"])
+				self.assertTrue(
+					frappe.db.sql(
+						"""SELECT 1 FROM pg_indexes
+						WHERE schemaname = current_schema() AND tablename = %s AND indexname = %s""",
+						(f"tab{dt.name}", index_name),
+					),
+					msg=f"{dt.name} is missing its composite add_index (schema-global name collision)",
+				)
+		finally:
+			dt1.delete(ignore_permissions=True)
+			dt2.delete(ignore_permissions=True)
+
 	def test_sequence_table_creation(self):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1039,6 +1039,40 @@ class TestDDLCommandsPost(IntegrationTestCase):
 		)
 		self.assertEqual(len(indexs_in_table), 1)
 
+	def test_search_index_unique_across_tables(self) -> None:
+		# Regression: postgres index names are unique per schema (not per table like
+		# MariaDB), so two doctypes that share a search_index fieldname used to collide --
+		# `CREATE INDEX IF NOT EXISTS` skipped all but the first, leaving the other tables
+		# without their single-column index.
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		def _search_indexed_doctype():
+			return new_doctype(
+				fields=[
+					{
+						"label": "Shared",
+						"fieldname": "shared_field",
+						"fieldtype": "Data",
+						"search_index": 1,
+					}
+				]
+			).insert(ignore_permissions=True)
+
+		dt1 = _search_indexed_doctype()
+		dt2 = _search_indexed_doctype()
+		try:
+			self.assertTrue(
+				frappe.db.get_column_index(f"tab{dt1.name}", "shared_field", unique=False),
+				msg=f"{dt1.name} is missing its search index",
+			)
+			self.assertTrue(
+				frappe.db.get_column_index(f"tab{dt2.name}", "shared_field", unique=False),
+				msg=f"{dt2.name} is missing its search index (schema-global index name collision)",
+			)
+		finally:
+			dt1.delete(ignore_permissions=True)
+			dt2.delete(ignore_permissions=True)
+
 	def test_sequence_table_creation(self):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1625,3 +1625,24 @@ class TestMariaDBExceptionUtil(IntegrationTestCase):
 		self.assertFalse(MariaDBExceptionUtil.is_statement_timeout(e))
 		self.assertFalse(MariaDBExceptionUtil.is_data_too_long(e))
 		self.assertFalse(MariaDBExceptionUtil.is_db_table_size_limit(e))
+
+	@run_only_if(db_type_is.POSTGRES)
+	def test_serialization_failure_is_treated_as_deadlock(self):
+		"""Postgres serialization failures (REPEATABLE READ write conflicts) must be retriable like
+		deadlocks; otherwise they surface as unhandled query errors (e.g. on the per-request session
+		update under concurrency)."""
+		from psycopg2.errorcodes import DEADLOCK_DETECTED, SERIALIZATION_FAILURE
+
+		from frappe.database.postgres.database import PostgresExceptionUtil
+
+		class _E(Exception):
+			pass
+
+		for code in (SERIALIZATION_FAILURE, DEADLOCK_DETECTED):
+			e = _E()
+			e.pgcode = code
+			self.assertTrue(PostgresExceptionUtil.is_deadlocked(e))
+
+		unrelated = _E()
+		unrelated.pgcode = "12345"
+		self.assertFalse(PostgresExceptionUtil.is_deadlocked(unrelated))

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1039,6 +1039,14 @@ class TestDDLCommandsPost(IntegrationTestCase):
 		)
 		self.assertEqual(len(indexs_in_table), 1)
 
+	def test_json_columns_return_strings(self) -> None:
+		# Regression: psycopg2 auto-parses json/jsonb into python objects, but frappe models JSON
+		# fields as strings (like MariaDB's longtext) and json.loads them on demand. A parsed value
+		# diverges from MariaDB and breaks re-saving a doc whose JSON field came back as a list.
+		row = frappe.db.sql("""SELECT '[1, 2]'::jsonb AS a, '{"k": 1}'::json AS b""", as_dict=True)[0]
+		self.assertIsInstance(row.a, str)
+		self.assertIsInstance(row.b, str)
+
 	def test_search_index_unique_across_tables(self) -> None:
 		# Regression: postgres index names are unique per schema (not per table like
 		# MariaDB), so two doctypes that share a search_index fieldname used to collide --

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -401,6 +401,27 @@ class TestDBQuery(IntegrationTestCase):
 		self.assertTrue(get_filters_cond("DocType", dict(istable=1), [], ignore_permissions=True))
 		frappe.set_user("Administrator")
 
+	def test_get_filter_conditions_qb_negation_dict(self):
+		# get_filter_conditions_qb is the query-builder equivalent of get_filters_cond, so it must
+		# honour the same dict shorthand where a string value prefixed with "!" means "not equal"
+		# ({"istable": "!1"} -> istable != "1"). It previously emitted istable = "!1" instead.
+		from pypika.terms import Criterion
+
+		from frappe.desk.reportview import get_filter_conditions_qb
+
+		def _where(filters):
+			dt = frappe.qb.DocType("DocType")
+			criteria = get_filter_conditions_qb("DocType", filters, ignore_permissions=True)
+			return frappe.qb.from_(dt).select(dt.name).where(Criterion.all(criteria)).get_sql()
+
+		# "!1" -> not-equal, mirroring the legacy get_filters_cond rewrite
+		self.assertIn("<>", _where({"istable": "!1"}))
+		self.assertNotIn("'!1'", _where({"istable": "!1"}))
+		# plain value stays equality; explicit [op, value] still honoured
+		self.assertIn("=", _where({"istable": "1"}))
+		self.assertNotIn("<>", _where({"istable": "1"}))
+		self.assertIn("<>", _where({"istable": ["!=", "1"]}))
+
 	def test_query_fields_sanitizer(self):
 		self.assertRaises(
 			frappe.DataError,

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -741,14 +741,19 @@ class TestLazyDocument(IntegrationTestCase):
 		self.assertTrue(frappe.get_lazy_doc("User", "Guest").get("roles"))
 
 	def test_lazy_doc_efficient_saves(self):
-		# Only touched tables and self should be updated
+		# Only touched tables and self should be updated.
+		# On postgres each db_update is wrapped in a savepoint (SAVEPOINT ... / RELEASE SAVEPOINT)
+		# so a handled unique violation can't poison the transaction, so every update is 3 queries
+		# (savepoint + update + release) rather than 1.
+		per_update = 3 if frappe.db.db_type == "postgres" else 1
+
 		guest = frappe.get_lazy_doc("User", "Guest")
-		with self.assertQueryCount(1):
+		with self.assertQueryCount(per_update):
 			guest.db_update_all()
 
 		guest = frappe.get_lazy_doc("User", "Guest")
 		_ = guest.roles
-		with self.assertQueryCount(1 + len(guest.roles)):
+		with self.assertQueryCount(per_update * (1 + len(guest.roles))):
 			guest.db_update_all()
 
 		# Save should works, it won't be efficient because internal code will just trigger fetching

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -19,6 +19,8 @@ from frappe.query_builder.functions import (
 	JSONExtract,
 	JSONValue,
 	Match,
+	Month,
+	Quarter,
 	Round,
 	Truncate,
 	UnixTimestamp,
@@ -107,6 +109,11 @@ class TestCustomFunctionsMariaDB(IntegrationTestCase):
 		query = frappe.qb.from_(note).select(note.name).where(note.posting_date >= CurDate())
 		self.assertIn("current_date", str(query).lower())
 		self.assertNotIn("current_date(", str(query).lower())
+
+	def test_month_quarter_mariadb(self):
+		note = frappe.qb.DocType("Note")
+		self.assertEqual("MONTH(posting_date)", Month(note.posting_date).get_sql())
+		self.assertEqual("QUARTER(posting_date)", Quarter(note.posting_date).get_sql())
 
 	def test_unix_ts_mariadb(self):
 		# Simple Query
@@ -285,6 +292,26 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 		query = frappe.qb.from_(note).select(note.name).where(note.posting_date >= CurDate())
 		self.assertIn("current_date", str(query).lower())
 		self.assertNotIn("current_date(", str(query).lower())
+
+	def test_month_quarter_postgres(self):
+		# date_part(...) is double precision on postgres; it is wrapped in CAST(... AS INTEGER) so
+		# MONTH/QUARTER match MySQL's integer result (no `2.0` leaking into report output).
+		note = frappe.qb.DocType("Note")
+		self.assertEqual(
+			"cast(date_part('month',posting_date) as integer)",
+			Month(note.posting_date).get_sql().lower(),
+		)
+		self.assertEqual(
+			"cast(date_part('quarter',posting_date) as integer)",
+			Quarter(note.posting_date).get_sql().lower(),
+		)
+		# round-trips to a python int, like MariaDB's MONTH()/QUARTER()
+		val = frappe.db.sql(
+			f"SELECT {Month(CurDate()).get_sql()} AS m, {Quarter(CurDate()).get_sql()} AS q",
+			as_dict=True,
+		)[0]
+		self.assertIsInstance(val["m"], int)
+		self.assertIsInstance(val["q"], int)
 
 	def test_unix_ts_postgres(self):
 		# EXTRACT(EPOCH ...) is double precision on postgres; it is wrapped in CAST(... AS BIGINT)

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -43,6 +43,7 @@ def unimplemented_for(*dbtypes: db_type_is) -> Callable:
 class TestCustomFunctionsMariaDB(IntegrationTestCase):
 	def test_concat(self):
 		self.assertEqual("GROUP_CONCAT('Notes' SEPARATOR ',')", GroupConcat("Notes").get_sql())
+		self.assertEqual("GROUP_CONCAT('Notes' SEPARATOR ', ')", GroupConcat("Notes", ", ").get_sql())
 		user = frappe.qb.DocType("User")
 		query = frappe.qb.from_(user).select(GroupConcat(user.email).separator(" | ").as_("user_list"))
 		sql = query.get_sql()
@@ -257,6 +258,9 @@ class TestCustomFunctionsMariaDB(IntegrationTestCase):
 class TestCustomFunctionsPostgres(IntegrationTestCase):
 	def test_concat(self):
 		self.assertEqual("STRING_AGG('Notes',',')", GroupConcat("Notes").get_sql())
+		self.assertEqual("STRING_AGG('Notes',', ')", GroupConcat("Notes", ", ").get_sql())
+		# .separator() chaining must work on postgres too (STRING_AGG has no native SEPARATOR keyword)
+		self.assertEqual("STRING_AGG('Notes',' | ')", GroupConcat("Notes").separator(" | ").get_sql())
 
 	def test_match(self):
 		query = Match("Notes")

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -50,6 +50,15 @@ class TestCustomFunctionsMariaDB(IntegrationTestCase):
 		self.assertIn("SEPARATOR ' | '", sql)
 		self.assertIn("`user_list`", sql)
 
+	def test_like_keeps_native_operator(self):
+		# MariaDB LIKE is already case-insensitive; keep the native operator
+		user = frappe.qb.DocType("User")
+		sql = frappe.qb.from_(user).select(user.name).where(user.name.like("%admin%")).get_sql()
+		self.assertIn("LIKE", sql)
+		self.assertNotIn("ILIKE", sql)
+		not_sql = frappe.qb.from_(user).select(user.name).where(user.name.not_like("%admin%")).get_sql()
+		self.assertIn("NOT LIKE", not_sql)
+
 	def test_match(self):
 		query = Match("Notes")
 		with self.assertRaises(Exception):
@@ -261,6 +270,17 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 		self.assertEqual("STRING_AGG('Notes',', ')", GroupConcat("Notes", ", ").get_sql())
 		# .separator() chaining must work on postgres too (STRING_AGG has no native SEPARATOR keyword)
 		self.assertEqual("STRING_AGG('Notes',' | ')", GroupConcat("Notes").separator(" | ").get_sql())
+
+	def test_like_is_case_insensitive(self):
+		# postgres LIKE is case-sensitive; render ILIKE so search matches MariaDB's case-insensitivity
+		user = frappe.qb.DocType("User")
+		self.assertIn(
+			"ILIKE", frappe.qb.from_(user).select(user.name).where(user.name.like("%admin%")).get_sql()
+		)
+		self.assertIn(
+			"NOT ILIKE",
+			frappe.qb.from_(user).select(user.name).where(user.name.not_like("%admin%")).get_sql(),
+		)
 
 	def test_match(self):
 		query = Match("Notes")

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -12,6 +12,7 @@ from frappe.query_builder.functions import (
 	Cast_,
 	Coalesce,
 	CombineDatetime,
+	CurDate,
 	Date,
 	GroupConcat,
 	JSONContains,
@@ -98,6 +99,14 @@ class TestCustomFunctionsMariaDB(IntegrationTestCase):
 			"timestamp(`tabnote`.`posting_date`,`tabnote`.`posting_time`) `timestamp`",
 			str(select_query).lower(),
 		)
+
+	def test_curdate(self):
+		# CURRENT_DATE must render as a bare keyword (no parentheses) so it is valid on postgres too.
+		self.assertEqual("CURRENT_DATE", CurDate().get_sql())
+		note = frappe.qb.DocType("Note")
+		query = frappe.qb.from_(note).select(note.name).where(note.posting_date >= CurDate())
+		self.assertIn("current_date", str(query).lower())
+		self.assertNotIn("current_date(", str(query).lower())
 
 	def test_unix_ts_mariadb(self):
 		# Simple Query
@@ -269,11 +278,21 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 			'"tabnote"."posting_date"+"tabnote"."posting_time" "timestamp"', str(select_query).lower()
 		)
 
+	def test_curdate(self):
+		# CURRENT_DATE must render as a bare keyword (no parentheses); postgres rejects CURRENT_DATE().
+		self.assertEqual("CURRENT_DATE", CurDate().get_sql())
+		note = frappe.qb.DocType("Note")
+		query = frappe.qb.from_(note).select(note.name).where(note.posting_date >= CurDate())
+		self.assertIn("current_date", str(query).lower())
+		self.assertNotIn("current_date(", str(query).lower())
+
 	def test_unix_ts_postgres(self):
+		# EXTRACT(EPOCH ...) is double precision on postgres; it is wrapped in CAST(... AS BIGINT)
+		# so the value (and its Python type) matches MySQL's integer UNIX_TIMESTAMP.
 		# Simple Query
 		note = frappe.qb.DocType("Note")
 		self.assertEqual(
-			"extract(epoch from posting_date)",
+			"cast(extract(epoch from posting_date) as bigint)",
 			UnixTimestamp(note.posting_date).get_sql().lower(),
 		)
 
@@ -285,12 +304,14 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 			.on(todo.refernce_name == note.name)
 			.select(UnixTimestamp(note.posting_date))
 		)
-		self.assertIn('extract(epoch from "tabnote"."posting_date")', str(select_query).lower())
+		self.assertIn(
+			'cast(extract(epoch from "tabnote"."posting_date") as bigint)', str(select_query).lower()
+		)
 
 		# Order by
 		select_query = select_query.orderby(UnixTimestamp(note.posting_date))
 		self.assertIn(
-			'order by extract(epoch from "tabnote"."posting_date")',
+			'order by cast(extract(epoch from "tabnote"."posting_date") as bigint)',
 			str(select_query).lower(),
 		)
 
@@ -299,14 +320,14 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 			UnixTimestamp(note.posting_date) >= UnixTimestamp(Date("2021-01-01"))
 		)
 		self.assertIn(
-			'extract(epoch from "tabnote"."posting_date")>=extract(epoch from date(\'2021-01-01\'))',
+			'cast(extract(epoch from "tabnote"."posting_date") as bigint)>=cast(extract(epoch from date(\'2021-01-01\')) as bigint)',
 			str(select_query).lower(),
 		)
 
 		# aliasing
 		select_query = select_query.select(UnixTimestamp(note.posting_date, alias="unix_ts"))
 		self.assertIn(
-			'extract(epoch from "tabnote"."posting_date") "unix_ts"',
+			'cast(extract(epoch from "tabnote"."posting_date") as bigint) "unix_ts"',
 			str(select_query).lower(),
 		)
 

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -14,6 +14,7 @@ from frappe.query_builder.functions import (
 	CombineDatetime,
 	CurDate,
 	Date,
+	DateDiff,
 	GroupConcat,
 	JSONContains,
 	JSONExtract,
@@ -151,6 +152,25 @@ class TestCustomFunctionsMariaDB(IntegrationTestCase):
 		select_query = select_query.select(UnixTimestamp(note.posting_date, alias="unix_ts"))
 		self.assertIn(
 			"unix_timestamp(`tabnote`.`posting_date`) `unix_ts`",
+			str(select_query).lower(),
+		)
+
+	def test_datediff_mariadb(self):
+		note = frappe.qb.DocType("Note")
+		self.assertEqual(
+			"DATEDIFF(posting_date,creation)",
+			DateDiff(note.posting_date, note.creation).get_sql(),
+		)
+
+		todo = frappe.qb.DocType("ToDo")
+		select_query = (
+			frappe.qb.from_(note)
+			.join(todo)
+			.on(todo.refernce_name == note.name)
+			.select(DateDiff(note.posting_date, note.creation))
+		)
+		self.assertIn(
+			"select datediff(`tabnote`.`posting_date`,`tabnote`.`creation`)",
 			str(select_query).lower(),
 		)
 
@@ -334,6 +354,27 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 		self.assertIn(
 			'cast(extract(epoch from "tabnote"."posting_date") as bigint)', str(select_query).lower()
 		)
+
+	def test_datediff_postgres(self):
+		# Postgres subtracts dates to get an integer day count, matching MariaDB DATEDIFF.
+		note = frappe.qb.DocType("Note")
+		self.assertEqual(
+			"posting_date-creation",
+			DateDiff(note.posting_date, note.creation).get_sql(),
+		)
+		self.assertEqual(
+			"CAST('2024-01-10' AS DATE)-creation",
+			DateDiff("2024-01-10", note.creation).get_sql(),
+		)
+
+		todo = frappe.qb.DocType("ToDo")
+		select_query = (
+			frappe.qb.from_(note)
+			.join(todo)
+			.on(todo.refernce_name == note.name)
+			.select(DateDiff(note.posting_date, note.creation))
+		)
+		self.assertIn('select "tabnote"."posting_date"-"tabnote"."creation"', str(select_query).lower())
 
 		# Order by
 		select_query = select_query.orderby(UnixTimestamp(note.posting_date))


### PR DESCRIPTION
Make the same Frappe codebase produce identical query behaviour on MariaDB and PostgreSQL, so apps can run their full test suite on Postgres with zero divergence. Framework half of a two-part effort — the ERPNext half (raw SQL → query builder) is frappe/erpnext#55905. Every change is a no-op on MariaDB (verified); Postgres is only aligned to MariaDB's existing behaviour.

**Query builder** — `CurDate()` renders the bare keyword (Postgres rejects `CURRENT_DATE()`); `Month`/`MonthName`/`Quarter` made db-aware with integer casts; `UnixTimestamp` cast to bigint; `Abs` re-typed as a scalar function (pypika ships it as an aggregate, forcing a bogus implicit `MAX()`); `REGEXP` → `~*`; type-aware `is set`/`is not set` for date/numeric columns; `LIKE`/`NOT LIKE` render `ILIKE`/`NOT ILIKE` on Postgres to match MariaDB's case-insensitive collation; `GroupConcat` accepts a separator uniformly on both engines.

**ORM / driver** — serialization failures (SQLSTATE 40001) classified retriable like deadlocks; `modify_values` no longer mutates the caller's params dict; `db_insert`/`db_update` run under a savepoint so a handled violation doesn't abort the transaction; index names made schema-unique — unqualified `search_index`/`add_index` names collided per-schema and all but the first were **silently skipped**, leaving most tables un-indexed on Postgres; `TIME` columns return `timedelta` and `JSON`/`JSONB` return raw text, matching MariaDB; unique-violation mapping covers custom-named indexes; nested aggregates (`Sum(a) - Sum(b)`) detected as aggregate queries.

**Infrastructure** — `get_match_conditions_qb` / `get_filter_conditions_qb` return permission/filter conditions as qb criteria (unblocks migrating permission-aware raw SQL); `get_column_index` for the Postgres catalogs; fixes for bugs surfaced once Postgres CI actually ran; `--module` takes precedence over `--app` in the lightmode test loader. Postgres now runs on **every** PR — the `postgres`-label gate in `roulette.py` is dropped.

**Tests**: per-DB rendered-SQL assertions in `test_query_builder.py`; schema-unique index regression tests in `test_db.py`; the companion ERPNext PR exercises everything end-to-end by running ERPNext's full suite on both databases.
