### PR TITLE
fix(grid): re-evaluate dependent columns on programmatic child field change

### DIFF
--- a/cypress/integration/depends_on.js
+++ b/cypress/integration/depends_on.js
@@ -26,6 +26,7 @@ context("Depends On", () => {
 							fieldname: "child_display_dependant_field",
 							fieldtype: "Data",
 							in_list_view: 1,
+							depends_on: "eval:doc.child_test_field == 'show'",
 						},
 					],
 				});
@@ -138,6 +139,41 @@ context("Depends On", () => {
 		cy.get("@row1-form_in_grid")
 			.find('.control-input [data-fieldname="child_dependant_field"]')
 			.should("be.disabled");
+	});
+	it("should re-evaluate an on-grid column's depends_on when a sibling field is set programmatically", () => {
+		// Reproduces the newest-row issue: a row's controlling field is set after the
+		// grid has already rendered (as `_add` handlers do), so the dependent column
+		// must be re-evaluated on the model change, not only on the next full refresh.
+		cy.new_form("Test Depends On");
+		cy.get('.frappe-control[data-fieldname="child_test_depends_on_field"]').as("table");
+		cy.get("@table").findByRole("button", { name: "Add row" }).click();
+
+		let dependant_df = (win) => {
+			let cdn =
+				win.cur_frm.fields_dict.child_test_depends_on_field.grid.grid_rows[0].doc.name;
+			return win.frappe.meta.get_docfield(
+				"Child Test Depends On",
+				"child_display_dependant_field",
+				cdn
+			);
+		};
+
+		// depends_on is not satisfied yet, so the column is hidden
+		cy.window().should((win) => {
+			expect(dependant_df(win).hidden_due_to_dependency).to.be.ok;
+		});
+
+		// set the controlling field programmatically (the path an `_add` handler takes)
+		cy.window().then((win) => {
+			let { doctype: cdt, name: cdn } =
+				win.cur_frm.fields_dict.child_test_depends_on_field.grid.grid_rows[0].doc;
+			win.frappe.model.set_value(cdt, cdn, "child_test_field", "show");
+		});
+
+		// the dependent column must become editable without another full grid refresh
+		cy.window().should((win) => {
+			expect(dependant_df(win).hidden_due_to_dependency).to.not.be.ok;
+		});
 	});
 	it("should display the field depending on other fields value", () => {
 		cy.new_form("Test Depends On");

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -984,7 +984,10 @@ export default class Grid {
 
 	set_value(fieldname, value, doc) {
 		if (this.display_status !== "None" && doc?.name && this.grid_rows_by_docname?.[doc.name]) {
-			this.grid_rows_by_docname[doc.name].refresh_field(fieldname, value);
+			let grid_row = this.grid_rows_by_docname[doc.name];
+			grid_row.refresh_field(fieldname, value);
+			// re-evaluate depends_on of sibling columns that reference this field
+			grid_row.refresh_dependency();
 		}
 	}
 


### PR DESCRIPTION
## Problem

On-grid child table columns that use a `depends_on` expression were only re-evaluated on a full grid refresh. When a sibling field is set programmatically after the row has already rendered (which is exactly what `_add` handlers do), `grid.set_value` only repainted the changed cell and never re-evaluated dependent columns. The dependent column kept its stale `hidden_due_to_dependency` state, so its on-grid control resolved to status `None` and became unclickable.

This was reported on Stock Reconciliation: with `batch_no` added as a grid column (it depends on `use_serial_batch_fields`), the newest row's Batch No cell is unclickable. `use_serial_batch_fields` is flipped to `1` asynchronously by the `items_add` handler after the row renders, and nothing re-evaluates `batch_no`'s `depends_on` until the next refresh. Adding another row refreshes the grid and fixes the previous row, so it is always the last row that stays broken. Opening the full row form works because that path builds the control fresh.

It is not specific to Stock Reconciliation: any on-grid column with a `depends_on` whose controlling field is set after render (for example via the shared `items_add` in `transaction.js`) hits the same stale state.

## Fix

Re-run the row's `refresh_dependency()` inside `grid.set_value`, so dependent columns are re-evaluated as soon as the controlling field changes, not only on the next full refresh. `refresh_dependency()` only re-renders the row when a dependency property actually changes, so it is a no-op for grids without `depends_on` columns.

## How to test

1. Customize Form on Stock Reconciliation Item and add Batch No to the grid (In List View).
2. Set the user default `use_serial_batch_fields = 1` (Use Serial / Batch Fields).
3. Open a new Stock Reconciliation, add a row, enter a batched item.
4. Add a second row. Before this fix the newest row's Batch No cell is unclickable; with the fix it is editable immediately.

A Cypress regression test is added in `cypress/integration/depends_on.js`: it adds a row, sets the controlling child field programmatically (the `_add` path), and asserts the dependent on-grid column's `hidden_due_to_dependency` clears.