### PR TITLE
feat(permissions): support pypika terms in permission_query_conditions

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1699,7 +1699,7 @@ class Engine:
 			tables.append(join.item.get_sql())
 		return list(set(tables))
 
-	def get_permission_query_conditions(self, doctype: str | None = None) -> list["RawCriterion"]:
+	def get_permission_query_conditions(self, doctype: str | None = None) -> list["Criterion"]:
 		"""Add permission query conditions from hooks and server scripts"""
 		from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
 
@@ -1710,7 +1710,9 @@ class Engine:
 
 		for method in condition_methods:
 			if c := frappe.call(frappe.get_attr(method), self.user, doctype=doctype):
-				conditions.append(RawCriterion(f"({c})"))
+				# Hooks may return a raw SQL string or a pypika term. A term already
+				# participates in `Criterion.all`/`get_sql`, so only strings need wrapping.
+				conditions.append(RawCriterion(f"({c})") if isinstance(c, str) else c)
 
 		active_child_tables = []
 		current_tables = self.get_queried_tables()

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1170,6 +1170,11 @@ from {tables}
 		condition_methods = hooks.get(self.doctype, []) + hooks.get("*", [])
 		for method in condition_methods:
 			if c := frappe.call(frappe.get_attr(method), self.user, doctype=self.doctype):
+				# Hooks may return a raw SQL string or a pypika term. This path builds a
+				# string WHERE clause, so render any term to namespaced SQL using the
+				# active dialect's identifier quote char.
+				if not isinstance(c, str):
+					c = self._render_permission_criterion(c)
 				conditions.append(c)
 
 		active_child_tables = []
@@ -1188,6 +1193,23 @@ from {tables}
 				conditions.append(condition)
 
 		return " and ".join(conditions) if conditions else ""
+
+	def _render_permission_criterion(self, criterion) -> str:
+		"""Render a pypika permission criterion to a namespaced SQL string.
+
+		The legacy query path concatenates conditions into a single WHERE string, so any
+		embedded value must be inlined. We collect values via a parameter wrapper and inline
+		them with `frappe.db.escape` (the driver's escaping) rather than pypika's bare
+		quote-doubling, which is unsafe on MariaDB where backslash is an escape character.
+		"""
+		from frappe.query_builder.terms import NamedParameterWrapper
+
+		quote_char = "`" if frappe.db.db_type == "mariadb" else '"'
+		param_wrapper = NamedParameterWrapper()
+		sql = criterion.get_sql(with_namespace=True, quote_char=quote_char, param_wrapper=param_wrapper)
+		for key, value in param_wrapper.get_parameters().items():
+			sql = sql.replace(f"%({key})s", frappe.db.escape(value))
+		return sql
 
 	def set_order_by(self, args):
 		if self.order_by and self.order_by != "KEEP_DEFAULT_ORDERING":

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1039,6 +1039,56 @@ class TestDBQuery(IntegrationTestCase):
 
 		self.assertTrue(dashboard_settings)
 
+	def test_permission_query_condition_supports_pypika(self):
+		"""The legacy DatabaseQuery path must also accept a pypika criterion from a hook."""
+		from frappe.desk.doctype.dashboard_settings.dashboard_settings import (
+			create_dashboard_settings,
+		)
+		from frappe.model.db_query import DatabaseQuery
+
+		self.user = "test@example.com"
+		create_dashboard_settings(self.user)
+
+		with self.patch_hooks(
+			{
+				"permission_query_conditions": {
+					"Dashboard Settings": ["frappe.tests.test_query.test_permission_hook_criterion"]
+				}
+			}
+		):
+			db_query = DatabaseQuery("Dashboard Settings", user=self.user)
+			conditions = db_query.get_permission_query_conditions()
+
+			# The criterion must be rendered to a namespaced SQL string (the `tab`-prefixed
+			# table name is dialect-independent; only the surrounding quote char differs).
+			self.assertIn("tabDashboard Settings", conditions)
+			self.assertIn("name", conditions)
+
+			# And the rendered string must be valid SQL that selects the user's record.
+			rows = frappe.db.sql(
+				f"SELECT name FROM `tabDashboard Settings` WHERE {conditions}",
+				as_dict=True,
+			)
+			self.assertTrue(any(r.name == self.user for r in rows))
+
+	def test_permission_criterion_escapes_values_safely(self):
+		"""Values inside a pypika permission criterion must be driver-escaped, not inlined raw.
+
+		pypika's bare quote-doubling is unsafe on MariaDB (backslash is an escape char), so the
+		legacy path must route values through frappe.db.escape. A backslash must be doubled and a
+		quote-breakout attempt must stay inside the string literal.
+		"""
+		from frappe.model.db_query import DatabaseQuery
+
+		payload = "back\\slash' OR 1=1 -- "
+		Dashboard = frappe.qb.DocType("Dashboard Settings")
+		rendered = DatabaseQuery("Dashboard Settings")._render_permission_criterion(Dashboard.name == payload)
+
+		# The value must appear exactly as frappe.db.escape produces it (driver-quality escaping:
+		# backslash doubled, quote escaped) — never the raw breakout sequence.
+		self.assertIn(frappe.db.escape(payload), rendered)
+		self.assertNotIn("slash' OR", rendered)
+
 	def test_virtual_doctype(self):
 		"""Test that virtual doctypes can be queried using get_all"""
 

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -1239,6 +1239,28 @@ class TestQuery(IntegrationTestCase):
 		frappe.clear_cache()
 		frappe.hooks.permission_query_conditions = original_hooks
 
+	def test_permission_query_condition_supports_pypika(self):
+		"""A permission_query_conditions hook may return a pypika criterion, not just a SQL string."""
+		from frappe.desk.doctype.dashboard_settings.dashboard_settings import create_dashboard_settings
+
+		self.user = "test@example.com"
+		create_dashboard_settings(self.user)
+
+		with self.patch_hooks(
+			{
+				"permission_query_conditions": {
+					"Dashboard Settings": ["frappe.tests.test_query.test_permission_hook_criterion"]
+				}
+			}
+		):
+			query = frappe.qb.get_query("Dashboard Settings", user=self.user, ignore_permissions=False)
+
+			# The criterion must render to valid SQL that matches the user's own record.
+			# Before pypika support, the term was str()-coerced into a string-literal
+			# comparison (e.g. "name"='...') that never matched, so the row went missing.
+			names = [d.name for d in query.run(as_dict=True)]
+			self.assertIn(self.user, names)
+
 	def test_link_field_target_permission(self):
 		"""Test that accessing link_field.target_field respects target field's permlevel."""
 		target_dt_name = "TargetDocForLinkPerm"
@@ -2730,3 +2752,10 @@ class TestQuery(IntegrationTestCase):
 # This function is used as a permission query condition hook
 def test_permission_hook_condition(user):
 	return "`tabDashboard Settings`.`name` = 'Administrator'"
+
+
+# This hook returns a pypika criterion instead of a raw SQL string.
+# Permission query conditions must accept both forms.
+def test_permission_hook_criterion(user):
+	DashboardSettings = frappe.qb.DocType("Dashboard Settings")
+	return DashboardSettings.name == user


### PR DESCRIPTION
## What this does

Today, a `permission_query_conditions` hook can only return a SQL string. If you build that condition with the query builder (`frappe.qb`), you have to turn it back into a string yourself. That means manual escaping and hardcoding the quote character, which can break on different databases.

This change lets a hook return a query builder term directly. Strings still work exactly as before.

## Example

Before:

```python
def todo_query_conditions(user, doctype=None):
    return f"`tabToDo`.`owner` = {frappe.db.escape(user)}"
```

After:

```python
def todo_query_conditions(user, doctype=None):
    ToDo = frappe.qb.DocType("ToDo")
    return ToDo.owner == user
```

The framework now handles the SQL, the quoting, and the database differences for you.

## How it works

There are two query paths, and each handles the term differently:

- New `frappe.qb` engine: the term is added to the query as-is, so the query builder renders it with the right table names and quoting.
- Legacy `DatabaseQuery`: this path builds a SQL string, so the term is rendered to a string first (with table names) before it's added.

## Tests

Two tests, both written first (failing before the change):

- `test_query.py` covers the new `frappe.qb` path.
- `test_db_query.py` covers the legacy path.

The existing string-based permission tests still pass, so this is fully backward compatible.

## Docs

no-docs — this extends an existing hook's accepted return type and is fully backward compatible; the hook's reference docs can be updated separately.