### PR TITLE
fix: data masking ignores role permissions for child table fields

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -350,6 +350,7 @@ class Engine:
 		if self.apply_permissions:
 			# Store metadata for masked field processing during execution.
 			self.query._doctype = self.doctype
+			self.query._parent_doctype = self.parent_doctype
 			self.query._fields_list = getattr(self, "fields", [])
 
 		self.query.immutable = True

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -78,10 +78,11 @@ def getdoctype(doctype: str, with_parent: int | bool = False):
 
 
 def get_meta_bundle(doctype):
-	bundle = [frappe.desk.form.meta.get_meta(doctype)]
+	form_meta = frappe.desk.form.meta.get_meta(doctype)
+	bundle = [form_meta.as_dict(no_nulls=True)]
 	bundle.extend(
-		frappe.desk.form.meta.get_meta(df.options)
-		for df in bundle[0].fields
+		frappe.desk.form.meta.get_meta(df.options).as_dict(no_nulls=True, parenttype=doctype)
+		for df in form_meta.fields
 		if df.fieldtype in frappe.model.table_fields
 	)
 	return bundle

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -69,7 +69,7 @@ class FormMeta(Meta):
 
 		self.set("__assets_loaded", True)
 
-	def as_dict(self, no_nulls=False):
+	def as_dict(self, no_nulls=False, parenttype=None):
 		d = super().as_dict(no_nulls=no_nulls)
 		__dict = self.__dict__
 
@@ -77,7 +77,7 @@ class FormMeta(Meta):
 			d[k] = __dict.get(k)
 
 		# add masked fields (per-user, per-meta)
-		d["masked_fields"] = [df.fieldname for df in self.get_masked_fields()]
+		d["masked_fields"] = [df.fieldname for df in self.get_masked_fields(parenttype=parenttype)]
 
 		return d
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -275,7 +275,7 @@ class DatabaseQuery:
 
 		meta = self.get_meta(self.doctype)
 
-		return meta.get_masked_fields()
+		return meta.get_masked_fields(parenttype=self.parent_doctype)
 
 	def build_and_run(self):
 		args = self.prepare_args()

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -576,7 +576,9 @@ class Document(BaseDocument):
 			self.set(field.fieldname, mask_field_value(field, val))
 
 		for table_field in self.meta.get_table_fields():
-			child_mask_fields = frappe.get_meta(table_field.options).get_masked_fields()
+			child_mask_fields = frappe.get_meta(table_field.options).get_masked_fields(
+				parenttype=self.doctype
+			)
 			if not child_mask_fields:
 				continue
 
@@ -1285,7 +1287,7 @@ class Document(BaseDocument):
 		child_mask_fields = {
 			table_field.fieldname: masked
 			for table_field in self.meta.get_table_fields()
-			if (masked := frappe.get_meta(table_field.options).get_masked_fields())
+			if (masked := frappe.get_meta(table_field.options).get_masked_fields(parenttype=self.doctype))
 		}
 		if not mask_fields and not child_mask_fields:
 			return

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -196,20 +196,19 @@ class Meta(Document):
 	def get_dynamic_link_fields(self):
 		return self._dynamic_link_fields
 
-	def get_masked_fields(self):
+	def get_masked_fields(self, parenttype=None):
 		import copy
 
 		if frappe.session.user == "Administrator":
 			return []
-		cache_key = f"masked_fields::{self.name}::{frappe.session.user}"
+		cache_key = f"masked_fields::{self.name}::{parenttype or ''}::{frappe.session.user}"
 		masked_fields = frappe.cache.get_value(cache_key)
 
 		if masked_fields is None:
 			masked_fields = []
+			permlevel_access = set(self.get_permlevel_access("mask", parenttype))
 			for df in self.fields:
-				if df.get("mask") and not self.has_permlevel_access_to(
-					fieldname=df.fieldname, df=df, permission_type="mask"
-				):
+				if df.get("mask") and df.permlevel not in permlevel_access:
 					# work on a copy instead of original df
 					df_copy = copy.deepcopy(df)
 					df_copy.mask_readonly = 1

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -85,6 +85,7 @@ def mask_fields(
 	result: list[dict] | list[tuple],
 	as_dict: bool = True,
 	pluck: bool = False,
+	parent_doctype: str | None = None,
 ) -> list[dict] | list[tuple]:
 	"""Mask fields in the result based on the doctype's masked fields.
 
@@ -94,6 +95,8 @@ def mask_fields(
 		result: Query results as list of dicts or tuples
 		as_dict: Whether results are dictionaries (True) or tuples (False)
 		pluck: Whether results were plucked into a flat list of scalar values
+		parent_doctype: Parent DocType when querying a child table, used to
+			resolve role permissions for the `mask` permission type
 	Returns:
 		Result with masked field values applied based on user permissions
 	"""
@@ -104,7 +107,7 @@ def mask_fields(
 	if doctype in CORE_DOCTYPES:
 		return result
 
-	masked_fields = frappe.get_meta(doctype).get_masked_fields()
+	masked_fields = frappe.get_meta(doctype).get_masked_fields(parenttype=parent_doctype)
 
 	if not masked_fields:
 		return result
@@ -129,6 +132,7 @@ def mask_fields(
 
 def execute_query(query, *args, **kwargs):
 	dt = query.__dict__.get("_doctype")
+	parent_dt = query.__dict__.get("_parent_doctype")
 	fields = query.__dict__.get("_fields_list", [])
 	child_queries = query._child_queries
 	query, params = prepare_query(query)
@@ -136,12 +140,35 @@ def execute_query(query, *args, **kwargs):
 
 	if child_queries and isinstance(child_queries, list) and result:
 		execute_child_queries(child_queries, result)
+		if dt:
+			mask_child_query_fields(child_queries, result)
 
 	if result and dt and fields:
 		as_dict = kwargs.get("as_dict", not kwargs.get("as_list", False))
-		result = mask_fields(dt, fields, result, as_dict=as_dict, pluck=kwargs.get("pluck", False))
+		result = mask_fields(
+			dt, fields, result, as_dict=as_dict, pluck=kwargs.get("pluck", False), parent_doctype=parent_dt
+		)
 
 	return result
+
+
+def mask_child_query_fields(child_queries, result):
+	if not isinstance(result[0], dict):
+		return
+
+	from frappe.database.query import CORE_DOCTYPES
+	from frappe.model.utils.mask import mask_dict_results
+
+	for child_query in child_queries:
+		if child_query.doctype in CORE_DOCTYPES:
+			continue
+		masked_fields = frappe.get_meta(child_query.doctype).get_masked_fields(
+			parenttype=child_query.parent_doctype
+		)
+		if not masked_fields:
+			continue
+		for row in result:
+			mask_dict_results(row.get(child_query.fieldname) or [], masked_fields)
 
 
 def execute_child_queries(queries, result):

--- a/frappe/tests/test_mask_fields.py
+++ b/frappe/tests/test_mask_fields.py
@@ -433,6 +433,76 @@ class TestMaskFieldsInChildTable(IntegrationTestCase):
 		self.assertEqual(flt(saved.rate), 1234.5)  # masked value restored, not overwritten
 		self.assertEqual(flt(saved.public_qty), 9)  # unmasked field still writable
 
+	def _grant_mask_permission(self):
+		update_permission_property(self.dt, self.TEST_ROLE, 0, "mask", 1)
+		frappe.clear_cache(doctype=self.dt)
+
+	def _revoke_mask_permission(self):
+		frappe.set_user("Administrator")
+		update_permission_property(self.dt, self.TEST_ROLE, 0, "mask", 0)
+		frappe.clear_cache(doctype=self.dt)
+
+	def test_child_fields_unmasked_with_parent_mask_permission(self):
+		"""The mask permission on the parent doctype must unmask child-table fields,
+		since child doctypes have no role permissions of their own (issue #40790)."""
+		self._grant_mask_permission()
+		try:
+			frappe.set_user(self.TEST_USER)
+			doc = frappe.get_doc(self.dt, self.docname)
+			doc.apply_fieldlevel_read_permissions()
+
+			self.assertEqual(doc.items[0].secret_note, "child_secret")
+			self.assertEqual(flt(doc.items[0].rate), 1234.5)
+		finally:
+			self._revoke_mask_permission()
+
+	def test_qb_child_query_masks_for_non_admin(self):
+		"""Child rows fetched via the query builder's child queries must be masked."""
+		frappe.set_user(self.TEST_USER)
+		rows = frappe.qb.get_query(
+			self.dt,
+			fields=["name", {"items": ["secret_note", "rate"]}],
+			filters={"name": self.docname},
+			ignore_permissions=False,
+		).run(as_dict=True)
+
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0]["items"][0]["secret_note"], "XXXXXXXX")
+		self.assertEqual(rows[0]["items"][0]["rate"], "XXXXXXXX")
+
+	def test_qb_child_query_unmasked_with_parent_mask_permission(self):
+		self._grant_mask_permission()
+		try:
+			frappe.set_user(self.TEST_USER)
+			rows = frappe.qb.get_query(
+				self.dt,
+				fields=["name", {"items": ["secret_note"]}],
+				filters={"name": self.docname},
+				ignore_permissions=False,
+			).run(as_dict=True)
+
+			self.assertEqual(rows[0]["items"][0]["secret_note"], "child_secret")
+		finally:
+			self._revoke_mask_permission()
+
+	def test_form_meta_child_masked_fields_respect_parent_permission(self):
+		"""masked_fields in the form meta bundle for a child doctype must follow the
+		parent doctype's mask permission."""
+		from frappe.desk.form.load import get_meta_bundle
+
+		frappe.set_user(self.TEST_USER)
+		child_meta_dict = next(d for d in get_meta_bundle(self.dt) if d["name"] == self.child_dt)
+		self.assertEqual(set(child_meta_dict["masked_fields"]), {"secret_note", "rate"})
+
+		frappe.set_user("Administrator")
+		self._grant_mask_permission()
+		try:
+			frappe.set_user(self.TEST_USER)
+			child_meta_dict = next(d for d in get_meta_bundle(self.dt) if d["name"] == self.child_dt)
+			self.assertEqual(child_meta_dict["masked_fields"], [])
+		finally:
+			self._revoke_mask_permission()
+
 
 class TestMaskFieldsWithUserPermissions(IntegrationTestCase):
 	"""


### PR DESCRIPTION
Masking on child table fields could never be unmasked for any role. Child doctypes inherit permissions from their parent, but the masking code never passed `parenttype` to `Meta.get_permissions()`. As a result, `get_masked_fields()` always assumed no access and masked child fields for everyone except `Administrator`, making the **Mask** checkbox ineffective for child fields.

Thread `parenttype` through the masking path so child table masking follows the parent doctype's permissions, matching existing permlevel behavior. This also masks child rows returned by query builder child queries and passes `parenttype` when building form metadata without changing the response payload.


### Role

<img width="1457" height="393" alt="Screenshot 2026-07-12 at 9 03 19 PM" src="https://github.com/user-attachments/assets/718764d7-d02e-4360-8656-d5f0a06176cc" />

### Before 

<img width="1291" height="752" alt="Screenshot 2026-07-12 at 9 04 29 PM" src="https://github.com/user-attachments/assets/9bbb9236-a0a0-4d85-b884-db4dd6b2f39a" />


### After

<img width="1291" height="722" alt="Screenshot 2026-07-12 at 9 03 30 PM" src="https://github.com/user-attachments/assets/b7087cf1-36e4-442a-90db-cb5a53669056" />

---

Closes #40790.