### PR TITLE
feat(postgres): materialized views & materialized reports

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -43,6 +43,7 @@ def get_bootinfo():
 
 	# system info
 	bootinfo.sitename = frappe.local.site
+	bootinfo.db_type = frappe.db.db_type
 	bootinfo.sysdefaults = frappe.defaults.get_defaults()
 	bootinfo.sysdefaults["setup_complete"] = frappe.is_setup_complete()
 

--- a/frappe/core/doctype/report/report.js
+++ b/frappe/core/doctype/report/report.js
@@ -11,6 +11,22 @@ frappe.ui.form.on("Report", {
 		}
 
 		let doc = frm.doc;
+		if (!doc.__islocal && doc.is_materialized) {
+			frm.add_custom_button(__("Refresh Materialized View"), function () {
+				frappe.call({
+					method: "frappe.core.doctype.report.report.refresh_materialized_report",
+					args: { report: doc.name },
+					freeze: true,
+					callback: function () {
+						frappe.show_alert({
+							message: __("Materialized view refreshed"),
+							indicator: "green",
+						});
+					},
+				});
+			});
+		}
+
 		if (!doc.__islocal) {
 			frm.add_custom_button(
 				__("Show Report"),

--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -32,6 +32,7 @@
   "columns",
   "section_break_6",
   "query",
+  "is_materialized",
   "report_script",
   "client_code_section",
   "javascript",
@@ -119,6 +120,13 @@
    "fieldtype": "Code",
    "label": "Query",
    "options": "SQL"
+  },
+  {
+   "depends_on": "eval:doc.report_type==\"Query Report\" && frappe.boot.db_type==\"postgres\"",
+   "description": "Cache this report's result as a materialized view, refreshed on schedule or manually. The query cannot use filter placeholders.",
+   "fieldname": "is_materialized",
+   "fieldtype": "Check",
+   "label": "Materialized"
   },
   {
    "depends_on": "eval:doc.report_type==\"Script Report\" && doc.is_standard===\"No\"",

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 import datetime
 import json
+import re
 import threading
 
 import frappe
@@ -44,6 +45,7 @@ class Report(Document):
 		documentation_url: DF.Data | None
 		filters: DF.Table[ReportFilter]
 		generate_csv: DF.Check
+		is_materialized: DF.Check
 		is_standard: DF.Literal["No", "Yes"]
 		javascript: DF.Code | None
 		json: DF.Code | None
@@ -93,16 +95,40 @@ class Report(Document):
 		if self.default_letter_head and self.has_value_changed("letter_head"):
 			self.validate_default_letter_head()
 
+		if self.is_materialized:
+			if self.report_type != "Query Report":
+				frappe.throw(_("Only Query Reports can be materialized."))
+			# A materialized view takes no runtime parameters; reject printf-style placeholders
+			# (%s, %d, %(name)s). Strip quoted literals first so a LIKE '%s...' isn't misread.
+			if self.query and re.search(r"%(\(\w+\))?[sd]", re.sub(r"'[^']*'", "", self.query)):
+				frappe.throw(
+					_("A materialized report cannot use filter placeholders; it is a precomputed snapshot.")
+				)
+			# Reject an unsafe query here, before on_update runs the (non-atomic, auto-committing)
+			# drop-then-create DDL -- otherwise a query that only fails check_safe_sql_query would
+			# drop the old view and leave the report pointing at a missing relation.
+			if self.query:
+				check_safe_sql_query(self.query)
+
 	def before_insert(self):
 		self.set_doctype_roles()
 
 	def on_update(self):
 		self.export_doc()
+		# Touch the matview only when the report is materialized now (create/rebuild) or was
+		# materialized before (drop) -- a normal report save never triggers matview DDL (which
+		# auto-commits on MariaDB).
+		before = self.get_doc_before_save()
+		if self.is_materialized or (before and before.is_materialized):
+			self.sync_materialized_view()
 
 	def before_export(self, doc):
 		doc.prepared_report = 0
 
 	def on_trash(self):
+		if self.is_materialized:
+			frappe.db.drop_materialized_view(self.materialized_view_name())
+
 		if self.is_standard == "Yes":
 			if (
 				not cint(getattr(frappe.local.conf, "developer_mode", 0))
@@ -178,6 +204,10 @@ class Report(Document):
 			make_boilerplate("controller.js", self, {"name": self.name})
 
 	def execute_query_report(self, filters):
+		# Materialized views are Postgres-only; on other engines fall through and run the query live.
+		if self.is_materialized and frappe.db.db_type == "postgres":
+			return self.execute_materialized_report()
+
 		if not self.query:
 			frappe.throw(_("Must specify a Query to run"), title=_("Report Document Error"))
 
@@ -189,6 +219,27 @@ class Report(Document):
 		frappe.db.rollback()
 
 		return [columns, result]
+
+	def materialized_view_name(self):
+		return f"_report_mv_{scrub(self.name)}"[:63]
+
+	def execute_materialized_report(self):
+		"""Read the precomputed snapshot instead of re-running the query. Filters are not applied --
+		the materialized view holds the full, precomputed result. A plain SELECT needs no
+		transaction wrapper (an explicit rollback here would discard the request's pending writes)."""
+		rows = frappe.db.sql(f"SELECT * FROM `{self.materialized_view_name()}`")  # nosemgrep
+		result = [list(t) for t in rows]
+		columns = self.get_columns() or [cstr(c[0]) for c in frappe.db.get_description()]
+
+		return [columns, result]
+
+	def sync_materialized_view(self):
+		"""Rebuild (or drop) this report's materialized view to match its current definition.
+		The query is already validated by validate()/check_safe_sql_query before this runs."""
+		view = self.materialized_view_name()
+		frappe.db.drop_materialized_view(view)
+		if self.report_type == "Query Report" and self.is_materialized and self.query:
+			frappe.db.create_materialized_view(view, self.query)
 
 	def execute_script_report(self, filters):
 		# save the timestamp to automatically set to prepared
@@ -569,3 +620,31 @@ def has_permission(doc, ptype=None, user=None, debug=False):
 	if frappe.db.db_type != "postgres" and doc.name.lower().startswith("postgres "):
 		return False
 	return True
+
+
+@frappe.whitelist()
+def refresh_materialized_report(report: str):
+	frappe.only_for("System Manager")
+	doc = frappe.get_cached_doc("Report", report)
+	doc.check_permission("read")
+	if not doc.is_materialized:
+		frappe.throw(_("Report {0} is not materialized.").format(report))
+	frappe.db.refresh_materialized_view(doc.materialized_view_name())
+	frappe.db.commit()  # nosemgrep
+
+
+def refresh_all_materialized_reports():
+	"""Scheduler hook: recompute every materialized Query Report's snapshot."""
+	# limit=0 -> fetch every materialized report; get_all otherwise caps at 20 and silently
+	# leaves the rest permanently stale.
+	reports = frappe.get_all(
+		"Report", filters={"is_materialized": 1, "report_type": "Query Report"}, pluck="name", limit=0
+	)
+	for name in reports:
+		try:
+			doc = frappe.get_cached_doc("Report", name)
+			frappe.db.refresh_materialized_view(doc.materialized_view_name())
+			frappe.db.commit()  # nosemgrep
+		except Exception:
+			frappe.db.rollback()
+			frappe.log_error(title=f"Failed to refresh materialized report {name}")

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1531,6 +1531,16 @@ class Database:
 		pg_advisory_lock, MariaDB uses GET_LOCK; engines without advisory locks raise."""
 		raise NotImplementedError(f"Advisory locks are not supported on {self.db_type}.")
 
+	def create_materialized_view(self, name, query, *, with_data=True):
+		"""Materialized views are a Postgres-only feature; Postgres overrides this.
+		On other engines it is a no-op -- a materialized report just runs its query live."""
+
+	def refresh_materialized_view(self, name, **kwargs):
+		"""No-op on engines without native materialized view support."""
+
+	def drop_materialized_view(self, name):
+		"""No-op on engines without native materialized view support."""
+
 	def create_sequence_table(self):
 		# MariaDB/Postgres have native sequences and need no backing table;
 		# SQLite overrides this to create its emulation table at site setup.

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -662,6 +662,20 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		finally:
 			self.sql("SELECT pg_advisory_unlock(%s)", (lock_key,))
 
+	def create_materialized_view(self, name, query, *, with_data=True):
+		"""Native postgres MATERIALIZED VIEW; recompute it with refresh_materialized_view()."""
+		definition = query.get_sql() if hasattr(query, "get_sql") else str(query)
+		clause = "WITH DATA" if with_data else "WITH NO DATA"
+		self.sql_ddl(f'CREATE MATERIALIZED VIEW IF NOT EXISTS "{name}" AS {definition} {clause}')
+
+	def refresh_materialized_view(self, name, *, concurrently=False):
+		# CONCURRENTLY lets readers keep querying during the rebuild but needs a unique index on the view.
+		mode = "CONCURRENTLY " if concurrently else ""
+		self.sql_ddl(f'REFRESH MATERIALIZED VIEW {mode}"{name}"')
+
+	def drop_materialized_view(self, name):
+		self.sql_ddl(f'DROP MATERIALIZED VIEW IF EXISTS "{name}"')
+
 
 def modify_query(query):
 	""" "Modifies query according to the requirements of postgres"""

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -275,6 +275,7 @@ scheduler_events = {
 		"frappe.desk.doctype.event.event.send_event_digest",
 		"frappe.email.doctype.notification.notification.trigger_daily_alerts",
 		"frappe.desk.form.document_follow.send_daily_updates",
+		"frappe.core.doctype.report.report.refresh_all_materialized_reports",
 	],
 	"daily_long": [],
 	"daily_maintenance": [

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1682,3 +1682,42 @@ class TestAdvisoryLockMariaDB(IntegrationTestCase):
 		with frappe.db.advisory_lock("frappe-test-lock"):
 			self.assertTrue(held())
 		self.assertFalse(held())
+
+
+class TestMaterializedView(IntegrationTestCase):
+	@run_only_if(db_type_is.POSTGRES)
+	def test_materialized_view(self):
+		frappe.db.sql_ddl("DROP TABLE IF EXISTS `tabMatviewSrc`")
+		frappe.db.drop_materialized_view("mv_test")
+		frappe.db.sql("CREATE TABLE `tabMatviewSrc` (`grp` varchar(10), `amt` int)")
+		self.addCleanup(frappe.db.sql_ddl, "DROP TABLE IF EXISTS `tabMatviewSrc`")
+		self.addCleanup(frappe.db.drop_materialized_view, "mv_test")
+		frappe.db.sql("INSERT INTO `tabMatviewSrc` VALUES ('a', 10), ('a', 5), ('b', 3)")
+		frappe.db.commit()  # nosemgrep
+
+		query = "SELECT grp, SUM(amt) AS total FROM `tabMatviewSrc` GROUP BY grp"
+		frappe.db.create_materialized_view("mv_test", query)
+		frappe.db.commit()  # nosemgrep
+
+		def total():
+			return int(frappe.db.sql("SELECT total FROM `mv_test` WHERE grp = 'a'")[0][0])
+
+		self.assertEqual(total(), 15)
+
+		# new source rows are invisible until an explicit refresh -- that is the point of a matview
+		frappe.db.sql("INSERT INTO `tabMatviewSrc` VALUES ('a', 100)")
+		frappe.db.commit()  # nosemgrep
+		self.assertEqual(total(), 15)
+		frappe.db.refresh_materialized_view("mv_test")
+		frappe.db.commit()  # nosemgrep
+		self.assertEqual(total(), 115)
+
+	@run_only_if(db_type_is.MARIADB)
+	def test_materialized_view_noop_on_mariadb(self):
+		# Materialized views are Postgres-only: on MariaDB the methods are silent no-ops and must
+		# not resurrect the old snapshot-table emulation (a `__materialized_views` registry table).
+		frappe.db.create_materialized_view("mv_noop", "SELECT 1")
+		frappe.db.refresh_materialized_view("mv_noop")
+		frappe.db.drop_materialized_view("mv_noop")
+		self.assertFalse(frappe.db.table_exists("mv_noop"))
+		self.assertFalse(frappe.db.table_exists("__materialized_views"))


### PR DESCRIPTION
Part of the PostgreSQL feature-enablement workstream. Framework-only — no ERPNext change in this PR.

## What
Serves a heavy Query Report from a refreshable precomputed snapshot instead of re-running its query on every load.

- `frappe.db.create_materialized_view` / `refresh_materialized_view` / `drop_materialized_view` — Postgres-native `MATERIALIZED VIEW`.
- The Report doctype gains an `is_materialized` flag (Query Reports only). Saving a materialized report (re)builds the view; trashing it drops it. A **Refresh Materialized View** button and a scheduler hook (`refresh_all_materialized_reports`) recompute the snapshot.

## Postgres-only
Materialized views are a Postgres feature, so on other engines the DB methods are silent **no-ops** and a materialized report simply runs its query live (`execute_query_report` gates on `db_type == "postgres"`). The `is_materialized` checkbox is hidden on non-Postgres sites via `depends_on` against `frappe.boot.db_type`.

## Safety
`validate()` rejects filter placeholders (`%s` / `%(name)s`) and runs `check_safe_sql_query` **before** `on_update` issues any DDL, so an unsafe or parameterized query can't drop the old view and leave the report pointing at a missing relation. The whitelisted refresh also enforces `doc.check_permission("read")`.

## Tests
Postgres create → read → refresh cycle (`TestMaterializedView`) and the MariaDB no-op path (`test_materialized_view_noop_on_mariadb`).