### PR TITLE
fix: two missed cases from JSON request type migration

### DIFF
--- a/frappe/desk/doctype/global_search_settings/global_search_settings.py
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.py
@@ -168,7 +168,7 @@ def _set_global_search_property_setter(cf: CustomizeForm, fieldname: str, enable
 
 
 @frappe.whitelist()
-def update_global_search_fields(doctype: str, fields: str):
+def update_global_search_fields(doctype: str, fields: str | list):
 	"""Apply global-search field selection via the same Property Setter path as Customize Form."""
 
 	frappe.only_for("System Manager")

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -839,7 +839,10 @@ def save_report(reference_report: str, report_name: str, columns: str | list, fi
 			{
 				"doctype": "Report",
 				"report_name": report_name,
-				"json": f'{{"columns":{columns},"filters":{filters}}}',
+				"json": json.dumps(
+					{"columns": frappe.parse_json(columns), "filters": frappe.parse_json(filters)},
+					separators=(",", ":"),
+				),
 				"ref_doctype": report_doc.ref_doctype,
 				"is_standard": "No",
 				"report_type": "Custom Report",


### PR DESCRIPTION
## Summary

Follow-up to #40237 (Switch to JSON as default request type). Two endpoints were missed by the partial fix in `435eb52016`:

- **`save_report` INSERT path** — `f'{{"columns":{columns},"filters":{filters}}}'` interpolates Python lists using their `repr` (single-quoted strings), producing invalid JSON. Fixed to use `json.dumps` with `frappe.parse_json` (same pattern as the already-fixed UPDATE path).

- **`update_global_search_fields`** — declared `fields: str`, but with a JSON body the whitelist decorator's Pydantic validator raises `FrappeTypeError` (HTTP 417) when it receives a native Python list. Widened to `fields: str | list`; `frappe.parse_json` inside the function already handles both forms.

These are the root causes of the two CI failures visible on develop PRs today (`query_report.js` datatable not found, `global_search_settings.js` 417 response).

## Test plan

- [x] Verify `global_search_settings.js` cypress test passes ("saves selected fields and shows success toast")
- [x] Verify `query_report.js` cypress test passes ("test multi level query report")