### PR TITLE
fix: guard against invalid navigator.language in alt shortcuts

### DIFF
--- a/frappe/public/js/frappe/ui/alt_keyboard_shortcuts.js
+++ b/frappe/public/js/frappe/ui/alt_keyboard_shortcuts.js
@@ -95,21 +95,18 @@ function get_shortcut_for_key(key) {
 frappe.ui.keys.AltShortcutGroup = class AltShortcutGroup {
 	constructor() {
 		this.shortcuts_dict = {};
+		this.blacklisted_letters = [];
 
-		const locale = new Intl.Locale(navigator.language);
+		let language;
+		try {
+			language = new Intl.Locale(navigator.language).language;
+		} catch {
+			language = null;
+		}
+
 		// Skip certain Keys for different Languages on different Platforms
-		switch (locale.language) {
-			case "de":
-				if (frappe.utils.is_mac()) {
-					this.blacklisted_letters = ["e", "l"];
-				} else {
-					this.blacklisted_letters = ["q"];
-				}
-
-				break;
-			default:
-				this.blacklisted_letters = [];
-				break;
+		if (language === "de") {
+			this.blacklisted_letters = frappe.utils.is_mac() ? ["e", "l"] : ["q"];
 		}
 
 		$current_dropdown = null;


### PR DESCRIPTION
`AltShortcutGroup` passes `navigator.language` directly to `new Intl.Locale()` without validation. `Intl.Locale` requires a valid BCP-47 language tag and throws on values browsers may legally return, such as an empty string (unknown locale) or malformed tags like `en_US`.

Since `AltShortcutGroup` is constructed during `Page.setup_page()`, the exception aborts page initialization and leaves the Desk blank.

The locale is only used to determine the German keyboard blacklist; every other locale already falls back to an empty blacklist. Default to the empty blacklist and treat invalid locale tags the same way instead of letting the exception escape. The single-case `switch` is simplified to an `if` as part of the change.