### PR TITLE
refactor!: make get_label return untranslated source labels

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -35,7 +35,7 @@ from frappe.utils.caching import deprecated_local_cache as local_cache
 from frappe.utils.caching import request_cache, site_cache
 from frappe.utils.data import as_unicode, bold, cint, cstr, safe_decode, safe_encode, sbool, scrub, unscrub
 from frappe.utils.local import Local, LocalProxy, release_local
-from frappe.utils.translations import _, _lt, set_user_lang
+from frappe.utils.translations import _, _lt, _noop, set_user_lang
 
 # Local application imports
 from .exceptions import *

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -35,7 +35,7 @@ from frappe.utils.caching import deprecated_local_cache as local_cache
 from frappe.utils.caching import request_cache, site_cache
 from frappe.utils.data import as_unicode, bold, cint, cstr, safe_decode, safe_encode, sbool, scrub, unscrub
 from frappe.utils.local import Local, LocalProxy, release_local
-from frappe.utils.translations import _, _lt, _noop, set_user_lang
+from frappe.utils.translations import N_, _, _lt, set_user_lang
 
 # Local application imports
 from .exceptions import *

--- a/frappe/core/doctype/audit_trail/audit_trail.html
+++ b/frappe/core/doctype/audit_trail/audit_trail.html
@@ -22,7 +22,7 @@
             <tbody>
                 {% for fieldname in field_keys %}
                     <tr>
-                        <td> {{ frappe.utils.escape_html(fieldname) }} </td>
+                        <td> {{ frappe.utils.escape_html(__(fieldname, null, doctype)) }} </td>
                         {% var values = changed[fieldname] %}
 
                         {% for value in values %}
@@ -47,7 +47,7 @@
                     {% for table in tables %}
                     <tr>
                         <tr>
-                            <td><b>{{ frappe.utils.escape_html(table) }}</b></td>
+                            <td><b>{{ frappe.utils.escape_html(__(table, null, doctype)) }}</b></td>
                             {% for doc in documents %}
                                 <td><b>{{ frappe.utils.escape_html(doc) }}</b></td>
                             {% endfor %}
@@ -59,7 +59,7 @@
                             {% var fields = Object.keys(row_changed[table][idx]).sort(); %}
                             {% for field in fields %}
                                 <tr>
-                                    <td>{{ frappe.utils.escape_html(field) }}</td>
+                                    <td>{{ frappe.utils.escape_html(__(field)) }}</td>
                                     {% var values = row_changed[table][idx][field] %}
                                     {% for value in values %}
                                         <td> {{ frappe.utils.escape_html(value) }} </td>

--- a/frappe/core/doctype/audit_trail/audit_trail.js
+++ b/frappe/core/doctype/audit_trail/audit_trail.js
@@ -93,6 +93,7 @@ frappe.ui.form.on("Audit Trail", {
 			documents: document_names,
 			changed: changed_fields.changed,
 			row_changed: changed_fields.row_changed,
+			doctype: frm.doc.doctype_name,
 		};
 		$(frappe.render_template("audit_trail", render_dict)).appendTo(
 			frm.fields_dict.version_table.$wrapper.empty()
@@ -113,6 +114,7 @@ frappe.ui.form.on("Audit Trail", {
 			hide_section = 0;
 			section_dict = {
 				added_or_removed: added_or_removed[key],
+				doctype: frm.doc.doctype_name,
 			};
 			$(frappe.render_template("audit_trail_rows_added_removed", section_dict)).appendTo(
 				frm.fields_dict[key].$wrapper.empty()

--- a/frappe/core/doctype/audit_trail/audit_trail.py
+++ b/frappe/core/doctype/audit_trail/audit_trail.py
@@ -136,7 +136,7 @@ def get_field_label(fieldname, doctype, child_field=None):
 	meta = frappe.get_meta(doctype)
 	label = meta.get_label(fieldname)
 	if label not in ["No Label", None, ""]:
-		return _(label, context=doctype)
+		return label
 	return fieldname
 
 

--- a/frappe/core/doctype/audit_trail/audit_trail.py
+++ b/frappe/core/doctype/audit_trail/audit_trail.py
@@ -136,7 +136,7 @@ def get_field_label(fieldname, doctype, child_field=None):
 	meta = frappe.get_meta(doctype)
 	label = meta.get_label(fieldname)
 	if label not in ["No Label", None, ""]:
-		return label
+		return _(label, context=doctype)
 	return fieldname
 
 

--- a/frappe/core/doctype/audit_trail/audit_trail_rows_added_removed.html
+++ b/frappe/core/doctype/audit_trail/audit_trail_rows_added_removed.html
@@ -7,12 +7,12 @@
             <br>
             {% var tables = Object.keys(added_or_removed[doc]) %}
             {% for table in tables %}
-                <h5 class="text-muted">{{ frappe.utils.escape_html(table) }}</h5>
+                <h5 class="text-muted">{{ frappe.utils.escape_html(__(table, null, doctype)) }}</h5>
                 <table class="table table-bordered">
                     <thead>
                         {% var fieldnames = Object.keys(added_or_removed[doc][table][0]) %}
                         {% for fieldname in fieldnames %}
-                            <th>{{ frappe.utils.escape_html(fieldname) }}</th>
+                            <th>{{ frappe.utils.escape_html(__(fieldname)) }}</th>
                         {% endfor %}
                     </thead>
                     <tbody>

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -161,7 +161,7 @@ class SystemSettings(Document):
 
 		if self.link_field_results_limit > 50:
 			self.link_field_results_limit = 50
-			label = _(self.meta.get_label("link_field_results_limit"))
+			label = _(self.meta.get_label("link_field_results_limit"), context=self.doctype)
 			frappe.msgprint(
 				_("{0} can not be more than {1}").format(label, 50), alert=True, indicator="yellow"
 			)

--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -31,6 +31,27 @@ class TestTranslation(IntegrationTestCase):
 			frappe.delete_doc(doctype, docname)
 			self.assertEqual(_(source_string, context=doctype), original_translation)
 
+	def test_meta_get_label_returns_source_strings(self):
+		doctype = "Translation"
+		meta = frappe.get_meta(doctype)
+		labels = {
+			"translated_text": "Translated Text",
+			"creation": "Created On",
+			"missing_field": "No Label",
+		}
+
+		for source_string in labels.values():
+			create_translation("de", source_string, f"Translated {source_string}", context=doctype)
+
+		frappe.local.lang = "de"
+		for fieldname, source_string in labels.items():
+			with self.subTest(fieldname=fieldname):
+				self.assertEqual(meta.get_label(fieldname), source_string)
+				self.assertEqual(
+					_(meta.get_label(fieldname), context=doctype),
+					f"Translated {source_string}",
+				)
+
 	def test_parent_language(self):
 		data = {
 			"Test Data": {

--- a/frappe/core/doctype/version/version_view.html
+++ b/frappe/core/doctype/version/version_view.html
@@ -60,7 +60,7 @@
 {% for item in data.changed %}
 	{% if htmlDiffs[item[0]] %}
 	<div class="version-diff-container">
-		<h5>{{ frappe.meta.get_label(doc.ref_doctype, item[0]) }}</h5>
+		<h5>{{ __(frappe.meta.get_label(doc.ref_doctype, item[0]), null, doc.ref_doctype) }}</h5>
 		<div class="version-html-diff">{{ htmlDiffs[item[0]] }}</div>
 	</div>
 	{% endif %}
@@ -79,7 +79,7 @@
 		{% for item in data.changed %}
 		{% if !htmlDiffs[item[0]] %}
 		<tr>
-			<td>{{ frappe.meta.get_label(doc.ref_doctype, item[0]) }}</td>
+			<td>{{ __(frappe.meta.get_label(doc.ref_doctype, item[0]), null, doc.ref_doctype) }}</td>
 			<td class="diff-remove">{{ getEscapedValue(item[1]) }}</td>
 			<td class="diff-add">{{ getEscapedValue(item[2]) }}</td>
 		</tr>
@@ -106,7 +106,7 @@
 			{% var values = data[key]; %}
 			{% for item in values %}
 			<tr>
-				<td>{{ frappe.meta.get_label(doc.ref_doctype, item[0]) }}</td>
+				<td>{{ __(frappe.meta.get_label(doc.ref_doctype, item[0]), null, doc.ref_doctype) }}</td>
 				<td class="{{ key==="added" ? "diff-add" : "diff-remove" }}">
 					{% var item_keys = Object.keys(item[1]).sort(); %}
 					<table class="table table-bordered">
@@ -146,7 +146,7 @@
 			{% var _changed = table_info[3]; %}
 			{% for item in _changed %}
 			<tr>
-				<td>{{ frappe.meta.get_label(doc.ref_doctype, table_info[0]) }}</td>
+				<td>{{ __(frappe.meta.get_label(doc.ref_doctype, table_info[0]), null, doc.ref_doctype) }}</td>
 				<td>{{ table_info[1] }}</td>
 				<td>{{ item[0] }}</td>
 				<td class="diff-remove">{{ getEscapedValue(item[1]) }}</td>

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -257,7 +257,11 @@ class CustomField(Document):
 			)
 
 		if self.fieldname == self.insert_after:
-			frappe.throw(_("Insert After cannot be set as {0}").format(meta.get_label(self.insert_after)))
+			frappe.throw(
+				_("Insert After cannot be set as {0}").format(
+					_(meta.get_label(self.insert_after), context=self.dt)
+				)
+			)
 
 	def get_permission_log_options(self, event=None):
 		if event != "after_delete" and self.fieldtype not in (

--- a/frappe/deprecation_dumpster.py
+++ b/frappe/deprecation_dumpster.py
@@ -1046,3 +1046,8 @@ def get_gravatar(email: str) -> str:
 	from frappe.utils import get_identicon
 
 	return get_identicon(email)
+
+
+@deprecated("frappe.desk.page.setup_wizard.install_fixtures._", "2026-07-16", "v17", "Use N_ instead")
+def _(x, *args, **kwargs):
+	return x

--- a/frappe/desk/page/setup_wizard/install_fixtures.py
+++ b/frappe/desk/page/setup_wizard/install_fixtures.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe import N_
+from frappe.deprecation_dumpster import _
 from frappe.desk.doctype.global_search_settings.global_search_settings import (
 	update_global_search_doctypes,
 )

--- a/frappe/desk/page/setup_wizard/install_fixtures.py
+++ b/frappe/desk/page/setup_wizard/install_fixtures.py
@@ -2,7 +2,7 @@
 # License: MIT. See LICENSE
 
 import frappe
-from frappe import _noop
+from frappe import N_
 from frappe.desk.doctype.global_search_settings.global_search_settings import (
 	update_global_search_doctypes,
 )
@@ -19,13 +19,13 @@ def install():
 
 def update_genders():
 	for gender in (
-		_noop("Male"),
-		_noop("Female"),
-		_noop("Other"),
-		_noop("Transgender"),
-		_noop("Genderqueer"),
-		_noop("Non-Conforming"),
-		_noop("Prefer not to say"),
+		N_("Male"),
+		N_("Female"),
+		N_("Other"),
+		N_("Transgender"),
+		N_("Genderqueer"),
+		N_("Non-Conforming"),
+		N_("Prefer not to say"),
 	):
 		doc = frappe.new_doc("Gender")
 		doc.gender = gender
@@ -34,15 +34,15 @@ def update_genders():
 
 def update_salutations():
 	for salutation in (
-		_noop("Mr"),
-		_noop("Ms"),
-		_noop("Mx"),
-		_noop("Dr"),
-		_noop("Mrs"),
-		_noop("Madam"),
-		_noop("Miss"),
-		_noop("Master"),
-		_noop("Prof"),
+		N_("Mr"),
+		N_("Ms"),
+		N_("Mx"),
+		N_("Dr"),
+		N_("Mrs"),
+		N_("Madam"),
+		N_("Miss"),
+		N_("Master"),
+		N_("Prof"),
 	):
 		doc = frappe.new_doc("Salutation")
 		doc.salutation = salutation

--- a/frappe/desk/page/setup_wizard/install_fixtures.py
+++ b/frappe/desk/page/setup_wizard/install_fixtures.py
@@ -2,17 +2,11 @@
 # License: MIT. See LICENSE
 
 import frappe
+from frappe import _noop
 from frappe.desk.doctype.global_search_settings.global_search_settings import (
 	update_global_search_doctypes,
 )
 from frappe.utils.dashboard import sync_dashboards
-
-
-def _(x, *args, **kwargs):
-	"""Redefine the translation function to return the string as is.
-	We want to create english records but still mark the strings as translatable.
-	The respective DocTypes have 'Translate Link Fields' enabled."""
-	return x
 
 
 def install():
@@ -25,13 +19,13 @@ def install():
 
 def update_genders():
 	for gender in (
-		_("Male"),
-		_("Female"),
-		_("Other"),
-		_("Transgender"),
-		_("Genderqueer"),
-		_("Non-Conforming"),
-		_("Prefer not to say"),
+		_noop("Male"),
+		_noop("Female"),
+		_noop("Other"),
+		_noop("Transgender"),
+		_noop("Genderqueer"),
+		_noop("Non-Conforming"),
+		_noop("Prefer not to say"),
 	):
 		doc = frappe.new_doc("Gender")
 		doc.gender = gender
@@ -40,15 +34,15 @@ def update_genders():
 
 def update_salutations():
 	for salutation in (
-		_("Mr"),
-		_("Ms"),
-		_("Mx"),
-		_("Dr"),
-		_("Mrs"),
-		_("Madam"),
-		_("Miss"),
-		_("Master"),
-		_("Prof"),
+		_noop("Mr"),
+		_noop("Ms"),
+		_noop("Mx"),
+		_noop("Dr"),
+		_noop("Mrs"),
+		_noop("Madam"),
+		_noop("Miss"),
+		_noop("Master"),
+		_noop("Prof"),
 	):
 		doc = frappe.new_doc("Salutation")
 		doc.salutation = salutation

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -619,7 +619,9 @@ def get_field_info(fields, parent_doctype):
 
 			if df:
 				fieldname = df.fieldname
-				label = _(meta.get_label(fieldname) or "", context=doctype)
+				label = meta.get_label(fieldname) or ""
+				if label:
+					label = _(label, context=doctype)
 
 				fieldtype = df.fieldtype
 				translatable = df.translatable or False

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -619,9 +619,7 @@ def get_field_info(fields, parent_doctype):
 
 			if df:
 				fieldname = df.fieldname
-
-				# default fields have no df.label; their labels come pre-translated from meta.get_label
-				label = _(df.label) if df.label else meta.get_label(fieldname) or ""
+				label = _(meta.get_label(fieldname) or "", context=doctype)
 
 				fieldtype = df.fieldtype
 				translatable = df.translatable or False

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -344,7 +344,7 @@ def validate_ignore_user_permissions(form_doctype, link_fieldname, link_doctype)
 	if not ignore_user_permissions:
 		_throw(
 			_("The field {0} in {1} does not allow ignoring user permissions").format(
-				bold(meta.get_label(link_fieldname)), bold(_(form_doctype))
+				bold(_(meta.get_label(link_fieldname), context=form_doctype)), bold(_(form_doctype))
 			)
 		)
 
@@ -359,7 +359,7 @@ def validate_ignore_user_permissions(form_doctype, link_fieldname, link_doctype)
 	if found_doctype != link_doctype:
 		_throw(
 			_("The field {0} in {1} links to {2} and not {3}").format(
-				bold(meta.get_label(link_fieldname)),
+				bold(_(meta.get_label(link_fieldname), context=form_doctype)),
 				bold(_(form_doctype)),
 				bold(_(found_doctype)),
 				bold(escape_html(link_doctype)),

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -213,7 +213,11 @@ class EmailAccount(Document):
 
 		if self.notify_if_unreplied:
 			if not self.send_notification_to:
-				frappe.throw(_("{0} is mandatory").format(self.meta.get_label("send_notification_to")))
+				frappe.throw(
+					_("{0} is mandatory").format(
+						_(self.meta.get_label("send_notification_to"), context=self.doctype)
+					)
+				)
 			for e in self.get_unreplied_notification_emails():
 				validate_email_address(e, True)
 

--- a/frappe/gettext/extractors/tests/test_python.py
+++ b/frappe/gettext/extractors/tests/test_python.py
@@ -10,7 +10,7 @@ class TestPython(UnitTestCase):
 	def test_extract_noop(self):
 		messages = list(
 			extract_python(
-				BytesIO(b'_noop("Created On")\n_lt("Last Updated On")'),
+				BytesIO(b'N_("Created On")\n_lt("Last Updated On")'),
 				keywords=PYTHON_KEYWORDS,
 				comment_tags=(),
 				options={},
@@ -19,5 +19,5 @@ class TestPython(UnitTestCase):
 
 		self.assertEqual(
 			[(line, function, message) for line, function, message, _comments in messages],
-			[(1, "_noop", "Created On"), (2, "_lt", "Last Updated On")],
+			[(1, "N_", "Created On"), (2, "_lt", "Last Updated On")],
 		)

--- a/frappe/gettext/extractors/tests/test_python.py
+++ b/frappe/gettext/extractors/tests/test_python.py
@@ -1,0 +1,23 @@
+from io import BytesIO
+
+from babel.messages.extract import extract_python
+
+from frappe.gettext.translate import PYTHON_KEYWORDS
+from frappe.tests import UnitTestCase
+
+
+class TestPython(UnitTestCase):
+	def test_extract_noop(self):
+		messages = list(
+			extract_python(
+				BytesIO(b'_noop("Created On")\n_lt("Last Updated On")'),
+				keywords=PYTHON_KEYWORDS,
+				comment_tags=(),
+				options={},
+			)
+		)
+
+		self.assertEqual(
+			[(line, function, message) for line, function, message, _comments in messages],
+			[(1, "_noop", "Created On"), (2, "_lt", "Last Updated On")],
+		)

--- a/frappe/gettext/translate.py
+++ b/frappe/gettext/translate.py
@@ -17,7 +17,7 @@ from frappe.utils import get_bench_path
 
 PO_DIR = "locale"  # po and pot files go into [app]/locale
 POT_FILE = "main.pot"  # the app's pot file is always main.pot
-PYTHON_KEYWORDS = DEFAULT_KEYWORDS | {"_lt": None, "_noop": None}
+PYTHON_KEYWORDS = DEFAULT_KEYWORDS | {"_lt": None, "N_": None}
 
 
 def new_catalog(app: str, locale: str | None = None) -> Catalog:

--- a/frappe/gettext/translate.py
+++ b/frappe/gettext/translate.py
@@ -17,6 +17,7 @@ from frappe.utils import get_bench_path
 
 PO_DIR = "locale"  # po and pot files go into [app]/locale
 POT_FILE = "main.pot"  # the app's pot file is always main.pot
+PYTHON_KEYWORDS = DEFAULT_KEYWORDS | {"_lt": None, "_noop": None}
 
 
 def new_catalog(app: str, locale: str | None = None) -> Catalog:
@@ -131,9 +132,6 @@ def generate_pot(target_app: str | None = None):
 	apps = [target_app] if target_app else frappe.get_all_apps(True)
 	default_method_map = get_method_map("frappe")
 
-	keywords = DEFAULT_KEYWORDS.copy()
-	keywords["_lt"] = None
-
 	for app in apps:
 		app_path = frappe.get_pymodule_path(app, "..")
 		catalog = new_catalog(app)
@@ -145,7 +143,7 @@ def generate_pot(target_app: str | None = None):
 		method_map.extend(default_method_map)
 
 		for filename, lineno, message, comments, context in extract_from_dir(
-			app_path, method_map, directory_filter=directory_filter, keywords=keywords
+			app_path, method_map, directory_filter=directory_filter, keywords=PYTHON_KEYWORDS
 		):
 			if not message:
 				continue

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1060,7 +1060,11 @@ class BaseDocument:
 				assert df.fieldtype == "Dynamic Link"
 				doctype = self.get(df.options)
 				if not doctype:
-					frappe.throw(_("{0} must be set first").format(_(self.meta.get_label(df.options))))
+					frappe.throw(
+						_("{0} must be set first").format(
+							_(self.meta.get_label(df.options), context=self.doctype)
+						)
+					)
 				invalidate_distinct_link_doctypes(df.parent, df.options, doctype)
 
 			meta = frappe.get_meta(doctype)
@@ -1189,7 +1193,7 @@ class BaseDocument:
 			if value not in options and not (frappe.in_test and value.startswith("_T-")):
 				# show an elaborate message
 				prefix = _("Row #{0}:").format(self.idx) if self.get("parentfield") else ""
-				label = _(self.meta.get_label(df.fieldname))
+				label = _(self.meta.get_label(df.fieldname), context=self.doctype)
 				comma_options = '", "'.join(_(each) for each in options)
 
 				frappe.throw(
@@ -1264,7 +1268,9 @@ class BaseDocument:
 
 			if self.get(fieldname) != value:
 				frappe.throw(
-					_("Value cannot be changed for {0}").format(_(self.meta.get_label(fieldname))),
+					_("Value cannot be changed for {0}").format(
+						_(self.meta.get_label(fieldname), context=self.doctype)
+					),
 					frappe.CannotChangeConstantError,
 				)
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1209,7 +1209,7 @@ class Document(BaseDocument):
 				if fail:
 					frappe.throw(
 						_("Value cannot be changed for {0}").format(
-							frappe.bold(_(self.meta.get_label(field.fieldname)))
+							frappe.bold(_(self.meta.get_label(field.fieldname), context=self.doctype))
 						),
 						exc=frappe.CannotChangeConstantError,
 					)
@@ -2116,7 +2116,7 @@ class Document(BaseDocument):
 		val2 = doc.cast(val2, df)
 
 		if not compare(val1, condition, val2):
-			label = doc.meta.get_label(fieldname)
+			label = _(doc.meta.get_label(fieldname), context=doc.doctype)
 			if doc.get("parentfield"):
 				msg = _("Incorrect value in row {0}:").format(doc.idx)
 			else:
@@ -2139,7 +2139,7 @@ class Document(BaseDocument):
 	def validate_table_has_rows(self, parentfield, raise_exception=None):
 		"""Raise exception if Table field is empty."""
 		if not (isinstance(self.get(parentfield), list) and len(self.get(parentfield)) > 0):
-			label = _(self.meta.get_label(parentfield))
+			label = _(self.meta.get_label(parentfield), context=self.doctype)
 			frappe.throw(
 				_("Table {0} cannot be empty").format(label), raise_exception or frappe.EmptyTableError
 			)
@@ -2379,8 +2379,8 @@ class Document(BaseDocument):
 			frappe.throw(
 				table_row
 				+ _("{0} must be after {1}").format(
-					frappe.bold(_(self.meta.get_label(to_date_field))),
-					frappe.bold(_(self.meta.get_label(from_date_field))),
+					frappe.bold(_(self.meta.get_label(to_date_field), context=self.doctype)),
+					frappe.bold(_(self.meta.get_label(from_date_field), context=self.doctype)),
 				),
 				frappe.exceptions.InvalidDates,
 			)

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -23,7 +23,7 @@ from datetime import datetime
 import click
 
 import frappe
-from frappe import _, _lt
+from frappe import _, _noop
 from frappe.model import (
 	NO_VALUE_FIELDS,
 	child_table_fields,
@@ -49,17 +49,17 @@ ListOrTuple = list | tuple
 SerializableTypes = str | int | float | datetime
 
 DEFAULT_FIELD_LABELS = {
-	"name": _lt("ID"),
-	"creation": _lt("Created On"),
-	"docstatus": _lt("Document Status"),
-	"idx": _lt("Index"),
-	"modified": _lt("Last Updated On"),
-	"modified_by": _lt("Last Updated By"),
-	"owner": _lt("Created By"),
-	"_user_tags": _lt("Tags"),
-	"_liked_by": _lt("Liked By"),
-	"_comments": _lt("Comments"),
-	"_assign": _lt("Assigned To"),
+	"name": _noop("ID"),
+	"creation": _noop("Created On"),
+	"docstatus": _noop("Document Status"),
+	"idx": _noop("Index"),
+	"modified": _noop("Last Updated On"),
+	"modified_by": _noop("Last Updated By"),
+	"owner": _noop("Created By"),
+	"_user_tags": _noop("Tags"),
+	"_liked_by": _noop("Liked By"),
+	"_comments": _noop("Comments"),
+	"_assign": _noop("Assigned To"),
 }
 
 # When number of rows in a table exceeds this number, we disable certain features automatically.
@@ -302,12 +302,12 @@ class Meta(Document):
 		return fieldname in self._fields
 
 	def get_label(self, fieldname):
-		"""Return label of the given fieldname."""
+		"""Return the untranslated source label of the given fieldname."""
 		if df := self.get_field(fieldname):
 			return df.get("label")
 
 		if fieldname in DEFAULT_FIELD_LABELS:
-			return str(DEFAULT_FIELD_LABELS[fieldname])
+			return DEFAULT_FIELD_LABELS[fieldname]
 
 		return "No Label"
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -23,7 +23,7 @@ from datetime import datetime
 import click
 
 import frappe
-from frappe import _, _noop
+from frappe import N_, _
 from frappe.model import (
 	NO_VALUE_FIELDS,
 	child_table_fields,
@@ -49,17 +49,17 @@ ListOrTuple = list | tuple
 SerializableTypes = str | int | float | datetime
 
 DEFAULT_FIELD_LABELS = {
-	"name": _noop("ID"),
-	"creation": _noop("Created On"),
-	"docstatus": _noop("Document Status"),
-	"idx": _noop("Index"),
-	"modified": _noop("Last Updated On"),
-	"modified_by": _noop("Last Updated By"),
-	"owner": _noop("Created By"),
-	"_user_tags": _noop("Tags"),
-	"_liked_by": _noop("Liked By"),
-	"_comments": _noop("Comments"),
-	"_assign": _noop("Assigned To"),
+	"name": N_("ID"),
+	"creation": N_("Created On"),
+	"docstatus": N_("Document Status"),
+	"idx": N_("Index"),
+	"modified": N_("Last Updated On"),
+	"modified_by": N_("Last Updated By"),
+	"owner": N_("Created By"),
+	"_user_tags": N_("Tags"),
+	"_liked_by": N_("Liked By"),
+	"_comments": N_("Comments"),
+	"_assign": N_("Assigned To"),
 }
 
 # When number of rows in a table exceeds this number, we disable certain features automatically.

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -224,7 +224,7 @@ def set_name_from_naming_options(autoname, doc):
 		# notify
 		if not doc.name:
 			fieldname = autoname[6:]
-			frappe.throw(_("{0} is required").format(doc.meta.get_label(fieldname)))
+			frappe.throw(_("{0} is required").format(_(doc.meta.get_label(fieldname), context=doc.doctype)))
 
 	elif _autoname.startswith("naming_series:"):
 		set_name_by_naming_series(doc)

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -126,7 +126,7 @@ class PrintFormat(Document):
 			if value and not re.fullmatch(r"#[0-9a-fA-F]{6}", value):
 				frappe.throw(
 					_("{0} must be a hex color code like #1a5fb4").format(
-						frappe.bold(_(self.meta.get_label(fieldname)))
+						frappe.bold(_(self.meta.get_label(fieldname), context=self.doctype))
 					)
 				)
 

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -440,7 +440,11 @@ class FormTimeline extends BaseTimeline {
 		let milestone_timeline_contents = [];
 
 		(this.doc_info.milestones || []).forEach((milestone_log) => {
-			const field = frappe.meta.get_label(this.frm.doctype, milestone_log.track_field);
+			const field = __(
+				frappe.meta.get_label(this.frm.doctype, milestone_log.track_field),
+				null,
+				this.frm.doctype
+			);
 			const value = frappe.utils.bold(milestone_log.value);
 			const user_link = get_user_link(milestone_log.owner);
 			const timeline_content = get_user_message(

--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -164,7 +164,9 @@ function get_version_timeline_content(version_doc, frm) {
 									frappe.meta.get_label(
 										frm.fields_dict[row[0]].grid.doctype,
 										p[0]
-									)
+									),
+									null,
+									frm.fields_dict[row[0]].grid.doctype
 								),
 								format_content_for_timeline(p[1]),
 								format_content_for_timeline(p[2]),
@@ -223,7 +225,7 @@ function get_version_timeline_content(version_doc, frm) {
 						field_display_status === "Write" ||
 						(df.hidden && df.show_on_timeline)
 					) {
-						return __(frappe.meta.get_label(frm.doctype, p[0]));
+						return __(frappe.meta.get_label(frm.doctype, p[0]), null, frm.doctype);
 					}
 				}
 			});

--- a/frappe/public/js/frappe/list/list_filter/layout_dialog.js
+++ b/frappe/public/js/frappe/list/list_filter/layout_dialog.js
@@ -180,7 +180,7 @@ export default class LayoutDialog {
 		if (fieldname === "idx") {
 			return __("Most Used");
 		}
-		return frappe.meta.get_label(this.doctype, fieldname);
+		return __(frappe.meta.get_label(this.doctype, fieldname), null, this.doctype);
 	}
 
 	get_initial_sorting() {

--- a/frappe/public/js/frappe/list/list_sidebar_group_by.js
+++ b/frappe/public/js/frappe/list/list_sidebar_group_by.js
@@ -51,7 +51,7 @@ frappe.views.ListGroupBy = class ListGroupBy {
 						aria-haspopup="true" aria-expanded="false"
 						data-label="${label}" data-fieldname="${fieldname}" data-fieldtype="${fieldtype}"
 						href="#" onclick="return false;">
-							<span class="ellipsis">${__(label)}</span>
+							<span class="ellipsis">${__(label, null, this.doctype)}</span>
 							<span>${frappe.utils.icon("chevrons-up-down", "xs")}</span>
 						</a>
 					<ul class="dropdown-menu group-by-dropdown" role="menu">

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -205,17 +205,17 @@ $.extend(frappe.meta, {
 
 	get_label: function (dt, fn, dn) {
 		var standard = {
-			name: __("ID"),
-			creation: __("Created On"),
-			docstatus: __("Document Status"),
-			idx: __("Index"),
-			modified: __("Last Updated On"),
-			modified_by: __("Last Updated By"),
-			owner: __("Created By"),
-			_user_tags: __("Tags"),
-			_liked_by: __("Liked By"),
-			_comments: __("Comments"),
-			_assign: __("Assigned To"),
+			name: "ID",
+			creation: "Created On",
+			docstatus: "Document Status",
+			idx: "Index",
+			modified: "Last Updated On",
+			modified_by: "Last Updated By",
+			owner: "Created By",
+			_user_tags: "Tags",
+			_liked_by: "Liked By",
+			_comments: "Comments",
+			_assign: "Assigned To",
 		};
 		if (standard[fn]) {
 			return standard[fn];

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -810,7 +810,11 @@ $.extend(frappe.model, {
 			frappe.throw(
 				__("Please specify") +
 					": " +
-					__(frappe.meta.get_label(doc.doctype, fieldname, doc.parent || doc.name))
+					__(
+						frappe.meta.get_label(doc.doctype, fieldname, doc.parent || doc.name),
+						null,
+						doc.doctype
+					)
 			);
 		}
 	},

--- a/frappe/public/js/frappe/ui/sort_selector.html
+++ b/frappe/public/js/frappe/ui/sort_selector.html
@@ -10,13 +10,13 @@
 			</span>
 		</button>
 		<button type="button" class="btn btn-default btn-sm sort-selector-button text-nowrap" data-toggle="dropdown">
-			<span class="dropdown-text hidden-sm">{{ __(sort_by_label) }}</span>
+			<span class="dropdown-text hidden-sm">{{ __(sort_by_label, null, doctype) }}</span>
 			<span>{{ frappe.utils.icon("chevron-down") }}</span>
 			<ul class="dropdown-menu dropdown-menu-right">
 				{% for value in options %}
 				<li>
 					<a class="dropdown-item option" data-value="{{ value.fieldname }}">
-						{{ __(value.label) }}
+						{{ __(value.label, null, doctype) }}
 					</a>
 				</li>
 				{% endfor %}

--- a/frappe/public/js/frappe/ui/sort_selector.js
+++ b/frappe/public/js/frappe/ui/sort_selector.js
@@ -15,7 +15,9 @@ frappe.ui.SortSelector = class SortSelector {
 	make() {
 		this.prepare_args();
 		this.parent.find(".sort-selector").remove();
-		this.wrapper = $(frappe.render_template("sort_selector", this.args)).appendTo(this.parent);
+		this.wrapper = $(
+			frappe.render_template("sort_selector", { ...this.args, doctype: this.doctype })
+		).appendTo(this.parent);
 		this.bind_events();
 	}
 	bind_events() {
@@ -41,7 +43,7 @@ frappe.ui.SortSelector = class SortSelector {
 
 		if (this.sort_by !== sort_by) {
 			this.sort_by = sort_by;
-			$text.html(__(this.get_label(sort_by)));
+			$text.html(__(this.get_label(sort_by), null, this.doctype));
 		}
 		if (this.sort_order !== sort_order) {
 			this.sort_order = sort_order;

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1004,7 +1004,9 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			}
 			const field_label = frappe.meta.get_label(doctype, field[0]);
 			frappe.show_alert(
-				__("Also adding the dependent currency field {0}", [__(field_label).bold()])
+				__("Also adding the dependent currency field {0}", [
+					__(field_label, null, doctype).bold(),
+				])
 			);
 		}
 	}
@@ -1017,7 +1019,9 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			this.refresh();
 			const field_label = frappe.meta.get_label(doctype, field[0]);
 			frappe.show_alert(
-				__("Also adding the status dependency field {0}", [__(field_label).bold()])
+				__("Also adding the status dependency field {0}", [
+					__(field_label, null, doctype).bold(),
+				])
 			);
 		}
 	}
@@ -1536,7 +1540,11 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				.map((f) => {
 					const [doctype, fieldname, condition, value] = f;
 					const docfield = frappe.meta.get_docfield(doctype, fieldname);
-					const label = `<b>${__(frappe.meta.get_label(doctype, fieldname))}</b>`;
+					const label = `<b>${__(
+						frappe.meta.get_label(doctype, fieldname),
+						null,
+						doctype
+					)}</b>`;
 					switch (condition) {
 						case "=":
 							return __("{0} is equal to {1}", [

--- a/frappe/tests/test_reportview.py
+++ b/frappe/tests/test_reportview.py
@@ -9,6 +9,7 @@ from frappe.desk.reportview import (
 	export_query,
 	extract_fieldnames,
 	get,
+	get_field_info,
 	get_filter_dashboard_data,
 	get_stats,
 )
@@ -16,6 +17,34 @@ from frappe.tests import IntegrationTestCase
 
 
 class TestReportview(IntegrationTestCase):
+	def test_get_field_info_translates_field_labels(self):
+		doctype = "Translation"
+		translations = {
+			"Created On": "Translated Created On",
+			"Translated Text": "Translated Field Label",
+		}
+		for source, translated in translations.items():
+			frappe.get_doc(
+				{
+					"doctype": "Translation",
+					"language": "de",
+					"source_text": source,
+					"translated_text": translated,
+					"context": doctype,
+				}
+			).insert()
+
+		frappe.local.lang = "de"
+		try:
+			field_info = get_field_info(["creation", "translated_text"], doctype)
+		finally:
+			frappe.local.lang = "en"
+
+		self.assertEqual(
+			[field["label"] for field in field_info],
+			["Translated Created On", "Translated Field Label"],
+		)
+
 	def test_get_accepts_native_filters_and_fields(self):
 		# native dict/list payloads (JSON request body) instead of JSON strings
 		frappe.local.form_dict = frappe._dict(

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import frappe
 import frappe.translate
-from frappe import _, _lt, _noop
+from frappe import N_, _, _lt
 from frappe.gettext.extractors.javascript import extract_javascript
 from frappe.tests import IntegrationTestCase
 from frappe.translate import (
@@ -64,7 +64,7 @@ class TestTranslate(IntegrationTestCase):
 
 	def test_noop_preserves_source_string(self):
 		frappe.local.lang = "de"
-		message = _noop("Communication")
+		message = N_("Communication")
 
 		self.assertIs(type(message), str)
 		self.assertEqual(message, "Communication")
@@ -223,7 +223,7 @@ class TestTranslate(IntegrationTestCase):
 			_(not_a_string)
 			_(not_a_string, context="wat")
 			_lt("Communication")
-			_noop("Created On")
+			N_("Created On")
 		"""
 		)
 		expected_output = [

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import frappe
 import frappe.translate
-from frappe import _, _lt
+from frappe import _, _lt, _noop
 from frappe.gettext.extractors.javascript import extract_javascript
 from frappe.tests import IntegrationTestCase
 from frappe.translate import (
@@ -61,6 +61,13 @@ class TestTranslate(IntegrationTestCase):
 
 		self.assertIsNone(frappe.cache.hget(USER_TRANSLATION_KEY, frappe.local.lang))
 		self.assertIsNone(frappe.cache.hget(MERGED_TRANSLATION_KEY, frappe.local.lang))
+
+	def test_noop_preserves_source_string(self):
+		frappe.local.lang = "de"
+		message = _noop("Communication")
+
+		self.assertIs(type(message), str)
+		self.assertEqual(message, "Communication")
 
 	def test_extract_message_from_file(self):
 		data = frappe.translate.get_messages_from_file(translation_string_file)
@@ -216,6 +223,7 @@ class TestTranslate(IntegrationTestCase):
 			_(not_a_string)
 			_(not_a_string, context="wat")
 			_lt("Communication")
+			_noop("Created On")
 		"""
 		)
 		expected_output = [
@@ -226,6 +234,7 @@ class TestTranslate(IntegrationTestCase):
 			(6, "broken on", "new line"),
 			(10, "broken on separate line", None),
 			(15, "Communication", None),
+			(16, "Created On", None),
 		]
 
 		output = extract_messages_from_python_code(code)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -646,7 +646,7 @@ def extract_messages_from_python_code(code: str) -> list[tuple[int, str, str | N
 
 	for message in extract_python(
 		io.BytesIO(code.encode()),
-		keywords=["_", "_lt", "_noop"],
+		keywords=["_", "_lt", "N_"],
 		comment_tags=(),
 		options={},
 	):

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -646,7 +646,7 @@ def extract_messages_from_python_code(code: str) -> list[tuple[int, str, str | N
 
 	for message in extract_python(
 		io.BytesIO(code.encode()),
-		keywords=["_", "_lt"],
+		keywords=["_", "_lt", "_noop"],
 		comment_tags=(),
 		options={},
 	):

--- a/frappe/utils/translations.py
+++ b/frappe/utils/translations.py
@@ -48,7 +48,7 @@ def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
 	return non_translated_string
 
 
-def N_(msg: str) -> str:
+def N_(msg: str, context: str | None = None) -> str:
 	"""Mark a string for translation extraction without translating it."""
 	return msg
 

--- a/frappe/utils/translations.py
+++ b/frappe/utils/translations.py
@@ -48,6 +48,11 @@ def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
 	return non_translated_string
 
 
+def _noop(msg: str) -> str:
+	"""Mark a string for translation extraction without translating it."""
+	return msg
+
+
 def _lt(msg: str, lang: str | None = None, context: str | None = None):
 	"""Lazily translate a string.
 

--- a/frappe/utils/translations.py
+++ b/frappe/utils/translations.py
@@ -48,7 +48,7 @@ def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
 	return non_translated_string
 
 
-def _noop(msg: str) -> str:
+def N_(msg: str) -> str:
 	"""Mark a string for translation extraction without translating it."""
 	return msg
 


### PR DESCRIPTION
Translate field labels at presentation with DocType context, and mark default labels with `N_` so gettext still extracts them.

Docs: https://github.com/frappe/frappe/wiki/Migrating-to-nightly-version#get_label-returns-untranslated-source-labels