### PR TITLE
fix(report): rows bypass user permissions with multiple link fields

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1782,6 +1782,7 @@ class Engine:
 			if not user_permissions:
 				return match_filters
 
+			permission_filters = {}
 			for df in self.get_doctype_link_fields(self.doctype):
 				if df.get("ignore_user_permissions"):
 					continue
@@ -1805,7 +1806,10 @@ class Engine:
 							docs.append(doc)
 
 					if docs:
-						match_filters.append({options: docs})
+						permission_filters[options] = docs
+
+			if permission_filters:
+				match_filters.append(permission_filters)
 
 			return match_filters
 

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -125,6 +125,25 @@ class TestPermissions(IntegrationTestCase):
 		self.assertTrue("_Test Blog Post 1" in names)
 		self.assertFalse("_Test Blog Post" in names)
 
+	def test_user_permissions_in_report_with_multiple_link_fields(self):
+		from frappe.desk.query_report import get_user_match_filters
+
+		add_user_permission("Test Blog Category", "_Test Blog Category 1", "test2@example.com")
+		add_user_permission("Test Blogger", "_Test Blogger 1", "test2@example.com")
+
+		frappe.set_user("test2@example.com")
+		match_filters = get_user_match_filters(["Test Blog Post"], "test2@example.com")
+
+		filter_list = match_filters["Test Blog Post"]
+		self.assertEqual(len(filter_list), 1)
+		self.assertEqual(
+			filter_list[0],
+			{
+				"Test Blog Category": ["_Test Blog Category 1"],
+				"Test Blogger": ["_Test Blogger 1"],
+			},
+		)
+
 	def test_default_values(self):
 		doc = frappe.new_doc("Test Blog Post")
 		self.assertFalse(doc.get("blog_category"))


### PR DESCRIPTION
Closes #39863

## Problem

Reports return records that a user should not have access to when User Permissions apply to more than one link field on the report's DocType.

When permissions exist on multiple link fields, a row is included if it matches the allowed value for **any** restricted field, rather than requiring it to match **all** restricted fields.

### Root Cause

`Engine.build_match_conditions(as_condition=False)` in `frappe/database/query.py` appends a separate permission dictionary for each link field to `match_filters`.

`has_match` in `frappe/desk/query_report.py` evaluates these entries using OR logic within a doctype:

```python
matched_for_doctype = matched_for_doctype or match
```

As a result, restrictions on different link fields are evaluated independently and combined with OR semantics, allowing records that satisfy only one permission constraint to pass.

Prior to #35857, `db_query.add_user_permissions` merged all link-field permissions into a single dictionary:

```python
{
    "Salutation": ["Mr"],
    "Gender": ["Male"]
}
```

This structure is evaluated by `has_match` using AND semantics across fields. After #35857, the report path migrated to the new Query Engine and this merging behavior was lost.

## Fix

Restore the legacy permission evaluation behavior by collecting permitted values for all link fields into a single permission dictionary before appending to `match_filters`.

### Before

```python
[
    {"Salutation": ["Mr"]},
    {"Gender": ["Male"]}
]
```

### After

```python
[
    {
        "Salutation": ["Mr"],
        "Gender": ["Male"]
    }
]
```

This ensures:

* Different link-field restrictions are evaluated using AND logic.
* Multiple allowed values within the same field continue to use OR logic.
* Report permission behavior remains consistent with the legacy `db_query` implementation.