### PR TITLE
fix: masked child table and link fields leak when selected through dot notation

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -280,7 +280,38 @@ class DatabaseQuery:
 
 		meta = self.get_meta(self.doctype)
 
-		return meta.get_masked_fields(parenttype=self.parent_doctype)
+		return meta.get_masked_fields(parenttype=self.parent_doctype) + self.get_masked_joined_fields()
+
+	def get_masked_joined_fields(self):
+		"""Get masked fields of the doctypes joined in through dot notation (`items.rate`)."""
+		from frappe.database.query import CORE_DOCTYPES
+		from frappe.desk.reportview import extract_fieldnames
+		from frappe.model.utils.mask import as_aliased_field
+
+		masked_fields = []
+		lookups = {}
+
+		for field in self.fields or []:
+			columns = extract_fieldnames(field)
+			if not columns or "." not in columns[0]:
+				continue
+
+			table, fieldname = columns[0].split(".", 1)
+			doctype = self.linked_table_aliases.get(table, table).replace("`", "").removeprefix("tab")
+
+			if doctype == self.doctype or doctype in CORE_DOCTYPES:
+				continue
+
+			if doctype not in lookups:
+				meta = self.get_meta(doctype)
+				parenttype = self.doctype if meta.istable else None
+				lookups[doctype] = {df.fieldname: df for df in meta.get_masked_fields(parenttype=parenttype)}
+
+			if df := lookups[doctype].get(fieldname):
+				alias = field.split(" as ")[1].strip(" '`") if " as " in field.lower() else None
+				masked_fields.append(as_aliased_field(df, alias))
+
+		return masked_fields
 
 	def build_and_run(self):
 		args = self.prepare_args()

--- a/frappe/model/utils/mask.py
+++ b/frappe/model/utils/mask.py
@@ -1,6 +1,18 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+import copy
 from typing import Any
+
+
+def as_aliased_field(df, alias: str | None):
+	"""Return the docfield keyed by the alias it is selected under, since masking matches
+	the result columns by fieldname (`items.rate as 'Item:rate'` lands under `Item:rate`)."""
+	if not alias:
+		return df
+
+	df = copy.copy(df)
+	df.fieldname = alias
+	return df
 
 
 def mask_field_value(field, val):
@@ -77,7 +89,8 @@ def mask_pluck_results(
 	if hasattr(first, "fields_"):
 		hit_name = next((f.name for f in first.fields_() if f.name in masked_names), None)
 	else:
-		name = getattr(first, "name", None)
+		# child / link fields selected through dot notation carry `fieldname`, not `name`
+		name = getattr(first, "name", None) or getattr(first, "fieldname", None)
 		hit_name = name if name in masked_names else None
 
 	if not hit_name:

--- a/frappe/model/utils/mask.py
+++ b/frappe/model/utils/mask.py
@@ -86,7 +86,11 @@ def mask_pluck_results(
 	# surface the underlying "secret" reference. Non-Term items (raw string
 	# fieldnames) don't have fields_(); fall back to a shallow name check.
 	first = fields[0]
-	if hasattr(first, "fields_"):
+	alias = getattr(first, "alias", None)
+
+	if alias and alias in masked_names:
+		hit_name = alias
+	elif hasattr(first, "fields_"):
 		hit_name = next((f.name for f in first.fields_() if f.name in masked_names), None)
 	else:
 		# child / link fields selected through dot notation carry `fieldname`, not `name`

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -107,7 +107,9 @@ def mask_fields(
 	if doctype in CORE_DOCTYPES:
 		return result
 
-	masked_fields = frappe.get_meta(doctype).get_masked_fields(parenttype=parent_doctype)
+	masked_fields = frappe.get_meta(doctype).get_masked_fields(
+		parenttype=parent_doctype
+	) + get_masked_joined_fields(doctype, fields)
 
 	if not masked_fields:
 		return result
@@ -121,13 +123,38 @@ def mask_fields(
 			# Handle aliases (e.g. `tabSI`.`posting_date` as posting_date)
 			if alias := getattr(field, "alias", None):
 				field_index_map[alias] = idx
-			elif name := getattr(field, "name", None):
+			elif name := getattr(field, "name", None) or getattr(field, "fieldname", None):
 				field_index_map[name] = idx
 
 		return mask_list_results(result, masked_fields, field_index_map)
 
 	# Handle as_dict format
 	return mask_dict_results(result, masked_fields)
+
+
+def get_masked_joined_fields(doctype: str, fields: list[Any]) -> list[Any]:
+	"""Get masked fields of the doctypes joined in through dot notation (`items.rate`)."""
+	from frappe.database.query import CORE_DOCTYPES, DynamicTableField
+	from frappe.model.utils.mask import as_aliased_field
+
+	masked_fields = []
+	lookups = {}
+
+	for field in fields:
+		if not isinstance(field, DynamicTableField) or field.doctype in CORE_DOCTYPES:
+			continue
+
+		if field.doctype not in lookups:
+			meta = frappe.get_meta(field.doctype)
+			parenttype = doctype if meta.istable else None
+			lookups[field.doctype] = {
+				df.fieldname: df for df in meta.get_masked_fields(parenttype=parenttype)
+			}
+
+		if df := lookups[field.doctype].get(field.fieldname):
+			masked_fields.append(as_aliased_field(df, field.alias))
+
+	return masked_fields
 
 
 def execute_query(query, *args, **kwargs):
@@ -144,7 +171,8 @@ def execute_query(query, *args, **kwargs):
 			mask_child_query_fields(child_queries, result)
 
 	if result and dt and fields:
-		as_dict = kwargs.get("as_dict", not kwargs.get("as_list", False))
+		# `db.sql` returns tuples unless `as_dict` is passed, so masking must not assume dicts
+		as_dict = bool(kwargs.get("as_dict"))
 		result = mask_fields(
 			dt, fields, result, as_dict=as_dict, pluck=kwargs.get("pluck", False), parent_doctype=parent_dt
 		)

--- a/frappe/tests/test_mask_fields.py
+++ b/frappe/tests/test_mask_fields.py
@@ -234,6 +234,16 @@ class TestMaskFieldsBehaviour(IntegrationTestCase):
 		).run(as_dict=True)
 		self.assertEqual(rows[0]["secret_data"], "top_secret_value")
 
+	def test_legacy_db_query_masks_plain_field(self):
+		frappe.set_user(self.TEST_USER)
+		from frappe.model.db_query import DatabaseQuery
+
+		rows = DatabaseQuery(self.dt).execute(
+			fields=["secret_data"],
+			filters={"name": self.docname},
+		)
+		self.assertEqual(rows[0]["secret_data"], "XXXXXXXX")
+
 	def test_legacy_db_query_does_not_mask_when_permissions_are_ignored(self):
 		frappe.set_user(self.TEST_USER)
 		from frappe.model.db_query import DatabaseQuery
@@ -485,6 +495,95 @@ class TestMaskFieldsInChildTable(IntegrationTestCase):
 		finally:
 			self._revoke_mask_permission()
 
+	def test_dotted_child_field_masked_in_get_list(self):
+		"""Selecting a masked child field through dot notation must mask it, the same as
+		querying the child doctype directly."""
+		frappe.set_user(self.TEST_USER)
+
+		rows = frappe.get_list(self.dt, filters={"name": self.docname}, fields=["name", "items.rate"])
+		self.assertEqual(rows[0]["rate"], "XXXXXXXX")
+
+		rows = frappe.get_list(
+			self.dt, filters={"name": self.docname}, fields=["name", "items.rate"], as_list=True
+		)
+		self.assertEqual(rows[0][1], "XXXXXXXX")
+
+	def test_dotted_child_field_masked_in_query_engine(self):
+		frappe.set_user(self.TEST_USER)
+		rows = frappe.qb.get_query(
+			self.dt,
+			fields=["name", "items.rate", "items.secret_note"],
+			filters={"name": self.docname},
+			ignore_permissions=False,
+		).run(as_dict=True)
+
+		self.assertEqual(rows[0]["rate"], "XXXXXXXX")
+		self.assertEqual(rows[0]["secret_note"], "XXXXXXXX")
+
+	def test_dotted_child_field_masked_in_legacy_db_query(self):
+		frappe.set_user(self.TEST_USER)
+		from frappe.model.db_query import DatabaseQuery
+
+		rows = DatabaseQuery(self.dt).execute(
+			fields=["name", "items.rate", f"`tab{self.child_dt}`.`secret_note` as 'child:secret_note'"],
+			filters={"name": self.docname},
+		)
+		self.assertEqual(rows[0]["rate"], "XXXXXXXX")
+		self.assertEqual(rows[0]["child:secret_note"], "XXXXXXXX")
+
+	def test_dotted_child_field_unmasked_with_parent_mask_permission(self):
+		"""A dotted child field resolves its mask permission through the parent, the same as
+		the child rows themselves."""
+		self._grant_mask_permission()
+		try:
+			frappe.set_user(self.TEST_USER)
+			rows = frappe.get_list(self.dt, filters={"name": self.docname}, fields=["items.rate"])
+			self.assertEqual(flt(rows[0]["rate"]), 1234.5)
+		finally:
+			self._revoke_mask_permission()
+
+	def test_aliased_child_field_masked(self):
+		"""The report view selects child columns under an alias (`items.rate as 'Item:rate'`),
+		so masking has to match the alias the value lands under."""
+		frappe.set_user(self.TEST_USER)
+
+		rows = frappe.get_list(
+			self.dt, filters={"name": self.docname}, fields=[f"`tab{self.child_dt}`.`rate` as 'child:rate'"]
+		)
+		self.assertEqual(rows[0]["child:rate"], "XXXXXXXX")
+
+		rows = frappe.qb.get_query(
+			self.dt,
+			fields=["items.rate as child_rate"],
+			filters={"name": self.docname},
+			ignore_permissions=False,
+		).run(as_dict=True)
+		self.assertEqual(rows[0]["child_rate"], "XXXXXXXX")
+
+	def test_plucked_dotted_child_field_masked(self):
+		frappe.set_user(self.TEST_USER)
+		values = frappe.qb.get_query(
+			self.dt,
+			fields=["items.rate"],
+			filters={"name": self.docname},
+			ignore_permissions=False,
+		).run(pluck="rate")
+
+		self.assertEqual(values[0], "XXXXXXXX")
+
+	def test_query_run_without_as_dict_masks(self):
+		"""`run()` returns tuples, so masking must not treat the result as dicts."""
+		frappe.set_user(self.TEST_USER)
+		rows = frappe.qb.get_query(
+			self.child_dt,
+			fields=["rate"],
+			filters={"parent": self.docname},
+			parent_doctype=self.dt,
+			ignore_permissions=False,
+		).run()
+
+		self.assertEqual(rows[0][0], "XXXXXXXX")
+
 	def test_form_meta_child_masked_fields_respect_parent_permission(self):
 		"""masked_fields in the form meta bundle for a child doctype must follow the
 		parent doctype's mask permission."""
@@ -502,6 +601,109 @@ class TestMaskFieldsInChildTable(IntegrationTestCase):
 			self.assertEqual(child_meta_dict["masked_fields"], [])
 		finally:
 			self._revoke_mask_permission()
+
+
+class TestMaskFieldsInLinkedDocType(IntegrationTestCase):
+	"""A masked field on a link target must stay masked when selected through the link
+	(`customer.tax_id`), not just when its own doctype is queried."""
+
+	TEST_USER = "test_mask_link_field_user@example.com"
+	TEST_ROLE = "Test Mask Link Field Role"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+
+		if not frappe.db.exists("Role", cls.TEST_ROLE):
+			frappe.get_doc({"doctype": "Role", "role_name": cls.TEST_ROLE, "desk_access": 1}).insert()
+
+		if not frappe.db.exists("User", cls.TEST_USER):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": cls.TEST_USER,
+					"first_name": "Mask Link Field Test",
+					"send_welcome_email": 0,
+					"roles": [{"role": cls.TEST_ROLE}],
+				}
+			).insert(ignore_permissions=True)
+		else:
+			frappe.get_doc("User", cls.TEST_USER).add_roles(cls.TEST_ROLE)
+
+		cls.target_dt = (
+			new_doctype(
+				fields=[_make_field("tax_id", "Data", mask=1)],
+				permissions=[{"role": cls.TEST_ROLE, "read": 1, "write": 1, "create": 1}],
+			)
+			.insert()
+			.name
+		)
+
+		cls.dt = (
+			new_doctype(
+				fields=[_make_field("customer", "Link", options=cls.target_dt, mask=0)],
+				permissions=[{"role": cls.TEST_ROLE, "read": 1, "write": 1, "create": 1}],
+			)
+			.insert()
+			.name
+		)
+
+		cls.target_name = frappe.get_doc({"doctype": cls.target_dt, "tax_id": "GST12345"}).insert().name
+		cls.docname = frappe.get_doc({"doctype": cls.dt, "customer": cls.target_name}).insert().name
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		frappe.db.delete(cls.dt)
+		frappe.db.delete(cls.target_dt)
+		frappe.delete_doc("DocType", cls.dt, force=True)
+		frappe.delete_doc("DocType", cls.target_dt, force=True)
+		if frappe.db.exists("User", cls.TEST_USER):
+			frappe.db.set_value("User", cls.TEST_USER, "enabled", 0)
+		super().tearDownClass()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_masked_field_selected_through_link_is_masked(self):
+		frappe.set_user(self.TEST_USER)
+
+		rows = frappe.get_list(self.dt, filters={"name": self.docname}, fields=["customer.tax_id"])
+		self.assertEqual(rows[0]["tax_id"], "XXXXXXXX")
+
+		rows = frappe.qb.get_query(
+			self.dt,
+			fields=["customer.tax_id"],
+			filters={"name": self.docname},
+			ignore_permissions=False,
+		).run(as_dict=True)
+		self.assertEqual(rows[0]["tax_id"], "XXXXXXXX")
+
+	def test_masked_field_through_link_masked_in_legacy_db_query(self):
+		"""The link target is joined under a counter alias (`tabUser_1`), which has to resolve
+		back to the real doctype before its masked fields can be looked up."""
+		frappe.set_user(self.TEST_USER)
+		from frappe.model.db_query import DatabaseQuery
+
+		rows = DatabaseQuery(self.dt).execute(
+			fields=["name", "customer.tax_id"],
+			filters={"name": self.docname},
+		)
+		self.assertEqual(rows[0]["tax_id"], "XXXXXXXX")
+
+	def test_masked_field_through_link_follows_target_mask_permission(self):
+		"""Link targets are standalone doctypes, so their own mask permission applies."""
+		update_permission_property(self.target_dt, self.TEST_ROLE, 0, "mask", 1)
+		frappe.clear_cache(doctype=self.target_dt)
+
+		try:
+			frappe.set_user(self.TEST_USER)
+			rows = frappe.get_list(self.dt, filters={"name": self.docname}, fields=["customer.tax_id"])
+			self.assertEqual(rows[0]["tax_id"], "GST12345")
+		finally:
+			frappe.set_user("Administrator")
+			update_permission_property(self.target_dt, self.TEST_ROLE, 0, "mask", 0)
+			frappe.clear_cache(doctype=self.target_dt)
 
 
 class TestMaskFieldsWithUserPermissions(IntegrationTestCase):

--- a/frappe/tests/test_mask_fields.py
+++ b/frappe/tests/test_mask_fields.py
@@ -571,6 +571,19 @@ class TestMaskFieldsInChildTable(IntegrationTestCase):
 
 		self.assertEqual(values[0], "XXXXXXXX")
 
+	def test_plucked_aliased_child_field_masked(self):
+		"""An aliased dotted field is keyed under its alias, so the pluck path has to match
+		the alias too."""
+		frappe.set_user(self.TEST_USER)
+		values = frappe.qb.get_query(
+			self.dt,
+			fields=["items.rate as child_rate"],
+			filters={"name": self.docname},
+			ignore_permissions=False,
+		).run(pluck="child_rate")
+
+		self.assertEqual(values[0], "XXXXXXXX")
+
 	def test_query_run_without_as_dict_masks(self):
 		"""`run()` returns tuples, so masking must not treat the result as dicts."""
 		frappe.set_user(self.TEST_USER)


### PR DESCRIPTION
Masked fields come back unmasked when they're selected from a joined doctype. `frappe.get_list("Sales Order", fields=["items.rate"])` pulls a column out of the child table into a flat result, but both query engines only look up masked fields on the queried doctype, so the child's mask flag is never checked. 

The same affects link fields (for example, `customer.tax_id`). Report Builder is affected as well because it selects child fields under aliases, allowing masked values to be returned.

Resolve each selected field against the doctype it actually belongs to and key the masked field under the returned column alias. 
Resolve each selected field against the doctype it actually belongs to and key the masked field under the returned column alias. Child fields follow the parent doctype's mask permission (child doctypes have no role permissions of their own), link fields use their own, and masking also works for tuple rows and plucked values returned by .run().

### URL

```
/api/method/frappe.client.get_list?doctype=Mask Demo Order&fields=["name"%2C"items.rate"%2C"items.secret_note"]
```

### Before

<img width="516" height="317" alt="Screenshot 2026-07-12 at 10 34 46 PM" src="https://github.com/user-attachments/assets/b35a66df-a1c9-4f3c-a601-b1048c1b0156" />
<img width="432" height="275" alt="Screenshot 2026-07-12 at 10 34 50 PM" src="https://github.com/user-attachments/assets/1db946e8-426b-48d7-b60e-b7457969ce07" />

### After
<img width="606" height="348" alt="Screenshot 2026-07-12 at 10 33 01 PM" src="https://github.com/user-attachments/assets/71b2f216-3647-4c9c-802d-bcc1394301cc" />
<img width="324" height="248" alt="Screenshot 2026-07-12 at 10 33 09 PM" src="https://github.com/user-attachments/assets/2aec5d10-4e9e-43a8-8194-59fcc18827b3" />
