### PR TITLE
feat: change print format creation flow

### DIFF
--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -70,7 +70,12 @@
 				:style="{ '--pfb-zoom': canvas_zoom / 100 }"
 				@click="clear_selection"
 			>
-				<KeepAlive>
+				<PrintFormatSetup
+					v-if="$store.needs_setup.value"
+					@start-default="on_start_default"
+					@start-blank="on_start_blank"
+				/>
+				<KeepAlive v-else>
 					<component :is="Preview" v-if="show_preview" />
 					<component :is="PrintFormat" v-else />
 				</KeepAlive>
@@ -82,6 +87,7 @@
 
 <script setup>
 import PrintFormat from "./components/editor/PrintFormat.vue";
+import PrintFormatSetup from "./components/editor/PrintFormatSetup.vue";
 import Preview from "./components/Preview.vue";
 import PrintFormatControls from "./components/PrintFormatControls.vue";
 import FieldInspector from "./components/inspector/FieldInspector.vue";
@@ -128,6 +134,25 @@ function toggle_preview() {
 function clear_selection() {
 	$store.value.selected_field.value = null;
 	$store.value.selected_section.value = null;
+}
+
+function on_start_default() {
+	// layout is already set to get_default_layout() — just persist and enter the builder
+	$store.value.print_format.value.format_data = JSON.stringify($store.value.layout.value);
+	$store.value.dirty.value = true;
+	$store.value.needs_setup.value = false;
+}
+
+function on_start_blank() {
+	const blank = {
+		sections: [],
+		header: { columns: [{ label: "", fields: [] }] },
+		footer: { columns: [{ label: "", fields: [] }] },
+	};
+	$store.value.layout.value = blank;
+	$store.value.print_format.value.format_data = JSON.stringify(blank);
+	$store.value.dirty.value = true;
+	$store.value.needs_setup.value = false;
 }
 
 function handle_keydown(e) {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSetup.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSetup.vue
@@ -1,0 +1,144 @@
+<template>
+	<div class="pfb-setup">
+		<div class="pfb-setup-card">
+			<div class="pfb-setup-icon" v-html="frappe.utils.icon('file', 'xl')"></div>
+			<h3 class="pfb-setup-title">{{ __("How do you want to start?") }}</h3>
+			<p class="pfb-setup-subtitle">
+				{{ __("Choose a starting point for your print format.") }}
+			</p>
+			<div class="pfb-setup-options">
+				<button class="pfb-setup-option" @click="$emit('start-default')">
+					<div
+						class="pfb-setup-option-icon"
+						v-html="frappe.utils.icon('list', 'md')"
+					></div>
+					<div class="pfb-setup-option-body">
+						<div class="pfb-setup-option-label">{{ __("Start from default") }}</div>
+						<div class="pfb-setup-option-desc">
+							{{ __("Pre-filled with all document fields. Customize from there.") }}
+						</div>
+					</div>
+					<div
+						class="pfb-setup-option-arrow"
+						v-html="frappe.utils.icon('right', 'xs')"
+					></div>
+				</button>
+				<button class="pfb-setup-option" @click="$emit('start-blank')">
+					<div
+						class="pfb-setup-option-icon"
+						v-html="frappe.utils.icon('add', 'md')"
+					></div>
+					<div class="pfb-setup-option-body">
+						<div class="pfb-setup-option-label">{{ __("Start blank") }}</div>
+						<div class="pfb-setup-option-desc">
+							{{ __("Empty canvas. Drag and drop fields to build from scratch.") }}
+						</div>
+					</div>
+					<div
+						class="pfb-setup-option-arrow"
+						v-html="frappe.utils.icon('right', 'xs')"
+					></div>
+				</button>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+defineEmits(["start-default", "start-blank"]);
+</script>
+
+<style scoped>
+.pfb-setup {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 60vh;
+	padding: var(--padding-xl);
+}
+
+.pfb-setup-card {
+	background: var(--fg-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-lg);
+	padding: var(--padding-xl);
+	max-width: 480px;
+	width: 100%;
+	text-align: center;
+	box-shadow: var(--shadow-sm);
+}
+
+.pfb-setup-icon {
+	color: var(--text-muted);
+	margin-bottom: var(--margin-md);
+}
+
+.pfb-setup-title {
+	font-size: var(--text-lg);
+	font-weight: var(--weight-semibold);
+	color: var(--text-color);
+	margin: 0 0 var(--margin-xs);
+}
+
+.pfb-setup-subtitle {
+	font-size: var(--text-sm);
+	color: var(--text-muted);
+	margin: 0 0 var(--margin-lg);
+}
+
+.pfb-setup-options {
+	display: flex;
+	flex-direction: column;
+	gap: var(--margin-sm);
+	text-align: left;
+}
+
+.pfb-setup-option {
+	display: flex;
+	align-items: center;
+	gap: var(--margin-md);
+	padding: var(--padding-md);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	background: var(--fg-color);
+	cursor: pointer;
+	transition: border-color 0.15s, background 0.15s;
+	width: 100%;
+	text-align: left;
+}
+
+.pfb-setup-option:hover {
+	border-color: var(--primary);
+	background: var(--blue-50);
+}
+
+.pfb-setup-option-icon {
+	color: var(--text-muted);
+	flex-shrink: 0;
+}
+
+.pfb-setup-option:hover .pfb-setup-option-icon {
+	color: var(--primary);
+}
+
+.pfb-setup-option-body {
+	flex: 1;
+}
+
+.pfb-setup-option-label {
+	font-size: var(--text-sm);
+	font-weight: var(--weight-semibold);
+	color: var(--text-color);
+	margin-bottom: 2px;
+}
+
+.pfb-setup-option-desc {
+	font-size: var(--text-xs);
+	color: var(--text-muted);
+}
+
+.pfb-setup-option-arrow {
+	color: var(--text-muted);
+	flex-shrink: 0;
+}
+</style>

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -10,6 +10,7 @@ export function getStore(print_format_name) {
 	let meta = ref(null);
 	let layout = ref(null);
 	let dirty = ref(false);
+	let needs_setup = ref(false);
 	let edit_letterhead = ref(false);
 	let scroll_to_section = ref(null);
 	let selected_field = ref(null);
@@ -28,7 +29,9 @@ export function getStore(print_format_name) {
 				frappe.model.with_doctype(_print_format.doc_type, () => {
 					meta.value = frappe.get_meta(_print_format.doc_type);
 					print_format.value = _print_format;
-					layout.value = get_layout() || get_default_layout();
+					const saved_layout = get_layout();
+					needs_setup.value = !saved_layout;
+					layout.value = saved_layout || get_default_layout();
 					// Migrate legacy string header/footer to section objects
 					layout.value.header = migrate_to_section(layout.value.header);
 					layout.value.footer = migrate_to_section(layout.value.footer);
@@ -228,6 +231,7 @@ export function getStore(print_format_name) {
 		meta,
 		layout,
 		dirty,
+		needs_setup,
 		edit_letterhead,
 		scroll_to_section,
 		selected_field,

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -28,10 +28,16 @@ export function getStore(print_format_name) {
 				frappe.model.with_doctype(_print_format.doc_type, () => {
 					meta.value = frappe.get_meta(_print_format.doc_type);
 					print_format.value = _print_format;
+					const had_format_data = !!get_layout();
 					layout.value = get_layout() || get_default_layout();
 					// Migrate legacy string header/footer to section objects
 					layout.value.header = migrate_to_section(layout.value.header);
 					layout.value.footer = migrate_to_section(layout.value.footer);
+					// Persist the default layout immediately so print works even if
+					// the user saves from the doctype form without opening the builder
+					if (!had_format_data) {
+						print_format.value.format_data = JSON.stringify(layout.value);
+					}
 					edit_letterhead.value = false;
 					selected_field.value = null;
 					selected_section.value = null;

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -28,16 +28,10 @@ export function getStore(print_format_name) {
 				frappe.model.with_doctype(_print_format.doc_type, () => {
 					meta.value = frappe.get_meta(_print_format.doc_type);
 					print_format.value = _print_format;
-					const had_format_data = !!get_layout();
 					layout.value = get_layout() || get_default_layout();
 					// Migrate legacy string header/footer to section objects
 					layout.value.header = migrate_to_section(layout.value.header);
 					layout.value.footer = migrate_to_section(layout.value.footer);
-					// Persist the default layout immediately so print works even if
-					// the user saves from the doctype form without opening the builder
-					if (!had_format_data) {
-						print_format.value.format_data = JSON.stringify(layout.value);
-					}
 					edit_letterhead.value = false;
 					selected_field.value = null;
 					selected_section.value = null;

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -270,84 +270,14 @@ class PrintFormatGenerator:
 	# ----- layout normalisation ------------------------------------------
 
 	def get_layout(self, print_format):
-		layout = frappe.parse_json(print_format.format_data) or self.create_default_layout(print_format)
+		layout = frappe.parse_json(print_format.format_data) or {
+			"sections": [],
+			"header": {"columns": []},
+			"footer": {"columns": []},
+		}
 		layout = self.set_field_renderers(layout)
 		layout = self.process_margin_texts(layout)
 		return layout
-
-	def create_default_layout(self, print_format):
-		"""Build a default layout from doctype meta, mirroring the JS create_default_layout."""
-		meta = frappe.get_meta(print_format.doc_type)
-		layout = {"header": {"columns": [{"label": "", "fields": []}]}, "sections": []}
-
-		section = None
-		column = None
-
-		def new_section(df=None):
-			return {"label": (df or {}).get("label") or "", "columns": [], "has_fields": False}
-
-		def new_column(df=None):
-			return {"label": (df or {}).get("label") or "", "fields": []}
-
-		def ensure_column():
-			nonlocal section, column
-			if not section:
-				section = new_section()
-				layout["sections"].append(section)
-			if not column:
-				column = new_column()
-				section["columns"].append(column)
-
-		for df in meta.fields:
-			if not df.fieldname:
-				continue
-			if df.fieldtype == "Section Break":
-				section = new_section(df.as_dict())
-				column = None
-				layout["sections"].append(section)
-			elif df.fieldtype == "Column Break":
-				if not section:
-					section = new_section()
-					layout["sections"].append(section)
-				column = new_column(df.as_dict())
-				section["columns"].append(column)
-			elif df.label and not df.print_hide:
-				ensure_column()
-				field = {
-					"label": df.label,
-					"fieldname": df.fieldname,
-					"fieldtype": df.fieldtype,
-					"options": df.options,
-				}
-				if df.fieldtype == "Table" and df.options:
-					field["table_columns"] = self._default_table_columns(df.options)
-				column["fields"].append(field)
-				section["has_fields"] = True
-
-		layout["sections"] = [s for s in layout["sections"] if s.get("has_fields")]
-		return layout
-
-	def _default_table_columns(self, child_doctype):
-		child_meta = frappe.get_meta(child_doctype)
-		columns = []
-		total_width = 0
-		for tf in child_meta.fields:
-			if tf.fieldtype in ("Section Break", "Column Break") or tf.print_hide or not tf.label:
-				continue
-			if total_width >= 100:
-				break
-			width = tf.width if (isinstance(tf.width, int) and tf.width < 100) else (20 if tf.width else 10)
-			columns.append(
-				{
-					"label": tf.label,
-					"fieldname": tf.fieldname,
-					"fieldtype": tf.fieldtype,
-					"options": tf.options,
-					"width": width,
-				}
-			)
-			total_width += width
-		return columns
 
 	def set_field_renderers(self, layout):
 		renderers = {"HTML Editor": "HTML", "Markdown Editor": "Markdown"}

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -270,7 +270,11 @@ class PrintFormatGenerator:
 	# ----- layout normalisation ------------------------------------------
 
 	def get_layout(self, print_format):
-		layout = frappe.parse_json(print_format.format_data)
+		layout = frappe.parse_json(print_format.format_data) or {
+			"sections": [],
+			"header": {"columns": []},
+			"footer": {"columns": []},
+		}
 		layout = self.set_field_renderers(layout)
 		layout = self.process_margin_texts(layout)
 		return layout

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -270,14 +270,84 @@ class PrintFormatGenerator:
 	# ----- layout normalisation ------------------------------------------
 
 	def get_layout(self, print_format):
-		layout = frappe.parse_json(print_format.format_data) or {
-			"sections": [],
-			"header": {"columns": []},
-			"footer": {"columns": []},
-		}
+		layout = frappe.parse_json(print_format.format_data) or self.create_default_layout(print_format)
 		layout = self.set_field_renderers(layout)
 		layout = self.process_margin_texts(layout)
 		return layout
+
+	def create_default_layout(self, print_format):
+		"""Build a default layout from doctype meta, mirroring the JS create_default_layout."""
+		meta = frappe.get_meta(print_format.doc_type)
+		layout = {"header": {"columns": [{"label": "", "fields": []}]}, "sections": []}
+
+		section = None
+		column = None
+
+		def new_section(df=None):
+			return {"label": (df or {}).get("label") or "", "columns": [], "has_fields": False}
+
+		def new_column(df=None):
+			return {"label": (df or {}).get("label") or "", "fields": []}
+
+		def ensure_column():
+			nonlocal section, column
+			if not section:
+				section = new_section()
+				layout["sections"].append(section)
+			if not column:
+				column = new_column()
+				section["columns"].append(column)
+
+		for df in meta.fields:
+			if not df.fieldname:
+				continue
+			if df.fieldtype == "Section Break":
+				section = new_section(df.as_dict())
+				column = None
+				layout["sections"].append(section)
+			elif df.fieldtype == "Column Break":
+				if not section:
+					section = new_section()
+					layout["sections"].append(section)
+				column = new_column(df.as_dict())
+				section["columns"].append(column)
+			elif df.label and not df.print_hide:
+				ensure_column()
+				field = {
+					"label": df.label,
+					"fieldname": df.fieldname,
+					"fieldtype": df.fieldtype,
+					"options": df.options,
+				}
+				if df.fieldtype == "Table" and df.options:
+					field["table_columns"] = self._default_table_columns(df.options)
+				column["fields"].append(field)
+				section["has_fields"] = True
+
+		layout["sections"] = [s for s in layout["sections"] if s.get("has_fields")]
+		return layout
+
+	def _default_table_columns(self, child_doctype):
+		child_meta = frappe.get_meta(child_doctype)
+		columns = []
+		total_width = 0
+		for tf in child_meta.fields:
+			if tf.fieldtype in ("Section Break", "Column Break") or tf.print_hide or not tf.label:
+				continue
+			if total_width >= 100:
+				break
+			width = tf.width if (isinstance(tf.width, int) and tf.width < 100) else (20 if tf.width else 10)
+			columns.append(
+				{
+					"label": tf.label,
+					"fieldname": tf.fieldname,
+					"fieldtype": tf.fieldtype,
+					"options": tf.options,
+					"width": width,
+				}
+			)
+			total_width += width
+		return columns
 
 	def set_field_renderers(self, layout):
 		renderers = {"HTML Editor": "HTML", "Markdown Editor": "Markdown"}

--- a/frappe/www/printpreview.py
+++ b/frappe/www/printpreview.py
@@ -10,7 +10,7 @@ def get_context(context):
 
 	pf = frappe.get_doc("Print Format", print_format)
 
-	if pf.get("print_format_builder_beta"):
+	if pf.get("print_format_builder_beta") and pf.get("format_data"):
 		from frappe.utils.print_format_generator import get_html
 
 		context.body = get_html(pf.doc_type, docname, print_format, letterhead)

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -72,7 +72,7 @@ def get_context(context) -> PrintContext:
 
 	print_format = get_print_format_doc(None, meta=meta)
 
-	if print_format and print_format.get("print_format_builder_beta"):
+	if print_format and print_format.get("print_format_builder_beta") and print_format.get("format_data"):
 		from frappe.utils.print_format_generator import get_html
 
 		body = get_html(
@@ -357,7 +357,7 @@ def get_html_and_style(
 	print_format = get_print_format_doc(print_format, meta=document.meta)
 	set_link_titles(document)
 
-	if print_format and print_format.get("print_format_builder_beta"):
+	if print_format and print_format.get("print_format_builder_beta") and print_format.get("format_data"):
 		from frappe.utils.print_format_generator import PrintFormatGenerator
 
 		generator = PrintFormatGenerator(print_format.name, document, None if no_letterhead else letterhead)


### PR DESCRIPTION
- Fix letterhead images overflowing in builder preview and print (CSS max-width, no hardcoded height cap)
- Generate default layout from doctype meta when format_data is empty so new formats print all fields without requiring builder open
- Fix printpreview crashing for non-beta formats and respect no_letterhead flag
- Minor: remove blue hover color on breadcrumb, improve page number badge styling



https://github.com/user-attachments/assets/742169c0-901c-47ca-b3e5-5db92145a985


`no-docs`