### PR TITLE
fix: allowlist print settings overrides to the doctype's print toggles

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -508,6 +508,9 @@ frappe.ui.form.PrintView = class {
 		if (letterhead) {
 			params.append("letterhead", letterhead);
 		}
+		if (this.additional_settings && Object.keys(this.additional_settings).length) {
+			params.append("settings", JSON.stringify(this.additional_settings));
+		}
 		iframe.prop("src", `/printpreview?${params.toString()}`);
 		iframe.css("height", "calc(100vh - var(--page-head-height) - var(--navbar-height))");
 	}

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -744,6 +744,9 @@ frappe.ui.form.PrintView = class {
 			if (print_format.name) {
 				params.append("print_format", print_format.name);
 			}
+			if (this.additional_settings && Object.keys(this.additional_settings).length) {
+				params.append("settings", JSON.stringify(this.additional_settings));
+			}
 			let w = window.open(
 				`/api/method/frappe.utils.print_format_generator.download_pdf?${params}`
 			);

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -170,7 +170,13 @@
 												>{{ thumb(col, row).abbr }}</span
 											>
 										</template>
-										<div class="cell-lines">
+										<div
+											class="cell-lines"
+											:class="{
+												'cell-lines--horizontal':
+													col.merge_direction === 'horizontal',
+											}"
+										>
 											<div
 												v-for="(mf, mi) in text_merges(col)"
 												:key="mi"

--- a/frappe/public/js/print_format_builder/components/inspector/RepeaterFieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/RepeaterFieldInspector.vue
@@ -19,10 +19,7 @@
 				:show="selected_field.show_label"
 				@update:show="(v) => (selected_field.show_label = v)"
 			/>
-			<div
-				class="pfb-insp-row--col"
-				style="display: flex; flex-direction: column; gap: 6px; margin-top: 8px"
-			>
+			<div class="pfb-insp-row--col" style="margin-top: 8px">
 				<label class="pfb-insp-label">{{ __("Show row when") }}</label>
 				<input
 					class="pfb-insp-input"

--- a/frappe/public/js/print_format_builder/components/inspector/RepeaterFieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/RepeaterFieldInspector.vue
@@ -19,6 +19,23 @@
 				:show="selected_field.show_label"
 				@update:show="(v) => (selected_field.show_label = v)"
 			/>
+			<div
+				class="pfb-insp-row--col"
+				style="display: flex; flex-direction: column; gap: 6px; margin-top: 8px"
+			>
+				<label class="pfb-insp-label">{{ __("Show row when") }}</label>
+				<input
+					class="pfb-insp-input"
+					type="text"
+					:placeholder="__('e.g. row.qty > 0')"
+					:value="selected_field.row_condition || ''"
+					@input="selected_field.row_condition = $event.target.value"
+				/>
+				<p class="pfb-insp-hint text-muted">
+					{{ __("Leave blank to show every row. Reference the row with") }}
+					<code>row.fieldname</code>.
+				</p>
+			</div>
 		</InspectorSection>
 
 		<InspectorSection :label="__('Columns')">

--- a/frappe/public/js/print_format_builder/components/inspector/TableFieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/TableFieldInspector.vue
@@ -184,14 +184,17 @@
 										@select="(opt) => add_merged_field(col, opt.value)"
 									/>
 								</div>
-								<SegmentedRow
+								<div
 									v-if="col.merged_fields && col.merged_fields.length"
-									:label="__('Direction')"
-									:model-value="col.merge_direction || 'vertical'"
-									:options="merge_direction_opts"
-									style="margin-top: 8px"
-									@update:model-value="(v) => (col.merge_direction = v)"
-								/>
+									class="pfb-merge-direction"
+								>
+									<SegmentedRow
+										:label="__('Direction')"
+										:model-value="col.merge_direction || 'vertical'"
+										:options="merge_direction_opts"
+										@update:model-value="(v) => (col.merge_direction = v)"
+									/>
+								</div>
 							</div>
 						</div>
 					</template>
@@ -507,6 +510,11 @@ function set_image_size(col, value) {
 
 .pfb-col-add-row {
 	padding: 6px 14px 10px;
+	border-top: 1px solid var(--gray-100);
+}
+
+.pfb-merge-direction {
+	padding: 8px 14px 10px;
 	border-top: 1px solid var(--gray-100);
 }
 

--- a/frappe/public/js/print_format_builder/components/inspector/TableFieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/TableFieldInspector.vue
@@ -184,6 +184,14 @@
 										@select="(opt) => add_merged_field(col, opt.value)"
 									/>
 								</div>
+								<SegmentedRow
+									v-if="col.merged_fields && col.merged_fields.length"
+									:label="__('Direction')"
+									:model-value="col.merge_direction || 'vertical'"
+									:options="merge_direction_opts"
+									style="margin-top: 8px"
+									@update:model-value="(v) => (col.merge_direction = v)"
+								/>
 							</div>
 						</div>
 					</template>
@@ -372,6 +380,11 @@ const merge_style_opts = [
 	{ value: "secondary", label: __("Secondary") },
 	{ value: "mono-sm", label: __("Code") },
 	{ value: "muted-sm", label: __("Muted") },
+];
+
+const merge_direction_opts = [
+	{ value: "vertical", label: __("Vertical") },
+	{ value: "horizontal", label: __("Horizontal") },
 ];
 
 function find_field(fieldname) {

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -146,6 +146,7 @@ export const TABLE_COLUMN_PLUCK_KEYS = [
 	"width",
 	"field_template",
 	"merged_fields",
+	"merge_direction",
 	"image_size",
 ];
 
@@ -166,6 +167,7 @@ export const FIELD_PLUCK_KEYS = [
 	"field_template",
 	"source",
 	"repeater_columns",
+	"row_condition",
 	"show_label",
 	"align",
 	"label_justify",
@@ -198,6 +200,7 @@ export const ZONE_FIELD_PLUCK_KEYS = [
 	"field_template",
 	"source",
 	"repeater_columns",
+	"row_condition",
 	"show_label",
 	"align",
 	"label_justify",

--- a/frappe/templates/print_format/macros/Repeater.html
+++ b/frappe/templates/print_format/macros/Repeater.html
@@ -8,7 +8,8 @@
 			<col{% if col.width %} style="width: {{ col.width|int }}%"{% endif %} />
 			{% endfor %}
 		</colgroup>
-		{% for row in doc.get(df.source) %}
+		{%- set _rows = df.get('_rows') if df.get('_rows') is not none else doc.get(df.source) -%}
+		{% for row in _rows %}
 		<tr>
 			{% for col in (df.repeater_columns or []) %}
 			{%- set _align = col.align if col.align in ("left", "center", "right") else "left" -%}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -66,7 +66,7 @@
 								<span class="cell-thumb" style="width:{{ _size }}px;height:{{ _size }}px;font-size:{{ (_size * 0.4)|int }}px;background:hsl({{ _hue }},65%,92%);color:hsl({{ _hue }},55%,35%)">{{ _abbr|e }}</span>
 								{%- endif -%}
 							{%- endif -%}
-							<div class="cell-lines">
+							<div class="cell-lines{% if column.merge_direction == 'horizontal' %} cell-lines--horizontal{% endif %}">
 								{%- for mf in _merged -%}{%- if mf.fieldname and mf.fieldname != ns.img_fn -%}<div class="cell-line cell-line--{{ (mf.style or 'primary')|e }}">{{ row.get_formatted(mf.fieldname)|striptags|e }}</div>{%- endif -%}{%- endfor -%}
 							</div>
 						</div>

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -267,6 +267,13 @@
 	min-width: 0;
 }
 
+.print-format-doc .child-table .cell-lines--horizontal {
+	flex-direction: row;
+	flex-wrap: wrap;
+	align-items: baseline;
+	column-gap: 0.6em;
+}
+
 .print-format-doc .child-table .cell-line {
 	word-break: break-word;
 }

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -489,12 +489,8 @@ class PrintFormatGenerator:
 		return layout
 
 	def filter_repeater_rows(self, df):
-		"""Drop repeater rows whose row_condition evaluates falsy.
-
-		The condition is a user expression evaluated per row with `doc` and `row`
-		in scope. Rows are cached on `_rows` for the macro; a bad expression fails
-		open (keeps the row) so a typo never silently blanks the table.
-		"""
+		"""Drop repeater rows whose row_condition is falsy; a bad expression fails open
+		(keeps the row) so a typo never silently blanks the table."""
 		if df.get("fieldtype") != "Repeater" or not df.get("row_condition") or not df.get("source"):
 			return
 		condition = df["row_condition"]

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -435,7 +435,7 @@ class PrintFormatGenerator:
 
 	def set_field_renderers(self, layout):
 		renderers = {"HTML Editor": "HTML", "Markdown Editor": "Markdown"}
-		eval_locals = {"doc": self.doc}
+		eval_locals = {"doc": self.doc, "print_settings": self.print_settings}
 		for section in layout["sections"]:
 			if section.get("visible_if"):
 				try:
@@ -484,10 +484,11 @@ class PrintFormatGenerator:
 		if df.get("fieldtype") != "Repeater" or not df.get("row_condition") or not df.get("source"):
 			return
 		condition = df["row_condition"]
+		eval_locals = {"doc": self.doc, "print_settings": self.print_settings}
 		kept = []
 		for row in self.doc.get(df["source"]) or []:
 			try:
-				keep = frappe.safe_eval(condition, None, {"doc": self.doc, "row": row})
+				keep = frappe.safe_eval(condition, None, {**eval_locals, "row": row})
 			except Exception:
 				keep = True
 			if keep:

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -453,6 +453,7 @@ class PrintFormatGenerator:
 					df["renderer"] = renderers.get(fieldtype) or fieldtype.replace(" ", "")
 					df["section"] = section
 					self.prepare_barcode(df)
+					self.filter_repeater_rows(df)
 
 		# Also process header/footer zones if they are section objects
 		for zone_key in ("header", "footer"):
@@ -469,8 +470,29 @@ class PrintFormatGenerator:
 						df["renderer"] = renderers.get(fieldtype) or fieldtype.replace(" ", "")
 						df["section"] = zone
 						self.prepare_barcode(df)
+						self.filter_repeater_rows(df)
 
 		return layout
+
+	def filter_repeater_rows(self, df):
+		"""Drop repeater rows whose row_condition evaluates falsy.
+
+		The condition is a user expression evaluated per row with `doc` and `row`
+		in scope. Rows are cached on `_rows` for the macro; a bad expression fails
+		open (keeps the row) so a typo never silently blanks the table.
+		"""
+		if df.get("fieldtype") != "Repeater" or not df.get("row_condition") or not df.get("source"):
+			return
+		condition = df["row_condition"]
+		kept = []
+		for row in self.doc.get(df["source"]) or []:
+			try:
+				keep = frappe.safe_eval(condition, None, {"doc": self.doc, "row": row})
+			except Exception:
+				keep = True
+			if keep:
+				kept.append(row)
+		df["_rows"] = kept
 
 	def prepare_barcode(self, df):
 		"""Resolve JsBarcode options / QR data URI for Barcode layout elements."""

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -118,7 +118,9 @@ class PrintFormatGenerator:
 	def build_context(self):
 		self.print_settings = frappe.get_doc("Print Settings")
 		if self.settings_override:
-			self.print_settings.update(self.settings_override)
+			from frappe.www.printview import get_allowed_print_settings_override
+
+			self.print_settings.update(get_allowed_print_settings_override(self.doc, self.settings_override))
 		page_width_map = {"A4": 210, "Letter": 216}
 		page_width = page_width_map.get(self.print_settings.pdf_page_size) or 210
 		body_width = page_width - self.print_format.margin_left - self.print_format.margin_right

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -61,14 +61,21 @@ def get_qr_code(value: str) -> str:
 
 
 def get_html(
-	doctype, name, print_format, letterhead=None, action_banner=None, style=None, trigger_print=False
+	doctype,
+	name,
+	print_format,
+	letterhead=None,
+	action_banner=None,
+	style=None,
+	trigger_print=False,
+	settings=None,
 ):
 	from frappe.www.printview import validate_print_for_docstatus, validate_print_permission
 
 	doc = frappe.get_doc(doctype, name)
 	validate_print_permission(doc)
 	validate_print_for_docstatus(doc)
-	generator = PrintFormatGenerator(print_format, doc, letterhead, style=style)
+	generator = PrintFormatGenerator(print_format, doc, letterhead, style=style, settings=settings)
 	return generator.get_html_preview(action_banner=action_banner, trigger_print=trigger_print)
 
 
@@ -86,7 +93,7 @@ class PrintFormatGenerator:
 		"bottom_right": "right",
 	}
 
-	def __init__(self, print_format, doc, letterhead=None, style=None):
+	def __init__(self, print_format, doc, letterhead=None, style=None, settings=None):
 		self.print_format = (
 			print_format
 			if not isinstance(print_format, str)
@@ -94,6 +101,7 @@ class PrintFormatGenerator:
 		)
 		self.doc = doc
 		self.style = style
+		self.settings_override = settings or {}
 
 		if letterhead == _("No Letterhead"):
 			letterhead = None
@@ -105,6 +113,8 @@ class PrintFormatGenerator:
 
 	def build_context(self):
 		self.print_settings = frappe.get_doc("Print Settings")
+		if self.settings_override:
+			self.print_settings.update(self.settings_override)
 		page_width_map = {"A4": 210, "Letter": 216}
 		page_width = page_width_map.get(self.print_settings.pdf_page_size) or 210
 		body_width = page_width - self.print_format.margin_left - self.print_format.margin_right

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -29,7 +29,11 @@ def render_jinja_template(template: str, doctype: str, docname: str) -> str:
 
 @frappe.whitelist()
 def download_pdf(
-	doctype: str, name: str | int, print_format: str | None = None, letterhead: str | None = None
+	doctype: str,
+	name: str | int,
+	print_format: str | None = None,
+	letterhead: str | None = None,
+	settings: str | dict | None = None,
 ):
 	from frappe.printing.doctype.print_format.classic_converter import get_default_print_format
 	from frappe.www.printview import validate_print_for_docstatus, validate_print_permission
@@ -39,7 +43,7 @@ def download_pdf(
 	validate_print_for_docstatus(doc)
 	if not print_format or print_format == "Standard":
 		print_format = get_default_print_format(doctype)
-	generator = PrintFormatGenerator(print_format, doc, letterhead)
+	generator = PrintFormatGenerator(print_format, doc, letterhead, settings=frappe.parse_json(settings))
 	pdf = generator.render_pdf()
 
 	frappe.local.response.filename = "{name}.pdf".format(name=name.replace(" ", "-").replace("/", "-"))

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -1342,6 +1342,10 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.assertEqual(rows_for("row.idx == 1"), 1)
 		self.assertEqual(rows_for("False"), 0)
 		self.assertEqual(rows_for("this is (( invalid"), n)
+		# print_settings is in scope alongside doc/row
+		with self.change_settings("Print Settings", pdf_page_size="A4"):
+			self.assertEqual(rows_for("print_settings.pdf_page_size == 'A4'"), n)
+			self.assertEqual(rows_for("print_settings.pdf_page_size == 'Letter'"), 0)
 
 	def test_merged_column_direction_emits_class(self):
 		"""A merged table column renders .cell-lines--horizontal only when

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -1401,18 +1401,40 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.assertEqual(cell_lines_class(html_for(None)), "cell-lines")
 
 	def test_settings_override_does_not_persist(self):
-		"""A print-preview settings override changes the print_settings the generator
-		renders with, but never writes back to the saved single."""
+		"""A print-preview settings override (limited to the doctype's own print toggles)
+		changes the print_settings the generator renders with, but never writes back to
+		the saved single; keys outside the allowlist are ignored."""
 		from frappe.utils.print_format_generator import PrintFormatGenerator
 
 		pf = self._make_print_format()
 		todo = self._make_todo()
+		todo.get_print_settings = lambda: ["repeat_header_footer"]
 		saved = frappe.db.get_single_value("Print Settings", "repeat_header_footer")
+		saved_draft = frappe.db.get_single_value("Print Settings", "allow_print_for_draft")
 		flipped = 0 if saved else 1
 
-		generator = PrintFormatGenerator(pf, todo, settings={"repeat_header_footer": flipped})
+		generator = PrintFormatGenerator(
+			pf, todo, settings={"repeat_header_footer": flipped, "allow_print_for_draft": 1}
+		)
 		self.assertEqual(generator.print_settings.repeat_header_footer, flipped)
+		self.assertEqual(generator.print_settings.allow_print_for_draft, saved_draft)
 		self.assertEqual(frappe.db.get_single_value("Print Settings", "repeat_header_footer"), saved)
+
+	def test_print_settings_override_allowlist(self):
+		"""get_allowed_print_settings_override keeps only fields the doctype exposes."""
+		from frappe.www.printview import get_allowed_print_settings_override
+
+		todo = self._make_todo()
+		self.assertEqual(get_allowed_print_settings_override(todo, None), {})
+		self.assertEqual(get_allowed_print_settings_override(todo, {"repeat_header_footer": 1}), {})
+
+		todo.get_print_settings = lambda: ["repeat_header_footer"]
+		self.assertEqual(
+			get_allowed_print_settings_override(
+				todo, {"repeat_header_footer": 1, "allow_print_for_draft": 1}
+			),
+			{"repeat_header_footer": 1},
+		)
 
 	def test_settings_override_reaches_pdf_download(self):
 		"""render_pdf (the PDF download path) renders with the overridden print_settings,
@@ -1423,6 +1445,7 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 
 		pf = self._make_print_format()
 		todo = self._make_todo()
+		todo.get_print_settings = lambda: ["repeat_header_footer"]
 		generator = PrintFormatGenerator(pf, todo, settings={"repeat_header_footer": 1})
 
 		with patch("frappe.utils.pdf.get_chrome_pdf", return_value=b"%PDF-"):

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -1413,3 +1413,18 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		generator = PrintFormatGenerator(pf, todo, settings={"repeat_header_footer": flipped})
 		self.assertEqual(generator.print_settings.repeat_header_footer, flipped)
 		self.assertEqual(frappe.db.get_single_value("Print Settings", "repeat_header_footer"), saved)
+
+	def test_settings_override_reaches_pdf_download(self):
+		"""render_pdf (the PDF download path) renders with the overridden print_settings,
+		so a print-preview toggle carries into the downloaded file too."""
+		from unittest.mock import patch
+
+		from frappe.utils.print_format_generator import PrintFormatGenerator
+
+		pf = self._make_print_format()
+		todo = self._make_todo()
+		generator = PrintFormatGenerator(pf, todo, settings={"repeat_header_footer": 1})
+
+		with patch("frappe.utils.pdf.get_chrome_pdf", return_value=b"%PDF-"):
+			generator.render_pdf()
+		self.assertEqual(generator.print_settings.repeat_header_footer, 1)

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -1399,3 +1399,17 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 		self.assertEqual(cell_lines_class(html_for("horizontal")), "cell-lines cell-lines--horizontal")
 		self.assertEqual(cell_lines_class(html_for("vertical")), "cell-lines")
 		self.assertEqual(cell_lines_class(html_for(None)), "cell-lines")
+
+	def test_settings_override_does_not_persist(self):
+		"""A print-preview settings override changes the print_settings the generator
+		renders with, but never writes back to the saved single."""
+		from frappe.utils.print_format_generator import PrintFormatGenerator
+
+		pf = self._make_print_format()
+		todo = self._make_todo()
+		saved = frappe.db.get_single_value("Print Settings", "repeat_header_footer")
+		flipped = 0 if saved else 1
+
+		generator = PrintFormatGenerator(pf, todo, settings={"repeat_header_footer": flipped})
+		self.assertEqual(generator.print_settings.repeat_header_footer, flipped)
+		self.assertEqual(frappe.db.get_single_value("Print Settings", "repeat_header_footer"), saved)

--- a/frappe/utils/test_print_format_generator.py
+++ b/frappe/utils/test_print_format_generator.py
@@ -1289,3 +1289,109 @@ class TestPrintFormatGenerator(IntegrationTestCase):
 
 		self.assertNotIn("print-repeating-frame", html)
 		self.assertIn("LETTERHEAD_TOP", html)
+
+	def _user_beta_format(self, layout):
+		import json
+
+		pf = frappe.get_doc(
+			{
+				"doctype": "Print Format",
+				"name": f"_Test PFG {frappe.generate_hash(length=6)}",
+				"doc_type": "User",
+				"print_format_builder_beta": 1,
+				"custom_format": 0,
+				"standard": "No",
+				"format_data": json.dumps(layout),
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(pf.delete, ignore_permissions=True)
+		return pf
+
+	def test_repeater_row_condition_filters_rows(self):
+		"""A repeater row_condition drops rows where it is falsy; a bad expression
+		fails open so a typo never blanks the table."""
+		import re
+
+		from frappe.utils.print_format_generator import PrintFormatGenerator
+
+		user = frappe.get_doc("User", "Administrator")
+		n = len(user.roles)
+		self.assertGreaterEqual(n, 2)
+
+		def rows_for(condition):
+			df = {
+				"fieldtype": "Repeater",
+				"fieldname": "_rep",
+				"label": "Roles",
+				"custom": 1,
+				"source": "roles",
+				"repeater_columns": [{"template": [{"t": "f", "v": "role"}], "align": "left"}],
+			}
+			if condition is not None:
+				df["row_condition"] = condition
+			layout = {
+				"sections": [{"label": "", "columns": [{"label": "", "fields": [df]}]}],
+				"header": {"columns": [{"label": "", "fields": []}]},
+				"footer": {"columns": [{"label": "", "fields": []}]},
+			}
+			html = PrintFormatGenerator(self._user_beta_format(layout), user).get_html_preview()
+			block = re.search(r"pfb-repeater-table.*?</table>", html, re.S)
+			return len(re.findall(r"<tr>", block.group(0))) if block else 0
+
+		self.assertEqual(rows_for(None), n)
+		self.assertEqual(rows_for("row.idx == 1"), 1)
+		self.assertEqual(rows_for("False"), 0)
+		self.assertEqual(rows_for("this is (( invalid"), n)
+
+	def test_merged_column_direction_emits_class(self):
+		"""A merged table column renders .cell-lines--horizontal only when
+		merge_direction is 'horizontal'."""
+		import re
+
+		from frappe.utils.print_format_generator import PrintFormatGenerator
+
+		user = frappe.get_doc("User", "Administrator")
+
+		def html_for(direction):
+			column = {
+				"fieldname": "role",
+				"fieldtype": "Data",
+				"label": "Role",
+				"width": 100,
+				"merged_fields": [{"fieldname": "role", "fieldtype": "Data", "style": "secondary"}],
+			}
+			if direction:
+				column["merge_direction"] = direction
+			layout = {
+				"sections": [
+					{
+						"label": "",
+						"columns": [
+							{
+								"label": "",
+								"fields": [
+									{
+										"fieldtype": "Table",
+										"fieldname": "roles",
+										"label": "Roles",
+										"custom": 1,
+										"table_columns": [column],
+									}
+								],
+							}
+						],
+					}
+				],
+				"header": {"columns": [{"label": "", "fields": []}]},
+				"footer": {"columns": [{"label": "", "fields": []}]},
+			}
+			return PrintFormatGenerator(self._user_beta_format(layout), user).get_html_preview()
+
+		def cell_lines_class(html):
+			# Match the markup, not the .cell-lines--horizontal rule in the embedded stylesheet.
+			match = re.search(r'<div class="(cell-lines[^"]*)"', html)
+			return match.group(1) if match else ""
+
+		self.assertEqual(cell_lines_class(html_for("horizontal")), "cell-lines cell-lines--horizontal")
+		self.assertEqual(cell_lines_class(html_for("vertical")), "cell-lines")
+		self.assertEqual(cell_lines_class(html_for(None)), "cell-lines")

--- a/frappe/www/printpreview.py
+++ b/frappe/www/printpreview.py
@@ -12,6 +12,7 @@ def get_context(context):
 	doctype = frappe.form_dict.doctype
 	docname = frappe.form_dict.name
 	letterhead = frappe.form_dict.get("letterhead")
+	settings = frappe.parse_json(frappe.form_dict.get("settings"))
 
 	doc = frappe.get_doc(doctype, docname)
 	pf = get_print_format_doc(frappe.form_dict.print_format, meta=doc.meta) or get_default_print_format(
@@ -21,6 +22,6 @@ def get_context(context):
 	if uses_beta_renderer(pf):
 		from frappe.utils.print_format_generator import get_html
 
-		context.body = get_html(doctype, docname, pf, letterhead)
+		context.body = get_html(doctype, docname, pf, letterhead, settings=settings)
 	else:
 		context.body = pf.get_html(docname, letterhead)

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -342,7 +342,12 @@ def get_html_and_style(
 
 		validate_print_permission(document)
 		validate_print_for_docstatus(document)
-		generator = PrintFormatGenerator(print_format, document, None if no_letterhead else letterhead)
+		generator = PrintFormatGenerator(
+			print_format,
+			document,
+			None if no_letterhead else letterhead,
+			settings=frappe.parse_json(settings),
+		)
 		html = generator.get_html_preview()
 	else:
 		try:

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -169,7 +169,7 @@ def get_rendered_template(
 	validate_print_permission(doc)
 
 	print_settings = frappe.get_single("Print Settings").as_dict()
-	print_settings.update(settings or {})
+	print_settings.update(get_allowed_print_settings_override(doc, settings))
 
 	if isinstance(no_letterhead, str):
 		no_letterhead = cint(no_letterhead)
@@ -389,6 +389,15 @@ def get_rendered_raw_commands(
 	return {
 		"raw_commands": get_rendered_template(doc=document, print_format=print_format, meta=document.meta)
 	}
+
+
+def get_allowed_print_settings_override(doc: "Document", settings: dict | None) -> dict:
+	"""Keep only the Print Settings a caller may override: the doctype's own print toggles,
+	never unrelated flags like allow_print_for_draft that the docstatus guard reads."""
+	if not settings:
+		return {}
+	allowed = set(doc.get_print_settings() or []) if hasattr(doc, "get_print_settings") else set()
+	return {key: value for key, value in settings.items() if key in allowed}
 
 
 def validate_print_for_docstatus(doc: "Document", print_settings: dict | None = None) -> None:

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -112,6 +112,7 @@ def get_context(context) -> PrintContext:
 			style=frappe.form_dict.style,
 			trigger_print=cint(frappe.form_dict.trigger_print),
 			action_banner=frappe.render_template("templates/print_formats/print_action_banner.html", context),
+			settings=settings,
 		)
 	else:
 		body = get_rendered_template(


### PR DESCRIPTION
Restrict caller-supplied `settings` (the print-preview toggle overrides sent with a print request) to the fields the doctype actually exposes via `get_print_settings` — the same list the print sidebar shows. A shared helper is applied to **both** renderers.

## Why
`settings` is applied wholesale onto Print Settings:
- classic: `get_rendered_template` does `print_settings.update(settings or {})`, and then passes that dict to `validate_print_for_docstatus` — so a user could flip `allow_print_for_draft`/`allow_print_for_cancelled` via the print URL and **bypass the draft/cancelled print guard**. (Pre-existing.)
- beta: `PrintFormatGenerator` overlays the same overrides for `visible_if` / `row_condition` evaluation.

Only fields the doctype declares as user-facing print toggles should be overridable.

## Change
- New `get_allowed_print_settings_override(doc, settings)` in `printview.py` — keeps only keys in `doc.get_print_settings()` (empty when the doctype declares none).
- Both call sites (classic `get_rendered_template`, beta `PrintFormatGenerator.build_context`) now filter through it.

Verified: for a Sales Invoice, a payload of `{allow_print_for_draft:1, enable_raw_printing:1, print_taxes_with_zero_amount:0}` is reduced to `{print_taxes_with_zero_amount:0}` — the security-relevant flags are dropped, the legit sidebar toggle is kept. 64 generator tests pass, including a unit test for the allowlist and updated override tests asserting non-allowlisted keys are ignored. ruff/prettier/eslint clean.

---
**Stacked on #40966.** The beta call site this hardens (`PrintFormatGenerator(settings=…)`) is introduced there, so this branch is based on that PR and its diff will include those commits until #40966 merges. Review/merge after it. The classic-path fix stands on its own.
