### PR TITLE
fix: report why chromium failed to start instead of a blanket timeout

### DIFF
--- a/frappe/utils/chromium/process.py
+++ b/frappe/utils/chromium/process.py
@@ -209,11 +209,15 @@ class ChromiumManager:
 		"""
 		stderr = self._chromium_process.stderr
 		start_time = time.time()
+		output = []
 
 		while time.time() - start_time < self.START_TIMEOUT:
 			# Read a single line from stderr and check if it contains the DevTools URL.
 			# Not using select() because it is not supported on Windows for non-socket file descriptors.
 			line = stderr.readline()
+			if not line:
+				break
+			output.append(line)
 			# not sure if "DevTools listening on" is consistent in all chromium versions.
 			if "DevTools listening on" in line:
 				url_start = line.find("ws://")
@@ -221,9 +225,28 @@ class ChromiumManager:
 					self._devtools_url = line[url_start:].strip()
 					break
 
-		if not self._devtools_url:
+		if self._devtools_url:
+			return
+
+		self._raise_start_failure(output)
+
+	def _raise_start_failure(self, output):
+		"""Report why Chromium never handed us a DevTools URL, quoting its own stderr."""
+		exit_code = self._chromium_process.poll()
+		chromium_output = "".join(output).strip() or "<no output on stderr>"
+
+		if exit_code is None:
 			self._chromium_process.terminate()
-			raise TimeoutError("Chromium took too long to start.")
+			raise TimeoutError(
+				f"Chromium did not report a DevTools URL within {self.START_TIMEOUT}s. "
+				f"Raise `chromium_start_timeout` in site config if this machine is slow.\n"
+				f"Chromium output:\n{chromium_output}"
+			)
+
+		raise RuntimeError(
+			f"Chromium exited with code {exit_code} before reporting a DevTools URL.\n"
+			f"Chromium output:\n{chromium_output}"
+		)
 
 	def _close_browser(self):
 		"""

--- a/frappe/utils/chromium/process.py
+++ b/frappe/utils/chromium/process.py
@@ -231,8 +231,15 @@ class ChromiumManager:
 		self._raise_start_failure(output)
 
 	def _raise_start_failure(self, output):
-		"""Report why Chromium never handed us a DevTools URL, quoting its own stderr."""
-		exit_code = self._chromium_process.poll()
+		"""Report why Chromium never handed us a DevTools URL, quoting its own stderr.
+
+		stderr reaching EOF races the process becoming reapable, so give a dead Chromium
+		a moment to be collected rather than misreporting it as a live one.
+		"""
+		try:
+			exit_code = self._chromium_process.wait(timeout=1)
+		except subprocess.TimeoutExpired:
+			exit_code = None
 		chromium_output = "".join(output).strip() or "<no output on stderr>"
 
 		if exit_code is None:


### PR DESCRIPTION
Every Chromium startup failure currently surfaces as `TimeoutError: Chromium took too long to start.`, and the stderr explaining why is discarded by `terminate()`. A Chromium that starts and dies immediately hits EOF on stderr, then busy-spins until `chromium_start_timeout` (default 3s) elapses and gets reported as slow rather than dead.

This is currently blocking ERPNext CI (`test_request_for_quotation.test_get_pdf`), where the real cause is unknowable from the message alone.

- Break on stderr EOF instead of spinning out the timeout
- Keep the stderr read so far and quote it in the error
- Raise `RuntimeError` with the exit code when Chromium died, `TimeoutError` (naming the `chromium_start_timeout` knob) when it is genuinely slow

Before:
```
TimeoutError: Chromium took too long to start.
```
After:
```
RuntimeError: Chromium exited with code 127 before reporting a DevTools URL.
Chromium output:
FATAL: cannot create sandbox
```

Verified against three subprocesses (crash-with-stderr, alive-but-silent, normal startup), plus a real Chromium render (62KB PDF) to confirm the happy path is untouched.

Note: `stderr.readline()` blocks, so `chromium_start_timeout` still does not bound a Chromium that starts and goes completely silent. That is a pre-existing bug in a separate mechanism and is deliberately left alone here.