### PR TITLE
fix: Always start with clean `frappe.local` in request/jobs

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -469,10 +469,11 @@ class init_site:
 
 def destroy():
 	"""Closes connection and releases werkzeug local."""
-	if db:
-		db.close()
-
-	release_local(local)
+	try:
+		if db:
+			db.close()
+	finally:
+		release_local(local)
 
 
 _redis_init_lock = threading.Lock()

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -279,9 +279,23 @@ if TYPE_CHECKING:  # pragma: no cover
 	lang: str
 
 
-def init(site: str, sites_path: str = ".", new_site: bool = False, force: bool = False) -> None:
+def init(
+	site: str,
+	sites_path: str = ".",
+	new_site: bool = False,
+	force: bool = False,
+	*,
+	is_request=False,
+	is_job=False,
+) -> None:
 	"""Initialize frappe for the current site. Reset thread locals `frappe.local`"""
-	if getattr(local, "initialised", None) and not force:
+	# Reset locals at start of the request.
+	# Previous request can fail in ways we might have no control over.
+	# release_local is inexpensive, so trigger it before every request/job.
+	if force:
+		release_local(local)
+
+	if getattr(local, "initialised", None):
 		return
 
 	if site and not SITE_NAME_PATTERN.match(site):
@@ -323,7 +337,7 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force: bool =
 
 	from frappe.config import get_site_config
 
-	local.conf = get_site_config(sites_path=sites_path, site_path=site_path, cached=bool(frappe.request))
+	local.conf = get_site_config(sites_path=sites_path, site_path=site_path, cached=is_request)
 	local.lang = local.conf.lang or "en"
 
 	local.module_app = None
@@ -348,7 +362,7 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force: bool =
 	if not cache or not client_cache:
 		setup_redis_cache_connection()
 
-	setup_module_map(include_all_apps=not (frappe.request or frappe.job or frappe.flags.in_migrate))
+	setup_module_map(include_all_apps=not (is_request or is_job or frappe.flags.in_migrate))
 
 	local.initialised = True
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -179,13 +179,12 @@ def run_after_request_hooks(request, response):
 
 
 def init_request(request):
-	frappe.local.request = request
-	frappe.local.request.after_response = CallbackManager()
-
-	frappe.local.is_ajax = frappe.get_request_header("X-Requested-With") == "XMLHttpRequest"
-
 	site = _site or request.headers.get("X-Frappe-Site-Name") or get_site_name(request.host)
-	frappe.init(site, sites_path=_sites_path, force=True)
+	frappe.init(site, sites_path=_sites_path, force=True, is_request=True)
+
+	frappe.local.request = request
+	frappe.local.is_ajax = frappe.get_request_header("X-Requested-With") == "XMLHttpRequest"
+	request.after_response = CallbackManager()
 
 	if not (frappe.local.conf and frappe.local.conf.db_name):
 		# site does not exist

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -146,6 +146,7 @@ class TestJinjaGlobals(IntegrationTestCase):
 		# reinit to create a new local ctx, this "simulates" two request running in two diff
 		# thread.
 		frappe.init(frappe.local.site, force=True)
+		frappe.connect()
 		second = get_jenv()
 		self.assertIsNot(first, second)
 		self.assertIsNot(first.globals, second.globals)

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -247,7 +247,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 	retval = None
 
 	if is_async:
-		frappe.init(site, force=True)
+		frappe.init(site, force=True, is_job=True)
 		frappe.connect()
 		if os.environ.get("CI"):
 			from frappe.tests.utils import toggle_test_mode
@@ -313,7 +313,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 
 	finally:
 		if not hasattr(frappe.local, "site"):
-			frappe.init(site, force=True)
+			frappe.init(site, force=True, is_job=True)
 			frappe.connect()
 		for after_job_task in frappe.get_hooks("after_job"):
 			frappe.call(after_job_task, method=method_name, kwargs=kwargs, result=retval)


### PR DESCRIPTION
- People attach things in frappe.local
- In some cases cleanup fails and stale `frappe.local` get reused for
  next job.
- It doesn't seem feasible to always ensure cleanup because request/job
  have hooks at end

It doesn't cost much to reset, so for safety I feel we should do BOTH:
fix causes of cleanup failure and cleanup before starting.


Internal notes: 
- https://gameplan.frappe.cloud/g/space/152/discussion/2250/ 
- https://frappe.io/raven/Frappe%20Cloud/threads/1eu5n5a8rj