### PR TITLE
feat: add empty state to awesomebar

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -35,6 +35,24 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				placeholder="${__("Search or type a command")}" autocomplete="off"
 			/>
 			<div class="modal-divider"></div>
+		</div>
+		<div class="awesomebar-empty-state hidden">
+			<div class="text-center">
+				<img src="/assets/frappe/images/ui-states/search-empty-state.svg"
+					alt="No recent searches"
+					class="null-state"
+				/>
+				<div class="awesomebar-empty-state-text">${__("Search or run a command")}</div>
+				<div class="awesomebar-empty-state-tip text-muted">
+					${__("Type")}
+					<span class="awesomebar-shortcut-key">new ...</span>
+					${__("to create,")}
+					<span class="awesomebar-shortcut-key">... in ...</span>
+					${__("to search in a list, or")}
+					<span class="awesomebar-shortcut-key">${frappe.utils.is_mac() ? "⌘G" : "Ctrl+G"}</span>
+					${__("for Global Search")}
+				</div>
+			</div>
 		</div>`;
 
 		let search_modal_footer = `<div class="awesomebar-modal-footer flex justify-between w-100">
@@ -189,6 +207,12 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				awesomplete.options_with_desc = me.create_options_with_descriptions(options);
 				Awesomplete.prototype._itemCursor = 0;
 				awesomplete.list = options;
+				const $empty_state = search_modal.find(".awesomebar-empty-state");
+				if (!txt && !options.length) {
+					$empty_state.removeClass("hidden");
+				} else {
+					$empty_state.addClass("hidden");
+				}
 			}, 50)
 		);
 

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -44,8 +44,8 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				<div class="awesomebar-empty-state-text">${__("Search or run a command")}</div>
 				<div class="awesomebar-empty-state-tip text-muted">
 					${__("Type to search")}
-					&nbsp;·&nbsp;<span class="awesomebar-shortcut-key">new ...</span> ${__("to create")}
-					&nbsp;·&nbsp;<span class="awesomebar-shortcut-key">... in ...</span> ${__("to scope")}
+					&nbsp;·&nbsp;<span class="awesomebar-shortcut-key">${__("new ...")}</span> ${__("to create")}
+					&nbsp;·&nbsp;<span class="awesomebar-shortcut-key">${__("... in ...")}</span> ${__("to scope")}
 					&nbsp;·&nbsp;<span class="awesomebar-shortcut-key">${
 						frappe.utils.is_mac() ? "⌘G" : "Ctrl+G"
 					}</span> ${__("global")}

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -38,19 +38,17 @@ frappe.search.AwesomeBar = class AwesomeBar {
 		</div>
 		<div class="awesomebar-empty-state hidden">
 			<div class="text-center">
-				<img src="/assets/frappe/images/ui-states/search-empty-state.svg"
-					alt="No recent searches"
-					class="null-state"
-				/>
+				<div class="awesomebar-empty-icon">
+					${frappe.utils.icon("search", "md")}
+				</div>
 				<div class="awesomebar-empty-state-text">${__("Search or run a command")}</div>
 				<div class="awesomebar-empty-state-tip text-muted">
-					${__("Type")}
-					<span class="awesomebar-shortcut-key">new ...</span>
-					${__("to create,")}
-					<span class="awesomebar-shortcut-key">... in ...</span>
-					${__("to search in a list, or")}
-					<span class="awesomebar-shortcut-key">${frappe.utils.is_mac() ? "⌘G" : "Ctrl+G"}</span>
-					${__("for Global Search")}
+					${__("Type to search")}
+					&nbsp;·&nbsp;<span class="awesomebar-shortcut-key">new ...</span> ${__("to create")}
+					&nbsp;·&nbsp;<span class="awesomebar-shortcut-key">... in ...</span> ${__("to scope")}
+					&nbsp;·&nbsp;<span class="awesomebar-shortcut-key">${
+						frappe.utils.is_mac() ? "⌘G" : "Ctrl+G"
+					}</span> ${__("global")}
 				</div>
 			</div>
 		</div>`;

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -58,19 +58,19 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				<span class="help-item-navigate">
 					<span class="help-item">${frappe.utils.icon("arrow-up", "xs")}</span>
 					<span class="help-item">${frappe.utils.icon("arrow-down", "xs")}</span>
-					<span>${__("to navigate")}</span>
+					<span>${__("navigate")}</span>
 				</span>
 				<span class="help-item-navigate">
 					<span class="help-item">${frappe.utils.icon("corner-down-left", "xs")}</span>
-					<span>${__("to select")}</span>
+					<span>${__("select")}</span>
 				</span>
 				<span class="help-item-navigate">
 					<span class="help-item help-item-escape">${frappe.utils.is_mac() ? "⌘K" : "Ctrl+K"}</span>
-					<span>${__("to close")}</span>
+					<span>${__("close")}</span>
 				</span>
 				<span class="help-item-navigate">
 					<span class="help-item help-item-escape">${frappe.utils.is_mac() ? "⌘G" : "Ctrl+G"}</span>
-					<span>${__("to open Global Search")}</span>
+					<span>${__("Global Search")}</span>
 				</span>
 			</div>
 		</div>`;

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -165,32 +165,35 @@
 }
 
 .awesomebar-empty-state {
-	padding: var(--padding-xl) var(--padding-lg);
+	padding: var(--padding-2xl) var(--padding-lg);
 
-	.null-state {
-		width: 120px;
-		height: auto;
+	.awesomebar-empty-icon {
+		width: 48px;
+		height: 48px;
+		border-radius: 50%;
+		background-color: var(--bg-color);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		margin: 0 auto var(--margin-md);
+		color: var(--text-muted);
 	}
 
 	.awesomebar-empty-state-text {
 		font-weight: 600;
 		color: var(--text-color);
-		margin-top: var(--margin-lg);
-		font-size: var(--text-xl);
+		font-size: var(--text-lg);
+		margin-bottom: var(--margin-sm);
 	}
 
 	.awesomebar-empty-state-tip {
 		font-size: var(--text-xs);
-		margin-top: var(--margin-md);
-		max-width: 28rem;
-		margin-left: auto;
-		margin-right: auto;
-		line-height: 1.45;
+		line-height: 1.6;
 	}
 
 	.awesomebar-shortcut-key {
 		background-color: var(--border-color);
-		padding: 2px 4px;
+		padding: 2px 6px;
 		border-radius: 4px;
 		font-size: x-small;
 		display: inline-block;

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -164,6 +164,39 @@
 	}
 }
 
+.awesomebar-empty-state {
+	padding: var(--padding-xl) var(--padding-lg);
+
+	.null-state {
+		width: 120px;
+		height: auto;
+	}
+
+	.awesomebar-empty-state-text {
+		font-weight: 600;
+		color: var(--text-color);
+		margin-top: var(--margin-lg);
+		font-size: var(--text-xl);
+	}
+
+	.awesomebar-empty-state-tip {
+		font-size: var(--text-xs);
+		margin-top: var(--margin-md);
+		max-width: 28rem;
+		margin-left: auto;
+		margin-right: auto;
+		line-height: 1.45;
+	}
+
+	.awesomebar-shortcut-key {
+		background-color: var(--border-color);
+		padding: 2px 4px;
+		border-radius: 4px;
+		font-size: x-small;
+		display: inline-block;
+	}
+}
+
 .navbar.bg-dark {
 	.dropdown-menu {
 		font-size: 0.75rem;

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -195,7 +195,7 @@
 		background-color: var(--border-color);
 		padding: 2px 6px;
 		border-radius: 4px;
-		font-size: x-small;
+		font-size: var(--text-xs);
 		display: inline-block;
 	}
 }


### PR DESCRIPTION
## Summary
- Shows a helpful empty state when the awesomebar has no recent or frequent link history (e.g. on a fresh site)
- Uses the same `search-empty-state.svg` illustration and styling as the Global Search empty state for visual consistency
- Includes inline command hints (`new ...`, `... in ...`, `⌘G`) so new users discover awesomebar commands
- Empty state hides automatically once the user has recent/frequent history
<img width="1912" height="882" alt="image" src="https://github.com/user-attachments/assets/ab9e8a74-6460-4b75-8d70-415f10343393" />

## Test plan
- [x] Open awesomebar on a fresh site with no history — should show empty state with icon and hints
- [x] Navigate a few pages, reopen awesomebar — recent links should appear, empty state hidden
- [x] Type in the search box — empty state should hide immediately

`no-docs`