### PR TITLE
feat: make field cards fully draggable in print format builder

### DIFF
--- a/frappe/printing/doctype/print_format_field_template/print_format_field_template.json
+++ b/frappe/printing/doctype/print_format_field_template/print_format_field_template.json
@@ -68,7 +68,7 @@
   },
   {
    "depends_on": "eval:doc.standard",
-   "description": "Path to the template file inside the app, e.g. my_app/templates/print_formats/my_template.html",
+   "description": "Path to the template file inside the app, e.g. templates/print_formats/my_template.html",
    "fieldname": "template_file",
    "fieldtype": "Data",
    "label": "Template File",

--- a/frappe/printing/doctype/print_format_field_template/print_format_field_template.json
+++ b/frappe/printing/doctype/print_format_field_template/print_format_field_template.json
@@ -9,10 +9,10 @@
  "field_order": [
   "document_type",
   "field",
-  "template_file",
   "column_break_3",
-  "module",
   "standard",
+  "module",
+  "template_file",
   "section_break_5",
   "template"
  ],
@@ -50,14 +50,17 @@
    "hide_border": 1
   },
   {
-   "depends_on": "standard",
+   "depends_on": "eval:doc.standard",
    "fieldname": "module",
    "fieldtype": "Link",
    "label": "Module",
+   "mandatory_depends_on": "eval:doc.standard",
    "options": "Module Def"
   },
   {
    "default": "0",
+   "depends_on": "eval:frappe.boot.developer_mode",
+   "description": "Load the template from a file in a module instead of the Template field. Requires developer mode.",
    "fieldname": "standard",
    "fieldtype": "Check",
    "in_list_view": 1,
@@ -65,6 +68,7 @@
   },
   {
    "depends_on": "eval:doc.standard",
+   "description": "Path to the template file inside the app, e.g. my_app/templates/print_formats/my_template.html",
    "fieldname": "template_file",
    "fieldtype": "Data",
    "label": "Template File",
@@ -73,7 +77,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:03:35.138827",
+ "modified": "2026-07-04 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format Field Template",

--- a/frappe/printing/doctype/print_format_field_template/print_format_field_template.py
+++ b/frappe/printing/doctype/print_format_field_template/print_format_field_template.py
@@ -26,8 +26,11 @@ class PrintFormatFieldTemplate(Document):
 	# end: auto-generated types
 
 	def validate(self):
-		if self.standard and not frappe.conf.developer_mode and not frappe.flags.in_patch:
-			frappe.throw(_("Enable developer mode to create a standard Print Template"))
+		if self.standard:
+			if not frappe.conf.developer_mode and not frappe.flags.in_patch:
+				frappe.throw(_("Enable developer mode to create a standard Print Template"))
+			if not self.module:
+				frappe.throw(_("Module is required for a standard Print Template"))
 
 	def before_insert(self):
 		self.validate_duplicate()

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -92,7 +92,7 @@ import Preview from "./components/Preview.vue";
 import PrintFormatControls from "./components/PrintFormatControls.vue";
 import FieldInspector from "./components/inspector/FieldInspector.vue";
 import { getStore } from "./stores";
-import { computed, ref, onMounted, onUnmounted, provide, nextTick } from "vue";
+import { computed, ref, onMounted, onUnmounted, provide, nextTick, watch } from "vue";
 
 // props
 const props = defineProps(["print_format_name"]);
@@ -129,6 +129,20 @@ provide("$store", $store.value);
 // methods
 function toggle_preview() {
 	show_preview.value = !show_preview.value;
+}
+
+watch(show_preview, (on) => {
+	if (on) {
+		history.pushState({ ...history.state, pfb_preview: true }, "");
+	} else if (history.state?.pfb_preview) {
+		history.back();
+	}
+});
+
+function handle_popstate() {
+	if (show_preview.value) {
+		show_preview.value = false;
+	}
 }
 
 function clear_selection() {
@@ -295,6 +309,7 @@ function init_doc_picker() {
 // mounted
 onMounted(() => {
 	document.addEventListener("keydown", handle_keydown);
+	window.addEventListener("popstate", handle_popstate);
 
 	// Detect desk sidebar open/close via MutationObserver on the wrapper's style attribute
 	check_sidebar();
@@ -314,6 +329,7 @@ onMounted(() => {
 
 onUnmounted(() => {
 	document.removeEventListener("keydown", handle_keydown);
+	window.removeEventListener("popstate", handle_popstate);
 	sidebar_observer_ref?.disconnect();
 });
 

--- a/frappe/public/js/print_format_builder/components/Preview.vue
+++ b/frappe/public/js/print_format_builder/components/Preview.vue
@@ -36,7 +36,7 @@ import { ref, computed, onMounted } from "vue";
 let { print_format, store } = useStore();
 
 // variables
-let type = ref("PDF");
+let type = ref("HTML");
 let docname = ref(null);
 let preview_loaded = ref(false);
 let iframe = ref(null);
@@ -96,7 +96,7 @@ onMounted(() => {
 			label: __("Preview type"),
 			fieldname: "docname",
 			fieldtype: "Select",
-			options: ["PDF", "HTML"],
+			options: ["HTML", "PDF"],
 			change: () => {
 				type.value = preview_type.value.get_value();
 			},

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -731,8 +731,17 @@ watch(
 	border: 1px dashed var(--gray-400);
 	padding: 0.4rem 0.5rem;
 	font-size: var(--text-sm);
-	cursor: default;
+	cursor: grab;
 	overflow: hidden;
+}
+
+.field:active {
+	cursor: grabbing;
+}
+
+.field.sortable-chosen,
+.field.sortable-ghost {
+	cursor: grabbing;
 }
 
 .field:focus-within {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -95,7 +95,7 @@
 							group="fields"
 							:animation="150"
 							item-key="id"
-							filter="a, input, textarea, select, button, [contenteditable], [role='button'], [tabindex]"
+							filter="a, input, textarea, select, button, label, summary, [contenteditable], [role='button'], [tabindex]"
 							:preventOnFilter="false"
 							:emptyInsertThreshold="100"
 							@add="select_section"

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -95,7 +95,7 @@
 							group="fields"
 							:animation="150"
 							item-key="id"
-							filter="a, input, textarea, select, button, [contenteditable]"
+							filter="a, input, textarea, select, button, [contenteditable], [role='button'], [tabindex]"
 							:preventOnFilter="false"
 							:emptyInsertThreshold="100"
 							@add="select_section"

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -95,7 +95,8 @@
 							group="fields"
 							:animation="150"
 							item-key="id"
-							handle=".drag-handle"
+							filter="input, textarea, select, button, [contenteditable]"
+							:preventOnFilter="false"
 							:emptyInsertThreshold="100"
 							@add="select_section"
 						>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -95,7 +95,7 @@
 							group="fields"
 							:animation="150"
 							item-key="id"
-							filter="input, textarea, select, button, [contenteditable]"
+							filter="a, input, textarea, select, button, [contenteditable]"
 							:preventOnFilter="false"
 							:emptyInsertThreshold="100"
 							@add="select_section"

--- a/frappe/templates/print_format/macros/Data.html
+++ b/frappe/templates/print_format/macros/Data.html
@@ -4,7 +4,7 @@
 {%- set _orientation = df.section.field_orientation or '' -%}
 {%- set _inline = (_show_label == 'inline') or (_orientation == 'left-right') -%}
 {%- set _justify = df.label_justify if df.label_justify else '' -%}
-{%- set _fstyle = (('gap: ' + df.label_gap|int|string + 'px;') if (_inline and df.label_gap is not none) else '') + (df.custom_style or '') -%}
+{%- set _fstyle = (('gap: ' + df.label_gap|int|string + 'px;') if (_inline and df.label_gap is defined and df.label_gap is not none) else '') + (df.custom_style or '') -%}
 <div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' %} field-justify-{{ _justify }}{% endif %}" {% if _fstyle %}style="{{ _fstyle|e }}"{% endif %} {{ field_attributes(df) }}>
 	{%- block label -%}
 	{%- if _show_label != 'hide' -%}

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -126,12 +126,16 @@ body {
 }
 
 {%- if print_format.label_color %}
-.print-format .field .label {
+.field .label,
+.field.left-right .label,
+.field.field-inline .label {
 	color: {{ print_format.label_color }};
 }
 {%- endif %}
 {%- if print_format.value_color %}
-.print-format .field .value {
+.field .value,
+.field.left-right .value,
+.field.field-inline .value {
 	color: {{ print_format.value_color }};
 }
 {%- endif %}

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -63,10 +63,6 @@ body {
 	}
 }
 
-.section:not(:first-child) {
-	margin-top: 1.5rem;
-}
-
 .section-label {
 	font-size: 1.1rem;
 	font-weight: 700;

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -565,7 +565,10 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		pf = self._make_print_format(label_color="#c0392b")
 		todo = self._make_todo()
 		html = get_html("ToDo", todo.name, pf.name)
-		self.assertIn(".print-format .field .label {\n\tcolor: #c0392b;\n}", html)
+		self.assertIn(
+			".field .label,\n.field.left-right .label,\n.field.field-inline .label {\n\tcolor: #c0392b;\n}",
+			html,
+		)
 
 	def test_value_color_rendered_in_css(self):
 		"""A value_color set on the print format emits a value color override rule."""
@@ -574,7 +577,10 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		pf = self._make_print_format(value_color="#1a5fb4")
 		todo = self._make_todo()
 		html = get_html("ToDo", todo.name, pf.name)
-		self.assertIn(".print-format .field .value {\n\tcolor: #1a5fb4;\n}", html)
+		self.assertIn(
+			".field .value,\n.field.left-right .value,\n.field.field-inline .value {\n\tcolor: #1a5fb4;\n}",
+			html,
+		)
 
 	def test_no_color_override_when_colors_unset(self):
 		"""Without label/value colors, no color override rule is emitted."""
@@ -583,8 +589,8 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		pf = self._make_print_format()
 		todo = self._make_todo()
 		html = get_html("ToDo", todo.name, pf.name)
-		self.assertNotIn(".print-format .field .label {", html)
-		self.assertNotIn(".print-format .field .value {", html)
+		self.assertNotIn(".field .label,\n.field.left-right .label", html)
+		self.assertNotIn(".field .value,\n.field.left-right .value", html)
 
 	def test_non_hex_color_rejected(self):
 		"""Colors that are not #RRGGBB hex codes are rejected on save."""


### PR DESCRIPTION
- Drag fields by the whole card instead of only the grip handle; interactive elements inside rendered content (inputs, buttons, links, labels, `<summary>`, `role="button"`, `tabindex`) are excluded from drag starts
- Show grab cursor on hover and grabbing cursor while dragging field cards
- Drop the default 1.5rem top margin between printed sections — spacing is now user-controlled per section and matches the builder preview
- Browser back while the builder preview is open now closes the preview instead of leaving the page
- Default the builder preview to HTML instead of PDF
- Apply label/value colors in print output (selectors required a `.print-format` wrapper that printview does not render) and stop emitting `gap: 0px` on fields when no label gap is set
- Remove the outer table border in plain table style print output — Bootstrap's `table-bordered` box double-bordered the header and did not match the builder preview
- Print Format Field Template: hide the Standard checkbox for non-developers, require Module when standard (client + server), and add descriptions for Standard/Template File

`no-docs`
