### PR TITLE
fix(report): add perm. conditions in perm. hooks

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -142,7 +142,7 @@ class Report(Document):
 				roles = [{"role": d.role} for d in meta.permissions if d.permlevel == 0]
 				self.set("roles", roles)
 
-	def is_permitted(self):
+	def is_permitted(self, user=None):
 		"""Return True if `Has Role` is not set or the user is allowed."""
 		from frappe.utils import has_common
 
@@ -156,7 +156,7 @@ class Report(Document):
 		if not allowed:
 			return True
 
-		if has_common(frappe.get_roles(), allowed):
+		if has_common(frappe.get_roles(user), allowed):
 			return True
 
 	def update_report_json(self):
@@ -554,12 +554,40 @@ def enable_prepared_report(report: str, site: str):
 
 def get_permission_query_conditions(user=None):
 	"""Hide Postgres-only diagnostic reports (named with a "Postgres " prefix) from the report
-	list on other database backends, where they raise instead of running."""
+	list on other database backends, where they raise instead of running.
+
+	Also hide reports whose Has Role table is set but does not include any role held by the
+	current user — mirroring the gate applied on the run path by get_report_doc()."""
+	user = user or frappe.session.user
+	user_roles = frappe.get_roles(user)
+	escaped_roles = ", ".join(frappe.db.escape(r) for r in user_roles)
+
 	if frappe.db.db_type == "postgres":
-		return None
+		return f"""(
+			NOT EXISTS (
+				SELECT 1 FROM "tabHas Role"
+				WHERE "parenttype" = 'Report' AND "parent" = "tabReport"."name"
+			)
+			OR EXISTS (
+				SELECT 1 FROM "tabHas Role"
+				WHERE "parenttype" = 'Report' AND "parent" = "tabReport"."name"
+				AND "role" IN ({escaped_roles})
+			)
+		)"""
+
 	# substr comparison, not LIKE 'Postgres %': a literal % in a permission condition is read as a
 	# printf placeholder when the list query is parameterized, raising "not enough arguments".
-	return "substr(`tabReport`.`name`, 1, 9) != 'Postgres '"
+	return f"""substr(`tabReport`.`name`, 1, 9) != 'Postgres ' AND (
+		NOT EXISTS (
+			SELECT 1 FROM `tabHas Role`
+			WHERE `parenttype` = 'Report' AND `parent` = `tabReport`.`name`
+		)
+		OR EXISTS (
+			SELECT 1 FROM `tabHas Role`
+			WHERE `parenttype` = 'Report' AND `parent` = `tabReport`.`name`
+			AND `role` IN ({escaped_roles})
+		)
+	)"""
 
 
 def has_permission(doc, ptype=None, user=None, debug=False):
@@ -567,5 +595,7 @@ def has_permission(doc, ptype=None, user=None, debug=False):
 	is separately guarded by its execute() raising on non-Postgres. Case-insensitive to match the
 	report list's SQL filter under MariaDB's case-insensitive collation."""
 	if frappe.db.db_type != "postgres" and doc.name and doc.name.lower().startswith("postgres "):
+		return False
+	if ptype in ("read", "report") and not doc.is_permitted(user):
 		return False
 	return True

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -563,31 +563,61 @@ def get_permission_query_conditions(user=None):
 	escaped_roles = ", ".join(frappe.db.escape(r) for r in user_roles)
 
 	if frappe.db.db_type == "postgres":
-		return f"""(
-			NOT EXISTS (
-				SELECT 1 FROM "tabHas Role"
-				WHERE "parenttype" = 'Report' AND "parent" = "tabReport"."name"
+		role_condition = f"""(
+			EXISTS (
+				SELECT 1 FROM "tabCustom Role" cr
+				JOIN "tabHas Role" hr ON hr.parent = cr.name AND hr.parenttype = 'Custom Role'
+				WHERE cr.report = "tabReport"."name" AND hr.role IN ({escaped_roles})
 			)
-			OR EXISTS (
-				SELECT 1 FROM "tabHas Role"
-				WHERE "parenttype" = 'Report' AND "parent" = "tabReport"."name"
-				AND "role" IN ({escaped_roles})
+			OR (
+				NOT EXISTS (
+					SELECT 1 FROM "tabCustom Role" cr
+					JOIN "tabHas Role" hr ON hr.parent = cr.name AND hr.parenttype = 'Custom Role'
+					WHERE cr.report = "tabReport"."name"
+				)
+				AND (
+					NOT EXISTS (
+						SELECT 1 FROM "tabHas Role"
+						WHERE "parenttype" = 'Report' AND "parent" = "tabReport"."name"
+					)
+					OR EXISTS (
+						SELECT 1 FROM "tabHas Role"
+						WHERE "parenttype" = 'Report' AND "parent" = "tabReport"."name"
+						AND "role" IN ({escaped_roles})
+					)
+				)
 			)
 		)"""
+		return role_condition
 
 	# substr comparison, not LIKE 'Postgres %': a literal % in a permission condition is read as a
 	# printf placeholder when the list query is parameterized, raising "not enough arguments".
-	return f"""substr(`tabReport`.`name`, 1, 9) != 'Postgres ' AND (
-		NOT EXISTS (
-			SELECT 1 FROM `tabHas Role`
-			WHERE `parenttype` = 'Report' AND `parent` = `tabReport`.`name`
+	role_condition = f"""(
+		EXISTS (
+			SELECT 1 FROM `tabCustom Role` cr
+			JOIN `tabHas Role` hr ON hr.parent = cr.name AND hr.parenttype = 'Custom Role'
+			WHERE cr.report = `tabReport`.`name` AND hr.role IN ({escaped_roles})
 		)
-		OR EXISTS (
-			SELECT 1 FROM `tabHas Role`
-			WHERE `parenttype` = 'Report' AND `parent` = `tabReport`.`name`
-			AND `role` IN ({escaped_roles})
+		OR (
+			NOT EXISTS (
+				SELECT 1 FROM `tabCustom Role` cr
+				JOIN `tabHas Role` hr ON hr.parent = cr.name AND hr.parenttype = 'Custom Role'
+				WHERE cr.report = `tabReport`.`name`
+			)
+			AND (
+				NOT EXISTS (
+					SELECT 1 FROM `tabHas Role`
+					WHERE `parenttype` = 'Report' AND `parent` = `tabReport`.`name`
+				)
+				OR EXISTS (
+					SELECT 1 FROM `tabHas Role`
+					WHERE `parenttype` = 'Report' AND `parent` = `tabReport`.`name`
+					AND `role` IN ({escaped_roles})
+				)
+			)
 		)
 	)"""
+	return f"substr(`tabReport`.`name`, 1, 9) != 'Postgres ' AND {role_condition}"
 
 
 def has_permission(doc, ptype=None, user=None, debug=False):

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -465,6 +465,78 @@ result = [
 		self.assertEqual(result[-1][1], 200)
 		self.assertEqual(result[-1][2], 150.50)
 
+	def test_read_path_blocked_by_has_role(self):
+		"""has_permission hook raises PermissionError for unpermitted user on frappe.get_doc."""
+		role = "Test Read Path Role"
+		report_name = "Test Read Path Block Report"
+		try:
+			if not frappe.db.exists("Role", role):
+				frappe.get_doc({"doctype": "Role", "role_name": role}).insert(ignore_permissions=True)
+
+			frappe.get_doc(
+				{
+					"doctype": "Report",
+					"report_name": report_name,
+					"ref_doctype": "User",
+					"report_type": "Query Report",
+					"is_standard": "No",
+					"query": "select name from tabUser limit 1",
+					"roles": [{"role": role}],
+				}
+			).insert(ignore_permissions=True)
+
+			unpermitted = create_user("test_read_blocked@example.com", "Website Manager")
+			permitted = create_user("test_read_allowed@example.com", role)
+
+			with self.set_user(unpermitted.email):
+				with self.assertRaises(frappe.PermissionError):
+					frappe.get_doc("Report", report_name, check_permission=True)
+
+			with self.set_user(permitted.email):
+				doc = frappe.get_doc("Report", report_name, check_permission=True)
+				self.assertEqual(doc.name, report_name)
+
+		finally:
+			frappe.set_user("Administrator")
+			frappe.db.delete("Report", {"name": report_name})
+
+	def test_get_list_filtered_by_has_role(self):
+		"""get_permission_query_conditions excludes restricted reports from list for unpermitted users."""
+		role = "Test List Filter Role"
+		report_name = "Test List Filter Report"
+		try:
+			if not frappe.db.exists("Role", role):
+				frappe.get_doc({"doctype": "Role", "role_name": role}).insert(ignore_permissions=True)
+
+			frappe.get_doc(
+				{
+					"doctype": "Report",
+					"report_name": report_name,
+					"ref_doctype": "User",
+					"report_type": "Query Report",
+					"is_standard": "No",
+					"query": "select name from tabUser limit 1",
+					"roles": [{"role": role}],
+				}
+			).insert(ignore_permissions=True)
+
+			unpermitted = create_user("test_list_blocked@example.com", "Website Manager")
+			permitted = create_user("test_list_allowed@example.com", role)
+
+			with self.set_user(unpermitted.email):
+				results = frappe.get_list("Report", filters={"name": report_name}, fields=["name", "query"])
+				self.assertEqual(results, [])
+
+			with self.set_user(permitted.email):
+				results = frappe.get_list("Report", filters={"name": report_name}, fields=["name", "query"])
+				self.assertEqual(len(results), 1)
+				self.assertEqual(results[0].name, report_name)
+				self.assertEqual(results[0].query, "select name from tabUser limit 1")
+
+		finally:
+			frappe.set_user("Administrator")
+			frappe.db.delete("Report", {"name": report_name})
+
 	def test_report_cache_invalidation(self):
 		import frappe.sessions
 		from frappe.utils import set_request


### PR DESCRIPTION
These hooks lacked a comprehensive perm. chk. This fixes that by adding the appropriate perm. checks.

closes Ticket 72119
