### PR TITLE
fix(dark-mode): contrast on custom HTML sidebar field in print format builder

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder.css
+++ b/frappe/printing/page/print_format_builder/print_format_builder.css
@@ -113,7 +113,8 @@
 }
 
 .print-format-builder-sidebar .sidebar-custom-field {
-	background-color: var(--gray-300);
+	background-color: var(--bg-gray);
+	color: var(--text-on-gray);
 }
 
 .print-format-builder-sidebar {


### PR DESCRIPTION
Resolve: #40477 

---

Before:
<img width="1832" height="591" alt="image" src="https://github.com/user-attachments/assets/ad7260af-7ad1-4e60-a7b9-87e46c9a98bd" />


After:

<img width="1832" height="591" alt="image" src="https://github.com/user-attachments/assets/de47c38e-aa8c-4e30-81d6-20df70bbe596" />
