### PR TITLE
fix(treeview): add spacing between search and toolbar filter

### DIFF
--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -69,6 +69,10 @@
 	align-items: center;
 	padding-left: 0px;
 
+	.filters:not(:empty) {
+		margin-left: var(--margin-sm, 8px);
+	}
+
 	.btn {
 		height: var(--btn-height);
 		margin-left: var(--margin-sm, 8px);


### PR DESCRIPTION
## Summary 

Tree views (Chart of Accounts and similar) render the root/company selector flush against the `Search ⌘K` widget, unlike list, report, and form views where toolbar controls have consistent spacing.

The missing gap occurs because toolbar buttons inherit `margin-left: 8px` from `.page-actions .btn`, but tree views render a form field instead of a button, and `restyle_field()` resets its margin to `0`.

This adds a matching `margin-left` to `.filters`, scoped with `:not(:empty)`, so spacing is applied only when a control is present (tree views) and remains a no-op elsewhere.

## Before/After

<img width="1507" height="605" alt="Screenshot 2026-07-02 at 7 27 05 PM" src="https://github.com/user-attachments/assets/6887b14a-b284-47ff-bffc-f0d76a26f6a9" />

<img width="1215" height="302" alt="Screenshot 2026-07-02 at 9 08 16 PM" src="https://github.com/user-attachments/assets/3f74d953-94b6-46c4-90e5-7600d0ba9228" />
