### PR TITLE
fix: don't force new classic print formats onto the beta builder

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -75,7 +75,7 @@ class PrintFormat(Document):
 			self.custom_format = 1
 
 		# New non-custom formats default to builder beta + Chrome
-		if self.is_new() and not self.custom_format:
+		if self.is_new() and not self.custom_format and not self.print_format_builder:
 			self.print_format_builder_beta = 1
 
 		if self.print_format_builder_beta and not self.custom_format:


### PR DESCRIPTION
- `before_save` sets `print_format_builder_beta = 1` on every new non-custom format, so `create_custom_format(beta=False)` (print view → Print Format Builder Classic) inserts a format with **both** builder flags and `pdf_generator = chrome`
- printview then routes the classic array `format_data` into `PrintFormatGenerator`, which crashes on `layout["sections"]`
- only default to beta when no builder flag was explicitly chosen

Why: classic formats created from the print view have been broken since bd1f2da029.