### PR TITLE
fix(sidebar): update box-shadow for active sidebar state

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -5,12 +5,15 @@
 	--sidebar-border-color: #ededed;
 	--divider-color: rgba(237, 237, 237, 1);
 	--sidebar-width: 220px;
+	--sidebar-active-shadow: 0 0 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.14);
 }
 [data-theme="dark"] {
 	--sidebar-hover-color: rgba(43, 43, 43, 1);
 	--sidebar-active-color: rgba(66, 66, 66, 1);
 	--sidebar-border-color: #232323;
 	--divider-color: rgba(52, 52, 52, 1);
+	--sidebar-active-shadow: 0 0 1px 0 rgba(0, 0, 0, 0.5), 0 1px 3px 0 rgba(0, 0, 0, 0.4),
+		inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 // sidebar-item states
@@ -279,7 +282,7 @@
 
 .active-sidebar {
 	background: var(--sidebar-active-color);
-	box-shadow: var(--shadow-sm);
+	box-shadow: var(--sidebar-active-shadow);
 	border-radius: 8px;
 	:hover {
 		text-decoration: none;


### PR DESCRIPTION
Related to: https://github.com/frappe/frappe/pull/39630
**Sidebar item shadow and color before fix**
<img width="217" height="291" alt="image" src="https://github.com/user-attachments/assets/4cd8a29e-b465-4cc1-8e37-f96440b3839b" />


**Sidebar item shadow and color after fix**
<img width="223" height="282" alt="image" src="https://github.com/user-attachments/assets/f747e28f-f843-4468-a1e0-7cd3232a5a25" />


---
**Dark Mode**
<img width="228" height="298" alt="image" src="https://github.com/user-attachments/assets/31def062-b712-4114-b1e1-3ac28bf21da6" />
