### PR TITLE
fix: guard against None table field in load_doc_before_save

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1829,7 +1829,7 @@ class Document(BaseDocument):
 			return frappe.clear_last_message()
 
 		for fieldname in self._non_computed_table_fieldnames:
-			for row in self.get(fieldname):
+			for row in self.get(fieldname) or []:
 				row._doc_before_save = next(
 					(d for d in (self._doc_before_save.get(fieldname) or []) if d.name == row.name), None
 				)


### PR DESCRIPTION
## Description

`load_doc_before_save` iterates over child table fields using `self.get(fieldname)`, which can raise a `TypeError` if the field is `None`.

The next line already guards the equivalent access with `or []`, but this iteration didn't. This change makes the behavior consistent by defaulting to an empty list when the field is `None`.

I couldn't reproduce the original issue on current `develop`, but this closes the gap and prevents the same failure in code paths where a child table field can still be `None`.

---
Closes #39311.