### PR TITLE
fix(postgres): match free-text equality case-insensitively like MariaDB

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -270,6 +270,9 @@ class Engine:
 		self.is_mariadb = db_type == "mariadb"
 		self.is_postgres = db_type == "postgres"
 		self.is_sqlite = db_type == "sqlite"
+		# memoizes (doctype, fieldname) -> is-free-text so postgres case-folding does not call
+		# get_meta once per equality filter on filter-heavy queries
+		self._free_text_field_cache: dict[tuple[str, str], bool] = {}
 		self.user = user or frappe.session.user
 		self.parent_doctype = parent_doctype
 		self.reference_doctype = reference_doctype
@@ -580,11 +583,15 @@ class Engine:
 			fieldname = fieldname.split(".")[-1]
 		if fieldname == "name":
 			return False
-		try:
-			df = frappe.get_meta(doctype).get_field(fieldname)
-		except Exception:
-			return False
-		return bool(df) and df.fieldtype in CASE_INSENSITIVE_FIELDTYPES
+		key = (doctype, fieldname)
+		if key not in self._free_text_field_cache:
+			try:
+				df = frappe.get_meta(doctype).get_field(fieldname)
+				self._free_text_field_cache[key] = bool(df) and df.fieldtype in CASE_INSENSITIVE_FIELDTYPES
+			except frappe.DoesNotExistError:
+				# unknown doctype -> treat as not free-text; any other error propagates
+				self._free_text_field_cache[key] = False
+		return self._free_text_field_cache[key]
 
 	def _build_criterion_for_simple_filter(
 		self,

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -39,6 +39,22 @@ CORE_DOCTYPES = DOCTYPES_FOR_DOCTYPE | frozenset(
 	)
 )
 
+# Free-text fieldtypes whose equality MariaDB's default collation compares case-insensitively.
+# Used to fold case on postgres for parity. Deliberately excludes Link/Select/Dynamic Link and the
+# `name` column, which are matched exactly on both backends.
+CASE_INSENSITIVE_FIELDTYPES = frozenset(
+	{
+		"Data",
+		"Small Text",
+		"Text",
+		"Long Text",
+		"Text Editor",
+		"Code",
+		"HTML Editor",
+		"Markdown Editor",
+	}
+)
+
 
 def _apply_date_field_filter_conversion(value, operator: str, doctype: str, field):
 	"""Apply datetime to date conversion for Date fieldtype filters.
@@ -556,6 +572,20 @@ class Engine:
 			else:
 				self.query = self.query.where(criterion)
 
+	def _is_free_text_filter_field(self, field, _field, doctype: str) -> bool:
+		"""Return True if `field` is a free-text column (Data/Text family) whose equality MariaDB
+		compares case-insensitively. `name`, Link and Select are matched exactly and excluded."""
+		fieldname = field if isinstance(field, str) else (getattr(_field, "name", None) or str(_field))
+		if "." in fieldname:
+			fieldname = fieldname.split(".")[-1]
+		if fieldname == "name":
+			return False
+		try:
+			df = frappe.get_meta(doctype).get_field(fieldname)
+		except Exception:
+			return False
+		return bool(df) and df.fieldtype in CASE_INSENSITIVE_FIELDTYPES
+
 	def _build_criterion_for_simple_filter(
 		self,
 		field: str | Field,
@@ -701,6 +731,19 @@ class Engine:
 			operator_fn = OPERATOR_MAP["ilike"]
 		else:
 			operator_fn = OPERATOR_MAP[_operator.casefold()]
+
+		# Fold case on postgres for equality against a free-text column so the matched rows are the
+		# same as on MariaDB (whose default collation is case-insensitive). Skipped for name/Link/
+		# Select (matched exactly on both) and for empty values (handled by the NULL-fallback paths
+		# below). MariaDB keeps its existing, already case-insensitive path.
+		apply_case_insensitive = (
+			self.is_postgres
+			and _operator.casefold() in ("=", "!=")
+			and isinstance(_value, str)
+			and _value != ""
+			and self._is_free_text_filter_field(field, _field, doctype or self.doctype)
+		)
+
 		if _value is None and isinstance(_field, Field):
 			if operator_fn == builtin_operator.ne:
 				filter_field_name = (
@@ -761,6 +804,8 @@ class Engine:
 
 				_field = functions.IfNull(_field, ValueWrapper(fallback_value))
 
+			if apply_case_insensitive:
+				return operator_fn(functions.Lower(_field), _value.lower())
 			return operator_fn(_field, _value)
 
 	def _parse_nested_filters(self, nested_list: list | tuple) -> "Criterion | None":

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -2730,3 +2730,33 @@ class TestQuery(IntegrationTestCase):
 # This function is used as a permission query condition hook
 def test_permission_hook_condition(user):
 	return "`tabDashboard Settings`.`name` = 'Administrator'"
+
+
+@run_only_if(db_type_is.POSTGRES)
+class TestPostgresCaseInsensitiveEquality(IntegrationTestCase):
+	"""On postgres, equality against a free-text column is folded with LOWER() so the matched rows
+	are the same as on MariaDB (whose default collation is case-insensitive)."""
+
+	def test_free_text_equality_is_case_insensitive(self):
+		todo = frappe.get_doc(doctype="ToDo", description="CaseFoldTest_ABC").insert()
+		self.addCleanup(todo.delete)
+
+		# a Data field equality folds case -> all of these match the one ToDo
+		for value in ("CaseFoldTest_ABC", "casefoldtest_abc", "CASEFOLDTEST_ABC"):
+			names = frappe.get_all("ToDo", filters={"description": value}, pluck="name")
+			self.assertIn(todo.name, names, f"{value!r} should match case-insensitively")
+
+		# the rendered SQL uses LOWER on the column
+		frappe.get_all("ToDo", filters={"description": "x"}, limit=1)
+		self.assertIn("LOWER", str(frappe.db.last_query).upper())
+
+		# != excludes it case-insensitively
+		names = frappe.get_all("ToDo", filters={"description": ("!=", "casefoldtest_abc")}, pluck="name")
+		self.assertNotIn(todo.name, names)
+
+	def test_name_and_link_are_not_folded(self):
+		# `name` and Link fields must keep exact-case matching (no LOWER)
+		frappe.get_all("User", filters={"name": "Administrator"}, limit=1)
+		self.assertNotIn("LOWER", str(frappe.db.last_query).upper())
+		frappe.get_all("User", filters={"role_profile_name": "x"}, limit=1)
+		self.assertNotIn("LOWER", str(frappe.db.last_query).upper())


### PR DESCRIPTION
## Problem

MariaDB's default collation makes string equality **case-insensitive**; PostgreSQL compares **case-sensitively**. So:

```python
frappe.get_all("Customer", {"customer_name": "Acme"})
# MariaDB:    matches "acme", "ACME", "Acme"
# PostgreSQL: matches only "Acme"
```

For dedup / lookup queries ("find the existing record before creating one") this means the lookup **silently misses on PostgreSQL** and a **duplicate record** is created (Customer, Lead, Contact, …) — or a Tax-Rule-style match fails. It's the equality counterpart of the `like` → `ILIKE` translation frappe already does.

## Fix

When the query engine builds an `=` / `!=` condition on PostgreSQL against a **free-text** column (the Data/Text family — see `CASE_INSENSITIVE_FIELDTYPES`), fold both operands with `LOWER()` so the matched rows are identical to MariaDB.

- **`name`, Link, Select, Dynamic Link are excluded** — they are matched exactly on both backends. (Document-name semantics genuinely differ: MariaDB's collation forbids `"ABC"` and `"abc"` coexisting as names, PostgreSQL allows both, so folding name/link comparison would be unsafe.)
- Empty-value equality keeps its existing NULL-fallback path (case is moot there).
- **MariaDB rendering is untouched** (guarded on `is_postgres`).

## Trade-offs / for discussion
- This makes every free-text equality filter case-insensitive on PostgreSQL. That's the point (parity with MariaDB), but it's a behaviour change for PG-only deployments, so flagging for review.
- `LOWER(col)` won't use a plain B-tree index; a functional `LOWER(col)` index would be needed for hot lookups. Happy to follow up on indexing guidance.
- Fold policy (which fieldtypes; whether to also fold Select) is a deliberate, conservative choice — open to maintainer input.

## Verification (live PostgreSQL site)
- Data-field equality renders `LOWER(col) = '<lowercased>'` and matches `Acme`/`acme`/`ACME`; `!=` excludes case-insensitively; a non-matching value still returns nothing.
- `name` and Link filters stay exact-case (no `LOWER`); MariaDB emits no `LOWER`.
- Added `TestPostgresCaseInsensitiveEquality` covering both.

> CI will run the full server suite on both backends (my local env has no Redis). Functionally validated as above.

Companion to #40234 (NULL-ordering parity).