### PR TITLE
fix: auto-assignment fails to follow document when triggered by web user

### DIFF
--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -14,7 +14,7 @@ from frappe.desk.doctype.notification_log.notification_log import (
 	get_title,
 	get_title_html,
 )
-from frappe.desk.form.document_follow import follow_document
+from frappe.desk.form.document_follow import _follow_document
 from frappe.utils.data import strip_html
 
 
@@ -118,7 +118,9 @@ def _add(args: dict[str, Any] | None = None, *, ignore_permissions: bool | int =
 
 			# make this document followed by assigned user
 			if frappe.get_cached_value("User", assign_to, "follow_assigned_documents"):
-				follow_document(args["doctype"], args["name"], assign_to)
+				_follow_document(
+					args["doctype"], args["name"], assign_to, ignore_permissions=ignore_permissions
+				)
 
 			# notify
 			notify_assignment(

--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -28,6 +28,12 @@ def update_follow(doctype: str, doc_name: str, following: bool | str):
 
 @frappe.whitelist()
 def follow_document(doctype: str, doc_name: str, user: str) -> Document | bool:
+	return _follow_document(doctype, doc_name, user, ignore_permissions=False)
+
+
+def _follow_document(
+	doctype: str, doc_name: str, user: str, *, ignore_permissions: bool | int = False
+) -> Document | bool:
 	"""
 	param:
 	Doctype name
@@ -61,7 +67,11 @@ def follow_document(doctype: str, doc_name: str, user: str) -> Document | bool:
 		frappe.toast(_("Administrator can't follow"))
 		return False
 
-	if user != frappe.session.user and not frappe.has_permission("Document Follow", "write"):
+	if (
+		not ignore_permissions
+		and user != frappe.session.user
+		and not frappe.has_permission("Document Follow", "write")
+	):
 		frappe.throw(_("You can only follow documents for yourself."), frappe.PermissionError)
 
 	if not frappe.has_permission(doctype, "read", doc=doc_name, user=user):
@@ -74,7 +84,7 @@ def follow_document(doctype: str, doc_name: str, user: str) -> Document | bool:
 	if not is_document_followed(doctype, doc_name, user):
 		doc = frappe.new_doc("Document Follow")
 		doc.update({"ref_doctype": doctype, "ref_docname": doc_name, "user": user})
-		doc.save()
+		doc.save(ignore_permissions=ignore_permissions)
 		frappe.toast(_("Following document {0}").format(doc_name))
 		return doc
 

--- a/frappe/email/doctype/document_follow/test_document_follow.py
+++ b/frappe/email/doctype/document_follow/test_document_follow.py
@@ -135,6 +135,23 @@ class TestDocumentFollow(IntegrationTestCase):
 		documents_followed = get_events_followed_by_user(event.name, user.name)
 		self.assertTrue(documents_followed)
 
+	def test_follow_on_assign_from_low_permission_session(self):
+		assignee = get_user(DocumentFollowConditions(0, 0, 0, 1))
+		event = get_event()
+
+		web_user = get_web_user()
+		frappe.set_user(web_user.name)
+
+		from frappe.desk.form.assign_to import _add
+
+		_add(
+			{"assign_to": [assignee.name], "doctype": event.doctype, "name": event.name},
+			ignore_permissions=True,
+		)
+
+		frappe.set_user("Administrator")
+		self.assertTrue(get_events_followed_by_user(event.name, assignee.name))
+
 	def test_do_not_follow_on_assign(self):
 		user = get_user()
 		frappe.set_user(user.name)
@@ -318,6 +335,19 @@ def get_user(document_follow=None):
 	doc.__dict__.update(document_follow.__dict__ if document_follow else {})
 	doc.insert()
 	doc.add_roles("System Manager")
+	return doc
+
+
+def get_web_user():
+	frappe.set_user("Administrator")
+	if frappe.db.exists("User", "webuser@docsub.com"):
+		frappe.delete_doc("User", "webuser@docsub.com")
+	doc = frappe.new_doc("User")
+	doc.email = "webuser@docsub.com"
+	doc.first_name = "Web"
+	doc.user_type = "Website User"
+	doc.send_welcome_email = 0
+	doc.insert()
 	return doc
 
 


### PR DESCRIPTION
## Summary

This fixes a permission error that could happen when an auto-assignment rule was triggered from a webform submission.

## Root Cause

Auto-assignment runs in the same session that triggered it, including a web user submitting a webform. While creating the assignment already used `ignore_permissions=True`, the "follow document on assign" step didn't.

Because of that, it tried to create the follow entry as the web user. Since web users don't have permission to create `Document Follow` records, the assignment failed with a permission error.

## Fix

Pass `ignore_permissions` through to the internal follow logic, keeping it consistent with the existing ToDo creation and document sharing steps.

The public `follow_document` API is unchanged and still enforces permission checks. Only the internal `_follow_document` helper accepts the permission bypass, so this doesn't allow web users to follow documents for other users.

---
Closes #35813