### PR TITLE
fix: reject malformed address headers (backport #39842)

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -465,6 +465,7 @@ class Email:
 	def set_from(self):
 		# gmail mailing-list compatibility
 		# use X-Original-Sender if available, as gmail sometimes modifies the 'From'
+		self.from_real_name = None
 		_from_email = self.decode_email(self.mail.get("X-Original-From") or self.mail["From"])
 		_reply_to = self.decode_email(self.mail.get("Reply-To"))
 
@@ -491,12 +492,28 @@ class Email:
 	def decode_email(email):
 		if not email:
 			return
+
+		raw_email = email if isinstance(email, str) else email.decode("utf-8", "replace")
 		decoded = ""
 		for part, encoding in decode_header(frappe.as_unicode(email).replace('"', " ").replace("'", " ")):
 			if encoding:
 				decoded += part.decode(encoding, "replace")
 			else:
 				decoded += safe_decode(part)
+
+		# Reject malformed address headers where decoding synthesizes a bare addr-spec.
+		# Allow valid encoded display-name forms like "=?utf-8?...?= <user@example.com>".
+		if decoded and "@" in decoded and "@" not in raw_email:
+			decoded_addr_spec = parse_addr(decoded)[1]
+			if decoded_addr_spec and decoded.strip() == decoded_addr_spec:
+				frappe.log_error(
+					title=_("Malformed Address Header"),
+					message=_("Rejected malformed encoded address header with synthesized '@': {0}").format(
+						repr(raw_email)
+					),
+				)
+				return None
+
 		return decoded
 
 	def set_content_and_type(self):

--- a/frappe/email/test_email_body.py
+++ b/frappe/email/test_email_body.py
@@ -239,6 +239,25 @@ Reply-To: test2_@erpnext.com
 		)
 		self.assertIn("user@example.com", mail)
 
+	def test_rejects_encoded_addr_spec_without_raw_at_sign(self):
+		email = Email.decode_email("=?utf-8?Q?admin=40example=2Ecom?=")
+		self.assertIsNone(email)
+
+		content_bytes = b"""MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Content-Transfer-Encoding: 8bit
+To: support@example.com
+From: =?utf-8?Q?admin=40example=2Ecom?=
+"""
+
+		mail = Email(content_bytes)
+		self.assertIsNone(mail.from_email)
+
+	def test_allows_encoded_display_name_with_valid_addr_spec(self):
+		email = Email.decode_email("=?utf-8?Q?Jane_Doe?= <jane@example.com>")
+		self.assertIn("jane@example.com", email)
+
 
 def fixed_column_width(string, chunk_size):
 	parts = [string[0 + i : chunk_size + i] for i in range(0, len(string), chunk_size)]


### PR DESCRIPTION
Backport of #39842 to `version-15-hotfix`.

Rejects malformed encoded address headers where decoding synthesizes a bare addr-spec (e.g. `=?utf-8?Q?admin=40example=2Ecom?=`), while still allowing valid encoded display-name forms like `=?utf-8?...?= <user@example.com>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)