### PR TITLE
fix(qb_query): preserve explicit unlimited page length for virtual doctype

### DIFF
--- a/frappe/model/qb_query.py
+++ b/frappe/model/qb_query.py
@@ -333,7 +333,9 @@ class DatabaseQuery:
 		if not isinstance(or_filters, Filters):
 			or_filters = Filters(or_filters, doctype=self.doctype)
 
-		_page_length = page_length or limit or limit_page_length or 20
+		# An explicit 0 means "no limit" (frappe.get_all passes
+		# limit_page_length=0), so only fall back when nothing was passed.
+		_page_length = next((x for x in (page_length, limit, limit_page_length) if x is not None), 20)
 		kwargs = {
 			"fields": fields,
 			"filters": filters,

--- a/frappe/tests/test_virtual_doctype.py
+++ b/frappe/tests/test_virtual_doctype.py
@@ -163,6 +163,31 @@ class TestVirtualDoctypes(IntegrationTestCase):
 	def test_get_count(self):
 		self.assertIsInstance(VirtualDoctypeTest.get_count(), int)
 
+	def test_get_all_preserves_unlimited_page_length(self):
+		"""An explicit limit_page_length=0 (fetch all, as passed by frappe.get_all)
+		must reach the controller unchanged instead of being coerced to the
+		default page length."""
+		from frappe.model.base_document import get_controller
+
+		controller = get_controller(TEST_DOCTYPE_NAME)
+		captured = {}
+
+		def spy_get_list(*args, **kwargs):
+			captured.update(kwargs)
+			return []
+
+		with patch.object(controller, "get_list", side_effect=spy_get_list):
+			frappe.get_all(TEST_DOCTYPE_NAME, limit_page_length=0)
+
+		self.assertEqual(captured.get("limit_page_length"), 0)
+		self.assertEqual(captured.get("page_length"), 0)
+
+		captured.clear()
+		with patch.object(controller, "get_list", side_effect=spy_get_list):
+			frappe.get_list(TEST_DOCTYPE_NAME)
+
+		self.assertEqual(captured.get("limit_page_length"), 20)
+
 	def test_delete_doc(self):
 		doc = frappe.get_doc(doctype=TEST_DOCTYPE_NAME).insert()
 


### PR DESCRIPTION
 preserve explicit unlimited page length for virtual doctypes

_handle_virtual_doctype coerced page_length with a falsy-or chain, so an explicit 0 (fetch all records, which is what frappe.get_all passes as limit_page_length) fell through to the default of 20. This truncated "bench rebuild-global-search" to 20 records for virtual doctypes.

Only apply the default when no limit argument was passed at all.

closes: #40763 

Credits: @tushardev-365 

