### PR TITLE
fix(list): persist standard filter operator preference without a value

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -1276,7 +1276,10 @@ class FilterArea {
 			];
 
 			if (input_fieldtypes.includes(df.fieldtype)) {
-				df.match_type = df.condition || "=";
+				const saved_conditions =
+					frappe.get_user_settings(this.list_view.doctype, this.list_view.view_name)
+						.filter_conditions || {};
+				df.match_type = saved_conditions[df.fieldname] || df.condition || "=";
 				this.filter_field_with_match_type(df);
 			}
 		});
@@ -1332,6 +1335,13 @@ class FilterArea {
 
 				field.df.match_type = new_type;
 				$dropdown.find("button").html(getIcon(new_type));
+
+				const saved_conditions =
+					frappe.get_user_settings(this.list_view.doctype, this.list_view.view_name)
+						.filter_conditions || {};
+				this.list_view.save_view_user_settings?.({
+					filter_conditions: { ...saved_conditions, [df.fieldname]: new_type },
+				});
 
 				let value = field.get_value?.();
 				if (new_type === "=" && value) {


### PR DESCRIPTION
Closes #35728

## Problem

Standard list filters let users switch text fields between **Equals (`=`)** and **Like (`≈`)**. However, the selected operator is only persisted when the filter has a value. If the operator is changed on an empty filter, reloading resets it to the default.

## Cause

`df.match_type` exists only in memory. `get_standard_filters` saves filters only when they have a value, so an empty filter's operator is never stored. On reload, `make_standard_filters` falls back to the fieldtype default.

## Fix

Persist the selected operator in user settings under `filter_conditions` whenever it changes, regardless of whether the filter has a value. `make_standard_filters` restores `match_type` from this preference, falling back to the existing fieldtype default when none exists. Preferences are stored per doctype and view.

## Behaviour 


https://github.com/user-attachments/assets/24b48b01-1f48-4bfb-8c60-a1dfdcc157cd


## Notes

* Existing behavior is unchanged for fields whose operator was never changed.
* Saving is skipped for views without `save_view_user_settings`.
* `filter_conditions` is read once during list initialization and written only when the operator changes, consistent with existing filter and sort preferences.

