### PR TITLE
fix: check image before trying to load in print

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -153,7 +153,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 	{% elif df.fieldtype=="Signature" %}
 		<img src="{{ doc[df.fieldname] }}" class="signature-img img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
-	{% elif df.fieldtype in ("Attach", "Attach Image") %}
+	{% elif df.fieldtype in ("Attach", "Attach Image") and frappe.utils.is_image(doc[df.fieldname]) %}
 		<img src="{{ doc[df.fieldname] }}" class="img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
 	{% elif df.fieldtype=="HTML" %}


### PR DESCRIPTION
## What changed

Backports the image validation from #27041 for `Attach` fields rendered by Format Builder print formats.

## Why

A blank Stock Entry Detail `image` field was rendered as an image URL, causing `wkhtmltopdf` to fail with `ContentNotFoundError`.

## Validation

- Cherry-picked the exact one-line change from 82a86fd046.
- Verified the hotfix diff contains only that change.