### PR TITLE
fix: view documentation design in tooltip

### DIFF
--- a/frappe/public/js/frappe/form/info_card.js
+++ b/frappe/public/js/frappe/form/info_card.js
@@ -43,9 +43,9 @@ export class InfoCard {
 			if (this.df.description && this.df.show_description_on_click) {
 				card_args.message += "<br>";
 			}
-			card_args.message += `<a style="display: inline-block; text-underline-offset: 2px;" class="py-1" href="${
+			card_args.message += `<a style="display: inline-flex; align-items: center; gap: 4px; text-decoration: underline; text-underline-offset: 2px;" class="py-1" href="${
 				this.df.documentation_url
-			}" target="_blank">${__("View Documentation")}</a>`;
+			}" target="_blank">${frappe.utils.icon("link-url", "sm")}${__("View Documentation")}</a>`;
 		}
 		this.card = new frappe.ui.SidebarCard(card_args);
 	}

--- a/frappe/public/js/frappe/form/info_card.js
+++ b/frappe/public/js/frappe/form/info_card.js
@@ -45,7 +45,9 @@ export class InfoCard {
 			}
 			card_args.message += `<a style="display: inline-flex; align-items: center; gap: 4px; text-decoration: underline; text-underline-offset: 2px;" class="py-1" href="${
 				this.df.documentation_url
-			}" target="_blank">${frappe.utils.icon("link-url", "sm")}${__("View Documentation")}</a>`;
+			}" target="_blank">${frappe.utils.icon("link-url", "sm")}${__(
+				"View Documentation"
+			)}</a>`;
 		}
 		this.card = new frappe.ui.SidebarCard(card_args);
 	}


### PR DESCRIPTION
Improvised design for the view documentation in tooltip

Before: 
<img width="1440" height="858" alt="image" src="https://github.com/user-attachments/assets/6c6502fa-8827-44fb-96f8-3e415588a77b" />

After: 
 
<img width="821" height="363" alt="image" src="https://github.com/user-attachments/assets/28fb2aab-8ea0-4598-8a52-d18f315ef079" />
