### PR TITLE
feat(print-format-builder): live preview renders unsaved edits through the print pipeline

### DIFF
--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -122,7 +122,7 @@ context("Print Format Builder — create flow", () => {
 		cy.intercept("POST", "api/method/frappe.client.save").as("save");
 		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
 
-		cy.get(".pfb-tab[title='Format']", { timeout: 30000 }).click();
+		cy.get(".pfb-tab[title='Setting']", { timeout: 30000 }).click();
 		cy.get(".pfb-margin-grid").should("be.visible");
 
 		cy.get(".freeze").should("not.exist");
@@ -211,7 +211,7 @@ context("Print Format Builder — create flow", () => {
 		cy.intercept("POST", "api/method/frappe.client.save").as("save");
 		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
 
-		cy.get(".pfb-tab[title='Format']", { timeout: 30000 }).click();
+		cy.get(".pfb-tab[title='Setting']", { timeout: 30000 }).click();
 		cy.get(".pfb-margin-grid").should("be.visible");
 
 		cy.contains("label", "Font Size")
@@ -266,7 +266,7 @@ context("Print Format Builder — create flow", () => {
 		cy.intercept("POST", "api/method/frappe.client.save").as("save");
 		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
 
-		cy.get(".pfb-tab[title='Format']", { timeout: 30000 }).click();
+		cy.get(".pfb-tab[title='Setting']", { timeout: 30000 }).click();
 		cy.get(".pfb-margin-grid").should("be.visible");
 
 		// The color field is rendered with Frappe's ControlColor (adds .selected-color swatch)

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -23,7 +23,7 @@
 			     v-show (not v-if) so the picker control survives a preview round-trip. -->
 			<div v-show="!show_preview" class="canvas-toolbar">
 				<div class="canvas-toolbar-left">
-					<span class="canvas-toolbar-eyebrow">{{ __("PREVIEW DATA") }}</span>
+					<span class="canvas-toolbar-eyebrow">{{ __("Data") }}</span>
 				</div>
 				<div class="canvas-toolbar-center">
 					<div ref="doc_picker_ref" class="canvas-doc-picker"></div>

--- a/frappe/public/js/print_format_builder/components/Preview.vue
+++ b/frappe/public/js/print_format_builder/components/Preview.vue
@@ -16,21 +16,20 @@
 				</button>
 			</div>
 		</div>
-		<div v-if="url && !preview_loaded">Generating preview...</div>
+		<div v-if="docname && !preview_loaded">{{ __("Generating preview...") }}</div>
 		<iframe
 			ref="iframe"
-			:src="url"
-			v-if="url"
-			v-show="preview_loaded"
+			:src="type === 'PDF' ? url : undefined"
+			v-show="docname && preview_loaded"
 			class="preview-iframe"
-			@load="preview_loaded = true"
+			@load="type === 'PDF' && (preview_loaded = true)"
 		></iframe>
 	</div>
 </template>
 
 <script setup>
 import { useStore } from "../stores";
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onMounted, onActivated } from "vue";
 
 // mixin
 let { print_format, store } = useStore();
@@ -46,8 +45,35 @@ let doc_select = ref(null);
 let preview_type = ref(null);
 
 // methods
+function render() {
+	if (!docname.value) return;
+	preview_loaded.value = false;
+	if (type.value === "PDF") return;
+	let params = {
+		print_format: store.value.get_preview_format_doc(),
+		doctype: doctype.value,
+		name: docname.value,
+	};
+	if (store.value.letterhead) {
+		params.letterhead = store.value.letterhead.name;
+	}
+	return frappe
+		.call("frappe.utils.print_format_generator.render_builder_preview", params)
+		.then((r) => {
+			let cd = iframe.value?.contentDocument;
+			if (!cd) return;
+			cd.open();
+			cd.write(r.message || "");
+			cd.close();
+			preview_loaded.value = true;
+		});
+}
 function refresh() {
-	iframe.value?.contentWindow.location.reload();
+	if (type.value === "PDF") {
+		iframe.value?.contentWindow.location.reload();
+	} else {
+		render();
+	}
 }
 function get_default_docname() {
 	return frappe.db.get_list(doctype.value, { limit: 1 }).then((doc) => {
@@ -75,6 +101,8 @@ let url = computed(() => {
 	return `${_url}?${params.toString()}`;
 });
 
+onActivated(render);
+
 // mounted
 onMounted(() => {
 	doc_select.value = frappe.ui.form.make_control({
@@ -88,6 +116,7 @@ onMounted(() => {
 				docname.value = doc_select.value.get_value();
 				// keep the editor's preview selection in sync with the preview
 				store.value.load_preview_doc(docname.value || null);
+				render();
 			},
 		},
 		render_input: true,
@@ -101,6 +130,7 @@ onMounted(() => {
 			options: ["HTML", "PDF"],
 			change: () => {
 				type.value = preview_type.value.get_value();
+				render();
 			},
 		},
 		render_input: true,

--- a/frappe/public/js/print_format_builder/components/Preview.vue
+++ b/frappe/public/js/print_format_builder/components/Preview.vue
@@ -43,12 +43,21 @@ let doc_select_ref = ref(null);
 let preview_type_ref = ref(null);
 let doc_select = ref(null);
 let preview_type = ref(null);
+let render_seq = 0;
 
 // methods
+function write_iframe(html) {
+	let cd = iframe.value?.contentDocument;
+	if (!cd) return;
+	cd.open();
+	cd.write(html);
+	cd.close();
+}
 function render() {
 	if (!docname.value) return;
 	preview_loaded.value = false;
 	if (type.value === "PDF") return;
+	let seq = ++render_seq;
 	let params = {
 		print_format: store.value.get_preview_format_doc(),
 		doctype: doctype.value,
@@ -60,11 +69,13 @@ function render() {
 	return frappe
 		.call("frappe.utils.print_format_generator.render_builder_preview", params)
 		.then((r) => {
-			let cd = iframe.value?.contentDocument;
-			if (!cd) return;
-			cd.open();
-			cd.write(r.message || "");
-			cd.close();
+			if (seq !== render_seq) return;
+			write_iframe(r.message || "");
+			preview_loaded.value = true;
+		})
+		.catch(() => {
+			if (seq !== render_seq) return;
+			write_iframe(`<p style="padding:1rem">${__("Could not generate preview.")}</p>`);
 			preview_loaded.value = true;
 		});
 }

--- a/frappe/public/js/print_format_builder/components/Preview.vue
+++ b/frappe/public/js/print_format_builder/components/Preview.vue
@@ -55,8 +55,8 @@ function write_iframe(html) {
 }
 function render() {
 	if (!docname.value) return;
-	preview_loaded.value = false;
 	if (type.value === "PDF") return;
+	preview_loaded.value = false;
 	let seq = ++render_seq;
 	let params = {
 		print_format: store.value.get_preview_format_doc(),

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -294,7 +294,7 @@ const tabs = computed(() => [
 	{ id: "blocks", label: __("Blocks") },
 	{ id: "templates", label: __("Templates") },
 	{ id: "outline", label: __("Outline") },
-	{ id: "format", label: __("Format") },
+	{ id: "format", label: __("Setting") },
 ]);
 
 // ── blocks tab items ──────────────────────────────────────
@@ -791,8 +791,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 .pfb-group-label {
 	font-size: var(--text-tiny);
 	font-weight: var(--weight-semibold);
-	text-transform: uppercase;
-	letter-spacing: 0.06em;
+	letter-spacing: 0;
 	color: var(--text-muted);
 	padding: 8px 10px 2px;
 	display: flex;

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -480,10 +480,7 @@ function build_field(df) {
 
 function select_section(section) {
 	store.scroll_to_section.value = section;
-	store.selected_section.value = section;
-	store.selected_field.value = null;
-	store.selected_letterhead.value = false;
-	store.selected_lh_footer.value = false;
+	store.select_section(section);
 }
 
 function clone_as_section() {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -186,7 +186,7 @@
 												class="cell-line"
 												:class="`cell-line--${mf.style || 'primary'}`"
 											>
-												{{ format_merged(row, mf.fieldname) }}
+												{{ format_merged(row, i, mf.fieldname) }}
 											</div>
 										</div>
 									</div>
@@ -814,10 +814,11 @@ function text_merges(col) {
 	return merged_fields(col).filter((mf) => mf.fieldname !== img?.fieldname);
 }
 
-// Format a merged sub-field using its own child docfield definition.
-// Merged lines are plain text, so strip any HTML kept for rich-text
-// fields (Text Editor / Long Text) down to its text content.
-function format_merged(row, fieldname) {
+function format_merged(row, i, fieldname) {
+	const server = store.preview_child_values.value?.[props.df.fieldname]?.[i]?.[fieldname];
+	if (server !== null && server !== undefined && server !== "") {
+		return strip_html_to_text(String(server)).trim();
+	}
 	const dcol = frappe.meta.get_docfield(props.df.options, fieldname) || {
 		fieldname,
 		fieldtype: "Data",

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -846,9 +846,7 @@ function thumb(col, row) {
 }
 
 function select_field() {
-	store.selected_field.value = props.df;
-	store.selected_letterhead.value = false;
-	store.selected_lh_footer.value = false;
+	store.select_field(props.df);
 	if (props.df.fieldtype !== "HTML") {
 		editing.value = true;
 	}

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -486,7 +486,8 @@ import {
 	thumb_hue,
 	parse_inline_style,
 } from "../../utils";
-import { createApp, ref, nextTick, watch, computed, inject, onUnmounted } from "vue";
+import { createApp, ref, nextTick, watch, computed, inject } from "vue";
+import { useColumnResize } from "../../composables/useColumnResize";
 import JsBarcode from "jsbarcode";
 
 const props = defineProps(["df", "field_orientation"]);
@@ -952,7 +953,7 @@ function get_column_to_add(fieldname) {
 	return { ...frappe.meta.get_docfield(props.df.options, fieldname), width: 10 };
 }
 
-let end_col_resize = null;
+const { start: start_column_resize } = useColumnResize();
 
 function start_col_resize(e, ci) {
 	const cols = props.df.table_columns;
@@ -963,30 +964,14 @@ function start_col_resize(e, ci) {
 	const start_x = e.clientX;
 	const start_left = left.width || 10;
 	const start_right = right.width || 10;
-	const handle = e.target;
-	handle.classList.add("col-resize-handle--active");
-	document.body.classList.add("pfb-col-resizing");
 	const on_move = (ev) => {
 		let delta = Math.round(((ev.clientX - start_x) / table_width) * 100);
 		delta = Math.max(5 - start_left, Math.min(start_right - 5, delta));
 		left.width = start_left + delta;
 		right.width = start_right - delta;
 	};
-	const on_up = () => {
-		document.removeEventListener("pointermove", on_move);
-		document.removeEventListener("pointerup", on_up);
-		document.removeEventListener("pointercancel", on_up);
-		handle.classList.remove("col-resize-handle--active");
-		document.body.classList.remove("pfb-col-resizing");
-		end_col_resize = null;
-	};
-	document.addEventListener("pointermove", on_move);
-	document.addEventListener("pointerup", on_up);
-	document.addEventListener("pointercancel", on_up);
-	end_col_resize = on_up;
+	start_column_resize(e.target, "col-resize-handle--active", on_move);
 }
-
-onUnmounted(() => end_col_resize?.());
 
 function validate_table_columns() {
 	if (props.df.fieldtype != "Table") return;

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -202,9 +202,9 @@
 											:alt="col.label || col.fieldname"
 										/>
 										<div
-											v-else-if="is_html_content_field(col)"
+											v-else-if="cell_server_html(i, col)"
 											class="preview-table-html"
-											v-html="format_cell(row, col)"
+											v-html="cell_server_html(i, col)"
 										></div>
 										<span v-else>{{ format_cell(row, col) }}</span>
 									</template>
@@ -764,8 +764,10 @@ function multiselect_display(df) {
 	);
 }
 
-function is_html_content_field(col) {
-	return HTML_CONTENT_FIELDTYPES.has(col?.fieldtype);
+function cell_server_html(i, col) {
+	const v = store.preview_child_values.value?.[props.df.fieldname]?.[i]?.[col.fieldname];
+	if (v === null || v === undefined || v === "") return null;
+	return sanitize_html(String(v));
 }
 
 function format_cell(row, col) {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -481,6 +481,7 @@ import ConfigureColumnsVue from "../inspector/ConfigureColumns.vue";
 import {
 	render_jinja_html,
 	sanitize_html,
+	strip_html_to_text,
 	evaluate_visible_if,
 	thumb_hue,
 	parse_inline_style,
@@ -688,9 +689,7 @@ let preview_value = computed(() => {
 		const formatted = frappe.format(raw, props.df, { only_value: true }, preview_doc.value);
 		// If frappe.format returned HTML markup, extract the text content
 		if (typeof formatted === "string" && formatted.includes("<")) {
-			const tmp = document.createElement("div");
-			tmp.innerHTML = formatted;
-			return tmp.textContent || tmp.innerText || String(raw);
+			return strip_html_to_text(formatted, String(raw));
 		}
 		return formatted;
 	} catch {
@@ -769,9 +768,7 @@ function format_cell(row, col) {
 	try {
 		const formatted = frappe.format(raw, col, { only_value: true }, row);
 		if (typeof formatted === "string" && formatted.includes("<")) {
-			const tmp = document.createElement("div");
-			tmp.innerHTML = formatted;
-			return tmp.textContent || tmp.innerText || String(raw);
+			return strip_html_to_text(formatted, String(raw));
 		}
 		return formatted;
 	} catch {
@@ -816,9 +813,7 @@ function format_merged(row, fieldname) {
 	};
 	const val = format_cell(row, dcol);
 	if (typeof val === "string" && val.includes("<")) {
-		const tmp = document.createElement("div");
-		tmp.innerHTML = val;
-		return (tmp.textContent || tmp.innerText || "").trim();
+		return strip_html_to_text(val).trim();
 	}
 	return val;
 }

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -337,6 +337,7 @@
 							/>
 						</svg>
 					</template>
+					<span v-else-if="preview_value_html" v-html="preview_value_html"></span>
 					<span v-else>{{ preview_value || "—" }}</span>
 				</div>
 			</template>
@@ -696,6 +697,21 @@ let preview_value = computed(() => {
 	} catch {
 		return String(raw);
 	}
+});
+
+let preview_value_html = computed(() => {
+	if (!preview_doc.value || !props.df.fieldname || props.df.fieldtype === "Check") return null;
+	const raw = preview_doc.value[props.df.fieldname];
+	if (raw === null || raw === undefined || raw === "") return null;
+	try {
+		const formatted = frappe.format(raw, props.df, { only_value: true }, preview_doc.value);
+		if (typeof formatted === "string" && formatted.includes("<")) {
+			return sanitize_html(formatted);
+		}
+	} catch {
+		return null;
+	}
+	return null;
 });
 
 // Same math as macros/Rating.html: value is a 0-1 fraction, df.options holds the star count

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -262,7 +262,7 @@
 									...(col.color ? { color: col.color } : {}),
 								}"
 							>
-								{{ repeater_cell(col, row) }}
+								{{ repeater_cell(col, i, row) }}
 							</td>
 						</tr>
 						<tr v-if="!(preview_doc[df.source] || []).length">
@@ -734,10 +734,14 @@ function cell_style(df) {
 	return parts.join("; ");
 }
 
-function repeater_cell(col, row) {
+function repeater_cell(col, i, row) {
 	return (col.template || [])
 		.map((tok) => {
 			if (tok.t === "s") return tok.v || "";
+			const server = store.preview_child_values.value?.[props.df.source]?.[i]?.[tok.v];
+			if (server !== null && server !== undefined && server !== "") {
+				return strip_html_to_text(String(server));
+			}
 			const child_df = repeater_child_df(tok.v);
 			return child_df ? format_cell(row || {}, child_df) : row?.[tok.v] ?? "";
 		})
@@ -751,6 +755,10 @@ function repeater_child_df(fieldname) {
 }
 
 function multiselect_display(df) {
+	const server = store.preview_values.value?.[df.fieldname];
+	if (server !== null && server !== undefined && server !== "") {
+		return strip_html_to_text(String(server));
+	}
 	const rows = preview_doc.value?.[df.fieldname] || [];
 	if (!rows.length) return "—";
 	const child_meta = frappe.get_meta(df.options);

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -701,17 +701,9 @@ let preview_value = computed(() => {
 
 let preview_value_html = computed(() => {
 	if (!preview_doc.value || !props.df.fieldname || props.df.fieldtype === "Check") return null;
-	const raw = preview_doc.value[props.df.fieldname];
-	if (raw === null || raw === undefined || raw === "") return null;
-	try {
-		const formatted = frappe.format(raw, props.df, { only_value: true }, preview_doc.value);
-		if (typeof formatted === "string" && formatted.includes("<")) {
-			return sanitize_html(formatted);
-		}
-	} catch {
-		return null;
-	}
-	return null;
+	const server = store.preview_values.value?.[props.df.fieldname];
+	if (server === null || server === undefined || server === "") return null;
+	return sanitize_html(String(server));
 });
 
 // Same math as macros/Rating.html: value is a 0-1 fraction, df.options holds the star count

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -263,8 +263,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 .zone-divider-label {
 	font-size: var(--text-tiny);
 	font-weight: var(--weight-medium);
-	text-transform: uppercase;
-	letter-spacing: 0.12em;
+	letter-spacing: 0;
 	white-space: nowrap;
 	color: var(--gray-400);
 }

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -174,7 +174,8 @@
 <script setup>
 import draggable from "vuedraggable";
 import Field from "./Field.vue";
-import { computed, inject, onUnmounted } from "vue";
+import { computed, inject } from "vue";
+import { useColumnResize } from "../../composables/useColumnResize";
 import { evaluate_visible_if, parse_inline_style } from "../../utils";
 
 const props = defineProps(["section", "is_header", "zone"]);
@@ -216,7 +217,7 @@ let handle_offset = computed(() => {
 	return `${-(gap + 12.5)}px`;
 });
 
-let end_col_width_resize = null;
+const { start: start_column_resize } = useColumnResize();
 
 function start_col_width_resize(e, i) {
 	const cols = props.section.columns;
@@ -226,8 +227,6 @@ function start_col_width_resize(e, i) {
 	const total = container.getBoundingClientRect().width;
 	const widths = col_els.map((el) => (el.getBoundingClientRect().width / total) * 100);
 	const start_x = e.clientX;
-	handle.classList.add("col-width-handle--active");
-	document.body.classList.add("pfb-col-resizing");
 	const on_move = (ev) => {
 		let delta = ((ev.clientX - start_x) / total) * 100;
 		delta = Math.max(10 - widths[i], Math.min(widths[i + 1] - 10, delta));
@@ -235,21 +234,8 @@ function start_col_width_resize(e, i) {
 		cols[i].width = Math.round(widths[i] + delta);
 		cols[i + 1].width = Math.round(widths[i + 1] - delta);
 	};
-	const on_up = () => {
-		document.removeEventListener("pointermove", on_move);
-		document.removeEventListener("pointerup", on_up);
-		document.removeEventListener("pointercancel", on_up);
-		handle.classList.remove("col-width-handle--active");
-		document.body.classList.remove("pfb-col-resizing");
-		end_col_width_resize = null;
-	};
-	document.addEventListener("pointermove", on_move);
-	document.addEventListener("pointerup", on_up);
-	document.addEventListener("pointercancel", on_up);
-	end_col_width_resize = on_up;
+	start_column_resize(handle, "col-width-handle--active", on_move);
 }
-
-onUnmounted(() => end_col_width_resize?.());
 
 let has_visible_fields = computed(
 	() =>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -276,26 +276,11 @@ let section_inline_style = computed(() => {
 });
 
 function select_section() {
-	store.selected_section.value = props.section;
-	store.selected_field.value = null;
-	store.selected_letterhead.value = false;
-	store.selected_lh_footer.value = false;
+	store.select_section(props.section);
 }
 
 function remove_section() {
-	const idx = store.layout.value.sections.indexOf(props.section);
-	if (idx !== -1) {
-		store.layout.value.sections.splice(idx, 1);
-		if (store.selected_section.value === props.section) {
-			store.selected_section.value = null;
-		}
-		if (
-			store.selected_field.value &&
-			props.section.columns.some((c) => c.fields.includes(store.selected_field.value))
-		) {
-			store.selected_field.value = null;
-		}
-	}
+	store.remove_section(props.section);
 }
 
 function remove_column(index) {

--- a/frappe/public/js/print_format_builder/components/inspector/LetterHeadZoneInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/LetterHeadZoneInspector.vue
@@ -221,7 +221,7 @@ function open_html_split_dialog({ title, initial_html, on_save, doctype, docname
 					.pfb-lh-split{display:flex;height:480px;gap:0;overflow:hidden;margin:-15px}
 					.pfb-lh-split-pane{display:flex;flex-direction:column;flex:1;min-width:0;overflow:hidden}
 					.pfb-lh-split-divider{width:1px;background:var(--border-color);flex-shrink:0}
-					.pfb-lh-split-label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted);padding:10px 12px 8px;border-bottom:1px solid var(--border-color);flex-shrink:0}
+					.pfb-lh-split-label{font-size:11px;font-weight:700;color:var(--text-muted);padding:10px 12px 8px;border-bottom:1px solid var(--border-color);flex-shrink:0}
 					.pfb-lh-split-ctrl{flex:1;overflow:hidden}
 					.pfb-lh-split-ctrl .pfb-html-ctrl-host{height:100%}
 					.pfb-lh-preview-iframe{flex:1;width:100%;border:none;background:#fff}
@@ -365,8 +365,7 @@ function lh_create_letterhead() {
 	gap: 6px;
 	font-size: var(--text-tiny);
 	font-weight: var(--weight-semibold);
-	text-transform: uppercase;
-	letter-spacing: 0.06em;
+	letter-spacing: 0;
 	color: var(--blue-500);
 	background: var(--blue-50);
 	border-bottom: 1px solid var(--blue-200);

--- a/frappe/public/js/print_format_builder/components/letterhead/LetterHeadZoneEditor.vue
+++ b/frappe/public/js/print_format_builder/components/letterhead/LetterHeadZoneEditor.vue
@@ -66,15 +66,7 @@ let empty_label = computed(() =>
 );
 
 function select_zone() {
-	if (props.zone === "header") {
-		raw_store.selected_letterhead.value = true;
-		raw_store.selected_lh_footer.value = false;
-	} else {
-		raw_store.selected_lh_footer.value = true;
-		raw_store.selected_letterhead.value = false;
-	}
-	raw_store.selected_field.value = null;
-	raw_store.selected_section.value = null;
+	raw_store.select_letterhead({ footer: props.zone !== "header" });
 }
 
 async function refresh_rendered_content() {

--- a/frappe/public/js/print_format_builder/composables/useColumnResize.js
+++ b/frappe/public/js/print_format_builder/composables/useColumnResize.js
@@ -1,0 +1,26 @@
+import { onUnmounted } from "vue";
+
+export function useColumnResize() {
+	let end = null;
+
+	function start(handle, active_class, on_move) {
+		handle.classList.add(active_class);
+		document.body.classList.add("pfb-col-resizing");
+		const on_up = () => {
+			document.removeEventListener("pointermove", on_move);
+			document.removeEventListener("pointerup", on_up);
+			document.removeEventListener("pointercancel", on_up);
+			handle.classList.remove(active_class);
+			document.body.classList.remove("pfb-col-resizing");
+			end = null;
+		};
+		document.addEventListener("pointermove", on_move);
+		document.addEventListener("pointerup", on_up);
+		document.addEventListener("pointercancel", on_up);
+		end = on_up;
+	}
+
+	onUnmounted(() => end?.());
+
+	return { start };
+}

--- a/frappe/public/js/print_format_builder/inspector.css
+++ b/frappe/public/js/print_format_builder/inspector.css
@@ -25,8 +25,7 @@
 .pfb-insp-section-label {
 	font-size: var(--text-tiny);
 	font-weight: var(--weight-bold);
-	text-transform: uppercase;
-	letter-spacing: 0.08em;
+	letter-spacing: 0;
 	color: var(--text-muted);
 }
 .pfb-insp-chevron {
@@ -167,8 +166,7 @@
 .pfb-html-split-label {
 	font-size: var(--text-tiny);
 	font-weight: var(--weight-bold);
-	text-transform: uppercase;
-	letter-spacing: 0.08em;
+	letter-spacing: 0;
 	color: var(--text-muted);
 	padding: 10px 12px 8px;
 	border-bottom: 1px solid var(--border-color);

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -35,6 +35,7 @@ export function getStore(print_format_name) {
 	let selected_lh_footer = ref(false);
 	let preview_doc = ref(null);
 	let preview_doc_name = ref(null);
+	let preview_values = ref({});
 
 	// methods
 	function fetch() {
@@ -214,6 +215,7 @@ export function getStore(print_format_name) {
 		if (!name) {
 			preview_doc.value = null;
 			preview_doc_name.value = null;
+			preview_values.value = {};
 			localStorage.removeItem(preview_doc_ls_key);
 			return;
 		}
@@ -222,6 +224,14 @@ export function getStore(print_format_name) {
 		frappe.db.get_doc(print_format.value.doc_type, name).then((doc) => {
 			preview_doc.value = doc;
 		});
+		frappe
+			.call("frappe.utils.print_format_generator.get_formatted_field_values", {
+				doctype: print_format.value.doc_type,
+				name,
+			})
+			.then((r) => {
+				preview_values.value = r.message || {};
+			});
 	}
 	function get_layout() {
 		if (print_format.value && print_format.value.format_data) {
@@ -344,6 +354,7 @@ export function getStore(print_format_name) {
 		selected_lh_footer,
 		preview_doc,
 		preview_doc_name,
+		preview_values,
 		load_preview_doc,
 		persisted_preview_doc_name,
 		fetch,

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -174,6 +174,37 @@ export function getStore(print_format_name) {
 		serialize_layout(snapshot);
 		return { ...print_format.value, format_data: JSON.stringify(snapshot) };
 	}
+	function select_field(df) {
+		selected_field.value = df;
+		selected_letterhead.value = false;
+		selected_lh_footer.value = false;
+	}
+	function select_section(section) {
+		selected_section.value = section;
+		selected_field.value = null;
+		selected_letterhead.value = false;
+		selected_lh_footer.value = false;
+	}
+	function select_letterhead({ footer = false } = {}) {
+		selected_letterhead.value = !footer;
+		selected_lh_footer.value = footer;
+		selected_field.value = null;
+		selected_section.value = null;
+	}
+	function remove_section(section) {
+		const idx = layout.value.sections.indexOf(section);
+		if (idx === -1) return;
+		layout.value.sections.splice(idx, 1);
+		if (selected_section.value === section) {
+			selected_section.value = null;
+		}
+		if (
+			selected_field.value &&
+			section.columns.some((c) => c.fields.includes(selected_field.value))
+		) {
+			selected_field.value = null;
+		}
+	}
 	// Persist the chosen preview record per print format so it survives a refresh
 	const preview_doc_ls_key = `pfb:preview_doc:${print_format_name}`;
 	function persisted_preview_doc_name() {
@@ -320,6 +351,10 @@ export function getStore(print_format_name) {
 		save_changes,
 		reset_changes,
 		get_preview_format_doc,
+		select_field,
+		select_section,
+		select_letterhead,
+		remove_section,
 		get_layout,
 		get_default_layout,
 		change_letterhead,

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -36,6 +36,7 @@ export function getStore(print_format_name) {
 	let preview_doc = ref(null);
 	let preview_doc_name = ref(null);
 	let preview_values = ref({});
+	let preview_child_values = ref({});
 
 	// methods
 	function fetch() {
@@ -216,6 +217,7 @@ export function getStore(print_format_name) {
 			preview_doc.value = null;
 			preview_doc_name.value = null;
 			preview_values.value = {};
+			preview_child_values.value = {};
 			localStorage.removeItem(preview_doc_ls_key);
 			return;
 		}
@@ -230,7 +232,8 @@ export function getStore(print_format_name) {
 				name,
 			})
 			.then((r) => {
-				preview_values.value = r.message || {};
+				preview_values.value = r.message?.values || {};
+				preview_child_values.value = r.message?.child || {};
 			});
 	}
 	function get_layout() {
@@ -355,6 +358,7 @@ export function getStore(print_format_name) {
 		preview_doc,
 		preview_doc_name,
 		preview_values,
+		preview_child_values,
 		load_preview_doc,
 		persisted_preview_doc_name,
 		fetch,

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -37,6 +37,7 @@ export function getStore(print_format_name) {
 	let preview_doc_name = ref(null);
 	let preview_values = ref({});
 	let preview_child_values = ref({});
+	let preview_load_seq = 0;
 
 	// methods
 	function fetch() {
@@ -213,6 +214,7 @@ export function getStore(print_format_name) {
 		return localStorage.getItem(preview_doc_ls_key);
 	}
 	function load_preview_doc(name) {
+		const seq = ++preview_load_seq;
 		if (!name) {
 			preview_doc.value = null;
 			preview_doc_name.value = null;
@@ -224,6 +226,7 @@ export function getStore(print_format_name) {
 		preview_doc_name.value = name;
 		localStorage.setItem(preview_doc_ls_key, name);
 		frappe.db.get_doc(print_format.value.doc_type, name).then((doc) => {
+			if (seq !== preview_load_seq) return;
 			preview_doc.value = doc;
 		});
 		frappe
@@ -232,6 +235,7 @@ export function getStore(print_format_name) {
 				name,
 			})
 			.then((r) => {
+				if (seq !== preview_load_seq) return;
 				preview_values.value = r.message?.values || {};
 				preview_child_values.value = r.message?.child || {};
 			});

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -169,6 +169,11 @@ export function getStore(print_format_name) {
 	function reset_changes() {
 		fetch();
 	}
+	function get_preview_format_doc() {
+		const snapshot = clone_plain(layout.value);
+		serialize_layout(snapshot);
+		return { ...print_format.value, format_data: JSON.stringify(snapshot) };
+	}
 	// Persist the chosen preview record per print format so it survives a refresh
 	const preview_doc_ls_key = `pfb:preview_doc:${print_format_name}`;
 	function persisted_preview_doc_name() {
@@ -314,6 +319,7 @@ export function getStore(print_format_name) {
 		update,
 		save_changes,
 		reset_changes,
+		get_preview_format_doc,
 		get_layout,
 		get_default_layout,
 		change_letterhead,

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -185,38 +185,9 @@ export const FIELD_PLUCK_KEYS = [
 	"show_text",
 ];
 
-export const ZONE_FIELD_PLUCK_KEYS = [
-	"label",
-	"fieldname",
-	"fieldtype",
-	"options",
-	"table_columns",
-	"table_style",
-	"table_bordered",
-	"table_header",
-	"table_header_bg",
-	"table_border_color",
-	"html",
-	"field_template",
-	"source",
-	"repeater_columns",
-	"row_condition",
-	"show_label",
-	"align",
-	"label_justify",
-	"label_gap",
-	"visible_if",
-	"custom_style",
-	"value_color",
-	"label_color",
-	"custom",
-	"image_url",
-	"width",
-	"barcode_field",
-	"barcode_value",
-	"barcode_format",
-	"show_text",
-];
+export const ZONE_FIELD_PLUCK_KEYS = FIELD_PLUCK_KEYS.filter(
+	(key) => key !== "table_cell_padding" && key !== "table_radius"
+);
 
 export function serialize_layout(layout) {
 	layout.sections = layout.sections

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -352,6 +352,12 @@ const SAFE_HTML_ATTRS = new Set([
 	"cellspacing",
 ]);
 
+export function strip_html_to_text(html, fallback = "") {
+	const tmp = document.createElement("div");
+	tmp.innerHTML = html;
+	return tmp.textContent || tmp.innerText || fallback;
+}
+
 export function sanitize_html(html) {
 	const root = document.createElement("div");
 	root.innerHTML = frappe.dom.remove_script_and_style(html || "");

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -36,11 +36,10 @@ def download_pdf(
 	settings: str | dict | None = None,
 ):
 	from frappe.printing.doctype.print_format.classic_converter import get_default_print_format
-	from frappe.www.printview import validate_print_for_docstatus, validate_print_permission
+	from frappe.www.printview import validate_print
 
 	doc = frappe.get_doc(doctype, name)
-	validate_print_permission(doc)
-	validate_print_for_docstatus(doc)
+	validate_print(doc)
 	if not print_format or print_format == "Standard":
 		print_format = get_default_print_format(doctype)
 	generator = PrintFormatGenerator(print_format, doc, letterhead, settings=frappe.parse_json(settings))
@@ -80,7 +79,7 @@ def render_builder_preview(
 	in-memory Print Format document (dict/JSON), not a saved name.
 	"""
 	from frappe.printing.doctype.print_format.print_format import printable_sample
-	from frappe.www.printview import validate_print_for_docstatus, validate_print_permission
+	from frappe.www.printview import validate_print
 
 	frappe.has_permission("Print Format", "write", throw=True)
 
@@ -93,8 +92,7 @@ def render_builder_preview(
 		return ""
 
 	doc = frappe.get_doc(doctype, name)
-	validate_print_permission(doc)
-	validate_print_for_docstatus(doc)
+	validate_print(doc)
 
 	generator = PrintFormatGenerator(pf, doc, letterhead, settings=frappe.parse_json(settings))
 	return generator.get_html_preview()
@@ -110,11 +108,10 @@ def get_html(
 	trigger_print=False,
 	settings=None,
 ):
-	from frappe.www.printview import validate_print_for_docstatus, validate_print_permission
+	from frappe.www.printview import validate_print
 
 	doc = frappe.get_doc(doctype, name)
-	validate_print_permission(doc)
-	validate_print_for_docstatus(doc)
+	validate_print(doc)
 	generator = PrintFormatGenerator(print_format, doc, letterhead, style=style, settings=settings)
 	return generator.get_html_preview(action_banner=action_banner, trigger_print=trigger_print)
 

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -64,6 +64,26 @@ def get_qr_code(value: str) -> str:
 
 
 @frappe.whitelist()
+def get_formatted_field_values(doctype: str, name: str) -> dict:
+	"""Return the same formatted value each field prints (`doc.get_formatted`) so the
+	builder canvas shows the server's output instead of re-formatting client-side."""
+	from frappe.model import table_fields
+
+	doc = frappe.get_doc(doctype, name)
+	doc.check_permission("read")
+
+	values = {}
+	for df in doc.meta.fields:
+		if df.fieldtype in table_fields:
+			continue
+		try:
+			values[df.fieldname] = doc.get_formatted(df.fieldname)
+		except Exception:
+			continue
+	return values
+
+
+@frappe.whitelist()
 def render_builder_preview(
 	print_format: str | dict,
 	doctype: str,

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -66,21 +66,37 @@ def get_qr_code(value: str) -> str:
 @frappe.whitelist()
 def get_formatted_field_values(doctype: str, name: str) -> dict:
 	"""Return the same formatted value each field prints (`doc.get_formatted`) so the
-	builder canvas shows the server's output instead of re-formatting client-side."""
+	builder canvas shows the server's output instead of re-formatting client-side.
+
+	`values` holds parent fields; `child` maps each table field to a per-row list
+	of its cells' formatted values (row order matches the document)."""
 	from frappe.model import table_fields
 
 	doc = frappe.get_doc(doctype, name)
 	doc.check_permission("read")
 
+	def formatted_fields(row):
+		out = {}
+		for df in row.meta.fields:
+			if df.fieldtype in table_fields:
+				continue
+			try:
+				out[df.fieldname] = row.get_formatted(df.fieldname)
+			except Exception:
+				continue
+		return out
+
 	values = {}
+	child = {}
 	for df in doc.meta.fields:
 		if df.fieldtype in table_fields:
-			continue
-		try:
-			values[df.fieldname] = doc.get_formatted(df.fieldname)
-		except Exception:
-			continue
-	return values
+			child[df.fieldname] = [formatted_fields(row) for row in doc.get(df.fieldname) or []]
+		else:
+			try:
+				values[df.fieldname] = doc.get_formatted(df.fieldname)
+			except Exception:
+				continue
+	return {"values": values, "child": child}
 
 
 @frappe.whitelist()

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -96,6 +96,11 @@ def get_formatted_field_values(doctype: str, name: str) -> dict:
 	for df in doc.meta.fields:
 		if df.fieldtype in table_fields:
 			child[df.fieldname] = [formatted_fields(row) for row in doc.get(df.fieldname) or []]
+			if df.fieldtype == "Table MultiSelect" and has_access(doc, df):
+				try:
+					values[df.fieldname] = doc.get_formatted(df.fieldname)
+				except Exception:
+					pass
 		elif has_access(doc, df):
 			try:
 				values[df.fieldname] = doc.get_formatted(df.fieldname)

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -71,17 +71,22 @@ def get_formatted_field_values(doctype: str, name: str) -> dict:
 	`values` holds parent fields; `child` maps each table field to a per-row list
 	of its cells' formatted values (row order matches the document)."""
 	from frappe.model import table_fields
+	from frappe.www.printview import set_link_titles
 
 	doc = frappe.get_doc(doctype, name)
 	doc.check_permission("read")
+	set_link_titles(doc)
 
-	def formatted_fields(row):
+	def has_access(d, df):
+		return not (df.permlevel or 0) or d.has_permlevel_access_to(df.fieldname, df)
+
+	def formatted_fields(d):
 		out = {}
-		for df in row.meta.fields:
-			if df.fieldtype in table_fields:
+		for df in d.meta.fields:
+			if df.fieldtype in table_fields or not has_access(d, df):
 				continue
 			try:
-				out[df.fieldname] = row.get_formatted(df.fieldname)
+				out[df.fieldname] = d.get_formatted(df.fieldname)
 			except Exception:
 				continue
 		return out
@@ -91,7 +96,7 @@ def get_formatted_field_values(doctype: str, name: str) -> dict:
 	for df in doc.meta.fields:
 		if df.fieldtype in table_fields:
 			child[df.fieldname] = [formatted_fields(row) for row in doc.get(df.fieldname) or []]
-		else:
+		elif has_access(doc, df):
 			try:
 				values[df.fieldname] = doc.get_formatted(df.fieldname)
 			except Exception:

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -64,6 +64,42 @@ def get_qr_code(value: str) -> str:
 	return "data:image/svg+xml;base64," + base64.b64encode(stream.getvalue()).decode()
 
 
+@frappe.whitelist()
+def render_builder_preview(
+	print_format: str | dict,
+	doctype: str,
+	name: str | None = None,
+	letterhead: str | None = None,
+	settings: str | dict | None = None,
+) -> str:
+	"""Render print HTML for an UNSAVED builder format.
+
+	The print format builder holds the format in memory; this lets its preview
+	reflect edits before they are saved, using the same renderer the PDF uses so
+	the preview cannot drift from the printed output. ``print_format`` is the
+	in-memory Print Format document (dict/JSON), not a saved name.
+	"""
+	from frappe.printing.doctype.print_format.print_format import printable_sample
+	from frappe.www.printview import validate_print_for_docstatus, validate_print_permission
+
+	frappe.has_permission("Print Format", "write", throw=True)
+
+	pf = frappe.get_doc(frappe.parse_json(print_format))
+	if pf.doctype != "Print Format":
+		frappe.throw(_("Expected an unsaved Print Format document"))
+
+	name = name or printable_sample(doctype)
+	if not name:
+		return ""
+
+	doc = frappe.get_doc(doctype, name)
+	validate_print_permission(doc)
+	validate_print_for_docstatus(doc)
+
+	generator = PrintFormatGenerator(pf, doc, letterhead, settings=frappe.parse_json(settings))
+	return generator.get_html_preview()
+
+
 def get_html(
 	doctype,
 	name,

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -132,6 +132,7 @@ class PrintFormatGenerator:
 		"bottom_center": "center",
 		"bottom_right": "right",
 	}
+	_FIELD_RENDERERS: ClassVar[dict[str, str]] = {"HTML Editor": "HTML", "Markdown Editor": "Markdown"}
 
 	def __init__(self, print_format, doc, letterhead=None, style=None, settings=None):
 		self.print_format = (
@@ -485,8 +486,19 @@ class PrintFormatGenerator:
 					df["table_columns"] = kept
 		return layout
 
+	def _prepare_field(self, df, section, eval_locals):
+		if df.get("visible_if"):
+			try:
+				df["_hidden"] = not frappe.safe_eval(df["visible_if"], eval_locals)
+			except Exception:
+				df["_hidden"] = False
+		fieldtype = df.get("fieldtype", "Data")
+		df["renderer"] = self._FIELD_RENDERERS.get(fieldtype) or fieldtype.replace(" ", "")
+		df["section"] = section
+		self.prepare_barcode(df)
+		self.filter_repeater_rows(df)
+
 	def set_field_renderers(self, layout):
-		renderers = {"HTML Editor": "HTML", "Markdown Editor": "Markdown"}
 		eval_locals = {"doc": self.doc, "print_settings": self.print_settings}
 		for section in layout["sections"]:
 			if section.get("visible_if"):
@@ -496,16 +508,7 @@ class PrintFormatGenerator:
 					section["_hidden"] = False
 			for column in section["columns"]:
 				for df in column["fields"]:
-					if df.get("visible_if"):
-						try:
-							df["_hidden"] = not frappe.safe_eval(df["visible_if"], eval_locals)
-						except Exception:
-							df["_hidden"] = False
-					fieldtype = df["fieldtype"]
-					df["renderer"] = renderers.get(fieldtype) or fieldtype.replace(" ", "")
-					df["section"] = section
-					self.prepare_barcode(df)
-					self.filter_repeater_rows(df)
+					self._prepare_field(df, section, eval_locals)
 
 		# Also process header/footer zones if they are section objects
 		for zone_key in ("header", "footer"):
@@ -513,16 +516,7 @@ class PrintFormatGenerator:
 			if isinstance(zone, dict) and "columns" in zone:
 				for column in zone.get("columns", []):
 					for df in column.get("fields", []):
-						if df.get("visible_if"):
-							try:
-								df["_hidden"] = not frappe.safe_eval(df["visible_if"], eval_locals)
-							except Exception:
-								df["_hidden"] = False
-						fieldtype = df.get("fieldtype", "Data")
-						df["renderer"] = renderers.get(fieldtype) or fieldtype.replace(" ", "")
-						df["section"] = zone
-						self.prepare_barcode(df)
-						self.filter_repeater_rows(df)
+						self._prepare_field(df, zone, eval_locals)
 
 		return layout
 

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -285,6 +285,26 @@ class TestPrintSurfaceParity(IntegrationTestCase):
 		email_rows = result["child"]["email_ids"]
 		self.assertEqual(email_rows[0]["email_id"], contact.email_ids[0].get_formatted("email_id"))
 
+	def test_formatted_field_values_respect_permlevel(self):
+		"""A reader without permlevel access must not get restricted field values —
+		the endpoint returns raw field data, so it has to honour permlevel like the
+		render path does."""
+		from unittest.mock import patch
+
+		from frappe.utils.print_format_generator import get_formatted_field_values
+
+		contact = self._make_contact()
+		restricted = frappe.get_meta("Contact").get_field("first_name")
+
+		with (
+			patch.object(restricted, "permlevel", 1),
+			patch("frappe.model.document.Document.has_permlevel_access_to", return_value=False),
+		):
+			result = get_formatted_field_values("Contact", contact.name)
+
+		self.assertNotIn("first_name", result["values"])
+		self.assertIn("email_ids", result["child"])
+
 	def test_rendered_html_carries_shared_markup_contract(self):
 		"""The server render must produce the markup vocabulary the shared
 		stylesheet and the canvas both rely on."""

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -253,6 +253,20 @@ class TestPrintSurfaceParity(IntegrationTestCase):
 
 		self.assertEqual(self._doc_body(preview), self._doc_body(pdf))
 
+	def test_builder_preview_endpoint_matches_saved_render(self):
+		"""render_builder_preview() renders an UNSAVED in-memory format; its body
+		must match the saved format's print render (which the PDF shares), so a
+		live preview of unsaved edits shows exactly what will print."""
+		from frappe.utils.print_format_generator import get_html, render_builder_preview
+
+		fmt = self._make_contact_format()
+		contact = self._make_contact()
+
+		saved = get_html("Contact", contact.name, fmt.name)
+		live = render_builder_preview(frappe.as_json(fmt.as_dict()), "Contact", name=contact.name)
+
+		self.assertEqual(self._doc_body(saved), self._doc_body(live))
+
 	def test_rendered_html_carries_shared_markup_contract(self):
 		"""The server render must produce the markup vocabulary the shared
 		stylesheet and the canvas both rely on."""

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -231,6 +231,28 @@ class TestPrintSurfaceParity(IntegrationTestCase):
 		self.addCleanup(doc.delete, ignore_permissions=True)
 		return doc
 
+	def _doc_body(self, html):
+		from bs4 import BeautifulSoup
+
+		el = BeautifulSoup(html, "html.parser").find(class_="print-format-doc")
+		self.assertIsNotNone(el, "render is missing the .print-format-doc body")
+		return self.normalize_html(str(el))
+
+	def test_preview_and_pdf_bodies_are_identical(self):
+		"""The builder preview (get_html_preview) and the PDF pipeline
+		(_build_html_for_chrome) must emit the same .print-format-doc body. Both
+		go through get_main_html(), so any divergence is a regression that would
+		make the on-screen preview lie about the printed output."""
+		from frappe.utils.print_format_generator import PrintFormatGenerator
+
+		fmt = self._make_contact_format()
+		contact = self._make_contact()
+
+		preview = PrintFormatGenerator(fmt, contact).get_html_preview()
+		pdf = PrintFormatGenerator(fmt, contact)._build_html_for_chrome()
+
+		self.assertEqual(self._doc_body(preview), self._doc_body(pdf))
+
 	def test_rendered_html_carries_shared_markup_contract(self):
 		"""The server render must produce the markup vocabulary the shared
 		stylesheet and the canvas both rely on."""

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -276,11 +276,14 @@ class TestPrintSurfaceParity(IntegrationTestCase):
 		fmt = self._make_contact_format()
 		contact = self._make_contact()
 
-		values = get_formatted_field_values("Contact", contact.name)
+		result = get_formatted_field_values("Contact", contact.name)
 		html = get_html("Contact", contact.name, fmt.name)
 
-		self.assertEqual(values["first_name"], contact.get_formatted("first_name"))
-		self.assertIn(values["first_name"], html)
+		self.assertEqual(result["values"]["first_name"], contact.get_formatted("first_name"))
+		self.assertIn(result["values"]["first_name"], html)
+
+		email_rows = result["child"]["email_ids"]
+		self.assertEqual(email_rows[0]["email_id"], contact.email_ids[0].get_formatted("email_id"))
 
 	def test_rendered_html_carries_shared_markup_contract(self):
 		"""The server render must produce the markup vocabulary the shared

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -267,6 +267,21 @@ class TestPrintSurfaceParity(IntegrationTestCase):
 
 		self.assertEqual(self._doc_body(saved), self._doc_body(live))
 
+	def test_formatted_field_values_match_print(self):
+		"""The canvas sources values from get_formatted_field_values; each value must
+		be the same one the print render emits, so the builder can't reformat it
+		differently (the whole point — one formatter, not two)."""
+		from frappe.utils.print_format_generator import get_formatted_field_values, get_html
+
+		fmt = self._make_contact_format()
+		contact = self._make_contact()
+
+		values = get_formatted_field_values("Contact", contact.name)
+		html = get_html("Contact", contact.name, fmt.name)
+
+		self.assertEqual(values["first_name"], contact.get_formatted("first_name"))
+		self.assertIn(values["first_name"], html)
+
 	def test_rendered_html_carries_shared_markup_contract(self):
 		"""The server render must produce the markup vocabulary the shared
 		stylesheet and the canvas both rely on."""

--- a/frappe/www/printpreview.py
+++ b/frappe/www/printpreview.py
@@ -3,11 +3,7 @@ no_cache = 1
 
 def get_context(context):
 	import frappe
-	from frappe.printing.doctype.print_format.classic_converter import (
-		get_default_print_format,
-		uses_beta_renderer,
-	)
-	from frappe.www.printview import get_print_format_doc
+	from frappe.www.printview import resolve_print_format
 
 	doctype = frappe.form_dict.doctype
 	docname = frappe.form_dict.name
@@ -15,11 +11,9 @@ def get_context(context):
 	settings = frappe.parse_json(frappe.form_dict.get("settings"))
 
 	doc = frappe.get_doc(doctype, docname)
-	pf = get_print_format_doc(frappe.form_dict.print_format, meta=doc.meta) or get_default_print_format(
-		doctype
-	)
+	pf, is_beta = resolve_print_format(frappe.form_dict.print_format, doc.meta)
 
-	if uses_beta_renderer(pf):
+	if is_beta:
 		from frappe.utils.print_format_generator import get_html
 
 		context.body = get_html(doctype, docname, pf, letterhead, settings=settings)

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -443,6 +443,12 @@ def validate_print_permission(doc: "Document") -> None:
 	doc._handle_permission_failure("print")
 
 
+def validate_print(doc: "Document", print_settings: dict | None = None) -> None:
+	"""Run both print gates for a document: permission, then draft/cancelled docstatus."""
+	validate_print_permission(doc)
+	validate_print_for_docstatus(doc, print_settings)
+
+
 def validate_key(key: str, doc: "Document") -> None:
 	document_key_expiry = frappe.get_cached_value(
 		"Document Share Key",

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -67,22 +67,12 @@ def get_context(context) -> PrintContext:
 
 	meta = frappe.get_meta(doc.doctype)
 
-	print_format = get_print_format_doc(None, meta=meta)
-
-	from frappe.printing.doctype.print_format.classic_converter import (
-		get_default_print_format,
-		uses_beta_renderer,
-	)
-
-	if print_format is None:
-		print_format = get_default_print_format(doc.doctype)
+	print_format, standalone = resolve_print_format(None, meta)
 
 	print_format_name = getattr(print_format, "name", "Standard")
 	pdf_generator = frappe.form_dict.get(
 		"pdf_generator", getattr(print_format, "pdf_generator", "wkhtmltopdf")
 	)
-
-	standalone = uses_beta_renderer(print_format)
 
 	context = {
 		"standalone": standalone,
@@ -155,6 +145,18 @@ def get_print_format_doc(print_format_name: str, meta: "Meta") -> "PrintFormat" 
 		except frappe.DoesNotExistError:
 			# if old name, return standard!
 			return None
+
+
+def resolve_print_format(print_format_name: "str | None", meta: "Meta") -> tuple["PrintFormat", bool]:
+	"""Resolve a print format name to its document — falling back to the doctype's
+	default beta format — and whether it renders through the beta renderer."""
+	from frappe.printing.doctype.print_format.classic_converter import (
+		get_default_print_format,
+		uses_beta_renderer,
+	)
+
+	print_format = get_print_format_doc(print_format_name, meta=meta) or get_default_print_format(meta.name)
+	return print_format, uses_beta_renderer(print_format)
 
 
 def get_rendered_template(
@@ -327,22 +329,13 @@ def get_html_and_style(
 	else:
 		document = frappe.get_doc(frappe.parse_json(doc), check_permission=True)
 
-	print_format = get_print_format_doc(print_format, meta=document.meta)
 	set_link_titles(document)
+	print_format, is_beta = resolve_print_format(print_format, document.meta)
 
-	from frappe.printing.doctype.print_format.classic_converter import (
-		get_default_print_format,
-		uses_beta_renderer,
-	)
-
-	if print_format is None:
-		print_format = get_default_print_format(document.doctype)
-
-	if uses_beta_renderer(print_format):
+	if is_beta:
 		from frappe.utils.print_format_generator import PrintFormatGenerator
 
-		validate_print_permission(document)
-		validate_print_for_docstatus(document)
+		validate_print(document)
 		generator = PrintFormatGenerator(
 			print_format,
 			document,


### PR DESCRIPTION
- Live preview now renders **unsaved** edits via new `render_builder_preview` (in-memory format → print HTML), not just the saved format.
- Canvas values now come from the server's `get_formatted` — parent fields, child cells, merged/repeater/multiselect — instead of client `frappe.format`, killing preview↔print drift (address `<br>`, currency, link titles). Endpoint enforces permlevel.
- Refactors: `validate_print` / `resolve_print_format` helpers, `_prepare_field` extraction, `useColumnResize` composable, store selection methods, pluck-key + html-to-text dedup.

Why: one renderer, not two — the builder shows what the document prints.


`no-docs`