### PR TITLE
fix(database): scope index subquery to current schema in get_table_co…

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -343,24 +343,26 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 	def get_table_columns_description(self, table_name):
 		"""Return list of columns with descriptions."""
 		return self.sql(
-			f"""select
+			"""select
 			column_name as 'name',
 			column_type as 'type',
 			column_default as 'default',
 			COALESCE(
 				(select 1
 				from information_schema.statistics
-				where table_name="{table_name}"
+				where table_name=%(table_name)s
 					and column_name=columns.column_name
 					and NON_UNIQUE=1
 					and Seq_in_index = 1
+					and table_schema = %(schema)s
 					limit 1
 			), 0) as 'index',
 			column_key = 'UNI' as 'unique',
 			(is_nullable = 'NO') AS 'not_nullable'
 			from information_schema.columns as columns
-			where table_name = '{table_name}'
-   			and table_schema = '{frappe.db.cur_db_name}' """,
+			where table_name = %(table_name)s
+   			and table_schema = %(schema)s """,
+			{"table_name": table_name, "schema": self.cur_db_name},
 			as_dict=1,
 		)
 

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -370,24 +370,26 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 	def get_table_columns_description(self, table_name):
 		"""Return list of columns with descriptions."""
 		return self.sql(
-			f"""select
+			"""select
 			column_name as 'name',
 			column_type as 'type',
 			column_default as 'default',
 			COALESCE(
 				(select 1
 				from information_schema.statistics
-				where table_name="{table_name}"
+				where table_name=%(table_name)s
 					and column_name=columns.column_name
 					and NON_UNIQUE=1
 					and Seq_in_index = 1
+					and table_schema = %(schema)s
 					limit 1
 			), 0) as 'index',
 			column_key = 'UNI' as 'unique',
 			(is_nullable = 'NO') AS 'not_nullable'
 			from information_schema.columns as columns
-			where table_name = '{table_name}'
-   			and table_schema = '{frappe.db.cur_db_name}' """,
+			where table_name = %(table_name)s
+   			and table_schema = %(schema)s """,
+			{"table_name": table_name, "schema": self.cur_db_name},
 			as_dict=1,
 		)
 


### PR DESCRIPTION
## Summary

This fixes an issue where `get_table_columns_description` on MariaDB could incorrectly report a column as indexed.

## Root Cause

The correlated subquery against `information_schema.statistics` only filters on `table_name`, not `table_schema`. Since Frappe sites live in separate databases but share the same `tab<Doctype>` table names, the query could pick up index metadata from another site's database.

This could make schema migration think an index already exists when it doesn't, causing it to skip creating the index. It also scans more metadata than necessary.

## Fix

Scope the subquery to the current database by adding `table_schema = current_db`. This keeps the index check accurate and avoids scanning index metadata from other schemas.

Applied the same fix to both MariaDB drivers (`database.py` and `mysqlclient.py`).

---

Closes #40321