### PR TITLE
fix(kanban): Autoscrolling

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -127,6 +127,15 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 		}
 	}
 
+	setup_result_container_area() {
+		// pass
+	}
+
+	setup_result_area() {
+		this.$result = $(`<div class="result">`);
+		this.$frappe_list.append(this.$result);
+	}
+
 	setup_paging_area() {
 		// pass
 	}


### PR DESCRIPTION
Resolve: #40019

## Problem

Dragging a card to the screen edge no longer triggered autoscroll in v16. `KanbanView` extends `ListView`, which sets `this.view = "List"`. A new `setup_result_container_area()` method added in v16 uses that check to wrap `$result` in a `.result-container` div. That div carries `overflow-x: auto` CSS, making it the nearest scrollable ancestor that SortableJS finds during drag. Scrolling it has no visible effect, so autoscroll appears broken.

> [!NOTE]
>   `.result-container` is intended only for the List view to enable horizontal scrolling of list rows. For Kanban, it acts as a dead scroll layer between the drag event and the actual `.kanban` scroll container.

This did not affect v15, which did not have `setup_result_container_area`.

## Fix

Override `setup_result_container_area` and `setup_result_area` in `KanbanView`, following the same pattern already used for `setup_paging_area` and `set_result_height`:

- `setup_result_container_area` is a no-op, so no intermediate container is created
- `setup_result_area` appends `$result` directly to `frappe-list`, bypassing the container lookup


https://github.com/user-attachments/assets/846dacc8-7a05-4583-a9df-b079669216d8

