### PR TITLE
fix(print): Allow report PDF assets from all site domains

### DIFF
--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -274,11 +274,42 @@ def report_to_pdf(html: str, orientation: str = "Landscape"):
 		{
 			"orientation": orientation,
 			"proxy": "http://0.0.0.0:0",
-			"bypass-proxy-for": urlparse(frappe.utils.get_url(allow_header_override=False)).hostname,
+			"bypass-proxy-for": _pdf_bypass_proxy_hosts(),
 			"load-error-handling": "ignore",
 		},
 	)
 	frappe.local.response.type = "pdf"
+
+
+def _pdf_bypass_proxy_hosts() -> list[str]:
+	"""Hosts wkhtmltopdf is allowed to fetch from while rendering a report PDF.
+
+	The report HTML is built client-side and posted back, so its asset URLs are
+	absolute against whichever domain the user is browsing. wkhtmltopdf is pinned
+	to a dead proxy and only bypasses it for these hosts, so a site reached via a
+	secondary domain would otherwise fail every asset fetch with UnknownNetworkError.
+
+	Always allows the canonical host. Additional hosts (e.g. a site's alternate
+	domains) can be allowed via the `domains` site config key. The bypass list is
+	limited to these, so genuinely external resources stay blocked.
+	"""
+	hosts = {_hostname(frappe.utils.get_url(allow_header_override=False))}
+	hosts.update(_hostname(domain) for domain in (frappe.conf.domains or []))
+	hosts.discard(None)
+	return sorted(hosts)
+
+
+def _hostname(value: str) -> str | None:
+	"""Bare hostname for a `--bypass-proxy-for` entry.
+
+	wkhtmltopdf wants a bare host, but config values may arrive as a full URL,
+	with a scheme, or with a port (e.g. "https://a.com", "a.com:443"). urlparse
+	only finds the host in the netloc, so give bare values one before parsing —
+	otherwise an un-normalized entry silently fails the bypass for that domain.
+	"""
+	if "://" not in value:
+		value = "//" + value
+	return urlparse(value).hostname
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Problem

Downloading a report as PDF works when a site is opened via its primary `host_name` domain, but fails on every other (custom/secondary) domain with:

```
OSError: wkhtmltopdf reported an error:
Exit with code 1 due to network error: UnknownNetworkError
```

## Root cause

`report_to_pdf` hardens wkhtmltopdf against SSRF — the report HTML is client-supplied to a whitelisted endpoint, so the renderer must not be able to fetch arbitrary internal URLs:

```python
get_pdf(html, {
    "proxy": "http://0.0.0.0:0",                                               # dead proxy → blocks all network
    "bypass-proxy-for": urlparse(get_url(allow_header_override=False)).hostname, # …except the canonical host
    "load-error-handling": "ignore",
})
```

But the report HTML is built **by the browser**, so its asset URLs are absolute against whichever domain the user is on. When the site is opened via a secondary domain, every `<link>`/`<img>` points at that domain, which is not the canonical `host_name`. Each fetch is therefore routed through the dead proxy and fails with `UnknownNetworkError`. That string is **not** in `PDF_CONTENT_ERRORS` (only *content* errors are), so `get_pdf` re-raises it instead of degrading gracefully, and the download fails outright. On the `host_name` domain the asset URLs match the bypass host, so it works — which is the entire host_name-vs-other-domains difference.

## Fix

Also bypass the proxy for the site's **own registered domains**, read from `frappe.conf.domains`:

```python
hosts = {urlparse(frappe.utils.get_url(allow_header_override=False)).hostname}
hosts.update(frappe.conf.domains or [])
hosts.discard(None)
# bypass-proxy-for: sorted(hosts)   # pdfkit repeats the flag per host
```

- `frappe.conf.domains` is written into `site_config.json` by the platform (Frappe Cloud), **not** derived from the request `Host`/`X-Forwarded-Host` header — so the SSRF surface widens only to the site's *own* domains, never an attacker-supplied host.
- Genuinely external resources (CDNs, third-party services) stay blocked, preserving the SSRF protection.
- Off-platform the key is absent, so the set collapses to just the canonical host — **no behaviour change**.

## Notes

- Companion Press change ensures all of a site's domains actually land in `frappe.conf.domains`: frappe/press#6769
