### PR TITLE
feat(doctype): add validation for link filters to ensure valid JSON format and structure

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1791,6 +1791,28 @@ def validate_fields(meta: Meta):
 					)
 				)
 
+	def validate_link_filters(docfield):
+		if not docfield.link_filters:
+			return
+
+		try:
+			link_filters = json.loads(docfield.link_filters)
+		except (TypeError, ValueError):
+			frappe.throw(
+				_("Invalid Link Filters for field {0}. Link Filters must be valid JSON.").format(
+					frappe.bold(docfield.label or docfield.fieldname)
+				)
+			)
+
+		if not isinstance(link_filters, list) or any(
+			not isinstance(filter_row, list) or len(filter_row) != 4 for filter_row in link_filters
+		):
+			frappe.throw(
+				_(
+					"Invalid Link Filters for field {0}. Link Filters must be a list of filters, where each filter is a list with four values: doctype, fieldname, operator, and value."
+				).format(frappe.bold(docfield.label or docfield.fieldname))
+			)
+
 	fields = meta.get("fields")
 	fieldname_list = [d.fieldname for d in fields]
 
@@ -1814,6 +1836,7 @@ def validate_fields(meta: Meta):
 		validate_fetch_from(d)
 		validate_data_field_type(d)
 		check_decimal_config(d)
+		validate_link_filters(d)
 
 		if not frappe.flags.in_migrate or in_ci:
 			check_unique_fieldname(meta.get("name"), d.fieldname)

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -679,6 +679,68 @@ class TestDocType(IntegrationTestCase):
 
 		self.assertEqual(test_json.test_json_field["hello"], "world")
 
+	def test_link_filters_must_be_valid_json(self):
+		doctype = new_doctype(
+			fields=[
+				{
+					"label": "User",
+					"fieldname": "user",
+					"fieldtype": "Link",
+					"options": "User",
+					"link_filters": "not valid json",
+				}
+			]
+		)
+
+		self.assertRaises(frappe.ValidationError, doctype.insert)
+
+	def test_link_filters_must_be_list_of_filters(self):
+		doctype = new_doctype(
+			fields=[
+				{
+					"label": "User",
+					"fieldname": "user",
+					"fieldtype": "Link",
+					"options": "User",
+					"link_filters": '{"name": "Administrator"}',
+				}
+			]
+		)
+
+		self.assertRaises(frappe.ValidationError, doctype.insert)
+
+	def test_custom_field_validates_link_filters(self):
+		custom_field = frappe.get_doc(
+			{
+				"doctype": "Custom Field",
+				"dt": "ToDo",
+				"fieldname": "invalid_link_filters",
+				"label": "Invalid Link Filters",
+				"fieldtype": "Link",
+				"options": "User",
+				"link_filters": '[["User", "name", "="]]',
+			}
+		)
+
+		self.assertRaises(frappe.ValidationError, custom_field.insert)
+		frappe.db.rollback()
+		frappe.clear_cache(doctype="ToDo")
+
+	def test_property_setter_validates_link_filters(self):
+		self.assertRaises(
+			frappe.ValidationError,
+			frappe.make_property_setter,
+			{
+				"doctype": "ToDo",
+				"fieldname": "allocated_to",
+				"property": "link_filters",
+				"value": '["not a filter row"]',
+				"property_type": "JSON",
+			},
+		)
+		frappe.db.rollback()
+		frappe.clear_cache(doctype="ToDo")
+
 	def test_no_delete_doc(self):
 		self.assertRaises(frappe.ValidationError, frappe.delete_doc, "DocType", "Address")
 


### PR DESCRIPTION
- Add backend validation for `link_filters` on fields so values must be valid JSON in the expected list-of-4 filter row format.
- Cover **DocType**, **Custom Field**, **Property Setter**, and **Customize Form** paths through the shared field validation.
- Checked existing 30 app's metadata on my bench; all `link_filters` values (48 instances) already conform to the validated format.
