### PR TITLE
fix(preview): only reset Chromium singleton on actual crash, not on application errors

### DIFF
--- a/frappe/utils/chromium/cdp_connection.py
+++ b/frappe/utils/chromium/cdp_connection.py
@@ -28,7 +28,7 @@ class CDPSocketClient:
 
 	async def _connect(self):
 		try:
-			self.connection = await websockets.connect(self.websocket_url)
+			self.connection = await websockets.connect(self.websocket_url, max_size=None)
 		except Exception:
 			frappe.log_error(title="Failed to connect to WebSocket:", message=f"{frappe.get_traceback()}")
 			raise

--- a/frappe/utils/preview.py
+++ b/frappe/utils/preview.py
@@ -86,12 +86,12 @@ def capture_screenshot(
 			safe_execute(session and session.disconnect)
 			generator.remove_browser(browser_id)
 	except Exception:
-		# Only reset the singleton when Chrome itself has crashed (process exited).
-		# Application errors (bad URL, timeout, invalid HTML) don't poison the shared
-		# instance — calling _close_browser() on every error causes runaway process
-		# spawning under concurrent load.
+		# Only reset the singleton when the local Chrome process has actually exited.
+		# - proc is None: external chromium_websocket_url is in use — no local process
+		#   to check; transient network errors must not reset the singleton.
+		# - proc.poll() is None: local process is still running — error is application-level.
 		proc = generator._chromium_process
-		if proc is None or proc.poll() is not None:
+		if proc is not None and proc.poll() is not None:
 			generator._close_browser()
 		raise
 

--- a/frappe/utils/preview.py
+++ b/frappe/utils/preview.py
@@ -86,7 +86,13 @@ def capture_screenshot(
 			safe_execute(session and session.disconnect)
 			generator.remove_browser(browser_id)
 	except Exception:
-		generator._close_browser()  # crashed Chrome → drop the poisoned singleton
+		# Only reset the singleton when Chrome itself has crashed (process exited).
+		# Application errors (bad URL, timeout, invalid HTML) don't poison the shared
+		# instance — calling _close_browser() on every error causes runaway process
+		# spawning under concurrent load.
+		proc = generator._chromium_process
+		if proc is None or proc.poll() is not None:
+			generator._close_browser()
 		raise
 
 


### PR DESCRIPTION
## Problem

`capture_screenshot` had a blanket `except Exception: generator._close_browser()`. This killed the shared Chromium singleton for **any** error — bad URL, timeout, invalid HTML — not just actual Chrome crashes.

The sequence under the original code:

1. Request comes in → `add_browser(id)` → `_browsers = [id]`
2. Error raised (e.g. URL unreachable)
3. `finally`: `remove_browser(id)` → `_browsers = []`
4. `except Exception`: `_close_browser()` — `_browsers` is now empty, so the guard passes → Chrome is terminated
5. Next request: `ChromiumManager.__new__` detects `poll() is not None` → creates new singleton → `start_chromium_process()` → new `headless_shell`

Under concurrent load, many requests fail simultaneously (timeouts, etc.), each removes its browser from the registry before the outer `except` fires, and each call to `_close_browser()` races past the concurrent-use guard. The result is dozens of accumulating `headless_shell` processes consuming all available CPU and memory — confirmed on preview.frappe.cloud (load average 291, all 16 cores at 100%).

## Fix

Only call `_close_browser()` when Chrome has actually exited:

```python
proc = generator._chromium_process
if proc is None or proc.poll() is not None:
    generator._close_browser()
```

`poll()` returns `None` while the process is alive, non-`None` once it exits. Application errors (bad URL, invalid HTML, timeout) leave the singleton intact. Chrome is only replaced when it genuinely crashed.

## Testing

- Preview generation with a bad URL should no longer kill Chrome for subsequent requests
- Chrome crash (kill -9 the headless_shell PID) should still trigger a clean respawn on the next request