### PR TITLE
fix!: Avoid fake `frappe.init` to fetch common site config

### DIFF
--- a/frappe/commands/redis_utils.py
+++ b/frappe/commands/redis_utils.py
@@ -24,8 +24,7 @@ def create_rq_users(set_admin_password=False, use_rq_auth=False):
 
 	acl_file_path = os.path.abspath("../config/redis_queue.acl")
 
-	with frappe.init_site():
-		acl_list, user_credentials = RedisQueue.gen_acl_list(set_admin_password=set_admin_password)
+	acl_list, user_credentials = RedisQueue.gen_acl_list(set_admin_password=set_admin_password)
 
 	with open(acl_file_path, "w") as f:
 		f.writelines([acl + "\n" for acl in acl_list])

--- a/frappe/config.py
+++ b/frappe/config.py
@@ -71,12 +71,8 @@ def _get_site_config(sites_path: str, site_path: str) -> _dict[str, Any]:
 
 		raise ValueError(f"Unsupported db_type={db_type}")
 
-	config["redis_queue"] = (
-		os.environ.get("FRAPPE_REDIS_QUEUE") or config.get("redis_queue") or "redis://127.0.0.1:11311"
-	)
-	config["redis_cache"] = (
-		os.environ.get("FRAPPE_REDIS_CACHE") or config.get("redis_cache") or "redis://127.0.0.1:13311"
-	)
+	_apply_common_env_overrides(config)
+
 	config["db_type"] = os.environ.get("FRAPPE_DB_TYPE") or config.get("db_type") or "mariadb"
 
 	if config["db_type"] in ("mariadb", "postgres"):
@@ -124,16 +120,28 @@ def get_common_site_config(sites_path: str | None = None, cached=False) -> _dict
 		return _get_common_site_config(sites_path)
 
 
+def _apply_common_env_overrides(config: _dict[str, Any]) -> None:
+	config["redis_queue"] = (
+		os.environ.get("FRAPPE_REDIS_QUEUE") or config.get("redis_queue") or "redis://127.0.0.1:11311"
+	)
+	config["redis_cache"] = (
+		os.environ.get("FRAPPE_REDIS_CACHE") or config.get("redis_cache") or "redis://127.0.0.1:13311"
+	)
+
+
 def _get_common_site_config(sites_path: str) -> _dict[str, Any]:
 	common_site_config = os.path.join(sites_path, "common_site_config.json")
+	config = _dict()
 	if os.path.exists(common_site_config):
 		try:
-			return _dict(get_file_json(common_site_config))
+			config = _dict(get_file_json(common_site_config))
 		except Exception as error:
 			click.secho("common_site_config.json is invalid", fg="red")
 			print(error)
 			raise
-	return _dict()
+
+	_apply_common_env_overrides(config)
+	return config
 
 
 # These variants cache the values in *memory* for repeat access, use it in web requests or anywhere

--- a/frappe/config.py
+++ b/frappe/config.py
@@ -151,6 +151,11 @@ def get_conf(site: str | None = None) -> _dict[str, Any]:
 	if hasattr(frappe.local, "conf"):
 		return frappe.local.conf
 
+	sites_path = os.environ.get("SITES_PATH", ".")
+
 	# if no site, get from common_site_config.json
-	with frappe.init_site(site):
-		return frappe.local.conf
+	if site:
+		with frappe.init_site(site):
+			return frappe.local.conf
+	else:
+		return get_common_site_config(sites_path)

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -338,13 +338,11 @@ def start_worker(
 
 	_start_sentry()
 
-	with frappe.init_site():
-		# empty init is required to get redis_queue from common_site_config.json
-		redis_connection = get_redis_conn(username=rq_username, password=rq_password)
+	redis_connection = get_redis_conn(username=rq_username, password=rq_password)
 
-		if queue:
-			queue = [q.strip() for q in queue.split(",")]
-		queues = get_queue_list(queue, build_queue_name=True)
+	if queue:
+		queue = [q.strip() for q in queue.split(",")]
+	queues = get_queue_list(queue, build_queue_name=True)
 
 	if os.environ.get("CI"):
 		setup_loghandlers("ERROR")
@@ -438,12 +436,11 @@ def start_worker_pool(
 	import frappe.website.path_resolver  # all the page types and resolver
 	# end: module pre-loading
 
-	with frappe.init_site():
-		redis_connection = get_redis_conn()
+	redis_connection = get_redis_conn()
 
-		if queue:
-			queue = [q.strip() for q in queue.split(",")]
-		queues = get_queue_list(queue, build_queue_name=True)
+	if queue:
+		queue = [q.strip() for q in queue.split(",")]
+	queues = get_queue_list(queue, build_queue_name=True)
 
 	if os.environ.get("CI"):
 		setup_loghandlers("ERROR")
@@ -575,10 +572,7 @@ def validate_queue(queue: str, default_queue_list: list | None = None) -> None:
 	reraise=True,
 )
 def get_redis_conn(username=None, password=None):
-	if not hasattr(frappe.local, "conf"):
-		raise Exception("You need to call frappe.init")
-
-	conf = frappe.get_site_config()
+	conf = frappe.get_conf()
 	if not conf.redis_queue:
 		raise Exception("redis_queue missing in common_site_config.json")
 


### PR DESCRIPTION
Instead fetch it directly. This fake init causes unintentional side
effects like triggering connection to cache or setting up modulemap etc.

Marking this as breaking change because unintentionally people might be
expecting `frappe.get_conf` to always cause a fake init.
