### PR TITLE
fix(document_follow): ignore if document cannot be followed

### DIFF
--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -65,7 +65,7 @@ def follow_document(doctype: str, doc_name: str, user: str) -> Document | bool:
 		frappe.throw(_("You can only follow documents for yourself."), frappe.PermissionError)
 
 	if not frappe.has_permission(doctype, "read", doc=doc_name, user=user):
-		frappe.throw(_("You do not have permission to access this document."), frappe.PermissionError)
+		return False
 
 	if not frappe.db.get_value("User", user, "document_follow_notify", ignore=True, cache=True):
 		frappe.toast(_("Document follow is not enabled for this user."))

--- a/frappe/email/doctype/document_follow/test_document_follow.py
+++ b/frappe/email/doctype/document_follow/test_document_follow.py
@@ -169,8 +169,8 @@ class TestDocumentFollow(IntegrationTestCase):
 		frappe.share.remove("Event", event_doc.name, user.name)
 
 		frappe.set_user(user.name)
-		with self.assertRaises(frappe.PermissionError):
-			document_follow.follow_document("Event", event_doc.name, user.name)
+		result = document_follow.follow_document("Event", event_doc.name, user.name)
+		self.assertFalse(result)
 		frappe.set_user("Administrator")
 
 	def test_revoked_access_cleans_up_follow(self):


### PR DESCRIPTION
Silently ignore if the document cannot be followed.

closes Ticket #72786
related to #39808