### PR TITLE
fix(ui): import labeling primitives from frappe-ui/experimental

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -47,7 +47,7 @@
     "vuedraggable": "^4.1.0"
   },
   "peerDependencies": {
-    "frappe-ui": "*",
+    "frappe-ui": ">=1.0.0-beta.16",
     "vue": ">=3.3.0",
     "vue-router": "^4.1.5"
   }

--- a/ui/src/components/FormLayout/fields/CodeEditorField.vue
+++ b/ui/src/components/FormLayout/fields/CodeEditorField.vue
@@ -116,7 +116,7 @@
 // `doc` (Frappe JSON/Code fields store strings) — the contract is unchanged.
 import { computed, onBeforeUnmount, onMounted, ref, useId, watch } from "vue";
 import { Button } from "frappe-ui";
-import { InputLabel, InputDescription } from "frappe-ui/internals";
+import { InputLabel, InputDescription } from "frappe-ui/experimental";
 import { CodeEditor, CodePreview } from "frappe-ui/code-editor";
 import { fieldtypeToLanguage } from "./fieldtypeToLanguage";
 import type { FieldComponentEmits, FieldComponentProps } from "../types";

--- a/ui/src/components/FormLayout/fields/ImageField.vue
+++ b/ui/src/components/FormLayout/fields/ImageField.vue
@@ -43,7 +43,7 @@
 // injected doc; falls back to its own `modelValue` if no `options` is set. No
 // upload, no emit.
 import { computed, inject, ref, useId } from "vue";
-import { InputLabel, InputDescription } from "frappe-ui/internals";
+import { InputLabel, InputDescription } from "frappe-ui/experimental";
 import { DocKey } from "../types";
 import type { FieldComponentProps } from "../types";
 

--- a/ui/src/components/Grid/Grid.vue
+++ b/ui/src/components/Grid/Grid.vue
@@ -219,14 +219,14 @@
 <script setup lang="ts" generic="T extends GridColumn">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { Button, Checkbox } from "frappe-ui";
-import { InputLabel, InputDescription, InputError, useInputLabeling } from "frappe-ui/internals";
+import { InputLabel, InputDescription, InputError, useInputLabeling } from "frappe-ui/experimental";
 // @ts-ignore — vuedraggable ships no bundled types
 import Draggable from "vuedraggable";
 import type { GridCellSlotProps, GridColumn, GridEmits } from "./types";
 
 // Mirrors frappe-ui's `FrappeUIError` (an `Error` whose `messages?: string[]`
 // render as stacked lines). Declared locally — the type isn't re-exported from
-// `frappe-ui/internals` — and is structurally compatible with what the composable
+// `frappe-ui/experimental` — and is structurally compatible with what the composable
 // expects.
 interface GridError extends Error {
 	messages?: string[];

--- a/ui/src/components/Grid/Grid.vue
+++ b/ui/src/components/Grid/Grid.vue
@@ -219,7 +219,12 @@
 <script setup lang="ts" generic="T extends GridColumn">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { Button, Checkbox } from "frappe-ui";
-import { InputLabel, InputDescription, InputError, useInputLabeling } from "frappe-ui/experimental";
+import {
+	InputLabel,
+	InputDescription,
+	InputError,
+	useInputLabeling,
+} from "frappe-ui/experimental";
 // @ts-ignore — vuedraggable ships no bundled types
 import Draggable from "vuedraggable";
 import type { GridCellSlotProps, GridColumn, GridEmits } from "./types";

--- a/ui/src/components/Phone/Phone.vue
+++ b/ui/src/components/Phone/Phone.vue
@@ -129,7 +129,7 @@
 
 <script setup lang="ts">
 import { Combobox, ItemListRow } from "frappe-ui";
-import { inputFontSizeClasses, useInputLabeling } from "frappe-ui/internals";
+import { inputFontSizeClasses, useInputLabeling } from "frappe-ui/experimental";
 import { computed, nextTick, onMounted, reactive, ref, useAttrs, useSlots, watch } from "vue";
 import type { Country, PhoneInputProps, PhoneInputSlots } from "./types";
 import {


### PR DESCRIPTION
## Why

frappe-ui renamed its unstable `frappe-ui/internals` subpath to `frappe-ui/experimental` in [frappe/frappe-ui#787](https://github.com/frappe/frappe-ui/pull/787). That is a breaking change — `frappe-ui/internals` no longer resolves — so every consumer importing from it must move to the new path.

## What

Updates every component that imports from the old subpath:

- `ui/src/components/Grid/Grid.vue` — `InputLabel`, `InputDescription`, `InputError`, `useInputLabeling`
- `ui/src/components/Phone/Phone.vue` — `inputFontSizeClasses`, `useInputLabeling`
- `ui/src/components/FormLayout/fields/CodeEditorField.vue` — `InputLabel`, `InputDescription`
- `ui/src/components/FormLayout/fields/ImageField.vue` — `InputLabel`, `InputDescription`

The exports are functionally identical; only the import path changed (`frappe-ui/internals` → `frappe-ui/experimental`).

## Note

This requires a `frappe-ui` version that includes #787 (the rename). Until the bundled `frappe-ui` is bumped to such a release, `frappe-ui/experimental` will not resolve at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)