### PR TITLE
fix: enforce permlevel read permission on order_by/group_by fields

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -327,9 +327,11 @@ from {tables}
 		self.set_order_by(args)
 
 		self.validate_order_by_and_group_by(args.order_by)
+		self.validate_fieldlevel_permissions_for_sort(args.order_by)
 		args.order_by = (args.order_by and (" order by " + args.order_by)) or ""
 
 		self.validate_order_by_and_group_by(self.group_by)
+		self.validate_fieldlevel_permissions_for_sort(self.group_by)
 		args.group_by = (self.group_by and (" group by " + self.group_by)) or ""
 
 		return args
@@ -1237,6 +1239,41 @@ from {tables}
 			for func in blacklisted_sql_functions:
 				if re.search(r"\b" + re.escape(func) + r"\W*\(", field.lower()):
 					frappe.throw(_("Cannot use {0} in order/group by").format(field))
+
+	def validate_fieldlevel_permissions_for_sort(self, parameters: str):
+		"""Block sorting/grouping by a field the user can't read at its permlevel."""
+		if not parameters or self.flags.ignore_permissions:
+			return
+
+		from frappe.desk.reportview import extract_fieldnames
+
+		for column in extract_fieldnames(parameters):
+			if not column or column == "*" or column[0] in {"'", '"'} or column.isnumeric():
+				continue
+
+			doctype = self.doctype
+			fieldname = column
+			if "." in column:
+				table, fieldname = column.split(".", 1)
+				doctype = self.linked_table_aliases.get(table, table)
+				doctype = doctype.replace("`", "").removeprefix("tab")
+
+			# Only real docfields with permlevel > 0 are gated. Standard/meta fields,
+			# aliases and pseudo-columns (get_field returns None) and permlevel-0 fields
+			# are always readable
+			df = frappe.get_meta(doctype).get_field(fieldname)
+			if not df or not df.permlevel:
+				continue
+
+			permitted = get_permitted_fields(
+				doctype=doctype,
+				parenttype=self.parent_doctype,
+				permission_type=self.permission_map.get(doctype),
+			)
+			if fieldname not in permitted:
+				raise frappe.PermissionError(
+					_("Not permitted to sort or group by {0}").format(frappe.bold(fieldname))
+				)
 
 	def add_limit(self):
 		if self.limit_page_length:

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -941,6 +941,37 @@ class TestDBQuery(FrappeTestCase):
 			self.assertTrue("name" in data[0])
 			self.assertEqual(len(data[0]), 1)
 
+	def test_permlevel_fields_in_order_by(self):
+		# A permlevel-protected field must not be usable in order by / group by,
+		# else its value leaks via a sorting side-channel oracle.
+		with setup_patched_blog_post(), setup_test_user(set_user=True):
+			for order_by in (
+				"published",
+				"`published` desc",
+				"`tabBlog Post`.`published`",
+				"field(strcmp(published, '1'), -1), name",
+			):
+				self.assertRaises(
+					frappe.PermissionError,
+					frappe.get_list,
+					"Blog Post",
+					fields=["name"],
+					order_by=order_by,
+					limit=1,
+				)
+
+			self.assertRaises(
+				frappe.PermissionError,
+				frappe.get_list,
+				"Blog Post",
+				fields=["name"],
+				group_by="published",
+				limit=1,
+			)
+
+			# permlevel-0 field must still be sortable
+			frappe.get_list("Blog Post", fields=["name"], order_by="title asc", limit=1)
+
 			data = frappe.get_list(
 				"Blog Post",
 				filters={"published": 1},


### PR DESCRIPTION
A low-privilege user could recover values of permlevel-protected fields by referencing them in `order_by`/`group_by` (e.g. `field(strcmp(secret,'x'),-1)`) and observing row order — the field is hidden from output but still influences the SQL `ORDER BY`, acting as a side-channel oracle.

This enforces field-level (permlevel) read permission on columns referenced in `order_by`/`group_by`, consistent with how selected fields are already filtered. Adds a regression test.

Ref: https://support.frappe.io/helpdesk/tickets/71227?view=VIEW-HD+Ticket-1547