### PR TITLE
fix: allow missing link_filters in validate_fields function

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1792,11 +1792,12 @@ def validate_fields(meta: Meta):
 				)
 
 	def validate_link_filters(docfield):
-		if not docfield.link_filters:
+		link_filters_value = docfield.get("link_filters")
+		if not link_filters_value:
 			return
 
 		try:
-			link_filters = json.loads(docfield.link_filters)
+			link_filters = json.loads(link_filters_value)
 		except (TypeError, ValueError):
 			frappe.throw(
 				_("Invalid Link Filters for field {0}. Link Filters must be valid JSON.").format(

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -18,6 +18,7 @@ from frappe.core.doctype.doctype.doctype import (
 	InvalidFieldNameError,
 	UniqueFieldnameError,
 	WrongOptionsDoctypeLinkError,
+	validate_fields,
 	validate_links_table_fieldnames,
 )
 from frappe.core.doctype.rq_job.test_rq_job import wait_for_completion
@@ -708,6 +709,12 @@ class TestDocType(IntegrationTestCase):
 		)
 
 		self.assertRaises(frappe.ValidationError, doctype.insert)
+
+	def test_missing_link_filters_field_is_allowed(self):
+		doctype = new_doctype()
+		doctype.fields[0].__dict__.pop("link_filters", None)
+
+		validate_fields(doctype)
 
 	def test_custom_field_validates_link_filters(self):
 		custom_field = frappe.get_doc(


### PR DESCRIPTION
`link_filters` does not exist during `pre_model_sync` patches on databases from <=v14.

Resolves https://github.com/frappe/erpnext/actions/runs/29002547857/job/86066276848?pr=56801