### PR TITLE
fix: exclude virtual child doctypes from linked docs query

### DIFF
--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -627,7 +627,8 @@ def get_linked_fields(doctype, without_ignore_user_permissions_enabled=False):
 	for doctype_name in links_dict:
 		ret[doctype_name] = {"fieldname": links_dict.get(doctype_name)}
 	table_doctypes = frappe.get_all(
-		"DocType", filters=[["istable", "=", "1"], ["name", "in", tuple(links_dict)]]
+		"DocType",
+		filters=[["istable", "=", "1"], ["is_virtual", "=", "0"], ["name", "in", tuple(links_dict)]],
 	)
 	child_filters = [
 		["fieldtype", "in", frappe.model.table_fields],

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -153,6 +153,54 @@ class TestLinkedWith(IntegrationTestCase):
 
 		self.assertRaises(frappe.LinkExistsError, doc.delete)
 
+	def test_virtual_child_table_excluded_from_linked_docs(self):
+		"""A virtual istable doctype with a Link field has no real table, so it must be excluded
+		from linked docs rather than resolved to its parent and queried."""
+		target = new_doctype("Linked Target DocType", issingle=1)
+		target.insert()
+
+		virtual_child = new_doctype(
+			"Virtual Linked Child",
+			fields=[
+				{
+					"label": "Target Link",
+					"fieldname": "target_link",
+					"fieldtype": "Link",
+					"options": "Linked Target DocType",
+				}
+			],
+		)
+		virtual_child.is_virtual = 1
+		virtual_child.istable = 1
+		virtual_child.insert()
+
+		parent = new_doctype(
+			"Virtual Child Parent",
+			fields=[
+				{
+					"label": "Items",
+					"fieldname": "items",
+					"fieldtype": "Table",
+					"options": "Virtual Linked Child",
+					"is_virtual": 1,
+				}
+			],
+			issingle=1,
+		)
+		parent.insert()
+
+		try:
+			linkinfo = linked_with.get_linked_doctypes("Linked Target DocType")
+
+			# the virtual child must not survive as a top-level link or be buried as a parent's child_doctype
+			self.assertNotIn("Virtual Linked Child", linkinfo)
+			self.assertNotIn(
+				"Virtual Linked Child", [info.get("child_doctype") for info in linkinfo.values()]
+			)
+		finally:
+			for doctype in ("Virtual Child Parent", "Virtual Linked Child", "Linked Target DocType"):
+				frappe.delete_doc("DocType", doctype)
+
 	def test_reserved_keywords(self):
 		dt_name = "Test " + "".join(random.sample(string.ascii_lowercase, 10))
 		new_doctype(


### PR DESCRIPTION
## Summary

Fix a crash in **Show Links** when opening an Item that is referenced by a virtual child table.

The issue occurred because reverse-link discovery attempted to query a virtual child doctype (`Work Order Additional Item`) that has `is_virtual=1` and therefore no backing database table. This resulted in the following error:

```
MySQLdb.OperationalError: (1054, "Unknown column 'tabWork Order Additional Item.item_code' in 'WHERE'")
```

## Root Cause

`Show Links` performs reverse-link discovery by scanning doctypes that contain links to the current document and querying them through `frappe.get_all`.

Virtual doctypes are intended to be excluded from this process:

* `get_dynamic_linked_fields` skips virtual doctypes using `meta.is_virtual`
* `get_linked_fields` removes virtual doctypes from the final result set

However, a gap existed for **virtual child tables**.

In `get_linked_fields`, child table doctypes are reparented under their parent doctype before the virtual-doctype filtering logic executes. As a result, a virtual child table such as `Work Order Additional Item` is no longer present as a top-level entry and bypasses the existing filter. The virtual child then reaches `get_linked_docs`, where a database query is attempted against a non-existent table.

## Fix

Exclude virtual doctypes from the `table_doctypes` lookup used during child-table reparenting.

By preventing virtual child tables from being reparented, they remain top-level entries and are removed by the existing virtual-doctype filtering logic before reverse-link queries are executed.

## Impact

* Prevents crashes when **Show Links** encounters virtual child tables.
* Keeps virtual doctypes consistently excluded across all linked-document discovery paths.
* Preserves existing behavior for non-virtual child tables, which continue to resolve under their parent doctypes.
* Aligns reverse-link discovery with the expectation that virtual doctypes cannot participate in SQL-based link scans because they do not have backing database tables.

---

Ref: https://support.frappe.io/helpdesk/tickets/71797?view=VIEW-HD+Ticket-1252