### PR TITLE
fix(sidebar): workspace sidebar not loading correctly on Kanban views

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -796,7 +796,7 @@ frappe.ui.Sidebar = class Sidebar {
 				// ["query-report", "Balance Sheet"] -> entity is the second element
 				return route[1];
 			default:
-				return route[0];
+				return route[1];
 		}
 	}
 


### PR DESCRIPTION
- The workspace sidebar was showing the wrong navigation when opening a Kanban board. 

https://github.com/user-attachments/assets/2c0360c1-5aae-4823-b079-39fe2df08bdf


- This PR fixes it so the correct sidebar always loads regardless of the view type.

https://github.com/user-attachments/assets/4ffaf724-971f-4d58-a373-1eae7d9b0cf9

