### PR TITLE
fix(form): preserve pristine field labels across currency-label updates

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1743,10 +1743,13 @@ frappe.ui.form.Form = class FrappeForm {
 		$.each(fields_list, function (i, fname) {
 			var docfield = frappe.meta.docfield_map[doctype][fname];
 			if (docfield) {
-				var label = __(docfield.label || "", null, docfield.parent).replace(
-					/\([^\)]*\)/g,
-					""
-				); // eslint-disable-line
+				// Preserve the pristine label before any currency suffix is applied,
+				// so we don't have to strip it back out of a mutated value on reset
+				// (which would also destroy legitimate parentheticals like "Rate (ex-tax)").
+				if (docfield._original_label === undefined) {
+					docfield._original_label = docfield.label;
+				}
+				var label = __(docfield._original_label || "", null, docfield.parent);
 				if (parentfield) {
 					grid_field_label_map[doctype + "-" + fname] =
 						label.trim() + " (" + __(currency) + ")";

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1752,7 +1752,7 @@ frappe.ui.form.Form = class FrappeForm {
 				var label = __(docfield._original_label || "", null, docfield.parent);
 				if (parentfield) {
 					grid_field_label_map[doctype + "-" + fname] =
-						label.trim() + " (" + __(currency) + ")";
+						label.trim() + " (" + currency + ")";
 				} else {
 					field_label_map[fname] = label.trim() + " (" + currency + ")";
 				}

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1769,6 +1769,35 @@ frappe.ui.form.Form = class FrappeForm {
 		});
 	}
 
+	reset_currency_labels(fields, parentfield) {
+		if (!fields.length) return;
+
+		const doctype = parentfield
+			? this.fields_dict[parentfield].grid.doctype
+			: this.doc.doctype;
+
+		fields.forEach((field) => {
+			const docfield = frappe.meta.docfield_map[doctype][field];
+			if (docfield) {
+				// Read the pristine label captured by set_currency_labels (or here on first use)
+				if (docfield._original_label === undefined) {
+					docfield._original_label = docfield.label;
+				}
+				const label = __(docfield._original_label || "", null, docfield.parent);
+
+				if (parentfield) {
+					this.fields_dict[parentfield].grid.update_docfield_property(
+						field,
+						"label",
+						label
+					);
+				} else {
+					this.fields_dict[field].set_label(label);
+				}
+			}
+		});
+	}
+
 	field_map(fnames, fn) {
 		if (typeof fnames === "string") {
 			if (fnames == "*") {


### PR DESCRIPTION
`set_currency_labels` and its inverse `reset_currency_labels` (the latter previously living in ERPNext) both mutated the shared `frappe.meta.docfield_map[dt][fn].label` and tried to reconstruct the pristine label by stripping parentheticals from the already-mutated value:

- `set_currency_labels` used `/\([^\)]*\)/g`, stripping *all* parentheticals.
- `reset_currency_labels` used `/\s*\([^\)]*\)\s*$/`, stripping only the trailing one.

Either regex permanently destroyed legitimate parenthetical suffixes on field labels (e.g. `Rate (ex-tax)` → `Rate`) on every same-currency render, because the shared `docfield_map` entry was mutated in place.

This change captures the pristine label once on the docfield (`_original_label`) before any currency suffix is applied, and both functions read from it instead of guessing the base label back out of a mutated string.

While here, `reset_currency_labels` is moved from `erpnext/public/js/controllers/transaction.js` into `frappe/public/js/frappe/form/form.js`, co-locating it with `set_currency_labels` and keeping the `_original_label` caching scheme framework-internal. ERPNext keeps a thin backwards-compat wrapper that delegates to `frm.reset_currency_labels(...)`. (see https://github.com/frappe/erpnext/pull/54691)
