### PR TITLE
fix: file dedup broken for JPEGs when EXIF stripping is enabled

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -688,6 +688,10 @@ class TestImage(IntegrationTestCase):
 		self.assertEqual(new_image._getexif(), None)
 		self.assertNotEqual(original_image._getexif(), new_image._getexif())
 
+		# Testing idempotency of strip_exif_data()
+		restripped_image_content = strip_exif_data(new_image_content, "image/jpeg")
+		self.assertEqual(restripped_image_content, new_image_content)
+
 	def test_optimize_image(self):
 		image_file_path = frappe.get_app_path("frappe", "tests", "data", "sample_image_for_optimization.jpg")
 		content_type = guess_type(image_file_path)[0]

--- a/frappe/utils/image.py
+++ b/frappe/utils/image.py
@@ -32,6 +32,8 @@ def strip_exif_data(content, content_type) -> bytes:
 	"""
 
 	original_image = Image.open(io.BytesIO(content))
+	if not original_image.getexif():
+		return content
 	# Apply EXIF orientation to pixels before stripping the tag.
 	original_image = ImageOps.exif_transpose(original_image)
 	output = io.BytesIO()


### PR DESCRIPTION
Opening PR for: @harshp4114 

Closes: #39909

## The Bug

When a JPEG is uploaded with `strip_exif_metadata_from_uploaded_images` enabled, `save_file()` runs it through `strip_exif_data()` before hashing:

**raw bytes A → strip_exif_data() → re-encoded bytes B → hash(B) = H1**

This works correctly when the same file is uploaded again from the device — the same raw bytes go through the same transformation, producing the same hash. The dedup logic finds the existing File record and points the new attachment to the existing blob.

The problem occurs when attaching a file from the library. The file on disk is already the stripped version (`B`), and passing it through `strip_exif_data()` again causes another lossy JPEG decode → re-encode cycle inside `image.save()`. This produces `B'` where `B' ≠ B`, so `hash(B') ≠ H1`. The dedup lookup finds nothing and writes a duplicate blob to disk with a new URL.

Another related problem is shown in the before video.

## The Fix

Make strip_exif_data() idempotent: only decode/re-encode when the image actually carries EXIF data (Image.getexif()); otherwise return the content unchanged.

After the first strip the image has no EXIF, so every subsequent call is a no-op and returns identical bytes — the content hash stays stable, dedup finds the existing blob, and no duplicate file on-disk copy is created.

## Before
https://github.com/user-attachments/assets/2c5bc79d-d5bf-47ed-8e55-5c75fa9be97f

## After
https://github.com/user-attachments/assets/684ad182-4e56-4094-8fd0-0bacba42ec53