### PR TITLE
fix: add search icon to awesome bar + empty state

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -114,6 +114,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				input_row.className = "awesomebar-input-row";
 				let icon = document.createElement("span");
 				icon.className = "awesomebar-search-icon";
+				icon.setAttribute("aria-hidden", "true");
 				icon.innerHTML = frappe.utils.icon("search", "sm");
 				input.parentNode.insertBefore(container, input);
 				input_row.appendChild(icon);

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -199,6 +199,13 @@ frappe.search.AwesomeBar = class AwesomeBar {
 					);
 					me.options = me.options.concat(frappe.search.utils.get_frequent_links());
 				}
+
+				// hide footer and remove spqcing when there are no results
+				$(this.awesomplete.ul).toggleClass("p-0 m-0", cint(me.options?.length) == 0);
+				me.search_modal
+					.find(".cool-awesomebar-modal-footer")
+					.toggleClass("hide", cint(me.options?.length) == 0);
+
 				let options = me.deduplicate(me.options);
 				awesomplete.options_with_desc = me.create_options_with_descriptions(options);
 				Awesomplete.prototype._itemCursor = 0;

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -107,6 +107,20 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			maxItems: 99,
 			autoFirst: true,
 			list: [],
+			container: function (input) {
+				let container = document.createElement("div");
+				container.className = "awesomplete";
+				let input_row = document.createElement("div");
+				input_row.className = "awesomebar-input-row";
+				let icon = document.createElement("span");
+				icon.className = "awesomebar-search-icon";
+				icon.innerHTML = frappe.utils.icon("search", "sm");
+				input.parentNode.insertBefore(container, input);
+				input_row.appendChild(icon);
+				input_row.appendChild(input);
+				container.appendChild(input_row);
+				return container;
+			},
 			filter: function (text, term) {
 				return true;
 			},

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -102,12 +102,16 @@
 .navbar-modal-wrapper {
 	#navbar-search {
 		display: flex;
-		flex: 1;
 	}
 
 	.awesomebar-input-row {
 		display: flex;
 		align-items: center;
+
+		input {
+			flex: 1;
+			min-width: 0;
+		}
 	}
 
 	.awesomebar-search-icon {

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -112,10 +112,11 @@
 	.awesomebar-search-icon {
 		display: flex;
 		align-items: center;
-		padding: 0px 7px;
+		padding-left: 10px;
 		color: var(--text-muted);
 		flex-shrink: 0;
 		pointer-events: none;
+		padding-right: 2px;
 	}
 
 	.awesomplete {

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -112,7 +112,7 @@
 	.awesomebar-search-icon {
 		display: flex;
 		align-items: center;
-		padding-left: 7px;
+		padding: 4px;
 		color: var(--text-muted);
 		flex-shrink: 0;
 		pointer-events: none;

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -104,6 +104,20 @@
 		display: flex;
 	}
 
+	.awesomebar-input-row {
+		display: flex;
+		align-items: center;
+	}
+
+	.awesomebar-search-icon {
+		display: flex;
+		align-items: center;
+		padding-left: 7px;
+		color: var(--text-muted);
+		flex-shrink: 0;
+		pointer-events: none;
+	}
+
 	.awesomplete {
 		width: 100%;
 

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -112,7 +112,7 @@
 	.awesomebar-search-icon {
 		display: flex;
 		align-items: center;
-		padding: 4px;
+		padding: 0px 7px;
 		color: var(--text-muted);
 		flex-shrink: 0;
 		pointer-events: none;

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -102,6 +102,7 @@
 .navbar-modal-wrapper {
 	#navbar-search {
 		display: flex;
+		flex: 1;
 	}
 
 	.awesomebar-input-row {


### PR DESCRIPTION
## Summary

- Adds a persistent search icon to the left of the awesome bar (`⌘K`) input, visible in both empty and results states
- Uses awesomplete's built-in `container` option to inject the icon — no library modifications, no impact on other awesomplete instances in the app
- Icon and input are wrapped in a flex row (`awesomebar-input-row`) so the icon stays pinned to the input regardless of how tall the results list grows below

### Before
<img width="1278" height="302" alt="image" src="https://github.com/user-attachments/assets/ed4ce0da-3e02-4c57-97b6-405a8a72dd0a" />

### After
<img width="1684" height="244" alt="image" src="https://github.com/user-attachments/assets/9349fa21-ba95-4ce5-8734-440ea66cee5c" />
