### PR TITLE
fix(doctype): validate Check field default value properly

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1465,8 +1465,8 @@ def validate_fields(meta: Meta):
 			default_value = cstr(d.default).strip()
 			if default_value not in ("0", "1"):
 				frappe.throw(
-					_("Default for 'Check' type of field {0} must be either '0' or '1'").format(
-						frappe.bold(d.fieldname)
+					_("The default value for the Check field {0} must be either '0' or '1'").format(
+						frappe.bold(d.label or d.fieldname)
 					)
 				)
 			d.default = default_value

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -33,7 +33,7 @@ from frappe.modules import get_doc_path, make_boilerplate
 from frappe.modules.import_file import get_file_path
 from frappe.permissions import ALL_USER_ROLE, AUTOMATIC_ROLES, SYSTEM_USER_ROLE
 from frappe.query_builder.functions import Concat
-from frappe.utils import cint, flt, get_datetime, is_a_property, random_string
+from frappe.utils import cint, cstr, flt, get_datetime, is_a_property, random_string
 from frappe.website.utils import clear_cache
 
 if TYPE_CHECKING:
@@ -1461,12 +1461,15 @@ def validate_fields(meta: Meta):
 	def check_illegal_default(d):
 		if d.fieldtype == "Check" and not d.default:
 			d.default = "0"
-		if d.fieldtype == "Check" and cint(d.default) not in (0, 1):
-			frappe.throw(
-				_("Default for 'Check' type of field {0} must be either '0' or '1'").format(
-					frappe.bold(d.fieldname)
+		if d.fieldtype == "Check":
+			default_value = cstr(d.default).strip()
+			if default_value not in ("0", "1"):
+				frappe.throw(
+					_("Default for 'Check' type of field {0} must be either '0' or '1'").format(
+						frappe.bold(d.fieldname)
+					)
 				)
-			)
+			d.default = default_value
 		if d.fieldtype == "Select" and d.default:
 			if not d.options:
 				frappe.throw(


### PR DESCRIPTION
`cint()` silently falls back to 0 for non-numeric input, so a default like "Test" passed validation unnoticed. 
Compare the trimmed string against "0"/"1" directly and normalize the stored default.

---
https://github.com/user-attachments/assets/0b1c0e7e-5c41-4428-8dfb-e77cfaeeb76f


`no-docs`

