### PR TITLE
feat: dynamic field descriptions driven by source field value

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -80,6 +80,7 @@
   "columns",
   "column_break_22",
   "description",
+  "dynamic_description",
   "documentation_url",
   "placeholder",
   "oldfieldname",
@@ -449,6 +450,12 @@
    "oldfieldtype": "Text",
    "print_width": "300px",
    "width": "300px"
+  },
+  {
+   "fieldname": "dynamic_description",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "label": "Dynamic Description"
   },
   {
    "fieldname": "oldfieldname",

--- a/frappe/core/doctype/docfield/test_docfield.py
+++ b/frappe/core/doctype/docfield/test_docfield.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+import json
+import random
+import string
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+
+def _new_doctype_name():
+	return "Test DynDesc " + "".join(random.sample(string.ascii_lowercase, 6))
+
+
+def _resolve_description(config: dict, source_value) -> str:
+	"""
+	Python mirror of refresh_dynamic_description() in layout.js.
+
+	Finds the first condition whose value matches source_value,
+	or falls back to config["default"].
+	"""
+	if not config.get("source_field"):
+		return config.get("default") or ""
+
+	for cond in config.get("conditions") or []:
+		if cond.get("value") == source_value:
+			return cond.get("description") or ""
+
+	return config.get("default") or ""
+
+
+class TestDocFieldDynamicDescription(IntegrationTestCase):
+	"""Tests for the dynamic_description feature on DocField."""
+
+	created_doctypes: list[str] = []
+
+	def tearDown(self):
+		for name in self.created_doctypes:
+			frappe.delete_doc_if_exists("DocType", name, force=True)
+		self.created_doctypes.clear()
+		frappe.db.rollback()
+
+	# ------------------------------------------------------------------ #
+	# Meta / schema tests                                                  #
+	# ------------------------------------------------------------------ #
+
+	def test_dynamic_description_field_exists_in_meta(self):
+		"""dynamic_description is declared as a DocField property."""
+		meta = frappe.get_meta("DocField")
+		fieldnames = [f.fieldname for f in meta.fields]
+		self.assertIn(
+			"dynamic_description",
+			fieldnames,
+			"dynamic_description missing from DocField meta — run bench migrate",
+		)
+
+	def test_dynamic_description_is_hidden(self):
+		"""dynamic_description should be hidden (managed via DynamicDescriptionEditor, not raw input)."""
+		meta = frappe.get_meta("DocField")
+		df = next(f for f in meta.fields if f.fieldname == "dynamic_description")
+		self.assertEqual(df.hidden, 1)
+
+	def test_dynamic_description_is_small_text(self):
+		"""dynamic_description must be Small Text to hold arbitrary-length JSON."""
+		meta = frappe.get_meta("DocField")
+		df = next(f for f in meta.fields if f.fieldname == "dynamic_description")
+		self.assertEqual(df.fieldtype, "Small Text")
+
+	# ------------------------------------------------------------------ #
+	# Persistence tests                                                    #
+	# ------------------------------------------------------------------ #
+
+	def test_dynamic_description_round_trips_through_db(self):
+		"""A config stored on a field should survive insert → reload."""
+		config = {
+			"source_field": "customer_type",
+			"conditions": [
+				{"value": "Individual", "description": "NET30 applies."},
+				{"value": "Company", "description": "NET60 terms."},
+			],
+			"default": "Standard terms apply.",
+		}
+
+		name = _new_doctype_name()
+		self.created_doctypes.append(name)
+
+		dt = frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"module": "Core",
+				"custom": 1,
+				"name": name,
+				"fields": [
+					{
+						"label": "Customer Type",
+						"fieldname": "customer_type",
+						"fieldtype": "Select",
+						"options": "Individual\nCompany",
+					},
+					{
+						"label": "Payment Terms",
+						"fieldname": "payment_terms",
+						"fieldtype": "Data",
+						"dynamic_description": json.dumps(config),
+					},
+				],
+				"permissions": [{"role": "System Manager", "read": 1}],
+			}
+		).insert(ignore_permissions=True)
+
+		dt.reload()
+
+		payment_field = next(f for f in dt.fields if f.fieldname == "payment_terms")
+		self.assertIsNotNone(payment_field.dynamic_description, "dynamic_description was not persisted")
+
+		saved_config = json.loads(payment_field.dynamic_description)
+		self.assertEqual(saved_config["source_field"], "customer_type")
+		self.assertEqual(len(saved_config["conditions"]), 2)
+		self.assertEqual(saved_config["conditions"][0]["value"], "Individual")
+		self.assertEqual(saved_config["conditions"][1]["description"], "NET60 terms.")
+		self.assertEqual(saved_config["default"], "Standard terms apply.")
+
+	def test_dynamic_description_coexists_with_static_description(self):
+		"""Both description and dynamic_description fields are independent."""
+		config = {
+			"source_field": "status",
+			"conditions": [],
+			"default": "Dynamic default",
+		}
+
+		name = _new_doctype_name()
+		self.created_doctypes.append(name)
+
+		dt = frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"module": "Core",
+				"custom": 1,
+				"name": name,
+				"fields": [
+					{
+						"label": "Status",
+						"fieldname": "status",
+						"fieldtype": "Data",
+						"description": "Static help text",
+						"dynamic_description": json.dumps(config),
+					}
+				],
+				"permissions": [{"role": "System Manager", "read": 1}],
+			}
+		).insert(ignore_permissions=True)
+
+		dt.reload()
+		field = next(f for f in dt.fields if f.fieldname == "status")
+
+		self.assertEqual(field.description, "Static help text")
+		saved = json.loads(field.dynamic_description)
+		self.assertEqual(saved["default"], "Dynamic default")
+
+	def test_dynamic_description_cleared_on_update(self):
+		"""Removing dynamic_description (switching back to static) persists as empty."""
+		config = {"source_field": "x", "conditions": [], "default": "D"}
+
+		name = _new_doctype_name()
+		self.created_doctypes.append(name)
+
+		dt = frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"module": "Core",
+				"custom": 1,
+				"name": name,
+				"fields": [
+					{
+						"label": "Field",
+						"fieldname": "field",
+						"fieldtype": "Data",
+						"dynamic_description": json.dumps(config),
+					}
+				],
+				"permissions": [{"role": "System Manager", "read": 1}],
+			}
+		).insert(ignore_permissions=True)
+
+		# Now clear dynamic_description (user switched back to static)
+		field_row = next(f for f in dt.fields if f.fieldname == "field")
+		field_row.dynamic_description = ""
+		dt.save(ignore_permissions=True)
+		dt.reload()
+
+		field_row = next(f for f in dt.fields if f.fieldname == "field")
+		self.assertFalse(
+			field_row.dynamic_description,
+			"dynamic_description should be empty after switching to static mode",
+		)
+
+	def test_invalid_json_stored_and_retrieved_as_string(self):
+		"""Malformed JSON is stored/returned as-is; JS side handles the parse error."""
+		bad_json = "not { valid json"
+
+		name = _new_doctype_name()
+		self.created_doctypes.append(name)
+
+		dt = frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"module": "Core",
+				"custom": 1,
+				"name": name,
+				"fields": [
+					{
+						"label": "Field",
+						"fieldname": "field",
+						"fieldtype": "Data",
+						"dynamic_description": bad_json,
+					}
+				],
+				"permissions": [{"role": "System Manager", "read": 1}],
+			}
+		).insert(ignore_permissions=True)
+
+		dt.reload()
+		field = next(f for f in dt.fields if f.fieldname == "field")
+		self.assertEqual(field.dynamic_description, bad_json)
+
+	# ------------------------------------------------------------------ #
+	# Resolution logic tests (mirrors refresh_dynamic_description in JS)  #
+	# ------------------------------------------------------------------ #
+
+	def test_resolve_matched_condition(self):
+		"""Returns the description for the matching condition value."""
+		config = {
+			"source_field": "customer_type",
+			"conditions": [
+				{"value": "Individual", "description": "NET30 applies."},
+				{"value": "Company", "description": "NET60 terms."},
+			],
+			"default": "Standard terms.",
+		}
+		self.assertEqual(_resolve_description(config, "Individual"), "NET30 applies.")
+		self.assertEqual(_resolve_description(config, "Company"), "NET60 terms.")
+
+	def test_resolve_falls_back_to_default_on_no_match(self):
+		"""Unrecognised source value falls back to config['default']."""
+		config = {
+			"source_field": "customer_type",
+			"conditions": [{"value": "Individual", "description": "NET30."}],
+			"default": "Standard terms.",
+		}
+		self.assertEqual(_resolve_description(config, "Non-Profit"), "Standard terms.")
+
+	def test_resolve_falls_back_to_default_on_none_value(self):
+		"""None (unset field) falls back to default."""
+		config = {
+			"source_field": "customer_type",
+			"conditions": [{"value": "Individual", "description": "NET30."}],
+			"default": "Default text.",
+		}
+		self.assertEqual(_resolve_description(config, None), "Default text.")
+
+	def test_resolve_falls_back_to_default_on_empty_string(self):
+		"""Empty string source value falls back to default."""
+		config = {
+			"source_field": "customer_type",
+			"conditions": [{"value": "Individual", "description": "NET30."}],
+			"default": "Default text.",
+		}
+		self.assertEqual(_resolve_description(config, ""), "Default text.")
+
+	def test_resolve_returns_empty_string_when_no_default(self):
+		"""No matching condition and no default → empty string (no description shown)."""
+		config = {
+			"source_field": "customer_type",
+			"conditions": [{"value": "Individual", "description": "NET30."}],
+			"default": "",
+		}
+		self.assertEqual(_resolve_description(config, "Company"), "")
+
+	def test_resolve_returns_default_when_no_source_field(self):
+		"""Empty source_field config returns the default (pre-configured state)."""
+		config = {"source_field": "", "conditions": [], "default": "Fallback."}
+		self.assertEqual(_resolve_description(config, "anything"), "Fallback.")
+
+	def test_resolve_returns_empty_when_no_source_field_and_no_default(self):
+		"""Empty source_field and no default returns empty string."""
+		config = {"source_field": "", "conditions": [], "default": ""}
+		self.assertEqual(_resolve_description(config, "x"), "")
+
+	def test_resolve_first_matching_condition_wins(self):
+		"""If multiple conditions match (duplicate values), the first one wins."""
+		config = {
+			"source_field": "field",
+			"conditions": [
+				{"value": "A", "description": "First A."},
+				{"value": "A", "description": "Second A."},
+			],
+			"default": "Default.",
+		}
+		self.assertEqual(_resolve_description(config, "A"), "First A.")
+
+	def test_resolve_empty_conditions_list_uses_default(self):
+		"""A dynamic config with no conditions always shows the default."""
+		config = {
+			"source_field": "status",
+			"conditions": [],
+			"default": "Always shown.",
+		}
+		self.assertEqual(_resolve_description(config, "Draft"), "Always shown.")
+		self.assertEqual(_resolve_description(config, "Submitted"), "Always shown.")
+
+	def test_resolve_matched_condition_with_empty_description(self):
+		"""A condition with an empty description string returns empty (clears the help text)."""
+		config = {
+			"source_field": "field",
+			"conditions": [{"value": "hide", "description": ""}],
+			"default": "Default shown otherwise.",
+		}
+		self.assertEqual(_resolve_description(config, "hide"), "")

--- a/frappe/core/doctype/docfield/test_docfield.py
+++ b/frappe/core/doctype/docfield/test_docfield.py
@@ -363,6 +363,52 @@ class TestDocFieldDynamicDescription(IntegrationTestCase):
 		self.assertEqual(saved["source_field"], "priority")
 		self.assertEqual(len(saved["conditions"]), 3)
 
+	def test_show_description_on_click_with_dynamic_description(self):
+		"""show_description_on_click and dynamic_description can be set together on the same field."""
+		config = {
+			"source_field": "status",
+			"conditions": [
+				{"value": "Draft", "description": "Not yet submitted."},
+				{"value": "Submitted", "description": "Locked for editing."},
+			],
+			"default": "Select a status.",
+		}
+
+		name = _new_doctype_name()
+		self.created_doctypes.append(name)
+
+		dt = frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"module": "Core",
+				"custom": 1,
+				"name": name,
+				"fields": [
+					{
+						"label": "Status",
+						"fieldname": "status",
+						"fieldtype": "Select",
+						"options": "Draft\nSubmitted",
+						"show_description_on_click": 1,
+						"dynamic_description": json.dumps(config),
+					}
+				],
+				"permissions": [{"role": "System Manager", "read": 1}],
+			}
+		).insert(ignore_permissions=True)
+
+		dt.reload()
+		field = next(f for f in dt.fields if f.fieldname == "status")
+
+		self.assertEqual(field.show_description_on_click, 1)
+		saved = json.loads(field.dynamic_description)
+		self.assertEqual(saved["source_field"], "status")
+
+		# Resolution logic still works regardless of show_description_on_click
+		self.assertEqual(_resolve_description(saved, "Draft"), "Not yet submitted.")
+		self.assertEqual(_resolve_description(saved, "Submitted"), "Locked for editing.")
+		self.assertEqual(_resolve_description(saved, "Cancelled"), "Select a status.")
+
 	def test_self_reference_resolution(self):
 		"""Resolution logic works when source_field == the field being described."""
 		config = {

--- a/frappe/core/doctype/docfield/test_docfield.py
+++ b/frappe/core/doctype/docfield/test_docfield.py
@@ -316,3 +316,64 @@ class TestDocFieldDynamicDescription(IntegrationTestCase):
 			"default": "Default shown otherwise.",
 		}
 		self.assertEqual(_resolve_description(config, "hide"), "")
+
+	# ------------------------------------------------------------------ #
+	# Self-reference tests                                                 #
+	# ------------------------------------------------------------------ #
+
+	def test_self_reference_select_field_persists(self):
+		"""A Select field can use its own value as the description source."""
+		config = {
+			"source_field": "priority",  # same as the field's own fieldname
+			"conditions": [
+				{"value": "Low", "description": "Resolved within 5 business days."},
+				{"value": "Medium", "description": "Resolved within 2 business days."},
+				{"value": "High", "description": "Escalated — resolved within 4 hours."},
+			],
+			"default": "Select a priority level.",
+		}
+
+		name = _new_doctype_name()
+		self.created_doctypes.append(name)
+
+		dt = frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"module": "Core",
+				"custom": 1,
+				"name": name,
+				"fields": [
+					{
+						"label": "Priority",
+						"fieldname": "priority",
+						"fieldtype": "Select",
+						"options": "Low\nMedium\nHigh",
+						"dynamic_description": json.dumps(config),
+					}
+				],
+				"permissions": [{"role": "System Manager", "read": 1}],
+			}
+		).insert(ignore_permissions=True)
+
+		dt.reload()
+		field = next(f for f in dt.fields if f.fieldname == "priority")
+		saved = json.loads(field.dynamic_description)
+
+		# source_field points to itself
+		self.assertEqual(saved["source_field"], "priority")
+		self.assertEqual(len(saved["conditions"]), 3)
+
+	def test_self_reference_resolution(self):
+		"""Resolution logic works when source_field == the field being described."""
+		config = {
+			"source_field": "status",
+			"conditions": [
+				{"value": "Draft", "description": "Not yet submitted. Still editable."},
+				{"value": "Submitted", "description": "Locked. Cancel to make changes."},
+			],
+			"default": "Select a status.",
+		}
+		# source_field == "status", and we pass the field's own current value
+		self.assertEqual(_resolve_description(config, "Draft"), "Not yet submitted. Still editable.")
+		self.assertEqual(_resolve_description(config, "Submitted"), "Locked. Cancel to make changes.")
+		self.assertEqual(_resolve_description(config, "Cancelled"), "Select a status.")

--- a/frappe/public/js/form_builder/components/DynamicDescriptionEditor.vue
+++ b/frappe/public/js/form_builder/components/DynamicDescriptionEditor.vue
@@ -45,8 +45,7 @@ function all_layout_fields() {
 	if (own && self_df && !no_value.includes(self_df.fieldtype)) {
 		result.push({
 			value: own,
-			label: (self_df.label || own) + " — " + __("this field"),
-			is_self: true,
+			label: self_df.label || own,
 		});
 	}
 
@@ -82,6 +81,17 @@ function find_df_in_layout(fieldname) {
 
 const value_fields = computed(() => all_layout_fields());
 
+const source_field_df = computed(() => ({
+	fieldtype: "Select",
+	label: __("Based on field"),
+	options: [{ label: __("Select Field"), value: "" }, ...value_fields.value],
+}));
+
+const source_field_model = computed({
+	get: () => config.value?.source_field || "",
+	set: (val) => set_source_field(val),
+});
+
 const own_fieldname = computed(() => store.form.selected_field?.fieldname);
 
 const source_df = computed(() => {
@@ -99,6 +109,15 @@ const source_options = computed(() => {
 	if (!source_is_select.value) return [];
 	return (source_df.value.options || "").split("\n").filter(Boolean);
 });
+
+const condition_value_df = computed(() => ({
+	fieldtype: "Select",
+	label: "",
+	options: [
+		{ label: __("Select value"), value: "" },
+		...source_options.value.map((o) => ({ label: o, value: o })),
+	],
+}));
 
 function set_source_field(fieldname) {
 	// Prefer selected_field directly for self so unsaved options are available
@@ -202,18 +221,11 @@ function update_default(val) {
 		<!-- Dynamic mode -->
 		<div v-else-if="config" class="dynamic-editor">
 			<div class="source-row">
-				<label class="sub-label">{{ __("Based on field") }}</label>
-				<select
-					class="form-control form-select source-select"
-					:value="config.source_field"
-					:disabled="read_only"
-					@change="set_source_field($event.target.value)"
-				>
-					<option value="">{{ __("— select a field —") }}</option>
-					<option v-for="f in value_fields" :key="f.value" :value="f.value">
-						{{ f.label }} ({{ f.value }})
-					</option>
-				</select>
+				<SelectControl
+					:df="source_field_df"
+					:read_only="read_only"
+					v-model="source_field_model"
+				/>
 			</div>
 
 			<div v-if="config.source_field" class="conditions-block">
@@ -229,20 +241,14 @@ function update_default(val) {
 					<tbody>
 						<tr v-for="(cond, i) in config.conditions" :key="i">
 							<td>
-								<select
+								<SelectControl
 									v-if="source_is_select"
-									class="form-control form-select cond-input"
-									:value="cond.value"
-									:disabled="read_only"
-									@change="update_condition_value(i, $event.target.value)"
-								>
-									<option value="">{{ __("— pick value —") }}</option>
-									<option
-										v-for="opt in source_options"
-										:key="opt"
-										:value="opt"
-									>{{ opt }}</option>
-								</select>
+									:df="condition_value_df"
+									:modelValue="cond.value"
+									:read_only="read_only"
+									:no_label="true"
+									@update:modelValue="update_condition_value(i, $event)"
+								/>
 								<input
 									v-else
 									type="text"
@@ -385,10 +391,6 @@ function update_default(val) {
 			color: var(--text-muted);
 			margin-bottom: 3px;
 			font-weight: normal;
-		}
-
-		.source-select {
-			font-size: var(--text-sm);
 		}
 
 		.conditions-block {

--- a/frappe/public/js/form_builder/components/DynamicDescriptionEditor.vue
+++ b/frappe/public/js/form_builder/components/DynamicDescriptionEditor.vue
@@ -174,42 +174,30 @@ function update_default(val) {
 	<div class="dynamic-description-editor">
 		<div class="editor-header">
 			<span class="field-label">{{ __("Description") }}</span>
-			<div class="mode-toggle">
-				<label
-					class="mode-option"
+			<div class="mode-toggle" role="group">
+				<button
+					type="button"
+					class="mode-btn"
 					:class="{ active: !is_dynamic }"
+					:disabled="read_only"
 					:title="__('Fixed description text')"
-				>
-					<input
-						type="radio"
-						name="desc_mode"
-						:checked="!is_dynamic"
-						:disabled="read_only"
-						@change="is_dynamic = false"
-					/>
-					{{ __("Static") }}
-				</label>
-				<label
-					class="mode-option"
+					@click="is_dynamic = false"
+				>{{ __("Static") }}</button>
+				<button
+					type="button"
+					class="mode-btn"
 					:class="{ active: is_dynamic }"
+					:disabled="read_only"
 					:title="__('Description changes based on another field value')"
-				>
-					<input
-						type="radio"
-						name="desc_mode"
-						:checked="is_dynamic"
-						:disabled="read_only"
-						@change="is_dynamic = true"
-					/>
-					{{ __("Dynamic") }}
-				</label>
+					@click="is_dynamic = true"
+				>{{ __("Dynamic") }}</button>
 			</div>
 		</div>
 
 		<!-- Static mode -->
 		<div v-if="!is_dynamic">
 			<textarea
-				class="form-control static-textarea"
+				class="form-control desc-textarea"
 				:value="store.form.selected_field.description"
 				:disabled="read_only"
 				rows="3"
@@ -230,75 +218,69 @@ function update_default(val) {
 
 			<div v-if="config.source_field" class="conditions-block">
 				<label class="sub-label">{{ __("Conditions") }}</label>
-				<table class="conditions-table">
-					<thead>
-						<tr>
-							<th>{{ __("When value is") }}</th>
-							<th>{{ __("Show description") }}</th>
-							<th v-if="!read_only" class="remove-th"></th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr v-for="(cond, i) in config.conditions" :key="i">
-							<td>
-								<SelectControl
-									v-if="source_is_select"
-									:df="condition_value_df"
-									:modelValue="cond.value"
-									:read_only="read_only"
-									:no_label="true"
-									@update:modelValue="update_condition_value(i, $event)"
-								/>
-								<input
-									v-else
-									type="text"
-									class="form-control cond-input"
-									:value="cond.value"
-									:disabled="read_only"
-									:placeholder="__('Value')"
-									@input="update_condition_value(i, $event.target.value)"
-								/>
-							</td>
-							<td>
-								<input
-									type="text"
-									class="form-control cond-input"
-									:value="cond.description"
-									:disabled="read_only"
-									:placeholder="__('Description text')"
-									@input="update_condition_description(i, $event.target.value)"
-								/>
-							</td>
-							<td v-if="!read_only">
-								<button
-									class="btn btn-xs remove-btn"
-									type="button"
-									:title="__('Remove')"
-									@click="remove_condition(i)"
-								>
-									<svg
-										xmlns="http://www.w3.org/2000/svg"
-										width="10"
-										height="10"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="2.5"
-									>
-										<line x1="18" y1="6" x2="6" y2="18"></line>
-										<line x1="6" y1="6" x2="18" y2="18"></line>
-									</svg>
-								</button>
-							</td>
-						</tr>
-						<tr v-if="!config.conditions.length">
-							<td
-								colspan="3"
-								class="empty-row"
-							>{{ __("No conditions yet. Add one below.") }}</td>
-						</tr>
-					</tbody>
-				</table>
+
+				<div
+					v-for="(cond, i) in config.conditions"
+					:key="i"
+					class="condition-card"
+				>
+					<div class="condition-card-header">
+						<span class="sub-label">{{ __("When value is") }}</span>
+						<button
+							v-if="!read_only"
+							class="btn btn-xs remove-btn"
+							type="button"
+							:title="__('Remove')"
+							@click="remove_condition(i)"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="10"
+								height="10"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2.5"
+							>
+								<line x1="18" y1="6" x2="6" y2="18"></line>
+								<line x1="6" y1="6" x2="18" y2="18"></line>
+							</svg>
+						</button>
+					</div>
+
+					<SelectControl
+						v-if="source_is_select"
+						:df="condition_value_df"
+						:modelValue="cond.value"
+						:read_only="read_only"
+						:no_label="true"
+						@update:modelValue="update_condition_value(i, $event)"
+					/>
+					<input
+						v-else
+						type="text"
+						class="form-control"
+						:value="cond.value"
+						:disabled="read_only"
+						:placeholder="__('Value')"
+						@input="update_condition_value(i, $event.target.value)"
+					/>
+
+					<label class="sub-label desc-label">{{ __("Description") }}</label>
+					<textarea
+						class="form-control desc-textarea"
+						:value="cond.description"
+						:disabled="read_only"
+						rows="2"
+						:placeholder="__('Description text')"
+						@input="update_condition_description(i, $event.target.value)"
+					></textarea>
+				</div>
+
+				<div v-if="!config.conditions.length" class="empty-conditions">
+					{{ __("No conditions yet. Add one below.") }}
+				</div>
+
 				<button
 					v-if="!read_only"
 					class="btn btn-xs btn-default add-btn"
@@ -309,14 +291,14 @@ function update_default(val) {
 
 			<div class="default-row">
 				<label class="sub-label">{{ __("Default") }}</label>
-				<input
-					type="text"
-					class="form-control"
+				<textarea
+					class="form-control desc-textarea"
 					:value="config.default"
 					:disabled="read_only"
+					rows="2"
 					:placeholder="__('Shown when no condition matches')"
 					@input="update_default($event.target.value)"
-				/>
+				></textarea>
 			</div>
 		</div>
 	</div>
@@ -344,10 +326,7 @@ function update_default(val) {
 			border-radius: var(--border-radius);
 			padding: 2px;
 
-			.mode-option {
-				display: flex;
-				align-items: center;
-				gap: 4px;
+			.mode-btn {
 				font-size: var(--text-xs);
 				font-weight: normal;
 				cursor: pointer;
@@ -355,29 +334,33 @@ function update_default(val) {
 				padding: 2px 8px;
 				border-radius: calc(var(--border-radius) - 2px);
 				color: var(--text-muted);
+				background: transparent;
+				border: none;
+				line-height: 1.5;
 				transition: background 0.15s, color 0.15s;
-
-				input[type="radio"] {
-					display: none;
-				}
 
 				&.active {
 					background: var(--primary);
 					color: white;
 				}
 
-				&:not(.active):hover {
+				&:not(.active):not(:disabled):hover {
 					background: var(--hover-bg);
 					color: var(--text-color);
+				}
+
+				&:disabled {
+					cursor: default;
+					opacity: 0.6;
 				}
 			}
 		}
 	}
 
-	.static-textarea {
+	.desc-textarea {
 		font-size: var(--text-sm);
 		resize: vertical;
-		min-height: 60px;
+		min-height: 52px;
 	}
 
 	.dynamic-editor {
@@ -394,75 +377,58 @@ function update_default(val) {
 		}
 
 		.conditions-block {
-			.conditions-table {
-				width: 100%;
-				border-collapse: collapse;
-				font-size: var(--text-xs);
-				margin-bottom: var(--margin-xs);
+			display: flex;
+			flex-direction: column;
+			gap: var(--margin-xs);
 
-				thead tr {
-					background: var(--fg-color);
-				}
+			.condition-card {
+				border: 1px solid var(--border-color);
+				border-radius: var(--border-radius);
+				padding: var(--padding-sm);
 
-				th {
-					padding: 4px 6px;
-					text-align: left;
-					font-weight: 500;
-					color: var(--text-muted);
-					border: 1px solid var(--border-color);
-					white-space: nowrap;
-				}
-
-				.remove-th {
-					width: 24px;
-				}
-
-				td {
-					padding: 3px 4px;
-					border: 1px solid var(--border-color);
-					vertical-align: middle;
-				}
-
-				.empty-row {
-					text-align: center;
-					color: var(--text-muted);
-					font-style: italic;
-					padding: 8px;
-				}
-
-				.cond-input {
-					font-size: var(--text-xs);
-					padding: 2px 6px;
-					height: auto;
-					min-height: 0;
-				}
-
-				.remove-btn {
+				.condition-card-header {
 					display: flex;
 					align-items: center;
-					justify-content: center;
-					width: 20px;
-					height: 20px;
-					padding: 0;
-					color: var(--text-muted);
-					background: transparent;
-					border: none;
+					justify-content: space-between;
+					margin-bottom: 3px;
 
-					&:hover {
-						color: var(--red);
+					.sub-label {
+						margin-bottom: 0;
+					}
+
+					.remove-btn {
+						display: flex;
+						align-items: center;
+						justify-content: center;
+						width: 20px;
+						height: 20px;
+						padding: 0;
+						color: var(--text-muted);
+						background: transparent;
+						border: none;
+
+						&:hover {
+							color: var(--red);
+						}
 					}
 				}
+
+				.desc-label {
+					margin-top: var(--margin-xs);
+				}
+			}
+
+			.empty-conditions {
+				font-size: var(--text-xs);
+				color: var(--text-muted);
+				font-style: italic;
+				text-align: center;
+				padding: var(--padding-sm) 0;
 			}
 
 			.add-btn {
 				width: 100%;
 				font-size: var(--text-xs);
-			}
-		}
-
-		.default-row {
-			input {
-				font-size: var(--text-sm);
 			}
 		}
 	}

--- a/frappe/public/js/form_builder/components/DynamicDescriptionEditor.vue
+++ b/frappe/public/js/form_builder/components/DynamicDescriptionEditor.vue
@@ -37,16 +37,29 @@ const config = computed({
 
 function all_layout_fields() {
 	const no_value = frappe.model.no_value_type || [];
-	const selected = store.form.selected_field?.fieldname;
+	const self_df = store.form.selected_field;
+	const own = self_df?.fieldname;
 	const result = [];
+
+	// Self at the top — read directly from selected_field so unsaved options are visible
+	if (own && self_df && !no_value.includes(self_df.fieldtype)) {
+		result.push({
+			value: own,
+			label: (self_df.label || own) + " — " + __("this field"),
+			is_self: true,
+		});
+	}
+
 	for (const tab of store.form.layout?.tabs || []) {
 		for (const section of tab.sections || []) {
 			for (const column of section.columns || []) {
 				for (const field of column.fields || []) {
 					const df = field.df;
-					if (!no_value.includes(df.fieldtype) && df.fieldname !== selected) {
-						result.push({ value: df.fieldname, label: df.label || df.fieldname });
+					// skip no-value types, blank fieldnames, and self (already added above)
+					if (!df.fieldname || no_value.includes(df.fieldtype) || df.fieldname === own) {
+						continue;
 					}
+					result.push({ value: df.fieldname, label: df.label || df.fieldname });
 				}
 			}
 		}
@@ -69,9 +82,15 @@ function find_df_in_layout(fieldname) {
 
 const value_fields = computed(() => all_layout_fields());
 
+const own_fieldname = computed(() => store.form.selected_field?.fieldname);
+
 const source_df = computed(() => {
 	const sf = config.value?.source_field;
-	return sf ? find_df_in_layout(sf) : null;
+	if (!sf) return null;
+	// When source is self, use selected_field directly so live options on an
+	// unsaved new field are always visible without a layout traversal.
+	if (sf === own_fieldname.value) return store.form.selected_field;
+	return find_df_in_layout(sf);
 });
 
 const source_is_select = computed(() => source_df.value?.fieldtype === "Select");
@@ -82,7 +101,11 @@ const source_options = computed(() => {
 });
 
 function set_source_field(fieldname) {
-	const actual_df = find_df_in_layout(fieldname);
+	// Prefer selected_field directly for self so unsaved options are available
+	const actual_df =
+		fieldname === own_fieldname.value
+			? store.form.selected_field
+			: find_df_in_layout(fieldname);
 	let conditions = [];
 	if (actual_df?.fieldtype === "Select") {
 		conditions = (actual_df.options || "")

--- a/frappe/public/js/form_builder/components/DynamicDescriptionEditor.vue
+++ b/frappe/public/js/form_builder/components/DynamicDescriptionEditor.vue
@@ -1,0 +1,445 @@
+<script setup>
+import { computed } from "vue";
+import { useStore } from "../store";
+
+const props = defineProps({ read_only: Boolean });
+const store = useStore();
+
+const is_dynamic = computed({
+	get: () => !!store.form.selected_field?.dynamic_description,
+	set: (val) => {
+		if (!val) {
+			store.form.selected_field.dynamic_description = "";
+		} else if (!store.form.selected_field.dynamic_description) {
+			store.form.selected_field.dynamic_description = JSON.stringify({
+				source_field: "",
+				conditions: [],
+				default: store.form.selected_field.description || "",
+			});
+			store.form.selected_field.description = "";
+		}
+	},
+});
+
+const config = computed({
+	get: () => {
+		if (!store.form.selected_field?.dynamic_description) return null;
+		try {
+			return JSON.parse(store.form.selected_field.dynamic_description);
+		} catch {
+			return null;
+		}
+	},
+	set: (val) => {
+		store.form.selected_field.dynamic_description = val ? JSON.stringify(val) : "";
+	},
+});
+
+function all_layout_fields() {
+	const no_value = frappe.model.no_value_type || [];
+	const selected = store.form.selected_field?.fieldname;
+	const result = [];
+	for (const tab of store.form.layout?.tabs || []) {
+		for (const section of tab.sections || []) {
+			for (const column of section.columns || []) {
+				for (const field of column.fields || []) {
+					const df = field.df;
+					if (!no_value.includes(df.fieldtype) && df.fieldname !== selected) {
+						result.push({ value: df.fieldname, label: df.label || df.fieldname });
+					}
+				}
+			}
+		}
+	}
+	return result;
+}
+
+function find_df_in_layout(fieldname) {
+	for (const tab of store.form.layout?.tabs || []) {
+		for (const section of tab.sections || []) {
+			for (const column of section.columns || []) {
+				for (const field of column.fields || []) {
+					if (field.df.fieldname === fieldname) return field.df;
+				}
+			}
+		}
+	}
+	return null;
+}
+
+const value_fields = computed(() => all_layout_fields());
+
+const source_df = computed(() => {
+	const sf = config.value?.source_field;
+	return sf ? find_df_in_layout(sf) : null;
+});
+
+const source_is_select = computed(() => source_df.value?.fieldtype === "Select");
+
+const source_options = computed(() => {
+	if (!source_is_select.value) return [];
+	return (source_df.value.options || "").split("\n").filter(Boolean);
+});
+
+function set_source_field(fieldname) {
+	const actual_df = find_df_in_layout(fieldname);
+	let conditions = [];
+	if (actual_df?.fieldtype === "Select") {
+		conditions = (actual_df.options || "")
+			.split("\n")
+			.filter(Boolean)
+			.map((o) => ({ value: o, description: "" }));
+	}
+	config.value = { ...config.value, source_field: fieldname, conditions };
+}
+
+function add_condition() {
+	const c = config.value;
+	config.value = { ...c, conditions: [...(c.conditions || []), { value: "", description: "" }] };
+}
+
+function remove_condition(i) {
+	const c = config.value;
+	config.value = { ...c, conditions: c.conditions.filter((_, idx) => idx !== i) };
+}
+
+function update_condition_value(i, val) {
+	const c = config.value;
+	config.value = {
+		...c,
+		conditions: c.conditions.map((cond, idx) =>
+			idx === i ? { ...cond, value: val } : cond
+		),
+	};
+}
+
+function update_condition_description(i, val) {
+	const c = config.value;
+	config.value = {
+		...c,
+		conditions: c.conditions.map((cond, idx) =>
+			idx === i ? { ...cond, description: val } : cond
+		),
+	};
+}
+
+function update_default(val) {
+	config.value = { ...config.value, default: val };
+}
+</script>
+
+<template>
+	<div class="dynamic-description-editor">
+		<div class="editor-header">
+			<span class="field-label">{{ __("Description") }}</span>
+			<div class="mode-toggle">
+				<label
+					class="mode-option"
+					:class="{ active: !is_dynamic }"
+					:title="__('Fixed description text')"
+				>
+					<input
+						type="radio"
+						name="desc_mode"
+						:checked="!is_dynamic"
+						:disabled="read_only"
+						@change="is_dynamic = false"
+					/>
+					{{ __("Static") }}
+				</label>
+				<label
+					class="mode-option"
+					:class="{ active: is_dynamic }"
+					:title="__('Description changes based on another field value')"
+				>
+					<input
+						type="radio"
+						name="desc_mode"
+						:checked="is_dynamic"
+						:disabled="read_only"
+						@change="is_dynamic = true"
+					/>
+					{{ __("Dynamic") }}
+				</label>
+			</div>
+		</div>
+
+		<!-- Static mode -->
+		<div v-if="!is_dynamic">
+			<textarea
+				class="form-control static-textarea"
+				:value="store.form.selected_field.description"
+				:disabled="read_only"
+				rows="3"
+				:placeholder="__('Enter field description...')"
+				@input="store.form.selected_field.description = $event.target.value"
+			></textarea>
+		</div>
+
+		<!-- Dynamic mode -->
+		<div v-else-if="config" class="dynamic-editor">
+			<div class="source-row">
+				<label class="sub-label">{{ __("Based on field") }}</label>
+				<select
+					class="form-control form-select source-select"
+					:value="config.source_field"
+					:disabled="read_only"
+					@change="set_source_field($event.target.value)"
+				>
+					<option value="">{{ __("— select a field —") }}</option>
+					<option v-for="f in value_fields" :key="f.value" :value="f.value">
+						{{ f.label }} ({{ f.value }})
+					</option>
+				</select>
+			</div>
+
+			<div v-if="config.source_field" class="conditions-block">
+				<label class="sub-label">{{ __("Conditions") }}</label>
+				<table class="conditions-table">
+					<thead>
+						<tr>
+							<th>{{ __("When value is") }}</th>
+							<th>{{ __("Show description") }}</th>
+							<th v-if="!read_only" class="remove-th"></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="(cond, i) in config.conditions" :key="i">
+							<td>
+								<select
+									v-if="source_is_select"
+									class="form-control form-select cond-input"
+									:value="cond.value"
+									:disabled="read_only"
+									@change="update_condition_value(i, $event.target.value)"
+								>
+									<option value="">{{ __("— pick value —") }}</option>
+									<option
+										v-for="opt in source_options"
+										:key="opt"
+										:value="opt"
+									>{{ opt }}</option>
+								</select>
+								<input
+									v-else
+									type="text"
+									class="form-control cond-input"
+									:value="cond.value"
+									:disabled="read_only"
+									:placeholder="__('Value')"
+									@input="update_condition_value(i, $event.target.value)"
+								/>
+							</td>
+							<td>
+								<input
+									type="text"
+									class="form-control cond-input"
+									:value="cond.description"
+									:disabled="read_only"
+									:placeholder="__('Description text')"
+									@input="update_condition_description(i, $event.target.value)"
+								/>
+							</td>
+							<td v-if="!read_only">
+								<button
+									class="btn btn-xs remove-btn"
+									type="button"
+									:title="__('Remove')"
+									@click="remove_condition(i)"
+								>
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										width="10"
+										height="10"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="2.5"
+									>
+										<line x1="18" y1="6" x2="6" y2="18"></line>
+										<line x1="6" y1="6" x2="18" y2="18"></line>
+									</svg>
+								</button>
+							</td>
+						</tr>
+						<tr v-if="!config.conditions.length">
+							<td
+								colspan="3"
+								class="empty-row"
+							>{{ __("No conditions yet. Add one below.") }}</td>
+						</tr>
+					</tbody>
+				</table>
+				<button
+					v-if="!read_only"
+					class="btn btn-xs btn-default add-btn"
+					type="button"
+					@click="add_condition"
+				>+ {{ __("Add Condition") }}</button>
+			</div>
+
+			<div class="default-row">
+				<label class="sub-label">{{ __("Default") }}</label>
+				<input
+					type="text"
+					class="form-control"
+					:value="config.default"
+					:disabled="read_only"
+					:placeholder="__('Shown when no condition matches')"
+					@input="update_default($event.target.value)"
+				/>
+			</div>
+		</div>
+	</div>
+</template>
+
+<style lang="scss" scoped>
+.dynamic-description-editor {
+	.editor-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: var(--margin-xs);
+
+		.field-label {
+			font-size: var(--text-sm);
+			font-weight: 500;
+			color: var(--text-color);
+		}
+
+		.mode-toggle {
+			display: flex;
+			gap: 2px;
+			background: var(--fg-color);
+			border: 1px solid var(--border-color);
+			border-radius: var(--border-radius);
+			padding: 2px;
+
+			.mode-option {
+				display: flex;
+				align-items: center;
+				gap: 4px;
+				font-size: var(--text-xs);
+				font-weight: normal;
+				cursor: pointer;
+				margin: 0;
+				padding: 2px 8px;
+				border-radius: calc(var(--border-radius) - 2px);
+				color: var(--text-muted);
+				transition: background 0.15s, color 0.15s;
+
+				input[type="radio"] {
+					display: none;
+				}
+
+				&.active {
+					background: var(--primary);
+					color: white;
+				}
+
+				&:not(.active):hover {
+					background: var(--hover-bg);
+					color: var(--text-color);
+				}
+			}
+		}
+	}
+
+	.static-textarea {
+		font-size: var(--text-sm);
+		resize: vertical;
+		min-height: 60px;
+	}
+
+	.dynamic-editor {
+		display: flex;
+		flex-direction: column;
+		gap: var(--margin-sm);
+
+		.sub-label {
+			display: block;
+			font-size: var(--text-xs);
+			color: var(--text-muted);
+			margin-bottom: 3px;
+			font-weight: normal;
+		}
+
+		.source-select {
+			font-size: var(--text-sm);
+		}
+
+		.conditions-block {
+			.conditions-table {
+				width: 100%;
+				border-collapse: collapse;
+				font-size: var(--text-xs);
+				margin-bottom: var(--margin-xs);
+
+				thead tr {
+					background: var(--fg-color);
+				}
+
+				th {
+					padding: 4px 6px;
+					text-align: left;
+					font-weight: 500;
+					color: var(--text-muted);
+					border: 1px solid var(--border-color);
+					white-space: nowrap;
+				}
+
+				.remove-th {
+					width: 24px;
+				}
+
+				td {
+					padding: 3px 4px;
+					border: 1px solid var(--border-color);
+					vertical-align: middle;
+				}
+
+				.empty-row {
+					text-align: center;
+					color: var(--text-muted);
+					font-style: italic;
+					padding: 8px;
+				}
+
+				.cond-input {
+					font-size: var(--text-xs);
+					padding: 2px 6px;
+					height: auto;
+					min-height: 0;
+				}
+
+				.remove-btn {
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					width: 20px;
+					height: 20px;
+					padding: 0;
+					color: var(--text-muted);
+					background: transparent;
+					border: none;
+
+					&:hover {
+						color: var(--red);
+					}
+				}
+			}
+
+			.add-btn {
+				width: 100%;
+				font-size: var(--text-xs);
+			}
+		}
+
+		.default-row {
+			input {
+				font-size: var(--text-sm);
+			}
+		}
+	}
+}
+</style>

--- a/frappe/public/js/form_builder/components/FieldProperties.vue
+++ b/frappe/public/js/form_builder/components/FieldProperties.vue
@@ -1,5 +1,6 @@
 <script setup>
 import SearchBox from "./SearchBox.vue";
+import DynamicDescriptionEditor from "./DynamicDescriptionEditor.vue";
 import { evaluate_depends_on_value } from "../utils";
 import { ref, computed } from "vue";
 import { useStore } from "../store";
@@ -16,6 +17,7 @@ const LAYOUT_OVERRIDE_PROPS = new Set([
 	"read_only",
 	"default",
 	"description",
+	"dynamic_description",
 	"depends_on",
 	"mandatory_depends_on",
 	"read_only_depends_on",
@@ -127,7 +129,12 @@ let docfield_df = computed(() => {
 	<div class="control-data">
 		<div v-if="store.form.selected_field">
 			<div class="field" v-for="(df, i) in docfield_df" :key="i">
+				<DynamicDescriptionEditor
+					v-if="df.fieldname === 'description'"
+					:read_only="store.read_only"
+				/>
 				<component
+					v-else
 					:is="df.fieldtype.replaceAll(' ', '') + 'Control'"
 					:args="args"
 					:df="df"

--- a/frappe/public/js/form_builder/store.js
+++ b/frappe/public/js/form_builder/store.js
@@ -37,6 +37,7 @@ export const useStore = defineStore("form-builder-store", () => {
 		"read_only",
 		"default",
 		"description",
+		"dynamic_description",
 		"depends_on",
 		"mandatory_depends_on",
 		"read_only_depends_on",

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -844,13 +844,28 @@ frappe.ui.form.Layout = class Layout {
 			}
 
 			if (!cfg?.source_field) {
-				if (cfg?.default !== undefined) f.set_description(cfg.default || "");
+				if (cfg?.default !== undefined) this._apply_dynamic_description(f, cfg.default || "");
 				continue;
 			}
 
 			const src_val = doc[cfg.source_field];
 			const matched = (cfg.conditions || []).find((c) => c.value === src_val);
-			f.set_description(matched?.description || cfg.default || "");
+			this._apply_dynamic_description(f, matched?.description || cfg.default || "");
+		}
+	}
+
+	_apply_dynamic_description(field, description) {
+		if (field.df.show_description_on_click) {
+			// set_description() returns early when show_description_on_click is true, and
+			// the InfoCard's DOM lives inside label_span rather than on _doc_url_info_card
+			// (because set_doc_url() also returns early, so _doc_url_info_card is never set).
+			// Update df.description for consistency and patch the card DOM directly.
+			field.df.description = description;
+			$(field.label_span)
+				.find(".sidebar-card-description")
+				.html(__(description, null, field.df.parent));
+		} else {
+			field.set_description(description);
 		}
 	}
 

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -819,6 +819,39 @@ frappe.ui.form.Layout = class Layout {
 				}
 			}
 		}
+
+		this.refresh_dynamic_description();
+	}
+
+	refresh_dynamic_description() {
+		let doc = this.doc;
+		if (!doc && this.get_values) {
+			doc = this.get_values(true);
+		}
+		if (!doc && this.frm) {
+			doc = this.frm.doc;
+		}
+		if (!doc) return;
+
+		for (const f of this.fields_list) {
+			if (!f.df?.dynamic_description || !f.set_description) continue;
+
+			let cfg;
+			try {
+				cfg = JSON.parse(f.df.dynamic_description);
+			} catch {
+				continue;
+			}
+
+			if (!cfg?.source_field) {
+				if (cfg?.default !== undefined) f.set_description(cfg.default || "");
+				continue;
+			}
+
+			const src_val = doc[cfg.source_field];
+			const matched = (cfg.conditions || []).find((c) => c.value === src_val);
+			f.set_description(matched?.description || cfg.default || "");
+		}
 	}
 
 	set_dependant_property(condition, fieldname, property) {

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -855,17 +855,25 @@ frappe.ui.form.Layout = class Layout {
 	}
 
 	_apply_dynamic_description(field, description) {
+		// Pre-set df.description before calling set_description() so that subclass
+		// overrides (time.js, datetime.js) that read this.df.description before
+		// calling super.set_description() — and declare no parameter — see the
+		// correct dynamic value and append their extra text (e.g. timezone) to it.
+		field.df.description = description;
+
 		if (field.df.show_description_on_click) {
 			// set_description() returns early when show_description_on_click is true, and
 			// the InfoCard's DOM lives inside label_span rather than on _doc_url_info_card
 			// (because set_doc_url() also returns early, so _doc_url_info_card is never set).
-			// Update df.description for consistency and patch the card DOM directly.
-			field.df.description = description;
+			// Patch the card DOM directly since df.description is already updated above.
 			$(field.label_span)
 				.find(".sidebar-card-description")
 				.html(__(description, null, field.df.parent));
 		} else {
-			field.set_description(description);
+			// Call with no arg — df.description is already set above, and the
+			// _description cache check in base_input.js will still short-circuit
+			// correctly when the description hasn't changed.
+			field.set_description();
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds a **Dynamic** mode to the Description property in the DocType Form Builder. Instead of a single static string, you configure a source field and a map of values → descriptions. The form evaluates this live whenever the source field changes — no client script required.

## Screenshots 

### Standard description - a field having a static description

<img width="2739" height="1088" alt="image" src="https://github.com/user-attachments/assets/5060fdf5-ebe9-41d0-a0d2-cca9dcf01717" />

### Dynamic description - a field having dynamic description based on the value of other fields (or own fields)

<img width="2784" height="1460" alt="image" src="https://github.com/user-attachments/assets/48f996fd-b730-43af-b76e-4634ed115983" />

## How it works

**Form Builder** — the Description property now has a Static / Dynamic toggle. In Dynamic mode:
- Pick a **source field** (any value-type field on the same form, including the field itself)
- For Select fields, conditions are auto-populated from the options list
- Each condition row has a **"When value is"** picker and a free-text description textarea
- A **Default** description is shown when no condition matches

**Storage** — a new hidden `dynamic_description` Small Text column on DocField stores the config as JSON:

```json
{
  "source_field": "gateway_environment",
  "conditions": [
    { "value": "Live",    "description": "⚠️ Live key — transactions will charge real customers" },
    { "value": "Sandbox", "description": "Sandbox key — safe for testing, no real charges" }
  ],
  "default": "Select an environment above to see key instructions"
}
```

**Runtime** — `Layout.refresh_dependency()` calls `refresh_dynamic_description()` on every dependency cycle. It reads the JSON config, matches `doc[source_field]` against conditions, and calls `set_description()` on the field with the matched text.

## Compatibility

- Static `description` is unchanged — existing fields are unaffected
- Works in **Customize Form** and **Layout Mode** (`dynamic_description` is in `LAYOUT_OVERRIDE_PROPS`)
- Works with **`show_description_on_click`** — the popover content updates live
- Works with **Time / Datetime fields** — timezone is appended after the dynamic text
- A field can use **its own value** as the source (self-reference)

## Known limitation

Description strings inside the JSON config are not extracted by the translation scanner — they won't appear in `.po` files automatically.

## Tests

20 server-side tests in `test_docfield.py` covering config parsing, condition matching, default fallback, self-reference, `show_description_on_click` interaction, and edge cases.
