### PR TITLE
feat(database): distinguish serialization conflicts from deadlocks

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -278,6 +278,10 @@ class Database:
 			if self.is_syntax_error(e):
 				frappe.log(f"Syntax error in query:\n{query} {values or ''}")
 
+			elif self.is_transaction_conflict(e):
+				self.db_type == "mariadb" and frappe.log_error("Transaction conflict", defer_insert=True)
+				raise frappe.TransactionConflictError(e) from e
+
 			elif self.is_deadlocked(e):
 				self.db_type == "mariadb" and frappe.log_error("Query deadlocked", defer_insert=True)
 				raise frappe.QueryDeadlockError(e) from e

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -29,6 +29,10 @@ class MariaDBExceptionUtil:
 		return e.args and e.args[0] in (ER.LOCK_DEADLOCK, ER.CHECKREAD)
 
 	@staticmethod
+	def is_transaction_conflict(e: pymysql.Error) -> bool:
+		return e.args and e.args[0] == ER.CHECKREAD
+
+	@staticmethod
 	def is_timedout(e: pymysql.Error) -> bool:
 		return e.args and e.args[0] == ER.LOCK_WAIT_TIMEOUT
 

--- a/frappe/database/mariadb/mysqlclient.py
+++ b/frappe/database/mariadb/mysqlclient.py
@@ -32,6 +32,10 @@ class MariaDBExceptionUtil:
 		return e.args and e.args[0] in (ER.LOCK_DEADLOCK, ER.CHECKREAD)
 
 	@staticmethod
+	def is_transaction_conflict(e: MySQLdb.Error) -> bool:
+		return e.args and e.args[0] == ER.CHECKREAD
+
+	@staticmethod
 	def is_timedout(e: MySQLdb.Error) -> bool:
 		return e.args and e.args[0] == ER.LOCK_WAIT_TIMEOUT
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -103,6 +103,10 @@ class PostgresExceptionUtil:
 		return getattr(e, "pgcode", None) in (DEADLOCK_DETECTED, SERIALIZATION_FAILURE)
 
 	@staticmethod
+	def is_transaction_conflict(e) -> bool:
+		return getattr(e, "pgcode", None) == SERIALIZATION_FAILURE
+
+	@staticmethod
 	def is_timedout(e):
 		# http://initd.org/psycopg/docs/extensions.html?highlight=datatype#psycopg2.extensions.QueryCanceledError
 		return isinstance(e, (psycopg2.extensions.QueryCanceledError | LockNotAvailable))

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -262,6 +262,13 @@ class QueryDeadlockError(Exception):
 	http_status_code = 508
 
 
+class TransactionConflictError(QueryDeadlockError):
+	# Not a true deadlock: the transaction lost a snapshot conflict (SERIALIZATION_FAILURE
+	# on postgres, ER_CHECKREAD on mariadb) and was rolled back. Subclassed so existing
+	# deadlock handling (508, retries) applies; catch this to tell the two apart.
+	pass
+
+
 class InReadOnlyMode(ValidationError):
 	http_status_code = 503  # temporarily not available
 	skip_error_log = True

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -1224,6 +1224,21 @@ class TestDDLCommandsPost(IntegrationTestCase):
 
 @run_only_if(db_type_is.POSTGRES)
 class TestTransactionManagement(IntegrationTestCase):
+	def test_transaction_conflict_classification(self):
+		conflict, deadlock = Exception(), Exception()
+		if frappe.db.db_type == "postgres":
+			conflict.pgcode = "40001"
+			deadlock.pgcode = "40P01"
+		else:
+			conflict.args = (1020, "Record has changed since last read")
+			deadlock.args = (1213, "Deadlock found")
+
+		self.assertTrue(frappe.db.is_transaction_conflict(conflict))
+		self.assertTrue(frappe.db.is_deadlocked(conflict))
+		self.assertFalse(frappe.db.is_transaction_conflict(deadlock))
+		self.assertTrue(frappe.db.is_deadlocked(deadlock))
+		self.assertTrue(issubclass(frappe.TransactionConflictError, frappe.QueryDeadlockError))
+
 	def test_create_proper_transactions(self):
 		def _get_transaction_id():
 			return frappe.db.sql("select txid_current()", pluck=True)


### PR DESCRIPTION
`sql()` raised SERIALIZATION_FAILURE (postgres) and ER_CHECKREAD (mariadb) as `QueryDeadlockError`. They are snapshot conflicts, not lock-order deadlocks — same retriability, different cause — and handlers and monitoring could not tell them apart.

New `TransactionConflictError` subclasses `QueryDeadlockError`, so the 508 mapping and every existing catcher keep working unchanged; `is_transaction_conflict` is added to all three drivers.

no-docs