### PR TITLE
fix: fold table colour controls into the style section

### DIFF
--- a/frappe/public/js/print_format_builder/components/inspector/ColorField.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/ColorField.vue
@@ -39,3 +39,11 @@ watch(
 	}
 );
 </script>
+
+<style scoped>
+/* only_input wraps the colour input in a .form-group with a 1rem bottom margin,
+   which unbalances the row's vertical centering against the label */
+.pfb-insp-row :deep(.form-group) {
+	margin-bottom: 0;
+}
+</style>

--- a/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
@@ -150,14 +150,14 @@
 		<InspectorSection :label="__('Style')" :init-open="false" :padded="false">
 			<div v-if="is_text_field" class="pfb-insp-section-body">
 				<ColorField
-					:label="__('Value color')"
-					:model-value="selected_field.value_color || ''"
-					@update:model-value="(v) => set_field_prop('value_color', v)"
-				/>
-				<ColorField
-					:label="__('Label color')"
+					:label="__('Label')"
 					:model-value="selected_field.label_color || ''"
 					@update:model-value="(v) => set_field_prop('label_color', v)"
+				/>
+				<ColorField
+					:label="__('Value')"
+					:model-value="selected_field.value_color || ''"
+					@update:model-value="(v) => set_field_prop('value_color', v)"
 				/>
 			</div>
 			<StyleSection :label="__('Custom CSS')" v-model="selected_field.custom_style" />

--- a/frappe/public/js/print_format_builder/components/inspector/TableFieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/TableFieldInspector.vue
@@ -203,25 +203,23 @@
 			</div>
 		</InspectorSection>
 
-		<!-- COLORS section -->
-		<InspectorSection :label="__('Colors')" :init-open="false">
-			<ColorField
-				:label="__('Header')"
-				:model-value="table_header_bg"
-				:placeholder="__('Default')"
-				@update:model-value="(v) => set_table_prop('table_header_bg', v)"
-			/>
-			<ColorField
-				:label="__('Border')"
-				:model-value="table_border_color"
-				:placeholder="__('Default')"
-				@update:model-value="(v) => set_table_prop('table_border_color', v)"
-			/>
-		</InspectorSection>
-
 		<!-- STYLE section -->
 		<InspectorSection :label="__('Style')" :init-open="false" :padded="false">
-			<StyleSection v-model="selected_field.custom_style" />
+			<div class="pfb-insp-section-body">
+				<ColorField
+					:label="__('Header')"
+					:model-value="table_header_bg"
+					:placeholder="__('Default')"
+					@update:model-value="(v) => set_table_prop('table_header_bg', v)"
+				/>
+				<ColorField
+					:label="__('Border')"
+					:model-value="table_border_color"
+					:placeholder="__('Default')"
+					@update:model-value="(v) => set_table_prop('table_border_color', v)"
+				/>
+			</div>
+			<StyleSection :label="__('Custom CSS')" v-model="selected_field.custom_style" />
 		</InspectorSection>
 
 		<!-- VISIBILITY section -->


### PR DESCRIPTION
- Move table header/border colour pickers from a separate Colors section into Style (matches the field inspector's layout)
- Fix colour picker row misalignment with its label (only_input wraps the control in a .form-group with a bootstrap margin-bottom that threw off vertical centering)
- Order field colour pickers label-first, drop redundant "colour" suffix from labels