### PR TITLE
feat: add site_age to pulse boot_config

### DIFF
--- a/frappe/utils/telemetry/pulse/client.py
+++ b/frappe/utils/telemetry/pulse/client.py
@@ -38,6 +38,10 @@ def boot_config() -> dict:
 	if not is_enabled():
 		return {"enabled": False}
 
+	# Local import: telemetry/__init__ imports this module, so a top-level import
+	# would be a cycle (site_age is defined after that import runs).
+	from frappe.utils.telemetry import site_age
+
 	host = pulse_host()
 
 	session_user = frappe.session.user
@@ -54,6 +58,7 @@ def boot_config() -> dict:
 		"site": frappe.local.site,
 		"user": anonymize_user(session_user),
 		"team": frappe.conf.get("fc_team"),
+		"site_age": site_age(),
 	}
 
 

--- a/frappe/utils/telemetry/pulse/test_pulse_client.py
+++ b/frappe/utils/telemetry/pulse/test_pulse_client.py
@@ -343,6 +343,15 @@ class TestTelemetryGate(TestPulseClient):
 		with self._conf(fc_team="team_x"), patch("frappe.get_system_settings", return_value=True):
 			self.assertEqual(boot_config()["team"], "team_x")
 
+	def test_boot_config_includes_site_age(self):
+		# Exposed so frappe-ui apps can gate onboarding-only tracking the way desk does.
+		with (
+			self._conf(),
+			patch("frappe.get_system_settings", return_value=True),
+			patch("frappe.utils.telemetry.site_age", return_value=3),
+		):
+			self.assertEqual(boot_config()["site_age"], 3)
+
 	def test_client_url_is_absolute_when_host_lacks_scheme(self):
 		# A scheme-less pulse_host must still yield an absolute client_url, else the
 		# browser resolves the import against the Frappe origin and telemetry never loads.


### PR DESCRIPTION
Adds `site_age` (days since site creation) to the whitelisted `boot_config()`
response so frappe-ui SPAs can gate onboarding-only telemetry the same way desk
does — desk already has this via `boot.telemetry_site_age`, SPAs had no way to
read it.

- `site_age` sourced from the existing cached `site_age()` helper (no extra cost)
- Imported locally inside `boot_config()` to avoid the telemetry package import cycle
- Backward compatible: older clients just ignore the new key

`no-docs`