### PR TITLE
fix(print-format): remove outer table border in plain style print output

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -1101,7 +1101,6 @@ watch(
 
 .preview-table--plain th {
 	background-color: transparent;
-	border-bottom: 2px solid var(--gray-300);
 }
 
 .preview-table--plain tr.odd td,
@@ -1124,7 +1123,6 @@ watch(
 /* ── Plain header variant ───────────────────────────── */
 .preview-table--plain-header th {
 	background-color: transparent;
-	border-bottom-width: 1px;
 }
 
 .preview-table-img {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -1124,7 +1124,7 @@ watch(
 /* ── Plain header variant ───────────────────────────── */
 .preview-table--plain-header th {
 	background-color: transparent;
-	border-bottom: 2px solid var(--gray-300);
+	border-bottom-width: 1px;
 }
 
 .preview-table-img {

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -280,7 +280,7 @@ body {
 /* plain header variant */
 .child-table--plain-header .table th {
 	background-color: transparent !important;
-	border-bottom: 2px solid #d1d5db !important;
+	border-bottom-width: 1px !important;
 }
 
 .child-table [data-fieldtype="Currency"],

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -250,6 +250,10 @@ body {
 }
 
 /* plain: no borders, bottom dividers only */
+.child-table--plain .table {
+	border: none !important;
+}
+
 .child-table--plain .table th,
 .child-table--plain .table td {
 	border: none !important;

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -251,9 +251,10 @@ body {
 
 /* plain: no borders, bottom dividers only */
 .child-table--plain .table {
-	border: none !important;
+	border: none;
 }
 
+/* !important needed: bootstrap print styles set table-bordered cell borders with !important */
 .child-table--plain .table th,
 .child-table--plain .table td {
 	border: none !important;
@@ -262,7 +263,6 @@ body {
 
 .child-table--plain .table th {
 	background-color: transparent !important;
-	border-bottom: 2px solid #d1d5db !important;
 }
 
 .child-table--plain .table .odd td,
@@ -280,7 +280,6 @@ body {
 /* plain header variant */
 .child-table--plain-header .table th {
 	background-color: transparent !important;
-	border-bottom-width: 1px !important;
 }
 
 .child-table [data-fieldtype="Currency"],


### PR DESCRIPTION
- Remove the outer table border in plain table style print output — Bootstrap's `table-bordered` box double-bordered the header and did not match the builder preview
- Remove the 2px header underline from every table style and header variant (editor + print); headers now use the same 1px border as body cells
- Drop `!important` from the plain table outer-border override where plain specificity already wins

`no-docs`
