### PR TITLE
fix: restrict print preview format/letterhead pickers to document-type records

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -114,7 +114,12 @@ frappe.ui.form.PrintView = class {
 			options: "Print Format",
 			label: __("Print Format"),
 			get_query: () => {
-				return { filters: { doc_type: this.frm.doctype } };
+				return {
+					filters: {
+						doc_type: this.frm.doctype,
+						print_format_for: "DocType",
+					},
+				};
 			},
 			change: () => this.refresh_print_format(),
 		}).$input;
@@ -147,6 +152,9 @@ frappe.ui.form.PrintView = class {
 			options: "Letter Head",
 			label: __("Letter Head"),
 			description: description,
+			get_query: () => {
+				return { filters: { letter_head_for: "DocType" } };
+			},
 			change: function () {
 				this.set_description(this.get_value() ? description : "");
 				print_view.preview();
@@ -415,7 +423,11 @@ frappe.ui.form.PrintView = class {
 		}
 
 		return frappe.db
-			.get_value("Letter Head", { disabled: 0, is_default: 1 }, "name")
+			.get_value(
+				"Letter Head",
+				{ disabled: 0, is_default: 1, letter_head_for: "DocType" },
+				"name"
+			)
 			.then(({ message }) => this.letterhead_selector.val(message.name));
 	}
 

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -428,7 +428,9 @@ frappe.ui.form.PrintView = class {
 				{ disabled: 0, is_default: 1, letter_head_for: "DocType" },
 				"name"
 			)
-			.then(({ message }) => this.letterhead_selector.val(message.name));
+			.then(({ message }) => {
+				if (message?.name) this.letterhead_selector.val(message.name);
+			});
 	}
 
 	set_user_lang() {

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -277,6 +277,7 @@ $.extend(frappe.meta, {
 			if (
 				!print_format_list.includes(d.name) &&
 				d.print_format_type !== "JS" &&
+				d.print_format_for === "DocType" &&
 				(cint(enable_raw_printing) || !d.raw_printing)
 			) {
 				print_format_list.push(d.name);


### PR DESCRIPTION
Closes #40046 

The Print Format and Letter Head selectors on the document print preview page listed every record matching the doctype filter, including ones explicitly created for Report printing (print_format_for/letter_head_for == "Report"). These should never be selectable when printing a regular document. Filter both pickers, the bulk-print/email format list, and the default-letterhead lookup to only consider DocType-scoped records.


Before : 
<img width="796" height="1132" alt="image" src="https://github.com/user-attachments/assets/719c743b-2f70-4be4-9c2d-877bf9501177" />

<img width="1626" height="786" alt="image" src="https://github.com/user-attachments/assets/8fd9ddc9-47bf-42bb-8198-9371728f1a9d" />


After : 
<img width="287" height="377" alt="image" src="https://github.com/user-attachments/assets/622d678e-f4ef-4002-a7b4-bd967126ea14" />

<img width="424" height="423" alt="image" src="https://github.com/user-attachments/assets/3e62f67e-bec1-4f65-a603-f7470c2112ba" />


