### PR TITLE
fix: lazy load click in print_utils to reduce worker memory usage

### DIFF
--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -2,8 +2,6 @@ import os
 import re
 from typing import Literal
 
-import click
-
 import frappe
 from frappe.utils.data import cint, cstr
 
@@ -183,8 +181,9 @@ def attach_print(
 
 def setup_chromium():
 	"""Setup Chromium at the bench level."""
-	# Load Chromium version from common_site_config.json or use default
+	import click
 
+	# Load Chromium version from common_site_config.json or use default
 	try:
 		executable = find_or_download_chromium_executable()
 		click.echo(f"Chromium is already set up at {executable}")
@@ -199,6 +198,8 @@ def find_or_download_chromium_executable():
 	import platform
 	import shutil
 	from pathlib import Path
+
+	import click
 
 	if chromium_path := shutil.which(frappe.get_common_site_config().get("chromium_path", "")):
 		return chromium_path
@@ -233,6 +234,7 @@ def download_chromium():
 	import shutil
 	import zipfile
 
+	import click
 	import requests
 
 	bench_path = frappe.utils.get_bench_path()
@@ -382,6 +384,8 @@ def get_chromium_download_url():
 
 def make_chromium_executable(executable):
 	"""Make the Chromium executable."""
+	import click
+
 	if os.path.exists(executable):
 		# check if the file is executable
 		if os.access(executable, os.X_OK):


### PR DESCRIPTION
## What

Moves `import click` from the module top level inside the functions that actually use it (`setup_chromium`, `find_or_download_chromium_executable`, `download_chromium`, `make_chromium_executable`).

## Why

`click` was being loaded on every frappe startup — including background workers — because `frappe/__init__.py` eagerly imports `from frappe.utils.print_utils import get_print, attach_print`. `click` is a CLI framework (~2-3 MB) and is only needed when setting up/downloading the chromium binary, not on every import.

This was causing `test_memory_usage` to fail on all PRs with `.py`/`.json` changes on `version-16-hotfix` (rss=57 MB vs threshold=56.7 MB).

**Root cause:** commit 8649c18125 ("feat: allow use of chrome pdf generator for standard print format"), which added `import click` at the top level of `print_utils.py` after the January 2026 baseline bump in the test.

Note: develop is not affected — it uses lazy loading for all `frappe/__init__.py` imports via `__getattr__`.