### PR TITLE
fix: form does not render when form sidebar is disabled

### DIFF
--- a/cypress/integration/form_web_link.js
+++ b/cypress/integration/form_web_link.js
@@ -1,0 +1,40 @@
+context("Form Web Link", () => {
+	const route = "cypress-web-link-page";
+
+	const set_form_sidebar = (value) => {
+		cy.window()
+			.its("frappe")
+			.then((frappe) => {
+				cy.set_value("User", frappe.session.user, { form_sidebar: value });
+			});
+	};
+
+	before(() => {
+		cy.login();
+		cy.visit("/desk/website");
+		cy.remove_doc("Web Page", route, true);
+		cy.insert_doc("Web Page", {
+			title: "Cypress Web Link Page",
+			route: route,
+			published: 1,
+			content_type: "HTML",
+			main_section_html: "<p>Cypress</p>",
+		});
+		set_form_sidebar(0);
+	});
+
+	after(() => {
+		cy.login();
+		cy.visit("/desk/website");
+		set_form_sidebar(1);
+		cy.remove_doc("Web Page", route, true);
+	});
+
+	it("renders a published website page when the form sidebar is disabled", () => {
+		cy.login();
+		cy.visit(`/desk/web-page/${route}`);
+
+		cy.get('.frappe-control[data-fieldname="title"]').should("be.visible");
+		cy.get('.frappe-control[data-fieldname="route"]').should("be.visible");
+	});
+});

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1411,6 +1411,8 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	add_web_link(path, label) {
+		if (!this.sidebar) return;
+
 		label = __(label) || __("See on Website");
 		this.web_link = this.sidebar
 			.add_user_action(__(label), function () {})


### PR DESCRIPTION
## Description

Opening a published Web Page (or any website generator document) with the form sidebar disabled rendered an empty form. The document loaded successfully, but the fields never rendered.

`render_form` only initializes `this.sidebar` when the `form_sidebar` user setting is enabled. However, `add_web_link` assumed the sidebar always existed, causing `show_web_link` to throw a `TypeError`. Since the exception occurred during the `render_form` promise chain, `refresh_fields()` was never reached, leaving the form blank.

This PR guards `add_web_link` when no sidebar is present. Since there is nowhere to display the web link without a sidebar, skipping it is the expected behavior. No behavior changes when the sidebar is enabled.

The same code path is also used by `show_report_bug_link` for beta doctypes.

## Before

<img width="1286" height="869" alt="Screenshot 2026-07-09 at 6 56 41 PM" src="https://github.com/user-attachments/assets/2440760c-8287-47c9-97c8-e4c06fee859e" />
<img width="592" height="147" alt="Screenshot 2026-07-09 at 6 56 34 PM" src="https://github.com/user-attachments/assets/60ef9810-3fd0-4e2a-80bf-c7c78e027d86" />


## After

<img width="1288" height="868" alt="Screenshot 2026-07-09 at 6 57 16 PM" src="https://github.com/user-attachments/assets/71858595-79ed-4421-9478-580e80434262" />
