### PR TITLE
ci: skip greptile review when not needed

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,5 +1,5 @@
 {
     "disabledLabels": [
-        "conflicts"
+        "conflicts", "skip-greptile"
     ]
 }


### PR DESCRIPTION
skip greptile review when not needed based on label `skip-greptile`