### PR TITLE
fix(auto repeat): filter reference_document to show only submitted doc

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.js
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.js
@@ -14,6 +14,7 @@ frappe.ui.form.on("Auto Repeat", {
 			return {
 				filters: {
 					auto_repeat: "",
+					docstatus: ["!=", 2],
 				},
 			};
 		};


### PR DESCRIPTION
 
**Issue:** Cancelled documents were also being displayed in the reference_document field.

**Description:** Updated the query condition for the reference_document field to display only submitted documents and exclude cancelled records.

**Before:** 

<img width="1280" height="573" alt="image" src="https://github.com/user-attachments/assets/06ce551d-4c94-4c69-a4b5-3d0a1e11cae6" />

**After:** 

<img width="1280" height="645" alt="image" src="https://github.com/user-attachments/assets/049df7e5-266c-40b1-b744-696387664547" />

**Backport Needed For V16 and V15**