### PR TITLE
perf: cache empty allowed pages/reports to avoid per-workspace rebuild

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -198,7 +198,7 @@ def get_allowed_report_names(cache=False) -> set[str]:
 def get_user_pages_or_reports(parent, cache=False):
 	if cache:
 		has_role = frappe.cache.get_value("has_role:" + parent, user=frappe.session.user)
-		if has_role:
+		if has_role is not None:
 			return has_role
 
 	roles = frappe.get_roles()
@@ -286,7 +286,9 @@ def get_user_pages_or_reports(parent, cache=False):
 
 	if is_report:
 		if not has_permission("Report", raise_exception=False):
-			return {}
+			has_role = {}
+			frappe.cache.set_value("has_role:" + parent, has_role, frappe.session.user, 21600)
+			return has_role
 
 		reports = frappe.get_list(
 			"Report",

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -31,18 +31,16 @@ class TestBootData(FrappeTestCase):
 	def test_empty_allowed_reports_are_served_from_cache(self):
 		from unittest.mock import patch
 
-		# An empty allowed-set is a valid result and must be a cache hit; otherwise the
-		# sidebar rebuilds it once per workspace on every desk/login load.
 		frappe.set_user("Administrator")
 		user = frappe.session.user
 		frappe.cache.delete_value("has_role:Report", user=user)
+		self.addCleanup(frappe.cache.delete_value, "has_role:Report", user=user)
 
 		with patch("frappe.boot.has_permission", return_value=False) as has_perm:
 			self.assertEqual(get_user_pages_or_reports("Report", cache=True), {})
 			builds = has_perm.call_count
 			self.assertGreaterEqual(builds, 1)
 
-			# fresh request: process-local cache cleared, redis cache stays warm
 			frappe.local.cache.clear()
 
 			self.assertEqual(get_user_pages_or_reports("Report", cache=True), {})

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -28,6 +28,26 @@ class TestBootData(FrappeTestCase):
 		unseen_notes = [d.title for d in get_unseen_notes()]
 		self.assertListEqual(unseen_notes, [])
 
+	def test_empty_allowed_reports_are_served_from_cache(self):
+		from unittest.mock import patch
+
+		# An empty allowed-set is a valid result and must be a cache hit; otherwise the
+		# sidebar rebuilds it once per workspace on every desk/login load.
+		frappe.set_user("Administrator")
+		user = frappe.session.user
+		frappe.cache.delete_value("has_role:Report", user=user)
+
+		with patch("frappe.boot.has_permission", return_value=False) as has_perm:
+			self.assertEqual(get_user_pages_or_reports("Report", cache=True), {})
+			builds = has_perm.call_count
+			self.assertGreaterEqual(builds, 1)
+
+			# fresh request: process-local cache cleared, redis cache stays warm
+			frappe.local.cache.clear()
+
+			self.assertEqual(get_user_pages_or_reports("Report", cache=True), {})
+			self.assertEqual(has_perm.call_count, builds)
+
 
 class TestPermissionQueries(FrappeTestCase):
 	@classmethod


### PR DESCRIPTION
## Summary

Backport of #40998; to v15.

`get_user_pages_or_reports()` caches the user's allowed pages/reports, but an empty result was never served from that cache for two reasons:

1. The cache guard used `if has_role:`, so an empty set (`{}`) was treated as a cache miss.
2. Users without Report permission returned `{}` before reaching the cache write, so the empty result was never cached.

Since the desk sidebar creates a `Workspace` for each page, each calling `get_allowed_pages()`/`get_allowed_reports(cache=True)`, users with no allowed reports - including the guest session rendering the login page - recomputed the same empty result once per workspace.

## Changes

- Cache the empty result before the early return.
- Change the cache guard to `if has_role is not None:`, allowing empty results to be treated as valid cache hits.

## Result

Empty permission sets are now cached and reused instead of being recomputed for every workspace. On a site with ~22 workspaces, guest sidebar generation dropped from **92 queries to 4**.