### PR TITLE
fix: link-field dropdown clipped by grid scroll container

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -308,7 +308,15 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			const dropdownRect = dropdown.getBoundingClientRect();
 			const viewportWidth = window.innerWidth;
 
-			if (dropdownRect.right > viewportWidth) {
+			// Also clamp against the nearest grid scroll container so the
+			// dropdown right-aligns when the column is near the container's
+			// right edge, not just the viewport edge.
+			const gridContainer = me.$input[0].closest(".form-grid-container");
+			const rightBoundary = gridContainer
+				? gridContainer.getBoundingClientRect().right
+				: viewportWidth;
+
+			if (dropdownRect.right > Math.min(viewportWidth, rightBoundary)) {
 				dropdown.classList.add("awesomplete-align-right");
 			} else {
 				dropdown.classList.remove("awesomplete-align-right");

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -801,16 +801,13 @@
 	}
 }
 
-// When a link-field dropdown is open inside the grid, lift horizontal
-// overflow clipping so the absolutely-positioned listbox is not truncated
-// by the scroll container's right edge. This rule is intentionally placed
-// after grid-row-open so it wins when a dropdown is opened inside an
-// expanded row. overflow-x: visible; overflow-y: clip avoids touching the
-// y-axis (preventing scroll-position reset in Safari) while still removing
-// the x-axis scroll container that causes the clipping.
+// When a link-field dropdown is open inside the grid, remove the scroll
+// container so the absolutely-positioned listbox is not clipped. The
+// dropdown extends both to the right (wide names) and downward (last rows),
+// so both axes must be visible. Placed after grid-row-open so this wins
+// when a dropdown opens inside an expanded row.
 .form-grid-container:has(.awesomplete > ul:not([hidden])) {
-	overflow-x: visible;
-	overflow-y: clip;
+	overflow: visible;
 }
 .sortable-handle span {
 	width: 31px;

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -792,6 +792,13 @@
 	width: 100%;
 }
 
+// When a link-field dropdown is open inside the grid, lift the overflow
+// clipping so the absolutely-positioned listbox is not truncated by the
+// scroll container's right edge.
+.form-grid-container:has(.awesomplete > ul:not([hidden])) {
+	overflow: unset;
+}
+
 .form-grid-container:has(.grid-row.grid-row-open) {
 	overflow-x: clip;
 	white-space: normal;

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -792,13 +792,6 @@
 	width: 100%;
 }
 
-// When a link-field dropdown is open inside the grid, lift the overflow
-// clipping so the absolutely-positioned listbox is not truncated by the
-// scroll container's right edge.
-.form-grid-container:has(.awesomplete > ul:not([hidden])) {
-	overflow: unset;
-}
-
 .form-grid-container:has(.grid-row.grid-row-open) {
 	overflow-x: clip;
 	white-space: normal;
@@ -806,6 +799,18 @@
 	.form-grid {
 		left: 0px !important;
 	}
+}
+
+// When a link-field dropdown is open inside the grid, lift horizontal
+// overflow clipping so the absolutely-positioned listbox is not truncated
+// by the scroll container's right edge. This rule is intentionally placed
+// after grid-row-open so it wins when a dropdown is opened inside an
+// expanded row. overflow-x: visible; overflow-y: clip avoids touching the
+// y-axis (preventing scroll-position reset in Safari) while still removing
+// the x-axis scroll container that causes the clipping.
+.form-grid-container:has(.awesomplete > ul:not([hidden])) {
+	overflow-x: visible;
+	overflow-y: clip;
 }
 .sortable-handle span {
 	width: 31px;


### PR DESCRIPTION
## Problem

On doctypes with child tables (Delivery Note, Purchase Receipt, Sales Invoice, Purchase Order, etc.), the Link field dropdown for warehouse/item columns appears truncated — long option names are cut off mid-text.

**Root cause:** `.form-grid-container` has `overflow-x: auto` to enable horizontal scrolling of wide tables. This creates a CSS overflow formatting context that clips all absolutely-positioned descendants extending beyond its right edge. The awesomplete listbox (`position: absolute`) falls inside this context, so it is clipped when the column is near the right side of the table.

The existing JS handler that right-aligns the dropdown when it overflows the viewport also fails here: it measures `dropdownRect.right` after the listbox is already clipped, so the check never triggers for container-boundary overflow (only for viewport overflow).

## Fix

**`grid.scss`** — Add a `:has()` rule that lifts `overflow` to `unset` on `.form-grid-container` while any awesomplete listbox is open. This removes the scroll-container boundary so the dropdown renders fully. `overflow-x: auto` is restored the moment the dropdown closes.

```scss
.form-grid-container:has(.awesomplete > ul:not([hidden])) {
    overflow: unset;
}
```

**`link.js`** — Extend the `awesomplete-open` right-alignment check to also compare against the grid container's right boundary, so the dropdown right-aligns when a column is near the container edge (not just the viewport edge).

```js
const gridContainer = me.$input[0].closest(".form-grid-container");
const rightBoundary = gridContainer
    ? gridContainer.getBoundingClientRect().right
    : viewportWidth;

if (dropdownRect.right > Math.min(viewportWidth, rightBoundary)) {
    dropdown.classList.add("awesomplete-align-right");
}
```

## Test plan

- [ ] Open Delivery Note → add a row → click the Warehouse cell → verify the dropdown is fully visible and not cut off
- [ ] Open Purchase Receipt → click Accepted Warehouse → same check
- [ ] Create a warehouse with a very long name → confirm it appears without mid-text clipping in the dropdown
- [ ] For a column near the right edge of the table, verify the dropdown right-aligns (extends leftward) instead of being clipped
- [ ] For a column in the middle of the table, verify the dropdown still opens to the right as usual
- [ ] Verify the table's horizontal scrollbar still works normally after the dropdown is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)