### PR TITLE
fix(socketio): short circuit websocket if in frappe cloud

### DIFF
--- a/frappe/realtime/auth.py
+++ b/frappe/realtime/auth.py
@@ -101,7 +101,7 @@ def authenticate(environ: dict, namespace: str, config: RealtimeConfig) -> Sessi
 	_validate_origin(environ)
 
 	credentials = _read_credentials(environ)
-	request = _make_request(environ, credentials, config)
+	request = _make_request(environ, credentials, config, site)
 	user_info = _get_user_info(request)
 
 	return _make_session(site, user_info, request)
@@ -161,7 +161,7 @@ def _read_sid(cookie_header: str | None) -> str | None:
 	return sid.value if sid else None
 
 
-def _make_request(environ: dict, credentials: Credentials, config: RealtimeConfig) -> WebRequest:
+def _make_request(environ: dict, credentials: Credentials, config: RealtimeConfig, site: str) -> WebRequest:
 	"""Build the authenticated request helper toward the web (socket.frappe_request port).
 
 	Forwards the client's credential plus the shared socketio secret (get_user_info
@@ -176,6 +176,8 @@ def _make_request(environ: dict, credentials: Credentials, config: RealtimeConfi
 		body: dict | None = None,
 	) -> dict:
 		headers = credentials.headers()
+		# Carry the tenant so loopback requests route to the right site.
+		headers["X-Frappe-Site-Name"] = site
 		if secret:
 			headers["X-Frappe-Socket-Secret"] = secret
 

--- a/frappe/realtime/config.py
+++ b/frappe/realtime/config.py
@@ -28,6 +28,7 @@ class RealtimeConfig:
 	default_site: str | None = None
 	developer_mode: bool = False
 	webserver_port: int | None = None
+	webserver_host: str | None = None
 
 
 def get_config(sites_path: str | None = None) -> RealtimeConfig:
@@ -45,4 +46,5 @@ def get_config(sites_path: str | None = None) -> RealtimeConfig:
 		default_site=conf.get("default_site") or None,
 		developer_mode=bool(conf.get("developer_mode")),
 		webserver_port=int(webserver_port) if webserver_port else None,
+		webserver_host=conf.get("webserver_host") or None,
 	)

--- a/frappe/realtime/util.py
+++ b/frappe/realtime/util.py
@@ -43,8 +43,11 @@ def get_url(origin: str | None, path: str, config: RealtimeConfig) -> str:
 		base = config.webserver_host
 		if "://" not in base:
 			base = f"http://{base}"
-		if urlsplit(base).port is None:
-			base = f"{base}:{config.webserver_port}"
+		parts = urlsplit(base)
+		if parts.port is None:
+			base = f"{parts.scheme}://{parts.netloc}:{config.webserver_port}"
+		else:
+			base = f"{parts.scheme}://{parts.netloc}"
 		return base + (path or "")
 	url = origin or ""
 	if config.developer_mode and config.webserver_port:

--- a/frappe/realtime/util.py
+++ b/frappe/realtime/util.py
@@ -36,7 +36,13 @@ def resolve_site_name(environ: dict, config: RealtimeConfig) -> str | None:
 
 
 def get_url(origin: str | None, path: str, config: RealtimeConfig) -> str:
-	"""Build the web-process URL. Loopback bypasses any proxy/CDN (e.g. Cloudflare);
-	the site travels in the X-Frappe-Site-Name header, so this still routes right."""
-	base = f"http://127.0.0.1:{config.webserver_port}" if config.webserver_port else (origin or "")
-	return base + (path or "")
+	"""Build the web-process URL for a request. Port of realtime/utils.js get_url."""
+	if config.webserver_host and config.webserver_port:
+		return f"http://{config.webserver_host}:{config.webserver_port}" + (path or "")
+	url = origin or ""
+	if config.developer_mode and config.webserver_port:
+		parts = url.split(":")
+		protocol = parts[0] if len(parts) > 0 else ""
+		host = parts[1] if len(parts) > 1 else ""
+		url = f"{protocol}:{host}:{config.webserver_port}"
+	return url + (path or "")

--- a/frappe/realtime/util.py
+++ b/frappe/realtime/util.py
@@ -36,11 +36,7 @@ def resolve_site_name(environ: dict, config: RealtimeConfig) -> str | None:
 
 
 def get_url(origin: str | None, path: str, config: RealtimeConfig) -> str:
-	"""Build the web-process URL for a request. Port of realtime/utils.js get_url."""
-	url = origin or ""
-	if config.developer_mode and config.webserver_port:
-		parts = url.split(":")
-		protocol = parts[0] if len(parts) > 0 else ""
-		host = parts[1] if len(parts) > 1 else ""
-		url = f"{protocol}:{host}:{config.webserver_port}"
-	return url + (path or "")
+	"""Build the web-process URL. Loopback bypasses any proxy/CDN (e.g. Cloudflare);
+	the site travels in the X-Frappe-Site-Name header, so this still routes right."""
+	base = f"http://127.0.0.1:{config.webserver_port}" if config.webserver_port else (origin or "")
+	return base + (path or "")

--- a/frappe/realtime/util.py
+++ b/frappe/realtime/util.py
@@ -3,6 +3,8 @@
 """Small helpers for the realtime connect path: header reads, hostnames, URLs,
 and site resolution. Kept separate so auth.py stays focused on the pipeline."""
 
+from urllib.parse import urlsplit
+
 from frappe.realtime.config import RealtimeConfig
 
 
@@ -38,7 +40,12 @@ def resolve_site_name(environ: dict, config: RealtimeConfig) -> str | None:
 def get_url(origin: str | None, path: str, config: RealtimeConfig) -> str:
 	"""Build the web-process URL for a request. Port of realtime/utils.js get_url."""
 	if config.webserver_host and config.webserver_port:
-		return f"http://{config.webserver_host}:{config.webserver_port}" + (path or "")
+		base = config.webserver_host
+		if "://" not in base:
+			base = f"http://{base}"
+		if urlsplit(base).port is None:
+			base = f"{base}:{config.webserver_port}"
+		return base + (path or "")
 	url = origin or ""
 	if config.developer_mode and config.webserver_port:
 		parts = url.split(":")

--- a/frappe/tests/test_realtime_py.py
+++ b/frappe/tests/test_realtime_py.py
@@ -174,6 +174,20 @@ class TestAuthHelpers(unittest.TestCase):
 			auth_mod.get_url("http://x.local:9000", "/p", make_config()), "http://x.local:9000/p"
 		)
 
+	def test_get_url_webserver_host(self):
+		# bare host gets http:// scheme and the configured port
+		cfg = make_config(webserver_host="127.0.0.1", webserver_port=8000)
+		self.assertEqual(auth_mod.get_url("http://x.local", "/p", cfg), "http://127.0.0.1:8000/p")
+		# scheme in the value is preserved, not double-prefixed
+		cfg = make_config(webserver_host="https://app.frappe.cloud", webserver_port=8000)
+		self.assertEqual(auth_mod.get_url("http://x.local", "/p", cfg), "https://app.frappe.cloud:8000/p")
+		# explicit port in the value is not doubled
+		cfg = make_config(webserver_host="https://app.frappe.cloud:443", webserver_port=8000)
+		self.assertEqual(auth_mod.get_url("http://x.local", "/p", cfg), "https://app.frappe.cloud:443/p")
+		# bracketed IPv6 literal
+		cfg = make_config(webserver_host="[::1]", webserver_port=8000)
+		self.assertEqual(auth_mod.get_url("http://x.local", "/p", cfg), "http://[::1]:8000/p")
+
 
 class TestAuthenticate(unittest.TestCase):
 	def setUp(self):

--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -58,7 +58,7 @@ function authenticate_with_frappe(socket, next) {
 		if (secret) {
 			headers["X-Frappe-Socket-Secret"] = secret;
 		}
-		return make_request(get_url(socket, path), headers, socket.request.headers.host, opts);
+		return make_request(get_url(socket, path), headers, get_site_name(socket), opts);
 	};
 
 	socket

--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -1,6 +1,6 @@
 const cookie = require("cookie");
 const { get_conf, get_redis_subscriber } = require("../../node_utils");
-const { get_url, get_hostname, make_request } = require("../utils");
+const { get_url, get_hostname } = require("../utils");
 const conf = get_conf();
 const redisClient = get_redis_subscriber("redis_queue");
 
@@ -58,7 +58,12 @@ function authenticate_with_frappe(socket, next) {
 		if (secret) {
 			headers["X-Frappe-Socket-Secret"] = secret;
 		}
-		return make_request(get_url(socket, path), headers, get_site_name(socket), opts);
+		// Carry the tenant so loopback requests route to the right site.
+		headers["X-Frappe-Site-Name"] = get_site_name(socket);
+		return fetch(get_url(socket, path), {
+			...opts,
+			headers,
+		});
 	};
 
 	socket

--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -1,6 +1,6 @@
 const cookie = require("cookie");
 const { get_conf, get_redis_subscriber } = require("../../node_utils");
-const { get_url } = require("../utils");
+const { get_url, get_hostname, make_request } = require("../utils");
 const conf = get_conf();
 const redisClient = get_redis_subscriber("redis_queue");
 
@@ -58,10 +58,7 @@ function authenticate_with_frappe(socket, next) {
 		if (secret) {
 			headers["X-Frappe-Socket-Secret"] = secret;
 		}
-		return fetch(get_url(socket, path), {
-			...opts,
-			headers,
-		});
+		return make_request(get_url(socket, path), headers, socket.request.headers.host, opts);
 	};
 
 	socket
@@ -102,14 +99,6 @@ function get_site_name(socket) {
 		socket.site_name = get_hostname(socket.request.headers.host);
 	}
 	return socket.site_name;
-}
-
-function get_hostname(url) {
-	if (!url) return undefined;
-	if (url.indexOf("://") > -1) {
-		url = url.split("/")[2];
-	}
-	return url.match(/:/g) ? url.slice(0, url.indexOf(":")) : url;
 }
 
 module.exports = authenticate_with_frappe;

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -46,6 +46,7 @@ function make_request(url, headers, host, opts = {}, _redirects = 0) {
 		};
 
 		const req = lib.request(options, (res) => {
+			res.on("error", reject);
 			if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
 				res.resume();
 				const redirectUrl = new URL(res.headers.location, parsed).toString();

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -14,7 +14,15 @@ function get_url(socket, path) {
 		path = "";
 	}
 	if (conf.webserver_host && conf.webserver_port) {
-		return `http://${conf.webserver_host}:${conf.webserver_port}${path}`;
+		let base = conf.webserver_host;
+		if (base.indexOf("://") === -1) {
+			base = `http://${base}`;
+		}
+		const authority = base.slice(base.indexOf("://") + 3).replace(/^\[[^\]]*\]/, "");
+		if (!authority.includes(":")) {
+			base = `${base}:${conf.webserver_port}`;
+		}
+		return base + path;
 	}
 	let url = socket.request.headers.origin;
 	if (conf.developer_mode) {

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -48,9 +48,8 @@ function make_request(url, headers, host, opts = {}, _redirects = 0) {
 		const req = lib.request(options, (res) => {
 			if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
 				res.resume();
-				return resolve(
-					make_request(res.headers.location, headers, host, opts, _redirects + 1)
-				);
+				const redirectUrl = new URL(res.headers.location, parsed).toString();
+				return resolve(make_request(redirectUrl, headers, host, opts, _redirects + 1));
 			}
 			let data = "";
 			res.on("data", (chunk) => {

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -27,8 +27,11 @@ function get_url(socket, path) {
 	return url + path;
 }
 
-function make_request(url, headers, host, opts = {}) {
+function make_request(url, headers, host, opts = {}, _redirects = 0) {
 	return new Promise((resolve, reject) => {
+		if (_redirects > 5) {
+			return reject(new Error("Too many redirects"));
+		}
 		const parsed = new URL(url);
 		const lib = parsed.protocol === "https:" ? https : http;
 		const options = {
@@ -43,6 +46,12 @@ function make_request(url, headers, host, opts = {}) {
 		};
 
 		const req = lib.request(options, (res) => {
+			if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+				res.resume();
+				return resolve(
+					make_request(res.headers.location, headers, host, opts, _redirects + 1)
+				);
+			}
 			let data = "";
 			res.on("data", (chunk) => {
 				data += chunk;

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -49,8 +49,16 @@ function make_request(url, headers, host, opts = {}, _redirects = 0) {
 			res.on("error", reject);
 			if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
 				res.resume();
-				const redirectUrl = new URL(res.headers.location, parsed).toString();
-				return resolve(make_request(redirectUrl, headers, host, opts, _redirects + 1));
+				const redirectParsed = new URL(res.headers.location, parsed);
+				return resolve(
+					make_request(
+						redirectParsed.toString(),
+						headers,
+						redirectParsed.hostname,
+						opts,
+						_redirects + 1
+					)
+				);
 			}
 			let data = "";
 			res.on("data", (chunk) => {

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -13,10 +13,8 @@ function get_url(socket, path) {
 	if (!path) {
 		path = "";
 	}
-	// Hit the web process over loopback to bypass any proxy/CDN (e.g. Cloudflare);
-	// the site travels in the X-Frappe-Site-Name header, so this still routes right.
-	if (conf.webserver_port) {
-		return `http://127.0.0.1:${conf.webserver_port}${path}`;
+	if (conf.webserver_host && conf.webserver_port) {
+		return `http://${conf.webserver_host}:${conf.webserver_port}${path}`;
 	}
 	let url = socket.request.headers.origin;
 	if (conf.developer_mode) {

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -54,7 +54,7 @@ function make_request(url, headers, host, opts = {}, _redirects = 0) {
 					make_request(
 						redirectParsed.toString(),
 						headers,
-						redirectParsed.hostname,
+						redirectParsed.host,
 						opts,
 						_redirects + 1
 					)

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -1,5 +1,3 @@
-const http = require("http");
-const https = require("https");
 const { get_conf } = require("../node_utils");
 const conf = get_conf();
 
@@ -15,8 +13,10 @@ function get_url(socket, path) {
 	if (!path) {
 		path = "";
 	}
-	if (conf.server_ip) {
-		return `http://${conf.server_ip}${path}`;
+	// Hit the web process over loopback to bypass any proxy/CDN (e.g. Cloudflare);
+	// the site travels in the X-Frappe-Site-Name header, so this still routes right.
+	if (conf.webserver_port) {
+		return `http://127.0.0.1:${conf.webserver_port}${path}`;
 	}
 	let url = socket.request.headers.origin;
 	if (conf.developer_mode) {
@@ -27,64 +27,7 @@ function get_url(socket, path) {
 	return url + path;
 }
 
-function make_request(url, headers, host, opts = {}, _redirects = 0) {
-	return new Promise((resolve, reject) => {
-		if (_redirects > 5) {
-			return reject(new Error("Too many redirects"));
-		}
-		const parsed = new URL(url);
-		const lib = parsed.protocol === "https:" ? https : http;
-		const options = {
-			hostname: parsed.hostname,
-			port: parsed.port || (parsed.protocol === "https:" ? 443 : 80),
-			path: parsed.pathname + parsed.search,
-			method: opts.method || "GET",
-			headers: {
-				...headers,
-				Host: host,
-			},
-		};
-
-		const req = lib.request(options, (res) => {
-			res.on("error", reject);
-			if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-				res.resume();
-				const redirectParsed = new URL(res.headers.location, parsed);
-				return resolve(
-					make_request(
-						redirectParsed.toString(),
-						headers,
-						redirectParsed.host,
-						opts,
-						_redirects + 1
-					)
-				);
-			}
-			let data = "";
-			res.on("data", (chunk) => {
-				data += chunk;
-			});
-			res.on("end", () => {
-				resolve({
-					json: () => Promise.resolve(JSON.parse(data)),
-					text: () => Promise.resolve(data),
-					status: res.statusCode,
-					ok: res.statusCode >= 200 && res.statusCode < 300,
-				});
-			});
-		});
-
-		req.on("error", reject);
-
-		if (opts.body) {
-			req.write(opts.body);
-		}
-		req.end();
-	});
-}
-
 module.exports = {
 	get_hostname,
 	get_url,
-	make_request,
 };

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -1,9 +1,22 @@
+const http = require("http");
+const https = require("https");
 const { get_conf } = require("../node_utils");
 const conf = get_conf();
+
+function get_hostname(url) {
+	if (!url) return undefined;
+	if (url.indexOf("://") > -1) {
+		url = url.split("/")[2];
+	}
+	return url.match(/:/g) ? url.slice(0, url.indexOf(":")) : url;
+}
 
 function get_url(socket, path) {
 	if (!path) {
 		path = "";
+	}
+	if (conf.server_ip) {
+		return `http://${conf.server_ip}${path}`;
 	}
 	let url = socket.request.headers.origin;
 	if (conf.developer_mode) {
@@ -14,6 +27,47 @@ function get_url(socket, path) {
 	return url + path;
 }
 
+function make_request(url, headers, host, opts = {}) {
+	return new Promise((resolve, reject) => {
+		const parsed = new URL(url);
+		const lib = parsed.protocol === "https:" ? https : http;
+		const options = {
+			hostname: parsed.hostname,
+			port: parsed.port || (parsed.protocol === "https:" ? 443 : 80),
+			path: parsed.pathname + parsed.search,
+			method: opts.method || "GET",
+			headers: {
+				...headers,
+				Host: host,
+			},
+		};
+
+		const req = lib.request(options, (res) => {
+			let data = "";
+			res.on("data", (chunk) => {
+				data += chunk;
+			});
+			res.on("end", () => {
+				resolve({
+					json: () => Promise.resolve(JSON.parse(data)),
+					text: () => Promise.resolve(data),
+					status: res.statusCode,
+					ok: res.statusCode >= 200 && res.statusCode < 300,
+				});
+			});
+		});
+
+		req.on("error", reject);
+
+		if (opts.body) {
+			req.write(opts.body);
+		}
+		req.end();
+	});
+}
+
 module.exports = {
+	get_hostname,
 	get_url,
+	make_request,
 };

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -18,11 +18,11 @@ function get_url(socket, path) {
 		if (base.indexOf("://") === -1) {
 			base = `http://${base}`;
 		}
-		const authority = base.slice(base.indexOf("://") + 3).replace(/^\[[^\]]*\]/, "");
-		if (!authority.includes(":")) {
-			base = `${base}:${conf.webserver_port}`;
+		const url = new URL(base);
+		if (!url.port) {
+			url.port = conf.webserver_port;
 		}
-		return base + path;
+		return url.origin + path;
 	}
 	let url = socket.request.headers.origin;
 	if (conf.developer_mode) {


### PR DESCRIPTION
Added `webserver_host` key in common site config. If that's provided, socketio will use that to communicate with it.

If no `webserver_host` provided, it will follow the old behaviour.