### PR TITLE
refactor(ui): migrate page header actions to espresso buttons

### DIFF
--- a/cypress/integration/control_attach.js
+++ b/cypress/integration/control_attach.js
@@ -53,7 +53,7 @@ context("Attach Control", () => {
 		//Deleting the doc
 		cy.go_to_list("Test Attach Control");
 		cy.get(".list-row-checkbox").eq(0).click();
-		cy.get(".actions-btn-group > .btn").contains("Actions").click();
+		cy.get(".actions-btn-group > button").contains("Actions").click();
 		cy.get('.actions-btn-group > .dropdown-menu [data-label="Delete"]').click();
 		cy.click_modal_primary_button("Yes");
 	});
@@ -109,7 +109,7 @@ context("Attach Control", () => {
 		cy.go_to_list("Test Attach Control");
 		cy.get(".list-row-checkbox").eq(0).click();
 		cy.get(".list-row-checkbox").eq(1).click();
-		cy.get(".actions-btn-group > .btn").contains("Actions").click();
+		cy.get(".actions-btn-group > button").contains("Actions").click();
 		cy.get('.actions-btn-group > .dropdown-menu [data-label="Delete"]').click();
 		cy.click_modal_primary_button("Yes");
 	});

--- a/cypress/integration/control_data.js
+++ b/cypress/integration/control_data.js
@@ -144,7 +144,7 @@ context("Data Control", () => {
 		//Deleting the inserted document
 		cy.go_to_list("Test Data Control");
 		cy.get(".list-row-checkbox").eq(0).click({ force: true });
-		cy.get(".actions-btn-group > .btn").contains("Actions").click();
+		cy.get(".actions-btn-group > button").contains("Actions").click();
 		cy.get('.actions-btn-group > .dropdown-menu [data-label="Delete"]').click();
 		cy.click_modal_primary_button("Yes");
 	});

--- a/cypress/integration/custom_buttons.js
+++ b/cypress/integration/custom_buttons.js
@@ -25,7 +25,7 @@ const check_button_count = (label, group = "TestGroup") => {
 	// Verify dropdown buttons in mobile view
 	cy.viewport(420, 900);
 	const dropdown_btn_label = `${group} > ${label}`;
-	cy.get(".menu-btn-group > .btn").click();
+	cy.get(".menu-btn-group > button").click();
 	cy.get(`[data-label="${encodeURIComponent(dropdown_btn_label)}"]`)
 		.should("have.length", 1)
 		.should("be.visible");

--- a/cypress/integration/datetime_field_form_validation.js
+++ b/cypress/integration/datetime_field_form_validation.js
@@ -30,7 +30,7 @@ context("Datetime Field Validation", () => {
 						expect(frm.is_dirty()).to.be.false;
 					});
 				cy.get('[data-testid="page-status"]').should("contain", "Draft");
-				cy.get(".btn-primary[data-label='Submit']").should("be.visible");
+				cy.get(".primary-action[data-label='Submit']").should("be.visible");
 			});
 	});
 });

--- a/cypress/integration/workspace.js
+++ b/cypress/integration/workspace.js
@@ -30,7 +30,7 @@ context("Workspace 2.0", () => {
 		// check if sidebar item is added in pubic section
 		cy.get('.sidebar-item-container[item-name="Test Private Page"]');
 		cy.wait(300);
-		cy.get('.standard-actions .btn-primary[data-label="Save"]').click();
+		cy.get('.standard-actions .primary-action[data-label="Save"]').click();
 		cy.wait(300);
 		cy.get('.sidebar-item-container[item-name="Test Private Page"]');
 
@@ -74,6 +74,6 @@ context("Workspace 2.0", () => {
 		cy.get(".ce-block:last .dropdown-item").contains("Expand").click();
 		cy.get(".ce-block:last").should("have.class", "col-xs-12");
 		cy.wait(300);
-		cy.get('.standard-actions .btn-primary[data-label="Save"]').click();
+		cy.get('.standard-actions .primary-action[data-label="Save"]').click();
 	});
 });

--- a/cypress/integration/workspace_blocks.js
+++ b/cypress/integration/workspace_blocks.js
@@ -28,7 +28,7 @@ context("Workspace Blocks", () => {
 		// check if sidebar item is added in private section
 		cy.get('.sidebar-item-container[item-name="Test Block Page"]');
 		cy.wait(300);
-		cy.get('.standard-actions .btn-primary[data-label="Save"]').click();
+		cy.get('.standard-actions .primary-action[data-label="Save"]').click();
 		cy.wait(300);
 		cy.get('.sidebar-item-container[item-name="Test Block Page"]');
 
@@ -87,7 +87,7 @@ context("Workspace Blocks", () => {
 		cy.get_open_dialog().find(".modal-header").click();
 		cy.get_open_dialog().find(".btn-primary").click();
 
-		cy.get('.standard-actions .btn-primary[data-label="Save"]').click();
+		cy.get('.standard-actions .primary-action[data-label="Save"]').click();
 
 		cy.get(".codex-editor__redactor .ce-block");
 
@@ -169,7 +169,7 @@ context("Workspace Blocks", () => {
 		cy.click_modal_primary_button("Add");
 		cy.get(".ce-block .number-widget-box").first().as("number_card");
 		cy.get("@number_card").find(".widget-title").should("contain", "Test Number Card");
-		cy.get('.standard-actions .btn-primary[data-label="Save"]').click();
+		cy.get('.standard-actions .primary-action[data-label="Save"]').click();
 		cy.get("@number_card").find(".widget-title").should("contain", "Test Number Card");
 
 		// edit number card
@@ -178,7 +178,7 @@ context("Workspace Blocks", () => {
 		cy.get_field("label", "Data").invoke("val", "ToDo Count");
 		cy.click_modal_primary_button("Save");
 		cy.get("@number_card").find(".widget-title").should("contain", "ToDo Count");
-		cy.get('.standard-actions .btn-primary[data-label="Save"]').click();
+		cy.get('.standard-actions .primary-action[data-label="Save"]').click();
 		cy.get("@number_card").find(".widget-title").should("contain", "ToDo Count");
 	});
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -460,7 +460,7 @@ Cypress.Commands.add("click_action_button", (name) => {
 });
 
 Cypress.Commands.add("click_menu_button", (name) => {
-	cy.get(".standard-actions .menu-btn-group > .btn").click();
+	cy.get(".standard-actions .menu-btn-group > button").click();
 	cy.get(`.menu-btn-group [data-label="${encodeURIComponent(name)}"]`).click();
 });
 

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -922,7 +922,10 @@ frappe.ui.form.Form = class FrappeForm {
 	save(save_action, callback, btn, on_error) {
 		let me = this;
 		return new Promise((resolve, reject) => {
-			btn && $(btn).prop("disabled", true);
+			// aria-busy mirrors the disabled handling here and in save.js —
+			// see the note in frappe.ui.form.save (this promise doesn't settle
+			// on every validation-error path)
+			btn && $(btn).prop("disabled", true).attr("aria-busy", "true");
 			frappe.ui.form.close_grid_form();
 			me.validate_and_save(save_action, callback, btn, on_error, resolve, reject);
 		})
@@ -974,7 +977,7 @@ frappe.ui.form.Form = class FrappeForm {
 			if (e) {
 				console.error(e);
 			}
-			btn && $(btn).prop("disabled", false);
+			btn && $(btn).prop("disabled", false).removeAttr("aria-busy");
 			if (on_error) {
 				on_error();
 				reject();
@@ -1341,7 +1344,7 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	handle_save_fail(btn, on_error) {
-		$(btn).prop("disabled", false);
+		$(btn).prop("disabled", false).removeAttr("aria-busy");
 		if (on_error) {
 			on_error();
 		}

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -2,7 +2,11 @@
 // MIT License. See license.txt
 
 frappe.ui.form.save = function (frm, action, callback, btn) {
-	$(btn).prop("disabled", true);
+	// aria-busy is managed everywhere this file manages disabled: the save
+	// promise never settles on validation errors (missing mandatory fields,
+	// "no changes"), so the page header's promise-based busy state can't be
+	// trusted to clear itself — the button would stay stuck on "Saving...".
+	$(btn).prop("disabled", true).attr("aria-busy", "true");
 
 	// specified here because there are keyboard shortcuts to save
 	const working_label = {
@@ -37,7 +41,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 		} else {
 			!frm.is_dirty() &&
 				frappe.show_alert({ message: __("No changes in document"), indicator: "orange" });
-			$(btn).prop("disabled", false);
+			$(btn).prop("disabled", false).removeAttr("aria-busy");
 		}
 	};
 
@@ -100,7 +104,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 			},
 			error: opts.error,
 			always: function (r) {
-				$(btn).prop("disabled", false);
+				$(btn).prop("disabled", false).removeAttr("aria-busy");
 				frappe.ui.form.is_saving = false;
 
 				if (r) {

--- a/frappe/public/js/frappe/list/list_filter/list_filter_menu.js
+++ b/frappe/public/js/frappe/list/list_filter/list_filter_menu.js
@@ -414,15 +414,9 @@ export const ListFilterMenu = {
 		if (!this.layout_menu_group) return;
 
 		const label = this.active_layout_label || this.default_layout_label;
-		const label_node = $(
-			`.inner-group-button[data-label="${encodeURIComponent(
-				this.saved_layout_group_label
-			)}"] button`
-		)
-			.contents()
-			.first()[0];
-		if (!label_node) return;
-		label_node.textContent = label;
+		// the group trigger is an es-button now — its text lives in the
+		// label span, not in the button's first text node
+		this.layout_menu_group.find("button .es-button__label").text(label);
 	},
 
 	/** Show tick on the currently selected layout row. */

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -291,7 +291,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			const doctype_name = __(frappe.router.doctype_layout) || __(this.doctype);
 			const add_button_label = __("Add {0}", [doctype_name], "Primary action in list view");
 			const create_button = this.page.set_primary_action(
-				add_button_label,
+				// CSS swaps to the short label below the md breakpoint, so the
+				// button stays right when the window is resized
+				{ label: add_button_label, short_label: __("Add") },
 				() => {
 					if (this.settings.primary_action) {
 						this.settings.primary_action();
@@ -319,11 +321,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				),
 				page: this.page,
 			});
-			if (frappe.is_mobile()) {
-				create_button.append(__("Add"));
-			} else {
-				this._trim_primary_action_if_overflow(create_button, add_button_label);
-			}
+			this._trim_primary_action_if_overflow(create_button, add_button_label);
 		} else {
 			frappe.ui.keys.off("ctrl+b", this.page);
 			this.page.clear_primary_action();
@@ -338,7 +336,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (btnRect.right > containerRect.right) {
 			const short_label = __("Add");
 			btn.attr("title", add_button_label).tooltip();
-			btn.find("span").text(short_label);
+			// only the full label span — the button also holds the spinner,
+			// loading-label and short-label spans
+			btn.find(".es-button__label").first().text(short_label);
 		}
 	}
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -290,28 +290,24 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (this.can_create && !frappe.boot.read_only) {
 			const doctype_name = __(frappe.router.doctype_layout) || __(this.doctype);
 			const add_button_label = __("Add {0}", [doctype_name], "Primary action in list view");
+			const primary_action = () => {
+				if (this.settings.primary_action) {
+					this.settings.primary_action();
+				} else {
+					this.make_new_doc();
+				}
+			};
 			const create_button = this.page.set_primary_action(
 				// CSS swaps to the short label below the md breakpoint, so the
 				// button stays right when the window is resized
 				{ label: add_button_label, short_label: __("Add") },
-				() => {
-					if (this.settings.primary_action) {
-						this.settings.primary_action();
-					} else {
-						this.make_new_doc();
-					}
-				},
+				primary_action,
 				"plus"
 			);
 			frappe.ui.keys.add_shortcut({
 				shortcut: "ctrl+b",
 				action: () => {
-					if (this.settings.primary_action) {
-						this.settings.primary_action();
-					} else {
-						this.make_new_doc();
-					}
-
+					primary_action();
 					return true;
 				},
 				description: __(
@@ -321,24 +317,27 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				),
 				page: this.page,
 			});
-			this._trim_primary_action_if_overflow(create_button, add_button_label);
+			this._trim_primary_action_if_overflow(create_button, add_button_label, primary_action);
 		} else {
 			frappe.ui.keys.off("ctrl+b", this.page);
 			this.page.clear_primary_action();
 		}
 	}
 
-	_trim_primary_action_if_overflow(btn, add_button_label) {
+	// If the full label makes the button overflow the header (very long
+	// doctype names), re-render it with the short label at every width. Done
+	// through set_primary_action, never by writing into the button's DOM, so
+	// the icon, responsive spans and shortcut wiring stay coherent.
+	_trim_primary_action_if_overflow(btn, add_button_label, primary_action) {
 		const container = this.page.wrapper.find(".page-head-content")[0];
 		if (!container || !btn[0]) return;
 		const containerRect = container.getBoundingClientRect();
 		const btnRect = btn[0].getBoundingClientRect();
 		if (btnRect.right > containerRect.right) {
-			const short_label = __("Add");
-			btn.attr("title", add_button_label).tooltip();
-			// only the full label span — the button also holds the spinner,
-			// loading-label and short-label spans
-			btn.find(".es-button__label").first().text(short_label);
+			this.page
+				.set_primary_action({ label: __("Add") }, primary_action, "plus")
+				.attr("title", add_button_label)
+				.tooltip();
 		}
 	}
 

--- a/frappe/public/js/frappe/ui/components/button.js
+++ b/frappe/public/js/frappe/ui/components/button.js
@@ -79,10 +79,20 @@ function button_html(opts = {}) {
 	}
 
 	const classes = escape(["es-button", opts.css_class].filter(Boolean).join(" "));
+
+	return `<button class="${classes}" ${attrs.join(" ")}>
+		${content_html(opts)}
+	</button>`;
+}
+
+// The button's children: spinner + loading label + icons + label. Shared by
+// the markup form above and by dress() below so the two can't drift.
+function content_html(opts) {
+	const escape = frappe.utils.escape_html;
 	// .es-button > svg in button.css sizes the icons to the button;
 	// currentColor keeps the stroke in sync with the button's text color
 	const render_icon = (name) => (name ? frappe.utils.icon(name, "sm", "", "", "", true) : "");
-	const icon_left = render_icon(icon_left_name);
+	const icon_left = render_icon(opts.icon_left || opts.icon);
 	const icon_right = render_icon(opts.icon_right);
 	const label = opts.label ? `<span class="es-button__label">${escape(opts.label)}</span>` : "";
 	const loading_label_text =
@@ -94,10 +104,7 @@ function button_html(opts = {}) {
 				loading_label_text
 		  )}</span>`
 		: "";
-
-	return `<button class="${classes}" ${attrs.join(" ")}>
-		<span class="es-spinner" aria-hidden="true"></span>${loading_label}${icon_left}${label}${icon_right}
-	</button>`;
+	return `<span class="es-spinner" aria-hidden="true"></span>${loading_label}${icon_left}${label}${icon_right}`;
 }
 
 /**
@@ -147,5 +154,58 @@ frappe.ui.button = function (opts = {}) {
 };
 
 frappe.ui.button.html = button_html;
+
+/**
+ * Apply the es-button contract to an EXISTING <button> element — the
+ * migration channel for legacy surfaces (like the page header) where external
+ * code holds a reference to the element, so it must be mutated in place, never
+ * replaced.
+ *
+ * Sets the `es-button` class and the data-variant/size/theme attributes
+ * (removing them when the value is the CSS default, so markup stays lean).
+ * When `label` or an icon is passed, the button's children are rebuilt to the
+ * es structure (spinner + loading label + icons + label span); otherwise the
+ * existing content is left untouched, so a trigger with bespoke children can
+ * be dressed for looks alone.
+ *
+ * Deliberately does NOT touch click handlers, disabled, aria-busy, or
+ * visibility — those stay the caller's domain. Can be re-applied to the same
+ * element (idempotent per option).
+ *
+ * @param {HTMLElement|JQuery} el The button to dress.
+ * @param {ButtonOpts} [opts] label / loading_label / icon / icon_left / icon_right / variant / size / theme.
+ * @returns {JQuery} the same element, dressed
+ * @example frappe.ui.button.dress(this.btn_primary, { label: __("Save"), variant: "solid" });
+ */
+frappe.ui.button.dress = function (el, opts = {}) {
+	const $el = $(el);
+	$el.addClass("es-button");
+	if (!$el.attr("type")) $el.attr("type", "button");
+
+	// undefined = leave the existing attribute alone; a value = set it,
+	// unless it's the CSS default, which is expressed by NO attribute
+	const set_data = (name, value, default_value) => {
+		if (value === undefined) return;
+		if (value === default_value) {
+			$el.removeAttr(`data-${name}`);
+		} else {
+			$el.attr(`data-${name}`, value);
+		}
+	};
+	set_data("variant", validated(opts.variant, VARIANTS, "variant", "button"), "subtle");
+	set_data("size", validated(opts.size, SIZES, "size", "button"), "sm");
+	set_data("theme", validated(opts.theme, THEMES, "theme", "button"), "gray");
+
+	const has_icon = Boolean(opts.icon || opts.icon_left || opts.icon_right);
+	if ("label" in opts || has_icon) {
+		$el.html(content_html(opts));
+		if (has_icon && !opts.label) {
+			$el.attr("data-icon-button", "true");
+		} else {
+			$el.removeAttr("data-icon-button");
+		}
+	}
+	return $el;
+};
 
 export default frappe.ui.button;

--- a/frappe/public/js/frappe/ui/find.js
+++ b/frappe/public/js/frappe/ui/find.js
@@ -1,6 +1,6 @@
 frappe.find = {
 	page_primary_action: () => {
-		return $(".page-actions:visible .btn-primary");
+		return $(".page-actions:visible .primary-action");
 	},
 	field: (fieldname, value) => {
 		return new Promise((resolve) => {

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -453,19 +453,31 @@ frappe.show_alert = frappe.toast = function (message, seconds = 7, actions = {})
 		});
 		return $root;
 	};
-	harden(handle.$el.find(".es-toast__message").html(sane(message.message || "")));
+	// legacy alerts could also pass a DOM element or jQuery for any of these
+	// channels (e.g. success_action's next-action buttons) — append those as
+	// they are, with their event bindings intact; stringifying them would
+	// print "[object Object]". Strings go through sanitise + harden as before.
+	const fill = ($target, content) => {
+		if (content && (content.jquery || content.nodeType)) {
+			return $target.append(content);
+		}
+		return harden($target.html(sane(content)));
+	};
+	fill(handle.$el.find(".es-toast__message"), message.message || "");
 	if (message.subtitle) {
-		harden(
-			$('<div class="es-toast__description"></div>')
-				.html(sane(message.subtitle))
-				.appendTo(handle.$el.find(".es-toast__content"))
+		fill(
+			$('<div class="es-toast__description"></div>').appendTo(
+				handle.$el.find(".es-toast__content")
+			),
+			message.subtitle
 		);
 	}
 	if (message.body) {
-		harden(
-			$('<div class="es-toast__body"></div>')
-				.html(sane(message.body))
-				.appendTo(handle.$el.find(".es-toast__content"))
+		fill(
+			$('<div class="es-toast__body"></div>').appendTo(
+				handle.$el.find(".es-toast__content")
+			),
+			message.body
 		);
 	}
 

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -70,33 +70,26 @@
 					<div class="standard-actions flex">
 						<span class="page-icon-group hide hidden-xs hidden-sm"></span>
 						<div class="menu-btn-group hide">
-							<button type="button" class="btn btn-default icon-btn menu-more-button" data-toggle="dropdown" aria-expanded="false" aria-label="{{ __("Menu") }}">
-								<span>
-									<span class="menu-btn-group-label">
-										<svg class="icon icon-sm">
-											<use href="#icon-ellipsis">
-											</use>
-										</svg>
-									</span>
-								</span>
-							</button>
+							{%= frappe.ui.button.html({
+								icon: "ellipsis",
+								title: __("Menu"),
+								css_class: "icon-btn menu-more-button",
+								attrs: { "data-toggle": "dropdown", "aria-expanded": "false" },
+							}) %}
 							<ul class="dropdown-menu dropdown-menu-right" role="menu"></ul>
 						</div>
-						<button class="btn btn-secondary btn-default btn-sm hide"></button>
+						{%= frappe.ui.button.html({ css_class: "secondary-action hide" }) %}
 						<div class="actions-btn-group hide">
-							<button type="button" class="btn btn-primary btn-sm justify-center" data-toggle="dropdown" aria-expanded="false">
-								<span>
-									<span class="hidden-xs actions-btn-group-label">{%= __("Actions") %}</span>
-									<svg class="icon icon-xs">
-										<use href="#icon-chevrons-up-down">
-										</use>
-									</svg>
-								</span>
-							</button>
+							{%= frappe.ui.button.html({
+								label: __("Actions"),
+								icon_right: "chevrons-up-down",
+								variant: "solid",
+								attrs: { "data-toggle": "dropdown", "aria-expanded": "false" },
+							}) %}
 							<ul class="dropdown-menu dropdown-menu-right" role="menu">
 							</ul>
 						</div>
-						<button class="btn btn-primary btn-sm hide primary-action"></button>
+						{%= frappe.ui.button.html({ variant: "solid", css_class: "primary-action hide" }) %}
 					</div>
 				</div>
 			</div>

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -26,6 +26,21 @@ frappe.ui.make_app_page = function (opts) {
 
 frappe.ui.pages = {};
 
+// bootstrap button types (the public add_inner_button/add_button vocabulary)
+// mapped onto the es-button contract; unknown types fall back to subtle
+const BTN_TYPE_TO_ES = {
+	default: { variant: "subtle" },
+	secondary: { variant: "subtle" },
+	light: { variant: "subtle" },
+	primary: { variant: "solid" },
+	danger: { variant: "solid", theme: "red" },
+	ghost: { variant: "ghost" },
+};
+
+function es_opts_for_btn_type(type) {
+	return BTN_TYPE_TO_ES[type] || BTN_TYPE_TO_ES.default;
+}
+
 frappe.ui.Page = class Page {
 	constructor(opts) {
 		$.extend(this, opts);
@@ -162,7 +177,7 @@ frappe.ui.Page = class Page {
 		this.filters = this.wrapper.find(".filters");
 		this.page_head = this.wrapper.find(".page-head");
 		this.btn_primary = this.page_actions.find(".primary-action");
-		this.btn_secondary = this.page_actions.find(".btn-secondary");
+		this.btn_secondary = this.page_actions.find(".secondary-action");
 
 		this.menu = this.page_actions.find(".menu-btn-group .dropdown-menu");
 		this.menu_btn_group = this.page_actions.find(".menu-btn-group");
@@ -190,14 +205,15 @@ frappe.ui.Page = class Page {
 			.on("click mousedown", function () {
 				$(this).tooltip("hide");
 			});
-		frappe.ui.keys
-			.get_shortcut_group(this.page_actions[0])
-			.add(menu_btn, menu_btn.find(".menu-btn-group-label"));
+		frappe.ui.keys.get_shortcut_group(this.page_actions[0]).add(menu_btn);
 
+		// desktop shows "Actions" + chevron; mobile keeps just the chevron.
+		// actions-btn-group-label stays as the legacy hook name for the span.
 		let action_btn = this.actions_btn_group.find("button");
-		frappe.ui.keys
-			.get_shortcut_group(this.page_actions[0])
-			.add(action_btn, action_btn.find(".actions-btn-group-label"));
+		let action_btn_label = action_btn
+			.find(".es-button__label")
+			.addClass("hidden-xs actions-btn-group-label");
+		frappe.ui.keys.get_shortcut_group(this.page_actions[0]).add(action_btn, action_btn_label);
 
 		// https://axesslab.com/skip-links
 		this.skip_link_to_main = $("<button>")
@@ -283,46 +299,80 @@ frappe.ui.Page = class Page {
 
 	set_action(btn, opts) {
 		let me = this;
-		if (opts.icon) {
-			opts.iconHTML = this.get_icon_label(opts.icon, opts.label);
-		}
 
 		this.clear_action_of(btn);
 
+		// icon can be a name or { icon, size } — the es contract sizes icons
+		// from the button itself, so only the name matters now
+		const icon = typeof opts.icon === "object" ? opts.icon.icon : opts.icon;
+		const dress_opts = {
+			label: opts.label,
+			icon: icon,
+			variant: opts.variant,
+		};
+		// only pass loading_label through when the caller gave one, so the
+		// component's default map (Save → Saving...) still applies otherwise
+		if (opts.working_label) {
+			dress_opts.loading_label = opts.working_label;
+		}
+		frappe.ui.button.dress(btn, dress_opts);
+
 		btn.removeClass("hide")
 			.prop("disabled", false)
-			.html(opts.iconHTML || opts.label)
 			.attr("data-label", opts.label)
 			.on("click", function () {
+				// busy blocks the mouse via pointer-events, but keyboard
+				// activation still fires — guard re-entry
+				if (btn.attr("aria-busy") === "true") return;
 				let response = opts.click.apply(this, [btn]);
 				me.btn_disable_enable(btn, response);
 			});
+
+		if (opts.short_label) {
+			// responsive label pair: the full label shows from md up, the short
+			// one below md (hidden-xs and hidden-lg are exact complements at
+			// the 768px boundary) — CSS decides, so resizing just works
+			btn.find(".es-button__label").addClass("hidden-xs");
+			$('<span class="es-button__label hidden-lg"></span>')
+				.text(opts.short_label)
+				.insertAfter(btn.find(".es-button__label").first());
+		} else if (opts.icon) {
+			// with an icon and no short label, mobile shows the icon alone
+			// (page.scss squares the button into an icon button below md)
+			btn.find(".es-button__label").addClass("hidden-xs");
+		}
 
 		if (opts.working_label) {
 			btn.attr("data-working-label", opts.working_label);
 		}
 
-		// alt shortcuts
-		let text_span = btn.find("span");
+		// alt shortcuts — pass the full label span alone; the button also
+		// contains the spinner, loading-label and short-label spans, whose
+		// text must not join in
+		let text_span = btn.find(".es-button__label").first();
 		frappe.ui.keys.get_shortcut_group(this).add(btn, text_span.length ? text_span : btn);
 	}
 
+	// `label` can be a plain string, or { label, short_label } to show a
+	// shorter text below the md breakpoint (e.g. "Add" for "Add Sales Order")
 	set_primary_action(label, click, icon, working_label) {
 		this.set_action(this.btn_primary, {
-			label: label,
+			...(typeof label === "object" ? label : { label }),
 			click: click,
 			icon: icon,
 			working_label: working_label,
+			variant: "solid",
 		});
 		return this.btn_primary;
 	}
 
 	set_secondary_action(label, click, icon, working_label) {
 		this.set_action(this.btn_secondary, {
-			label: label,
+			...(typeof label === "object" ? label : { label }),
 			click: click,
 			icon: icon,
 			working_label: working_label,
+			variant: "subtle",
 		});
 
 		return this.btn_secondary;
@@ -578,13 +628,21 @@ frappe.ui.Page = class Page {
 		if (!$group.length) {
 			$group = $(
 				`<div class="inner-group-button" data-label="${encodeURIComponent(label)}">
-					<button type="button" class="btn btn-default ellipsis" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						${label}
-						${frappe.utils.icon("chevrons-up-down", "xs")}
-					</button>
 					<div role="menu" class="dropdown-menu ${align_right ? "dropdown-menu-right" : ""}"></div>
 				</div>`
 			).appendTo(this.inner_toolbar);
+			frappe.ui
+				.button({
+					label: label,
+					icon_right: "chevrons-up-down",
+					css_class: "ellipsis",
+					attrs: {
+						"data-toggle": "dropdown",
+						"aria-haspopup": "true",
+						"aria-expanded": "false",
+					},
+				})
+				.prependTo($group);
 		}
 		return $group;
 	}
@@ -600,23 +658,24 @@ frappe.ui.Page = class Page {
 		const dropdown_items = group.find(".dropdown-menu .dropdown-item");
 
 		if (dropdown_items.length > 0) {
-			group.find("button").removeClass("btn-default").addClass("btn-primary");
+			group.find("button").attr("data-variant", "solid");
 		} else {
 			group.toggleClass("hide", true);
 		}
 	}
 
 	btn_disable_enable(btn, response) {
+		// aria-busy, not disabled: disabling ejects keyboard focus, busy shows
+		// the es-button spinner/loading-label and blocks clicks. Direct
+		// .prop("disabled") pokes from outside still work (es-button styles
+		// :disabled) — this only changes what the page does on its own.
+		const busy = (on) => (on ? btn.attr("aria-busy", "true") : btn.removeAttr("aria-busy"));
 		if (response && response.then) {
-			btn.prop("disabled", true);
-			response.finally(() => {
-				btn.prop("disabled", false);
-			});
+			busy(true);
+			response.finally(() => busy(false));
 		} else if (response && response.always) {
-			btn.prop("disabled", true);
-			response.always(() => {
-				btn.prop("disabled", false);
-			});
+			busy(true);
+			response.always(() => busy(false));
 		}
 	}
 	add_divider_to_button_group(group) {
@@ -666,11 +725,12 @@ frappe.ui.Page = class Page {
 				`button[data-label="${encodeURIComponent(label)}"]`
 			);
 			if (button.length == 0) {
-				button = $(`<button data-label="${encodeURIComponent(
-					label
-				)}" class="btn btn-${type} ellipsis">
-					${__(label)}
-				</button>`);
+				button = frappe.ui.button({
+					label: __(label),
+					...es_opts_for_btn_type(type),
+					css_class: "ellipsis",
+					attrs: { "data-label": encodeURIComponent(label) },
+				});
 				button.on("click", _action);
 				button.appendTo(this.inner_toolbar.removeClass("hide"));
 			}
@@ -700,16 +760,25 @@ frappe.ui.Page = class Page {
 		let btn;
 
 		if (group) {
+			// dropdown items keep the legacy class treatment until the menu
+			// wave; note this strips any extra classes (pre-existing behavior)
 			var $group = this.get_inner_group_button(__(group));
 			if ($group.length) {
 				btn = $group.find(`.dropdown-item[data-label="${encodeURIComponent(label)}"]`);
+				if (btn) btn.removeClass().addClass(`btn btn-${type} ellipsis`);
 			}
 		} else {
+			// es-buttons change look via data attributes — the classes
+			// (es-button, ellipsis, data-label hooks) must survive
 			btn = this.inner_toolbar.find(`button[data-label="${encodeURIComponent(label)}"]`);
-		}
-
-		if (btn) {
-			btn.removeClass().addClass(`btn btn-${type} ellipsis`);
+			if (btn.length) {
+				const es = es_opts_for_btn_type(type);
+				// defaults (subtle/gray) are expressed by NO attribute
+				es.variant === "subtle"
+					? btn.removeAttr("data-variant")
+					: btn.attr("data-variant", es.variant);
+				es.theme ? btn.attr("data-theme", es.theme) : btn.removeAttr("data-theme");
+			}
 		}
 	}
 
@@ -769,11 +838,19 @@ frappe.ui.Page = class Page {
 
 	add_button(label, click, opts) {
 		if (!opts) opts = {};
-		let button = $(`<button
-			class="btn ${opts.btn_class || "btn-default"} ${opts.btn_size || "btn-sm"} ellipsis">
-				${opts.icon ? frappe.utils.icon(opts.icon) : ""}
-				${label}
-		</button>`);
+		// btn_class/btn_size keep their bootstrap vocabulary ("btn-primary",
+		// "btn-xs") and are mapped onto the es contract; a class we don't
+		// recognize passes through so custom hooks keep working
+		const type = (opts.btn_class || "btn-default").replace(/^btn-/, "");
+		const known = Boolean(BTN_TYPE_TO_ES[type]);
+		let button = frappe.ui.button({
+			label: label,
+			icon: opts.icon,
+			...es_opts_for_btn_type(type),
+			size: opts.btn_size === "btn-xs" ? "xs" : undefined,
+			css_class: ["ellipsis", !known && opts.btn_class].filter(Boolean).join(" "),
+			attrs: { "data-label": encodeURIComponent(label) },
+		});
 		// Add actions as menu item in Mobile View (similar to "add_custom_button" in forms.js)
 		let menu_item = this.add_menu_item(label, click, false);
 		menu_item.parent().addClass("hidden-xl");
@@ -786,30 +863,28 @@ frappe.ui.Page = class Page {
 	}
 
 	add_custom_button_group(label, icon, parent) {
-		let dropdown_label = `<span class="hidden-xs">
-			<span class="custom-btn-group-label">${__(label)}</span>
-			${frappe.utils.icon("chevrons-up-down", "xs")}
-		</span>`;
-
-		if (icon) {
-			dropdown_label = `<span class="hidden-xs">
-				${frappe.utils.icon(icon)}
-				<span class="custom-btn-group-label">${__(label)}</span>
-				${frappe.utils.icon("chevrons-up-down", "xs")}
-			</span>
-			<span class="visible-xs">
-				${frappe.utils.icon(icon)}
-			</span>`;
-		}
-
 		let custom_btn_group = $(`
 			<div class="custom-btn-group">
-				<button type="button" class="btn btn-default btn-sm ellipsis" data-toggle="dropdown" aria-expanded="false">
-					${dropdown_label}
-				</button>
 				<ul class="dropdown-menu" role="menu"></ul>
 			</div>
 		`);
+
+		let $button = frappe.ui.button({
+			label: __(label),
+			icon: icon,
+			icon_right: "chevrons-up-down",
+			css_class: "ellipsis",
+			attrs: { "data-toggle": "dropdown", "aria-expanded": "false" },
+		});
+		$button.find(".es-button__label").addClass("custom-btn-group-label");
+		if (icon) {
+			// with an icon, mobile collapses to it alone: label and chevron
+			// hide below md and page.scss squares the button. Without an icon
+			// there is nothing to collapse to, so the label stays.
+			$button.find(".es-button__label").addClass("hidden-xs");
+			$button.children("svg").last().addClass("hidden-xs");
+		}
+		$button.prependTo(custom_btn_group);
 
 		if (!parent)
 			parent = frappe.is_mobile() ? this.custom_mobile_actions : this.custom_actions;

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -303,8 +303,9 @@ frappe.ui.Page = class Page {
 		this.clear_action_of(btn);
 
 		// icon can be a name or { icon, size } — the es contract sizes icons
-		// from the button itself, so only the name matters now
-		const icon = typeof opts.icon === "object" ? opts.icon.icon : opts.icon;
+		// from the button itself, so only the name matters now. Guard against
+		// null: callers pass it to skip the icon (typeof null === "object")
+		const icon = opts.icon && typeof opts.icon === "object" ? opts.icon.icon : opts.icon;
 		const dress_opts = {
 			label: opts.label,
 			icon: icon,
@@ -357,7 +358,7 @@ frappe.ui.Page = class Page {
 	// shorter text below the md breakpoint (e.g. "Add" for "Add Sales Order")
 	set_primary_action(label, click, icon, working_label) {
 		this.set_action(this.btn_primary, {
-			...(typeof label === "object" ? label : { label }),
+			...(label && typeof label === "object" ? label : { label }),
 			click: click,
 			icon: icon,
 			working_label: working_label,
@@ -368,7 +369,7 @@ frappe.ui.Page = class Page {
 
 	set_secondary_action(label, click, icon, working_label) {
 		this.set_action(this.btn_secondary, {
-			...(typeof label === "object" ? label : { label }),
+			...(label && typeof label === "object" ? label : { label }),
 			click: click,
 			icon: icon,
 			working_label: working_label,

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -92,8 +92,28 @@
 		padding: 4px 8px;
 	}
 
+	// the header buttons are es-buttons now; they style themselves, but the
+	// spacing between siblings still comes from here (until the layout moves
+	// to gap in the header-skeleton PR)
+	.es-button {
+		margin-left: var(--margin-sm, 8px);
+	}
+
+	// below md, a button whose label is breakpoint-hidden (hidden-xs) with no
+	// short-label swap (hidden-lg) is icon-only — square it like an icon
+	// button instead of leaving a lone icon with text padding
+	@include media-breakpoint-down(sm) {
+		.es-button:has(> .es-button__label.hidden-xs):not(:has(> .es-button__label.hidden-lg)) {
+			padding-inline: 0;
+			width: var(--es-bt-h);
+			min-width: 0;
+		}
+	}
+
 	.btn-primary,
-	.btn-secondary {
+	.btn-secondary,
+	.primary-action,
+	.secondary-action {
 		min-width: 40px;
 	}
 


### PR DESCRIPTION
This PR replaces the buttons in the page toolbar with new Espresso styled buttons.
All standard Page APIs (`set_primary_action`, `set_secondary_action`, `add_inner_button`,` add_button`, `add_custom_button_group`, `change_inner_button_type`, …)  will work as usual. If custom apps perform any direct DOM manipulation using older class names - those would break.


Visually, this PR makes the buttons consistent (also works better in dark mode) and they do not break on resizing the window to mobile width. Future PRs will improve the Dropdown menus on the toolbar.

#### Breaking changes for direct DOM manipulation

1. The header buttons no longer carry btn, btn-primary, btn-secondary, btn-default, btn-sm. Select the primary button via .primary-action (unchanged) and the secondary via the new .secondary-action. Menu/Actions triggers: .menu-btn-group button / .actions-btn-group button.
2. The button's accessible structure changed: the label lives in span.es-button__label, alongside a spinner and an optional loading-label span. Don't read the label with $btn.text() (it can include the hidden loading text) — use $btn.attr("data-label"). Don't write the label with .text()/.html()/.append() — call set_primary_action(...) again or frappe.ui.button.dress($btn, { label }).
3. While a promise-returning action runs, the button is locked via aria-busy="true", not disabled. Test assertions like should("be.disabled") should assert [aria-busy="true"] instead. Setting .prop("disabled", true) yourself still works and renders correctly.
4. Labels passed to set_primary_action/set_secondary_action/add_button/add_inner_button are HTML-escaped now. Use the icon parameter instead of embedding markup in labels.
set_primary_action/set_secondary_action additionally accept { label, short_label } as the first argument for a responsive label pair (short label shows below 768px).
5. CSS keyed on the old header classes (e.g. .page-actions .btn) no longer applies; style .page-actions .es-button or the hook classes.



`no-docs`