### PR TITLE
feat: add N_ noop for translation extraction (backport #40961)

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -42,7 +42,7 @@ from frappe.utils.caching import deprecated_local_cache as local_cache
 from frappe.utils.caching import request_cache, site_cache
 from frappe.utils.data import as_unicode, bold, cint, cstr, safe_decode, safe_encode, sbool
 from frappe.utils.local import Local, LocalProxy, release_local
-from frappe.utils.translations import _, _lt, set_user_lang
+from frappe.utils.translations import N_, _, _lt, set_user_lang
 
 # Local application imports
 from .exceptions import *

--- a/frappe/gettext/extractors/tests/test_python.py
+++ b/frappe/gettext/extractors/tests/test_python.py
@@ -1,0 +1,23 @@
+from io import BytesIO
+
+from babel.messages.extract import extract_python
+
+from frappe.gettext.translate import PYTHON_KEYWORDS
+from frappe.tests import UnitTestCase
+
+
+class TestPython(UnitTestCase):
+	def test_extract_noop(self):
+		messages = list(
+			extract_python(
+				BytesIO(b'N_("Created On")\n_lt("Last Updated On")'),
+				keywords=PYTHON_KEYWORDS,
+				comment_tags=(),
+				options={},
+			)
+		)
+
+		self.assertEqual(
+			[(line, function, message) for line, function, message, _comments in messages],
+			[(1, "N_", "Created On"), (2, "_lt", "Last Updated On")],
+		)

--- a/frappe/gettext/translate.py
+++ b/frappe/gettext/translate.py
@@ -17,6 +17,7 @@ from frappe.utils import get_bench_path
 
 PO_DIR = "locale"  # po and pot files go into [app]/locale
 POT_FILE = "main.pot"  # the app's pot file is always main.pot
+PYTHON_KEYWORDS = DEFAULT_KEYWORDS | {"_lt": None, "N_": None}
 
 
 def new_catalog(app: str, locale: str | None = None) -> Catalog:
@@ -131,9 +132,6 @@ def generate_pot(target_app: str | None = None):
 	apps = [target_app] if target_app else frappe.get_all_apps(True)
 	default_method_map = get_method_map("frappe")
 
-	keywords = DEFAULT_KEYWORDS.copy()
-	keywords["_lt"] = None
-
 	for app in apps:
 		app_path = frappe.get_pymodule_path(app, "..")
 		catalog = new_catalog(app)
@@ -145,7 +143,7 @@ def generate_pot(target_app: str | None = None):
 		method_map.extend(default_method_map)
 
 		for filename, lineno, message, comments, context in extract_from_dir(
-			app_path, method_map, directory_filter=directory_filter, keywords=keywords
+			app_path, method_map, directory_filter=directory_filter, keywords=PYTHON_KEYWORDS
 		):
 			if not message:
 				continue

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import frappe
 import frappe.translate
-from frappe import _, _lt
+from frappe import N_, _, _lt
 from frappe.gettext.extractors.javascript import extract_javascript
 from frappe.tests import IntegrationTestCase
 from frappe.translate import (
@@ -61,6 +61,13 @@ class TestTranslate(IntegrationTestCase):
 
 		self.assertIsNone(frappe.cache.hget(USER_TRANSLATION_KEY, frappe.local.lang))
 		self.assertIsNone(frappe.cache.hget(MERGED_TRANSLATION_KEY, frappe.local.lang))
+
+	def test_noop_preserves_source_string(self):
+		frappe.local.lang = "de"
+		message = N_("Communication")
+
+		self.assertIs(type(message), str)
+		self.assertEqual(message, "Communication")
 
 	def test_extract_message_from_file(self):
 		data = frappe.translate.get_messages_from_file(translation_string_file)
@@ -216,6 +223,7 @@ class TestTranslate(IntegrationTestCase):
 			_(not_a_string)
 			_(not_a_string, context="wat")
 			_lt("Communication")
+			N_("Created On")
 		"""
 		)
 		expected_output = [
@@ -226,6 +234,7 @@ class TestTranslate(IntegrationTestCase):
 			(6, "broken on", "new line"),
 			(10, "broken on separate line", None),
 			(15, "Communication", None),
+			(16, "Created On", None),
 		]
 
 		output = extract_messages_from_python_code(code)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -623,7 +623,7 @@ def extract_messages_from_python_code(code: str) -> list[tuple[int, str, str | N
 
 	for message in extract_python(
 		io.BytesIO(code.encode()),
-		keywords=["_", "_lt"],
+		keywords=["_", "_lt", "N_"],
 		comment_tags=(),
 		options={},
 	):

--- a/frappe/utils/translations.py
+++ b/frappe/utils/translations.py
@@ -48,6 +48,11 @@ def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
 	return non_translated_string
 
 
+def N_(msg: str, context: str | None = None) -> str:
+	"""Mark a string for translation extraction without translating it."""
+	return msg
+
+
 def _lt(msg: str, lang: str | None = None, context: str | None = None):
 	"""Lazily translate a string.
 


### PR DESCRIPTION
Backports `N_` from #40961 so strings can be marked for gettext extraction without translating them at call time.