### PR TITLE
ci: hide eo.po from translation PR review details

### DIFF
--- a/.github/workflows/review-translation-changes.yaml
+++ b/.github/workflows/review-translation-changes.yaml
@@ -23,3 +23,5 @@ jobs:
 
     steps:
       - uses: alyf-de/po-review-action@ffb92a299452595ca50fb1429ee98a7ebacb571e # v1.1.0
+        with:
+          hidden-po-files: eo.po


### PR DESCRIPTION
## Summary
- Hide Crowdin in-context `eo.po` files from `po-review-action` language detail tables via `hidden-po-files`.