### PR TITLE
fix: update depends_on when same perm_type is reused across doctypes

### DIFF
--- a/frappe/core/doctype/permission_type/permission_type.py
+++ b/frappe/core/doctype/permission_type/permission_type.py
@@ -86,10 +86,18 @@ class PermissionType(Document):
 	def create_custom_field(self, target):
 		from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 
-		if not self.custom_field_exists(target):
-			field = "share_doctype" if target == "DocShare" else "parent"
-			depends_on = f"eval:doc.{field} == '{self.doc_type}'"
+		field = "share_doctype" if target == "DocShare" else "parent"
 
+		if existing := self.custom_field_exists(target):
+			all_doc_types = frappe.get_all(
+				"Permission Type",
+				filters={"perm_type": self.perm_type},
+				pluck="doc_type",
+			)
+			depends_on = f"eval:{frappe.as_json(all_doc_types)}.includes(doc.{field})"
+			frappe.db.set_value("Custom Field", existing, "depends_on", depends_on)
+		else:
+			depends_on = f"eval:{frappe.as_json([self.doc_type])}.includes(doc.{field})"
 			create_custom_field(
 				target,
 				{
@@ -113,8 +121,20 @@ class PermissionType(Document):
 			delete_folder(module, "Permission Type", self.name)
 
 	def delete_custom_field(self, target):
-		if name := self.custom_field_exists(target):
-			frappe.delete_doc("Custom Field", name)
+		if not (existing := self.custom_field_exists(target)):
+			return
+
+		siblings = frappe.get_all(
+			"Permission Type",
+			filters={"perm_type": self.perm_type, "name": ["!=", self.name]},
+			pluck="doc_type",
+		)
+		if not siblings:
+			frappe.delete_doc("Custom Field", existing)
+		else:
+			field = "share_doctype" if target == "DocShare" else "parent"
+			depends_on = f"eval:{frappe.as_json(siblings)}.includes(doc.{field})"
+			frappe.db.set_value("Custom Field", existing, "depends_on", depends_on)
 
 	def custom_field_exists(self, target):
 		return frappe.db.exists(

--- a/frappe/core/doctype/permission_type/permission_type.py
+++ b/frappe/core/doctype/permission_type/permission_type.py
@@ -129,6 +129,7 @@ class PermissionType(Document):
 			"Permission Type",
 			filters={"perm_type": self.perm_type, "name": ["!=", self.name]},
 			pluck="doc_type",
+			limit=0,
 		)
 		if not siblings:
 			frappe.delete_doc("Custom Field", existing)

--- a/frappe/core/doctype/permission_type/permission_type.py
+++ b/frappe/core/doctype/permission_type/permission_type.py
@@ -93,6 +93,7 @@ class PermissionType(Document):
 				"Permission Type",
 				filters={"perm_type": self.perm_type},
 				pluck="doc_type",
+				limit=0,
 			)
 			depends_on = f"eval:{frappe.as_json(all_doc_types)}.includes(doc.{field})"
 			frappe.db.set_value("Custom Field", existing, "depends_on", depends_on)

--- a/frappe/core/doctype/permission_type/test_permission_type.py
+++ b/frappe/core/doctype/permission_type/test_permission_type.py
@@ -47,6 +47,32 @@ class IntegrationTestPermissionType(IntegrationTestCase):
 			frappe.delete_doc("User", user.name, force=True)
 			frappe.delete_doc("Permission Type", ptype_doc.name, force=True)
 
+	def test_same_perm_type_multiple_doctypes(self):
+		"""Regression: same perm_type for two different doc_types must update depends_on on the shared Custom Field."""
+		ptype_name = "multi_dt_ptype"
+		doc_type_a = "Web Page"
+		doc_type_b = "ToDo"
+
+		ptype_a = self._create_permission_type(ptype_name, doc_type_a)
+		ptype_b = self._create_permission_type(ptype_name, doc_type_b)
+
+		try:
+			for target in ["Custom DocPerm", "DocPerm", "DocShare"]:
+				custom_field = frappe.get_doc("Custom Field", {"dt": target, "fieldname": ptype_name})
+				self.assertIn(doc_type_a, custom_field.depends_on)
+				self.assertIn(doc_type_b, custom_field.depends_on)
+
+			# deleting one sibling should update depends_on, not delete the field
+			frappe.delete_doc("Permission Type", ptype_b.name, force=True)
+			for target in ["Custom DocPerm", "DocPerm", "DocShare"]:
+				custom_field = frappe.get_doc("Custom Field", {"dt": target, "fieldname": ptype_name})
+				self.assertNotIn(doc_type_b, custom_field.depends_on)
+				self.assertIn(doc_type_a, custom_field.depends_on)
+		finally:
+			frappe.delete_doc("Permission Type", ptype_a.name, force=True)
+			if frappe.db.exists("Permission Type", ptype_b.name):
+				frappe.delete_doc("Permission Type", ptype_b.name, force=True)
+
 	def test_permission_type_creation_reserved_name(self):
 		"""Test that permission types with reserved names are rejected."""
 		doc = frappe.get_doc(


### PR DESCRIPTION
## Problem

When two `Permission Type` records share the same `perm_type` but have
different `doc_type`, only the first one works. `create_custom_field`
skips creation if the Custom Field already exists, so the second doctype
is never added to `depends_on`.

Similarly, `delete_custom_field` unconditionally deletes the Custom Field,
breaking all other doctypes sharing that `perm_type`.

## Fix

- `create_custom_field`: when the field exists, update `depends_on` from
  all sibling records. On first creation, no extra query needed.
- `delete_custom_field`: update `depends_on` to remove the trashed doctype;
  only delete the field when no siblings remain.

Closes #39876