### PR TITLE
test: stop relying on shipped .po strings in translate tests

### DIFF
--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -31,8 +31,8 @@ first_lang, second_lang, third_lang, fourth_lang, fifth_lang = choices(
 	k=5,
 )
 
-
-_lazy_translations = _lt("Communication")
+_LAZY_SOURCE = "Lazy Translation Source"
+_lazy_translations = _lt(_LAZY_SOURCE)
 
 
 class TestTranslate(IntegrationTestCase):
@@ -64,10 +64,10 @@ class TestTranslate(IntegrationTestCase):
 
 	def test_noop_preserves_source_string(self):
 		frappe.local.lang = "de"
-		message = N_("Communication")
+		message = N_("Noop Source")
 
 		self.assertIs(type(message), str)
-		self.assertEqual(message, "Communication")
+		self.assertEqual(message, "Noop Source")
 
 	def test_extract_message_from_file(self):
 		data = frappe.translate.get_messages_from_file(translation_string_file)
@@ -90,15 +90,37 @@ class TestTranslate(IntegrationTestCase):
 			self.assertEqual(ext_line, exp_line)
 
 	def test_read_language_variant(self):
-		self.assertEqual(_("Mobile No"), "Mobile No")
+		source = "Language Variant Source"
+		t_pt = frappe.get_doc(
+			{
+				"doctype": "Translation",
+				"language": "pt",
+				"source_text": source,
+				"translated_text": "Tradução PT",
+			}
+		).insert()
+		t_pt_br = frappe.get_doc(
+			{
+				"doctype": "Translation",
+				"language": "pt-BR",
+				"source_text": source,
+				"translated_text": "Tradução PT-BR",
+			}
+		).insert()
+
 		try:
+			self.assertEqual(_(source), source)
+
 			frappe.local.lang = "pt-BR"
-			self.assertEqual(_("Mobile No"), "Celular")
+			self.assertEqual(_(source), "Tradução PT-BR")
+
 			frappe.local.lang = "pt"
-			self.assertEqual(_("Mobile No"), "Nr. de Telemóvel")
+			self.assertEqual(_(source), "Tradução PT")
 		finally:
+			t_pt.delete()
+			t_pt_br.delete()
 			frappe.local.lang = "en"
-			self.assertEqual(_("Mobile No"), "Mobile No")
+			self.assertEqual(_(source), source)
 
 	def test_translation_with_context(self):
 		t1 = frappe.new_doc("Translation")
@@ -122,19 +144,34 @@ class TestTranslate(IntegrationTestCase):
 		t2.delete()
 
 	def test_lazy_translations(self):
-		frappe.local.lang = "de"
-		eager_translation = _("Communication")
-		self.assertEqual(str(_lazy_translations), eager_translation)
-		self.assertRaises(NotImplementedError, lambda: _lazy_translations == "blah")
+		# _lazy_translations is defined at module scope and only evaluated when cast to str
+		translation = frappe.get_doc(
+			{
+				"doctype": "Translation",
+				"language": "de",
+				"source_text": _LAZY_SOURCE,
+				"translated_text": "Lazy Übersetzung",
+			}
+		).insert()
 
-		# auto casts when added or radded
-		self.assertEqual(_lazy_translations + "A", eager_translation + "A")
-		x = _lazy_translations
-		x += "A"
-		self.assertEqual(x, eager_translation + "A")
+		try:
+			frappe.local.lang = "de"
+			eager_translation = _(_LAZY_SOURCE)
+			self.assertEqual(eager_translation, "Lazy Übersetzung")
+			self.assertEqual(str(_lazy_translations), eager_translation)
+			self.assertRaises(NotImplementedError, lambda: _lazy_translations == "blah")
 
-		# f string usually auto-casts
-		self.assertEqual(f"{_lazy_translations}", eager_translation)
+			# auto casts when added or radded
+			self.assertEqual(_lazy_translations + "A", eager_translation + "A")
+			x = _lazy_translations
+			x += "A"
+			self.assertEqual(x, eager_translation + "A")
+
+			# f string usually auto-casts
+			self.assertEqual(f"{_lazy_translations}", eager_translation)
+		finally:
+			translation.delete()
+			frappe.local.lang = "en"
 
 	def test_request_language_resolution_with_form_dict(self):
 		"""Test for frappe.translate.get_language


### PR DESCRIPTION
## Summary
- Translation tests no longer assert specific strings from shipped `.po` files (e.g. "Mobile No" → "Celular"), which can change whenever Crowdin syncs and break CI without related code changes.
- Language-variant and lazy-translation coverage now uses **Translation** records instead, which take precedence over file-based translations and stay under test control.
- Lazy `_lt` is still defined at module scope so the test still checks deferred evaluation on string cast.

## Motivation
`.po` content is continuous upstream noise, not a stable API. Hardcoding expected msgstr values couples unit tests to Crowdin updates and causes unrelated failures. Custom **Translation** docs give the same behavior guarantees (including parent/child language resolution) without that dependency.

## Test plan
- [ ] `bench --site test-site-dev run-tests --module frappe.tests.test_translate`