### PR TITLE
fix(client): don't reject whole-doc set_value over standard fields

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -200,9 +200,15 @@ def set_value(doctype: str, name: str | int, fieldname: str | dict[str, Any], va
 		values = {fieldname: value}
 
 	forbidden = set(frappe.model.default_fields + frappe.model.child_table_fields)
-	for field in values:
-		if field in forbidden:
-			frappe.throw(_("Cannot edit standard fields"))
+
+	# In whole-doc payloads, framework-managed fields are incidental (e.g. name,
+	# owner, creation, idx echoed back), so strip them instead of failing.
+	# throws if only editing framework-managed fields
+	editable = {field: val for field, val in values.items() if field not in forbidden}
+	if values and not editable:
+		frappe.throw(_("Cannot edit standard fields"))
+
+	values = editable
 
 	# check for child table doctype
 	if not frappe.get_meta(doctype).istable:


### PR DESCRIPTION
PR #38951 changed `set_value` to iterate every key of the payload and
throw "Cannot edit standard fields" if any key was a default/child
field. Sending a whole doc (the common inline-edit / reorder pattern)
always includes name, owner, creation, modified, idx, etc., so it
started throwing for legitimate updates.

Restore the behaviour by stripping framework-managed fields from
dict/whole-doc payloads instead of failing, while still erroring when a
single standard field is targeted explicitly. This also unblocks child
row reordering via idx in a whole-doc save.
