### PR TITLE
feat(ui): empty state component

### DIFF
--- a/frappe/core/doctype/role/role.js
+++ b/frappe/core/doctype/role/role.js
@@ -299,7 +299,9 @@ class DocumentsTab extends RoleTab {
 		return {
 			page_size: 50,
 			description: __("DocTypes this role can access."),
-			empty_message: __("No DocTypes are accessible to this role."),
+			empty_message: __("No documents added."),
+			empty_icon: "file-text",
+			no_match_message: __("No documents found."),
 			add_button: { label: __("Add Permission"), action: () => this.add() },
 			columns: this.columns(),
 			on_row_click: (row) => this.edit(row),
@@ -566,7 +568,9 @@ class ReportsTab extends RoleAccessTab {
 	list_config() {
 		return {
 			description: __("Reports this role can access."),
-			empty_message: __("This role has no Report access."),
+			empty_message: __("This role does not have access to any reports."),
+			empty_icon: "sheet",
+			no_match_message: __("No reports found."),
 			add_button: { label: __("Add Report"), action: () => this.add() },
 			columns: [
 				{
@@ -594,7 +598,9 @@ class PagesTab extends RoleAccessTab {
 	list_config() {
 		return {
 			description: __("Pages this role can access."),
-			empty_message: __("This role has no Page access."),
+			empty_message: __("This role does not have access to any pages."),
+			empty_icon: "file",
+			no_match_message: __("No pages found."),
 			add_button: { label: __("Add Page"), action: () => this.add() },
 			columns: [
 				{
@@ -623,7 +629,9 @@ class WorkspacesTab extends RoleAccessTab {
 	list_config() {
 		return {
 			description: __("Workspaces this role can access."),
-			empty_message: __("This role has no Workspace access."),
+			empty_message: __("This role does not have access to any workspaces."),
+			empty_icon: "table-2",
+			no_match_message: __("No workspaces found."),
 			add_button: { label: __("Add Workspace"), action: () => this.add() },
 			columns: [
 				{

--- a/frappe/core/doctype/role/role.js
+++ b/frappe/core/doctype/role/role.js
@@ -52,16 +52,26 @@ class RoleForm {
 		};
 		// EmbeddedList is lazy (not in the desk bundle); build the tabs' lists
 		// once it's loaded so build()/refresh() stay synchronous below.
-		frappe.require("embedded_list.bundle.js").then(() => {
-			Object.values(this.tabs).forEach((tab) => tab.build());
+		frappe
+			.require("embedded_list.bundle.js")
+			.then(() => {
+				Object.values(this.tabs).forEach((tab) => tab.build());
 
-			// Role Profiles live in the always-visible Details tab — load eagerly.
-			const profiles = new RoleProfilesTab(this.frm);
-			profiles.build();
-			profiles.refresh();
+				// Role Profiles live in the always-visible Details tab — load eagerly.
+				const profiles = new RoleProfilesTab(this.frm);
+				profiles.build();
+				profiles.refresh();
 
-			this.load_active_tab();
-		});
+				this.load_active_tab();
+			})
+			.catch((e) => {
+				// a failed lazy load must not leave the form silently blank
+				console.error("Role form: failed to load embedded_list.bundle.js", e);
+				frappe.ui.toast({
+					message: __("Could not load this section. Please refresh the page."),
+					type: "error",
+				});
+			});
 	}
 
 	load_active_tab() {

--- a/frappe/core/doctype/role/role.js
+++ b/frappe/core/doctype/role/role.js
@@ -50,14 +50,18 @@ class RoleForm {
 			pages_tab: new PagesTab(this.frm),
 			workspace_tab: new WorkspacesTab(this.frm),
 		};
-		Object.values(this.tabs).forEach((tab) => tab.build());
+		// EmbeddedList is lazy (not in the desk bundle); build the tabs' lists
+		// once it's loaded so build()/refresh() stay synchronous below.
+		frappe.require("embedded_list.bundle.js").then(() => {
+			Object.values(this.tabs).forEach((tab) => tab.build());
 
-		// Role Profiles live in the always-visible Details tab — load eagerly.
-		const profiles = new RoleProfilesTab(this.frm);
-		profiles.build();
-		profiles.refresh();
+			// Role Profiles live in the always-visible Details tab — load eagerly.
+			const profiles = new RoleProfilesTab(this.frm);
+			profiles.build();
+			profiles.refresh();
 
-		this.load_active_tab();
+			this.load_active_tab();
+		});
 	}
 
 	load_active_tab() {

--- a/frappe/core/page/component_explorer/component_explorer.js
+++ b/frappe/core/page/component_explorer/component_explorer.js
@@ -761,6 +761,64 @@ frappe.pages["component-explorer"].on_page_load = function (wrapper) {
 				},
 			],
 		},
+		"Empty State": {
+			helper: "frappe.ui.empty_state",
+			stacked: true,
+			groups: [
+				{
+					title: __("Basic (icon + title + description)"),
+					items: [
+						{
+							icon: "inbox",
+							title: "No invoices yet",
+							description: "Invoices you create will show up here.",
+						},
+					],
+				},
+				{
+					title: __("With a create action"),
+					items: [
+						{
+							icon: "file-text",
+							title: "No sales orders",
+							description: "Create your first sales order to get started.",
+							actions: [
+								{
+									label: "New Sales Order",
+									variant: "solid",
+									icon: "plus",
+									onclick: () => frappe.ui.toast({ message: "New Sales Order" }),
+								},
+							],
+						},
+					],
+				},
+				{
+					title: __("Multiple actions (create button + docs link)"),
+					items: [
+						{
+							__code: 'frappe.ui.empty_state({\n  icon: "package",\n  title: "No items yet",\n  description: "Add an item, or read how stock works.",\n  actions: [\n    { label: "New Item", variant: "solid", icon: "plus", onclick: () => new_item() },\n    { label: "Documentation", href: "https://docs.erpnext.com/", icon: "external-link" },\n  ],\n})',
+							icon: "package",
+							title: "No items yet",
+							description: "Add an item, or read how stock works.",
+							actions: [
+								{
+									label: "New Item",
+									variant: "solid",
+									icon: "plus",
+									onclick: () => frappe.ui.toast({ message: "New Item" }),
+								},
+								{
+									label: "Documentation",
+									href: "https://docs.frappe.io/",
+									icon: "external-link",
+								},
+							],
+						},
+					],
+				},
+			],
+		},
 		Toast: {
 			helper: "frappe.ui.toast",
 			html: (opts) => "",

--- a/frappe/public/js/desk.bundle.js
+++ b/frappe/public/js/desk.bundle.js
@@ -24,6 +24,7 @@ import "./frappe/ui/components/hover_card.js";
 import "./frappe/ui/components/tabs.js";
 import "./frappe/ui/components/tab_buttons.js";
 import "./frappe/ui/components/progress.js";
+import "./frappe/ui/components/empty_state.js";
 
 import "./frappe/ui/background_tasks/background_tasks.js";
 import "./frappe/ui/keyboard.js";

--- a/frappe/public/js/desk.bundle.js
+++ b/frappe/public/js/desk.bundle.js
@@ -68,7 +68,6 @@ import "./frappe/ui/settings_dialog.js";
 import "./frappe/ui/user_settings_dialog.js";
 import "./frappe/ui/menu.js";
 import "./frappe/ui/capture.js";
-import "./frappe/ui/embedded_list.js";
 import "./frappe/ui/permission_dialog.js";
 import "./frappe/ui/app_icon.js";
 import "./frappe/ui/theme_switcher.js";

--- a/frappe/public/js/embedded_list.bundle.js
+++ b/frappe/public/js/embedded_list.bundle.js
@@ -1,0 +1,5 @@
+// Lazy bundle for frappe.ui.EmbeddedList — it's a feature component used in
+// only a few places (the DocType Settings dialog, the Role form), so it's
+// kept out of the eager desk bundle and pulled in on demand with
+// frappe.require("embedded_list.bundle.js").
+import "./frappe/ui/embedded_list.js";

--- a/frappe/public/js/frappe-web.bundle.js
+++ b/frappe/public/js/frappe-web.bundle.js
@@ -26,6 +26,7 @@ import "./frappe/ui/components/hover_card.js";
 import "./frappe/ui/components/tabs.js";
 import "./frappe/ui/components/tab_buttons.js";
 import "./frappe/ui/components/progress.js";
+import "./frappe/ui/components/empty_state.js";
 
 import "./frappe/utils/common.js";
 import "./frappe/ui/messages.js";

--- a/frappe/public/js/frappe/form/doctype_settings/doctype_settings.js
+++ b/frappe/public/js/frappe/form/doctype_settings/doctype_settings.js
@@ -25,8 +25,17 @@ frappe.doctype_settings.open = function (doctype) {
 
 	// EmbeddedList is lazy (not in the desk bundle); load it in parallel with
 	// the settings check so the tabs that use it (Naming, Permissions) can
-	// build their lists synchronously by the time the dialog renders.
-	const ready = frappe.require("embedded_list.bundle.js");
+	// build their lists synchronously by the time the dialog renders. If the
+	// lazy load fails we still open the dialog (the other tabs work) and warn,
+	// rather than leave a rejected promise / a dialog that never opens.
+	const ready = frappe.require("embedded_list.bundle.js").catch((e) => {
+		console.error("DocType Settings: failed to load embedded_list.bundle.js", e);
+		// warning, not error: the dialog still opens and the other tabs work
+		frappe.ui.toast({
+			message: __("Some settings tabs may not load. Please refresh the page."),
+			type: "warning",
+		});
+	});
 
 	return (
 		frappe

--- a/frappe/public/js/frappe/form/doctype_settings/doctype_settings.js
+++ b/frappe/public/js/frappe/form/doctype_settings/doctype_settings.js
@@ -23,15 +23,20 @@ import "./tabs/settings_map";
 frappe.doctype_settings.open = function (doctype) {
 	if (!doctype) return;
 
+	// EmbeddedList is lazy (not in the desk bundle); load it in parallel with
+	// the settings check so the tabs that use it (Naming, Permissions) can
+	// build their lists synchronously by the time the dialog renders.
+	const ready = frappe.require("embedded_list.bundle.js");
+
 	return (
 		frappe
 			.call({
 				method: "frappe.desk.doctype_settings.settings_map.has_settings_map",
 				args: { doctype },
 			})
-			.then((r) => build_dialog(doctype, !!(r && r.message)))
+			.then((r) => ready.then(() => build_dialog(doctype, !!(r && r.message))))
 			// A failure on the check must not block the whole dialog.
-			.catch(() => build_dialog(doctype, false))
+			.catch(() => ready.then(() => build_dialog(doctype, false)))
 	);
 };
 

--- a/frappe/public/js/frappe/form/doctype_settings/registry.js
+++ b/frappe/public/js/frappe/form/doctype_settings/registry.js
@@ -71,31 +71,24 @@ frappe.doctype_settings.overflow_menu = function (items) {
 };
 
 /**
- * Shared empty state (banking-style: muted icon ▸ title ▸ description ▸ subtle action).
- * Renders into `$container` (cleared by the caller).
+ * Shared empty state — thin wrapper over frappe.ui.empty_state so every
+ * settings tab gets the standard component. Same signature as before, so
+ * callers don't change; its single `action` maps to the component's actions
+ * array. Renders into `$container` (cleared by the caller).
  * `opts`: { icon, title, description, action: { label, onclick() } }.
  */
 frappe.doctype_settings.empty_state = function ($container, opts) {
 	opts = opts || {};
-	const $empty = $('<div class="dts-empty"></div>').appendTo($container);
-	$('<div class="dts-empty-icon"></div>')
-		.append(frappe.utils.icon(opts.icon || "list", "lg"))
-		.appendTo($empty);
-	$('<div class="dts-empty-title"></div>')
-		.text(opts.title || __("Nothing here yet"))
-		.appendTo($empty);
-	if (opts.description) {
-		$('<div class="dts-empty-description"></div>').text(opts.description).appendTo($empty);
-	}
-	if (opts.action) {
-		frappe.ui
-			.button({
-				label: opts.action.label,
-				css_class: "dts-empty-action",
-				onclick: () => opts.action.onclick(),
-			})
-			.appendTo($empty);
-	}
+	const actions = opts.action
+		? [{ label: opts.action.label, variant: "subtle", onclick: () => opts.action.onclick() }]
+		: [];
+	const $empty = frappe.ui.empty_state({
+		icon: opts.icon || "list",
+		title: opts.title || __("Nothing here yet"),
+		description: opts.description,
+		actions,
+	});
+	$empty.appendTo($container);
 	return $empty;
 };
 

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -193,9 +193,9 @@ frappe.views.BaseList = class BaseList {
 				List: "list",
 				Report: "sheet",
 				Calendar: "calendar",
-				Gantt: "gantt",
-				Kanban: "kanban",
-				Dashboard: "dashboard",
+				Gantt: "square-chart-gantt",
+				Kanban: "square-kanban",
+				Dashboard: "layout-dashboard",
 				Map: "map",
 			};
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -576,27 +576,22 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		return fields_order;
 	}
 
-	get_documentation_link() {
-		if (this.meta.documentation) {
-			return `<a href="${
-				this.meta.documentation
-			}" target="blank" class="meta-description small text-muted">${__("Need Help?")}</a>`;
-		}
-		return "";
-	}
-
 	get_no_result_message() {
-		let help_link = this.get_documentation_link();
 		let filters = this.filter_area && this.filter_area.get();
 
 		let has_filters_set = filters && filters.length;
-		let no_result_message = has_filters_set
-			? __("No {0} found with matching filters. Clear filters to see all {0}.", [
-					__(this.doctype),
-			  ])
+		// a short title; the detail (the doctype's own description, or the
+		// clear-filters hint) goes in the description below
+		let title = has_filters_set
+			? __("No {0} found", [__(this.doctype)])
+			: __("No {0} created", [__(this.doctype)]);
+		let description = has_filters_set
+			? __("Clear the filters to see all {0}.", [__(this.doctype)])
 			: this.meta.description
 			? __(this.meta.description)
-			: __("You haven't created a {0} yet", [__(this.doctype)]);
+			: this.can_create
+			? __("Create your first {0} to get started.", [__(this.doctype)])
+			: __("Nothing has been added yet.");
 
 		let new_button_label = has_filters_set
 			? __("Create a new {0}", [__(this.doctype)], "Create a new document from list view")
@@ -606,24 +601,38 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					"Create a new document from list view"
 			  );
 
-		const new_button = this.can_create
-			? `<p><button class="btn btn-default btn-sm btn-new-doc hidden-xs">
-				${new_button_label}
-			</button> <button class="btn btn-primary btn-new-doc visible-xs">
-				${__("Create New", null, "Create a new document from list view")}
-			</button></p>`
-			: "";
+		// the shared empty-state component. The create button keeps its
+		// .btn-new-doc class so setup_new_doc_event() still wires its click,
+		// and the docs link becomes a plain action — nothing else changes.
+		const actions = [];
+		if (this.can_create) {
+			actions.push({
+				label: new_button_label,
+				icon: "plus",
+				css_class: "btn-new-doc",
+			});
+		}
+		if (this.meta.documentation) {
+			actions.push({
+				label: __("Documentation"),
+				href: this.meta.documentation,
+				icon: "external-link",
+				variant: "outline",
+			});
+		}
 
-		return `<div class="msg-box no-border">
-			<div class="mb-4">
-			  	<svg class="icon icon-xl" style="stroke: var(--text-light);">
-					<use href="#icon-file"></use>
-				</svg>
-			</div>
-			<p>${no_result_message}</p>
-			${new_button}
-			${help_link}
-		</div>`;
+		let icon = "file";
+		if (this.meta.icon && !this.meta.icon.startsWith("fa fa-")) {
+			icon = this.meta.icon;
+		}
+
+		// returned as a string: base_list.setup_no_result_area interpolates it
+		return frappe.ui.empty_state({
+			icon,
+			title,
+			description,
+			actions,
+		})[0].outerHTML;
 	}
 
 	freeze() {

--- a/frappe/public/js/frappe/ui/components/empty_state.js
+++ b/frappe/public/js/frappe/ui/components/empty_state.js
@@ -1,0 +1,152 @@
+import { validated, safe_href } from "./utils.js";
+
+frappe.provide("frappe.ui");
+
+/**
+ * @typedef {Object} EmptyStateAction
+ * @property {string} label Button/link text. Rendered as text, never HTML.
+ * @property {"solid"|"subtle"|"outline"|"ghost"} [variant] Button look (defaults: subtle for buttons, ghost for links).
+ * @property {"gray"|"red"} [theme]
+ * @property {string} [icon] Leading lucide icon.
+ * @property {function} [onclick] Renders the action as a button (element form only).
+ * @property {string} [href] Renders the action as a link (opens in a new tab). Code-running schemes are refused.
+ * @property {string} [css_class] Extra classes on this action (e.g. a hook a caller wires clicks to).
+ */
+
+/**
+ * @typedef {Object} EmptyStateOpts
+ * @property {string} [icon] Lucide icon shown in a round grey well above the title.
+ * @property {string} title The headline. Rendered as text, never HTML.
+ * @property {string} [description] Smaller supporting line under the title.
+ * @property {EmptyStateAction[]} [actions] One or more actions — e.g. a "New …" button plus a docs link. Rendered in a row.
+ * @property {string} [css_class] Extra classes on the root (e.g. a min-height so it fills its container).
+ */
+
+const VARIANTS = ["solid", "subtle", "outline", "ghost"];
+
+// EmptyState has no state and no data-attribute contract, so it carries NO
+// component stylesheet — it's composed entirely from the shared utility
+// classes (utilities.scss + typography.css) right in the markup. The styling
+// mirrors frappe-ui (AccountingDesktop.vue): a round grey icon well, a
+// medium title, a small muted description, then the actions.
+
+/** One action → a button (onclick) or a link (href), styled as an es-button. */
+function build_action(action) {
+	if (!action || !action.label) return null;
+
+	if (action.href) {
+		// a real <a> so the docs link behaves like a link (new tab, etc.);
+		// reuses the es-button look via the class (button.css is element-neutral)
+		const href = safe_href(action.href, "empty_state");
+		const variant =
+			validated(action.variant, VARIANTS, "action variant", "empty_state") || "ghost";
+		const a = document.createElement("a");
+		a.className = ["es-button", action.css_class].filter(Boolean).join(" ");
+		if (variant !== "subtle") a.setAttribute("data-variant", variant);
+		if (action.theme === "red") a.setAttribute("data-theme", "red");
+		if (href) {
+			a.href = href;
+			a.target = "_blank";
+			a.rel = "noreferrer noopener";
+		}
+		if (action.icon) {
+			a.insertAdjacentHTML(
+				"beforeend",
+				frappe.utils.icon(action.icon, "sm", "", "", "", true)
+			);
+		}
+		const label = document.createElement("span");
+		label.className = "es-button__label";
+		label.textContent = action.label;
+		a.appendChild(label);
+		return a;
+	}
+
+	// onclick (or nothing) → a normal button
+	return frappe.ui.button({
+		label: action.label,
+		variant: action.variant,
+		theme: action.theme,
+		icon: action.icon,
+		size: action.size,
+		css_class: action.css_class,
+		onclick: action.onclick,
+	})[0];
+}
+
+/**
+ * A "nothing here yet" block for empty lists, reports, tables and pages:
+ * an icon, a title, an optional description, and any number of actions
+ * (a create button, a docs link, both). Styled purely with utility classes
+ * — there is no empty-state stylesheet.
+ * @param {EmptyStateOpts} [opts]
+ * @returns {JQuery} the root element
+ * @example
+ * list_area.append(frappe.ui.empty_state({
+ *     icon: "inbox",
+ *     title: __("No invoices yet"),
+ *     description: __("Create your first invoice to get started."),
+ *     actions: [
+ *         { label: __("New Invoice"), variant: "solid", icon: "plus", onclick: () => this.new_doc() },
+ *         { label: __("Learn more"), href: "https://docs.erpnext.com/invoicing", icon: "external-link" },
+ *     ],
+ * }));
+ */
+frappe.ui.empty_state = function (opts = {}) {
+	const wrap = document.createElement("div");
+	// Default breathing room: the content centres in a min-height box so it
+	// isn't jammed against the edges. Pass a bigger min-h-* in css_class to
+	// override — utilities are ordered ascending, so a larger step wins.
+	wrap.className = [
+		"flex flex-col items-center justify-center text-center gap-3 min-h-48",
+		opts.css_class,
+	]
+		.filter(Boolean)
+		.join(" ");
+
+	if (opts.icon) {
+		const well = document.createElement("div");
+		well.className =
+			"flex size-11 items-center justify-center rounded-full bg-surface-gray-2 text-ink-gray-5";
+		// icon inherits the well's ink colour via stroke="currentColor"
+		well.insertAdjacentHTML("beforeend", frappe.utils.icon(opts.icon, "md", "", "", "", true));
+		wrap.appendChild(well);
+	}
+
+	// title + description sit close together (their own tight gap)
+	const text = document.createElement("div");
+	text.className = "flex flex-col items-center gap-1";
+	const title = document.createElement("div");
+	title.className = "text-base-medium text-ink-gray-8";
+	title.textContent = opts.title || "";
+	text.appendChild(title);
+	if (opts.description) {
+		const desc = document.createElement("div");
+		desc.className = "text-p-sm text-ink-gray-5 max-w-xs";
+		desc.textContent = opts.description;
+		text.appendChild(desc);
+	}
+	wrap.appendChild(text);
+
+	const actions = (opts.actions || []).map(build_action).filter(Boolean);
+	if (actions.length) {
+		const row = document.createElement("div");
+		row.className = "flex flex-wrap items-center justify-center gap-2";
+		actions.forEach((node) => row.appendChild(node));
+		wrap.appendChild(row);
+	}
+
+	return $(wrap);
+};
+
+/**
+ * Markup-string form for templates. Static — button `onclick`s can't survive
+ * a string, so use `href` actions (or the element form) when you need clicks.
+ * @param {EmptyStateOpts} [opts]
+ * @returns {string}
+ */
+frappe.ui.empty_state.html = function (opts = {}) {
+	return frappe.ui.empty_state(opts)[0].outerHTML;
+};
+
+export default frappe.ui.empty_state;

--- a/frappe/public/js/frappe/ui/embedded_list.js
+++ b/frappe/public/js/frappe/ui/embedded_list.js
@@ -10,6 +10,10 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 			{
 				page_size: 50,
 				empty_message: __("No records found."),
+				empty_icon: "list",
+				// shown when records exist but the search box matched none of them
+				no_match_message: __("No matching records."),
+				no_match_icon: "search-x",
 				loading_message: __("Loading..."),
 				error_message: __("Failed to load data."),
 				columns: [],
@@ -43,9 +47,8 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 		this.$result = $(`<div class="embedded-list-result"></div>`)
 			.appendTo(this.$wrapper)
 			.hide();
-		this.$no_result = $(
-			`<div class="embedded-list-no-result text-muted">${this.empty_message}</div>`
-		)
+		this.$no_result = frappe.ui
+			.empty_state({ icon: this.empty_icon, title: this.empty_message })
 			.appendTo(this.$wrapper)
 			.hide();
 
@@ -377,7 +380,21 @@ frappe.ui.EmbeddedList = class EmbeddedList {
 	}
 
 	toggle_result_area() {
-		this.$result.toggle(this.data.length > 0);
-		this.$no_result.toggle(this.data.length === 0);
+		const has_rows = this.data.length > 0;
+		this.$result.toggle(has_rows);
+
+		if (!has_rows) {
+			// "no documents at all" vs "the search box filtered them all out"
+			// — records exist in _all_data only in the latter case
+			const searched = this._all_data && this._all_data.length > 0;
+			const $empty = frappe.ui.empty_state(
+				searched
+					? { icon: this.no_match_icon, title: this.no_match_message }
+					: { icon: this.empty_icon, title: this.empty_message }
+			);
+			this.$no_result.replaceWith($empty);
+			this.$no_result = $empty;
+		}
+		this.$no_result.toggle(!has_rows);
 	}
 };

--- a/frappe/public/js/frappe/views/dashboard/dashboard_view.js
+++ b/frappe/public/js/frappe/views/dashboard/dashboard_view.js
@@ -189,27 +189,17 @@ frappe.views.DashboardView = class DashboardView extends frappe.views.ListView {
 	}
 
 	render_empty_state() {
-		const no_result_message_html = `<p>${__(
-			"You haven't added any Dashboard Charts or Number Cards yet."
-		)}
-			<br>${__("Click On Customize to add your first widget")}</p>`;
-
-		const customize_button = `<p><button class="btn btn-primary btn-sm" data-action="customize">
-				${__("Customize")}
-			</button></p>`;
-
-		const empty_state_html = `<div class="msg-box no-border empty-dashboard">
-			<div>
-				<svg class="icon icon-xl" style="stroke: var(--text-light);">
-					<use href="#icon-file"></use>
-				</svg>
-			</div>
-			${no_result_message_html}
-			${customize_button}
-		</div>`;
-
-		this.$dashboard_wrapper.append(empty_state_html);
-		this.$empty_state = this.$dashboard_wrapper.find(".empty-dashboard");
+		// element form (appended, not interpolated) so the button's onclick
+		// survives; $empty_state is the element itself for the later .remove()
+		this.$empty_state = frappe.ui.empty_state({
+			icon: "layout-dashboard",
+			title: __("No charts or cards yet"),
+			description: __("Click Customize to add your first widget."),
+			actions: [
+				{ label: __("Customize"), variant: "solid", onclick: () => this.customize() },
+			],
+		});
+		this.$dashboard_wrapper.append(this.$empty_state);
 	}
 
 	customize() {

--- a/frappe/public/js/frappe/views/inbox/inbox_view.js
+++ b/frappe/public/js/frappe/views/inbox/inbox_view.js
@@ -168,41 +168,34 @@ frappe.views.InboxView = class InboxView extends frappe.views.ListView {
 	}
 
 	get_no_result_message() {
-		var email_account = this.email_account;
-		var args;
+		const email_account = this.email_account;
 		if (["Spam", "Trash"].includes(email_account)) {
-			return __("No {0} mail", [email_account]);
-		} else if (!email_account && !frappe.boot.email_accounts.length) {
-			// email account is not configured
-			args = {
-				doctype: "Email Account",
-				msg: __("No Email Account"),
-				label: __("New Email Account"),
-			};
-		} else {
-			// no sent mail
-			args = {
-				doctype: "Communication",
-				msg: __("No Emails"),
-				label: __("Compose Email"),
-			};
+			return frappe.ui.empty_state({
+				icon: "mail",
+				title: __("No {0} mail", [email_account]),
+			})[0].outerHTML;
 		}
 
-		const html = frappe.model.can_create(args.doctype)
-			? `<p>${args.msg}</p>
-			<p>
-				<button class="btn btn-primary btn-sm btn-new-doc">
-					${args.label}
-				</button>
-			</p>
-			`
-			: `<p>${__("No Email Accounts Assigned")}</p>`;
+		const args =
+			!email_account && !frappe.boot.email_accounts.length
+				? // email account is not configured
+				  {
+						doctype: "Email Account",
+						msg: __("No Email Account"),
+						label: __("New Email Account"),
+				  }
+				: // no mail
+				  { doctype: "Communication", msg: __("No Emails"), label: __("Compose Email") };
 
-		return `
-			<div class="msg-box no-border">
-				${html}
-			</div>
-		`;
+		// the create button keeps .btn-new-doc so setup_new_doc_event() wires it
+		const can_create = frappe.model.can_create(args.doctype);
+		return frappe.ui.empty_state({
+			icon: "mail",
+			title: can_create ? args.msg : __("No Email Accounts Assigned"),
+			actions: can_create
+				? [{ label: args.label, icon: "plus", css_class: "btn-new-doc" }]
+				: [],
+		})[0].outerHTML;
 	}
 
 	make_new_doc() {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -103,12 +103,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	get_no_result_message() {
-		return `<div class="msg-box no-border">
-			<svg class="icon icon-xl mb-4" style="stroke: var(--text-light);">
-				<use href="#icon-table"></use>
-			</svg>
-			<p>${__("Nothing to show")}</p>
-		</div>`;
+		return frappe.ui.empty_state({ icon: "sheet", title: __("Nothing to show") })[0].outerHTML;
 	}
 
 	setup_events() {

--- a/frappe/public/scss/common/utilities.scss
+++ b/frappe/public/scss/common/utilities.scss
@@ -171,6 +171,33 @@ $spacing-steps: (
 	min-width: 0;
 }
 
+/* size-<n> sets width AND height together (Tailwind's size-*), reusing the
+   spacing scale (1 step = 0.25rem) — for square boxes like icon wells and
+   avatars. Add steps to the list as call sites need them. */
+$size-steps: 4, 5, 6, 8, 9, 10, 11, 12, 14, 16;
+
+@each $n in $size-steps {
+	.size-#{$n} {
+		width: spacing-step($n);
+		height: spacing-step($n);
+	}
+}
+
+/* max-width caps (Tailwind's named scale). Add more as call sites need them. */
+.max-w-xs {
+	max-width: 20rem;
+}
+
+/* min-height steps (Tailwind's min-h-*, on the spacing scale) — e.g. giving
+   an empty state room to breathe. Bootstrap has no min-h-*, so no collision. */
+$min-h-steps: 24, 32, 40, 48, 64, 80, 96;
+
+@each $n in $min-h-steps {
+	.min-h-#{$n} {
+		min-height: spacing-step($n);
+	}
+}
+
 .truncate {
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -187,6 +214,11 @@ $spacing-steps: (
 
 .whitespace-nowrap {
 	white-space: nowrap;
+}
+
+/* ---- text alignment ---- */
+.text-center {
+	text-align: center;
 }
 
 /* ---- borders (1px, outline-gray-2 by default; add a border-outline-*

--- a/frappe/public/scss/desk/dashboard_view.scss
+++ b/frappe/public/scss/desk/dashboard_view.scss
@@ -20,11 +20,6 @@
 			min-height: 110px;
 		}
 	}
-
-	.empty-dashboard {
-		margin-top: 45px;
-	}
-
 	// .page-form {
 	// 	height: 50px;
 

--- a/frappe/public/scss/desk/doctype_settings.scss
+++ b/frappe/public/scss/desk/doctype_settings.scss
@@ -423,38 +423,3 @@
 	border-radius: var(--radius);
 	background-color: var(--surface-base);
 }
-
-// Empty state muted icon ▸ bold title ▸ muted description ▸ subtle action.
-.dts-empty {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	text-align: center;
-	padding: var(--padding-2xl) var(--padding-lg);
-	gap: calc(var(--spacing) * 2);
-
-	.dts-empty-icon {
-		color: var(--ink-gray-5);
-
-		.icon {
-			width: 32px;
-			height: 32px;
-		}
-	}
-
-	.dts-empty-title {
-		color: var(--ink-gray-8);
-		font-size: var(--text-2xl);
-		font-weight: var(--weight-medium);
-	}
-
-	.dts-empty-description {
-		color: var(--ink-gray-5);
-		font-size: var(--text-base);
-	}
-
-	// Spacing only — the button's look comes from `.es-button` (subtle gray variant).
-	.dts-empty-action {
-		margin-top: var(--spacing);
-	}
-}

--- a/frappe/public/scss/desk/embedded_list.scss
+++ b/frappe/public/scss/desk/embedded_list.scss
@@ -139,14 +139,6 @@
 		}
 	}
 
-	.embedded-list-no-result {
-		text-align: center;
-		padding: 40px 20px;
-		border: 1px dashed var(--border-color);
-		border-radius: var(--radius-5);
-		margin-bottom: 14px;
-	}
-
 	.embedded-list-more {
 		display: flex;
 		justify-content: space-between;


### PR DESCRIPTION
1. Adds a new common empty state component for list views, dashboard, reports etc.
2. Replaced empty state components in Embedded List and DocType settings in favour of the new standard component. Dropped duplicate CSS.
3. Replaced empty state components and simplified language in DocType lists, dashboard, reports. If a DocType has description + icon + documentation link added - the empty state looks really nice. Follow up would be to update major DocTypes in ERPNext/HR with these.
4. EmbeddedList is now lazy loaded and split from the main desk bundle
5. Fixed icons on the page dropdown for views

<img width="3510" height="1976" alt="CleanShot 2026-07-12 at 20 45 02@2x" src="https://github.com/user-attachments/assets/c63e5dcc-2d22-4798-b265-6421ffe49a55" />

<img width="1916" height="989" alt="image" src="https://github.com/user-attachments/assets/e39fdb70-e272-4f65-9aea-bd1532a609f3" />


`no-docs`