### PR TITLE
fix: Always set `frappe.request`

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -180,15 +180,15 @@ def run_after_request_hooks(request, response):
 
 def init_request(request):
 	site = _site or request.headers.get("X-Frappe-Site-Name") or get_site_name(request.host)
-	frappe.init(site, sites_path=_sites_path, force=True, is_request=True)
+	try:
+		frappe.init(site, sites_path=_sites_path, force=True, is_request=True)
+	finally:
+		frappe.local.request = request
+		request.after_response = CallbackManager()
 
-	frappe.local.request = request
-	frappe.local.is_ajax = frappe.get_request_header("X-Requested-With") == "XMLHttpRequest"
-	request.after_response = CallbackManager()
+	assert frappe.local.conf and frappe.local.conf.db_name, "config should be loaded"
 
-	if not (frappe.local.conf and frappe.local.conf.db_name):
-		# site does not exist
-		raise NotFound
+	frappe.local.is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
 
 	frappe.connect(set_admin_as_user=False)
 	if frappe.local.conf.maintenance_mode:


### PR DESCRIPTION
related to https://github.com/frappe/frappe/pull/40388

Because of how request was always set before init, a failed init now
causes frappe.request to remain unset.

This change just mimics same semantics so that previous behaviour
continues to work.

`NotFound` check was removed because `init` is supposed to cause
exception if site doesn't exist. Converted to assertion.
