### PR TITLE
fix(model): self-heal a write that fails because a field's column is missing

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -846,6 +846,9 @@ class BaseDocument:
 				# unique constraint
 				self.show_unique_validation_message(e)
 
+			elif self._recover_missing_column(e):
+				return self.db_insert(ignore_if_duplicate=ignore_if_duplicate)
+
 			else:
 				raise
 		else:
@@ -853,6 +856,32 @@ class BaseDocument:
 				frappe.db.release_savepoint(save_point)
 
 		self.set("__islocal", False)
+
+	def _recover_missing_column(self, exc) -> bool:
+		"""Self-heal a write that failed because a defined field's column is missing.
+
+		When the database table is out of sync with the DocType (the field exists in the meta
+		but its column was never created), recreate the column by re-syncing the schema so the
+		write can be retried — the user's save just works instead of erroring.
+
+		Returns True if the schema was re-synced and the caller should retry the write. Returns
+		False for any other unknown column (a genuine bug, typo, or dropped non-field column),
+		so the original error is preserved. If the column cannot be recreated (for example the
+		row size limit is exceeded), the actionable error from the schema sync propagates.
+		"""
+		# Only attempt the recovery once per write to avoid an endless retry loop.
+		if self.flags.get("schema_resync_attempted") or not frappe.db.is_missing_column(exc):
+			return False
+
+		match = re.search(r"column ['\"]?(\w+)['\"]?", str(exc), flags=re.IGNORECASE)
+		column = match.group(1) if match else None
+		if not column or not self.meta.get_field(column):
+			return False
+
+		self.flags.schema_resync_attempted = True
+		frappe.db.updatedb(self.doctype)
+		frappe.clear_cache(doctype=self.doctype)
+		return True
 
 	def db_update(self):
 		if self.get("__islocal") or not self.name:
@@ -903,6 +932,8 @@ class BaseDocument:
 
 			if frappe.db.is_unique_key_violation(e):
 				self.show_unique_validation_message(e)
+			elif self._recover_missing_column(e):
+				return self.db_update()
 			else:
 				raise
 		else:

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -35,6 +35,32 @@ class TestDocument(IntegrationTestCase):
 		d = frappe.get_doc({"doctype": "User"})
 		self.assertEqual(d.get("roles"), [])
 
+	def test_missing_column_self_heals(self):
+		# A write that fails because a defined field's column is missing from the table should
+		# recreate the column and retry, so the save succeeds instead of erroring.
+		dt = new_doctype(fields=[{"label": "FG", "fieldname": "custom_fg", "fieldtype": "Data"}]).insert().name
+		try:
+			frappe.db.sql_ddl(f"ALTER TABLE `tab{dt}` DROP COLUMN `custom_fg`")
+			frappe.db.commit()
+			frappe.clear_cache(doctype=dt)
+			self.assertNotIn("custom_fg", frappe.db.get_table_columns(dt))
+
+			# insert should self-heal: recreate the column and save successfully
+			doc = frappe.get_doc({"doctype": dt, "custom_fg": "value"}).insert()
+			self.assertTrue(doc.name)
+			frappe.clear_cache(doctype=dt)
+			self.assertIn("custom_fg", frappe.db.get_table_columns(dt))
+
+			# an unknown column that is not a defined field is NOT recovered
+			self.assertFalse(
+				frappe.new_doc(dt)._recover_missing_column(
+					Exception("(1054, \"Unknown column 'not_a_field' in 'field list'\")")
+				)
+			)
+		finally:
+			frappe.delete_doc("DocType", dt, force=True)
+			frappe.db.commit()
+
 	def test_load(self):
 		d = frappe.get_doc("DocType", "User")
 		self.assertEqual(d.doctype, "DocType")


### PR DESCRIPTION
## Problem

A document write can fail with an opaque error when a field exists in the DocType's metadata but its column was never created in the table:

```
Unknown column 'custom_fg_item_name' in 'INSERT INTO'
(pymysql.err.OperationalError 1054)
```

The table schema is out of sync with the DocType (e.g. a migration didn't fully apply, or a column couldn't be added). The user just sees a raw stack trace with no way forward.

## Fix

<img width="1764" height="698" alt="Screenshot 2026-06-26 at 4 00 50 PM" src="https://github.com/user-attachments/assets/35f1316d-3c78-47de-8970-7ace866c9b2e" />

 
`db_insert()` / `db_update()` now detect this and **self-heal**: when the missing column maps to a field that exists in the DocType's meta, the column is recreated by re-syncing the schema and the write is **retried once** — so the user's save just works, with no error.

Safeguards:
- **Only** triggers when the missing column is a defined field. Any other unknown column (a genuine bug, typo, or dropped non-field column) keeps its original error.
- Retries **at most once** per write (a flag guards against loops).
- If the column **can't** be recreated (for example the table exceeds the row size limit), the actionable error from the schema sync propagates instead of a raw one — e.g. *"… has too many fields to fit in a single database row…"* (see #40144).

## Behaviour

| Case | Result |
|---|---|
| Column can be recreated | Save **just works** (column recreated + write retried) |
| Column can't be recreated (too many fields) | One clear, actionable error |
| Unknown column (not a field) | Original error preserved |

## Testing

- Reproduced the exact 1054 (field in meta, column dropped from the table) and confirmed the insert now self-heals and succeeds.
- Confirmed the over-limit case surfaces the actionable "too many fields" error rather than a raw one.
- `test_missing_column_self_heals`: drops a field's column, inserts → column recreated and doc saved; an unknown non-field column is not recovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)