### PR TITLE
fix(print-format-builder): apply column widths in builder table preview

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -59,6 +59,7 @@
 									v-for="col in df.table_columns"
 									:key="col.fieldname"
 									:class="numeric_align_class(col)"
+									:style="col.width ? { width: col.width + '%' } : {}"
 								>
 									{{ col.label || col.fieldname }}
 								</th>
@@ -784,6 +785,7 @@ watch(
 	width: 100%;
 	border-collapse: collapse;
 	font-size: var(--text-sm);
+	table-layout: fixed;
 }
 
 /* ── Default: bordered + styled header (matches PDF) ─── */


### PR DESCRIPTION
- Add `width` style binding on `<th>` elements using `col.width + '%'`
- Add `table-layout: fixed` to `.preview-table` so percentage widths are respected

Why: Column widths set in the inspector had no effect on the builder preview table — only PDF/print preview reflected them