### PR TITLE
refactor: replace get_attr usage in has_child_permission

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -882,10 +882,16 @@ def has_child_permission(
 			)
 			return False
 
+		parent_doc = child_doc.parent_doc if hasattr(child_doc, "parent_doc") else None
+		if parent_doc is None:
+			parent_doc = child_doc.parent
+	else:
+		parent_doc = None
+
 	return has_permission(
 		parent_doctype,
 		ptype=ptype,
-		doc=child_doc and getattr(child_doc, "parent_doc", child_doc.parent),
+		doc=parent_doc,
 		user=user,
 		print_logs=print_logs,
 		debug=debug,


### PR DESCRIPTION
A subtle bug in the usage of getattr causes problems mentioned in Ticket 70432.

part of closing Ticket 70432