### PR TITLE
fix: print format builder UI and print preview fixes

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -129,10 +129,12 @@ let page_number_style = computed(() => {
 	let style = {
 		position: "absolute",
 		background: "var(--fg-color)",
-		padding: "4px",
+		padding: "3px 8px",
 		borderRadius: "var(--border-radius)",
 		border: "1px solid var(--border-color)",
 		fontSize: "11px",
+		color: "var(--text-muted)",
+		lineHeight: "1.4",
 	};
 	if (print_format.value.page_number.includes("Top")) {
 		style.top = print_format.value.margin_top / 2 + "mm";

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -1,53 +1,56 @@
 <template>
-	<div
-		class="print-format-main"
-		:style="rootStyles"
-		:class="{
-			'pfb-clean-preview': !!store.preview_doc.value,
-		}"
-	>
-		<div :style="page_number_style">{{ __("1 of 2") }}</div>
-
-		<LetterHeadZoneEditor zone="header" />
-
-		<!-- Body wrapper: font size/family applied here so letterhead zones are unaffected -->
-		<div class="pfb-body" :style="bodyStyles">
-			<div class="zone-divider zone-divider--header">
-				<span class="zone-divider-label">{{ __("Header") }}</span>
-			</div>
-			<PrintFormatSection :section="layout.header" :is_header="true" zone="header" />
-			<div class="zone-divider zone-divider--body">
-				<span class="zone-divider-label">{{ __("Body") }}</span>
-			</div>
-
-			<draggable
-				class="sections-container"
-				v-model="layout.sections"
-				group="sections"
-				:animation="200"
-				item-key="id"
-				handle=".section-drag-handle"
-				filter=".section-columns, .column, .field"
-				@add="on_section_add"
-			>
-				<template #item="{ element, index }">
-					<div class="section-with-insert">
-						<SectionInsert @insert="add_section_at(index)" />
-						<PrintFormatSection :section="element" />
-					</div>
-				</template>
-				<template #footer>
-					<SectionInsert @insert="add_section_at(layout.sections.length)" />
-				</template>
-			</draggable>
-
-			<div class="zone-divider zone-divider--footer">
-				<span class="zone-divider-label">{{ __("Footer") }}</span>
-			</div>
-			<PrintFormatSection :section="layout.footer" :is_header="true" zone="footer" />
+	<div class="pfb-page-wrapper">
+		<div v-if="!page_number_hidden" class="pfb-page-num" :style="page_number_style">
+			{{ __("1 of 2") }}
 		</div>
+		<div
+			class="print-format-main"
+			:style="rootStyles"
+			:class="{
+				'pfb-clean-preview': !!store.preview_doc.value,
+			}"
+		>
+			<LetterHeadZoneEditor zone="header" />
 
-		<LetterHeadZoneEditor v-if="letterhead" zone="footer" />
+			<!-- Body wrapper: font size/family applied here so letterhead zones are unaffected -->
+			<div class="pfb-body" :style="bodyStyles">
+				<div class="zone-divider zone-divider--header">
+					<span class="zone-divider-label">{{ __("Header") }}</span>
+				</div>
+				<PrintFormatSection :section="layout.header" :is_header="true" zone="header" />
+				<div class="zone-divider zone-divider--body">
+					<span class="zone-divider-label">{{ __("Body") }}</span>
+				</div>
+
+				<draggable
+					class="sections-container"
+					v-model="layout.sections"
+					group="sections"
+					:animation="200"
+					item-key="id"
+					handle=".section-drag-handle"
+					filter=".section-columns, .column, .field"
+					@add="on_section_add"
+				>
+					<template #item="{ element, index }">
+						<div class="section-with-insert">
+							<SectionInsert @insert="add_section_at(index)" />
+							<PrintFormatSection :section="element" />
+						</div>
+					</template>
+					<template #footer>
+						<SectionInsert @insert="add_section_at(layout.sections.length)" />
+					</template>
+				</draggable>
+
+				<div class="zone-divider zone-divider--footer">
+					<span class="zone-divider-label">{{ __("Footer") }}</span>
+				</div>
+				<PrintFormatSection :section="layout.footer" :is_header="true" zone="footer" />
+			</div>
+
+			<LetterHeadZoneEditor v-if="letterhead" zone="footer" />
+		</div>
 	</div>
 </template>
 
@@ -125,37 +128,29 @@ let bodyStyles = computed(() => {
 	return styles;
 });
 
+let page_number_hidden = computed(() => print_format.value.page_number.includes("Hide"));
+
 let page_number_style = computed(() => {
-	let style = {
-		position: "absolute",
-		background: "var(--fg-color)",
-		padding: "3px 8px",
-		borderRadius: "var(--border-radius)",
-		border: "1px solid var(--border-color)",
-		fontSize: "11px",
-		color: "var(--text-muted)",
-		lineHeight: "1.4",
-	};
-	if (print_format.value.page_number.includes("Top")) {
-		style.top = print_format.value.margin_top / 2 + "mm";
-		style.transform = "translateY(-50%)";
+	const pn = print_format.value.page_number;
+	// Position the badge outside the document in the canvas gutter
+	const style = {};
+	if (pn.includes("Top")) {
+		style.bottom = "100%";
+		style.marginBottom = "var(--margin-xs)";
 	}
-	if (print_format.value.page_number.includes("Left")) {
-		style.left = print_format.value.margin_left + "mm";
+	if (pn.includes("Bottom")) {
+		style.top = "100%";
+		style.marginTop = "var(--margin-xs)";
 	}
-	if (print_format.value.page_number.includes("Right")) {
-		style.right = print_format.value.margin_right + "mm";
+	if (pn.includes("Left")) {
+		style.left = "0";
 	}
-	if (print_format.value.page_number.includes("Bottom")) {
-		style.bottom = print_format.value.margin_bottom / 2 + "mm";
-		style.transform = "translateY(50%)";
+	if (pn.includes("Right")) {
+		style.right = "0";
 	}
-	if (print_format.value.page_number.includes("Center")) {
+	if (pn.includes("Center")) {
 		style.left = "50%";
-		style.transform += " translateX(-50%)";
-	}
-	if (print_format.value.page_number.includes("Hide")) {
-		style.display = "none";
+		style.transform = "translateX(-50%)";
 	}
 	return style;
 });
@@ -165,6 +160,25 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 </script>
 
 <style scoped>
+.pfb-page-wrapper {
+	position: relative;
+	display: inline-block;
+	/* top padding gives space for the page-number badge above the document */
+	padding-top: var(--padding-lg);
+}
+
+.pfb-page-num {
+	position: absolute;
+	font-size: var(--text-xs);
+	color: var(--text-muted);
+	background: var(--fg-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	padding: var(--padding-xs) var(--padding-sm);
+	line-height: 1.4;
+	white-space: nowrap;
+}
+
 .print-format-main {
 	position: relative;
 	margin-right: auto;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -1,56 +1,55 @@
 <template>
-	<div class="pfb-page-wrapper">
+	<div
+		class="print-format-main"
+		:style="rootStyles"
+		:class="{
+			'pfb-clean-preview': !!store.preview_doc.value,
+		}"
+	>
 		<div v-if="!page_number_hidden" class="pfb-page-num" :style="page_number_style">
 			{{ __("1 of 2") }}
 		</div>
-		<div
-			class="print-format-main"
-			:style="rootStyles"
-			:class="{
-				'pfb-clean-preview': !!store.preview_doc.value,
-			}"
-		>
-			<LetterHeadZoneEditor zone="header" />
 
-			<!-- Body wrapper: font size/family applied here so letterhead zones are unaffected -->
-			<div class="pfb-body" :style="bodyStyles">
-				<div class="zone-divider zone-divider--header">
-					<span class="zone-divider-label">{{ __("Header") }}</span>
-				</div>
-				<PrintFormatSection :section="layout.header" :is_header="true" zone="header" />
-				<div class="zone-divider zone-divider--body">
-					<span class="zone-divider-label">{{ __("Body") }}</span>
-				</div>
+		<LetterHeadZoneEditor zone="header" />
 
-				<draggable
-					class="sections-container"
-					v-model="layout.sections"
-					group="sections"
-					:animation="200"
-					item-key="id"
-					handle=".section-drag-handle"
-					filter=".section-columns, .column, .field"
-					@add="on_section_add"
-				>
-					<template #item="{ element, index }">
-						<div class="section-with-insert">
-							<SectionInsert @insert="add_section_at(index)" />
-							<PrintFormatSection :section="element" />
-						</div>
-					</template>
-					<template #footer>
-						<SectionInsert @insert="add_section_at(layout.sections.length)" />
-					</template>
-				</draggable>
-
-				<div class="zone-divider zone-divider--footer">
-					<span class="zone-divider-label">{{ __("Footer") }}</span>
-				</div>
-				<PrintFormatSection :section="layout.footer" :is_header="true" zone="footer" />
+		<!-- Body wrapper: font size/family applied here so letterhead zones are unaffected -->
+		<div class="pfb-body" :style="bodyStyles">
+			<div class="zone-divider zone-divider--header">
+				<span class="zone-divider-label">{{ __("Header") }}</span>
+			</div>
+			<PrintFormatSection :section="layout.header" :is_header="true" zone="header" />
+			<div class="zone-divider zone-divider--body">
+				<span class="zone-divider-label">{{ __("Body") }}</span>
 			</div>
 
-			<LetterHeadZoneEditor v-if="letterhead" zone="footer" />
+			<draggable
+				class="sections-container"
+				v-model="layout.sections"
+				group="sections"
+				:animation="200"
+				item-key="id"
+				handle=".section-drag-handle"
+				filter=".section-columns, .column, .field"
+				@add="on_section_add"
+			>
+				<template #item="{ element, index }">
+					<div class="section-with-insert">
+						<SectionInsert @insert="add_section_at(index)" />
+						<PrintFormatSection :section="element" />
+					</div>
+				</template>
+				<template #footer>
+					<SectionInsert @insert="add_section_at(layout.sections.length)" />
+				</template>
+			</draggable>
+
+			<div class="zone-divider zone-divider--footer">
+				<span class="zone-divider-label">{{ __("Footer") }}</span>
+			</div>
+			<PrintFormatSection :section="layout.footer" :is_header="true" zone="footer" />
 		</div>
+
+		<LetterHeadZoneEditor v-if="letterhead" zone="footer" />
 	</div>
 </template>
 
@@ -132,25 +131,21 @@ let page_number_hidden = computed(() => print_format.value.page_number.includes(
 
 let page_number_style = computed(() => {
 	const pn = print_format.value.page_number;
-	// Position the badge outside the document in the canvas gutter
-	const style = {};
+	const { margin_top, margin_bottom, margin_left, margin_right } = print_format.value;
+	const style = { position: "absolute" };
 	if (pn.includes("Top")) {
-		style.bottom = "100%";
-		style.marginBottom = "var(--margin-xs)";
+		style.top = margin_top / 2 + "mm";
+		style.transform = "translateY(-50%)";
 	}
 	if (pn.includes("Bottom")) {
-		style.top = "100%";
-		style.marginTop = "var(--margin-xs)";
+		style.bottom = margin_bottom / 2 + "mm";
+		style.transform = "translateY(50%)";
 	}
-	if (pn.includes("Left")) {
-		style.left = "0";
-	}
-	if (pn.includes("Right")) {
-		style.right = "0";
-	}
+	if (pn.includes("Left")) style.left = margin_left + "mm";
+	if (pn.includes("Right")) style.right = margin_right + "mm";
 	if (pn.includes("Center")) {
 		style.left = "50%";
-		style.transform = "translateX(-50%)";
+		style.transform = (style.transform || "") + " translateX(-50%)";
 	}
 	return style;
 });
@@ -160,15 +155,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 </script>
 
 <style scoped>
-.pfb-page-wrapper {
-	position: relative;
-	display: inline-block;
-	/* top padding gives space for the page-number badge above the document */
-	padding-top: var(--padding-lg);
-}
-
 .pfb-page-num {
-	position: absolute;
 	font-size: var(--text-xs);
 	color: var(--text-muted);
 	background: var(--fg-color);

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -97,10 +97,6 @@
 										v-html="frappe.utils.icon('x', 'xs')"
 									></button>
 									<div class="empty-drop-zone-hint">
-										<span
-											class="text-muted"
-											v-html="frappe.utils.icon('plus', 'sm')"
-										></span>
 										<span class="text-muted">{{
 											__("Drop fields here")
 										}}</span>

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -952,7 +952,6 @@ function set_padding(side, value) {
 
 .pfb-breadcrumb-btn:hover {
 	background: var(--gray-100);
-	color: var(--blue-500);
 }
 
 .pfb-breadcrumb-label {

--- a/frappe/public/js/print_format_builder/components/letterhead/LetterHeadEditor.vue
+++ b/frappe/public/js/print_format_builder/components/letterhead/LetterHeadEditor.vue
@@ -173,11 +173,4 @@ defineExpose({ aspect_ratio, range_input_field });
 	font-size: var(--text-sm);
 	padding: 0.5rem 0;
 }
-
-.letterhead :deep(img) {
-	max-width: 100%;
-	max-height: 80px;
-	width: auto;
-	height: auto;
-}
 </style>

--- a/frappe/public/js/print_format_builder/components/letterhead/LetterHeadEditor.vue
+++ b/frappe/public/js/print_format_builder/components/letterhead/LetterHeadEditor.vue
@@ -173,4 +173,11 @@ defineExpose({ aspect_ratio, range_input_field });
 	font-size: var(--text-sm);
 	padding: 0.5rem 0;
 }
+
+.letterhead :deep(img) {
+	max-width: 100%;
+	max-height: 80px;
+	width: auto;
+	height: auto;
+}
 </style>

--- a/frappe/public/js/print_format_builder/components/letterhead/LetterHeadZoneEditor.vue
+++ b/frappe/public/js/print_format_builder/components/letterhead/LetterHeadZoneEditor.vue
@@ -86,7 +86,7 @@ async function refresh_rendered_content() {
 		return;
 	}
 	if (!needs_server_render(content)) {
-		rendered_content.value = content;
+		rendered_content.value = constrain_images(content);
 		return;
 	}
 	if (render_pending.value) return;
@@ -97,12 +97,20 @@ async function refresh_rendered_content() {
 			doctype: raw_store.meta.value.name,
 			docname: raw_store.preview_doc_name.value,
 		});
-		rendered_content.value = r.message ?? content;
+		rendered_content.value = constrain_images(r.message ?? content);
 	} catch {
-		rendered_content.value = content;
+		rendered_content.value = constrain_images(content);
 	} finally {
 		render_pending.value = false;
 	}
+}
+
+function constrain_images(html) {
+	if (!html) return html;
+	return html.replace(
+		/<img(\s)/gi,
+		'<img style="max-width:100%;max-height:80px;width:auto;height:auto;"$1'
+	);
 }
 
 watch([preview_doc, zone_content], refresh_rendered_content, { immediate: true });

--- a/frappe/public/js/print_format_builder/components/letterhead/LetterHeadZoneEditor.vue
+++ b/frappe/public/js/print_format_builder/components/letterhead/LetterHeadZoneEditor.vue
@@ -86,7 +86,7 @@ async function refresh_rendered_content() {
 		return;
 	}
 	if (!needs_server_render(content)) {
-		rendered_content.value = constrain_images(content);
+		rendered_content.value = content;
 		return;
 	}
 	if (render_pending.value) return;
@@ -97,20 +97,12 @@ async function refresh_rendered_content() {
 			doctype: raw_store.meta.value.name,
 			docname: raw_store.preview_doc_name.value,
 		});
-		rendered_content.value = constrain_images(r.message ?? content);
+		rendered_content.value = r.message ?? content;
 	} catch {
-		rendered_content.value = constrain_images(content);
+		rendered_content.value = content;
 	} finally {
 		render_pending.value = false;
 	}
-}
-
-function constrain_images(html) {
-	if (!html) return html;
-	return html.replace(
-		/<img(\s)/gi,
-		'<img style="max-width:100%;max-height:80px;width:auto;height:auto;"$1'
-	);
 }
 
 watch([preview_doc, zone_content], refresh_rendered_content, { immediate: true });
@@ -197,5 +189,10 @@ defineExpose({ aspect_ratio, range_input_field, F });
 	color: var(--text-muted);
 	font-size: var(--text-sm);
 	padding: 0.5rem 0;
+}
+
+.lh-zone :deep(img) {
+	max-width: 100%;
+	height: auto;
 }
 </style>

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -296,6 +296,14 @@ body {
 	max-width: 50% !important;
 }
 
+/* Keep letterhead images from overflowing the page when no explicit width is set */
+header img {
+	max-width: 100%;
+	max-height: 80px;
+	width: auto;
+	height: auto;
+}
+
 .document-header {
 	border-bottom-width: 1px;
 	border-bottom-style: solid;

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -299,8 +299,6 @@ body {
 /* Keep letterhead images from overflowing the page when no explicit width is set */
 header img {
 	max-width: 100%;
-	max-height: 80px;
-	width: auto;
 	height: auto;
 }
 

--- a/frappe/www/printpreview.html
+++ b/frappe/www/printpreview.html
@@ -3,8 +3,4 @@ no_cache: 1
 ---
 
 <!-- </body> -->
-{{
-    frappe
-        .get_doc('Print Format', frappe.form_dict.print_format)
-        .get_html(frappe.form_dict.name, frappe.form_dict.letterhead)
-}}
+{{ body }}

--- a/frappe/www/printpreview.py
+++ b/frappe/www/printpreview.py
@@ -3,11 +3,16 @@ no_cache = 1
 
 def get_context(context):
 	import frappe
-	from frappe.utils.print_format_generator import get_html
 
 	print_format = frappe.form_dict.print_format
 	docname = frappe.form_dict.name
 	letterhead = frappe.form_dict.get("letterhead")
 
 	pf = frappe.get_doc("Print Format", print_format)
-	context.body = get_html(pf.doc_type, docname, print_format, letterhead)
+
+	if pf.get("print_format_builder_beta"):
+		from frappe.utils.print_format_generator import get_html
+
+		context.body = get_html(pf.doc_type, docname, print_format, letterhead)
+	else:
+		context.body = pf.get_html(docname, letterhead)

--- a/frappe/www/printpreview.py
+++ b/frappe/www/printpreview.py
@@ -1,0 +1,13 @@
+no_cache = 1
+
+
+def get_context(context):
+	import frappe
+	from frappe.utils.print_format_generator import get_html
+
+	print_format = frappe.form_dict.print_format
+	docname = frappe.form_dict.name
+	letterhead = frappe.form_dict.get("letterhead")
+
+	pf = frappe.get_doc("Print Format", print_format)
+	context.body = get_html(pf.doc_type, docname, print_format, letterhead)

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -357,19 +357,25 @@ def get_html_and_style(
 	print_format = get_print_format_doc(print_format, meta=document.meta)
 	set_link_titles(document)
 
-	try:
-		html = get_rendered_template(
-			doc=document,
-			print_format=print_format,
-			meta=document.meta,
-			no_letterhead=no_letterhead,
-			letterhead=letterhead,
-			trigger_print=trigger_print,
-			settings=frappe.parse_json(settings),
-		)
-	except frappe.TemplateNotFoundError:
-		frappe.clear_last_message()
-		html = None
+	if print_format and print_format.get("print_format_builder_beta"):
+		from frappe.utils.print_format_generator import PrintFormatGenerator
+
+		generator = PrintFormatGenerator(print_format.name, document, letterhead)
+		html = generator.get_html_preview()
+	else:
+		try:
+			html = get_rendered_template(
+				doc=document,
+				print_format=print_format,
+				meta=document.meta,
+				no_letterhead=no_letterhead,
+				letterhead=letterhead,
+				trigger_print=trigger_print,
+				settings=frappe.parse_json(settings),
+			)
+		except frappe.TemplateNotFoundError:
+			frappe.clear_last_message()
+			html = None
 
 	return {"html": html, "style": get_print_style(style=style, print_format=print_format)}
 

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -360,7 +360,7 @@ def get_html_and_style(
 	if print_format and print_format.get("print_format_builder_beta"):
 		from frappe.utils.print_format_generator import PrintFormatGenerator
 
-		generator = PrintFormatGenerator(print_format.name, document, letterhead)
+		generator = PrintFormatGenerator(print_format.name, document, None if no_letterhead else letterhead)
 		html = generator.get_html_preview()
 	else:
 		try:


### PR DESCRIPTION
- Remove misleading `+` icon from empty drop zone (zone is drag-only, not clickable)
- Fix print preview crash when using a print_format_builder_beta format in the print dialog — `get_html_and_style` was routing all formats through `get_rendered_template`, which expects `format_data` to be a list but the new builder stores it as a JSON object