### PR TITLE
fix(session_default): prevent saving empty rows in session defaults

### DIFF
--- a/frappe/core/doctype/session_default/session_default.json
+++ b/frappe/core/doctype/session_default/session_default.json
@@ -13,18 +13,20 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Document Type",
-   "options": "DocType"
+   "options": "DocType",
+   "reqd": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-23 16:03:38.225606",
+ "modified": "2026-06-12 00:07:01.418734",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Session Default",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/core/doctype/session_default/session_default.py
+++ b/frappe/core/doctype/session_default/session_default.py
@@ -19,7 +19,7 @@ class SessionDefault(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		ref_doctype: DF.Link | None
+		ref_doctype: DF.Link
 	# end: auto-generated types
 
 	pass


### PR DESCRIPTION
Issue: In the Session Default Settings child table, users can click "Add Row" and save the document without selecting a value in the newly added row. This allows empty entries to be saved, resulting in incomplete and invalid data.

Before : 

<img width="1838" height="930" alt="image" src="https://github.com/user-attachments/assets/d6a7d74e-c457-40f4-9068-220065cff682" />

After : 

<img width="1855" height="936" alt="image" src="https://github.com/user-attachments/assets/599876e2-f973-48cc-bc3a-5210fb82438c" />

Backport Needed For V16 and V15