### PR TITLE
perf: lazy load user settings dialog

### DIFF
--- a/frappe/public/js/desk.bundle.js
+++ b/frappe/public/js/desk.bundle.js
@@ -65,7 +65,6 @@ import "./frappe/form/link_selector.js";
 import "./frappe/form/multi_select_dialog.js";
 import "./frappe/ui/dialog.js";
 import "./frappe/ui/settings_dialog.js";
-import "./frappe/ui/user_settings_dialog.js";
 import "./frappe/ui/menu.js";
 import "./frappe/ui/capture.js";
 import "./frappe/ui/permission_dialog.js";

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -423,7 +423,23 @@ frappe.ui.Sidebar = class Sidebar {
 					label: __("Settings"),
 					icon: "settings",
 					onClick: function () {
-						frappe.ui.show_user_settings("profile");
+						// The Settings dialog is lazy (not in the desk bundle); pull it
+						// in on click, then open it.
+						frappe
+							.require("user_settings_dialog.bundle.js")
+							.then(() => frappe.ui.show_user_settings("profile"))
+							.catch((e) => {
+								console.error(
+									"Sidebar: failed to load user_settings_dialog.bundle.js",
+									e
+								);
+								frappe.ui.toast({
+									message: __(
+										"Could not open Settings. Please refresh the page."
+									),
+									type: "error",
+								});
+							});
 					},
 				},
 				{

--- a/frappe/public/js/frappe/ui/user_settings_dialog.js
+++ b/frappe/public/js/frappe/ui/user_settings_dialog.js
@@ -191,7 +191,6 @@ function _profile_tab(user_data) {
 					</div>
 					${frappe.ui.button.html({
 						label: __("Change Password"),
-						icon: "rotate-ccw-key",
 						css_class: "change-password-btn",
 					})}
 				</div>

--- a/frappe/public/js/frappe/ui/user_settings_dialog.js
+++ b/frappe/public/js/frappe/ui/user_settings_dialog.js
@@ -46,9 +46,9 @@ frappe.ui.show_user_settings = async function (default_tab) {
 			...response.message,
 		};
 	} catch (e) {
-		frappe.show_alert({
+		frappe.ui.toast({
 			message: __("Failed to load settings"),
-			indicator: "red",
+			type: "error",
 		});
 		console.error(e);
 		return;
@@ -87,9 +87,14 @@ function _save_user(fieldname_or_dict, value) {
 	return frappe.db
 		.set_value("User", frappe.session.user, fieldname_or_dict, value)
 		.then((res) => {
-			frappe.show_alert({
-				message: __("Saved. Refresh to see changes."),
-				indicator: "green",
+			frappe.ui.toast({
+				message: __("Saved"),
+				description: __("Refresh to see changes"),
+				type: "success",
+				action: {
+					label: __("Refresh"),
+					onclick: () => location.reload(),
+				},
 			});
 			if (frappe.boot.user) {
 				// Update the user data in the boot user object
@@ -110,7 +115,7 @@ function _save_user(fieldname_or_dict, value) {
 			return Promise.resolve(res);
 		})
 		.catch((e) => {
-			frappe.show_alert({ message: __("Failed to save"), indicator: "red" });
+			frappe.ui.toast({ message: __("Failed to save"), type: "error" });
 			console.error(e);
 			throw e;
 		});
@@ -692,17 +697,17 @@ function _session_defaults_tab() {
 					args: { default_values: values },
 					callback(data) {
 						if (data.message === "success") {
-							frappe.show_alert({
+							frappe.ui.toast({
 								message: __("Saved"),
-								indicator: "green",
+								type: "success",
 							});
 							frappe.ui.toolbar.clear_cache();
 						} else {
-							frappe.show_alert({
+							frappe.ui.toast({
 								message: __(
 									"An error occurred while updating your session defaults."
 								),
-								indicator: "red",
+								type: "error",
 							});
 						}
 					},

--- a/frappe/public/js/frappe/ui/user_settings_dialog.js
+++ b/frappe/public/js/frappe/ui/user_settings_dialog.js
@@ -180,18 +180,27 @@ function _profile_tab(user_data) {
 			const email = frappe.session.user_email || user;
 
 			panel.body.html(`
-				<div class="user-settings-profile-header">
-					<div class="profile-avatar-upload" title="${__("Upload Photo")}">
-						${frappe.avatar(user, "avatar-large")}
-						<div class="profile-avatar-overlay">${frappe.utils.icon("camera", "md")}</div>
+				<div class="flex items-center gap-3 pt-4 pb-5">
+					<div class="profile-avatar-upload relative flex shrink-0 rounded-full overflow-hidden cursor-pointer" title="${__(
+						"Upload Photo"
+					)}">
+						${frappe.ui.avatar.html({
+							image: frappe.user_info(user).image,
+							label: full_name,
+							size: "3xl",
+						})}
+						<div class="profile-avatar-overlay absolute inset-0 flex items-center justify-center">${frappe.utils.icon(
+							"camera",
+							"md"
+						)}</div>
 					</div>
-					<div class="profile-user-info">
-						<div class="profile-full-name">${frappe.utils.escape_html(full_name)}</div>
-						<div class="profile-email">${frappe.utils.escape_html(email)}</div>
+					<div class="flex flex-col gap-0.5">
+						<div class="text-lg-semibold text-ink-gray-8">${frappe.utils.escape_html(full_name)}</div>
+						<div class="text-sm text-ink-gray-6">${frappe.utils.escape_html(email)}</div>
 					</div>
 					${frappe.ui.button.html({
 						label: __("Change Password"),
-						css_class: "change-password-btn",
+						css_class: "change-password-btn ms-auto",
 					})}
 				</div>
 			`);
@@ -342,7 +351,7 @@ function _render_layout_cards(panel) {
 		{ name: "full", label: __("Full Width"), full: true },
 	];
 
-	const $grid = $(`<div class="layout-grid"></div>`);
+	const $grid = $(`<div class="flex gap-3 mb-4 max-w-lg"></div>`);
 
 	options.forEach((opt) => {
 		const selected = opt.full === is_full;
@@ -378,8 +387,14 @@ function _layout_preview_window(type) {
 		<div class="theme-preview-input"></div>
 	</div>`;
 
-	return `<div class="layout-preview-frame">
-		<div class="layout-preview-window">
+	// The mock browser window: a "frame" tucked into the surface with the window
+	// inset from its top + start edges (ps-5/pt-4), and the window drawing only
+	// its top + start borders so the rest bleeds off. The compact variant insets
+	// its body (px-8) so the fields look narrower than full width.
+	const body_class = type === "compact" ? "px-8" : "";
+
+	return `<div class="flex flex-1 bg-surface-base ps-5 pt-4 rounded-ss-sm">
+		<div class="w-full flex flex-col overflow-hidden bg-surface-base border-t border-s rounded-ss-sm">
 			<div class="theme-preview-titlebar">
 				<span class="theme-preview-dot theme-preview-dot--red"></span>
 				<span class="theme-preview-dot theme-preview-dot--yellow"></span>
@@ -392,7 +407,7 @@ function _layout_preview_window(type) {
 						<div class="theme-preview-header-title"></div>
 						<div class="theme-preview-header-action"></div>
 					</div>
-					<div class="theme-preview-body layout-preview-body--${type}">
+					<div class="theme-preview-body ${body_class}">
 						${field}${field}${field}${field}
 					</div>
 				</div>
@@ -494,10 +509,12 @@ function _preferences_tab(user_data) {
 
 function _add_preference_row(parent, { label, value, button_label, onClick }) {
 	const $row = $(`
-		<div class="preference-row">
-			<div>
-				<div class="preference-label">${label}</div>
-				<div class="preference-value">${frappe.utils.escape_html(value || "")}</div>
+		<div class="flex justify-between items-center gap-8 py-2">
+			<div class="flex flex-col min-w-0 gap-0.5">
+				<div class="text-sm text-ink-gray-6">${label}</div>
+				<div class="preference-value text-base text-ink-gray-8">${frappe.utils.escape_html(
+					value || ""
+				)}</div>
 			</div>
 			${frappe.ui.button.html({ label: button_label })}
 		</div>
@@ -708,7 +725,9 @@ function _session_defaults_tab() {
 			? undefined
 			: (panel) => {
 					panel.body.html(
-						`<div class="text-muted">${__("No session defaults configured.")}</div>`
+						`<div class="text-ink-gray-6">${__(
+							"No session defaults configured."
+						)}</div>`
 					);
 			  },
 	};
@@ -729,7 +748,7 @@ function _keyboard_shortcuts_tab() {
 				if (html) panel.body.append(html);
 			});
 			panel.body.append(
-				`<div class="text-muted mt-2">${__(
+				`<div class="text-ink-gray-6 mt-2">${__(
 					"Press Alt Key to trigger additional shortcuts in Menu and Sidebar"
 				)}</div>`
 			);

--- a/frappe/public/js/user_settings_dialog.bundle.js
+++ b/frappe/public/js/user_settings_dialog.bundle.js
@@ -1,0 +1,5 @@
+// Lazy bundle for frappe.ui.show_user_settings — the user Settings dialog is
+// only opened on demand (from the sidebar user menu), so it's kept out of the
+// eager desk bundle and pulled in with
+// frappe.require("user_settings_dialog.bundle.js").
+import "./frappe/ui/user_settings_dialog.js";

--- a/frappe/public/scss/common/utilities.scss
+++ b/frappe/public/scss/common/utilities.scss
@@ -37,6 +37,19 @@
 	display: none;
 }
 
+/* ---- position ---- (Tailwind's names; bootstrap uses .position-* so no clash) */
+.relative {
+	position: relative;
+}
+
+.absolute {
+	position: absolute;
+}
+
+.inset-0 {
+	inset: 0;
+}
+
 /* ---- flex direction / wrap ---- */
 .flex-col {
 	flex-direction: column;
@@ -110,6 +123,9 @@ $spacing-steps: (
 	"2": 2,
 	"3": 3,
 	"4": 4,
+	"5": 5,
+	"6": 6,
+	"8": 8,
 );
 
 @function spacing-step($n) {
@@ -126,12 +142,14 @@ $spacing-steps: (
 	}
 }
 
-/* TODO: we can't add p-, px-, py-, pt-, pb- or the m- versions yet.
-   Bootstrap already has classes with these exact names that use
-   !important, so ours would never take effect. Once Bootstrap's spacing
-   classes are removed (about 100 places in markup still use them), these
-   names become free. Until then, use ps-* and pe-* together when you
-   need both sides. */
+/* p-*, px-, py-, pt-, pb- and the m- versions are NOT defined here — but you
+   can use them in markup anyway. Bootstrap owns those exact names (with
+   !important), and as of the $spacers remap in desk/variables.scss its scale
+   now matches ours: bootstrap .p-3 = 12px = our .gap-3, .p-4 = 16px, and so on
+   up the 4px grid. So reach for bootstrap's p-* and m-* for physical padding and
+   margin; use ps-*,pe-*,ms-*,me-* below when you need logical (RTL-flipping)
+   sides, or gap on the parent. When bootstrap's utilities are eventually
+   dropped, these names move here — same values, no markup change. */
 
 @each $name, $n in $spacing-steps {
 	.ps-#{$name} {
@@ -188,6 +206,10 @@ $size-steps: 4, 5, 6, 8, 9, 10, 11, 12, 14, 16;
 	max-width: 20rem;
 }
 
+.max-w-lg {
+	max-width: 32rem;
+}
+
 /* min-height steps (Tailwind's min-h-*, on the spacing scale) — e.g. giving
    an empty state room to breathe. Bootstrap has no min-h-*, so no collision. */
 $min-h-steps: 24, 32, 40, 48, 64, 80, 96;
@@ -214,6 +236,11 @@ $min-h-steps: 24, 32, 40, 48, 64, 80, 96;
 
 .whitespace-nowrap {
 	white-space: nowrap;
+}
+
+/* ---- cursor ---- */
+.cursor-pointer {
+	cursor: pointer;
 }
 
 /* ---- text alignment ---- */
@@ -389,6 +416,38 @@ $focus-colors: "default", "red", "green", "amber", "blue", "violet";
 
 .rounded-full {
 	border-radius: var(--radius-full);
+}
+
+/* per-corner radius — Tailwind's logical corner names, so a rounded corner
+   tucked against a border-s/border-t edge stays put when the layout flips:
+     ss = start-start (top-left in LTR)   se = start-end (top-right)
+     es = end-start   (bottom-left)       ee = end-end   (bottom-right)
+   The suffix picks the same radius tokens as the all-corner .rounded-* scale
+   above (unsuffixed = the base radius). rtlcss leaves logical properties alone,
+   so these flip for free. */
+$radius-corners: (
+	"ss": start-start,
+	"se": start-end,
+	"es": end-start,
+	"ee": end-end,
+);
+$radius-sizes: (
+	"-none": var(--radius-none),
+	"-sm": var(--radius-sm),
+	"": var(--radius),
+	"-md": var(--radius-md),
+	"-lg": var(--radius-lg),
+	"-xl": var(--radius-xl),
+	"-2xl": var(--radius-2xl),
+	"-full": var(--radius-full),
+);
+
+@each $corner, $edges in $radius-corners {
+	@each $suffix, $token in $radius-sizes {
+		.rounded-#{$corner}#{$suffix} {
+			border-#{$edges}-radius: $token;
+		}
+	}
 }
 
 /* ---- responsive and dark-mode variants (add only when needed) ----

--- a/frappe/public/scss/desk/user_settings_dialog.scss
+++ b/frappe/public/scss/desk/user_settings_dialog.scss
@@ -1,131 +1,15 @@
-.settings-dialog-wrapper {
-	.user-settings-profile-header {
-		display: flex;
-		align-items: center;
-		gap: var(--padding-lg);
-		padding: var(--padding-md) 0 var(--padding-lg);
+.profile-avatar-overlay {
+	background-color: var(--surface-alpha-gray-7);
+	color: var(--ink-base);
+	opacity: 0;
+	transition: opacity 0.2s ease-in-out;
+}
 
-		.profile-avatar-upload {
-			position: relative;
-			flex-shrink: 0;
-			border-radius: 50%;
-			overflow: hidden;
-			cursor: pointer;
-		}
+[data-theme="dark"] .profile-avatar-overlay {
+	background-color: var(--surface-alpha-gray-4);
+	color: var(--ink-gray-9);
+}
 
-		.profile-avatar-overlay {
-			position: absolute;
-			inset: 0;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			background-color: var(--surface-alpha-gray-7);
-			color: var(--white);
-			opacity: 0;
-			transition: opacity 0.2s ease-in-out;
-
-			.icon use {
-				stroke: var(--white);
-			}
-		}
-
-		.profile-avatar-upload:hover .profile-avatar-overlay {
-			opacity: 1;
-		}
-
-		.avatar {
-			flex-shrink: 0;
-		}
-
-		.profile-user-info {
-			display: flex;
-			flex-direction: column;
-			gap: 2px;
-		}
-
-		.profile-full-name {
-			font-size: var(--text-lg);
-			font-weight: var(--weight-semibold);
-			color: var(--text-color);
-		}
-
-		.profile-email {
-			font-size: var(--text-sm);
-			color: var(--text-muted);
-		}
-
-		.change-password-btn {
-			margin-left: auto;
-		}
-	}
-
-	.settings-shortcuts-table {
-		font-size: var(--text-sm);
-		margin-top: 0;
-		margin-bottom: var(--margin-lg);
-
-		kbd {
-			font-size: var(--text-xs);
-		}
-	}
-
-	.layout-grid {
-		display: flex;
-		gap: 12px;
-		max-width: 484px;
-		margin-bottom: var(--margin-md);
-	}
-
-	.layout-preview-frame {
-		flex: 1;
-		display: flex;
-		padding-left: 20px;
-		padding-top: 14px;
-		background-color: var(--surface-base);
-		border-top-left-radius: var(--radius-sm);
-	}
-
-	.layout-preview-window {
-		width: 100%;
-		display: flex;
-		flex-direction: column;
-		overflow: hidden;
-		border: 1px solid var(--outline-gray-2);
-		border-bottom: none;
-		border-right: none;
-		border-top-left-radius: var(--radius-sm);
-		background-color: var(--surface-base);
-	}
-
-	.layout-preview-body--compact {
-		padding-left: 30px;
-		padding-right: 30px;
-	}
-
-	.preference-row {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		gap: 2rem;
-		padding: var(--padding-sm) 0;
-
-		> :first-child {
-			display: flex;
-			flex-direction: column;
-			gap: 2px;
-			min-width: 0;
-		}
-	}
-
-	.preference-label {
-		font-size: var(--text-sm);
-		font-weight: var(--weight-regular);
-		color: var(--text-muted);
-	}
-
-	.preference-value {
-		font-size: var(--text-base);
-		font-weight: var(--weight-regular);
-		color: var(--text-color);
-	}
+.profile-avatar-upload:hover .profile-avatar-overlay {
+	opacity: 1;
 }

--- a/frappe/public/scss/desk/variables.scss
+++ b/frappe/public/scss/desk/variables.scss
@@ -118,6 +118,32 @@ $dropdown-item-padding-y: var(--padding-sm);
 $dropdown-item-padding-x: var(--padding-sm);
 
 $spacer: 14px;
+
+// Remap Bootstrap's spacing scale onto the espresso 4px grid. Bootstrap derives
+// $spacers from $spacer (14px), which produced off-grid values (p-2=7px, p-3=14,
+// p-4=21, p-5=42) that never lined up with our gap-*/ps-* utilities (--spacing =
+// 4px). Overriding the whole map here — before the bootstrap import below, and
+// bootstrap's own $spacers is !default so ours wins — puts bootstrap's p-*/m-*
+// utilities on the SAME grid as espresso: bootstrap .p-3 = 12px = our .gap-3.
+// That unifies the two systems and lets markup use p-*/m-* freely (they were
+// unusable before — see the note in scss/common/utilities.scss).
+// NOTE (develop-only, pixel-shifting): p-1/p-2/p-3 move ≤2px, but p-4 (21→16)
+// and p-5 (42→20) shift a lot — the ~478 p-4/p-5 sites across frappe/erpnext/hrms
+// need a visual audit before this ships. Steps 6/7/8/10/12 are additive (new).
+$spacers: (
+	0: 0,
+	1: 0.25rem,
+	2: 0.5rem,
+	3: 0.75rem,
+	4: 1rem,
+	5: 1.25rem,
+	6: 1.5rem,
+	7: 1.75rem,
+	8: 2rem,
+	10: 2.5rem,
+	12: 3rem,
+);
+
 $grid-breakpoints: (
 	xs: 0,
 	sm: 576px,


### PR DESCRIPTION
1. Lazy load user settings dialog
2. Remove all custom CSS and replace with standard classes
3. Remove icon from change password button
4. Use the new toast component to embed a refresh button in the toast when chaging language etc


Note: this PR changes Bootstrap's spacer scale to match Espresso's scale While this is okay for most values (the difference is minimal for p-2/p-3 etc.) - for larger values like p-5 the difference will be huge. Thankfully, the usage of such large values is minimal throughout Frappe/ERPNext/HRMS and will be audited and fixed in a subsequent PR.