### PR TITLE
fix(form): translate description in info card when `show_description_on_click` is set

### DIFF
--- a/frappe/public/js/frappe/form/info_card.js
+++ b/frappe/public/js/frappe/form/info_card.js
@@ -31,7 +31,9 @@ export class InfoCard {
 		this.$info_card = $("<div class='info-card'></div>").appendTo(this.label_span);
 		let card_args = {
 			title: "",
-			message: this.df.show_description_on_click ? this.df.description || "" : "",
+			message: this.df.show_description_on_click
+				? __(this.df.description, null, this.df.parent) || ""
+				: "",
 			parent: this.$info_card,
 			trigger: $(this.label_span).find("svg").get(0),
 			close_button: true,


### PR DESCRIPTION
Resolve: #40807

---

Co-authored-by: @naraitua