### PR TITLE
feat(postgres): partial, covering, trigram & full-text indexes via add_index()

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1381,7 +1381,7 @@ class Database:
 	def has_index(self, table_name, index_name):
 		raise NotImplementedError
 
-	def add_index(self, doctype, fields, index_name=None):
+	def add_index(self, doctype, fields, index_name=None, using=None, where=None, include=None):
 		raise NotImplementedError
 
 	def add_unique(self, doctype, fields, constraint_name=None):

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -414,11 +414,17 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 			if not clustered_index:
 				return index
 
-	def add_index(self, doctype: str, fields: list, index_name: str | None = None):
+	def add_index(
+		self, doctype: str, fields: list, index_name: str | None = None, using=None, where=None, include=None
+	):
 		"""Creates an index with given fields if not already created.
-		Index name will be `fieldname1_fieldname2_index`"""
+		`using`/`where`/`include` are postgres-only (trigram/partial/covering) with no MariaDB
+		equivalent, so they are silently ignored: a `using` kind skips index creation, and
+		`where`/`include` fall back to a plain index over `fields`."""
 		from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 
+		if using:
+			return
 		index_name = index_name or self.get_index_name(fields)
 		table_name = get_table_name(doctype)
 		if not self.has_index(table_name, index_name):

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -441,11 +441,17 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 			if not clustered_index:
 				return index
 
-	def add_index(self, doctype: str, fields: list, index_name: str | None = None):
+	def add_index(
+		self, doctype: str, fields: list, index_name: str | None = None, using=None, where=None, include=None
+	):
 		"""Creates an index with given fields if not already created.
-		Index name will be `fieldname1_fieldname2_index`"""
+		`using`/`where`/`include` are postgres-only (trigram/partial/covering) with no MariaDB
+		equivalent, so they are silently ignored: a `using` kind skips index creation, and
+		`where`/`include` fall back to a plain index over `fields`."""
 		from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 
+		if using:
+			return
 		index_name = index_name or self.get_index_name(fields)
 		table_name = get_table_name(doctype)
 		if not self.has_index(table_name, index_name):

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -78,6 +78,10 @@ FROM_TAB_PATTERN = re.compile(r"from tab([\w-]*)", flags=re.IGNORECASE)
 # MySQL's REGEXP operator -> postgres `~*` (case-insensitive, matching MySQL's default collation)
 REGEXP_PATTERN = re.compile(r"\sREGEXP\s", flags=re.IGNORECASE)
 
+# Index methods accepted by add_index(using=...): the two custom GIN modes plus postgres'
+# native access methods. Anything else is rejected before it reaches the DDL string.
+INDEX_METHODS = frozenset({"gin_trgm", "gin_fulltext", "btree", "hash", "gist", "gin", "brin", "spgist"})
+
 
 class PostgresExceptionUtil:
 	ProgrammingError = psycopg2.ProgrammingError
@@ -430,6 +434,14 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 				published int not null default 0,
 				unique (doctype, name))"""
 			)
+		# GIN index over the full-text vector so search()/web_search() do an index scan instead of
+		# recomputing to_tsvector for every row. Runs unconditionally (CREATE INDEX IF NOT EXISTS is
+		# idempotent) so an existing deployment that already has the table still gets it on upgrade.
+		# Expression must match the query's to_tsvector('english', content).
+		self.sql_ddl(
+			"""CREATE INDEX IF NOT EXISTS "__global_search_fts"
+			ON "__global_search" USING gin (to_tsvector('english', content))"""
+		)
 
 	def create_user_settings_table(self):
 		self.sql_ddl(
@@ -503,23 +515,68 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		)
 		return result[0] if result else None
 
-	def add_index(self, doctype: str, fields: list, index_name: str | None = None):
+	def add_index(
+		self, doctype: str, fields: list, index_name: str | None = None, using=None, where=None, include=None
+	):
 		"""Creates an index with given fields if not already created.
+
 		Default index name is `<table>_<field1>_<field2>_index` (table-qualified so it is unique
-		per *schema*, as postgres requires)."""
+		per *schema*, as postgres requires).
+
+		using: index kind beyond the default btree --
+			"gin_trgm"     GIN + gin_trgm_ops for fast LIKE/ILIKE substring search (needs pg_trgm)
+			"gin_fulltext" GIN over to_tsvector(...) for full-text search on text columns
+			or a bare access method ("btree", "hash", "gist", "gin", "brin", "spgist").
+		where: predicate for a partial index, e.g. "docstatus < 2". A trusted DDL fragment
+			interpolated verbatim -- callers MUST NOT pass user-supplied input.
+		include: non-key columns to carry in a covering (INCLUDE) btree index, so an index-only
+			scan answers the query without touching the heap.
+		"""
 		from frappe.database.postgres.schema import get_qualified_index_name
+
+		# `using` is interpolated into DDL, so reject anything outside the known-safe set.
+		if using and using not in INDEX_METHODS:
+			frappe.throw(f"Unsupported index method: {using}")
 
 		table_name = get_table_name(doctype)
 		clean_fields = [re.sub(r"\(.*\)", "", field) for field in fields]
+		# Column identifiers are interpolated into the DDL string, so reject anything that isn't a
+		# plain name -- a value like `id") ...; DROP TABLE ...` would otherwise inject into it.
+		for column in (*clean_fields, *(include or ())):
+			if not re.fullmatch(r"\w+", column):
+				frappe.throw(f"Invalid index column: {column}")
 		# postgres index names are per-schema, not per-table: an unqualified default name collides
 		# across tables sharing these fields and `CREATE INDEX IF NOT EXISTS` then silently skips
-		# all but the first, leaving the index missing. Qualify with the table so each one is made.
-		index_name = index_name or get_qualified_index_name(table_name, clean_fields)
-		fields_str = '", "'.join(clean_fields)
+		# all but the first, leaving the index missing. Qualify with the table (and `using`, so a
+		# trigram index never clashes with the plain one on the same column).
+		index_name = index_name or get_qualified_index_name(table_name, clean_fields, using)
 
+		if using == "gin_trgm":
+			self.sql_ddl("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+		method = f" USING {'gin' if using in ('gin_trgm', 'gin_fulltext') else using}" if using else ""
+		include_clause = f""" INCLUDE ("{'", "'.join(include)}")""" if include else ""
+		condition = f" WHERE {where}" if where else ""
 		self.sql_ddl(
-			f'CREATE INDEX IF NOT EXISTS "{index_name}" ON "{self.db_schema}"."{table_name}" ("{fields_str}")'
+			f'CREATE INDEX IF NOT EXISTS "{index_name}" ON "{self.db_schema}"."{table_name}"'
+			f"{method} ({self._index_target(clean_fields, using)}){include_clause}{condition}"
 		)
+
+	def _index_target(self, fields: list[str], using: str | None) -> str:
+		"""The column list (or functional expression) an index is built over, per `using` mode."""
+		if using == "gin_trgm":
+			return ", ".join(f'"{field}" gin_trgm_ops' for field in fields)
+		if using == "gin_fulltext":
+			# 'english' regconfig keeps to_tsvector immutable so it can be indexed; the search query
+			# must use the same config. ponytail: hardcoded -- add a `config` arg if multilingual
+			# full-text is ever needed.
+			document = (
+				f'"{fields[0]}"'
+				if len(fields) == 1
+				else " || ' ' || ".join(f"coalesce(\"{field}\", '')" for field in fields)
+			)
+			return f"to_tsvector('english', {document})"
+		return '"' + '", "'.join(fields) + '"'
 
 	def add_unique(self, doctype, fields, constraint_name=None):
 		if isinstance(fields, str):

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -12,8 +12,10 @@ from frappe.utils.defaults import get_not_null_defaults
 # company, posting_date, lft/rgt, ...) and `CREATE INDEX IF NOT EXISTS` silently skips all but
 # the first -- so most tables never get that index. Qualify the name with the table so it is
 # schema-unique, hashing if it would exceed postgres's 63-byte identifier cap.
-def get_qualified_index_name(table_name: str, fields: list[str]) -> str:
+def get_qualified_index_name(table_name: str, fields: list[str], suffix: str | None = None) -> str:
 	base = f"{table_name}_" + "_".join(fields)
+	if suffix:
+		base += f"_{suffix}"
 	name = f"{base}_index"
 	if len(name.encode()) > 63:
 		digest = hashlib.md5(base.encode()).hexdigest()[:10]

--- a/frappe/database/sqlite/database.py
+++ b/frappe/database/sqlite/database.py
@@ -382,13 +382,20 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 			if index_info and index_info[0]["name"] == fieldname:
 				return index
 
-	def add_index(self, doctype: str, fields: list, index_name: str | None = None):
-		"""Creates an index with given fields if not already created."""
+	def add_index(
+		self, doctype: str, fields: list, index_name: str | None = None, using=None, where=None, include=None
+	):
+		"""Creates an index with given fields if not already created.
+		`using`/`where`/`include` are postgres-only (trigram/partial/covering); a `using` kind
+		has no SQLite equivalent so it is skipped, and a plain index covers all rows regardless of
+		`where`/`include`."""
 
 		from frappe.custom.doctype.property_setter.property_setter import (
 			make_property_setter,
 		)
 
+		if using:
+			return
 		# We can't specify the length of the index in SQLite
 		fields = [re.sub(r"\(.*?\)", "", field) for field in fields]
 

--- a/frappe/query_builder/custom.py
+++ b/frappe/query_builder/custom.py
@@ -96,13 +96,16 @@ class TO_TSVECTOR(DistinctOptionFunction):
 		        column (str): [ column to search in ]
 		"""
 		alias = kwargs.get("alias")
-		super().__init__("TO_TSVECTOR", column, *args, alias=alias)
+		# Pin the 'english' regconfig: it makes to_tsvector immutable so a GIN index can back it
+		# (the 1-arg form depends on a session GUC and can't be indexed); plainto_tsquery uses the
+		# same config so the index over to_tsvector('english', content) is actually used.
+		super().__init__("TO_TSVECTOR", "english", column, *args, alias=alias)
 		self._PLAINTO_TSQUERY = False
 
 	def get_function_sql(self, **kwargs):
 		s = super(DistinctOptionFunction, self).get_function_sql(**kwargs)
 		if self._PLAINTO_TSQUERY:
-			return f"{s} @@ PLAINTO_TSQUERY({frappe.db.escape(self._PLAINTO_TSQUERY)})"
+			return f"{s} @@ PLAINTO_TSQUERY('english', {frappe.db.escape(self._PLAINTO_TSQUERY)})"
 		return s
 
 	@builder

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1057,6 +1057,47 @@ class TestDDLCommandsPost(IntegrationTestCase):
 			self.assertEqual(advisory_count(), before + 1)
 		self.assertEqual(advisory_count(), before)
 
+	def _indexdef(self, field: str, using: str) -> str:
+		from frappe.database.postgres.schema import get_qualified_index_name
+
+		name = get_qualified_index_name(f"tab{self.test_table_name}", [field], using)
+		return frappe.db.sql("SELECT indexdef FROM pg_indexes WHERE indexname = %s", (name,))[0][0]
+
+	def test_add_index_trigram(self) -> None:
+		frappe.db.add_index(self.test_table_name, ["content"], using="gin_trgm")
+		indexdef = self._indexdef("content", "gin_trgm")
+		self.assertIn("USING gin", indexdef)
+		self.assertIn("gin_trgm_ops", indexdef)
+
+	def test_add_index_fulltext(self) -> None:
+		frappe.db.add_index(self.test_table_name, ["content"], using="gin_fulltext")
+		indexdef = self._indexdef("content", "gin_fulltext")
+		self.assertIn("USING gin", indexdef)
+		self.assertIn("to_tsvector", indexdef)
+
+	def test_add_index_partial(self) -> None:
+		frappe.db.add_index(self.test_table_name, ["id"], index_name="test_partial", where="id > 0")
+		indexdef = frappe.db.sql("SELECT indexdef FROM pg_indexes WHERE indexname = 'test_partial'")[0][0]
+		self.assertIn("WHERE", indexdef)
+
+	def test_covering_index(self) -> None:
+		frappe.db.add_index(self.test_table_name, ["id"], index_name="test_covering", include=["content"])
+		indexdef = frappe.db.sql("SELECT indexdef FROM pg_indexes WHERE indexname = 'test_covering'")[0][0]
+		self.assertIn("INCLUDE", indexdef)
+		self.assertIn("content", indexdef)
+
+	def test_add_index_rejects_unknown_method(self) -> None:
+		# `using` reaches the DDL string verbatim, so an unknown method must be refused, not run.
+		with self.assertRaises(frappe.ValidationError):
+			frappe.db.add_index(self.test_table_name, ["content"], using="gin; DROP TABLE x")
+
+	def test_add_index_rejects_unsafe_columns(self) -> None:
+		# field and include column names are interpolated into the DDL, so reject non-identifiers.
+		with self.assertRaises(frappe.ValidationError):
+			frappe.db.add_index(self.test_table_name, ['id") ; DROP TABLE x --'])
+		with self.assertRaises(frappe.ValidationError):
+			frappe.db.add_index(self.test_table_name, ["id"], include=['content") ; DROP TABLE x --'])
+
 	def test_json_columns_return_strings(self) -> None:
 		# Regression: psycopg2 auto-parses json/jsonb into python objects, but frappe models JSON
 		# fields as strings (like MariaDB's longtext) and json.loads them on demand. A parsed value

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -283,10 +283,13 @@ class TestCustomFunctionsPostgres(IntegrationTestCase):
 		)
 
 	def test_match(self):
+		# 'english' regconfig is pinned so a GIN index over to_tsvector('english', col) can back it
 		query = Match("Notes")
-		self.assertEqual("TO_TSVECTOR('Notes')", query.get_sql())
+		self.assertEqual("TO_TSVECTOR('english','Notes')", query.get_sql())
 		query = Match("Notes").Against("text")
-		self.assertEqual("TO_TSVECTOR('Notes') @@ PLAINTO_TSQUERY('text')", query.get_sql())
+		self.assertEqual(
+			"TO_TSVECTOR('english','Notes') @@ PLAINTO_TSQUERY('english', 'text')", query.get_sql()
+		)
 
 	def test_constant_column(self):
 		query = frappe.qb.from_("DocType").select("name", ConstantColumn("John").as_("User"))

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -543,7 +543,7 @@ def search(text: str, start: int = 0, limit: int = 20, doctype: str = ""):
 	return sorted_results
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep
 def web_search(text: str, scope: str | None = None, start: int = 0, limit: int = 20):
 	"""
 	Search for given text in __global_search where published = 1
@@ -570,7 +570,9 @@ def web_search(text: str, scope: str | None = None, start: int = 0, limit: int =
 		mariadb_conditions += "MATCH(`content`) AGAINST ({} IN BOOLEAN MODE)".format(
 			frappe.db.escape("+" + text + "*")
 		)
-		postgres_conditions += f'TO_TSVECTOR("content") @@ PLAINTO_TSQUERY({frappe.db.escape(text)})'
+		postgres_conditions += (
+			f"to_tsvector('english', \"content\") @@ plainto_tsquery('english', {frappe.db.escape(text)})"
+		)
 
 		values = {"scope": "".join([scope, "%"]) if scope else "", "limit": limit, "start": start}
 


### PR DESCRIPTION
Part of the PostgreSQL feature-enablement workstream — splitting the merged MariaDB→Postgres branch into reviewable, per-feature PRs.

## What
Extends `frappe.db.add_index()` with Postgres-native index kinds:
- `where="…"` — partial indexes
- `include=[…]` — covering (INCLUDE) indexes for index-only scans
- `using="gin_trgm"` — trigram GIN for fast `LIKE '%…%'` (auto-creates the `pg_trgm` extension)
- `using="gin_fulltext"` — GIN over `to_tsvector(…)` for full-text search

Also adds `to_tsvector`/`Match` query-builder helpers (pinned to the `english` regconfig so the expression is immutable/indexable) and a full-text GIN index on `__global_search`. Index names are table-qualified so they're unique per schema (a Postgres requirement).

## Cross-engine
`using`/`where`/`include` are Postgres-only; MariaDB/SQLite fall back to a plain index (or skip, for `using`). Verified on Postgres and MariaDB.

---
🔗 Companion ERPNext PR: https://github.com/frappe/erpnext/pull/56696