### PR TITLE
fix(oauth): allow loopback redirect URIs

### DIFF
--- a/frappe/integrations/test_utils.py
+++ b/frappe/integrations/test_utils.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# License: MIT. See LICENSE
+
+from unittest.mock import patch
+
+import frappe
+from frappe.integrations.utils import OAuth2DynamicClientMetadata, validate_dynamic_client_metadata
+from frappe.tests import UnitTestCase
+
+
+class TestOAuth2DynamicClientMetadata(UnitTestCase):
+	@patch.dict(frappe.conf, {"developer_mode": 0})
+	def test_redirect_uri_scheme(self):
+		for redirect_uri in (
+			"https://example.com/callback",
+			"http://127.0.0.1:8080/callback",
+			"http://127.42.0.9/callback",
+			"http://[::1]:8080/callback",
+		):
+			with self.subTest(redirect_uri=redirect_uri):
+				client = OAuth2DynamicClientMetadata(client_name="Test Client", redirect_uris=[redirect_uri])
+				self.assertIsNone(validate_dynamic_client_metadata(client))
+
+		for redirect_uri in (
+			"http://example.com/callback",
+			"http://localhost/callback",
+			"http://192.168.1.1/callback",
+		):
+			with self.subTest(redirect_uri=redirect_uri):
+				client = OAuth2DynamicClientMetadata(client_name="Test Client", redirect_uris=[redirect_uri])
+				self.assertEqual(validate_dynamic_client_metadata(client), "redirect_uris must be https")

--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -233,7 +233,7 @@ def _is_secure_redirect_uri(uri: HttpUrl) -> bool:
 		return False
 
 	try:
-		return ipaddress.ip_address(uri.host.strip("[]")).is_loopback
+		return ipaddress.ip_address((uri.host or "").strip("[]")).is_loopback
 	except ValueError:
 		return False
 

--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import datetime
+import ipaddress
 import json
 from typing import Any, cast
 from urllib.parse import parse_qs
@@ -213,13 +214,28 @@ def validate_dynamic_client_metadata(client: OAuth2DynamicClientMetadata):
 	if client.response_types and not all(rt == "code" for rt in client.response_types):
 		invalidation_reasons.append("only 'code' response_type is supported")
 
-	if not frappe.conf.developer_mode and any(c.scheme != "https" for c in client.redirect_uris):
+	if not frappe.conf.developer_mode and any(
+		not _is_secure_redirect_uri(uri) for uri in client.redirect_uris
+	):
 		invalidation_reasons.append("redirect_uris must be https")
 
 	if invalidation_reasons:
 		return ",\n".join(invalidation_reasons)
 
 	return None
+
+
+def _is_secure_redirect_uri(uri: HttpUrl) -> bool:
+	if uri.scheme == "https":
+		return True
+
+	if uri.scheme != "http":
+		return False
+
+	try:
+		return ipaddress.ip_address(uri.host.strip("[]")).is_loopback
+	except ValueError:
+		return False
 
 
 def create_new_oauth_client(client: OAuth2DynamicClientMetadata):


### PR DESCRIPTION
Skipping HTTP on loopback is safe and required for native apps. 

https://www.rfc-editor.org/rfc/rfc8252.html#section-8.3 