### PR TITLE
fix(oauth): harden OAuth login

### DIFF
--- a/frappe/integrations/doctype/social_login_key/test_social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/test_social_login_key.py
@@ -9,7 +9,7 @@ from frappe.auth import CookieManager, LoginManager
 from frappe.integrations.doctype.social_login_key.social_login_key import BaseUrlNotSetError
 from frappe.tests import IntegrationTestCase
 from frappe.utils import set_request
-from frappe.utils.oauth import login_via_oauth2
+from frappe.utils.oauth import consume_oauth_state, create_oauth_state, login_via_oauth2
 
 TEST_GITHUB_USER = "githublogin@example.com"
 
@@ -35,7 +35,7 @@ class TestSocialLoginKey(IntegrationTestCase):
 		mock_session.get.side_effect = github_response_for_private_email
 
 		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
-			login_via_oauth2("github", "iwriu", {"token": "ewrwerwer"})  # Dummy code and state token
+			login_via_oauth2("github", "iwriu", create_oauth_state(None))  # Dummy code, real state token
 
 	def test_github_login_with_public_email(self):
 		github_social_login_setup()
@@ -44,7 +44,7 @@ class TestSocialLoginKey(IntegrationTestCase):
 		mock_session.get.side_effect = github_response_for_public_email
 
 		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
-			login_via_oauth2("github", "iwriu", {"token": "ewrwerwer"})  # Dummy code and state token
+			login_via_oauth2("github", "iwriu", create_oauth_state(None))  # Dummy code, real state token
 
 	def test_normal_signup_and_github_login(self):
 		github_social_login_setup()
@@ -57,8 +57,56 @@ class TestSocialLoginKey(IntegrationTestCase):
 		mock_session.get.side_effect = github_response_for_login
 
 		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
-			login_via_oauth2("github", "iwriu", {"token": "ewrwerwer"})
+			login_via_oauth2("github", "iwriu", create_oauth_state(None))
 		self.assertEqual(frappe.session.user, TEST_GITHUB_USER)
+
+	def test_oauth_state_helpers_reject_unknown_and_reused_tokens(self):
+		"""consume_oauth_state must only resolve tokens it minted itself, and only once."""
+		self.assertIsNone(consume_oauth_state("attacker-forged-token"))
+		self.assertIsNone(consume_oauth_state(""))
+
+		state = create_oauth_state("/app/some-page")
+		self.assertEqual(consume_oauth_state(state), "/app/some-page")
+		# same token can't be redeemed twice
+		self.assertIsNone(consume_oauth_state(state))
+
+	def test_forged_oauth_state_is_rejected_end_to_end(self):
+		"""A state value that wasn't issued via create_oauth_state() must not log anyone in
+		or produce a redirect, regardless of what it contains."""
+		github_social_login_setup()
+
+		mock_session = MagicMock()
+		mock_session.get.side_effect = github_response_for_login
+
+		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
+			login_via_oauth2("github", "iwriu", "attacker-forged-token")
+
+		self.assertEqual(frappe.session.user, "Guest")
+		self.assertEqual(frappe.local.response.get("http_status_code"), 417)
+		self.assertNotEqual(frappe.local.response.get("type"), "redirect")
+
+	def test_oauth_state_cannot_be_replayed(self):
+		"""A legitimate state token must not be usable a second time."""
+		github_social_login_setup()
+
+		mock_session = MagicMock()
+		mock_session.get.side_effect = github_response_for_login
+
+		state = create_oauth_state("/app/some-legit-page")
+
+		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
+			login_via_oauth2("github", "iwriu", state)
+		self.assertEqual(frappe.session.user, TEST_GITHUB_USER)
+		self.assertEqual(frappe.local.response.get("location"), "/app/some-legit-page")
+
+		frappe.set_user("Guest")
+		frappe.local.response.pop("location", None)
+		frappe.local.response.pop("http_status_code", None)
+
+		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
+			login_via_oauth2("github", "iwriu", state)
+		self.assertEqual(frappe.session.user, "Guest")
+		self.assertEqual(frappe.local.response.get("http_status_code"), 417)
 
 	def test_force_disabled_signups(self):
 		key = github_social_login_setup()
@@ -69,7 +117,7 @@ class TestSocialLoginKey(IntegrationTestCase):
 		mock_session.get.side_effect = github_response_for_login
 
 		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
-			login_via_oauth2("github", "iwriu", {"token": "ewrwerwer"})
+			login_via_oauth2("github", "iwriu", create_oauth_state(None))
 		self.assertEqual(frappe.session.user, "Guest")
 
 	@IntegrationTestCase.change_settings("Website Settings", disable_signup=1)
@@ -83,7 +131,7 @@ class TestSocialLoginKey(IntegrationTestCase):
 		mock_session.get.side_effect = github_response_for_login
 
 		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
-			login_via_oauth2("github", "iwriu", {"token": "ewrwerwer"})
+			login_via_oauth2("github", "iwriu", create_oauth_state(None))
 
 		self.assertEqual(frappe.session.user, TEST_GITHUB_USER)
 

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import base64
 import json
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -93,19 +92,40 @@ def get_oauth_keys(provider: str) -> dict[str, str]:
 	}
 
 
+OAUTH_LOGIN_FLOW_CACHE_PREFIX = "frappe_oauth_login"
+
+
+def create_oauth_state(redirect_to: str | None) -> str:
+	"""Create a single-use token referencing this login attempt's `redirect_to`.
+
+	The returned token is what gets sent to the OAuth provider as `state`.
+	"""
+	state = frappe.generate_hash(length=32)
+	frappe.cache.set_value(f"{OAUTH_LOGIN_FLOW_CACHE_PREFIX}:{state}", redirect_to or "", expires_in_sec=600)
+	return state
+
+
+def consume_oauth_state(state: str) -> str | None:
+	"""Look up and invalidate the redirect_to stored for this login attempt.
+
+	Returns None if `state` doesn't reference a known, unused login attempt.
+	"""
+	if not state:
+		return None
+	key = f"{OAUTH_LOGIN_FLOW_CACHE_PREFIX}:{state}"
+	redirect_to = frappe.cache.get_value(key)
+	frappe.cache.delete_value(key)
+	return redirect_to
+
+
 def get_oauth2_authorize_url(provider: str, redirect_to: str) -> str:
 	flow = get_oauth2_flow(provider)
 
-	state = {
-		"site": frappe.utils.get_url(),
-		"token": frappe.generate_hash(),
-		"redirect_to": redirect_to,
-	}
+	state = create_oauth_state(redirect_to)
 
-	# relative to absolute url
 	data = {
 		"redirect_uri": get_redirect_uri(provider),
-		"state": base64.b64encode(bytes(json.dumps(state).encode("utf-8"))),
+		"state": state,
 	}
 
 	oauth2_providers = get_oauth2_providers()
@@ -199,19 +219,19 @@ def login_oauth_user(
 	data: dict | str,
 	*,
 	provider: str | None = None,
-	state: dict | str,
+	state: str,
 	generate_login_token: bool = False,
 ):
-	# json.loads data and state
 	if isinstance(data, str):
 		data = json.loads(data)
 
-	if isinstance(state, str):
-		state = base64.b64decode(state)
-		state = json.loads(state.decode("utf-8"))
-
-	if not (state and state["token"]):
-		frappe.respond_as_web_page(_("Invalid Request"), _("Token is missing"), http_status_code=417)
+	redirect_to = consume_oauth_state(state)
+	if redirect_to is None:
+		frappe.respond_as_web_page(
+			_("Invalid Request"),
+			_("Your login attempt is invalid or has expired. Please try again."),
+			http_status_code=417,
+		)
 		return
 
 	# All user emails are stored as lowercase, but OAuth provider could have it in mixed case.
@@ -248,10 +268,9 @@ def login_oauth_user(
 		frappe.response["login_token"] = login_token
 
 	else:
-		redirect_to = state.get("redirect_to")
 		redirect_post_login(
 			desk_user=frappe.local.response.get("message") == "Logged In",
-			redirect_to=redirect_to,
+			redirect_to=redirect_to or None,
 			provider=provider,
 		)
 


### PR DESCRIPTION
Hardening OAuth Login by replacing the JSON-encoded state parameter with a random single-use token backed by server-side cache, resolving `redirect_to` via lookup instead of decoding it from state.


closes Ticket 73520