### PR TITLE
fix: update field types of `route_signature` field from `Data` to `Small Text`

### DIFF
--- a/frappe/desk/doctype/list_layout/list_layout.json
+++ b/frappe/desk/doctype/list_layout/list_layout.json
@@ -9,8 +9,8 @@
   "reference_doctype",
   "column_break_mfss",
   "sort_field",
-  "for_user",
   "sort_order",
+  "for_user",
   "route_signature",
   "section_break_aljf",
   "filters",
@@ -37,7 +37,7 @@
   },
   {
    "fieldname": "route_signature",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "label": "Route Signature",
    "read_only": 1
   },
@@ -78,7 +78,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2026-06-18 17:09:26.853519",
+ "modified": "2026-06-25 12:07:04.897997",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "List Layout",

--- a/frappe/desk/doctype/list_layout/list_layout.py
+++ b/frappe/desk/doctype/list_layout/list_layout.py
@@ -20,11 +20,11 @@ class ListLayout(Document):
 		from frappe.types import DF
 
 		columns: DF.LongText | None
-		layout_name: DF.Data | None
 		filters: DF.LongText | None
 		for_user: DF.Link | None
+		layout_name: DF.Data | None
 		reference_doctype: DF.Link | None
-		route_signature: DF.Data | None
+		route_signature: DF.SmallText | None
 		sort_field: DF.Data | None
 		sort_order: DF.Data | None
 	# end: auto-generated types

--- a/frappe/patches/v16_0/rename_list_filter_to_list_layout.py
+++ b/frappe/patches/v16_0/rename_list_filter_to_list_layout.py
@@ -9,6 +9,6 @@ def execute():
 		return
 
 	if frappe.db.table_exists("List Filter") and not frappe.db.has_column("List Filter", "route_signature"):
-		add_column("List Filter", "route_signature", "Data")
+		add_column("List Filter", "route_signature", "Small Text")
 
 	rename_doc("DocType", "List Filter", "List Layout", force=True)


### PR DESCRIPTION
Patch was failing due to `Data` fieldtype of `route_signature` field as it contain all filters text and when filters are more and huge get the error as ```Data too long for column 'route_signature``` so changing its datatype to `Small Text`