### PR TITLE
feat: Handling ForwardRefs and speeding up type validations

### DIFF
--- a/frappe/utils/typing_validations.py
+++ b/frappe/utils/typing_validations.py
@@ -72,7 +72,6 @@ def validate_argument_types(
 		func.__annotations__ = get_type_hints(func)  # it should handle both aka `forwardRef or str` recursively!
 		are_forwardRef_resolved = True
 	except Exception as e:
-		print(f"cannot resolved.. will try again at runtime..  {func.__annotations__}")
 		# Should only get an error, when `ForwardRef or str` annotations couldn't be resolved. `get_type_hints` handles a lot of common cases like missing annotations without throwing errors Its ok, we will try again at runtime.
 		pass
 
@@ -117,7 +116,7 @@ def validate_argument_types(
 
 		if apply_condition is None or apply_condition():
 			# setting `force_types` as False, as would have already that code in the previous block!
-			args, kwargs = transform_parameter_types(func, args, kwargs, force_types=False)
+			args, kwargs = transform_parameter_types(func, args, kwargs)
 
 		return func(*args, **kwargs)
 
@@ -174,28 +173,13 @@ def TypeAdapter(type_):
 		raise e
 
 
-def transform_parameter_types(func: Callable, args: tuple, kwargs: dict, force_types=False):
+def transform_parameter_types(func: Callable, args: tuple, kwargs: dict):
 	"""
 	Validate the types of the arguments passed to a function with the type annotations
 	defined on the function.
 	"""
 
 	annotations = func.__annotations__
-	func_params = frappe._get_cached_signature_params(func)[0]
-
-	# TODO: remove this block, as being handled before call to this routine.
-	if force_types:
-		for idx, (param_name, parameter) in enumerate(func_params.items()):
-			if idx == 0 and param_name in ("self", "cls"):
-				continue
-			if parameter.kind in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL):
-				continue
-			if param_name not in annotations:
-				module, qualname = func.__module__, func.__qualname__
-				raise FrappeTypeError(
-					f"Argument '{param_name}' in '{module}.{qualname}' is missing type annotation. "
-					f"All arguments must have type annotations when type checking is enforced."
-				)
 
 	if (
 		not (args or kwargs)
@@ -226,34 +210,14 @@ def transform_parameter_types(func: Callable, args: tuple, kwargs: dict, force_t
 
 		current_arg_value = prepared_args[current_arg]
 
-		# if the type is a ForwardRef or str, ignore it
-		# TODO: remove checks for ForwardRef, as would be resolved using `get_type_hints` before call to this routine!
-		if isinstance(current_arg_type, ForwardRefOrStr):
-			continue
-		elif any(isinstance(x, ForwardRefOrStr) for x in getattr(current_arg_type, "__args__", [])):
-			continue
 		# ignore unittest.mock objects
-		elif isinstance(current_arg_value, mock.Mock):
+		if isinstance(current_arg_value, mock.Mock):
 			continue
 
 		# allow slack for Frappe types
 		if current_arg_type in SLACK_DICT:
 			current_arg_type = SLACK_DICT[current_arg_type]
 
-		param_def = func_params.get(current_arg)
-
-		# add default value's type in acceptable types
-		# TODO: remove this block.. as we are handling this during declaration, and it is buggy!
-		if param_def.default is not _empty:
-			if isinstance(current_arg_type, tuple):
-				if type(param_def.default) not in current_arg_type:
-					current_arg_type += (type(param_def.default),)
-				current_arg_type = Union[current_arg_type]  # noqa: UP007
-
-			elif param_def.default != current_arg_type:
-				current_arg_type = Union[current_arg_type, type(param_def.default)]  # noqa: UP007
-		elif isinstance(current_arg_type, tuple):
-			current_arg_type = Union[current_arg_type]  # noqa: UP007
 
 		# validate the type set using pydantic - raise a TypeError if Validation is raised or Ellipsis is returned
 		try:

--- a/frappe/utils/typing_validations.py
+++ b/frappe/utils/typing_validations.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 from functools import lru_cache, wraps
 from inspect import _empty, isclass
 from types import EllipsisType
-from typing import ForwardRef, TypeVar, Union
+from typing import ForwardRef, TypeVar, Union, get_type_hints
 from unittest import mock
 
 from pydantic import ConfigDict, PydanticUserError
@@ -47,6 +47,16 @@ def validate_argument_types(
 			is_annotation_valid = False   # stored in closure environment, so much easier to access when wrapper would actually be called!
 			invalid_param_name = param_name
 			break
+	del annotations, func_params
+
+	# Resolving whatever forwardRefs at declaration time!
+	are_forwardRef_resolved:bool = False    # private, would be part of closure environment. (trapped)
+	try:
+		func.__annotations__ = get_type_hints(func)  # it should handle both aka `forwardRef or str` recursively!
+		are_forwardRef_resolved = True
+	except Exception as e:
+		# Should only get an error, when `ForwardRef or str` annotations couldn't be resolved. `get_type_hints` handles a lot of common cases like missing annotations without throwing errors Its ok, we will try again at runtime.
+		pass
 
 	@wraps(func)
 	def wrapper(*args, **kwargs):
@@ -55,20 +65,36 @@ def validate_argument_types(
 		:param args: Function arguments.
 		:param kwargs: Function keyword arguments."""
 
-		nonlocal force_types
-		
+		nonlocal force_types, are_forwardRef_resolved
+
 		# Resolve it only once
 		if force_types is None:
 			force_types = any(frappe.get_hooks("require_type_annotated_api_methods", app_name=app))
 
-		# NOTE: force_types value depends on `frappe` module, which have to be resolved, otherwise we could have raised "not Annotations present" error in the decorator itself during startup! 
+		# NOTE: force_types value depends on `frappe` module, which have to be resolved, otherwise we could have raised "not Annotations present" error in the decorator itself during startup!
 		if force_types and not (is_annotation_valid):
 			module, qualname = func.__module__, func.__qualname__
 			raise FrappeTypeError(
 				f"Argument '{invalid_param_name}' in '{module}.{qualname}' is missing type annotation.."
 				f"All arguments must have type annotations when type checking is enforced."
 			)
-		
+
+		if are_forwardRef_resolved:
+			# Only if error ocurred earlier this branch would be taken/necessary, meaning there are `annotations` and also `forwardRefs` which couldn't be resolved.
+			# get_type_hints, handles cases where there are no annotation for a parameter or if `cls` self like parameters, so if error occured, then it should mean `forwardRefs` failed to get resolved!
+			try:
+				func.__annotations__ = get_type_hints(func)
+			except Exception as e:
+				# We put this conditional check instead in exception block.
+				if force_types:
+					module, qualname = func.__module__, func.__qualname__
+					raise FrappeTypeError(
+						f"Couldn't resolve all ForwardRefs for function: {module}.{qualname} as {e}'"
+						f"At Runtime All ForwardRefs or ClassName (as string) must have had a Corresponding Class Declared with same name!"
+					)
+				else:
+					pass
+
 		if apply_condition is None or apply_condition():
 			# setting `force_types` as False, as would have already that code in the previous block!
 			args, kwargs = transform_parameter_types(func, args, kwargs, force_types=False)

--- a/frappe/utils/typing_validations.py
+++ b/frappe/utils/typing_validations.py
@@ -30,6 +30,24 @@ def validate_argument_types(
 ):
 	app = func.__module__.split(".")[0]
 
+	# saving annotation, func_params as soon as available to do away redundant annotations check during transform_argument_types.
+	annotations = func.__annotations__
+	func_params = inspect.signature(func).parameters # why call through another wrapper, this is what we want, would be called once for each function and that only at startup/decoration!
+
+	# Checking annotations as soon as can.(during decoration itself).
+	# would be part of closure environment. (have to do it as `force_types = any ..` code should only be used after `frappe` proper resolution.. stop making it more dynamic !!!!
+	is_annotation_valid = True
+	invalid_param_name = None
+	for idx, (param_name, parameter) in enumerate(func_params.items()):
+		if idx == 0 and param_name in ("self", "cls"):
+			continue
+		if parameter.kind in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL):
+			continue
+		if not (param_name in annotations):
+			is_annotation_valid = False   # stored in closure environment, so much easier to access when wrapper would actually be called!
+			invalid_param_name = param_name
+			break
+
 	@wraps(func)
 	def wrapper(*args, **kwargs):
 		"""Validate argument types of whitelisted functions.
@@ -38,13 +56,22 @@ def validate_argument_types(
 		:param kwargs: Function keyword arguments."""
 
 		nonlocal force_types
-
+		
 		# Resolve it only once
 		if force_types is None:
 			force_types = any(frappe.get_hooks("require_type_annotated_api_methods", app_name=app))
 
+		# NOTE: force_types value depends on `frappe` module, which have to be resolved, otherwise we could have raised "not Annotations present" error in the decorator itself during startup! 
+		if force_types and not (is_annotation_valid):
+			module, qualname = func.__module__, func.__qualname__
+			raise FrappeTypeError(
+				f"Argument '{invalid_param_name}' in '{module}.{qualname}' is missing type annotation.."
+				f"All arguments must have type annotations when type checking is enforced."
+			)
+		
 		if apply_condition is None or apply_condition():
-			args, kwargs = transform_parameter_types(func, args, kwargs, force_types)
+			# setting `force_types` as False, as would have already that code in the previous block!
+			args, kwargs = transform_parameter_types(func, args, kwargs, force_types=False)
 
 		return func(*args, **kwargs)
 

--- a/frappe/utils/typing_validations.py
+++ b/frappe/utils/typing_validations.py
@@ -55,6 +55,7 @@ def validate_argument_types(
 		func.__annotations__ = get_type_hints(func)  # it should handle both aka `forwardRef or str` recursively!
 		are_forwardRef_resolved = True
 	except Exception as e:
+		print(f"cannot resolved.. will try again at runtime..  {func.__annotations__}")
 		# Should only get an error, when `ForwardRef or str` annotations couldn't be resolved. `get_type_hints` handles a lot of common cases like missing annotations without throwing errors Its ok, we will try again at runtime.
 		pass
 
@@ -79,11 +80,12 @@ def validate_argument_types(
 				f"All arguments must have type annotations when type checking is enforced."
 			)
 
-		if are_forwardRef_resolved:
+		if not are_forwardRef_resolved:
 			# Only if error ocurred earlier this branch would be taken/necessary, meaning there are `annotations` and also `forwardRefs` which couldn't be resolved.
 			# get_type_hints, handles cases where there are no annotation for a parameter or if `cls` self like parameters, so if error occured, then it should mean `forwardRefs` failed to get resolved!
 			try:
-				func.__annotations__ = get_type_hints(func)
+				func.__annotations__ = get_type_hints(func) # don't directly assign..as make sure
+				are_forwardRef_resolved = True				# would be reflected for later calls!
 			except Exception as e:
 				# We put this conditional check instead in exception block.
 				if force_types:

--- a/frappe/utils/typing_validations.py
+++ b/frappe/utils/typing_validations.py
@@ -53,7 +53,7 @@ def validate_argument_types(
 	# Checking annotations as soon as can.(during decoration itself).
 	# would be part of closure environment. (have to do it as `force_types = any ..` code should only be used after `frappe` proper resolution.. stop making it more dynamic !!!!
 	annotations = func.__annotations__
-	is_annotation_valid = True
+	are_annotations_comprehensive = True
 	invalid_param_name = None
 	for idx, (param_name, parameter) in enumerate(func_params.items()):
 		if idx == 0 and param_name in ("self", "cls"):
@@ -61,7 +61,7 @@ def validate_argument_types(
 		if parameter.kind in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL):
 			continue
 		if not (param_name in annotations):
-			is_annotation_valid = False   # stored in closure environment, so much easier to access when wrapper would actually be called!
+			are_annotations_comprehensive = False   # stored in closure environment, so much easier to access when wrapper would actually be called!
 			invalid_param_name = param_name
 			break
 	del annotations, func_params
@@ -89,8 +89,8 @@ def validate_argument_types(
 			force_types = any(frappe.get_hooks("require_type_annotated_api_methods", app_name=app))
 
 		# NOTE: force_types value depends on `frappe` module, which have to be resolved, otherwise we could have raised "not Annotations present" error in the decorator itself during startup!
-		if force_types and not (is_annotation_valid):
-			# NOTE: is_annotation_valid is evaluated during the `declaration/decoration` (by @whitelist) and then only checked if `force_types` has been set to True. (force_types) comes from this `frappe` module itself, so we have to wait it for fully resolved to get `force_types` correct value :(
+		if force_types and not (are_annotations_comprehensive):
+			# NOTE: are_annotations_comprehensive is evaluated during the `declaration/decoration` (by @whitelist) and then only checked if `force_types` has been set to True. (force_types) comes from this `frappe` module itself, so we have to wait it for fully resolved to get `force_types` correct value :(
 			module, qualname = func.__module__, func.__qualname__
 			raise FrappeTypeError(
 				f"Argument '{invalid_param_name}' in '{module}.{qualname}' is missing type annotation.."

--- a/frappe/utils/typing_validations.py
+++ b/frappe/utils/typing_validations.py
@@ -5,6 +5,7 @@ from inspect import _empty, isclass
 from types import EllipsisType
 from typing import ForwardRef, TypeVar, Union, get_type_hints
 from unittest import mock
+from copy import deepcopy
 
 from pydantic import ConfigDict, PydanticUserError
 from pydantic import TypeAdapter as PydanticTypeAdapter
@@ -28,14 +29,30 @@ def validate_argument_types(
 	apply_condition: Callable | None = None,
 	force_types: bool | None = None,
 ):
+	# NOTE: this is evaluated/called during declaration (@whitelist) (i.e at compile time kind of) so better to do a lot of checking here!
 	app = func.__module__.split(".")[0]
 
-	# saving annotation, func_params as soon as available to do away redundant annotations check during transform_argument_types.
-	annotations = func.__annotations__
-	func_params = inspect.signature(func).parameters # why call through another wrapper, this is what we want, would be called once for each function and that only at startup/decoration!
+
+	# Evaluate default values for functions parameters. For default values we do 2 things, if only default value with no annotation, we update the `__annotations__` to reflect the type(default), if default and with annotation, we create a UNION.
+	# TODO: ideally we should prevent any default values with mismatched type, like if for float type as annotation, no int values, as this would be caught during declaration and force user to provide expected type for default value.
+	new_annotations = deepcopy(func.__annotations__)
+	func_params = inspect.signature(func).parameters
+	for (param_name, parameter) in func_params.items():
+		if not(parameter.default == inspect._empty):
+			if  param_name in new_annotations:
+				# have a default value and an annotation. Union would handle if both types are same! (a set)
+				new_annotations[param_name] = Union[new_annotations[param_name], type(parameter.default)]
+			else:
+				# have a default value but no annotation.
+				assert not(param_name in new_annotations)  # sanity check.
+				new_annotations[param_name] = type(parameter.default)
+	assert len(new_annotations) >= len(func.__annotations__)  # sanity check.
+	func.__annotations__ = new_annotations   # overwriting. (This would be reflected in `get_type_hints` as well when we later use that...)
+	del new_annotations
 
 	# Checking annotations as soon as can.(during decoration itself).
 	# would be part of closure environment. (have to do it as `force_types = any ..` code should only be used after `frappe` proper resolution.. stop making it more dynamic !!!!
+	annotations = func.__annotations__
 	is_annotation_valid = True
 	invalid_param_name = None
 	for idx, (param_name, parameter) in enumerate(func_params.items()):
@@ -74,6 +91,7 @@ def validate_argument_types(
 
 		# NOTE: force_types value depends on `frappe` module, which have to be resolved, otherwise we could have raised "not Annotations present" error in the decorator itself during startup!
 		if force_types and not (is_annotation_valid):
+			# NOTE: is_annotation_valid is evaluated during the `declaration/decoration` (by @whitelist) and then only checked if `force_types` has been set to True. (force_types) comes from this `frappe` module itself, so we have to wait it for fully resolved to get `force_types` correct value :(
 			module, qualname = func.__module__, func.__qualname__
 			raise FrappeTypeError(
 				f"Argument '{invalid_param_name}' in '{module}.{qualname}' is missing type annotation.."
@@ -84,7 +102,7 @@ def validate_argument_types(
 			# Only if error ocurred earlier this branch would be taken/necessary, meaning there are `annotations` and also `forwardRefs` which couldn't be resolved.
 			# get_type_hints, handles cases where there are no annotation for a parameter or if `cls` self like parameters, so if error occured, then it should mean `forwardRefs` failed to get resolved!
 			try:
-				func.__annotations__ = get_type_hints(func) # don't directly assign..as make sure
+				func.__annotations__ = get_type_hints(func) # No need to pass specific `globalns`, Default works expectedly otherwise we will get an error!
 				are_forwardRef_resolved = True				# would be reflected for later calls!
 			except Exception as e:
 				# We put this conditional check instead in exception block.
@@ -165,6 +183,7 @@ def transform_parameter_types(func: Callable, args: tuple, kwargs: dict, force_t
 	annotations = func.__annotations__
 	func_params = frappe._get_cached_signature_params(func)[0]
 
+	# TODO: remove this block, as being handled before call to this routine.
 	if force_types:
 		for idx, (param_name, parameter) in enumerate(func_params.items()):
 			if idx == 0 and param_name in ("self", "cls"):
@@ -208,6 +227,7 @@ def transform_parameter_types(func: Callable, args: tuple, kwargs: dict, force_t
 		current_arg_value = prepared_args[current_arg]
 
 		# if the type is a ForwardRef or str, ignore it
+		# TODO: remove checks for ForwardRef, as would be resolved using `get_type_hints` before call to this routine!
 		if isinstance(current_arg_type, ForwardRefOrStr):
 			continue
 		elif any(isinstance(x, ForwardRefOrStr) for x in getattr(current_arg_type, "__args__", [])):
@@ -223,6 +243,7 @@ def transform_parameter_types(func: Callable, args: tuple, kwargs: dict, force_t
 		param_def = func_params.get(current_arg)
 
 		# add default value's type in acceptable types
+		# TODO: remove this block.. as we are handling this during declaration, and it is buggy!
 		if param_def.default is not _empty:
 			if isinstance(current_arg_type, tuple):
 				if type(param_def.default) not in current_arg_type:


### PR DESCRIPTION
Handles Issue: #37560 

We handle/resolve ForwardRefs now using `get_type_hints`, which recursively can resolve such forward refs for containers like `List`, `dict` as well.

Example 1.
```python
import frappe

@ frappe.whitelist(force_types = True)
def test_1(data: list["Test"]):
  pass

test_1([2, 3])   # Error as Class Test wouldn't be defined yet!

class Test(object):
  pass
  
test_1([2,3])   # ForwardRef for "test" would be resolved, but Pydantic raises Error as "Annotated" Type would be different than runtime type.

test_1([Test()])  # Works.
```

Example 2.
```python
# Handling default values at declaration time.
@frappe.whitelist()
def test_2(data = 2.1):
  pass
 
# assuming a closure index 4, points to our defined function
test_2.__closure__[4].cell_contents.__annotations__   # would reflect {"data":int}

@frappe.whitelist()
def test_3(data:int = 2.1):
  pass
  
test_3.__closure__[4].cell_contents.__annotations__   # would reflect {"data": int | float}
```
