### PR TITLE
feat(print-format-builder): field/section styling, unified font size, editable table headers

### DIFF
--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -227,13 +227,23 @@
 
 			<div class="pfb-group-label mt-3">{{ __("Font") }}</div>
 			<div class="form-group">
-				<label class="control-label">{{ __("Google Font") }}</label>
+				<label class="control-label">{{ __("Font family") }}</label>
 				<select class="form-control form-control-sm" v-model="print_format.font">
-					<option v-for="font in google_fonts" :value="font">{{ font }}</option>
+					<option value="Default">{{ __("Default") }}</option>
+					<optgroup :label="__('System')">
+						<option v-for="font in system_fonts" :key="font" :value="font">
+							{{ font }}
+						</option>
+					</optgroup>
+					<optgroup :label="__('Google Fonts')">
+						<option v-for="font in google_fonts" :key="font" :value="font">
+							{{ font }}
+						</option>
+					</optgroup>
 				</select>
 			</div>
 			<div class="form-group">
-				<label class="control-label">{{ __("Font Size (pt)") }}</label>
+				<label class="control-label">{{ __("Font Size (px)") }}</label>
 				<input
 					type="number"
 					class="form-control form-control-sm"
@@ -264,6 +274,17 @@ import { computed, onMounted, onUnmounted, nextTick, ref, watch, inject } from "
 // state
 let search_text = ref("");
 let google_fonts = ref([]);
+const system_fonts = [
+	"Arial",
+	"Helvetica",
+	"Verdana",
+	"Tahoma",
+	"Trebuchet MS",
+	"Georgia",
+	"Times New Roman",
+	"Garamond",
+	"Courier New",
+];
 let activeTab = ref("fields");
 let search_input = ref(null);
 let raw_templates = ref([]);
@@ -541,8 +562,10 @@ onMounted(() => {
 	let method = "frappe.printing.page.print_format_builder.print_format_builder.get_google_fonts";
 	frappe.call(method).then((r) => {
 		google_fonts.value = r.message || [];
-		if (!google_fonts.value.includes(print_format.value.font)) {
-			google_fonts.value.push(print_format.value.font);
+		// Only surface a saved font if it isn't already a Default/system option
+		const f = print_format.value.font;
+		if (f && f !== "Default" && !system_fonts.includes(f) && !google_fonts.value.includes(f)) {
+			google_fonts.value.push(f);
 		}
 	});
 

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -7,6 +7,7 @@
 			'field--preview': !!preview_doc,
 			'field--condition-hidden': preview_doc && !is_field_visible,
 		}"
+		:style="wrap_style"
 		v-show="!df.remove"
 		:title="df.label || df.fieldname"
 		@click.stop="select_field"
@@ -30,9 +31,7 @@
 				<!-- Table MultiSelect field: render as a comma-separated value list -->
 				<div
 					v-else-if="df.fieldtype == 'Table MultiSelect'"
-					:style="
-						field_orientation !== 'left-right' ? { textAlign: df.align || 'left' } : {}
-					"
+					:style="lr_style"
 					:class="[
 						'field-preview-lr',
 						field_orientation === 'left-right' && df.label_justify
@@ -43,12 +42,17 @@
 							: '',
 					]"
 				>
-					<div v-if="df.label && df.show_label !== 'hide'" class="field-preview-label">
+					<div
+						v-if="df.label && df.show_label !== 'hide'"
+						class="field-preview-label"
+						:style="label_style"
+					>
 						{{ df.label }}
 					</div>
 					<div
 						class="field-preview-value"
 						:class="{ 'text-muted': !(preview_doc[df.fieldname] || []).length }"
+						:style="value_style"
 					>
 						{{ multiselect_display(df) }}
 					</div>
@@ -56,72 +60,79 @@
 				<!-- Table field -->
 				<div v-else-if="df.fieldtype == 'Table'" class="field-preview-table">
 					<div v-if="df.label" class="field-preview-label">{{ df.label }}</div>
-					<table
-						class="preview-table"
-						:class="{
-							[`preview-table--${df.table_style || 'lined'}`]: true,
-							'preview-table--borderless': df.table_bordered === false,
-							'preview-table--plain-header': df.table_header === 'plain',
-						}"
-					>
-						<thead>
-							<tr>
-								<th
-									v-for="col in df.table_columns"
-									:key="col.fieldname"
-									:class="numeric_align_class(col)"
-									:style="col.width ? { width: col.width + '%' } : {}"
+					<div class="preview-table-wrap" :style="table_radius_style">
+						<table
+							class="preview-table"
+							:class="{
+								[`preview-table--${df.table_style || 'lined'}`]: true,
+								'preview-table--borderless': df.table_bordered === false,
+								'preview-table--plain-header': df.table_header === 'plain',
+							}"
+						>
+							<thead v-if="df.table_header !== 'none'">
+								<tr>
+									<th
+										v-for="col in df.table_columns"
+										:key="col.fieldname"
+										:class="numeric_align_class(col)"
+										:style="[
+											col.width ? { width: col.width + '%' } : {},
+											cell_pad_style,
+										]"
+									>
+										{{ col.label || col.fieldname }}
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr
+									v-for="(row, i) in (preview_doc[df.fieldname] || []).slice(
+										0,
+										4
+									)"
+									:key="i"
+									:class="i % 2 === 0 ? 'odd' : 'even'"
 								>
-									{{ col.label || col.fieldname }}
-								</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr
-								v-for="(row, i) in (preview_doc[df.fieldname] || []).slice(0, 4)"
-								:key="i"
-								:class="i % 2 === 0 ? 'odd' : 'even'"
-							>
-								<td
-									v-for="col in df.table_columns"
-									:key="col.fieldname"
-									:class="numeric_align_class(col)"
-								>
-									<img
-										v-if="
-											is_image_field(col, row[col.fieldname]) &&
-											row[col.fieldname]
-										"
-										:src="row[col.fieldname]"
-										class="preview-table-img"
-										:alt="col.label || col.fieldname"
-									/>
-									<div
-										v-else-if="is_html_content_field(col)"
-										class="preview-table-html"
-										v-html="format_cell(row, col)"
-									></div>
-									<span v-else>{{ format_cell(row, col) }}</span>
-								</td>
-							</tr>
-							<tr v-if="!preview_doc[df.fieldname]?.length">
-								<td
-									:colspan="df.table_columns?.length || 1"
-									class="text-muted"
-									style="text-align: center; font-size: 11px; padding: 6px"
-								>
-									{{ __("No rows") }}
-								</td>
-							</tr>
-						</tbody>
-					</table>
+									<td
+										v-for="col in df.table_columns"
+										:key="col.fieldname"
+										:class="numeric_align_class(col)"
+										:style="cell_pad_style"
+									>
+										<img
+											v-if="
+												is_image_field(col, row[col.fieldname]) &&
+												row[col.fieldname]
+											"
+											:src="row[col.fieldname]"
+											class="preview-table-img"
+											:alt="col.label || col.fieldname"
+										/>
+										<div
+											v-else-if="is_html_content_field(col)"
+											class="preview-table-html"
+											v-html="format_cell(row, col)"
+										></div>
+										<span v-else>{{ format_cell(row, col) }}</span>
+									</td>
+								</tr>
+								<tr v-if="!preview_doc[df.fieldname]?.length">
+									<td
+										:colspan="df.table_columns?.length || 1"
+										class="text-muted"
+										style="text-align: center; font-size: 11px; padding: 6px"
+									>
+										{{ __("No rows") }}
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
 				</div>
 				<!-- Regular field -->
 				<div
 					v-else
-					:style="
-						field_orientation !== 'left-right' ? { textAlign: df.align || 'left' } : {}
-					"
+					:style="lr_style"
 					:class="[
 						'field-preview-lr',
 						field_orientation === 'left-right' && df.label_justify
@@ -132,10 +143,18 @@
 							: '',
 					]"
 				>
-					<div v-if="df.label && df.show_label !== 'hide'" class="field-preview-label">
+					<div
+						v-if="df.label && df.show_label !== 'hide'"
+						class="field-preview-label"
+						:style="label_style"
+					>
 						{{ df.label }}
 					</div>
-					<div class="field-preview-value" :class="{ 'text-muted': !preview_value }">
+					<div
+						class="field-preview-value"
+						:class="{ 'text-muted': !preview_value }"
+						:style="value_style"
+					>
 						<img
 							v-if="is_image_field(df, preview_value) && preview_value"
 							:src="preview_value"
@@ -191,7 +210,7 @@
 							@keydown.enter="editing = false"
 							@blur="editing = false"
 						/>
-						<span v-else-if="df.label">{{ df.label }}</span>
+						<span v-else-if="df.label" :style="label_style">{{ df.label }}</span>
 						<i class="text-muted" v-else>{{ __("No Label") }} ({{ df.fieldname }})</i>
 					</div>
 					<div class="field-meta">
@@ -255,6 +274,60 @@ let rendered_template = ref(null);
 let is_selected = computed(() => store.selected_field.value === props.df);
 let preview_doc = computed(() => store.preview_doc.value);
 let is_field_visible = computed(() => evaluate_visible_if(props.df.visible_if, preview_doc.value));
+
+// ── User field styling (mirrors the PDF render in Data.html) ──
+function box_css(box) {
+	if (!box) return null;
+	return `${box.top || 0}px ${box.right || 0}px ${box.bottom || 0}px ${box.left || 0}px`;
+}
+
+let wrap_style = computed(() => {
+	const o = props.df.style;
+	if (!o) return {};
+	const st = {};
+	if (o.background) st.backgroundColor = o.background;
+	const pad = box_css(o.padding);
+	if (pad) st.padding = pad;
+	const mar = box_css(o.margin);
+	if (mar) st.margin = mar;
+	return st;
+});
+
+// Label and value carry independent typography (color / bold). Font size is
+// page-level (set in the Format tab), so it is intentionally not per-field.
+function typo_style(target) {
+	const o = props.df.style?.[target];
+	if (!o) return {};
+	const st = {};
+	if (o.color) st.color = o.color;
+	if (o.bold) st.fontWeight = "600";
+	return st;
+}
+
+let value_style = computed(() => typo_style("value"));
+
+// Per-cell padding for child tables (px). Applied to every th/td.
+let cell_pad_style = computed(() => {
+	const p = props.df.table_cell_padding;
+	return p || p === 0 ? { padding: p + "px" } : {};
+});
+
+// Table corner radius: round + clip via the wrapper so collapsed borders curve
+let table_radius_style = computed(() => {
+	const r = props.df.table_radius;
+	return r ? { borderRadius: r + "px", overflow: "hidden" } : {};
+});
+
+let label_style = computed(() => typo_style("label"));
+
+// Style for the label+value container: text alignment (top mode) + custom gap
+let lr_style = computed(() => {
+	const st = {};
+	if (props.field_orientation !== "left-right") st.textAlign = props.df.align || "left";
+	const g = props.df.style?.gap;
+	if (g) st.gap = g + "px";
+	return st;
+});
 
 // Render Jinja2 HTML fields server-side when in preview mode
 watch(
@@ -693,6 +766,9 @@ watch(
 	background: transparent;
 	padding: 0;
 	position: relative;
+	/* Inherit the page base size (.pfb-body) so the em-based label/value text
+	   below scales with the print format's font size instead of a fixed value. */
+	font-size: inherit;
 }
 
 .field--condition-hidden {
@@ -718,7 +794,7 @@ watch(
 }
 
 .field-preview-label {
-	font-size: var(--text-tiny);
+	font-size: 1em;
 	font-weight: var(--weight-semibold);
 	color: #6b7280;
 	margin-bottom: 1px;
@@ -775,7 +851,7 @@ watch(
 }
 
 .field-preview-value {
-	font-size: var(--text-sm);
+	font-size: 1em;
 	color: var(--text-color);
 	word-break: break-word;
 }
@@ -835,7 +911,7 @@ watch(
 }
 
 .field-preview-table > .field-preview-label {
-	font-size: 0.8em;
+	font-size: 1em;
 	font-weight: var(--weight-semibold);
 	color: var(--text-muted);
 	margin-bottom: 0.4rem;
@@ -844,7 +920,7 @@ watch(
 .preview-table {
 	width: 100%;
 	border-collapse: collapse;
-	font-size: var(--text-sm);
+	font-size: 1em;
 	table-layout: fixed;
 }
 
@@ -853,7 +929,7 @@ watch(
 	background-color: var(--gray-100);
 	color: var(--text-color);
 	font-weight: var(--weight-semibold);
-	font-size: var(--text-tiny);
+	font-size: 1em;
 	padding: 0.45rem 0.6rem;
 	border: 1px solid var(--gray-200);
 	text-align: left;
@@ -903,11 +979,10 @@ watch(
 	text-align: right;
 }
 
-/* ── Borderless variant ──────────────────────────────── */
+/* ── Borderless variant — no cell borders at all ─────── */
 .preview-table--borderless th,
 .preview-table--borderless td {
 	border: none;
-	border-bottom: 1px solid var(--gray-200);
 }
 
 /* ── Plain header variant ───────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -143,8 +143,11 @@ let rootStyles = computed(() => {
 let bodyStyles = computed(() => {
 	const { font_size, font } = print_format.value;
 	const styles = {};
-	if (font_size) styles.fontSize = `${font_size}pt`;
-	if (font) styles.fontFamily = `'${font}', sans-serif`;
+	// Base size in px to match the actual print output (print_format.css sets
+	// `html, body { font-size: <font_size>px }`). The em-based field text below
+	// scales off this, so changing the page font size is visible here too.
+	styles.fontSize = `${parseFloat(font_size) || 14}px`;
+	if (font && font !== "Default") styles.fontFamily = `'${font}', sans-serif`;
 	return styles;
 });
 
@@ -322,13 +325,13 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	opacity: 1;
 }
 
-/* Section title: match PDF's .section-label look */
+/* Section title: match PDF's .section-label look (same size as body, bold) */
 .pfb-clean-preview :deep(.section-title-display) {
 	display: block;
 	padding: 0 0 0.3rem;
 	margin-bottom: 0.4rem;
 	border-bottom: 1.5px solid var(--border-color);
-	font-size: var(--text-lg);
+	font-size: 1em;
 	font-weight: var(--weight-bold);
 	color: var(--text-color);
 }

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -22,6 +22,8 @@
 			:class="{
 				'section--selected': is_selected,
 				'label-uppercase': section.label_case === 'uppercase',
+				'section--grid': is_grid,
+				'section--grid-rows': is_grid && grid_inner_rows,
 			}"
 			:style="section_inline_style"
 			@click.stop="select_section"
@@ -62,14 +64,13 @@
 			>
 				{{ section.label }}
 			</div>
-			<div
-				class="section-columns"
-				:style="
-					section.columns.length > 1 && section.gap ? { gap: section.gap + 'px' } : {}
-				"
-			>
+			<div class="section-columns" :style="columns_style">
 				<template v-for="(column, i) in section.columns" :key="i">
-					<div v-if="i > 0" class="column-divider"></div>
+					<div
+						v-if="i > 0 && show_col_divider"
+						class="column-divider"
+						:style="divider_style"
+					></div>
 					<div
 						class="column"
 						:class="{ 'column-align-right': column.align === 'right' }"
@@ -138,6 +139,29 @@ let is_section_visible = computed(() =>
 	evaluate_visible_if(props.section.visible_if, preview_doc.value)
 );
 
+// ── Table-layout (field borders) state ────────────────────
+let is_grid = computed(() => !!props.section.field_borders);
+let grid_inner_rows = computed(() => props.section.inner_rows !== false);
+let grid_inner_cols = computed(() => props.section.inner_cols !== false);
+let grid_cell_pad = computed(() => props.section.cell_padding ?? 8);
+
+// The shared "1px solid #color" edge used for both the outer box and inner lines
+let grid_edge = computed(() => {
+	const b = props.section.border || {};
+	return `${b.width || 1}px ${b.style || "solid"} ${b.color || "#e5e7eb"}`;
+});
+
+// Apply the per-side border to a target style object using the border config
+function apply_border(style, b) {
+	if (!b || !b.width) return;
+	const edge = `${b.width}px ${b.style || "solid"} ${b.color || "#000000"}`;
+	if (b.top !== false) style.borderTop = edge;
+	if (b.right !== false) style.borderRight = edge;
+	if (b.bottom !== false) style.borderBottom = edge;
+	if (b.left !== false) style.borderLeft = edge;
+	if (b.radius) style.borderRadius = b.radius + "px";
+}
+
 let section_inline_style = computed(() => {
 	const style = {};
 	if (props.section.background) style.backgroundColor = props.section.background;
@@ -145,7 +169,34 @@ let section_inline_style = computed(() => {
 		const p = props.section.padding;
 		style.padding = `${p.top || 0}px ${p.right || 0}px ${p.bottom || 0}px ${p.left || 0}px`;
 	}
+	// In grid mode the border/radius live on .section-columns instead of the wrapper
+	if (!is_grid.value) apply_border(style, props.section.border);
 	return style;
+});
+
+let columns_style = computed(() => {
+	const style = {};
+	if (props.section.columns.length > 1 && props.section.gap) {
+		style.gap = props.section.gap + "px";
+	}
+	if (is_grid.value) {
+		apply_border(style, props.section.border);
+		style.padding = "0";
+		style.gap = "0";
+		if (props.section.border?.radius) style.overflow = "hidden";
+		// CSS vars consumed by the scoped grid rules
+		style["--pfb-line"] = grid_edge.value;
+		style["--pfb-cell-pad"] = grid_cell_pad.value + "px";
+	}
+	return style;
+});
+
+// Column dividers double as the inner vertical lines in grid mode
+let show_col_divider = computed(() => (is_grid.value ? grid_inner_cols.value : true));
+let divider_style = computed(() => {
+	if (!is_grid.value) return {};
+	const b = props.section.border || {};
+	return { width: (b.width || 1) + "px", background: b.color || "#e5e7eb", margin: "0" };
 });
 
 function select_section() {
@@ -334,6 +385,35 @@ function remove_column(index) {
 	background: var(--border-color);
 	margin: 0 0.5rem;
 	flex-shrink: 0;
+}
+
+/* ── Table layout (field borders) ────────────────────────── */
+/* Cells fill their column; reset each field's own chrome and use cell padding */
+.section--grid .column {
+	padding: 0;
+}
+
+.section--grid .drag-container {
+	gap: 0;
+	min-height: 0;
+	border-radius: 0;
+}
+
+.section--grid :deep(.field) {
+	border: none !important;
+	border-radius: 0 !important;
+	background: transparent !important;
+	margin: 0 !important;
+	padding: var(--pfb-cell-pad, 8px) !important;
+}
+
+.section--grid :deep(.field-preview-wrap) {
+	padding: 0 !important;
+}
+
+/* Horizontal inner lines: between adjacent cells in a column */
+.section--grid-rows :deep(.drag-container > .field + .field) {
+	border-top: var(--pfb-line, 1px solid var(--border-color)) !important;
 }
 
 .drag-container {

--- a/frappe/public/js/print_format_builder/components/inspector/BoxInput.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/BoxInput.vue
@@ -1,0 +1,70 @@
+<template>
+	<div class="pfb-box">
+		<label v-for="side in sides" :key="side" class="pfb-box-cell" :title="__(side)">
+			<span>{{ side[0].toUpperCase() }}</span>
+			<input
+				type="number"
+				min="0"
+				placeholder="0"
+				:value="modelValue && modelValue[side] ? modelValue[side] : ''"
+				@change="(e) => update(side, e.target.value)"
+			/>
+		</label>
+	</div>
+</template>
+
+<script setup>
+// Compact top / right / bottom / left number inputs bound to a single
+// { top, right, bottom, left } object. Emits null once every side is 0 so the
+// caller can drop the key entirely.
+const props = defineProps({
+	modelValue: { type: Object, default: null },
+});
+const emit = defineEmits(["update:modelValue"]);
+
+const sides = ["top", "right", "bottom", "left"];
+
+function update(side, raw) {
+	const next = { top: 0, right: 0, bottom: 0, left: 0, ...(props.modelValue || {}) };
+	next[side] = Math.max(0, parseInt(raw) || 0);
+	emit("update:modelValue", sides.every((s) => !next[s]) ? null : next);
+}
+</script>
+
+<style scoped>
+.pfb-box {
+	display: flex;
+	gap: 4px;
+}
+
+.pfb-box-cell {
+	display: flex;
+	align-items: center;
+	gap: 3px;
+	flex: 1;
+	min-width: 0;
+	margin: 0;
+}
+
+.pfb-box-cell span {
+	font-size: var(--text-tiny);
+	color: var(--text-muted);
+}
+
+.pfb-box-cell input {
+	width: 100%;
+	min-width: 0;
+	text-align: center;
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	background: var(--fg-color);
+	color: var(--text-color);
+	padding: 3px 2px;
+	font-size: var(--text-sm);
+	outline: none;
+}
+
+.pfb-box-cell input:focus {
+	border-color: var(--primary);
+}
+</style>

--- a/frappe/public/js/print_format_builder/components/inspector/ColorInput.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/ColorInput.vue
@@ -1,0 +1,50 @@
+<template>
+	<div ref="mount" class="pfb-colorinput"></div>
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount, watch } from "vue";
+
+// Thin wrapper around frappe's built-in Color control so the print-format
+// builder reuses the standard picker (palette + native picker + hex entry)
+// instead of a bespoke widget.
+const props = defineProps({
+	modelValue: { type: String, default: "" },
+});
+const emit = defineEmits(["update:modelValue"]);
+
+const mount = ref(null);
+let control = null;
+
+onMounted(() => {
+	control = frappe.ui.form.make_control({
+		parent: mount.value,
+		df: {
+			fieldtype: "Color",
+			fieldname: "color",
+			change: () => {
+				const v = control.get_value() || "";
+				if (v !== (props.modelValue || "")) emit("update:modelValue", v);
+			},
+		},
+		render_input: true,
+		only_input: true,
+	});
+	control.set_value(props.modelValue || "");
+});
+
+watch(
+	() => props.modelValue,
+	(v) => {
+		if (control && (control.get_value() || "") !== (v || "")) control.set_value(v || "");
+	}
+);
+
+onBeforeUnmount(() => control?.$wrapper?.remove());
+</script>
+
+<style scoped>
+.pfb-colorinput :deep(.control-input) {
+	min-width: 0;
+}
+</style>

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -133,7 +133,7 @@
 							<span class="pfb-insp-label">{{ __("Header") }}</span>
 							<div class="pfb-seg">
 								<button
-									:class="{ active: table_header !== 'plain' }"
+									:class="{ active: table_header === 'styled' }"
 									@click="selected_field.table_header = 'styled'"
 								>
 									{{ __("Styled") }}
@@ -144,7 +144,37 @@
 								>
 									{{ __("Plain") }}
 								</button>
+								<button
+									:class="{ active: table_header === 'none' }"
+									:title="__('Hide the header row')"
+									@click="selected_field.table_header = 'none'"
+								>
+									{{ __("None") }}
+								</button>
 							</div>
+						</div>
+						<!-- Cell padding -->
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Cell padding") }}</span>
+							<input
+								class="pfb-num"
+								type="number"
+								min="0"
+								:value="cell_padding"
+								@change="(e) => set_cell_padding(e.target.value)"
+							/>
+						</div>
+						<!-- Corner radius -->
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Radius") }}</span>
+							<input
+								class="pfb-num"
+								type="number"
+								min="0"
+								placeholder="0"
+								:value="selected_field.table_radius || ''"
+								@change="(e) => set_table_radius(e.target.value)"
+							/>
 						</div>
 					</div>
 				</div>
@@ -179,9 +209,13 @@
 										class="pfb-col-drag"
 										v-html="frappe.utils.icon('drag', 'xs')"
 									></span>
-									<span class="pfb-col-label" :title="col.fieldname">{{
-										col.label || col.fieldname
-									}}</span>
+									<input
+										class="pfb-col-label-input"
+										type="text"
+										v-model="col.label"
+										:placeholder="col.fieldname"
+										:title="__('Header label') + ' (' + col.fieldname + ')'"
+									/>
 									<input
 										class="pfb-col-width-input"
 										type="number"
@@ -339,6 +373,111 @@
 					</div>
 				</div>
 
+				<div class="pfb-insp-section" v-if="!is_html_field">
+					<div class="pfb-insp-section-head" @click="toggle('f_style')">
+						<span class="pfb-insp-section-label">{{ __("Style") }}</span>
+						<span
+							class="pfb-insp-chevron"
+							:class="{ collapsed: !open.f_style }"
+							v-html="frappe.utils.icon('chevron-down', 'xs')"
+						></span>
+					</div>
+					<div v-show="open.f_style" class="pfb-insp-section-body">
+						<!-- Label styling -->
+						<div class="pfb-box-block">
+							<div class="pfb-box-title">{{ __("Label") }}</div>
+							<div class="pfb-insp-row pfb-insp-row--col">
+								<span class="pfb-insp-label">{{ __("Color") }}</span>
+								<ColorInput
+									:modelValue="lstyle.color || ''"
+									@update:modelValue="set_typo('label', 'color', $event)"
+								/>
+							</div>
+							<div class="pfb-insp-row">
+								<span class="pfb-insp-label">{{ __("Bold") }}</span>
+								<div class="pfb-seg">
+									<button
+										:class="{ active: !lstyle.bold }"
+										@click="set_typo('label', 'bold', false)"
+									>
+										{{ __("No") }}
+									</button>
+									<button
+										:class="{ active: !!lstyle.bold }"
+										@click="set_typo('label', 'bold', true)"
+									>
+										{{ __("Yes") }}
+									</button>
+								</div>
+							</div>
+						</div>
+						<!-- Value styling -->
+						<div class="pfb-box-block">
+							<div class="pfb-box-title">{{ __("Value") }}</div>
+							<div class="pfb-insp-row pfb-insp-row--col">
+								<span class="pfb-insp-label">{{ __("Color") }}</span>
+								<ColorInput
+									:modelValue="vstyle.color || ''"
+									@update:modelValue="set_typo('value', 'color', $event)"
+								/>
+							</div>
+							<div class="pfb-insp-row">
+								<span class="pfb-insp-label">{{ __("Bold") }}</span>
+								<div class="pfb-seg">
+									<button
+										:class="{ active: !vstyle.bold }"
+										@click="set_typo('value', 'bold', false)"
+									>
+										{{ __("No") }}
+									</button>
+									<button
+										:class="{ active: !!vstyle.bold }"
+										@click="set_typo('value', 'bold', true)"
+									>
+										{{ __("Yes") }}
+									</button>
+								</div>
+							</div>
+						</div>
+						<!-- Label / value gap -->
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Gap") }}</span>
+							<input
+								class="pfb-num"
+								type="number"
+								min="0"
+								placeholder="—"
+								:value="fstyle.gap || ''"
+								@change="(e) => set_field_gap(e.target.value)"
+							/>
+						</div>
+						<!-- Background -->
+						<div class="pfb-insp-row pfb-insp-row--col">
+							<span class="pfb-insp-label">{{ __("Background") }}</span>
+							<ColorInput
+								:modelValue="fstyle.background || ''"
+								@update:modelValue="set_field_style('background', $event)"
+							/>
+						</div>
+						<!-- Padding -->
+						<div class="pfb-insp-row pfb-insp-row--col">
+							<span class="pfb-insp-label">{{ __("Padding (px)") }}</span>
+							<BoxInput
+								:modelValue="fstyle.padding"
+								@update:modelValue="(v) => set_field_box('padding', v)"
+							/>
+						</div>
+						<!-- Margin -->
+						<div class="pfb-insp-row pfb-insp-row--col">
+							<span class="pfb-insp-label">{{ __("Margin (px)") }}</span>
+							<BoxInput
+								:modelValue="fstyle.margin"
+								@update:modelValue="(v) => set_field_box('margin', v)"
+							/>
+						</div>
+					</div>
+				</div>
+
 				<div class="pfb-insp-section">
 					<div class="pfb-insp-section-head" @click="toggle('f_visibility')">
 						<span class="pfb-insp-section-label">{{ __("Visibility") }}</span>
@@ -446,24 +585,19 @@
 						<!-- Gap -->
 						<div class="pfb-insp-row">
 							<span class="pfb-insp-label">{{ __("Gap") }}</span>
-							<div class="pfb-stepper">
-								<button @click="adjust_gap(-4)">−</button>
-								<input
-									class="pfb-stepper-input"
-									type="number"
-									min="0"
-									:value="section_gap"
-									@change="
-										(e) =>
-											(selected_section.gap = Math.max(
-												0,
-												parseInt(e.target.value) || 0
-											))
-									"
-								/>
-								<span class="pfb-stepper-unit">px</span>
-								<button @click="adjust_gap(4)">+</button>
-							</div>
+							<input
+								class="pfb-num"
+								type="number"
+								min="0"
+								:value="section_gap"
+								@change="
+									(e) =>
+										(selected_section.gap = Math.max(
+											0,
+											parseInt(e.target.value) || 0
+										))
+								"
+							/>
 						</div>
 
 						<!-- Label case -->
@@ -498,16 +632,12 @@
 						></span>
 					</div>
 					<div v-show="open.s_bg" class="pfb-insp-section-body">
-						<div class="pfb-color-swatches">
-							<button
-								v-for="swatch in bg_swatches"
-								:key="swatch.value"
-								class="pfb-swatch"
-								:class="{ active: section_bg === swatch.value }"
-								:title="swatch.label"
-								:style="swatch.style"
-								@click="selected_section.background = swatch.value"
-							></button>
+						<div class="pfb-insp-row pfb-insp-row--col">
+							<span class="pfb-insp-label">{{ __("Color") }}</span>
+							<ColorInput
+								:modelValue="section_bg"
+								@update:modelValue="(v) => (selected_section.background = v)"
+							/>
 						</div>
 					</div>
 				</div>
@@ -523,30 +653,144 @@
 						></span>
 					</div>
 					<div v-show="open.s_padding" class="pfb-insp-section-body">
-						<div class="pfb-padding-grid">
-							<div
-								v-for="side in ['top', 'right', 'bottom', 'left']"
-								:key="side"
-								class="pfb-padding-cell"
-							>
-								<div class="pfb-padding-label">
-									{{ __(side[0].toUpperCase() + side.slice(1)) }}
-								</div>
-								<div class="pfb-stepper pfb-stepper--sm">
-									<button @click="adjust_padding(side, -4)">−</button>
-									<input
-										class="pfb-stepper-input"
-										type="number"
-										min="0"
-										:value="section_padding[side]"
-										@change="
-											(e) => set_padding(side, parseInt(e.target.value) || 0)
-										"
-									/>
-									<button @click="adjust_padding(side, 4)">+</button>
-								</div>
+						<BoxInput
+							:modelValue="selected_section.padding"
+							@update:modelValue="set_section_padding"
+						/>
+					</div>
+				</div>
+
+				<!-- BORDER -->
+				<div class="pfb-insp-section">
+					<div class="pfb-insp-section-head" @click="toggle('s_border')">
+						<span class="pfb-insp-section-label">{{ __("Border") }}</span>
+						<span
+							class="pfb-insp-chevron"
+							:class="{ collapsed: !open.s_border }"
+							v-html="frappe.utils.icon('chevron-down', 'xs')"
+						></span>
+					</div>
+					<div v-show="open.s_border" class="pfb-insp-section-body">
+						<!-- Table layout (field borders) -->
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Table layout") }}</span>
+							<div class="pfb-seg">
+								<button
+									:class="{ active: !section_field_borders }"
+									@click="toggle_field_borders(false)"
+								>
+									{{ __("Off") }}
+								</button>
+								<button
+									:class="{ active: section_field_borders }"
+									@click="toggle_field_borders(true)"
+								>
+									{{ __("On") }}
+								</button>
 							</div>
 						</div>
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Width") }}</span>
+							<input
+								class="pfb-num"
+								type="number"
+								min="0"
+								placeholder="0"
+								:value="section_border.width || ''"
+								@change="(e) => set_section_border('width', e.target.value)"
+							/>
+						</div>
+						<!-- Sides -->
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Sides") }}</span>
+							<div class="pfb-seg">
+								<button
+									v-for="side in ['top', 'right', 'bottom', 'left']"
+									:key="side"
+									:class="{ active: section_border_side(side) }"
+									:title="__(side)"
+									@click="toggle_section_border_side(side)"
+								>
+									{{ side[0].toUpperCase() }}
+								</button>
+							</div>
+						</div>
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Style") }}</span>
+							<select
+								class="pfb-insp-select"
+								:value="section_border.style || 'solid'"
+								@change="set_section_border('style', $event.target.value)"
+							>
+								<option value="solid">{{ __("Solid") }}</option>
+								<option value="dashed">{{ __("Dashed") }}</option>
+								<option value="dotted">{{ __("Dotted") }}</option>
+							</select>
+						</div>
+						<div class="pfb-insp-row pfb-insp-row--col">
+							<span class="pfb-insp-label">{{ __("Border color") }}</span>
+							<ColorInput
+								:modelValue="section_border.color || ''"
+								@update:modelValue="set_section_border('color', $event)"
+							/>
+						</div>
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Radius") }}</span>
+							<input
+								class="pfb-num"
+								type="number"
+								min="0"
+								placeholder="0"
+								:value="section_border.radius || ''"
+								@change="(e) => set_section_border('radius', e.target.value)"
+							/>
+						</div>
+						<template v-if="section_field_borders">
+							<div class="pfb-insp-row">
+								<span class="pfb-insp-label">{{ __("Row lines") }}</span>
+								<div class="pfb-seg">
+									<button
+										:class="{ active: !section_inner_rows }"
+										@click="set_section_bool('inner_rows', false)"
+									>
+										{{ __("No") }}
+									</button>
+									<button
+										:class="{ active: section_inner_rows }"
+										@click="set_section_bool('inner_rows', true)"
+									>
+										{{ __("Yes") }}
+									</button>
+								</div>
+							</div>
+							<div class="pfb-insp-row">
+								<span class="pfb-insp-label">{{ __("Column lines") }}</span>
+								<div class="pfb-seg">
+									<button
+										:class="{ active: !section_inner_cols }"
+										@click="set_section_bool('inner_cols', false)"
+									>
+										{{ __("No") }}
+									</button>
+									<button
+										:class="{ active: section_inner_cols }"
+										@click="set_section_bool('inner_cols', true)"
+									>
+										{{ __("Yes") }}
+									</button>
+								</div>
+							</div>
+							<div class="pfb-insp-row">
+								<span class="pfb-insp-label">{{ __("Cell padding") }}</span>
+								<input
+									class="pfb-num"
+									type="number"
+									min="0"
+									:value="section_cell_padding"
+									@change="(e) => set_section_cell_padding(e.target.value)"
+								/>
+							</div>
+						</template>
 					</div>
 				</div>
 
@@ -601,6 +845,8 @@ import { useStore } from "../../stores";
 import LetterHeadZoneInspector from "./LetterHeadZoneInspector.vue";
 import Autocomplete from "../../../vue-components/Autocomplete.vue";
 import VisibilitySection from "./VisibilitySection.vue";
+import ColorInput from "./ColorInput.vue";
+import BoxInput from "./BoxInput.vue";
 
 let store = inject("$store");
 let { letterhead, layout } = useStore();
@@ -613,10 +859,12 @@ let preview_doc = computed(() => store.preview_doc.value);
 
 const open = ref({
 	f_field: true,
+	f_style: false,
 	f_visibility: false,
 	s_section: true,
 	s_bg: true,
 	s_padding: true,
+	s_border: true,
 	s_visibility: false,
 	t_table: true,
 	t_columns: true,
@@ -863,30 +1111,74 @@ function clamp_width(col) {
 	col.width = Math.max(5, Math.min(100, parseInt(col.width) || 10));
 }
 
+// ── Field style helpers ────────────────────────────────────
+let fstyle = computed(() => selected_field.value?.style ?? {});
+
+function ensure_field_style() {
+	if (!selected_field.value.style) selected_field.value.style = {};
+	return selected_field.value.style;
+}
+
+// Set/clear a flat style key. Falsy values (empty string, false, 0) clear it
+// so the saved style object stays minimal.
+function set_field_style(key, value) {
+	const s = ensure_field_style();
+	if (value === "" || value === false || value === null || value === undefined) {
+		delete s[key];
+	} else {
+		s[key] = value;
+	}
+}
+
+function set_field_box(prop, obj) {
+	const s = ensure_field_style();
+	if (obj) s[prop] = obj;
+	else delete s[prop];
+}
+
+// ── Label / Value typography (separate styling for each) ───
+let lstyle = computed(() => selected_field.value?.style?.label ?? {});
+let vstyle = computed(() => selected_field.value?.style?.value ?? {});
+
+// target = "label" | "value"
+function set_typo(target, key, value) {
+	const s = ensure_field_style();
+	if (!s[target]) s[target] = {};
+	if (value === "" || value === false || value === null || value === undefined) {
+		delete s[target][key];
+	} else {
+		s[target][key] = value;
+	}
+	if (!Object.keys(s[target]).length) delete s[target];
+}
+
+// Spacing between a field's label and its value
+function set_field_gap(value) {
+	const n = parseInt(value);
+	set_field_style("gap", n > 0 ? n : "");
+}
+
+// ── Table cell padding ─────────────────────────────────────
+let cell_padding = computed(() => selected_field.value?.table_cell_padding ?? 7);
+
+function set_cell_padding(value) {
+	if (!selected_field.value) return;
+	selected_field.value.table_cell_padding = Math.max(0, parseInt(value) || 0);
+}
+
+function set_table_radius(value) {
+	if (!selected_field.value) return;
+	const n = parseInt(value);
+	if (!n || n <= 0) delete selected_field.value.table_radius;
+	else selected_field.value.table_radius = n;
+}
+
 // ── Section helpers ────────────────────────────────────────
 let section_show_label = computed(() => selected_section.value?.show_label ?? "show");
 let section_orientation = computed(() => selected_section.value?.field_orientation ?? "");
 let section_gap = computed(() => selected_section.value?.gap ?? 20);
 let section_label_case = computed(() => selected_section.value?.label_case ?? "normal");
 let section_bg = computed(() => selected_section.value?.background ?? "");
-let section_padding = computed(() => ({
-	top: selected_section.value?.padding?.top ?? 0,
-	right: selected_section.value?.padding?.right ?? 0,
-	bottom: selected_section.value?.padding?.bottom ?? 0,
-	left: selected_section.value?.padding?.left ?? 0,
-}));
-
-const bg_swatches = [
-	{
-		value: "",
-		label: __("None"),
-		style: "background: repeating-conic-gradient(#ccc 0% 25%, #fff 0% 50%) 0 0 / 10px 10px",
-	},
-	{ value: "#ffffff", label: __("White"), style: "background:#ffffff; border-color:#e5e7eb" },
-	{ value: "#EFF6FF", label: __("Blue"), style: "background:#EFF6FF" },
-	{ value: "#F0FDF4", label: __("Green"), style: "background:#F0FDF4" },
-	{ value: "#FFF7ED", label: __("Orange"), style: "background:#FFF7ED" },
-];
 
 function set_columns(n) {
 	if (!selected_section.value) return;
@@ -898,24 +1190,81 @@ function set_columns(n) {
 	selected_section.value.columns = new_columns;
 }
 
-function adjust_gap(delta) {
-	const current = selected_section.value?.gap ?? 20;
-	selected_section.value.gap = Math.max(0, current + delta);
+function set_section_padding(obj) {
+	const s = selected_section.value;
+	if (!s) return;
+	if (obj) s.padding = obj;
+	else delete s.padding;
 }
 
-function adjust_padding(side, delta) {
-	if (!selected_section.value.padding) {
-		selected_section.value.padding = { top: 0, right: 0, bottom: 0, left: 0 };
+// ── Section table layout (field borders) ──────────────────
+let section_field_borders = computed(() => !!selected_section.value?.field_borders);
+let section_inner_rows = computed(() => selected_section.value?.inner_rows !== false);
+let section_inner_cols = computed(() => selected_section.value?.inner_cols !== false);
+let section_cell_padding = computed(() => selected_section.value?.cell_padding ?? 8);
+
+function toggle_field_borders(on) {
+	const s = selected_section.value;
+	if (!s) return;
+	if (on) {
+		s.field_borders = true;
+		// Seed sensible defaults so turning it on immediately looks like a table
+		if (!s.border) s.border = {};
+		if (!s.border.width) s.border.width = 1;
+		if (!s.border.color) s.border.color = "#e5e7eb";
+		if (s.border.radius === undefined) s.border.radius = 6;
+		if (s.inner_rows === undefined) s.inner_rows = true;
+		if (s.inner_cols === undefined) s.inner_cols = true;
+		if (s.cell_padding === undefined) s.cell_padding = 8;
+	} else {
+		delete s.field_borders;
 	}
-	const current = selected_section.value.padding[side] ?? 0;
-	selected_section.value.padding[side] = Math.max(0, current + delta);
 }
 
-function set_padding(side, value) {
-	if (!selected_section.value.padding) {
-		selected_section.value.padding = { top: 0, right: 0, bottom: 0, left: 0 };
+function set_section_bool(key, value) {
+	if (selected_section.value) selected_section.value[key] = value;
+}
+
+function set_section_cell_padding(value) {
+	if (selected_section.value) {
+		selected_section.value.cell_padding = Math.max(0, parseInt(value) || 0);
 	}
-	selected_section.value.padding[side] = Math.max(0, value);
+}
+
+// ── Section border ─────────────────────────────────────────
+let section_border = computed(() => selected_section.value?.border ?? {});
+
+function set_section_border(key, value) {
+	const s = selected_section.value;
+	if (!s) return;
+	if (!s.border) s.border = {};
+	if (key === "width" || key === "radius") {
+		const n = parseInt(value);
+		if (!n || n <= 0) delete s.border[key];
+		else s.border[key] = n;
+	} else if (value === "" || value === null || value === undefined) {
+		delete s.border[key];
+	} else {
+		s.border[key] = value;
+	}
+	// A border needs a width to render; drop the object once nothing visible remains
+	if (!s.border.width && !s.border.radius) delete s.border;
+}
+
+// Per-side toggles. Absence of a side key means "on", so we only store `false`
+// for sides the user has switched off. Sides default to all-on for a new border.
+function section_border_side(side) {
+	const b = selected_section.value?.border;
+	return !!b && b[side] !== false;
+}
+
+function toggle_section_border_side(side) {
+	const s = selected_section.value;
+	if (!s) return;
+	if (!s.border) s.border = { width: 1 };
+	if (s.border[side] === false) delete s.border[side];
+	else s.border[side] = false;
+	if (!s.border.width && !s.border.radius) delete s.border;
 }
 </script>
 
@@ -1030,13 +1379,6 @@ function set_padding(side, value) {
 	overflow-y: auto;
 	display: flex;
 	flex-direction: column;
-}
-
-.pfb-insp-placeholder {
-	align-items: center;
-	justify-content: center;
-	padding: 24px;
-	text-align: center;
 }
 
 /* ── Collapsible sections ────────────────────────────────── */
@@ -1167,6 +1509,22 @@ function set_padding(side, value) {
 	border-color: var(--gray-500);
 }
 
+.pfb-num {
+	width: 100%;
+	text-align: center;
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	background: var(--fg-color);
+	color: var(--text-color);
+	padding: 4px 6px;
+	font-size: var(--text-sm);
+	outline: none;
+}
+
+.pfb-num:focus {
+	border-color: var(--primary);
+}
+
 /* ── Segmented control ───────────────────────────────────── */
 .pfb-seg {
 	display: inline-flex;
@@ -1208,122 +1566,17 @@ function set_padding(side, value) {
 	box-shadow: var(--shadow-xs);
 }
 
-/* ── Stepper (+/−) ───────────────────────────────────────── */
-.pfb-stepper {
-	display: inline-flex;
-	align-items: center;
-	border: 1px solid var(--border-color);
-	border-radius: var(--radius);
-	overflow: hidden;
-	background: var(--subtle-accent);
-	width: 100%;
-}
-
-.pfb-stepper button {
-	padding: 4px 8px;
-	border: none;
-	background: transparent;
-	cursor: pointer;
-	font-size: 14px;
-	color: var(--text-muted);
-	line-height: 1;
-	flex-shrink: 0;
-}
-
-.pfb-stepper button:hover {
-	background: var(--gray-100);
-	color: var(--text-color);
-}
-
-.pfb-stepper-val {
-	flex: 1;
-	text-align: center;
-	font-size: var(--text-sm);
-	font-weight: 500;
-	border-left: 1px solid var(--border-color);
-	border-right: 1px solid var(--border-color);
-	padding: 4px 4px;
-}
-
-.pfb-stepper-input {
-	flex: 1;
-	min-width: 0;
-	width: 100%;
-	text-align: center;
-	font-size: var(--text-sm);
-	font-weight: 500;
-	border: none;
-	border-left: 1px solid var(--border-color);
-	border-right: 1px solid var(--border-color);
-	background: transparent;
-	color: var(--text-color);
-	padding: 4px 2px;
-	outline: none;
-}
-
-.pfb-stepper-input:focus {
-	background: var(--fg-color);
-}
-
-/* hide number spin arrows */
-.pfb-stepper-input::-webkit-inner-spin-button,
-.pfb-stepper-input::-webkit-outer-spin-button {
-	-webkit-appearance: none;
-}
-
-.pfb-stepper-unit {
-	font-size: var(--text-tiny);
-	color: var(--text-muted);
-	padding: 0 6px 0 2px;
-}
-
-.pfb-stepper--sm {
-	width: auto;
-}
-
-/* ── Background swatches ─────────────────────────────────── */
-.pfb-color-swatches {
-	display: flex;
-	gap: 6px;
-	flex-wrap: wrap;
-}
-
-.pfb-swatch {
-	width: 28px;
-	height: 28px;
-	border-radius: var(--radius);
-	border: 1.5px solid var(--border-color);
-	cursor: pointer;
-	padding: 0;
-	transition: transform 0.1s, border-color 0.1s;
-}
-
-.pfb-swatch:hover {
-	transform: scale(1.1);
-}
-
-.pfb-swatch.active {
-	border-color: var(--primary);
-	box-shadow: 0 0 0 2px var(--primary-light);
-}
-
-/* ── Padding grid ────────────────────────────────────────── */
-.pfb-padding-grid {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: 8px;
-}
-
-.pfb-padding-cell {
+/* ── Box block (field padding / margin) ──────────────────── */
+.pfb-box-block {
 	display: flex;
 	flex-direction: column;
-	gap: 3px;
+	gap: 4px;
 }
 
-.pfb-padding-label {
+.pfb-box-title {
 	font-size: var(--text-tiny);
+	font-weight: var(--weight-medium);
 	color: var(--text-muted);
-	text-align: center;
 }
 
 /* ── Hint ────────────────────────────────────────────────── */
@@ -1386,12 +1639,30 @@ function set_padding(side, value) {
 	color: var(--gray-500);
 }
 
-.pfb-col-label {
+.pfb-col-label-input {
 	flex: 1;
+	min-width: 0;
 	font-size: var(--text-sm);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	border: 1px solid transparent;
+	border-radius: var(--radius);
+	background: transparent;
+	color: var(--text-color);
+	padding: 2px 4px;
+	outline: none;
+}
+
+.pfb-col-label-input:hover {
+	border-color: var(--gray-300);
+}
+
+.pfb-col-label-input:focus {
+	border-color: var(--gray-500);
+	background: var(--fg-color);
+}
+
+.pfb-col-label-input::placeholder {
+	color: var(--gray-400);
+	font-style: italic;
 }
 
 .pfb-col-width-input {

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -113,12 +113,15 @@ export function getStore(print_format_name) {
 								"table_style",
 								"table_bordered",
 								"table_header",
+								"table_cell_padding",
+								"table_radius",
 								"html",
 								"field_template",
 								"show_label",
 								"align",
 								"label_justify",
 								"visible_if",
+								"style",
 							]);
 						});
 					return column;
@@ -136,12 +139,15 @@ export function getStore(print_format_name) {
 			"table_style",
 			"table_bordered",
 			"table_header",
+			"table_cell_padding",
+			"table_radius",
 			"html",
 			"field_template",
 			"show_label",
 			"align",
 			"label_justify",
 			"visible_if",
+			"style",
 		];
 		function clean_zone(zone) {
 			if (!zone || !zone.columns) return zone;

--- a/frappe/templates/print_format/macros/Data.html
+++ b/frappe/templates/print_format/macros/Data.html
@@ -4,14 +4,29 @@
 {%- set _orientation = df.section.field_orientation or '' -%}
 {%- set _inline = (_show_label == 'inline') or (_orientation == 'left-right') -%}
 {%- set _justify = df.label_justify if df.label_justify else '' -%}
-<div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' %} field-justify-{{ _justify }}{% endif %}" {{ field_attributes(df) }}>
+{#- Build inline styles from the field's user-defined style object -#}
+{%- set _st = df.style or {} -%}
+{%- set ns = namespace(wrap='', val='', lbl='') -%}
+{%- if _st.background -%}{%- set ns.wrap = ns.wrap + 'background:' + _st.background + ';' -%}{%- endif -%}
+{%- if _st.padding -%}{%- set p = _st.padding -%}{%- set ns.wrap = ns.wrap + 'padding:' + (p.top or 0)|string + 'px ' + (p.right or 0)|string + 'px ' + (p.bottom or 0)|string + 'px ' + (p.left or 0)|string + 'px;' -%}{%- endif -%}
+{%- if _st.margin -%}{%- set m = _st.margin -%}{%- set ns.wrap = ns.wrap + 'margin:' + (m.top or 0)|string + 'px ' + (m.right or 0)|string + 'px ' + (m.bottom or 0)|string + 'px ' + (m.left or 0)|string + 'px;' -%}{%- endif -%}
+{#- Independent label / value colour + weight (font size is page-level) -#}
+{%- set _lbl = _st.label or {} -%}
+{%- set _val = _st.value or {} -%}
+{%- if _lbl.color -%}{%- set ns.lbl = ns.lbl + 'color:' + _lbl.color + ';' -%}{%- endif -%}
+{%- if _lbl.bold -%}{%- set ns.lbl = ns.lbl + 'font-weight:600;' -%}{%- endif -%}
+{%- if _val.color -%}{%- set ns.val = ns.val + 'color:' + _val.color + ';' -%}{%- endif -%}
+{%- if _val.bold -%}{%- set ns.val = ns.val + 'font-weight:600;' -%}{%- endif -%}
+{#- Gap between label and value: horizontal when inline, vertical when stacked -#}
+{%- if _st.gap -%}{%- if _inline -%}{%- set ns.wrap = ns.wrap + 'gap:' + _st.gap|string + 'px;' -%}{%- else -%}{%- set ns.lbl = ns.lbl + 'margin-bottom:' + _st.gap|string + 'px;' -%}{%- endif -%}{%- endif -%}
+<div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' %} field-justify-{{ _justify }}{% endif %}"{% if ns.wrap %} style="{{ ns.wrap }}"{% endif %} {{ field_attributes(df) }}>
 	{%- block label -%}
 	{%- if _show_label != 'hide' -%}
-	<div class="label">{{ _(df.label) }}</div>
+	<div class="label"{% if ns.lbl %} style="{{ ns.lbl }}"{% endif %}>{{ _(df.label) }}</div>
 	{%- endif -%}
 	{%- endblock -%}
 	{%- block value -%}
-	<div class="value">{{ doc.get_formatted(df.fieldname) }}</div>
+	<div class="value"{% if ns.val %} style="{{ ns.val }}"{% endif %}>{{ doc.get_formatted(df.fieldname) }}</div>
 	{%- endblock -%}
 </div>
 {% endif %}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -2,26 +2,33 @@
 {% set _style = df.table_style or "lined" %}
 {% set _bordered = df.table_bordered != False %}
 {% set _plain_header = df.table_header == "plain" %}
+{% set _no_header = df.table_header == "none" %}
+{% set _cell_pad = df.table_cell_padding %}
+{% set _cell_style = ("padding:" ~ _cell_pad ~ "px") if _cell_pad is not none else "" %}
+{% set _radius = df.table_radius %}
 <div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}" {{ field_attributes(df) }}>
 	<div class="label">
 		{{ _(df.label) }}
 	</div>
+	{% if _radius %}<div class="child-table-radius" style="border-radius:{{ _radius }}px;overflow:hidden;">{% endif %}
 	<table class="table{% if _bordered %} table-bordered{% endif %}">
 		{% set columns = df.table_columns %}
+		{% if not _no_header %}
 		<thead>
 			<tr class="table-row">
 				{% for column in columns %}
-				<th class="column-header" width="{{ column.width }}%" {{ field_attributes(column) }}>
+				<th class="column-header" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style }}"{% endif %} {{ field_attributes(column) }}>
 					{{ _(column.label) }}
 				</th>
 				{% endfor %}
 			</tr>
 		</thead>
+		{% endif %}
 		<tbody>
 			{% for row in doc.get(df.fieldname) %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}">
 				{% for column in columns %}
-				<td class="column-value" width="{{ column.width }}%" {{ field_attributes(column) }}>
+				<td class="column-value" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style }}"{% endif %} {{ field_attributes(column) }}>
 					{# Image cells: validated URL + server-side thumbnail + escaped src. #}
 					{%- set _src = (row.get(column.options) if column.fieldtype == "Image" else row.get(column.fieldname)) or "" -%}
 					{%- set _src = _src|string|trim -%}
@@ -38,5 +45,6 @@
 			{% endfor %}
 		</tbody>
 	</table>
+	{% if _radius %}</div>{% endif %}
 </div>
 {% endif %}

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -22,7 +22,7 @@
 }
 
 html, body {
-	font-size: {{ print_format.font_size }}px;
+	font-size: {{ print_format.font_size or 14 }}px;
 }
 
 body {
@@ -68,7 +68,7 @@ body {
 }
 
 .section-label {
-	font-size: 1.1rem;
+	font-size: 1em;
 	font-weight: 700;
 	color: #1a1a1a;
 	padding-bottom: 0.35rem;
@@ -89,9 +89,9 @@ body {
 	page-break-inside: avoid;
 }
 
-/* Stacked (default): muted label above value */
+/* Stacked (default): label same size as value, distinguished by weight/colour */
 .field .label {
-	font-size: 0.75em;
+	font-size: 1em;
 	font-weight: 600;
 	color: #6b7280;
 	margin-bottom: 0.1rem;
@@ -99,6 +99,33 @@ body {
 
 .field .value {
 	color: #111827;
+}
+
+/* ── Section table layout (field borders) ────────────────── */
+.section-grid .section-columns {
+	align-items: stretch;
+}
+
+.section-grid .column {
+	padding: 0;
+}
+
+.section-grid .field {
+	border: none !important;
+	border-radius: 0 !important;
+	background: transparent !important;
+	margin: 0 !important;
+	padding: var(--pfb-cell-pad, 8px) !important;
+}
+
+/* Horizontal inner lines: between rows within a column */
+.section-grid-rows .column > .field + .field {
+	border-top: var(--pfb-line, 1px solid #e5e7eb) !important;
+}
+
+/* Vertical inner lines: between columns */
+.section-grid-cols .column + .column {
+	border-left: var(--pfb-line, 1px solid #e5e7eb) !important;
 }
 
 /* Left-right (section-level): label shrinks to content width, value takes the rest */
@@ -112,7 +139,7 @@ body {
 .field.left-right .label,
 .field.field-inline .label {
 	flex-shrink: 0;
-	font-size: 0.8em;
+	font-size: 1em;
 	font-weight: 600;
 	color: #374151;
 	text-transform: none;
@@ -172,14 +199,14 @@ body {
 }
 
 .child-table > .label {
-	font-size: 0.8em;
+	font-size: 1em;
 	font-weight: 600;
 	color: #6b7280;
 	margin-bottom: 0.4rem;
 }
 
 .child-table .table {
-	font-size: 0.9em;
+	font-size: 1em;
 	border-collapse: collapse;
 	width: 100%;
 }
@@ -188,7 +215,7 @@ body {
 	background-color: #f3f4f6 !important;
 	color: #374151;
 	font-weight: 600;
-	font-size: 0.85em;
+	font-size: 1em;
 	padding: 0.45rem 0.6rem;
 	border: 1px solid #e5e7eb !important;
 }
@@ -231,11 +258,10 @@ body {
 	background-color: #ffffff !important;
 }
 
-/* borderless variant */
+/* borderless variant — remove every cell border (header keeps its background) */
 .child-table--borderless .table th,
 .child-table--borderless .table td {
 	border: none !important;
-	border-bottom: 1px solid #e5e7eb !important;
 }
 
 /* plain header variant */

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -60,6 +60,8 @@
 	{%- if not section.label or ns.has_content -%}
 	{#- Build inline style for section background + padding -#}
 	{%- set ns3 = namespace(section_style='') -%}
+	{%- set _grid = section.field_borders -%}
+	{%- set ns4 = namespace(cols_style='') -%}
 	{%- if section.background -%}
 		{%- set ns3.section_style = ns3.section_style + 'background:' + section.background + ';' -%}
 	{%- endif -%}
@@ -67,7 +69,24 @@
 		{%- set p = section.padding -%}
 		{%- set ns3.section_style = ns3.section_style + 'padding:' + (p.top or 0)|string + 'px ' + (p.right or 0)|string + 'px ' + (p.bottom or 0)|string + 'px ' + (p.left or 0)|string + 'px;' -%}
 	{%- endif -%}
-	<div class="section {{ resolve_class({'page-break': section.page_break}) }} {{ 'label-uppercase' if section.label_case == 'uppercase' else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style }}"{% endif %}>
+	{%- set _bw = (section.border.width if section.border and section.border.width else 1) -%}
+	{%- set _bs = (section.border.style if section.border and section.border.style else 'solid') -%}
+	{%- set _bc = (section.border.color if section.border and section.border.color else '#e5e7eb') -%}
+	{%- if section.border and section.border.width -%}
+		{%- set _sb = section.border -%}
+		{%- set _edge = _sb.width|string + 'px ' + (_sb.style or 'solid') + ' ' + (_sb.color or '#000000') -%}
+		{%- set _bstr = '' -%}
+		{%- if _sb.top != false -%}{%- set _bstr = _bstr + 'border-top:' + _edge + ';' -%}{%- endif -%}
+		{%- if _sb.right != false -%}{%- set _bstr = _bstr + 'border-right:' + _edge + ';' -%}{%- endif -%}
+		{%- if _sb.bottom != false -%}{%- set _bstr = _bstr + 'border-bottom:' + _edge + ';' -%}{%- endif -%}
+		{%- if _sb.left != false -%}{%- set _bstr = _bstr + 'border-left:' + _edge + ';' -%}{%- endif -%}
+		{%- if _sb.radius -%}{%- set _bstr = _bstr + 'border-radius:' + _sb.radius|string + 'px;overflow:hidden;' -%}{%- endif -%}
+		{%- if _grid -%}{%- set ns4.cols_style = ns4.cols_style + _bstr -%}{%- else -%}{%- set ns3.section_style = ns3.section_style + _bstr -%}{%- endif -%}
+	{%- endif -%}
+	{%- if _grid -%}
+		{%- set ns4.cols_style = ns4.cols_style + 'padding:0;margin:0;gap:0;--pfb-line:' + _bw|string + 'px ' + _bs + ' ' + _bc + ';--pfb-cell-pad:' + (section.cell_padding if section.cell_padding is not none else 8)|string + 'px;' -%}
+	{%- endif -%}
+	<div class="section {{ resolve_class({'page-break': section.page_break}) }} {{ 'label-uppercase' if section.label_case == 'uppercase' else '' }}{% if _grid %} section-grid{% if section.inner_rows != false %} section-grid-rows{% endif %}{% if section.inner_cols != false %} section-grid-cols{% endif %}{% endif %}"{% if ns3.section_style %} style="{{ ns3.section_style }}"{% endif %}>
 		{% if section.label and section.show_label != 'hide' %}
 		<div class="section-label">{{ _(section.label) }}</div>
 		{% endif %}
@@ -83,7 +102,7 @@
 			{%- set row_layout = '' -%}
 		{%- endif -%}
 		{%- set col_gap = (section.gap if section.gap is defined and section.gap != None else 20)|string + 'px' -%}
-		<div class="section-columns row {{ row_layout }}" style="gap:{{ col_gap }}">
+		<div class="section-columns row {{ row_layout }}"{% if _grid %} style="{{ ns4.cols_style }}"{% else %} style="gap:{{ col_gap }}"{% endif %}>
 			{% for column in section.columns %}
 			<div class="column col">
 				{% for df in column.fields %}

--- a/frappe/templates/styles/standard.css
+++ b/frappe/templates/styles/standard.css
@@ -104,7 +104,7 @@
 }
 
 .print-format {
-	font-size: {{ print_settings.font_size|flt or 9 }}pt;
+	font-size: {{ font_size|flt or 9 }}pt;
 	font-family: {{ font }};
 	-webkit-print-color-adjust:exact;
 }

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -620,10 +620,17 @@ def get_print_style(
 	if not style:
 		style = print_settings.print_style or ""
 
+	# Per-print-format font size takes precedence over the global Print Settings size
+	font_size = None
+	if print_format and print_format.get("font_size"):
+		font_size = print_format.font_size
+	font_size = font_size or print_settings.font_size or 9
+
 	context = {
 		"print_settings": print_settings,
 		"print_style": style,
 		"font": get_font(print_settings, print_format, for_legacy),
+		"font_size": font_size,
 	}
 
 	css = frappe.get_template("templates/styles/standard.css").render(context)


### PR DESCRIPTION
## What

Adds styling and usability controls to the Print Format Builder Beta, applied consistently across the canvas preview and PDF/HTML render.

## Changes

- **Page-level font** — font size (px) and family now set once for the whole format; content text scales via `em` off the body base, so label, value, headings, and table cells stay consistent.
- **Field styling** — separate label/value color + bold, background, padding, margin, and a label↔value gap. New `ColorField` control with native picker + hex input.
- **Section styling** — per-side borders (top/right/bottom/left) with corner radius, plus a table/grid layout mode that puts a section's fields into bordered cells.
- **Table styling** — cell padding, corner radius, three-way header (styled / plain / none), true borderless mode that removes all cell borders, and editable column header labels.
- **Cleanup** — removed dead CSS and unused per-field font/border helpers.

## Render paths

Beta preview (`print_format_generator`) and legacy print view both updated; new `style` / `table_cell_padding` / `table_radius` keys are persisted via the layout pluck whitelists.

## Testing

- All Vue SFCs compile; Jinja templates parse.