### PR TITLE
feat(ui): add synthetic list columns to ColumnSettings/ListView

### DIFF
--- a/ui/src/components/ColumnSettings/ColumnSettings.vue
+++ b/ui/src/components/ColumnSettings/ColumnSettings.vue
@@ -140,13 +140,21 @@ import { Button, Combobox, Popover, TextInput } from "frappe-ui";
 import Draggable from "vuedraggable";
 import { useDoctypeMeta } from "../../composables/useDoctypeMeta";
 import { getColumnOptions } from "./getColumnOptions";
-import type { Column, ColumnOption } from "./types";
+import type { Column, ColumnOption, SyntheticColumn } from "./types";
 
 const props = withDefaults(
-	defineProps<{ doctype: string; hideLabel?: boolean; canReset?: boolean }>(),
+	defineProps<{
+		doctype: string;
+		hideLabel?: boolean;
+		canReset?: boolean;
+		// Host-declared synthetic columns (ADR-0033): the picker offers these in
+		// union with Meta fields, so a hidden synthetic column stays re-addable.
+		synthetic?: SyntheticColumn[];
+	}>(),
 	{
 		hideLabel: false,
 		canReset: false,
+		synthetic: () => [],
 	}
 );
 
@@ -179,8 +187,11 @@ const popoverRef = ref<{ open: () => void } | null>(null);
 
 const { meta } = useDoctypeMeta(props.doctype);
 
-// Field Options derived client-side from Meta — no CRM endpoint.
-const allOptions = computed<ColumnOption[]>(() => getColumnOptions(meta.value?.fields ?? []));
+// Field Options derived client-side from Meta, unioned with the host's synthetic
+// columns (ADR-0033) — no CRM endpoint.
+const allOptions = computed<ColumnOption[]>(() =>
+	getColumnOptions(meta.value?.fields ?? [], props.synthetic)
+);
 
 // The "add" picker offers every column not already shown.
 const addableOptions = computed<ColumnOption[]>(() => {

--- a/ui/src/components/ColumnSettings/columns.ts
+++ b/ui/src/components/ColumnSettings/columns.ts
@@ -1,6 +1,12 @@
 import type { RawMetaField } from "../FormLayout/types";
 import type { Column, SyntheticColumn, WireColumn } from "./types";
 
+/** The leading character reserved for a synthetic column's `key` (ADR-0033), so it
+ *  can never collide with a docfield. A `_`-prefixed column in a persisted layout is
+ *  only valid while a live declaration still claims it — see
+ *  {@link dropOrphanedSyntheticColumns}. */
+export const SYNTHETIC_KEY_PREFIX = "_";
+
 /** Auto-width (fr) a column flexes to when its Column carries no explicit `width`.
  *  frappe-ui's `getGridTemplateColumns` renders a *number* as `fr` (flex, fills
  *  the available track) and a *string* (`"150px"`, `"10rem"`) as a fixed size — so
@@ -128,6 +134,27 @@ export function clearColumnWidth(
     const { width: _omit, ...rest } = c;
     return rest;
   });
+}
+
+/**
+ * Drop **orphaned synthetic columns** from a persisted layout: any `_`-prefixed
+ * column (a synthetic `key`, ADR-0033) no longer claimed by a live declaration. A
+ * customized layout can outlive the declaration that seeded it — the host stops
+ * declaring the Record indicator, yet `_indicator` still sits in the stored
+ * `Column[]`. Left in, it names no docfield, so `serializeColumns` mistakes it for a
+ * `Data` field and `fetchFields` requests it, erroring `get_list`. This scrubs it on
+ * read, keeping the rest of the user's customization; a docfield column (no `_`) is
+ * always kept. Returns the same reference when nothing is orphaned (byte-identical),
+ * so a layout with no synthetic residue is untouched.
+ */
+export function dropOrphanedSyntheticColumns(
+  columns: Column[],
+  synthetic: SyntheticColumn[]
+): Column[] {
+  const live = new Set(synthetic.map((s) => s.key));
+  const isOrphan = (c: Column) =>
+    c.fieldname.startsWith(SYNTHETIC_KEY_PREFIX) && !live.has(c.fieldname);
+  return columns.some(isOrphan) ? columns.filter((c) => !isOrphan(c)) : columns;
 }
 
 /**

--- a/ui/src/components/ColumnSettings/columns.ts
+++ b/ui/src/components/ColumnSettings/columns.ts
@@ -1,5 +1,5 @@
 import type { RawMetaField } from "../FormLayout/types";
-import type { Column, WireColumn } from "./types";
+import type { Column, SyntheticColumn, WireColumn } from "./types";
 
 /** Auto-width (fr) a column flexes to when its Column carries no explicit `width`.
  *  frappe-ui's `getGridTemplateColumns` renders a *number* as `fr` (flex, fills
@@ -33,25 +33,51 @@ export function getColumnAlign(fieldtype: string): "left" | "right" {
  * the available space (a numeric `fr`, larger for the leading column); only a
  * resized column carries a fixed px `width`. A Column with no Meta field — a
  * standard field like `name` that isn't in `meta.fields` — falls back to a
- * left-aligned `Data` column. The inverse of {@link parseColumns}.
+ * left-aligned `Data` column. A Column whose `fieldname` matches a host-declared
+ * synthetic column (ADR-0033) takes its render metadata from the declaration instead
+ * of Meta. The inverse of {@link parseColumns}.
  */
 export function serializeColumns(
   columns: Column[],
-  fields: RawMetaField[]
+  fields: RawMetaField[],
+  synthetic: SyntheticColumn[] = []
 ): WireColumn[] {
   const byName = new Map(fields.map((f) => [f.fieldname, f]));
+  const bySynthetic = new Map(synthetic.map((s) => [s.key, s]));
+  const autoWidth = (i: number) => (i === 0 ? AUTO_LEADING_FR : AUTO_FR);
   return columns.map((c, i) => {
+    const declaration = bySynthetic.get(c.fieldname);
+    if (declaration) return syntheticWireColumn(c, declaration, autoWidth(i));
     const field = byName.get(c.fieldname);
     const type = field?.fieldtype ?? "Data";
     return {
       key: c.fieldname,
       label: c.label,
-      width: c.width ?? (i === 0 ? AUTO_LEADING_FR : AUTO_FR),
+      width: c.width ?? autoWidth(i),
       type,
       options: field?.options,
       align: getColumnAlign(type),
     };
   });
+}
+
+/** The wire form of a synthetic column (ADR-0033): its `type`/`align` come from the
+ *  host declaration (never Meta), while a user resize (`column.width`) still overrides
+ *  the declaration's default width, falling back to the auto `fr` when neither is set. */
+function syntheticWireColumn(
+  column: Column,
+  declaration: SyntheticColumn,
+  autoWidth: number
+): WireColumn {
+  const type = declaration.type ?? "Data";
+  return {
+    key: column.fieldname,
+    label: column.label,
+    width: column.width ?? declaration.width ?? autoWidth,
+    type,
+    options: undefined,
+    align: declaration.align ?? getColumnAlign(type),
+  };
 }
 
 /**
@@ -102,4 +128,21 @@ export function clearColumnWidth(
     const { width: _omit, ...rest } = c;
     return rest;
   });
+}
+
+/**
+ * The field set `get_list` fetches for a set of wire columns: `name` plus each
+ * column's key, minus the host-declared synthetic columns (ADR-0033). A synthetic
+ * key (`_indicator`) names no docfield, so requesting it would error the fetch —
+ * the real fields its cell reads are the host's concern, fetched separately. Deduped.
+ * With no synthetic declarations it is `name` + every key (byte-identical default).
+ * The library-side companion to a host's own fetch-field builder.
+ */
+export function fetchFields(
+  wire: WireColumn[],
+  synthetic: SyntheticColumn[] = []
+): string[] {
+  const syntheticKeys = new Set(synthetic.map((s) => s.key));
+  const keys = wire.map((c) => c.key).filter((key) => !syntheticKeys.has(key));
+  return Array.from(new Set(["name", ...keys]));
 }

--- a/ui/src/components/ColumnSettings/getColumnOptions.ts
+++ b/ui/src/components/ColumnSettings/getColumnOptions.ts
@@ -1,5 +1,5 @@
 import type { RawMetaField } from "../FormLayout/types";
-import type { ColumnOption } from "./types";
+import type { ColumnOption, SyntheticColumn } from "./types";
 
 /** Fieldtypes that hold no list-renderable value — layout/presentation breaks and
  *  child tables. A column can't be shown for any of these, so they're dropped from
@@ -35,16 +35,22 @@ const toOption = (label: string, fieldname: string): ColumnOption => ({
 /**
  * Derive a doctype's available column Field Options from its Meta fields,
  * client-side: drop the layout/no-data fieldtypes and child tables, keep only
- * fields with both a label and fieldname, then append the standard fields. The
- * component filters out already-selected columns; this stays a pure Meta→options
- * map. See CONTEXT.md ("Field Options").
+ * fields with both a label and fieldname, then append the standard fields and any
+ * host-declared synthetic columns (ADR-0033) — the union so a hidden synthetic
+ * column stays re-addable, since it is not a Meta field. The component filters out
+ * already-selected columns; this stays a pure Meta→options map. See CONTEXT.md
+ * ("Field Options").
  */
-export function getColumnOptions(fields: RawMetaField[]): ColumnOption[] {
+export function getColumnOptions(
+  fields: RawMetaField[],
+  synthetic: SyntheticColumn[] = []
+): ColumnOption[] {
   const fieldOptions = fields
     .filter(
       (f) => !NON_COLUMN_FIELDTYPES.has(f.fieldtype) && f.label && f.fieldname
     )
     .map((f) => toOption(f.label as string, f.fieldname));
   const standard = STANDARD_FIELDS.map((f) => toOption(f.label, f.fieldname));
-  return [...fieldOptions, ...standard];
+  const declared = synthetic.map((s) => toOption(s.label, s.key));
+  return [...fieldOptions, ...standard, ...declared];
 }

--- a/ui/src/components/ColumnSettings/getDefaultColumns.ts
+++ b/ui/src/components/ColumnSettings/getDefaultColumns.ts
@@ -58,9 +58,10 @@ function toColumn(declaration: SyntheticColumn): Column {
  * each declaration is inserted at its `place` anchor (`'start'` | `'after-title'`
  * [right after the leading title/name column] | `'end'`, default `'end'`), and any
  * docfield it `subsumes` is dropped from the seed (default-only, so it stays
- * re-addable). Seeds the default `shown` *only* — once the user customizes order, the
- * persisted layout wins. With no declarations it returns the seed untouched (same
- * reference), so a consumer that declares none is byte-identical.
+ * re-addable). Columns sharing an anchor keep their declaration order. Seeds the
+ * default `shown` *only* — once the user customizes order, the persisted layout wins.
+ * With no declarations it returns the seed untouched (same reference), so a consumer
+ * that declares none is byte-identical.
  */
 export function foldSyntheticColumns(
   defaults: Column[],
@@ -70,12 +71,15 @@ export function foldSyntheticColumns(
   const subsumed = new Set(
     synthetic.map((s) => s.subsumes).filter((f): f is string => !!f)
   );
-  const columns = defaults.filter((c) => !subsumed.has(c.fieldname));
-  for (const declaration of synthetic) {
-    const column = toColumn(declaration);
-    if (declaration.place === "start") columns.unshift(column);
-    else if (declaration.place === "after-title") columns.splice(1, 0, column);
-    else columns.push(column);
-  }
-  return columns;
+  const kept = defaults.filter((c) => !subsumed.has(c.fieldname));
+  // Build each anchor group in one pass so declarations sharing an anchor keep their
+  // order — inserting one at a time at a fixed index would reverse them.
+  const at = (place: SyntheticColumn["place"]) =>
+    synthetic.filter((s) => (s.place ?? "end") === place).map(toColumn);
+  const [leading, ...rest] = kept;
+  const afterLeading =
+    leading === undefined
+      ? at("after-title")
+      : [leading, ...at("after-title"), ...rest];
+  return [...at("start"), ...afterLeading, ...at("end")];
 }

--- a/ui/src/components/ColumnSettings/getDefaultColumns.ts
+++ b/ui/src/components/ColumnSettings/getDefaultColumns.ts
@@ -1,5 +1,5 @@
 import type { RawMetaField } from "../FormLayout/types";
-import type { Column } from "./types";
+import type { Column, SyntheticColumn } from "./types";
 
 /** The `name` standard field — the default leading column when the doctype has
  *  no `title_field`. The list always surfaces the record's identifier first (the
@@ -38,4 +38,44 @@ export function getDefaultColumns(
       .filter((f) => f.in_list_view && f.fieldname !== leading.fieldname)
       .map((f) => ({ fieldname: f.fieldname, label: f.label ?? f.fieldname })),
   ];
+}
+
+/** Convert a synthetic declaration to its persisted {@link Column} form: the `key`
+ *  rides the `fieldname` slot, the declaration's default `width` seeds the column
+ *  (dropped when unset so it flexes). Render metadata (`type`/`align`) is never
+ *  stored — `serializeColumns` re-derives it from the declaration (ADR-0033). */
+function toColumn(declaration: SyntheticColumn): Column {
+  const column: Column = {
+    fieldname: declaration.key,
+    label: declaration.label,
+  };
+  if (declaration.width) column.width = declaration.width;
+  return column;
+}
+
+/**
+ * Fold host-declared synthetic columns (ADR-0033) into a Meta-derived default seed:
+ * each declaration is inserted at its `place` anchor (`'start'` | `'after-title'`
+ * [right after the leading title/name column] | `'end'`, default `'end'`), and any
+ * docfield it `subsumes` is dropped from the seed (default-only, so it stays
+ * re-addable). Seeds the default `shown` *only* — once the user customizes order, the
+ * persisted layout wins. With no declarations it returns the seed untouched (same
+ * reference), so a consumer that declares none is byte-identical.
+ */
+export function foldSyntheticColumns(
+  defaults: Column[],
+  synthetic: SyntheticColumn[]
+): Column[] {
+  if (!synthetic.length) return defaults;
+  const subsumed = new Set(
+    synthetic.map((s) => s.subsumes).filter((f): f is string => !!f)
+  );
+  const columns = defaults.filter((c) => !subsumed.has(c.fieldname));
+  for (const declaration of synthetic) {
+    const column = toColumn(declaration);
+    if (declaration.place === "start") columns.unshift(column);
+    else if (declaration.place === "after-title") columns.splice(1, 0, column);
+    else columns.push(column);
+  }
+  return columns;
 }

--- a/ui/src/components/ColumnSettings/index.ts
+++ b/ui/src/components/ColumnSettings/index.ts
@@ -11,7 +11,9 @@ export {
   getColumnAlign,
   applyColumnWidth,
   clearColumnWidth,
+  dropOrphanedSyntheticColumns,
   fetchFields,
+  SYNTHETIC_KEY_PREFIX,
 } from "./columns";
 export { getColumnOptions } from "./getColumnOptions";
 export { getDefaultColumns, foldSyntheticColumns } from "./getDefaultColumns";

--- a/ui/src/components/ColumnSettings/index.ts
+++ b/ui/src/components/ColumnSettings/index.ts
@@ -11,7 +11,13 @@ export {
   getColumnAlign,
   applyColumnWidth,
   clearColumnWidth,
+  fetchFields,
 } from "./columns";
 export { getColumnOptions } from "./getColumnOptions";
-export { getDefaultColumns } from "./getDefaultColumns";
-export type { Column, ColumnOption, WireColumn } from "./types";
+export { getDefaultColumns, foldSyntheticColumns } from "./getDefaultColumns";
+export type {
+  Column,
+  ColumnOption,
+  SyntheticColumn,
+  WireColumn,
+} from "./types";

--- a/ui/src/components/ColumnSettings/tests/columns.test.ts
+++ b/ui/src/components/ColumnSettings/tests/columns.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyColumnWidth,
   clearColumnWidth,
+  dropOrphanedSyntheticColumns,
   fetchFields,
   getColumnAlign,
   parseColumns,
@@ -231,5 +232,43 @@ describe("fetchFields", () => {
 
   it("fetches every column key when nothing is synthetic (byte-identical default)", () => {
     expect(fetchFields(wire)).toEqual(["name", "_indicator", "status"]);
+  });
+});
+
+describe("dropOrphanedSyntheticColumns", () => {
+  const layout: Column[] = [
+    { fieldname: "name", label: "Name" },
+    { fieldname: "_indicator", label: "Status" },
+    { fieldname: "amount", label: "Amount" },
+  ];
+
+  it("drops a `_`-prefixed column no live declaration claims", () => {
+    // The declaration was removed after the user customized; `_indicator` is orphaned.
+    expect(dropOrphanedSyntheticColumns(layout, []).map((c) => c.fieldname)).toEqual(
+      ["name", "amount"]
+    );
+  });
+
+  it("keeps a `_`-prefixed column a live declaration still claims", () => {
+    expect(
+      dropOrphanedSyntheticColumns(layout, [{ key: "_indicator", label: "Status" }])
+    ).toBe(layout);
+  });
+
+  it("returns the same reference when no column is synthetic (byte-identical)", () => {
+    const docfields: Column[] = [
+      { fieldname: "name", label: "Name" },
+      { fieldname: "amount", label: "Amount" },
+    ];
+    expect(dropOrphanedSyntheticColumns(docfields, [])).toBe(docfields);
+  });
+
+  it("never drops a docfield column, even with no declarations", () => {
+    expect(
+      dropOrphanedSyntheticColumns(
+        [{ fieldname: "amount", label: "Amount" }],
+        []
+      )
+    ).toEqual([{ fieldname: "amount", label: "Amount" }]);
   });
 });

--- a/ui/src/components/ColumnSettings/tests/columns.test.ts
+++ b/ui/src/components/ColumnSettings/tests/columns.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
   applyColumnWidth,
   clearColumnWidth,
+  fetchFields,
   getColumnAlign,
   parseColumns,
   serializeColumns,
 } from "../columns";
 import type { RawMetaField } from "../../FormLayout/types";
-import type { Column } from "../types";
+import type { Column, WireColumn } from "../types";
 
 const FIELDS: RawMetaField[] = [
   {
@@ -95,6 +96,50 @@ describe("serializeColumns", () => {
       align: "left",
     });
   });
+
+  it("emits a synthetic column's render metadata from its declaration, not Meta", () => {
+    const [, wire] = serializeColumns(
+      [
+        { fieldname: "name", label: "Name" },
+        { fieldname: "_indicator", label: "Status" },
+      ],
+      FIELDS,
+      [
+        {
+          key: "_indicator",
+          label: "Status",
+          type: "Status",
+          place: "after-title",
+        },
+      ]
+    );
+    expect(wire).toEqual({
+      key: "_indicator",
+      label: "Status",
+      width: 1,
+      type: "Status",
+      options: undefined,
+      align: "left",
+    });
+  });
+
+  it("keeps a resized synthetic column's stored width over the declaration default", () => {
+    const [wire] = serializeColumns(
+      [{ fieldname: "_indicator", label: "Status", width: "12rem" }],
+      FIELDS,
+      [{ key: "_indicator", label: "Status", type: "Status", width: "8rem" }]
+    );
+    expect(wire.width).toBe("12rem");
+  });
+
+  it("honors an explicit align on the declaration over the type-derived default", () => {
+    const [wire] = serializeColumns(
+      [{ fieldname: "_amount", label: "Total" }],
+      FIELDS,
+      [{ key: "_amount", label: "Total", type: "Data", align: "right" }]
+    );
+    expect(wire.align).toBe("right");
+  });
 });
 
 describe("parseColumns", () => {
@@ -159,5 +204,32 @@ describe("clearColumnWidth", () => {
   it("no-ops on an already-auto column and on a missing one", () => {
     expect(clearColumnWidth(columns, "status")).toEqual(columns);
     expect(clearColumnWidth(columns, "missing")).toEqual(columns);
+  });
+});
+
+describe("fetchFields", () => {
+  const wire: WireColumn[] = [
+    { key: "name", label: "Name", width: 2, align: "left", type: "Data" },
+    {
+      key: "_indicator",
+      label: "Status",
+      width: 1,
+      align: "left",
+      type: "Status",
+    },
+    { key: "status", label: "Status", width: 1, align: "left", type: "Select" },
+  ];
+
+  it("is `name` plus each column key, skipping declared synthetic keys (ADR-0033)", () => {
+    // `_indicator` names no docfield, so requesting it would error get_list; the real
+    // fields its cell reads are the host's concern (fetched separately). A re-added
+    // subsumed field like `status` is a real docfield and stays.
+    expect(fetchFields(wire, [{ key: "_indicator", label: "Status" }])).toEqual(
+      ["name", "status"]
+    );
+  });
+
+  it("fetches every column key when nothing is synthetic (byte-identical default)", () => {
+    expect(fetchFields(wire)).toEqual(["name", "_indicator", "status"]);
   });
 });

--- a/ui/src/components/ColumnSettings/tests/getColumnOptions.test.ts
+++ b/ui/src/components/ColumnSettings/tests/getColumnOptions.test.ts
@@ -39,4 +39,17 @@ describe("getColumnOptions", () => {
       ...STANDARD,
     ]);
   });
+
+  it("appends declared synthetic columns so a hidden one is re-addable (ADR-0033)", () => {
+    expect(
+      getColumnOptions(
+        [{ fieldname: "status", fieldtype: "Select", label: "Status" }],
+        [{ key: "_indicator", label: "Status", type: "Status" }]
+      )
+    ).toEqual([
+      { label: "Status", value: "status", fieldname: "status" },
+      ...STANDARD,
+      { label: "Status", value: "_indicator", fieldname: "_indicator" },
+    ]);
+  });
 });

--- a/ui/src/components/ColumnSettings/tests/getDefaultColumns.test.ts
+++ b/ui/src/components/ColumnSettings/tests/getDefaultColumns.test.ts
@@ -144,6 +144,26 @@ describe("foldSyntheticColumns", () => {
     ).toEqual(["_flag", "subject", "status", "modified"]);
   });
 
+  it("keeps declaration order for multiple columns sharing the `after-title` anchor", () => {
+    // A host declaring a flag then a status badge, both after-title, must see them in
+    // that order — not reversed by inserting each at the same fixed index.
+    expect(
+      foldSyntheticColumns(defaults, [
+        { key: "_flag", label: "Flag", place: "after-title" },
+        { key: "_indicator", label: "Status", place: "after-title" },
+      ]).map((c) => c.fieldname)
+    ).toEqual(["subject", "_flag", "_indicator", "status", "modified"]);
+  });
+
+  it("keeps declaration order for multiple `start` columns", () => {
+    expect(
+      foldSyntheticColumns(defaults, [
+        { key: "_a", label: "A", place: "start" },
+        { key: "_b", label: "B", place: "start" },
+      ]).map((c) => c.fieldname)
+    ).toEqual(["_a", "_b", "subject", "status", "modified"]);
+  });
+
   it("drops the docfield a declaration subsumes from the seed", () => {
     expect(
       foldSyntheticColumns(defaults, [

--- a/ui/src/components/ColumnSettings/tests/getDefaultColumns.test.ts
+++ b/ui/src/components/ColumnSettings/tests/getDefaultColumns.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { getDefaultColumns } from "../getDefaultColumns";
+import { getDefaultColumns, foldSyntheticColumns } from "../getDefaultColumns";
+import type { Column } from "../types";
 
 describe("getDefaultColumns", () => {
   it("maps the in_list_view fields to Columns, prepending Name", () => {
@@ -111,5 +112,60 @@ describe("getDefaultColumns", () => {
       { fieldname: "name", label: "Name" },
       { fieldname: "status", label: "Status" },
     ]);
+  });
+});
+
+describe("foldSyntheticColumns", () => {
+  const defaults: Column[] = [
+    { fieldname: "subject", label: "Subject" },
+    { fieldname: "status", label: "Status" },
+    { fieldname: "modified", label: "Modified" },
+  ];
+
+  it("appends a synthetic column at the end by default", () => {
+    expect(
+      foldSyntheticColumns(defaults, [{ key: "_indicator", label: "Status" }])
+    ).toEqual([...defaults, { fieldname: "_indicator", label: "Status" }]);
+  });
+
+  it("inserts an `after-title` column right after the leading column", () => {
+    expect(
+      foldSyntheticColumns(defaults, [
+        { key: "_indicator", label: "Status", place: "after-title" },
+      ]).map((c) => c.fieldname)
+    ).toEqual(["subject", "_indicator", "status", "modified"]);
+  });
+
+  it("prepends a `start` column before the leading column", () => {
+    expect(
+      foldSyntheticColumns(defaults, [
+        { key: "_flag", label: "Flag", place: "start" },
+      ]).map((c) => c.fieldname)
+    ).toEqual(["_flag", "subject", "status", "modified"]);
+  });
+
+  it("drops the docfield a declaration subsumes from the seed", () => {
+    expect(
+      foldSyntheticColumns(defaults, [
+        {
+          key: "_indicator",
+          label: "Status",
+          place: "after-title",
+          subsumes: "status",
+        },
+      ]).map((c) => c.fieldname)
+    ).toEqual(["subject", "_indicator", "modified"]);
+  });
+
+  it("carries the declaration's default width onto the folded column", () => {
+    expect(
+      foldSyntheticColumns(defaults, [
+        { key: "_indicator", label: "Status", width: "8rem" },
+      ]).at(-1)
+    ).toEqual({ fieldname: "_indicator", label: "Status", width: "8rem" });
+  });
+
+  it("returns the seed untouched (same reference) when no column is declared", () => {
+    expect(foldSyntheticColumns(defaults, [])).toBe(defaults);
   });
 });

--- a/ui/src/components/ColumnSettings/tests/useColumns.test.ts
+++ b/ui/src/components/ColumnSettings/tests/useColumns.test.ts
@@ -153,4 +153,43 @@ describe("useColumns", () => {
       "amount",
     ]);
   });
+
+  it("scrubs an orphaned synthetic key from a customized layout when the declaration is removed", async () => {
+    const { ref } = await import("vue");
+    setMeta(FIELDS);
+    const source = ref<any[]>([indicator]);
+    const { shown } = useColumns("Test DT", { synthetic: source });
+    // The user customizes while the indicator is active — `_indicator` sticks in the
+    // persisted layout, ahead of the docfields.
+    shown.value = [
+      { fieldname: "name", label: "Name" },
+      { fieldname: "_indicator", label: "Status" },
+      { fieldname: "amount", label: "Amount" },
+    ];
+    // The declaration is later removed (the syntheticDemo toggle). The orphaned
+    // `_indicator` would otherwise name no docfield and error get_list.
+    source.value = [];
+    expect(shown.value.map((c) => c.fieldname)).toEqual(["name", "amount"]);
+    // A re-declared key simply reappears — the customized layout still carries it.
+    source.value = [indicator];
+    expect(shown.value.map((c) => c.fieldname)).toEqual([
+      "name",
+      "_indicator",
+      "amount",
+    ]);
+  });
+
+  it("keeps the orphaned key out of the wire columns (so get_list never requests it)", async () => {
+    const { ref } = await import("vue");
+    setMeta(FIELDS);
+    const source = ref<any[]>([indicator]);
+    const { shown, wire } = useColumns("Test DT", { synthetic: source });
+    shown.value = [
+      { fieldname: "name", label: "Name" },
+      { fieldname: "_indicator", label: "Status" },
+      { fieldname: "amount", label: "Amount" },
+    ];
+    source.value = [];
+    expect(wire.value.map((c) => c.key)).toEqual(["name", "amount"]);
+  });
 });

--- a/ui/src/components/ColumnSettings/tests/useColumns.test.ts
+++ b/ui/src/components/ColumnSettings/tests/useColumns.test.ts
@@ -103,4 +103,54 @@ describe("useColumns", () => {
     const { wire } = useColumns("Test DT");
     expect(wire.value.map((c) => c.key)).toEqual(["name", "status", "amount"]);
   });
+
+  const indicator = {
+    key: "_indicator",
+    label: "Status",
+    type: "Status",
+    place: "after-title" as const,
+    subsumes: "status",
+  };
+
+  it("folds a synthetic declaration into the default shown at its place anchor", () => {
+    setMeta(FIELDS);
+    const { shown } = useColumns("Test DT", { synthetic: [indicator] });
+    // after-title → right after `name`; `subsumes: status` drops the status field.
+    expect(shown.value.map((c) => c.fieldname)).toEqual([
+      "name",
+      "_indicator",
+      "amount",
+    ]);
+  });
+
+  it("wires a synthetic column's render metadata from the declaration (type Status)", () => {
+    setMeta(FIELDS);
+    const { wire } = useColumns("Test DT", { synthetic: [indicator] });
+    expect(wire.value.find((c) => c.key === "_indicator")?.type).toBe("Status");
+  });
+
+  it("exposes the declarations so the host can bind ColumnSettings' picker union", () => {
+    setMeta(FIELDS);
+    const { synthetic } = useColumns("Test DT", { synthetic: [indicator] });
+    expect(synthetic.value).toEqual([indicator]);
+  });
+
+  it("folds in a declaration that resolves asynchronously (a ref source)", async () => {
+    const { ref } = await import("vue");
+    setMeta(FIELDS);
+    // The indicator rides a live field-meta fetch, so it is empty at first and arrives later.
+    const source = ref<any[]>([]);
+    const { shown } = useColumns("Test DT", { synthetic: source });
+    expect(shown.value.map((c) => c.fieldname)).toEqual([
+      "name",
+      "status",
+      "amount",
+    ]);
+    source.value = [indicator];
+    expect(shown.value.map((c) => c.fieldname)).toEqual([
+      "name",
+      "_indicator",
+      "amount",
+    ]);
+  });
 });

--- a/ui/src/components/ColumnSettings/types.ts
+++ b/ui/src/components/ColumnSettings/types.ts
@@ -13,6 +13,31 @@ export interface Column {
   width?: string;
 }
 
+/** A **synthetic column**: a list column the *host* declares instead of resolving
+ *  from doctype Meta, carrying its own render metadata (ADR-0033). It is a first-class
+ *  member of the column state — it lives in `shown`, persists in the View Snapshot, and
+ *  appears in ColumnSettings — but the library only *declares* it; the host draws its
+ *  cell (via the `#cell` slot's `type` hint). Declaration (static, host-authored) and
+ *  state (dynamic, user-owned) stay disjoint: the persisted {@link Column} shape does not
+ *  change — a synthetic column rides the `fieldname` slot with its `key` (reserved leading
+ *  `_`, e.g. `_indicator`, so it can never collide with a docfield). Passed to
+ *  `useColumns(doctype, { synthetic })` (threaded from `useListView`). */
+export interface SyntheticColumn {
+  /** The reserved identity (leading `_`), matched against `shown` at serialize time. */
+  key: string;
+  label: string;
+  /** Render hint the host's cell slot reads (`'Status'`); also drives `align` default. */
+  type?: string;
+  align?: "left" | "right";
+  /** Default width; a user resize overrides it via the Column's own `width`. */
+  width?: string;
+  /** Default position anchor for the fold into the seed (default `'end'`). */
+  place?: "start" | "after-title" | "end";
+  /** A docfield this column replaces — dropped from the *default seed only*, not a
+   *  render block, so it stays re-addable from the picker (renders plain text). */
+  subsumes?: string;
+}
+
 /** A column the control offers to add, derived from doctype Meta. Shape mirrors
  *  the other controls' Field Options (`value === fieldname`) so it drops straight
  *  into an Autocomplete. See CONTEXT.md ("Field Options"). */

--- a/ui/src/components/ColumnSettings/useColumns.ts
+++ b/ui/src/components/ColumnSettings/useColumns.ts
@@ -1,13 +1,28 @@
-import { computed, ref } from "vue";
-import type { Ref, WritableComputedRef } from "vue";
+import { computed, ref, toValue } from "vue";
+import type {
+  ComputedRef,
+  MaybeRefOrGetter,
+  Ref,
+  WritableComputedRef,
+} from "vue";
 import { useDoctypeMeta } from "../../composables/useDoctypeMeta";
 import {
   serializeColumns,
   applyColumnWidth,
   clearColumnWidth,
 } from "./columns";
-import { getDefaultColumns } from "./getDefaultColumns";
-import type { Column, WireColumn } from "./types";
+import { getDefaultColumns, foldSyntheticColumns } from "./getDefaultColumns";
+import type { Column, SyntheticColumn, WireColumn } from "./types";
+
+export interface UseColumnsOptions {
+  /** Host-declared synthetic columns (ADR-0033) — columns not resolved from Meta.
+   *  Folded into the default `shown` at their `place` anchor, wired from their own
+   *  render metadata, and offered back by the picker. Default: none (byte-identical).
+   *  A `MaybeRefOrGetter` so a host whose declarations resolve asynchronously (e.g. the
+   *  Record indicator, which rides a live field-meta fetch) can pass a computed and have
+   *  the fold recompute when it arrives — plain arrays work unchanged. */
+  synthetic?: MaybeRefOrGetter<SyntheticColumn[]>;
+}
 
 export interface UseColumns {
   /** The list's shown columns (order = display order, `width` = the resize slice).
@@ -29,6 +44,11 @@ export interface UseColumns {
   /** Write a resized column's width back into `shown` by `fieldname` (the
    *  resize→settings half of the sync). The `save` flag a host might debounce on is
    *  the host's concern and ignored here. */
+  /** The resolved host-declared synthetic columns (ADR-0033), so a host can bind
+   *  ColumnSettings' `:synthetic` prop (its picker union) from the same place it reads
+   *  `shown` — one source, threaded from `useListView`. A `ComputedRef` so it tracks a
+   *  reactive/async declaration source. */
+  synthetic: ComputedRef<SyntheticColumn[]>;
   setWidth: (fieldname: string, width: string) => void;
   /** Drop a column's fixed `width` so it flexes to fill again (the reset half of the
    *  resize story). A host wires this to a double-click on the header resizer; with
@@ -44,17 +64,29 @@ export interface UseColumns {
  * `doctype` is taken by value: the Shell remounts the controls via `:key="doctype"`
  * and Meta is cached per doctype string, so reconstructing on a switch is cheap.
  */
-export function useColumns(doctype: string): UseColumns {
+export function useColumns(
+  doctype: string,
+  options: UseColumnsOptions = {}
+): UseColumns {
   const { meta } = useDoctypeMeta(doctype);
+  // Resolved reactively so an async declaration source (the indicator rides a live
+  // field-meta fetch) folds in the moment it arrives, like the Meta-derived defaults do.
+  const synthetic = computed<SyntheticColumn[]>(
+    () => toValue(options.synthetic) ?? []
+  );
 
   // `null` ⇒ "use the Meta-derived default"; a value ⇒ customized. The default
   // tracks Meta as it loads, yet the first write (a ColumnSettings edit or a resize)
-  // sticks — no seed watch needed.
+  // sticks — no seed watch needed. Synthetic declarations fold into the default seed
+  // only (ADR-0033); once customized, the persisted layout carries them.
   const customColumns = ref<Column[] | null>(null);
   const shown = computed<Column[]>({
     get: () =>
       customColumns.value ??
-      getDefaultColumns(meta.value?.fields ?? [], meta.value?.title_field),
+      foldSyntheticColumns(
+        getDefaultColumns(meta.value?.fields ?? [], meta.value?.title_field),
+        synthetic.value
+      ),
     set: (value) => {
       customColumns.value = value;
     },
@@ -66,7 +98,7 @@ export function useColumns(doctype: string): UseColumns {
   };
 
   const wire = computed(() =>
-    serializeColumns(shown.value, meta.value?.fields ?? [])
+    serializeColumns(shown.value, meta.value?.fields ?? [], synthetic.value)
   );
 
   // A drag in the frappe-ui header emits `{ key, width }`; writing it back into
@@ -81,5 +113,5 @@ export function useColumns(doctype: string): UseColumns {
     shown.value = clearColumnWidth(shown.value, fieldname);
   };
 
-  return { shown, isCustomized, reset, wire, setWidth, resetWidth };
+  return { shown, isCustomized, reset, wire, synthetic, setWidth, resetWidth };
 }

--- a/ui/src/components/ColumnSettings/useColumns.ts
+++ b/ui/src/components/ColumnSettings/useColumns.ts
@@ -41,14 +41,14 @@ export interface UseColumns {
   /** The frappe-ui `ListView` render columns (`serializeColumns`): the table binds
    *  these for headers + grid tracks, with `align`/`type`/`options` derived from Meta. */
   wire: Ref<WireColumn[]>;
-  /** Write a resized column's width back into `shown` by `fieldname` (the
-   *  resize→settings half of the sync). The `save` flag a host might debounce on is
-   *  the host's concern and ignored here. */
   /** The resolved host-declared synthetic columns (ADR-0033), so a host can bind
    *  ColumnSettings' `:synthetic` prop (its picker union) from the same place it reads
    *  `shown` — one source, threaded from `useListView`. A `ComputedRef` so it tracks a
    *  reactive/async declaration source. */
   synthetic: ComputedRef<SyntheticColumn[]>;
+  /** Write a resized column's width back into `shown` by `fieldname` (the
+   *  resize→settings half of the sync). The `save` flag a host might debounce on is
+   *  the host's concern and ignored here. */
   setWidth: (fieldname: string, width: string) => void;
   /** Drop a column's fixed `width` so it flexes to fill again (the reset half of the
    *  resize story). A host wires this to a double-click on the header resizer; with

--- a/ui/src/components/ColumnSettings/useColumns.ts
+++ b/ui/src/components/ColumnSettings/useColumns.ts
@@ -10,6 +10,7 @@ import {
   serializeColumns,
   applyColumnWidth,
   clearColumnWidth,
+  dropOrphanedSyntheticColumns,
 } from "./columns";
 import { getDefaultColumns, foldSyntheticColumns } from "./getDefaultColumns";
 import type { Column, SyntheticColumn, WireColumn } from "./types";
@@ -78,15 +79,23 @@ export function useColumns(
   // `null` ⇒ "use the Meta-derived default"; a value ⇒ customized. The default
   // tracks Meta as it loads, yet the first write (a ColumnSettings edit or a resize)
   // sticks — no seed watch needed. Synthetic declarations fold into the default seed
-  // only (ADR-0033); once customized, the persisted layout carries them.
+  // only (ADR-0033); once customized, the persisted layout carries them. A customized
+  // layout is scrubbed of orphaned synthetic keys on read (`dropOrphanedSyntheticColumns`):
+  // a declaration can be removed after the user customized, leaving a `_`-prefixed column
+  // that names no docfield and would error `get_list` — dropping it keeps the layout valid
+  // while a re-declared key simply reappears.
   const customColumns = ref<Column[] | null>(null);
   const shown = computed<Column[]>({
     get: () =>
-      customColumns.value ??
-      foldSyntheticColumns(
-        getDefaultColumns(meta.value?.fields ?? [], meta.value?.title_field),
-        synthetic.value
-      ),
+      customColumns.value
+        ? dropOrphanedSyntheticColumns(customColumns.value, synthetic.value)
+        : foldSyntheticColumns(
+            getDefaultColumns(
+              meta.value?.fields ?? [],
+              meta.value?.title_field
+            ),
+            synthetic.value
+          ),
     set: (value) => {
       customColumns.value = value;
     },

--- a/ui/src/components/ListView/index.ts
+++ b/ui/src/components/ListView/index.ts
@@ -5,6 +5,6 @@
 // will join them here.
 export { default as ListViewShell } from "./ListViewShell.vue";
 export { useListView } from "./useListView";
-export type { UseListView } from "./useListView";
+export type { UseListView, UseListViewOptions } from "./useListView";
 export { useListData } from "./useListData";
 export type { UseListData } from "./useListData";

--- a/ui/src/components/ListView/stories/ListViewToolbar.vue
+++ b/ui/src/components/ListView/stories/ListViewToolbar.vue
@@ -43,6 +43,7 @@
 				<ColumnSettings
 					v-model="view.columns.shown.value"
 					:doctype="doctype"
+					:synthetic="view.columns.synthetic.value"
 					:can-reset="view.columns.isCustomized.value"
 					@reset="view.columns.reset()"
 				/>
@@ -76,6 +77,20 @@
 					@dblclick="onResizerDoubleClick"
 				/>
 				<ListRows />
+				<!-- The synthetic column (ADR-0033) carries no docfield value — the HOST draws
+				     its cell. A production host (frappe-os) resolves a per-row Record indicator
+				     here; this story renders a representative badge to show the "library carries
+				     the column, host owns the cell" half of the seam. Every other cell renders
+				     its value as before. -->
+				<template #cell="{ column, item }">
+					<Badge
+						v-if="column.type === 'Status'"
+						:label="column.label"
+						theme="green"
+						variant="subtle"
+					/>
+					<span v-else class="text-base">{{ item }}</span>
+				</template>
 				<!-- The selection banner lives in the default-slot fallback we're
 				     overriding, so the host re-adds it. Its `#actions` slot is where
 				     bulk actions go; these are demo no-ops (a real host would mutate). -->
@@ -111,6 +126,7 @@
 
 <script setup lang="ts">
 import {
+	Badge,
 	Button,
 	Dropdown,
 	ListView,
@@ -120,7 +136,7 @@ import {
 	ListFooter,
 	toast,
 } from "frappe-ui";
-import { onMounted, watch } from "vue";
+import { computed, onMounted, watch } from "vue";
 import { ListViewShell } from "../index";
 import { useListView } from "../useListView";
 import { useListData } from "../useListData";
@@ -128,11 +144,31 @@ import { Filter } from "../../Filter";
 import { SortBy } from "../../SortBy";
 import { QuickFilter } from "../../QuickFilter";
 import { ColumnSettings } from "../../ColumnSettings";
+import type { SyntheticColumn } from "../../ColumnSettings";
 
-const props = defineProps<{ doctype: string }>();
+const props = defineProps<{ doctype: string; syntheticDemo?: boolean }>();
+
+// A demo synthetic column (ADR-0033) — the Record indicator, the OS's first synthetic
+// column — declared by the host and folded into the column state: after the title,
+// subsuming the raw `status` docfield. Reactive, so the Shell's toggle folds it in/out
+// live; `useColumns` takes it as a getter. Off ⇒ no declaration ⇒ identical behaviour.
+const synthetic = computed<SyntheticColumn[]>(() =>
+	props.syntheticDemo
+		? [
+				{
+					key: "_indicator",
+					label: "Status",
+					type: "Status",
+					place: "after-title",
+					subsumes: "status",
+				},
+		  ]
+		: []
+);
+
 // `view.quickFilter.customizing` / `.canCustomize` come from the shared composable,
 // so the toggle below works regardless of where it sits — no template ref needed.
-const view = useListView(props.doctype);
+const view = useListView(props.doctype, { synthetic });
 // The host owns fetching: `useListData` turns the controls' wire projections into
 // live `get_list` rows + total, and pages via the footer.
 const data = useListData(props.doctype, view);

--- a/ui/src/components/ListView/stories/Shell.story.vue
+++ b/ui/src/components/ListView/stories/Shell.story.vue
@@ -6,25 +6,35 @@
   reconstructs `useListView` per doctype — also resetting the controls, no reset watch.
 
   Story chrome (the doctype picker) uses frappe-ui components, not raw HTML, per
-  the workspace convention.
+  the workspace convention. The "Synthetic column" switch declares a host Record-
+  indicator column (ADR-0033) and folds it into the list — it appears after the
+  title (subsuming the raw `status` field), shows in ColumnSettings (toggle / re-add),
+  rides the wire `columns` readout, and is never requested from `get_list`; its cell
+  is drawn by the host (a representative badge here — see ListViewToolbar).
 -->
 <template>
 	<!-- `h-full` fills the layout's content area so the list gets a finite height
 	     to distribute (toolbar/footer fixed, rows scroll). `min-h-0` lets the flex
 	     children shrink rather than overflow the page. -->
 	<div class="flex h-full min-h-0 flex-col gap-4 p-6">
-		<div class="flex shrink-0 items-center gap-2">
-			<span class="text-p-sm text-ink-gray-6">Doctype</span>
-			<Select v-model="doctype" :options="doctypeOptions" class="w-56" />
+		<div class="flex shrink-0 items-center gap-4">
+			<div class="flex items-center gap-2">
+				<span class="text-p-sm text-ink-gray-6">Doctype</span>
+				<Select v-model="doctype" :options="doctypeOptions" class="w-56" />
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="text-p-sm text-ink-gray-6">Synthetic column</span>
+				<Switch v-model="showSynthetic" />
+			</div>
 		</div>
 
-		<ListViewToolbar :key="doctype" :doctype="doctype" />
+		<ListViewToolbar :key="doctype" :doctype="doctype" :synthetic-demo="showSynthetic" />
 	</div>
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue";
-import { Select } from "frappe-ui";
+import { Select, Switch } from "frappe-ui";
 import ListViewToolbar from "./ListViewToolbar.vue";
 
 const props = withDefaults(defineProps<{ doctype?: string; doctypeOptions?: string[] }>(), {
@@ -34,4 +44,5 @@ const props = withDefaults(defineProps<{ doctype?: string; doctypeOptions?: stri
 
 const doctype = ref(props.doctype);
 const doctypeOptions = props.doctypeOptions;
+const showSynthetic = ref(false);
 </script>

--- a/ui/src/components/ListView/tests/snapshot.test.ts
+++ b/ui/src/components/ListView/tests/snapshot.test.ts
@@ -116,6 +116,25 @@ describe("useListView snapshot / restore", () => {
     expect(view.columns.isCustomized.value).toBe(false);
   });
 
+  it("threads synthetic column declarations through to useColumns (ADR-0033)", () => {
+    const indicator = {
+      key: "_indicator",
+      label: "Status",
+      type: "Status",
+      place: "after-title" as const,
+      subsumes: "status",
+    };
+    const view = useListView("Sales Order", { synthetic: [indicator] });
+    // Folded into the default shown at its anchor, `status` subsumed out of the seed.
+    expect(view.columns.shown.value.map((c) => c.fieldname)).toEqual([
+      "name",
+      "_indicator",
+      "customer",
+    ]);
+    // And exposed so the host can bind ColumnSettings' picker union from one place.
+    expect(view.columns.synthetic.value).toEqual([indicator]);
+  });
+
   it("round-trips: a captured snapshot restores to the same effective state", () => {
     const source = useListView("Sales Order");
     source.filters.conditions.value = [

--- a/ui/src/components/ListView/useListData.ts
+++ b/ui/src/components/ListView/useListData.ts
@@ -1,6 +1,7 @@
 import { computed, ref, watch } from "vue";
 import type { ComputedRef, Ref } from "vue";
 import { createListResource, createResource } from "frappe-ui";
+import { fetchFields } from "../ColumnSettings/columns";
 import type { UseListView } from "./useListView";
 
 /**
@@ -36,9 +37,10 @@ export interface UseListData {
 export function useListData(doctype: string, view: UseListView): UseListData {
   const pageLength = ref(20);
 
-  // get_list fetches the row key plus every shown column's field.
+  // get_list fetches the row key plus every shown column's field, skipping synthetic
+  // columns (ADR-0033) — their keys name no docfield, so the host draws those cells.
   const fields = computed(() =>
-    Array.from(new Set(["name", ...view.columns.wire.value.map((c) => c.key)]))
+    fetchFields(view.columns.wire.value, view.columns.synthetic.value)
   );
 
   const list = createListResource({

--- a/ui/src/components/ListView/useListView.ts
+++ b/ui/src/components/ListView/useListView.ts
@@ -7,7 +7,10 @@ import type { UseSort } from "../SortBy/useSort";
 import { useQuickFilter } from "../QuickFilter/useQuickFilter";
 import type { UseQuickFilter } from "../QuickFilter/useQuickFilter";
 import { useColumns } from "../ColumnSettings/useColumns";
-import type { UseColumns } from "../ColumnSettings/useColumns";
+import type {
+  UseColumns,
+  UseColumnsOptions,
+} from "../ColumnSettings/useColumns";
 import type { FilterCondition, FilterField } from "../Filter/types";
 import type { Sort } from "../SortBy/types";
 import type { Column } from "../ColumnSettings/types";
@@ -59,6 +62,10 @@ export interface UseListView {
   restore: (snapshot: Partial<ListViewSnapshot>) => void;
 }
 
+/** Host options threaded into the composed controls. Currently just the synthetic
+ *  column declarations (ADR-0033), passed to `useColumns`. */
+export interface UseListViewOptions extends UseColumnsOptions {}
+
 /**
  * The composite List View's state owner — the shared composable ADR-0001 deferred
  * until two controls needed to share state (Filter + QuickFilter are that moment,
@@ -75,11 +82,14 @@ export interface UseListView {
  * reconstructing `useListView` on a doctype switch is cheap and needs no internal
  * reset watch.
  */
-export function useListView(doctype: string): UseListView {
+export function useListView(
+  doctype: string,
+  options: UseListViewOptions = {}
+): UseListView {
   const filters = useFilters();
   const sort = useSort();
   const quickFilter = useQuickFilter(doctype);
-  const columns = useColumns(doctype);
+  const columns = useColumns(doctype, { synthetic: options.synthetic });
 
   // Reads the *effective* state off each control (the writable computeds resolve
   // custom-or-default), capturing live references — safe because every control


### PR DESCRIPTION
## Synthetic list columns

Adds a **synthetic column** primitive to the `@framework/ui` list-view controls: a
list column the *host* declares (carrying its own render metadata) instead of
resolving it from doctype Meta. This is a reusable seam for columns that aren't
backed by a docfield — record indicators, action columns, avatar/computed columns —
kept presentation-agnostic (the library carries the column; the host draws the cell).

### What's added
- **`useColumns(doctype, { synthetic })`** — folds declarations into the default
  `shown` at their `place` anchor (`start` / `after-title` / `end`), dropping any
  docfield a declaration `subsumes` from the **default seed only** (still re-addable).
  Accepts a `MaybeRefOrGetter` so async declarations fold in when they resolve.
- **`serializeColumns(cols, fields, synthetic?)`** — emits a synthetic key's wire
  column from its declaration (`type`/`align`/`width`), not a Meta lookup; a user
  resize still overrides the declaration's default width.
- **`getColumnOptions(fields, synthetic?)`** — the "Add Column" picker offers
  (Meta fields ∪ declared synthetic) so a hidden synthetic column is re-addable.
- **`fetchFields(wire, synthetic?)`** + `useListData` — skip `_`-prefixed synthetic
  keys so `get_list` is never asked for a non-field.
- **`ColumnSettings`** gains a `:synthetic` prop; `useListView({ synthetic })` threads
  it through and exposes it.
- Persisted `Column` shape is **unchanged** — a synthetic column rides the existing
  `{ fieldname, label, width? }` slot with its reserved `_`-prefixed key.

### Additive
Zero synthetic declarations ⇒ behaviour is byte-identical for existing consumers
(CRM), so this is a safe upstream addition. The Shell story gains a "Synthetic column"
toggle that demonstrates the whole seam end-to-end.

### Tests
Unit coverage for fold-in position, `subsumes` default-drop, synthetic pass-through
in `serializeColumns`, the picker union, async-reactive threading, and `fetchFields`
skipping synthetic keys.

Part of the list-view controls work (#40404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

>no-docs
