### PR TITLE
feat: redesign role form with embedded list based access management

### DIFF
--- a/frappe/core/doctype/role/role.js
+++ b/frappe/core/doctype/role/role.js
@@ -52,10 +52,12 @@ frappe.ui.form.on("Role", {
 	refresh(frm) {
 		frm.role_form = new RoleForm(frm);
 		frm.role_form.render();
+		frm.page.wrapper.off("show.role_tabs").on("show.role_tabs", () => {
+			frm.role_form && frm.role_form.load_active_tab();
+		});
 	},
 
 	on_tab_change(frm) {
-		// Lazy-load the active tab's data the first time it is opened.
 		frm.role_form && frm.role_form.load_active_tab();
 	},
 });
@@ -91,6 +93,7 @@ class RoleForm {
 			document_tab: new DocumentsTab(this.frm),
 			report_tab: new ReportsTab(this.frm),
 			pages_tab: new PagesTab(this.frm),
+			workspace_tab: new WorkspacesTab(this.frm),
 		};
 		Object.values(this.tabs).forEach((tab) => tab.build());
 
@@ -103,10 +106,12 @@ class RoleForm {
 	}
 
 	load_active_tab() {
+		// Refresh on every activation so externally-made changes show up without a
+		// full form reload (the first activation is also when the tab lazy-loads).
 		const active = this.frm.get_active_tab && this.frm.get_active_tab();
 		const fieldname = active && active.df && active.df.fieldname;
 		const tab = fieldname && this.tabs && this.tabs[fieldname];
-		if (tab) tab.load_once();
+		if (tab) tab.refresh();
 	}
 
 	show_banner() {
@@ -144,7 +149,6 @@ class RoleTab {
 	constructor(frm, html_fieldname) {
 		this.frm = frm;
 		this.html_fieldname = html_fieldname;
-		this.loaded = false;
 	}
 
 	get role() {
@@ -173,12 +177,6 @@ class RoleTab {
 		this.list && this.list.refresh();
 	}
 
-	load_once() {
-		if (this.loaded || !this.list) return;
-		this.loaded = true;
-		this.refresh();
-	}
-
 	// Subclasses return the EmbeddedList options (minus wrapper/show_index).
 	list_config() {
 		return {};
@@ -196,7 +194,6 @@ class RoleProfilesTab extends RoleTab {
 
 	list_config() {
 		return {
-			title: __("Role Profiles"),
 			description: __("Role Profiles that include this role."),
 			empty_message: __("No Role Profiles include this role."),
 			columns: [
@@ -248,7 +245,7 @@ class UsersTab extends RoleTab {
 							label: __("Remove"),
 							icon: "x",
 							danger: true,
-							confirm: __("Remove '{0}' from this role?"),
+							confirm: __("Remove {0} from this role?"),
 							confirm_field: "full_name",
 							action: (row, refresh) => this.remove(row.name).then(refresh),
 						},
@@ -297,30 +294,37 @@ class UsersTab extends RoleTab {
 			],
 			primary_action_label: __("Add"),
 			primary_action: (values) => {
-				this.add_role(values.user).then(() => {
-					dialog.hide();
-					frappe.show_alert({ message: __("User added."), indicator: "green" });
-					this.refresh();
-				});
+				return this.add_role(values.user)
+					.then(() => {
+						dialog.hide();
+						frappe.show_alert({ message: __("User added."), indicator: "green" });
+						this.refresh();
+					})
+					.catch((e) => {
+						frappe.show_alert({
+							message: e.message || __("Failed to add user."),
+							indicator: "red",
+						});
+					});
 			},
 		});
 		dialog.show();
 	}
 
 	add_role(user_name) {
-		return frappe.db.get_doc("User", user_name).then((user) => {
-			user.roles = user.roles || [];
-			if (!user.roles.find((r) => r.role === this.role)) {
-				user.roles.push({ role: this.role });
+		return frappe.db.get_doc("User", user_name).then((doc) => {
+			doc.roles = doc.roles || [];
+			if (!doc.roles.find((r) => r.role === this.role)) {
+				doc.roles.push({ role: this.role });
 			}
-			return client_save(user);
+			return frappe.call({ method: "frappe.client.save", args: { doc } });
 		});
 	}
 
 	remove(user_name) {
-		return frappe.db.get_doc("User", user_name).then((user) => {
-			user.roles = (user.roles || []).filter((r) => r.role !== this.role);
-			return client_save(user);
+		return frappe.db.get_doc("User", user_name).then((doc) => {
+			doc.roles = (doc.roles || []).filter((r) => r.role !== this.role);
+			return frappe.call({ method: "frappe.client.save", args: { doc } });
 		});
 	}
 }
@@ -480,7 +484,7 @@ class PermissionDialog {
 
 	title() {
 		return this.is_edit
-			? __("{0} Permission — {1}", [__(this.row.source), this.row.parent])
+			? __("{0} Permission for {1}", [__(this.row.source), this.row.parent])
 			: __("Add Permission for {0}", [this.role]);
 	}
 
@@ -495,7 +499,7 @@ class PermissionDialog {
 			{
 				fieldtype: "Section Break",
 				fieldname: "sb_only_if_creator",
-				label: __("Creator Access"),
+				label: __("Creator's Access"),
 			},
 
 			this.if_owner_field(seed),
@@ -624,11 +628,6 @@ class PermissionDialog {
 	}
 
 	add_row_actions() {
-		if (this.row.permlevel > 0) {
-			this.dialog.add_custom_action(__("View Fields"), () =>
-				new FieldsDialog(this.row).show()
-			);
-		}
 		this.dialog.add_custom_action(__("Remove Permission"), () => this.confirm_remove());
 	}
 
@@ -645,7 +644,7 @@ class PermissionDialog {
 	}
 
 	confirm_remove() {
-		frappe.confirm(__("Remove this role's permission on '{0}'?", [this.row.parent]), () => {
+		frappe.confirm(__("Remove this role's permission on {0}?", [this.row.parent]), () => {
 			this.tab.remove(this.row).then(() => {
 				this.dialog.hide();
 				frappe.show_alert({ message: __("Permission removed."), indicator: "green" });
@@ -656,72 +655,11 @@ class PermissionDialog {
 }
 
 // ============================================================
-// FieldsDialog — fields sitting at a given permlevel for a doctype.
 // ============================================================
-
-class FieldsDialog {
-	constructor(row) {
-		this.row = row;
-	}
-
-	show() {
-		this.dialog = new frappe.ui.Dialog({
-			title: __("Fields at Level {0} — {1}", [this.row.permlevel, this.row.parent]),
-			size: "large",
-		});
-		this.dialog.show();
-		this.dialog.$body.html(placeholder_html(__("Loading...")));
-		this.load();
-	}
-
-	load() {
-		Promise.all([
-			frappe.db.get_list("DocField", {
-				filters: { parent: this.row.parent, permlevel: this.row.permlevel },
-				fields: ["fieldname", "label", "fieldtype"],
-				limit: 0,
-			}),
-			frappe.db.get_list("Custom Field", {
-				filters: { dt: this.row.parent, permlevel: this.row.permlevel },
-				fields: ["fieldname", "label", "fieldtype"],
-				limit: 0,
-			}),
-		]).then(([std, custom]) => this.render([...std, ...custom]));
-	}
-
-	render(fields) {
-		if (!fields.length) {
-			this.dialog.$body.html(
-				placeholder_html(__("No fields are set to this permission level."))
-			);
-			return;
-		}
-		this.dialog.$body.html(this.table_html(fields));
-	}
-
-	table_html(fields) {
-		const body = fields.map((field) => this.row_html(field)).join("");
-		return `<table class="table table-bordered">
-				<thead><tr><th>${__("Label")}</th><th>${__("Fieldname")}</th><th>${__("Type")}</th></tr></thead>
-				<tbody>${body}</tbody>
-			</table>`;
-	}
-
-	row_html(field) {
-		return `<tr>
-				<td>${frappe.utils.escape_html(__(field.label) || field.fieldname)}</td>
-				<td class="text-muted">${frappe.utils.escape_html(field.fieldname)}</td>
-				<td class="text-muted">${frappe.utils.escape_html(field.fieldtype)}</td>
-			</tr>`;
-	}
-}
-
-// ============================================================
-// ReportsTab & PagesTab — reverse lookup on a `roles` child table.
+// ReportsTab & PagesTab — direct lookup on the `roles` child table.
 // ============================================================
 
 class RoleAccessTab extends RoleTab {
-	// Subclasses set access_doctype / label / meta_fields and provide list_config().
 	get_data() {
 		return frappe.db
 			.get_list("Has Role", {
@@ -729,7 +667,10 @@ class RoleAccessTab extends RoleTab {
 				fields: ["parent"],
 				limit: 0,
 			})
-			.then((rows) => this.fetch_records(unique_parents(rows)));
+			.then((rows) => {
+				const names = unique_parents(rows);
+				return this.fetch_records(names);
+			});
 	}
 
 	fetch_records(names) {
@@ -742,7 +683,6 @@ class RoleAccessTab extends RoleTab {
 		});
 	}
 
-	// A clickable name column that opens the underlying record.
 	name_link_column() {
 		return {
 			label: __(this.label),
@@ -752,7 +692,6 @@ class RoleAccessTab extends RoleTab {
 		};
 	}
 
-	// An inline Remove action (no dialog — there is nothing to edit here).
 	remove_action_column() {
 		return {
 			type: "actions",
@@ -761,7 +700,7 @@ class RoleAccessTab extends RoleTab {
 					label: __("Remove"),
 					icon: "x",
 					danger: true,
-					confirm: __("Remove this role's access to '{0}'?"),
+					confirm: __("Remove this role's access to {0}?"),
 					confirm_field: "name",
 					action: (row, refresh) => this.remove(row.name).then(refresh),
 				},
@@ -785,30 +724,37 @@ class RoleAccessTab extends RoleTab {
 			],
 			primary_action_label: __("Add"),
 			primary_action: (values) => {
-				this.add_role(values.doc).then(() => {
-					dialog.hide();
-					frappe.show_alert({ message: __("Access added."), indicator: "green" });
-					this.refresh();
-				});
+				return this.add_role(values.doc)
+					.then(() => {
+						dialog.hide();
+						frappe.show_alert({ message: __("Access added."), indicator: "green" });
+						this.refresh();
+					})
+					.catch((e) => {
+						frappe.show_alert({
+							message: e.message || __("Failed to add access."),
+							indicator: "red",
+						});
+					});
 			},
 		});
 		dialog.show();
 	}
 
-	add_role(name) {
-		return frappe.db.get_doc(this.access_doctype, name).then((doc) => {
+	add_role(record_name) {
+		return frappe.db.get_doc(this.access_doctype, record_name).then((doc) => {
 			doc.roles = doc.roles || [];
 			if (!doc.roles.find((r) => r.role === this.role)) {
 				doc.roles.push({ role: this.role });
 			}
-			return client_save(doc);
+			return frappe.call({ method: "frappe.client.save", args: { doc } });
 		});
 	}
 
-	remove(name) {
-		return frappe.db.get_doc(this.access_doctype, name).then((doc) => {
+	remove(record_name) {
+		return frappe.db.get_doc(this.access_doctype, record_name).then((doc) => {
 			doc.roles = (doc.roles || []).filter((r) => r.role !== this.role);
-			return client_save(doc);
+			return frappe.call({ method: "frappe.client.save", args: { doc } });
 		});
 	}
 }
@@ -818,7 +764,14 @@ class ReportsTab extends RoleAccessTab {
 		super(frm, "report_roles_html");
 		this.access_doctype = "Report";
 		this.label = "Report";
-		this.meta_fields = ["name", "module"];
+		this.meta_fields = ["name", "module", "report_type", "ref_doctype"];
+	}
+
+	report_route(row) {
+		if (row.report_type === "Report Builder") {
+			return ["List", row.ref_doctype, "Report", row.name];
+		}
+		return ["query-report", row.name];
 	}
 
 	list_config() {
@@ -827,7 +780,12 @@ class ReportsTab extends RoleAccessTab {
 			empty_message: __("This role has no Report access."),
 			add_button: { label: __("+ Add Report"), action: () => this.add() },
 			columns: [
-				this.name_link_column(),
+				{
+					label: __("Report"),
+					fieldname: "name",
+					type: "link",
+					route: (row) => this.report_route(row),
+				},
 				{ label: __("Module"), fieldname: "module" },
 				this.remove_action_column(),
 			],
@@ -856,6 +814,35 @@ class PagesTab extends RoleAccessTab {
 					type: "link",
 					text: (row) => row.title || row.name,
 					route: (row) => ["Form", "Page", row.name],
+				},
+				{ label: __("Module"), fieldname: "module" },
+				this.remove_action_column(),
+			],
+			get_data: () => this.get_data(),
+		};
+	}
+}
+
+class WorkspacesTab extends RoleAccessTab {
+	constructor(frm) {
+		super(frm, "workspace_roles_html");
+		this.access_doctype = "Workspace";
+		this.label = "Workspace";
+		this.meta_fields = ["name", "title", "module"];
+	}
+
+	list_config() {
+		return {
+			description: __("Workspaces this role can access."),
+			empty_message: __("This role has no Workspace access."),
+			add_button: { label: __("+ Add Workspace"), action: () => this.add() },
+			columns: [
+				{
+					label: __("Workspace"),
+					fieldname: "title",
+					type: "link",
+					text: (row) => row.title || row.name,
+					route: (row) => [row.name],
 				},
 				{ label: __("Module"), fieldname: "module" },
 				this.remove_action_column(),

--- a/frappe/core/doctype/role/role.js
+++ b/frappe/core/doctype/role/role.js
@@ -458,7 +458,8 @@ class DocumentsTab extends RoleTab {
 
 		// Standard row: one sequential call triggers setup_custom_perms (converts
 		// standard DocPerm → Custom DocPerm), then set_value on the new row.
-		const [[first_ptype, first_value]] = Object.entries(data);
+		// Deliberately use "read" (not "if_owner") as the trigger flag so that
+		// if_owner is not mutated before we look up the row by it.
 		return frappe
 			.call({
 				method: "frappe.core.page.permission_manager.permission_manager.update",
@@ -466,8 +467,8 @@ class DocumentsTab extends RoleTab {
 					doctype: row.parent,
 					role: this.role,
 					permlevel: row.permlevel,
-					ptype: first_ptype,
-					value: first_value,
+					ptype: "read",
+					value: data.read,
 					if_owner: row.if_owner || 0,
 				},
 			})

--- a/frappe/core/doctype/role/role.js
+++ b/frappe/core/doctype/role/role.js
@@ -8,28 +8,53 @@ const PERM_FLAGS = ["read", "write", "create", "delete", "submit", "cancel", "am
 // help text. Strings are translated lazily at field-build time, not at load.
 const PERM_SECTIONS = [
 	{
-		label: "Primary",
+		label: __("Primary"),
 		flags: [
-			{ name: "read", description: "Allows the user to view the document." },
-			{ name: "write", description: "Allows the user to edit existing records they have access to." },
-			{ name: "create", description: "Allows the user to create new documents." },
-			{ name: "delete", description: "Allows the user to delete documents." },
-			{ name: "submit", description: "Allows the user to submit documents (submittable doctypes)." },
-			{ name: "cancel", description: "Allows the user to cancel submitted documents." },
-			{ name: "amend", description: "Allows the user to amend a cancelled document into a new copy." },
-			{ name: "select", description: "Allows the user to search and see records." },
-			{ name: "mask", description: "Allows users to enable the mask property for any field of the respective doctype." },
+			{ name: "read", description: __("Allows the user to view the document.") },
+			{
+				name: "write",
+				description: __("Allows the user to edit existing records they have access to."),
+			},
+			{ name: "create", description: __("Allows the user to create new documents.") },
+			{ name: "delete", description: __("Allows the user to delete documents.") },
+			{
+				name: "submit",
+				description: __("Allows the user to submit documents (submittable doctypes)."),
+			},
+			{ name: "cancel", description: __("Allows the user to cancel submitted documents.") },
+			{
+				name: "amend",
+				description: __("Allows the user to amend a cancelled document into a new copy."),
+			},
+			{ name: "select", description: __("Allows the user to search and see records.") },
+			{
+				name: "mask",
+				description: __(
+					"Allows users to enable the mask property for any field of the respective doctype."
+				),
+			},
 		],
 	},
 	{
-		label: "Reporting & Sharing",
+		label: __("Reporting & Sharing"),
 		flags: [
-			{ name: "report", description: "Allows the user to access reports related to the document." },
-			{ name: "export", description: "Allows the user to export data from the Report view." },
-			{ name: "import", description: "Allows the user to use Data Import tool to create / update records." },
-			{ name: "share", description: "Allows sharing document access with other users." },
-			{ name: "print", description: "Allows printing or PDF download of documents." },
-			{ name: "email", description: "Allows the user to email from the document." },
+			{
+				name: "report",
+				description: __("Allows the user to access reports related to the document."),
+			},
+			{
+				name: "export",
+				description: __("Allows the user to export data from the Report view."),
+			},
+			{
+				name: "import",
+				description: __(
+					"Allows the user to use Data Import tool to create / update records."
+				),
+			},
+			{ name: "share", description: __("Allows sharing document access with other users.") },
+			{ name: "print", description: __("Allows printing or PDF download of documents.") },
+			{ name: "email", description: __("Allows the user to email from the document.") },
 		],
 	},
 ];
@@ -449,7 +474,12 @@ class DocumentsTab extends RoleTab {
 			.then(() =>
 				frappe.db.get_value(
 					"Custom DocPerm",
-					{ parent: row.parent, role: this.role, permlevel: row.permlevel, if_owner: row.if_owner || 0 },
+					{
+						parent: row.parent,
+						role: this.role,
+						permlevel: row.permlevel,
+						if_owner: row.if_owner || 0,
+					},
 					"name"
 				)
 			)
@@ -464,7 +494,12 @@ class DocumentsTab extends RoleTab {
 	remove(row) {
 		return frappe.call({
 			method: "frappe.core.page.permission_manager.permission_manager.remove",
-			args: { doctype: row.parent, role: this.role, permlevel: row.permlevel, if_owner: row.if_owner || 0 },
+			args: {
+				doctype: row.parent,
+				role: this.role,
+				permlevel: row.permlevel,
+				if_owner: row.if_owner || 0,
+			},
 		});
 	}
 

--- a/frappe/core/doctype/role/role.js
+++ b/frappe/core/doctype/role/role.js
@@ -23,7 +23,7 @@ const PERM_SECTIONS = [
 	{
 		label: "Reporting & Sharing",
 		flags: [
-			{ name: "report", description: "Access report and list views." },
+			{ name: "report", description: "Run reports for this DocType." },
 			{ name: "export", description: "Export records to a file." },
 			{ name: "import", description: "Import records from a file." },
 			{ name: "share", description: "Share documents with specific users." },
@@ -52,9 +52,6 @@ frappe.ui.form.on("Role", {
 	refresh(frm) {
 		frm.role_form = new RoleForm(frm);
 		frm.role_form.render();
-		frm.page.wrapper.off("show.role_tabs").on("show.role_tabs", () => {
-			frm.role_form && frm.role_form.load_active_tab();
-		});
 	},
 
 	on_tab_change(frm) {
@@ -181,6 +178,12 @@ class RoleTab {
 	list_config() {
 		return {};
 	}
+	save_roles_on_doc(doctype, name, transform) {
+		return frappe.db.get_doc(doctype, name).then((doc) => {
+			doc.roles = transform(doc.roles || []);
+			return client_save(doc);
+		});
+	}
 }
 
 // ============================================================
@@ -294,7 +297,7 @@ class UsersTab extends RoleTab {
 			],
 			primary_action_label: __("Add"),
 			primary_action: (values) => {
-				return this.add_role(values.user)
+				this.add_role(values.user)
 					.then(() => {
 						dialog.hide();
 						frappe.show_alert({ message: __("User added."), indicator: "green" });
@@ -312,20 +315,16 @@ class UsersTab extends RoleTab {
 	}
 
 	add_role(user_name) {
-		return frappe.db.get_doc("User", user_name).then((doc) => {
-			doc.roles = doc.roles || [];
-			if (!doc.roles.find((r) => r.role === this.role)) {
-				doc.roles.push({ role: this.role });
-			}
-			return frappe.call({ method: "frappe.client.save", args: { doc } });
+		return this.save_roles_on_doc("User", user_name, (roles) => {
+			if (!roles.find((r) => r.role === this.role)) roles.push({ role: this.role });
+			return roles;
 		});
 	}
 
 	remove(user_name) {
-		return frappe.db.get_doc("User", user_name).then((doc) => {
-			doc.roles = (doc.roles || []).filter((r) => r.role !== this.role);
-			return frappe.call({ method: "frappe.client.save", args: { doc } });
-		});
+		return this.save_roles_on_doc("User", user_name, (roles) =>
+			roles.filter((r) => r.role !== this.role)
+		);
 	}
 }
 
@@ -372,7 +371,7 @@ class DocumentsTab extends RoleTab {
 		const cols = [
 			{ label: __("DocType"), fieldname: "parent" },
 			{
-				label: __("Source"),
+				label: __("Type"),
 				fieldname: "source",
 				type: "badge",
 				color: (row) => (row.source === "Custom" ? "blue" : "gray"),
@@ -407,15 +406,21 @@ class DocumentsTab extends RoleTab {
 	create(values) {
 		const doctype = values.ref_doctype;
 		const permlevel = cint(values.permlevel);
-		const filters = { parent: doctype, role: this.role, permlevel, if_owner: 0 };
 		return frappe
 			.call({
 				method: "frappe.core.page.permission_manager.permission_manager.add",
 				args: { parent: doctype, role: this.role, permlevel },
 			})
-			.then(() => frappe.db.get_value("Custom DocPerm", filters, "name"))
-			.then((r) => {
-				const name = r.message && r.message.name;
+			.then(() =>
+				frappe.db.get_list("Custom DocPerm", {
+					filters: { parent: doctype, role: this.role, permlevel, if_owner: 0 },
+					fields: ["name"],
+					order_by: "creation desc",
+					limit: 1,
+				})
+			)
+			.then((rows) => {
+				const name = rows && rows[0] && rows[0].name;
 				return name
 					? frappe.db.set_value("Custom DocPerm", name, this.perm_data(values))
 					: null;
@@ -429,7 +434,12 @@ class DocumentsTab extends RoleTab {
 		}
 		return frappe.db.get_doc("DocType", row.parent).then((dt) => {
 			const perm = (dt.permissions || []).find((p) => p.name === row.name);
-			if (perm) Object.assign(perm, data);
+			if (!perm) {
+				frappe.throw(
+					__("Permission row not found. It may have been removed — please refresh.")
+				);
+			}
+			Object.assign(perm, data);
 			return client_save(dt);
 		});
 	}
@@ -633,23 +643,40 @@ class PermissionDialog {
 
 	save(values) {
 		const promise = this.is_edit ? this.tab.update(this.row, values) : this.tab.create(values);
-		promise.then(() => {
-			this.dialog.hide();
-			frappe.show_alert({
-				message: this.is_edit ? __("Permission updated.") : __("Permission added."),
-				indicator: "green",
+		promise
+			.then(() => {
+				this.dialog.hide();
+				frappe.show_alert({
+					message: this.is_edit ? __("Permission updated.") : __("Permission added."),
+					indicator: "green",
+				});
+				this.tab.refresh();
+			})
+			.catch((e) => {
+				frappe.msgprint({
+					title: __("Error"),
+					message: e.message || __("Failed to save permission."),
+					indicator: "red",
+				});
 			});
-			this.tab.refresh();
-		});
 	}
 
 	confirm_remove() {
 		frappe.confirm(__("Remove this role's permission on {0}?", [this.row.parent]), () => {
-			this.tab.remove(this.row).then(() => {
-				this.dialog.hide();
-				frappe.show_alert({ message: __("Permission removed."), indicator: "green" });
-				this.tab.refresh();
-			});
+			this.tab
+				.remove(this.row)
+				.then(() => {
+					this.dialog.hide();
+					frappe.show_alert({ message: __("Permission removed."), indicator: "green" });
+					this.tab.refresh();
+				})
+				.catch((e) => {
+					frappe.msgprint({
+						title: __("Error"),
+						message: e.message || __("Failed to remove permission."),
+						indicator: "red",
+					});
+				});
 		});
 	}
 }
@@ -724,7 +751,7 @@ class RoleAccessTab extends RoleTab {
 			],
 			primary_action_label: __("Add"),
 			primary_action: (values) => {
-				return this.add_role(values.doc)
+				this.add_role(values.doc)
 					.then(() => {
 						dialog.hide();
 						frappe.show_alert({ message: __("Access added."), indicator: "green" });
@@ -742,20 +769,16 @@ class RoleAccessTab extends RoleTab {
 	}
 
 	add_role(record_name) {
-		return frappe.db.get_doc(this.access_doctype, record_name).then((doc) => {
-			doc.roles = doc.roles || [];
-			if (!doc.roles.find((r) => r.role === this.role)) {
-				doc.roles.push({ role: this.role });
-			}
-			return frappe.call({ method: "frappe.client.save", args: { doc } });
+		return this.save_roles_on_doc(this.access_doctype, record_name, (roles) => {
+			if (!roles.find((r) => r.role === this.role)) roles.push({ role: this.role });
+			return roles;
 		});
 	}
 
 	remove(record_name) {
-		return frappe.db.get_doc(this.access_doctype, record_name).then((doc) => {
-			doc.roles = (doc.roles || []).filter((r) => r.role !== this.role);
-			return frappe.call({ method: "frappe.client.save", args: { doc } });
-		});
+		return this.save_roles_on_doc(this.access_doctype, record_name, (roles) =>
+			roles.filter((r) => r.role !== this.role)
+		);
 	}
 }
 

--- a/frappe/core/doctype/role/role.js
+++ b/frappe/core/doctype/role/role.js
@@ -1,94 +1,961 @@
 // Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 // MIT License. See LICENSE
 
+// Flags shown as columns in the Documents table (compact view).
+const PERM_FLAGS = ["read", "write", "create", "delete", "submit", "cancel", "amend"];
+
+// Full permission set for the add/edit dialog, grouped into three sections with
+// help text. Strings are translated lazily at field-build time, not at load.
+const PERM_SECTIONS = [
+	{
+		label: "Primary",
+		flags: [
+			{ name: "read", description: "View documents of this type." },
+			{ name: "write", description: "Edit existing documents." },
+			{ name: "create", description: "Create new documents." },
+			{ name: "delete", description: "Delete documents." },
+			{ name: "submit", description: "Submit documents (submittable doctypes)." },
+			{ name: "cancel", description: "Cancel submitted documents." },
+			{ name: "amend", description: "Amend a cancelled document into a new copy." },
+			{ name: "select", description: "Select records in link fields." },
+		],
+	},
+	{
+		label: "Reporting & Sharing",
+		flags: [
+			{ name: "report", description: "Access report and list views." },
+			{ name: "export", description: "Export records to a file." },
+			{ name: "import", description: "Import records from a file." },
+			{ name: "share", description: "Share documents with specific users." },
+			{ name: "print", description: "Print documents." },
+			{ name: "email", description: "Email documents." },
+		],
+	},
+	{
+		label: "Others",
+		flags: [{ name: "mask", description: "Mask sensitive field values." }],
+	},
+];
+
+// Every flag the dialog can write back (across all three sections).
+const ALL_PERM_FLAGS = PERM_SECTIONS.flatMap((section) => section.flags.map((flag) => flag.name));
+
+// Permission levels offered in the add dialog (0–9).
+const PERMLEVEL_OPTIONS = Array.from({ length: 10 }, (_, i) => String(i)).join("\n");
+
+// Rights that only apply to submittable doctypes (hidden otherwise).
+const SUBMITTABLE_FLAGS = ["submit", "cancel", "amend"];
+// At permlevel > 0, only these field-level rights apply.
+const PERMLEVEL_FLAGS = ["read", "write", "mask"];
+
 frappe.ui.form.on("Role", {
-	refresh: function (frm) {
-		if (frm.doc.name === "All") {
-			frm.dashboard.add_comment(
-				__("Role 'All' will be given to all system + website users."),
-				"yellow"
-			);
-		} else if (frm.doc.name === "Desk User") {
-			frm.dashboard.add_comment(
-				__("Role 'Desk User' will be given to all system users."),
-				"yellow"
-			);
-		}
+	refresh(frm) {
+		frm.role_form = new RoleForm(frm);
+		frm.role_form.render();
+	},
 
-		frm.set_df_property("is_custom", "read_only", frappe.session.user !== "Administrator");
+	on_tab_change(frm) {
+		// Lazy-load the active tab's data the first time it is opened.
+		frm.role_form && frm.role_form.load_active_tab();
+	},
+});
 
-		frm.add_custom_button(
+// ============================================================
+// RoleForm — top-level controller for the form.
+// ============================================================
+
+class RoleForm {
+	constructor(frm) {
+		this.frm = frm;
+	}
+
+	get role() {
+		return this.frm.doc.name;
+	}
+
+	render() {
+		this.show_banner();
+		this.frm.set_df_property(
+			"is_custom",
+			"read_only",
+			frappe.session.user !== "Administrator"
+		);
+		this.add_buttons();
+		this.setup_tabs();
+	}
+
+	setup_tabs() {
+		// Keyed by Tab Break fieldname so `load_active_tab` can find the editor.
+		this.tabs = {
+			users_tab: new UsersTab(this.frm),
+			document_tab: new DocumentsTab(this.frm),
+			report_tab: new ReportsTab(this.frm),
+			pages_tab: new PagesTab(this.frm),
+		};
+		Object.values(this.tabs).forEach((tab) => tab.build());
+
+		// Role Profiles live in the always-visible Details tab — load eagerly.
+		const profiles = new RoleProfilesTab(this.frm);
+		profiles.build();
+		profiles.refresh();
+
+		this.load_active_tab();
+	}
+
+	load_active_tab() {
+		const active = this.frm.get_active_tab && this.frm.get_active_tab();
+		const fieldname = active && active.df && active.df.fieldname;
+		const tab = fieldname && this.tabs && this.tabs[fieldname];
+		if (tab) tab.load_once();
+	}
+
+	show_banner() {
+		const messages = {
+			All: __("Role 'All' will be given to all system + website users."),
+			"Desk User": __("Role 'Desk User' will be given to all system users."),
+		};
+		if (messages[this.role]) this.frm.dashboard.add_comment(messages[this.role], "yellow");
+	}
+
+	add_buttons() {
+		this.frm.add_custom_button(
 			__("Role Permissions Manager"),
-			function () {
-				frappe.route_options = { role: frm.doc.name };
+			() => {
+				frappe.route_options = { role: this.role };
 				frappe.set_route("permission-manager");
 			},
 			__("View")
 		);
-
-		frm.add_custom_button(
-			__("Show Users"),
-			function () {
-				frappe.route_options = { role: frm.doc.name };
-				frappe.set_route("List", "User", "Report");
-			},
-			__("View")
-		);
-
 		if (frappe.user.has_role("System Manager")) {
-			frm.add_custom_button(
+			this.frm.add_custom_button(
 				__("Replicate Role"),
-				function () {
-					replicate_role(frm);
-				},
+				() => new ReplicateRoleDialog(this.frm).show(),
 				__("Action")
 			);
 		}
-	},
-});
+	}
+}
 
-function replicate_role(frm) {
-	const dialog = new frappe.ui.Dialog({
-		title: __("Replicate Role"),
-		fields: [
-			{
-				label: __("New Role Name"),
-				fieldname: "new_role_name",
-				fieldtype: "Data",
-				default: frm.doc.name,
-				reqd: 1,
+// ============================================================
+// RoleTab — base class for a tab backed by an EmbeddedList.
+// ============================================================
+
+class RoleTab {
+	constructor(frm, html_fieldname) {
+		this.frm = frm;
+		this.html_fieldname = html_fieldname;
+		this.loaded = false;
+	}
+
+	get role() {
+		return this.frm.doc.name;
+	}
+
+	get wrapper() {
+		const field = this.frm.fields_dict[this.html_fieldname];
+		return field ? field.$wrapper : null;
+	}
+
+	// Builds the EmbeddedList, or a placeholder for an unsaved role.
+	build() {
+		const wrapper = this.wrapper && this.wrapper.empty();
+		if (!wrapper) return;
+		if (this.frm.is_new()) {
+			wrapper.html(placeholder_html(__("Save the role first to view this information.")));
+			return;
+		}
+		this.list = new frappe.ui.EmbeddedList(
+			Object.assign({ wrapper, show_index: true }, this.list_config())
+		);
+	}
+
+	refresh() {
+		this.list && this.list.refresh();
+	}
+
+	load_once() {
+		if (this.loaded || !this.list) return;
+		this.loaded = true;
+		this.refresh();
+	}
+
+	// Subclasses return the EmbeddedList options (minus wrapper/show_index).
+	list_config() {
+		return {};
+	}
+}
+
+// ============================================================
+// RoleProfilesTab (Details tab) & UsersTab
+// ============================================================
+
+class RoleProfilesTab extends RoleTab {
+	constructor(frm) {
+		super(frm, "role_profiles_html");
+	}
+
+	list_config() {
+		return {
+			title: __("Role Profiles"),
+			description: __("Role Profiles that include this role."),
+			empty_message: __("No Role Profiles include this role."),
+			columns: [
+				{
+					label: __("Role Profile"),
+					fieldname: "name",
+					type: "link",
+					route: (row) => ["Form", "Role Profile", row.name],
+				},
+			],
+			get_data: () => this.get_data(),
+		};
+	}
+
+	get_data() {
+		return frappe.db
+			.get_list("Has Role", {
+				filters: { role: this.role, parenttype: "Role Profile" },
+				fields: ["parent"],
+				limit: 0,
+			})
+			.then((rows) => unique_parents(rows).map((parent) => ({ name: parent })));
+	}
+}
+
+class UsersTab extends RoleTab {
+	constructor(frm) {
+		super(frm, "users_html");
+	}
+
+	list_config() {
+		return {
+			description: __("Users who have this role."),
+			empty_message: __("No users have this role."),
+			add_button: { label: __("+ Add User"), action: () => this.add() },
+			columns: [
+				{
+					label: __("Full Name"),
+					fieldname: "full_name",
+					type: "link",
+					text: (row) => row.full_name || row.name,
+					route: (row) => ["Form", "User", row.name],
+				},
+				{ label: __("Email"), fieldname: "email" },
+				{
+					type: "actions",
+					actions: [
+						{
+							label: __("Remove"),
+							icon: "x",
+							danger: true,
+							confirm: __("Remove '{0}' from this role?"),
+							confirm_field: "full_name",
+							action: (row, refresh) => this.remove(row.name).then(refresh),
+						},
+					],
+				},
+			],
+			get_data: () => this.get_data(),
+		};
+	}
+
+	get_data() {
+		return frappe.db
+			.get_list("Has Role", {
+				filters: { role: this.role, parenttype: "User" },
+				fields: ["parent"],
+				limit: 0,
+			})
+			.then((rows) => this.fetch_users(unique_parents(rows)));
+	}
+
+	fetch_users(names) {
+		if (!names.length) return [];
+		return frappe.db.get_list("User", {
+			filters: { name: ["in", names], enabled: 1 },
+			fields: ["name", "full_name", "email"],
+			order_by: "full_name asc",
+			limit: 0,
+		});
+	}
+
+	add() {
+		const existing = unique_values(this.list.data, "name");
+		const dialog = new frappe.ui.Dialog({
+			title: __("Add User to {0}", [this.role]),
+			fields: [
+				{
+					label: __("User"),
+					fieldname: "user",
+					fieldtype: "Link",
+					options: "User",
+					reqd: 1,
+					get_query: () => ({
+						filters: { enabled: 1, name: ["not in", not_in(existing)] },
+					}),
+				},
+			],
+			primary_action_label: __("Add"),
+			primary_action: (values) => {
+				this.add_role(values.user).then(() => {
+					dialog.hide();
+					frappe.show_alert({ message: __("User added."), indicator: "green" });
+					this.refresh();
+				});
 			},
-		],
-		freeze: true,
-		freeze_message: __("Replicating Role..."),
-		primary_action_label: __("Replicate"),
-		primary_action: function (values) {
-			dialog.hide();
-			frappe.call({
-				method: "replicate_role",
-				doc: frm.doc,
-				args: {
-					cur_role: frm.doc.name,
-					new_role: values.new_role_name,
-				},
-				callback: function (r) {
-					if (r.message) {
-						frappe.set_route("Form", "Role", r.message);
-						frappe.show_alert({
-							message: __("New role created successfully."),
-							indicator: "green",
-						});
-					} else if (r.exc) {
-						JSON.parse(r.exc).forEach((err) => {
-							frappe.show_alert({
-								message: __(err),
-								indicator: "red",
-							});
-						});
-					}
-				},
+		});
+		dialog.show();
+	}
+
+	add_role(user_name) {
+		return frappe.db.get_doc("User", user_name).then((user) => {
+			user.roles = user.roles || [];
+			if (!user.roles.find((r) => r.role === this.role)) {
+				user.roles.push({ role: this.role });
+			}
+			return client_save(user);
+		});
+	}
+
+	remove(user_name) {
+		return frappe.db.get_doc("User", user_name).then((user) => {
+			user.roles = (user.roles || []).filter((r) => r.role !== this.role);
+			return client_save(user);
+		});
+	}
+}
+
+// ============================================================
+// DocumentsTab — DocPerm + Custom DocPerm via get_permissions.
+// ============================================================
+
+class DocumentsTab extends RoleTab {
+	constructor(frm) {
+		super(frm, "document_permissions_html");
+	}
+
+	list_config() {
+		return {
+			page_size: 20,
+			description: __("DocTypes this role can access."),
+			empty_message: __("No DocTypes are accessible to this role."),
+			add_button: { label: __("+ Add Permission"), action: () => this.add() },
+			columns: this.columns(),
+			on_row_click: (row) => this.edit(row),
+			get_data: () => this.get_data(),
+		};
+	}
+
+	get_data() {
+		return frappe
+			.call({
+				method: "frappe.core.page.permission_manager.permission_manager.get_permissions",
+				args: { role: this.role },
+			})
+			.then((r) => this.transform(r.message || []));
+	}
+
+	transform(perms) {
+		return perms
+			.map((perm) => ({ ...perm, source: perm.parenttype ? "Standard" : "Custom" }))
+			.sort(
+				(a, b) =>
+					a.parent.localeCompare(b.parent) || (a.permlevel || 0) - (b.permlevel || 0)
+			);
+	}
+
+	columns() {
+		const cols = [
+			{ label: __("DocType"), fieldname: "parent" },
+			{
+				label: __("Source"),
+				fieldname: "source",
+				type: "badge",
+				color: (row) => (row.source === "Custom" ? "blue" : "gray"),
+			},
+			{ label: __("Permission Level"), fieldname: "permlevel", align: "center" },
+			{
+				label: __("Only if Creator"),
+				fieldname: "if_owner",
+				type: "check",
+				align: "center",
+			},
+		];
+		PERM_FLAGS.forEach((flag) =>
+			cols.push({
+				label: __(capitalize(flag)),
+				fieldname: flag,
+				type: "check",
+				align: "center",
+			})
+		);
+		return cols;
+	}
+
+	edit(row) {
+		new PermissionDialog(this, { row }).show();
+	}
+
+	add() {
+		new PermissionDialog(this, {}).show();
+	}
+
+	create(values) {
+		const doctype = values.ref_doctype;
+		const permlevel = cint(values.permlevel);
+		const filters = { parent: doctype, role: this.role, permlevel, if_owner: 0 };
+		return frappe
+			.call({
+				method: "frappe.core.page.permission_manager.permission_manager.add",
+				args: { parent: doctype, role: this.role, permlevel },
+			})
+			.then(() => frappe.db.get_value("Custom DocPerm", filters, "name"))
+			.then((r) => {
+				const name = r.message && r.message.name;
+				return name
+					? frappe.db.set_value("Custom DocPerm", name, this.perm_data(values))
+					: null;
 			});
-		},
-	});
-	dialog.show();
+	}
+
+	update(row, values) {
+		const data = this.perm_data(values);
+		if (row.source === "Custom") {
+			return frappe.db.set_value("Custom DocPerm", row.name, data);
+		}
+		return frappe.db.get_doc("DocType", row.parent).then((dt) => {
+			const perm = (dt.permissions || []).find((p) => p.name === row.name);
+			if (perm) Object.assign(perm, data);
+			return client_save(dt);
+		});
+	}
+
+	remove(row) {
+		if (row.source === "Custom") {
+			return frappe.db.delete_doc("Custom DocPerm", row.name);
+		}
+		return frappe.db.get_doc("DocType", row.parent).then((dt) => {
+			dt.permissions = (dt.permissions || []).filter((p) => p.name !== row.name);
+			return client_save(dt);
+		});
+	}
+
+	perm_data(values) {
+		const data = {};
+		["if_owner", ...ALL_PERM_FLAGS].forEach((flag) => (data[flag] = values[flag] ? 1 : 0));
+		return data;
+	}
+}
+
+// ============================================================
+// PermissionDialog — the add / edit permission dialog.
+// ============================================================
+
+class PermissionDialog {
+	constructor(tab, opts) {
+		this.tab = tab;
+		this.row = opts.row || null;
+		this.is_submittable = this.row ? !!this.row.is_submittable : false;
+	}
+
+	get role() {
+		return this.tab.role;
+	}
+
+	get is_edit() {
+		return !!this.row;
+	}
+
+	show() {
+		this.dialog = new frappe.ui.Dialog({
+			title: this.title(),
+			fields: this.fields(),
+			primary_action_label: this.is_edit ? __("Save") : __("Add"),
+			primary_action: (values) => this.save(values),
+		});
+		if (this.is_edit) this.add_row_actions();
+		this.dialog.show();
+		this.apply_visibility(this.is_edit ? this.row.permlevel : 0);
+	}
+
+	title() {
+		return this.is_edit
+			? __("{0} Permission — {1}", [__(this.row.source), this.row.parent])
+			: __("Add Permission for {0}", [this.role]);
+	}
+
+	fields() {
+		const level_field = this.is_edit ? this.edit_level_field() : this.add_level_field();
+		const seed = this.is_edit ? this.row : { read: 1 };
+		return [
+			this.doctype_field(),
+			level_field,
+			...this.flag_fields(seed),
+
+			{
+				fieldtype: "Section Break",
+				fieldname: "sb_only_if_creator",
+				label: __("Creator Access"),
+			},
+
+			this.if_owner_field(seed),
+		];
+	}
+
+	doctype_field() {
+		if (this.is_edit) {
+			return {
+				fieldtype: "Link",
+				fieldname: "ref_doctype",
+				label: __("DocType"),
+				options: "DocType",
+				read_only: 1,
+				default: this.row.parent,
+			};
+		}
+		return {
+			fieldtype: "Link",
+			fieldname: "ref_doctype",
+			label: __("DocType"),
+			options: "DocType",
+			reqd: 1,
+			onchange: () => this.on_doctype_change(),
+		};
+	}
+
+	edit_level_field() {
+		const level = String(this.row.permlevel || 0);
+		return {
+			fieldtype: "Select",
+			fieldname: "permlevel",
+			label: __("Permission Level"),
+			options: level,
+			default: level,
+			read_only: 1,
+		};
+	}
+
+	add_level_field() {
+		return {
+			fieldtype: "Select",
+			fieldname: "permlevel",
+			label: __("Permission Level"),
+			options: PERMLEVEL_OPTIONS,
+			default: "0",
+			onchange: () => this.refresh_visibility(),
+		};
+	}
+
+	flag_fields(seed) {
+		const fields = [];
+		PERM_SECTIONS.forEach((section) => {
+			fields.push({
+				fieldtype: "Section Break",
+				fieldname: section_break_fieldname(section.label),
+				label: __(section.label),
+			});
+			const half = Math.ceil(section.flags.length / 2);
+			section.flags.forEach((flag, i) => {
+				if (i === half) fields.push({ fieldtype: "Column Break" });
+				fields.push(this.check_field(flag.name, flag.description, seed));
+			});
+		});
+		return fields;
+	}
+
+	check_field(fieldname, description, seed) {
+		return {
+			fieldtype: "Check",
+			fieldname,
+			label: __(capitalize(fieldname)),
+			description: __(description),
+			show_description_on_click: 1,
+			default: seed[fieldname] || 0,
+		};
+	}
+
+	if_owner_field(seed) {
+		const field = this.check_field(
+			"if_owner",
+			"Apply this permission only to documents created by the user.",
+			seed
+		);
+		field.label = __("Only if Creator");
+		field.show_description_on_click = 0;
+		return field;
+	}
+
+	on_doctype_change() {
+		const doctype = this.dialog.get_value("ref_doctype");
+		if (!doctype) {
+			this.is_submittable = false;
+			return this.refresh_visibility();
+		}
+		// The submittable flag decides whether submit/cancel/amend apply.
+		frappe.db.get_value("DocType", doctype, "is_submittable").then((r) => {
+			this.is_submittable = !!(r.message && cint(r.message.is_submittable));
+			this.refresh_visibility();
+		});
+	}
+
+	refresh_visibility() {
+		this.apply_visibility(this.dialog.get_value("permlevel"));
+	}
+
+	apply_visibility(permlevel) {
+		const high_level = cint(permlevel) > 0;
+		const visible = (flag) => {
+			if (!this.is_submittable && SUBMITTABLE_FLAGS.includes(flag)) return false;
+			if (high_level && !PERMLEVEL_FLAGS.includes(flag)) return false;
+			return true;
+		};
+		ALL_PERM_FLAGS.forEach((flag) =>
+			this.dialog.set_df_property(flag, "hidden", visible(flag) ? 0 : 1)
+		);
+		this.dialog.set_df_property("if_owner", "hidden", high_level ? 1 : 0);
+		PERM_SECTIONS.forEach((section) => {
+			const any = section.flags.some((flag) => visible(flag.name));
+			this.dialog.set_df_property(
+				section_break_fieldname(section.label),
+				"hidden",
+				any ? 0 : 1
+			);
+		});
+	}
+
+	add_row_actions() {
+		if (this.row.permlevel > 0) {
+			this.dialog.add_custom_action(__("View Fields"), () =>
+				new FieldsDialog(this.row).show()
+			);
+		}
+		this.dialog.add_custom_action(__("Remove Permission"), () => this.confirm_remove());
+	}
+
+	save(values) {
+		const promise = this.is_edit ? this.tab.update(this.row, values) : this.tab.create(values);
+		promise.then(() => {
+			this.dialog.hide();
+			frappe.show_alert({
+				message: this.is_edit ? __("Permission updated.") : __("Permission added."),
+				indicator: "green",
+			});
+			this.tab.refresh();
+		});
+	}
+
+	confirm_remove() {
+		frappe.confirm(__("Remove this role's permission on '{0}'?", [this.row.parent]), () => {
+			this.tab.remove(this.row).then(() => {
+				this.dialog.hide();
+				frappe.show_alert({ message: __("Permission removed."), indicator: "green" });
+				this.tab.refresh();
+			});
+		});
+	}
+}
+
+// ============================================================
+// FieldsDialog — fields sitting at a given permlevel for a doctype.
+// ============================================================
+
+class FieldsDialog {
+	constructor(row) {
+		this.row = row;
+	}
+
+	show() {
+		this.dialog = new frappe.ui.Dialog({
+			title: __("Fields at Level {0} — {1}", [this.row.permlevel, this.row.parent]),
+			size: "large",
+		});
+		this.dialog.show();
+		this.dialog.$body.html(placeholder_html(__("Loading...")));
+		this.load();
+	}
+
+	load() {
+		Promise.all([
+			frappe.db.get_list("DocField", {
+				filters: { parent: this.row.parent, permlevel: this.row.permlevel },
+				fields: ["fieldname", "label", "fieldtype"],
+				limit: 0,
+			}),
+			frappe.db.get_list("Custom Field", {
+				filters: { dt: this.row.parent, permlevel: this.row.permlevel },
+				fields: ["fieldname", "label", "fieldtype"],
+				limit: 0,
+			}),
+		]).then(([std, custom]) => this.render([...std, ...custom]));
+	}
+
+	render(fields) {
+		if (!fields.length) {
+			this.dialog.$body.html(
+				placeholder_html(__("No fields are set to this permission level."))
+			);
+			return;
+		}
+		this.dialog.$body.html(this.table_html(fields));
+	}
+
+	table_html(fields) {
+		const body = fields.map((field) => this.row_html(field)).join("");
+		return `<table class="table table-bordered">
+				<thead><tr><th>${__("Label")}</th><th>${__("Fieldname")}</th><th>${__("Type")}</th></tr></thead>
+				<tbody>${body}</tbody>
+			</table>`;
+	}
+
+	row_html(field) {
+		return `<tr>
+				<td>${frappe.utils.escape_html(__(field.label) || field.fieldname)}</td>
+				<td class="text-muted">${frappe.utils.escape_html(field.fieldname)}</td>
+				<td class="text-muted">${frappe.utils.escape_html(field.fieldtype)}</td>
+			</tr>`;
+	}
+}
+
+// ============================================================
+// ReportsTab & PagesTab — reverse lookup on a `roles` child table.
+// ============================================================
+
+class RoleAccessTab extends RoleTab {
+	// Subclasses set access_doctype / label / meta_fields and provide list_config().
+	get_data() {
+		return frappe.db
+			.get_list("Has Role", {
+				filters: { role: this.role, parenttype: this.access_doctype },
+				fields: ["parent"],
+				limit: 0,
+			})
+			.then((rows) => this.fetch_records(unique_parents(rows)));
+	}
+
+	fetch_records(names) {
+		if (!names.length) return [];
+		return frappe.db.get_list(this.access_doctype, {
+			filters: { name: ["in", names] },
+			fields: this.meta_fields,
+			order_by: "name asc",
+			limit: 0,
+		});
+	}
+
+	// A clickable name column that opens the underlying record.
+	name_link_column() {
+		return {
+			label: __(this.label),
+			fieldname: "name",
+			type: "link",
+			route: (row) => ["Form", this.access_doctype, row.name],
+		};
+	}
+
+	// An inline Remove action (no dialog — there is nothing to edit here).
+	remove_action_column() {
+		return {
+			type: "actions",
+			actions: [
+				{
+					label: __("Remove"),
+					icon: "x",
+					danger: true,
+					confirm: __("Remove this role's access to '{0}'?"),
+					confirm_field: "name",
+					action: (row, refresh) => this.remove(row.name).then(refresh),
+				},
+			],
+		};
+	}
+
+	add() {
+		const existing = unique_values(this.list.data, "name");
+		const dialog = new frappe.ui.Dialog({
+			title: __("Add {0} Access to {1}", [__(this.label), this.role]),
+			fields: [
+				{
+					label: __(this.label),
+					fieldname: "doc",
+					fieldtype: "Link",
+					options: this.access_doctype,
+					reqd: 1,
+					get_query: () => ({ filters: { name: ["not in", not_in(existing)] } }),
+				},
+			],
+			primary_action_label: __("Add"),
+			primary_action: (values) => {
+				this.add_role(values.doc).then(() => {
+					dialog.hide();
+					frappe.show_alert({ message: __("Access added."), indicator: "green" });
+					this.refresh();
+				});
+			},
+		});
+		dialog.show();
+	}
+
+	add_role(name) {
+		return frappe.db.get_doc(this.access_doctype, name).then((doc) => {
+			doc.roles = doc.roles || [];
+			if (!doc.roles.find((r) => r.role === this.role)) {
+				doc.roles.push({ role: this.role });
+			}
+			return client_save(doc);
+		});
+	}
+
+	remove(name) {
+		return frappe.db.get_doc(this.access_doctype, name).then((doc) => {
+			doc.roles = (doc.roles || []).filter((r) => r.role !== this.role);
+			return client_save(doc);
+		});
+	}
+}
+
+class ReportsTab extends RoleAccessTab {
+	constructor(frm) {
+		super(frm, "report_roles_html");
+		this.access_doctype = "Report";
+		this.label = "Report";
+		this.meta_fields = ["name", "module"];
+	}
+
+	list_config() {
+		return {
+			description: __("Reports this role can access."),
+			empty_message: __("This role has no Report access."),
+			add_button: { label: __("+ Add Report"), action: () => this.add() },
+			columns: [
+				this.name_link_column(),
+				{ label: __("Module"), fieldname: "module" },
+				this.remove_action_column(),
+			],
+			get_data: () => this.get_data(),
+		};
+	}
+}
+
+class PagesTab extends RoleAccessTab {
+	constructor(frm) {
+		super(frm, "page_roles_html");
+		this.access_doctype = "Page";
+		this.label = "Page";
+		this.meta_fields = ["name", "title", "module"];
+	}
+
+	list_config() {
+		return {
+			description: __("Pages this role can access."),
+			empty_message: __("This role has no Page access."),
+			add_button: { label: __("+ Add Page"), action: () => this.add() },
+			columns: [
+				{
+					label: __("Title"),
+					fieldname: "title",
+					type: "link",
+					text: (row) => row.title || row.name,
+					route: (row) => ["Form", "Page", row.name],
+				},
+				{ label: __("Module"), fieldname: "module" },
+				this.remove_action_column(),
+			],
+			get_data: () => this.get_data(),
+		};
+	}
+}
+
+// ============================================================
+// ReplicateRoleDialog
+// ============================================================
+
+class ReplicateRoleDialog {
+	constructor(frm) {
+		this.frm = frm;
+	}
+
+	show() {
+		this.dialog = new frappe.ui.Dialog({
+			title: __("Replicate Role"),
+			fields: [
+				{
+					label: __("New Role Name"),
+					fieldname: "new_role_name",
+					fieldtype: "Data",
+					default: this.frm.doc.name,
+					reqd: 1,
+				},
+			],
+			freeze: true,
+			freeze_message: __("Replicating Role..."),
+			primary_action_label: __("Replicate"),
+			primary_action: (values) => this.replicate(values.new_role_name),
+		});
+		this.dialog.show();
+	}
+
+	replicate(new_role) {
+		this.dialog.hide();
+		frappe.call({
+			method: "replicate_role",
+			doc: this.frm.doc,
+			args: { cur_role: this.frm.doc.name, new_role },
+			callback: (r) => this.on_replicated(r),
+		});
+	}
+
+	on_replicated(r) {
+		if (r.message) {
+			frappe.set_route("Form", "Role", r.message);
+			frappe.show_alert({
+				message: __("New role created successfully."),
+				indicator: "green",
+			});
+		} else if (r.exc) {
+			JSON.parse(r.exc).forEach((err) =>
+				frappe.show_alert({ message: __(err), indicator: "red" })
+			);
+		}
+	}
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function client_save(doc) {
+	return frappe.call({ method: "frappe.client.save", args: { doc } });
+}
+
+function unique_parents(rows) {
+	return [...new Set(rows.map((row) => row.parent))];
+}
+
+// Distinct, defined values of `field` across rows (used to exclude already-listed
+// records from the Add dialogs).
+function unique_values(rows, field) {
+	return [...new Set((rows || []).map((row) => row[field]).filter(Boolean))];
+}
+
+// A safe "not in" list for link filters (empty lists confuse the query builder).
+function not_in(values) {
+	return values.length ? values : [""];
+}
+
+function section_break_fieldname(label) {
+	return (
+		"sb_" +
+		label
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "_")
+			.replace(/_+$/, "")
+	);
+}
+
+function capitalize(string) {
+	return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function placeholder_html(message) {
+	return `<div class="text-muted">${message}</div>`;
 }

--- a/frappe/core/doctype/role/role.js
+++ b/frappe/core/doctype/role/role.js
@@ -10,30 +10,27 @@ const PERM_SECTIONS = [
 	{
 		label: "Primary",
 		flags: [
-			{ name: "read", description: "View documents of this type." },
-			{ name: "write", description: "Edit existing documents." },
-			{ name: "create", description: "Create new documents." },
-			{ name: "delete", description: "Delete documents." },
-			{ name: "submit", description: "Submit documents (submittable doctypes)." },
-			{ name: "cancel", description: "Cancel submitted documents." },
-			{ name: "amend", description: "Amend a cancelled document into a new copy." },
-			{ name: "select", description: "Select records in link fields." },
+			{ name: "read", description: "Allows the user to view the document." },
+			{ name: "write", description: "Allows the user to edit existing records they have access to." },
+			{ name: "create", description: "Allows the user to create new documents." },
+			{ name: "delete", description: "Allows the user to delete documents." },
+			{ name: "submit", description: "Allows the user to submit documents (submittable doctypes)." },
+			{ name: "cancel", description: "Allows the user to cancel submitted documents." },
+			{ name: "amend", description: "Allows the user to amend a cancelled document into a new copy." },
+			{ name: "select", description: "Allows the user to search and see records." },
+			{ name: "mask", description: "Allows users to enable the mask property for any field of the respective doctype." },
 		],
 	},
 	{
 		label: "Reporting & Sharing",
 		flags: [
-			{ name: "report", description: "Run reports for this DocType." },
-			{ name: "export", description: "Export records to a file." },
-			{ name: "import", description: "Import records from a file." },
-			{ name: "share", description: "Share documents with specific users." },
-			{ name: "print", description: "Print documents." },
-			{ name: "email", description: "Email documents." },
+			{ name: "report", description: "Allows the user to access reports related to the document." },
+			{ name: "export", description: "Allows the user to export data from the Report view." },
+			{ name: "import", description: "Allows the user to use Data Import tool to create / update records." },
+			{ name: "share", description: "Allows sharing document access with other users." },
+			{ name: "print", description: "Allows printing or PDF download of documents." },
+			{ name: "email", description: "Allows the user to email from the document." },
 		],
-	},
-	{
-		label: "Others",
-		flags: [{ name: "mask", description: "Mask sensitive field values." }],
 	},
 ];
 
@@ -339,7 +336,7 @@ class DocumentsTab extends RoleTab {
 
 	list_config() {
 		return {
-			page_size: 20,
+			page_size: 50,
 			description: __("DocTypes this role can access."),
 			empty_message: __("No DocTypes are accessible to this role."),
 			add_button: { label: __("+ Add Permission"), action: () => this.add() },
@@ -429,28 +426,45 @@ class DocumentsTab extends RoleTab {
 
 	update(row, values) {
 		const data = this.perm_data(values);
+
 		if (row.source === "Custom") {
 			return frappe.db.set_value("Custom DocPerm", row.name, data);
 		}
-		return frappe.db.get_doc("DocType", row.parent).then((dt) => {
-			const perm = (dt.permissions || []).find((p) => p.name === row.name);
-			if (!perm) {
-				frappe.throw(
-					__("Permission row not found. It may have been removed — please refresh.")
-				);
-			}
-			Object.assign(perm, data);
-			return client_save(dt);
-		});
+
+		// Standard row: one sequential call triggers setup_custom_perms (converts
+		// standard DocPerm → Custom DocPerm), then set_value on the new row.
+		const [[first_ptype, first_value]] = Object.entries(data);
+		return frappe
+			.call({
+				method: "frappe.core.page.permission_manager.permission_manager.update",
+				args: {
+					doctype: row.parent,
+					role: this.role,
+					permlevel: row.permlevel,
+					ptype: first_ptype,
+					value: first_value,
+					if_owner: row.if_owner || 0,
+				},
+			})
+			.then(() =>
+				frappe.db.get_value(
+					"Custom DocPerm",
+					{ parent: row.parent, role: this.role, permlevel: row.permlevel, if_owner: row.if_owner || 0 },
+					"name"
+				)
+			)
+			.then((r) => {
+				const name = r.message && r.message.name;
+				if (!name)
+					frappe.throw(__("Permission row not found after conversion. Please refresh."));
+				return frappe.db.set_value("Custom DocPerm", name, data);
+			});
 	}
 
 	remove(row) {
-		if (row.source === "Custom") {
-			return frappe.db.delete_doc("Custom DocPerm", row.name);
-		}
-		return frappe.db.get_doc("DocType", row.parent).then((dt) => {
-			dt.permissions = (dt.permissions || []).filter((p) => p.name !== row.name);
-			return client_save(dt);
+		return frappe.call({
+			method: "frappe.core.page.permission_manager.permission_manager.remove",
+			args: { doctype: row.parent, role: this.role, permlevel: row.permlevel, if_owner: row.if_owner || 0 },
 		});
 	}
 
@@ -591,7 +605,7 @@ class PermissionDialog {
 	if_owner_field(seed) {
 		const field = this.check_field(
 			"if_owner",
-			"Apply this permission only to documents created by the user.",
+			"When checked, these permissions apply only to documents this user created.",
 			seed
 		);
 		field.label = __("Only if Creator");

--- a/frappe/core/doctype/role/role.json
+++ b/frappe/core/doctype/role/role.json
@@ -9,12 +9,22 @@
  "field_order": [
   "role_name",
   "home_page",
-  "restrict_to_domain",
   "column_break_4",
   "disabled",
   "is_custom",
   "desk_access",
-  "two_factor_auth"
+  "two_factor_auth",
+  "configure_section",
+  "restrict_to_domain",
+  "role_profiles_html",
+  "users_tab",
+  "users_html",
+  "document_tab",
+  "document_permissions_html",
+  "report_tab",
+  "report_roles_html",
+  "pages_tab",
+  "page_roles_html"
  ],
  "fields": [
   {
@@ -68,13 +78,63 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Is Custom"
+  },
+  {
+   "fieldname": "configure_section",
+   "fieldtype": "Section Break",
+   "label": "Configure"
+  },
+  {
+   "fieldname": "role_profiles_html",
+   "fieldtype": "HTML",
+   "label": "Role Profiles"
+  },
+  {
+   "fieldname": "users_tab",
+   "fieldtype": "Tab Break",
+   "label": "Users"
+  },
+  {
+   "fieldname": "users_html",
+   "fieldtype": "HTML",
+   "label": "Users"
+  },
+  {
+   "fieldname": "document_tab",
+   "fieldtype": "Tab Break",
+   "label": "Documents"
+  },
+  {
+   "fieldname": "document_permissions_html",
+   "fieldtype": "HTML",
+   "label": "Document Permissions"
+  },
+  {
+   "fieldname": "report_tab",
+   "fieldtype": "Tab Break",
+   "label": "Reports"
+  },
+  {
+   "fieldname": "report_roles_html",
+   "fieldtype": "HTML",
+   "label": "Reports"
+  },
+  {
+   "fieldname": "pages_tab",
+   "fieldtype": "Tab Break",
+   "label": "Pages"
+  },
+  {
+   "fieldname": "page_roles_html",
+   "fieldtype": "HTML",
+   "label": "Pages"
   }
  ],
  "icon": "fa fa-bookmark",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-28 15:58:11.939407",
+ "modified": "2026-06-15 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Role",

--- a/frappe/core/doctype/role/role.json
+++ b/frappe/core/doctype/role/role.json
@@ -9,13 +9,13 @@
  "field_order": [
   "role_name",
   "home_page",
+  "restrict_to_domain",
   "column_break_4",
   "disabled",
   "is_custom",
   "desk_access",
   "two_factor_auth",
-  "configure_section",
-  "restrict_to_domain",
+  "role_profiles_section",
   "role_profiles_html",
   "users_tab",
   "users_html",
@@ -24,7 +24,9 @@
   "report_tab",
   "report_roles_html",
   "pages_tab",
-  "page_roles_html"
+  "page_roles_html",
+  "workspace_tab",
+  "workspace_roles_html"
  ],
  "fields": [
   {
@@ -37,11 +39,34 @@
    "unique": 1
   },
   {
+   "description": "Route: Example \"/desk\"",
+   "fieldname": "home_page",
+   "fieldtype": "Data",
+   "label": "Home Page"
+  },
+  {
+   "fieldname": "restrict_to_domain",
+   "fieldtype": "Link",
+   "label": "Restrict To Domain",
+   "options": "Domain"
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
+  },
+  {
    "default": "0",
    "description": "If disabled, this role will be removed from all users.",
    "fieldname": "disabled",
    "fieldtype": "Check",
    "label": "Disabled"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_custom",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Is Custom"
   },
   {
    "default": "1",
@@ -57,32 +82,9 @@
    "label": "Two Factor Authentication"
   },
   {
-   "fieldname": "restrict_to_domain",
-   "fieldtype": "Link",
-   "label": "Restrict To Domain",
-   "options": "Domain"
-  },
-  {
-   "description": "Route: Example \"/desk\"",
-   "fieldname": "home_page",
-   "fieldtype": "Data",
-   "label": "Home Page"
-  },
-  {
-   "fieldname": "column_break_4",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "fieldname": "is_custom",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "label": "Is Custom"
-  },
-  {
-   "fieldname": "configure_section",
+   "fieldname": "role_profiles_section",
    "fieldtype": "Section Break",
-   "label": "Configure"
+   "label": "Role Profiles"
   },
   {
    "fieldname": "role_profiles_html",
@@ -128,6 +130,16 @@
    "fieldname": "page_roles_html",
    "fieldtype": "HTML",
    "label": "Pages"
+  },
+  {
+   "fieldname": "workspace_tab",
+   "fieldtype": "Tab Break",
+   "label": "Workspaces"
+  },
+  {
+   "fieldname": "workspace_roles_html",
+   "fieldtype": "HTML",
+   "label": "Workspaces"
   }
  ],
  "icon": "fa fa-bookmark",

--- a/frappe/desk/page/desktop/desktop.json
+++ b/frappe/desk/page/desktop/desktop.json
@@ -5,7 +5,7 @@
  "doctype": "Page",
  "icon": "",
  "idx": 0,
- "modified": "2025-10-08 13:31:06.525425",
+ "modified": "2026-06-17 12:56:17.129975",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "desktop",
@@ -14,6 +14,9 @@
  "roles": [
   {
    "role": "All"
+  },
+  {
+   "role": "Sales User"
   }
  ],
  "script": null,

--- a/frappe/desk/page/desktop/desktop.json
+++ b/frappe/desk/page/desktop/desktop.json
@@ -14,9 +14,6 @@
  "roles": [
   {
    "role": "All"
-  },
-  {
-   "role": "Sales User"
   }
  ],
  "script": null,

--- a/frappe/public/js/desk.bundle.js
+++ b/frappe/public/js/desk.bundle.js
@@ -46,6 +46,7 @@ import "./frappe/form/multi_select_dialog.js";
 import "./frappe/ui/dialog.js";
 import "./frappe/ui/menu.js";
 import "./frappe/ui/capture.js";
+import "./frappe/ui/embedded_list.js";
 import "./frappe/ui/app_icon.js";
 import "./frappe/ui/theme_switcher.js";
 

--- a/frappe/public/js/frappe/ui/embedded_list.js
+++ b/frappe/public/js/frappe/ui/embedded_list.js
@@ -65,7 +65,9 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 					this.add_button.label || __("+ Add")
 			  }</button>`
 			: "";
-		const search = `<input type="text" class="form-control form-control-sm embedded-list-search" data-action="search" placeholder="${__("Search")}">`;
+		const search = `<input type="text" class="form-control form-control-sm embedded-list-search" data-action="search" placeholder="${__(
+			"Search"
+		)}">`;
 
 		if (!title && !description && !add) {
 			this.$header.hide();
@@ -359,11 +361,19 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 
 	run_action(action, row) {
 		const refresh = () => this.refresh();
+		const run = () =>
+			Promise.resolve(action.action(row, refresh)).catch((e) => {
+				frappe.msgprint({
+					title: __("Error"),
+					message: (e && e.message) || __("Action failed."),
+					indicator: "red",
+				});
+			});
 		if (action.confirm) {
 			const label = action.confirm_field ? row[action.confirm_field] : "";
-			frappe.confirm(__(action.confirm, [label]), () => action.action(row, refresh));
+			frappe.confirm(__(action.confirm, [label]), run);
 		} else {
-			action.action(row, refresh);
+			run();
 		}
 	}
 

--- a/frappe/public/js/frappe/ui/embedded_list.js
+++ b/frappe/public/js/frappe/ui/embedded_list.js
@@ -164,13 +164,13 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 		const count = Math.min(remaining, this.page_size);
 		$(
 			`<div class="embedded-list-more">
-				<button class="btn btn-xs btn-default" data-action="load-more">
-					${__("Load {0} more", [count])}
-				</button>
 				<span class="embedded-list-count">${__("Showing {0} of {1}", [
 					this.rendered_count,
 					this.data.length,
 				])}</span>
+				<button class="btn btn-xs btn-default" data-action="load-more">
+					${__("Load More")}
+				</button>
 			</div>`
 		).appendTo(this.$result);
 	}

--- a/frappe/public/js/frappe/ui/embedded_list.js
+++ b/frappe/public/js/frappe/ui/embedded_list.js
@@ -1,0 +1,353 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+// MIT License. See LICENSE
+
+frappe.provide("frappe.ui");
+
+frappe.ui.EmbeddedList = class EmbeddedList {
+	constructor(opts) {
+		Object.assign(
+			this,
+			{
+				page_size: 50,
+				empty_message: __("No records found."),
+				loading_message: __("Loading..."),
+				error_message: __("Failed to load data."),
+				columns: [],
+				filters: {},
+				fields: ["name"],
+				order_by: null,
+			},
+			opts
+		);
+
+		// `wrapper` may be a jQuery object or a raw element.
+		this.$wrapper = this.wrapper instanceof jQuery ? this.wrapper : $(this.wrapper);
+
+		this.data = [];
+		this.rendered_count = 0;
+
+		this.make();
+	}
+
+	make() {
+		this.$wrapper.addClass("embedded-list");
+		this.$header = $('<div class="embedded-list-header"></div>').appendTo(this.$wrapper);
+		this.$loading = $(
+			`<div class="embedded-list-loading text-muted">${this.loading_message}</div>`
+		)
+			.appendTo(this.$wrapper)
+			.hide();
+		this.$error = $(`<div class="embedded-list-error text-danger"></div>`)
+			.appendTo(this.$wrapper)
+			.hide();
+		this.$result = $(`<div class="embedded-list-result"></div>`)
+			.appendTo(this.$wrapper)
+			.hide();
+		this.$no_result = $(
+			`<div class="embedded-list-no-result text-muted">${this.empty_message}</div>`
+		)
+			.appendTo(this.$wrapper)
+			.hide();
+
+		this.render_header();
+		this.bind_events();
+	}
+
+	// Header: title + description on the left, an optional Add button on the
+	// right. Always visible (so rows can be added even when the list is empty).
+	render_header() {
+		const title = this.title ? `<div class="embedded-list-title">${this.title}</div>` : "";
+		const description = this.description
+			? `<div class="embedded-list-description">${this.description}</div>`
+			: "";
+		const add = this.add_button
+			? `<button class="btn btn-xs btn-default" data-action="add-row">${
+					this.add_button.label || __("+ Add")
+			  }</button>`
+			: "";
+
+		if (!title && !description && !add) {
+			this.$header.hide();
+			return;
+		}
+		this.$header.html(
+			`<div class="embedded-list-heading">${title}${description}</div>
+			<div class="embedded-list-header-actions">${add}</div>`
+		);
+	}
+
+	// --- Data ---
+
+	// Override `get_args` to customise the query without replacing `get_data`.
+	get_args() {
+		return {
+			filters: this.filters,
+			fields: this.fields,
+			order_by: this.order_by,
+			limit: 0,
+		};
+	}
+
+	// Override `get_data` for multi-doctype / merge logic. Must return a Promise
+	// that resolves to an array of row objects.
+	get_data() {
+		if (!this.doctype) {
+			// eslint-disable-next-line no-console
+			console.error("EmbeddedList: set `doctype` or override `get_data()`.");
+			return Promise.resolve([]);
+		}
+		return frappe.db.get_list(this.doctype, this.get_args());
+	}
+
+	refresh() {
+		this.$error.hide();
+		this.$result.hide();
+		this.$no_result.hide();
+		this.$loading.show();
+
+		return this.get_data()
+			.then((data) => {
+				this.data = data || [];
+				this.$loading.hide();
+				this.before_render();
+				this.render();
+				this.after_render();
+				this.toggle_result_area();
+			})
+			.catch((e) => {
+				// eslint-disable-next-line no-console
+				console.error("EmbeddedList: failed to load data", e);
+				this.$loading.hide();
+				this.$error.text(this.error_message).show();
+			});
+	}
+
+	before_render() {}
+	after_render() {}
+
+	render() {
+		this.rendered_count = 0;
+		this.$result.empty();
+
+		if (!this.data.length) return;
+
+		// The table sits inside a rounded, bordered container; the footer
+		// (load-more / count) sits outside it.
+		const $wrap = $('<div class="embedded-list-table-wrap"></div>');
+		const $table = $(`
+			<table class="embedded-list-table">
+				<thead>${this.build_header_html()}</thead>
+				<tbody></tbody>
+			</table>
+		`);
+		$wrap.append($table).appendTo(this.$result);
+		this.$tbody = $table.find("tbody");
+
+		this.render_more();
+	}
+
+	render_more() {
+		const next = this.data.slice(this.rendered_count, this.rendered_count + this.page_size);
+		const rows_html = next
+			.map((row, i) => this.build_row_html(row, this.rendered_count + i))
+			.join("");
+		this.$tbody.append(rows_html);
+		this.rendered_count += next.length;
+		this.render_load_more();
+	}
+
+	render_load_more() {
+		this.$result.find(".embedded-list-more").remove();
+		if (this.rendered_count >= this.data.length) return;
+
+		const remaining = this.data.length - this.rendered_count;
+		const count = Math.min(remaining, this.page_size);
+		$(
+			`<div class="embedded-list-more">
+				<button class="btn btn-xs btn-default" data-action="load-more">
+					${__("Load {0} more", [count])}
+				</button>
+				<span class="embedded-list-count">${__("Showing {0} of {1}", [
+					this.rendered_count,
+					this.data.length,
+				])}</span>
+			</div>`
+		).appendTo(this.$result);
+	}
+
+	build_header_html() {
+		let cells = this.columns
+			.map((col) => {
+				const label = frappe.utils.escape_html(col.label || "");
+				const title = col.title ? ` title="${frappe.utils.escape_html(col.title)}"` : "";
+				const align = col.align === "center" ? ' class="text-center"' : "";
+				return `<th${align}${title}>${label}</th>`;
+			})
+			.join("");
+		if (this.show_index) {
+			cells = `<th class="embedded-list-index">${__("No.")}</th>` + cells;
+		}
+		return `<tr>${cells}</tr>`;
+	}
+
+	build_row_html(row, index) {
+		const clickable = this.on_row_click ? ' style="cursor: pointer;"' : "";
+		let cells = this.columns
+			.map((col, col_idx) => this.build_cell_html(col, col_idx, row))
+			.join("");
+		if (this.show_index) {
+			cells = `<td class="embedded-list-index">${index + 1}</td>` + cells;
+		}
+		return `<tr data-row-idx="${index}"${clickable}>${cells}</tr>`;
+	}
+
+	build_cell_html(col, col_idx, row) {
+		const align = col.align === "center" ? ' class="text-center"' : "";
+		const clickable = typeof col.on_click === "function";
+		const col_attr = clickable
+			? ` data-col-idx="${col_idx}" class="embedded-list-clickable"`
+			: "";
+
+		if (col.type === "actions") {
+			return `<td class="text-center embedded-list-actions" data-col-idx="${col_idx}">${this.build_actions_html(
+				col
+			)}</td>`;
+		}
+
+		if (typeof col.render === "function") {
+			return `<td${align}${col_attr}>${col.render(row) ?? ""}</td>`;
+		}
+
+		const raw = col.fieldname ? row[col.fieldname] : "";
+
+		if (col.type === "check") {
+			return `<td class="text-center"${col_attr}>${
+				raw ? frappe.utils.icon("tick", "xs") : ""
+			}</td>`;
+		}
+
+		if (col.type === "badge") {
+			if (raw == null || raw === "") return `<td${align}${col_attr}></td>`;
+			const color = typeof col.color === "function" ? col.color(row) : col.color || "gray";
+			return `<td${align}${col_attr}><span class="indicator-pill ${color}">${frappe.utils.escape_html(
+				raw
+			)}</span></td>`;
+		}
+
+		if (col.type === "link") {
+			// `text(row)` lets the label be computed (e.g. a fallback); otherwise
+			// the field value is used.
+			const label = typeof col.text === "function" ? col.text(row) : raw;
+			const text = frappe.utils.escape_html(label ?? "");
+			if (col.url) {
+				return `<td${align}><a href="${col.url(
+					row
+				)}" onclick="event.stopPropagation();">${text}</a></td>`;
+			}
+			// Route-based link: the delegated handler navigates and stops
+			// propagation itself, so no inline onclick (which would prevent the
+			// event from reaching that handler).
+			return `<td${align}><a href="#" data-route-link="${col_idx}">${text}</a></td>`;
+		}
+
+		return `<td${align}${col_attr}>${frappe.utils.escape_html(raw ?? "")}</td>`;
+	}
+
+	build_actions_html(col) {
+		return (col.actions || [])
+			.map((action, action_idx) => {
+				const danger = action.danger ? " text-danger" : "";
+				const title = action.label
+					? ` title="${frappe.utils.escape_html(action.label)}"`
+					: "";
+				// `xs` + currentColor matches Frappe's inline row actions (grid_row.js)
+				// so danger actions inherit the button's red instead of the muted stroke.
+				const inner = action.icon
+					? frappe.utils.icon(action.icon, "xs", "", "", "", true)
+					: frappe.utils.escape_html(action.label || "");
+				return `<button class="btn btn-xs btn-link${danger}" data-action-idx="${action_idx}"${title}>${inner}</button>`;
+			})
+			.join("");
+	}
+
+	// --- Events ---
+
+	bind_events() {
+		// Namespaced + unbound first so re-instantiating on the same wrapper
+		// (e.g. on every form refresh) does not stack duplicate handlers.
+		this.$wrapper.off(".embedded_list");
+
+		// Add row
+		this.$wrapper.on("click.embedded_list", "[data-action='add-row']", (e) => {
+			e.preventDefault();
+			if (this.add_button && this.add_button.action) {
+				this.add_button.action(() => this.refresh());
+			}
+		});
+
+		// Load more
+		this.$wrapper.on("click.embedded_list", "[data-action='load-more']", (e) => {
+			e.preventDefault();
+			this.render_more();
+		});
+
+		// Row actions
+		this.$wrapper.on(
+			"click.embedded_list",
+			".embedded-list-actions [data-action-idx]",
+			(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				const $btn = $(e.currentTarget);
+				const row = this.row_for(e);
+				const col = this.columns[parseInt($btn.closest("td").attr("data-col-idx"), 10)];
+				if (!col) return;
+				const action = col.actions[parseInt($btn.attr("data-action-idx"), 10)];
+				if (action) this.run_action(action, row);
+			}
+		);
+
+		// Clickable cells (custom on_click)
+		this.$wrapper.on("click.embedded_list", "td.embedded-list-clickable", (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			const col = this.columns[parseInt($(e.currentTarget).attr("data-col-idx"), 10)];
+			if (col && typeof col.on_click === "function") col.on_click(this.row_for(e));
+		});
+
+		// Route-based links
+		this.$wrapper.on("click.embedded_list", "a[data-route-link]", (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			const col = this.columns[parseInt($(e.currentTarget).attr("data-route-link"), 10)];
+			if (col && col.route) frappe.set_route(...col.route(this.row_for(e)));
+		});
+
+		// Whole-row click
+		this.$wrapper.on("click.embedded_list", "tr[data-row-idx]", (e) => {
+			if (!this.on_row_click) return;
+			this.on_row_click(this.row_for(e));
+		});
+	}
+
+	// Resolve the data row for an event by walking up to the <tr>.
+	row_for(e) {
+		const idx = parseInt($(e.currentTarget).closest("tr").attr("data-row-idx"), 10);
+		return this.data[idx];
+	}
+
+	run_action(action, row) {
+		const refresh = () => this.refresh();
+		if (action.confirm) {
+			const label = action.confirm_field ? row[action.confirm_field] : "";
+			frappe.confirm(__(action.confirm, [label]), () => action.action(row, refresh));
+		} else {
+			action.action(row, refresh);
+		}
+	}
+
+	toggle_result_area() {
+		this.$result.toggle(this.data.length > 0);
+		this.$no_result.toggle(this.data.length === 0);
+	}
+};

--- a/frappe/public/js/frappe/ui/embedded_list.js
+++ b/frappe/public/js/frappe/ui/embedded_list.js
@@ -65,6 +65,7 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 					this.add_button.label || __("+ Add")
 			  }</button>`
 			: "";
+		const search = `<input type="text" class="form-control form-control-sm embedded-list-search" data-action="search" placeholder="${__("Search")}">`;
 
 		if (!title && !description && !add) {
 			this.$header.hide();
@@ -72,7 +73,7 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 		}
 		this.$header.html(
 			`<div class="embedded-list-heading">${title}${description}</div>
-			<div class="embedded-list-header-actions">${add}</div>`
+			<div class="embedded-list-header-actions">${search}${add}</div>`
 		);
 	}
 
@@ -107,12 +108,10 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 
 		return this.get_data()
 			.then((data) => {
-				this.data = data || [];
+				this._all_data = data || [];
 				this.$loading.hide();
 				this.before_render();
-				this.render();
-				this.after_render();
-				this.toggle_result_area();
+				this._apply_filter();
 			})
 			.catch((e) => {
 				// eslint-disable-next-line no-console
@@ -120,6 +119,23 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 				this.$loading.hide();
 				this.$error.text(this.error_message).show();
 			});
+	}
+
+	_apply_filter() {
+		const term = (this.$wrapper.find("[data-action='search']").val() || "")
+			.trim()
+			.toLowerCase();
+		this.data = term
+			? this._all_data.filter((row) =>
+					Object.values(row).some(
+						(val) => val != null && String(val).toLowerCase().includes(term)
+					)
+			  )
+			: [...this._all_data];
+		this.rendered_count = 0;
+		this.render();
+		this.after_render();
+		this.toggle_result_area();
 	}
 
 	before_render() {}
@@ -276,6 +292,11 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 		// Namespaced + unbound first so re-instantiating on the same wrapper
 		// (e.g. on every form refresh) does not stack duplicate handlers.
 		this.$wrapper.off(".embedded_list");
+
+		// Search
+		this.$wrapper.on("input.embedded_list", "[data-action='search']", () => {
+			this._apply_filter();
+		});
 
 		// Add row
 		this.$wrapper.on("click.embedded_list", "[data-action='add-row']", (e) => {

--- a/frappe/public/scss/desk/embedded_list.scss
+++ b/frappe/public/scss/desk/embedded_list.scss
@@ -1,0 +1,141 @@
+.embedded-list {
+	--icon-stroke: var(--text-muted);
+
+	.embedded-list-loading,
+	.embedded-list-error {
+		padding: var(--padding-sm) 0;
+		font-size: var(--text-md);
+	}
+
+	.embedded-list-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: var(--padding-md);
+		margin-bottom: 12px;
+	}
+
+	.embedded-list-title {
+		font-weight: 600;
+		font-size: var(--text-md);
+		color: var(--text-color);
+		margin-bottom: 2px;
+	}
+
+	.embedded-list-description {
+		font-size: var(--text-sm);
+		color: var(--text-muted);
+	}
+
+	.embedded-list-header-actions {
+		flex-shrink: 0;
+	}
+
+	.embedded-list-table-wrap {
+		border: 1px solid var(--border-color);
+		border-radius: var(--border-radius-md);
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+		margin-bottom: 16px;
+	}
+
+	table.embedded-list-table {
+		width: 100%;
+		margin-bottom: 0;
+		border-collapse: collapse;
+		font-size: var(--text-md);
+		color: var(--text-color);
+
+		thead tr {
+			background: var(--subtle-fg);
+		}
+
+		th {
+			padding: 8px 10px;
+			font-weight: 400;
+			color: var(--text-muted);
+			border-bottom: 1px solid var(--border-color);
+			white-space: nowrap;
+		}
+
+		td {
+			padding: 0 10px;
+			height: 38px;
+			border-bottom: 1px solid var(--border-color);
+			vertical-align: middle;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			max-width: 320px;
+		}
+
+		tbody tr:last-child td {
+			border-bottom: none;
+		}
+
+		tbody tr:hover {
+			background: var(--highlight-color);
+		}
+
+		a {
+			color: var(--text-color);
+		}
+
+		.embedded-list-index {
+			width: 42px;
+			text-align: center;
+			color: var(--text-muted);
+			font-size: var(--text-sm);
+		}
+
+		.embedded-list-clickable {
+			cursor: pointer;
+		}
+
+		// Inline row actions sit on the right, muted until hovered.
+		.embedded-list-actions {
+			width: 1%;
+			white-space: nowrap;
+			text-align: right;
+
+			.btn-link {
+				padding: 4px;
+				line-height: 1;
+				border-radius: var(--border-radius);
+				color: var(--text-muted);
+				text-decoration: none;
+
+				&:hover {
+					color: var(--text-color);
+					background-color: var(--bg-color);
+				}
+
+				&.text-danger:hover {
+					color: var(--red-500);
+				}
+			}
+		}
+	}
+
+	.embedded-list-no-result {
+		text-align: center;
+		padding: 40px 20px;
+		color: var(--text-muted);
+		border: 1px dashed var(--border-color);
+		border-radius: var(--border-radius-md);
+		margin-bottom: 14px;
+	}
+
+	.embedded-list-more {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-top: 10px;
+		margin-bottom: 16px;
+
+		.embedded-list-count {
+			font-size: var(--text-sm);
+			color: var(--text-muted);
+		}
+	}
+}

--- a/frappe/public/scss/desk/embedded_list.scss
+++ b/frappe/public/scss/desk/embedded_list.scss
@@ -29,12 +29,17 @@
 
 	.embedded-list-header-actions {
 		flex-shrink: 0;
+		display: flex;
+		align-items: center;
+		gap: var(--padding-sm);
 	}
 
 	.embedded-list-table-wrap {
 		border: 1px solid var(--border-color);
 		border-radius: var(--border-radius-md);
 		overflow-x: auto;
+		overflow-y: auto;
+		max-height: 600px;
 		-webkit-overflow-scrolling: touch;
 		margin-bottom: 16px;
 	}
@@ -45,6 +50,12 @@
 		border-collapse: collapse;
 		font-size: var(--text-md);
 		color: var(--text-color);
+
+		thead {
+			position: sticky;
+			top: 0;
+			z-index: 1;
+		}
 
 		thead tr {
 			background: var(--subtle-fg);
@@ -59,8 +70,7 @@
 		}
 
 		td {
-			padding: 0 10px;
-			height: 38px;
+			padding: 10px;
 			border-bottom: 1px solid var(--border-color);
 			vertical-align: middle;
 			white-space: nowrap;
@@ -99,15 +109,15 @@
 			text-align: right;
 
 			.btn-link {
-				padding: 4px;
+				padding: 2px 4px;
 				line-height: 1;
-				border-radius: var(--border-radius);
 				color: var(--text-muted);
 				text-decoration: none;
+				background: none;
 
 				&:hover {
 					color: var(--text-color);
-					background-color: var(--bg-color);
+					background: none;
 				}
 
 				&.text-danger:hover {

--- a/frappe/public/scss/desk/embedded_list.scss
+++ b/frappe/public/scss/desk/embedded_list.scss
@@ -34,6 +34,10 @@
 		gap: var(--padding-sm);
 	}
 
+	.embedded-list-search {
+		width: 180px;
+	}
+
 	.embedded-list-table-wrap {
 		border: 1px solid var(--border-color);
 		border-radius: var(--border-radius-md);

--- a/frappe/public/scss/desk/index.scss
+++ b/frappe/public/scss/desk/index.scss
@@ -49,6 +49,7 @@
 @import "data_import";
 @import "driver";
 @import "role_editor";
+@import "embedded_list";
 @import "user_profile";
 @import "theme_switcher";
 @import "link_preview";


### PR DESCRIPTION
Rewrites the Role doctype form to surface all role-related data in one place, replacing the previous approach of navigating to separate doctypes to understand what a role controls.

### What's new

- **EmbeddedList component** - reusable `frappe.ui.EmbeddedList` backed by a custom SCSS stylesheet, registered in `desk.bundle.js`. Handles rendering, pagination, row actions, and route-based navigation. All tabs use it.
- **Tabbed interface on the Role form** - five tabs added via `role.json`: Users, Documents, Reports, Pages, Workspaces
- **Role Profiles section** - shown on the Details tab (always visible, not behind a tab click)

### Per-tab behaviour

**Users**
- Lists enabled users assigned this role (full name, email).
- Add User dialog with a User link field filtered to exclude already-assigned users.
- Per-row remove with a confirm prompt before removing.
- Clicking a row navigates to the User form.

**Documents**
- Lists DocPerm and Custom DocPerm rows for the role, one row per DocType with flag columns (Read, Write, Create, Delete, Submit, Cancel, Amend) and a Source column.
- Clicking a row opens an edit dialog titled "Standard Permission for X" or "Custom Permission for X" based on source, with the DocType and permlevel read-only.
- Remove action dispatches to the correct backend path based on the row's source.

**Reports**
- Lists reports this role can access.
- Clicking a row navigates to the live report — `query-report/<name>` for Query and Script reports, Report Builder path for builder reports.
- Per-row remove with a confirm prompt before removing.

**Pages**
- Lists desk pages accessible to this role.
- Clicking a row navigates to the Page form.
- Per-row remove with a confirm prompt before removing.

**Workspaces**
- Lists workspaces visible to this role.
- Clicking a row navigates directly to the workspace.
- Per-row remove with a confirm prompt before removing.

All tabs lazy-load on activation and re-fetch on every tab switch so external changes made on the User, Page, Report, or Workspace form reflect immediately without a full page reload.

- [ ] Update docs

no-docs

## Screenshots

<img width="1194" height="484" alt="Screenshot 2026-06-17 at 7 45 39 PM" src="https://github.com/user-attachments/assets/b5b88de6-1fc0-46ee-9cba-1509688019cb" />
<img width="1143" height="561" alt="Screenshot 2026-06-17 at 7 48 55 PM" src="https://github.com/user-attachments/assets/1657f0af-79f8-479c-accc-43f18136e8a2" />
<img width="1146" height="833" alt="Screenshot 2026-06-17 at 7 49 25 PM" src="https://github.com/user-attachments/assets/37058aef-1eba-4764-bc13-a2949c818b94" />
<img width="974" height="837" alt="Screenshot 2026-06-19 at 2 50 42 PM" src="https://github.com/user-attachments/assets/6cee1b7d-6853-4bad-8e14-d010b0910067" />
<img width="1194" height="833" alt="Screenshot 2026-06-17 at 7 50 12 PM" src="https://github.com/user-attachments/assets/486662f2-5561-4744-9cef-4c5aceba6756" />
<img width="1190" height="617" alt="Screenshot 2026-06-17 at 7 50 25 PM" src="https://github.com/user-attachments/assets/a672191e-3611-4ca8-8303-f7e5b787d12c" />
<img width="1191" height="646" alt="Screenshot 2026-06-17 at 7 50 32 PM" src="https://github.com/user-attachments/assets/487f067b-fc99-4a68-9bee-f07deab58437" />

