### PR TITLE
fix: preserve tree view expansion state on back-navigation

### DIFF
--- a/cypress/integration/tree_view.js
+++ b/cypress/integration/tree_view.js
@@ -1,6 +1,7 @@
 context("Tree View", () => {
 	before(() => {
 		cy.login();
+		cy.visit("/desk/website");
 		cy.call("frappe.tests.ui_test_helpers.setup_tree_doctype");
 	});
 

--- a/cypress/integration/tree_view.js
+++ b/cypress/integration/tree_view.js
@@ -8,23 +8,18 @@ context("Tree View", () => {
 	it("keeps expanded nodes when navigating back to the tree", () => {
 		cy.visit("/app/custom-tree/view/tree");
 
-		let tree_route;
-		cy.window().then((win) => {
-			tree_route = win.frappe.get_route();
-		});
-
 		// root auto-expands; expand the parent to load its child
 		cy.get('.tree-link[data-label="Parent Node"]').click();
 		cy.get('.tree-link[data-label="Child Node"]').should("be.visible");
 
-		// navigate away; wait until the tree page is actually hidden before returning,
-		// otherwise the two route changes race and the tree may never settle back
+		// leave the tree, then return with the browser back button
 		cy.window().then((win) => win.frappe.set_route("List", "ToDo"));
 		cy.get('[data-page-route="Tree/Custom Tree"]').should("not.be.visible");
 
-		cy.window().then((win) => win.frappe.set_route(tree_route));
+		cy.go("back");
 		cy.get('[data-page-route="Tree/Custom Tree"]').should("be.visible");
 		cy.get('.tree-link[data-label="Child Node"]').should("be.visible");
+
 		cy.window()
 			.its("cur_tree")
 			.then((tree) => {

--- a/cypress/integration/tree_view.js
+++ b/cypress/integration/tree_view.js
@@ -17,11 +17,13 @@ context("Tree View", () => {
 		cy.get('.tree-link[data-label="Parent Node"]').click();
 		cy.get('.tree-link[data-label="Child Node"]').should("be.visible");
 
-		// navigate away and back within the desk (no page reload)
+		// navigate away; wait until the tree page is actually hidden before returning,
+		// otherwise the two route changes race and the tree may never settle back
 		cy.window().then((win) => win.frappe.set_route("List", "ToDo"));
-		cy.window().then((win) => win.frappe.set_route(tree_route));
+		cy.get('[data-page-route="Tree/Custom Tree"]').should("not.be.visible");
 
-		// the tree comes back exactly as it was left, without rebuilding
+		cy.window().then((win) => win.frappe.set_route(tree_route));
+		cy.get('[data-page-route="Tree/Custom Tree"]').should("be.visible");
 		cy.get('.tree-link[data-label="Child Node"]').should("be.visible");
 		cy.window()
 			.its("cur_tree")

--- a/cypress/integration/tree_view.js
+++ b/cypress/integration/tree_view.js
@@ -26,4 +26,22 @@ context("Tree View", () => {
 				expect(tree.nodes["Parent Node"].expanded).to.be.true;
 			});
 	});
+
+	it("restores the scroll position when navigating back to the tree", () => {
+		cy.visit("/app/custom-tree/view/tree");
+
+		// root auto-expands; scroll a deep node into view to move the page down
+		cy.get('.tree-link[data-label="Scroll Node 39"]').scrollIntoView();
+		cy.get(".main-section")
+			.its("0.scrollTop")
+			.should("be.gt", 0)
+			.then((scroll_position) => {
+				cy.window().then((win) => win.frappe.set_route("List", "ToDo"));
+				cy.get('[data-page-route="Tree/Custom Tree"]').should("not.be.visible");
+
+				cy.go("back");
+				cy.get('[data-page-route="Tree/Custom Tree"]').should("be.visible");
+				cy.get(".main-section").its("0.scrollTop").should("eq", scroll_position);
+			});
+	});
 });

--- a/cypress/integration/tree_view.js
+++ b/cypress/integration/tree_view.js
@@ -1,0 +1,31 @@
+context("Tree View", () => {
+	before(() => {
+		cy.login();
+		cy.call("frappe.tests.ui_test_helpers.setup_tree_doctype");
+	});
+
+	it("keeps expanded nodes when navigating back to the tree", () => {
+		cy.visit("/app/custom-tree/view/tree");
+
+		let tree_route;
+		cy.window().then((win) => {
+			tree_route = win.frappe.get_route();
+		});
+
+		// root auto-expands; expand the parent to load its child
+		cy.get('.tree-link[data-label="Parent Node"]').click();
+		cy.get('.tree-link[data-label="Child Node"]').should("be.visible");
+
+		// navigate away and back within the desk (no page reload)
+		cy.window().then((win) => win.frappe.set_route("List", "ToDo"));
+		cy.window().then((win) => win.frappe.set_route(tree_route));
+
+		// the tree comes back exactly as it was left, without rebuilding
+		cy.get('.tree-link[data-label="Child Node"]').should("be.visible");
+		cy.window()
+			.its("cur_tree")
+			.then((tree) => {
+				expect(tree.nodes["Parent Node"].expanded).to.be.true;
+			});
+	});
+});

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -27,15 +27,16 @@ frappe.views.TreeFactory = class TreeFactory extends frappe.views.Factory {
 
 	on_show() {
 		/**
-		 * When the the treeview is visited using the previous button,
-		 * the framework just show the treeview element that is hidden.
-		 * Due to this, the data of the tree can be old.
-		 * To deal with this, the tree will be refreshed whenever the
-		 * treeview is visible.
+		 * On back-navigation the framework re-shows the existing treeview
+		 * element instead of rebuilding it, so the expanded nodes are kept
+		 * as the user left them. Point cur_tree back at this tree; use the
+		 * Refresh menu item to reload data when it may have changed.
 		 */
 		let route = frappe.get_route();
 		let treeview = frappe.views.trees[route[1]];
-		treeview && treeview.make_tree();
+		if (treeview && treeview.tree) {
+			cur_tree = treeview.tree;
+		}
 	}
 
 	get view_name() {

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -36,6 +36,9 @@ frappe.views.TreeFactory = class TreeFactory extends frappe.views.Factory {
 		let treeview = frappe.views.trees[route[1]];
 		if (treeview && treeview.tree) {
 			cur_tree = treeview.tree;
+			if (treeview.scroll_position) {
+				frappe.utils.scroll_to(treeview.scroll_position, false, 0, $(".main-section"));
+			}
 		}
 	}
 
@@ -87,6 +90,11 @@ frappe.views.TreeView = class TreeView {
 		if (!this.opts || !this.opts.do_not_make_page) {
 			this.parent = frappe.container.add_page(this.page_name);
 			$(this.parent).addClass("treeview");
+			$(".main-section").on("scroll.treeview_" + this.page_name, () => {
+				if (frappe.get_route_str() === me.page_name) {
+					me.scroll_position = $(".main-section").scrollTop();
+				}
+			});
 			frappe.ui.make_app_page({ parent: this.parent, single_column: true });
 			this.page = this.parent.page;
 			frappe.container.change_to(this.page_name);

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -472,11 +472,13 @@ def setup_tree_doctype():
 	).insert()
 
 	if not frappe.db.exists("Custom Tree", "All Trees"):
-		frappe.get_doc({"doctype": "Custom Tree", "tree": "All Trees"}).insert()
+		frappe.get_doc({"doctype": "Custom Tree", "tree": "All Trees", "is_group": 1}).insert()
 
-	for parent, child in (("All Trees", "Parent Node"), ("Parent Node", "Child Node")):
+	for parent, child, is_group in (("All Trees", "Parent Node", 1), ("Parent Node", "Child Node", 0)):
 		if not frappe.db.exists("Custom Tree", child):
-			frappe.get_doc({"doctype": "Custom Tree", "tree": child, "parent_custom_tree": parent}).insert()
+			frappe.get_doc(
+				{"doctype": "Custom Tree", "tree": child, "parent_custom_tree": parent, "is_group": is_group}
+			).insert()
 
 
 @whitelist_for_tests()

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -474,6 +474,10 @@ def setup_tree_doctype():
 	if not frappe.db.exists("Custom Tree", "All Trees"):
 		frappe.get_doc({"doctype": "Custom Tree", "tree": "All Trees"}).insert()
 
+	for parent, child in (("All Trees", "Parent Node"), ("Parent Node", "Child Node")):
+		if not frappe.db.exists("Custom Tree", child):
+			frappe.get_doc({"doctype": "Custom Tree", "tree": child, "parent_custom_tree": parent}).insert()
+
 
 @whitelist_for_tests()
 def setup_image_doctype():

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -480,6 +480,13 @@ def setup_tree_doctype():
 				{"doctype": "Custom Tree", "tree": child, "parent_custom_tree": parent, "is_group": is_group}
 			).insert()
 
+	for i in range(40):
+		name = f"Scroll Node {i}"
+		if not frappe.db.exists("Custom Tree", name):
+			frappe.get_doc(
+				{"doctype": "Custom Tree", "tree": name, "parent_custom_tree": "All Trees", "is_group": 0}
+			).insert()
+
 
 @whitelist_for_tests()
 def setup_image_doctype():


### PR DESCRIPTION
Opening a tree (Chart of Accounts, Item Group, etc.), expanding a few nodes, and then returning to it via the back button, breadcrumbs, or sidebar always rebuilt the tree from the root, collapsing every expanded node. On large trees, this meant repeatedly re-expanding branches and waiting for a full reload.

The framework already preserves the tree's DOM across navigation, but `on_show` was unconditionally calling `make_tree()`, a behavior introduced in #17383 to pick up external changes.

This removes that rebuild and reuses the existing DOM, preserving the user's expansion state and making back navigation instant. Changes made outside the current view can still be synchronized through the existing **Refresh** action, while in-view operations already update the DOM incrementally.

Also follows up on the tree expansion-state fix by preserving the scroll position when navigating back to a tree view.

## Behaviour 

https://github.com/user-attachments/assets/a83bc066-ff43-481d-924e-12920f3d29ac



---

Closes #39454