### PR TITLE
fix(notifications): stop rendering raw description in sidebar panel

### DIFF
--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -297,15 +297,9 @@ class NotificationsView extends BaseNotificationsView {
 			? message.replace(title[1], frappe.ellipsis(strip_html(title[1]), 100))
 			: message;
 
-		let description = notification_log.description || "";
-		let description_html = description
-			? `<div class="notification-description text-muted">${description}</div>`
-			: "";
-
 		let timestamp = frappe.datetime.comment_when(notification_log.creation);
 		let message_html = `<div class="message">
 			<div>${message}</div>
-			${description_html}
 			<div class="notification-timestamp text-muted">
 				${timestamp}
 			</div>


### PR DESCRIPTION
The desk notification panel rendered the notification's description as raw HTML. For mentions and rule-based notifications the description is mirrored from email_content (the full comment/email markup), so block elements, embedded avatars and empty mention pills leaked into the panel and broke the row layout, putting each fragment on its own line.

Drop the description block from the dropdown item so the panel shows just the title/subject line and timestamp, matching the behaviour before the title/description fields were introduced.d