### PR TITLE
fix: field inspector label and align/spacing conflict in print format builder

### DIFF
--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -326,6 +326,72 @@ context("Print Format Builder — create flow", () => {
 		cy.get(".pfb-inspector .pfb-rep-col-color .selected-color").should("exist");
 		cy.get(".pfb-inspector .pfb-col-width-input").should("exist");
 	});
+
+	// 10. Inspector header shows the doctype field's label, not a custom print label
+	it("field inspector header keeps the doctype label after a custom rename", () => {
+		cy.visit("/app");
+
+		insert_builder_format(PF_NAME, [
+			{
+				label: "Details",
+				columns: [
+					{
+						label: "",
+						fields: [{ fieldtype: "Date", fieldname: "date", label: "Deadline" }],
+					},
+				],
+			},
+		]);
+
+		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
+
+		cy.get("[data-pfb-section]", { timeout: 30000 }).should("be.visible");
+		cy.contains("[data-pfb-section]", "Details").find(".field").first().click({ force: true });
+
+		cy.get(".pfb-inspector").should("contain", "Due Date");
+		cy.get(".pfb-inspector").should("not.contain", "Deadline");
+		cy.contains(".pfb-insp-row", "Label")
+			.find("input.pfb-insp-input")
+			.should("have.value", "Deadline");
+	});
+
+	// 11. Center/right align wins over a stale Spacing value, and the now-irrelevant
+	// Spacing control is hidden instead of silently conflicting with it
+	it("field align overrides a conflicting label-justify setting", () => {
+		cy.visit("/app");
+
+		insert_builder_format(PF_NAME, [
+			{
+				label: "Details",
+				field_orientation: "left-right",
+				columns: [
+					{
+						label: "",
+						fields: [
+							{
+								fieldtype: "Date",
+								fieldname: "date",
+								label: "Due Date",
+								align: "center",
+								label_justify: "space-between",
+							},
+						],
+					},
+				],
+			},
+		]);
+
+		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
+
+		cy.get("[data-pfb-section]", { timeout: 30000 }).should("be.visible");
+		cy.contains("[data-pfb-section]", "Details")
+			.find(".field.left-right")
+			.as("field")
+			.click({ force: true });
+
+		cy.get("@field").should("have.css", "justify-content", "center");
+		cy.get(".pfb-inspector").should("not.contain", "Spacing");
+	});
 });
 
 // ─── Setup flow ───────────────────────────────────────────────────────────────

--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -360,6 +360,10 @@ context("Print Format Builder — create flow", () => {
 	it("field align overrides a conflicting label-justify setting", () => {
 		cy.visit("/app");
 
+		// the left-right/align classes only render in live preview mode, so
+		// the doctype needs at least one record to auto-preview
+		cy.insert_doc("ToDo", { description: "pfb align override preview" }, true);
+
 		insert_builder_format(PF_NAME, [
 			{
 				label: "Details",

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -553,7 +553,9 @@ const preview_root = computed(() => {
 			lr ? "left-right" : "",
 			!lr && df.show_label === "inline" ? "field-inline" : "",
 			df.align ? `field-align-${df.align}` : "",
-			lr && df.label_justify ? `field-justify-${df.label_justify}` : "",
+			lr && df.label_justify && !["center", "right"].includes(df.align)
+				? `field-justify-${df.label_justify}`
+				: "",
 		],
 		style: { ...style, ...custom },
 	};

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -86,7 +86,7 @@ import TableFieldInspector from "./TableFieldInspector.vue";
 import FieldPropertiesPanel from "./FieldPropertiesPanel.vue";
 
 let store = inject("$store");
-let { letterhead, layout } = useStore();
+let { letterhead, layout, print_format } = useStore();
 
 let selected_field = computed(() => store.selected_field.value);
 let selected_section = computed(() => store.selected_section.value);
@@ -110,7 +110,11 @@ let inspector_kind = computed(() => {
 let inspector_subtitle = computed(() => {
 	if (selected_lh_footer.value) return __("Footer");
 	if (selected_letterhead.value) return letterhead.value?.name || "";
-	if (selected_field.value) return selected_field.value.label || selected_field.value.fieldname;
+	if (selected_field.value) {
+		const df = selected_field.value;
+		if (df.custom) return df.label || df.fieldname;
+		return frappe.meta.get_label(print_format.value.doc_type, df.fieldname);
+	}
 	if (selected_section.value) return selected_section.value.label || __("Untitled section");
 	return "";
 });

--- a/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldPropertiesPanel.vue
@@ -119,7 +119,7 @@
 					:options="align_opts"
 					@update:model-value="(v) => (selected_field.align = v)"
 				/>
-				<div class="pfb-insp-row" v-if="fieldIsInline">
+				<div class="pfb-insp-row" v-if="fieldIsInline && current_align === 'left'">
 					<span class="pfb-insp-label">{{ __("Spacing") }}</span>
 					<select
 						class="pfb-insp-select"

--- a/frappe/templates/print_format/macros/Data.html
+++ b/frappe/templates/print_format/macros/Data.html
@@ -7,7 +7,7 @@
 {%- set _fstyle = (('gap: ' + df.label_gap|int|string + 'px;') if (_inline and df.label_gap is defined and df.label_gap is not none) else '') + (df.custom_style or '') -%}
 {%- set _lbl_style = ('color:' + df.label_color + ';') if df.label_color else '' -%}
 {%- set _val_style = ('color:' + df.value_color + ';') if df.value_color else '' -%}
-<div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' %} field-justify-{{ _justify }}{% endif %}" {% if _fstyle %}style="{{ _fstyle|e }}"{% endif %} {{ field_attributes(df) }}>
+<div class="field {{ _orientation }}{% if _inline and _orientation != 'left-right' %} field-inline{% endif %}{% if _align %} field-align-{{ _align }}{% endif %}{% if _justify and _orientation == 'left-right' and _align not in ('center', 'right') %} field-justify-{{ _justify }}{% endif %}" {% if _fstyle %}style="{{ _fstyle|e }}"{% endif %} {{ field_attributes(df) }}>
 	{%- block label -%}
 	{%- if _show_label != 'hide' -%}
 	<div class="label"{% if _lbl_style %} style="{{ _lbl_style|e }}"{% endif %}>{{ _(df.label) }}</div>


### PR DESCRIPTION
- inspector header now shows the field's real doctype label (via `frappe.meta.get_label`) instead of the custom print label, so renaming a field's print label no longer hides which document field you're editing
- "Align: Center/Right" and "Spacing: Space Between/Evenly" both drove the same `justify-content`, so Spacing silently overrode Align; Spacing is now only shown for Align: Left, and stale conflicting data resolves in Align's favor on both the canvas and print/PDF output