### PR TITLE
feat: Error Fingerprinting

### DIFF
--- a/frappe/core/doctype/error_log/error_log.js
+++ b/frappe/core/doctype/error_log/error_log.js
@@ -5,13 +5,13 @@ frappe.ui.form.on("Error Log", {
 	refresh: function (frm) {
 		frm.disable_save();
 
-		if (frm.doc.reference_doctype && frm.doc.reference_name) {
-			frm.add_custom_button(__("Show Related Errors"), function () {
-				frappe.set_route("List", "Error Log", {
-					reference_doctype: frm.doc.reference_doctype,
-					reference_name: frm.doc.reference_name,
-				});
+		if (frm.doc.fingerprint) {
+			frm.add_custom_button(__("Show Similar Errors"), function () {
+				frappe.set_route("List", "Error Log", { fingerprint: frm.doc.fingerprint });
 			});
+		}
+
+		if (frm.doc.reference_doctype && frm.doc.reference_name) {
 			frm.add_custom_button(__("Open reference document"), function () {
 				frappe.set_route("Form", frm.doc.reference_doctype, frm.doc.reference_name);
 			});

--- a/frappe/core/doctype/error_log/error_log.json
+++ b/frappe/core/doctype/error_log/error_log.json
@@ -80,14 +80,15 @@
    "fieldname": "fingerprint",
    "fieldtype": "Data",
    "hidden": 1,
-   "label": "Fingerprint"
+   "label": "Fingerprint",
+   "search_index": 1
   }
  ],
  "icon": "fa fa-warning-sign",
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2026-07-01 09:22:52.555535",
+ "modified": "2026-07-01 09:59:20.900933",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Error Log",

--- a/frappe/core/doctype/error_log/error_log.json
+++ b/frappe/core/doctype/error_log/error_log.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "creation": "2013-01-16 13:09:40",
  "doctype": "DocType",
  "document_type": "System",
@@ -13,6 +14,7 @@
   "method",
   "error",
   "trace_id",
+  "fingerprint",
   "metadata"
  ],
  "fields": [
@@ -73,13 +75,19 @@
    "fieldtype": "Code",
    "label": "Metadata",
    "read_only": 1
+  },
+  {
+   "fieldname": "fingerprint",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Fingerprint"
   }
  ],
  "icon": "fa fa-warning-sign",
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2025-11-27 18:04:21.399557",
+ "modified": "2026-07-01 09:22:52.555535",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Error Log",

--- a/frappe/core/doctype/error_log/error_log.py
+++ b/frappe/core/doctype/error_log/error_log.py
@@ -19,6 +19,7 @@ class ErrorLog(Document):
 		from frappe.types import DF
 
 		error: DF.Code | None
+		fingerprint: DF.Data | None
 		metadata: DF.Code | None
 		method: DF.Data | None
 		reference_doctype: DF.Link | None

--- a/frappe/core/doctype/error_log/test_error_log.py
+++ b/frappe/core/doctype/error_log/test_error_log.py
@@ -16,6 +16,29 @@ class TestErrorLog(IntegrationTestCase):
 		error = doc.log_error("This is an error")
 		self.assertEqual(error.doctype, "Error Log")
 
+	def test_error_fingerprint(self):
+		def boom(msg):
+			raise ValueError(msg)
+
+		fingerprints = []
+		for msg in ("first", "second"):
+			try:
+				boom(msg)
+			except ValueError:
+				fingerprints.append(frappe.log_error().fingerprint)
+
+		# Same call path + exception type => same fingerprint, regardless of message
+		self.assertEqual(fingerprints[0], fingerprints[1])
+
+		# Different exception type => different fingerprint
+		try:
+			raise KeyError("first")
+		except KeyError:
+			self.assertNotEqual(frappe.log_error().fingerprint, fingerprints[0])
+
+		# No exception in context => None
+		self.assertIsNone(frappe.log_error().fingerprint)
+
 	def test_ldap_exceptions(self):
 		exc = [LDAPException, LDAPInappropriateAuthenticationResult]
 

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -2,13 +2,20 @@
 # License: MIT. See LICENSE
 
 import functools
+import hashlib
 import inspect
 import re
+import sys
+import traceback as traceback_module
 from collections import Counter
 from contextlib import suppress
+from typing import TYPE_CHECKING
 
 import frappe
 from frappe.monitor import add_data_to_monitor
+
+if TYPE_CHECKING:
+	from frappe.core.doctype.error_log.error_log import ErrorLog
 
 EXCLUDE_EXCEPTIONS = (
 	frappe.AuthenticationError,
@@ -34,7 +41,14 @@ def _is_ldap_exception(e):
 	return False
 
 
-def log_error(title=None, message=None, reference_doctype=None, reference_name=None, *, defer_insert=False):
+def log_error(
+	title=None,
+	message=None,
+	reference_doctype=None,
+	reference_name=None,
+	*,
+	defer_insert=False,
+) -> "ErrorLog":
 	"""Log error to Error Log"""
 	from frappe.monitor import get_trace_id
 	from frappe.utils.sentry import capture_exception
@@ -60,6 +74,7 @@ def log_error(title=None, message=None, reference_doctype=None, reference_name=N
 
 	trace_id = get_trace_id()
 	metadata = get_error_metadata()
+	fingerprint = get_error_fingerprint()
 
 	error_log = frappe.get_doc(
 		doctype="Error Log",
@@ -69,15 +84,45 @@ def log_error(title=None, message=None, reference_doctype=None, reference_name=N
 		reference_name=reference_name,
 		trace_id=trace_id,
 		metadata=metadata,
+		fingerprint=fingerprint,
 	)
 
 	if frappe.flags.read_only or defer_insert:
 		error_log.deferred_insert()
 	else:
-		return error_log.insert(ignore_permissions=True)
+		error_log.insert(ignore_permissions=True)
 
 	# Capture exception data if telemetry is enabled
 	capture_exception(message=f"{title}\n{traceback}")
+
+	return error_log
+
+
+def get_error_fingerprint(exception: BaseException | None = None) -> str | None:
+	"""Compute a stable fingerprint for an exception.
+
+	This hashes the *relevant* parts of the exception so that identical errors can be grouped and
+	counted together. For each stack frame we combine the file, line number and function, along
+	with the exception type.
+	"""
+	from frappe.utils import get_bench_path
+
+	with suppress(Exception):
+		if exception is None:
+			exception = sys.exc_info()[1]
+
+		if exception is None:
+			return None
+
+		bench_path = get_bench_path() + "/"
+
+		parts = [type(exception).__name__]
+		for frame, lineno in traceback_module.walk_tb(exception.__traceback__):
+			code = frame.f_code
+			filename = code.co_filename.replace(bench_path, "")
+			parts.append(f"{filename}:{lineno}:{code.co_name}")
+
+		return hashlib.sha1("\n".join(parts).encode(), usedforsecurity=False).hexdigest()
 
 
 def get_error_metadata() -> str:

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -71,13 +71,13 @@ def log_error(title=None, message=None, reference_doctype=None, reference_name=N
 		metadata=metadata,
 	)
 
-	# Capture exception data if telemetry is enabled
-	capture_exception(message=f"{title}\n{traceback}")
-
 	if frappe.flags.read_only or defer_insert:
 		error_log.deferred_insert()
 	else:
 		return error_log.insert(ignore_permissions=True)
+
+	# Capture exception data if telemetry is enabled
+	capture_exception(message=f"{title}\n{traceback}")
 
 
 def get_error_metadata() -> str:


### PR DESCRIPTION
`Error Log` on their own are just flat logs. If you want some actionable
list then you need a way to sort them by how frequently they occur.

Fingerprinting is a way to uniquely identify each error by hashing the
relevant parts:

e.g. `hash([filename, line_no, func] for each frame)`
