### PR TITLE
fix(text_editor): guard against null blot when deleting selected image

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -202,6 +202,20 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 			e.stopPropagation();
 		});
 
+		const imageResizeModule = this.quill.getModule("imageResize");
+		if (imageResizeModule) {
+			imageResizeModule.checkImage = (evt) => {
+				if (imageResizeModule.img) {
+					// Delete / Backspace key pressed
+					if (evt.keyCode == 46 || evt.keyCode == 8) {
+						const blot = Quill.find(imageResizeModule.img);
+						if (blot) blot.deleteAt(0);
+					}
+					imageResizeModule.hide();
+				}
+			};
+		}
+
 		// font size dropdown
 		let $font_size_label = this.$wrapper.find(".ql-size .ql-picker-label:first");
 		let $default_font_size = this.$wrapper.find(".ql-size .ql-picker-item:first");


### PR DESCRIPTION
Resolve: #40077 


https://github.com/user-attachments/assets/7a588b6e-7ad1-4ed2-893c-4966c22d1872

