### PR TITLE
fix: handle partial migration state by dropping existing List Layout

### DIFF
--- a/frappe/patches/v16_0/rename_list_filter_to_list_layout.py
+++ b/frappe/patches/v16_0/rename_list_filter_to_list_layout.py
@@ -3,16 +3,39 @@ from frappe.database.schema import add_column
 from frappe.model.rename_doc import rename_doc
 
 
+def _resolve_list_layout_table_conflict():
+	"""Unblock rename when both tables exist from a failed/partial migration."""
+	if not (frappe.db.table_exists("List Filter") and frappe.db.table_exists("List Layout")):
+		return
+
+	filter_rows = frappe.db.count("List Filter", distinct=False)
+	layout_rows = frappe.db.count("List Layout", distinct=False)
+
+	if layout_rows and not filter_rows:
+		# Data is already in tabList Layout; swap so rename_doc can finish.
+		frappe.db.rename_table("List Layout", "List Filter")
+	elif not layout_rows:
+		frappe.db.sql_ddl("drop table `tabList Layout`")
+	else:
+		# Both populated: keep original List Filter rows.
+		frappe.db.sql_ddl("drop table `tabList Layout`")
+
+
 def execute():
 	"""Rename List Filter DocType to List Layout before model sync."""
 	if not frappe.db.exists("DocType", "List Filter"):
 		return
 
-	# Handle partial migration state from failed reruns.
-	if frappe.db.table_exists("List Filter") and frappe.db.table_exists("List Layout"):
-		frappe.db.sql_ddl("drop table `tabList Layout`")
+	_resolve_list_layout_table_conflict()
 
 	if frappe.db.table_exists("List Filter") and not frappe.db.has_column("List Filter", "route_signature"):
 		add_column("List Filter", "route_signature", "Small Text")
+
+	# Model sync may have created List Layout DocType before rename completed.
+	if frappe.db.exists("DocType", "List Layout"):
+		if frappe.db.table_exists("List Filter") and not frappe.db.table_exists("List Layout"):
+			frappe.db.rename_table("List Filter", "List Layout")
+		frappe.delete_doc("DocType", "List Filter", force=True)
+		return
 
 	rename_doc("DocType", "List Filter", "List Layout", force=True)

--- a/frappe/patches/v16_0/rename_list_filter_to_list_layout.py
+++ b/frappe/patches/v16_0/rename_list_filter_to_list_layout.py
@@ -8,6 +8,10 @@ def execute():
 	if not frappe.db.exists("DocType", "List Filter"):
 		return
 
+	# Handle partial migration state from failed reruns.
+	if frappe.db.table_exists("List Filter") and frappe.db.table_exists("List Layout"):
+		frappe.db.sql_ddl("drop table `tabList Layout`")
+
 	if frappe.db.table_exists("List Filter") and not frappe.db.has_column("List Filter", "route_signature"):
 		add_column("List Filter", "route_signature", "Small Text")
 


### PR DESCRIPTION
This PR fixes List Filter to List Layout migration failures on reruns by making the rename patch resilient to partial migration state (where both old and new tables may exist), and by updating route_signature handling to use Small Text so backfill values don’t fail due to length limits.