### PR TITLE
fix(print-format-builder): pixel parity between builder canvas and print output

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -1,294 +1,207 @@
 <template>
 	<div
-		class="field"
-		:class="{
-			'field--table': df.fieldtype == 'Table',
-			'field--selected': is_selected,
-			'field--preview': !!preview_doc,
-			'field--condition-hidden': preview_doc && !is_field_visible,
-		}"
+		:class="[
+			preview_doc ? preview_root_classes : 'field field--chip',
+			{
+				'field--table': df.fieldtype == 'Table',
+				'field--selected': is_selected,
+				'field--preview': !!preview_doc,
+				'field--condition-hidden': preview_doc && !is_field_visible,
+			},
+		]"
+		:style="preview_doc ? preview_root_style : undefined"
+		:data-fieldname="preview_data_attr(df.fieldname)"
+		:data-fieldtype="preview_data_attr(df.fieldtype)"
 		v-show="!df.remove"
 		:title="df.label || df.fieldname"
 		@click.stop="select_field"
 	>
 		<!-- ── Preview mode: show actual doc values ─────────── -->
 		<template v-if="preview_doc">
-			<div class="field-preview-wrap" :style="custom_style">
-				<!-- Handle HTML fields: render Jinja2 server-side if needed -->
+			<!-- Handle HTML fields: render Jinja2 server-side if needed -->
+			<div v-if="df.fieldtype == 'HTML' && df.html" v-html="rendered_html ?? df.html"></div>
+			<!-- Spacer/Divider: the root element itself is the rendered output -->
+			<i
+				v-else-if="df.fieldtype == 'Spacer' || df.fieldtype == 'Divider'"
+				v-show="false"
+			></i>
+			<template v-else-if="df.fieldtype == 'Image'">
+				<img
+					v-if="df.image_url || preview_doc[df.fieldname]"
+					:src="df.image_url || preview_doc[df.fieldname]"
+					:style="{ maxWidth: '100%', ...(df.width ? { width: df.width } : {}) }"
+					:alt="df.label || ''"
+				/>
+				<span v-else class="text-muted">{{ __("No image — set one in the panel") }}</span>
+			</template>
+			<template v-else-if="df.fieldtype == 'Barcode' && df.custom">
+				<img
+					v-if="df.barcode_format == 'QR' && qr_src"
+					:src="qr_src"
+					:style="{ width: df.width || '35mm' }"
+				/>
 				<div
-					v-if="df.fieldtype == 'HTML' && df.html"
-					class="custom-html"
-					v-html="rendered_html ?? df.html"
+					v-else-if="barcode_svg"
+					class="pf-barcode-svg"
+					:style="df.width ? { width: df.width } : {}"
+					v-html="barcode_svg"
 				></div>
-				<div v-else-if="df.fieldtype == 'Spacer'" class="field-preview-spacer"></div>
-				<div v-else-if="df.fieldtype == 'Divider'" class="field-preview-divider"></div>
-				<div
-					v-else-if="df.fieldtype == 'Image' && df.custom"
-					:style="{ textAlign: df.align || 'left' }"
+				<span
+					v-else-if="barcode_raw_value && df.barcode_format !== 'QR'"
+					class="text-muted"
+					>{{ __("Invalid value for {0}", [df.barcode_format || "CODE128"]) }}</span
 				>
-					<img
-						v-if="df.image_url"
-						:src="df.image_url"
-						class="pf-element-img"
-						:style="df.width ? { width: df.width } : {}"
-						:alt="df.label || ''"
-					/>
-					<span v-else class="text-muted">{{
-						__("No image — set one in the panel")
-					}}</span>
+				<span v-else class="text-muted">{{
+					__("No barcode value — set one in the panel")
+				}}</span>
+			</template>
+			<div
+				v-else-if="df.fieldtype == 'Field Template'"
+				v-html="rendered_template || ''"
+			></div>
+			<!-- Table MultiSelect field: render as a comma-separated value list -->
+			<template v-else-if="df.fieldtype == 'Table MultiSelect'">
+				<div
+					v-if="df.label && df.show_label !== 'hide'"
+					class="label"
+					:style="label_text_style(df)"
+				>
+					{{ df.label }}
 				</div>
 				<div
-					v-else-if="df.fieldtype == 'Barcode' && df.custom"
-					:style="{ textAlign: df.align || 'left' }"
+					class="value"
+					:class="{ 'text-muted': !(preview_doc[df.fieldname] || []).length }"
+					:style="value_text_style(df)"
 				>
-					<img
-						v-if="df.barcode_format == 'QR' && qr_src"
-						:src="qr_src"
-						class="pf-element-img"
-						:style="{ width: df.width || '35mm' }"
-					/>
-					<div
-						v-else-if="barcode_svg"
-						class="pf-barcode-svg"
-						:style="df.width ? { width: df.width } : {}"
-						v-html="barcode_svg"
-					></div>
-					<span
-						v-else-if="barcode_raw_value && df.barcode_format !== 'QR'"
-						class="text-muted"
-						>{{ __("Invalid value for {0}", [df.barcode_format || "CODE128"]) }}</span
-					>
-					<span v-else class="text-muted">{{
-						__("No barcode value — set one in the panel")
-					}}</span>
+					{{ multiselect_display(df) }}
 				</div>
-				<div
-					v-else-if="df.fieldtype == 'Field Template'"
-					class="custom-html"
-					v-html="rendered_template || ''"
-				></div>
-				<!-- Table MultiSelect field: render as a comma-separated value list -->
-				<div
-					v-else-if="df.fieldtype == 'Table MultiSelect'"
-					:style="field_style(df, true)"
-					:class="[
-						'field-preview-lr',
-						field_orientation === 'left-right' && df.label_justify
-							? `field-preview-lr--${df.label_justify}`
-							: '',
-						field_orientation === 'left-right' && df.align && df.align !== 'left'
-							? `field-preview-lr--align-${df.align}`
-							: '',
-					]"
-				>
-					<div
-						v-if="df.label && df.show_label !== 'hide'"
-						class="field-preview-label"
-						:style="label_text_style(df)"
-					>
-						{{ df.label }}
-					</div>
-					<div
-						class="field-preview-value"
-						:class="{ 'text-muted': !(preview_doc[df.fieldname] || []).length }"
-						:style="value_text_style(df)"
-					>
-						{{ multiselect_display(df) }}
-					</div>
+			</template>
+			<!-- Table field -->
+			<template v-else-if="df.fieldtype == 'Table'">
+				<div v-if="df.label && df.show_label !== 'hide'" class="label">
+					{{ df.label }}
 				</div>
-				<!-- Table field -->
+				<!-- radius lives on a wrapper: border-radius is a no-op on a
+				     border-collapse:collapse table, same as the PDF markup -->
 				<div
-					v-else-if="df.fieldtype == 'Table'"
-					class="child-table"
-					:class="{
-						[`child-table--${df.table_style || 'lined'}`]: true,
-						'child-table--borderless': df.table_bordered === false,
-						'child-table--plain-header': df.table_header === 'plain',
-					}"
+					:style="
+						df.table_radius != null
+							? { borderRadius: df.table_radius + 'px', overflow: 'hidden' }
+							: {}
+					"
 				>
-					<div v-if="df.label && df.show_label !== 'hide'" class="label">
-						{{ df.label }}
-					</div>
-					<!-- radius lives on a wrapper: border-radius is a no-op on a
-					     border-collapse:collapse table, same as the PDF markup -->
-					<div
-						:style="
-							df.table_radius != null
-								? { borderRadius: df.table_radius + 'px', overflow: 'hidden' }
-								: {}
-						"
+					<table
+						class="table"
+						:class="{ 'table-bordered': df.table_bordered !== false }"
 					>
-						<table
-							class="table"
-							:class="{ 'table-bordered': df.table_bordered !== false }"
-						>
-							<thead v-if="df.table_header !== 'none'">
-								<!-- inline !important mirrors the server markup: the shared
+						<thead v-if="df.table_header !== 'none'">
+							<!-- inline !important mirrors the server markup: the shared
 								     stylesheet's own !important rules must lose to these -->
-								<tr
+							<tr
+								:style="
+									df.table_header_bg
+										? `background-color: ${df.table_header_bg} !important`
+										: ''
+								"
+							>
+								<th
+									v-for="col in df.table_columns"
+									:key="col.fieldname"
+									class="column-header"
+									:class="{ 'column-value--merged': has_merge(col) }"
+									:data-fieldtype="col.fieldtype"
+									:data-fieldname="col.fieldname"
 									:style="
-										df.table_header_bg
-											? `background-color: ${df.table_header_bg} !important`
-											: ''
+										(col.width ? `width: ${col.width}%; ` : '') +
+										cell_style(df)
 									"
 								>
-									<th
-										v-for="col in df.table_columns"
-										:key="col.fieldname"
-										class="column-header"
-										:class="{ 'column-value--merged': has_merge(col) }"
-										:data-fieldtype="col.fieldtype"
-										:data-fieldname="col.fieldname"
-										:style="
-											(col.width ? `width: ${col.width}%; ` : '') +
-											cell_style(df)
-										"
-									>
-										{{ col.label || col.fieldname }}
-									</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr
-									v-for="(row, i) in (preview_doc[df.fieldname] || []).slice(
-										0,
-										4
-									)"
-									:key="i"
-									:class="i % 2 === 0 ? 'odd' : 'even'"
-								>
-									<td
-										v-for="col in df.table_columns"
-										:key="col.fieldname"
-										class="column-value"
-										:class="{ 'column-value--merged': has_merge(col) }"
-										:data-fieldtype="col.fieldtype"
-										:data-fieldname="col.fieldname"
-										:style="cell_style(df)"
-									>
-										<!-- Merged cell: image (if any) floats left, text lines stack -->
-										<div v-if="has_merge(col)" class="cell-merged">
-											<template v-if="image_merge(col)">
-												<img
-													v-if="cell_image(col, row)"
-													:src="cell_image(col, row)"
-													class="cell-thumb-img"
-													:style="thumb_box(col)"
-													:alt="col.label || col.fieldname"
-												/>
-												<span
-													v-else
-													class="cell-thumb"
-													:style="thumb(col, row).style"
-													>{{ thumb(col, row).abbr }}</span
-												>
-											</template>
-											<div class="cell-lines">
-												<div
-													v-for="(mf, mi) in text_merges(col)"
-													:key="mi"
-													class="cell-line"
-													:class="`cell-line--${mf.style || 'primary'}`"
-												>
-													{{ format_merged(row, mf.fieldname) }}
-												</div>
-											</div>
-										</div>
-										<!-- Single (default) -->
-										<template v-else>
-											<img
-												v-if="
-													is_image_field(col, row[col.fieldname]) &&
-													row[col.fieldname]
-												"
-												:src="row[col.fieldname]"
-												class="preview-table-img"
-												:alt="col.label || col.fieldname"
-											/>
-											<div
-												v-else-if="is_html_content_field(col)"
-												class="preview-table-html"
-												v-html="format_cell(row, col)"
-											></div>
-											<span v-else>{{ format_cell(row, col) }}</span>
-										</template>
-									</td>
-								</tr>
-								<tr v-if="!preview_doc[df.fieldname]?.length">
-									<td
-										:colspan="df.table_columns?.length || 1"
-										class="text-muted"
-										style="text-align: center; font-size: 11px; padding: 6px"
-									>
-										{{ __("No rows") }}
-									</td>
-								</tr>
-								<tr v-if="(preview_doc[df.fieldname] || []).length > 4">
-									<td
-										:colspan="df.table_columns?.length || 1"
-										class="text-muted"
-										style="text-align: center; font-size: 11px; padding: 6px"
-									>
-										{{
-											__(
-												"+ {0} more rows in this document — all print in the real output",
-												[preview_doc[df.fieldname].length - 4]
-											)
-										}}
-									</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-				</div>
-				<!-- Repeater field -->
-				<div v-else-if="df.fieldtype == 'Repeater'" class="pfb-repeater">
-					<div v-if="df.label && df.show_label !== 'hide'" class="label">
-						{{ df.label }}
-					</div>
-					<table class="pfb-repeater-table">
-						<colgroup>
-							<col
-								v-for="(col, ci) in df.repeater_columns || []"
-								:key="ci"
-								:style="col.width ? { width: col.width + '%' } : {}"
-							/>
-						</colgroup>
+									{{ col.label || col.fieldname }}
+								</th>
+							</tr>
+						</thead>
 						<tbody>
 							<tr
-								v-for="(row, i) in (preview_doc[df.source] || []).slice(0, 6)"
+								v-for="(row, i) in (preview_doc[df.fieldname] || []).slice(0, 4)"
 								:key="i"
+								:class="i % 2 === 0 ? 'odd' : 'even'"
 							>
 								<td
-									v-for="(col, ci) in df.repeater_columns || []"
-									:key="ci"
-									class="pfb-repeater-cell"
-									:style="{
-										textAlign: col.align || 'left',
-										...(col.color ? { color: col.color } : {}),
-									}"
+									v-for="col in df.table_columns"
+									:key="col.fieldname"
+									class="column-value"
+									:class="{ 'column-value--merged': has_merge(col) }"
+									:data-fieldtype="col.fieldtype"
+									:data-fieldname="col.fieldname"
+									:style="cell_style(df)"
 								>
-									{{ repeater_cell(col, row) }}
+									<!-- Merged cell: image (if any) floats left, text lines stack -->
+									<div v-if="has_merge(col)" class="cell-merged">
+										<template v-if="image_merge(col)">
+											<img
+												v-if="cell_image(col, row)"
+												:src="cell_image(col, row)"
+												class="cell-thumb-img"
+												:style="thumb_box(col)"
+												:alt="col.label || col.fieldname"
+											/>
+											<span
+												v-else
+												class="cell-thumb"
+												:style="thumb(col, row).style"
+												>{{ thumb(col, row).abbr }}</span
+											>
+										</template>
+										<div class="cell-lines">
+											<div
+												v-for="(mf, mi) in text_merges(col)"
+												:key="mi"
+												class="cell-line"
+												:class="`cell-line--${mf.style || 'primary'}`"
+											>
+												{{ format_merged(row, mf.fieldname) }}
+											</div>
+										</div>
+									</div>
+									<!-- Single (default) -->
+									<template v-else>
+										<img
+											v-if="
+												is_image_field(col, row[col.fieldname]) &&
+												row[col.fieldname]
+											"
+											:src="row[col.fieldname]"
+											class="preview-table-img"
+											:alt="col.label || col.fieldname"
+										/>
+										<div
+											v-else-if="is_html_content_field(col)"
+											class="preview-table-html"
+											v-html="format_cell(row, col)"
+										></div>
+										<span v-else>{{ format_cell(row, col) }}</span>
+									</template>
 								</td>
 							</tr>
-							<tr v-if="!(preview_doc[df.source] || []).length">
+							<tr v-if="!preview_doc[df.fieldname]?.length">
 								<td
+									:colspan="df.table_columns?.length || 1"
 									class="text-muted"
 									style="text-align: center; font-size: 11px; padding: 6px"
 								>
-									{{ df.source ? __("No rows") : __("Pick a source table") }}
+									{{ __("No rows") }}
 								</td>
 							</tr>
-							<tr v-if="(preview_doc[df.source] || []).length > 6">
+							<tr v-if="(preview_doc[df.fieldname] || []).length > 4">
 								<td
-									:colspan="df.repeater_columns?.length || 1"
+									:colspan="df.table_columns?.length || 1"
 									class="text-muted"
 									style="text-align: center; font-size: 11px; padding: 6px"
 								>
 									{{
 										__(
 											"+ {0} more rows in this document — all print in the real output",
-											[preview_doc[df.source].length - 6]
+											[preview_doc[df.fieldname].length - 4]
 										)
 									}}
 								</td>
@@ -296,44 +209,97 @@
 						</tbody>
 					</table>
 				</div>
-				<!-- Regular field -->
-				<div
-					v-else
-					:style="field_style(df)"
-					:class="[
-						field_orientation === 'left-right' || df.show_label === 'inline'
-							? 'field-preview-lr'
-							: '',
-						field_orientation === 'left-right' && df.label_justify
-							? `field-preview-lr--${df.label_justify}`
-							: '',
-						field_orientation === 'left-right' && df.align && df.align !== 'left'
-							? `field-preview-lr--align-${df.align}`
-							: '',
-					]"
-				>
-					<div
-						v-if="df.label && df.show_label !== 'hide'"
-						class="field-preview-label"
-						:style="label_text_style(df)"
-					>
-						{{ df.label }}
-					</div>
-					<div
-						class="field-preview-value"
-						:class="{ 'text-muted': !preview_value }"
-						:style="value_text_style(df)"
-					>
-						<img
-							v-if="is_image_field(df, preview_value) && preview_value"
-							:src="preview_value"
-							class="preview-field-img"
-							:alt="df.label || df.fieldname"
-						/>
-						<span v-else>{{ preview_value || "—" }}</span>
-					</div>
+			</template>
+			<!-- Repeater field -->
+			<template v-else-if="df.fieldtype == 'Repeater'">
+				<div v-if="df.label && df.show_label !== 'hide'" class="label">
+					{{ df.label }}
 				</div>
-			</div>
+				<table class="pfb-repeater-table">
+					<colgroup>
+						<col
+							v-for="(col, ci) in df.repeater_columns || []"
+							:key="ci"
+							:style="col.width ? { width: col.width + '%' } : {}"
+						/>
+					</colgroup>
+					<tbody>
+						<tr
+							v-for="(row, i) in (preview_doc[df.source] || []).slice(0, 6)"
+							:key="i"
+						>
+							<td
+								v-for="(col, ci) in df.repeater_columns || []"
+								:key="ci"
+								class="pfb-repeater-cell"
+								:style="{
+									textAlign: col.align || 'left',
+									...(col.color ? { color: col.color } : {}),
+								}"
+							>
+								{{ repeater_cell(col, row) }}
+							</td>
+						</tr>
+						<tr v-if="!(preview_doc[df.source] || []).length">
+							<td
+								class="text-muted"
+								style="text-align: center; font-size: 11px; padding: 6px"
+							>
+								{{ df.source ? __("No rows") : __("Pick a source table") }}
+							</td>
+						</tr>
+						<tr v-if="(preview_doc[df.source] || []).length > 6">
+							<td
+								:colspan="df.repeater_columns?.length || 1"
+								class="text-muted"
+								style="text-align: center; font-size: 11px; padding: 6px"
+							>
+								{{
+									__(
+										"+ {0} more rows in this document — all print in the real output",
+										[preview_doc[df.source].length - 6]
+									)
+								}}
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</template>
+			<!-- Regular field -->
+			<template v-else>
+				<div
+					v-if="df.label && df.show_label !== 'hide'"
+					class="label"
+					:style="label_text_style(df)"
+				>
+					{{ df.label }}
+				</div>
+				<div
+					class="value"
+					:class="{ 'text-muted': !preview_value }"
+					:style="value_text_style(df)"
+				>
+					<img
+						v-if="df.fieldtype == 'Attach Image' && preview_doc[df.fieldname]"
+						class="w-100"
+						:src="preview_doc[df.fieldname]"
+						:alt="df.label || df.fieldname"
+					/>
+					<a
+						v-else-if="df.fieldtype == 'Attach' && preview_doc[df.fieldname]"
+						:href="preview_doc[df.fieldname]"
+						>{{ String(preview_doc[df.fieldname]).split("/").pop() }}</a
+					>
+					<template v-else-if="df.fieldtype == 'Color' && preview_doc[df.fieldname]">
+						<div
+							class="color-square"
+							:style="{ backgroundColor: preview_doc[df.fieldname] }"
+						></div>
+						{{ preview_doc[df.fieldname] }}
+					</template>
+					<span v-else>{{ preview_value || "—" }}</span>
+				</div>
+			</template>
 			<!-- Top-right actions pill: drag + remove -->
 			<div class="field-preview-actions">
 				<div
@@ -484,22 +450,6 @@ import JsBarcode from "jsbarcode";
 
 const props = defineProps(["df", "field_orientation"]);
 
-// Inline style for a preview field: text alignment (stacked only) plus an
-// optional label-to-value gap. `always_row` is for fields that are always a
-// flex row (e.g. Table MultiSelect) regardless of section orientation.
-function field_style(df, always_row = false) {
-	const style = {};
-	if (props.field_orientation !== "left-right") {
-		style.textAlign = df.align || "left";
-	}
-	const is_row =
-		always_row || props.field_orientation === "left-right" || df.show_label === "inline";
-	if (is_row && df.label_gap != null) {
-		style.gap = df.label_gap + "px";
-	}
-	return style;
-}
-
 // Per-field text colour for the label and value lines.
 function label_text_style(df) {
 	return df.label_color ? { color: df.label_color } : {};
@@ -519,6 +469,79 @@ let custom_style = computed(() => parse_inline_style(props.df.custom_style));
 let is_selected = computed(() => store.selected_field.value === props.df);
 let preview_doc = computed(() => store.preview_doc.value);
 let is_field_visible = computed(() => evaluate_visible_if(props.df.visible_if, preview_doc.value));
+
+// Fieldtypes whose server macro is not the label/value field div (Data.html)
+const NON_VALUE_FIELDTYPES = new Set([
+	"Table",
+	"Repeater",
+	"HTML",
+	"Field Template",
+	"Spacer",
+	"Divider",
+	"Image",
+	"Barcode",
+]);
+
+// In preview mode the root element IS the server element: these mirror the
+// class/style/data-attribute output of templates/print_format/macros/*.html
+// so every shared-stylesheet rule hits the canvas exactly like the PDF.
+const preview_root_classes = computed(() => {
+	const df = props.df;
+	if (df.fieldtype === "Table") {
+		return [
+			"child-table",
+			`child-table--${df.table_style || "lined"}`,
+			df.table_bordered === false ? "child-table--borderless" : "",
+			df.table_header === "plain" ? "child-table--plain-header" : "",
+		];
+	}
+	if (df.fieldtype === "Repeater") return ["pfb-repeater"];
+	if (df.fieldtype === "HTML") return ["custom-html"];
+	if (df.fieldtype === "Field Template") return ["field-template"];
+	if (df.fieldtype === "Spacer" || df.fieldtype === "Divider") return [];
+	if (df.fieldtype === "Image" || df.fieldtype === "Barcode") {
+		return [
+			"field",
+			df.fieldtype === "Image" ? "print-image" : "print-barcode",
+			df.align ? `field-align-${df.align}` : "",
+		];
+	}
+	const lr = props.field_orientation === "left-right";
+	return [
+		"field",
+		lr ? "left-right" : "",
+		!lr && df.show_label === "inline" ? "field-inline" : "",
+		df.align ? `field-align-${df.align}` : "",
+		lr && df.label_justify ? `field-justify-${df.label_justify}` : "",
+	];
+});
+
+const preview_root_style = computed(() => {
+	const df = props.df;
+	if (df.fieldtype === "Spacer") return { height: "1em", ...custom_style.value };
+	if (df.fieldtype === "Divider") {
+		return {
+			height: "1px",
+			margin: "0.5em 0",
+			borderBottom: "1px solid",
+			borderBottomColor: "var(--dark-border-color)",
+			...custom_style.value,
+		};
+	}
+	const style = {};
+	const inline = props.field_orientation === "left-right" || df.show_label === "inline";
+	if (!NON_VALUE_FIELDTYPES.has(df.fieldtype) && inline && df.label_gap != null) {
+		style.gap = df.label_gap + "px";
+	}
+	return { ...style, ...custom_style.value };
+});
+
+// Spacer/Divider carry no data attributes on the server either
+function preview_data_attr(value) {
+	if (!preview_doc.value || !value) return undefined;
+	if (props.df.fieldtype === "Spacer" || props.df.fieldtype === "Divider") return undefined;
+	return value;
+}
 
 // Render Jinja2 HTML fields server-side when in preview mode
 watch(
@@ -911,7 +934,7 @@ watch(
 </script>
 
 <style scoped>
-.field {
+.field--chip {
 	display: flex;
 	flex-direction: column;
 	gap: 0;
@@ -926,21 +949,21 @@ watch(
 	overflow: hidden;
 }
 
-.field:active {
+.field--chip:active {
 	cursor: grabbing;
 }
 
-.field.sortable-chosen,
-.field.sortable-ghost {
+.field--chip.sortable-chosen,
+.field--chip.sortable-ghost {
 	cursor: grabbing;
 }
 
-.field:focus-within {
+.field--chip:focus-within {
 	border-style: solid;
 	border-color: var(--gray-600);
 }
 
-.field--selected {
+.field--chip.field--selected {
 	border-style: solid;
 	border-color: var(--gray-500);
 }
@@ -995,7 +1018,7 @@ watch(
 	gap: 2px;
 }
 
-.custom-html {
+.field--chip .custom-html {
 	word-break: break-all;
 }
 
@@ -1088,10 +1111,8 @@ watch(
 
 /* ── Preview mode ────────────────────────────────────────── */
 .field--preview {
-	border: 1px solid transparent;
-	background: transparent;
-	padding: 0;
 	position: relative;
+	border-radius: var(--radius);
 }
 
 .field--condition-hidden {
@@ -1099,92 +1120,16 @@ watch(
 	border-radius: var(--radius);
 }
 
+/* Selection chrome is outline-only: it must never change the geometry
+   of the previewed markup, which mirrors the printed page 1:1. */
 .field--preview:hover {
-	border-color: var(--gray-200);
-	background: var(--gray-50);
+	outline: 1px dashed var(--gray-400);
+	outline-offset: 1px;
 }
 
 .field--preview.field--selected {
-	border-style: solid;
-	border-color: var(--gray-500);
-	background: var(--fg-color);
-}
-
-.field-preview-wrap {
-	padding: 2px 4px;
-	width: 100%;
-}
-
-.field-preview-label {
-	font-size: var(--text-sm);
-	color: var(--pfb-label-color, #6b7280);
-	margin-bottom: 1px;
-}
-
-/* Left-right: label and value side by side */
-.field-preview-lr {
-	display: flex;
-	align-items: baseline;
-	gap: 6px;
-}
-
-.field-preview-lr .field-preview-label {
-	flex-shrink: 0;
-	margin-bottom: 0;
-	white-space: nowrap;
-}
-
-.field-preview-lr .field-preview-value {
-	flex: 1;
-	min-width: 0;
-}
-
-.field-preview-lr--space-between {
-	justify-content: space-between;
-}
-.field-preview-lr--space-evenly {
-	justify-content: space-evenly;
-}
-.field-preview-lr--align-center {
-	justify-content: center;
-}
-.field-preview-lr--align-right {
-	justify-content: flex-end;
-}
-
-/* Spacing: value shrinks to natural width so justify-content has room to push it */
-.field-preview-lr--space-between .field-preview-value,
-.field-preview-lr--space-evenly .field-preview-value {
-	flex: none;
-}
-
-.field-preview-lr--space-between .field-preview-value {
-	text-align: right;
-}
-
-/* Align: both label and value shrink to natural width so the pair can be repositioned */
-.field-preview-lr--align-center .field-preview-label,
-.field-preview-lr--align-center .field-preview-value,
-.field-preview-lr--align-right .field-preview-label,
-.field-preview-lr--align-right .field-preview-value {
-	flex: none;
-	width: auto;
-}
-
-.field-preview-value {
-	font-size: var(--text-sm);
-	color: var(--pfb-value-color, var(--text-color));
-	word-break: break-word;
-}
-
-.field-preview-spacer {
-	height: 12px;
-}
-
-.field-preview-divider {
-	height: 1px;
-	background: var(--gray-300);
-	margin: 4px 0;
+	outline: 1px solid var(--gray-400);
+	outline-offset: 1px;
 }
 
 /* Top-right actions pill: drag + remove — hidden until hover/selected */
@@ -1232,12 +1177,6 @@ watch(
 	white-space: normal;
 }
 
-.pf-element-img {
-	max-width: 100%;
-	display: inline-block;
-	vertical-align: top;
-}
-
 .pf-barcode-svg {
 	display: inline-block;
 	max-width: 100%;
@@ -1249,13 +1188,5 @@ watch(
 	object-fit: contain;
 	border-radius: var(--radius);
 	vertical-align: middle;
-}
-
-.preview-field-img {
-	max-width: 100%;
-	max-height: 80px;
-	object-fit: contain;
-	border-radius: var(--radius);
-	display: block;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		:class="[
-			preview_doc ? preview_root_classes : 'field field--chip',
+			preview_doc ? preview_root.classes : 'field field--chip',
 			{
 				'field--table': df.fieldtype == 'Table',
 				'field--selected': is_selected,
@@ -9,7 +9,7 @@
 				'field--condition-hidden': preview_doc && !is_field_visible,
 			},
 		]"
-		:style="preview_doc ? preview_root_style : undefined"
+		:style="preview_doc ? preview_root.style : undefined"
 		:data-fieldname="preview_data_attr(df.fieldname)"
 		:data-fieldtype="preview_data_attr(df.fieldtype)"
 		v-show="!df.remove"
@@ -186,8 +186,7 @@
 							<tr v-if="!preview_doc[df.fieldname]?.length">
 								<td
 									:colspan="df.table_columns?.length || 1"
-									class="text-muted"
-									style="text-align: center; font-size: 11px; padding: 6px"
+									class="text-muted pfb-table-note"
 								>
 									{{ __("No rows") }}
 								</td>
@@ -195,8 +194,7 @@
 							<tr v-if="(preview_doc[df.fieldname] || []).length > 4">
 								<td
 									:colspan="df.table_columns?.length || 1"
-									class="text-muted"
-									style="text-align: center; font-size: 11px; padding: 6px"
+									class="text-muted pfb-table-note"
 								>
 									{{
 										__(
@@ -241,18 +239,14 @@
 							</td>
 						</tr>
 						<tr v-if="!(preview_doc[df.source] || []).length">
-							<td
-								class="text-muted"
-								style="text-align: center; font-size: 11px; padding: 6px"
-							>
+							<td class="text-muted pfb-table-note">
 								{{ df.source ? __("No rows") : __("Pick a source table") }}
 							</td>
 						</tr>
 						<tr v-if="(preview_doc[df.source] || []).length > 6">
 							<td
 								:colspan="df.repeater_columns?.length || 1"
-								class="text-muted"
-								style="text-align: center; font-size: 11px; padding: 6px"
+								class="text-muted pfb-table-note"
 							>
 								{{
 									__(
@@ -288,6 +282,7 @@
 					<a
 						v-else-if="df.fieldtype == 'Attach' && preview_doc[df.fieldname]"
 						:href="preview_doc[df.fieldname]"
+						@click.prevent
 						>{{ String(preview_doc[df.fieldname]).split("/").pop() }}</a
 					>
 					<template v-else-if="df.fieldtype == 'Color' && preview_doc[df.fieldname]">
@@ -470,70 +465,62 @@ let is_selected = computed(() => store.selected_field.value === props.df);
 let preview_doc = computed(() => store.preview_doc.value);
 let is_field_visible = computed(() => evaluate_visible_if(props.df.visible_if, preview_doc.value));
 
-// Fieldtypes whose server macro is not the label/value field div (Data.html)
-const NON_VALUE_FIELDTYPES = new Set([
-	"Table",
-	"Repeater",
-	"HTML",
-	"Field Template",
-	"Spacer",
-	"Divider",
-	"Image",
-	"Barcode",
-]);
-
-// In preview mode the root element IS the server element: these mirror the
-// class/style/data-attribute output of templates/print_format/macros/*.html
-// so every shared-stylesheet rule hits the canvas exactly like the PDF.
-const preview_root_classes = computed(() => {
+// Mirrors the root markup of templates/print_format/macros/*.html per fieldtype
+const preview_root = computed(() => {
 	const df = props.df;
+	const custom = custom_style.value;
 	if (df.fieldtype === "Table") {
-		return [
-			"child-table",
-			`child-table--${df.table_style || "lined"}`,
-			df.table_bordered === false ? "child-table--borderless" : "",
-			df.table_header === "plain" ? "child-table--plain-header" : "",
-		];
-	}
-	if (df.fieldtype === "Repeater") return ["pfb-repeater"];
-	if (df.fieldtype === "HTML") return ["custom-html"];
-	if (df.fieldtype === "Field Template") return ["field-template"];
-	if (df.fieldtype === "Spacer" || df.fieldtype === "Divider") return [];
-	if (df.fieldtype === "Image" || df.fieldtype === "Barcode") {
-		return [
-			"field",
-			df.fieldtype === "Image" ? "print-image" : "print-barcode",
-			df.align ? `field-align-${df.align}` : "",
-		];
-	}
-	const lr = props.field_orientation === "left-right";
-	return [
-		"field",
-		lr ? "left-right" : "",
-		!lr && df.show_label === "inline" ? "field-inline" : "",
-		df.align ? `field-align-${df.align}` : "",
-		lr && df.label_justify ? `field-justify-${df.label_justify}` : "",
-	];
-});
-
-const preview_root_style = computed(() => {
-	const df = props.df;
-	if (df.fieldtype === "Spacer") return { height: "1em", ...custom_style.value };
-	if (df.fieldtype === "Divider") {
 		return {
-			height: "1px",
-			margin: "0.5em 0",
-			borderBottom: "1px solid",
-			borderBottomColor: "var(--dark-border-color)",
-			...custom_style.value,
+			classes: [
+				"child-table",
+				`child-table--${df.table_style || "lined"}`,
+				df.table_bordered === false ? "child-table--borderless" : "",
+				df.table_header === "plain" ? "child-table--plain-header" : "",
+			],
+			style: custom,
 		};
 	}
+	if (df.fieldtype === "Repeater") return { classes: ["pfb-repeater"], style: custom };
+	if (df.fieldtype === "HTML") return { classes: ["custom-html"], style: custom };
+	if (df.fieldtype === "Field Template") return { classes: ["field-template"], style: custom };
+	if (df.fieldtype === "Spacer") return { classes: [], style: { height: "1em", ...custom } };
+	if (df.fieldtype === "Divider") {
+		return {
+			classes: [],
+			style: {
+				height: "1px",
+				margin: "0.5em 0",
+				borderBottom: "1px solid",
+				borderBottomColor: "var(--dark-border-color)",
+				...custom,
+			},
+		};
+	}
+	if (df.fieldtype === "Image" || df.fieldtype === "Barcode") {
+		return {
+			classes: [
+				"field",
+				df.fieldtype === "Image" ? "print-image" : "print-barcode",
+				df.align ? `field-align-${df.align}` : "",
+			],
+			style: custom,
+		};
+	}
+	const lr = props.field_orientation === "left-right";
 	const style = {};
-	const inline = props.field_orientation === "left-right" || df.show_label === "inline";
-	if (!NON_VALUE_FIELDTYPES.has(df.fieldtype) && inline && df.label_gap != null) {
+	if ((lr || df.show_label === "inline") && df.label_gap != null) {
 		style.gap = df.label_gap + "px";
 	}
-	return { ...style, ...custom_style.value };
+	return {
+		classes: [
+			"field",
+			lr ? "left-right" : "",
+			!lr && df.show_label === "inline" ? "field-inline" : "",
+			df.align ? `field-align-${df.align}` : "",
+			lr && df.label_justify ? `field-justify-${df.label_justify}` : "",
+		],
+		style: { ...style, ...custom },
+	};
 });
 
 // Spacer/Divider carry no data attributes on the server either
@@ -1120,8 +1107,7 @@ watch(
 	border-radius: var(--radius);
 }
 
-/* Selection chrome is outline-only: it must never change the geometry
-   of the previewed markup, which mirrors the printed page 1:1. */
+/* outline-only selection chrome: must not change previewed geometry */
 .field--preview:hover {
 	outline: 1px dashed var(--gray-400);
 	outline-offset: 1px;
@@ -1133,6 +1119,12 @@ watch(
 }
 
 /* Top-right actions pill: drag + remove — hidden until hover/selected */
+.pfb-table-note {
+	text-align: center;
+	font-size: 11px;
+	padding: 6px;
+}
+
 .field-preview-actions {
 	display: none;
 	position: absolute;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -142,14 +142,46 @@ let rootStyles = computed(() => {
 });
 
 let bodyStyles = computed(() => {
-	const { font_size, font, label_color, value_color } = print_format.value;
+	const { font_size, font } = print_format.value;
 	const styles = {};
 	if (font_size) styles.fontSize = `${parseFloat(font_size)}px`;
 	if (font) styles.fontFamily = `'${font}', sans-serif`;
-	if (label_color) styles["--pfb-label-color"] = label_color;
-	if (value_color) styles["--pfb-value-color"] = value_color;
 	return styles;
 });
+
+// Format-level label/value colours: emit the same scoped rules the server
+// appends after the shared stylesheet (templates/print_format/print_format.css),
+// so the cascade on the canvas is identical to the printed page.
+const COLOR_CSS_ID = "pfb-format-color-css";
+watch(
+	() => [print_format.value.label_color, print_format.value.value_color],
+	([label_color, value_color]) => {
+		let el = document.getElementById(COLOR_CSS_ID);
+		if (!label_color && !value_color) {
+			el?.remove();
+			return;
+		}
+		if (!el) {
+			el = document.createElement("style");
+			el.id = COLOR_CSS_ID;
+			document.head.appendChild(el);
+		}
+		let css = "";
+		if (label_color) {
+			css += `.print-format-doc .field .label,
+.print-format-doc .field.left-right .label,
+.print-format-doc .field.field-inline .label { color: ${label_color}; }\n`;
+		}
+		if (value_color) {
+			css += `.print-format-doc .field .value,
+.print-format-doc .field.left-right .value,
+.print-format-doc .field.field-inline .value { color: ${value_color}; }\n`;
+		}
+		el.textContent = css;
+	},
+	{ immediate: true }
+);
+onUnmounted(() => document.getElementById(COLOR_CSS_ID)?.remove());
 
 let page_number_hidden = computed(() => print_format.value.page_number.includes("Hide"));
 
@@ -288,28 +320,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	margin-bottom: 0;
 }
 
-/* Default field skin in clean-preview — grid cells style themselves */
-.pfb-clean-preview :deep(.field--preview:not(.section--grid *)) {
-	border: 1px solid transparent;
-	background: transparent;
-	padding: 0;
-	border-radius: var(--radius);
-	transition: border-color 0.1s;
-}
-
-.pfb-clean-preview :deep(.field--preview:hover:not(.section--grid *)) {
-	border: 1px dashed var(--gray-400);
-	background: transparent;
-}
-
-.pfb-clean-preview :deep(.field--preview.field--selected:not(.section--grid *)) {
-	border: 1px solid var(--gray-400);
-	background: transparent;
-}
-
-.pfb-clean-preview :deep(.field--preview.field--condition-hidden:not(.section--grid *)) {
-	border: 1px dashed var(--gray-400);
-}
+/* Field selection chrome lives in Field.vue and is outline-only */
 
 /* Section columns: no vertical padding in preview (matches PDF) */
 .pfb-clean-preview :deep(.section-columns) {
@@ -341,15 +352,5 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 /* Section title: typography/border come from the shared .section-label rules */
 .pfb-clean-preview :deep(.section-title-display) {
 	display: block;
-}
-
-.pfb-body :deep(.field--preview) {
-	font-size: inherit;
-}
-.pfb-body :deep(.field--preview .field-preview-value) {
-	font-size: 1em;
-}
-.pfb-body :deep(.field--preview .field-preview-label) {
-	font-size: 1em;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -1,6 +1,5 @@
 <template>
 	<div
-		ref="root_el"
 		class="print-format-main"
 		:style="rootStyles"
 		:class="{
@@ -10,21 +9,13 @@
 	>
 		<component :is="'style'" v-if="color_css">{{ color_css }}</component>
 		<div v-if="!page_number_hidden" class="pfb-page-num" :style="page_number_style">
-			{{ __("1 of {0}", [page_count]) }}
-		</div>
-		<div
-			v-for="guide in page_guides"
-			:key="guide.page"
-			class="page-guide"
-			:style="{ top: guide.top + 'px' }"
-		>
-			<span class="page-guide-label">{{ __("Page {0}", [guide.page]) }}</span>
+			{{ __("1 of 2") }}
 		</div>
 
 		<LetterHeadZoneEditor zone="header" />
 
 		<!-- Body wrapper: font size/family applied here so letterhead zones are unaffected -->
-		<div ref="body_el" class="pfb-body" :style="bodyStyles">
+		<div class="pfb-body" :style="bodyStyles">
 			<div class="zone-divider">
 				<span class="zone-divider-label">{{ __("Header") }}</span>
 			</div>
@@ -75,57 +66,14 @@ import { computed, inject, watch, nextTick, onMounted, onUnmounted, ref } from "
 let { layout, letterhead, print_format } = useStore();
 let store = inject("$store");
 
-// Where the printed page boundaries fall on the canvas. Heights on the canvas
-// match print heights (shared stylesheet, em spacing), so the boundary is
-// page height minus margins minus the repeating letterhead zones, measured
-// from where the body content starts.
 const PAGE_SIZES_MM = { A4: [210, 297], Letter: [216, 279.4] };
-
-let root_el = ref(null);
-let body_el = ref(null);
 let page_size = ref("A4");
-let page_guides = ref([]);
-let page_count = computed(() => page_guides.value.length + 1);
-let resize_observer = null;
-
-function update_guides() {
-	const root = root_el.value;
-	const body = body_el.value;
-	if (!root || !body) return;
-	const rr = root.getBoundingClientRect();
-	const br = body.getBoundingClientRect();
-	if (!rr.width || !br.height) {
-		page_guides.value = [];
-		return;
-	}
-	const [page_w, page_h] = PAGE_SIZES_MM[page_size.value] || PAGE_SIZES_MM.A4;
-	const px_mm = rr.width / page_w;
-	const { margin_top = 0, margin_bottom = 0 } = print_format.value;
-	const zones = root.querySelectorAll(":scope > .lh-zone");
-	const lh_head = zones[0]?.offsetHeight || 0;
-	const lh_foot = zones.length > 1 ? zones[zones.length - 1].offsetHeight : 0;
-	const usable = (page_h - margin_top - margin_bottom) * px_mm - lh_head - lh_foot;
-	const guides = [];
-	if (usable > 0) {
-		const body_top = br.top - rr.top;
-		const content_end = br.bottom - rr.top;
-		for (let k = 1; body_top + k * usable < content_end - 1 && k <= 100; k++) {
-			guides.push({ page: k + 1, top: Math.round(body_top + k * usable) });
-		}
-	}
-	page_guides.value = guides;
-}
 
 onMounted(() => {
 	frappe.db.get_single_value("Print Settings", "pdf_page_size").then((v) => {
 		if (v && PAGE_SIZES_MM[v]) page_size.value = v;
-		nextTick(update_guides);
 	});
-	resize_observer = new ResizeObserver(update_guides);
-	if (root_el.value) resize_observer.observe(root_el.value);
-	if (body_el.value) resize_observer.observe(body_el.value);
 });
-onUnmounted(() => resize_observer?.disconnect());
 
 const CUSTOM_CSS_ID = "pfb-letterhead-custom-css";
 watch(
@@ -308,30 +256,6 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	color: var(--text-muted);
 	background: var(--gray-100);
 	border: 1px solid var(--gray-300);
-}
-
-.page-guide {
-	position: absolute;
-	left: 0;
-	right: 0;
-	border-top: 1px dashed var(--gray-400);
-	pointer-events: none;
-	z-index: 5;
-}
-
-.page-guide-label {
-	position: absolute;
-	left: 50%;
-	top: 0;
-	transform: translate(-50%, -50%);
-	font-size: var(--text-tiny);
-	font-weight: var(--weight-medium);
-	color: var(--text-muted);
-	background: var(--gray-100);
-	border: 1px solid var(--gray-300);
-	border-radius: var(--radius);
-	padding: 1px 6px;
-	white-space: nowrap;
 }
 
 .section-with-insert {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -7,6 +7,7 @@
 			'print-format-doc': !!store.preview_doc.value,
 		}"
 	>
+		<component :is="'style'" v-if="color_css">{{ color_css }}</component>
 		<div v-if="!page_number_hidden" class="pfb-page-num" :style="page_number_style">
 			{{ __("1 of 2") }}
 		</div>
@@ -15,11 +16,11 @@
 
 		<!-- Body wrapper: font size/family applied here so letterhead zones are unaffected -->
 		<div class="pfb-body" :style="bodyStyles">
-			<div class="zone-divider zone-divider--header">
+			<div class="zone-divider">
 				<span class="zone-divider-label">{{ __("Header") }}</span>
 			</div>
 			<PrintFormatSection :section="layout.header" :is_header="true" zone="header" />
-			<div class="zone-divider zone-divider--body">
+			<div class="zone-divider">
 				<span class="zone-divider-label">{{ __("Body") }}</span>
 			</div>
 
@@ -44,7 +45,7 @@
 				</template>
 			</draggable>
 
-			<div class="zone-divider zone-divider--footer">
+			<div class="zone-divider">
 				<span class="zone-divider-label">{{ __("Footer") }}</span>
 			</div>
 			<PrintFormatSection :section="layout.footer" :is_header="true" zone="footer" />
@@ -149,39 +150,23 @@ let bodyStyles = computed(() => {
 	return styles;
 });
 
-// Format-level label/value colours: emit the same scoped rules the server
-// appends after the shared stylesheet (templates/print_format/print_format.css),
-// so the cascade on the canvas is identical to the printed page.
-const COLOR_CSS_ID = "pfb-format-color-css";
-watch(
-	() => [print_format.value.label_color, print_format.value.value_color],
-	([label_color, value_color]) => {
-		let el = document.getElementById(COLOR_CSS_ID);
-		if (!label_color && !value_color) {
-			el?.remove();
-			return;
-		}
-		if (!el) {
-			el = document.createElement("style");
-			el.id = COLOR_CSS_ID;
-			document.head.appendChild(el);
-		}
-		let css = "";
-		if (label_color) {
-			css += `.print-format-doc .field .label,
+// Same scoped colour rules the server appends after the shared stylesheet;
+// rendered as a style element inside the component so it dies with the DOM
+let color_css = computed(() => {
+	const { label_color, value_color } = print_format.value;
+	let css = "";
+	if (label_color) {
+		css += `.print-format-doc .field .label,
 .print-format-doc .field.left-right .label,
 .print-format-doc .field.field-inline .label { color: ${label_color}; }\n`;
-		}
-		if (value_color) {
-			css += `.print-format-doc .field .value,
+	}
+	if (value_color) {
+		css += `.print-format-doc .field .value,
 .print-format-doc .field.left-right .value,
 .print-format-doc .field.field-inline .value { color: ${value_color}; }\n`;
-		}
-		el.textContent = css;
-	},
-	{ immediate: true }
-);
-onUnmounted(() => document.getElementById(COLOR_CSS_ID)?.remove());
+	}
+	return css;
+});
 
 let page_number_hidden = computed(() => print_format.value.page_number.includes("Hide"));
 
@@ -258,24 +243,9 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	white-space: nowrap;
 	padding: 2px 8px;
 	border-radius: var(--radius);
-}
-
-.zone-divider--header .zone-divider-label {
-	color: var(--blue-500);
-	background: var(--blue-50);
-	border: 1px solid var(--blue-200);
-}
-
-.zone-divider--body .zone-divider-label {
 	color: var(--text-muted);
 	background: var(--gray-100);
 	border: 1px solid var(--gray-300);
-}
-
-.zone-divider--footer .zone-divider-label {
-	color: var(--blue-500);
-	background: var(--blue-50);
-	border: 1px solid var(--blue-200);
 }
 
 .section-with-insert {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -1,5 +1,6 @@
 <template>
 	<div
+		ref="root_el"
 		class="print-format-main"
 		:style="rootStyles"
 		:class="{
@@ -9,13 +10,21 @@
 	>
 		<component :is="'style'" v-if="color_css">{{ color_css }}</component>
 		<div v-if="!page_number_hidden" class="pfb-page-num" :style="page_number_style">
-			{{ __("1 of 2") }}
+			{{ __("1 of {0}", [page_count]) }}
+		</div>
+		<div
+			v-for="guide in page_guides"
+			:key="guide.page"
+			class="page-guide"
+			:style="{ top: guide.top + 'px' }"
+		>
+			<span class="page-guide-label">{{ __("Page {0}", [guide.page]) }}</span>
 		</div>
 
 		<LetterHeadZoneEditor zone="header" />
 
 		<!-- Body wrapper: font size/family applied here so letterhead zones are unaffected -->
-		<div class="pfb-body" :style="bodyStyles">
+		<div ref="body_el" class="pfb-body" :style="bodyStyles">
 			<div class="zone-divider">
 				<span class="zone-divider-label">{{ __("Header") }}</span>
 			</div>
@@ -61,10 +70,62 @@ import LetterHeadZoneEditor from "../letterhead/LetterHeadZoneEditor.vue";
 import PrintFormatSection from "./PrintFormatSection.vue";
 import SectionInsert from "./SectionInsert.vue";
 import { useStore } from "../../stores";
-import { computed, inject, watch, nextTick, onUnmounted } from "vue";
+import { computed, inject, watch, nextTick, onMounted, onUnmounted, ref } from "vue";
 
 let { layout, letterhead, print_format } = useStore();
 let store = inject("$store");
+
+// Where the printed page boundaries fall on the canvas. Heights on the canvas
+// match print heights (shared stylesheet, em spacing), so the boundary is
+// page height minus margins minus the repeating letterhead zones, measured
+// from where the body content starts.
+const PAGE_SIZES_MM = { A4: [210, 297], Letter: [216, 279.4] };
+
+let root_el = ref(null);
+let body_el = ref(null);
+let page_size = ref("A4");
+let page_guides = ref([]);
+let page_count = computed(() => page_guides.value.length + 1);
+let resize_observer = null;
+
+function update_guides() {
+	const root = root_el.value;
+	const body = body_el.value;
+	if (!root || !body) return;
+	const rr = root.getBoundingClientRect();
+	const br = body.getBoundingClientRect();
+	if (!rr.width || !br.height) {
+		page_guides.value = [];
+		return;
+	}
+	const [page_w, page_h] = PAGE_SIZES_MM[page_size.value] || PAGE_SIZES_MM.A4;
+	const px_mm = rr.width / page_w;
+	const { margin_top = 0, margin_bottom = 0 } = print_format.value;
+	const zones = root.querySelectorAll(":scope > .lh-zone");
+	const lh_head = zones[0]?.offsetHeight || 0;
+	const lh_foot = zones.length > 1 ? zones[zones.length - 1].offsetHeight : 0;
+	const usable = (page_h - margin_top - margin_bottom) * px_mm - lh_head - lh_foot;
+	const guides = [];
+	if (usable > 0) {
+		const body_top = br.top - rr.top;
+		const content_end = br.bottom - rr.top;
+		for (let k = 1; body_top + k * usable < content_end - 1 && k <= 100; k++) {
+			guides.push({ page: k + 1, top: Math.round(body_top + k * usable) });
+		}
+	}
+	page_guides.value = guides;
+}
+
+onMounted(() => {
+	frappe.db.get_single_value("Print Settings", "pdf_page_size").then((v) => {
+		if (v && PAGE_SIZES_MM[v]) page_size.value = v;
+		nextTick(update_guides);
+	});
+	resize_observer = new ResizeObserver(update_guides);
+	if (root_el.value) resize_observer.observe(root_el.value);
+	if (body_el.value) resize_observer.observe(body_el.value);
+});
+onUnmounted(() => resize_observer?.disconnect());
 
 const CUSTOM_CSS_ID = "pfb-letterhead-custom-css";
 watch(
@@ -135,10 +196,11 @@ let rootStyles = computed(() => {
 		margin_left = 0,
 		margin_right = 0,
 	} = print_format.value;
+	const [page_w, page_h] = PAGE_SIZES_MM[page_size.value] || PAGE_SIZES_MM.A4;
 	return {
 		padding: `${margin_top}mm ${margin_right}mm ${margin_bottom}mm ${margin_left}mm`,
-		width: "210mm",
-		minHeight: "297mm",
+		width: `${page_w}mm`,
+		minHeight: `${page_h}mm`,
 	};
 });
 
@@ -246,6 +308,30 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	color: var(--text-muted);
 	background: var(--gray-100);
 	border: 1px solid var(--gray-300);
+}
+
+.page-guide {
+	position: absolute;
+	left: 0;
+	right: 0;
+	border-top: 1px dashed var(--gray-400);
+	pointer-events: none;
+	z-index: 5;
+}
+
+.page-guide-label {
+	position: absolute;
+	left: 50%;
+	top: 0;
+	transform: translate(-50%, -50%);
+	font-size: var(--text-tiny);
+	font-weight: var(--weight-medium);
+	color: var(--text-muted);
+	background: var(--gray-100);
+	border: 1px solid var(--gray-300);
+	border-radius: var(--radius);
+	padding: 1px 6px;
+	white-space: nowrap;
 }
 
 .section-with-insert {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -96,19 +96,17 @@
 			</div>
 			<div
 				class="section-columns"
-				:style="
-					is_grid
-						? { gap: '0' }
-						: section.columns.length > 1 && section.gap
-						? { gap: section.gap + 'px' }
-						: {}
-				"
+				:class="preview_doc ? ['row', row_layout] : []"
+				:style="columns_gap_style"
 			>
 				<template v-for="(column, i) in section.columns" :key="i">
 					<div v-if="i > 0 && !preview_doc" class="column-divider"></div>
 					<div
 						class="column"
-						:class="{ 'column-align-right': column.align === 'right' }"
+						:class="{
+							'column-align-right': column.align === 'right',
+							col: !!preview_doc,
+						}"
 					>
 						<draggable
 							class="drag-container"
@@ -184,6 +182,25 @@ let is_section_visible = computed(() =>
 );
 
 let is_grid = computed(() => !!props.section.field_borders);
+
+// Mirrors the row layout class print_format.html picks for right-aligned columns
+let row_layout = computed(() => {
+	const cols = props.section.columns || [];
+	if (!cols.some((c) => c.align === "right")) return "";
+	return cols.length === 1 ? "row-col-right-end" : "row-col-space-between";
+});
+
+// In preview the gap mirrors the server default (20px unless set, 0 for grid)
+let columns_gap_style = computed(() => {
+	if (preview_doc.value) {
+		return { gap: is_grid.value ? "0" : `${props.section.gap ?? 20}px` };
+	}
+	return is_grid.value
+		? { gap: "0" }
+		: props.section.columns.length > 1 && props.section.gap
+		? { gap: props.section.gap + "px" }
+		: {};
+});
 
 let has_visible_fields = computed(
 	() =>
@@ -483,23 +500,24 @@ function remove_column(index) {
 .section--grid :deep(.drag-container) {
 	gap: 0;
 }
-.section--grid :deep(.field) {
+.section--grid :deep(.field--chip) {
 	padding: var(--pfb-cell-pad, 8px);
 	border: none;
 	border-bottom: 1px solid var(--border-color);
 	border-radius: 0;
 	background: transparent;
 }
-.section--grid :deep(.field:last-child) {
+.section--grid :deep(.field--chip:last-child) {
 	border-bottom: none;
 }
 .section--grid-rows .column:not(:last-child) {
 	border-right: none;
 }
-.section--grid-columns :deep(.field) {
+.section--grid-columns :deep(.field--chip) {
 	border-bottom: none;
 }
-.section--grid :deep(.field:hover),
+.section--grid :deep(.field--chip:hover),
+.section--grid :deep(.field--preview:hover),
 .section--grid :deep(.field--selected) {
 	outline: 1px dashed var(--gray-400);
 	outline-offset: -1px;

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -101,13 +101,7 @@
 			>
 				<template v-for="(column, i) in section.columns" :key="i">
 					<div v-if="i > 0 && !preview_doc" class="column-divider"></div>
-					<div
-						class="column"
-						:class="{
-							'column-align-right': column.align === 'right',
-							col: !!preview_doc,
-						}"
-					>
+					<div class="column" :class="{ col: !!preview_doc }">
 						<draggable
 							class="drag-container"
 							v-model="column.fields"
@@ -183,8 +177,10 @@ let is_section_visible = computed(() =>
 
 let is_grid = computed(() => !!props.section.field_borders);
 
-// Mirrors the row layout class print_format.html picks for right-aligned columns
+// Mirrors the row layout class print_format.html picks for right-aligned
+// columns; the server computes it for body sections only, never header/footer
 let row_layout = computed(() => {
+	if (props.is_header) return "";
 	const cols = props.section.columns || [];
 	if (!cols.some((c) => c.align === "right")) return "";
 	return cols.length === 1 ? "row-col-right-end" : "row-col-space-between";

--- a/frappe/templates/print_format/macros/Divider.html
+++ b/frappe/templates/print_format/macros/Divider.html
@@ -1,2 +1,2 @@
-<div style="height: 1px; margin: 0.5rem 0; border-bottom: 1px solid; border-bottom-color: var(--dark-border-color);{{ df.custom_style|e if df.custom_style }}">
+<div style="height: 1px; margin: 0.5em 0; border-bottom: 1px solid; border-bottom-color: var(--dark-border-color);{{ df.custom_style|e if df.custom_style }}">
 </div>

--- a/frappe/templates/print_format/macros/Spacer.html
+++ b/frappe/templates/print_format/macros/Spacer.html
@@ -1,2 +1,2 @@
-<div style="height: 1rem;{{ df.custom_style|e if df.custom_style }}">
+<div style="height: 1em;{{ df.custom_style|e if df.custom_style }}">
 </div>

--- a/frappe/templates/print_format/print_format.css
+++ b/frappe/templates/print_format/print_format.css
@@ -49,6 +49,24 @@ body {
 	}
 }
 
+{%- if action_banner %}
+@media screen {
+	.action-banner {
+		position: fixed;
+		top: 0;
+		right: 0;
+		display: flex;
+		justify-content: flex-end;
+		padding-right: 20px;
+	}
+}
+@media print {
+	.action-banner {
+		display: none !important;
+	}
+}
+{%- endif %}
+
 {% include "templates/print_format/print_format_doc.css" %}
 
 {%- if print_format.label_color %}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -20,6 +20,7 @@
 	{%- endif -%}
 </head>
 <body class="print-format-doc">
+	{{ action_banner or '' }}
 	{{ header or '' }}
 	{#- Chrome PDF: layout.header rendered once as a body element (page 1 only, reliable height) -#}
 	{{ chrome_layout_header or '' }}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -1,7 +1,7 @@
 {% import "templates/print_format/macros.html" as macros %}
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ lang or 'en' }}"{% if layout_direction %} dir="{{ layout_direction }}"{% endif %}>
 <head>
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -135,5 +135,6 @@
 	{{ footer or '' }}
 	{{ include_script('print.bundle.js') }}
 	<script>document.querySelectorAll("svg[data-barcode-value]").forEach(render_barcode);</script>
+	{{ trigger_print_script or '' }}
 </body>
 </html>

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -14,12 +14,16 @@
 	}
 }
 
+/* Spacing uses em, not rem: the builder canvas lives inside the desk page, so
+   rem there resolves against the desk root, not the format's font size. Values
+   inside a scope that changes font-size are pre-divided by that multiplier so
+   the computed size is unchanged (e.g. td padding 0.5em × 0.9 = 0.45 body-em). */
 .print-format-doc .section-label {
-	font-size: 1.1rem;
+	font-size: 1.1em;
 	font-weight: 700;
 	color: #1a1a1a;
-	padding-bottom: 0.35rem;
-	margin-bottom: 0.75rem;
+	padding-bottom: 0.3182em;
+	margin-bottom: 0.6818em;
 	border-bottom: 1.5px solid #e2e2e2;
 	/* Don't let the section heading sit alone at the bottom of a page */
 	break-after: avoid;
@@ -27,7 +31,7 @@
 }
 
 .print-format-doc .field + .field {
-	margin-top: 0.5rem;
+	margin-top: 0.5em;
 }
 
 /* Keep field label and value on the same page */
@@ -40,7 +44,7 @@
 .print-format-doc .field .label {
 	font-size: 1em;
 	color: #6b7280;
-	margin-bottom: 0.1rem;
+	margin-bottom: 0.1em;
 }
 
 .print-format-doc .field .value {
@@ -52,7 +56,7 @@
 .print-format-doc .field.field-inline {
 	display: flex;
 	align-items: baseline;
-	gap: 0.5rem;
+	gap: 0.5em;
 }
 
 .print-format-doc .field.left-right .label,
@@ -62,7 +66,7 @@
 	color: #374151;
 	text-transform: none;
 	letter-spacing: 0;
-	padding-top: 0.05rem;
+	padding-top: 0.05em;
 	white-space: nowrap;
 }
 
@@ -123,13 +127,13 @@
 }
 
 .print-format-doc .pfb-repeater-table tr + tr .pfb-repeater-cell {
-	padding-top: 0.5rem;
+	padding-top: 0.5em;
 }
 
 /* Child table + Repeater share the same block-label styling */
 .print-format-doc .pfb-repeater,
 .print-format-doc .child-table {
-	margin-top: 0.5rem;
+	margin-top: 0.5em;
 }
 
 .print-format-doc .pfb-repeater > .label,
@@ -137,7 +141,7 @@
 	font-size: 0.8em;
 	font-weight: 600;
 	color: #6b7280;
-	margin-bottom: 0.4rem;
+	margin-bottom: 0.5em;
 }
 
 .print-format-doc .child-table .table {
@@ -151,7 +155,7 @@
 	color: #374151;
 	font-weight: 600;
 	font-size: 0.85em;
-	padding: 0.45rem 0.6rem;
+	padding: 0.5882em 0.7843em;
 	border: none !important;
 }
 
@@ -162,7 +166,7 @@
 }
 
 .print-format-doc .child-table .table td {
-	padding: 0.45rem 0.6rem;
+	padding: 0.5em 0.6667em;
 	border: 1px solid #e5e7eb !important;
 	vertical-align: top;
 }
@@ -241,7 +245,7 @@
 .print-format-doc .child-table .cell-merged {
 	display: flex;
 	align-items: flex-start;
-	gap: 0.5rem;
+	gap: 0.5556em;
 }
 
 /* size comes from an inline style (column.image_size) */
@@ -267,7 +271,7 @@
 .print-format-doc .child-table .cell-lines {
 	display: flex;
 	flex-direction: column;
-	gap: 0.1rem;
+	gap: 0.1111em;
 	min-width: 0;
 }
 
@@ -355,7 +359,7 @@
 }
 
 .print-format-doc .field[data-fieldtype="Rating"] .rating-star {
-	width: 1.5rem;
+	width: 1.5em;
 }
 
 .print-format-doc .field[data-fieldtype="Long Text"] .value, .print-format-doc .field[data-fieldtype="Text"] .value {
@@ -368,14 +372,14 @@
 }
 
 .print-format-doc .field[data-fieldtype="Color"] .color-square {
-	width: 1rem;
-	height: 1rem;
-	margin-right: 0.3rem;
+	width: 1em;
+	height: 1em;
+	margin-right: 0.3em;
 	border-radius: var(--radius);
 }
 
 .print-format-doc .field[data-fieldtype="Check"] #icon-tick {
-	width: 1rem;
+	width: 1em;
 }
 
 /* ── Table layout (field-borders mode) ───────────────────── */

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -14,10 +14,8 @@
 	}
 }
 
-/* Spacing uses em, not rem: the builder canvas lives inside the desk page, so
-   rem there resolves against the desk root, not the format's font size. Values
-   inside a scope that changes font-size are pre-divided by that multiplier so
-   the computed size is unchanged (e.g. td padding 0.5em × 0.9 = 0.45 body-em). */
+/* em only, never rem (the canvas rem root is the desk page); values inside a
+   font-size scope are pre-divided by that multiplier (0.5em × 0.9 = 0.45). */
 .print-format-doc .section-label {
 	font-size: 1.1em;
 	font-weight: 700;
@@ -81,6 +79,14 @@
 }
 
 /* Field-level alignment */
+.print-format-doc .field.field-align-left {
+	text-align: left;
+}
+
+.print-format-doc .field.field-align-left .value {
+	text-align: left;
+}
+
 .print-format-doc .field.field-align-center {
 	text-align: center;
 }

--- a/frappe/templates/print_formats/print_action_banner.html
+++ b/frappe/templates/print_formats/print_action_banner.html
@@ -1,0 +1,9 @@
+<div class="action-banner print-hide">
+	<a class="p-2" onclick="window.print();">
+		{{ _("Print") }}
+	</a>
+	<a class="p-2"
+		href="/api/method/frappe.utils.print_format.download_pdf?doctype={{doctype|e}}&name={{name|e}}&format={{print_format|e}}&letterhead={{letterhead|e}}&no_letterhead={{no_letterhead|e}}&_lang={{lang|e}}&key={{key|e}}&pdf_generator={{pdf_generator|e}}">
+		{{ _('Get PDF') }}
+	</a>
+</div>

--- a/frappe/templates/print_formats/print_action_banner.html
+++ b/frappe/templates/print_formats/print_action_banner.html
@@ -3,7 +3,7 @@
 		{{ _("Print") }}
 	</a>
 	<a class="p-2"
-		href="/api/method/frappe.utils.print_format.download_pdf?doctype={{doctype|e}}&name={{name|e}}&format={{print_format|e}}&letterhead={{letterhead|e}}&no_letterhead={{no_letterhead|e}}&_lang={{lang|e}}&key={{key|e}}&pdf_generator={{pdf_generator|e}}">
+		href="/api/method/frappe.utils.print_format.download_pdf?doctype={{doctype|e}}&name={{name|e}}&format={{print_format|e}}{% if letterhead %}&letterhead={{letterhead|e}}{% endif %}{% if no_letterhead %}&no_letterhead={{no_letterhead|e}}{% endif %}{% if lang %}&_lang={{lang|e}}{% endif %}{% if key %}&key={{key|e}}{% endif %}{% if pdf_generator %}&pdf_generator={{pdf_generator|e}}{% endif %}">
 		{{ _('Get PDF') }}
 	</a>
 </div>

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -46,8 +46,11 @@ def get_qr_code(value: str) -> str:
 
 
 def get_html(doctype, name, print_format, letterhead=None, action_banner=None):
+	from frappe.www.printview import validate_print_permission
+
 	doc = frappe.get_doc(doctype, name)
-	doc.check_permission("print")
+	if not frappe.flags.ignore_print_permissions:
+		validate_print_permission(doc)
 	generator = PrintFormatGenerator(print_format, doc, letterhead)
 	return generator.get_html_preview(action_banner=action_banner)
 

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -45,11 +45,11 @@ def get_qr_code(value: str) -> str:
 	return "data:image/svg+xml;base64," + base64.b64encode(stream.getvalue()).decode()
 
 
-def get_html(doctype, name, print_format, letterhead=None):
+def get_html(doctype, name, print_format, letterhead=None, action_banner=None):
 	doc = frappe.get_doc(doctype, name)
 	doc.check_permission("print")
 	generator = PrintFormatGenerator(print_format, doc, letterhead)
-	return generator.get_html_preview()
+	return generator.get_html_preview(action_banner=action_banner)
 
 
 class PrintFormatGenerator:
@@ -102,10 +102,11 @@ class PrintFormatGenerator:
 
 	# ----- HTML preview (browser printview) ------------------------------
 
-	def get_html_preview(self):
+	def get_html_preview(self, action_banner=None):
 		header_html, footer_html = self.get_header_footer_html()
 		self.context.header = header_html
 		self.context.footer = footer_html
+		self.context.action_banner = action_banner
 		return self.get_main_html()
 
 	def get_main_html(self):

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -5,6 +5,7 @@ from typing import ClassVar
 
 import frappe
 from frappe import _
+from frappe.utils.jinja_globals import is_rtl
 
 
 @frappe.whitelist()
@@ -22,8 +23,10 @@ def render_jinja_template(template: str, doctype: str, docname: str) -> str:
 
 @frappe.whitelist()
 def download_pdf(doctype: str, name: str | int, print_format: str, letterhead: str | None = None):
+	from frappe.www.printview import validate_print_permission
+
 	doc = frappe.get_doc(doctype, name)
-	doc.check_permission("print")
+	validate_print_permission(doc)
 	generator = PrintFormatGenerator(print_format, doc, letterhead)
 	pdf = generator.render_pdf()
 
@@ -45,14 +48,15 @@ def get_qr_code(value: str) -> str:
 	return "data:image/svg+xml;base64," + base64.b64encode(stream.getvalue()).decode()
 
 
-def get_html(doctype, name, print_format, letterhead=None, action_banner=None):
+def get_html(
+	doctype, name, print_format, letterhead=None, action_banner=None, style=None, trigger_print=False
+):
 	from frappe.www.printview import validate_print_permission
 
 	doc = frappe.get_doc(doctype, name)
-	if not frappe.flags.ignore_print_permissions:
-		validate_print_permission(doc)
-	generator = PrintFormatGenerator(print_format, doc, letterhead)
-	return generator.get_html_preview(action_banner=action_banner)
+	validate_print_permission(doc)
+	generator = PrintFormatGenerator(print_format, doc, letterhead, style=style)
+	return generator.get_html_preview(action_banner=action_banner, trigger_print=trigger_print)
 
 
 class PrintFormatGenerator:
@@ -69,9 +73,10 @@ class PrintFormatGenerator:
 		"bottom_right": "right",
 	}
 
-	def __init__(self, print_format, doc, letterhead=None):
+	def __init__(self, print_format, doc, letterhead=None, style=None):
 		self.print_format = frappe.get_doc("Print Format", print_format)
 		self.doc = doc
+		self.style = style
 
 		if letterhead == _("No Letterhead"):
 			letterhead = None
@@ -86,11 +91,8 @@ class PrintFormatGenerator:
 		page_width_map = {"A4": 210, "Letter": 216}
 		page_width = page_width_map.get(self.print_settings.pdf_page_size) or 210
 		body_width = page_width - self.print_format.margin_left - self.print_format.margin_right
-		print_style = (
-			frappe.get_doc("Print Style", self.print_settings.print_style)
-			if self.print_settings.print_style
-			else None
-		)
+		style_name = self.style or self.print_settings.print_style
+		print_style = frappe.get_doc("Print Style", style_name) if style_name else None
 		self.context = frappe._dict(
 			{
 				"doc": self.doc,
@@ -100,16 +102,22 @@ class PrintFormatGenerator:
 				"letterhead": self.letterhead,
 				"page_width": page_width,
 				"body_width": body_width,
+				"lang": frappe.local.lang,
+				"layout_direction": "rtl" if is_rtl() else "ltr",
 			}
 		)
 
 	# ----- HTML preview (browser printview) ------------------------------
 
-	def get_html_preview(self, action_banner=None):
+	def get_html_preview(self, action_banner=None, trigger_print=False):
 		header_html, footer_html = self.get_header_footer_html()
 		self.context.header = header_html
 		self.context.footer = footer_html
 		self.context.action_banner = action_banner
+		if trigger_print:
+			from frappe.www.printview import trigger_print_script
+
+			self.context.trigger_print_script = trigger_print_script
 		return self.get_main_html()
 
 	def get_main_html(self):

--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -145,27 +145,28 @@ def attach_print(
 		print_format_doc = frappe.get_cached_doc("Print Format", print_format)
 		is_beta_print_format = print_format_doc.get("print_format_builder_beta")
 
-	with print_language(lang or frappe.local.lang):
-		content = ""
-		if cint(print_settings.send_print_as_pdf):
-			ext = ".pdf"
-			if html:
-				content = get_pdf(html, options={"password": password} if password else None)
-			elif is_beta_print_format:
-				from frappe.utils.print_format_generator import PrintFormatGenerator
+	try:
+		with print_language(lang or frappe.local.lang):
+			content = ""
+			if cint(print_settings.send_print_as_pdf):
+				ext = ".pdf"
+				if html:
+					content = get_pdf(html, options={"password": password} if password else None)
+				elif is_beta_print_format:
+					from frappe.utils.print_format_generator import PrintFormatGenerator
 
-				doc_obj = doc or frappe.get_cached_doc(doctype, name)
-				letterhead_name = letterhead if print_letterhead else None
-				generator = PrintFormatGenerator(print_format, doc_obj, letterhead_name)
-				content = generator.render_pdf()
+					doc_obj = doc or frappe.get_cached_doc(doctype, name)
+					letterhead_name = letterhead if print_letterhead else None
+					generator = PrintFormatGenerator(print_format, doc_obj, letterhead_name)
+					content = generator.render_pdf()
+				else:
+					kwargs["as_pdf"] = True
+					content = get_print(doctype, name, **kwargs)
 			else:
-				kwargs["as_pdf"] = True
-				content = get_print(doctype, name, **kwargs)
-		else:
-			ext = ".html"
-			content = html or scrub_urls(get_print(doctype, name, **kwargs)).encode("utf-8")
-
-	frappe.local.flags.ignore_print_permissions = False
+				ext = ".html"
+				content = html or scrub_urls(get_print(doctype, name, **kwargs)).encode("utf-8")
+	finally:
+		frappe.local.flags.ignore_print_permissions = False
 
 	if not file_name:
 		file_name = name

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -473,7 +473,7 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 			)
 			html = get_html("ToDo", todo.name, pf.name)
 			self.assertIn("margin-top: 11px", html)
-			self.assertIn("height: 1rem;height: 33px", html)
+			self.assertIn("height: 1em;height: 33px", html)
 			self.assertIn("border-bottom-color: #123456", html)
 
 		contact = self._make_contact_with_email()

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -9,12 +9,13 @@ language: same class names, same data attributes, same inline-style inputs.
 These tests fail when one surface learns a word the other doesn't know.
 """
 
+import functools
 import json
 import re
 from pathlib import Path
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, UnitTestCase
 
 APP_PATH = Path(frappe.get_app_path("frappe"))
 SHARED_CSS = APP_PATH / "templates" / "print_format" / "print_format_doc.css"
@@ -45,10 +46,22 @@ SERVER_ONLY_CLASSES = {
 CANVAS_ONLY_CLASSES = set()
 
 
-def _read(paths):
-	return "\n".join(p.read_text() for p in paths)
+@functools.cache
+def _server_text():
+	return "\n".join(p.read_text() for p in SERVER_SOURCES)
 
 
+@functools.cache
+def _canvas_text():
+	return "\n".join(p.read_text() for p in CANVAS_SOURCES)
+
+
+@functools.cache
+def _field_vue_text():
+	return (BUILDER_DIR / "components" / "editor" / "Field.vue").read_text()
+
+
+@functools.cache
 def _shared_css_selector_tokens():
 	"""Class names and data-* attributes used by the shared stylesheet's selectors."""
 	css = SHARED_CSS.read_text()
@@ -60,26 +73,27 @@ def _shared_css_selector_tokens():
 	return classes, data_attrs
 
 
+# Variant suffixes interpolated from field properties on both surfaces
+VARIANT_PREFIXES = (
+	"child-table--",
+	"field-align-",
+	"field-justify-",
+	"cell-line--",
+	"section--grid-",
+)
+
+
 def _present(token, haystack):
-	"""A token counts as present if it appears literally, or if it is a
-	dynamic-variant class (child-table--striped, field-justify-space-between)
-	whose composition prefix (child-table--, field-justify-) appears on that
-	surface — variant suffixes are interpolated from field properties."""
 	if token in haystack:
 		return True
-	parts = re.split(r"(-+)", token)  # keep separators
-	for i in range(len(parts) - 2, 0, -2):
-		prefix = "".join(parts[: i + 1])
-		if len(prefix) >= 5 and prefix in haystack:
-			return True
-	return False
+	return any(token.startswith(p) and p in haystack for p in VARIANT_PREFIXES)
 
 
-class TestPrintSurfaceParity(IntegrationTestCase):
+class TestPrintSurfaceMarkupContract(UnitTestCase):
 	def test_shared_stylesheet_classes_exist_on_both_surfaces(self):
 		classes, data_attrs = _shared_css_selector_tokens()
-		server = _read(SERVER_SOURCES)
-		canvas = _read(CANVAS_SOURCES)
+		server = _server_text()
+		canvas = _canvas_text()
 
 		missing_server = sorted(
 			t for t in classes | data_attrs if t not in CANVAS_ONLY_CLASSES and not _present(t, server)
@@ -102,10 +116,8 @@ class TestPrintSurfaceParity(IntegrationTestCase):
 		)
 
 	def test_scope_class_applied_on_both_surfaces(self):
-		server = _read(SERVER_SOURCES)
-		canvas = _read(CANVAS_SOURCES)
-		self.assertIn("print-format-doc", server)
-		self.assertIn("print-format-doc", canvas)
+		self.assertIn("print-format-doc", _server_text())
+		self.assertIn("print-format-doc", _canvas_text())
 
 	def test_data_html_field_properties_mirrored_in_canvas(self):
 		"""Every df.* property the regular-field macro reads must be handled by Field.vue."""
@@ -125,18 +137,15 @@ class TestPrintSurfaceParity(IntegrationTestCase):
 		skip = {"get", "renderer", "section", "html"}
 		macro = macro_path.read_text()
 		props = set(re.findall(r"df\.([a-z_]+)", macro)) - skip
-		field_vue = (BUILDER_DIR / "components" / "editor" / "Field.vue").read_text()
-		missing = sorted(p for p in props if f"df.{p}" not in field_vue)
+		missing = sorted(p for p in props if f"df.{p}" not in _field_vue_text())
 		self.assertFalse(
 			missing,
 			f"{macro_path.name} reads df properties {missing} that Field.vue never handles — "
 			"the canvas preview will silently ignore them. Mirror them in Field.vue's preview markup.",
 		)
 
-	# ------------------------------------------------------------------ #
-	# rendered-HTML contract
-	# ------------------------------------------------------------------ #
 
+class TestPrintSurfaceParity(IntegrationTestCase):
 	def _make_contact_format(self):
 		name = f"_Test PFP {frappe.generate_hash(length=6)}"
 		doc = frappe.get_doc(

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+"""Parity guards between the two print surfaces.
+
+The builder canvas (Vue) and the server render (Jinja) share one stylesheet
+(templates/print_format/print_format_doc.css) and must emit the same markup
+language: same class names, same data attributes, same inline-style inputs.
+These tests fail when one surface learns a word the other doesn't know.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+APP_PATH = Path(frappe.get_app_path("frappe"))
+SHARED_CSS = APP_PATH / "templates" / "print_format" / "print_format_doc.css"
+
+SERVER_SOURCES = [
+	APP_PATH / "templates" / "print_format" / "print_format.html",
+	APP_PATH / "templates" / "print_format" / "print_format.css",
+	APP_PATH / "templates" / "print_format" / "print_header.html",
+	APP_PATH / "templates" / "print_format" / "print_footer.html",
+	APP_PATH / "templates" / "print_format" / "macros.html",
+	*sorted((APP_PATH / "templates" / "print_format" / "macros").glob("*.html")),
+	APP_PATH / "templates" / "print_formats" / "chrome_pdf_header_footer.html",
+]
+
+BUILDER_DIR = APP_PATH / "public" / "js" / "print_format_builder"
+CANVAS_SOURCES = sorted(BUILDER_DIR.rglob("*.vue"))
+
+# Classes that legitimately exist on only one surface.
+SERVER_ONLY_CLASSES = {
+	# letterhead HTML is user-authored and rendered server-side only
+	"letter-head",
+	# star SVGs come from macros/Rating.html; the canvas previews the numeric value
+	"rating-star",
+	"active",
+	# Chrome PDF overlay wrapper (templates/print_formats/chrome_pdf_header_footer.html)
+	"document-header",
+}
+CANVAS_ONLY_CLASSES = set()
+
+
+def _read(paths):
+	return "\n".join(p.read_text() for p in paths)
+
+
+def _shared_css_selector_tokens():
+	"""Class names and data-* attributes used by the shared stylesheet's selectors."""
+	css = SHARED_CSS.read_text()
+	css = re.sub(r"/\*.*?\*/", "", css, flags=re.S)
+	selectors = " ".join(re.findall(r"(?:^|})([^{}@]*?){", css, flags=re.S))
+	classes = set(re.findall(r"\.([A-Za-z][\w-]*)", selectors))
+	data_attrs = set(re.findall(r"\[(data-[\w-]+)", selectors))
+	classes.discard("print-format-doc")  # the scope itself is asserted separately
+	return classes, data_attrs
+
+
+def _present(token, haystack):
+	"""A token counts as present if it appears literally, or if it is a
+	dynamic-variant class (child-table--striped, field-justify-space-between)
+	whose composition prefix (child-table--, field-justify-) appears on that
+	surface — variant suffixes are interpolated from field properties."""
+	if token in haystack:
+		return True
+	parts = re.split(r"(-+)", token)  # keep separators
+	for i in range(len(parts) - 2, 0, -2):
+		prefix = "".join(parts[: i + 1])
+		if len(prefix) >= 5 and prefix in haystack:
+			return True
+	return False
+
+
+class TestPrintSurfaceParity(IntegrationTestCase):
+	def test_shared_stylesheet_classes_exist_on_both_surfaces(self):
+		classes, data_attrs = _shared_css_selector_tokens()
+		server = _read(SERVER_SOURCES)
+		canvas = _read(CANVAS_SOURCES)
+
+		missing_server = sorted(
+			t for t in classes | data_attrs if t not in CANVAS_ONLY_CLASSES and not _present(t, server)
+		)
+		missing_canvas = sorted(
+			t for t in classes | data_attrs if t not in SERVER_ONLY_CLASSES and not _present(t, canvas)
+		)
+
+		self.assertFalse(
+			missing_server,
+			f"print_format_doc.css styles {missing_server}, but no server template emits them. "
+			"Either emit them in templates/print_format/ or add them to CANVAS_ONLY_CLASSES "
+			"with a comment saying why the PDF render can never produce them.",
+		)
+		self.assertFalse(
+			missing_canvas,
+			f"print_format_doc.css styles {missing_canvas}, but the builder canvas never emits them. "
+			"Either emit them in public/js/print_format_builder/ (preview mode must mirror the "
+			"server markup) or add them to SERVER_ONLY_CLASSES with a comment saying why.",
+		)
+
+	def test_scope_class_applied_on_both_surfaces(self):
+		server = _read(SERVER_SOURCES)
+		canvas = _read(CANVAS_SOURCES)
+		self.assertIn("print-format-doc", server)
+		self.assertIn("print-format-doc", canvas)
+
+	def test_data_html_field_properties_mirrored_in_canvas(self):
+		"""Every df.* property the regular-field macro reads must be handled by Field.vue."""
+		self._assert_df_props_mirrored(APP_PATH / "templates" / "print_format" / "macros" / "Data.html")
+
+	def test_table_macro_properties_mirrored_in_canvas(self):
+		"""Every df.* property the child-table macro reads (cell padding, border
+		colour, header background, ...) must be handled by Field.vue — these are
+		inline styles, so the stylesheet can't catch drift here."""
+		self._assert_df_props_mirrored(APP_PATH / "templates" / "print_format" / "macros" / "Table.html")
+
+	def test_repeater_macro_properties_mirrored_in_canvas(self):
+		self._assert_df_props_mirrored(APP_PATH / "templates" / "print_format" / "macros" / "Repeater.html")
+
+	def _assert_df_props_mirrored(self, macro_path):
+		# properties that are server-render concerns, not canvas inputs
+		skip = {"get", "renderer", "section", "html"}
+		macro = macro_path.read_text()
+		props = set(re.findall(r"df\.([a-z_]+)", macro)) - skip
+		field_vue = (BUILDER_DIR / "components" / "editor" / "Field.vue").read_text()
+		missing = sorted(p for p in props if f"df.{p}" not in field_vue)
+		self.assertFalse(
+			missing,
+			f"{macro_path.name} reads df properties {missing} that Field.vue never handles — "
+			"the canvas preview will silently ignore them. Mirror them in Field.vue's preview markup.",
+		)
+
+	# ------------------------------------------------------------------ #
+	# rendered-HTML contract
+	# ------------------------------------------------------------------ #
+
+	def _make_contact_format(self):
+		name = f"_Test PFP {frappe.generate_hash(length=6)}"
+		doc = frappe.get_doc(
+			{
+				"doctype": "Print Format",
+				"name": name,
+				"doc_type": "Contact",
+				"print_format_builder_beta": 1,
+				"custom_format": 0,
+				"standard": "No",
+				"format_data": json.dumps(
+					{
+						"sections": [
+							{
+								"label": "Details",
+								"columns": [
+									{
+										"label": "",
+										"fields": [
+											{
+												"fieldtype": "Data",
+												"fieldname": "first_name",
+												"label": "First Name",
+											},
+											{
+												"fieldtype": "Table",
+												"fieldname": "email_ids",
+												"label": "Emails",
+												"table_columns": [
+													{
+														"fieldtype": "Int",
+														"fieldname": "idx",
+														"label": "No.",
+														"width": 10,
+													},
+													{
+														"fieldtype": "Data",
+														"fieldname": "email_id",
+														"label": "Email",
+														"width": 90,
+													},
+												],
+											},
+										],
+									}
+								],
+							}
+						],
+						"header": {"columns": [{"label": "", "fields": []}]},
+						"footer": {"columns": [{"label": "", "fields": []}]},
+					}
+				),
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		self.addCleanup(doc.delete, ignore_permissions=True)
+		return doc
+
+	def _make_contact(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Contact",
+				"first_name": "Parity",
+				"email_ids": [{"email_id": "parity@example.com", "is_primary": 1}],
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		self.addCleanup(doc.delete, ignore_permissions=True)
+		return doc
+
+	def test_rendered_html_carries_shared_markup_contract(self):
+		"""The server render must produce the markup vocabulary the shared
+		stylesheet and the canvas both rely on."""
+		from frappe.utils.print_format_generator import get_html
+
+		fmt = self._make_contact_format()
+		contact = self._make_contact()
+		html = get_html("Contact", contact.name, fmt.name)
+
+		for token in (
+			'class="print-format-doc"',
+			'class="section-label"',
+			'class="label"',
+			'class="value"',
+			'data-fieldname="first_name"',
+			'data-fieldtype="Data"',
+			"child-table child-table--lined",
+			'<table class="table table-bordered">',
+			"column-header",
+			'data-fieldname="idx"',
+			'data-fieldname="email_id"',
+			"section-columns row",
+		):
+			self.assertIn(token, html)

--- a/frappe/www/printview.html
+++ b/frappe/www/printview.html
@@ -1,3 +1,6 @@
+{%- if standalone -%}
+{{ body }}
+{%- else -%}
 <!DOCTYPE html>
 <html lang="{{ lang }}" dir="{{ layout_direction }}">
 <head>
@@ -14,15 +17,7 @@
 	{% endif %}
 </head>
 <body>
-	<div class="action-banner print-hide">
-		<a class="p-2" onclick="window.print();">
-			{{ _("Print") }}
-		</a>
-		<a class="p-2"
-			href="/api/method/frappe.utils.print_format.download_pdf?doctype={{doctype|e}}&name={{name|e}}&format={{print_format|e}}&letterhead={{letterhead|e}}&no_letterhead={{no_letterhead|e}}&_lang={{lang|e}}&key={{key|e}}&pdf_generator={{pdf_generator|e}}">
-			{{ _('Get PDF') }}
-		</a>
-	</div>
+	{% include "templates/print_formats/print_action_banner.html" %}
 	<div class="print-format-gutter">
 		<div class="print-format">
 			{{ body }}
@@ -52,3 +47,4 @@
 <!-- {{ comment }} -->
 {%- endif -%}
 </html>
+{%- endif -%}

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -72,7 +72,16 @@ def get_context(context) -> PrintContext:
 
 	print_format = get_print_format_doc(None, meta=meta)
 
-	if print_format and print_format.get("print_format_builder_beta") and print_format.get("format_data"):
+	print_format_name = getattr(print_format, "name", "Standard")
+	pdf_generator = frappe.form_dict.get(
+		"pdf_generator", getattr(print_format, "pdf_generator", "wkhtmltopdf")
+	)
+
+	standalone = bool(
+		print_format and print_format.get("print_format_builder_beta") and print_format.get("format_data")
+	)
+
+	if standalone:
 		from frappe.utils.print_format_generator import get_html
 
 		body = get_html(
@@ -80,8 +89,22 @@ def get_context(context) -> PrintContext:
 			name=frappe.form_dict.name,
 			print_format=print_format.name,
 			letterhead=letterhead,
+			action_banner=frappe.render_template(
+				"templates/print_formats/print_action_banner.html",
+				{
+					"doctype": frappe.form_dict.doctype,
+					"name": frappe.form_dict.name,
+					"print_format": print_format_name,
+					"letterhead": letterhead,
+					"no_letterhead": frappe.form_dict.no_letterhead,
+					"lang": frappe.local.lang,
+					"key": frappe.form_dict.get("key"),
+					"pdf_generator": pdf_generator,
+				},
+			),
 		)
-		body += trigger_print_script
+		if cint(frappe.form_dict.trigger_print):
+			body += trigger_print_script
 	else:
 		body = get_rendered_template(
 			doc,
@@ -93,10 +116,6 @@ def get_context(context) -> PrintContext:
 			settings=settings,
 		)
 
-	# Include selected print format name in access log
-	print_format_name = getattr(print_format, "name", "Standard")
-	pdf_generator = getattr(print_format, "pdf_generator", "wkhtmltopdf")
-
 	make_access_log(
 		doctype=frappe.form_dict.doctype,
 		document=frappe.form_dict.name,
@@ -107,7 +126,8 @@ def get_context(context) -> PrintContext:
 
 	return {
 		"body": body,
-		"print_style": get_print_style(frappe.form_dict.style, print_format),
+		"standalone": standalone,
+		"print_style": "" if standalone else get_print_style(frappe.form_dict.style, print_format),
 		"comment": frappe.session.user,
 		"title": frappe.utils.strip_html(cstr(doc.get_title() or doc.name)),
 		"lang": frappe.local.lang,
@@ -118,7 +138,7 @@ def get_context(context) -> PrintContext:
 		"print_format": print_format_name,
 		"letterhead": letterhead,
 		"no_letterhead": frappe.form_dict.no_letterhead,
-		"pdf_generator": frappe.form_dict.get("pdf_generator", pdf_generator),
+		"pdf_generator": pdf_generator,
 	}
 
 

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -81,6 +81,21 @@ def get_context(context) -> PrintContext:
 		print_format and print_format.get("print_format_builder_beta") and print_format.get("format_data")
 	)
 
+	context = {
+		"standalone": standalone,
+		"comment": frappe.session.user,
+		"title": frappe.utils.strip_html(cstr(doc.get_title() or doc.name)),
+		"lang": frappe.local.lang,
+		"layout_direction": "rtl" if is_rtl() else "ltr",
+		"doctype": frappe.form_dict.doctype,
+		"name": frappe.form_dict.name,
+		"key": frappe.form_dict.get("key"),
+		"print_format": print_format_name,
+		"letterhead": letterhead,
+		"no_letterhead": frappe.form_dict.no_letterhead,
+		"pdf_generator": pdf_generator,
+	}
+
 	if standalone:
 		from frappe.utils.print_format_generator import get_html
 
@@ -89,22 +104,10 @@ def get_context(context) -> PrintContext:
 			name=frappe.form_dict.name,
 			print_format=print_format.name,
 			letterhead=letterhead,
-			action_banner=frappe.render_template(
-				"templates/print_formats/print_action_banner.html",
-				{
-					"doctype": frappe.form_dict.doctype,
-					"name": frappe.form_dict.name,
-					"print_format": print_format_name,
-					"letterhead": letterhead,
-					"no_letterhead": frappe.form_dict.no_letterhead,
-					"lang": frappe.local.lang,
-					"key": frappe.form_dict.get("key"),
-					"pdf_generator": pdf_generator,
-				},
-			),
+			style=frappe.form_dict.style,
+			trigger_print=cint(frappe.form_dict.trigger_print),
+			action_banner=frappe.render_template("templates/print_formats/print_action_banner.html", context),
 		)
-		if cint(frappe.form_dict.trigger_print):
-			body += trigger_print_script
 	else:
 		body = get_rendered_template(
 			doc,
@@ -124,22 +127,13 @@ def get_context(context) -> PrintContext:
 		page=f"Print Format: {print_format_name}",
 	)
 
-	return {
-		"body": body,
-		"standalone": standalone,
-		"print_style": "" if standalone else get_print_style(frappe.form_dict.style, print_format),
-		"comment": frappe.session.user,
-		"title": frappe.utils.strip_html(cstr(doc.get_title() or doc.name)),
-		"lang": frappe.local.lang,
-		"layout_direction": "rtl" if is_rtl() else "ltr",
-		"doctype": frappe.form_dict.doctype,
-		"name": frappe.form_dict.name,
-		"key": frappe.form_dict.get("key"),
-		"print_format": print_format_name,
-		"letterhead": letterhead,
-		"no_letterhead": frappe.form_dict.no_letterhead,
-		"pdf_generator": pdf_generator,
-	}
+	context.update(
+		{
+			"body": body,
+			"print_style": "" if standalone else get_print_style(frappe.form_dict.style, print_format),
+		}
+	)
+	return context
 
 
 def get_print_format_doc(print_format_name: str, meta: "Meta") -> "PrintFormat" | None:
@@ -166,8 +160,7 @@ def get_rendered_template(
 	trigger_print: bool = False,
 	settings: dict | None = None,
 ) -> str:
-	if not frappe.flags.ignore_print_permissions:
-		validate_print_permission(doc)
+	validate_print_permission(doc)
 
 	print_settings = frappe.get_single("Print Settings").as_dict()
 	print_settings.update(settings or {})
@@ -424,6 +417,9 @@ def get_rendered_raw_commands(
 
 
 def validate_print_permission(doc: "Document") -> None:
+	if frappe.flags.ignore_print_permissions:
+		return
+
 	for ptype in ("read", "print"):
 		if frappe.has_permission(doc.doctype, ptype, doc):
 			return


### PR DESCRIPTION
Follow-up to #40744 — closes the remaining gaps between the builder canvas and the real print output, and adds tests that keep the two surfaces from drifting again.

- Shared stylesheet spacing converted from rem to compensated em: the canvas lives inside the desk page where rem resolves against the desk root, so spacing previously ran ~14% wide vs the PDF. All values now resolve against the format's font size on both surfaces (wkhtmltopdf output verified byte-identical, Chrome pixel-identical except a sub-pixel rounding nudge on one label).
- Canvas preview now emits the server's exact markup per fieldtype (`.field`/`.label`/`.value`, `left-right`/`field-inline`/`field-align-*`/`field-justify-*`, bare `.child-table`, `.pfb-repeater`, `custom-html`, `print-image`, data attributes on the field root) and the deprecated parallel `field-preview-*` skin is deleted. Section columns mirror the server's `row`/`col`/`row-col-*` classes and default 20px gap. Selection chrome is outline-only so it never changes geometry.
- Format-level label/value colours are injected as the same scoped rules the server appends after the shared stylesheet, so the cascade is identical.
- New parity contract tests: every class/data-attribute in `print_format_doc.css` must be emitted by both surfaces (with an explicit allowlist), every `df.*` property read by `Data.html`/`Table.html`/`Repeater.html` must be handled by `Field.vue` (guards the inline-style twins), and the rendered HTML must carry the shared markup vocabulary.

Why: the builder preview must be a truthful preview — same stylesheet, same markup, same numbers.
- /printview serves beta formats standalone through `PrintFormatGenerator` instead of the legacy template path, with a print action banner replacing the desk toolbar.
- Document share key (`?key=`) links now grant guest access to beta formats: `get_html` routes through the key-aware `validate_print_permission` instead of a bare `check_permission("print")`.
