### PR TITLE
fix(print-format-builder): close color picker on outside click and swatch pick

### DIFF
--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -264,6 +264,7 @@
 import draggable from "vuedraggable";
 import Autocomplete from "../../vue-components/Autocomplete.vue";
 import { get_table_columns, pluck } from "../utils";
+import { mountColorControl } from "./inspector/useColorControl";
 import { useStore } from "../stores";
 import { computed, onMounted, onUnmounted, nextTick, ref, watch, inject } from "vue";
 
@@ -381,24 +382,17 @@ function mount_color_controls() {
 	for (const c of color_settings) {
 		const host = color_hosts.value[c.fieldname];
 		if (!host) continue;
-		host.innerHTML = "";
-		const control = frappe.ui.form.make_control({
-			parent: host,
-			df: {
-				fieldtype: "Color",
-				fieldname: c.fieldname,
-				placeholder: c.label,
-				change() {
-					const value = control.get_value() || null;
-					if ((print_format.value[c.fieldname] ?? null) !== value) {
-						print_format.value[c.fieldname] = value;
-					}
-				},
+		mountColorControl(host, {
+			value: print_format.value[c.fieldname] || "",
+			placeholder: c.label,
+			fieldname: c.fieldname,
+			onChange(value) {
+				const v = value || null;
+				if ((print_format.value[c.fieldname] ?? null) !== v) {
+					print_format.value[c.fieldname] = v;
+				}
 			},
-			render_input: true,
-			only_input: true,
 		});
-		control.set_value(print_format.value[c.fieldname] || "");
 	}
 }
 

--- a/frappe/public/js/print_format_builder/components/inspector/useColorControl.js
+++ b/frappe/public/js/print_format_builder/components/inspector/useColorControl.js
@@ -22,5 +22,29 @@ export function mountColorControl(
 	// `change` skips that validate-and-clear so typing a colour isn't erased.
 	control.change = control.df.change;
 	control.set_value(value || "");
+	setup_popover_close(control, host);
 	return control;
+}
+
+// The core popover closes via a bubbled body click, which never arrives in the
+// builder (canvas/inspector handlers stop propagation) — close on capture instead
+function setup_popover_close(control, host) {
+	const hide = () => control.$wrapper.popover("hide");
+	const close_if_outside = (e) => {
+		if (!document.body.contains(host)) {
+			document.removeEventListener("click", close_if_outside, true);
+			return;
+		}
+		if (e.target.closest(".color-picker-popover") || host.contains(e.target)) return;
+		hide();
+	};
+	control.$wrapper
+		.on("shown.bs.popover", () => document.addEventListener("click", close_if_outside, true))
+		.on("hidden.bs.popover", () =>
+			document.removeEventListener("click", close_if_outside, true)
+		);
+	// A swatch is a discrete pick — commit and close
+	control.picker?.color_picker_wrapper?.addEventListener("click", (e) => {
+		if (e.target.closest(".swatch")) hide();
+	});
 }

--- a/frappe/public/js/print_format_builder/components/inspector/useColorControl.js
+++ b/frappe/public/js/print_format_builder/components/inspector/useColorControl.js
@@ -31,7 +31,7 @@ export function mountColorControl(
 function setup_popover_close(control, host) {
 	const hide = () => control.$wrapper.popover("hide");
 	const close_if_outside = (e) => {
-		if (!document.body.contains(host)) {
+		if (!document.body.contains(control.$wrapper[0])) {
 			document.removeEventListener("click", close_if_outside, true);
 			return;
 		}


### PR DESCRIPTION
- the color popover never closed in the builder: the core control closes via a bubbled `body` click, and the builder's canvas/inspector click handlers stop propagation, so the click never reached it — close via a capture-phase document listener instead
- clicking a swatch is a discrete pick, so it commits and closes the popover (gradient/hue interaction keeps it open)
- `PrintFormatControls` duplicated the color-control mount inline; folded into the shared `mountColorControl` so all four call sites get the fix