### PR TITLE
fix: revert date-based naming series against name's date, not current date

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -481,9 +481,16 @@ def revert_series_if_last(key, name, doc=None):
 		prefix = key
 
 	if "." in prefix:
-		prefix = parse_naming_series(prefix.split("."), doc=doc)
-
-	count = cint(name.replace(prefix, ""))
+		# Prefix has placeholders (e.g. date parts .YYYY./.MM./.DD.). Resolving them against
+		# the current date breaks reverts when a document is deleted on a different day than
+		# it was created. The resolved prefix length is date-independent (YYYY is always 4
+		# chars, MM 2, etc.), so resolve only to learn the length, then slice the prefix and
+		# counter from the document's own name.
+		boundary = len(parse_naming_series(prefix.split("."), doc=doc))
+		count = cint(name[boundary:])
+		prefix = name[:boundary]
+	else:
+		count = cint(name.replace(prefix, ""))
 	series = DocType("Series")
 	current = (frappe.qb.from_(series).where(series.name == prefix).for_update().select("current")).run()
 

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -275,6 +275,22 @@ class TestNaming(IntegrationTestCase):
 
 		frappe.db.delete("Series", {"name": series})
 
+	def test_revert_series_date_based_cross_date(self):
+		# A date-templated series must revert against the date embedded in the name,
+		# not the current date. Deleting a doc created on a different day should still
+		# decrement that day's counter.
+		key = "PO-.YYYY.-.MM.-.DD.-.###"
+		series = "PO-2020-01-01-"
+		name = "PO-2020-01-01-005"
+		frappe.db.delete("Series", {"name": series})
+		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 5)""", (series,))
+		revert_series_if_last(key, name)
+		current_index = frappe.db.sql(
+			"""SELECT current from `tabSeries` where name = %s""", series, as_dict=True
+		)[0]
+		self.assertEqual(current_index.get("current"), 4)
+		frappe.db.delete("Series", {"name": series})
+
 	def test_naming_for_cancelled_and_amended_doc(self):
 		submittable_doctype = frappe.get_doc(
 			{


### PR DESCRIPTION
## Problem

Deleting the last document of a **date-templated** naming series (e.g. `PO-.YYYY.-.MM.-.DD.-.###`) does not free up its number when the deletion happens on a **different day** than the document was created. The next document gets a new number instead of reusing the deleted one.

Reproduction:
- Create `PO-2026-05-18-049` on May 18
- On a later day, delete it
- Next PO becomes `...-050` instead of reusing `...-049`

## Root cause

`revert_series_if_last()` re-resolved the prefix by calling `parse_naming_series(prefix.split("."), doc=doc)`, which expands `.YYYY./.MM./.DD.` placeholders against `now_datetime()` — i.e. **today**. When the delete happens on a different day, this produces the wrong `tabSeries` key (today's date), so the row for the document's actual creation-date counter is never found and never decremented.

## Fix

When the prefix still contains placeholders, derive the prefix and counter directly from the document's own name (which already has the correct date baked in) instead of re-resolving placeholders against the current date. Non-templated series are untouched (they take the existing `else` path).

The decrement remains guarded by an exact match (`current == count` for the exact prefix row), so a malformed name can only no-op, never corrupt a counter.

## Tests

Added `test_revert_series_date_based_cross_date` covering the cross-date revert. Existing naming tests pass.
