### PR TITLE
fix(filters): preserve numeric values across locale formats

### DIFF
--- a/cypress/integration/filter_group.js
+++ b/cypress/integration/filter_group.js
@@ -1,0 +1,37 @@
+context("Filter Group", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/desk/website");
+	});
+
+	it("preserves numeric filter values with a comma decimal separator", () => {
+		cy.window().then(async ({ frappe, $ }) => {
+			const original_number_format = frappe.boot.sysdefaults.number_format;
+			frappe.boot.sysdefaults.number_format = "#.###,##";
+			await frappe.model.with_doctype("Currency");
+
+			const $parent = $("<div>").appendTo("body");
+			try {
+				const filter_group = new frappe.ui.FilterGroup({
+					parent: $parent,
+					doctype: "Currency",
+					on_change: () => {},
+				});
+
+				await filter_group.add_filter(
+					"Currency",
+					"smallest_currency_fraction_value",
+					"=",
+					7.95
+				);
+
+				expect(filter_group.get_filters()).to.deep.equal([
+					["Currency", "smallest_currency_fraction_value", "=", 7.95],
+				]);
+			} finally {
+				$parent.remove();
+				frappe.boot.sysdefaults.number_format = original_number_format;
+			}
+		});
+	});
+});

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -276,8 +276,9 @@ frappe.ui.Filter = class {
 
 		if (Array.isArray(value)) {
 			this._filter_value_set = this.field.set_value(value);
-		} else if (value !== undefined || value !== null) {
-			this._filter_value_set = this.field.set_value((value + "").trim());
+		} else if (value !== undefined && value !== null) {
+			const field_value = typeof value === "number" ? value : String(value).trim();
+			this._filter_value_set = this.field.set_value(field_value);
 		}
 		return this._filter_value_set;
 	}


### PR DESCRIPTION
## Description

Fixes #41008 by preserving numeric filter values instead of converting them to locale-sensitive strings.

**Before:** `7.95` became `795` with comma-decimal number formats.

**After:** The filter correctly retains `7.95` and displays `7,95`.

## Tests

Added a Cypress regression test that fails before the fix and passes after it.