### PR TITLE
fix: settings dialog panel scroll

### DIFF
--- a/frappe/public/scss/desk/settings_dialog.scss
+++ b/frappe/public/scss/desk/settings_dialog.scss
@@ -1,7 +1,10 @@
 .settings-dialog-wrapper {
+	// `clip` (not `hidden`) — a hidden container can still be scrolled programmatically
+	// (e.g. the browser scrolling a below-the-fold control into view on focus), and with
+	// no scrollbar the user can't scroll it back, leaving the dialog stuck mid-scroll.
 	.modal-content {
 		height: calc(100vh - 8rem);
-		overflow: hidden;
+		overflow: clip;
 	}
 
 	.modal-body.settings-dialog-body {
@@ -9,7 +12,7 @@
 		flex: 1;
 		min-height: 0;
 		padding: 0;
-		overflow: hidden;
+		overflow: clip;
 	}
 }
 
@@ -140,6 +143,7 @@
 	flex-direction: column;
 	width: 100%;
 	height: 100%;
+	min-height: 0;
 	padding: 2rem 1.5rem;
 	gap: 1rem;
 	color: var(--text-color);
@@ -186,6 +190,11 @@
 
 .settings-dialog-panel-body {
 	flex: 1;
+	// Without this a flex child won't shrink below its content height, so a long tab
+	// (e.g. General with many settings) overflows the panel instead of scrolling here —
+	// and focusing a control below the fold then scrolls the overflow-hidden modal
+	// shell, which the user cannot scroll back.
+	min-height: 0;
 	display: flex;
 	flex-direction: column;
 	overflow-y: auto;

--- a/frappe/public/scss/desk/settings_dialog.scss
+++ b/frappe/public/scss/desk/settings_dialog.scss
@@ -191,9 +191,6 @@
 .settings-dialog-panel-body {
 	flex: 1;
 	// Without this a flex child won't shrink below its content height, so a long tab
-	// (e.g. General with many settings) overflows the panel instead of scrolling here —
-	// and focusing a control below the fold then scrolls the overflow-hidden modal
-	// shell, which the user cannot scroll back.
 	min-height: 0;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
The settings dialog scrolling breaks when there are multiple entries and some setting is enabled, this fixes it 

Before:
<img width="1312" height="732" alt="Screenshot 2026-07-03 at 5 53 14 PM" src="https://github.com/user-attachments/assets/8d4e559d-6c4e-4ebf-b1dd-a24ad748bf48" />

After: 
<img width="1353" height="724" alt="Screenshot 2026-07-04 at 10 14 53 AM" src="https://github.com/user-attachments/assets/e58a42d8-3365-4211-a2e7-2eeeb69b5181" />
