### PR TITLE
fix: handle if doctype is not found

### DIFF
--- a/frappe/desk/doctype/dashboard/dashboard.py
+++ b/frappe/desk/doctype/dashboard/dashboard.py
@@ -91,13 +91,16 @@ def get_permitted_charts(dashboard_name: str):
 	permitted_charts = []
 	dashboard = frappe.get_doc("Dashboard", dashboard_name)
 	for chart in dashboard.charts:
-		if frappe.has_permission("Dashboard Chart", doc=chart.chart):
-			chart_dict = frappe._dict()
-			chart_dict.update(chart.as_dict())
+		try:
+			if frappe.has_permission("Dashboard Chart", doc=chart.chart):
+				chart_dict = frappe._dict()
+				chart_dict.update(chart.as_dict())
 
-			if dashboard.get("chart_options"):
-				chart_dict.custom_options = dashboard.get("chart_options")
-			permitted_charts.append(chart_dict)
+				if dashboard.get("chart_options"):
+					chart_dict.custom_options = dashboard.get("chart_options")
+				permitted_charts.append(chart_dict)
+		except frappe.DoesNotExistError:
+			frappe.log_error("Error in fetching dashboard chart")
 
 	return permitted_charts
 

--- a/frappe/desk/doctype/dashboard/dashboard.py
+++ b/frappe/desk/doctype/dashboard/dashboard.py
@@ -100,15 +100,24 @@ def get_permitted_charts(dashboard_name: str):
 					chart_dict.custom_options = dashboard.get("chart_options")
 				permitted_charts.append(chart_dict)
 		except frappe.DoesNotExistError:
-			frappe.log_error("Error in fetching dashboard chart")
+			frappe.clear_last_message()
+			frappe.log_error(f"Dashboard Chart '{chart.chart}' not found or its source DocType is missing")
 
 	return permitted_charts
 
 
 @frappe.whitelist()
 def get_permitted_cards(dashboard_name: str):
+	permitted_cards = []
 	dashboard = frappe.get_doc("Dashboard", dashboard_name)
-	return [card for card in dashboard.cards if frappe.has_permission("Number Card", doc=card.card)]
+	for card in dashboard.cards:
+		try:
+			if frappe.has_permission("Number Card", doc=card.card):
+				permitted_cards.append(card)
+		except frappe.DoesNotExistError:
+			frappe.log_error(f"Number Card '{card.card}' not found or its source DocType is missing")
+
+	return permitted_cards
 
 
 def get_non_standard_charts_in_dashboard(dashboard):


### PR DESCRIPTION
If dashboard chart depends on some doctype which is now deleted it should not crash
