### PR TITLE
refactor: accept checkbox value for hide_currency_symbol default

### DIFF
--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -164,7 +164,10 @@ function format_currency(v, currency, decimals) {
 
 function get_currency_symbol(currency) {
 	if (frappe.boot) {
-		if (frappe.boot.sysdefaults && frappe.boot.sysdefaults.hide_currency_symbol == "Yes")
+		if (
+			frappe.boot.sysdefaults &&
+			["1", "Yes"].includes(frappe.boot.sysdefaults.hide_currency_symbol)
+		)
 			return null;
 
 		if (!currency) currency = frappe.boot.sysdefaults.currency;

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1474,7 +1474,7 @@ def fmt_money(
 	if amount != "0":
 		amount = minus + amount
 
-	if currency and frappe.defaults.get_global_default("hide_currency_symbol") != "Yes":
+	if currency and frappe.defaults.get_global_default("hide_currency_symbol") not in ("1", "Yes"):
 		symbol = frappe.db.get_value("Currency", currency, "symbol", cache=True) or currency
 		symbol_on_right = frappe.db.get_value("Currency", currency, "symbol_on_right", cache=True)
 

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -366,7 +366,7 @@ class XLSXStyleBuilder:
 
 	@staticmethod
 	def _get_currency_symbol_info(currency: str | None) -> tuple[str, bool]:
-		if not currency or frappe.db.get_default("hide_currency_symbol") == "Yes":
+		if not currency or frappe.db.get_default("hide_currency_symbol") in ("1", "Yes"):
 			return "", False
 
 		symbol, on_right = frappe.db.get_value("Currency", currency, ["symbol", "symbol_on_right"])


### PR DESCRIPTION
ERPNext's Global Defaults `hide_currency_symbol` is being converted from a Select (""/No/Yes) to a Check field (frappe/erpnext#57135). Updates the three readers of this default to accept the new "1" value while still accepting "Yes", so behavior is unchanged on sites where frappe updates before erpnext's data patch runs.