### PR TITLE
fix: multiple similar files shown in the upload dialog's library tab

### DIFF
--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -39,7 +39,9 @@ def get_attached_images(doctype: str, names: list[str] | str) -> frappe._dict:
 
 
 @frappe.whitelist()
-def get_files_in_folder(folder: str, start: int = 0, page_length: int = 20) -> dict:
+def get_files_in_folder(
+	folder: str, start: int = 0, page_length: int = 20, seen_files: list | str | None = None
+) -> dict:
 	fields = ["name", "file_name", "file_url", "is_folder", "modified", "is_private"]
 
 	files = frappe.get_list(
@@ -50,14 +52,15 @@ def get_files_in_folder(folder: str, start: int = 0, page_length: int = 20) -> d
 		limit=page_length + 1,
 	)
 
-	seen_files = set()
+	seen_files = {tuple(file_tuple) for file_tuple in frappe.parse_json(seen_files or "[]")}
 	deduped = []
-	for file in files:
+	for file in files[:page_length]:
 		file_tuple = (file.file_url, file.file_name)
 		if file_tuple not in seen_files and file.name != "Home/Attachments":
 			seen_files.add(file_tuple)
 			deduped.append(file)
 
+	attachment_folder = None
 	if folder == "Home" and start == 0:
 		attachment_folder = frappe.db.get_value(
 			"File",
@@ -67,8 +70,12 @@ def get_files_in_folder(folder: str, start: int = 0, page_length: int = 20) -> d
 		)
 		if attachment_folder:
 			deduped.insert(0, attachment_folder)
-
-	return {"files": deduped[:page_length], "has_more": len(files) > page_length}
+	limit = page_length + 1 if attachment_folder else page_length
+	return {
+		"files": deduped[:limit],
+		"has_more": len(files) > page_length,
+		"seen_files": [list(file_tuple) for file_tuple in seen_files],
+	}
 
 
 @frappe.whitelist()
@@ -76,15 +83,16 @@ def get_files_by_search_text(text: str) -> list[dict]:
 	if not text:
 		return []
 
-	text = "%" + cstr(text).lower() + "%"
+	text = cstr(text).lower()
+	like_text = f"%{text}%"
 	files = frappe.get_list(
 		"File",
 		fields=["name", "file_name", "file_url", "is_folder", "modified", "is_private"],
 		filters={"is_folder": False},
 		or_filters={
-			"file_name": ("like", text),
-			"file_url": text,
-			"name": ("like", text),
+			"file_name": ("like", like_text),
+			"file_url": ("=", text),
+			"name": ("like", like_text),
 		},
 		order_by="creation desc",
 		limit=20,

--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -40,7 +40,7 @@ def get_attached_images(doctype: str, names: list[str] | str) -> frappe._dict:
 
 @frappe.whitelist()
 def get_files_in_folder(folder: str, start: int = 0, page_length: int = 20) -> dict:
-	fields = ["name", "file_name", "file_url", "is_folder", "modified"]
+	fields = ["name", "file_name", "file_url", "is_folder", "modified", "is_private"]
 
 	files = frappe.get_list(
 		"File",
@@ -79,7 +79,7 @@ def get_files_by_search_text(text: str) -> list[dict]:
 	text = "%" + cstr(text).lower() + "%"
 	files = frappe.get_list(
 		"File",
-		fields=["name", "file_name", "file_url", "is_folder", "modified"],
+		fields=["name", "file_name", "file_url", "is_folder", "modified", "is_private"],
 		filters={"is_folder": False},
 		or_filters={
 			"file_name": ("like", text),

--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -46,8 +46,8 @@ def get_files_in_folder(folder: str, start: int = 0, page_length: int = 20) -> d
 		"File",
 		{"folder": folder},
 		fields,
-		start=start,
-		page_length=page_length + 1,
+		offset=start,
+		limit=page_length + 1,
 	)
 
 	seen_urls = set()

--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -40,25 +40,28 @@ def get_attached_images(doctype: str, names: list[str] | str) -> frappe._dict:
 
 @frappe.whitelist()
 def get_files_in_folder(folder: str, start: int = 0, page_length: int = 20) -> dict:
-	attachment_folder = frappe.db.get_value(
-		"File",
-		"Home/Attachments",
-		["name", "file_name", "file_url", "is_folder", "modified"],
-		as_dict=1,
-	)
+	fields = ["name", "file_name", "file_url", "is_folder", "modified"]
+
+	attachment_folder = frappe.db.get_value("File", "Home/Attachments", fields, as_dict=1)
+	is_first_page = cint(start)
+	folders = []
+	if is_first_page == 0:
+		folders = frappe.get_list("File", {"folder": folder, "is_folder": 1}, fields)
 
 	files = frappe.get_list(
 		"File",
-		{"folder": folder},
-		["name", "file_name", "file_url", "is_folder", "modified"],
+		{"folder": folder, "is_folder": 0},
+		fields,
 		start=start,
 		page_length=page_length + 1,
+		group_by="file_url",
 	)
+	result = folders + files[:page_length]
 
-	if folder == "Home" and attachment_folder not in files:
-		files.insert(0, attachment_folder)
+	if folder == "Home" and is_first_page == 0 and attachment_folder and attachment_folder not in result:
+		result.insert(0, attachment_folder)
 
-	return {"files": files[:page_length], "has_more": len(files) > page_length}
+	return {"files": result, "has_more": len(files) > page_length}
 
 
 @frappe.whitelist()
@@ -77,6 +80,9 @@ def get_files_by_search_text(text: str) -> list[dict]:
 			"name": ("like", text),
 		},
 		order_by="creation desc",
+		# Results are all files (is_folder=False), so collapse duplicates that
+		# point to the same blob (same file_url) to one entry.
+		group_by="file_url",
 		limit=20,
 	)
 

--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -42,26 +42,32 @@ def get_attached_images(doctype: str, names: list[str] | str) -> frappe._dict:
 def get_files_in_folder(folder: str, start: int = 0, page_length: int = 20) -> dict:
 	fields = ["name", "file_name", "file_url", "is_folder", "modified"]
 
-	attachment_folder = frappe.db.get_value("File", "Home/Attachments", fields, as_dict=1)
-	is_first_page = cint(start)
-	folders = []
-	if is_first_page == 0:
-		folders = frappe.get_list("File", {"folder": folder, "is_folder": 1}, fields)
-
 	files = frappe.get_list(
 		"File",
-		{"folder": folder, "is_folder": 0},
+		{"folder": folder},
 		fields,
 		start=start,
 		page_length=page_length + 1,
-		group_by="file_url",
 	)
-	result = folders + files[:page_length]
 
-	if folder == "Home" and is_first_page == 0 and attachment_folder and attachment_folder not in result:
-		result.insert(0, attachment_folder)
+	seen_urls = set()
+	deduped = []
+	for file in files:
+		if file.file_url not in seen_urls and file.name != "Home/Attachments":
+			seen_urls.add(file.file_url)
+			deduped.append(file)
 
-	return {"files": result, "has_more": len(files) > page_length}
+	if folder == "Home" and start == 0:
+		attachment_folder = frappe.db.get_value(
+			"File",
+			"Home/Attachments",
+			fields,
+			as_dict=1,
+		)
+		if attachment_folder:
+			deduped.insert(0, attachment_folder)
+
+	return {"files": deduped[:page_length], "has_more": len(files) > page_length}
 
 
 @frappe.whitelist()
@@ -70,7 +76,7 @@ def get_files_by_search_text(text: str) -> list[dict]:
 		return []
 
 	text = "%" + cstr(text).lower() + "%"
-	return frappe.get_list(
+	files = frappe.get_list(
 		"File",
 		fields=["name", "file_name", "file_url", "is_folder", "modified"],
 		filters={"is_folder": False},
@@ -80,11 +86,17 @@ def get_files_by_search_text(text: str) -> list[dict]:
 			"name": ("like", text),
 		},
 		order_by="creation desc",
-		# Results are all files (is_folder=False), so collapse duplicates that
-		# point to the same blob (same file_url) to one entry.
-		group_by="file_url",
 		limit=20,
 	)
+
+	seen_urls = set()
+	deduped = []
+	for file in files:
+		if file.file_url not in seen_urls:
+			seen_urls.add(file.file_url)
+			deduped.append(file)
+
+	return deduped
 
 
 @frappe.whitelist(allow_guest=True)

--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -50,11 +50,12 @@ def get_files_in_folder(folder: str, start: int = 0, page_length: int = 20) -> d
 		limit=page_length + 1,
 	)
 
-	seen_urls = set()
+	seen_files = set()
 	deduped = []
 	for file in files:
-		if file.file_url not in seen_urls and file.name != "Home/Attachments":
-			seen_urls.add(file.file_url)
+		file_tuple = (file.file_url, file.file_name)
+		if file_tuple not in seen_files and file.name != "Home/Attachments":
+			seen_files.add(file_tuple)
 			deduped.append(file)
 
 	if folder == "Home" and start == 0:
@@ -89,11 +90,12 @@ def get_files_by_search_text(text: str) -> list[dict]:
 		limit=20,
 	)
 
-	seen_urls = set()
+	seen_files = set()
 	deduped = []
 	for file in files:
-		if file.file_url not in seen_urls:
-			seen_urls.add(file.file_url)
+		file_tuple = (file.file_url, file.file_name)
+		if file_tuple not in seen_files:
+			seen_files.add(file_tuple)
 			deduped.append(file)
 
 	return deduped

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -937,6 +937,17 @@ class TestAttachmentsAccess(IntegrationTestCase):
 		self.assertIn("test_user_attachment.txt", system_manager_attachments_files)
 		self.assertIn("test_user_attachment.txt", user_attachments_files)
 
+	def test_duplicate_file_urls_shown_only_once(self):
+		file1 = frappe.new_doc("File", file_name="dup_a.txt", content="same blob", is_private=0).insert()
+		file2 = frappe.new_doc("File", file_name="dup_b.txt", content="same blob", is_private=0).insert()
+
+		self.assertEqual(file1.file_url, file2.file_url)
+
+		result = get_files_in_folder("Home")
+		# skip Home/Attachments always pinned at top
+		result["files"].pop(0)
+		self.assertEqual(len(result["files"]), 1)
+
 	def tearDown(self) -> None:
 		frappe.set_user("Administrator")
 		frappe.db.rollback()

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -940,13 +940,15 @@ class TestAttachmentsAccess(IntegrationTestCase):
 	def test_duplicate_file_urls_shown_only_once(self):
 		file1 = frappe.new_doc("File", file_name="dup_a.txt", content="same blob", is_private=0).insert()
 		file2 = frappe.new_doc("File", file_name="dup_b.txt", content="same blob", is_private=0).insert()
+		file3 = frappe.new_doc("File", file_name="dup_b.txt", content="same blob", is_private=0).insert()
 
 		self.assertEqual(file1.file_url, file2.file_url)
+		self.assertEqual(file2.file_url, file3.file_url)
 
 		result = get_files_in_folder("Home")
 		# skip Home/Attachments always pinned at top
 		result["files"].pop(0)
-		self.assertEqual(len(result["files"]), 1)
+		self.assertEqual(len(result["files"]), 2)
 
 	def tearDown(self) -> None:
 		frappe.set_user("Administrator")

--- a/frappe/public/js/frappe/file_uploader/FileBrowser.vue
+++ b/frappe/public/js/frappe/file_uploader/FileBrowser.vue
@@ -40,6 +40,7 @@ let node = ref({
 	children: [],
 	children_start: 0,
 	children_loading: false,
+	seen_files: [],
 	is_leaf: false,
 	fetching: false,
 	fetched: false,
@@ -57,13 +58,15 @@ function toggle_node(node) {
 		node.fetching = true;
 		node.children_start = 0;
 		node.children_loading = false;
-		get_files_in_folder(node.value, 0).then(({ files, has_more }) => {
+		node.seen_files = [];
+		get_files_in_folder(node.value, 0, []).then(({ files, has_more, seen_files }) => {
 			node.open = true;
 			node.children = files;
 			node.fetched = true;
 			node.fetching = false;
 			node.children_start += page_length.value;
 			node.has_more_children = has_more;
+			node.seen_files = seen_files;
 		});
 	} else {
 		node.open = !node.open;
@@ -74,12 +77,15 @@ function load_more(node) {
 	if (node.has_more_children) {
 		let start = node.children_start;
 		node.children_loading = true;
-		get_files_in_folder(node.value, start).then(({ files, has_more }) => {
-			node.children = node.children.concat(files);
-			node.children_start += page_length.value;
-			node.has_more_children = has_more;
-			node.children_loading = false;
-		});
+		get_files_in_folder(node.value, start, node.seen_files || []).then(
+			({ files, has_more, seen_files }) => {
+				node.children = node.children.concat(files);
+				node.children_start += page_length.value;
+				node.has_more_children = has_more;
+				node.children_loading = false;
+				node.seen_files = seen_files;
+			}
+		);
 	}
 }
 function select_node(node) {
@@ -87,15 +93,20 @@ function select_node(node) {
 		selected_node.value = node;
 	}
 }
-function get_files_in_folder(folder, start) {
+function get_files_in_folder(folder, start, seen_files = []) {
 	return frappe
 		.call("frappe.core.api.file.get_files_in_folder", {
 			folder,
 			start,
 			page_length: page_length.value,
+			seen_files,
 		})
 		.then((r) => {
-			let { files = [], has_more = false } = r.message || {};
+			let {
+				files = [],
+				has_more = false,
+				seen_files: next_seen_files = [],
+			} = r.message || {};
 			files.sort((a, b) => {
 				if (a.is_folder && b.is_folder) {
 					return a.modified < b.modified ? -1 : 1;
@@ -109,7 +120,7 @@ function get_files_in_folder(folder, start) {
 				return 0;
 			});
 			files = files.map((file) => make_file_node(file));
-			return { files, has_more };
+			return { files, has_more, seen_files: next_seen_files };
 		});
 }
 function search_by_name() {
@@ -152,6 +163,7 @@ function make_file_node(file) {
 		children: [],
 		children_loading: false,
 		children_start: 0,
+		seen_files: [],
 		open: false,
 		fetching: false,
 		filtered: true,

--- a/frappe/public/js/frappe/file_uploader/FileBrowser.vue
+++ b/frappe/public/js/frappe/file_uploader/FileBrowser.vue
@@ -146,6 +146,7 @@ function make_file_node(file) {
 		filename: filename,
 		file_url: file.file_url,
 		value: file.name,
+		is_private: file.is_private,
 		is_leaf: !file.is_folder,
 		fetched: !file.is_folder, // fetched if node is leaf
 		children: [],

--- a/frappe/public/js/frappe/file_uploader/TreeNode.vue
+++ b/frappe/public/js/frappe/file_uploader/TreeNode.vue
@@ -11,6 +11,9 @@
 		>
 			<div v-html="icon"></div>
 			<a class="tree-label">{{ node.label }}</a>
+			<span v-if="node.is_private" class="text-muted private-label">{{
+				__("(private)")
+			}}</span>
 			<!-- Icon open File record in new tab -->
 			<a
 				v-if="node.is_leaf"
@@ -133,5 +136,10 @@ function onMouseleave() {
 }
 .popover {
 	padding: 10px;
+}
+.private-label {
+	margin-left: 0.25rem;
+	font-size: var(--text-xs);
+	white-space: nowrap;
 }
 </style>


### PR DESCRIPTION
Opening PR for: @harshp4114

## Deduplicate files shown in the Library tab

### The bug

When opening the Library tab to upload a file, the user was shown multiple files with the same name. These are all the separate File documents that exist in the system. This happened even when every one of them pointed to the same underlying file. The same problem also showed up when searching for a file in the Library tab.


### The fix

This PR adds dedup logic to the Library tab. File documents are now deduplicated by both file_url and file_name, so any files that point to the same file_url and share the same file_name are shown as a single entry.

## Before

https://github.com/user-attachments/assets/7460ccb8-eb84-40de-9b2c-d1d9be79bb0e

## After

https://github.com/user-attachments/assets/2143acd7-ff89-4ad1-be7f-a13a81a8034f

---

<img width="767" height="624" alt="image" src="https://github.com/user-attachments/assets/e76fcc69-3451-489f-8a80-50bcf083b1dd" />

The file browser in the upload dialog now marks private files. Any file (or folder) whose `is_private` flag is set shows a `(private)` label next to its name, so you can tell at a glance which attachments are restricted without opening each File record. Applies to both folder browsing and search results.

**Change in api**

`get_files_in_folder` now accepts a `seen_files` param (list of [file_url, file_name] pairs) and echoes back the accumulated set in its response. This lets the client carry dedup state across paginated calls, fixing duplicate files showing up across pages.
