### PR TITLE
fix(postgres): sort NULLs like MariaDB (NULLS FIRST under ASC, LAST under DESC)

### DIFF
--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -28,6 +28,51 @@ NestedSetHierarchy = (
 # split when non-alphabetical character is found
 QUERY_TYPE_PATTERN = re.compile(r"\s*([A-Za-z]*)")
 
+# matches a trailing DESC on an ORDER BY term (so a NULLS modifier can be chosen)
+_TRAILING_DESC = re.compile(r"\bdesc\b\s*$", re.IGNORECASE)
+
+
+def add_null_ordering_for_postgres(order_by: str) -> str:
+	"""Append ``NULLS FIRST``/``NULLS LAST`` so NULLs sort on PostgreSQL the way they do on MariaDB.
+
+	MariaDB treats ``NULL`` as the lowest value (NULLs first under ``ASC``, last under ``DESC``);
+	PostgreSQL defaults to the opposite (``NULLS LAST`` for ``ASC``, ``NULLS FIRST`` for ``DESC``).
+	Without this, an ``ORDER BY ... LIMIT 1`` or a first-row pick on a nullable column returns a
+	different row on the two backends. Reproducing MariaDB's placement keeps them identical.
+
+	``order_by`` is the clause body (no leading ``order by``). Terms are split on *top-level* commas
+	so a function call's argument commas are preserved, and a term that already carries ``NULLS`` is
+	left untouched (idempotent). Intended for PostgreSQL only; MariaDB needs no modifier.
+	"""
+	if not order_by:
+		return order_by
+
+	terms, depth, current = [], 0, []
+	for char in order_by:
+		if char == "(":
+			depth += 1
+		elif char == ")":
+			depth = max(depth - 1, 0)
+		if char == "," and depth == 0:
+			terms.append("".join(current))
+			current = []
+		else:
+			current.append(char)
+	terms.append("".join(current))
+
+	out = []
+	for term in terms:
+		term = term.strip()
+		if not term:
+			continue
+		if " nulls " in f" {term.lower()} ":  # already has NULLS FIRST/LAST
+			out.append(term)
+		elif _TRAILING_DESC.search(term):
+			out.append(f"{term} NULLS LAST")
+		else:  # ASC or unspecified -> ascending -> NULLs first, like MariaDB
+			out.append(f"{term} NULLS FIRST")
+	return ", ".join(out)
+
 
 def convert_to_value(o: FilterValue):
 	if isinstance(o, bool):

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -30,6 +30,8 @@ QUERY_TYPE_PATTERN = re.compile(r"\s*([A-Za-z]*)")
 
 # matches a trailing DESC on an ORDER BY term (so a NULLS modifier can be chosen)
 _TRAILING_DESC = re.compile(r"\bdesc\b\s*$", re.IGNORECASE)
+# matches an existing NULLS FIRST/LAST modifier (so the term is left untouched)
+_NULLS_MODIFIER = re.compile(r"\bnulls\s+(first|last)\b", re.IGNORECASE)
 
 
 def add_null_ordering_for_postgres(order_by: str) -> str:
@@ -65,7 +67,7 @@ def add_null_ordering_for_postgres(order_by: str) -> str:
 		term = term.strip()
 		if not term:
 			continue
-		if " nulls " in f" {term.lower()} ":  # already has NULLS FIRST/LAST
+		if _NULLS_MODIFIER.search(term):  # already has NULLS FIRST/LAST
 			out.append(term)
 		elif _TRAILING_DESC.search(term):
 			out.append(f"{term} NULLS LAST")

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -244,8 +244,39 @@ def patch_like_operators():
 	Term.not_like = not_like  # nosemgrep: frappe-monkey-patching-not-allowed
 
 
+def patch_null_ordering():
+	"""Make NULLs sort on postgres the way they sort on MariaDB.
+
+	MariaDB treats NULL as the lowest value -- NULLs come first under ASC and last under DESC.
+	Postgres defaults to the opposite (NULLs last under ASC, first under DESC), so an
+	``ORDER BY ... LIMIT 1`` or a first-row pick on a nullable column returns a different row on the
+	two backends. Appending an explicit ``NULLS FIRST``/``NULLS LAST`` per term reproduces MariaDB's
+	placement. This covers every query the query builder renders -- ``get_all``/``get_list`` (which
+	build on it) and raw ``frappe.qb`` alike. MariaDB rendering is untouched.
+
+	Patches ``QueryBuilder._orderby_sql`` the same way ``patch_like_operators`` patches ``Term.like``
+	(pypika has no hook for dialect-specific rendering).
+	"""
+	from pypika.queries import QueryBuilder  # nosemgrep: frappe-monkey-patching-not-allowed
+
+	_orderby_sql = QueryBuilder._orderby_sql
+	prefix = " ORDER BY "
+
+	def orderby_sql(self, *args, **kwargs):
+		sql = _orderby_sql(self, *args, **kwargs)
+		if sql and sql.startswith(prefix) and frappe.db and frappe.db.db_type == "postgres":
+			# imported lazily: frappe.database.utils <-> frappe.query_builder.builder would cycle at boot
+			from frappe.database.utils import add_null_ordering_for_postgres
+
+			sql = prefix + add_null_ordering_for_postgres(sql[len(prefix) :])
+		return sql
+
+	QueryBuilder._orderby_sql = orderby_sql  # nosemgrep: frappe-monkey-patching-not-allowed
+
+
 def patch_all():
 	patch_query_execute()
 	patch_query_aggregation()
 	patch_get_query()
 	patch_like_operators()
+	patch_null_ordering()

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -784,7 +784,11 @@ class TestNullOrdering(IntegrationTestCase):
 			'COALESCE("valid_from", \'1900-01-01\') desc NULLS LAST, "creation" asc NULLS FIRST',
 		)
 		# idempotent
+		# idempotent only on a real NULLS FIRST/LAST modifier ...
 		self.assertEqual(nz('"x" desc NULLS LAST'), '"x" desc NULLS LAST')
+		# ... a column/alias literally named `nulls` is not a modifier and still gets one appended
+		self.assertEqual(nz('"nulls" desc'), '"nulls" desc NULLS LAST')
+		self.assertEqual(nz("nulls asc"), "nulls asc NULLS FIRST")
 		self.assertEqual(nz(""), "")
 
 	@run_only_if(db_type_is.POSTGRES)
@@ -793,3 +797,29 @@ class TestNullOrdering(IntegrationTestCase):
 		user = frappe.qb.DocType("User")
 		query = str(frappe.qb.from_(user).select(user.name).orderby(user.last_login, order=frappe.qb.desc))
 		self.assertIn("NULLS LAST", query.upper())
+
+	@run_only_if(db_type_is.POSTGRES)
+	def test_null_row_sorts_like_mariadb(self):
+		"""A NULL sort value lands last under DESC and first under ASC, like MariaDB."""
+		dated = frappe.get_doc(doctype="ToDo", description="nulls_dated", date="2024-01-01").insert()
+		undated = frappe.get_doc(doctype="ToDo", description="nulls_undated", date="2024-02-01").insert()
+		self.addCleanup(dated.delete)
+		self.addCleanup(undated.delete)
+		# force a genuine NULL date (the doctype would otherwise default it)
+		frappe.db.sql("UPDATE `tabToDo` SET date = NULL WHERE name = %s", undated.name)
+
+		names = ["nulls_dated", "nulls_undated"]
+		desc = frappe.get_all(
+			"ToDo",
+			filters={"description": ["in", names]},
+			fields=["description", "date"],
+			order_by="date desc",
+		)
+		asc = frappe.get_all(
+			"ToDo",
+			filters={"description": ["in", names]},
+			fields=["description", "date"],
+			order_by="date asc",
+		)
+		self.assertIsNone(desc[-1].date, "NULL date should sort last under DESC")
+		self.assertIsNone(asc[0].date, "NULL date should sort first under ASC")

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -764,3 +764,32 @@ class TestOperatorIn(IntegrationTestCase):
 		self.assertIn(None, results)
 		self.assertIn("", results)
 		self.assertIn("user1", results)
+
+
+class TestNullOrdering(IntegrationTestCase):
+	def test_add_null_ordering_for_postgres(self):
+		"""The helper appends NULLS FIRST under ASC and NULLS LAST under DESC, like MariaDB."""
+		from frappe.database.utils import add_null_ordering_for_postgres as nz
+
+		self.assertEqual(nz('"valid_from" desc'), '"valid_from" desc NULLS LAST')
+		self.assertEqual(nz('"creation" asc'), '"creation" asc NULLS FIRST')
+		self.assertEqual(nz('"name"'), '"name" NULLS FIRST')  # unspecified -> ascending
+		self.assertEqual(
+			nz('"a" desc, "b" asc, "c"'),
+			'"a" desc NULLS LAST, "b" asc NULLS FIRST, "c" NULLS FIRST',
+		)
+		# commas inside a function call must not be treated as term separators
+		self.assertEqual(
+			nz('COALESCE("valid_from", \'1900-01-01\') desc, "creation" asc'),
+			'COALESCE("valid_from", \'1900-01-01\') desc NULLS LAST, "creation" asc NULLS FIRST',
+		)
+		# idempotent
+		self.assertEqual(nz('"x" desc NULLS LAST'), '"x" desc NULLS LAST')
+		self.assertEqual(nz(""), "")
+
+	@run_only_if(db_type_is.POSTGRES)
+	def test_query_builder_emits_nulls_modifier(self):
+		"""On Postgres the rendered ORDER BY carries the MariaDB-matching NULLS placement."""
+		user = frappe.qb.DocType("User")
+		query = str(frappe.qb.from_(user).select(user.name).orderby(user.last_login, order=frappe.qb.desc))
+		self.assertIn("NULLS LAST", query.upper())


### PR DESCRIPTION
## Problem

MariaDB treats `NULL` as the **lowest** value, so NULLs sort **first under `ASC`** and **last under `DESC`**. PostgreSQL defaults to the **opposite** (`NULLS LAST` under `ASC`, `NULLS FIRST` under `DESC`).

For an app that runs on both backends, this means an `ORDER BY <nullable> ... LIMIT 1` — or any first-row pick (`[0]`, `next()`) on a nullable column — **silently returns a different row** on PostgreSQL than on MariaDB. It's a quiet, recurring source of cross-engine divergence (e.g. "most recent price", "latest entry" lookups where the sort column is nullable).

```
-- MariaDB:    ORDER BY valid_from DESC   -> real dates first, NULL last
-- PostgreSQL: ORDER BY valid_from DESC   -> NULL first  (different LIMIT 1 row!)
```

## Fix

Append an explicit `NULLS FIRST` / `NULLS LAST` per `ORDER BY` term on PostgreSQL so NULLs land where MariaDB puts them (`ASC → NULLS FIRST`, `DESC → NULLS LAST`).

It's applied by post-processing the rendered `ORDER BY` in `QueryBuilder._orderby_sql` — the **same monkey-patch approach already used for `like` → `ILIKE`** (`patch_like_operators`). Because every higher-level path renders through the query builder, this covers **`get_all` / `get_list`** *and* **raw `frappe.qb`** in one place.

- MariaDB rendering is **untouched** (guarded on `frappe.db.db_type == "postgres"`).
- A term that already specifies `NULLS …` is left as-is (idempotent).
- Terms are split on **top-level** commas, so a function call's argument commas (e.g. `COALESCE(x, '...')`) are preserved.

## Verification (on a live PostgreSQL site)

- `get_all(order_by="<col> desc")`, `get_all(order_by="<col> asc")`, and raw `frappe.qb(...).orderby(col, desc)` all render the `NULLS` modifier; MariaDB renders none.
- With mixed NULL/non-NULL data: `DESC` → values high→low then **NULL last**; `ASC` → **NULL first** then values low→high — i.e. byte-for-byte MariaDB's placement.
- Added `TestNullOrdering` covering the helper (split/idempotency/function-arg commas) and a Postgres-gated rendering assertion.

> Note: I couldn't run the full server test suite locally (no Redis in my env); CI will exercise it on both backends. Functionally validated as above.