### PR TITLE
fix(report): write report date columns as real excel date cells

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -425,7 +425,7 @@ def _export_query(form_params, csv_params, populate_response=True):
 
 		data["result"] = filtered_result
 
-	format_fields(data)
+	format_fields(data, file_format_type)
 
 	xlsx_data, column_widths, styles = build_xlsx_data(
 		data,
@@ -478,7 +478,9 @@ def valid_report_name(report_name, suffix):
 	return False
 
 
-def format_fields(data: frappe._dict) -> None:
+def format_fields(data: frappe._dict, file_format_type: str | None = None) -> None:
+	stringify_dates = file_format_type != "Excel"
+
 	for i, col in enumerate(data.columns):
 		if col.get("fieldtype") == "Duration":
 			for row in data.result:
@@ -492,13 +494,13 @@ def format_fields(data: frappe._dict) -> None:
 				val = row.get(index) if isinstance(row, dict) else row[index]
 				if val:
 					row[index] = round(val, col.get("precision"))
-		elif col.get("fieldtype") == "Date":
+		elif col.get("fieldtype") == "Date" and stringify_dates:
 			for row in data.result:
 				index = col.get("fieldname") if isinstance(row, dict) else i
 				val = row.get(index) if isinstance(row, dict) else row[index]
 				if val:
 					row[index] = formatdate(val)
-		elif col.get("fieldtype") == "Datetime":
+		elif col.get("fieldtype") == "Datetime" and stringify_dates:
 			for row in data.result:
 				index = col.get("fieldname") if isinstance(row, dict) else i
 				val = row.get(index) if isinstance(row, dict) else row[index]

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -123,7 +123,9 @@ class TestQueryReport(IntegrationTestCase):
 
 		# the Date column carries a date number_format so Excel renders it as a date
 		date_style = {}
-		for sid in styles["column_styles"][0]:
+		col0_style_ids = styles["column_styles"].get(0)
+		self.assertIsNotNone(col0_style_ids, "No column style registered for the Date column")
+		for sid in col0_style_ids:
 			date_style.update(styles["styles"][sid])
 		self.assertIn("num_format", date_style)
 

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import datetime
+
 import frappe
-from frappe.desk.query_report import build_xlsx_data, export_query, run
+from frappe.desk.query_report import build_xlsx_data, export_query, format_fields, run
 from frappe.tests import IntegrationTestCase
 from frappe.utils.xlsxutils import XLSXMetadata, XLSXStyleBuilder, make_xlsx
 
@@ -89,6 +91,47 @@ class TestQueryReport(IntegrationTestCase):
 		for row in xlsx_data:
 			# column_b should be 'str' even with composite cell value
 			self.assertEqual(type(row[1]), str)
+
+	def test_xlsx_export_preserves_date_objects(self):
+		"""Date/Datetime columns must reach Excel as real date objects, while CSV keeps strings"""
+
+		posting_date = datetime.date(2026, 6, 1)
+		created_on = datetime.datetime(2026, 6, 1, 9, 30)
+
+		def make_data():
+			return frappe._dict(
+				report_name="",
+				columns=[
+					{"label": "Posting Date", "fieldname": "posting_date", "fieldtype": "Date"},
+					{"label": "Created On", "fieldname": "created_on", "fieldtype": "Datetime"},
+				],
+				result=[{"posting_date": posting_date, "created_on": created_on}],
+				filters={},
+				applied_filters={},
+			)
+
+		# Excel: date objects are preserved so make_xlsx can write real date cells
+		excel_data = make_data()
+		format_fields(excel_data, "Excel")
+		self.assertEqual(excel_data.result[0]["posting_date"], posting_date)
+		self.assertIsInstance(excel_data.result[0]["created_on"], datetime.datetime)
+
+		# build_xlsx_data passes the date through untouched for the Excel sheet
+		xlsx_data, _, styles = build_xlsx_data(excel_data, build_styles=True)
+		self.assertIsInstance(xlsx_data[1][0], datetime.date)
+		self.assertIsInstance(xlsx_data[1][1], datetime.datetime)
+
+		# the Date column carries a date number_format so Excel renders it as a date
+		date_style = {}
+		for sid in styles["column_styles"][0]:
+			date_style.update(styles["styles"][sid])
+		self.assertIn("num_format", date_style)
+
+		# CSV (default): dates are stringified for display
+		csv_data = make_data()
+		format_fields(csv_data)
+		self.assertIsInstance(csv_data.result[0]["posting_date"], str)
+		self.assertIsInstance(csv_data.result[0]["created_on"], str)
 
 	def test_csv(self):
 		from csv import QUOTE_ALL, QUOTE_MINIMAL, QUOTE_NONE, QUOTE_NONNUMERIC, DictReader


### PR DESCRIPTION
## Bug

Exporting Query Reports and Script Reports to Excel writes `Date` and `Datetime` columns as text instead of native Excel date values. As a result, Excel and Google Sheets treat them as strings, preventing date formatting, calculations, and filtering.

## Root Cause

`_export_query` calls `format_fields(data)` before generating the export. `format_fields` converts `Date` and `Datetime` values into display strings using `formatdate` and `format_datetime`, so `make_xlsx` receives plain strings rather than date objects.

Although the XLSX export pipeline already supports native `datetime.date` and `datetime.datetime` values and applies the correct date format, those objects never reach it.

## Fix

`format_fields` now accepts an optional `file_format_type` parameter. When exporting to Excel, `Date` and `Datetime` values are left unchanged so they are written as native Excel date cells. CSV exports continue to use string values since CSV has no native date type.

## Note

Reports that return pre-formatted date strings will still export them as text, since no date object is available to preserve.
 
---

Ref: https://support.frappe.io/helpdesk/tickets/70291?view=VIEW-HD+Ticket-1252