### PR TITLE
fix: don't delete recent FIFOs in backup dir based on file type

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -663,8 +663,10 @@ def delete_temp_backups(older_than=23):
 
 
 def is_file_old(file_path, older_than=24) -> bool:
-	"""Return True if file exists and is older than specified hours."""
-	if os.path.isfile(file_path):
+	"""
+	Return True if the path is older than specified hours. Also treat non-existent paths as "old".
+	"""
+	if os.path.exists(file_path):
 		from datetime import timedelta
 
 		# Get timestamp of the file


### PR DESCRIPTION
is_file_old() used os.path.isfile(), which is False for FIFOs (and other non-regular files). Those fell into the else branch and were always reported as old, so delete_temp_backups() would remove them regardless of when they were created.

FIFOs are genuinely useful in the backup dir as rclone input for streaming backups directly to S3-compatible object storages. This line was preventing that. Switch to os.path.exists() so the age check applies to any existing path and only truly missing paths are treated as old.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
