### PR TITLE
fix: remove attribution link from about dialog

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/about.js
+++ b/frappe/public/js/frappe/ui/toolbar/about.js
@@ -73,13 +73,6 @@ frappe.ui.misc.about = function () {
 				</div>
 
 				<div id='about-app-versions'>${__("Loading versions...")}</div>
-				<p>
-					<b>
-						<a href="/attribution" target="_blank" class="text-muted">
-							${__("Dependencies & Licenses")}
-						</a>
-					</b>
-				</p>
 
 				<hr>
 


### PR DESCRIPTION
- closes: https://github.com/frappe/frappe/issues/35267

- Related PR: https://github.com/frappe/frappe/pull/24209