### PR TITLE
fix: slow select all / unselect all in multicheck with many options

### DIFF
--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -125,15 +125,17 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 	}
 
 	select_all(deselect = false) {
-		$(this.wrapper)
-			.find(`:checkbox`)
-			.prop("checked", function () {
-				if (this.disabled) {
-					return this.checked;
-				}
-				return deselect;
-			})
-			.trigger("click");
+		this.selected_options = [];
+		this.options.forEach((option) => {
+			const checkbox = option.$checkbox.find(":checkbox").get(0);
+			if (!checkbox.disabled) {
+				checkbox.checked = !deselect;
+			}
+			if (checkbox.checked) {
+				this.selected_options.push(option.value);
+			}
+		});
+		this.df.on_change && this.df.on_change();
 	}
 
 	select_options(selected_options) {


### PR DESCRIPTION
## Problem

Selecting or unselecting all options in a `MultiCheck` field (for example, the role picker on the User form) became noticeably slower as the number of options increased. With around 500 roles, the operation could take several seconds.

The bottleneck was in `select_all()`. It updated each checkbox individually and triggered a synthetic click for every one. Since each click invoked the change handler, `df.on_change` ran once per checkbox. In the role editor, that meant repeatedly calling `set_roles_in_table()`, which already iterates over all rows, resulting in a large amount of unnecessary work.

## Fix

`select_all()` now updates the checkbox state directly in a single pass, rebuilds `selected_options` inline, and calls `on_change` only once after all checkboxes have been updated.

Disabled checkboxes retain their existing state, so the behavior remains the same for all `MultiCheck` consumers. The only change is that the redundant per-checkbox change events have been eliminated, making **Select All** and **Unselect All** scale much better for large option sets.

## Behaviour


https://github.com/user-attachments/assets/2e3dc431-7209-409f-a27d-60d450e10b96


---

Closes #38222