### PR TITLE
fix(print-format): scope preview cleanup to generated files only

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -290,24 +290,25 @@ def generate_preview(name: str) -> str | None:
 		frappe.log_error(f"Print format preview generation failed: {name}")
 		return None
 
+	fname = f"pf-preview-{frappe.generate_hash(length=10)}.webp"
+	file = save_file(fname, image, "Print Format", name, is_private=1, df="preview_image")
+	# Don't bump `modified` — generating a preview isn't a content edit. Otherwise the
+	# background refresh would stale-date an open form and break its next save with a
+	# timestamp mismatch.
+	doc.db_set("preview_image", file.file_url, update_modified=False)
+
 	stale = frappe.get_all(
 		"File",
 		filters={
 			"attached_to_doctype": "Print Format",
 			"attached_to_name": name,
-			"file_url": ("like", "%pf-preview-%"),
+			"attached_to_field": "preview_image",
+			"name": ("!=", file.name),
 		},
 		pluck="name",
 	)
 	for old in stale:
 		frappe.delete_doc("File", old, ignore_permissions=True, delete_permanently=True)
-
-	fname = f"pf-preview-{frappe.generate_hash(length=10)}.webp"
-	file = save_file(fname, image, "Print Format", name, is_private=1)
-	# Don't bump `modified` — generating a preview isn't a content edit. Otherwise the
-	# background refresh would stale-date an open form and break its next save with a
-	# timestamp mismatch.
-	doc.db_set("preview_image", file.file_url, update_modified=False)
 
 	for old in stale:
 		notify_docinfo_attachment(name, {"name": old}, "delete")

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -456,3 +456,61 @@ class TestClassicConverter(IntegrationTestCase):
 
 		self.assertIn(self.FORMAT_NAME, report)
 		self.assertNotIn(bad_name, report)
+
+
+class TestPrintFormatPreview(IntegrationTestCase):
+	FORMAT_NAME = "_Test Preview Sweep"
+
+	def setUp(self):
+		frappe.delete_doc("Print Format", self.FORMAT_NAME, force=True, ignore_missing=True)
+		frappe.get_doc(
+			{
+				"doctype": "Print Format",
+				"name": self.FORMAT_NAME,
+				"doc_type": "ToDo",
+				"print_format_builder_beta": 1,
+				"format_data": frappe.as_json(
+					{
+						"sections": [{"label": "", "columns": [{"label": "", "fields": []}]}],
+						"header": {"columns": []},
+						"footer": {"columns": []},
+					}
+				),
+			}
+		).insert()
+		frappe.get_doc({"doctype": "ToDo", "description": "preview sample"}).insert()
+		self.addCleanup(frappe.delete_doc, "Print Format", self.FORMAT_NAME, force=True)
+
+	def _preview_files(self):
+		return frappe.get_all(
+			"File",
+			filters={
+				"attached_to_doctype": "Print Format",
+				"attached_to_name": self.FORMAT_NAME,
+				"attached_to_field": "preview_image",
+			},
+			pluck="name",
+		)
+
+	def test_regenerate_keeps_single_preview_and_spares_user_files(self):
+		from unittest.mock import patch
+
+		from frappe.printing.doctype.print_format.print_format import generate_preview
+		from frappe.utils.file_manager import save_file
+
+		user_file = save_file("my-notes.txt", b"keep me", "Print Format", self.FORMAT_NAME, is_private=1)
+
+		with (
+			patch("frappe.get_print", return_value="<html><body>x</body></html>"),
+			patch("frappe.utils.preview.get_preview_from_html", side_effect=[b"webp-AAAA", b"webp-BBBB"]),
+		):
+			generate_preview(self.FORMAT_NAME)
+			generate_preview(self.FORMAT_NAME)
+
+		previews = self._preview_files()
+		self.assertEqual(len(previews), 1, "regenerating a preview must not accumulate files")
+
+		self.assertTrue(frappe.db.exists("File", user_file.name), "user attachment must not be swept")
+
+		url = frappe.db.get_value("Print Format", self.FORMAT_NAME, "preview_image")
+		self.assertEqual(frappe.db.get_value("File", previews[0], "file_url"), url)


### PR DESCRIPTION
Follow-up to #41013.

- Identify generated previews by `attached_to_field="preview_image"` instead of a `pf-preview-*` filename match, so a file the user attached to the format is never deleted.
- Save the new preview first, then delete the older ones, so a render/write failure can't leave the format without a preview image.
- Add a regression test: regenerating keeps exactly one preview file and leaves user attachments untouched.
