### PR TITLE
fix: guard against missing old_doc in validate_snapshot_reports

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -220,6 +220,8 @@ class SystemSettings(Document):
 
 	def validate_snapshot_reports(self):
 		old_doc = self.get_doc_before_save()
+		if not old_doc:
+			return
 		if (old_doc.enable_snapshot_reports != self.enable_snapshot_reports) or (
 			old_doc.frequency != self.frequency
 		):


### PR DESCRIPTION
Fixes AttributeError when System Settings is inserted fresh (e.g. via fixture import) with no prior doc to compare against.

https://support.frappe.io/helpdesk/tickets/73880?view=VIEW-HD+Ticket-1547