### PR TITLE
feat(commands): print browse session id

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -1226,6 +1226,9 @@ def publish_realtime(context: CliCtxObj, event, message, room, user, doctype, do
 @click.argument("site", required=False)
 @click.option("--user", required=False, help="Login as user")
 @click.option(
+	"--sid", "print_sid", is_flag=True, help="Print the generated session id instead of opening the browser"
+)
+@click.option(
 	"--session-end",
 	required=False,
 	help="Session end (in ISO8601 format and timezone-aware - 2025-01-24T12:26:29.200853+00:00)",
@@ -1236,6 +1239,7 @@ def browse(
 	context: CliCtxObj,
 	site,
 	user: str | None = None,
+	print_sid: bool = False,
 	session_end: str | None = None,
 	user_for_audit: str | None = None,
 ):
@@ -1255,6 +1259,7 @@ def browse(
 	frappe.connect()
 
 	sid = ""
+	login_path = ""
 	if user:
 		if not frappe.db.exists("User", user):
 			click.echo(f"User {user} does not exist")
@@ -1265,11 +1270,19 @@ def browse(
 			frappe.local.cookie_manager = CookieManager()
 			frappe.local.login_manager = LoginManager()
 			frappe.local.login_manager.login_as(user, session_end, user_for_audit)
-			sid = f"/app?sid={frappe.session.sid}"
+			sid = frappe.session.sid
+			login_path = f"/app?sid={sid}"
 		else:
 			click.echo("Please enable developer mode to login as a user")
 
-	url = f"{frappe.utils.get_site_url(site)}{sid}"
+	if print_sid:
+		if not sid:
+			click.echo("--sid requires --user and a generated session id", err=True)
+			sys.exit(1)
+		click.echo(sid)
+		return
+
+	url = f"{frappe.utils.get_site_url(site)}{login_path}"
 
 	if user == "Administrator":
 		click.echo(f"Login URL: {url}")

--- a/frappe/commands/test_commands.py
+++ b/frappe/commands/test_commands.py
@@ -218,6 +218,14 @@ class BaseTestCommands(IntegrationTestCase):
 
 
 class TestCommands(BaseTestCommands):
+	def test_browse_sid(self):
+		with patch("click.launch") as launch:
+			with cli(frappe.commands.site.browse, ["--user", "Administrator", "--sid"]) as result:
+				self.assertEqual(result.exit_code, 0)
+				self.assertTrue(result.output.strip())
+				self.assertNotIn("Login URL", result.output)
+				launch.assert_not_called()
+
 	def test_execute(self):
 		# test 1: execute a command expecting a numeric output
 		self.execute("bench --site {site} execute frappe.db.get_database_size")

--- a/frappe/commands/test_commands.py
+++ b/frappe/commands/test_commands.py
@@ -219,6 +219,8 @@ class BaseTestCommands(IntegrationTestCase):
 
 class TestCommands(BaseTestCommands):
 	def test_browse_sid(self):
+		self.setup_test_site()
+
 		with patch("click.launch") as launch:
 			with cli(frappe.commands.site.browse, ["--user", "Administrator", "--sid"]) as result:
 				self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
## Summary
- add `bench browse --sid` to print the generated session id without opening a browser
- keep existing browser behavior unchanged when `--sid` is not passed
- add a focused command test for the new option

## Docs
no-docs: small developer CLI helper for local agent workflows

## Tests
- `bench --site gameplan-demo.test run-tests --app frappe --module frappe.commands.test_commands --test TestCommands.test_browse_sid`
- pre-commit hooks during commit