### PR TITLE
fix: workspace save fails when adding a new chart or widget

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -606,7 +606,7 @@ def get_custom_report_list(module):
 def save_new_widget(doc, page, blocks, new_widgets):
 	widgets = _dict()
 	if new_widgets:
-		widgets = _dict(loads(new_widgets))
+		widgets = _dict(frappe.parse_json(new_widgets))
 
 		if widgets.chart:
 			doc.charts.extend(new_widget(widgets.chart, "Workspace Chart", "charts"))

--- a/frappe/desk/doctype/workspace/test_workspace.py
+++ b/frappe/desk/doctype/workspace/test_workspace.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
+import json
+
 import frappe
 from frappe.tests import IntegrationTestCase
 
@@ -36,6 +38,35 @@ class TestWorkspace(IntegrationTestCase):
 	# 		self.assertEqual(len(cards), 2)
 	# 	else:
 	# 		self.assertEqual(len(cards), 1)
+
+	def test_save_page_with_new_widgets_as_dict(self):
+		"""save_page receives new_widgets already parsed into a dict by the request layer."""
+		from frappe.desk.doctype.workspace.workspace import save_page
+
+		workspace = frappe.new_doc("Workspace")
+		workspace.label = "New Widget Test Workspace"
+		workspace.title = "New Widget Test Workspace"
+		workspace.public = 0
+		workspace.for_user = frappe.session.user
+		workspace.content = "[]"
+		workspace.insert()
+
+		blocks = json.dumps(
+			[{"id": "abcdef1234", "type": "shortcut", "data": {"shortcut_name": "ToDo", "col": 4}}]
+		)
+
+		try:
+			save_page(
+				name=workspace.name,
+				public=0,
+				new_widgets={"shortcut": [{"type": "DocType", "link_to": "ToDo", "label": "ToDo"}]},
+				blocks=blocks,
+			)
+
+			saved = frappe.get_doc("Workspace", workspace.name)
+			self.assertEqual([shortcut.label for shortcut in saved.shortcuts], ["ToDo"])
+		finally:
+			frappe.db.delete("Workspace", {"name": workspace.name})
 
 	def test_role_restricted_non_public_workspace_visible_to_permitted_user(self):
 		"""Non-public workspace with roles should be visible to users with matching role."""


### PR DESCRIPTION
## Summary

`save_page` already parses `new_widgets` into a `dict`, but `save_new_widget` attempted to parse it again with `json.loads()`, causing a `TypeError` when saving workspace changes. This uses `frappe.parse_json()` instead, which supports both JSON strings and parsed dictionaries.

Fixes saving user-created workspaces and standard workspaces in `developer_mode` for all widget types.

## Before/After


https://github.com/user-attachments/assets/fc0ceed2-8abd-4fb7-b363-0846bd799a38

https://github.com/user-attachments/assets/6aadf2f4-26c1-4ec5-bb6a-3a3f1eb8dc89


---
Closes #40872.