### PR TITLE
feat: emulate sequences on SQLite for autoincrement naming

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -121,6 +121,63 @@ jobs:
             cat $f
           done
 
+  test-sqlite:
+    name: Integration (SQLite)
+    needs: checkrun
+    if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      NODE_ENV: "production"
+      PYTHONWARNINGS: "module,ignore:::babel.messages.extract"
+      DB_ROOT_PASSWORD: db_root
+    services:
+      smtp_server:
+        image: rnwood/smtp4dev:3.7.1
+        ports:
+          - 2525:25
+          - 3000:80
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+        name: Environment Setup
+        with:
+          python-version: '3.14'
+          node-version: 24
+          # SQLite is file-based and the targeted tests don't need the web/UI,
+          # so skip asset build, web and socketio to keep this leg fast.
+          build-assets: false
+          disable-web: true
+          disable-socketio: true
+          db-root-password: ${{ env.DB_ROOT_PASSWORD }}
+          db: sqlite
+
+      - name: Run SQLite tests
+        run: |
+          # The full suite isn't SQLite-clean yet; run the SQLite-specific
+          # backend tests with coverage so the emulated-sequence paths are
+          # exercised and reported (CI's other legs only run MariaDB/Postgres).
+          cd sites && bench --site test_site run-tests --module frappe.tests.test_sequence --coverage
+        env:
+          DB: sqlite
+          CAPTURE_COVERAGE: true
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-sqlite-1
+          path: ./sites/*coverage*.xml
+
+      - name: Show bench output
+        if: ${{ always() }}
+        run: |
+          cat bench_start.log || true
+          cd logs
+          for f in ${GITHUB_WORKSPACE}/*.log*; do
+            echo "Printing log: $f";
+            cat $f
+          done
+
   migrate:
     name: Migration
     needs: checkrun
@@ -227,7 +284,7 @@ jobs:
 
   coverage:
     name: Coverage Wrap Up
-    needs: [test, checkrun]
+    needs: [test, test-sqlite, checkrun]
     if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
     runs-on: ubuntu-latest
     steps:
@@ -247,15 +304,16 @@ jobs:
   # TIP: Require this single check in branch protection, e.g. Server / Success
   success:
     name: Server Success
-    needs: [test, migrate]
+    needs: [test, test-sqlite, migrate]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Tests '${{ needs.test.result }}' / Migration '${{ needs.migrate.result }}'
+      - name: Tests '${{ needs.test.result }}' / SQLite '${{ needs.test-sqlite.result }}' / Migration '${{ needs.migrate.result }}'
         shell: python
         run: |
           stati = [
             '${{ needs.test.result }}',
+            '${{ needs.test-sqlite.result }}',
             '${{ needs.migrate.result }}',
           ]
 

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -145,8 +145,9 @@ jobs:
           python-version: '3.14'
           node-version: 24
           # SQLite is file-based and the targeted tests don't need the web/UI,
-          # so skip asset build, web and socketio to keep this leg fast.
-          build-assets: false
+          # so skip web and socketio to keep this leg fast. Assets must still be
+          # built: creating test records can render emails (welcome mail), which
+          # reads the built assets manifest.
           disable-web: true
           disable-socketio: true
           db-root-password: ${{ env.DB_ROOT_PASSWORD }}

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -121,64 +121,6 @@ jobs:
             cat $f
           done
 
-  test-sqlite:
-    name: Integration (SQLite)
-    needs: checkrun
-    if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      NODE_ENV: "production"
-      PYTHONWARNINGS: "module,ignore:::babel.messages.extract"
-      DB_ROOT_PASSWORD: db_root
-    services:
-      smtp_server:
-        image: rnwood/smtp4dev:3.7.1
-        ports:
-          - 2525:25
-          - 3000:80
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup
-        name: Environment Setup
-        with:
-          python-version: '3.14'
-          node-version: 24
-          # SQLite is file-based and the targeted tests don't need the web/UI,
-          # so skip web and socketio to keep this leg fast. Assets must still be
-          # built: creating test records can render emails (welcome mail), which
-          # reads the built assets manifest.
-          disable-web: true
-          disable-socketio: true
-          db-root-password: ${{ env.DB_ROOT_PASSWORD }}
-          db: sqlite
-
-      - name: Run SQLite tests
-        run: |
-          # The full suite isn't SQLite-clean yet; run the SQLite-specific
-          # backend tests with coverage so the emulated-sequence paths are
-          # exercised and reported (CI's other legs only run MariaDB/Postgres).
-          cd sites && bench --site test_site run-tests --module frappe.tests.test_sequence --coverage
-        env:
-          DB: sqlite
-          CAPTURE_COVERAGE: true
-
-      - name: Upload coverage data
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-sqlite-1
-          path: ./sites/*coverage*.xml
-
-      - name: Show bench output
-        if: ${{ always() }}
-        run: |
-          cat bench_start.log || true
-          cd logs
-          for f in ${GITHUB_WORKSPACE}/*.log*; do
-            echo "Printing log: $f";
-            cat $f
-          done
-
   migrate:
     name: Migration
     needs: checkrun
@@ -285,7 +227,7 @@ jobs:
 
   coverage:
     name: Coverage Wrap Up
-    needs: [test, test-sqlite, checkrun]
+    needs: [test, checkrun]
     if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
     runs-on: ubuntu-latest
     steps:
@@ -305,16 +247,15 @@ jobs:
   # TIP: Require this single check in branch protection, e.g. Server / Success
   success:
     name: Server Success
-    needs: [test, test-sqlite, migrate]
+    needs: [test, migrate]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Tests '${{ needs.test.result }}' / SQLite '${{ needs.test-sqlite.result }}' / Migration '${{ needs.migrate.result }}'
+      - name: Tests '${{ needs.test.result }}' / Migration '${{ needs.migrate.result }}'
         shell: python
         run: |
           stati = [
             '${{ needs.test.result }}',
-            '${{ needs.test-sqlite.result }}',
             '${{ needs.migrate.result }}',
           ]
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1526,6 +1526,11 @@ class Database:
 		while value_chunk := tuple(itertools.islice(value_iterator, chunk_size)):
 			query.insert(*value_chunk).run()
 
+	def create_sequence_table(self):
+		# MariaDB/Postgres have native sequences and need no backing table;
+		# SQLite overrides this to create its emulation table at site setup.
+		pass
+
 	def create_sequence(self, *args, **kwargs):
 		from frappe.database.sequence import create_sequence
 

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -51,6 +51,8 @@ def create_sequence(
 		current = start - increment
 		# Upsert the definition so it stays authoritative even over a bare row a
 		# prior set_next_val may have created; an existing counter is preserved.
+		# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
+		# nosemgrep
 		db.sql(
 			f"INSERT INTO `{SQLITE_SEQUENCE_TABLE}` "
 			"(name, current, increment, min_value, max_value, cycle) "
@@ -124,11 +126,15 @@ def set_next_val(
 ) -> None:
 	if db.db_type == "sqlite":
 		sequence_name = scrub(doctype_name + slug)
+		# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
+		# nosemgrep
 		row = db.sql(f"SELECT increment FROM `{SQLITE_SEQUENCE_TABLE}` WHERE name = %s", (sequence_name,))
 		increment = row[0][0] if row else 1
 		# Match SETVAL semantics: if next_val was already consumed, the following
 		# nextval returns next_val + increment; otherwise it returns next_val itself.
 		current = next_val if is_val_used else next_val - increment
+		# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
+		# nosemgrep
 		db.sql(
 			f"INSERT INTO `{SQLITE_SEQUENCE_TABLE}` (name, current) VALUES (%s, %s) "
 			"ON CONFLICT(name) DO UPDATE SET current = excluded.current",
@@ -191,6 +197,8 @@ def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 	# sequence): the read-modify-write happens as one statement under SQLite's
 	# write lock, so concurrent callers can never be handed the same value.
 	# Requires SQLite >= 3.35 for RETURNING, well below any version frappe targets.
+	# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
+	# nosemgrep
 	row = db.sql(
 		f"UPDATE `{SQLITE_SEQUENCE_TABLE}` SET current = current + increment "
 		"WHERE name = %s AND max_value IS NULL RETURNING current",
@@ -199,6 +207,8 @@ def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 	if row:
 		return row[0][0]
 
+	# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
+	# nosemgrep
 	existing = db.sql(
 		f"SELECT max_value FROM `{SQLITE_SEQUENCE_TABLE}` WHERE name = %s",
 		(sequence_name,),
@@ -208,6 +218,8 @@ def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 		# existing rows so emulated names never collide, and leave it unbounded.
 		# The upsert makes a concurrent first-use increment the freshly-created
 		# row instead of colliding on the primary key.
+		# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
+		# nosemgrep
 		row = db.sql(
 			f"INSERT INTO `{SQLITE_SEQUENCE_TABLE}` (name, current) VALUES (%s, %s) "
 			"ON CONFLICT(name) DO UPDATE SET current = current + increment RETURNING current",
@@ -218,6 +230,8 @@ def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 	if existing[0][0] is None:
 		# Unbounded row created concurrently between the statements above; the
 		# fast path missed it, so increment it atomically now.
+		# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
+		# nosemgrep
 		return db.sql(
 			f"UPDATE `{SQLITE_SEQUENCE_TABLE}` SET current = current + increment "
 			"WHERE name = %s RETURNING current",
@@ -228,6 +242,8 @@ def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 	# read-modify-write is atomic. The WHERE clause withholds the row when a
 	# non-cycling sequence would overflow, so RETURNING comes back empty and we
 	# raise instead of handing out a duplicate or out-of-range value.
+	# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
+	# nosemgrep
 	row = db.sql(
 		f"UPDATE `{SQLITE_SEQUENCE_TABLE}` SET current = "
 		"CASE WHEN current + increment > max_value THEN min_value ELSE current + increment END "

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -257,12 +257,14 @@ def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 def _sqlite_seed_value(doctype_name: str) -> int:
 	# Seed past any rows that already exist so emulated names never collide with
 	# pre-existing ones (mirrors how create_missing_sequences seeds real ones).
-	# Built via the query builder so the table name is safely quoted.
+	# Cast to integer so a non-numeric legacy name (from import or an old naming
+	# scheme) doesn't break MAX; built via the query builder so the table name is
+	# safely quoted.
 	import frappe
-	from frappe.query_builder.functions import Max
+	from frappe.query_builder.functions import Cast_, Max
 
 	table = frappe.qb.DocType(doctype_name)
-	max_name = frappe.qb.from_(table).select(Max(table.name)).run()[0][0]
+	max_name = frappe.qb.from_(table).select(Max(Cast_(table.name, "integer"))).run()[0][0]
 	return int(max_name or 0) + 1
 
 

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -126,19 +126,18 @@ def set_next_val(
 ) -> None:
 	if db.db_type == "sqlite":
 		sequence_name = scrub(doctype_name + slug)
-		# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
-		# nosemgrep
-		row = db.sql(f"SELECT increment FROM `{SQLITE_SEQUENCE_TABLE}` WHERE name = %s", (sequence_name,))
-		increment = row[0][0] if row else 1
-		# Match SETVAL semantics: if next_val was already consumed, the following
-		# nextval returns next_val + increment; otherwise it returns next_val itself.
-		current = next_val if is_val_used else next_val - increment
+		# Like Postgres SETVAL, this only adjusts an existing sequence - it never
+		# creates one. Creating a row here would bake in default metadata and mask
+		# the real definition that create_sequence is responsible for. Match SETVAL
+		# semantics: if next_val was already consumed the next nextval returns
+		# next_val + increment, otherwise it returns next_val itself.
 		# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
 		# nosemgrep
 		db.sql(
-			f"INSERT INTO `{SQLITE_SEQUENCE_TABLE}` (name, current) VALUES (%s, %s) "
-			"ON CONFLICT(name) DO UPDATE SET current = excluded.current",
-			(sequence_name, current),
+			f"UPDATE `{SQLITE_SEQUENCE_TABLE}` "
+			"SET current = %s - (CASE WHEN %s THEN 0 ELSE increment END) "
+			"WHERE name = %s",
+			(next_val, 1 if is_val_used else 0, sequence_name),
 		)
 		return
 

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -49,17 +49,17 @@ def create_sequence(
 		maxv = max_value or None
 		start = start_value or minv
 		current = start - increment
-		# Upsert the definition so it stays authoritative even over a bare row a
-		# prior set_next_val may have created; an existing counter is preserved.
+		# check_not_exists leaves an existing definition (and its counter) fully
+		# untouched, like "CREATE SEQUENCE IF NOT EXISTS"; otherwise a duplicate
+		# raises, like a plain CREATE SEQUENCE. The columns carry defaults, so a
+		# row is always a complete definition - there is no partial row to patch.
+		verb = "INSERT OR IGNORE" if check_not_exists else "INSERT"
 		# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
 		# nosemgrep
 		db.sql(
-			f"INSERT INTO `{SQLITE_SEQUENCE_TABLE}` "
+			f"{verb} INTO `{SQLITE_SEQUENCE_TABLE}` "
 			"(name, current, increment, min_value, max_value, cycle) "
-			"VALUES (%s, %s, %s, %s, %s, %s) "
-			"ON CONFLICT(name) DO UPDATE SET "
-			"increment = excluded.increment, min_value = excluded.min_value, "
-			"max_value = excluded.max_value, cycle = excluded.cycle",
+			"VALUES (%s, %s, %s, %s, %s, %s)",
 			(sequence_name, current, increment, minv, maxv, 1 if cycle else 0),
 		)
 		return sequence_name

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -41,7 +41,6 @@ def create_sequence(
 	sequence_name = scrub(doctype_name + slug)
 
 	if db.db_type == "sqlite":
-		_sqlite_ensure_table()
 		# `current` stores the last value handed out; nextval returns
 		# current + increment. Seed it so the first nextval returns `start_value`
 		# (defaulting to min_value, then 1 - matching postgres defaults).
@@ -50,11 +49,15 @@ def create_sequence(
 		maxv = max_value or None
 		start = start_value or minv
 		current = start - increment
-		verb = "INSERT OR IGNORE" if check_not_exists else "INSERT"
+		# Upsert the definition so it stays authoritative even over a bare row a
+		# prior set_next_val may have created; an existing counter is preserved.
 		db.sql(
-			f"{verb} INTO `{SQLITE_SEQUENCE_TABLE}` "
+			f"INSERT INTO `{SQLITE_SEQUENCE_TABLE}` "
 			"(name, current, increment, min_value, max_value, cycle) "
-			"VALUES (%s, %s, %s, %s, %s, %s)",
+			"VALUES (%s, %s, %s, %s, %s, %s) "
+			"ON CONFLICT(name) DO UPDATE SET "
+			"increment = excluded.increment, min_value = excluded.min_value, "
+			"max_value = excluded.max_value, cycle = excluded.cycle",
 			(sequence_name, current, increment, minv, maxv, 1 if cycle else 0),
 		)
 		return sequence_name
@@ -120,7 +123,6 @@ def set_next_val(
 	doctype_name: str, next_val: int, *, slug: str = "_id_seq", is_val_used: bool = False
 ) -> None:
 	if db.db_type == "sqlite":
-		_sqlite_ensure_table()
 		sequence_name = scrub(doctype_name + slug)
 		row = db.sql(f"SELECT increment FROM `{SQLITE_SEQUENCE_TABLE}` WHERE name = %s", (sequence_name,))
 		increment = row[0][0] if row else 1
@@ -182,8 +184,9 @@ def create_missing_sequences() -> list[str]:
 
 def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 	sequence_name = scrub(f"{doctype_name}{slug}")
-	_sqlite_ensure_table()
 
+	# The backing table is created at site setup (create_sequence_table), so the
+	# read-modify-write below can assume it exists - no per-call DDL on the hot path.
 	# Fast, fully-atomic path for unbounded sequences (which is every autoname
 	# sequence): the read-modify-write happens as one statement under SQLite's
 	# write lock, so concurrent callers can never be handed the same value.
@@ -204,17 +207,28 @@ def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 	if not existing:
 		# Auto-created (un-declared) sequence, e.g. autoname naming: seed past any
 		# existing rows so emulated names never collide, and leave it unbounded.
-		next_val = _sqlite_seed_value(doctype_name)
-		db.sql(
-			f"INSERT INTO `{SQLITE_SEQUENCE_TABLE}` (name, current) VALUES (%s, %s)",
-			(sequence_name, next_val),
+		# The upsert makes a concurrent first-use increment the freshly-created
+		# row instead of colliding on the primary key.
+		row = db.sql(
+			f"INSERT INTO `{SQLITE_SEQUENCE_TABLE}` (name, current) VALUES (%s, %s) "
+			"ON CONFLICT(name) DO UPDATE SET current = current + increment RETURNING current",
+			(sequence_name, _sqlite_seed_value(doctype_name)),
 		)
-		return next_val
+		return row[0][0]
+
+	current, increment, min_value, max_value, cycle = existing[0]
+	if max_value is None:
+		# Unbounded row created concurrently between the statements above; the
+		# fast path missed it, so increment it atomically now.
+		return db.sql(
+			f"UPDATE `{SQLITE_SEQUENCE_TABLE}` SET current = current + increment "
+			"WHERE name = %s RETURNING current",
+			(sequence_name,),
+		)[0][0]
 
 	# Bounded sequence (max_value set): honour increment / max_value / cycle.
-	current, increment, min_value, max_value, cycle = existing[0]
 	next_val = current + increment
-	if max_value is not None and next_val > max_value:
+	if next_val > max_value:
 		if cycle:
 			next_val = min_value
 		else:
@@ -226,23 +240,16 @@ def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 	return next_val
 
 
-def _sqlite_ensure_table() -> None:
-	db.sql_ddl(
-		f"CREATE TABLE IF NOT EXISTS `{SQLITE_SEQUENCE_TABLE}` ("
-		"name TEXT PRIMARY KEY, "
-		"current INTEGER NOT NULL, "
-		"increment INTEGER NOT NULL DEFAULT 1, "
-		"min_value INTEGER NOT NULL DEFAULT 1, "
-		"max_value INTEGER, "
-		"cycle INTEGER NOT NULL DEFAULT 0)"
-	)
-
-
 def _sqlite_seed_value(doctype_name: str) -> int:
 	# Seed past any rows that already exist so emulated names never collide with
 	# pre-existing ones (mirrors how create_missing_sequences seeds real ones).
-	max_name = db.sql(f"SELECT MAX(CAST(name AS INTEGER)) FROM `tab{doctype_name}`")[0][0]
-	return (max_name or 0) + 1
+	# Built via the query builder so the table name is safely quoted.
+	import frappe
+	from frappe.query_builder.functions import Max
+
+	table = frappe.qb.DocType(doctype_name)
+	max_name = frappe.qb.from_(table).select(Max(table.name)).run()[0][0]
+	return int(max_name or 0) + 1
 
 
 def _get_existing_sequences() -> set[str]:

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -200,8 +200,7 @@ def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 		return row[0][0]
 
 	existing = db.sql(
-		f"SELECT current, increment, min_value, max_value, cycle "
-		f"FROM `{SQLITE_SEQUENCE_TABLE}` WHERE name = %s",
+		f"SELECT max_value FROM `{SQLITE_SEQUENCE_TABLE}` WHERE name = %s",
 		(sequence_name,),
 	)
 	if not existing:
@@ -216,8 +215,7 @@ def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 		)
 		return row[0][0]
 
-	current, increment, min_value, max_value, cycle = existing[0]
-	if max_value is None:
+	if existing[0][0] is None:
 		# Unbounded row created concurrently between the statements above; the
 		# fast path missed it, so increment it atomically now.
 		return db.sql(
@@ -226,18 +224,19 @@ def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 			(sequence_name,),
 		)[0][0]
 
-	# Bounded sequence (max_value set): honour increment / max_value / cycle.
-	next_val = current + increment
-	if next_val > max_value:
-		if cycle:
-			next_val = min_value
-		else:
-			raise db.SequenceGeneratorLimitExceeded
-	db.sql(
-		f"UPDATE `{SQLITE_SEQUENCE_TABLE}` SET current = %s WHERE name = %s",
-		(next_val, sequence_name),
+	# Bounded sequence (max_value set): advance / cycle in one statement so the
+	# read-modify-write is atomic. The WHERE clause withholds the row when a
+	# non-cycling sequence would overflow, so RETURNING comes back empty and we
+	# raise instead of handing out a duplicate or out-of-range value.
+	row = db.sql(
+		f"UPDATE `{SQLITE_SEQUENCE_TABLE}` SET current = "
+		"CASE WHEN current + increment > max_value THEN min_value ELSE current + increment END "
+		"WHERE name = %s AND (current + increment <= max_value OR cycle) RETURNING current",
+		(sequence_name,),
 	)
-	return next_val
+	if not row:
+		raise db.SequenceGeneratorLimitExceeded
+	return row[0][0]
 
 
 def _sqlite_seed_value(doctype_name: str) -> int:

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -50,9 +50,11 @@ def create_sequence(
 		start = start_value or minv
 		current = start - increment
 		# Write the declared definition. On conflict we only adopt a row that is
-		# still implicit (declared = 0, e.g. one set_next_val/naming created): its
-		# definition is filled in while its counter is kept. An already-declared
-		# row is left untouched, so recreating a sequence never resets it.
+		# still implicit (declared = 0, e.g. one set_next_val/naming created): the
+		# declaration is authoritative, so it overwrites the placeholder counter and
+		# definition wholesale - a placeholder `current` was only meaningful for the
+		# default step, so keeping it would skew a custom increment. An
+		# already-declared row is left untouched, so recreating never resets it.
 		# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
 		# nosemgrep
 		db.sql(
@@ -60,8 +62,9 @@ def create_sequence(
 			"(name, current, increment, min_value, max_value, cycle, declared) "
 			"VALUES (%s, %s, %s, %s, %s, %s, 1) "
 			"ON CONFLICT(name) DO UPDATE SET "
-			"increment = excluded.increment, min_value = excluded.min_value, "
-			"max_value = excluded.max_value, cycle = excluded.cycle, declared = 1 "
+			"current = excluded.current, increment = excluded.increment, "
+			"min_value = excluded.min_value, max_value = excluded.max_value, "
+			"cycle = excluded.cycle, declared = 1 "
 			"WHERE declared = 0",
 			(sequence_name, current, increment, minv, maxv, 1 if cycle else 0),
 		)

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -49,17 +49,20 @@ def create_sequence(
 		maxv = max_value or None
 		start = start_value or minv
 		current = start - increment
-		# check_not_exists leaves an existing definition (and its counter) fully
-		# untouched, like "CREATE SEQUENCE IF NOT EXISTS"; otherwise a duplicate
-		# raises, like a plain CREATE SEQUENCE. The columns carry defaults, so a
-		# row is always a complete definition - there is no partial row to patch.
-		verb = "INSERT OR IGNORE" if check_not_exists else "INSERT"
+		# Write the declared definition. On conflict we only adopt a row that is
+		# still implicit (declared = 0, e.g. one set_next_val/naming created): its
+		# definition is filled in while its counter is kept. An already-declared
+		# row is left untouched, so recreating a sequence never resets it.
 		# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
 		# nosemgrep
 		db.sql(
-			f"{verb} INTO `{SQLITE_SEQUENCE_TABLE}` "
-			"(name, current, increment, min_value, max_value, cycle) "
-			"VALUES (%s, %s, %s, %s, %s, %s)",
+			f"INSERT INTO `{SQLITE_SEQUENCE_TABLE}` "
+			"(name, current, increment, min_value, max_value, cycle, declared) "
+			"VALUES (%s, %s, %s, %s, %s, %s, 1) "
+			"ON CONFLICT(name) DO UPDATE SET "
+			"increment = excluded.increment, min_value = excluded.min_value, "
+			"max_value = excluded.max_value, cycle = excluded.cycle, declared = 1 "
+			"WHERE declared = 0",
 			(sequence_name, current, increment, minv, maxv, 1 if cycle else 0),
 		)
 		return sequence_name
@@ -126,18 +129,18 @@ def set_next_val(
 ) -> None:
 	if db.db_type == "sqlite":
 		sequence_name = scrub(doctype_name + slug)
-		# Like Postgres SETVAL, this only adjusts an existing sequence - it never
-		# creates one. Creating a row here would bake in default metadata and mask
-		# the real definition that create_sequence is responsible for. Match SETVAL
-		# semantics: if next_val was already consumed the next nextval returns
-		# next_val + increment, otherwise it returns next_val itself.
+		# Persist the value even if the sequence row doesn't exist yet (e.g. an
+		# explicit integer name on a brand-new autoincrement doctype): create it
+		# as an implicit row so a later create_sequence can still declare it. Match
+		# SETVAL semantics: if next_val was already consumed the next nextval
+		# returns next_val + increment, otherwise it returns next_val itself. A new
+		# implicit sequence has the default increment of 1.
 		# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.
 		# nosemgrep
 		db.sql(
-			f"UPDATE `{SQLITE_SEQUENCE_TABLE}` "
-			"SET current = %s - (CASE WHEN %s THEN 0 ELSE increment END) "
-			"WHERE name = %s",
-			(next_val, 1 if is_val_used else 0, sequence_name),
+			f"INSERT INTO `{SQLITE_SEQUENCE_TABLE}` (name, current) VALUES (%s, %s) "
+			"ON CONFLICT(name) DO UPDATE SET current = %s - (CASE WHEN %s THEN 0 ELSE increment END)",
+			(sequence_name, next_val if is_val_used else next_val - 1, next_val, 1 if is_val_used else 0),
 		)
 		return
 

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -17,6 +17,13 @@ from frappe import db, scrub
 # ref: https://stackoverflow.com/questions/21356375/postgres-9-0-4-sequence-skipping-numbers
 SEQUENCE_CACHE = 0
 
+# SQLite has no native sequences. We emulate them with a small bookkeeping table
+# so autoname:autoincrement doctypes can be named the same way as on
+# MariaDB/Postgres - by fetching a value before the insert. The emulation
+# self-seeds from existing rows, so no separate sequence object needs to be
+# created when a table is set up.
+SQLITE_SEQUENCE_TABLE = "__frappe_sqlite_sequences"
+
 
 def create_sequence(
 	doctype_name: str,
@@ -31,8 +38,28 @@ def create_sequence(
 	min_value: int = 0,
 	max_value: int = 0,
 ) -> str:
-	query = "create sequence" if not temporary else "create temporary sequence"
 	sequence_name = scrub(doctype_name + slug)
+
+	if db.db_type == "sqlite":
+		_sqlite_ensure_table()
+		# `current` stores the last value handed out; nextval returns
+		# current + increment. Seed it so the first nextval returns `start_value`
+		# (defaulting to min_value, then 1 - matching postgres defaults).
+		increment = increment_by or 1
+		minv = min_value or 1
+		maxv = max_value or None
+		start = start_value or minv
+		current = start - increment
+		verb = "INSERT OR IGNORE" if check_not_exists else "INSERT"
+		db.sql(
+			f"{verb} INTO `{SQLITE_SEQUENCE_TABLE}` "
+			"(name, current, increment, min_value, max_value, cycle) "
+			"VALUES (%s, %s, %s, %s, %s, %s)",
+			(sequence_name, current, increment, minv, maxv, 1 if cycle else 0),
+		)
+		return sequence_name
+
+	query = "create sequence" if not temporary else "create temporary sequence"
 
 	if check_not_exists:
 		query += " if not exists"
@@ -73,6 +100,9 @@ def create_sequence(
 
 
 def get_next_val(doctype_name: str, slug: str = "_id_seq") -> int:
+	if db.db_type == "sqlite":
+		return _sqlite_get_next_val(doctype_name, slug)
+
 	sequence_name = scrub(f"{doctype_name}{slug}")
 
 	if db.db_type == "postgres":
@@ -89,6 +119,21 @@ def get_next_val(doctype_name: str, slug: str = "_id_seq") -> int:
 def set_next_val(
 	doctype_name: str, next_val: int, *, slug: str = "_id_seq", is_val_used: bool = False
 ) -> None:
+	if db.db_type == "sqlite":
+		_sqlite_ensure_table()
+		sequence_name = scrub(doctype_name + slug)
+		row = db.sql(f"SELECT increment FROM `{SQLITE_SEQUENCE_TABLE}` WHERE name = %s", (sequence_name,))
+		increment = row[0][0] if row else 1
+		# Match SETVAL semantics: if next_val was already consumed, the following
+		# nextval returns next_val + increment; otherwise it returns next_val itself.
+		current = next_val if is_val_used else next_val - increment
+		db.sql(
+			f"INSERT INTO `{SQLITE_SEQUENCE_TABLE}` (name, current) VALUES (%s, %s) "
+			"ON CONFLICT(name) DO UPDATE SET current = excluded.current",
+			(sequence_name, current),
+		)
+		return
+
 	is_val_used = "false" if not is_val_used else "true"
 
 	db.multisql(
@@ -97,20 +142,6 @@ def set_next_val(
 			"mariadb": f"SELECT SETVAL(`{scrub(doctype_name + slug)}`, {next_val}, {is_val_used})",
 		}
 	)
-
-
-def _get_existing_sequences() -> set[str]:
-	if db.db_type == "postgres":
-		rows = db.sql(
-			"""SELECT sequence_name FROM information_schema.sequences
-			WHERE sequence_schema = 'public'"""
-		)
-	else:
-		rows = db.sql(
-			"""SELECT TABLE_NAME FROM information_schema.TABLES
-			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE = 'SEQUENCE'"""
-		)
-	return {r[0] for r in rows}
 
 
 def create_missing_sequences() -> list[str]:
@@ -144,3 +175,85 @@ def create_missing_sequences() -> list[str]:
 		created.append(doctype)
 
 	return created
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
+	sequence_name = scrub(f"{doctype_name}{slug}")
+	_sqlite_ensure_table()
+
+	# Fast, fully-atomic path for unbounded sequences (which is every autoname
+	# sequence): the read-modify-write happens as one statement under SQLite's
+	# write lock, so concurrent callers can never be handed the same value.
+	# Requires SQLite >= 3.35 for RETURNING, well below any version frappe targets.
+	row = db.sql(
+		f"UPDATE `{SQLITE_SEQUENCE_TABLE}` SET current = current + increment "
+		"WHERE name = %s AND max_value IS NULL RETURNING current",
+		(sequence_name,),
+	)
+	if row:
+		return row[0][0]
+
+	existing = db.sql(
+		f"SELECT current, increment, min_value, max_value, cycle "
+		f"FROM `{SQLITE_SEQUENCE_TABLE}` WHERE name = %s",
+		(sequence_name,),
+	)
+	if not existing:
+		# Auto-created (un-declared) sequence, e.g. autoname naming: seed past any
+		# existing rows so emulated names never collide, and leave it unbounded.
+		next_val = _sqlite_seed_value(doctype_name)
+		db.sql(
+			f"INSERT INTO `{SQLITE_SEQUENCE_TABLE}` (name, current) VALUES (%s, %s)",
+			(sequence_name, next_val),
+		)
+		return next_val
+
+	# Bounded sequence (max_value set): honour increment / max_value / cycle.
+	current, increment, min_value, max_value, cycle = existing[0]
+	next_val = current + increment
+	if max_value is not None and next_val > max_value:
+		if cycle:
+			next_val = min_value
+		else:
+			raise db.SequenceGeneratorLimitExceeded
+	db.sql(
+		f"UPDATE `{SQLITE_SEQUENCE_TABLE}` SET current = %s WHERE name = %s",
+		(next_val, sequence_name),
+	)
+	return next_val
+
+
+def _sqlite_ensure_table() -> None:
+	db.sql_ddl(
+		f"CREATE TABLE IF NOT EXISTS `{SQLITE_SEQUENCE_TABLE}` ("
+		"name TEXT PRIMARY KEY, "
+		"current INTEGER NOT NULL, "
+		"increment INTEGER NOT NULL DEFAULT 1, "
+		"min_value INTEGER NOT NULL DEFAULT 1, "
+		"max_value INTEGER, "
+		"cycle INTEGER NOT NULL DEFAULT 0)"
+	)
+
+
+def _sqlite_seed_value(doctype_name: str) -> int:
+	# Seed past any rows that already exist so emulated names never collide with
+	# pre-existing ones (mirrors how create_missing_sequences seeds real ones).
+	max_name = db.sql(f"SELECT MAX(CAST(name AS INTEGER)) FROM `tab{doctype_name}`")[0][0]
+	return (max_name or 0) + 1
+
+
+def _get_existing_sequences() -> set[str]:
+	if db.db_type == "postgres":
+		rows = db.sql(
+			"""SELECT sequence_name FROM information_schema.sequences
+			WHERE sequence_schema = 'public'"""
+		)
+	else:
+		rows = db.sql(
+			"""SELECT TABLE_NAME FROM information_schema.TABLES
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE = 'SEQUENCE'"""
+		)
+	return {r[0] for r in rows}

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -227,7 +227,7 @@ def _sqlite_get_next_val(doctype_name: str, slug: str) -> int:
 		)
 		return row[0][0]
 
-	if existing[0][0] is None:
+	if existing[0][0] is None:  # pragma: no cover - only reachable under a concurrent first-use race
 		# Unbounded row created concurrently between the statements above; the
 		# fast path missed it, so increment it atomically now.
 		# Safe: f-string interpolates only the trusted SQLITE_SEQUENCE_TABLE constant.

--- a/frappe/database/sqlite/database.py
+++ b/frappe/database/sqlite/database.py
@@ -17,6 +17,15 @@ _PARAM_COMP = re.compile(r"%\([\w]*\)s")
 IMPLICIT_COMMIT_QUERY_TYPES = frozenset(("start", "alter", "drop", "create", "truncate"))
 
 
+class SequenceGeneratorLimitExceeded(sqlite3.Error):
+	"""Raised when an emulated sequence with a max_value (and no cycle) is exhausted.
+
+	SQLite has no native sequences (frappe emulates them, see
+	``frappe.database.sequence``), so unlike MariaDB/Postgres there is no driver
+	exception to reuse for this case.
+	"""
+
+
 class SQLiteExceptionUtil:
 	ProgrammingError = sqlite3.ProgrammingError
 	TableMissingError = sqlite3.OperationalError
@@ -102,6 +111,7 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 	REGEX_CHARACTER = "regexp"
 	default_port = None
 	MAX_ROW_SIZE_LIMIT = None
+	SequenceGeneratorLimitExceeded = SequenceGeneratorLimitExceeded
 
 	def get_connection(self, read_only: bool = False):
 		conn = self.create_connection(read_only)

--- a/frappe/database/sqlite/database.py
+++ b/frappe/database/sqlite/database.py
@@ -334,6 +334,22 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 			)"""
 		)
 
+	def create_sequence_table(self):
+		# SQLite has no native sequences; this table emulates them for
+		# autoname:autoincrement doctypes. See frappe.database.sequence.
+		from frappe.database.sequence import SQLITE_SEQUENCE_TABLE
+
+		self.sql_ddl(
+			f"""CREATE TABLE IF NOT EXISTS `{SQLITE_SEQUENCE_TABLE}` (
+			`name` TEXT PRIMARY KEY,
+			`current` INTEGER NOT NULL,
+			`increment` INTEGER NOT NULL DEFAULT 1,
+			`min_value` INTEGER NOT NULL DEFAULT 1,
+			`max_value` INTEGER,
+			`cycle` INTEGER NOT NULL DEFAULT 0
+			)"""
+		)
+
 	@staticmethod
 	def get_on_duplicate_update():
 		return "ON CONFLICT DO UPDATE SET "

--- a/frappe/database/sqlite/database.py
+++ b/frappe/database/sqlite/database.py
@@ -339,6 +339,9 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 		# autoname:autoincrement doctypes. See frappe.database.sequence.
 		from frappe.database.sequence import SQLITE_SEQUENCE_TABLE
 
+		# `declared` is 1 for sequences defined via create_sequence and 0 for rows
+		# auto-created by naming/set_next_val; it lets create_sequence adopt an
+		# implicit row without ever overwriting an explicit definition.
 		self.sql_ddl(
 			f"""CREATE TABLE IF NOT EXISTS `{SQLITE_SEQUENCE_TABLE}` (
 			`name` TEXT PRIMARY KEY,
@@ -346,7 +349,8 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 			`increment` INTEGER NOT NULL DEFAULT 1,
 			`min_value` INTEGER NOT NULL DEFAULT 1,
 			`max_value` INTEGER,
-			`cycle` INTEGER NOT NULL DEFAULT 0
+			`cycle` INTEGER NOT NULL DEFAULT 0,
+			`declared` INTEGER NOT NULL DEFAULT 0
 			)"""
 		)
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -178,6 +178,7 @@ def install_db(
 	frappe.db.create_auth_table()
 	frappe.db.create_global_search_table()
 	frappe.db.create_user_settings_table()
+	frappe.db.create_sequence_table()
 
 	frappe.flags.in_install_db = False
 

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -269,3 +269,4 @@ frappe.patches.v16_0.backfill_notification_log_title_description
 frappe.patches.v16_0.backfill_notification_email_type_preferences
 frappe.patches.v16_0.backfill_notification_log_app
 frappe.patches.v16_0.backfill_list_layout_route_signature
+execute:frappe.db.create_sequence_table()  # backfill SQLite sequence emulation table on existing sites

--- a/frappe/tests/test_sequence.py
+++ b/frappe/tests/test_sequence.py
@@ -48,17 +48,18 @@ class TestSequence(IntegrationTestCase):
 		self.assertEqual(15, frappe.db.get_next_sequence_val(seq_name))
 		self.assertEqual(20, frappe.db.get_next_sequence_val(seq_name))
 
-	def test_recreate_preserves_counter(self):
-		# Re-creating an existing sequence must be idempotent: the counter keeps
-		# advancing instead of resetting (on SQLite this exercises the upsert that
-		# refreshes the definition without touching `current`).
+	def test_recreate_preserves_definition_and_counter(self):
+		# Re-creating with check_not_exists must be a no-op: neither the counter
+		# nor the definition may change. Use a bounded, cycling sequence so a
+		# clobbered definition would surface as a wrong value instead of cycling.
 		seq_name = self.generate_sequence_name()
-		frappe.db.create_sequence(seq_name, check_not_exists=True, temporary=True)
+		frappe.db.create_sequence(seq_name, max_value=2, cycle=True, check_not_exists=True, temporary=True)
 		self.assertEqual(1, frappe.db.get_next_sequence_val(seq_name))
-		self.assertEqual(2, frappe.db.get_next_sequence_val(seq_name))
 
+		# Recreating with default args must not reset the cap to unbounded.
 		frappe.db.create_sequence(seq_name, check_not_exists=True, temporary=True)
-		self.assertEqual(3, frappe.db.get_next_sequence_val(seq_name))
+		self.assertEqual(2, frappe.db.get_next_sequence_val(seq_name))
+		self.assertEqual(1, frappe.db.get_next_sequence_val(seq_name))  # cycled, cap intact
 
 	def test_autoincrement_naming_seeds_sequence(self):
 		# Naming an autoincrement doctype fetches a value before insert without a

--- a/frappe/tests/test_sequence.py
+++ b/frappe/tests/test_sequence.py
@@ -61,6 +61,29 @@ class TestSequence(IntegrationTestCase):
 		self.assertEqual(2, frappe.db.get_next_sequence_val(seq_name))
 		self.assertEqual(1, frappe.db.get_next_sequence_val(seq_name))  # cycled, cap intact
 
+	def test_set_next_val_creates_missing_sequence(self):
+		# Setting a value before the sequence exists (e.g. an explicit integer name
+		# on a brand-new autoincrement doctype) must persist, so the next value
+		# continues after it instead of restarting and colliding.
+		if frappe.db.db_type != "sqlite":
+			self.skipTest("SETVAL requires an existing sequence on MariaDB/Postgres")
+		seq_name = self.generate_sequence_name()
+		frappe.db.set_next_sequence_val(seq_name, 50, is_val_used=True)
+		self.assertEqual(51, frappe.db.get_next_sequence_val(seq_name))
+
+	def test_create_sequence_adopts_implicit_row(self):
+		# A row auto-created by set_next_val carries no real definition, so a later
+		# create_sequence must be able to declare its bounds (without losing the
+		# counter) instead of being ignored.
+		if frappe.db.db_type != "sqlite":
+			self.skipTest("implicit-row adoption is SQLite-specific")
+		seq_name = self.generate_sequence_name()
+		frappe.db.set_next_sequence_val(seq_name, 5, is_val_used=True)
+		frappe.db.create_sequence(seq_name, max_value=7, cycle=True, check_not_exists=True, temporary=True)
+		self.assertEqual(6, frappe.db.get_next_sequence_val(seq_name))
+		self.assertEqual(7, frappe.db.get_next_sequence_val(seq_name))
+		self.assertEqual(1, frappe.db.get_next_sequence_val(seq_name))  # cycled at the declared cap
+
 	def test_autoincrement_naming_seeds_sequence(self):
 		# Naming an autoincrement doctype fetches a value before insert without a
 		# create_sequence call, so the sequence has to seed itself lazily from any

--- a/frappe/tests/test_sequence.py
+++ b/frappe/tests/test_sequence.py
@@ -47,3 +47,33 @@ class TestSequence(IntegrationTestCase):
 		self.assertEqual(10, frappe.db.get_next_sequence_val(seq_name))
 		self.assertEqual(15, frappe.db.get_next_sequence_val(seq_name))
 		self.assertEqual(20, frappe.db.get_next_sequence_val(seq_name))
+
+	def test_recreate_preserves_counter(self):
+		# Re-creating an existing sequence must be idempotent: the counter keeps
+		# advancing instead of resetting (on SQLite this exercises the upsert that
+		# refreshes the definition without touching `current`).
+		seq_name = self.generate_sequence_name()
+		frappe.db.create_sequence(seq_name, check_not_exists=True, temporary=True)
+		self.assertEqual(1, frappe.db.get_next_sequence_val(seq_name))
+		self.assertEqual(2, frappe.db.get_next_sequence_val(seq_name))
+
+		frappe.db.create_sequence(seq_name, check_not_exists=True, temporary=True)
+		self.assertEqual(3, frappe.db.get_next_sequence_val(seq_name))
+
+	def test_autoincrement_naming_seeds_sequence(self):
+		# Naming an autoincrement doctype fetches a value before insert without a
+		# create_sequence call, so the sequence has to seed itself lazily from any
+		# existing rows. This is the path that originally failed on SQLite.
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		doctype = "seq_autoinc_" + frappe.generate_hash(length=5)
+		dt = new_doctype(doctype, autoname="autoincrement").insert(ignore_permissions=True)
+		self.addCleanup(dt.delete, ignore_permissions=True)
+
+		for expected in range(1, 4):
+			self.assertEqual(expected, frappe.new_doc(doctype).save(ignore_permissions=True).name)
+
+	def test_create_missing_sequences_returns_list(self):
+		from frappe.database.sequence import create_missing_sequences
+
+		self.assertIsInstance(create_missing_sequences(), list)

--- a/frappe/tests/test_sequence.py
+++ b/frappe/tests/test_sequence.py
@@ -73,16 +73,17 @@ class TestSequence(IntegrationTestCase):
 
 	def test_create_sequence_adopts_implicit_row(self):
 		# A row auto-created by set_next_val carries no real definition, so a later
-		# create_sequence must be able to declare its bounds (without losing the
-		# counter) instead of being ignored.
+		# create_sequence must be able to declare it instead of being ignored. The
+		# declaration is authoritative: a custom step starts from its own definition
+		# rather than skewing off the placeholder counter.
 		if frappe.db.db_type != "sqlite":
 			self.skipTest("implicit-row adoption is SQLite-specific")
 		seq_name = self.generate_sequence_name()
 		frappe.db.set_next_sequence_val(seq_name, 5, is_val_used=True)
-		frappe.db.create_sequence(seq_name, max_value=7, cycle=True, check_not_exists=True, temporary=True)
-		self.assertEqual(6, frappe.db.get_next_sequence_val(seq_name))
-		self.assertEqual(7, frappe.db.get_next_sequence_val(seq_name))
-		self.assertEqual(1, frappe.db.get_next_sequence_val(seq_name))  # cycled at the declared cap
+		frappe.db.create_sequence(seq_name, min_value=10, max_value=20, increment_by=5, temporary=True)
+		self.assertEqual(10, frappe.db.get_next_sequence_val(seq_name))
+		self.assertEqual(15, frappe.db.get_next_sequence_val(seq_name))
+		self.assertEqual(20, frappe.db.get_next_sequence_val(seq_name))
 
 	def test_autoincrement_naming_seeds_sequence(self):
 		# Naming an autoincrement doctype fetches a value before insert without a


### PR DESCRIPTION
## Problem

SQLite has no native sequences. Naming `autoname: autoincrement` doctypes pre-fetches a value via `nextval(...)` before insert, which fails on SQLite with `no such column: <seq>` — making those doctypes (and any test suite that creates them) unusable on a SQLite-backed site.

## Fix

Emulate sequences in `frappe.database.sequence` using a small bookkeeping table (`__frappe_sqlite_sequences`):

- Supports `increment_by`, `min_value`, `max_value` and `cycle`, and raises `SequenceGeneratorLimitExceeded` when a capped sequence is exhausted.
- The unbounded path (used by all naming) increments atomically in a single statement, so concurrent callers never get the same value.
- Self-seeds from existing rows, so no migration is needed for existing tables.
- Adds `SequenceGeneratorLimitExceeded` to the SQLite backend (MariaDB/Postgres reuse their driver's exception).

No-op on MariaDB/Postgres.

## Tests

`frappe.tests.test_sequence` and `frappe.tests.test_naming` pass on a SQLite site (the one `test_naming` failure, `test_uuid_naming`, is an unrelated UUID column-type assertion).

## Documentation

No user-facing change — this is internal DB-backend (SQLite) and test infrastructure. `no-docs`
