### PR TITLE
fix(schema): actionable error when a DocType exceeds the database row size limit

### DIFF
--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -48,6 +48,25 @@ class TestDocType(IntegrationTestCase):
 			doc = new_doctype(name).insert()
 			doc.delete()
 
+	def test_max_fields_row_size_limit(self):
+		# When syncing a table fails because it exceeds the database row size limit
+		# (too many fields), the raw DB error should be replaced with an actionable
+		# message that points to the documented field limit.
+		from frappe.database.schema import DBTable
+
+		table = DBTable("User")
+
+		with (
+			patch.object(table, "alter", side_effect=Exception("Row size too large")),
+			patch.object(frappe.db, "is_db_table_size_limit", return_value=True),
+		):
+			with self.assertRaises(frappe.ValidationError) as cm:
+				table.sync()
+
+		message = str(cm.exception)
+		self.assertIn("too many fields", message)
+		self.assertIn("maximum-number-of-fields-in-a-form", message)
+
 	@skipIf(
 		frappe.conf.db_type == "sqlite",
 		"Not for SQLite for now",

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -45,11 +45,40 @@ class DBTable:
 		if self.meta.get("is_virtual"):
 			# no schema to sync for virtual doctypes
 			return
-		if self.is_new():
-			self.create()
-		else:
-			frappe.client_cache.delete_value(f"table_columns::{self.table_name}")
-			self.alter()
+		try:
+			if self.is_new():
+				self.create()
+			else:
+				frappe.client_cache.delete_value(f"table_columns::{self.table_name}")
+				self.alter()
+		except Exception as e:
+			if frappe.db.is_db_table_size_limit(e):
+				self._throw_max_fields_exceeded(e)
+			raise
+
+	def _throw_max_fields_exceeded(self, exc):
+		"""Raise a user-friendly error when a table exceeds the database row size limit.
+
+		This typically happens when a DocType has too many fields (often after adding
+		several custom fields). The underlying database error ("Row size too large") is
+		not actionable for end users, so point them to the documented limit instead.
+		"""
+		docs_link = "https://docs.frappe.io/erpnext/maximum-number-of-fields-in-a-form"
+		frappe.throw(
+			_(
+				"{0} has too many fields to fit in a single database row, which is limited by the database."
+			).format(frappe.bold(_(self.doctype)))
+			+ "<br><br>"
+			+ _(
+				"{0}: Reorganise the fields to stay within the limit — for example, move a group of"
+				" related fields into a child table, or split them across separate linked DocTypes."
+			).format(frappe.bold(_("Possible Fix")))
+			+ "<br><br>"
+			+ _("Refer to {0} for detailed steps.").format(
+				f'<a href="{docs_link}" target="_blank">{_("Maximum number of fields in a form")}</a>'
+			),
+			title=_("Maximum Fields Limit Exceeded"),
+		)
 
 	def create(self):
 		pass


### PR DESCRIPTION
## Problem

Adding too many fields to a DocType (commonly via custom fields) can exceed the database's maximum row size (65535 bytes for MariaDB/MySQL). The save fails with an opaque, non-actionable error:

```
Row size too large. The maximum row size for the used table type, not counting
BLOBs, is 65535. ... You have to change some columns to TEXT or BLOBs
(pymysql.err.OperationalError 1118)
```

End users have no idea what to do with this.

## Fix

`DBTable.sync()` now catches the row-size-limit error (via the existing `frappe.db.is_db_table_size_limit` helper, which was defined but unused) and raises a clear, actionable message:

> **Maximum Fields Limit Exceeded**
> {DocType} has too many fields to fit in a single database row, which is limited by the database.
>
> **Possible Fix:** Reorganise the fields to stay within the limit — for example, move a group of related fields into a child table, or split them across separate linked DocTypes.
>
> Refer to [Maximum number of fields in a form](https://docs.frappe.io/erpnext/maximum-number-of-fields-in-a-form) for detailed steps.

The handling is centralized in `sync()`, so it covers both `create()` (new table) and `alter()` (adding fields to an existing table), across all DB backends (the helper exists on each).

## Testing

- Reproduced the exact 1118 error by creating a DocType with enough `Data` fields to exceed the row size, and confirmed the friendly message replaces the raw error.
- Added `test_max_fields_row_size_limit` (mocks the row-size DB error during sync and asserts the actionable message is raised).