### PR TITLE
fix: support query parameters in set_route function

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -405,10 +405,14 @@ frappe.router = {
 			// called as frappe.set_route(['a', 'b', 'c']);
 			route = route[0];
 		}
-
 		if (route.length === 1 && route[0] && route[0].includes("/")) {
-			// called as frappe.set_route('a/b/c')
-			route = $.map(route[0].split("/"), this.decode_component);
+			// called as frappe.set_route('a/b/c') or frappe.set_route('/desk/a/b?x=1')
+			let [path, query_string] = route[0].split("?");
+			if (query_string) {
+				frappe.route_options = frappe.route_options || {};
+				new URLSearchParams(query_string).forEach((v, k) => (frappe.route_options[k] = v));
+			}
+			route = $.map(path.split("/"), this.decode_component);
 		}
 
 		if (route && route[0] == "") {
@@ -510,7 +514,7 @@ frappe.router = {
 		if (window.location.pathname !== path || window.location.search !== query_params) {
 			// push/replace state so the browser looks fine
 			const method = frappe.route_flags.replace_route ? "replaceState" : "pushState";
-			history[method](null, null, path);
+			history[method](null, null, path + query_params);
 
 			// now process the route
 			this.route();

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -383,7 +383,13 @@ frappe.router = {
 					const route_options = frappe.route_options || {};
 					const query_params = Object.entries(route_options)
 						.map(
-							([key, value]) => `${key}=` + encodeURIComponent(JSON.stringify(value))
+							([key, value]) =>
+								`${key}=` +
+								encodeURIComponent(
+									value !== null && typeof value === "object"
+										? JSON.stringify(value)
+										: String(value)
+								)
 						)
 						.join("&");
 					this.push_state(sub_path, query_params ? `?${query_params}` : "");

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -413,7 +413,9 @@ frappe.router = {
 		}
 		if (route.length === 1 && route[0] && route[0].includes("/")) {
 			// called as frappe.set_route('a/b/c') or frappe.set_route('/desk/a/b?x=1')
-			let [path, query_string] = route[0].split("?");
+			const qIdx = route[0].indexOf("?");
+			let path = qIdx >= 0 ? route[0].slice(0, qIdx) : route[0];
+			let query_string = qIdx >= 0 ? route[0].slice(qIdx + 1) : null;
 			if (query_string) {
 				frappe.route_options = frappe.route_options || {};
 				new URLSearchParams(query_string).forEach((v, k) => (frappe.route_options[k] = v));


### PR DESCRIPTION
Resolve: #39219
`frappe.set_route` did not handle query parameters when passed a full URL string (e.g. from `frappe.utils.get_form_link`). The `?key=value` part was being split into the path, causing `make_url` to encode it as %3F... in the pathname and never populating frappe.route_options. Additionally, `push_state` was building the query string but ignoring it in history.pushState, so the URL bar never reflected the params.

Fixed by extracting the query string before path splitting in `get_route_from_arguments`, and including it in the `history.pushState` call.

Test snippet:

```js
cur_frm.add_custom_button("Test query param", () => {
    let url = frappe.utils.get_form_link("ToDo", "new", false, null, {
        description: "Pre-filled from set_route",
        priority: "High",
    });
    frappe.set_route(url);
});
```
**Expected**: clicking the button opens the new ToDo form with Description and Priority already filled in.

https://github.com/user-attachments/assets/782e142b-c0a3-4853-900a-63320f0158cf


