### PR TITLE
fix: ensure all deferred inserts are properly committed

### DIFF
--- a/frappe/deferred_insert.py
+++ b/frappe/deferred_insert.py
@@ -35,17 +35,15 @@ def save_to_db():
 			records = frappe.cache.lpop(queue_key)
 			records = json.loads(records.decode("utf-8"))
 			if isinstance(records, dict):
-				record_count += 1
-				insert_record(records, doctype)
-				continue
+				records = [records]
 			for record in records:
 				record_count += 1
 				insert_record(record, doctype)
 				if record_count % 100 == 0:
 					frappe.db.commit()
 
-			if record_count % 100 == 0:
-				frappe.db.commit()
+		if record_count:
+			frappe.db.commit()
 
 
 def insert_record(record: dict | "Document", doctype: str):


### PR DESCRIPTION
Previously, `save_to_db` failed to commit records inside the function if the batch size wasn't a perfect multiple of 100, or if the payload was a single dictionary. This caused stranded records in the open transaction, leading to silent data loss if the worker crashed or when called directly during migrations.

This fix:
- Wraps single dicts in a list, removing the buggy `continue` statement so they are processed safely by the main loop.
- Adds a final catch-all commit outside the `while` loop to guarantee any remaining records are successfully commited to the database before moving to the next queue.

Closes #40107

On bahelf of @AdnanQuazi 