### PR TITLE
fix: orphan doctype removal deletes doctypes on transient import failure

### DIFF
--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -983,21 +983,21 @@ class TestDocType(IntegrationTestCase):
 	)
 	@patch.dict(frappe.conf, {"developer_mode": 1})
 	def test_keep_doctype_when_controller_import_fails_but_schema_exists(self):
-		doctype = new_doctype(custom=0).insert()
+		dt = new_doctype(custom=0).insert()
 		real_get_controller = frappe.model.sync.get_controller
 
-		def failing_get_controller(name):
-			if name == doctype.name:
+		def failing_get_controller(doctype):
+			if doctype == dt.name:
 				raise frappe.DoesNotExistError
-			return real_get_controller(name)
+			return real_get_controller(doctype)
 
 		try:
 			with patch("frappe.model.sync.get_controller", side_effect=failing_get_controller):
 				remove_orphan_doctypes()
 
-			self.assertTrue(frappe.db.exists("DocType", doctype.name))
+			self.assertTrue(frappe.db.exists("DocType", dt.name))
 		finally:
-			delete_controllers(doctype.name, doctype.module)
+			delete_controllers(dt.name, dt.module)
 
 	def test_not_in_list_view_for_not_allowed_mandatory_field(self):
 		doctype = new_doctype(

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -978,6 +978,27 @@ class TestDocType(IntegrationTestCase):
 		frappe.db.rollback()
 		self.assertFalse(frappe.db.exists("DocType", doctype.name))
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
+	@patch.dict(frappe.conf, {"developer_mode": 1})
+	def test_keep_doctype_when_controller_import_fails_but_schema_exists(self):
+		doctype = new_doctype(custom=0).insert()
+		real_get_controller = frappe.model.sync.get_controller
+
+		def failing_get_controller(name):
+			if name == doctype.name:
+				raise frappe.DoesNotExistError
+			return real_get_controller(name)
+
+		try:
+			with patch("frappe.model.sync.get_controller", side_effect=failing_get_controller):
+				remove_orphan_doctypes()
+
+			self.assertTrue(frappe.db.exists("DocType", doctype.name))
+		finally:
+			delete_controllers(doctype.name, doctype.module)
+
 	def test_not_in_list_view_for_not_allowed_mandatory_field(self):
 		doctype = new_doctype(
 			fields=[

--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -176,12 +176,14 @@ def schema_file_exists(doctype: str) -> bool:
 	module = frappe.db.get_value("DocType", doctype, "module")
 	if not module:
 		return False
-	try:
-		module_path = frappe.get_module_path(module)
-	except Exception:
-		return False
 	scrubbed = frappe.scrub(doctype)
-	return os.path.exists(os.path.join(module_path, "doctype", scrubbed, f"{scrubbed}.json"))
+	try:
+		json_path = frappe.get_module_path(module, "doctype", scrubbed, f"{scrubbed}.json")
+	except Exception:
+		# A failed path lookup is the same fragile signal as the bug being fixed, so
+		# assume the schema is present rather than deleting a possibly-valid doctype.
+		return True
+	return os.path.exists(json_path)
 
 
 def remove_orphan_doctypes():

--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -173,15 +173,15 @@ def get_doc_files(files, start_path):
 
 
 def schema_file_exists(doctype: str) -> bool:
+	# Return False only when the schema file is confirmed missing; on any uncertainty
+	# assume it exists so a valid doctype is never deleted on a failed lookup.
 	module = frappe.db.get_value("DocType", doctype, "module")
 	if not module:
-		return False
+		return True
 	scrubbed = frappe.scrub(doctype)
 	try:
 		json_path = frappe.get_module_path(module, "doctype", scrubbed, f"{scrubbed}.json")
 	except Exception:
-		# A failed path lookup is the same fragile signal as the bug being fixed, so
-		# assume the schema is present rather than deleting a possibly-valid doctype.
 		return True
 	return os.path.exists(json_path)
 

--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -172,6 +172,18 @@ def get_doc_files(files, start_path):
 	return files
 
 
+def schema_file_exists(doctype: str) -> bool:
+	module = frappe.db.get_value("DocType", doctype, "module")
+	if not module:
+		return False
+	try:
+		module_path = frappe.get_module_path(module)
+	except Exception:
+		return False
+	scrubbed = frappe.scrub(doctype)
+	return os.path.exists(os.path.join(module_path, "doctype", scrubbed, f"{scrubbed}.json"))
+
+
 def remove_orphan_doctypes():
 	"""Find and remove any orphaned doctypes.
 
@@ -184,10 +196,28 @@ def remove_orphan_doctypes():
 
 	doctype_names = frappe.get_all("DocType", {"custom": 0}, pluck="name")
 
+<<<<<<< HEAD
 	# Existence of the schema file is enough, importing the controller just to check if the doctype
 	# exists is expensive and can fail for unrelated reasons.
 	known_doctypes = create_entity_file_map(["DocType"])["DocType"]
 	orphan_doctypes = [doctype for doctype in doctype_names if doctype not in known_doctypes]
+=======
+	clear_controller_cache()
+	class_overrides = frappe.get_hooks("override_doctype_class", {})
+
+	for doctype in doctype_names:
+		if doctype in class_overrides:
+			continue
+		try:
+			get_controller(doctype=doctype)
+		except (ImportError, frappe.DoesNotExistError):
+			# An import failure alone is not proof of deletion; confirm the schema file
+			# is actually gone before treating the doctype as orphaned.
+			if not schema_file_exists(doctype):
+				orphan_doctypes.append(doctype)
+		except Exception:
+			continue
+>>>>>>> 02aa0dbf5a (fix(sync): only remove orphan doctype when its schema file is gone)
 
 	if not orphan_doctypes:
 		return


### PR DESCRIPTION
`remove_orphan_doctypes()` assumed any `get_controller()` failure meant the DocType had been deleted. That's not always true; imports can fail for unrelated reasons, and `bench migrate` would end up deleting a valid DocType while leaving its database table behind.

This change only treats a DocType as orphaned if its schema `.json` is actually missing. If the file exists, it won't be deleted even if the controller fails to import.

Reported in #37799. The report was right that `get_controller()` isn't a reliable orphan check, but the root cause wasn't a stale `module_app` cache. The real issue is controller import failures for individual DocTypes, which this fixes.

---
Closes #37799. 