### PR TITLE
fix(cache): clear bench asset cache on full cache clear

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -294,7 +294,7 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 			keys_to_delete.difference_update(frappe.cache.get_keys(key))
 		frappe.cache.delete_value(list(keys_to_delete), make_keys=False)
 		frappe.cache.delete_value(bench_cache_keys, shared=True)
-		
+
 		reset_metadata_version()
 		frappe.local.cache = {}
 		frappe.local.new_doc_templates = {}

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -293,7 +293,8 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 		for key in frappe.get_hooks("persistent_cache_keys"):
 			keys_to_delete.difference_update(frappe.cache.get_keys(key))
 		frappe.cache.delete_value(list(keys_to_delete), make_keys=False)
-
+		frappe.cache.delete_value(bench_cache_keys, shared=True)
+		
 		reset_metadata_version()
 		frappe.local.cache = {}
 		frappe.local.new_doc_templates = {}


### PR DESCRIPTION
Raising PR on behalf of @DanielRadlAMR .

## Issue

`bench_cache_keys` are only cleared in `clear_global_cache()`, while standard bench cache-clearing operations invoke `frappe.clear_cache()` instead.

As a result, bench-level cache entries such as `assets_json` can remain stale after running `bench clear-cache`.

This is particularly problematic in Docker-based deployments where asset building is separated from the runtime environment. In CI/CD pipelines, the current workaround is to either flush Redis entirely or manually delete the cached value during deployment.

## Expected behavior

`frappe.clear_cache()` should also clear entries registered in `bench_cache_keys`.

## Additional Info

This issue only affects `v16` instances. In `v15` migrate called `clear_global_cache()`, but in `v16` this was changed to `clear_cache()`

Context:
https://github.com/frappe/frappe_docker/issues/1353#issuecomment-4216108771


closes #39812