### PR TITLE
fix: guard subject/sender filters when Append To doctype lacks subject_field

### DIFF
--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -652,6 +652,19 @@ class TestInboundMail(IntegrationTestCase):
 			# Should return None instead of raising an exception
 			self.assertIsNone(inbound_mail.match_record_by_subject_and_sender("ToDo"))
 
+	def test_subject_match_when_append_to_doctype_has_no_sender_field(self):
+		"""Subject matching must skip the sender filter (not crash) when sender_field is absent."""
+		mail_content = self.get_test_mail(fname="incoming-subject-placeholder.raw").replace(
+			"{{ subject }}", "RE: An unmatched subject line"
+		)
+		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")
+		inbound_mail = InboundMail(mail_content, email_account, 12345, 1)
+
+		# subject_field set, sender_field absent: must build the subject filter and skip the sender one.
+		no_sender_field = frappe._dict(subject_field="description", sender_field=None)
+		with patch.object(InboundMail, "get_email_fields", return_value=no_sender_field):
+			self.assertIsNone(inbound_mail.match_record_by_subject_and_sender("ToDo"))
+
 	def test_reference_document_by_subject_match_with_accents(self):
 		subject = "Nouvelle tâche à faire 😃"
 		todo = self.new_todo(sender="test_sender@example.com", description=subject)

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -639,6 +639,19 @@ class TestInboundMail(IntegrationTestCase):
 		reference_doc = inbound_mail.reference_document()
 		self.assertEqual(todo.name, reference_doc.name)
 
+	def test_subject_match_when_append_to_doctype_has_no_subject_field(self):
+		"""Inbound mail must not raise when the `Append To` doctype has no subject_field configured."""
+		mail_content = self.get_test_mail(fname="incoming-subject-placeholder.raw").replace(
+			"{{ subject }}", "RE: An unmatched subject line"
+		)
+		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")
+		inbound_mail = InboundMail(mail_content, email_account, 12345, 1)
+
+		no_subject_fields = frappe._dict(subject_field=None, sender_field=None)
+		with patch.object(InboundMail, "get_email_fields", return_value=no_subject_fields):
+			# Should return None instead of raising an exception
+			self.assertIsNone(inbound_mail.match_record_by_subject_and_sender("ToDo"))
+
 	def test_reference_document_by_subject_match_with_accents(self):
 		subject = "Nouvelle tâche à faire 😃"
 		todo = self.new_todo(sender="test_sender@example.com", description=subject)

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -894,6 +894,10 @@ class InboundMail(Email):
 		record = self.get_doc(doctype, name, ignore_error=True) if name else None
 
 		if not record:
+			# Subject matching is only possible if the doctype declares a subject_field.
+			if not email_fields.subject_field:
+				return record
+
 			subject = self.clean_subject(self.subject)
 			filters = {
 				email_fields.subject_field: ("like", f"%{subject}%"),
@@ -901,7 +905,7 @@ class InboundMail(Email):
 			}
 
 			# Sender check is not needed incase mail is from system user.
-			if not (len(subject) > 10 and is_system_user(self.from_email)):
+			if email_fields.sender_field and not (len(subject) > 10 and is_system_user(self.from_email)):
 				filters[email_fields.sender_field] = self.from_email
 
 			name = frappe.db.get_value(self.email_account.append_to, filters=filters)

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -896,7 +896,7 @@ class InboundMail(Email):
 		if not record:
 			# Subject matching is only possible if the doctype declares a subject_field.
 			if not email_fields.subject_field:
-				return record
+				return None
 
 			subject = self.clean_subject(self.subject)
 			filters = {


### PR DESCRIPTION
Inbound emails crashed on every pull when the Email Account's Append To doctype has no subject_field (e.g. CRM Lead), filling the Error Log. The filter was built with a None key, raising "AttributeError: 'NoneType' object has no attribute 'like'".

Skip subject matching when subject_field/sender_field are absent. This restores a null-guard that existed before the 2021 "refactor: incoming mails" (5b96b79ed4) dropped it. Adds a regression test.
