### PR TITLE
fix: print format builder table + preview fixes

### DIFF
--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -20,8 +20,9 @@
 				</button>
 			</div>
 
-			<!-- Canvas toolbar: sample data picker (hidden in preview mode) -->
-			<div v-if="!show_preview" class="canvas-toolbar">
+			<!-- Canvas toolbar: sample data picker (hidden in preview mode).
+			     v-show (not v-if) so the picker control survives a preview round-trip. -->
+			<div v-show="!show_preview" class="canvas-toolbar">
 				<div class="canvas-toolbar-left">
 					<span class="canvas-toolbar-eyebrow">{{ __("PREVIEW DATA") }}</span>
 				</div>
@@ -152,8 +153,15 @@ watch(fullscreen, (on) => {
 watch(show_preview, (on) => {
 	if (on) {
 		history.pushState({ ...history.state, pfb_preview: true }, "");
-	} else if (history.state?.pfb_preview) {
-		history.back();
+	} else {
+		// Reflect a document changed in preview mode back in the edit-mode picker
+		const name = $store.value.preview_doc_name.value;
+		if (name && doc_picker_ctrl.value?.get_value() !== name) {
+			doc_picker_ctrl.value?.set_value(name);
+		}
+		if (history.state?.pfb_preview) {
+			history.back();
+		}
 	}
 });
 
@@ -310,16 +318,24 @@ function init_doc_picker() {
 	doc_picker_ref.value.querySelector(".control-label")?.remove();
 	doc_picker_ref.value.querySelector(".form-group")?.style.setProperty("margin", "0");
 
-	// Auto-select the first available record so preview is ready immediately
-	frappe.db
-		.get_list(meta?.name, { limit: 1, fields: ["name"], order_by: "creation desc" })
-		.then((rows) => {
-			if (rows?.length) {
-				const first = rows[0].name;
-				doc_picker_ctrl.value?.set_value(first);
-				$store.value.load_preview_doc(first);
-			}
-		});
+	const select = (name) => {
+		doc_picker_ctrl.value?.set_value(name);
+		$store.value.load_preview_doc(name);
+	};
+	// Prefer the record chosen last time (persisted across refresh); otherwise
+	// auto-select the most recent record so the preview is ready immediately.
+	const saved = $store.value.persisted_preview_doc_name();
+	const auto_select = () =>
+		frappe.db
+			.get_list(meta?.name, { limit: 1, fields: ["name"], order_by: "creation desc" })
+			.then((rows) => rows?.length && select(rows[0].name));
+	if (saved) {
+		frappe.db
+			.get_value(meta?.name, saved, "name")
+			.then((r) => (r?.message?.name ? select(saved) : auto_select()));
+	} else {
+		auto_select();
+	}
 }
 
 // mounted

--- a/frappe/public/js/print_format_builder/components/Preview.vue
+++ b/frappe/public/js/print_format_builder/components/Preview.vue
@@ -86,6 +86,8 @@ onMounted(() => {
 			options: doctype.value,
 			change: () => {
 				docname.value = doc_select.value.get_value();
+				// keep the editor's preview selection in sync with the preview
+				store.value.load_preview_doc(docname.value || null);
 			},
 		},
 		render_input: true,
@@ -104,9 +106,17 @@ onMounted(() => {
 		render_input: true,
 	});
 	preview_type.value.set_value(type.value);
-	get_default_docname().then((doc_name) => {
-		doc_name && doc_select.value.set_value(doc_name);
-	});
+	// Prefer the document already chosen while editing; only fall back to a
+	// default when nothing has been selected yet. `store` is ref(inject("$store")),
+	// so `store.value` is a reactive proxy that unwraps preview_doc_name to a string.
+	const selected = store.value.preview_doc_name;
+	if (selected) {
+		doc_select.value.set_value(selected);
+	} else {
+		get_default_docname().then((doc_name) => {
+			doc_name && doc_select.value.set_value(doc_name);
+		});
+	}
 });
 </script>
 

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -598,6 +598,8 @@ const NUMERIC_FIELDTYPES = new Set(["Currency", "Float", "Int", "Percent"]);
 const HTML_CONTENT_FIELDTYPES = new Set(["Text Editor", "Long Text"]);
 
 function numeric_align_class(col) {
+	// Serial-number column is centered (matches the PDF)
+	if (col?.fieldname === "idx") return "col-center";
 	// Merged cells are left-aligned (like the PDF), even on numeric columns
 	return !has_merge(col) && NUMERIC_FIELDTYPES.has(col?.fieldtype) ? "col-numeric" : "";
 }
@@ -1258,6 +1260,11 @@ watch(
 /* Numeric columns right-aligned — same as PDF */
 .preview-table .col-numeric {
 	text-align: right;
+}
+
+/* Serial-number column centered — same as PDF */
+.preview-table .col-center {
+	text-align: center;
 }
 
 /* ── Borderless variant ──────────────────────────────── */

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -114,13 +114,20 @@ export function getStore(print_format_name) {
 	function reset_changes() {
 		fetch();
 	}
+	// Persist the chosen preview record per print format so it survives a refresh
+	const preview_doc_ls_key = `pfb:preview_doc:${print_format_name}`;
+	function persisted_preview_doc_name() {
+		return localStorage.getItem(preview_doc_ls_key);
+	}
 	function load_preview_doc(name) {
 		if (!name) {
 			preview_doc.value = null;
 			preview_doc_name.value = null;
+			localStorage.removeItem(preview_doc_ls_key);
 			return;
 		}
 		preview_doc_name.value = name;
+		localStorage.setItem(preview_doc_ls_key, name);
 		frappe.db.get_doc(print_format.value.doc_type, name).then((doc) => {
 			preview_doc.value = doc;
 		});
@@ -192,6 +199,7 @@ export function getStore(print_format_name) {
 		preview_doc,
 		preview_doc_name,
 		load_preview_doc,
+		persisted_preview_doc_name,
 		fetch,
 		update,
 		save_changes,

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -297,7 +297,7 @@ body {
 
 /* ── Merged cells (multiple fields, optional left image) ─── */
 /* Same specificity as the numeric-align rule above but declared later, so
-   this wins the cascade without needing !important. */
+   this wins the cascade without needing !important */
 .child-table .column-value--merged {
 	text-align: left;
 }

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -290,6 +290,11 @@ body {
 	text-align: right;
 }
 
+/* Serial-number column is centered */
+.child-table [data-fieldname="idx"] {
+	text-align: center;
+}
+
 /* ── Merged cells (multiple fields, optional left image) ─── */
 /* Same specificity as the numeric-align rule above but declared later, so
    this wins the cascade without needing !important. */

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -64,7 +64,7 @@
 	{%- if not section.label or ns.has_content -%}
 	{%- set ns3 = namespace(section_style='') -%}
 	{%- if section.background -%}
-		{%- set ns3.section_style = ns3.section_style + 'background:' + section.background + ';border-radius:8px;' -%}
+		{%- set ns3.section_style = ns3.section_style + 'background:' + section.background + ';' -%}
 	{%- endif -%}
 	{%- for prop in ['padding', 'margin'] -%}
 		{%- set box = section.get(prop) -%}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -64,7 +64,7 @@
 	{%- if not section.label or ns.has_content -%}
 	{%- set ns3 = namespace(section_style='') -%}
 	{%- if section.background -%}
-		{%- set ns3.section_style = ns3.section_style + 'background:' + section.background + ';' -%}
+		{%- set ns3.section_style = ns3.section_style + 'background:' + section.background + ';border-radius:8px;' -%}
 	{%- endif -%}
 	{%- for prop in ['padding', 'margin'] -%}
 		{%- set box = section.get(prop) -%}


### PR DESCRIPTION
- Center serial-number column in child tables
- Round section background corners in print output
- Keep preview document selection in sync (edit ↔ preview) and across refresh