### PR TITLE
fix: dashboard quick list check filter drops "= No"

### DIFF
--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -18,6 +18,24 @@ context("List View", () => {
 		cy.get(".list-row-container .list-row-checkbox:checked").should("be.visible");
 	});
 
+	it("keeps a Check '= No' standard filter applied", { scrollBehavior: false }, () => {
+		cy.go_to_list("Web Page");
+		cy.clear_filters();
+		cy.window().then((win) => {
+			win.frappe.route_options = { published: ["=", 0] };
+			win.frappe.set_route("List", "Web Page");
+		});
+		cy.get(".filter-selector .filter-button .button-label").should("contain", "Filters");
+		cy.window()
+			.its("cur_list.filter_area")
+			.then((filter_area) => {
+				const has_published_no = filter_area
+					.get()
+					.some((f) => f[1] === "published" && String(f[3]) === "0");
+				expect(has_published_no, "published = No filter applied").to.be.true;
+			});
+	});
+
 	it('enables "Actions" button', { scrollBehavior: false }, () => {
 		const actions = [
 			"Approve",

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -804,8 +804,12 @@ class FilterArea {
 
 			// set in list view area if filters are present
 			// don't set like filter on link fields (gets reset)
+			// a Check standard filter is a checkbox that can't hold "= 0", so keep it as a regular filter
+			const is_unchecked_check =
+				fields_dict[fieldname]?.df?.fieldtype === "Check" && !cint(value);
 			if (
 				fields_dict[fieldname] &&
+				!is_unchecked_check &&
 				(condition === "=" ||
 					(condition === "like" && fields_dict[fieldname]?.df?.fieldtype != "Link") ||
 					(condition === "descendants of (inclusive)" &&


### PR DESCRIPTION
## Description

Fixes an issue where `Check = 0` filters were ignored when the field was configured as a standard list filter.

Standard filter checkboxes can't distinguish between "unchecked" and "no filter", so `Check = 0` was dropped before reaching the query. This change keeps `Check = 0` filters as regular filters, where the value is preserved correctly.

## Before/After

https://github.com/user-attachments/assets/eb37e245-eac9-495c-bc9b-e4eca1d61852

https://github.com/user-attachments/assets/cbd158ea-54d0-46bf-9f69-f360f18046ee

---
Closes #38931.