### PR TITLE
feat: add profiling support to lightmode test runner

### DIFF
--- a/frappe/commands/testing.py
+++ b/frappe/commands/testing.py
@@ -183,6 +183,10 @@ def main(
 
 
 def run_tests_in_light_mode(test_params):
+	import cProfile
+	import pstats
+	from io import StringIO
+
 	from frappe.testing.loader import FrappeTestLoader
 	from frappe.testing.result import FrappeTestResult
 	from frappe.tests.utils import toggle_test_mode
@@ -201,7 +205,20 @@ def run_tests_in_light_mode(test_params):
 
 	toggle_test_mode(True)
 	suite = FrappeTestLoader().discover_tests(test_params)
+
+	if test_params.profile:
+		pr = cProfile.Profile()
+		pr.enable()
+
 	result = unittest.TextTestRunner(failfast=test_params.failfast, resultclass=FrappeTestResult).run(suite)
+
+	if test_params.profile:
+		pr.disable()
+		s = StringIO()
+		ps = pstats.Stats(pr, stream=s).sort_stats("cumulative")
+		ps.print_stats()
+		print(s.getvalue())
+
 	if not result.wasSuccessful():
 		sys.exit(1)
 


### PR DESCRIPTION
Add support for profiling in Lightmode test runner
`no-docs`