### PR TITLE
fix: postgres GroupingError when filtering list views by child-table fields

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1271,10 +1271,47 @@ class Engine:
 
 	def apply_group_by(self, group_by: str | None = None):
 		parsed_group_by_fields = self._validate_group_by(group_by)
+		if self._is_main_table_pk_group_by(parsed_group_by_fields):
+			parsed_group_by_fields += self._joined_link_table_pks()
 		self._grouped_queries = {
 			f.get_sql() if hasattr(f, "get_sql") else str(f) for f in parsed_group_by_fields
 		}
 		self.query = self.query.groupby(*parsed_group_by_fields)
+
+	def _is_main_table_pk_group_by(self, parsed_fields: list) -> bool:
+		"""Group by on just the parent primary key — the dedup form list views send
+		along with child-table filters."""
+		if len(parsed_fields) != 1:
+			return False
+		field = parsed_fields[0]
+		return (
+			isinstance(field, Field)
+			and field.name == "name"
+			and (field.table is None or field.table == self.table)
+		)
+
+	def _joined_link_table_pks(self) -> list[Field]:
+		"""Primary keys of 1:1 joined link tables.
+
+		When deduping by the parent primary key, grouping additionally by each link
+		table's primary key cannot change the result (at most one link row per
+		parent) but satisfies postgres' functional-dependency rule for the link
+		table's selected columns, e.g. title fields fetched for
+		`show_title_field_in_link` (GH-39851). Child tables (istable) are excluded:
+		grouping by their primary key would undo the dedup.
+		"""
+		pks = []
+		for join in self.query._joins:
+			table = join.item
+			if not isinstance(table, Table):
+				continue
+			try:
+				meta = frappe.get_meta(get_doctype_name(table.get_sql()))
+			except frappe.DoesNotExistError:
+				continue
+			if not meta.istable:
+				pks.append(table["name"])
+		return pks
 
 	def apply_order_by(self, order_by: str | None):
 		if not order_by or order_by == DefaultOrderBy:

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -265,6 +265,7 @@ class Engine:
 		self.permitted_fields_cache = {}  # Cache for get_permitted_fields results
 		self.is_aggregate_query = False
 		self._grouped_queries = set()
+		self._joined_link_tables = []
 
 		assert db_type in ("mariadb", "postgres", "sqlite"), f"unexpected db_type: {db_type}"
 
@@ -1271,7 +1272,7 @@ class Engine:
 
 	def apply_group_by(self, group_by: str | None = None):
 		parsed_group_by_fields = self._validate_group_by(group_by)
-		if self._is_main_table_pk_group_by(parsed_group_by_fields):
+		if self.is_postgres and self._is_main_table_pk_group_by(parsed_group_by_fields):
 			parsed_group_by_fields += self._joined_link_table_pks()
 		self._grouped_queries = {
 			f.get_sql() if hasattr(f, "get_sql") else str(f) for f in parsed_group_by_fields
@@ -1291,27 +1292,16 @@ class Engine:
 		)
 
 	def _joined_link_table_pks(self) -> list[Field]:
-		"""Primary keys of 1:1 joined link tables.
+		"""Primary keys of 1:1 joined link tables, recorded by LinkTableField.apply_join.
 
 		When deduping by the parent primary key, grouping additionally by each link
 		table's primary key cannot change the result (at most one link row per
 		parent) but satisfies postgres' functional-dependency rule for the link
 		table's selected columns, e.g. title fields fetched for
-		`show_title_field_in_link` (GH-39851). Child tables (istable) are excluded:
+		`show_title_field_in_link` (GH-39851). Child table joins are not recorded:
 		grouping by their primary key would undo the dedup.
 		"""
-		pks = []
-		for join in self.query._joins:
-			table = join.item
-			if not isinstance(table, Table):
-				continue
-			try:
-				meta = frappe.get_meta(get_doctype_name(table.get_sql()))
-			except frappe.DoesNotExistError:
-				continue
-			if not meta.istable:
-				pks.append(table["name"])
-		return pks
+		return [table["name"] for table in self._joined_link_tables]
 
 	def apply_order_by(self, order_by: str | None):
 		if not order_by or order_by == DefaultOrderBy:
@@ -2195,6 +2185,8 @@ class LinkTableField(DynamicTableField):
 					clause &= condition
 
 			query = query.left_join(table).on(clause)
+			if engine is not None:
+				engine._joined_link_tables.append(table)
 
 		return query
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -81,6 +81,7 @@ class DatabaseQuery:
 		self.conditions = []
 		self.or_conditions = []
 		self.fields = None
+		self.join = "left join"
 		self.user = user or frappe.session.user
 		self.ignore_ifnull = False
 		self.flags = frappe._dict()
@@ -88,6 +89,7 @@ class DatabaseQuery:
 		self.permission_map = {}
 		self.shared = []
 		self._fetch_shared_documents = False
+		self._child_filters_via_exists = False
 		self._metas = {}
 
 	@cached_property
@@ -321,6 +323,8 @@ from {tables}
 		self.extract_tables()
 		self.set_optional_columns()
 		self.build_conditions()
+		# decided before cast_name_fields wraps name columns in cast() on postgres
+		drop_dedup_group_by = self._is_redundant_dedup_group_by()
 		self.apply_fieldlevel_read_permissions()
 
 		args = frappe._dict()
@@ -384,10 +388,26 @@ from {tables}
 		self.validate_order_by_and_group_by(args.order_by)
 		args.order_by = (args.order_by and (" order by " + args.order_by)) or ""
 
+		if drop_dedup_group_by:
+			# list views send group_by=parent primary key to dedup child-table join
+			# rows; once child filters use exists() nothing multiplies rows, and
+			# keeping it breaks postgres when fields include columns from joined
+			# link tables (show_title_field_in_link)
+			self.group_by = None
+
 		self.validate_order_by_and_group_by(self.group_by)
 		args.group_by = (self.group_by and (" group by " + self.group_by)) or ""
 
 		return args
+
+	def _is_redundant_dedup_group_by(self) -> bool:
+		if not (self.group_by and self._child_filters_via_exists and len(self.tables) == 1):
+			return False
+		if any("(" in (field or "") for field in self.fields):
+			# aggregates change meaning without group by, keep it
+			return False
+		group_by = self.group_by.replace("`", "").replace('"', "").strip()
+		return group_by in (f"tab{self.doctype}.name", "name")
 
 	def prepare_select_args(self, args):
 		order_field = ORDER_BY_PATTERN.sub("", args.order_by)
@@ -668,14 +688,79 @@ from {tables}
 	def build_conditions(self):
 		self.conditions = []
 		self.grouped_or_conditions = []
-		self.build_filter_conditions(self.filters, self.conditions)
-		self.build_filter_conditions(self.or_filters, self.grouped_or_conditions)
+
+		filters, exists_groups = self._split_child_table_filters(self.filters)
+		or_filters, or_exists_groups = self._split_child_table_filters(self.or_filters)
+
+		# a child table filtered in both filters and or_filters keeps the legacy
+		# join: both groups must test the same joined child row
+		for doctype in exists_groups.keys() & or_exists_groups.keys():
+			filters.extend(exists_groups.pop(doctype))
+			or_filters.extend(or_exists_groups.pop(doctype))
+
+		self._child_filters_via_exists = bool(exists_groups or or_exists_groups)
+
+		self.build_filter_conditions(filters, self.conditions)
+		for doctype, group in exists_groups.items():
+			self.conditions.append(self.prepare_exists_condition(doctype, group))
+
+		self.build_filter_conditions(or_filters, self.grouped_or_conditions)
+		for doctype, group in or_exists_groups.items():
+			self.grouped_or_conditions.append(self.prepare_exists_condition(doctype, group, any_match=True))
 
 		# match conditions
 		if not self.flags.ignore_permissions:
 			match_conditions = self.build_match_conditions()
 			if match_conditions:
 				self.conditions.append(f"({match_conditions})")
+
+	def _split_child_table_filters(self, filters: Filters) -> tuple[list, dict[str, list]]:
+		"""Separate filters on child tables that are not part of the query itself.
+
+		These filter through an exists() subquery instead of a join, so the outer
+		query needs no `group by` to deduplicate parents. Return the remaining
+		filters and the exists candidates grouped by child doctype.
+		"""
+		from frappe.boot import get_additional_filters_from_hooks
+
+		joined: list = []
+		exists_groups: dict[str, list] = {}
+		if not filters:
+			return joined, exists_groups
+
+		additional_filters_config = get_additional_filters_from_hooks()
+		for ft in filters:
+			f = get_filter(self.doctype, ft, additional_filters_config)
+			if (
+				self.join == "left join"
+				and f.doctype
+				and f.doctype != self.doctype
+				and f"`tab{f.doctype}`" not in self.tables
+				and self.get_meta(f.doctype).istable
+			):
+				exists_groups.setdefault(f.doctype, []).append(ft)
+			else:
+				joined.append(ft)
+		return joined, exists_groups
+
+	def prepare_exists_condition(self, child_doctype: str, filters: list, any_match=False) -> str:
+		"""Return an exists() condition that filters by a child table without joining it.
+
+		The child table is left joined to a one-row derived table, so a parent with
+		no child rows is tested against a single all-NULL child row — exactly like
+		the outer left join this replaces (filters like "is not set" must match
+		parents without child rows).
+		"""
+		self.check_read_permission(child_doctype, parent_doctype=self.doctype)
+		child_table = f"`tab{child_doctype}`"
+		joiner = " or " if any_match else " and "
+		conditions = joiner.join(self.prepare_filter_condition(f, skip_join=True) for f in filters)
+		parent_name = cast_name(f"{self.tables[0]}.name")
+		return (
+			f"exists (select 1 from (select 1) as `_one_row` "
+			f"left join {child_table} on ({child_table}.parenttype = {frappe.db.escape(self.doctype)} "
+			f"and {child_table}.parent = {parent_name}) where {conditions})"
+		)
 
 	def build_filter_conditions(self, filters: Filters, conditions: list, ignore_permissions=None):
 		"""build conditions from user filters"""
@@ -791,7 +876,7 @@ from {tables}
 			else:
 				self.remove_field(i)
 
-	def prepare_filter_condition(self, ft: FilterTuple) -> str:
+	def prepare_filter_condition(self, ft: FilterTuple, *, skip_join: bool = False) -> str:
 		"""Return a filter condition in the format:
 
 		ifnull(`tabDocType`.`fieldname`, fallback) operator "value"
@@ -805,7 +890,7 @@ from {tables}
 		f: FilterTuple = get_filter(self.doctype, ft, additional_filters_config)
 
 		tname = "`tab" + f.doctype + "`"
-		if tname not in self.tables:
+		if not skip_join and tname not in self.tables:
 			self.append_table(tname)
 
 		column_name = cast_name(f.fieldname if "ifnull(" in f.fieldname else f"{tname}.`{f.fieldname}`")

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -398,18 +398,32 @@ from {tables}
 			self.group_by = None
 
 		self.validate_order_by_and_group_by(self.group_by)
-		args.group_by = (self.group_by and (" group by " + self.group_by)) or ""
+		args.group_by = (self.group_by and (" group by " + self._group_by_with_link_table_pks())) or ""
 
 		return args
 
 	def _is_redundant_dedup_group_by(self) -> bool:
-		if not (self.group_by and self._child_filters_via_exists and len(self.tables) == 1):
+		if not (self._child_filters_via_exists and len(self.tables) == 1):
 			return False
 		if any("(" in (field or "") for field in self.fields):
 			# aggregates change meaning without group by, keep it
 			return False
+		return self._is_dedup_group_by()
+
+	def _is_dedup_group_by(self) -> bool:
+		if not self.group_by:
+			return False
 		group_by = self.group_by.replace("`", "").replace('"', "").strip()
 		return group_by in (f"tab{self.doctype}.name", "name")
+
+	def _group_by_with_link_table_pks(self) -> str:
+		"""When a dedup group by survives (e.g. a child table stays joined), the
+		selected columns of 1:1 joined link tables are not functionally dependent
+		on the parent primary key for postgres; grouping additionally by each link
+		table's primary key covers them without changing partitions."""
+		if not (self.link_tables and frappe.db.db_type == "postgres" and self._is_dedup_group_by()):
+			return self.group_by
+		return ", ".join([self.group_by, *(f"{link.table_alias}.`name`" for link in self.link_tables)])
 
 	def prepare_select_args(self, args):
 		order_field = ORDER_BY_PATTERN.sub("", args.order_by)
@@ -702,11 +716,13 @@ from {tables}
 
 		self._child_filters_via_exists = bool(exists_groups or or_exists_groups)
 
-		self.build_filter_conditions(filters, self.conditions)
+		for ft, parsed in filters:
+			self.conditions.append(self.prepare_filter_condition(ft, parsed=parsed))
 		for doctype, group in exists_groups.items():
 			self.conditions.append(self.prepare_exists_condition(doctype, group))
 
-		self.build_filter_conditions(or_filters, self.grouped_or_conditions)
+		for ft, parsed in or_filters:
+			self.grouped_or_conditions.append(self.prepare_filter_condition(ft, parsed=parsed))
 		for doctype, group in or_exists_groups.items():
 			self.grouped_or_conditions.append(self.prepare_exists_condition(doctype, group, any_match=True))
 
@@ -721,7 +737,8 @@ from {tables}
 
 		These filter through an exists() subquery instead of a join, so the outer
 		query needs no `group by` to deduplicate parents. Return the remaining
-		filters and the exists candidates grouped by child doctype.
+		filters and the exists candidates grouped by child doctype, both as
+		(filter, parsed filter) pairs so no filter is parsed twice.
 		"""
 		from frappe.boot import get_additional_filters_from_hooks
 
@@ -730,7 +747,7 @@ from {tables}
 		if not filters:
 			return joined, exists_groups
 		if not self._can_filter_via_exists():
-			return list(filters), exists_groups
+			return [(ft, None) for ft in filters], exists_groups
 
 		additional_filters_config = get_additional_filters_from_hooks()
 		for ft in filters:
@@ -743,9 +760,9 @@ from {tables}
 				and f"`tab{f.doctype}`" not in (self.order_by or "")
 				and self.get_meta(f.doctype).istable
 			):
-				exists_groups.setdefault(f.doctype, []).append(ft)
+				exists_groups.setdefault(f.doctype, []).append((ft, f))
 			else:
-				joined.append(ft)
+				joined.append((ft, f))
 		return joined, exists_groups
 
 	def _can_filter_via_exists(self) -> bool:
@@ -770,7 +787,9 @@ from {tables}
 		self.check_read_permission(child_doctype, parent_doctype=self.doctype)
 		child_table = f"`tab{child_doctype}`"
 		joiner = " or " if any_match else " and "
-		conditions = joiner.join(self.prepare_filter_condition(f, skip_join=True) for f in filters)
+		conditions = joiner.join(
+			self.prepare_filter_condition(ft, skip_join=True, parsed=parsed) for ft, parsed in filters
+		)
 		return (
 			f"exists (select 1 from (select 1) as `_one_row` "
 			f"left join {child_table} on ({self._child_join_condition(child_table)}) where {conditions})"
@@ -894,7 +913,7 @@ from {tables}
 			else:
 				self.remove_field(i)
 
-	def prepare_filter_condition(self, ft: FilterTuple, *, skip_join: bool = False) -> str:
+	def prepare_filter_condition(self, ft: FilterTuple, *, skip_join: bool = False, parsed=None) -> str:
 		"""Return a filter condition in the format:
 
 		ifnull(`tabDocType`.`fieldname`, fallback) operator "value"
@@ -905,7 +924,9 @@ from {tables}
 		from frappe.boot import get_additional_filters_from_hooks
 
 		additional_filters_config = get_additional_filters_from_hooks()
-		f: FilterTuple = get_filter(self.doctype, ft, additional_filters_config)
+		f: FilterTuple = (
+			parsed if parsed is not None else get_filter(self.doctype, ft, additional_filters_config)
+		)
 
 		tname = "`tab" + f.doctype + "`"
 		if not skip_join and tname not in self.tables:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -82,6 +82,9 @@ class DatabaseQuery:
 		self.or_conditions = []
 		self.fields = None
 		self.join = "left join"
+		self.order_by = None
+		self.group_by = None
+		self.with_childnames = False
 		self.user = user or frappe.session.user
 		self.ignore_ifnull = False
 		self.flags = frappe._dict()
@@ -340,8 +343,7 @@ from {tables}
 
 		# left join parent, child tables
 		for child in self.tables[1:]:
-			parent_name = cast_name(f"{self.tables[0]}.name")
-			args.tables += f" {self.join} {child} on ({child}.parenttype = {frappe.db.escape(self.doctype)} and {child}.parent = {parent_name})"
+			args.tables += f" {self.join} {child} on ({self._child_join_condition(child)})"
 
 		# left join link tables
 		for link in self.link_tables:
@@ -727,21 +729,35 @@ from {tables}
 		exists_groups: dict[str, list] = {}
 		if not filters:
 			return joined, exists_groups
+		if not self._can_filter_via_exists():
+			return list(filters), exists_groups
 
 		additional_filters_config = get_additional_filters_from_hooks()
 		for ft in filters:
 			f = get_filter(self.doctype, ft, additional_filters_config)
 			if (
-				self.join == "left join"
-				and f.doctype
+				f.doctype
 				and f.doctype != self.doctype
 				and f"`tab{f.doctype}`" not in self.tables
+				and f"`tab{f.doctype}`" not in (self.group_by or "")
+				and f"`tab{f.doctype}`" not in (self.order_by or "")
 				and self.get_meta(f.doctype).istable
 			):
 				exists_groups.setdefault(f.doctype, []).append(ft)
 			else:
 				joined.append(ft)
 		return joined, exists_groups
+
+	def _can_filter_via_exists(self) -> bool:
+		if self.join != "left join" or self.with_childnames:
+			return False
+		if any("(" in (field or "") for field in self.fields or []):
+			return False
+		if self.order_by and self.order_by != DefaultOrderBy and "(" in self.order_by:
+			return False
+		if self.flags.ignore_permissions:
+			return True
+		return not get_server_script_map().get("permission_query", {}).get(self.doctype)
 
 	def prepare_exists_condition(self, child_doctype: str, filters: list, any_match=False) -> str:
 		"""Return an exists() condition that filters by a child table without joining it.
@@ -755,12 +771,14 @@ from {tables}
 		child_table = f"`tab{child_doctype}`"
 		joiner = " or " if any_match else " and "
 		conditions = joiner.join(self.prepare_filter_condition(f, skip_join=True) for f in filters)
-		parent_name = cast_name(f"{self.tables[0]}.name")
 		return (
 			f"exists (select 1 from (select 1) as `_one_row` "
-			f"left join {child_table} on ({child_table}.parenttype = {frappe.db.escape(self.doctype)} "
-			f"and {child_table}.parent = {parent_name}) where {conditions})"
+			f"left join {child_table} on ({self._child_join_condition(child_table)}) where {conditions})"
 		)
+
+	def _child_join_condition(self, child_table: str) -> str:
+		parent_name = cast_name(f"`tab{self.doctype}`.name")
+		return f"{child_table}.parenttype = {frappe.db.escape(self.doctype)} and {child_table}.parent = {parent_name}"
 
 	def build_filter_conditions(self, filters: Filters, conditions: list, ignore_permissions=None):
 		"""build conditions from user filters"""

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -182,6 +182,168 @@ class TestDBQuery(IntegrationTestCase):
 		self.assertIn("parent 1 child record 2", parent1_children)
 		self.assertEqual(results2[0].child_title, "parent 2 child record 1")
 
+	def make_note(self, seen_by=None):
+		note = frappe.get_doc(
+			doctype="Note",
+			title=f"test exists filter {frappe.generate_hash(length=8)}",
+			content="test",
+			seen_by=[{"user": user} for user in (seen_by or [])],
+		).insert()
+		self.addCleanup(note.delete)
+		return note
+
+	def test_child_table_filter_uses_exists(self):
+		"""Filter-only child tables filter via exists() — no join, no group by needed."""
+		note = self.make_note(seen_by=["Administrator"])
+
+		result = frappe.get_all(
+			"Note",
+			filters=[["Note Seen By", "user", "=", "Administrator"]],
+			fields=["name", "title"],
+		)
+		self.assertIn(note.name, [r.name for r in result])
+
+		query = DatabaseQuery("Note")
+		sql = query.execute(
+			filters=[["Note Seen By", "user", "=", "Administrator"]], fields=["name", "title"], run=0
+		)
+		self.assertEqual(query.tables, ["`tabNote`"])
+		self.assertIn("exists (", sql)
+
+		# the dedup group by sent by list views is dropped once nothing multiplies rows
+		sql = DatabaseQuery("Note").execute(
+			filters=[["Note Seen By", "user", "=", "Administrator"]],
+			fields=["name", "title"],
+			group_by="`tabNote`.`name`",
+			run=0,
+		)
+		self.assertNotIn("group by", sql)
+
+	def test_child_table_filter_with_link_field_fetch(self):
+		"""Full list view repro of GH-39851: child-table filter + link table column in
+		fields (show_title_field_in_link) + dedup group by. Raised GroupingError on
+		PostgreSQL when the group by survived alongside the link table column."""
+		# live engine (frappe.model.qb_query via get_all)
+		result = frappe.get_all(
+			"User",
+			filters=[["Has Role", "role", "=", "System Manager"]],
+			fields=["name", "language.language_name as language_title"],
+			group_by="`tabUser`.`name`",
+			order_by="`tabUser`.`modified` desc",
+		)
+		self.assertIn("Administrator", [r.name for r in result])
+
+		# legacy engine
+		result = DatabaseQuery("User").execute(
+			filters=[["Has Role", "role", "=", "System Manager"]],
+			fields=["name", "language.language_name as language_title"],
+			group_by="`tabUser`.`name`",
+			order_by="`tabUser`.`modified` desc",
+		)
+		self.assertIn("Administrator", [r.name for r in result])
+
+	def test_child_table_filter_matches_parents_without_child_rows(self):
+		"""Parents with no child rows must keep matching "empty" style filters,
+		exactly like the left join these filters used before."""
+		childless = self.make_note()
+		seen = self.make_note(seen_by=["Administrator"])
+
+		result = frappe.get_all("Note", filters=[["Note Seen By", "user", "is", "not set"]], pluck="name")
+		self.assertIn(childless.name, result)
+		self.assertNotIn(seen.name, result)
+
+		result = frappe.get_all(
+			"Note", filters=[["Note Seen By", "user", "!=", "Administrator"]], pluck="name"
+		)
+		self.assertIn(childless.name, result)
+		self.assertNotIn(seen.name, result)
+
+		result = frappe.get_all(
+			"Note", filters=[["Note Seen By", "user", "=", "Administrator"]], pluck="name"
+		)
+		self.assertIn(seen.name, result)
+		self.assertNotIn(childless.name, result)
+
+	def test_child_table_filters_match_same_child_row(self):
+		"""Multiple filters on one child table must all match the same child row,
+		like they did against a single joined table."""
+		note = self.make_note(seen_by=["Administrator", "Guest"])
+
+		result = frappe.get_all(
+			"Note",
+			filters=[
+				["Note Seen By", "user", "=", "Administrator"],
+				["Note Seen By", "user", "=", "Guest"],
+			],
+			pluck="name",
+		)
+		self.assertNotIn(note.name, result)
+
+		result = frappe.get_all(
+			"Note",
+			filters=[
+				["Note Seen By", "user", "=", "Administrator"],
+				["Note Seen By", "user", "like", "Admin%"],
+			],
+			pluck="name",
+		)
+		self.assertIn(note.name, result)
+
+	def test_child_table_or_filters_via_exists(self):
+		note = self.make_note(seen_by=["Administrator"])
+
+		result = frappe.get_all(
+			"Note",
+			filters={"name": note.name},
+			or_filters=[
+				["Note Seen By", "user", "=", "Administrator"],
+				["Note Seen By", "user", "=", "some-nonexistent-user"],
+			],
+			pluck="name",
+		)
+		self.assertEqual(result, [note.name])
+
+		query = DatabaseQuery("Note")
+		query.execute(
+			filters={"name": note.name},
+			or_filters=[["Note Seen By", "user", "=", "Administrator"]],
+			fields=["name"],
+			run=0,
+		)
+		self.assertEqual(query.tables, ["`tabNote`"])
+
+	def test_child_table_filter_in_both_filter_groups_uses_join(self):
+		"""A child table filtered in both filters and or_filters keeps the legacy
+		join so that both groups test the same joined child row."""
+		query = DatabaseQuery("Note")
+		sql = query.execute(
+			filters=[["Note Seen By", "user", "=", "Administrator"]],
+			or_filters=[["Note Seen By", "user", "=", "Guest"]],
+			fields=["name"],
+			run=0,
+		)
+		self.assertIn("`tabNote Seen By`", query.tables)
+		self.assertNotIn("exists (", sql)
+
+	def test_child_table_in_fields_still_uses_join(self):
+		"""A child table that is selected stays joined; its filters apply to the join."""
+		note = self.make_note(seen_by=["Administrator"])
+
+		result = frappe.get_all(
+			"Note",
+			filters=[["Note Seen By", "user", "=", "Administrator"]],
+			fields=["name", "`tabNote Seen By`.user as seen_user"],
+		)
+		self.assertIn(note.name, [r.name for r in result])
+
+		query = DatabaseQuery("Note")
+		query.execute(
+			filters=[["Note Seen By", "user", "=", "Administrator"]],
+			fields=["name", "`tabNote Seen By`.user"],
+			run=0,
+		)
+		self.assertIn("`tabNote Seen By`", query.tables)
+
 	def test_link_field_syntax(self):
 		todo = frappe.get_doc(doctype="ToDo", description="Test ToDo", allocated_to="Administrator").insert()
 		result = frappe.get_all(

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -192,6 +192,16 @@ class TestDBQuery(IntegrationTestCase):
 		self.addCleanup(note.delete)
 		return note
 
+	def assert_note_filter_results(self, filters, includes=(), excludes=(), or_filters=None):
+		for result in (
+			frappe.get_all("Note", filters=filters, or_filters=or_filters, pluck="name"),
+			DatabaseQuery("Note").execute(filters=filters, or_filters=or_filters, pluck="name"),
+		):
+			for name in includes:
+				self.assertIn(name, result)
+			for name in excludes:
+				self.assertNotIn(name, result)
+
 	def test_child_table_filter_uses_exists(self):
 		"""Filter-only child tables filter via exists() — no join, no group by needed."""
 		note = self.make_note(seen_by=["Administrator"])
@@ -248,27 +258,27 @@ class TestDBQuery(IntegrationTestCase):
 		childless = self.make_note()
 		seen = self.make_note(seen_by=["Administrator"])
 
-		result = frappe.get_all("Note", filters=[["Note Seen By", "user", "is", "not set"]], pluck="name")
-		self.assertIn(childless.name, result)
-		self.assertNotIn(seen.name, result)
-
-		result = frappe.get_all(
-			"Note", filters=[["Note Seen By", "user", "!=", "Administrator"]], pluck="name"
+		self.assert_note_filter_results(
+			[["Note Seen By", "user", "is", "not set"]], includes=[childless.name], excludes=[seen.name]
 		)
-		self.assertIn(childless.name, result)
-		self.assertNotIn(seen.name, result)
-
-		result = frappe.get_all(
-			"Note", filters=[["Note Seen By", "user", "=", "Administrator"]], pluck="name"
+		self.assert_note_filter_results(
+			[["Note Seen By", "user", "!=", "Administrator"]],
+			includes=[childless.name],
+			excludes=[seen.name],
 		)
-		self.assertIn(seen.name, result)
-		self.assertNotIn(childless.name, result)
+		self.assert_note_filter_results(
+			[["Note Seen By", "user", "=", "Administrator"]],
+			includes=[seen.name],
+			excludes=[childless.name],
+		)
 
 	def test_child_table_filters_match_same_child_row(self):
 		"""Multiple filters on one child table must all match the same child row,
 		like they did against a single joined table."""
 		note = self.make_note(seen_by=["Administrator", "Guest"])
 
+		# legacy engine not asserted here: Filters normalization coalesces the two
+		# `=` filters into one `in` filter before they reach the query
 		result = frappe.get_all(
 			"Note",
 			filters=[
@@ -279,15 +289,20 @@ class TestDBQuery(IntegrationTestCase):
 		)
 		self.assertNotIn(note.name, result)
 
-		result = frappe.get_all(
-			"Note",
-			filters=[
+		self.assert_note_filter_results(
+			[
 				["Note Seen By", "user", "=", "Administrator"],
 				["Note Seen By", "user", "like", "Admin%"],
 			],
-			pluck="name",
+			includes=[note.name],
 		)
-		self.assertIn(note.name, result)
+		self.assert_note_filter_results(
+			[
+				["Note Seen By", "user", "!=", "Guest"],
+				["Note Seen By", "user", "like", "Admin%"],
+			],
+			includes=[note.name],
+		)
 
 	def test_child_table_or_filters_via_exists(self):
 		note = self.make_note(seen_by=["Administrator"])
@@ -311,6 +326,16 @@ class TestDBQuery(IntegrationTestCase):
 			run=0,
 		)
 		self.assertEqual(query.tables, ["`tabNote`"])
+
+		result = DatabaseQuery("Note").execute(
+			filters={"name": note.name},
+			or_filters=[
+				["Note Seen By", "user", "=", "Administrator"],
+				["Note Seen By", "user", "=", "some-nonexistent-user"],
+			],
+			pluck="name",
+		)
+		self.assertEqual(result, [note.name])
 
 	def test_child_table_filter_in_both_filter_groups_uses_join(self):
 		"""A child table filtered in both filters and or_filters keeps the legacy
@@ -343,6 +368,71 @@ class TestDBQuery(IntegrationTestCase):
 			run=0,
 		)
 		self.assertIn("`tabNote Seen By`", query.tables)
+
+	def test_child_table_filter_with_aggregate_field_keeps_join(self):
+		note = self.make_note(seen_by=["Administrator", "Guest"])
+
+		query = DatabaseQuery("Note")
+		result = query.execute(
+			filters=[
+				["Note", "name", "=", note.name],
+				["Note Seen By", "user", "in", ["Administrator", "Guest"]],
+			],
+			fields=["count(`tabNote Seen By`.`name`) as seen_count"],
+		)
+		self.assertIn("`tabNote Seen By`", query.tables)
+		self.assertEqual(result[0].seen_count, 2)
+
+	def test_child_table_filter_with_child_order_by_keeps_join(self):
+		note = self.make_note(seen_by=["Administrator"])
+
+		query = DatabaseQuery("Note")
+		result = query.execute(
+			filters=[["Note", "name", "=", note.name], ["Note Seen By", "user", "=", "Administrator"]],
+			fields=["name"],
+			order_by="`tabNote Seen By`.`user` asc",
+			pluck="name",
+		)
+		self.assertIn("`tabNote Seen By`", query.tables)
+		self.assertEqual(result, [note.name])
+
+		query = DatabaseQuery("Note")
+		query.execute(
+			filters=[["Note Seen By", "user", "=", "Administrator"]],
+			fields=["name"],
+			group_by="`tabNote Seen By`.`user`",
+			run=0,
+		)
+		self.assertIn("`tabNote Seen By`", query.tables)
+
+	def test_child_table_filter_with_childnames_keeps_join(self):
+		query = DatabaseQuery("Note")
+		query.execute(
+			filters=[["Note Seen By", "user", "=", "Administrator"]],
+			fields=["name"],
+			with_childnames=True,
+			run=0,
+		)
+		self.assertIn("`tabNote Seen By`", query.tables)
+
+	def test_child_table_filter_with_permission_script_keeps_join(self):
+		import frappe.model.db_query as db_query_module
+
+		with (
+			patch.object(
+				db_query_module,
+				"get_server_script_map",
+				return_value={"permission_query": {"Note": "test-script"}},
+			),
+			patch.object(DatabaseQuery, "get_permission_query_conditions", return_value=""),
+		):
+			query = DatabaseQuery("Note")
+			sql = query.execute(
+				filters=[["Note Seen By", "user", "=", "Administrator"]], fields=["name"], run=0
+			)
+
+		self.assertIn("`tabNote Seen By`", query.tables)
+		self.assertNotIn("exists (", sql)
 
 	def test_link_field_syntax(self):
 		todo = frappe.get_doc(doctype="ToDo", description="Test ToDo", allocated_to="Administrator").insert()

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -350,6 +350,17 @@ class TestDBQuery(IntegrationTestCase):
 		self.assertIn("`tabNote Seen By`", query.tables)
 		self.assertNotIn("exists (", sql)
 
+		# the surviving dedup group by must not break when link table columns are
+		# selected (GH-39851 with the join fallback)
+		result = DatabaseQuery("User").execute(
+			filters=[["Has Role", "role", "=", "System Manager"]],
+			or_filters=[["Has Role", "role", "=", "Guest"], ["User", "enabled", "=", 1]],
+			fields=["name", "modified", "language.language_name as language_title"],
+			group_by="`tabUser`.`name`",
+			order_by="modified desc",
+		)
+		self.assertIn("Administrator", [r.name for r in result])
+
 	def test_child_table_in_fields_still_uses_join(self):
 		"""A child table that is selected stays joined; its filters apply to the join."""
 		note = self.make_note(seen_by=["Administrator"])


### PR DESCRIPTION
Closes #39851

Filtering a list view by a child-table field makes the frontend send `group_by = tabParent.name` to dedup the child-join row multiplication. When the select also carries a column from a joined link table (a `show_title_field_in_link` title field), postgres rejects the query with `GroupingError: column must appear in the GROUP BY clause`. Since c90d3c5c20 the list view routes through the qb Engine, not `db_query` — which is why the earlier attempts (#40435) didn't fix it on develop. This fixes both engines:

**qb Engine (the live list-view path)** — on postgres, when the group by is exactly the parent PK, also group by the PK of each 1:1-joined link table. The link PK is functionally dependent on the parent row, so no partition (or aggregate) can change — it only satisfies postgres' functional-dependency rule. MariaDB/SQLite SQL is byte-identical to before.

**legacy db_query** — child-table filters whose table isn't otherwise referenced are rewritten as `exists()` subqueries: no join, nothing multiplies rows, and the redundant dedup group by is dropped. Semantics are preserved exactly — NULL-row behaviour for `is not set` on parents with no children, same-row AND for multiple filters on one child table, or_filters, and the child read-permission check. Anything that genuinely depends on the join (aggregate/function fields, child-table order/group by, `with_childnames`, Server Script permission queries, the child doctype in both filter groups) falls back to the legacy join, where a pk-only group by is widened with link-table PKs the same way as the qb fix.

Out of scope: selecting child columns alongside `group_by=parent.name` still errors on postgres (real ambiguity — caller should aggregate, per #40435 review); migrating the qb Engine's child filters to exists() is a follow-up.

**Tests**: eleven tests in `test_db_query.py` — the issue repro through both engines, absent-row and same-row semantics, or_filters, every join fallback, and the widened group by on the fallback path. Green locally on postgres; MariaDB via CI.

Credit to @ZeinabMohammed and @Bowrna for the diagnosis and earlier attempts, and to @ankush for the review direction in #40435.
