### PR TITLE
refactor: rebuild auth pages on espresso components and utilities

### DIFF
--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -78,8 +78,6 @@ body {
 			gap: 12px;
 
 			.social-logins {
-				@include get_textstyle("base", "regular");
-
 				.btn-salesforce i {
 					color: var(--blue-400);
 				}
@@ -108,12 +106,9 @@ body {
 				align-items: center;
 				gap: 8px;
 				align-self: stretch;
-				@include get_textstyle("base", "regular");
-				color: var(--ink-gray-6);
-				margin-bottom: 0;
 
 				a {
-					color: var(--ink-gray-6);
+					color: inherit;
 					text-decoration: underline;
 				}
 			}
@@ -159,9 +154,6 @@ body {
 
 			.field-error {
 				display: none;
-				@include get_textstyle("base", "regular");
-				color: var(--ink-red-8);
-				margin-bottom: 0;
 			}
 
 			.form-group.invalid {
@@ -173,26 +165,6 @@ body {
 
 				.field-error {
 					display: block;
-				}
-			}
-
-			.form-label {
-				@include get_textstyle("base", "regular");
-				color: var(--ink-gray-5);
-				width: 100%;
-				line-height: 115%;
-				margin-bottom: 0;
-			}
-
-			.forgot-password-message {
-				text-align: right;
-				align-self: stretch;
-				line-height: 115%;
-				margin-bottom: 0;
-
-				> * {
-					color: var(--ink-gray-5);
-					@include get_textstyle("base", "regular");
 				}
 			}
 
@@ -237,14 +209,9 @@ body {
 	.sign-up-message {
 		margin-top: auto;
 		margin-bottom: 0;
-		color: var(--ink-gray-6);
-		@include get_textstyle("sm", "regular");
-		line-height: 150%;
 
 		a {
-			color: var(--ink-gray-6);
-			font-weight: var(--weight-regular);
-			letter-spacing: 0.195px;
+			color: inherit;
 			text-decoration-line: underline;
 			text-decoration-style: solid;
 			text-decoration-skip-ink: none;
@@ -301,49 +268,9 @@ body {
 		gap: 6px;
 		align-self: stretch;
 	}
-
-	h4 {
-		margin: 0;
-		font-size: var(--text-2xl);
-		font-weight: var(--weight-bold);
-		letter-spacing: 0.01em;
-		line-height: 115%;
-		color: var(--heading-color);
-		align-self: stretch;
-	}
-
-	.page-card-subtitle {
-		margin: 0;
-		font-size: var(--text-base);
-		font-weight: var(--weight-regular);
-		line-height: 150%;
-		letter-spacing: 0.28px;
-		color: var(--ink-gray-6);
-	}
 }
 
 .for-reset-password {
-	.password-hint {
-		@include get_textstyle("sm", "regular");
-		color: var(--ink-gray-5);
-		margin-bottom: 0;
-		line-height: 150%;
-
-		&.hidden {
-			display: none;
-		}
-	}
-
-	.password-mismatch-message {
-		@include get_textstyle("sm", "regular");
-		color: var(--ink-red-8);
-		margin-bottom: 0;
-
-		&.hidden {
-			display: none;
-		}
-	}
-
 	.password-label-row {
 		display: flex;
 		justify-content: space-between;
@@ -352,34 +279,21 @@ body {
 		gap: 8px;
 	}
 
-	.password-strength-indicator {
-		@include get_textstyle("sm", "regular");
-		color: var(--ink-gray-5);
-		line-height: 150%;
-		white-space: nowrap;
-
-		&.hidden {
-			display: none;
+	.password-strength-value {
+		&.strength-red {
+			color: var(--red-700);
 		}
 
-		.password-strength-value {
-			@include get_textstyle("sm", "medium");
+		&.strength-orange {
+			color: var(--orange-700);
+		}
 
-			&.strength-red {
-				color: var(--red-700);
-			}
+		&.strength-blue {
+			color: var(--blue-700);
+		}
 
-			&.strength-orange {
-				color: var(--orange-700);
-			}
-
-			&.strength-blue {
-				color: var(--blue-700);
-			}
-
-			&.strength-green {
-				color: var(--green-700);
-			}
+		&.strength-green {
+			color: var(--green-700);
 		}
 	}
 }

--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -38,9 +38,6 @@ body {
 		width: 100%;
 		margin: 0 auto;
 		border-radius: var(--radius-lg);
-		display: flex;
-		flex-direction: column;
-		gap: var(--margin-lg);
 
 		@include media-breakpoint-down(xs) {
 			max-width: 100%;
@@ -48,21 +45,6 @@ body {
 			border-radius: 0;
 			border: none;
 			padding: 60px 32px 32px;
-		}
-
-		// 6px is off the Espresso 4px spacing scale (Figma spec), so it stays here
-		// instead of a gap-* utility
-		.form-group {
-			display: flex;
-			flex-direction: column;
-			align-items: flex-start;
-			gap: 6px;
-			align-self: stretch;
-			margin-bottom: 0;
-
-			&:has(.forgot-password-message) {
-				gap: 8px;
-			}
 		}
 
 		.social-logins {
@@ -95,10 +77,6 @@ body {
 		}
 
 		.page-card-body {
-			display: flex;
-			flex-direction: column;
-			gap: 14px;
-
 			::placeholder,
 			/* Chrome, Firefox, Opera, Safari 10.1+ */
 			::-ms-input-placeholder {
@@ -228,14 +206,6 @@ body {
 	img.app-logo {
 		max-height: 32px;
 		width: auto;
-	}
-
-	// 6px is off the Espresso 4px spacing scale (Figma spec)
-	.page-card-head-text {
-		display: flex;
-		flex-direction: column;
-		gap: 6px;
-		align-self: stretch;
 	}
 }
 

--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -77,99 +77,12 @@ body {
 			flex-direction: column;
 			gap: 12px;
 
-			.btn-login,
-			.btn-ldap-login {
-				@include get_textstyle("base", "regular");
-				line-height: 115%;
-				color: white;
-				background: var(--gray-900);
-				border: none;
-				box-shadow: none;
-				padding: 6px 8px;
-				border-radius: var(--radius);
-				width: 100%;
-
-				&:hover,
-				&:focus,
-				&:active {
-					background: var(--gray-800);
-					color: white;
-					border: none;
-					box-shadow: none;
-				}
-
-				&:disabled {
-					background: var(--gray-900);
-					color: white;
-					opacity: 1;
-					pointer-events: none;
-				}
-			}
-
-			.btn-signup {
-				@include get_textstyle("base", "regular");
-				line-height: 115%;
-				background: var(--surface-gray-2);
-				color: var(--ink-gray-4);
-				border: none;
-				box-shadow: none;
-				padding: 6px 8px;
-				border-radius: var(--radius);
-				width: 100%;
-
-				&:not(:disabled) {
-					background: var(--surface-gray-10);
-					color: white;
-
-					&:hover,
-					&:focus,
-					&:active {
-						background: var(--gray-800);
-						color: white;
-						border: none;
-						box-shadow: none;
-					}
-				}
-
-				&:disabled {
-					opacity: 1;
-					pointer-events: none;
-				}
-			}
-
-			.btn-login-option {
-				@include get_textstyle("base", "medium");
-				line-height: 115%;
-				color: var(--gray-800);
-				background: var(--gray-100);
-				box-shadow: none;
-				border: none;
-				display: flex;
-				justify-content: center;
-				align-items: center;
-				padding: 6px 8px;
-				margin-top: 0;
-				border-radius: var(--radius);
-				width: 100%;
-
-				&.btn-salesforce {
-					i {
-						color: var(--blue-400);
-					}
-				}
-
-				img {
-					margin-right: var(--padding-xs);
-				}
-
-				&:hover {
-					border: none;
-					background: var(--gray-200);
-				}
-			}
-
 			.social-logins {
 				@include get_textstyle("base", "regular");
+
+				.btn-salesforce i {
+					color: var(--blue-400);
+				}
 
 				.social-login-buttons {
 					margin-top: var(--margin-md);

--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -250,11 +250,11 @@ body {
 				align-items: center;
 				gap: 8px;
 				align-self: stretch;
-				background-color: var(--surface-green-1);
+				background-color: var(--surface-gray-1);
 				border-radius: var(--radius);
 				@include get_textstyle("base", "regular");
 				line-height: 115%;
-				color: var(--ink-green-6);
+				color: var(--ink-gray-8);
 
 				svg {
 					margin: 0;
@@ -266,17 +266,17 @@ body {
 			.login-error-banner {
 				display: none;
 				padding: 6px 8px;
-				align-items: center;
+				align-items: flex-start;
 				gap: 8px;
 				align-self: stretch;
-				background-color: var(--red-50);
+				background-color: var(--surface-gray-1);
 				border-radius: var(--radius);
 				@include get_textstyle("base", "regular");
-				color: var(--ink-red-8);
+				color: var(--ink-gray-8);
 
 				svg {
-					margin: 0;
-					stroke: var(--ink-red-8);
+					margin: 3px 0 0;
+					stroke: var(--ink-red-6);
 					flex-shrink: 0;
 				}
 			}

--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -34,7 +34,7 @@ body {
 	.page-card {
 		padding: 24px;
 		background-color: var(--bg-color);
-		max-width: 371px;
+		max-width: 400px;
 		width: 100%;
 		margin: 0 auto;
 		border-radius: var(--radius-lg);
@@ -69,11 +69,6 @@ body {
 					}
 				}
 			}
-		}
-
-		.resend-link a {
-			color: inherit;
-			text-decoration: underline;
 		}
 
 		.page-card-body {
@@ -160,20 +155,6 @@ body {
 		}
 	}
 
-	.sign-up-message {
-		margin-top: auto;
-		margin-bottom: 0;
-
-		a {
-			color: inherit;
-			text-decoration-line: underline;
-			text-decoration-style: solid;
-			text-decoration-skip-ink: none;
-			text-decoration-thickness: 1px;
-			text-underline-position: from-font;
-		}
-	}
-
 	.invalid-login {
 		animation: wiggle 0.4s ease-in-out;
 	}
@@ -206,25 +187,5 @@ body {
 	img.app-logo {
 		max-height: 32px;
 		width: auto;
-	}
-}
-
-.for-reset-password {
-	.password-strength-value {
-		&.strength-red {
-			color: var(--red-700);
-		}
-
-		&.strength-orange {
-			color: var(--orange-700);
-		}
-
-		&.strength-blue {
-			color: var(--blue-700);
-		}
-
-		&.strength-green {
-			color: var(--green-700);
-		}
 	}
 }

--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -257,6 +257,7 @@ body {
 				color: var(--ink-green-6);
 
 				svg {
+					margin: 0;
 					stroke: var(--ink-green-6);
 					flex-shrink: 0;
 				}
@@ -274,6 +275,7 @@ body {
 				color: var(--ink-red-8);
 
 				svg {
+					margin: 0;
 					stroke: var(--ink-red-8);
 					flex-shrink: 0;
 				}
@@ -332,7 +334,8 @@ body {
 				position: relative;
 				width: 100%;
 
-				input {
+				// only pad for a leading icon when one is present
+				&:has(.field-icon) input {
 					padding-left: 38px;
 				}
 			}
@@ -445,18 +448,13 @@ body {
 
 .for-reset-password {
 	.password-hint {
-		display: flex;
-		align-items: flex-start;
-		gap: 8px;
 		@include get_textstyle("sm", "regular");
 		color: var(--ink-gray-5);
 		margin-bottom: 0;
 		line-height: 150%;
 
-		svg {
-			fill: var(--ink-gray-4);
-			flex-shrink: 0;
-			margin-top: 1px;
+		&.hidden {
+			display: none;
 		}
 	}
 
@@ -470,85 +468,41 @@ body {
 		}
 	}
 
-	.password-strength-message {
+	.password-label-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		align-self: stretch;
+		gap: 8px;
+	}
+
+	.password-strength-indicator {
 		@include get_textstyle("sm", "regular");
 		color: var(--ink-gray-5);
-		margin-bottom: 0;
-
-		&.hidden {
-			display: none;
-		}
-	}
-
-	.password-strength-group {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		align-items: flex-start;
-		gap: 6px;
-		align-self: stretch;
-		margin-top: 2px;
-	}
-
-	.password-strength-container {
-		display: flex;
-		flex-direction: column;
-		align-items: flex-start;
-		gap: 10px;
-		align-self: stretch;
-		padding-top: 4px;
+		line-height: 150%;
+		white-space: nowrap;
 
 		&.hidden {
 			display: none;
 		}
 
-		.password-strength-label {
-			@include get_textstyle("base", "medium");
+		.password-strength-value {
+			@include get_textstyle("sm", "medium");
 
 			&.strength-red {
-				color: var(--dark-red-500, #b01f1f);
+				color: var(--red-700);
 			}
 
 			&.strength-orange {
-				color: var(--dark-orange-500, var(--orange-700));
+				color: var(--orange-700);
 			}
 
 			&.strength-blue {
-				color: var(--dark-blue-500, var(--blue-700));
+				color: var(--blue-700);
 			}
 
 			&.strength-green {
-				color: var(--dark-green-500, var(--green-700));
-			}
-		}
-
-		.password-strength-bar-track {
-			height: 4px;
-			background: var(--surface-gray-2);
-			border-radius: var(--radius);
-			align-self: stretch;
-			overflow: hidden;
-		}
-
-		.password-strength-bar-fill {
-			height: 100%;
-			border-radius: 20px 4px 4px 20px;
-			transition: width 0.3s ease;
-
-			&.strength-red {
-				background: var(--dark-red-500, #b01f1f);
-			}
-
-			&.strength-orange {
-				background: var(--dark-orange-500, var(--orange-700));
-			}
-
-			&.strength-blue {
-				background: var(--dark-blue-500, var(--blue-700));
-			}
-
-			&.strength-green {
-				background: var(--dark-green-500, var(--green-700));
+				color: var(--green-700);
 			}
 		}
 	}

--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -117,24 +117,10 @@ body {
 				}
 			}
 
-			.field-icon {
-				left: 8px;
-				top: 50%;
-				transform: translateY(-50%);
-				position: absolute;
-				z-index: 2;
-				stroke: var(--ink-gray-5);
-			}
-
 			.email-field,
 			.password-field {
 				position: relative;
 				width: 100%;
-
-				// only pad for a leading icon when one is present
-				&:has(.field-icon) input {
-					padding-left: 38px;
-				}
 			}
 
 			.password-field {

--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -244,43 +244,6 @@ body {
 				}
 			}
 
-			.login-success-banner {
-				display: none;
-				padding: 6px 8px;
-				align-items: center;
-				gap: 8px;
-				align-self: stretch;
-				background-color: var(--surface-gray-1);
-				border-radius: var(--radius);
-				@include get_textstyle("base", "regular");
-				line-height: 115%;
-				color: var(--ink-gray-8);
-
-				svg {
-					margin: 0;
-					stroke: var(--ink-green-6);
-					flex-shrink: 0;
-				}
-			}
-
-			.login-error-banner {
-				display: none;
-				padding: 6px 8px;
-				align-items: flex-start;
-				gap: 8px;
-				align-self: stretch;
-				background-color: var(--surface-gray-1);
-				border-radius: var(--radius);
-				@include get_textstyle("base", "regular");
-				color: var(--ink-gray-8);
-
-				svg {
-					margin: 3px 0 0;
-					stroke: var(--ink-red-6);
-					flex-shrink: 0;
-				}
-			}
-
 			.field-error {
 				display: none;
 				@include get_textstyle("base", "regular");

--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -50,72 +50,48 @@ body {
 			padding: 60px 32px 32px;
 		}
 
-		form {
+		// 6px is off the Espresso 4px spacing scale (Figma spec), so it stays here
+		// instead of a gap-* utility
+		.form-group {
 			display: flex;
 			flex-direction: column;
-			gap: 16px;
-			max-width: 100%;
-			margin: 0;
+			align-items: flex-start;
+			gap: 6px;
+			align-self: stretch;
+			margin-bottom: 0;
 
-			.form-group {
-				display: flex;
-				flex-direction: column;
-				align-items: flex-start;
-				gap: 6px;
-				align-self: stretch;
-				margin-bottom: 0;
+			&:has(.forgot-password-message) {
+				gap: 8px;
+			}
+		}
 
-				&:has(.forgot-password-message) {
-					gap: 8px;
+		.social-logins {
+			.btn-salesforce i {
+				color: var(--blue-400);
+			}
+
+			.social-login-buttons {
+				margin-top: var(--margin-md);
+
+				.login-button-wrapper {
+					@include media-breakpoint-up(md) {
+						min-width: 33.33%;
+					}
+
+					min-width: 50%;
+					padding: 0 4px;
+					margin-bottom: var(--margin-md);
+
+					&:last-child {
+						margin-bottom: 0;
+					}
 				}
 			}
 		}
 
-		.page-card-actions {
-			margin-top: 0;
-			display: flex;
-			flex-direction: column;
-			gap: 12px;
-
-			.social-logins {
-				.btn-salesforce i {
-					color: var(--blue-400);
-				}
-
-				.social-login-buttons {
-					margin-top: var(--margin-md);
-
-					.login-button-wrapper {
-						@include media-breakpoint-up(md) {
-							min-width: 33.33%;
-						}
-
-						min-width: 50%;
-						padding: 0 4px;
-						margin-bottom: var(--margin-md);
-
-						&:last-child {
-							margin-bottom: 0;
-						}
-					}
-				}
-			}
-
-			.resend-link {
-				display: none;
-				align-items: center;
-				gap: 8px;
-				align-self: stretch;
-
-				a {
-					color: inherit;
-					text-decoration: underline;
-				}
-			}
-
-			.login-divider {
-				margin: var(--margin-md) 0;
-			}
+		.resend-link a {
+			color: inherit;
+			text-decoration: underline;
 		}
 
 		.page-card-body {
@@ -249,19 +225,12 @@ body {
 }
 
 .page-card-head {
-	padding: 0;
-	margin: 0;
-	text-align: left;
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: 16px;
-
 	img.app-logo {
 		max-height: 32px;
 		width: auto;
 	}
 
+	// 6px is off the Espresso 4px spacing scale (Figma spec)
 	.page-card-head-text {
 		display: flex;
 		flex-direction: column;
@@ -271,14 +240,6 @@ body {
 }
 
 .for-reset-password {
-	.password-label-row {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		align-self: stretch;
-		gap: 8px;
-	}
-
 	.password-strength-value {
 		&.strength-red {
 			color: var(--red-700);

--- a/frappe/public/scss/website.bundle.scss
+++ b/frappe/public/scss/website.bundle.scss
@@ -3,3 +3,7 @@
 /* Espresso components (.es-* classes) — same aggregator as desk; available on
    all website/portal pages incl. web forms (loaded via website.bundle.css). */
 @import "./espresso_components";
+
+/* Tailwind-style utility classes (same file desk uses) — kept as the LAST
+   import so utilities win over component/legacy rules. */
+@import "common/utilities";

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -65,19 +65,16 @@ login.bind_events = function () {
 			login.show_field_error("forgot_email", {{ _("Invalid Email.") | tojson }});
 			return false;
 		}
-		// route the server confirmation into the success banner instead of a modal
 		login.call(args, null, "/", "section.for-forgot .login-success-banner .es-alert__title");
 		return false;
 	});
 
 	$("#forgot_email").on("input", function () {
-		// editing the email resets the "Sent" state back to the default label
 		$(".btn-forgot").text({{ _("Send Link") | tojson }}).prop("disabled", !$(this).val().trim());
 	});
 
 	$("#login_with_email_link_email").on("input", function () {
-		// changing the email resets the "Sent" state; the success banner is cleared
-		// by the shared .page-card-body input handler, so only reset the button + resend link here
+		// the shared input handler clears the banner; only button + resend link reset here
 		$(".form-login-with-email-link .btn-login-with-email-link")
 			.text({{ _("Send login link") | tojson }}).prop("disabled", false);
 		$("section.for-login-with-email-link .resend-link").addClass("hidden");
@@ -92,8 +89,7 @@ login.bind_events = function () {
 			login.show_field_error("login_with_email_link_email", {{ _("Invalid Email.") | tojson }});
 			return false;
 		}
-		// route the rate-limit / server error into the banner instead of a modal
-		// (success sends no server message, so the green success banner is unaffected)
+		// errors land in the error banner via error_msg; success sends no server message
 		login.call(args, null, "/", "section.for-login-with-email-link .login-error-banner .es-alert__title").then(() => {
 			$("section:visible .login-success-banner").removeClass("hidden");
 			$("section:visible .resend-link").removeClass("hidden");
@@ -109,8 +105,7 @@ login.bind_events = function () {
 	$("#signup_fullname, #signup_email").on("input", function () {
 		var name = $("#signup_fullname").val().trim();
 		var email = $("#signup_email").val().trim();
-		// restore the default label in case a previous submit left a status message
-		// (e.g. "Already Registered") on the button
+		// a previous submit may have left "Already Registered" on the button
 		$(".form-signup .btn-signup").text({{ _("Create Account") | tojson }}).prop("disabled", !(name && email));
 	});
 
@@ -233,8 +228,7 @@ login.call = function (args, callback, url="/", error_msg=null) {
 }
 
 login.show_loading = function () {
-	// swap the visible primary button's label for the Espresso spinner; es-button
-	// only reveals it (and blocks clicks) while aria-busy is set
+	// es-button shows the spinner (and blocks clicks) only while aria-busy is set
 	$('section:visible .es-button[data-variant="solid"]:not([aria-busy])').each(function () {
 		$(this)
 			.data("label", $(this).text().trim())
@@ -244,7 +238,6 @@ login.show_loading = function () {
 };
 
 login.hide_loading = function () {
-	// restore the label saved by show_loading
 	$('.es-button[aria-busy="true"]').each(function () {
 		$(this).removeAttr("aria-busy").text($(this).data("label") || "");
 	});
@@ -286,8 +279,7 @@ login.set_invalid = function (message) {
 		login.show_error_banner(message);
 		return;
 	}
-	// sign-in: restore the button label, flag the fields, error in the banner
-	// (the OTP screen has no banner — there the message replaces the button label)
+	// sign-in; the OTP screen has no banner — there the message replaces the button label
 	login.hide_loading();
 	$("section:visible .page-card-body").addClass("invalid");
 	if ($("section:visible .login-error-banner").length) {
@@ -358,13 +350,12 @@ login.login_handlers = (function () {
 				$("section:visible .login-success-banner").removeClass("hidden");
 			} else if (window.location.hash === '#signup') {
 				if (cint(data.message[0]) == 0) {
-					// signup failed (e.g. already registered): show in the banner, restore the button
+					// signup failed (e.g. already registered)
 					login.hide_loading();
 					$("section:visible .login-success-banner").addClass("hidden");
 					login.show_error_banner(data.message[1]);
 				} else {
 					login.set_status({{ _("Success") | tojson }}, 'green');
-					// show the confirmation in the banner instead of a modal
 					$("section:visible .login-error-banner").addClass("hidden");
 					login.show_success_banner(data.message[1]);
 				}

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -228,8 +228,15 @@ login.call = function (args, callback, url="/", error_msg=null) {
 }
 
 login.show_loading = function () {
+	// only the button that triggered the request (falls back to the section's
+	// primary button for keyboard submits); matters when both password and
+	// LDAP login render their own solid button
+	var $btn = $(document.activeElement).filter('section:visible .es-button[data-variant="solid"]');
+	if (!$btn.length) {
+		$btn = $('section:visible .es-button[data-variant="solid"]').first();
+	}
 	// es-button shows the spinner (and blocks clicks) only while aria-busy is set
-	$('section:visible .es-button[data-variant="solid"]:not([aria-busy])').each(function () {
+	$btn.not("[aria-busy]").each(function () {
 		$(this)
 			.data("label", $(this).text().trim())
 			.attr("aria-busy", "true")
@@ -244,7 +251,12 @@ login.hide_loading = function () {
 };
 
 login.set_status = function (message, color) {
-	$('section:visible .es-button[data-variant="solid"]').removeAttr("aria-busy").text(message);
+	// the busy button is the one whose request this status answers
+	var $btn = $('section:visible .es-button[aria-busy="true"]');
+	if (!$btn.length) {
+		$btn = $('section:visible .es-button[data-variant="solid"]').first();
+	}
+	$btn.removeAttr("aria-busy").text(message);
 	if (color == "red") {
 		$('section:visible .page-card-body').addClass("invalid");
 	}

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -73,6 +73,13 @@ login.bind_events = function () {
 		$(".btn-forgot").prop("disabled", !$(this).val().trim());
 	});
 
+	$("#login_with_email_link_email").on("input", function () {
+		// changing the email resets the "Sent" state back to the default
+		$(".form-login-with-email-link .btn-login-with-email-link")
+			.text({{ _("Send login link") | tojson }}).prop("disabled", false);
+		$("section.for-login-with-email-link .login-success-banner, section.for-login-with-email-link .resend-link").hide();
+	});
+
 	$(".form-login-with-email-link").on("submit", function (event) {
 		event.preventDefault();
 		var args = {};
@@ -96,7 +103,9 @@ login.bind_events = function () {
 	$("#signup_fullname, #signup_email").on("input", function () {
 		var name = $("#signup_fullname").val().trim();
 		var email = $("#signup_email").val().trim();
-		$(".btn-signup").prop("disabled", !(name && email));
+		// restore the default label in case a previous submit left a status message
+		// (e.g. "Already Registered") on the button
+		$(".form-signup .btn-signup").text({{ _("Create Account") | tojson }}).prop("disabled", !(name && email));
 	});
 
 	$(".btn-resend-link").on("click", function (e) {
@@ -237,6 +246,17 @@ login.set_invalid = function (message) {
 	setTimeout(() => {
 		$(".login-content.page-card").removeClass('invalid-login');
 	}, 500)
+	// forgot: error in a banner + reset its button (it isn't reset elsewhere)
+	if ($("section.for-forgot").is(":visible")) {
+		$(".form-forgot .btn-forgot").text({{ _("Send Link") | tojson }});
+		login.show_error_banner(message);
+		return;
+	}
+	// email-link: error in a banner (button reset by the form's own catch)
+	if ($("section.for-login-with-email-link").is(":visible")) {
+		login.show_error_banner(message);
+		return;
+	}
 	login.set_status(message, 'red');
 	login.show_error_banner(message);
 	$("#login_password").focus();

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -80,7 +80,7 @@ login.bind_events = function () {
 		// by the shared .page-card-body input handler, so only reset the button + resend link here
 		$(".form-login-with-email-link .btn-login-with-email-link")
 			.text({{ _("Send login link") | tojson }}).prop("disabled", false);
-		$("section.for-login-with-email-link .resend-link").hide();
+		$("section.for-login-with-email-link .resend-link").addClass("hidden");
 	});
 
 	$(".form-login-with-email-link").on("submit", function (event) {
@@ -96,7 +96,7 @@ login.bind_events = function () {
 		// (success sends no server message, so the green success banner is unaffected)
 		login.call(args, null, "/", "section.for-login-with-email-link .login-error-banner .es-alert__title").then(() => {
 			$("section:visible .login-success-banner").removeClass("hidden");
-			$("section:visible .resend-link").css("display", "flex");
+			$("section:visible .resend-link").removeClass("hidden");
 			login.set_status({{ _("Sent") | tojson }});
 			$("section:visible .btn-login-with-email-link").prop("disabled", true);
 		}).catch(() => {
@@ -166,7 +166,7 @@ login.reset_sections = function (hide) {
 		$(".form-signup .btn-signup").prop("disabled", true).text({{ _("Create Account") | tojson }});
 		$(".form-login-with-email-link .btn-login-with-email-link").prop("disabled", false).text({{ _("Send login link") | tojson }});
 		$(".btn-login-option.btn-login-with-email-link").prop("disabled", false);
-		$("section.for-login-with-email-link .resend-link").hide();
+		$("section.for-login-with-email-link .resend-link").addClass("hidden");
 	}
 	$('section:not(.signup-disabled) .indicator').each(function () {
 		$(this).removeClass().addClass('indicator').addClass('blue')

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -74,7 +74,6 @@ login.bind_events = function () {
 	});
 
 	$("#login_with_email_link_email").on("input", function () {
-		// the shared input handler clears the banner; only button + resend link reset here
 		$(".form-login-with-email-link .btn-login-with-email-link")
 			.text({{ _("Send login link") | tojson }}).prop("disabled", false);
 		$("section.for-login-with-email-link .resend-link").addClass("hidden");
@@ -89,7 +88,6 @@ login.bind_events = function () {
 			login.show_field_error("login_with_email_link_email", {{ _("Invalid Email.") | tojson }});
 			return false;
 		}
-		// errors land in the error banner via error_msg; success sends no server message
 		login.call(args, null, "/", "section.for-login-with-email-link .login-error-banner .es-alert__title").then(() => {
 			$("section:visible .login-success-banner").removeClass("hidden");
 			$("section:visible .resend-link").removeClass("hidden");
@@ -105,7 +103,6 @@ login.bind_events = function () {
 	$("#signup_fullname, #signup_email").on("input", function () {
 		var name = $("#signup_fullname").val().trim();
 		var email = $("#signup_email").val().trim();
-		// a previous submit may have left "Already Registered" on the button
 		$(".form-signup .btn-signup").text({{ _("Create Account") | tojson }}).prop("disabled", !(name && email));
 	});
 
@@ -228,14 +225,10 @@ login.call = function (args, callback, url="/", error_msg=null) {
 }
 
 login.show_loading = function () {
-	// only the button that triggered the request (falls back to the section's
-	// primary button for keyboard submits); matters when both password and
-	// LDAP login render their own solid button
 	var $btn = $(document.activeElement).filter('section:visible .es-button[data-variant="solid"]');
 	if (!$btn.length) {
 		$btn = $('section:visible .es-button[data-variant="solid"]').first();
 	}
-	// es-button shows the spinner (and blocks clicks) only while aria-busy is set
 	$btn.not("[aria-busy]").each(function () {
 		$(this)
 			.data("label", $(this).text().trim())
@@ -251,7 +244,6 @@ login.hide_loading = function () {
 };
 
 login.set_status = function (message, color) {
-	// the busy button is the one whose request this status answers
 	var $btn = $('section:visible .es-button[aria-busy="true"]');
 	if (!$btn.length) {
 		$btn = $('section:visible .es-button[data-variant="solid"]').first();
@@ -280,18 +272,15 @@ login.set_invalid = function (message) {
 	setTimeout(() => {
 		$(".login-content.page-card").removeClass('invalid-login');
 	}, 500)
-	// forgot: error in a banner + restore its button label
 	if ($("section.for-forgot").is(":visible")) {
 		login.hide_loading();
 		login.show_error_banner(message);
 		return;
 	}
-	// email-link: error in a banner (button reset by the form's own catch)
 	if ($("section.for-login-with-email-link").is(":visible")) {
 		login.show_error_banner(message);
 		return;
 	}
-	// sign-in; the OTP screen has no banner — there the message replaces the button label
 	login.hide_loading();
 	$("section:visible .page-card-body").addClass("invalid");
 	if ($("section:visible .login-error-banner").length) {
@@ -358,11 +347,9 @@ login.login_handlers = (function () {
 				// Always show the same message regardless of whether the account
 				// exists or not, to prevent username enumeration (CWE-204).
 				login.set_status({{ _("Sent") | tojson }}, 'green');
-				// reveal the success banner; its text is filled by the error_msg handler
 				$("section:visible .login-success-banner").removeClass("hidden");
 			} else if (window.location.hash === '#signup') {
 				if (cint(data.message[0]) == 0) {
-					// signup failed (e.g. already registered)
 					login.hide_loading();
 					$("section:visible .login-success-banner").addClass("hidden");
 					login.show_error_banner(data.message[1]);

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -97,7 +97,8 @@ login.bind_events = function () {
 		login.call(args, null, "/", "section.for-login-with-email-link .login-error-banner .es-alert__title").then(() => {
 			$("section:visible .login-success-banner").removeClass("hidden");
 			$("section:visible .resend-link").css("display", "flex");
-			$("section:visible .btn-login-with-email-link").text({{ _("Sent") | tojson }}).prop("disabled", true);
+			login.set_status({{ _("Sent") | tojson }});
+			$("section:visible .btn-login-with-email-link").prop("disabled", true);
 		}).catch(() => {
 			login.set_status({{ _("Send login link") | tojson }}, 'blue');
 		});
@@ -160,6 +161,7 @@ login.reset_sections = function (hide) {
 		$forms.find(".page-card-body").removeClass("invalid");
 		$forms.find(".form-group").removeClass("invalid").find(".field-error").text("");
 		$forms.find(".login-error-banner, .login-success-banner").addClass("hidden");
+		$(".es-button[aria-busy]").removeAttr("aria-busy");
 		$(".form-forgot .btn-forgot").prop("disabled", true).text({{ _("Send Link") | tojson }});
 		$(".form-signup .btn-signup").prop("disabled", true).text({{ _("Create Account") | tojson }});
 		$(".form-login-with-email-link .btn-login-with-email-link").prop("disabled", false).text({{ _("Send login link") | tojson }});
@@ -231,15 +233,25 @@ login.call = function (args, callback, url="/", error_msg=null) {
 }
 
 login.show_loading = function () {
-	// replace the submit button label with the Espresso spinner while the request is
-	// in flight; a later set_status()/reset_sections() call restores the label
-	$('section:visible .btn-primary').html(
-		'<span class="es-spinner" role="status" aria-label="{{ _("Loading") | e }}"></span>'
-	);
+	// swap the visible primary button's label for the Espresso spinner; es-button
+	// only reveals it (and blocks clicks) while aria-busy is set
+	$('section:visible .es-button[data-variant="solid"]:not([aria-busy])').each(function () {
+		$(this)
+			.data("label", $(this).text().trim())
+			.attr("aria-busy", "true")
+			.html('<span class="es-spinner" aria-hidden="true"></span>');
+	});
+};
+
+login.hide_loading = function () {
+	// restore the label saved by show_loading
+	$('.es-button[aria-busy="true"]').each(function () {
+		$(this).removeAttr("aria-busy").text($(this).data("label") || "");
+	});
 };
 
 login.set_status = function (message, color) {
-	$('section:visible .btn-primary').text(message)
+	$('section:visible .es-button[data-variant="solid"]').removeAttr("aria-busy").text(message);
 	if (color == "red") {
 		$('section:visible .page-card-body').addClass("invalid");
 	}
@@ -263,9 +275,9 @@ login.set_invalid = function (message) {
 	setTimeout(() => {
 		$(".login-content.page-card").removeClass('invalid-login');
 	}, 500)
-	// forgot: error in a banner + reset its button (it isn't reset elsewhere)
+	// forgot: error in a banner + restore its button label
 	if ($("section.for-forgot").is(":visible")) {
-		$(".form-forgot .btn-forgot").text({{ _("Send Link") | tojson }});
+		login.hide_loading();
 		login.show_error_banner(message);
 		return;
 	}
@@ -274,8 +286,15 @@ login.set_invalid = function (message) {
 		login.show_error_banner(message);
 		return;
 	}
-	login.set_status(message, 'red');
-	login.show_error_banner(message);
+	// sign-in: restore the button label, flag the fields, error in the banner
+	// (the OTP screen has no banner — there the message replaces the button label)
+	login.hide_loading();
+	$("section:visible .page-card-body").addClass("invalid");
+	if ($("section:visible .login-error-banner").length) {
+		login.show_error_banner(message);
+	} else {
+		login.set_status(message, 'red');
+	}
 	$("#login_password").focus();
 }
 
@@ -340,7 +359,7 @@ login.login_handlers = (function () {
 			} else if (window.location.hash === '#signup') {
 				if (cint(data.message[0]) == 0) {
 					// signup failed (e.g. already registered): show in the banner, restore the button
-					$(".form-signup .btn-signup").text({{ _("Create Account") | tojson }});
+					login.hide_loading();
 					$("section:visible .login-success-banner").addClass("hidden");
 					login.show_error_banner(data.message[1]);
 				} else {
@@ -412,7 +431,7 @@ var request_otp = function (r) {
 				</div>
 				<div id="otp_div"></div>
 				<input type="text" id="login_token" autocomplete="off" class="form-control" placeholder="{{ _("Verification Code") | e }}" required="">
-				<button class="btn btn-sm btn-primary btn-block mt-3" id="verify_token">{{ _("Verify") | e }}</button>
+				<button class="es-button w-full mt-3" data-variant="solid" id="verify_token">{{ _("Verify") | e }}</button>
 			</form>
 		</div>`
 	);

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -34,7 +34,7 @@ login.bind_events = function () {
 
 	$(".page-card-body input").on("input", function () {
 		$(this).closest(".form-group").removeClass("invalid").find(".field-error").text("");
-		$(this).closest(".page-card-body").removeClass("invalid").find(".login-error-banner").hide();
+		$(this).closest(".page-card-body").removeClass("invalid").find(".login-error-banner, .login-success-banner").hide();
 	});
 
 	$(".form-signup").on("submit", function (event) {
@@ -65,19 +65,22 @@ login.bind_events = function () {
 			login.show_field_error("forgot_email", {{ _("Invalid Email.") | tojson }});
 			return false;
 		}
-		login.call(args);
+		// route the server confirmation into the success banner instead of a modal
+		login.call(args, null, "/", "section.for-forgot .login-success-banner span");
 		return false;
 	});
 
 	$("#forgot_email").on("input", function () {
-		$(".btn-forgot").prop("disabled", !$(this).val().trim());
+		// editing the email resets the "Sent" state back to the default label
+		$(".btn-forgot").text({{ _("Send Link") | tojson }}).prop("disabled", !$(this).val().trim());
 	});
 
 	$("#login_with_email_link_email").on("input", function () {
-		// changing the email resets the "Sent" state back to the default
+		// changing the email resets the "Sent" state; the success banner is cleared
+		// by the shared .page-card-body input handler, so only reset the button + resend link here
 		$(".form-login-with-email-link .btn-login-with-email-link")
 			.text({{ _("Send login link") | tojson }}).prop("disabled", false);
-		$("section.for-login-with-email-link .login-success-banner, section.for-login-with-email-link .resend-link").hide();
+		$("section.for-login-with-email-link .resend-link").hide();
 	});
 
 	$(".form-login-with-email-link").on("submit", function (event) {
@@ -89,7 +92,9 @@ login.bind_events = function () {
 			login.show_field_error("login_with_email_link_email", {{ _("Invalid Email.") | tojson }});
 			return false;
 		}
-		login.call(args).then(() => {
+		// route the rate-limit / server error into the banner instead of a modal
+		// (success sends no server message, so the green success banner is unaffected)
+		login.call(args, null, "/", "section.for-login-with-email-link .login-error-banner span").then(() => {
 			$("section:visible .login-success-banner").css("display", "flex");
 			$("section:visible .resend-link").css("display", "flex");
 			$("section:visible .btn-login-with-email-link").text({{ _("Sent") | tojson }}).prop("disabled", true);
@@ -154,12 +159,11 @@ login.reset_sections = function (hide) {
 		$forms.find("input:not([type='submit'])").val("");
 		$forms.find(".page-card-body").removeClass("invalid");
 		$forms.find(".form-group").removeClass("invalid").find(".field-error").text("");
-		$forms.find(".login-error-banner").hide();
+		$forms.find(".login-error-banner, .login-success-banner").hide();
 		$(".form-forgot .btn-forgot").prop("disabled", true).text({{ _("Send Link") | tojson }});
 		$(".form-signup .btn-signup").prop("disabled", true).text({{ _("Create Account") | tojson }});
 		$(".form-login-with-email-link .btn-login-with-email-link").prop("disabled", false).text({{ _("Send login link") | tojson }});
 		$(".btn-login-option.btn-login-with-email-link").prop("disabled", false);
-		$("section.for-login-with-email-link .login-success-banner").hide();
 		$("section.for-login-with-email-link .resend-link").hide();
 	}
 	$('section:not(.signup-disabled) .indicator').each(function () {
@@ -212,8 +216,8 @@ login.signup = function () {
 
 
 // Login
-login.call = function (args, callback, url="/") {
-	login.set_status({{ _("Verifying...") | tojson }}, 'blue');
+login.call = function (args, callback, url="/", error_msg=null) {
+	login.show_loading();
 
 	return frappe.call({
 		type: "POST",
@@ -221,9 +225,18 @@ login.call = function (args, callback, url="/") {
 		args: args,
 		callback: callback,
 		freeze: true,
+		error_msg: error_msg,
 		statusCode: login.login_handlers
 	});
 }
+
+login.show_loading = function () {
+	// replace the submit button label with the Espresso spinner while the request is
+	// in flight; a later set_status()/reset_sections() call restores the label
+	$('section:visible .btn-primary').html(
+		'<span class="es-spinner" role="status" aria-label="{{ _("Loading") | e }}"></span>'
+	);
+};
 
 login.set_status = function (message, color) {
 	$('section:visible .btn-primary').text(message)
@@ -239,6 +252,10 @@ login.show_field_error = function (input_id, message) {
 
 login.show_error_banner = function (message) {
 	$("section:visible .login-error-banner").css("display", "flex").find("span").text(message);
+};
+
+login.show_success_banner = function (message) {
+	$("section:visible .login-success-banner").css("display", "flex").find("span").text(message);
 };
 
 login.set_invalid = function (message) {
@@ -318,14 +335,20 @@ login.login_handlers = (function () {
 				// Always show the same message regardless of whether the account
 				// exists or not, to prevent username enumeration (CWE-204).
 				login.set_status({{ _("Sent") | tojson }}, 'green');
+				// reveal the success banner; its text is filled by the error_msg handler
+				$("section:visible .login-success-banner").css("display", "flex");
 			} else if (window.location.hash === '#signup') {
 				if (cint(data.message[0]) == 0) {
-					login.set_status(data.message[1], 'red');
+					// signup failed (e.g. already registered): show in the banner, restore the button
+					$(".form-signup .btn-signup").text({{ _("Create Account") | tojson }});
+					$("section:visible .login-success-banner").hide();
+					login.show_error_banner(data.message[1]);
 				} else {
 					login.set_status({{ _("Success") | tojson }}, 'green');
-					frappe.msgprint(data.message[1])
+					// show the confirmation in the banner instead of a modal
+					$("section:visible .login-error-banner").hide();
+					login.show_success_banner(data.message[1]);
 				}
-				//login.set_status(__(data.message), 'green');
 			}
 
 			//OTP verification

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -34,7 +34,7 @@ login.bind_events = function () {
 
 	$(".page-card-body input").on("input", function () {
 		$(this).closest(".form-group").removeClass("invalid").find(".field-error").text("");
-		$(this).closest(".page-card-body").removeClass("invalid").find(".login-error-banner, .login-success-banner").hide();
+		$(this).closest(".page-card-body").removeClass("invalid").find(".login-error-banner, .login-success-banner").addClass("hidden");
 	});
 
 	$(".form-signup").on("submit", function (event) {
@@ -66,7 +66,7 @@ login.bind_events = function () {
 			return false;
 		}
 		// route the server confirmation into the success banner instead of a modal
-		login.call(args, null, "/", "section.for-forgot .login-success-banner span");
+		login.call(args, null, "/", "section.for-forgot .login-success-banner .es-alert__title");
 		return false;
 	});
 
@@ -94,8 +94,8 @@ login.bind_events = function () {
 		}
 		// route the rate-limit / server error into the banner instead of a modal
 		// (success sends no server message, so the green success banner is unaffected)
-		login.call(args, null, "/", "section.for-login-with-email-link .login-error-banner span").then(() => {
-			$("section:visible .login-success-banner").css("display", "flex");
+		login.call(args, null, "/", "section.for-login-with-email-link .login-error-banner .es-alert__title").then(() => {
+			$("section:visible .login-success-banner").removeClass("hidden");
 			$("section:visible .resend-link").css("display", "flex");
 			$("section:visible .btn-login-with-email-link").text({{ _("Sent") | tojson }}).prop("disabled", true);
 		}).catch(() => {
@@ -159,7 +159,7 @@ login.reset_sections = function (hide) {
 		$forms.find("input:not([type='submit'])").val("");
 		$forms.find(".page-card-body").removeClass("invalid");
 		$forms.find(".form-group").removeClass("invalid").find(".field-error").text("");
-		$forms.find(".login-error-banner, .login-success-banner").hide();
+		$forms.find(".login-error-banner, .login-success-banner").addClass("hidden");
 		$(".form-forgot .btn-forgot").prop("disabled", true).text({{ _("Send Link") | tojson }});
 		$(".form-signup .btn-signup").prop("disabled", true).text({{ _("Create Account") | tojson }});
 		$(".form-login-with-email-link .btn-login-with-email-link").prop("disabled", false).text({{ _("Send login link") | tojson }});
@@ -251,11 +251,11 @@ login.show_field_error = function (input_id, message) {
 };
 
 login.show_error_banner = function (message) {
-	$("section:visible .login-error-banner").css("display", "flex").find("span").text(message);
+	$("section:visible .login-error-banner").removeClass("hidden").find(".es-alert__title").text(message);
 };
 
 login.show_success_banner = function (message) {
-	$("section:visible .login-success-banner").css("display", "flex").find("span").text(message);
+	$("section:visible .login-success-banner").removeClass("hidden").find(".es-alert__title").text(message);
 };
 
 login.set_invalid = function (message) {
@@ -336,17 +336,17 @@ login.login_handlers = (function () {
 				// exists or not, to prevent username enumeration (CWE-204).
 				login.set_status({{ _("Sent") | tojson }}, 'green');
 				// reveal the success banner; its text is filled by the error_msg handler
-				$("section:visible .login-success-banner").css("display", "flex");
+				$("section:visible .login-success-banner").removeClass("hidden");
 			} else if (window.location.hash === '#signup') {
 				if (cint(data.message[0]) == 0) {
 					// signup failed (e.g. already registered): show in the banner, restore the button
 					$(".form-signup .btn-signup").text({{ _("Create Account") | tojson }});
-					$("section:visible .login-success-banner").hide();
+					$("section:visible .login-success-banner").addClass("hidden");
 					login.show_error_banner(data.message[1]);
 				} else {
 					login.set_status({{ _("Success") | tojson }}, 'green');
 					// show the confirmation in the banner instead of a modal
-					$("section:visible .login-error-banner").hide();
+					$("section:visible .login-error-banner").addClass("hidden");
 					login.show_success_banner(data.message[1]);
 				}
 			}

--- a/frappe/templates/includes/login/macros.html
+++ b/frappe/templates/includes/login/macros.html
@@ -1,0 +1,11 @@
+{%- macro alert_banner(type, text="") -%}
+{%- set is_error = type == "error" -%}
+<div class="login-{{ type }}-banner es-alert hidden" role="alert" data-theme="{{ 'red' if is_error else 'green' }}">
+	<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+		<use href="#icon-{{ 'circle-alert' if is_error else 'circle-check' }}"></use>
+	</svg>
+	<div class="es-alert__content">
+		<span class="es-alert__title">{{ text }}</span>
+	</div>
+</div>
+{%- endmacro %}

--- a/frappe/templates/signup.html
+++ b/frappe/templates/signup.html
@@ -1,21 +1,8 @@
+{% from "templates/includes/login/macros.html" import alert_banner %}
 <form class="form-signin form-signup hide flex flex-col gap-8" role="form" novalidate>
     <div class="page-card-body flex flex-col gap-4">
-        <div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
-            <svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <use href="#icon-circle-check"></use>
-            </svg>
-            <div class="es-alert__content">
-                <span class="es-alert__title"></span>
-            </div>
-        </div>
-        <div class="login-error-banner es-alert hidden" role="alert" data-theme="red">
-            <svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <use href="#icon-circle-alert"></use>
-            </svg>
-            <div class="es-alert__content">
-                <span class="es-alert__title"></span>
-            </div>
-        </div>
+        {{ alert_banner("success") }}
+        {{ alert_banner("error") }}
         <div class="form-group flex flex-col items-start gap-1.5 mb-0">
             <label class="text-base text-ink-gray-5 w-full mb-0" for="signup_fullname">{{ _("Full Name") }}</label>
             <input type="text" id="signup_fullname" class="form-control" placeholder="{{ _('Jane Doe') }}"

--- a/frappe/templates/signup.html
+++ b/frappe/templates/signup.html
@@ -1,4 +1,4 @@
-<form class="form-signin form-signup hide" role="form" novalidate>
+<form class="form-signin form-signup hide flex flex-col gap-4" role="form" novalidate>
     <div class="page-card-body">
         <div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
             <svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -29,7 +29,7 @@
             <p class="field-error text-base text-ink-red-8 mb-0"></p>
         </div>
     </div>
-    <div class="page-card-actions">
+    <div class="page-card-actions flex flex-col gap-3">
         <button class="es-button w-full btn-signup" data-variant="solid"
             type="submit" disabled>{{ _("Create Account") }}</button>
 

--- a/frappe/templates/signup.html
+++ b/frappe/templates/signup.html
@@ -1,13 +1,13 @@
 <form class="form-signin form-signup hide" role="form" novalidate>
     <div class="page-card-body">
         <div class="form-group">
-            <label class="form-label sr-only" for="signup_fullname">{{ _("Full Name") }}</label>
+            <label class="form-label" for="signup_fullname">{{ _("Full Name") }}</label>
             <input type="text" id="signup_fullname" class="form-control" placeholder="{{ _('Jane Doe') }}"
                 required autofocus autocomplete="name">
             <p class="field-error"></p>
         </div>
         <div class="form-group">
-            <label class="form-label sr-only" for="signup_email">{{ _("Email") }}</label>
+            <label class="form-label" for="signup_email">{{ _("Email") }}</label>
             <input type="email" id="signup_email" class="form-control"
                 placeholder="{{ _('jane@example.com') }}" required autocomplete="username">
             <p class="field-error"></p>

--- a/frappe/templates/signup.html
+++ b/frappe/templates/signup.html
@@ -30,7 +30,7 @@
         </div>
     </div>
     <div class="page-card-actions">
-        <button class="btn btn-sm btn-primary btn-block btn-signup"
+        <button class="es-button w-full btn-signup" data-variant="solid"
             type="submit" disabled>{{ _("Create Account") }}</button>
 
         <p class="text-center sign-up-message">

--- a/frappe/templates/signup.html
+++ b/frappe/templates/signup.html
@@ -33,8 +33,8 @@
         <button class="es-button w-full btn-signup" data-variant="solid"
             type="submit" disabled>{{ _("Create Account") }}</button>
 
-        <p class="text-center sign-up-message text-p-sm text-ink-gray-6">
-            <a href="#login" class="blue">{{ _("Have an account? Login") }}</a>
+        <p class="text-center sign-up-message text-p-sm text-ink-gray-6 mt-auto mb-0">
+            <a href="#login" class="text-p-sm-semibold text-ink-gray-6">{{ _("Have an account? Login") }}</a>
         </p>
     </div>
 </form>

--- a/frappe/templates/signup.html
+++ b/frappe/templates/signup.html
@@ -1,5 +1,5 @@
-<form class="form-signin form-signup hide flex flex-col gap-4" role="form" novalidate>
-    <div class="page-card-body">
+<form class="form-signin form-signup hide flex flex-col gap-8" role="form" novalidate>
+    <div class="page-card-body flex flex-col gap-4">
         <div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
             <svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <use href="#icon-circle-check"></use>
@@ -16,13 +16,13 @@
                 <span class="es-alert__title"></span>
             </div>
         </div>
-        <div class="form-group">
+        <div class="form-group flex flex-col items-start gap-1.5 mb-0">
             <label class="text-base text-ink-gray-5 w-full mb-0" for="signup_fullname">{{ _("Full Name") }}</label>
             <input type="text" id="signup_fullname" class="form-control" placeholder="{{ _('Jane Doe') }}"
                 required autofocus autocomplete="name">
             <p class="field-error text-base text-ink-red-8 mb-0"></p>
         </div>
-        <div class="form-group">
+        <div class="form-group flex flex-col items-start gap-1.5 mb-0">
             <label class="text-base text-ink-gray-5 w-full mb-0" for="signup_email">{{ _("Email") }}</label>
             <input type="email" id="signup_email" class="form-control"
                 placeholder="{{ _('jane@example.com') }}" required autocomplete="username">

--- a/frappe/templates/signup.html
+++ b/frappe/templates/signup.html
@@ -1,5 +1,19 @@
 <form class="form-signin form-signup hide" role="form" novalidate>
     <div class="page-card-body">
+        <div class="login-success-banner">
+            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-sm">
+                <use href="#icon-circle-check"></use>
+            </svg>
+            <span></span>
+        </div>
+        <div class="login-error-banner">
+            <div class="flex align-items-center justify-content-center">
+                <svg class="icon icon-sm" xmlns="http://www.w3.org/2000/svg">
+                    <use href="#icon-circle-alert"></use>
+                </svg>
+            </div>
+            <span></span>
+        </div>
         <div class="form-group">
             <label class="form-label" for="signup_fullname">{{ _("Full Name") }}</label>
             <input type="text" id="signup_fullname" class="form-control" placeholder="{{ _('Jane Doe') }}"

--- a/frappe/templates/signup.html
+++ b/frappe/templates/signup.html
@@ -1,18 +1,20 @@
 <form class="form-signin form-signup hide" role="form" novalidate>
     <div class="page-card-body">
-        <div class="login-success-banner">
-            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-sm">
+        <div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
+            <svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <use href="#icon-circle-check"></use>
             </svg>
-            <span></span>
-        </div>
-        <div class="login-error-banner">
-            <div class="flex align-items-center justify-content-center">
-                <svg class="icon icon-sm" xmlns="http://www.w3.org/2000/svg">
-                    <use href="#icon-circle-alert"></use>
-                </svg>
+            <div class="es-alert__content">
+                <span class="es-alert__title"></span>
             </div>
-            <span></span>
+        </div>
+        <div class="login-error-banner es-alert hidden" role="alert" data-theme="red">
+            <svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <use href="#icon-circle-alert"></use>
+            </svg>
+            <div class="es-alert__content">
+                <span class="es-alert__title"></span>
+            </div>
         </div>
         <div class="form-group">
             <label class="form-label" for="signup_fullname">{{ _("Full Name") }}</label>

--- a/frappe/templates/signup.html
+++ b/frappe/templates/signup.html
@@ -17,23 +17,23 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="form-label" for="signup_fullname">{{ _("Full Name") }}</label>
+            <label class="text-base text-ink-gray-5 w-full mb-0" for="signup_fullname">{{ _("Full Name") }}</label>
             <input type="text" id="signup_fullname" class="form-control" placeholder="{{ _('Jane Doe') }}"
                 required autofocus autocomplete="name">
-            <p class="field-error"></p>
+            <p class="field-error text-base text-ink-red-8 mb-0"></p>
         </div>
         <div class="form-group">
-            <label class="form-label" for="signup_email">{{ _("Email") }}</label>
+            <label class="text-base text-ink-gray-5 w-full mb-0" for="signup_email">{{ _("Email") }}</label>
             <input type="email" id="signup_email" class="form-control"
                 placeholder="{{ _('jane@example.com') }}" required autocomplete="username">
-            <p class="field-error"></p>
+            <p class="field-error text-base text-ink-red-8 mb-0"></p>
         </div>
     </div>
     <div class="page-card-actions">
         <button class="es-button w-full btn-signup" data-variant="solid"
             type="submit" disabled>{{ _("Create Account") }}</button>
 
-        <p class="text-center sign-up-message">
+        <p class="text-center sign-up-message text-p-sm text-ink-gray-6">
             <a href="#login" class="blue">{{ _("Have an account? Login") }}</a>
         </p>
     </div>

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -164,19 +164,19 @@ $.extend(frappe, {
 
 		if (data._server_messages) {
 			var server_messages = JSON.parse(data._server_messages || "[]");
-			server_messages
-				.map((msg) => {
-					// temp fix for messages sent as dict
-					try {
-						return JSON.parse(msg);
-					} catch (e) {
-						return msg;
-					}
-				})
-				.join("<br>");
 
 			if (opts.error_msg) {
-				$(opts.error_msg).html(server_messages).toggle(true);
+				var message_html = server_messages
+					.map((msg) => {
+						// temp fix for messages sent as dict
+						try {
+							return JSON.parse(msg).message;
+						} catch (e) {
+							return msg;
+						}
+					})
+					.join("<br>");
+				$(opts.error_msg).html(message_html).toggle(true);
 			} else {
 				frappe.msgprint(server_messages);
 			}

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -168,9 +168,9 @@ $.extend(frappe, {
 			if (opts.error_msg) {
 				var message_html = server_messages
 					.map((msg) => {
-						// temp fix for messages sent as dict
 						try {
-							return JSON.parse(msg).message;
+							const parsed = JSON.parse(msg);
+							return parsed && typeof parsed === "object" ? parsed.message : parsed;
 						} catch (e) {
 							return msg;
 						}

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -86,9 +86,9 @@
 	<img class="app-logo" src="{{ logo }}">
 	<div class="page-card-head-text">
 		{% if title %}
-		<h4 class="text-2xl-bold text-ink-gray-9 w-full mt-0 mb-0">{{ _(title) }}</h4>
+		<h4 class="text-3xl-bold text-ink-gray-9 w-full mt-0 mb-0">{{ _(title) }}</h4>
 		{% else %}
-		<h4 class="text-2xl-bold text-ink-gray-9 w-full mt-0 mb-0">{{ _('Sign In') }}</h4>
+		<h4 class="text-3xl-bold text-ink-gray-9 w-full mt-0 mb-0">{{ _('Sign In') }}</h4>
 		{% endif %}
 		{% if subtitle %}
 		<p class="page-card-subtitle text-p-base text-ink-gray-6 mb-0">{{ _(subtitle) }}</p>

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -1,3 +1,4 @@
+{% from "templates/includes/login/macros.html" import alert_banner %}
 {% extends "templates/web.html" %}
 {% block navbar %}
 {% if show_language_picker %}
@@ -7,14 +8,7 @@
 {% macro email_login_body() -%}
 {% if not disable_user_pass_login or (ldap_settings and ldap_settings.enabled) %}
 <div class="page-card-body flex flex-col gap-4">
-	<div class="login-error-banner es-alert hidden" role="alert" data-theme="red">
-		<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-			<use href="#icon-circle-alert"></use>
-		</svg>
-		<div class="es-alert__content">
-			<span class="es-alert__title"></span>
-		</div>
-	</div>
+	{{ alert_banner("error") }}
 	<div class="form-group flex flex-col items-start gap-1.5 mb-0">
 		<label class="text-base text-ink-gray-5 w-full mb-0" for="login_email">{{ login_label or _("Email")}}</label>
 		<div class="email-field">
@@ -161,22 +155,8 @@
 			{{ logo_section(_('Forgot Password?'), _("Please enter your email, we'll send you password reset link")) }}
 			<form class="form-signin form-forgot hide flex flex-col gap-8" role="form" novalidate>
 				<div class="page-card-body flex flex-col gap-4">
-					<div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
-						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-							<use href="#icon-circle-check"></use>
-						</svg>
-						<div class="es-alert__content">
-							<span class="es-alert__title"></span>
-						</div>
-					</div>
-					<div class="login-error-banner es-alert hidden" role="alert" data-theme="red">
-						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-							<use href="#icon-circle-alert"></use>
-						</svg>
-						<div class="es-alert__content">
-							<span class="es-alert__title"></span>
-						</div>
-					</div>
+					{{ alert_banner("success") }}
+					{{ alert_banner("error") }}
 					<div class="form-group flex flex-col items-start gap-1.5 mb-0">
 						<label class="text-base text-ink-gray-5 w-full mb-0" for="forgot_email">{{ _("Email") }}</label>
 						<div class="email-field">
@@ -202,22 +182,8 @@
 			{{ logo_section(_('Sign In'), _('Welcome! Please sign in to continue.')) }}
 			<form class="form-signin form-login-with-email-link hide flex flex-col gap-8" role="form" novalidate>
 				<div class="page-card-body flex flex-col gap-4">
-					<div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
-						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-							<use href="#icon-circle-check"></use>
-						</svg>
-						<div class="es-alert__content">
-							<span class="es-alert__title">{{ _("Please check your email.") }}</span>
-						</div>
-					</div>
-					<div class="login-error-banner es-alert hidden" role="alert" data-theme="red">
-						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-							<use href="#icon-circle-alert"></use>
-						</svg>
-						<div class="es-alert__content">
-							<span class="es-alert__title"></span>
-						</div>
-					</div>
+					{{ alert_banner("success", _("Please check your email.")) }}
+					{{ alert_banner("error") }}
 					<div class="form-group flex flex-col items-start gap-1.5 mb-0">
 						<label class="text-base text-ink-gray-5 w-full mb-0" for="login_with_email_link_email">{{ _("Email") }}</label>
 						<div class="email-field">

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -16,17 +16,17 @@
 		</div>
 	</div>
 	<div class="form-group">
-		<label class="form-label" for="login_email">{{ login_label or _("Email")}}</label>
+		<label class="text-base text-ink-gray-5 w-full mb-0" for="login_email">{{ login_label or _("Email")}}</label>
 		<div class="email-field">
 			<input type="text" id="login_email" class="form-control"
 				placeholder="{% if login_name_placeholder %}{{ login_name_placeholder  }}{% else %}{{ _('jane@example.com') }}{% endif %}"
 				required autofocus autocomplete="username">
 		</div>
-		<p class="field-error"></p>
+		<p class="field-error text-base text-ink-red-8 mb-0"></p>
 	</div>
 
 	<div class="form-group">
-		<label class="form-label" for="login_password">{{ _("Password") }}</label>
+		<label class="text-base text-ink-gray-5 w-full mb-0" for="login_password">{{ _("Password") }}</label>
 		<div class="password-field">
 			<input type="password" id="login_password" class="form-control" placeholder="••••••••"
 				autocomplete="current-password" required>
@@ -35,10 +35,10 @@
 					<use href="#icon-eye"></use>
 				</svg>
 		</div>
-		<p class="field-error"></p>
+		<p class="field-error text-base text-ink-red-8 mb-0"></p>
 		{% if not disable_user_pass_login %}
-		<p class="forgot-password-message">
-			<a href="#forgot">{{ _("Forgot password?") }}</a>
+		<p class="forgot-password-message text-base text-right w-full mb-0">
+			<a href="#forgot" class="text-ink-gray-5">{{ _("Forgot password?") }}</a>
 		</p>
 		{% endif %}
 	</div>
@@ -59,7 +59,7 @@
 		{{ _("Login with Email Link") }}</a>
 	{% endif %}
 	{% if social_login %}
-	<div class="social-logins text-center">
+	<div class="social-logins text-center text-base">
 		<div class="social-login-buttons">
 			{% for provider in provider_logins %}
 			<div class="login-button-wrapper">
@@ -86,12 +86,12 @@
 	<img class="app-logo" src="{{ logo }}">
 	<div class="page-card-head-text">
 		{% if title %}
-		<h4>{{ _(title) }}</h4>
+		<h4 class="text-2xl-bold text-ink-gray-9 w-full mt-0 mb-0">{{ _(title) }}</h4>
 		{% else %}
-		<h4>{{ _('Sign In') }}</h4>
+		<h4 class="text-2xl-bold text-ink-gray-9 w-full mt-0 mb-0">{{ _('Sign In') }}</h4>
 		{% endif %}
 		{% if subtitle %}
-		<p class="page-card-subtitle">{{ _(subtitle) }}</p>
+		<p class="page-card-subtitle text-p-base text-ink-gray-6 mb-0">{{ _(subtitle) }}</p>
 		{% endif %}
 	</div>
 </div>
@@ -115,7 +115,7 @@
 				{{ email_login_body() }}
 			</form>
 			{%- if not disable_signup and not disable_user_pass_login -%}
-			<div class="text-center sign-up-message">
+			<div class="text-center sign-up-message text-p-sm text-ink-gray-6">
 				{{ _("Don't have an account?") }}
 				<a href="#signup">{{ _("Sign up") }}</a>
 			</div>
@@ -131,7 +131,7 @@
 			{{ email_login_body() }}
 			</form>
 			{%- if not disable_signup and not disable_user_pass_login -%}
-			<div class="text-center sign-up-message">
+			<div class="text-center sign-up-message text-p-sm text-ink-gray-6">
 				{{ _("Don't have an account?") }}
 				<a href="#signup">{{ _("Sign up") }}</a>
 			</div>
@@ -176,12 +176,12 @@
 						</div>
 					</div>
 					<div class="form-group">
-						<label class="form-label" for="forgot_email">{{ _("Email") }}</label>
+						<label class="text-base text-ink-gray-5 w-full mb-0" for="forgot_email">{{ _("Email") }}</label>
 						<div class="email-field">
 							<input type="email" id="forgot_email" class="form-control"
 								placeholder="{{ _('jane@example.com') }}" required autofocus autocomplete="username">
 						</div>
-						<p class="field-error"></p>
+						<p class="field-error text-base text-ink-red-8 mb-0"></p>
 					</div>
 				</div>
 				<div class="page-card-actions">
@@ -189,7 +189,7 @@
 						type="submit" disabled>{{ _("Send Link") }}</button>
 				</div>
 			</form>
-			<div class="text-center sign-up-message">
+			<div class="text-center sign-up-message text-p-sm text-ink-gray-6">
 				<a href="#login">{{ _("Back to sign in") }}</a>
 			</div>
 		</div>
@@ -217,16 +217,16 @@
 						</div>
 					</div>
 					<div class="form-group">
-						<label class="form-label" for="login_with_email_link_email">{{ _("Email") }}</label>
+						<label class="text-base text-ink-gray-5 w-full mb-0" for="login_with_email_link_email">{{ _("Email") }}</label>
 						<div class="email-field">
 							<input type="email" id="login_with_email_link_email" class="form-control"
 								placeholder="{{ _('jane@example.com') }}" required autofocus autocomplete="username">
 						</div>
-						<p class="field-error"></p>
+						<p class="field-error text-base text-ink-red-8 mb-0"></p>
 					</div>
 				</div>
 				<div class="page-card-actions">
-					<p class="resend-link">
+					<p class="resend-link text-base text-ink-gray-6 mb-0">
 						{{ _("Didn't receive the link?") }} <a href="#" class="btn-resend-link">{{ _("Resend") }}</a>
 					</p>
 					<button class="es-button w-full btn-login-with-email-link" data-variant="solid"
@@ -236,7 +236,7 @@
 				</div>
 			</form>
 			{%- if not disable_signup -%}
-			<div class="text-center sign-up-message">
+			<div class="text-center sign-up-message text-p-sm text-ink-gray-6">
 				{{ _("Don't have an account?") }}
 				<a href="#signup">{{ _("Sign up") }}</a>
 			</div>

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% macro email_login_body() -%}
 {% if not disable_user_pass_login or (ldap_settings and ldap_settings.enabled) %}
-<div class="page-card-body">
+<div class="page-card-body flex flex-col gap-4">
 	<div class="login-error-banner es-alert hidden" role="alert" data-theme="red">
 		<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 			<use href="#icon-circle-alert"></use>
@@ -15,7 +15,7 @@
 			<span class="es-alert__title"></span>
 		</div>
 	</div>
-	<div class="form-group">
+	<div class="form-group flex flex-col items-start gap-1.5 mb-0">
 		<label class="text-base text-ink-gray-5 w-full mb-0" for="login_email">{{ login_label or _("Email")}}</label>
 		<div class="email-field">
 			<input type="text" id="login_email" class="form-control"
@@ -25,19 +25,21 @@
 		<p class="field-error text-base text-ink-red-8 mb-0"></p>
 	</div>
 
-	<div class="form-group">
-		<label class="text-base text-ink-gray-5 w-full mb-0" for="login_password">{{ _("Password") }}</label>
-		<div class="password-field">
-			<input type="password" id="login_password" class="form-control" placeholder="••••••••"
-				autocomplete="current-password" required>
+	<div class="form-group flex flex-col items-start gap-2 mb-0">
+		<div class="flex flex-col items-start gap-1.5 w-full">
+			<label class="text-base text-ink-gray-5 w-full mb-0" for="login_password">{{ _("Password") }}</label>
+			<div class="password-field">
+				<input type="password" id="login_password" class="form-control" placeholder="••••••••"
+					autocomplete="current-password" required>
 
-			<svg toggle="#login_password" class="icon icon-sm toggle-password" xmlns="http://www.w3.org/2000/svg">
-					<use href="#icon-eye"></use>
-				</svg>
+				<svg toggle="#login_password" class="icon icon-sm toggle-password" xmlns="http://www.w3.org/2000/svg">
+						<use href="#icon-eye"></use>
+					</svg>
+			</div>
+			<p class="field-error text-base text-ink-red-8 mb-0"></p>
 		</div>
-		<p class="field-error text-base text-ink-red-8 mb-0"></p>
 		{% if not disable_user_pass_login %}
-		<p class="forgot-password-message text-lg text-right w-full mb-0">
+		<p class="text-lg text-right w-full mb-0">
 			<a href="#forgot" class="text-base text-ink-gray-5">{{ _("Forgot password?") }}</a>
 		</p>
 		{% endif %}
@@ -84,7 +86,7 @@
 {% macro logo_section(title=null, subtitle=null) %}
 <div class="page-card-head flex flex-col items-start gap-4 text-left">
 	<img class="app-logo" src="{{ logo }}">
-	<div class="page-card-head-text">
+	<div class="page-card-head-text flex flex-col gap-1.5 w-full">
 		{% if title %}
 		<h4 class="text-3xl-bold text-ink-gray-9 w-full mt-0 mb-0">{{ _(title) }}</h4>
 		{% else %}
@@ -109,9 +111,9 @@
 		</div>
 	</noscript>
 	<section class='for-login'>
-		<div class="login-content page-card">
+		<div class="login-content page-card flex flex-col gap-5">
 			{{ logo_section(_('Sign In'), _('Welcome! Please sign in to continue.')) }}
-			<form class="form-signin form-login flex flex-col gap-4" role="form" novalidate>
+			<form class="form-signin form-login flex flex-col gap-8" role="form" novalidate>
 				{{ email_login_body() }}
 			</form>
 			{%- if not disable_signup and not disable_user_pass_login -%}
@@ -125,9 +127,9 @@
 
 	{%- if social_login -%}
 	<section class='for-email-login'>
-		<div class="login-content page-card">
+		<div class="login-content page-card flex flex-col gap-5">
 			{{ logo_section(_('Sign In'), _('Welcome! Please sign in to continue.')) }}
-			<form class="form-signin form-login flex flex-col gap-4" role="form" novalidate>
+			<form class="form-signin form-login flex flex-col gap-8" role="form" novalidate>
 			{{ email_login_body() }}
 			</form>
 			{%- if not disable_signup and not disable_user_pass_login -%}
@@ -140,7 +142,7 @@
 	</section>
 	{%- endif -%}
 	<section class='for-signup {{ "signup-disabled" if disable_signup else "" }}'>
-		<div class="login-content page-card">
+		<div class="login-content page-card flex flex-col gap-5">
 			{{ logo_section(_('Sign Up'), _("Let's setup your account.")) }}
 			{%- if not disable_signup -%}
 			{{ signup_form_template }}
@@ -155,10 +157,10 @@
 	</section>
 
 	<section class='for-forgot'>
-		<div class="login-content page-card">
+		<div class="login-content page-card flex flex-col gap-5">
 			{{ logo_section(_('Forgot Password?'), _("Please enter your email, we'll send you password reset link")) }}
-			<form class="form-signin form-forgot hide flex flex-col gap-4" role="form" novalidate>
-				<div class="page-card-body">
+			<form class="form-signin form-forgot hide flex flex-col gap-8" role="form" novalidate>
+				<div class="page-card-body flex flex-col gap-4">
 					<div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
 						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 							<use href="#icon-circle-check"></use>
@@ -175,7 +177,7 @@
 							<span class="es-alert__title"></span>
 						</div>
 					</div>
-					<div class="form-group">
+					<div class="form-group flex flex-col items-start gap-1.5 mb-0">
 						<label class="text-base text-ink-gray-5 w-full mb-0" for="forgot_email">{{ _("Email") }}</label>
 						<div class="email-field">
 							<input type="email" id="forgot_email" class="form-control"
@@ -196,10 +198,10 @@
 	</section>
 
 	<section class='for-login-with-email-link'>
-		<div class="login-content page-card">
+		<div class="login-content page-card flex flex-col gap-5">
 			{{ logo_section(_('Sign In'), _('Welcome! Please sign in to continue.')) }}
-			<form class="form-signin form-login-with-email-link hide flex flex-col gap-4" role="form" novalidate>
-				<div class="page-card-body">
+			<form class="form-signin form-login-with-email-link hide flex flex-col gap-8" role="form" novalidate>
+				<div class="page-card-body flex flex-col gap-4">
 					<div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
 						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 							<use href="#icon-circle-check"></use>
@@ -216,7 +218,7 @@
 							<span class="es-alert__title"></span>
 						</div>
 					</div>
-					<div class="form-group">
+					<div class="form-group flex flex-col items-start gap-1.5 mb-0">
 						<label class="text-base text-ink-gray-5 w-full mb-0" for="login_with_email_link_email">{{ _("Email") }}</label>
 						<div class="email-field">
 							<input type="email" id="login_with_email_link_email" class="form-control"

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -21,9 +21,6 @@
 			<input type="text" id="login_email" class="form-control"
 				placeholder="{% if login_name_placeholder %}{{ login_name_placeholder  }}{% else %}{{ _('jane@example.com') }}{% endif %}"
 				required autofocus autocomplete="username">
-			<svg class="icon icon-sm field-icon email-icon" xmlns="http://www.w3.org/2000/svg">
-				<use href="#icon-mail"></use>
-			</svg>
 		</div>
 		<p class="field-error"></p>
 	</div>
@@ -31,13 +28,9 @@
 	<div class="form-group">
 		<label class="form-label" for="login_password">{{ _("Password") }}</label>
 		<div class="password-field">
-			<input type="password" id="login_password" class="form-control" placeholder="•••••"
+			<input type="password" id="login_password" class="form-control" placeholder="••••••••"
 				autocomplete="current-password" required>
 
-			<svg class="icon icon-sm field-icon password-icon"
-				xmlns="http://www.w3.org/2000/svg">
-					<use href="#icon-lock"></use>
-			</svg>
 			<svg toggle="#login_password" class="icon icon-sm toggle-password" xmlns="http://www.w3.org/2000/svg">
 					<use href="#icon-eye"></use>
 				</svg>
@@ -166,15 +159,19 @@
 			{{ logo_section(_('Forgot Password?'), _("Please enter your email, we'll send you password reset link")) }}
 			<form class="form-signin form-forgot hide" role="form" novalidate>
 				<div class="page-card-body">
+					<div class="login-error-banner">
+						<div class="flex align-items-center justify-content-center">
+							<svg class="icon icon-sm" xmlns="http://www.w3.org/2000/svg">
+								<use href="#icon-triangle-alert"></use>
+							</svg>
+						</div>
+						<span></span>
+					</div>
 					<div class="form-group">
 						<label class="form-label" for="forgot_email">{{ _("Email") }}</label>
 						<div class="email-field">
 							<input type="email" id="forgot_email" class="form-control"
 								placeholder="{{ _('jane@example.com') }}" required autofocus autocomplete="username">
-							<svg class="icon icon-sm field-icon email-icon"
-								xmlns="http://www.w3.org/2000/svg">
-								<use href="#icon-mail"></use>
-							</svg>
 						</div>
 						<p class="field-error"></p>
 					</div>
@@ -201,15 +198,19 @@
 						</svg>
 						<span>{{ _("Please check your email.") }}</span>
 					</div>
+					<div class="login-error-banner">
+						<div class="flex align-items-center justify-content-center">
+							<svg class="icon icon-sm" xmlns="http://www.w3.org/2000/svg">
+								<use href="#icon-triangle-alert"></use>
+							</svg>
+						</div>
+						<span></span>
+					</div>
 					<div class="form-group">
 						<label class="form-label" for="login_with_email_link_email">{{ _("Email") }}</label>
 						<div class="email-field">
 							<input type="email" id="login_with_email_link_email" class="form-control"
 								placeholder="{{ _('jane@example.com') }}" required autofocus autocomplete="username">
-							<svg class="icon icon-sm field-icon email-icon"
-								xmlns="http://www.w3.org/2000/svg">
-								<use href="#icon-mail"></use>
-							</svg>
 						</div>
 						<p class="field-error"></p>
 					</div>

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -10,7 +10,7 @@
 	<div class="login-error-banner">
 		<div class="flex align-items-center justify-content-center">
 			<svg class="icon icon-sm" xmlns="http://www.w3.org/2000/svg">
-				<use href="#icon-triangle-alert"></use>
+				<use href="#icon-circle-alert"></use>
 			</svg>
 		</div>
 		<span></span>
@@ -159,10 +159,16 @@
 			{{ logo_section(_('Forgot Password?'), _("Please enter your email, we'll send you password reset link")) }}
 			<form class="form-signin form-forgot hide" role="form" novalidate>
 				<div class="page-card-body">
+					<div class="login-success-banner">
+						<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-sm">
+							<use href="#icon-circle-check"></use>
+						</svg>
+						<span></span>
+					</div>
 					<div class="login-error-banner">
 						<div class="flex align-items-center justify-content-center">
 							<svg class="icon icon-sm" xmlns="http://www.w3.org/2000/svg">
-								<use href="#icon-triangle-alert"></use>
+								<use href="#icon-circle-alert"></use>
 							</svg>
 						</div>
 						<span></span>
@@ -194,14 +200,14 @@
 				<div class="page-card-body">
 					<div class="login-success-banner">
 						<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-sm">
-							<use href="#icon-circle-alert"></use>
+							<use href="#icon-circle-check"></use>
 						</svg>
 						<span>{{ _("Please check your email.") }}</span>
 					</div>
 					<div class="login-error-banner">
 						<div class="flex align-items-center justify-content-center">
 							<svg class="icon icon-sm" xmlns="http://www.w3.org/2000/svg">
-								<use href="#icon-triangle-alert"></use>
+								<use href="#icon-circle-alert"></use>
 							</svg>
 						</div>
 						<span></span>

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -37,14 +37,14 @@
 		</div>
 		<p class="field-error text-base text-ink-red-8 mb-0"></p>
 		{% if not disable_user_pass_login %}
-		<p class="forgot-password-message text-base text-right w-full mb-0">
-			<a href="#forgot" class="text-ink-gray-5">{{ _("Forgot password?") }}</a>
+		<p class="forgot-password-message text-lg text-right w-full mb-0">
+			<a href="#forgot" class="text-base text-ink-gray-5">{{ _("Forgot password?") }}</a>
 		</p>
 		{% endif %}
 	</div>
 </div>
 {% endif %}
-<div class="page-card-actions">
+<div class="page-card-actions flex flex-col gap-3">
 	{% if not disable_user_pass_login %}
 	<button class="es-button w-full" data-variant="solid" type="submit">
 		{{ _("Continue") }}</button>
@@ -82,7 +82,7 @@
 {% endblock %}
 
 {% macro logo_section(title=null, subtitle=null) %}
-<div class="page-card-head">
+<div class="page-card-head flex flex-col items-start gap-4 text-left">
 	<img class="app-logo" src="{{ logo }}">
 	<div class="page-card-head-text">
 		{% if title %}
@@ -111,7 +111,7 @@
 	<section class='for-login'>
 		<div class="login-content page-card">
 			{{ logo_section(_('Sign In'), _('Welcome! Please sign in to continue.')) }}
-			<form class="form-signin form-login" role="form" novalidate>
+			<form class="form-signin form-login flex flex-col gap-4" role="form" novalidate>
 				{{ email_login_body() }}
 			</form>
 			{%- if not disable_signup and not disable_user_pass_login -%}
@@ -127,7 +127,7 @@
 	<section class='for-email-login'>
 		<div class="login-content page-card">
 			{{ logo_section(_('Sign In'), _('Welcome! Please sign in to continue.')) }}
-			<form class="form-signin form-login" role="form" novalidate>
+			<form class="form-signin form-login flex flex-col gap-4" role="form" novalidate>
 			{{ email_login_body() }}
 			</form>
 			{%- if not disable_signup and not disable_user_pass_login -%}
@@ -157,7 +157,7 @@
 	<section class='for-forgot'>
 		<div class="login-content page-card">
 			{{ logo_section(_('Forgot Password?'), _("Please enter your email, we'll send you password reset link")) }}
-			<form class="form-signin form-forgot hide" role="form" novalidate>
+			<form class="form-signin form-forgot hide flex flex-col gap-4" role="form" novalidate>
 				<div class="page-card-body">
 					<div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
 						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -184,7 +184,7 @@
 						<p class="field-error text-base text-ink-red-8 mb-0"></p>
 					</div>
 				</div>
-				<div class="page-card-actions">
+				<div class="page-card-actions flex flex-col gap-3">
 					<button class="es-button w-full btn-forgot" data-variant="solid"
 						type="submit" disabled>{{ _("Send Link") }}</button>
 				</div>
@@ -198,7 +198,7 @@
 	<section class='for-login-with-email-link'>
 		<div class="login-content page-card">
 			{{ logo_section(_('Sign In'), _('Welcome! Please sign in to continue.')) }}
-			<form class="form-signin form-login-with-email-link hide" role="form" novalidate>
+			<form class="form-signin form-login-with-email-link hide flex flex-col gap-4" role="form" novalidate>
 				<div class="page-card-body">
 					<div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
 						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -225,8 +225,8 @@
 						<p class="field-error text-base text-ink-red-8 mb-0"></p>
 					</div>
 				</div>
-				<div class="page-card-actions">
-					<p class="resend-link text-base text-ink-gray-6 mb-0">
+				<div class="page-card-actions flex flex-col gap-3">
+					<p class="resend-link hidden flex items-center gap-2 w-full text-base text-ink-gray-6 mb-0">
 						{{ _("Didn't receive the link?") }} <a href="#" class="btn-resend-link">{{ _("Resend") }}</a>
 					</p>
 					<button class="es-button w-full btn-login-with-email-link" data-variant="solid"

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -117,9 +117,9 @@
 				{{ email_login_body() }}
 			</form>
 			{%- if not disable_signup and not disable_user_pass_login -%}
-			<div class="text-center sign-up-message text-p-sm text-ink-gray-6">
+			<div class="text-center sign-up-message text-p-sm text-ink-gray-6 mt-auto mb-0">
 				{{ _("Don't have an account?") }}
-				<a href="#signup">{{ _("Sign up") }}</a>
+				<a href="#signup" class="text-p-sm-semibold text-ink-gray-6">{{ _("Sign up") }}</a>
 			</div>
 			{%- endif -%}
 		</div>
@@ -133,9 +133,9 @@
 			{{ email_login_body() }}
 			</form>
 			{%- if not disable_signup and not disable_user_pass_login -%}
-			<div class="text-center sign-up-message text-p-sm text-ink-gray-6">
+			<div class="text-center sign-up-message text-p-sm text-ink-gray-6 mt-auto mb-0">
 				{{ _("Don't have an account?") }}
-				<a href="#signup">{{ _("Sign up") }}</a>
+				<a href="#signup" class="text-p-sm-semibold text-ink-gray-6">{{ _("Sign up") }}</a>
 			</div>
 			{%- endif -%}
 		</div>
@@ -191,8 +191,8 @@
 						type="submit" disabled>{{ _("Send Link") }}</button>
 				</div>
 			</form>
-			<div class="text-center sign-up-message text-p-sm text-ink-gray-6">
-				<a href="#login">{{ _("Back to sign in") }}</a>
+			<div class="text-center sign-up-message text-p-sm text-ink-gray-6 mt-auto mb-0">
+				<a href="#login" class="text-p-sm-semibold text-ink-gray-6">{{ _("Back to sign in") }}</a>
 			</div>
 		</div>
 	</section>
@@ -229,7 +229,7 @@
 				</div>
 				<div class="page-card-actions flex flex-col gap-3">
 					<p class="resend-link hidden flex items-center gap-2 w-full text-base text-ink-gray-6 mb-0">
-						{{ _("Didn't receive the link?") }} <a href="#" class="btn-resend-link">{{ _("Resend") }}</a>
+						{{ _("Didn't receive the link?") }} <a href="#" class="btn-resend-link text-base-semibold text-ink-gray-6">{{ _("Resend") }}</a>
 					</p>
 					<button class="es-button w-full btn-login-with-email-link" data-variant="solid"
 						type="submit">{{ _("Send login link") }}</button>
@@ -238,9 +238,9 @@
 				</div>
 			</form>
 			{%- if not disable_signup -%}
-			<div class="text-center sign-up-message text-p-sm text-ink-gray-6">
+			<div class="text-center sign-up-message text-p-sm text-ink-gray-6 mt-auto mb-0">
 				{{ _("Don't have an account?") }}
-				<a href="#signup">{{ _("Sign up") }}</a>
+				<a href="#signup" class="text-p-sm-semibold text-ink-gray-6">{{ _("Sign up") }}</a>
 			</div>
 			{%- endif -%}
 		</div>

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -46,16 +46,16 @@
 {% endif %}
 <div class="page-card-actions">
 	{% if not disable_user_pass_login %}
-	<button class="btn btn-sm btn-default btn-block btn-login" type="submit">
+	<button class="es-button w-full" data-variant="solid" type="submit">
 		{{ _("Continue") }}</button>
 	{% endif %}
 	{% if ldap_settings and ldap_settings.enabled %}
-	<button class="btn btn-sm {{ "btn-primary" if disable_user_pass_login else "btn-default" }} btn-block btn-login btn-ldap-login">
+	<button class="es-button w-full btn-ldap-login" data-variant="solid">
 		{{ _("Login with LDAP") }}</button>
 	{% endif %}
 	{% if login_with_email_link %}
 	<a href="#login-with-email-link"
-		class="btn btn-block btn-default btn-sm btn-login-option btn-login-with-email-link">
+		class="es-button w-full btn-login-option btn-login-with-email-link">
 		{{ _("Login with Email Link") }}</a>
 	{% endif %}
 	{% if social_login %}
@@ -64,7 +64,7 @@
 			{% for provider in provider_logins %}
 			<div class="login-button-wrapper">
 				<a href="{{ provider.auth_url }}"
-					class="btn btn-block btn-default btn-sm btn-login-option btn-{{ provider.name }}">
+					class="es-button w-full btn-login-option btn-{{ provider.name }}">
 					{% if provider.icon %}
 						{{ provider.icon }}
 					{% endif %}
@@ -148,7 +148,7 @@
 			<div class="signup-disabled-message">
 				<span class='indicator gray'>{{_("Signup Disabled")}}</span>
 				<p class="text-muted text-normal sign-up-message mt-1 mb-8">{{_("Signups have been disabled for this website.")}}</p>
-				<div><a href='/' class='btn btn-primary btn-md'>{{ _("Home") }}</a></div>
+				<div><a href='/' class='es-button' data-variant="solid">{{ _("Home") }}</a></div>
 			</div>
 			{%- endif -%}
 		</div>
@@ -185,7 +185,7 @@
 					</div>
 				</div>
 				<div class="page-card-actions">
-					<button class="btn btn-sm btn-primary btn-block btn-signup btn-forgot"
+					<button class="es-button w-full btn-forgot" data-variant="solid"
 						type="submit" disabled>{{ _("Send Link") }}</button>
 				</div>
 			</form>
@@ -229,9 +229,9 @@
 					<p class="resend-link">
 						{{ _("Didn't receive the link?") }} <a href="#" class="btn-resend-link">{{ _("Resend") }}</a>
 					</p>
-					<button class="btn btn-sm btn-primary btn-block btn-login btn-login-with-email-link"
+					<button class="es-button w-full btn-login-with-email-link" data-variant="solid"
 						type="submit">{{ _("Send login link") }}</button>
-					<a href="#login" class="btn btn-sm btn-default btn-block btn-login-option">
+					<a href="#login" class="es-button w-full btn-login-option">
 						{{ _("Login with password") }}</a>
 				</div>
 			</form>

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -7,13 +7,13 @@
 {% macro email_login_body() -%}
 {% if not disable_user_pass_login or (ldap_settings and ldap_settings.enabled) %}
 <div class="page-card-body">
-	<div class="login-error-banner">
-		<div class="flex align-items-center justify-content-center">
-			<svg class="icon icon-sm" xmlns="http://www.w3.org/2000/svg">
-				<use href="#icon-circle-alert"></use>
-			</svg>
+	<div class="login-error-banner es-alert hidden" role="alert" data-theme="red">
+		<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+			<use href="#icon-circle-alert"></use>
+		</svg>
+		<div class="es-alert__content">
+			<span class="es-alert__title"></span>
 		</div>
-		<span></span>
 	</div>
 	<div class="form-group">
 		<label class="form-label" for="login_email">{{ login_label or _("Email")}}</label>
@@ -159,19 +159,21 @@
 			{{ logo_section(_('Forgot Password?'), _("Please enter your email, we'll send you password reset link")) }}
 			<form class="form-signin form-forgot hide" role="form" novalidate>
 				<div class="page-card-body">
-					<div class="login-success-banner">
-						<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-sm">
+					<div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
+						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 							<use href="#icon-circle-check"></use>
 						</svg>
-						<span></span>
-					</div>
-					<div class="login-error-banner">
-						<div class="flex align-items-center justify-content-center">
-							<svg class="icon icon-sm" xmlns="http://www.w3.org/2000/svg">
-								<use href="#icon-circle-alert"></use>
-							</svg>
+						<div class="es-alert__content">
+							<span class="es-alert__title"></span>
 						</div>
-						<span></span>
+					</div>
+					<div class="login-error-banner es-alert hidden" role="alert" data-theme="red">
+						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+							<use href="#icon-circle-alert"></use>
+						</svg>
+						<div class="es-alert__content">
+							<span class="es-alert__title"></span>
+						</div>
 					</div>
 					<div class="form-group">
 						<label class="form-label" for="forgot_email">{{ _("Email") }}</label>
@@ -198,19 +200,21 @@
 			{{ logo_section(_('Sign In'), _('Welcome! Please sign in to continue.')) }}
 			<form class="form-signin form-login-with-email-link hide" role="form" novalidate>
 				<div class="page-card-body">
-					<div class="login-success-banner">
-						<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-sm">
+					<div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
+						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 							<use href="#icon-circle-check"></use>
 						</svg>
-						<span>{{ _("Please check your email.") }}</span>
-					</div>
-					<div class="login-error-banner">
-						<div class="flex align-items-center justify-content-center">
-							<svg class="icon icon-sm" xmlns="http://www.w3.org/2000/svg">
-								<use href="#icon-circle-alert"></use>
-							</svg>
+						<div class="es-alert__content">
+							<span class="es-alert__title">{{ _("Please check your email.") }}</span>
 						</div>
-						<span></span>
+					</div>
+					<div class="login-error-banner es-alert hidden" role="alert" data-theme="red">
+						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+							<use href="#icon-circle-alert"></use>
+						</svg>
+						<div class="es-alert__content">
+							<span class="es-alert__title"></span>
+						</div>
 					</div>
 					<div class="form-group">
 						<label class="form-label" for="login_with_email_link_email">{{ _("Email") }}</label>

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -106,7 +106,7 @@ def get_context(context):
 	if frappe.utils.cint(frappe.get_system_settings("allow_login_using_user_name")):
 		login_label.append(_("Username"))
 
-	context["login_label"] = f" {_('or')} ".join(login_label)
+	context["login_label"] = " / ".join(login_label)
 
 	context["login_with_email_link"] = frappe.get_system_settings("login_with_email_link")
 

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -211,8 +211,7 @@ frappe.ready(function() {
 		return false;
 	});
 
-	// hint appears only while typing an incomplete password, and goes away once it
-	// fulfils the instruction (min 8 chars + a number or special character) or is empty
+	// hint shows only while the typed password doesn't meet the rule yet
 	const fulfills_instruction = (pwd) => pwd.length >= 8 && /[0-9]|[^A-Za-z0-9]/.test(pwd);
 
 	new_password.on('input', function() {
@@ -246,7 +245,7 @@ frappe.ready(function() {
 		},500)
 	)
 
-	// strength label + colour (ink token utility class) by zxcvbn score (0-4)
+	// strength label + colour by zxcvbn score (0-4)
 	const strength_map = {
 		0: { label: "{{ _('Poor') }}",    color: "text-ink-red-8"    },
 		1: { label: "{{ _('Poor') }}",    color: "text-ink-red-8"    },
@@ -296,7 +295,7 @@ frappe.ready(function() {
 			.text(config.label)
 			.attr('class', 'password-strength-value text-sm-medium ' + config.color);
 
-		// declutter: once the password is great, hide the indicator after a few seconds
+		// auto-hide shortly after reaching Great
 		if (score === 4) {
 			window.strength_hide_timeout = setTimeout(function() {
 				password_strength_indicator.addClass('hidden');

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -1,3 +1,4 @@
+{% from "templates/includes/login/macros.html" import alert_banner %}
 {% extends "templates/web.html" %}
 
 {% block title %} {{ _("Set Password") }} {% endblock %}
@@ -22,22 +23,8 @@
 			</div>
 			<form id="reset-password" class="flex flex-col gap-8" novalidate>
 				<div class="page-card-body flex flex-col gap-4">
-					<div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
-						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-							<use href="#icon-circle-check"></use>
-						</svg>
-						<div class="es-alert__content">
-							<span class="es-alert__title"></span>
-						</div>
-					</div>
-					<div class="login-error-banner es-alert hidden" role="alert" data-theme="red">
-						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-							<use href="#icon-circle-alert"></use>
-						</svg>
-						<div class="es-alert__content">
-							<span class="es-alert__title"></span>
-						</div>
-					</div>
+					{{ alert_banner("success") }}
+					{{ alert_banner("error") }}
 					<div class="form-group flex flex-col items-start gap-1.5 mb-0">
 						<label class="text-base text-ink-gray-5 w-full mb-0" for="old_password">{{ _("Old Password") }}</label>
 						<div class="password-field">

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -12,17 +12,17 @@
 {% block page_content %}
 <div>
 	<section class="for-reset-password">
-		<div class="login-content page-card">
+		<div class="login-content page-card flex flex-col gap-5">
 			<div class="page-card-head flex flex-col items-start gap-4 text-left">
 				<img class="app-logo" src="{{ logo }}">
-				<div class="page-card-head-text">
+				<div class="page-card-head-text flex flex-col gap-1.5 w-full">
 					<h4 class="text-3xl-bold text-ink-gray-9 w-full mt-0 mb-0">{{ _("Set Password") }}</h4>
 					<p class="page-card-subtitle text-p-base text-ink-gray-6 mb-0">{{ _("Use strong passwords.") }}</p>
 				</div>
 			</div>
-			<form id="reset-password" class="flex flex-col gap-4" novalidate>
-				<div class="page-card-body">
-					<div class="form-group">
+			<form id="reset-password" class="flex flex-col gap-8" novalidate>
+				<div class="page-card-body flex flex-col gap-4">
+					<div class="form-group flex flex-col items-start gap-1.5 mb-0">
 						<label class="text-base text-ink-gray-5 w-full mb-0" for="old_password">{{ _("Old Password") }}</label>
 						<div class="password-field">
 							<input id="old_password" type="password" class="form-control"
@@ -36,7 +36,7 @@
 							</svg>
 						</div>
 					</div>
-					<div class="form-group">
+					<div class="form-group flex flex-col items-start gap-1.5 mb-0">
 						<div class="flex justify-between items-center gap-2 w-full">
 							<label class="text-base text-ink-gray-5 mb-0" for="new_password">{{ _("New Password") }}</label>
 							<span class="password-strength-indicator hidden text-p-sm text-ink-gray-5 whitespace-nowrap">
@@ -58,7 +58,7 @@
 							{{ _("Minimum 8 characters, including at least one number or special character.") }}
 						</p>
 					</div>
-					<div class="form-group">
+					<div class="form-group flex flex-col items-start gap-1.5 mb-0">
 						<label class="text-base text-ink-gray-5 w-full mb-0" for="confirm_password">{{ _("Confirm New Password") }}</label>
 						<div class="password-field">
 							<input id="confirm_password" type="password" class="form-control"

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -189,7 +189,6 @@ frappe.ready(function() {
 			method: "frappe.core.doctype.user.user.update_password",
 			btn: update_button,
 			args: args,
-			// route server messages into the error banner instead of a modal
 			error_msg: "section.for-reset-password .login-error-banner .es-alert__title",
 			statusCode: {
 				401: function() {
@@ -210,8 +209,6 @@ frappe.ready(function() {
 				}
 			}
 		}).catch(function() {
-			// statuses without a handler above (e.g. 417): error_msg has written the
-			// server message into the banner — reveal it if there is one
 			if (error_banner.find(".es-alert__title").text().trim()) {
 				error_banner.removeClass("hidden");
 			}
@@ -220,7 +217,6 @@ frappe.ready(function() {
 		return false;
 	});
 
-	// hint shows only while the typed password doesn't meet the rule yet
 	const fulfills_instruction = (pwd) => pwd.length >= 8 && /[0-9]|[^A-Za-z0-9]/.test(pwd);
 
 	new_password.on('input', function() {
@@ -254,7 +250,6 @@ frappe.ready(function() {
 		},500)
 	)
 
-	// strength label + colour by zxcvbn score (0-4)
 	const strength_map = {
 		0: { label: "{{ _('Poor') }}",    color: "text-ink-red-8"    },
 		1: { label: "{{ _('Poor') }}",    color: "text-ink-red-8"    },
@@ -304,7 +299,6 @@ frappe.ready(function() {
 			.text(config.label)
 			.attr('class', 'password-strength-value text-sm-medium ' + config.color);
 
-		// auto-hide shortly after reaching Great
 		if (score === 4) {
 			window.strength_hide_timeout = setTimeout(function() {
 				password_strength_indicator.addClass('hidden');

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -13,21 +13,21 @@
 <div>
 	<section class="for-reset-password">
 		<div class="login-content page-card">
-			<div class="page-card-head">
+			<div class="page-card-head flex flex-col items-start gap-4 text-left">
 				<img class="app-logo" src="{{ logo }}">
 				<div class="page-card-head-text">
 					<h4 class="text-2xl-bold text-ink-gray-9 w-full mt-0 mb-0">{{ _("Set Password") }}</h4>
 					<p class="page-card-subtitle text-p-base text-ink-gray-6 mb-0">{{ _("Use strong passwords.") }}</p>
 				</div>
 			</div>
-			<form id="reset-password" novalidate>
+			<form id="reset-password" class="flex flex-col gap-4" novalidate>
 				<div class="page-card-body">
 					<div class="form-group">
 						<label class="text-base text-ink-gray-5 w-full mb-0" for="old_password">{{ _("Old Password") }}</label>
 						<div class="password-field">
 							<input id="old_password" type="password" class="form-control"
 								placeholder="••••••••" autocomplete="current-password">
-							<svg class="icon icon-sm field-icon password-icon"
+							<svg class="icon icon-sm field-icon"
 								xmlns="http://www.w3.org/2000/svg">
 								<use href="#icon-lock"></use>
 							</svg>
@@ -37,7 +37,7 @@
 						</div>
 					</div>
 					<div class="form-group">
-						<div class="password-label-row">
+						<div class="flex justify-between items-center gap-2 w-full">
 							<label class="text-base text-ink-gray-5 mb-0" for="new_password">{{ _("New Password") }}</label>
 							<span class="password-strength-indicator hidden text-p-sm text-ink-gray-5 whitespace-nowrap">
 								{{ _("Strength:") }} <span class="password-strength-value text-sm-medium"></span>
@@ -46,7 +46,7 @@
 						<div class="password-field">
 							<input type="password" id="new_password" class="form-control"
 								placeholder="••••••••" autocomplete="new-password">
-							<svg class="icon icon-sm field-icon password-icon"
+							<svg class="icon icon-sm field-icon"
 								xmlns="http://www.w3.org/2000/svg">
 								<use href="#icon-lock"></use>
 							</svg>
@@ -63,7 +63,7 @@
 						<div class="password-field">
 							<input id="confirm_password" type="password" class="form-control"
 								placeholder="••••••••" autocomplete="new-password">
-							<svg class="icon icon-sm field-icon password-icon"
+							<svg class="icon icon-sm field-icon"
 								xmlns="http://www.w3.org/2000/svg">
 								<use href="#icon-lock"></use>
 							</svg>
@@ -74,7 +74,7 @@
 						<p class="password-mismatch-message hidden text-p-sm mb-0"></p>
 					</div>
 				</div>
-				<div class="page-card-actions">
+				<div class="page-card-actions flex flex-col gap-3">
 					<button type="submit" id="update" disabled
 						class="es-button w-full" data-variant="solid">
 						{{ _("Confirm") }}

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -16,14 +16,14 @@
 			<div class="page-card-head">
 				<img class="app-logo" src="{{ logo }}">
 				<div class="page-card-head-text">
-					<h4>{{ _("Set Password") }}</h4>
-					<p class="page-card-subtitle">{{ _("Use strong passwords.") }}</p>
+					<h4 class="text-2xl-bold text-ink-gray-9 w-full mt-0 mb-0">{{ _("Set Password") }}</h4>
+					<p class="page-card-subtitle text-p-base text-ink-gray-6 mb-0">{{ _("Use strong passwords.") }}</p>
 				</div>
 			</div>
 			<form id="reset-password" novalidate>
 				<div class="page-card-body">
 					<div class="form-group">
-						<label class="form-label" for="old_password">{{ _("Old Password") }}</label>
+						<label class="text-base text-ink-gray-5 w-full mb-0" for="old_password">{{ _("Old Password") }}</label>
 						<div class="password-field">
 							<input id="old_password" type="password" class="form-control"
 								placeholder="••••••••" autocomplete="current-password">
@@ -38,9 +38,9 @@
 					</div>
 					<div class="form-group">
 						<div class="password-label-row">
-							<label class="form-label" for="new_password">{{ _("New Password") }}</label>
-							<span class="password-strength-indicator hidden">
-								{{ _("Strength:") }} <span class="password-strength-value"></span>
+							<label class="text-base text-ink-gray-5 mb-0" for="new_password">{{ _("New Password") }}</label>
+							<span class="password-strength-indicator hidden text-p-sm text-ink-gray-5 whitespace-nowrap">
+								{{ _("Strength:") }} <span class="password-strength-value text-sm-medium"></span>
 							</span>
 						</div>
 						<div class="password-field">
@@ -54,12 +54,12 @@
 								<use href="#icon-eye"></use>
 							</svg>
 						</div>
-						<p class="password-hint hidden">
+						<p class="password-hint hidden text-p-sm text-ink-gray-5 mb-0">
 							{{ _("Minimum 8 characters, including at least one number or special character.") }}
 						</p>
 					</div>
 					<div class="form-group">
-						<label class="form-label" for="confirm_password">{{ _("Confirm New Password") }}</label>
+						<label class="text-base text-ink-gray-5 w-full mb-0" for="confirm_password">{{ _("Confirm New Password") }}</label>
 						<div class="password-field">
 							<input id="confirm_password" type="password" class="form-control"
 								placeholder="••••••••" autocomplete="new-password">
@@ -71,7 +71,7 @@
 								<use href="#icon-eye"></use>
 							</svg>
 						</div>
-						<p class="password-mismatch-message hidden"></p>
+						<p class="password-mismatch-message hidden text-p-sm mb-0"></p>
 					</div>
 				</div>
 				<div class="page-card-actions">
@@ -81,7 +81,7 @@
 					</button>
 				</div>
 			</form>
-			<div class="text-center sign-up-message">
+			<div class="text-center sign-up-message text-p-sm text-ink-gray-6">
 				<a href="/login">{{ _("Back to sign in") }}</a>
 			</div>
 		</div>

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -16,7 +16,7 @@
 			<div class="page-card-head flex flex-col items-start gap-4 text-left">
 				<img class="app-logo" src="{{ logo }}">
 				<div class="page-card-head-text">
-					<h4 class="text-2xl-bold text-ink-gray-9 w-full mt-0 mb-0">{{ _("Set Password") }}</h4>
+					<h4 class="text-3xl-bold text-ink-gray-9 w-full mt-0 mb-0">{{ _("Set Password") }}</h4>
 					<p class="page-card-subtitle text-p-base text-ink-gray-6 mb-0">{{ _("Use strong passwords.") }}</p>
 				</div>
 			</div>

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -22,6 +22,22 @@
 			</div>
 			<form id="reset-password" class="flex flex-col gap-8" novalidate>
 				<div class="page-card-body flex flex-col gap-4">
+					<div class="login-success-banner es-alert hidden" role="alert" data-theme="green">
+						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+							<use href="#icon-circle-check"></use>
+						</svg>
+						<div class="es-alert__content">
+							<span class="es-alert__title"></span>
+						</div>
+					</div>
+					<div class="login-error-banner es-alert hidden" role="alert" data-theme="red">
+						<svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+							<use href="#icon-circle-alert"></use>
+						</svg>
+						<div class="es-alert__content">
+							<span class="es-alert__title"></span>
+						</div>
+					</div>
 					<div class="form-group flex flex-col items-start gap-1.5 mb-0">
 						<label class="text-base text-ink-gray-5 w-full mb-0" for="old_password">{{ _("Old Password") }}</label>
 						<div class="password-field">
@@ -81,8 +97,8 @@
 					</button>
 				</div>
 			</form>
-			<div class="text-center sign-up-message text-p-sm text-ink-gray-6">
-				<a href="/login">{{ _("Back to sign in") }}</a>
+			<div class="text-center sign-up-message text-p-sm text-ink-gray-6 mt-auto mb-0">
+				<a href="/login" class="text-p-sm-semibold text-ink-gray-6">{{ _("Back to sign in") }}</a>
 			</div>
 		</div>
 	</section>
@@ -104,6 +120,18 @@ frappe.ready(function() {
 	const password_mismatch_message = $('.password-mismatch-message');
 	const password_hint = $('.password-hint');
 	const password_strength_indicator = $('.password-strength-indicator');
+	const error_banner = $('.login-error-banner');
+	const success_banner = $('.login-success-banner');
+
+	function show_error_banner(message) {
+		success_banner.addClass('hidden');
+		error_banner.removeClass('hidden').find('.es-alert__title').text(message);
+	}
+
+	function show_success_banner(message) {
+		error_banner.addClass('hidden');
+		success_banner.removeClass('hidden').find('.es-alert__title').text(message);
+	}
 	// Info text
 	const password_not_same_as_old_password = "{{ _('New password cannot be same as old password') }}";
 	const password_mismatch = "{{ _('Passwords do not match') }}";
@@ -115,6 +143,11 @@ frappe.ready(function() {
 	if(password_expired) {
 		$('.page-card-subtitle').text("{{ _('Your password has expired. Please set a new password.') }}");
 	}
+
+	$("#reset-password input").on("input", function() {
+		error_banner.addClass("hidden");
+		success_banner.addClass("hidden");
+	});
 
 	$(".toggle-password").click(function() {
 		var input = $($(this).attr("toggle"));
@@ -132,24 +165,13 @@ frappe.ready(function() {
 			logout_all_sessions: 1
 		}
 		if (!args.old_password && !args.key) {
-			frappe.msgprint({
-				title: "{{ _('Missing Value') }}",
-				message: "{{ _('Please enter your old password.') }}",
-				clear: true
-			});
+			show_error_banner("{{ _('Please enter your old password.') }}");
 		}
 		if (!args.new_password) {
-			frappe.msgprint({
-				title: "{{ _('Missing Value') }}",
-				message: "{{ _('Please enter your new password.') }}",
-				clear: true
-			});
+			show_error_banner("{{ _('Please enter your new password.') }}");
 		}
 		if (args.old_password === args.new_password) {
-			frappe.msgprint({
-				title: "{{ _('Invalid Password') }}",
-				message: password_not_same_as_old_password,
-			});
+			show_error_banner(password_not_same_as_old_password);
 			return;
 		}
 
@@ -164,31 +186,20 @@ frappe.ready(function() {
 			method: "frappe.core.doctype.user.user.update_password",
 			btn: update_button,
 			args: args,
+			// route server messages into the error banner instead of a modal
+			error_msg: "section.for-reset-password .login-error-banner .es-alert__title",
 			statusCode: {
 				401: function() {
-					frappe.msgprint({
-						title: "{{ _('Invalid Password') }}",
-						message: "{{ _('Your old password is incorrect.') }}",
-						// clear any server message
-						clear: true
-					});
+					show_error_banner("{{ _('Your old password is incorrect.') }}");
 				},
 				410: function({ responseJSON }) {
-					const title = "{{ _('Invalid Link') }}";
-					const message = responseJSON.message;
-					frappe.msgprint({ title: title, message: message, clear: true });
+					show_error_banner(responseJSON.message);
 				},
 				200: function(r) {
 					$("input").val("");
 					password_strength_indicator.addClass("hidden");
 					if(r.message) {
-						frappe.msgprint({
-							title: "{{ _('Password set') }}",
-							message: "{{ _('Your new password has been set successfully.') }}",
-							// password is updated successfully
-							// clear any server message
-							clear: true
-						});
+						show_success_banner("{{ _('Your new password has been set successfully.') }}");
 						setTimeout(function() {
 							window.location.href = r.message;
 						}, 2000);
@@ -235,13 +246,13 @@ frappe.ready(function() {
 		},500)
 	)
 
-	// strength label + colour by zxcvbn score (0-4)
+	// strength label + colour (ink token utility class) by zxcvbn score (0-4)
 	const strength_map = {
-		0: { label: "{{ _('Poor') }}",    color: "red"    },
-		1: { label: "{{ _('Poor') }}",    color: "red"    },
-		2: { label: "{{ _('Average') }}", color: "orange" },
-		3: { label: "{{ _('Good') }}",    color: "blue"   },
-		4: { label: "{{ _('Great') }}",   color: "green"  },
+		0: { label: "{{ _('Poor') }}",    color: "text-ink-red-8"    },
+		1: { label: "{{ _('Poor') }}",    color: "text-ink-red-8"    },
+		2: { label: "{{ _('Average') }}", color: "text-ink-orange-8" },
+		3: { label: "{{ _('Good') }}",    color: "text-ink-blue-8"   },
+		4: { label: "{{ _('Great') }}",   color: "text-ink-green-8"  },
 	};
 
 	window.test_password_strength = function() {
@@ -283,7 +294,7 @@ frappe.ready(function() {
 			.removeClass('hidden')
 			.find('.password-strength-value')
 			.text(config.label)
-			.attr('class', 'password-strength-value strength-' + config.color);
+			.attr('class', 'password-strength-value text-sm-medium ' + config.color);
 
 		// declutter: once the password is great, hide the indicator after a few seconds
 		if (score === 4) {

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -76,7 +76,7 @@
 				</div>
 				<div class="page-card-actions">
 					<button type="submit" id="update" disabled
-						class="btn btn-sm btn-block btn-signup">
+						class="es-button w-full" data-variant="solid">
 						{{ _("Confirm") }}
 					</button>
 				</div>

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -43,10 +43,6 @@
 						<div class="password-field">
 							<input id="old_password" type="password" class="form-control"
 								placeholder="••••••••" autocomplete="current-password">
-							<svg class="icon icon-sm field-icon"
-								xmlns="http://www.w3.org/2000/svg">
-								<use href="#icon-lock"></use>
-							</svg>
 							<svg toggle="#old_password" class="icon icon-sm toggle-password" xmlns="http://www.w3.org/2000/svg">
 								<use href="#icon-eye"></use>
 							</svg>
@@ -62,10 +58,6 @@
 						<div class="password-field">
 							<input type="password" id="new_password" class="form-control"
 								placeholder="••••••••" autocomplete="new-password">
-							<svg class="icon icon-sm field-icon"
-								xmlns="http://www.w3.org/2000/svg">
-								<use href="#icon-lock"></use>
-							</svg>
 							<svg toggle="#new_password" class="icon icon-sm toggle-password" xmlns="http://www.w3.org/2000/svg">
 								<use href="#icon-eye"></use>
 							</svg>
@@ -79,10 +71,6 @@
 						<div class="password-field">
 							<input id="confirm_password" type="password" class="form-control"
 								placeholder="••••••••" autocomplete="new-password">
-							<svg class="icon icon-sm field-icon"
-								xmlns="http://www.w3.org/2000/svg">
-								<use href="#icon-lock"></use>
-							</svg>
 							<svg toggle="#confirm_password" class="icon icon-sm toggle-password" xmlns="http://www.w3.org/2000/svg">
 								<use href="#icon-eye"></use>
 							</svg>

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -26,7 +26,7 @@
 						<label class="form-label" for="old_password">{{ _("Old Password") }}</label>
 						<div class="password-field">
 							<input id="old_password" type="password" class="form-control"
-								placeholder="•••••" autocomplete="current-password">
+								placeholder="••••••••" autocomplete="current-password">
 							<svg class="icon icon-sm field-icon password-icon"
 								xmlns="http://www.w3.org/2000/svg">
 								<use href="#icon-lock"></use>
@@ -37,10 +37,15 @@
 						</div>
 					</div>
 					<div class="form-group">
-						<label class="form-label" for="new_password">{{ _("New Password") }}</label>
+						<div class="password-label-row">
+							<label class="form-label" for="new_password">{{ _("New Password") }}</label>
+							<span class="password-strength-indicator hidden">
+								{{ _("Strength:") }} <span class="password-strength-value"></span>
+							</span>
+						</div>
 						<div class="password-field">
 							<input type="password" id="new_password" class="form-control"
-								placeholder="----" autocomplete="new-password">
+								placeholder="••••••••" autocomplete="new-password">
 							<svg class="icon icon-sm field-icon password-icon"
 								xmlns="http://www.w3.org/2000/svg">
 								<use href="#icon-lock"></use>
@@ -49,27 +54,15 @@
 								<use href="#icon-eye"></use>
 							</svg>
 						</div>
-						<div class="password-strength-group">
-							<div class="password-strength-container hidden">
-								<div class="password-strength-label"></div>
-								<div class="password-strength-bar-track">
-									<div class="password-strength-bar-fill"></div>
-								</div>
-							</div>
-							<p class="password-hint">
-								<svg class="icon icon-sm" xmlns="http://www.w3.org/2000/svg">
-									<use href="#icon-circle-alert"></use>
-								</svg>
-								{{ _("Use minimum of 8 characters (case sensitive) with at least one number or special character.") }}
-							</p>
-							<p class="password-strength-message hidden"></p>
-						</div>
+						<p class="password-hint hidden">
+							{{ _("Minimum 8 characters, including at least one number or special character.") }}
+						</p>
 					</div>
 					<div class="form-group">
 						<label class="form-label" for="confirm_password">{{ _("Confirm New Password") }}</label>
 						<div class="password-field">
 							<input id="confirm_password" type="password" class="form-control"
-								placeholder="•••••" autocomplete="new-password">
+								placeholder="••••••••" autocomplete="new-password">
 							<svg class="icon icon-sm field-icon password-icon"
 								xmlns="http://www.w3.org/2000/svg">
 								<use href="#icon-lock"></use>
@@ -108,8 +101,9 @@ frappe.ready(function() {
 	const new_password = $('#new_password');
 	const confirm_password = $('#confirm_password');
 	const update_button = $('#update');
-	const password_strength_message = $('.password-strength-message');
 	const password_mismatch_message = $('.password-mismatch-message');
+	const password_hint = $('.password-hint');
+	const password_strength_indicator = $('.password-strength-indicator');
 	// Info text
 	const password_not_same_as_old_password = "{{ _('New password cannot be same as old password') }}";
 	const password_mismatch = "{{ _('Passwords do not match') }}";
@@ -156,14 +150,12 @@ frappe.ready(function() {
 				title: "{{ _('Invalid Password') }}",
 				message: password_not_same_as_old_password,
 			});
-			password_strength_message.addClass('hidden');
 			return;
 		}
 
 		if (args.new_password !== args.confirm_password) {
 			password_mismatch_message.text(password_mismatch)
 				.removeClass('hidden text-muted').addClass('text-danger');
-			password_strength_message.addClass('hidden');
 			return;
 		}
 
@@ -188,8 +180,7 @@ frappe.ready(function() {
 				},
 				200: function(r) {
 					$("input").val("");
-					$('.password-strength-container').addClass('hidden');
-					strength_message.addClass("hidden");
+					password_strength_indicator.addClass("hidden");
 					if(r.message) {
 						frappe.msgprint({
 							title: "{{ _('Password set') }}",
@@ -209,9 +200,13 @@ frappe.ready(function() {
 		return false;
 	});
 
-	window.strength_message = password_strength_message;
+	// hint appears only while typing an incomplete password, and goes away once it
+	// fulfils the instruction (min 8 chars + a number or special character) or is empty
+	const fulfills_instruction = (pwd) => pwd.length >= 8 && /[0-9]|[^A-Za-z0-9]/.test(pwd);
 
-	new_password.on('keyup', function() {
+	new_password.on('input', function() {
+		const val = new_password.val();
+		password_hint.toggleClass('hidden', !(val && !fulfills_instruction(val)));
 		window.clear_timeout();
 		window.timout_password_strength = setTimeout(window.test_password_strength, 200);
 	});
@@ -222,23 +217,14 @@ frappe.ready(function() {
 		if (new_password.val() && old_password.val() === new_password.val()) {
 			password_mismatch_message.text(password_not_same_as_old_password)
 				.removeClass("hidden text-muted").addClass("text-danger");
-
-			password_strength_message.addClass("hidden");
 		}
 		if ((new_password.val() || old_password.val) && old_password.val() !== new_password.val()) {
 			password_mismatch_message.addClass("hidden");
-			password_strength_message.removeClass("hidden");
 			password_mismatch_message.text('')
-		}
-
-		if (new_password.val() === confirm_password.val() && old_password.val() !== new_password.val() ) {
-			password_mismatch_message.addClass("hidden");
-			password_strength_message.removeClass("hidden");
 		}
 		if (confirm_password.val() &&  new_password.val() !== confirm_password.val()) {
 			password_mismatch_message.text(password_mismatch)
 				.removeClass("hidden text-muted").addClass("text-danger");
-			password_strength_message.addClass("hidden");
 		}
 		if ((key || (!key && old_password.val() )) && common_conditions ) {
 			update_button.prop("disabled", false).css("cursor", "pointer");
@@ -249,65 +235,62 @@ frappe.ready(function() {
 		},500)
 	)
 
+	// strength label + colour by zxcvbn score (0-4)
+	const strength_map = {
+		0: { label: "{{ _('Poor') }}",    color: "red"    },
+		1: { label: "{{ _('Poor') }}",    color: "red"    },
+		2: { label: "{{ _('Average') }}", color: "orange" },
+		3: { label: "{{ _('Good') }}",    color: "blue"   },
+		4: { label: "{{ _('Great') }}",   color: "green"  },
+	};
+
 	window.test_password_strength = function() {
 		window.timout_password_strength = null;
 
-		var args = {
-			key: key || "",
-			old_password: old_password.val(),
-			new_password: new_password.val()
-		}
-
-		if (!args.new_password) {
-			set_strength_indicator('grey', {'warning': "{{ _('Please enter the password') }}" });
+		if (!new_password.val()) {
+			set_strength_indicator(null);
 			return;
 		}
 
 		return frappe.call({
 			method: 'frappe.core.doctype.user.user.test_password_strength',
-			args: args,
+			args: {
+				key: key || "",
+				old_password: old_password.val(),
+				new_password: new_password.val()
+			},
 			statusCode: {
 				401: function() {},
 				200: function(r) {
 					if (r.message && r.message.score !== undefined && r.message.score !== null) {
-						var score = r.message.score;
-						var feedback = r.message.feedback || {};
-						var colors = ["red", "red", "orange", "blue", "green"];
-						feedback.score = score;
-						set_strength_indicator(colors[score], feedback);
+						set_strength_indicator(r.message.score);
 					}
 				}
 			}
 		});
 	};
 
-	window.set_strength_indicator = function(color, feedback) {
-		var strength_map = {
-			red:    { label: "{{ _('Poor!') }}",   percentage: 25  },
-			orange: { label: "{{ _('Average') }}", percentage: 50  },
-			blue:   { label: "{{ _('Good') }}",    percentage: 75  },
-			green:  { label: "{{ _('Great!') }}",  percentage: 100 },
-		};
+	window.set_strength_indicator = function(score) {
+		clearTimeout(window.strength_hide_timeout);
 
-		var container = $('.password-strength-container');
-
-		if (!strength_map[color]) {
-			container.addClass('hidden');
-			strength_message.addClass('hidden').html('');
+		var config = strength_map[score];
+		if (!config) {
+			password_strength_indicator.addClass('hidden');
 			return;
 		}
 
-		var config = strength_map[color];
-		container.find('.password-strength-label')
+		password_strength_indicator
+			.removeClass('hidden')
+			.find('.password-strength-value')
 			.text(config.label)
-			.attr('class', 'password-strength-label strength-' + color);
-		container.find('.password-strength-bar-fill')
-			.css('width', config.percentage + '%')
-			.attr('class', 'password-strength-bar-fill strength-' + color);
-		container.removeClass('hidden');
+			.attr('class', 'password-strength-value strength-' + config.color);
 
-		strength_message.addClass('hidden').html('');
-		password_mismatch_message.addClass('hidden');
+		// declutter: once the password is great, hide the indicator after a few seconds
+		if (score === 4) {
+			window.strength_hide_timeout = setTimeout(function() {
+				password_strength_indicator.addClass('hidden');
+			}, 3000);
+		}
 	}
 
 	window.clear_timeout = function() {

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -156,7 +156,8 @@ frappe.ready(function() {
 		$(this).find("use").attr("href", isPassword ? "#icon-eye-off" : "#icon-eye");
 	});
 
-	$("#reset-password").on("submit", function() {
+	$("#reset-password").on("submit", function(e) {
+		e.preventDefault();
 		var args = {
 			key: key || "",
 			old_password: old_password.val(),
@@ -166,9 +167,11 @@ frappe.ready(function() {
 		}
 		if (!args.old_password && !args.key) {
 			show_error_banner("{{ _('Please enter your old password.') }}");
+			return;
 		}
 		if (!args.new_password) {
 			show_error_banner("{{ _('Please enter your new password.') }}");
+			return;
 		}
 		if (args.old_password === args.new_password) {
 			show_error_banner(password_not_same_as_old_password);
@@ -205,6 +208,12 @@ frappe.ready(function() {
 						}, 2000);
 					}
 				}
+			}
+		}).catch(function() {
+			// statuses without a handler above (e.g. 417): error_msg has written the
+			// server message into the banner — reveal it if there is one
+			if (error_banner.find(".es-alert__title").text().trim()) {
+				error_banner.removeClass("hidden");
 			}
 		});
 


### PR DESCRIPTION
1. Errors now show as alerts instead of dialogs (invalid link, wrong old password, etc.)
2. Moved auth pages to espresso - components, tokens, utilities; login CSS ~510 → ~190 lines
3. Enabled utility classes on website pages
4. Matched title size, gaps and links to design; custom CSS only for inputs, layout and animations
5. Redesigned set password page to match the new design


`no-docs`