### PR TITLE
fix: evaluate creation-based SQL cutoffs against the system timezone clock

### DIFF
--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -7,6 +7,7 @@ import frappe
 from frappe import _
 from frappe.model.base_document import get_controller
 from frappe.model.document import Document
+from frappe.query_builder import Table
 from frappe.utils import add_days, cint, now_datetime
 from frappe.utils.caching import site_cache
 
@@ -164,30 +165,27 @@ def clear_log_table(doctype, days=90):
 	original = get_table_name(doctype)
 	temporary = f"{original} temp_table"
 	backup = f"{original} backup_table"
+
+	original_table = Table(original)
 	cutoff = add_days(now_datetime(), -cint(days))
+	copy_recent_rows = (
+		frappe.qb.into(Table(temporary))
+		.from_(original_table)
+		.select("*")
+		.where(original_table.creation > cutoff)
+	)
 
 	try:
 		if frappe.db.db_type == "postgres":
 			frappe.db.sql_ddl(f'CREATE TABLE "{temporary}" (LIKE "{original}" INCLUDING ALL)')
 
-			frappe.db.sql(
-				f"""INSERT INTO "{temporary}"
-					SELECT * FROM "{original}"
-					WHERE "{original}"."creation" > %(cutoff)s""",
-				{"cutoff": cutoff},
-			)
+			copy_recent_rows.run()
 			frappe.db.sql_ddl(f'ALTER TABLE "{original}" RENAME TO "{backup}"')
 			frappe.db.sql_ddl(f'ALTER TABLE "{temporary}" RENAME TO "{original}"')
 		elif frappe.db.db_type == "mariadb":
 			frappe.db.sql_ddl(f"CREATE TABLE `{temporary}` LIKE `{original}`")
 
-			# Copy all recent data to new table
-			frappe.db.sql(
-				f"""INSERT INTO `{temporary}`
-					SELECT * FROM `{original}`
-					WHERE `{original}`.`creation` > %(cutoff)s""",
-				{"cutoff": cutoff},
-			)
+			copy_recent_rows.run()
 			frappe.db.sql_ddl(f"RENAME TABLE `{original}` TO `{backup}`, `{temporary}` TO `{original}`")
 	except Exception:
 		frappe.db.rollback()

--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -7,7 +7,7 @@ import frappe
 from frappe import _
 from frappe.model.base_document import get_controller
 from frappe.model.document import Document
-from frappe.utils import cint
+from frappe.utils import add_days, cint, now_datetime
 from frappe.utils.caching import site_cache
 
 
@@ -164,6 +164,7 @@ def clear_log_table(doctype, days=90):
 	original = get_table_name(doctype)
 	temporary = f"{original} temp_table"
 	backup = f"{original} backup_table"
+	cutoff = add_days(now_datetime(), -cint(days))
 
 	try:
 		if frappe.db.db_type == "postgres":
@@ -172,7 +173,8 @@ def clear_log_table(doctype, days=90):
 			frappe.db.sql(
 				f"""INSERT INTO "{temporary}"
 					SELECT * FROM "{original}"
-					WHERE "{original}"."creation" > NOW() - INTERVAL '{days}' DAY"""
+					WHERE "{original}"."creation" > %(cutoff)s""",
+				{"cutoff": cutoff},
 			)
 			frappe.db.sql_ddl(f'ALTER TABLE "{original}" RENAME TO "{backup}"')
 			frappe.db.sql_ddl(f'ALTER TABLE "{temporary}" RENAME TO "{original}"')
@@ -183,7 +185,8 @@ def clear_log_table(doctype, days=90):
 			frappe.db.sql(
 				f"""INSERT INTO `{temporary}`
 					SELECT * FROM `{original}`
-					WHERE `{original}`.`creation` > NOW() - INTERVAL '{days}' DAY"""
+					WHERE `{original}`.`creation` > %(cutoff)s""",
+				{"cutoff": cutoff},
 			)
 			frappe.db.sql_ddl(f"RENAME TABLE `{original}` TO `{backup}`, `{temporary}` TO `{original}`")
 	except Exception:

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -49,10 +49,10 @@ def get_emails_sent_today(email_account=None):
 		WHERE
 			`status` in ('Sent', 'Not Sent', 'Sending')
 			AND
-			`creation` > (NOW() - INTERVAL '24' HOUR)
+			`creation` > %(since)s
 	"""
 
-	q_args = {}
+	q_args = {"since": add_to_date(now_datetime(), hours=-24)}
 	if email_account is not None:
 		if email_account:
 			q += " AND email_account = %(email_account)s"

--- a/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
@@ -9,7 +9,7 @@ from frappe import _
 from frappe.core.utils import find
 from frappe.desk.doctype.notification_settings.notification_settings import is_email_notifications_enabled
 from frappe.model.document import Document
-from frappe.utils import get_datetime, get_fullname, time_diff_in_hours
+from frappe.utils import add_days, get_datetime, get_fullname, now_datetime, time_diff_in_hours
 from frappe.utils.user import get_system_managers
 from frappe.utils.verified_command import get_signed_params, verify_request
 
@@ -379,7 +379,8 @@ def remove_unverified_record():
 		"""
 		DELETE FROM `tabPersonal Data Deletion Request`
 		WHERE `status` = 'Pending Verification'
-		AND `creation` < (NOW() - INTERVAL '7' DAY)"""
+		AND `creation` < %(cutoff)s""",
+		{"cutoff": add_days(now_datetime(), -7)},
 	)
 
 


### PR DESCRIPTION
Application timestamps such as `creation` and `modified` are written using `now_datetime()`, which respects **System Settings → Time Zone**. 
However, a few raw SQL queries compared those values against `NOW()`, which uses the database server's timezone instead. If the two clocks differ, the comparisons are off by the timezone offset. MariaDB also truncates `NOW()` to whole seconds, causing intermittent boundary failures when comparing against microsecond-precision timestamps.

Replace `NOW()` with a Python-computed cutoff based on `now_datetime()`, passed as a query parameter. 
This keeps both sides of the comparison on the same clock, preserves microsecond precision, and eliminates the flaky boundary case in `test_unverified_record_removal`. No behavior changes when the database timezone already matches System Settings.
