### PR TITLE
fix: don't crash query validation on large generated queries

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -209,12 +209,9 @@ _PARSE_FULL_QUERY_LOCK = threading.Lock()
 
 
 def _parse_full_query(query: str):
-	# sqlparse caps grouping at 10k tokens as a DoS guard for untrusted SQL. Here the input
-	# is our own generated (and about-to-be-executed) query, where a large but legitimate
-	# `IN (...)` list can exceed the cap; lift it for this parse so validation doesn't crash.
-	# The lock makes the save-mutate-restore of the module global atomic: without it, a
-	# concurrent thread can capture None as the "original" value and restore it, permanently
-	# disabling the cap for the process.
+	# Lift sqlparse's 10k-token DoS cap for our own generated query (a large but legitimate
+	# `IN (...)` list can exceed it). Lock keeps the save-restore of the global atomic across
+	# threads, else a concurrent parse can capture None as "original" and leave the cap off.
 	with _PARSE_FULL_QUERY_LOCK:
 		original_limit = sqlparse.engine.grouping.MAX_GROUPING_TOKENS
 		sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -6,6 +6,7 @@ import copy
 import datetime
 import json
 import re
+import threading
 from collections import Counter
 from functools import lru_cache
 
@@ -204,16 +205,23 @@ def _find_disallowed_function(node) -> str | None:
 	return None
 
 
+_PARSE_FULL_QUERY_LOCK = threading.Lock()
+
+
 def _parse_full_query(query: str):
 	# sqlparse caps grouping at 10k tokens as a DoS guard for untrusted SQL. Here the input
 	# is our own generated (and about-to-be-executed) query, where a large but legitimate
 	# `IN (...)` list can exceed the cap; lift it for this parse so validation doesn't crash.
-	original_limit = sqlparse.engine.grouping.MAX_GROUPING_TOKENS
-	sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None
-	try:
-		return sqlparse.parse(query)
-	finally:
-		sqlparse.engine.grouping.MAX_GROUPING_TOKENS = original_limit
+	# The lock makes the save-mutate-restore of the module global atomic: without it, a
+	# concurrent thread can capture None as the "original" value and restore it, permanently
+	# disabling the cap for the process.
+	with _PARSE_FULL_QUERY_LOCK:
+		original_limit = sqlparse.engine.grouping.MAX_GROUPING_TOKENS
+		sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None
+		try:
+			return sqlparse.parse(query)
+		finally:
+			sqlparse.engine.grouping.MAX_GROUPING_TOKENS = original_limit
 
 
 @lru_cache(maxsize=1024)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -10,6 +10,7 @@ from collections import Counter
 from functools import lru_cache
 
 import sqlparse
+import sqlparse.engine.grouping
 from sqlparse import tokens
 from sqlparse.sql import Function, Parenthesis, Statement
 
@@ -203,6 +204,18 @@ def _find_disallowed_function(node) -> str | None:
 	return None
 
 
+def _parse_full_query(query: str):
+	# sqlparse caps grouping at 10k tokens as a DoS guard for untrusted SQL. Here the input
+	# is our own generated (and about-to-be-executed) query, where a large but legitimate
+	# `IN (...)` list can exceed the cap; lift it for this parse so validation doesn't crash.
+	original_limit = sqlparse.engine.grouping.MAX_GROUPING_TOKENS
+	sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None
+	try:
+		return sqlparse.parse(query)
+	finally:
+		sqlparse.engine.grouping.MAX_GROUPING_TOKENS = original_limit
+
+
 @lru_cache(maxsize=1024)
 def validate_generated_query(query: str) -> None:
 	"""Parse a finally generated query and reject constructs a list query must never contain.
@@ -217,7 +230,7 @@ def validate_generated_query(query: str) -> None:
 	7. No subqueries.
 	8. Only functions in `ALLOWED_SQL_FUNCTIONS` are used.
 	"""
-	statements = [s for s in sqlparse.parse(query) if s.token_first(skip_cm=True) is not None]
+	statements = [s for s in _parse_full_query(query) if s.token_first(skip_cm=True) is not None]
 
 	# stacked queries
 	if len(statements) != 1:

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -268,6 +268,12 @@ class TestDBQuery(FrappeTestCase):
 				result in DatabaseQuery("DocType").execute(filters={"name": ["not in", "DocType,DocField"]})
 			)
 
+	def test_large_in_filter_does_not_exceed_sqlparse_token_limit(self):
+		# A large `in (...)` list produces a query that exceeds sqlparse's 10k-token
+		# cap; query validation must not crash with SQLParseError.
+		names = [f"NONEXISTENT-{i:06d}" for i in range(6000)]
+		self.assertEqual(DatabaseQuery("DocType").execute(filters={"name": ["in", names]}), [])
+
 	def test_in_filter_json_encoded_values(self):
 		# JSON-encoded list string should work the same as comma-separated
 		for result in [{"name": "DocType"}, {"name": "DocField"}]:


### PR DESCRIPTION
## Summary
`validate_generated_query` (added in #40522) parses the *entire* generated SQL of every `get_list`/`get_all` with `sqlparse.parse()`. sqlparse 0.5.x caps grouping at `MAX_GROUPING_TOKENS = 10000` as a DoS guard for untrusted input. A large but legitimate `IN (...)` filter (a few thousand values) exceeds the cap, so validation raises `SQLParseError: Maximum number of tokens exceeded (10000)` and the query crashes.

This is the root cause behind the "token exceeded" report errors. #40877 patched one specific call site (`get_data_for_custom_field`) by batching, but any other path that builds a large filter still hits it — this fixes it centrally.

The cap is meant for untrusted SQL; here the input is our own generated, about-to-be-executed query, so we lift it just for this parse. All structural security checks (single plain SELECT, no comments/set-ops/subqueries/secondary DML-DDL/disallowed functions) still run on the fully parsed statement.
