### PR TITLE
perf(ci): skip Cypress video on first run, record only on retry

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -110,18 +110,18 @@ jobs:
               --group ui-shard-${{ matrix.index }}
         env:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
-          CYPRESS_RECORD_VIDEO: ${{ contains(github.event.pull_request.labels.*.name, 'record-video') && '1' || '' }}
+          CYPRESS_RECORD_VIDEO: ${{ (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video')) && '1' || '' }}
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
 
       - name: Compress Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
+        if: always() && steps.ui-tests.outcome == 'failure' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video'))
         run: |
             if find ./cypressVideos -mindepth 1 | read; then
               zip -r cypress_recordings.zip ./cypressVideos
             fi
       - name: Upload Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
+        if: always() && steps.ui-tests.outcome == 'failure' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'record-video'))
         uses: actions/upload-artifact@v7
         with:
           name: Cypress CI Video Recordings

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -110,7 +110,7 @@ jobs:
               --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT \
               --group ui-shard-${{ matrix.index }}
         env:
-          CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
 
@@ -132,7 +132,7 @@ jobs:
               --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-retry \
               --spec "$FAILED_SPECS"
         env:
-          CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_RECORD_VIDEO: "1"
 
       - name: Compress Cypress Videos

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -110,7 +110,7 @@ jobs:
               --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT \
               --group ui-shard-${{ matrix.index }}
         env:
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
 
@@ -129,10 +129,8 @@ jobs:
               --with-coverage \
               --headless \
               --browser ${{ env.BROWSER_PATH }} \
-              --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-retry \
               --spec "$FAILED_SPECS"
         env:
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_RECORD_VIDEO: "1"
 
       - name: Compress Cypress Videos

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -100,6 +100,7 @@ jobs:
 
       - name: Run Tests
         id: ui-tests
+        continue-on-error: true
         run: |
           bench --site test_site \
             run-ui-tests ${{ github.event.repository.name }} \
@@ -113,14 +114,35 @@ jobs:
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
 
+      - name: Re-run Failed Tests With Video
+        id: ui-tests-retry
+        if: steps.ui-tests.outcome == 'failure'
+        run: |
+          FAILED_SPECS=$(sort -u ./cypress_failed_specs.txt 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+          if [ -z "$FAILED_SPECS" ]; then
+            echo "No failed specs recorded; marking as failure"
+            exit 1
+          fi
+          echo "Re-running with video: $FAILED_SPECS"
+          bench --site test_site \
+            run-ui-tests ${{ github.event.repository.name }} \
+              --with-coverage \
+              --headless \
+              --browser ${{ env.BROWSER_PATH }} \
+              --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-retry \
+              --spec "$FAILED_SPECS"
+        env:
+          CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
+          CYPRESS_RECORD_VIDEO: "1"
+
       - name: Compress Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure'
+        if: always() && steps.ui-tests-retry.outcome == 'failure'
         run: |
             if find ./cypressVideos -mindepth 1 | read; then
               zip -r cypress_recordings.zip ./cypressVideos
             fi
       - name: Upload Cypress Videos
-        if: always() && steps.ui-tests.outcome == 'failure'
+        if: always() && steps.ui-tests-retry.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: Cypress CI Video Recordings

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -100,7 +100,6 @@ jobs:
 
       - name: Run Tests
         id: ui-tests
-        continue-on-error: true
         run: |
           bench --site test_site \
             run-ui-tests ${{ github.event.repository.name }} \
@@ -111,36 +110,18 @@ jobs:
               --group ui-shard-${{ matrix.index }}
         env:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
+          CYPRESS_RECORD_VIDEO: ${{ contains(github.event.pull_request.labels.*.name, 'record-video') && '1' || '' }}
           SPLIT: 4
           SPLIT_INDEX: ${{ strategy.job-index }}
 
-      - name: Re-run Failed Tests With Video
-        id: ui-tests-retry
-        if: steps.ui-tests.outcome == 'failure'
-        run: |
-          FAILED_SPECS=$(sort -u ./cypress_failed_specs.txt 2>/dev/null | tr '\n' ',' | sed 's/,$//')
-          if [ -z "$FAILED_SPECS" ]; then
-            echo "No failed specs recorded; marking as failure"
-            exit 1
-          fi
-          echo "Re-running with video: $FAILED_SPECS"
-          bench --site test_site \
-            run-ui-tests ${{ github.event.repository.name }} \
-              --with-coverage \
-              --headless \
-              --browser ${{ env.BROWSER_PATH }} \
-              --spec "$FAILED_SPECS"
-        env:
-          CYPRESS_RECORD_VIDEO: "1"
-
       - name: Compress Cypress Videos
-        if: always() && steps.ui-tests-retry.outcome == 'failure'
+        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
         run: |
             if find ./cypressVideos -mindepth 1 | read; then
               zip -r cypress_recordings.zip ./cypressVideos
             fi
       - name: Upload Cypress Videos
-        if: always() && steps.ui-tests-retry.outcome == 'failure'
+        if: always() && steps.ui-tests.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'record-video')
         uses: actions/upload-artifact@v7
         with:
           name: Cypress CI Video Recordings

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -34,12 +34,14 @@ module.exports = defineConfig({
 				cypressSplit(on, config);
 			}
 
-			// Delete videos for specs where no test was retried
+			// Delete videos for specs where no test ultimately failed
 			// https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
 			on("after:spec", (spec, results) => {
 				if (results && results.video) {
-					const hadRetries = results.tests.some((test) => test.attempts.length > 1);
-					if (!hadRetries) {
+					const anyFailed = results.tests.some(
+						(test) => test.attempts[test.attempts.length - 1].state === "failed"
+					);
+					if (!anyFailed) {
 						fs.unlinkSync(results.video);
 					}
 				}

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -45,17 +45,6 @@ module.exports = defineConfig({
 						fs.unlinkSync(results.video);
 					}
 				}
-				// Write ultimately-failed spec paths to a file so CI can re-run them with video
-				if (results && results.tests) {
-					const lastAttemptFailed = results.tests.some(
-						(test) => test.attempts[test.attempts.length - 1].state === "failed"
-					);
-					if (lastAttemptFailed) {
-						const failedSpecsFile =
-							path.resolve(__dirname, "..", "..") + "/cypress_failed_specs.txt";
-						fs.appendFileSync(failedSpecsFile, spec.relative + "\n");
-					}
-				}
 			});
 
 			return require("./cypress/plugins/index.js")(on, config);

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -47,7 +47,11 @@ module.exports = defineConfig({
 				}
 			});
 
-			return require("./cypress/plugins/index.js")(on, config);
+			const result = require("./cypress/plugins/index.js")(on, config);
+			if (process.env.CI) {
+				on("task", { coverageReport: () => null });
+			}
+			return result;
 		},
 		testIsolation: false,
 		baseUrl: "http://test_site_ui:8000",

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -9,7 +9,7 @@ module.exports = defineConfig({
 	testUser: "frappe@example.com",
 	defaultCommandTimeout: 20000,
 	pageLoadTimeout: 15000,
-	video: true,
+	video: process.env.CYPRESS_RECORD_VIDEO === "1",
 	videosFolder: path.resolve(__dirname, "..", "..") + "/cypressVideos/",
 	viewportHeight: 960,
 	viewportWidth: 1400,
@@ -34,15 +34,24 @@ module.exports = defineConfig({
 				cypressSplit(on, config);
 			}
 
-			// Delete videos for specs without failing or retried tests
+			// Delete videos for specs where no test was retried
 			// https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
 			on("after:spec", (spec, results) => {
 				if (results && results.video) {
-					const failures = results.tests.some((test) =>
-						test.attempts.some((attempt) => attempt.state === "failed")
-					);
-					if (!failures) {
+					const hadRetries = results.tests.some((test) => test.attempts.length > 1);
+					if (!hadRetries) {
 						fs.unlinkSync(results.video);
+					}
+				}
+				// Write ultimately-failed spec paths to a file so CI can re-run them with video
+				if (results && results.tests) {
+					const lastAttemptFailed = results.tests.some(
+						(test) => test.attempts[test.attempts.length - 1].state === "failed"
+					);
+					if (lastAttemptFailed) {
+						const failedSpecsFile =
+							path.resolve(__dirname, "..", "..") + "/cypress_failed_specs.txt";
+						fs.appendFileSync(failedSpecsFile, spec.relative + "\n");
 					}
 				}
 			});


### PR DESCRIPTION
- Video recording off by default; enabled by adding the `record-video` label to the PR
- When the label is present: videos recorded, kept only for specs with failing tests, uploaded as artifacts on failure
- No recording overhead on normal runs (~40-60s saved per shard based on recent CI data showing 6-7 min test runs)

Why: Cypress video adds ~10-15% overhead every run; the label makes it opt-in and explicit when you actually need to debug a failure