### PR TITLE
fix(db): expand GROUP BY to include all non-aggregated SELECT fields on PG

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -297,7 +297,7 @@ class DatabaseQuery:
 		# Postgres requires any field that appears in the select clause to also
 		# appear in the order by and group by clause
 		if frappe.db.db_type == "postgres" and args.order_by and args.group_by:
-			args = self.prepare_select_args(args)
+			args = self.prepare_args_for_postgres_group_by(args)
 
 		query = """select {fields}
 from {tables}
@@ -388,14 +388,103 @@ from {tables}
 
 		return args
 
-	def prepare_select_args(self, args):
-		order_field = ORDER_BY_PATTERN.sub("", args.order_by)
+	_AGGREGATE_RE = re.compile(
+		r"^\s*(COUNT|SUM|AVG|MIN|MAX|GROUP_CONCAT|STRING_AGG|ARRAY_AGG)\s*\(",
+		re.IGNORECASE,
+	)
 
-		if order_field not in args.fields:
+	@staticmethod
+	def _split_fields(fields_str: str) -> list[str]:
+		"""Split a comma-separated field list, respecting parentheses depth."""
+		result = []
+		current: list[str] = []
+		depth = 0
+		for char in fields_str:
+			if char == "(":
+				depth += 1
+			elif char == ")":
+				depth = max(depth - 1, 0)
+			elif char == "," and depth == 0:
+				token = "".join(current).strip()
+				if token:
+					result.append(token)
+				current = []
+				continue
+			current.append(char)
+		token = "".join(current).strip()
+		if token:
+			result.append(token)
+		return result
+
+	@staticmethod
+	def _strip_alias(field: str) -> str:
+		"""Return field expression without a trailing ``AS alias``, respecting parentheses.
+
+		Naive ``field.split(" as ")`` would incorrectly split
+		``CAST(x as varchar) as alias`` on the inner ``as``.
+		"""
+		lower = field.lower()
+		depth = 0
+		last_as = -1
+		for i, char in enumerate(lower):
+			if char == "(":
+				depth += 1
+			elif char == ")":
+				depth = max(depth - 1, 0)
+			elif depth == 0 and lower[i : i + 4] == " as ":
+				last_as = i
+		if last_as > 0:
+			return field[:last_as].strip()
+		return field
+
+	def prepare_args_for_postgres_group_by(self, args):
+		"""Expand GROUP BY to include every non-aggregated SELECT field.
+
+		PostgreSQL (unlike MySQL) enforces SQL standard GROUP BY semantics:
+		every column in SELECT must either appear in GROUP BY or be wrapped
+		in an aggregate function.  When Frappe adds ``GROUP BY parent.name``
+		(e.g. for child-table filters), the remaining SELECT columns must
+		be appended to the GROUP BY clause.
+
+		The ORDER BY column is wrapped in ``MAX()`` only when it does not
+		already appear in GROUP BY or in the SELECT list (to avoid creating
+		a reference to a non-existent column when the ORDER BY value is
+		actually an alias like ``count``).
+		"""
+		fields_str = args.fields
+		# DISTINCT prefix is not a column — strip it before parsing
+		if fields_str.lower().startswith("distinct "):
+			fields_str = fields_str[9:]
+
+		group_by_str = args.group_by.replace(" group by ", "").strip()
+		existing = {col.strip() for col in group_by_str.split(",") if col.strip()}
+
+		extra: list[str] = []
+		for field in self._split_fields(fields_str):
+			if field == "*":
+				continue
+			# Skip aggregate functions — they don't belong in GROUP BY
+			if self._AGGREGATE_RE.match(field):
+				continue
+			# Skip correlated sub-selects like (SELECT COUNT(*) FROM …)
+			stripped = field.lstrip()
+			if stripped.startswith("(") and stripped.lstrip("( ").lower().startswith("select"):
+				continue
+			col = self._strip_alias(field)
+			if col not in existing:
+				extra.append(col)
+				existing.add(col)
+
+		if extra:
+			args.group_by = args.group_by.rstrip() + ", " + ", ".join(extra)
+
+		# Wrap ORDER BY in MAX() only if not already covered by GROUP BY
+		# or present in SELECT (to avoid referencing aliases as column names)
+		order_field = ORDER_BY_PATTERN.sub("", args.order_by)
+		if order_field and order_field not in existing and order_field not in args.fields:
 			extracted_column = order_column = order_field.replace("`", "")
 			if "." in extracted_column:
 				extracted_column = extracted_column.split(".")[1]
-
 			args.fields += f", MAX({extracted_column}) as `{order_column}`"
 			args.order_by = args.order_by.replace(order_field, f"`{order_column}`")
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -877,6 +877,67 @@ class TestDBQuery(IntegrationTestCase):
 		)
 		self.assertTrue(len(doctypes[0]) == 2)  # same for pg as well since we order_by None
 
+	def test_child_table_filter_with_group_by(self):
+		"""Filtering by a child-table field must not break on PostgreSQL.
+
+		When a child-table filter is applied, Frappe adds a LEFT JOIN and
+		GROUP BY `tabParent`.`name`.  On PostgreSQL every non-aggregated
+		SELECT column must appear in GROUP BY — prepare_args_for_postgres_group_by
+		handles this automatically.
+		"""
+		note = frappe.get_doc(
+			doctype="Note",
+			title=f"Test GROUP BY {frappe.utils.random_string(8)}",
+			content="test",
+			public=1,
+			seen_by=[{"user": "Administrator"}],
+		).insert()
+		self.addCleanup(note.delete)
+
+		results = frappe.get_all(
+			"Note",
+			filters=[["Note Seen By", "user", "=", "Administrator"]],
+			fields=["name", "title", "owner", "modified", "creation"],
+			limit=10,
+		)
+		self.assertTrue(any(r.name == note.name for r in results))
+
+	def test_split_fields_respects_parentheses(self):
+		"""_split_fields must not break on commas inside function calls."""
+		split = DatabaseQuery._split_fields
+
+		self.assertEqual(
+			split("`t`.`a`, `t`.`b`, `t`.`c`"),
+			["`t`.`a`", "`t`.`b`", "`t`.`c`"],
+		)
+		self.assertEqual(
+			split("COALESCE(`t`.`a`, ''), `t`.`b`"),
+			["COALESCE(`t`.`a`, '')", "`t`.`b`"],
+		)
+		self.assertEqual(
+			split("IFNULL(CONCAT(`a`, `b`), 'x'), `c`"),
+			["IFNULL(CONCAT(`a`, `b`), 'x')", "`c`"],
+		)
+		self.assertEqual(
+			split("(SELECT COUNT(*) FROM `tabComment` WHERE parent=`t`.`name`), `t`.`name`"),
+			["(SELECT COUNT(*) FROM `tabComment` WHERE parent=`t`.`name`)", "`t`.`name`"],
+		)
+
+	def test_strip_alias_respects_cast(self):
+		"""_strip_alias must not confuse CAST(… as …) with a column alias."""
+		strip = DatabaseQuery._strip_alias
+
+		self.assertEqual(strip("`tabNote`.`name` as note_name"), "`tabNote`.`name`")
+		self.assertEqual(
+			strip("cast(`tabNote`.`name` as varchar)"),
+			"cast(`tabNote`.`name` as varchar)",
+		)
+		self.assertEqual(
+			strip("cast(`tabNote`.`name` as varchar) as `tabNote`.`name`"),
+			"cast(`tabNote`.`name` as varchar)",
+		)
+		self.assertEqual(strip("`tabNote`.`title`"), "`tabNote`.`title`")
+
 	def test_field_comparison(self):
 		"""Test DatabaseQuery.execute to test field comparison"""
 		users_unedited = frappe.get_all(


### PR DESCRIPTION
In PostgreSQL, When filtering a list view by a child-table field (e.g. Table MultiSelect), Frappe adds a LEFT JOIN and GROUP BY `tabParent`.`name`. PostgreSQL rejects the resulting query because every non-aggregated SELECT column must appear in the GROUP BY clause — unlike MySQL which is lenient.

Replace `prepare_select_args` with `prepare_args_for_postgres_group_by` that:

- Parses SELECT fields with parenthesis-aware splitting (handles COALESCE, IFNULL, CAST, sub-selects safely)
- Appends every non-aggregated, non-sub-select column to GROUP BY
- Strips column aliases correctly, even for CAST(x as varchar) as alias
- Wraps ORDER BY in MAX() only when the field is not already in GROUP BY or SELECT (avoids referencing aliases like `count` as column names)

Guarded by `frappe.db.db_type == "postgres"` — zero impact on MySQL/MariaDB.

closes: #39851 
fixes: #39851 

authored by: @ZeinabMohammed

