### PR TITLE
fix(chromium): parse URL pathname correctly in PDF request interceptor

### DIFF
--- a/frappe/utils/chromium/page.py
+++ b/frappe/utils/chromium/page.py
@@ -131,9 +131,9 @@ class Page:
 				data["request_id"] = params["requestId"]
 				url = params["request"]["url"]
 
-				if url.startswith(get_host_url()):
-					path = urllib.parse.urlparse(url).path.lstrip("/")
-					clean_path = urllib.parse.unquote(path)
+				if isinstance(url, str) and url.startswith(get_host_url()):
+					parsed = urllib.parse.urlparse(url)
+					clean_path = urllib.parse.unquote(parsed.path).lstrip("/")
 
 					if clean_path.startswith("assets/"):
 						final_system_path = os.path.abspath(os.path.join(bench_sites, clean_path))
@@ -149,7 +149,7 @@ class Page:
 						content = frappe.read_file(final_system_path, as_base64=True)
 						response_headers = []
 						# write logic to handle all file types as required
-						if path.endswith(".svg"):
+						if clean_path.endswith(".svg"):
 							response_headers.append({"name": "Content-Type", "value": "image/svg+xml"})
 						if content:
 							self.session.send(
@@ -163,7 +163,7 @@ class Page:
 								return_future=True,
 							)
 							return
-					elif path:
+					elif clean_path:
 						self.session.send(
 							"Fetch.failRequest",
 							{"requestId": data["request_id"], "errorReason": "AccessDenied"},
@@ -171,7 +171,7 @@ class Page:
 						)
 						frappe.log_error(
 							title="Attempted Unauthorized File Access in PDF Generator",
-							message=f"Blocked access to: {path} \nResolved Path to: {final_system_path}",
+							message=f"Blocked access to: {clean_path} \nResolved Path to: {final_system_path}",
 						)
 						return
 				self.session.send(

--- a/frappe/utils/chromium/page.py
+++ b/frappe/utils/chromium/page.py
@@ -132,7 +132,7 @@ class Page:
 				url = params["request"]["url"]
 
 				if url.startswith(get_host_url()):
-					path = urllib.parse.urlparse(url).path
+					path = urllib.parse.urlparse(url).path.lstrip("/")
 					clean_path = urllib.parse.unquote(path)
 
 					if clean_path.startswith("assets/"):

--- a/frappe/utils/chromium/page.py
+++ b/frappe/utils/chromium/page.py
@@ -132,7 +132,7 @@ class Page:
 				url = params["request"]["url"]
 
 				if url.startswith(get_host_url()):
-					path = url.replace(get_host_url(), "").split("?v", 1)[0]
+					path = urllib.parse.urlparse(url).path
 					clean_path = urllib.parse.unquote(path)
 
 					if clean_path.startswith("assets/"):


### PR DESCRIPTION
Resolve: #40394 

---
Fix file URLs with `?fid=` query parameter being blocked in the Chromium PDF generator.

The request interceptor was splitting on `?v` to strip versioned asset query strings, which left `?fid=`... intact. This caused the resolved filesystem path to include the query string, making the path safety check fail with "**Attempted Unauthorized File Access".**

Replace the fragile string split with `urllib.parse.urlparse(url).path` which correctly extracts the pathname for any query parameter.

#### Test Script:
Run in bench console:
```py
import urllib.parse

cases = [
    "http://example.com/files/9YF3p5Z.png?fid=8a0139b1d6",
    "http://example.com/assets/frappe/js/app.js?v=1234567",
    "http://example.com/files/plain.png",
]

for url in cases:
    path = urllib.parse.urlparse(url).path
    print(f"{url}")
    print(f"  Parsed path: {path}")
    print()
    
# ===============
# Expected output:
http://example.com/files/9YF3p5Z.png?fid=8a0139b1d6
  Parsed path: /files/9YF3p5Z.png

http://example.com/assets/frappe/js/app.js?v=1234567
  Parsed path: /assets/frappe/js/app.js

http://example.com/files/plain.png
  Parsed path: /files/plain.png

```