### PR TITLE
fix: always enable btn; failure on throw from client side

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -605,7 +605,7 @@ frappe.ui.Page = class Page {
 	btn_disable_enable(btn, response) {
 		if (response && response.then) {
 			btn.prop("disabled", true);
-			response.then(() => {
+			response.finally(() => {
 				btn.prop("disabled", false);
 			});
 		} else if (response && response.always) {


### PR DESCRIPTION
## Issue

Primary button did not enable after frappe.throw

### Before

https://github.com/user-attachments/assets/e2acfca4-5f9d-4417-bd8a-1411e147f8cd

### After

https://github.com/user-attachments/assets/dc4d39da-5dcb-4454-9ea4-b269cfe22cac
