### PR TITLE
fix(awesome-bar): search modal doesn't open after SPA navigation

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -67,7 +67,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			.addClass("cool-awesomebar-modal-footer")
 			.html(search_modal_footer);
 
-		$search_element.on("click", () => {
+		$(document).on("click", element, () => {
 			if (this.is_open()) {
 				this.close();
 				return;


### PR DESCRIPTION
- Use event delegation (`$(document).on("click", element, ...)`) instead of direct binding for the search button click handler

Why: Each page navigation renders a new `.navbar-modal-search-mobile` button from `page.html`, but `setup_awesomebar()` only runs once — direct binding only attaches to the first button, leaving all subsequent buttons unresponsive