### PR TITLE
fix: Make HTTP caching work on fingerprint stats

### DIFF
--- a/frappe/core/doctype/error_log/error_log.js
+++ b/frappe/core/doctype/error_log/error_log.js
@@ -26,6 +26,8 @@ function render_fingerprint_stats(frm) {
 
 	frappe.call({
 		method: "frappe.core.doctype.error_log.error_log.get_fingerprint_stats",
+		type: "GET",
+		cache: true,
 		args: { fingerprint: frm.doc.fingerprint },
 		callback: function (r) {
 			const stats = r.message;


### PR DESCRIPTION
These methods were supposed to use cache but don't because it only works
on GET
