### PR TITLE
fix: check "Include filters" by default in report print/PDF settings

### DIFF
--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -78,6 +78,7 @@ frappe.ui.get_print_settings = function (
 			fieldtype: "Check",
 			fieldname: "include_filters",
 			depends_on: "eval: !doc.print_format",
+			default: 1,
 		});
 	}
 


### PR DESCRIPTION
Closes #35265 

Before :
<img width="2022" height="1094" alt="image" src="https://github.com/user-attachments/assets/e90cfb3a-9dca-4e83-a5d0-9357c5f7fcdb" />

After : 
<img width="711" height="525" alt="image" src="https://github.com/user-attachments/assets/e2f59da6-b7ec-4ad7-8014-1d1930144735" />

