### PR TITLE
fix: remove hover effect from column/table resize handle

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -900,7 +900,7 @@
 	cursor: col-resize;
 	user-select: none;
 
-	// Invisible at rest (the column border is the separator); a soft gray edge on hover.
+	// Invisible at rest (the column border is the separator).
 	&::before {
 		content: "";
 		position: absolute;
@@ -910,11 +910,6 @@
 		width: 2px;
 		background-color: var(--gray-400);
 		opacity: 0;
-		transition: opacity 0.15s;
-	}
-
-	&:hover::before {
-		opacity: 0.6;
 	}
 }
 

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -900,7 +900,7 @@
 	cursor: col-resize;
 	user-select: none;
 
-	// Invisible at rest (the column border is the separator).
+	// Invisible at rest (the column border is the separator); a soft gray edge on hover.
 	&::before {
 		content: "";
 		position: absolute;
@@ -910,6 +910,11 @@
 		width: 2px;
 		background-color: var(--gray-400);
 		opacity: 0;
+		transition: opacity 0.15s;
+	}
+
+	&:hover::before {
+		opacity: 0.6;
 	}
 }
 

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -245,23 +245,7 @@
 		background-color: var(--gray-500);
 		// Always show a faint resting separator so users can discover resize
 		opacity: 0.25;
-		transition: opacity 0.15s, background-color 0.15s, width 0.15s, height 0.15s;
 	}
-
-	&:hover::before {
-		background-color: var(--primary);
-		width: 3px;
-		height: 20px;
-		opacity: 1 !important;
-	}
-}
-
-// Darken & grow all separators when cursor enters the header row
-.list-row-head:hover .list-col-resize-handle::before {
-	background-color: var(--gray-600);
-	width: 3px;
-	height: 18px;
-	opacity: 0.7;
 }
 
 body.list-col-resizing {


### PR DESCRIPTION
**Issue**

When hovering over the column resize handle (the separator line between table headers), the resize handle changes to a darker color due to the hover styling. This creates an unnecessary visual highlight that can be distracting, especially since it does not provide any additional information or improve usability.