### PR TITLE
fix: notification dot styles

### DIFF
--- a/frappe/public/scss/desk/workspace_dock.scss
+++ b/frappe/public/scss/desk/workspace_dock.scss
@@ -168,7 +168,7 @@
 			padding: 0;
 			border-radius: 50%;
 			border: 1px solid var(--surface-base);
-			background: var(--surface-red-6);
+			background: var(--surface-blue-5);
 			// dot only — hide any count text the shared notifications view sets on it
 			font-size: 0;
 			color: transparent;


### PR DESCRIPTION
Before

<img width="154" height="92" alt="Screenshot 2026-07-17 at 1 46 25 PM" src="https://github.com/user-attachments/assets/f58ee797-5ec7-4811-945b-eb63d29be303" />

After

<img width="168" height="127" alt="Screenshot 2026-07-17 at 1 46 11 PM" src="https://github.com/user-attachments/assets/c4816553-810c-48cb-9d10-7ff8f5609c31" />