### PR TITLE
fix(workflow): gate confirm action via email by forcing login

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -157,24 +157,15 @@ def apply_action(
 		return_link_expired_page(doc, doc_workflow_state)
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def confirm_action(doctype: str, docname: str | int, user: str, action: str):
 	if not verify_request():
 		return
-
-	logged_in_user = frappe.session.user
-	if logged_in_user == "Guest" and user:
-		# to allow user to apply action without login
-		frappe.set_user(user)
 
 	doc = frappe.get_doc(doctype, docname)
 	newdoc = apply_workflow(doc, action)
 	frappe.db.commit()
 	return_success_page(newdoc)
-
-	# reset session user
-	if logged_in_user == "Guest":
-		frappe.set_user(logged_in_user)
 
 
 def return_success_page(doc):
@@ -195,6 +186,7 @@ def return_action_confirmation_page(doc, action, action_link, alert_doc_change=F
 		"action": action,
 		"action_link": action_link,
 		"alert_doc_change": alert_doc_change,
+		"is_guest": frappe.session.user == "Guest",
 	}
 
 	template_params["pdf_link"] = get_pdf_link(doc.get("doctype"), doc.get("name"))

--- a/frappe/www/confirm_workflow_action.html
+++ b/frappe/www/confirm_workflow_action.html
@@ -11,6 +11,10 @@
   <p>
     <a target="_blank" class="underline" href="{{ pdf_link }}">{{ _('View document') }}</a>
   </p>
+  {% if is_guest %}
+  <a href="/login?redirect-to={{ action_link | urlencode }}" class="btn btn-primary btn-action">{{ action }}</a>
+  {% else %}
   <a href="{{ action_link }}" class="btn btn-primary btn-action">{{ action }}</a>
+  {% endif %}
   <a href="/" class="btn btn-secondary btn-action">Cancel</a>
 {% endblock %}


### PR DESCRIPTION
Should ideally be forcing login in, only then allowing state approvals.
related to closing Tickets 68999 & 63210