### PR TITLE
feat(PFB): UI UX improvements

### DIFF
--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -425,7 +425,7 @@ context("Print Format Builder — section insert", () => {
 			1
 		);
 
-		cy.get(".section-with-insert .section-insert").first().click({ force: true });
+		cy.get(".section-with-insert .section-insert-btn").first().click({ force: true });
 
 		cy.get(".sections-container [data-pfb-section]").should("have.length", 2);
 	});
@@ -449,7 +449,7 @@ context("Print Format Builder — section insert", () => {
 			1
 		);
 
-		cy.get(".sections-container > .section-insert").click({ force: true });
+		cy.get(".sections-container > .section-insert .section-insert-btn").click({ force: true });
 
 		cy.get(".sections-container [data-pfb-section]").should("have.length", 2);
 	});
@@ -475,13 +475,13 @@ context("Print Format Builder — section insert", () => {
 		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
 		cy.get(".sections-container [data-pfb-section]").should("have.length", 0);
 
-		cy.get(".sections-container > .section-insert").click({ force: true });
+		cy.get(".sections-container > .section-insert .section-insert-btn").click({ force: true });
 		cy.get(".sections-container [data-pfb-section]").should("have.length", 1);
 
-		cy.get(".sections-container > .section-insert").click({ force: true });
+		cy.get(".sections-container > .section-insert .section-insert-btn").click({ force: true });
 		cy.get(".sections-container [data-pfb-section]").should("have.length", 2);
 
-		cy.get(".sections-container > .section-insert").click({ force: true });
+		cy.get(".sections-container > .section-insert .section-insert-btn").click({ force: true });
 		cy.get(".sections-container [data-pfb-section]").should("have.length", 3);
 	});
 

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -351,13 +351,16 @@ frappe.ui.form.PrintView = class {
 			this.set_default_letterhead();
 			return;
 		}
-		frappe.model.with_doc("Print Format", format_name, () => {
-			const letter_head = this.get_print_format(format_name).letter_head;
-			if (letter_head) {
-				this.letterhead_selector.val(letter_head);
-			} else {
-				this.set_default_letterhead();
-			}
+		frappe.call({
+			method: "frappe.client.get",
+			args: { doctype: "Print Format", name: format_name },
+			callback: (r) => {
+				if (r.message?.letter_head) {
+					this.letterhead_selector.val(r.message.letter_head);
+				} else {
+					this.set_default_letterhead();
+				}
+			},
 		});
 	}
 

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -341,7 +341,23 @@ frappe.ui.form.PrintView = class {
 	refresh_print_format() {
 		this.set_default_print_language();
 		this.toggle_raw_printing();
+		this.update_letterhead_for_print_format();
 		this.preview();
+	}
+
+	update_letterhead_for_print_format() {
+		const format_name = this.selected_format();
+		if (!format_name || format_name === "Standard") {
+			this.set_default_letterhead();
+			return;
+		}
+		frappe.db.get_value("Print Format", format_name, "letter_head").then(({ message }) => {
+			if (message?.letter_head) {
+				this.letterhead_selector.val(message.letter_head);
+			} else {
+				this.set_default_letterhead();
+			}
+		});
 	}
 
 	// bind_events () {

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -355,8 +355,16 @@ frappe.ui.form.PrintView = class {
 				args: { doctype: "Print Format", name: format_name },
 			})
 			.then((r) => {
-				if (r.message?.letter_head) {
-					this.letterhead_selector.val(r.message.letter_head);
+				let letter_head = null;
+				try {
+					letter_head = r.message?.format_data
+						? JSON.parse(r.message.format_data)?.letter_head
+						: null;
+				} catch (_) {
+					// malformed format_data — fall through to default letterhead
+				}
+				if (letter_head) {
+					this.letterhead_selector.val(letter_head);
 				} else {
 					return this.set_default_letterhead();
 				}

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -341,27 +341,26 @@ frappe.ui.form.PrintView = class {
 	refresh_print_format() {
 		this.set_default_print_language();
 		this.toggle_raw_printing();
-		this.update_letterhead_for_print_format();
-		this.preview();
+		this.update_letterhead_for_print_format().then(() => this.preview());
 	}
 
 	update_letterhead_for_print_format() {
 		const format_name = this.selected_format();
 		if (!format_name || format_name === "Standard") {
-			this.set_default_letterhead();
-			return;
+			return this.set_default_letterhead();
 		}
-		frappe.call({
-			method: "frappe.client.get",
-			args: { doctype: "Print Format", name: format_name },
-			callback: (r) => {
+		return frappe
+			.call({
+				method: "frappe.client.get",
+				args: { doctype: "Print Format", name: format_name },
+			})
+			.then((r) => {
 				if (r.message?.letter_head) {
 					this.letterhead_selector.val(r.message.letter_head);
 				} else {
-					this.set_default_letterhead();
+					return this.set_default_letterhead();
 				}
-			},
-		});
+			});
 	}
 
 	// bind_events () {

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -351,9 +351,10 @@ frappe.ui.form.PrintView = class {
 			this.set_default_letterhead();
 			return;
 		}
-		frappe.db.get_value("Print Format", format_name, "letter_head").then(({ message }) => {
-			if (message?.letter_head) {
-				this.letterhead_selector.val(message.letter_head);
+		frappe.model.with_doc("Print Format", format_name, () => {
+			const letter_head = this.get_print_format(format_name).letter_head;
+			if (letter_head) {
+				this.letterhead_selector.val(letter_head);
 			} else {
 				this.set_default_letterhead();
 			}

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -16,6 +16,19 @@ frappe.pages["print-format-builder"].on_page_show = function (wrapper) {
 	load_print_format_builder(wrapper);
 };
 
+function patch_breadcrumbs_once() {
+	if (frappe.breadcrumbs._pfb_patched) return;
+	frappe.breadcrumbs._pfb_patched = true;
+	const orig = frappe.breadcrumbs.update.bind(frappe.breadcrumbs);
+	frappe.breadcrumbs.update = function () {
+		orig();
+		const crumbs = this.all[this.current_page()];
+		if (crumbs?._extra_label) {
+			this.append_breadcrumb_element("", crumbs._extra_label);
+		}
+	};
+}
+
 function load_print_format_builder(wrapper) {
 	let route = frappe.get_route();
 	let $parent = $(wrapper).find(".layout-main-section");
@@ -23,12 +36,15 @@ function load_print_format_builder(wrapper) {
 
 	if (route.length > 1) {
 		// Two-level breadcrumb: "Print Format Builder" → "[Format Name]"
+		// Store _extra_label in the breadcrumb object so update() re-renders it
+		// every time, not just once as a DOM append that gets wiped.
+		patch_breadcrumbs_once();
 		frappe.breadcrumbs.add({
 			type: "Custom",
 			label: __("Print Format Builder"),
 			route: "/desk/print-format-builder",
+			_extra_label: route[1],
 		});
-		frappe.breadcrumbs.append_breadcrumb_element("", route[1]);
 		wrapper.page.set_title(route[1]);
 
 		frappe.require("print_format_builder.bundle.js").then(() => {

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -22,11 +22,12 @@ function load_print_format_builder(wrapper) {
 	$parent.empty();
 
 	if (route.length > 1) {
-		// Override the breadcrumb to show the format name being edited.
+		// Keep breadcrumb as "Print Format Builder" (back to the root builder),
+		// and show the format name in the page heading only.
 		frappe.breadcrumbs.add({
 			type: "Custom",
-			label: route[1],
-			route: frappe.get_route_str(),
+			label: __("Print Format Builder"),
+			route: "print-format-builder",
 		});
 		wrapper.page.set_title(route[1]);
 

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -22,6 +22,11 @@ function load_print_format_builder(wrapper) {
 	$parent.empty();
 
 	if (route.length > 1) {
+		// Set title immediately so the breadcrumb shows the format name
+		// without waiting for the bundle to load.
+		wrapper.page.set_title(route[1]);
+		wrapper.page.set_title_sub(__("Print Format Builder"));
+
 		frappe.require("print_format_builder.bundle.js").then(() => {
 			frappe.print_format_builder = new frappe.ui.PrintFormatBuilder({
 				wrapper: $parent,

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -22,13 +22,13 @@ function load_print_format_builder(wrapper) {
 	$parent.empty();
 
 	if (route.length > 1) {
-		// Keep breadcrumb as "Print Format Builder" (back to the root builder),
-		// and show the format name in the page heading only.
+		// Two-level breadcrumb: "Print Format Builder" → "[Format Name]"
 		frappe.breadcrumbs.add({
 			type: "Custom",
 			label: __("Print Format Builder"),
-			route: "print-format-builder",
+			route: "/desk/print-format-builder",
 		});
+		frappe.breadcrumbs.append_breadcrumb_element("", route[1]);
 		wrapper.page.set_title(route[1]);
 
 		frappe.require("print_format_builder.bundle.js").then(() => {

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -35,9 +35,7 @@ function load_print_format_builder(wrapper) {
 	$parent.empty();
 
 	if (route.length > 1) {
-		// Two-level breadcrumb: "Print Format Builder" → "[Format Name]"
-		// Store _extra_label in the breadcrumb object so update() re-renders it
-		// every time, not just once as a DOM append that gets wiped.
+		// _extra_label is re-appended on every breadcrumbs.update() call so it survives route changes
 		patch_breadcrumbs_once();
 		frappe.breadcrumbs.add({
 			type: "Custom",

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -22,10 +22,13 @@ function load_print_format_builder(wrapper) {
 	$parent.empty();
 
 	if (route.length > 1) {
-		// Set title immediately so the breadcrumb shows the format name
-		// without waiting for the bundle to load.
+		// Override the breadcrumb to show the format name being edited.
+		frappe.breadcrumbs.add({
+			type: "Custom",
+			label: route[1],
+			route: frappe.get_route_str(),
+		});
 		wrapper.page.set_title(route[1]);
-		wrapper.page.set_title_sub(__("Print Format Builder"));
 
 		frappe.require("print_format_builder.bundle.js").then(() => {
 			frappe.print_format_builder = new frappe.ui.PrintFormatBuilder({

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -736,12 +736,8 @@ watch(
 	justify-content: space-between;
 }
 
-.field-preview-lr--space-between .field-preview-label {
-	flex-shrink: 0;
-}
-
 .field-preview-lr--space-between .field-preview-value {
-	flex: 0;
+	flex: none;
 	text-align: right;
 }
 
@@ -749,12 +745,8 @@ watch(
 	justify-content: space-evenly;
 }
 
-.field-preview-lr--space-evenly .field-preview-label {
-	flex-shrink: 0;
-}
-
 .field-preview-lr--space-evenly .field-preview-value {
-	flex: 0;
+	flex: none;
 }
 
 .field-preview-value {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -59,6 +59,7 @@
 									v-for="col in df.table_columns"
 									:key="col.fieldname"
 									:class="numeric_align_class(col)"
+									:style="col.width ? { width: col.width + '%' } : {}"
 								>
 									{{ col.label || col.fieldname }}
 								</th>
@@ -784,6 +785,7 @@ watch(
 	width: 100%;
 	border-collapse: collapse;
 	font-size: var(--text-sm);
+	table-layout: fixed;
 }
 
 /* ── Default: bordered + styled header (matches PDF) ─── */

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -745,34 +745,29 @@ watch(
 .field-preview-lr--space-between {
 	justify-content: space-between;
 }
-
-.field-preview-lr--space-between .field-preview-value {
-	flex: none;
-	text-align: right;
-}
-
 .field-preview-lr--space-evenly {
 	justify-content: space-evenly;
 }
-
-.field-preview-lr--space-evenly .field-preview-value {
-	flex: none;
-}
-
 .field-preview-lr--align-center {
 	justify-content: center;
 }
-
-.field-preview-lr--align-center .field-preview-label,
-.field-preview-lr--align-center .field-preview-value {
-	flex: none;
-	width: auto;
-}
-
 .field-preview-lr--align-right {
 	justify-content: flex-end;
 }
 
+/* Spacing: value shrinks to natural width so justify-content has room to push it */
+.field-preview-lr--space-between .field-preview-value,
+.field-preview-lr--space-evenly .field-preview-value {
+	flex: none;
+}
+
+.field-preview-lr--space-between .field-preview-value {
+	text-align: right;
+}
+
+/* Align: both label and value shrink to natural width so the pair can be repositioned */
+.field-preview-lr--align-center .field-preview-label,
+.field-preview-lr--align-center .field-preview-value,
 .field-preview-lr--align-right .field-preview-label,
 .field-preview-lr--align-right .field-preview-value {
 	flex: none;

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -31,7 +31,12 @@
 				<div
 					v-else-if="df.fieldtype == 'Table MultiSelect'"
 					:style="{ textAlign: df.align || 'left' }"
-					:class="{ 'field-preview-lr': field_orientation === 'left-right' }"
+					:class="[
+						'field-preview-lr',
+						field_orientation === 'left-right' && df.label_justify
+							? `field-preview-lr--${df.label_justify}`
+							: '',
+					]"
 				>
 					<div v-if="df.label && df.show_label !== 'hide'" class="field-preview-label">
 						{{ df.label }}
@@ -110,7 +115,12 @@
 				<div
 					v-else
 					:style="{ textAlign: df.align || 'left' }"
-					:class="{ 'field-preview-lr': field_orientation === 'left-right' }"
+					:class="[
+						'field-preview-lr',
+						field_orientation === 'left-right' && df.label_justify
+							? `field-preview-lr--${df.label_justify}`
+							: '',
+					]"
 				>
 					<div v-if="df.label && df.show_label !== 'hide'" class="field-preview-label">
 						{{ df.label }}
@@ -720,6 +730,31 @@ watch(
 .field-preview-lr .field-preview-value {
 	flex: 1;
 	min-width: 0;
+}
+
+.field-preview-lr--space-between {
+	justify-content: space-between;
+}
+
+.field-preview-lr--space-between .field-preview-label {
+	flex-shrink: 0;
+}
+
+.field-preview-lr--space-between .field-preview-value {
+	flex: 0;
+	text-align: right;
+}
+
+.field-preview-lr--space-evenly {
+	justify-content: space-evenly;
+}
+
+.field-preview-lr--space-evenly .field-preview-label {
+	flex-shrink: 0;
+}
+
+.field-preview-lr--space-evenly .field-preview-value {
+	flex: 0;
 }
 
 .field-preview-value {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -30,11 +30,16 @@
 				<!-- Table MultiSelect field: render as a comma-separated value list -->
 				<div
 					v-else-if="df.fieldtype == 'Table MultiSelect'"
-					:style="{ textAlign: df.align || 'left' }"
+					:style="
+						field_orientation !== 'left-right' ? { textAlign: df.align || 'left' } : {}
+					"
 					:class="[
 						'field-preview-lr',
 						field_orientation === 'left-right' && df.label_justify
 							? `field-preview-lr--${df.label_justify}`
+							: '',
+						field_orientation === 'left-right' && df.align && df.align !== 'left'
+							? `field-preview-lr--align-${df.align}`
 							: '',
 					]"
 				>
@@ -114,11 +119,16 @@
 				<!-- Regular field -->
 				<div
 					v-else
-					:style="{ textAlign: df.align || 'left' }"
+					:style="
+						field_orientation !== 'left-right' ? { textAlign: df.align || 'left' } : {}
+					"
 					:class="[
 						'field-preview-lr',
 						field_orientation === 'left-right' && df.label_justify
 							? `field-preview-lr--${df.label_justify}`
+							: '',
+						field_orientation === 'left-right' && df.align && df.align !== 'left'
+							? `field-preview-lr--align-${df.align}`
 							: '',
 					]"
 				>
@@ -747,6 +757,26 @@ watch(
 
 .field-preview-lr--space-evenly .field-preview-value {
 	flex: none;
+}
+
+.field-preview-lr--align-center {
+	justify-content: center;
+}
+
+.field-preview-lr--align-center .field-preview-label,
+.field-preview-lr--align-center .field-preview-value {
+	flex: none;
+	width: auto;
+}
+
+.field-preview-lr--align-right {
+	justify-content: flex-end;
+}
+
+.field-preview-lr--align-right .field-preview-label,
+.field-preview-lr--align-right .field-preview-value {
+	flex: none;
+	width: auto;
 }
 
 .field-preview-value {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -6,7 +6,7 @@
 			'field--selected': is_selected,
 			'field--preview': !!preview_doc,
 		}"
-		v-show="!df.remove"
+		v-show="!df.remove && (preview_doc ? is_field_visible : true)"
 		:title="df.label || df.fieldname"
 		@click.stop="select_field"
 	>
@@ -220,7 +220,7 @@
 
 <script setup>
 import ConfigureColumnsVue from "../inspector/ConfigureColumns.vue";
-import { render_jinja_html, sanitize_html } from "../../utils";
+import { render_jinja_html, sanitize_html, evaluate_visible_if } from "../../utils";
 import { createApp, ref, nextTick, watch, computed, inject } from "vue";
 
 const props = defineProps(["df", "field_orientation"]);
@@ -233,6 +233,7 @@ let rendered_template = ref(null);
 
 let is_selected = computed(() => store.selected_field.value === props.df);
 let preview_doc = computed(() => store.preview_doc.value);
+let is_field_visible = computed(() => evaluate_visible_if(props.df.visible_if, preview_doc.value));
 
 // Render Jinja2 HTML fields server-side when in preview mode
 watch(

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -5,8 +5,9 @@
 			'field--table': df.fieldtype == 'Table',
 			'field--selected': is_selected,
 			'field--preview': !!preview_doc,
+			'field--condition-hidden': preview_doc && !is_field_visible,
 		}"
-		v-show="!df.remove && (preview_doc ? is_field_visible : true)"
+		v-show="!df.remove"
 		:title="df.label || df.fieldname"
 		@click.stop="select_field"
 	>
@@ -672,6 +673,12 @@ watch(
 	background: transparent;
 	padding: 0;
 	position: relative;
+}
+
+.field--condition-hidden {
+	opacity: 0.35;
+	border: 1px dashed var(--gray-400) !important;
+	border-radius: var(--radius);
 }
 
 .field--preview:hover {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -693,7 +693,7 @@ watch(
 .field-preview-label {
 	font-size: var(--text-tiny);
 	font-weight: var(--weight-semibold);
-	color: var(--gray-500);
+	color: #6b7280;
 	margin-bottom: 1px;
 }
 

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -2,7 +2,7 @@
 	<div
 		class="print-format-section-container"
 		data-pfb-section
-		v-show="!preview_doc || is_section_visible"
+		:class="{ 'section-container--condition-hidden': preview_doc && !is_section_visible }"
 	>
 		<!-- Top-left actions pill shown on hover in clean-preview (toolbar is hidden) -->
 		<div v-if="!is_header" class="section-preview-actions">
@@ -184,6 +184,13 @@ function remove_column(index) {
 
 .print-format-section-container:not(:last-child) {
 	margin-bottom: 0.5rem;
+}
+
+.section-container--condition-hidden {
+	opacity: 0.35;
+	outline: 2px dashed var(--gray-400);
+	outline-offset: 2px;
+	border-radius: var(--radius);
 }
 
 .print-format-section {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -1,5 +1,9 @@
 <template>
-	<div class="print-format-section-container" data-pfb-section>
+	<div
+		class="print-format-section-container"
+		data-pfb-section
+		v-show="!preview_doc || is_section_visible"
+	>
 		<!-- Top-left actions pill shown on hover in clean-preview (toolbar is hidden) -->
 		<div v-if="!is_header" class="section-preview-actions">
 			<div
@@ -122,12 +126,17 @@
 import draggable from "vuedraggable";
 import Field from "./Field.vue";
 import { computed, inject } from "vue";
+import { evaluate_visible_if } from "../../utils";
 
 const props = defineProps(["section", "is_header", "zone"]);
 
 let store = inject("$store");
 
 let is_selected = computed(() => store.selected_section.value === props.section);
+let preview_doc = computed(() => store.preview_doc.value);
+let is_section_visible = computed(() =>
+	evaluate_visible_if(props.section.visible_if, preview_doc.value)
+);
 
 let section_inline_style = computed(() => {
 	const style = {};

--- a/frappe/public/js/print_format_builder/components/editor/SectionInsert.vue
+++ b/frappe/public/js/print_format_builder/components/editor/SectionInsert.vue
@@ -1,7 +1,7 @@
 <template>
-	<div class="section-insert" @click="$emit('insert')">
+	<div class="section-insert">
 		<div class="section-insert-line"></div>
-		<button class="section-insert-btn">
+		<button class="section-insert-btn" @click="$emit('insert')">
 			<span v-html="frappe.utils.icon('plus', 'xs')"></span>
 			{{ __("Add Section") }}
 		</button>
@@ -19,7 +19,6 @@ defineEmits(["insert"]);
 	align-items: center;
 	gap: 8px;
 	height: 1.5rem;
-	cursor: pointer;
 	opacity: 0;
 	transition: opacity 0.15s ease;
 }

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -219,6 +219,24 @@
 					</div>
 				</div>
 
+				<!-- VISIBILITY section -->
+				<div class="pfb-insp-section">
+					<div class="pfb-insp-section-head" @click="toggle('t_visibility')">
+						<span class="pfb-insp-section-label">{{ __("Visibility") }}</span>
+						<span
+							class="pfb-insp-chevron"
+							:class="{ collapsed: !open.t_visibility }"
+							v-html="frappe.utils.icon('chevron-down', 'xs')"
+						></span>
+					</div>
+					<div v-show="open.t_visibility">
+						<VisibilitySection
+							v-model="selected_field.visible_if"
+							:previewDoc="preview_doc"
+						/>
+					</div>
+				</div>
+
 				<div class="pfb-insp-actions">
 					<button class="btn btn-xs btn-danger-subtle" @click="remove_field">
 						<span v-html="frappe.utils.icon('x', 'xs')"></span>
@@ -316,10 +334,11 @@
 							v-html="frappe.utils.icon('chevron-down', 'xs')"
 						></span>
 					</div>
-					<div v-show="open.f_visibility" class="pfb-insp-section-body">
-						<p class="pfb-insp-hint text-muted">
-							{{ __("Conditional visibility coming soon.") }}
-						</p>
+					<div v-show="open.f_visibility">
+						<VisibilitySection
+							v-model="selected_field.visible_if"
+							:previewDoc="preview_doc"
+						/>
 					</div>
 				</div>
 
@@ -527,10 +546,11 @@
 							v-html="frappe.utils.icon('chevron-down', 'xs')"
 						></span>
 					</div>
-					<div v-show="open.s_visibility" class="pfb-insp-section-body">
-						<p class="pfb-insp-hint text-muted">
-							{{ __("Conditional visibility coming soon.") }}
-						</p>
+					<div v-show="open.s_visibility">
+						<VisibilitySection
+							v-model="selected_section.visible_if"
+							:previewDoc="preview_doc"
+						/>
 					</div>
 				</div>
 
@@ -566,6 +586,7 @@ import draggable from "vuedraggable";
 import { useStore } from "../../stores";
 import LetterHeadZoneInspector from "./LetterHeadZoneInspector.vue";
 import Autocomplete from "../../../vue-components/Autocomplete.vue";
+import VisibilitySection from "./VisibilitySection.vue";
 
 let store = inject("$store");
 let { letterhead, layout } = useStore();
@@ -574,6 +595,7 @@ let selected_field = computed(() => store.selected_field.value);
 let selected_section = computed(() => store.selected_section.value);
 let selected_letterhead = computed(() => store.selected_letterhead.value);
 let selected_lh_footer = computed(() => store.selected_lh_footer.value);
+let preview_doc = computed(() => store.preview_doc.value);
 
 const open = ref({
 	f_field: true,
@@ -584,6 +606,7 @@ const open = ref({
 	s_visibility: false,
 	t_table: true,
 	t_columns: true,
+	t_visibility: false,
 });
 
 function toggle(key) {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -606,7 +606,7 @@ const open = ref({
 	s_visibility: false,
 	t_table: true,
 	t_columns: true,
-	t_visibility: false,
+	t_visibility: true,
 });
 
 function toggle(key) {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -321,6 +321,19 @@
 									></button>
 								</div>
 							</div>
+							<div class="pfb-insp-row">
+								<span class="pfb-insp-label">{{ __("Spacing") }}</span>
+								<div class="pfb-seg">
+									<button
+										v-for="opt in label_justify_opts"
+										:key="opt.value"
+										:class="{ active: current_label_justify === opt.value }"
+										:title="opt.title"
+										@click="selected_field.label_justify = opt.value"
+										v-html="opt.icon"
+									></button>
+								</div>
+							</div>
 						</template>
 					</div>
 				</div>
@@ -685,6 +698,7 @@ let short_fieldtype = computed(() => {
 
 let current_show_label = computed(() => selected_field.value?.show_label ?? "show");
 let current_align = computed(() => selected_field.value?.align ?? "left");
+let current_label_justify = computed(() => selected_field.value?.label_justify ?? "");
 
 const show_label_opts = [
 	{ value: "show", label: __("Show") },
@@ -701,6 +715,31 @@ const align_opts = [
 	{ value: "left", title: __("Align left"), icon: align_icons.left },
 	{ value: "center", title: __("Align center"), icon: align_icons.center },
 	{ value: "right", title: __("Align right"), icon: align_icons.right },
+];
+
+// Label-value spacing (justify-content for left-right orientation)
+const justify_icons = {
+	normal: `<svg xmlns="http://www.w3.org/2000/svg" width="28" height="12" viewBox="0 0 28 12" fill="currentColor"><rect x="1" y="2" width="9" height="8" rx="1.5" opacity="0.5"/><rect x="12" y="2" width="9" height="8" rx="1.5"/></svg>`,
+	"space-between": `<svg xmlns="http://www.w3.org/2000/svg" width="28" height="12" viewBox="0 0 28 12" fill="currentColor"><rect x="1" y="2" width="9" height="8" rx="1.5" opacity="0.5"/><rect x="18" y="2" width="9" height="8" rx="1.5"/></svg>`,
+	"space-evenly": `<svg xmlns="http://www.w3.org/2000/svg" width="28" height="12" viewBox="0 0 28 12" fill="currentColor"><rect x="4" y="2" width="8" height="8" rx="1.5" opacity="0.5"/><rect x="16" y="2" width="8" height="8" rx="1.5"/></svg>`,
+};
+
+const label_justify_opts = [
+	{
+		value: "",
+		title: __("Normal — label and value packed together"),
+		icon: justify_icons.normal,
+	},
+	{
+		value: "space-between",
+		title: __("Space between — label at start, value at end"),
+		icon: justify_icons["space-between"],
+	},
+	{
+		value: "space-evenly",
+		title: __("Space evenly — equal space around label and value"),
+		icon: justify_icons["space-evenly"],
+	},
 ];
 
 function remove_field() {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -323,16 +323,17 @@
 							</div>
 							<div class="pfb-insp-row">
 								<span class="pfb-insp-label">{{ __("Spacing") }}</span>
-								<div class="pfb-seg">
-									<button
-										v-for="opt in label_justify_opts"
-										:key="opt.value"
-										:class="{ active: current_label_justify === opt.value }"
-										:title="opt.title"
-										@click="selected_field.label_justify = opt.value"
-										v-html="opt.icon"
-									></button>
-								</div>
+								<select
+									class="pfb-insp-select"
+									:value="current_label_justify"
+									@change="selected_field.label_justify = $event.target.value"
+								>
+									<option value="">{{ __("Normal") }}</option>
+									<option value="space-between">
+										{{ __("Space Between") }}
+									</option>
+									<option value="space-evenly">{{ __("Space Evenly") }}</option>
+								</select>
 							</div>
 						</template>
 					</div>
@@ -715,31 +716,6 @@ const align_opts = [
 	{ value: "left", title: __("Align left"), icon: align_icons.left },
 	{ value: "center", title: __("Align center"), icon: align_icons.center },
 	{ value: "right", title: __("Align right"), icon: align_icons.right },
-];
-
-// Label-value spacing (justify-content for left-right orientation)
-const justify_icons = {
-	normal: `<svg xmlns="http://www.w3.org/2000/svg" width="28" height="12" viewBox="0 0 28 12" fill="currentColor"><rect x="1" y="2" width="9" height="8" rx="1.5" opacity="0.5"/><rect x="12" y="2" width="9" height="8" rx="1.5"/></svg>`,
-	"space-between": `<svg xmlns="http://www.w3.org/2000/svg" width="28" height="12" viewBox="0 0 28 12" fill="currentColor"><rect x="1" y="2" width="9" height="8" rx="1.5" opacity="0.5"/><rect x="18" y="2" width="9" height="8" rx="1.5"/></svg>`,
-	"space-evenly": `<svg xmlns="http://www.w3.org/2000/svg" width="28" height="12" viewBox="0 0 28 12" fill="currentColor"><rect x="4" y="2" width="8" height="8" rx="1.5" opacity="0.5"/><rect x="16" y="2" width="8" height="8" rx="1.5"/></svg>`,
-};
-
-const label_justify_opts = [
-	{
-		value: "",
-		title: __("Normal — label and value packed together"),
-		icon: justify_icons.normal,
-	},
-	{
-		value: "space-between",
-		title: __("Space between — label at start, value at end"),
-		icon: justify_icons["space-between"],
-	},
-	{
-		value: "space-evenly",
-		title: __("Space evenly — equal space around label and value"),
-		icon: justify_icons["space-evenly"],
-	},
 ];
 
 function remove_field() {
@@ -1172,6 +1148,22 @@ function set_padding(side, value) {
 }
 
 .pfb-insp-input:focus {
+	border-color: var(--gray-500);
+}
+
+.pfb-insp-select {
+	width: 100%;
+	padding: 5px 8px;
+	font-size: var(--text-sm);
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	background: var(--fg-color);
+	color: var(--text-color);
+	outline: none;
+	cursor: pointer;
+}
+
+.pfb-insp-select:focus {
 	border-color: var(--gray-500);
 }
 

--- a/frappe/public/js/print_format_builder/components/inspector/VisibilitySection.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/VisibilitySection.vue
@@ -1,0 +1,104 @@
+<template>
+	<div class="pfb-visibility-body">
+		<div class="pfb-insp-row--col" style="display: flex; flex-direction: column; gap: 6px">
+			<label class="pfb-insp-label">{{ __("Show when") }}</label>
+			<input
+				class="pfb-insp-input"
+				type="text"
+				:placeholder="__('e.g. doc.status == \'Paid\'')"
+				:value="modelValue"
+				@input="$emit('update:modelValue', $event.target.value)"
+			/>
+			<div v-if="modelValue && modelValue.trim()" class="pfb-vis-status-row">
+				<template v-if="previewDoc">
+					<span
+						:class="[
+							'pfb-vis-badge',
+							is_visible ? 'pfb-vis-badge--show' : 'pfb-vis-badge--hide',
+						]"
+					>
+						<span class="pfb-vis-dot"></span>
+						{{ is_visible ? __("Currently visible") : __("Currently hidden") }}
+					</span>
+				</template>
+				<span v-else class="pfb-vis-hint-no-doc">
+					{{ __("Load a document to see live status") }}
+				</span>
+			</div>
+			<p class="pfb-insp-hint text-muted">
+				{{ __("Leave blank to always show. Reference fields with") }}
+				<code>doc.fieldname</code>.
+			</p>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { evaluate_visible_if } from "../../utils";
+
+const props = defineProps(["modelValue", "previewDoc"]);
+defineEmits(["update:modelValue"]);
+
+let is_visible = computed(() => evaluate_visible_if(props.modelValue, props.previewDoc));
+</script>
+
+<style scoped>
+.pfb-visibility-body {
+	padding: 4px 14px 12px;
+}
+
+.pfb-vis-status-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.pfb-vis-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	font-size: var(--text-xs);
+	font-weight: var(--weight-medium);
+	padding: 2px 8px;
+	border-radius: var(--radius-full);
+}
+
+.pfb-vis-badge--show {
+	background: var(--green-100);
+	color: var(--green-700);
+}
+
+.pfb-vis-badge--hide {
+	background: var(--gray-100);
+	color: var(--gray-500);
+}
+
+.pfb-vis-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.pfb-vis-badge--show .pfb-vis-dot {
+	background: var(--green-500);
+}
+
+.pfb-vis-badge--hide .pfb-vis-dot {
+	background: var(--gray-400);
+}
+
+.pfb-vis-hint-no-doc {
+	font-size: var(--text-xs);
+	color: var(--text-muted);
+}
+
+.pfb-insp-hint code {
+	font-size: var(--text-xs);
+	background: var(--gray-100);
+	padding: 1px 4px;
+	border-radius: var(--radius);
+	font-family: var(--monospace-font-family, monospace);
+}
+</style>

--- a/frappe/public/js/print_format_builder/components/inspector/VisibilitySection.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/VisibilitySection.vue
@@ -94,6 +94,22 @@ let is_visible = computed(() => evaluate_visible_if(props.modelValue, props.prev
 	color: var(--text-muted);
 }
 
+.pfb-insp-input {
+	width: 100%;
+	padding: 6px 8px;
+	font-size: var(--text-sm);
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	background: var(--fg-color);
+	color: var(--text-color);
+	outline: none;
+	box-sizing: border-box;
+}
+
+.pfb-insp-input:focus {
+	border-color: var(--gray-500);
+}
+
 .pfb-insp-hint code {
 	font-size: var(--text-xs);
 	background: var(--gray-100);

--- a/frappe/public/js/print_format_builder/components/letterhead/LetterHeadEditor.vue
+++ b/frappe/public/js/print_format_builder/components/letterhead/LetterHeadEditor.vue
@@ -173,4 +173,9 @@ defineExpose({ aspect_ratio, range_input_field });
 	font-size: var(--text-sm);
 	padding: 0.5rem 0;
 }
+
+.letterhead :deep(img) {
+	max-width: 100%;
+	height: auto;
+}
 </style>

--- a/frappe/public/js/print_format_builder/print_format_builder.bundle.js
+++ b/frappe/public/js/print_format_builder/print_format_builder.bundle.js
@@ -12,7 +12,6 @@ class PrintFormatBuilder {
 		this.page.clear_custom_actions();
 
 		this.page.set_title(this.print_format);
-		this.page.set_title_sub(__("Print Format Builder"));
 		this.page.set_primary_action(__("Save"), () => {
 			this.$component.$store.save_changes();
 		});

--- a/frappe/public/js/print_format_builder/print_format_builder.bundle.js
+++ b/frappe/public/js/print_format_builder/print_format_builder.bundle.js
@@ -11,7 +11,8 @@ class PrintFormatBuilder {
 		this.page.clear_icons();
 		this.page.clear_custom_actions();
 
-		this.page.set_title(__("Editing {0}", [this.print_format]));
+		this.page.set_title(this.print_format);
+		this.page.set_title_sub(__("Print Format Builder"));
 		this.page.set_primary_action(__("Save"), () => {
 			this.$component.$store.save_changes();
 		});

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -117,6 +117,7 @@ export function getStore(print_format_name) {
 								"field_template",
 								"show_label",
 								"align",
+								"visible_if",
 							]);
 						});
 					return column;
@@ -138,6 +139,7 @@ export function getStore(print_format_name) {
 			"field_template",
 			"show_label",
 			"align",
+			"visible_if",
 		];
 		function clean_zone(zone) {
 			if (!zone || !zone.columns) return zone;

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -160,6 +160,9 @@ export function getStore(print_format_name) {
 		layout.value.header = clean_zone(layout.value.header);
 		layout.value.footer = clean_zone(layout.value.footer);
 
+		// Keep the Print Format doctype's letter_head field in sync with the
+		// builder selection so the print preview uses the correct letterhead.
+		print_format.value.letter_head = layout.value.letter_head || "";
 		print_format.value.format_data = JSON.stringify(layout.value);
 
 		frappe

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -117,6 +117,7 @@ export function getStore(print_format_name) {
 								"field_template",
 								"show_label",
 								"align",
+								"label_justify",
 								"visible_if",
 							]);
 						});
@@ -139,6 +140,7 @@ export function getStore(print_format_name) {
 			"field_template",
 			"show_label",
 			"align",
+			"label_justify",
 			"visible_if",
 		];
 		function clean_zone(zone) {

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -42,8 +42,12 @@ export function getStore(print_format_name) {
 					selected_letterhead.value = false;
 					selected_lh_footer.value = false;
 
-					// load the letter head stored in format_data, if any
-					const lh_name = layout.value?.letter_head;
+					// load the letter head: prefer format_data, fall back to the
+					// letter_head field on the Print Format doctype itself.
+					const lh_name = layout.value?.letter_head || _print_format.letter_head;
+					if (lh_name && !layout.value.letter_head) {
+						layout.value.letter_head = lh_name;
+					}
 					const load_lh = lh_name
 						? frappe.db
 								.get_doc("Letter Head", lh_name)

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -42,12 +42,8 @@ export function getStore(print_format_name) {
 					selected_letterhead.value = false;
 					selected_lh_footer.value = false;
 
-					// load the letter head: prefer format_data, fall back to the
-					// letter_head field on the Print Format doctype itself.
-					const lh_name = layout.value?.letter_head || _print_format.letter_head;
-					if (lh_name && !layout.value.letter_head) {
-						layout.value.letter_head = lh_name;
-					}
+					// load the letter head stored in format_data, if any
+					const lh_name = layout.value?.letter_head;
 					const load_lh = lh_name
 						? frappe.db
 								.get_doc("Letter Head", lh_name)
@@ -160,9 +156,6 @@ export function getStore(print_format_name) {
 		layout.value.header = clean_zone(layout.value.header);
 		layout.value.footer = clean_zone(layout.value.footer);
 
-		// Keep the Print Format doctype's letter_head field in sync with the
-		// builder selection so the print preview uses the correct letterhead.
-		print_format.value.letter_head = layout.value.letter_head || "";
 		print_format.value.format_data = JSON.stringify(layout.value);
 
 		frappe

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -283,6 +283,16 @@ export function sanitize_html(html) {
 	return root.innerHTML;
 }
 
+export function evaluate_visible_if(expr, doc) {
+	if (!expr || !expr.trim()) return true;
+	try {
+		// eslint-disable-next-line no-new-func
+		return !!new Function("doc", `return (${expr})`)(doc);
+	} catch {
+		return true;
+	}
+}
+
 export function get_image_dimensions(src) {
 	return new Promise((resolve) => {
 		let img = new Image();

--- a/frappe/templates/print_format/macros.html
+++ b/frappe/templates/print_format/macros.html
@@ -1,6 +1,8 @@
 {% macro render_field(df, doc) %}
+{%- if not df.get('_hidden') -%}
 {%- set value = doc.get(df.fieldname) -%}
 {% include ['templates/print_format/macros/' + df.renderer + '.html', 'templates/print_format/macros/Data.html'] ignore missing %}
+{%- endif -%}
 {% endmacro %}
 
 {% macro field_attributes(df) %}

--- a/frappe/templates/print_format/macros/Data.html
+++ b/frappe/templates/print_format/macros/Data.html
@@ -3,7 +3,8 @@
 {%- set _align = df.align if df.align else '' -%}
 {%- set _orientation = df.section.field_orientation or '' -%}
 {%- set _inline = (_show_label == 'inline') or (_orientation == 'left-right') -%}
-<div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}" {{ field_attributes(df) }}>
+{%- set _justify = df.label_justify if df.label_justify else '' -%}
+<div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' %} field-justify-{{ _justify }}{% endif %}" {{ field_attributes(df) }}>
 	{%- block label -%}
 	{%- if _show_label != 'hide' -%}
 	<div class="label">{{ _(df.label) }}</div>

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -158,13 +158,25 @@ body {
 	text-align: right;
 }
 
-/* In left-right orientation, alignment applies to the whole flex row */
+/* In left-right orientation, alignment moves the whole label+value group */
 .field.left-right.field-align-right {
 	justify-content: flex-end;
 }
 
+.field.left-right.field-align-right .label,
+.field.left-right.field-align-right .value {
+	width: auto;
+	flex: none;
+}
+
 .field.left-right.field-align-center {
 	justify-content: center;
+}
+
+.field.left-right.field-align-center .label,
+.field.left-right.field-align-center .value {
+	width: auto;
+	flex: none;
 }
 
 /* Label-value spacing in left-right orientation */

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -167,6 +167,31 @@ body {
 	justify-content: center;
 }
 
+/* Label-value spacing in left-right orientation */
+.field.left-right.field-justify-space-between {
+	justify-content: space-between;
+}
+
+.field.left-right.field-justify-space-between .label,
+.field.left-right.field-justify-space-between .value {
+	width: auto;
+	flex: 0;
+}
+
+.field.left-right.field-justify-space-between .value {
+	text-align: right;
+}
+
+.field.left-right.field-justify-space-evenly {
+	justify-content: space-evenly;
+}
+
+.field.left-right.field-justify-space-evenly .label,
+.field.left-right.field-justify-space-evenly .value {
+	width: auto;
+	flex: 0;
+}
+
 /* Child table */
 .child-table {
 	margin-top: 0.5rem;

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -175,7 +175,7 @@ body {
 .field.left-right.field-justify-space-between .label,
 .field.left-right.field-justify-space-between .value {
 	width: auto;
-	flex: 0;
+	flex: none;
 }
 
 .field.left-right.field-justify-space-between .value {
@@ -189,7 +189,7 @@ body {
 .field.left-right.field-justify-space-evenly .label,
 .field.left-right.field-justify-space-evenly .value {
 	width: auto;
-	flex: 0;
+	flex: none;
 }
 
 /* Child table */

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -158,51 +158,25 @@ body {
 	text-align: right;
 }
 
-/* In left-right orientation, alignment moves the whole label+value group */
-.field.left-right.field-align-right {
-	justify-content: flex-end;
-}
-
+/* In left-right orientation, alignment/spacing variants reset fixed widths so
+   justify-content can actually reposition the label+value pair. */
 .field.left-right.field-align-right .label,
-.field.left-right.field-align-right .value {
-	width: auto;
-	flex: none;
-}
-
-.field.left-right.field-align-center {
-	justify-content: center;
-}
-
+.field.left-right.field-align-right .value,
 .field.left-right.field-align-center .label,
-.field.left-right.field-align-center .value {
-	width: auto;
-	flex: none;
-}
-
-/* Label-value spacing in left-right orientation */
-.field.left-right.field-justify-space-between {
-	justify-content: space-between;
-}
-
+.field.left-right.field-align-center .value,
 .field.left-right.field-justify-space-between .label,
-.field.left-right.field-justify-space-between .value {
-	width: auto;
-	flex: none;
-}
-
-.field.left-right.field-justify-space-between .value {
-	text-align: right;
-}
-
-.field.left-right.field-justify-space-evenly {
-	justify-content: space-evenly;
-}
-
+.field.left-right.field-justify-space-between .value,
 .field.left-right.field-justify-space-evenly .label,
 .field.left-right.field-justify-space-evenly .value {
 	width: auto;
 	flex: none;
 }
+
+.field.left-right.field-align-right { justify-content: flex-end; }
+.field.left-right.field-align-center { justify-content: center; }
+.field.left-right.field-justify-space-between { justify-content: space-between; }
+.field.left-right.field-justify-space-between .value { text-align: right; }
+.field.left-right.field-justify-space-evenly { justify-content: space-evenly; }
 
 /* Child table */
 .child-table {

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -42,6 +42,7 @@
 	{%- endif -%}
 	{%- endif -%}
 	{% for section in layout.sections %}
+	{%- if section.get('_hidden') -%}{%- continue -%}{%- endif -%}
 	{#- Skip labelled sections where every data field is empty -#}
 	{%- set ns = namespace(has_content=false) -%}
 	{%- for column in section.columns -%}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -42,7 +42,7 @@
 	{%- endif -%}
 	{%- endif -%}
 	{% for section in layout.sections %}
-	{%- if section.get('_hidden') -%}{%- continue -%}{%- endif -%}
+	{%- if not section.get('_hidden') -%}
 	{#- Skip labelled sections where every data field is empty -#}
 	{%- set ns = namespace(has_content=false) -%}
 	{%- for column in section.columns -%}
@@ -90,6 +90,7 @@
 			{% endfor %}
 		</div>
 	</div>
+	{%- endif -%}
 	{%- endif -%}
 	{% endfor %}
 	{#- Chrome PDF: layout.footer rendered once at the end of body -#}

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -228,6 +228,7 @@ class PrintFormatGenerator:
 {%- for column in section.columns %}
 <div class="column col">
 {%- for df in column.get('fields', []) -%}
+{%- if not df.get('_hidden') -%}
 {%- if df.fieldtype == 'HTML' and df.html -%}
 <div class="custom-html">{{ frappe.render_template(df.html, {'doc': doc}) }}</div>
 {%- elif df.fieldtype == 'Spacer' -%}
@@ -241,6 +242,7 @@ class PrintFormatGenerator:
 {%- if df.show_label != 'hide' %}<div class="label">{{ _(df.label or df.fieldname) }}</div>{%- endif -%}
 <div class="value">{{ doc.get_formatted(df.fieldname) }}</div>
 </div>
+{%- endif -%}
 {%- endif -%}
 {%- endif -%}
 {%- endfor -%}

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -281,9 +281,20 @@ class PrintFormatGenerator:
 
 	def set_field_renderers(self, layout):
 		renderers = {"HTML Editor": "HTML", "Markdown Editor": "Markdown"}
+		eval_locals = {"doc": self.doc}
 		for section in layout["sections"]:
+			if section.get("visible_if"):
+				try:
+					section["_hidden"] = not frappe.safe_eval(section["visible_if"], eval_locals)
+				except Exception:
+					section["_hidden"] = False
 			for column in section["columns"]:
 				for df in column["fields"]:
+					if df.get("visible_if"):
+						try:
+							df["_hidden"] = not frappe.safe_eval(df["visible_if"], eval_locals)
+						except Exception:
+							df["_hidden"] = False
 					fieldtype = df["fieldtype"]
 					df["renderer"] = renderers.get(fieldtype) or fieldtype.replace(" ", "")
 					df["section"] = section
@@ -294,6 +305,11 @@ class PrintFormatGenerator:
 			if isinstance(zone, dict) and "columns" in zone:
 				for column in zone.get("columns", []):
 					for df in column.get("fields", []):
+						if df.get("visible_if"):
+							try:
+								df["_hidden"] = not frappe.safe_eval(df["visible_if"], eval_locals)
+							except Exception:
+								df["_hidden"] = False
 						fieldtype = df.get("fieldtype", "Data")
 						df["renderer"] = renderers.get(fieldtype) or fieldtype.replace(" ", "")
 						df["section"] = zone


### PR DESCRIPTION
**feat**
- Conditional visibility for fields and sections via `visible_if` expression

https://github.com/user-attachments/assets/bf970cae-9d02-4711-9029-00efe3d1ee1b



- Label-value spacing control for left-right field orientation

https://github.com/user-attachments/assets/9f920b96-b099-4091-b30d-d97880b34636



**fix**
- Letterhead syncs correctly when switching print formats in print preview
- Format name shown in page title and breadcrumb
- Letterhead image constrained to container width
- Column widths applied in builder table preview
- `visible_if` persisted in saved layout and respected in header/footer zones
- `flex:0` no longer collapses value width in spacing modes
- Align applies to whole label+value pair in left-right mode


`no-docs`