### PR TITLE
fix(dynamic_link): add support for single doctype

### DIFF
--- a/cypress/integration/control_dynamic_link.js
+++ b/cypress/integration/control_dynamic_link.js
@@ -150,7 +150,7 @@ context("Dynamic Link", () => {
 		cy.get_field("doc_type").clear();
 	});
 
-	it("Shows error when invalid DocType is passed", () => {
+	it("Shows only one option when Single DocType is passed", () => {
 		cy.new_form("Test Dynamic Link");
 		cy.get_field("doc_type").clear();
 
@@ -161,11 +161,12 @@ context("Dynamic Link", () => {
 		cy.window().its("cur_frm.doc.doc_type").should("eq", "System Settings");
 		cy.get_field("doc_id").click();
 
-		//Checking if the system throws error
-		cy.get(".modal-title").should("have.text", "Error");
-		cy.get(".msgprint").should(
-			"have.text",
-			"System Settings is not a valid DocType for Dynamic Link"
-		);
+		//Checking if the listbox have length equal to 1
+		cy.get('[data-fieldname="doc_id"]')
+			.find(".awesomplete")
+			.find("div")
+			.its("length")
+			.should("equal", 1);
+		cy.get_field("doc_type").clear();
 	});
 });

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -12,6 +12,7 @@ import frappe
 from frappe import _, bold, is_whitelisted
 from frappe.database.schema import SPECIAL_CHAR_PATTERN
 from frappe.model.db_query import get_order_by
+from frappe.model.utils import is_single_doctype
 from frappe.permissions import has_permission
 from frappe.utils import cint, cstr, escape_html, sbool, unique
 from frappe.utils.caching import http_cache
@@ -137,6 +138,15 @@ def search_widget(
 
 	if not searchfield:
 		searchfield = "name"
+
+	if is_single_doctype(doctype):
+		meta = frappe.get_meta(doctype)
+		name = _(doctype) if meta.translated_doctype else doctype
+		if for_link_validation:
+			return [[doctype]] if txt == doctype else []
+		if as_dict:
+			return [frappe._dict({"name": name})]
+		return [[name]]
 
 	standard_queries = frappe.get_hooks().standard_queries or {}
 

--- a/frappe/public/js/frappe/form/controls/dynamic_link.js
+++ b/frappe/public/js/frappe/form/controls/dynamic_link.js
@@ -21,10 +21,6 @@ frappe.ui.form.ControlDynamicLink = class ControlDynamicLink extends frappe.ui.f
 			options = frappe.model.get_value(this.df.parent, this.docname, this.df.options);
 		}
 
-		if (frappe.model.is_single(options)) {
-			frappe.throw(__("{0} is not a valid DocType for Dynamic Link", [options.bold()]));
-		}
-
 		return options;
 	}
 };

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -521,8 +521,8 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					}
 
 					// advanced search
-					if (locals && locals["DocType"]) {
-						// not applicable in web forms
+					if (locals && locals["DocType"] && !frappe.model.is_single(doctype)) {
+						// not applicable in web forms and single doctype for dynamic link
 						r.message.push({
 							html:
 								"<span class='link-option'>" +


### PR DESCRIPTION
Changes include:

- Previously, using a Single DocType as the linked type in a Dynamic Link field threw an error (`"{DocType} is not a valid DocType for Dynamic Link"`). Single DocTypes are valid link targets and this change adds proper support for them.
- `search_widget` in `frappe/desk/search.py` now short-circuits when the queried doctype is a single — it returns the doctype name directly as the only result, handling both `as_dict` and `for_link_validation` modes.
- The client-side error throw in `dynamic_link.js` is removed since singles are now handled gracefully server-side.
- The "Advanced Search" option in the link dropdown (`link.js`) is suppressed for single doctypes, as it is not meaningful — there is only one possible value.
- The Cypress test in `control_dynamic_link.js` is updated to verify that exactly one option is shown in the autocomplete when a Single DocType is selected, replacing the old assertion that an error dialog appears.

---

This is necessary as there are use cases where Dynamic Link fields have Single DocTypes, for example, users are allowed to send emails from a Single DocType; however, if they open the Communication record for that particular email, they're welcomed with the following error:

<img width="1160" height="653" alt="image" src="https://github.com/user-attachments/assets/32fee788-4ab2-4d02-b069-8e882bd06387" />
