### PR TITLE
fix: independent table style controls in print format builder

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -99,13 +99,18 @@
 					<table
 						class="table"
 						:class="{ 'table-bordered': df.table_bordered !== false }"
+						:style="
+							df.table_bordered !== false && df.table_border_color
+								? { borderColor: df.table_border_color }
+								: {}
+						"
 					>
 						<thead v-if="df.table_header !== 'none'">
 							<!-- inline !important mirrors the server markup: the shared
 								     stylesheet's own !important rules must lose to these -->
 							<tr
 								:style="
-									df.table_header_bg
+									df.table_header_bg && df.table_header !== 'plain'
 										? `background-color: ${df.table_header_bg} !important`
 										: ''
 								"
@@ -506,7 +511,6 @@ const preview_root = computed(() => {
 			classes: [
 				"child-table",
 				`child-table--${df.table_style || "lined"}`,
-				df.table_bordered === false ? "child-table--borderless" : "",
 				df.table_header === "plain" ? "child-table--plain-header" : "",
 			],
 			style: custom,

--- a/frappe/public/js/print_format_builder/components/inspector/TableFieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/TableFieldInspector.vue
@@ -12,33 +12,22 @@
 				:show="selected_field.show_label"
 				@update:show="(v) => (selected_field.show_label = v)"
 			/>
-			<!-- Style -->
-			<SegmentedRow
-				:label="__('Style')"
-				:model-value="table_style"
-				:options="table_style_opts"
-				@update:model-value="(v) => (selected_field.table_style = v)"
-			/>
-			<!-- Bordered -->
-			<SegmentedRow
-				:label="__('Bordered')"
-				:model-value="table_bordered !== false"
-				:options="[
-					{ value: true, label: __('Yes') },
-					{ value: false, label: __('No') },
-				]"
-				@update:model-value="(v) => (selected_field.table_bordered = v)"
-			/>
-			<!-- Cell padding -->
-			<StepperRow
-				:label="__('Cell padding')"
-				:model-value="table_cell_padding"
-				:base="7"
-				unit="px"
-				:placeholder="__('auto')"
-				allow-empty
-				@update:model-value="set_cell_padding"
-			/>
+			<!-- Style: one look = one (table_style, table_bordered) pair -->
+			<div class="pfb-insp-row">
+				<span class="pfb-insp-label">{{ __("Style") }}</span>
+				<select
+					class="pfb-insp-select"
+					:value="table_look ?? ''"
+					@change="set_table_look($event.target.value)"
+				>
+					<option v-if="table_look === null" value="" disabled hidden>
+						{{ __("Custom") }}
+					</option>
+					<option v-for="o in table_look_opts" :key="o.value" :value="o.value">
+						{{ o.label }}
+					</option>
+				</select>
+			</div>
 			<!-- Header -->
 			<SegmentedRow
 				:label="__('Header')"
@@ -49,6 +38,16 @@
 					{ value: 'none', label: __('None') },
 				]"
 				@update:model-value="(v) => (selected_field.table_header = v)"
+			/>
+			<!-- Cell padding -->
+			<StepperRow
+				:label="__('Cell padding')"
+				:model-value="table_cell_padding"
+				:base="7"
+				unit="px"
+				:placeholder="__('auto')"
+				allow-empty
+				@update:model-value="set_cell_padding"
 			/>
 			<!-- Corner radius -->
 			<StepperRow
@@ -207,12 +206,14 @@
 		<InspectorSection :label="__('Style')" :init-open="false" :padded="false">
 			<div class="pfb-insp-section-body">
 				<ColorField
+					v-if="table_header === 'styled'"
 					:label="__('Header')"
 					:model-value="table_header_bg"
 					:placeholder="__('Default')"
 					@update:model-value="(v) => set_table_prop('table_header_bg', v)"
 				/>
 				<ColorField
+					v-if="has_lines"
 					:label="__('Border')"
 					:model-value="table_border_color"
 					:placeholder="__('Default')"
@@ -252,6 +253,12 @@ let table_cell_padding = computed(() => selected_field.value?.table_cell_padding
 let table_radius = computed(() => selected_field.value?.table_radius ?? null);
 let table_header_bg = computed(() => selected_field.value?.table_header_bg ?? "");
 let table_border_color = computed(() => selected_field.value?.table_border_color ?? "");
+let has_lines = computed(
+	() =>
+		table_bordered.value !== false ||
+		table_style.value === "lined" ||
+		table_header.value === "plain"
+);
 
 function set_table_prop(key, value) {
 	if (value) selected_field.value[key] = value;
@@ -268,11 +275,35 @@ function set_table_radius(v) {
 	else selected_field.value.table_radius = v;
 }
 
-const table_style_opts = [
-	{ value: "lined", label: __("Lined") },
+const LOOKS = {
+	grid: { style: "lined", bordered: true },
+	rows: { style: "lined", bordered: false },
+	striped: { style: "striped", bordered: false },
+	clean: { style: "plain", bordered: false },
+};
+
+const table_look_opts = [
+	{ value: "grid", label: __("Grid") },
+	{ value: "rows", label: __("Rows") },
 	{ value: "striped", label: __("Striped") },
-	{ value: "plain", label: __("Plain") },
+	{ value: "clean", label: __("None") },
 ];
+
+let table_look = computed(
+	() =>
+		Object.keys(LOOKS).find(
+			(k) =>
+				LOOKS[k].style === table_style.value && LOOKS[k].bordered === table_bordered.value
+		) ?? null
+);
+
+function set_table_look(look) {
+	const { style, bordered } = LOOKS[look];
+	if (style === "lined") delete selected_field.value.table_style;
+	else selected_field.value.table_style = style;
+	if (bordered) delete selected_field.value.table_bordered;
+	else selected_field.value.table_bordered = bordered;
+}
 
 let child_value_fields = computed(() => {
 	const dt = selected_field.value?.options;

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -7,10 +7,10 @@
 {%- set _cell_style = ('padding:' + _cell_pad|string + 'px') if _cell_pad is not none else '' -%}
 {%- set _border_color = df.table_border_color if df.table_border_color else none -%}
 {%- set _cell_style = ((_cell_style + ';') if _cell_style else '') + (('border-color:' + _border_color + ' !important') if _border_color else '') -%}
-{%- set _header_style = ('background-color:' + df.table_header_bg + ' !important') if df.table_header_bg else '' -%}
+{%- set _header_style = ('background-color:' + df.table_header_bg + ' !important') if df.table_header_bg and not _plain_header else '' -%}
 {%- set _radius = df.table_radius if df.table_radius is defined and df.table_radius is not none else none -%}
 {%- set _radius_style = ('border-radius:' + _radius|string + 'px;overflow:hidden') if _radius is not none else '' -%}
-<div class="child-table child-table--{{ _style }}{% if not _bordered %} child-table--borderless{% endif %}{% if _plain_header %} child-table--plain-header{% endif %}"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
+<div class="child-table child-table--{{ _style }}{% if _plain_header %} child-table--plain-header{% endif %}"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
 	{%- set _show_label = df.show_label if df.show_label else 'show' -%}
 	{% if df.label and _show_label != 'hide' %}
 	<div class="label">
@@ -20,7 +20,7 @@
 	{#- border-radius has no effect on a border-collapse:collapse table per spec, so the
 	   radius + clip live on a wrapper div around the table instead of on the table itself -#}
 	<div{% if _radius_style %} style="{{ _radius_style|e }}"{% endif %}>
-	<table class="table{% if _bordered %} table-bordered{% endif %}">
+	<table class="table{% if _bordered %} table-bordered{% endif %}"{% if _bordered and _border_color %} style="border-color: {{ _border_color|e }}"{% endif %}>
 		{% set columns = df.table_columns %}
 		{%- if not _no_header -%}
 		<thead>

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -4,13 +4,6 @@
 .print-format-doc {
 	-webkit-print-color-adjust: exact;
 	print-color-adjust: exact;
-	--pf-text: #111827;
-	--pf-heading: #374151;
-	--pf-muted: #6b7280;
-	--pf-line: #e5e7eb;
-	--pf-fill: #f3f4f6;
-	--pf-fill-soft: #f9fafb;
-	--pf-paper: #ffffff;
 }
 .print-format-doc .label {
 	border: none;
@@ -21,10 +14,10 @@
 .print-format-doc .section-label {
 	font-size: 1.1em;
 	font-weight: 700;
-	color: #1a1a1a;
+	color: var(--gray-900);
 	padding-bottom: 0.3182em;
 	margin-bottom: 0.6818em;
-	border-bottom: 1.5px solid #e2e2e2;
+	border-bottom: 1.5px solid var(--gray-300);
 	/* Don't let the section heading sit alone at the bottom of a page */
 	break-after: avoid;
 	page-break-after: avoid;
@@ -43,12 +36,12 @@
 /* Stacked (default): muted label above value */
 .print-format-doc .field .label {
 	font-size: 1em;
-	color: var(--pf-muted);
+	color: var(--gray-600);
 	margin-bottom: 0.1em;
 }
 
 .print-format-doc .field .value {
-	color: var(--pf-text);
+	color: var(--gray-900);
 }
 
 /* Left-right (section-level): label shrinks to content width, value takes the rest */
@@ -63,7 +56,7 @@
 .print-format-doc .field.field-inline .label {
 	flex-shrink: 0;
 	font-size: 1em;
-	color: var(--pf-heading);
+	color: var(--gray-800);
 	text-transform: none;
 	letter-spacing: 0;
 	padding-top: 0.05em;
@@ -152,7 +145,7 @@
 .print-format-doc .child-table > .label {
 	font-size: 0.8em;
 	font-weight: 600;
-	color: var(--pf-muted);
+	color: var(--gray-600);
 	margin-bottom: 0.5em;
 }
 
@@ -170,7 +163,7 @@
    !important (Bootstrap print sets .table-bordered cell borders !important)
    so each axis opts back in without touching the others. */
 .print-format-doc .child-table .table th {
-	color: var(--pf-heading);
+	color: var(--gray-800);
 	font-weight: 600;
 	font-size: 0.85em;
 	padding: 0.5882em 0.7843em;
@@ -183,35 +176,35 @@
 /* header background lives on the row, not each cell, so a wrapper's border-radius
    clips one continuous bar instead of fighting per-cell backgrounds at the seams */
 .print-format-doc .child-table .table thead tr {
-	background-color: var(--pf-fill) !important;
+	background-color: var(--gray-100) !important;
 }
 
 .print-format-doc .child-table .table td {
 	padding: 0.5em 0.6667em;
 	border: none !important;
-	background-color: var(--pf-paper) !important;
+	background-color: var(--white) !important;
 	vertical-align: top;
 }
 
 /* lined: a divider under the header and under each row */
 .print-format-doc .child-table--lined .table th,
 .print-format-doc .child-table--lined .table td {
-	border-bottom: 1px solid var(--pf-line) !important;
+	border-bottom: 1px solid var(--gray-300) !important;
 }
 
 /* striped: alternating row fill instead of dividers */
 .print-format-doc .child-table--striped .table .even td {
-	background-color: var(--pf-fill-soft) !important;
+	background-color: var(--gray-50) !important;
 }
 
 /* bordered: column separators + outer frame; adjacent cell borders collapse */
 .print-format-doc .child-table .table-bordered {
-	border: 1px solid var(--pf-line);
+	border: 1px solid var(--gray-300);
 }
 
 .print-format-doc .child-table .table-bordered td {
-	border-left: 1px solid var(--pf-line) !important;
-	border-right: 1px solid var(--pf-line) !important;
+	border-left: 1px solid var(--gray-300) !important;
+	border-right: 1px solid var(--gray-300) !important;
 }
 
 /* plain header: no fill, a single rule under the header row instead */
@@ -220,7 +213,7 @@
 }
 
 .print-format-doc .child-table--plain-header .table th {
-	border-bottom: 1px solid var(--pf-line) !important;
+	border-bottom: 1px solid var(--gray-300) !important;
 }
 
 .print-format-doc .child-table [data-fieldtype="Currency"],
@@ -280,7 +273,7 @@
 
 .print-format-doc .child-table .cell-line--primary,
 .print-format-doc .child-table .cell-line--secondary {
-	color: var(--pf-text);
+	color: var(--gray-900);
 }
 
 .print-format-doc .child-table .cell-line--primary {
@@ -294,7 +287,7 @@
 .print-format-doc .child-table .cell-line--mono-sm,
 .print-format-doc .child-table .cell-line--muted-sm {
 	font-size: 0.85em;
-	color: var(--pf-muted);
+	color: var(--gray-600);
 }
 
 .print-format-doc .page-break {
@@ -354,7 +347,7 @@
 .print-format-doc .document-header {
 	border-bottom-width: 1px;
 	border-bottom-style: solid;
-	border-bottom-color: var(--pf-line);
+	border-bottom-color: var(--gray-300);
 }
 
 .print-format-doc .field[data-fieldtype="Rating"] .rating-star {
@@ -383,7 +376,7 @@
 
 /* ── Table layout (field-borders mode) ───────────────────── */
 .print-format-doc .section--grid {
-	border: 1px solid var(--pf-line);
+	border: 1px solid var(--gray-300);
 	border-radius: var(--border-radius-md, 8px);
 	overflow: hidden;
 	padding: 0;
@@ -391,7 +384,7 @@
 .print-format-doc .section--grid .section-label {
 	padding: var(--pfb-cell-pad, 8px);
 	margin: 0;
-	border-bottom: 1px solid var(--pf-line);
+	border-bottom: 1px solid var(--gray-300);
 }
 .print-format-doc .section--grid .section-columns {
 	padding: 0;
@@ -402,11 +395,11 @@
 	padding: 0;
 }
 .print-format-doc .section--grid .col:not(:last-child) {
-	border-right: 1px solid var(--pf-line);
+	border-right: 1px solid var(--gray-300);
 }
 .print-format-doc .section--grid .field {
 	padding: var(--pfb-cell-pad, 8px);
-	border-bottom: 1px solid var(--pf-line);
+	border-bottom: 1px solid var(--gray-300);
 }
 .print-format-doc .section--grid .field + .field {
 	margin-top: 0;

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -157,13 +157,20 @@
 	word-break: break-word;
 }
 
-/* !important needed: bootstrap print styles set table-bordered cell borders with !important */
+/* Table variants are three independent axes: Style (--lined/--striped/--plain)
+   draws horizontal lines/fills, .table-bordered draws vertical lines + frame,
+   --plain-header restyles the header. The base kills every border with
+   !important (Bootstrap print sets .table-bordered cell borders !important)
+   so each axis opts back in without touching the others. */
 .print-format-doc .child-table .table th {
 	color: #374151;
 	font-weight: 600;
 	font-size: 0.85em;
 	padding: 0.5882em 0.7843em;
 	border: none !important;
+	/* Bootstrap print paints th white !important, which would cover the
+	   thead tr fill; transparent cells let the row background through */
+	background-color: transparent !important;
 }
 
 /* header background lives on the row, not each cell, so a wrapper's border-radius
@@ -174,60 +181,38 @@
 
 .print-format-doc .child-table .table td {
 	padding: 0.5em 0.6667em;
-	border: 1px solid #e5e7eb !important;
+	border: none !important;
+	background-color: #ffffff !important;
 	vertical-align: top;
 }
 
-/* lined (default): no row alternation — target td directly to beat Bootstrap @media print */
-.print-format-doc .child-table--lined .table .odd td,
-.print-format-doc .child-table--lined .table .even td {
-	background-color: #ffffff !important;
+/* lined: a divider under the header and under each row */
+.print-format-doc .child-table--lined .table th,
+.print-format-doc .child-table--lined .table td {
+	border-bottom: 1px solid #e5e7eb !important;
 }
 
-/* striped: alternating rows */
-.print-format-doc .child-table--striped .table .odd td {
-	background-color: #ffffff !important;
-}
-
+/* striped: alternating row fill instead of dividers */
 .print-format-doc .child-table--striped .table .even td {
 	background-color: #f9fafb !important;
 }
 
-/* plain: no borders, bottom dividers only */
-.print-format-doc .child-table--plain .table {
-	border: none;
+/* bordered: column separators + outer frame; adjacent cell borders collapse */
+.print-format-doc .child-table .table-bordered {
+	border: 1px solid #e5e7eb;
 }
 
-/* !important needed: bootstrap print styles set table-bordered cell borders with !important */
-.print-format-doc .child-table--plain .table th,
-.print-format-doc .child-table--plain .table td {
-	border: none !important;
-	border-bottom: 1px solid #e5e7eb !important;
+.print-format-doc .child-table .table-bordered td {
+	border-left: 1px solid #e5e7eb !important;
+	border-right: 1px solid #e5e7eb !important;
 }
 
-.print-format-doc .child-table--plain .table thead tr {
-	background-color: transparent !important;
-}
-
-.print-format-doc .child-table--plain .table .odd td,
-.print-format-doc .child-table--plain .table .even td {
-	background-color: #ffffff !important;
-}
-
-/* borderless variant */
-.print-format-doc .child-table--borderless .table th,
-.print-format-doc .child-table--borderless .table td {
-	border: none !important;
-	border-bottom: 1px solid #e5e7eb !important;
-}
-
-/* plain header variant: no fill, a single rule under the header row instead */
+/* plain header: no fill, a single rule under the header row instead */
 .print-format-doc .child-table--plain-header .table thead tr {
 	background-color: transparent !important;
 }
 
 .print-format-doc .child-table--plain-header .table th {
-	border: none !important;
 	border-bottom: 1px solid #e5e7eb !important;
 }
 

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -4,6 +4,13 @@
 .print-format-doc {
 	-webkit-print-color-adjust: exact;
 	print-color-adjust: exact;
+	--pf-text: #111827;
+	--pf-heading: #374151;
+	--pf-muted: #6b7280;
+	--pf-line: #e5e7eb;
+	--pf-fill: #f3f4f6;
+	--pf-fill-soft: #f9fafb;
+	--pf-paper: #ffffff;
 }
 .print-format-doc .label {
 	border: none;
@@ -36,12 +43,12 @@
 /* Stacked (default): muted label above value */
 .print-format-doc .field .label {
 	font-size: 1em;
-	color: #6b7280;
+	color: var(--pf-muted);
 	margin-bottom: 0.1em;
 }
 
 .print-format-doc .field .value {
-	color: #111827;
+	color: var(--pf-text);
 }
 
 /* Left-right (section-level): label shrinks to content width, value takes the rest */
@@ -56,7 +63,7 @@
 .print-format-doc .field.field-inline .label {
 	flex-shrink: 0;
 	font-size: 1em;
-	color: #374151;
+	color: var(--pf-heading);
 	text-transform: none;
 	letter-spacing: 0;
 	padding-top: 0.05em;
@@ -145,7 +152,7 @@
 .print-format-doc .child-table > .label {
 	font-size: 0.8em;
 	font-weight: 600;
-	color: #6b7280;
+	color: var(--pf-muted);
 	margin-bottom: 0.5em;
 }
 
@@ -163,7 +170,7 @@
    !important (Bootstrap print sets .table-bordered cell borders !important)
    so each axis opts back in without touching the others. */
 .print-format-doc .child-table .table th {
-	color: #374151;
+	color: var(--pf-heading);
 	font-weight: 600;
 	font-size: 0.85em;
 	padding: 0.5882em 0.7843em;
@@ -176,35 +183,35 @@
 /* header background lives on the row, not each cell, so a wrapper's border-radius
    clips one continuous bar instead of fighting per-cell backgrounds at the seams */
 .print-format-doc .child-table .table thead tr {
-	background-color: #f3f4f6 !important;
+	background-color: var(--pf-fill) !important;
 }
 
 .print-format-doc .child-table .table td {
 	padding: 0.5em 0.6667em;
 	border: none !important;
-	background-color: #ffffff !important;
+	background-color: var(--pf-paper) !important;
 	vertical-align: top;
 }
 
 /* lined: a divider under the header and under each row */
 .print-format-doc .child-table--lined .table th,
 .print-format-doc .child-table--lined .table td {
-	border-bottom: 1px solid #e5e7eb !important;
+	border-bottom: 1px solid var(--pf-line) !important;
 }
 
 /* striped: alternating row fill instead of dividers */
 .print-format-doc .child-table--striped .table .even td {
-	background-color: #f9fafb !important;
+	background-color: var(--pf-fill-soft) !important;
 }
 
 /* bordered: column separators + outer frame; adjacent cell borders collapse */
 .print-format-doc .child-table .table-bordered {
-	border: 1px solid #e5e7eb;
+	border: 1px solid var(--pf-line);
 }
 
 .print-format-doc .child-table .table-bordered td {
-	border-left: 1px solid #e5e7eb !important;
-	border-right: 1px solid #e5e7eb !important;
+	border-left: 1px solid var(--pf-line) !important;
+	border-right: 1px solid var(--pf-line) !important;
 }
 
 /* plain header: no fill, a single rule under the header row instead */
@@ -213,7 +220,7 @@
 }
 
 .print-format-doc .child-table--plain-header .table th {
-	border-bottom: 1px solid #e5e7eb !important;
+	border-bottom: 1px solid var(--pf-line) !important;
 }
 
 .print-format-doc .child-table [data-fieldtype="Currency"],
@@ -273,7 +280,7 @@
 
 .print-format-doc .child-table .cell-line--primary,
 .print-format-doc .child-table .cell-line--secondary {
-	color: #111827;
+	color: var(--pf-text);
 }
 
 .print-format-doc .child-table .cell-line--primary {
@@ -287,7 +294,7 @@
 .print-format-doc .child-table .cell-line--mono-sm,
 .print-format-doc .child-table .cell-line--muted-sm {
 	font-size: 0.85em;
-	color: #6b7280;
+	color: var(--pf-muted);
 }
 
 .print-format-doc .page-break {
@@ -347,7 +354,7 @@
 .print-format-doc .document-header {
 	border-bottom-width: 1px;
 	border-bottom-style: solid;
-	border-bottom-color: #e5e7eb;
+	border-bottom-color: var(--pf-line);
 }
 
 .print-format-doc .field[data-fieldtype="Rating"] .rating-star {
@@ -376,7 +383,7 @@
 
 /* ── Table layout (field-borders mode) ───────────────────── */
 .print-format-doc .section--grid {
-	border: 1px solid #e5e7eb;
+	border: 1px solid var(--pf-line);
 	border-radius: var(--border-radius-md, 8px);
 	overflow: hidden;
 	padding: 0;
@@ -384,7 +391,7 @@
 .print-format-doc .section--grid .section-label {
 	padding: var(--pfb-cell-pad, 8px);
 	margin: 0;
-	border-bottom: 1px solid #e5e7eb;
+	border-bottom: 1px solid var(--pf-line);
 }
 .print-format-doc .section--grid .section-columns {
 	padding: 0;
@@ -395,11 +402,11 @@
 	padding: 0;
 }
 .print-format-doc .section--grid .col:not(:last-child) {
-	border-right: 1px solid #e5e7eb;
+	border-right: 1px solid var(--pf-line);
 }
 .print-format-doc .section--grid .field {
 	padding: var(--pfb-cell-pad, 8px);
-	border-bottom: 1px solid #e5e7eb;
+	border-bottom: 1px solid var(--pf-line);
 }
 .print-format-doc .section--grid .field + .field {
 	margin-top: 0;


### PR DESCRIPTION
- decouple child table variants: style now controls only horizontal lines/stripes, bordered only column lines + frame, header only the header row (plain style no longer forces the header transparent)
- header fills (default and custom) now survive chrome pdf/browser print — bootstrap's print stylesheet painted th white over the thead row fill
- inspector: single Style dropdown (Grid / Rows / Striped / None) replaces the Style + Bordered controls; header color shown only for styled headers, border color only when lines are drawn

Before
<img width="274" height="267" alt="Screenshot 2026-07-15 at 10 45 44 PM" src="https://github.com/user-attachments/assets/48981ae3-f6e8-4108-b736-d182d3c2994f" />

After
<img width="284" height="243" alt="Screenshot 2026-07-15 at 10 45 05 PM" src="https://github.com/user-attachments/assets/7eb559d8-3b6c-4480-a12b-d9e0b2d305bf" />

