### PR TITLE
fix(portal): render list pages for doctypes without a custom template

### DIFF
--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -219,8 +219,8 @@ def get_address_list(doctype, txt, filters, limit_start, limit_page_length=20, o
 	user = frappe.session.user
 
 	if not filters:
-		filters = []
-	filters.append(("Address", "owner", "=", user))
+		filters = frappe._dict()
+	filters["owner"] = user
 
 	return get_list(doctype, txt, filters, limit_start, limit_page_length)
 

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -145,7 +145,7 @@ def get_list_context(context, doctype, web_form_name=None):
 		list_context.row_template = meta.get_row_template()
 
 	if not meta.custom and not list_context.list_template:
-		list_context.template = meta.get_list_template()
+		list_context.template = meta.get_list_template() or "www/portal.html"
 
 	return list_context
 

--- a/frappe/www/portal.html
+++ b/frappe/www/portal.html
@@ -18,7 +18,7 @@
         <p>{{ introduction }}</p>
     {% endif %}
 
-    {% include list_template %}
+    {% include list_template or "templates/includes/list/list.html" %}
 
     {% if list_footer %}
         {{ list_footer }}


### PR DESCRIPTION
Fixes #39799

Portal lists for doctypes that opt in via `get_list_context` but do not provide a custom `_list.html` template could fail with a 500 error. This happened because `get_list_context` overwrote the page template with `None` when no custom list template existed, causing Jinja template loading to fail.

Restore the missing fallback behavior by defaulting to the current portal page and list partial when no custom template is defined. Doctypes with custom list pages remain unchanged, module-level `list_template` overrides continue to work, and the renderer gate introduced in #35182 is unaffected.
