### PR TITLE
fix: null names crashing report Add Column feature

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -2254,7 +2254,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		});
 		this.data.forEach((row) => {
 			doctypes.forEach((doc) => {
-				this.doctype_field_map[doc.doctype][doc.fieldname].names.add(row[doc.fieldname]);
+				if (row[doc.fieldname] != null) {
+					this.doctype_field_map[doc.doctype][doc.fieldname].names.add(
+						row[doc.fieldname]
+					);
+				}
 			});
 		});
 


### PR DESCRIPTION
- Skip null/undefined field values when building the `names` set in `get_linked_doctypes()` before calling `get_data_for_custom_field`
Why: rows without a value for the linked field (e.g. blank/total rows) added `null` into the names list, which failed strict type validation on the backend

Error seen:
```
frappe.exceptions.FrappeTypeError: Argument 'names' in 'frappe.desk.query_report.get_data_for_custom_field' should be of type 'str | list[str] | None' but got 'list' instead.
```