### PR TITLE
fix: duration picker opens away from the field in scrolled grids

### DIFF
--- a/frappe/public/js/frappe/form/controls/duration.js
+++ b/frappe/public/js/frappe/form/controls/duration.js
@@ -13,6 +13,7 @@ frappe.ui.form.ControlDuration = class ControlDuration extends frappe.ui.form.Co
 
 	make_picker() {
 		this.inputs = [];
+		this.reposition_picker = () => this.position_picker();
 		this.set_duration_options();
 		this.$picker = $(
 			`<div class="duration-picker">
@@ -104,7 +105,7 @@ frappe.ui.form.ControlDuration = class ControlDuration extends frappe.ui.form.Co
 
 		this.$input.on("focus", () => {
 			if (this.df.read_only) return;
-			this.$picker.show();
+			this.show_picker();
 			let is_picker_set = this.is_duration_picker_set(this.inputs);
 			if (!is_picker_set) {
 				this.set_duration_picker_value(this.value);
@@ -117,9 +118,36 @@ frappe.ui.form.ControlDuration = class ControlDuration extends frappe.ui.form.Co
 				clicked = false;
 			} else {
 				// blur event was not due to duration inputs
-				this.$picker.hide();
+				this.hide_picker();
 			}
 			this.set_formatted_input(this.value);
+		});
+	}
+
+	show_picker() {
+		this.$picker.show();
+		this.position_picker();
+		document.addEventListener("scroll", this.reposition_picker, true);
+		window.addEventListener("resize", this.reposition_picker);
+	}
+
+	hide_picker() {
+		this.$picker.hide();
+		document.removeEventListener("scroll", this.reposition_picker, true);
+		window.removeEventListener("resize", this.reposition_picker);
+	}
+
+	position_picker() {
+		let input = this.$input.get(0);
+		if (!input.isConnected) {
+			this.hide_picker();
+			return;
+		}
+
+		let rect = input.getBoundingClientRect();
+		this.$picker.css({
+			top: rect.bottom + 10 + "px",
+			left: rect.left + "px",
 		});
 	}
 


### PR DESCRIPTION
## Description

The duration picker could appear far away from its input after the page was scrolled. Since the picker is `position: fixed`, it needs to be positioned in viewport coordinates, but no `top`/`left` values were being set.

This PR positions the picker using the input's `getBoundingClientRect()` when it opens, and keeps it anchored while the page is scrolled or resized. The event listeners are only active while the picker is visible.


https://github.com/user-attachments/assets/87245fea-492a-48a0-a37c-6e2e6ef3297b



---
Closes #40702.