### PR TITLE
fix: handle type check when selected_children is called from frappe.model.open_mapped_doc

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -11,7 +11,7 @@ from frappe.utils import cstr
 
 @frappe.whitelist()
 def make_mapped_doc(
-	method: str, source_name: str, selected_children: str | list | None = None, args: str | dict | None = None
+	method: str, source_name: str, selected_children: str | dict | list | None = None, args: str | dict | None = None
 ):
 	"""Return the mapped document calling the given mapper method.
 	Set `selected_children` as flags for the `get_mapped_doc` method.

--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -11,7 +11,10 @@ from frappe.utils import cstr
 
 @frappe.whitelist()
 def make_mapped_doc(
-	method: str, source_name: str, selected_children: str | dict | list | None = None, args: str | dict | None = None
+	method: str,
+	source_name: str,
+	selected_children: str | dict | list | None = None,
+	args: str | dict | None = None,
 ):
 	"""Return the mapped document calling the given mapper method.
 	Set `selected_children` as flags for the `get_mapped_doc` method.


### PR DESCRIPTION
### Replicate Issue
```python
  frappe.model.open_mapped_doc({
      method: "path.to.custom_method",
      frm: frm,
  });

```

### Traceback

```
request.js:313  POST http://ic.localhost:8000/api/method/frappe.model.mapper.make_mapped_doc 417 (EXPECTATION FAILED)
send @ jquery.js:9930
ajax @ jquery.js:9511
(anonymous) @ request.js:313
(anonymous) @ request.js:121
open_mapped_doc @ create_new.js:336
eval @ purchase_invoice__js:2528
(anonymous) @ page.js:641
(anonymous) @ page.js:500
dispatch @ jquery.js:5135
(anonymous) @ jquery.js:4939
request.js:509 Traceback (most recent call last):
  File "apps/frappe/frappe/utils/typing_validations.py", line 184, in transform_parameter_types
    current_arg_value_after = TypeAdapter(current_arg_type).validate_python(current_arg_value)
  File "env/lib/python3.14/site-packages/pydantic/type_adapter.py", line 441, in validate_python
    return self.validator.validate_python(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        object,
        ^^^^^^^
    ...<6 lines>...
        by_name=by_name,
        ^^^^^^^^^^^^^^^^
    )
    ^
pydantic_core._pydantic_core.ValidationError: 2 validation errors for nullable[union[str,list[any]]]
str
  Input should be a valid string [type=string_type, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.13/v/string_type
list[any]
  Input should be a valid list [type=list_type, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.13/v/list_type

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 125, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 64, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 54, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 87, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1134, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 47, in wrapper
    args, kwargs = transform_parameter_types(func, args, kwargs, force_types)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 186, in transform_parameter_types
    raise_type_error(func, current_arg, current_arg_type, current_arg_value, current_exception=e)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 86, in raise_type_error
    raise FrappeTypeError(
    ...<2 lines>...
    ) from current_exception
frappe.exceptions.FrappeTypeError: Argument 'selected_children' in 'frappe.model.mapper.make_mapped_doc' should be of type 'str | list | None' but got 'dict' instead.

(anonymous) @ request.js:509
(anonymous) @ request.js:507
(anonymous) @ request.js:359
(anonymous) @ jquery.js:3213
fireWith @ jquery.js:3343
done @ jquery.js:9619
(anonymous) @ jquery.js:9878
XMLHttpRequest.send
send @ jquery.js:9930
ajax @ jquery.js:9511
(anonymous) @ request.js:313
(anonymous) @ request.js:121
open_mapped_doc @ create_new.js:336
eval @ purchase_invoice__js:2528
(anonymous) @ page.js:641
(anonymous) @ page.js:500
dispatch @ jquery.js:5135
(anonymous) @ jquery.js:4939
PINV-26-00017:1 The resource http://ic.localhost:8000/assets/frappe/dist/css/desk.bundle.OX5ZFIDQ.css was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.

```