### PR TITLE
refactor(commands): validate path arguments with click.Path

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -56,7 +56,12 @@ from frappe.utils.bench_helper import CliCtxObj
 @click.option("--admin-password", help="Administrator password for new site", default=None)
 @click.option("--verbose", is_flag=True, default=False, help="Verbose")
 @click.option("--force", help="Force restore if site/database already exists", is_flag=True, default=False)
-@click.option("--source-sql", "--source_sql", help="Initiate database with a SQL file")
+@click.option(
+	"--source-sql",
+	"--source_sql",
+	type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+	help="Initiate database with a SQL file",
+)
 @click.option("--install-app", multiple=True, help="Install app after installation")
 @click.option("--set-default", is_flag=True, default=False, help="Set the new site as default site")
 @click.option(
@@ -157,7 +162,10 @@ def new_site(
 
 
 @click.command("restore")
-@click.argument("sql-file-path")
+@click.argument(
+	"sql-file-path",
+	type=click.Path(dir_okay=False, resolve_path=True),
+)
 @click.option(
 	"--db-root-username",
 	"--mariadb-root-username",
@@ -167,9 +175,14 @@ def new_site(
 @click.option("--db-name", help="Database name for site in case it is a new one")
 @click.option("--admin-password", help="Administrator password for new site")
 @click.option("--install-app", multiple=True, help="Install app after installation")
-@click.option("--with-public-files", help="Restores the public files of the site, given path to its tar file")
+@click.option(
+	"--with-public-files",
+	type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+	help="Restores the public files of the site, given path to its tar file",
+)
 @click.option(
 	"--with-private-files",
+	type=click.Path(exists=True, dir_okay=False, resolve_path=True),
 	help="Restores the private files of the site, given path to its tar file",
 )
 @click.option(
@@ -379,17 +392,16 @@ def restore_backup(
 
 
 @click.command("partial-restore")
-@click.argument("sql-file-path")
+@click.argument(
+	"sql-file-path",
+	type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+)
 @click.option("--verbose", "-v", is_flag=True)
 @click.option("--encryption-key", help="Backup encryption key")
 @pass_context
 def partial_restore(context: CliCtxObj, sql_file_path, verbose, encryption_key=None):
 	from frappe.installer import is_partial, partial_restore
 	from frappe.utils.backups import decrypt_backup, get_or_generate_backup_encryption_key
-
-	if not os.path.exists(sql_file_path):
-		print("Invalid path", sql_file_path)
-		sys.exit(1)
 
 	site = get_site(context)
 	verbose = context.verbose or verbose
@@ -835,11 +847,36 @@ def use(site, sites_path="."):
 	type=str,
 	help="Specify the DocTypes to not backup seperated by commas",
 )
-@click.option("--backup-path", default=None, help="Set path for saving all the files in this operation")
-@click.option("--backup-path-db", default=None, help="Set path for saving database file")
-@click.option("--backup-path-files", default=None, help="Set path for saving public file")
-@click.option("--backup-path-private-files", default=None, help="Set path for saving private file")
-@click.option("--backup-path-conf", default=None, help="Set path for saving config file")
+@click.option(
+	"--backup-path",
+	default=None,
+	type=click.Path(dir_okay=True, file_okay=False, resolve_path=True),
+	help="Set path for saving all the files in this operation",
+)
+@click.option(
+	"--backup-path-db",
+	default=None,
+	type=click.Path(dir_okay=False, file_okay=True, resolve_path=True),
+	help="Set path for saving database file",
+)
+@click.option(
+	"--backup-path-files",
+	default=None,
+	type=click.Path(dir_okay=False, file_okay=True, resolve_path=True),
+	help="Set path for saving public file",
+)
+@click.option(
+	"--backup-path-private-files",
+	default=None,
+	type=click.Path(dir_okay=False, file_okay=True, resolve_path=True),
+	help="Set path for saving private file",
+)
+@click.option(
+	"--backup-path-conf",
+	default=None,
+	type=click.Path(dir_okay=False, file_okay=True, resolve_path=True),
+	help="Set path for saving config file",
+)
 @click.option(
 	"--ignore-backup-conf",
 	default=False,
@@ -991,7 +1028,10 @@ def uninstall(context: CliCtxObj, app, dry_run, yes, no_backup, force):
 	"--root-password",
 	help="Root password for MariaDB or PostgreSQL",
 )
-@click.option("--archived-sites-path")
+@click.option(
+	"--archived-sites-path",
+	type=click.Path(dir_okay=True, file_okay=False, resolve_path=True),
+)
 @click.option("--no-backup", is_flag=True, default=False)
 @click.option("--force", help="Force drop-site even if an error is encountered", is_flag=True, default=False)
 def drop_site(

--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -285,7 +285,11 @@ def _get_doctypes_for_module_def(app, module_def):
 @click.option("--coverage", is_flag=True, default=False)
 @click.option("--skip-test-records", is_flag=True, default=False, help="DEPRECATED")
 @click.option("--skip-before-tests", is_flag=True, default=False, help="Don't run before tests hook")
-@click.option("--junit-xml-output", help="Destination file path for junit xml report")
+@click.option(
+	"--junit-xml-output",
+	type=click.Path(dir_okay=False, file_okay=True, resolve_path=True),
+	help="Destination file path for junit xml report",
+)
 @click.option(
 	"--failfast", is_flag=True, default=False, help="Stop the test run on the first error or failure"
 )
@@ -442,7 +446,11 @@ def run_parallel_tests(
 @click.option("--parallel", is_flag=True, help="Run UI Test in parallel mode")
 @click.option("--with-coverage", is_flag=True, help="Generate coverage report")
 @click.option("--browser", default="chrome", help="Browser to run tests in")
-@click.option("--spec", help="Spec file to run")
+@click.option(
+	"--spec",
+	type=click.Path(dir_okay=False, file_okay=True),
+	help="Spec file to run",
+)
 @click.option("--ci-build-id")
 @pass_context
 def run_ui_tests(

--- a/frappe/commands/translate.py
+++ b/frappe/commands/translate.py
@@ -46,7 +46,10 @@ def new_language(context: CliCtxObj, lang_code, app):
 @click.command("get-untranslated")
 @click.option("--app", default="_ALL_APPS")
 @click.argument("lang")
-@click.argument("untranslated_file")
+@click.argument(
+	"untranslated_file",
+	type=click.Path(dir_okay=False, file_okay=True, resolve_path=True),
+)
 @click.option("--all", default=False, is_flag=True, help="Get all message strings")
 @pass_context
 def get_untranslated(context: CliCtxObj, lang, untranslated_file, app="_ALL_APPS", all=None):
@@ -65,8 +68,14 @@ def get_untranslated(context: CliCtxObj, lang, untranslated_file, app="_ALL_APPS
 @click.command("update-translations")
 @click.option("--app", default="_ALL_APPS")
 @click.argument("lang")
-@click.argument("untranslated_file")
-@click.argument("translated-file")
+@click.argument(
+	"untranslated_file",
+	type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+)
+@click.argument(
+	"translated-file",
+	type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+)
 @pass_context
 def update_translations(context: CliCtxObj, lang, untranslated_file, translated_file, app="_ALL_APPS"):
 	"Update translated strings"
@@ -83,7 +92,10 @@ def update_translations(context: CliCtxObj, lang, untranslated_file, translated_
 
 @click.command("import-translations")
 @click.argument("lang")
-@click.argument("path")
+@click.argument(
+	"path",
+	type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+)
 @pass_context
 def import_translations(context: CliCtxObj, lang, path):
 	"Update translated strings"

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -275,7 +275,10 @@ def execute(context: CliCtxObj, method, args=None, kwargs=None, profile=False, e
 
 
 @click.command("add-to-email-queue")
-@click.argument("email-path")
+@click.argument(
+	"email-path",
+	type=click.Path(exists=True, dir_okay=True, file_okay=False, resolve_path=True),
+)
 @pass_context
 def add_to_email_queue(context: CliCtxObj, email_path):
 	"Add an email to the Email Queue"
@@ -313,7 +316,10 @@ def export_doc(context: CliCtxObj, doctype, docname):
 
 @click.command("export-json")
 @click.argument("doctype")
-@click.argument("path")
+@click.argument(
+	"path",
+	type=click.Path(dir_okay=False, file_okay=True),
+)
 @click.option("--name", help="Export only one document")
 @pass_context
 def export_json(context: CliCtxObj, doctype, path, name=None):
@@ -333,7 +339,10 @@ def export_json(context: CliCtxObj, doctype, path, name=None):
 
 @click.command("export-csv")
 @click.argument("doctype")
-@click.argument("path")
+@click.argument(
+	"path",
+	type=click.Path(dir_okay=False, file_okay=True, resolve_path=True),
+)
 @pass_context
 def export_csv(context: CliCtxObj, doctype, path):
 	"Export data import template with data for DocType"
@@ -369,7 +378,10 @@ def export_fixtures(context: CliCtxObj, app=None):
 
 
 @click.command("import-doc")
-@click.argument("path")
+@click.argument(
+	"path",
+	type=click.Path(dir_okay=True, file_okay=True),
+)
 @pass_context
 def import_doc(context: CliCtxObj, path, force=False):
 	"Import (insert/update) doclist. If the argument is a directory, all files ending with .json are imported"
@@ -429,7 +441,10 @@ def data_import(
 
 @click.command("bulk-rename")
 @click.argument("doctype")
-@click.argument("path")
+@click.argument(
+	"path",
+	type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+)
 @pass_context
 def bulk_rename(context: CliCtxObj, doctype, path):
 	"Rename multiple records via CSV file"
@@ -778,7 +793,11 @@ def serve(
 
 @click.command("request")
 @click.option("--args", help="arguments like `?cmd=test&key=value` or `/api/request/method?..`")
-@click.option("--path", help="path to request JSON")
+@click.option(
+	"--path",
+	type=click.Path(dir_okay=False, file_okay=True),
+	help="path to request JSON",
+)
 @pass_context
 def request(context: CliCtxObj, args=None, path=None):
 	"Run a request as an admin"
@@ -815,7 +834,10 @@ def request(context: CliCtxObj, args=None, path=None):
 
 
 @click.command("make-app")
-@click.argument("destination")
+@click.argument(
+	"destination",
+	type=click.Path(exists=True, dir_okay=True, file_okay=False, resolve_path=True),
+)
 @click.argument("app_name")
 @click.option("--no-git", is_flag=True, default=False, help="Do not initialize git repository for the app")
 def make_app(destination, app_name, no_git=False):


### PR DESCRIPTION
Add `click.Path` types to file and directory arguments across site, utils, translate, and testing commands for early validation and path resolution. Remove redundant existence check in partial-restore.