### PR TITLE
fix(form): hide submit button for non-submittable documents

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -671,6 +671,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 	}
 	can_submit() {
 		return (
+			frappe.model.is_submittable(this.frm.doc.doctype) &&
 			this.get_docstatus() === 0 &&
 			!this.frm.doc.__islocal &&
 			!this.frm.doc.__unsaved &&


### PR DESCRIPTION
Resolve: #40879 

---

**Before:**

<img width="1842" height="963" alt="image" src="https://github.com/user-attachments/assets/951e45ac-dad0-4641-bc05-ed268b9fed81" />


**After:**
<img width="1842" height="960" alt="image" src="https://github.com/user-attachments/assets/91479fc2-7931-4fad-9045-2c29999be3ef" />
