### PR TITLE
fix(ui): remove border from filled search bar

### DIFF
--- a/frappe/public/scss/desk/search_widget.scss
+++ b/frappe/public/scss/desk/search_widget.scss
@@ -14,7 +14,6 @@
 	gap: 6px;
 	padding: 0 10px;
 	background-color: var(--control-bg);
-	border: 1px solid var(--border-color);
 	border-radius: var(--radius);
 	width: 100%;
 	justify-content: space-between;


### PR DESCRIPTION
The search bar had a background fill and a border. The fill already separates it from the navbar, so the border was a second edge on top of it. Removed it from `.search-widget-button`, which covers both the compact pill and the full-width variant.

### Fix
<img width="952" height="181" alt="Screenshot 2026-07-09 at 11 33 39 AM" src="https://github.com/user-attachments/assets/6ee77440-789b-4e02-98d6-8abd51f45530" />
<img width="955" height="195" alt="Screenshot 2026-07-09 at 11 33 21 AM" src="https://github.com/user-attachments/assets/aa9e45ee-bebe-457a-ace3-7cac3f537ff7" />

<img width="423" height="139" alt="Screenshot 2026-07-09 at 11 33 46 AM" src="https://github.com/user-attachments/assets/fdd301e9-93c4-4c08-8d69-4487a09657ee" />
<img width="436" height="145" alt="Screenshot 2026-07-09 at 11 33 16 AM" src="https://github.com/user-attachments/assets/90e8029d-e650-4462-9e95-b9a6098fb2c6" />

---
Closes #40685.