### PR TITLE
fix(Link): re-evaluate link_filters per search without breaking doc-based get_query

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -781,11 +781,6 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			return obj;
 		};
 
-		// apply link field filters
-		if (this.df.link_filters && !!this.df.link_filters.length) {
-			this.apply_link_field_filters();
-		}
-
 		if (this.get_query || this.df.get_query) {
 			var get_query = this.get_query || this.df.get_query;
 			if ($.isPlainObject(get_query)) {
@@ -847,22 +842,14 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			if (!args.filters) args.filters = {};
 			$.extend(args.filters, this.df.filters);
 		}
+
+		if (this.df.link_filters && !!this.df.link_filters.length) {
+			args.filters = { ...(args.filters || {}), ...this.apply_link_field_filters() };
+		}
 	}
 
 	apply_link_field_filters() {
-		let filters = this.parse_filters(JSON.parse(this.df.link_filters));
-		// take filters from the link field and add to the query
-
-		const query_filters = this.get_query?.()?.filters || {};
-		if (query_filters) {
-			filters = { ...query_filters, ...filters };
-		}
-
-		this.get_query = function () {
-			return {
-				filters,
-			};
-		};
+		return this.parse_filters(JSON.parse(this.df.link_filters));
 	}
 
 	parse_filters(link_filters) {

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -849,7 +849,12 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 	}
 
 	apply_link_field_filters() {
-		return this.parse_filters(JSON.parse(this.df.link_filters));
+		try {
+			return this.parse_filters(JSON.parse(this.df.link_filters));
+		} catch (e) {
+			console.error("Invalid link_filters JSON:", this.df.link_filters, e);
+			return {};
+		}
 	}
 
 	parse_filters(link_filters) {


### PR DESCRIPTION
### Problem
A Link field that has both a Customize-Form **Link Filter** and a programmatic
`frm.set_query` reading `doc` throws as soon as the dropdown is opened:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'company')
```

Reproduced on a custom DocType (a Customer link + `set_query` reading `doc.customer_type`)
and on a standard one (Production Plan `for_warehouse`, whose query reads `doc.company`).
The link control breaks → awesomplete never opens → empty dropdown.

A second, related symptom: even without a crash, `link_filters` using `eval:` stop
refreshing after the first search — changing the dependency field still shows results
for the old value until the form is reloaded (#39797).

### Cause
`apply_link_field_filters()` (in `set_custom_query`) did two harmful things:
1. Called the existing programmatic `get_query()` with **no `doc`** (`this.get_query?.()`),
   so any `set_query` callback that dereferences `doc` throws.
2. **Overwrote** `this.get_query` with a frozen `{ filters }` closure computed once, so
   `eval:` link_filters never re-evaluated on later searches.

### Fix
Make `apply_link_field_filters()` pure — it just returns the parsed link_filters — and
merge them into `args.filters` at the end of `set_custom_query`, on every search:

```js
if (this.df.link_filters && !!this.df.link_filters.length) {
    args.filters = { ...(args.filters || {}), ...this.apply_link_field_filters() };
}

apply_link_field_filters() {
    return this.parse_filters(JSON.parse(this.df.link_filters));
}
```

The early `apply_link_field_filters()` call at the top of `set_custom_query` is removed.

Net effect:
- No no-arg `get_query()` call → `doc`-based `set_query` callbacks no longer crash.
- `get_query` is never overwritten → the programmatic query (incl. custom server `query`
  methods) keeps running with the real `doc`.
- link_filters are re-parsed each search → `eval:` filters refresh on dependency change.
- link_filters are spread last → they **win on key collision**, preserving the precedence
  established in #39942, while non-conflicting `get_query` / `df.filters` keys are kept.

### Testing
Verified on `develop`:
- `set_query` reading `doc` + Link Filter → no crash; callback receives the real `doc`.
- Key collision → Link Filter wins; non-conflicting filters from both sides preserved.
- `set_query` returning a custom server `query` method → `args.query` preserved, link_filters
  delivered in `args.filters`.
- Standard Production Plan `for_warehouse` → no crash; filters merged.
- `eval: doc.project` link_filter re-filters correctly on dependency change.

### Related
Fixes #39797. Supersedes the structural part of #39935 (closed) while keeping #39942's
link_filters-win precedence. Regression originally introduced in #39231.

**Support Ticket**: [71149](https://support.frappe.io/helpdesk/tickets/71149 )

### Before Fix
[Screencast from 2026-06-30 10-56-52.webm](https://github.com/user-attachments/assets/f6035371-a86b-4add-a27e-838830adb79a)

### After Fix
[Screencast from 2026-06-30 10-51-59.webm](https://github.com/user-attachments/assets/d4a4af13-0cb4-4e36-b2f7-e883e6e71ab6)

