### PR TITLE
fix(backup): Fail loudly if incorrect doctype is passed in backup cli as include or exclude option

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -939,9 +939,10 @@ def backup(
 				old_backup_metadata=old_backup_metadata,
 				rollback_callback=rollback_callback,
 			)
-		except Exception:
+		except Exception as e:
+			error_msg = str(e).strip() or "Database or site_config.json may be corrupted"
 			click.secho(
-				f"Backup failed for Site {site}. Database or site_config.json may be corrupted",
+				f"Backup failed for Site {site}: {error_msg}",
 				fg="red",
 			)
 			if rollback_callback:

--- a/frappe/commands/test_commands.py
+++ b/frappe/commands/test_commands.py
@@ -697,6 +697,21 @@ class TestBackups(BaseTestCommands):
 		self.assertIn("successfully completed", self.stdout)
 		self.assertNotEqual(before_backup["database"], after_backup["database"])
 
+	def test_backup_fails_on_unknown_include_doctype(self):
+		"""Regression: --include with an unknown doctype must abort, not
+		silently take a full backup (which would be filed as if it were the
+		requested partial subset)."""
+		self.execute("bench --site {site} backup --include NonExistentDoctypeXYZ")
+		self.assertEqual(self.returncode, 1)
+		self.assertIn("NonExistentDoctypeXYZ", self.stderr + self.stdout)
+
+	def test_backup_fails_on_unknown_exclude_doctype(self):
+		"""Regression: --exclude with an unknown doctype must abort — same
+		silent-full-backup class of bug as --include."""
+		self.execute("bench --site {site} backup --exclude NonExistentDoctypeXYZ")
+		self.assertEqual(self.returncode, 1)
+		self.assertIn("NonExistentDoctypeXYZ", self.stderr + self.stdout)
+
 	@skipIf(
 		not (frappe.conf.db_type == "mariadb"),
 		"Only for MariaDB",

--- a/frappe/desk/desk_views.py
+++ b/frappe/desk/desk_views.py
@@ -230,15 +230,21 @@ class DeskViews:
 
 			reports = frappe.get_list(
 				"Report",
-				fields=["name", "report_type"],
+				fields=["name", "report_type", "ref_doctype"],
 				filters={"name": ("in", has_role.keys())},
 				ignore_ifnull=True,
 				user=user,
 			)
+			permitted_names = set()
 			for report in reports:
+				if report.ref_doctype and not has_permission(
+					report.ref_doctype, "report", user=user, print_logs=False
+				):
+					continue
 				has_role[report.name]["report_type"] = report.report_type
+				permitted_names.add(report.name)
 
-			non_permitted_reports = set(has_role.keys()) - {r.name for r in reports}
+			non_permitted_reports = set(has_role.keys()) - permitted_names
 			for r in non_permitted_reports:
 				has_role.pop(r, None)
 

--- a/frappe/desk/doctype/route_history/route_history.py
+++ b/frappe/desk/doctype/route_history/route_history.py
@@ -48,11 +48,42 @@ def deferred_insert(routes: str | list[dict[str, Any]]):
 
 @frappe.whitelist()
 def frequently_visited_links():
-	return frappe.get_all(
+	from frappe.desk.desk_views import DeskViews
+
+	# Fetch a larger candidate set since some entries may be filtered out
+	candidates = frappe.get_all(
 		"Route History",
 		fields=["route", {"COUNT": "name", "as": "count"}],
 		filters={"user": frappe.session.user},
 		group_by="route",
 		order_by="count desc",
-		limit=5,
+		limit=25,
 	)
+
+	allowed_report_names = set(DeskViews.get_allowed_reports(cache=True).keys())
+	result = []
+	for link in candidates:
+		if _is_permitted_link(link["route"], allowed_report_names):
+			result.append(link)
+		if len(result) == 5:
+			break
+	return result
+
+
+def _is_permitted_link(route: str, allowed_report_names: set) -> bool:
+	"""Filter Route History entries by report accessibility.
+
+	Route History persists routes forever. When the user loses permission on
+	the underlying report/doctype, the route stays in the table and would
+	otherwise resurface as a "frequently visited" suggestion. Non-report
+	routes (Form/List/etc.) pass through — their permissions are enforced
+	when the route is followed.
+	"""
+	parts = route.split("/")
+	# Query Report: "query-report/<name>"
+	if len(parts) >= 2 and parts[0] == "query-report":
+		return parts[1] in allowed_report_names
+	# Report Builder: "List/<doctype>/Report/<name>"
+	if len(parts) >= 4 and parts[0] == "List" and parts[2] == "Report":
+		return parts[3] in allowed_report_names
+	return True

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -531,14 +531,31 @@ download only after 24 hours."""
 
 
 def _get_tables(doctypes: list[str], existing_tables: list[str]) -> list[str]:
-	"""Return a list of tables for the given doctypes that exist in the database."""
+	"""Return tables for the existing doctypes. Raises if any non-empty input
+	doctype doesn't resolve to an existing table.
+	"""
 	tables = []
+	missing = []
 	for doctype in doctypes:
+		doctype = (doctype or "").strip()
 		if not doctype:
 			continue
 		table = frappe.utils.get_table_name(doctype)
 		if table in existing_tables:
 			tables.append(table)
+		else:
+			missing.append(doctype)
+
+	if missing:
+		frappe.throw(
+			_(
+				"Backup requested for unknown DocType(s): {0}. "
+				"Check for typos or use the exact DocType name (case-sensitive). "
+				"Aborting to avoid taking a full backup instead of the requested subset."
+			).format(", ".join(missing)),
+			exc=frappe.ValidationError,
+		)
+
 	return tables
 
 


### PR DESCRIPTION
Invalid input doctype names with typos/wrongcase passed during backup is failed loudly with appropriate error messages