### PR TITLE
perf(grid): strip rich text instead of rendering html in static cells

### DIFF
--- a/cypress/integration/grid_rich_text.js
+++ b/cypress/integration/grid_rich_text.js
@@ -1,0 +1,62 @@
+context("Grid Rich Text Column", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/desk/website");
+		return cy
+			.window()
+			.its("frappe")
+			.then((frappe) => {
+				return frappe.xcall("frappe.tests.ui_test_helpers.create_child_doctype", {
+					name: "Child Test Rich Text",
+					fields: [
+						{
+							label: "Title",
+							fieldname: "title",
+							fieldtype: "Data",
+							in_list_view: 1,
+						},
+						{
+							label: "Content",
+							fieldname: "content",
+							fieldtype: "Text Editor",
+							in_list_view: 1,
+						},
+					],
+				});
+			})
+			.then((frappe) => {
+				return frappe.xcall("frappe.tests.ui_test_helpers.create_doctype", {
+					name: "Test Rich Text Grid",
+					fields: [
+						{
+							label: "Items",
+							fieldname: "items",
+							fieldtype: "Table",
+							options: "Child Test Rich Text",
+						},
+					],
+				});
+			});
+	});
+
+	it("shows stripped text instead of rendered HTML in static grid cells", () => {
+		cy.new_form("Test Rich Text Grid");
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				frm.add_child("items", {
+					title: "Row 1",
+					content: "<h1>Heading</h1><p><b>bold</b> and <i>italic</i></p>",
+				});
+				frm.refresh_field("items");
+			});
+
+		cy.get('.frappe-control[data-fieldname="items"]').as("table");
+		cy.get("@table")
+			.find('.grid-body .grid-row [data-fieldname="content"] .static-area')
+			.as("cell");
+		cy.get("@cell").should("contain.text", "Heading");
+		cy.get("@cell").should("contain.text", "bold and italic");
+		cy.get("@cell").find("h1, b, i, .ql-editor").should("not.exist");
+	});
+});

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -734,12 +734,7 @@ export default class GridRow {
 			let width = col[1];
 
 			let txt = this.doc
-				? frappe.format(
-						this._escape_for_format(this.doc[df.fieldname], df),
-						df,
-						null,
-						this.doc
-				  )
+				? this._format_static_value(this.doc[df.fieldname], df, this.doc)
 				: __(df.label, null, df.parent);
 
 			if (this.doc && df.fieldtype === "Select") {
@@ -1142,12 +1137,7 @@ export default class GridRow {
 					let df = this.grid.visible_columns[index][0];
 
 					let txt = this.doc
-						? frappe.format(
-								this._escape_for_format(this.doc[df.fieldname], df),
-								df,
-								null,
-								this.doc
-						  )
+						? this._format_static_value(this.doc[df.fieldname], df, this.doc)
 						: __(df.label, null, df.parent);
 
 					this.refresh_field(df.fieldname, txt);
@@ -1519,6 +1509,16 @@ export default class GridRow {
 		return value;
 	}
 
+	// Static cells clip to a single line, so building the full rich-text HTML per cell
+	// is wasted work — show stripped text instead, like the list view does.
+	_format_static_value(value, df, doc) {
+		const RICH_TEXT_FIELDTYPES = ["Text Editor", "HTML Editor", "Markdown Editor"];
+		if (df && RICH_TEXT_FIELDTYPES.includes(df.fieldtype)) {
+			return strip_html(cstr(value));
+		}
+		return frappe.format(this._escape_for_format(value, df), df, null, doc);
+	}
+
 	refresh_field(fieldname, txt) {
 		let fields =
 			this.grid.user_defined_columns && this.grid.user_defined_columns.length > 0
@@ -1531,21 +1531,11 @@ export default class GridRow {
 
 		// format values if no frm
 		if (df && this.doc) {
-			txt = frappe.format(
-				this._escape_for_format(this.doc[fieldname], df),
-				df,
-				null,
-				this.doc
-			);
+			txt = this._format_static_value(this.doc[fieldname], df, this.doc);
 		}
 
 		if (!txt && this.frm) {
-			txt = frappe.format(
-				this._escape_for_format(this.doc[fieldname], df),
-				df,
-				null,
-				this.frm.doc
-			);
+			txt = this._format_static_value(this.doc[fieldname], df, this.frm.doc);
 		}
 
 		// reset static value


### PR DESCRIPTION
## Description

Improves child table rendering performance for rich text fields in grid view.

Instead of rendering full HTML for static grid cells, rich text fields now display plain text while all other field types continue to use `frappe.format()`. The full editor content is still available when the row is opened.

Also adds a UI test to verify rich text cells render as plain text in the grid.

Closes #35289.