### PR TITLE
fix: list toolbar keeps mobile layout after the viewport gets wider

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -676,7 +676,7 @@ class FilterArea {
 	setup_mobile_toolbar() {
 		this.list_view.page.page_form.addClass("list-page-form");
 
-		$(`<button class="filter-toggle btn btn-default btn-sm filter-button hidden-lg">
+		$(`<button class="filter-toggle btn btn-default btn-sm hidden-lg">
 					<span class="filter-icon button-icon">
 						${frappe.utils.icon("chevrons-up-down")}
 					</span>

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -12,6 +12,7 @@ frappe.views.BaseList = class BaseList {
 			() => this.hide_skeleton(),
 			() => this.check_permissions(),
 			() => this.init(),
+			() => this.filter_area?.place_id_filter(),
 			() => this.setup_list_filter_by(),
 			() => this.before_refresh(),
 			() => this.refresh(),
@@ -438,6 +439,7 @@ frappe.views.BaseList = class BaseList {
 					if (cur_list?.$result?.is(":visible")) {
 						cur_list.set_result_height();
 					}
+					cur_list?.filter_area?.place_id_filter();
 				}, 300)
 			);
 	}
@@ -668,41 +670,42 @@ class FilterArea {
 			300
 		);
 		this.setup();
-		if (frappe.is_mobile()) this.setup_mobile(list_view);
+		if (!this.list_view.hide_page_form) this.setup_mobile_toolbar();
 	}
 
-	setup_mobile(list_view) {
-		const me = this;
-		this.standard_filters_visible = false;
-		this.standard_filters_wrapper?.hide();
-		this.list_view.page.page_form.css("justify-content", "flex-end");
-		list_view.page.page_form.addClass("flex-column");
-		this.$filter_list_wrapper.addClass("justify-between p-0");
+	setup_mobile_toolbar() {
+		this.list_view.page.page_form.addClass("list-page-form");
 
-		// added this to manage spaceing between filter and sorf area
-		this.$filter_list_wrapper.find(".filter-selector").css("margin", "0 0 0 auto");
-
-		$(`<button class="filter-toggle btn btn-default btn-sm filter-button">
+		$(`<button class="filter-toggle btn btn-default btn-sm filter-button hidden-lg">
 					<span class="filter-icon button-icon">
 						${frappe.utils.icon("chevrons-up-down")}
 					</span>
-				</button>
-			</div>`)
+				</button>`)
 			.prependTo(this.$filter_list_wrapper.find(".filter-selector"))
-			.on("click", function () {
-				me.toggle_standard_filter();
-			});
-		let children = list_view.page.page_form.children();
-		list_view.page.page_form.append(children.get().reverse());
+			.on("click", () => this.toggle_standard_filter());
+
+		this.$mobile_id_filter = $('<div class="mobile-id-filter hidden-lg">').prependTo(
+			this.$filter_list_wrapper
+		);
 	}
 
 	toggle_standard_filter() {
-		if (this.standard_filters_visible) {
-			this.standard_filters_visible = false;
-			this.standard_filters_wrapper.hide();
+		this.list_view.page.page_form.toggleClass("standard-filters-visible");
+	}
+
+	place_id_filter() {
+		const id_filter = this.list_view.page.fields_dict.name;
+		if (!id_filter || !this.$mobile_id_filter) return;
+
+		// matchMedia keeps placement in sync with the toolbar media queries in list.scss
+		const mobile_layout = window.matchMedia("(max-width: 767.98px)").matches;
+		const target = mobile_layout ? this.$mobile_id_filter : this.standard_filters_wrapper;
+		if (id_filter.wrapper.parentElement === target[0]) return;
+
+		if (mobile_layout) {
+			target.append(id_filter.wrapper);
 		} else {
-			this.standard_filters_visible = true;
-			this.standard_filters_wrapper.show();
+			target.prepend(id_filter.wrapper);
 		}
 	}
 
@@ -1164,14 +1167,7 @@ class FilterArea {
 				onchange: () => this.debounced_refresh_list_view(),
 			};
 
-			if (frappe.is_mobile()) {
-				let mobile_id_filter = this.$filter_list_wrapper.append(
-					`<div class="mobile-id-filter"></div>`
-				);
-				this.list_view.page.add_field(field, mobile_id_filter.find(".mobile-id-filter"));
-			} else {
-				fields.push(field);
-			}
+			fields.push(field);
 		}
 
 		if (
@@ -1291,6 +1287,8 @@ class FilterArea {
 				this.filter_field_with_match_type(df);
 			}
 		});
+
+		this.place_id_filter();
 	}
 
 	filter_field_with_match_type(df) {

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -615,6 +615,31 @@ input.list-header-checkbox {
 			}
 		}
 	}
+
+	&.list-page-form {
+		@include media-breakpoint-between(xs, sm) {
+			flex-direction: column-reverse;
+			justify-content: flex-end;
+
+			.standard-filter-section {
+				display: none;
+			}
+
+			&.standard-filters-visible .standard-filter-section {
+				display: flex;
+			}
+		}
+	}
+}
+
+.filter-section {
+	@include media-breakpoint-between(xs, sm) {
+		justify-content: space-between;
+
+		.filter-selector {
+			margin: 0 0 0 auto;
+		}
+	}
 }
 
 .restricted-button {


### PR DESCRIPTION
The list view's filter toolbar decides between the mobile and desktop layout only once, when `FilterArea` is constructed, by calling `frappe.is_mobile()` (a `window.innerWidth < 768` check). Nothing re-evaluates it afterwards, so resizing the window, rotating a phone, or docking DevTools leaves the toolbar stuck in the layout chosen when the page was first loaded.

Coming from a wide viewport, the desktop toolbar is squeezed into a narrow screen with overflowing filters, wrapped buttons, and clipped controls. Coming from a narrow viewport, the mobile toolbar remains on a wide screen, keeping filters hidden behind the toggle and using the mobile layout unnecessarily.

Move the mobile/desktop split into CSS, using the existing `768px` breakpoint so the layout responds automatically to viewport changes. The only remaining JavaScript is relocating the ID filter between its two containers on load and resize, since CSS can't move DOM nodes. This also unifies the ID filter implementation so both layouts use the same standard filter control.

## Before

https://github.com/user-attachments/assets/e0cb864f-5483-4e46-92ab-7e277aadad6c



## After


https://github.com/user-attachments/assets/653d82c9-3390-4472-b3e3-bdf81acc0309

