### PR TITLE
fix: prevent duplicate awesomebar instances on page navigation

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -49,7 +49,7 @@ frappe.ui.Page = class Page {
 	}
 
 	setup_awesomebar() {
-		if (frappe.boot.desk_settings.search_bar) {
+		if (frappe.boot.desk_settings.search_bar && !frappe.app.awesome_bar) {
 			let awesome_bar = new frappe.search.AwesomeBar();
 			awesome_bar.setup(".navbar-modal-search-mobile");
 			frappe.app.awesome_bar = awesome_bar;


### PR DESCRIPTION
## Summary
- Every `Page` instantiation called `setup_awesomebar()` unconditionally, creating a new `AwesomeBar` and binding an extra click handler to the same navbar button on each navigation
- After navigating List → Form → List, there were 2+ stacked handlers firing on each click, each showing its own Bootstrap modal behind the other
- The user had to click outside twice to fully dismiss the awesomebar

## Root Cause
`setup_awesomebar()` in `page.js` was called from `make()` on every page load. Since the navbar button (`.navbar-modal-search-mobile`) is a persistent DOM element, each new `Page` would attach another `click` handler to it, stacking modals on open.

## Fix
Guard `setup_awesomebar()` with `!frappe.app.awesome_bar` so the bar is initialized only once per session.

## Test plan
- [x] Navigate List → Form → List → open awesomebar → one click outside should fully close it
- [x] Open awesomebar via ⌘K → one click outside should close it
- [x] Keyboard shortcut ⌘K should still toggle open/close correctly after navigation