### PR TITLE
fix: xls file import fails with "startswith first arg must be str or a tuple of str, not bytes"

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -44,6 +44,8 @@ ImageFile.LOAD_TRUNCATED_IMAGES = True  # nosemgrep
 
 URL_PREFIXES = ("http://", "https://", "/api/method/")
 FILE_ENCODING_OPTIONS = ("utf-8-sig", "utf-8", "windows-1250", "windows-1252")
+# OLE2 Compound File Binary signature, used by legacy .xls/.doc/.ppt files, which filetype fails to detect
+OLE_FILE_SIGNATURE = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
 
 
 class File(Document):
@@ -681,7 +683,7 @@ class File(Document):
 			self._content = f.read()
 			# Only decode if not a binary file
 			kind = filetype.guess(self._content)
-			if not kind:
+			if not kind and not self._content.startswith(OLE_FILE_SIGNATURE):
 				# looping will not result in slowdown, as the content is usually utf-8 or utf-8-sig
 				# encoded so the first iteration will be enough most of the time
 				for encoding in encodings:

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -83,6 +83,29 @@ class TestSimpleFile(IntegrationTestCase):
 		self.assertEqual(content, self.test_content)
 
 
+class TestBinaryFileContent(IntegrationTestCase):
+	def test_ole_xls_content_not_decoded(self):
+		from frappe.core.doctype.file.file import OLE_FILE_SIGNATURE
+
+		attached_to_doctype, attached_to_docname = make_test_doc()
+		xls_content = OLE_FILE_SIGNATURE + b"\x00\x01Sheet1\x00Amount\x00" + b"\x20" * 64
+		_file = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": f"statement-{frappe.generate_hash(length=8)}.xls",
+				"attached_to_doctype": attached_to_doctype,
+				"attached_to_name": attached_to_docname,
+				"content": xls_content,
+			}
+		)
+		_file.save()
+
+		saved_file = frappe.get_doc("File", _file.name)
+		content = saved_file.get_content()
+		self.assertIsInstance(content, bytes)
+		self.assertTrue(content.startswith(OLE_FILE_SIGNATURE))
+
+
 class TestFSRollbacks(IntegrationTestCase):
 	def test_rollback_from_file_system(self):
 		file_name = content = frappe.generate_hash()


### PR DESCRIPTION
## Description

Fixes an issue where importing legacy `.xls` files failed with `startswith first arg must be str or a tuple of str, not bytes`.

The content loader incorrectly decoded OLE2 files as text because their format wasn't detected, causing `.xls` data to be passed to `xlrd` as a string instead of bytes.

This change preserves OLE2 files as binary content, allowing `.xls` imports to work correctly while leaving `.xlsx` behavior unchanged.

Closes #40591.