### PR TITLE
feat(print-format-builder): custom styles, font picker and editor fixes

### DIFF
--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -164,13 +164,13 @@ function on_start_blank() {
 function handle_keydown(e) {
 	// Zoom shortcuts: Ctrl+= / Ctrl+- / Ctrl+0
 	if (e.ctrlKey || e.metaKey) {
-		if (e.key === "z" || e.key === "Z") {
-			// let inputs keep their own undo
+		if (e.key === "z" || e.key === "Z" || e.key === "y") {
+			// rich text editors and dialogs keep their own undo
 			const el = document.activeElement;
-			if (el?.tagName === "INPUT" || el?.tagName === "TEXTAREA" || el?.isContentEditable)
-				return;
+			if (el?.isContentEditable || el?.closest(".modal")) return;
 			e.preventDefault();
-			$store.value.undo();
+			if (e.key === "y" || e.shiftKey) $store.value.redo();
+			else $store.value.undo();
 			return;
 		}
 		if (e.key === "=" || e.key === "+") {

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -167,7 +167,8 @@ function handle_keydown(e) {
 		if (e.key === "z" || e.key === "Z" || e.key === "y") {
 			// rich text editors and dialogs keep their own undo
 			const el = document.activeElement;
-			if (el?.isContentEditable || el?.closest(".modal")) return;
+			if (el?.tagName === "TEXTAREA" || el?.isContentEditable || el?.closest(".modal"))
+				return;
 			e.preventDefault();
 			if (e.key === "y" || e.shiftKey) $store.value.redo();
 			else $store.value.undo();

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -167,7 +167,12 @@ function handle_keydown(e) {
 		if (e.key === "z" || e.key === "Z" || e.key === "y") {
 			// rich text editors and dialogs keep their own undo
 			const el = document.activeElement;
-			if (el?.tagName === "TEXTAREA" || el?.isContentEditable || el?.closest(".modal"))
+			if (
+				el?.tagName === "INPUT" ||
+				el?.tagName === "TEXTAREA" ||
+				el?.isContentEditable ||
+				el?.closest(".modal")
+			)
 				return;
 			e.preventDefault();
 			if (e.key === "y" || e.shiftKey) $store.value.redo();

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -227,9 +227,11 @@
 			</div>
 			<div class="form-group">
 				<label class="control-label">{{ __("Google Font") }}</label>
-				<select class="form-control form-control-sm" v-model="print_format.font">
-					<option v-for="font in google_fonts" :value="font">{{ font }}</option>
-				</select>
+				<Autocomplete
+					:options="font_options"
+					:placeholder="print_format.font || __('Default')"
+					@select="(o) => (print_format.font = o.value)"
+				/>
 			</div>
 			<div class="form-group">
 				<label class="control-label">{{ __("Font Size (pt)") }}</label>
@@ -259,6 +261,7 @@
 
 <script setup>
 import draggable from "vuedraggable";
+import Autocomplete from "../../vue-components/Autocomplete.vue";
 import { get_table_columns, pluck } from "../utils";
 import { useStore } from "../stores";
 import { computed, onMounted, onUnmounted, nextTick, ref, watch, inject } from "vue";
@@ -266,6 +269,10 @@ import { computed, onMounted, onUnmounted, nextTick, ref, watch, inject } from "
 // state
 let search_text = ref("");
 let google_fonts = ref([]);
+let font_options = computed(() => [
+	{ label: __("Default"), value: "" },
+	...google_fonts.value.map((f) => ({ label: f, value: f })),
+]);
 let activeTab = ref("fields");
 let search_input = ref(null);
 let raw_templates = ref([]);
@@ -594,7 +601,7 @@ onMounted(() => {
 	let method = "frappe.printing.page.print_format_builder.print_format_builder.get_google_fonts";
 	frappe.call(method).then((r) => {
 		google_fonts.value = r.message || [];
-		if (!google_fonts.value.includes(print_format.value.font)) {
+		if (print_format.value.font && !google_fonts.value.includes(print_format.value.font)) {
 			google_fonts.value.push(print_format.value.font);
 		}
 	});

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -229,7 +229,8 @@
 				<label class="control-label">{{ __("Google Font") }}</label>
 				<Autocomplete
 					:options="font_options"
-					:placeholder="print_format.font || __('Default')"
+					:model-value="print_format.font || ''"
+					:placeholder="__('Default')"
 					@select="(o) => (print_format.font = o.value)"
 				/>
 			</div>

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -248,7 +248,7 @@
 		<template v-else>
 			<div
 				class="field-row"
-				:style="{ textAlign: df.align || 'left' }"
+				:style="{ textAlign: df.align || 'left', ...custom_style }"
 				:class="{ 'field-row--lr': field_orientation === 'left-right' }"
 			>
 				<div

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -13,7 +13,7 @@
 	>
 		<!-- ── Preview mode: show actual doc values ─────────── -->
 		<template v-if="preview_doc">
-			<div class="field-preview-wrap">
+			<div class="field-preview-wrap" :style="custom_style">
 				<!-- Handle HTML fields: render Jinja2 server-side if needed -->
 				<div
 					v-if="df.fieldtype == 'HTML' && df.html"
@@ -333,7 +333,13 @@
 
 <script setup>
 import ConfigureColumnsVue from "../inspector/ConfigureColumns.vue";
-import { render_jinja_html, sanitize_html, evaluate_visible_if, thumb_hue } from "../../utils";
+import {
+	render_jinja_html,
+	sanitize_html,
+	evaluate_visible_if,
+	thumb_hue,
+	parse_inline_style,
+} from "../../utils";
 import { createApp, ref, nextTick, watch, computed, inject } from "vue";
 
 const props = defineProps(["df", "field_orientation"]);
@@ -359,6 +365,8 @@ let editing = ref(false);
 let label_input = ref(null);
 let rendered_html = ref(null);
 let rendered_template = ref(null);
+
+let custom_style = computed(() => parse_inline_style(props.df.custom_style));
 
 let is_selected = computed(() => store.selected_field.value === props.df);
 let preview_doc = computed(() => store.preview_doc.value);

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -1060,10 +1060,14 @@ watch(
 	color: var(--text-color);
 }
 
-/* Repeater rows are tight by default — spacing is opt-in via the section */
+/* Repeater rows follow the same vertical rhythm as fields in a column */
 .field-preview-repeater .preview-table td {
 	padding: 0;
 	border: none;
+}
+
+.field-preview-repeater .preview-table tr + tr td {
+	padding-top: 0.4rem;
 }
 
 /* lined (default): no alternating rows */

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -53,7 +53,9 @@
 				</div>
 				<!-- Table field -->
 				<div v-else-if="df.fieldtype == 'Table'" class="field-preview-table">
-					<div v-if="df.label" class="field-preview-label">{{ df.label }}</div>
+					<div v-if="df.label && df.show_label !== 'hide'" class="field-preview-label">
+						{{ df.label }}
+					</div>
 					<table
 						class="preview-table"
 						:class="{

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -904,7 +904,6 @@ watch(
 
 .field--condition-hidden {
 	opacity: 0.35;
-	border: 1px dashed var(--gray-400) !important;
 	border-radius: var(--radius);
 }
 

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -459,8 +459,18 @@ function numeric_align_class(col) {
 
 function repeater_cell(col, row) {
 	return (col.template || [])
-		.map((tok) => (tok.t === "s" ? tok.v || "" : row?.[tok.v] ?? ""))
+		.map((tok) => {
+			if (tok.t === "s") return tok.v || "";
+			const child_df = repeater_child_df(tok.v);
+			return child_df ? format_cell(row || {}, child_df) : row?.[tok.v] ?? "";
+		})
 		.join("");
+}
+
+function repeater_child_df(fieldname) {
+	const source = store.meta.value?.fields?.find((f) => f.fieldname === props.df.source);
+	if (!source) return null;
+	return frappe.get_meta(source.options)?.fields?.find((f) => f.fieldname === fieldname) || null;
 }
 
 function multiselect_display(df) {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -259,11 +259,11 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 /* Hide all editor chrome */
 .pfb-clean-preview :deep(.section-toolbar),
 .pfb-clean-preview :deep(.configure-columns-btn) {
-	display: none !important;
+	display: none;
 }
 
-/* Section hover/selected states in clean-preview */
-.pfb-clean-preview :deep(.print-format-section) {
+/* Default section skin in clean-preview — grid sections style themselves */
+.pfb-clean-preview :deep(.print-format-section:not(.section--grid)) {
 	border: 1px solid transparent;
 	border-radius: var(--radius);
 	overflow: visible;
@@ -284,8 +284,8 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	margin-bottom: 0;
 }
 
-/* Field hover/selected states in clean-preview */
-.pfb-clean-preview :deep(.field--preview) {
+/* Default field skin in clean-preview — grid cells style themselves */
+.pfb-clean-preview :deep(.field--preview:not(.section--grid *)) {
 	border: 1px solid transparent;
 	background: transparent;
 	padding: 0;
@@ -293,14 +293,18 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	transition: border-color 0.1s;
 }
 
-.pfb-clean-preview :deep(.field--preview:hover) {
+.pfb-clean-preview :deep(.field--preview:hover:not(.section--grid *)) {
 	border: 1px dashed var(--gray-400);
 	background: transparent;
 }
 
-.pfb-clean-preview :deep(.field--preview.field--selected) {
+.pfb-clean-preview :deep(.field--preview.field--selected:not(.section--grid *)) {
 	border: 1px solid var(--gray-400);
 	background: transparent;
+}
+
+.pfb-clean-preview :deep(.field--preview.field--condition-hidden:not(.section--grid *)) {
+	border: 1px dashed var(--gray-400);
 }
 
 /* Section columns: no vertical padding in preview (matches PDF) */
@@ -308,9 +312,12 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	padding: 0;
 }
 
-/* Remove drag container min-height gaps */
+/* Remove drag container min-height gaps; grid sections keep their own gap */
 .pfb-clean-preview :deep(.drag-container) {
 	min-height: 0;
+}
+
+.pfb-clean-preview :deep(.drag-container:not(.section--grid *)) {
 	gap: 0.15rem;
 }
 
@@ -337,15 +344,18 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	pointer-events: none;
 }
 
-/* Section title: match PDF's .section-label look */
+/* Section title: match PDF's .section-label look; grid sections keep their own box */
 .pfb-clean-preview :deep(.section-title-display) {
 	display: block;
-	padding: 0 0 0.3rem;
-	margin-bottom: 0.4rem;
-	border-bottom: 1.5px solid var(--border-color);
 	font-size: var(--text-lg);
 	font-weight: var(--weight-bold);
 	color: var(--text-color);
+}
+
+.pfb-clean-preview :deep(.section-title-display:not(.section--grid *)) {
+	padding: 0 0 0.3rem;
+	margin-bottom: 0.4rem;
+	border-bottom: 1.5px solid var(--border-color);
 }
 
 .pfb-body :deep(.field--preview) {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -271,11 +271,13 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 .pfb-clean-preview :deep(.print-format-section:hover) {
-	border: 1px dashed var(--gray-400);
+	outline: 1px dashed var(--gray-400);
+	outline-offset: 2px;
 }
 
 .pfb-clean-preview :deep(.print-format-section.section--selected) {
-	border: 1px solid var(--gray-400);
+	outline: 1px solid var(--gray-400);
+	outline-offset: 2px;
 }
 
 .pfb-clean-preview :deep(.print-format-section-container) {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -512,18 +512,18 @@ function remove_column(index) {
 
 /* ── Table layout (field borders) ───────────────────────── */
 .section--grid {
-	border: 1px solid var(--border-color) !important;
-	border-radius: var(--border-radius-md, 8px) !important;
-	overflow: hidden !important;
-	padding: 0 !important;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md, 8px);
+	overflow: hidden;
+	padding: 0;
 }
 .section--grid.section--selected {
-	border-color: var(--gray-400) !important;
+	border-color: var(--gray-400);
 }
 .section--grid .section-title-display {
-	padding: var(--pfb-cell-pad, 8px) !important;
-	margin: 0 !important;
-	border-bottom: 1px solid var(--border-color) !important;
+	padding: var(--pfb-cell-pad, 8px);
+	margin: 0;
+	border-bottom: 1px solid var(--border-color);
 }
 .section--grid .section-columns {
 	padding: 0;
@@ -538,17 +538,17 @@ function remove_column(index) {
 	display: none;
 }
 .section--grid :deep(.drag-container) {
-	gap: 0 !important;
+	gap: 0;
 }
 .section--grid :deep(.field) {
-	padding: var(--pfb-cell-pad, 8px) !important;
-	border: none !important;
-	border-bottom: 1px solid var(--border-color) !important;
-	border-radius: 0 !important;
-	background: transparent !important;
+	padding: var(--pfb-cell-pad, 8px);
+	border: none;
+	border-bottom: 1px solid var(--border-color);
+	border-radius: 0;
+	background: transparent;
 }
 .section--grid :deep(.field:last-child) {
-	border-bottom: none !important;
+	border-bottom: none;
 }
 .section--grid :deep(.field:hover),
 .section--grid :deep(.field--selected) {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -22,7 +22,6 @@
 			class="print-format-section"
 			:class="{
 				'section--selected': is_selected,
-				'label-uppercase': section.label_case === 'uppercase',
 				'section--grid': is_grid,
 			}"
 			:style="section_inline_style"
@@ -484,30 +483,6 @@ function remove_column(index) {
 .section-preview-actions .btn-icon:hover {
 	background: var(--red-50);
 	color: var(--red-500);
-}
-
-/* ── Label case: uppercase (mirrors print_format.css rules for builder canvas) */
-
-/* section-title-display is in this same component — plain scoped selector */
-.print-format-section.label-uppercase .section-title-display {
-	text-transform: uppercase;
-	letter-spacing: 0.06em;
-}
-
-/* field-preview-* and preview-table are inside child Field.vue — need :deep() */
-.print-format-section.label-uppercase :deep(.field-preview-label) {
-	text-transform: uppercase;
-	letter-spacing: 0.04em;
-}
-
-.print-format-section.label-uppercase :deep(.field-preview-table > .field-preview-label) {
-	text-transform: uppercase;
-	letter-spacing: 0.03em;
-}
-
-.print-format-section.label-uppercase :deep(.preview-table th) {
-	text-transform: uppercase;
-	letter-spacing: 0.03em;
 }
 
 /* ── Table layout (field borders) ───────────────────────── */

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -517,6 +517,9 @@ function remove_column(index) {
 	overflow: hidden !important;
 	padding: 0 !important;
 }
+.section--grid.section--selected {
+	border-color: var(--gray-400) !important;
+}
 .section--grid .section-title-display {
 	padding: var(--pfb-cell-pad, 8px) !important;
 	margin: 0 !important;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -132,7 +132,7 @@
 import draggable from "vuedraggable";
 import Field from "./Field.vue";
 import { computed, inject } from "vue";
-import { evaluate_visible_if } from "../../utils";
+import { evaluate_visible_if, parse_inline_style } from "../../utils";
 
 const props = defineProps(["section", "is_header", "zone"]);
 
@@ -163,7 +163,7 @@ let section_inline_style = computed(() => {
 		const pad = props.section.cell_padding ?? 8;
 		style["--pfb-cell-pad"] = `${pad}px`;
 	}
-	return style;
+	return { ...style, ...parse_inline_style(props.section.custom_style) };
 });
 
 function select_section() {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -154,7 +154,7 @@ let has_visible_fields = computed(
 let section_inline_style = computed(() => {
 	const style = {};
 	if (props.section.background) style.backgroundColor = props.section.background;
-	if (props.section.padding && !is_grid.value) {
+	if (props.section.padding) {
 		const p = props.section.padding;
 		style.padding = `${p.top || 0}px ${p.right || 0}px ${p.bottom || 0}px ${p.left || 0}px`;
 	}

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -301,6 +301,21 @@
 					</div>
 				</div>
 
+				<!-- STYLE section -->
+				<div class="pfb-insp-section">
+					<div class="pfb-insp-section-head" @click="toggle('t_style')">
+						<span class="pfb-insp-section-label">{{ __("Style") }}</span>
+						<span
+							class="pfb-insp-chevron"
+							:class="{ collapsed: !open.t_style }"
+							v-html="frappe.utils.icon('chevron-down', 'xs')"
+						></span>
+					</div>
+					<div v-show="open.t_style">
+						<StyleSection v-model="selected_field.custom_style" />
+					</div>
+				</div>
+
 				<!-- VISIBILITY section -->
 				<div class="pfb-insp-section">
 					<div class="pfb-insp-section-head" @click="toggle('t_visibility')">
@@ -422,6 +437,20 @@
 					</div>
 				</div>
 
+				<div class="pfb-insp-section">
+					<div class="pfb-insp-section-head" @click="toggle('r_style')">
+						<span class="pfb-insp-section-label">{{ __("Style") }}</span>
+						<span
+							class="pfb-insp-chevron"
+							:class="{ collapsed: !open.r_style }"
+							v-html="frappe.utils.icon('chevron-down', 'xs')"
+						></span>
+					</div>
+					<div v-show="open.r_style">
+						<StyleSection v-model="selected_field.custom_style" />
+					</div>
+				</div>
+
 				<div class="pfb-insp-actions">
 					<button class="btn btn-xs btn-danger-subtle" @click="remove_field">
 						<span v-html="frappe.utils.icon('x', 'xs')"></span>
@@ -511,6 +540,20 @@
 								@update:model-value="(v) => (selected_field.label_gap = v)"
 							/>
 						</template>
+					</div>
+				</div>
+
+				<div class="pfb-insp-section">
+					<div class="pfb-insp-section-head" @click="toggle('f_style')">
+						<span class="pfb-insp-section-label">{{ __("Style") }}</span>
+						<span
+							class="pfb-insp-chevron"
+							:class="{ collapsed: !open.f_style }"
+							v-html="frappe.utils.icon('chevron-down', 'xs')"
+						></span>
+					</div>
+					<div v-show="open.f_style">
+						<StyleSection v-model="selected_field.custom_style" />
 					</div>
 				</div>
 
@@ -680,6 +723,21 @@
 					</div>
 				</div>
 
+				<!-- STYLE -->
+				<div class="pfb-insp-section">
+					<div class="pfb-insp-section-head" @click="toggle('s_style')">
+						<span class="pfb-insp-section-label">{{ __("Style") }}</span>
+						<span
+							class="pfb-insp-chevron"
+							:class="{ collapsed: !open.s_style }"
+							v-html="frappe.utils.icon('chevron-down', 'xs')"
+						></span>
+					</div>
+					<div v-show="open.s_style">
+						<StyleSection v-model="selected_section.custom_style" />
+					</div>
+				</div>
+
 				<!-- VISIBILITY -->
 				<div class="pfb-insp-section">
 					<div class="pfb-insp-section-head" @click="toggle('s_visibility')">
@@ -731,6 +789,7 @@ import { useStore } from "../../stores";
 import LetterHeadZoneInspector from "./LetterHeadZoneInspector.vue";
 import Autocomplete from "../../../vue-components/Autocomplete.vue";
 import VisibilitySection from "./VisibilitySection.vue";
+import StyleSection from "./StyleSection.vue";
 import TemplateInput from "./TemplateInput.vue";
 import LabelField from "./LabelField.vue";
 import SegmentedRow from "./SegmentedRow.vue";
@@ -749,17 +808,21 @@ let preview_doc = computed(() => store.preview_doc.value);
 
 const open = ref({
 	f_field: true,
+	f_style: false,
 	f_visibility: false,
 	s_section: true,
 	s_bg: true,
 	s_padding: true,
 	s_layout: false,
+	s_style: false,
 	s_visibility: false,
 	t_table: true,
 	t_columns: true,
+	t_style: false,
 	t_visibility: true,
 	r_repeater: true,
 	r_columns: true,
+	r_style: false,
 });
 
 function toggle(key) {

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -91,6 +91,10 @@
 							v-model="selected_field.label"
 							:label="__('Title')"
 							:placeholder="__('Table title')"
+							show-toggle
+							:show-label="__('Show title')"
+							:show="selected_field.show_label"
+							@update:show="(v) => (selected_field.show_label = v)"
 						/>
 						<!-- Style -->
 						<SegmentedRow

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -364,7 +364,8 @@
 							<span class="pfb-insp-label">{{ __("Source") }}</span>
 							<Autocomplete
 								:options="repeater_source_opts"
-								:placeholder="repeater_source_label || __('Select table…')"
+								:model-value="selected_field.source || ''"
+								:placeholder="__('Select table…')"
 								@select="(o) => (selected_field.source = o.value)"
 							/>
 						</div>
@@ -842,12 +843,6 @@ let repeater_field_opts = computed(() => {
 		.filter((f) => !frappe.model.no_value_type.includes(f.fieldtype) && f.fieldname !== "name")
 		.map((f) => ({ value: f.fieldname, label: f.label || f.fieldname }));
 });
-
-let repeater_source_label = computed(
-	() =>
-		repeater_source_opts.value.find((o) => o.value === selected_field.value?.source)?.label ||
-		""
-);
 
 function add_repeater_column() {
 	if (!selected_field.value.repeater_columns) selected_field.value.repeater_columns = [];

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -646,19 +646,6 @@
 							unit="px"
 							@update:model-value="(v) => (selected_section.gap = v)"
 						/>
-
-						<!-- Label case -->
-						<SegmentedRow
-							:label="__('Label case')"
-							:model-value="
-								section_label_case === 'uppercase' ? 'uppercase' : 'normal'
-							"
-							:options="[
-								{ value: 'normal', label: __('Normal') },
-								{ value: 'uppercase', label: __('UPPER') },
-							]"
-							@update:model-value="(v) => (selected_section.label_case = v)"
-						/>
 					</div>
 				</div>
 
@@ -1200,7 +1187,6 @@ function set_image_size(col, value) {
 // ── Section helpers ────────────────────────────────────────
 let section_orientation = computed(() => selected_section.value?.field_orientation ?? "");
 let section_gap = computed(() => selected_section.value?.gap ?? 20);
-let section_label_case = computed(() => selected_section.value?.label_case ?? "normal");
 const bg_color_host = ref(null);
 
 function mount_bg_color_control() {

--- a/frappe/public/js/print_format_builder/components/inspector/PaddingGrid.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/PaddingGrid.vue
@@ -3,7 +3,6 @@
 		<div v-for="side in sides" :key="side" class="pfb-padding-cell">
 			<div class="pfb-padding-label">{{ side_labels[side] }}</div>
 			<Stepper
-				sm
 				:value="modelValue?.[side] ?? 0"
 				@decrement="adjust(side, -step)"
 				@increment="adjust(side, step)"

--- a/frappe/public/js/print_format_builder/components/inspector/StyleSection.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/StyleSection.vue
@@ -1,0 +1,38 @@
+<template>
+	<div class="pfb-style-body">
+		<textarea
+			class="pfb-insp-input pfb-style-input"
+			rows="4"
+			spellcheck="false"
+			:placeholder="'border: 1px solid #e5e7eb;\npadding: 6px;'"
+			:value="modelValue"
+			@input="$emit('update:modelValue', $event.target.value)"
+		></textarea>
+		<p class="pfb-insp-hint text-muted">
+			{{ __("CSS declarations applied inline, e.g.") }} <code>color: #1a5fb4;</code>
+		</p>
+	</div>
+</template>
+
+<script setup>
+defineProps(["modelValue"]);
+defineEmits(["update:modelValue"]);
+</script>
+
+<style scoped>
+.pfb-style-body {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 4px 14px 12px;
+}
+
+.pfb-style-input {
+	width: 100%;
+	font-family: var(--monospace-font-family, monospace);
+	font-size: var(--text-sm);
+	line-height: 1.5;
+	resize: vertical;
+	min-height: 60px;
+}
+</style>

--- a/frappe/public/js/print_format_builder/components/inspector/TemplateInput.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/TemplateInput.vue
@@ -19,6 +19,7 @@
 					:style="i === display.length - 1 ? null : { width: tok.v.length + 'ch' }"
 					:placeholder="only_empty_text ? __('Type text…') : ''"
 					@input="commit"
+					@keydown="on_key($event, i)"
 				/>
 			</template>
 		</div>
@@ -100,6 +101,45 @@ function add_field(opt) {
 	}
 	adding.value = false;
 }
+function on_key(e, i) {
+	const inputs = [...row.value.querySelectorAll(".pfb-tpl-text")];
+	const pos = inputs.indexOf(e.target);
+	const collapsed = e.target.selectionStart === e.target.selectionEnd;
+	const at_start = collapsed && e.target.selectionStart === 0;
+	const at_end = collapsed && e.target.selectionStart === e.target.value.length;
+
+	if (e.key === "ArrowRight" && at_end && inputs[pos + 1]) {
+		e.preventDefault();
+		inputs[pos + 1].focus();
+		inputs[pos + 1].setSelectionRange(0, 0);
+	} else if (e.key === "ArrowLeft" && at_start && inputs[pos - 1]) {
+		e.preventDefault();
+		const prev = inputs[pos - 1];
+		prev.focus();
+		prev.setSelectionRange(prev.value.length, prev.value.length);
+	} else if (e.key === "Backspace" && at_start && display.value[i - 1]?.t === "f") {
+		e.preventDefault();
+		const caret = display.value[i - 2]?.v.length ?? 0;
+		remove(i - 1);
+		focus_slot(Math.max(pos - 1, 0), caret);
+	} else if (e.key === "Delete" && at_end && display.value[i + 1]?.t === "f") {
+		e.preventDefault();
+		const caret = e.target.value.length;
+		remove(i + 1);
+		focus_slot(pos, caret);
+	}
+}
+
+function focus_slot(pos, caret) {
+	nextTick(() => {
+		const input = row.value?.querySelectorAll(".pfb-tpl-text")[pos];
+		if (input) {
+			input.focus();
+			input.setSelectionRange(caret, caret);
+		}
+	});
+}
+
 function remove(i) {
 	display.value.splice(i, 1);
 	// merge text slots that became adjacent

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -52,6 +52,7 @@ export function getStore(print_format_name) {
 
 					load_lh.then(() => {
 						history = [];
+						redo_stack = [];
 						last_snap = JSON.stringify(layout.value);
 						nextTick(() => (dirty.value = false));
 						resolve();
@@ -246,23 +247,41 @@ export function getStore(print_format_name) {
 
 	// ── Undo history (Ctrl/Cmd+Z) ──────────────────────────
 	let history = [];
+	let redo_stack = [];
 	let restoring = false;
 	let last_snap = null;
-	const record_history = frappe.utils.debounce(() => {
+	function take_snapshot() {
 		const snap = JSON.stringify(layout.value);
 		if (snap === last_snap) return;
 		if (last_snap !== null) history.push(last_snap);
 		if (history.length > 50) history.shift();
 		last_snap = snap;
-	}, 400);
+		redo_stack = [];
+	}
+	const record_history = frappe.utils.debounce(take_snapshot, 400);
 
-	function undo() {
-		if (!history.length) return;
+	function restore(snap) {
 		restoring = true;
-		last_snap = history.pop();
-		layout.value = JSON.parse(last_snap);
+		last_snap = snap;
+		layout.value = JSON.parse(snap);
 		selected_field.value = null;
 		selected_section.value = null;
+	}
+
+	function undo() {
+		record_history.cancel();
+		take_snapshot();
+		if (!history.length) return;
+		redo_stack.push(last_snap);
+		restore(history.pop());
+	}
+
+	function redo() {
+		record_history.cancel();
+		take_snapshot();
+		if (!redo_stack.length) return;
+		history.push(last_snap);
+		restore(redo_stack.pop());
 	}
 
 	// watch
@@ -307,6 +326,7 @@ export function getStore(print_format_name) {
 		get_default_layout,
 		change_letterhead,
 		undo,
+		redo,
 	};
 }
 

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -135,6 +135,7 @@ export function getStore(print_format_name) {
 								"label_justify",
 								"label_gap",
 								"visible_if",
+								"custom_style",
 							]);
 						});
 					return column;
@@ -161,6 +162,7 @@ export function getStore(print_format_name) {
 			"label_justify",
 			"label_gap",
 			"visible_if",
+			"custom_style",
 		];
 		function clean_zone(zone) {
 			if (!zone || !zone.columns) return zone;

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -138,6 +138,21 @@ export function pluck(object, keys) {
 	return out;
 }
 
+// Parse "border: 1px solid; padding: 4px" into a Vue style-binding object.
+// Splits on the first ":" per declaration so values like url(http://…) survive.
+export function parse_inline_style(css) {
+	const style = {};
+	if (!css || typeof css !== "string") return style;
+	for (const decl of css.split(";")) {
+		const idx = decl.indexOf(":");
+		if (idx === -1) continue;
+		const prop = decl.slice(0, idx).trim();
+		const value = decl.slice(idx + 1).trim();
+		if (prop && value) style[prop] = value;
+	}
+	return style;
+}
+
 // Deterministic pastel colour for a merged-cell initials thumbnail, keyed off
 // the first character so the canvas and the PDF (Table.html, same formula)
 // always agree — no palette table to keep in sync across the two.

--- a/frappe/public/js/vue-components/Autocomplete.vue
+++ b/frappe/public/js/vue-components/Autocomplete.vue
@@ -4,6 +4,9 @@
   Props:
     options     Array<{ label, value, badge? }>   List of options to search through
     placeholder string                            Input placeholder (default: "Search...")
+    modelValue  string (optional)                 Single-select mode: the current value is
+                                                  shown as the input text when idle, and as
+                                                  the placeholder while searching.
 
   Events:
     @select(opt)   Fired when user picks an option. `opt` is the full option object.
@@ -33,8 +36,9 @@
 				ref="input_el"
 				class="frappe-autocomplete-input"
 				type="text"
-				:placeholder="placeholder || __('Search...')"
-				v-model="query"
+				:placeholder="(focused && display_value) || placeholder || __('Search...')"
+				:value="focused ? query : display_value || query"
+				@input="query = $event.target.value"
 				@focus="focused = true"
 				@blur="on_blur"
 				@keydown.escape="on_escape"
@@ -69,6 +73,7 @@ import { ref, computed, watch } from "vue";
 const props = defineProps({
 	options: { type: Array, default: () => [] },
 	placeholder: { type: String, default: "" },
+	modelValue: { type: String, default: null },
 });
 
 const emit = defineEmits(["select"]);
@@ -77,6 +82,12 @@ const input_el = ref(null);
 const query = ref("");
 const focused = ref(false);
 const highlight = ref(0);
+
+const display_value = computed(() => {
+	if (props.modelValue == null) return "";
+	const opt = props.options.find((o) => o.value === props.modelValue);
+	return opt ? opt.label : props.modelValue;
+});
 
 const filtered = computed(() => {
 	const q = query.value.toLowerCase();
@@ -94,7 +105,10 @@ watch(filtered, () => {
 });
 
 function on_blur() {
-	setTimeout(() => (focused.value = false), 100);
+	setTimeout(() => {
+		focused.value = false;
+		if (props.modelValue != null) query.value = "";
+	}, 100);
 }
 
 function on_escape() {

--- a/frappe/public/js/vue-components/Autocomplete.vue
+++ b/frappe/public/js/vue-components/Autocomplete.vue
@@ -10,7 +10,8 @@
 
   Events:
     @select(opt)   Fired when user picks an option. `opt` is the full option object.
-                   Input clears automatically; dropdown stays open for the next pick.
+                   Input clears automatically; dropdown stays open for the next pick
+                   in add-more mode, and closes in single-select mode.
 
   Exposes:
     focus()   Programmatically focus the input
@@ -119,6 +120,10 @@ function select(opt) {
 	emit("select", opt);
 	query.value = "";
 	highlight.value = 0;
+	if (props.modelValue != null) {
+		focused.value = false;
+		input_el.value?.blur();
+	}
 }
 
 function confirm_highlight() {

--- a/frappe/templates/print_format/macros/Data.html
+++ b/frappe/templates/print_format/macros/Data.html
@@ -4,7 +4,8 @@
 {%- set _orientation = df.section.field_orientation or '' -%}
 {%- set _inline = (_show_label == 'inline') or (_orientation == 'left-right') -%}
 {%- set _justify = df.label_justify if df.label_justify else '' -%}
-<div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' %} field-justify-{{ _justify }}{% endif %}" {% if _inline and df.label_gap is not none %}style="gap: {{ df.label_gap|int }}px"{% endif %} {{ field_attributes(df) }}>
+{%- set _fstyle = (('gap: ' + df.label_gap|int|string + 'px;') if (_inline and df.label_gap is not none) else '') + (df.custom_style or '') -%}
+<div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' %} field-justify-{{ _justify }}{% endif %}" {% if _fstyle %}style="{{ _fstyle|e }}"{% endif %} {{ field_attributes(df) }}>
 	{%- block label -%}
 	{%- if _show_label != 'hide' -%}
 	<div class="label">{{ _(df.label) }}</div>

--- a/frappe/templates/print_format/macros/Divider.html
+++ b/frappe/templates/print_format/macros/Divider.html
@@ -1,2 +1,2 @@
-<div style="height: 1px; margin: 0.5rem 0; border-bottom: 1px solid; border-bottom-color: var(--dark-border-color);">
+<div style="height: 1px; margin: 0.5rem 0; border-bottom: 1px solid; border-bottom-color: var(--dark-border-color);{{ df.custom_style|e if df.custom_style }}">
 </div>

--- a/frappe/templates/print_format/macros/FieldTemplate.html
+++ b/frappe/templates/print_format/macros/FieldTemplate.html
@@ -1,4 +1,4 @@
-<div class="field-template" {{ field_attributes(df) }}>
+<div class="field-template"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
 	{% set template = frappe.db.get_value('Print Format Field Template', df.field_template, ['template', 'template_file', 'standard'], as_dict=1) %}
 	{{ frappe.render_template(template.template_file if template.standard else template.template, {'doc': doc}) }}
 </div>

--- a/frappe/templates/print_format/macros/HTML.html
+++ b/frappe/templates/print_format/macros/HTML.html
@@ -1,3 +1,3 @@
-<div class="custom-html" {{ field_attributes(df) }}>
+<div class="custom-html"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
 	{{ frappe.render_template(df.html, {'doc': doc}) }}
 </div>

--- a/frappe/templates/print_format/macros/Repeater.html
+++ b/frappe/templates/print_format/macros/Repeater.html
@@ -1,6 +1,6 @@
 {%- set _show_label = df.show_label if df.show_label else 'show' -%}
 {% if df.source and doc.get(df.source) %}
-<div class="pfb-repeater" {{ field_attributes(df) }}>
+<div class="pfb-repeater"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
 	{% if df.label and _show_label != 'hide' %}<div class="label">{{ _(df.label) }}</div>{% endif %}
 	<table class="pfb-repeater-table">
 		<colgroup>

--- a/frappe/templates/print_format/macros/Spacer.html
+++ b/frappe/templates/print_format/macros/Spacer.html
@@ -1,2 +1,2 @@
-<div style="height: 1rem">
+<div style="height: 1rem;{{ df.custom_style|e if df.custom_style }}">
 </div>

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -8,9 +8,12 @@
 {%- set _radius = df.table_radius if df.table_radius is defined and df.table_radius is not none else none -%}
 {%- set _radius_style = ('border-radius:' + _radius|string + 'px;overflow:hidden') if _radius is not none else '' -%}
 <div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
+	{%- set _show_label = df.show_label if df.show_label else 'show' -%}
+	{% if df.label and _show_label != 'hide' %}
 	<div class="label">
 		{{ _(df.label) }}
 	</div>
+	{% endif %}
 	<table class="table{% if _bordered %} table-bordered{% endif %}"{% if _radius_style %} style="{{ _radius_style|e }}"{% endif %}>
 		{% set columns = df.table_columns %}
 		{%- if not _no_header -%}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -7,7 +7,7 @@
 {%- set _cell_style = ('padding:' + _cell_pad|string + 'px') if _cell_pad is not none else '' -%}
 {%- set _radius = df.table_radius if df.table_radius is defined and df.table_radius is not none else none -%}
 {%- set _radius_style = ('border-radius:' + _radius|string + 'px;overflow:hidden') if _radius is not none else '' -%}
-<div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}" {{ field_attributes(df) }}>
+<div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
 	<div class="label">
 		{{ _(df.label) }}
 	</div>

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -197,6 +197,10 @@ body {
 	vertical-align: top;
 }
 
+.pfb-repeater-table tr + tr .pfb-repeater-cell {
+	padding-top: 0.5rem;
+}
+
 /* Child table */
 .child-table {
 	margin-top: 0.5rem;

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -429,27 +429,6 @@ header img {
 	width: 1rem;
 }
 
-/* ── Label case: uppercase (opt-in per section) ──────────── */
-.label-uppercase .section-label {
-	text-transform: uppercase;
-	letter-spacing: 0.04em;
-}
-
-.label-uppercase .field .label {
-	text-transform: uppercase;
-	letter-spacing: 0.03em;
-}
-
-.label-uppercase .child-table > .label {
-	text-transform: uppercase;
-	letter-spacing: 0.03em;
-}
-
-.label-uppercase .child-table .table th {
-	text-transform: uppercase;
-	letter-spacing: 0.03em;
-}
-
 /* ── Table layout (field-borders mode) ───────────────────── */
 .section--grid {
 	border: 1px solid #e5e7eb;

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -50,8 +50,12 @@
 	{%- set ns = namespace(has_content=false) -%}
 	{%- for column in section.columns -%}
 		{%- for df in column.fields -%}
-			{%- if df.fieldtype in ('HTML', 'Divider', 'Spacer') -%}
+			{%- if df.fieldtype in ('HTML', 'Divider', 'Spacer', 'Field Template') -%}
 				{%- set ns.has_content = true -%}
+			{%- elif df.fieldtype == 'Repeater' -%}
+				{%- if df.source and doc.get(df.source) -%}
+					{%- set ns.has_content = true -%}
+				{%- endif -%}
 			{%- elif doc.get(df.fieldname) -%}
 				{%- set ns.has_content = true -%}
 			{%- endif -%}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -70,6 +70,9 @@
 		{%- set _cp = (section.cell_padding if section.cell_padding is defined and section.cell_padding is not none else 8) -%}
 		{%- set ns3.section_style = ns3.section_style + '--pfb-cell-pad:' + _cp|string + 'px;' -%}
 	{%- endif -%}
+	{%- if section.custom_style -%}
+		{%- set ns3.section_style = ns3.section_style + section.custom_style|string -%}
+	{%- endif -%}
 	<div class="section {{ resolve_class({'page-break': section.page_break}) }} {{ 'label-uppercase' if section.label_case == 'uppercase' else '' }}{{ ' section--grid' if section.field_borders else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style|e }}"{% endif %}>
 		{% if section.label and section.show_label != 'hide' %}
 		<div class="section-label">{{ _(section.label) }}</div>

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -66,7 +66,7 @@
 	{%- if section.background -%}
 		{%- set ns3.section_style = ns3.section_style + 'background:' + section.background + ';' -%}
 	{%- endif -%}
-	{%- if section.padding and not section.field_borders -%}
+	{%- if section.padding -%}
 		{%- set p = section.padding -%}
 		{%- set ns3.section_style = ns3.section_style + 'padding:' + (p.top or 0)|string + 'px ' + (p.right or 0)|string + 'px ' + (p.bottom or 0)|string + 'px ' + (p.left or 0)|string + 'px;' -%}
 	{%- endif -%}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -32,7 +32,7 @@
 	{%- for col in layout.header.columns -%}{%- for df in col.get('fields', []) -%}{%- set ns_h.has_fields = true -%}{%- endfor -%}{%- endfor -%}
 	{%- if ns_h.has_fields -%}
 	{%- set col_gap = (layout.header.gap if layout.header.gap is defined and layout.header.gap != None else 20)|string + 'px' -%}
-	<div class="section document-header-content {{ 'label-uppercase' if layout.header.label_case == 'uppercase' else '' }}">
+	<div class="section document-header-content">
 	<div class="section-columns row" style="gap:{{ col_gap }}">
 	{%- for column in layout.header.columns %}
 	<div class="column col">
@@ -77,7 +77,7 @@
 	{%- if section.custom_style -%}
 		{%- set ns3.section_style = ns3.section_style + section.custom_style|string -%}
 	{%- endif -%}
-	<div class="section {{ resolve_class({'page-break': section.page_break}) }} {{ 'label-uppercase' if section.label_case == 'uppercase' else '' }}{{ ' section--grid' if section.field_borders else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style|e }}"{% endif %}>
+	<div class="section {{ resolve_class({'page-break': section.page_break}) }}{{ ' section--grid' if section.field_borders else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style|e }}"{% endif %}>
 		{% if section.label and section.show_label != 'hide' %}
 		<div class="section-label">{{ _(section.label) }}</div>
 		{% endif %}
@@ -117,7 +117,7 @@
 	{%- for col in layout.footer.columns -%}{%- for df in col.get('fields', []) -%}{%- set ns_f.has_fields = true -%}{%- endfor -%}{%- endfor -%}
 	{%- if ns_f.has_fields -%}
 	{%- set col_gap_f = (layout.footer.gap if layout.footer.gap is defined and layout.footer.gap != None else 20)|string + 'px' -%}
-	<div class="section document-footer-content {{ 'label-uppercase' if layout.footer.label_case == 'uppercase' else '' }}">
+	<div class="section document-footer-content">
 	<div class="section-columns row" style="gap:{{ col_gap_f }}">
 	{%- for column in layout.footer.columns %}
 	<div class="column col">

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -225,8 +225,7 @@ class PrintFormatGenerator:
 {%- for col in section.columns -%}{%- for df in col.get('fields', []) -%}{%- set ns.has_fields = true -%}{%- endfor -%}{%- endfor -%}
 {%- if ns.has_fields -%}
 {%- set col_gap = (section.gap if section.gap is defined and section.gap is not none else 20)|string + 'px' -%}
-{%- set _lc = 'label-uppercase' if section.get('label_case') == 'uppercase' else '' -%}
-<div class="section {{ _lc }} section-columns row" style="gap:{{ col_gap }}">
+<div class="section section-columns row" style="gap:{{ col_gap }}">
 {%- for column in section.columns %}
 <div class="column col">
 {%- for df in column.get('fields', []) -%}

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -459,6 +459,109 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.assertIn("border:1px", html)
 		self.assertNotIn('"><b>PWN</b>', html)
 
+	def test_block_custom_style_in_html(self):
+		"""custom_style renders on HTML, Spacer and Divider block roots."""
+		from frappe.utils.print_format_generator import get_html
+
+		pf = self._make_print_format(
+			format_data=json.dumps(
+				{
+					"sections": [
+						{
+							"label": "Blocks",
+							"columns": [
+								{
+									"fields": [
+										{
+											"fieldtype": "HTML",
+											"fieldname": "_html1",
+											"html": "<p>hello</p>",
+											"custom_style": "margin-top: 11px",
+										},
+										{
+											"fieldtype": "Spacer",
+											"fieldname": "_spacer1",
+											"custom_style": "height: 33px",
+										},
+										{
+											"fieldtype": "Divider",
+											"fieldname": "_divider1",
+											"custom_style": "border-bottom-color: #123456",
+										},
+									]
+								}
+							],
+						}
+					],
+					"header": {"columns": [{"label": "", "fields": []}]},
+					"footer": {"columns": [{"label": "", "fields": []}]},
+				}
+			)
+		)
+		todo = self._make_todo()
+		html = get_html("ToDo", todo.name, pf.name)
+		self.assertIn("margin-top: 11px", html)
+		self.assertIn("height: 1rem;height: 33px", html)
+		self.assertIn("border-bottom-color: #123456", html)
+
+	def test_table_custom_style_in_html(self):
+		"""custom_style on a child table renders on the child-table wrapper."""
+		from frappe.utils.print_format_generator import get_html
+
+		contact = self._make_contact_with_email()
+		pf = frappe.get_doc(
+			{
+				"doctype": "Print Format",
+				"name": f"_Test PFG Contact {frappe.generate_hash(length=6)}",
+				"doc_type": "Contact",
+				"print_format_builder_beta": 1,
+				"custom_format": 0,
+				"standard": "No",
+				"format_data": json.dumps(
+					{
+						"sections": [
+							{
+								"label": "Emails",
+								"columns": [
+									{
+										"fields": [
+											{
+												"fieldtype": "Table",
+												"fieldname": "email_ids",
+												"label": "Emails",
+												"custom_style": "margin-top: 27px",
+												"table_columns": [
+													{"fieldname": "email_id", "label": "Email", "width": 100}
+												],
+											}
+										]
+									}
+								],
+							}
+						],
+						"header": {"columns": [{"label": "", "fields": []}]},
+						"footer": {"columns": [{"label": "", "fields": []}]},
+					}
+				),
+			}
+		)
+		pf.insert(ignore_permissions=True)
+		self.addCleanup(pf.delete, ignore_permissions=True)
+		html = get_html("Contact", contact.name, pf.name)
+		self.assertIn('style="margin-top: 27px"', html)
+
+	def test_repeater_custom_style_in_html(self):
+		"""custom_style on a repeater renders on the pfb-repeater wrapper."""
+		from frappe.utils.print_format_generator import get_html
+
+		contact = self._make_contact_with_email()
+		pf = self._make_repeater_format(
+			columns=[{"template": [{"t": "f", "v": "email_id"}], "align": "left"}],
+			custom_style="padding: 13px",
+		)
+		html = get_html("Contact", contact.name, pf.name)
+		self.assertIn('style="padding: 13px"', html)
+
 	# ------------------------------------------------------------------ #
 	# Label / value colors (Format settings)
 	# ------------------------------------------------------------------ #
@@ -588,13 +691,16 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.addCleanup(contact.delete, ignore_permissions=True)
 		return contact
 
-	def _make_repeater_format(self, label="", columns=None, omit_repeater_columns=False):
+	def _make_repeater_format(
+		self, label="", columns=None, omit_repeater_columns=False, section_label="", **field_extra
+	):
 		name = f"_Test PFG Rep {frappe.generate_hash(length=6)}"
 		repeater_field = {
 			"fieldtype": "Repeater",
 			"fieldname": "rep1",
 			"label": label,
 			"source": "email_ids",
+			**field_extra,
 		}
 		if not omit_repeater_columns:
 			repeater_field["repeater_columns"] = columns or []
@@ -610,7 +716,7 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 					{
 						"sections": [
 							{
-								"label": "",
+								"label": section_label,
 								"columns": [{"fields": [repeater_field]}],
 							}
 						],
@@ -623,6 +729,32 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		pf.insert(ignore_permissions=True)
 		self.addCleanup(pf.delete, ignore_permissions=True)
 		return pf
+
+	def test_labeled_section_with_only_repeater_renders(self):
+		"""A labeled section whose only field is a repeater must not be skipped as empty."""
+		from frappe.utils.print_format_generator import get_html
+
+		contact = self._make_contact_with_email()
+		pf = self._make_repeater_format(
+			columns=[{"template": [{"t": "f", "v": "email_id"}], "align": "left"}],
+			section_label="Emails Section",
+		)
+		html = get_html("Contact", contact.name, pf.name)
+		self.assertIn("Emails Section", html)
+		self.assertIn('<div class="pfb-repeater"', html)
+
+	def test_labeled_section_with_empty_repeater_hidden(self):
+		"""A labeled section stays hidden when its only repeater has no source rows."""
+		from frappe.utils.print_format_generator import get_html
+
+		contact = self._make_contact_with_email()
+		pf = self._make_repeater_format(
+			columns=[{"template": [{"t": "f", "v": "number"}], "align": "left"}],
+			section_label="Phones Section",
+			source="phone_nos",
+		)
+		html = get_html("Contact", contact.name, pf.name)
+		self.assertNotIn("Phones Section", html)
 
 	def test_repeater_renders_templated_rows(self):
 		"""A repeater renders each child row via its column token templates."""

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -413,127 +413,54 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 			}
 		)
 
-	def test_field_custom_style_in_html(self):
-		"""custom_style on a field should render as an inline style on the field wrapper."""
+	def test_custom_style_in_html(self):
+		"""custom_style renders as an inline style on every component root."""
 		from frappe.utils.print_format_generator import get_html
 
-		pf = self._make_print_format(
-			format_data=self._custom_style_format_data(field_style="border: 1px solid #123456; padding: 6px")
-		)
 		todo = self._make_todo()
-		html = get_html("ToDo", todo.name, pf.name)
-		self.assertIn("border: 1px solid #123456; padding: 6px", html)
 
-	def test_section_custom_style_in_html(self):
-		"""custom_style on a section should render as an inline style on the section wrapper."""
-		from frappe.utils.print_format_generator import get_html
-
-		pf = self._make_print_format(
-			format_data=self._custom_style_format_data(section_style="border-radius: 9px")
-		)
-		todo = self._make_todo()
-		html = get_html("ToDo", todo.name, pf.name)
-		self.assertIn("border-radius: 9px", html)
-
-	def test_field_custom_style_is_escaped(self):
-		"""A crafted custom_style must not break out of the style attribute."""
-		from frappe.utils.print_format_generator import get_html
-
-		pf = self._make_print_format(
-			format_data=self._custom_style_format_data(field_style='color:red;"><b>PWN</b>')
-		)
-		todo = self._make_todo()
-		html = get_html("ToDo", todo.name, pf.name)
-		self.assertIn("color:red", html)
-		self.assertNotIn('"><b>PWN</b>', html)
-
-	def test_section_custom_style_is_escaped(self):
-		"""A crafted section custom_style must not break out of the style attribute."""
-		from frappe.utils.print_format_generator import get_html
-
-		pf = self._make_print_format(
-			format_data=self._custom_style_format_data(section_style='border:1px;"><b>PWN</b>')
-		)
-		todo = self._make_todo()
-		html = get_html("ToDo", todo.name, pf.name)
-		self.assertIn("border:1px", html)
-		self.assertNotIn('"><b>PWN</b>', html)
-
-	def test_block_custom_style_in_html(self):
-		"""custom_style renders on HTML, Spacer and Divider block roots."""
-		from frappe.utils.print_format_generator import get_html
-
-		pf = self._make_print_format(
-			format_data=json.dumps(
-				{
-					"sections": [
-						{
-							"label": "Blocks",
-							"columns": [
-								{
-									"fields": [
-										{
-											"fieldtype": "HTML",
-											"fieldname": "_html1",
-											"html": "<p>hello</p>",
-											"custom_style": "margin-top: 11px",
-										},
-										{
-											"fieldtype": "Spacer",
-											"fieldname": "_spacer1",
-											"custom_style": "height: 33px",
-										},
-										{
-											"fieldtype": "Divider",
-											"fieldname": "_divider1",
-											"custom_style": "border-bottom-color: #123456",
-										},
-									]
-								}
-							],
-						}
-					],
-					"header": {"columns": [{"label": "", "fields": []}]},
-					"footer": {"columns": [{"label": "", "fields": []}]},
-				}
+		with self.subTest("field"):
+			pf = self._make_print_format(
+				format_data=self._custom_style_format_data(
+					field_style="border: 1px solid #123456; padding: 6px"
+				)
 			)
-		)
-		todo = self._make_todo()
-		html = get_html("ToDo", todo.name, pf.name)
-		self.assertIn("margin-top: 11px", html)
-		self.assertIn("height: 1rem;height: 33px", html)
-		self.assertIn("border-bottom-color: #123456", html)
+			html = get_html("ToDo", todo.name, pf.name)
+			self.assertIn("border: 1px solid #123456; padding: 6px", html)
 
-	def test_table_custom_style_in_html(self):
-		"""custom_style on a child table renders on the child-table wrapper."""
-		from frappe.utils.print_format_generator import get_html
+		with self.subTest("section"):
+			pf = self._make_print_format(
+				format_data=self._custom_style_format_data(section_style="border-radius: 9px")
+			)
+			html = get_html("ToDo", todo.name, pf.name)
+			self.assertIn("border-radius: 9px", html)
 
-		contact = self._make_contact_with_email()
-		pf = frappe.get_doc(
-			{
-				"doctype": "Print Format",
-				"name": f"_Test PFG Contact {frappe.generate_hash(length=6)}",
-				"doc_type": "Contact",
-				"print_format_builder_beta": 1,
-				"custom_format": 0,
-				"standard": "No",
-				"format_data": json.dumps(
+		with self.subTest("blocks"):
+			pf = self._make_print_format(
+				format_data=json.dumps(
 					{
 						"sections": [
 							{
-								"label": "Emails",
+								"label": "Blocks",
 								"columns": [
 									{
 										"fields": [
 											{
-												"fieldtype": "Table",
-												"fieldname": "email_ids",
-												"label": "Emails",
-												"custom_style": "margin-top: 27px",
-												"table_columns": [
-													{"fieldname": "email_id", "label": "Email", "width": 100}
-												],
-											}
+												"fieldtype": "HTML",
+												"fieldname": "_html1",
+												"html": "<p>hello</p>",
+												"custom_style": "margin-top: 11px",
+											},
+											{
+												"fieldtype": "Spacer",
+												"fieldname": "_spacer1",
+												"custom_style": "height: 33px",
+											},
+											{
+												"fieldtype": "Divider",
+												"fieldname": "_divider1",
+												"custom_style": "border-bottom-color: #123456",
+											},
 										]
 									}
 								],
@@ -542,25 +469,90 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 						"header": {"columns": [{"label": "", "fields": []}]},
 						"footer": {"columns": [{"label": "", "fields": []}]},
 					}
-				),
-			}
-		)
-		pf.insert(ignore_permissions=True)
-		self.addCleanup(pf.delete, ignore_permissions=True)
-		html = get_html("Contact", contact.name, pf.name)
-		self.assertIn('style="margin-top: 27px"', html)
-
-	def test_repeater_custom_style_in_html(self):
-		"""custom_style on a repeater renders on the pfb-repeater wrapper."""
-		from frappe.utils.print_format_generator import get_html
+				)
+			)
+			html = get_html("ToDo", todo.name, pf.name)
+			self.assertIn("margin-top: 11px", html)
+			self.assertIn("height: 1rem;height: 33px", html)
+			self.assertIn("border-bottom-color: #123456", html)
 
 		contact = self._make_contact_with_email()
-		pf = self._make_repeater_format(
-			columns=[{"template": [{"t": "f", "v": "email_id"}], "align": "left"}],
-			custom_style="padding: 13px",
-		)
-		html = get_html("Contact", contact.name, pf.name)
-		self.assertIn('style="padding: 13px"', html)
+
+		with self.subTest("table"):
+			pf = frappe.get_doc(
+				{
+					"doctype": "Print Format",
+					"name": f"_Test PFG Contact {frappe.generate_hash(length=6)}",
+					"doc_type": "Contact",
+					"print_format_builder_beta": 1,
+					"custom_format": 0,
+					"standard": "No",
+					"format_data": json.dumps(
+						{
+							"sections": [
+								{
+									"label": "Emails",
+									"columns": [
+										{
+											"fields": [
+												{
+													"fieldtype": "Table",
+													"fieldname": "email_ids",
+													"label": "Emails",
+													"custom_style": "margin-top: 27px",
+													"table_columns": [
+														{
+															"fieldname": "email_id",
+															"label": "Email",
+															"width": 100,
+														}
+													],
+												}
+											]
+										}
+									],
+								}
+							],
+							"header": {"columns": [{"label": "", "fields": []}]},
+							"footer": {"columns": [{"label": "", "fields": []}]},
+						}
+					),
+				}
+			)
+			pf.insert(ignore_permissions=True)
+			self.addCleanup(pf.delete, ignore_permissions=True)
+			html = get_html("Contact", contact.name, pf.name)
+			self.assertIn('style="margin-top: 27px"', html)
+
+		with self.subTest("repeater"):
+			pf = self._make_repeater_format(
+				columns=[{"template": [{"t": "f", "v": "email_id"}], "align": "left"}],
+				custom_style="padding: 13px",
+			)
+			html = get_html("Contact", contact.name, pf.name)
+			self.assertIn('style="padding: 13px"', html)
+
+	def test_custom_style_is_escaped(self):
+		"""A crafted custom_style must not break out of the style attribute."""
+		from frappe.utils.print_format_generator import get_html
+
+		todo = self._make_todo()
+
+		with self.subTest("field"):
+			pf = self._make_print_format(
+				format_data=self._custom_style_format_data(field_style='color:red;"><b>PWN</b>')
+			)
+			html = get_html("ToDo", todo.name, pf.name)
+			self.assertIn("color:red", html)
+			self.assertNotIn('"><b>PWN</b>', html)
+
+		with self.subTest("section"):
+			pf = self._make_print_format(
+				format_data=self._custom_style_format_data(section_style='border:1px;"><b>PWN</b>')
+			)
+			html = get_html("ToDo", todo.name, pf.name)
+			self.assertIn("border:1px", html)
+			self.assertNotIn('"><b>PWN</b>', html)
 
 	# ------------------------------------------------------------------ #
 	# Label / value colors (Format settings)
@@ -730,31 +722,30 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.addCleanup(pf.delete, ignore_permissions=True)
 		return pf
 
-	def test_labeled_section_with_only_repeater_renders(self):
-		"""A labeled section whose only field is a repeater must not be skipped as empty."""
+	def test_labeled_section_with_only_repeater(self):
+		"""A labeled section whose only field is a repeater renders when the source
+		has rows and stays hidden when it does not."""
 		from frappe.utils.print_format_generator import get_html
 
 		contact = self._make_contact_with_email()
-		pf = self._make_repeater_format(
-			columns=[{"template": [{"t": "f", "v": "email_id"}], "align": "left"}],
-			section_label="Emails Section",
-		)
-		html = get_html("Contact", contact.name, pf.name)
-		self.assertIn("Emails Section", html)
-		self.assertIn('<div class="pfb-repeater"', html)
 
-	def test_labeled_section_with_empty_repeater_hidden(self):
-		"""A labeled section stays hidden when its only repeater has no source rows."""
-		from frappe.utils.print_format_generator import get_html
+		with self.subTest("renders when source has rows"):
+			pf = self._make_repeater_format(
+				columns=[{"template": [{"t": "f", "v": "email_id"}], "align": "left"}],
+				section_label="Emails Section",
+			)
+			html = get_html("Contact", contact.name, pf.name)
+			self.assertIn("Emails Section", html)
+			self.assertIn('<div class="pfb-repeater"', html)
 
-		contact = self._make_contact_with_email()
-		pf = self._make_repeater_format(
-			columns=[{"template": [{"t": "f", "v": "number"}], "align": "left"}],
-			section_label="Phones Section",
-			source="phone_nos",
-		)
-		html = get_html("Contact", contact.name, pf.name)
-		self.assertNotIn("Phones Section", html)
+		with self.subTest("hidden when source is empty"):
+			pf = self._make_repeater_format(
+				columns=[{"template": [{"t": "f", "v": "number"}], "align": "left"}],
+				section_label="Phones Section",
+				source="phone_nos",
+			)
+			html = get_html("Contact", contact.name, pf.name)
+			self.assertNotIn("Phones Section", html)
 
 	def test_repeater_renders_templated_rows(self):
 		"""A repeater renders each child row via its column token templates."""

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -447,6 +447,18 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.assertIn("color:red", html)
 		self.assertNotIn('"><b>PWN</b>', html)
 
+	def test_section_custom_style_is_escaped(self):
+		"""A crafted section custom_style must not break out of the style attribute."""
+		from frappe.utils.print_format_generator import get_html
+
+		pf = self._make_print_format(
+			format_data=self._custom_style_format_data(section_style='border:1px;"><b>PWN</b>')
+		)
+		todo = self._make_todo()
+		html = get_html("ToDo", todo.name, pf.name)
+		self.assertIn("border:1px", html)
+		self.assertNotIn('"><b>PWN</b>', html)
+
 	# ------------------------------------------------------------------ #
 	# Label / value colors (Format settings)
 	# ------------------------------------------------------------------ #

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -384,6 +384,70 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.assertNotIn('"><b>PWN</b>', html)
 
 	# ------------------------------------------------------------------ #
+	# Custom style (per-component inline CSS)
+	# ------------------------------------------------------------------ #
+
+	def _custom_style_format_data(self, field_style=None, section_style=None):
+		section = {
+			"label": "Styled",
+			"columns": [
+				{
+					"fields": [
+						{
+							"fieldtype": "Data",
+							"fieldname": "description",
+							"label": "Description",
+							**({"custom_style": field_style} if field_style else {}),
+						}
+					]
+				}
+			],
+		}
+		if section_style:
+			section["custom_style"] = section_style
+		return json.dumps(
+			{
+				"sections": [section],
+				"header": {"columns": [{"label": "", "fields": []}]},
+				"footer": {"columns": [{"label": "", "fields": []}]},
+			}
+		)
+
+	def test_field_custom_style_in_html(self):
+		"""custom_style on a field should render as an inline style on the field wrapper."""
+		from frappe.utils.print_format_generator import get_html
+
+		pf = self._make_print_format(
+			format_data=self._custom_style_format_data(field_style="border: 1px solid #123456; padding: 6px")
+		)
+		todo = self._make_todo()
+		html = get_html("ToDo", todo.name, pf.name)
+		self.assertIn("border: 1px solid #123456; padding: 6px", html)
+
+	def test_section_custom_style_in_html(self):
+		"""custom_style on a section should render as an inline style on the section wrapper."""
+		from frappe.utils.print_format_generator import get_html
+
+		pf = self._make_print_format(
+			format_data=self._custom_style_format_data(section_style="border-radius: 9px")
+		)
+		todo = self._make_todo()
+		html = get_html("ToDo", todo.name, pf.name)
+		self.assertIn("border-radius: 9px", html)
+
+	def test_field_custom_style_is_escaped(self):
+		"""A crafted custom_style must not break out of the style attribute."""
+		from frappe.utils.print_format_generator import get_html
+
+		pf = self._make_print_format(
+			format_data=self._custom_style_format_data(field_style='color:red;"><b>PWN</b>')
+		)
+		todo = self._make_todo()
+		html = get_html("ToDo", todo.name, pf.name)
+		self.assertIn("color:red", html)
+		self.assertNotIn('"><b>PWN</b>', html)
+
+	# ------------------------------------------------------------------ #
 	# Label / value colors (Format settings)
 	# ------------------------------------------------------------------ #
 


### PR DESCRIPTION
- Collapsible Style group in the inspector for sections, fields, child tables, repeaters and blocks — raw CSS declarations applied inline in both the builder canvas and rendered print output, attribute-escaped server-side, persisted as `custom_style`
- Searchable font picker with a default option
- Show/hide toggle for child table titles
- Undo/redo: Cmd/Ctrl+Z / Shift+Z / Y shortcuts on the canvas; native text undo preserved while typing in inputs and textareas
- Section hover/selected indicators work on grid (field-borders) sections; all CSS `!important` overrides removed in favor of proper cascade scoping
- Keyboard navigation across template field chips; repeater row spacing and cell value formatting match regular fields
- Removed the per-section label case option

Why: one-off tweaks (borders, spacing, colors) shouldn't require a custom HTML format



`no-docs`