### PR TITLE
fix: force restrict_globals mode for render only funcs.

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -90,7 +90,7 @@ class AssignmentRule(Document):
 				assign_to=[user],
 				doctype=doc.get("doctype"),
 				name=doc.get("name"),
-				description=frappe.render_template(self.description, doc),
+				description=frappe.render_template(self.description, doc, restrict_globals=True),
 				assignment_rule=self.name,
 				notify=True,
 				date=doc.get(self.due_date_based_on) if self.due_date_based_on else None,

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -622,8 +622,8 @@ def generate_message_preview(name: str):
 	doc = frappe.get_doc(auto_repeat.reference_doctype, auto_repeat.reference_document)
 	doc.check_permission()
 	subject_preview = _("Please add a subject to your email")
-	msg_preview = frappe.render_template(auto_repeat.message, {"doc": doc})
+	msg_preview = frappe.render_template(auto_repeat.message, {"doc": doc}, restrict_globals=True)
 	if auto_repeat.subject:
-		subject_preview = frappe.render_template(auto_repeat.subject, {"doc": doc})
+		subject_preview = frappe.render_template(auto_repeat.subject, {"doc": doc}, restrict_globals=True)
 
 	return {"message": msg_preview, "subject": subject_preview}

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -417,7 +417,7 @@ class AutoRepeat(Document):
 		if not self.subject:
 			subject = _("New {0}: {1}").format(new_doc.doctype, new_doc.name)
 		elif "{" in self.subject:
-			subject = frappe.render_template(self.subject, {"doc": new_doc})
+			subject = frappe.render_template(self.subject, {"doc": new_doc}, restrict_globals=True)
 
 		print_format = self.print_format or "Standard"
 		error_string = None
@@ -445,7 +445,7 @@ class AutoRepeat(Document):
 		elif not self.message:
 			message = _("Please find attached {0}: {1}").format(new_doc.doctype, new_doc.name)
 		elif "{" in self.message:
-			message = frappe.render_template(self.message, {"doc": new_doc})
+			message = frappe.render_template(self.message, {"doc": new_doc}, restrict_globals=True)
 
 		make(
 			doctype=new_doc.doctype,

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -181,7 +181,7 @@ def render_address(address: dict | str | None, check_permissions=True) -> str | 
 	name, template = get_address_templates(address)
 
 	try:
-		return frappe.render_template(template, address)
+		return frappe.render_template(template, address, restrict_globals=True)
 	except TemplateSyntaxError:
 		frappe.throw(_("There is an error in your Address Template {0}").format(name))
 

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -822,7 +822,9 @@ class EmailAccount(Document):
 				sender=self.email_id,
 				reply_to=communication.incoming_email_account,
 				subject=" ".join([_("Re:"), communication.subject]),
-				content=render_template(self.auto_reply_message or "", communication.as_dict())
+				content=render_template(
+					self.auto_reply_message or "", communication.as_dict(), restrict_globals=True
+				)
 				or frappe.get_template("templates/emails/auto_reply.html").render(communication.as_dict()),
 				reference_doctype=communication.reference_doctype,
 				reference_name=communication.reference_name,

--- a/frappe/email/doctype/email_group/email_group.py
+++ b/frappe/email/doctype/email_group/email_group.py
@@ -152,7 +152,7 @@ def send_welcome_email(welcome_email, email, email_group):
 		return
 
 	args = dict(email=email, email_group=email_group)
-	message = frappe.render_template(welcome_email.response_, args)
+	message = frappe.render_template(welcome_email.response_, args, restrict_globals=True)
 	frappe.sendmail(email, subject=welcome_email.subject, message=message)
 
 

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -117,7 +117,7 @@ class Notification(Document):
 				context["comments"] = json.loads(doc.get("_comments"))
 			if self.is_standard:
 				self.load_standard_properties(context)
-			msg = frappe.render_template(self.message, context)
+			msg = frappe.render_template(self.message, context, restrict_globals=True)
 			if self.channel == "SMS":
 				return frappe.utils.strip_html_tags(msg)
 			return msg
@@ -137,7 +137,7 @@ class Notification(Document):
 			if not self.subject:
 				return _("No subject")
 			if "{" in self.subject:
-				return frappe.render_template(self.subject, context)
+				return frappe.render_template(self.subject, context, restrict_globals=True)
 			return self.subject
 		except Exception as e:
 			return _("Failed to render subject: {}").format(str(e))
@@ -438,7 +438,7 @@ def get_context(context):
 	def create_system_notification(self, doc, context):
 		subject = self.subject
 		if "{" in subject:
-			subject = frappe.render_template(self.subject, context)
+			subject = frappe.render_template(self.subject, context, restrict_globals=True)
 
 		attachments = self.get_attachment(doc)
 
@@ -455,7 +455,7 @@ def get_context(context):
 			"document_name": get_reference_name(doc),
 			"subject": subject,
 			"from_user": doc.modified_by or doc.owner,
-			"email_content": frappe.render_template(self.message, context),
+			"email_content": frappe.render_template(self.message, context, restrict_globals=True),
 			"attached_file": json.dumps(attachments) if attachments else None,
 		}
 		enqueue_create_notification(users, notification_doc)
@@ -467,7 +467,7 @@ def get_context(context):
 
 		subject = self.subject
 		if "{" in subject:
-			subject = frappe.render_template(self.subject, context)
+			subject = frappe.render_template(self.subject, context, restrict_globals=True)
 
 		attachments = self.get_attachment(doc)
 		recipients, cc, bcc = self.get_list_of_recipients(doc, context)
@@ -475,7 +475,7 @@ def get_context(context):
 			return
 
 		sender = None
-		message = frappe.render_template(self.message, context)
+		message = frappe.render_template(self.message, context, restrict_globals=True)
 		if self.sender and self.sender_email:
 			sender = formataddr((self.sender, self.sender_email))
 
@@ -526,7 +526,7 @@ def get_context(context):
 	def send_a_slack_msg(self, doc, context):
 		send_slack_message(
 			webhook_url=self.slack_webhook_url,
-			message=frappe.render_template(self.message, context),
+			message=frappe.render_template(self.message, context, restrict_globals=True),
 			reference_doctype=get_reference_doctype(doc),
 			reference_name=get_reference_name(doc),
 		)
@@ -534,7 +534,9 @@ def get_context(context):
 	def send_sms(self, doc, context):
 		send_sms(
 			receiver_list=self.get_receiver_list(doc, context, "mobile_no", self.get_mobile_no),
-			msg=frappe.utils.strip_html_tags(frappe.render_template(self.message, context)),
+			msg=frappe.utils.strip_html_tags(
+				frappe.render_template(self.message, context, restrict_globals=True)
+			),
 		)
 
 	@staticmethod
@@ -863,7 +865,7 @@ def get_emails_from_template(template, context):
 	if not template:
 		return ()
 
-	emails = frappe.render_template(template, context) if "{" in template else template
+	emails = frappe.render_template(template, context, restrict_globals=True) if "{" in template else template
 	return filter(None, emails.replace(",", "\n").split("\n"))
 
 

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -260,7 +260,7 @@ def get_email_subject_for_2fa(kwargs_dict):
 	subject_template = _("Login Verification Code from {}").format(
 		frappe.get_system_settings("otp_issuer_name")
 	)
-	return frappe.render_template(subject_template, kwargs_dict)
+	return frappe.render_template(subject_template, kwargs_dict, restrict_globals=True)
 
 
 def get_email_body_for_2fa(kwargs_dict):
@@ -270,7 +270,7 @@ def get_email_body_for_2fa(kwargs_dict):
 		<br><br>
 		<b style="font-size: 18px;">{{ otp }}</b>
 	"""
-	return frappe.render_template(body_template, kwargs_dict)
+	return frappe.render_template(body_template, kwargs_dict, restrict_globals=True)
 
 
 def get_email_subject_for_qr_code(kwargs_dict):
@@ -278,7 +278,7 @@ def get_email_subject_for_qr_code(kwargs_dict):
 	subject_template = _("One Time Password (OTP) Registration Code from {}").format(
 		frappe.get_system_settings("otp_issuer_name")
 	)
-	return frappe.render_template(subject_template, kwargs_dict)
+	return frappe.render_template(subject_template, kwargs_dict, restrict_globals=True)
 
 
 def get_email_body_for_qr_code(kwargs_dict):
@@ -286,7 +286,7 @@ def get_email_body_for_qr_code(kwargs_dict):
 	body_template = _(
 		"Please click on the following link and follow the instructions on the page. {0}"
 	).format("<br><br> <a href='{{qrcode_link}}'>{{qrcode_link}}</a>")
-	return frappe.render_template(body_template, kwargs_dict)
+	return frappe.render_template(body_template, kwargs_dict, restrict_globals=True)
 
 
 def get_link_for_qrcode(user, totp_uri):
@@ -347,7 +347,7 @@ def get_rendered_otp_message(otp: str) -> str:
 	custom_template = frappe.get_system_settings("otp_sms_template")
 	template = custom_template or default_template
 
-	return frappe.render_template(template, {"otp": otp})
+	return frappe.render_template(template, {"otp": otp}, restrict_globals=True)
 
 
 def send_token_via_email(user, token, otp_secret, otp_issuer, subject=None, message=None):


### PR DESCRIPTION
This endpoint should not really need exec. globals so force restricting it in code.
