### PR TITLE
fix: print format builder regressions

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -81,7 +81,7 @@ watch(
 		}
 		el.textContent = css;
 	},
-	{ immediate: true }
+	{ immediate: true, deep: true }
 );
 onUnmounted(() => document.getElementById(CUSTOM_CSS_ID)?.remove());
 

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -59,10 +59,31 @@ import LetterHeadZoneEditor from "../letterhead/LetterHeadZoneEditor.vue";
 import PrintFormatSection from "./PrintFormatSection.vue";
 import SectionInsert from "./SectionInsert.vue";
 import { useStore } from "../../stores";
-import { computed, inject, watch, nextTick } from "vue";
+import { computed, inject, watch, nextTick, onUnmounted } from "vue";
 
 let { layout, letterhead, print_format } = useStore();
 let store = inject("$store");
+
+const CUSTOM_CSS_ID = "pfb-letterhead-custom-css";
+watch(
+	letterhead,
+	(lh) => {
+		let el = document.getElementById(CUSTOM_CSS_ID);
+		const css = lh?.custom_css;
+		if (!css) {
+			el?.remove();
+			return;
+		}
+		if (!el) {
+			el = document.createElement("style");
+			el.id = CUSTOM_CSS_ID;
+			document.head.appendChild(el);
+		}
+		el.textContent = css;
+	},
+	{ immediate: true }
+);
+onUnmounted(() => document.getElementById(CUSTOM_CSS_ID)?.remove());
 
 watch(
 	() => store.scroll_to_section.value,

--- a/frappe/public/js/print_format_builder/components/letterhead/LetterHeadZoneEditor.vue
+++ b/frappe/public/js/print_format_builder/components/letterhead/LetterHeadZoneEditor.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="lh-zone" :class="{ 'lh-zone--selected': is_selected }" @click.stop="select_zone">
-		<div v-if="letterhead && zone_content">
+		<div v-if="letterhead && zone_content" class="letter-head">
 			<!-- Preview mode: render Jinja server-side; edit mode: show raw -->
 			<div v-if="preview_doc" v-html="rendered_content ?? zone_content"></div>
 			<div v-else v-html="zone_content"></div>

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -101,7 +101,7 @@ body {
 	color: #111827;
 }
 
-/* Left-right (section-level): label takes 40%, value takes 60% */
+/* Left-right (section-level): label shrinks to content width, value takes the rest */
 .field.left-right,
 .field.field-inline {
 	display: flex;
@@ -118,27 +118,17 @@ body {
 	text-transform: none;
 	letter-spacing: 0;
 	padding-top: 0.05rem;
-}
-
-.field.left-right .label {
-	width: 40%;
-}
-
-.field.field-inline .label {
-	width: auto;
+	white-space: nowrap;
 }
 
 .field.field-inline .label::after {
 	content: ":";
 }
 
-.field.left-right .value {
-	width: 60%;
-	flex: 1;
-}
-
+.field.left-right .value,
 .field.field-inline .value {
 	flex: 1;
+	min-width: 0;
 }
 
 /* Field-level alignment */
@@ -158,17 +148,9 @@ body {
 	text-align: right;
 }
 
-/* In left-right orientation, alignment/spacing variants reset fixed widths so
-   justify-content can actually reposition the label+value pair. */
-.field.left-right.field-align-right .label,
-.field.left-right.field-align-right .value,
-.field.left-right.field-align-center .label,
-.field.left-right.field-align-center .value,
-.field.left-right.field-justify-space-between .label,
+/* Spacing/alignment variants for left-right orientation */
 .field.left-right.field-justify-space-between .value,
-.field.left-right.field-justify-space-evenly .label,
 .field.left-right.field-justify-space-evenly .value {
-	width: auto;
 	flex: none;
 }
 

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -148,7 +148,13 @@ body {
 	text-align: right;
 }
 
-/* Spacing/alignment variants for left-right orientation */
+/* Spacing/alignment variants for left-right orientation.
+   For right/center align and spacing variants, both label and value must be
+   flex:none so justify-content can reposition the pair as a unit. */
+.field.left-right.field-align-right .label,
+.field.left-right.field-align-right .value,
+.field.left-right.field-align-center .label,
+.field.left-right.field-align-center .value,
 .field.left-right.field-justify-space-between .value,
 .field.left-right.field-justify-space-evenly .value {
 	flex: none;

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -149,8 +149,8 @@ body {
 }
 
 /* Spacing/alignment variants for left-right orientation.
-   For right/center align and spacing variants, both label and value must be
-   flex:none so justify-content can reposition the pair as a unit. */
+   Right/center align: both label and value need flex:none so the pair moves as a unit.
+   Space-between/evenly: only value needs flex:none (label already has flex-shrink:0). */
 .field.left-right.field-align-right .label,
 .field.left-right.field-align-right .value,
 .field.left-right.field-align-center .label,

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -15,6 +15,9 @@
 	{%- if print_format.css -%}
 	<style>{{ print_format.css }}</style>
 	{%- endif -%}
+	{%- if letterhead and letterhead.custom_css -%}
+	<style>{{ letterhead.custom_css }}</style>
+	{%- endif -%}
 </head>
 <body>
 	{{ header or '' }}

--- a/frappe/templates/print_format/print_header.html
+++ b/frappe/templates/print_format/print_header.html
@@ -15,6 +15,6 @@
 </style>
 <header>
 	{%- if letterhead -%}
-	{{ frappe.render_template(letterhead.content, {'doc': doc}) }}
+	<div class="letter-head">{{ frappe.render_template(letterhead.content, {'doc': doc}) }}</div>
 	{%- endif -%}
 </header>

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -202,7 +202,9 @@ class PrintFormatGenerator:
 		if is_header and page_no_html:
 			parts.append(page_no_html)
 		if letterhead_html:
-			parts.append(frappe.render_template(letterhead_html, ctx))
+			parts.append(
+				'<div class="letter-head">' + frappe.render_template(letterhead_html, ctx) + "</div>"
+			)
 		if layout_template:
 			if isinstance(layout_template, str):
 				# layout_template is persisted header/footer HTML from the stored Print Format document.


### PR DESCRIPTION
**fix**
- Letterhead syncs correctly when switching print formats in print preview
- Letterhead `custom_css` now applied in HTML preview, PDF, and builder canvas
- Letterhead content wrapped in `.letter-head` across all render paths so user CSS selectors match
- Label width in left-right orientation uses natural content width instead of fixed 40%
- Right/center aligned fields in left-right orientation keep label+value as a tight pair

**feat**
- Conditional visibility for fields and sections via `visible_if` expression
- Label-value spacing control for left-right field orientation