### PR TITLE
fix(timeline): make timeline comment cards respect full-width toggle

### DIFF
--- a/frappe/public/scss/desk/timeline.scss
+++ b/frappe/public/scss/desk/timeline.scss
@@ -107,9 +107,12 @@ $threshold: 34;
 
 		.timeline-content {
 			position: relative;
-			max-width: var(--timeline-content-max-width);
 			padding: var(--padding-sm);
 			margin-left: var(--margin-md);
+
+			body:not(.full-width) & {
+				max-width: var(--timeline-content-max-width);
+			}
 
 			> .ql-editor {
 				display: inline-flex;
@@ -147,8 +150,11 @@ $threshold: 34;
 
 		.timeline-load-more {
 			margin-left: calc(var(--timeline-item-left-margin) + var(--padding-sm));
-			width: var(--timeline-content-max-width);
 			text-align: center;
+
+			body:not(.full-width) & {
+				width: var(--timeline-content-max-width);
+			}
 		}
 
 		.timeline-message-box {


### PR DESCRIPTION
Resolve: #40644

---

**Before:**

<img width="2078" height="318" alt="image" src="https://github.com/user-attachments/assets/6cadb9f5-c4cb-470a-8bb0-628fc6b6b2ea" />


**After:**

https://github.com/user-attachments/assets/1645ed88-b03b-4d62-9def-14cd28f066bd

