### PR TITLE
perf: lazy-load concurrent_limit in frappe/__init__.py

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1594,7 +1594,16 @@ from frappe.utils.error import log_error
 from frappe.utils.formatters import format_value
 from frappe.utils.print_utils import get_print, attach_print
 from frappe.email import sendmail
-from frappe.concurrency_limiter import concurrent_limit
+
+
+def __getattr__(name: str):
+	if name == "concurrent_limit":
+		from frappe.concurrency_limiter import concurrent_limit
+
+		globals()["concurrent_limit"] = concurrent_limit
+		return concurrent_limit
+	raise AttributeError(f"module 'frappe' has no attribute {name!r}")
+
 
 # for backwards compatibility
 format = format_value


### PR DESCRIPTION
## Problem

`test_memory_usage` fails on **every PR that touches `.py`/`.json` files** on `version-16-hotfix`:

```
AssertionError: 57 not less than or equal to 56.7
```

## Root Cause

**PR #38576** added `from frappe.concurrency_limiter import concurrent_limit` as an **eager top-level import** at the bottom of `frappe/__init__.py`. This causes `concurrency_limiter` and its `redis_semaphore` dependency to be loaded on **every** frappe startup — including background job workers — increasing RSS by ~2 MB.

The test baseline (54 MB threshold × 1.05 = 56.7 MB) was set before this import was added in April 2026, so the now-57 MB RSS exceeds it.

## Fix

Remove the eager import and replace it with a module-level `__getattr__` that loads `concurrent_limit` only on first access. Callers using `@frappe.concurrent_limit()` continue to work transparently; the module just isn't loaded at startup.

```python
# before
from frappe.concurrency_limiter import concurrent_limit   # loaded on every startup

# after — loaded only when first accessed as frappe.concurrent_limit
def __getattr__(name: str):
    if name == "concurrent_limit":
        from frappe.concurrency_limiter import concurrent_limit
        globals()["concurrent_limit"] = concurrent_limit
        return concurrent_limit
    raise AttributeError(f"module 'frappe' has no attribute {name!r}")
```

**Note:** `develop` already has this fixed via `_LAZY_IMPORTS` + `__getattr__` (commit `e2a02985a0`). This PR applies the equivalent minimal fix to `version-16-hotfix` which lacks that infrastructure.