### PR TITLE
feat: utilities for settings dialog

### DIFF
--- a/frappe/public/js/desk.bundle.js
+++ b/frappe/public/js/desk.bundle.js
@@ -44,6 +44,7 @@ import "./frappe/ui/field_group.js";
 import "./frappe/form/link_selector.js";
 import "./frappe/form/multi_select_dialog.js";
 import "./frappe/ui/dialog.js";
+import "./frappe/ui/settings_dialog.js";
 import "./frappe/ui/menu.js";
 import "./frappe/ui/capture.js";
 import "./frappe/ui/app_icon.js";

--- a/frappe/public/js/frappe/form/controls/control.js
+++ b/frappe/public/js/frappe/form/controls/control.js
@@ -17,6 +17,7 @@ import "./code";
 import "./text_editor";
 import "./comment";
 import "./check";
+import "./switch";
 import "./image";
 import "./attach";
 import "./attach_image";

--- a/frappe/public/js/frappe/form/controls/switch.js
+++ b/frappe/public/js/frappe/form/controls/switch.js
@@ -1,0 +1,33 @@
+// A sliding toggle. Reuses ControlCheck wholesale — same checkbox input and
+// 0/1 value semantics (get_values() returns 1/0, validate, set_input, read-only
+// disp) — and only swaps the markup so CSS can skin it as a switch. Usable
+// anywhere a control is built (FieldGroup, Dialog, forms) via fieldtype "Switch".
+frappe.ui.form.ControlSwitch = class ControlSwitch extends frappe.ui.form.ControlCheck {
+	make_input() {
+		super.make_input();
+		// Communicate toggle-switch semantics to assistive technology (otherwise
+		// the underlying checkbox is announced as a checkbox, not a switch).
+		this.$input.attr("role", "switch");
+	}
+
+	make_wrapper() {
+		// Everything is inside the <label>, so clicking the text toggles the switch.
+		// The real checkbox lives in `.input-area` (visually hidden via CSS); the
+		// `.switch-visual` sibling reflects its :checked state with `:has()`.
+		// set_label() fills `.label-area`; set_description() fills `.help-box`.
+		this.$wrapper = $(`<div class="form-group frappe-control">
+			<label class="switch-control">
+				<span class="switch-text">
+					<span class="label-area"></span>
+					<span class="disp-area"></span>
+					<div class="help-box small text-extra-muted hide"></div>
+				</span>
+				<span class="input-area"></span>
+				<span class="switch-visual" aria-hidden="true">
+					<span class="switch-thumb"></span>
+				</span>
+				<span class="ml-1 help"></span>
+			</label>
+		</div>`).appendTo(this.parent);
+	}
+};

--- a/frappe/public/js/frappe/ui/settings_dialog.js
+++ b/frappe/public/js/frappe/ui/settings_dialog.js
@@ -1,0 +1,300 @@
+import "./dialog";
+
+frappe.provide("frappe.ui");
+
+/**
+ * Controller for a single settings panel. Both `render(panel)` and every
+ * `action.click(panel)` receive the same instance, so actions can drive the
+ * rendering — e.g. a "Create" action can swap the header and redraw the body,
+ * then `panel.refresh()` returns to the default view.
+ *   panel.body                     // jQuery content wrapper (build into this)
+ *   panel.set_view({ title, description, actions, fields, render })
+ *                                  // atomically swap the whole view (header +
+ *                                  // actions + body); the unit a stateful panel
+ *                                  // moves between (e.g. list ➜ form ➜ back)
+ *   panel.set_header({ title, description, actions })   // header only
+ *   panel.add_fields(fields)       // low-level: mount a FieldGroup into the body
+ *   panel.refresh()                // reset to the tab's default view (the item)
+ *   panel.dialog                   // the SettingsDialog instance
+ *
+ * When the item declares `fields`, the panel builds a `frappe.ui.FieldGroup`
+ * (the same form primitive Dialog uses) into its body, so an action can read
+ * inputs with `panel.get_values()` — null if a mandatory field is empty:
+ *
+ *   panel.get_values()             // validated values dict, or null
+ *   panel.get_value(fieldname)     // single field value
+ *   panel.set_values({ ... })      // populate fields (returns a Promise)
+ *   panel.fieldgroup               // the underlying FieldGroup
+ */
+frappe.ui.SettingsDialogPanel = class SettingsDialogPanel {
+	constructor(dialog, item) {
+		this.dialog = dialog;
+		this.item = item;
+		this.fieldgroup = null;
+
+		this.$el = $('<div class="settings-dialog-panel"></div>');
+		this.$header = $(`
+			<div class="settings-dialog-panel-header hide">
+				<div class="settings-dialog-panel-heading"></div>
+				<div class="settings-dialog-panel-actions"></div>
+			</div>
+		`).appendTo(this.$el);
+		this.$body = $('<div class="settings-dialog-panel-body"></div>').appendTo(this.$el);
+		// `body` is the public handle consumers render into.
+		this.body = this.$body;
+	}
+
+	set_header({ title, description, actions } = {}) {
+		const $heading = this.$header.find(".settings-dialog-panel-heading").empty();
+		const $actions = this.$header.find(".settings-dialog-panel-actions").empty();
+
+		if (title) {
+			$('<div class="settings-dialog-panel-title"></div>').text(title).appendTo($heading);
+		}
+		if (description) {
+			$('<div class="settings-dialog-panel-description"></div>')
+				.text(description)
+				.appendTo($heading);
+		}
+		(actions || []).forEach((action) => $actions.append(this.make_action(action)));
+
+		const has_header = Boolean(title || description || (actions && actions.length));
+		this.$header.toggleClass("hide", !has_header);
+		return this;
+	}
+
+	make_action(action) {
+		const $btn = $(`<button type="button"></button>`)
+			.addClass(`btn btn-sm ${action.primary ? "btn-primary" : "btn-default"}`)
+			.addClass(action.class || "")
+			.text(action.label || "");
+		// `this` and the first argument are both the panel, so actions can mutate it.
+		action.click && $btn.on("click", () => action.click.call(this, this));
+		return $btn;
+	}
+
+	add_fields(fields) {
+		// Low-level: mount a FieldGroup into the (already-cleared) body.
+		this.fieldgroup = new frappe.ui.FieldGroup({
+			fields,
+			body: this.$body.get(0),
+		});
+		this.fieldgroup.make();
+		return this.fieldgroup;
+	}
+
+	set_view({ title, description, actions, fields, render } = {}) {
+		// Atomically swap the whole view: header (title/description/actions), then
+		// body (fields and/or custom render). Mounting actions + fields together
+		// guarantees an action's get_values() reads the form mounted alongside it.
+		this.set_header({ title, description, actions });
+
+		this.$body.empty();
+		this.fieldgroup = null;
+		if (fields && fields.length) this.add_fields(fields);
+		render && render(this);
+
+		return this;
+	}
+
+	refresh() {
+		return this.set_view(this.item);
+	}
+
+	get_values(...args) {
+		return this.fieldgroup ? this.fieldgroup.get_values(...args) : {};
+	}
+
+	get_value(fieldname) {
+		return this.fieldgroup ? this.fieldgroup.get_value(fieldname) : undefined;
+	}
+
+	set_values(values) {
+		return this.fieldgroup ? this.fieldgroup.set_values(values) : Promise.resolve();
+	}
+
+	get_field(fieldname) {
+		return this.fieldgroup ? this.fieldgroup.get_field(fieldname) : undefined;
+	}
+};
+
+/**
+ * A reusable two-pane settings dialog: a grouped vertical tab rail on the left
+ * and lazily-rendered panels on the right. Extends `frappe.ui.Dialog` so it
+ * reuses the full modal lifecycle (backdrop, show/hide, ESC, the open-dialog
+ * stack) while replacing the standard header/body/footer with the settings
+ * layout.
+ *
+ * The visual design mirrors the banking app's `settings-dialog.tsx` and binds
+ * to the framework's existing Espresso tokens (`--surface-*`, `--ink-gray-*`).
+ *
+ * Usage:
+ *
+ *   const d = new frappe.ui.SettingsDialog({
+ *       title: __("Settings"),
+ *       default_tab: "preferences",
+ *       tabs: [
+ *           {
+ *               group: __("Configuration"),
+ *               items: [
+ *                   {
+ *                       id: "preferences",
+ *                       label: __("Preferences"),
+ *                       icon: "sliders-vertical", // sprite name (resolved via icon util)
+ *                       // icon_html: "<svg…>"    // alternative: raw, TRUSTED markup only
+ *                       // Declarative header sugar (optional):
+ *                       title: __("Preferences"),
+ *                       description: __("Manage your preferences"),
+ *                       actions: [{ label: __("Save"), primary: true, click(panel) {} }],
+ *                       render(panel) {
+ *                           // build content into `panel.body`; call
+ *                           // panel.set_header(...) / panel.refresh() for
+ *                           // stateful, action-driven views.
+ *                       },
+ *                   },
+ *               ],
+ *           },
+ *       ],
+ *   });
+ *   d.show();
+ */
+frappe.ui.SettingsDialog = class SettingsDialog extends frappe.ui.Dialog {
+	constructor(opts) {
+		super(
+			Object.assign(
+				{
+					size: "extra-large",
+				},
+				opts
+			)
+		);
+	}
+
+	make() {
+		// Build the standard modal shell + lifecycle, then repurpose it.
+		super.make();
+
+		this.tabs = this.tabs || [];
+		// Flat lookup of every tab item by id, and a cache of panel controllers.
+		this._items = {};
+		this._panels = {};
+
+		this.$wrapper.addClass("settings-dialog-wrapper");
+
+		// Drop the standard title bar; each panel owns its own header (banking design).
+		this.header.addClass("hide");
+
+		// Replace the default body with the two-pane layout. Mount directly into
+		// `.modal-body` (not `this.$body`, which is an extra unstyled wrapper) so the
+		// flex height chain reaches the modal content and the panes fill the dialog.
+		this.$body.addClass("hide");
+		this.$message.addClass("hide");
+		this.modal_body.addClass("settings-dialog-body");
+
+		this.$layout = $(`
+			<div class="settings-dialog">
+				<div class="settings-dialog-sidebar"></div>
+				<div class="settings-dialog-panels"></div>
+			</div>
+		`).appendTo(this.modal_body);
+
+		this.$sidebar = this.$layout.find(".settings-dialog-sidebar");
+		this.$panels = this.$layout.find(".settings-dialog-panels");
+
+		this.render_sidebar();
+
+		const default_tab = this.default_tab || this.first_tab_id();
+		if (default_tab) this.activate(default_tab);
+	}
+
+	first_tab_id() {
+		for (const group of this.tabs) {
+			if (group.items && group.items.length) return group.items[0].id;
+		}
+		return null;
+	}
+
+	render_sidebar() {
+		this.$sidebar.empty();
+
+		this.tabs.forEach((group) => {
+			const $group = $('<div class="settings-dialog-tab-group"></div>').appendTo(
+				this.$sidebar
+			);
+
+			if (group.group) {
+				$(`<div class="settings-dialog-group-header"><span></span></div>`)
+					.find("span")
+					.text(group.group)
+					.end()
+					.appendTo($group);
+			}
+
+			const $nav = $('<nav class="settings-dialog-tab-list"></nav>').appendTo($group);
+
+			(group.items || []).forEach((item) => {
+				this._items[item.id] = item;
+				$nav.append(this.make_tab_item(item));
+			});
+		});
+	}
+
+	make_tab_item(item) {
+		const $item = $(`
+			<button type="button" class="settings-dialog-tab-item" data-tab-id="${frappe.utils.escape_html(
+				item.id
+			)}">
+				<span class="settings-dialog-tab-item-content">
+					<span class="settings-dialog-tab-icon"></span>
+					<span class="settings-dialog-tab-label"></span>
+				</span>
+			</button>
+		`);
+
+		const $icon = $item.find(".settings-dialog-tab-icon");
+		if (item.icon_html) {
+			// Raw markup — only ever set developer-authored, trusted HTML here.
+			// Never populate `icon_html` from a server response or user input.
+			$icon.html(item.icon_html);
+		} else if (item.icon) {
+			// Sprite icon name, resolved (and escaped) through the icon util.
+			$icon.html(frappe.utils.icon(item.icon, "sm"));
+		} else {
+			$icon.remove();
+		}
+
+		$item.find(".settings-dialog-tab-label").text(item.label || item.id);
+
+		$item.on("click", () => this.activate(item.id));
+		return $item;
+	}
+
+	activate(id) {
+		const item = this._items[id];
+		if (!item) return;
+
+		this.active_tab = id;
+
+		this.$sidebar.find(".settings-dialog-tab-item").each((i, el) => {
+			$(el).toggleClass("active", $(el).data("tab-id") === id);
+		});
+
+		// Lazy: build the panel controller on first activation, then just toggle so
+		// each panel keeps its own state across tab switches.
+		if (!this._panels[id]) {
+			const panel = new frappe.ui.SettingsDialogPanel(this, item);
+			this._panels[id] = panel;
+			this.$panels.append(panel.$el);
+			panel.refresh();
+		}
+
+		Object.values(this._panels).forEach((p) => p.$el.addClass("hide"));
+		this._panels[id].$el.removeClass("hide");
+
+		item.on_activate && item.on_activate(this._panels[id]);
+	}
+
+	get_panel(id) {
+		return this._panels[id];
+	}
+};

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -585,3 +585,104 @@ button.data-pill {
 	right: 0;
 	cursor: pointer;
 }
+
+//switch
+label.switch-control {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 2rem; // gap-8
+	width: 100%;
+	margin-bottom: 0;
+	padding: 0.25rem 0;
+	cursor: pointer;
+}
+
+.switch-control {
+	// Left column: label + description.
+	.switch-text {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+	}
+
+	.label-area {
+		font-size: var(--text-base);
+		color: var(--ink-gray-6);
+	}
+
+	// Description sits under the label
+	.help-box {
+		margin: 2px 0 0;
+		font-size: var(--text-sm);
+		line-height: 1.4;
+		color: var(--ink-gray-5);
+	}
+
+	// Keep the checkbox accessible and label-clickable, but visually hidden
+	// (standard sr-only clip pattern — focus moves through it to drive the track).
+	.input-area {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		clip-path: inset(50%);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	.switch-visual {
+		display: inline-flex;
+		align-items: center;
+		flex-shrink: 0;
+		width: 26px;
+		height: 16px;
+		padding: 2px;
+		border-radius: var(--border-radius-full, 999px);
+		background-color: var(--ink-gray-2);
+		transition: background-color 0.15s ease-in-out;
+	}
+
+	.switch-thumb {
+		width: 12px;
+		height: 12px;
+		border-radius: 50%;
+		background-color: var(--surface-white);
+		box-shadow: var(--shadow-sm);
+		transition: transform 0.15s ease-in-out;
+	}
+
+	// Checked: darken track, slide thumb (26 − 2·2 − 12 = 10px).
+	.input-area:has(input:checked) ~ .switch-visual {
+		background-color: var(--ink-gray-8);
+
+		.switch-thumb {
+			transform: translateX(10px);
+		}
+	}
+
+	// Hover states.
+	&:hover .input-area:not(:has(input:checked)) ~ .switch-visual {
+		background-color: var(--ink-gray-3);
+	}
+	&:hover .input-area:has(input:checked) ~ .switch-visual {
+		background-color: var(--ink-gray-7);
+	}
+
+	// The real input is visually hidden, so surface keyboard focus on the track.
+	.input-area:has(input:focus-visible) ~ .switch-visual {
+		box-shadow: 0 0 0 2px var(--outline-gray-3);
+	}
+
+	// Disabled.
+	&:has(input:disabled) {
+		cursor: not-allowed;
+
+		.switch-visual {
+			background-color: var(--ink-gray-1);
+		}
+	}
+}

--- a/frappe/public/scss/desk/index.scss
+++ b/frappe/public/scss/desk/index.scss
@@ -16,6 +16,7 @@
 @import "navbar";
 @import "search_widget";
 @import "../common/modal";
+@import "settings_dialog";
 @import "../common/about";
 @import "slides";
 @import "toast";

--- a/frappe/public/scss/desk/settings_dialog.scss
+++ b/frappe/public/scss/desk/settings_dialog.scss
@@ -1,0 +1,191 @@
+.settings-dialog-wrapper {
+	.modal-content {
+		height: calc(100vh - 8rem);
+		overflow: hidden;
+	}
+
+	.modal-body.settings-dialog-body {
+		display: flex;
+		flex: 1;
+		min-height: 0;
+		padding: 0;
+		overflow: hidden;
+	}
+}
+
+.settings-dialog {
+	display: flex;
+	flex: 1;
+	min-height: 0;
+	background-color: var(--surface-menu-bar);
+}
+
+// --- Sidebar -------------------------------------------------------------
+
+.settings-dialog-sidebar {
+	display: flex;
+	flex-direction: column;
+	flex-shrink: 0;
+	width: 14rem; // w-56
+	margin: 0.25rem; // m-1
+	overflow-y: auto;
+	background-color: var(--surface-menu-bar);
+}
+
+.settings-dialog-group-header {
+	position: sticky;
+	top: 0;
+	z-index: 1;
+	display: flex;
+	align-items: center;
+	gap: 0.375rem; // gap-1.5
+	height: 1.875rem; // h-7.5
+	margin: 3px 0; // my-[3px]
+	padding: 0 0.5rem; // px-2
+	font-size: var(--text-xs);
+	font-weight: var(--weight-medium);
+	color: var(--ink-gray-5);
+	background-color: var(--surface-menu-bar);
+	cursor: default;
+}
+
+.settings-dialog-tab-list {
+	display: flex;
+	flex-direction: column;
+	gap: 3px; // space-y-[3px]
+	padding: 0 0.25rem; // px-1
+}
+
+.settings-dialog-tab-group {
+	padding-bottom: 5px; // trailing spacer (mt-[5px])
+}
+
+.settings-dialog-tab-item {
+	display: flex;
+	align-items: center;
+	width: 100%; // w-full
+	height: 1.875rem; // h-7.5
+	padding: 0;
+	border: none;
+	border-radius: var(--border-radius-sm); // 8px
+	background-color: transparent;
+	color: var(--ink-gray-6);
+	text-align: left;
+	cursor: pointer;
+	transition: background-color 0.2s ease-in-out;
+
+	&:hover {
+		background-color: var(--surface-gray-3);
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 2px var(--outline-gray-3); // ring-2 ring-outline-gray-3
+	}
+
+	&.active {
+		background-color: var(--surface-selected, var(--surface-white));
+		box-shadow: var(--shadow-xs);
+
+		&:hover {
+			background-color: var(--surface-selected, var(--surface-white));
+		}
+	}
+}
+
+[data-theme="dark"] .settings-dialog-tab-item.active {
+	box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.7), 0px 0px 14px rgba(0, 0, 0, 0.18),
+		0px 0.5px 0.5px 0.5px rgba(255, 255, 255, 0.04) inset;
+}
+
+.settings-dialog-tab-item-content {
+	display: flex;
+	align-items: center;
+	width: 100%;
+	min-width: 0;
+	padding: 7px 0.5rem; // py-[7px] px-2
+}
+
+.settings-dialog-tab-icon {
+	display: flex;
+	align-items: center;
+	flex-shrink: 0;
+	color: var(--ink-gray-6);
+	--icon-stroke: var(--ink-gray-6);
+	// Size comes from the `.icon-sm` class that frappe.utils.icon(name, "sm")
+	// applies (16px) — no hardcoded svg sizing needed.
+}
+
+// ms-2 only when an icon precedes the label
+.settings-dialog-tab-icon + .settings-dialog-tab-label {
+	margin-left: 0.5rem;
+}
+
+.settings-dialog-tab-label {
+	flex: 1;
+	min-width: 0;
+	font-size: var(--text-sm); // text-sm
+	line-height: 1rem; // leading-4
+	color: var(--ink-gray-7);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.settings-dialog-panels {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	overflow-y: auto;
+	background-color: var(--surface-modal);
+}
+
+.settings-dialog-panel {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	height: 100%;
+	padding: 2rem 1.5rem;
+	gap: 1.5rem;
+	color: var(--ink-gray-9);
+}
+
+.settings-dialog-panel-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+	padding: 0 0.5rem;
+}
+
+.settings-dialog-panel-heading {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.settings-dialog-panel-title {
+	font-size: var(--text-2xl); // 20px
+	font-weight: var(--weight-semibold);
+	line-height: 1.2;
+	color: var(--ink-gray-8);
+}
+
+.settings-dialog-panel-description {
+	font-size: var(--text-base);
+	color: var(--ink-gray-6);
+}
+
+.settings-dialog-panel-actions {
+	display: flex;
+	gap: 0.5rem;
+	align-items: center;
+	flex-shrink: 0;
+}
+
+.settings-dialog-panel-body {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	overflow-y: auto;
+	padding: 0 0.5rem;
+}


### PR DESCRIPTION
Adds two reusable client-side primitives:

1. **`frappe.ui.SettingsDialog`** — a two-pane settings dialog (grouped vertical tab rail + lazily-rendered panels), extending `frappe.ui.Dialog` so it reuses the full modal lifecycle (backdrop, show/hide, ESC, open-dialog stack).
2. **`Switch` control** (`frappe.ui.form.ControlSwitch`) — a sliding toggle usable as `fieldtype: "Switch"` anywhere a control is built (FieldGroup,Dialog, forms).

## SettingsDialog API

Config-driven, grouped tabs; each tab owns its panel:


```
new frappe.ui.SettingsDialog({
  title: __("Settings"),
  default_tab: "preferences",
  tabs: [{
    group: __("Configuration"),
    items: [{
      id: "preferences",
      label: __("Preferences"),
      icon: "sliders-vertical",
      title: __("Preferences"),
      description: __("Manage your preferences"),
      fields: [ /* FieldGroup config */ ],
      actions: [{ label: __("Save"), primary: true, click(panel) {
        const values = panel.get_values();   // null if a reqd field is empty
      }}],
      render(panel) { /* custom body into panel.body */ },
    }],
  }],
}).show();
```

Each panel is a SettingsDialogPanel controller shared by render and every action. click. The atomic unit is a view — panel.set_view({ title, description, actions, fields, render }) swaps header + actions + form together, so an action always reads the form mounted alongside it. This supports stateful panels (list → form → save → back) without cross-call coordination.

- panel.set_view(spec) — swap the whole view
- panel.refresh() — reset to the default view (the item config)
- panel.get_values() / get_value / set_values — proxied to the panel's FieldGroup
- panel.set_header(...) / add_fields(...) — lower-level helpers

## Switch control
Subclasses ControlCheck, so it keeps the real <input type="checkbox"> and all 0/1 value semantics (get_values() returns 1/0, validation, read-only display). Only the markup is swapped; CSS skins it as a slider via:has(). Clicking anywhere on the row toggles (the whole row is one <label>).


<img width="1439" height="814" alt="Screenshot 2026-06-15 at 5 29 27 PM" src="https://github.com/user-attachments/assets/5aeb395c-5cf2-4d79-86e4-2d5ce6aa3517" />


`no-docs`