### PR TITLE
fix: create notification settings during boot if missing

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -384,7 +384,19 @@ def get_desk_settings():
 
 
 def get_notification_settings():
-	return frappe.get_cached_doc("Notification Settings", frappe.session.user)
+	from frappe.desk.doctype.notification_settings.notification_settings import (
+		create_notification_settings,
+	)
+
+	try:
+		return frappe.get_cached_doc("Notification Settings", frappe.session.user)
+	except frappe.DoesNotExistError:
+		if frappe.flags.read_only:
+			raise
+		frappe.clear_last_message()
+		create_notification_settings(frappe.session.user)
+		frappe.local.flags.commit = True
+		return frappe.get_cached_doc("Notification Settings", frappe.session.user)
 
 
 def get_link_title_doctypes():


### PR DESCRIPTION
- `get_notification_settings` now creates the user's Notification Settings doc on `DoesNotExistError` instead of failing the entire session boot with `SessionBootFailed`
- sets `frappe.local.flags.commit` so the insert survives the GET request rollback; re-raises on read-only connections

Why: a user whose Notification Settings doc is missing (e.g. skipped during a rename because the doc never existed) is permanently locked out of desk.



https://support.frappe.io/helpdesk/tickets/73508