### PR TITLE
fix: report_error crashes when response has unserializable values

### DIFF
--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -387,6 +387,16 @@ class TestMethodAPI(FrappeAPITestCase):
 
 		self.assertEqual(response.json["message"], test_data)
 
+	def test_unserializable_response_v1(self):
+		method = "frappe.tests.test_api.test_unserializable_response"
+
+		with suppress_stdout():
+			response = self.get(self.method(method), {"sid": self.sid})
+
+		self.assertEqual(response.status_code, 500)
+		self.assertEqual(response.json["exc_type"], "TypeError")
+		self.assertIn("Integer exceeds 64-bit range", response.json["exception"])
+
 
 class TestReadOnlyMode(FrappeAPITestCase):
 	"""During migration if read only mode can be enabled.
@@ -560,3 +570,8 @@ def test(
 @whitelist_for_tests(allow_guest=True)
 def test_array(data: typing.Any):
 	return data
+
+
+@whitelist_for_tests()
+def test_unserializable_response():
+	frappe.response["value"] = 2**70

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -208,6 +208,15 @@ class TestMethodAPIV2(FrappeAPITestCase):
 		)
 		self.assertEqual(expanded_response.data, shorthand_response.data)
 
+	def test_unserializable_response_v2(self):
+		method = "frappe.tests.test_api.test_unserializable_response"
+
+		with suppress_stdout():
+			response = self.get(self.method(method), {"sid": self.sid})
+
+		self.assertEqual(response.status_code, 500)
+		self.assertEqual(response.json["errors"][0]["type"], "TypeError")
+
 	def test_logout_v2(self):
 		self.post(self.method("logout"), {"sid": self.sid})
 		response = self.get(self.method("ping"))

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -59,7 +59,15 @@ def report_error(status_code):
 			_link_error_with_message_log(error_log, exc_value, frappe.message_log)
 			frappe.local.response.errors = [error_log]
 
-	response = build_response("json")
+	try:
+		response = build_response("json")
+	except TypeError:
+		error_keys = ("exception", "exc_type", "errors")
+		frappe.local.response = frappe._dict(
+			{key: frappe.local.response[key] for key in error_keys if key in frappe.local.response}
+		)
+		response = build_response("json")
+
 	response.status_code = status_code
 
 	return response

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -66,7 +66,10 @@ def report_error(status_code):
 		frappe.local.response = frappe._dict(
 			{key: frappe.local.response[key] for key in error_keys if key in frappe.local.response}
 		)
-		response = build_response("json")
+		try:
+			response = build_response("json")
+		except TypeError:
+			response = Response(orjson.dumps({"exc_type": exc_type.__name__}), mimetype="application/json")
 
 	response.status_code = status_code
 


### PR DESCRIPTION
When `frappe.local.response` contains a value that `orjson` cannot serialize (for example, an integer exceeding 64 bits), `as_json` fails while building the response. `report_error` then retries with the same response dictionary and fails identically, so the client receives Werkzeug's HTML 500 page instead of a JSON error.

```text
File "apps/frappe/frappe/utils/response.py", line 155, in as_json
TypeError: Integer exceeds 64-bit range

During handling of the above exception, another exception occurred:

File "apps/frappe/frappe/utils/response.py", line 62, in report_error
TypeError: Integer exceeds 64-bit range
```

Retry serialization with a minimal error-only response (`exception`, `exc_type`/`errors`) instead of reusing the original response. Successful requests are unaffected.

Surfaced/Related while fixing #40783.