### PR TITLE
fix: stop badge from clipping text descenders

### DIFF
--- a/frappe/public/css/espresso/components/badge.css
+++ b/frappe/public/css/espresso/components/badge.css
@@ -33,7 +33,8 @@
   height: calc(var(--es-sp) * 5);
   padding-inline: calc(var(--es-sp) * 1.5);
   font-size: 0.75rem;
-  line-height: 1;
+  /* was 1 — too tight, clipped text descenders like "g"/"p" inside the badge */
+  line-height: 1.3;
 
   /* default variant = subtle */
   background: var(--c-fill);

--- a/frappe/public/css/espresso/components/badge.css
+++ b/frappe/public/css/espresso/components/badge.css
@@ -33,7 +33,6 @@
   height: calc(var(--es-sp) * 5);
   padding-inline: calc(var(--es-sp) * 1.5);
   font-size: 0.75rem;
-  /* was 1 — too tight, clipped text descenders like "g"/"p" inside the badge */
   line-height: 1.3;
 
   /* default variant = subtle */


### PR DESCRIPTION
## Problem

Badge text with descenders (e.g. a Select value like "Engineering") gets its "g" clipped at the bottom. `.es-badge` set `line-height: 1`, so the descender fell outside the text box and was cut off.

## Solution

Bump the badge `line-height` to `1.3` so descenders fit. Badge height is unchanged.