### PR TITLE
feat: redact email message after it is sent

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import re
 from collections.abc import Iterable
 from datetime import timedelta
 from functools import cached_property, lru_cache
@@ -516,19 +515,13 @@ class User(Document):
 	def password_reset_mail(self, link):
 		reset_password_template = frappe.db.get_system_setting("reset_password_template")
 
-		q = self.send_login_mail(
+		self.send_login_mail(
 			_("Password Reset"),
 			"password_reset",
 			{"link": link},
 			now=True,
 			custom_template=reset_password_template,
 		)
-		if q:
-			raw_message = q.message
-			parts = re.split(r"(?i)Dear", raw_message, maxsplit=1)
-			if len(parts) > 1:
-				redacted_message = parts[0] + "[THE FOLLOWING CONTENT HAS BEEN REDACTED FOR SECURITY REASONS]"
-				frappe.db.set_value("Email Queue", q.name, "message", redacted_message, update_modified=False)
 
 	def send_welcome_mail_to_user(self):
 		from frappe.utils import get_url
@@ -547,7 +540,7 @@ class User(Document):
 
 		welcome_email_template = frappe.db.get_system_setting("welcome_email_template")
 
-		q = self.send_login_mail(
+		self.send_login_mail(
 			subject,
 			"new_user",
 			dict(
@@ -556,12 +549,6 @@ class User(Document):
 			),
 			custom_template=welcome_email_template,
 		)
-		if q:
-			raw_message = q.message
-			parts = re.split(r"(?i)Hello", raw_message, maxsplit=1)
-			if len(parts) > 1:
-				redacted_message = parts[0] + "[THE FOLLOWING CONTENT HAS BEEN REDACTED FOR SECURITY REASONS]"
-				frappe.db.set_value("Email Queue", q.name, "message", redacted_message, update_modified=False)
 
 	def send_login_mail(self, subject, template, add_args, now=None, custom_template=None):
 		"""send mail with login details"""
@@ -606,6 +593,7 @@ class User(Document):
 			header=[subject, "green"],
 			delayed=(not now) if now is not None else self.flags.delay_emails,
 			retry=3,
+			redact_message_after_send=True,
 		)
 
 	def on_trash(self):

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -155,6 +155,7 @@ def sendmail(
 	email_headers=None,
 	raw_html=False,
 	add_css=True,
+	redact_message_after_send=False,
 ) -> EmailQueue | None:
 	"""Send email using user's default **Email Account** or global default **Email Account**.
 
@@ -188,6 +189,7 @@ def sendmail(
 	    :param email_headers: Additional headers to be added in the email, e.g. {"X-Custom-Header": "value"} or {"Custom-Header": "value"}. Automatically prepends "X-" to the header name if not present.
 	    :param raw_html: Whether to treat email template as a complete HTML file
 	    :param add_css: Whether to add CSS from hooks/email_css to the email template
+	    :param redact_message_after_send: Replace the message body with a placeholder once sent, for emails carrying sensitive content.
 	"""
 
 	from frappe.utils.jinja import get_email_from_template
@@ -249,6 +251,7 @@ def sendmail(
 		email_headers=email_headers,
 		raw_html=raw_html,
 		add_css=add_css,
+		redact_message_after_send=redact_message_after_send,
 	)
 
 	# build email queue and send the email if send_now is True.

--- a/frappe/email/doctype/email_queue/email_queue.json
+++ b/frappe/email/doctype/email_queue/email_queue.json
@@ -26,7 +26,8 @@
   "attachments",
   "retry",
   "email_account",
-  "raw_html"
+  "raw_html",
+  "redact_message_after_send"
  ],
  "fields": [
   {
@@ -157,13 +158,21 @@
    "fieldtype": "Check",
    "label": "Send As Raw HTML",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "description": "Replace the message body with a placeholder once the email has been sent, so that sensitive content like password reset links is not retained in the queue.",
+   "fieldname": "redact_message_after_send",
+   "fieldtype": "Check",
+   "label": "Redact Message After Send",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-envelope",
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2026-01-06 05:45:35.503215",
+ "modified": "2026-07-16 07:11:53.229233",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Queue",

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -357,7 +357,14 @@ class SendMailContext:
 		self.queue_doc.update_status(**update_fields, commit=True)
 
 		if not exc_type and self.queue_doc.redact_message_after_send:
-			self.queue_doc.redact_message()
+			try:
+				self.queue_doc.redact_message()
+			except Exception:
+				frappe.log_error(
+					title="Failed to redact email message after send",
+					reference_doctype=self.queue_doc.doctype,
+					reference_name=self.queue_doc.name,
+				)
 
 	@savepoint(catch=Exception)
 	def notify_failed_email(self):

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -41,6 +41,8 @@ from frappe.utils.verified_command import get_signed_params
 if TYPE_CHECKING:
 	from typing import Literal
 
+REDACTED_MESSAGE = "[THE FOLLOWING CONTENT HAS BEEN REDACTED FOR SECURITY REASONS]"
+
 
 class EmailQueue(Document):
 	_DOCTYPE_NAME = "Email Queue"
@@ -65,6 +67,7 @@ class EmailQueue(Document):
 		priority: DF.Int
 		raw_html: DF.Check
 		recipients: DF.Table[EmailQueueRecipient]
+		redact_message_after_send: DF.Check
 		reference_doctype: DF.Link | None
 		reference_name: DF.Data | None
 		retry: DF.Int
@@ -135,6 +138,18 @@ class EmailQueue(Document):
 		if self.communication and frappe.db.exists("Communication", self.communication):
 			communication_doc = frappe.get_doc("Communication", self.communication)
 			communication_doc.set_delivery_status(commit=commit)
+
+	def redact_message(self):
+		"""Drop the message body, keeping the headers.
+
+		Only called once the email is out of the door, since the queued message is the only
+		copy the retrying sender has.
+		"""
+		message = Parser(policy=SMTP).parsestr(self.message)
+		message.clear_content()
+		message.set_content(REDACTED_MESSAGE)
+
+		self.update_db(message=message.as_string(), commit=True)
 
 	@property
 	def cc(self):
@@ -340,6 +355,9 @@ class SendMailContext:
 			update_fields = {"status": "Sent"}
 
 		self.queue_doc.update_status(**update_fields, commit=True)
+
+		if not exc_type and self.queue_doc.redact_message_after_send:
+			self.queue_doc.redact_message()
 
 	@savepoint(catch=Exception)
 	def notify_failed_email(self):
@@ -587,6 +605,7 @@ class QueueBuilder:
 		email_headers=None,
 		raw_html=False,
 		add_css=True,
+		redact_message_after_send=False,
 	):
 		"""Add email to sending queue (Email Queue)
 
@@ -620,6 +639,7 @@ class QueueBuilder:
 		:param email_headers: Additional headers to be added in the email, e.g. {"X-Custom-Header": "value"} or {"Custom-Header": "value"}. Automatically prepends "X-" to the header name if not present.
 		:param raw_html: Whether to treat email template as a complete HTML file
 		:param add_css: Add default CSS from hooks/email_css to the email template (default True)
+		:param redact_message_after_send: Replace the message body with a placeholder once sent, for emails carrying sensitive content.
 		"""
 
 		self._unsubscribe_method = unsubscribe_method
@@ -659,6 +679,7 @@ class QueueBuilder:
 		self.email_headers = email_headers
 		self.raw_html = raw_html
 		self.add_css = add_css
+		self.redact_message_after_send = redact_message_after_send
 
 	@property
 	def unsubscribe_method(self):
@@ -934,6 +955,7 @@ class QueueBuilder:
 			"email_read_tracker_url": self.email_read_tracker_url,
 			"raw_html": self.raw_html,
 			"add_css": self.add_css,
+			"redact_message_after_send": self.redact_message_after_send,
 		}
 
 		if include_recipients:

--- a/frappe/email/doctype/email_queue/test_email_queue.py
+++ b/frappe/email/doctype/email_queue/test_email_queue.py
@@ -124,3 +124,53 @@ class TestEmailQueue(IntegrationTestCase):
 			frappe.flags.testing_email = False
 
 		mock_smtp_server.discard_session.assert_called_once()
+
+	def test_redacts_message_only_once_sent(self):
+		"""A failed send must keep the message intact, it is the only copy the retry has."""
+		link = f"http://example.com/update-password?key={frappe.generate_hash()}"
+		email_record = frappe.new_doc(
+			"Email Queue",
+			sender="Test <test@example.com>",
+			show_as_cc="",
+			email_account="_Test Email Account 1",
+			message=textwrap.dedent(
+				f"""\
+			MIME-Version: 1.0
+			Content-Type: text/plain; charset="utf-8"
+			Message-Id: {frappe.generate_hash()}
+			Subject: Welcome
+			From: Test <test@example.com>
+			To: <!--recipient-->
+
+			Hello, complete your registration at {link}
+			"""
+			),
+			status="Not Sent",
+			priority=1,
+			redact_message_after_send=1,
+			recipients=[{"recipient": "test_redact@example.com"}],
+		).insert()
+
+		mock_session = MagicMock()
+		mock_session.has_extn.return_value = False
+		mock_session.sendmail.side_effect = smtplib.SMTPRecipientsRefused(
+			{"test_redact@example.com": (450, b"Mailbox busy")}
+		)
+		mock_smtp_server = MagicMock()
+		mock_smtp_server.session = mock_session
+
+		frappe.flags.testing_email = True
+		try:
+			with self.assertRaises(smtplib.SMTPRecipientsRefused):
+				email_record.send(smtp_server_instance=mock_smtp_server)
+
+			self.assertIn(link, frappe.db.get_value("Email Queue", email_record.name, "message"))
+
+			mock_session.sendmail.side_effect = None
+			email_record.reload()
+			email_record.send(smtp_server_instance=mock_smtp_server)
+		finally:
+			frappe.flags.testing_email = False
+
+		self.assertIn(link, mock_session.sendmail.call_args.kwargs["msg"].decode())
+		self.assertNotIn(link, frappe.db.get_value("Email Queue", email_record.name, "message"))


### PR DESCRIPTION
### What this adds

Emails that carry sensitive content, like the welcome email and the password reset email, now get their body redacted in the Email Queue **after** the email has been sent, not before.

The queue keeps the real message for as long as it is needed to actually deliver it, and replaces the body with a placeholder the moment delivery succeeds. Sensitive content like password setup links is no longer left sitting in the database, and the user still receives the full email.

### Why

#37554 started this: strip the password reset link out of the Email Queue so it is not stored in the database, while keeping the email headers. Good idea.

But it redacts at queue time, before the email is sent. That is safe only for the very first send attempt, which runs in the same request off the in-memory copy. Any later attempt reads the message back from the database, and the database copy is already redacted:

- The first attempt fails, for example the SMTP server is down for a moment.
- The row stays `Not Sent`, the scheduler retries it later.
- The retry reads the redacted message from the database and sends that.
- The user gets the redaction banner and no setup link.

Same story whenever the first attempt does not go through: emails muted, `suspend_email_queue` set, `send_after` set, or a manual resend. An Email Queue exists to send later, so this is the normal case, not an edge case. And it cannot be recovered: the real message only lived in memory during that one request, and `reset_password_key` is hashed on User, so the link is gone.

This PR completes the idea by moving the redaction to the right moment.

### How

Redaction becomes something the Email Queue does, because the queue is what knows whether the
mail actually left:

- Email Queue gets a `redact_message_after_send` check field, set through `frappe.sendmail`, in the same shape as the existing `raw_html` flag.
- `SendMailContext.__exit__` redacts only when the send raised nothing, right after it already sets `status = Sent`.
- `User.send_login_mail()` passes the flag, so welcome and password reset are both covered.

Failed attempt keeps the message so the retry can send a real email. Successful attempt redacts it. Every path is covered: in-request, scheduler retry, muted then flushed, manual resend.

`EmailQueue.redact_message()` parses the MIME, clears the body and sets a single banner, keeping the headers. This is also sturdier than the previous string split, which:

- did nothing when a custom `welcome_email_template` had no "Hello" in it, so those sites got no redaction at all, and
- cut the raw MIME string mid-body and dropped the closing boundaries, producing a broken message that clients rendered as flat text.

Parsing the structure covers any template and always produces valid MIME. `Content-Type` is rewritten to `text/plain` since the multipart body it described is gone; every identity header (`Subject`, `From`, `To`, `Message-Id`, `Date`, `Reply-To`, `X-Frappe-Site`) is preserved.

no-docs

**Support Ticket**: [73836](https://support.frappe.io/helpdesk/tickets/73836)

### Before Fix
[Screencast from 2026-07-16 14-05-07.webm](https://github.com/user-attachments/assets/86596d6e-767b-4a4d-bba8-0f29301f9df7)

### After Fix
[Screencast from 2026-07-16 14-11-13.webm](https://github.com/user-attachments/assets/2c8cbfb0-1940-468b-b70e-05b6c598fd2f)

