### PR TITLE
feat(print-format-builder): zone divider polish, inline title row, drag-resize table columns

### DIFF
--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -587,6 +587,201 @@ context("Print Format Builder — section insert", () => {
 	});
 });
 
+// ─── Column width resize ──────────────────────────────────────────────────────
+
+context("Print Format Builder — column width resize", () => {
+	let PF_NAME;
+
+	before(() => {
+		cy.login();
+		cy.visit("/app");
+	});
+
+	beforeEach(() => {
+		PF_NAME = pf_name();
+	});
+
+	afterEach(() => {
+		cy.window().then((win) => cleanup(win, PF_NAME));
+	});
+
+	function two_column_section() {
+		return [
+			{
+				label: "Two Cols",
+				columns: [
+					{
+						label: "",
+						fields: [
+							{ fieldtype: "Data", fieldname: "description", label: "Description" },
+						],
+					},
+					{
+						label: "",
+						fields: [{ fieldtype: "Data", fieldname: "status", label: "Status" }],
+					},
+				],
+			},
+		];
+	}
+
+	function drag_handle(selector, dx) {
+		cy.get(selector)
+			.first()
+			.then(($h) => {
+				const rect = $h[0].getBoundingClientRect();
+				const x = rect.left + rect.width / 2;
+				const y = rect.top + rect.height / 2;
+				const opts = { button: 0, pointerId: 1, pointerType: "mouse", isPrimary: true };
+				cy.wrap($h).trigger("pointerdown", { ...opts, clientX: x, clientY: y });
+				cy.get("body")
+					.trigger("pointermove", { ...opts, clientX: x + dx, clientY: y })
+					.trigger("pointerup", { ...opts, clientX: x + dx, clientY: y });
+			});
+	}
+
+	// 16. One handle per column boundary; none for a single-column section
+	it("renders a resize handle only between section columns", () => {
+		insert_builder_format(PF_NAME, [
+			...two_column_section(),
+			{ label: "One Col", columns: [{ label: "", fields: [] }] },
+		]);
+
+		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
+		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
+
+		cy.contains("[data-pfb-section]", "Two Cols")
+			.find(".col-width-handle")
+			.should("have.length", 1);
+		cy.contains("[data-pfb-section]", "One Col")
+			.find(".col-width-handle")
+			.should("have.length", 0);
+	});
+
+	// 17. Dragging the boundary applies flex ratios on the canvas and persists
+	// column widths in format_data on save
+	it("dragging the section column handle resizes and persists widths", () => {
+		insert_builder_format(PF_NAME, two_column_section());
+
+		cy.intercept("POST", "api/method/frappe.client.save").as("save");
+		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
+		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
+
+		cy.get(".sections-container .column").first().should("not.have.attr", "style");
+
+		cy.get(".sections-container .section-columns")
+			.first()
+			.then(($sc) => {
+				const total = $sc[0].getBoundingClientRect().width;
+				drag_handle(".sections-container .col-width-handle", -total * 0.2);
+			});
+
+		cy.get(".sections-container .column")
+			.first()
+			.should(($el) => {
+				const flex_grow = parseInt($el.css("flex-grow"), 10);
+				expect(flex_grow).to.be.within(25, 35);
+			});
+		cy.get(".sections-container .column")
+			.eq(1)
+			.should(($el) => {
+				const flex_grow = parseInt($el.css("flex-grow"), 10);
+				expect(flex_grow).to.be.within(65, 75);
+			});
+
+		cy.contains(".page-actions .primary-action", "Save").click({ force: true });
+		cy.wait("@save").then((interception) => {
+			expect(interception.response.statusCode).to.equal(200);
+			const layout = JSON.parse(interception.response.body.message.format_data);
+			const cols = layout.sections[0].columns;
+			// the container gap is excluded from measured widths and each width
+			// is rounded, so the sum lands a few points under 100
+			expect(cols[0].width).to.be.within(23, 38);
+			expect(cols[1].width).to.be.within(60, 77);
+			expect(cols[0].width + cols[1].width).to.be.within(88, 100);
+		});
+	});
+
+	// 18. Dragging respects the 10% minimum per column
+	it("section column resize clamps at the 10% minimum", () => {
+		insert_builder_format(PF_NAME, two_column_section());
+
+		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
+		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
+
+		drag_handle(".sections-container .col-width-handle", -5000);
+
+		cy.get(".sections-container .column")
+			.first()
+			.should(($el) => {
+				expect(parseInt($el.css("flex-grow"), 10)).to.be.at.least(10);
+			});
+	});
+
+	// 19. Dragging a table column header boundary transfers width between
+	// neighbours and persists via table_columns
+	it("dragging the table column handle resizes and persists widths", () => {
+		insert_builder_format(PF_NAME, [
+			{
+				label: "Tbl",
+				columns: [
+					{
+						label: "",
+						fields: [
+							{
+								fieldtype: "Table",
+								fieldname: "assignments_cy1",
+								label: "Items",
+								custom: 1,
+								table_columns: [
+									{
+										fieldname: "a",
+										label: "Alpha",
+										fieldtype: "Data",
+										width: 50,
+									},
+									{
+										fieldname: "b",
+										label: "Beta",
+										fieldtype: "Data",
+										width: 50,
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		]);
+
+		cy.intercept("POST", "api/method/frappe.client.save").as("save");
+		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
+		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
+
+		cy.get(".sections-container th.column-header").should("have.length", 2);
+		cy.get(".sections-container .col-resize-handle").should("have.length", 1);
+
+		cy.get(".sections-container table.table")
+			.first()
+			.then(($t) => {
+				const total = $t[0].getBoundingClientRect().width;
+				drag_handle(".sections-container .col-resize-handle", -total * 0.2);
+			});
+
+		cy.contains(".page-actions .primary-action", "Save").click({ force: true });
+		cy.wait("@save").then((interception) => {
+			expect(interception.response.statusCode).to.equal(200);
+			const layout = JSON.parse(interception.response.body.message.format_data);
+			const fields = layout.sections.flatMap((s) => s.columns).flatMap((c) => c.fields);
+			const table = fields.find((f) => f.fieldtype === "Table");
+			expect(table, "table field survived").to.exist;
+			expect(table.table_columns[0].width).to.be.within(25, 35);
+			expect(table.table_columns[1].width).to.be.within(65, 75);
+			expect(table.table_columns[0].width + table.table_columns[1].width).to.equal(100);
+		});
+	});
+});
+
 // ─── Image and Barcode blocks ─────────────────────────────────────────────────
 
 context("Print Format Builder — image and barcode blocks", () => {

--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -721,6 +721,10 @@ context("Print Format Builder — column width resize", () => {
 	// 19. Dragging a table column header boundary transfers width between
 	// neighbours and persists via table_columns
 	it("dragging the table column handle resizes and persists widths", () => {
+		// table markup (and its resize handles) only renders in live preview
+		// mode, so the doctype needs at least one record to auto-preview
+		cy.insert_doc("ToDo", { description: "pfb column resize preview" }, true);
+
 		insert_builder_format(PF_NAME, [
 			{
 				label: "Tbl",

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -447,7 +447,7 @@ import {
 	thumb_hue,
 	parse_inline_style,
 } from "../../utils";
-import { createApp, ref, nextTick, watch, computed, inject } from "vue";
+import { createApp, ref, nextTick, watch, computed, inject, onUnmounted } from "vue";
 import JsBarcode from "jsbarcode";
 
 const props = defineProps(["df", "field_orientation"]);
@@ -907,6 +907,8 @@ function get_column_to_add(fieldname) {
 	return { ...frappe.meta.get_docfield(props.df.options, fieldname), width: 10 };
 }
 
+let end_col_resize = null;
+
 function start_col_resize(e, ci) {
 	const cols = props.df.table_columns;
 	const left = cols[ci];
@@ -927,12 +929,19 @@ function start_col_resize(e, ci) {
 	};
 	const on_up = () => {
 		document.removeEventListener("pointermove", on_move);
+		document.removeEventListener("pointerup", on_up);
+		document.removeEventListener("pointercancel", on_up);
 		handle.classList.remove("col-resize-handle--active");
 		document.body.classList.remove("pfb-col-resizing");
+		end_col_resize = null;
 	};
 	document.addEventListener("pointermove", on_move);
-	document.addEventListener("pointerup", on_up, { once: true });
+	document.addEventListener("pointerup", on_up);
+	document.addEventListener("pointercancel", on_up);
+	end_col_resize = on_up;
 }
+
+onUnmounted(() => end_col_resize?.());
 
 function validate_table_columns() {
 	if (props.df.fieldtype != "Table") return;

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -120,7 +120,8 @@
 									<span
 										v-if="ci < df.table_columns.length - 1"
 										class="col-resize-handle"
-										@mousedown.prevent.stop="start_col_resize($event, ci)"
+										@pointerdown.prevent.stop="start_col_resize($event, ci)"
+										@mousedown.prevent.stop
 										@click.stop
 									></span>
 								</th>
@@ -925,12 +926,12 @@ function start_col_resize(e, ci) {
 		right.width = start_right - delta;
 	};
 	const on_up = () => {
-		document.removeEventListener("mousemove", on_move);
+		document.removeEventListener("pointermove", on_move);
 		handle.classList.remove("col-resize-handle--active");
 		document.body.classList.remove("pfb-col-resizing");
 	};
-	document.addEventListener("mousemove", on_move);
-	document.addEventListener("mouseup", on_up, { once: true });
+	document.addEventListener("pointermove", on_move);
+	document.addEventListener("pointerup", on_up, { once: true });
 }
 
 function validate_table_columns() {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -105,7 +105,7 @@
 								"
 							>
 								<th
-									v-for="col in df.table_columns"
+									v-for="(col, ci) in df.table_columns"
 									:key="col.fieldname"
 									class="column-header"
 									:class="{ 'column-value--merged': has_merge(col) }"
@@ -117,6 +117,12 @@
 									"
 								>
 									{{ col.label || col.fieldname }}
+									<span
+										v-if="ci < df.table_columns.length - 1"
+										class="col-resize-handle"
+										@mousedown.prevent.stop="start_col_resize($event, ci)"
+										@click.stop
+									></span>
 								</th>
 							</tr>
 						</thead>
@@ -900,6 +906,33 @@ function get_column_to_add(fieldname) {
 	return { ...frappe.meta.get_docfield(props.df.options, fieldname), width: 10 };
 }
 
+function start_col_resize(e, ci) {
+	const cols = props.df.table_columns;
+	const left = cols[ci];
+	const right = cols[ci + 1];
+	if (!right) return;
+	const table_width = e.target.closest("table").getBoundingClientRect().width;
+	const start_x = e.clientX;
+	const start_left = left.width || 10;
+	const start_right = right.width || 10;
+	const handle = e.target;
+	handle.classList.add("col-resize-handle--active");
+	document.body.classList.add("pfb-col-resizing");
+	const on_move = (ev) => {
+		let delta = Math.round(((ev.clientX - start_x) / table_width) * 100);
+		delta = Math.max(5 - start_left, Math.min(start_right - 5, delta));
+		left.width = start_left + delta;
+		right.width = start_right - delta;
+	};
+	const on_up = () => {
+		document.removeEventListener("mousemove", on_move);
+		handle.classList.remove("col-resize-handle--active");
+		document.body.classList.remove("pfb-col-resizing");
+	};
+	document.addEventListener("mousemove", on_move);
+	document.addEventListener("mouseup", on_up, { once: true });
+}
+
 function validate_table_columns() {
 	if (props.df.fieldtype != "Table") return;
 	let total = 0;
@@ -920,7 +953,45 @@ watch(
 );
 </script>
 
+<style>
+body.pfb-col-resizing,
+body.pfb-col-resizing * {
+	cursor: col-resize !important;
+	user-select: none;
+}
+</style>
+
 <style scoped>
+.column-header {
+	position: relative;
+}
+
+.col-resize-handle {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	right: -4px;
+	width: 8px;
+	cursor: col-resize;
+	z-index: 1;
+}
+
+.col-resize-handle::after {
+	content: "";
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 3px;
+	width: 2px;
+	background: var(--gray-400);
+	opacity: 0;
+}
+
+.col-resize-handle:hover::after,
+.col-resize-handle--active::after {
+	opacity: 1;
+}
+
 .field--chip {
 	display: flex;
 	flex-direction: column;

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -979,12 +979,18 @@ body.pfb-col-resizing * {
 .col-resize-handle::after {
 	content: "";
 	position: absolute;
-	top: 0;
-	bottom: 0;
+	top: 2px;
+	bottom: 2px;
 	left: 3px;
 	width: 2px;
+	border-radius: 1px;
 	background: var(--gray-400);
 	opacity: 0;
+	transition: opacity 0.15s;
+}
+
+thead:hover .col-resize-handle::after {
+	opacity: 0.4;
 }
 
 .col-resize-handle:hover::after,

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -17,7 +17,12 @@
 		<!-- Body wrapper: font size/family applied here so letterhead zones are unaffected -->
 		<div class="pfb-body" :style="bodyStyles">
 			<div class="zone-divider">
-				<span class="zone-divider-label">{{ __("Header") }}</span>
+				<span class="zone-divider-label">
+					{{ __("Header") }}
+					<span v-if="repeat_header_footer" class="zone-divider-hint"
+						>· {{ __("repeats on all pages") }}</span
+					>
+				</span>
 			</div>
 			<PrintFormatSection :section="layout.header" :is_header="true" zone="header" />
 			<div class="zone-divider">
@@ -46,7 +51,12 @@
 			</draggable>
 
 			<div class="zone-divider">
-				<span class="zone-divider-label">{{ __("Footer") }}</span>
+				<span class="zone-divider-label">
+					{{ __("Footer") }}
+					<span v-if="repeat_header_footer" class="zone-divider-hint"
+						>· {{ __("repeats on all pages") }}</span
+					>
+				</span>
 			</div>
 			<PrintFormatSection :section="layout.footer" :is_header="true" zone="footer" />
 		</div>
@@ -178,6 +188,10 @@ let color_css = computed(() => {
 	return css;
 });
 
+let repeat_header_footer = computed(
+	() => !!frappe.model.get_doc(":Print Settings", "Print Settings")?.repeat_header_footer
+);
+
 let page_number_hidden = computed(() => print_format.value.page_number.includes("Hide"));
 
 let page_number_style = computed(() => {
@@ -233,7 +247,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 .zone-divider {
 	display: flex;
 	align-items: center;
-	gap: 8px;
+	gap: 12px;
 	margin: 0.75rem 0 0.5rem;
 }
 
@@ -242,20 +256,22 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	content: "";
 	flex: 1;
 	height: 1px;
-	background: var(--gray-300);
+	background: var(--gray-200);
 }
 
 .zone-divider-label {
 	font-size: var(--text-tiny);
-	font-weight: var(--weight-bold);
+	font-weight: var(--weight-medium);
 	text-transform: uppercase;
-	letter-spacing: 0.08em;
+	letter-spacing: 0.12em;
 	white-space: nowrap;
-	padding: 2px 8px;
-	border-radius: var(--radius);
-	color: var(--text-muted);
-	background: var(--gray-100);
-	border: 1px solid var(--gray-300);
+	color: var(--gray-400);
+}
+
+.zone-divider-hint {
+	text-transform: none;
+	font-weight: var(--weight-regular);
+	letter-spacing: 0.02em;
 }
 
 .section-with-insert {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -174,7 +174,7 @@
 <script setup>
 import draggable from "vuedraggable";
 import Field from "./Field.vue";
-import { computed, inject } from "vue";
+import { computed, inject, onUnmounted } from "vue";
 import { evaluate_visible_if, parse_inline_style } from "../../utils";
 
 const props = defineProps(["section", "is_header", "zone"]);
@@ -216,6 +216,8 @@ let handle_offset = computed(() => {
 	return `${-(gap + 12.5)}px`;
 });
 
+let end_col_width_resize = null;
+
 function start_col_width_resize(e, i) {
 	const cols = props.section.columns;
 	const handle = e.currentTarget;
@@ -235,12 +237,19 @@ function start_col_width_resize(e, i) {
 	};
 	const on_up = () => {
 		document.removeEventListener("pointermove", on_move);
+		document.removeEventListener("pointerup", on_up);
+		document.removeEventListener("pointercancel", on_up);
 		handle.classList.remove("col-width-handle--active");
 		document.body.classList.remove("pfb-col-resizing");
+		end_col_width_resize = null;
 	};
 	document.addEventListener("pointermove", on_move);
-	document.addEventListener("pointerup", on_up, { once: true });
+	document.addEventListener("pointerup", on_up);
+	document.addEventListener("pointercancel", on_up);
+	end_col_width_resize = on_up;
 }
+
+onUnmounted(() => end_col_width_resize?.());
 
 let has_visible_fields = computed(
 	() =>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -110,7 +110,8 @@
 							v-if="i < section.columns.length - 1"
 							class="col-width-handle"
 							:style="{ right: handle_offset }"
-							@mousedown.prevent.stop="start_col_width_resize($event, i)"
+							@pointerdown.prevent.stop="start_col_width_resize($event, i)"
+							@mousedown.prevent.stop
 							@click.stop
 						></div>
 						<draggable
@@ -233,12 +234,12 @@ function start_col_width_resize(e, i) {
 		cols[i + 1].width = Math.round(widths[i + 1] - delta);
 	};
 	const on_up = () => {
-		document.removeEventListener("mousemove", on_move);
+		document.removeEventListener("pointermove", on_move);
 		handle.classList.remove("col-width-handle--active");
 		document.body.classList.remove("pfb-col-resizing");
 	};
-	document.addEventListener("mousemove", on_move);
-	document.addEventListener("mouseup", on_up, { once: true });
+	document.addEventListener("pointermove", on_move);
+	document.addEventListener("pointerup", on_up, { once: true });
 }
 
 let has_visible_fields = computed(

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -101,7 +101,18 @@
 			>
 				<template v-for="(column, i) in section.columns" :key="i">
 					<div v-if="i > 0 && !preview_doc" class="column-divider"></div>
-					<div class="column" :class="{ col: !!preview_doc }">
+					<div
+						class="column"
+						:class="{ col: !!preview_doc }"
+						:style="column.width ? { flex: `${column.width} 1 0%` } : {}"
+					>
+						<div
+							v-if="i < section.columns.length - 1"
+							class="col-width-handle"
+							:style="{ right: handle_offset }"
+							@mousedown.prevent.stop="start_col_width_resize($event, i)"
+							@click.stop
+						></div>
 						<draggable
 							class="drag-container"
 							v-model="column.fields"
@@ -197,6 +208,38 @@ let columns_gap_style = computed(() => {
 		? { gap: props.section.gap + "px" }
 		: {};
 });
+
+let handle_offset = computed(() => {
+	if (preview_doc.value) return `${-((props.section.gap ?? 20) / 2 + 4)}px`;
+	const gap = props.section.columns.length > 1 && props.section.gap ? props.section.gap : 0;
+	return `${-(gap + 12.5)}px`;
+});
+
+function start_col_width_resize(e, i) {
+	const cols = props.section.columns;
+	const handle = e.currentTarget;
+	const container = handle.closest(".section-columns");
+	const col_els = [...container.children].filter((el) => el.classList.contains("column"));
+	const total = container.getBoundingClientRect().width;
+	const widths = col_els.map((el) => (el.getBoundingClientRect().width / total) * 100);
+	const start_x = e.clientX;
+	handle.classList.add("col-width-handle--active");
+	document.body.classList.add("pfb-col-resizing");
+	const on_move = (ev) => {
+		let delta = ((ev.clientX - start_x) / total) * 100;
+		delta = Math.max(10 - widths[i], Math.min(widths[i + 1] - 10, delta));
+		cols.forEach((c, j) => (c.width = Math.round(widths[j])));
+		cols[i].width = Math.round(widths[i] + delta);
+		cols[i + 1].width = Math.round(widths[i + 1] - delta);
+	};
+	const on_up = () => {
+		document.removeEventListener("mousemove", on_move);
+		handle.classList.remove("col-width-handle--active");
+		document.body.classList.remove("pfb-col-resizing");
+	};
+	document.addEventListener("mousemove", on_move);
+	document.addEventListener("mouseup", on_up, { once: true });
+}
 
 let has_visible_fields = computed(
 	() =>
@@ -375,6 +418,37 @@ function remove_column(index) {
 	background: var(--border-color);
 	margin: 0 0.5rem;
 	flex-shrink: 0;
+}
+
+.col-width-handle {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 8px;
+	cursor: col-resize;
+	z-index: 2;
+}
+
+.col-width-handle::after {
+	content: "";
+	position: absolute;
+	top: 2px;
+	bottom: 2px;
+	left: 3px;
+	width: 2px;
+	border-radius: 1px;
+	background: var(--gray-400);
+	opacity: 0;
+	transition: opacity 0.15s;
+}
+
+.section-columns:hover .col-width-handle::after {
+	opacity: 0.4;
+}
+
+.col-width-handle:hover::after,
+.col-width-handle--active::after {
+	opacity: 1;
 }
 
 .drag-container {

--- a/frappe/public/js/print_format_builder/components/inspector/LabelField.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/LabelField.vue
@@ -1,29 +1,30 @@
 <template>
-	<div class="pfb-insp-row" v-if="showToggle">
-		<span class="pfb-insp-label">{{ showLabel }}</span>
-		<label class="switch-control">
-			<span class="input-area">
-				<input
-					type="checkbox"
-					role="switch"
-					:checked="show_on"
-					@change="$emit('update:show', $event.target.checked ? 'show' : 'hide')"
-				/>
-			</span>
-			<span class="switch-visual" aria-hidden="true">
-				<span class="switch-thumb"></span>
-			</span>
-		</label>
-	</div>
-	<div class="pfb-insp-row pfb-insp-row--col" v-if="!showToggle || show_on">
+	<div class="pfb-insp-row pfb-insp-row--col">
 		<span class="pfb-insp-label">{{ label }}</span>
-		<input
-			class="pfb-insp-input"
-			type="text"
-			:placeholder="placeholder"
-			:value="modelValue"
-			@input="$emit('update:modelValue', $event.target.value)"
-		/>
+		<div class="label-field-controls">
+			<label v-if="showToggle" class="switch-control" :title="showLabel">
+				<span class="input-area">
+					<input
+						type="checkbox"
+						role="switch"
+						:aria-label="showLabel"
+						:checked="show_on"
+						@change="$emit('update:show', $event.target.checked ? 'show' : 'hide')"
+					/>
+				</span>
+				<span class="switch-visual" aria-hidden="true">
+					<span class="switch-thumb"></span>
+				</span>
+			</label>
+			<input
+				v-if="!showToggle || show_on"
+				class="pfb-insp-input"
+				type="text"
+				:placeholder="placeholder"
+				:value="modelValue"
+				@input="$emit('update:modelValue', $event.target.value)"
+			/>
+		</div>
 	</div>
 </template>
 
@@ -42,3 +43,15 @@ defineEmits(["update:modelValue", "update:show"]);
 
 let show_on = computed(() => props.show !== "hide");
 </script>
+
+<style scoped>
+.label-field-controls {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.label-field-controls .pfb-insp-input {
+	flex: 1;
+}
+</style>

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -36,7 +36,7 @@
 	<div class="section document-header-content">
 	<div class="section-columns row" style="gap:{{ col_gap }}">
 	{%- for column in layout.header.columns %}
-	<div class="column col">
+	<div class="column col"{% if column.width %} style="flex: {{ column.width|float }} 1 0%"{% endif %}>
 	{%- for df in column.fields %}{{ macros.render_field(df, doc) }}{%- endfor %}
 	</div>
 	{%- endfor %}
@@ -98,7 +98,7 @@
 		{%- set col_gap = ('0' if section.field_borders else (section.gap if section.gap is defined and section.gap != None else 20)|string + 'px') -%}
 		<div class="section-columns row {{ row_layout }}" style="gap:{{ col_gap }}">
 			{% for column in section.columns %}
-			<div class="column col">
+			<div class="column col"{% if column.width %} style="flex: {{ column.width|float }} 1 0%"{% endif %}>
 				{% for df in column.fields %}
 				{{ macros.render_field(df, doc) }}
 				{% endfor %}
@@ -123,7 +123,7 @@
 	<div class="section document-footer-content">
 	<div class="section-columns row" style="gap:{{ col_gap_f }}">
 	{%- for column in layout.footer.columns %}
-	<div class="column col">
+	<div class="column col"{% if column.width %} style="flex: {{ column.width|float }} 1 0%"{% endif %}>
 	{%- for df in column.fields %}{{ macros.render_field(df, doc) }}{%- endfor %}
 	</div>
 	{%- endfor %}

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -253,7 +253,7 @@ class PrintFormatGenerator:
 {%- set col_gap = (section.gap if section.gap is defined and section.gap is not none else 20)|string + 'px' -%}
 <div class="section section-columns row" style="gap:{{ col_gap }}">
 {%- for column in section.columns %}
-<div class="column col">
+<div class="column col"{% if column.get('width') %} style="flex: {{ column.get('width')|float }} 1 0%"{% endif %}>
 {%- for df in column.get('fields', []) -%}
 {%- if not df.get('_hidden') -%}
 {%- if df.fieldtype == 'HTML' and df.html -%}


### PR DESCRIPTION
- Zone dividers (Header/Body/Footer) are now plain light-gray uppercase labels between thin lines instead of bordered chips
- Header/Footer dividers show a "repeats on all pages" hint when Print Settings has Repeat Header and Footer enabled
- Inspector label/title controls: show-toggle and text input now sit inline in a single row under the label
- Table columns on the canvas can be resized by dragging the boundary between column headers; width transfers between neighbours, min 5% per column
- Section columns can be resized by dragging the boundary between columns; widths persist as flex ratios in format_data and are honoured by the PDF (body sections, header/footer zones, and the repeating Chrome overlay); formats without widths keep the equal split
- Resize handles use pointer events (SortableJS preventDefaults pointerdown on filtered elements, which suppresses mousedown)
- Cypress coverage: handle placement, section drag + persistence, 10% clamp, table column drag + persistence

`no-docs`