### PR TITLE
fix: set database session time zone from system settings on connect

### DIFF
--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -229,6 +229,9 @@ class TestRQJob(IntegrationTestCase):
 		# TODO: Observed higher usage on 2026-05-26. Temporarily raising the limit
 		LAST_MEASURED_USAGE += 1
 
+		# Setting session time zone on connect loads System Settings in the worker
+		LAST_MEASURED_USAGE += 3
+
 		self.assertLessEqual(rss, LAST_MEASURED_USAGE * 1.05, msg)
 
 	def test_clear_failed_jobs(self):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -39,6 +39,7 @@ from frappe.utils import (
 	CallbackManager,
 	cint,
 	get_datetime,
+	get_system_timezone,
 	get_table_name,
 	getdate,
 	now,
@@ -154,9 +155,18 @@ class Database:
 		except Exception as e:
 			self.logger.warning(f"Couldn't set execution timeout {e}")
 
+		try:
+			self.set_session_time_zone(get_system_timezone())
+		except Exception as e:
+			self.logger.warning(f"Couldn't set session time zone {e}")
+
 	def set_execution_timeout(self, seconds: int):
 		"""Set session speicifc timeout on exeuction of statements.
 		If any statement takes more time it will be killed along with entire transaction."""
+		raise NotImplementedError
+
+	def set_session_time_zone(self, timezone: str):
+		"""Set session time zone so database clock functions match the system timezone."""
 		raise NotImplementedError
 
 	def use(self, db_name):

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -7,7 +7,7 @@ from pymysql.converters import conversions, escape_string
 import frappe
 from frappe.database.database import Database
 from frappe.database.mariadb.schema import MariaDBTable
-from frappe.utils import UnicodeWithAttrs, cstr, get_datetime, get_table_name
+from frappe.utils import UnicodeWithAttrs, cstr, get_datetime, get_table_name, get_timezone_utc_offset
 
 
 class MariaDBExceptionUtil:
@@ -122,6 +122,12 @@ class MariaDBConnectionUtil:
 
 	def set_execution_timeout(self, seconds: int):
 		self.sql("set session max_statement_time = %s", int(seconds))
+
+	def set_session_time_zone(self, timezone: str):
+		try:
+			self.sql("set session time_zone = %s", timezone)
+		except pymysql.OperationalError:
+			self.sql("set session time_zone = %s", get_timezone_utc_offset(timezone))
 
 	def get_connection_settings(self) -> dict:
 		conn_settings = {

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -9,7 +9,7 @@ from MySQLdb.converters import conversions
 import frappe
 from frappe.database.database import Database
 from frappe.database.mariadb.schema import MariaDBTable
-from frappe.utils import get_datetime, get_table_name
+from frappe.utils import get_datetime, get_table_name, get_timezone_utc_offset
 
 ER_STATEMENT_TIMEOUT = 1969
 
@@ -124,6 +124,12 @@ class MariaDBConnectionUtil:
 
 	def set_execution_timeout(self, seconds: int):
 		self.sql("set session max_statement_time = %s", int(seconds))
+
+	def set_session_time_zone(self, timezone: str):
+		try:
+			self.sql("set session time_zone = %s", timezone)
+		except MySQLdb.OperationalError:
+			self.sql("set session time_zone = %s", get_timezone_utc_offset(timezone))
 
 	def get_connection_settings(self) -> dict:
 		conn_settings = {

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -272,6 +272,9 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		# Postgres expects milliseconds as input
 		self.sql("set local statement_timeout = %s", int(seconds) * 1000)
 
+	def set_session_time_zone(self, timezone: str):
+		self.sql("set time zone %s", timezone)
+
 	def escape(self, s, percent=True):
 		"""Escape quotes and percent in given string."""
 		if isinstance(s, bytes):

--- a/frappe/database/sqlite/database.py
+++ b/frappe/database/sqlite/database.py
@@ -148,6 +148,9 @@ class SQLiteDatabase(SQLiteExceptionUtil, Database):
 	def set_execution_timeout(self, seconds: int):
 		self.sql(f"PRAGMA busy_timeout = {int(seconds) * 1000}")
 
+	def set_session_time_zone(self, timezone: str):
+		pass
+
 	def setup_type_map(self):
 		self.db_type = "sqlite"
 		self.type_map = {

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -5,11 +5,12 @@ import datetime
 from math import ceil
 from random import choice
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import frappe
 from frappe.core.utils import find
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
-from frappe.database import savepoint
+from frappe.database import get_db, savepoint
 from frappe.database.database import get_query_execution_timeout
 from frappe.database.utils import FallBackDateTimeStr
 from frappe.query_builder import Field
@@ -761,6 +762,25 @@ class TestDB(IntegrationTestCase):
 
 	def test_db_explain(self):
 		frappe.db.sql("select 1", debug=1, explain=1)
+
+	@unimplemented_for(db_type_is.SQLITE)
+	def test_session_time_zone_follows_system_timezone(self):
+		with patch("frappe.database.database.get_system_timezone", return_value="America/New_York"):
+			db = get_db(
+				socket=frappe.db.socket,
+				host=frappe.db.host,
+				user=frappe.db.user,
+				password=frappe.db.password,
+				port=frappe.db.port,
+				cur_db_name=frappe.db.cur_db_name,
+			)
+			try:
+				db_now = db.sql("select LOCALTIMESTAMP")[0][0]
+			finally:
+				db.close()
+
+		expected = datetime.datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)
+		self.assertLess(abs((expected - db_now).total_seconds()), 10)
 
 
 @run_only_if(db_type_is.MARIADB)

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -782,6 +782,33 @@ class TestDB(IntegrationTestCase):
 		expected = datetime.datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)
 		self.assertLess(abs((expected - db_now).total_seconds()), 10)
 
+	@run_only_if(db_type_is.MARIADB)
+	def test_session_time_zone_falls_back_to_utc_offset(self):
+		with patch.object(
+			frappe.db.__class__, "sql", side_effect=[frappe.db.OperationalError, None]
+		) as mocked_sql:
+			frappe.db.set_session_time_zone("Asia/Kolkata")
+
+		mocked_sql.assert_called_with("set session time_zone = %s", "+05:30")
+
+	@unimplemented_for(db_type_is.SQLITE)
+	def test_connect_survives_session_time_zone_failure(self):
+		with patch(
+			"frappe.database.database.get_system_timezone", side_effect=Exception("timezone unavailable")
+		):
+			db = get_db(
+				socket=frappe.db.socket,
+				host=frappe.db.host,
+				user=frappe.db.user,
+				password=frappe.db.password,
+				port=frappe.db.port,
+				cur_db_name=frappe.db.cur_db_name,
+			)
+			try:
+				self.assertEqual(db.sql("select 1")[0][0], 1)
+			finally:
+				db.close()
+
 
 @run_only_if(db_type_is.MARIADB)
 class TestDDLCommandsMaria(IntegrationTestCase):

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -784,12 +784,14 @@ class TestDB(IntegrationTestCase):
 
 	@run_only_if(db_type_is.MARIADB)
 	def test_session_time_zone_falls_back_to_utc_offset(self):
-		with patch.object(
-			frappe.db.__class__, "sql", side_effect=[frappe.db.OperationalError, None]
-		) as mocked_sql:
-			frappe.db.set_session_time_zone("Asia/Kolkata")
+		from frappe.database.mariadb.database import MariaDBDatabase
+		from frappe.database.mariadb.mysqlclient import MariaDBDatabase as MySQLClientDatabase
 
-		mocked_sql.assert_called_with("set session time_zone = %s", "+05:30")
+		for db_class in (MariaDBDatabase, MySQLClientDatabase):
+			with patch.object(db_class, "sql", side_effect=[db_class.OperationalError, None]) as mocked_sql:
+				db_class(cur_db_name=frappe.db.cur_db_name).set_session_time_zone("Asia/Kolkata")
+
+			mocked_sql.assert_called_with("set session time_zone = %s", "+05:30")
 
 	@unimplemented_for(db_type_is.SQLITE)
 	def test_connect_survives_session_time_zone_failure(self):

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -241,7 +241,7 @@ class TestOverheadCalls(FrappeAPITestCase):
 	Every call increase here is an actual increase in cost!
 	"""
 
-	BASE_SQL_CALLS = 2  # rollback + begin
+	BASE_SQL_CALLS = 3  # rollback + begin + session time zone on connect
 
 	def test_ping_overheads(self):
 		self.get(self.method("ping"), {"sid": "Guest"})

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -875,6 +875,11 @@ class TestDateUtils(IntegrationTestCase):
 		self.assertEqual(frappe.utils.is_last_day_of_the_month("2020-12-24"), False)
 		self.assertEqual(frappe.utils.is_last_day_of_the_month("2020-12-31"), True)
 
+	def test_get_timezone_utc_offset(self):
+		self.assertEqual(frappe.utils.data.get_timezone_utc_offset("UTC"), "+00:00")
+		self.assertEqual(frappe.utils.data.get_timezone_utc_offset("Asia/Kolkata"), "+05:30")
+		self.assertEqual(frappe.utils.data.get_timezone_utc_offset("Pacific/Marquesas"), "-09:30")
+
 	def test_get_time(self):
 		datetime_input = now_datetime()
 		timedelta_input = get_timedelta()

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -390,6 +390,14 @@ def get_system_timezone() -> str:
 	return frappe.get_system_settings("time_zone") or "Asia/Kolkata"  # Default to India ?!
 
 
+def get_timezone_utc_offset(timezone: str) -> str:
+	"""Return the current UTC offset of the given timezone in ±HH:MM format."""
+	offset_seconds = int(datetime.datetime.now(ZoneInfo(timezone)).utcoffset().total_seconds())
+	sign = "+" if offset_seconds >= 0 else "-"
+	hours, minutes = divmod(abs(offset_seconds) // 60, 60)
+	return f"{sign}{hours:02d}:{minutes:02d}"
+
+
 def convert_utc_to_timezone(utc_timestamp: datetime.datetime, time_zone: str) -> datetime.datetime:
 	if utc_timestamp.tzinfo is None:
 		utc_timestamp = utc_timestamp.replace(tzinfo=ZoneInfo("UTC"))


### PR DESCRIPTION
## Summary

Framework-generated timestamps (`creation`, `modified`, and anything using `now_datetime()`) use the **System Settings** `time_zone`, but the database session timezone was never configured. As a result, raw SQL using the database clock (`NOW()`, Query Builder `NOW()`) executed in the server's default timezone, causing comparisons against framework-generated timestamps to be incorrect when the two timezones differed.

Issue #40858 addressed specific occurrences of this problem. This PR fixes the root cause by configuring the database session timezone from **System Settings** in `Database.connect()`, ensuring consistent behavior across all database connections, including reconnects and read replicas.

## Implementation

- Sets the database session timezone during `Database.connect()`.
- Applies to all new connections, reconnects, and read replicas.
- MariaDB:
  - Uses the configured named timezone when supported.
  - Falls back to the timezone's current UTC offset if MySQL timezone tables are not loaded (a common configuration).
- PostgreSQL:
  - Uses the named timezone directly.
- SQLite:
  - No-op, as SQLite has no session clock timezone.
- Follows a best-effort approach similar to `set_execution_timeout()`:
  - If `System Settings` cannot be read yet or the configured timezone is invalid, a warning is logged and the previous behavior is preserved.

## Impact

On sites where the framework timezone and database session timezone previously differed:

- Raw SQL using `NOW()` or Query Builder `NOW()` will now align with framework-generated timestamps.
- Custom SQL that manually compensated for the timezone difference may need to be updated.
- On MariaDB, `TIMESTAMP` columns are converted using the session timezone. Frappe core primarily uses `DATETIME(6)`, so core behavior is unaffected, but custom applications using `TIMESTAMP` columns may observe shifted reads.

Closes #39065.