### PR TITLE
perf: use client_cache setter in `get_db_table_columns`

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1363,7 +1363,7 @@ class Database:
 			)
 
 			if columns:
-				frappe.cache.set_value(key, columns)
+				frappe.client_cache.set_value(key, columns)
 
 		return columns
 


### PR DESCRIPTION
PR open on behalf @AdnanQuazi

When fetching table columns on a cache miss, the code mistakenly wrote the database result back using `frappe.cache.set_value()` instead of `frappe.client_cache.set_value()`.

Because it used the wrong setter, the data was sent to Redis but bypassed the ClientCache's local RAM dictionary. This forced the very next call on the same worker to make an unnecessary Redis round-trip instead of a near-instant in-process hit.

This commit changes the setter to correctly populate the in-memory cache, avoiding the Redis network overhead on subsequent calls.

Closes #40243

