### PR TITLE
fix(report-view): bind inline edit to row at edit start, not submit

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -703,16 +703,16 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 		control.df.change = () => control.set_focus();
 
+		const cell = this.datatable.getCell(colIndex, rowIndex);
+		const fieldname = this.datatable.getColumn(colIndex).docfield.fieldname;
+		const docname = cell.name;
+		const doctype = cell.doctype;
+
 		return {
 			initValue: (value) => {
 				return control.set_value(value);
 			},
 			setValue: (value) => {
-				const cell = this.datatable.getCell(colIndex, rowIndex);
-				let fieldname = this.datatable.getColumn(colIndex).docfield.fieldname;
-				let docname = cell.name;
-				let doctype = cell.doctype;
-
 				control.set_value(value);
 				return this.set_control_value(doctype, docname, fieldname, value)
 					.then((updated_doc) => {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -746,6 +746,12 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 								_data[field] = updated_doc[field];
 							}
 						}
+
+						const cell_at_index =
+							this.datatable.datamanager.rows[rowIndex]?.[colIndex];
+						if (cell_at_index?.name !== docname) {
+							this.datatable.refresh(this.get_data(this.data), this.columns);
+						}
 					})
 					.then(() => this.refresh_charts());
 			},


### PR DESCRIPTION
## Description

Editing a cell in Report View could save changes to the wrong record if a quick filter changed while the cell was still being edited.

The editor previously captured only the `rowIndex` and `colIndex`. When the edit was submitted, the target document was resolved by calling `getCell(colIndex, rowIndex)`. If a quick filter had been applied or cleared in the meantime, the datatable rebuilt its row view, causing the same row index to point to a different record. As a result, the edited value could be written to the wrong document.

The target cell is now resolved when editing begins, while the row index still maps to the correct record, and the captured document identity is used throughout the save operation.

The change also keeps the UI in sync after the save completes. The current cell at the original index is compared with the captured record, and the datatable is re-rendered only if the row ordering changed while the edit was in progress. This avoids unnecessary re-renders while ensuring the displayed data remains accurate.

Although the issue was reported for a child table column, the underlying behavior affects all inline-editable columns in Report View.

---
### Before

Filter Users down to Jane so she's the only row, start editing her Username, then clear the filter without clicking out. The edit lands on Agent - the user now sitting in row 0 - and Jane is untouched.

https://github.com/user-attachments/assets/ea599a42-6c25-4c88-a6ad-6df8248a224c

---

### After

Same steps. The edit saves to Jane, because the row is resolved when editing
starts rather than when the value is submitted.

https://github.com/user-attachments/assets/b556b746-29db-4037-a6e6-3773bf6316cf

---


Closes #39249.