### PR TITLE
feat(ui): standard helper to render buttons

### DIFF
--- a/frappe/public/css/espresso/components/button.css
+++ b/frappe/public/css/espresso/components/button.css
@@ -14,7 +14,7 @@
  *   data-size      xs | sm | md | lg                         (default: sm)
  *   data-theme     gray | red                                (default: gray)
  *   data-icon-button="true"   square, no inline padding
- *   data-loading              blocks interaction without the disabled dimming
+ *   aria-busy="true"          loading: blocks interaction without the disabled dimming
  *   aria-invalid="true"       red focus ring + red border (matches Raven)
  *
  * DEFAULTS live on the base `.es-button` rule (variant=subtle, size=sm,
@@ -214,12 +214,13 @@
     background: transparent;
 }
 
-/* ---- loading: block interaction without the disabled dimming ---- */
-.es-button[data-loading] {
+/* ---- loading: block interaction without the disabled dimming. Styled off
+       aria-busy so the visual and accessibility states cannot drift. ---- */
+.es-button[aria-busy="true"] {
     pointer-events: none;
 }
 
-.es-button:not([data-loading]) .es-button__spinner {
+.es-button:not([aria-busy="true"]) .es-button__spinner {
     display: none;
 }
 

--- a/frappe/public/css/espresso/components/button.css
+++ b/frappe/public/css/espresso/components/button.css
@@ -220,30 +220,23 @@
     pointer-events: none;
 }
 
-.es-button:not([aria-busy="true"]) .es-button__spinner {
+.es-button:not([aria-busy="true"]) > .es-spinner,
+.es-button:not([aria-busy="true"]) > .es-button__loading-label {
     display: none;
 }
 
-/* ---- icons + spinner: size follows the button size ---- */
-.es-button>svg {
+/* while busy, a loading label replaces the normal label + icon */
+.es-button[aria-busy="true"]:has(> .es-button__loading-label) > .es-button__label,
+.es-button[aria-busy="true"]:has(> .es-button__loading-label) > svg {
+    display: none;
+}
+
+/* ---- icons + spinner (painted by components/spinner.css): size follows
+       the button size ---- */
+.es-button > svg,
+.es-button > .es-spinner {
     pointer-events: none;
     flex-shrink: 0;
     width: var(--es-bt-icon);
     height: var(--es-bt-icon);
-}
-
-.es-button__spinner {
-    flex-shrink: 0;
-    width: var(--es-bt-icon);
-    height: var(--es-bt-icon);
-    border-radius: 9999px;
-    border: 2px solid currentColor;
-    border-top-color: transparent;
-    animation: es-button-spin 600ms linear infinite;
-}
-
-@keyframes es-button-spin {
-    to {
-        transform: rotate(360deg);
-    }
 }

--- a/frappe/public/css/espresso/components/spinner.css
+++ b/frappe/public/css/espresso/components/spinner.css
@@ -1,0 +1,125 @@
+/* Espresso Spinner — comet-arc loading indicator.
+ *
+ * Pure CSS on an empty element used as a paint surface (span, svg, div).
+ * Color comes from currentColor; size from the consumer (a width/height
+ * class, inline style, or a parent component like .es-button) over the
+ * 16px default below. Ring thickness and inset stay proportional via
+ * %-based defaults.
+ *
+ * Attributes (optional):
+ *   data-track="true"   faint full-circle track behind the arc
+ *
+ * Standalone use should add role="status" and an aria-label; inside
+ * aria-busy components (e.g. .es-button) keep it aria-hidden instead.
+ *
+ * Baseline: Chrome 111+, Safari 16.4+, Firefox 128+ (@property, trig
+ * functions in calc, color-mix). */
+
+/* Registered so the angle interpolates in animation. The animation spins
+   the GRADIENT angle, not the element: rotating the element rasterizes
+   the circle once and any sub-device-pixel offset in that raster orbits
+   visibly (wobble at 16px/18px on 2x displays). With a static element the
+   circle is re-painted antialiased around a fixed center every frame —
+   wobble is geometrically impossible. */
+@property --es-spinner-angle {
+    syntax: "<angle>";
+    inherits: false;
+    initial-value: 0deg;
+}
+
+.es-spinner {
+    display: inline-block;
+    flex-shrink: 0;
+    /* default box; any width/height from the consumer overrides */
+    width: 16px;
+    height: 16px;
+
+    /* Two rulers, one thickness: a percentage resolves against the paint
+       radius in the mask gradient but against the paint box in the cap
+       gradient, so the mask value is 2× the cap value. Anchored to the md
+       spec: 16px box − 2×1.2px inset = 13.6px paint box; 2px ring =
+       14.7% of 13.6px = 29.4% of the 6.8px radius. */
+    --es-spinner-thickness: 14.7%;
+    --es-spinner-mask-thickness: 29.4%;
+    --es-spinner-inset: 7.5%;
+    --es-spinner-paint-size: calc(100% - 2 * var(--es-spinner-inset));
+    --es-spinner-track-color: transparent;
+
+    /* the spinning comet arc over an optional faint track —
+       layer 1: a round dot capping the solid head (rounded end); it orbits
+                the arc centerline radius (50% − t/2) at the animated angle
+       layer 2: a conic gradient fading from transparent (gap + tail) to
+                solid, rotated by the same animated angle
+       layer 3: a full circle, transparent unless data-track is set */
+    background-image:
+        radial-gradient(
+            calc(var(--es-spinner-thickness) / 2)
+                calc(var(--es-spinner-thickness) / 2) at
+                calc(
+                    50% + (50% - var(--es-spinner-thickness) / 2) *
+                        sin(var(--es-spinner-angle))
+                )
+                calc(
+                    50% - (50% - var(--es-spinner-thickness) / 2) *
+                        cos(var(--es-spinner-angle))
+                ),
+            currentColor 92%,
+            transparent
+        ),
+        conic-gradient(
+            from var(--es-spinner-angle),
+            transparent 32%,
+            currentColor 92%,
+            currentColor 100%
+        ),
+        linear-gradient(
+            var(--es-spinner-track-color),
+            var(--es-spinner-track-color)
+        );
+    background-size: var(--es-spinner-paint-size) var(--es-spinner-paint-size);
+    background-position: center;
+    background-repeat: no-repeat;
+
+    /* clip everything painted above into a ring of the configured thickness.
+       The outer transparent stop bounds the ring circle (the corners of the
+       square mask image sit beyond `farthest-side` and would show otherwise);
+       the half-pixel fade is for antialiasing. */
+    -webkit-mask: radial-gradient(
+            farthest-side,
+            transparent calc(100% - var(--es-spinner-mask-thickness)),
+            #000 calc(100% - var(--es-spinner-mask-thickness)),
+            #000 calc(100% - 0.5px),
+            transparent 100%
+        )
+        center / var(--es-spinner-paint-size) var(--es-spinner-paint-size)
+        no-repeat;
+    mask: radial-gradient(
+            farthest-side,
+            transparent calc(100% - var(--es-spinner-mask-thickness)),
+            #000 calc(100% - var(--es-spinner-mask-thickness)),
+            #000 calc(100% - 0.5px),
+            transparent 100%
+        )
+        center / var(--es-spinner-paint-size) var(--es-spinner-paint-size)
+        no-repeat;
+
+    /* spins the gradient angle — the element itself never moves */
+    animation: es-spinner-rotate 0.7s linear infinite;
+}
+
+/* faint full-circle track behind the arc */
+.es-spinner[data-track="true"] {
+    --es-spinner-track-color: color-mix(in srgb, currentColor 15%, transparent);
+}
+
+@keyframes es-spinner-rotate {
+    to {
+        --es-spinner-angle: 360deg;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .es-spinner {
+        animation-duration: 1.6s;
+    }
+}

--- a/frappe/public/js/desk.bundle.js
+++ b/frappe/public/js/desk.bundle.js
@@ -7,6 +7,7 @@ import "./frappe/format.js";
 import "./frappe/form/formatters.js";
 import "./frappe/dom.js";
 import "./frappe/ui/messages.js";
+import "./frappe/ui/components/button.js";
 import "./frappe/ui/background_tasks/background_tasks.js";
 import "./frappe/ui/keyboard.js";
 import "./frappe/ui/colors.js";

--- a/frappe/public/js/frappe/form/doctype_settings/list_panel.js
+++ b/frappe/public/js/frappe/form/doctype_settings/list_panel.js
@@ -276,8 +276,8 @@ class ListPanel {
 		$('<div class="text-muted small"></div>')
 			.text(__("Could not load this tab."))
 			.appendTo($err);
-		$(`<button type="button" class="es-button" data-size="xs">${__("Retry")}</button>`)
-			.appendTo($err)
-			.on("click", () => this.load());
+		frappe.ui
+			.button({ label: __("Retry"), size: "xs", onclick: () => this.load() })
+			.appendTo($err);
 	}
 }

--- a/frappe/public/js/frappe/form/doctype_settings/registry.js
+++ b/frappe/public/js/frappe/form/doctype_settings/registry.js
@@ -38,11 +38,20 @@ frappe.doctype_settings.overflow_menu = function (items) {
 	if (!items.length) return $cell;
 
 	const $wrap = $('<div class="dropdown dts-actions"></div>').appendTo($cell);
-	$(
-		`<button type="button" class="es-button dts-actions-btn" data-size="xs" data-variant="ghost" data-icon-button="true" data-toggle="dropdown" aria-haspopup="menu" aria-expanded="false" aria-label="${__(
-			"More actions"
-		)}"><span aria-hidden="true">⋯</span></button>`
-	).appendTo($wrap);
+	frappe.ui
+		.button({
+			icon: "ellipsis",
+			size: "xs",
+			variant: "ghost",
+			title: __("More actions"),
+			css_class: "dts-actions-btn",
+			attrs: {
+				"data-toggle": "dropdown",
+				"aria-haspopup": "menu",
+				"aria-expanded": "false",
+			},
+		})
+		.appendTo($wrap);
 	const $menu = $('<div class="dropdown-menu dropdown-menu-right" role="menu"></div>').appendTo(
 		$wrap
 	);
@@ -79,10 +88,13 @@ frappe.doctype_settings.empty_state = function ($container, opts) {
 		$('<div class="dts-empty-description"></div>').text(opts.description).appendTo($empty);
 	}
 	if (opts.action) {
-		$(`<button type="button" class="es-button dts-empty-action" data-size="sm"></button>`)
-			.text(opts.action.label)
-			.appendTo($empty)
-			.on("click", () => opts.action.onclick());
+		frappe.ui
+			.button({
+				label: opts.action.label,
+				css_class: "dts-empty-action",
+				onclick: () => opts.action.onclick(),
+			})
+			.appendTo($empty);
 	}
 	return $empty;
 };
@@ -90,9 +102,7 @@ frappe.doctype_settings.empty_state = function ($container, opts) {
 frappe.doctype_settings.render_error = function (panel, retry_fn) {
 	const $err = panel.body.empty();
 	$('<div class="text-muted small"></div>').text(__("Could not load this tab.")).appendTo($err);
-	$(`<button type="button" class="es-button" data-size="xs">${__("Retry")}</button>`)
-		.appendTo($err)
-		.on("click", () => retry_fn());
+	frappe.ui.button({ label: __("Retry"), size: "xs", onclick: () => retry_fn() }).appendTo($err);
 };
 
 // Shared helper: write a DocType-level Property Setter (same mechanism Customize Form uses).

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
@@ -47,10 +47,12 @@ function make_section($parent, { title, description, add_label, on_add }, list_o
 	list.refresh();
 
 	if (add_label) {
-		$(`<button type="button" class="es-button" data-size="sm" data-variant="subtle"></button>`)
-			.append(frappe.utils.icon("plus", "sm"))
-			.append($("<span></span>").text(add_label))
-			.on("click", () => on_add(() => list.refresh()))
+		frappe.ui
+			.button({
+				label: add_label,
+				icon: "plus",
+				onclick: () => on_add(() => list.refresh()),
+			})
 			.appendTo($header.find(".settings-dialog-panel-actions"));
 	}
 	return list;

--- a/frappe/public/js/frappe/ui/components/button.js
+++ b/frappe/public/js/frappe/ui/components/button.js
@@ -3,6 +3,7 @@ frappe.provide("frappe.ui");
 /**
  * @typedef {Object} ButtonOpts
  * @property {string} [label] Button text (pre-translated). HTML-escaped.
+ * @property {string} [loading_label] Text shown while busy. Defaults for common labels (Save → Saving..., Delete → Deleting..., Submit → Submitting...); pass "" to opt out.
  * @property {"solid"|"subtle"|"outline"|"ghost"} [variant="subtle"]
  * @property {"xs"|"sm"|"md"|"lg"} [size="sm"]
  * @property {"gray"|"red"} [theme="gray"]
@@ -19,6 +20,17 @@ frappe.provide("frappe.ui");
 const VARIANTS = ["solid", "subtle", "outline", "ghost"];
 const SIZES = ["xs", "sm", "md", "lg"];
 const THEMES = ["gray", "red"];
+
+function default_loading_label(label) {
+	if (!label) return null;
+	// keyed by translated label so it matches whenever the caller used __()
+	const map = {
+		[__("Save")]: __("Saving..."),
+		[__("Delete")]: __("Deleting..."),
+		[__("Submit")]: __("Submitting..."),
+	};
+	return map[label] || null;
+}
 
 function validated(value, allowed, option) {
 	if (value == null) return null;
@@ -79,9 +91,18 @@ function button_html(opts = {}) {
 	// currentColor keeps the stroke in sync with the button's text color
 	const icon = opts.icon ? frappe.utils.icon(opts.icon, "sm", "", "", "", true) : "";
 	const label = opts.label ? `<span class="es-button__label">${escape(opts.label)}</span>` : "";
+	const loading_label_text =
+		"loading_label" in opts ? opts.loading_label : default_loading_label(opts.label);
+	// aria-live: best-effort announcement of the busy text when it appears;
+	// screen readers do not reliably announce a focused button's name change
+	const loading_label = loading_label_text
+		? `<span class="es-button__loading-label" aria-live="polite">${escape(
+				loading_label_text
+		  )}</span>`
+		: "";
 
 	return `<button class="${classes}" ${attrs.join(" ")}>
-		<span class="es-button__spinner" aria-hidden="true"></span>${icon}${label}
+		<span class="es-spinner" aria-hidden="true"></span>${loading_label}${icon}${label}
 	</button>`;
 }
 
@@ -98,6 +119,9 @@ frappe.ui.button = function (opts = {}) {
 	const $btn = $(button_html(opts));
 	if (opts.onclick) {
 		$btn.on("click", function (e) {
+			// pointer-events:none only blocks the mouse — keyboard activation
+			// (Enter/Space) still fires, so guard re-entry while busy
+			if ($btn.attr("aria-busy") === "true") return;
 			const result = opts.onclick.call(this, e);
 			if (result && typeof result.then === "function") {
 				$btn.attr("aria-busy", "true");

--- a/frappe/public/js/frappe/ui/components/button.js
+++ b/frappe/public/js/frappe/ui/components/button.js
@@ -57,10 +57,12 @@ function button_html(opts = {}) {
 		if (icon_only) attrs.push(`aria-label="${escape(opts.title)}"`);
 	}
 	for (const [key, value] of Object.entries(opts.attrs || {})) {
-		// on* values execute as JS after HTML entity decoding, so escaping
-		// cannot protect user data in them — bind handlers via onclick instead
-		if (/^on/i.test(key)) {
-			console.warn(`frappe.ui.button: refusing event-handler attribute "${key}"`);
+		// attribute names become markup (computed keys can carry user data,
+		// e.g. fieldnames), so enforce a safe charset; refuse on* handlers —
+		// their values execute as JS after HTML entity decoding, so escaping
+		// cannot protect user data in them. Bind handlers via onclick instead.
+		if (!/^[a-zA-Z][\w.:-]*$/.test(key) || /^on/i.test(key)) {
+			console.warn(`frappe.ui.button: refusing unsafe attribute "${key}"`);
 			continue;
 		}
 		attrs.push(value === true ? key : `${key}="${escape(value)}"`);

--- a/frappe/public/js/frappe/ui/components/button.js
+++ b/frappe/public/js/frappe/ui/components/button.js
@@ -1,0 +1,123 @@
+frappe.provide("frappe.ui");
+
+/**
+ * @typedef {Object} ButtonOpts
+ * @property {string} [label] Button text (pre-translated). HTML-escaped.
+ * @property {"solid"|"subtle"|"outline"|"ghost"} [variant="subtle"]
+ * @property {"xs"|"sm"|"md"|"lg"} [size="sm"]
+ * @property {"gray"|"red"} [theme="gray"]
+ * @property {string} [icon] Lucide icon name. Icon without label renders a square icon-button — pass `title`.
+ * @property {string} [title] Tooltip; doubles as aria-label on icon-only buttons.
+ * @property {boolean} [disabled]
+ * @property {boolean} [loading] Shows spinner, blocks clicks, sets aria-busy.
+ * @property {"button"|"submit"|"reset"} [type="button"]
+ * @property {string} [css_class] Extra CSS classes.
+ * @property {Object<string, string|true>} [attrs] Extra attributes, e.g. { "data-toggle": "dropdown" }.
+ * @property {function} [onclick] Click handler (element form only). Return a promise to show the busy state until it settles.
+ */
+
+const VARIANTS = ["solid", "subtle", "outline", "ghost"];
+const SIZES = ["xs", "sm", "md", "lg"];
+const THEMES = ["gray", "red"];
+
+function validated(value, allowed, option) {
+	if (value == null) return null;
+	if (!allowed.includes(value)) {
+		console.warn(
+			`frappe.ui.button: unknown ${option} "${value}" — expected ${allowed.join(" | ")}`
+		);
+		return null;
+	}
+	return value;
+}
+
+/**
+ * Espresso button (`.es-button`) as a markup string, for template literals.
+ * @param {ButtonOpts} [opts]
+ * @returns {string}
+ * @example `<div>${frappe.ui.button.html({ label: __("Load More") })}</div>`
+ */
+function button_html(opts = {}) {
+	const escape = frappe.utils.escape_html;
+	const variant = validated(opts.variant, VARIANTS, "variant");
+	const size = validated(opts.size, SIZES, "size");
+	const theme = validated(opts.theme, THEMES, "theme");
+	const icon_only = Boolean(opts.icon && !opts.label);
+
+	const attrs = [`type="${escape(opts.type || "button")}"`];
+	// omit attributes that equal the CSS defaults (subtle / sm / gray)
+	if (variant && variant !== "subtle") attrs.push(`data-variant="${variant}"`);
+	if (size && size !== "sm") attrs.push(`data-size="${size}"`);
+	if (theme && theme !== "gray") attrs.push(`data-theme="${theme}"`);
+	if (icon_only) attrs.push('data-icon-button="true"');
+	if (opts.loading) attrs.push('aria-busy="true"');
+	if (opts.disabled) attrs.push("disabled");
+	if (opts.title) {
+		attrs.push(`title="${escape(opts.title)}"`);
+		if (icon_only) attrs.push(`aria-label="${escape(opts.title)}"`);
+	}
+	for (const [key, value] of Object.entries(opts.attrs || {})) {
+		// on* values execute as JS after HTML entity decoding, so escaping
+		// cannot protect user data in them — bind handlers via onclick instead
+		if (/^on/i.test(key)) {
+			console.warn(`frappe.ui.button: refusing event-handler attribute "${key}"`);
+			continue;
+		}
+		attrs.push(value === true ? key : `${key}="${escape(value)}"`);
+	}
+
+	if (icon_only && !opts.title && !(opts.attrs || {})["aria-label"]) {
+		console.warn(
+			`frappe.ui.button: icon-only button ("${opts.icon}") needs a title for accessibility`
+		);
+	}
+
+	const classes = escape(["es-button", opts.css_class].filter(Boolean).join(" "));
+	// .es-button > svg in button.css sizes the icon to the button;
+	// currentColor keeps the stroke in sync with the button's text color
+	const icon = opts.icon ? frappe.utils.icon(opts.icon, "sm", "", "", "", true) : "";
+	const label = opts.label ? `<span class="es-button__label">${escape(opts.label)}</span>` : "";
+
+	return `<button class="${classes}" ${attrs.join(" ")}>
+		<span class="es-button__spinner" aria-hidden="true"></span>${icon}${label}
+	</button>`;
+}
+
+/**
+ * Espresso button (`.es-button`) as a wired jQuery element.
+ * If `onclick` returns a promise, the button is busy (aria-busy, spinner,
+ * clicks blocked) until it settles. Use `frappe.ui.button.html(opts)` for
+ * the markup-string form.
+ * @param {ButtonOpts} [opts]
+ * @returns {JQuery} button element, with `opts.onclick` bound
+ * @example frappe.ui.button({ label: __("Save"), variant: "solid", onclick: () => frm.save() });
+ */
+frappe.ui.button = function (opts = {}) {
+	const $btn = $(button_html(opts));
+	if (opts.onclick) {
+		$btn.on("click", function (e) {
+			const result = opts.onclick.call(this, e);
+			if (result && typeof result.then === "function") {
+				$btn.attr("aria-busy", "true");
+				result.then(
+					() => $btn.removeAttr("aria-busy"),
+					(err) => {
+						$btn.removeAttr("aria-busy");
+						// observing the promise marks its rejection as handled, which
+						// would hide handler bugs. Re-report in developer mode only:
+						// in production, API-level failures already surface through
+						// frappe.call's own error dialogs.
+						if (frappe.boot?.developer_mode) {
+							console.error("frappe.ui.button: onclick rejected", err);
+						}
+					}
+				);
+			}
+		});
+	}
+	return $btn;
+};
+
+frappe.ui.button.html = button_html;
+
+export default frappe.ui.button;

--- a/frappe/public/js/frappe/ui/embedded_list.js
+++ b/frappe/public/js/frappe/ui/embedded_list.js
@@ -61,9 +61,10 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 			? `<div class="embedded-list-description">${this.description}</div>`
 			: "";
 		const add = this.add_button
-			? `<button class="es-button" data-action="add-row">${
-					this.add_button.label || __("Add")
-			  }</button>`
+			? frappe.ui.button.html({
+					label: this.add_button.label || __("Add"),
+					attrs: { "data-action": "add-row" },
+			  })
 			: "";
 		const search = `<input type="text" class="form-control form-control-sm embedded-list-search" data-action="search" placeholder="${__(
 			"Search"
@@ -186,9 +187,7 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 					this.rendered_count,
 					this.data.length,
 				])}</span>
-				<button class="es-button" data-action="load-more">
-					${__("Load More")}
-				</button>
+				${frappe.ui.button.html({ label: __("Load More"), attrs: { "data-action": "load-more" } })}
 			</div>`
 		).appendTo(this.$result);
 	}
@@ -273,19 +272,18 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 
 	build_actions_html(col) {
 		return (col.actions || [])
-			.map((action, action_idx) => {
-				const title = action.label
-					? ` title="${frappe.utils.escape_html(action.label)}"`
-					: "";
-				// `xs` + currentColor matches Frappe's inline row actions (grid_row.js);
-				// only danger actions take the red theme, others stay neutral gray.
-				const theme = action.danger ? "red" : "gray";
-				const icon_button = action.icon ? "true" : "false";
-				const inner = action.icon
-					? frappe.utils.icon(action.icon, "xs", "", "", "", true)
-					: frappe.utils.escape_html(action.label || "");
-				return `<button class="es-button" data-icon-button="${icon_button}" data-size="xs" data-theme="${theme}" data-variant="ghost" data-action-idx="${action_idx}"${title}>${inner}</button>`;
-			})
+			.map((action, action_idx) =>
+				// only danger actions take the red theme, others stay neutral gray
+				frappe.ui.button.html({
+					label: action.icon ? "" : action.label || "",
+					icon: action.icon,
+					size: "xs",
+					variant: "ghost",
+					theme: action.danger ? "red" : null,
+					title: action.label,
+					attrs: { "data-action-idx": String(action_idx) },
+				})
+			)
 			.join("");
 	}
 

--- a/frappe/public/js/frappe/ui/settings_dialog.js
+++ b/frappe/public/js/frappe/ui/settings_dialog.js
@@ -64,14 +64,14 @@ frappe.ui.SettingsDialogPanel = class SettingsDialogPanel {
 	}
 
 	make_action(action) {
-		const $btn = $(`<button type="button" class="es-button" data-size="sm"></button>`)
-			.attr("data-variant", action.variant || "subtle")
-			.addClass(action.class || "");
-		if (action.icon) $btn.append(frappe.utils.icon(action.icon, "sm"));
-		$btn.append($("<span></span>").text(action.label || ""));
-		// `this` and the first argument are both the panel, so actions can mutate it.
-		action.click && $btn.on("click", () => action.click.call(this, this));
-		return $btn;
+		return frappe.ui.button({
+			label: action.label || "",
+			icon: action.icon,
+			variant: action.variant,
+			css_class: action.class,
+			// `this` and the first argument are both the panel, so actions can mutate it.
+			onclick: action.click && (() => action.click.call(this, this)),
+		});
 	}
 
 	add_fields(fields) {

--- a/frappe/public/js/frappe/ui/user_settings_dialog.js
+++ b/frappe/public/js/frappe/ui/user_settings_dialog.js
@@ -189,9 +189,11 @@ function _profile_tab(user_data) {
 						<div class="profile-full-name">${frappe.utils.escape_html(full_name)}</div>
 						<div class="profile-email">${frappe.utils.escape_html(email)}</div>
 					</div>
-					<button class="es-button change-password-btn">
-						${frappe.utils.icon("rotate-ccw-key")} ${__("Change Password")}
-					</button>
+					${frappe.ui.button.html({
+						label: __("Change Password"),
+						icon: "rotate-ccw-key",
+						css_class: "change-password-btn",
+					})}
 				</div>
 			`);
 
@@ -498,7 +500,7 @@ function _add_preference_row(parent, { label, value, button_label, onClick }) {
 				<div class="preference-label">${label}</div>
 				<div class="preference-value">${frappe.utils.escape_html(value || "")}</div>
 			</div>
-			<button class="es-button">${button_label}</button>
+			${frappe.ui.button.html({ label: button_label })}
 		</div>
 	`);
 	$row.find("button").on("click", onClick);

--- a/frappe/public/js/frappe/ui/user_settings_dialog.js
+++ b/frappe/public/js/frappe/ui/user_settings_dialog.js
@@ -160,7 +160,7 @@ function _profile_tab(user_data) {
 						last_name: values.last_name || "",
 						username: values.username || "",
 					};
-					_save_user(payload).then(() => {
+					return _save_user(payload).then(() => {
 						Object.assign(user_data, payload);
 						const fn = [payload.first_name, payload.middle_name, payload.last_name]
 							.filter(Boolean)
@@ -294,7 +294,7 @@ function _email_tab(user_data) {
 				label: __("Save"),
 				variant: "solid",
 				click(panel) {
-					_save_user("email_signature", panel.get_value("email_signature"));
+					return _save_user("email_signature", panel.get_value("email_signature"));
 				},
 			},
 		],
@@ -671,7 +671,7 @@ function _session_defaults_tab() {
 				fields.forEach((f) => {
 					if (!values[f.fieldname]) values[f.fieldname] = "";
 				});
-				frappe.call({
+				return frappe.call({
 					method: "frappe.core.doctype.session_default_settings.session_default_settings.set_session_default_values",
 					args: { default_values: values },
 					callback(data) {

--- a/frappe/public/scss/espresso_components.scss
+++ b/frappe/public/scss/espresso_components.scss
@@ -12,3 +12,5 @@
 @import "frappe/public/css/espresso/components/badge-legacy-colors.css";
 
 @import "frappe/public/css/espresso/components/button.css";
+
+@import "frappe/public/css/espresso/components/spinner.css";


### PR DESCRIPTION
This PR introduces a simple helper to render a button component in Framework.

`frappe.ui.button(opts)` - creates an Espresso -style button in the interface - without having to write all the markup.

You can use the utility in two ways:
- `frappe.ui.button(opts)` → wired jQuery element (binds onclick - also supports promise handling and loading states)
- `frappe.ui.button.html(opts)` → markup string, for template literals

Options mirror button.css' data attributes and JSDocs have been added in the codebase to support autocomplete + definition help in code editors.

<img width="1122" height="366" alt="image" src="https://github.com/user-attachments/assets/15c0e23d-8629-45e4-976a-9878ec3e0735" />

### Why

Hand-writing `es-button` markup leads to drifts across the codebase. Cases like handling of loading states (`aria-busy`), icon buttons (setting `data-icon-button` and ensuring `title` is passed with `aria-label`) are not handled, and sometimes text is not escaped. This provides a standard utility to do all that.

### Details

- Loading state = Sets `aria-busy="true"`. If `onclick` in the jQuery element variant returns a Promise, it handles setting/unsetting loading states on it's own
- Security: labels, titles, classes, and attribute values are HTML-escaped; `on*` attributes are refused (entity decoding makes escaping useless for them — use onclick instead, which binds via .on())
- Icons are automatically rendered via `frappe.utils.icon` with no explicit sizing since that's handled by the button's CSS.


#### Note to reviewers

The first commit in the PR adds the utility. The second one replaces all the existing `es-button` implementations. A follow up PR will then replace all the existing `btn` implementations throughout the app.


`no-docs`