### PR TITLE
fix(pdf): always terminate chrome and close pages after pdf generation

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -182,10 +182,9 @@ def get_chrome_pdf(print_format, html, options, output, pdf_generator=None):
 		# transforms and merges header, footer into body pdf and returns merged pdf
 		return transformer.transform_pdf(output=output)
 	except Exception:
-		# Chrome timeout / crash: reset singleton so the next request gets a fresh
-		# Chrome instance. _browsers cleanup is handled by Browser.__init__'s finally.
-		generator._close_browser()
 		raise
+	finally:
+		generator._close_browser()
 
 
 def get_file_data_from_writer(writer_obj):

--- a/frappe/utils/pdf_generator/browser.py
+++ b/frappe/utils/pdf_generator/browser.py
@@ -34,8 +34,6 @@ class Browser:
 			# now wait for page to load as we need DOM to generate pdf
 			self.body_page.wait_for_set_content()
 			self.body_pdf = self.body_page.generate_pdf(raw=not self.header_page and not self.footer_page)
-			if not self.debug_mode:
-				self.body_page.close()
 			self.update_header_footer_page()
 
 			if self.header_page:
@@ -45,8 +43,6 @@ class Browser:
 					)
 				else:
 					self.header_pdf = self.header_page.generate_pdf()
-				if not self.debug_mode:
-					self.header_page.close()
 
 			if self.footer_page:
 				if not self.is_footer_dynamic:
@@ -55,12 +51,19 @@ class Browser:
 					)
 				else:
 					self.footer_pdf = self.footer_page.generate_pdf()
-				if not self.debug_mode:
-					self.footer_page.close()
-
-			if not self.debug_mode:
-				self.close()
 		finally:
+			if not self.debug_mode:
+				for attr in ("body_page", "header_page", "footer_page"):
+					page = getattr(self, attr, None)
+					if page:
+						try:
+							page.close()
+						except Exception:
+							pass
+				try:
+					self.close()
+				except Exception:
+					pass
 			generator.remove_browser(self.browserID)
 		if self.debug_mode:
 			generator.detach_debug_browser()

--- a/frappe/utils/pdf_generator/browser.py
+++ b/frappe/utils/pdf_generator/browser.py
@@ -59,11 +59,11 @@ class Browser:
 						try:
 							page.close()
 						except Exception:
-							pass
+							frappe.log_error(f"Failed to close {attr} in Chrome")
 				try:
 					self.close()
 				except Exception:
-					pass
+					frappe.log_error("Failed to disconnect CDP session")
 			generator.remove_browser(self.browserID)
 		if self.debug_mode:
 			generator.detach_debug_browser()


### PR DESCRIPTION
- Move page/session cleanup in \`Browser.__init__\` to \`finally\` so tabs and CDP session are closed even when an exception occurs mid-job
- Move \`_close_browser()\` in \`get_chrome_pdf\` to \`finally\` so Chrome process is always terminated after each PDF (success or failure)

Why: Chrome processes were accumulating on the server — each failed job left open tabs and CDP sessions inside Chrome, and Chrome itself was never killed on successful requests, growing unboundedly over time.

> **Note:** Chrome now starts and stops per PDF request (~1–2s startup overhead). A future improvement would be a singleton with an idle timeout to restore warmup speed for high-volume usage.