### PR TITLE
fix: has_perm unreliable before a doctype's meta is loaded

### DIFF
--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -58,7 +58,19 @@ $.extend(frappe.perm, {
 			return frappe.perm._get_perm(doctype, doc);
 		}
 
-		return (frappe.perm.doctype_perm[doctype] ??= frappe.perm._get_perm(doctype));
+		if (frappe.perm.doctype_perm[doctype]) {
+			return frappe.perm.doctype_perm[doctype];
+		}
+
+		const perm = frappe.perm._get_perm(doctype);
+
+		// don't cache a perm computed before the meta loads; it's degraded (read only)
+		// and would stay pinned for the session
+		if (frappe.get_meta(doctype)) {
+			frappe.perm.doctype_perm[doctype] = perm;
+		}
+
+		return perm;
 	},
 
 	_get_perm: (doctype, doc) => {
@@ -92,7 +104,7 @@ $.extend(frappe.perm, {
 			return admin_perm;
 		}
 
-		let perm = [{ read: 0, permlevel: 0 }];
+		let perm = [{ read: 0, permlevel: 0, rights_without_if_owner: new Set() }];
 
 		if (!meta) {
 			if (frappe.boot.user.can_read.includes(doctype)) {
@@ -159,7 +171,7 @@ $.extend(frappe.perm, {
 		}
 		*/
 
-		let perm = [{ read: 0, permlevel: 0 }];
+		let perm = [{ read: 0, permlevel: 0, rights_without_if_owner: new Set() }];
 		const rights = frappe.perm.get_rights(meta.name);
 
 		(meta.permissions || []).forEach((p) => {


### PR DESCRIPTION
## Summary

`frappe.perm.has_perm()` and the list view's restricted indicator could behave incorrectly when a doctype's metadata had not yet been loaded on the client (for example, before its list view or a document had been opened in the current session).

Without the metadata, `_get_perm` can only determine `read` permission from `boot.user.can_read`, so all other permission types resolve to `false`. That incomplete result was then cached, causing subsequent permission checks to continue returning incorrect values even after the metadata became available.

Additionally, the degraded permission object did not initialize `rights_without_if_owner`, causing the list view to throw `Cannot read properties of undefined (reading 'has')` in `get_match_rules`.

## Changes

- Only cache the computed permissions after the doctype metadata has been loaded, allowing permission checks to recompute once metadata is available.
- Initialize `perm[0].rights_without_if_owner` to an empty `Set` when metadata is unavailable or when `meta.permissions` is empty.

## Result

- Client-side `has_perm()` now returns the correct permissions once metadata is loaded.
- The list view no longer throws when opening a doctype before its permission map has been initialized.

Fixes #40960 (problems 2 and 3).