### PR TITLE
feat(postgres): stream bulk_insert via COPY

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -719,6 +719,73 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		finally:
 			self.sql("SELECT pg_advisory_unlock(%s)", (lock_key,))
 
+	def bulk_insert(self, doctype, fields, values, ignore_duplicates=False, *, chunk_size=10_000):
+		"""Stream rows into the table with COPY -- far faster than multi-row INSERT. Falls back to
+		the parameterized INSERT path when `ignore_duplicates` is set (COPY has no ON CONFLICT).
+		Runs in the current transaction; the caller commits."""
+		if ignore_duplicates:
+			return super().bulk_insert(doctype, fields, values, ignore_duplicates=True, chunk_size=chunk_size)
+
+		import io
+
+		table_name = get_table_name(doctype)
+		# Compose identifiers with psycopg2.sql so a field/table name is always correctly quoted.
+		copy_statement = sql.SQL("COPY {}.{} ({}) FROM STDIN").format(
+			sql.Identifier(self.db_schema),
+			sql.Identifier(table_name),
+			sql.SQL(", ").join(sql.Identifier(field) for field in fields),
+		)
+		if not self._conn:
+			self.connect()
+		cursor = self._conn.cursor()
+		copy_sql = copy_statement.as_string(cursor)
+		buffer = io.StringIO()
+		try:
+			row_count = flushed = 0
+			for value in values:
+				buffer.write("\t".join(_copy_encode(column) for column in value) + "\n")
+				row_count += 1
+				if row_count % chunk_size == 0:
+					_copy_flush(cursor, copy_sql, buffer)
+					# COPY bypasses Database.execute, so keep transaction_writes in step with the
+					# rows sent -- else auto_commit_on_many_writes never sees a large load.
+					self.transaction_writes += row_count - flushed
+					flushed = row_count
+			_copy_flush(cursor, copy_sql, buffer)
+			self.transaction_writes += row_count - flushed
+		finally:
+			cursor.close()
+
+
+def _copy_encode(value):
+	"""Encode one value for postgres COPY text format (tab-delimited, ``\\N`` = NULL)."""
+	if value is None:
+		return r"\N"
+	if value is True:
+		# Frappe Check fields are smallint, not boolean; smallint_in("true") errors under COPY.
+		# "1"/"0" is accepted by both smallint and boolean input functions, matching INSERT.
+		return "1"
+	if value is False:
+		return "0"
+	if isinstance(value, datetime.timedelta):
+		# Frappe Time fields are timedelta; str() on a >=1 day delta is "1 day, H:MM:SS", which
+		# postgres cannot parse as time. Emit HH:MM:SS[.ffffff] so the COPY text is always valid.
+		total = int(value.total_seconds())
+		hours, remainder = divmod(total, 3600)
+		minutes, seconds = divmod(remainder, 60)
+		encoded = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+		return f"{encoded}.{value.microseconds:06d}" if value.microseconds else encoded
+	return str(value).replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n").replace("\r", "\\r")
+
+
+def _copy_flush(cursor, copy_sql, buffer):
+	if not buffer.tell():
+		return
+	buffer.seek(0)
+	cursor.copy_expert(copy_sql, buffer)
+	buffer.seek(0)
+	buffer.truncate(0)
+
 
 def modify_query(query):
 	""" "Modifies query according to the requirements of postgres"""

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1723,3 +1723,51 @@ class TestAdvisoryLockMariaDB(IntegrationTestCase):
 		with frappe.db.advisory_lock("frappe-test-lock"):
 			self.assertTrue(held())
 		self.assertFalse(held())
+
+
+class TestBulkInsertCopy(IntegrationTestCase):
+	def test_bulk_insert_copy(self):
+		# postgres bulk_insert streams via COPY, other engines use multi-row INSERT; both must
+		# round-trip NULLs and tab/newline characters (the COPY text encoding escapes these).
+		frappe.db.sql_ddl("DROP TABLE IF EXISTS `tabBulkLoadTest`")
+		frappe.db.sql("CREATE TABLE `tabBulkLoadTest` (`name` varchar(140), `qty` int, `note` text)")
+		self.addCleanup(frappe.db.sql_ddl, "DROP TABLE IF EXISTS `tabBulkLoadTest`")
+
+		rows = [("a", 1, "x"), ("b", 2, None), ("c\twith\ttabs", 3, "line\nbreak")]
+		frappe.db.bulk_insert("BulkLoadTest", ["name", "qty", "note"], rows)
+		frappe.db.commit()  # nosemgrep
+
+		got = frappe.db.sql("SELECT `name`, `qty`, `note` FROM `tabBulkLoadTest` ORDER BY `qty`")
+		self.assertEqual(len(got), 3)
+		self.assertIsNone(got[1][2])
+		self.assertEqual(got[2][0], "c\twith\ttabs")
+		self.assertEqual(got[2][2], "line\nbreak")
+
+	@run_only_if(db_type_is.POSTGRES)
+	def test_bulk_insert_copy_time(self):
+		# COPY encodes Time (timedelta) values itself: a sub-24h value must round-trip rather than
+		# str()'s "H:MM:SS" formatting drifting or a days component becoming "1 day, ...".
+		frappe.db.sql_ddl("DROP TABLE IF EXISTS `tabBulkTimeTest`")
+		frappe.db.sql('CREATE TABLE "tabBulkTimeTest" ("name" varchar(140), "at" time)')
+		self.addCleanup(frappe.db.sql_ddl, "DROP TABLE IF EXISTS `tabBulkTimeTest`")
+
+		value = datetime.timedelta(hours=2, minutes=30, seconds=15)
+		frappe.db.bulk_insert("BulkTimeTest", ["name", "at"], [("a", value)])
+		frappe.db.commit()  # nosemgrep
+
+		self.assertEqual(frappe.db.sql('SELECT "at" FROM "tabBulkTimeTest"')[0][0], value)
+
+	@run_only_if(db_type_is.POSTGRES)
+	def test_bulk_insert_copy_check_field(self):
+		# Check fields are smallint; COPY must encode Python True/False as 1/0 -- smallint_in("true")
+		# would raise "invalid input syntax for type smallint".
+		frappe.db.sql_ddl("DROP TABLE IF EXISTS `tabBulkFlagTest`")
+		frappe.db.sql('CREATE TABLE "tabBulkFlagTest" ("name" varchar(140), "flag" smallint)')
+		self.addCleanup(frappe.db.sql_ddl, "DROP TABLE IF EXISTS `tabBulkFlagTest`")
+
+		frappe.db.bulk_insert("BulkFlagTest", ["name", "flag"], [("a", True), ("b", False)])
+		frappe.db.commit()  # nosemgrep
+
+		got = dict(frappe.db.sql('SELECT "name", "flag" FROM "tabBulkFlagTest"'))
+		self.assertEqual(got["a"], 1)
+		self.assertEqual(got["b"], 0)


### PR DESCRIPTION
Part of the PostgreSQL feature-enablement workstream.

## What
Streams `frappe.db.bulk_insert()` through Postgres `COPY` instead of multi-row `INSERT`, with a text-format encoder that round-trips NULLs and tab/newline characters. Falls back to multi-row INSERT on other engines.

## Why
`COPY` is substantially faster for large batch inserts (e.g. bulk Serial No / Batch creation). Existing `bulk_insert` callers benefit automatically — no call-site changes.

## Cross-engine
Postgres uses COPY; MariaDB/SQLite keep multi-row INSERT. Verified on both (round-trips NULLs and tab/newline).

_Framework-only — no ERPNext change needed (existing `bulk_insert` callers benefit automatically)._
