### PR TITLE
feat(print-format-builder): table field styling and table-layout sections

### DIFF
--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -247,9 +247,10 @@ context("Print Format Builder — create flow", () => {
 			.blur();
 
 		cy.get(".pfb-body").should(($el) => {
-			const fs = $el.css("font-size");
-			// 18pt ≈ 24px
-			expect(parseInt(fs, 10)).to.be.greaterThan(20);
+			const fs = parseInt($el.css("font-size"), 10);
+			// Font size is applied as px to match the print output
+			// (print_format.css: font-size: {{ font_size }}px)
+			expect(fs).to.equal(18);
 		});
 	});
 });

--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -248,8 +248,6 @@ context("Print Format Builder — create flow", () => {
 
 		cy.get(".pfb-body").should(($el) => {
 			const fs = parseInt($el.css("font-size"), 10);
-			// Font size is applied as px to match the print output
-			// (print_format.css: font-size: {{ font_size }}px)
 			expect(fs).to.equal(18);
 		});
 	});

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -64,7 +64,7 @@
 							'preview-table--plain-header': df.table_header === 'plain',
 						}"
 					>
-						<thead>
+						<thead v-if="df.table_header !== 'none'">
 							<tr>
 								<th
 									v-for="col in df.table_columns"

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -54,15 +54,7 @@
 					</div>
 				</div>
 				<!-- Table field -->
-				<div
-					v-else-if="df.fieldtype == 'Table'"
-					class="field-preview-table"
-					:style="
-						df.table_radius != null
-							? { borderRadius: df.table_radius + 'px', overflow: 'hidden' }
-							: {}
-					"
-				>
+				<div v-else-if="df.fieldtype == 'Table'" class="field-preview-table">
 					<div v-if="df.label" class="field-preview-label">{{ df.label }}</div>
 					<table
 						class="preview-table"
@@ -71,6 +63,11 @@
 							'preview-table--borderless': df.table_bordered === false,
 							'preview-table--plain-header': df.table_header === 'plain',
 						}"
+						:style="
+							df.table_radius != null
+								? { borderRadius: df.table_radius + 'px', overflow: 'hidden' }
+								: {}
+						"
 					>
 						<thead v-if="df.table_header !== 'none'">
 							<tr>

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -54,7 +54,15 @@
 					</div>
 				</div>
 				<!-- Table field -->
-				<div v-else-if="df.fieldtype == 'Table'" class="field-preview-table">
+				<div
+					v-else-if="df.fieldtype == 'Table'"
+					class="field-preview-table"
+					:style="
+						df.table_radius != null
+							? { borderRadius: df.table_radius + 'px', overflow: 'hidden' }
+							: {}
+					"
+				>
 					<div v-if="df.label" class="field-preview-label">{{ df.label }}</div>
 					<table
 						class="preview-table"

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -70,7 +70,12 @@
 									v-for="col in df.table_columns"
 									:key="col.fieldname"
 									:class="numeric_align_class(col)"
-									:style="col.width ? { width: col.width + '%' } : {}"
+									:style="{
+										...(col.width ? { width: col.width + '%' } : {}),
+										...(df.table_cell_padding != null
+											? { padding: df.table_cell_padding + 'px' }
+											: {}),
+									}"
 								>
 									{{ col.label || col.fieldname }}
 								</th>
@@ -86,6 +91,11 @@
 									v-for="col in df.table_columns"
 									:key="col.fieldname"
 									:class="numeric_align_class(col)"
+									:style="
+										df.table_cell_padding != null
+											? { padding: df.table_cell_padding + 'px' }
+											: {}
+									"
 								>
 									<img
 										v-if="

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -332,4 +332,15 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	font-weight: var(--weight-bold);
 	color: var(--text-color);
 }
+
+/* Font size set on .pfb-body cascades into preview field text */
+.pfb-body :deep(.field-preview-value) {
+	font-size: 1em;
+}
+.pfb-body :deep(.field-preview-label) {
+	font-size: 0.85em;
+}
+.pfb-body :deep(.preview-table) {
+	font-size: 0.9em;
+}
 </style>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -143,7 +143,10 @@ let rootStyles = computed(() => {
 let bodyStyles = computed(() => {
 	const { font_size, font } = print_format.value;
 	const styles = {};
-	styles.fontSize = `${parseFloat(font_size) || 14}px`;
+	// px (not pt) to mirror the print output, which sets
+	// `font-size: {{ font_size }}px` in print_format.css. Only apply when set so an
+	// unset format falls back to the CSS default instead of being forced to a value.
+	if (font_size) styles.fontSize = `${parseFloat(font_size)}px`;
 	if (font) styles.fontFamily = `'${font}', sans-serif`;
 	return styles;
 });

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -335,12 +335,12 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 
 /* Font size set on .pfb-body cascades into preview field text */
 .pfb-body :deep(.field-preview-value) {
-	font-size: 1em;
+	font-size: 1em !important;
 }
 .pfb-body :deep(.field-preview-label) {
-	font-size: 0.85em;
+	font-size: 0.85em !important;
 }
 .pfb-body :deep(.preview-table) {
-	font-size: 0.9em;
+	font-size: 0.9em !important;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -333,14 +333,20 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	color: var(--text-color);
 }
 
-/* Font size set on .pfb-body cascades into preview field text */
-.pfb-body :deep(.field-preview-value) {
-	font-size: 1em !important;
+/* Font size set on .pfb-body must cascade into preview field text.
+   Root cause: .field hard-codes font-size: var(--text-sm), which resets the
+   cascade so em-based children scale off 13px, not the body's font size.
+   Make preview fields inherit, then size their text relative to that. */
+.pfb-body :deep(.field--preview) {
+	font-size: inherit;
 }
-.pfb-body :deep(.field-preview-label) {
-	font-size: 0.85em !important;
+.pfb-body :deep(.field--preview .field-preview-value) {
+	font-size: 1em;
 }
-.pfb-body :deep(.preview-table) {
-	font-size: 0.9em !important;
+.pfb-body :deep(.field--preview .field-preview-label) {
+	font-size: 0.8em;
+}
+.pfb-body :deep(.field--preview .preview-table) {
+	font-size: 0.9em;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -143,7 +143,7 @@ let rootStyles = computed(() => {
 let bodyStyles = computed(() => {
 	const { font_size, font } = print_format.value;
 	const styles = {};
-	if (font_size) styles.fontSize = `${font_size}pt`;
+	styles.fontSize = `${parseFloat(font_size) || 14}px`;
 	if (font) styles.fontFamily = `'${font}', sans-serif`;
 	return styles;
 });

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -143,9 +143,6 @@ let rootStyles = computed(() => {
 let bodyStyles = computed(() => {
 	const { font_size, font } = print_format.value;
 	const styles = {};
-	// px (not pt) to mirror the print output, which sets
-	// `font-size: {{ font_size }}px` in print_format.css. Only apply when set so an
-	// unset format falls back to the CSS default instead of being forced to a value.
 	if (font_size) styles.fontSize = `${parseFloat(font_size)}px`;
 	if (font) styles.fontFamily = `'${font}', sans-serif`;
 	return styles;
@@ -336,10 +333,6 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	color: var(--text-color);
 }
 
-/* Font size set on .pfb-body must cascade into preview field text.
-   Root cause: .field hard-codes font-size: var(--text-sm), which resets the
-   cascade so em-based children scale off 13px, not the body's font size.
-   Make preview fields inherit, then size their text relative to that. */
 .pfb-body :deep(.field--preview) {
 	font-size: inherit;
 }

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -501,25 +501,21 @@ function remove_column(index) {
 
 /* ── Table layout (field borders) ───────────────────────── */
 .section--grid .column {
+	border: 1px solid var(--border-color);
 	padding: 0;
-}
-.section--grid .drag-container {
-	display: contents;
-}
-.section--grid .section-columns {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
-	gap: 0;
+	margin-left: -1px;
 }
 .section--grid .column-divider {
 	display: none;
 }
 .section--grid :deep(.field) {
 	padding: var(--pfb-cell-pad, 8px);
-	border: 1px solid var(--border-color);
-	margin: -1px 0 0 -1px;
+	border: none;
+	border-bottom: 1px solid var(--border-color);
+	border-radius: 0;
+	background: transparent;
 }
-.section--grid :deep(.field-preview-wrap) {
-	padding: 0;
+.section--grid :deep(.field:last-child) {
+	border-bottom: none;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -70,7 +70,7 @@
 				"
 			>
 				<template v-for="(column, i) in section.columns" :key="i">
-					<div v-if="i > 0" class="column-divider"></div>
+					<div v-if="i > 0 && !preview_doc" class="column-divider"></div>
 					<div
 						class="column"
 						:class="{ 'column-align-right': column.align === 'right' }"
@@ -93,7 +93,9 @@
 							</template>
 						</draggable>
 						<div
-							v-if="column.fields.filter((f) => !f.remove).length === 0"
+							v-if="
+								!preview_doc && column.fields.filter((f) => !f.remove).length === 0
+							"
 							class="empty-drop-zone"
 						>
 							<button
@@ -151,6 +153,9 @@ let section_inline_style = computed(() => {
 	if (is_grid.value) {
 		const pad = props.section.cell_padding ?? 8;
 		style["--pfb-cell-pad"] = `${pad}px`;
+		style.borderRadius = "8px";
+		style.overflow = "hidden";
+		style.border = `1px solid var(--border-color)`;
 	}
 	return style;
 });
@@ -501,21 +506,19 @@ function remove_column(index) {
 
 /* ── Table layout (field borders) ───────────────────────── */
 .section--grid .column {
-	border: 1px solid var(--border-color);
 	padding: 0;
-	margin-left: -1px;
 }
 .section--grid .column-divider {
 	display: none;
 }
 .section--grid :deep(.field) {
-	padding: var(--pfb-cell-pad, 8px);
-	border: none;
-	border-bottom: 1px solid var(--border-color);
-	border-radius: 0;
-	background: transparent;
+	padding: var(--pfb-cell-pad, 8px) !important;
+	border: none !important;
+	border-bottom: 1px solid var(--border-color) !important;
+	border-radius: 0 !important;
+	background: transparent !important;
 }
 .section--grid :deep(.field:last-child) {
-	border-bottom: none;
+	border-bottom: none !important;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -155,8 +155,6 @@ let has_visible_fields = computed(() =>
 let section_inline_style = computed(() => {
 	const style = {};
 	if (props.section.background) style.backgroundColor = props.section.background;
-	// In grid (table) mode the cells sit flush against the section border, so the
-	// section itself carries no padding — spacing comes from per-cell padding instead.
 	if (props.section.padding && !is_grid.value) {
 		const p = props.section.padding;
 		style.padding = `${p.top || 0}px ${p.right || 0}px ${p.bottom || 0}px ${p.left || 0}px`;
@@ -517,10 +515,8 @@ function remove_column(index) {
 	border: 1px solid var(--border-color) !important;
 	border-radius: var(--border-radius-md, 8px) !important;
 	overflow: hidden !important;
-	/* No outer padding: cells run flush to the border so dividers reach edge-to-edge */
 	padding: 0 !important;
 }
-/* Title becomes a full-width header row with its own cell padding */
 .section--grid .section-title-display {
 	padding: var(--pfb-cell-pad, 8px) !important;
 	margin: 0 !important;
@@ -532,21 +528,15 @@ function remove_column(index) {
 .section--grid .column {
 	padding: 0;
 }
-/* Full-height vertical divider between columns */
 .section--grid .column:not(:last-child) {
 	border-right: 1px solid var(--border-color);
 }
 .section--grid .column-divider {
 	display: none;
 }
-/* Rows sit flush like table rows — cell padding provides the spacing */
 .section--grid :deep(.drag-container) {
 	gap: 0 !important;
 }
-/* Cell padding + horizontal row separators.
-   !important is required here: the clean-preview base rules
-   (.pfb-clean-preview .field--preview) set transparent borders at equal
-   specificity and would otherwise suppress the row lines. */
 .section--grid :deep(.field) {
 	padding: var(--pfb-cell-pad, 8px) !important;
 	border: none !important;
@@ -557,8 +547,6 @@ function remove_column(index) {
 .section--grid :deep(.field:last-child) {
 	border-bottom: none !important;
 }
-/* Hover/selection highlight uses outline, not border, so it draws a full box
-   (including the bottom edge) without fighting the row-separator borders. */
 .section--grid :deep(.field:hover),
 .section--grid :deep(.field--selected) {
 	outline: 1px dashed var(--gray-400);

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -155,7 +155,9 @@ let has_visible_fields = computed(() =>
 let section_inline_style = computed(() => {
 	const style = {};
 	if (props.section.background) style.backgroundColor = props.section.background;
-	if (props.section.padding) {
+	// In grid (table) mode the cells sit flush against the section border, so the
+	// section itself carries no padding — spacing comes from per-cell padding instead.
+	if (props.section.padding && !is_grid.value) {
 		const p = props.section.padding;
 		style.padding = `${p.top || 0}px ${p.right || 0}px ${p.bottom || 0}px ${p.left || 0}px`;
 	}
@@ -515,18 +517,31 @@ function remove_column(index) {
 	border: 1px solid var(--border-color) !important;
 	border-radius: var(--border-radius-md, 8px) !important;
 	overflow: hidden !important;
+	/* No outer padding: cells run flush to the border so dividers reach edge-to-edge */
+	padding: 0 !important;
+}
+/* Title becomes a full-width header row with its own cell padding */
+.section--grid .section-title-display {
+	padding: var(--pfb-cell-pad, 8px) !important;
+	margin: 0 !important;
+	border-bottom: 1px solid var(--border-color) !important;
 }
 .section--grid .section-columns {
-	padding: 0;
+	padding: 0 !important;
 }
 .section--grid .column {
 	padding: 0;
 }
+/* Full-height vertical divider between columns */
 .section--grid .column:not(:last-child) {
 	border-right: 1px solid var(--border-color);
 }
 .section--grid .column-divider {
 	display: none;
+}
+/* Rows sit flush like table rows — cell padding provides the spacing */
+.section--grid :deep(.drag-container) {
+	gap: 0 !important;
 }
 .section--grid :deep(.field:not(.field--preview)) {
 	padding: var(--pfb-cell-pad, 8px) !important;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -528,9 +528,15 @@ function remove_column(index) {
 .section--grid .column-divider {
 	display: none;
 }
-.section--grid :deep(.field) {
+.section--grid :deep(.field:not(.field--preview)) {
 	padding: var(--pfb-cell-pad, 8px) !important;
 	border: none !important;
+	border-bottom: 1px solid var(--border-color) !important;
+	border-radius: 0 !important;
+	background: transparent !important;
+}
+.section--grid :deep(.field--preview) {
+	padding: var(--pfb-cell-pad, 8px) !important;
 	border-bottom: 1px solid var(--border-color) !important;
 	border-radius: 0 !important;
 	background: transparent !important;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -145,6 +145,17 @@ let section_inline_style = computed(() => {
 		const p = props.section.padding;
 		style.padding = `${p.top || 0}px ${p.right || 0}px ${p.bottom || 0}px ${p.left || 0}px`;
 	}
+	if (props.section.border) {
+		const b = props.section.border;
+		const color = b.color || "#e5e7eb";
+		if (b.top) style.borderTop = `1px solid ${color}`;
+		if (b.right) style.borderRight = `1px solid ${color}`;
+		if (b.bottom) style.borderBottom = `1px solid ${color}`;
+		if (b.left) style.borderLeft = `1px solid ${color}`;
+	}
+	if (props.section.border_radius) {
+		style.borderRadius = `${props.section.border_radius}px`;
+	}
 	return style;
 });
 

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -67,7 +67,11 @@
 			<div
 				class="section-columns"
 				:style="
-					section.columns.length > 1 && section.gap ? { gap: section.gap + 'px' } : {}
+					is_grid
+						? { gap: '0' }
+						: section.columns.length > 1 && section.gap
+						? { gap: section.gap + 'px' }
+						: {}
 				"
 			>
 				<template v-for="(column, i) in section.columns" :key="i">
@@ -512,8 +516,17 @@ function remove_column(index) {
 	border-radius: var(--border-radius-md, 8px) !important;
 	overflow: hidden !important;
 }
+.section--grid .section-columns {
+	padding: 0;
+}
 .section--grid .column {
 	padding: 0;
+}
+.section--grid .column:not(:last-child) {
+	border-right: 1px solid var(--border-color);
+}
+.section--grid .column-divider {
+	display: none;
 }
 .section--grid :deep(.field) {
 	padding: var(--pfb-cell-pad, 8px) !important;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -158,9 +158,6 @@ let section_inline_style = computed(() => {
 	if (is_grid.value) {
 		const pad = props.section.cell_padding ?? 8;
 		style["--pfb-cell-pad"] = `${pad}px`;
-		style.borderRadius = "8px";
-		style.overflow = "hidden";
-		style.border = `1px solid var(--border-color)`;
 	}
 	return style;
 });
@@ -510,11 +507,13 @@ function remove_column(index) {
 }
 
 /* ── Table layout (field borders) ───────────────────────── */
+.section--grid {
+	border: 1px solid var(--border-color) !important;
+	border-radius: var(--border-radius-md, 8px) !important;
+	overflow: hidden !important;
+}
 .section--grid .column {
 	padding: 0;
-}
-.section--grid .column-divider {
-	display: none;
 }
 .section--grid :deep(.field) {
 	padding: var(--pfb-cell-pad, 8px) !important;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -527,7 +527,7 @@ function remove_column(index) {
 	border-bottom: 1px solid var(--border-color) !important;
 }
 .section--grid .section-columns {
-	padding: 0 !important;
+	padding: 0;
 }
 .section--grid .column {
 	padding: 0;
@@ -543,20 +543,28 @@ function remove_column(index) {
 .section--grid :deep(.drag-container) {
 	gap: 0 !important;
 }
-.section--grid :deep(.field:not(.field--preview)) {
+/* Cell padding + horizontal row separators.
+   !important is required here: the clean-preview base rules
+   (.pfb-clean-preview .field--preview) set transparent borders at equal
+   specificity and would otherwise suppress the row lines. */
+.section--grid :deep(.field) {
 	padding: var(--pfb-cell-pad, 8px) !important;
 	border: none !important;
 	border-bottom: 1px solid var(--border-color) !important;
 	border-radius: 0 !important;
 	background: transparent !important;
 }
-.section--grid :deep(.field--preview) {
-	padding: var(--pfb-cell-pad, 8px) !important;
-	border-bottom: 1px solid var(--border-color) !important;
-	border-radius: 0 !important;
-	background: transparent !important;
-}
 .section--grid :deep(.field:last-child) {
 	border-bottom: none !important;
+}
+/* Hover/selection highlight uses outline, not border, so it draws a full box
+   (including the bottom edge) without fighting the row-separator borders. */
+.section--grid :deep(.field:hover),
+.section--grid :deep(.field--selected) {
+	outline: 1px dashed var(--gray-400);
+	outline-offset: -1px;
+}
+.section--grid :deep(.field--selected) {
+	outline-style: solid;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -148,13 +148,6 @@ let section_inline_style = computed(() => {
 		const p = props.section.padding;
 		style.padding = `${p.top || 0}px ${p.right || 0}px ${p.bottom || 0}px ${p.left || 0}px`;
 	}
-	if (props.section.border?.on) {
-		const color = props.section.border.color || "#e5e7eb";
-		style.border = `1px solid ${color}`;
-	}
-	if (props.section.border_radius) {
-		style.borderRadius = `${props.section.border_radius}px`;
-	}
 	if (is_grid.value) {
 		const pad = props.section.cell_padding ?? 8;
 		style["--pfb-cell-pad"] = `${pad}px`;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -22,6 +22,7 @@
 			:class="{
 				'section--selected': is_selected,
 				'label-uppercase': section.label_case === 'uppercase',
+				'section--grid': is_grid,
 			}"
 			:style="section_inline_style"
 			@click.stop="select_section"
@@ -138,6 +139,8 @@ let is_section_visible = computed(() =>
 	evaluate_visible_if(props.section.visible_if, preview_doc.value)
 );
 
+let is_grid = computed(() => !!props.section.field_borders);
+
 let section_inline_style = computed(() => {
 	const style = {};
 	if (props.section.background) style.backgroundColor = props.section.background;
@@ -145,16 +148,16 @@ let section_inline_style = computed(() => {
 		const p = props.section.padding;
 		style.padding = `${p.top || 0}px ${p.right || 0}px ${p.bottom || 0}px ${p.left || 0}px`;
 	}
-	if (props.section.border) {
-		const b = props.section.border;
-		const color = b.color || "#e5e7eb";
-		if (b.top) style.borderTop = `1px solid ${color}`;
-		if (b.right) style.borderRight = `1px solid ${color}`;
-		if (b.bottom) style.borderBottom = `1px solid ${color}`;
-		if (b.left) style.borderLeft = `1px solid ${color}`;
+	if (props.section.border?.on) {
+		const color = props.section.border.color || "#e5e7eb";
+		style.border = `1px solid ${color}`;
 	}
 	if (props.section.border_radius) {
 		style.borderRadius = `${props.section.border_radius}px`;
+	}
+	if (is_grid.value) {
+		const pad = props.section.cell_padding ?? 8;
+		style["--pfb-cell-pad"] = `${pad}px`;
 	}
 	return style;
 });
@@ -501,5 +504,29 @@ function remove_column(index) {
 .print-format-section.label-uppercase :deep(.preview-table th) {
 	text-transform: uppercase;
 	letter-spacing: 0.03em;
+}
+
+/* ── Table layout (field borders) ───────────────────────── */
+.section--grid .column {
+	padding: 0;
+}
+.section--grid .drag-container {
+	display: contents;
+}
+.section--grid .section-columns {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+	gap: 0;
+}
+.section--grid .column-divider {
+	display: none;
+}
+.section--grid :deep(.field) {
+	padding: var(--pfb-cell-pad, 8px);
+	border: 1px solid var(--border-color);
+	margin: -1px 0 0 -1px;
+}
+.section--grid :deep(.field-preview-wrap) {
+	padding: 0;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -2,6 +2,7 @@
 	<div
 		class="print-format-section-container"
 		data-pfb-section
+		v-show="!preview_doc || has_visible_fields"
 		:class="{ 'section-container--condition-hidden': preview_doc && !is_section_visible }"
 	>
 		<!-- Top-left actions pill shown on hover in clean-preview (toolbar is hidden) -->
@@ -142,6 +143,10 @@ let is_section_visible = computed(() =>
 );
 
 let is_grid = computed(() => !!props.section.field_borders);
+
+let has_visible_fields = computed(() =>
+	props.section.columns.some((col) => col.fields.some((f) => !f.remove))
+);
 
 let section_inline_style = computed(() => {
 	const style = {};

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -185,9 +185,13 @@
 										class="pfb-col-drag"
 										v-html="frappe.utils.icon('drag', 'xs')"
 									></span>
-									<span class="pfb-col-label" :title="col.fieldname">{{
-										col.label || col.fieldname
-									}}</span>
+									<input
+										class="pfb-col-label-input"
+										type="text"
+										v-model="col.label"
+										:placeholder="col.fieldname"
+										:title="col.fieldname"
+									/>
 									<input
 										class="pfb-col-width-input"
 										type="number"
@@ -1392,12 +1396,24 @@ function set_padding(side, value) {
 	color: var(--gray-500);
 }
 
-.pfb-col-label {
+.pfb-col-label-input {
 	flex: 1;
+	min-width: 0;
 	font-size: var(--text-sm);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	border: 1px solid transparent;
+	border-radius: var(--radius);
+	background: transparent;
+	padding: 1px 4px;
+	outline: none;
+}
+
+.pfb-col-label-input:hover {
+	border-color: var(--gray-300);
+}
+
+.pfb-col-label-input:focus {
+	border-color: var(--gray-500);
+	background: var(--fg-color);
 }
 
 .pfb-col-width-input {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -133,7 +133,7 @@
 							<span class="pfb-insp-label">{{ __("Header") }}</span>
 							<div class="pfb-seg">
 								<button
-									:class="{ active: table_header !== 'plain' }"
+									:class="{ active: table_header === 'styled' }"
 									@click="selected_field.table_header = 'styled'"
 								>
 									{{ __("Styled") }}
@@ -143,6 +143,12 @@
 									@click="selected_field.table_header = 'plain'"
 								>
 									{{ __("Plain") }}
+								</button>
+								<button
+									:class="{ active: table_header === 'none' }"
+									@click="selected_field.table_header = 'none'"
+								>
+									{{ __("None") }}
 								</button>
 							</div>
 						</div>

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -605,36 +605,41 @@
 						></span>
 					</div>
 					<div v-show="open.s_border" class="pfb-insp-section-body">
-						<!-- Side toggles -->
+						<!-- Border on/off -->
 						<div class="pfb-insp-row">
-							<span class="pfb-insp-label">{{ __("Sides") }}</span>
+							<span class="pfb-insp-label">{{ __("Show") }}</span>
 							<div class="pfb-seg">
 								<button
-									v-for="side in ['top', 'right', 'bottom', 'left']"
-									:key="side"
-									:class="{ active: section_border[side] }"
-									@click="toggle_border_side(side)"
-									:title="__(side[0].toUpperCase() + side.slice(1))"
+									:class="{ active: !section_border_on }"
+									@click="set_section_border(false)"
 								>
-									{{ side[0].toUpperCase() }}
+									{{ __("None") }}
+								</button>
+								<button
+									:class="{ active: section_border_on }"
+									@click="set_section_border(true)"
+								>
+									{{ __("All sides") }}
 								</button>
 							</div>
 						</div>
-						<!-- Color -->
-						<div class="pfb-insp-row">
-							<span class="pfb-insp-label">{{ __("Color") }}</span>
-							<div class="pfb-color-swatches">
-								<button
-									v-for="swatch in border_swatches"
-									:key="swatch.value"
-									class="pfb-swatch"
-									:class="{ active: section_border_color === swatch.value }"
-									:title="swatch.label"
-									:style="swatch.style"
-									@click="set_border_color(swatch.value)"
-								></button>
+						<!-- Color (only when border is on) -->
+						<template v-if="section_border_on">
+							<div class="pfb-insp-row">
+								<span class="pfb-insp-label">{{ __("Color") }}</span>
+								<div class="pfb-color-swatches">
+									<button
+										v-for="swatch in border_swatches"
+										:key="swatch.value"
+										class="pfb-swatch"
+										:class="{ active: section_border_color === swatch.value }"
+										:title="swatch.label"
+										:style="swatch.style"
+										@click="set_border_color(swatch.value)"
+									></button>
+								</div>
 							</div>
-						</div>
+						</template>
 						<!-- Radius -->
 						<div class="pfb-insp-row">
 							<span class="pfb-insp-label">{{ __("Radius") }}</span>
@@ -650,6 +655,57 @@
 								/>
 								<span class="pfb-stepper-unit">px</span>
 								<button @click="adjust_border_radius(1)">+</button>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<!-- LAYOUT -->
+				<div class="pfb-insp-section">
+					<div class="pfb-insp-section-head" @click="toggle('s_layout')">
+						<span class="pfb-insp-section-label">{{ __("Layout") }}</span>
+						<span
+							class="pfb-insp-chevron"
+							:class="{ collapsed: !open.s_layout }"
+							v-html="frappe.utils.icon('chevron-down', 'xs')"
+						></span>
+					</div>
+					<div v-show="open.s_layout" class="pfb-insp-section-body">
+						<!-- Layout mode -->
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Mode") }}</span>
+							<div class="pfb-seg">
+								<button
+									:class="{ active: !section_field_borders }"
+									@click="toggle_field_borders(false)"
+								>
+									{{ __("Normal") }}
+								</button>
+								<button
+									:class="{ active: section_field_borders }"
+									@click="toggle_field_borders(true)"
+								>
+									{{ __("Table") }}
+								</button>
+							</div>
+						</div>
+						<!-- Cell padding (only in table layout) -->
+						<div v-if="section_field_borders" class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Cell padding") }}</span>
+							<div class="pfb-stepper">
+								<button @click="adjust_section_cell_padding(-1)">−</button>
+								<input
+									class="pfb-stepper-input"
+									type="number"
+									min="0"
+									:value="section_cell_padding"
+									@change="
+										(e) =>
+											set_section_cell_padding(parseInt(e.target.value) || 0)
+									"
+								/>
+								<span class="pfb-stepper-unit">px</span>
+								<button @click="adjust_section_cell_padding(1)">+</button>
 							</div>
 						</div>
 					</div>
@@ -723,6 +779,7 @@ const open = ref({
 	s_bg: true,
 	s_padding: true,
 	s_border: false,
+	s_layout: false,
 	s_visibility: false,
 	t_table: true,
 	t_columns: true,
@@ -1054,12 +1111,11 @@ function set_padding(side, value) {
 	selected_section.value.padding[side] = Math.max(0, value);
 }
 
-let section_border = computed(
-	() =>
-		selected_section.value?.border || { top: false, right: false, bottom: false, left: false }
-);
+let section_border_on = computed(() => !!selected_section.value?.border?.on);
 let section_border_color = computed(() => selected_section.value?.border?.color ?? "#e5e7eb");
 let section_border_radius = computed(() => selected_section.value?.border_radius ?? null);
+let section_field_borders = computed(() => !!selected_section.value?.field_borders);
+let section_cell_padding = computed(() => selected_section.value?.cell_padding ?? 8);
 
 const border_swatches = [
 	{ value: "#e5e7eb", label: __("Gray"), style: "background:#e5e7eb" },
@@ -1068,22 +1124,16 @@ const border_swatches = [
 	{ value: "#000000", label: __("Black"), style: "background:#000000" },
 ];
 
-function toggle_border_side(side) {
+function set_section_border(on) {
 	if (!selected_section.value.border) {
-		selected_section.value.border = {
-			top: false,
-			right: false,
-			bottom: false,
-			left: false,
-			color: "#e5e7eb",
-		};
+		selected_section.value.border = { color: "#e5e7eb" };
 	}
-	selected_section.value.border[side] = !selected_section.value.border[side];
+	selected_section.value.border.on = on;
 }
 
 function set_border_color(color) {
 	if (!selected_section.value.border) {
-		selected_section.value.border = { top: false, right: false, bottom: false, left: false };
+		selected_section.value.border = { on: true };
 	}
 	selected_section.value.border.color = color;
 }
@@ -1100,6 +1150,23 @@ function set_border_radius(value) {
 	} else {
 		selected_section.value.border_radius = Math.max(0, v);
 	}
+}
+
+function toggle_field_borders(on) {
+	if (on) {
+		selected_section.value.field_borders = true;
+	} else {
+		delete selected_section.value.field_borders;
+	}
+}
+
+function adjust_section_cell_padding(delta) {
+	const current = selected_section.value?.cell_padding ?? 8;
+	selected_section.value.cell_padding = Math.max(0, current + delta);
+}
+
+function set_section_cell_padding(value) {
+	selected_section.value.cell_padding = Math.max(0, value);
 }
 </script>
 

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -594,6 +594,67 @@
 					</div>
 				</div>
 
+				<!-- BORDER -->
+				<div class="pfb-insp-section">
+					<div class="pfb-insp-section-head" @click="toggle('s_border')">
+						<span class="pfb-insp-section-label">{{ __("Border") }}</span>
+						<span
+							class="pfb-insp-chevron"
+							:class="{ collapsed: !open.s_border }"
+							v-html="frappe.utils.icon('chevron-down', 'xs')"
+						></span>
+					</div>
+					<div v-show="open.s_border" class="pfb-insp-section-body">
+						<!-- Side toggles -->
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Sides") }}</span>
+							<div class="pfb-seg">
+								<button
+									v-for="side in ['top', 'right', 'bottom', 'left']"
+									:key="side"
+									:class="{ active: section_border[side] }"
+									@click="toggle_border_side(side)"
+									:title="__(side[0].toUpperCase() + side.slice(1))"
+								>
+									{{ side[0].toUpperCase() }}
+								</button>
+							</div>
+						</div>
+						<!-- Color -->
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Color") }}</span>
+							<div class="pfb-color-swatches">
+								<button
+									v-for="swatch in border_swatches"
+									:key="swatch.value"
+									class="pfb-swatch"
+									:class="{ active: section_border_color === swatch.value }"
+									:title="swatch.label"
+									:style="swatch.style"
+									@click="set_border_color(swatch.value)"
+								></button>
+							</div>
+						</div>
+						<!-- Radius -->
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Radius") }}</span>
+							<div class="pfb-stepper">
+								<button @click="adjust_border_radius(-1)">−</button>
+								<input
+									class="pfb-stepper-input"
+									type="number"
+									min="0"
+									:value="section_border_radius ?? ''"
+									:placeholder="__('none')"
+									@change="(e) => set_border_radius(e.target.value)"
+								/>
+								<span class="pfb-stepper-unit">px</span>
+								<button @click="adjust_border_radius(1)">+</button>
+							</div>
+						</div>
+					</div>
+				</div>
+
 				<!-- VISIBILITY -->
 				<div class="pfb-insp-section">
 					<div class="pfb-insp-section-head" @click="toggle('s_visibility')">
@@ -661,6 +722,7 @@ const open = ref({
 	s_section: true,
 	s_bg: true,
 	s_padding: true,
+	s_border: false,
 	s_visibility: false,
 	t_table: true,
 	t_columns: true,
@@ -990,6 +1052,54 @@ function set_padding(side, value) {
 		selected_section.value.padding = { top: 0, right: 0, bottom: 0, left: 0 };
 	}
 	selected_section.value.padding[side] = Math.max(0, value);
+}
+
+let section_border = computed(
+	() =>
+		selected_section.value?.border || { top: false, right: false, bottom: false, left: false }
+);
+let section_border_color = computed(() => selected_section.value?.border?.color ?? "#e5e7eb");
+let section_border_radius = computed(() => selected_section.value?.border_radius ?? null);
+
+const border_swatches = [
+	{ value: "#e5e7eb", label: __("Gray"), style: "background:#e5e7eb" },
+	{ value: "#d1d5db", label: __("Dark Gray"), style: "background:#d1d5db" },
+	{ value: "#93c5fd", label: __("Blue"), style: "background:#93c5fd" },
+	{ value: "#000000", label: __("Black"), style: "background:#000000" },
+];
+
+function toggle_border_side(side) {
+	if (!selected_section.value.border) {
+		selected_section.value.border = {
+			top: false,
+			right: false,
+			bottom: false,
+			left: false,
+			color: "#e5e7eb",
+		};
+	}
+	selected_section.value.border[side] = !selected_section.value.border[side];
+}
+
+function set_border_color(color) {
+	if (!selected_section.value.border) {
+		selected_section.value.border = { top: false, right: false, bottom: false, left: false };
+	}
+	selected_section.value.border.color = color;
+}
+
+function adjust_border_radius(delta) {
+	const current = selected_section.value?.border_radius ?? 0;
+	selected_section.value.border_radius = Math.max(0, current + delta);
+}
+
+function set_border_radius(value) {
+	const v = parseInt(value);
+	if (isNaN(v) || value === "") {
+		delete selected_section.value.border_radius;
+	} else {
+		selected_section.value.border_radius = Math.max(0, v);
+	}
 }
 </script>
 

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -623,8 +623,8 @@
 								</button>
 							</div>
 						</div>
-						<!-- Cell padding (only in table layout) -->
-						<div v-if="section_field_borders" class="pfb-insp-row">
+						<!-- Cell padding -->
+						<div class="pfb-insp-row">
 							<span class="pfb-insp-label">{{ __("Cell padding") }}</span>
 							<div class="pfb-stepper">
 								<button @click="adjust_section_cell_padding(-1)">−</button>

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -169,6 +169,23 @@
 								</button>
 							</div>
 						</div>
+						<!-- Corner radius -->
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Radius") }}</span>
+							<div class="pfb-stepper">
+								<button @click="adjust_table_radius(-1)">−</button>
+								<input
+									class="pfb-stepper-input"
+									type="number"
+									min="0"
+									:value="table_radius ?? ''"
+									:placeholder="__('none')"
+									@change="(e) => set_table_radius(e.target.value)"
+								/>
+								<span class="pfb-stepper-unit">px</span>
+								<button @click="adjust_table_radius(1)">+</button>
+							</div>
+						</div>
 					</div>
 				</div>
 
@@ -833,6 +850,7 @@ let table_style = computed(() => selected_field.value?.table_style ?? "lined");
 let table_bordered = computed(() => selected_field.value?.table_bordered ?? true);
 let table_header = computed(() => selected_field.value?.table_header ?? "styled");
 let table_cell_padding = computed(() => selected_field.value?.table_cell_padding ?? null);
+let table_radius = computed(() => selected_field.value?.table_radius ?? null);
 
 function adjust_cell_padding(delta) {
 	const current = selected_field.value?.table_cell_padding ?? 7;
@@ -845,6 +863,20 @@ function set_cell_padding(value) {
 		delete selected_field.value.table_cell_padding;
 	} else {
 		selected_field.value.table_cell_padding = Math.max(0, v);
+	}
+}
+
+function adjust_table_radius(delta) {
+	const current = selected_field.value?.table_radius ?? 0;
+	selected_field.value.table_radius = Math.max(0, current + delta);
+}
+
+function set_table_radius(value) {
+	const v = parseInt(value);
+	if (isNaN(v) || value === "") {
+		delete selected_field.value.table_radius;
+	} else {
+		selected_field.value.table_radius = Math.max(0, v);
 	}
 }
 

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -594,72 +594,6 @@
 					</div>
 				</div>
 
-				<!-- BORDER -->
-				<div class="pfb-insp-section">
-					<div class="pfb-insp-section-head" @click="toggle('s_border')">
-						<span class="pfb-insp-section-label">{{ __("Border") }}</span>
-						<span
-							class="pfb-insp-chevron"
-							:class="{ collapsed: !open.s_border }"
-							v-html="frappe.utils.icon('chevron-down', 'xs')"
-						></span>
-					</div>
-					<div v-show="open.s_border" class="pfb-insp-section-body">
-						<!-- Border on/off -->
-						<div class="pfb-insp-row">
-							<span class="pfb-insp-label">{{ __("Show") }}</span>
-							<div class="pfb-seg">
-								<button
-									:class="{ active: !section_border_on }"
-									@click="set_section_border(false)"
-								>
-									{{ __("None") }}
-								</button>
-								<button
-									:class="{ active: section_border_on }"
-									@click="set_section_border(true)"
-								>
-									{{ __("All sides") }}
-								</button>
-							</div>
-						</div>
-						<!-- Color (only when border is on) -->
-						<template v-if="section_border_on">
-							<div class="pfb-insp-row">
-								<span class="pfb-insp-label">{{ __("Color") }}</span>
-								<div class="pfb-color-swatches">
-									<button
-										v-for="swatch in border_swatches"
-										:key="swatch.value"
-										class="pfb-swatch"
-										:class="{ active: section_border_color === swatch.value }"
-										:title="swatch.label"
-										:style="swatch.style"
-										@click="set_border_color(swatch.value)"
-									></button>
-								</div>
-							</div>
-						</template>
-						<!-- Radius -->
-						<div class="pfb-insp-row">
-							<span class="pfb-insp-label">{{ __("Radius") }}</span>
-							<div class="pfb-stepper">
-								<button @click="adjust_border_radius(-1)">−</button>
-								<input
-									class="pfb-stepper-input"
-									type="number"
-									min="0"
-									:value="section_border_radius ?? ''"
-									:placeholder="__('none')"
-									@change="(e) => set_border_radius(e.target.value)"
-								/>
-								<span class="pfb-stepper-unit">px</span>
-								<button @click="adjust_border_radius(1)">+</button>
-							</div>
-						</div>
-					</div>
-				</div>
-
 				<!-- LAYOUT -->
 				<div class="pfb-insp-section">
 					<div class="pfb-insp-section-head" @click="toggle('s_layout')">
@@ -778,7 +712,6 @@ const open = ref({
 	s_section: true,
 	s_bg: true,
 	s_padding: true,
-	s_border: false,
 	s_layout: false,
 	s_visibility: false,
 	t_table: true,
@@ -1111,46 +1044,8 @@ function set_padding(side, value) {
 	selected_section.value.padding[side] = Math.max(0, value);
 }
 
-let section_border_on = computed(() => !!selected_section.value?.border?.on);
-let section_border_color = computed(() => selected_section.value?.border?.color ?? "#e5e7eb");
-let section_border_radius = computed(() => selected_section.value?.border_radius ?? null);
 let section_field_borders = computed(() => !!selected_section.value?.field_borders);
 let section_cell_padding = computed(() => selected_section.value?.cell_padding ?? 8);
-
-const border_swatches = [
-	{ value: "#e5e7eb", label: __("Gray"), style: "background:#e5e7eb" },
-	{ value: "#d1d5db", label: __("Dark Gray"), style: "background:#d1d5db" },
-	{ value: "#93c5fd", label: __("Blue"), style: "background:#93c5fd" },
-	{ value: "#000000", label: __("Black"), style: "background:#000000" },
-];
-
-function set_section_border(on) {
-	if (!selected_section.value.border) {
-		selected_section.value.border = { color: "#e5e7eb" };
-	}
-	selected_section.value.border.on = on;
-}
-
-function set_border_color(color) {
-	if (!selected_section.value.border) {
-		selected_section.value.border = { on: true };
-	}
-	selected_section.value.border.color = color;
-}
-
-function adjust_border_radius(delta) {
-	const current = selected_section.value?.border_radius ?? 0;
-	selected_section.value.border_radius = Math.max(0, current + delta);
-}
-
-function set_border_radius(value) {
-	const v = parseInt(value);
-	if (isNaN(v) || value === "") {
-		delete selected_section.value.border_radius;
-	} else {
-		selected_section.value.border_radius = Math.max(0, v);
-	}
-}
 
 function toggle_field_borders(on) {
 	if (on) {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -128,6 +128,23 @@
 								</button>
 							</div>
 						</div>
+						<!-- Cell padding -->
+						<div class="pfb-insp-row">
+							<span class="pfb-insp-label">{{ __("Cell padding") }}</span>
+							<div class="pfb-stepper">
+								<button @click="adjust_cell_padding(-1)">−</button>
+								<input
+									class="pfb-stepper-input"
+									type="number"
+									min="0"
+									:value="table_cell_padding ?? ''"
+									:placeholder="__('auto')"
+									@change="(e) => set_cell_padding(e.target.value)"
+								/>
+								<span class="pfb-stepper-unit">px</span>
+								<button @click="adjust_cell_padding(1)">+</button>
+							</div>
+						</div>
 						<!-- Header -->
 						<div class="pfb-insp-row">
 							<span class="pfb-insp-label">{{ __("Header") }}</span>
@@ -815,6 +832,21 @@ function edit_html_field() {
 let table_style = computed(() => selected_field.value?.table_style ?? "lined");
 let table_bordered = computed(() => selected_field.value?.table_bordered ?? true);
 let table_header = computed(() => selected_field.value?.table_header ?? "styled");
+let table_cell_padding = computed(() => selected_field.value?.table_cell_padding ?? null);
+
+function adjust_cell_padding(delta) {
+	const current = selected_field.value?.table_cell_padding ?? 7;
+	selected_field.value.table_cell_padding = Math.max(0, current + delta);
+}
+
+function set_cell_padding(value) {
+	const v = parseInt(value);
+	if (isNaN(v) || value === "") {
+		delete selected_field.value.table_cell_padding;
+	} else {
+		selected_field.value.table_cell_padding = Math.max(0, v);
+	}
+}
 
 const table_style_opts = [
 	{ value: "lined", label: __("Lined") },

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -114,6 +114,7 @@ export function getStore(print_format_name) {
 								"table_bordered",
 								"table_header",
 								"table_cell_padding",
+								"table_radius",
 								"html",
 								"field_template",
 								"show_label",

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -113,6 +113,7 @@ export function getStore(print_format_name) {
 								"table_style",
 								"table_bordered",
 								"table_header",
+								"table_cell_padding",
 								"html",
 								"field_template",
 								"show_label",

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -5,7 +5,9 @@
 {% set _no_header = df.table_header == "none" %}
 {%- set _cell_pad = df.table_cell_padding if df.table_cell_padding is defined and df.table_cell_padding is not none else none -%}
 {%- set _cell_style = ('padding:' + _cell_pad|string + 'px') if _cell_pad is not none else '' -%}
-<div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}" {{ field_attributes(df) }}>
+{%- set _radius = df.table_radius if df.table_radius is defined and df.table_radius is not none else none -%}
+{%- set _radius_style = ('border-radius:' + _radius|string + 'px;overflow:hidden') if _radius is not none else '' -%}
+<div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}"{% if _radius_style %} style="{{ _radius_style }}"{% endif %} {{ field_attributes(df) }}>
 	<div class="label">
 		{{ _(df.label) }}
 	</div>

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -4,20 +4,20 @@
 {% set _plain_header = df.table_header == "plain" %}
 {% set _no_header = df.table_header == "none" %}
 {%- set _cell_pad = df.table_cell_padding if df.table_cell_padding is defined and df.table_cell_padding is not none else none -%}
-{%- set _cell_style = ('padding:' + _cell_pad|int|string + 'px') if _cell_pad is not none else '' -%}
+{%- set _cell_style = ('padding:' + _cell_pad|string + 'px') if _cell_pad is not none else '' -%}
 {%- set _radius = df.table_radius if df.table_radius is defined and df.table_radius is not none else none -%}
-{%- set _radius_style = ('border-radius:' + _radius|int|string + 'px;overflow:hidden') if _radius is not none else '' -%}
+{%- set _radius_style = ('border-radius:' + _radius|string + 'px;overflow:hidden') if _radius is not none else '' -%}
 <div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}" {{ field_attributes(df) }}>
 	<div class="label">
 		{{ _(df.label) }}
 	</div>
-	<table class="table{% if _bordered %} table-bordered{% endif %}"{% if _radius_style %} style="{{ _radius_style }}"{% endif %}>
+	<table class="table{% if _bordered %} table-bordered{% endif %}"{% if _radius_style %} style="{{ _radius_style|e }}"{% endif %}>
 		{% set columns = df.table_columns %}
 		{%- if not _no_header -%}
 		<thead>
 			<tr class="table-row">
 				{% for column in columns %}
-				<th class="column-header" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style }}"{% endif %} {{ field_attributes(column) }}>
+				<th class="column-header" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style|e }}"{% endif %} {{ field_attributes(column) }}>
 					{{ _(column.label or column.fieldname) }}
 				</th>
 				{% endfor %}
@@ -28,7 +28,7 @@
 			{% for row in doc.get(df.fieldname) %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}">
 				{% for column in columns %}
-				<td class="column-value" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style }}"{% endif %} {{ field_attributes(column) }}>
+				<td class="column-value" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style|e }}"{% endif %} {{ field_attributes(column) }}>
 					{# Image cells: validated URL + server-side thumbnail + escaped src. #}
 					{%- set _src = (row.get(column.options) if column.fieldtype == "Image" else row.get(column.fieldname)) or "" -%}
 					{%- set _src = _src|string|trim -%}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -4,9 +4,9 @@
 {% set _plain_header = df.table_header == "plain" %}
 {% set _no_header = df.table_header == "none" %}
 {%- set _cell_pad = df.table_cell_padding if df.table_cell_padding is defined and df.table_cell_padding is not none else none -%}
-{%- set _cell_style = ('padding:' + _cell_pad|string + 'px') if _cell_pad is not none else '' -%}
+{%- set _cell_style = ('padding:' + _cell_pad|int|string + 'px') if _cell_pad is not none else '' -%}
 {%- set _radius = df.table_radius if df.table_radius is defined and df.table_radius is not none else none -%}
-{%- set _radius_style = ('border-radius:' + _radius|string + 'px;overflow:hidden') if _radius is not none else '' -%}
+{%- set _radius_style = ('border-radius:' + _radius|int|string + 'px;overflow:hidden') if _radius is not none else '' -%}
 <div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}" {{ field_attributes(df) }}>
 	<div class="label">
 		{{ _(df.label) }}
@@ -18,7 +18,7 @@
 			<tr class="table-row">
 				{% for column in columns %}
 				<th class="column-header" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style }}"{% endif %} {{ field_attributes(column) }}>
-					{{ _(column.label) }}
+					{{ _(column.label or column.fieldname) }}
 				</th>
 				{% endfor %}
 			</tr>

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -2,12 +2,14 @@
 {% set _style = df.table_style or "lined" %}
 {% set _bordered = df.table_bordered != False %}
 {% set _plain_header = df.table_header == "plain" %}
+{% set _no_header = df.table_header == "none" %}
 <div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}" {{ field_attributes(df) }}>
 	<div class="label">
 		{{ _(df.label) }}
 	</div>
 	<table class="table{% if _bordered %} table-bordered{% endif %}">
 		{% set columns = df.table_columns %}
+		{%- if not _no_header -%}
 		<thead>
 			<tr class="table-row">
 				{% for column in columns %}
@@ -17,6 +19,7 @@
 				{% endfor %}
 			</tr>
 		</thead>
+		{%- endif -%}
 		<tbody>
 			{% for row in doc.get(df.fieldname) %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}">

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -3,6 +3,8 @@
 {% set _bordered = df.table_bordered != False %}
 {% set _plain_header = df.table_header == "plain" %}
 {% set _no_header = df.table_header == "none" %}
+{%- set _cell_pad = df.table_cell_padding if df.table_cell_padding is defined and df.table_cell_padding is not none else none -%}
+{%- set _cell_style = ('padding:' + _cell_pad|string + 'px') if _cell_pad is not none else '' -%}
 <div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}" {{ field_attributes(df) }}>
 	<div class="label">
 		{{ _(df.label) }}
@@ -13,7 +15,7 @@
 		<thead>
 			<tr class="table-row">
 				{% for column in columns %}
-				<th class="column-header" width="{{ column.width }}%" {{ field_attributes(column) }}>
+				<th class="column-header" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style }}"{% endif %} {{ field_attributes(column) }}>
 					{{ _(column.label) }}
 				</th>
 				{% endfor %}
@@ -24,7 +26,7 @@
 			{% for row in doc.get(df.fieldname) %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}">
 				{% for column in columns %}
-				<td class="column-value" width="{{ column.width }}%" {{ field_attributes(column) }}>
+				<td class="column-value" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style }}"{% endif %} {{ field_attributes(column) }}>
 					{# Image cells: validated URL + server-side thumbnail + escaped src. #}
 					{%- set _src = (row.get(column.options) if column.fieldtype == "Image" else row.get(column.fieldname)) or "" -%}
 					{%- set _src = _src|string|trim -%}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -7,11 +7,11 @@
 {%- set _cell_style = ('padding:' + _cell_pad|string + 'px') if _cell_pad is not none else '' -%}
 {%- set _radius = df.table_radius if df.table_radius is defined and df.table_radius is not none else none -%}
 {%- set _radius_style = ('border-radius:' + _radius|string + 'px;overflow:hidden') if _radius is not none else '' -%}
-<div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}"{% if _radius_style %} style="{{ _radius_style }}"{% endif %} {{ field_attributes(df) }}>
+<div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}" {{ field_attributes(df) }}>
 	<div class="label">
 		{{ _(df.label) }}
 	</div>
-	<table class="table{% if _bordered %} table-bordered{% endif %}">
+	<table class="table{% if _bordered %} table-bordered{% endif %}"{% if _radius_style %} style="{{ _radius_style }}"{% endif %}>
 		{% set columns = df.table_columns %}
 		{%- if not _no_header -%}
 		<thead>

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -355,7 +355,7 @@ header img {
 /* ── Table layout (field-borders mode) ───────────────────── */
 .section--grid {
 	border: 1px solid #e5e7eb;
-	border-radius: 8px;
+	border-radius: var(--border-radius-md, 8px);
 	overflow: hidden;
 }
 .section--grid .col {

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -357,16 +357,32 @@ header img {
 	border: 1px solid #e5e7eb;
 	border-radius: var(--border-radius-md, 8px);
 	overflow: hidden;
+	/* Cells run flush to the border so dividers reach edge-to-edge */
+	padding: 0;
+}
+/* Section title becomes a full-width header row */
+.section--grid .section-label {
+	padding: var(--pfb-cell-pad, 8px);
+	margin: 0;
+	border-bottom: 1px solid #e5e7eb;
+}
+.section--grid .section-columns {
+	padding: 0;
 }
 .section--grid .col {
 	padding: 0;
 }
+/* Full-height vertical divider between columns */
 .section--grid .col:not(:last-child) {
 	border-right: 1px solid #e5e7eb;
 }
 .section--grid .field {
 	padding: var(--pfb-cell-pad, 8px);
 	border-bottom: 1px solid #e5e7eb;
+}
+/* Rows sit flush like table rows */
+.section--grid .field + .field {
+	margin-top: 0;
 }
 .section--grid .field:last-child {
 	border-bottom: none;

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -357,10 +357,8 @@ header img {
 	border: 1px solid #e5e7eb;
 	border-radius: var(--border-radius-md, 8px);
 	overflow: hidden;
-	/* Cells run flush to the border so dividers reach edge-to-edge */
 	padding: 0;
 }
-/* Section title becomes a full-width header row */
 .section--grid .section-label {
 	padding: var(--pfb-cell-pad, 8px);
 	margin: 0;
@@ -368,14 +366,12 @@ header img {
 }
 .section--grid .section-columns {
 	padding: 0;
-	/* Cancel Bootstrap .row's negative gutters so cells stay inside the border */
 	margin-left: 0;
 	margin-right: 0;
 }
 .section--grid .col {
 	padding: 0;
 }
-/* Full-height vertical divider between columns */
 .section--grid .col:not(:last-child) {
 	border-right: 1px solid #e5e7eb;
 }
@@ -383,7 +379,6 @@ header img {
 	padding: var(--pfb-cell-pad, 8px);
 	border-bottom: 1px solid #e5e7eb;
 }
-/* Rows sit flush like table rows */
 .section--grid .field + .field {
 	margin-top: 0;
 }

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -353,16 +353,15 @@ header img {
 }
 
 /* ── Table layout (field-borders mode) ───────────────────── */
-.section--grid .section-columns {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
-	gap: 0;
-}
 .section--grid .col {
+	border: 1px solid #e5e7eb;
 	padding: 0;
+	margin-left: -1px;
 }
 .section--grid .field {
 	padding: var(--pfb-cell-pad, 8px);
-	border: 1px solid #e5e7eb;
-	margin: -1px 0 0 -1px;
+	border-bottom: 1px solid #e5e7eb;
+}
+.section--grid .field:last-child {
+	border-bottom: none;
 }

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -353,10 +353,13 @@ header img {
 }
 
 /* ── Table layout (field-borders mode) ───────────────────── */
-.section--grid .col {
+.section--grid {
 	border: 1px solid #e5e7eb;
+	border-radius: 8px;
+	overflow: hidden;
+}
+.section--grid .col {
 	padding: 0;
-	margin-left: -1px;
 }
 .section--grid .field {
 	padding: var(--pfb-cell-pad, 8px);

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -361,6 +361,9 @@ header img {
 .section--grid .col {
 	padding: 0;
 }
+.section--grid .col:not(:last-child) {
+	border-right: 1px solid #e5e7eb;
+}
 .section--grid .field {
 	padding: var(--pfb-cell-pad, 8px);
 	border-bottom: 1px solid #e5e7eb;

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -368,6 +368,9 @@ header img {
 }
 .section--grid .section-columns {
 	padding: 0;
+	/* Cancel Bootstrap .row's negative gutters so cells stay inside the border */
+	margin-left: 0;
+	margin-right: 0;
 }
 .section--grid .col {
 	padding: 0;

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -351,3 +351,18 @@ header img {
 	text-transform: uppercase;
 	letter-spacing: 0.03em;
 }
+
+/* ── Table layout (field-borders mode) ───────────────────── */
+.section--grid .section-columns {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+	gap: 0;
+}
+.section--grid .col {
+	padding: 0;
+}
+.section--grid .field {
+	padding: var(--pfb-cell-pad, 8px);
+	border: 1px solid #e5e7eb;
+	margin: -1px 0 0 -1px;
+}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -63,7 +63,7 @@
 	{%- if section.background -%}
 		{%- set ns3.section_style = ns3.section_style + 'background:' + section.background + ';' -%}
 	{%- endif -%}
-	{%- if section.padding -%}
+	{%- if section.padding and not section.field_borders -%}
 		{%- set p = section.padding -%}
 		{%- set ns3.section_style = ns3.section_style + 'padding:' + (p.top or 0)|string + 'px ' + (p.right or 0)|string + 'px ' + (p.bottom or 0)|string + 'px ' + (p.left or 0)|string + 'px;' -%}
 	{%- endif -%}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -31,7 +31,7 @@
 	{%- set ns_h = namespace(has_fields=false) -%}
 	{%- for col in layout.header.columns -%}{%- for df in col.get('fields', []) -%}{%- set ns_h.has_fields = true -%}{%- endfor -%}{%- endfor -%}
 	{%- if ns_h.has_fields -%}
-	{%- set col_gap = (layout.header.gap if layout.header.gap is defined and layout.header.gap != None else 20)|string + 'px' -%}
+	{%- set col_gap = (layout.header.gap if layout.header.gap is defined and layout.header.gap != None else 20)|int|string + 'px' -%}
 	<div class="section document-header-content {{ 'label-uppercase' if layout.header.label_case == 'uppercase' else '' }}">
 	<div class="section-columns row" style="gap:{{ col_gap }}">
 	{%- for column in layout.header.columns %}
@@ -58,20 +58,23 @@
 		{%- endfor -%}
 	{%- endfor -%}
 	{%- if not section.label or ns.has_content -%}
-	{#- Build inline style for section background + padding -#}
+	{#- Build inline style for section background + padding.
+	    Numeric values are coerced with |int and the background colour is rejected if
+	    it contains characters that could break out of the CSS value; the assembled
+	    string is escaped at the render site to prevent attribute/HTML injection. -#}
 	{%- set ns3 = namespace(section_style='') -%}
-	{%- if section.background -%}
+	{%- if section.background and not (';' in section.background or '<' in section.background or '>' in section.background or '"' in section.background) -%}
 		{%- set ns3.section_style = ns3.section_style + 'background:' + section.background + ';' -%}
 	{%- endif -%}
 	{%- if section.padding and not section.field_borders -%}
 		{%- set p = section.padding -%}
-		{%- set ns3.section_style = ns3.section_style + 'padding:' + (p.top or 0)|string + 'px ' + (p.right or 0)|string + 'px ' + (p.bottom or 0)|string + 'px ' + (p.left or 0)|string + 'px;' -%}
+		{%- set ns3.section_style = ns3.section_style + 'padding:' + (p.top or 0)|int|string + 'px ' + (p.right or 0)|int|string + 'px ' + (p.bottom or 0)|int|string + 'px ' + (p.left or 0)|int|string + 'px;' -%}
 	{%- endif -%}
 	{%- if section.field_borders -%}
 		{%- set _cp = (section.cell_padding if section.cell_padding is defined and section.cell_padding is not none else 8) -%}
-		{%- set ns3.section_style = ns3.section_style + '--pfb-cell-pad:' + _cp|string + 'px;' -%}
+		{%- set ns3.section_style = ns3.section_style + '--pfb-cell-pad:' + _cp|int|string + 'px;' -%}
 	{%- endif -%}
-	<div class="section {{ resolve_class({'page-break': section.page_break}) }} {{ 'label-uppercase' if section.label_case == 'uppercase' else '' }}{{ ' section--grid' if section.field_borders else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style }}"{% endif %}>
+	<div class="section {{ resolve_class({'page-break': section.page_break}) }} {{ 'label-uppercase' if section.label_case == 'uppercase' else '' }}{{ ' section--grid' if section.field_borders else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style|e }}"{% endif %}>
 		{% if section.label and section.show_label != 'hide' %}
 		<div class="section-label">{{ _(section.label) }}</div>
 		{% endif %}
@@ -86,7 +89,7 @@
 		{%- else -%}
 			{%- set row_layout = '' -%}
 		{%- endif -%}
-		{%- set col_gap = ('0' if section.field_borders else (section.gap if section.gap is defined and section.gap != None else 20)|string + 'px') -%}
+		{%- set col_gap = ('0' if section.field_borders else (section.gap if section.gap is defined and section.gap != None else 20)|int|string + 'px') -%}
 		<div class="section-columns row {{ row_layout }}" style="gap:{{ col_gap }}">
 			{% for column in section.columns %}
 			<div class="column col">
@@ -110,7 +113,7 @@
 	{%- set ns_f = namespace(has_fields=false) -%}
 	{%- for col in layout.footer.columns -%}{%- for df in col.get('fields', []) -%}{%- set ns_f.has_fields = true -%}{%- endfor -%}{%- endfor -%}
 	{%- if ns_f.has_fields -%}
-	{%- set col_gap_f = (layout.footer.gap if layout.footer.gap is defined and layout.footer.gap != None else 20)|string + 'px' -%}
+	{%- set col_gap_f = (layout.footer.gap if layout.footer.gap is defined and layout.footer.gap != None else 20)|int|string + 'px' -%}
 	<div class="section document-footer-content {{ 'label-uppercase' if layout.footer.label_case == 'uppercase' else '' }}">
 	<div class="section-columns row" style="gap:{{ col_gap_f }}">
 	{%- for column in layout.footer.columns %}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -67,13 +67,6 @@
 		{%- set p = section.padding -%}
 		{%- set ns3.section_style = ns3.section_style + 'padding:' + (p.top or 0)|string + 'px ' + (p.right or 0)|string + 'px ' + (p.bottom or 0)|string + 'px ' + (p.left or 0)|string + 'px;' -%}
 	{%- endif -%}
-	{%- if section.border and section.border.on -%}
-		{%- set _bc = (section.border.color if section.border.color else '#e5e7eb') -%}
-		{%- set ns3.section_style = ns3.section_style + 'border:1px solid ' + _bc + ';' -%}
-	{%- endif -%}
-	{%- if section.border_radius -%}
-		{%- set ns3.section_style = ns3.section_style + 'border-radius:' + section.border_radius|string + 'px;' -%}
-	{%- endif -%}
 	{%- if section.field_borders -%}
 		{%- set _cp = (section.cell_padding if section.cell_padding is defined and section.cell_padding is not none else 8) -%}
 		{%- set ns3.section_style = ns3.section_style + '--pfb-cell-pad:' + _cp|string + 'px;' -%}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -67,6 +67,17 @@
 		{%- set p = section.padding -%}
 		{%- set ns3.section_style = ns3.section_style + 'padding:' + (p.top or 0)|string + 'px ' + (p.right or 0)|string + 'px ' + (p.bottom or 0)|string + 'px ' + (p.left or 0)|string + 'px;' -%}
 	{%- endif -%}
+	{%- if section.border -%}
+		{%- set b = section.border -%}
+		{%- set _bc = (b.color if b.color else '#e5e7eb') -%}
+		{%- if b.top -%}{%- set ns3.section_style = ns3.section_style + 'border-top:1px solid ' + _bc + ';' -%}{%- endif -%}
+		{%- if b.right -%}{%- set ns3.section_style = ns3.section_style + 'border-right:1px solid ' + _bc + ';' -%}{%- endif -%}
+		{%- if b.bottom -%}{%- set ns3.section_style = ns3.section_style + 'border-bottom:1px solid ' + _bc + ';' -%}{%- endif -%}
+		{%- if b.left -%}{%- set ns3.section_style = ns3.section_style + 'border-left:1px solid ' + _bc + ';' -%}{%- endif -%}
+	{%- endif -%}
+	{%- if section.border_radius -%}
+		{%- set ns3.section_style = ns3.section_style + 'border-radius:' + section.border_radius|string + 'px;' -%}
+	{%- endif -%}
 	<div class="section {{ resolve_class({'page-break': section.page_break}) }} {{ 'label-uppercase' if section.label_case == 'uppercase' else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style }}"{% endif %}>
 		{% if section.label and section.show_label != 'hide' %}
 		<div class="section-label">{{ _(section.label) }}</div>

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -86,7 +86,7 @@
 		{%- else -%}
 			{%- set row_layout = '' -%}
 		{%- endif -%}
-		{%- set col_gap = (section.gap if section.gap is defined and section.gap != None else 20)|string + 'px' -%}
+		{%- set col_gap = ('0' if section.field_borders else (section.gap if section.gap is defined and section.gap != None else 20)|string + 'px') -%}
 		<div class="section-columns row {{ row_layout }}" style="gap:{{ col_gap }}">
 			{% for column in section.columns %}
 			<div class="column col">

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -31,7 +31,7 @@
 	{%- set ns_h = namespace(has_fields=false) -%}
 	{%- for col in layout.header.columns -%}{%- for df in col.get('fields', []) -%}{%- set ns_h.has_fields = true -%}{%- endfor -%}{%- endfor -%}
 	{%- if ns_h.has_fields -%}
-	{%- set col_gap = (layout.header.gap if layout.header.gap is defined and layout.header.gap != None else 20)|int|string + 'px' -%}
+	{%- set col_gap = (layout.header.gap if layout.header.gap is defined and layout.header.gap != None else 20)|string + 'px' -%}
 	<div class="section document-header-content {{ 'label-uppercase' if layout.header.label_case == 'uppercase' else '' }}">
 	<div class="section-columns row" style="gap:{{ col_gap }}">
 	{%- for column in layout.header.columns %}
@@ -58,21 +58,17 @@
 		{%- endfor -%}
 	{%- endfor -%}
 	{%- if not section.label or ns.has_content -%}
-	{#- Build inline style for section background + padding.
-	    Numeric values are coerced with |int and the background colour is rejected if
-	    it contains characters that could break out of the CSS value; the assembled
-	    string is escaped at the render site to prevent attribute/HTML injection. -#}
 	{%- set ns3 = namespace(section_style='') -%}
-	{%- if section.background and not (';' in section.background or '<' in section.background or '>' in section.background or '"' in section.background) -%}
+	{%- if section.background -%}
 		{%- set ns3.section_style = ns3.section_style + 'background:' + section.background + ';' -%}
 	{%- endif -%}
 	{%- if section.padding and not section.field_borders -%}
 		{%- set p = section.padding -%}
-		{%- set ns3.section_style = ns3.section_style + 'padding:' + (p.top or 0)|int|string + 'px ' + (p.right or 0)|int|string + 'px ' + (p.bottom or 0)|int|string + 'px ' + (p.left or 0)|int|string + 'px;' -%}
+		{%- set ns3.section_style = ns3.section_style + 'padding:' + (p.top or 0)|string + 'px ' + (p.right or 0)|string + 'px ' + (p.bottom or 0)|string + 'px ' + (p.left or 0)|string + 'px;' -%}
 	{%- endif -%}
 	{%- if section.field_borders -%}
 		{%- set _cp = (section.cell_padding if section.cell_padding is defined and section.cell_padding is not none else 8) -%}
-		{%- set ns3.section_style = ns3.section_style + '--pfb-cell-pad:' + _cp|int|string + 'px;' -%}
+		{%- set ns3.section_style = ns3.section_style + '--pfb-cell-pad:' + _cp|string + 'px;' -%}
 	{%- endif -%}
 	<div class="section {{ resolve_class({'page-break': section.page_break}) }} {{ 'label-uppercase' if section.label_case == 'uppercase' else '' }}{{ ' section--grid' if section.field_borders else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style|e }}"{% endif %}>
 		{% if section.label and section.show_label != 'hide' %}
@@ -89,7 +85,7 @@
 		{%- else -%}
 			{%- set row_layout = '' -%}
 		{%- endif -%}
-		{%- set col_gap = ('0' if section.field_borders else (section.gap if section.gap is defined and section.gap != None else 20)|int|string + 'px') -%}
+		{%- set col_gap = ('0' if section.field_borders else (section.gap if section.gap is defined and section.gap != None else 20)|string + 'px') -%}
 		<div class="section-columns row {{ row_layout }}" style="gap:{{ col_gap }}">
 			{% for column in section.columns %}
 			<div class="column col">
@@ -113,7 +109,7 @@
 	{%- set ns_f = namespace(has_fields=false) -%}
 	{%- for col in layout.footer.columns -%}{%- for df in col.get('fields', []) -%}{%- set ns_f.has_fields = true -%}{%- endfor -%}{%- endfor -%}
 	{%- if ns_f.has_fields -%}
-	{%- set col_gap_f = (layout.footer.gap if layout.footer.gap is defined and layout.footer.gap != None else 20)|int|string + 'px' -%}
+	{%- set col_gap_f = (layout.footer.gap if layout.footer.gap is defined and layout.footer.gap != None else 20)|string + 'px' -%}
 	<div class="section document-footer-content {{ 'label-uppercase' if layout.footer.label_case == 'uppercase' else '' }}">
 	<div class="section-columns row" style="gap:{{ col_gap_f }}">
 	{%- for column in layout.footer.columns %}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -67,18 +67,18 @@
 		{%- set p = section.padding -%}
 		{%- set ns3.section_style = ns3.section_style + 'padding:' + (p.top or 0)|string + 'px ' + (p.right or 0)|string + 'px ' + (p.bottom or 0)|string + 'px ' + (p.left or 0)|string + 'px;' -%}
 	{%- endif -%}
-	{%- if section.border -%}
-		{%- set b = section.border -%}
-		{%- set _bc = (b.color if b.color else '#e5e7eb') -%}
-		{%- if b.top -%}{%- set ns3.section_style = ns3.section_style + 'border-top:1px solid ' + _bc + ';' -%}{%- endif -%}
-		{%- if b.right -%}{%- set ns3.section_style = ns3.section_style + 'border-right:1px solid ' + _bc + ';' -%}{%- endif -%}
-		{%- if b.bottom -%}{%- set ns3.section_style = ns3.section_style + 'border-bottom:1px solid ' + _bc + ';' -%}{%- endif -%}
-		{%- if b.left -%}{%- set ns3.section_style = ns3.section_style + 'border-left:1px solid ' + _bc + ';' -%}{%- endif -%}
+	{%- if section.border and section.border.on -%}
+		{%- set _bc = (section.border.color if section.border.color else '#e5e7eb') -%}
+		{%- set ns3.section_style = ns3.section_style + 'border:1px solid ' + _bc + ';' -%}
 	{%- endif -%}
 	{%- if section.border_radius -%}
 		{%- set ns3.section_style = ns3.section_style + 'border-radius:' + section.border_radius|string + 'px;' -%}
 	{%- endif -%}
-	<div class="section {{ resolve_class({'page-break': section.page_break}) }} {{ 'label-uppercase' if section.label_case == 'uppercase' else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style }}"{% endif %}>
+	{%- if section.field_borders -%}
+		{%- set _cp = (section.cell_padding if section.cell_padding is defined and section.cell_padding is not none else 8) -%}
+		{%- set ns3.section_style = ns3.section_style + '--pfb-cell-pad:' + _cp|string + 'px;' -%}
+	{%- endif -%}
+	<div class="section {{ resolve_class({'page-break': section.page_break}) }} {{ 'label-uppercase' if section.label_case == 'uppercase' else '' }}{{ ' section--grid' if section.field_borders else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style }}"{% endif %}>
 		{% if section.label and section.show_label != 'hide' %}
 		<div class="section-label">{{ _(section.label) }}</div>
 		{% endif %}


### PR DESCRIPTION
- Add table field styling: cell padding, corner radius, header style (styled/plain/none), and inline-editable column labels
- Add section "table layout" mode that renders a section as a bordered grid with column dividers and per-cell padding
- Apply font size in px so the canvas preview matches the print output
- Escape inline section/table styles in the print template


`no-docs`