### PR TITLE
fix: grid row dependencies leaking across rows when columns are configured

### DIFF
--- a/cypress/fixtures/child_table_doctype_1.js
+++ b/cypress/fixtures/child_table_doctype_1.js
@@ -44,6 +44,12 @@ export default {
 			in_list_view: 1,
 			label: "Date",
 		},
+		{
+			depends_on: "data",
+			fieldname: "dependent_data",
+			fieldtype: "Data",
+			label: "Dependent Data",
+		},
 	],
 	links: [],
 	istable: 1,

--- a/cypress/integration/grid_row_dependency.js
+++ b/cypress/integration/grid_row_dependency.js
@@ -1,0 +1,67 @@
+import doctype_with_child_table from "../fixtures/doctype_with_child_table";
+import child_table_doctype from "../fixtures/child_table_doctype";
+import child_table_doctype_1 from "../fixtures/child_table_doctype_1";
+const doctype_with_child_table_name = doctype_with_child_table.name;
+
+context("Grid Row Dependency", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/desk/website");
+		cy.insert_doc("DocType", child_table_doctype, true);
+		cy.insert_doc("DocType", child_table_doctype_1, true);
+		cy.insert_doc("DocType", doctype_with_child_table, true);
+	});
+
+	after(() => {
+		cy.window()
+			.its("frappe")
+			.then((frappe) => {
+				return frappe.model.user_settings.save(
+					doctype_with_child_table_name,
+					"GridView",
+					null
+				);
+			});
+	});
+
+	it("keeps a dependent column on rows whose dependency is met", () => {
+		cy.visit("/desk/website");
+
+		cy.window()
+			.its("frappe")
+			.then((frappe) => {
+				return frappe.model.user_settings.save(doctype_with_child_table_name, "GridView", {
+					"Child Table Doctype 1": [
+						{ fieldname: "data", columns: 3 },
+						{ fieldname: "dependent_data", columns: 3 },
+					],
+				});
+			});
+
+		cy.new_form(doctype_with_child_table_name);
+
+		cy.window()
+			.its("cur_frm")
+			.then((frm) => {
+				frm.add_child("child_table_1", { data: "has data" });
+				frm.add_child("child_table_1", {});
+				frm.refresh();
+			});
+
+		cy.get('.frappe-control[data-fieldname="child_table_1"]').as("table");
+
+		cy.get("@table").find(".grid-body .rows .grid-row").eq(1).find(".data-row").click();
+		cy.get("@table")
+			.find(".grid-body .rows .grid-row")
+			.eq(1)
+			.find('[data-fieldname="dependent_data"] input')
+			.should("not.exist");
+
+		cy.get("@table").find(".grid-body .rows .grid-row").eq(0).find(".data-row").click();
+		cy.get("@table")
+			.find(".grid-body .rows .grid-row")
+			.eq(0)
+			.find('[data-fieldname="dependent_data"] input')
+			.should("be.visible");
+	});
+});

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -727,7 +727,7 @@ export default class GridRow {
 
 		this.grid.visible_columns.forEach((col, ci) => {
 			// to get update df for the row
-			let df = fields.find((field) => field?.fieldname === col[0].fieldname);
+			let df = this.get_column_docfield(fields, col[0].fieldname);
 
 			this.set_dependant_property(df);
 
@@ -795,6 +795,19 @@ export default class GridRow {
 			this.doc &&
 			!column.df.hidden
 		);
+	}
+
+	get_column_docfield(fields, fieldname) {
+		const column_df = fields.find((field) => field?.fieldname === fieldname);
+		const row_df = this.docfields?.find((df) => df.fieldname === fieldname);
+
+		if (!column_df || !row_df || column_df === row_df) return column_df;
+
+		row_df.width = column_df.width;
+		row_df.sticky = column_df.sticky;
+		row_df.in_list_view = column_df.in_list_view;
+
+		return row_df;
 	}
 
 	set_dependant_property(df) {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -803,7 +803,6 @@ export default class GridRow {
 
 		if (!column_df || !row_df || column_df === row_df) return column_df;
 
-		row_df.width = column_df.width;
 		row_df.sticky = column_df.sticky;
 		row_df.in_list_view = column_df.in_list_view;
 

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1538,9 +1538,7 @@ export default class GridRow {
 				? this.grid.user_defined_columns
 				: this.docfields;
 
-		let df = fields.find((col) => {
-			return col?.fieldname === fieldname;
-		});
+		let df = this.get_column_docfield(fields, fieldname);
 
 		// format values if no frm
 		if (df && this.doc) {


### PR DESCRIPTION
When a grid uses user-configured columns, every row shares the same `DocField` object from `grid.user_defined_columns`. Dependency evaluation then mutates that shared object, so the last row rendered determines `hidden_due_to_dependency`, `reqd`, and `read_only` for the entire column.

As a result, a row where the dependency is false can hide the field on rows where it should be visible—for example, a Delivery Note item with no Item Price hides the **Discount** field on priced rows.

Use a per-row `DocField` copy while preserving the configured column layout (`width`, `sticky`, `in_list_view`), so dependency state remains row-local.