### PR TITLE
fix: mask fields in child tables and keep masked numeric fields hidden

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -568,7 +568,7 @@ class BaseDocument:
 			# Masked fields hold the XXXXXXXX placeholder; pass it through untouched so it is not
 			# cast back to 0 for numeric fieldtypes. Only truthy values get masked, so falsy ones
 			# fall through to the normal null-aware path.
-			if masked_fieldnames and fieldname in masked_fieldnames and value:
+			if value and fieldname in (masked_fieldnames or ()):
 				d[fieldname] = value
 				continue
 

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -560,9 +560,16 @@ class BaseDocument:
 		d = _dict()
 		field_values = self.__dict__
 		field_map = self.meta._fields
+		masked_fieldnames = self.flags.get("masked_fieldnames")
 
 		for fieldname in self.meta.get_valid_fields():
 			value = field_values.get(fieldname)
+
+			# Masked fields hold the XXXXXXXX placeholder; pass it through untouched so it
+			# is not cast back to 0 for numeric fieldtypes.
+			if masked_fieldnames and fieldname in masked_fieldnames:
+				d[fieldname] = value
+				continue
 
 			# if no need for sanitization and value is None, continue
 			if not sanitize and value is None:

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -565,9 +565,10 @@ class BaseDocument:
 		for fieldname in self.meta.get_valid_fields():
 			value = field_values.get(fieldname)
 
-			# Masked fields hold the XXXXXXXX placeholder; pass it through untouched so it
-			# is not cast back to 0 for numeric fieldtypes.
-			if masked_fieldnames and fieldname in masked_fieldnames:
+			# Masked fields hold the XXXXXXXX placeholder; pass it through untouched so it is not
+			# cast back to 0 for numeric fieldtypes. Only truthy values get masked, so falsy ones
+			# fall through to the normal null-aware path.
+			if masked_fieldnames and fieldname in masked_fieldnames and value:
 				d[fieldname] = value
 				continue
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -566,9 +566,25 @@ class Document(BaseDocument):
 
 		mask_fields = frappe.get_meta(self.doctype).get_masked_fields()
 
+		if mask_fields:
+			# Flag masked fields so get_valid_dict() does not cast the XXXXXXXX placeholder
+			# back to 0 for numeric fieldtypes when serializing the response.
+			self.flags.masked_fieldnames = {field.fieldname for field in mask_fields}
+
 		for field in mask_fields:
 			val = self.get(field.fieldname)
 			self.set(field.fieldname, mask_field_value(field, val))
+
+		for table_field in self.meta.get_table_fields():
+			child_mask_fields = frappe.get_meta(table_field.options).get_masked_fields()
+			if not child_mask_fields:
+				continue
+
+			masked_fieldnames = {field.fieldname for field in child_mask_fields}
+			for row in self.get(table_field.fieldname) or []:
+				row.flags.masked_fieldnames = masked_fieldnames
+				for field in child_mask_fields:
+					row.set(field.fieldname, mask_field_value(field, row.get(field.fieldname)))
 
 	def load_children_from_db(self):
 		is_doctype = self.doctype == "DocType"
@@ -1225,7 +1241,12 @@ class Document(BaseDocument):
 			return
 
 		mask_fields = self.meta.get_masked_fields()
-		if not mask_fields:
+		child_mask_fields = {
+			table_field.fieldname: masked
+			for table_field in self.meta.get_table_fields()
+			if (masked := frappe.get_meta(table_field.options).get_masked_fields())
+		}
+		if not mask_fields and not child_mask_fields:
 			return
 
 		# frappe.db.get_value() goes through the query builder which re-masks results for
@@ -1234,6 +1255,15 @@ class Document(BaseDocument):
 		db_doc = frappe.get_doc(self.doctype, self.name)
 		for df in mask_fields:
 			self.set(df.fieldname, db_doc.get(df.fieldname))
+
+		for fieldname, masked in child_mask_fields.items():
+			db_rows = {row.name: row for row in db_doc.get(fieldname)}
+			for row in self.get(fieldname) or []:
+				db_row = db_rows.get(row.name)
+				if not db_row:
+					continue
+				for df in masked:
+					row.set(df.fieldname, db_row.get(df.fieldname))
 
 	def validate_higher_perm_levels(self):
 		"""If the user does not have permissions at permlevel > 0, then reset the values to original / default"""

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1260,6 +1260,7 @@ class Document(BaseDocument):
 			db_rows = {row.name: row for row in db_doc.get(fieldname)}
 			for row in self.get(fieldname) or []:
 				db_row = db_rows.get(row.name)
+				# new rows have no DB counterpart — nothing to restore
 				if not db_row:
 					continue
 				for df in masked:

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -725,9 +725,23 @@ export default class Grid {
 
 		this._apply_layout_child_overrides();
 		this._apply_column_disp_overrides();
+		this._apply_mask_overrides();
 
 		this.docfields.forEach((df) => {
 			this.fields_map[df.fieldname] = df;
+		});
+	}
+
+	_apply_mask_overrides() {
+		const masked_fields = frappe.get_meta(this.doctype)?.masked_fields || [];
+		if (!masked_fields.length) return;
+
+		// Shallow copy so the shared `frappe.meta` docfield is not mutated. Render masked
+		// child fields as read-only Data so the grid shows the XXXXXXXX placeholder and the
+		// cell can't be edited inline, matching the form view (layout.init_field).
+		this.docfields = this.docfields.map((df) => {
+			if (!masked_fields.includes(df.fieldname)) return df;
+			return Object.assign({}, df, { read_only: 1, fieldtype: "Data" });
 		});
 	}
 

--- a/frappe/tests/test_mask_fields.py
+++ b/frappe/tests/test_mask_fields.py
@@ -19,6 +19,7 @@ from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.model.utils.mask import mask_field_value
 from frappe.permissions import add_user_permission, update_permission_property
 from frappe.tests import IntegrationTestCase
+from frappe.utils import flt
 
 
 def _make_field(fieldname, fieldtype="Data", options=None, mask=1, **kwargs):
@@ -302,6 +303,106 @@ class TestMaskFieldsBehaviour(IntegrationTestCase):
 		finally:
 			update_permission_property(self.dt, self.TEST_ROLE, 0, "mask", 0)
 			frappe.clear_cache(doctype=self.dt)
+
+
+class TestMaskFieldsInChildTable(IntegrationTestCase):
+	"""Regression test for issue #39679: masked child-table fields must be masked on read
+	(numeric ones as the placeholder, not cast back to 0) and restored on save."""
+
+	TEST_USER = "test_mask_child_user@example.com"
+	TEST_ROLE = "Test Mask Child Role"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+
+		if not frappe.db.exists("Role", cls.TEST_ROLE):
+			frappe.get_doc({"doctype": "Role", "role_name": cls.TEST_ROLE, "desk_access": 1}).insert()
+
+		if not frappe.db.exists("User", cls.TEST_USER):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": cls.TEST_USER,
+					"first_name": "Mask Child Test",
+					"send_welcome_email": 0,
+					"roles": [{"role": cls.TEST_ROLE}],
+				}
+			).insert(ignore_permissions=True)
+		else:
+			frappe.get_doc("User", cls.TEST_USER).add_roles(cls.TEST_ROLE)
+
+		# Child doctype with a masked Data field, a masked Currency field and an unmasked Float
+		cls.child_dt = (
+			new_doctype(
+				istable=1,
+				fields=[
+					_make_field("secret_note", "Data", mask=1),
+					_make_field("rate", "Currency", mask=1),
+					_make_field("public_qty", "Float", mask=0),
+				],
+			)
+			.insert()
+			.name
+		)
+
+		cls.dt = (
+			new_doctype(
+				fields=[_make_field("items", "Table", options=cls.child_dt, mask=0)],
+				permissions=[{"role": cls.TEST_ROLE, "read": 1, "write": 1, "create": 1}],
+			)
+			.insert()
+			.name
+		)
+
+		doc = frappe.get_doc(
+			{
+				"doctype": cls.dt,
+				"items": [{"secret_note": "child_secret", "rate": 1234.5, "public_qty": 7}],
+			}
+		).insert()
+		cls.docname = doc.name
+		cls.row_name = doc.items[0].name
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		frappe.db.delete(cls.dt)
+		frappe.db.delete(cls.child_dt)
+		frappe.delete_doc("DocType", cls.dt, force=True)
+		frappe.delete_doc("DocType", cls.child_dt, force=True)
+		if frappe.db.exists("User", cls.TEST_USER):
+			frappe.db.set_value("User", cls.TEST_USER, "enabled", 0)
+		super().tearDownClass()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_child_masked_fields_masked_for_non_admin(self):
+		"""Child masked fields are masked on read; numeric ones survive serialization as the
+		placeholder instead of being cast to 0."""
+		frappe.set_user(self.TEST_USER)
+		doc = frappe.get_doc(self.dt, self.docname)
+		doc.apply_fieldlevel_read_permissions()
+
+		self.assertEqual(doc.items[0].secret_note, "XXXXXXXX")
+		self.assertEqual(doc.items[0].rate, "XXXXXXXX")
+		self.assertEqual(doc.items[0].public_qty, 7)  # unmasked field untouched
+		# numeric placeholder must not be cast back to 0 when serialized for the client
+		self.assertEqual(doc.as_dict()["items"][0]["rate"], "XXXXXXXX")
+
+	def test_masked_child_value_preserved_on_save(self):
+		"""Saving with the placeholder in a masked child field keeps the real DB value."""
+		frappe.set_user(self.TEST_USER)
+		doc = frappe.get_doc(self.dt, self.docname)
+		doc.items[0].rate = "XXXXXXXX"  # as sent by the client
+		doc.items[0].public_qty = 9
+		doc.save()
+
+		frappe.set_user("Administrator")
+		saved = frappe.db.get_value(self.child_dt, self.row_name, ["rate", "public_qty"], as_dict=True)
+		self.assertEqual(flt(saved.rate), 1234.5)  # masked value restored, not overwritten
+		self.assertEqual(flt(saved.public_qty), 9)  # unmasked field still writable
 
 
 class TestMaskFieldsWithUserPermissions(IntegrationTestCase):


### PR DESCRIPTION
## Problem

The `mask` DocField property hides a field's value from users who lack the `mask` permission. It worked for top-level fields but broke down for fields inside child tables, and behaved inconsistently for numeric fields.

For a user without the `mask` permission:

- A masked field in a child-table grid **leaked its real value**, stayed editable inline, and only switched to read-only after the row form was opened and closed.
- Masked numeric fields (Currency/Float/Int) rendered as `0` instead of a masked placeholder; worse than hiding them, since `0` reads as a real value.

## Root cause

- `Document.mask_fields()` only masked the parent doctype's own fields. Child rows load via raw SQL (`_load_child_table_from_db`), which bypasses the query-builder masking layer, and `mask_fields()` never walked the child tables; so child masked values reached the client untouched.
- On save, `_restore_masked_fields_from_db()` restored only the parent's masked fields, so a placeholder posted back for a masked child field could overwrite the stored value.
- In the grid, only the expanded row form applied the read-only/placeholder treatment; inline cells rendered as normal editable columns.
- For numeric fields, `mask_field_value()` returns the `XXXXXXXX` string, but `get_valid_dict()` cast it back to `0` for numeric fieldtypes during serialization, so the client never received a placeholder.

## Fix

- `mask_fields()` now also iterates child tables and masks their masked fields, mirroring the child-table handling already in `apply_fieldlevel_read_permissions()`.
- `_restore_masked_fields_from_db()` restores masked child fields from the database (matching rows by `name`) before write-permission checks, so a placeholder can't overwrite real data.
- The grid marks masked child columns read-only and renders the placeholder, matching the row form.
- For numeric fields, `mask_fields()` records the masked fieldnames in a flag and `get_valid_dict()` passes those values through without casting, so the `XXXXXXXX` placeholder survives serialization. The flag is set only on the read path (inside `apply_fieldlevel_read_permissions()`), so serialization during a save is unaffected.

## Result

For a user without the `mask` permission, every masked field - Data, Currency, Float, on the parent form and inside the child-table grid; now shows the masked placeholder and is read-only, instead of leaking the value, showing `0`, or
remaining editable.

## Steps to reproduce

1. Create a role without the `mask` permission on a doctype that has a child table, and a user with only that role.
2. On the parent and child doctypes, enable `mask` on a Data field and on a Currency/Float field.
3. As that user, open an existing record with data.

## Before/After
<img width="1178" height="580" alt="Screenshot 2026-06-23 at 3 38 56 PM" src="https://github.com/user-attachments/assets/f93c294e-913a-4e8e-b403-b54e489df427" />
<img width="1005" height="767" alt="Screenshot 2026-06-23 at 3 39 12 PM" src="https://github.com/user-attachments/assets/1c41048c-b3bd-4a3c-9af7-e23ce7e5a943" />

---
Closes #39679