### PR TITLE
feat(query_builder): add WITH RECURSIVE (recursive CTE) support to frappe.qb

### DIFF
--- a/frappe/query_builder/builder.py
+++ b/frappe/query_builder/builder.py
@@ -71,14 +71,44 @@ class Base:
 			throw(_("Invalid DocType: {0}").format(doctype))
 
 
+class RecursiveCTEMixin:
+	"""Adds `WITH RECURSIVE` support to a pypika query builder. Pass `recursive=True` to
+	`frappe.qb.with_(subquery, name, recursive=True)` and reference the CTE inside its own recursive
+	term via `pypika.Table(name)`. Renders `WITH RECURSIVE` on postgres, mariadb (10.2+) and sqlite;
+	a non-recursive builder is byte-for-byte unchanged (`recursive` defaults to False)."""
+
+	def __init__(self, *args, recursive: bool = False, **kwargs):
+		super().__init__(*args, **kwargs)
+		self._recursive_cte = recursive
+
+	def _with_sql(self, **kwargs) -> str:
+		keyword = "WITH RECURSIVE " if getattr(self, "_recursive_cte", False) else "WITH "
+		return keyword + ",".join(
+			clause.name + " AS (" + clause.get_sql(subquery=False, with_alias=False, **kwargs) + ") "
+			for clause in self._with
+		)
+
+
+class RecursiveMySQLQueryBuilder(RecursiveCTEMixin, MySQLQueryBuilder):
+	pass
+
+
+class RecursivePostgreSQLQueryBuilder(RecursiveCTEMixin, PostgreSQLQueryBuilder):
+	pass
+
+
+class RecursiveSQLLiteQueryBuilder(RecursiveCTEMixin, SQLLiteQueryBuilder):
+	pass
+
+
 class MariaDB(Base, MySQLQuery):
 	Field = terms.Field
 
-	_BuilderClasss = MySQLQueryBuilder
+	_BuilderClasss = RecursiveMySQLQueryBuilder
 
 	@classmethod
-	def _builder(cls, *args, **kwargs) -> "MySQLQueryBuilder":
-		return super()._builder(*args, wrapper_cls=ParameterizedValueWrapper, **kwargs)
+	def _builder(cls, *args, **kwargs) -> "RecursiveMySQLQueryBuilder":
+		return RecursiveMySQLQueryBuilder(*args, wrapper_cls=ParameterizedValueWrapper, **kwargs)
 
 	@classmethod
 	def from_(cls, table, *args, **kwargs):
@@ -99,11 +129,11 @@ class Postgres(Base, PostgreSQLQuery):
 	# they are two different objects. The quick fix used here is to replace the
 	# Field names in the "Field" function.
 
-	_BuilderClasss = PostgreSQLQueryBuilder
+	_BuilderClasss = RecursivePostgreSQLQueryBuilder
 
 	@classmethod
-	def _builder(cls, *args, **kwargs) -> "PostgreSQLQueryBuilder":
-		return super()._builder(*args, wrapper_cls=ParameterizedValueWrapper, **kwargs)
+	def _builder(cls, *args, **kwargs) -> "RecursivePostgreSQLQueryBuilder":
+		return RecursivePostgreSQLQueryBuilder(*args, wrapper_cls=ParameterizedValueWrapper, **kwargs)
 
 	@classmethod
 	def Field(cls, field_name, *args, **kwargs):
@@ -127,11 +157,11 @@ class Postgres(Base, PostgreSQLQuery):
 class SQLite(Base, SQLLiteQuery):
 	Field = terms.Field
 
-	_BuilderClasss = SQLLiteQueryBuilder
+	_BuilderClasss = RecursiveSQLLiteQueryBuilder
 
 	@classmethod
-	def _builder(cls, *args, **kwargs) -> "SQLLiteQueryBuilder":
-		return super()._builder(*args, wrapper_cls=SQLiteParameterizedValueWrapper, **kwargs)
+	def _builder(cls, *args, **kwargs) -> "RecursiveSQLLiteQueryBuilder":
+		return RecursiveSQLLiteQueryBuilder(*args, wrapper_cls=SQLiteParameterizedValueWrapper, **kwargs)
 
 	@classmethod
 	def from_(cls, table, *args, **kwargs):

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -785,3 +785,30 @@ class TestOperatorIn(IntegrationTestCase):
 		self.assertIn(None, results)
 		self.assertIn("", results)
 		self.assertIn("user1", results)
+
+
+class TestRecursiveCTE(IntegrationTestCase):
+	def test_recursive_keyword_is_emitted(self):
+		# recursive=True renders WITH RECURSIVE so a CTE may reference itself in its recursive term.
+		from pypika import AliasedQuery, Table
+
+		nodes = Table("nodes")
+		tree = AliasedQuery("tree")
+		seed = frappe.qb.from_(nodes).select(nodes.name, nodes.parent).where(nodes.parent.isnull())
+		recurse = (
+			frappe.qb.from_(nodes).join(tree).on(nodes.parent == tree.name).select(nodes.name, nodes.parent)
+		)
+		query = frappe.qb.with_(seed + recurse, "tree", recursive=True).from_(tree).select(tree.name)
+		self.assertIn("WITH RECURSIVE tree AS", query.get_sql())
+
+	def test_non_recursive_with_matches_pypika(self):
+		# recursive defaults to False and must keep pypika's exact multi-CTE formatting (the join
+		# is ") ," between clauses) -- the override changes nothing on the non-recursive path.
+		from pypika import AliasedQuery, Table
+
+		a = frappe.qb.from_(Table("t1")).select("x")
+		b = frappe.qb.from_(Table("t2")).select("y")
+		sql = frappe.qb.with_(a, "cte_a").with_(b, "cte_b").from_(AliasedQuery("cte_a")).select("x").get_sql()
+		self.assertTrue(sql.startswith("WITH cte_a AS "))
+		self.assertNotIn("WITH RECURSIVE", sql)
+		self.assertIn(") ,cte_b AS (", sql)


### PR DESCRIPTION
Part of the PostgreSQL feature-enablement workstream — splitting the merged MariaDB→Postgres branch into reviewable, per-feature PRs.

## What
Adds `WITH RECURSIVE` support to `frappe.qb`: a `RecursiveCTEMixin` + per-dialect builder subclasses. Passing `recursive=True` to `frappe.qb.with_(seed + recursion, name, recursive=True)` emits `WITH RECURSIVE`; without it, rendered SQL is byte-for-byte unchanged.

## Why
pypika 0.48.9 can't express recursive CTEs. This lets adjacency-list tree traversals (BOM trees, task dependency graphs) run as a single query instead of a query-per-node — from one cross-engine codebase.

## Cross-engine
Portable across Postgres, MariaDB 10.2+ and SQLite; verified on Postgres and MariaDB.

---
🔗 Companion ERPNext PR: https://github.com/frappe/erpnext/pull/56695