### PR TITLE
fix: custom permission types denied for Administrator on client

### DIFF
--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -77,13 +77,14 @@ $.extend(frappe.perm, {
 				// used Set for "unique" levels
 				permlevels = [...new Set([0, ...levels])].sort();
 			}
+			const rights = frappe.perm.get_rights(doctype);
 			const admin_perm = [];
 			permlevels.forEach((level) => {
 				const p = {
 					permlevel: level,
-					rights_without_if_owner: new Set(frappe.perm.rights),
+					rights_without_if_owner: new Set(rights),
 				};
-				frappe.perm.rights.forEach((right) => {
+				rights.forEach((right) => {
 					p[right] = 1;
 				});
 				admin_perm[level] = p;


### PR DESCRIPTION
## Summary

During the #40251 backport (#40284), a merge conflict in `perm.js` left the Administrator branch of `_get_perm` on the older v16 implementation, which iterates the hardcoded `frappe.perm.rights` list. While the other permission paths were updated to use `frappe.perm.get_rights()`, the Administrator path was not, causing custom permission types to always evaluate to `false` for Administrator on the client.

This updates the Administrator branch to use `frappe.perm.get_rights(doctype)`, matching the role-permission and `if_owner` paths as well as the behavior on `develop`.

## Result

Custom permission types now resolve correctly for Administrator in client-side permission checks.

Fixes the Administrator part of #40960.