### PR TITLE
fix(postgres): read UnixTimestamp in the session time zone like MariaDB

### DIFF
--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -142,14 +142,6 @@ class _PostgresUnixTimestamp(Extract):
 		with_alias = kwargs.pop("with_alias", False)
 		field = self.field if isinstance(self.field, Term) else Term.wrap_constant(self.field)
 		field_sql = field.get_sql(**kwargs)
-		# MySQL's UNIX_TIMESTAMP(value) reads the (naive) value in the connection's time zone and
-		# returns the UTC epoch. Postgres EXTRACT(EPOCH FROM <timestamp without time zone>) instead
-		# treats the value as UTC, so on a server whose time zone is not UTC the two diverge by the
-		# server's offset (e.g. an Item heatmap bucket lands on a different day). Re-interpret the
-		# value in the session TimeZone so the epoch matches MariaDB. The value is cast to a naive
-		# timestamp first: AT TIME ZONE on a bare `date` picks the wrong overload (it converts a
-		# timestamptz back to local time) and would double-shift the result.
-		# CAST to BIGINT because EXTRACT returns double precision while MySQL returns an integer.
 		sql = (
 			"CAST(EXTRACT(EPOCH FROM "
 			f"(CAST({field_sql} AS TIMESTAMP) AT TIME ZONE CURRENT_SETTING('TimeZone'))) AS BIGINT)"

--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -139,10 +139,21 @@ class _PostgresUnixTimestamp(Extract):
 		self.field = field
 
 	def get_sql(self, **kwargs):
-		# MySQL's UNIX_TIMESTAMP returns an integer, but EXTRACT(EPOCH ...) is double precision on
-		# postgres; cast to bigint so the value (and its Python type) matches across backends.
 		with_alias = kwargs.pop("with_alias", False)
-		sql = f"CAST({super().get_sql(**kwargs)} AS BIGINT)"
+		field = self.field if isinstance(self.field, Term) else Term.wrap_constant(self.field)
+		field_sql = field.get_sql(**kwargs)
+		# MySQL's UNIX_TIMESTAMP(value) reads the (naive) value in the connection's time zone and
+		# returns the UTC epoch. Postgres EXTRACT(EPOCH FROM <timestamp without time zone>) instead
+		# treats the value as UTC, so on a server whose time zone is not UTC the two diverge by the
+		# server's offset (e.g. an Item heatmap bucket lands on a different day). Re-interpret the
+		# value in the session TimeZone so the epoch matches MariaDB. The value is cast to a naive
+		# timestamp first: AT TIME ZONE on a bare `date` picks the wrong overload (it converts a
+		# timestamptz back to local time) and would double-shift the result.
+		# CAST to BIGINT because EXTRACT returns double precision while MySQL returns an integer.
+		sql = (
+			"CAST(EXTRACT(EPOCH FROM "
+			f"(CAST({field_sql} AS TIMESTAMP) AT TIME ZONE CURRENT_SETTING('TimeZone'))) AS BIGINT)"
+		)
 		if with_alias:
 			return format_alias_sql(sql, self.alias, **kwargs)
 		return sql

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -391,10 +391,13 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 		from datetime import datetime
 		from zoneinfo import ZoneInfo
 
-		expr = UnixTimestamp(Date("2021-06-01")).get_sql()
+		# select the (constant) epoch expression through the query builder so no SQL string is
+		# interpolated; DocType is always populated, so LIMIT 1 returns a row.
+		dt = frappe.qb.DocType("DocType")
+		epoch = UnixTimestamp(Date("2021-06-01"))
 		for tz in ("UTC", "Asia/Kolkata", "America/New_York"):
-			frappe.db.sql(f"SET LOCAL TIME ZONE '{tz}'")
-			(got,) = frappe.db.sql(f"SELECT {expr}")[0]
+			frappe.db.sql("SET LOCAL TIME ZONE %s", (tz,))
+			got = frappe.qb.from_(dt).select(epoch).limit(1).run()[0][0]
 			expected = int(datetime(2021, 6, 1, tzinfo=ZoneInfo(tz)).timestamp())
 			self.assertEqual(got, expected, msg=f"timezone {tz}")
 

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -358,12 +358,15 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 		self.assertIsInstance(val["q"], int)
 
 	def test_unix_ts_postgres(self):
-		# EXTRACT(EPOCH ...) is double precision on postgres; it is wrapped in CAST(... AS BIGINT)
-		# so the value (and its Python type) matches MySQL's integer UNIX_TIMESTAMP.
+		# EXTRACT(EPOCH ...) is double precision on postgres; it is wrapped in CAST(... AS BIGINT) so
+		# the value (and its Python type) matches MySQL's integer UNIX_TIMESTAMP. The value is also
+		# re-interpreted in the session TimeZone (AT TIME ZONE) so the epoch matches MariaDB's
+		# UNIX_TIMESTAMP, which reads the value in the connection time zone rather than UTC.
 		# Simple Query
 		note = frappe.qb.DocType("Note")
 		self.assertEqual(
-			"cast(extract(epoch from posting_date) as bigint)",
+			"cast(extract(epoch from (cast(posting_date as timestamp) "
+			"at time zone current_setting('timezone'))) as bigint)",
 			UnixTimestamp(note.posting_date).get_sql().lower(),
 		)
 
@@ -376,8 +379,24 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 			.select(UnixTimestamp(note.posting_date))
 		)
 		self.assertIn(
-			'cast(extract(epoch from "tabnote"."posting_date") as bigint)', str(select_query).lower()
+			'cast(extract(epoch from (cast("tabnote"."posting_date" as timestamp) '
+			"at time zone current_setting('timezone'))) as bigint)",
+			str(select_query).lower(),
 		)
+
+	def test_unix_ts_postgres_uses_session_timezone(self):
+		# MariaDB's UNIX_TIMESTAMP(value) reads the (naive) value in the connection time zone;
+		# postgres must do the same instead of treating it as UTC, otherwise heatmap day-buckets land
+		# on a different calendar day on a non-UTC server. Verify the epoch tracks the session TimeZone.
+		from datetime import datetime
+		from zoneinfo import ZoneInfo
+
+		expr = UnixTimestamp(Date("2021-06-01")).get_sql()
+		for tz in ("UTC", "Asia/Kolkata", "America/New_York"):
+			frappe.db.sql(f"SET LOCAL TIME ZONE '{tz}'")
+			(got,) = frappe.db.sql(f"SELECT {expr}")[0]
+			expected = int(datetime(2021, 6, 1, tzinfo=ZoneInfo(tz)).timestamp())
+			self.assertEqual(got, expected, msg=f"timezone {tz}")
 
 	def test_datediff_postgres(self):
 		# Postgres subtracts dates to get an integer day count, matching MariaDB DATEDIFF.
@@ -403,7 +422,8 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 		# Order by
 		select_query = select_query.orderby(UnixTimestamp(note.posting_date))
 		self.assertIn(
-			'order by cast(extract(epoch from "tabnote"."posting_date") as bigint)',
+			'order by cast(extract(epoch from (cast("tabnote"."posting_date" as timestamp) '
+			"at time zone current_setting('timezone'))) as bigint)",
 			str(select_query).lower(),
 		)
 
@@ -412,14 +432,18 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 			UnixTimestamp(note.posting_date) >= UnixTimestamp(Date("2021-01-01"))
 		)
 		self.assertIn(
-			'cast(extract(epoch from "tabnote"."posting_date") as bigint)>=cast(extract(epoch from date(\'2021-01-01\')) as bigint)',
+			'cast(extract(epoch from (cast("tabnote"."posting_date" as timestamp) '
+			"at time zone current_setting('timezone'))) as bigint)"
+			">=cast(extract(epoch from (cast(date('2021-01-01') as timestamp) "
+			"at time zone current_setting('timezone'))) as bigint)",
 			str(select_query).lower(),
 		)
 
 		# aliasing
 		select_query = select_query.select(UnixTimestamp(note.posting_date, alias="unix_ts"))
 		self.assertIn(
-			'cast(extract(epoch from "tabnote"."posting_date") as bigint) "unix_ts"',
+			'cast(extract(epoch from (cast("tabnote"."posting_date" as timestamp) '
+			"at time zone current_setting('timezone'))) as bigint) \"unix_ts\"",
 			str(select_query).lower(),
 		)
 

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -358,10 +358,6 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 		self.assertIsInstance(val["q"], int)
 
 	def test_unix_ts_postgres(self):
-		# EXTRACT(EPOCH ...) is double precision on postgres; it is wrapped in CAST(... AS BIGINT) so
-		# the value (and its Python type) matches MySQL's integer UNIX_TIMESTAMP. The value is also
-		# re-interpreted in the session TimeZone (AT TIME ZONE) so the epoch matches MariaDB's
-		# UNIX_TIMESTAMP, which reads the value in the connection time zone rather than UTC.
 		# Simple Query
 		note = frappe.qb.DocType("Note")
 		self.assertEqual(
@@ -385,21 +381,19 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 		)
 
 	def test_unix_ts_postgres_uses_session_timezone(self):
-		# MariaDB's UNIX_TIMESTAMP(value) reads the (naive) value in the connection time zone;
-		# postgres must do the same instead of treating it as UTC, otherwise heatmap day-buckets land
-		# on a different calendar day on a non-UTC server. Verify the epoch tracks the session TimeZone.
 		from datetime import datetime
 		from zoneinfo import ZoneInfo
 
-		# select the (constant) epoch expression through the query builder so no SQL string is
-		# interpolated; DocType is always populated, so LIMIT 1 returns a row.
 		dt = frappe.qb.DocType("DocType")
 		epoch = UnixTimestamp(Date("2021-06-01"))
-		for tz in ("UTC", "Asia/Kolkata", "America/New_York"):
-			frappe.db.sql("SET LOCAL TIME ZONE %s", (tz,))
-			got = frappe.qb.from_(dt).select(epoch).limit(1).run()[0][0]
-			expected = int(datetime(2021, 6, 1, tzinfo=ZoneInfo(tz)).timestamp())
-			self.assertEqual(got, expected, msg=f"timezone {tz}")
+		try:
+			for tz in ("UTC", "Asia/Kolkata", "America/New_York"):
+				frappe.db.sql("SET LOCAL TIME ZONE %s", (tz,))
+				got = frappe.qb.from_(dt).select(epoch).limit(1).run()[0][0]
+				expected = int(datetime(2021, 6, 1, tzinfo=ZoneInfo(tz)).timestamp())
+				self.assertEqual(got, expected, msg=f"timezone {tz}")
+		finally:
+			frappe.db.sql("RESET TIME ZONE")
 
 	def test_datediff_postgres(self):
 		# Postgres subtracts dates to get an integer day count, matching MariaDB DATEDIFF.


### PR DESCRIPTION
`UnixTimestamp` maps to `UNIX_TIMESTAMP(value)` on MariaDB and `EXTRACT(EPOCH FROM value)` on Postgres, and the two disagree on a non-UTC server: MariaDB reads the naive value in the connection's time zone, Postgres treats it as UTC. The epochs diverge by the server offset, so e.g. heatmaps that bucket by `UNIX_TIMESTAMP(date)` land events on a different calendar day on Postgres.

Fix (Postgres branch only): render `CAST(EXTRACT(EPOCH FROM (CAST(<field> AS TIMESTAMP) AT TIME ZONE CURRENT_SETTING('TimeZone'))) AS BIGINT)`. `AT TIME ZONE CURRENT_SETTING('TimeZone')` re-reads the naive value in the session time zone like MariaDB does; the inner cast to naive `TIMESTAMP` is required so `AT TIME ZONE` picks the interpret-as-local overload (on a bare `date` it would double-shift); the outer `BIGINT` cast matches MySQL's integer return type.

Tests: updated the Postgres SQL-shape assertions; new `test_unix_ts_postgres_uses_session_timezone` executes the expression under UTC, Asia/Kolkata and America/New_York and asserts the epoch tracks the session zone.

Parity note: this matches the engines when the Postgres session `TimeZone` equals MariaDB's `time_zone`. Frappe sets neither explicitly, so align the two settings on deployments where the defaults differ.
