### PR TITLE
fix: clean error on incompatible field type change

### DIFF
--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -123,6 +123,21 @@ class TestDocType(IntegrationTestCase):
 		doc1.delete()
 		doc2.delete()
 
+	def test_change_field_type_with_incompatible_values(self):
+		if frappe.db.exists("DocType", "Test Field Type Change"):
+			frappe.delete_doc("DocType", "Test Field Type Change")
+
+		dt = new_doctype("Test Field Type Change")
+		dt.insert()
+
+		doc = frappe.new_doc("Test Field Type Change")
+		doc.some_fieldname = "not a number"
+		doc.insert()
+
+		dt.fields[0].fieldtype = "Int"
+		self.assertRaises(frappe.ValidationError, dt.save)
+		frappe.db.rollback()
+
 	def test_validate_search_fields(self):
 		doc = new_doctype("Test Search Fields")
 		doc.search_fields = "some_fieldname"

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -77,6 +77,10 @@ class MariaDBExceptionUtil:
 		return e.args and e.args[0] == ER.DATA_TOO_LONG
 
 	@staticmethod
+	def is_data_truncated(e: pymysql.Error) -> bool:
+		return e.args and e.args[0] == ER.TRUNCATED_WRONG_VALUE
+
+	@staticmethod
 	def is_db_table_size_limit(e: pymysql.Error) -> bool:
 		return e.args and e.args[0] == ER.TOO_BIG_ROWSIZE
 

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -80,6 +80,10 @@ class MariaDBExceptionUtil:
 		return e.args and e.args[0] == ER.DATA_TOO_LONG
 
 	@staticmethod
+	def is_data_truncated(e: MySQLdb.Error) -> bool:
+		return e.args and e.args[0] == ER.TRUNCATED_WRONG_VALUE
+
+	@staticmethod
 	def is_db_table_size_limit(e: MySQLdb.Error) -> bool:
 		return e.args and e.args[0] == ER.TOO_BIG_ROWSIZE
 

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -172,6 +172,14 @@ class MariaDBTable(DBTable):
 					).format(fieldname, self.table_name)
 				)
 
+			if frappe.db.is_data_truncated(e):
+				frappe.throw(
+					_(
+						"Cannot change field type in {0}: some existing values cannot be converted to the new type"
+					).format(self.doctype),
+					title=_("Incompatible Values"),
+				)
+
 			raise
 
 	def alter_primary_key(self) -> str | None:


### PR DESCRIPTION
Changing a field type (e.g. Data → Int) when existing rows hold values that can't be cast surfaced a raw `MySQLdb.OperationalError: (1292, "Truncated incorrect INTEGER value: ...")` to the user.

`alter()` now catches that error code and throws a readable message, mirroring the existing duplicate-entry handling in the same block. Added `is_data_truncated` to both MariaDB drivers for parity.

Closes #38366