### PR TITLE
fix: default assigned-to and liked-by filters to "like" instead of "="

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2773,6 +2773,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					});
 				} else if (Array.isArray(value)) {
 					filters.push([doctype, field, value[0], value[1]]);
+				} else if (["_assign", "_liked_by"].includes(field)) {
+					// stored as a JSON array, so an exact match can never hit
+					filters.push([doctype, field, "like", `%${value}%`]);
 				} else {
 					filters.push([doctype, field, "=", value]);
 				}

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -555,7 +555,10 @@ frappe.ui.filter_utils = {
 
 	get_default_condition(df) {
 		const meta = frappe.get_meta(df.parent);
-		if (df.fieldtype == "Data" && !meta?.is_large_table) {
+		if (["_assign", "_liked_by"].includes(df.fieldname)) {
+			// stored as a JSON array, so an exact match can never hit
+			return "like";
+		} else if (df.fieldtype == "Data" && !meta?.is_large_table) {
 			return "like";
 		} else if (df.fieldtype == "Date" || df.fieldtype == "Datetime") {
 			return "Between";


### PR DESCRIPTION
## Bug

Filtering by **Assigned To** or **Liked By** returns no results even when matching documents exist. Both filters default to the **Equals** operator, which does not match the stored data format.

## Root Cause

`_assign` and `_liked_by` are stored as JSON arrays (for example, `["jane@example.com"]`), not as plain user IDs.

When a filter is created, `get_default_condition` in `filter.js` selects the operator based on field type. Since `_assign` is a Text field, it falls back to the default `=` operator. An exact match such as:

```text
_assign = 'jane@example.com'
```

cannot match a stored value like:

```text
["jane@example.com"]
```

The same issue exists for route-based filters. A URL such as:

```text
?_assign=jane@example.com
```

is parsed into an `=` filter by `parse_filters_from_route_options` in `list_view.js`, producing no results.

## Fix

Default `_assign` and `_liked_by` to the `like` operator in both filter-generation paths.

The filter control already wraps values with `%...%` for `like`, allowing matches within the stored JSON array.

This aligns these paths with existing behavior used by:

* Sidebar group-by filters
* Standard list filters (`base_list.js`)
* Liked By toggle (`list_view.js`)
* Sidebar filters (`list_sidebar_group_by.js`)

These were the only remaining paths still defaulting to `=`.

Users can still manually choose a different operator; only the default selection changes.

## Behavior After Fix

* Filtering by **Assigned To** returns matching assigned documents.
* Filtering by **Liked By** returns matching liked documents.
* Route-based filters such as `?_assign=user@example.com` work as expected.
* Existing manual operator selection remains unchanged.


https://github.com/user-attachments/assets/9e349a4c-6cd8-4f4b-9b85-01e27b0b7e9d


## Testing

* Verified Assigned To filter returns matching documents.
* Verified Liked By filter returns matching documents.
* Verified route-based filters work correctly.
* Verified users can still manually change the operator.

---
Closes #39695
