### PR TITLE
fix: assign to filter fails with type validation error on strict stacks

### DIFF
--- a/frappe/desk/listview.py
+++ b/frappe/desk/listview.py
@@ -32,7 +32,7 @@ def set_list_settings(doctype: str, values: str | dict[str, Any]):
 
 
 @frappe.whitelist()
-def get_group_by_count(doctype: str, current_filters: str, field: str) -> list[dict]:
+def get_group_by_count(doctype: str, current_filters: str | list, field: str) -> list[dict]:
 	current_filters = frappe.parse_json(current_filters)
 
 	if field == "assigned_to":

--- a/frappe/desk/test_listview.py
+++ b/frappe/desk/test_listview.py
@@ -1,17 +1,19 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import frappe
 from frappe.desk.listview import get_group_by_count
 from frappe.tests import IntegrationTestCase
 
 
 class TestListView(IntegrationTestCase):
 	def test_group_by_count_accepts_filters_as_list(self):
-		# the client sends current_filters as a list, type validation must not reject it
-		result = get_group_by_count("User", [], "enabled")
+		# the client sends current_filters as a list of [doctype, field, operator, value]
+		# arrays; type validation must accept it, not just a JSON string
+		filters = [["User", "enabled", "=", 1]]
+		result = get_group_by_count("User", filters, "enabled")
 		self.assertIsInstance(result, list)
 
 	def test_group_by_count_assigned_to_accepts_filters_as_list(self):
-		result = get_group_by_count("User", [], "assigned_to")
+		filters = [["User", "enabled", "=", 1]]
+		result = get_group_by_count("User", filters, "assigned_to")
 		self.assertIsInstance(result, list)

--- a/frappe/desk/test_listview.py
+++ b/frappe/desk/test_listview.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.desk.listview import get_group_by_count
+from frappe.tests import IntegrationTestCase
+
+
+class TestListView(IntegrationTestCase):
+	def test_group_by_count_accepts_filters_as_list(self):
+		# the client sends current_filters as a list, type validation must not reject it
+		result = get_group_by_count("User", [], "enabled")
+		self.assertIsInstance(result, list)
+
+	def test_group_by_count_assigned_to_accepts_filters_as_list(self):
+		result = get_group_by_count("User", [], "assigned_to")
+		self.assertIsInstance(result, list)


### PR DESCRIPTION
## Description

Toggling the **Group By** dropdown for the **Assign To** sidebar filter could raise a type validation error because the client sends `current_filters` as a list, while the server method only accepted `str`.

This PR updates the annotation to `str | list`, matching the existing behavior of the method and preventing the validation error.


https://github.com/user-attachments/assets/3d6feaf4-f469-432d-a4f9-272d5f3cc541

---
Closes #40659.