### PR TITLE
feat(db): cross-engine advisory_lock() context manager

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1526,6 +1526,11 @@ class Database:
 		while value_chunk := tuple(itertools.islice(value_iterator, chunk_size)):
 			query.insert(*value_chunk).run()
 
+	def advisory_lock(self, key, *, timeout=10):
+		"""Hold a session-level advisory lock for the duration of the `with` block. Postgres uses
+		pg_advisory_lock, MariaDB uses GET_LOCK; engines without advisory locks raise."""
+		raise NotImplementedError(f"Advisory locks are not supported on {self.db_type}.")
+
 	def create_sequence_table(self):
 		# MariaDB/Postgres have native sequences and need no backing table;
 		# SQLite overrides this to create its emulation table at site setup.

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -439,6 +439,31 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 					for_doctype=False,  # Applied on docfield
 				)
 
+	@contextmanager
+	def advisory_lock(self, key, *, timeout=10):
+		"""Hold a session-level named lock (GET_LOCK) for the duration of the `with` block -- the
+		MariaDB equivalent of pg_advisory_lock. Session-scoped, so it survives intermediate commits.
+		Waits up to `timeout` seconds, then raises QueryTimeoutError. The key is hashed to a fixed
+		64-char digest so long keys can't collide via GET_LOCK's silent name truncation."""
+		import hashlib
+
+		from frappe.exceptions import QueryTimeoutError
+
+		name = hashlib.sha256(str(key).encode()).hexdigest()
+		result = self.sql("SELECT GET_LOCK(%s, %s)", (name, timeout))
+		value = result[0][0] if result else None
+		# GET_LOCK returns 1 (acquired), 0 (timed out), or NULL (server error, e.g. OOM/killed
+		# thread). Only 0 is a timeout -- surfacing NULL as QueryTimeoutError would make a caller
+		# retry straight back into the same server failure.
+		if value is None:
+			raise RuntimeError(f"GET_LOCK returned NULL acquiring advisory lock {key!r} (server error)")
+		if value != 1:
+			raise QueryTimeoutError(f"Could not acquire advisory lock {key!r} within {timeout}s")
+		try:
+			yield
+		finally:
+			self.sql("SELECT RELEASE_LOCK(%s)", (name,))
+
 	def add_unique(self, doctype, fields, constraint_name=None):
 		if isinstance(fields, str):
 			fields = [fields]

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -466,6 +466,31 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 					for_doctype=False,  # Applied on docfield
 				)
 
+	@contextmanager
+	def advisory_lock(self, key, *, timeout=10):
+		"""Hold a session-level named lock (GET_LOCK) for the duration of the `with` block -- the
+		MariaDB equivalent of pg_advisory_lock. Session-scoped, so it survives intermediate commits.
+		Waits up to `timeout` seconds, then raises QueryTimeoutError. The key is hashed to a fixed
+		64-char digest so long keys can't collide via GET_LOCK's silent name truncation."""
+		import hashlib
+
+		from frappe.exceptions import QueryTimeoutError
+
+		name = hashlib.sha256(str(key).encode()).hexdigest()
+		result = self.sql("SELECT GET_LOCK(%s, %s)", (name, timeout))
+		value = result[0][0] if result else None
+		# GET_LOCK returns 1 (acquired), 0 (timed out), or NULL (server error, e.g. OOM/killed
+		# thread). Only 0 is a timeout -- surfacing NULL as QueryTimeoutError would make a caller
+		# retry straight back into the same server failure.
+		if value is None:
+			raise RuntimeError(f"GET_LOCK returned NULL acquiring advisory lock {key!r} (server error)")
+		if value != 1:
+			raise QueryTimeoutError(f"Could not acquire advisory lock {key!r} within {timeout}s")
+		try:
+			yield
+		finally:
+			self.sql("SELECT RELEASE_LOCK(%s)", (name,))
+
 	def add_unique(self, doctype, fields, constraint_name=None):
 		if isinstance(fields, str):
 			fields = [fields]

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -640,6 +640,28 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			self._cursor = original_cursor
 			new_cursor.close()
 
+	@contextmanager
+	def advisory_lock(self, key, *, timeout=10):
+		"""Hold a session-level advisory lock for the duration of the `with` block. Session-scoped
+		(pg_advisory_lock) so it survives any intermediate commits the caller makes -- a txn-scoped
+		lock would release at the first commit. Polls pg_try_advisory_lock up to `timeout` seconds,
+		then raises QueryTimeoutError. `key` is hashed to the bigint the lock functions expect."""
+		import hashlib
+		import time
+
+		from frappe.exceptions import QueryTimeoutError
+
+		lock_key = int.from_bytes(hashlib.sha256(str(key).encode()).digest()[:8], "big", signed=True)
+		deadline = time.monotonic() + timeout
+		while not self.sql("SELECT pg_try_advisory_lock(%s)", (lock_key,))[0][0]:
+			if time.monotonic() >= deadline:
+				raise QueryTimeoutError(f"Could not acquire advisory lock {key!r} within {timeout}s")
+			time.sleep(0.1)
+		try:
+			yield
+		finally:
+			self.sql("SELECT pg_advisory_unlock(%s)", (lock_key,))
+
 
 def modify_query(query):
 	""" "Modifies query according to the requirements of postgres"""

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1048,6 +1048,15 @@ class TestDDLCommandsPost(IntegrationTestCase):
 		)
 		self.assertEqual(len(indexs_in_table), 1)
 
+	def test_advisory_lock(self) -> None:
+		def advisory_count():
+			return frappe.db.sql("SELECT count(*) FROM pg_locks WHERE locktype = 'advisory'")[0][0]
+
+		before = advisory_count()
+		with frappe.db.advisory_lock("frappe-test-lock"):
+			self.assertEqual(advisory_count(), before + 1)
+		self.assertEqual(advisory_count(), before)
+
 	def test_json_columns_return_strings(self) -> None:
 		# Regression: psycopg2 auto-parses json/jsonb into python objects, but frappe models JSON
 		# fields as strings (like MariaDB's longtext) and json.loads them on demand. A parsed value
@@ -1655,3 +1664,21 @@ class TestMariaDBExceptionUtil(IntegrationTestCase):
 		unrelated = _E()
 		unrelated.pgcode = "12345"
 		self.assertFalse(PostgresExceptionUtil.is_deadlocked(unrelated))
+
+
+class TestAdvisoryLockMariaDB(IntegrationTestCase):
+	@run_only_if(db_type_is.MARIADB)
+	def test_advisory_lock_get_release(self):
+		# Exercises the MariaDB GET_LOCK / RELEASE_LOCK path (the Postgres test uses pg_locks).
+		import hashlib
+
+		name = hashlib.sha256(b"frappe-test-lock").hexdigest()
+
+		def held():
+			# IS_USED_LOCK returns the connection id holding the lock, or NULL when free.
+			return frappe.db.sql("SELECT IS_USED_LOCK(%s)", (name,))[0][0] is not None
+
+		self.assertFalse(held())
+		with frappe.db.advisory_lock("frappe-test-lock"):
+			self.assertTrue(held())
+		self.assertFalse(held())


### PR DESCRIPTION
Part of the PostgreSQL feature-enablement workstream.

## What
Adds a cross-engine `frappe.db.advisory_lock(key, *, timeout=10)` context manager holding a **session-level** advisory lock for the `with` block:
- **Postgres** — `pg_advisory_lock`, with a real timeout via `pg_try_advisory_lock` polling.
- **MariaDB** — `GET_LOCK`/`RELEASE_LOCK` (native timeout).

Session-scoped so it survives intermediate commits; keys are hashed (collision-safe); raises `QueryTimeoutError` on timeout. SQLite raises `NotImplementedError`.

## Why
Lets callers serialize a logical resource (e.g. a stock item's reposting) as an outer gate in front of row locks, turning lock-order deadlocks into an orderly wait.

## Cross-engine
Verified on Postgres and MariaDB (mutual exclusion, timeout, survives-commit, release).

---
🔗 Companion ERPNext PR: https://github.com/frappe/erpnext/pull/56697