### PR TITLE
fix: cleanup property setters in test_index_and_unique_constraints

### DIFF
--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -4,7 +4,10 @@ from unittest.case import skipIf
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.core.utils import find
-from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+from frappe.custom.doctype.property_setter.property_setter import (
+	delete_property_setter,
+	make_property_setter,
+)
 from frappe.query_builder.utils import db_type_is
 from frappe.tests import IntegrationTestCase
 from frappe.tests.test_query_builder import run_only_if
@@ -45,6 +48,15 @@ class TestDBUpdate(IntegrationTestCase):
 		doctype = "User"
 		frappe.reload_doctype("User", force=True)
 		frappe.model.meta.trim_tables("User")
+
+		def _cleanup():
+			# DDL and inserts in this test auto-commit, so we must explicitly undo.
+			# Leaving middle_name with unique=1 breaks subsequent bench migrate runs.
+			delete_property_setter(doctype, field_name="middle_name")
+			frappe.db.updatedb(doctype)
+			frappe.reload_doctype(doctype, force=True)
+
+		self.addCleanup(_cleanup)
 
 		make_property_setter(doctype, "middle_name", "unique", "1", "Check")
 		frappe.db.updatedb(doctype)


### PR DESCRIPTION
## Problem

`test_index_and_unique_constraints` creates Property Setters for `User.middle_name` (including `unique = 1`) but never cleans them up. Since `make_property_setter` → `insert()` and `frappe.db.updatedb()` (DDL) auto-commit in MariaDB, these changes survive `frappe.db.rollback()` and persist in the database after the test run.

The stale `User-middle_name-unique = 1` property setter causes `bench migrate` to attempt adding a unique constraint on `middle_name` in `tabUser`, which fails with:

```
ValidationError: middle_name field cannot be set as unique in tabUser, as there are non-unique existing values
```

## Fix

Add an `addCleanup` callback that deletes the property setters and resets the DB column state after each test run.