### PR TITLE
fix(database): correct Int type-change conversion and unify out-of-range error

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -78,7 +78,9 @@ class MariaDBExceptionUtil:
 
 	@staticmethod
 	def is_data_truncated(e: pymysql.Error) -> bool:
-		return e.args and e.args[0] == ER.TRUNCATED_WRONG_VALUE
+		# WARN_DATA_OUT_OF_RANGE: a value that doesn't fit the column's new type on a type change,
+		# mirroring postgres's NUMERIC_VALUE_OUT_OF_RANGE so both engines raise the same error
+		return e.args and e.args[0] in (ER.TRUNCATED_WRONG_VALUE, ER.WARN_DATA_OUT_OF_RANGE)
 
 	@staticmethod
 	def is_db_table_size_limit(e: pymysql.Error) -> bool:

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -81,7 +81,9 @@ class MariaDBExceptionUtil:
 
 	@staticmethod
 	def is_data_truncated(e: MySQLdb.Error) -> bool:
-		return e.args and e.args[0] == ER.TRUNCATED_WRONG_VALUE
+		# WARN_DATA_OUT_OF_RANGE: a value that doesn't fit the column's new type on a type change,
+		# mirroring postgres's NUMERIC_VALUE_OUT_OF_RANGE so both engines raise the same error
+		return e.args and e.args[0] in (ER.TRUNCATED_WRONG_VALUE, ER.WARN_DATA_OUT_OF_RANGE)
 
 	@staticmethod
 	def is_db_table_size_limit(e: MySQLdb.Error) -> bool:

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -118,7 +118,13 @@ class PostgresTable(DBTable):
 				# Duration/Rating are nullable (not in NOT_NULL_TYPES), so keep blanks NULL.
 				using_clause = f"USING NULLIF(`{col.fieldname}`::text, '')::numeric"
 			elif col.fieldtype == "Int":
-				using_clause = f"USING COALESCE(NULLIF(`{col.fieldname}`::text, ''), '0')::numeric::int"
+				# cast to the actual target type: Int with length > 11 is a bigint column
+				# (Long Int), so a plain ::int would overflow its legitimate values; a standard
+				# Int stays int and still errors on out-of-range values (use Long Int for those).
+				int_type = get_definition(col.fieldtype, length=col.length)
+				using_clause = (
+					f"USING COALESCE(NULLIF(`{col.fieldname}`::text, ''), '0')::numeric::{int_type}"
+				)
 			elif col.fieldtype == "JSON":
 				using_clause = f"USING NULLIF(`{col.fieldname}`::text, '')::json"
 

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -144,6 +144,30 @@ class TestDBUpdate(IntegrationTestCase):
 		doctype.save()
 		frappe.get_doc(doctype=doctype.name, int_field=2**62 - 1).insert()
 
+	def test_bigint_conversion_with_existing_data(self):
+		# existing text data beyond int4 range must survive a Data -> Int(bigint) change; length > 11
+		# maps Int to a bigint column, so the postgres USING cast has to widen to bigint too
+		big_value = 2**40  # > int4 max (2,147,483,647)
+		doctype = new_doctype(fields=[{"fieldname": "big_field", "fieldtype": "Data"}]).insert()
+		doc = frappe.get_doc(doctype=doctype.name, big_field=str(big_value)).insert()
+
+		doctype.fields[0].fieldtype = "Int"
+		doctype.fields[0].length = 14
+		doctype.save()
+
+		self.assertEqual(frappe.db.get_value(doctype.name, doc.name, "big_field"), big_value)
+
+	def test_int_conversion_overflow_errors_on_standard_int(self):
+		# a standard Int column (int4) must still reject a value out of its range; only Int with
+		# length > 11 (a bigint column) may hold it
+		doctype = new_doctype(fields=[{"fieldname": "big_field", "fieldtype": "Data"}]).insert()
+		frappe.get_doc(doctype=doctype.name, big_field=str(2**40)).insert()
+
+		doctype.fields[0].fieldtype = "Int"  # no length -> standard int4 column
+		with self.assertRaises(frappe.ValidationError):
+			doctype.save()
+		frappe.db.rollback()
+
 	def test_unique_index_on_install(self):
 		"""Only one unique index should be added"""
 		for dt in frappe.get_all("DocType", {"is_virtual": 0, "issingle": 0}, pluck="name"):


### PR DESCRIPTION
Two related fixes for changing a field type over existing data.

### 1. Postgres: `Int` USING cast overflowed for `Long Int` columns
The `change_type` USING clause added in #40338 cast the `Int` branch through `::int` (int4). But an `Int` field with `length > 11` maps to a **bigint** column (`get_definition` → `Long Int`), so `::int` overflowed on its legitimate values > 2,147,483,647 and aborted the migrate. The branch now casts to whatever `get_definition` resolves for the field — the same call already used for the column type:

- **standard `Int`** → `int` column → `::int` → out-of-range value still errors (belongs in a Long Int field)
- **`Int` with `length > 11`** → `bigint` column → `::bigint` → legitimate big values convert

### 2. Cross-engine: out-of-range on type change now raises the same error
Surfacing #1 in a test exposed a divergence: Postgres wraps `NUMERIC_VALUE_OUT_OF_RANGE` into a friendly `ValidationError` ("Cannot change field type … some existing values cannot be converted"), but MariaDB’s `is_data_truncated` matched only `TRUNCATED_WRONG_VALUE` (1292) and leaked a raw `DataError` for `WARN_DATA_OUT_OF_RANGE` (1264). Now both MariaDB drivers (pymysql + mysqlclient) recognise 1264, so both engines raise the same `ValidationError`.

### Tests (verified on both Postgres and MariaDB)
- `test_bigint_conversion_with_existing_data` — a value beyond int4 range converted to `Int` `length=14` (bigint column) survives.
- `test_int_conversion_overflow_errors_on_standard_int` — the same value converted to a standard `Int` (int4 column) raises `ValidationError` on both engines, locking in that out-of-range values are rejected, not silently accepted.