### PR TITLE
fix: qualify SET columns in joined UPDATE queries on mariadb

### DIFF
--- a/frappe/query_builder/builder.py
+++ b/frappe/query_builder/builder.py
@@ -89,7 +89,33 @@ class RecursiveCTEMixin:
 		)
 
 
-class RecursiveMySQLQueryBuilder(RecursiveCTEMixin, MySQLQueryBuilder):
+class MultiTableUpdateMixin:
+	"""Qualifies assigned columns in a joined `UPDATE`, which MariaDB rejects as ambiguous otherwise.
+	MariaDB only: postgres and sqlite reject a qualified column on the left of `SET`."""
+
+	def _set_sql(self, **kwargs) -> str:
+		if not self._joins:
+			return super()._set_sql(**kwargs)
+
+		namespaced = dict(kwargs, with_namespace=True)
+
+		return " SET {set}".format(
+			set=",".join(
+				"{field}={value}".format(
+					field=self._qualify_update_field(field).get_sql(**namespaced),
+					value=value.get_sql(**kwargs),
+				)
+				for field, value in self._updates
+			)
+		)
+
+	def _qualify_update_field(self, field: terms.Field) -> terms.Field:
+		if field.table is not None:
+			return field
+		return terms.Field(field.name, alias=field.alias, table=self._update_table)
+
+
+class RecursiveMySQLQueryBuilder(RecursiveCTEMixin, MultiTableUpdateMixin, MySQLQueryBuilder):
 	pass
 
 

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -679,10 +679,12 @@ class TestBuilderMaria(IntegrationTestCase, TestBuilderBase):
 			.join(docfield)
 			.on(docfield.parent == doctype.name)
 			.set(doctype.module, docfield.fieldname)
+			.set(doctype.description, docfield.label)
 		)
 		self.assertEqual(
 			"UPDATE `tabDocType` JOIN `tabDocField` ON `tabDocField`.`parent`=`tabDocType`.`name` "
-			"SET `tabDocType`.`module`=`tabDocField`.`fieldname`",
+			"SET `tabDocType`.`module`=`tabDocField`.`fieldname`,"
+			"`tabDocType`.`description`=`tabDocField`.`label`",
 			query.get_sql(),
 		)
 

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -671,6 +671,41 @@ class TestBuilderMaria(IntegrationTestCase, TestBuilderBase):
 		qb = get_query_builder(frappe.db.db_type)
 		self.assertEqual("SELECT * FROM `tabDocType`", qb().from_("DocType").select("*").get_sql())
 
+	def test_joined_update_qualifies_set_columns(self):
+		doctype = frappe.qb.DocType("DocType")
+		docfield = frappe.qb.DocType("DocField")
+		query = (
+			frappe.qb.update(doctype)
+			.join(docfield)
+			.on(docfield.parent == doctype.name)
+			.set(doctype.module, docfield.fieldname)
+		)
+		self.assertEqual(
+			"UPDATE `tabDocType` JOIN `tabDocField` ON `tabDocField`.`parent`=`tabDocType`.`name` "
+			"SET `tabDocType`.`module`=`tabDocField`.`fieldname`",
+			query.get_sql(),
+		)
+
+	def test_joined_update_qualifies_set_columns_passed_as_string(self):
+		doctype = frappe.qb.DocType("DocType")
+		docfield = frappe.qb.DocType("DocField")
+		query = (
+			frappe.qb.update(doctype)
+			.join(docfield)
+			.on(docfield.parent == doctype.name)
+			.set("module", docfield.fieldname)
+		)
+		self.assertEqual(
+			"UPDATE `tabDocType` JOIN `tabDocField` ON `tabDocField`.`parent`=`tabDocType`.`name` "
+			"SET `tabDocType`.`module`=`tabDocField`.`fieldname`",
+			query.get_sql(),
+		)
+
+	def test_update_without_join_keeps_set_columns_unqualified(self):
+		doctype = frappe.qb.DocType("DocType")
+		query = frappe.qb.update(doctype).set(doctype.module, "Core")
+		self.assertEqual("UPDATE `tabDocType` SET `module`='Core'", query.get_sql())
+
 
 @run_only_if(db_type_is.POSTGRES)
 class TestBuilderPostgres(IntegrationTestCase, TestBuilderBase):


### PR DESCRIPTION
## Summary

Joined `UPDATE` queries built by the MariaDB query builder generated unqualified columns in the `SET` clause. When both the updated table and the joined table contained the same column name, MariaDB rejected the query with:

> `Column '<column>' in field list is ambiguous`

This happened because PyPika always renders `SET` targets without a table namespace, which is correct for single-table updates but becomes ambiguous once a `JOIN` introduces additional tables.

## Changes

- Add a `MultiTableUpdateMixin` to the MariaDB query builder.
- Qualify columns in the `SET` clause when the update includes joins, while leaving single-table updates unchanged.
- Bind string column names passed to `.set()` to the updated table, matching the intended behavior.

## Notes

This change is limited to the MariaDB query builder. PostgreSQL and SQLite require `UPDATE ... FROM` syntax and do not allow qualified columns on the left-hand side of `SET`, so joined updates remain unsupported there.

Closes #20292.