### PR TITLE
fix: get_next rejecting list-type filters

### DIFF
--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -82,7 +82,7 @@ def get_next(
 	doctype: str,
 	value: str,
 	prev: str | int,
-	filters: dict | str | None = None,
+	filters: dict | str | list | None = None,
 	sort_order: str = "desc",
 	sort_field: str = "creation",
 ):


### PR DESCRIPTION
- Widen `filters` type on `frappe.desk.form.utils.get_next` to `dict | str | list | None`
Why: the doc navigation "next/prev" arrows send filters as a list (from `get_filters_for_args()`), which the query builder already supports, but the stricter param type validation rejected it with a FrappeTypeError