### PR TITLE
fix: Avoid snapshot violation on login/session extension

### DIFF
--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -8,19 +8,18 @@ permission, homepage, default variables, system defaults etc
 """
 
 import json
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 from urllib.parse import unquote
 
 import redis
 
 import frappe
-import frappe.defaults
-import frappe.model.meta
 import frappe.translate
 import frappe.utils
 from frappe import _
 from frappe.apps import get_apps, get_default_path, is_desk_apps
 from frappe.cache_manager import clear_user_cache, reset_metadata_version
+from frappe.database import savepoint
 from frappe.query_builder import Order
 from frappe.utils import cint, cstr, get_assets_json
 from frappe.utils.change_log import has_app_update_notifications
@@ -286,19 +285,15 @@ class Session:
 		if self.user != "Guest":
 			self.insert_session_record()
 
-			# update user
-			user = frappe.get_lazy_doc("User", self.data["user"])
-			user_doctype = frappe.qb.DocType("User")
-			(
-				frappe.qb.update(user_doctype)
-				.set(user_doctype.last_login, frappe.utils.now())
-				.set(user_doctype.last_ip, frappe.local.request_ip)
-				.set(user_doctype.last_active, frappe.utils.now())
-				.where(user_doctype.name == self.data["user"])
-			).run()
-
-			user.run_notifications("before_change")
-			user.run_notifications("on_update")
+			# update user's login metadata
+			now = frappe.utils.now()
+			update_user_metadata(
+				self.data["user"],
+				run_notifications=True,
+				last_login=now,
+				last_ip=frappe.local.request_ip,
+				last_active=now,
+			)
 			frappe.db.commit()
 
 		assert (self.user == "Guest") == (sid == "Guest"), (
@@ -437,30 +432,22 @@ class Session:
 			self.data.data.session_ip = frappe.local.request_ip
 
 			Sessions = frappe.qb.DocType("Sessions")
-			try:
-				# update sessions table
-				(
-					frappe.qb.update(Sessions)
-					.where(Sessions.sid == self.data["sid"])
-					.set(
-						Sessions.sessiondata,
-						frappe.as_json(self.data["data"], indent=None, separators=(",", ":")),
-					)
-					.set(Sessions.lastupdate, now)
-				).run()
+			# update sessions table
+			(
+				frappe.qb.update(Sessions)
+				.where(Sessions.sid == self.data["sid"])
+				.set(
+					Sessions.sessiondata,
+					frappe.as_json(self.data["data"], indent=None, separators=(",", ":")),
+				)
+				.set(Sessions.lastupdate, now)
+			).run()
 
-				frappe.db.set_value("User", frappe.session.user, "last_active", now, update_modified=False)
+			update_user_metadata(frappe.session.user, last_active=now)
 
-				frappe.db.commit(chain=True)
-			except frappe.QueryDeadlockError:
-				# A concurrent request updated this session row first (on postgres a REPEATABLE READ
-				# write conflict surfaces as a serialization failure). Persistence here is best-effort
-				# -- the cache is the source of truth and the next request will persist -- so roll back
-				# the conflicting transaction rather than error out of this after-response hook.
-				frappe.db.rollback()
-			else:
-				updated_in_db = True
-				frappe.cache.hset("session", self.sid, self.data)
+			frappe.db.commit(chain=True)
+			updated_in_db = True
+			frappe.cache.hset("session", self.sid, self.data)
 
 		return updated_in_db
 
@@ -468,6 +455,45 @@ class Session:
 		self.data.data.impersonated_by = original_user
 		# Forcefully flush session
 		self.update(force=True)
+
+
+def update_user_metadata(
+	user: str,
+	*,
+	last_login: str | None = None,
+	last_ip: str | None = None,
+	last_active: str | None = None,
+	run_notifications: bool = False,
+):
+	"""Best-effort update of a user's session metadata (``last_login``, ``last_ip``, ``last_active``).
+
+	A user can be logged in from many sessions/tabs at once, so these writes frequently
+	contend on the same User row and can deadlock. The data is non-critical -- the next
+	request refreshes it -- so the write is wrapped in a savepoint and any failure is
+	swallowed rather than aborting the surrounding transaction.
+	"""
+	values = {}
+	if last_login is not None:
+		values["last_login"] = last_login
+	if last_ip is not None:
+		values["last_ip"] = last_ip
+	if last_active is not None:
+		values["last_active"] = last_active
+
+	if user == "Guest" or not values:
+		return
+
+	with savepoint(frappe.QueryDeadlockError):
+		user_doctype = frappe.qb.DocType("User")
+		query = frappe.qb.update(user_doctype).where(user_doctype.name == user)
+		for field, value in values.items():
+			query = query.set(user_doctype[field], value)
+		query.run()
+
+		if run_notifications:
+			user_doc = frappe.get_lazy_doc("User", user)
+			user_doc.run_notifications("before_change")
+			user_doc.run_notifications("on_update")
 
 
 def get_expiry_period_for_query():

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -443,7 +443,7 @@ class Session:
 				.set(Sessions.lastupdate, now)
 			).run()
 
-			update_user_metadata(frappe.session.user, last_active=now)
+			update_user_metadata(frappe.session.user, last_active=now, last_ip=frappe.local.request_ip)
 
 			frappe.db.commit(chain=True)
 			updated_in_db = True


### PR DESCRIPTION
User's metadata keep refreshing on every session update. This can cause
snapshot violation if same user is logged in multiple sessions.

This fix just ignores them as this violation isn't important from correctness POV.


