### PR TITLE
fix: remove empty state from awesomebar

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -36,22 +36,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			/>
 			<div class="modal-divider"></div>
 		</div>
-		<div class="awesomebar-empty-state hidden">
-			<div class="text-center">
-				<div class="awesomebar-empty-icon">
-					${frappe.utils.icon("search", "md")}
-				</div>
-				<div class="awesomebar-empty-state-text">${__("Search or run a command")}</div>
-				<div class="awesomebar-empty-state-tip text-muted">
-					${__("Type to search")}
-					&nbsp;·&nbsp;<span class="awesomebar-shortcut-key">${__("new ...")}</span> ${__("to create")}
-					&nbsp;·&nbsp;<span class="awesomebar-shortcut-key">${__("... in ...")}</span> ${__("to scope")}
-					&nbsp;·&nbsp;<span class="awesomebar-shortcut-key">${
-						frappe.utils.is_mac() ? "⌘G" : "Ctrl+G"
-					}</span> ${__("global")}
-				</div>
-			</div>
-		</div>`;
+		`;
 
 		let search_modal_footer = `<div class="awesomebar-modal-footer flex justify-between w-100">
 			<div class="help-navigation">
@@ -205,12 +190,6 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				awesomplete.options_with_desc = me.create_options_with_descriptions(options);
 				Awesomplete.prototype._itemCursor = 0;
 				awesomplete.list = options;
-				const $empty_state = search_modal.find(".awesomebar-empty-state");
-				if (!txt && !options.length) {
-					$empty_state.removeClass("hidden");
-				} else {
-					$empty_state.addClass("hidden");
-				}
 			}, 50)
 		);
 

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -27,14 +27,16 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			setTimeout(() => input.focus(), 10);
 		});
 
-		let search_modal_body = `<div class="align-baseline flex p-2 relative navbar-modal-wrapper">
-			<span class="awesomebar-search-icon">${frappe.utils.icon("search", "sm")}</span>
-			<input
-				id="navbar-search"
-				type="text"
-				class="form-control bg-transparent shadow-none" aria-haspopup="true"
-				placeholder="${__("Search or type a command")}" autocomplete="off"
-			/>
+		let search_modal_body = `<div class="p-2 navbar-modal-wrapper">
+			<div class="awesomebar-input-row">
+				<span class="awesomebar-search-icon">${frappe.utils.icon("search", "sm")}</span>
+				<input
+					id="navbar-search"
+					type="text"
+					class="form-control" aria-haspopup="true"
+					placeholder="${__("Search or type a command")}" autocomplete="off"
+				/>
+			</div>
 			<div class="modal-divider"></div>
 		</div>
 		`;
@@ -182,10 +184,10 @@ frappe.search.AwesomeBar = class AwesomeBar {
 					me.options = me.options.concat(me.build_options(txt));
 					me.options = me.options.concat(me.global_results);
 				} else {
-					me.options = me.options.concat(
-						me.deduplicate(frappe.search.utils.get_recent_pages(txt || ""))
-					);
-					me.options = me.options.concat(frappe.search.utils.get_frequent_links());
+					// me.options = me.options.concat(
+					// 	me.deduplicate(frappe.search.utils.get_recent_pages(txt || ""))
+					// );
+					// me.options = me.options.concat(frappe.search.utils.get_frequent_links());
 				}
 				let options = me.deduplicate(me.options);
 				awesomplete.options_with_desc = me.create_options_with_descriptions(options);

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -191,13 +191,6 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				awesomplete.options_with_desc = me.create_options_with_descriptions(options);
 				Awesomplete.prototype._itemCursor = 0;
 				awesomplete.list = options;
-				const has_results = Boolean(options.length);
-				$(awesomplete.ul).toggleClass("awesomebar-ul-empty", !has_results);
-				search_modal.find(".modal-divider").toggleClass("hidden", !has_results);
-				search_modal
-					.closest(".modal")
-					.find(".modal-footer")
-					.toggleClass("hidden", !has_results);
 			}, 50)
 		);
 
@@ -211,10 +204,16 @@ frappe.search.AwesomeBar = class AwesomeBar {
 
 		$input.on("awesomplete-open", function (e) {
 			me.autocomplete_open = e.target;
+			$(awesomplete.ul).removeClass("awesomebar-ul-empty");
+			search_modal.find(".modal-divider").removeClass("hidden");
+			search_modal.closest(".modal").find(".modal-footer").removeClass("hidden");
 		});
 
 		$input.on("awesomplete-close", function (e) {
 			me.autocomplete_open = false;
+			$(awesomplete.ul).addClass("awesomebar-ul-empty");
+			search_modal.find(".modal-divider").addClass("hidden");
+			search_modal.closest(".modal").find(".modal-footer").addClass("hidden");
 		});
 
 		$input.on("awesomplete-select", function (e) {

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -28,15 +28,12 @@ frappe.search.AwesomeBar = class AwesomeBar {
 		});
 
 		let search_modal_body = `<div class="p-2 navbar-modal-wrapper">
-			<div class="awesomebar-input-row">
-				<span class="awesomebar-search-icon">${frappe.utils.icon("search", "sm")}</span>
-				<input
-					id="navbar-search"
-					type="text"
-					class="form-control" aria-haspopup="true"
-					placeholder="${__("Search or type a command")}" autocomplete="off"
-				/>
-			</div>
+			<input
+				id="navbar-search"
+				type="text"
+				class="form-control" aria-haspopup="true"
+				placeholder="${__("Search or type a command")}" autocomplete="off"
+			/>
 			<div class="modal-divider"></div>
 		</div>
 		`;

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -27,11 +27,11 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			setTimeout(() => input.focus(), 10);
 		});
 
-		let search_modal_body = `<div class="p-2 navbar-modal-wrapper">
+		let search_modal_body = `<div class="align-baseline flex p-2 relative navbar-modal-wrapper">
 			<input
 				id="navbar-search"
 				type="text"
-				class="form-control" aria-haspopup="true"
+				class="form-control bg-transparent shadow-none" aria-haspopup="true"
 				placeholder="${__("Search or type a command")}" autocomplete="off"
 			/>
 			<div class="modal-divider"></div>
@@ -181,10 +181,10 @@ frappe.search.AwesomeBar = class AwesomeBar {
 					me.options = me.options.concat(me.build_options(txt));
 					me.options = me.options.concat(me.global_results);
 				} else {
-					// me.options = me.options.concat(
-					// 	me.deduplicate(frappe.search.utils.get_recent_pages(txt || ""))
-					// );
-					// me.options = me.options.concat(frappe.search.utils.get_frequent_links());
+					me.options = me.options.concat(
+						me.deduplicate(frappe.search.utils.get_recent_pages(txt || ""))
+					);
+					me.options = me.options.concat(frappe.search.utils.get_frequent_links());
 				}
 				let options = me.deduplicate(me.options);
 				awesomplete.options_with_desc = me.create_options_with_descriptions(options);

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -192,6 +192,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				Awesomplete.prototype._itemCursor = 0;
 				awesomplete.list = options;
 				const has_results = Boolean(options.length);
+				$(awesomplete.ul).toggleClass("awesomebar-ul-empty", !has_results);
 				search_modal.find(".modal-divider").toggleClass("hidden", !has_results);
 				search_modal
 					.closest(".modal")

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -28,6 +28,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 		});
 
 		let search_modal_body = `<div class="align-baseline flex p-2 relative navbar-modal-wrapper">
+			<span class="awesomebar-search-icon">${frappe.utils.icon("search", "sm")}</span>
 			<input
 				id="navbar-search"
 				type="text"
@@ -65,7 +66,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 		search_modal
 			.find(".modal-footer")
 			.removeClass("hide")
-			.addClass("cool-awesomebar-modal-footer")
+			.addClass("cool-awesomebar-modal-footer hidden")
 			.html(search_modal_footer);
 
 		$search_element.on("click", () => {
@@ -190,6 +191,10 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				awesomplete.options_with_desc = me.create_options_with_descriptions(options);
 				Awesomplete.prototype._itemCursor = 0;
 				awesomplete.list = options;
+				search_modal
+					.closest(".modal")
+					.find(".modal-footer")
+					.toggleClass("hidden", !options.length);
 			}, 50)
 		);
 

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -164,6 +164,9 @@ frappe.search.AwesomeBar = class AwesomeBar {
 
 		this.awesomplete = awesomplete;
 
+		// Start in empty state — awesomplete-open removes this, awesomplete-close restores it
+		$(awesomplete.ul).addClass("awesomebar-ul-empty");
+
 		$input.on(
 			"input",
 			frappe.utils.debounce(function (e) {

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -61,6 +61,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 		</div>`;
 
 		search_modal.find(".modal-body").css("padding", "0").html(search_modal_body);
+		search_modal.find(".modal-divider").addClass("hidden");
 		search_modal.find(".modal-header").css("display", "none");
 		search_modal
 			.find(".modal-footer")
@@ -181,19 +182,21 @@ frappe.search.AwesomeBar = class AwesomeBar {
 					me.options = me.options.concat(me.build_options(txt));
 					me.options = me.options.concat(me.global_results);
 				} else {
-					me.options = me.options.concat(
-						me.deduplicate(frappe.search.utils.get_recent_pages(txt || ""))
-					);
-					me.options = me.options.concat(frappe.search.utils.get_frequent_links());
+					// me.options = me.options.concat(
+					// 	me.deduplicate(frappe.search.utils.get_recent_pages(txt || ""))
+					// );
+					// me.options = me.options.concat(frappe.search.utils.get_frequent_links());
 				}
 				let options = me.deduplicate(me.options);
 				awesomplete.options_with_desc = me.create_options_with_descriptions(options);
 				Awesomplete.prototype._itemCursor = 0;
 				awesomplete.list = options;
+				const has_results = Boolean(options.length);
+				search_modal.find(".modal-divider").toggleClass("hidden", !has_results);
 				search_modal
 					.closest(".modal")
 					.find(".modal-footer")
-					.toggleClass("hidden", !options.length);
+					.toggleClass("hidden", !has_results);
 			}, 50)
 		);
 

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -99,17 +99,22 @@
 	}
 }
 
-.awesomebar-search-icon {
-	display: inline-flex;
-	align-items: center;
-	flex-shrink: 0;
-	color: var(--text-muted);
-	margin-right: var(--margin-sm);
-}
-
 .navbar-modal-wrapper {
+	.awesomebar-search-icon {
+		position: absolute;
+		left: var(--padding-sm);
+		top: var(--padding-sm);
+		height: 36px;
+		display: inline-flex;
+		align-items: center;
+		color: var(--text-muted);
+		pointer-events: none;
+		z-index: 1;
+	}
+
 	#navbar-search {
 		display: flex;
+		padding-left: 1.75rem;
 	}
 
 	.awesomplete {

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -99,6 +99,14 @@
 	}
 }
 
+.awesomebar-search-icon {
+	display: inline-flex;
+	align-items: center;
+	flex-shrink: 0;
+	color: var(--text-muted);
+	margin-right: var(--margin-sm);
+}
+
 .navbar-modal-wrapper {
 	#navbar-search {
 		display: flex;

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -100,11 +100,8 @@
 }
 
 .navbar-modal-wrapper {
-	position: relative;
-
 	.awesomplete {
-		flex: 1;
-		min-width: 0;
+		width: 100%;
 
 		ul {
 			position: relative;

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -100,6 +100,10 @@
 }
 
 .navbar-modal-wrapper {
+	#navbar-search {
+		display: flex;
+	}
+
 	.awesomplete {
 		width: 100%;
 
@@ -118,16 +122,13 @@
 		}
 	}
 
-	#navbar-search {
-		border: none;
-		box-shadow: none !important;
-		background: transparent;
-	}
-
 	.modal-divider {
 		width: 100%;
 		height: 1px;
 		background-color: var(--border-color);
+		position: absolute;
+		top: 40px;
+		left: 0px;
 	}
 }
 

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -164,42 +164,6 @@
 	}
 }
 
-.awesomebar-empty-state {
-	padding: var(--padding-2xl) var(--padding-lg);
-
-	.awesomebar-empty-icon {
-		width: 48px;
-		height: 48px;
-		border-radius: 50%;
-		background-color: var(--bg-color);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		margin: 0 auto var(--margin-md);
-		color: var(--text-muted);
-	}
-
-	.awesomebar-empty-state-text {
-		font-weight: 600;
-		color: var(--text-color);
-		font-size: var(--text-lg);
-		margin-bottom: var(--margin-sm);
-	}
-
-	.awesomebar-empty-state-tip {
-		font-size: var(--text-xs);
-		line-height: 1.6;
-	}
-
-	.awesomebar-shortcut-key {
-		background-color: var(--border-color);
-		padding: 2px 6px;
-		border-radius: 4px;
-		font-size: var(--text-xs);
-		display: inline-block;
-	}
-}
-
 .navbar.bg-dark {
 	.dropdown-menu {
 		font-size: 0.75rem;

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -118,7 +118,6 @@
 
 		ul[hidden] {
 			display: block !important;
-			margin-top: 0;
 		}
 	}
 

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -102,20 +102,6 @@
 .navbar-modal-wrapper {
 	position: relative;
 
-	.awesomebar-input-row {
-		display: flex;
-		align-items: flex-start;
-		gap: var(--margin-sm);
-	}
-
-	.awesomebar-search-icon {
-		flex-shrink: 0;
-		display: inline-flex;
-		align-items: center;
-		height: calc(1.5 * 1rem + 0.75rem + 2px); // match Bootstrap form-control height
-		color: var(--text-muted);
-	}
-
 	.awesomplete {
 		flex: 1;
 		min-width: 0;

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -102,9 +102,9 @@
 .navbar-modal-wrapper {
 	.awesomebar-search-icon {
 		position: absolute;
-		left: var(--padding-sm);
-		top: var(--padding-sm);
-		height: 36px;
+		left: 0.5rem;
+		top: 0.5rem;
+		height: 2.375rem;
 		display: inline-flex;
 		align-items: center;
 		color: var(--text-muted);

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -100,25 +100,25 @@
 }
 
 .navbar-modal-wrapper {
-	.awesomebar-search-icon {
-		position: absolute;
-		left: 0.5rem;
-		top: 0.5rem;
-		height: 2.375rem;
-		display: inline-flex;
-		align-items: center;
-		color: var(--text-muted);
-		pointer-events: none;
-		z-index: 1;
+	position: relative;
+
+	.awesomebar-input-row {
+		display: flex;
+		align-items: flex-start;
+		gap: var(--margin-sm);
 	}
 
-	#navbar-search {
-		display: flex;
-		padding-left: 1.75rem;
+	.awesomebar-search-icon {
+		flex-shrink: 0;
+		display: inline-flex;
+		align-items: center;
+		height: calc(1.5 * 1rem + 0.75rem + 2px); // match Bootstrap form-control height
+		color: var(--text-muted);
 	}
 
 	.awesomplete {
-		width: 100%;
+		flex: 1;
+		min-width: 0;
 
 		ul {
 			position: relative;
@@ -131,17 +131,20 @@
 
 		ul[hidden] {
 			display: block !important;
+			margin-top: 0;
 		}
+	}
+
+	#navbar-search {
+		border: none;
+		box-shadow: none !important;
+		background: transparent;
 	}
 
 	.modal-divider {
 		width: 100%;
 		height: 1px;
 		background-color: var(--border-color);
-		position: absolute;
-		top: 40px;
-		left: 0px;
-		border-radius: 50%;
 	}
 }
 

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -119,6 +119,10 @@
 		ul[hidden] {
 			display: block !important;
 		}
+
+		ul.awesomebar-ul-empty {
+			margin-top: 0 !important;
+		}
 	}
 
 	.modal-divider {


### PR DESCRIPTION
## Summary
- Removes the empty state UI (icon + hints) that was added to the awesomebar when a user has no recent or frequent link history
- When there's no history, the modal now shows just the search input with the dimmed backdrop — cleaner and less noisy for new users

## Test plan
- [ ] Open awesomebar on a fresh site with no history — should show just the search bar, no empty state
- [ ] Open awesomebar after navigating a few pages — recent links should appear as before
- [ ] Typing in the search box should still show results normally