### PR TITLE
feat(doctype): warn about leftover files when a doctype module changes

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -565,6 +565,7 @@ class DocType(Document):
 				self.run_module_method("after_doctype_insert")
 
 		if allow_doctype_export:
+			self.warn_on_module_change()
 
 			def export_doctype_files():
 				self.export_doc()
@@ -889,6 +890,20 @@ class DocType(Document):
 
 		if "field_order" in docdict:
 			del docdict["field_order"]
+
+	def warn_on_module_change(self):
+		"""Warn that the old module folder is left behind after a module change, since export only writes to the new one."""
+		previous = self.get_doc_before_save()
+		if not previous or previous.module == self.module:
+			return
+
+		old_path = get_doc_path(previous.module, "doctype", self.name)
+		frappe.msgprint(
+			_(
+				"Module changed to {0}. Files in the previous module were not moved and remain at {1}, remove or relocate them manually."
+			).format(frappe.bold(self.module), old_path),
+			alert=True,
+		)
 
 	def export_doc(self):
 		"""Export to standard folder `[module]/doctype/[name]/[name].json`."""

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -897,11 +897,15 @@ class DocType(Document):
 		if not previous or previous.module == self.module:
 			return
 
-		old_path = get_doc_path(previous.module, "doctype", self.name)
+		try:
+			old_path = get_doc_path(previous.module, "doctype", self.name)
+		except Exception:
+			return
+
 		frappe.msgprint(
 			_(
 				"Module changed to {0}. Files in the previous module were not moved and remain at {1}, remove or relocate them manually."
-			).format(frappe.bold(self.module), old_path),
+			).format(frappe.bold(self.module), frappe.bold(str(old_path))),
 			alert=True,
 		)
 

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -727,6 +727,28 @@ class TestDocType(IntegrationTestCase):
 					shutil.rmtree(controller_folder, ignore_errors=True)
 				frappe.local.request = previous_request
 
+	def test_warn_on_module_change(self):
+		doc = frappe.new_doc("DocType")
+		doc.name = "Test Module Change Warning"
+		doc.module = "Custom"
+
+		messages = []
+		with patch.object(frappe, "msgprint", side_effect=lambda msg, **kwargs: messages.append(msg)):
+			doc.get_doc_before_save = lambda: frappe._dict(module="Core")
+			doc.warn_on_module_change()
+			self.assertEqual(len(messages), 1)
+			self.assertIn("Custom", messages[0])
+
+			messages.clear()
+			doc.get_doc_before_save = lambda: frappe._dict(module="Custom")
+			doc.warn_on_module_change()
+			self.assertEqual(messages, [])
+
+			messages.clear()
+			doc.get_doc_before_save = lambda: frappe._dict(module="Does Not Exist")
+			doc.warn_on_module_change()
+			self.assertEqual(messages, [])
+
 	@unittest.skipUnless(
 		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
 	)


### PR DESCRIPTION
Reported in #37901: when a DocType is moved to a different module, the old module folder is left behind, along with any custom files (for example, `listview.js`).

Automatically moving or deleting those files on save is risky since they may contain hand-written code. Git already makes the leftover folder visible, so instead this adds a warning when the module changes, reminding the developer to clean up the old folder and move any custom files if needed.

The warning is only shown in `developer_mode` (following the existing export path) and only when the module actually changes.

#no-docs

---
Closes #37901.
