### PR TITLE
fix(print): remove `letter_head_for` filter missing from v16 schema

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -387,7 +387,7 @@ frappe.ui.form.PrintView = class {
 			frappe.db
 				.get_value(
 					"Letter Head",
-					{ disabled: 0, is_default: 1, letter_head_for: "DocType" },
+					{ disabled: 0, is_default: 1 },
 					"name"
 				)
 				.then(({ message }) => {

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -385,11 +385,7 @@ frappe.ui.form.PrintView = class {
 	set_default_letterhead() {
 		const get_default = () =>
 			frappe.db
-				.get_value(
-					"Letter Head",
-					{ disabled: 0, is_default: 1 },
-					"name"
-				)
+				.get_value("Letter Head", { disabled: 0, is_default: 1 }, "name")
 				.then(({ message }) => {
 					if (message?.name) this.letterhead_selector.val(message.name);
 				});


### PR DESCRIPTION
Context: https://github.com/frappe/frappe/pull/40112#issuecomment-4808004705