### PR TITLE
fix: dashboard chart crashes when filters_json is a dict

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -123,7 +123,7 @@ def get(
 
 	timegrain = time_interval or chart.time_interval
 	filters = frappe.parse_json(filters) or frappe.parse_json(chart.filters_json)
-	if not filters:
+	if not isinstance(filters, list):
 		filters = []
 
 	# don't include cancelled documents

--- a/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
@@ -110,6 +110,25 @@ class TestDashboardChart(IntegrationTestCase):
 			self.assertEqual(result.get("labels")[idx], get_period(month))
 			cur_date += relativedelta(months=1)
 
+	def test_dashboard_chart_with_dict_filters_json(self):
+		if frappe.db.exists("Dashboard Chart", "Test Dict Filters Dashboard Chart"):
+			frappe.delete_doc("Dashboard Chart", "Test Dict Filters Dashboard Chart")
+
+		frappe.get_doc(
+			doctype="Dashboard Chart",
+			chart_name="Test Dict Filters Dashboard Chart",
+			chart_type="Count",
+			document_type="Error Log",
+			based_on="creation",
+			timespan="Last Year",
+			time_interval="Monthly",
+			filters_json='{"charts_based_on": "Status"}',
+			timeseries=1,
+		).insert()
+
+		result = get(chart_name="Test Dict Filters Dashboard Chart", refresh=1)
+		self.assertIn("labels", result)
+
 	def test_chart_wih_one_value(self):
 		if frappe.db.exists("Dashboard Chart", "Test Empty Dashboard Chart 2"):
 			frappe.delete_doc("Dashboard Chart", "Test Empty Dashboard Chart 2")


### PR DESCRIPTION
## What this fixes

Report-type Dashboard Charts could fail to load when `filters_json` contained a JSON object instead of a list (e.g. `{"charts_based_on": "Status"}` from a bad import).

The existing check only validated truthiness, allowing a `frappe._dict` to reach `filters.append(...)`, which resulted in a `TypeError`.

## Fix

Validate that `filters` is a list before appending to it:

```python
if not isinstance(filters, list):
    filters = []
```

This preserves the existing behavior for `None`/empty values while safely handling malformed dictionary-based filters.
