### PR TITLE
fix(report): Preserve UI sorting in report view export

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -440,8 +440,25 @@ def _export_query(form_params, csv_params, populate_response=True):
 	add_totals_row = cint(form_params.pop("add_totals_row", 0))
 	translate_values = cint(form_params.pop("translate_values", 0))
 
+	visible_names = form_params.pop("visible_names", None)
+	if isinstance(visible_names, str):
+		visible_names = frappe.parse_json(visible_names)
+	if not (isinstance(visible_names, list) and visible_names):
+		visible_names = None
+
 	if selection := form_params.pop("selected_items", None):
 		form_params["filters"] = {"name": ("in", frappe.parse_json(selection))}
+
+	# visible_names is the client's ordered display sequence
+	# When present, take precedence over generic filters/order/pagination: fetch
+	# exactly those rows, then reorder in Python below.
+	# Mirrors the visible_idx pattern in Query Report.
+	if visible_names:
+		form_params["filters"] = {"name": ("in", visible_names)}
+		form_params["order_by"] = None
+		form_params.pop("page_length", None)
+		form_params.pop("limit_page_length", None)
+		form_params.pop("start", None)
 
 	make_access_log(
 		doctype=doctype,
@@ -452,6 +469,9 @@ def _export_query(form_params, csv_params, populate_response=True):
 
 	db_query = DatabaseQuery(doctype)
 	ret = db_query.execute(**form_params)
+
+	if visible_names:
+		ret = _reorder_by_visible_names(ret, form_params.get("fields", []), doctype, visible_names)
 
 	if not frappe.permissions.can_export(doctype):
 		if frappe.permissions.can_export(doctype, is_owner=True):
@@ -515,6 +535,29 @@ def _export_query(form_params, csv_params, populate_response=True):
 		return title, file_extension, content
 
 	provide_binary_file(_(title), file_extension, content)
+
+
+def _reorder_by_visible_names(ret, fields, doctype, visible_names):
+	"""Reorder `ret` (list of row tuples, `as_list=True`) so that rows appear
+	in the same order as `visible_names`. Rows whose primary key isn't in
+	`visible_names` are dropped. If the primary key column can't be located in
+	`fields`, `ret` is returned unchanged (server-order fallback).
+
+	Only the primary doctype's `name` column is a valid match.
+	Using linked doctype's `name` as the reorder key
+	would silently rebuild the export against the wrong identifier."""
+	name_field = f"`tab{doctype}`.`name`"
+	name_idx = None
+	for i, field in enumerate(fields):
+		if not isinstance(field, str):
+			continue
+		if field == name_field or field == "name":
+			name_idx = i
+			break
+	if name_idx is None:
+		return ret
+	ret_by_name = {row[name_idx]: row for row in ret}
+	return [ret_by_name[n] for n in visible_names if n in ret_by_name]
 
 
 def append_totals_row(data):

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1802,9 +1802,56 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 							if (!data.export_all_rows) {
 								args.start = 0;
 								args.page_length = this.data.length;
+
+								// Send display-order primary keys so the server
+								// can filter+reorder the exported rows.
+								// Mirrors Query Report's visible_idx pattern.
+								const view_order = this.datatable?.datamanager?.rowViewOrder;
+								if (view_order?.length && this.data?.length) {
+									let visible_names = view_order
+										.map((idx) => this.data[idx]?.name)
+										.filter((n) => n);
+									if (selected_items?.length) {
+										const checked = new Set(selected_items);
+										visible_names = visible_names.filter((n) =>
+											checked.has(n)
+										);
+									}
+									if (visible_names.length) {
+										args.visible_names = JSON.stringify(visible_names);
+									}
+								}
 							} else {
 								delete args.start;
 								delete args.page_length;
+
+								// "Export all rows" bypasses visible_names.
+								//  Reflect the datatable's client-side column sort into
+								// args.order_by so all matching rows return in
+								// the user's chosen sort.
+								const sorted_col = this.datatable?.datamanager
+									?.getColumns?.()
+									?.find(
+										(c) =>
+											c.sortOrder &&
+											c.sortOrder !== "none" &&
+											c.docfield?.fieldname
+									);
+								if (sorted_col) {
+									const order = sorted_col.sortOrder;
+									// Whitelist guard to validate order_by
+									if (["asc", "desc"].includes(order)) {
+										const parent_dt =
+											sorted_col.docfield.parent || this.doctype;
+										const table = "`tab" + parent_dt + "`";
+										const field = "`" + sorted_col.docfield.fieldname + "`";
+										args.order_by = ["name", "creation", "modified"].includes(
+											sorted_col.docfield.fieldname
+										)
+											? `${table}.${field} ${order}`
+											: `${table}.${field} ${order}, ${table}.\`name\` ${order}`;
+									}
+								}
 							}
 							args.export_in_background = data.export_in_background;
 							if (data.export_in_background) {

--- a/frappe/tests/test_reportview.py
+++ b/frappe/tests/test_reportview.py
@@ -1,8 +1,17 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import json
+
 import frappe
-from frappe.desk.reportview import export_query, extract_fieldnames, get, get_filter_dashboard_data, get_stats
+from frappe.desk.reportview import (
+	_reorder_by_visible_names,
+	export_query,
+	extract_fieldnames,
+	get,
+	get_filter_dashboard_data,
+	get_stats,
+)
 from frappe.tests import IntegrationTestCase
 
 
@@ -67,6 +76,43 @@ class TestReportview(IntegrationTestCase):
 					for row in reader:
 						self.assertEqual(int(row["Is Single"]), 1)
 						self.assertEqual(row["Module"], "Core")
+
+	def test_reorder_by_visible_names(self):
+		fields = ["`tabDocType`.`name`", "`tabDocType`.`module`"]
+		ret = [
+			("DocType", "Core"),
+			("DocField", "Core"),
+			("Report", "Core"),
+		]
+		# Reorder — server-order was DocType, DocField, Report; client shows Report first.
+		reordered = _reorder_by_visible_names(ret, fields, "DocType", ["Report", "DocType"])
+		self.assertEqual(reordered, [("Report", "Core"), ("DocType", "Core")])
+
+		# When name column can't be located, fall back to ret unchanged.
+		fields_without_name = ["`tabDocType`.`module`"]
+		ret_no_name = [("Core",), ("Website",)]
+		unchanged = _reorder_by_visible_names(ret_no_name, fields_without_name, "DocType", ["x"])
+		self.assertEqual(unchanged, ret_no_name)
+
+	def test_export_query_preserves_visible_names_order(self):
+		from csv import DictReader
+		from io import StringIO
+
+		# Pick three known DocTypes and request them in a non-alphabetical order.
+		desired_order = ["Report", "DocType", "DocField"]
+		frappe.local.form_dict = frappe._dict(
+			doctype="DocType",
+			file_format_type="CSV",
+			fields=("`tabDocType`.`name`", "`tabDocType`.`module`"),
+			filters={"name": ("in", desired_order)},
+			order_by="`tabDocType`.`name` asc",  # would otherwise sort alphabetically
+			visible_names=json.dumps(desired_order),
+		)
+		export_query()
+		with StringIO(frappe.response["filecontent"].decode("utf-8")) as buf:
+			rows = list(DictReader(buf))
+		names_in_export = [row["ID"] for row in rows if row.get("ID") in desired_order]
+		self.assertEqual(names_in_export, desired_order)
 
 	def test_extract_fieldname(self):
 		self.assertEqual(


### PR DESCRIPTION
related: #39093 

In report builder, the sort order was not preserved during export. Fixed this in similar way how the query builder handles using visible_idx. Here visible_names is passed to backend to preserve the order.