### PR TITLE
fix: email account save fails with NONAUTH IMAP error on invalid credentials

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -426,7 +426,10 @@ class EmailAccount(Document):
 
 			all_error_codes = auth_error_codes + other_error_codes
 
-			if in_receive and any(map(lambda t: t in message, all_error_codes)):
+			# Disable only on background fetch; save validation errors should surface.
+			is_background_receive = in_receive and not bool(self.flags.validate_imap_pop_connection)
+
+			if is_background_receive and any(map(lambda t: t in message, all_error_codes)):
 				# if called via self.receive and it leads to authentication error,
 				# disable incoming and send email to System Manager
 				error_message = _(
@@ -438,7 +441,7 @@ class EmailAccount(Document):
 				self.handle_incoming_connect_error(description=error_message)
 				return None
 
-			elif not in_receive and any(map(lambda t: t in message, auth_error_codes)):
+			elif not is_background_receive and any(map(lambda t: t in message, auth_error_codes)):
 				SMTPServer.throw_invalid_credentials_exception()
 			else:
 				frappe.throw(cstr(e))

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -429,7 +429,7 @@ class EmailAccount(Document):
 			# Disable only on background fetch; save validation errors should surface.
 			is_background_receive = in_receive and not bool(self.flags.validate_imap_pop_connection)
 
-			if is_background_receive and any(map(lambda t: t in message, all_error_codes)):
+			if is_background_receive and any(t in message for t in all_error_codes):
 				# if called via self.receive and it leads to authentication error,
 				# disable incoming and send email to System Manager
 				error_message = _(
@@ -441,7 +441,7 @@ class EmailAccount(Document):
 				self.handle_incoming_connect_error(description=error_message)
 				return None
 
-			elif not is_background_receive and any(map(lambda t: t in message, auth_error_codes)):
+			elif not is_background_receive and any(t in message for t in auth_error_codes):
 				SMTPServer.throw_invalid_credentials_exception()
 			else:
 				frappe.throw(cstr(e))

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -406,6 +406,9 @@ class EmailAccount(Document):
 
 	def check_email_server_connection(self, email_server, in_receive):
 		# tries to connect to email server and handles failure
+		# in_receive is also set during save validation; only a real background fetch
+		# should auto-disable the account, a failed save must surface the error
+		is_background_receive = in_receive and not bool(self.flags.validate_imap_pop_connection)
 		try:
 			email_server.connect()
 
@@ -426,9 +429,6 @@ class EmailAccount(Document):
 
 			all_error_codes = auth_error_codes + other_error_codes
 
-			# Disable only on background fetch; save validation errors should surface.
-			is_background_receive = in_receive and not bool(self.flags.validate_imap_pop_connection)
-
 			if is_background_receive and any(t in message for t in all_error_codes):
 				# if called via self.receive and it leads to authentication error,
 				# disable incoming and send email to System Manager
@@ -447,7 +447,7 @@ class EmailAccount(Document):
 				frappe.throw(cstr(e))
 
 		except OSError:
-			if in_receive:
+			if is_background_receive:
 				# timeout while connecting, see receive.py connect method
 				description = frappe.message_log.pop() if frappe.message_log else "Socket Error"
 				self.db_set("no_failed", self.no_failed + 1)

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -2,10 +2,11 @@
 # License: MIT. See LICENSE
 
 import email
+import imaplib
 import os
 import unittest
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.core.doctype.communication.email import make
@@ -377,6 +378,31 @@ class TestEmailAccount(IntegrationTestCase):
 
 		with self.assertRaises(Exception):
 			email_account.validate()
+
+	def test_validation_surfaces_imap_auth_error(self):
+		# auth failure on save must raise, not swallow and leak a NONAUTH LIST error
+		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")
+		email_account.flags.validate_imap_pop_connection = True
+
+		server = MagicMock()
+		server.connect.side_effect = imaplib.IMAP4.error("[AUTHENTICATIONFAILED] Invalid credentials")
+
+		with self.assertRaises(frappe.ValidationError):
+			email_account.check_email_server_connection(server, in_receive=True)
+
+	def test_background_receive_auth_error_disables_account(self):
+		# auth failure during background receive disables incoming instead of raising
+		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")
+		email_account.flags.validate_imap_pop_connection = False
+
+		server = MagicMock()
+		server.connect.side_effect = imaplib.IMAP4.error("[AUTHENTICATIONFAILED] Invalid credentials")
+
+		with patch.object(email_account, "handle_incoming_connect_error") as mocked_handler:
+			result = email_account.check_email_server_connection(server, in_receive=True)
+
+		self.assertIsNone(result)
+		mocked_handler.assert_called_once()
 
 	def test_append_to(self):
 		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -390,6 +390,17 @@ class TestEmailAccount(IntegrationTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			email_account.check_email_server_connection(server, in_receive=True)
 
+	def test_validation_surfaces_imap_connection_error(self):
+		# a connection/timeout failure on save must raise too, not swallow into a NONAUTH leak
+		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")
+		email_account.flags.validate_imap_pop_connection = True
+
+		server = MagicMock()
+		server.connect.side_effect = OSError("timed out")
+
+		with self.assertRaises(OSError):
+			email_account.check_email_server_connection(server, in_receive=True)
+
 	def test_background_receive_auth_error_disables_account(self):
 		# auth failure during background receive disables incoming instead of raising
 		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")


### PR DESCRIPTION
## Problem

Saving an Email Account with IMAP enabled and incorrect credentials fails with a
raw traceback instead of a clear credentials error:

## Root cause

`validate()` opens the incoming connection via `get_incoming_server(in_receive=self.use_imap)`, so for IMAP accounts
`in_receive` is `True`. This routes an authentication failure into `check_email_server_connection`'s background-receive branch, which disables incoming and returns `None` instead of raising.

`get_incoming_server` then hands back the unauthenticated server, and `validate_imap_folders_exist` calls `server.imap.list()` on a connection still in the `NONAUTH` state which is where the `imaplib` error originates.

That branch is meant for the scheduled fetch, not for validation on save.

## Fix

`validate()` already sets `self.flags.validate_imap_pop_connection`. The
connection check now uses this flag to separate the two paths:

- **Background fetch** → still disables the account on auth failure (unchanged).
- **Save / validation** → surfaces the credentials error and never reaches the
  folder listing.

Closes #39567