### PR TITLE
fix(List View): fetch newly added column's data without reload

### DIFF
--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -65,13 +65,11 @@ export default class ListSettings {
 					me.listview.list_filter
 						.update_layout_columns(layout, me.fields, { debounce: false })
 						.then(async () => {
-							// setup_columns is async (may load linked doctype meta for
-							// link-title columns); wait before rendering the header.
 							await me.listview.setup_columns(me.fields);
-							me.listview.render_header(true);
-							me.listview.apply_column_widths?.();
+							await me.listview.refresh(true);
 							me.dialog.hide();
-						});
+						})
+						.catch((e) => frappe.show_alert({ message: e.message, indicator: "red" }));
 					return;
 				}
 			}


### PR DESCRIPTION
## Problem

When a column is added to a List View (List View Settings → add a field), the new column shows **empty values for every row** — e.g. **0** for Currency/Float fields — even though the data is correct on the record. It only shows the real values after a full page reload.

## Steps to reproduce

1. Open any List View (e.g. **Item**).
2. Add a Currency/Float column that isn't shown by default (e.g. **Valuation Rate**).
3. The new column renders **0** for all rows, even for records where the value is set.
4. Reload the page → the column now shows the correct values.

## Root cause

`refresh_columns` (called after saving List View Settings) rebuilds the **columns** via `setup_columns()`, but it does **not** rebuild the list of **fields fetched** from the server. `this.fields` is only built once by `set_fields()`/`setup_fields()` during initial setup.

So after adding a column:
- The new column is rendered, but the data query still uses the **old** field list (without the new field), so `doc[fieldname]` is `undefined` → rendered as `0` for currency/number fields.
- `refresh()`'s `no_change()` guard can also **skip the re-fetch** entirely, because the query args are unchanged.

## Fix

Rebuild the fetched fields in `refresh_columns` (reset `this.fields` and run `setup_fields()`) before refreshing, so the newly added column is actually queried and shows its real values immediately — no reload required.

## Verification

Reproduced on an **Item** list with a **Valuation Rate** column: before the fix it showed `0` for all rows; after the fix, adding the column re-fetches the data and shows the correct values (e.g. 2250, 1150, 0.5) without reloading.
