### PR TITLE
fix: multiple changes in duckdb sync

### DIFF
--- a/frappe/core/doctype/duckdb_sync/duckdb_sync.json
+++ b/frappe/core/doctype/duckdb_sync/duckdb_sync.json
@@ -45,6 +45,8 @@
   {
    "fieldname": "filename",
    "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Filename"
   },
   {
@@ -56,7 +58,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-06-24 13:22:03.530667",
+ "modified": "2026-07-16 12:04:25.120678",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DuckDB Sync",

--- a/frappe/core/doctype/duckdb_sync/duckdb_sync.py
+++ b/frappe/core/doctype/duckdb_sync/duckdb_sync.py
@@ -59,6 +59,9 @@ class DuckDBSync(Document):
 				ddbt.sync(duck_conn)
 		duck_conn.close()
 
+	def on_cancel(self):
+		self.flags.ignore_links = True
+
 	def on_trash(self):
 		if self.docstatus.is_cancelled():
 			from frappe.database import delete_duckdb_file
@@ -123,7 +126,7 @@ def sync_data_to_duckdb(docname: str):
 		conn = frappe.get_doc("DuckDB Sync", docname).get_duckdb_conn()
 		try:
 			conn.sql(
-				f"attach 'user={frappe.conf.db_name} password={frappe.conf.db_password} host={frappe.conf.db_host} database={frappe.conf.db_name}' as mariadb_db (TYPE mysql);"
+				f"attach 'user={frappe.conf.db_name} password={frappe.conf.db_password} host={frappe.conf.db_host} database={frappe.conf.db_name} port={frappe.conf.db_port}' as mariadb_db (TYPE mysql);"
 			)
 			columns = frappe.get_meta(dt).get_valid_columns()
 			# quotted fields

--- a/frappe/database/duckdb/schema.py
+++ b/frappe/database/duckdb/schema.py
@@ -122,7 +122,7 @@ class DuckDBTable(DBTable):
 	def create(self, conn):
 		additional_definitions = []
 		varchar_len = frappe.db.VARCHAR_LEN
-		name_column = f"name varchar({varchar_len}) primary key"
+		name_column = f"name varchar({varchar_len})"
 
 		# columns
 		column_defs = self.get_column_definitions()


### PR DESCRIPTION
 - use db_port from 'frappe.conf'
 - filename in list view
 - ignore_links on cancel
 - don't set primary key