### PR TITLE
fix: loading a kanban board wipes all user settings cache

### DIFF
--- a/frappe/desk/doctype/kanban_board/kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/kanban_board.py
@@ -6,6 +6,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.model.utils.user_settings import clear_user_settings_cache
 from frappe.utils import cint
 
 
@@ -36,7 +37,7 @@ class KanbanBoard(Document):
 
 	def on_change(self):
 		frappe.clear_cache(doctype=self.reference_doctype)
-		frappe.cache.delete_keys("_user_settings")
+		clear_user_settings_cache(self.reference_doctype)
 
 	def before_insert(self):
 		for column in self.columns:

--- a/frappe/desk/doctype/kanban_board/test_kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/test_kanban_board.py
@@ -180,6 +180,23 @@ class TestKanbanBoard(IntegrationTestCase):
 		self.assertEqual(len(_decompress_kanban_cards(open_data["cards"])), 3)
 		self.assertEqual(len(_decompress_kanban_cards(closed_data["cards"])), 1)
 
+	def test_on_change_clears_only_reference_doctype_user_settings(self):
+		from frappe.model.utils import user_settings
+
+		user = frappe.session.user
+		user_settings.update_user_settings("ToDo", {"sentinel": "ref"})
+		user_settings.update_user_settings("User", {"sentinel": "other"})
+
+		self.assertIsNotNone(frappe.cache.hget("_user_settings", f"ToDo::{user}"))
+		self.assertIsNotNone(frappe.cache.hget("_user_settings", f"User::{user}"))
+
+		frappe.get_doc("Kanban Board", self.board_name).save(ignore_permissions=True)
+
+		self.assertIsNone(frappe.cache.hget("_user_settings", f"ToDo::{user}"))
+		self.assertIsNotNone(frappe.cache.hget("_user_settings", f"User::{user}"))
+
+		frappe.cache.hdel("_user_settings", f"User::{user}")
+
 	def test_get_kanban_column_page(self):
 		frappe.local.form_dict = frappe._dict(
 			{

--- a/frappe/model/utils/user_settings.py
+++ b/frappe/model/utils/user_settings.py
@@ -43,6 +43,18 @@ def update_user_settings(doctype, user_settings, for_update=False):
 	frappe.cache.hset("_user_settings", f"{doctype}::{frappe.session.user}", json.dumps(current))
 
 
+def clear_user_settings_cache(doctype: str):
+	"""Clear cached user settings for a doctype across all users."""
+	prefix = f"{doctype}::"
+	keys = [
+		decoded
+		for key in frappe.cache.hkeys("_user_settings")
+		if (decoded := safe_decode(key)).startswith(prefix)
+	]
+	if keys:
+		frappe.cache.hdel("_user_settings", keys)
+
+
 def sync_user_settings():
 	"""Sync from cache to database (called asynchronously via the browser)"""
 	for key, data in frappe.cache.hgetall("_user_settings").items():


### PR DESCRIPTION
## Summary

Updating a Kanban Board cleared the entire `_user_settings` cache, resetting list filters, page limits, sort order, and last-view state for all users across all doctypes.

The cache invalidation introduced in #16509 was intended to fix stale Kanban view state after a board is deleted, but only the settings for the board's `reference_doctype` need to be cleared.

## Changes

- Replace the wildcard cache deletion with `clear_user_settings_cache(reference_doctype)`.
- Clear only `_user_settings` entries prefixed with `{reference_doctype}::`, preserving settings for all other doctypes and users.

## Result

Updating a Kanban Board now invalidates only the relevant user settings while retaining the 404 fix introduced in #16509.

Closes #17227.