### PR TITLE
fix: prevent broken pipe from aborting dashboard sync during setup

### DIFF
--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -87,7 +87,10 @@ def sync_dashboards(app=None):
 	apps = [app] if app else frappe.get_installed_apps()
 
 	for app_name in apps:
-		print(f"Updating Dashboard for {app_name}")
+		try:
+			print(f"Updating Dashboard for {app_name}")
+		except BrokenPipeError:
+			pass
 		for module_name in frappe.local.app_modules.get(app_name) or []:
 			frappe.flags.in_import = True
 			make_records_in_module(app_name, module_name)


### PR DESCRIPTION
## Description

Prevents a `BrokenPipeError` from aborting `sync_dashboards` during the Setup Wizard.

The progress `print` can fail when stdout is no longer available (for example, if the web worker's connection is closed). 
This change makes the progress output best-effort so a failed `print` doesn't interrupt dashboard synchronization, while preserving CLI output.

---
Closes #38017.