### PR TITLE
fix: retry interactive writes on deadlock before surfacing 508

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -4,6 +4,8 @@
 import functools
 import logging
 import os
+import random
+import time
 
 import orjson
 from werkzeug.exceptions import HTTPException, NotFound
@@ -97,53 +99,19 @@ def after_response_wrapper(app):
 	return application
 
 
+# ponytail: background jobs retry deadlocks (background_jobs.execute_job) but interactive
+# writes don't. Adjacent docs submitted at once gap-lock each other on child-table indexes;
+# re-run the request a few times with jittered backoff before surfacing the 508.
+MAX_DEADLOCK_RETRIES = 2
+
+
 @after_response_wrapper
 @Request.application
 def application(request: Request):
 	response = None
 
 	try:
-		init_request(request)
-
-		validate_auth()
-
-		if request.method == "OPTIONS":
-			response = Response()
-
-		elif frappe.form_dict.cmd:
-			from frappe.deprecation_dumpster import deprecation_warning
-
-			deprecation_warning(
-				"unknown",
-				"v17",
-				f"{frappe.form_dict.cmd}: Sending `cmd` for RPC calls is deprecated, call REST API instead `/api/method/cmd`",
-			)
-			frappe.handler.handle()
-			response = frappe.utils.response.build_response("json")
-
-		elif request.path.startswith("/api/"):
-			response = frappe.api.handle(request)
-
-		elif request.path.startswith("/backups"):
-			response = frappe.utils.response.download_backup(request.path)
-
-		elif request.path.startswith("/private/files/"):
-			response = frappe.utils.response.download_private_file(request.path)
-
-		elif request.path == "/.well-known/security.txt" and request.method == "GET":
-			if request.scheme != "https":
-				raise NotFound
-			security_settings = frappe.get_doc("Security Settings")
-			response = Response(security_settings.security_txt, content_type="text/plain")
-
-		elif request.path.startswith("/.well-known/") and request.method == "GET":
-			response = handle_wellknown(request.path)
-
-		elif request.method in ("GET", "HEAD", "POST"):
-			response = get_response()
-
-		else:
-			raise NotFound
+		response = process_request_with_deadlock_retry(request)
 
 	except Exception as e:
 		response = e.get_response(request.environ) if isinstance(e, HTTPException) else handle_exception(e)
@@ -168,6 +136,63 @@ def application(request: Request):
 	process_response(response)
 
 	return response
+
+
+def process_request_with_deadlock_retry(request):
+	for attempt in range(MAX_DEADLOCK_RETRIES + 1):
+		try:
+			return process_request(request)
+		except frappe.QueryDeadlockError:
+			# Only writes deadlock, and the rolled-back attempt left nothing committed, so
+			# re-running from init_request (force=True resets local state) is a clean retry.
+			if request.method not in UNSAFE_HTTP_METHODS or attempt == MAX_DEADLOCK_RETRIES:
+				raise
+			if db := getattr(frappe.local, "db", None):
+				db.rollback(chain=True)
+			# Jitter so the two victims don't realign and re-collide on the same gap.
+			time.sleep(random.uniform(0.025, 0.1) * (attempt + 1))
+
+
+def process_request(request):
+	init_request(request)
+	validate_auth()
+
+	if request.method == "OPTIONS":
+		return Response()
+
+	if frappe.form_dict.cmd:
+		from frappe.deprecation_dumpster import deprecation_warning
+
+		deprecation_warning(
+			"unknown",
+			"v17",
+			f"{frappe.form_dict.cmd}: Sending `cmd` for RPC calls is deprecated, call REST API instead `/api/method/cmd`",
+		)
+		frappe.handler.handle()
+		return frappe.utils.response.build_response("json")
+
+	if request.path.startswith("/api/"):
+		return frappe.api.handle(request)
+
+	if request.path.startswith("/backups"):
+		return frappe.utils.response.download_backup(request.path)
+
+	if request.path.startswith("/private/files/"):
+		return frappe.utils.response.download_private_file(request.path)
+
+	if request.path == "/.well-known/security.txt" and request.method == "GET":
+		if request.scheme != "https":
+			raise NotFound
+		security_settings = frappe.get_doc("Security Settings")
+		return Response(security_settings.security_txt, content_type="text/plain")
+
+	if request.path.startswith("/.well-known/") and request.method == "GET":
+		return handle_wellknown(request.path)
+
+	if request.method in ("GET", "HEAD", "POST"):
+		return get_response()
+
+	raise NotFound
 
 
 def run_after_request_hooks(request, response):

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -111,7 +111,7 @@ def application(request: Request):
 	response = None
 
 	try:
-		response = process_request_with_deadlock_retry(request)
+		response = process_request(request)
 
 	except Exception as e:
 		response = e.get_response(request.environ) if isinstance(e, HTTPException) else handle_exception(e)
@@ -138,21 +138,26 @@ def application(request: Request):
 	return response
 
 
-def process_request_with_deadlock_retry(request):
-	for attempt in range(MAX_DEADLOCK_RETRIES + 1):
-		try:
-			return process_request(request)
-		except frappe.QueryDeadlockError:
-			# Only writes deadlock, and the rolled-back attempt left nothing committed, so
-			# re-running from init_request (force=True resets local state) is a clean retry.
-			if request.method not in UNSAFE_HTTP_METHODS or attempt == MAX_DEADLOCK_RETRIES:
-				raise
-			if db := getattr(frappe.local, "db", None):
-				db.rollback(chain=True)
-			# Jitter so the two victims don't realign and re-collide on the same gap.
-			time.sleep(random.uniform(0.025, 0.1) * (attempt + 1))
+def retry_deadlocks(fn):
+	@functools.wraps(fn)
+	def wrapper(request):
+		for attempt in range(MAX_DEADLOCK_RETRIES + 1):
+			try:
+				return fn(request)
+			except frappe.QueryDeadlockError:
+				# Only writes deadlock, and the rolled-back attempt left nothing committed, so
+				# re-running from init_request (force=True resets local state) is a clean retry.
+				if request.method not in UNSAFE_HTTP_METHODS or attempt == MAX_DEADLOCK_RETRIES:
+					raise
+				if db := getattr(frappe.local, "db", None):
+					db.rollback(chain=True)
+				# Jitter so the two victims don't realign and re-collide on the same gap.
+				time.sleep(random.uniform(0.025, 0.1) * (attempt + 1))
+
+	return wrapper
 
 
+@retry_deadlocks
 def process_request(request):
 	init_request(request)
 	validate_auth()

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -99,9 +99,9 @@ def after_response_wrapper(app):
 	return application
 
 
-# ponytail: background jobs retry deadlocks (background_jobs.execute_job) but interactive
-# writes don't. Adjacent docs submitted at once gap-lock each other on child-table indexes;
-# re-run the request a few times with jittered backoff before surfacing the 508.
+# ponytail: adjacent docs submitted concurrently gap-lock each other on child-table indexes.
+# Retry just the dispatch (auth, hooks, and the DB connection are reused) with jittered
+# backoff, and only when the failed attempt did nothing a rollback can't undo.
 MAX_DEADLOCK_RETRIES = 2
 
 
@@ -138,30 +138,54 @@ def application(request: Request):
 	return response
 
 
-def retry_deadlocks(fn):
-	@functools.wraps(fn)
+def retry_deadlocks(handler):
+	@functools.wraps(handler)
 	def wrapper(request):
 		for attempt in range(MAX_DEADLOCK_RETRIES + 1):
+			commits_before = frappe.db.commit_count
+			jobs_before = frappe.local.flags.enqueued_jobs
 			try:
-				return fn(request)
+				return handler(request)
 			except frappe.QueryDeadlockError:
-				# Only writes deadlock, and the rolled-back attempt left nothing committed, so
-				# re-running from init_request (force=True resets local state) is a clean retry.
-				if request.method not in UNSAFE_HTTP_METHODS or attempt == MAX_DEADLOCK_RETRIES:
+				if attempt == MAX_DEADLOCK_RETRIES or not replay_is_safe(request, commits_before, jobs_before):
 					raise
-				if db := getattr(frappe.local, "db", None):
-					db.rollback(chain=True)
+				frappe.db.rollback()
+				reset_response_state()
+				frappe.logger().warning(
+					f"Deadlock retry {attempt + 1}/{MAX_DEADLOCK_RETRIES}: {request.method} {request.path}"
+				)
 				# Jitter so the two victims don't realign and re-collide on the same gap.
 				time.sleep(random.uniform(0.025, 0.1) * (attempt + 1))
 
 	return wrapper
 
 
-@retry_deadlocks
+def replay_is_safe(request, commits_before, jobs_before):
+	# Commits, redis-pushed jobs, and consumed multipart streams survive the rollback —
+	# replaying after any of them duplicates work or corrupts uploads.
+	return (
+		frappe.db.commit_count == commits_before
+		and frappe.local.flags.enqueued_jobs == jobs_before
+		and request.mimetype != "multipart/form-data"
+	)
+
+
+def reset_response_state():
+	# Mirrors init_local: the failed attempt may have dirtied these; auth and form_dict stay valid.
+	frappe.local.error_log = []
+	frappe.local.message_log = []
+	frappe.local.debug_log = []
+	frappe.local.response = frappe._dict({"docs": []})
+
+
 def process_request(request):
 	init_request(request)
 	validate_auth()
+	return dispatch_request(request)
 
+
+@retry_deadlocks
+def dispatch_request(request):
 	if request.method == "OPTIONS":
 		return Response()
 
@@ -402,10 +426,13 @@ def handle_exception(e):
 	elif isinstance(e, frappe.SessionStopped):
 		response = frappe.utils.response.handle_session_stopped()
 
-	elif (
-		http_status_code == 500
-		and (frappe.db and isinstance(e, frappe.db.InternalError))
-		and (frappe.db and (frappe.db.is_deadlocked(e) or frappe.db.is_timedout(e)))
+	elif http_status_code == 500 and (
+		isinstance(e, (frappe.QueryDeadlockError, frappe.QueryTimeoutError))
+		or (
+			frappe.db
+			and isinstance(e, frappe.db.InternalError)
+			and (frappe.db.is_deadlocked(e) or frappe.db.is_timedout(e))
+		)
 	):
 		http_status_code = 508
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -120,6 +120,7 @@ class Database:
 		self._conn = None
 
 		self.transaction_writes = 0
+		self.commit_count = 0
 		self.auto_commit_on_many_writes = 0
 
 		self.value_cache = recursive_defaultdict()
@@ -1195,6 +1196,7 @@ class Database:
 			self.sql("commit")
 			self.begin()
 
+		self.commit_count += 1
 		self.value_cache.clear()
 		self.after_commit.run()
 

--- a/frappe/tests/test_deadlock_retry.py
+++ b/frappe/tests/test_deadlock_retry.py
@@ -1,49 +1,100 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import frappe
 import frappe.app as app
+from frappe.tests import UnitTestCase
 
 
-class FakeRequest:
-	def __init__(self, method):
-		self.method = method
+class FakeDB:
+	def __init__(self):
+		self.commit_count = 0
+		self.rollbacks = 0
+
+	def rollback(self):
+		self.rollbacks += 1
 
 
-class TestDeadlockRetry(unittest.TestCase):
-	"""retry_deadlocks: writes retry on deadlock, reads don't."""
+class TestDeadlockRetry(UnitTestCase):
+	"""retry_deadlocks: transient deadlocks replay, non-replayable attempts don't."""
 
-	def _run(self, method, fail_times):
-		calls = {"n": 0}
-		sleeps = []
+	def setUp(self):
+		self.db = FakeDB()
+		self.patchers = [
+			patch.object(frappe, "db", self.db),
+			patch.object(app, "time", MagicMock()),
+			patch.object(frappe, "logger", MagicMock(return_value=MagicMock())),
+		]
+		for patcher in self.patchers:
+			patcher.start()
+		frappe.local.flags = frappe._dict()
+		app.reset_response_state()
+
+	def tearDown(self):
+		for patcher in self.patchers:
+			patcher.stop()
+
+	def _run(self, fail_times=1, during_attempt=None, mimetype="application/json"):
+		request = SimpleNamespace(method="POST", path="/api/method/test", mimetype=mimetype)
+		calls = 0
 
 		@app.retry_deadlocks
 		def dispatch(request):
-			if calls["n"] < fail_times:
-				calls["n"] += 1
+			nonlocal calls
+			calls += 1
+			if during_attempt:
+				during_attempt()
+			if calls <= fail_times:
 				raise frappe.QueryDeadlockError("deadlock")
 			return "ok"
 
-		with patch.object(app.time, "sleep", sleeps.append):
-			result = dispatch(FakeRequest(method))
-		return result, calls["n"], sleeps
+		try:
+			return dispatch(request), calls
+		except frappe.QueryDeadlockError:
+			return None, calls
 
-	def test_write_succeeds_after_retries(self):
-		result, attempts, sleeps = self._run("POST", fail_times=app.MAX_DEADLOCK_RETRIES)
+	def test_retries_transient_deadlock(self):
+		result, calls = self._run(fail_times=app.MAX_DEADLOCK_RETRIES)
 		self.assertEqual(result, "ok")
-		self.assertEqual(attempts, app.MAX_DEADLOCK_RETRIES)
-		self.assertEqual(len(sleeps), app.MAX_DEADLOCK_RETRIES)
+		self.assertEqual(calls, app.MAX_DEADLOCK_RETRIES + 1)
+		self.assertEqual(self.db.rollbacks, app.MAX_DEADLOCK_RETRIES)
 
-	def test_write_gives_up_after_max(self):
-		with self.assertRaises(frappe.QueryDeadlockError):
-			self._run("POST", fail_times=app.MAX_DEADLOCK_RETRIES + 1)
+	def test_gives_up_after_max_retries(self):
+		result, calls = self._run(fail_times=app.MAX_DEADLOCK_RETRIES + 1)
+		self.assertIsNone(result)
+		self.assertEqual(calls, app.MAX_DEADLOCK_RETRIES + 1)
 
-	def test_read_not_retried(self):
-		with self.assertRaises(frappe.QueryDeadlockError):
-			self._run("GET", fail_times=1)
+	def test_no_replay_after_commit(self):
+		def commit():
+			self.db.commit_count += 1
 
+		result, calls = self._run(during_attempt=commit)
+		self.assertIsNone(result)
+		self.assertEqual(calls, 1)
+		self.assertEqual(self.db.rollbacks, 0)
 
-if __name__ == "__main__":
-	unittest.main()
+	def test_no_replay_after_enqueue(self):
+		def enqueue():
+			frappe.local.flags.enqueued_jobs = (frappe.local.flags.enqueued_jobs or 0) + 1
+
+		result, calls = self._run(during_attempt=enqueue)
+		self.assertIsNone(result)
+		self.assertEqual(calls, 1)
+
+	def test_no_replay_for_multipart(self):
+		result, calls = self._run(mimetype="multipart/form-data")
+		self.assertIsNone(result)
+		self.assertEqual(calls, 1)
+
+	def test_response_state_reset_between_attempts(self):
+		seen_logs = []
+
+		def dirty_response():
+			seen_logs.append(list(frappe.local.message_log))
+			frappe.local.message_log.append("leftover")
+
+		result, _calls = self._run(fail_times=1, during_attempt=dirty_response)
+		self.assertEqual(result, "ok")
+		self.assertEqual(seen_logs, [[], []])

--- a/frappe/tests/test_deadlock_retry.py
+++ b/frappe/tests/test_deadlock_retry.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+import unittest
+from unittest.mock import patch
+
+import frappe
+import frappe.app as app
+
+
+class FakeRequest:
+	def __init__(self, method):
+		self.method = method
+
+
+class TestDeadlockRetry(unittest.TestCase):
+	"""process_request_with_deadlock_retry: writes retry on deadlock, reads don't."""
+
+	def _run(self, method, fail_times):
+		calls = {"n": 0}
+		sleeps = []
+
+		def fake_process_request(request):
+			if calls["n"] < fail_times:
+				calls["n"] += 1
+				raise frappe.QueryDeadlockError("deadlock")
+			return "ok"
+
+		with (
+			patch.object(app, "process_request", fake_process_request),
+			patch.object(app.time, "sleep", sleeps.append),
+		):
+			result = app.process_request_with_deadlock_retry(FakeRequest(method))
+		return result, calls["n"], sleeps
+
+	def test_write_succeeds_after_retries(self):
+		result, attempts, sleeps = self._run("POST", fail_times=app.MAX_DEADLOCK_RETRIES)
+		self.assertEqual(result, "ok")
+		self.assertEqual(attempts, app.MAX_DEADLOCK_RETRIES)
+		self.assertEqual(len(sleeps), app.MAX_DEADLOCK_RETRIES)
+
+	def test_write_gives_up_after_max(self):
+		with self.assertRaises(frappe.QueryDeadlockError):
+			self._run("POST", fail_times=app.MAX_DEADLOCK_RETRIES + 1)
+
+	def test_read_not_retried(self):
+		with self.assertRaises(frappe.QueryDeadlockError):
+			self._run("GET", fail_times=1)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/frappe/tests/test_deadlock_retry.py
+++ b/frappe/tests/test_deadlock_retry.py
@@ -13,23 +13,21 @@ class FakeRequest:
 
 
 class TestDeadlockRetry(unittest.TestCase):
-	"""process_request_with_deadlock_retry: writes retry on deadlock, reads don't."""
+	"""retry_deadlocks: writes retry on deadlock, reads don't."""
 
 	def _run(self, method, fail_times):
 		calls = {"n": 0}
 		sleeps = []
 
-		def fake_process_request(request):
+		@app.retry_deadlocks
+		def dispatch(request):
 			if calls["n"] < fail_times:
 				calls["n"] += 1
 				raise frappe.QueryDeadlockError("deadlock")
 			return "ok"
 
-		with (
-			patch.object(app, "process_request", fake_process_request),
-			patch.object(app.time, "sleep", sleeps.append),
-		):
-			result = app.process_request_with_deadlock_retry(FakeRequest(method))
+		with patch.object(app.time, "sleep", sleeps.append):
+			result = dispatch(FakeRequest(method))
 		return result, calls["n"], sleeps
 
 	def test_write_succeeds_after_retries(self):

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -212,6 +212,8 @@ def enqueue(
 		frappe.db.after_commit.add(enqueue_call)
 		return
 
+	# Immediate pushes survive a transaction rollback; deadlock replay must not repeat them.
+	frappe.local.flags.enqueued_jobs = (frappe.local.flags.enqueued_jobs or 0) + 1
 	return enqueue_call()
 
 


### PR DESCRIPTION
## Problem

Background jobs retry deadlocks (`background_jobs.execute_job`), but synchronous HTTP requests don't — a write that loses a deadlock fails immediately. Concurrent submits of **adjacent** documents (sequential naming series) gap-lock each other on child-table `parent` secondary indexes during `bulk_insert` (`SHOW ENGINE INNODB STATUS`: `index parent ... lock_mode X locks gap before rec insert intention waiting`, two transactions on *different* parents). On Postgres under REPEATABLE READ the same collision surfaces as a serialization failure (40001), which `is_deadlocked` already classifies as `QueryDeadlockError`.

## Change

Retry the **dispatch only** — not the whole request — on `frappe.QueryDeadlockError`, up to 2 extra attempts with jittered backoff:

- **Narrow seam:** `process_request` = `init_request` + `validate_auth` + `dispatch_request`; only `dispatch_request` is wrapped. Auth, `before_request` hooks (rate limiter, monitor), form parsing, and the DB connection run once and are reused across attempts. Only response-state locals (`response`, `message_log`, `debug_log`, `error_log`) are reset between attempts.
- **Replay fences** — retry is skipped when the failed attempt did anything a rollback can't undo:
  - a commit happened during the attempt (new `Database.commit_count`),
  - a job was pushed to redis (`enqueue` now flags `frappe.local.flags.enqueued_jobs`; the `enqueue_after_commit` path needs no flag — rollback resets those callbacks),
  - the request is `multipart/form-data` (consumed `FileStorage` streams can't be replayed).
- **No verb gate:** the fences are the actual safety predicate, so write-capable GETs (`flags.commit`) are covered and idempotent reads retry harmlessly.
- **Observability:** each retry logs a warning (`Deadlock retry n/N: METHOD path`).
- **508 fix:** `handle_exception` now maps `QueryDeadlockError`/`QueryTimeoutError` to HTTP 508 — the existing check (`isinstance(e, frappe.db.InternalError)`) could never match the wrapper exceptions frappe.db actually raises, so deadlocks surfaced as generic 500s.

## Known limits (accepted)

- External side effects inside handlers (payment gateways, raw HTTP calls) are invisible to the framework and may replay. DB-mediated effects (email queue, webhooks-after-commit) roll back and are safe.
- Commit-time failures in `sync_database` are outside the retried unit; retrying just a COMMIT is invalid anyway (the transaction must be replayed). Rare outside Galera/SSI.
- Retry policy is intentionally separate from `execute_job`'s (different latency budgets); unifying the deadlock classifiers is a follow-up.

## Tests

`frappe/tests/test_deadlock_retry.py` (UnitTestCase): transient deadlock retries then succeeds; gives up after max; no replay after mid-attempt commit / enqueue / for multipart; response state reset between attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)