### PR TITLE
fix(postgres): aggregate the goal column, not a string literal

### DIFF
--- a/frappe/tests/test_goal.py
+++ b/frappe/tests/test_goal.py
@@ -27,6 +27,22 @@ class TestGoal(IntegrationTestCase):
 
 		self.assertEqual(result_dict.get(format_date(today(), "MM-yyyy")), 2)
 
+	def test_get_monthly_results_sum(self):
+		"""sum/avg must aggregate the column, not a string literal -- the literal form
+		(`sum('send_reminder')`) sums to 0 on MariaDB and errors on Postgres."""
+		for name in frappe.get_all("Event", filters={"event_type": "Private"}, pluck="name"):
+			frappe.db.set_value("Event", name, "send_reminder", 1)
+
+		result_dict = get_monthly_results(
+			"Event",
+			"send_reminder",
+			"creation",
+			filters={"event_type": "Private"},
+			aggregation="sum",
+		)
+
+		self.assertEqual(result_dict.get(format_date(today(), "MM-yyyy")), 2)
+
 	def test_get_monthly_goal_graph_data(self):
 		"""Test for accurate values in graph data (based on test_get_monthly_results)"""
 		docname = frappe.get_list("Event", filters={"subject": ["=", "_Test Event 1"]})[0]["name"]

--- a/frappe/utils/goal.py
+++ b/frappe/utils/goal.py
@@ -39,7 +39,7 @@ def get_monthly_results(
 			table=goal_doctype,
 			fields=[
 				DateFormat(Table[date_col], date_format).as_("month_year"),
-				Function(aggregation, goal_field),
+				Function(aggregation, Table[goal_field]),
 			],
 			filters=filters,
 			ignore_permissions=False,


### PR DESCRIPTION
`get_monthly_results` builds `Function(aggregation, goal_field)` with a bare string, which pypika renders as a value literal — `sum('base_grand_total')`, the string, not the column. Postgres errors with `function sum(unknown) is not unique`, so the monthly goal graph fails to load; MariaDB coerces the literal to 0 and silently returns 0. `count` happens to work on a literal, which is why the existing test never caught it — `sum`/`avg`/`min`/`max` were all broken.

Fix: pass the column, `Function(aggregation, Table[goal_field])`, exactly like the adjacent `DateFormat` call. Note for MariaDB: the result changes from a constant 0 to the real aggregate — this fixes a pre-existing silent bug, it doesn't change a previously-correct result.

Tests: new `test_get_monthly_results_sum` asserts the real total (errors on postgres and returns 0 on MariaDB without the fix); `test_goal` green on both engines.
