### PR TITLE
fix: hide `Default layout` button on Report and Image view

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -634,6 +634,10 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	setup_list_filter_by() {
+		if (!this.show_saved_layout_menu) {
+			return Promise.resolve();
+		}
+
 		return new Promise((resolve) => {
 			frappe.require("list_filter.bundle.js", () => {
 				this.list_filter = new frappe.views.ListFilter(this);

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -82,6 +82,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		return "List";
 	}
 
+	get show_saved_layout_menu() {
+		return true;
+	}
+
 	get view_user_settings() {
 		return this.user_settings[this.view_name] || {};
 	}

--- a/frappe/public/js/frappe/views/image/image_view.js
+++ b/frappe/public/js/frappe/views/image/image_view.js
@@ -8,6 +8,10 @@ frappe.views.ImageView = class ImageView extends frappe.views.ListView {
 		return "Image";
 	}
 
+	get show_saved_layout_menu() {
+		return false;
+	}
+
 	setup_defaults() {
 		return super.setup_defaults().then(() => {
 			this.page_title = this.page_title + " " + __("Images");

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -11,6 +11,10 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		return "Report";
 	}
 
+	get show_saved_layout_menu() {
+		return false;
+	}
+
 	render_header() {
 		// Override List View Header
 	}


### PR DESCRIPTION
There is no need of Default Layout button in this view so removing it
<img width="1464" height="495" alt="image" src="https://github.com/user-attachments/assets/5a023784-cd3e-4c89-9bca-79c673a1ead3" />

<img width="1449" height="760" alt="image" src="https://github.com/user-attachments/assets/19446f56-27c8-4a9f-9049-f2b24d07e920" />

`no-docs`
