### PR TITLE
fix(db): harden advisory_lock error paths on both engines

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -452,19 +452,24 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 		Waits up to `timeout` seconds, then raises QueryTimeoutError. The key is hashed to a fixed
 		64-char digest so long keys can't collide via GET_LOCK's silent name truncation."""
 		import hashlib
+		import time
 
 		from frappe.exceptions import QueryTimeoutError
 
 		name = hashlib.sha256(str(key).encode()).hexdigest()
-		result = self.sql("SELECT GET_LOCK(%s, %s)", (name, timeout))
-		value = result[0][0] if result else None
-		# GET_LOCK returns 1 (acquired), 0 (timed out), or NULL (server error, e.g. OOM/killed
-		# thread). Only 0 is a timeout -- surfacing NULL as QueryTimeoutError would make a caller
-		# retry straight back into the same server failure.
-		if value is None:
-			raise RuntimeError(f"GET_LOCK returned NULL acquiring advisory lock {key!r} (server error)")
-		if value != 1:
-			raise QueryTimeoutError(f"Could not acquire advisory lock {key!r} within {timeout}s")
+		deadline = time.monotonic() + timeout
+		while True:
+			remaining = deadline - time.monotonic()
+			result = self.sql("SELECT GET_LOCK(%s, %s)", (name, max(remaining, 0)))
+			value = result[0][0] if result else None
+			if value == 1:
+				break
+			# GET_LOCK returns 1 (acquired), 0 (waited out the remaining budget for the holder), or
+			# NULL (transient server error, e.g. killed thread). Retry NULL within the budget so a
+			# blip self-heals instead of failing the whole operation; give up once the budget is spent.
+			if value == 0 or remaining <= 0:
+				raise QueryTimeoutError(f"Could not acquire advisory lock {key!r} within {timeout}s")
+			time.sleep(0.1)
 		try:
 			yield
 		finally:

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -479,19 +479,24 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 		Waits up to `timeout` seconds, then raises QueryTimeoutError. The key is hashed to a fixed
 		64-char digest so long keys can't collide via GET_LOCK's silent name truncation."""
 		import hashlib
+		import time
 
 		from frappe.exceptions import QueryTimeoutError
 
 		name = hashlib.sha256(str(key).encode()).hexdigest()
-		result = self.sql("SELECT GET_LOCK(%s, %s)", (name, timeout))
-		value = result[0][0] if result else None
-		# GET_LOCK returns 1 (acquired), 0 (timed out), or NULL (server error, e.g. OOM/killed
-		# thread). Only 0 is a timeout -- surfacing NULL as QueryTimeoutError would make a caller
-		# retry straight back into the same server failure.
-		if value is None:
-			raise RuntimeError(f"GET_LOCK returned NULL acquiring advisory lock {key!r} (server error)")
-		if value != 1:
-			raise QueryTimeoutError(f"Could not acquire advisory lock {key!r} within {timeout}s")
+		deadline = time.monotonic() + timeout
+		while True:
+			remaining = deadline - time.monotonic()
+			result = self.sql("SELECT GET_LOCK(%s, %s)", (name, max(remaining, 0)))
+			value = result[0][0] if result else None
+			if value == 1:
+				break
+			# GET_LOCK returns 1 (acquired), 0 (waited out the remaining budget for the holder), or
+			# NULL (transient server error, e.g. killed thread). Retry NULL within the budget so a
+			# blip self-heals instead of failing the whole operation; give up once the budget is spent.
+			if value == 0 or remaining <= 0:
+				raise QueryTimeoutError(f"Could not acquire advisory lock {key!r} within {timeout}s")
+			time.sleep(0.1)
 		try:
 			yield
 		finally:

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -717,7 +717,18 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		try:
 			yield
 		finally:
-			self.sql("SELECT pg_advisory_unlock(%s)", (lock_key,))
+			try:
+				self.sql("SELECT pg_advisory_unlock(%s)", (lock_key,))
+			except Exception:
+				# A DB error inside the block leaves the transaction aborted, so the unlock above
+				# fails and the session-scoped lock would leak (ROLLBACK does not release it). Clear
+				# the aborted state and release. Guarded so a failed cleanup never masks the original
+				# error -- a dropped session releases the lock anyway.
+				try:
+					self.rollback()
+					self.sql("SELECT pg_advisory_unlock(%s)", (lock_key,))
+				except Exception:
+					pass
 
 	def bulk_insert(self, doctype, fields, values, ignore_duplicates=False, *, chunk_size=10_000):
 		"""Stream rows into the table with COPY -- far faster than multi-row INSERT. Falls back to

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1057,6 +1057,19 @@ class TestDDLCommandsPost(IntegrationTestCase):
 			self.assertEqual(advisory_count(), before + 1)
 		self.assertEqual(advisory_count(), before)
 
+	def test_advisory_lock_released_after_query_error(self) -> None:
+		# A DB error inside the block aborts the transaction; the session-scoped lock must still be
+		# released on exit, not leaked. Regression: the unlock in `finally` runs on the aborted txn.
+		def advisory_count():
+			return frappe.db.sql("SELECT count(*) FROM pg_locks WHERE locktype = 'advisory'")[0][0]
+
+		before = advisory_count()
+		with self.assertRaises(Exception):
+			with frappe.db.advisory_lock("frappe-test-lock-error"):
+				frappe.db.sql("SELECT * FROM tab_does_not_exist")
+		frappe.db.rollback()
+		self.assertEqual(advisory_count(), before)
+
 	def _indexdef(self, field: str, using: str) -> str:
 		from frappe.database.postgres.schema import get_qualified_index_name
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1737,6 +1737,27 @@ class TestAdvisoryLockMariaDB(IntegrationTestCase):
 			self.assertTrue(held())
 		self.assertFalse(held())
 
+	@run_only_if(db_type_is.MARIADB)
+	def test_advisory_lock_retries_on_transient_null(self):
+		# GET_LOCK returns NULL on a transient server error (e.g. a killed thread). The acquire loop
+		# must retry within the budget and self-heal, not fail the whole operation with a bare error.
+		from unittest.mock import patch
+
+		real_sql = frappe.db.sql
+		get_lock_calls = []
+
+		def fake_sql(query, values=(), **kwargs):
+			if isinstance(query, str) and "GET_LOCK" in query:
+				get_lock_calls.append(values)
+				return ((None,),) if len(get_lock_calls) < 3 else ((1,),)  # two blips, then acquire
+			return real_sql(query, values, **kwargs)
+
+		with patch.object(frappe.db, "sql", fake_sql):
+			with frappe.db.advisory_lock("frappe-test-null", timeout=5):
+				pass
+
+		self.assertGreaterEqual(len(get_lock_calls), 3)
+
 
 class TestBulkInsertCopy(IntegrationTestCase):
 	def test_bulk_insert_copy(self):


### PR DESCRIPTION
Two error-path fixes to the `advisory_lock` primitive (#40466), one per engine.

## Postgres — lock leaks when the guarded block errors
A DB error inside the `with` block aborts the transaction, so the `pg_advisory_unlock` in `finally` runs on the aborted txn, fails with `InFailedSqlTransaction`, and the **session-scoped lock leaks** — a plain `ROLLBACK` does not release `pg_advisory_lock`. Other sessions then block for the full timeout until the holding connection is recycled, and the unlock failure masks the original exception.

Fix: if the unlock fails, roll back the aborted state and release. Guarded so failed cleanup never masks the original error (a dropped session releases the lock anyway).

This fires on exactly the workload advisory locks are used for — serializing work that hits a deadlock / serialization failure inside the block (e.g. ERPNext repost serialization, [erpnext#56697](https://github.com/frappe/erpnext/pull/56697)).

## MariaDB — transient GET_LOCK NULL failed the whole acquire
`GET_LOCK` returns NULL on a transient server error (e.g. a killed thread). The old code raised a bare `RuntimeError` — unclassifiable and non-recoverable — turning a blip into a hard failure (ERPNext marked the repost permanently `Failed`).

Fix: poll `GET_LOCK` within the timeout budget, retrying NULL so a blip self-heals, and raise `QueryTimeoutError` once the budget is spent. Now both engines surface one consistent, classifiable acquire-failure exception, and neither the `0` (held) nor the acquired path changes behaviour.

## Tests
- `test_advisory_lock_released_after_query_error` (Postgres): abort the txn inside the block, assert the advisory-lock count returns to baseline. Fails on `develop`, passes with the fix.
- `test_advisory_lock_retries_on_transient_null` (MariaDB): GET_LOCK blips NULL then acquires; assert the loop retries instead of raising.