### PR TITLE
fix: expose mask property on Custom Field

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -41,6 +41,7 @@
   "unique",
   "is_virtual",
   "read_only",
+  "mask",
   "ignore_user_permissions",
   "hidden",
   "print_hide",
@@ -499,6 +500,13 @@
    "fieldname": "set_only_once",
    "fieldtype": "Check",
    "label": "Set only once"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:[\"Select\", \"Read Only\", \"Phone\", \"Percent\", \"Password\", \"Link\", \"Int\", \"Float\", \"Dynamic Link\", \"Duration\", \"Datetime\", \"Currency\", \"Data\", \"Date\"].includes(doc.fieldtype)",
+   "fieldname": "mask",
+   "fieldtype": "Check",
+   "label": "Mask"
   }
  ],
  "grid_page_length": 50,
@@ -506,7 +514,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-12 10:00:00.000000",
+ "modified": "2026-06-28 17:40:35.172946",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -102,6 +102,7 @@ class CustomField(Document):
 		length: DF.Int
 		link_filters: DF.JSON | None
 		mandatory_depends_on: DF.Code | None
+		mask: DF.Check
 		module: DF.Link | None
 		no_copy: DF.Check
 		non_negative: DF.Check


### PR DESCRIPTION
The mask field property masks a docfield's value for users who lack the mask permission at its permlevel. Standard DocFields expose it through a `Mask checkbox`, but Custom Field never carried the property, so it could not be set on custom fields from the UI.

Add mask to Custom Field, mirroring the DocField definition (same `depends_on`, limiting the checkbox to maskable fieldtypes). The masking runtime is untouched - `get_masked_fields` already iterates every `docfield` by `fieldname` regardless of origin, so masking applied to custom fields as soon as the property could be set.

<img width="1179" height="867" alt="Screenshot 2026-06-28 at 1 26 01 AM" src="https://github.com/user-attachments/assets/5cd2d868-a987-493f-8cfb-7ec473d6c9e5" />
<img width="1010" height="863" alt="Screenshot 2026-06-28 at 1 26 28 AM" src="https://github.com/user-attachments/assets/38d1dedb-bffa-42c6-bab0-6dc6e2f5df39" />

---
Closes #39511