### PR TITLE
refactor(print-format): combine onload template queries using or_filters

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -55,17 +55,15 @@ class PrintFormat(Document):
 	# end: auto-generated types
 
 	def onload(self):
-		specific = frappe.get_all(
+		templates = frappe.get_all(
 			"Print Format Field Template",
 			fields=["template", "field", "name"],
-			filters={"document_type": self.doc_type},
+			or_filters=[
+				["document_type", "=", self.doc_type],
+				["document_type", "is", "not set"],
+			],
 		)
-		generic = frappe.get_all(
-			"Print Format Field Template",
-			fields=["template", "field", "name"],
-			filters={"document_type": ("is", "not set")},
-		)
-		self.set_onload("print_templates", specific + generic)
+		self.set_onload("print_templates", templates)
 
 	def before_save(self):
 		if self.print_format_for == "Report":

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -62,6 +62,7 @@ class PrintFormat(Document):
 				["document_type", "=", self.doc_type],
 				["document_type", "is", "not set"],
 			],
+			order_by="document_type desc",
 		)
 		self.set_onload("print_templates", templates)
 


### PR DESCRIPTION
- Replace two separate `frappe.get_all` calls in `PrintFormat.onload` with a single query using `or_filters`