### PR TITLE
fix: skip error log for expected exceptions

### DIFF
--- a/frappe/api/discovery.py
+++ b/frappe/api/discovery.py
@@ -19,6 +19,7 @@ DISCOVERY_BUILD_JOB_ID = "api-v2-discovery-build"
 
 class DiscoveryCacheUnavailable(frappe.ValidationError):
 	http_status_code = 503
+	skip_error_log = True
 
 
 def root() -> dict[str, Any]:

--- a/frappe/core/doctype/error_log/test_error_log.py
+++ b/frappe/core/doctype/error_log/test_error_log.py
@@ -6,7 +6,7 @@ from ldap3.core.exceptions import LDAPException, LDAPInappropriateAuthentication
 
 import frappe
 from frappe.tests import IntegrationTestCase
-from frappe.utils.error import _is_ldap_exception, guess_exception_source
+from frappe.utils.error import _is_ldap_exception, guess_exception_source, log_error_snapshot
 
 
 class TestErrorLog(IntegrationTestCase):
@@ -44,6 +44,15 @@ class TestErrorLog(IntegrationTestCase):
 
 		for e in exc:
 			self.assertTrue(_is_ldap_exception(e()))
+
+	def test_log_error_snapshot_can_be_skipped_by_exception_flag(self):
+		class ExpectedException(Exception):
+			skip_error_log = True
+
+		with patch("frappe.utils.error.log_error") as log_error:
+			log_error_snapshot(ExpectedException("expected"))
+
+		log_error.assert_not_called()
 
 
 _RAW_EXC = """

--- a/frappe/core/doctype/error_log/test_error_log.py
+++ b/frappe/core/doctype/error_log/test_error_log.py
@@ -54,6 +54,18 @@ class TestErrorLog(IntegrationTestCase):
 
 		log_error.assert_not_called()
 
+	def test_builtin_excluded_exceptions_use_skip_error_log_flag(self):
+		exceptions = [
+			frappe.AuthenticationError,
+			frappe.CSRFTokenError,
+			frappe.SecurityException,
+			frappe.InReadOnlyMode,
+		]
+
+		for exception in exceptions:
+			with self.subTest(exception=exception.__name__):
+				self.assertTrue(exception.skip_error_log)
+
 
 _RAW_EXC = """
    File "apps/frappe/frappe/model/document.py", line 1284, in runner

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -31,6 +31,7 @@ class FrappeTypeError(TypeError):
 
 class AuthenticationError(Exception):
 	http_status_code = 401
+	skip_error_log = True
 
 
 class SessionExpired(Exception):
@@ -80,6 +81,7 @@ class Redirect(Exception):
 
 class CSRFTokenError(Exception):
 	http_status_code = 400
+	skip_error_log = True
 
 
 class TooManyRequestsError(Exception):
@@ -220,7 +222,7 @@ class CircularLinkingError(ValidationError):
 
 
 class SecurityException(Exception):
-	pass
+	skip_error_log = True
 
 
 class InvalidColumnName(ValidationError):
@@ -261,6 +263,7 @@ class QueryDeadlockError(Exception):
 
 class InReadOnlyMode(ValidationError):
 	http_status_code = 503  # temporarily not available
+	skip_error_log = True
 
 
 class SessionBootFailed(ValidationError):

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -1,5 +1,6 @@
 import typing
 from random import choice
+from unittest.mock import patch
 
 import requests
 
@@ -659,10 +660,11 @@ class TestDiscoveryAPIV2(FrappeAPITestCase):
 
 	def test_cold_cache_returns_retryable_response_v2(self):
 		discovery.clear_cache()
-		with suppress_stdout():
+		with suppress_stdout(), patch("frappe.utils.error.log_error") as log_error:
 			response = self.get(self.discovery_path(), {"sid": self.sid})
 		self.assertEqual(response.status_code, 503)
 		self.assertNotIn("Retry-After", response.headers)
+		log_error.assert_not_called()
 
 	def test_discovery_requires_developer_role_v2(self):
 		sid = self.non_developer_sid()

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -166,7 +166,11 @@ def get_error_metadata() -> str:
 
 
 def log_error_snapshot(exception: Exception):
-	if isinstance(exception, EXCLUDE_EXCEPTIONS) or _is_ldap_exception(exception):
+	if (
+		isinstance(exception, EXCLUDE_EXCEPTIONS)
+		or _is_ldap_exception(exception)
+		or getattr(exception, "skip_error_log", False)
+	):
 		return
 
 	logger = frappe.logger(with_more_info=True)

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -17,13 +17,6 @@ from frappe.monitor import add_data_to_monitor
 if TYPE_CHECKING:
 	from frappe.core.doctype.error_log.error_log import ErrorLog
 
-EXCLUDE_EXCEPTIONS = (
-	frappe.AuthenticationError,
-	frappe.CSRFTokenError,  # CSRF covers OAuth too
-	frappe.SecurityException,
-	frappe.InReadOnlyMode,
-)
-
 LDAP_BASE_EXCEPTION = "LDAPException"
 
 
@@ -166,11 +159,7 @@ def get_error_metadata() -> str:
 
 
 def log_error_snapshot(exception: Exception):
-	if (
-		isinstance(exception, EXCLUDE_EXCEPTIONS)
-		or _is_ldap_exception(exception)
-		or getattr(exception, "skip_error_log", False)
-	):
+	if getattr(exception, "skip_error_log", False) or _is_ldap_exception(exception):
 		return
 
 	logger = frappe.logger(with_more_info=True)


### PR DESCRIPTION
## Summary
- add skip_error_log to exception classes that were previously excluded from Error Log snapshots
- use skip_error_log as the single opt-out signal in log_error_snapshot
- keep DiscoveryCacheUnavailable covered by the same exception flag behavior

## Tests
- bench --site dev.localhost run-tests --app frappe --module frappe.core.doctype.error_log.test_error_log --test TestErrorLog
- bench --site dev.localhost run-tests --app frappe --module frappe.tests.test_api_v2 --test TestDiscoveryAPIV2