### PR TITLE
fix: exclude total rows when aggregating report data for number cards

### DIFF
--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -221,8 +221,13 @@ export default class NumberCardWidget extends Widget {
 
 	get_number_for_report_card(res) {
 		const field = this.card_doc.report_field;
-		const vals = res.result.reduce((acc, col) => {
-			col[field] && acc.push(col[field]);
+		// Strip the frappe-generated total row (last row when add_total_row is set),
+		// then also skip any array-format totals and bold summary rows added by
+		// script reports directly — matching how make_chart_options excludes totals.
+		const rows = res.add_total_row ? res.result.slice(0, -1) : res.result;
+		const vals = rows.reduce((acc, row) => {
+			if (Array.isArray(row) || row.bold) return acc;
+			if (row[field]) acc.push(row[field]);
 			return acc;
 		}, []);
 		const col = res.columns.find((col) => col.fieldname == field);


### PR DESCRIPTION
## Summary

- Number card widgets with **Type = Report** were including the summary total row in Sum/Average/Min/Max calculations, producing wrong values (e.g. 7.046% instead of the true average of data rows).
- The `get_number_for_report_card` function iterated over all `res.result` rows without filtering out total rows, while `make_chart_options` in `report_utils.js` already handled this correctly for charts.

## Fix

Mirror the same exclusion logic used by `make_chart_options`:

1. Slice off the last row when `res.add_total_row` is set (frappe-generated totals appended by `add_total_row()`).
2. Skip array-format rows (also frappe-generated totals returned as arrays).
3. Skip rows with `bold: 1` (total rows added directly by script reports).

## Related

Companion PR in `frappe/erpnext`: marks the Gross Profit report's invoice-grouped total row with `bold: 1` so it is excluded by rule 3 above (the report has `add_total_row: 0` and its total is a dict, so rules 1 and 2 do not apply).