### PR TITLE
fix: cascading 503 Multiple MAIL commands not allowed after a failed SMTP Send

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -251,12 +251,16 @@ class EmailQueue(Document):
 								mail_options=mail_options,
 								rcpt_options=rcpt_options,
 							)
-						except smtplib.SMTPResponseException:
+						except smtplib.SMTPException:
 							# A failed send can leave the server-side transaction
 							# open even though our cached session still looks
 							# alive (NOOP succeeds). Reusing it would fail every
 							# subsequent recipient with "Multiple MAIL commands
 							# not allowed" instead of surfacing the real error.
+							# Caught broadly (not just SMTPResponseException) since
+							# SMTPRecipientsRefused doesn't subclass it, yet can
+							# leave the session in the same poisoned state on
+							# non-compliant servers.
 							ctx.smtp_server.discard_session()
 							raise
 

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import quopri
+import smtplib
 import traceback
 from contextlib import suppress
 from email.parser import Parser
@@ -242,13 +243,22 @@ class EmailQueue(Document):
 						msg_bytes = validate_and_prepare_message(message)
 						mail_options, rcpt_options = get_smtp_options()
 
-						ctx.smtp_server.session.sendmail(
-							from_addr=self.sender,
-							to_addrs=recipient.recipient,
-							msg=msg_bytes,
-							mail_options=mail_options,
-							rcpt_options=rcpt_options,
-						)
+						try:
+							ctx.smtp_server.session.sendmail(
+								from_addr=self.sender,
+								to_addrs=recipient.recipient,
+								msg=msg_bytes,
+								mail_options=mail_options,
+								rcpt_options=rcpt_options,
+							)
+						except smtplib.SMTPResponseException:
+							# A failed send can leave the server-side transaction
+							# open even though our cached session still looks
+							# alive (NOOP succeeds). Reusing it would fail every
+							# subsequent recipient with "Multiple MAIL commands
+							# not allowed" instead of surfacing the real error.
+							ctx.smtp_server.discard_session()
+							raise
 
 				ctx.update_recipient_status_to_sent(recipient)
 

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -252,15 +252,8 @@ class EmailQueue(Document):
 								rcpt_options=rcpt_options,
 							)
 						except smtplib.SMTPException:
-							# A failed send can leave the server-side transaction
-							# open even though our cached session still looks
-							# alive (NOOP succeeds). Reusing it would fail every
-							# subsequent recipient with "Multiple MAIL commands
-							# not allowed" instead of surfacing the real error.
-							# Caught broadly (not just SMTPResponseException) since
-							# SMTPRecipientsRefused doesn't subclass it, yet can
-							# leave the session in the same poisoned state on
-							# non-compliant servers.
+							# Session can be poisoned server-side even though NOOP
+							# still reports it alive; discard so the next recipient reconnects.
 							ctx.smtp_server.discard_session()
 							raise
 

--- a/frappe/email/doctype/email_queue/test_email_queue.py
+++ b/frappe/email/doctype/email_queue/test_email_queue.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
+import smtplib
 import textwrap
+from unittest.mock import MagicMock
 
 import frappe
 from frappe.email.doctype.email_queue.email_queue import SendMailContext, get_email_retry_limit
@@ -93,3 +95,37 @@ class TestEmailQueue(IntegrationTestCase):
 		q2 = frappe.new_doc("Email Queue", email_account="_Test Email Account 1")
 		self.assertIsNot(get_server(frappe.new_doc("Email Queue")), get_server(q1))
 		self.assertIs(get_server(q1), get_server(q2))
+
+	def test_discards_smtp_session_on_send_failure(self):
+		"""A failed sendmail() must discard the (possibly poisoned) SMTP session so it
+		isn't reused for the next recipient, else every subsequent send in the same
+		batch fails with "503 Multiple MAIL commands not allowed" instead of surfacing
+		the real error. `SMTPRecipientsRefused` is deliberately used here since it
+		doesn't subclass `SMTPResponseException`, only the broader `SMTPException`.
+		"""
+		email_record = frappe.new_doc(
+			"Email Queue",
+			sender="Test <test@example.com>",
+			show_as_cc="",
+			message="Test message",
+			status="Not Sent",
+			priority=1,
+			recipients=[{"recipient": "test_refused@example.com"}],
+		).insert()
+
+		mock_session = MagicMock()
+		mock_session.has_extn.return_value = False
+		mock_session.sendmail.side_effect = smtplib.SMTPRecipientsRefused(
+			{"test_refused@example.com": (550, b"Mailbox unavailable")}
+		)
+		mock_smtp_server = MagicMock()
+		mock_smtp_server.session = mock_session
+
+		frappe.flags.testing_email = True
+		try:
+			with self.assertRaises(smtplib.SMTPRecipientsRefused):
+				email_record.send(smtp_server_instance=mock_smtp_server)
+		finally:
+			frappe.flags.testing_email = False
+
+		mock_smtp_server.discard_session.assert_called_once()

--- a/frappe/email/doctype/email_queue/test_email_queue.py
+++ b/frappe/email/doctype/email_queue/test_email_queue.py
@@ -97,12 +97,7 @@ class TestEmailQueue(IntegrationTestCase):
 		self.assertIs(get_server(q1), get_server(q2))
 
 	def test_discards_smtp_session_on_send_failure(self):
-		"""A failed sendmail() must discard the (possibly poisoned) SMTP session so it
-		isn't reused for the next recipient, else every subsequent send in the same
-		batch fails with "503 Multiple MAIL commands not allowed" instead of surfacing
-		the real error. `SMTPRecipientsRefused` is deliberately used here since it
-		doesn't subclass `SMTPResponseException`, only the broader `SMTPException`.
-		"""
+		"""SMTPRecipientsRefused (not an SMTPResponseException) must still discard the session."""
 		email_record = frappe.new_doc(
 			"Email Queue",
 			sender="Test <test@example.com>",

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -129,14 +129,9 @@ class SMTPServer:
 				return False
 
 	def discard_session(self):
-		"""Force the cached session to be dropped so the next `session` access reconnects.
+		"""Drop the cached session so the next `session` access reconnects.
 
-		A failed `sendmail()` (e.g. server-side rate limiting) can leave the
-		connection mid-transaction on the server side even though `NOOP` still
-		reports the socket as alive. Reusing such a session causes every
-		subsequent send to fail with "Multiple MAIL commands not allowed"
-		instead of the real, original error. Call this after any exception
-		raised from `session.sendmail()`.
+		A failed sendmail() can poison the connection server-side even though NOOP still reports it alive.
 		"""
 		if self._session:
 			with suppress(Exception):

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -128,6 +128,21 @@ class SMTPServer:
 			except Exception:
 				return False
 
+	def discard_session(self):
+		"""Force the cached session to be dropped so the next `session` access reconnects.
+
+		A failed `sendmail()` (e.g. server-side rate limiting) can leave the
+		connection mid-transaction on the server side even though `NOOP` still
+		reports the socket as alive. Reusing such a session causes every
+		subsequent send to fail with "Multiple MAIL commands not allowed"
+		instead of the real, original error. Call this after any exception
+		raised from `session.sendmail()`.
+		"""
+		if self._session:
+			with suppress(Exception):
+				self._session.close()
+			self._session = None
+
 	def quit(self):
 		with suppress(TimeoutError):
 			if self.is_session_active():

--- a/frappe/email/test_smtp.py
+++ b/frappe/email/test_smtp.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # License: The MIT License
 
+from unittest.mock import Mock
+
 import frappe
 from frappe.email.doctype.email_account.email_account import EmailAccount
 from frappe.email.smtp import SMTPServer
@@ -8,6 +10,34 @@ from frappe.tests import IntegrationTestCase
 
 
 class TestSMTP(IntegrationTestCase):
+	def test_discard_session_closes_and_clears_active_session(self):
+		server = SMTPServer(server="smtp.example.com")
+		fake_session = Mock()
+		server._session = fake_session
+
+		server.discard_session()
+
+		fake_session.close.assert_called_once()
+		self.assertIsNone(server._session)
+
+	def test_discard_session_suppresses_close_errors(self):
+		server = SMTPServer(server="smtp.example.com")
+		fake_session = Mock()
+		fake_session.close.side_effect = OSError("already disconnected")
+		server._session = fake_session
+
+		server.discard_session()  # must not raise
+
+		self.assertIsNone(server._session)
+
+	def test_discard_session_is_noop_without_active_session(self):
+		server = SMTPServer(server="smtp.example.com")
+		server._session = None
+
+		server.discard_session()  # must not raise
+
+		self.assertIsNone(server._session)
+
 	def test_smtp_ssl_session(self):
 		for port in [None, 0, 465, "465"]:
 			make_server(port, 1, 0)


### PR DESCRIPTION
### Problem

When a send fails mid-transaction on a reused SMTP session (e.g. the mail server returns 452 4.4.5 Maximum number of messages per session exceeded, or any other error raised partway through MAIL FROM → RCPT TO → DATA), the connection is left in an inconsistent state on the server side even though the client-side connection still looks alive.

SMTPServer.is_session_active() only checks session.noop(), which returns 250 OK regardless of whether the previous transaction completed cleanly. So the next flush() iteration reuses the same session, issues a fresh MAIL FROM, and the server rejects it:

```
smtplib.SMTPSenderRefused: (503, b'5.5.1 Multiple MAIL commands not allowed.', ...)
```

Every subsequent send that reuses this poisoned session fails the same way, cascading through the rest of the batch — turning one transient failure into hundreds.



PR created on behalf of @palkanp