### PR TITLE
refactor(telemetry): pulse capture() site keyword-only + drop is_enabled cache

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -7,7 +7,6 @@ from frappe import _
 from frappe.model import no_value_fields
 from frappe.model.document import Document
 from frappe.utils import cint, today
-from frappe.utils.telemetry.pulse.client import is_enabled as pulse_enabled
 
 
 class SystemSettings(Document):
@@ -209,9 +208,6 @@ class SystemSettings(Document):
 	def on_update(self):
 		self.set_defaults()
 		clear_system_settings_cache()
-
-		if not frappe.flags.in_setup_wizard and self.has_value_changed("enable_telemetry"):
-			pulse_enabled.clear_cache()
 
 		if frappe.flags.update_last_reset_password_date:
 			update_last_reset_password_date()

--- a/frappe/utils/telemetry/pulse/app_heartbeat_event.py
+++ b/frappe/utils/telemetry/pulse/app_heartbeat_event.py
@@ -11,7 +11,6 @@ def capture_app_heartbeat(app):
 	if app and app != "frappe":
 		capture(
 			event_name="app_heartbeat",
-			site=frappe.local.site,
 			app=app,
 			properties={
 				"app_version": get_app_version(app),

--- a/frappe/utils/telemetry/pulse/client.py
+++ b/frappe/utils/telemetry/pulse/client.py
@@ -1,15 +1,16 @@
 from typing import Any
 
 import frappe
-from frappe.utils.caching import site_cache
 
 from .queue import EventQueue
 from .transport import PulseHTTP
 from .utils import anonymize_user, pulse_host, utc_iso
 
 
-@site_cache(ttl=60 * 60)
 def is_enabled() -> bool:
+	# Not cached: the underlying reads are conf lookups (in-memory) and System Settings
+	# (already request- and redis-cached by frappe), so a local cache here buys nothing
+	# but staleness — notably during the setup wizard, where enable_telemetry flips on.
 	if not frappe.conf.get("pulse_api_key"):
 		return False
 

--- a/frappe/utils/telemetry/pulse/client.py
+++ b/frappe/utils/telemetry/pulse/client.py
@@ -59,13 +59,14 @@ def boot_config() -> dict:
 
 def capture(
 	event_name: str,
-	site: str | None = None,
 	app: str | None = None,
 	user: str | None = None,
 	team: str | None = None,
 	captured_at: str | None = None,
 	properties: dict[str, Any] | None = None,
 	interval: int | str | None = None,
+	*,
+	site: str | None = None,
 ):
 	if not is_enabled():
 		return

--- a/frappe/utils/telemetry/pulse/test_pulse_client.py
+++ b/frappe/utils/telemetry/pulse/test_pulse_client.py
@@ -364,7 +364,7 @@ class TestCapture(TestPulseClient):
 		mock_enabled.return_value = False
 		eq = EventQueue()
 
-		capture("test_event", site="test.localhost")
+		capture("test_event")
 
 		self.assertEqual(eq.length, 0)
 
@@ -377,7 +377,6 @@ class TestCapture(TestPulseClient):
 
 		capture(
 			"test_event",
-			site="test.localhost",
 			app="frappe",
 			user="fc_priya",
 			team="team_test",
@@ -396,7 +395,7 @@ class TestCapture(TestPulseClient):
 		mock_enabled.return_value = True
 		eq = EventQueue()
 
-		capture("test_event", site="test.localhost", user="fc_priya", team="team_priya")
+		capture("test_event", user="fc_priya", team="team_priya")
 
 		events = eq.collect(batch_size=1)
 		# user is always anonymized (the privacy gate); team is the raw group id
@@ -411,7 +410,7 @@ class TestCapture(TestPulseClient):
 		mock_enabled.return_value = True
 		eq = EventQueue()
 
-		capture("test_event", site="test.localhost")
+		capture("test_event")
 
 		events = eq.collect(batch_size=1)
 		# user defaults to the (anonymized) session user
@@ -427,10 +426,23 @@ class TestCapture(TestPulseClient):
 		eq = EventQueue()
 
 		with patch.dict(frappe.conf, {"fc_team": "team_x"}):
-			capture("test_event", site="test.localhost")
+			capture("test_event")
 
 		events = eq.collect(batch_size=1)
 		self.assertEqual(events[0]["team"], "team_x")
+
+	@patch("frappe.utils.telemetry.pulse.client.is_enabled")
+	def test_capture_explicit_site_overrides_local(self, mock_enabled):
+		"""site defaults to frappe.local.site but an explicit site= wins (the simulator
+		emits for many sites from one process)."""
+		is_enabled.clear_cache()
+		mock_enabled.return_value = True
+		eq = EventQueue()
+
+		capture("test_event", site="other.localhost")
+
+		events = eq.collect(batch_size=1)
+		self.assertEqual(events[0]["site"], "other.localhost")
 
 
 class TestIdentify(TestPulseClient):

--- a/frappe/utils/telemetry/pulse/test_pulse_client.py
+++ b/frappe/utils/telemetry/pulse/test_pulse_client.py
@@ -300,8 +300,6 @@ class TestTelemetryGate(TestPulseClient):
 	def _conf(self, **overrides):
 		conf = {"pulse_api_key": "k", "developer_mode": 0, "pulse_force_enabled": 0}
 		conf.update(overrides)
-		is_enabled.clear_cache()
-		self.addCleanup(is_enabled.clear_cache)
 		return patch.dict(frappe.conf, conf)
 
 	def test_off_by_default_and_endpoint_leaks_nothing(self):
@@ -360,7 +358,6 @@ class TestCapture(TestPulseClient):
 	@patch("frappe.utils.telemetry.pulse.client.is_enabled")
 	def test_capture_when_disabled(self, mock_enabled):
 		"""Test that capture does nothing when disabled"""
-		is_enabled.clear_cache()
 		mock_enabled.return_value = False
 		eq = EventQueue()
 
@@ -371,7 +368,6 @@ class TestCapture(TestPulseClient):
 	@patch("frappe.utils.telemetry.pulse.client.is_enabled")
 	def test_capture_basic(self, mock_enabled):
 		"""Test basic event capture"""
-		is_enabled.clear_cache()
 		mock_enabled.return_value = True
 		eq = EventQueue()
 
@@ -391,7 +387,6 @@ class TestCapture(TestPulseClient):
 	@patch("frappe.utils.telemetry.pulse.client.is_enabled")
 	def test_capture_user_and_team_group(self, mock_enabled):
 		"""On events, team is the identity subject and user is a per-actor dimension"""
-		is_enabled.clear_cache()
 		mock_enabled.return_value = True
 		eq = EventQueue()
 
@@ -406,7 +401,6 @@ class TestCapture(TestPulseClient):
 	def test_capture_defaults_user_and_leaves_team_empty(self, mock_enabled):
 		"""user defaults to the anon site user; team is null when the site has no
 		fc_team configured (e.g. a marketing site)"""
-		is_enabled.clear_cache()
 		mock_enabled.return_value = True
 		eq = EventQueue()
 
@@ -421,7 +415,6 @@ class TestCapture(TestPulseClient):
 	@patch("frappe.utils.telemetry.pulse.client.is_enabled")
 	def test_capture_defaults_team_from_site_config(self, mock_enabled):
 		"""A site with fc_team set stamps it on events without the caller passing it."""
-		is_enabled.clear_cache()
 		mock_enabled.return_value = True
 		eq = EventQueue()
 
@@ -435,7 +428,6 @@ class TestCapture(TestPulseClient):
 	def test_capture_explicit_site_overrides_local(self, mock_enabled):
 		"""site defaults to frappe.local.site but an explicit site= wins (the simulator
 		emits for many sites from one process)."""
-		is_enabled.clear_cache()
 		mock_enabled.return_value = True
 		eq = EventQueue()
 
@@ -450,7 +442,6 @@ class TestIdentify(TestPulseClient):
 	@patch("frappe.utils.telemetry.pulse.client.is_enabled")
 	def test_identify_noop_when_disabled(self, mock_enabled, mock_session):
 		"""identify does nothing (and posts nothing) when telemetry is disabled"""
-		is_enabled.clear_cache()
 		mock_enabled.return_value = False
 
 		identify({"plan": "pro"})
@@ -461,7 +452,6 @@ class TestIdentify(TestPulseClient):
 	@patch("frappe.utils.telemetry.pulse.client.is_enabled")
 	def test_identify_swallows_bad_json(self, mock_enabled, mock_session):
 		"""A malformed properties string is logged, not raised — and nothing is posted."""
-		is_enabled.clear_cache()
 		mock_enabled.return_value = True
 
 		with patch.dict(frappe.conf, {"fc_team": "team_test"}):
@@ -473,7 +463,6 @@ class TestIdentify(TestPulseClient):
 	@patch("frappe.utils.telemetry.pulse.client.is_enabled")
 	def test_identify_posts_profile(self, mock_enabled, mock_session):
 		"""identify posts the team + properties to the identify endpoint"""
-		is_enabled.clear_cache()
 		mock_enabled.return_value = True
 
 		posted = {}
@@ -499,7 +488,6 @@ class TestIdentify(TestPulseClient):
 	@patch("frappe.utils.telemetry.pulse.client.is_enabled")
 	def test_alias_posts_mapping(self, mock_enabled, mock_session):
 		"""alias posts the previous_id → team mapping to the alias endpoint"""
-		is_enabled.clear_cache()
 		mock_enabled.return_value = True
 
 		posted = {}


### PR DESCRIPTION
Two small telemetry-client fixes.

**1. `capture()` `site` is now keyword-only.** The positional `site` slot was a footgun — `capture("event", "erpnext")` looked like it set `site`, though the public wrapper always forwards `app` by keyword so it never actually did. Promotes `app` to the second positional (matching the wrapper) and makes `site` keyword-only. `site` still defaults to `frappe.local.site` and an explicit `site=` still wins (the multi-site simulator relies on it).

**2. `is_enabled()` no longer cached.** The one-hour `site_cache` meant a setup-wizard opt-in wasn't seen for up to an hour. The reads are already cheap (in-memory conf + redis-cached System Settings), so the cache only added staleness. Also drops the now-dead `clear_cache()` call in System Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
