### PR TITLE
fix(user): redirect to login page if 2fa is enabled

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -24,6 +24,7 @@ from frappe.model.document import Document
 from frappe.query_builder import DocType
 from frappe.rate_limiter import rate_limit
 from frappe.sessions import clear_sessions
+from frappe.twofactor import should_run_2fa
 from frappe.utils import (
 	cint,
 	escape_html,
@@ -995,10 +996,13 @@ def update_password(
 		redirect_url = redirect_to
 		frappe.cache.hdel("redirect_after_login", user)
 
-	frappe.local.login_manager.login_as(user)
-
 	frappe.db.set_value("User", user, "last_password_reset_date", today())
 	frappe.db.set_value("User", user, "reset_password_key", "")
+
+	if key and should_run_2fa(user):
+		return "/login"
+
+	frappe.local.login_manager.login_as(user)
 
 	if user_doc.user_type == "System User":
 		return get_default_path() or "/desk"


### PR DESCRIPTION
After updating your password, you should not be logged in if 2fa is enabled, this fixes that by redirecting to login iff 2fa is enabled.

- [ ] Design?