### PR TITLE
refactor(realtime): Ensure frappe.local doesn't leak

### DIFF
--- a/frappe/realtime/context.py
+++ b/frappe/realtime/context.py
@@ -33,7 +33,8 @@ def frappe_context(site: str, user: str):
 		yield frappe
 		frappe.db.commit()  # nosemgrep
 	except Exception:
-		frappe.db.rollback()
+		if frappe.db:
+			frappe.db.rollback()
 		raise
 	finally:
 		frappe.destroy()

--- a/frappe/realtime/context.py
+++ b/frappe/realtime/context.py
@@ -23,11 +23,13 @@ def frappe_context(site: str, user: str):
 	import frappe
 	from frappe.realtime.server import force_pymysql
 
-	frappe.init(site)
-	force_pymysql(frappe.local.conf)
-	frappe.connect()
-	frappe.set_user(user)  # nosemgrep
 	try:
+		frappe.init(site, force=True)
+		force_pymysql(frappe.local.conf)
+
+		frappe.connect(set_admin_as_user=False)
+		frappe.set_user(user)  # nosemgrep
+
 		yield frappe
 		frappe.db.commit()  # nosemgrep
 	except Exception:

--- a/frappe/realtime/server.py
+++ b/frappe/realtime/server.py
@@ -56,6 +56,9 @@ def patch_pre_existing_stdlib_thread_locks() -> None:
 	if hasattr(_frappe, "_redis_init_lock"):
 		_frappe._redis_init_lock = threading.Lock()
 
+	if getattr(_frappe, "client_cache", None) is not None:
+		_frappe.client_cache.lock = threading.RLock()
+
 
 def ensure_thread_context_isolation() -> None:
 	"""

--- a/frappe/realtime/server.py
+++ b/frappe/realtime/server.py
@@ -36,6 +36,27 @@ from frappe.realtime.dispatch import wire
 logger = logging.getLogger("frappe.realtime")
 
 
+def patch_pre_existing_stdlib_thread_locks() -> None:
+	"""
+	Thread locks can cause deadlocks when getting used in greenlets.
+	We import frappe model during preload and the locks gets created that time
+	and copied over to the realtime process.
+
+	So, after patch we need to re-init the locks, so that gevent patch can
+	make it gevent.threading.Lock
+	"""
+	import sys
+	import threading
+
+	if "frappe" not in sys.modules:
+		return
+
+	import frappe as _frappe
+
+	if hasattr(_frappe, "_redis_init_lock"):
+		_frappe._redis_init_lock = threading.Lock()
+
+
 def ensure_thread_context_isolation() -> None:
 	"""
 	Python 3.14's thread_inherit_context makes new threads copy the parent's
@@ -145,6 +166,8 @@ def serve(config: RealtimeConfig | None = None) -> None:
 
 	assert_no_mysqlclient()
 	ensure_thread_context_isolation()
+	patch_pre_existing_stdlib_thread_locks()
+
 	config = config or get_config()
 
 	if os.path.isdir("sites"):

--- a/frappe/realtime/server.py
+++ b/frappe/realtime/server.py
@@ -36,6 +36,25 @@ from frappe.realtime.dispatch import wire
 logger = logging.getLogger("frappe.realtime")
 
 
+def ensure_thread_context_isolation() -> None:
+	"""
+	Python 3.14's thread_inherit_context makes new threads copy the parent's
+	contextvars (on by default for free-threaded builds). frappe.local lives in
+	a contextvar, so this aliases it across threads. Refuse to start if it is on.
+
+	Ref: https://github.com/python/cpython/issues/128555
+	"""
+	import sys
+
+	if not getattr(sys.flags, "thread_inherit_context", 0):
+		return
+
+	raise RuntimeError(
+		"thread_inherit_context is enabled; this aliases frappe.local across threads. "
+		"Restart with -X thread_inherit_context=0."
+	)
+
+
 def assert_no_mysqlclient() -> None:
 	"""Fail loudly if the mysqlclient C extension was imported.
 
@@ -125,6 +144,7 @@ def serve(config: RealtimeConfig | None = None) -> None:
 	import os
 
 	assert_no_mysqlclient()
+	ensure_thread_context_isolation()
 	config = config or get_config()
 
 	if os.path.isdir("sites"):


### PR DESCRIPTION
- Forcefully release frappe.local before starting a context when `frappe_context=True` gets passed in `@realtime.on`
- Re-init the thread locks which were created before gevent patch
- Add a guard to fail loudly if thread_inherit_context is disabled, which by default copies the contextvar

Also, python-socketio, engineio none use copy_context(). So it will be safe.