### PR TITLE
fix: allow Desk users to read global search settings

### DIFF
--- a/frappe/desk/doctype/global_search_settings/global_search_settings.json
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.json
@@ -35,11 +35,8 @@
    "write": 1
   },
   {
-   "email": 1,
-   "print": 1,
    "read": 1,
-   "role": "Desk User",
-   "share": 1
+   "role": "Desk User"
   }
  ],
  "quick_entry": 1,

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.json
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "creation": "2019-09-03 16:08:21.333698",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -17,7 +18,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-03-23 16:03:26.580482",
+ "modified": "2026-06-18 19:49:32.063572",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Global Search Settings",
@@ -32,9 +33,17 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Desk User",
+   "share": 1
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/frappe/desk/doctype/global_search_settings/test_global_search_settings.py
+++ b/frappe/desk/doctype/global_search_settings/test_global_search_settings.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestGlobalSearchSettings(IntegrationTestCase):
+	"""
+	Integration tests for GlobalSearchSettings.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass


### PR DESCRIPTION
Desk users should be able to read global search settings - we fetch the DocTypes available in Global Search to show filters in the UI. Desk users should not be able to write to these settings.

`no-docs`

Fixes #40100 