### PR TITLE
fix(query_builder): dont explode plucked scalars on masked doctypes

### DIFF
--- a/frappe/model/utils/mask.py
+++ b/frappe/model/utils/mask.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+from typing import Any
 
 
 def mask_field_value(field, val):
@@ -39,6 +40,51 @@ def mask_field_value(field, val):
 		return "XX-XX-XXXX XX:XX"
 	else:
 		return "XXXXXXXX"
+
+
+def mask_pluck_results(
+	result: list[Any],
+	masked_fields: list[Any],
+	fields: list[Any],
+) -> list[Any]:
+	"""Mask plucked (scalar) results.
+
+	With ``pluck``, the database layer has already reduced each row to the
+	scalar value of the first selected field, so ``result`` is a flat list of
+	values rather than a list of tuples/dicts. Mask each value when the
+	plucked expression references a masked field — directly, or transitively
+	through a wrapper (Coalesce, Max, aliased expressions, arithmetic, ...).
+
+	Args:
+		result: Flat list of scalar values (one per row)
+		masked_fields: List of DocField objects with masking configuration
+		fields: List of field objects from the query (the plucked field is first)
+
+	Returns:
+		List of scalar values, with the plucked value masked when the
+		plucked expression references any masked field.
+	"""
+	if not fields:
+		return result
+
+	masked_names = {f.fieldname for f in masked_fields}
+
+	# pypika's Term.fields_() returns every Field reference in the expression
+	# subtree, so Coalesce(secret, x) / Max(secret) / secret + suffix all
+	# surface the underlying "secret" reference. Non-Term items (raw string
+	# fieldnames) don't have fields_(); fall back to a shallow name check.
+	first = fields[0]
+	if hasattr(first, "fields_"):
+		hit_name = next((f.name for f in first.fields_() if f.name in masked_names), None)
+	else:
+		name = getattr(first, "name", None)
+		hit_name = name if name in masked_names else None
+
+	if not hit_name:
+		return result
+
+	masked_field = next(f for f in masked_fields if f.fieldname == hit_name)
+	return [mask_field_value(masked_field, val) for val in result]
 
 
 def mask_dict_results(result, masked_fields):

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -84,6 +84,7 @@ def mask_fields(
 	fields: list[Any],
 	result: list[dict] | list[tuple],
 	as_dict: bool = True,
+	pluck: bool = False,
 ) -> list[dict] | list[tuple]:
 	"""Mask fields in the result based on the doctype's masked fields.
 
@@ -92,12 +93,12 @@ def mask_fields(
 		fields: List of field objects from the query
 		result: Query results as list of dicts or tuples
 		as_dict: Whether results are dictionaries (True) or tuples (False)
-
+		pluck: Whether results were plucked into a flat list of scalar values
 	Returns:
 		Result with masked field values applied based on user permissions
 	"""
 	from frappe.database.query import CORE_DOCTYPES
-	from frappe.model.utils.mask import mask_dict_results, mask_list_results
+	from frappe.model.utils.mask import mask_dict_results, mask_list_results, mask_pluck_results
 
 	# We can't query meta for core doctypes here
 	if doctype in CORE_DOCTYPES:
@@ -107,6 +108,9 @@ def mask_fields(
 
 	if not masked_fields:
 		return result
+
+	if pluck:
+		return mask_pluck_results(result, masked_fields, fields)
 
 	if not as_dict:
 		field_index_map = {}
@@ -135,7 +139,7 @@ def execute_query(query, *args, **kwargs):
 
 	if result and dt and fields:
 		as_dict = kwargs.get("as_dict", not kwargs.get("as_list", False))
-		result = mask_fields(dt, fields, result, as_dict=as_dict)
+		result = mask_fields(dt, fields, result, as_dict=as_dict, pluck=kwargs.get("pluck", False))
 
 	return result
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -933,6 +933,132 @@ class TestDBQuery(IntegrationTestCase):
 				limit=1,
 			)
 
+	def test_get_list_pluck_with_masked_fields(self):
+		"""Regression for the pluck-on-masked-doctype crash and mask handling.
+
+		For a non-admin user, a doctype with a masked field used to corrupt
+		``frappe.db.get_list(..., pluck=<name>)`` results: ``mask_list_results``
+		ran ``list(row)`` on each already-plucked scalar, so a string like
+		"P-1156" came back as the tuple ('P','-','1','1','5','6') and a non-
+		string value (int) raised ``TypeError`` on ``list(int)``.
+
+		Since eb9bf4428e made masking opt-in on ``apply_permissions``, only
+		permission-checking APIs (``frappe.db.get_list``) trigger masking.
+		``frappe.db.get_values`` and ``get_query(..., ignore_permissions=True)``
+		intentionally do not mask.
+		"""
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		frappe.delete_doc_if_exists("DocType", "Test Masked Pluck")
+		new_doctype(
+			"Test Masked Pluck",
+			fields=[
+				{"label": "Secret", "fieldname": "secret", "fieldtype": "Data", "mask": 1},
+				{"label": "Amount", "fieldname": "amount", "fieldtype": "Int"},
+			],
+			permissions=[
+				{"role": "System Manager", "read": 1, "write": 1, "create": 1, "mask": 1},
+				{"role": "Blogger", "read": 1},
+			],
+		).insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc_if_exists, "DocType", "Test Masked Pluck")
+
+		record = frappe.get_doc({"doctype": "Test Masked Pluck", "secret": "P-1156", "amount": 42}).insert(
+			ignore_permissions=True
+		)
+
+		# Sanity: Administrator is never masked and gets the raw values.
+		self.assertEqual(
+			frappe.db.get_list("Test Masked Pluck", filters={"name": record.name}, pluck="name"),
+			[record.name],
+		)
+
+		with setup_test_user(set_user=True):
+			# `secret` is masked for this user, so the doctype has masked fields.
+			self.assertTrue(frappe.get_meta("Test Masked Pluck").get_masked_fields())
+
+			# Plucking a non-masked string field must return the scalar, not a
+			# char tuple.
+			self.assertEqual(
+				frappe.db.get_list("Test Masked Pluck", filters={"name": record.name}, pluck="name"),
+				[record.name],
+			)
+
+			# Plucking a non-masked int field must not raise (used to:
+			# list(int) -> TypeError).
+			self.assertEqual(
+				frappe.db.get_list("Test Masked Pluck", filters={"name": record.name}, pluck="amount"),
+				[42],
+			)
+
+			# Plucking the masked field itself returns the masked scalar value.
+			self.assertEqual(
+				frappe.db.get_list("Test Masked Pluck", filters={"name": record.name}, pluck="secret"),
+				["XXXXXXXX"],
+			)
+		frappe.set_user("Administrator")
+
+	def test_pluck_masks_field_wrapped_in_expression(self):
+		"""Regression for expression-tree bypass in mask_pluck_results.
+
+		Wrapping a masked field in a SQL function (Coalesce, Max, ...) or an
+		arithmetic expression must still mask the plucked result. The prior
+		check compared only ``fields[0].name`` — which returns the function
+		name ('COALESCE', 'MAX') for wrappers and is missing for arithmetic —
+		letting the raw value through.
+
+		Uses ``qb.get_query(..., ignore_permissions=False)`` since direct
+		``qb.from_(...).select(...).run()`` skips permission handling and
+		therefore skips masking (per eb9bf4428e).
+		"""
+		from pypika import functions as fn
+
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		frappe.delete_doc_if_exists("DocType", "Test Masked Pluck Wrapped")
+		new_doctype(
+			"Test Masked Pluck Wrapped",
+			fields=[
+				{"label": "Secret", "fieldname": "secret", "fieldtype": "Data", "mask": 1},
+				{"label": "Amount", "fieldname": "amount", "fieldtype": "Int"},
+			],
+			permissions=[
+				{"role": "System Manager", "read": 1, "write": 1, "create": 1, "mask": 1},
+				{"role": "Blogger", "read": 1},
+			],
+		).insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc_if_exists, "DocType", "Test Masked Pluck Wrapped")
+
+		record = frappe.get_doc(
+			{"doctype": "Test Masked Pluck Wrapped", "secret": "P-1156", "amount": 42}
+		).insert(ignore_permissions=True)
+
+		def _pluck(field_expr):
+			return frappe.qb.get_query(
+				"Test Masked Pluck Wrapped",
+				fields=[field_expr],
+				filters={"name": record.name},
+				ignore_permissions=False,
+			).run(pluck=True)
+
+		with setup_test_user(set_user=True):
+			dt = frappe.qb.DocType("Test Masked Pluck Wrapped")
+
+			# Coalesce(secret, fallback) — Coalesce returns the raw secret when
+			# it is non-null, so the plucked result must be masked.
+			self.assertEqual(_pluck(fn.Coalesce(dt.secret, "fb")), ["XXXXXXXX"])
+
+			# Aggregation over the masked field — same principle.
+			self.assertEqual(_pluck(fn.Max(dt.secret)), ["XXXXXXXX"])
+
+			# Aliased wrapper — the alias must NOT hide the masked reference.
+			self.assertEqual(_pluck(fn.Coalesce(dt.secret, "fb").as_("s")), ["XXXXXXXX"])
+
+			# Non-masked field wrapped in a function — must NOT mask.
+			self.assertEqual(_pluck(fn.Max(dt.amount)), [42])
+
+		frappe.set_user("Administrator")
+
 	def test_cast_name(self):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype
 


### PR DESCRIPTION
closes: https://github.com/frappe/frappe/issues/39953

Credits to @pipech for raising this issue and sending the first PR where minor changes are added alone