### PR TITLE
fix: print view crash on direct load

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -15,7 +15,8 @@ frappe.pages["print"].on_page_load = function (wrapper) {
 				frm.doc = frappe.get_doc(doctype, docname);
 				frappe.model.with_doctype(doctype, () => {
 					frm.meta = frappe.get_meta(route[1]);
-					frm.meta.module && frappe.app.sidebar.show_sidebar_for_module(frm.meta.module);
+					frm.meta.module &&
+						frappe.app.sidebar?.show_sidebar_for_module?.(frm.meta.module);
 					print_view.show(frm);
 				});
 			});


### PR DESCRIPTION
- guard `frappe.app.sidebar.show_sidebar_for_module` call with optional chaining — the method no longer exists (only a commented-out reference remains in workspace.js), so opening or reloading `/app/print/<doctype>/<name>` directly threw a TypeError, aborted `print_view.show()`, and left the page half-rendered with a second downstream error in `get_query`