### PR TITLE
fix: batch name lookups in get_data_for_custom_field

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -15,7 +15,17 @@ from frappe.model.utils import render_include
 from frappe.modules import get_module_path, scrub
 from frappe.monitor import add_data_to_monitor
 from frappe.permissions import get_role_permissions, get_roles, has_permission
-from frappe.utils import cint, cstr, flt, format_datetime, format_duration, formatdate, get_html_format, sbool
+from frappe.utils import (
+	cint,
+	create_batch,
+	cstr,
+	flt,
+	format_datetime,
+	format_duration,
+	formatdate,
+	get_html_format,
+	sbool,
+)
 from frappe.utils.caching import request_cache
 
 
@@ -648,13 +658,19 @@ def get_data_for_custom_field(doctype, field, names=None):
 	if not frappe.has_permission(doctype, "read"):
 		frappe.throw(_("Not Permitted to read {0}").format(_(doctype)), frappe.PermissionError)
 
-	filters = {}
-	if names:
-		if isinstance(names, str | bytearray):
-			names = frappe.json.loads(names)
-		filters.update({"name": ["in", names]})
+	if not names:
+		return frappe._dict(frappe.get_list(doctype, fields=["name", field], as_list=1))
 
-	return frappe._dict(frappe.get_list(doctype, filters=filters, fields=["name", field], as_list=1))
+	if isinstance(names, str | bytearray):
+		names = frappe.json.loads(names)
+
+	value_map = frappe._dict()
+	for batch in create_batch(names, 1000):
+		value_map.update(
+			frappe.get_list(doctype, filters={"name": ["in", batch]}, fields=["name", field], as_list=1)
+		)
+
+	return value_map
 
 
 def get_data_for_custom_report(columns, result):

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -17,6 +17,15 @@ class TestQueryReport(FrappeTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 
+	def test_get_data_for_custom_field_with_large_name_list(self):
+		from frappe.desk.query_report import get_data_for_custom_field
+
+		frappe.set_user("Administrator")
+
+		names = [f"NONEXISTENT-{i:06d}" for i in range(6000)]
+		result = get_data_for_custom_field("ToDo", "description", names)
+		self.assertEqual(result, {})
+
 	def test_xlsx_data_with_multiple_datatypes(self):
 		"""Test exporting report using rows with multiple datatypes (list, dict)"""
 


### PR DESCRIPTION
## Summary
A custom report with a link column builds a single `name in (...)` filter containing every row's link value. With a few thousand rows this generates a query large enough to exceed sqlparse's token limit during `validate_generated_query`, crashing the report with `SQLParseError: Maximum number of tokens exceeded (10000)`.

Fixes it by batching `get_data_for_custom_field` lookups (1000 names per query) instead of issuing one query for the full list.
