### PR TITLE
fix: use frappe.parse_json for scheduler actions

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -194,17 +194,17 @@ class ScheduledJobType(Document):
 
 
 @frappe.whitelist()
-def execute_event(doc: str):
+def execute_event(doc: str | dict):
 	frappe.only_for("System Manager")
-	doc = json.loads(doc)
+	doc = frappe.parse_json(doc)
 	frappe.get_doc("Scheduled Job Type", doc.get("name")).enqueue(force=True)
 	return doc
 
 
 @frappe.whitelist()
-def skip_next_execution(doc: str):
+def skip_next_execution(doc: str | dict):
 	frappe.only_for("System Manager")
-	doc = json.loads(doc)
+	doc = frappe.parse_json(doc)
 	doc: ScheduledJobType = frappe.get_doc("Scheduled Job Type", doc.get("name"))
 	doc.last_execution = doc.next_execution
 	return doc.save()


### PR DESCRIPTION
Scheduled Job Type actions - Execute and Skip Next Execution is broken after switching to JSON as request type

```
16:24:44 web.1         |   File "apps/frappe/frappe/app.py", line 125, in application
16:24:44 web.1         |     response = frappe.api.handle(request)
16:24:44 web.1         |   File "apps/frappe/frappe/api/__init__.py", line 64, in handle
16:24:44 web.1         |     data = endpoint(**arguments)
16:24:44 web.1         |   File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
16:24:44 web.1         |     return frappe.handler.handle()
16:24:44 web.1         |            ~~~~~~~~~~~~~~~~~~~~~^^
16:24:44 web.1         |   File "apps/frappe/frappe/handler.py", line 54, in handle
16:24:44 web.1         |     data = execute_cmd(cmd)
16:24:44 web.1         |   File "apps/frappe/frappe/handler.py", line 87, in execute_cmd
16:24:44 web.1         |     return frappe.call(method, **frappe.form_dict)
16:24:44 web.1         |            ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
16:24:44 web.1         |   File "apps/frappe/frappe/__init__.py", line 1134, in call
16:24:44 web.1         |     return fn(*args, **newargs)
16:24:44 web.1         |   File "apps/frappe/frappe/utils/typing_validations.py", line 49, in wrapper
16:24:44 web.1         |     return func(*args, **kwargs)
16:24:44 web.1         |   File "apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 199, in execute_event
16:24:44 web.1         |     doc = json.loads(doc)
16:24:44 web.1         |   File "/home/ruthra/.local/share/uv/python/cpython-3.14.2-linux-x86_64-gnu/lib/python3.14/json/__init__.py", line 345, in loads
16:24:44 web.1         |     raise TypeError(f'the JSON object must be str, bytes or bytearray, '
16:24:44 web.1         |                     f'not {s.__class__.__name__}')
16:24:44 web.1         | TypeError: the JSON object must be str, bytes or bytearray, not dict
```