### PR TITLE
fix: render portal address rows safely

### DIFF
--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -205,12 +205,17 @@ def get_territory_from_address(address):
 
 
 def get_list_context(context=None):
-	return {
-		"title": _("Addresses"),
-		"get_list": get_address_list,
-		"row_template": "templates/includes/address_row.html",
-		"no_breadcrumbs": True,
-	}
+	context = context or frappe._dict()
+	context.update(
+		{
+			"title": _("Addresses"),
+			"get_list": get_address_list,
+			"list_template": "templates/includes/list/list.html",
+			"row_template": "templates/includes/address_row.html",
+			"no_breadcrumbs": True,
+		}
+	)
+	return context
 
 
 def get_address_list(doctype, txt, filters, limit_start, limit_page_length=20, order_by=None):
@@ -220,9 +225,16 @@ def get_address_list(doctype, txt, filters, limit_start, limit_page_length=20, o
 
 	if not filters:
 		filters = []
-	filters.append(("Address", "owner", "=", user))
+	try:
+		filters["owner"] = user
+	except:
+		filters.append(("Address", "owner", "=", user))
 
-	return get_list(doctype, txt, filters, limit_start, limit_page_length)
+	addresses = get_list(doctype, txt, filters, limit_start, limit_page_length)
+	for address in addresses:
+		address.address_display = get_address_display(address)
+
+	return addresses
 
 
 def has_website_permission(doc, ptype, user, verbose=False):

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -168,7 +168,7 @@ def get_address_display(address_dict: dict | str | None) -> str | None:
 	return render_address(address_dict)
 
 
-def render_address(address: dict | str | None, check_permissions=True) -> str | None:
+def render_address(address: dict | str | None, check_permissions=True, address_template=None) -> str | None:
 	if not address:
 		return
 
@@ -178,7 +178,7 @@ def render_address(address: dict | str | None, check_permissions=True) -> str | 
 			address.check_permission()
 		address = address.as_dict()
 
-	name, template = get_address_templates(address)
+	name, template = address_template or get_address_templates(address)
 
 	try:
 		return frappe.render_template(template, address, restrict_globals=True)
@@ -227,12 +227,15 @@ def get_address_list(doctype, txt, filters, limit_start, limit_page_length=20, o
 		filters = []
 	try:
 		filters["owner"] = user
-	except:
+	except TypeError:
 		filters.append(("Address", "owner", "=", user))
 
 	addresses = get_list(doctype, txt, filters, limit_start, limit_page_length)
+	address_templates, default_template = get_address_template_map(addresses)
 	for address in addresses:
-		address.address_display = get_address_display(address)
+		address.address_display = render_address(
+			address, address_template=address_templates.get(address.get("country")) or default_template
+		)
 
 	return addresses
 
@@ -254,16 +257,46 @@ def get_address_templates(address):
 	)
 
 	if not result:
-		result = frappe.db.get_value("Address Template", {"is_default": 1}, ["name", "template"])
+		result = get_default_address_template()
 
+	return result
+
+
+def get_default_address_template():
+	result = frappe.db.get_value("Address Template", {"is_default": 1}, ["name", "template"])
 	if not result:
 		frappe.throw(
 			_(
-				"No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template."
+				"No default Address Template found. Please create a new one from "
+				"Setup > Printing and Branding > Address Template."
 			)
 		)
-	else:
-		return result
+
+	return result
+
+
+def get_address_template_map(addresses):
+	if not addresses:
+		return {}, None
+
+	countries = {address.get("country") for address in addresses if address.get("country")}
+	has_missing_country = any(not address.get("country") for address in addresses)
+	address_templates = {}
+	if countries:
+		address_templates = {
+			template.country: (template.name, template.template)
+			for template in frappe.get_all(
+				"Address Template",
+				filters={"country": ("in", tuple(countries))},
+				fields=["country", "name", "template"],
+			)
+		}
+
+	default_template = None
+	if len(address_templates) < len(countries) or has_missing_country:
+		default_template = get_default_address_template()
+
+	return address_templates, default_template
 
 
 def get_company_address(company):

--- a/frappe/contacts/doctype/address/test_address.py
+++ b/frappe/contacts/doctype/address/test_address.py
@@ -3,12 +3,17 @@
 from functools import partial
 
 import frappe
-from frappe.contacts.doctype.address.address import address_query, get_address_display
+from frappe.contacts.doctype.address.address import (
+	address_query,
+	get_address_display,
+	get_address_list,
+	get_list_context,
+)
 from frappe.tests import IntegrationTestCase
 
 
 class TestAddress(IntegrationTestCase):
-	def test_template_works(self):
+	def create_test_address(self):
 		if not frappe.db.exists("Address Template", "India"):
 			frappe.get_doc({"doctype": "Address Template", "country": "India", "is_default": 1}).insert()
 
@@ -27,9 +32,36 @@ class TestAddress(IntegrationTestCase):
 				}
 			).insert()
 
+		return "_Test Address-Office"
+
+	def test_template_works(self):
+		self.create_test_address()
+
 		address = frappe.get_list("Address")[0].name
 		display = get_address_display(frappe.get_doc("Address", address).as_dict())
 		self.assertTrue(display)
+
+	def test_get_address_list_sets_display(self):
+		address = self.create_test_address()
+
+		rows = get_address_list("Address", None, [["name", "=", address]], 0)
+
+		self.assertEqual(rows[0].name, address)
+		self.assertEqual(rows[0].address_display, get_address_display(rows[0]))
+
+	def test_get_address_list_accepts_dict_filters(self):
+		address = self.create_test_address()
+
+		rows = get_address_list("Address", None, frappe._dict(name=address), 0)
+
+		self.assertEqual(rows[0].name, address)
+		self.assertEqual(rows[0].address_display, get_address_display(rows[0]))
+
+	def test_get_list_context_preserves_page_template(self):
+		context = get_list_context(frappe._dict(template="www/portal.html"))
+
+		self.assertEqual(context.template, "www/portal.html")
+		self.assertEqual(context.list_template, "templates/includes/list/list.html")
 
 	def test_address_query(self):
 		def query(doctype="Address", txt="", searchfield="name", start=0, page_len=20, filters=None):

--- a/frappe/contacts/doctype/address/test_address.py
+++ b/frappe/contacts/doctype/address/test_address.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 from functools import partial
+from unittest.mock import patch
 
 import frappe
 from frappe.contacts.doctype.address.address import (
@@ -13,26 +14,33 @@ from frappe.tests import IntegrationTestCase
 
 
 class TestAddress(IntegrationTestCase):
-	def create_test_address(self):
+	def create_test_address(self, address_title="_Test Address", address_type="Office"):
 		if not frappe.db.exists("Address Template", "India"):
 			frappe.get_doc({"doctype": "Address Template", "country": "India", "is_default": 1}).insert()
 
-		if not frappe.db.exists("Address", "_Test Address-Office"):
-			frappe.get_doc(
-				{
-					"address_line1": "_Test Address Line 1",
-					"address_title": "_Test Address",
-					"address_type": "Office",
-					"city": "_Test City",
-					"state": "Test State",
-					"country": "India",
-					"doctype": "Address",
-					"is_primary_address": 1,
-					"phone": "+91 0000000000",
-				}
-			).insert()
+		address = frappe.db.get_value(
+			"Address", {"address_title": address_title, "address_type": address_type}
+		)
+		if not address:
+			address = (
+				frappe.get_doc(
+					{
+						"address_line1": "_Test Address Line 1",
+						"address_title": address_title,
+						"address_type": address_type,
+						"city": "_Test City",
+						"state": "Test State",
+						"country": "India",
+						"doctype": "Address",
+						"is_primary_address": 1,
+						"phone": "+91 0000000000",
+					}
+				)
+				.insert()
+				.name
+			)
 
-		return "_Test Address-Office"
+		return address
 
 	def test_template_works(self):
 		self.create_test_address()
@@ -56,6 +64,21 @@ class TestAddress(IntegrationTestCase):
 
 		self.assertEqual(rows[0].name, address)
 		self.assertEqual(rows[0].address_display, get_address_display(rows[0]))
+
+	def test_get_address_list_reuses_address_templates(self):
+		addresses = {
+			self.create_test_address(),
+			self.create_test_address(address_title="_Test Address Two"),
+		}
+
+		with patch.object(frappe.db, "get_value", wraps=frappe.db.get_value) as get_value:
+			rows = get_address_list("Address", None, [["name", "in", list(addresses)]], 0)
+
+		self.assertEqual({row.name for row in rows}, addresses)
+		address_template_calls = [
+			call for call in get_value.call_args_list if call.args and call.args[0] == "Address Template"
+		]
+		self.assertEqual(address_template_calls, [])
 
 	def test_get_list_context_preserves_page_template(self):
 		context = get_list_context(frappe._dict(template="www/portal.html"))

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -64,6 +64,9 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	}
 
 	make_form_dirty() {
+		if (!this.is_new && !this.in_edit_mode) {
+			return;
+		}
 		frappe.form_dirty = true;
 		$("#not-saved-badge").removeClass("hide");
 	}

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -91,7 +91,9 @@
 							<h1 class="ellipsis">{{ _(title) }}</h1>
 						{% endif %}
 					</div>
-					<span class="es-badge hide" id="not-saved-badge" data-theme="amber">{{ _("Not Saved") }}</span>
+					{% if is_new or in_edit_mode %}
+						<span class="es-badge hide" id="not-saved-badge" data-theme="amber">{{ _("Not Saved") }}</span>
+					{% endif %}
 					<div class="web-form-actions">
 						{{ header_buttons() }}
 					</div>


### PR DESCRIPTION
The `/addresses` portal page broke after restricted template rendering: the ERPNext row template called document methods from Jinja, and the Address list context replaced the incoming page context instead of extending it, dropping the portal template. Saved Address web forms could also show a stale "Not Saved" badge when opened in read mode.

- Preserve the incoming list-page context for Address portal lists.
- Add a generic list template for Address portal rows and compute `address_display` server-side.
- Don't show the Web Form dirty badge on saved read-only pages.

Tests: focused Address list-context and row-display tests; Address doctype suite green.
