### PR TITLE
fix: honour print settings pdf generator for standard printing

### DIFF
--- a/frappe/printing/doctype/print_settings/print_settings.json
+++ b/frappe/printing/doctype/print_settings/print_settings.json
@@ -185,7 +185,8 @@
    "fieldname": "pdf_generator",
    "fieldtype": "Select",
    "label": "PDF Generator",
-   "options": "wkhtmltopdf\nchrome"
+   "options": "wkhtmltopdf\nchrome",
+   "description": "wkhtmltopdf cannot render multi-column layouts and is no longer maintained. Use chrome unless you depend on a wkhtmltopdf-specific print format."
   }
  ],
  "icon": "fa fa-cog",

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -239,9 +239,6 @@ def download_pdf(
 	letterhead: str | None = None,
 	pdf_generator: Literal["wkhtmltopdf", "chrome"] | None = None,
 ):
-	if pdf_generator is None:
-		pdf_generator = "wkhtmltopdf"
-
 	doc = doc or frappe.get_doc(doctype, name)
 	validate_print_permission(doc)
 

--- a/frappe/utils/print_utils.py
+++ b/frappe/utils/print_utils.py
@@ -23,6 +23,24 @@ def _print_format_doc_or_none(print_format: str | None):
 		return None
 
 
+def resolve_pdf_generator(print_format=None, pdf_generator: str | None = None) -> str:
+	"""Pick the PDF engine for a render.
+
+	The beta renderer emits flexbox layouts that only Chromium lays out correctly, so a
+	beta format pins itself to Chrome. Everything else honours an explicit choice, then
+	the format's own setting, then the site default in Print Settings.
+	"""
+	from frappe.printing.doctype.print_format.classic_converter import uses_beta_renderer
+
+	if print_format and uses_beta_renderer(print_format):
+		return "chrome"
+	if pdf_generator:
+		return pdf_generator
+	if print_format and print_format.get("pdf_generator"):
+		return print_format.get("pdf_generator")
+	return frappe.db.get_single_value("Print Settings", "pdf_generator") or "wkhtmltopdf"
+
+
 def get_print(
 	doctype=None,
 	name=None,
@@ -58,18 +76,8 @@ def get_print(
 
 	local = frappe.local
 	if "pdf_generator" not in local.form_dict:
-		from frappe.printing.doctype.print_format.classic_converter import uses_beta_renderer
-
 		pf_doc = _print_format_doc_or_none(print_format)
-		requires_chrome = not pf_doc or uses_beta_renderer(pf_doc)
-
-		if requires_chrome:
-			pdf_generator = "chrome"
-		elif pdf_generator is None:
-			pdf_generator = (
-				frappe.get_cached_value("Print Format", print_format, "pdf_generator") or "wkhtmltopdf"
-			)
-		local.form_dict.pdf_generator = pdf_generator
+		local.form_dict.pdf_generator = resolve_pdf_generator(pf_doc, pdf_generator)
 
 	original_form_dict = copy.deepcopy(local.form_dict)
 	try:
@@ -168,7 +176,9 @@ def attach_print(
 	)
 
 	pf_doc = _print_format_doc_or_none(print_format)
-	render_via_generator = pf_doc is None or uses_beta_renderer(pf_doc)
+	render_via_generator = (pf_doc is None or uses_beta_renderer(pf_doc)) and resolve_pdf_generator(
+		pf_doc
+	) == "chrome"
 
 	try:
 		with print_language(lang or frappe.local.lang):

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -246,13 +246,30 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 
 	def test_get_print_degrades_for_deleted_format(self):
 		"""A print_format name that no longer exists must not raise DoesNotExistError
-		during pdf_generator resolution — it degrades to the Standard (chrome) render,
-		so notifications referencing a removed format still send."""
+		during pdf_generator resolution — it degrades to the Standard render, so
+		notifications referencing a removed format still send."""
 		from frappe.utils.print_utils import _print_format_doc_or_none
 
 		self.assertIsNone(_print_format_doc_or_none("_No Such Format ZZZ"))
 		self.assertIsNone(_print_format_doc_or_none("Standard"))
 		self.assertIsNone(_print_format_doc_or_none(None))
+
+	def test_standard_print_follows_print_settings_pdf_generator(self):
+		"""Standard (no print format) must honour Print Settings, while a beta format
+		stays pinned to chrome — wkhtmltopdf cannot lay out its flexbox columns."""
+		from frappe.utils.print_utils import resolve_pdf_generator
+
+		beta = self._make_print_format()
+		original = frappe.db.get_single_value("Print Settings", "pdf_generator")
+		self.addCleanup(frappe.db.set_single_value, "Print Settings", "pdf_generator", original)
+
+		for setting in ("wkhtmltopdf", "chrome"):
+			frappe.db.set_single_value("Print Settings", "pdf_generator", setting)
+			self.assertEqual(resolve_pdf_generator(None), setting)
+			self.assertEqual(resolve_pdf_generator(beta), "chrome")
+
+		frappe.db.set_single_value("Print Settings", "pdf_generator", "wkhtmltopdf")
+		self.assertEqual(resolve_pdf_generator(None, "chrome"), "chrome")
 
 	# ------------------------------------------------------------------ #
 	# printpreview: Standard (no format selected) renders the beta default


### PR DESCRIPTION
Standard printing (no print format selected) forced `chrome`, ignoring `Print Settings > PDF Generator`. That field was never read anywhere — the only reference was its type stub — and `get_print` fell back to a hardcoded `"wkhtmltopdf"` instead.

Forcing chrome also made Chromium a hard dependency of the most common print path. It is what currently breaks ERPNext CI (`test_request_for_quotation.test_get_pdf`), where Chromium cannot start.

- Resolve the engine in one place (`resolve_pdf_generator`): explicit argument, then the format's own `pdf_generator`, then `Print Settings`, defaulting to wkhtmltopdf
- Standard printing now follows `Print Settings > PDF Generator`
- `download_pdf` no longer collapses `pdf_generator=None` to `"wkhtmltopdf"` before `get_print` can resolve it
- `attach_print` only takes the chrome-only generator path when the resolved engine is chrome
- Beta formats stay pinned to chrome (`before_save` already forces it)

Known trade-off: wkhtmltopdf (QtWebKit) has no modern flexbox, so the beta layout's multi-column sections render as a single column there. Verified by rendering the same Standard HTML through both engines — chrome produced 4 rows with side-by-side field columns (`First Name` | `Status`), wkhtmltopdf produced none, and only the child `<table>` survived as two-column. The Print Settings field now carries a description recommending chrome.