### PR TITLE
fix(Note): don't leak list of users

### DIFF
--- a/frappe/desk/doctype/note/note.json
+++ b/frappe/desk/doctype/note/note.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "autoname": "hash",
  "creation": "2013-05-24 13:41:00",
  "doctype": "DocType",
@@ -80,14 +81,14 @@
    "fieldtype": "Table",
    "label": "Seen By Table",
    "options": "Note Seen By",
-   "permlevel": 1
+   "permlevel": 2
   }
  ],
  "grid_page_length": 50,
  "icon": "fa fa-file-text",
  "idx": 1,
  "links": [],
- "modified": "2025-03-26 18:19:45.079747",
+ "modified": "2026-06-24 16:54:57.011270",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Note",

--- a/frappe/desk/doctype/note/note.py
+++ b/frappe/desk/doctype/note/note.py
@@ -62,6 +62,8 @@ def mark_as_seen(note: str):
 	note.check_permission("read")
 	current_user = frappe.session.user
 
+	# Save as Administrator so marking a public note as seen does not expose
+	# the viewing user through standard owner/modified_by metadata.
 	try:
 		frappe.set_user("Administrator")
 		added = note.mark_seen_by(current_user)

--- a/frappe/desk/doctype/note/note.py
+++ b/frappe/desk/doctype/note/note.py
@@ -48,11 +48,12 @@ class Note(Document):
 		frappe.cache.delete_keys(UNSEEN_NOTES_KEY)
 		return super().clear_cache()
 
-	def mark_seen_by(self, user: str) -> None:
+	def mark_seen_by(self, user: str) -> bool:
 		if user in [d.user for d in self.seen_by]:
-			return
+			return False
 
 		self.append("seen_by", {"user": user})
+		return True
 
 
 @frappe.whitelist(methods=["POST"])
@@ -63,8 +64,9 @@ def mark_as_seen(note: str):
 
 	try:
 		frappe.set_user("Administrator")
-		note.mark_seen_by(current_user)
-		note.save(ignore_version=True)
+		added = note.mark_seen_by(current_user)
+		if added:
+			note.save(ignore_version=True)
 	finally:
 		frappe.set_user(current_user)
 

--- a/frappe/desk/doctype/note/note.py
+++ b/frappe/desk/doctype/note/note.py
@@ -55,12 +55,18 @@ class Note(Document):
 		self.append("seen_by", {"user": user})
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def mark_as_seen(note: str):
 	note: Note = frappe.get_doc("Note", note)
 	note.check_permission("read")
-	note.mark_seen_by(frappe.session.user)
-	note.save(ignore_permissions=True, ignore_version=True)
+	current_user = frappe.session.user
+
+	try:
+		frappe.set_user("Administrator")
+		note.mark_seen_by(current_user)
+		note.save(ignore_version=True)
+	finally:
+		frappe.set_user(current_user)
 
 
 def get_permission_query_conditions(user):


### PR DESCRIPTION
- The `seen_by` table should not be read by regular users -> perm level 2
    - So far, only the link to user in the table had permlevel 2, because back then permlevel on tables didn't work.
- The seeing user should not be recorded in `modified_by` and `owner` cause these fields can't be permleveled -> switch to Administrator
    - If public **Note** is marked as seen by the user, their email is stored in standard metadata and could be read by everybody.