### PR TITLE
fix(form): don't show saved toast when quick entry insert fails

### DIFF
--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -260,6 +260,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm extends frappe.ui.Dialog {
 					} else {
 						me.process_after_insert(r);
 					}
+					resolve(me.dialog.doc);
 				},
 				error: function () {
 					if (!me.skip_redirect_on_error) {
@@ -268,7 +269,6 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm extends frappe.ui.Dialog {
 				},
 				always: function () {
 					me.dialog.working = false;
-					resolve(me.dialog.doc);
 				},
 			});
 		});


### PR DESCRIPTION
## Problem

Saving from a Quick Entry dialog with invalid data shows a green "`<name>` saved" toast alongside the red validation error. The document is never inserted, so the success notification contradicts the actual outcome.

## Root Cause

`insert()` in `quick_entry.js` returns a Promise that resolves inside the `always` callback of `frappe.call`.

Since `always` executes on both success and error, the Promise resolves even when `frappe.client.save` fails with a validation error. As a result, the primary action handler's `.then()` callback still runs, hiding the dialog and displaying the success toast despite the failed save.

## Fix

Move `resolve(me.dialog.doc)` from the `always` callback into the success callback, after the `submit` / `process_after_insert` branch completes.

This ensures that:

* The Promise resolves only after a successful save.
* Validation and server-side errors no longer trigger the success path.
* The dialog remains open when save fails.
* The green success toast is shown only when the document is actually created.

The `working` flag reset remains in `always`, allowing users to correct the error and retry without refreshing the dialog.

## Behavior Before

https://github.com/user-attachments/assets/e7568b89-a0a8-4a99-aba0-9afae6d03ab5


## Behavior After

* Invalid save triggers a validation error.
* Quick Entry dialog remains open.
* No success toast is shown.
* User can correct the data and retry.
* Success toast appears only after a successful insert.


