### PR TITLE
fix(communication): sync comment cache on relink

### DIFF
--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -154,6 +154,28 @@ def update_comment_in_doc(doc):
 		update_comments_in_parent(doc.reference_doctype, doc.reference_name, _comments)
 
 
+def relink_comment_cache(doc, old_reference_doctype, old_reference_name):
+	"""Move `doc`'s cached entry out of the old parent's `_comments` and into the new one.
+
+	Used both by ``Communication.on_update`` (old reference read from
+	``get_doc_before_save()``) and by ``frappe.email.relink`` (old reference captured
+	before the raw SQL update), so the cache stays in sync whichever way the
+	reference is changed.
+	"""
+	if (
+		old_reference_doctype
+		and old_reference_name
+		and (old_reference_doctype, old_reference_name) != (doc.reference_doctype, doc.reference_name)
+	):
+		_comments = get_comments_from_parent(
+			frappe._dict(reference_doctype=old_reference_doctype, reference_name=old_reference_name)
+		)
+		_comments = [c for c in _comments if c.get("name") != doc.name]
+		update_comments_in_parent(old_reference_doctype, old_reference_name, _comments)
+
+	update_comment_in_doc(doc)
+
+
 def get_comments_from_parent(doc):
 	"""
 	get the list of comments cached in the document record in the column

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -13,7 +13,7 @@ from frappe.automation.doctype.assignment_rule.assignment_rule import (
 	apply as apply_assignment_rule,
 )
 from frappe.contacts.doctype.contact.contact import get_contact_name
-from frappe.core.doctype.comment.comment import update_comment_in_doc
+from frappe.core.doctype.comment.comment import relink_comment_cache
 from frappe.core.doctype.communication.email import validate_email
 from frappe.core.doctype.communication.mixins import CommunicationEmailMixin
 from frappe.core.utils import get_parent_doc
@@ -242,9 +242,16 @@ class Communication(Document, CommunicationEmailMixin):
 			self.set_signature_in_email_content()
 
 	def on_update(self):
-		# add to _comment property of the doctype, so it shows up in
-		# comments count for the list view
-		update_comment_in_doc(self)
+		"""
+		add to _comment property of the doctype, so it shows up in comments count for the list view;
+		also move the cached entry off the old parent if the reference changed (e.g. via Communication.save())
+		"""
+		before_save = self.get_doc_before_save()
+		relink_comment_cache(
+			self,
+			before_save.reference_doctype if before_save else None,
+			before_save.reference_name if before_save else None,
+		)
 
 		parent = get_parent_doc(self)
 		if (method := getattr(parent, "on_communication_update", None)) and callable(method):

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+import json
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import frappe
 from frappe.core.doctype.communication.communication import Communication, get_emails, parse_email
 from frappe.core.doctype.communication.email import add_attachments, make, undo_email_send
+from frappe.email import relink
 from frappe.email.doctype.email_queue.email_queue import EmailQueue
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, now_datetime
@@ -180,6 +182,178 @@ class TestCommunication(IntegrationTestCase):
 		self.assertIn(contact_sender.name, contact_links)
 		self.assertIn(contact_recipient.name, contact_links)
 		self.assertIn(contact_cc.name, contact_links)
+
+	def test_relink_updates_comment_count(self):
+		"""https://github.com/frappe/frappe/issues/4513"""
+		frappe.delete_doc_if_exists("Note", "test relink comment count - old")
+		frappe.delete_doc_if_exists("Note", "test relink comment count - new")
+
+		old_note = frappe.get_doc(
+			{"doctype": "Note", "title": "test relink comment count - old", "content": "old"}
+		).insert(ignore_permissions=True)
+		new_note = frappe.get_doc(
+			{"doctype": "Note", "title": "test relink comment count - new", "content": "new"}
+		).insert(ignore_permissions=True)
+
+		comm = frappe.get_doc(
+			{
+				"doctype": "Communication",
+				"communication_type": "Communication",
+				"content": "Test relink comment count",
+				"reference_doctype": "Note",
+				"reference_name": old_note.name,
+			}
+		).insert(ignore_permissions=True)
+
+		def comment_count(doctype, name):
+			_comments = frappe.db.get_value(doctype, name, "_comments") or "[]"
+			return len(json.loads(_comments))
+
+		self.assertEqual(comment_count("Note", old_note.name), 1)
+		self.assertEqual(comment_count("Note", new_note.name), 0)
+
+		relink(comm.name, reference_doctype="Note", reference_name=new_note.name)
+
+		self.assertEqual(comment_count("Note", old_note.name), 0)
+		self.assertEqual(comment_count("Note", new_note.name), 1)
+
+	def test_relink_across_doctypes_with_shared_name(self):
+		"""relinking to a different doctype that shares the old parent's name must still
+		clear the old parent's comment cache (https://github.com/frappe/frappe/issues/4513)"""
+		shared_name = "test-relink-shared-name"
+		frappe.delete_doc_if_exists("Role", shared_name)
+		frappe.delete_doc_if_exists("Tag", shared_name)
+
+		old_parent = frappe.get_doc({"doctype": "Role", "role_name": shared_name}).insert(
+			ignore_permissions=True
+		)
+		new_parent = frappe.get_doc({"doctype": "Tag", "name": shared_name}).insert(ignore_permissions=True)
+		self.assertEqual(old_parent.name, new_parent.name)
+
+		comm = frappe.get_doc(
+			{
+				"doctype": "Communication",
+				"communication_type": "Communication",
+				"content": "Test relink across doctypes",
+				"reference_doctype": "Role",
+				"reference_name": old_parent.name,
+			}
+		).insert(ignore_permissions=True)
+
+		def comment_count(doctype, name):
+			_comments = frappe.db.get_value(doctype, name, "_comments") or "[]"
+			return len(json.loads(_comments))
+
+		self.assertEqual(comment_count("Role", old_parent.name), 1)
+		self.assertEqual(comment_count("Tag", new_parent.name), 0)
+
+		relink(comm.name, reference_doctype="Tag", reference_name=new_parent.name)
+
+		self.assertEqual(comment_count("Role", old_parent.name), 0)
+		self.assertEqual(comment_count("Tag", new_parent.name), 1)
+
+	def test_relink_noop_for_non_communication_type(self):
+		"""relink() must only act on communication_type "Communication"; the DB update
+		it issues never touches other types, so any comment-cache change alongside it
+		would desync from the (unmoved) row (https://github.com/frappe/frappe/issues/4513)"""
+		frappe.delete_doc_if_exists("Note", "test relink noop - old")
+		frappe.delete_doc_if_exists("Note", "test relink noop - new")
+
+		old_note = frappe.get_doc(
+			{"doctype": "Note", "title": "test relink noop - old", "content": "old"}
+		).insert(ignore_permissions=True)
+		new_note = frappe.get_doc(
+			{"doctype": "Note", "title": "test relink noop - new", "content": "new"}
+		).insert(ignore_permissions=True)
+
+		comm = frappe.get_doc(
+			{
+				"doctype": "Communication",
+				"communication_type": "Automated Message",
+				"content": "Test relink noop",
+				"reference_doctype": "Note",
+				"reference_name": old_note.name,
+			}
+		).insert(ignore_permissions=True)
+
+		def comment_count(doctype, name):
+			_comments = frappe.db.get_value(doctype, name, "_comments") or "[]"
+			return len(json.loads(_comments))
+
+		self.assertEqual(comment_count("Note", old_note.name), 1)
+		self.assertEqual(comment_count("Note", new_note.name), 0)
+
+		relink(comm.name, reference_doctype="Note", reference_name=new_note.name)
+
+		self.assertEqual(frappe.db.get_value("Communication", comm.name, "reference_name"), old_note.name)
+		self.assertEqual(comment_count("Note", old_note.name), 1)
+		self.assertEqual(comment_count("Note", new_note.name), 0)
+
+	def test_relink_unlink_clears_old_parent_cache(self):
+		"""relinking to no reference (reference_name=None) must still clear the old
+		parent's cached comment entry (https://github.com/frappe/frappe/issues/4513)"""
+		frappe.delete_doc_if_exists("Note", "test relink unlink - old")
+
+		old_note = frappe.get_doc(
+			{"doctype": "Note", "title": "test relink unlink - old", "content": "old"}
+		).insert(ignore_permissions=True)
+
+		comm = frappe.get_doc(
+			{
+				"doctype": "Communication",
+				"communication_type": "Communication",
+				"content": "Test relink unlink",
+				"reference_doctype": "Note",
+				"reference_name": old_note.name,
+			}
+		).insert(ignore_permissions=True)
+
+		def comment_count(doctype, name):
+			_comments = frappe.db.get_value(doctype, name, "_comments") or "[]"
+			return len(json.loads(_comments))
+
+		self.assertEqual(comment_count("Note", old_note.name), 1)
+
+		relink(comm.name, reference_doctype=None, reference_name=None)
+
+		self.assertIsNone(frappe.db.get_value("Communication", comm.name, "reference_name"))
+		self.assertEqual(comment_count("Note", old_note.name), 0)
+
+	def test_save_updates_comment_count(self):
+		"""changing reference_doctype/reference_name via Document.save() (not just relink())
+		must also move the cached comment entry (https://github.com/frappe/frappe/issues/4513)"""
+		frappe.delete_doc_if_exists("Note", "test save comment count - old")
+		frappe.delete_doc_if_exists("Note", "test save comment count - new")
+
+		old_note = frappe.get_doc(
+			{"doctype": "Note", "title": "test save comment count - old", "content": "old"}
+		).insert(ignore_permissions=True)
+		new_note = frappe.get_doc(
+			{"doctype": "Note", "title": "test save comment count - new", "content": "new"}
+		).insert(ignore_permissions=True)
+
+		comm = frappe.get_doc(
+			{
+				"doctype": "Communication",
+				"communication_type": "Communication",
+				"content": "Test save comment count",
+				"reference_doctype": "Note",
+				"reference_name": old_note.name,
+			}
+		).insert(ignore_permissions=True)
+
+		def comment_count(doctype, name):
+			_comments = frappe.db.get_value(doctype, name, "_comments") or "[]"
+			return len(json.loads(_comments))
+
+		self.assertEqual(comment_count("Note", old_note.name), 1)
+		self.assertEqual(comment_count("Note", new_note.name), 0)
+
+		comm.reference_name = new_note.name
+		comm.save(ignore_permissions=True)
+
+		self.assertEqual(comment_count("Note", old_note.name), 0)
+		self.assertEqual(comment_count("Note", new_note.name), 1)
 
 	def test_get_communication_data(self):
 		from frappe.desk.form.load import get_communication_data

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -61,7 +61,17 @@ def get_system_managers():
 
 @frappe.whitelist()
 def relink(name: str, reference_doctype: str | None = None, reference_name: str | None = None):
+	from frappe.core.doctype.comment.comment import relink_comment_cache
+
 	frappe.has_permission("Communication", "write", name, throw=True)
+
+	comm = frappe.get_doc("Communication", name)
+	if comm.communication_type != "Communication":
+		return
+
+	old_reference_doctype = comm.reference_doctype
+	old_reference_name = comm.reference_name
+
 	frappe.db.sql(
 		"""update
 			`tabCommunication`
@@ -70,10 +80,13 @@ def relink(name: str, reference_doctype: str | None = None, reference_name: str 
 			reference_name = %s,
 			status = "Linked"
 		where
-			communication_type = "Communication" and
 			name = %s""",
 		(reference_doctype, reference_name, name),
 	)
+
+	comm.reference_doctype = reference_doctype
+	comm.reference_name = reference_name
+	relink_comment_cache(comm, old_reference_doctype, old_reference_name)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/4513

relink() updated tabCommunication directly via raw SQL, bypassing on_update, so the old and new parent's _comments cache never synced. Added a regression test covering both the old and new parent.


### Before

https://github.com/user-attachments/assets/94d0862a-1c11-4212-b5bb-af7d34960c5c




### After

https://github.com/user-attachments/assets/9ec7585f-4cf6-4761-bf87-11c7b71a2186


Raises on behalf of @g-sowani 