### PR TITLE
fix(comments): preserve guest-submitted name/email

### DIFF
--- a/frappe/templates/includes/comments/comments.py
+++ b/frappe/templates/includes/comments/comments.py
@@ -34,8 +34,6 @@ def add_comment(
 	route: str,
 	web_form: str | None = None,
 ):
-	comment_email = frappe.session.user
-	comment_by = frappe.get_value("User", frappe.session.user, "full_name")
 	if frappe.session.user == "Guest":
 		allowed_doctypes = ["Web Page"]
 		comments_permission_config = frappe.get_hooks("has_comment_permission")
@@ -50,6 +48,11 @@ def add_comment(
 
 		if not guest_allowed:
 			frappe.throw(_("Please login to post a comment."), exc=frappe.AuthenticationError)
+	else:
+		# override with the logged-in user's identity to prevent spoofing;
+		# guests must supply their own name/email in the request
+		comment_email = frappe.session.user
+		comment_by = frappe.get_value("User", frappe.session.user, "full_name")
 
 	if not comment.strip():
 		frappe.msgprint(_("The comment cannot be empty"))


### PR DESCRIPTION
### Problem
Guest comments are saved as "Guest" instead of the name/email the visitor submitted.

### Cause
#39373 added an anti-spoofing override but placed it **above** the `if frappe.session.user == "Guest"` check, so it ran for guests too — overwriting their submitted `comment_by`/`comment_email` with `"Guest"`.

### Fix
Scope the override to logged-in users (`else` branch). Guests keep their submitted name/email; logged-in spoofing stays blocked.
