### PR TITLE
fix(print-format-builder): make builder preview pixel-match print output

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -1235,12 +1235,10 @@ thead:hover .col-resize-handle::after {
 /* ── Preview mode ────────────────────────────────────────── */
 .field--preview {
 	position: relative;
-	border-radius: var(--radius);
 }
 
 .field--condition-hidden {
 	opacity: 0.35;
-	border-radius: var(--radius);
 }
 
 /* outline-only selection chrome: must not change previewed geometry */

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -1308,6 +1308,7 @@ thead:hover .col-resize-handle::after {
 
 .pf-barcode-svg {
 	display: inline-block;
+	max-width: 100%;
 }
 
 .pf-builder-thumb {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -151,7 +151,10 @@
 									:class="{ 'column-value--merged': has_merge(col) }"
 									:data-fieldtype="col.fieldtype"
 									:data-fieldname="col.fieldname"
-									:style="cell_style(df)"
+									:style="
+										(col.width ? `width: ${col.width}%; ` : '') +
+										cell_style(df)
+									"
 								>
 									<!-- Merged cell: image (if any) floats left, text lines stack -->
 									<div v-if="has_merge(col)" class="cell-merged">
@@ -840,7 +843,7 @@ function thumb(col, row) {
 		abbr: frappe.get_abbr(raw) || "?",
 		style: {
 			...thumb_box(col),
-			fontSize: Math.round((col.image_size || 40) * 0.4) + "px",
+			fontSize: Math.floor((col.image_size || 40) * 0.4) + "px",
 			background: `hsl(${hue}, 65%, 92%)`,
 			color: `hsl(${hue}, 55%, 35%)`,
 		},
@@ -1305,7 +1308,6 @@ thead:hover .col-resize-handle::after {
 
 .pf-barcode-svg {
 	display: inline-block;
-	max-width: 100%;
 }
 
 .pf-builder-thumb {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -1,6 +1,7 @@
 <template>
 	<div
 		class="print-format-main"
+		data-theme="light"
 		:style="rootStyles"
 		:class="{
 			'pfb-clean-preview': !!store.preview_doc.value,

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -402,10 +402,6 @@ function remove_column(index) {
 /* Section title — hidden in editor (toolbar shows it), revealed via parent :deep() */
 .section-title-display {
 	display: none;
-	font-size: var(--text-sm);
-	font-weight: var(--weight-semibold);
-	color: var(--text-muted);
-	padding: 0;
 }
 
 .section-columns {
@@ -552,7 +548,7 @@ function remove_column(index) {
 
 /* ── Table layout (field borders) ───────────────────────── */
 .section--grid {
-	border: 1px solid var(--border-color);
+	border: 1px solid var(--gray-300);
 	border-radius: var(--border-radius-md, 8px);
 	overflow: hidden;
 	padding: 0;
@@ -563,7 +559,7 @@ function remove_column(index) {
 .section--grid .section-title-display {
 	padding: var(--pfb-cell-pad, 8px);
 	margin: 0;
-	border-bottom: 1px solid var(--border-color);
+	border-bottom: 1px solid var(--gray-300);
 }
 .section--grid .section-columns {
 	padding: 0;
@@ -572,7 +568,7 @@ function remove_column(index) {
 	padding: 0;
 }
 .section--grid .column:not(:last-child) {
-	border-right: 1px solid var(--border-color);
+	border-right: 1px solid var(--gray-300);
 }
 .section--grid .column-divider {
 	display: none;
@@ -583,7 +579,7 @@ function remove_column(index) {
 .section--grid :deep(.field--chip) {
 	padding: var(--pfb-cell-pad, 8px);
 	border: none;
-	border-bottom: 1px solid var(--border-color);
+	border-bottom: 1px solid var(--gray-300);
 	border-radius: 0;
 	background: transparent;
 }


### PR DESCRIPTION
The builder's live preview is meant to render identically to the printed/PDF output (same markup, same shared `print_format_doc.css`). A parity sweep of every preview-shared element turned up several canvas-only styles that diverged from the print side. This aligns them.

- **Canvas light-theme lock** — the PDF always renders with light-mode token values (print has no dark theme), but the preview canvas inherited the desk's `[data-theme="dark"]`, so the whole gray palette shifted (e.g. `--gray-300` `#e2e2e2`→`#999999`) and every border/label previewed heavier than it prints. Stamped `data-theme="light"` on `.print-format-main` so the white-paper subtree resolves tokens exactly as print does, in any desk theme. One lock covers all current and future tokens.
- **Section heading** — `.section-title-display` (only ever shown in preview) overrode the shared `.section-label` typography, so headings previewed smaller / semibold / muted-grey instead of the PDF's 1.1em / 700 / gray-900. Dropped the overrides so the shared rule governs.
- **Field radius** — `.field--preview` added a `border-radius` the print output never has (rounded each field in table-layout sections). Removed.
- **Grid borders** — the table-layout section border, column dividers, and label underline used `--border-color` while the shared sheet uses `--gray-300`. Aligned to `--gray-300` so the same token drives both surfaces.
- **Header-less tables** — `<td>` carried no width, so columns auto-sized in preview while the PDF constrains them (server sets `width` on both th and td). Added width to the td.
- **Merged-cell initials** — font-size used `Math.round` vs the server's `int` truncation (off-by-one px). Switched to `Math.floor`.

Why: preview must match the PDF; these were all canvas-only styles with no server twin.
