### PR TITLE
fix(queue): Avoid false matching custom queue name with default ones

### DIFF
--- a/frappe/core/doctype/rq_job/rq_job.py
+++ b/frappe/core/doctype/rq_job/rq_job.py
@@ -96,7 +96,11 @@ class RQJob(Document):
 
 		matched_job_ids = []
 		for queue in get_queues():
-			if not queue.name.endswith(tuple(queues)):
+			# RQ keys are prefixed with the bench path (e.g. `...bench:long`);
+			# split on ":" and compare the short name exactly. `endswith` alone
+			# would false-match custom queues whose name is a suffix of a
+			# standard one (e.g. `schedulelong` under `queue=long`).
+			if queue.name.rsplit(":", 1)[-1] not in queues:
 				continue
 			for status in statuses:
 				matched_job_ids.extend(fetch_job_ids(queue, status))

--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -100,6 +100,51 @@ class TestRQJob(IntegrationTestCase):
 		with self.assertRaises(rq_exc.NoSuchJobError):
 			job.refresh()
 
+	def test_queue_filter_rejects_suffix_collision(self):
+		"""`queue = long` must not include a custom
+		queue whose name is a suffix of `long` (e.g. `schedulelong`).
+
+		The old check `queue.name.endswith(tuple(queues))` false-matched any
+		suffix. Fix uses `rsplit(":", 1)[-1] not in queues` so only exact
+		short-name matches pass.
+		"""
+		from unittest.mock import MagicMock, patch
+
+		site = frappe.local.site
+
+		# Two fake queues with bench-prefixed names, one a legitimate `long`
+		# and one a custom queue whose short name ends with `long` as a
+		# substring.
+		long_queue = MagicMock(name="long_queue")
+		long_queue.name = "test-bench:long"
+		collide_queue = MagicMock(name="collide_queue")
+		collide_queue.name = "test-bench:schedulelong"
+
+		def fake_fetch(queue, status):
+			# Return one ID per (queue, status), site-prefixed so
+			# filter_current_site_jobs doesn't strip them.
+			short = queue.name.rsplit(":", 1)[-1]
+			return [f"{site}||{short}-{status}"]
+
+		module = "frappe.core.doctype.rq_job.rq_job"
+		with (
+			patch(f"{module}.get_queues", return_value=[long_queue, collide_queue]),
+			patch(f"{module}.get_custom_queues", return_value=["schedulelong"]),
+			patch(f"{module}.fetch_job_ids", side_effect=fake_fetch),
+		):
+			result = RQJob.get_matching_job_ids(filters=[["RQ Job", "queue", "=", "long"]])
+
+		self.assertFalse(
+			any("schedulelong" in job_id for job_id in result),
+			f"queue=long filter must exclude schedulelong, got: {result!r}",
+		)
+		self.assertTrue(
+			all("||long-" in job_id for job_id in result),
+			f"every returned id should be from the long queue, got: {result!r}",
+		)
+		# One id per status from the single matching queue.
+		self.assertEqual(len(result), 7)
+
 	@timeout
 	def test_multi_queue_burst_consumption(self):
 		for _ in range(3):


### PR DESCRIPTION
 `endswith` check would false-match custom queues whose name is a suffix of a standard one (e.g. `schedulelong` under `queue=long`). Do exact match to prevent this issue.

