### PR TITLE
fix: truncate MultiSelectList status text within the control box

### DIFF
--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -100,6 +100,8 @@ select.form-control {
 	.status-text {
 		position: absolute;
 		top: 4px;
+		left: 8px;
+		right: 8px;
 	}
 
 	.dropdown-menu {


### PR DESCRIPTION
### Problem

In a `MultiSelectList` control (e.g. the **Account** filter of the General Ledger report), a long selected label such as `Application of Funds (Assets)` overflowed past the right edge of the control box instead of truncating cleanly inside it.

Before:

<img width="206" height="49" alt="Screenshot 2026-07-14 at 3 37 34 PM" src="https://github.com/user-attachments/assets/61730eee-19cd-4d39-bdcf-cb3bb1f4298e" />

After:

<img width="205" height="46" alt="Screenshot 2026-07-14 at 5 32 01 PM" src="https://github.com/user-attachments/assets/cd0c7af8-f47e-4beb-a391-8d7aae64fad1" />

