### PR TITLE
fix: resolve blob URL hostname before checking external link warning

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -594,10 +594,12 @@ frappe.router = {
 
 			// Check that the origin is external (does not prevent self-clickjacking on GET endpoints)
 			const url = new URL(aElement.href);
+			const hostname = url.hostname;
 
-			// For blob: URLs, hostname is empty extract the real host from the embedded URL in pathname
-			const hostname =
-				url.protocol === "blob:" ? new URL(url.pathname).hostname : url.hostname;
+			// For blob: URLs, skip the link check
+			if (url.protocol === "blob:") {
+			  return false; // blob: URLs are not checked
+			}
 			if (hostname === window.location.hostname) {
 				return false; // self-linking is allowed
 			}

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -598,7 +598,7 @@ frappe.router = {
 
 			// For blob: URLs, skip the link check
 			if (url.protocol === "blob:") {
-			  return false; // blob: URLs are not checked
+				return false; // blob: URLs are not checked
 			}
 			if (hostname === window.location.hostname) {
 				return false; // self-linking is allowed

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -594,7 +594,10 @@ frappe.router = {
 
 			// Check that the origin is external (does not prevent self-clickjacking on GET endpoints)
 			const url = new URL(aElement.href);
-			const hostname = url.hostname;
+
+			// For blob: URLs, hostname is empty extract the real host from the embedded URL in pathname
+			const hostname =
+				url.protocol === "blob:" ? new URL(url.pathname).hostname : url.hostname;
 			if (hostname === window.location.hostname) {
 				return false; // self-linking is allowed
 			}


### PR DESCRIPTION
Resolve: #40005 

blob: URLs have an empty hostname, causing them to always fail the same-host check and incorrectly trigger the external link warning. Extract the real hostname from the embedded URL in the pathname so same-origin blob URLs (e.g. PDF downloads) are allowed through, while blob URLs from a different origin still show the warning.

---

**Before:**

https://github.com/user-attachments/assets/8c8bc03e-d2ea-4c61-bc83-412453b5acbb




**After:**

https://github.com/user-attachments/assets/e3832c6b-11e0-4127-b5a9-d317927ae866



