### PR TITLE
fix(postgres): read Time columns back with their precision

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -625,6 +625,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			CASE LOWER(a.data_type)
 				WHEN 'character varying' THEN CONCAT('varchar(', a.character_maximum_length ,')')
 				WHEN 'timestamp without time zone' THEN 'timestamp'
+				WHEN 'time without time zone' THEN CONCAT('time(', a.datetime_precision, ')')
 				WHEN 'integer' THEN 'int'
 				WHEN 'numeric' THEN CONCAT('decimal(', a.numeric_precision, ',', a.numeric_scale, ')')
 				ELSE a.data_type
@@ -646,7 +647,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			) b ON b.column_name = a.column_name
 			WHERE a.table_name = '{table_name}'
 				AND a.table_schema = '{self.db_schema}'
-			GROUP BY a.column_name, a.data_type, a.column_default, a.character_maximum_length, a.is_nullable, a.numeric_precision, a.numeric_scale;
+			GROUP BY a.column_name, a.data_type, a.column_default, a.character_maximum_length, a.is_nullable, a.numeric_precision, a.numeric_scale, a.datetime_precision;
 		""",
 			as_dict=1,
 		)


### PR DESCRIPTION
## Problem
`get_table_columns_description` normalizes `timestamp without time zone` → `timestamp` but has no mapping for `time without time zone`. A Time column therefore reads back as `"time without time zone"`, which never equals its expected definition `time(6)` — so `build_for_alter_table` marks it as a type change on **every** `bench migrate`.

Since #40338 (USING casts) that re-alter *succeeds* silently, so the loop never converges:
```sql
ALTER TABLE "tabEvent Notifications" ALTER COLUMN "time" DROP DEFAULT,
  ALTER COLUMN "time" TYPE time(6) USING NULLIF("time"::text, '')::time without time zone,
  ALTER COLUMN "time" SET DEFAULT NULL
```
`test_no_unnecessary_migrates` now fails on the postgres integration shard (e.g. on #40431, which merges the develop tip).

## Fix
Map `time without time zone` → `time(<datetime_precision>)`, mirroring the existing varchar/numeric handling. Verified against live PostgreSQL: `time(6)` and bare `time` read back `time(6)` (matches the frappe definition → no spurious alter), `time(0)` reads `time(0)` (a genuine mismatch still triggers the alter).
