### PR TITLE
feat: print format table merged cells

### DIFF
--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -164,6 +164,15 @@ function on_start_blank() {
 function handle_keydown(e) {
 	// Zoom shortcuts: Ctrl+= / Ctrl+- / Ctrl+0
 	if (e.ctrlKey || e.metaKey) {
+		if (e.key === "z" || e.key === "Z") {
+			// let inputs keep their own undo
+			const el = document.activeElement;
+			if (el?.tagName === "INPUT" || el?.tagName === "TEXTAREA" || el?.isContentEditable)
+				return;
+			e.preventDefault();
+			$store.value.undo();
+			return;
+		}
 		if (e.key === "=" || e.key === "+") {
 			e.preventDefault();
 			zoom_in();

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -426,13 +426,16 @@ function format_cell(row, col) {
 // Image fieldtypes that store a URL directly, so they can float left.
 const MERGE_IMAGE_FIELDTYPES = new Set(["Attach Image", "Attach"]);
 
+// The column's own field is always the implicit first (primary) line;
+// col.merged_fields holds only the extra fields merged in beside it.
 function merged_fields(col) {
-	return (col.merged_fields || []).filter((mf) => mf && mf.fieldname);
+	const extra = (col.merged_fields || []).filter((mf) => mf && mf.fieldname);
+	if (!extra.length) return [];
+	return [{ fieldname: col.fieldname, fieldtype: col.fieldtype, style: "primary" }, ...extra];
 }
 
-// A column is "merged" only once it has a second field beyond its own.
 function has_merge(col) {
-	return merged_fields(col).length > 1;
+	return (col.merged_fields || []).length > 0;
 }
 
 // The first merged field that is an image — rendered on the left.

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -102,46 +102,32 @@
 											: {}
 									"
 								>
-									<!-- Image + text: thumbnail on the left, merged fields stacked -->
-									<div
-										v-if="col.cell_layout === 'image_text'"
-										class="pf-cell-imgtext"
-									>
-										<img
-											v-if="cell_image(col, row)"
-											:src="cell_image(col, row)"
-											class="pf-cell-thumb-img"
-											:alt="col.label || col.fieldname"
-										/>
-										<span
-											v-else
-											class="pf-cell-thumb"
-											:style="thumb_style(col, row)"
-											>{{ thumb_abbr(col, row) }}</span
-										>
+									<!-- Merged cell: image (if any) floats left, text lines stack -->
+									<div v-if="has_merge(col)" class="pf-cell-merged">
+										<template v-if="image_merge(col)">
+											<img
+												v-if="cell_image(col, row)"
+												:src="cell_image(col, row)"
+												class="pf-cell-thumb-img"
+												:style="thumb_box(col)"
+												:alt="col.label || col.fieldname"
+											/>
+											<span
+												v-else
+												class="pf-cell-thumb"
+												:style="thumb_style(col, row)"
+												>{{ thumb_abbr(col, row) }}</span
+											>
+										</template>
 										<div class="pf-cell-lines">
 											<div
-												v-for="(mf, mi) in merged_lines(col)"
+												v-for="(mf, mi) in text_merges(col)"
 												:key="mi"
 												class="pf-merge-line"
 												:class="`pf-merge--${mf.style || 'primary'}`"
 											>
 												{{ format_merged(row, mf.fieldname) }}
 											</div>
-										</div>
-									</div>
-									<!-- Stacked: merged fields, one per line -->
-									<div
-										v-else-if="col.cell_layout === 'stacked'"
-										class="pf-cell-lines"
-									>
-										<div
-											v-for="(mf, mi) in merged_lines(col)"
-											:key="mi"
-											class="pf-merge-line"
-											:class="`pf-merge--${mf.style || 'primary'}`"
-										>
-											{{ format_merged(row, mf.fieldname) }}
 										</div>
 									</div>
 									<!-- Single (default) -->
@@ -440,13 +426,31 @@ function format_cell(row, col) {
 	}
 }
 
-// ── Merged / image-text cell helpers ───────────────────────
-function merged_lines(col) {
-	const list =
-		Array.isArray(col.merged_fields) && col.merged_fields.length
-			? col.merged_fields
-			: [{ fieldname: col.fieldname, style: "primary" }];
-	return list.filter((mf) => mf && mf.fieldname);
+// ── Merged cell helpers ────────────────────────────────────
+// Image fieldtypes that store a URL directly, so they can float left.
+const MERGE_IMAGE_FIELDTYPES = new Set(["Attach Image", "Attach"]);
+
+function merged_fields(col) {
+	return (col.merged_fields || []).filter((mf) => mf && mf.fieldname);
+}
+
+function has_merge(col) {
+	return merged_fields(col).length > 0;
+}
+
+function merge_fieldtype(mf) {
+	return mf.fieldtype || frappe.meta.get_docfield(props.df.options, mf.fieldname)?.fieldtype;
+}
+
+// The first merged field that is an image — rendered on the left.
+function image_merge(col) {
+	return merged_fields(col).find((mf) => MERGE_IMAGE_FIELDTYPES.has(merge_fieldtype(mf))) || null;
+}
+
+// Remaining fields render as stacked text lines.
+function text_merges(col) {
+	const img = image_merge(col);
+	return merged_fields(col).filter((mf) => mf !== img);
 }
 
 // Format a merged sub-field using its own child docfield definition
@@ -459,12 +463,23 @@ function format_merged(row, fieldname) {
 }
 
 function cell_image(col, row) {
-	const v = col.image_fieldname ? row[col.image_fieldname] : null;
+	const img = image_merge(col);
+	const v = img ? row[img.fieldname] : null;
 	return typeof v === "string" && v ? v : null;
 }
 
+function image_px(col) {
+	return col.image_size || 40;
+}
+
+function thumb_box(col) {
+	const s = image_px(col) + "px";
+	return { width: s, height: s };
+}
+
+// Initials fallback shown when an image field is merged but the row has none.
 function thumb_primary_text(col, row) {
-	const primary = merged_lines(col)[0]?.fieldname;
+	const primary = text_merges(col)[0]?.fieldname;
 	const raw = primary ? row[primary] : "";
 	return raw === null || raw === undefined ? "" : String(raw);
 }
@@ -475,7 +490,12 @@ function thumb_abbr(col, row) {
 
 function thumb_style(col, row) {
 	const palette = thumb_palette_for(thumb_primary_text(col, row));
-	return { background: palette.bg, color: palette.fg };
+	return {
+		...thumb_box(col),
+		fontSize: Math.round(image_px(col) * 0.4) + "px",
+		background: palette.bg,
+		color: palette.fg,
+	};
 }
 
 function select_field() {
@@ -1027,17 +1047,16 @@ watch(
 	display: block;
 }
 
-/* ── Merged / image-text cells ───────────────────────────── */
-.pf-cell-imgtext {
+/* ── Merged cells ────────────────────────────────────────── */
+.pf-cell-merged {
 	display: flex;
 	align-items: flex-start;
 	gap: 8px;
 }
 
+/* size comes from an inline style (col.image_size) */
 .pf-cell-thumb-img,
 .pf-cell-thumb {
-	width: 34px;
-	height: 34px;
 	border-radius: 6px;
 	flex-shrink: 0;
 }
@@ -1050,7 +1069,6 @@ watch(
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 11px;
 	font-weight: var(--weight-semibold);
 	text-transform: uppercase;
 	line-height: 1;

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -434,8 +434,9 @@ function merged_fields(col) {
 	return (col.merged_fields || []).filter((mf) => mf && mf.fieldname);
 }
 
+// A column is "merged" only once it has a second field beyond its own.
 function has_merge(col) {
-	return merged_fields(col).length > 0;
+	return merged_fields(col).length > 1;
 }
 
 function merge_fieldtype(mf) {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -445,7 +445,9 @@ function merge_fieldtype(mf) {
 
 // The first merged field that is an image — rendered on the left.
 function image_merge(col) {
-	return merged_fields(col).find((mf) => MERGE_IMAGE_FIELDTYPES.has(merge_fieldtype(mf))) || null;
+	return (
+		merged_fields(col).find((mf) => MERGE_IMAGE_FIELDTYPES.has(merge_fieldtype(mf))) || null
+	);
 }
 
 // Remaining fields render as stacked text lines.

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -124,7 +124,7 @@
 												v-for="(mf, mi) in text_merges(col)"
 												:key="mi"
 												class="pf-merge-line"
-												:class="`pf-merge--${mf.style || 'primary'}`"
+												:class="{ 'pf-merge-line--primary': mi === 0 }"
 											>
 												{{ format_merged(row, mf.fieldname) }}
 											</div>
@@ -287,12 +287,7 @@
 
 <script setup>
 import ConfigureColumnsVue from "../inspector/ConfigureColumns.vue";
-import {
-	render_jinja_html,
-	sanitize_html,
-	evaluate_visible_if,
-	thumb_palette_for,
-} from "../../utils";
+import { render_jinja_html, sanitize_html, evaluate_visible_if, thumb_hue } from "../../utils";
 import { createApp, ref, nextTick, watch, computed, inject } from "vue";
 
 const props = defineProps(["df", "field_orientation"]);
@@ -440,15 +435,9 @@ function has_merge(col) {
 	return merged_fields(col).length > 1;
 }
 
-function merge_fieldtype(mf) {
-	return mf.fieldtype || frappe.meta.get_docfield(props.df.options, mf.fieldname)?.fieldtype;
-}
-
 // The first merged field that is an image — rendered on the left.
 function image_merge(col) {
-	return (
-		merged_fields(col).find((mf) => MERGE_IMAGE_FIELDTYPES.has(merge_fieldtype(mf))) || null
-	);
+	return merged_fields(col).find((mf) => MERGE_IMAGE_FIELDTYPES.has(mf.fieldtype)) || null;
 }
 
 // Remaining fields render as stacked text lines.
@@ -489,14 +478,14 @@ function thumb_box(col) {
 // but the row has no image. Colour keyed off the first text field.
 function thumb(col, row) {
 	const raw = String(row[text_merges(col)[0]?.fieldname] ?? "");
-	const palette = thumb_palette_for(raw);
+	const hue = thumb_hue(raw);
 	return {
 		abbr: frappe.get_abbr(raw) || "?",
 		style: {
 			...thumb_box(col),
 			fontSize: Math.round((col.image_size || 40) * 0.4) + "px",
-			background: palette.bg,
-			color: palette.fg,
+			background: `hsl(${hue}, 65%, 92%)`,
+			color: `hsl(${hue}, 55%, 35%)`,
 		},
 	};
 }
@@ -1086,22 +1075,14 @@ watch(
 
 .pf-merge-line {
 	word-break: break-word;
-}
-
-.pf-merge--primary,
-.pf-merge--secondary {
-	color: var(--text-color);
-}
-.pf-merge--primary {
-	font-weight: var(--weight-semibold);
-}
-.pf-merge--mono-sm,
-.pf-merge--muted-sm {
 	font-size: 0.85em;
 	color: var(--text-muted);
 }
-.pf-merge--mono-sm {
-	font-family: var(--monospace-font-family, monospace);
+
+.pf-merge-line--primary {
+	font-size: 1em;
+	font-weight: var(--weight-semibold);
+	color: var(--text-color);
 }
 
 .preview-table-html {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -115,8 +115,8 @@
 											<span
 												v-else
 												class="pf-cell-thumb"
-												:style="thumb_style(col, row)"
-												>{{ thumb_abbr(col, row) }}</span
+												:style="thumb(col, row).style"
+												>{{ thumb(col, row).abbr }}</span
 											>
 										</template>
 										<div class="pf-cell-lines">
@@ -477,33 +477,24 @@ function cell_image(col, row) {
 	return typeof v === "string" && v ? v : null;
 }
 
-function image_px(col) {
-	return col.image_size || 40;
-}
-
 function thumb_box(col) {
-	const s = image_px(col) + "px";
+	const s = (col.image_size || 40) + "px";
 	return { width: s, height: s };
 }
 
-// Initials fallback shown when an image field is merged but the row has none.
-function thumb_primary_text(col, row) {
-	const primary = text_merges(col)[0]?.fieldname;
-	const raw = primary ? row[primary] : "";
-	return raw === null || raw === undefined ? "" : String(raw);
-}
-
-function thumb_abbr(col, row) {
-	return frappe.get_abbr(thumb_primary_text(col, row)) || "?";
-}
-
-function thumb_style(col, row) {
-	const palette = thumb_palette_for(thumb_primary_text(col, row));
+// Initials fallback (abbr + coloured box) when an image field is merged
+// but the row has no image. Colour keyed off the first text field.
+function thumb(col, row) {
+	const raw = String(row[text_merges(col)[0]?.fieldname] ?? "");
+	const palette = thumb_palette_for(raw);
 	return {
-		...thumb_box(col),
-		fontSize: Math.round(image_px(col) * 0.4) + "px",
-		background: palette.bg,
-		color: palette.fg,
+		abbr: frappe.get_abbr(raw) || "?",
+		style: {
+			...thumb_box(col),
+			fontSize: Math.round((col.image_size || 40) * 0.4) + "px",
+			background: palette.bg,
+			color: palette.fg,
+		},
 	};
 }
 
@@ -1094,24 +1085,20 @@ watch(
 	word-break: break-word;
 }
 
-.pf-merge--primary {
-	font-weight: var(--weight-semibold);
-	color: var(--text-color);
-}
-
+.pf-merge--primary,
 .pf-merge--secondary {
 	color: var(--text-color);
 }
-
-.pf-merge--mono-sm {
-	font-family: var(--monospace-font-family, monospace);
-	font-size: 0.85em;
-	color: var(--text-muted);
+.pf-merge--primary {
+	font-weight: var(--weight-semibold);
 }
-
+.pf-merge--mono-sm,
 .pf-merge--muted-sm {
 	font-size: 0.85em;
 	color: var(--text-muted);
+}
+.pf-merge--mono-sm {
+	font-family: var(--monospace-font-family, monospace);
 }
 
 .preview-table-html {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -453,13 +453,21 @@ function text_merges(col) {
 	return merged_fields(col).filter((mf) => mf !== img);
 }
 
-// Format a merged sub-field using its own child docfield definition
+// Format a merged sub-field using its own child docfield definition.
+// Merged lines are plain text, so strip any HTML kept for rich-text
+// fields (Text Editor / Long Text) down to its text content.
 function format_merged(row, fieldname) {
 	const dcol = frappe.meta.get_docfield(props.df.options, fieldname) || {
 		fieldname,
 		fieldtype: "Data",
 	};
-	return format_cell(row, dcol);
+	const val = format_cell(row, dcol);
+	if (typeof val === "string" && val.includes("<")) {
+		const tmp = document.createElement("div");
+		tmp.innerHTML = val;
+		return (tmp.textContent || tmp.innerText || "").trim();
+	}
+	return val;
 }
 
 function cell_image(col, row) {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -124,7 +124,7 @@
 												v-for="(mf, mi) in text_merges(col)"
 												:key="mi"
 												class="pf-merge-line"
-												:class="{ 'pf-merge-line--primary': mi === 0 }"
+												:class="`pf-merge--${mf.style || 'primary'}`"
 											>
 												{{ format_merged(row, mf.fieldname) }}
 											</div>
@@ -1075,14 +1075,21 @@ watch(
 
 .pf-merge-line {
 	word-break: break-word;
+}
+.pf-merge--primary,
+.pf-merge--secondary {
+	color: var(--text-color);
+}
+.pf-merge--primary {
+	font-weight: var(--weight-semibold);
+}
+.pf-merge--mono-sm,
+.pf-merge--muted-sm {
 	font-size: 0.85em;
 	color: var(--text-muted);
 }
-
-.pf-merge-line--primary {
-	font-size: 1em;
-	font-weight: var(--weight-semibold);
-	color: var(--text-color);
+.pf-merge--mono-sm {
+	font-family: var(--monospace-font-family, monospace);
 }
 
 .preview-table-html {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -386,7 +386,8 @@ const NUMERIC_FIELDTYPES = new Set(["Currency", "Float", "Int", "Percent"]);
 const HTML_CONTENT_FIELDTYPES = new Set(["Text Editor", "Long Text"]);
 
 function numeric_align_class(col) {
-	return NUMERIC_FIELDTYPES.has(col?.fieldtype) ? "col-numeric" : "";
+	// Merged cells are left-aligned (like the PDF), even on numeric columns
+	return !has_merge(col) && NUMERIC_FIELDTYPES.has(col?.fieldtype) ? "col-numeric" : "";
 }
 
 function multiselect_display(df) {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -102,21 +102,66 @@
 											: {}
 									"
 								>
-									<img
-										v-if="
-											is_image_field(col, row[col.fieldname]) &&
-											row[col.fieldname]
-										"
-										:src="row[col.fieldname]"
-										class="preview-table-img"
-										:alt="col.label || col.fieldname"
-									/>
+									<!-- Image + text: thumbnail on the left, merged fields stacked -->
 									<div
-										v-else-if="is_html_content_field(col)"
-										class="preview-table-html"
-										v-html="format_cell(row, col)"
-									></div>
-									<span v-else>{{ format_cell(row, col) }}</span>
+										v-if="col.cell_layout === 'image_text'"
+										class="pf-cell-imgtext"
+									>
+										<img
+											v-if="cell_image(col, row)"
+											:src="cell_image(col, row)"
+											class="pf-cell-thumb-img"
+											:alt="col.label || col.fieldname"
+										/>
+										<span
+											v-else
+											class="pf-cell-thumb"
+											:style="thumb_style(col, row)"
+											>{{ thumb_abbr(col, row) }}</span
+										>
+										<div class="pf-cell-lines">
+											<div
+												v-for="(mf, mi) in merged_lines(col)"
+												:key="mi"
+												class="pf-merge-line"
+												:class="`pf-merge--${mf.style || 'primary'}`"
+											>
+												{{ format_merged(row, mf.fieldname) }}
+											</div>
+										</div>
+									</div>
+									<!-- Stacked: merged fields, one per line -->
+									<div
+										v-else-if="col.cell_layout === 'stacked'"
+										class="pf-cell-lines"
+									>
+										<div
+											v-for="(mf, mi) in merged_lines(col)"
+											:key="mi"
+											class="pf-merge-line"
+											:class="`pf-merge--${mf.style || 'primary'}`"
+										>
+											{{ format_merged(row, mf.fieldname) }}
+										</div>
+									</div>
+									<!-- Single (default) -->
+									<template v-else>
+										<img
+											v-if="
+												is_image_field(col, row[col.fieldname]) &&
+												row[col.fieldname]
+											"
+											:src="row[col.fieldname]"
+											class="preview-table-img"
+											:alt="col.label || col.fieldname"
+										/>
+										<div
+											v-else-if="is_html_content_field(col)"
+											class="preview-table-html"
+											v-html="format_cell(row, col)"
+										></div>
+										<span v-else>{{ format_cell(row, col) }}</span>
+									</template>
 								</td>
 							</tr>
 							<tr v-if="!preview_doc[df.fieldname]?.length">
@@ -256,7 +301,12 @@
 
 <script setup>
 import ConfigureColumnsVue from "../inspector/ConfigureColumns.vue";
-import { render_jinja_html, sanitize_html, evaluate_visible_if } from "../../utils";
+import {
+	render_jinja_html,
+	sanitize_html,
+	evaluate_visible_if,
+	thumb_palette_for,
+} from "../../utils";
 import { createApp, ref, nextTick, watch, computed, inject } from "vue";
 
 const props = defineProps(["df", "field_orientation"]);
@@ -388,6 +438,44 @@ function format_cell(row, col) {
 	} catch {
 		return String(raw);
 	}
+}
+
+// ── Merged / image-text cell helpers ───────────────────────
+function merged_lines(col) {
+	const list =
+		Array.isArray(col.merged_fields) && col.merged_fields.length
+			? col.merged_fields
+			: [{ fieldname: col.fieldname, style: "primary" }];
+	return list.filter((mf) => mf && mf.fieldname);
+}
+
+// Format a merged sub-field using its own child docfield definition
+function format_merged(row, fieldname) {
+	const dcol = frappe.meta.get_docfield(props.df.options, fieldname) || {
+		fieldname,
+		fieldtype: "Data",
+	};
+	return format_cell(row, dcol);
+}
+
+function cell_image(col, row) {
+	const v = col.image_fieldname ? row[col.image_fieldname] : null;
+	return typeof v === "string" && v ? v : null;
+}
+
+function thumb_primary_text(col, row) {
+	const primary = merged_lines(col)[0]?.fieldname;
+	const raw = primary ? row[primary] : "";
+	return raw === null || raw === undefined ? "" : String(raw);
+}
+
+function thumb_abbr(col, row) {
+	return frappe.get_abbr(thumb_primary_text(col, row)) || "?";
+}
+
+function thumb_style(col, row) {
+	const palette = thumb_palette_for(thumb_primary_text(col, row));
+	return { background: palette.bg, color: palette.fg };
 }
 
 function select_field() {
@@ -937,6 +1025,66 @@ watch(
 	max-width: 80px;
 	object-fit: contain;
 	display: block;
+}
+
+/* ── Merged / image-text cells ───────────────────────────── */
+.pf-cell-imgtext {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+}
+
+.pf-cell-thumb-img,
+.pf-cell-thumb {
+	width: 34px;
+	height: 34px;
+	border-radius: 6px;
+	flex-shrink: 0;
+}
+
+.pf-cell-thumb-img {
+	object-fit: cover;
+}
+
+.pf-cell-thumb {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 11px;
+	font-weight: var(--weight-semibold);
+	text-transform: uppercase;
+	line-height: 1;
+}
+
+.pf-cell-lines {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+.pf-merge-line {
+	word-break: break-word;
+}
+
+.pf-merge--primary {
+	font-weight: var(--weight-semibold);
+	color: var(--text-color);
+}
+
+.pf-merge--secondary {
+	color: var(--text-color);
+}
+
+.pf-merge--mono-sm {
+	font-family: var(--monospace-font-family, monospace);
+	font-size: 0.85em;
+	color: var(--text-muted);
+}
+
+.pf-merge--muted-sm {
+	font-size: 0.85em;
+	color: var(--text-muted);
 }
 
 .preview-table-html {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -232,10 +232,10 @@
 											:class="{
 												active:
 													col.merged_fields &&
-													col.merged_fields.length > 1,
+													col.merged_fields.length > 0,
 												open: expanded_col === ci,
 											}"
-											@click="toggle_col(ci)"
+											@click="expanded_col = expanded_col === ci ? null : ci"
 											:title="__('Merge fields')"
 											v-html="frappe.utils.icon('settings-2', 'xs')"
 										></button>
@@ -298,12 +298,6 @@
 													</select>
 													<button
 														class="pfb-col-remove"
-														:style="
-															is_base_merge(col, mf)
-																? 'visibility: hidden'
-																: ''
-														"
-														:disabled="is_base_merge(col, mf)"
 														@click="remove_merged_field(col, mi)"
 														:title="__('Remove field')"
 														v-html="frappe.utils.icon('x', 'xs')"
@@ -1118,24 +1112,6 @@ const merge_style_opts = [
 	{ value: "muted-sm", label: __("Muted") },
 ];
 
-function toggle_col(ci) {
-	const next = expanded_col.value === ci ? null : ci;
-	expanded_col.value = next;
-	if (next === null) return;
-	// Opening the editor means "merge into this column": always show the
-	// column's own field as the (non-removable) primary line.
-	const col = selected_field.value.table_columns[next];
-	const mf = ensure_merged(col);
-	if (!mf.some((m) => m.fieldname === col.fieldname)) {
-		const own = find_field(col.fieldname);
-		mf.unshift({
-			fieldname: col.fieldname,
-			fieldtype: own?.fieldtype || col.fieldtype || "Data",
-			style: "primary",
-		});
-	}
-}
-
 // Value-holding fields of the child doctype, for the merged-field pickers.
 let child_fields = computed(() => {
 	const dt = selected_field.value?.options;
@@ -1152,18 +1128,15 @@ function merge_field_label(mf) {
 	return find_field(mf.fieldname)?.label || mf.fieldname;
 }
 
-// Child fields not yet merged into this column, for the "Add field..."
-// autocomplete — same {label, value, badge} shape as available_column_opts.
+// Child fields not yet merged into this column (the column's own field is
+// always the implicit primary line, so it's excluded here too) — for the
+// "Add field..." autocomplete, same {label, value, badge} shape as
+// available_column_opts.
 function merge_field_opts(col) {
-	const used = new Set((col.merged_fields || []).map((m) => m.fieldname));
+	const used = new Set([col.fieldname, ...(col.merged_fields || []).map((m) => m.fieldname)]);
 	return child_fields.value
 		.filter((f) => !used.has(f.fieldname))
 		.map((f) => ({ label: f.label || f.fieldname, value: f.fieldname, badge: f.fieldtype }));
-}
-
-// The base row is the column's own field — locked and not removable.
-function is_base_merge(col, mf) {
-	return mf.fieldname === col.fieldname;
 }
 
 function is_image_merge(mf) {
@@ -1171,7 +1144,9 @@ function is_image_merge(mf) {
 }
 
 function has_image_merge(col) {
-	return (col.merged_fields || []).some(is_image_merge);
+	return (
+		IMAGE_COL_FIELDTYPES.has(col.fieldtype) || (col.merged_fields || []).some(is_image_merge)
+	);
 }
 
 function ensure_merged(col) {
@@ -1179,13 +1154,15 @@ function ensure_merged(col) {
 	return col.merged_fields;
 }
 
+// First added field defaults to Secondary (own field is already primary), rest Muted.
 function add_merged_field(col, fieldname) {
 	const f = find_field(fieldname);
+	const mf = ensure_merged(col);
 	if (f)
-		ensure_merged(col).push({
+		mf.push({
 			fieldname: f.fieldname,
 			fieldtype: f.fieldtype,
-			style: "muted-sm",
+			style: mf.length ? "muted-sm" : "secondary",
 		});
 }
 
@@ -1862,7 +1839,7 @@ function set_section_cell_padding(value) {
 }
 
 .pfb-col-editor {
-	background: var(--fg-color);
+	background: var(--gray-50);
 	border-top: 1px solid var(--gray-100);
 	padding-bottom: 6px;
 }

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -1839,11 +1839,11 @@ function set_section_cell_padding(value) {
 }
 
 .pfb-col-editor {
-	background: var(--gray-50);
-	border-top: 1px solid var(--gray-100);
-	border-left: 2px solid var(--gray-300);
-	margin-left: 10px;
-	padding-bottom: 6px;
+	margin: 6px 10px 10px;
+	background: var(--fg-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	overflow: hidden;
 }
 
 /* Rows inside the merge editor are always in an active-editing context, so

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -272,54 +272,20 @@
 														class="pfb-merge-drag"
 														v-html="frappe.utils.icon('drag', 'xs')"
 													></span>
-													<input
-														v-if="is_base_merge(col, mf)"
-														class="pfb-insp-input"
-														style="flex: 1; min-width: 0"
-														:value="merge_field_label(mf)"
-														:title="__('This column\'s own field')"
-														disabled
-													/>
-													<select
-														v-else
-														class="pfb-insp-select"
-														style="flex: 1; min-width: 0"
-														:value="mf.fieldname"
-														@change="
-															set_merged_field(
-																mf,
-																$event.target.value
-															)
+													<span
+														class="pfb-insp-label"
+														style="
+															flex: 1;
+															min-width: 0;
+															color: var(--text-color);
 														"
+														>{{ merge_field_label(mf) }}</span
 													>
-														<option
-															v-for="f in merge_field_opts(col, mf)"
-															:key="f.fieldname"
-															:value="f.fieldname"
-														>
-															{{ f.label }}
-														</option>
-													</select>
 													<span
 														v-if="is_image_merge(mf)"
 														class="pfb-type-badge"
 														>{{ __("Image") }}</span
 													>
-													<select
-														v-else
-														class="pfb-insp-select"
-														style="width: 96px; flex: none"
-														v-model="mf.style"
-														:title="__('Text style')"
-													>
-														<option
-															v-for="s in merge_style_opts"
-															:key="s.value"
-															:value="s.value"
-														>
-															{{ s.label }}
-														</option>
-													</select>
 													<button
 														v-if="!is_base_merge(col, mf)"
 														class="pfb-col-remove"
@@ -330,27 +296,16 @@
 												</div>
 											</template>
 										</draggable>
-										<div class="pfb-col-add-row">
-											<button
-												class="btn btn-xs btn-default"
-												@click="add_merged_field(col)"
-											>
-												<span
-													v-html="frappe.utils.icon('add', 'xs')"
-												></span>
-												{{ __("Add field") }}
-											</button>
-										</div>
-										<p
-											class="pfb-insp-hint text-muted"
-											style="padding: 0 14px 8px"
+										<div
+											class="pfb-col-add-row"
+											v-if="merge_field_opts(col).length"
 										>
-											{{
-												__(
-													"Add fields to merge into this column. An image field is shown on the left."
-												)
-											}}
-										</p>
+											<Autocomplete
+												:options="merge_field_opts(col)"
+												:placeholder="__('Add field...')"
+												@select="(opt) => add_merged_field(col, opt.value)"
+											/>
+										</div>
 										<div
 											v-if="has_image_merge(col)"
 											class="pfb-insp-row"
@@ -1136,14 +1091,6 @@ function clamp_width(col) {
 // merged fields is an image, it renders on the left (see Field.vue /
 // Table.html); the rest stack as styled text lines.
 let expanded_col = ref(null);
-const DEFAULT_IMAGE_SIZE = 40;
-
-const merge_style_opts = [
-	{ value: "primary", label: __("Primary") },
-	{ value: "secondary", label: __("Secondary") },
-	{ value: "mono-sm", label: __("Code") },
-	{ value: "muted-sm", label: __("Muted") },
-];
 
 // Fieldtypes that store an image URL directly, so they can float left.
 const IMAGE_COL_FIELDTYPES = new Set(["Attach Image", "Attach"]);
@@ -1151,18 +1098,17 @@ const IMAGE_COL_FIELDTYPES = new Set(["Attach Image", "Attach"]);
 function toggle_col(ci) {
 	const next = expanded_col.value === ci ? null : ci;
 	expanded_col.value = next;
+	if (next === null) return;
 	// Opening the editor means "merge into this column": always show the
 	// column's own field as the (non-removable) primary line.
-	if (next !== null) {
-		const col = selected_field.value.table_columns[next];
-		const mf = ensure_merged(col);
-		if (!mf.some((m) => m.fieldname === col.fieldname)) {
-			mf.unshift({
-				fieldname: col.fieldname,
-				fieldtype: own_fieldtype(col),
-				style: "primary",
-			});
-		}
+	const col = selected_field.value.table_columns[next];
+	const mf = ensure_merged(col);
+	if (!mf.some((m) => m.fieldname === col.fieldname)) {
+		const own = find_field(col.fieldname);
+		mf.unshift({
+			fieldname: col.fieldname,
+			fieldtype: own?.fieldtype || col.fieldtype || "Data",
+		});
 	}
 }
 
@@ -1174,31 +1120,26 @@ let child_fields = computed(() => {
 	return meta.fields.filter((f) => !frappe.model.no_value_type.includes(f.fieldtype));
 });
 
-function own_fieldtype(col) {
-	return (
-		child_fields.value.find((f) => f.fieldname === col.fieldname)?.fieldtype ||
-		col.fieldtype ||
-		"Data"
-	);
+function find_field(fieldname) {
+	return child_fields.value.find((f) => f.fieldname === fieldname);
 }
 
-// Options for a merged-field select: exclude fields already used by other
-// rows so each fieldname stays unique (keeps it a valid list key).
-function merge_field_opts(col, current) {
+function merge_field_label(mf) {
+	return find_field(mf.fieldname)?.label || mf.fieldname;
+}
+
+// Child fields not yet merged into this column, for the "Add field..."
+// autocomplete — same {label, value, badge} shape as available_column_opts.
+function merge_field_opts(col) {
 	const used = new Set((col.merged_fields || []).map((m) => m.fieldname));
-	used.delete(current.fieldname);
 	return child_fields.value
 		.filter((f) => !used.has(f.fieldname))
-		.map((f) => ({ fieldname: f.fieldname, label: f.label || f.fieldname }));
+		.map((f) => ({ label: f.label || f.fieldname, value: f.fieldname, badge: f.fieldtype }));
 }
 
 // The base row is the column's own field — locked and not removable.
 function is_base_merge(col, mf) {
 	return mf.fieldname === col.fieldname;
-}
-
-function merge_field_label(mf) {
-	return child_fields.value.find((f) => f.fieldname === mf.fieldname)?.label || mf.fieldname;
 }
 
 function is_image_merge(mf) {
@@ -1214,18 +1155,9 @@ function ensure_merged(col) {
 	return col.merged_fields;
 }
 
-function add_merged_field(col) {
-	const mf = ensure_merged(col);
-	const used = new Set(mf.map((m) => m.fieldname));
-	const next = child_fields.value.find((f) => !used.has(f.fieldname));
-	if (!next) return; // every field already merged
-	mf.push({ fieldname: next.fieldname, fieldtype: next.fieldtype, style: "muted-sm" });
-}
-
-// Keep the stored fieldtype in sync so image detection works server-side.
-function set_merged_field(mf, fieldname) {
-	mf.fieldname = fieldname;
-	mf.fieldtype = child_fields.value.find((f) => f.fieldname === fieldname)?.fieldtype || "Data";
+function add_merged_field(col, fieldname) {
+	const f = find_field(fieldname);
+	if (f) ensure_merged(col).push({ fieldname: f.fieldname, fieldtype: f.fieldtype });
 }
 
 function remove_merged_field(col, mi) {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -1832,7 +1832,6 @@ function set_section_cell_padding(value) {
 	background: var(--fg-color);
 	border: 1px solid var(--border-color);
 	border-radius: var(--radius);
-	overflow: hidden;
 }
 
 /* Rows inside the merge editor are always in an active-editing context, so

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -281,15 +281,10 @@
 														"
 														>{{ merge_field_label(mf) }}</span
 													>
-													<span
-														v-if="is_image_merge(mf)"
-														class="pfb-type-badge"
-														>{{ __("Image") }}</span
-													>
 													<select
-														v-else
+														v-if="!is_image_merge(mf)"
 														class="pfb-insp-select"
-														style="width: 92px; flex: none"
+														style="width: 104px; flex: none"
 														v-model="mf.style"
 														:title="__('Text style')"
 													>
@@ -302,8 +297,13 @@
 														</option>
 													</select>
 													<button
-														v-if="!is_base_merge(col, mf)"
 														class="pfb-col-remove"
+														:style="
+															is_base_merge(col, mf)
+																? 'visibility: hidden'
+																: ''
+														"
+														:disabled="is_base_merge(col, mf)"
 														@click="remove_merged_field(col, mi)"
 														:title="__('Remove field')"
 														v-html="frappe.utils.icon('x', 'xs')"
@@ -1862,7 +1862,7 @@ function set_section_cell_padding(value) {
 }
 
 .pfb-col-editor {
-	background: var(--subtle-accent);
+	background: var(--fg-color);
 	border-top: 1px solid var(--gray-100);
 	padding-bottom: 6px;
 }

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -227,12 +227,12 @@
 											class="pfb-col-config"
 											:class="{
 												active:
-													col.cell_layout &&
-													col.cell_layout !== 'single',
+													col.merged_fields &&
+													col.merged_fields.length,
 												open: expanded_col === ci,
 											}"
 											@click="toggle_col(ci)"
-											:title="__('Cell layout & merged fields')"
+											:title="__('Merge fields')"
 											v-html="frappe.utils.icon('settings-2', 'xs')"
 										></button>
 										<input
@@ -253,129 +253,122 @@
 										></button>
 									</div>
 
-									<!-- Per-column cell layout + merged fields editor -->
+									<!-- Per-column merged-fields editor -->
 									<div v-if="expanded_col === ci" class="pfb-col-editor">
-										<div class="pfb-insp-row">
-											<span class="pfb-insp-label">{{ __("Cell") }}</span>
-											<div class="pfb-seg">
-												<button
-													v-for="opt in cell_layout_opts"
-													:key="opt.value"
-													:class="{
-														active:
-															(col.cell_layout || 'single') ===
-															opt.value,
-													}"
-													@click="set_cell_layout(col, opt.value)"
-												>
-													{{ opt.label }}
-												</button>
-											</div>
-										</div>
-
-										<div
-											v-if="col.cell_layout === 'image_text'"
-											class="pfb-insp-row"
-										>
-											<span class="pfb-insp-label">{{ __("Image") }}</span>
-											<select
-												class="pfb-insp-select"
-												:value="col.image_fieldname || ''"
-												@change="col.image_fieldname = $event.target.value"
+										<div class="pfb-merge-head">
+											<span class="pfb-insp-label">{{
+												__("Merged fields")
+											}}</span>
+											<button
+												class="pfb-merge-add"
+												@click="add_merged_field(col)"
 											>
-												<option value="">
-													{{ __("Initials only") }}
-												</option>
-												<option
-													v-for="f in image_field_opts"
-													:key="f.fieldname"
-													:value="f.fieldname"
-												>
-													{{ f.label }}
-												</option>
-											</select>
+												<span
+													v-html="frappe.utils.icon('add', 'xs')"
+												></span>
+												{{ __("Add field") }}
+											</button>
 										</div>
-
-										<template
-											v-if="
-												col.cell_layout === 'stacked' ||
-												col.cell_layout === 'image_text'
-											"
+										<draggable
+											:list="col.merged_fields"
+											handle=".pfb-merge-drag"
+											:animation="150"
+											item-key="fieldname"
+											class="pfb-merge-list"
 										>
-											<div class="pfb-merge-head">
-												<span class="pfb-insp-label">{{
-													__("Merged fields")
-												}}</span>
-												<button
-													class="pfb-merge-add"
-													@click="add_merged_field(col)"
-												>
+											<template #item="{ element: mf, index: mi }">
+												<div class="pfb-merge-row">
 													<span
-														v-html="frappe.utils.icon('add', 'xs')"
+														class="pfb-merge-drag"
+														v-html="frappe.utils.icon('drag', 'xs')"
 													></span>
-													{{ __("Add") }}
-												</button>
+													<select
+														class="pfb-merge-field"
+														:value="mf.fieldname"
+														@change="
+															set_merged_field(
+																mf,
+																$event.target.value
+															)
+														"
+													>
+														<option
+															v-for="f in merge_field_opts(col, mf)"
+															:key="f.fieldname"
+															:value="f.fieldname"
+														>
+															{{ f.label }}
+														</option>
+													</select>
+													<span
+														v-if="is_image_merge(mf)"
+														class="pfb-merge-tag"
+														>{{ __("Image") }}</span
+													>
+													<select
+														v-else
+														class="pfb-merge-style"
+														v-model="mf.style"
+														:title="__('Text style')"
+													>
+														<option
+															v-for="s in merge_style_opts"
+															:key="s.value"
+															:value="s.value"
+														>
+															{{ s.label }}
+														</option>
+													</select>
+													<button
+														class="pfb-col-remove"
+														@click="remove_merged_field(col, mi)"
+														:title="__('Remove field')"
+														v-html="frappe.utils.icon('x', 'xs')"
+													></button>
+												</div>
+											</template>
+										</draggable>
+										<p
+											v-if="col.merged_fields && col.merged_fields.length"
+											class="pfb-merge-hint"
+										>
+											{{
+												__(
+													"Add two or more fields to merge them into one cell. An image field is shown on the left."
+												)
+											}}
+										</p>
+										<p v-else class="pfb-merge-hint">
+											{{
+												__(
+													"Merge several child fields into this column."
+												)
+											}}
+										</p>
+
+										<!-- Image size (only when a merged image field is present) -->
+										<div v-if="has_image_merge(col)" class="pfb-insp-row">
+											<span class="pfb-insp-label">{{
+												__("Image size")
+											}}</span>
+											<div class="pfb-merge-size">
+												<input
+													type="range"
+													class="pfb-lh-slider"
+													min="24"
+													max="96"
+													step="4"
+													:value="col.image_size || 40"
+													@input="
+														col.image_size =
+															Number($event.target.value)
+													"
+												/>
+												<span class="pfb-merge-size-val"
+													>{{ col.image_size || 40 }}px</span
+												>
 											</div>
-											<draggable
-												:list="col.merged_fields"
-												handle=".pfb-merge-drag"
-												:animation="150"
-												item-key="fieldname"
-												class="pfb-merge-list"
-											>
-												<template #item="{ element: mf, index: mi }">
-													<div class="pfb-merge-row">
-														<span
-															class="pfb-merge-drag"
-															v-html="
-																frappe.utils.icon('drag', 'xs')
-															"
-														></span>
-														<select
-															class="pfb-merge-field"
-															v-model="mf.fieldname"
-														>
-															<option
-																v-for="f in merge_field_opts(
-																	col,
-																	mf
-																)"
-																:key="f.fieldname"
-																:value="f.fieldname"
-															>
-																{{ f.label }}
-															</option>
-														</select>
-														<select
-															class="pfb-merge-style"
-															v-model="mf.style"
-															:title="__('Text style')"
-														>
-															<option
-																v-for="s in merge_style_opts"
-																:key="s.value"
-																:value="s.value"
-															>
-																{{ s.label }}
-															</option>
-														</select>
-														<button
-															class="pfb-col-remove"
-															@click="remove_merged_field(col, mi)"
-															:title="__('Remove field')"
-															v-html="frappe.utils.icon('x', 'xs')"
-														></button>
-													</div>
-												</template>
-											</draggable>
-											<p class="pfb-merge-hint">
-												{{
-													__(
-														"First field drives the thumbnail initials. Drag to reorder."
-													)
-												}}
-											</p>
-										</template>
+										</div>
 									</div>
 								</div>
 							</template>
@@ -1128,14 +1121,12 @@ function clamp_width(col) {
 	col.width = Math.max(5, Math.min(100, parseInt(col.width) || 10));
 }
 
-// ── Per-column cell layout + merged fields ─────────────────
+// ── Per-column merged fields ───────────────────────────────
+// A column can merge several child fields into one cell. If one of the
+// merged fields is an image, it renders on the left (see Field.vue /
+// Table.html); the rest stack as styled text lines.
 let expanded_col = ref(null);
-
-const cell_layout_opts = [
-	{ value: "single", label: __("Single") },
-	{ value: "stacked", label: __("Stacked") },
-	{ value: "image_text", label: __("Image + text") },
-];
+const DEFAULT_IMAGE_SIZE = 40;
 
 const merge_style_opts = [
 	{ value: "primary", label: __("Primary") },
@@ -1144,22 +1135,17 @@ const merge_style_opts = [
 	{ value: "muted-sm", label: __("Muted") },
 ];
 
-// Only fieldtypes that store the image URL directly in the field can be
-// picked as the cell image; "Image" resolves its URL via another field.
+// Fieldtypes that store an image URL directly, so they can float left.
 const IMAGE_COL_FIELDTYPES = new Set(["Attach Image", "Attach"]);
 
 function toggle_col(ci) {
 	const next = expanded_col.value === ci ? null : ci;
 	expanded_col.value = next;
-	// Normalise a (possibly persisted) merged column so its editor is never empty
-	if (next !== null) {
-		const col = selected_field.value.table_columns[next];
-		if (col.cell_layout && col.cell_layout !== "single") seed_merged(col);
-	}
+	// Give the draggable a real array to bind to; empty = plain single cell.
+	if (next !== null) ensure_merged(selected_field.value.table_columns[next]);
 }
 
-// Value-holding fields of the child doctype — shared by the merged-field
-// pickers and the image-field picker.
+// Value-holding fields of the child doctype, for the merged-field pickers.
 let child_fields = computed(() => {
 	const dt = selected_field.value?.options;
 	const meta = dt && frappe.get_meta(dt);
@@ -1167,21 +1153,22 @@ let child_fields = computed(() => {
 	return meta.fields.filter((f) => !frappe.model.no_value_type.includes(f.fieldtype));
 });
 
-function field_opt(f) {
-	return { fieldname: f.fieldname, label: f.label || f.fieldname };
-}
-
-let child_field_opts = computed(() => child_fields.value.map(field_opt));
-let image_field_opts = computed(() =>
-	child_fields.value.filter((f) => IMAGE_COL_FIELDTYPES.has(f.fieldtype)).map(field_opt)
-);
-
 // Options for a merged-field select: exclude fields already used by other
 // rows so each fieldname stays unique (keeps it a valid list key).
 function merge_field_opts(col, current) {
 	const used = new Set((col.merged_fields || []).map((m) => m.fieldname));
 	used.delete(current.fieldname);
-	return child_field_opts.value.filter((f) => !used.has(f.fieldname));
+	return child_fields.value
+		.filter((f) => !used.has(f.fieldname))
+		.map((f) => ({ fieldname: f.fieldname, label: f.label || f.fieldname }));
+}
+
+function is_image_merge(mf) {
+	return IMAGE_COL_FIELDTYPES.has(mf.fieldtype);
+}
+
+function has_image_merge(col) {
+	return (col.merged_fields || []).some(is_image_merge);
 }
 
 function ensure_merged(col) {
@@ -1189,24 +1176,22 @@ function ensure_merged(col) {
 	return col.merged_fields;
 }
 
-// Guarantee at least one line so a merged cell is never empty
-function seed_merged(col) {
-	const mf = ensure_merged(col);
-	if (!mf.length) mf.push({ fieldname: col.fieldname, style: "primary" });
-	return mf;
-}
-
-function set_cell_layout(col, value) {
-	col.cell_layout = value;
-	if (value !== "single") seed_merged(col);
-}
-
 function add_merged_field(col) {
 	const mf = ensure_merged(col);
 	const used = new Set(mf.map((m) => m.fieldname));
-	const next = child_field_opts.value.find((f) => !used.has(f.fieldname));
+	const next = child_fields.value.find((f) => !used.has(f.fieldname));
 	if (!next) return; // every field already merged
-	mf.push({ fieldname: next.fieldname, style: mf.length ? "muted-sm" : "primary" });
+	mf.push({
+		fieldname: next.fieldname,
+		fieldtype: next.fieldtype,
+		style: mf.length ? "muted-sm" : "primary",
+	});
+}
+
+// Keep the stored fieldtype in sync so image detection works server-side.
+function set_merged_field(mf, fieldname) {
+	mf.fieldname = fieldname;
+	mf.fieldtype = child_fields.value.find((f) => f.fieldname === fieldname)?.fieldtype || "Data";
 }
 
 function remove_merged_field(col, mi) {
@@ -1941,6 +1926,37 @@ function set_section_cell_padding(value) {
 	color: var(--text-muted);
 	margin: 0;
 	line-height: 1.4;
+}
+
+/* Image badge shown in place of the text-style select for image fields */
+.pfb-merge-tag {
+	width: 84px;
+	flex-shrink: 0;
+	text-align: center;
+	font-size: var(--text-tiny);
+	color: var(--text-muted);
+	background: var(--gray-100);
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	padding: 4px 4px;
+}
+
+.pfb-merge-size {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.pfb-merge-size .pfb-lh-slider {
+	flex: 1;
+	min-width: 0;
+}
+
+.pfb-merge-size-val {
+	font-size: var(--text-tiny);
+	color: var(--text-muted);
+	white-space: nowrap;
+	flex-shrink: 0;
 }
 
 /* ── Letter Head inspector ───────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -286,6 +286,21 @@
 														class="pfb-type-badge"
 														>{{ __("Image") }}</span
 													>
+													<select
+														v-else
+														class="pfb-insp-select"
+														style="width: 92px; flex: none"
+														v-model="mf.style"
+														:title="__('Text style')"
+													>
+														<option
+															v-for="s in merge_style_opts"
+															:key="s.value"
+															:value="s.value"
+														>
+															{{ s.label }}
+														</option>
+													</select>
 													<button
 														v-if="!is_base_merge(col, mf)"
 														class="pfb-col-remove"
@@ -1095,6 +1110,14 @@ let expanded_col = ref(null);
 // Fieldtypes that store an image URL directly, so they can float left.
 const IMAGE_COL_FIELDTYPES = new Set(["Attach Image", "Attach"]);
 
+// Text style per merged line (drives the cell-line--* class in Field.vue / Table.html).
+const merge_style_opts = [
+	{ value: "primary", label: __("Primary") },
+	{ value: "secondary", label: __("Secondary") },
+	{ value: "mono-sm", label: __("Code") },
+	{ value: "muted-sm", label: __("Muted") },
+];
+
 function toggle_col(ci) {
 	const next = expanded_col.value === ci ? null : ci;
 	expanded_col.value = next;
@@ -1108,6 +1131,7 @@ function toggle_col(ci) {
 		mf.unshift({
 			fieldname: col.fieldname,
 			fieldtype: own?.fieldtype || col.fieldtype || "Data",
+			style: "primary",
 		});
 	}
 }
@@ -1157,7 +1181,12 @@ function ensure_merged(col) {
 
 function add_merged_field(col, fieldname) {
 	const f = find_field(fieldname);
-	if (f) ensure_merged(col).push({ fieldname: f.fieldname, fieldtype: f.fieldtype });
+	if (f)
+		ensure_merged(col).push({
+			fieldname: f.fieldname,
+			fieldtype: f.fieldtype,
+			style: "muted-sm",
+		});
 }
 
 function remove_merged_field(col, mi) {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -214,34 +214,169 @@
 							class="pfb-col-list"
 						>
 							<template #item="{ element: col, index: ci }">
-								<div class="pfb-col-row">
-									<span
-										class="pfb-col-drag"
-										v-html="frappe.utils.icon('drag', 'xs')"
-									></span>
-									<input
-										class="pfb-col-label-input"
-										type="text"
-										v-model="col.label"
-										:placeholder="col.fieldname"
-										:title="col.fieldname"
-									/>
-									<input
-										class="pfb-col-width-input"
-										type="number"
-										min="5"
-										max="100"
-										v-model.number="col.width"
-										@blur="clamp_width(col)"
-										:title="__('Width %')"
-									/>
-									<span class="pfb-col-width-unit">%</span>
-									<button
-										class="pfb-col-remove"
-										@click="remove_table_column(ci)"
-										:title="__('Remove column')"
-										v-html="frappe.utils.icon('x', 'xs')"
-									></button>
+								<div class="pfb-col-item">
+									<div class="pfb-col-row">
+										<span
+											class="pfb-col-drag"
+											v-html="frappe.utils.icon('drag', 'xs')"
+										></span>
+										<span class="pfb-col-label" :title="col.fieldname">{{
+											col.label || col.fieldname
+										}}</span>
+										<button
+											class="pfb-col-config"
+											:class="{
+												active:
+													col.cell_layout &&
+													col.cell_layout !== 'single',
+												open: expanded_col === ci,
+											}"
+											@click="toggle_col(ci)"
+											:title="__('Cell layout & merged fields')"
+											v-html="frappe.utils.icon('settings-2', 'xs')"
+										></button>
+										<input
+											class="pfb-col-width-input"
+											type="number"
+											min="5"
+											max="100"
+											v-model.number="col.width"
+											@blur="clamp_width(col)"
+											:title="__('Width %')"
+										/>
+										<span class="pfb-col-width-unit">%</span>
+										<button
+											class="pfb-col-remove"
+											@click="remove_table_column(ci)"
+											:title="__('Remove column')"
+											v-html="frappe.utils.icon('x', 'xs')"
+										></button>
+									</div>
+
+									<!-- Per-column cell layout + merged fields editor -->
+									<div v-if="expanded_col === ci" class="pfb-col-editor">
+										<div class="pfb-insp-row">
+											<span class="pfb-insp-label">{{ __("Cell") }}</span>
+											<div class="pfb-seg">
+												<button
+													v-for="opt in cell_layout_opts"
+													:key="opt.value"
+													:class="{
+														active:
+															(col.cell_layout || 'single') ===
+															opt.value,
+													}"
+													@click="set_cell_layout(col, opt.value)"
+												>
+													{{ opt.label }}
+												</button>
+											</div>
+										</div>
+
+										<div
+											v-if="col.cell_layout === 'image_text'"
+											class="pfb-insp-row"
+										>
+											<span class="pfb-insp-label">{{ __("Image") }}</span>
+											<select
+												class="pfb-insp-select"
+												:value="col.image_fieldname || ''"
+												@change="col.image_fieldname = $event.target.value"
+											>
+												<option value="">
+													{{ __("Initials only") }}
+												</option>
+												<option
+													v-for="f in image_field_opts"
+													:key="f.fieldname"
+													:value="f.fieldname"
+												>
+													{{ f.label }}
+												</option>
+											</select>
+										</div>
+
+										<template
+											v-if="
+												col.cell_layout === 'stacked' ||
+												col.cell_layout === 'image_text'
+											"
+										>
+											<div class="pfb-merge-head">
+												<span class="pfb-insp-label">{{
+													__("Merged fields")
+												}}</span>
+												<button
+													class="pfb-merge-add"
+													@click="add_merged_field(col)"
+												>
+													<span
+														v-html="frappe.utils.icon('add', 'xs')"
+													></span>
+													{{ __("Add") }}
+												</button>
+											</div>
+											<draggable
+												:list="col.merged_fields"
+												handle=".pfb-merge-drag"
+												:animation="150"
+												item-key="fieldname"
+												class="pfb-merge-list"
+											>
+												<template #item="{ element: mf, index: mi }">
+													<div class="pfb-merge-row">
+														<span
+															class="pfb-merge-drag"
+															v-html="
+																frappe.utils.icon('drag', 'xs')
+															"
+														></span>
+														<select
+															class="pfb-merge-field"
+															v-model="mf.fieldname"
+														>
+															<option
+																v-for="f in merge_field_opts(
+																	col,
+																	mf
+																)"
+																:key="f.fieldname"
+																:value="f.fieldname"
+															>
+																{{ f.label }}
+															</option>
+														</select>
+														<select
+															class="pfb-merge-style"
+															v-model="mf.style"
+															:title="__('Text style')"
+														>
+															<option
+																v-for="s in merge_style_opts"
+																:key="s.value"
+																:value="s.value"
+															>
+																{{ s.label }}
+															</option>
+														</select>
+														<button
+															class="pfb-col-remove"
+															@click="remove_merged_field(col, mi)"
+															:title="__('Remove field')"
+															v-html="frappe.utils.icon('x', 'xs')"
+														></button>
+													</div>
+												</template>
+											</draggable>
+											<p class="pfb-merge-hint">
+												{{
+													__(
+														"First field drives the thumbnail initials. Drag to reorder."
+													)
+												}}
+											</p>
+										</template>
+									</div>
 								</div>
 							</template>
 						</draggable>
@@ -690,7 +825,7 @@
 </template>
 
 <script setup>
-import { computed, inject, ref } from "vue";
+import { computed, inject, ref, watch } from "vue";
 import draggable from "vuedraggable";
 import { useStore } from "../../stores";
 import LetterHeadZoneInspector from "./LetterHeadZoneInspector.vue";
@@ -983,10 +1118,99 @@ function pick_column(opt) {
 function remove_table_column(idx) {
 	selected_field.value.table_columns.splice(idx, 1);
 	selected_field.value.table_columns = [...selected_field.value.table_columns];
+	expanded_col.value = null;
 }
+
+// Close the column editor when switching to a different field/table
+watch(selected_field, () => (expanded_col.value = null));
 
 function clamp_width(col) {
 	col.width = Math.max(5, Math.min(100, parseInt(col.width) || 10));
+}
+
+// ── Per-column cell layout + merged fields ─────────────────
+let expanded_col = ref(null);
+
+const cell_layout_opts = [
+	{ value: "single", label: __("Single") },
+	{ value: "stacked", label: __("Stacked") },
+	{ value: "image_text", label: __("Image + text") },
+];
+
+const merge_style_opts = [
+	{ value: "primary", label: __("Primary") },
+	{ value: "secondary", label: __("Secondary") },
+	{ value: "mono-sm", label: __("Code") },
+	{ value: "muted-sm", label: __("Muted") },
+];
+
+// Only fieldtypes that store the image URL directly in the field can be
+// picked as the cell image; "Image" resolves its URL via another field.
+const IMAGE_COL_FIELDTYPES = new Set(["Attach Image", "Attach"]);
+
+function toggle_col(ci) {
+	const next = expanded_col.value === ci ? null : ci;
+	expanded_col.value = next;
+	// Normalise a (possibly persisted) merged column so its editor is never empty
+	if (next !== null) {
+		const col = selected_field.value.table_columns[next];
+		if (col.cell_layout && col.cell_layout !== "single") seed_merged(col);
+	}
+}
+
+// Value-holding fields of the child doctype — shared by the merged-field
+// pickers and the image-field picker.
+let child_fields = computed(() => {
+	const dt = selected_field.value?.options;
+	const meta = dt && frappe.get_meta(dt);
+	if (!meta) return [];
+	return meta.fields.filter((f) => !frappe.model.no_value_type.includes(f.fieldtype));
+});
+
+function field_opt(f) {
+	return { fieldname: f.fieldname, label: f.label || f.fieldname };
+}
+
+let child_field_opts = computed(() => child_fields.value.map(field_opt));
+let image_field_opts = computed(() =>
+	child_fields.value.filter((f) => IMAGE_COL_FIELDTYPES.has(f.fieldtype)).map(field_opt)
+);
+
+// Options for a merged-field select: exclude fields already used by other
+// rows so each fieldname stays unique (keeps it a valid list key).
+function merge_field_opts(col, current) {
+	const used = new Set((col.merged_fields || []).map((m) => m.fieldname));
+	used.delete(current.fieldname);
+	return child_field_opts.value.filter((f) => !used.has(f.fieldname));
+}
+
+function ensure_merged(col) {
+	if (!Array.isArray(col.merged_fields)) col.merged_fields = [];
+	return col.merged_fields;
+}
+
+// Guarantee at least one line so a merged cell is never empty
+function seed_merged(col) {
+	const mf = ensure_merged(col);
+	if (!mf.length) mf.push({ fieldname: col.fieldname, style: "primary" });
+	return mf;
+}
+
+function set_cell_layout(col, value) {
+	col.cell_layout = value;
+	if (value !== "single") seed_merged(col);
+}
+
+function add_merged_field(col) {
+	const mf = ensure_merged(col);
+	const used = new Set(mf.map((m) => m.fieldname));
+	const next = child_field_opts.value.find((f) => !used.has(f.fieldname));
+	if (!next) return; // every field already merged
+	mf.push({ fieldname: next.fieldname, style: mf.length ? "muted-sm" : "primary" });
+}
+
+function remove_merged_field(col, mi) {
+	col.merged_fields.splice(mi, 1);
 }
 
 // ── Section helpers ────────────────────────────────────────
@@ -1508,19 +1732,23 @@ function set_section_cell_padding(value) {
 	padding: 4px 0;
 }
 
+.pfb-col-item {
+	border-bottom: 1px solid var(--gray-100);
+}
+
+.pfb-col-item:last-child {
+	border-bottom: none;
+}
+
 .pfb-col-row {
 	display: flex;
 	align-items: center;
 	gap: 6px;
 	padding: 5px 14px;
-	border-bottom: 1px solid var(--gray-100);
 }
 
-.pfb-col-row:last-child {
-	border-bottom: none;
-}
-
-.pfb-col-drag {
+.pfb-col-drag,
+.pfb-merge-drag {
 	cursor: grab;
 	color: var(--gray-300);
 	display: flex;
@@ -1528,7 +1756,8 @@ function set_section_cell_padding(value) {
 	flex-shrink: 0;
 }
 
-.pfb-col-drag:hover {
+.pfb-col-drag:hover,
+.pfb-merge-drag:hover {
 	color: var(--gray-500);
 }
 
@@ -1604,6 +1833,114 @@ function set_section_cell_padding(value) {
 
 .pfb-insp-col-count {
 	font-size: var(--text-tiny);
+}
+
+/* ── Per-column cell layout / merged fields editor ───────── */
+.pfb-col-config {
+	display: flex;
+	align-items: center;
+	padding: 2px;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	color: var(--gray-400);
+	border-radius: var(--radius);
+	flex-shrink: 0;
+}
+
+.pfb-col-config:hover {
+	background: var(--gray-100);
+	color: var(--gray-600);
+}
+
+.pfb-col-config.active {
+	color: var(--primary);
+}
+
+.pfb-col-config.open {
+	background: var(--gray-100);
+	color: var(--gray-700);
+}
+
+.pfb-col-editor {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 8px 14px 12px 30px;
+	background: var(--subtle-accent);
+	border-top: 1px solid var(--gray-100);
+}
+
+.pfb-merge-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.pfb-merge-add {
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-medium);
+	color: var(--text-muted);
+	background: var(--fg-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	padding: 2px 6px;
+	cursor: pointer;
+}
+
+.pfb-merge-add:hover {
+	color: var(--text-color);
+	border-color: var(--gray-400);
+}
+
+.pfb-merge-list {
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+}
+
+.pfb-merge-row {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+}
+
+.pfb-merge-field,
+.pfb-merge-style {
+	padding: 4px 6px;
+	font-size: var(--text-tiny);
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	background: var(--fg-color);
+	color: var(--text-color);
+	outline: none;
+	cursor: pointer;
+}
+
+.pfb-merge-field {
+	flex: 1;
+	min-width: 0;
+}
+
+.pfb-merge-style {
+	width: 84px;
+	flex-shrink: 0;
+	color: var(--text-muted);
+}
+
+.pfb-merge-field:focus,
+.pfb-merge-style:focus {
+	border-color: var(--gray-500);
+}
+
+.pfb-merge-hint {
+	font-size: var(--text-tiny);
+	color: var(--text-muted);
+	margin: 0;
+	line-height: 1.4;
 }
 
 /* ── Letter Head inspector ───────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -220,9 +220,13 @@
 											class="pfb-col-drag"
 											v-html="frappe.utils.icon('drag', 'xs')"
 										></span>
-										<span class="pfb-col-label" :title="col.fieldname">{{
-											col.label || col.fieldname
-										}}</span>
+										<input
+											class="pfb-col-label-input"
+											type="text"
+											v-model="col.label"
+											:placeholder="col.fieldname"
+											:title="col.fieldname"
+										/>
 										<button
 											class="pfb-col-config"
 											:class="{
@@ -253,44 +257,33 @@
 										></button>
 									</div>
 
-									<!-- Per-column merged-fields editor -->
+									<!-- Per-column merged-fields editor: reuses inspector primitives -->
 									<div v-if="expanded_col === ci" class="pfb-col-editor">
-										<div class="pfb-merge-head">
-											<span class="pfb-insp-label">{{
-												__("Merged fields")
-											}}</span>
-											<button
-												class="pfb-merge-add"
-												@click="add_merged_field(col)"
-											>
-												<span
-													v-html="frappe.utils.icon('add', 'xs')"
-												></span>
-												{{ __("Add field") }}
-											</button>
-										</div>
 										<draggable
 											:list="col.merged_fields"
 											handle=".pfb-merge-drag"
 											:animation="150"
 											item-key="fieldname"
-											class="pfb-merge-list"
+											class="pfb-col-list"
 										>
 											<template #item="{ element: mf, index: mi }">
-												<div class="pfb-merge-row">
+												<div class="pfb-col-row">
 													<span
 														class="pfb-merge-drag"
 														v-html="frappe.utils.icon('drag', 'xs')"
 													></span>
-													<span
+													<input
 														v-if="is_base_merge(col, mf)"
-														class="pfb-merge-field pfb-merge-field--locked"
+														class="pfb-insp-input"
+														style="flex: 1; min-width: 0"
+														:value="merge_field_label(mf)"
 														:title="__('This column\'s own field')"
-														>{{ merge_field_label(mf) }}</span
-													>
+														disabled
+													/>
 													<select
 														v-else
-														class="pfb-merge-field"
+														class="pfb-insp-select"
+														style="flex: 1; min-width: 0"
 														:value="mf.fieldname"
 														@change="
 															set_merged_field(
@@ -309,12 +302,13 @@
 													</select>
 													<span
 														v-if="is_image_merge(mf)"
-														class="pfb-merge-tag"
+														class="pfb-type-badge"
 														>{{ __("Image") }}</span
 													>
 													<select
 														v-else
-														class="pfb-merge-style"
+														class="pfb-insp-select"
+														style="width: 96px; flex: none"
 														v-model="mf.style"
 														:title="__('Text style')"
 													>
@@ -327,12 +321,8 @@
 														</option>
 													</select>
 													<button
+														v-if="!is_base_merge(col, mf)"
 														class="pfb-col-remove"
-														:class="{
-															'pfb-col-remove--hidden':
-																is_base_merge(col, mf),
-														}"
-														:disabled="is_base_merge(col, mf)"
 														@click="remove_merged_field(col, mi)"
 														:title="__('Remove field')"
 														v-html="frappe.utils.icon('x', 'xs')"
@@ -340,36 +330,52 @@
 												</div>
 											</template>
 										</draggable>
-										<p class="pfb-merge-hint">
+										<div class="pfb-col-add-row">
+											<button
+												class="btn btn-xs btn-default"
+												@click="add_merged_field(col)"
+											>
+												<span
+													v-html="frappe.utils.icon('add', 'xs')"
+												></span>
+												{{ __("Add field") }}
+											</button>
+										</div>
+										<p
+											class="pfb-insp-hint text-muted"
+											style="padding: 0 14px 8px"
+										>
 											{{
 												__(
 													"Add fields to merge into this column. An image field is shown on the left."
 												)
 											}}
 										</p>
-
-										<!-- Image size (only when a merged image field is present) -->
-										<div v-if="has_image_merge(col)" class="pfb-insp-row">
+										<div
+											v-if="has_image_merge(col)"
+											class="pfb-insp-row"
+											style="padding: 0 14px 10px"
+										>
 											<span class="pfb-insp-label">{{
 												__("Image size")
 											}}</span>
-											<div class="pfb-merge-size">
+											<div class="pfb-stepper">
+												<button @click="adjust_image_size(col, -4)">
+													−
+												</button>
 												<input
-													type="range"
-													class="pfb-lh-slider"
-													min="24"
-													max="96"
-													step="4"
+													class="pfb-stepper-input"
+													type="number"
+													min="16"
 													:value="col.image_size || 40"
-													@input="
-														col.image_size = Number(
-															$event.target.value
-														)
+													@change="
+														(e) => set_image_size(col, e.target.value)
 													"
 												/>
-												<span class="pfb-merge-size-val"
-													>{{ col.image_size || 40 }}px</span
-												>
+												<span class="pfb-stepper-unit">px</span>
+												<button @click="adjust_image_size(col, 4)">
+													+
+												</button>
 											</div>
 										</div>
 									</div>
@@ -1225,6 +1231,16 @@ function remove_merged_field(col, mi) {
 	col.merged_fields.splice(mi, 1);
 }
 
+// Image size — same stepper pattern as table Radius / section Gap
+function adjust_image_size(col, delta) {
+	col.image_size = Math.max(16, (col.image_size || 40) + delta);
+}
+
+function set_image_size(col, value) {
+	const v = parseInt(value);
+	col.image_size = isNaN(v) ? 40 : Math.max(16, v);
+}
+
 // ── Section helpers ────────────────────────────────────────
 let section_show_label = computed(() => selected_section.value?.show_label ?? "show");
 let section_orientation = computed(() => selected_section.value?.field_orientation ?? "");
@@ -1884,131 +1900,9 @@ function set_section_cell_padding(value) {
 }
 
 .pfb-col-editor {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-	padding: 8px 14px 12px 30px;
 	background: var(--subtle-accent);
 	border-top: 1px solid var(--gray-100);
-}
-
-.pfb-merge-head {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-}
-
-.pfb-merge-add {
-	display: inline-flex;
-	align-items: center;
-	gap: 2px;
-	font-size: var(--text-tiny);
-	font-weight: var(--weight-medium);
-	color: var(--text-muted);
-	background: var(--fg-color);
-	border: 1px solid var(--border-color);
-	border-radius: var(--radius);
-	padding: 2px 6px;
-	cursor: pointer;
-}
-
-.pfb-merge-add:hover {
-	color: var(--text-color);
-	border-color: var(--gray-400);
-}
-
-.pfb-merge-list {
-	display: flex;
-	flex-direction: column;
-	gap: 5px;
-}
-
-.pfb-merge-row {
-	display: flex;
-	align-items: center;
-	gap: 5px;
-}
-
-/* Merged-row controls share a compact boxed look */
-.pfb-merge-field,
-.pfb-merge-style,
-.pfb-merge-tag {
-	padding: 4px 6px;
-	font-size: var(--text-tiny);
-	border: 1px solid var(--border-color);
-	border-radius: var(--radius);
-	background: var(--fg-color);
-	outline: none;
-}
-
-.pfb-merge-field,
-.pfb-merge-style {
-	color: var(--text-color);
-	cursor: pointer;
-}
-
-.pfb-merge-field {
-	flex: 1;
-	min-width: 0;
-}
-
-/* Style select + image badge: same fixed width, muted, on the right */
-.pfb-merge-style,
-.pfb-merge-tag {
-	width: 84px;
-	flex-shrink: 0;
-	color: var(--text-muted);
-}
-
-.pfb-merge-tag {
-	text-align: center;
-	background: var(--gray-100);
-}
-
-/* Base row: the column's own field, shown locked instead of a select */
-.pfb-merge-field--locked {
-	display: flex;
-	align-items: center;
-	color: var(--text-muted);
-	background: var(--gray-50);
-	cursor: default;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.pfb-col-remove--hidden {
-	visibility: hidden;
-}
-
-.pfb-merge-field:focus,
-.pfb-merge-style:focus {
-	border-color: var(--gray-500);
-}
-
-.pfb-merge-hint {
-	font-size: var(--text-tiny);
-	color: var(--text-muted);
-	margin: 0;
-	line-height: 1.4;
-}
-
-.pfb-merge-size {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-}
-
-.pfb-merge-size .pfb-lh-slider {
-	flex: 1;
-	min-width: 0;
-}
-
-.pfb-merge-size-val {
-	font-size: var(--text-tiny);
-	color: var(--text-muted);
-	white-space: nowrap;
-	flex-shrink: 0;
+	padding-bottom: 6px;
 }
 
 /* ── Letter Head inspector ───────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -228,7 +228,7 @@
 											:class="{
 												active:
 													col.merged_fields &&
-													col.merged_fields.length,
+													col.merged_fields.length > 1,
 												open: expanded_col === ci,
 											}"
 											@click="toggle_col(ci)"
@@ -282,7 +282,14 @@
 														class="pfb-merge-drag"
 														v-html="frappe.utils.icon('drag', 'xs')"
 													></span>
+													<span
+														v-if="is_base_merge(col, mf)"
+														class="pfb-merge-field pfb-merge-field--locked"
+														:title="__('This column\'s own field')"
+														>{{ merge_field_label(mf) }}</span
+													>
 													<select
+														v-else
 														class="pfb-merge-field"
 														:value="mf.fieldname"
 														@change="
@@ -321,6 +328,11 @@
 													</select>
 													<button
 														class="pfb-col-remove"
+														:class="{
+															'pfb-col-remove--hidden':
+																is_base_merge(col, mf),
+														}"
+														:disabled="is_base_merge(col, mf)"
 														@click="remove_merged_field(col, mi)"
 														:title="__('Remove field')"
 														v-html="frappe.utils.icon('x', 'xs')"
@@ -328,20 +340,10 @@
 												</div>
 											</template>
 										</draggable>
-										<p
-											v-if="col.merged_fields && col.merged_fields.length"
-											class="pfb-merge-hint"
-										>
+										<p class="pfb-merge-hint">
 											{{
 												__(
-													"Add two or more fields to merge them into one cell. An image field is shown on the left."
-												)
-											}}
-										</p>
-										<p v-else class="pfb-merge-hint">
-											{{
-												__(
-													"Merge several child fields into this column."
+													"Add fields to merge into this column. An image field is shown on the left."
 												)
 											}}
 										</p>
@@ -1141,8 +1143,19 @@ const IMAGE_COL_FIELDTYPES = new Set(["Attach Image", "Attach"]);
 function toggle_col(ci) {
 	const next = expanded_col.value === ci ? null : ci;
 	expanded_col.value = next;
-	// Give the draggable a real array to bind to; empty = plain single cell.
-	if (next !== null) ensure_merged(selected_field.value.table_columns[next]);
+	// Opening the editor means "merge into this column": always show the
+	// column's own field as the (non-removable) primary line.
+	if (next !== null) {
+		const col = selected_field.value.table_columns[next];
+		const mf = ensure_merged(col);
+		if (!mf.some((m) => m.fieldname === col.fieldname)) {
+			mf.unshift({
+				fieldname: col.fieldname,
+				fieldtype: own_fieldtype(col),
+				style: "primary",
+			});
+		}
+	}
 }
 
 // Value-holding fields of the child doctype, for the merged-field pickers.
@@ -1153,6 +1166,14 @@ let child_fields = computed(() => {
 	return meta.fields.filter((f) => !frappe.model.no_value_type.includes(f.fieldtype));
 });
 
+function own_fieldtype(col) {
+	return (
+		child_fields.value.find((f) => f.fieldname === col.fieldname)?.fieldtype ||
+		col.fieldtype ||
+		"Data"
+	);
+}
+
 // Options for a merged-field select: exclude fields already used by other
 // rows so each fieldname stays unique (keeps it a valid list key).
 function merge_field_opts(col, current) {
@@ -1161,6 +1182,15 @@ function merge_field_opts(col, current) {
 	return child_fields.value
 		.filter((f) => !used.has(f.fieldname))
 		.map((f) => ({ fieldname: f.fieldname, label: f.label || f.fieldname }));
+}
+
+// The base row is the column's own field — locked and not removable.
+function is_base_merge(col, mf) {
+	return mf.fieldname === col.fieldname;
+}
+
+function merge_field_label(mf) {
+	return child_fields.value.find((f) => f.fieldname === mf.fieldname)?.label || mf.fieldname;
 }
 
 function is_image_merge(mf) {
@@ -1178,16 +1208,6 @@ function ensure_merged(col) {
 
 function add_merged_field(col) {
 	const mf = ensure_merged(col);
-	// The first merged field defaults to the column's own field, as primary.
-	if (!mf.length) {
-		const own = child_fields.value.find((f) => f.fieldname === col.fieldname);
-		mf.push({
-			fieldname: col.fieldname,
-			fieldtype: own?.fieldtype || col.fieldtype || "Data",
-			style: "primary",
-		});
-		return;
-	}
 	const used = new Set(mf.map((m) => m.fieldname));
 	const next = child_fields.value.find((f) => !used.has(f.fieldname));
 	if (!next) return; // every field already merged
@@ -1923,6 +1943,22 @@ function set_section_cell_padding(value) {
 .pfb-merge-field {
 	flex: 1;
 	min-width: 0;
+}
+
+/* Base row: the column's own field, shown locked instead of a select */
+.pfb-merge-field--locked {
+	display: flex;
+	align-items: center;
+	color: var(--text-muted);
+	background: var(--gray-50);
+	cursor: default;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.pfb-col-remove--hidden {
+	visibility: hidden;
 }
 
 .pfb-merge-style {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -1831,6 +1831,15 @@ function set_section_cell_padding(value) {
 	color: var(--gray-400);
 	border-radius: var(--radius);
 	flex-shrink: 0;
+	/* Hidden until the row is hovered — space is reserved so inputs don't shift.
+	   Stays visible when the column is merged (active) or its editor is open. */
+	visibility: hidden;
+}
+
+.pfb-col-item:hover .pfb-col-config,
+.pfb-col-config.active,
+.pfb-col-config.open {
+	visibility: visible;
 }
 
 .pfb-col-config:hover {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -1040,28 +1040,33 @@ const table_style_opts = [
 	{ value: "striped", label: __("Striped") },
 	{ value: "plain", label: __("Plain") },
 ];
+// Value-holding fields of the child doctype — shared base for both the
+// "add column" and "add merge field" pickers below.
+let child_value_fields = computed(() => {
+	const dt = selected_field.value?.options;
+	const meta = dt && frappe.get_meta(dt);
+	if (!meta) return [];
+	return meta.fields.filter((f) => !frappe.model.no_value_type.includes(f.fieldtype));
+});
+
+function to_field_opts(fields) {
+	return fields.map((f) => ({
+		label: f.label || f.fieldname,
+		value: f.fieldname,
+		badge: f.fieldtype,
+	}));
+}
+
 let available_columns = computed(() => {
 	if (!selected_field.value?.options) return [];
-	const meta = frappe.get_meta(selected_field.value.options);
-	if (!meta) return [];
 	const existing = new Set((selected_field.value.table_columns || []).map((c) => c.fieldname));
 	const standard = [{ label: __("Sr No."), fieldname: "idx", fieldtype: "Data" }];
 	return standard
-		.concat(
-			meta.fields.filter(
-				(f) => !frappe.model.no_value_type.includes(f.fieldtype) && f.fieldname !== "name"
-			)
-		)
+		.concat(child_value_fields.value.filter((f) => f.fieldname !== "name"))
 		.filter((f) => !existing.has(f.fieldname));
 });
 
-let available_column_opts = computed(() =>
-	available_columns.value.map((c) => ({
-		label: c.label || c.fieldname,
-		value: c.fieldname,
-		badge: c.fieldtype,
-	}))
-);
+let available_column_opts = computed(() => to_field_opts(available_columns.value));
 
 function pick_column(opt) {
 	const meta = frappe.get_meta(selected_field.value.options);
@@ -1113,16 +1118,8 @@ const merge_style_opts = [
 	{ value: "muted-sm", label: __("Muted") },
 ];
 
-// Value-holding fields of the child doctype, for the merged-field pickers.
-let child_fields = computed(() => {
-	const dt = selected_field.value?.options;
-	const meta = dt && frappe.get_meta(dt);
-	if (!meta) return [];
-	return meta.fields.filter((f) => !frappe.model.no_value_type.includes(f.fieldtype));
-});
-
 function find_field(fieldname) {
-	return child_fields.value.find((f) => f.fieldname === fieldname);
+	return child_value_fields.value.find((f) => f.fieldname === fieldname);
 }
 
 function merge_field_label(mf) {
@@ -1131,13 +1128,10 @@ function merge_field_label(mf) {
 
 // Child fields not yet merged into this column (the column's own field is
 // always the implicit primary line, so it's excluded here too) — for the
-// "Add field..." autocomplete, same {label, value, badge} shape as
-// available_column_opts.
+// "Add field..." autocomplete.
 function merge_field_opts(col) {
 	const used = new Set([col.fieldname, ...(col.merged_fields || []).map((m) => m.fieldname)]);
-	return child_fields.value
-		.filter((f) => !used.has(f.fieldname))
-		.map((f) => ({ label: f.label || f.fieldname, value: f.fieldname, badge: f.fieldtype }));
+	return to_field_opts(child_value_fields.value.filter((f) => !used.has(f.fieldname)));
 }
 
 function is_image_merge(mf) {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -1178,14 +1178,20 @@ function ensure_merged(col) {
 
 function add_merged_field(col) {
 	const mf = ensure_merged(col);
+	// The first merged field defaults to the column's own field, as primary.
+	if (!mf.length) {
+		const own = child_fields.value.find((f) => f.fieldname === col.fieldname);
+		mf.push({
+			fieldname: col.fieldname,
+			fieldtype: own?.fieldtype || col.fieldtype || "Data",
+			style: "primary",
+		});
+		return;
+	}
 	const used = new Set(mf.map((m) => m.fieldname));
 	const next = child_fields.value.find((f) => !used.has(f.fieldname));
 	if (!next) return; // every field already merged
-	mf.push({
-		fieldname: next.fieldname,
-		fieldtype: next.fieldtype,
-		style: mf.length ? "muted-sm" : "primary",
-	});
+	mf.push({ fieldname: next.fieldname, fieldtype: next.fieldtype, style: "muted-sm" });
 }
 
 // Keep the stored fieldtype in sync so image detection works server-side.

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -296,6 +296,35 @@
 															{{ s.label }}
 														</option>
 													</select>
+													<div
+														v-else
+														class="pfb-stepper pfb-stepper--sm"
+														:title="__('Image size')"
+													>
+														<button
+															@click="adjust_image_size(col, -4)"
+														>
+															−
+														</button>
+														<input
+															class="pfb-stepper-input"
+															type="number"
+															min="16"
+															max="200"
+															:value="col.image_size || 40"
+															@change="
+																(e) =>
+																	set_image_size(
+																		col,
+																		e.target.value
+																	)
+															"
+														/>
+														<span class="pfb-stepper-unit">px</span>
+														<button @click="adjust_image_size(col, 4)">
+															+
+														</button>
+													</div>
 													<button
 														class="pfb-col-remove"
 														@click="remove_merged_field(col, mi)"
@@ -314,34 +343,6 @@
 												:placeholder="__('Add field...')"
 												@select="(opt) => add_merged_field(col, opt.value)"
 											/>
-										</div>
-										<div
-											v-if="has_image_merge(col)"
-											class="pfb-insp-row"
-											style="padding: 0 14px 10px"
-										>
-											<span class="pfb-insp-label">{{
-												__("Image size")
-											}}</span>
-											<div class="pfb-stepper">
-												<button @click="adjust_image_size(col, -4)">
-													−
-												</button>
-												<input
-													class="pfb-stepper-input"
-													type="number"
-													min="16"
-													max="200"
-													:value="col.image_size || 40"
-													@change="
-														(e) => set_image_size(col, e.target.value)
-													"
-												/>
-												<span class="pfb-stepper-unit">px</span>
-												<button @click="adjust_image_size(col, 4)">
-													+
-												</button>
-											</div>
 										</div>
 									</div>
 								</div>
@@ -1141,12 +1142,6 @@ function merge_field_opts(col) {
 
 function is_image_merge(mf) {
 	return IMAGE_COL_FIELDTYPES.has(mf.fieldtype);
-}
-
-function has_image_merge(col) {
-	return (
-		IMAGE_COL_FIELDTYPES.has(col.fieldtype) || (col.merged_fields || []).some(is_image_merge)
-	);
 }
 
 function ensure_merged(col) {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -362,8 +362,9 @@
 													step="4"
 													:value="col.image_size || 40"
 													@input="
-														col.image_size =
-															Number($event.target.value)
+														col.image_size = Number(
+															$event.target.value
+														)
 													"
 												/>
 												<span class="pfb-merge-size-val"

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -367,6 +367,7 @@
 													class="pfb-stepper-input"
 													type="number"
 													min="16"
+													max="200"
 													:value="col.image_size || 40"
 													@change="
 														(e) => set_image_size(col, e.target.value)
@@ -1231,14 +1232,14 @@ function remove_merged_field(col, mi) {
 	col.merged_fields.splice(mi, 1);
 }
 
-// Image size — same stepper pattern as table Radius / section Gap
+// Image size (px) — same stepper pattern as table Radius / section Gap, clamped 16–200
 function adjust_image_size(col, delta) {
-	col.image_size = Math.max(16, (col.image_size || 40) + delta);
+	col.image_size = Math.max(16, Math.min(200, (col.image_size || 40) + delta));
 }
 
 function set_image_size(col, value) {
 	const v = parseInt(value);
-	col.image_size = isNaN(v) ? 40 : Math.max(16, v);
+	col.image_size = isNaN(v) ? 40 : Math.max(16, Math.min(200, v));
 }
 
 // ── Section helpers ────────────────────────────────────────

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -1928,21 +1928,40 @@ function set_section_cell_padding(value) {
 	gap: 5px;
 }
 
+/* Merged-row controls share a compact boxed look */
 .pfb-merge-field,
-.pfb-merge-style {
+.pfb-merge-style,
+.pfb-merge-tag {
 	padding: 4px 6px;
 	font-size: var(--text-tiny);
 	border: 1px solid var(--border-color);
 	border-radius: var(--radius);
 	background: var(--fg-color);
-	color: var(--text-color);
 	outline: none;
+}
+
+.pfb-merge-field,
+.pfb-merge-style {
+	color: var(--text-color);
 	cursor: pointer;
 }
 
 .pfb-merge-field {
 	flex: 1;
 	min-width: 0;
+}
+
+/* Style select + image badge: same fixed width, muted, on the right */
+.pfb-merge-style,
+.pfb-merge-tag {
+	width: 84px;
+	flex-shrink: 0;
+	color: var(--text-muted);
+}
+
+.pfb-merge-tag {
+	text-align: center;
+	background: var(--gray-100);
 }
 
 /* Base row: the column's own field, shown locked instead of a select */
@@ -1961,12 +1980,6 @@ function set_section_cell_padding(value) {
 	visibility: hidden;
 }
 
-.pfb-merge-style {
-	width: 84px;
-	flex-shrink: 0;
-	color: var(--text-muted);
-}
-
 .pfb-merge-field:focus,
 .pfb-merge-style:focus {
 	border-color: var(--gray-500);
@@ -1977,19 +1990,6 @@ function set_section_cell_padding(value) {
 	color: var(--text-muted);
 	margin: 0;
 	line-height: 1.4;
-}
-
-/* Image badge shown in place of the text-style select for image fields */
-.pfb-merge-tag {
-	width: 84px;
-	flex-shrink: 0;
-	text-align: center;
-	font-size: var(--text-tiny);
-	color: var(--text-muted);
-	background: var(--gray-100);
-	border: 1px solid var(--border-color);
-	border-radius: var(--radius);
-	padding: 4px 4px;
 }
 
 .pfb-merge-size {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -1841,7 +1841,16 @@ function set_section_cell_padding(value) {
 .pfb-col-editor {
 	background: var(--gray-50);
 	border-top: 1px solid var(--gray-100);
+	border-left: 2px solid var(--gray-300);
+	margin-left: 10px;
 	padding-bottom: 6px;
+}
+
+/* Rows inside the merge editor are always in an active-editing context, so
+   their icons stay clearly visible instead of the outer list's hover-reveal. */
+.pfb-col-editor .pfb-col-remove,
+.pfb-col-editor .pfb-merge-drag {
+	color: var(--gray-400);
 }
 
 /* ── Letter Head inspector ───────────────────────────────── */

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -94,6 +94,10 @@ export function getStore(print_format_name) {
 						.map((df) => {
 							if (df.table_columns) {
 								df.table_columns = df.table_columns.map((tf) => {
+									// Drop an empty merged list so plain columns stay clean
+									if (Array.isArray(tf.merged_fields) && !tf.merged_fields.length) {
+										delete tf.merged_fields;
+									}
 									return pluck(tf, [
 										"label",
 										"fieldname",
@@ -101,9 +105,8 @@ export function getStore(print_format_name) {
 										"options",
 										"width",
 										"field_template",
-										"cell_layout",
 										"merged_fields",
-										"image_fieldname",
+										"image_size",
 									]);
 								});
 							}

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -96,10 +96,10 @@ export function getStore(print_format_name) {
 						.map((df) => {
 							if (df.table_columns) {
 								df.table_columns = df.table_columns.map((tf) => {
-									// A single (base-only) merge is just a plain column — drop it
+									// An empty merge list is just a plain column — drop it
 									if (
 										Array.isArray(tf.merged_fields) &&
-										tf.merged_fields.length < 2
+										!tf.merged_fields.length
 									) {
 										delete tf.merged_fields;
 									}

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -51,6 +51,8 @@ export function getStore(print_format_name) {
 						: Promise.resolve((letterhead.value = null));
 
 					load_lh.then(() => {
+						history = [];
+						last_snap = JSON.stringify(layout.value);
 						nextTick(() => (dirty.value = false));
 						resolve();
 					});
@@ -231,10 +233,40 @@ export function getStore(print_format_name) {
 		});
 	}
 
+	// ── Undo history (Ctrl/Cmd+Z) ──────────────────────────
+	let history = [];
+	let restoring = false;
+	let last_snap = null;
+	const record_history = frappe.utils.debounce(() => {
+		const snap = JSON.stringify(layout.value);
+		if (snap === last_snap) return;
+		if (last_snap !== null) history.push(last_snap);
+		if (history.length > 50) history.shift();
+		last_snap = snap;
+	}, 400);
+
+	function undo() {
+		if (!history.length) return;
+		restoring = true;
+		last_snap = history.pop();
+		layout.value = JSON.parse(last_snap);
+		selected_field.value = null;
+		selected_section.value = null;
+	}
+
 	// watch
-	watch(layout, () => {
-		dirty.value = true;
-	});
+	watch(
+		layout,
+		() => {
+			dirty.value = true;
+			if (restoring) {
+				restoring = false;
+				return;
+			}
+			record_history();
+		},
+		{ deep: true }
+	);
 	watch(print_format, () => {
 		dirty.value = true;
 	});
@@ -263,6 +295,7 @@ export function getStore(print_format_name) {
 		get_layout,
 		get_default_layout,
 		change_letterhead,
+		undo,
 	};
 }
 

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -101,6 +101,9 @@ export function getStore(print_format_name) {
 										"options",
 										"width",
 										"field_template",
+										"cell_layout",
+										"merged_fields",
+										"image_fieldname",
 									]);
 								});
 							}

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -94,8 +94,11 @@ export function getStore(print_format_name) {
 						.map((df) => {
 							if (df.table_columns) {
 								df.table_columns = df.table_columns.map((tf) => {
-									// Drop an empty merged list so plain columns stay clean
-									if (Array.isArray(tf.merged_fields) && !tf.merged_fields.length) {
+									// A single (base-only) merge is just a plain column — drop it
+									if (
+										Array.isArray(tf.merged_fields) &&
+										tf.merged_fields.length < 2
+									) {
 										delete tf.merged_fields;
 									}
 									return pluck(tf, [

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -138,6 +138,31 @@ export function pluck(object, keys) {
 	return out;
 }
 
+// ── Shared thumbnail palette for merged "Image + text" table cells ──
+// Keyed deterministically by the first character so the builder canvas
+// (Field.vue) and the PDF render (templates/print_format/macros/Table.html)
+// pick the same colour for a given value. Keep the order in sync with the
+// palette literal in Table.html.
+export const THUMB_PALETTE = [
+	{ bg: "#EFF6FF", fg: "#2563EB" }, // blue
+	{ bg: "#FFF7ED", fg: "#EA580C" }, // orange
+	{ bg: "#F0FDF4", fg: "#16A34A" }, // green
+	{ bg: "#FAF5FF", fg: "#9333EA" }, // purple
+	{ bg: "#FEF2F2", fg: "#DC2626" }, // red
+	{ bg: "#F0FDFA", fg: "#0D9488" }, // teal
+];
+
+export function thumb_palette_for(text) {
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+	const first = String(text || "")
+		.trim()
+		.charAt(0)
+		.toLowerCase();
+	let idx = chars.indexOf(first);
+	if (idx < 0) idx = 0;
+	return THUMB_PALETTE[idx % THUMB_PALETTE.length];
+}
+
 export async function render_jinja_html(html, doctype, docname) {
 	if (!html) return html;
 	if (!html.includes("{{") && !html.includes("{%")) return html;

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -138,29 +138,17 @@ export function pluck(object, keys) {
 	return out;
 }
 
-// ── Shared thumbnail palette for merged "Image + text" table cells ──
-// Keyed deterministically by the first character so the builder canvas
-// (Field.vue) and the PDF render (templates/print_format/macros/Table.html)
-// pick the same colour for a given value. Keep the order in sync with the
-// palette literal in Table.html.
-export const THUMB_PALETTE = [
-	{ bg: "#EFF6FF", fg: "#2563EB" }, // blue
-	{ bg: "#FFF7ED", fg: "#EA580C" }, // orange
-	{ bg: "#F0FDF4", fg: "#16A34A" }, // green
-	{ bg: "#FAF5FF", fg: "#9333EA" }, // purple
-	{ bg: "#FEF2F2", fg: "#DC2626" }, // red
-	{ bg: "#F0FDFA", fg: "#0D9488" }, // teal
-];
-
-export function thumb_palette_for(text) {
-	const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-	const first = String(text || "")
-		.trim()
-		.charAt(0)
-		.toLowerCase();
-	let idx = chars.indexOf(first);
-	if (idx < 0) idx = 0;
-	return THUMB_PALETTE[idx % THUMB_PALETTE.length];
+// Deterministic pastel colour for a merged-cell initials thumbnail, keyed off
+// the first character so the canvas and the PDF (Table.html, same formula)
+// always agree — no palette table to keep in sync across the two.
+export function thumb_hue(text) {
+	const idx = "abcdefghijklmnopqrstuvwxyz0123456789".indexOf(
+		String(text || "")
+			.trim()
+			.charAt(0)
+			.toLowerCase()
+	);
+	return ((idx < 0 ? 0 : idx) * 37) % 360;
 }
 
 export async function render_jinja_html(html, doctype, docname) {

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -57,8 +57,7 @@
 								{%- endif -%}
 							{%- endif -%}
 							<div class="cell-lines">
-								{%- set nsl = namespace(first=True) -%}
-								{%- for mf in _merged -%}{%- if mf.fieldname and mf.fieldname != ns.img_fn -%}<div class="cell-line{% if nsl.first %} cell-line--primary{% endif %}">{{ row.get_formatted(mf.fieldname)|striptags|e }}</div>{%- set nsl.first = False -%}{%- endif -%}{%- endfor -%}
+								{%- for mf in _merged -%}{%- if mf.fieldname and mf.fieldname != ns.img_fn -%}<div class="cell-line cell-line--{{ (mf.style or 'primary')|e }}">{{ row.get_formatted(mf.fieldname)|striptags|e }}</div>{%- endif -%}{%- endfor -%}
 							</div>
 						</div>
 					{%- else -%}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -17,7 +17,8 @@
 		<thead>
 			<tr class="table-row">
 				{% for column in columns %}
-				<th class="column-header" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style|e }}"{% endif %} {{ field_attributes(column) }}>
+				{%- set _merged_col = column.merged_fields and column.merged_fields|length > 1 -%}
+				<th class="column-header{% if _merged_col %} column-value--merged{% endif %}" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style|e }}"{% endif %} {{ field_attributes(column) }}>
 					{{ _(column.label or column.fieldname) }}
 				</th>
 				{% endfor %}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -17,7 +17,7 @@
 		<thead>
 			<tr class="table-row">
 				{% for column in columns %}
-				{%- set _merged_col = column.merged_fields and column.merged_fields|length > 1 -%}
+				{%- set _merged_col = column.merged_fields and column.merged_fields|length > 0 -%}
 				<th class="column-header{% if _merged_col %} column-value--merged{% endif %}" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style|e }}"{% endif %} {{ field_attributes(column) }}>
 					{{ _(column.label or column.fieldname) }}
 				</th>
@@ -29,7 +29,8 @@
 			{% for row in doc.get(df.fieldname) %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}">
 				{% for column in columns %}
-				{%- set _merged = column.merged_fields if (column.merged_fields and column.merged_fields|length > 1) else None -%}
+				{# Column's own field is always the implicit primary line; merged_fields holds the extra fields. #}
+				{%- set _merged = ([{"fieldname": column.fieldname, "fieldtype": column.fieldtype, "style": "primary"}] + column.merged_fields) if column.merged_fields else None -%}
 				<td class="column-value{% if _merged %} column-value--merged{% endif %}" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style|e }}"{% endif %} {{ field_attributes(column) }}>
 					{%- if _merged -%}
 						{# Merged cell: an image field (if any) floats left, the rest stack as text lines (first = primary). #}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -35,13 +35,13 @@
 						{%- set _imgtypes = ("Attach Image", "Attach") -%}
 						{%- set ns = namespace(img_fn=None) -%}
 						{%- for mf in _merged -%}{%- if ns.img_fn is none and mf.fieldname and mf.fieldtype in _imgtypes -%}{%- set ns.img_fn = mf.fieldname -%}{%- endif -%}{%- endfor -%}
-						{%- set _size = column.image_size or 40 -%}
+						{%- set _size = (column.image_size or 40)|int -%}
 						<div class="cell-merged">
 							{%- if ns.img_fn -%}
 								{%- set _src = (row.get(ns.img_fn) or "")|string|trim -%}
 								{%- set _safe = _src.startswith("/") or _src.startswith("http://") or _src.startswith("https://") -%}
 								{%- if _safe -%}
-								<img class="cell-thumb-img" style="width:{{ _size }}px;height:{{ _size }}px" src="{{ frappe.utils.get_image_thumbnail_uri(_src)|e }}" alt="" />
+								<img class="cell-thumb-img" style="width:{{ _size }}px;height:{{ _size }}px" src="{{ frappe.utils.get_image_thumbnail_uri(_src)|e }}" alt="{{ _(column.label or '')|e }}" />
 								{%- else -%}
 								{# Fallback: initials from the first text field, coloured to match the builder canvas. #}
 								{%- set ns2 = namespace(txt="") -%}
@@ -54,7 +54,7 @@
 								{%- endif -%}
 							{%- endif -%}
 							<div class="cell-lines">
-								{%- for mf in _merged -%}{%- if mf.fieldname and mf.fieldname != ns.img_fn -%}<div class="cell-line cell-line--{{ mf.style or 'primary' }}">{{ row.get_formatted(mf.fieldname)|striptags }}</div>{%- endif -%}{%- endfor -%}
+								{%- for mf in _merged -%}{%- if mf.fieldname and mf.fieldname != ns.img_fn -%}<div class="cell-line cell-line--{{ (mf.style or 'primary')|e }}">{{ row.get_formatted(mf.fieldname)|striptags|e }}</div>{%- endif -%}{%- endfor -%}
 							</div>
 						</div>
 					{%- else -%}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -28,34 +28,35 @@
 			{% for row in doc.get(df.fieldname) %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}">
 				{% for column in columns %}
-				{%- set _layout = column.cell_layout or "single" -%}
-				<td class="column-value{% if _layout != 'single' %} column-value--{{ _layout }}{% endif %}" width="{{ column.width }}%" {{ field_attributes(column) }}>
-					{%- if _layout in ("stacked", "image_text") -%}
-						{# Merged cell: render each configured field on its own styled line. #}
-						{%- set _mf = column.merged_fields or [{"fieldname": column.fieldname, "style": "primary"}] -%}
-						{%- if _layout == "image_text" -%}
-							{%- set _img = (row.get(column.image_fieldname) if column.image_fieldname else "")|string|trim -%}
-							{%- set _img_ok = _img and (_img.startswith("/") or _img.startswith("http://") or _img.startswith("https://")) -%}
-							<div class="cell-imgtext">
-								{%- if _img_ok -%}
-								<img class="cell-thumb-img" src="{{ frappe.utils.get_image_thumbnail_uri(_img)|e }}" alt="" />
+				{%- set _merged = column.merged_fields -%}
+				<td class="column-value{% if _merged %} column-value--merged{% endif %}" width="{{ column.width }}%" {{ field_attributes(column) }}>
+					{%- if _merged -%}
+						{# Merged cell: an image field (if any) floats left, the rest stack as styled lines. #}
+						{%- set _imgtypes = ("Attach Image", "Attach") -%}
+						{%- set ns = namespace(img_fn=None) -%}
+						{%- for mf in _merged -%}{%- if ns.img_fn is none and mf.fieldname and mf.fieldtype in _imgtypes -%}{%- set ns.img_fn = mf.fieldname -%}{%- endif -%}{%- endfor -%}
+						{%- set _size = column.image_size or 40 -%}
+						<div class="cell-merged">
+							{%- if ns.img_fn -%}
+								{%- set _src = (row.get(ns.img_fn) or "")|string|trim -%}
+								{%- set _safe = _src.startswith("/") or _src.startswith("http://") or _src.startswith("https://") -%}
+								{%- if _safe -%}
+								<img class="cell-thumb-img" style="width:{{ _size }}px;height:{{ _size }}px" src="{{ frappe.utils.get_image_thumbnail_uri(_src)|e }}" alt="" />
 								{%- else -%}
-								{# Fallback thumbnail: initials + a deterministic colour matching the builder canvas. #}
-								{%- set _abbr = frappe.utils.get_abbr((row.get(_mf[0].fieldname) if _mf else "")|string) -%}
+								{# Fallback: initials from the first text field, coloured to match the builder canvas. #}
+								{%- set ns2 = namespace(txt="") -%}
+								{%- for mf in _merged -%}{%- if not ns2.txt and mf.fieldname and mf.fieldname != ns.img_fn -%}{%- set ns2.txt = row.get(mf.fieldname)|string -%}{%- endif -%}{%- endfor -%}
+								{%- set _abbr = frappe.utils.get_abbr(ns2.txt) -%}
 								{%- set _ci = "abcdefghijklmnopqrstuvwxyz0123456789".find((_abbr[:1] or "a")|lower) -%}
 								{%- set _pal = [["#EFF6FF", "#2563EB"], ["#FFF7ED", "#EA580C"], ["#F0FDF4", "#16A34A"], ["#FAF5FF", "#9333EA"], ["#FEF2F2", "#DC2626"], ["#F0FDFA", "#0D9488"]] -%}
 								{%- set _c = _pal[(_ci if _ci >= 0 else 0) % 6] -%}
-								<span class="cell-thumb" style="background:{{ _c[0] }};color:{{ _c[1] }}">{{ _abbr|e }}</span>
+								<span class="cell-thumb" style="width:{{ _size }}px;height:{{ _size }}px;font-size:{{ (_size * 0.4)|int }}px;background:{{ _c[0] }};color:{{ _c[1] }}">{{ _abbr|e }}</span>
 								{%- endif -%}
-								<div class="cell-lines">
-									{%- for mf in _mf -%}{%- if mf.fieldname -%}<div class="cell-line cell-line--{{ mf.style or 'primary' }}">{{ row.get_formatted(mf.fieldname) }}</div>{%- endif -%}{%- endfor -%}
-								</div>
-							</div>
-						{%- else -%}
+							{%- endif -%}
 							<div class="cell-lines">
-								{%- for mf in _mf -%}{%- if mf.fieldname -%}<div class="cell-line cell-line--{{ mf.style or 'primary' }}">{{ row.get_formatted(mf.fieldname) }}</div>{%- endif -%}{%- endfor -%}
+								{%- for mf in _merged -%}{%- if mf.fieldname and mf.fieldname != ns.img_fn -%}<div class="cell-line cell-line--{{ mf.style or 'primary' }}">{{ row.get_formatted(mf.fieldname) }}</div>{%- endif -%}{%- endfor -%}
 							</div>
-						{%- endif -%}
+						</div>
 					{%- else -%}
 						{# Image cells: validated URL + server-side thumbnail + escaped src. #}
 						{%- set _src = (row.get(column.options) if column.fieldtype == "Image" else row.get(column.fieldname)) or "" -%}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -28,7 +28,7 @@
 			{% for row in doc.get(df.fieldname) %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}">
 				{% for column in columns %}
-				{%- set _merged = column.merged_fields -%}
+				{%- set _merged = column.merged_fields if (column.merged_fields and column.merged_fields|length > 1) else None -%}
 				<td class="column-value{% if _merged %} column-value--merged{% endif %}" width="{{ column.width }}%" {{ field_attributes(column) }}>
 					{%- if _merged -%}
 						{# Merged cell: an image field (if any) floats left, the rest stack as styled lines. #}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -54,7 +54,7 @@
 								{%- endif -%}
 							{%- endif -%}
 							<div class="cell-lines">
-								{%- for mf in _merged -%}{%- if mf.fieldname and mf.fieldname != ns.img_fn -%}<div class="cell-line cell-line--{{ mf.style or 'primary' }}">{{ row.get_formatted(mf.fieldname) }}</div>{%- endif -%}{%- endfor -%}
+								{%- for mf in _merged -%}{%- if mf.fieldname and mf.fieldname != ns.img_fn -%}<div class="cell-line cell-line--{{ mf.style or 'primary' }}">{{ row.get_formatted(mf.fieldname)|striptags }}</div>{%- endif -%}{%- endfor -%}
 							</div>
 						</div>
 					{%- else -%}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -47,7 +47,7 @@
 								{# Fallback: initials from the first text field, coloured to match the builder canvas. #}
 								{%- set ns2 = namespace(txt="") -%}
 								{%- for mf in _merged -%}{%- if not ns2.txt and mf.fieldname and mf.fieldname != ns.img_fn -%}{%- set ns2.txt = row.get(mf.fieldname)|string -%}{%- endif -%}{%- endfor -%}
-								{%- set _abbr = frappe.utils.get_abbr(ns2.txt) -%}
+								{%- set _abbr = frappe.utils.get_abbr(ns2.txt) or "?" -%}
 								{%- set _ci = "abcdefghijklmnopqrstuvwxyz0123456789".find((_abbr[:1] or "a")|lower) -%}
 								{%- set _pal = [["#EFF6FF", "#2563EB"], ["#FFF7ED", "#EA580C"], ["#F0FDF4", "#16A34A"], ["#FAF5FF", "#9333EA"], ["#FEF2F2", "#DC2626"], ["#F0FDFA", "#0D9488"]] -%}
 								{%- set _c = _pal[(_ci if _ci >= 0 else 0) % 6] -%}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -29,7 +29,7 @@
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}">
 				{% for column in columns %}
 				{%- set _merged = column.merged_fields if (column.merged_fields and column.merged_fields|length > 1) else None -%}
-				<td class="column-value{% if _merged %} column-value--merged{% endif %}" width="{{ column.width }}%" {{ field_attributes(column) }}>
+				<td class="column-value{% if _merged %} column-value--merged{% endif %}" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style|e }}"{% endif %} {{ field_attributes(column) }}>
 					{%- if _merged -%}
 						{# Merged cell: an image field (if any) floats left, the rest stack as styled lines. #}
 						{%- set _imgtypes = ("Attach Image", "Attach") -%}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -28,16 +28,45 @@
 			{% for row in doc.get(df.fieldname) %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}">
 				{% for column in columns %}
-				<td class="column-value" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style|e }}"{% endif %} {{ field_attributes(column) }}>
-					{# Image cells: validated URL + server-side thumbnail + escaped src. #}
-					{%- set _src = (row.get(column.options) if column.fieldtype == "Image" else row.get(column.fieldname)) or "" -%}
-					{%- set _src = _src|string|trim -%}
-					{%- set _is_image = column.fieldtype in ("Attach Image", "Image") or (column.fieldtype == "Attach" and frappe.utils.is_image(_src)) -%}
-					{%- set _safe = _src.startswith("/") or _src.startswith("http://") or _src.startswith("https://") -%}
-					{%- if _is_image and _safe -%}
-						<img src="{{ frappe.utils.get_image_thumbnail_uri(_src)|e }}" alt="{{ _(column.label or '')|e }}" style="max-width: 100%; max-height: 100px;" />
+				{%- set _layout = column.cell_layout or "single" -%}
+				<td class="column-value{% if _layout != 'single' %} column-value--{{ _layout }}{% endif %}" width="{{ column.width }}%" {{ field_attributes(column) }}>
+					{%- if _layout in ("stacked", "image_text") -%}
+						{# Merged cell: render each configured field on its own styled line. #}
+						{%- set _mf = column.merged_fields or [{"fieldname": column.fieldname, "style": "primary"}] -%}
+						{%- if _layout == "image_text" -%}
+							{%- set _img = (row.get(column.image_fieldname) if column.image_fieldname else "")|string|trim -%}
+							{%- set _img_ok = _img and (_img.startswith("/") or _img.startswith("http://") or _img.startswith("https://")) -%}
+							<div class="cell-imgtext">
+								{%- if _img_ok -%}
+								<img class="cell-thumb-img" src="{{ frappe.utils.get_image_thumbnail_uri(_img)|e }}" alt="" />
+								{%- else -%}
+								{# Fallback thumbnail: initials + a deterministic colour matching the builder canvas. #}
+								{%- set _abbr = frappe.utils.get_abbr((row.get(_mf[0].fieldname) if _mf else "")|string) -%}
+								{%- set _ci = "abcdefghijklmnopqrstuvwxyz0123456789".find((_abbr[:1] or "a")|lower) -%}
+								{%- set _pal = [["#EFF6FF", "#2563EB"], ["#FFF7ED", "#EA580C"], ["#F0FDF4", "#16A34A"], ["#FAF5FF", "#9333EA"], ["#FEF2F2", "#DC2626"], ["#F0FDFA", "#0D9488"]] -%}
+								{%- set _c = _pal[(_ci if _ci >= 0 else 0) % 6] -%}
+								<span class="cell-thumb" style="background:{{ _c[0] }};color:{{ _c[1] }}">{{ _abbr|e }}</span>
+								{%- endif -%}
+								<div class="cell-lines">
+									{%- for mf in _mf -%}{%- if mf.fieldname -%}<div class="cell-line cell-line--{{ mf.style or 'primary' }}">{{ row.get_formatted(mf.fieldname) }}</div>{%- endif -%}{%- endfor -%}
+								</div>
+							</div>
+						{%- else -%}
+							<div class="cell-lines">
+								{%- for mf in _mf -%}{%- if mf.fieldname -%}<div class="cell-line cell-line--{{ mf.style or 'primary' }}">{{ row.get_formatted(mf.fieldname) }}</div>{%- endif -%}{%- endfor -%}
+							</div>
+						{%- endif -%}
 					{%- else -%}
-						{{ row.get_formatted(column.fieldname) }}
+						{# Image cells: validated URL + server-side thumbnail + escaped src. #}
+						{%- set _src = (row.get(column.options) if column.fieldtype == "Image" else row.get(column.fieldname)) or "" -%}
+						{%- set _src = _src|string|trim -%}
+						{%- set _is_image = column.fieldtype in ("Attach Image", "Image") or (column.fieldtype == "Attach" and frappe.utils.is_image(_src)) -%}
+						{%- set _safe = _src.startswith("/") or _src.startswith("http://") or _src.startswith("https://") -%}
+						{%- if _is_image and _safe -%}
+							<img src="{{ frappe.utils.get_image_thumbnail_uri(_src)|e }}" alt="{{ _(column.label or '')|e }}" style="max-width: 100%; max-height: 100px;" />
+						{%- else -%}
+							{{ row.get_formatted(column.fieldname) }}
+						{%- endif -%}
 					{%- endif -%}
 				</td>
 				{% endfor %}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -32,10 +32,15 @@
 				{%- set _merged = column.merged_fields if (column.merged_fields and column.merged_fields|length > 1) else None -%}
 				<td class="column-value{% if _merged %} column-value--merged{% endif %}" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style|e }}"{% endif %} {{ field_attributes(column) }}>
 					{%- if _merged -%}
-						{# Merged cell: an image field (if any) floats left, the rest stack as styled lines. #}
-						{%- set _imgtypes = ("Attach Image", "Attach") -%}
-						{%- set ns = namespace(img_fn=None) -%}
-						{%- for mf in _merged -%}{%- if ns.img_fn is none and mf.fieldname and mf.fieldtype in _imgtypes -%}{%- set ns.img_fn = mf.fieldname -%}{%- endif -%}{%- endfor -%}
+						{# Merged cell: an image field (if any) floats left, the rest stack as text lines (first = primary). #}
+						{%- set ns = namespace(img_fn=None, first_txt="") -%}
+						{%- for mf in _merged -%}
+							{%- if mf.fieldtype in ("Attach Image", "Attach") -%}
+								{%- if ns.img_fn is none -%}{%- set ns.img_fn = mf.fieldname -%}{%- endif -%}
+							{%- elif mf.fieldname and not ns.first_txt -%}
+								{%- set ns.first_txt = row.get(mf.fieldname)|string -%}
+							{%- endif -%}
+						{%- endfor -%}
 						{%- set _size = (column.image_size or 40)|int -%}
 						<div class="cell-merged">
 							{%- if ns.img_fn -%}
@@ -44,18 +49,16 @@
 								{%- if _safe -%}
 								<img class="cell-thumb-img" style="width:{{ _size }}px;height:{{ _size }}px" src="{{ frappe.utils.get_image_thumbnail_uri(_src)|e }}" alt="{{ _(column.label or '')|e }}" />
 								{%- else -%}
-								{# Fallback: initials from the first text field, coloured to match the builder canvas. #}
-								{%- set ns2 = namespace(txt="") -%}
-								{%- for mf in _merged -%}{%- if not ns2.txt and mf.fieldname and mf.fieldname != ns.img_fn -%}{%- set ns2.txt = row.get(mf.fieldname)|string -%}{%- endif -%}{%- endfor -%}
-								{%- set _abbr = frappe.utils.get_abbr(ns2.txt) or "?" -%}
-								{%- set _ci = "abcdefghijklmnopqrstuvwxyz0123456789".find((_abbr[:1] or "a")|lower) -%}
-								{%- set _pal = [["#EFF6FF", "#2563EB"], ["#FFF7ED", "#EA580C"], ["#F0FDF4", "#16A34A"], ["#FAF5FF", "#9333EA"], ["#FEF2F2", "#DC2626"], ["#F0FDFA", "#0D9488"]] -%}
-								{%- set _c = _pal[(_ci if _ci >= 0 else 0) % 6] -%}
-								<span class="cell-thumb" style="width:{{ _size }}px;height:{{ _size }}px;font-size:{{ (_size * 0.4)|int }}px;background:{{ _c[0] }};color:{{ _c[1] }}">{{ _abbr|e }}</span>
+								{# Fallback: initials, coloured to match the builder canvas (same hue formula, no shared palette table). #}
+								{%- set _abbr = frappe.utils.get_abbr(ns.first_txt) or "?" -%}
+								{%- set _fc = "abcdefghijklmnopqrstuvwxyz0123456789".find((_abbr[:1] or "a")|lower) -%}
+								{%- set _hue = ((_fc if _fc >= 0 else 0) * 37) % 360 -%}
+								<span class="cell-thumb" style="width:{{ _size }}px;height:{{ _size }}px;font-size:{{ (_size * 0.4)|int }}px;background:hsl({{ _hue }},65%,92%);color:hsl({{ _hue }},55%,35%)">{{ _abbr|e }}</span>
 								{%- endif -%}
 							{%- endif -%}
 							<div class="cell-lines">
-								{%- for mf in _merged -%}{%- if mf.fieldname and mf.fieldname != ns.img_fn -%}<div class="cell-line cell-line--{{ (mf.style or 'primary')|e }}">{{ row.get_formatted(mf.fieldname)|striptags|e }}</div>{%- endif -%}{%- endfor -%}
+								{%- set nsl = namespace(first=True) -%}
+								{%- for mf in _merged -%}{%- if mf.fieldname and mf.fieldname != ns.img_fn -%}<div class="cell-line{% if nsl.first %} cell-line--primary{% endif %}">{{ row.get_formatted(mf.fieldname)|striptags|e }}</div>{%- set nsl.first = False -%}{%- endif -%}{%- endfor -%}
 							</div>
 						</div>
 					{%- else -%}

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -251,8 +251,10 @@ body {
 }
 
 /* ── Merged cells (multiple fields, optional left image) ─── */
+/* Same specificity as the numeric-align rule above but declared later, so
+   this wins the cascade without needing !important. */
 .child-table .column-value--merged {
-	text-align: left !important;
+	text-align: left;
 }
 
 .child-table .cell-merged {

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -292,21 +292,20 @@ body {
 	word-break: break-word;
 }
 
-.child-table .cell-line--primary {
-	font-weight: 600;
-	color: #111827;
-}
-
+.child-table .cell-line--primary,
 .child-table .cell-line--secondary {
 	color: #111827;
 }
 
-.child-table .cell-line--mono-sm {
-	font-family: var(--monospace-font-family, monospace);
-	font-size: 0.85em;
-	color: #6b7280;
+.child-table .cell-line--primary {
+	font-weight: 600;
 }
 
+.child-table .cell-line--mono-sm {
+	font-family: var(--monospace-font-family, monospace);
+}
+
+.child-table .cell-line--mono-sm,
 .child-table .cell-line--muted-sm {
 	font-size: 0.85em;
 	color: #6b7280;

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -250,22 +250,20 @@ body {
 	text-align: right;
 }
 
-/* ── Merged "Stacked" / "Image + text" cells ─────────────── */
-.child-table .column-value--stacked,
-.child-table .column-value--image_text {
+/* ── Merged cells (multiple fields, optional left image) ─── */
+.child-table .column-value--merged {
 	text-align: left !important;
 }
 
-.child-table .cell-imgtext {
+.child-table .cell-merged {
 	display: flex;
 	align-items: flex-start;
 	gap: 0.5rem;
 }
 
+/* size comes from an inline style (column.image_size) */
 .child-table .cell-thumb-img,
 .child-table .cell-thumb {
-	width: 34px;
-	height: 34px;
 	border-radius: 6px;
 	flex-shrink: 0;
 }
@@ -278,7 +276,6 @@ body {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 0.72em;
 	font-weight: 600;
 	text-transform: uppercase;
 	line-height: 1;

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -290,14 +290,25 @@ body {
 
 .child-table .cell-line {
 	word-break: break-word;
-	font-size: 0.85em;
-	color: #6b7280;
+}
+
+.child-table .cell-line--primary,
+.child-table .cell-line--secondary {
+	color: #111827;
 }
 
 .child-table .cell-line--primary {
-	font-size: 1em;
 	font-weight: 600;
-	color: #111827;
+}
+
+.child-table .cell-line--mono-sm {
+	font-family: var(--monospace-font-family, monospace);
+}
+
+.child-table .cell-line--mono-sm,
+.child-table .cell-line--muted-sm {
+	font-size: 0.85em;
+	color: #6b7280;
 }
 
 .page-break {

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -250,6 +250,71 @@ body {
 	text-align: right;
 }
 
+/* ── Merged "Stacked" / "Image + text" cells ─────────────── */
+.child-table .column-value--stacked,
+.child-table .column-value--image_text {
+	text-align: left !important;
+}
+
+.child-table .cell-imgtext {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5rem;
+}
+
+.child-table .cell-thumb-img,
+.child-table .cell-thumb {
+	width: 34px;
+	height: 34px;
+	border-radius: 6px;
+	flex-shrink: 0;
+}
+
+.child-table .cell-thumb-img {
+	object-fit: cover;
+}
+
+.child-table .cell-thumb {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 0.72em;
+	font-weight: 600;
+	text-transform: uppercase;
+	line-height: 1;
+}
+
+.child-table .cell-lines {
+	display: flex;
+	flex-direction: column;
+	gap: 0.1rem;
+	min-width: 0;
+}
+
+.child-table .cell-line {
+	word-break: break-word;
+}
+
+.child-table .cell-line--primary {
+	font-weight: 600;
+	color: #111827;
+}
+
+.child-table .cell-line--secondary {
+	color: #111827;
+}
+
+.child-table .cell-line--mono-sm {
+	font-family: var(--monospace-font-family, monospace);
+	font-size: 0.85em;
+	color: #6b7280;
+}
+
+.child-table .cell-line--muted-sm {
+	font-size: 0.85em;
+	color: #6b7280;
+}
+
 .page-break {
 	page-break-after: always;
 }

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -290,25 +290,14 @@ body {
 
 .child-table .cell-line {
 	word-break: break-word;
-}
-
-.child-table .cell-line--primary,
-.child-table .cell-line--secondary {
-	color: #111827;
+	font-size: 0.85em;
+	color: #6b7280;
 }
 
 .child-table .cell-line--primary {
+	font-size: 1em;
 	font-weight: 600;
-}
-
-.child-table .cell-line--mono-sm {
-	font-family: var(--monospace-font-family, monospace);
-}
-
-.child-table .cell-line--mono-sm,
-.child-table .cell-line--muted-sm {
-	font-size: 0.85em;
-	color: #6b7280;
+	color: #111827;
 }
 
 .page-break {


### PR DESCRIPTION
Turn several child-table fields into one tidy cell — like a product column showing image, name, code, and description together instead of four separate columns.

How it works
Hit the merge toggle on any column → its own field locks in as the primary line.

+ Add field to stack more. Pick a style per line (Primary / Secondary / Code / Muted).
Got an image field in the mix? It floats left automatically, sized to taste — no image, and you get clean colored initials instead.
- Merge multiple child-table fields into one cell (canvas + PDF)
- Optional image on the left, auto-detected from merged fields
- Resizable image size (16–200px)
- Per-line text style: Primary / Secondary / Code / Muted
- Colored initials fallback when no image is set
- Numeric columns left-align when merged (instead of default right-align)
- Undo/redo (Ctrl/Cmd+Z) in the builder



https://github.com/user-attachments/assets/fce36034-f829-46e6-aa09-417810295c99




`no-docs`