### PR TITLE
fix: prevent child row identity corruption on sync after reorder

### DIFF
--- a/cypress/integration/grid.js
+++ b/cypress/integration/grid.js
@@ -1,7 +1,22 @@
 context("Grid", () => {
+	let original_log_settings_rows;
 	beforeEach(() => {
 		cy.login();
 		cy.visit("/app/website");
+	});
+	afterEach(() => {
+		if (!original_log_settings_rows) return;
+		const rows = original_log_settings_rows;
+		original_log_settings_rows = null;
+		cy.visit("/app/log-settings");
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				frm.doc.logs_to_clear = [];
+				rows.forEach((row) => frm.add_child("logs_to_clear", row));
+				frm.refresh_field("logs_to_clear");
+			});
+		cy.save();
 	});
 	before(() => {
 		cy.login();
@@ -112,16 +127,14 @@ context("Grid", () => {
 			});
 	});
 	it("keeps child table in sync after backend removes a reordered row", () => {
-		let original_rows;
 		cy.visit("/app/log-settings");
 		cy.window()
 			.its("cur_frm")
 			.then((frm) => {
-				original_rows = frm.doc.logs_to_clear.map((row) => ({
+				original_log_settings_rows = frm.doc.logs_to_clear.map((row) => ({
 					ref_doctype: row.ref_doctype,
 					days: row.days,
 				}));
-				// add an unsupported doctype and move it off the last position
 				frm.add_child("logs_to_clear", { ref_doctype: "User", days: 30 });
 				const rows = frm.doc.logs_to_clear;
 				rows.splice(1, 0, rows.pop());
@@ -135,17 +148,11 @@ context("Grid", () => {
 			.its("cur_frm")
 			.then((frm) => {
 				const rows = frm.doc.logs_to_clear;
-				// the unsupported row is gone and no empty/ghost rows remain
 				expect(rows.find((row) => row.ref_doctype === "User")).to.be.undefined;
 				expect(rows.every((row) => row.ref_doctype)).to.be.true;
 				cy.get(
 					'.frappe-control[data-fieldname="logs_to_clear"] .grid-body .grid-row'
 				).should("have.length", rows.length);
-				// restore the full original table so the global singleton is left untouched
-				frm.doc.logs_to_clear = [];
-				original_rows.forEach((row) => frm.add_child("logs_to_clear", row));
-				frm.refresh_field("logs_to_clear");
 			});
-		cy.save();
 	});
 });

--- a/cypress/integration/grid.js
+++ b/cypress/integration/grid.js
@@ -112,12 +112,15 @@ context("Grid", () => {
 			});
 	});
 	it("keeps child table in sync after backend removes a reordered row", () => {
-		let original_order;
+		let original_rows;
 		cy.visit("/app/log-settings");
 		cy.window()
 			.its("cur_frm")
 			.then((frm) => {
-				original_order = frm.doc.logs_to_clear.map((row) => row.ref_doctype);
+				original_rows = frm.doc.logs_to_clear.map((row) => ({
+					ref_doctype: row.ref_doctype,
+					days: row.days,
+				}));
 				// add an unsupported doctype and move it off the last position
 				frm.add_child("logs_to_clear", { ref_doctype: "User", days: 30 });
 				const rows = frm.doc.logs_to_clear;
@@ -138,13 +141,9 @@ context("Grid", () => {
 				cy.get(
 					'.frappe-control[data-fieldname="logs_to_clear"] .grid-body .grid-row'
 				).should("have.length", rows.length);
-				// restore the original order so the global singleton is left untouched
-				rows.sort(
-					(a, b) =>
-						original_order.indexOf(a.ref_doctype) -
-						original_order.indexOf(b.ref_doctype)
-				);
-				rows.forEach((row, i) => (row.idx = i + 1));
+				// restore the full original table so the global singleton is left untouched
+				frm.doc.logs_to_clear = [];
+				original_rows.forEach((row) => frm.add_child("logs_to_clear", row));
 				frm.refresh_field("logs_to_clear");
 			});
 		cy.save();

--- a/cypress/integration/grid.js
+++ b/cypress/integration/grid.js
@@ -112,10 +112,12 @@ context("Grid", () => {
 			});
 	});
 	it("keeps child table in sync after backend removes a reordered row", () => {
+		let original_order;
 		cy.visit("/app/log-settings");
 		cy.window()
 			.its("cur_frm")
 			.then((frm) => {
+				original_order = frm.doc.logs_to_clear.map((row) => row.ref_doctype);
 				// add an unsupported doctype and move it off the last position
 				frm.add_child("logs_to_clear", { ref_doctype: "User", days: 30 });
 				const rows = frm.doc.logs_to_clear;
@@ -136,6 +138,15 @@ context("Grid", () => {
 				cy.get(
 					'.frappe-control[data-fieldname="logs_to_clear"] .grid-body .grid-row'
 				).should("have.length", rows.length);
+				// restore the original order so the global singleton is left untouched
+				rows.sort(
+					(a, b) =>
+						original_order.indexOf(a.ref_doctype) -
+						original_order.indexOf(b.ref_doctype)
+				);
+				rows.forEach((row, i) => (row.idx = i + 1));
+				frm.refresh_field("logs_to_clear");
 			});
+		cy.save();
 	});
 });

--- a/cypress/integration/grid.js
+++ b/cypress/integration/grid.js
@@ -111,4 +111,31 @@ context("Grid", () => {
 				cy.get("@table-form").find(".grid-footer-toolbar").click();
 			});
 	});
+	it("keeps child table in sync after backend removes a reordered row", () => {
+		cy.visit("/app/log-settings");
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				// add an unsupported doctype and move it off the last position
+				frm.add_child("logs_to_clear", { ref_doctype: "User", days: 30 });
+				const rows = frm.doc.logs_to_clear;
+				rows.splice(1, 0, rows.pop());
+				rows.forEach((row, i) => (row.idx = i + 1));
+				frm.refresh_field("logs_to_clear");
+			});
+		cy.save();
+		cy.get(".modal-dialog").contains("not supported").should("be.visible");
+		cy.get(".modal-header .btn-modal-close").click({ force: true });
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				const rows = frm.doc.logs_to_clear;
+				// the unsupported row is gone and no empty/ghost rows remain
+				expect(rows.find((row) => row.ref_doctype === "User")).to.be.undefined;
+				expect(rows.every((row) => row.ref_doctype)).to.be.true;
+				cy.get(
+					'.frappe-control[data-fieldname="logs_to_clear"] .grid-body .grid-row'
+				).should("have.length", rows.length);
+			});
+	});
 });

--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -181,6 +181,7 @@ Object.assign(frappe.model, {
 					for (let i = doc[fieldname].length; i < local_doc[fieldname].length; i++) {
 						// clear from local
 						let d = local_doc[fieldname][i];
+						if (incoming_names.has(d.name)) continue;
 						if (locals[d.doctype] && locals[d.doctype][d.name]) {
 							delete locals[d.doctype][d.name];
 						}

--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -126,60 +126,67 @@ Object.assign(frappe.model, {
 					local_doc[fieldname] = [];
 				}
 
-				// reconcile child rows by identity (name), not index, so
-				// server-side reorders/removals don't corrupt locals
+				// child table, override each row and append new rows if required
 				const incoming_names = new Set(doc[fieldname].map((d) => d.name));
-				const local_rows = local_doc[fieldname];
-				const local_by_name = {};
-				for (const row of local_rows) local_by_name[row.name] = row;
-
-				// unsaved local rows receive real names from the server on save;
-				// pair them, in order, with incoming rows that match no local name
-				const unmatched_new_rows = local_rows.filter(
-					(row) => row.__islocal && !incoming_names.has(row.name)
-				);
-
-				const reconciled = [];
-				for (const d of doc[fieldname]) {
-					if (!d.name) d.name = frappe.model.get_new_name(doc.doctype);
-					let local_d = local_by_name[d.name];
-
-					if (!local_d && unmatched_new_rows.length) {
-						local_d = unmatched_new_rows.shift();
-						const old_name = local_d.name;
-						if (locals[d.doctype]) delete locals[d.doctype][old_name];
-
-						const dc = frappe.meta.docfield_copy[d.doctype];
-						if (dc?.[old_name]) {
-							dc[d.name] = dc[old_name];
-							delete dc[old_name];
-						}
-					}
-
+				for (let i = 0; i < doc[fieldname].length; i++) {
+					let d = doc[fieldname][i];
+					let local_d_in_parent = local_doc[fieldname][i];
+					const local_d = locals[d.doctype] ? locals[d.doctype][d.name] : null;
 					if (local_d) {
 						Object.assign(local_d, d);
 						clear_keys(d, local_d);
+						if (local_d_in_parent !== local_d) {
+							local_doc[fieldname][i] = local_d;
+						}
+						continue;
+					}
+					if (local_d_in_parent && !incoming_names.has(local_d_in_parent.name)) {
+						if (!locals[d.doctype]) locals[d.doctype] = {};
+
+						if (!d.name) {
+							// incoming row is new, find a new name
+							d.name = frappe.model.get_new_name(doc.doctype);
+						}
+
+						// if incoming row is not registered, register it
+						if (!locals[d.doctype][d.name]) {
+							const old_name = local_d_in_parent.name;
+
+							// detach old key
+							delete locals[d.doctype][old_name];
+
+							// re-attach with new name
+							locals[d.doctype][d.name] = local_d_in_parent;
+
+							// migrate per-row docfield overrides to new name
+							const dc = frappe.meta.docfield_copy[d.doctype];
+							if (dc?.[old_name]) {
+								dc[d.name] = dc[old_name];
+								delete dc[old_name];
+							}
+						}
+
+						// row exists, just copy the values
+						Object.assign(local_d_in_parent, d);
+						clear_keys(d, local_d_in_parent);
 					} else {
-						local_d = d;
-					}
-
-					if (!local_d.parent) local_d.parent = doc.name;
-					if (!locals[local_d.doctype]) locals[local_d.doctype] = {};
-					locals[local_d.doctype][local_d.name] = local_d;
-					reconciled.push(local_d);
-				}
-
-				// drop rows no longer present server-side
-				const kept_names = new Set(reconciled.map((d) => d.name));
-				for (const row of local_rows) {
-					if (!kept_names.has(row.name) && locals[row.doctype]?.[row.name] === row) {
-						delete locals[row.doctype][row.name];
+						local_doc[fieldname][i] = d;
+						if (!d.parent) d.parent = doc.name;
+						frappe.model.add_to_locals(d);
 					}
 				}
 
-				// rebuild in place so the array reference is preserved
-				local_doc[fieldname].length = 0;
-				local_doc[fieldname].push(...reconciled);
+				// remove extra rows
+				if (local_doc[fieldname].length > doc[fieldname].length) {
+					for (let i = doc[fieldname].length; i < local_doc[fieldname].length; i++) {
+						// clear from local
+						let d = local_doc[fieldname][i];
+						if (locals[d.doctype] && locals[d.doctype][d.name]) {
+							delete locals[d.doctype][d.name];
+						}
+					}
+					local_doc[fieldname].length = doc[fieldname].length;
+				}
 			} else {
 				// literal
 				local_doc[fieldname] = doc[fieldname];

--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -141,6 +141,7 @@ Object.assign(frappe.model, {
 
 				const reconciled = [];
 				for (const d of doc[fieldname]) {
+					if (!d.name) d.name = frappe.model.get_new_name(doc.doctype);
 					let local_d = local_by_name[d.name];
 
 					if (!local_d && unmatched_new_rows.length) {

--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -126,58 +126,59 @@ Object.assign(frappe.model, {
 					local_doc[fieldname] = [];
 				}
 
-				// child table, override each row and append new rows if required
-				for (let i = 0; i < doc[fieldname].length; i++) {
-					let d = doc[fieldname][i];
-					let local_d = local_doc[fieldname][i];
+				// reconcile child rows by identity (name), not index, so
+				// server-side reorders/removals don't corrupt locals
+				const incoming_names = new Set(doc[fieldname].map((d) => d.name));
+				const local_rows = local_doc[fieldname];
+				const local_by_name = {};
+				for (const row of local_rows) local_by_name[row.name] = row;
+
+				// unsaved local rows receive real names from the server on save;
+				// pair them, in order, with incoming rows that match no local name
+				const unmatched_new_rows = local_rows.filter(
+					(row) => row.__islocal && !incoming_names.has(row.name)
+				);
+
+				const reconciled = [];
+				for (const d of doc[fieldname]) {
+					let local_d = local_by_name[d.name];
+
+					if (!local_d && unmatched_new_rows.length) {
+						local_d = unmatched_new_rows.shift();
+						const old_name = local_d.name;
+						if (locals[d.doctype]) delete locals[d.doctype][old_name];
+
+						const dc = frappe.meta.docfield_copy[d.doctype];
+						if (dc?.[old_name]) {
+							dc[d.name] = dc[old_name];
+							delete dc[old_name];
+						}
+					}
+
 					if (local_d) {
-						// deleted and added again
-						if (!locals[d.doctype]) locals[d.doctype] = {};
-
-						if (!d.name) {
-							// incoming row is new, find a new name
-							d.name = frappe.model.get_new_name(doc.doctype);
-						}
-
-						// if incoming row is not registered, register it
-						if (!locals[d.doctype][d.name]) {
-							const old_name = local_d.name;
-
-							// detach old key
-							delete locals[d.doctype][old_name];
-
-							// re-attach with new name
-							locals[d.doctype][d.name] = local_d;
-
-							// migrate per-row docfield overrides to new name
-							const dc = frappe.meta.docfield_copy[d.doctype];
-							if (dc?.[old_name]) {
-								dc[d.name] = dc[old_name];
-								delete dc[old_name];
-							}
-						}
-
-						// row exists, just copy the values
 						Object.assign(local_d, d);
 						clear_keys(d, local_d);
 					} else {
-						local_doc[fieldname].push(d);
-						if (!d.parent) d.parent = doc.name;
-						frappe.model.add_to_locals(d);
+						local_d = d;
+					}
+
+					if (!local_d.parent) local_d.parent = doc.name;
+					if (!locals[local_d.doctype]) locals[local_d.doctype] = {};
+					locals[local_d.doctype][local_d.name] = local_d;
+					reconciled.push(local_d);
+				}
+
+				// drop rows no longer present server-side
+				const kept_names = new Set(reconciled.map((d) => d.name));
+				for (const row of local_rows) {
+					if (!kept_names.has(row.name) && locals[row.doctype]?.[row.name] === row) {
+						delete locals[row.doctype][row.name];
 					}
 				}
 
-				// remove extra rows
-				if (local_doc[fieldname].length > doc[fieldname].length) {
-					for (let i = doc[fieldname].length; i < local_doc[fieldname].length; i++) {
-						// clear from local
-						let d = local_doc[fieldname][i];
-						if (locals[d.doctype] && locals[d.doctype][d.name]) {
-							delete locals[d.doctype][d.name];
-						}
-					}
-					local_doc[fieldname].length = doc[fieldname].length;
-				}
+				// rebuild in place so the array reference is preserved
+				local_doc[fieldname].length = 0;
+				local_doc[fieldname].push(...reconciled);
 			} else {
 				// literal
 				local_doc[fieldname] = doc[fieldname];


### PR DESCRIPTION
## Description

Fixes an issue in v15 where child table rows could become misaligned after save if the backend reordered or removed rows.

The existing reconciliation matched rows by array index, which could overwrite the wrong local rows and leave behind empty or orphaned entries. This change matches rows by document name instead, preserving row identity and correctly handling reordered, added, and removed rows.

This is an adaptation of the fix already available on `develop` for the v15 codebase.

---

Ref: https://support.frappe.io/helpdesk/tickets/69149?view=VIEW-HD+Ticket-1252

## Before/After

https://github.com/user-attachments/assets/b037914f-cf26-4f81-9b65-aa719a0693a6


https://github.com/user-attachments/assets/3aaf8b06-8a00-4386-8d4e-b79c5d9bbad7



