### PR TITLE
fix(web form): allow printing submitted documents

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -482,5 +482,20 @@ export default class WebForm extends frappe.ui.FieldGroup {
 				</a>
 			`);
 		}
+
+		if (this.allow_print && data.name) {
+			let print_url =
+				`/printview?doctype=${encodeURIComponent(data.doctype)}` +
+				`&name=${encodeURIComponent(data.name)}` +
+				`&format=${encodeURIComponent(data.print_format || "Standard")}`;
+			if (data.print_key) {
+				print_url += `&key=${data.print_key}`;
+			}
+			$(".success-footer").append(`
+				<a href="${print_url}" target="_blank" class="print-button btn btn-default btn-md">
+					${__("Print", null, "Button in web form")}
+				</a>
+			`);
+		}
 	}
 }

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -34,6 +34,9 @@
 
 	{% if allow_print and in_view_mode %}
 		{% set print_format_url = "/printview?doctype=" + doc_type + "&name=" + doc_name + "&format=" + (print_format or "standard") %}
+		{% if print_key is defined and print_key %}
+			{% set print_format_url = print_format_url + "&key=" + print_key %}
+		{% endif %}
 		<!-- print button -->
 		<a href="{{ print_format_url }}" target="_blank" class="print-btn btn btn-default btn-sm ml-2">
 			<svg class="icon icon-sm"><use href="#icon-printer"></use></svg>

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -5,7 +5,7 @@ import json
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import set_request
-from frappe.website.doctype.web_form.web_form import accept
+from frappe.website.doctype.web_form.web_form import accept, get_published_web_forms
 from frappe.website.serve import get_response_content
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Web Form"]
@@ -14,9 +14,17 @@ EXTRA_TEST_RECORD_DEPENDENCIES = ["Web Form"]
 class TestWebForm(IntegrationTestCase):
 	def setUp(self):
 		frappe.conf.disable_website_cache = True
+		# isolate request state: rendering a specific document leaves `name`/`is_read`
+		# in form_dict, which would otherwise leak into sibling tests' /new requests
+		frappe.set_user("Administrator")
+		frappe.local.form_dict = frappe._dict()
 
 	def tearDown(self):
 		frappe.conf.disable_website_cache = False
+		frappe.set_user("Administrator")
+		frappe.local.form_dict = frappe._dict()
+		# drop any web form created during a test from the cached published-forms list
+		get_published_web_forms.clear_cache()
 
 	def test_accept(self):
 		frappe.set_user("Administrator")
@@ -61,28 +69,69 @@ class TestWebForm(IntegrationTestCase):
 		self.assertIn('source-type="Generator"', content)
 
 	def test_webform_print(self):
-		# enable printing on the web form
-		web_form = frappe.get_doc("Web Form", "manage-events")
-		web_form.allow_print = 1
-		web_form.save()
+		# Use Note: a viewer doesn't get standard print permission on it, so the share
+		# key is what lets them print. (Event grants "print" to the "All" role, so it
+		# can't exercise the share-key path.)
+		web_form = frappe.get_doc(
+			{
+				"doctype": "Web Form",
+				"title": "Test Note Print",
+				"route": "test-note-print",
+				"doc_type": "Note",
+				"module": "Website",
+				"login_required": 1,
+				"allow_multiple": 1,
+				"allow_edit": 1,
+				"show_list": 1,
+				"allow_print": 1,
+				"published": 1,
+				"web_form_fields": [
+					{"fieldname": "title", "fieldtype": "Data", "label": "Title", "reqd": 1}
+				],
+			}
+		).insert(ignore_permissions=True)
+		get_published_web_forms.clear_cache()
 
-		# create a submission and view it
-		self.test_accept()
-		path = f"manage-events/{self.event_name}"
+		user = "test-web-form-print@example.com"
+		if not frappe.db.exists("User", user):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": user,
+					"first_name": "Test Web Form Print",
+					"user_type": "Website User",
+					"send_welcome_email": 0,
+				}
+			).insert(ignore_permissions=True)
+
+		# the user owns the submission (so the web form lets them view it) but has no
+		# standard print permission on Note
+		frappe.set_user(user)
+		note = frappe.get_doc({"doctype": "Note", "title": "_Test Note Print"}).insert(
+			ignore_permissions=True
+		)
+		self.assertFalse(frappe.has_permission("Note", "print", note.name))
+
+		path = f"{web_form.route}/{note.name}"
 		set_request(method="GET", path=path)
 		content = get_response_content(path)
 
-		# the print button must carry a document share key, otherwise users who can
-		# only view their submission (without standard print permission) get an error
-		# when printing. See #19160.
-		self.assertIn("/printview?doctype=Event", content)
+		# the print link must carry a document share key, otherwise /printview rejects
+		# the user and the print button errors out. See #19160.
+		self.assertIn(f"/printview?doctype=Note&name={note.name}", content)
 		self.assertIn("&key=", content)
-		self.assertTrue(
-			frappe.db.exists(
-				"Document Share Key",
-				{"reference_doctype": "Event", "reference_docname": self.event_name},
+
+		def share_key_count():
+			return frappe.db.count(
+				"Document Share Key", {"reference_doctype": "Note", "reference_docname": note.name}
 			)
-		)
+
+		self.assertEqual(share_key_count(), 1)
+
+		# viewing again must reuse the key, not insert a new one on every request/day
+		set_request(method="GET", path=path)
+		get_response_content(path)
+		self.assertEqual(share_key_count(), 1)
 
 	def test_webform_html_meta_is_added(self):
 		set_request(method="GET", path="manage-events/new")

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -18,11 +18,13 @@ class TestWebForm(IntegrationTestCase):
 		# in form_dict, which would otherwise leak into sibling tests' /new requests
 		frappe.set_user("Administrator")
 		frappe.local.form_dict = frappe._dict()
+		frappe.flags.commit = False
 
 	def tearDown(self):
 		frappe.conf.disable_website_cache = False
 		frappe.set_user("Administrator")
 		frappe.local.form_dict = frappe._dict()
+		frappe.flags.commit = False
 		# drop any web form created during a test from the cached published-forms list
 		get_published_web_forms.clear_cache()
 
@@ -121,6 +123,10 @@ class TestWebForm(IntegrationTestCase):
 		self.assertIn(f"/printview?doctype=Note&name={note.name}", content)
 		self.assertIn("&key=", content)
 
+		# the key is created during a GET render, which is rolled back by default; the
+		# request must be flagged to commit so the key survives for the print request
+		self.assertTrue(frappe.flags.commit)
+
 		def share_key_count():
 			return frappe.db.count(
 				"Document Share Key", {"reference_doctype": "Note", "reference_docname": note.name}
@@ -132,6 +138,43 @@ class TestWebForm(IntegrationTestCase):
 		set_request(method="GET", path=path)
 		get_response_content(path)
 		self.assertEqual(share_key_count(), 1)
+
+	def test_webform_print_after_submit(self):
+		# accept() must hand back a share key + print format so the success page can show
+		# a working Print button right after submitting, even on anonymous forms. See #19160.
+		web_form = frappe.get_doc(
+			{
+				"doctype": "Web Form",
+				"title": "Test Note Print Submit",
+				"route": "test-note-print-submit",
+				"doc_type": "Note",
+				"module": "Website",
+				"login_required": 0,
+				"allow_multiple": 1,
+				"allow_print": 1,
+				"published": 1,
+				"web_form_fields": [
+					{"fieldname": "title", "fieldtype": "Data", "label": "Title", "reqd": 1}
+				],
+			}
+		).insert(ignore_permissions=True)
+
+		# simulate the submit POST (accept() is rate-limited and reads the request IP)
+		set_request(method="POST", path=f"/{web_form.route}/new")
+		frappe.local.request_ip = "127.0.0.1"
+		result = accept(
+			web_form=web_form.name,
+			data=json.dumps({"doctype": "Note", "title": "_Test Submit Print"}),
+		)
+
+		self.assertTrue(result.get("print_key"))
+		self.assertEqual(result.get("print_format"), "Standard")
+		self.assertTrue(
+			frappe.db.exists(
+				"Document Share Key",
+				{"reference_doctype": "Note", "reference_docname": result.get("name")},
+			)
+		)
 
 	def test_webform_html_meta_is_added(self):
 		set_request(method="GET", path="manage-events/new")

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -60,6 +60,30 @@ class TestWebForm(IntegrationTestCase):
 		self.assertIn('data-path="manage-events/new"', content)
 		self.assertIn('source-type="Generator"', content)
 
+	def test_webform_print(self):
+		# enable printing on the web form
+		web_form = frappe.get_doc("Web Form", "manage-events")
+		web_form.allow_print = 1
+		web_form.save()
+
+		# create a submission and view it
+		self.test_accept()
+		path = f"manage-events/{self.event_name}"
+		set_request(method="GET", path=path)
+		content = get_response_content(path)
+
+		# the print button must carry a document share key, otherwise users who can
+		# only view their submission (without standard print permission) get an error
+		# when printing. See #19160.
+		self.assertIn("/printview?doctype=Event", content)
+		self.assertIn("&key=", content)
+		self.assertTrue(
+			frappe.db.exists(
+				"Document Share Key",
+				{"reference_doctype": "Event", "reference_docname": self.event_name},
+			)
+		)
+
 	def test_webform_html_meta_is_added(self):
 		set_request(method="GET", path="manage-events/new")
 		content = self.normalize_html(get_response_content("manage-events/new"))

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -493,6 +493,18 @@ def get_context(context):
 			context.reference_doctype = context.reference_doc.doctype
 			context.reference_name = context.reference_doc.name
 
+			# A user viewing a submission may have access through the web form's own
+			# permission model (e.g. document owner) without holding standard print/read
+			# permissions on the doctype. Pass a document share key so the print view can
+			# authorize them, otherwise the print button errors out. See #19160.
+			if self.allow_print and context.in_view_mode:
+				# Pass an explicit expiry so an existing key is reused within its validity
+				# window instead of creating a new one on every view.
+				expiry_days = frappe.get_system_settings("document_share_key_expiry") or 90
+				context.print_key = context.reference_doc.get_document_share_key(
+					expires_on=frappe.utils.add_days(None, expiry_days)
+				)
+
 			if self.show_attachments:
 				context.attachments = self.get_webform_attachments(context)
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -648,6 +648,10 @@ def get_print_share_key(doc):
 
 	Reuses an existing, non-expired key instead of inserting a new record on every
 	view (a fresh key per request/day would accumulate unboundedly).
+
+	The web form is served over a GET request, which the framework rolls back by
+	default. When a new key is created, flag the request to commit so the key
+	persists for the subsequent print-view request (otherwise printing 403s).
 	"""
 	key = frappe.db.get_value(
 		"Document Share Key",
@@ -658,7 +662,12 @@ def get_print_share_key(doc):
 		},
 		"key",
 	)
-	return key or doc.get_document_share_key()
+	if key:
+		return key
+
+	key = doc.get_document_share_key()
+	frappe.flags.commit = True
+	return key
 
 
 def get_web_form_module(doc):
@@ -770,6 +779,16 @@ def accept(web_form: str, data: str):
 		frappe.session.user = user
 
 	frappe.flags.web_form_doc = doc
+
+	if web_form.allow_print and doc.name:
+		# Return a document share key so the submitter can print their submission from
+		# the success page, even on anonymous/public forms where they hold no print
+		# permission. accept() is a POST, so the key is committed. See #19160.
+		response = doc.as_dict()
+		response["print_key"] = get_print_share_key(doc)
+		response["print_format"] = web_form.print_format or "Standard"
+		return response
+
 	return doc
 
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -494,16 +494,16 @@ def get_context(context):
 			context.reference_name = context.reference_doc.name
 
 			# A user viewing a submission may have access through the web form's own
-			# permission model (e.g. document owner) without holding standard print/read
-			# permissions on the doctype. Pass a document share key so the print view can
-			# authorize them, otherwise the print button errors out. See #19160.
-			if self.allow_print and context.in_view_mode:
-				# Pass an explicit expiry so an existing key is reused within its validity
-				# window instead of creating a new one on every view.
-				expiry_days = frappe.get_system_settings("document_share_key_expiry") or 90
-				context.print_key = context.reference_doc.get_document_share_key(
-					expires_on=frappe.utils.add_days(None, expiry_days)
-				)
+			# permission model (e.g. document owner) without holding standard print
+			# permission on the doctype. The print view rejects such users, so pass them
+			# a document share key (which it accepts) and the print button works. Users
+			# who already have print permission don't need one. See #19160.
+			if (
+				self.allow_print
+				and context.in_view_mode
+				and not frappe.has_permission(self.doc_type, "print", context.reference_doc)
+			):
+				context.print_key = get_print_share_key(context.reference_doc)
 
 			if self.show_attachments:
 				context.attachments = self.get_webform_attachments(context)
@@ -641,6 +641,24 @@ def process_link_field(field, web_form_name):
 		web_form_name, field.options, getattr(field, "allow_read_on_all_link_options", False)
 	)
 	return field
+
+
+def get_print_share_key(doc):
+	"""Return a document share key for printing `doc` via the web form.
+
+	Reuses an existing, non-expired key instead of inserting a new record on every
+	view (a fresh key per request/day would accumulate unboundedly).
+	"""
+	key = frappe.db.get_value(
+		"Document Share Key",
+		{
+			"reference_doctype": doc.doctype,
+			"reference_docname": doc.name,
+			"expires_on": [">=", frappe.utils.today()],
+		},
+		"key",
+	)
+	return key or doc.get_document_share_key()
 
 
 def get_web_form_module(doc):


### PR DESCRIPTION
Raising this PR on behalf of @skyasir

The web form 'Allow print' button links to /printview, which only authorizes users that hold standard read/print permission on the doctype, a website permission, or a document share key.

A portal user viewing their own submission is granted access through the web form's permission model (document owner / website permission / apply_document_permissions) but usually has none of the three that printview accepts, so clicking Print errors out with a permission error. This has been broken since the feature was reported in 2017.

Generate a document share key for the viewed submission and append it to the print URL so printview can authorize the same user that the web form already authorized. An explicit expiry is passed so an existing key is reused within its validity window instead of creating one per view.

Fixes #19160 