### PR TITLE
feat(print-format-builder): conditional visibility for fields and sections

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -6,7 +6,7 @@
 			'field--selected': is_selected,
 			'field--preview': !!preview_doc,
 		}"
-		v-show="!df.remove"
+		v-show="!df.remove && (preview_doc ? is_field_visible : true)"
 		:title="df.label || df.fieldname"
 		@click.stop="select_field"
 	>
@@ -219,7 +219,7 @@
 
 <script setup>
 import ConfigureColumnsVue from "../inspector/ConfigureColumns.vue";
-import { render_jinja_html, sanitize_html } from "../../utils";
+import { render_jinja_html, sanitize_html, evaluate_visible_if } from "../../utils";
 import { createApp, ref, nextTick, watch, computed, inject } from "vue";
 
 const props = defineProps(["df", "field_orientation"]);
@@ -232,6 +232,7 @@ let rendered_template = ref(null);
 
 let is_selected = computed(() => store.selected_field.value === props.df);
 let preview_doc = computed(() => store.preview_doc.value);
+let is_field_visible = computed(() => evaluate_visible_if(props.df.visible_if, preview_doc.value));
 
 // Render Jinja2 HTML fields server-side when in preview mode
 watch(

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -1,5 +1,9 @@
 <template>
-	<div class="print-format-section-container" data-pfb-section>
+	<div
+		class="print-format-section-container"
+		data-pfb-section
+		v-show="!preview_doc || is_section_visible"
+	>
 		<!-- Top-left actions pill shown on hover in clean-preview (toolbar is hidden) -->
 		<div v-if="!is_header" class="section-preview-actions">
 			<div
@@ -122,12 +126,17 @@
 import draggable from "vuedraggable";
 import Field from "./Field.vue";
 import { computed, inject } from "vue";
+import { evaluate_visible_if } from "../../utils";
 
 const props = defineProps(["section", "is_header", "zone"]);
 
 let store = inject("$store");
 
 let is_selected = computed(() => store.selected_section.value === props.section);
+let preview_doc = computed(() => store.preview_doc.value);
+let is_section_visible = computed(() =>
+	evaluate_visible_if(props.section.visible_if, preview_doc.value)
+);
 
 let section_inline_style = computed(() => {
 	const style = {};

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -219,6 +219,24 @@
 					</div>
 				</div>
 
+				<!-- VISIBILITY section -->
+				<div class="pfb-insp-section">
+					<div class="pfb-insp-section-head" @click="toggle('t_visibility')">
+						<span class="pfb-insp-section-label">{{ __("Visibility") }}</span>
+						<span
+							class="pfb-insp-chevron"
+							:class="{ collapsed: !open.t_visibility }"
+							v-html="frappe.utils.icon('chevron-down', 'xs')"
+						></span>
+					</div>
+					<div v-show="open.t_visibility">
+						<VisibilitySection
+							v-model="selected_field.visible_if"
+							:previewDoc="preview_doc"
+						/>
+					</div>
+				</div>
+
 				<div class="pfb-insp-actions">
 					<button class="btn btn-xs btn-danger-subtle" @click="remove_field">
 						<span v-html="frappe.utils.icon('x', 'xs')"></span>
@@ -316,10 +334,11 @@
 							v-html="frappe.utils.icon('chevron-down', 'xs')"
 						></span>
 					</div>
-					<div v-show="open.f_visibility" class="pfb-insp-section-body">
-						<p class="pfb-insp-hint text-muted">
-							{{ __("Conditional visibility coming soon.") }}
-						</p>
+					<div v-show="open.f_visibility">
+						<VisibilitySection
+							v-model="selected_field.visible_if"
+							:previewDoc="preview_doc"
+						/>
 					</div>
 				</div>
 
@@ -527,10 +546,11 @@
 							v-html="frappe.utils.icon('chevron-down', 'xs')"
 						></span>
 					</div>
-					<div v-show="open.s_visibility" class="pfb-insp-section-body">
-						<p class="pfb-insp-hint text-muted">
-							{{ __("Conditional visibility coming soon.") }}
-						</p>
+					<div v-show="open.s_visibility">
+						<VisibilitySection
+							v-model="selected_section.visible_if"
+							:previewDoc="preview_doc"
+						/>
 					</div>
 				</div>
 
@@ -566,6 +586,7 @@ import draggable from "vuedraggable";
 import { useStore } from "../../stores";
 import LetterHeadZoneInspector from "./LetterHeadZoneInspector.vue";
 import Autocomplete from "../../../vue-components/Autocomplete.vue";
+import VisibilitySection from "./VisibilitySection.vue";
 
 let store = inject("$store");
 let { letterhead, layout } = useStore();
@@ -574,6 +595,7 @@ let selected_field = computed(() => store.selected_field.value);
 let selected_section = computed(() => store.selected_section.value);
 let selected_letterhead = computed(() => store.selected_letterhead.value);
 let selected_lh_footer = computed(() => store.selected_lh_footer.value);
+let preview_doc = computed(() => store.preview_doc.value);
 
 const open = ref({
 	f_field: true,
@@ -584,6 +606,7 @@ const open = ref({
 	s_visibility: false,
 	t_table: true,
 	t_columns: true,
+	t_visibility: false,
 });
 
 function toggle(key) {

--- a/frappe/public/js/print_format_builder/components/inspector/VisibilitySection.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/VisibilitySection.vue
@@ -1,0 +1,104 @@
+<template>
+	<div class="pfb-visibility-body">
+		<div class="pfb-insp-row--col" style="display: flex; flex-direction: column; gap: 6px">
+			<label class="pfb-insp-label">{{ __("Show when") }}</label>
+			<input
+				class="pfb-insp-input"
+				type="text"
+				:placeholder="__('e.g. doc.status == \'Paid\'')"
+				:value="modelValue"
+				@input="$emit('update:modelValue', $event.target.value)"
+			/>
+			<div v-if="modelValue && modelValue.trim()" class="pfb-vis-status-row">
+				<template v-if="previewDoc">
+					<span
+						:class="[
+							'pfb-vis-badge',
+							is_visible ? 'pfb-vis-badge--show' : 'pfb-vis-badge--hide',
+						]"
+					>
+						<span class="pfb-vis-dot"></span>
+						{{ is_visible ? __("Currently visible") : __("Currently hidden") }}
+					</span>
+				</template>
+				<span v-else class="pfb-vis-hint-no-doc">
+					{{ __("Load a document to see live status") }}
+				</span>
+			</div>
+			<p class="pfb-insp-hint text-muted">
+				{{ __("Leave blank to always show. Reference fields with") }}
+				<code>doc.fieldname</code>.
+			</p>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { evaluate_visible_if } from "../../utils";
+
+const props = defineProps(["modelValue", "previewDoc"]);
+defineEmits(["update:modelValue"]);
+
+let is_visible = computed(() => evaluate_visible_if(props.modelValue, props.previewDoc));
+</script>
+
+<style scoped>
+.pfb-visibility-body {
+	padding: 4px 14px 12px;
+}
+
+.pfb-vis-status-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.pfb-vis-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	font-size: var(--text-xs);
+	font-weight: var(--weight-medium);
+	padding: 2px 8px;
+	border-radius: var(--radius-full);
+}
+
+.pfb-vis-badge--show {
+	background: var(--green-100);
+	color: var(--green-700);
+}
+
+.pfb-vis-badge--hide {
+	background: var(--gray-100);
+	color: var(--gray-500);
+}
+
+.pfb-vis-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.pfb-vis-badge--show .pfb-vis-dot {
+	background: var(--green-500);
+}
+
+.pfb-vis-badge--hide .pfb-vis-dot {
+	background: var(--gray-400);
+}
+
+.pfb-vis-hint-no-doc {
+	font-size: var(--text-xs);
+	color: var(--text-muted);
+}
+
+.pfb-insp-hint code {
+	font-size: var(--text-xs);
+	background: var(--gray-100);
+	padding: 1px 4px;
+	border-radius: var(--radius);
+	font-family: var(--monospace-font-family, monospace);
+}
+</style>

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -283,6 +283,16 @@ export function sanitize_html(html) {
 	return root.innerHTML;
 }
 
+export function evaluate_visible_if(expr, doc) {
+	if (!expr || !expr.trim()) return true;
+	try {
+		// eslint-disable-next-line no-new-func
+		return !!new Function("doc", `return (${expr})`)(doc);
+	} catch {
+		return true;
+	}
+}
+
 export function get_image_dimensions(src) {
 	return new Promise((resolve) => {
 		let img = new Image();

--- a/frappe/templates/print_format/macros.html
+++ b/frappe/templates/print_format/macros.html
@@ -1,6 +1,8 @@
 {% macro render_field(df, doc) %}
+{%- if not df.get('_hidden') -%}
 {%- set value = doc.get(df.fieldname) -%}
 {% include ['templates/print_format/macros/' + df.renderer + '.html', 'templates/print_format/macros/Data.html'] ignore missing %}
+{%- endif -%}
 {% endmacro %}
 
 {% macro field_attributes(df) %}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -42,6 +42,7 @@
 	{%- endif -%}
 	{%- endif -%}
 	{% for section in layout.sections %}
+	{%- if section.get('_hidden') -%}{%- continue -%}{%- endif -%}
 	{#- Skip labelled sections where every data field is empty -#}
 	{%- set ns = namespace(has_content=false) -%}
 	{%- for column in section.columns -%}

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -281,9 +281,20 @@ class PrintFormatGenerator:
 
 	def set_field_renderers(self, layout):
 		renderers = {"HTML Editor": "HTML", "Markdown Editor": "Markdown"}
+		eval_locals = {"doc": self.doc}
 		for section in layout["sections"]:
+			if section.get("visible_if"):
+				try:
+					section["_hidden"] = not frappe.safe_eval(section["visible_if"], eval_locals)
+				except Exception:
+					section["_hidden"] = False
 			for column in section["columns"]:
 				for df in column["fields"]:
+					if df.get("visible_if"):
+						try:
+							df["_hidden"] = not frappe.safe_eval(df["visible_if"], eval_locals)
+						except Exception:
+							df["_hidden"] = False
 					fieldtype = df["fieldtype"]
 					df["renderer"] = renderers.get(fieldtype) or fieldtype.replace(" ", "")
 					df["section"] = section
@@ -294,6 +305,11 @@ class PrintFormatGenerator:
 			if isinstance(zone, dict) and "columns" in zone:
 				for column in zone.get("columns", []):
 					for df in column.get("fields", []):
+						if df.get("visible_if"):
+							try:
+								df["_hidden"] = not frappe.safe_eval(df["visible_if"], eval_locals)
+							except Exception:
+								df["_hidden"] = False
 						fieldtype = df.get("fieldtype", "Data")
 						df["renderer"] = renderers.get(fieldtype) or fieldtype.replace(" ", "")
 						df["section"] = zone


### PR DESCRIPTION
- New `VisibilitySection.vue` component — shared condition-input UI used across all three inspectors (field, table field, section)
- Visibility section added to table-field inspector (was missing entirely)
- `visible_if` condition evaluated live in builder preview with a green/gray status badge
- Fields and sections hidden in preview mode when condition is false; editor mode always shows everything
- Server-side: `frappe.safe_eval` evaluates conditions in `PrintFormatGenerator` so PDF/printview respects visibility too
- Utility: `evaluate_visible_if(expr, doc)` added to `utils.js` — shared by all preview components

Why: "Conditional visibility coming soon" replaced with a first-class feature; table-field inspector had no visibility section at all