### PR TITLE
fix(reportview): resolve link titles in report view export

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -483,6 +483,8 @@ def _export_query(form_params, csv_params, populate_response=True):
 		else:
 			raise frappe.PermissionError(_("You are not allowed to export {} doctype").format(doctype))
 
+	ret = resolve_link_titles(ret, db_query.fields, doctype)
+
 	if add_totals_row:
 		ret = append_totals_row(ret)
 
@@ -650,6 +652,52 @@ def get_field_info(fields, parent_doctype):
 		)
 
 	return field_info
+
+
+def resolve_link_titles(data, fields, parent_doctype):
+	"""Replace Link values with the linked document's title for doctypes with
+	`show_title_field_in_link`, matching what Report View renders on screen.
+	Values without a title (or not found) are kept as-is."""
+	title_map_by_column = {}
+
+	for index, field in enumerate(fields):
+		try:
+			doctype, fieldname = parse_field(field)
+		except ValueError:
+			continue
+
+		doctype = doctype or parent_doctype
+		df = frappe.get_meta(doctype).get_field(fieldname)
+		if not df or df.fieldtype != "Link" or not df.options:
+			continue
+
+		link_meta = frappe.get_meta(df.options)
+		if not (link_meta.show_title_field_in_link and link_meta.title_field):
+			continue
+
+		names = {row[index] for row in data if row[index]}
+		if not names:
+			continue
+
+		titles = frappe.get_all(
+			df.options,
+			filters={"name": ("in", names)},
+			fields=["name", link_meta.title_field],
+			as_list=True,
+			order_by=None,
+		)
+		title_map_by_column[index] = {name: title for name, title in titles if title}
+
+	if not title_map_by_column:
+		return data
+
+	return [
+		[
+			title_map_by_column[index].get(value, value) if index in title_map_by_column else value
+			for index, value in enumerate(row)
+		]
+		for row in data
+	]
 
 
 def handle_duration_fieldtype_values(parent_doctype, data, fields):

--- a/frappe/tests/test_reportview.py
+++ b/frappe/tests/test_reportview.py
@@ -12,6 +12,7 @@ from frappe.desk.reportview import (
 	get_field_info,
 	get_filter_dashboard_data,
 	get_stats,
+	resolve_link_titles,
 )
 from frappe.tests import IntegrationTestCase
 
@@ -142,6 +143,60 @@ class TestReportview(IntegrationTestCase):
 			rows = list(DictReader(buf))
 		names_in_export = [row["ID"] for row in rows if row.get("ID") in desired_order]
 		self.assertEqual(names_in_export, desired_order)
+
+	def test_resolve_link_titles(self):
+		# `language` links to Language, which has show_title_field_in_link
+		fields = ["`tabUser`.`name`", "`tabUser`.`language`", "`tabUser`.`user_type`", "`tabUser`.`owner`"]
+		data = [
+			("Administrator", "de", "System User", "Administrator"),
+			("Guest", None, "System User", "Administrator"),
+			("test@example.com", "no-such-language", "System User", "Administrator"),
+		]
+		resolved = resolve_link_titles(data, fields, "User")
+
+		self.assertEqual(resolved[0][1], "Deutsch")  # replaced with title
+		self.assertIsNone(resolved[1][1])  # empty values untouched
+		self.assertEqual(resolved[2][1], "no-such-language")  # unknown names kept as-is
+		# non-Link and Link-without-flag columns untouched
+		self.assertEqual(resolved[0][0], "Administrator")
+		self.assertEqual(resolved[0][2], "System User")
+		self.assertEqual(resolved[0][3], "Administrator")
+
+	def test_export_query_resolves_link_titles(self):
+		from csv import DictReader
+		from io import StringIO
+
+		doc = frappe.get_doc(
+			{
+				"doctype": "Translation",
+				"language": "de",
+				"source_text": "Export link title source",
+				"translated_text": "Export link title translated",
+			}
+		).insert()
+
+		frappe.local.form_dict = frappe._dict(
+			doctype="Translation",
+			file_format_type="CSV",
+			fields=("`tabTranslation`.`name`", "`tabTranslation`.`language`"),
+			filters={"name": doc.name},
+		)
+		export_query()
+		with StringIO(frappe.response["filecontent"].decode("utf-8")) as buf:
+			rows = list(DictReader(buf))
+		# on-screen Report View shows the Language title, export must match
+		self.assertEqual(rows[0]["Language"], "Deutsch")
+
+		frappe.local.form_dict.file_format_type = "Excel"
+		export_query()
+		self.assertTrue(frappe.response["filename"].endswith(".xlsx"))
+
+		from io import BytesIO
+
+		from openpyxl import load_workbook
+
+		sheet = load_workbook(BytesIO(frappe.response["filecontent"])).active
+		self.assertIn("Deutsch", [cell.value for row in sheet.iter_rows() for cell in row])
 
 	def test_extract_fieldname(self):
 		self.assertEqual(


### PR DESCRIPTION
## Problem

Report View resolves link titles on screen — any Link column whose target doctype has `show_title_field_in_link` displays the linked document's title (client-side, `report_view.js` → `set_link_title_field_value`). The export path (`frappe.desk.reportview.export_query`) returns raw `DatabaseQuery` values, so the downloaded CSV/Excel shows the stored name instead of the title the user sees on screen.

Reported against ERPNext Delivery Notes: the Incoterm column shows "Free On Board" on screen but exports as "FOB".

## Fix

Resolve link titles server-side in `_export_query` via a new `resolve_link_titles` helper, using the same rule as the client and `frappe.desk.form.load.set_link_titles`: Link column + target meta has `show_title_field_in_link` **and** `title_field`. Titles are batch-fetched once per column; values without a title (or not found) fall back to the raw name.

Placement notes (order matters):
- runs **after** the owner-based export permission check, which compares raw `owner` values
- runs **after** the `visible_names` reorder, which keys on raw `name` values
- runs **before** `add_totals_row` and value translation, so totals rows are untouched and titles of `translated_doctype` targets still get translated — matching on-screen `frappe.format`

Both the foreground export and the background (`export_in_background` → email) path go through `_export_query`, so one change covers both. The primary `name` column and the server-appended `owner` column are not affected (only fields defined in meta are resolved). `frappe.desk.query_report` has its own export path and is out of scope.