### PR TITLE
fix: pass parent_doctype when fetching Has Role in Role form tabs

### DIFF
--- a/frappe/core/doctype/role/role.js
+++ b/frappe/core/doctype/role/role.js
@@ -189,6 +189,7 @@ class RoleProfilesTab extends RoleTab {
 				filters: { role: this.role, parenttype: "Role Profile" },
 				fields: ["parent"],
 				limit: 0,
+				parent_doctype: "Role Profile",
 			})
 			.then((rows) => unique_parents(rows).map((parent) => ({ name: parent })));
 	}
@@ -237,6 +238,7 @@ class UsersTab extends RoleTab {
 				filters: { role: this.role, parenttype: "User" },
 				fields: ["parent"],
 				limit: 0,
+				parent_doctype: "User",
 			})
 			.then((rows) => this.fetch_users(unique_parents(rows)));
 	}
@@ -475,6 +477,7 @@ class RoleAccessTab extends RoleTab {
 				filters: { role: this.role, parenttype: this.access_doctype },
 				fields: ["parent"],
 				limit: 0,
+				parent_doctype: this.access_doctype,
 			})
 			.then((rows) => {
 				const names = unique_parents(rows);

--- a/frappe/core/doctype/role/test_role.py
+++ b/frappe/core/doctype/role/test_role.py
@@ -49,3 +49,25 @@ class TestUser(IntegrationTestCase):
 
 		for user in sys_managers:
 			self.assertIn(role, frappe.get_roles(user))
+
+	def test_has_role_query_needs_parent_doctype(self):
+		frappe.get_doc("User", "test@example.com").add_roles("_Test Role 2")
+		frappe.set_user("test@example.com")
+		try:
+			self.assertRaises(
+				frappe.PermissionError,
+				frappe.get_list,
+				"Has Role",
+				filters={"role": "_Test Role 2", "parenttype": "User"},
+				fields=["parent"],
+			)
+
+			parents = frappe.get_list(
+				"Has Role",
+				filters={"role": "_Test Role 2", "parenttype": "User"},
+				fields=["parent"],
+				parent_doctype="User",
+			)
+			self.assertIn("test@example.com", [p.parent for p in parents])
+		finally:
+			frappe.set_user("Administrator")


### PR DESCRIPTION
## Summary
Opening any Role record as a non-Administrator user throws `Insufficient Permission for Has Role` when the Users, Role Profiles, or Reports/Pages tabs load.

`Has Role` is a child doctype, so its permissions are derived from the parent doctype via `has_child_permission`, which requires `parent_doctype` to be passed. The three `frappe.db.get_list("Has Role", ...)` calls in `role.js` never passed it, so the permission check always failed for every user except `Administrator`.

Fix: pass `parent_doctype` (`User`, `Role Profile`, or `this.access_doctype`) in each call.