### PR TITLE
fix(postgres): cast column data with USING when changing column types

### DIFF
--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -100,14 +100,34 @@ class PostgresTable(DBTable):
 		new_column_names = {col.fieldname for col in self.add_column}
 
 		for col in self.change_type:
+			# Postgres won't implicitly cast text/varchar to these types, so SET DATA TYPE
+			# needs an explicit USING expression. NOT NULL numerics coalesce blanks to 0;
+			# nullable types map blanks to NULL.
 			using_clause = ""
-			if col.fieldtype in ("Datetime"):
-				# The USING option of SET DATA TYPE can actually specify any expression
-				# involving the old values of the row
-				# read more https://www.postgresql.org/docs/9.1/sql-altertable.html
-				using_clause = f"USING {col.fieldname}::timestamp without time zone"
+			if col.fieldtype == "Datetime":
+				using_clause = f"USING NULLIF(`{col.fieldname}`::text, '')::timestamp without time zone"
+			elif col.fieldtype == "Date":
+				using_clause = f"USING NULLIF(`{col.fieldname}`::text, '')::date"
+			elif col.fieldtype == "Time":
+				using_clause = f"USING NULLIF(`{col.fieldname}`::text, '')::time without time zone"
 			elif col.fieldtype == "Check":
-				using_clause = f"USING {col.fieldname}::smallint"
+				using_clause = f"USING COALESCE(NULLIF(`{col.fieldname}`::text, ''), '0')::smallint"
+			elif col.fieldtype in ("Currency", "Float", "Percent"):
+				using_clause = f"USING COALESCE(NULLIF(`{col.fieldname}`::text, ''), '0')::numeric"
+			elif col.fieldtype in ("Duration", "Rating"):
+				# Duration/Rating are nullable (not in NOT_NULL_TYPES), so keep blanks NULL.
+				using_clause = f"USING NULLIF(`{col.fieldname}`::text, '')::numeric"
+			elif col.fieldtype == "Int":
+				using_clause = f"USING COALESCE(NULLIF(`{col.fieldname}`::text, ''), '0')::numeric::int"
+			elif col.fieldtype == "JSON":
+				using_clause = f"USING NULLIF(`{col.fieldname}`::text, '')::json"
+
+			if using_clause:
+				# the column's existing (string) DEFAULT can't be cast to the new type, so
+				# drop it and re-apply the proper default via the set_default pass below.
+				query.append(f"ALTER COLUMN `{col.fieldname}` DROP DEFAULT")
+				if col not in self.set_default:
+					self.set_default.append(col)
 
 			query.append(
 				"ALTER COLUMN `{}` TYPE {} {}".format(
@@ -131,6 +151,7 @@ class PostgresTable(DBTable):
 				col_default = flt(col.default)
 
 			elif not col.default:
+				# nullable types (e.g. Duration, Rating) keep their NULL default
 				col_default = "NULL"
 
 			else:


### PR DESCRIPTION
PostgreSQL won't implicitly cast `text`/`varchar` to `numeric`, `integer`, `smallint`, `date`, `time`, `timestamp` or `json`. So `DBTable.alter()` fails with `column "X" cannot be cast automatically to type Y` whenever a DocField's type changes — e.g. running `bench migrate` after importing data converted from MariaDB, or an upgrade that changes a field's type. Previously only `Datetime` and `Check` had a `USING` clause.

This emits a `USING` expression for each affected conversion, respecting nullability (`NOT_NULL_TYPES`):
- NOT NULL numerics (`Check`, `Currency`, `Float`, `Percent`, `Int`) → `COALESCE(NULLIF(col::text, ''), '0')::TYPE` (blank → 0)
- Nullable types (`Date`, `Time`, `Datetime`, `JSON`, `Duration`, `Rating`) → `NULLIF(col::text, '')::TYPE` (blank → NULL)

It also drops the column's stale string `DEFAULT` before the type change (it can't be cast to the new type either) and re-applies the correct default via the existing `set_default` pass.
