### PR TITLE
fix: make postgres transactions read committed by default

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -26,7 +26,7 @@ from psycopg2.errors import (
 	SequenceGeneratorLimitExceeded,
 	SyntaxError,
 )
-from psycopg2.extensions import ISOLATION_LEVEL_REPEATABLE_READ
+from psycopg2.extensions import ISOLATION_LEVEL_READ_COMMITTED
 
 import frappe
 from frappe.database.database import CREATE_OR_DROP, Database
@@ -264,7 +264,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			conn_settings["port"] = self.port
 
 		conn = psycopg2.connect(**conn_settings)
-		conn.set_isolation_level(ISOLATION_LEVEL_REPEATABLE_READ)
+		conn.set_isolation_level(ISOLATION_LEVEL_READ_COMMITTED)
 
 		return conn
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -96,10 +96,10 @@ class PostgresExceptionUtil:
 	@staticmethod
 	def is_deadlocked(e):
 		# Treat serialization failures like deadlocks: both are retriable transaction-rollback
-		# (class 40) errors. Under REPEATABLE READ, a write-write conflict makes MariaDB lock and
-		# wait, but postgres aborts the loser with SERIALIZATION_FAILURE ("could not serialize
-		# access due to concurrent update"). Classifying it here routes it through frappe's deadlock
-		# retry instead of surfacing as an unhandled query error.
+		# (class 40) errors. READ COMMITTED (the default now) doesn't raise SERIALIZATION_FAILURE
+		# on plain write conflicts, but transactions explicitly run at a stricter level still can;
+		# keep classifying it here so those route through frappe's deadlock retry instead of
+		# surfacing as an unhandled query error.
 		return getattr(e, "pgcode", None) in (DEADLOCK_DETECTED, SERIALIZATION_FAILURE)
 
 	@staticmethod


### PR DESCRIPTION
Reason: apps (like ERPNext) already handle concurrency through row locks, repeatable read under high concurrent load is always bound to error. It is impossible to gauge the randomness of transactions as a single action in ERPNext can touch many different tables