### PR TITLE
fix!: Switch to JSON as default request type

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -124,12 +124,24 @@ def get_bootinfo():
 	if sentry_dsn := get_sentry_dsn():
 		bootinfo.sentry_dsn = sentry_dsn
 
+	bootinfo.json_request_apps = get_json_request_apps()
 	bootinfo.setup_wizard_completed_apps = get_setup_wizard_completed_apps() or []
 	bootinfo.desktop_icon_urls = get_desktop_icon_urls()
 	bootinfo.desktop_icon_style = get_icon_style() or "Subtle"
 	if bootinfo.is_fc_site:
 		bootinfo.site_info = current_site_info()
 	return bootinfo
+
+
+def get_json_request_apps() -> list[str]:
+	"""Apps that opt into native JSON request bodies via `use_json_request_body` in hooks.py.
+
+	The frontend (`frappe.request`) uses this to decide, per call, whether to send args as a
+	native `application/json` body. Apps that don't opt in keep the legacy form-encoded payload.
+	"""
+	return [
+		app for app in frappe.get_installed_apps() if frappe.get_hooks("use_json_request_body", app_name=app)
+	]
 
 
 def get_icon_style():

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -140,7 +140,9 @@ def get_json_request_apps() -> list[str]:
 	native `application/json` body. Apps that don't opt in keep the legacy form-encoded payload.
 	"""
 	return [
-		app for app in frappe.get_installed_apps() if frappe.get_hooks("use_json_request_body", app_name=app)
+		app
+		for app in frappe.get_installed_apps()
+		if any(frappe.get_hooks("use_json_request_body", app_name=app))
 	]
 
 
@@ -266,7 +268,7 @@ def add_home_page(bootinfo, docs):
 		page = frappe.desk.desk_page.get(home_page)
 		docs.append(page)
 		bootinfo["home_page"] = page.name
-	except (frappe.DoesNotExistError, frappe.PermissionError):
+	except frappe.DoesNotExistError, frappe.PermissionError:
 		frappe.clear_last_message()
 		bootinfo["home_page"] = "desktop"
 

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import json
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -196,7 +195,7 @@ def set_value(doctype: str, name: str | int, fieldname: str | dict[str, Any], va
 		values = fieldname
 		if isinstance(fieldname, str):
 			try:
-				values = json.loads(fieldname)
+				values = frappe.parse_json(fieldname)
 			except ValueError:
 				values = {fieldname: ""}
 	else:
@@ -222,8 +221,7 @@ def insert(doc: str | dict[str, Any] | None = None):
 	"""Insert a document
 
 	:param doc: JSON or dict object to be inserted"""
-	if isinstance(doc, str):
-		doc = json.loads(doc)
+	doc = frappe.parse_json(doc)
 
 	return insert_doc(doc).as_dict()
 
@@ -233,8 +231,7 @@ def insert_many(docs: str | list[dict[str, Any]] | None = None):
 	"""Insert multiple documents
 
 	:param docs: JSON or list of dict objects to be inserted in one request"""
-	if isinstance(docs, str):
-		docs = json.loads(docs)
+	docs = frappe.parse_json(docs)
 
 	if len(docs) > 200:
 		frappe.throw(_("Only 200 inserts allowed in one request"))
@@ -247,8 +244,7 @@ def save(doc: str | dict[str, Any]):
 	"""Update (save) an existing document
 
 	:param doc: JSON or dict object with the properties of the document to be updated"""
-	if isinstance(doc, str):
-		doc = json.loads(doc)
+	doc = frappe.parse_json(doc)
 
 	doc = frappe.get_doc(doc)
 	doc.save()
@@ -272,8 +268,7 @@ def submit(doc: str | dict[str, Any]):
 	"""Submit a document
 
 	:param doc: JSON or dict object to be submitted remotely"""
-	if isinstance(doc, str):
-		doc = json.loads(doc)
+	doc = frappe.parse_json(doc)
 
 	doc = frappe.get_doc(doc)
 	doc.submit()
@@ -303,11 +298,11 @@ def delete(doctype: str, name: str | int):
 
 
 @frappe.whitelist(methods=["POST", "PUT"])
-def bulk_update(docs: str):
+def bulk_update(docs: str | list):
 	"""Bulk update documents
 
 	:param docs: JSON list of documents to be updated remotely. Each document must have `docname` property"""
-	docs = json.loads(docs)
+	docs = frappe.parse_json(docs)
 	failed_docs = []
 	for doc in docs:
 		doc.pop("flags", None)

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -386,11 +386,10 @@ def contact_query(
 
 
 @frappe.whitelist()
-def address_query(links: str):
-	import json
-
+def address_query(links: str | list):
 	links = [
-		{"link_doctype": d.get("link_doctype"), "link_name": d.get("link_name")} for d in json.loads(links)
+		{"link_doctype": d.get("link_doctype"), "link_name": d.get("link_name")}
+		for d in frappe.parse_json(links)
 	]
 	result = []
 

--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -45,6 +45,13 @@ class TestContact(IntegrationTestCase):
 			"John Jane Doe",
 		)
 
+	def test_address_query_accepts_native_list(self):
+		from frappe.contacts.doctype.contact.contact import address_query
+
+		# links as a native list of dicts instead of a JSON string (frappe.parse_json passthrough)
+		result = address_query(links=[{"link_doctype": "User", "link_name": "Administrator"}])
+		self.assertIsInstance(result, list)
+
 	def test_get_contact_list(self):
 		# First time from database
 		results = get_contact_list("_Test Supplier")

--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -1,5 +1,3 @@
-import json
-
 import frappe
 from frappe.core.doctype.file.file import File
 from frappe.core.doctype.file.utils import setup_folder_path
@@ -17,8 +15,7 @@ def unzip_file(name: str):
 def get_attached_images(doctype: str, names: list[str] | str) -> frappe._dict:
 	"""Return list of image urls attached in form `{name: ['image.jpg', 'image.png']}`."""
 
-	if isinstance(names, str):
-		names = json.loads(names)
+	names = frappe.parse_json(names)
 
 	img_urls = frappe.db.get_list(
 		"File",
@@ -107,8 +104,7 @@ def create_new_folder(file_name: str, folder: str) -> File:
 
 @frappe.whitelist()
 def move_file(file_list: list[File | dict] | str, new_parent: str, old_parent: str) -> None:
-	if isinstance(file_list, str):
-		file_list = json.loads(file_list)
+	file_list = frappe.parse_json(file_list)
 
 	# will check for permission on each file & update parent
 	for file_obj in file_list:

--- a/frappe/core/api/test_file.py
+++ b/frappe/core/api/test_file.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.core.api.file import get_attached_images, move_file
+from frappe.tests import IntegrationTestCase
+
+
+class TestFileAPI(IntegrationTestCase):
+	def test_get_attached_images_accepts_native_list(self):
+		todo = frappe.get_doc(doctype="ToDo", description="file api").insert()
+		# names as a native list instead of a JSON string (frappe.parse_json passthrough)
+		out = get_attached_images("ToDo", [todo.name])
+		self.assertIsInstance(out, dict)
+		todo.delete()
+
+	def test_move_file_accepts_native_list(self):
+		# file_list as a native list (frappe.parse_json passthrough); empty list is a no-op move
+		move_file(file_list=[], new_parent="Home", old_parent="Home")

--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -117,8 +117,7 @@ def update_installed_apps_order(new_order: list[str] | str):
 	"""
 	frappe.only_for("System Manager")
 
-	if isinstance(new_order, str):
-		new_order = json.loads(new_order)
+	new_order = frappe.parse_json(new_order)
 
 	frappe.local.request_cache and frappe.local.request_cache.clear()
 	existing_order = frappe.get_installed_apps(_ensure_on_bench=True)

--- a/frappe/desk/calendar.py
+++ b/frappe/desk/calendar.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import json
 from datetime import date
 
 import frappe
@@ -11,10 +10,10 @@ from frappe.query_builder.terms import ValueWrapper
 
 
 @frappe.whitelist()
-def update_event(args: str, field_map: str):
+def update_event(args: str | dict, field_map: str | dict):
 	"""Updates Event (called via calendar) based on passed `field_map`"""
-	args = frappe._dict(json.loads(args))
-	field_map = frappe._dict(json.loads(field_map))
+	args = frappe._dict(frappe.parse_json(args))
+	field_map = frappe._dict(frappe.parse_json(field_map))
 	w = frappe.get_doc(args.doctype, args.name)
 	w.set(field_map.start, args[field_map.start])
 	w.set(field_map.end, args.get(field_map.end))
@@ -36,11 +35,11 @@ def get_events(
 	doctype: str,
 	start: date,
 	end: date,
-	field_map: str,
-	filters: str | None = None,
+	field_map: str | dict,
+	filters: str | list | dict | None = None,
 	fields: str | list[str] | None = None,
 ):
-	field_map = frappe._dict(json.loads(field_map))
+	field_map = frappe._dict(frappe.parse_json(field_map))
 	fields = frappe.parse_json(fields)
 
 	doc_meta = frappe.get_meta(doctype)
@@ -48,7 +47,7 @@ def get_events(
 		if d.fieldtype == "Color":
 			field_map.update({"color": d.fieldname})
 
-	filters = json.loads(filters) if filters else []
+	filters = frappe.parse_json(filters) or []
 
 	if not fields:
 		fields = [field_map.start, field_map.end, field_map.title, "name"]

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -317,7 +317,7 @@ class Workspace(DeskViews):
 
 @frappe.whitelist()
 @frappe.read_only()
-def get_desktop_page(page: str):
+def get_desktop_page(page: str | dict):
 	"""Apply permissions, customizations and return the configuration for a page on desk.
 
 	Args:
@@ -327,7 +327,7 @@ def get_desktop_page(page: str):
 	        dict: dictionary of cards, charts and shortcuts to be displayed on website
 	"""
 	try:
-		workspace = Workspace(loads(page))
+		workspace = Workspace(frappe.parse_json(page))
 		workspace.build_workspace()
 		return {
 			"charts": workspace.charts,

--- a/frappe/desk/doctype/desktop_layout/desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.py
@@ -27,10 +27,10 @@ class DesktopLayout(Document):
 
 
 @frappe.whitelist()
-def save_layout(user: str, layout: str, new_icons: str | None = None):
+def save_layout(user: str, layout: str | dict | list, new_icons: str | list | None = None):
 	if not user:
 		user = frappe.session.user
-	layout = json.loads(layout)
+	layout = frappe.parse_json(layout)
 	desktop_layout = None
 	try:
 		desktop_layout = frappe.get_doc("Desktop Layout", frappe.session.user)
@@ -43,7 +43,7 @@ def save_layout(user: str, layout: str, new_icons: str | None = None):
 		desktop_layout.layout = json.dumps(layout)
 		desktop_layout.save()
 	if new_icons:
-		new_icons = json.loads(new_icons)
+		new_icons = frappe.parse_json(new_icons)
 		for icon in new_icons:
 			workspace = icon.get("workspace")
 			if workspace:

--- a/frappe/desk/doctype/desktop_layout/test_desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/test_desktop_layout.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Frappe Technologies and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests import IntegrationTestCase
 
 # On IntegrationTestCase, the doctype test records and all
@@ -17,4 +17,10 @@ class IntegrationTestDesktopLayout(IntegrationTestCase):
 	Use this class for testing interactions between multiple components.
 	"""
 
-	pass
+	def test_save_layout_accepts_native_payloads(self):
+		from frappe.desk.doctype.desktop_layout.desktop_layout import save_layout
+
+		# layout as a native list instead of a JSON string (frappe.parse_json passthrough)
+		save_layout(user=frappe.session.user, layout=[{"name": "ToDo", "label": "ToDo"}])
+		self.assertTrue(frappe.db.exists("Desktop Layout", frappe.session.user))
+		frappe.delete_doc("Desktop Layout", frappe.session.user, force=True)

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -260,8 +260,7 @@ def update_attending_status(event_name: str, attendee: str, status: str):
 
 @frappe.whitelist()
 def delete_communication(event: str | dict[str, Any], reference_doctype: str, reference_docname: str | int):
-	if isinstance(event, str):
-		event = json.loads(event)
+	event = frappe.parse_json(event)
 
 	deleted_participant = frappe.get_doc(reference_doctype, reference_docname)
 
@@ -356,8 +355,7 @@ def get_events(
 	type EventLikeDict = Event | frappe._dict
 	resolved_events: list[EventLikeDict] = []
 
-	if isinstance(filters, str):
-		filters = json.loads(filters)
+	filters = frappe.parse_json(filters)
 
 	filter_condition = get_filters_cond("Event", filters, [])
 

--- a/frappe/desk/doctype/event/test_event.py
+++ b/frappe/desk/doctype/event/test_event.py
@@ -70,6 +70,16 @@ class TestEvent(IntegrationTestCase):
 
 		self.assertIn("_Test Event Different Timezone", [event.subject for event in events])
 
+	def test_get_events_accepts_native_filters(self):
+		frappe.set_user("Administrator")
+		# filters as a native list instead of a JSON string (frappe.parse_json passthrough)
+		events = get_events(
+			start="2014-01-01",
+			end="2030-12-31",
+			filters=[["Event", "subject", "=", "_Test Event 1"]],
+		)
+		self.assertIsInstance(events, list)
+
 	def test_revert_logic(self):
 		ev = frappe.get_doc(self.globalTestRecords["Event"][0]).insert()
 		name = ev.name

--- a/frappe/desk/doctype/kanban_board/kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/kanban_board.py
@@ -103,7 +103,7 @@ def archive_restore_column(board_name: str, column_title: str, status: str):
 
 
 @frappe.whitelist()
-def update_order(board_name: str, order: str):
+def update_order(board_name: str, order: str | dict):
 	"""Save the order of cards in columns"""
 	board = frappe.get_doc("Kanban Board", board_name)
 	doctype = board.reference_doctype
@@ -114,7 +114,7 @@ def update_order(board_name: str, order: str):
 		return board, updated_cards
 
 	fieldname = board.field_name
-	order_dict = json.loads(order)
+	order_dict = frappe.parse_json(order)
 
 	for col_name, cards in order_dict.items():
 		for card in cards:
@@ -237,10 +237,10 @@ def get_order_for_column(board, colname):
 
 
 @frappe.whitelist()
-def update_column_order(board_name: str, order: str):
+def update_column_order(board_name: str, order: str | list):
 	"""Set the order of columns in Kanban Board"""
 	board = frappe.get_doc("Kanban Board", board_name)
-	order = json.loads(order)
+	order = frappe.parse_json(order)
 	old_columns = board.columns
 	new_columns = []
 
@@ -282,8 +282,8 @@ def set_indicator(board_name: str, column_name: str, indicator: str):
 
 
 @frappe.whitelist()
-def save_settings(board_name: str, settings: str) -> Document:
-	settings = json.loads(settings)
+def save_settings(board_name: str, settings: str | dict) -> Document:
+	settings = frappe.parse_json(settings)
 	doc = frappe.get_doc("Kanban Board", board_name)
 
 	fields = settings["fields"]

--- a/frappe/desk/doctype/kanban_board/test_kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/test_kanban_board.py
@@ -1,7 +1,25 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
+import frappe
+from frappe.desk.doctype.kanban_board import kanban_board as kb
 from frappe.tests import IntegrationTestCase
 
 
 class TestKanbanBoard(IntegrationTestCase):
-	pass
+	def setUp(self):
+		self.board = kb.quick_kanban_board("ToDo", frappe.generate_hash(length=10), "status")
+
+	def tearDown(self):
+		frappe.delete_doc("Kanban Board", self.board.name, force=True)
+
+	def test_endpoints_accept_native_payloads(self):
+		# update_column_order with a native list (frappe.parse_json passthrough)
+		kb.update_column_order(self.board.name, [c.column_name for c in self.board.columns])
+
+		# save_settings with a native dict
+		resp = kb.save_settings(self.board.name, {"fields": [], "show_labels": 0})
+		self.assertEqual(resp["doctype"], "Kanban Board")
+
+		# update_order with a native dict
+		_board, updated_cards = kb.update_order(self.board.name, {})
+		self.assertEqual(updated_cards, [])

--- a/frappe/desk/doctype/onboarding_step/onboarding_step.py
+++ b/frappe/desk/doctype/onboarding_step/onboarding_step.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
-import json
-
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -53,9 +51,9 @@ class OnboardingStep(Document):
 
 
 @frappe.whitelist()
-def get_onboarding_steps(ob_steps: str):
+def get_onboarding_steps(ob_steps: str | list):
 	steps = []
-	for s in json.loads(ob_steps):
+	for s in frappe.parse_json(ob_steps):
 		doc = frappe.get_doc("Onboarding Step", s.get("step"))
 		step = doc.as_dict().copy()
 		step.label = _(doc.title)

--- a/frappe/desk/doctype/onboarding_step/test_onboarding_step.py
+++ b/frappe/desk/doctype/onboarding_step/test_onboarding_step.py
@@ -1,8 +1,23 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-# import frappe
+import frappe
+from frappe.desk.doctype.onboarding_step.onboarding_step import get_onboarding_steps
 from frappe.tests import IntegrationTestCase
 
 
 class TestOnboardingStep(IntegrationTestCase):
-	pass
+	def test_get_onboarding_steps_accepts_native_list(self):
+		step_name = "Native Onboarding Step " + frappe.generate_hash(length=6)
+		step = frappe.get_doc(
+			doctype="Onboarding Step",
+			__newname=step_name,
+			title=step_name,
+			action="Go to Page",
+			path="/app/todo",
+		).insert(ignore_permissions=True)
+
+		# ob_steps as a native list of dicts instead of a JSON string (frappe.parse_json passthrough)
+		steps = get_onboarding_steps([{"step": step.name}])
+		self.assertEqual(len(steps), 1)
+		self.assertEqual(steps[0].name, step.name)
+		step.delete()

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -3,7 +3,6 @@
 
 """assign/unassign to ToDo"""
 
-import json
 from typing import Any
 
 import frappe
@@ -151,7 +150,7 @@ def add_multiple() -> None:
 
 	args = frappe.local.form_dict
 
-	docname_list = json.loads(args["name"])
+	docname_list = frappe.parse_json(args["name"])
 
 	for docname in docname_list:
 		args.update({"name": docname})
@@ -190,11 +189,11 @@ def _remove(doctype: str, name: str | int, assign_to: str, ignore_permissions: b
 
 
 @frappe.whitelist()
-def remove_multiple(doctype: str, names: str):
+def remove_multiple(doctype: str, names: str | list):
 	if not frappe.get_cached_value("User", frappe.session.user, "bulk_actions"):
 		frappe.throw(_("You are not allowed to perform bulk actions"), frappe.PermissionError)
 
-	docname_list = json.loads(names)
+	docname_list = frappe.parse_json(names)
 
 	for name in docname_list:
 		assignments = get({"doctype": doctype, "name": name})

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 
 import itertools
-import json
 from collections import defaultdict
 
 import frappe
@@ -41,8 +40,7 @@ def get_submitted_linked_docs(
 	        you will be finding documents using parent document and parent document links.
 	"""
 
-	if isinstance(ignore_doctypes_on_cancel_all, str):
-		ignore_doctypes_on_cancel_all = json.loads(ignore_doctypes_on_cancel_all)
+	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all)
 
 	frappe.has_permission(doctype, doc=name, throw=True)
 	tree = SubmittableDocumentTree(doctype, name)
@@ -370,7 +368,7 @@ def get_referencing_documents(
 
 
 @frappe.whitelist()
-def cancel_all_linked_docs(docs: str, ignore_doctypes_on_cancel_all: str | list[str] | None = None):
+def cancel_all_linked_docs(docs: str | list, ignore_doctypes_on_cancel_all: str | list[str] | None = None):
 	"""
 	Cancel all linked doctype, optionally ignore doctypes specified in a list.
 
@@ -381,9 +379,8 @@ def cancel_all_linked_docs(docs: str, ignore_doctypes_on_cancel_all: str | list[
 	if ignore_doctypes_on_cancel_all is None:
 		ignore_doctypes_on_cancel_all = []
 
-	docs = json.loads(docs)
-	if isinstance(ignore_doctypes_on_cancel_all, str):
-		ignore_doctypes_on_cancel_all = json.loads(ignore_doctypes_on_cancel_all)
+	docs = frappe.parse_json(docs)
+	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all)
 	for i, doc in enumerate(docs, 1):
 		if validate_linked_doc(doc, ignore_doctypes_on_cancel_all):
 			linked_doc = frappe.get_doc(doc.get("doctype"), doc.get("name"))
@@ -428,9 +425,8 @@ def get_exempted_doctypes():
 
 
 def get_linked_docs(doctype: str, name: str, linkinfo: dict | None = None) -> dict[str, list]:
-	if isinstance(linkinfo, str):
-		# additional fields are added in linkinfo
-		linkinfo = json.loads(linkinfo)
+	# additional fields are added in linkinfo
+	linkinfo = frappe.parse_json(linkinfo)
 
 	results = {}
 

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -40,7 +40,7 @@ def get_submitted_linked_docs(
 	        you will be finding documents using parent document and parent document links.
 	"""
 
-	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all)
+	ignore_doctypes_on_cancel_all = frappe.parse_json(ignore_doctypes_on_cancel_all) or []
 
 	frappe.has_permission(doctype, doc=name, throw=True)
 	tree = SubmittableDocumentTree(doctype, name)

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -503,9 +503,9 @@ def update_user_info(docinfo, doc=None):
 
 
 @frappe.whitelist()
-def get_user_info_for_viewers(users: str):
+def get_user_info_for_viewers(users: str | list):
 	user_info = {}
-	for user in json.loads(users):
+	for user in frappe.parse_json(users):
 		frappe.utils.add_user_info(user, user_info)
 
 	return user_info

--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -13,9 +13,9 @@ from frappe.utils.telemetry import capture_doc
 
 
 @frappe.whitelist(methods=["POST", "PUT"])
-def savedocs(doc: str, action: str):
+def savedocs(doc: str | dict, action: str):
 	"""save / submit / update doclist"""
-	doc = frappe.get_doc(json.loads(doc))
+	doc = frappe.get_doc(frappe.parse_json(doc))
 	capture_doc(doc, action)
 	if doc.get("__islocal") and doc.name.startswith("new-" + doc.doctype.lower().replace(" ", "-")):
 		# required to relink missing attachments if they exist.

--- a/frappe/desk/form/test_assign.py
+++ b/frappe/desk/form/test_assign.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.desk.form.assign_to import add, get, remove_multiple
+from frappe.tests import IntegrationTestCase
+
+
+class TestAssign(IntegrationTestCase):
+	def test_remove_multiple_accepts_native_list(self):
+		frappe.set_user("Administrator")
+		frappe.db.set_value("User", "Administrator", "bulk_actions", 1)
+		frappe.clear_cache(doctype="User")
+
+		todo1 = frappe.get_doc(doctype="ToDo", description="assign 1").insert()
+		todo2 = frappe.get_doc(doctype="ToDo", description="assign 2").insert()
+		for todo in (todo1, todo2):
+			add({"doctype": "ToDo", "name": todo.name, "assign_to": ["Administrator"]})
+
+		# names as a native list instead of a JSON string (frappe.parse_json passthrough)
+		remove_multiple("ToDo", [todo1.name, todo2.name])
+
+		self.assertEqual(get({"doctype": "ToDo", "name": todo1.name}), [])
+		self.assertEqual(get({"doctype": "ToDo", "name": todo2.name}), [])
+
+		todo1.delete()
+		todo2.delete()

--- a/frappe/desk/form/test_form.py
+++ b/frappe/desk/form/test_form.py
@@ -13,6 +13,16 @@ class TestForm(IntegrationTestCase):
 		self.assertTrue("User" in results)
 		self.assertTrue("DocType" in results)
 
+	def test_savedocs_accepts_native_dict(self):
+		from frappe.desk.form.save import savedocs
+
+		frappe.local.form_dict = frappe._dict()
+		# doc as a native dict instead of a JSON string (frappe.parse_json passthrough, L18)
+		savedocs(doc={"doctype": "ToDo", "description": "via dict"}, action="Save")
+		self.assertTrue(frappe.local.response.docs)
+		self.assertEqual(frappe.local.response.docs[0].description, "via dict")
+		frappe.delete_doc("ToDo", frappe.local.response.docs[0].name)
+
 	def test_sort_field_fallback(self):
 		self.assertIsNone(_sort_field_fallback("Note", "name"))
 		self.assertIsNone(_sort_field_fallback("Note", "creation"))

--- a/frappe/desk/form/test_load.py
+++ b/frappe/desk/form/test_load.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+from frappe.desk.form.load import get_user_info_for_viewers
+from frappe.tests import IntegrationTestCase
+
+
+class TestLoad(IntegrationTestCase):
+	def test_get_user_info_for_viewers_accepts_native_list(self):
+		# users as a native list instead of a JSON string (frappe.parse_json passthrough)
+		info = get_user_info_for_viewers(["Administrator"])
+		self.assertIn("Administrator", info)

--- a/frappe/desk/gantt.py
+++ b/frappe/desk/gantt.py
@@ -7,10 +7,10 @@ import frappe
 
 
 @frappe.whitelist()
-def update_task(args: str, field_map: str):
+def update_task(args: str | dict, field_map: str | dict):
 	"""Updates Doc (called via gantt) based on passed `field_map`"""
-	args = frappe._dict(json.loads(args))
-	field_map = frappe._dict(json.loads(field_map))
+	args = frappe._dict(frappe.parse_json(args))
+	field_map = frappe._dict(frappe.parse_json(field_map))
 	d = frappe.get_doc(args.doctype, args.name)
 	d.set(field_map.start, args.start)
 	d.set(field_map.end, args.end)

--- a/frappe/desk/like.py
+++ b/frappe/desk/like.py
@@ -10,6 +10,7 @@ from frappe import _
 from frappe.database.schema import add_column
 from frappe.desk.form.document_follow import follow_document
 from frappe.utils import get_link_to_form
+from frappe.utils.data import sbool
 
 
 @frappe.whitelist()
@@ -43,7 +44,7 @@ def _toggle_like(doctype, name, add, user=None):
 		else:
 			liked_by = []
 
-		if add == "Yes":
+		if sbool(add):
 			if user not in liked_by:
 				liked_by.append(user)
 				add_comment(doctype, name)

--- a/frappe/desk/like.py
+++ b/frappe/desk/like.py
@@ -44,7 +44,8 @@ def _toggle_like(doctype, name, add, user=None):
 		else:
 			liked_by = []
 
-		if sbool(add):
+		# `add` may be the legacy string "Yes"/"No" or a native bool (JSON request body)
+		if (add == "Yes") if isinstance(add, str) else sbool(add):
 			if user not in liked_by:
 				liked_by.append(user)
 				add_comment(doctype, name)

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import json
 from typing import Literal
 
 from bs4 import BeautifulSoup
@@ -275,7 +274,7 @@ def _get_linked_document_counts(doctype: str, name: str, items=None):
 			items.extend(group.get("items"))
 
 	if not isinstance(items, list):
-		items = json.loads(items)
+		items = frappe.parse_json(items)
 
 	out = {
 		"external_links_found": [],

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -388,6 +388,8 @@ def _export_query(form_params, csv_params, populate_response=True):
 
 	if isinstance(visible_idx, str):
 		visible_idx = json.loads(visible_idx)
+	elif not isinstance(visible_idx, list):
+		visible_idx = []
 
 	data = run(
 		report_name,
@@ -810,7 +812,7 @@ def get_data_for_custom_report(columns, result):
 
 
 @frappe.whitelist()
-def save_report(reference_report: str, report_name: str, columns: str, filters: str):
+def save_report(reference_report: str, report_name: str, columns: str | list, filters: str | list | dict):
 	report_doc = get_report_doc(reference_report)
 
 	docname = frappe.db.exists(
@@ -825,8 +827,8 @@ def save_report(reference_report: str, report_name: str, columns: str, filters: 
 	if docname:
 		report = frappe.get_doc("Report", docname)
 		existing_jd = json.loads(report.json)
-		existing_jd["columns"] = json.loads(columns)
-		existing_jd["filters"] = json.loads(filters)
+		existing_jd["columns"] = frappe.parse_json(columns)
+		existing_jd["filters"] = frappe.parse_json(filters)
 		report.update({"json": json.dumps(existing_jd, separators=(",", ":"))})
 		report.save()
 		frappe.msgprint(_("Report updated successfully"))

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -266,10 +266,10 @@ def parse_json(data):
 		data["fields"] = ["*"] if fields == "*" else frappe.parse_json(fields)
 	if isinstance(data.get("docstatus"), str):
 		data["docstatus"] = frappe.parse_json(data["docstatus"])
-	if isinstance(data.get("save_user_settings"), str):
-		data["save_user_settings"] = frappe.parse_json(data["save_user_settings"])
-	else:
+	if "save_user_settings" not in data:
 		data["save_user_settings"] = True
+	elif isinstance(data.get("save_user_settings"), str):
+		data["save_user_settings"] = frappe.parse_json(data["save_user_settings"])
 	if isinstance(data.get("start"), str):
 		data["start"] = cint(data.get("start"))
 	if isinstance(data.get("page_length"), str):

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -257,17 +257,17 @@ def clean_params(data):
 
 def parse_json(data):
 	if (filters := data.get("filters")) and isinstance(filters, str):
-		data["filters"] = json.loads(filters)
+		data["filters"] = frappe.parse_json(filters)
 	if (applied_filters := data.get("applied_filters")) and isinstance(applied_filters, str):
-		data["applied_filters"] = json.loads(applied_filters)
+		data["applied_filters"] = frappe.parse_json(applied_filters)
 	if (or_filters := data.get("or_filters")) and isinstance(or_filters, str):
-		data["or_filters"] = json.loads(or_filters)
+		data["or_filters"] = frappe.parse_json(or_filters)
 	if (fields := data.get("fields")) and isinstance(fields, str):
-		data["fields"] = ["*"] if fields == "*" else json.loads(fields)
+		data["fields"] = ["*"] if fields == "*" else frappe.parse_json(fields)
 	if isinstance(data.get("docstatus"), str):
-		data["docstatus"] = json.loads(data["docstatus"])
+		data["docstatus"] = frappe.parse_json(data["docstatus"])
 	if isinstance(data.get("save_user_settings"), str):
-		data["save_user_settings"] = json.loads(data["save_user_settings"])
+		data["save_user_settings"] = frappe.parse_json(data["save_user_settings"])
 	else:
 		data["save_user_settings"] = True
 	if isinstance(data.get("start"), str):
@@ -435,11 +435,11 @@ def _export_query(form_params, csv_params, populate_response=True):
 		form_params["fields"] = form_params["fields"] + (owner_field,)
 	file_format_type = form_params.pop("file_format_type")
 	title = form_params.pop("title", doctype)
-	add_totals_row = 1 if form_params.pop("add_totals_row", None) == "1" else None
-	translate_values = 1 if form_params.pop("translate_values", None) == "1" else None
+	add_totals_row = cint(form_params.pop("add_totals_row", 0))
+	translate_values = cint(form_params.pop("translate_values", 0))
 
 	if selection := form_params.pop("selected_items", None):
-		form_params["filters"] = {"name": ("in", json.loads(selection))}
+		form_params["filters"] = {"name": ("in", frappe.parse_json(selection))}
 
 	make_access_log(
 		doctype=doctype,
@@ -662,9 +662,7 @@ def delete_items():
 	if not (frappe.get_cached_value("User", frappe.session.user, "bulk_actions")):
 		frappe.throw(_("You are not allowed to perform bulk actions."), frappe.PermissionError)
 
-	import json
-
-	items = sorted(json.loads(frappe.form_dict.get("items")), reverse=True)
+	items = sorted(frappe.parse_json(frappe.form_dict.get("items")), reverse=True)
 	doctype = frappe.form_dict.get("doctype")
 
 	if len(items) > 10:
@@ -733,15 +731,13 @@ def get_sidebar_stats(
 
 @frappe.whitelist()
 @frappe.read_only()
-def get_stats(stats: str, doctype: str, filters: str | None = None):
+def get_stats(stats: str | list, doctype: str, filters: str | list | dict | None = None):
 	"""get tag info"""
-	import json
-
 	if filters is None:
 		filters = []
-	columns = json.loads(stats)
+	columns = frappe.parse_json(stats)
 	if filters:
-		filters = json.loads(filters)
+		filters = frappe.parse_json(filters)
 	results = {}
 
 	try:
@@ -790,12 +786,10 @@ def get_stats(stats: str, doctype: str, filters: str | None = None):
 
 
 @frappe.whitelist()
-def get_filter_dashboard_data(stats: str, doctype: str, filters: str | None = None):
+def get_filter_dashboard_data(stats: str | list, doctype: str, filters: str | list | dict | None = None):
 	"""get tags info"""
-	import json
-
-	tags = json.loads(stats)
-	filters = json.loads(filters or [])
+	tags = frappe.parse_json(stats)
+	filters = frappe.parse_json(filters) or []
 	stats = {}
 
 	columns = frappe.db.get_table_columns(doctype)
@@ -886,8 +880,7 @@ def build_match_conditions(doctype, user=None, as_condition=True):
 
 
 def get_filters_cond(doctype, filters, conditions, ignore_permissions=None, with_match_conditions=False):
-	if isinstance(filters, str):
-		filters = json.loads(filters)
+	filters = frappe.parse_json(filters)
 
 	if filters:
 		flt = filters

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -84,7 +84,7 @@ def search_widget(
 	start: int = 0,
 	page_length: int = 10,
 	filters: str | None | dict | list = None,
-	filter_fields: str | None = None,
+	filter_fields: str | list | None = None,
 	as_dict: bool = False,
 	reference_doctype: str | None = None,
 	ignore_user_permissions: bool = False,
@@ -221,7 +221,7 @@ def search_widget(
 	# format a list of fields combining search fields and filter fields
 	fields = get_std_fields_list(meta, searchfield or "name")
 	if filter_fields:
-		fields = list(set(fields + json.loads(filter_fields)))
+		fields = list(set(fields + frappe.parse_json(filter_fields)))
 	formatted_fields = [f.strip() for f in fields]
 
 	# Insert title field query after name

--- a/frappe/desk/test_desktop.py
+++ b/frappe/desk/test_desktop.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.desk.desktop import get_desktop_page
+from frappe.tests import IntegrationTestCase
+
+
+class TestDesktop(IntegrationTestCase):
+	def test_get_desktop_page_accepts_native_dict(self):
+		workspace = frappe.db.get_value("Workspace", {"public": 1}, "name")
+		# page as a native dict instead of a JSON string (frappe.parse_json passthrough)
+		result = get_desktop_page({"name": workspace})
+		self.assertIsInstance(result, dict)
+		self.assertIn("charts", result)

--- a/frappe/desk/test_like.py
+++ b/frappe/desk/test_like.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.desk.like import toggle_like
+from frappe.tests import IntegrationTestCase
+
+
+class TestLike(IntegrationTestCase):
+	def _liked_by(self, todo):
+		return frappe.parse_json(frappe.db.get_value("ToDo", todo.name, "_liked_by") or "[]")
+
+	def test_toggle_like_accepts_bool_and_string(self):
+		todo = frappe.get_doc(doctype="ToDo", description="like me").insert()
+
+		# native bool path (sbool branch) adds the like
+		toggle_like("ToDo", todo.name, add=True)
+		self.assertIn(frappe.session.user, self._liked_by(todo))
+
+		# native bool False removes the like
+		toggle_like("ToDo", todo.name, add=False)
+		self.assertNotIn(frappe.session.user, self._liked_by(todo))
+
+		# legacy "Yes"/"No" string path still works
+		toggle_like("ToDo", todo.name, add="Yes")
+		self.assertIn(frappe.session.user, self._liked_by(todo))
+
+		toggle_like("ToDo", todo.name, add="No")
+		self.assertNotIn(frappe.session.user, self._liked_by(todo))
+
+		todo.delete()

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -493,8 +493,7 @@ def retry_sending(queues: str | list[str]):
 	if not frappe.has_permission("Email Queue", throw=True):
 		return
 
-	if isinstance(queues, str):
-		queues = json.loads(queues)
+	queues = frappe.parse_json(queues)
 
 	if not queues:
 		return

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -450,17 +450,15 @@ def get_formatted_html(
 @frappe.whitelist()
 def get_email_html(
 	template: str,
-	args: str,
+	args: str | dict,
 	subject: str,
 	header: str | list | None = None,
 	with_container: str | int | bool = False,
 ):
-	import json
-
 	with_container = cint(with_container)
-	args = json.loads(args)
-	if header and header.startswith("["):
-		header = json.loads(header)
+	args = frappe.parse_json(args)
+	if isinstance(header, str) and header.startswith("["):
+		header = frappe.parse_json(header)
 	email = frappe.utils.jinja.get_email_from_template(template, args)
 	return get_formatted_html(subject, email[0], header=header, with_container=with_container)
 

--- a/frappe/email/inbox.py
+++ b/frappe/email/inbox.py
@@ -38,7 +38,7 @@ def get_email_accounts(user=None):
 
 
 @frappe.whitelist()
-def create_email_flag_queue(names: str, action: str):
+def create_email_flag_queue(names: str | list, action: str):
 	"""create email flag queue to mark email either as read or unread"""
 
 	def mark_as_seen_unseen(name, action):
@@ -53,7 +53,7 @@ def create_email_flag_queue(names: str, action: str):
 	if not all([names, action]):
 		return
 
-	for name in json.loads(names or []):
+	for name in frappe.parse_json(names):
 		uid, seen_status, email_account = frappe.db.get_value(
 			"Communication", name, ["uid", "seen", "email_account"]
 		)

--- a/frappe/email/test_inbox.py
+++ b/frappe/email/test_inbox.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.email.inbox import create_email_flag_queue
+from frappe.tests import IntegrationTestCase
+
+
+class TestInbox(IntegrationTestCase):
+	def test_create_email_flag_queue_accepts_native_list(self):
+		comm = frappe.get_doc(
+			doctype="Communication",
+			communication_type="Communication",
+			content="test inbox flag",
+			subject="test inbox flag",
+			sent_or_received="Received",
+		).insert(ignore_permissions=True)
+
+		# names as a native list instead of a JSON string (frappe.parse_json passthrough);
+		# the communication has no uid so it is skipped, but the parse_json loop is exercised
+		create_email_flag_queue([comm.name], "Read")
+		comm.delete()

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -478,6 +478,10 @@ get_changelog_feed = "frappe.desk.doctype.changelog_feed.changelog_feed.get_feed
 
 export_python_type_annotations = True
 
+# Send non-GET requests for this app's endpoints as native `application/json`
+# bodies instead of form-encoded, per-key JSON-stringified values.
+use_json_request_body = True
+
 standard_help_items = [
 	{
 		"item_label": "About",

--- a/frappe/integrations/google_oauth.py
+++ b/frappe/integrations/google_oauth.py
@@ -167,12 +167,12 @@ def is_valid_access_token(access_token: str) -> bool:
 
 
 @frappe.whitelist(methods=["GET"])
-def callback(state: str, code: str | None = None, error: str | None = None) -> None:
+def callback(state: str | dict, code: str | None = None, error: str | None = None) -> None:
 	"""Common callback for google integrations.
 	Invokes functions using `frappe.get_attr` and also adds required (keyworded) arguments
 	along with committing and redirecting us back to frappe site."""
 
-	state = json.loads(state)
+	state = frappe.parse_json(state)
 	redirect = state.pop("redirect", "/desk")
 	success_query_param = state.pop("success_query_param", "")
 	failure_query_param = state.pop("failure_query_param", "")

--- a/frappe/integrations/test_google_oauth.py
+++ b/frappe/integrations/test_google_oauth.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.integrations.google_oauth import callback
+from frappe.tests import IntegrationTestCase
+
+
+class TestGoogleOAuth(IntegrationTestCase):
+	def test_callback_accepts_native_state_dict(self):
+		frappe.local.response = frappe._dict()
+		# state as a native dict instead of a JSON string (frappe.parse_json passthrough);
+		# an error short-circuits the domain dispatch and just redirects back
+		callback(
+			state={"redirect": "/app/todo", "failure_query_param": "failed=1"},
+			error="access_denied",
+		)
+		self.assertEqual(frappe.local.response["type"], "redirect")
+		self.assertEqual(frappe.local.response["location"], "/app/todo?failed=1")

--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -11,7 +11,7 @@ from frappe.utils import cstr
 
 @frappe.whitelist()
 def make_mapped_doc(
-	method: str, source_name: str, selected_children: str | None = None, args: str | None = None
+	method: str, source_name: str, selected_children: str | list | None = None, args: str | dict | None = None
 ):
 	"""Return the mapped document calling the given mapper method.
 	Set `selected_children` as flags for the `get_mapped_doc` method.
@@ -22,10 +22,10 @@ def make_mapped_doc(
 	frappe.is_whitelisted(method)
 
 	if selected_children:
-		selected_children = json.loads(selected_children)
+		selected_children = frappe.parse_json(selected_children)
 
 	if args:
-		frappe.flags.args = frappe._dict(json.loads(args))
+		frappe.flags.args = frappe._dict(frappe.parse_json(args))
 
 	frappe.flags.selected_children = selected_children or None
 
@@ -33,7 +33,9 @@ def make_mapped_doc(
 
 
 @frappe.whitelist()
-def map_docs(method: str, source_names: str, target_doc: Document | dict | str, args: str | None = None):
+def map_docs(
+	method: str, source_names: str | list, target_doc: Document | dict | str, args: str | dict | None = None
+):
 	"""Return the mapped document calling the given mapper method with each of the given source docs on the target doc.
 
 	:param args: Args as string to pass to the mapper method
@@ -44,8 +46,8 @@ def map_docs(method: str, source_names: str, target_doc: Document | dict | str, 
 
 	frappe.is_whitelisted(method)
 
-	for src in json.loads(source_names):
-		_args = (src, target_doc, json.loads(args)) if args else (src, target_doc)
+	for src in frappe.parse_json(source_names):
+		_args = (src, target_doc, frappe.parse_json(args)) if args else (src, target_doc)
 		target_doc = method(*_args)
 	return target_doc
 

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -699,7 +699,7 @@ def bulk_rename(doctype: str, rows: list[list] | None = None, via_console: bool 
 	for row in rows:
 		# if row has some content
 		if len(row) > 1 and row[0] and row[1]:
-			merge = len(row) > 2 and (row[2] == "1" or row[2].lower() == "true")
+			merge = len(row) > 2 and sbool(row[2])
 			try:
 				if rename_doc(doctype, row[0], row[1], merge=merge, rebuild_search=False):
 					msg = _("Successful: {0} to {1}").format(row[0], row[1])

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -699,7 +699,7 @@ def bulk_rename(doctype: str, rows: list[list] | None = None, via_console: bool 
 	for row in rows:
 		# if row has some content
 		if len(row) > 1 and row[0] and row[1]:
-			merge = len(row) > 2 and sbool(row[2])
+			merge = len(row) > 2 and sbool(row[2]) is True
 			try:
 				if rename_doc(doctype, row[0], row[1], merge=merge, rebuild_search=False):
 					msg = _("Successful: {0} to {1}").format(row[0], row[1])

--- a/frappe/model/utils/test_user_settings.py
+++ b/frappe/model/utils/test_user_settings.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.model.utils.user_settings import get, save
+from frappe.tests import IntegrationTestCase
+
+
+class TestUserSettings(IntegrationTestCase):
+	def test_save_accepts_native_dict(self):
+		# user_settings as a native dict instead of a JSON string (frappe.parse_json passthrough)
+		saved = save("ToDo", {"sort_by": "modified"})
+		self.assertEqual(saved["sort_by"], "modified")
+
+		stored = frappe.parse_json(get("ToDo"))
+		self.assertEqual(stored.get("sort_by"), "modified")

--- a/frappe/model/utils/user_settings.py
+++ b/frappe/model/utils/user_settings.py
@@ -64,7 +64,7 @@ def sync_user_settings():
 
 @frappe.whitelist()
 def save(doctype: str, user_settings: str | dict):
-	user_settings = frappe.parse_json(user_settings)
+	user_settings = frappe.parse_json(user_settings) or {}
 	update_user_settings(doctype, user_settings)
 	return user_settings
 

--- a/frappe/model/utils/user_settings.py
+++ b/frappe/model/utils/user_settings.py
@@ -63,8 +63,8 @@ def sync_user_settings():
 
 
 @frappe.whitelist()
-def save(doctype: str, user_settings: str):
-	user_settings = json.loads(user_settings or "{}")
+def save(doctype: str, user_settings: str | dict):
+	user_settings = frappe.parse_json(user_settings)
 	update_user_settings(doctype, user_settings)
 	return user_settings
 

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import json
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
@@ -316,8 +315,8 @@ def get_workflow_field_value(workflow_name, field):
 
 
 @frappe.whitelist()
-def bulk_workflow_approval(docnames: str, doctype: str, action: str):
-	docnames = json.loads(docnames)
+def bulk_workflow_approval(docnames: str | list, doctype: str, action: str):
+	docnames = frappe.parse_json(docnames)
 	if len(docnames) < 20:
 		_bulk_workflow_action(docnames, doctype, action)
 	elif len(docnames) <= 500:
@@ -413,8 +412,7 @@ def print_workflow_log(messages, title, doctype, indicator):
 @frappe.whitelist()
 def get_common_transition_actions(docs: str | list[dict[str, Any]], doctype: str):
 	common_actions = []
-	if isinstance(docs, str):
-		docs = json.loads(docs)
+	docs = frappe.parse_json(docs)
 	try:
 		for i, doc in enumerate(docs, 1):
 			if not doc.get("doctype"):

--- a/frappe/onboarding.py
+++ b/frappe/onboarding.py
@@ -10,8 +10,8 @@ def get_onboarding_status():
 
 
 @frappe.whitelist()
-def update_user_onboarding_status(steps: str, appName: str):
-	steps = json.loads(steps)
+def update_user_onboarding_status(steps: str | list | dict, appName: str):
+	steps = frappe.parse_json(steps)
 
 	# get the current onboarding status
 	onboarding_status = frappe.db.get_value("User", frappe.session.user, "onboarding_status")

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -139,17 +139,23 @@ frappe.ui.form.Toolbar = class Toolbar {
 		let rename_document = () => {
 			if (input_name != docname) frappe.realtime.doctype_subscribe(doctype, input_name);
 			return frappe
-				.xcall("frappe.model.rename_doc.update_document_title", {
-					doctype,
-					docname,
-					name: input_name,
-					title: input_title,
-					enqueue: true,
-					merge,
-					freeze: true,
-					freeze_message: __("Updating related fields..."),
-					queue,
-				})
+				.xcall(
+					"frappe.model.rename_doc.update_document_title",
+					{
+						doctype,
+						docname,
+						name: input_name,
+						title: input_title,
+						enqueue: true,
+						merge,
+						queue,
+					},
+					"POST",
+					{
+						freeze: true,
+						freeze_message: __("Updating related fields..."),
+					}
+				)
 				.then((new_docname) => {
 					const reload_form = (input_name) => {
 						$(document).trigger("rename", [doctype, docname, input_name]);

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -369,9 +369,9 @@ export default class BulkOperations {
 				frappe
 					.call({
 						method: "frappe.desk.doctype.bulk_update.bulk_update.submit_cancel_or_update_docs",
+						freeze: true,
 						args: {
 							doctype: this.doctype,
-							freeze: true,
 							docnames: docnames,
 							action: "update",
 							data: update_data,

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -12,8 +12,9 @@ frappe.request.logs = {};
 
 // When true, non-GET requests send their args as a native `application/json`
 // body instead of form-encoding per-key JSON-stringified values. Can be
-// overridden per-call with `opts.json`. Ships off; flipped in a later phase.
-frappe.request.use_json = false;
+// overridden per-call with `opts.json` (pass `false` as an escape hatch for
+// any endpoint that still needs the legacy form-encoded payload).
+frappe.request.use_json = true;
 
 frappe.xcall = function (method, params, type, opts = {}) {
 	return new Promise((resolve, reject) => {
@@ -294,11 +295,10 @@ frappe.request.call = function (opts) {
 		// send a native JSON body instead of letting jQuery form-encode the args
 		let body = $.extend({}, opts.args);
 
-		// strip request-control keys that aren't endpoint arguments
+		// strip freeze controls: some callers nest these in `args` (e.g.
+		// bulk_operations) but they're UI hints, not endpoint arguments.
 		delete body.freeze;
 		delete body.freeze_message;
-		delete body.btn;
-		delete body.callback;
 
 		ajax_args.data = JSON.stringify(body);
 		ajax_args.contentType = "application/json; charset=UTF-8";

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -21,7 +21,9 @@ frappe.request.app_uses_json = function (cmd) {
 	// cmd is the dotted endpoint path (e.g. "frappe.client.get_list"); its
 	// first segment is the owning app. Unrecognized apps keep legacy behaviour.
 	if (!cmd) return false;
-	let app = cmd.split(".")[0];
+	// `run_doc_method` is a dotless built-in frappe endpoint (doc method calls,
+	// form saves); resolve it to frappe so it tracks frappe's opt-in.
+	let app = cmd === "run_doc_method" ? "frappe" : cmd.split(".")[0];
 	let apps = (frappe.boot && frappe.boot.json_request_apps) || [];
 	return apps.includes(app);
 };

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -10,6 +10,11 @@ frappe.request.ajax_count = 0;
 frappe.request.waiting_for_ajax = [];
 frappe.request.logs = {};
 
+// When true, non-GET requests send their args as a native `application/json`
+// body instead of form-encoding per-key JSON-stringified values. Can be
+// overridden per-call with `opts.json`. Ships off; flipped in a later phase.
+frappe.request.use_json = false;
+
 frappe.xcall = function (method, params, type, opts = {}) {
 	return new Promise((resolve, reject) => {
 		frappe.call({
@@ -117,10 +122,15 @@ frappe.call = function (opts) {
 		api_version: opts.api_version,
 		url,
 		cache: opts.cache,
+		json: opts.json,
 	});
 };
 
 frappe.request.call = function (opts) {
+	// JSON body only applies to non-GET requests (GET carries no meaningful body).
+	let json_pref = opts.json != null ? opts.json : frappe.request.use_json;
+	opts.use_json = json_pref && (opts.type || "POST").toUpperCase() !== "GET";
+
 	frappe.request.prepare(opts);
 
 	var statusCode = {
@@ -280,6 +290,21 @@ frappe.request.call = function (opts) {
 		ajax_args.headers["X-Frappe-Doctype"] = encodeURIComponent(opts.args.doctype);
 	}
 
+	if (opts.use_json) {
+		// send a native JSON body instead of letting jQuery form-encode the args
+		let body = $.extend({}, opts.args);
+
+		// strip request-control keys that aren't endpoint arguments
+		delete body.freeze;
+		delete body.freeze_message;
+		delete body.btn;
+		delete body.callback;
+
+		ajax_args.data = JSON.stringify(body);
+		ajax_args.contentType = "application/json; charset=UTF-8";
+		ajax_args.processData = false;
+	}
+
 	frappe.last_request = ajax_args.data;
 
 	return $.ajax(ajax_args)
@@ -403,10 +428,12 @@ frappe.request.prepare = function (opts) {
 	// freeze page
 	if (opts.freeze) frappe.dom.freeze(opts.freeze_message);
 
-	// stringify args if required
-	for (var key in opts.args) {
-		if (opts.args[key] && ($.isPlainObject(opts.args[key]) || $.isArray(opts.args[key]))) {
-			opts.args[key] = JSON.stringify(opts.args[key]);
+	// stringify args if required (skipped when sending a native JSON body)
+	if (!opts.use_json) {
+		for (var key in opts.args) {
+			if (opts.args[key] && ($.isPlainObject(opts.args[key]) || $.isArray(opts.args[key]))) {
+				opts.args[key] = JSON.stringify(opts.args[key]);
+			}
 		}
 	}
 
@@ -643,9 +670,11 @@ frappe.request.report_error = function (xhr, request_opts) {
 frappe.request.cleanup_request_opts = function (request_opts) {
 	let doc = (request_opts.args || {}).doc;
 	if (doc) {
-		doc = JSON.parse(doc);
+		// `doc` may be a JSON string (form-encoded mode) or a native object (JSON mode)
+		let was_string = typeof doc === "string";
+		if (was_string) doc = JSON.parse(doc);
 		frappe.utils.mask_passwords(doc);
-		request_opts.args.doc = JSON.stringify(doc);
+		request_opts.args.doc = was_string ? JSON.stringify(doc) : doc;
 	}
 
 	if (request_opts.args) {

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -59,11 +59,6 @@ frappe.call = function (opts) {
 	}
 	var args = $.extend({}, opts.args);
 
-	if (args.freeze) {
-		opts.freeze = opts.freeze || args.freeze;
-		opts.freeze_message = opts.freeze_message || args.freeze_message;
-	}
-
 	// cmd
 	if (opts.module && opts.page) {
 		args.cmd = opts.module + ".page." + opts.page + "." + opts.page + "." + opts.method;
@@ -293,14 +288,7 @@ frappe.request.call = function (opts) {
 
 	if (opts.use_json) {
 		// send a native JSON body instead of letting jQuery form-encode the args
-		let body = $.extend({}, opts.args);
-
-		// strip freeze controls: some callers nest these in `args` (e.g.
-		// bulk_operations) but they're UI hints, not endpoint arguments.
-		delete body.freeze;
-		delete body.freeze_message;
-
-		ajax_args.data = JSON.stringify(body);
+		ajax_args.data = JSON.stringify(opts.args);
 		ajax_args.contentType = "application/json; charset=UTF-8";
 		ajax_args.processData = false;
 	}

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -10,11 +10,21 @@ frappe.request.ajax_count = 0;
 frappe.request.waiting_for_ajax = [];
 frappe.request.logs = {};
 
-// When true, non-GET requests send their args as a native `application/json`
-// body instead of form-encoding per-key JSON-stringified values. Can be
-// overridden per-call with `opts.json` (pass `false` as an escape hatch for
-// any endpoint that still needs the legacy form-encoded payload).
-frappe.request.use_json = true;
+// Apps opt into native `application/json` request bodies (instead of
+// form-encoding per-key JSON-stringified values) by setting
+// `use_json_request_body = True` in their `hooks.py`. The boot then exposes the
+// list of opted-in apps as `frappe.boot.json_request_apps` and the encoding for
+// each call is chosen from the app that owns the endpoint (see
+// `frappe.request.app_uses_json`). Apps that don't opt in keep the legacy
+// form-encoded behaviour. A call can still override the choice with `opts.json`.
+frappe.request.app_uses_json = function (cmd) {
+	// cmd is the dotted endpoint path (e.g. "frappe.client.get_list"); its
+	// first segment is the owning app. Unrecognized apps keep legacy behaviour.
+	if (!cmd) return false;
+	let app = cmd.split(".")[0];
+	let apps = (frappe.boot && frappe.boot.json_request_apps) || [];
+	return apps.includes(app);
+};
 
 frappe.xcall = function (method, params, type, opts = {}) {
 	return new Promise((resolve, reject) => {
@@ -73,6 +83,10 @@ frappe.call = function (opts) {
 		args.cmd = opts.method;
 	}
 
+	// Pick the request body encoding from the app that owns the endpoint, unless
+	// the caller explicitly set `opts.json` as an escape hatch.
+	let json = opts.json != null ? opts.json : frappe.request.app_uses_json(args.cmd);
+
 	var callback = function (data, response_text) {
 		if (data.task_id) {
 			// async call, subscribe
@@ -118,14 +132,13 @@ frappe.call = function (opts) {
 		api_version: opts.api_version,
 		url,
 		cache: opts.cache,
-		json: opts.json,
+		json,
 	});
 };
 
 frappe.request.call = function (opts) {
 	// JSON body only applies to non-GET requests (GET carries no meaningful body).
-	let json_pref = opts.json != null ? opts.json : frappe.request.use_json;
-	opts.use_json = json_pref && (opts.type || "POST").toUpperCase() !== "GET";
+	opts.use_json = opts.json && (opts.type || "POST").toUpperCase() !== "GET";
 
 	frappe.request.prepare(opts);
 

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -28,6 +28,14 @@ class TestBootData(IntegrationTestCase):
 		unseen_notes = [d.title for d in get_unseen_notes()]
 		self.assertListEqual(unseen_notes, [])
 
+	def test_get_json_request_apps_includes_frappe(self):
+		from frappe.boot import get_json_request_apps
+
+		# frappe opts into native JSON request bodies via `use_json_request_body` in hooks.py
+		apps = get_json_request_apps()
+		self.assertIsInstance(apps, list)
+		self.assertIn("frappe", apps)
+
 
 class TestPermissionQueries(IntegrationTestCase):
 	@classmethod

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -292,6 +292,35 @@ class TestClient(IntegrationTestCase):
 		for doc in docs:
 			frappe.delete_doc("Note", doc)
 
+	def test_client_crud_accepts_native_dict(self):
+		import frappe.client as client
+
+		# save (frappe.parse_json passthrough) accepts a native dict, not a JSON string
+		doc = client.insert({"doctype": "ToDo", "description": "json-body insert"})
+		self.assertEqual(doc["doctype"], "ToDo")
+
+		doc["description"] = "edited"
+		saved = client.save(doc)
+		self.assertEqual(saved["description"], "edited")
+
+		# insert_many with a native list of dicts
+		names = client.insert_many([{"doctype": "ToDo", "description": "native insert_many"}])
+		self.assertTrue(names)
+
+		frappe.delete_doc("ToDo", doc["name"])
+		for name in names:
+			frappe.delete_doc("ToDo", name)
+
+	def test_bulk_update_accepts_native_list(self):
+		from frappe.client import bulk_update
+
+		todo = frappe.get_doc(doctype="ToDo", description="bulk").insert()
+		# bulk_update with a native list of dicts (frappe.parse_json passthrough)
+		result = bulk_update([{"doctype": "ToDo", "docname": todo.name, "description": "updated"}])
+		self.assertEqual(result["failed_docs"], [])
+		self.assertEqual(frappe.db.get_value("ToDo", todo.name, "description"), "updated")
+		todo.delete()
+
 	def test_get_value_scientific_notation_docname(self):
 		from frappe.client import get_value
 

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -139,6 +139,37 @@ class TestLinkedWith(IntegrationTestCase):
 		child_record.delete()
 		parent_record.delete()
 
+	def test_cancel_all_linked_docs_accepts_native(self):
+		doc = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		doc.submit()
+
+		# docs as a native list of dicts and ignore_doctypes as a native list (JSON request body)
+		linked_with.cancel_all_linked_docs(
+			docs=[{"doctype": "Parent DocType", "name": doc.name, "docstatus": 1}],
+			ignore_doctypes_on_cancel_all=["Comment"],
+		)
+		self.assertEqual(frappe.db.get_value("Parent DocType", doc.name, "docstatus"), 2)
+		doc.reload().delete()
+
+	def test_get_submitted_linked_docs_accepts_native_ignore_list(self):
+		parent_record = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+
+		# ignore_doctypes_on_cancel_all as a native list (frappe.parse_json passthrough, L43)
+		result = linked_with.get_submitted_linked_docs(
+			parent_record.doctype, parent_record.name, ignore_doctypes_on_cancel_all=["Comment"]
+		)
+		self.assertIn("docs", result)
+		parent_record.delete()
+
+	def test_get_linked_docs_accepts_native_linkinfo(self):
+		parent_record = frappe.get_doc({"doctype": "Parent DocType"}).insert()
+		# linkinfo as a native dict instead of a JSON string (L429)
+		out = linked_with.get_linked_docs(
+			"Parent DocType", parent_record.name, linkinfo=linked_with.get_linked_doctypes("Parent DocType")
+		)
+		self.assertIsInstance(out, dict)
+		parent_record.delete()
+
 	def test_check_delete_integrity(self):
 		"""Don't allow deleting cancelled document if amendment exists"""
 		doc = frappe.get_doc({"doctype": "Parent DocType"}).insert()

--- a/frappe/tests/test_mapper.py
+++ b/frappe/tests/test_mapper.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import whitelist_for_tests
 
 
-@frappe.whitelist()
+@whitelist_for_tests()
 def _collect_sources(source_name: str, target_doc: dict | None = None, args: dict | None = None):
 	"""A minimal mapper method: accumulates source names (and optional args) onto the target."""
 	target_doc = target_doc or {"sources": [], "args": None}

--- a/frappe/tests/test_mapper.py
+++ b/frappe/tests/test_mapper.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+
+@frappe.whitelist()
+def _collect_sources(source_name: str, target_doc: dict | None = None, args: dict | None = None):
+	"""A minimal mapper method: accumulates source names (and optional args) onto the target."""
+	target_doc = target_doc or {"sources": [], "args": None}
+	target_doc["sources"].append(source_name)
+	if args:
+		target_doc["args"] = args
+	return target_doc
+
+
+class TestMapper(IntegrationTestCase):
+	def test_map_docs_accepts_native_lists(self):
+		from frappe.model.mapper import map_docs
+
+		method = "frappe.tests.test_mapper._collect_sources"
+		# source_names as a native list and args as a native dict (frappe.parse_json passthrough)
+		target = map_docs(
+			method=method,
+			source_names=["SRC-001", "SRC-002"],
+			target_doc={"sources": [], "args": None},
+			args={"key": "val"},
+		)
+		self.assertEqual(target["sources"], ["SRC-001", "SRC-002"])
+		self.assertEqual(target["args"], {"key": "val"})

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import datetime
+import json
 
 import frappe
 from frappe.desk.query_report import build_xlsx_data, export_query, format_fields, run
@@ -17,6 +18,66 @@ class TestQueryReport(IntegrationTestCase):
 
 	def tearDown(self):
 		frappe.db.rollback()
+
+	def test_save_report_accepts_native_columns_and_filters(self):
+		from frappe.desk.query_report import save_report
+
+		frappe.set_user("Administrator")
+		ref = frappe.get_doc(
+			{
+				"doctype": "Report",
+				"ref_doctype": "ToDo",
+				"report_name": "Native Save Reference " + frappe.generate_hash(length=6),
+				"report_type": "Report Builder",
+				"is_standard": "No",
+			}
+		).insert(ignore_permissions=True)
+
+		custom_name = "Native Save Custom " + frappe.generate_hash(length=6)
+		frappe.get_doc(
+			{
+				"doctype": "Report",
+				"report_name": custom_name,
+				"json": '{"columns":[],"filters":[]}',
+				"ref_doctype": "ToDo",
+				"is_standard": "No",
+				"report_type": "Custom Report",
+				"reference_report": ref.name,
+			}
+		).insert(ignore_permissions=True)
+
+		# columns as a native list and filters as a native dict (frappe.parse_json passthrough)
+		docname = save_report(
+			ref.name, custom_name, columns=[{"fieldname": "name"}], filters={"status": "Open"}
+		)
+		saved = json.loads(frappe.get_doc("Report", docname).json)
+		self.assertEqual(saved["columns"], [{"fieldname": "name"}])
+		self.assertEqual(saved["filters"], {"status": "Open"})
+
+	def test_export_query_coerces_non_list_visible_idx(self):
+		frappe.set_user("Administrator")
+		report = frappe.get_doc(
+			{
+				"doctype": "Report",
+				"report_name": "Native Export Query " + frappe.generate_hash(length=6),
+				"ref_doctype": "ToDo",
+				"report_type": "Report Builder",
+				"is_standard": "No",
+				"roles": [{"role": "System Manager"}],
+			}
+		).insert(ignore_permissions=True)
+
+		# visible_idx as a non-list, non-str value is coerced to [] (the new elif branch).
+		# The coercion runs before the report executes, so the call must complete without the
+		# TypeError that a non-list visible_idx would otherwise cause downstream.
+		frappe.local.form_dict = frappe._dict(
+			report_name=report.name,
+			file_format_type="CSV",
+			visible_idx=5,
+		)
+		frappe.local.response = frappe._dict()
+		export_query()
+		self.assertIn("type", frappe.local.response)
 
 	def test_xlsx_data_with_multiple_datatypes(self):
 		"""Test exporting report using rows with multiple datatypes (list, dict)"""

--- a/frappe/tests/test_rename_doc.py
+++ b/frappe/tests/test_rename_doc.py
@@ -245,6 +245,14 @@ class TestRenameDoc(IntegrationTestCase):
 				doctype=self.test_doctype,
 			)
 
+	def test_bulk_rename_accepts_native_merge_flag(self):
+		# 3rd column as a native bool exercises sbool(row[2]); False keeps it a simple rename
+		input_data = [[x, f"{x}-native", False] for x in self.available_documents]
+
+		with patch_db(["commit", "rollback"]), patch("frappe.enqueue"):
+			message_log = bulk_rename(self.test_doctype, input_data, via_console=False)
+			self.assertEqual(len(message_log), len(self.available_documents))
+
 	def test_doc_rename_method(self):
 		name = choice(self.available_documents)
 		new_name = f"{name}-{frappe.generate_hash(length=4)}"

--- a/frappe/tests/test_reportview.py
+++ b/frappe/tests/test_reportview.py
@@ -2,11 +2,46 @@
 # License: MIT. See LICENSE
 
 import frappe
-from frappe.desk.reportview import export_query, extract_fieldnames
+from frappe.desk.reportview import export_query, extract_fieldnames, get, get_filter_dashboard_data, get_stats
 from frappe.tests import IntegrationTestCase
 
 
 class TestReportview(IntegrationTestCase):
+	def test_get_accepts_native_filters_and_fields(self):
+		# native dict/list payloads (JSON request body) instead of JSON strings
+		frappe.local.form_dict = frappe._dict(
+			doctype="ToDo",
+			filters={"status": "Open"},
+			fields=["name", "status"],
+		)
+		result = get()
+		self.assertIn("keys", result)
+		self.assertIn("values", result)
+
+	def test_get_stats_accepts_native(self):
+		# stats as native list (L738) and filters as native list (L740)
+		out = get_stats(stats=["_user_tags"], doctype="ToDo", filters=[["ToDo", "status", "=", "Open"]])
+		self.assertIsInstance(out, dict)
+
+	def test_get_filter_dashboard_data_accepts_native(self):
+		out = get_filter_dashboard_data(
+			stats=[{"name": "status", "type": "Select"}], doctype="ToDo", filters=[]
+		)
+		self.assertIsInstance(out, dict)
+
+	def test_export_query_with_totals_and_translate(self):
+		frappe.local.form_dict = frappe._dict(
+			doctype="DocType",
+			file_format_type="CSV",
+			fields=("name", "module", "issingle"),
+			filters={"issingle": 1, "module": "Core"},
+			add_totals_row=1,
+			translate_values=1,
+		)
+		export_query()
+		self.assertTrue(frappe.response["filename"].endswith(".csv"))
+		self.assertEqual(frappe.response["type"], "binary")
+
 	def test_csv(self):
 		from csv import QUOTE_ALL, QUOTE_MINIMAL, QUOTE_NONE, QUOTE_NONNUMERIC, DictReader
 		from io import StringIO

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -318,6 +318,18 @@ class TestTranslate(IntegrationTestCase):
 			args, ("Multiline translation with format replacements and no context {0} {1}", None)
 		)
 
+	def test_update_translations_for_source_accepts_native_dict(self):
+		from frappe.translate import update_translations_for_source
+
+		source = "Native translation source " + frappe.generate_hash(length=8)
+		frappe.db.delete("Translation", {"source_text": source})
+		# translation_dict as a native dict instead of a JSON string (frappe.parse_json passthrough)
+		update_translations_for_source(source=source, translation_dict={"de": "Hallo Quelle"})
+		self.assertTrue(
+			frappe.db.exists("Translation", {"source_text": source, "translated_text": "Hallo Quelle"})
+		)
+		frappe.db.delete("Translation", {"source_text": source})
+
 
 def verify_translation_files(app):
 	"""Function to verify translation file syntax in app."""

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -673,6 +673,22 @@ class TestValidationUtils(IntegrationTestCase):
 		for not_iban in invalid_ibans:
 			self.assertFalse(is_valid_iban(not_iban))
 
+	def test_parse_json_passthrough_and_decode(self):
+		from frappe.utils.data import parse_json
+
+		# already-native values pass through untouched (the new JSON request-body path)
+		self.assertEqual(parse_json({"a": 1}), {"a": 1})
+		self.assertEqual(parse_json([1, 2]), [1, 2])
+		self.assertEqual(parse_json(None), None)
+		self.assertEqual(parse_json(1), 1)
+
+		# strings still decode (legacy form-encoded path)
+		self.assertEqual(parse_json('{"a": 1}'), {"a": 1})
+		self.assertEqual(parse_json("[1, 2]"), [1, 2])
+
+		# decoded dicts become frappe._dict (attribute access)
+		self.assertEqual(parse_json('{"a": 1}').a, 1)
+
 
 class TestImage(IntegrationTestCase):
 	def test_strip_exif_data(self):

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -1371,13 +1371,13 @@ class TestTypingValidations(IntegrationTestCase):
 class TestTBSanitization(IntegrationTestCase):
 	def test_traceback_sanitzation(self):
 		try:
-			password = "42"  # noqa: F841
-			args = {"password": "42", "pwd": "42", "safe": "safe_value"}
-			args = frappe._dict({"password": "42", "pwd": "42", "safe": "safe_value"})  # noqa: F841
+			password = "424242"  # noqa: F841
+			args = {"password": "424242", "pwd": "424242", "safe": "safe_value"}
+			args = frappe._dict({"password": "424242", "pwd": "424242", "safe": "safe_value"})  # noqa: F841
 			raise Exception
 		except Exception:
 			traceback = frappe.get_traceback(with_context=True)
-			self.assertNotIn("42", traceback)
+			self.assertNotIn("424242", traceback)
 			self.assertIn("********", traceback)
 			self.assertIn("password =", traceback)
 			self.assertIn("safe_value", traceback)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -909,11 +909,11 @@ def deduplicate_messages(messages):
 
 
 @frappe.whitelist()
-def update_translations_for_source(source: str | None = None, translation_dict: str | None = None):
+def update_translations_for_source(source: str | None = None, translation_dict: str | dict | None = None):
 	if not (source and translation_dict):
 		return
 
-	translation_dict = json.loads(translation_dict)
+	translation_dict = frappe.parse_json(translation_dict)
 
 	if is_html(source):
 		source = strip_html_tags(source)

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -410,6 +410,10 @@ app_description = "{app_description}"
 app_email = "{app_email}"
 app_license = "{app_license}"
 
+# Send non-GET requests for this app's endpoints as native `application/json`
+# bodies instead of form-encoded, per-key JSON-stringified values.
+use_json_request_body = True
+
 # Apps
 # ------------------
 

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import csv
-import json
 from csv import Sniffer
 from io import StringIO
 from typing import Any
@@ -109,10 +108,7 @@ def read_csv_content(fcontent, use_sniffer: bool = False, delimiter: str | None 
 
 @frappe.whitelist()
 def send_csv_to_client(args: str | dict[str, Any]):
-	if isinstance(args, str):
-		args = json.loads(args)
-
-	args = frappe._dict(args)
+	args = frappe._dict(frappe.parse_json(args))
 
 	frappe.response["result"] = cstr(to_csv(args.data))
 	frappe.response["doctype"] = args.filename

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2653,7 +2653,7 @@ def validate_json_string(string: str) -> None:
 		raise frappe.ValidationError
 
 
-def parse_json(val: str):
+def parse_json(val: Any):
 	"""
 	Parses json if string else return
 	"""

--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -3,7 +3,6 @@
 
 import base64
 import hashlib
-import json
 import mimetypes
 import os
 from copy import copy
@@ -402,8 +401,7 @@ def add_attachments(doctype: str, name: str | int, attachments: str | list[str])
 	if not frappe.has_permission(doctype, "write", doc=name):
 		frappe.throw(_("You need write permissions to add attachments to this record."))
 
-	if isinstance(attachments, str):
-		attachments = json.loads(attachments)
+	attachments = frappe.parse_json(attachments)
 	# loop through attachments
 	files = []
 	for a in attachments:

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -1,5 +1,4 @@
 import http
-import json
 import os
 import uuid
 from io import BytesIO
@@ -61,7 +60,7 @@ def download_multi_pdf_async(
 	if isinstance(doctype, dict):
 		doc_count = sum([len(doctype[dt]) for dt in doctype])
 	else:
-		doc_count = len(json.loads(name))
+		doc_count = len(frappe.parse_json(name))
 
 	frappe.enqueue(
 		_download_multi_pdf,
@@ -124,11 +123,10 @@ def _download_multi_pdf(
 
 	pdf_writer = PdfWriter()
 
-	if isinstance(options, str):
-		options = json.loads(options)
+	options = frappe.parse_json(options)
 
 	if not isinstance(doctype, dict):
-		result = json.loads(name)
+		result = frappe.parse_json(name)
 		total_docs = len(result)
 		filename = f"{doctype}_"
 
@@ -290,7 +288,7 @@ def render_letterhead_for_print(letterhead: str | None = None, doc: dict | str |
 
 	if isinstance(doc, str):
 		try:
-			doc = json.loads(doc)
+			doc = frappe.parse_json(doc)
 		except Exception:
 			doc = {}
 

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -5,7 +5,7 @@ import json
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import set_request
-from frappe.website.doctype.web_form.web_form import accept
+from frappe.website.doctype.web_form.web_form import accept, delete_multiple
 from frappe.website.serve import get_response_content
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Web Form"]
@@ -32,6 +32,30 @@ class TestWebForm(IntegrationTestCase):
 
 		self.event_name = frappe.db.get_value("Event", {"subject": "_Test Event Web Form"})
 		self.assertTrue(self.event_name)
+
+	def test_accept_and_delete_multiple_accept_native_payloads(self):
+		frappe.set_user("Administrator")
+
+		# accept with a native dict instead of a JSON string (frappe.parse_json passthrough)
+		accept(
+			web_form="manage-events",
+			data={
+				"doctype": "Event",
+				"subject": "_Test Event Web Form Native",
+				"description": "_Test Event Description",
+				"starts_on": "2014-09-09",
+			},
+		)
+		event_name = frappe.db.get_value("Event", {"subject": "_Test Event Web Form Native"})
+		self.assertTrue(event_name)
+
+		web_form = frappe.get_doc("Web Form", "manage-events")
+		web_form.allow_delete = 1
+		web_form.save(ignore_permissions=True)
+
+		# delete_multiple with a native list of docnames
+		delete_multiple("manage-events", [event_name])
+		self.assertFalse(frappe.db.exists("Event", event_name))
 
 	def test_edit(self):
 		self.test_accept()

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -638,9 +638,9 @@ def get_web_form_module(doc):
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(key="web_form", limit=10, seconds=60)
-def accept(web_form: str, data: str):
+def accept(web_form: str, data: str | dict):
 	"""Save the web form"""
-	data = frappe._dict(json.loads(data))
+	data = frappe._dict(frappe.parse_json(data))
 
 	files = []
 	files_to_delete = []
@@ -755,10 +755,10 @@ def delete(web_form_name: str, docname: str | int):
 
 
 @frappe.whitelist()
-def delete_multiple(web_form_name: str, docnames: str):
+def delete_multiple(web_form_name: str, docnames: str | list):
 	web_form = frappe.get_lazy_doc("Web Form", web_form_name)
 
-	docnames = json.loads(docnames)
+	docnames = frappe.parse_json(docnames)
 
 	allowed_docnames = []
 	restricted_docnames = []

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -91,6 +91,14 @@ class TestWorkflow(IntegrationTestCase):
 		actions = get_common_transition_actions([todo1, todo2], "ToDo")
 		self.assertListEqual(actions, ["Review"])
 
+	def test_bulk_workflow_approval_accepts_native_list(self):
+		from frappe.model.workflow import bulk_workflow_approval
+
+		todo = create_new_todo()
+		# docnames as a native list (frappe.parse_json passthrough); < 20 docs runs inline
+		bulk_workflow_approval([todo.name], "ToDo", "Approve")
+		self.assertEqual(frappe.db.get_value("ToDo", todo.name, "workflow_state"), "Approved")
+
 	def test_if_workflow_actions_were_processed_using_role(self):
 		user = frappe.get_doc("User", "test2@example.com")
 		user.add_roles("Test Approver", "System Manager")


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/19652

This is a major breaking change: All request using frappe.call / frappe.xcall so far were using `x-url-encoded` which has two major problems:

1. It's not type safe. `1` and `"1"` are same. This results in weird bugs and security issues.
2. It doesn't support complex type so list and dicts as arguments are always JSON serialized on client and deserialized on server. This causes so much unnecessary code on server-side and promotes shit patterns like moving all arguments in single `args` to avoid parsing things one-by-one.


This change, while breaking may not be as breaking for you because:

1. It's only enabled in frappe
2. It's opt-in by specifying a hook `use_json_request_body = True`
3. It can never apply to `GET` requests *anyway*, so some part of code is untouched.

Changes in this PR:
- Per app toggle for request type.
- Migrate frappe code to support both. Basically: Use `frappe.parse_json` instead of `json.loads`.
- Audit code for type-unsafety and other stupid stuff like `arg == "1"`.


Assistance: Planned with Opus, core executed with Opus, Grunt work with Qwencoder and some of my brain.
