### PR TITLE
fix: Table MultiSelect dropdown keeps excluding the previous document's selections

### DIFF
--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -184,6 +184,7 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 		return result;
 	}
 	set_formatted_input(value) {
+		this._update_rows(value || []);
 		const link_field = this.get_link_field();
 		const values = (value || []).map((row) => row[link_field.fieldname]);
 		this.set_pill_html(values);


### PR DESCRIPTION
## Bug

Form controls are reused across documents of the same doctype. `ControlTableMultiSelect._rows_list` — the list `awesomplete.filter` uses to hide already-selected values from the dropdown — is only updated on user edits (`set_model_value`, pill removal). It is never synced when the control renders a different document.

**Repro:** add some values to a Table MultiSelect on document A and save. Open document B of the same doctype and click the same field: the values selected on A are missing from the dropdown, even though B has none selected. Only a full page reload (which recreates the control with an empty `_rows_list`) shows the complete list again.

## Fix

Sync `_update_rows` in `set_formatted_input`, which is exactly the point where the control renders the currently loaded document's pills — so the exclusion list always matches the pills on screen.

Verified on a Table MultiSelect field (company restrictions on Item/Customer/Supplier, frappe/erpnext#57258): after saving selections on one document, the next document's dropdown shows the full list without a reload.