### PR TITLE
fix: dark theme preview in theme switcher

### DIFF
--- a/frappe/public/scss/desk/theme_switcher.scss
+++ b/frappe/public/scss/desk/theme_switcher.scss
@@ -91,6 +91,11 @@
 
 // TODO: Replace with better alternative
 [data-theme="dark"] {
+	--bg-color: var(--surface-base);
+	--card-bg: var(--surface-base);
+	--subtle-accent: var(--surface-gray-1);
+	--text-light: var(--ink-gray-5);
+
 	.background {
 		border: 1px solid var(--gray-500);
 	}


### PR DESCRIPTION
Resolve: #40384

**Before:**

<img width="1011" height="460" alt="image" src="https://github.com/user-attachments/assets/65f86fd2-3e76-4ed2-b1d7-c7b7849367d6" />


**After:**

<img width="696" height="293" alt="image" src="https://github.com/user-attachments/assets/5dba6535-4fdb-48eb-843b-08cda656a1a5" />
