### PR TITLE
fix(postgres): disable libpq GSSAPI so RQ workers are fork-safe

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -230,8 +230,9 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			# libpg defaults to default socket if not specified
 			"host": self.host or self.socket,
 			# libpq's GSSAPI (krb5) path is not fork-safe; with the default gssencmode=prefer
-			# RQ work horses segfault on fork ("work-horse terminated unexpectedly").
-			"gssencmode": frappe.conf.get("db_gssencmode", "disable"),
+			# RQ work horses segfault on fork ("work-horse terminated unexpectedly"). `or`
+			# coerces a falsy/non-string site-config value back to a valid libpq mode.
+			"gssencmode": frappe.conf.get("db_gssencmode") or "disable",
 		}
 		if self.password:
 			conn_settings["password"] = self.password

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -224,19 +224,21 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		self._cursor.execute("SET search_path TO %s", (self.db_schema,))
 
 	def get_connection(self):
-		# libpq's GSSAPI (krb5) path is not fork-safe; with the default gssencmode=prefer
-		# RQ work horses segfault on fork ("work-horse terminated unexpectedly"). Validate the
-		# site-config override against libpq's modes so a bad value can't break every connection.
-		gssencmode = str(frappe.conf.get("db_gssencmode") or "disable")
-		if gssencmode not in ("disable", "allow", "prefer", "require"):
-			gssencmode = "disable"
 		conn_settings = {
 			"dbname": self.cur_db_name,
 			"user": self.user,
 			# libpg defaults to default socket if not specified
 			"host": self.host or self.socket,
-			"gssencmode": gssencmode,
 		}
+		# libpq's GSSAPI (krb5) path is not fork-safe; with the default gssencmode=prefer RQ work
+		# horses segfault on fork ("work-horse terminated unexpectedly"). The option exists from
+		# libpq 12, so guard on the runtime version (an older client lib would reject it); validate
+		# any site-config override against libpq's modes so a bad value can't break every connection.
+		if psycopg2.extensions.libpq_version() >= 120000:
+			gssencmode = str(frappe.conf.get("db_gssencmode") or "disable")
+			if gssencmode not in ("disable", "allow", "prefer", "require"):
+				gssencmode = "disable"
+			conn_settings["gssencmode"] = gssencmode
 		if self.password:
 			conn_settings["password"] = self.password
 		if not self.socket and self.port:

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -224,15 +224,18 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		self._cursor.execute("SET search_path TO %s", (self.db_schema,))
 
 	def get_connection(self):
+		# libpq's GSSAPI (krb5) path is not fork-safe; with the default gssencmode=prefer
+		# RQ work horses segfault on fork ("work-horse terminated unexpectedly"). Validate the
+		# site-config override against libpq's modes so a bad value can't break every connection.
+		gssencmode = str(frappe.conf.get("db_gssencmode") or "disable")
+		if gssencmode not in ("disable", "allow", "prefer", "require"):
+			gssencmode = "disable"
 		conn_settings = {
 			"dbname": self.cur_db_name,
 			"user": self.user,
 			# libpg defaults to default socket if not specified
 			"host": self.host or self.socket,
-			# libpq's GSSAPI (krb5) path is not fork-safe; with the default gssencmode=prefer
-			# RQ work horses segfault on fork ("work-horse terminated unexpectedly"). `or`
-			# coerces a falsy/non-string site-config value back to a valid libpq mode.
-			"gssencmode": frappe.conf.get("db_gssencmode") or "disable",
+			"gssencmode": gssencmode,
 		}
 		if self.password:
 			conn_settings["password"] = self.password

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -229,6 +229,9 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			"user": self.user,
 			# libpg defaults to default socket if not specified
 			"host": self.host or self.socket,
+			# libpq's GSSAPI (krb5) path is not fork-safe; with the default gssencmode=prefer
+			# RQ work horses segfault on fork ("work-horse terminated unexpectedly").
+			"gssencmode": frappe.conf.get("db_gssencmode", "disable"),
 		}
 		if self.password:
 			conn_settings["password"] = self.password


### PR DESCRIPTION
## Problem
libpq's GSSAPI (Kerberos) negotiation path is not fork-safe. With libpq's default `gssencmode=prefer`, Postgres-backed sites running RQ background workers segfault on `fork()` — surfacing as `Work-horse terminated unexpectedly`.

## Fix
Default the connection's `gssencmode` to `disable`, overridable per-site via the `db_gssencmode` site-config key.
