### PR TITLE
fix(print-format-builder): child table support and html cell rendering

### DIFF
--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -413,7 +413,12 @@ let field_groups = computed(() => {
 			continue;
 		}
 		if (df.fieldtype === "Column Break") continue;
-		if (frappe.model.no_value_type.includes(df.fieldtype)) continue;
+		if (
+			frappe.model.no_value_type.includes(df.fieldtype) &&
+			df.fieldtype !== "Table" &&
+			df.fieldtype !== "Table MultiSelect"
+		)
+			continue;
 
 		if (q) {
 			const match =

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -347,13 +347,17 @@ function clone_field(df) {
 }
 
 function add_to_layout(df) {
-	const sections = layout.value?.sections;
+	const lv = layout.value;
+	const sections = lv?.sections;
 	if (!sections || !sections.length) return;
 
-	// If a field is selected, insert right after it in the same column
+	// If a field is selected, insert right after it in the same column.
+	// Search body sections and header/footer zones so a selected header field
+	// is used as the anchor when inserting from the panel.
 	const selected_field = store.selected_field.value;
 	if (selected_field && !selected_field.remove) {
-		for (const section of sections) {
+		const all_zones = [lv?.header, lv?.footer, ...sections].filter(Boolean);
+		for (const section of all_zones) {
 			for (const column of section.columns) {
 				const idx = column.fields.indexOf(selected_field);
 				if (idx !== -1) {
@@ -364,11 +368,13 @@ function add_to_layout(df) {
 		}
 	}
 
-	// Otherwise add to the last column of the selected (or last) section
-	const target_section =
-		store.selected_section.value && sections.includes(store.selected_section.value)
-			? store.selected_section.value
-			: sections.slice(-1)[0];
+	// Otherwise add to the last column of the selected (or last body) section.
+	// Header/footer zone sections are valid targets when they are selected.
+	const selected = store.selected_section.value;
+	const is_valid_target =
+		selected &&
+		(sections.includes(selected) || selected === lv?.header || selected === lv?.footer);
+	const target_section = is_valid_target ? selected : sections.slice(-1)[0];
 	if (!target_section) return;
 	const last_column = target_section.columns.slice(-1)[0];
 	if (!last_column) return;

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -349,9 +349,12 @@ function clone_field(df) {
 function add_to_layout(df) {
 	const sections = layout.value?.sections;
 	if (!sections || !sections.length) return;
-	const last_section = sections.slice(-1)[0];
-	if (!last_section) return;
-	const last_column = last_section.columns.slice(-1)[0];
+	const target_section =
+		store.selected_section.value && sections.includes(store.selected_section.value)
+			? store.selected_section.value
+			: sections.slice(-1)[0];
+	if (!target_section) return;
+	const last_column = target_section.columns.slice(-1)[0];
 	if (!last_column) return;
 	last_column.fields.push(clone_field(df));
 }

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -413,11 +413,7 @@ let field_groups = computed(() => {
 			continue;
 		}
 		if (df.fieldtype === "Column Break") continue;
-		if (
-			frappe.model.no_value_type.includes(df.fieldtype) &&
-			df.fieldtype !== "Table" &&
-			df.fieldtype !== "Table MultiSelect"
-		)
+		if (frappe.model.no_value_type.includes(df.fieldtype) && df.fieldtype !== "Table")
 			continue;
 
 		if (q) {

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -349,7 +349,7 @@ function clone_field(df) {
 function add_to_layout(df) {
 	const sections = layout.value?.sections;
 	if (!sections || !sections.length) return;
-	const last_section = sections.filter((s) => !s.remove).slice(-1)[0];
+	const last_section = sections.slice(-1)[0];
 	if (!last_section) return;
 	const last_column = last_section.columns.slice(-1)[0];
 	if (!last_column) return;
@@ -413,7 +413,11 @@ let field_groups = computed(() => {
 			continue;
 		}
 		if (df.fieldtype === "Column Break") continue;
-		if (frappe.model.no_value_type.includes(df.fieldtype) && df.fieldtype !== "Table")
+		if (
+			frappe.model.no_value_type.includes(df.fieldtype) &&
+			df.fieldtype !== "Table" &&
+			df.fieldtype !== "Table MultiSelect"
+		)
 			continue;
 
 		if (q) {

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -747,16 +747,6 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	flex-shrink: 0;
 }
 
-.pfb-plus-icon {
-	opacity: 0;
-	flex-shrink: 0;
-	transition: opacity 0.1s;
-}
-
-.pfb-template-card:hover .pfb-plus-icon {
-	opacity: 1;
-}
-
 /* ── Block card (Blocks tab) ─────────────────────────────── */
 .pfb-block-card {
 	display: flex;

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -349,6 +349,22 @@ function clone_field(df) {
 function add_to_layout(df) {
 	const sections = layout.value?.sections;
 	if (!sections || !sections.length) return;
+
+	// If a field is selected, insert right after it in the same column
+	const selected_field = store.selected_field.value;
+	if (selected_field) {
+		for (const section of sections) {
+			for (const column of section.columns) {
+				const idx = column.fields.indexOf(selected_field);
+				if (idx !== -1) {
+					column.fields.splice(idx + 1, 0, clone_field(df));
+					return;
+				}
+			}
+		}
+	}
+
+	// Otherwise add to the last column of the selected (or last) section
 	const target_section =
 		store.selected_section.value && sections.includes(store.selected_section.value)
 			? store.selected_section.value

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -352,7 +352,7 @@ function add_to_layout(df) {
 
 	// If a field is selected, insert right after it in the same column
 	const selected_field = store.selected_field.value;
-	if (selected_field) {
+	if (selected_field && !selected_field.remove) {
 		for (const section of sections) {
 			for (const column of section.columns) {
 				const idx = column.fields.indexOf(selected_field);

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -226,7 +226,7 @@
 
 <script setup>
 import ConfigureColumnsVue from "../inspector/ConfigureColumns.vue";
-import { render_jinja_html } from "../../utils";
+import { render_jinja_html, sanitize_html } from "../../utils";
 import { createApp, ref, nextTick, watch, computed, inject } from "vue";
 
 const props = defineProps(["df", "field_orientation"]);
@@ -326,122 +326,12 @@ function is_html_content_field(col) {
 	return HTML_CONTENT_FIELDTYPES.has(col?.fieldtype);
 }
 
-const SAFE_HTML_TAGS = new Set([
-	"a",
-	"abbr",
-	"b",
-	"blockquote",
-	"br",
-	"caption",
-	"cite",
-	"code",
-	"col",
-	"colgroup",
-	"dd",
-	"del",
-	"div",
-	"dl",
-	"dt",
-	"em",
-	"figcaption",
-	"figure",
-	"h1",
-	"h2",
-	"h3",
-	"h4",
-	"h5",
-	"h6",
-	"hr",
-	"i",
-	"img",
-	"ins",
-	"kbd",
-	"li",
-	"mark",
-	"ol",
-	"p",
-	"pre",
-	"q",
-	"s",
-	"samp",
-	"small",
-	"span",
-	"strong",
-	"sub",
-	"summary",
-	"sup",
-	"table",
-	"tbody",
-	"td",
-	"tfoot",
-	"th",
-	"thead",
-	"tr",
-	"u",
-	"ul",
-	"var",
-	"wbr",
-]);
-
-const SAFE_HTML_ATTRS = new Set([
-	"alt",
-	"cite",
-	"class",
-	"colspan",
-	"datetime",
-	"dir",
-	"height",
-	"href",
-	"lang",
-	"rowspan",
-	"scope",
-	"span",
-	"src",
-	"style",
-	"title",
-	"width",
-	"align",
-	"valign",
-	"border",
-	"cellpadding",
-	"cellspacing",
-]);
-
-function sanitize_cell_html(html) {
-	const root = document.createElement("div");
-	root.innerHTML = frappe.dom.remove_script_and_style(html || "");
-	(function clean(node) {
-		for (const child of [...node.childNodes]) {
-			if (child.nodeType === Node.TEXT_NODE) continue;
-			if (child.nodeType !== Node.ELEMENT_NODE) {
-				child.remove();
-				continue;
-			}
-			if (!SAFE_HTML_TAGS.has(child.tagName.toLowerCase())) {
-				child.replaceWith(...child.childNodes);
-				continue;
-			}
-			for (const attr of [...child.attributes]) {
-				const name = attr.name.toLowerCase();
-				if (!SAFE_HTML_ATTRS.has(name) || name.startsWith("on")) {
-					child.removeAttribute(attr.name);
-				} else if (name === "href" || name === "src") {
-					if (!/^(https?:|data:image\/)/i.test(attr.value.trim()))
-						child.removeAttribute(attr.name);
-				}
-			}
-			clean(child);
-		}
-	})(root);
-	return root.innerHTML;
-}
-
 function format_cell(row, col) {
 	const raw = row[col.fieldname];
 	if (raw === null || raw === undefined || raw === "") return "";
 	if (col.fieldtype === "Check") return raw ? __("Yes") : __("No");
 	// HTML content fields: sanitize then return for v-html rendering
-	if (HTML_CONTENT_FIELDTYPES.has(col.fieldtype)) return sanitize_cell_html(raw);
+	if (HTML_CONTENT_FIELDTYPES.has(col.fieldtype)) return sanitize_html(raw);
 	try {
 		const formatted = frappe.format(raw, col, { only_value: true }, row);
 		if (typeof formatted === "string" && formatted.includes("<")) {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -26,6 +26,29 @@
 					class="custom-html"
 					v-html="rendered_template || ''"
 				></div>
+				<!-- Table MultiSelect field: render as a comma-separated value list -->
+				<div
+					v-else-if="df.fieldtype == 'Table MultiSelect'"
+					:style="{ textAlign: df.align || 'left' }"
+					:class="{ 'field-preview-lr': field_orientation === 'left-right' }"
+				>
+					<div v-if="df.label && df.show_label !== 'hide'" class="field-preview-label">
+						{{ df.label }}
+					</div>
+					<div
+						class="field-preview-value"
+						:class="{
+							'text-muted': !(preview_doc[df.fieldname] || []).length,
+						}"
+					>
+						{{
+							(preview_doc[df.fieldname] || [])
+								.map((r) => r.value)
+								.filter(Boolean)
+								.join(", ") || "—"
+						}}
+					</div>
+				</div>
 				<!-- Table field -->
 				<div v-else-if="df.fieldtype == 'Table'" class="field-preview-table">
 					<div v-if="df.label" class="field-preview-label">{{ df.label }}</div>
@@ -452,6 +475,7 @@ let short_fieldtype = computed(() => {
 		Check: "Check",
 		Select: "Select",
 		Table: "Table",
+		"Table MultiSelect": "Multi",
 		"Long Text": "Text",
 		Text: "Text",
 		Link: "Link",

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -303,17 +303,114 @@ function is_html_content_field(col) {
 	return HTML_CONTENT_FIELDTYPES.has(col?.fieldtype);
 }
 
+const SAFE_HTML_TAGS = new Set([
+	"a",
+	"abbr",
+	"b",
+	"blockquote",
+	"br",
+	"caption",
+	"cite",
+	"code",
+	"col",
+	"colgroup",
+	"dd",
+	"del",
+	"div",
+	"dl",
+	"dt",
+	"em",
+	"figcaption",
+	"figure",
+	"h1",
+	"h2",
+	"h3",
+	"h4",
+	"h5",
+	"h6",
+	"hr",
+	"i",
+	"img",
+	"ins",
+	"kbd",
+	"li",
+	"mark",
+	"ol",
+	"p",
+	"pre",
+	"q",
+	"s",
+	"samp",
+	"small",
+	"span",
+	"strong",
+	"sub",
+	"summary",
+	"sup",
+	"table",
+	"tbody",
+	"td",
+	"tfoot",
+	"th",
+	"thead",
+	"tr",
+	"u",
+	"ul",
+	"var",
+	"wbr",
+]);
+
+const SAFE_HTML_ATTRS = new Set([
+	"alt",
+	"cite",
+	"class",
+	"colspan",
+	"datetime",
+	"dir",
+	"height",
+	"href",
+	"lang",
+	"rowspan",
+	"scope",
+	"span",
+	"src",
+	"style",
+	"title",
+	"width",
+	"align",
+	"valign",
+	"border",
+	"cellpadding",
+	"cellspacing",
+]);
+
 function sanitize_cell_html(html) {
-	const tmp = document.createElement("div");
-	tmp.innerHTML = frappe.dom.remove_script_and_style(html || "");
-	tmp.querySelectorAll("*").forEach((el) => {
-		for (const attr of [...el.attributes]) {
-			if (attr.name.startsWith("on")) el.removeAttribute(attr.name);
+	const root = document.createElement("div");
+	root.innerHTML = frappe.dom.remove_script_and_style(html || "");
+	(function clean(node) {
+		for (const child of [...node.childNodes]) {
+			if (child.nodeType === Node.TEXT_NODE) continue;
+			if (child.nodeType !== Node.ELEMENT_NODE) {
+				child.remove();
+				continue;
+			}
+			if (!SAFE_HTML_TAGS.has(child.tagName.toLowerCase())) {
+				child.replaceWith(...child.childNodes);
+				continue;
+			}
+			for (const attr of [...child.attributes]) {
+				const name = attr.name.toLowerCase();
+				if (!SAFE_HTML_ATTRS.has(name) || name.startsWith("on")) {
+					child.removeAttribute(attr.name);
+				} else if (name === "href" || name === "src") {
+					if (!/^(https?:|data:image\/)/i.test(attr.value.trim()))
+						child.removeAttribute(attr.name);
+				}
+			}
+			clean(child);
 		}
-		if (el.tagName === "A" && /^javascript:/i.test(el.getAttribute("href") || ""))
-			el.removeAttribute("href");
-	});
-	return tmp.innerHTML;
+	})(root);
+	return root.innerHTML;
 }
 
 function format_cell(row, col) {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -68,6 +68,11 @@
 										class="preview-table-img"
 										:alt="col.label || col.fieldname"
 									/>
+									<div
+										v-else-if="is_html_content_field(col)"
+										class="preview-table-html"
+										v-html="format_cell(row, col)"
+									></div>
 									<span v-else>{{ format_cell(row, col) }}</span>
 								</td>
 							</tr>
@@ -288,14 +293,22 @@ function is_image_field(col, value) {
 }
 
 const NUMERIC_FIELDTYPES = new Set(["Currency", "Float", "Int", "Percent"]);
+const HTML_CONTENT_FIELDTYPES = new Set(["Text Editor", "Long Text"]);
+
 function numeric_align_class(col) {
 	return NUMERIC_FIELDTYPES.has(col?.fieldtype) ? "col-numeric" : "";
+}
+
+function is_html_content_field(col) {
+	return HTML_CONTENT_FIELDTYPES.has(col?.fieldtype);
 }
 
 function format_cell(row, col) {
 	const raw = row[col.fieldname];
 	if (raw === null || raw === undefined || raw === "") return "";
 	if (col.fieldtype === "Check") return raw ? __("Yes") : __("No");
+	// HTML content fields: value is already HTML, return as-is for v-html rendering
+	if (HTML_CONTENT_FIELDTYPES.has(col.fieldtype)) return raw;
 	try {
 		const formatted = frappe.format(raw, col, { only_value: true }, row);
 		if (typeof formatted === "string" && formatted.includes("<")) {
@@ -816,6 +829,11 @@ watch(
 	max-width: 80px;
 	object-fit: contain;
 	display: block;
+}
+
+.preview-table-html {
+	word-break: break-word;
+	white-space: normal;
 }
 
 .preview-field-img {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -303,12 +303,25 @@ function is_html_content_field(col) {
 	return HTML_CONTENT_FIELDTYPES.has(col?.fieldtype);
 }
 
+function sanitize_cell_html(html) {
+	const tmp = document.createElement("div");
+	tmp.innerHTML = frappe.dom.remove_script_and_style(html || "");
+	tmp.querySelectorAll("*").forEach((el) => {
+		for (const attr of [...el.attributes]) {
+			if (attr.name.startsWith("on")) el.removeAttribute(attr.name);
+		}
+		if (el.tagName === "A" && /^javascript:/i.test(el.getAttribute("href") || ""))
+			el.removeAttribute("href");
+	});
+	return tmp.innerHTML;
+}
+
 function format_cell(row, col) {
 	const raw = row[col.fieldname];
 	if (raw === null || raw === undefined || raw === "") return "";
 	if (col.fieldtype === "Check") return raw ? __("Yes") : __("No");
-	// HTML content fields: value is already HTML, return as-is for v-html rendering
-	if (HTML_CONTENT_FIELDTYPES.has(col.fieldtype)) return raw;
+	// HTML content fields: sanitize then return for v-html rendering
+	if (HTML_CONTENT_FIELDTYPES.has(col.fieldtype)) return sanitize_cell_html(raw);
 	try {
 		const formatted = frappe.format(raw, col, { only_value: true }, row);
 		if (typeof formatted === "string" && formatted.includes("<")) {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -37,16 +37,9 @@
 					</div>
 					<div
 						class="field-preview-value"
-						:class="{
-							'text-muted': !(preview_doc[df.fieldname] || []).length,
-						}"
+						:class="{ 'text-muted': !(preview_doc[df.fieldname] || []).length }"
 					>
-						{{
-							(preview_doc[df.fieldname] || [])
-								.map((r) => r.value)
-								.filter(Boolean)
-								.join(", ") || "—"
-						}}
+						{{ multiselect_display(df) }}
 					</div>
 				</div>
 				<!-- Table field -->
@@ -320,6 +313,20 @@ const HTML_CONTENT_FIELDTYPES = new Set(["Text Editor", "Long Text"]);
 
 function numeric_align_class(col) {
 	return NUMERIC_FIELDTYPES.has(col?.fieldtype) ? "col-numeric" : "";
+}
+
+function multiselect_display(df) {
+	const rows = preview_doc.value?.[df.fieldname] || [];
+	if (!rows.length) return "—";
+	const child_meta = frappe.get_meta(df.options);
+	const link_field = child_meta?.fields.find((f) => f.fieldtype === "Link");
+	if (!link_field) return "—";
+	return (
+		rows
+			.map((r) => r[link_field.fieldname])
+			.filter(Boolean)
+			.join(", ") || "—"
+	);
 }
 
 function is_html_content_field(col) {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -33,7 +33,7 @@
 				@add="on_section_add"
 			>
 				<template #item="{ element, index }">
-					<div class="section-with-insert">
+					<div v-if="!element.remove" class="section-with-insert">
 						<SectionInsert @insert="add_section_at(index)" />
 						<PrintFormatSection :section="element" />
 					</div>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -33,7 +33,7 @@
 				@add="on_section_add"
 			>
 				<template #item="{ element, index }">
-					<div v-if="!element.remove" class="section-with-insert">
+					<div class="section-with-insert">
 						<SectionInsert @insert="add_section_at(index)" />
 						<PrintFormatSection :section="element" />
 					</div>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -357,8 +357,9 @@ function set_column_align(column, value) {
 }
 
 .empty-drop-zone {
-	position: absolute;
-	inset: 0;
+	position: relative;
+	flex: 1;
+	min-height: 6rem;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -98,7 +98,22 @@
 								v-html="frappe.utils.icon('x', 'xs')"
 							></button>
 							<div class="empty-drop-zone-hint">
-								<span class="text-muted">{{ __("Drop fields here") }}</span>
+								<svg
+									class="drop-icon"
+									width="16"
+									height="16"
+									viewBox="0 0 16 16"
+									fill="none"
+									xmlns="http://www.w3.org/2000/svg"
+								>
+									<path
+										d="M8 3v10M3 8h10"
+										stroke="currentColor"
+										stroke-width="1.5"
+										stroke-linecap="round"
+									/>
+								</svg>
+								<span>{{ __("Drop fields here") }}</span>
 							</div>
 						</div>
 					</div>
@@ -333,7 +348,7 @@ function set_column_align(column, value) {
 .drag-container {
 	flex: 1;
 	min-width: 0;
-	min-height: 4rem;
+	min-height: 6rem;
 	border-radius: var(--radius);
 	display: flex;
 	flex-direction: column;
@@ -347,17 +362,25 @@ function set_column_align(column, value) {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	border: 1.5px dashed var(--gray-300);
+	border: 1.5px dashed var(--gray-400);
 	border-radius: var(--radius);
 	color: var(--text-muted);
 	font-size: var(--text-xs);
 	pointer-events: none;
+	background: var(--gray-50);
+	transition: border-color 0.15s, background 0.15s;
 }
 
 .empty-drop-zone-hint {
 	display: flex;
+	flex-direction: column;
 	align-items: center;
-	gap: 0.25rem;
+	gap: 0.35rem;
+	color: var(--gray-500);
+}
+
+.drop-icon {
+	color: var(--gray-400);
 }
 
 .empty-col-remove {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -153,6 +153,12 @@ function remove_section() {
 		if (store.selected_section.value === props.section) {
 			store.selected_section.value = null;
 		}
+		if (
+			store.selected_field.value &&
+			props.section.columns.some((c) => c.fields.includes(store.selected_field.value))
+		) {
+			store.selected_field.value = null;
+		}
 	}
 }
 

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -147,7 +147,12 @@ function select_section() {
 
 function remove_section() {
 	const idx = store.layout.value.sections.indexOf(props.section);
-	if (idx !== -1) store.layout.value.sections.splice(idx, 1);
+	if (idx !== -1) {
+		store.layout.value.sections.splice(idx, 1);
+		if (store.selected_section.value === props.section) {
+			store.selected_section.value = null;
+		}
+	}
 }
 
 function remove_column(index) {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -329,6 +329,12 @@ function remove_column(index) {
 }
 
 .column:has(.sortable-ghost) .empty-drop-zone {
+	background: transparent;
+	border-color: var(--blue-300);
+	border-style: solid;
+}
+
+.column:has(.sortable-ghost) .empty-drop-zone-hint {
 	display: none;
 }
 

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -328,6 +328,10 @@ function remove_column(index) {
 	min-height: 3rem;
 }
 
+.column:has(.sortable-ghost) .empty-drop-zone {
+	display: none;
+}
+
 .empty-drop-zone {
 	position: absolute;
 	inset: 0;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -98,21 +98,6 @@
 								v-html="frappe.utils.icon('x', 'xs')"
 							></button>
 							<div class="empty-drop-zone-hint">
-								<svg
-									class="drop-icon"
-									width="16"
-									height="16"
-									viewBox="0 0 16 16"
-									fill="none"
-									xmlns="http://www.w3.org/2000/svg"
-								>
-									<path
-										d="M8 3v10M3 8h10"
-										stroke="currentColor"
-										stroke-width="1.5"
-										stroke-linecap="round"
-									/>
-								</svg>
 								<span>{{ __("Drop fields here") }}</span>
 							</div>
 						</div>
@@ -348,7 +333,7 @@ function set_column_align(column, value) {
 .drag-container {
 	flex: 1;
 	min-width: 0;
-	min-height: 6rem;
+	min-height: 3rem;
 	border-radius: var(--radius);
 	display: flex;
 	flex-direction: column;
@@ -359,7 +344,7 @@ function set_column_align(column, value) {
 .empty-drop-zone {
 	position: relative;
 	flex: 1;
-	min-height: 6rem;
+	min-height: 3rem;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -373,15 +358,7 @@ function set_column_align(column, value) {
 }
 
 .empty-drop-zone-hint {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 0.35rem;
 	color: var(--gray-500);
-}
-
-.drop-icon {
-	color: var(--gray-400);
 }
 
 .empty-col-remove {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -341,10 +341,13 @@ function set_column_align(column, value) {
 	overflow: visible;
 }
 
-.empty-drop-zone {
-	position: relative;
-	flex: 1;
+.column:has(.empty-drop-zone) {
 	min-height: 3rem;
+}
+
+.empty-drop-zone {
+	position: absolute;
+	inset: 0;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -145,36 +145,9 @@ function select_section() {
 	store.selected_lh_footer.value = false;
 }
 
-function set_columns(n) {
-	const current = props.section.columns.length;
-	if (n === current) return;
-
-	// collect all fields preserving order
-	const all_fields = props.section.columns.flatMap((col) => col.fields);
-
-	// build n fresh columns and distribute fields round-robin
-	const new_columns = Array.from({ length: n }, () => ({ label: "", fields: [] }));
-	all_fields.forEach((field, i) => new_columns[i % n].fields.push(field));
-
-	props.section.columns = new_columns;
-}
-
 function remove_column(index) {
 	if (props.section.columns.length <= 1) return;
 	props.section.columns.splice(index, 1);
-}
-
-function toggle_page_break() {
-	props.section["page_break"] = !props.section.page_break;
-}
-
-function toggle_orientation() {
-	props.section["field_orientation"] =
-		props.section.field_orientation === "left-right" ? "" : "left-right";
-}
-
-function set_column_align(column, value) {
-	column.align = value;
 }
 </script>
 

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="print-format-section-container" v-if="!section.remove" data-pfb-section>
+	<div class="print-format-section-container" data-pfb-section>
 		<!-- Top-left actions pill shown on hover in clean-preview (toolbar is hidden) -->
 		<div v-if="!is_header" class="section-preview-actions">
 			<div
@@ -9,7 +9,7 @@
 			<button
 				class="btn btn-xs btn-icon"
 				:title="__('Remove section')"
-				@click.stop="section['remove'] = true"
+				@click.stop="remove_section"
 				v-html="frappe.utils.icon('x', 'xs')"
 			></button>
 		</div>
@@ -45,7 +45,7 @@
 						v-if="!is_header"
 						class="btn btn-xs btn-icon toolbar-btn toolbar-btn-danger"
 						:title="__('Remove section')"
-						@click.stop="section['remove'] = true"
+						@click.stop="remove_section"
 					>
 						<span v-html="frappe.utils.icon('x', 'sm')"></span>
 					</button>
@@ -143,6 +143,11 @@ function select_section() {
 	store.selected_field.value = null;
 	store.selected_letterhead.value = false;
 	store.selected_lh_footer.value = false;
+}
+
+function remove_section() {
+	const idx = store.layout.value.sections.indexOf(props.section);
+	if (idx !== -1) store.layout.value.sections.splice(idx, 1);
 }
 
 function remove_column(index) {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -78,6 +78,7 @@
 							item-key="id"
 							handle=".drag-handle"
 							:emptyInsertThreshold="100"
+							@add="select_section"
 						>
 							<template #item="{ element }">
 								<Field

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -538,11 +538,17 @@
 					<button
 						class="btn btn-xs btn-danger-subtle"
 						@click="
-							const idx = layout.value.sections.indexOf(
-								store.selected_section.value
-							);
+							const section = store.selected_section.value;
+							const idx = layout.value.sections.indexOf(section);
 							if (idx !== -1) layout.value.sections.splice(idx, 1);
 							store.selected_section.value = null;
+							if (
+								section &&
+								section.columns.some((c) =>
+									c.fields.includes(store.selected_field.value)
+								)
+							)
+								store.selected_field.value = null;
 						"
 					>
 						<span v-html="frappe.utils.icon('x', 'xs')"></span>

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -538,7 +538,10 @@
 					<button
 						class="btn btn-xs btn-danger-subtle"
 						@click="
-							selected_section.remove = true;
+							const idx = layout.value.sections.indexOf(
+								store.selected_section.value
+							);
+							if (idx !== -1) layout.value.sections.splice(idx, 1);
 							store.selected_section.value = null;
 						"
 					>

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -32,6 +32,8 @@ export function getStore(print_format_name) {
 					const saved_layout = get_layout();
 					needs_setup.value = !saved_layout;
 					layout.value = saved_layout || get_default_layout();
+					// Drop legacy sections that were soft-deleted before immediate splice was introduced
+					layout.value.sections = layout.value.sections.filter((s) => !s.remove);
 					// Migrate legacy string header/footer to section objects
 					layout.value.header = migrate_to_section(layout.value.header);
 					layout.value.footer = migrate_to_section(layout.value.footer);

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -154,6 +154,116 @@ export async function render_jinja_html(html, doctype, docname) {
 	}
 }
 
+const SAFE_HTML_TAGS = new Set([
+	"a",
+	"abbr",
+	"b",
+	"blockquote",
+	"br",
+	"caption",
+	"cite",
+	"code",
+	"col",
+	"colgroup",
+	"dd",
+	"del",
+	"div",
+	"dl",
+	"dt",
+	"em",
+	"figcaption",
+	"figure",
+	"h1",
+	"h2",
+	"h3",
+	"h4",
+	"h5",
+	"h6",
+	"hr",
+	"i",
+	"img",
+	"ins",
+	"kbd",
+	"li",
+	"mark",
+	"ol",
+	"p",
+	"pre",
+	"q",
+	"s",
+	"samp",
+	"small",
+	"span",
+	"strong",
+	"sub",
+	"summary",
+	"sup",
+	"table",
+	"tbody",
+	"td",
+	"tfoot",
+	"th",
+	"thead",
+	"tr",
+	"u",
+	"ul",
+	"var",
+	"wbr",
+]);
+
+const SAFE_HTML_ATTRS = new Set([
+	"alt",
+	"cite",
+	"class",
+	"colspan",
+	"datetime",
+	"dir",
+	"height",
+	"href",
+	"lang",
+	"rowspan",
+	"scope",
+	"span",
+	"src",
+	"style",
+	"title",
+	"width",
+	"align",
+	"valign",
+	"border",
+	"cellpadding",
+	"cellspacing",
+]);
+
+export function sanitize_html(html) {
+	const root = document.createElement("div");
+	root.innerHTML = frappe.dom.remove_script_and_style(html || "");
+	(function clean(node) {
+		for (const child of [...node.childNodes]) {
+			if (child.nodeType === Node.TEXT_NODE) continue;
+			if (child.nodeType !== Node.ELEMENT_NODE) {
+				child.remove();
+				continue;
+			}
+			if (!SAFE_HTML_TAGS.has(child.tagName.toLowerCase())) {
+				child.replaceWith(...child.childNodes);
+				continue;
+			}
+			for (const attr of [...child.attributes]) {
+				const name = attr.name.toLowerCase();
+				if (!SAFE_HTML_ATTRS.has(name) || name.startsWith("on")) {
+					child.removeAttribute(attr.name);
+				} else if (name === "href" || name === "src") {
+					if (!/^(https?:|data:image\/)/i.test(attr.value.trim()))
+						child.removeAttribute(attr.name);
+				}
+			}
+			clean(child);
+		}
+	})(root);
+	return root.innerHTML;
+}
+
 export function get_image_dimensions(src) {
 	return new Promise((resolve) => {
 		let img = new Image();

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -225,7 +225,6 @@ const SAFE_HTML_ATTRS = new Set([
 	"scope",
 	"span",
 	"src",
-	"style",
 	"title",
 	"width",
 	"align",
@@ -239,14 +238,24 @@ export function sanitize_html(html) {
 	const root = document.createElement("div");
 	root.innerHTML = frappe.dom.remove_script_and_style(html || "");
 	(function clean(node) {
-		for (const child of [...node.childNodes]) {
-			if (child.nodeType === Node.TEXT_NODE) continue;
+		// Linked-list traversal so promoted children are visited immediately
+		let child = node.firstChild;
+		while (child) {
+			const next = child.nextSibling;
+			if (child.nodeType === Node.TEXT_NODE) {
+				child = next;
+				continue;
+			}
 			if (child.nodeType !== Node.ELEMENT_NODE) {
 				child.remove();
+				child = next;
 				continue;
 			}
 			if (!SAFE_HTML_TAGS.has(child.tagName.toLowerCase())) {
+				const first_promoted = child.firstChild;
 				child.replaceWith(...child.childNodes);
+				// Continue from first promoted child so they are sanitized too
+				child = first_promoted || next;
 				continue;
 			}
 			for (const attr of [...child.attributes]) {
@@ -261,6 +270,7 @@ export function sanitize_html(html) {
 				}
 			}
 			clean(child);
+			child = next;
 		}
 	})(root);
 	return root.innerHTML;

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -253,9 +253,11 @@ export function sanitize_html(html) {
 				const name = attr.name.toLowerCase();
 				if (!SAFE_HTML_ATTRS.has(name) || name.startsWith("on")) {
 					child.removeAttribute(attr.name);
-				} else if (name === "href" || name === "src") {
+				} else if (name === "src") {
 					if (!/^(https?:|data:image\/)/i.test(attr.value.trim()))
 						child.removeAttribute(attr.name);
+				} else if (name === "href") {
+					if (!/^https?:/i.test(attr.value.trim())) child.removeAttribute(attr.name);
 				}
 			}
 			clean(child);

--- a/frappe/utils/chromium/page.py
+++ b/frappe/utils/chromium/page.py
@@ -145,7 +145,7 @@ class Page:
 							os.path.commonpath([final_system_path, site_public_root]) == site_public_root
 						)
 
-					if is_safe:
+					if is_safe and os.path.isfile(final_system_path):
 						content = frappe.read_file(final_system_path, as_base64=True)
 						response_headers = []
 						# write logic to handle all file types as required


### PR DESCRIPTION
- Show Table and Table MultiSelect fields in the fields panel (filtered out by `no_value_type`)
- Render Text Editor / Long Text child-table columns with `v-html`; sanitized via an allowlist sanitizer (safe tags + attributes only, `style` stripped, `src` restricted to same-origin/relative/data URIs, `href` to `https:` only)
- Resolve correct Link fieldname for Table MultiSelect preview values
- Clicking a field in the sidebar adds it to the selected section/after the selected field, not always the last section
- Header and footer zones are now valid insertion targets when selected
- Sections are spliced immediately on removal to keep vuedraggable in sync; selected section/field cleared on remove
- Fix PDF generation hang caused by `IsADirectoryError` in the Chromium local resource interceptor