### PR TITLE
fix(print): fallback to default letterhead when stored one is disabled

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -417,20 +417,22 @@ frappe.ui.form.PrintView = class {
 	}
 
 	set_default_letterhead() {
-		if (this.frm.doc.letter_head) {
-			this.letterhead_selector.val(this.frm.doc.letter_head);
-			return;
-		}
+		const get_default = () =>
+			frappe.db
+				.get_value(
+					"Letter Head",
+					{ disabled: 0, is_default: 1, letter_head_for: "DocType" },
+					"name"
+				)
+				.then(({ message }) => this.letterhead_selector.val(message?.name || ""));
+
+		if (!this.frm.doc.letter_head) return get_default();
 
 		return frappe.db
-			.get_value(
-				"Letter Head",
-				{ disabled: 0, is_default: 1, letter_head_for: "DocType" },
-				"name"
-			)
-			.then(({ message }) => {
-				if (message?.name) this.letterhead_selector.val(message.name);
-			});
+			.get_value("Letter Head", { name: this.frm.doc.letter_head, disabled: 0 }, "name")
+			.then(({ message }) =>
+				message?.name ? this.letterhead_selector.val(message.name) : get_default()
+			);
 	}
 
 	set_user_lang() {

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -424,7 +424,9 @@ frappe.ui.form.PrintView = class {
 					{ disabled: 0, is_default: 1, letter_head_for: "DocType" },
 					"name"
 				)
-				.then(({ message }) => this.letterhead_selector.val(message?.name || ""));
+				.then(({ message }) => {
+					if (message?.name) this.letterhead_selector.val(message.name);
+				});
 
 		if (!this.frm.doc.letter_head) return get_default();
 


### PR DESCRIPTION
Resolve: #40093

----

**Before:**

https://github.com/user-attachments/assets/463bed57-a237-4441-9dd2-a58dd2bcb62e


**After**

https://github.com/user-attachments/assets/965b63af-5da1-4fdc-9a2d-fa9b2a208b82


