### PR TITLE
fix: color field shows no swatch in list view

### DIFF
--- a/frappe/public/scss/common/color_picker.scss
+++ b/frappe/public/scss/common/color_picker.scss
@@ -132,3 +132,14 @@
 		z-index: 2;
 	}
 }
+
+.list-row-col {
+	.selected-color {
+		display: inline-block;
+		width: 12px;
+		height: 12px;
+		border-radius: 4px;
+		margin-right: 6px;
+		vertical-align: middle;
+	}
+}

--- a/frappe/public/scss/common/color_picker.scss
+++ b/frappe/public/scss/common/color_picker.scss
@@ -132,14 +132,3 @@
 		z-index: 2;
 	}
 }
-
-.list-row-col {
-	.selected-color {
-		display: inline-block;
-		width: 12px;
-		height: 12px;
-		border-radius: 4px;
-		margin-right: 6px;
-		vertical-align: middle;
-	}
-}

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -326,6 +326,15 @@ body.list-col-resizing {
 		cursor: pointer;
 		text-decoration: underline;
 	}
+
+	.selected-color {
+		display: inline-block;
+		width: 12px;
+		height: 12px;
+		border-radius: 4px;
+		margin-right: 6px;
+		vertical-align: middle;
+	}
 }
 
 $level-margin-right: 8px;


### PR DESCRIPTION
## Bug

A Color field set to show in list view renders only the raw hex value (e.g. `#e24c4c`) with no color swatch, unlike the form control which shows the swatch next to the value.

  ## Why it happens

The `Color` formatter in `formatters.js` emits the swatch markup (`div.selected-color`) in every context, including list cells. But the swatch's dimensions live in a rule scoped under `.frappe-control[data-fieldtype="Color"]` in `color_picker.scss`. List rows sit under `.list-row-col`, never inside that control, so the swatch collapses to 0×0 and only the hex text is visible.

  ## Fix

Add a `.list-row-col .selected-color` rule giving the swatch size and inline layout so it renders before the hex value in list view. The existing form-control rule is untouched, so form rendering is unaffected.

## How it looks

<img width="1511" height="445" alt="Screenshot 2026-06-25 at 9 27 01 PM" src="https://github.com/user-attachments/assets/0688c04d-f128-4594-8d94-98c0008f4fa5" />

---
  Closes #39694