### PR TITLE
fix: sidebar edit icon stacks rename dialogs on repeated clicks

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -231,7 +231,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 
 	setup_editable_title_click_event(element) {
 		let me = this;
-		element.on("click", () => {
+		element.off("click").on("click", () => {
 			let fields = [];
 			let docname = me.frm.doc.name;
 			let title_field = me.frm.meta.title_field || "";


### PR DESCRIPTION
## Summary

This fixes an issue where clicking the edit (pencil) icon in the form sidebar would open multiple rename dialogs. Each click added another event handler, causing the dialogs to stack up over time.

## Root Cause

The edit icon calls `setup_editable_title_click_event`, which binds a `click` handler using `.on("click")`. Since this method was called on every click, a new handler was added each time instead of reusing the existing one. As a result, all accumulated handlers were triggered together, opening multiple rename dialogs.

## Fix

Use `.off("click").on("click")` so the previous click handler is removed before a new one is attached. This ensures only a single handler is active and prevents duplicate dialogs from appearing.

---

Fixes #40457
Ref: https://support.frappe.io/helpdesk/tickets/71969?view=VIEW-HD+Ticket-1252 and many more.