### PR TITLE
fix(oauth): hash bearer tokens at rest

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -664,6 +664,7 @@ def validate_oauth(authorization_header):
 	        authorization_header (list of str): The 'Authorization' header containing the prefix and token
 	"""
 
+	from frappe.integrations.doctype.oauth_bearer_token.oauth_bearer_token import get_oauth_token_hash
 	from frappe.integrations.oauth2 import get_oauth_server
 	from frappe.oauth import get_url_delimiter
 
@@ -683,14 +684,16 @@ def validate_oauth(authorization_header):
 		body = None
 
 	try:
-		required_scopes = frappe.db.get_value("OAuth Bearer Token", token, "scopes").split(
+		token_hash = get_oauth_token_hash(token)
+		token_filters = {"access_token": token_hash}
+		required_scopes = frappe.db.get_value("OAuth Bearer Token", token_filters, "scopes").split(
 			get_url_delimiter()
 		)
 		valid, _oauthlib_request = get_oauth_server().verify_request(
 			uri, http_method, body, headers, required_scopes
 		)
 		if valid:
-			user = frappe.db.get_value("OAuth Bearer Token", token, "user")
+			user = frappe.db.get_value("OAuth Bearer Token", token_filters, "user")
 			if not frappe.db.get_value("User", user, "enabled"):
 				frappe.throw(_("User {0} is disabled").format(user), frappe.AuthenticationError)
 			frappe.set_user(user)

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -686,15 +686,18 @@ def validate_oauth(authorization_header):
 	try:
 		token_hash = get_oauth_token_hash(token)
 		token_filters = {"access_token": token_hash}
-		required_scopes = frappe.db.get_value("OAuth Bearer Token", token_filters, "scopes").split(
-			get_url_delimiter()
+		token_details = frappe.db.get_value(
+			"OAuth Bearer Token", token_filters, ("scopes", "user"), as_dict=True
 		)
+		if not token_details:
+			return
+		required_scopes = token_details.scopes.split(get_url_delimiter())
 		valid, _oauthlib_request = get_oauth_server().verify_request(
 			uri, http_method, body, headers, required_scopes
 		)
 		if valid:
-			user = frappe.db.get_value("OAuth Bearer Token", token_filters, "user")
-			if not frappe.db.get_value("User", user, "enabled"):
+			user = token_details.user
+			if not frappe.get_cached_value("User", user, "enabled"):
 				frappe.throw(_("User {0} is disabled").format(user), frappe.AuthenticationError)
 			frappe.set_user(user)
 			frappe.local.form_dict = form_dict

--- a/frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
+++ b/frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "field:access_token",
+ "autoname": "hash",
  "creation": "2016-08-24 14:10:17.471264",
  "doctype": "DocType",
  "document_type": "Document",
@@ -52,7 +52,8 @@
    "fieldname": "refresh_token",
    "fieldtype": "Data",
    "label": "Refresh Token",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "expiration_time",
@@ -82,7 +83,7 @@
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Bearer Token",
- "naming_rule": "By fieldname",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {

--- a/frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
+++ b/frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
@@ -53,7 +53,7 @@
    "fieldtype": "Data",
    "label": "Refresh Token",
    "read_only": 1,
-   "search_index": 1
+   "unique": 1
   },
   {
    "fieldname": "expiration_time",

--- a/frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.py
+++ b/frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.py
@@ -9,7 +9,7 @@ from frappe.utils.data import add_to_date, sha256_hash
 
 
 def get_oauth_token_hash(token: str | bytes | None) -> str | None:
-	if token is None:
+	if not token:
 		return None
 	return sha256_hash(token)
 

--- a/frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.py
+++ b/frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.py
@@ -5,7 +5,13 @@ import frappe
 from frappe.model.document import Document
 from frappe.query_builder import Interval
 from frappe.query_builder.functions import Now
-from frappe.utils.data import add_to_date
+from frappe.utils.data import add_to_date, sha256_hash
+
+
+def get_oauth_token_hash(token: str | bytes | None) -> str | None:
+	if token is None:
+		return None
+	return sha256_hash(token)
 
 
 class OAuthBearerToken(Document):
@@ -28,6 +34,12 @@ class OAuthBearerToken(Document):
 		status: DF.Literal["Active", "Revoked"]
 		user: DF.Link
 	# end: auto-generated types
+
+	def before_insert(self):
+		if self.access_token:
+			self.access_token = get_oauth_token_hash(self.access_token)
+		if self.refresh_token:
+			self.refresh_token = get_oauth_token_hash(self.refresh_token)
 
 	def validate(self):
 		if not self.expiration_time:

--- a/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
+++ b/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
+from frappe.integrations.doctype.oauth_bearer_token.oauth_bearer_token import get_oauth_token_hash
 from frappe.patches.v16_0.hash_oauth_bearer_tokens import execute as hash_existing_tokens
 from frappe.tests import IntegrationTestCase
 from frappe.utils import sha256_hash
@@ -16,6 +17,7 @@ class TestOAuthBearerToken(IntegrationTestCase):
 		self.assertNotIn(token.name, (access_token, sha256_hash(access_token)))
 		self.assertEqual(token.access_token, sha256_hash(access_token))
 		self.assertEqual(token.refresh_token, sha256_hash(refresh_token))
+		self.assertIsNone(get_oauth_token_hash(""))
 
 	def test_refresh_token_is_looked_up_by_hash(self):
 		from frappe.oauth import OAuthWebRequestValidator
@@ -75,6 +77,7 @@ class TestOAuthBearerToken(IntegrationTestCase):
 			pluck="name",
 		)
 		self.assertEqual(len(remaining_tokens), 1)
+		self.assertEqual(remaining_tokens[0], duplicate_token.name)
 
 	def test_patch_normalizes_missing_refresh_tokens_to_null(self):
 		null_token = make_bearer_token(frappe.generate_hash(), frappe.generate_hash())

--- a/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
+++ b/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
@@ -61,24 +61,6 @@ class TestOAuthBearerToken(IntegrationTestCase):
 		self.assertEqual(stored_token.access_token, sha256_hash(access_token))
 		self.assertEqual(stored_token.refresh_token, sha256_hash(refresh_token))
 
-	def test_patch_removes_duplicate_refresh_tokens(self):
-		refresh_token = frappe.generate_hash()
-		first_token = make_bearer_token(frappe.generate_hash(), refresh_token)
-		duplicate_token = make_bearer_token(frappe.generate_hash(), frappe.generate_hash())
-
-		frappe.db.set_value(
-			"OAuth Bearer Token", duplicate_token.name, "refresh_token", first_token.refresh_token
-		)
-		hash_existing_tokens()
-
-		remaining_tokens = frappe.get_all(
-			"OAuth Bearer Token",
-			filters={"name": ["in", [first_token.name, duplicate_token.name]]},
-			pluck="name",
-		)
-		self.assertEqual(len(remaining_tokens), 1)
-		self.assertEqual(remaining_tokens[0], duplicate_token.name)
-
 	def test_patch_normalizes_missing_refresh_tokens_to_null(self):
 		null_token = make_bearer_token(frappe.generate_hash(), frappe.generate_hash())
 		empty_token = make_bearer_token(frappe.generate_hash(), frappe.generate_hash())

--- a/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
+++ b/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
@@ -51,6 +51,51 @@ class TestOAuthBearerToken(IntegrationTestCase):
 		self.assertEqual(stored_token.refresh_token, sha256_hash(refresh_token))
 		self.assertFalse(frappe.db.exists("OAuth Bearer Token", access_token))
 
+		name_after_first_run = stored_token.name
+		hash_existing_tokens()
+		stored_token.reload()
+
+		self.assertEqual(stored_token.name, name_after_first_run)
+		self.assertEqual(stored_token.access_token, sha256_hash(access_token))
+		self.assertEqual(stored_token.refresh_token, sha256_hash(refresh_token))
+
+	def test_patch_removes_duplicate_refresh_tokens(self):
+		refresh_token = frappe.generate_hash()
+		first_token = make_bearer_token(frappe.generate_hash(), refresh_token)
+		duplicate_token = make_bearer_token(frappe.generate_hash(), frappe.generate_hash())
+
+		frappe.db.set_value(
+			"OAuth Bearer Token", duplicate_token.name, "refresh_token", first_token.refresh_token
+		)
+		hash_existing_tokens()
+
+		remaining_tokens = frappe.get_all(
+			"OAuth Bearer Token",
+			filters={"name": ["in", [first_token.name, duplicate_token.name]]},
+			pluck="name",
+		)
+		self.assertEqual(len(remaining_tokens), 1)
+
+	def test_patch_normalizes_missing_refresh_tokens_to_null(self):
+		null_token = make_bearer_token(frappe.generate_hash(), frappe.generate_hash())
+		empty_token = make_bearer_token(frappe.generate_hash(), frappe.generate_hash())
+		token_table = frappe.qb.DocType("OAuth Bearer Token")
+		(
+			frappe.qb.update(token_table)
+			.set(token_table.refresh_token, None)
+			.where(token_table.name == null_token.name)
+		).run()
+		(
+			frappe.qb.update(token_table)
+			.set(token_table.refresh_token, "")
+			.where(token_table.name == empty_token.name)
+		).run()
+
+		hash_existing_tokens()
+
+		self.assertIsNone(frappe.db.get_value("OAuth Bearer Token", null_token.name, "refresh_token"))
+		self.assertIsNone(frappe.db.get_value("OAuth Bearer Token", empty_token.name, "refresh_token"))
+
 
 def make_bearer_token(access_token: str, refresh_token: str):
 	return frappe.get_doc(

--- a/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
+++ b/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
@@ -1,8 +1,66 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
+from frappe.patches.v16_0.hash_oauth_bearer_tokens import execute as hash_existing_tokens
 from frappe.tests import IntegrationTestCase
+from frappe.utils import sha256_hash
 
 
 class TestOAuthBearerToken(IntegrationTestCase):
-	pass
+	def test_tokens_are_hashed_before_insert(self):
+		access_token = frappe.generate_hash()
+		refresh_token = frappe.generate_hash()
+
+		token = make_bearer_token(access_token, refresh_token)
+
+		self.assertNotIn(token.name, (access_token, sha256_hash(access_token)))
+		self.assertEqual(token.access_token, sha256_hash(access_token))
+		self.assertEqual(token.refresh_token, sha256_hash(refresh_token))
+
+	def test_refresh_token_is_looked_up_by_hash(self):
+		from frappe.oauth import OAuthWebRequestValidator
+
+		refresh_token = frappe.generate_hash()
+		make_bearer_token(frappe.generate_hash(), refresh_token)
+		request = frappe._dict()
+		validator = OAuthWebRequestValidator()
+
+		self.assertEqual(validator.get_original_scopes(refresh_token, request), "all openid")
+		self.assertTrue(validator.validate_refresh_token(refresh_token, None, request))
+		self.assertEqual(request.user, "Administrator")
+
+	def test_patch_hashes_existing_tokens(self):
+		access_token = frappe.generate_hash()
+		refresh_token = frappe.generate_hash()
+		token = make_bearer_token(access_token, refresh_token)
+
+		token_table = frappe.qb.DocType("OAuth Bearer Token")
+		(
+			frappe.qb.update(token_table)
+			.set(token_table.name, access_token)
+			.set(token_table.access_token, access_token)
+			.set(token_table.refresh_token, refresh_token)
+			.where(token_table.name == token.name)
+		).run()
+
+		hash_existing_tokens()
+
+		stored_token = frappe.get_doc("OAuth Bearer Token", {"access_token": sha256_hash(access_token)})
+		self.assertNotIn(stored_token.name, (access_token, sha256_hash(access_token)))
+		self.assertEqual(stored_token.access_token, sha256_hash(access_token))
+		self.assertEqual(stored_token.refresh_token, sha256_hash(refresh_token))
+		self.assertFalse(frappe.db.exists("OAuth Bearer Token", access_token))
+
+
+def make_bearer_token(access_token: str, refresh_token: str):
+	return frappe.get_doc(
+		{
+			"doctype": "OAuth Bearer Token",
+			"access_token": access_token,
+			"refresh_token": refresh_token,
+			"expires_in": 3600,
+			"scopes": "all openid",
+			"status": "Active",
+			"user": "Administrator",
+		}
+	).insert(ignore_permissions=True)

--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -108,21 +108,24 @@ def authorize(**kwargs):
 				frappe.flags.oauth_credentials,
 			) = get_oauth_server().validate_authorization_request(r.url, r.method, r.get_data(), r.headers)
 
-			skip_auth = frappe.db.get_value(
+			skip_auth = frappe.get_cached_value(
 				"OAuth Client",
 				frappe.flags.oauth_credentials["client_id"],
 				"skip_authorization",
 			)
-			unrevoked_tokens = frappe.db.exists(
-				"OAuth Bearer Token",
-				{
-					"status": "Active",
-					"user": frappe.session.user,
-					"client": frappe.flags.oauth_credentials["client_id"],
-				},
+			authorization_skipped = skip_auth or (
+				get_oauth_settings().skip_authorization == "Auto"
+				and frappe.db.exists(
+					"OAuth Bearer Token",
+					{
+						"status": "Active",
+						"user": frappe.session.user,
+						"client": frappe.flags.oauth_credentials["client_id"],
+					},
+				)
 			)
 
-			if skip_auth or (get_oauth_settings().skip_authorization == "Auto" and unrevoked_tokens):
+			if authorization_skipped:
 				headers, _body, _status = get_oauth_server().create_authorization_response(
 					uri=frappe.flags.oauth_credentials["redirect_uri"],
 					body=r.get_data(),
@@ -140,7 +143,7 @@ def authorize(**kwargs):
 				# Show Allow/Deny screen.
 				response_html_params = frappe._dict(
 					{
-						"client_id": frappe.db.get_value("OAuth Client", kwargs["client_id"], "app_name"),
+						"client_id": frappe.get_cached_value("OAuth Client", kwargs["client_id"], "app_name"),
 						"success_url": success_url,
 						"failure_url": failure_url,
 						"details": scopes,
@@ -252,7 +255,7 @@ def introspect_token(token: str, token_type_hint: str | None = None):
 				"OAuth Bearer Token", {"refresh_token": get_oauth_token_hash(token)}
 			)
 
-		client = frappe.get_doc("OAuth Client", bearer_token.client)
+		client = frappe.get_cached_doc("OAuth Client", bearer_token.client)
 
 		token_response = frappe._dict(
 			{
@@ -265,16 +268,9 @@ def introspect_token(token: str, token_type_hint: str | None = None):
 		)
 
 		if "openid" in bearer_token.scopes:
-			sub = frappe.get_value(
-				"User Social Login",
-				{"provider": "frappe", "parent": bearer_token.user},
-				"userid",
-			)
-
-			if sub:
-				token_response.update({"sub": sub})
-				user = frappe.get_doc("User", bearer_token.user)
-				userinfo = get_userinfo(user)
+			user = frappe.get_cached_doc("User", bearer_token.user)
+			userinfo = get_userinfo(user)
+			if userinfo.sub:
 				token_response.update(userinfo)
 
 		frappe.local.response = token_response

--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -12,6 +12,7 @@ from werkzeug.exceptions import NotFound
 import frappe
 import frappe.utils
 from frappe import oauth
+from frappe.integrations.doctype.oauth_bearer_token.oauth_bearer_token import get_oauth_token_hash
 from frappe.integrations.utils import (
 	OAuth2DynamicClientMetadata,
 	create_new_oauth_client,
@@ -245,9 +246,11 @@ def introspect_token(token: str, token_type_hint: str | None = None):
 	try:
 		bearer_token = None
 		if token_type_hint == "access_token":
-			bearer_token = frappe.get_doc("OAuth Bearer Token", {"access_token": token})
+			bearer_token = frappe.get_doc("OAuth Bearer Token", {"access_token": get_oauth_token_hash(token)})
 		elif token_type_hint == "refresh_token":
-			bearer_token = frappe.get_doc("OAuth Bearer Token", {"refresh_token": token})
+			bearer_token = frappe.get_doc(
+				"OAuth Bearer Token", {"refresh_token": get_oauth_token_hash(token)}
+			)
 
 		client = frappe.get_doc("OAuth Client", bearer_token.client)
 

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -18,12 +18,14 @@ class OAuthWebRequestValidator(RequestValidator):
 	# Pre- and post-authorization.
 	def validate_client_id(self, client_id, request, *args, **kwargs):
 		# Simple validity check, does client exist? Not banned?
-		cli_id = frappe.db.get_value("OAuth Client", {"name": client_id})
-		if cli_id:
-			client = frappe.get_doc("OAuth Client", client_id)
-			if client.user_has_allowed_role():
-				request.client = client.as_dict()
-				return True
+		try:
+			client = frappe.get_cached_doc("OAuth Client", client_id)
+		except frappe.DoesNotExistError:
+			return False
+
+		if client.user_has_allowed_role():
+			request.client = client.as_dict()
+			return True
 		return False
 
 	def validate_redirect_uri(self, client_id, redirect_uri, request, *args, **kwargs):
@@ -31,7 +33,7 @@ class OAuthWebRequestValidator(RequestValidator):
 		# the client previously registered this EXACT redirect uri.
 
 		redirect_uris = (
-			cstr(frappe.db.get_value("OAuth Client", client_id, "redirect_uris"))
+			cstr(frappe.get_cached_value("OAuth Client", client_id, "redirect_uris"))
 			.strip()
 			.split(get_url_delimiter())
 		)
@@ -45,7 +47,7 @@ class OAuthWebRequestValidator(RequestValidator):
 		# The redirect used if none has been supplied.
 		# Prefer your clients to pre register a redirect uri rather than
 		# supplying one on each authorization request.
-		return frappe.db.get_value("OAuth Client", client_id, "default_redirect_uri")
+		return frappe.get_cached_value("OAuth Client", client_id, "default_redirect_uri")
 
 	def validate_scopes(self, client_id, scopes, client, request, *args, **kwargs):
 		# Is the client allowed to access the requested scopes?
@@ -112,7 +114,7 @@ class OAuthWebRequestValidator(RequestValidator):
 
 			client_name = frappe.db.get_value("OAuth Bearer Token", filters=token_filters, fieldname="client")
 
-		oc: OAuthClient = frappe.get_doc("OAuth Client", client_name)
+		oc: OAuthClient = frappe.get_cached_doc("OAuth Client", client_name)
 		try:
 			request.client = request.client or oc.as_dict()
 		except Exception as e:
@@ -121,37 +123,35 @@ class OAuthWebRequestValidator(RequestValidator):
 		return True
 
 	def authenticate_client_id(self, client_id, request, *args, **kwargs):
-		cli_id = frappe.db.get_value("OAuth Client", client_id, "name")
-		if not cli_id:
+		try:
+			client = frappe.get_cached_doc("OAuth Client", client_id)
+		except frappe.DoesNotExistError:
 			# Don't allow public (non-authenticated) clients
 			return False
-		else:
-			request["client"] = frappe.get_doc("OAuth Client", cli_id)
-			return True
+
+		request["client"] = client
+		return True
 
 	def validate_code(self, client_id, code, client, request, *args, **kwargs):
 		# Validate the code belongs to the client. Add associated scopes,
 		# state and user to request.scopes and request.user.
 
-		validcodes = frappe.get_all(
+		code_details = frappe.db.get_value(
 			"OAuth Authorization Code",
-			filters={"client": client_id, "validity": "Valid"},
+			{"name": code, "client": client_id, "validity": "Valid"},
+			("scopes", "user", "code_challenge_method", "code_challenge"),
+			as_dict=True,
 		)
 
-		if code in [vcode["name"] for vcode in validcodes]:
-			request.scopes = frappe.db.get_value("OAuth Authorization Code", code, "scopes").split(
-				get_url_delimiter()
-			)
-			request.user = frappe.db.get_value("OAuth Authorization Code", code, "user")
-			code_challenge_method = frappe.db.get_value(
-				"OAuth Authorization Code", code, "code_challenge_method"
-			)
-			code_challenge = frappe.db.get_value("OAuth Authorization Code", code, "code_challenge")
+		if code_details:
+			request.scopes = code_details.scopes.split(get_url_delimiter())
+			request.user = code_details.user
+			code_challenge_method = code_details.code_challenge_method
+			code_challenge = code_details.code_challenge
 
 			if code_challenge and not request.code_verifier:
-				if frappe.db.exists("OAuth Authorization Code", code):
-					frappe.delete_doc("OAuth Authorization Code", code, ignore_permissions=True, force=True)
-					frappe.db.commit()
+				frappe.delete_doc("OAuth Authorization Code", code, ignore_permissions=True, force=True)
+				frappe.db.commit()
 				return False
 
 			if code_challenge_method == "s256":
@@ -171,9 +171,11 @@ class OAuthWebRequestValidator(RequestValidator):
 		return False
 
 	def confirm_redirect_uri(self, client_id, code, redirect_uri, client, *args, **kwargs):
-		saved_redirect_uri = frappe.db.get_value("OAuth Client", client_id, "default_redirect_uri")
-
-		redirect_uris = frappe.db.get_value("OAuth Client", client_id, "redirect_uris")
+		client_redirects = frappe.get_cached_value(
+			"OAuth Client", client_id, ("default_redirect_uri", "redirect_uris"), as_dict=True
+		)
+		saved_redirect_uri = client_redirects.default_redirect_uri
+		redirect_uris = client_redirects.redirect_uris
 
 		if redirect_uris:
 			redirect_uris = redirect_uris.split(get_url_delimiter())
@@ -215,7 +217,7 @@ class OAuthWebRequestValidator(RequestValidator):
 		otoken.save(ignore_permissions=True)
 		frappe.db.commit()
 
-		return frappe.db.get_value("OAuth Client", request.client["name"], "default_redirect_uri")
+		return frappe.get_cached_value("OAuth Client", request.client["name"], "default_redirect_uri")
 
 	def invalidate_authorization_code(self, client_id, code, request, *args, **kwargs):
 		# Authorization codes are use once, invalidate it when a Bearer token
@@ -230,7 +232,7 @@ class OAuthWebRequestValidator(RequestValidator):
 		# Remember to check expiration and scope membership
 		otoken = frappe.get_doc("OAuth Bearer Token", {"access_token": get_oauth_token_hash(token)})
 		is_token_valid = (now_datetime() < otoken.expiration_time) and otoken.status != "Revoked"
-		client_scopes = frappe.db.get_value("OAuth Client", otoken.client, "scopes").split(
+		client_scopes = frappe.get_cached_value("OAuth Client", otoken.client, "scopes").split(
 			get_url_delimiter()
 		)
 		are_scopes_valid = all(scope in client_scopes for scope in scopes)
@@ -541,7 +543,7 @@ def delete_oauth2_data():
 
 
 def get_client_scopes(client_id):
-	scopes_string = frappe.db.get_value("OAuth Client", client_id, "scopes")
+	scopes_string = frappe.get_cached_value("OAuth Client", client_id, "scopes")
 	return scopes_string.split()
 
 

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -9,6 +9,7 @@ from oauthlib.openid import RequestValidator
 
 import frappe
 from frappe.auth import LoginManager
+from frappe.integrations.doctype.oauth_bearer_token.oauth_bearer_token import get_oauth_token_hash
 from frappe.integrations.doctype.oauth_client.oauth_client import OAuthClient
 from frappe.utils.data import cstr, get_system_timezone, now_datetime
 
@@ -102,11 +103,12 @@ class OAuthWebRequestValidator(RequestValidator):
 		else:
 			# Extract token, instantiate OAuth Bearer Token and use clientid from there.
 			if "refresh_token" in frappe.form_dict:
-				token_filters = {"refresh_token": frappe.form_dict["refresh_token"]}
+				token_filters = {"refresh_token": get_oauth_token_hash(frappe.form_dict["refresh_token"])}
 			elif "token" in frappe.form_dict:
-				token_filters = {"name": frappe.form_dict["token"]}
+				token_filters = {"access_token": get_oauth_token_hash(frappe.form_dict["token"])}
 			else:
-				token_filters = {"name": frappe.get_request_header("Authorization").split(" ")[1]}
+				token = frappe.get_request_header("Authorization").split(" ")[1]
+				token_filters = {"access_token": get_oauth_token_hash(token)}
 
 			client_name = frappe.db.get_value("OAuth Bearer Token", filters=token_filters, fieldname="client")
 
@@ -199,7 +201,7 @@ class OAuthWebRequestValidator(RequestValidator):
 				if request.user
 				else frappe.db.get_value(
 					"OAuth Bearer Token",
-					{"refresh_token": request.body.get("refresh_token")},
+					{"refresh_token": get_oauth_token_hash(request.body.get("refresh_token"))},
 					"user",
 				)
 			)
@@ -226,7 +228,7 @@ class OAuthWebRequestValidator(RequestValidator):
 
 	def validate_bearer_token(self, token, scopes, request):
 		# Remember to check expiration and scope membership
-		otoken = frappe.get_doc("OAuth Bearer Token", token)
+		otoken = frappe.get_doc("OAuth Bearer Token", {"access_token": get_oauth_token_hash(token)})
 		is_token_valid = (now_datetime() < otoken.expiration_time) and otoken.status != "Revoked"
 		client_scopes = frappe.db.get_value("OAuth Client", otoken.client, "scopes").split(
 			get_url_delimiter()
@@ -241,7 +243,9 @@ class OAuthWebRequestValidator(RequestValidator):
 		# return its scopes, these will be passed on to the refreshed
 		# access token if the client did not specify a scope during the
 		# request.
-		obearer_token = frappe.get_doc("OAuth Bearer Token", {"refresh_token": refresh_token})
+		obearer_token = frappe.get_doc(
+			"OAuth Bearer Token", {"refresh_token": get_oauth_token_hash(refresh_token)}
+		)
 		return obearer_token.scopes
 
 	def revoke_token(self, token, token_type_hint, request, *args, **kwargs):
@@ -255,11 +259,26 @@ class OAuthWebRequestValidator(RequestValidator):
 		- Revocation Endpoint
 		"""
 		if token_type_hint == "access_token":
-			frappe.db.set_value("OAuth Bearer Token", token, "status", "Revoked")
+			frappe.db.set_value(
+				"OAuth Bearer Token",
+				{"access_token": get_oauth_token_hash(token)},
+				"status",
+				"Revoked",
+			)
 		elif token_type_hint == "refresh_token":
-			frappe.db.set_value("OAuth Bearer Token", {"refresh_token": token}, "status", "Revoked")
+			frappe.db.set_value(
+				"OAuth Bearer Token",
+				{"refresh_token": get_oauth_token_hash(token)},
+				"status",
+				"Revoked",
+			)
 		else:
-			frappe.db.set_value("OAuth Bearer Token", token, "status", "Revoked")
+			frappe.db.set_value(
+				"OAuth Bearer Token",
+				{"access_token": get_oauth_token_hash(token)},
+				"status",
+				"Revoked",
+			)
 		frappe.db.commit()
 
 	def validate_refresh_token(self, refresh_token, client, request, *args, **kwargs):
@@ -281,7 +300,7 @@ class OAuthWebRequestValidator(RequestValidator):
 
 		otoken = frappe.get_doc(
 			"OAuth Bearer Token",
-			{"refresh_token": refresh_token, "status": "Active"},
+			{"refresh_token": get_oauth_token_hash(refresh_token), "status": "Active"},
 		)
 
 		if not otoken:
@@ -354,7 +373,7 @@ class OAuthWebRequestValidator(RequestValidator):
 
 	def validate_id_token(self, token, scopes, request):
 		try:
-			id_token = frappe.get_doc("OAuth Bearer Token", token)
+			id_token = frappe.get_doc("OAuth Bearer Token", {"access_token": get_oauth_token_hash(token)})
 			if id_token.status == "Active":
 				return True
 		except Exception:
@@ -364,7 +383,7 @@ class OAuthWebRequestValidator(RequestValidator):
 
 	def validate_jwt_bearer_token(self, token, scopes, request):
 		try:
-			jwt = frappe.get_doc("OAuth Bearer Token", token)
+			jwt = frappe.get_doc("OAuth Bearer Token", {"access_token": get_oauth_token_hash(token)})
 			if jwt.status == "Active":
 				return True
 		except Exception:

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -1,5 +1,6 @@
 [pre_model_sync]
 frappe.patches.v16_0.enable_setup_complete #01-07-2025 re-run-patch
+frappe.patches.v16_0.hash_oauth_bearer_tokens
 frappe.patches.v15_0.remove_implicit_primary_key
 frappe.patches.v12_0.remove_deprecated_fields_from_doctype #3
 execute:frappe.utils.global_search.setup_global_search_table()
@@ -266,4 +267,3 @@ execute:frappe.db.create_sequence_table()  # backfill SQLite sequence emulation 
 frappe.patches.v16_0.migrate_workspace_sidebar_to_workspace
 frappe.patches.v16_0.populate_workspace_sidebar_from_shortcuts
 frappe.desk.doctype.workspace.patches.set_standard_flag
-frappe.patches.v16_0.hash_oauth_bearer_tokens

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -266,3 +266,4 @@ execute:frappe.db.create_sequence_table()  # backfill SQLite sequence emulation 
 frappe.patches.v16_0.migrate_workspace_sidebar_to_workspace
 frappe.patches.v16_0.populate_workspace_sidebar_from_shortcuts
 frappe.desk.doctype.workspace.patches.set_standard_flag
+frappe.patches.v16_0.hash_oauth_bearer_tokens

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -1,6 +1,5 @@
 [pre_model_sync]
 frappe.patches.v16_0.enable_setup_complete #01-07-2025 re-run-patch
-frappe.patches.v16_0.hash_oauth_bearer_tokens
 frappe.patches.v15_0.remove_implicit_primary_key
 frappe.patches.v12_0.remove_deprecated_fields_from_doctype #3
 execute:frappe.utils.global_search.setup_global_search_table()
@@ -196,6 +195,7 @@ execute:frappe.reload_doc("desk", "doctype", "Form Tour")
 execute:frappe.delete_doc('Page', 'recorder', ignore_missing=True, force=True)
 frappe.patches.v14_0.modify_value_column_size_for_singles
 frappe.integrations.doctype.oauth_bearer_token.patches.clear_old_tokens
+frappe.patches.v16_0.hash_oauth_bearer_tokens
 execute:frappe.db.truncate("Desktop Icon")
 
 [post_model_sync]

--- a/frappe/patches/v16_0/hash_oauth_bearer_tokens.py
+++ b/frappe/patches/v16_0/hash_oauth_bearer_tokens.py
@@ -2,6 +2,8 @@ import frappe
 from frappe.model.naming import make_autoname
 from frappe.utils import sha256_hash
 
+BATCH_SIZE = 1000
+
 
 def is_sha256_hash(value: str) -> bool:
 	return len(value) == 64 and all(character in "0123456789abcdef" for character in value.lower())
@@ -17,33 +19,62 @@ def hash_token(token: str | None) -> str | None:
 
 def execute():
 	token_table = frappe.qb.DocType("OAuth Bearer Token")
-	tokens = frappe.get_all(
+	start = 0
+	while tokens := frappe.get_all(
 		"OAuth Bearer Token",
 		fields=["name", "access_token", "refresh_token"],
-		order_by="creation asc",
-	)
-	seen_refresh_tokens = set()
-
-	for token in tokens:
-		refresh_token = hash_token(token.refresh_token)
-		if refresh_token and refresh_token in seen_refresh_tokens:
-			frappe.db.delete("OAuth Bearer Token", {"name": token.name})
-			continue
-		if refresh_token:
-			seen_refresh_tokens.add(refresh_token)
-
-		new_name = token.name
-		if token.name == token.access_token or sha256_hash(token.name) == token.access_token:
-			new_name = make_autoname("hash", "OAuth Bearer Token")
-			while frappe.db.exists("OAuth Bearer Token", new_name):
+		order_by="creation asc, name asc",
+		offset=start,
+		limit=BATCH_SIZE,
+	):
+		for token in tokens:
+			new_name = token.name
+			if token.name == token.access_token or sha256_hash(token.name) == token.access_token:
 				new_name = make_autoname("hash", "OAuth Bearer Token")
+				while frappe.db.exists("OAuth Bearer Token", new_name):
+					new_name = make_autoname("hash", "OAuth Bearer Token")
 
-		query = (
-			frappe.qb.update(token_table)
-			.set(token_table.name, new_name)
-			.set(token_table.access_token, hash_token(token.access_token))
-			.set(token_table.refresh_token, refresh_token)
-			.where(token_table.name == token.name)
-		)
+			(
+				frappe.qb.update(token_table)
+				.set(token_table.name, new_name)
+				.set(token_table.access_token, hash_token(token.access_token))
+				.set(token_table.refresh_token, hash_token(token.refresh_token))
+				.where(token_table.name == token.name)
+			).run()
 
-		query.run()
+		start += len(tokens)
+
+	delete_duplicate_refresh_tokens()
+
+
+def delete_duplicate_refresh_tokens():
+	frappe.db.multisql(
+		{
+			"mariadb": """
+				DELETE FROM `tabOAuth Bearer Token`
+				WHERE name IN (
+					SELECT name FROM (
+						SELECT name, ROW_NUMBER() OVER (
+							PARTITION BY refresh_token ORDER BY creation DESC, name DESC
+						) AS row_num
+						FROM `tabOAuth Bearer Token`
+						WHERE refresh_token IS NOT NULL
+					) duplicate_tokens
+					WHERE row_num > 1
+				)
+			""",
+			"postgres": """
+				DELETE FROM "tabOAuth Bearer Token"
+				WHERE name IN (
+					SELECT name FROM (
+						SELECT name, ROW_NUMBER() OVER (
+							PARTITION BY refresh_token ORDER BY creation DESC, name DESC
+						) AS row_num
+						FROM "tabOAuth Bearer Token"
+						WHERE refresh_token IS NOT NULL
+					) AS duplicate_tokens
+					WHERE row_num > 1
+				)
+			""",
+		}
+	)

--- a/frappe/patches/v16_0/hash_oauth_bearer_tokens.py
+++ b/frappe/patches/v16_0/hash_oauth_bearer_tokens.py
@@ -1,0 +1,30 @@
+import frappe
+from frappe.model.naming import make_autoname
+from frappe.utils import sha256_hash
+
+
+def execute():
+	token_table = frappe.qb.DocType("OAuth Bearer Token")
+	tokens = frappe.get_all(
+		"OAuth Bearer Token",
+		fields=["name", "access_token", "refresh_token"],
+	)
+
+	for token in tokens:
+		new_name = make_autoname("hash", "OAuth Bearer Token")
+		while frappe.db.exists("OAuth Bearer Token", new_name):
+			new_name = make_autoname("hash", "OAuth Bearer Token")
+
+		query = (
+			frappe.qb.update(token_table)
+			.set(token_table.name, new_name)
+			.set(
+				token_table.access_token,
+				sha256_hash(token.access_token) if token.access_token else token.access_token,
+			)
+			.where(token_table.name == token.name)
+		)
+		if token.refresh_token:
+			query = query.set(token_table.refresh_token, sha256_hash(token.refresh_token))
+
+		query.run()

--- a/frappe/patches/v16_0/hash_oauth_bearer_tokens.py
+++ b/frappe/patches/v16_0/hash_oauth_bearer_tokens.py
@@ -3,28 +3,47 @@ from frappe.model.naming import make_autoname
 from frappe.utils import sha256_hash
 
 
+def is_sha256_hash(value: str) -> bool:
+	return len(value) == 64 and all(character in "0123456789abcdef" for character in value.lower())
+
+
+def hash_token(token: str | None) -> str | None:
+	if not token:
+		return None
+	if is_sha256_hash(token):
+		return token
+	return sha256_hash(token)
+
+
 def execute():
 	token_table = frappe.qb.DocType("OAuth Bearer Token")
 	tokens = frappe.get_all(
 		"OAuth Bearer Token",
 		fields=["name", "access_token", "refresh_token"],
+		order_by="creation asc",
 	)
+	seen_refresh_tokens = set()
 
 	for token in tokens:
-		new_name = make_autoname("hash", "OAuth Bearer Token")
-		while frappe.db.exists("OAuth Bearer Token", new_name):
+		refresh_token = hash_token(token.refresh_token)
+		if refresh_token and refresh_token in seen_refresh_tokens:
+			frappe.db.delete("OAuth Bearer Token", {"name": token.name})
+			continue
+		if refresh_token:
+			seen_refresh_tokens.add(refresh_token)
+
+		new_name = token.name
+		if token.name == token.access_token or sha256_hash(token.name) == token.access_token:
 			new_name = make_autoname("hash", "OAuth Bearer Token")
+			while frappe.db.exists("OAuth Bearer Token", new_name):
+				new_name = make_autoname("hash", "OAuth Bearer Token")
 
 		query = (
 			frappe.qb.update(token_table)
 			.set(token_table.name, new_name)
-			.set(
-				token_table.access_token,
-				sha256_hash(token.access_token) if token.access_token else token.access_token,
-			)
+			.set(token_table.access_token, hash_token(token.access_token))
+			.set(token_table.refresh_token, refresh_token)
 			.where(token_table.name == token.name)
 		)
-		if token.refresh_token:
-			query = query.set(token_table.refresh_token, sha256_hash(token.refresh_token))
 
 		query.run()


### PR DESCRIPTION
## What changed

- Store access and refresh tokens as SHA-256 digests while returning raw tokens only to the client at issuance.
- Decouple OAuth Bearer Token document names from access tokens by using random names.
- Look up authentication, refresh, revocation, and introspection requests through the hashed token fields.
- Keep access-token lookup covered by its unique index and add an index for refresh-token lookup.
- Migrate existing rows by hashing both token fields and replacing plaintext document names with random names.
- Speed up oauth by replacing queries with cache access. Reduce queries too.