### PR TITLE
feat(postgres): hide Postgres-only reports on non-Postgres sites

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -550,3 +550,22 @@ def enable_prepared_report(report: str, site: str):
 	frappe.db.set_value("Report", report, "prepared_report", 1)
 	frappe.db.commit()
 	frappe.destroy()
+
+
+def get_permission_query_conditions(user=None):
+	"""Hide Postgres-only diagnostic reports (named with a "Postgres " prefix) from the report
+	list on other database backends, where they raise instead of running."""
+	if frappe.db.db_type == "postgres":
+		return None
+	# substr comparison, not LIKE 'Postgres %': a literal % in a permission condition is read as a
+	# printf placeholder when the list query is parameterized, raising "not enough arguments".
+	return "substr(`tabReport`.`name`, 1, 9) != 'Postgres '"
+
+
+def has_permission(doc, ptype=None, user=None, debug=False):
+	"""Deny document-level access to a Postgres-only report on other backends. Running the report
+	is separately guarded by its execute() raising on non-Postgres. Case-insensitive to match the
+	report list's SQL filter under MariaDB's case-insensitive collation."""
+	if frappe.db.db_type != "postgres" and doc.name.lower().startswith("postgres "):
+		return False
+	return True

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -110,6 +110,7 @@ pdf_generator = "frappe.utils.pdf.get_chrome_pdf"
 # permissions
 
 permission_query_conditions = {
+	"Report": "frappe.core.doctype.report.report.get_permission_query_conditions",
 	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
 	"ToDo": "frappe.desk.doctype.todo.todo.get_permission_query_conditions",
 	"User": "frappe.core.doctype.user.user.get_permission_query_conditions",
@@ -132,6 +133,7 @@ permission_query_conditions = {
 }
 
 has_permission = {
+	"Report": "frappe.core.doctype.report.report.has_permission",
 	"Event": "frappe.desk.doctype.event.event.has_permission",
 	"ToDo": "frappe.desk.doctype.todo.todo.has_permission",
 	"Note": "frappe.desk.doctype.note.note.has_permission",


### PR DESCRIPTION
Postgres-only diagnostic reports (**Postgres Query Stats**, **Postgres Index Suggestions**) `frappe.throw` on other backends, but still appear in the report list. This gates their visibility.

Two hooks on the **Report** doctype:
- `get_permission_query_conditions` → adds `` `tabReport`.`name` not like 'Postgres %' `` on non-Postgres, so they never show in report lists.
- `has_permission` → denies a `"Postgres "`-prefixed report on non-Postgres, so it cannot be opened by direct URL.

Both short-circuit to no-op when `db_type == "postgres"`. Uses a `"Postgres "` name-prefix convention so it covers every Postgres-only report without hardcoding names.

Verified: Postgres → visible + accessible; MariaDB → hidden from list + direct access denied; other reports unaffected.

Split out of #40469 so the visibility gate is independent of the query-stats report.