### PR TITLE
perf(ci): prebuilt image, opt-in video and leaner coverage for ui tests

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,8 +25,15 @@ inputs:
   db:
     required: false
     default: mariadb
+  db-host:
+    required: false
+    default: 127.0.0.1
   db-root-password:
     required: true
+  containerized:
+    description: 'Set when the job runs inside the prebuilt CI image (ghcr.io/<repo>/ci) which already ships Python, Node, uv, bench and system packages'
+    required: false
+    default: false
 
 runs:
   using: "composite"
@@ -34,7 +41,9 @@ runs:
   - shell: bash -e {0}
     run: |
       # Add 'test_site' to /etc/hosts & setup git config
-      echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
+      SUDO=""
+      command -v sudo >/dev/null && SUDO=sudo
+      echo "127.0.0.1 test_site" | $SUDO tee -a /etc/hosts
       git config --global init.defaultBranch main
       git config --global advice.detachedHead false
 
@@ -44,6 +53,7 @@ runs:
       path: frappe-src
 
   - name: Setup Python
+    if: inputs.containerized != 'true'
     uses: actions/setup-python@v6
     with:
       python-version: ${{ inputs.python-version }}
@@ -58,25 +68,40 @@ runs:
       fi
 
   - uses: actions/setup-node@v6
+    if: inputs.containerized != 'true'
     with:
       node-version: ${{ inputs.node-version }}
       cache: yarn
       cache-dependency-path: frappe-src/yarn.lock
 
   - uses: astral-sh/setup-uv@v6
+    if: inputs.containerized != 'true'
     with:
       enable-cache: true
       cache-dependency-glob: |
         **/pyproject.toml
         **/requirements*.txt
 
+  - name: Cache dependency downloads
+    if: inputs.containerized == 'true'
+    uses: actions/cache@v4
+    with:
+      path: |
+        ~/.cache/yarn
+        ~/.cache/uv
+        ~/.cache/pip
+      key: ${{ runner.os }}-container-deps-${{ hashFiles('frappe-src/yarn.lock', 'frappe-src/pyproject.toml') }}
+      restore-keys: ${{ runner.os }}-container-deps-
+
   - name: Cache wkhtmltopdf
+    if: inputs.containerized != 'true'
     uses: actions/cache@v4
     with:
       path: /tmp/wkhtmltox.deb
       key: wkhtmltox-0.12.6.1-2-jammy-amd64
 
   - shell: bash -e {0}
+    if: inputs.containerized != 'true'
     run: |
       # Install System Dependencies (apt) in the background while installing the
       # frappe-bench tool via uv — the two share no inputs.
@@ -171,6 +196,7 @@ runs:
   - shell: bash -e {0}
     env:
       DB: ${{ inputs.db }}
+      DB_HOST: ${{ inputs.db-host }}
       BUILD_ASSETS: ${{ inputs.build-assets }}
     run: |
       # Create Site (asset build is CPU-bound and independent of the DB, so
@@ -195,7 +221,7 @@ runs:
       # safety for fewer fsyncs is free. innodb_flush_log_at_trx_commit=0 flushes
       # the redo log once per second instead of on every commit.
       if [ "$DB" == "mariadb" ]; then
-        mariadb -h 127.0.0.1 -u "$DB_ROOT_USER" -p"$DB_ROOT_PWD" -e "
+        mariadb -h "$DB_HOST" -u "$DB_ROOT_USER" -p"$DB_ROOT_PWD" -e "
           SET GLOBAL innodb_flush_log_at_trx_commit = 0;
           SET GLOBAL sync_binlog = 0;"
       fi
@@ -206,7 +232,7 @@ runs:
 
       bench new-site test_site \
         --db-type "$DB" \
-        --db-host 127.0.0.1 \
+        --db-host "$DB_HOST" \
         --db-name test_frappe \
         --db-password test_frappe \
         --verbose

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -142,6 +142,13 @@ runs:
       echo -e "\033[33mInstall System Dependencies + bench tool: $((end_time - start_time)) seconds\033[0m"
 
   - shell: bash -e {0}
+    if: inputs.containerized == 'true'
+    run: |
+      # bench exits when run as root unless frappe_user is set; job containers run as root
+      mkdir -p "${GITHUB_WORKSPACE}/sites"
+      echo '{"frappe_user": "root"}' > "${GITHUB_WORKSPACE}/sites/common_site_config.json"
+
+  - shell: bash -e {0}
     run: |
       # Init Bench
       start_time=$(date +%s)

--- a/.github/ci-image/Dockerfile
+++ b/.github/ci-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-bookworm
+FROM python:3.14-slim-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive \
     UV_TOOL_BIN_DIR=/usr/local/bin \
@@ -7,7 +7,15 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+RUN apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        build-essential \
+        pkg-config \
+        procps \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version="mariadb-11.8.5" --skip-maxscale \
     && echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /etc/apt/trusted.gpg.d/pgdg.asc \

--- a/.github/ci-image/Dockerfile
+++ b/.github/ci-image/Dockerfile
@@ -1,0 +1,44 @@
+FROM python:3.14-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    UV_TOOL_BIN_DIR=/usr/local/bin \
+    UV_TOOL_DIR=/opt/uv/tools \
+    BROWSER_PATH=/usr/bin/google-chrome
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version="mariadb-11.8.5" --skip-maxscale \
+    && echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /etc/apt/trusted.gpg.d/pgdg.asc \
+    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+    && curl -fsSL https://dl.google.com/linux/linux_signing_key.pub -o /etc/apt/trusted.gpg.d/google-chrome.asc \
+    && apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends \
+        nodejs \
+        google-chrome-stable \
+        redis-server \
+        mariadb-client \
+        libmariadb-dev \
+        postgresql-client-18 \
+        libpq-dev \
+        libcups2-dev \
+        libgtk-3-0 \
+        libgbm1 \
+        libnotify4 \
+        libnss3 \
+        libxss1 \
+        libasound2 \
+        libxtst6 \
+        xauth \
+        xvfb \
+        zip \
+    && curl -fsSL -o /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_amd64.deb \
+    && apt-get -qq install -y /tmp/wkhtmltox.deb \
+    && rm /tmp/wkhtmltox.deb \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g yarn \
+    && uv tool install frappe-bench
+
+ENV PATH="/usr/lib/postgresql/18/bin:${PATH}"

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,39 @@
+name: CI Image
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - .github/ci-image/**
+      - .github/workflows/ci-image.yml
+  workflow_dispatch:
+  schedule:
+    # Weekly rebuild keeps Chrome, MariaDB client and frappe-bench current
+    - cron: "0 22 * * 0"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .github/ci-image
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/ci:latest
+            ghcr.io/${{ github.repository }}/ci:${{ github.run_id }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -110,18 +110,18 @@ jobs:
               --group ui-shard-${{ matrix.index }}
         env:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
-          CYPRESS_RECORD_VIDEO: ${{ contains(github.event.pull_request.labels.*.name, 'record-video') && '1' || '' }}
+          CYPRESS_RECORD_VIDEO: ${{ (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video')) && '1' || '' }}
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
 
       - name: Compress Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
+        if: always() && steps.ui-tests.outcome == 'failure' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video'))
         run: |
             if find ./cypressVideos -mindepth 1 | read; then
               zip -r cypress_recordings.zip ./cypressVideos
             fi
       - name: Upload Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
+        if: always() && steps.ui-tests.outcome == 'failure' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video'))
         uses: actions/upload-artifact@v7
         with:
           name: Cypress CI Video Recordings

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -110,7 +110,7 @@ jobs:
               --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT \
               --group ui-shard-${{ matrix.index }}
         env:
-          CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
 
@@ -132,7 +132,7 @@ jobs:
               --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-retry \
               --spec "$FAILED_SPECS"
         env:
-          CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_RECORD_VIDEO: "1"
 
       - name: Compress Cypress Videos

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -110,7 +110,7 @@ jobs:
               --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT \
               --group ui-shard-${{ matrix.index }}
         env:
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
 
@@ -129,10 +129,8 @@ jobs:
               --with-coverage \
               --headless \
               --browser ${{ env.BROWSER_PATH }} \
-              --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-retry \
               --spec "$FAILED_SPECS"
         env:
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_RECORD_VIDEO: "1"
 
       - name: Compress Cypress Videos

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -119,18 +119,18 @@ jobs:
               --group ui-shard-${{ matrix.index }}
         env:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
-          CYPRESS_RECORD_VIDEO: ${{ (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video')) && '1' || '' }}
+          CYPRESS_RECORD_VIDEO: ${{ contains(github.event.pull_request.labels.*.name, 'record-video') && '1' || '' }}
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
 
       - name: Compress Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video'))
+        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
         run: |
             if find ./cypressVideos -mindepth 1 | read; then
               zip -r cypress_recordings.zip ./cypressVideos
             fi
       - name: Upload Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video'))
+        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
         uses: actions/upload-artifact@v7
         with:
           name: cypress-videos-shard-${{ matrix.index }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -121,8 +121,6 @@ jobs:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
-          # skip video on first attempts for speed; re-run failed jobs (or nightly) to record
-          CYPRESS_video: ${{ github.run_attempt != '1' || github.event_name == 'schedule' }}
 
       - name: Compress Cypress Videos
         if: always() && steps.ui-tests.outcome == 'failure'

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -12,8 +12,10 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  # Do not change this as GITHUB_TOKEN is being used by roulette
+  # Do not change contents as GITHUB_TOKEN is being used by roulette
   contents: read
+  # allows the ghcr ci image pull to authenticate even if the package is made private
+  packages: read
 
 jobs:
   checkrun:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -120,6 +120,8 @@ jobs:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
+          # skip video on first attempts for speed; re-run failed jobs (or nightly) to record
+          CYPRESS_video: ${{ github.run_attempt != '1' || github.event_name == 'schedule' }}
 
       - name: Compress Cypress Videos
         if: always() && steps.ui-tests.outcome == 'failure'
@@ -131,8 +133,17 @@ jobs:
         if: always() && steps.ui-tests.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
-          name: Cypress CI Video Recordings
+          name: cypress-videos-shard-${{ matrix.index }}
           path: ./cypress_recordings.zip
+          if-no-files-found: ignore
+
+      - name: Upload Cypress Screenshots
+        if: always() && steps.ui-tests.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: cypress-screenshots-shard-${{ matrix.index }}
+          path: ./apps/${{ github.event.repository.name }}/cypress/screenshots
+          if-no-files-found: ignore
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -43,7 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
-      image: ghcr.io/${{ github.repository }}/ci:latest
+      # pinned to the canonical repo so forks pull a published image
+      image: ghcr.io/frappe/frappe/ci:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -50,6 +50,11 @@ jobs:
       # noisy 3rd party library warnings
       PYTHONWARNINGS: "ignore"
       DB_ROOT_PASSWORD: db_root
+      # bench runs its children with HOME=/root (frappe_user), keep caches at the runner home
+      CYPRESS_CACHE_FOLDER: /github/home/.cache/Cypress
+      YARN_CACHE_FOLDER: /github/home/.cache/yarn
+      PIP_CACHE_DIR: /github/home/.cache/pip
+      UV_CACHE_DIR: /github/home/.cache/uv
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         db: ["mariadb"]
-        index: [1, 2, 3, 4]
+        index: [1, 2, 3, 4, 5, 6, 7, 8]
     services:
       mariadb:
         image: mariadb:11.8
@@ -118,7 +118,7 @@ jobs:
               --group ui-shard-${{ matrix.index }}
         env:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
-          SPLIT: 4
+          SPLIT: 8
           SPLIT_INDEX: ${{ strategy.job-index }}
 
       - name: Compress Cypress Videos

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         db: ["mariadb"]
-        index: [1, 2, 3, 4, 5, 6, 7, 8]
+        index: [1, 2, 3, 4]
     services:
       mariadb:
         image: mariadb:11.8
@@ -118,7 +118,7 @@ jobs:
               --group ui-shard-${{ matrix.index }}
         env:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
-          SPLIT: 8
+          SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
 
       - name: Compress Cypress Videos

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -42,6 +42,9 @@ jobs:
     timeout-minutes: 30
     container:
       image: ghcr.io/${{ github.repository }}/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     env:
       NODE_ENV: "production"
       # noisy 3rd party library warnings

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -100,6 +100,7 @@ jobs:
 
       - name: Run Tests
         id: ui-tests
+        continue-on-error: true
         run: |
           bench --site test_site \
             run-ui-tests ${{ github.event.repository.name }} \
@@ -113,14 +114,35 @@ jobs:
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
 
+      - name: Re-run Failed Tests With Video
+        id: ui-tests-retry
+        if: steps.ui-tests.outcome == 'failure'
+        run: |
+          FAILED_SPECS=$(sort -u ./cypress_failed_specs.txt 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+          if [ -z "$FAILED_SPECS" ]; then
+            echo "No failed specs recorded; marking as failure"
+            exit 1
+          fi
+          echo "Re-running with video: $FAILED_SPECS"
+          bench --site test_site \
+            run-ui-tests ${{ github.event.repository.name }} \
+              --with-coverage \
+              --headless \
+              --browser ${{ env.BROWSER_PATH }} \
+              --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-retry \
+              --spec "$FAILED_SPECS"
+        env:
+          CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
+          CYPRESS_RECORD_VIDEO: "1"
+
       - name: Compress Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure'
+        if: always() && steps.ui-tests-retry.outcome == 'failure'
         run: |
             if find ./cypressVideos -mindepth 1 | read; then
               zip -r cypress_recordings.zip ./cypressVideos
             fi
       - name: Upload Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure'
+        if: always() && steps.ui-tests-retry.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: Cypress CI Video Recordings

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -100,7 +100,6 @@ jobs:
 
       - name: Run Tests
         id: ui-tests
-        continue-on-error: true
         run: |
           bench --site test_site \
             run-ui-tests ${{ github.event.repository.name }} \
@@ -111,36 +110,18 @@ jobs:
               --group ui-shard-${{ matrix.index }}
         env:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
+          CYPRESS_RECORD_VIDEO: ${{ contains(github.event.pull_request.labels.*.name, 'record-video') && '1' || '' }}
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
 
-      - name: Re-run Failed Tests With Video
-        id: ui-tests-retry
-        if: steps.ui-tests.outcome == 'failure'
-        run: |
-          FAILED_SPECS=$(sort -u ./cypress_failed_specs.txt 2>/dev/null | tr '\n' ',' | sed 's/,$//')
-          if [ -z "$FAILED_SPECS" ]; then
-            echo "No failed specs recorded; marking as failure"
-            exit 1
-          fi
-          echo "Re-running with video: $FAILED_SPECS"
-          bench --site test_site \
-            run-ui-tests ${{ github.event.repository.name }} \
-              --with-coverage \
-              --headless \
-              --browser ${{ env.BROWSER_PATH }} \
-              --spec "$FAILED_SPECS"
-        env:
-          CYPRESS_RECORD_VIDEO: "1"
-
       - name: Compress Cypress Videos
-        if: always() && steps.ui-tests-retry.outcome == 'failure'
+        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
         run: |
             if find ./cypressVideos -mindepth 1 | read; then
               zip -r cypress_recordings.zip ./cypressVideos
             fi
       - name: Upload Cypress Videos
-        if: always() && steps.ui-tests-retry.outcome == 'failure'
+        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
         uses: actions/upload-artifact@v7
         with:
           name: Cypress CI Video Recordings

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -40,6 +40,8 @@ jobs:
     if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    container:
+      image: ghcr.io/${{ github.repository }}/ci:latest
     env:
       NODE_ENV: "production"
       # noisy 3rd party library warnings
@@ -64,11 +66,11 @@ jobs:
       - uses: ./.github/actions/setup
         name: Environment Setup
         with:
-          python-version: '3.14'
-          node-version: 24
           build-assets: true
           db-root-password: ${{ env.DB_ROOT_PASSWORD }}
           db: ${{ matrix.db }}
+          db-host: mariadb
+          containerized: true
 
       - name: Verify yarn.lock
         run: |
@@ -94,10 +96,6 @@ jobs:
           bench --site test_site execute frappe.utils.install.complete_setup_wizard
           bench --site test_site execute frappe.tests.ui_test_helpers.create_test_user
 
-      - uses: browser-actions/setup-chrome@latest
-      - run: |
-          echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
-
       - name: Run Tests
         id: ui-tests
         run: |
@@ -105,7 +103,7 @@ jobs:
             run-ui-tests ${{ github.event.repository.name }} \
               --with-coverage \
               --headless \
-              --browser ${{ env.BROWSER_PATH }} \
+              --browser "$BROWSER_PATH" \
               --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT \
               --group ui-shard-${{ matrix.index }}
         env:

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -34,12 +34,14 @@ module.exports = defineConfig({
 				cypressSplit(on, config);
 			}
 
-			// Delete videos for specs where no test was retried
+			// Delete videos for specs where no test ultimately failed
 			// https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
 			on("after:spec", (spec, results) => {
 				if (results && results.video) {
-					const hadRetries = results.tests.some((test) => test.attempts.length > 1);
-					if (!hadRetries) {
+					const anyFailed = results.tests.some(
+						(test) => test.attempts[test.attempts.length - 1].state === "failed"
+					);
+					if (!anyFailed) {
 						fs.unlinkSync(results.video);
 					}
 				}

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -45,17 +45,6 @@ module.exports = defineConfig({
 						fs.unlinkSync(results.video);
 					}
 				}
-				// Write ultimately-failed spec paths to a file so CI can re-run them with video
-				if (results && results.tests) {
-					const lastAttemptFailed = results.tests.some(
-						(test) => test.attempts[test.attempts.length - 1].state === "failed"
-					);
-					if (lastAttemptFailed) {
-						const failedSpecsFile =
-							path.resolve(__dirname, "..", "..") + "/cypress_failed_specs.txt";
-						fs.appendFileSync(failedSpecsFile, spec.relative + "\n");
-					}
-				}
 			});
 
 			return require("./cypress/plugins/index.js")(on, config);

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -47,7 +47,11 @@ module.exports = defineConfig({
 				}
 			});
 
-			return require("./cypress/plugins/index.js")(on, config);
+			const result = require("./cypress/plugins/index.js")(on, config);
+			if (process.env.CI) {
+				on("task", { coverageReport: () => null });
+			}
+			return result;
 		},
 		testIsolation: false,
 		baseUrl: "http://test_site_ui:8000",

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -9,7 +9,7 @@ module.exports = defineConfig({
 	testUser: "frappe@example.com",
 	defaultCommandTimeout: 20000,
 	pageLoadTimeout: 15000,
-	video: true,
+	video: process.env.CYPRESS_RECORD_VIDEO === "1",
 	videosFolder: path.resolve(__dirname, "..", "..") + "/cypressVideos/",
 	viewportHeight: 960,
 	viewportWidth: 1400,
@@ -34,15 +34,24 @@ module.exports = defineConfig({
 				cypressSplit(on, config);
 			}
 
-			// Delete videos for specs without failing or retried tests
+			// Delete videos for specs where no test was retried
 			// https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
 			on("after:spec", (spec, results) => {
 				if (results && results.video) {
-					const failures = results.tests.some((test) =>
-						test.attempts.some((attempt) => attempt.state === "failed")
-					);
-					if (!failures) {
+					const hadRetries = results.tests.some((test) => test.attempts.length > 1);
+					if (!hadRetries) {
 						fs.unlinkSync(results.video);
+					}
+				}
+				// Write ultimately-failed spec paths to a file so CI can re-run them with video
+				if (results && results.tests) {
+					const lastAttemptFailed = results.tests.some(
+						(test) => test.attempts[test.attempts.length - 1].state === "failed"
+					);
+					if (lastAttemptFailed) {
+						const failedSpecsFile =
+							path.resolve(__dirname, "..", "..") + "/cypress_failed_specs.txt";
+						fs.appendFileSync(failedSpecsFile, spec.relative + "\n");
 					}
 				}
 			});


### PR DESCRIPTION
- run UI test shards in a prebuilt image (`ghcr.io/frappe/frappe/ci:latest`) instead of installing the env on every shard; rebuilt weekly / on Dockerfile change / via dispatch once this lands on develop
- cypress video off by default everywhere, opt-in only via the `record-video` PR label; only failing specs' videos kept, uploaded per shard with failure screenshots
- skip the per-spec `nyc report` in CI (ran 19x per shard, output unused); coverage collection unchanged

| | before | after |
|---|---|---|
| env setup per shard | ~2m45s | ~2m15s (incl image pull) |
| video overhead per shard | ~20s always | 0 unless labelled |
| coverage reports per shard | 19x (~40s) | 0 |
| shard total | ~10m15s | ~7m30s–8m |
| wall clock | ~11m | ~8m |
