### PR TITLE
feat: retry requests and jobs that lose transaction conflicts

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -2,8 +2,11 @@
 # License: MIT. See LICENSE
 
 import functools
+import itertools
 import logging
 import os
+import random
+import time
 
 import orjson
 from werkzeug.exceptions import HTTPException, NotFound
@@ -103,55 +106,65 @@ def application(request: Request):
 	response = None
 
 	try:
-		init_request(request)
+		for attempt in itertools.count():
+			try:
+				init_request(request)
 
-		validate_auth()
+				validate_auth()
 
-		if request.method == "OPTIONS":
-			response = Response()
+				if request.method == "OPTIONS":
+					response = Response()
 
-		elif frappe.form_dict.cmd:
-			from frappe.deprecation_dumpster import deprecation_warning
+				elif frappe.form_dict.cmd:
+					from frappe.deprecation_dumpster import deprecation_warning
 
-			deprecation_warning(
-				"unknown",
-				"v17",
-				f"{frappe.form_dict.cmd}: Sending `cmd` for RPC calls is deprecated, call REST API instead `/api/method/cmd`",
-			)
-			frappe.handler.handle()
-			response = frappe.utils.response.build_response("json")
+					deprecation_warning(
+						"unknown",
+						"v17",
+						f"{frappe.form_dict.cmd}: Sending `cmd` for RPC calls is deprecated, call REST API instead `/api/method/cmd`",
+					)
+					frappe.handler.handle()
+					response = frappe.utils.response.build_response("json")
 
-		elif request.path.startswith("/api/"):
-			response = frappe.api.handle(request)
+				elif request.path.startswith("/api/"):
+					response = frappe.api.handle(request)
 
-		elif request.path.startswith("/backups"):
-			response = frappe.utils.response.download_backup(request.path)
+				elif request.path.startswith("/backups"):
+					response = frappe.utils.response.download_backup(request.path)
 
-		elif request.path.startswith("/private/files/"):
-			response = frappe.utils.response.download_private_file(request.path)
+				elif request.path.startswith("/private/files/"):
+					response = frappe.utils.response.download_private_file(request.path)
 
-		elif request.path == "/.well-known/security.txt" and request.method == "GET":
-			if request.scheme != "https":
-				raise NotFound
-			security_settings = frappe.get_doc("Security Settings")
-			response = Response(security_settings.security_txt, content_type="text/plain")
+				elif request.path == "/.well-known/security.txt" and request.method == "GET":
+					if request.scheme != "https":
+						raise NotFound
+					security_settings = frappe.get_doc("Security Settings")
+					response = Response(security_settings.security_txt, content_type="text/plain")
 
-		elif request.path.startswith("/.well-known/") and request.method == "GET":
-			response = handle_wellknown(request.path)
+				elif request.path.startswith("/.well-known/") and request.method == "GET":
+					response = handle_wellknown(request.path)
 
-		elif request.method in ("GET", "HEAD", "POST"):
-			response = get_response()
+				elif request.method in ("GET", "HEAD", "POST"):
+					response = get_response()
 
-		else:
-			raise NotFound
+				else:
+					raise NotFound
 
-	except Exception as e:
-		response = e.get_response(request.environ) if isinstance(e, HTTPException) else handle_exception(e)
-		if db := getattr(frappe.local, "db", None):
-			db.rollback(chain=True)
+			except Exception as e:
+				if should_retry_transaction_conflict(e, attempt):
+					frappe.local.db.rollback()
+					transaction_conflict_backoff(attempt)
+					continue
+				response = (
+					e.get_response(request.environ) if isinstance(e, HTTPException) else handle_exception(e)
+				)
+				if db := getattr(frappe.local, "db", None):
+					db.rollback(chain=True)
 
-	else:
-		sync_database()
+			else:
+				sync_database()
+
+			break
 
 	finally:
 		# Important note:
@@ -168,6 +181,36 @@ def application(request: Request):
 	process_response(response)
 
 	return response
+
+
+# Replay budget for a request whose transaction lost a serialization/deadlock conflict
+# (SERIALIZATION_FAILURE on postgres, ER_LOCK_DEADLOCK / ER_CHECKREAD on mariadb).
+# Overridable per site with `db_conflict_retries` (0 disables).
+TRANSACTION_CONFLICT_RETRIES = 2
+
+
+def should_retry_transaction_conflict(exception, attempt) -> bool:
+	"""A lost conflict rolled the whole transaction back, so replaying the request is an
+	all-or-nothing redo. Only safe while nothing was committed mid-request: after a commit,
+	a replay would apply the already-committed work twice."""
+	db = getattr(frappe.local, "db", None)
+	if db is None or db.commit_count:
+		return False
+
+	is_conflict = isinstance(exception, frappe.QueryDeadlockError) or (
+		isinstance(exception, db.InternalError) and db.is_deadlocked(exception)
+	)
+	if not is_conflict:
+		return False
+
+	retries = frappe.local.conf.get("db_conflict_retries")
+	return attempt < (cint(retries) if retries is not None else TRANSACTION_CONFLICT_RETRIES)
+
+
+def transaction_conflict_backoff(attempt):
+	# Full jitter: two conflicting requests that both retry after a fixed delay would
+	# just collide again in lockstep.
+	time.sleep(random.uniform(0, 0.2 * (2**attempt)))
 
 
 def run_after_request_hooks(request, response):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -123,6 +123,7 @@ class Database:
 		self._conn = None
 
 		self.transaction_writes = 0
+		self.commit_count = 0
 		self.auto_commit_on_many_writes = 0
 
 		self.value_cache = recursive_defaultdict()
@@ -1198,6 +1199,7 @@ class Database:
 			self.sql("commit")
 			self.begin()
 
+		self.commit_count += 1
 		self.value_cache.clear()
 		self.after_commit.run()
 

--- a/frappe/tests/test_request_retry.py
+++ b/frappe/tests/test_request_retry.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.tests.test_api import FrappeAPITestCase
+
+calls = {"flaky": 0, "after_commit": 0}
+
+
+@frappe.whitelist(allow_guest=True)
+def flaky_method():
+	calls["flaky"] += 1
+	if calls["flaky"] == 1:
+		raise frappe.QueryDeadlockError("simulated transaction conflict")
+	return "ok"
+
+
+@frappe.whitelist(allow_guest=True)
+def conflict_after_commit():
+	calls["after_commit"] += 1
+	frappe.db.commit()
+	raise frappe.QueryDeadlockError("simulated conflict after commit")
+
+
+class TestTransactionConflictRetry(FrappeAPITestCase):
+	def test_conflicted_request_is_replayed(self):
+		calls["flaky"] = 0
+		response = self.get(self.method(f"{__name__}.flaky_method"))
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(calls["flaky"], 2)
+
+	def test_no_replay_after_mid_request_commit(self):
+		calls["after_commit"] = 0
+		response = self.get(self.method(f"{__name__}.conflict_after_commit"))
+		self.assertNotEqual(response.status_code, 200)
+		self.assertEqual(calls["after_commit"], 1)

--- a/frappe/tests/test_request_retry.py
+++ b/frappe/tests/test_request_retry.py
@@ -3,11 +3,12 @@
 
 import frappe
 from frappe.tests.test_api import FrappeAPITestCase
+from frappe.tests.utils import whitelist_for_tests
 
 calls = {"flaky": 0, "after_commit": 0}
 
 
-@frappe.whitelist(allow_guest=True)
+@whitelist_for_tests(allow_guest=True)
 def flaky_method():
 	calls["flaky"] += 1
 	if calls["flaky"] == 1:
@@ -15,7 +16,7 @@ def flaky_method():
 	return "ok"
 
 
-@frappe.whitelist(allow_guest=True)
+@whitelist_for_tests(allow_guest=True)
 def conflict_after_commit():
 	calls["after_commit"] += 1
 	frappe.db.commit()

--- a/frappe/tests/test_request_retry.py
+++ b/frappe/tests/test_request_retry.py
@@ -19,7 +19,8 @@ def flaky_method():
 @whitelist_for_tests(allow_guest=True)
 def conflict_after_commit():
 	calls["after_commit"] += 1
-	frappe.db.commit()
+	# the mid-request commit is the point: it must disable the replay
+	frappe.db.commit()  # nosemgrep
 	raise frappe.QueryDeadlockError("simulated conflict after commit")
 
 

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -278,11 +278,13 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 	try:
 		retval = method(**kwargs)
 
-	except (frappe.db.InternalError, frappe.RetryBackgroundJobError) as e:
+	except (frappe.db.InternalError, frappe.RetryBackgroundJobError, frappe.QueryDeadlockError) as e:
 		frappe.db.rollback(chain=True)
 
 		if retry < 5 and (
-			isinstance(e, frappe.RetryBackgroundJobError)
+			# sql() wraps deadlocks/serialization conflicts in QueryDeadlockError, so the raw
+			# is_deadlocked check below never sees them -- catch the wrapper explicitly.
+			isinstance(e, (frappe.RetryBackgroundJobError, frappe.QueryDeadlockError))
 			or (frappe.db.is_deadlocked(e) or frappe.db.is_timedout(e))
 		):
 			# retry the job if


### PR DESCRIPTION
A deadlock/serialization-failure loser is fully rolled back, so replaying it is an all-or-nothing redo that usually succeeds — the winner has committed by then. Today web requests just surface 508 ("Please try again") and the human retries.

- Web requests: replay up to 2 times with full-jitter backoff. Guarded by a new `db.commit_count` — a request that committed anything mid-flight is never replayed (it would double-apply) and keeps the current 508 behavior. Per-site override: `db_conflict_retries` (0 disables).
- Background jobs: the existing 5x deadlock retry never fired — `sql()` wraps driver errors in `QueryDeadlockError`, which `execute_job` didn't catch. Catch the wrapper.

Independent of but pairs with #40921 (distinct `TransactionConflictError`); the retry keys on the base class, so it covers both.

no-docs