### PR TITLE
feat: Print format builder UX improvements

### DIFF
--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -256,6 +256,75 @@ context("Print Format Builder — create flow", () => {
 				expect(parseInt($el.css("border-right-width"), 10)).to.be.greaterThan(0);
 			});
 	});
+
+	// 8. Format tab: label color uses the Frappe Color control and persists on save
+	it("Format tab: label color persists on save", () => {
+		cy.visit("/app");
+
+		insert_builder_format(PF_NAME, []);
+
+		cy.intercept("POST", "api/method/frappe.client.save").as("save");
+		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
+
+		cy.get(".pfb-tab[title='Format']", { timeout: 30000 }).click();
+		cy.get(".pfb-margin-grid").should("be.visible");
+
+		// The color field is rendered with Frappe's ControlColor (adds .selected-color swatch)
+		cy.get('[data-fieldname="label_color"] .selected-color').should("exist");
+
+		cy.get('[data-fieldname="label_color"] input:visible')
+			.clear()
+			.type("#c0392b")
+			.trigger("change")
+			.blur();
+
+		cy.get('[data-testid="page-status"]', { timeout: 5000 })
+			.should("be.visible")
+			.and("contain", "Not Saved");
+
+		cy.contains(".page-actions .primary-action", "Save").click({ force: true });
+		cy.wait("@save").then((interception) => {
+			expect(interception.response.statusCode).to.equal(200);
+			expect(interception.response.body.message.label_color).to.equal("#c0392b");
+		});
+	});
+
+	// 9. Selecting a repeater field exposes per-column width and style controls
+	it("repeater inspector shows column width and style controls", () => {
+		cy.visit("/app");
+
+		insert_builder_format(PF_NAME, [
+			{
+				label: "Rep Section",
+				columns: [
+					{
+						label: "",
+						fields: [
+							{
+								fieldtype: "Repeater",
+								fieldname: "rep1",
+								label: "Rep",
+								repeater_columns: [{ template: [], align: "left" }],
+							},
+						],
+					},
+				],
+			},
+		]);
+
+		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
+
+		cy.get("[data-pfb-section]", { timeout: 30000 }).should("be.visible");
+		cy.contains("[data-pfb-section]", "Rep Section")
+			.find(".field")
+			.first()
+			.click({ force: true });
+
+		cy.get(".pfb-inspector").should("contain", "Repeater");
+		cy.get(".pfb-inspector").should("contain", "Columns");
+		cy.get(".pfb-inspector").should("contain", "Style");
+		cy.get(".pfb-inspector .pfb-col-width-input").should("exist");
+	});
 });
 
 // ─── Setup flow ───────────────────────────────────────────────────────────────

--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -289,8 +289,8 @@ context("Print Format Builder — create flow", () => {
 		});
 	});
 
-	// 9. Selecting a repeater field exposes per-column width and style controls
-	it("repeater inspector shows column width and style controls", () => {
+	// 9. Selecting a repeater field exposes per-column width and color controls
+	it("repeater inspector shows column width and color controls", () => {
 		cy.visit("/app");
 
 		insert_builder_format(PF_NAME, [
@@ -322,7 +322,8 @@ context("Print Format Builder — create flow", () => {
 
 		cy.get(".pfb-inspector").should("contain", "Repeater");
 		cy.get(".pfb-inspector").should("contain", "Columns");
-		cy.get(".pfb-inspector").should("contain", "Style");
+		cy.get(".pfb-inspector").should("contain", "Color");
+		cy.get(".pfb-inspector .pfb-rep-col-color .selected-color").should("exist");
 		cy.get(".pfb-inspector .pfb-col-width-input").should("exist");
 	});
 });

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -34,6 +34,8 @@
   "column_break_11",
   "font_size",
   "font",
+  "label_color",
+  "value_color",
   "page_number",
   "css_section",
   "css",
@@ -179,6 +181,18 @@
    "fieldname": "font",
    "fieldtype": "Data",
    "label": "Google Font"
+  },
+  {
+   "depends_on": "eval:!doc.custom_format",
+   "fieldname": "label_color",
+   "fieldtype": "Color",
+   "label": "Label Color"
+  },
+  {
+   "depends_on": "eval:!doc.custom_format",
+   "fieldname": "value_color",
+   "fieldtype": "Color",
+   "label": "Value Color"
   },
   {
    "depends_on": "eval:!doc.raw_printing",

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -317,7 +317,7 @@
  "icon": "fa fa-print",
  "idx": 1,
  "links": [],
- "modified": "2026-06-18 11:43:16.136944",
+ "modified": "2026-07-03 01:28:04.950020",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import json
+import re
 
 import frappe
 import frappe.utils
@@ -117,6 +118,18 @@ class PrintFormat(Document):
 
 		if self.print_format_for == "Report" and not self.report:
 			frappe.throw(_("{0} is required").format(frappe.bold(_("Report"))), frappe.MandatoryError)
+
+		self.validate_colors()
+
+	def validate_colors(self):
+		for fieldname in ("label_color", "value_color"):
+			value = self.get(fieldname)
+			if value and not re.fullmatch(r"#[0-9a-fA-F]{6}", value):
+				frappe.throw(
+					_("{0} must be a hex color code like #1a5fb4").format(
+						frappe.bold(_(self.meta.get_label(fieldname)))
+					)
+				)
 
 	def extract_images(self):
 		from frappe.core.doctype.file.utils import extract_images_from_html

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -33,6 +33,7 @@ class PrintFormat(Document):
 		font_size: DF.Int
 		format_data: DF.Code | None
 		html: DF.Code | None
+		label_color: DF.Color | None
 		line_breaks: DF.Check
 		margin_bottom: DF.Float
 		margin_left: DF.Float
@@ -53,6 +54,7 @@ class PrintFormat(Document):
 		report: DF.Link | None
 		show_section_headings: DF.Check
 		standard: DF.Literal["No", "Yes"]
+		value_color: DF.Color | None
 	# end: auto-generated types
 
 	def onload(self):

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -10,7 +10,6 @@
 				:title="tab.label"
 				@click="activeTab = tab.id"
 			>
-				<span class="pfb-tab-icon" v-html="frappe.utils.icon(tab.icon, 'sm')"></span>
 				<span class="pfb-tab-label">{{ tab.label }}</span>
 			</button>
 		</div>
@@ -279,11 +278,11 @@ let { meta, print_format, layout } = useStore();
 
 // ── tab definitions ───────────────────────────────────────
 const tabs = computed(() => [
-	{ id: "fields", label: __("Fields"), icon: "list" },
-	{ id: "blocks", label: __("Blocks"), icon: "blocks" },
-	{ id: "templates", label: __("Templates"), icon: "table" },
-	{ id: "outline", label: __("Outline"), icon: "layout-list" },
-	{ id: "format", label: __("Format"), icon: "settings" },
+	{ id: "fields", label: __("Fields") },
+	{ id: "blocks", label: __("Blocks") },
+	{ id: "templates", label: __("Templates") },
+	{ id: "outline", label: __("Outline") },
+	{ id: "format", label: __("Format") },
 ]);
 
 // ── blocks tab items ──────────────────────────────────────
@@ -610,10 +609,9 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 .pfb-tab {
 	flex: 1;
 	display: flex;
-	flex-direction: column;
 	align-items: center;
-	gap: 2px;
-	padding: 6px 2px 8px;
+	justify-content: center;
+	padding: 8px 2px;
 	border: none;
 	background: transparent;
 	border-radius: var(--radius) var(--radius) 0 0;
@@ -644,12 +642,6 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	height: 2px;
 	background: var(--primary);
 	border-radius: 2px 2px 0 0;
-}
-
-.pfb-tab-icon {
-	display: flex;
-	align-items: center;
-	line-height: 1;
 }
 
 .pfb-tab-label {

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -358,7 +358,10 @@ function mount_color_controls() {
 				fieldname: c.fieldname,
 				placeholder: c.label,
 				change() {
-					print_format.value[c.fieldname] = control.get_value() || null;
+					const value = control.get_value() || null;
+					if ((print_format.value[c.fieldname] ?? null) !== value) {
+						print_format.value[c.fieldname] = value;
+					}
 				},
 			},
 			render_input: true,

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -346,8 +346,9 @@ const color_settings = [
 	{ fieldname: "value_color", label: __("Value") },
 ];
 let color_hosts = ref({});
-let color_controls = {};
 
+// The Format tab is v-if, so its DOM is recreated on each visit — (re)mount the
+// Frappe color controls into the fresh host divs when the tab is shown.
 function mount_color_controls() {
 	for (const c of color_settings) {
 		const host = color_hosts.value[c.fieldname];
@@ -366,7 +367,6 @@ function mount_color_controls() {
 			render_input: true,
 		});
 		control.set_value(print_format.value[c.fieldname] || "");
-		color_controls[c.fieldname] = control;
 	}
 }
 

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -209,22 +209,22 @@
 		</div>
 
 		<!-- ── Format ─────────────────────────────────────────── -->
-		<div v-else-if="activeTab === 'format'" class="pfb-tab-body">
-			<div class="pfb-group-label">{{ __("Page margins (mm)") }}</div>
-			<div class="pfb-margin-grid">
-				<div class="pfb-margin-cell" v-for="df in margins" :key="df.fieldname">
-					<label class="pfb-margin-label control-label">{{ df.label }}</label>
-					<input
-						type="number"
-						class="form-control form-control-sm"
-						:value="print_format[df.fieldname]"
-						min="0"
-						@change="(e) => update_margin(df.fieldname, e.target.value)"
-					/>
+		<div v-else-if="activeTab === 'format'" class="pfb-tab-body pfb-format-tab">
+			<div class="form-group">
+				<label class="control-label">{{ __("Page Margins (mm)") }}</label>
+				<div class="pfb-margin-grid">
+					<div class="pfb-margin-cell" v-for="df in margins" :key="df.fieldname">
+						<label class="pfb-margin-label control-label">{{ df.label }}</label>
+						<input
+							type="number"
+							class="form-control form-control-sm"
+							:value="print_format[df.fieldname]"
+							min="0"
+							@change="(e) => update_margin(df.fieldname, e.target.value)"
+						/>
+					</div>
 				</div>
 			</div>
-
-			<div class="pfb-group-label mt-3">{{ __("Font") }}</div>
 			<div class="form-group">
 				<label class="control-label">{{ __("Google Font") }}</label>
 				<select class="form-control form-control-sm" v-model="print_format.font">
@@ -241,15 +241,12 @@
 					@change="(e) => (print_format.font_size = parseFloat(e.target.value))"
 				/>
 			</div>
-
-			<div class="pfb-group-label mt-3">{{ __("Colors") }}</div>
 			<div class="form-group" v-for="c in color_settings" :key="c.fieldname">
 				<label class="control-label">{{ c.label }}</label>
 				<div :ref="(el) => (color_hosts[c.fieldname] = el)"></div>
 			</div>
-
-			<div class="pfb-group-label mt-3">{{ __("Page number") }}</div>
 			<div class="form-group">
+				<label class="control-label">{{ __("Page Number") }}</label>
 				<select class="form-control form-control-sm" v-model="print_format.page_number">
 					<option v-for="p in page_number_positions" :value="p.value">
 						{{ p.label }}
@@ -342,8 +339,8 @@ const draggable_blocks = [
 ];
 
 const color_settings = [
-	{ fieldname: "label_color", label: __("Label") },
-	{ fieldname: "value_color", label: __("Value") },
+	{ fieldname: "label_color", label: __("Label Color") },
+	{ fieldname: "value_color", label: __("Value Color") },
 ];
 let color_hosts = ref({});
 
@@ -365,6 +362,7 @@ function mount_color_controls() {
 				},
 			},
 			render_input: true,
+			only_input: true,
 		});
 		control.set_value(print_format.value[c.fieldname] || "");
 	}
@@ -968,11 +966,22 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 /* ── Format tab ──────────────────────────────────────────── */
+.pfb-format-tab .form-group {
+	margin-bottom: 10px;
+}
+
+.pfb-format-tab .form-group:last-child {
+	margin-bottom: 0;
+}
+
+.pfb-format-tab :deep(.frappe-control) {
+	margin-bottom: 0;
+}
+
 .pfb-margin-grid {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	gap: 6px;
-	margin-bottom: 6px;
 }
 
 .pfb-margin-cell {

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -242,6 +242,33 @@
 				/>
 			</div>
 
+			<div class="pfb-group-label mt-3">{{ __("Colors") }}</div>
+			<div class="form-group" v-for="c in color_settings" :key="c.fieldname">
+				<label class="control-label">{{ c.label }}</label>
+				<div class="pfb-color-row">
+					<input
+						type="color"
+						class="pfb-color-swatch"
+						:value="print_format[c.fieldname] || c.default"
+						@input="(e) => (print_format[c.fieldname] = e.target.value)"
+					/>
+					<input
+						type="text"
+						class="form-control form-control-sm"
+						:placeholder="c.default"
+						:value="print_format[c.fieldname]"
+						@change="(e) => (print_format[c.fieldname] = e.target.value || null)"
+					/>
+					<button
+						v-if="print_format[c.fieldname]"
+						class="btn btn-xs btn-icon pfb-color-clear"
+						:title="__('Reset')"
+						@click="print_format[c.fieldname] = null"
+						v-html="frappe.utils.icon('x', 'xs')"
+					></button>
+				</div>
+			</div>
+
 			<div class="pfb-group-label mt-3">{{ __("Page number") }}</div>
 			<div class="form-group">
 				<select class="form-control form-control-sm" v-model="print_format.page_number">
@@ -333,6 +360,11 @@ const draggable_blocks = [
 			{ template: [], align: "right" },
 		],
 	},
+];
+
+const color_settings = [
+	{ fieldname: "label_color", label: __("Label"), default: "#6b7280" },
+	{ fieldname: "value_color", label: __("Value"), default: "#111827" },
 ];
 
 // ── helpers ────────────────────────────────────────────────
@@ -947,6 +979,28 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 
 .pfb-margin-label {
 	font-size: var(--text-tiny);
+}
+
+.pfb-color-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.pfb-color-swatch {
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	background: none;
+	cursor: pointer;
+	flex-shrink: 0;
+}
+
+.pfb-color-clear {
+	flex-shrink: 0;
+	color: var(--text-muted);
 }
 
 /* ── Empty state ─────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -245,28 +245,7 @@
 			<div class="pfb-group-label mt-3">{{ __("Colors") }}</div>
 			<div class="form-group" v-for="c in color_settings" :key="c.fieldname">
 				<label class="control-label">{{ c.label }}</label>
-				<div class="pfb-color-row">
-					<input
-						type="color"
-						class="pfb-color-swatch"
-						:value="print_format[c.fieldname] || c.default"
-						@input="(e) => (print_format[c.fieldname] = e.target.value)"
-					/>
-					<input
-						type="text"
-						class="form-control form-control-sm"
-						:placeholder="c.default"
-						:value="print_format[c.fieldname]"
-						@change="(e) => (print_format[c.fieldname] = e.target.value || null)"
-					/>
-					<button
-						v-if="print_format[c.fieldname]"
-						class="btn btn-xs btn-icon pfb-color-clear"
-						:title="__('Reset')"
-						@click="print_format[c.fieldname] = null"
-						v-html="frappe.utils.icon('x', 'xs')"
-					></button>
-				</div>
+				<div :ref="(el) => (color_hosts[c.fieldname] = el)"></div>
 			</div>
 
 			<div class="pfb-group-label mt-3">{{ __("Page number") }}</div>
@@ -363,9 +342,33 @@ const draggable_blocks = [
 ];
 
 const color_settings = [
-	{ fieldname: "label_color", label: __("Label"), default: "#6b7280" },
-	{ fieldname: "value_color", label: __("Value"), default: "#111827" },
+	{ fieldname: "label_color", label: __("Label") },
+	{ fieldname: "value_color", label: __("Value") },
 ];
+let color_hosts = ref({});
+let color_controls = {};
+
+function mount_color_controls() {
+	for (const c of color_settings) {
+		const host = color_hosts.value[c.fieldname];
+		if (!host) continue;
+		host.innerHTML = "";
+		const control = frappe.ui.form.make_control({
+			parent: host,
+			df: {
+				fieldtype: "Color",
+				fieldname: c.fieldname,
+				placeholder: c.label,
+				change() {
+					print_format.value[c.fieldname] = control.get_value() || null;
+				},
+			},
+			render_input: true,
+		});
+		control.set_value(print_format.value[c.fieldname] || "");
+		color_controls[c.fieldname] = control;
+	}
+}
 
 // ── helpers ────────────────────────────────────────────────
 function update_margin(fieldname, value) {
@@ -532,6 +535,7 @@ function fetch_templates() {
 
 watch(activeTab, (tab) => {
 	if (tab === "templates") fetch_templates();
+	if (tab === "format") nextTick(mount_color_controls);
 });
 
 let print_templates_list = computed(() => {
@@ -979,28 +983,6 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 
 .pfb-margin-label {
 	font-size: var(--text-tiny);
-}
-
-.pfb-color-row {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-}
-
-.pfb-color-swatch {
-	width: 28px;
-	height: 28px;
-	padding: 0;
-	border: 1px solid var(--border-color);
-	border-radius: var(--radius);
-	background: none;
-	cursor: pointer;
-	flex-shrink: 0;
-}
-
-.pfb-color-clear {
-	flex-shrink: 0;
-	color: var(--text-muted);
 }
 
 /* ── Empty state ─────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -30,12 +30,7 @@
 				<!-- Table MultiSelect field: render as a comma-separated value list -->
 				<div
 					v-else-if="df.fieldtype == 'Table MultiSelect'"
-					:style="{
-						...(field_orientation !== 'left-right'
-							? { textAlign: df.align || 'left' }
-							: {}),
-						...(df.label_gap != null ? { gap: df.label_gap + 'px' } : {}),
-					}"
+					:style="field_style(df, true)"
 					:class="[
 						'field-preview-lr',
 						field_orientation === 'left-right' && df.label_justify
@@ -206,15 +201,7 @@
 				<!-- Regular field -->
 				<div
 					v-else
-					:style="{
-						...(field_orientation !== 'left-right'
-							? { textAlign: df.align || 'left' }
-							: {}),
-						...((field_orientation === 'left-right' || df.show_label === 'inline') &&
-						df.label_gap != null
-							? { gap: df.label_gap + 'px' }
-							: {}),
-					}"
+					:style="field_style(df)"
 					:class="[
 						field_orientation === 'left-right' || df.show_label === 'inline'
 							? 'field-preview-lr'
@@ -348,6 +335,22 @@ import { render_jinja_html, sanitize_html, evaluate_visible_if, thumb_hue } from
 import { createApp, ref, nextTick, watch, computed, inject } from "vue";
 
 const props = defineProps(["df", "field_orientation"]);
+
+// Inline style for a preview field: text alignment (stacked only) plus an
+// optional label-to-value gap. `always_row` is for fields that are always a
+// flex row (e.g. Table MultiSelect) regardless of section orientation.
+function field_style(df, always_row = false) {
+	const style = {};
+	if (props.field_orientation !== "left-right") {
+		style.textAlign = df.align || "left";
+	}
+	const is_row =
+		always_row || props.field_orientation === "left-right" || df.show_label === "inline";
+	if (is_row && df.label_gap != null) {
+		style.gap = df.label_gap + "px";
+	}
+	return style;
+}
 
 let store = inject("$store");
 let editing = ref(false);
@@ -1054,21 +1057,22 @@ watch(
 	border: none;
 }
 
-/* Repeater column styles — mirror the child-table cell-line palette */
-.field-preview-repeater td.cell-line--primary {
-	font-weight: 600;
-	color: #111827;
-}
+/* Repeater column styles — same palette as child-table cells (.pf-merge--*),
+   driven by theme tokens; scoped to td to out-specify the .preview-table td color */
+.field-preview-repeater td.cell-line--primary,
 .field-preview-repeater td.cell-line--secondary {
-	color: #111827;
+	color: var(--text-color);
+}
+.field-preview-repeater td.cell-line--primary {
+	font-weight: var(--weight-semibold);
 }
 .field-preview-repeater td.cell-line--mono-sm {
 	font-family: var(--monospace-font-family, monospace);
 }
 .field-preview-repeater td.cell-line--mono-sm,
 .field-preview-repeater td.cell-line--muted-sm {
-	font-size: 0.9em;
-	color: #6b7280;
+	font-size: 0.85em;
+	color: var(--text-muted);
 }
 
 /* lined (default): no alternating rows */

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -171,6 +171,13 @@
 						{{ df.label }}
 					</div>
 					<table class="preview-table preview-table--borderless">
+						<colgroup>
+							<col
+								v-for="(col, ci) in df.repeater_columns || []"
+								:key="ci"
+								:style="col.width ? { width: col.width + '%' } : {}"
+							/>
+						</colgroup>
 						<tbody>
 							<tr
 								v-for="(row, i) in (preview_doc[df.source] || []).slice(0, 6)"

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -30,9 +30,12 @@
 				<!-- Table MultiSelect field: render as a comma-separated value list -->
 				<div
 					v-else-if="df.fieldtype == 'Table MultiSelect'"
-					:style="
-						field_orientation !== 'left-right' ? { textAlign: df.align || 'left' } : {}
-					"
+					:style="{
+						...(field_orientation !== 'left-right'
+							? { textAlign: df.align || 'left' }
+							: {}),
+						...(df.label_gap != null ? { gap: df.label_gap + 'px' } : {}),
+					}"
 					:class="[
 						'field-preview-lr',
 						field_orientation === 'left-right' && df.label_justify
@@ -164,7 +167,9 @@
 				</div>
 				<!-- Repeater field -->
 				<div v-else-if="df.fieldtype == 'Repeater'" class="field-preview-repeater">
-					<div v-if="df.label" class="field-preview-label">{{ df.label }}</div>
+					<div v-if="df.label && df.show_label !== 'hide'" class="field-preview-label">
+						{{ df.label }}
+					</div>
 					<table class="preview-table preview-table--borderless">
 						<tbody>
 							<tr
@@ -193,9 +198,15 @@
 				<!-- Regular field -->
 				<div
 					v-else
-					:style="
-						field_orientation !== 'left-right' ? { textAlign: df.align || 'left' } : {}
-					"
+					:style="{
+						...(field_orientation !== 'left-right'
+							? { textAlign: df.align || 'left' }
+							: {}),
+						...((field_orientation === 'left-right' || df.show_label === 'inline') &&
+						df.label_gap != null
+							? { gap: df.label_gap + 'px' }
+							: {}),
+					}"
 					:class="[
 						field_orientation === 'left-right' || df.show_label === 'inline'
 							? 'field-preview-lr'
@@ -881,7 +892,7 @@ watch(
 }
 
 .field-preview-label {
-	font-size: var(--text-tiny);
+	font-size: var(--text-sm);
 	font-weight: var(--weight-semibold);
 	color: #6b7280;
 	margin-bottom: 1px;

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -181,8 +181,10 @@
 								<td
 									v-for="(col, ci) in df.repeater_columns || []"
 									:key="ci"
-									:class="col.style ? `cell-line--${col.style}` : ''"
-									:style="{ textAlign: col.align || 'left' }"
+									:style="{
+										textAlign: col.align || 'left',
+										...(col.color ? { color: col.color } : {}),
+									}"
 								>
 									{{ repeater_cell(col, row) }}
 								</td>
@@ -1055,24 +1057,6 @@ watch(
 .field-preview-repeater .preview-table td {
 	padding: 0;
 	border: none;
-}
-
-/* Repeater column styles — same palette as child-table cells (.pf-merge--*),
-   driven by theme tokens; scoped to td to out-specify the .preview-table td color */
-.field-preview-repeater td.cell-line--primary,
-.field-preview-repeater td.cell-line--secondary {
-	color: var(--text-color);
-}
-.field-preview-repeater td.cell-line--primary {
-	font-weight: var(--weight-semibold);
-}
-.field-preview-repeater td.cell-line--mono-sm {
-	font-family: var(--monospace-font-family, monospace);
-}
-.field-preview-repeater td.cell-line--mono-sm,
-.field-preview-repeater td.cell-line--muted-sm {
-	font-size: 0.85em;
-	color: var(--text-muted);
 }
 
 /* lined (default): no alternating rows */

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -906,7 +906,6 @@ watch(
 
 .field-preview-label {
 	font-size: var(--text-sm);
-	font-weight: var(--weight-semibold);
 	color: var(--pfb-label-color, #6b7280);
 	margin-bottom: 1px;
 }

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -186,6 +186,7 @@
 								<td
 									v-for="(col, ci) in df.repeater_columns || []"
 									:key="ci"
+									:class="col.style ? `cell-line--${col.style}` : ''"
 									:style="{ textAlign: col.align || 'left' }"
 								>
 									{{ repeater_cell(col, row) }}
@@ -901,7 +902,7 @@ watch(
 .field-preview-label {
 	font-size: var(--text-sm);
 	font-weight: var(--weight-semibold);
-	color: #6b7280;
+	color: var(--pfb-label-color, #6b7280);
 	margin-bottom: 1px;
 }
 
@@ -957,7 +958,7 @@ watch(
 
 .field-preview-value {
 	font-size: var(--text-sm);
-	color: var(--text-color);
+	color: var(--pfb-value-color, var(--text-color));
 	word-break: break-word;
 }
 
@@ -1051,6 +1052,23 @@ watch(
 .field-preview-repeater .preview-table td {
 	padding: 0;
 	border: none;
+}
+
+/* Repeater column styles — mirror the child-table cell-line palette */
+.field-preview-repeater td.cell-line--primary {
+	font-weight: 600;
+	color: #111827;
+}
+.field-preview-repeater td.cell-line--secondary {
+	color: #111827;
+}
+.field-preview-repeater td.cell-line--mono-sm {
+	font-family: var(--monospace-font-family, monospace);
+}
+.field-preview-repeater td.cell-line--mono-sm,
+.field-preview-repeater td.cell-line--muted-sm {
+	font-size: 0.9em;
+	color: #6b7280;
 }
 
 /* lined (default): no alternating rows */

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -326,9 +326,11 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 
 /* Hide the section pill while a field inside is hovered/selected so it doesn't
    collide with the field's own top-right pill */
-.pfb-clean-preview :deep(.print-format-section-container:has(.field--preview:hover) .section-preview-actions),
 .pfb-clean-preview
-	:deep(.print-format-section-container:has(.field--preview.field--selected) .section-preview-actions) {
+	:deep(.print-format-section-container:has(.field--preview:hover) .section-preview-actions),
+.pfb-clean-preview
+	:deep(.print-format-section-container:has(.field--preview.field--selected)
+		.section-preview-actions) {
 	opacity: 0;
 	pointer-events: none;
 }

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -340,7 +340,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	font-size: 1em;
 }
 .pfb-body :deep(.field--preview .field-preview-label) {
-	font-size: 0.8em;
+	font-size: 1em;
 }
 .pfb-body :deep(.field--preview .preview-table) {
 	font-size: 0.9em;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -141,10 +141,12 @@ let rootStyles = computed(() => {
 });
 
 let bodyStyles = computed(() => {
-	const { font_size, font } = print_format.value;
+	const { font_size, font, label_color, value_color } = print_format.value;
 	const styles = {};
 	if (font_size) styles.fontSize = `${parseFloat(font_size)}px`;
 	if (font) styles.fontFamily = `'${font}', sans-serif`;
+	if (label_color) styles["--pfb-label-color"] = label_color;
+	if (value_color) styles["--pfb-value-color"] = value_color;
 	return styles;
 });
 
@@ -320,6 +322,15 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 .pfb-clean-preview
 	:deep(.print-format-section-container:has(.section--selected) .section-preview-actions) {
 	opacity: 1;
+}
+
+/* Hide the section pill while a field inside is hovered/selected so it doesn't
+   collide with the field's own top-right pill */
+.pfb-clean-preview :deep(.print-format-section-container:has(.field--preview:hover) .section-preview-actions),
+.pfb-clean-preview
+	:deep(.print-format-section-container:has(.field--preview.field--selected) .section-preview-actions) {
+	opacity: 0;
+	pointer-events: none;
 }
 
 /* Section title: match PDF's .section-label look */

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -5,7 +5,7 @@
 		v-show="!preview_doc || has_visible_fields"
 		:class="{ 'section-container--condition-hidden': preview_doc && !is_section_visible }"
 	>
-		<!-- Top-left actions pill shown on hover in clean-preview (toolbar is hidden) -->
+		<!-- Top-right actions pill shown on hover in clean-preview (toolbar is hidden) -->
 		<div v-if="!is_header" class="section-preview-actions">
 			<div
 				class="drag-handle section-drag-handle"
@@ -449,8 +449,8 @@ function remove_column(index) {
 .section-preview-actions {
 	display: none; /* shown via .pfb-clean-preview :deep() override */
 	position: absolute;
-	top: 4px;
-	left: 4px;
+	top: -12px;
+	right: 4px;
 	z-index: 2;
 	gap: 2px;
 	padding: 1px 2px;

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -408,17 +408,11 @@
 								style="margin-top: 8px"
 							/>
 							<div class="pfb-insp-row" style="margin-top: 8px">
-								<span class="pfb-insp-label">{{ __("Style") }}</span>
-								<select class="pfb-insp-select" v-model="col.style">
-									<option value="">{{ __("Normal") }}</option>
-									<option
-										v-for="s in merge_style_opts"
-										:key="s.value"
-										:value="s.value"
-									>
-										{{ s.label }}
-									</option>
-								</select>
+								<span class="pfb-insp-label">{{ __("Color") }}</span>
+								<div
+									class="pfb-rep-col-color"
+									:ref="(el) => (rep_color_hosts[ci] = el)"
+								></div>
 							</div>
 						</div>
 						<button class="pfb-add-btn" @click="add_repeater_column">
@@ -632,17 +626,7 @@
 						></span>
 					</div>
 					<div v-show="open.s_bg" class="pfb-insp-section-body">
-						<div class="pfb-color-swatches">
-							<button
-								v-for="swatch in bg_swatches"
-								:key="swatch.value"
-								class="pfb-swatch"
-								:class="{ active: section_bg === swatch.value }"
-								:title="swatch.label"
-								:style="swatch.style"
-								@click="selected_section.background = swatch.value"
-							></button>
-						</div>
+						<div ref="bg_color_host"></div>
 					</div>
 				</div>
 
@@ -741,7 +725,7 @@
 </template>
 
 <script setup>
-import { computed, inject, ref, watch } from "vue";
+import { computed, inject, nextTick, ref, watch } from "vue";
 import draggable from "vuedraggable";
 import { useStore } from "../../stores";
 import LetterHeadZoneInspector from "./LetterHeadZoneInspector.vue";
@@ -1150,19 +1134,65 @@ function set_image_size(col, value) {
 let section_orientation = computed(() => selected_section.value?.field_orientation ?? "");
 let section_gap = computed(() => selected_section.value?.gap ?? 20);
 let section_label_case = computed(() => selected_section.value?.label_case ?? "normal");
-let section_bg = computed(() => selected_section.value?.background ?? "");
+const bg_color_host = ref(null);
 
-const bg_swatches = [
-	{
-		value: "",
-		label: __("None"),
-		style: "background: repeating-conic-gradient(#ccc 0% 25%, #fff 0% 50%) 0 0 / 10px 10px",
-	},
-	{ value: "#ffffff", label: __("White"), style: "background:#ffffff; border-color:#e5e7eb" },
-	{ value: "#EFF6FF", label: __("Blue"), style: "background:#EFF6FF" },
-	{ value: "#F0FDF4", label: __("Green"), style: "background:#F0FDF4" },
-	{ value: "#FFF7ED", label: __("Orange"), style: "background:#FFF7ED" },
-];
+function mount_bg_color_control() {
+	const host = bg_color_host.value;
+	if (!host) return;
+	host.innerHTML = "";
+	const control = frappe.ui.form.make_control({
+		parent: host,
+		df: {
+			fieldtype: "Color",
+			fieldname: "section_background",
+			placeholder: __("Transparent"),
+			change() {
+				const value = control.get_value() || "";
+				if ((selected_section.value?.background ?? "") !== value) {
+					selected_section.value.background = value;
+				}
+			},
+		},
+		render_input: true,
+		only_input: true,
+	});
+	control.set_value(selected_section.value?.background || "");
+}
+
+watch(selected_section, () => nextTick(mount_bg_color_control), { immediate: true });
+
+const rep_color_hosts = ref({});
+
+function mount_repeater_color_controls() {
+	(selected_field.value?.repeater_columns || []).forEach((col, ci) => {
+		const host = rep_color_hosts.value[ci];
+		if (!host) return;
+		host.innerHTML = "";
+		const control = frappe.ui.form.make_control({
+			parent: host,
+			df: {
+				fieldtype: "Color",
+				fieldname: `repeater_col_color_${ci}`,
+				placeholder: __("Default"),
+				change() {
+					const value = control.get_value() || "";
+					if ((col.color ?? "") !== value) {
+						col.color = value;
+					}
+				},
+			},
+			render_input: true,
+			only_input: true,
+		});
+		control.set_value(col.color || "");
+	});
+}
+
+watch(
+	() => [selected_field.value, selected_field.value?.repeater_columns?.length],
+	() => nextTick(mount_repeater_color_controls),
+	{ immediate: true }
+);
 
 function set_columns(n) {
 	if (!selected_section.value) return;
@@ -1322,32 +1352,6 @@ function toggle_field_borders(on) {
 	padding: 1px 5px;
 	white-space: nowrap;
 	flex-shrink: 0;
-}
-
-/* ── Background swatches ─────────────────────────────────── */
-.pfb-color-swatches {
-	display: flex;
-	gap: 6px;
-	flex-wrap: wrap;
-}
-
-.pfb-swatch {
-	width: 28px;
-	height: 28px;
-	border-radius: var(--radius);
-	border: 1.5px solid var(--border-color);
-	cursor: pointer;
-	padding: 0;
-	transition: transform 0.1s, border-color 0.1s;
-}
-
-.pfb-swatch:hover {
-	transform: scale(1.1);
-}
-
-.pfb-swatch.active {
-	border-color: var(--primary);
-	box-shadow: 0 0 0 2px var(--primary-light);
 }
 
 /* ── Hint ────────────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -407,6 +407,15 @@
 								:options="align_opts"
 								style="margin-top: 8px"
 							/>
+							<div class="pfb-insp-row" style="margin-top: 8px">
+								<span class="pfb-insp-label">{{ __("Style") }}</span>
+								<select class="pfb-insp-select" v-model="col.style">
+									<option value="">{{ __("Normal") }}</option>
+									<option v-for="s in merge_style_opts" :key="s.value" :value="s.value">
+										{{ s.label }}
+									</option>
+								</select>
+							</div>
 						</div>
 						<button class="pfb-add-btn" @click="add_repeater_column">
 							<span v-html="frappe.utils.icon('add', 'xs')"></span>

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -353,6 +353,10 @@
 							v-model="selected_field.label"
 							:label="__('Title')"
 							:placeholder="__('Optional heading')"
+							show-toggle
+							:show-label="__('Show title')"
+							:show="selected_field.show_label"
+							@update:show="(v) => (selected_field.show_label = v)"
 						/>
 					</div>
 				</div>
@@ -475,6 +479,17 @@
 									<option value="space-evenly">{{ __("Space Evenly") }}</option>
 								</select>
 							</div>
+							<StepperRow
+								v-if="field_is_inline"
+								:label="__('Label gap')"
+								:model-value="selected_field.label_gap"
+								:base="8"
+								:step="2"
+								unit="px"
+								:placeholder="__('auto')"
+								allow-empty
+								@update:model-value="(v) => (selected_field.label_gap = v)"
+							/>
 						</template>
 					</div>
 				</div>

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -380,12 +380,25 @@
 								<span class="pfb-insp-label">{{
 									__("Column {0}", [ci + 1])
 								}}</span>
-								<button
-									class="btn btn-xs btn-icon"
-									:title="__('Remove column')"
-									@click="remove_repeater_column(ci)"
-									v-html="frappe.utils.icon('x', 'xs')"
-								></button>
+								<div class="pfb-rep-col-head-actions">
+									<input
+										class="pfb-col-width-input"
+										type="number"
+										min="5"
+										max="100"
+										v-model.number="col.width"
+										@blur="clamp_repeater_width(col)"
+										:placeholder="__('auto')"
+										:title="__('Width %')"
+									/>
+									<span class="pfb-col-width-unit">%</span>
+									<button
+										class="btn btn-xs btn-icon"
+										:title="__('Remove column')"
+										@click="remove_repeater_column(ci)"
+										v-html="frappe.utils.icon('x', 'xs')"
+									></button>
+								</div>
 							</div>
 							<TemplateInput v-model="col.template" :fields="repeater_field_opts" />
 							<SegmentedRow
@@ -1043,6 +1056,14 @@ function clamp_width(col) {
 	col.width = Math.max(5, Math.min(100, parseInt(col.width) || 10));
 }
 
+function clamp_repeater_width(col) {
+	if (col.width === "" || col.width == null || isNaN(parseInt(col.width))) {
+		delete col.width;
+		return;
+	}
+	col.width = Math.max(5, Math.min(100, parseInt(col.width)));
+}
+
 // ── Per-column merged fields ───────────────────────────────
 // A column can merge several child fields into one cell. If one of the
 // merged fields is an image, it renders on the left (see Field.vue /
@@ -1614,5 +1635,10 @@ function toggle_field_borders(on) {
 	align-items: center;
 	justify-content: space-between;
 	margin-bottom: 6px;
+}
+.pfb-rep-col-head-actions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -1066,11 +1066,12 @@ function clamp_width(col) {
 }
 
 function clamp_repeater_width(col) {
-	if (col.width === "" || col.width == null || isNaN(parseInt(col.width))) {
+	// Repeater widths are optional — a blank value means "auto"
+	if (isNaN(parseInt(col.width))) {
 		delete col.width;
 		return;
 	}
-	col.width = Math.max(5, Math.min(100, parseInt(col.width)));
+	clamp_width(col);
 }
 
 // ── Per-column merged fields ───────────────────────────────

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -411,7 +411,11 @@
 								<span class="pfb-insp-label">{{ __("Style") }}</span>
 								<select class="pfb-insp-select" v-model="col.style">
 									<option value="">{{ __("Normal") }}</option>
-									<option v-for="s in merge_style_opts" :key="s.value" :value="s.value">
+									<option
+										v-for="s in merge_style_opts"
+										:key="s.value"
+										:value="s.value"
+									>
 										{{ s.label }}
 									</option>
 								</select>

--- a/frappe/public/js/print_format_builder/components/letterhead/LetterHeadZoneEditor.vue
+++ b/frappe/public/js/print_format_builder/components/letterhead/LetterHeadZoneEditor.vue
@@ -144,7 +144,7 @@ watch(
 onMounted(() => {
 	if (props.zone === "header" && !letterhead.value && !layout.value?.letter_head) {
 		const lh_name = frappe.boot.sysdefaults.letter_head;
-		if (lh_name) store.value.change_letterhead(lh_name);
+		if (lh_name) store.value.change_letterhead(lh_name, { keep_clean: true });
 	}
 });
 

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -133,6 +133,7 @@ export function getStore(print_format_name) {
 								"show_label",
 								"align",
 								"label_justify",
+								"label_gap",
 								"visible_if",
 							]);
 						});
@@ -158,6 +159,7 @@ export function getStore(print_format_name) {
 			"show_label",
 			"align",
 			"label_justify",
+			"label_gap",
 			"visible_if",
 		];
 		function clean_zone(zone) {

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -228,13 +228,16 @@ export function getStore(print_format_name) {
 	function get_default_layout() {
 		return create_default_layout(meta.value, print_format.value);
 	}
-	function change_letterhead(_letterhead) {
+	function change_letterhead(_letterhead, { keep_clean = false } = {}) {
 		return frappe.db.get_doc("Letter Head", _letterhead).then((doc) => {
 			letterhead.value = doc;
 			// persist the letter head name inside format_data (layout) so it
 			// survives save → reload without needing a separate doctype field
 			if (layout.value) {
 				layout.value.letter_head = _letterhead;
+				if (keep_clean) {
+					nextTick(() => (dirty.value = false));
+				}
 			}
 		});
 	}

--- a/frappe/templates/print_format/macros/Data.html
+++ b/frappe/templates/print_format/macros/Data.html
@@ -4,7 +4,7 @@
 {%- set _orientation = df.section.field_orientation or '' -%}
 {%- set _inline = (_show_label == 'inline') or (_orientation == 'left-right') -%}
 {%- set _justify = df.label_justify if df.label_justify else '' -%}
-<div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' %} field-justify-{{ _justify }}{% endif %}" {{ field_attributes(df) }}>
+<div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' %} field-justify-{{ _justify }}{% endif %}" {% if _inline and df.label_gap is not none %}style="gap: {{ df.label_gap|int }}px"{% endif %} {{ field_attributes(df) }}>
 	{%- block label -%}
 	{%- if _show_label != 'hide' -%}
 	<div class="label">{{ _(df.label) }}</div>

--- a/frappe/templates/print_format/macros/Repeater.html
+++ b/frappe/templates/print_format/macros/Repeater.html
@@ -3,6 +3,11 @@
 <div class="pfb-repeater" {{ field_attributes(df) }}>
 	{% if df.label and _show_label != 'hide' %}<div class="label">{{ _(df.label) }}</div>{% endif %}
 	<table class="pfb-repeater-table">
+		<colgroup>
+			{% for col in (df.repeater_columns or []) %}
+			<col{% if col.width %} style="width: {{ col.width|int }}%"{% endif %} />
+			{% endfor %}
+		</colgroup>
 		{% for row in doc.get(df.source) %}
 		<tr>
 			{% for col in (df.repeater_columns or []) %}

--- a/frappe/templates/print_format/macros/Repeater.html
+++ b/frappe/templates/print_format/macros/Repeater.html
@@ -11,7 +11,7 @@
 		{% for row in doc.get(df.source) %}
 		<tr>
 			{% for col in (df.repeater_columns or []) %}
-			<td class="pfb-repeater-cell" style="text-align: {{ (col.align or 'left')|e }}">
+			<td class="pfb-repeater-cell{% if col.style %} cell-line--{{ col.style|e }}{% endif %}" style="text-align: {{ (col.align or 'left')|e }}">
 				{%- for tok in (col.template or []) -%}
 					{%- if tok.t == 'f' -%}{{ row.get_formatted(tok.v) }}{%- else -%}{{ tok.v|e }}{%- endif -%}
 				{%- endfor -%}

--- a/frappe/templates/print_format/macros/Repeater.html
+++ b/frappe/templates/print_format/macros/Repeater.html
@@ -11,7 +11,9 @@
 		{% for row in doc.get(df.source) %}
 		<tr>
 			{% for col in (df.repeater_columns or []) %}
-			<td class="pfb-repeater-cell{% if col.style %} cell-line--{{ col.style|e }}{% endif %}" style="text-align: {{ (col.align or 'left')|e }}">
+			{%- set _style = col.style if col.style in ("primary", "secondary", "mono-sm", "muted-sm") else None -%}
+			{%- set _align = col.align if col.align in ("left", "center", "right") else "left" -%}
+			<td class="pfb-repeater-cell{% if _style %} cell-line--{{ _style }}{% endif %}" style="text-align: {{ _align }}">
 				{%- for tok in (col.template or []) -%}
 					{%- if tok.t == 'f' -%}{{ row.get_formatted(tok.v) }}{%- else -%}{{ tok.v|e }}{%- endif -%}
 				{%- endfor -%}

--- a/frappe/templates/print_format/macros/Repeater.html
+++ b/frappe/templates/print_format/macros/Repeater.html
@@ -1,6 +1,7 @@
+{%- set _show_label = df.show_label if df.show_label else 'show' -%}
 {% if df.source and doc.get(df.source) %}
 <div class="pfb-repeater" {{ field_attributes(df) }}>
-	{% if df.label %}<div class="label">{{ _(df.label) }}</div>{% endif %}
+	{% if df.label and _show_label != 'hide' %}<div class="label">{{ _(df.label) }}</div>{% endif %}
 	<table class="pfb-repeater-table">
 		{% for row in doc.get(df.source) %}
 		<tr>

--- a/frappe/templates/print_format/macros/Repeater.html
+++ b/frappe/templates/print_format/macros/Repeater.html
@@ -11,9 +11,9 @@
 		{% for row in doc.get(df.source) %}
 		<tr>
 			{% for col in (df.repeater_columns or []) %}
-			{%- set _style = col.style if col.style in ("primary", "secondary", "mono-sm", "muted-sm") else None -%}
 			{%- set _align = col.align if col.align in ("left", "center", "right") else "left" -%}
-			<td class="pfb-repeater-cell{% if _style %} cell-line--{{ _style }}{% endif %}" style="text-align: {{ _align }}">
+			{%- set _color = col.color if col.color and col.color|length == 7 and col.color[0] == "#" and col.color[1:]|lower|select("in", "0123456789abcdef")|list|length == 6 else None -%}
+			<td class="pfb-repeater-cell" style="text-align: {{ _align }}{% if _color %}; color: {{ _color }}{% endif %}">
 				{%- for tok in (col.template or []) -%}
 					{%- if tok.t == 'f' -%}{{ row.get_formatted(tok.v) }}{%- else -%}{{ tok.v|e }}{%- endif -%}
 				{%- endfor -%}

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -93,12 +93,12 @@ body {
 .field .label {
 	font-size: 1em;
 	font-weight: 600;
-	color: var(--pfb-label-color, #6b7280);
+	color: #6b7280;
 	margin-bottom: 0.1rem;
 }
 
 .field .value {
-	color: var(--pfb-value-color, #111827);
+	color: #111827;
 }
 
 /* Left-right (section-level): label shrinks to content width, value takes the rest */
@@ -114,7 +114,7 @@ body {
 	flex-shrink: 0;
 	font-size: 1em;
 	font-weight: 600;
-	color: var(--pfb-label-color, #374151);
+	color: #374151;
 	text-transform: none;
 	letter-spacing: 0;
 	padding-top: 0.05rem;
@@ -132,13 +132,13 @@ body {
 }
 
 {%- if print_format.label_color %}
-.print-format {
-	--pfb-label-color: {{ print_format.label_color }};
+.print-format .field .label {
+	color: {{ print_format.label_color }};
 }
 {%- endif %}
 {%- if print_format.value_color %}
-.print-format {
-	--pfb-value-color: {{ print_format.value_color }};
+.print-format .field .value {
+	color: {{ print_format.value_color }};
 }
 {%- endif %}
 

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -93,12 +93,12 @@ body {
 .field .label {
 	font-size: 1em;
 	font-weight: 600;
-	color: #6b7280;
+	color: var(--pfb-label-color, #6b7280);
 	margin-bottom: 0.1rem;
 }
 
 .field .value {
-	color: #111827;
+	color: var(--pfb-value-color, #111827);
 }
 
 /* Left-right (section-level): label shrinks to content width, value takes the rest */
@@ -114,7 +114,7 @@ body {
 	flex-shrink: 0;
 	font-size: 1em;
 	font-weight: 600;
-	color: #374151;
+	color: var(--pfb-label-color, #374151);
 	text-transform: none;
 	letter-spacing: 0;
 	padding-top: 0.05rem;
@@ -132,15 +132,13 @@ body {
 }
 
 {%- if print_format.label_color %}
-.print-format .field .label,
-.print-format .field.left-right .label,
-.print-format .field.field-inline .label {
-	color: {{ print_format.label_color }};
+.print-format {
+	--pfb-label-color: {{ print_format.label_color }};
 }
 {%- endif %}
 {%- if print_format.value_color %}
-.print-format .field .value {
-	color: {{ print_format.value_color }};
+.print-format {
+	--pfb-value-color: {{ print_format.value_color }};
 }
 {%- endif %}
 
@@ -199,23 +197,6 @@ body {
 .pfb-repeater-cell {
 	padding: 0;
 	vertical-align: top;
-}
-
-/* Repeater column styles — mirror the child-table cell-line palette */
-.pfb-repeater-cell.cell-line--primary,
-.pfb-repeater-cell.cell-line--secondary {
-	color: #111827;
-}
-.pfb-repeater-cell.cell-line--primary {
-	font-weight: 600;
-}
-.pfb-repeater-cell.cell-line--mono-sm {
-	font-family: var(--monospace-font-family, monospace);
-}
-.pfb-repeater-cell.cell-line--mono-sm,
-.pfb-repeater-cell.cell-line--muted-sm {
-	font-size: 0.9em;
-	color: #6b7280;
 }
 
 /* Child table */
@@ -347,20 +328,26 @@ body {
 }
 
 .child-table .cell-line--primary,
-.child-table .cell-line--secondary {
+.child-table .cell-line--secondary,
+.pfb-repeater-cell.cell-line--primary,
+.pfb-repeater-cell.cell-line--secondary {
 	color: #111827;
 }
 
-.child-table .cell-line--primary {
+.child-table .cell-line--primary,
+.pfb-repeater-cell.cell-line--primary {
 	font-weight: 600;
 }
 
-.child-table .cell-line--mono-sm {
+.child-table .cell-line--mono-sm,
+.pfb-repeater-cell.cell-line--mono-sm {
 	font-family: var(--monospace-font-family, monospace);
 }
 
 .child-table .cell-line--mono-sm,
-.child-table .cell-line--muted-sm {
+.child-table .cell-line--muted-sm,
+.pfb-repeater-cell.cell-line--mono-sm,
+.pfb-repeater-cell.cell-line--muted-sm {
 	font-size: 0.85em;
 	color: #6b7280;
 }

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -131,6 +131,19 @@ body {
 	min-width: 0;
 }
 
+{%- if print_format.label_color %}
+.print-format .field .label,
+.print-format .field.left-right .label,
+.print-format .field.field-inline .label {
+	color: {{ print_format.label_color }};
+}
+{%- endif %}
+{%- if print_format.value_color %}
+.print-format .field .value {
+	color: {{ print_format.value_color }};
+}
+{%- endif %}
+
 /* Field-level alignment */
 .field.field-align-center {
 	text-align: center;
@@ -186,6 +199,23 @@ body {
 .pfb-repeater-cell {
 	padding: 0;
 	vertical-align: top;
+}
+
+/* Repeater column styles — mirror the child-table cell-line palette */
+.pfb-repeater-cell.cell-line--primary,
+.pfb-repeater-cell.cell-line--secondary {
+	color: #111827;
+}
+.pfb-repeater-cell.cell-line--primary {
+	font-weight: 600;
+}
+.pfb-repeater-cell.cell-line--mono-sm {
+	font-family: var(--monospace-font-family, monospace);
+}
+.pfb-repeater-cell.cell-line--mono-sm,
+.pfb-repeater-cell.cell-line--muted-sm {
+	font-size: 0.9em;
+	color: #6b7280;
 }
 
 /* Child table */

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -91,7 +91,7 @@ body {
 
 /* Stacked (default): muted label above value */
 .field .label {
-	font-size: 0.75em;
+	font-size: 1em;
 	font-weight: 600;
 	color: #6b7280;
 	margin-bottom: 0.1rem;
@@ -112,7 +112,7 @@ body {
 .field.left-right .label,
 .field.field-inline .label {
 	flex-shrink: 0;
-	font-size: 0.8em;
+	font-size: 1em;
 	font-weight: 600;
 	color: #374151;
 	text-transform: none;

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -328,26 +328,20 @@ body {
 }
 
 .child-table .cell-line--primary,
-.child-table .cell-line--secondary,
-.pfb-repeater-cell.cell-line--primary,
-.pfb-repeater-cell.cell-line--secondary {
+.child-table .cell-line--secondary {
 	color: #111827;
 }
 
-.child-table .cell-line--primary,
-.pfb-repeater-cell.cell-line--primary {
+.child-table .cell-line--primary {
 	font-weight: 600;
 }
 
-.child-table .cell-line--mono-sm,
-.pfb-repeater-cell.cell-line--mono-sm {
+.child-table .cell-line--mono-sm {
 	font-family: var(--monospace-font-family, monospace);
 }
 
 .child-table .cell-line--mono-sm,
-.child-table .cell-line--muted-sm,
-.pfb-repeater-cell.cell-line--mono-sm,
-.pfb-repeater-cell.cell-line--muted-sm {
+.child-table .cell-line--muted-sm {
 	font-size: 0.85em;
 	color: #6b7280;
 }

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -92,7 +92,6 @@ body {
 /* Stacked (default): muted label above value */
 .field .label {
 	font-size: 1em;
-	font-weight: 600;
 	color: #6b7280;
 	margin-bottom: 0.1rem;
 }
@@ -113,7 +112,6 @@ body {
 .field.field-inline .label {
 	flex-shrink: 0;
 	font-size: 1em;
-	font-weight: 600;
 	color: #374151;
 	text-transform: none;
 	letter-spacing: 0;

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -420,8 +420,8 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			self._make_print_format(label_color="red; } * { display: none")
 
-	def test_repeater_column_unknown_style_ignored(self):
-		"""A repeater column style outside the whitelist renders no style class."""
+	def test_repeater_column_invalid_color_and_align_ignored(self):
+		"""Repeater column color/align values outside the whitelist render nothing."""
 		from frappe.utils.print_format_generator import get_html
 
 		contact = self._make_contact_with_email()
@@ -430,13 +430,13 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 				{
 					"template": [{"t": "f", "v": "email_id"}],
 					"align": "up; position:fixed",
-					"style": "primary muted-sm",
+					"color": "red; } * { display: none",
 				}
 			]
 		)
 		html = get_html("Contact", contact.name, pf.name)
-		self.assertNotIn("primary muted-sm", html)
 		self.assertNotIn("position:fixed", html)
+		self.assertNotIn("display: none", html)
 		self.assertIn('class="pfb-repeater-cell" style="text-align: left"', html)
 
 	def test_blank_table_column_header_falls_back_to_fieldname(self):
@@ -616,19 +616,19 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.assertIn("<colgroup>", html)
 		self.assertIn("width: 40%", html)
 
-	def test_repeater_column_style_rendered(self):
-		"""A repeater column style emits the matching cell-line--* class on the cell."""
+	def test_repeater_column_color_rendered(self):
+		"""A repeater column color is rendered as an inline color on the cell."""
 		from frappe.utils.print_format_generator import get_html
 
 		contact = self._make_contact_with_email()
 		pf = self._make_repeater_format(
-			columns=[{"template": [{"t": "f", "v": "email_id"}], "align": "left", "style": "primary"}]
+			columns=[{"template": [{"t": "f", "v": "email_id"}], "align": "left", "color": "#C0392B"}]
 		)
 		html = get_html("Contact", contact.name, pf.name)
-		self.assertIn('class="pfb-repeater-cell cell-line--primary"', html)
+		self.assertIn('style="text-align: left; color: #C0392B"', html)
 
-	def test_repeater_column_no_style_class_when_unset(self):
-		"""A repeater column without a style emits no cell-line--* class on the cell."""
+	def test_repeater_column_no_color_when_unset(self):
+		"""A repeater column without a color emits no inline color on the cell."""
 		from frappe.utils.print_format_generator import get_html
 
 		contact = self._make_contact_with_email()
@@ -636,7 +636,7 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 			columns=[{"template": [{"t": "f", "v": "email_id"}], "align": "left"}]
 		)
 		html = get_html("Contact", contact.name, pf.name)
-		self.assertNotIn('class="pfb-repeater-cell cell-line--', html)
+		self.assertIn('class="pfb-repeater-cell" style="text-align: left"', html)
 
 	# ------------------------------------------------------------------ #
 	# Field orientation / spacing

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -598,9 +598,7 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 
 		contact = self._make_contact_with_email()
 		pf = self._make_repeater_format(
-			columns=[
-				{"template": [{"t": "f", "v": "email_id"}], "align": "left", "style": "primary"}
-			]
+			columns=[{"template": [{"t": "f", "v": "email_id"}], "align": "left", "style": "primary"}]
 		)
 		html = get_html("Contact", contact.name, pf.name)
 		self.assertIn('class="pfb-repeater-cell cell-line--primary"', html)

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -388,34 +388,32 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 	# ------------------------------------------------------------------ #
 
 	def test_label_color_rendered_in_css(self):
-		"""A label_color set on the print format emits a scoped label color rule."""
+		"""A label_color set on the print format emits the label color CSS variable."""
 		from frappe.utils.print_format_generator import get_html
 
 		pf = self._make_print_format(label_color="#c0392b")
 		todo = self._make_todo()
 		html = get_html("ToDo", todo.name, pf.name)
-		self.assertIn(".print-format .field .label", html)
-		self.assertIn("#c0392b", html)
+		self.assertIn("--pfb-label-color: #c0392b", html)
 
 	def test_value_color_rendered_in_css(self):
-		"""A value_color set on the print format emits a scoped value color rule."""
+		"""A value_color set on the print format emits the value color CSS variable."""
 		from frappe.utils.print_format_generator import get_html
 
 		pf = self._make_print_format(value_color="#1a5fb4")
 		todo = self._make_todo()
 		html = get_html("ToDo", todo.name, pf.name)
-		self.assertIn(".print-format .field .value", html)
-		self.assertIn("#1a5fb4", html)
+		self.assertIn("--pfb-value-color: #1a5fb4", html)
 
-	def test_no_color_rule_when_colors_unset(self):
-		"""Without label/value colors, no scoped color override is emitted."""
+	def test_no_color_variable_when_colors_unset(self):
+		"""Without label/value colors, no color variable is emitted."""
 		from frappe.utils.print_format_generator import get_html
 
 		pf = self._make_print_format()
 		todo = self._make_todo()
 		html = get_html("ToDo", todo.name, pf.name)
-		self.assertNotIn(".print-format .field .label", html)
-		self.assertNotIn(".print-format .field .value", html)
+		self.assertNotIn("--pfb-label-color:", html)
+		self.assertNotIn("--pfb-value-color:", html)
 
 	def test_blank_table_column_header_falls_back_to_fieldname(self):
 		"""A child-table column with an empty label should render its fieldname as the header."""

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -388,32 +388,32 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 	# ------------------------------------------------------------------ #
 
 	def test_label_color_rendered_in_css(self):
-		"""A label_color set on the print format emits the label color CSS variable."""
+		"""A label_color set on the print format emits a label color override rule."""
 		from frappe.utils.print_format_generator import get_html
 
 		pf = self._make_print_format(label_color="#c0392b")
 		todo = self._make_todo()
 		html = get_html("ToDo", todo.name, pf.name)
-		self.assertIn("--pfb-label-color: #c0392b", html)
+		self.assertIn(".print-format .field .label {\n\tcolor: #c0392b;\n}", html)
 
 	def test_value_color_rendered_in_css(self):
-		"""A value_color set on the print format emits the value color CSS variable."""
+		"""A value_color set on the print format emits a value color override rule."""
 		from frappe.utils.print_format_generator import get_html
 
 		pf = self._make_print_format(value_color="#1a5fb4")
 		todo = self._make_todo()
 		html = get_html("ToDo", todo.name, pf.name)
-		self.assertIn("--pfb-value-color: #1a5fb4", html)
+		self.assertIn(".print-format .field .value {\n\tcolor: #1a5fb4;\n}", html)
 
-	def test_no_color_variable_when_colors_unset(self):
-		"""Without label/value colors, no color variable is emitted."""
+	def test_no_color_override_when_colors_unset(self):
+		"""Without label/value colors, no color override rule is emitted."""
 		from frappe.utils.print_format_generator import get_html
 
 		pf = self._make_print_format()
 		todo = self._make_todo()
 		html = get_html("ToDo", todo.name, pf.name)
-		self.assertNotIn("--pfb-label-color:", html)
-		self.assertNotIn("--pfb-value-color:", html)
+		self.assertNotIn(".print-format .field .label {", html)
+		self.assertNotIn(".print-format .field .value {", html)
 
 	def test_blank_table_column_header_falls_back_to_fieldname(self):
 		"""A child-table column with an empty label should render its fieldname as the header."""

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -383,6 +383,40 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.assertIn("background:red", html)
 		self.assertNotIn('"><b>PWN</b>', html)
 
+	# ------------------------------------------------------------------ #
+	# Label / value colors (Format settings)
+	# ------------------------------------------------------------------ #
+
+	def test_label_color_rendered_in_css(self):
+		"""A label_color set on the print format emits a scoped label color rule."""
+		from frappe.utils.print_format_generator import get_html
+
+		pf = self._make_print_format(label_color="#c0392b")
+		todo = self._make_todo()
+		html = get_html("ToDo", todo.name, pf.name)
+		self.assertIn(".print-format .field .label", html)
+		self.assertIn("#c0392b", html)
+
+	def test_value_color_rendered_in_css(self):
+		"""A value_color set on the print format emits a scoped value color rule."""
+		from frappe.utils.print_format_generator import get_html
+
+		pf = self._make_print_format(value_color="#1a5fb4")
+		todo = self._make_todo()
+		html = get_html("ToDo", todo.name, pf.name)
+		self.assertIn(".print-format .field .value", html)
+		self.assertIn("#1a5fb4", html)
+
+	def test_no_color_rule_when_colors_unset(self):
+		"""Without label/value colors, no scoped color override is emitted."""
+		from frappe.utils.print_format_generator import get_html
+
+		pf = self._make_print_format()
+		todo = self._make_todo()
+		html = get_html("ToDo", todo.name, pf.name)
+		self.assertNotIn(".print-format .field .label", html)
+		self.assertNotIn(".print-format .field .value", html)
+
 	def test_blank_table_column_header_falls_back_to_fieldname(self):
 		"""A child-table column with an empty label should render its fieldname as the header."""
 		import re
@@ -544,6 +578,45 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		)
 		html = get_html("Contact", contact.name, pf.name)
 		self.assertNotIn('"><b>PWN</b>', html)
+
+	def test_repeater_column_width_rendered(self):
+		"""A repeater column width emits a colgroup <col> with a width percentage."""
+		from frappe.utils.print_format_generator import get_html
+
+		contact = self._make_contact_with_email()
+		pf = self._make_repeater_format(
+			columns=[
+				{"template": [{"t": "f", "v": "email_id"}], "align": "left", "width": 40},
+				{"template": [{"t": "f", "v": "email_id"}], "align": "left"},
+			]
+		)
+		html = get_html("Contact", contact.name, pf.name)
+		self.assertIn("<colgroup>", html)
+		self.assertIn("width: 40%", html)
+
+	def test_repeater_column_style_rendered(self):
+		"""A repeater column style emits the matching cell-line--* class on the cell."""
+		from frappe.utils.print_format_generator import get_html
+
+		contact = self._make_contact_with_email()
+		pf = self._make_repeater_format(
+			columns=[
+				{"template": [{"t": "f", "v": "email_id"}], "align": "left", "style": "primary"}
+			]
+		)
+		html = get_html("Contact", contact.name, pf.name)
+		self.assertIn('class="pfb-repeater-cell cell-line--primary"', html)
+
+	def test_repeater_column_no_style_class_when_unset(self):
+		"""A repeater column without a style emits no cell-line--* class on the cell."""
+		from frappe.utils.print_format_generator import get_html
+
+		contact = self._make_contact_with_email()
+		pf = self._make_repeater_format(
+			columns=[{"template": [{"t": "f", "v": "email_id"}], "align": "left"}]
+		)
+		html = get_html("Contact", contact.name, pf.name)
+		self.assertNotIn('class="pfb-repeater-cell cell-line--', html)
 
 	# ------------------------------------------------------------------ #
 	# Field orientation / spacing

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -415,6 +415,30 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.assertNotIn(".print-format .field .label {", html)
 		self.assertNotIn(".print-format .field .value {", html)
 
+	def test_non_hex_color_rejected(self):
+		"""Colors that are not #RRGGBB hex codes are rejected on save."""
+		with self.assertRaises(frappe.ValidationError):
+			self._make_print_format(label_color="red; } * { display: none")
+
+	def test_repeater_column_unknown_style_ignored(self):
+		"""A repeater column style outside the whitelist renders no style class."""
+		from frappe.utils.print_format_generator import get_html
+
+		contact = self._make_contact_with_email()
+		pf = self._make_repeater_format(
+			columns=[
+				{
+					"template": [{"t": "f", "v": "email_id"}],
+					"align": "up; position:fixed",
+					"style": "primary muted-sm",
+				}
+			]
+		)
+		html = get_html("Contact", contact.name, pf.name)
+		self.assertNotIn("primary muted-sm", html)
+		self.assertNotIn("position:fixed", html)
+		self.assertIn('class="pfb-repeater-cell" style="text-align: left"', html)
+
 	def test_blank_table_column_header_falls_back_to_fieldname(self):
 		"""A child-table column with an empty label should render its fieldname as the header."""
 		import re


### PR DESCRIPTION
- Repeater: title show/hide toggle, per-column width and style (muted/mono/secondary/primary), like child table columns
- Fields: label/value font size unified, configurable label-value gap
- Print Format: global label and value color options (Format tab), rendered via CSS variables in print output
- Section action pill moved to top-right; hidden while a field in the section is hovered/selected to avoid overlap
- Sidebar tab bar: text-only labels, icons removed
- Server tests for color/repeater rendering, Cypress tests for new inspector controls


`no-docs`