### PR TITLE
fix: show address title requirement in form and quick entry

### DIFF
--- a/frappe/contacts/doctype/address/address.json
+++ b/frappe/contacts/doctype/address/address.json
@@ -34,9 +34,11 @@
    "options": "fa fa-map-marker"
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "address_title",
    "fieldtype": "Data",
-   "label": "Address Title"
+   "label": "Address Title",
+   "mandatory_depends_on": "eval:!doc.links?.length"
   },
   {
    "fieldname": "address_type",
@@ -151,7 +153,7 @@
  "icon": "fa fa-map-marker",
  "idx": 5,
  "links": [],
- "modified": "2024-03-23 16:01:27.068028",
+ "modified": "2026-06-20 16:01:27.068028",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Address",


### PR DESCRIPTION
## Problem

Creating an Address without a title fails on save with:

```text
Address Title is mandatory.
```

The field does not display a required indicator in the standard form, and it is omitted entirely from the Quick Entry dialog. As a result, users receive no indication that a title is required until save is rejected. In Quick Entry, the field cannot be populated at all.

## Root Cause

`address_title` is not marked as `reqd` in the Address DocType. Instead, the requirement is enforced in `Address.autoname` (`address.py`), which throws an error when:

- `address_title` is empty, and
- no link row exists from which a title can be derived.

Since `autoname` executes before `validate` during insert, it only has access to the links provided by the client.

Because the field has neither a `reqd` flag nor a `mandatory_depends_on` condition:

- the standard form does not render a required-field indicator (`*`), and
- the Quick Entry builder excludes the field because it only includes fields marked as `reqd` or `allow_in_quick_entry`.

## Fix

Add the following properties to `address_title`:

- `mandatory_depends_on: eval:!doc.links?.length`
- `allow_in_quick_entry`

The `mandatory_depends_on` condition mirrors the existing `autoname` logic: a title is required only when there are no linked documents available to derive one from.

| Links Present | address_title Behavior |
|---------------|------------------------|
| No            | Required (`*` shown)   |
| Yes           | Optional, auto-derived |

Address creation flows from Customer and Contact already populate the links table client-side in `address.js`, so those workflows continue to function without requiring manual title entry.

Adding `allow_in_quick_entry` ensures the field is available in the Quick Entry dialog, where the same dependency condition controls whether it is marked as required.

This makes the requirement visible before save in both the standard form and Quick Entry, eliminating the current validation surprise.

## Behavior Before

<img width="608" height="828" alt="Screenshot 2026-06-20 at 7 54 48 PM" src="https://github.com/user-attachments/assets/49a1e023-dfc7-4178-90b9-40ed64608f75" />

<img width="1453" height="338" alt="Screenshot 2026-06-20 at 7 57 51 PM" src="https://github.com/user-attachments/assets/8c02f87e-2aa5-4d09-a6b7-80edbe8a0697" />

## Behavior After

<img width="621" height="860" alt="Screenshot 2026-06-20 at 7 53 06 PM" src="https://github.com/user-attachments/assets/e2e766b2-7ace-4ec4-85dc-c2541a1a0f67" />

<img width="1455" height="350" alt="Screenshot 2026-06-20 at 7 59 18 PM" src="https://github.com/user-attachments/assets/0bf3f18b-8478-4ec9-a810-659b26053aa7" />
