### PR TITLE
fix(perm): respect custom permission types client-side

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -13,6 +13,7 @@ from frappe.core.doctype.installed_applications.installed_applications import (
 	get_setup_wizard_completed_apps,
 )
 from frappe.core.doctype.navbar_settings.navbar_settings import get_app_logo, get_navbar_settings
+from frappe.core.doctype.permission_type.permission_type import get_doctype_ptype_map
 from frappe.desk.desk_views import DeskViews
 from frappe.desk.doctype.changelog_feed.changelog_feed import get_changelog_feed_items
 from frappe.desk.doctype.desktop_icon.desktop_icon import get_desktop_icons
@@ -113,6 +114,7 @@ def get_bootinfo():
 	bootinfo.app_logo_url = get_app_logo()
 	bootinfo.link_title_doctypes = get_link_title_doctypes()
 	bootinfo.translated_doctypes = get_translated_doctypes()
+	bootinfo.doctype_ptype_map = get_doctype_ptype_map()
 	bootinfo.subscription_conf = add_subscription_conf()
 	bootinfo.marketplace_apps = get_marketplace_apps()
 	bootinfo.is_fc_site = is_fc_site()

--- a/frappe/core/doctype/permission_type/permission_type.py
+++ b/frappe/core/doctype/permission_type/permission_type.py
@@ -154,7 +154,9 @@ class PermissionType(Document):
 
 @site_cache
 def get_doctype_ptype_map():
-	ptypes = frappe.get_all("Permission Type", fields=["perm_type", "doc_type"], order_by="perm_type")
+	ptypes = frappe.get_all(
+		"Permission Type", fields=["perm_type", "doc_type"], order_by="perm_type", limit=0
+	)
 
 	doctype_ptype_map = defaultdict(list)
 	for pt in ptypes:

--- a/frappe/core/doctype/permission_type/permission_type.py
+++ b/frappe/core/doctype/permission_type/permission_type.py
@@ -70,6 +70,8 @@ class PermissionType(Document):
 		for target in CUSTOM_FIELD_TARGET:
 			self.create_custom_field(target)
 
+		get_doctype_ptype_map.clear_cache()
+
 		if self.should_export():
 			from frappe.modules.export_file import export_to_files
 
@@ -116,6 +118,8 @@ class PermissionType(Document):
 
 		for target in CUSTOM_FIELD_TARGET:
 			self.delete_custom_field(target)
+
+		get_doctype_ptype_map.clear_cache()
 
 		if self.should_export():
 			module = frappe.db.get_value("DocType", self.doc_type, "module")

--- a/frappe/core/doctype/permission_type/test_permission_type.py
+++ b/frappe/core/doctype/permission_type/test_permission_type.py
@@ -73,6 +73,27 @@ class IntegrationTestPermissionType(IntegrationTestCase):
 			if frappe.db.exists("Permission Type", ptype_b.name):
 				frappe.delete_doc("Permission Type", ptype_b.name, force=True)
 
+	def test_doctype_ptype_map_cache_invalidated(self):
+		"""get_doctype_ptype_map() is the source boot exposes to the client (frappe.perm) so it
+		can mirror server-side get_rights(); its (site-cached) value must reflect ptype creation
+		and deletion immediately. See https://github.com/frappe/frappe/issues/40233
+		"""
+		from frappe.core.doctype.permission_type.permission_type import get_doctype_ptype_map
+
+		ptype_name = "map_cache_ptype"
+		doc_type = "ToDo"
+
+		# prime the site cache so a stale entry would be returned if it isn't invalidated
+		get_doctype_ptype_map()
+
+		ptype_doc = self._create_permission_type(ptype_name, doc_type)
+		try:
+			self.assertIn(ptype_name, get_doctype_ptype_map().get(doc_type, []))
+		finally:
+			frappe.delete_doc("Permission Type", ptype_doc.name, force=True)
+
+		self.assertNotIn(ptype_name, get_doctype_ptype_map().get(doc_type, []))
+
 	def test_permission_type_creation_reserved_name(self):
 		"""Test that permission types with reserved names are rejected."""
 		doc = frappe.get_doc(

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -11,7 +11,6 @@ import frappe.defaults
 import frappe.desk.form.meta
 import frappe.utils
 from frappe import _, _dict
-from frappe.core.doctype.permission_type.permission_type import get_doctype_ptype_map
 from frappe.desk.form.document_follow import is_document_followed
 from frappe.model.document import Document
 from frappe.model.utils.user_settings import get_user_settings
@@ -128,7 +127,6 @@ def get_docinfo(
 			"is_document_followed": is_document_followed(doc.doctype, doc.name, frappe.session.user),
 			"tags": get_tags(doc.doctype, doc.name),
 			"document_email": get_document_email(doc.doctype, doc.name),
-			"custom_perm_types": get_doctype_ptype_map().get(doc.doctype, []),
 		}
 	)
 

--- a/frappe/public/js/frappe/form/sidebar/share.js
+++ b/frappe/public/js/frappe/form/sidebar/share.js
@@ -97,7 +97,7 @@ frappe.ui.form.Share = class Share {
 				frm: this.frm,
 				shared: this.shared,
 				everyone: everyone,
-				custom_perm_types: this.frm.get_docinfo().custom_perm_types || [],
+				custom_perm_types: frappe.boot.doctype_ptype_map?.[this.frm.doctype] || [],
 			})
 		).appendTo(d.body);
 
@@ -154,7 +154,7 @@ frappe.ui.form.Share = class Share {
 				args.share = $(d.body).find(".add-share-share").prop("checked") ? 1 : 0;
 
 				// Add custom permissions
-				var custom_perm_types = me.frm.get_docinfo().custom_perm_types || [];
+				var custom_perm_types = frappe.boot.doctype_ptype_map?.[me.frm.doctype] || [];
 				custom_perm_types.forEach(function (perm) {
 					args[perm] = $(d.body)
 						.find(".add-share-" + perm)

--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -34,6 +34,17 @@ $.extend(frappe.perm, {
 
 	doctype_perm: {},
 
+	// Mirror of `frappe.permissions.get_rights()` on the server: the standard rights
+	// plus any custom permission types (Permission Type doctype) defined for `doctype`.
+	// Without this, custom ptypes — though enforced server-side — are silently dropped
+	// client-side. See https://github.com/frappe/frappe/issues/40233
+	get_rights: (doctype) => {
+		const custom_rights = (doctype && frappe.boot?.doctype_ptype_map?.[doctype]) || [];
+		return custom_rights.length
+			? [...frappe.perm.rights, ...custom_rights]
+			: frappe.perm.rights;
+	},
+
 	has_perm: (doctype, permlevel = 0, ptype = "read", doc) => {
 		const perms = frappe.perm.get_perm(doctype, doc);
 		return !!perms?.[permlevel]?.[ptype];
@@ -66,13 +77,14 @@ $.extend(frappe.perm, {
 				// used Set for "unique" levels
 				permlevels = [...new Set([0, ...levels])].sort();
 			}
+			const rights = frappe.perm.get_rights(doctype);
 			const admin_perm = [];
 			permlevels.forEach((level) => {
 				const p = {
 					permlevel: level,
-					rights_without_if_owner: new Set(frappe.perm.rights),
+					rights_without_if_owner: new Set(rights),
 				};
-				frappe.perm.rights.forEach((right) => {
+				rights.forEach((right) => {
 					p[right] = 1;
 				});
 				admin_perm[level] = p;
@@ -102,7 +114,7 @@ $.extend(frappe.perm, {
 
 			// if owner
 			if (doc.owner !== user) {
-				for (const right of frappe.perm.rights) {
+				for (const right of frappe.perm.get_rights(doctype)) {
 					if (base_perm[right] && !base_perm.rights_without_if_owner.has(right)) {
 						base_perm[right] = 0;
 					}
@@ -148,6 +160,7 @@ $.extend(frappe.perm, {
 		*/
 
 		let perm = [{ read: 0, permlevel: 0 }];
+		const rights = frappe.perm.get_rights(meta.name);
 
 		(meta.permissions || []).forEach((p) => {
 			const permlevel = cint(p.permlevel);
@@ -159,7 +172,7 @@ $.extend(frappe.perm, {
 
 			// if user has this role
 			if (frappe.user_roles.includes(p.role)) {
-				frappe.perm.rights.forEach((right) => {
+				rights.forEach((right) => {
 					if (!p[right]) return;
 
 					current_perm[right] = 1;

--- a/frappe/public/js/frappe/roles_editor.js
+++ b/frappe/public/js/frappe/roles_editor.js
@@ -93,6 +93,15 @@ frappe.RoleEditor = class {
 						${__("{0} role does not have permission on any doctype", [__(role)])}
 					</div>`);
 				} else {
+					// standard rights + any custom permission types for the doctypes shown
+					const rights = [
+						...frappe.perm.rights,
+						...new Set(
+							permissions.flatMap(
+								(perm) => frappe.boot?.doctype_ptype_map?.[perm.parent] || []
+							)
+						),
+					];
 					$body.append(`
 						<div style="max-height:calc(100vh - 200px); overflow-y:auto;">
 							<table class="user-perm">
@@ -101,7 +110,7 @@ frappe.RoleEditor = class {
 										<th class="sticky-top ${header_bg_color}"> ${__("Document Type")} </th>
 										<th class="sticky-top ${header_bg_color}"> ${__("Level")} </th>
 										<th class="sticky-top ${header_bg_color}"> ${__("If Owner")} </th>
-										${frappe.perm.rights
+										${rights
 											.map(
 												(p) =>
 													`<th class="sticky-top ${header_bg_color}">${__(
@@ -121,7 +130,7 @@ frappe.RoleEditor = class {
 								<td>${__(perm.parent)}</td>
 								<td>${perm.permlevel}</td>
 								<td>${perm.if_owner ? frappe.utils.icon("check", "xs") : "-"}</td>
-								${frappe.perm.rights
+								${rights
 									.map(
 										(p) =>
 											`<td class="text-muted bold">${


### PR DESCRIPTION
`frappe.perm.has_perm()` only iterated the hardcoded `frappe.perm.rights`
list, so custom permission types (Permission Type doctype) — though fully
enforced server-side via `get_rights()` — were silently treated as denied
on the client.

Expose `doctype_ptype_map` via boot and add `frappe.perm.get_rights(doctype)`
mirroring the server, then route the role-permission, Administrator and
if_owner paths through it. Also fix the role permissions matrix dialog to
render custom ptype columns.

Additionally invalidate the `get_doctype_ptype_map` site cache on Permission
Type create/delete; it was never cleared on these targets, so a new ptype
would not reflect server-side until a process restart.

Fixes #40233
