### PR TITLE
fix(print-format-builder): exclude image field from merged cell text lines

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -514,7 +514,7 @@ function image_merge(col) {
 // Remaining fields render as stacked text lines.
 function text_merges(col) {
 	const img = image_merge(col);
-	return merged_fields(col).filter((mf) => mf !== img);
+	return merged_fields(col).filter((mf) => mf.fieldname !== img?.fieldname);
 }
 
 // Format a merged sub-field using its own child docfield definition.


### PR DESCRIPTION
- Builder canvas rendered the image column's raw URL as a text line when other fields were merged into it; filter the image field by fieldname instead of object identity
Why: `merged_fields()` builds the implicit primary line as a new object per call, so the identity check in `text_merges()` never excluded it

🤖 Generated with [Claude Code](https://claude.com/claude-code)