### PR TITLE
fix(print-format-builder): render rating stars from fraction values

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -299,6 +299,24 @@
 						></div>
 						{{ preview_doc[df.fieldname] }}
 					</template>
+					<!-- Mirrors the star SVG of templates/print_format/macros/Rating.html -->
+					<template v-else-if="df.fieldtype == 'Rating' && preview_doc[df.fieldname]">
+						<svg
+							v-for="i in rating_stars.total"
+							:key="i"
+							class="rating-star"
+							:class="{ active: i <= rating_stars.filled }"
+							viewBox="0 0 24 24"
+							fill="none"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<path
+								:fill="i <= rating_stars.filled ? '#f6c35e' : '#dce0e3'"
+								:stroke="i <= rating_stars.filled ? '#f6c35e' : '#dce0e3'"
+								d="M11.5516 2.90849C11.735 2.53687 12.265 2.53687 12.4484 2.90849L14.8226 7.71919C14.8954 7.86677 15.0362 7.96905 15.1991 7.99271L20.508 8.76415C20.9181 8.82374 21.0818 9.32772 20.7851 9.61699L16.9435 13.3616C16.8257 13.4765 16.7719 13.642 16.7997 13.8042L17.7066 19.0916C17.7766 19.5001 17.3479 19.8116 16.9811 19.6187L12.2327 17.1223C12.087 17.0457 11.913 17.0457 11.7673 17.1223L7.01888 19.6187C6.65207 19.8116 6.22335 19.5001 6.29341 19.0916L7.20028 13.8042C7.2281 13.642 7.17433 13.4765 7.05648 13.3616L3.21491 9.61699C2.91815 9.32772 3.08191 8.82374 3.49202 8.76415L8.80094 7.99271C8.9638 7.96905 9.10458 7.86677 9.17741 7.71919L11.5516 2.90849Z"
+							/>
+						</svg>
+					</template>
 					<span v-else>{{ preview_value || "—" }}</span>
 				</div>
 			</template>
@@ -651,6 +669,13 @@ let preview_value = computed(() => {
 	} catch {
 		return String(raw);
 	}
+});
+
+// Same math as macros/Rating.html: value is a 0-1 fraction, df.options holds the star count
+let rating_stars = computed(() => {
+	const total = parseInt(props.df.options) || 5;
+	const value = (preview_doc.value && preview_doc.value[props.df.fieldname]) || 0;
+	return { total, filled: Math.min(Math.floor(value * total + 0.5), total) };
 });
 
 const IMAGE_FIELDTYPES = new Set(["Attach Image", "Image", "Attach"]);

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -19,7 +19,13 @@
 		<!-- ── Preview mode: show actual doc values ─────────── -->
 		<template v-if="preview_doc">
 			<!-- Handle HTML fields: render Jinja2 server-side if needed -->
-			<div v-if="df.fieldtype == 'HTML' && df.html" v-html="rendered_html ?? df.html"></div>
+			<span v-if="template_render_failed" class="text-muted">{{
+				__("Couldn't render this template for the previewed document")
+			}}</span>
+			<div
+				v-else-if="df.fieldtype == 'HTML' && df.html"
+				v-html="rendered_html ?? df.html"
+			></div>
 			<!-- Spacer/Divider: the root element itself is the rendered output -->
 			<i
 				v-else-if="df.fieldtype == 'Spacer' || df.fieldtype == 'Divider'"
@@ -482,6 +488,7 @@ let store = inject("$store");
 let editing = ref(false);
 let label_input = ref(null);
 let rendered_html = ref(null);
+let template_render_failed = ref(false);
 let rendered_template = ref(null);
 
 let custom_style = computed(() => parse_inline_style(props.df.custom_style));
@@ -562,6 +569,7 @@ watch(
 		const html = props.df.html;
 		if (!doc || !html || props.df.fieldtype !== "HTML") {
 			rendered_html.value = null;
+			template_render_failed.value = false;
 			return;
 		}
 		rendered_html.value = await render_jinja_html(
@@ -569,6 +577,7 @@ watch(
 			store.meta.value?.name,
 			store.preview_doc_name.value
 		);
+		template_render_failed.value = rendered_html.value === null;
 	},
 	{ immediate: true }
 );
@@ -579,6 +588,7 @@ watch(
 	async ([doc]) => {
 		if (!doc || props.df.fieldtype !== "Field Template" || !props.df.field_template) {
 			rendered_template.value = null;
+			template_render_failed.value = false;
 			return;
 		}
 		try {
@@ -593,8 +603,10 @@ watch(
 				store.meta.value?.name,
 				store.preview_doc_name.value
 			);
+			template_render_failed.value = rendered_template.value === null;
 		} catch {
 			rendered_template.value = null;
+			template_render_failed.value = true;
 		}
 	},
 	{ immediate: true }

--- a/frappe/public/js/print_format_builder/components/inspector/LetterHeadZoneInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/LetterHeadZoneInspector.vue
@@ -268,7 +268,10 @@ function open_html_split_dialog({ title, initial_html, on_save, doctype, docname
 
 	async function update_preview(iframe, html) {
 		if (!iframe) return;
-		write_to_iframe(iframe, await render_jinja_html(html || "", doctype, docname));
+		write_to_iframe(
+			iframe,
+			(await render_jinja_html(html || "", doctype, docname)) ?? html ?? ""
+		);
 	}
 
 	setTimeout(() => {

--- a/frappe/public/js/print_format_builder/components/letterhead/LetterHeadZoneEditor.vue
+++ b/frappe/public/js/print_format_builder/components/letterhead/LetterHeadZoneEditor.vue
@@ -2,7 +2,10 @@
 	<div class="lh-zone" :class="{ 'lh-zone--selected': is_selected }" @click.stop="select_zone">
 		<div v-if="letterhead && zone_content" class="letter-head">
 			<!-- Preview mode: render Jinja server-side; edit mode: show raw -->
-			<div v-if="preview_doc" v-html="rendered_content ?? zone_content"></div>
+			<span v-if="preview_doc && render_failed" class="text-muted">{{
+				__("Couldn't render this letter head for the previewed document")
+			}}</span>
+			<div v-else-if="preview_doc" v-html="rendered_content ?? zone_content"></div>
 			<div v-else v-html="zone_content"></div>
 		</div>
 		<div v-else class="lh-zone-empty">
@@ -47,6 +50,7 @@ const F = computed(() =>
 
 let preview_doc = computed(() => raw_store.preview_doc.value);
 let rendered_content = ref(null);
+let render_failed = ref(false);
 let render_pending = ref(false);
 
 let zone_content = computed(() => letterhead.value?.[F.value.content] ?? "");
@@ -78,6 +82,7 @@ async function refresh_rendered_content() {
 	const content = zone_content.value;
 	if (!doc || !content) {
 		rendered_content.value = null;
+		render_failed.value = false;
 		return;
 	}
 	if (render_pending.value) return;
@@ -88,6 +93,7 @@ async function refresh_rendered_content() {
 			raw_store.meta.value?.name,
 			raw_store.preview_doc_name.value
 		);
+		render_failed.value = rendered_content.value === null;
 	} finally {
 		render_pending.value = false;
 	}

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -287,14 +287,14 @@ export async function render_jinja_html(html, doctype, docname) {
 	if (!html.includes("{{") && !html.includes("{%")) return html;
 	if (!doctype || !docname) return html;
 	try {
-		const r = await frappe.call("frappe.utils.print_format_generator.render_jinja_template", {
-			template: html,
-			doctype,
-			docname,
+		const r = await frappe.call({
+			method: "frappe.utils.print_format_generator.render_jinja_template",
+			args: { template: html, doctype, docname },
+			silent: 1,
 		});
 		return r.message ?? html;
 	} catch {
-		return html;
+		return null;
 	}
 }
 

--- a/frappe/templates/print_format/macros/Rating.html
+++ b/frappe/templates/print_format/macros/Rating.html
@@ -11,11 +11,14 @@
 {% endmacro %}
 
 {%- block value -%}
+{#- Rating values are stored as a 0-1 fraction; df.options holds the star count -#}
+{%- set total = df.options | int or 5 -%}
+{%- set filled = [((value or 0) * total + 0.5) | int, total] | min -%}
 <div class="value">
-    {%- for i in range(value) -%}
+    {%- for i in range(filled) -%}
     {{ star(true) }}
     {%- endfor -%}
-    {%- for i in range(5 - value) -%}
+    {%- for i in range(total - filled) -%}
     {{ star() }}
     {%- endfor -%}
 </div>

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -16,9 +16,15 @@ def render_jinja_template(template: str, doctype: str, docname: str) -> str:
 	doc.check_permission("print")
 	# template is rendered inside frappe's SandboxedEnvironment (Jinja2 sandbox).
 	# The caller must hold the "print" permission on the document before reaching this line.
-	return frappe.render_template(
-		template, {"doc": doc}
-	)  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
+	try:
+		return frappe.render_template(
+			template, {"doc": doc}
+		)  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
+	except Exception as e:
+		# fail with 417 instead of 500 so the canvas can degrade inline
+		# rather than the client popping the error-report dialog
+		frappe.clear_last_message()
+		frappe.throw(_("Failed to render template: {0}").format(e), frappe.ValidationError)
 
 
 @frappe.whitelist()

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -24,7 +24,7 @@ def render_jinja_template(template: str, doctype: str, docname: str) -> str:
 		# fail with 417 instead of 500 so the canvas can degrade inline
 		# rather than the client popping the error-report dialog
 		frappe.clear_last_message()
-		frappe.throw(_("Failed to render template: {0}").format(e), frappe.ValidationError)
+		frappe.throw(_("Failed to render template: {0}").format(str(e)), frappe.ValidationError)
 
 
 @frappe.whitelist()

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -37,9 +37,6 @@ CANVAS_SOURCES = sorted(BUILDER_DIR.rglob("*.vue"))
 SERVER_ONLY_CLASSES = {
 	# letterhead HTML is user-authored and rendered server-side only
 	"letter-head",
-	# star SVGs come from macros/Rating.html; the canvas previews the numeric value
-	"rating-star",
-	"active",
 	# Chrome PDF overlay wrapper (templates/print_formats/chrome_pdf_header_footer.html)
 	"document-header",
 }
@@ -131,6 +128,9 @@ class TestPrintSurfaceMarkupContract(UnitTestCase):
 
 	def test_repeater_macro_properties_mirrored_in_canvas(self):
 		self._assert_df_props_mirrored(APP_PATH / "templates" / "print_format" / "macros" / "Repeater.html")
+
+	def test_rating_macro_properties_mirrored_in_canvas(self):
+		self._assert_df_props_mirrored(APP_PATH / "templates" / "print_format" / "macros" / "Rating.html")
 
 	def _assert_df_props_mirrored(self, macro_path):
 		# properties that are server-render concerns, not canvas inputs

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -132,6 +132,18 @@ class TestPrintSurfaceMarkupContract(UnitTestCase):
 	def test_rating_macro_properties_mirrored_in_canvas(self):
 		self._assert_df_props_mirrored(APP_PATH / "templates" / "print_format" / "macros" / "Rating.html")
 
+	def test_rating_star_svg_matches_on_both_surfaces(self):
+		"""The star SVG can't come from a shared helper (the desk sprite star is a
+		different shape and sprites don't exist in the PDF render), so Field.vue
+		hand-mirrors macros/Rating.html — this pins the path and colours together."""
+		macro = (APP_PATH / "templates" / "print_format" / "macros" / "Rating.html").read_text()
+		canvas = _field_vue_text()
+		path_d = re.search(r'd="(M11\.5[^"]+)"', macro).group(1)
+		self.assertIn(path_d, canvas)
+		for color in ("#f6c35e", "#dce0e3"):
+			self.assertIn(color, macro)
+			self.assertIn(color, canvas)
+
 	def _assert_df_props_mirrored(self, macro_path):
 		# properties that are server-render concerns, not canvas inputs
 		skip = {"get", "renderer", "section", "html"}


### PR DESCRIPTION
- fix `macros/Rating.html`: rating values are stored as a 0-1 fraction, so `range(value)` raised `TypeError` and crashed the print for any beta format containing a Rating field; stars now scale by `df.options` (default 5)
- builder canvas mirrors the same star SVGs (`rating-star` / `active`) with identical rounding, instead of stripping the formatter HTML to empty text
- parity tests: `rating-star`/`active` removed from `SERVER_ONLY_CLASSES`, added Rating macro to the df-property mirror guard

Follow-up to #40782.