### PR TITLE
fix(versions): match exact docname for loading all versions

### DIFF
--- a/frappe/core/doctype/version/version.js
+++ b/frappe/core/doctype/version/version.js
@@ -3,7 +3,7 @@ frappe.ui.form.on("Version", {
 		frm.add_custom_button(__("Show all Versions"), function () {
 			frappe.set_route("List", "Version", {
 				ref_doctype: frm.doc.ref_doctype,
-				docname: frm.doc.docname,
+				docname: ["=", frm.doc.docname],
 			});
 		});
 


### PR DESCRIPTION
Ref ticket https://support.frappe.io/helpdesk/tickets/71646?view=VIEW-HD+Ticket-1547

It right now uses like %docname% which ignores the index 
