### PR TITLE
fix: monitor flush leaves one entry in redis, duplicating it every cycle

### DIFF
--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -134,4 +134,4 @@ def flush():
 			f.write("\n")
 
 	# Remove fetched entries from cache
-	frappe.cache.ltrim(MONITOR_REDIS_KEY, len(logs) - 1, -1)
+	frappe.cache.ltrim(MONITOR_REDIS_KEY, len(logs), -1)

--- a/frappe/tests/test_monitor.py
+++ b/frappe/tests/test_monitor.py
@@ -81,6 +81,26 @@ class TestMonitor(IntegrationTestCase):
 		log = frappe.parse_json(logs[0])
 		self.assertEqual(log.transaction_type, "request")
 
+	def test_flush_clears_redis(self):
+		set_request(method="GET", path="/api/method/frappe.ping")
+		response = build_response("json")
+
+		for _ in range(3):
+			frappe.monitor.start()
+			frappe.monitor.stop(response)
+
+		self.assertEqual(frappe.cache.llen(MONITOR_REDIS_KEY), 3)
+
+		open(frappe.monitor.log_file(), "w").close()
+		frappe.monitor.flush()
+
+		self.assertEqual(frappe.cache.llen(MONITOR_REDIS_KEY), 0)
+
+		frappe.monitor.flush()
+		with open(frappe.monitor.log_file()) as f:
+			logs = f.readlines()
+		self.assertEqual(len(logs), 3)
+
 	def test_trace_ids(self):
 		set_request(method="GET", path="/api/method/frappe.ping")
 		response = build_response("json")


### PR DESCRIPTION
## Summary

This fixes a small off-by-one error in `flush()` that caused the last processed monitor entry to remain in Redis after each flush.

## Root Cause

`flush()` reads all monitor entries, writes them to `monitor.json.log`, and then trims the Redis list. The trim used `ltrim(..., len(logs) - 1, -1)`, which kept the last fetched entry instead of removing it.

That leftover entry was written again on the next flush, resulting in one duplicate log line per flush.

## Fix

Change the trim to `ltrim(MONITOR_REDIS_KEY, len(logs), -1)` so all processed entries are removed, while any new entries added after the read are preserved.

---

Closes #40341