### PR TITLE
fix: avoid field masking when permissions are ignored

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -347,9 +347,10 @@ class Engine:
 
 		self.add_permission_conditions()
 
-		# Store metadata for masked field processing during execution
-		self.query._doctype = self.doctype
-		self.query._fields_list = getattr(self, "fields", [])
+		if self.apply_permissions:
+			# Store metadata for masked field processing during execution.
+			self.query._doctype = self.doctype
+			self.query._fields_list = getattr(self, "fields", [])
 
 		self.query.immutable = True
 		return self.query

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -240,7 +240,7 @@ class DatabaseQuery:
 		if pluck:
 			return [d[pluck] for d in result]
 
-		if self.doctype and result:
+		if self.doctype and result and not self.flags.ignore_permissions:
 			result = self.mask_fields(result)
 
 		return result

--- a/frappe/tests/test_mask_fields.py
+++ b/frappe/tests/test_mask_fields.py
@@ -219,6 +219,21 @@ class TestMaskFieldsBehaviour(IntegrationTestCase):
 		)
 		self.assertEqual(rows[0]["secret_data"], "top_secret_value")
 
+	def test_db_get_value_does_not_mask_when_permissions_are_ignored(self):
+		frappe.set_user(self.TEST_USER)
+		value = frappe.db.get_value(self.dt, self.docname, "secret_data")
+		self.assertEqual(value, "top_secret_value")
+
+	def test_qb_get_query_does_not_mask_when_permissions_are_ignored(self):
+		frappe.set_user(self.TEST_USER)
+		rows = frappe.qb.get_query(
+			self.dt,
+			fields=["secret_data"],
+			filters={"name": self.docname},
+			ignore_permissions=True,
+		).run(as_dict=True)
+		self.assertEqual(rows[0]["secret_data"], "top_secret_value")
+
 	def test_legacy_db_query_does_not_mask_when_permissions_are_ignored(self):
 		frappe.set_user(self.TEST_USER)
 		from frappe.model.db_query import DatabaseQuery

--- a/frappe/tests/test_mask_fields.py
+++ b/frappe/tests/test_mask_fields.py
@@ -219,6 +219,17 @@ class TestMaskFieldsBehaviour(IntegrationTestCase):
 		)
 		self.assertEqual(rows[0]["secret_data"], "top_secret_value")
 
+	def test_legacy_db_query_does_not_mask_when_permissions_are_ignored(self):
+		frappe.set_user(self.TEST_USER)
+		from frappe.model.db_query import DatabaseQuery
+
+		rows = DatabaseQuery(self.dt).execute(
+			fields=["secret_data"],
+			filters={"name": self.docname},
+			ignore_permissions=True,
+		)
+		self.assertEqual(rows[0]["secret_data"], "top_secret_value")
+
 	# ------------------------------------------------------------------
 	# Save: server hooks and permission checks see real values
 	# ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- skip field masking in legacy DatabaseQuery when permissions are ignored
- skip query-builder result masking when the query is built without permissions
- make query report masking resolve mask permissions for the target report user

## Tests
- bench --site dev.localhost run-tests --app frappe --module frappe.tests.test_mask_fields