### PR TITLE
fix: update Frappe Mail API endpoints to suite app routes

### DIFF
--- a/frappe/email/frappemail.py
+++ b/frappe/email/frappemail.py
@@ -68,6 +68,7 @@ class FrappeMail:
 		files: dict | None = None,
 		headers: dict[str, str] | None = None,
 		timeout: int | tuple[int, int] = (60, 120),
+		raw_response: bool = False,
 	) -> Any | None:
 		"""Makes a request to the Frappe Mail API."""
 
@@ -90,6 +91,11 @@ class FrappeMail:
 			timeout=timeout,
 		)
 		raise_for_status(response)
+
+		# The suite app routes return raw JSON without Frappe's `message`/`data`
+		# wrapper, which `post_process()` would collapse to `None`.
+		if raw_response:
+			return response.json()
 
 		return self.client.post_process(response)
 
@@ -142,7 +148,7 @@ class FrappeMail:
 
 		data = {"mailbox": mailbox, "limit": limit, "last_received_at": last_received_at}
 		headers = {"X-Site": frappe.utils.get_url()}
-		response = self.request("GET", endpoint=endpoint, data=data, headers=headers)
+		response = self.request("GET", endpoint=endpoint, data=data, headers=headers, raw_response=True)
 		last_received_at = convert_utc_to_system_timezone(get_datetime(response["last_received_at"]))
 
 		return {"latest_messages": response["mails"], "last_received_at": last_received_at}

--- a/frappe/email/frappemail.py
+++ b/frappe/email/frappemail.py
@@ -96,7 +96,7 @@ class FrappeMail:
 	def validate(self) -> None:
 		"""Validates if the user is allowed to send or receive emails."""
 
-		endpoint = "/api/method/mail.api.auth.validate"
+		endpoint = "/auth/validate"
 		data = {"email": self.email}
 		self.request("POST", endpoint=endpoint, data=data)
 
@@ -106,7 +106,7 @@ class FrappeMail:
 		"""Sends an email using the Frappe Mail API."""
 
 		session_id = str(uuid.uuid4())
-		endpoint = "/api/method/mail.api.outbound.send_raw"
+		endpoint = "/outbound/send-raw"
 
 		if isinstance(message, str):
 			message = message.encode("utf-8")
@@ -136,7 +136,7 @@ class FrappeMail:
 	) -> dict[str, str | list[str]]:
 		"""Pull emails for the account using the Frappe Mail API."""
 
-		endpoint = "/api/method/mail.api.inbound.pull_raw"
+		endpoint = "/inbound/pull-raw"
 		if last_received_at:
 			last_received_at = add_or_update_tzinfo(last_received_at)
 


### PR DESCRIPTION
## Context

The mail app was recently moved to the suite app, and the endpoints for its APIs changed accordingly. This PR updates the Frappe Mail API endpoints in `frappe/email/frappemail.py` to the latest routes.

## Changes

| Purpose | Old endpoint | New endpoint |
| --- | --- | --- |
| Validate | `/api/method/mail.api.auth.validate` | `/auth/validate` |
| Send raw | `/api/method/mail.api.outbound.send_raw` | `/outbound/send-raw` |
| Pull raw | `/api/method/mail.api.inbound.pull_raw` | `/inbound/pull-raw` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)