### PR TITLE
fix: normalize Check formatter value with cint to prevent 0 rendering as checked

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -167,7 +167,7 @@ frappe.form.formatters = {
 	},
 	Check: function (value) {
 		return `<input type="checkbox" disabled
-			class="disabled-${value ? "selected" : "deselected"}">`;
+			class="disabled-${cint(value) ? "selected" : "deselected"}">`;
 	},
 
 	Link: function (value, docfield, options, doc) {


### PR DESCRIPTION
## Summary
Grid list-view cells render Check fields with value "0" (string) as checked, because JS truthiness treats non-empty strings as true. Web Form grids store the default as the string "0", so collapsed rows show a checked box while inline edit (ControlCheck, which uses cint) shows it unchecked.

Fix: normalize with `cint(value)` in `formatters -> Check`, matching `ControlCheck.set_input` and the existing `cint` normalization in grid.

Fixes #40652

### Before Fix
[Screencast from 2026-07-07 19-03-27.webm](https://github.com/user-attachments/assets/858f0cbd-2a16-4e49-bc04-f6f6db308935)

### After Fix
[Screencast from 2026-07-07 19-06-37.webm](https://github.com/user-attachments/assets/2f909de5-8ffa-4328-b69f-827ef412a25d)
