### PR TITLE
fix(toolbar): use frappe.model.is_single to gate Customize menu

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -643,7 +643,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 			let doctype = is_doctype_form ? this.frm.docname : this.frm.doctype;
 			let is_core_doctype = frappe.model.core_doctypes_list.includes(doctype);
 
-			if (!is_core_doctype && this.frm.meta.issingle === 0) {
+			if (!is_core_doctype && !frappe.model.is_single(doctype)) {
 				this.page.add_menu_item(
 					__("Settings"),
 					() => {


### PR DESCRIPTION
When editing a DocType record, `this.frm.doctype` is `"DocType"` itself, so `this.frm.meta` always resolved to the DocType meta-doctype's meta — not the meta of the doctype actually being edited.

Since DocType is never a Single, `this.frm.meta.issingle` was always `0`, so the guard `this.frm.meta.issingle === 0` was always true regardless of the target.

This caused the **Settings**/**Customize** menu items to always appear, even when editing a Single DocType, letting users open **Customize Form** on a Single and hit the server-side validation:

> "Single DocTypes cannot be customized."

