### PR TITLE
fix(comments): don't block logged-in users from commenting

### DIFF
--- a/frappe/templates/includes/comments/comments.py
+++ b/frappe/templates/includes/comments/comments.py
@@ -54,9 +54,6 @@ def add_comment(
 		comment_email = frappe.session.user
 		comment_by = frappe.get_value("User", frappe.session.user, "full_name")
 
-		if frappe.db.exists("User", comment_email):
-			frappe.throw(_("Please login to post a comment."))
-
 	if not comment.strip():
 		frappe.msgprint(_("The comment cannot be empty"))
 		return False


### PR DESCRIPTION
- Remove the stray `db.exists("User", comment_email)` throw that landed inside the logged-in `else` branch of `add_comment`
- For any signed-in user `comment_email` is set to their username (e.g. `Administrator`), which always exists, so every logged-in comment raised "Please login to post a comment."

Why: bad conflict resolution in the backport #40741 kept a guest-only anti-spoof check in the logged-in branch; develop (#40739) does not have it. Fixes the deterministic `test_public_comment` failure on version-16-hotfix.