### PR TITLE
feat(telemetry): make team the pulse identity subject

### DIFF
--- a/frappe/utils/telemetry/pulse/client.py
+++ b/frappe/utils/telemetry/pulse/client.py
@@ -91,15 +91,17 @@ def capture(
 		frappe.logger("pulse").error(f"pulse-client - capture failed: {e!s}")
 
 
-def identify(user: str, properties: str | dict[str, Any] | None = None):
-	"""Attach attributes to a user — upserts its Pulse Person profile.
+def identify(properties: str | dict[str, Any] | None = None):
+	"""Attach attributes to the account team — upserts its Pulse profile.
 
-	Server-side only (not whitelisted): press calls this in Python when a person's
-	attributes change (e.g. setting an FC user's persona at signup/payment). Posted
-	directly rather than queued: it's low-frequency, and a missed call self-heals on
-	the next change. Telemetry never raises to the caller.
+	The identity subject is always this site's Frappe Cloud team (`fc_team`): a site
+	belongs to exactly one team, so it's implicit and can't be mistyped — a setup
+	wizard just passes properties. Server-side only (not whitelisted): posted directly
+	rather than queued — it's low-frequency, and a missed call self-heals on the next
+	change. Telemetry never raises to the caller.
 	"""
-	if not is_enabled() or not user:
+	team = frappe.conf.get("fc_team")
+	if not is_enabled() or not team:
 		return
 
 	if isinstance(properties, str):
@@ -112,22 +114,23 @@ def identify(user: str, properties: str | dict[str, Any] | None = None):
 			return
 
 	endpoint = frappe.conf.get("pulse_identify_endpoint") or "/api/method/pulse.api.identify"
-	PulseHTTP().post(endpoint, {"user": user, "properties": properties or {}}, label="identify")
+	PulseHTTP().post(endpoint, {"team": team, "properties": properties or {}}, label="identify")
 
 
-def alias(previous_id: str, user: str):
-	"""Link a previous (anonymous) user id to a known user.
+def alias(previous_id: str):
+	"""Link a previous (anonymous) id to this site's account team (`fc_team`).
 
-	Server-side only (not whitelisted): identity merges must be press-controlled —
-	a browser-callable alias would let anyone re-point ids and poison the graph.
-	Press calls this in its signup handler to stitch the pre-signup anonymous
-	browser id to the FC user. Same delivery semantics as identify.
+	The alias target is always the site's team — implicit, single-tenant. Server-side
+	only (not whitelisted): identity merges must be press-controlled — a
+	browser-callable alias would let anyone re-point ids and poison the graph. Same
+	delivery semantics as identify.
 	"""
-	if not is_enabled() or not previous_id or not user:
+	team = frappe.conf.get("fc_team")
+	if not is_enabled() or not previous_id or not team:
 		return
 
 	endpoint = frappe.conf.get("pulse_alias_endpoint") or "/api/method/pulse.api.alias"
-	PulseHTTP().post(endpoint, {"previous_id": previous_id, "user": user}, label="alias")
+	PulseHTTP().post(endpoint, {"previous_id": previous_id, "team": team}, label="alias")
 
 
 def send_queued_events():

--- a/frappe/utils/telemetry/pulse/test_pulse_client.py
+++ b/frappe/utils/telemetry/pulse/test_pulse_client.py
@@ -391,7 +391,7 @@ class TestCapture(TestPulseClient):
 
 	@patch("frappe.utils.telemetry.pulse.client.is_enabled")
 	def test_capture_user_and_team_group(self, mock_enabled):
-		"""The user is the identity; the team is a group it belongs to"""
+		"""On events, team is the identity subject and user is a per-actor dimension"""
 		is_enabled.clear_cache()
 		mock_enabled.return_value = True
 		eq = EventQueue()
@@ -441,7 +441,7 @@ class TestIdentify(TestPulseClient):
 		is_enabled.clear_cache()
 		mock_enabled.return_value = False
 
-		identify("team_test", {"plan": "pro"})
+		identify({"plan": "pro"})
 
 		mock_session.assert_not_called()
 
@@ -452,14 +452,15 @@ class TestIdentify(TestPulseClient):
 		is_enabled.clear_cache()
 		mock_enabled.return_value = True
 
-		identify("fc_priya", "{not valid json")  # must not raise
+		with patch.dict(frappe.conf, {"fc_team": "team_test"}):
+			identify("{not valid json")  # must not raise
 
 		mock_session.assert_not_called()
 
 	@patch("frappe.utils.telemetry.pulse.transport.PulseHTTP._session")
 	@patch("frappe.utils.telemetry.pulse.client.is_enabled")
 	def test_identify_posts_profile(self, mock_enabled, mock_session):
-		"""identify posts the user + properties to the identify endpoint"""
+		"""identify posts the team + properties to the identify endpoint"""
 		is_enabled.clear_cache()
 		mock_enabled.return_value = True
 
@@ -475,16 +476,17 @@ class TestIdentify(TestPulseClient):
 
 		mock_session.return_value = type("_Session", (), {"post": staticmethod(_fake_post)})()
 
-		identify("fc_priya", {"persona": "founder"})
+		with patch.dict(frappe.conf, {"fc_team": "team_x"}):
+			identify({"persona": "founder"})
 
-		self.assertEqual(posted["data"]["user"], "fc_priya")
+		self.assertEqual(posted["data"]["team"], "team_x")
 		self.assertEqual(posted["data"]["properties"]["persona"], "founder")
 		self.assertTrue(posted["url"].endswith("/api/method/pulse.api.identify"))
 
 	@patch("frappe.utils.telemetry.pulse.transport.PulseHTTP._session")
 	@patch("frappe.utils.telemetry.pulse.client.is_enabled")
 	def test_alias_posts_mapping(self, mock_enabled, mock_session):
-		"""alias posts the previous_id → user mapping to the alias endpoint"""
+		"""alias posts the previous_id → team mapping to the alias endpoint"""
 		is_enabled.clear_cache()
 		mock_enabled.return_value = True
 
@@ -500,10 +502,11 @@ class TestIdentify(TestPulseClient):
 
 		mock_session.return_value = type("_Session", (), {"post": staticmethod(_fake_post)})()
 
-		alias("anon_8f2c", "fc_priya")
+		with patch.dict(frappe.conf, {"fc_team": "team_x"}):
+			alias("anon_8f2c")
 
 		self.assertEqual(posted["data"]["previous_id"], "anon_8f2c")
-		self.assertEqual(posted["data"]["user"], "fc_priya")
+		self.assertEqual(posted["data"]["team"], "team_x")
 		self.assertTrue(posted["url"].endswith("/api/method/pulse.api.alias"))
 
 


### PR DESCRIPTION
identify()/alias() now target the site's Frappe Cloud team (fc_team) as the
identity subject instead of the per-site anonymized user, and derive it
implicitly since a site belongs to exactly one team. The wire field is now
`team`. The event `user` dimension is unchanged.

`no-docs`
