### PR TITLE
fix: slugify workspace name in get_url_to_workspace

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2011,11 +2011,10 @@ def get_link_to_form(doctype: str, name: str | None = None, label: str | None = 
 
 
 def get_url_to_workspace(workspace: str, is_public: bool):
-	url_prefix = "/desk/"
-	if not is_public:
-		workspace_url = "/desk/private/"
-	workspace_url = url_prefix + workspace.lower()
-	return workspace_url
+	from frappe.desk.utils import slug
+
+	url_prefix = "/desk/" if is_public else "/desk/private/"
+	return url_prefix + slug(workspace)
 
 
 def get_link_to_report(


### PR DESCRIPTION
## Fix workspace default-redirect slug

`get_url_to_workspace()` lowercased the workspace name but never replaced spaces with hyphens. A public Workspace named `Daily Desk` set as a User's Default Workspace redirected to `/desk/daily%20desk` after login → `DoesNotExistError`.

Now reuses `frappe.desk.utils.slug()` (`lower().replace(" ", "-")`), matching the JS `frappe.router.slug()`. Also fixes the dead `is_public=False` branch, which was overwritten unconditionally.

**Before:** `/desk/daily desk`  **After:** `/desk/daily-desk`

**Support Ticket** : [72567](https://support.frappe.io/helpdesk/tickets/72567)