### PR TITLE
fix: use Meta obj. internally for safer_get_visible_columns

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -239,8 +239,11 @@ def safer_log_error(
 	return {}
 
 
-def safer_get_visible_columns(*args, **kwargs):
-	cols = get_visible_columns(*args, **kwargs)
+def safer_get_visible_columns(data, _table_meta, df):
+	if not df.get("options"):
+		return []
+	real_meta = frappe.get_meta(df.get("options"))
+	cols = get_visible_columns(data, real_meta, df)
 	if cols is None:
 		return None
 	return [c if isinstance(c, dict) else c.as_dict() for c in cols]
@@ -286,7 +289,7 @@ def make_safe_get_request(url: str, **kwargs):
 	for record in addr_info:
 		try:
 			addr = ipaddress.ip_address(record[4][0])
-		except ValueError, IndexError:
+		except (ValueError, IndexError):
 			continue
 
 		if not addr.is_global:


### PR DESCRIPTION
Use real meta instead of a dehydrated obj. in `get_visible_columns`. 

Resolves breakages where:

```python
  File "apps/frappe/frappe/utils/safe_exec.py", line 243, in safer_get_visible_columns
    cols = get_visible_columns(*args, **kwargs)
  File "apps/frappe/frappe/www/printview.py", line 672, in get_visible_columns
    docfield = table_meta.get_field(col_df.get("fieldname"))
TypeError: 'NoneType' object is not callable
```