### PR TITLE
fix: allow mention to render correctly

### DIFF
--- a/frappe/public/js/frappe/form/controls/quill-mention/blots/mention.js
+++ b/frappe/public/js/frappe/form/controls/quill-mention/blots/mention.js
@@ -10,7 +10,7 @@ class MentionBlot extends Embed {
 		denotationChar.innerHTML = data.denotationChar;
 		node.appendChild(denotationChar);
 		const valueSpan = document.createElement("span");
-		valueSpan.textContent = data.value;
+		valueSpan.innerHTML = data.value;
 		node.appendChild(valueSpan);
 		if (data.isGroup === "true") {
 			node.innerHTML += frappe.utils.icon("users");


### PR DESCRIPTION
Backport of #40420 to `version-16`.

Changes `textContent` back to `innerHTML` for mention rendering, which was broken by the XSS fix. This also unblocks the release PR #40426 by resolving the merge conflict.