### PR TITLE
fix: date picker shows stale month when field is empty

### DIFF
--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -19,6 +19,7 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 		if (!this.datepicker) return;
 		if (!value) {
 			this.datepicker.clear();
+			this.datepicker.date = this.get_now_date();
 			return;
 		}
 

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -4,6 +4,7 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 		if (!this.datepicker) return;
 		if (!value) {
 			this.datepicker.clear();
+			this.datepicker.date = this.get_now_date();
 			return;
 		} else if (value.toLowerCase() === "today") {
 			value = this.get_now_date();
@@ -19,7 +20,7 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 		} else if (value && !this.datepicker.selectedDates.length) {
 			const date_obj = frappe.datetime.str_to_obj(raw_value);
 			this.datepicker.selectedDates = [date_obj];
-			this.datepicker.viewDate = date_obj;
+			this.datepicker.date = date_obj;
 			this.datepicker.lastSelectedDate = date_obj;
 		}
 	}


### PR DESCRIPTION
## Summary

Date and Datetime controls reuse the same datepicker instance across documents. When an empty field called `datepicker.clear()`, it cleared the selected value but left the datepicker's view on the previously selected month. As a result, opening an empty date field on a new document showed the previous document's month instead of the current one.

This resets the datepicker's view to today whenever an empty field is cleared. It uses `get_now_date()` instead of `get_start_date()` because the Datetime implementation of `get_start_date()` still reads the old field value at that point.

Additionally, this fixes an unrelated bug where `ControlDatetime.set_formatted_input()` assigned `datepicker.viewDate`, which is not a valid property. It now updates the picker using the correct `date` property, ensuring Datetime fields open on the month of their value.

---
Closes #40910.