### PR TITLE
fix(pddr): set export file and PDDR owner to the user whose data is exported

### DIFF
--- a/frappe/website/doctype/personal_data_download_request/personal_data_download_request.py
+++ b/frappe/website/doctype/personal_data_download_request/personal_data_download_request.py
@@ -53,6 +53,10 @@ class PersonalDataDownloadRequest(Document):
 		f.flags.skip_file_size_check = True
 		f.save(ignore_permissions=True)
 
+		# Bind ownership
+		frappe.db.set_value("File", f.name, "owner", self.user)
+		self.db_set("owner", self.user)
+
 		file_link = (
 			frappe.utils.get_url("/api/method/frappe.utils.file_manager.download_file")
 			+ "?"

--- a/frappe/website/doctype/personal_data_download_request/test_personal_data_download_request.py
+++ b/frappe/website/doctype/personal_data_download_request/test_personal_data_download_request.py
@@ -36,15 +36,20 @@ class TestRequestPersonalData(IntegrationTestCase):
 
 		frappe.set_user("Administrator")
 
-		file_count = frappe.db.count(
+		files = frappe.get_all(
 			"File",
-			{
+			filters={
 				"attached_to_doctype": "Personal Data Download Request",
 				"attached_to_name": download_request.name,
 			},
+			fields=["name", "owner"],
 		)
 
-		self.assertEqual(file_count, 1)
+		self.assertEqual(len(files), 1)
+		self.assertEqual(files[0].owner, "test_privacy@example.com")
+
+		pddr_owner = frappe.db.get_value("Personal Data Download Request", download_request.name, "owner")
+		self.assertEqual(pddr_owner, "test_privacy@example.com")
 
 		email_queue = frappe.get_all("Email Queue", fields=["message"], order_by="creation DESC", limit=1)
 		self.assertIn(frappe._("Download Your Data"), email_queue[0].message)


### PR DESCRIPTION
This PR sets export file and PDDR owner to the user whose data is exported.

related to closing Ticket 70432