### PR TITLE
fix: apply LinkTableField permission conditions in JOIN, not WHERE

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -2144,10 +2144,13 @@ class LinkTableField(DynamicTableField):
 		table = frappe.qb.DocType(self.doctype)
 		main_table = frappe.qb.DocType(self.parent_doctype)
 		if not query.is_joined(table):
-			query = query.left_join(table).on(table.name == getattr(main_table, self.link_fieldname))
+			clause = table.name == getattr(main_table, self.link_fieldname)
+
 			if engine and engine.apply_permissions:
 				if condition := engine.get_permission_conditions(self.doctype, table):
-					query = query.where(condition)
+					clause &= condition
+
+			query = query.left_join(table).on(clause)
 
 		return query
 

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -1371,6 +1371,106 @@ class TestQuery(IntegrationTestCase):
 		test_user_doc.remove_roles(test_role)
 		frappe.delete_doc("Role", test_role, force=True)
 
+	def test_link_table_field_optional_link_not_filtered_by_target_permission_conditions(self):
+		"""An optional (empty) Link field fetched via dot-notation must not cause the
+		parent row to disappear because of the *target* doctype's permission_query_conditions.
+
+		LinkTableField.apply_join LEFT JOINs the linked doctype and applies the target's
+		permission_query_conditions as a WHERE clause. When the link value is empty, the
+		joined row is entirely NULL, so any non-trivial condition on it evaluates false and
+		silently drops the parent row -- even though the parent row never referenced
+		anything the user isn't allowed to see. The condition belongs in the JOIN's ON
+		clause, where it only ever affects what gets attached, never whether the parent
+		row survives.
+		"""
+		target_dt_name = "TargetDocForOptionalLink"
+		source_dt_name = "SourceDocForOptionalLink"
+		test_role = "OptionalLinkPermTestRole"
+		test_user = "test3@example.com"
+
+		# Cleanup previous runs
+		frappe.set_user("Administrator")
+		frappe.delete_doc("DocType", source_dt_name, ignore_missing=True, force=True)
+		frappe.delete_doc("DocType", target_dt_name, ignore_missing=True, force=True)
+		frappe.delete_doc("Role", test_role, ignore_missing=True, force=True)
+		test_user_doc = frappe.get_doc("User", test_user)
+		test_user_doc.remove_roles(test_role)
+
+		# Create Doctypes: source has an OPTIONAL link to target
+		target_dt = new_doctype(
+			target_dt_name,
+			fields=[{"fieldname": "value", "fieldtype": "Data", "label": "Value"}],
+		).insert(ignore_if_duplicate=True)
+
+		source_dt = new_doctype(
+			source_dt_name,
+			fields=[
+				{
+					"fieldname": "link_field",
+					"fieldtype": "Link",
+					"options": target_dt_name,
+					"label": "Link Field",
+					"reqd": 0,
+				}
+			],
+		).insert(ignore_if_duplicate=True)
+
+		# Setup Role and Permissions
+		frappe.get_doc({"doctype": "Role", "role_name": test_role}).insert(ignore_if_duplicate=True)
+		add_permission(source_dt_name, test_role, 0, ptype="read")
+		add_permission(target_dt_name, test_role, 0, ptype="read")
+		test_user_doc.add_roles(test_role)
+
+		# Create records: one source doc points at a target, the other has no link at all
+		target_doc = frappe.get_doc(doctype=target_dt_name, value="Secret Data").insert(
+			ignore_permissions=True
+		)
+		linked_source = frappe.get_doc(doctype=source_dt_name, link_field=target_doc.name).insert(
+			ignore_permissions=True
+		)
+		unlinked_source = frappe.get_doc(doctype=source_dt_name).insert(ignore_permissions=True)
+
+		# Target doctype's permission_query_conditions denies every row for every user,
+		# simulating "the user can't see the specific document this field would point to".
+		with self.patch_hooks(
+			{
+				"permission_query_conditions": {
+					target_dt_name: ["frappe.tests.test_query.test_deny_all_permission_hook"]
+				}
+			}
+		):
+			frappe.set_user(test_user)
+			result = frappe.qb.get_query(
+				source_dt_name,
+				filters={"name": ["in", [linked_source.name, unlinked_source.name]]},
+				fields=["name", "link_field.value as linked_value"],
+				ignore_permissions=False,
+			).run(as_dict=True)
+
+			by_name = {d.name: d for d in result}
+			self.assertIn(
+				unlinked_source.name,
+				by_name,
+				"A row with no link at all must not be filtered out by an unrelated "
+				"doctype's permission condition.",
+			)
+			self.assertIsNone(by_name[unlinked_source.name].linked_value)
+
+			# The row that *does* link to an inaccessible target should still be visible
+			# (its own permissions are unaffected) but must not leak the target's data.
+			self.assertIn(linked_source.name, by_name)
+			self.assertIsNone(by_name[linked_source.name].linked_value)
+
+		# Cleanup
+		frappe.set_user("Administrator")
+		linked_source.delete(ignore_permissions=True)
+		unlinked_source.delete(ignore_permissions=True)
+		target_doc.delete(ignore_permissions=True)
+		source_dt.delete()
+		target_dt.delete()
+		test_user_doc.remove_roles(test_role)
+		frappe.delete_doc("Role", test_role, force=True)
+
 	def test_filter_direct_field_permission(self):
 		"""Test that filtering is only allowed on permitted direct fields."""
 		with setup_patched_blog_post(), setup_test_user(set_user=True) as user:
@@ -2759,3 +2859,8 @@ def test_permission_hook_condition(user):
 def test_permission_hook_criterion(user):
 	DashboardSettings = frappe.qb.DocType("Dashboard Settings")
 	return DashboardSettings.name == user
+
+
+# Used to simulate "user cannot see any row of this doctype" for LinkTableField tests.
+def test_deny_all_permission_hook(user, doctype=None):
+	return "1=0"


### PR DESCRIPTION
## Summary

`LinkTableField.apply_join` (used whenever a query fetches a linked field via dot notation, e.g. `discussion.title`) LEFT JOINs the linked doctype and then applies that doctype's `permission_query_conditions` as a `WHERE` clause on the outer query.

Since the underlying link field is frequently optional, a record that has no value set for it produces an all-`NULL` joined row. ANDing that row's permission condition into the outer `WHERE` evaluates false for an all-NULL row, which silently drops the *parent* row — even though the parent document never referenced anything the current user can't see. This effectively turns the LEFT JOIN into an INNER JOIN whenever the linked doctype has a non-trivial permission condition for the requesting user.

This was introduced by 9a774de21e ("fix: add permission conditions to where clause instead of join"), which moved the condition out of the join's `ON` clause into a `WHERE` without accounting for optional/null links (no test accompanied that change).

### Real-world impact

Found via the Gameplan app: its Notifications page fetches `GP Notification` rows with several optional dotted fields (`discussion.title`, `task.title`, `project.title`, `team.title`). Since a given notification only ever has one or two of those links set, and each linked doctype (`GP Discussion`, `GP Task`, ...) has its own `permission_query_conditions`, non-admin users got zero rows back from `/api/v2/document/GP Notification` — every notification failed at least one of the ANDed conditions on its unset links. Admins never noticed because `is_global_admin` short-circuits every one of those conditions to `None`.

## Fix

Move the permission condition back into the join's `ON` clause instead of the outer `WHERE`, restoring the pre-regression behavior:

```python
def apply_join(self, query, engine=None):
    table = frappe.qb.DocType(self.doctype)
    main_table = frappe.qb.DocType(self.parent_doctype)
    if not query.is_joined(table):
        clause = table.name == getattr(main_table, self.link_fieldname)
        if engine and engine.apply_permissions:
            if condition := engine.get_permission_conditions(self.doctype, table):
                clause &= condition
        query = query.left_join(table).on(clause)
    return query
```

Now a missing or permission-denied link degrades to a null field on the parent row, instead of deleting the row entirely.

I also tried an alternative fix (keep the `WHERE`, but add an `OR link_field IS NULL` escape hatch). It fixes the null-link case too, but changes behavior for the case where the link *is* set to something inaccessible: the WHERE-based fix excludes the row entirely, while the ON-clause fix keeps the row and just nulls the field (matching what this code did before the regression). I went with the ON-clause version since it's a straight revert to previously-shipped, previously-tested behavior rather than a new policy choice.

## Test plan

- [x] Added `test_link_table_field_optional_link_not_filtered_by_target_permission_conditions` in `frappe/tests/test_query.py`: two doctypes linked by an optional Link field, a `permission_query_conditions` hook that denies every row of the target doctype, fetched via dot notation as a restricted user. Covers both the null-link case (row must survive) and the set-but-denied case (row survives, field is nulled).
- [x] Confirmed the new test fails against current `develop` (red) and passes with the fix (green).
- [x] Full `frappe.tests.test_query`, `frappe.tests.test_db_query`, `frappe.tests.test_query_builder`, `frappe.tests.test_permissions`, and `frappe.tests.test_api_v2` suites pass with the fix applied — no regressions.