### PR TITLE
fix(sidebar): resolve workspace sidebar on cold load of query report

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -786,13 +786,18 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 
 	entity_from_route(route) {
+		// View routes carry the entity in the second segment, e.g.
+		// ["query-report", "General Ledger"] or ["Tree", "Account"]. Without this the
+		// length-2 default would return the view keyword ("query-report") and the
+		// sidebar would fail to resolve on a cold load (duplicated tab / refresh).
+		const view_route_prefixes = ["query-report", "Tree", "dashboard-view", "print"];
 		switch (route.length) {
 			case 1:
 				return route[0];
 			case 3:
 				return route[0] === "Workspaces" && route[1] === "private" ? route[2] : route[1];
 			default:
-				return route[0];
+				return view_route_prefixes.includes(route[0]) ? route[1] : route[0];
 		}
 	}
 


### PR DESCRIPTION
## Problem

When a query report (e.g. **General Ledger**) is opened via a cold page load — duplicating the browser tab, refreshing, or pasting the URL — the left workspace sidebar does not render. It only appears during in-app (SPA) navigation. Reported with v16, reproducible on `develop`.

## Root cause

The route for a query report is `["query-report", "<report>"]` (length 2). In `Sidebar.entity_from_route()` the length-2 `default` branch returned `route[0]` — the literal view keyword `"query-report"` — instead of the report name. `resolve_sidebar()` therefore found no workspace linking that entity, `setup()` was never called, and the sidebar stayed empty.

During normal navigation the previously shown sidebar persists (`sidebar_title` is already set), which masks the bug; a fresh load has no prior sidebar, so the rail is blank.

## Fix

For view-keyword routes (`query-report`, `Tree`, `dashboard-view`, `print`), use the second route segment as the entity, so resolution matches the workspace that links the report/document. These keyword routes never resolved to a sidebar before, so other routes are unaffected. This also fixes the same latent issue for Tree views (e.g. Chart of Accounts) and dashboards.

## Steps to verify

1. Open General Ledger.
2. Duplicate the tab (or hard-refresh).
3. Sidebar now renders (previously empty).