### PR TITLE
fix: preserve collapsible section state on form refresh

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -386,7 +386,15 @@ frappe.ui.form.Layout = class Layout {
 	}
 
 	refresh(doc) {
+		const prev_docname = this.doc?.name;
 		if (doc) this.doc = doc;
+
+		// Reset user-toggled state when switching to a different document so
+		// sections start collapsed (their default) instead of inheriting the
+		// open/closed state left over from the previous document.
+		if (this.doc?.name && this.doc.name !== prev_docname) {
+			this.sections.forEach((s) => (s.user_toggled = false));
+		}
 
 		if (this.frm) {
 			this.wrapper.find(".empty-form-alert").remove();

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -528,6 +528,15 @@ frappe.ui.form.Layout = class Layout {
 
 				if (df.collapsible_depends_on) {
 					collapse = !this.evaluate_depends_on_value(df.collapsible_depends_on);
+				} else if (section.user_toggled) {
+					// User manually toggled the section; preserve their choice
+					collapse = section.is_collapsed();
+				} else if (df.css_class) {
+					// No in-session toggle yet; respect state persisted in localStorage
+					const stored = localStorage.getItem(df.css_class + "-closed");
+					if (stored !== null) {
+						collapse = stored === "1";
+					}
 				}
 
 				if (collapse && section.has_missing_mandatory()) {

--- a/frappe/public/js/frappe/form/section.js
+++ b/frappe/public/js/frappe/form/section.js
@@ -76,10 +76,12 @@ export default class Section {
 			this.head.addClass("collapsible");
 			// show / hide based on status
 			this.collapse_link = this.head.on("click", () => {
+				this.user_toggled = true;
 				this.collapse();
 			});
 			const me = this;
 			this.collapse_link.enterKey(function () {
+				me.user_toggled = true;
 				me.collapse();
 			});
 			this.set_icon();


### PR DESCRIPTION
## Problem

When editing fields inside a collapsible section (e.g. **Additional Discount** in Sales Invoice, Sales Order, Quotation), any field value change triggers a form refresh which calls `refresh_section_collapse`. For sections without `collapsible_depends_on`, this always defaulted `collapse = true`, re-collapsing the section mid-edit.

## Fix

- **`section.js`** – set `user_toggled = true` when the user explicitly clicks (or uses keyboard) to expand/collapse a section.
- **`layout.js / refresh_section_collapse`** – when there's no `collapsible_depends_on`, preserve the user's in-session toggle state (`user_toggled`). For sections with a `css_class`, also respect the localStorage-persisted state so the section stays open after a soft page reload.

Sections without user interaction still collapse by default on initial render.

Fixes the issue for all DocTypes with a collapsible Additional Discount section (Sales Invoice, Sales Order, Quotation) and any other collapsible section without `collapsible_depends_on`.