### PR TITLE
fix: dashboard chart form does not mark fields the server requires

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -75,20 +75,23 @@
    "fieldname": "document_type",
    "fieldtype": "Link",
    "label": "Document Type",
+   "mandatory_depends_on": "eval: doc.chart_type !== 'Custom' && doc.chart_type !== 'Report'",
    "options": "DocType",
    "set_only_once": 1
   },
   {
-   "depends_on": "eval: doc.timeseries && ['Count', 'Sum', 'Average'].includes(doc.chart_type)",
+   "depends_on": "eval: ['Count', 'Sum', 'Average'].includes(doc.chart_type)",
    "fieldname": "based_on",
    "fieldtype": "Select",
-   "label": "Time Series Based On"
+   "label": "Time Series Based On",
+   "mandatory_depends_on": "eval: ['Count', 'Sum', 'Average'].includes(doc.chart_type)"
   },
   {
    "depends_on": "eval: ['Sum', 'Average'].includes(doc.chart_type)\n",
    "fieldname": "value_based_on",
    "fieldtype": "Select",
-   "label": "Value Based On"
+   "label": "Value Based On",
+   "mandatory_depends_on": "eval: ['Sum', 'Average'].includes(doc.chart_type)"
   },
   {
    "fieldname": "column_break_6",
@@ -163,7 +166,8 @@
    "depends_on": "eval:doc.chart_type === 'Group By'",
    "fieldname": "group_by_based_on",
    "fieldtype": "Select",
-   "label": "Group By Based On"
+   "label": "Group By Based On",
+   "mandatory_depends_on": "eval:doc.chart_type === 'Group By'"
   },
   {
    "default": "Count",
@@ -177,7 +181,8 @@
    "depends_on": "eval: ['Sum', 'Average'].includes(doc.group_by_type)",
    "fieldname": "aggregate_function_based_on",
    "fieldtype": "Select",
-   "label": "Aggregate Function Based On"
+   "label": "Aggregate Function Based On",
+   "mandatory_depends_on": "eval: doc.chart_type === 'Group By' && ['Sum', 'Average'].includes(doc.group_by_type)"
   },
   {
    "depends_on": "eval:doc.chart_type === 'Group By'",
@@ -304,7 +309,7 @@
   }
  ],
  "links": [],
- "modified": "2025-06-08 22:49:08.587921",
+ "modified": "2026-07-17 11:05:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -90,8 +90,7 @@
    "depends_on": "eval: ['Sum', 'Average'].includes(doc.chart_type)\n",
    "fieldname": "value_based_on",
    "fieldtype": "Select",
-   "label": "Value Based On",
-   "mandatory_depends_on": "eval: ['Sum', 'Average'].includes(doc.chart_type)"
+   "label": "Value Based On"
   },
   {
    "fieldname": "column_break_6",
@@ -309,7 +308,7 @@
   }
  ],
  "links": [],
- "modified": "2026-07-17 11:05:00.000000",
+ "modified": "2026-07-17 11:42:00.000000",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",


### PR DESCRIPTION
## Summary

Several fields validated by `check_required_field` in the Dashboard Chart controller were not marked mandatory in the form, so users only discovered missing values after a failed save. In one case, the required field was hidden entirely, making the chart impossible to save.

This aligns the form with the existing server-side validation by adding `mandatory_depends_on` to the affected fields and relaxing one `depends_on` condition that incorrectly hid a required field. The server-side validation remains unchanged as a safeguard for API requests.

## Changes

- **Time Series Based On (`based_on`)** — no longer hidden behind the **Time Series** checkbox, and marked mandatory for Count, Sum, and Average charts.
- **Document Type (`document_type`)** — marked mandatory wherever the server already requires it.
- **Value Based On (`value_based_on`)** — marked mandatory for Sum and Average charts, preventing them from silently falling back to a count while still being labelled as Sum or Average.
- **Group By Based On (`group_by_based_on`)** — marked mandatory for Group By charts.
- **Aggregate Function Based On (`aggregate_function_based_on`)** — marked mandatory for Group By charts when the Group By Type is Sum or Average.

## Result

The form now surfaces required fields before submission, matching existing server-side validation and preventing save-time errors caused by hidden or unmarked mandatory fields.

## Supporting evidence

### Before
<img width="490" height="376" alt="Screenshot 2026-07-17 at 11 31 40 AM" src="https://github.com/user-attachments/assets/8e833571-2258-47da-b609-b0e4b1f480c6" />


https://github.com/user-attachments/assets/786b3985-09d8-420f-979b-377045015d85

### After
<img width="484" height="449" alt="Screenshot 2026-07-17 at 11 35 48 AM" src="https://github.com/user-attachments/assets/648ed6db-1bb5-4e30-9935-02c275fce5f0" />

