### PR TITLE
fix: print view is unusable on mobile

### DIFF
--- a/frappe/public/scss/desk/print_preview.scss
+++ b/frappe/public/scss/desk/print_preview.scss
@@ -55,6 +55,17 @@
 	}
 }
 
+@include media-breakpoint-down(sm) {
+	.layout-main:has(> .print-preview-sidebar) {
+		flex-direction: column;
+
+		.layout-main-section-wrapper {
+			flex: 1 0 auto;
+			width: 100%;
+		}
+	}
+}
+
 .print-preview {
 	padding: 0;
 	max-width: 8.3in;

--- a/frappe/public/scss/desk/print_preview.scss
+++ b/frappe/public/scss/desk/print_preview.scss
@@ -62,6 +62,11 @@
 	min-height: 11.69in;
 	background: white;
 	border-radius: var(--radius);
+	overflow-x: auto;
+
+	.print-format-container {
+		min-width: 8.3in;
+	}
 }
 
 .print-format-skeleton {


### PR DESCRIPTION
## Description

The print view had two usability issues on mobile devices.

### Print preview clipped on small screens

The print preview container shrank to the device width, causing the embedded print iframe to reflow its contents into a narrow layout. Wide elements such as item tables could not shrink further, resulting in content overflowing the iframe and becoming inaccessible because the iframe does not allow scrolling.

The iframe is now pinned to the actual page width (`8.3in`), while the surrounding container becomes horizontally scrollable. On desktop, where the container already resolves to the same width, the layout remains unchanged.

### Print sidebar unusable on mobile

The print page uses the standard two-column layout, which leaves the sidebar extremely narrow on small screens. Since the sidebar contains the print format, language, letterhead, and print settings controls, hiding it on mobile is not an option.

Below the `sm` breakpoint, the layout now stacks vertically, placing the sidebar above the print preview at full width. This keeps all controls accessible without affecting the desktop layout.

This layout change is scoped specifically to the print page using `:has()`, so it does not impact other Desk pages.

---
## Broken behaviour


https://github.com/user-attachments/assets/a76859d2-9371-4c70-86a2-c8edb0c6b0b5



## New behaviour 


https://github.com/user-attachments/assets/0614efee-a229-4811-972a-0a2e02a3382e


---

Ref: https://support.frappe.io/helpdesk/tickets/73492?view=VIEW-HD+Ticket-1252
