### PR TITLE
fix: render text fields as rich text

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -118,8 +118,6 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 	{%- endif %}
 	{%- if df.fieldtype=="Code" %}
 		<pre class="value">{{ doc.get(df.fieldname)|e }}</pre>
-	{%- elif df.fieldtype=="Long Text" -%}
-		{{ doc.get_formatted(df.fieldname, parent_doc or doc, translated=df.translatable)|e }}
 	{%- else -%}
 		{{ doc.get_formatted(df.fieldname, parent_doc or doc, translated=df.translatable) }}
 	{%- endif -%}
@@ -169,9 +167,6 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 	{% elif df.fieldtype=="Currency" %}
 		{{ doc.get_formatted(df.fieldname, parent_doc or doc, translated=df.translatable) }}
 	{% elif df.fieldtype=="Data" %}
-		{%- set parent = parent_doc or doc -%}
-		{{ doc.get_formatted(df.fieldname, parent, translated=df.translatable, absolute_value=parent.absolute_value) |e }}
-	{% elif df.fieldtype=="Long Text" %}
 		{%- set parent = parent_doc or doc -%}
 		{{ doc.get_formatted(df.fieldname, parent, translated=df.translatable, absolute_value=parent.absolute_value) |e }}
 	{% else %}

--- a/frappe/utils/formatters.py
+++ b/frappe/utils/formatters.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import datetime
+import re
 
 from dateutil.parser import ParserError
 
@@ -18,6 +19,8 @@ from frappe.utils import (
 	format_timedelta,
 	formatdate,
 )
+
+BLOCK_TAGS_PATTERN = re.compile(r"(<br|<div|<p)")
 
 
 def format_value(value, df=None, doc=None, currency=None, translated=False, format=None):
@@ -94,8 +97,9 @@ def format_value(value, df=None, doc=None, currency=None, translated=False, form
 	elif df.get("fieldtype") == "Percent":
 		return f"{flt(value, 2)}%"
 
-	elif df.get("fieldtype") in ("Text", "Small Text"):
-		return frappe.utils.escape_html(frappe.safe_decode(value)).replace("\n", "<br>")
+	elif df.get("fieldtype") in ("Text", "Small Text", "Long Text"):
+		if not BLOCK_TAGS_PATTERN.search(value):
+			return frappe.safe_decode(value).replace("\n", "<br>")
 
 	elif df.get("fieldtype") == "Markdown Editor":
 		return frappe.utils.markdown(value)


### PR DESCRIPTION
Allowing this for now, but eventually needs to be rendered as Plain Txt. after migrations in frappe/erpnext#54718.

closes #40102

related to #39892
closes Ticket 71895
