### PR TITLE
fix(print-format-builder): sanitizer and dead code cleanup

### DIFF
--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -794,10 +794,6 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	border-color: var(--gray-500);
 }
 
-.pfb-block-card--click {
-	cursor: pointer;
-}
-
 .pfb-block-icon {
 	display: flex;
 	align-items: center;

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -3,7 +3,6 @@ import { watch, ref, inject, computed, nextTick } from "vue";
 
 export function getStore(print_format_name) {
 	// variables
-	let letterhead_name = ref(null);
 	let print_format = ref(null);
 	let letterhead = ref(null);
 	let doctype = ref(null);
@@ -226,7 +225,6 @@ export function getStore(print_format_name) {
 	});
 
 	return {
-		letterhead_name,
 		print_format,
 		letterhead,
 		doctype,

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -265,7 +265,8 @@ export function sanitize_html(html) {
 				} else if (name === "src") {
 					const val = attr.value.trim();
 					const is_data_image = /^data:image\//i.test(val);
-					const is_relative = /^\//.test(val) || !/^[a-z][a-z0-9+\-.]*:/i.test(val);
+					const is_relative =
+						/^\/(?!\/)/.test(val) || !/^[a-z][a-z0-9+\-.]*:/i.test(val);
 					const is_same_origin =
 						typeof window !== "undefined" &&
 						val.startsWith(window.location.origin + "/");

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -266,7 +266,7 @@ export function sanitize_html(html) {
 					const val = attr.value.trim();
 					const is_data_image = /^data:image\//i.test(val);
 					const is_relative =
-						/^\/(?!\/)/.test(val) || !/^[a-z][a-z0-9+\-.]*:/i.test(val);
+						!val.startsWith("//") && !/^[a-z][a-z0-9+\-.]*:/i.test(val);
 					const is_same_origin =
 						typeof window !== "undefined" &&
 						val.startsWith(window.location.origin + "/");

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -263,7 +263,13 @@ export function sanitize_html(html) {
 				if (!SAFE_HTML_ATTRS.has(name) || name.startsWith("on")) {
 					child.removeAttribute(attr.name);
 				} else if (name === "src") {
-					if (!/^(https?:|data:image\/)/i.test(attr.value.trim()))
+					const val = attr.value.trim();
+					const is_data_image = /^data:image\//i.test(val);
+					const is_relative = /^\//.test(val) || !/^[a-z][a-z0-9+\-.]*:/i.test(val);
+					const is_same_origin =
+						typeof window !== "undefined" &&
+						val.startsWith(window.location.origin + "/");
+					if (!is_data_image && !is_relative && !is_same_origin)
 						child.removeAttribute(attr.name);
 				} else if (name === "href") {
 					if (!/^https?:/i.test(attr.value.trim())) child.removeAttribute(attr.name);


### PR DESCRIPTION
- Restrict `src` in HTML sanitizer to same-origin, relative, and `data:image/` URLs — blocks external tracking pixels from auto-loading in the builder preview
- Remove unused `letterhead_name` store ref and dead `.pfb-block-card--click` CSS class