### PR TITLE
wip: Freethreaded compatiblity checks

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -92,6 +92,7 @@ jobs:
 
       - name: Run Tests
         run: |
+          ./env/bin/python3 -m pip uninstall -y lxml
           cd sites && ../env/bin/python3 ../apps/frappe/.github/helper/ci.py
         env:
           DB: ${{ matrix.db }}

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: ./.github/actions/setup
         name: Environment Setup
         with:
-          python-version: '3.14'
+          python-version: '3.14t'
           node-version: 24
           disable-socketio: true
           db-root-password: ${{ env.DB_ROOT_PASSWORD }}
@@ -143,7 +143,7 @@ jobs:
       - uses: ./.github/actions/setup
         name: Environment Setup
         with:
-          python-version: '3.14'
+          python-version: '3.14t'
           node-version: 24
           disable-socketio: true
           disable-web: true
@@ -154,7 +154,7 @@ jobs:
         with:
           python-version: |
             3.13
-            3.14
+            3.14t
 
       - name: Download database artifact
         env:

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -2,10 +2,10 @@
 # License: MIT. See LICENSE
 
 import functools
+import json
 import logging
 import os
 
-import orjson
 from werkzeug.exceptions import HTTPException, NotFound
 from werkzeug.middleware.profiler import ProfilerMiddleware
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -331,8 +331,8 @@ def make_form_dict(request: Request):
 	request_data = request.get_data(as_text=True)
 	if request_data and request.is_json:
 		try:
-			args = orjson.loads(request_data)
-		except orjson.JSONDecodeError:
+			args = json.loads(request_data)
+		except json.JSONDecodeError:
 			frappe.throw(_("Invalid request body"), frappe.DataError)
 	else:
 		args = {}

--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import json
 import os
 import re
-
-import orjson
 
 import frappe
 from frappe import _
@@ -154,7 +153,7 @@ def get_installed_apps(*, _ensure_on_bench: bool = False) -> list[str]:
 	if not frappe.db:
 		frappe.connect()
 
-	installed = orjson.loads(frappe.db.get_global("installed_apps") or "[]")
+	installed = json.loads(frappe.db.get_global("installed_apps") or "[]")
 
 	if _ensure_on_bench:
 		all_apps = frappe.cache.get_value("all_apps", get_all_apps)

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -5,7 +5,6 @@ from collections import Counter
 from email.utils import getaddresses
 from urllib.parse import unquote_plus
 
-from bs4 import BeautifulSoup
 
 import frappe
 from frappe import _
@@ -203,6 +202,8 @@ class Communication(Document, CommunicationEmailMixin):
 		if not self.content:
 			return
 
+
+		from bs4 import BeautifulSoup
 		soup = BeautifulSoup(self.content, "html.parser")
 		email_body = soup.find("div", {"class": "ql-editor read-mode"})
 
@@ -228,6 +229,7 @@ class Communication(Document, CommunicationEmailMixin):
 		if not signature:
 			return
 
+		from bs4 import BeautifulSoup
 		soup = BeautifulSoup(signature, "html.parser")
 		html_signature = soup.find("div", {"class": "ql-editor read-mode"})
 		_signature = None

--- a/frappe/core/utils.py
+++ b/frappe/core/utils.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 
 
-from markdownify import markdownify as md
 
 import frappe
 
@@ -88,6 +87,8 @@ def ljust_list(_list, length, fill_word=None):
 def html2text(html: str, strip_links=False, wrap=True) -> str:
 	"""Return the given `html` as markdown text."""
 	strip = ["a"] if strip_links else None
+
+	from markdownify import markdownify as md
 	return md(html, heading_style="ATX", strip=strip, wrap=wrap)
 
 

--- a/frappe/desk/doctype/document_template/document_template.py
+++ b/frappe/desk/doctype/document_template/document_template.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Frappe Technologies and contributors
 # For license information, please see license.txt
 
-import orjson
+import json
 
 import frappe
 from frappe import _
@@ -84,8 +84,8 @@ class DocumentTemplate(Document):
 		- Reformats the stored JSON with consistent indentation.
 		"""
 		try:
-			parsed_data = orjson.loads(self.data)
-		except orjson.JSONDecodeError:
+			parsed_data = json.loads(self.data)
+		except json.JSONDecodeError:
 			frappe.throw(_("Template data must be valid JSON"))
 
 		if not isinstance(parsed_data, dict) or not parsed_data:
@@ -166,7 +166,7 @@ def _has_user_permissions_on_template_data(template_data: str, reference_doctype
 	role permissions *and* user permissions (link-field restrictions) are both
 	evaluated, matching the same path taken for real documents.
 	"""
-	data = orjson.loads(template_data)
+	data = json.loads(template_data)
 	temp_doc = frappe.get_doc({"doctype": reference_doctype, "__islocal": 1, **data})
 	return has_user_permission(temp_doc, user=user, strict=False)
 

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -3,7 +3,6 @@
 
 from typing import Literal
 
-from bs4 import BeautifulSoup
 
 import frappe
 from frappe import _
@@ -421,6 +420,8 @@ def notify_mentions(ref_doctype, ref_name, content):
 
 def extract_mentions(txt):
 	"""Find all instances of @mentions in the html."""
+
+	from bs4 import BeautifulSoup
 	soup = BeautifulSoup(txt, "html.parser")
 	emails = []
 	for mention in soup.find_all(class_="mention"):

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -465,6 +465,7 @@ def get_email_html(
 
 def inline_style_in_html(html, add_css=True):
 	"""Convert email.css and html to inline-styled html."""
+	return html
 	from premailer import Premailer
 
 	from frappe.utils.jinja_globals import bundled_asset

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import hashlib
+import json
 import os
-
-import orjson
 
 import frappe
 from frappe.model.base_document import get_controller
@@ -174,7 +173,7 @@ def read_doc_from_file(path):
 	if os.path.exists(path):
 		with open(path) as f:
 			try:
-				doc = orjson.loads(f.read())
+				doc = json.loads(f.read())
 			except ValueError:
 				print(f"bad json: {path}")
 				raise

--- a/frappe/search/sqlite_search.py
+++ b/frappe/search/sqlite_search.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-from bs4 import BeautifulSoup
 
 import frappe
 from frappe.model.document import Document
@@ -1588,6 +1587,7 @@ class SQLiteSearch(ABC):
 		# Convert to string in case it's a Mock object or other type
 		content = str(content)
 
+		from bs4 import BeautifulSoup
 		soup = BeautifulSoup(content, "html.parser")
 
 		# Extract text content from links before removing HTML tags

--- a/frappe/search/website_search.py
+++ b/frappe/search/website_search.py
@@ -3,7 +3,6 @@
 
 import os
 
-from bs4 import BeautifulSoup
 from whoosh.fields import ID, TEXT, Schema
 
 import frappe
@@ -62,6 +61,8 @@ class WebsiteSearch(FullTextSearch):
 		try:
 			set_request(method="GET", path=route)
 			content = get_response_content(route)
+
+			from bs4 import BeautifulSoup
 			soup = BeautifulSoup(content, "html.parser")
 			page_content = soup.find(class_="page_content")
 			text_content = page_content.text if page_content else ""
@@ -99,6 +100,7 @@ def slugs_with_web_view(_items_to_index):
 				docs = frappe.get_all(doctype.name, filters=filters, fields=[*fields, "title"])
 				for doc in docs:
 					content = frappe.utils.md_to_html(getattr(doc, doctype.website_search_field))
+					from bs4 import BeautifulSoup
 					soup = BeautifulSoup(content, "html.parser")
 					text_content = soup.text if soup else ""
 					_items_to_index += [frappe._dict(title=doc.title, content=text_content, path=doc.route)]

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -23,7 +23,6 @@ from email.header import decode_header, make_header
 from email.utils import formataddr, getaddresses, parseaddr
 from typing import Any, Generic, TypeAlias, TypedDict
 
-import orjson
 from werkzeug.test import Client
 
 from frappe.deprecation_dumpster import (
@@ -848,7 +847,7 @@ def get_site_info():
 		site_info.update(frappe.get_attr(method_name)(site_info) or {})
 
 	# dumps -> loads to prevent datatype conflicts
-	return orjson.loads(frappe.as_json(site_info))
+	return json.loads(frappe.as_json(site_info))
 
 
 def get_db_count(*args):
@@ -869,7 +868,7 @@ def get_db_count(*args):
 	for doctype in args:
 		db_count[doctype] = frappe.db.count(doctype)
 
-	return orjson.loads(frappe.as_json(db_count))
+	return json.loads(frappe.as_json(db_count))
 
 
 def call(fn, *args, **kwargs):
@@ -885,12 +884,12 @@ def call(fn, *args, **kwargs):
 	        via terminal:
 	                bench --site erpnext.local execute frappe.utils.call --args '''["frappe.get_all", "Activity Log"]''' --kwargs '''{"fields": ["user", "creation", "full_name"], "filters":{"Operation": "Login", "Status": "Success"}, "limit": "10"}'''
 	"""
-	return orjson.loads(frappe.as_json(frappe.call(fn, *args, **kwargs)))
+	return json.loads(frappe.as_json(frappe.call(fn, *args, **kwargs)))
 
 
 def get_safe_filters(filters):
 	try:
-		parsed = orjson.loads(filters)
+		parsed = json.loads(filters)
 	except (TypeError, ValueError):
 		# not a string, or not valid json
 		return filters
@@ -1055,7 +1054,7 @@ def safe_json_loads(*args):
 
 	for arg in args:
 		try:
-			arg = orjson.loads(arg)
+			arg = json.loads(arg)
 		except Exception:
 			pass
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -19,7 +19,6 @@ from typing import Any, Literal, Optional, TypeVar
 from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlparse, urlunparse
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-import orjson
 from click import secho
 from dateutil import parser
 from dateutil.parser import ParserError
@@ -83,14 +82,6 @@ DURATION_PATTERN = re.compile(r"^(?:(\d+d)?((^|\s)\d+h)?((^|\s)\d+m)?((^|\s)\d+s
 HTML_TAG_PATTERN = re.compile("<[^>]+>")
 MARIADB_SPECIFIC_COMMENT = re.compile(r"#.*")
 
-# these options are necessary to use orjson with frappe
-#
-# OPT_PASSTHROUGH_DATETIME allows datetime objects to be passed through
-# to the default function without conversion by orjson
-# frappe converts datetime objects differently (__str__) from orjson (RFC 3339)
-#
-# OPT_NON_STR_KEYS slightly reduces performance of orjson, but allows for non-string keys in dicts
-DEFAULT_ORJSON_OPTIONS = orjson.OPT_PASSTHROUGH_DATETIME | orjson.OPT_NON_STR_KEYS
 
 
 class Weekday(Enum):
@@ -2647,7 +2638,7 @@ def guess_date_format(date_string: str) -> str:
 
 def validate_json_string(string: str) -> None:
 	try:
-		orjson.loads(string)
+		json.loads(string)
 	except (TypeError, ValueError):
 		raise frappe.ValidationError
 
@@ -2657,23 +2648,17 @@ def parse_json(val: Any):
 	Parses json if string else return
 	"""
 	if isinstance(val, str):
-		val = orjson.loads(val)
+		val = json.loads(val)
 	if isinstance(val, dict):
 		val = frappe._dict(val)
 	return val
 
 
 def orjson_dumps(obj, default=None, option=None, decode=True):
-	"""A wrapper around `orjson.dumps`, with some default options set"""
+	"""A wrapper around `json.dumps`, with some default options set"""
 
-	if option is not None:
-		# user defined options are merged with the default options
-		option = option | DEFAULT_ORJSON_OPTIONS
-	else:
-		option = DEFAULT_ORJSON_OPTIONS
-
-	value = orjson.dumps(obj, default, option)
-	return value.decode() if decode else value
+	value = json.dumps(obj, default=default)
+	return value if decode else value.encode()
 
 
 class _UserInfo(typing.TypedDict):

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -14,7 +14,6 @@ import pdfkit.api
 from pdfkit.pdfkit import PDFKit as OriginalPDFKit
 
 pdfkit.source.unicode = str  # NOTE: upstream bug; PYTHONOPTIMIZE=1 optimized this away
-from bs4 import BeautifulSoup
 from packaging.version import Version
 from pypdf import PdfReader, PdfWriter, errors
 
@@ -266,6 +265,8 @@ def get_cookie_options():
 
 def read_options_from_html(html):
 	options = {}
+
+	from bs4 import BeautifulSoup
 	soup = BeautifulSoup(html, "html5lib")
 
 	options.update(prepare_header_footer(soup))

--- a/frappe/utils/pdf_generator/browser.py
+++ b/frappe/utils/pdf_generator/browser.py
@@ -1,6 +1,5 @@
 from typing import ClassVar
 
-from bs4 import BeautifulSoup
 
 import frappe
 from frappe.utils.data import cint
@@ -85,6 +84,8 @@ class Browser:
 		self.browser_context_id = result["browserContextId"]
 
 	def set_html(self, html):
+
+		from bs4 import BeautifulSoup
 		self.soup = BeautifulSoup(html, "html5lib")
 
 	def set_options(self, options):

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -3,6 +3,7 @@
 
 import datetime
 import functools
+import json
 import mimetypes
 import os
 import sys
@@ -14,7 +15,6 @@ from typing import TYPE_CHECKING
 from urllib.parse import quote
 from uuid import UUID
 
-import orjson
 import werkzeug.utils
 from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.local import LocalProxy
@@ -195,15 +195,13 @@ def _make_logs_v1():
 	if frappe.error_log and is_traceback_allowed():
 		if source := guess_exception_source(frappe.local.error_log and frappe.local.error_log[0]["exc"]):
 			response["_exc_source"] = source
-		response["exc"] = orjson.dumps([frappe.utils.cstr(d["exc"]) for d in frappe.local.error_log]).decode()
+		response["exc"] = json.dumps([frappe.utils.cstr(d["exc"]) for d in frappe.local.error_log])
 
 	if frappe.local.message_log:
-		response["_server_messages"] = orjson.dumps(
-			[orjson.dumps(d).decode() for d in frappe.local.message_log]
-		).decode()
+		response["_server_messages"] = json.dumps([json.dumps(d) for d in frappe.local.message_log])
 
 	if frappe.debug_log and is_traceback_allowed():
-		response["_debug_messages"] = orjson.dumps(frappe.local.debug_log).decode()
+		response["_debug_messages"] = json.dumps(frappe.local.debug_log)
 
 	if frappe.flags.error_message:
 		response["_error_message"] = frappe.flags.error_message
@@ -252,8 +250,6 @@ def json_handler(obj):
 	elif isinstance(obj, Path):
 		return str(obj)
 
-	# orjson does this already
-	# but json_handler needs to be compatible with built-in json module also
 	elif isinstance(obj, UUID):
 		return str(obj)
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -11,7 +11,6 @@ from itertools import chain
 from types import FunctionType, MethodType, ModuleType
 from typing import TYPE_CHECKING, Any
 
-import orjson
 import RestrictedPython.Guards
 from RestrictedPython import PrintCollector, compile_restricted, safe_globals
 from RestrictedPython.transformer import RestrictingNodeTransformer
@@ -917,10 +916,7 @@ WHITELISTED_SAFE_EVAL_GLOBALS = {
 	"_inplacevar_": protected_inplacevar,
 }
 
-SAFE_ORJSON = NamespaceDict(loads=orjson.loads, dumps=orjson.dumps)
-for key, val in vars(orjson).items():
-	if key.startswith("OPT_"):
-		SAFE_ORJSON[key] = val
+SAFE_ORJSON = NamespaceDict(loads=json.loads, dumps=json.dumps)
 
 SAFE_EXCEPTIONS = get_module_properties(
 	frappe.exceptions, lambda obj: inspect.isclass(obj) and issubclass(obj, Exception)

--- a/frappe/utils/telemetry/pulse/queue.py
+++ b/frappe/utils/telemetry/pulse/queue.py
@@ -1,7 +1,6 @@
 import time
 from contextlib import suppress
-
-from orjson import JSONDecodeError
+from json import JSONDecodeError
 
 import frappe
 

--- a/frappe/website/doctype/web_template/test_web_template.py
+++ b/frappe/website/doctype/web_template/test_web_template.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-from bs4 import BeautifulSoup
 
 import frappe
 from frappe.tests import IntegrationTestCase
@@ -19,6 +18,7 @@ class TestWebTemplate(IntegrationTestCase):
 		}
 		html = doc.render(values)
 
+		from bs4 import BeautifulSoup
 		soup = BeautifulSoup(html, "html.parser")
 		heading = soup.find("h1")
 		self.assertTrue("Test Hero" in heading.text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "Jinja2~=3.1.6",
     "Pillow~=12.2.0",
     "PyJWT~=2.13.0",
-    "duckdb~=1.4.3",
+    # "duckdb~=1.4.3",
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.2",
@@ -49,7 +49,7 @@ dependencies = [
     "oauthlib~=3.3.1",
     "openpyxl~=3.1.5",
     "xlsxwriter~=3.2.9",
-    "orjson~=3.11.5",
+    #"orjson~=3.11.5",
     "passlib~=1.7.4",
     "pdfkit~=1.0.0",
     "phonenumbers~=9.0.21",
@@ -63,7 +63,7 @@ dependencies = [
     "pytz==2026.2",
     "rauth~=0.7.3",
     "redis~=7.1.0",
-    "hiredis~=3.3.0",
+    # "hiredis~=3.3.0",
     "requests-oauthlib~=2.0.0",
     "requests~=2.34.2",
     # We depend on internal attributes of RQ.
@@ -92,12 +92,12 @@ dependencies = [
     # realtime (Python Socket.IO server) — speaks Socket.IO v5 / Engine.IO v4,
     # wire-compatible with the browser's socket.io-client ^4.7.1.
     # Pin exact versions after a manual handshake check (polling + websocket upgrade).
-    "python-socketio~=5.16.2",
-    "python-engineio~=4.13.2",
-    "gevent~=25.9.1",
+    # "python-socketio~=5.16.2",
+    # "python-engineio~=4.13.2",
+    # "gevent~=25.9.1",
     # gevent-websocket is effectively unmaintained but is the documented websocket
     # path for python-socketio's gevent WSGIServer. Pinned deliberately.
-    "gevent-websocket~=0.10.1",
+    # "gevent-websocket~=0.10.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
free-threading *mostly* works with Frappe now.

Following modules don't work:

- [ ] `orjson` (replaceable),
- [ ] `duckdb` (likely works, but need to compile a giant build so I removed)
- [ ] `gevent` and related stuff. Not supported at all.
- [ ]  `hiredis` - optional accel for parsing, doesn't declare itself as compatible. Should be straight-forward to support IMO. 
- [ ] `lxml` via bs4 / markdownify / premailer. We don't use it in our code directly. This one can be handled by monkey-patching use of LXML behind mutex or something. 
