### PR TITLE
fix: match quoted and unquoted sort/group references to child tables

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -750,14 +750,17 @@ from {tables}
 			return [(ft, None) for ft in filters], exists_groups
 
 		additional_filters_config = get_additional_filters_from_hooks()
+		# quotes are stripped so `tabX`.`col`, "tabX".col and tabX.col forms all match
+		sort_group_references = f"{self.group_by or ''} {self.order_by or ''}".replace("`", "").replace(
+			'"', ""
+		)
 		for ft in filters:
 			f = get_filter(self.doctype, ft, additional_filters_config)
 			if (
 				f.doctype
 				and f.doctype != self.doctype
 				and f"`tab{f.doctype}`" not in self.tables
-				and f"`tab{f.doctype}`" not in (self.group_by or "")
-				and f"`tab{f.doctype}`" not in (self.order_by or "")
+				and f"tab{f.doctype}" not in sort_group_references
 				and self.get_meta(f.doctype).istable
 			):
 				exists_groups.setdefault(f.doctype, []).append((ft, f))

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -416,6 +416,17 @@ class TestDBQuery(IntegrationTestCase):
 		)
 		self.assertIn("`tabNote Seen By`", query.tables)
 
+		# unquoted and double-quoted references must keep the join too
+		for group_by in ("tabNote Seen By.user", '"tabNote Seen By".user'):
+			query = DatabaseQuery("Note")
+			query.execute(
+				filters=[["Note Seen By", "user", "=", "Administrator"]],
+				fields=["name"],
+				group_by=group_by,
+				run=0,
+			)
+			self.assertIn("`tabNote Seen By`", query.tables)
+
 	def test_child_table_filter_with_childnames_keeps_join(self):
 		query = DatabaseQuery("Note")
 		query.execute(


### PR DESCRIPTION
Follow-up to #40602.

The exists() rewrite keeps the legacy join when `order_by`/`group_by` references the filtered child table, but the containment check only matched the backtick-quoted form. Unquoted (`tabChild.field`) and postgres-style double-quoted (`"tabChild".field`) references slipped past — and `validate_order_by_and_group_by` also only inspects backticked tokens — so the query reached the database referencing a table the exists() subquery never joins and failed with a missing FROM-clause entry.

Fix: strip backticks and double quotes once in `_split_child_table_filters` and compare the unquoted `tab<Doctype>` form, so all three spellings route the filter back to the legacy join. A false positive only falls back to the join — exactly the pre-#40602 behaviour, so the conservative direction is safe.

Tests: `test_child_table_filter_with_child_order_by_keeps_join` extended with the unquoted and double-quoted forms; `test_db_query` green locally on postgres.
