### PR TITLE
feat: support YEAR query function

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -24,7 +24,7 @@ from frappe.model import OPTIONAL_FIELDS, get_permitted_fields
 from frappe.model.base_document import DOCTYPES_FOR_DOCTYPE
 from frappe.model.document import Document
 from frappe.query_builder import Criterion, Field, Order, functions
-from frappe.query_builder.custom import Month, MonthName, Quarter
+from frappe.query_builder.custom import Month, MonthName, Quarter, Year
 
 CORE_DOCTYPES = DOCTYPES_FOR_DOCTYPE | frozenset(
 	(
@@ -193,6 +193,7 @@ FUNCTION_MAPPING = {
 	"MONTHNAME": MonthName,
 	"QUARTER": Quarter,
 	"MONTH": Month,
+	"YEAR": Year,
 }
 
 # Functions that accept '*' as an argument (e.g., COUNT(*))

--- a/frappe/query_builder/custom.py
+++ b/frappe/query_builder/custom.py
@@ -178,3 +178,8 @@ class Month(_PostgresIntDatePart, Function):
 			super().__init__("date_part", "month", field, alias=alias)
 		else:
 			super().__init__("MONTH", field, alias=alias)
+
+
+class Year(Function):
+	def __init__(self, field, alias=None):
+		super().__init__("YEAR", field, alias=alias)

--- a/frappe/query_builder/custom.py
+++ b/frappe/query_builder/custom.py
@@ -180,6 +180,10 @@ class Month(_PostgresIntDatePart, Function):
 			super().__init__("MONTH", field, alias=alias)
 
 
-class Year(Function):
+class Year(_PostgresIntDatePart, Function):
 	def __init__(self, field, alias=None):
-		super().__init__("YEAR", field, alias=alias)
+		self._postgres = _is_postgres()
+		if self._postgres:
+			super().__init__("date_part", "year", field, alias=alias)
+		else:
+			super().__init__("YEAR", field, alias=alias)

--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -14,6 +14,7 @@ from frappe.query_builder.custom import (
 	Month,
 	MonthName,
 	Quarter,
+	Year,
 )
 from frappe.query_builder.utils import ImportMapper, db_type_is
 

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -1841,6 +1841,14 @@ class TestQuery(IntegrationTestCase):
 		sql = query.get_sql()
 		self.assertIn(self.normalize_sql("MAX(`creation`) `latest_user`"), sql)
 
+		# Test YEAR function
+		query = frappe.qb.get_query(
+			"User", fields=[{"YEAR": "creation", "as": "creation_year"}], group_by="creation_year"
+		)
+		sql = query.get_sql()
+		self.assertIn(self.normalize_sql("YEAR(`creation`) `creation_year`"), sql)
+		self.assertIn(self.normalize_sql("GROUP BY `creation_year`"), sql)
+
 		# Test MIN function
 		query = frappe.qb.get_query(
 			"User", fields=[{"MIN": "creation", "as": "earliest_user"}], group_by="user_type"

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -1846,8 +1846,12 @@ class TestQuery(IntegrationTestCase):
 			"User", fields=[{"YEAR": "creation", "as": "creation_year"}], group_by="creation_year"
 		)
 		sql = query.get_sql()
-		self.assertIn(self.normalize_sql("YEAR(`creation`) `creation_year`"), sql)
-		self.assertIn(self.normalize_sql("GROUP BY `creation_year`"), sql)
+		if frappe.db.db_type == "postgres":
+			self.assertIn("CAST(date_part('year'", sql)
+			self.assertIn('"creation_year"', sql)
+		else:
+			self.assertIn(self.normalize_sql("YEAR(`creation`) `creation_year`"), sql)
+		self.assertIn(self.normalize_sql("GROUP BY `creation_year`"), self.normalize_sql(sql))
 
 		# Test MIN function
 		query = frappe.qb.get_query(


### PR DESCRIPTION
Add YEAR() to the supported SQL function mapping used by frappe.get_list / frappe.get_all. This PR does that.

Currently YEAR is rejected as unsupported function

**Suggested Changes**
Add a Year query-builder function class, exposes it via frappe.query_builder.functions, and registers YEAR in the supported function mapping.

**Why?**
Grouping or filtering reports by calendar year is a common use case, and YEAR() was previously possible through raw SQL field strings. Supporting it in the new dict-based function syntax preserves that common workflow while staying within the safer query-builder parser.

Raising PR on behalf of @DanielRadlAMR .

closes #39726