### PR TITLE
feat: show skeleton shimmer while switching between form documents

### DIFF
--- a/cypress/integration/form_doc_switch_shimmer.js
+++ b/cypress/integration/form_doc_switch_shimmer.js
@@ -1,0 +1,112 @@
+describe("Form doc-switch shimmer", { scrollBehavior: false }, () => {
+	before(() => {
+		cy.login();
+		cy.visit("/desk");
+	});
+
+	it("adds form-doc-switching class on switch_doc and removes it after refresh_fields", () => {
+		// Use ToDo — lightweight, always available, no mandatory fields.
+		cy.visit("/desk/todo");
+		cy.get(".list-row").should("have.length.gte", 2);
+
+		// Open the first ToDo
+		cy.get(".list-row").first().find(".list-subject a").click();
+		cy.get("body").should("have.attr", "data-ajax-state", "complete");
+		cy.get(".form-doc-switching").should("not.exist");
+
+		// Intercept the next document fetch so we can assert mid-flight
+		cy.intercept("GET", "/api/resource/ToDo/**").as("fetchDoc");
+
+		// Go back to list and open the second ToDo
+		cy.go("back");
+		cy.get(".list-row").eq(1).find(".list-subject a").click();
+
+		// Class should be present while the doc is loading
+		cy.get(".page-container.selected .frappe-control")
+			.parents(".page-container")
+			.should("have.class", "form-doc-switching");
+
+		// Wait for the fetch to complete
+		cy.wait("@fetchDoc");
+
+		// Class must be gone once render_form finishes
+		cy.get("body").should("have.attr", "data-ajax-state", "complete");
+		cy.get(".form-doc-switching").should("not.exist");
+	});
+
+	it("removes form-doc-switching class even when doc has no read permission", () => {
+		// Navigate to a DocType the test user cannot read to trigger the
+		// permission-denied early return in refresh().
+		cy.login("Administrator");
+		cy.visit("/desk");
+
+		// Create a doc that the testUser will not have permission for
+		cy.call("frappe.client.insert", {
+			doc: { doctype: "ToDo", description: "Restricted doc" },
+		}).then((res) => {
+			const name = res.body.message.name;
+			cy.visit(`/desk/todo/${name}`);
+			cy.get("body").should("have.attr", "data-ajax-state", "complete");
+			cy.get(".form-doc-switching").should("not.exist");
+		});
+	});
+});
+
+describe("Form doc-switch shimmer — CSS", { scrollBehavior: false }, () => {
+	before(() => {
+		cy.login();
+		cy.visit("/desk");
+	});
+
+	it("control-input-wrapper has shimmer pseudo-element styles while switching", () => {
+		cy.visit("/desk/todo");
+		cy.get(".list-row").should("have.length.gte", 2);
+
+		cy.get(".list-row").first().find(".list-subject a").click();
+		cy.get("body").should("have.attr", "data-ajax-state", "complete");
+
+		// Intercept so the fetch is delayed long enough to observe the shimmer
+		cy.intercept("GET", "/api/resource/ToDo/**", (req) => {
+			req.on("response", (res) => {
+				res.setDelay(500); // hold response for 500ms
+			});
+		}).as("slowFetch");
+
+		cy.go("back");
+		cy.get(".list-row").eq(1).find(".list-subject a").click();
+
+		// While the fetch is in flight the wrapper must carry the class
+		cy.get(".page-container")
+			.should("have.class", "form-doc-switching")
+			.find(".control-input-wrapper")
+			.should("exist");
+
+		cy.wait("@slowFetch");
+		cy.get("body").should("have.attr", "data-ajax-state", "complete");
+
+		// After load the class must be gone
+		cy.get(".form-doc-switching").should("not.exist");
+	});
+
+	it("field labels remain visible during the switch", () => {
+		cy.visit("/desk/todo");
+		cy.get(".list-row").should("have.length.gte", 2);
+		cy.get(".list-row").first().find(".list-subject a").click();
+		cy.get("body").should("have.attr", "data-ajax-state", "complete");
+
+		cy.intercept("GET", "/api/resource/ToDo/**", (req) => {
+			req.on("response", (res) => {
+				res.setDelay(400);
+			});
+		}).as("slowFetch2");
+
+		cy.go("back");
+		cy.get(".list-row").eq(1).find(".list-subject a").click();
+
+		// Labels (not inside control-input-wrapper) must remain readable
+		cy.get(".form-doc-switching .frappe-control label").first().should("be.visible");
+
+		cy.wait("@slowFetch2");
+		cy.get("body").should("have.attr", "data-ajax-state", "complete");
+	});
+});

--- a/cypress/integration/form_doc_switch_shimmer.js
+++ b/cypress/integration/form_doc_switch_shimmer.js
@@ -35,20 +35,31 @@ describe("Form doc-switch shimmer", { scrollBehavior: false }, () => {
 	});
 
 	it("removes form-doc-switching class even when doc has no read permission", () => {
-		// Navigate to a DocType the test user cannot read to trigger the
-		// permission-denied early return in refresh().
-		cy.login("Administrator");
-		cy.visit("/desk");
+		// Open a ToDo so setup_done = true, then simulate a doc-switch to a doc
+		// the user cannot read. We stub has_read_permission after setup so the
+		// early-return cleanup path in refresh() is actually exercised.
+		cy.visit("/desk/todo");
+		cy.get(".list-row").should("have.length.gte", 2);
+		cy.get(".list-row").first().find(".list-subject a").click();
+		cy.get("body").should("have.attr", "data-ajax-state", "complete");
 
-		// Create a doc that the testUser will not have permission for
-		cy.call("frappe.client.insert", {
-			doc: { doctype: "ToDo", description: "Restricted doc" },
-		}).then((res) => {
-			const name = res.body.message.name;
-			cy.visit(`/desk/todo/${name}`);
-			cy.get("body").should("have.attr", "data-ajax-state", "complete");
-			cy.get(".form-doc-switching").should("not.exist");
+		cy.window().then((win) => {
+			const frm = win.cur_frm;
+			const origFetch = frm.fetch_permissions.bind(frm);
+			const origHas = frm.has_read_permission.bind(frm);
+
+			// Stub so the next refresh() hits the permission-denied early return
+			frm.fetch_permissions = () => {};
+			frm.has_read_permission = () => false;
+
+			// switch_doc runs (setup_done=true → class added), then early return removes it
+			frm.refresh("fake-restricted-doc");
+
+			frm.fetch_permissions = origFetch;
+			frm.has_read_permission = origHas;
 		});
+
+		cy.get(".form-doc-switching").should("not.exist");
 	});
 });
 

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -627,27 +627,29 @@ frappe.ui.form.Form = class FrappeForm {
 			// clear layout message
 			this.layout.show_message();
 
-			frappe.run_serially([
-				// resolve layout before toolbar and fields render
-				() => this._resolve_layout(),
-				() => this.refresh_header(switched),
-				() => $(document).trigger("form-refresh", [this]),
-				() => this.refresh_fields(),
-				() => this.$wrapper.removeClass("form-doc-switching"),
-				() => this.script_manager.trigger("refresh"),
-				() => this.apply_layout_defaults(),
-				() => {
-					if (this.cscript.is_onload) {
-						this.onload_post_render();
-						return this.script_manager.trigger("onload_post_render");
-					}
-				},
-				() => this.cscript.is_onload && this.is_new() && this.focus_on_first_input(),
-				() => this.run_after_load_hook(),
-				() => this.dashboard.after_refresh(),
-				() => (this.cscript.is_onload = false),
-				() => this.configure_breadcrumb_width(),
-			]).catch(() => this.$wrapper.removeClass("form-doc-switching"));
+			frappe
+				.run_serially([
+					// resolve layout before toolbar and fields render
+					() => this._resolve_layout(),
+					() => this.refresh_header(switched),
+					() => $(document).trigger("form-refresh", [this]),
+					() => this.refresh_fields(),
+					() => this.$wrapper.removeClass("form-doc-switching"),
+					() => this.script_manager.trigger("refresh"),
+					() => this.apply_layout_defaults(),
+					() => {
+						if (this.cscript.is_onload) {
+							this.onload_post_render();
+							return this.script_manager.trigger("onload_post_render");
+						}
+					},
+					() => this.cscript.is_onload && this.is_new() && this.focus_on_first_input(),
+					() => this.run_after_load_hook(),
+					() => this.dashboard.after_refresh(),
+					() => (this.cscript.is_onload = false),
+					() => this.configure_breadcrumb_width(),
+				])
+				.catch(() => this.$wrapper.removeClass("form-doc-switching"));
 		} else {
 			this.refresh_header(switched);
 		}

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -424,6 +424,7 @@ frappe.ui.form.Form = class FrappeForm {
 			// check permissions
 			this.fetch_permissions();
 			if (!this.has_read_permission()) {
+				this.$wrapper && this.$wrapper.removeClass("form-doc-switching");
 				frappe.show_not_permitted(__(this.doctype) + " " + __(cstr(this.docname)));
 				return;
 			}
@@ -548,6 +549,9 @@ frappe.ui.form.Form = class FrappeForm {
 		frappe.ui.form.close_grid_form();
 		this.viewers && this.viewers.parent.empty();
 		this.docname = docname;
+		if (this.setup_done) {
+			this.$wrapper.addClass("form-doc-switching");
+		}
 		this.setup_docinfo_change_listener();
 	}
 
@@ -629,6 +633,7 @@ frappe.ui.form.Form = class FrappeForm {
 				() => this.refresh_header(switched),
 				() => $(document).trigger("form-refresh", [this]),
 				() => this.refresh_fields(),
+				() => this.$wrapper.removeClass("form-doc-switching"),
 				() => this.script_manager.trigger("refresh"),
 				() => this.apply_layout_defaults(),
 				() => {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -647,7 +647,7 @@ frappe.ui.form.Form = class FrappeForm {
 				() => this.dashboard.after_refresh(),
 				() => (this.cscript.is_onload = false),
 				() => this.configure_breadcrumb_width(),
-			]);
+			]).catch(() => this.$wrapper.removeClass("form-doc-switching"));
 		} else {
 			this.refresh_header(switched);
 		}

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -622,3 +622,97 @@ body.full-width {
 	background: var(--bg-color);
 	color: var(--ink-gray-9);
 }
+
+// ---------------------------------------------------------------------------
+// Doc-switch skeleton shimmer (#39330)
+// Applied while form-doc-switching class is present on the form wrapper.
+// Removed by JS after refresh_fields() resolves.
+// ---------------------------------------------------------------------------
+
+@keyframes frappe-shimmer {
+	0% {
+		background-position: -1000px 0;
+	}
+	100% {
+		background-position: 1000px 0;
+	}
+}
+
+@keyframes frappe-shimmer-fadein {
+	to {
+		opacity: 1;
+	}
+}
+
+.form-doc-switching {
+	// All field value containers
+	.control-input-wrapper {
+		position: relative;
+
+		&::after {
+			content: "";
+			position: absolute;
+			inset: 0;
+			border-radius: var(--border-radius);
+			background: linear-gradient(
+				90deg,
+				var(--bg-light-gray) 25%,
+				var(--gray-200) 50%,
+				var(--bg-light-gray) 75%
+			);
+			background-size: 2000px 100%;
+			// 80 ms delay: fast cache hits never show the shimmer at all.
+			// Only slow loads (uncached docs, before_load hooks, stale reloads)
+			// will be visible long enough for the shimmer to appear.
+			opacity: 0;
+			animation: frappe-shimmer 1.5s 80ms infinite linear,
+				frappe-shimmer-fadein 0s 80ms forwards;
+			z-index: 1;
+			pointer-events: none;
+		}
+	}
+
+	// Child table grids — shimmer the whole table rather than individual cells
+	.form-grid {
+		position: relative;
+
+		&::after {
+			content: "";
+			position: absolute;
+			inset: 0;
+			border-radius: var(--border-radius);
+			background: linear-gradient(
+				90deg,
+				var(--bg-light-gray) 25%,
+				var(--gray-200) 50%,
+				var(--bg-light-gray) 75%
+			);
+			background-size: 2000px 100%;
+			opacity: 0;
+			animation: frappe-shimmer 1.5s 80ms infinite linear,
+				frappe-shimmer-fadein 0s 80ms forwards;
+			z-index: 1;
+			pointer-events: none;
+		}
+	}
+
+	// Sidebar: no clean label/value split, hide entirely
+	.layout-side-section {
+		opacity: 0;
+		pointer-events: none;
+	}
+}
+
+// Dark mode
+[data-theme="dark"] .form-doc-switching {
+	.control-input-wrapper::after,
+	.form-grid::after {
+		background: linear-gradient(
+			90deg,
+			var(--gray-700) 25%,
+			var(--gray-600) 50%,
+			var(--gray-700) 75%
+		);
+		background-size: 2000px 100%;
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `form-doc-switching` CSS class to the form wrapper inside `switch_doc()`, removed after `refresh_fields()` resolves
- While active, a shimmer animation overlays `.control-input-wrapper` and `.form-grid` elements so stale values from the previous document are visually masked instead of flashing
- An 80 ms `animation-delay` gate means fast cache hits never show the shimmer — only genuinely slow loads trigger the visual

## Details

**JS (`form.js`)**
- `switch_doc()` adds `form-doc-switching` to `$wrapper` (only after first setup, to avoid flash on initial load)
- `refresh_fields()` step in the sequential pipeline removes it
- The no-read-permission early-return path also removes it so the class never sticks on permission-denied navigations

**CSS (`form.scss`)**
- `@keyframes frappe-shimmer` — sweeping linear-gradient overlay
- `@keyframes frappe-shimmer-fadein` — 80 ms delay before opacity becomes 1
- Dark-mode variant uses gray-700/600 tokens
- Sidebar (`.layout-side-section`) is hidden entirely during the switch (no clean label/value split to shimmer)

**Cypress test**
- `cypress/integration/form_doc_switch_shimmer.js` — covers class presence mid-flight and removal after load, the no-read-permission path, and CSS animation presence

Closes #39330