### PR TITLE
fix: connected app race on concurrent token refresh

### DIFF
--- a/frappe/integrations/doctype/connected_app/connected_app.py
+++ b/frappe/integrations/doctype/connected_app/connected_app.py
@@ -143,24 +143,22 @@ class ConnectedApp(Document):
 		user = user or frappe.session.user
 		token_cache = self.get_token_cache(user)
 		if token_cache and token_cache.is_expired():
-			with filelock(f"token_cache_{token_cache.name}"):
-				# Another worker may have refreshed while we waited for the lock.
-				token_cache.reload()
-				if not token_cache.is_expired():
-					return token_cache
+			try:
+				with filelock(f"token_cache_{token_cache.name}"):
+					# Another worker may have refreshed while we waited for the lock.
+					token_cache.reload()
+					if not token_cache.is_expired():
+						return token_cache
 
-				oauth_session = self.get_oauth2_session(user)
-
-				try:
+					oauth_session = self.get_oauth2_session(user)
 					token = oauth_session.refresh_token(
 						body=f"redirect_uri={self.redirect_uri}",
 						token_url=self.token_uri,
 					)
-				except Exception:
-					self.log_error("Token Refresh Error")
-					return None
-
-				token_cache.update_data(token)
+					token_cache.update_data(token)
+			except Exception:
+				self.log_error("Token Refresh Error")
+				return None
 
 		return token_cache
 

--- a/frappe/integrations/doctype/connected_app/connected_app.py
+++ b/frappe/integrations/doctype/connected_app/connected_app.py
@@ -11,6 +11,7 @@ import frappe
 from frappe import _
 from frappe.integrations.utils import make_get_request
 from frappe.model.document import Document
+from frappe.utils.synchronization import filelock
 
 if any((os.getenv("CI"), frappe.conf.developer_mode, frappe.conf.allow_tests)):
 	# Disable mandatory TLS in developer mode and tests
@@ -142,18 +143,24 @@ class ConnectedApp(Document):
 		user = user or frappe.session.user
 		token_cache = self.get_token_cache(user)
 		if token_cache and token_cache.is_expired():
-			oauth_session = self.get_oauth2_session(user)
+			with filelock(f"token_cache_{token_cache.name}"):
+				# Another worker may have refreshed while we waited for the lock.
+				token_cache.reload()
+				if not token_cache.is_expired():
+					return token_cache
 
-			try:
-				token = oauth_session.refresh_token(
-					body=f"redirect_uri={self.redirect_uri}",
-					token_url=self.token_uri,
-				)
-			except Exception:
-				self.log_error("Token Refresh Error")
-				return None
+				oauth_session = self.get_oauth2_session(user)
 
-			token_cache.update_data(token)
+				try:
+					token = oauth_session.refresh_token(
+						body=f"redirect_uri={self.redirect_uri}",
+						token_url=self.token_uri,
+					)
+				except Exception:
+					self.log_error("Token Refresh Error")
+					return None
+
+				token_cache.update_data(token)
 
 		return token_cache
 

--- a/frappe/integrations/doctype/connected_app/test_connected_app.py
+++ b/frappe/integrations/doctype/connected_app/test_connected_app.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2019, Frappe Technologies and contributors
 # License: MIT. See LICENSE
+from unittest.mock import patch
 from urllib.parse import urljoin
 
 import requests
@@ -8,6 +9,7 @@ import frappe
 from frappe.integrations.doctype.social_login_key.test_social_login_key import (
 	create_or_update_social_login_key,
 )
+from frappe.integrations.doctype.token_cache.token_cache import TokenCache
 from frappe.tests import IntegrationTestCase
 
 
@@ -92,18 +94,14 @@ class TestConnectedApp(IntegrationTestCase):
 		self.connected_app.reload()
 		self.oauth_client.reload()
 
-	def test_web_application_flow(self):
-		"""Simulate a logged in user who opens the authorization URL."""
-
-		def login():
-			return session.get(
-				urljoin(self.base_url, "/api/method/login"),
-				params={"usr": self.user_name, "pwd": self.user_password},
-			)
-
+	def complete_web_application_flow(self):
+		"""Simulate a logged in user who opens the authorization URL and store the token."""
 		session = requests.Session()
 
-		first_login = login()
+		first_login = session.get(
+			urljoin(self.base_url, "/api/method/login"),
+			params={"usr": self.user_name, "pwd": self.user_password},
+		)
 		self.assertEqual(first_login.status_code, 200)
 
 		authorization_url = self.connected_app.initiate_web_application_flow(user=self.user_name)
@@ -115,12 +113,43 @@ class TestConnectedApp(IntegrationTestCase):
 		self.assertEqual(callback_response.status_code, 200)
 
 		self.token_cache = self.connected_app.get_token_cache(self.user_name)
+		return session
+
+	def test_web_application_flow(self):
+		"""Simulate a logged in user who opens the authorization URL."""
+		self.complete_web_application_flow()
+
 		token = self.token_cache.get_password("access_token")
 		self.assertNotEqual(token, None)
 
 		oauth2_session = self.connected_app.get_oauth2_session(self.user_name)
 		resp = oauth2_session.get(urljoin(self.base_url, "/api/method/frappe.auth.get_logged_user"))
 		self.assertEqual(resp.json().get("message"), self.user_name)
+
+	def test_concurrent_refresh_skips_redundant_call(self):
+		"""A refresh must be skipped if another worker already refreshed the token."""
+		self.complete_web_application_flow()
+
+		self.token_cache.db_set("expires_in", -1)
+
+		# Stand in for a concurrent worker that refreshed first: the reload under the lock
+		# returns a token that is no longer expired.
+		original_reload = TokenCache.reload
+
+		def reload_as_fresh(token_cache, *args, **kwargs):
+			original_reload(token_cache, *args, **kwargs)
+			token_cache.expires_in = 3600
+			return token_cache
+
+		with (
+			patch.object(
+				self.connected_app, "get_oauth2_session", wraps=self.connected_app.get_oauth2_session
+			) as session_spy,
+			patch.object(TokenCache, "reload", reload_as_fresh),
+		):
+			self.connected_app.get_active_token(self.user_name)
+
+		session_spy.assert_not_called()
 
 	def tearDown(self):
 		def delete_if_exists(attribute):


### PR DESCRIPTION
## Problem

`ConnectedApp.get_active_token()` was checking `is_expired()` and refreshing the token without any synchronization. If multiple workers hit an expired token at the same time, they would all try to refresh it using the same refresh token.

This becomes a problem with providers that rotate refresh tokens (Google, Azure, Okta, etc.). The first refresh succeeds and invalidates the old refresh token, while the remaining requests fail because they're still using the now-invalid token. Depending on timing, this can leave the cached token state inconsistent and require the user to re-authorize the app.

## Fix

The refresh path is now protected by a per-token-cache file lock.

Once a worker acquires the lock, it reloads the cached token and checks again whether it still needs to be refreshed. If another worker has already refreshed and stored a new token, it simply uses the updated token instead of making another refresh request.

This ensures that only one refresh happens for a given expired token while other workers reuse the refreshed credentials.

## Scope

The locking is only applied to the refresh-token flow.

`get_backend_app_token()` uses the client credentials grant, so there is no refresh token involved and no risk of refresh-token rotation. Concurrent requests there are independent and don't require synchronization.

---

Closes #38248