### PR TITLE
fix: correct Turkmenistan currency to TMT

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -2788,11 +2788,11 @@
  },
  "Turkmenistan": {
   "code": "tm",
-  "currency": "TMM",
-  "currency_fraction": "Tennesi",
+  "currency": "TMT",
+  "currency_fraction": "Tenge",
   "currency_fraction_units": 100,
   "currency_name": "Manat",
-  "currency_symbol": "m",
+  "currency_symbol": "TMT",
   "number_format": "#,###.##",
   "timezones": [
    "Asia/Ashgabat"


### PR DESCRIPTION
TMM is the obsolete pre-2009 manat, withdrawn after the redenomination. The active ISO 4217 code is TMT (Turkmenistan New Manat). Also corrects the currency_symbol and the 'Tenge' subunit spelling.