### PR TITLE
fix(ui): correct FileUploadDialog import path in AttachField

### DIFF
--- a/ui/src/components/Fields/AttachField.vue
+++ b/ui/src/components/Fields/AttachField.vue
@@ -121,9 +121,7 @@ import { Popover, TextInput } from "frappe-ui";
 import type { FieldComponentEmits, FieldComponentProps } from "./types";
 import type { Restrictions, UploadResult, UploadTransport } from "../FileUpload/types";
 
-const FileUploadDialog = defineAsyncComponent(
-	() => import("../FileUpload/FileUploadDialog.vue")
-);
+const FileUploadDialog = defineAsyncComponent(() => import("../FileUpload/FileUploadDialog.vue"));
 
 // `transport` / `restrictions` are optional presentation props, supplied via the
 // node's `ui.props` overlay (e.g. a story's fake transport, or an app's

--- a/ui/src/components/Fields/AttachField.vue
+++ b/ui/src/components/Fields/AttachField.vue
@@ -122,7 +122,7 @@ import type { FieldComponentEmits, FieldComponentProps } from "./types";
 import type { Restrictions, UploadResult, UploadTransport } from "../FileUpload/types";
 
 const FileUploadDialog = defineAsyncComponent(
-	() => import("../../FileUpload/FileUploadDialog.vue")
+	() => import("../FileUpload/FileUploadDialog.vue")
 );
 
 // `transport` / `restrictions` are optional presentation props, supplied via the


### PR DESCRIPTION
### Problem

`AttachField.vue` lives in `ui/src/components/Fields/`, but its lazy `FileUploadDialog` import still uses the pre-move path `../../FileUpload/FileUploadDialog.vue`. From the `Fields/` folder that resolves to `src/FileUpload/` — one level too high — instead of `src/components/FileUpload/`.

As soon as an `Attach` / `Attach Image` field renders, Vite throws:

```
Failed to resolve import "../../FileUpload/FileUploadDialog.vue"
  from "ui/src/components/Fields/AttachField.vue". Does the file exist?
```

### Fix

Drop the extra `../` so the path matches the sibling `../FileUpload/types` import on the line above:

```diff
-	() => import("../../FileUpload/FileUploadDialog.vue")
+	() => import("../FileUpload/FileUploadDialog.vue")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)