### PR TITLE
fix(print-format): warn and auto-clear disabled default print format

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -30,6 +30,7 @@ frappe.ui.form.on("Customize Form", {
 				filters: {
 					print_format_type: ["!=", "JS"],
 					doc_type: ["=", frm.doc.doc_type],
+					disabled: ["!=", 1],
 				},
 			};
 		});

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -68,7 +68,6 @@ frappe.ui.form.on("Customize Form", {
 							frm.refresh();
 							frm.trigger("add_customize_child_table_button");
 							frm.trigger("setup_default_views");
-							frm.trigger("check_default_print_format");
 						}
 					}
 				},
@@ -84,29 +83,6 @@ frappe.ui.form.on("Customize Form", {
 
 	is_calendar_and_gantt: function (frm) {
 		frm.trigger("setup_default_views");
-	},
-
-	default_print_format: function (frm) {
-		frm.trigger("check_default_print_format");
-	},
-
-	check_default_print_format: function (frm) {
-		const print_format = frm.doc.default_print_format;
-		if (!print_format) return;
-
-		frappe.db.get_value("Print Format", print_format, "disabled", (r) => {
-			// return if the field has changed while the request was in flight
-			if (frm.doc.default_print_format !== print_format) return;
-
-			if (r && r.disabled) {
-				frappe.show_alert({
-					message: __("The selected default print format {0} is disabled.", [
-						print_format.bold(),
-					]),
-					indicator: "orange",
-				});
-			}
-		});
 	},
 
 	add_customize_child_table_button: function (frm) {

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -68,6 +68,7 @@ frappe.ui.form.on("Customize Form", {
 							frm.refresh();
 							frm.trigger("add_customize_child_table_button");
 							frm.trigger("setup_default_views");
+							frm.trigger("check_default_print_format");
 						}
 					}
 				},
@@ -83,6 +84,29 @@ frappe.ui.form.on("Customize Form", {
 
 	is_calendar_and_gantt: function (frm) {
 		frm.trigger("setup_default_views");
+	},
+
+	default_print_format: function (frm) {
+		frm.trigger("check_default_print_format");
+	},
+
+	check_default_print_format: function (frm) {
+		const print_format = frm.doc.default_print_format;
+		if (!print_format) return;
+
+		frappe.db.get_value("Print Format", print_format, "disabled", (r) => {
+			// return if the field has changed while the request was in flight
+			if (frm.doc.default_print_format !== print_format) return;
+
+			if (r && r.disabled) {
+				frappe.show_alert({
+					message: __("The selected default print format {0} is disabled.", [
+						print_format.bold(),
+					]),
+					indicator: "orange",
+				});
+			}
+		});
 	},
 
 	add_customize_child_table_button: function (frm) {

--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -94,6 +94,22 @@ frappe.ui.form.on("Print Format", {
 	doc_type: function (frm) {
 		frm.trigger("hide_absolute_value_field");
 	},
+	disabled: function (frm) {
+		if (!frm.doc.disabled || !frm.doc.doc_type) return;
+
+		frappe.model.with_doctype(frm.doc.doc_type, () => {
+			if (frappe.get_meta(frm.doc.doc_type).default_print_format !== frm.doc.name) return;
+
+			frappe.confirm(
+				__(
+					"{0} is the default print format for {1}. Disabling it will remove it as the default. Do you want to continue?",
+					[frm.doc.name.bold(), frm.doc.doc_type.bold()]
+				),
+				null,
+				() => frm.set_value("disabled", 0)
+			);
+		});
+	},
 	print_format_for: function (frm) {
 		if (frm.doc.print_format_for === "Report") {
 			frm.set_value("custom_format", 1);

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -152,6 +152,7 @@ class PrintFormat(Document):
 
 		self.export_doc()
 		self.enqueue_preview_generation()
+		self.clear_default_print_format_if_disabled()
 
 	def enqueue_preview_generation(self):
 		"""Refresh the preview image in the background so saving the format isn't blocked by
@@ -174,6 +175,36 @@ class PrintFormat(Document):
 			job_id=f"print_format_preview::{self.name}",
 			deduplicate=True,
 			name=self.name,
+		)
+
+	def clear_default_print_format_if_disabled(self):
+		"""If this format is disabled while set as its DocType's default, unset it as default."""
+		if not (self.disabled and self.doc_type):
+			return
+
+		meta = frappe.get_meta(self.doc_type)
+		if meta.default_print_format != self.name:
+			return
+
+		if meta.custom:
+			frappe.db.set_value("DocType", self.doc_type, "default_print_format", "")
+		else:
+			frappe.make_property_setter(
+				{
+					"doctype_or_field": "DocType",
+					"doctype": self.doc_type,
+					"property": "default_print_format",
+					"value": "",
+				}
+			)
+
+		frappe.clear_cache(doctype=self.doc_type)
+		frappe.msgprint(
+			_(
+				"{0} was the default print format for {1}. Since it is now disabled, it has been removed as the default."
+			).format(frappe.bold(self.name), frappe.bold(self.doc_type)),
+			indicator="orange",
+			alert=True,
 		)
 
 	def after_rename(self, old: str, new: str, *args, **kwargs):

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -7,6 +7,7 @@ import re
 import frappe
 import frappe.utils
 from frappe import _
+from frappe.custom.doctype.property_setter.property_setter import delete_property_setter
 from frappe.model.document import Document
 from frappe.utils.jinja import validate_template
 from frappe.utils.print_format_generator import download_pdf, get_html
@@ -189,14 +190,7 @@ class PrintFormat(Document):
 		if meta.custom:
 			frappe.db.set_value("DocType", self.doc_type, "default_print_format", "")
 		else:
-			frappe.make_property_setter(
-				{
-					"doctype_or_field": "DocType",
-					"doctype": self.doc_type,
-					"property": "default_print_format",
-					"value": "",
-				}
-			)
+			delete_property_setter(self.doc_type, "default_print_format")
 
 		frappe.clear_cache(doctype=self.doc_type)
 		frappe.msgprint(


### PR DESCRIPTION
Resolve: #40508

---

**Problem**
If a Print Format is set as the Default Print Format for a DocType and later gets disabled, Customize Form keeps showing it as selected with no indication it is disabled. the stored value stays silent and confusing.

**Fix**
 Checking Disabled on the Print Format form now warns via `frappe.confirm` if it's the current default, letting the user cancel or proceed. On save, the backend automatically clears that default using `frappe.make_property_setter` (or a direct field update for custom DocTypes).

https://github.com/user-attachments/assets/48ba985c-df91-4762-b716-935c30b80fdd


**Why:** The warning belongs where the user's intent is (Print Format form), and auto-clearing on save fixes the root cause