### PR TITLE
fix: normalize whitelisted HTTP methods

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -563,7 +563,7 @@ def get_request_header(key, default=None):
 whitelisted: set[Callable] = set()
 guest_methods: set[Callable] = set()
 xss_safe_methods: set[Callable] = set()
-allowed_http_methods_for_whitelisted_func: dict[Callable, list[str]] = {}
+allowed_http_methods_for_whitelisted_func: dict[Callable, tuple[str, ...]] = {}
 
 
 def _in_request_or_test():
@@ -594,7 +594,11 @@ def whitelist(allow_guest=False, xss_safe=False, methods=None, force_types=None)
 	"""
 
 	if not methods:
-		methods = ["GET", "POST", "PUT", "DELETE"]
+		methods = ("GET", "POST", "PUT", "DELETE")
+	elif isinstance(methods, str):
+		methods = (methods,)
+	else:
+		methods = tuple(methods)
 
 	def innerfn(fn):
 		from frappe.utils.typing_validations import validate_argument_types

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -1418,6 +1418,32 @@ class TestTypingValidations(IntegrationTestCase):
 
 		func(1)  # should run without error
 
+	def test_whitelisted_http_methods_are_stored_as_tuple(self):
+		def default_methods():
+			pass
+
+		def list_methods():
+			pass
+
+		def tuple_methods():
+			pass
+
+		def string_method():
+			pass
+
+		default_methods = frappe.whitelist()(default_methods)
+		list_methods = frappe.whitelist(methods=["GET", "POST"])(list_methods)
+		tuple_methods = frappe.whitelist(methods=("PUT", "DELETE"))(tuple_methods)
+		string_method = frappe.whitelist(methods="GET")(string_method)
+
+		self.assertEqual(
+			frappe.allowed_http_methods_for_whitelisted_func[default_methods],
+			("GET", "POST", "PUT", "DELETE"),
+		)
+		self.assertEqual(frappe.allowed_http_methods_for_whitelisted_func[list_methods], ("GET", "POST"))
+		self.assertEqual(frappe.allowed_http_methods_for_whitelisted_func[tuple_methods], ("PUT", "DELETE"))
+		self.assertEqual(frappe.allowed_http_methods_for_whitelisted_func[string_method], ("GET",))
+
 
 class TestTBSanitization(IntegrationTestCase):
 	def test_traceback_sanitzation(self):


### PR DESCRIPTION
## Summary
- store whitelisted HTTP methods as tuples in the internal registry
- treat a bare string method as a single method tuple
- add coverage for default, list, tuple, and string inputs

## Tests
- bench --site dev.localhost run-tests --app frappe --module frappe.tests.test_utils --case TestTypingValidations