### PR TITLE
fix: don't disable telemetry mid-setup-wizard

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -7,6 +7,7 @@ from frappe import _
 from frappe.model import no_value_fields
 from frappe.model.document import Document
 from frappe.utils import cint, today
+from frappe.utils.telemetry.pulse.client import is_enabled as pulse_enabled
 
 
 class SystemSettings(Document):
@@ -204,6 +205,9 @@ class SystemSettings(Document):
 	def on_update(self):
 		self.set_defaults()
 		clear_system_settings_cache()
+
+		if not frappe.flags.in_setup_wizard and self.has_value_changed("enable_telemetry"):
+			pulse_enabled.clear_cache()
 
 		if frappe.flags.update_last_reset_password_date:
 			update_last_reset_password_date()

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -144,8 +144,21 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 		if (id === this.slides.length) {
 			return;
 		}
+		const moving_forward = id > this.current_id;
 		super.show_slide(id);
 		frappe.set_route(this.page_name, cstr(id));
+		// Commit the telemetry opt-out only when the user actually advances past a
+		// slide, not on every checkbox change — so toggling it back and forth within
+		// the slide stays reversible (disable() is one-way and can't be undone).
+		if (moving_forward) {
+			this.sync_telemetry_preference();
+		}
+	}
+
+	sync_telemetry_preference() {
+		if (frappe.telemetry.enabled && !this.values.enable_telemetry) {
+			frappe.telemetry.disable();
+		}
 	}
 
 	show_hide_prev_next(id) {
@@ -206,6 +219,9 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 		frappe.telemetry.capture("initated_client_side", "setup");
 		if (!this.current_slide.set_values()) return;
 		this.update_values();
+		// Single-slide wizards (e.g. developer_mode) reach completion without ever
+		// advancing past a slide, so commit the telemetry opt-out here too.
+		this.sync_telemetry_preference();
 		this.show_working_state();
 		this.disable_keyboard_nav();
 		this.listen_for_setup_stages();
@@ -383,12 +399,6 @@ frappe.setup.SetupWizardSlide = class SetupWizardSlide extends frappe.ui.Slide {
 			field.fieldname &&
 				me.get_input(field.fieldname)?.on?.("change", function () {
 					frappe.telemetry.capture(`${field.fieldname}_set`, "setup");
-					if (
-						field.fieldname == "enable_telemetry" &&
-						!me.get_value("enable_telemetry")
-					) {
-						frappe.telemetry.disable();
-					}
 				});
 		});
 	}

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -144,18 +144,15 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 		if (id === this.slides.length) {
 			return;
 		}
-		const moving_forward = id > this.current_id;
 		super.show_slide(id);
 		frappe.set_route(this.page_name, cstr(id));
-		// Commit the telemetry opt-out only when the user actually advances past a
-		// slide, not on every checkbox change — so toggling it back and forth within
-		// the slide stays reversible (disable() is one-way and can't be undone).
-		if (moving_forward) {
-			this.sync_telemetry_preference();
-		}
 	}
 
 	sync_telemetry_preference() {
+		// Apply the opt-out from the final committed values, not on each checkbox
+		// change, so toggling within a slide stays reversible — disable() is one-way.
+		// Called from action_on_complete *after* initated_client_side is captured,
+		// so the funnel event still fires for users who opted out.
 		if (frappe.telemetry.enabled && !this.values.enable_telemetry) {
 			frappe.telemetry.disable();
 		}
@@ -219,8 +216,6 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 		frappe.telemetry.capture("initated_client_side", "setup");
 		if (!this.current_slide.set_values()) return;
 		this.update_values();
-		// Single-slide wizards (e.g. developer_mode) reach completion without ever
-		// advancing past a slide, so commit the telemetry opt-out here too.
 		this.sync_telemetry_preference();
 		this.show_working_state();
 		this.disable_keyboard_nav();

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -96,6 +96,7 @@ def process_setup_stages(stages, user_input, is_background_task=False):
 	from frappe.utils.telemetry import capture
 
 	setup_wizard_completed_apps = get_setup_wizard_completed_apps()
+	telemetry_enabled = bool(cint(user_input.get("enable_telemetry")))
 
 	capture("initated_server_side", "setup")
 	try:
@@ -125,6 +126,14 @@ def process_setup_stages(stages, user_input, is_background_task=False):
 	except Exception:
 		handle_setup_exception(user_input)
 		message = current_task.get("fail_msg") if current_task else "Failed to complete setup"
+		capture(
+			"setup_failed",
+			"setup",
+			properties={
+				"telemetry_enabled": telemetry_enabled,
+				"stage": message,
+			},
+		)
 		frappe.log_error(title=f"Setup failed: {message}")
 		if not is_background_task:
 			frappe.response["setup_wizard_failure_message"] = message
@@ -136,7 +145,13 @@ def process_setup_stages(stages, user_input, is_background_task=False):
 		)
 	else:
 		run_setup_success(user_input)
-		capture("completed_server_side", "setup")
+		capture(
+			"completed_server_side",
+			"setup",
+			properties={
+				"telemetry_enabled": telemetry_enabled,
+			},
+		)
 		if not is_background_task:
 			return {"status": "ok"}
 		frappe.publish_realtime("setup_task", {"status": "ok"}, user=frappe.session.user)


### PR DESCRIPTION
Decline-telemetry made the setup funnel unmeasurable: `disable()` ran
mid-wizard, dropping `initated_client_side`, while `completed_server_side` only
survived via a stale `is_enabled()` cache.
- Server: `completed_server_side` carries a `telemetry_enabled` property and adds
  an explicit `setup_failed` event; `on_update` clears the `is_enabled()` cache
  except mid-wizard, so outcome events still fire after opt-out.
- Client: commit the opt-out at Next/Complete instead of on every change, so
  in-slide toggling stays reversible.
