### PR TITLE
fix(list): render Markdown Editor standard filters as text search

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -1215,6 +1215,7 @@ class FilterArea {
 							"Small Text",
 							"Text Editor",
 							"HTML Editor",
+							"Markdown Editor",
 							"Data",
 							"Code",
 							"Phone",


### PR DESCRIPTION
Resolve: #40876
Backport: `version-16`, `version-15`

----

**Before:**
<img width="1920" height="996" alt="image" src="https://github.com/user-attachments/assets/41dbb878-0fc2-4a3b-bfe1-d8551528e705" />


**After**



https://github.com/user-attachments/assets/cf955809-92e5-40d9-8831-65df5f98fb5f



