### PR TITLE
fix: don't mutate caller's get_query().filters in MultiSelectDialog

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -547,7 +547,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 
 	get_filters_from_setters() {
 		let me = this;
-		let filters = (this.get_query ? this.get_query().filters : {}) || {};
+		let filters = Object.assign({}, (this.get_query ? this.get_query().filters : {}) || {});
 		let filter_fields = [];
 
 		if ($.isArray(this.setters)) {

--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -547,7 +547,10 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 
 	get_filters_from_setters() {
 		let me = this;
-		let filters = Object.assign({}, (this.get_query ? this.get_query().filters : {}) || {});
+		let query_filters = (this.get_query ? this.get_query().filters : {}) || {};
+		let filters = Array.isArray(query_filters)
+			? query_filters.slice()
+			: Object.assign({}, query_filters);
 		let filter_fields = [];
 
 		if ($.isArray(this.setters)) {


### PR DESCRIPTION
Resolve: #40347

---
**Testing**

Verified with a console script | `get_filters_from_setters()` / `get_args_for_search()` directly against a shared filters object (simulating a caller like `erpnext.utils.map_current_doc` that reuses the same object across searches):

```js
(async () => {
	const sharedFilters = { docstatus: ["!=", 2] };
	const d = new frappe.ui.form.MultiSelectDialog({
		doctype: "ToDo",
		target: {},
		setters: {},
		get_query: () => ({ filters: sharedFilters }),
		add_filters_group: 1,
		action: () => {},
	});

	await new Promise((r) => setTimeout(r, 300));

	const [filters1] = d.get_filters_from_setters();
	console.log("PASS: returns a clone, not the same reference =", filters1 !== sharedFilters);

	d.get_custom_filters = () => ({ owner: ["=", "test@example.com"] });
	d.get_args_for_search();
	console.log("PASS: caller's object untouched after custom filter added =", !("owner" in sharedFilters));

	d.get_custom_filters = () => ({});
	d.get_args_for_search();
	console.log("PASS: caller's object still clean after filter removed =", !("owner" in sharedFilters));

	d.dialog.hide();
})();
```

**Output**
PASS: returns a clone, not the same reference = true
PASS: caller's object untouched after custom filter added = true
PASS: caller's object still clean after filter removed = true

