### PR TITLE
fix: restrict print format builder preview to sys. man.

### DIFF
--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -10,6 +10,7 @@ from frappe import _
 @frappe.whitelist()
 def render_jinja_template(template: str, doctype: str, docname: str) -> str:
 	"""Render a raw Jinja2 template string with doc context (used by the print format builder preview)."""
+	frappe.only_for("System Manager")
 	doc = frappe.get_doc(doctype, docname)
 	doc.check_permission("print")
 	# template is rendered inside frappe's SandboxedEnvironment (Jinja2 sandbox).


### PR DESCRIPTION
Enforcing API to be strictly for Sys. Man.

closes Ticket 73260

Thanks to Michael Holmquist @mtholmquist for reporting this issue!