### PR TITLE
fix(workspace): remove duplicate ellipsis menu button on repeated edit-save

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -217,11 +217,11 @@ frappe.views.Workspace = class Workspace {
 					route: "#",
 				});
 				if (!this.add_workspace_controls) {
-					let workspace_actions_button = this.page.add_action_icon("ellipsis", "", "");
-					$(workspace_actions_button).removeAttr("data-original-title");
-					$(workspace_actions_button).removeClass("btn-default");
+					this.workspace_actions_button = this.page.add_action_icon("ellipsis", "", "");
+					$(this.workspace_actions_button).removeAttr("data-original-title");
+					$(this.workspace_actions_button).removeClass("btn-default");
 					frappe.ui.create_menu({
-						parent: $(workspace_actions_button),
+						parent: $(this.workspace_actions_button),
 						open_on_left: true,
 						size: "fit-content",
 						menu_items: [
@@ -411,6 +411,7 @@ frappe.views.Workspace = class Workspace {
 				frappe.set_route(`workspace/${page.name}`);
 			});
 		}
+		$(this.workspace_actions_button).remove();
 		this.add_workspace_controls = false;
 	}
 


### PR DESCRIPTION
Resolve: #40643
A previous cherry-pick  
- https://github.com/frappe/frappe/pull/39871 
hit a merge conflict when picked into this branch. The conflict resolution kept this.add_workspace_controls = false; but dropped the accompanying $(this.workspace_actions_button).remove(); line from the original fix.

Without that removal, resetting add_workspace_controls to false on every Edit click caused add_action_icon() — which always appends a new button rather than replacing one — to create an extra "..." icon each time the Workspace reloaded after Save/Discard.

**After Fix**


https://github.com/user-attachments/assets/a57cb488-3405-491d-bbc4-7a518d4aa123



