### PR TITLE
fix(report): give datatable a definite height on mobile

### DIFF
--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -281,4 +281,9 @@
 	.group-by-box .row > div[class*="col-sm-"] {
 		margin-bottom: 5px;
 	}
+
+	.datatable .dt-scrollable {
+		height: calc(100vh - 200px) !important;
+		height: calc(100dvh - 200px) !important;
+	}
 }


### PR DESCRIPTION
## Problem

On v15, Query Reports render badly on mobile (iPhone/Safari): the DataTable body collapses to ~150px with its own internal scroll, the page scrolls separately, and there is a large blank area below the table.

`.dt-scrollable` (the DataTable body scroll area) has only `max-height` and `min-height`, with no definite `height`. The DataTable uses HyperList virtual scrolling, which measures the container with `getComputedStyle(.dt-scrollable).height` and renders only enough rows to fill it. With no definite height, the container resolves near its `min-height` on mobile Safari, so the table collapses and everything below it is blank.

## Fix

Add a mobile-only override that gives `.dt-scrollable` a viewport-sized height. The rule is global (`.datatable .dt-scrollable`), so the list "Report" view (same component) benefits too. Form grids and the standard List view use different components and are unaffected.

The two `height` declarations are intentional: older browsers use the `vh` line; modern browsers use `dvh`, which tracks the visible viewport on mobile and discards the `vh` line.

This is a backport of the mobile portion of #36991. Together with #34841 and #35723, this was fixed on develop/v16 but never backported to v15.

## How to test

1. `bench build --app frappe`
2. Hard-refresh / clear cache on the device.
3. Open any Query Report with enough rows to scroll.
4. In DevTools responsive mode below 576px width, confirm `.dt-scrollable` computed height is viewport-sized (not ~150px) and the blank area is gone.
5. Confirm on a real iPhone in Safari.

Support ticket: 72602
