### PR TITLE
fix: add distro to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "croniter~=6.2.2",
     "cryptography~=48.0.1",
     "cssutils~=2.15.0",
+    "distro~=1.9.0",
     "email-reply-parser~=0.5.12",
     "Faker~=40.23.0",
     "gunicorn @ git+https://github.com/frappe/gunicorn@f189de0ec3143581d8826f707343fa36c3fb0184",


### PR DESCRIPTION
`get_linux_distribution_info()` in `frappe/utils/print_utils.py` does 'import distro' but the package was never declared as a dependency, causing `ModuleNotFoundError: No module named 'distro'` when downloading Chromium for PDF generation.

<img width="975" height="656" alt="image" src="https://github.com/user-attachments/assets/ea0f449a-1fe7-46fe-8799-067086bf7c50" />


Regression introduced in 964dd6c0347eb8f0a50084bb618e4b3cc10207bd (feat: Chrome PDF generator).