### PR TITLE
fix: always return the correct entity

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -791,6 +791,10 @@ frappe.ui.Sidebar = class Sidebar {
 				return route[0];
 			case 3:
 				return route[0] === "Workspaces" && route[1] === "private" ? route[2] : route[1];
+			case 2:
+				// view-type routes like ["List", "Customer"] or
+				// ["query-report", "Balance Sheet"] -> entity is the second element
+				return route[1];
 			default:
 				return route[0];
 		}


### PR DESCRIPTION
Query reports will now load the correct shell


https://github.com/user-attachments/assets/67a2f56e-c346-4317-989e-764844f6cbca




