### PR TITLE
fix: make controls not have mandatory error border on web forms

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -270,9 +270,14 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		// do not set has-error class on form load
 		if (this.frm && this.frm.cscript && this.frm.cscript.is_onload) return;
 
-		// do not set has-error class while dialog is rendered
-		// set has-error if dialog primary button is clicked
-		if (this.layout && this.layout.is_dialog && !this.layout.primary_action_fulfilled) return;
+		// do not set has-error class while a dialog or web form is rendered
+		// set has-error only once the primary action (submit) has been attempted
+		if (
+			this.layout &&
+			(this.layout.is_dialog || this.layout.doctype === "Web Form") &&
+			!this.layout.primary_action_fulfilled
+		)
+			return;
 
 		const is_invalid = this.$wrapper.hasClass("has-error-invalid");
 		this.$wrapper.toggleClass("has-error-mandatory", Boolean(this.df.reqd && is_null(value)));

--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -155,7 +155,7 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 				if (!is_null(v)) ret[f.df.fieldname] = v;
 			}
 
-			if (this.is_dialog && f.df.reqd && !f.value) {
+			if ((this.is_dialog || this.doctype === "Web Form") && f.df.reqd && !f.value) {
 				f.refresh_input();
 			}
 

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -218,6 +218,9 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	validate_section() {
 		if (this.allow_incomplete) return true;
 
+		// submit attempted: allow mandatory fields to show the error highlight
+		this.primary_action_fulfilled = true;
+
 		let fields = $(`${this.get_page(this.current_section)} .form-control`);
 		let errors = [];
 		let invalid_values = [];
@@ -235,8 +238,10 @@ export default class WebForm extends frappe.ui.FieldGroup {
 				if (
 					field.df.reqd &&
 					is_null(typeof value === "string" ? strip_html(value) : value)
-				)
+				) {
 					errors.push(__(field.df.label));
+					field.refresh_input();
+				}
 
 				if (
 					field.df.reqd &&
@@ -381,6 +386,8 @@ export default class WebForm extends frappe.ui.FieldGroup {
 
 	save() {
 		let is_new = this.is_new;
+		// submit attempted: allow mandatory fields to show the error highlight
+		this.primary_action_fulfilled = true;
 		let valid = this.validate && this.validate();
 		if (!valid && valid !== undefined) {
 			frappe.msgprint(


### PR DESCRIPTION
Before

<img width="1025" height="814" alt="Screenshot 2026-07-03 at 5 01 41 PM" src="https://github.com/user-attachments/assets/a5d668d2-ad8b-4d33-bf71-ca2f480e9ec1" />

After

<img width="1113" height="809" alt="Screenshot 2026-07-03 at 5 00 33 PM" src="https://github.com/user-attachments/assets/df356093-8980-424c-b981-46c71594802a" />
