### PR TITLE
fix(test): bump memory baseline for concurrency_limiter eager import

### DIFF
--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -181,6 +181,12 @@ class TestRQJob(IntegrationTestCase):
 		# Observed higher usage on 3.14. Temporarily raising the limit
 		LAST_MEASURED_USAGE += 6
 
+		# PR #38576 added `from frappe.concurrency_limiter import concurrent_limit` as an eager
+		# top-level import in frappe/__init__.py, which loads concurrency_limiter and its
+		# redis_semaphore dependency on every frappe startup including background jobs.
+		# (On develop this is already lazy via _LAZY_IMPORTS; backporting that is out of scope here.)
+		LAST_MEASURED_USAGE += 2
+
 		self.assertLessEqual(rss, LAST_MEASURED_USAGE * 1.05, msg)
 
 	def test_clear_failed_jobs(self):


### PR DESCRIPTION
## Problem

`test_memory_usage` is failing on **every PR that touches `.py` or `.json` files** on the `version-16-hotfix` branch:

```
AssertionError: 57 not less than or equal to 56.7 : Memory usage of simple background job increased.
```

RSS = **57 MB**, threshold = **56.7 MB** (= 54 × 1.05). The test is failing by 0.3 MB.

## Root Cause

**PR #38576** ("feat: add `@frappe.concurrent_limit()` decorator") added this eager top-level import to `frappe/__init__.py`:

```python
from frappe.concurrency_limiter import concurrent_limit
```

This causes `frappe.concurrency_limiter` and its dependency `frappe.utils.redis_semaphore` to be loaded on **every** frappe startup — including background jobs. The test measures RSS of a minimal background job, so this extra load is reflected directly in the measurement.

The baseline was last bumped in January 2026 (adding `+6` for Python 3.14), before the concurrency limiter was introduced in April 2026.

## Why develop is not affected

On `develop`, this was already fixed in commit `e2a02985a0` which moved `concurrent_limit` into the `_LAZY_IMPORTS` registry (loaded only on first access via `__getattr__`). Backporting the entire `_LAZY_IMPORTS` infrastructure to `version-16-hotfix` is out of scope for a hotfix.

## Fix

Bump `LAST_MEASURED_USAGE` by `+2` on `version-16-hotfix` with a comment explaining the root cause, bringing the threshold to:
- **Without mysqlclient**: 54 × 1.05 = **56.7 MB**
- **With mysqlclient (CI)**: 56 × 1.05 = **58.8 MB** ✓ (RSS = 57 MB passes)

## Test Plan
- [ ] `bench run-tests --module frappe.core.doctype.rq_job.test_rq_job` passes