### PR TITLE
fix!: Don't run frappe under optimize flag

### DIFF
--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -11,6 +11,15 @@ from textwrap import dedent
 
 import click
 
+PYTHON_OPTIMIZE_ERROR = (
+	"Frappe cannot run with Python optimization enabled. "
+	"Unset PYTHONOPTIMIZE and do not use python -O or python -OO."
+)
+
+if sys.flags.optimize > 0:
+	raise SystemExit(PYTHON_OPTIMIZE_ERROR)
+
+
 import frappe
 import frappe.utils
 


### PR DESCRIPTION
These flags have almost zero benefit, this isn't `-O2` to compilers.
They just disable `assert` which shouldn't be disabled in Frappe
deployments.

Will consider removing this or making configurable if there's any
genuine need.
