### PR TITLE
fix: append custom Tab Break to end of tab instead of splitting it

### DIFF
--- a/frappe/custom/doctype/custom_field/test_custom_field.py
+++ b/frappe/custom/doctype/custom_field/test_custom_field.py
@@ -166,6 +166,40 @@ class TestCustomField(IntegrationTestCase):
 		]
 		self.assertEqual(field_names, expected_order)
 
+	def test_custom_tab_break_ordering(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"name": "Test Custom Tab Break Ordering",
+				"custom": 1,
+				"module": "Core",
+				"fields": [
+					{"fieldname": "tab1", "fieldtype": "Tab Break", "label": "Tab 1"},
+					{"fieldname": "field1", "fieldtype": "Data", "label": "Field 1"},
+					{"fieldname": "field2", "fieldtype": "Data", "label": "Field 2"},
+					{"fieldname": "tab2", "fieldtype": "Tab Break", "label": "Tab 2"},
+				],
+			}
+		)
+		doc.insert()
+
+		# A custom Tab Break should be appended after the first tab instead of splitting it
+		frappe.get_doc(
+			{
+				"doctype": "Custom Field",
+				"dt": "Test Custom Tab Break Ordering",
+				"fieldname": "custom_tab",
+				"fieldtype": "Tab Break",
+				"insert_after": "field1",
+				"label": "Custom Tab",
+			}
+		).insert()
+
+		updated_meta = frappe.get_meta("Test Custom Tab Break Ordering", cached=False)
+		field_names = [field.fieldname for field in updated_meta.fields]
+
+		self.assertEqual(field_names, ["tab1", "field1", "field2", "custom_tab", "tab2"])
+
 	def test_custom_field_renaming(self):
 		def gen_fieldname():
 			return "test_" + frappe.generate_hash()

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -605,6 +605,13 @@ class Meta(Document):
 							# Break out to add this just after the last field
 							break
 						target_position = current_field
+				elif field.fieldtype == "Tab Break" and target_position in field_order:
+					# Find the next tab break and set target_position to just one field before,
+					# so the new tab is appended after the current tab instead of splitting it
+					for current_field in field_order[field_order.index(target_position) + 1 :]:
+						if self._fields[current_field].fieldtype == "Tab Break":
+							break
+						target_position = current_field
 				insertion_map.setdefault(target_position, []).append(field.fieldname)
 
 			else:


### PR DESCRIPTION

Reported in #40071. 
The reported case: a Tab Break followed by a Section Break with no fields beneath either, inserted after the last field; does not actually reproduce a bug. `insert_after` is respected; the tab simply does not render because it contains no fields.

The real issue occurs when a custom Tab Break is inserted via `insert_after` onto a field inside an existing tab. `Meta.sort_fields` already snaps custom Section Breaks and Column Breaks to their container boundaries to avoid splitting the host section or column, but Tab Breaks were not handled the same way.

As a result, the new tab was inserted directly after the target field, causing all subsequent fields in the current tab to be moved into the new tab and rendered under the wrong tab.

This change applies the same boundary-aware behavior to Tab Breaks: it advances to the next Tab Break and inserts just before it, ensuring the new tab is appended after the current tab rather than splitting it.