### PR TITLE
fix(web-form): allow printing when user has web form permission

### DIFF
--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -33,7 +33,7 @@
 	{% endif %}
 
 	{% if allow_print and in_view_mode %}
-		{% set print_format_url = "/printview?doctype=" + doc_type + "&name=" + doc_name + "&format=" + (print_format or "standard") %}
+		{% set print_format_url = "/printview?doctype=" + doc_type + "&name=" + doc_name + "&format=" + (print_format or "standard") + "&web_form_name=" + web_form_doc.name %}
 		<!-- print button -->
 		<a href="{{ print_format_url }}" target="_blank" class="print-btn btn btn-default btn-sm ml-2">
 			<svg class="icon icon-sm"><use href="#icon-printer"></use></svg>

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -33,7 +33,7 @@
 	{% endif %}
 
 	{% if allow_print and in_view_mode %}
-		{% set print_format_url = "/printview?doctype=" + doc_type + "&name=" + doc_name + "&format=" + (print_format or "standard") + "&web_form_name=" + web_form_doc.name %}
+		{% set print_format_url = "/printview?doctype=" + doc_type + "&name=" + doc_name + "&format=" + (print_format or "standard") %}
 		<!-- print button -->
 		<a href="{{ print_format_url }}" target="_blank" class="print-btn btn btn-default btn-sm ml-2">
 			<svg class="icon icon-sm"><use href="#icon-printer"></use></svg>

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -412,6 +412,18 @@ def validate_print_permission(doc: "Document") -> None:
 	if (key := frappe.form_dict.key) and isinstance(key, str) and validate_key(key, doc) is not False:
 		return
 
+	if web_form_name := frappe.form_dict.get("web_form_name"):
+		try:
+			web_form = frappe.get_lazy_doc("Web Form", web_form_name)
+			if (
+				web_form.allow_print
+				and web_form.doc_type == doc.doctype
+				and web_form.has_web_form_permission(doc.doctype, doc.name)
+			):
+				return
+		except frappe.DoesNotExistError:
+			pass
+
 	doc._handle_permission_failure("print")
 
 

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -412,17 +412,14 @@ def validate_print_permission(doc: "Document") -> None:
 	if (key := frappe.form_dict.key) and isinstance(key, str) and validate_key(key, doc) is not False:
 		return
 
-	if web_form_name := frappe.form_dict.get("web_form_name"):
-		try:
-			web_form = frappe.get_lazy_doc("Web Form", web_form_name)
-			if (
-				web_form.allow_print
-				and web_form.doc_type == doc.doctype
-				and web_form.has_web_form_permission(doc.doctype, doc.name)
-			):
-				return
-		except frappe.DoesNotExistError:
-			pass
+	for wf_name in frappe.get_all(
+		"Web Form",
+		filters={"doc_type": doc.doctype, "allow_print": 1, "published": 1},
+		pluck="name",
+	):
+		wf = frappe.get_lazy_doc("Web Form", wf_name)
+		if wf.has_web_form_permission(doc.doctype, doc.name):
+			return
 
 	doc._handle_permission_failure("print")
 


### PR DESCRIPTION
- In `validate_print_permission`, check web form permission as a fallback when standard desk/website permissions fail

Fixes #19160