### PR TITLE
fix: Harden DCR and cleanup OAuth authorization UI

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -230,7 +230,6 @@ scheduler_events = {
 		# 10 minutes
 		"0/10 * * * *": [
 			"frappe.email.doctype.email_account.email_account.pull",
-			"frappe.integrations.doctype.oauth_client.oauth_client.delete_unused_dynamic_clients",
 		],
 		# Hourly but offset by 30 minutes
 		"30 * * * *": [],
@@ -238,10 +237,6 @@ scheduler_events = {
 		"45 0 * * *": [],
 		"0 */3 * * *": [
 			"frappe.search.sqlite_search.build_index_if_not_exists",
-		],
-		# Daily at 6:00 AM.
-		"0 6 * * *": [
-			"frappe.core.doctype.security_settings.security_settings_alert.check_security_txt_expiry",
 		],
 	},
 	"all": [
@@ -280,6 +275,8 @@ scheduler_events = {
 		"frappe.core.doctype.log_settings.log_settings.run_log_clean_up",
 		"frappe.core.doctype.user_invitation.user_invitation.mark_expired_invitations",
 		"frappe.core.doctype.duckdb_sync.duckdb_sync.cleanup_old_syncs",
+		"frappe.integrations.doctype.oauth_client.oauth_client.delete_unused_dynamic_clients",
+		"frappe.core.doctype.security_settings.security_settings_alert.check_security_txt_expiry",
 	],
 	"weekly_long": [
 		"frappe.desk.form.document_follow.send_weekly_updates",

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -230,6 +230,7 @@ scheduler_events = {
 		# 10 minutes
 		"0/10 * * * *": [
 			"frappe.email.doctype.email_account.email_account.pull",
+			"frappe.integrations.doctype.oauth_client.oauth_client.delete_unused_dynamic_clients",
 		],
 		# Hourly but offset by 30 minutes
 		"30 * * * *": [],

--- a/frappe/integrations/doctype/oauth_client/oauth_client.json
+++ b/frappe/integrations/doctype/oauth_client/oauth_client.json
@@ -13,6 +13,7 @@
   "client_secret",
   "default_redirect_uri",
   "skip_authorization",
+  "is_dynamic_client",
   "client_metadata_section",
   "app_name",
   "scopes",
@@ -69,6 +70,15 @@
    "fieldname": "skip_authorization",
    "fieldtype": "Check",
    "label": "Skip Authorization"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_dynamic_client",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Is Dynamic Client",
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "default": "all openid",
@@ -201,7 +211,7 @@
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-07-04 14:07:36.146393",
+ "modified": "2026-07-11 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Client",

--- a/frappe/integrations/doctype/oauth_client/oauth_client.py
+++ b/frappe/integrations/doctype/oauth_client/oauth_client.py
@@ -9,6 +9,9 @@ import frappe.utils
 from frappe import _
 from frappe.model.document import Document
 from frappe.permissions import SYSTEM_USER_ROLE
+from frappe.utils import add_to_date, now_datetime
+
+DYNAMIC_CLIENT_GRACE_PERIOD_MINUTES = 10
 
 
 class OAuthClient(Document):
@@ -31,6 +34,7 @@ class OAuthClient(Document):
 		contacts: DF.SmallText | None
 		default_redirect_uri: DF.Data
 		grant_type: DF.Literal["Authorization Code", "Implicit"]
+		is_dynamic_client: DF.Check
 		logo_uri: DF.Data | None
 		policy_uri: DF.Data | None
 		redirect_uris: DF.Text | None
@@ -84,3 +88,33 @@ class OAuthClient(Document):
 			return int(d.timestamp())
 		except Exception:
 			return int(frappe.utils.now_datetime().timestamp())
+
+
+def delete_unused_dynamic_clients():
+	"""Delete dynamic clients that did not issue a token within the grace period."""
+	client_names = frappe.get_all(
+		"OAuth Client",
+		filters={
+			"is_dynamic_client": 1,
+			"creation": ["<=", add_to_date(now_datetime(), minutes=-DYNAMIC_CLIENT_GRACE_PERIOD_MINUTES)],
+		},
+		pluck="name",
+	)
+	if not client_names:
+		return
+
+	used_clients = set(
+		frappe.get_all("OAuth Bearer Token", filters={"client": ["in", client_names]}, pluck="client")
+	)
+	for client_name in set(client_names) - used_clients:
+		try:
+			frappe.delete_doc(
+				"OAuth Client",
+				client_name,
+				ignore_doctypes=["OAuth Authorization Code"],
+				ignore_permissions=True,
+			)
+		except frappe.LinkExistsError:
+			# A client linked from another record is still in use even without a token.
+			continue
+		frappe.db.delete("OAuth Authorization Code", {"client": client_name})

--- a/frappe/integrations/doctype/oauth_client/oauth_client.py
+++ b/frappe/integrations/doctype/oauth_client/oauth_client.py
@@ -47,7 +47,7 @@ class OAuthClient(Document):
 	def validate(self):
 		self.client_id = self.name
 		if not self.client_secret:
-			self.client_secret = frappe.generate_hash(length=10)
+			self.client_secret = frappe.generate_hash()
 		self.validate_grant_and_response()
 		self.add_default_role()
 

--- a/frappe/integrations/doctype/oauth_client/test_oauth_client.py
+++ b/frappe/integrations/doctype/oauth_client/test_oauth_client.py
@@ -5,4 +5,9 @@ from frappe.tests import IntegrationTestCase
 
 
 class TestOAuthClient(IntegrationTestCase):
-	pass
+	def test_generates_strong_client_secret(self):
+		client = frappe.new_doc("OAuth Client")
+
+		client.validate()
+
+		self.assertGreaterEqual(len(client.client_secret), 56)

--- a/frappe/integrations/doctype/oauth_client/test_oauth_client.py
+++ b/frappe/integrations/doctype/oauth_client/test_oauth_client.py
@@ -1,13 +1,101 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
+from frappe.integrations.doctype.oauth_client.oauth_client import delete_unused_dynamic_clients
+from frappe.integrations.oauth2 import register_client
+from frappe.integrations.utils import OAuth2DynamicClientMetadata, create_new_oauth_client
 from frappe.tests import IntegrationTestCase
+from frappe.utils import add_to_date, now_datetime
 
 
 class TestOAuthClient(IntegrationTestCase):
+	def create_dynamic_client(self):
+		return create_new_oauth_client(
+			OAuth2DynamicClientMetadata(
+				client_name="Test Dynamic Client",
+				redirect_uris=["https://example.com/oauth/callback"],
+			)
+		)
+
 	def test_generates_strong_client_secret(self):
 		client = frappe.new_doc("OAuth Client")
 
 		client.validate()
 
 		self.assertGreaterEqual(len(client.client_secret), 56)
+
+	def test_dynamic_registration_marks_client(self):
+		client = self.create_dynamic_client()
+
+		self.assertTrue(client.is_dynamic_client)
+
+	def test_deletes_unused_dynamic_client_after_grace_period(self):
+		client = self.create_dynamic_client()
+		frappe.db.set_value(
+			"OAuth Client",
+			client.name,
+			"creation",
+			add_to_date(now_datetime(), minutes=-11),
+			update_modified=False,
+		)
+
+		delete_unused_dynamic_clients()
+
+		self.assertFalse(frappe.db.exists("OAuth Client", client.name))
+
+	def test_preserves_dynamic_client_that_issued_token(self):
+		client = self.create_dynamic_client()
+		frappe.db.set_value(
+			"OAuth Client",
+			client.name,
+			"creation",
+			add_to_date(now_datetime(), minutes=-11),
+			update_modified=False,
+		)
+		frappe.get_doc(
+			{
+				"doctype": "OAuth Bearer Token",
+				"access_token": frappe.generate_hash(),
+				"client": client.name,
+				"expires_in": 3600,
+				"scopes": "openid",
+				"status": "Active",
+				"user": "Administrator",
+			}
+		).insert(ignore_permissions=True)
+
+		delete_unused_dynamic_clients()
+
+		self.assertTrue(frappe.db.exists("OAuth Client", client.name))
+
+	def test_dynamic_registration_is_rate_limited_by_ip(self):
+		request_ip = "192.0.2.1"
+		original_request = getattr(frappe.local, "request", None)
+		original_request_ip = getattr(frappe.local, "request_ip", None)
+		original_form_dict = getattr(frappe.local, "form_dict", None)
+		frappe.local.request_ip = request_ip
+		frappe.local.request = frappe._dict(
+			method="POST",
+			json={
+				"client_name": "Rate Limited Dynamic Client",
+				"redirect_uris": ["https://example.com/oauth/callback"],
+			},
+		)
+		frappe.local.form_dict = frappe._dict(cmd="frappe.integrations.oauth2.register_client")
+		frappe.db.set_single_value("OAuth Settings", "enable_dynamic_client_registration", 1)
+		frappe.clear_cache(doctype="OAuth Settings")
+		rate_limit_key = (
+			frappe.cache.make_key(f"rl:frappe.integrations.oauth2.register_client:{request_ip}") + b":600"
+		)
+		frappe.cache.delete(rate_limit_key)
+
+		try:
+			response = register_client()
+			self.assertEqual(response.status_code, 201)
+			self.assertRaises(frappe.RateLimitExceededError, register_client)
+		finally:
+			frappe.cache.delete(rate_limit_key)
+			frappe.local.request = original_request
+			frappe.local.request_ip = original_request_ip
+			frappe.local.form_dict = original_form_dict
+			frappe.clear_cache(doctype="OAuth Settings")

--- a/frappe/integrations/doctype/oauth_client/test_oauth_client.py
+++ b/frappe/integrations/doctype/oauth_client/test_oauth_client.py
@@ -90,8 +90,9 @@ class TestOAuthClient(IntegrationTestCase):
 		frappe.cache.delete(rate_limit_key)
 
 		try:
-			response = register_client()
-			self.assertEqual(response.status_code, 201)
+			for _ in range(5):
+				response = register_client()
+				self.assertEqual(response.status_code, 201)
 			self.assertRaises(frappe.RateLimitExceededError, register_client)
 		finally:
 			frappe.cache.delete(rate_limit_key)

--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -25,6 +25,7 @@ from frappe.oauth import (
 	get_server_url,
 	get_userinfo,
 )
+from frappe.rate_limiter import rate_limit
 from frappe.sessions import get_csrf_token
 
 ENDPOINTS = {
@@ -346,6 +347,7 @@ def _get_authorization_server_metadata():
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
+@rate_limit(limit=1, seconds=10 * 60)
 def register_client():
 	"""
 	Registers an OAuth client.

--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -349,7 +349,7 @@ def _get_authorization_server_metadata():
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
-@rate_limit(limit=1, seconds=10 * 60)
+@rate_limit(limit=5, seconds=10 * 60)
 def register_client():
 	"""
 	Registers an OAuth client.

--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -12,6 +12,7 @@ from werkzeug.exceptions import NotFound
 import frappe
 import frappe.utils
 from frappe import oauth
+from frappe.core.doctype.navbar_settings.navbar_settings import get_app_logo
 from frappe.integrations.doctype.oauth_bearer_token.oauth_bearer_token import get_oauth_token_hash
 from frappe.integrations.utils import (
 	OAuth2DynamicClientMetadata,
@@ -151,6 +152,7 @@ def authorize(**kwargs):
 						"csrf_token": get_csrf_token(),
 					}
 				)
+				response_html_params.logo = get_app_logo()
 				resp_html = frappe.render_template(
 					"templates/includes/oauth_confirmation.html", response_html_params
 				)

--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -249,6 +249,7 @@ def create_new_oauth_client(client: OAuth2DynamicClientMetadata):
 	doc.response_type = "Code"
 	doc.grant_type = "Authorization Code"
 	doc.skip_authorization = False
+	doc.is_dynamic_client = True
 
 	if client.client_uri:
 		doc.client_uri = client.client_uri.encoded_string()

--- a/frappe/templates/includes/oauth_confirmation.html
+++ b/frappe/templates/includes/oauth_confirmation.html
@@ -1,26 +1,161 @@
 {% if not error %}
+<style>
+	body {
+		background-color: var(--bg-color);
+	}
 
-<div class="portal-container">
-	<div class="portal-section">
-		<p>{{ _(client_id) }} {{ _("wants to access the following details from your account") }}</p>
-	</div>
-	<div class="portal-items">
-		{% for dtl in details %}
-		<div class="portal-section">
-			{{ _(dtl.title()) }}
+	.error-page {
+		height: auto;
+		display: block;
+	}
+
+	.error-page > div > .page-card-head {
+		display: none;
+	}
+
+	.error-page .details {
+		max-width: none;
+		margin: 0;
+		padding: 60px 0 0;
+		border: 0;
+		text-align: left;
+	}
+
+	.error-page .details > p {
+		margin: 0;
+	}
+
+	.page-card {
+		display: flex;
+		flex-direction: column;
+		gap: var(--margin-lg);
+		width: 100%;
+		max-width: 371px;
+		margin: 0 auto;
+		padding: 24px;
+		background-color: var(--bg-color);
+		border-radius: var(--radius-lg);
+	}
+
+	.page-card-head {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 16px;
+		margin: 0;
+		padding: 0;
+		text-align: left;
+	}
+
+	.app-logo {
+		width: auto;
+		max-height: 32px;
+	}
+
+	.page-card-head-text,
+	.oauth-permissions {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.page-card-head h4 {
+		align-self: stretch;
+		margin: 0;
+		color: var(--heading-color);
+		font-size: var(--text-2xl);
+		font-weight: var(--weight-bold);
+		line-height: 115%;
+		text-align: left;
+	}
+
+	.page-card-subtitle,
+	.oauth-permissions-label {
+		margin: 0;
+		color: var(--ink-gray-6);
+	}
+
+	.oauth-scope-list {
+		overflow: hidden;
+		border: 1px solid var(--border-color);
+		border-radius: var(--radius);
+	}
+
+	.oauth-scope {
+		padding: 10px 12px;
+		border-bottom: 1px solid var(--border-color);
+	}
+
+	.oauth-scope:last-child {
+		border-bottom: 0;
+	}
+
+	.oauth-actions {
+		display: flex;
+		gap: 12px;
+	}
+
+	.oauth-actions form,
+	.oauth-actions .btn {
+		flex: 1;
+	}
+
+	.oauth-actions .btn {
+		width: 100%;
+	}
+
+	.oauth-actions .btn-primary {
+		color: white;
+		background: var(--gray-900);
+		border-color: var(--gray-900);
+	}
+
+	@media (max-width: 575.98px) {
+		.error-page .details {
+			padding: 0;
+		}
+
+		.page-card {
+			max-width: 100%;
+			min-height: 100svh;
+			padding: 60px 32px 32px;
+			border: 0;
+			border-radius: 0;
+		}
+	}
+</style>
+<section>
+	<div class="oauth-content page-card">
+		<div class="page-card-head">
+			<img class="app-logo" src="{{ logo }}" alt="">
+			<div class="page-card-head-text">
+				<h4>{{ _("Authorize App") }}</h4>
+				<p class="page-card-subtitle">
+					{{ _("{0} wants to access your account").format(_(client_id)) }}
+				</p>
+			</div>
 		</div>
-      	{% endfor %}
-	</div>
-	<div class="portal-section">
-		<div class="action-buttons" style="display: flex; flex-direction: row-reverse; width: 100%;">
+
+		<div class="oauth-permissions">
+			<p class="oauth-permissions-label">{{ _("This will allow {0} to:").format(_(client_id)) }}</p>
+			<div class="oauth-scope-list">
+				{% for detail in details %}
+				<div class="oauth-scope">
+					<span>{{ _(detail.title()) }}</span>
+				</div>
+				{% endfor %}
+			</div>
+		</div>
+
+		<div class="oauth-actions">
+			<a href="{{ failure_url | string }}" class="btn btn-sm btn-default">{{ _("Deny") }}</a>
 			<form method="POST" action="{{ success_url | string }}">
 				<input type="hidden" name="csrf_token" value="{{ csrf_token }}">
 				<button type="submit" class="btn btn-sm btn-primary">{{ _("Allow") }}</button>
 			</form>
-			<a href="{{ failure_url | string }}" class="btn btn-sm btn-light mr-3">{{ _("Deny") }}</a>
 		</div>
 	</div>
-</div>
+</section>
 {% else %}
 <div class="panel panel-danger">
   <div class="panel-heading">


### PR DESCRIPTION
Similar to login page cleanup. Nothing great but (slightly more) consistent with espresso.

<img width="1920" height="921" alt="image" src="https://github.com/user-attachments/assets/6d4d4ecb-7016-42d0-a4af-de3bff585e4d" />
