### PR TITLE
feat(postgres): add transaction-scoped advisory lock

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1531,6 +1531,12 @@ class Database:
 		pg_advisory_lock, MariaDB uses GET_LOCK; engines without advisory locks raise."""
 		raise NotImplementedError(f"Advisory locks are not supported on {self.db_type}.")
 
+	def transaction_advisory_lock(self, key, *, timeout=10):
+		"""Take an advisory lock released automatically when the current transaction ends.
+		Postgres only (pg_advisory_xact_lock); other engines have no transaction-scoped
+		advisory locks and raise."""
+		raise NotImplementedError(f"Transaction-scoped advisory locks are not supported on {self.db_type}.")
+
 	def create_sequence_table(self):
 		# MariaDB/Postgres have native sequences and need no backing table;
 		# SQLite overrides this to create its emulation table at site setup.

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -697,23 +697,39 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			self._cursor = original_cursor
 			new_cursor.close()
 
+	@staticmethod
+	def _advisory_lock_key(key) -> int:
+		import hashlib
+
+		return int.from_bytes(hashlib.sha256(str(key).encode()).digest()[:8], "big", signed=True)
+
+	def _poll_advisory_lock(self, try_function, key, timeout):
+		import time
+
+		from frappe.exceptions import QueryTimeoutError
+
+		lock_key = self._advisory_lock_key(key)
+		deadline = time.monotonic() + timeout
+		while not self.sql(f"SELECT {try_function}(%s)", (lock_key,))[0][0]:
+			if time.monotonic() >= deadline:
+				raise QueryTimeoutError(f"Could not acquire advisory lock {key!r} within {timeout}s")
+			time.sleep(0.1)
+		return lock_key
+
+	def transaction_advisory_lock(self, key, *, timeout=10):
+		"""Take an advisory lock that Postgres releases automatically when the current transaction
+		commits or rolls back (pg_advisory_xact_lock) -- no explicit unlock, participates in
+		deadlock detection alongside row locks, re-entrant within a transaction. Polls up to
+		`timeout` seconds, then raises QueryTimeoutError."""
+		self._poll_advisory_lock("pg_try_advisory_xact_lock", key, timeout)
+
 	@contextmanager
 	def advisory_lock(self, key, *, timeout=10):
 		"""Hold a session-level advisory lock for the duration of the `with` block. Session-scoped
 		(pg_advisory_lock) so it survives any intermediate commits the caller makes -- a txn-scoped
 		lock would release at the first commit. Polls pg_try_advisory_lock up to `timeout` seconds,
 		then raises QueryTimeoutError. `key` is hashed to the bigint the lock functions expect."""
-		import hashlib
-		import time
-
-		from frappe.exceptions import QueryTimeoutError
-
-		lock_key = int.from_bytes(hashlib.sha256(str(key).encode()).digest()[:8], "big", signed=True)
-		deadline = time.monotonic() + timeout
-		while not self.sql("SELECT pg_try_advisory_lock(%s)", (lock_key,))[0][0]:
-			if time.monotonic() >= deadline:
-				raise QueryTimeoutError(f"Could not acquire advisory lock {key!r} within {timeout}s")
-			time.sleep(0.1)
+		lock_key = self._poll_advisory_lock("pg_try_advisory_lock", key, timeout)
 		try:
 			yield
 		finally:

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1236,6 +1236,17 @@ class TestTransactionManagement(IntegrationTestCase):
 		frappe.db.commit()
 		self.assertEqual(_get_transaction_id(), _get_transaction_id())
 
+	def test_transaction_advisory_lock(self):
+		def advisory_count():
+			return frappe.db.sql("SELECT count(*) FROM pg_locks WHERE locktype = 'advisory'")[0][0]
+
+		before = advisory_count()
+		frappe.db.transaction_advisory_lock("frappe-test-xact-lock")
+		self.assertEqual(advisory_count(), before + 1)
+		frappe.db.transaction_advisory_lock("frappe-test-xact-lock")  # re-entrant
+		frappe.db.rollback()
+		self.assertEqual(advisory_count(), before)
+
 
 # Treat same DB as replica for tests, a separate connection will be opened
 class TestReplicaConnections(IntegrationTestCase):


### PR DESCRIPTION
`frappe.db.transaction_advisory_lock(key)` takes `pg_advisory_xact_lock`: released automatically when the transaction commits or rolls back, participates in deadlock detection alongside row locks, re-entrant within a transaction, and polls with the same timeout semantics as the session-scoped `advisory_lock` (key hashing and the polling loop are now shared helpers).

The base class raises `NotImplementedError`: MariaDB's `GET_LOCK` is session-only and non-transactional, so a cross-engine emulation would have wrong release semantics — callers must gate on `db_type`.

Motivation: lets apps serialize validate-then-commit sections on Postgres without row-locking large history ranges. First consumer is ERPNext's batch valuation, which currently row-locks an item's entire SLE history per outward movement on Postgres (a lock-marker write on every historical tuple); with this it takes one in-memory lock instead. Companion ERPNext PR to follow.

Test: `test_transaction_advisory_lock` in `TestTransactionManagement` — asserts the lock is visible in `pg_locks`, re-entrant, and released on rollback.


no-docs — developer-level `frappe.db` primitive, documented by its docstring.
