### PR TITLE
fix(postgres): raise a clean error on incompatible field-type change

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -7,9 +7,12 @@ import psycopg2.extensions
 from psycopg2 import sql
 from psycopg2.errorcodes import (
 	CLASS_INTEGRITY_CONSTRAINT_VIOLATION,
+	DATATYPE_MISMATCH,
 	DEADLOCK_DETECTED,
 	DUPLICATE_COLUMN,
 	INSUFFICIENT_PRIVILEGE,
+	INVALID_TEXT_REPRESENTATION,
+	NUMERIC_VALUE_OUT_OF_RANGE,
 	SERIALIZATION_FAILURE,
 	STRING_DATA_RIGHT_TRUNCATION,
 	UNDEFINED_COLUMN,
@@ -157,6 +160,18 @@ class PostgresExceptionUtil:
 	@staticmethod
 	def is_data_too_long(e):
 		return getattr(e, "pgcode", None) == STRING_DATA_RIGHT_TRUNCATION
+
+	@staticmethod
+	def is_data_truncated(e):
+		# a value cannot be cast to the column's new type -- e.g. changing a field holding
+		# "not a number" to Int. MariaDB reports TRUNCATED_WRONG_VALUE; postgres is stricter and
+		# aborts the ALTER: it refuses to auto-cast the column (datatype mismatch) or a value fails
+		# the cast (invalid representation / numeric out of range).
+		return getattr(e, "pgcode", None) in (
+			DATATYPE_MISMATCH,
+			INVALID_TEXT_REPRESENTATION,
+			NUMERIC_VALUE_OUT_OF_RANGE,
+		)
 
 	@staticmethod
 	def is_db_table_size_limit(e) -> bool:

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -304,6 +304,13 @@ class PostgresTable(DBTable):
 						"{0} field cannot be set as unique in {1}, as there are non-unique existing values"
 					).format(fieldname, self.table_name)
 				)
+			elif frappe.db.is_data_truncated(e):
+				frappe.throw(
+					_(
+						"Cannot change field type in {0}: some existing values cannot be converted to the new type"
+					).format(self.doctype),
+					title=_("Incompatible Values"),
+				)
 			else:
 				raise e
 


### PR DESCRIPTION
## Problem
Changing a DocType field to a numeric type (e.g. `Int`) when the column holds values that can't be converted makes **Postgres** abort the schema `ALTER` with a raw `psycopg2` error instead of a clean `frappe.ValidationError`:

```
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type numeric: "not a number"
psycopg2.errors.DatatypeMismatch: column "x" cannot be cast automatically to type integer
```

MariaDB raises `frappe.ValidationError` here (via `is_data_truncated`), so `test_change_field_type_with_incompatible_values` passes on MariaDB but **errors on Postgres**.

## Fix
Mirror MariaDB: add `PostgresExceptionUtil.is_data_truncated()` covering the Postgres error codes for an incompatible column conversion (`DATATYPE_MISMATCH`, `INVALID_TEXT_REPRESENTATION`, `NUMERIC_VALUE_OUT_OF_RANGE`) and handle it in `PostgresTable.alter()`, raising a `frappe.ValidationError` with the same "Incompatible Values" message MariaDB uses.

## Test
`test_change_field_type_with_incompatible_values` now passes on Postgres (verified locally) and is unchanged on MariaDB (Postgres-only code path).
