### PR TITLE
fix(API): apply default ordering in v1 & v2 list endpoints

### DIFF
--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -3,6 +3,7 @@ import json
 from werkzeug.routing import Rule
 
 import frappe
+import frappe.client
 from frappe import _
 from frappe.utils import attach_expanded_links
 from frappe.utils.data import sbool

--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -5,6 +5,7 @@ from werkzeug.routing import Rule
 import frappe
 import frappe.client
 from frappe import _
+from frappe.database.utils import DefaultOrderBy
 from frappe.utils import attach_expanded_links
 from frappe.utils.data import sbool
 
@@ -21,6 +22,9 @@ def document_list(doctype: str):
 		"limit_page_length",
 		frappe.form_dict.limit or frappe.form_dict.limit_page_length or 20,
 	)
+
+	# default to the doctype's configured sort order
+	frappe.form_dict.setdefault("order_by", DefaultOrderBy)
 
 	# convert strings to native types - only as_dict and debug accept bool
 	for param in ["as_dict", "debug"]:

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -18,6 +18,7 @@ import frappe.client
 from frappe import _, cint, cstr, get_newargs, is_whitelisted
 from frappe.api import discovery
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
+from frappe.database.utils import DefaultOrderBy
 from frappe.handler import is_valid_http_method, run_server_script, upload_file
 
 PERMISSION_MAP = {
@@ -133,7 +134,7 @@ def document_list(doctype: str) -> list[dict[str, Any]]:
 	args = frappe.form_dict
 	fields: list | None = frappe.parse_json(args.get("fields", None))
 	filters: dict | None = frappe.parse_json(args.get("filters", None))
-	order_by: str | None = args.get("order_by", None)
+	order_by: str | None = args.get("order_by", DefaultOrderBy)
 	start: int = cint(args.get("start", 0))
 	limit: int = cint(args.get("limit", 20))
 	group_by: str | None = args.get("group_by", None)

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -244,6 +244,17 @@ class TestResourceAPI(FrappeAPITestCase):
 		json = frappe._dict(response.json)
 		self.assertIn("description", json.data[0])
 
+	def test_get_list_default_order_by_v1(self):
+		# without an explicit order_by, results should fall back to the
+		# doctype's configured sort order (ToDo => creation desc)
+		response = self.get(
+			self.resource(self.DOCTYPE),
+			{"sid": self.sid, "fields": '["creation"]', "limit": 5},
+		)
+		self.assertEqual(response.status_code, 200)
+		creations = [row["creation"] for row in response.json["data"]]
+		self.assertEqual(creations, sorted(creations, reverse=True))
+
 	def test_create_document_v1(self):
 		data = {"description": frappe.mock("paragraph"), "sid": self.sid}
 		response = self.post(self.resource(self.DOCTYPE), data)

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -73,6 +73,17 @@ class TestResourceAPIV2(FrappeAPITestCase):
 		self.assertIsInstance(json.data, list)
 		self.assertIsInstance(json.data[0], list)
 
+	def test_get_list_default_order_by_v2(self):
+		# without an explicit order_by, results should fall back to the
+		# doctype's configured sort order (ToDo => creation desc)
+		response = self.get(
+			self.resource(self.DOCTYPE),
+			{"sid": self.sid, "fields": '["creation"]', "limit": 5},
+		)
+		self.assertEqual(response.status_code, 200)
+		creations = [row["creation"] for row in response.json["data"]]
+		self.assertEqual(creations, sorted(creations, reverse=True))
+
 	def test_get_list_fields_v2(self):
 		# test 6: fetch response with fields
 		response = self.get(self.resource(self.DOCTYPE), {"sid": self.sid, "fields": '["description"]'})


### PR DESCRIPTION
Neither the v1 nor v2 REST list endpoints applied a default sort order, so records came back in an undefined/unstable order.

- **v2** (`frappe/api/v2.py`): `order_by` defaulted to `None`, and the query builder only applies ordering `if order_by:` — so no ordering was ever added.
- **v1** (`frappe/api/v1.py`): `order_by` was never seeded in `form_dict`, so `db_query`'s meta-based default sort was skipped as well.