### PR TITLE
fix: don't probe external links with a nonexistent fieldname in get_open_count

### DIFF
--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -309,6 +309,15 @@ class TestAutoRepeat(IntegrationTestCase):
 
 		self.assertEqual(new_todo_count, 2)
 
+	def tearDown(self):
+		# every test here commits, so IntegrationTestCase's per-test rollback can't
+		# undo them. The assignee tests assign generated ToDos to Guest, which shares
+		# those ToDos with Guest; left behind, that lets anonymous API reads succeed
+		# in unrelated tests later in the same shard. Drop the committed artifacts.
+		frappe.db.delete("DocShare", {"share_doctype": "ToDo", "user": "Guest"})
+		# the leaked shares were committed, so the cleanup must be committed too
+		frappe.db.commit()  # nosemgrep
+
 
 def make_auto_repeat(**args):
 	args = frappe._dict(args)

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -289,12 +289,13 @@ def _get_linked_document_counts(doctype: str, name: str, items=None):
 			internal_links_data_for_d = get_internal_links(doc, internal_link_for_doctype, d)
 			if internal_links_data_for_d["count"]:
 				out["internal_links_found"].append(internal_links_data_for_d)
+			elif has_external_link_field(d, links):
+				# pairs can be linked from either side, e.g. a Sales Invoice made
+				# from a Delivery Note (internal) vs one a Delivery Note was made
+				# from (external), so probe the other direction too
+				out["external_links_found"].append(get_external_links(d, name, links))
 			else:
-				try:
-					external_links_data_for_d = get_external_links(d, name, links)
-					out["external_links_found"].append(external_links_data_for_d)
-				except Exception:
-					out["external_links_found"].append({"doctype": d, "open_count": 0, "count": 0})
+				out["external_links_found"].append({"doctype": d, "open_count": 0, "count": 0})
 		else:
 			external_links_data_for_d = get_external_links(d, name, links)
 			out["external_links_found"].append(external_links_data_for_d)
@@ -335,8 +336,23 @@ def get_internal_links(doc, link, link_doctype):
 	return data
 
 
+def get_external_link_fieldname(doctype, links):
+	return links.get("non_standard_fieldnames", {}).get(doctype, links.get("fieldname"))
+
+
+def has_external_link_field(doctype, links):
+	"""Whether `doctype` (or one of its child tables) has the field that links it back."""
+	fieldname = get_external_link_fieldname(doctype, links)
+	if not fieldname:
+		return False
+	meta = frappe.get_meta(doctype)
+	return meta.has_field(fieldname) or any(
+		frappe.get_meta(df.options).has_field(fieldname) for df in meta.get_table_fields()
+	)
+
+
 def get_external_links(doctype, name, links):
-	fieldname = links.get("non_standard_fieldnames", {}).get(doctype, links.get("fieldname"))
+	fieldname = get_external_link_fieldname(doctype, links)
 	filters = {fieldname: name}
 
 	# updating filters based on dynamic_links

--- a/frappe/tests/test_background_jobs.py
+++ b/frappe/tests/test_background_jobs.py
@@ -95,12 +95,24 @@ def after_job(*args, **kwargs):
 def freeze_local():
 	locals = frappe.local
 	frappe.local = Local()
-	yield locals
-	frappe.local = locals
+	try:
+		yield locals
+	finally:
+		# without the restore, every test running after this one in the same
+		# process sees an unbound frappe.local and fails
+		frappe.local = locals
 
 
-def patch_job_hooks(event: str):
-	return {
+_real_get_hooks = frappe.get_hooks
+
+
+def patch_job_hooks(event: str, *args, **kwargs):
+	test_hooks = {
 		"before_job": ["frappe.tests.test_background_jobs.before_job"],
 		"after_job": ["frappe.tests.test_background_jobs.after_job"],
-	}[event]
+	}
+	if event in test_hooks:
+		return test_hooks[event]
+	# anything else the job execution looks up (e.g. typing_validations'
+	# require_type_annotated_api_methods) must behave as usual
+	return _real_get_hooks(event, *args, **kwargs)

--- a/frappe/tests/test_dashboard_connections.py
+++ b/frappe/tests/test_dashboard_connections.py
@@ -122,6 +122,40 @@ class TestDashboardConnections(IntegrationTestCase):
 				expected_open_count,
 			)
 
+	def test_internal_link_without_external_field_reports_zero(self):
+		venus = frappe.get_doc(
+			{
+				"doctype": "Test Doctype A With Child Table With Link To Doctype B",
+				"title": "Venus",
+			}
+		)
+		venus.append("child_table", {"title": "Venus"})
+		venus.insert()
+
+		# internal link with no rows falls back to an external-link probe; the
+		# fieldname doesn't exist on the target doctype, so no query should run
+		dashboard = get_dashboard_for_test_doctype_a_with_test_child_table_with_link_to_doctype_b()
+		dashboard.fieldname = "nonexistent_column"
+
+		expected_open_count = {
+			"count": {
+				"external_links_found": [
+					{
+						"doctype": "Test Doctype B With Child Table With Link To Doctype A",
+						"open_count": 0,
+						"count": 0,
+					}
+				],
+				"internal_links_found": [],
+			}
+		}
+
+		with patch.object(venus.meta, "get_dashboard_data", return_value=dashboard):
+			self.assertEqual(
+				get_open_count("Test Doctype A With Child Table With Link To Doctype B", "Venus"),
+				expected_open_count,
+			)
+
 	def test_external_doctype_link_with_dashboard_override(self):
 		# add a custom links
 		todo = TestCustomizeForm().get_customize_form("ToDo")

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1594,7 +1594,12 @@ class TestPostgresSchemaQueryIndependence(ExtIntegrationTestCase):
 
 
 class TestDbConnectWithEnvCredentials(IntegrationTestCase):
-	current_site = frappe.local.site
+	@classmethod
+	def setUpClass(cls):
+		# resolved here instead of the class body: at import time there may be
+		# no site context (depends on which test modules ran before this one)
+		super().setUpClass()
+		cls.current_site = frappe.local.site
 
 	def tearDown(self):
 		frappe.init(self.current_site, force=True)


### PR DESCRIPTION
Opening the Connections tab on a form calls `get_open_count`, which 500s on postgres sites with `InFailedSqlTransaction` (underlying error: `column "sales_invoice" does not exist`).

When a doctype in the dashboard's `internal_links` has no linked rows, `_get_linked_document_counts` falls back to counting it as an external link: it guesses a reverse fieldname and queries the target doctype with it, relying on a bare `except` as the "does that field exist" check. For internal-only pairs the guessed column doesn't exist — MariaDB swallows the failed query (silently firing a doomed query per doctype on every Connections load), while on postgres the failed statement aborts the transaction and every subsequent count query raises `InFailedSqlTransaction`.

Fix: before running the fallback query, check the resolved fieldname actually exists on the target doctype or one of its child tables (child tables matter — that's how e.g. Journal Entry `accounts.reference_name` links resolve). If it doesn't, report zero without touching the database, and drop the exception swallow. Pairs with a real reverse field are counted exactly as before.

Tests: new `test_internal_link_without_external_field_reports_zero` reproduces the failure shape (fails with `InFailedSqlTransaction` on postgres without the fix); existing `test_external_link_count` covers the positive case. `test_dashboard_connections` green on both engines.
