### PR TITLE
feat: mask datetime fields to match date/time placeholder format

### DIFF
--- a/frappe/model/utils/mask.py
+++ b/frappe/model/utils/mask.py
@@ -17,6 +17,7 @@ def mask_field_value(field, val):
 		- Email (Data + Email option): Shows "XXXXXX@domain"
 		- Date: Shows "XX-XX-XXXX"
 		- Time: Shows "XX:XX"
+		- Datetime: Shows "XX-XX-XXXX XX:XX"
 		- Default: Shows "XXXXXXXX"
 	"""
 	if not val:
@@ -34,6 +35,8 @@ def mask_field_value(field, val):
 		return "XX-XX-XXXX"
 	elif field.fieldtype == "Time":
 		return "XX:XX"
+	elif field.fieldtype == "Datetime":
+		return "XX-XX-XXXX XX:XX"
 	else:
 		return "XXXXXXXX"
 

--- a/frappe/tests/test_mask_fields.py
+++ b/frappe/tests/test_mask_fields.py
@@ -65,6 +65,9 @@ class TestMaskFieldValue(IntegrationTestCase):
 	def test_time_field_masked(self):
 		self.assertEqual(mask_field_value(self._field("Time"), "14:30:00"), "XX:XX")
 
+	def test_datetime_field_masked(self):
+		self.assertEqual(mask_field_value(self._field("Datetime"), "2024-01-15 14:30:00"), "XX-XX-XXXX XX:XX")
+
 	def test_none_value_is_not_masked(self):
 		self.assertIsNone(mask_field_value(self._field("Data"), None))
 


### PR DESCRIPTION
## Description

The field-masking utility already renders Date as `XX-XX-XXXX` and Time as `XX:XX`, but Datetime fell through to the generic `XXXXXXXX` placeholder. 
This adds a Datetime branch so masked datetime fields show `XX-XX-XXXX XX:XX:XX`, keeping the masked output consistent with the date and time formats it composes.

## Actual data/Masked data

<img width="1176" height="868" alt="Screenshot 2026-06-24 at 8 16 15 PM" src="https://github.com/user-attachments/assets/f90f7a68-f103-45e8-b95e-0de56cbd5db1" />

<img width="1231" height="867" alt="Screenshot 2026-06-24 at 8 16 05 PM" src="https://github.com/user-attachments/assets/251e7031-a163-4ba5-993d-1a99afca3d96" />

#no-docs
