### PR TITLE
fix: revoke old token after refreshing

### DIFF
--- a/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
+++ b/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
@@ -61,6 +61,36 @@ class TestOAuthBearerToken(IntegrationTestCase):
 		self.assertEqual(stored_token.access_token, sha256_hash(access_token))
 		self.assertEqual(stored_token.refresh_token, sha256_hash(refresh_token))
 
+	def test_refresh_grant_revokes_the_rotated_token(self):
+		from frappe.oauth import OAuthWebRequestValidator
+
+		old_refresh_token = frappe.generate_hash()
+		old_token = make_bearer_token(frappe.generate_hash(), old_refresh_token)
+
+		new_access_token = frappe.generate_hash()
+		new_refresh_token = frappe.generate_hash()
+		request = frappe._dict(
+			client={"name": old_token.client},
+			user=None,
+			scopes=["all", "openid"],
+			body={"refresh_token": old_refresh_token},
+		)
+		OAuthWebRequestValidator().save_bearer_token(
+			{
+				"access_token": new_access_token,
+				"refresh_token": new_refresh_token,
+				"expires_in": 3600,
+			},
+			request,
+		)
+
+		# The rotated token is revoked, the freshly issued one is active and
+		# inherits the user from the token it replaced.
+		self.assertEqual(frappe.db.get_value("OAuth Bearer Token", old_token.name, "status"), "Revoked")
+		new_token = frappe.get_doc("OAuth Bearer Token", {"access_token": sha256_hash(new_access_token)})
+		self.assertEqual(new_token.status, "Active")
+		self.assertEqual(new_token.user, "Administrator")
+
 	def test_patch_normalizes_missing_refresh_tokens_to_null(self):
 		null_token = make_bearer_token(frappe.generate_hash(), frappe.generate_hash())
 		empty_token = make_bearer_token(frappe.generate_hash(), frappe.generate_hash())

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -195,19 +195,29 @@ class OAuthWebRequestValidator(RequestValidator):
 		# access_token and the refresh_token and set expiration for the
 		# access_token to now + expires_in seconds.
 
+		# When this is a refresh_token grant, oauthlib has already issued a fresh
+		# access/refresh token pair. Look up the token being rotated so we can both
+		# inherit its user and revoke it once the replacement is saved. Other grants
+		# (authorization_code, implicit) carry no refresh_token, and their request
+		# body may not even be a mapping (e.g. an empty string for implicit).
+		try:
+			incoming_refresh_token = request.body.get("refresh_token")
+		except AttributeError:
+			incoming_refresh_token = None
+
+		old_token_name = None
+		if incoming_refresh_token:
+			old_token_name = frappe.db.get_value(
+				"OAuth Bearer Token", {"refresh_token": get_oauth_token_hash(incoming_refresh_token)}, "name"
+			)
+
 		otoken = frappe.new_doc("OAuth Bearer Token")
 		otoken.client = request.client["name"]
-		try:
-			otoken.user = (
-				request.user
-				if request.user
-				else frappe.db.get_value(
-					"OAuth Bearer Token",
-					{"refresh_token": get_oauth_token_hash(request.body.get("refresh_token"))},
-					"user",
-				)
-			)
-		except Exception:
+		if request.user:
+			otoken.user = request.user
+		elif old_token_name:
+			otoken.user = frappe.db.get_value("OAuth Bearer Token", old_token_name, "user")
+		else:
 			otoken.user = frappe.session.user
 
 		otoken.scopes = get_url_delimiter().join(request.scopes)
@@ -215,6 +225,12 @@ class OAuthWebRequestValidator(RequestValidator):
 		otoken.refresh_token = token.get("refresh_token")
 		otoken.expires_in = token["expires_in"]
 		otoken.save(ignore_permissions=True)
+
+		# Rotate: revoke the token that was refreshed so the old access/refresh
+		# pair can no longer be used once a replacement has been issued.
+		if old_token_name:
+			frappe.db.set_value("OAuth Bearer Token", old_token_name, "status", "Revoked")
+
 		frappe.db.commit()
 
 		return frappe.get_cached_value("OAuth Client", request.client["name"], "default_redirect_uri")


### PR DESCRIPTION
This can be mildly breaking if clients don't support this.

