### PR TITLE
fix(data_import): inherit Data Import permissions for log count

### DIFF
--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -1083,12 +1083,10 @@ frappe.ui.form.on("Data Import", {
 		}
 
 		frappe.call({
-			method: "frappe.client.get_count",
+			method: "frappe.core.doctype.data_import.data_import.get_import_log_count",
+			type: "GET",
 			args: {
-				doctype: "Data Import Log",
-				filters: {
-					data_import: frm.doc.name,
-				},
+				data_import: frm.doc.name,
 			},
 			callback: function (r) {
 				let count = r.message;

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -353,6 +353,15 @@ def get_import_status(data_import_name: str):
 	return import_status
 
 
+@frappe.whitelist(methods=["GET"])
+@frappe.read_only()
+def get_import_log_count(data_import: str):
+	doc = frappe.get_doc("Data Import", data_import)
+	doc.check_permission("read")
+
+	return frappe.db.count("Data Import Log", {"data_import": data_import})
+
+
 @frappe.whitelist()
 def get_import_logs(data_import: str):
 	doc = frappe.get_doc("Data Import", data_import)


### PR DESCRIPTION
Replace `frappe.client.get_count` with `get_import_log_count` so users with read access on **Data Import** can load import logs without separate **Data Import Log** permissions.