### PR TITLE
feat(postgres): convert MariaDB backups to PostgreSQL via pgloader

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -192,6 +192,16 @@ def new_site(
 	help="Ignore the validations and downgrade warnings. This action is not recommended",
 )
 @click.option("--encryption-key", help="Backup encryption key")
+@click.option("--source-mariadb-host", help="Host of a MariaDB server used to stage a MariaDB backup for conversion to PostgreSQL")
+@click.option("--source-mariadb-port", default="3306", help="Port of the staging MariaDB server")
+@click.option("--source-mariadb-root-username", default="root", help="Root user of the staging MariaDB server")
+@click.option("--source-mariadb-root-password", help="Root password of the staging MariaDB server")
+@click.option(
+	"--pgloader-dynamic-space-size",
+	type=int,
+	default=None,
+	help="Heap (MB) for pgloader when converting a MariaDB backup (default: pgloader's own); raise for very large dumps",
+)
 @pass_context
 def restore(
 	context: CliCtxObj,
@@ -206,13 +216,32 @@ def restore(
 	force=None,
 	with_public_files=None,
 	with_private_files=None,
+	source_mariadb_host=None,
+	source_mariadb_port="3306",
+	source_mariadb_root_username="root",
+	source_mariadb_root_password=None,
+	pgloader_dynamic_space_size=None,
 ):
 	"Restore site database from an sql file"
 
+	from frappe.database.postgres.import_from_mariadb import set_staging_mariadb
 	from frappe.utils.synchronization import filelock
 
 	site = get_site(context)
 	frappe.init(site)
+
+	# A MariaDB backup restored onto a PostgreSQL site is converted via pgloader, which
+	# needs a live MariaDB server to stage the dump (see import_from_mariadb).
+	if source_mariadb_host:
+		set_staging_mariadb(
+			{
+				"host": source_mariadb_host,
+				"port": source_mariadb_port,
+				"user": source_mariadb_root_username,
+				"password": source_mariadb_root_password,
+			},
+			dynamic_space_mb=pgloader_dynamic_space_size,
+		)
 
 	with filelock("site_restore", timeout=1):
 		_restore(
@@ -349,7 +378,7 @@ def restore_backup(
 ):
 	from pathlib import Path
 
-	from frappe.installer import _new_site, is_downgrade, is_partial, validate_database_sql
+	from frappe.installer import _new_site, get_dump_db_type, is_downgrade, is_partial, validate_database_sql
 
 	if is_partial(sql_file_path):
 		click.secho(
@@ -368,6 +397,20 @@ def restore_backup(
 			"This is not recommended and may lead to unexpected behaviour. Do you want to continue anyway?"
 		)
 		click.confirm(warn_message, abort=True)
+
+	# A MariaDB backup restored onto a PostgreSQL site is converted with pgloader first.
+	if not force and frappe.conf.db_type == "postgres" and get_dump_db_type(sql_file_path) == "mariadb":
+		click.confirm(
+			click.style(
+				"You have given a MariaDB backup for a PostgreSQL site restore. It will be converted "
+				"with pgloader before restoring.\n"
+				"- This does not work on ARM / Apple Silicon.\n"
+				"- PostgreSQL support is experimental, so a successful conversion is not guaranteed.\n"
+				"Continue with the conversion?",
+				fg="yellow",
+			),
+			abort=True,
+		)
 
 	# Validate the sql file
 	validate_database_sql(sql_file_path, _raise=not force)
@@ -1667,6 +1710,67 @@ def sync_desktop_icons(context: CliCtxObj):
 			update_progress_bar("Updating Desktop Icons", i, len(files))
 
 
+@click.command("convert-mariadb-backup")
+@click.argument("sql-file-path", type=click.Path(exists=True, dir_okay=False, resolve_path=True))
+@click.option("--output", help="Path for the converted PostgreSQL backup (default: alongside the input)")
+@click.option("--db-host", default="localhost", help="PostgreSQL host used to stage the conversion")
+@click.option("--db-port", default="5432", help="PostgreSQL port")
+@click.option("--db-root-username", default="postgres", help="PostgreSQL superuser")
+@click.option("--db-root-password", help="PostgreSQL superuser password")
+@click.option("--source-mariadb-host", default="localhost", help="Staging MariaDB host")
+@click.option("--source-mariadb-port", default="3306", help="Staging MariaDB port")
+@click.option("--source-mariadb-root-username", default="root", help="Staging MariaDB root user")
+@click.option("--source-mariadb-root-password", help="Staging MariaDB root password")
+@click.option(
+	"--dynamic-space-size",
+	type=int,
+	default=None,
+	help="Heap (MB) for pgloader (default: pgloader's own); raise for very large dumps",
+)
+def convert_mariadb_backup(
+	sql_file_path,
+	output=None,
+	db_host="localhost",
+	db_port="5432",
+	db_root_username="postgres",
+	db_root_password=None,
+	source_mariadb_host="localhost",
+	source_mariadb_port="3306",
+	source_mariadb_root_username="root",
+	source_mariadb_root_password=None,
+	dynamic_space_size=None,
+):
+	"Convert a MariaDB site backup into a restorable PostgreSQL backup (needs pgloader; x86_64 only)"
+	from frappe.database.postgres.import_from_mariadb import convert_backup_to_postgres
+
+	output = output or _converted_backup_path(sql_file_path)
+	mariadb = {
+		"host": source_mariadb_host,
+		"port": source_mariadb_port,
+		"user": source_mariadb_root_username,
+		"password": source_mariadb_root_password,
+	}
+	postgres_root = {
+		"host": db_host,
+		"port": db_port,
+		"user": db_root_username,
+		"password": db_root_password,
+	}
+	try:
+		convert_backup_to_postgres(
+			sql_file_path, output, mariadb, postgres_root, verbose=True, dynamic_space_mb=dynamic_space_size
+		)
+	except (frappe.ValidationError, frappe.ExecutableNotFound) as e:
+		click.secho(str(e), fg="red")
+		raise SystemExit(1)
+	click.secho(f"Converted PostgreSQL backup written to {output}", fg="green")
+
+
+def _converted_backup_path(sql_file_path: str) -> str:
+	base = sql_file_path.removesuffix(".gz").removesuffix(".sql")
+	return f"{base}-postgres.sql.gz"
+
+
 commands = [
 	add_system_manager,
 	add_user_for_sites,
@@ -1704,4 +1808,5 @@ commands = [
 	clear_log_table,
 	bypass_patch,
 	sync_desktop_icons,
+	convert_mariadb_backup,
 ]

--- a/frappe/database/postgres/import_from_mariadb.py
+++ b/frappe/database/postgres/import_from_mariadb.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+"""Convert a MariaDB site backup into a PostgreSQL database using pgloader.
+
+pgloader reads from a live MySQL/MariaDB server (not a `.sql` dump) and does not run on
+ARM/Apple Silicon, so conversion needs a reachable MariaDB server to stage the dump and an
+x86_64 host. The pgloader run reproduces Frappe's PostgreSQL column types; JSON fields
+(longtext in MariaDB) land as text and are reconciled to native `json` by the `bench
+migrate` that follows the restore.
+
+Very large schemas can exceed PostgreSQL's `max_locks_per_transaction` while pgloader
+builds them ("out of shared memory"); if pgloader reports it, raise that setting in
+postgresql.conf and restart the server (it's postmaster-level, so it can't be set per run).
+"""
+
+import os
+import platform
+import shlex
+import tempfile
+from shutil import which
+from urllib.parse import quote
+
+import frappe
+from frappe.utils import execute_in_shell
+
+# MariaDB type -> PostgreSQL type rules that reproduce the columns Frappe itself creates.
+TYPE_CASTS = (
+	'type datetime to "timestamp without time zone" drop typemod using zero-dates-to-null',
+	"type date drop not null using zero-dates-to-null",
+	'type time to "time without time zone" drop typemod',
+	"type tinyint to smallint drop typemod",
+	"type int to integer drop typemod",
+	"type bigint to bigint drop typemod",
+	"type decimal to numeric keep typemod",
+	"type varchar to varchar keep typemod",
+	"type text to text",
+	"type tinytext to text",
+	"type mediumtext to text",
+	"type longtext to text",
+)
+
+# Conversion options for the restore hook. Module globals (not frappe.flags) because the
+# frappe.init() inside _new_site() resets frappe.local before the hook runs.
+_staging_mariadb: dict | None = None
+# MB for pgloader's SBCL heap; None leaves pgloader's own default. Raise for very large dumps.
+_dynamic_space_mb: int | None = None
+
+
+def set_staging_mariadb(conn: dict | None, dynamic_space_mb: int | None = None) -> None:
+	global _staging_mariadb, _dynamic_space_mb
+	_staging_mariadb = conn
+	if dynamic_space_mb:
+		_dynamic_space_mb = dynamic_space_mb
+
+
+def assert_conversion_supported() -> None:
+	"""Fail early unless pgloader can run here (x86_64 with pgloader installed).
+
+	Raises exception classes directly (not frappe.throw) so it works in the standalone
+	`bench convert-mariadb-backup` command, which runs without an initialised frappe.
+	"""
+	if platform.machine().lower() in ("arm64", "aarch64"):
+		raise frappe.ValidationError(
+			"Converting MariaDB backups to PostgreSQL needs pgloader, which does not run on "
+			"ARM/Apple Silicon. Run the conversion on an x86_64 host."
+		)
+	if not which("pgloader"):
+		raise frappe.ExecutableNotFound(
+			"`pgloader` not found in PATH. It is required to convert MariaDB backups to "
+			"PostgreSQL; install it (e.g. `apt-get install pgloader`) and retry."
+		)
+
+
+def _uri(scheme: str, conn: dict, db_name: str) -> str:
+	user = quote(conn["user"], safe="")
+	password = quote(conn.get("password") or "", safe="")
+	credentials = f"{user}:{password}@" if password else f"{user}@"
+	return f"{scheme}://{credentials}{conn['host']}:{conn['port']}/{db_name}"
+
+
+def build_pgloader_command(source_db: str, mariadb: dict, postgres: dict, target_db: str) -> str:
+	"""Return the pgloader load-file contents for a MariaDB -> PostgreSQL data copy."""
+	casts = ",\n      ".join(TYPE_CASTS)
+	return f"""LOAD DATABASE
+     FROM      {_uri("mysql", mariadb, source_db)}
+     INTO      {_uri("postgresql", postgres, target_db)}
+
+ WITH include drop, create tables, create indexes, reset sequences,
+      quote identifiers,
+      workers = 8, concurrency = 1,
+      batch rows = 5000, prefetch rows = 10000
+
+ SET PostgreSQL PARAMETERS
+      maintenance_work_mem to '512MB',
+      work_mem to '128MB'
+
+ CAST {casts}
+
+ ALTER SCHEMA '{source_db}' RENAME TO 'public'
+;
+"""
+
+
+class MariaDBToPostgres:
+	"""Populate an existing PostgreSQL database from a MariaDB site dump.
+
+	The target PostgreSQL database must already exist; pgloader creates the schema and
+	copies the data into it. JSON fields land as text (MariaDB stores them as longtext);
+	the subsequent `bench migrate` reconciles them to native json.
+	"""
+
+	def __init__(
+		self,
+		source_dump,
+		mariadb,
+		postgres,
+		staging_db=None,
+		verbose=False,
+		keep_staging=False,
+		dynamic_space_mb=None,
+	):
+		self.source_dump = source_dump
+		self.mariadb = mariadb
+		self.postgres = postgres
+		self.staging_db = staging_db or f"_pgload_{frappe.generate_hash(length=10)}"
+		self.verbose = verbose
+		self.keep_staging = keep_staging
+		self.dynamic_space_mb = dynamic_space_mb
+
+	def run(self):
+		assert_conversion_supported()
+		self._validate_source()
+		try:
+			self._stage_dump_in_mariadb()
+			self._run_pgloader()
+		finally:
+			if not self.keep_staging:
+				self._drop_staging()
+
+	def _validate_source(self):
+		from frappe.installer import get_dump_db_type, is_partial, validate_database_sql
+
+		validate_database_sql(self.source_dump)
+		if get_dump_db_type(self.source_dump) != "mariadb":
+			raise frappe.ValidationError(f"{self.source_dump} is not a MariaDB database dump.")
+		if is_partial(self.source_dump):
+			raise frappe.ValidationError("Cannot convert a partial backup to PostgreSQL.")
+
+	def _sh(self, command: str):
+		execute_in_shell(command, check_exit_code=True, verbose=self.verbose)
+
+	def _mysql(self) -> str:
+		args = [
+			"mysql",
+			f"--host={self.mariadb['host']}",
+			f"--port={self.mariadb['port']}",
+			f"--user={self.mariadb['user']}",
+		]
+		if self.mariadb.get("password"):
+			args.append(f"--password={self.mariadb['password']}")
+		return " ".join(args)
+
+	def _stage_dump_in_mariadb(self):
+		mysql = self._mysql()
+		create = (
+			f"DROP DATABASE IF EXISTS {self.staging_db}; "
+			f"CREATE DATABASE {self.staging_db} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+		)
+		self._sh(f"{mysql} -e {shlex.quote(create)}")
+
+		dump = shlex.quote(self.source_dump)
+		decompress = f"gzip -dc {dump}" if self.source_dump.endswith(".gz") else f"cat {dump}"
+		# Strip the MariaDB sandbox-mode line that older clients choke on (as bench restore does).
+		self._sh(f"set -o pipefail; {decompress} | sed '/\\/\\*M!999999/d' | {mysql} {self.staging_db}")
+
+	def _run_pgloader(self):
+		content = build_pgloader_command(self.staging_db, self.mariadb, self.postgres, self.postgres["db_name"])
+		with tempfile.NamedTemporaryFile("w", suffix=".load", delete=False) as load_file:
+			load_file.write(content)
+			path = load_file.name
+		try:
+			space = f"--dynamic-space-size {self.dynamic_space_mb} " if self.dynamic_space_mb else ""
+			self._sh(f"pgloader {space}{shlex.quote(path)}")
+		finally:
+			os.unlink(path)
+
+	def _drop_staging(self):
+		self._sh(f"{self._mysql()} -e {shlex.quote(f'DROP DATABASE IF EXISTS {self.staging_db};')}")
+
+
+def _connect(conn: dict, db_name: str):
+	import psycopg2
+
+	connection = psycopg2.connect(
+		host=conn["host"], port=conn["port"], dbname=db_name, user=conn["user"], password=conn.get("password") or ""
+	)
+	connection.autocommit = True
+	return connection
+
+
+def import_mariadb_dump(source_dump: str, verbose: bool = False):
+	"""Restore hook: convert a MariaDB dump into the current PostgreSQL site's database."""
+	if not _staging_mariadb:
+		raise frappe.ValidationError(
+			"Restoring a MariaDB backup onto a PostgreSQL site needs the source MariaDB "
+			"connection. Pass --source-mariadb-host / --source-mariadb-root-username / "
+			"--source-mariadb-root-password to bench restore."
+		)
+	postgres = {
+		"host": frappe.conf.db_host or "localhost",
+		"port": frappe.conf.db_port or 5432,
+		"user": frappe.conf.db_user,
+		"password": frappe.conf.db_password,
+		"db_name": frappe.conf.db_name,
+	}
+	MariaDBToPostgres(
+		source_dump, _staging_mariadb, postgres, verbose=verbose, dynamic_space_mb=_dynamic_space_mb
+	).run()
+
+
+def convert_backup_to_postgres(
+	source_dump,
+	output,
+	mariadb,
+	postgres_root,
+	verbose=False,
+	dynamic_space_mb=None,
+) -> str:
+	"""Convert a MariaDB backup file into a restorable PostgreSQL backup file.
+
+	Loads into a throwaway PostgreSQL database, then dumps it out as a Frappe-style
+	gzipped backup. `postgres_root` must be a superuser able to create databases.
+	"""
+	assert_conversion_supported()
+	scratch_db = f"_pgconv_{frappe.generate_hash(length=10)}"
+	_admin_sql(postgres_root, f'CREATE DATABASE "{scratch_db}"')
+	try:
+		target = {**postgres_root, "db_name": scratch_db}
+		MariaDBToPostgres(source_dump, mariadb, target, verbose=verbose, dynamic_space_mb=dynamic_space_mb).run()
+		_pg_dump_to_file(target, output, source_dump)
+	finally:
+		_admin_sql(postgres_root, f'DROP DATABASE IF EXISTS "{scratch_db}"')
+	return output
+
+
+def _admin_sql(postgres_root: dict, statement: str):
+	connection = _connect(postgres_root, "postgres")
+	try:
+		with connection.cursor() as cursor:
+			cursor.execute(statement)
+	finally:
+		connection.close()
+
+
+def _pg_dump_to_file(target: dict, output: str, source_dump: str):
+	header = _frappe_metadata_header(source_dump)
+	uri = _uri("postgresql", target, target["db_name"])
+	with tempfile.NamedTemporaryFile("w", suffix=".hdr", delete=False) as header_file:
+		header_file.write(header)
+		header_path = header_file.name
+	try:
+		# A gzip file may hold multiple members, so the header and dump concatenate cleanly.
+		execute_in_shell(
+			f"set -o pipefail; gzip -c {shlex.quote(header_path)} > {shlex.quote(output)}; "
+			f"pg_dump --no-owner --no-acl {shlex.quote(uri)} | gzip >> {shlex.quote(output)}",
+			check_exit_code=True,
+		)
+	finally:
+		os.unlink(header_path)
+
+
+def _frappe_metadata_header(source_dump: str) -> str:
+	"""Carry over the `-- begin/end frappe metadata` block from the source dump."""
+	from frappe.installer import get_db_dump_header
+
+	header = get_db_dump_header(source_dump, file_bytes=512)
+	start = header.find("-- begin frappe metadata")
+	end = header.find("-- end frappe metadata")
+	if start != -1 and end != -1:
+		return header[start : end + len("-- end frappe metadata")] + "\n"
+	return "-- begin frappe metadata\n-- end frappe metadata\n"

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -45,8 +45,16 @@ def setup_database():
 
 
 def bootstrap_database(verbose, source_sql=None):
-	frappe.connect()
-	import_db_from_sql(source_sql, verbose)
+	from frappe.installer import get_dump_db_type
+
+	if source_sql and get_dump_db_type(source_sql) == "mariadb":
+		# A MariaDB backup restored onto a PostgreSQL site is converted with pgloader.
+		from frappe.database.postgres.import_from_mariadb import import_mariadb_dump
+
+		import_mariadb_dump(source_sql, verbose)
+	else:
+		frappe.connect()
+		import_db_from_sql(source_sql, verbose)
 
 	frappe.connect()
 	if "tabDefaultValue" not in frappe.db.get_tables():

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -956,7 +956,25 @@ def get_db_dump_header(file_path: str, file_bytes: int = 256) -> str:
 	# Use `gzip` to open the file if the extension is `.gz`
 	if file_path.endswith(".gz"):
 		with gzip.open(file_path, "rb") as f:
-			return f.read(file_bytes).decode()
+			return f.read(file_bytes).decode(errors="ignore")
 
 	with open(file_path, "rb") as f:
-		return f.read(file_bytes).decode()
+		return f.read(file_bytes).decode(errors="ignore")
+
+
+def get_dump_db_type(sql_file_path: str) -> str:
+	"""Return the database engine ("mariadb" or "postgres") a SQL dump was produced by.
+
+	Detection is based on markers in the dump header: mysqldump quotes identifiers with
+	backticks and emits `MariaDB dump` / `/*!40101`, while pg_dump quotes with double
+	quotes and emits `PostgreSQL database dump` / `COPY public.`.
+	"""
+	header = get_db_dump_header(sql_file_path, file_bytes=2048)
+
+	if any(marker in header for marker in ("MariaDB dump", "MySQL dump", "/*!40101", "CREATE TABLE `")):
+		return "mariadb"
+	if any(marker in header for marker in ("PostgreSQL database dump", 'CREATE TABLE "', "CREATE TABLE public.", "COPY public.")):
+		return "postgres"
+
+	# Fallback: backtick identifiers are a MariaDB-only trait
+	return "mariadb" if "`" in header else "postgres"

--- a/frappe/tests/test_mariadb_to_postgres.py
+++ b/frappe/tests/test_mariadb_to_postgres.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+import gzip
+import os
+import tempfile
+from unittest.mock import patch
+
+import frappe
+from frappe.database.postgres import import_from_mariadb as converter
+from frappe.installer import get_dump_db_type
+from frappe.tests import UnitTestCase
+
+MARIADB_DUMP_HEADER = (
+	"-- begin frappe metadata\n-- version = 15.0.0\n-- end frappe metadata\n"
+	"/*!40101 SET NAMES utf8mb4 */;\n-- MariaDB dump 10.19\n"
+	"CREATE TABLE `tabUser` (\n  `name` varchar(140) NOT NULL\n);\n"
+)
+POSTGRES_DUMP_HEADER = (
+	"-- begin frappe metadata\n-- version = 15.0.0\n-- end frappe metadata\n"
+	"--\n-- PostgreSQL database dump\n--\n"
+	'CREATE TABLE public."tabUser" (\n  "name" varchar(140) NOT NULL\n);\n'
+)
+
+
+def _write_dump(text: str, suffix: str) -> str:
+	path = tempfile.mktemp(suffix=suffix)
+	opener = gzip.open if suffix.endswith(".gz") else open
+	with opener(path, "wt") as f:
+		f.write(text)
+	return path
+
+
+class TestMariaDBToPostgres(UnitTestCase):
+	def test_detects_dump_engine(self):
+		for suffix in (".sql", ".sql.gz"):
+			maria = _write_dump(MARIADB_DUMP_HEADER, suffix)
+			postgres = _write_dump(POSTGRES_DUMP_HEADER, suffix)
+			self.addCleanup(os.unlink, maria)
+			self.addCleanup(os.unlink, postgres)
+			self.assertEqual(get_dump_db_type(maria), "mariadb")
+			self.assertEqual(get_dump_db_type(postgres), "postgres")
+
+	def test_arm_is_unsupported(self):
+		with patch("platform.machine", return_value="arm64"):
+			self.assertRaises(frappe.ValidationError, converter.assert_conversion_supported)
+
+	def test_missing_pgloader_is_reported(self):
+		with patch("platform.machine", return_value="x86_64"), patch.object(converter, "which", return_value=None):
+			self.assertRaises(frappe.ExecutableNotFound, converter.assert_conversion_supported)
+
+	def test_pgloader_command_uses_frappe_conventions(self):
+		command = converter.build_pgloader_command(
+			"srcdb",
+			{"host": "mh", "port": "3306", "user": "root", "password": "p@s s"},
+			{"host": "ph", "port": "5432", "user": "u", "password": "pw"},
+			"targetdb",
+		)
+		self.assertIn("quote identifiers", command)
+		self.assertIn("ALTER SCHEMA 'srcdb' RENAME TO 'public'", command)
+		self.assertIn("type tinyint to smallint drop typemod", command)
+		self.assertIn("type decimal to numeric keep typemod", command)
+		# credentials are URL-encoded into the connection URIs
+		self.assertIn("mysql://root:p%40s%20s@mh:3306/srcdb", command)
+		self.assertIn("postgresql://u:pw@ph:5432/targetdb", command)
+
+	def _converter(self, **kwargs):
+		return converter.MariaDBToPostgres(
+			"/x.sql.gz",
+			{"host": "h", "port": "3306", "user": "root", "password": ""},
+			{"host": "ph", "port": "5432", "user": "u", "password": "pw", "db_name": "db"},
+			**kwargs,
+		)
+
+	def test_dynamic_space_omitted_by_default(self):
+		conv = self._converter()
+		self.assertIsNone(conv.dynamic_space_mb)
+		with patch.object(converter, "execute_in_shell") as run:
+			conv._run_pgloader()
+		self.assertNotIn("--dynamic-space-size", run.call_args.args[0])
+
+	def test_pgloader_run_uses_configured_dynamic_space(self):
+		conv = self._converter(dynamic_space_mb=9000)
+		with patch.object(converter, "execute_in_shell") as run:
+			conv._run_pgloader()
+		self.assertIn("--dynamic-space-size 9000", run.call_args.args[0])


### PR DESCRIPTION
## What
Restore a MariaDB site backup onto a PostgreSQL site. A new core converter stages the dump in a MariaDB server and runs `pgloader` to reproduce frappe's PostgreSQL schema; JSON columns are reconciled to native `json` by the `bench migrate` that follows.

## How
- `frappe/database/postgres/import_from_mariadb.py` — `MariaDBToPostgres` converter + `assert_conversion_supported()` (hard-fails on ARM/Apple Silicon, where pgloader is unsupported, and when `pgloader` is absent).
- `installer.get_dump_db_type()` — detect a dump's engine (mariadb/postgres) from its header.
- `setup_db.bootstrap_database()` — route a MariaDB dump through the converter during restore.
- `bench restore` — `--source-mariadb-*` staging options + a confirm prompt; `bench convert-mariadb-backup` — standalone file→file conversion.

## Notes
- `pgloader` only runs on **x86_64 Linux** and must be installed separately (this PR does not install it).
- Complements #40338 (USING casts so `bench migrate` reconciles type drift) and #40395 (gssencmode fork-safety). Companion Pilot integration: frappe/pilot#140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)