### PR TITLE
fix: show a session expired message and redirect to login instead of "Method Not Allowed"

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -627,6 +627,9 @@ def is_whitelisted(method):
 
 	is_guest = session["user"] == "Guest"
 	if method not in whitelisted or (is_guest and method not in guest_methods):
+		if method in whitelisted and is_guest and response.get("session_expired"):
+			raise SessionExpired
+
 		summary = _("You are not permitted to access this resource. Login to access")
 		detail = _("Function {0} is not whitelisted.").format(bold(f"{method.__module__}.{method.__name__}"))
 		msg = f"<details><summary>{summary}</summary>{detail}</details>"

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -404,7 +404,18 @@ frappe.Application = class Application {
 		});
 	}
 	handle_session_expired() {
-		frappe.app.redirect_to_login();
+		if (frappe.app.session_expired_dialog) {
+			return;
+		}
+		const dialog = new frappe.ui.Dialog({
+			title: __("Session Expired"),
+		});
+		dialog.onhide = () => frappe.app.redirect_to_login();
+		frappe.app.session_expired_dialog = dialog;
+		dialog.show();
+		dialog.set_message(
+			__("Your session has expired due to inactivity. Please log in again to continue.")
+		);
 	}
 	redirect_to_login() {
 		window.location.href = `/login?redirect-to=${encodeURIComponent(

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -149,10 +149,12 @@ frappe.request.call = function (opts) {
 			opts.success_callback && opts.success_callback(data, xhr.responseText);
 		},
 		401: function (xhr) {
-			if (frappe.app.session_expired_dialog && frappe.app.session_expired_dialog.display) {
-				frappe.app.redirect_to_login();
-			} else {
+			if (
+				frappe.app.session_expired_dialog ||
+				frappe.request.is_session_expired(xhr.responseJSON)
+			) {
 				frappe.app.handle_session_expired();
+				return;
 			}
 			opts.error_callback && opts.error_callback();
 		},
@@ -166,17 +168,14 @@ frappe.request.call = function (opts) {
 			opts.error_callback && opts.error_callback();
 		},
 		403: function (xhr) {
-			const user_id = document.cookie
-				.split(";")
-				.find((c) => c.trim().startsWith("user_id="))
-				?.split("=")[1];
 			if (
-				user_id === "Guest" ||
-				(frappe.session.user === "Guest" && frappe.session.logged_in_user !== "Guest")
+				frappe.app.session_expired_dialog ||
+				frappe.request.is_session_expired(xhr.responseJSON)
 			) {
-				// session expired
 				frappe.app.handle_session_expired();
-			} else if (xhr.responseJSON && xhr.responseJSON._error_message) {
+				return;
+			}
+			if (xhr.responseJSON && xhr.responseJSON._error_message) {
 				frappe.msgprint({
 					title: __("Not permitted"),
 					indicator: "red",
@@ -452,6 +451,20 @@ frappe.request.prepare = function (opts) {
 	delete opts.error;
 };
 
+frappe.request.is_session_expired = function (response) {
+	if (response?.session_expired) return true;
+
+	const was_logged_in =
+		frappe.session.logged_in_user && frappe.session.logged_in_user !== "Guest";
+	if (!was_logged_in) return false;
+
+	const user_id = document.cookie
+		.split(";")
+		.find((c) => c.trim().startsWith("user_id="))
+		?.split("=")[1];
+	return !user_id || user_id === "Guest" || frappe.session.user === "Guest";
+};
+
 frappe.request.cleanup = function (opts, r) {
 	// stop button indicator
 	if (opts.btn) {
@@ -464,11 +477,7 @@ frappe.request.cleanup = function (opts, r) {
 	if (opts.freeze) frappe.dom.unfreeze();
 
 	if (r) {
-		// session expired? - Guest has no business here!
-		if (
-			r.session_expired ||
-			(frappe.session.user === "Guest" && frappe.session.logged_in_user !== "Guest")
-		) {
+		if (frappe.app.session_expired_dialog || frappe.request.is_session_expired(r)) {
 			frappe.app.handle_session_expired();
 			return;
 		}

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -275,3 +275,30 @@ class TestSessionExpiry(FrappeAPITestCase):
 		with self.freeze_time(time_of_expiry):
 			self.assertIn(sid, get_expired_sessions())
 			self.assertFalse(s.get_session_data_from_db())
+
+	def test_expired_session_answers_401_without_leaking_method(self):
+		from frappe.auth import get_logged_user
+
+		frappe.set_user("Guest")
+		self.addCleanup(frappe.set_user, "Administrator")
+		self.addCleanup(frappe.local.response.pop, "session_expired", None)
+		self.addCleanup(frappe.clear_messages)
+
+		frappe.local.response["session_expired"] = 1
+		frappe.clear_messages()
+		with self.assertRaises(frappe.SessionExpired):
+			frappe.is_whitelisted(get_logged_user)
+		self.assertEqual(
+			frappe.get_message_log(), [], "an expired session must not send a message to the client"
+		)
+
+		frappe.local.response.pop("session_expired", None)
+		with self.assertRaises(frappe.PermissionError):
+			frappe.is_whitelisted(get_logged_user)
+
+		def not_whitelisted():
+			pass
+
+		frappe.local.response["session_expired"] = 1
+		with self.assertRaises(frappe.PermissionError):
+			frappe.is_whitelisted(not_whitelisted)


### PR DESCRIPTION
closes #39831
closes #40857

### The problem

When a session expires the desk does not send the user back to login. Instead they get a popup saying "Method Not Allowed: You are not permitted to access this resource. Login to access", which also names the internal method that was called (for example "Function frappe.auth.get_logged_user is not whitelisted"). Closing it and clicking anything else shows the same popup again with a different method name. The user stays stuck on the page until they log out by hand.

### Why it happens

Two separate causes, one on each side.

**Backend.** A whitelisted method called with an expired session reaches `is_whitelisted()` as a Guest and gets a 403 `PermissionError` titled "Method Not Allowed". An expired session is not a permission problem. Because the error is raised through `throw()`, the response also carries a `_server_messages` naming the internal method to a caller who is now logged out. `frappe.SessionExpired` already exists and maps to 401, but nothing ever raised it.

**Frontend.** `request.js` only treated a session as expired when the `user_id` cookie equalled `"Guest"`. On expiry the server calls `clear_cookies()`, which deletes that cookie, so the check never matched and the raw server message was shown instead. Separately, `handle_session_expired()` redirected immediately with no message at all, and the 401 handler fired a second redirect as soon as the dialog appeared, cutting it off before it could be read.

### What changed

Backend (`frappe/__init__.py`):

- Raise the existing `frappe.SessionExpired` (401) when a Guest hits a **whitelisted** method it is not allowed to call, on a request the session layer already flagged as expired. It raises directly rather than going through `throw()`, so no message is emitted and the method name never reaches a logged out caller.
- The raise is limited to the whitelisted-but-not-guest case. A genuinely non whitelisted method still raises the regular `PermissionError`, so a real wiring mistake stays visible during development. A Guest without an expired session is likewise unaffected.

Frontend (`request.js`, `desk.js`):

- New `frappe.request.is_session_expired()` puts detection in one place: the server flag first, then a logged in user whose session cookie is gone (the case the old check missed).
- The 401 and 403 handlers and `cleanup()` all bail through that helper, so once the session is known to be gone nothing else renders behind the dialog. A non session 401 such as a wrong password from `verify_password` (also 401) still runs the caller's error callback and shows its own message, instead of being mistaken for an expired session.
- `handle_session_expired()` now shows a single "Session Expired" dialog and redirects to login when it is dismissed, either via the close button or by clicking outside it. The auto redirect that was cutting the message off is gone. The caller's error callback is skipped only on the session-expired path, so error state does not flicker on the page behind the dialog while it waits for the user.

### How to test

1. Set the session expiry to a short value (for example 0:05) in System Settings.
2. Log in to the desk and leave the tab idle past the expiry.
3. Click anything that triggers a request.

Expected: a single "Session Expired" dialog explaining that the session expired. Closing it or clicking outside it lands on the login page.

Worth checking the network tab too: the expired request now answers 401 with no `_server_messages`, **instead of a 403 carrying the method name.**

### Tests

Added `test_expired_session_answers_401_without_leaking_method` in `frappe/tests/test_auth.py`. It asserts the 401 and an empty message log on expiry, that a plain Guest still gets `PermissionError`, and that a genuinely non whitelisted method during an expired session still raises `PermissionError` (so wiring mistakes stay visible). Without the backend change it fails with the exact message reported in #39831.

`frappe/tests/test_api.py` and `frappe/tests/test_api_v2.py` pass.

### One open point

`frappe.response["session_expired"]` is only set on the first request after expiry, because that same request clears the cookies and every later request arrives as a plain Guest. After that the server cannot distinguish an expired session from a visitor who never logged in, so the backend guard covers the first request and the frontend cookie check covers the stragglers.

Making the backend answer 401 for every Guest call to an auth required method would close this fully, and is arguably more correct (401 is unauthenticated, which a Guest is; 403 is authenticated but forbidden, which they are not). I left it out because it changes the status code for existing anonymous API calls.
