### PR TITLE
feat(safe_exec): add SafeDoc class

### DIFF
--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -242,6 +242,33 @@ class TestSafeDoc(IntegrationTestCase):
 		self.assertEqual(row.get_label_from_fieldname("rate"), "Rate")
 		self.assertEqual(row.get_label_from_fieldname("amount"), "Amount")
 
+	def test_in_format_data(self):
+		parent = self._make_parent()
+		row = parent.get("rows")[0]
+
+		# no format_data_map set — all fields visible
+		self.assertTrue(row.in_format_data("rate"))
+		self.assertTrue(row.in_format_data("amount"))
+
+		# parent itself has no parent_doc — falls back to self
+		self.assertTrue(parent.in_format_data("absolute_value"))
+
+		# with format_data_map on parent — only listed fields visible
+		parent["format_data_map"] = {"rate": True}
+		self.assertTrue(row.in_format_data("rate"))
+		self.assertFalse(row.in_format_data("amount"))
+
+	def test_is_print_hide(self):
+		parent = self._make_parent()
+		row = parent.get("rows")[0]
+
+		# field with no print_hide set — should not be hidden
+		self.assertFalse(row.is_print_hide("description"))
+
+		# explicit df with print_hide=1
+		df = frappe._dict(print_hide=1, print_hide_if_no_value=0)
+		self.assertTrue(row.is_print_hide("description", df=df))
+
 	def test_absolute_value_from_parent(self):
 		parent = self._make_parent(absolute_value=1)
 		row = parent.get("rows")[0]

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -3,7 +3,7 @@ import types
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils.jinja import get_jenv, render_template
-from frappe.utils.safe_exec import ServerScriptNotEnabled, get_safe_globals, safe_exec
+from frappe.utils.safe_exec import SafeDoc, ServerScriptNotEnabled, get_safe_globals, safe_exec
 
 
 class TestSafeExec(IntegrationTestCase):
@@ -133,6 +133,122 @@ class TestSafeExec(IntegrationTestCase):
 		test_str = frappe.generate_hash()
 		safe_exec(f"print('{test_str}')")
 		self.assertEqual(frappe.local.debug_log[-1], test_str)
+
+
+class TestSafeDoc(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		if not frappe.db.exists("DocType", "Test SafeDoc Row"):
+			frappe.get_doc(
+				{
+					"doctype": "DocType",
+					"module": "Core",
+					"name": "Test SafeDoc Row",
+					"istable": 1,
+					"custom": 1,
+					"fields": [
+						{"fieldname": "description", "fieldtype": "Data", "label": "Description"},
+						{"fieldname": "rate", "fieldtype": "Float", "label": "Rate"},
+						{"fieldname": "amount", "fieldtype": "Currency", "label": "Amount"},
+					],
+				}
+			).insert(ignore_permissions=True)
+
+		if not frappe.db.exists("DocType", "Test SafeDoc Parent"):
+			frappe.get_doc(
+				{
+					"doctype": "DocType",
+					"module": "Core",
+					"name": "Test SafeDoc Parent",
+					"custom": 1,
+					"fields": [
+						{"fieldname": "absolute_value", "fieldtype": "Check", "label": "Absolute Value"},
+						{
+							"fieldname": "rows",
+							"fieldtype": "Table",
+							"label": "Rows",
+							"options": "Test SafeDoc Row",
+						},
+					],
+				}
+			).insert(ignore_permissions=True)
+
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.delete_doc("DocType", "Test SafeDoc Parent", ignore_missing=True, force=True)
+		frappe.delete_doc("DocType", "Test SafeDoc Row", ignore_missing=True, force=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def _make_parent(self, absolute_value=0):
+		return SafeDoc(
+			{
+				"doctype": "Test SafeDoc Parent",
+				"name": "TEST-001",
+				"absolute_value": absolute_value,
+				"rows": [
+					{
+						"doctype": "Test SafeDoc Row",
+						"description": "Test Row",
+						"rate": 18.0,
+						"amount": -90.0,
+					}
+				],
+			}
+		)
+
+	def test_safe_doc_instance(self):
+		from frappe.utils.safe_exec import get_doc_as_dict
+
+		doc = get_doc_as_dict("User", frappe.session.user)
+		self.assertIsInstance(doc, SafeDoc)
+
+		parent = self._make_parent()
+		row = parent.get("rows")[0]
+		self.assertIsInstance(row, SafeDoc)
+
+	def test_parent_doc_attr(self):
+		parent = self._make_parent()
+		row = parent.get("rows")[0]
+		self.assertIs(row.parent_doc, parent)
+
+	def test_safe_get_formatted(self):
+		from frappe.utils.safe_exec import get_doc_as_dict
+
+		doc = get_doc_as_dict("User", frappe.session.user)
+		# email is a Data field — formatted value equals the raw value
+		self.assertEqual(doc.get_formatted("email"), doc.get("email"))
+
+		parent = self._make_parent()
+		row = parent.get("rows")[0]
+		result = row.get_formatted("rate")
+		self.assertIn("18", result)
+
+		result = row.get_formatted("amount", currency="INR")
+		self.assertIn("₹", result)
+
+	def test_absolute_value_from_parent(self):
+		parent = self._make_parent(absolute_value=1)
+		row = parent.get("rows")[0]
+		result = row.get_formatted("amount")
+		self.assertNotIn("-", result)
+
+	def test_absolute_value_not_set(self):
+		parent = self._make_parent(absolute_value=0)
+		row = parent.get("rows")[0]
+		result = row.get_formatted("amount")
+		self.assertIn("-", result)
+
+	def test_jinja_get_formatted_in_template(self):
+		expected = frappe.db.get_value("User", frappe.session.user, "first_name")
+		result = render_template(
+			"{{ frappe.get_doc('User', frappe.session.user).get_formatted('first_name') }}",
+			restrict_globals=True,
+		)
+		self.assertEqual(result.strip(), expected)
 
 
 class TestNoSafeExec(IntegrationTestCase):

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -242,6 +242,24 @@ class TestSafeDoc(IntegrationTestCase):
 		self.assertEqual(row.get_label_from_fieldname("rate"), "Rate")
 		self.assertEqual(row.get_label_from_fieldname("amount"), "Amount")
 
+	def test_meta_property(self):
+		from frappe.utils.safe_exec import get_doc_as_dict
+
+		doc = get_doc_as_dict("User", frappe.session.user)
+		# meta returns a plain dict, not a live Meta object
+		self.assertIsInstance(doc.meta, frappe._dict)
+		self.assertIsNotNone(doc.meta.get("is_submittable"))
+
+		# works on child rows too
+		parent = self._make_parent()
+		row = parent.get("rows")[0]
+		self.assertIsInstance(row.meta, frappe._dict)
+		self.assertEqual(row.meta.get("name"), "Test SafeDoc Row")
+
+		# no mutating methods exposed
+		self.assertIsNone(doc.meta.get("save"))
+		self.assertIsNone(doc.meta.get("insert"))
+
 	def test_in_format_data(self):
 		parent = self._make_parent()
 		row = parent.get("rows")[0]

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -230,6 +230,18 @@ class TestSafeDoc(IntegrationTestCase):
 		result = row.get_formatted("amount", currency="INR")
 		self.assertIn("₹", result)
 
+	def test_get_label_from_fieldname(self):
+		from frappe.utils.safe_exec import get_doc_as_dict
+
+		doc = get_doc_as_dict("User", frappe.session.user)
+		self.assertEqual(doc.get_label_from_fieldname("email"), "Email")
+		self.assertIsNone(doc.get_label_from_fieldname("nonexistent_field"))
+
+		parent = self._make_parent()
+		row = parent.get("rows")[0]
+		self.assertEqual(row.get_label_from_fieldname("rate"), "Rate")
+		self.assertEqual(row.get_label_from_fieldname("amount"), "Amount")
+
 	def test_absolute_value_from_parent(self):
 		parent = self._make_parent(absolute_value=1)
 		row = parent.get("rows")[0]

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -183,7 +183,7 @@ class SafeDoc(frappe._dict):
 				for v in val:
 					if isinstance(v, dict):
 						child = SafeDoc(v)
-						child.parent_doc = self
+						object.__setattr__(child, "parent_doc", self)
 						children.append(child)
 					else:
 						children.append(v)
@@ -200,7 +200,7 @@ class SafeDoc(frappe._dict):
 	):
 		from frappe.utils.formatters import format_value
 
-		meta = frappe.get_meta(self.get("doctype"))
+		meta = frappe.get_meta(self.get("doctype")) if self.get("doctype") else None
 		df = meta.get_field(fieldname) if meta else None
 
 		if not df:

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -230,6 +230,11 @@ class SafeDoc(frappe._dict):
 
 		return format_value(val, df=df, doc=doc, currency=currency, format=format)
 
+	def get_label_from_fieldname(self, fieldname):
+		meta = frappe.get_meta(self.get("doctype")) if self.get("doctype") else None
+		df = meta.get_field(fieldname) if meta else None
+		return _(df.label) if df and df.label else None
+
 
 def get_doc_as_dict(*args, **kwargs):
 	return SafeDoc(frappe.get_doc(*args, **kwargs).as_dict())

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -172,16 +172,75 @@ def safe_exec_flags():
 		frappe.flags.in_safe_exec -= 1
 
 
+class SafeDoc(frappe._dict):
+	"""An extension of frappe._dict that exposes safer subset of methods."""
+
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		for key, val in self.items():
+			if isinstance(val, list):
+				children = []
+				for v in val:
+					if isinstance(v, dict):
+						child = SafeDoc(v)
+						child.parent_doc = self
+						children.append(child)
+					else:
+						children.append(v)
+				self[key] = children
+
+	def get_formatted(
+		self,
+		fieldname,
+		doc=None,
+		currency=None,
+		absolute_value=False,
+		translated=False,
+		format=None,
+	):
+		from frappe.utils.formatters import format_value
+
+		meta = frappe.get_meta(self.get("doctype"))
+		df = meta.get_field(fieldname) if meta else None
+
+		if not df:
+			from frappe.model.meta import get_default_df
+
+			df = get_default_df(fieldname)
+
+		if (
+			df
+			and df.fieldtype == "Currency"
+			and not currency
+			and (currency_field := df.get("options"))
+			and (currency_value := self.get(currency_field))
+		):
+			currency = frappe.db.get_value("Currency", currency_value, cache=True)
+
+		val = self.get(fieldname)
+
+		if translated:
+			val = _(val)
+
+		if not doc:
+			doc = getattr(self, "parent_doc", None) or self
+
+		if (absolute_value or doc.get("absolute_value")) and isinstance(val, int | float):
+			val = abs(val)
+
+		return format_value(val, df=df, doc=doc, currency=currency, format=format)
+
+
 def get_doc_as_dict(*args, **kwargs):
-	return frappe.get_doc(*args, **kwargs).as_dict()
+	return SafeDoc(frappe.get_doc(*args, **kwargs).as_dict())
 
 
 def safer_get_last_doc(*args, **kwargs):
-	return frappe.get_last_doc(*args, **kwargs).as_dict()
+	return SafeDoc(frappe.get_last_doc(*args, **kwargs).as_dict())
 
 
 def safer_get_cached_doc(*args, **kwargs):
-	return frappe.get_cached_doc(*args, **kwargs).as_dict()
+	return SafeDoc(frappe.get_cached_doc(*args, **kwargs).as_dict())
 
 
 def remove_unsafe_fields(fields):

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -235,6 +235,33 @@ class SafeDoc(frappe._dict):
 		df = meta.get_field(fieldname) if meta else None
 		return _(df.label) if df and df.label else None
 
+	def in_format_data(self, fieldname):
+		doc = getattr(self, "parent_doc", None) or self
+		format_data_map = doc.get("format_data_map")
+		if format_data_map:
+			return fieldname in format_data_map
+		return True
+
+	def is_print_hide(self, fieldname, df=None, for_print=True):
+		meta = frappe.get_meta(self.get("doctype")) if self.get("doctype") else None
+		meta_df = meta.get_field(fieldname) if meta else None
+
+		if meta_df and meta_df.get("__print_hide"):
+			return True
+
+		print_hide = 0
+
+		if self.get(fieldname) == 0 and not (meta and meta.istable):
+			print_hide = (df and df.print_hide_if_no_value) or (meta_df and meta_df.print_hide_if_no_value)
+
+		if not print_hide:
+			if df and df.print_hide is not None:
+				print_hide = df.print_hide
+			elif meta_df:
+				print_hide = meta_df.print_hide
+
+		return print_hide
+
 
 def get_doc_as_dict(*args, **kwargs):
 	return SafeDoc(frappe.get_doc(*args, **kwargs).as_dict())

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -189,6 +189,14 @@ class SafeDoc(frappe._dict):
 						children.append(v)
 				self[key] = children
 
+	@property
+	def meta(self):
+		doctype = self.get("doctype")
+		if not isinstance(doctype, str):
+			return None
+		meta = frappe.get_meta(doctype)
+		return meta.as_dict() if meta else None
+
 	def get_formatted(
 		self,
 		fieldname,


### PR DESCRIPTION
Added a SafeDoc class that extends a _dict by including some internal methods of `Document`.

related to #37924