### PR TITLE
feat(print-format-builder): image and barcode blocks with width option

### DIFF
--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -605,8 +605,9 @@ context("Print Format Builder — image and barcode blocks", () => {
 		cy.window().then((win) => cleanup(win, PF_NAME));
 	});
 
-	function media_sections() {
-		return [
+	// Regression: serialize_layout must not strip image/barcode props on save
+	it("image and barcode props survive the save round-trip", () => {
+		insert_builder_format(PF_NAME, [
 			{
 				label: "Media",
 				columns: [
@@ -627,7 +628,6 @@ context("Print Format Builder — image and barcode blocks", () => {
 								fieldname: "barcode_cy1",
 								label: "",
 								custom: 1,
-								barcode_field: "",
 								barcode_value: "CY-TEST-1",
 								barcode_format: "CODE128",
 								show_text: true,
@@ -637,46 +637,14 @@ context("Print Format Builder — image and barcode blocks", () => {
 					},
 				],
 			},
-		];
-	}
-
-	// 16. Canvas renders the image block and the inspector shows its controls
-	it("image block renders in canvas and inspector shows upload control", () => {
-		insert_builder_format(PF_NAME, media_sections());
-
-		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
-		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
-
-		cy.get('.field img[src*="frappe-framework-logo"]').should("exist");
-
-		cy.get('.field img[src*="frappe-framework-logo"]')
-			.closest(".field")
-			.click({ force: true });
-		cy.get(".pfb-inspector .pfb-image-upload").should("exist");
-		cy.get(".pfb-inspector .pfb-size-slider").should("exist");
-	});
-
-	// 17. Inspector for a barcode block shows value/format/size controls
-	it("barcode inspector shows value, format and size controls", () => {
-		insert_builder_format(PF_NAME, media_sections());
-
-		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
-		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
-
-		cy.contains("[data-pfb-section]", "Media").find(".field").eq(1).click({ force: true });
-
-		cy.get(".pfb-inspector").should("contain", "Value from");
-		cy.get(".pfb-inspector").should("contain", "Format");
-		cy.get(".pfb-inspector .pfb-size-slider").should("exist");
-	});
-
-	// 18. Regression: serialize_layout must not strip image/barcode props on save
-	it("image and barcode props survive the save round-trip", () => {
-		insert_builder_format(PF_NAME, media_sections());
+		]);
 
 		cy.intercept("POST", "api/method/frappe.client.save").as("save");
 		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
 		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
+
+		// both blocks render in the canvas
+		cy.get('.field img[src*="frappe-framework-logo"]').should("exist");
 
 		cy.contains(".page-actions .primary-action", "Save").click({ force: true });
 		cy.wait("@save").then((interception) => {
@@ -686,18 +654,22 @@ context("Print Format Builder — image and barcode blocks", () => {
 
 			const img = fields.find((f) => f.fieldtype === "Image");
 			expect(img, "image field survived").to.exist;
-			expect(img.custom).to.equal(1);
-			expect(img.image_url).to.contain("frappe-framework-logo");
-			expect(img.width).to.equal("40mm");
-			expect(img.align).to.equal("center");
+			expect(img).to.include({
+				custom: 1,
+				image_url: "/assets/frappe/images/frappe-framework-logo.svg",
+				width: "40mm",
+				align: "center",
+			});
 
 			const bar = fields.find((f) => f.fieldtype === "Barcode");
 			expect(bar, "barcode field survived").to.exist;
-			expect(bar.custom).to.equal(1);
-			expect(bar.barcode_value).to.equal("CY-TEST-1");
-			expect(bar.barcode_format).to.equal("CODE128");
-			expect(bar.show_text).to.equal(true);
-			expect(bar.width).to.equal("200px");
+			expect(bar).to.include({
+				custom: 1,
+				barcode_value: "CY-TEST-1",
+				barcode_format: "CODE128",
+				show_text: true,
+				width: "200px",
+			});
 		});
 	});
 });

--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -586,3 +586,118 @@ context("Print Format Builder — section insert", () => {
 		cy.get(".section-insert").first().should("not.have.css", "display", "none");
 	});
 });
+
+// ─── Image and Barcode blocks ─────────────────────────────────────────────────
+
+context("Print Format Builder — image and barcode blocks", () => {
+	let PF_NAME;
+
+	before(() => {
+		cy.login();
+		cy.visit("/app");
+	});
+
+	beforeEach(() => {
+		PF_NAME = pf_name();
+	});
+
+	afterEach(() => {
+		cy.window().then((win) => cleanup(win, PF_NAME));
+	});
+
+	function media_sections() {
+		return [
+			{
+				label: "Media",
+				columns: [
+					{
+						label: "",
+						fields: [
+							{
+								fieldtype: "Image",
+								fieldname: "image_cy1",
+								label: "Logo",
+								custom: 1,
+								image_url: "/assets/frappe/images/frappe-framework-logo.svg",
+								width: "40mm",
+								align: "center",
+							},
+							{
+								fieldtype: "Barcode",
+								fieldname: "barcode_cy1",
+								label: "",
+								custom: 1,
+								barcode_field: "",
+								barcode_value: "CY-TEST-1",
+								barcode_format: "CODE128",
+								show_text: true,
+								width: "200px",
+							},
+						],
+					},
+				],
+			},
+		];
+	}
+
+	// 16. Canvas renders the image block and the inspector shows its controls
+	it("image block renders in canvas and inspector shows upload control", () => {
+		insert_builder_format(PF_NAME, media_sections());
+
+		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
+		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
+
+		cy.get('.field img[src*="frappe-framework-logo"]').should("exist");
+
+		cy.get('.field img[src*="frappe-framework-logo"]')
+			.closest(".field")
+			.click({ force: true });
+		cy.get(".pfb-inspector .pfb-image-upload").should("exist");
+		cy.get(".pfb-inspector .pfb-size-slider").should("exist");
+	});
+
+	// 17. Inspector for a barcode block shows value/format/size controls
+	it("barcode inspector shows value, format and size controls", () => {
+		insert_builder_format(PF_NAME, media_sections());
+
+		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
+		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
+
+		cy.contains("[data-pfb-section]", "Media").find(".field").eq(1).click({ force: true });
+
+		cy.get(".pfb-inspector").should("contain", "Value from");
+		cy.get(".pfb-inspector").should("contain", "Format");
+		cy.get(".pfb-inspector .pfb-size-slider").should("exist");
+	});
+
+	// 18. Regression: serialize_layout must not strip image/barcode props on save
+	it("image and barcode props survive the save round-trip", () => {
+		insert_builder_format(PF_NAME, media_sections());
+
+		cy.intercept("POST", "api/method/frappe.client.save").as("save");
+		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
+		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
+
+		cy.contains(".page-actions .primary-action", "Save").click({ force: true });
+		cy.wait("@save").then((interception) => {
+			expect(interception.response.statusCode).to.equal(200);
+			const layout = JSON.parse(interception.response.body.message.format_data);
+			const fields = layout.sections.flatMap((s) => s.columns).flatMap((c) => c.fields);
+
+			const img = fields.find((f) => f.fieldtype === "Image");
+			expect(img, "image field survived").to.exist;
+			expect(img.custom).to.equal(1);
+			expect(img.image_url).to.contain("frappe-framework-logo");
+			expect(img.width).to.equal("40mm");
+			expect(img.align).to.equal("center");
+
+			const bar = fields.find((f) => f.fieldtype === "Barcode");
+			expect(bar, "barcode field survived").to.exist;
+			expect(bar.custom).to.equal(1);
+			expect(bar.barcode_value).to.equal("CY-TEST-1");
+			expect(bar.barcode_format).to.equal("CODE128");
+			expect(bar.show_text).to.equal(true);
+			expect(bar.width).to.equal("200px");
+		});
+	});
+});

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -62,3 +62,151 @@ class TestPrintFormat(IntegrationTestCase):
 					self.assertEqual(value, doc_dict[key])
 
 		self.addCleanup(os.remove, exported_doc_path)
+
+
+class TestPrintFormatBuilderElements(IntegrationTestCase):
+	"""Image and Barcode layout elements of the beta print format builder."""
+
+	FORMAT_NAME = "_Test Builder Elements"
+
+	def make_format(self, fields):
+		frappe.delete_doc("Print Format", self.FORMAT_NAME, force=True, ignore_missing=True)
+		format_data = {
+			"sections": [{"label": "", "columns": [{"label": "", "fields": fields}]}],
+			"header": {"columns": []},
+			"footer": {"columns": []},
+		}
+		pf = frappe.get_doc(
+			{
+				"doctype": "Print Format",
+				"name": self.FORMAT_NAME,
+				"doc_type": "User",
+				"standard": "No",
+				"print_format_builder_beta": 1,
+				"format_data": frappe.as_json(format_data),
+			}
+		).insert()
+		self.addCleanup(frappe.delete_doc, "Print Format", self.FORMAT_NAME, force=True)
+		return pf
+
+	def get_rendered_html(self):
+		from frappe.utils.print_format_generator import get_html
+
+		return get_html("User", "Administrator", self.FORMAT_NAME)
+
+	def test_image_element(self):
+		self.make_format(
+			[
+				{
+					"label": "Logo",
+					"fieldname": "image_test",
+					"fieldtype": "Image",
+					"custom": 1,
+					"image_url": "/assets/frappe/images/frappe-framework-logo.svg",
+					"width": "40mm",
+					"align": "center",
+				}
+			]
+		)
+		html = self.get_rendered_html()
+		self.assertIn('src="/assets/frappe/images/frappe-framework-logo.svg"', html)
+		self.assertIn("width: 40mm", html)
+		self.assertIn("field-align-center", html)
+
+	def test_image_element_without_source_renders_nothing(self):
+		self.make_format(
+			[{"label": "", "fieldname": "image_test", "fieldtype": "Image", "custom": 1, "image_url": ""}]
+		)
+		html = self.get_rendered_html()
+		self.assertNotIn("print-image", html)
+
+	def test_barcode_element_static_value(self):
+		self.make_format(
+			[
+				{
+					"label": "",
+					"fieldname": "barcode_test",
+					"fieldtype": "Barcode",
+					"custom": 1,
+					"barcode_field": "",
+					"barcode_value": "TEST-123",
+					"barcode_format": "CODE39",
+					"show_text": False,
+					"width": "50mm",
+				}
+			]
+		)
+		html = self.get_rendered_html()
+		self.assertIn('data-barcode-value="TEST-123"', html)
+		self.assertIn('"format": "CODE39"', html)
+		self.assertIn('"displayValue": false', html)
+		self.assertIn("width: 50mm", html)
+		# the client-side renderer must be shipped with the document
+		self.assertIn("print.bundle", html)
+		self.assertIn("render_barcode", html)
+
+	def test_barcode_element_field_value(self):
+		self.make_format(
+			[
+				{
+					"label": "",
+					"fieldname": "barcode_test",
+					"fieldtype": "Barcode",
+					"custom": 1,
+					"barcode_field": "name",
+					"barcode_value": "",
+					"barcode_format": "CODE128",
+				}
+			]
+		)
+		html = self.get_rendered_html()
+		self.assertIn('data-barcode-value="Administrator"', html)
+
+	def test_qr_element_renders_server_side(self):
+		self.make_format(
+			[
+				{
+					"label": "",
+					"fieldname": "barcode_test",
+					"fieldtype": "Barcode",
+					"custom": 1,
+					"barcode_field": "name",
+					"barcode_value": "",
+					"barcode_format": "QR",
+					"width": "30mm",
+					"align": "right",
+				}
+			]
+		)
+		html = self.get_rendered_html()
+		self.assertIn('src="data:image/png;base64,', html)
+		self.assertIn("field-align-right", html)
+		self.assertNotIn("<svg data-barcode-value", html)
+
+	def test_barcode_element_without_value_renders_nothing(self):
+		self.make_format(
+			[
+				{
+					"label": "",
+					"fieldname": "barcode_test",
+					"fieldtype": "Barcode",
+					"custom": 1,
+					"barcode_field": "",
+					"barcode_value": "",
+					"barcode_format": "CODE128",
+				}
+			]
+		)
+		html = self.get_rendered_html()
+		self.assertNotIn("print-barcode", html)
+
+	def test_get_qr_code(self):
+		import base64
+
+		from frappe.utils.print_format_generator import get_qr_code
+
+		data_uri = get_qr_code("hello world")
+		prefix = "data:image/png;base64,"
+		self.assertTrue(data_uri.startswith(prefix))
+		png = base64.b64decode(data_uri[len(prefix) :])
+		self.assertEqual(png[:8], b"\x89PNG\r\n\x1a\n")

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -144,12 +144,12 @@ class TestPrintFormatBuilderElements(IntegrationTestCase):
 				"align": "right",
 			}
 		)
-		# QR renders server-side as an embedded PNG, no client-side svg
-		self.assertIn('src="data:image/png;base64,', html)
+		# QR renders server-side as an embedded SVG image, no client-side JsBarcode svg
+		self.assertIn('src="data:image/svg+xml;base64,', html)
 		self.assertIn("field-align-right", html)
 		self.assertNotIn("<svg data-barcode-value", html)
 
 		data_uri = get_qr_code("hello world")
-		prefix = "data:image/png;base64,"
+		prefix = "data:image/svg+xml;base64,"
 		self.assertTrue(data_uri.startswith(prefix))
-		self.assertEqual(base64.b64decode(data_uri[len(prefix) :])[:8], b"\x89PNG\r\n\x1a\n")
+		self.assertIn(b"<svg", base64.b64decode(data_uri[len(prefix) :]))

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -69,14 +69,16 @@ class TestPrintFormatBuilderElements(IntegrationTestCase):
 
 	FORMAT_NAME = "_Test Builder Elements"
 
-	def make_format(self, fields):
+	def render(self, df):
+		from frappe.utils.print_format_generator import get_html
+
 		frappe.delete_doc("Print Format", self.FORMAT_NAME, force=True, ignore_missing=True)
 		format_data = {
-			"sections": [{"label": "", "columns": [{"label": "", "fields": fields}]}],
+			"sections": [{"label": "", "columns": [{"label": "", "fields": [df]}]}],
 			"header": {"columns": []},
 			"footer": {"columns": []},
 		}
-		pf = frappe.get_doc(
+		frappe.get_doc(
 			{
 				"doctype": "Print Format",
 				"name": self.FORMAT_NAME,
@@ -87,56 +89,30 @@ class TestPrintFormatBuilderElements(IntegrationTestCase):
 			}
 		).insert()
 		self.addCleanup(frappe.delete_doc, "Print Format", self.FORMAT_NAME, force=True)
-		return pf
-
-	def get_rendered_html(self):
-		from frappe.utils.print_format_generator import get_html
-
 		return get_html("User", "Administrator", self.FORMAT_NAME)
 
 	def test_image_element(self):
-		self.make_format(
-			[
-				{
-					"label": "Logo",
-					"fieldname": "image_test",
-					"fieldtype": "Image",
-					"custom": 1,
-					"image_url": "/assets/frappe/images/frappe-framework-logo.svg",
-					"width": "40mm",
-					"align": "center",
-				}
-			]
-		)
-		html = self.get_rendered_html()
-		self.assertIn('src="/assets/frappe/images/frappe-framework-logo.svg"', html)
+		df = {"fieldname": "image_test", "fieldtype": "Image", "custom": 1, "label": "Logo"}
+		html = self.render(df | {"image_url": "/img/logo.svg", "width": "40mm", "align": "center"})
+		self.assertIn('src="/img/logo.svg"', html)
 		self.assertIn("width: 40mm", html)
 		self.assertIn("field-align-center", html)
 
-	def test_image_element_without_source_renders_nothing(self):
-		self.make_format(
-			[{"label": "", "fieldname": "image_test", "fieldtype": "Image", "custom": 1, "image_url": ""}]
-		)
-		html = self.get_rendered_html()
-		self.assertNotIn("print-image", html)
+		# no source -> block is skipped entirely
+		self.assertNotIn("print-image", self.render(df | {"image_url": ""}))
 
-	def test_barcode_element_static_value(self):
-		self.make_format(
-			[
-				{
-					"label": "",
-					"fieldname": "barcode_test",
-					"fieldtype": "Barcode",
-					"custom": 1,
-					"barcode_field": "",
-					"barcode_value": "TEST-123",
-					"barcode_format": "CODE39",
-					"show_text": False,
-					"width": "50mm",
-				}
-			]
+	def test_barcode_element(self):
+		df = {"fieldname": "barcode_test", "fieldtype": "Barcode", "custom": 1, "label": ""}
+
+		html = self.render(
+			df
+			| {
+				"barcode_value": "TEST-123",
+				"barcode_format": "CODE39",
+				"show_text": False,
+				"width": "50mm",
+			}
 		)
-		html = self.get_rendered_html()
 		self.assertIn('data-barcode-value="TEST-123"', html)
 		self.assertIn('"format": "CODE39"', html)
 		self.assertIn('"displayValue": false', html)
@@ -145,68 +121,35 @@ class TestPrintFormatBuilderElements(IntegrationTestCase):
 		self.assertIn("print.bundle", html)
 		self.assertIn("render_barcode", html)
 
-	def test_barcode_element_field_value(self):
-		self.make_format(
-			[
-				{
-					"label": "",
-					"fieldname": "barcode_test",
-					"fieldtype": "Barcode",
-					"custom": 1,
-					"barcode_field": "name",
-					"barcode_value": "",
-					"barcode_format": "CODE128",
-				}
-			]
-		)
-		html = self.get_rendered_html()
+		# value bound to a doc field
+		html = self.render(df | {"barcode_field": "name", "barcode_format": "CODE128"})
 		self.assertIn('data-barcode-value="Administrator"', html)
 
-	def test_qr_element_renders_server_side(self):
-		self.make_format(
-			[
-				{
-					"label": "",
-					"fieldname": "barcode_test",
-					"fieldtype": "Barcode",
-					"custom": 1,
-					"barcode_field": "name",
-					"barcode_value": "",
-					"barcode_format": "QR",
-					"width": "30mm",
-					"align": "right",
-				}
-			]
-		)
-		html = self.get_rendered_html()
-		self.assertIn('src="data:image/png;base64,', html)
-		self.assertIn("field-align-right", html)
-		self.assertNotIn("<svg data-barcode-value", html)
+		# no value -> block is skipped entirely
+		self.assertNotIn("print-barcode", self.render(df | {"barcode_value": ""}))
 
-	def test_barcode_element_without_value_renders_nothing(self):
-		self.make_format(
-			[
-				{
-					"label": "",
-					"fieldname": "barcode_test",
-					"fieldtype": "Barcode",
-					"custom": 1,
-					"barcode_field": "",
-					"barcode_value": "",
-					"barcode_format": "CODE128",
-				}
-			]
-		)
-		html = self.get_rendered_html()
-		self.assertNotIn("print-barcode", html)
-
-	def test_get_qr_code(self):
+	def test_qr_code(self):
 		import base64
 
 		from frappe.utils.print_format_generator import get_qr_code
 
+		html = self.render(
+			{
+				"fieldname": "barcode_test",
+				"fieldtype": "Barcode",
+				"custom": 1,
+				"barcode_field": "name",
+				"barcode_format": "QR",
+				"width": "30mm",
+				"align": "right",
+			}
+		)
+		# QR renders server-side as an embedded PNG, no client-side svg
+		self.assertIn('src="data:image/png;base64,', html)
+		self.assertIn("field-align-right", html)
+		self.assertNotIn("<svg data-barcode-value", html)
+
 		data_uri = get_qr_code("hello world")
 		prefix = "data:image/png;base64,"
 		self.assertTrue(data_uri.startswith(prefix))
-		png = base64.b64decode(data_uri[len(prefix) :])
-		self.assertEqual(png[:8], b"\x89PNG\r\n\x1a\n")
+		self.assertEqual(base64.b64decode(data_uri[len(prefix) :])[:8], b"\x89PNG\r\n\x1a\n")

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -332,6 +332,29 @@ const draggable_blocks = [
 		desc: __("Horizontal rule"),
 	},
 	{
+		label: __("Image"),
+		fieldname: "image",
+		fieldtype: "Image",
+		custom: 1,
+		icon: "image",
+		desc: __("Upload an image or use a URL"),
+		image_url: "",
+		width: "",
+	},
+	{
+		label: __("Barcode"),
+		fieldname: "barcode",
+		fieldtype: "Barcode",
+		custom: 1,
+		icon: "barcode",
+		desc: __("Barcode or QR code from a field or static value"),
+		barcode_field: "",
+		barcode_value: "",
+		barcode_format: "CODE128",
+		show_text: true,
+		width: "",
+	},
+	{
 		label: __("Repeater"),
 		fieldname: "repeater",
 		fieldtype: "Repeater",
@@ -397,6 +420,13 @@ function clone_field(df) {
 		"field_template",
 		"source",
 		"repeater_columns",
+		"custom",
+		"image_url",
+		"width",
+		"barcode_field",
+		"barcode_value",
+		"barcode_format",
+		"show_text",
 	]);
 	if (cloned.custom) {
 		cloned.fieldname += "_" + frappe.utils.get_random(8);

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -23,6 +23,41 @@
 				<div v-else-if="df.fieldtype == 'Spacer'" class="field-preview-spacer"></div>
 				<div v-else-if="df.fieldtype == 'Divider'" class="field-preview-divider"></div>
 				<div
+					v-else-if="df.fieldtype == 'Image' && df.custom"
+					:style="{ textAlign: df.align || 'left' }"
+				>
+					<img
+						v-if="df.image_url"
+						:src="df.image_url"
+						class="pf-element-img"
+						:style="df.width ? { width: df.width } : {}"
+						:alt="df.label || ''"
+					/>
+					<span v-else class="text-muted">{{
+						__("No image — set one in the panel")
+					}}</span>
+				</div>
+				<div
+					v-else-if="df.fieldtype == 'Barcode' && df.custom"
+					:style="{ textAlign: df.align || 'left' }"
+				>
+					<img
+						v-if="df.barcode_format == 'QR' && qr_src"
+						:src="qr_src"
+						class="pf-element-img"
+						:style="{ width: df.width || '35mm' }"
+					/>
+					<div
+						v-else-if="barcode_svg"
+						class="pf-barcode-svg"
+						:style="df.width ? { width: df.width } : {}"
+						v-html="barcode_svg"
+					></div>
+					<span v-else class="text-muted">{{
+						__("No barcode value — set one in the panel")
+					}}</span>
+				</div>
+				<div
 					v-else-if="df.fieldtype == 'Field Template'"
 					class="custom-html"
 					v-html="rendered_template || ''"
@@ -271,6 +306,12 @@
 						<div class="custom-html" v-else-if="df.fieldtype == 'Field Template'">
 							{{ df.label }}
 						</div>
+						<img
+							v-else-if="df.fieldtype == 'Image' && df.custom && df.image_url"
+							:src="df.image_url"
+							class="pf-builder-thumb"
+							:alt="df.label || ''"
+						/>
 						<input
 							v-else-if="editing && df.fieldtype != 'HTML'"
 							ref="label_input"
@@ -354,6 +395,7 @@ import {
 	parse_inline_style,
 } from "../../utils";
 import { createApp, ref, nextTick, watch, computed, inject } from "vue";
+import JsBarcode from "jsbarcode";
 
 const props = defineProps(["df", "field_orientation"]);
 
@@ -427,6 +469,56 @@ watch(
 			rendered_template.value = null;
 		}
 	},
+	{ immediate: true }
+);
+
+// ── Barcode element (custom layout block) ─────────────────
+let qr_src = ref(null);
+
+let barcode_raw_value = computed(() => {
+	if (props.df.fieldtype !== "Barcode" || !props.df.custom) return null;
+	if (props.df.barcode_field) {
+		return preview_doc.value?.[props.df.barcode_field] ?? null;
+	}
+	return props.df.barcode_value || null;
+});
+
+let barcode_svg = computed(() => {
+	const value = barcode_raw_value.value;
+	if (!value || props.df.barcode_format === "QR") return null;
+	const str = String(value);
+	if (str.startsWith("<svg")) return sanitize_html(str);
+	const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+	try {
+		JsBarcode(svg, str, {
+			format: props.df.barcode_format || "CODE128",
+			displayValue: props.df.show_text !== false,
+			height: 40,
+			margin: 0,
+		});
+		svg.setAttribute("width", "100%");
+		return svg.outerHTML;
+	} catch {
+		return null;
+	}
+});
+
+watch(
+	[barcode_raw_value, () => props.df.barcode_format],
+	frappe.utils.debounce(async ([value, format]) => {
+		if (format !== "QR" || !value) {
+			qr_src.value = null;
+			return;
+		}
+		try {
+			const r = await frappe.call("frappe.utils.print_format_generator.get_qr_code", {
+				value: String(value),
+			});
+			qr_src.value = r.message || null;
+		} catch {
+			qr_src.value = null;
+		}
+	}, 300),
 	{ immediate: true }
 );
 
@@ -622,6 +714,8 @@ let short_fieldtype = computed(() => {
 		HTML: "HTML",
 		Spacer: "Space",
 		Divider: "Line",
+		Image: "Img",
+		Barcode: "Code",
 		"Field Template": "Tmpl",
 		Repeater: "Repeat",
 	};
@@ -1189,6 +1283,25 @@ watch(
 .preview-table-html {
 	word-break: break-word;
 	white-space: normal;
+}
+
+.pf-element-img {
+	max-width: 100%;
+	display: inline-block;
+	vertical-align: top;
+}
+
+.pf-barcode-svg {
+	display: inline-block;
+	max-width: 100%;
+}
+
+.pf-builder-thumb {
+	max-height: 32px;
+	max-width: 120px;
+	object-fit: contain;
+	border-radius: var(--radius);
+	vertical-align: middle;
 }
 
 .preview-field-img {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -53,6 +53,11 @@
 						:style="df.width ? { width: df.width } : {}"
 						v-html="barcode_svg"
 					></div>
+					<span
+						v-else-if="barcode_raw_value && df.barcode_format !== 'QR'"
+						class="text-muted"
+						>{{ __("Invalid value for {0}", [df.barcode_format || "CODE128"]) }}</span
+					>
 					<span v-else class="text-muted">{{
 						__("No barcode value — set one in the panel")
 					}}</span>

--- a/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
@@ -25,50 +25,20 @@
 				</button>
 			</template>
 			<template v-else-if="is_image_element">
-				<div class="pfb-insp-row">
-					<span class="pfb-insp-label">{{ __("Image") }}</span>
-					<div class="pfb-image-source">
-						<img
-							v-if="selected_field.image_url"
-							:src="selected_field.image_url"
-							class="pfb-image-thumb"
-						/>
-						<div class="pfb-image-actions">
-							<button class="es-button" data-size="xs" @click="upload_image">
-								<span v-html="frappe.utils.icon('upload', 'xs')"></span>
-								{{ __("Upload") }}
-							</button>
-							<button
-								v-if="selected_field.image_url"
-								class="es-button"
-								data-size="xs"
-								data-theme="red"
-								data-variant="ghost"
-								@click="selected_field.image_url = ''"
-							>
-								{{ __("Clear") }}
-							</button>
-						</div>
-					</div>
-				</div>
-				<div class="pfb-insp-row">
-					<span class="pfb-insp-label">{{ __("or URL") }}</span>
+				<ImageUploadControl
+					:model-value="selected_field.image_url"
+					:alt="selected_field.label"
+					@update:model-value="set_image_url"
+				/>
+				<div v-if="selected_field.image_url" class="pfb-insp-row pfb-insp-row--col">
+					<span class="pfb-insp-label">{{ __("Size") }}</span>
 					<input
-						type="text"
-						class="pfb-insp-input"
-						:placeholder="__('https://… or /files/…')"
-						:value="selected_field.image_url"
-						@change="selected_field.image_url = $event.target.value.trim()"
-					/>
-				</div>
-				<div class="pfb-insp-row">
-					<span class="pfb-insp-label">{{ __("Width") }}</span>
-					<input
-						type="text"
-						class="pfb-insp-input"
-						:placeholder="__('auto — e.g. 40mm, 200px, 50%')"
-						:value="selected_field.width"
-						@change="selected_field.width = $event.target.value.trim()"
+						class="pfb-size-slider"
+						type="range"
+						min="20"
+						max="700"
+						:value="image_size"
+						@input="selected_field.width = $event.target.value + 'px'"
 					/>
 				</div>
 				<SegmentedRow
@@ -114,24 +84,26 @@
 						</option>
 					</select>
 				</div>
-				<div class="pfb-insp-row">
-					<span class="pfb-insp-label">{{ __("Width") }}</span>
+				<div class="pfb-insp-row pfb-insp-row--col">
+					<span class="pfb-insp-label">{{ __("Size") }}</span>
 					<input
-						type="text"
-						class="pfb-insp-input"
-						:placeholder="__('auto — e.g. 40mm, 200px, 50%')"
-						:value="selected_field.width"
-						@change="selected_field.width = $event.target.value.trim()"
+						class="pfb-size-slider"
+						type="range"
+						min="40"
+						max="500"
+						:value="barcode_size"
+						@input="selected_field.width = $event.target.value + 'px'"
 					/>
 				</div>
 				<div class="pfb-insp-row" v-if="selected_field.barcode_format !== 'QR'">
+					<span class="pfb-insp-label">{{ __("Value text") }}</span>
 					<label class="pfb-insp-check">
 						<input
 							type="checkbox"
 							:checked="selected_field.show_text !== false"
 							@change="selected_field.show_text = $event.target.checked"
 						/>
-						{{ __("Show value text") }}
+						{{ __("Show") }}
 					</label>
 				</div>
 				<SegmentedRow
@@ -202,6 +174,8 @@ import InspectorSection from "./InspectorSection.vue";
 import StepperRow from "./StepperRow.vue";
 import StyleSection from "./StyleSection.vue";
 import VisibilitySection from "./VisibilitySection.vue";
+import ImageUploadControl from "./ImageUploadControl.vue";
+import { get_image_dimensions } from "../../utils";
 import { align_opts } from "./align_opts";
 import { useSelectedField } from "./useSelectedField";
 
@@ -231,13 +205,23 @@ let barcode_field_options = computed(() => {
 	];
 });
 
-function upload_image() {
-	new frappe.ui.FileUploader({
-		folder: "Home/Attachments",
-		restrictions: { allowed_file_types: ["image/*"] },
-		on_success: (file_doc) => {
-			selected_field.value.image_url = file_doc.file_url;
-		},
+let image_size = computed(() => parseFloat(selected_field.value?.width) || 200);
+let barcode_size = computed(
+	() =>
+		parseFloat(selected_field.value?.width) ||
+		(selected_field.value?.barcode_format === "QR" ? 130 : 200)
+);
+
+function set_image_url(url) {
+	selected_field.value.image_url = url;
+	if (!url) {
+		selected_field.value.width = "";
+		return;
+	}
+	get_image_dimensions(url).then(({ width }) => {
+		if (!parseFloat(selected_field.value.width)) {
+			selected_field.value.width = Math.min(width, 300) + "px";
+		}
 	});
 }
 

--- a/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
@@ -191,7 +191,7 @@ let is_barcode_element = computed(
 	() => selected_field.value?.fieldtype === "Barcode" && selected_field.value?.custom
 );
 
-const barcode_formats = ["CODE128", "CODE39", "EAN13", "EAN8", "UPC", "ITF14", "MSI", "QR"];
+const barcode_formats = ["CODE128", "CODE39", "QR"];
 
 let store = inject("$store");
 

--- a/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
@@ -24,6 +24,123 @@
 					{{ __("Edit HTML") }}
 				</button>
 			</template>
+			<template v-else-if="is_image_element">
+				<div class="pfb-insp-row">
+					<span class="pfb-insp-label">{{ __("Image") }}</span>
+					<div class="pfb-image-source">
+						<img
+							v-if="selected_field.image_url"
+							:src="selected_field.image_url"
+							class="pfb-image-thumb"
+						/>
+						<div class="pfb-image-actions">
+							<button class="es-button" data-size="xs" @click="upload_image">
+								<span v-html="frappe.utils.icon('upload', 'xs')"></span>
+								{{ __("Upload") }}
+							</button>
+							<button
+								v-if="selected_field.image_url"
+								class="es-button"
+								data-size="xs"
+								data-theme="red"
+								data-variant="ghost"
+								@click="selected_field.image_url = ''"
+							>
+								{{ __("Clear") }}
+							</button>
+						</div>
+					</div>
+				</div>
+				<div class="pfb-insp-row">
+					<span class="pfb-insp-label">{{ __("or URL") }}</span>
+					<input
+						type="text"
+						class="pfb-insp-input"
+						:placeholder="__('https://… or /files/…')"
+						:value="selected_field.image_url"
+						@change="selected_field.image_url = $event.target.value.trim()"
+					/>
+				</div>
+				<div class="pfb-insp-row">
+					<span class="pfb-insp-label">{{ __("Width") }}</span>
+					<input
+						type="text"
+						class="pfb-insp-input"
+						:placeholder="__('auto — e.g. 40mm, 200px, 50%')"
+						:value="selected_field.width"
+						@change="selected_field.width = $event.target.value.trim()"
+					/>
+				</div>
+				<SegmentedRow
+					:label="__('Align')"
+					:model-value="current_align"
+					:options="align_opts"
+					@update:model-value="(v) => (selected_field.align = v)"
+				/>
+			</template>
+			<template v-else-if="is_barcode_element">
+				<div class="pfb-insp-row">
+					<span class="pfb-insp-label">{{ __("Value from") }}</span>
+					<select
+						class="pfb-insp-select"
+						:value="selected_field.barcode_field || ''"
+						@change="selected_field.barcode_field = $event.target.value"
+					>
+						<option value="">{{ __("Static value") }}</option>
+						<option v-for="f in barcode_field_options" :key="f.value" :value="f.value">
+							{{ f.label }}
+						</option>
+					</select>
+				</div>
+				<div class="pfb-insp-row" v-if="!selected_field.barcode_field">
+					<span class="pfb-insp-label">{{ __("Value") }}</span>
+					<input
+						type="text"
+						class="pfb-insp-input"
+						:placeholder="__('Static value')"
+						:value="selected_field.barcode_value"
+						@change="selected_field.barcode_value = $event.target.value"
+					/>
+				</div>
+				<div class="pfb-insp-row">
+					<span class="pfb-insp-label">{{ __("Format") }}</span>
+					<select
+						class="pfb-insp-select"
+						:value="selected_field.barcode_format || 'CODE128'"
+						@change="selected_field.barcode_format = $event.target.value"
+					>
+						<option v-for="fmt in barcode_formats" :key="fmt" :value="fmt">
+							{{ fmt }}
+						</option>
+					</select>
+				</div>
+				<div class="pfb-insp-row">
+					<span class="pfb-insp-label">{{ __("Width") }}</span>
+					<input
+						type="text"
+						class="pfb-insp-input"
+						:placeholder="__('auto — e.g. 40mm, 200px, 50%')"
+						:value="selected_field.width"
+						@change="selected_field.width = $event.target.value.trim()"
+					/>
+				</div>
+				<div class="pfb-insp-row" v-if="selected_field.barcode_format !== 'QR'">
+					<label class="pfb-insp-check">
+						<input
+							type="checkbox"
+							:checked="selected_field.show_text !== false"
+							@change="selected_field.show_text = $event.target.checked"
+						/>
+						{{ __("Show value text") }}
+					</label>
+				</div>
+				<SegmentedRow
+					:label="__('Align')"
+					:model-value="current_align"
+					:options="align_opts"
+					@update:model-value="(v) => (selected_field.align = v)"
+				/>
+			</template>
 			<template v-else>
 				<LabelField
 					v-model="selected_field.label"
@@ -78,7 +195,7 @@
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { computed, inject } from "vue";
 import LabelField from "./LabelField.vue";
 import SegmentedRow from "./SegmentedRow.vue";
 import InspectorSection from "./InspectorSection.vue";
@@ -93,6 +210,36 @@ defineProps(["fieldIsInline"]);
 const { selected_field, preview_doc } = useSelectedField();
 
 let is_html_field = computed(() => selected_field.value?.fieldtype === "HTML");
+let is_image_element = computed(
+	() => selected_field.value?.fieldtype === "Image" && selected_field.value?.custom
+);
+let is_barcode_element = computed(
+	() => selected_field.value?.fieldtype === "Barcode" && selected_field.value?.custom
+);
+
+const barcode_formats = ["CODE128", "CODE39", "EAN13", "EAN8", "UPC", "ITF14", "MSI", "QR"];
+
+let store = inject("$store");
+
+let barcode_field_options = computed(() => {
+	const fields = store.meta.value?.fields || [];
+	return [
+		{ label: __("ID (name)"), value: "name" },
+		...fields
+			.filter((f) => !frappe.model.no_value_type.includes(f.fieldtype))
+			.map((f) => ({ label: f.label || f.fieldname, value: f.fieldname })),
+	];
+});
+
+function upload_image() {
+	new frappe.ui.FileUploader({
+		folder: "Home/Attachments",
+		restrictions: { allowed_file_types: ["image/*"] },
+		on_success: (file_doc) => {
+			selected_field.value.image_url = file_doc.file_url;
+		},
+	});
+}
 
 let short_fieldtype = computed(() => {
 	if (!selected_field.value) return "";

--- a/frappe/public/js/print_format_builder/components/inspector/ImageUploadControl.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/ImageUploadControl.vue
@@ -1,0 +1,47 @@
+<template>
+	<div class="pfb-image-upload">
+		<div v-if="modelValue" class="pfb-image-upload-preview">
+			<img :src="modelValue" :alt="alt || ''" />
+		</div>
+		<div class="pfb-image-upload-actions">
+			<button class="es-button" data-size="xs" @click="upload">
+				<span v-html="frappe.utils.icon('upload', 'xs')"></span>
+				{{ modelValue ? __("Change Image") : __("Upload Image") }}
+			</button>
+			<button
+				v-if="modelValue"
+				class="es-button"
+				data-size="xs"
+				data-theme="red"
+				data-variant="ghost"
+				@click="$emit('update:modelValue', '')"
+			>
+				{{ __("Clear") }}
+			</button>
+		</div>
+		<input
+			type="text"
+			class="pfb-insp-input"
+			:placeholder="__('or image URL')"
+			:value="modelValue"
+			@change="$emit('update:modelValue', $event.target.value.trim())"
+		/>
+	</div>
+</template>
+
+<script setup>
+defineProps({
+	modelValue: { type: String, default: "" },
+	alt: { type: String, default: "" },
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+function upload() {
+	new frappe.ui.FileUploader({
+		folder: "Home/Attachments",
+		restrictions: { allowed_file_types: ["image/*"] },
+		on_success: (file_doc) => emit("update:modelValue", file_doc.file_url),
+	});
+}
+</script>

--- a/frappe/public/js/print_format_builder/components/inspector/LetterHeadZoneInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/LetterHeadZoneInspector.vue
@@ -90,13 +90,11 @@
 						@input="(e) => set_size(e.target.value)"
 					/>
 				</div>
-				<!-- Actions -->
-				<div class="pfb-lh-actions">
-					<button class="es-button" data-size="xs" @click="upload_image">
-						<span v-html="frappe.utils.icon('upload', 'xs')"></span>
-						{{ letterhead[image_field] ? __("Change Image") : __("Upload Image") }}
-					</button>
-				</div>
+				<!-- Image source -->
+				<ImageUploadControl
+					:model-value="letterhead[image_field] || ''"
+					@update:model-value="set_image"
+				/>
 			</template>
 			<template v-else>
 				<p class="pfb-insp-hint text-muted">
@@ -113,6 +111,7 @@ import { useStore } from "../../stores";
 import { get_image_dimensions, render_jinja_html } from "../../utils";
 import SegmentedRow from "./SegmentedRow.vue";
 import InspectorSection from "./InspectorSection.vue";
+import ImageUploadControl from "./ImageUploadControl.vue";
 
 const props = defineProps({
 	zone: { type: String, required: true },
@@ -184,29 +183,29 @@ function set_size(val) {
 	letterhead.value._dirty = true;
 }
 
-function upload_image() {
-	new frappe.ui.FileUploader({
-		folder: "Home/Attachments",
-		on_success: (file_doc) => {
-			get_image_dimensions(file_doc.file_url).then(({ width, height }) => {
-				aspect_ratio.value = width / height;
-				range_field.value =
-					aspect_ratio.value > 1 ? width_field.value : height_field.value;
-				let new_width = width > 200 ? 200 : width;
-				let new_height = new_width / aspect_ratio.value;
-				if (new_height > 80) {
-					new_height = 80;
-					new_width = aspect_ratio.value * new_height;
-				}
-				letterhead.value[image_field.value] = file_doc.file_url;
-				letterhead.value[width_field.value] = new_width;
-				letterhead.value[height_field.value] = new_height;
-				if (props.zone === "footer") {
-					letterhead.value[source_field.value] = "Image";
-				}
-				letterhead.value._dirty = true;
-			});
-		},
+function set_image(url) {
+	if (!letterhead.value) return;
+	if (!url) {
+		letterhead.value[image_field.value] = "";
+		letterhead.value._dirty = true;
+		return;
+	}
+	get_image_dimensions(url).then(({ width, height }) => {
+		aspect_ratio.value = width / height;
+		range_field.value = aspect_ratio.value > 1 ? width_field.value : height_field.value;
+		let new_width = width > 200 ? 200 : width;
+		let new_height = new_width / aspect_ratio.value;
+		if (new_height > 80) {
+			new_height = 80;
+			new_width = aspect_ratio.value * new_height;
+		}
+		letterhead.value[image_field.value] = url;
+		letterhead.value[width_field.value] = new_width;
+		letterhead.value[height_field.value] = new_height;
+		if (props.zone === "footer") {
+			letterhead.value[source_field.value] = "Image";
+		}
+		letterhead.value._dirty = true;
 	});
 }
 

--- a/frappe/public/js/print_format_builder/inspector.css
+++ b/frappe/public/js/print_format_builder/inspector.css
@@ -226,3 +226,35 @@
 	padding: 16px 20px;
 	font-size: var(--text-sm);
 }
+
+/* ── Image / Barcode element rows ───────────────────────── */
+.pfb-image-source {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.pfb-image-thumb {
+	max-height: 36px;
+	max-width: 72px;
+	object-fit: contain;
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	background: var(--fg-color);
+}
+
+.pfb-image-actions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.pfb-insp-check {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: var(--text-sm);
+	color: var(--text-color);
+	cursor: pointer;
+	margin: 0;
+}

--- a/frappe/public/js/print_format_builder/inspector.css
+++ b/frappe/public/js/print_format_builder/inspector.css
@@ -228,25 +228,43 @@
 }
 
 /* ── Image / Barcode element rows ───────────────────────── */
-.pfb-image-source {
+.pfb-image-upload {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	min-width: 0;
+}
+
+.pfb-image-upload-preview {
 	display: flex;
 	align-items: center;
-	gap: 8px;
-}
-
-.pfb-image-thumb {
-	max-height: 36px;
-	max-width: 72px;
-	object-fit: contain;
+	justify-content: center;
+	width: 100%;
+	max-height: 120px;
+	padding: 4px;
+	overflow: hidden;
 	border: 1px solid var(--border-color);
 	border-radius: var(--radius);
-	background: var(--fg-color);
+	background: var(--gray-50);
+	box-sizing: border-box;
 }
 
-.pfb-image-actions {
+.pfb-image-upload-preview img {
+	display: block;
+	max-width: 100%;
+	max-height: 110px;
+	object-fit: contain;
+}
+
+.pfb-image-upload-actions {
 	display: flex;
 	align-items: center;
 	gap: 4px;
+}
+
+.pfb-size-slider {
+	width: 100%;
+	accent-color: var(--primary);
 }
 
 .pfb-insp-check {

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -170,6 +170,13 @@ export const FIELD_PLUCK_KEYS = [
 	"label_gap",
 	"visible_if",
 	"custom_style",
+	"custom",
+	"image_url",
+	"width",
+	"barcode_field",
+	"barcode_value",
+	"barcode_format",
+	"show_text",
 ];
 
 export const ZONE_FIELD_PLUCK_KEYS = [
@@ -191,6 +198,13 @@ export const ZONE_FIELD_PLUCK_KEYS = [
 	"label_gap",
 	"visible_if",
 	"custom_style",
+	"custom",
+	"image_url",
+	"width",
+	"barcode_field",
+	"barcode_value",
+	"barcode_format",
+	"show_text",
 ];
 
 export function serialize_layout(layout) {

--- a/frappe/templates/print_format/macros/Barcode.html
+++ b/frappe/templates/print_format/macros/Barcode.html
@@ -1,0 +1,14 @@
+{%- set bval = value if (value and not df.get('custom')) else (doc.get(df.barcode_field) if df.barcode_field else df.barcode_value) -%}
+{%- if bval or df.get('_qr_data_uri') -%}
+<div class="field print-barcode{% if df.align %} field-align-{{ df.align }}{% endif %}"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
+	{%- if df.barcode_format == 'QR' -%}
+	{%- if df.get('_qr_data_uri') -%}
+	<img src="{{ df._qr_data_uri }}" alt="QR" style="{% if df.width %}width: {{ df.width|e }};{% else %}width: 35mm;{% endif %}">
+	{%- endif -%}
+	{%- elif bval is string and bval.startswith('<svg') -%}
+	<div style="display: inline-block;{% if df.width %} width: {{ df.width|e }};{% endif %}">{{ bval }}</div>
+	{%- else -%}
+	<div style="display: inline-block;{% if df.width %} width: {{ df.width|e }};{% endif %}"><svg data-barcode-value="{{ bval|e }}" data-options='{{ df.get("_barcode_options") or "{}" }}'></svg></div>
+	{%- endif -%}
+</div>
+{%- endif -%}

--- a/frappe/templates/print_format/macros/Image.html
+++ b/frappe/templates/print_format/macros/Image.html
@@ -1,0 +1,6 @@
+{%- set src = df.image_url or value -%}
+{%- if src -%}
+<div class="field print-image{% if df.align %} field-align-{{ df.align }}{% endif %}"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
+	<img src="{{ src }}" alt="{{ _(df.label) if df.label else '' }}" style="max-width: 100%;{% if df.width %} width: {{ df.width|e }};{% endif %}">
+</div>
+{%- endif -%}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -50,7 +50,7 @@
 	{%- set ns = namespace(has_content=false) -%}
 	{%- for column in section.columns -%}
 		{%- for df in column.fields -%}
-			{%- if df.fieldtype in ('HTML', 'Divider', 'Spacer', 'Field Template') -%}
+			{%- if df.fieldtype in ('HTML', 'Divider', 'Spacer', 'Field Template', 'Image', 'Barcode') -%}
 				{%- set ns.has_content = true -%}
 			{%- elif df.fieldtype == 'Repeater' -%}
 				{%- if df.source and doc.get(df.source) -%}
@@ -132,5 +132,7 @@
 	{%- endif -%}
 	{%- endif -%}
 	{{ footer or '' }}
+	{{ include_script('print.bundle.js') }}
+	<script>document.querySelectorAll("svg[data-barcode-value]").forEach(render_barcode);</script>
 </body>
 </html>

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -33,15 +33,15 @@ def download_pdf(doctype: str, name: str | int, print_format: str, letterhead: s
 
 @frappe.whitelist()
 def get_qr_code(value: str) -> str:
-	"""Return a QR code for `value` as a PNG data URI (used by Barcode print elements)."""
+	"""Return a QR code for `value` as an SVG data URI (used by Barcode print elements)."""
 	import base64
 	import io
 
 	from pyqrcode import create as qrcreate
 
 	stream = io.BytesIO()
-	qrcreate(value).png(stream, scale=5, quiet_zone=1)
-	return "data:image/png;base64," + base64.b64encode(stream.getvalue()).decode()
+	qrcreate(value).svg(stream, scale=5, quiet_zone=1)
+	return "data:image/svg+xml;base64," + base64.b64encode(stream.getvalue()).decode()
 
 
 def get_html(doctype, name, print_format, letterhead=None):

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -31,6 +31,19 @@ def download_pdf(doctype: str, name: str | int, print_format: str, letterhead: s
 	frappe.local.response.type = "pdf"
 
 
+@frappe.whitelist()
+def get_qr_code(value: str) -> str:
+	"""Return a QR code for `value` as a PNG data URI (used by Barcode print elements)."""
+	import base64
+	import io
+
+	from pyqrcode import create as qrcreate
+
+	stream = io.BytesIO()
+	qrcreate(value).png(stream, scale=5, quiet_zone=1)
+	return "data:image/png;base64," + base64.b64encode(stream.getvalue()).decode()
+
+
 def get_html(doctype, name, print_format, letterhead=None):
 	doc = frappe.get_doc(doctype, name)
 	doc.check_permission("print")
@@ -236,6 +249,19 @@ class PrintFormatGenerator:
 <div style="height:12px"></div>
 {%- elif df.fieldtype == 'Divider' -%}
 <hr style="border-top:1px solid #e5e7eb;margin:4px 0"/>
+{%- elif df.fieldtype == 'Image' -%}
+{%- set _src = df.image_url or doc.get(df.fieldname) -%}
+{%- if _src -%}
+<div{% if df.align and df.align != 'left' %} style="text-align:{{ df.align }}"{% endif %}>
+<img src="{{ _src }}" style="max-width:100%;{% if df.width %}width:{{ df.width|e }};{% endif %}">
+</div>
+{%- endif -%}
+{%- elif df.fieldtype == 'Barcode' -%}
+{%- if df.get('_qr_data_uri') -%}
+<div{% if df.align and df.align != 'left' %} style="text-align:{{ df.align }}"{% endif %}>
+<img src="{{ df._qr_data_uri }}" style="{% if df.width %}width:{{ df.width|e }};{% else %}width:35mm;{% endif %}">
+</div>
+{%- endif -%}
 {%- else -%}
 {%- set _raw = doc.get(df.fieldname) -%}
 {%- if _raw is not none and _raw != '' -%}
@@ -301,6 +327,7 @@ class PrintFormatGenerator:
 					fieldtype = df["fieldtype"]
 					df["renderer"] = renderers.get(fieldtype) or fieldtype.replace(" ", "")
 					df["section"] = section
+					self.prepare_barcode(df)
 
 		# Also process header/footer zones if they are section objects
 		for zone_key in ("header", "footer"):
@@ -316,8 +343,30 @@ class PrintFormatGenerator:
 						fieldtype = df.get("fieldtype", "Data")
 						df["renderer"] = renderers.get(fieldtype) or fieldtype.replace(" ", "")
 						df["section"] = zone
+						self.prepare_barcode(df)
 
 		return layout
+
+	def prepare_barcode(self, df):
+		"""Resolve JsBarcode options / QR data URI for Barcode layout elements."""
+		if df.get("fieldtype") != "Barcode" or not df.get("custom"):
+			return
+		if df.get("barcode_format") == "QR":
+			value = (
+				self.doc.get(df.get("barcode_field")) if df.get("barcode_field") else df.get("barcode_value")
+			)
+			if value:
+				df["_qr_data_uri"] = get_qr_code(str(value))
+		else:
+			df["_barcode_options"] = frappe.as_json(
+				{
+					"format": df.get("barcode_format") or "CODE128",
+					"displayValue": bool(df.get("show_text", True)),
+					"height": 40,
+					"margin": 0,
+				},
+				indent=None,
+			)
 
 	def process_margin_texts(self, layout):
 		for key in (*self._TOP_POSITIONS, *self._BOTTOM_POSITIONS):


### PR DESCRIPTION
- New **Image** block in the builder palette
- New **Barcode** block: value from a doc field or static text, formats
- Linear barcodes render via the existing `print.bundle.js` JsBarcode pipeline (browser print view, print preview and Chrome PDF); QR codes are generated server-side with pyqrcode as a data-URI PNG
- Palette clone now preserves the `custom` flag, so custom blocks get unique fieldnames as originally intended


https://github.com/user-attachments/assets/20b6584c-0d08-46c1-8206-acf128a79df5

> Known limitation: linear barcodes inside repeating header/footer zones don't render in the Chrome PDF overlay (overlay height is measured before client-side JsBarcode could draw; needs server-side generation — follow-up). QR works everywhere; body sections fully supported.

`no-docs`