### PR TITLE
feat: add hook to allow drive to overrwrite file perms

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -953,6 +953,9 @@ def on_doctype_update():
 def has_permission(doc, ptype=None, user=None, debug=False):
 	user = user or frappe.session.user
 
+	if any(frappe.get_hooks("ignore_file_permissions")):
+		return True
+
 	if user == "Administrator":
 		return True
 
@@ -992,6 +995,10 @@ def has_permission(doc, ptype=None, user=None, debug=False):
 
 def get_permission_query_conditions(user: str | None = None) -> str:
 	user = user or frappe.session.user
+
+	if any(frappe.get_hooks("ignore_file_permissions")):
+		return ""
+
 	if user == "Administrator":
 		return ""
 


### PR DESCRIPTION
If two hooks conflict, the `False` is respected. But Drive needs its own perm set over `File` regardless of Framework. 

This PR adds a hook to solve that.

`no-docs`