### PR TITLE
perf: import only the bootstrap parts print formats use

### DIFF
--- a/frappe/public/scss/print_format.bundle.scss
+++ b/frappe/public/scss/print_format.bundle.scss
@@ -2,4 +2,16 @@
 @import "./common/mixins.scss";
 @import "./common/global.scss";
 @import "./common/icons.scss";
-@import "~bootstrap/scss/bootstrap";
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins";
+@import "~bootstrap/scss/root";
+@import "~bootstrap/scss/reboot";
+@import "~bootstrap/scss/type";
+@import "~bootstrap/scss/grid";
+@import "~bootstrap/scss/tables";
+@import "~bootstrap/scss/print";
+@import "~bootstrap/scss/utilities/display";
+@import "~bootstrap/scss/utilities/text";
+@import "~bootstrap/scss/utilities/align";
+@import "~bootstrap/scss/utilities/spacing";


### PR DESCRIPTION
The print format bundle imports all of Bootstrap, most of which print formats never use. Importing only the parts that are actually referenced takes the built stylesheet from **303K to 177K (42% smaller)** with no rendering change.

Kept: `reboot` and `type` (both load-bearing — dropping `type` alone moved ~2% of pixels), `grid`, `tables`, `print`, and the display/text/align/spacing utilities. `~bootstrap/scss/print` in particular must stay: `print_format_doc.css` is written against it (`th { background-color: transparent !important }` only works because Bootstrap paints table cells white in `@media print`).

Verified by rendering PDFs via Chromium and comparing pixels against the full-bundle baseline on current develop:

| Case | Result |
| --- | --- |
| Control (same CSS rendered twice) | `0/501832` — confirms the method |
| Purchase Receipt Serial and Batch Bundle Print (app-shipped, uses `table-bordered` + `text-right`) | `0/501832` (0.0000%) |
| Contact (child table) | `0/501832` |
| Contact + letter head (uses `.container`) | `0/501832` |
| User (3 pages) | `0/1505496` |
| ToDo | `0/501832` |

The class set was chosen from what app-shipped beta formats and letter heads actually reference, not guessed: an audit of every beta format's custom HTML and every Letter Head turned up `row`, `container`, `table-bordered`, and the `text-*` utilities. `global.scss` also `@extend`s `.d-none`, hence the display utilities.

Note: `col-xs-*` is unaffected — Bootstrap 4 has no such tier before or after this change.

Caveat for review: only the print surface was verified. `print_format.bundle.css` is also referenced by `microtemplate.js`, so a consumer there could rely on a part these renders do not exercise.