### PR TITLE
fix(ui): pin only action columns, not a trailing data column

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -861,8 +861,11 @@
 }
 
 .form-grid {
-	// Pin action and index columns so wide grids stay usable.
-	.grid-row > .row .col:last-child,
+	// Pin action and index columns so wide grids stay usable. Data columns
+	// (.grid-static-col) are exempt: a grid without a trailing action column
+	// (e.g. an in_place_edit dialog table) ends on a data column, which must
+	// keep its width instead of being pinned to 30px.
+	.grid-row > .row .col:last-child:not(.grid-static-col),
 	.grid-row > .dialog-assignment-row .col:first-child,
 	.grid-row > .dialog-assignment-row .col:last-child {
 		max-width: 30px;


### PR DESCRIPTION
## Problem

`.form-grid .grid-row > .row .col:last-child` pins the last column of every grid row to 30px, assuming rows always end with the action column. A grid that renders no action column — e.g. a dialog table with `in_place_edit` and `cannot_add_rows` — ends on a **data** column, which gets crushed to a 30px sliver while its neighbours flex-grow into the released space, behind a horizontal scrollbar.

Easy repro: ERPNext's *Select Items for Quality Inspection* dialog (two Data columns) — the second column renders ~30px wide with its label truncated.

## Fix

Data columns carry `grid-static-col`; action columns don't. Exempt them: `.col:last-child:not(.grid-static-col)`. Grids with an action column are unchanged; grids without one keep their last data column at its configured width.