### PR TITLE
fix(list): scope .progress height override to list results

### DIFF
--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -377,8 +377,14 @@ $level-margin-right: 8px;
 	}
 }
 
-.progress {
+.result .progress {
 	height: 10px;
+}
+
+// The list header row never renders a progress bar; guard against the
+// generic list .progress height override above leaking into it
+.list-row-head .progress {
+	height: auto;
 }
 
 .list-liked-by-me {


### PR DESCRIPTION
## Problem
`.progress { height: 10px; }` in `list.scss` is unscoped, so it applies to every `.progress` element on any page — not just the Percent-fieldtype bars rendered in list view rows. This leaks into unrelated components that reuse Bootstrap's `.progress` class (password strength meter, background task notifications, form dashboard charts, etc.), forcing them all to a 10px height regardless of their own intended sizing.

## Fix
Scope the rule to `.result .progress` (the list results container) instead of the bare `.progress` selector, and explicitly guard `.list-row-head .progress` since the list header row never renders a progress bar.

## Test plan
- [x] Added a "% Progress" column to the Task list view and confirmed the data-row progress bar still renders correctly at 10px height
- [x] Confirmed the header row is unaffected
- [x] Verified other `.progress` usages (password strength meter, background task notifications) are no longer forced to 10px