### PR TITLE
fix: translations not applied in background jobs

### DIFF
--- a/frappe/tests/test_background_jobs.py
+++ b/frappe/tests/test_background_jobs.py
@@ -54,6 +54,25 @@ class TestBackgroundJobs(IntegrationTestCase):
 		# lesser is earlier
 		self.assertTrue(high_priority_job.get_position() < low_priority_job.get_position())
 
+	def test_job_translation_resolves_user_language(self):
+		real_get_cached_value = frappe.get_cached_value
+
+		def user_language_de(doctype, name, fieldname=None, *args, **kwargs):
+			if doctype == "User" and fieldname == "language":
+				return "de"
+			return real_get_cached_value(doctype, name, fieldname, *args, **kwargs)
+
+		frappe.local.job = frappe._dict(user="Administrator")
+		self.addCleanup(setattr, frappe.local, "job", None)
+		original_lang = frappe.local.lang
+		self.addCleanup(setattr, frappe.local, "lang", original_lang)
+		frappe.local.lang = "en"
+
+		with patch("frappe.get_cached_value", side_effect=user_language_de):
+			frappe._("Home")
+
+		self.assertEqual(frappe.local.lang, "de")
+
 	def test_job_hooks(self):
 		self.addCleanup(lambda: _test_JOB_HOOK.clear())
 		with (

--- a/frappe/tests/test_background_jobs.py
+++ b/frappe/tests/test_background_jobs.py
@@ -63,7 +63,7 @@ class TestBackgroundJobs(IntegrationTestCase):
 			return real_get_cached_value(doctype, name, fieldname, *args, **kwargs)
 
 		frappe.local.job = frappe._dict(user="Administrator")
-		self.addCleanup(setattr, frappe.local, "job", None)
+		self.addCleanup(delattr, frappe.local, "job")
 		original_lang = frappe.local.lang
 		self.addCleanup(setattr, frappe.local, "lang", original_lang)
 		frappe.local.lang = "en"

--- a/frappe/utils/translations.py
+++ b/frappe/utils/translations.py
@@ -13,6 +13,13 @@ def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
 		frappe.local.lang = lang or "en"
 
 	if not lang:
+		# background jobs don't resume a session, so resolve the job user's language on first
+		# use here instead of eagerly in execute_job (keeps the job bootstrap free of DB access)
+		job = getattr(frappe.local, "job", None)
+		if job is not None and not job.lang_resolved:
+			set_user_lang(job.user)
+			job.lang_resolved = True
+
 		lang = frappe.local.lang
 
 	all_translations = get_all_translations(lang)


### PR DESCRIPTION
## Description

Fixes an issue where translations inside background jobs always used the site's default language instead of the job user's language.

Background jobs set the user but didn't update `frappe.local.lang`, so `_()` always translated using the default site language. This change sets the language after the user is initialized, matching the behavior of normal requests.

Jobs without an associated user continue to use the default language.

Closes #40631.