### PR TITLE
fix: Redesigned the general tab for DocType Setting

### DIFF
--- a/frappe/public/js/frappe/form/doctype_settings/list_panel.js
+++ b/frappe/public/js/frappe/form/doctype_settings/list_panel.js
@@ -75,7 +75,7 @@ class ListPanel {
 				this.rows = rows || [];
 				this.render();
 			})
-			.catch(() => this.render_error());
+			.catch((err) => this.render_error(err));
 	}
 
 	// ── public controller API ──
@@ -265,8 +265,18 @@ class ListPanel {
 		$('<div class="text-muted small dts-list-state"></div>').text(text).appendTo(this.$body);
 	}
 
-	render_error() {
+	render_error(err) {
 		this.$body.empty();
+		// Permission failures get a terminal no-access state — no Retry, a 403 won't
+		// succeed on the second try.
+		if (frappe.doctype_settings.is_permission_error(err)) {
+			frappe.doctype_settings.empty_state(this.$body, {
+				icon: "lock",
+				title: __("No access"),
+				description: __("You don't have permission to view this."),
+			});
+			return;
+		}
 		const $err = $('<div class="dts-list-state"></div>').appendTo(this.$body);
 		$('<div class="text-muted small"></div>')
 			.text(__("Could not load this tab."))

--- a/frappe/public/js/frappe/form/doctype_settings/list_panel.js
+++ b/frappe/public/js/frappe/form/doctype_settings/list_panel.js
@@ -265,8 +265,6 @@ class ListPanel {
 
 	render_error(err) {
 		this.$body.empty();
-		// Permission failures get a terminal no-access state — no Retry, a 403 won't
-		// succeed on the second try.
 		if (frappe.doctype_settings.is_permission_error(err)) {
 			frappe.doctype_settings.empty_state(this.$body, {
 				icon: "lock",

--- a/frappe/public/js/frappe/form/doctype_settings/list_panel.js
+++ b/frappe/public/js/frappe/form/doctype_settings/list_panel.js
@@ -67,7 +67,8 @@ class ListPanel {
 	}
 
 	load() {
-		this.render_state(__("Loading"));
+		this.$body.empty();
+		frappe.doctype_settings.render_loading(this.$body);
 		const c = this.config;
 		const source = c.load ? c.load() : Promise.resolve(c.rows || []);
 		Promise.resolve(source)
@@ -116,7 +117,7 @@ class ListPanel {
 
 	make_head() {
 		const c = this.config;
-		const $head = $('<div class="dts-list-row dts-list-head"></div>');
+		const $head = $('<div class="dts-list-row dts-list-head text-sm-medium"></div>');
 
 		// The title column owns the leading media, so its header label sits at the
 		// column's left edge (above the thumbnail) and the rest stays aligned.
@@ -155,7 +156,7 @@ class ListPanel {
 
 		// Primary line: name + inline tags (attributes of the row, e.g. Default / Global).
 		const $primaryRow = $('<div class="dts-list-primary-row"></div>').appendTo($text);
-		const $primary = $('<div class="dts-list-primary ellipsis"></div>')
+		const $primary = $('<div class="dts-list-primary text-base-medium ellipsis"></div>')
 			.text(tc.primary ? tc.primary(row) : "")
 			.appendTo($primaryRow);
 		if (tc.onclick) {
@@ -170,7 +171,9 @@ class ListPanel {
 		);
 
 		if (tc.secondary && tc.secondary(row)) {
-			$('<div class="dts-list-secondary"></div>').text(tc.secondary(row)).appendTo($text);
+			$('<div class="dts-list-secondary text-p-sm"></div>')
+				.text(tc.secondary(row))
+				.appendTo($text);
 		}
 
 		// Middle columns: text or badge.
@@ -260,11 +263,6 @@ class ListPanel {
 		});
 	}
 
-	render_state(text) {
-		this.$body.empty();
-		$('<div class="text-muted small dts-list-state"></div>').text(text).appendTo(this.$body);
-	}
-
 	render_error(err) {
 		this.$body.empty();
 		// Permission failures get a terminal no-access state — no Retry, a 403 won't
@@ -278,7 +276,7 @@ class ListPanel {
 			return;
 		}
 		const $err = $('<div class="dts-list-state"></div>').appendTo(this.$body);
-		$('<div class="text-muted small"></div>')
+		$('<div class="text-muted text-p-sm"></div>')
 			.text(__("Could not load this tab."))
 			.appendTo($err);
 		frappe.ui

--- a/frappe/public/js/frappe/form/doctype_settings/registry.js
+++ b/frappe/public/js/frappe/form/doctype_settings/registry.js
@@ -22,6 +22,13 @@ frappe.doctype_settings.register = function (tab_id, builder) {
 	frappe.doctype_settings.builders[tab_id] = builder;
 };
 
+frappe.doctype_settings.get_list = function (doctype, args) {
+	args = Object.assign({ fields: ["name"], limit: 20 }, args, { doctype });
+	return frappe
+		.call({ method: "frappe.desk.reportview.get_list", args, type: "GET" })
+		.then((r) => r.message);
+};
+
 /**
  * Shared overflow "…" menu used by list rows and custom tabs, built on the
  * espresso Dropdown component (open/close, positioning, keyboard handling all
@@ -39,6 +46,7 @@ frappe.doctype_settings.overflow_menu = function (items) {
 	frappe.ui
 		.dropdown({
 			button: {
+				label: "",
 				icon: "ellipsis",
 				size: "xs",
 				variant: "ghost",
@@ -88,9 +96,6 @@ frappe.doctype_settings.empty_state = function ($container, opts) {
 	return $empty;
 };
 
-// Tab load failures land here. Permission failures get a dedicated state without a
-// Retry button (retrying a 403 will always fail again); everything else keeps the
-// generic message + Retry, the right affordance for transient/network errors.
 frappe.doctype_settings.render_error = function (panel, retry_fn, err) {
 	if (frappe.doctype_settings.is_permission_error(err)) {
 		panel.body.empty();
@@ -108,8 +113,6 @@ frappe.doctype_settings.render_error = function (panel, retry_fn, err) {
 	frappe.ui.button({ label: __("Retry"), size: "xs", onclick: () => retry_fn() }).appendTo($err);
 };
 
-// Rejections reach the tabs in different shapes depending on the API: frappe.call
-// hands back the xhr, frappe.db/xcall the parsed server message. Sniff all of them.
 frappe.doctype_settings.is_permission_error = function (err) {
 	if (!err) return false;
 	return (

--- a/frappe/public/js/frappe/form/doctype_settings/registry.js
+++ b/frappe/public/js/frappe/form/doctype_settings/registry.js
@@ -23,10 +23,9 @@ frappe.doctype_settings.register = function (tab_id, builder) {
 };
 
 /**
- * Shared overflow "…" menu used by list rows and custom tabs.
- *
- * Uses Bootstrap's native dropdown (`data-toggle="dropdown"`), which handles
- * open/close and outside-click on its own — no manual toggling.
+ * Shared overflow "…" menu used by list rows and custom tabs, built on the
+ * espresso Dropdown component (open/close, positioning, keyboard handling all
+ * come from it).
  *
  * `items`: [{ label, icon, danger, onclick() }] — falsy entries are skipped.
  * Returns the actions cell ($div) ready to append to a row. Callers that need a
@@ -37,37 +36,34 @@ frappe.doctype_settings.overflow_menu = function (items) {
 	const $cell = $('<div class="dts-list-cell dts-list-cell-actions"></div>');
 	if (!items.length) return $cell;
 
-	const $wrap = $('<div class="dropdown dts-actions"></div>').appendTo($cell);
 	frappe.ui
-		.button({
-			icon: "ellipsis",
-			size: "xs",
-			variant: "ghost",
-			title: __("More actions"),
-			css_class: "dts-actions-btn",
-			attrs: {
-				"data-toggle": "dropdown",
-				"aria-haspopup": "menu",
-				"aria-expanded": "false",
+		.dropdown({
+			button: {
+				icon: "ellipsis",
+				size: "xs",
+				variant: "ghost",
+				title: __("More actions"),
 			},
+			align: "end",
+			options: items.map((item) => ({
+				label: item.label,
+				icon: item.icon,
+				theme: item.danger ? "red" : undefined,
+				onclick: () => item.onclick(),
+			})),
 		})
-		.appendTo($wrap);
-	const $menu = $('<div class="dropdown-menu dropdown-menu-right" role="menu"></div>').appendTo(
-		$wrap
-	);
-
-	items.forEach((item) => {
-		const $a = $(
-			'<button type="button" class="dropdown-item dts-action-item" role="menuitem"></button>'
-		);
-		if (item.icon) $a.append(frappe.utils.icon(item.icon, "sm"));
-		$a.append($("<span></span>").text(item.label));
-		if (item.danger) $a.addClass("text-danger");
-		$a.on("click", () => item.onclick());
-		$menu.append($a);
-	});
+		.appendTo($cell);
 
 	return $cell;
+};
+
+// Shared loading placeholder: a few skeleton lines instead of bare "Loading" text.
+frappe.doctype_settings.render_loading = function ($container) {
+	const $wrap = $('<div class="dts-loading" aria-label="' + __("Loading") + '"></div>');
+	["40%", "70%", "55%"].forEach((width) => {
+		$wrap.append(frappe.ui.skeleton({ width, height: "14px" }));
+	});
+	return $wrap.appendTo($container);
 };
 
 /**
@@ -106,7 +102,9 @@ frappe.doctype_settings.render_error = function (panel, retry_fn, err) {
 		return;
 	}
 	const $err = panel.body.empty();
-	$('<div class="text-muted small"></div>').text(__("Could not load this tab.")).appendTo($err);
+	$('<div class="text-muted text-p-sm"></div>')
+		.text(__("Could not load this tab."))
+		.appendTo($err);
 	frappe.ui.button({ label: __("Retry"), size: "xs", onclick: () => retry_fn() }).appendTo($err);
 };
 

--- a/frappe/public/js/frappe/form/doctype_settings/registry.js
+++ b/frappe/public/js/frappe/form/doctype_settings/registry.js
@@ -92,10 +92,34 @@ frappe.doctype_settings.empty_state = function ($container, opts) {
 	return $empty;
 };
 
-frappe.doctype_settings.render_error = function (panel, retry_fn) {
+// Tab load failures land here. Permission failures get a dedicated state without a
+// Retry button (retrying a 403 will always fail again); everything else keeps the
+// generic message + Retry, the right affordance for transient/network errors.
+frappe.doctype_settings.render_error = function (panel, retry_fn, err) {
+	if (frappe.doctype_settings.is_permission_error(err)) {
+		panel.body.empty();
+		frappe.doctype_settings.empty_state(panel.body, {
+			icon: "lock",
+			title: __("No access"),
+			description: __("You don't have permission to view this."),
+		});
+		return;
+	}
 	const $err = panel.body.empty();
 	$('<div class="text-muted small"></div>').text(__("Could not load this tab.")).appendTo($err);
 	frappe.ui.button({ label: __("Retry"), size: "xs", onclick: () => retry_fn() }).appendTo($err);
+};
+
+// Rejections reach the tabs in different shapes depending on the API: frappe.call
+// hands back the xhr, frappe.db/xcall the parsed server message. Sniff all of them.
+frappe.doctype_settings.is_permission_error = function (err) {
+	if (!err) return false;
+	return (
+		err.status === 403 ||
+		err.exc_type === "PermissionError" ||
+		(err.responseJSON || {}).exc_type === "PermissionError" ||
+		(typeof err === "string" && err.includes("PermissionError"))
+	);
 };
 
 // Shared helper: write a DocType-level Property Setter (same mechanism Customize Form uses).
@@ -113,12 +137,25 @@ frappe.doctype_settings.set_property = function (doctype, property, value) {
 		.then(() => frappe.show_alert({ message: __("Default updated"), indicator: "green" }));
 };
 
+// Each `condition` hides a tab the user could never load anyway (boot perms are a
+// client-side hint; the server still enforces). A tab that is guaranteed to 403
+// shouldn't be offered at all — see render_error for the residual failure path.
 frappe.doctype_settings.groups = [
 	{
 		group: __("Document"),
 		items: [
-			{ id: "naming", label: __("Naming"), icon: "tag" },
-			{ id: "workflow", label: __("Workflow"), icon: "workflow" },
+			{
+				id: "naming",
+				label: __("Naming"),
+				icon: "tag",
+				condition: () => frappe.model.can_read("Document Naming Rule"),
+			},
+			{
+				id: "workflow",
+				label: __("Workflow"),
+				icon: "workflow",
+				condition: () => frappe.model.can_read("Workflow"),
+			},
 			{
 				id: "permissions",
 				label: __("Permissions"),
@@ -126,19 +163,41 @@ frappe.doctype_settings.groups = [
 				// Role permission APIs are System-Manager-only; hide the tab otherwise.
 				condition: () => frappe.user.has_role("System Manager"),
 			},
-			{ id: "print-format", label: __("Print Formats"), icon: "printer" },
+			{
+				id: "print-format",
+				label: __("Print Formats"),
+				icon: "printer",
+				condition: () => frappe.model.can_read("Print Format"),
+			},
 		],
 	},
 	{
 		group: __("Communication"),
 		items: [
-			{ id: "notifications", label: __("Notifications"), icon: "bell" },
-			{ id: "email-template", label: __("Email Templates"), icon: "mail" },
+			{
+				id: "notifications",
+				label: __("Notifications"),
+				icon: "bell",
+				condition: () => frappe.model.can_read("Notification"),
+			},
+			{
+				id: "email-template",
+				label: __("Email Templates"),
+				icon: "mail",
+				condition: () => frappe.model.can_read("Email Template"),
+			},
 		],
 	},
 	{
 		group: __("Data"),
-		items: [{ id: "global-search", label: __("Global Search"), icon: "search" }],
+		items: [
+			{
+				id: "global-search",
+				label: __("Global Search"),
+				icon: "search",
+				condition: () => frappe.model.can_read("Global Search Settings"),
+			},
+		],
 	},
 ];
 

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/email_template.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/email_template.js
@@ -17,7 +17,7 @@ frappe.doctype_settings.register("email-template", function (panel, doctype) {
 		primary_action: { label: __("New"), icon: "plus", onclick: create },
 		load: () =>
 			Promise.all([
-				frappe.db.get_list("Email Template", {
+				frappe.doctype_settings.get_list("Email Template", {
 					filters: { reference_doctype: doctype },
 					fields: ["name", "subject"],
 					order_by: "name asc",

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/global_search.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/global_search.js
@@ -10,7 +10,7 @@ frappe.doctype_settings.register("global-search", function (panel, doctype) {
 
 function load(panel, doctype) {
 	panel.body.empty();
-	$(`<div class="text-muted small">${__("Loading")}</div>`).appendTo(panel.body);
+	frappe.doctype_settings.render_loading(panel.body);
 
 	frappe.db
 		.get_doc(SETTINGS)

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/global_search.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/global_search.js
@@ -30,7 +30,9 @@ function load(panel, doctype) {
 					render(panel, doctype, true, r.message || []);
 				});
 		})
-		.catch(() => frappe.doctype_settings.render_error(panel, () => load(panel, doctype)));
+		.catch((err) =>
+			frappe.doctype_settings.render_error(panel, () => load(panel, doctype), err)
+		);
 }
 
 function render(panel, doctype, included, options) {

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/global_search.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/global_search.js
@@ -72,17 +72,12 @@ function draw(panel, doctype, state) {
 	$body.append(
 		make_switch(
 			__("Include {0} in global search", [doctype]),
+			__("{0} documents become searchable for everyone in this site", [doctype]),
 			state.included,
 			(checked, input) => {
-				// Membership affects global search for everyone — confirm either way, revert on cancel.
-				const message = checked
-					? __("Add {0} to global search?", [doctype])
-					: __("Remove {0} from global search?", [doctype]);
-				frappe.confirm(
-					message,
-					() => set_included(doctype, checked).then(() => load(panel, doctype)),
-					() => (input.checked = !checked)
-				);
+				set_included(doctype, checked)
+					.then(() => load(panel, doctype))
+					.catch(() => (input.checked = !checked));
 			}
 		)
 	);
@@ -152,17 +147,27 @@ function save(panel, doctype, state) {
 	});
 }
 
-function make_switch(label, checked, onchange) {
-	const $el = $(`<label class="switch-control dts-gs-switch">
-			<span class="switch-text"><span class="label-area"></span></span>
+function make_switch(label, description, checked, onchange) {
+	const id = frappe.dom.get_unique_id();
+	const $row = $('<div class="dts-gs-switch flex items-center justify-between gap-8"></div>');
+	const $text = $('<div class="min-w-0"></div>').appendTo($row);
+	$('<label class="text-base text-ink-gray-7 cursor-pointer"></label>')
+		.attr("for", id)
+		.text(label)
+		.appendTo($text);
+	if (description) {
+		$('<div class="text-p-sm text-ink-gray-5"></div>').text(description).appendTo($text);
+	}
+	const $toggle = $(`<label class="switch-control dts-gs-toggle">
 			<span class="input-area"><input type="checkbox" role="switch" /></span>
 			<span class="switch-visual" aria-hidden="true"><span class="switch-thumb"></span></span>
-		</label>`);
-	$el.find(".label-area").text(label);
-	$el.find("input")
+		</label>`).appendTo($row);
+	$toggle
+		.find("input")
+		.attr("id", id)
 		.prop("checked", checked)
 		.on("change", (e) => onchange(e.target.checked, e.target));
-	return $el;
+	return $row;
 }
 
 function make_check(label, checked, onchange) {

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
@@ -271,9 +271,6 @@ async function remove_series(doctype, series, refresh) {
 // Load the Document Naming Settings Single into client locals and resolve with it, so
 // frappe.call({ doc }) (which reads the doc from locals by name) can drive its
 // whitelisted instance methods. Calls reuse one doc and must stay sequential.
-// Not frappe.model.with_doc: its callback only fires on success, so a failed fetch
-// (e.g. no permission) would never settle this promise and the tab would hang on
-// "Loading" forever. Fetch via getdoc directly so failures reject to the caller.
 function load_settings() {
 	const cached = frappe.get_doc(NAMING_SETTINGS, NAMING_SETTINGS);
 	if (cached) return Promise.resolve(cached);

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/naming.js
@@ -271,12 +271,20 @@ async function remove_series(doctype, series, refresh) {
 // Load the Document Naming Settings Single into client locals and resolve with it, so
 // frappe.call({ doc }) (which reads the doc from locals by name) can drive its
 // whitelisted instance methods. Calls reuse one doc and must stay sequential.
+// Not frappe.model.with_doc: its callback only fires on success, so a failed fetch
+// (e.g. no permission) would never settle this promise and the tab would hang on
+// "Loading" forever. Fetch via getdoc directly so failures reject to the caller.
 function load_settings() {
-	return new Promise((resolve) =>
-		frappe.model.with_doc(NAMING_SETTINGS, NAMING_SETTINGS, () =>
-			resolve(frappe.get_doc(NAMING_SETTINGS, NAMING_SETTINGS))
-		)
-	);
+	const cached = frappe.get_doc(NAMING_SETTINGS, NAMING_SETTINGS);
+	if (cached) return Promise.resolve(cached);
+
+	return frappe
+		.call({
+			method: "frappe.desk.form.load.getdoc",
+			type: "GET",
+			args: { doctype: NAMING_SETTINGS, name: NAMING_SETTINGS },
+		})
+		.then(() => frappe.get_doc(NAMING_SETTINGS, NAMING_SETTINGS));
 }
 
 function settings_call(doc, method) {

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/notification.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/notification.js
@@ -28,7 +28,7 @@ frappe.doctype_settings.register("notifications", function (panel, doctype) {
 		show_header: true,
 		primary_action: { label: __("New"), icon: "plus", onclick: create },
 		load: () =>
-			frappe.db.get_list("Notification", {
+			frappe.doctype_settings.get_list("Notification", {
 				filters: { document_type: doctype },
 				fields: ["name", "event", "channel", "enabled"],
 				order_by: "name asc",

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/permissions.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/permissions.js
@@ -37,7 +37,7 @@ function draw(panel, doctype) {
 	Promise.all([
 		perm_call("get_permissions", { doctype }),
 		// A Custom DocPerm row means this doctype's permissions diverge from standard.
-		frappe.db.get_list("Custom DocPerm", {
+		frappe.doctype_settings.get_list("Custom DocPerm", {
 			filters: { parent: doctype },
 			fields: ["name"],
 			limit: 1,

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/permissions.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/permissions.js
@@ -52,7 +52,9 @@ function draw(panel, doctype) {
 				roles: perms.map((p) => ({ ...p, source: is_customized ? "Custom" : "Standard" })),
 			});
 		})
-		.catch(() => frappe.doctype_settings.render_error(panel, () => draw(panel, doctype)));
+		.catch((err) =>
+			frappe.doctype_settings.render_error(panel, () => draw(panel, doctype), err)
+		);
 }
 
 function render(panel, doctype, { roles, is_customized }) {

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/permissions.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/permissions.js
@@ -32,7 +32,7 @@ function perm_call(method, args) {
 
 function draw(panel, doctype) {
 	const $body = panel.body.empty();
-	$(`<div class="text-muted small dts-perm-state">${__("Loading")}</div>`).appendTo($body);
+	frappe.doctype_settings.render_loading($body);
 
 	Promise.all([
 		perm_call("get_permissions", { doctype }),
@@ -204,37 +204,36 @@ function flag_badge() {
 }
 
 function customized_banner(panel, doctype, reload) {
-	const $banner = $('<div class="alert alert-warning dts-perm-banner" role="alert"></div>');
-	$banner.append(frappe.utils.icon("triangle-alert", "sm"));
-	$('<span class="dts-perm-banner-text"></span>')
-		.text(__("Permissions for this doctype have been customized."))
-		.appendTo($banner);
-	$('<a href="#" class="dts-perm-banner-action"></a>')
-		.text(__("Reset to default"))
-		.appendTo($banner)
-		.on("click", (e) => {
-			e.preventDefault();
-			frappe.confirm(
-				__("Reset {0} permissions to their default? This removes all customizations.", [
-					doctype,
-				]),
-				() =>
-					perm_call("reset", { doctype }).then(() => {
-						frappe.show_alert({
-							message: __("Permissions reset"),
-							indicator: "green",
-						});
-						reload();
-					})
-			);
-		});
-	return $banner;
+	const reset = () =>
+		frappe.confirm(
+			__("Reset {0} permissions to their default? This removes all customizations.", [
+				doctype,
+			]),
+			() =>
+				perm_call("reset", { doctype }).then(() => {
+					frappe.show_alert({ message: __("Permissions reset"), indicator: "green" });
+					reload();
+				})
+		);
+
+	return frappe.ui
+		.alert({
+			title: __("Permissions for this doctype have been customized."),
+			theme: "yellow",
+			footer: frappe.ui.button({
+				label: __("Reset to default"),
+				size: "sm",
+				variant: "outline",
+				onclick: reset,
+			}),
+		})
+		.addClass("dts-perm-banner");
 }
 
 function footer(panel, doctype) {
 	const $footer = $('<div class="dts-perm-footer"></div>');
 	$("<span></span>").appendTo($footer); // spacer to keep the link right-aligned
-	$('<a href="#" class="dts-perm-footer-link"></a>')
+	$('<a href="#" class="dts-perm-footer-link text-base-medium"></a>')
 		.append($("<span></span>").text(__("Open Role Permissions Manager")))
 		.append(frappe.utils.icon("external-link", "sm"))
 		.appendTo($footer)

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/print_format.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/print_format.js
@@ -76,7 +76,7 @@ frappe.doctype_settings.register("print-format", function (panel, doctype) {
 				default_pf = current_default;
 				render(formats || []);
 			})
-			.catch(() => frappe.doctype_settings.render_error(panel, load));
+			.catch((err) => frappe.doctype_settings.render_error(panel, load, err));
 	}
 
 	// Default print format lives in a Property Setter for standard doctypes (Customize

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/print_format.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/print_format.js
@@ -47,7 +47,7 @@ frappe.doctype_settings.register("print-format", function (panel, doctype) {
 
 	function load() {
 		panel.body.empty();
-		$(`<div class="text-muted small">${__("Loading")}</div>`).appendTo(panel.body);
+		frappe.doctype_settings.render_loading(panel.body);
 
 		// Reuse generic client APIs: get_list for the formats and a printable sample
 		// (submitted-only for submittable doctypes) for previews. The current default is
@@ -191,7 +191,8 @@ frappe.doctype_settings.register("print-format", function (panel, doctype) {
 			fields: [{ fieldtype: "HTML", fieldname: "preview" }],
 		});
 		const $wrapper = dialog.fields_dict.preview.$wrapper;
-		$wrapper.html(`<div class="text-muted small">${__("Loading")}</div>`);
+		$wrapper.empty();
+		frappe.doctype_settings.render_loading($wrapper);
 		dialog.show();
 
 		// Render the print HTML server-side and inject it as a static (JS-free) iframe via

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/print_format.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/print_format.js
@@ -57,13 +57,13 @@ frappe.doctype_settings.register("print-format", function (panel, doctype) {
 		const sample_filters = meta.is_submittable ? { docstatus: 1 } : {};
 
 		Promise.all([
-			frappe.db.get_list("Print Format", {
+			frappe.doctype_settings.get_list("Print Format", {
 				filters: { doc_type: doctype },
 				fields: ["name", "standard", "preview_image"],
 				order_by: "standard asc, name asc",
 				limit: 0,
 			}),
-			frappe.db.get_list(doctype, {
+			frappe.doctype_settings.get_list(doctype, {
 				filters: sample_filters,
 				fields: ["name"],
 				order_by: "modified desc",

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
@@ -19,7 +19,7 @@ frappe.doctype_settings.register("general", function (panel, doctype) {
 
 function load(panel, doctype) {
 	const $body = panel.body.empty();
-	$('<div class="text-muted small"></div>').text(__("Loading")).appendTo($body);
+	frappe.doctype_settings.render_loading($body);
 
 	frappe
 		.call({
@@ -47,14 +47,41 @@ function render(panel, doctype, groups) {
 		return;
 	}
 
-	// Flat list — every field across every source single, no per-single section headers.
-	// Each field keeps its `group` context (the source single + its `doc`) for saving and
-	// dependency evaluation, plus its own `can_write` flag (doc-level write ∧ field permlevel).
+	// One section per source single (Selling Settings, Stock Settings, …) so long maps
+	// scan in chunks and every setting keeps its provenance. A single-source map stays
+	// flat — one heading over the whole list is noise. Each field keeps its `group`
+	// context (the source single + its `doc`) for saving and dependency evaluation,
+	// plus its own `can_write` flag (doc-level write ∧ field permlevel).
+	const show_headings = groups.length > 1;
 	groups.forEach((group) => {
 		group.doc = group.doc || {};
+		if (show_headings) $body.append(make_heading(panel, group));
 		group.fields.forEach((field) => render_field($body, group, field));
 		apply_dependencies(group);
 	});
+}
+
+// Section heading for one source single: its label plus a jump link to the full
+// settings form, for anything beyond the curated subset shown here.
+function make_heading(panel, group) {
+	// Self-contained: espresso typography utility for the title instead of the shared
+	// section-heading classes, so nothing is inherited or overridden across files.
+	const $heading = $('<div class="dts-settings-group-heading"></div>');
+	$('<div class="text-base text-ink-gray-6"></div>').text(group.label).appendTo($heading);
+	// Icon-only arrow right beside the title — the whole heading names the single, so
+	// the glyph is the affordance; the tooltip/aria-label carry the full action.
+	$('<a href="#" class="dts-settings-group-link"></a>')
+		.attr("title", __("Open {0}", [group.label]))
+		.attr("aria-label", __("Open {0}", [group.label]))
+		.append(frappe.utils.icon("arrow-up-right", "sm"))
+		.appendTo($heading)
+		.on("click", (e) => {
+			e.preventDefault();
+			panel.dialog.hide();
+			frappe.set_route("Form", group.settings);
+		});
+	group.$heading = $heading; // referenced by apply_dependencies() to hide emptied groups
+	return $heading;
 }
 
 // One consistent row for every field type: label + description on the left, a compact
@@ -65,9 +92,11 @@ function render_field($body, group, field) {
 	field.$row = $row; // referenced by apply_dependencies() to show/hide the field
 
 	const $text = $('<div class="dts-setting-text"></div>').appendTo($row);
-	$('<div class="dts-setting-label"></div>').text(field.label).appendTo($text);
+	$('<div class="dts-setting-label text-base-medium"></div>').text(field.label).appendTo($text);
 	if (field.description) {
-		$('<div class="dts-setting-description"></div>').text(field.description).appendTo($text);
+		$('<div class="dts-setting-description text-p-sm"></div>')
+			.text(field.description)
+			.appendTo($text);
 	}
 
 	const $control = $('<div class="dts-setting-control"></div>').appendTo($row);
@@ -146,12 +175,18 @@ function save(group, field, value, revert) {
 // Show/hide and lock each field in a group per its depends_on / read_only_depends_on,
 // evaluated against the group's live `doc`.
 function apply_dependencies(group) {
+	let any_visible = false;
 	group.fields.forEach((field) => {
-		field.$row.toggle(evaluate(field.depends_on, group.doc));
+		const visible = evaluate(field.depends_on, group.doc);
+		field.$row.toggle(visible);
+		any_visible = any_visible || visible;
 
 		const ro = field.read_only_depends_on && evaluate(field.read_only_depends_on, group.doc);
 		field.set_locked && field.set_locked(!field.can_write || !!ro);
 	});
+	// A group whose fields are all dependency-hidden takes its heading with it —
+	// no orphaned section titles mid-list.
+	group.$heading && group.$heading.toggle(any_visible);
 }
 
 // Mirrors frappe.ui.form.Layout.evaluate_depends_on_value, minus the frm-only `fn:` branch.

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
@@ -30,7 +30,9 @@ function load(panel, doctype) {
 			if (r.exc) throw r.exc;
 			render(panel, doctype, r.message || []);
 		})
-		.catch(() => frappe.doctype_settings.render_error(panel, () => load(panel, doctype)));
+		.catch((err) =>
+			frappe.doctype_settings.render_error(panel, () => load(panel, doctype), err)
+		);
 }
 
 function render(panel, doctype, groups) {

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
@@ -47,11 +47,6 @@ function render(panel, doctype, groups) {
 		return;
 	}
 
-	// One section per source single (Selling Settings, Stock Settings, …) so long maps
-	// scan in chunks and every setting keeps its provenance. A single-source map stays
-	// flat — one heading over the whole list is noise. Each field keeps its `group`
-	// context (the source single + its `doc`) for saving and dependency evaluation,
-	// plus its own `can_write` flag (doc-level write ∧ field permlevel).
 	const show_headings = groups.length > 1;
 	groups.forEach((group) => {
 		group.doc = group.doc || {};
@@ -64,12 +59,8 @@ function render(panel, doctype, groups) {
 // Section heading for one source single: its label plus a jump link to the full
 // settings form, for anything beyond the curated subset shown here.
 function make_heading(panel, group) {
-	// Self-contained: espresso typography utility for the title instead of the shared
-	// section-heading classes, so nothing is inherited or overridden across files.
 	const $heading = $('<div class="dts-settings-group-heading"></div>');
 	$('<div class="text-base text-ink-gray-6"></div>').text(group.label).appendTo($heading);
-	// Icon-only arrow right beside the title — the whole heading names the single, so
-	// the glyph is the affordance; the tooltip/aria-label carry the full action.
 	$('<a href="#" class="dts-settings-group-link"></a>')
 		.attr("title", __("Open {0}", [group.label]))
 		.attr("aria-label", __("Open {0}", [group.label]))
@@ -80,7 +71,7 @@ function make_heading(panel, group) {
 			panel.dialog.hide();
 			frappe.set_route("Form", group.settings);
 		});
-	group.$heading = $heading; // referenced by apply_dependencies() to hide emptied groups
+	group.$heading = $heading;
 	return $heading;
 }
 
@@ -184,8 +175,6 @@ function apply_dependencies(group) {
 		const ro = field.read_only_depends_on && evaluate(field.read_only_depends_on, group.doc);
 		field.set_locked && field.set_locked(!field.can_write || !!ro);
 	});
-	// A group whose fields are all dependency-hidden takes its heading with it —
-	// no orphaned section titles mid-list.
 	group.$heading && group.$heading.toggle(any_visible);
 }
 

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
@@ -60,7 +60,7 @@ function render(panel, doctype, groups) {
 // settings form, for anything beyond the curated subset shown here.
 function make_heading(panel, group) {
 	const $heading = $('<div class="dts-settings-group-heading"></div>');
-	$('<div class="text-base-medium text-ink-gray-8"></div>').text(group.label).appendTo($heading);
+	$('<div class="text-base text-ink-gray-5"></div>').text(group.label).appendTo($heading);
 	$('<a href="#" class="dts-settings-group-link"></a>')
 		.attr("title", __("Open {0}", [group.label]))
 		.attr("aria-label", __("Open {0}", [group.label]))
@@ -83,7 +83,7 @@ function render_field($body, group, field) {
 	field.$row = $row; // referenced by apply_dependencies() to show/hide the field
 
 	const $text = $('<div class="dts-setting-text"></div>').appendTo($row);
-	$('<div class="dts-setting-label text-base"></div>').text(field.label).appendTo($text);
+	$('<div class="dts-setting-label text-base-medium"></div>').text(field.label).appendTo($text);
 	if (field.description) {
 		$('<div class="dts-setting-description text-p-sm"></div>')
 			.text(field.description)

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
@@ -134,6 +134,7 @@ function render_input($control, group, field) {
 		control.df.read_only = locked ? 1 : 0;
 		control.refresh();
 	};
+	control.tooltip && control.tooltip.remove();
 	control.set_value(field.value);
 	control.refresh();
 }

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/settings_map.js
@@ -60,7 +60,7 @@ function render(panel, doctype, groups) {
 // settings form, for anything beyond the curated subset shown here.
 function make_heading(panel, group) {
 	const $heading = $('<div class="dts-settings-group-heading"></div>');
-	$('<div class="text-base text-ink-gray-6"></div>').text(group.label).appendTo($heading);
+	$('<div class="text-base-medium text-ink-gray-8"></div>').text(group.label).appendTo($heading);
 	$('<a href="#" class="dts-settings-group-link"></a>')
 		.attr("title", __("Open {0}", [group.label]))
 		.attr("aria-label", __("Open {0}", [group.label]))
@@ -83,7 +83,7 @@ function render_field($body, group, field) {
 	field.$row = $row; // referenced by apply_dependencies() to show/hide the field
 
 	const $text = $('<div class="dts-setting-text"></div>').appendTo($row);
-	$('<div class="dts-setting-label text-base-medium"></div>').text(field.label).appendTo($text);
+	$('<div class="dts-setting-label text-base"></div>').text(field.label).appendTo($text);
 	if (field.description) {
 		$('<div class="dts-setting-description text-p-sm"></div>')
 			.text(field.description)

--- a/frappe/public/js/frappe/form/doctype_settings/tabs/workflow.js
+++ b/frappe/public/js/frappe/form/doctype_settings/tabs/workflow.js
@@ -18,7 +18,7 @@ frappe.doctype_settings.register("workflow", function (panel, doctype) {
 		show_header: true,
 		primary_action: { label: __("New"), icon: "plus", onclick: create },
 		load: () =>
-			frappe.db.get_list("Workflow", {
+			frappe.doctype_settings.get_list("Workflow", {
 				filters: { document_type: doctype },
 				fields: ["name", "workflow_name", "is_active"],
 				order_by: "name asc",

--- a/frappe/public/scss/desk/doctype_settings.scss
+++ b/frappe/public/scss/desk/doctype_settings.scss
@@ -4,12 +4,19 @@
 // grid, the print-format card grid, and the shared empty state.
 
 // ── Global Search tab: inclusion toggle + searchable-field checkbox grid ──
-// Selector carries `.switch-control` too, to beat `label.switch-control`'s padding /
-// margin-bottom from controls.scss (otherwise the divider hugs the search bar).
-.switch-control.dts-gs-switch {
+// The inclusion row is a plain flex container (layout via utilities); only the switch
+// itself is a `.switch-control` label, so clicking the row's empty space does nothing.
+.dts-gs-switch {
 	padding-bottom: var(--padding-md);
 	margin-bottom: var(--padding-md);
 	border-bottom: 1px solid var(--border-color);
+}
+
+// Bare toggle: neutralise label.switch-control's full-width/padding so it hugs its
+// switch instead of stretching across the row (same as .dts-setting-toggle).
+.dts-gs-toggle.switch-control {
+	width: auto;
+	padding: 0;
 }
 
 .dts-gs-search {

--- a/frappe/public/scss/desk/doctype_settings.scss
+++ b/frappe/public/scss/desk/doctype_settings.scss
@@ -59,12 +59,6 @@
 	}
 }
 
-// Related Settings: one section per source single, styled after the CRM settings
-// dialog (the design reference for this dialog family): the section title is a size
-// step above the row labels (espresso `text-lg-medium` utility, set in the markup),
-// and the heading floats in clear space — separators belong to the rows
-// (border-bottom on .dts-setting), never to the heading. Self-contained: no shared
-// section-heading classes, so nothing cascades in from other dialogs.
 .dts-settings-group-heading {
 	display: flex;
 	align-items: center;
@@ -98,8 +92,6 @@
 	justify-content: space-between;
 	gap: var(--margin-lg);
 	padding: var(--padding-md) 0;
-	// Separator under each row (CRM reference) — this also closes off a group before
-	// the next section heading. The final row of the tab ends clean.
 	border-bottom: 1px solid var(--border-color);
 
 	&:last-child {
@@ -111,8 +103,6 @@
 	min-width: 0;
 }
 
-// Type comes from espresso utilities in the markup (text-base-medium / text-p-sm);
-// only color and rhythm live here.
 .dts-setting-label {
 	color: var(--ink-gray-8);
 }
@@ -156,7 +146,6 @@
 	border-bottom: 1px solid var(--border-color);
 }
 
-// Type via espresso `text-sm-medium` utility in the markup.
 .dts-list-head {
 	padding: 0 0 var(--padding-sm);
 	color: var(--ink-gray-5);
@@ -208,8 +197,6 @@
 	min-width: 0;
 }
 
-// Truncation comes from the shared `.ellipsis` utility, type from espresso
-// `text-base-medium` / `text-p-sm` utilities on the elements.
 .dts-list-primary {
 	color: var(--ink-gray-8);
 	min-width: 0;
@@ -243,8 +230,6 @@
 	cursor: pointer;
 }
 
-// Shared loading placeholder (see frappe.doctype_settings.render_loading): a
-// short stack of skeleton lines.
 .dts-loading {
 	display: flex;
 	flex-direction: column;

--- a/frappe/public/scss/desk/doctype_settings.scss
+++ b/frappe/public/scss/desk/doctype_settings.scss
@@ -30,7 +30,6 @@
 	gap: var(--padding-sm);
 	margin: 0;
 	padding: var(--padding-xs) 0;
-	font-weight: var(--weight-regular);
 	cursor: pointer;
 
 	input {
@@ -60,6 +59,37 @@
 	}
 }
 
+// Related Settings: one section per source single, styled after the CRM settings
+// dialog (the design reference for this dialog family): the section title is a size
+// step above the row labels (espresso `text-lg-medium` utility, set in the markup),
+// and the heading floats in clear space — separators belong to the rows
+// (border-bottom on .dts-setting), never to the heading. Self-contained: no shared
+// section-heading classes, so nothing cascades in from other dialogs.
+.dts-settings-group-heading {
+	display: flex;
+	align-items: center;
+	gap: var(--margin-xs);
+	margin-top: var(--margin-xl);
+	margin-bottom: var(--margin-xs);
+
+	&:first-child {
+		margin-top: 0;
+		padding-top: 12px; // match the panel body's own padding-top
+	}
+}
+
+// Icon-only arrow beside the section title, linking to the source single's form.
+.dts-settings-group-link {
+	display: inline-flex;
+	align-items: center;
+	flex-shrink: 0;
+	color: var(--ink-gray-5);
+
+	&:hover {
+		color: var(--ink-gray-8);
+	}
+}
+
 // Related Settings: a uniform settings row — label + description on the left, a compact
 // control on the right — so toggles, selects and inputs all read the same way.
 .dts-setting {
@@ -68,9 +98,12 @@
 	justify-content: space-between;
 	gap: var(--margin-lg);
 	padding: var(--padding-md) 0;
+	// Separator under each row (CRM reference) — this also closes off a group before
+	// the next section heading. The final row of the tab ends clean.
+	border-bottom: 1px solid var(--border-color);
 
-	& + & {
-		border-top: 1px solid var(--border-color);
+	&:last-child {
+		border-bottom: none;
 	}
 }
 
@@ -78,15 +111,14 @@
 	min-width: 0;
 }
 
+// Type comes from espresso utilities in the markup (text-base-medium / text-p-sm);
+// only color and rhythm live here.
 .dts-setting-label {
-	font-size: var(--text-base);
 	color: var(--ink-gray-8);
 }
 
 .dts-setting-description {
 	margin-top: 2px;
-	font-size: var(--text-sm);
-	line-height: 1.4;
 	color: var(--ink-gray-5);
 }
 
@@ -124,11 +156,10 @@
 	border-bottom: 1px solid var(--border-color);
 }
 
+// Type via espresso `text-sm-medium` utility in the markup.
 .dts-list-head {
 	padding: 0 0 var(--padding-sm);
 	color: var(--ink-gray-5);
-	font-size: var(--text-sm);
-	font-weight: var(--weight-medium);
 	border-bottom: 1px solid var(--border-color);
 }
 
@@ -177,10 +208,10 @@
 	min-width: 0;
 }
 
-// Truncation comes from the shared `.ellipsis` utility on the element.
+// Truncation comes from the shared `.ellipsis` utility, type from espresso
+// `text-base-medium` / `text-p-sm` utilities on the elements.
 .dts-list-primary {
 	color: var(--ink-gray-8);
-	font-weight: var(--weight-medium);
 	min-width: 0;
 
 	&.dts-list-link {
@@ -196,7 +227,6 @@
 .dts-list-secondary {
 	margin-top: 2px;
 	color: var(--ink-gray-5);
-	font-size: var(--text-sm);
 }
 
 .dts-list-state {
@@ -213,62 +243,20 @@
 	cursor: pointer;
 }
 
-// Overflow "…" menu trigger — open/close + positioning handled by Bootstrap's dropdown.
-.dts-actions .dts-actions-btn {
-	line-height: 1;
-	font-weight: var(--weight-bold);
-}
-
-// Overflow menu item: icon + label grouped left (zero any inherited margins that
-// otherwise push the label to the right edge).
-.dts-action-item.dropdown-item {
+// Shared loading placeholder (see frappe.doctype_settings.render_loading): a
+// short stack of skeleton lines.
+.dts-loading {
 	display: flex;
-	align-items: center;
-	justify-content: flex-start;
-	gap: var(--padding-sm);
-	text-align: left;
-
-	.icon {
-		flex-shrink: 0;
-		margin: 0;
-	}
-
-	> span {
-		margin: 0;
-	}
+	flex-direction: column;
+	gap: var(--margin-sm);
+	padding: var(--padding-md) 0;
 }
 
 // ── Permissions tab: EmbeddedList of roles with rights badges + customized banner
 // + footer link ──
-// "Customized" notice with a reset action. Color/padding/radius come from the
-// framework's `.alert.alert-warning`; only the inline row layout is local.
+// "Customized" notice is the espresso alert component; only the outer margin is local.
 .dts-perm-banner {
-	display: flex;
-	align-items: center;
-	gap: var(--padding-sm);
 	margin-bottom: var(--margin-sm);
-	font-size: var(--text-sm);
-
-	// Keep the warning glyph small and from shrinking.
-	.icon {
-		flex: 0 0 auto;
-		width: 14px;
-		height: 14px;
-	}
-
-	// Text fills the space and stays left-aligned beside the icon.
-	.dts-perm-banner-text {
-		flex: 1;
-		min-width: 0;
-	}
-
-	.dts-perm-banner-action {
-		flex: 0 0 auto;
-		color: inherit;
-		font-weight: var(--weight-medium);
-		text-decoration: underline;
-		white-space: nowrap;
-	}
 }
 
 // Granted-right badge: a compact green pill holding just the check icon.
@@ -289,20 +277,12 @@
 	padding-top: var(--padding-md);
 	border-top: 1px solid var(--border-color);
 
-	.dts-perm-footer-note {
-		display: flex;
-		align-items: center;
-		gap: var(--padding-xs);
-		color: var(--ink-gray-5);
-		font-size: var(--text-sm);
-	}
-
+	// Weight comes from the espresso `text-base-medium` utility in the markup.
 	.dts-perm-footer-link {
 		display: inline-flex;
 		align-items: center;
 		gap: var(--padding-xs);
 		color: var(--ink-gray-7);
-		font-weight: var(--weight-medium);
 		white-space: nowrap;
 	}
 }
@@ -406,7 +386,6 @@
 // Truncation comes from the shared `.ellipsis` utility on the element.
 .dts-pf-name {
 	display: block;
-	font-weight: var(--weight-regular);
 	color: var(--ink-gray-8);
 	cursor: pointer;
 

--- a/frappe/public/scss/desk/settings_dialog.scss
+++ b/frappe/public/scss/desk/settings_dialog.scss
@@ -218,8 +218,8 @@ table + .settings-dialog-section-heading {
 
 .settings-dialog-section-title {
 	margin-top: var(--margin-md);
-	font-size: var(--text-base);
-	font-weight: var(--weight-medium);
+	font-size: var(--text-lg);
+	font-weight: var(--weight-semibold);
 	line-height: 1.5;
 }
 


### PR DESCRIPTION
Redesigned the general tab for the DocType Setting dialog, which displays the settings based on the group of single settings it comes from. 

Before: 
<img width="1250" height="739" alt="Screenshot 2026-07-18 at 12 41 08 PM" src="https://github.com/user-attachments/assets/9af2a4fe-03eb-4cde-bc74-b5fe1fa2f9e6" />
After: 
<img width="1231" height="731" alt="Screenshot 2026-07-18 at 12 41 18 PM" src="https://github.com/user-attachments/assets/f6a5ec22-bb97-45b8-8b95-9338dcd80d1b" />

Also fixed the issue of the settings tab displaying when a user has non-admin permissions.