### PR TITLE
feat: surface data import failures in log files

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -234,8 +234,8 @@ def start_import(data_import):
 	except Exception:
 		frappe.db.rollback()
 		data_import.db_set("status", "Error")
-		frappe.logger("data_import").error(f"Data import {data_import.name} failed", exc_info=True)
 		data_import.log_error("Data import failed")
+		frappe.logger("data_import").error(f"Data import {data_import.name} failed", exc_info=True)
 	finally:
 		frappe.flags.in_import = False
 

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -234,6 +234,7 @@ def start_import(data_import):
 	except Exception:
 		frappe.db.rollback()
 		data_import.db_set("status", "Error")
+		frappe.logger("data_import").error(f"Data import {data_import.name} failed", exc_info=True)
 		data_import.log_error("Data import failed")
 	finally:
 		frappe.flags.in_import = False

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -235,7 +235,10 @@ def start_import(data_import):
 		frappe.db.rollback()
 		data_import.db_set("status", "Error")
 		data_import.log_error("Data import failed")
-		frappe.logger("data_import").error(f"Data import {data_import.name} failed", exc_info=True)
+		try:
+			frappe.logger("data_import").error(f"Data import {data_import.name} failed", exc_info=True)
+		except Exception:
+			pass
 	finally:
 		frappe.flags.in_import = False
 

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -262,6 +262,10 @@ class Importer:
 					frappe.db.commit()
 
 				except Exception:
+					frappe.logger("data_import").error(
+						f"Data Import {self.data_import.name}: row(s) {row_indexes} failed to import",
+						exc_info=True,
+					)
 					messages = frappe.local.message_log
 					frappe.clear_messages()
 
@@ -307,6 +311,9 @@ class Importer:
 			status = "Error"
 		elif len(failures) > 0 and len(successes) > 0:
 			status = "Partial Success"
+			frappe.logger("data_import").warning(
+				f"Data Import {self.data_import.name}: {len(failures)} of {attempted_payload_count} rows failed"
+			)
 		else:
 			status = "Pending"
 

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -281,10 +281,13 @@ class Importer:
 
 					log_index += 1
 
-					frappe.logger("data_import").error(
-						f"Data Import {self.data_import.name}: row(s) {row_indexes} failed to import",
-						exc_info=True,
-					)
+					try:
+						frappe.logger("data_import").error(
+							f"Data Import {self.data_import.name}: row(s) {row_indexes} failed to import",
+							exc_info=True,
+						)
+					except Exception:
+						pass
 
 		# Logs are db inserted directly so will have to be fetched again
 		import_log = (
@@ -312,9 +315,12 @@ class Importer:
 			status = "Error"
 		elif len(failures) > 0 and len(successes) > 0:
 			status = "Partial Success"
-			frappe.logger("data_import").warning(
-				f"Data Import {self.data_import.name}: {len(failures)} of {attempted_payload_count} rows failed"
-			)
+			try:
+				frappe.logger("data_import").warning(
+					f"Data Import {self.data_import.name}: {len(failures)} of {attempted_payload_count} rows failed"
+				)
+			except Exception:
+				pass
 		else:
 			status = "Pending"
 

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -262,10 +262,6 @@ class Importer:
 					frappe.db.commit()
 
 				except Exception:
-					frappe.logger("data_import").error(
-						f"Data Import {self.data_import.name}: row(s) {row_indexes} failed to import",
-						exc_info=True,
-					)
 					messages = frappe.local.message_log
 					frappe.clear_messages()
 
@@ -284,6 +280,11 @@ class Importer:
 					)
 
 					log_index += 1
+
+					frappe.logger("data_import").error(
+						f"Data Import {self.data_import.name}: row(s) {row_indexes} failed to import",
+						exc_info=True,
+					)
 
 		# Logs are db inserted directly so will have to be fetched again
 		import_log = (

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -187,6 +187,14 @@ class TestImporter(IntegrationTestCase):
 			"Title is required",
 		)
 
+	def test_row_failure_is_logged_to_logger(self):
+		import_file = get_import_file("sample_import_file_without_mandatory")
+		data_import = self.get_importer(doctype_name, import_file)
+		frappe.clear_messages()
+		with self.assertLogs(frappe.logger("data_import"), level="ERROR") as captured:
+			data_import.start_import()
+		self.assertTrue(any("failed to import" in message for message in captured.output))
+
 	def test_data_import_update(self):
 		existing_doc = frappe.get_doc(
 			doctype=doctype_name,


### PR DESCRIPTION
Data Import failures currently only reach database-backed logs: row-level errors go to Data Import Log, while crashed background jobs are recorded in Error Log via `log_error()`. Nothing is written to `frappe.logger()`, so `frappe.log`, `worker.log`, and external log aggregation receive no signal when imports fail.

This adds `frappe.logger("data_import")` calls to the existing exception handlers without changing the current Data Import Log or Error Log behavior. Row failures are logged at `ERROR` with a traceback, crashed jobs are logged at `ERROR` alongside `log_error()`, and partial-success runs emit a one-line `WARNING` summary.

`#no-docs`

---

Closes #40374.