### PR TITLE
fix: notification subject shows "None" when the title field is empty

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -114,7 +114,9 @@ def get_permission_query_conditions(for_user):
 def get_title(doctype, docname, title_field=None):
 	if not title_field:
 		title_field = frappe.get_meta(doctype).get_title_field()
-	return docname if title_field == "name" else frappe.db.get_value(doctype, docname, title_field)
+	if title_field == "name":
+		return docname
+	return frappe.db.get_value(doctype, docname, title_field) or docname
 
 
 def get_title_html(title):

--- a/frappe/desk/doctype/notification_log/test_notification_log.py
+++ b/frappe/desk/doctype/notification_log/test_notification_log.py
@@ -5,6 +5,7 @@ from frappe.core.doctype.user.user import get_system_users
 from frappe.desk.doctype.notification_log.notification_log import (
 	enqueue_create_notification,
 	get_email_header,
+	get_title,
 )
 from frappe.desk.doctype.notification_type.notification_type import install_notification_types
 from frappe.desk.form.assign_to import add as assign_task
@@ -124,6 +125,11 @@ class TestNotificationLog(IntegrationTestCase):
 			frappe.db.get_value("Notification Log", name, "assistance_url"),
 			"https://docs.example.com/fix",
 		)
+
+	def test_get_title_falls_back_to_docname_when_title_is_empty(self):
+		note = frappe.get_doc({"doctype": "Note", "title": "Notification title"}).insert()
+		frappe.db.set_value("Note", note.name, "title", None, update_modified=False)
+		self.assertEqual(get_title("Note", note.name), note.name)
 
 	def test_app_derived_from_document_type(self):
 		"""`app` is filled from the reference document's owning app on insert."""


### PR DESCRIPTION
## Description

Mention, assignment, and share notifications use the referenced document's title when building the notification subject. If the configured title field is empty, `get_title()` returns `None`, resulting in subjects such as **"Sales Order None"** in both in-app notifications and notification emails.

The inconsistency is particularly noticeable because other parts of the same email, such as the header and **Open Document** link, already use the document name and therefore display the correct reference.

This can occur on customized doctypes where the configured `title_field` is empty, as well as on standard doctypes whenever the title field has no value for a document.

`get_title()` now falls back to the document name when the title field is empty, matching the behavior already used elsewhere in the framework (for example, in Print View).

### Example

**Before**

> Administrator mentioned you in a comment in ToDo None

<img width="1440" height="900" alt="notification-title-before" src="https://github.com/user-attachments/assets/d51755ce-968e-4973-aa96-fb8ba55129c1" />


**After**

> Administrator mentioned you in a comment in ToDo h7nhbn75q5

<img width="1440" height="900" alt="notification-title-after" src="https://github.com/user-attachments/assets/054499c9-65f7-456a-a063-c2b8fa110c22" />

---

Ref: https://support.frappe.io/helpdesk/tickets/73056?view=VIEW-HD+Ticket-1242