### PR TITLE
feat: min_value and max_value properties for numeric fields

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -669,7 +669,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-04-24 13:21:02.590853",
+ "modified": "2026-07-11 11:35:29.567463",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -14,6 +14,8 @@
   "length",
   "precision",
   "non_negative",
+  "min_value",
+  "max_value",
   "hide_days",
   "hide_seconds",
   "reqd",
@@ -516,6 +518,18 @@
    "fieldname": "non_negative",
    "fieldtype": "Check",
    "label": "Non Negative"
+  },
+  {
+   "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
+   "fieldname": "min_value",
+   "fieldtype": "Float",
+   "label": "Min Value"
+  },
+  {
+   "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
+   "fieldname": "max_value",
+   "fieldtype": "Float",
+   "label": "Max Value"
   },
   {
    "fieldname": "column_break_18",

--- a/frappe/core/doctype/docfield/docfield.py
+++ b/frappe/core/doctype/docfield/docfield.py
@@ -97,6 +97,8 @@ class DocField(Document):
 		mandatory_depends_on: DF.Code | None
 		mask: DF.Check
 		max_height: DF.Data | None
+		max_value: DF.Float
+		min_value: DF.Float
 		no_copy: DF.Check
 		non_negative: DF.Check
 		not_nullable: DF.Check

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -37,6 +37,8 @@
   "read_only_depends_on",
   "properties",
   "non_negative",
+  "min_value",
+  "max_value",
   "reqd",
   "unique",
   "is_virtual",
@@ -450,6 +452,18 @@
    "fieldname": "non_negative",
    "fieldtype": "Check",
    "label": "Non Negative"
+  },
+  {
+   "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
+   "fieldname": "min_value",
+   "fieldtype": "Float",
+   "label": "Min Value"
+  },
+  {
+   "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
+   "fieldname": "max_value",
+   "fieldtype": "Float",
+   "label": "Max Value"
   },
   {
    "fieldname": "module",

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -528,7 +528,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-08 13:37:37.503488",
+ "modified": "2026-07-11 11:35:29.567463",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -103,6 +103,8 @@ class CustomField(Document):
 		link_filters: DF.JSON | None
 		mandatory_depends_on: DF.Code | None
 		mask: DF.Check
+		max_value: DF.Float
+		min_value: DF.Float
 		module: DF.Link | None
 		no_copy: DF.Check
 		non_negative: DF.Check

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -781,6 +781,8 @@ docfield_properties = {
 	"print_width": "Data",
 	"alignment": "Select",
 	"non_negative": "Check",
+	"min_value": "Float",
+	"max_value": "Float",
 	"reqd": "Check",
 	"unique": "Check",
 	"ignore_user_permissions": "Check",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -545,7 +545,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-04-27 12:00:00.000000",
+ "modified": "2026-07-11 11:35:29.567463",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -13,6 +13,8 @@
   "fieldtype",
   "fieldname",
   "non_negative",
+  "min_value",
+  "max_value",
   "reqd",
   "unique",
   "is_virtual",
@@ -459,6 +461,18 @@
    "fieldname": "non_negative",
    "fieldtype": "Check",
    "label": "Non Negative"
+  },
+  {
+   "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
+   "fieldname": "min_value",
+   "fieldtype": "Float",
+   "label": "Min Value"
+  },
+  {
+   "depends_on": "eval:in_list([\"Int\", \"Float\", \"Currency\", \"Percent\"], doc.fieldtype)",
+   "fieldname": "max_value",
+   "fieldtype": "Float",
+   "label": "Max Value"
   },
   {
    "default": "0",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.py
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.py
@@ -95,6 +95,8 @@ class CustomizeFormField(Document):
 		link_filters: DF.JSON | None
 		mandatory_depends_on: DF.Code | None
 		mask: DF.Check
+		max_value: DF.Float
+		min_value: DF.Float
 		no_copy: DF.Check
 		non_negative: DF.Check
 		options: DF.SmallText | None

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1153,7 +1153,11 @@ class Document(BaseDocument):
 			if not (min_value or max_value):
 				continue
 
-			value = flt(self.get(df.fieldname))
+			value = self.get(df.fieldname)
+			if value in (None, ""):
+				continue
+
+			value = flt(value)
 
 			if min_value and value < min_value:
 				msg = get_msg(df, _("Value cannot be less than {0} for").format(frappe.bold(min_value)))

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -30,7 +30,7 @@ from frappe.model.utils import is_virtual_doctype, simple_singledispatch
 from frappe.model.workflow import set_workflow_state_on_action, validate_workflow
 from frappe.types import DF
 from frappe.types.filter import FilterSignature
-from frappe.utils import compare, cstr, date_diff, file_lock, flt, get_table_name, now
+from frappe.utils import cint, compare, cstr, date_diff, file_lock, flt, get_table_name, now
 from frappe.utils.data import get_absolute_url, get_datetime, get_timedelta, getdate
 from frappe.utils.global_search import update_global_search
 
@@ -1077,6 +1077,7 @@ class Document(BaseDocument):
 		self._validate_data_fields()
 		self._validate_selects()
 		self._validate_non_negative()
+		self._validate_min_max_value()
 		self._validate_length()
 		self._fix_rating_value()
 		self._validate_code_fields()
@@ -1090,6 +1091,7 @@ class Document(BaseDocument):
 			d._validate_data_fields()
 			d._validate_selects()
 			d._validate_non_negative()
+			d._validate_min_max_value()
 			d._validate_length()
 			d._fix_rating_value()
 			d._validate_code_fields()
@@ -1125,6 +1127,41 @@ class Document(BaseDocument):
 			if flt(self.get(df.fieldname)) < 0:
 				msg = get_msg(df)
 				frappe.throw(msg, frappe.NonNegativeError, title=_("Negative Value"))
+
+	def _validate_min_max_value(self):
+		def get_msg(df, constraint):
+			if self.get("parentfield"):
+				return "{} {} #{}: {} {}".format(
+					frappe.bold(_(self.doctype)),
+					_("Row"),
+					self.idx,
+					constraint,
+					frappe.bold(_(df.label, context=df.parent)),
+				)
+			else:
+				return "{} {}: {}".format(
+					constraint, _(df.parent), frappe.bold(_(df.label, context=df.parent))
+				)
+
+		for df in self.meta.get("fields", {"fieldtype": ("in", ["Int", "Float", "Currency", "Percent"])}):
+			min_value = flt(df.get("min_value"))
+			max_value = flt(df.get("max_value"))
+
+			if df.fieldtype == "Int":
+				min_value, max_value = cint(min_value), cint(max_value)
+
+			if not (min_value or max_value):
+				continue
+
+			value = flt(self.get(df.fieldname))
+
+			if min_value and value < min_value:
+				msg = get_msg(df, _("Value cannot be less than {0} for").format(frappe.bold(min_value)))
+				frappe.throw(msg, title=_("Value Too Small"))
+
+			if max_value and value > max_value:
+				msg = get_msg(df, _("Value cannot be more than {0} for").format(frappe.bold(max_value)))
+				frappe.throw(msg, title=_("Value Too Large"))
 
 	def _fix_rating_value(self):
 		for field in self.meta.get("fields", {"fieldtype": "Rating"}):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1161,11 +1161,11 @@ class Document(BaseDocument):
 
 			if min_value and value < min_value:
 				msg = get_msg(df, _("Value cannot be less than {0} for").format(frappe.bold(min_value)))
-				frappe.throw(msg, title=_("Value Too Small"))
+				frappe.throw(msg, title=_("Value is too small"))
 
 			if max_value and value > max_value:
 				msg = get_msg(df, _("Value cannot be more than {0} for").format(frappe.bold(max_value)))
-				frappe.throw(msg, title=_("Value Too Large"))
+				frappe.throw(msg, title=_("Value is too large"))
 
 	def _fix_rating_value(self):
 		for field in self.meta.get("fields", {"fieldtype": "Rating"}):

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -347,6 +347,27 @@ class TestDocument(IntegrationTestCase):
 
 		frappe.delete_doc_if_exists("Currency", "Frappe Coin", 1)
 
+	def test_min_max_value_check(self):
+		doctype = new_doctype(
+			fields=[
+				{
+					"fieldname": "qty",
+					"fieldtype": "Int",
+					"label": "Qty",
+					"min_value": 5,
+					"max_value": 10,
+				}
+			]
+		).insert()
+
+		try:
+			self.assertRaises(frappe.ValidationError, frappe.get_doc(doctype=doctype.name, qty=3).insert)
+			self.assertRaises(frappe.ValidationError, frappe.get_doc(doctype=doctype.name, qty=12).insert)
+			frappe.get_doc(doctype=doctype.name, qty=7).insert()
+		finally:
+			doctype.delete(force=True)
+			frappe.db.commit()
+
 	def test_get_formatted(self):
 		frappe.get_doc(
 			{

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -364,6 +364,7 @@ class TestDocument(IntegrationTestCase):
 			self.assertRaises(frappe.ValidationError, frappe.get_doc(doctype=doctype.name, qty=3).insert)
 			self.assertRaises(frappe.ValidationError, frappe.get_doc(doctype=doctype.name, qty=12).insert)
 			frappe.get_doc(doctype=doctype.name, qty=7).insert()
+			frappe.get_doc(doctype=doctype.name).insert()
 		finally:
 			doctype.delete(force=True)
 

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -366,7 +366,6 @@ class TestDocument(IntegrationTestCase):
 			frappe.get_doc(doctype=doctype.name, qty=7).insert()
 		finally:
 			doctype.delete(force=True)
-			frappe.db.commit()
 
 	def test_get_formatted(self):
 		frappe.get_doc(


### PR DESCRIPTION
## Summary

Int, Float, Currency and Percent fields can now declare `min_value` and `max_value` from the DocType form, Custom Field and Customize Form. Values outside the range are rejected on save with a message naming the violated bound and the field.

Validation lives in `Document._validate_min_max_value`, next to the existing `_validate_non_negative` check, and runs for parent and child table rows. Customize Form persists the bounds as property setters like any other field property.

## Note

A bound set to `0` is treated as unset, since `0` is the column default for every existing field. A zero lower bound is already covered by `non_negative`.


https://github.com/user-attachments/assets/50aac995-64b0-484c-b1cf-9e2524a63a80


`#no-docs`

---
Closes #40116.