### PR TITLE
fix: password strength check fails on long random passwords

### DIFF
--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -27,6 +27,7 @@ from frappe.tests.classes.context_managers import change_settings
 from frappe.tests.test_api import FrappeAPITestCase
 from frappe.tests.utils import toggle_test_mode
 from frappe.utils import get_url
+from frappe.utils.data import orjson_dumps
 from frappe.www.login import sanitize_redirect
 
 user_module = frappe.core.doctype.user.user
@@ -207,6 +208,10 @@ class TestUser(IntegrationTestCase):
 			# Score 4; should pass
 			result = test_password_strength("Eastern_43A1W")
 			self.assertEqual(result["feedback"]["password_policy_validation_passed"], True)
+
+			result = test_password_strength("xK9#mP2$vL8@qR5&wN3*zB7!cF4^hJ6%tD1(gS0)yA9-eU2_iO5+kM8=nQ4~rV7")
+			self.assertEqual(set(result), {"score", "feedback"})
+			orjson_dumps(result)
 
 			# test password strength while saving user with new password
 			user = frappe.get_doc("User", "test@example.com")

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1043,8 +1043,7 @@ def test_password_strength(
 			password_policy_validation_passed = True
 
 		result["feedback"]["password_policy_validation_passed"] = password_policy_validation_passed
-		result.pop("password", None)
-		return result
+		return {"score": result["score"], "feedback": result["feedback"]}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Pasting a long random string - such as a password-manager-generated password or an API key stored in a Password field; causes `test_password_strength` to return a **500**. In the browser, the only visible error is:

```text
SyntaxError: Unexpected token '<' ... is not valid JSON
```

This happens because the error response also fails to serialize, so the client receives an HTML error page instead of JSON.

```text
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 125, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 70, in handle
    data = build_response("json")
  File "apps/frappe/frappe/utils/response.py", line 106, in build_response
    return response_type_map[frappe.response.get("type") or response_type]()
  File "apps/frappe/frappe/utils/response.py", line 155, in as_json
    response.data = orjson_dumps(frappe.local.response, default=json_handler)
  File "apps/frappe/frappe/utils/data.py", line 2675, in orjson_dumps
    value = orjson.dumps(obj, default, option)
TypeError: Integer exceeds 64-bit range
```

The endpoint currently returns the full `zxcvbn` result. For high-entropy input, `zxcvbn`'s `guesses` value can exceed the 64-bit integer range, which `orjson` refuses to serialize. This change returns only `score` and `feedback`, the only fields consumed by the Desk password control, `update-password.html`, and server-side password policy checks. 

The `frappe.utils.password_strength` wrapper remains unchanged, so save-time validation continues to receive the full `zxcvbn` result.