### PR TITLE
fix: accept dict for selected_children in make_mapped_doc

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -11,7 +11,10 @@ from frappe.utils import cstr
 
 @frappe.whitelist()
 def make_mapped_doc(
-	method: str, source_name: str, selected_children: str | list | None = None, args: str | dict | None = None
+	method: str,
+	source_name: str,
+	selected_children: str | list | dict | None = None,
+	args: str | dict | None = None,
 ):
 	"""Return the mapped document calling the given mapper method.
 	Set `selected_children` as flags for the `get_mapped_doc` method.


### PR DESCRIPTION
`open_mapped_doc` sends `selected_children` from `cur_frm.get_selected()`, which is always a dict (`{}` when nothing is selected, `{fieldname: [rows]}` otherwise). Under the native JSON request body it arrives as a real dict instead of a JSON string, but the signature only allowed `str | list | None`, so the type check rejects it and every "Create → X" mapped-doc action fails with a 417.

Add `dict` to the annotation. `frappe.parse_json` already passes dicts through unchanged, so no logic change is needed.

Related: #40237 (JSON request body opt-in for frappe), frappe/erpnext#56439 (erpnext companion).