### PR TITLE
fix: code fields show stale value after navigating between documents

### DIFF
--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -181,6 +181,10 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 		this.editor.resize();
 	}
 
+	on_section_collapse(hide) {
+		!hide && this.editor?.resize();
+	}
+
 	toggle_label() {
 		this.$expand_button && this.$expand_button.text(this.get_button_label());
 	}


### PR DESCRIPTION
## Description

Fixes an issue where `Code` fields inside collapsed sections could display stale values after navigating between documents.

The editor was updated with the new value, but Ace didn't repaint while hidden inside a collapsed section, so expanding it showed the previous document's content.

This adds the section expand hook to `ControlCode` so the editor resizes and repaints when the section is opened.

Closes #40151.