### PR TITLE
feat(print-format): beta builder enhancements — conditions, outline, snippets, multi-select

### DIFF
--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -466,7 +466,7 @@ context("Print Format Builder — setup flow", () => {
 		cy.contains(".pfb-setup-option-label", "Start blank").click();
 
 		cy.get(".pfb-setup").should("not.exist");
-		cy.get(".sections-container").should("be.visible");
+		cy.get(".body-empty").should("be.visible");
 		// blank canvas — no body sections
 		cy.get(".sections-container [data-pfb-section]").should("have.length", 0);
 
@@ -616,7 +616,7 @@ context("Print Format Builder — section insert", () => {
 		);
 
 		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
-		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
+		cy.get(".body-empty", { timeout: 20000 }).should("be.visible");
 		cy.get(".sections-container [data-pfb-section]").should("have.length", 0);
 
 		// blank canvas: the first section is added via the empty-state CTA

--- a/cypress/integration/print_format_builder.js
+++ b/cypress/integration/print_format_builder.js
@@ -160,11 +160,11 @@ context("Print Format Builder — create flow", () => {
 		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
 
 		cy.get(".pfb-tab[title='Outline']", { timeout: 30000 }).click();
-		cy.contains(".pfb-outline-item", "Beta").click();
+		cy.contains(".pfb-tree-row", "Beta").click();
 
 		cy.get(".pfb-inspector").should("contain", "Section");
 		cy.get(".pfb-inspector").should("contain", "Beta");
-		cy.contains(".pfb-outline-item", "Beta").should("have.class", "active");
+		cy.contains(".pfb-tree-row", "Beta").should("have.class", "active");
 	});
 
 	// 5. Field inspector breadcrumb navigates back to parent section
@@ -188,7 +188,7 @@ context("Print Format Builder — create flow", () => {
 		cy.visit(`/app/print-format-builder/${encodeURIComponent(PF_NAME)}`);
 
 		cy.get(".pfb-tab[title='Outline']", { timeout: 30000 }).click();
-		cy.contains(".pfb-outline-item", "Details").click();
+		cy.contains(".pfb-tree-row", "Details").click();
 
 		cy.get(".print-format-container").click();
 		cy.contains("[data-pfb-section]", "Details").find(".field").first().click({ force: true });
@@ -619,7 +619,8 @@ context("Print Format Builder — section insert", () => {
 		cy.get(".sections-container", { timeout: 20000 }).should("be.visible");
 		cy.get(".sections-container [data-pfb-section]").should("have.length", 0);
 
-		cy.get(".sections-container > .section-insert .section-insert-btn").click({ force: true });
+		// blank canvas: the first section is added via the empty-state CTA
+		cy.get(".body-empty").click({ force: true });
 		cy.get(".sections-container [data-pfb-section]").should("have.length", 1);
 
 		cy.get(".sections-container > .section-insert .section-insert-btn").click({ force: true });

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -514,3 +514,81 @@ class TestPrintFormatPreview(IntegrationTestCase):
 
 		url = frappe.db.get_value("Print Format", self.FORMAT_NAME, "preview_image")
 		self.assertEqual(frappe.db.get_value("File", previews[0], "file_url"), url)
+
+
+class TestPrintFormatChildTableVisibility(IntegrationTestCase):
+	"""Per-row and per-column conditional visibility for child Table fields."""
+
+	FORMAT_NAME = "_Test Child Table Visibility"
+
+	def setUp(self):
+		frappe.delete_doc("Contact", "PFB Table Test", force=True, ignore_missing=True)
+		self.contact = frappe.get_doc(
+			{
+				"doctype": "Contact",
+				"first_name": "PFB Table Test",
+				"email_ids": [
+					{"email_id": "primary@example.com", "is_primary": 1},
+					{"email_id": "secondary@example.com", "is_primary": 0},
+				],
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Contact", self.contact.name, force=True)
+
+	def render(self, df):
+		from frappe.utils.print_format_generator import get_html
+
+		frappe.delete_doc("Print Format", self.FORMAT_NAME, force=True, ignore_missing=True)
+		format_data = {
+			"sections": [{"label": "", "columns": [{"label": "", "fields": [df]}]}],
+			"header": {"columns": []},
+			"footer": {"columns": []},
+		}
+		frappe.get_doc(
+			{
+				"doctype": "Print Format",
+				"name": self.FORMAT_NAME,
+				"doc_type": "Contact",
+				"standard": "No",
+				"print_format_builder_beta": 1,
+				"format_data": frappe.as_json(format_data),
+			}
+		).insert()
+		self.addCleanup(frappe.delete_doc, "Print Format", self.FORMAT_NAME, force=True)
+		return get_html("Contact", self.contact.name, self.FORMAT_NAME)
+
+	def table_field(self, **overrides):
+		df = {
+			"fieldname": "email_ids",
+			"fieldtype": "Table",
+			"label": "Emails",
+			"options": "Contact Email",
+			"table_columns": [
+				{"label": "Email", "fieldname": "email_id", "fieldtype": "Data", "width": 60},
+				{"label": "Primary", "fieldname": "is_primary", "fieldtype": "Check", "width": 40},
+			],
+		}
+		df.update(overrides)
+		return df
+
+	def test_row_condition_drops_non_matching_rows(self):
+		html = self.render(self.table_field(row_condition="row.is_primary"))
+		self.assertIn("primary@example.com", html)
+		self.assertNotIn("secondary@example.com", html)
+
+	def test_bad_row_condition_keeps_all_rows(self):
+		html = self.render(self.table_field(row_condition="row.does_not_exist >"))
+		self.assertIn("primary@example.com", html)
+		self.assertIn("secondary@example.com", html)
+
+	def test_column_condition_drops_column(self):
+		kept = self.render(self.table_field())
+		self.assertIn('data-fieldname="is_primary"', kept)
+
+		df = self.table_field()
+		df["table_columns"][1]["column_condition"] = "doc.first_name == 'no match'"
+		html = self.render(df)
+		self.assertNotIn('data-fieldname="is_primary"', html)
+		self.assertIn('data-fieldname="email_id"', html)
+		self.assertIn("primary@example.com", html)
+		self.assertIn("secondary@example.com", html)

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -592,3 +592,16 @@ class TestPrintFormatChildTableVisibility(IntegrationTestCase):
 		self.assertIn('data-fieldname="email_id"', html)
 		self.assertIn("primary@example.com", html)
 		self.assertIn("secondary@example.com", html)
+
+	def test_print_settings_available_in_conditions(self):
+		html = self.render(
+			self.table_field(row_condition="print_settings.doctype == 'Print Settings' and row.is_primary")
+		)
+		self.assertIn("primary@example.com", html)
+		self.assertNotIn("secondary@example.com", html)
+
+		df = self.table_field()
+		df["table_columns"][1]["column_condition"] = "print_settings.doctype == 'Nope'"
+		html = self.render(df)
+		self.assertNotIn('data-fieldname="is_primary"', html)
+		self.assertIn('data-fieldname="email_id"', html)

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -593,6 +593,13 @@ class TestPrintFormatChildTableVisibility(IntegrationTestCase):
 		self.assertIn("primary@example.com", html)
 		self.assertIn("secondary@example.com", html)
 
+	def test_bad_column_condition_keeps_column(self):
+		df = self.table_field()
+		df["table_columns"][1]["column_condition"] = "doc.does_not_exist >"
+		html = self.render(df)
+		self.assertIn('data-fieldname="is_primary"', html)
+		self.assertIn('data-fieldname="email_id"', html)
+
 	def test_print_settings_available_in_conditions(self):
 		html = self.render(
 			self.table_field(row_condition="print_settings.doctype == 'Print Settings' and row.is_primary")

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -581,6 +581,17 @@ class TestPrintFormatChildTableVisibility(IntegrationTestCase):
 		self.assertIn("primary@example.com", html)
 		self.assertIn("secondary@example.com", html)
 
+	def test_all_rows_filtered_hides_table(self):
+		html = self.render(self.table_field(row_condition="1 == 2"))
+		self.assertNotIn('data-fieldname="email_ids"', html)
+
+	def test_all_columns_dropped_hides_table(self):
+		df = self.table_field()
+		for col in df["table_columns"]:
+			col["column_condition"] = "1 == 2"
+		html = self.render(df)
+		self.assertNotIn('data-fieldname="email_ids"', html)
+
 	def test_column_condition_drops_column(self):
 		kept = self.render(self.table_field())
 		self.assertIn('data-fieldname="is_primary"', kept)

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -593,6 +593,16 @@ class TestPrintFormatChildTableVisibility(IntegrationTestCase):
 		self.assertIn("primary@example.com", html)
 		self.assertIn("secondary@example.com", html)
 
+	def test_column_emptiness_respects_row_condition(self):
+		# Keep only the non-primary row; is_primary is 0 in that row, so the column has
+		# no value in the rendered rows and must be dropped — even though the filtered-out
+		# primary row had a 1.
+		html = self.render(self.table_field(row_condition="not row.is_primary"))
+		self.assertIn("secondary@example.com", html)
+		self.assertNotIn("primary@example.com", html)
+		self.assertIn('data-fieldname="email_id"', html)
+		self.assertNotIn('data-fieldname="is_primary"', html)
+
 	def test_bad_column_condition_keeps_column(self):
 		df = self.table_field()
 		df["table_columns"][1]["column_condition"] = "doc.does_not_exist >"

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -32,6 +32,7 @@ function patch_breadcrumbs_once() {
 function load_print_format_builder(wrapper) {
 	let route = frappe.get_route();
 	let $parent = $(wrapper).find(".layout-main-section");
+	frappe.print_format_builder?.destroy?.();
 	$parent.empty();
 
 	if (route.length > 1) {

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -221,6 +221,20 @@ function handle_keydown(e) {
 			}
 			return;
 		}
+		if (e.key === "d" || e.key === "D") {
+			const el = document.activeElement;
+			if (
+				el?.tagName === "INPUT" ||
+				el?.tagName === "TEXTAREA" ||
+				el?.isContentEditable ||
+				el?.closest(".modal")
+			)
+				return;
+			if (!$store.value.selected_field.value && !$store.value.selected_section.value) return;
+			e.preventDefault();
+			$store.value.duplicate_selection();
+			return;
+		}
 		if (e.key === "=" || e.key === "+") {
 			e.preventDefault();
 			zoom_in();

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -178,33 +178,29 @@ function on_start_blank() {
 	$store.value.needs_setup.value = false;
 }
 
+function is_typing_context() {
+	const el = document.activeElement;
+	return !!(
+		el?.tagName === "INPUT" ||
+		el?.tagName === "TEXTAREA" ||
+		el?.isContentEditable ||
+		el?.closest(".modal")
+	);
+}
+
 function handle_keydown(e) {
 	// Zoom shortcuts: Ctrl+= / Ctrl+- / Ctrl+0
 	if (e.ctrlKey || e.metaKey) {
 		if (e.key === "z" || e.key === "Z" || e.key === "y") {
 			// rich text editors and dialogs keep their own undo
-			const el = document.activeElement;
-			if (
-				el?.tagName === "INPUT" ||
-				el?.tagName === "TEXTAREA" ||
-				el?.isContentEditable ||
-				el?.closest(".modal")
-			)
-				return;
+			if (is_typing_context()) return;
 			e.preventDefault();
 			if (e.key === "y" || e.shiftKey) $store.value.redo();
 			else $store.value.undo();
 			return;
 		}
 		if (e.key === "c" || e.key === "C" || e.key === "v" || e.key === "V") {
-			const el = document.activeElement;
-			if (
-				el?.tagName === "INPUT" ||
-				el?.tagName === "TEXTAREA" ||
-				el?.isContentEditable ||
-				el?.closest(".modal")
-			)
-				return;
+			if (is_typing_context()) return;
 			const is_copy = e.key === "c" || e.key === "C";
 			if (is_copy) {
 				// Let native copy work when text is highlighted or nothing in the
@@ -222,14 +218,7 @@ function handle_keydown(e) {
 			return;
 		}
 		if (e.key === "d" || e.key === "D") {
-			const el = document.activeElement;
-			if (
-				el?.tagName === "INPUT" ||
-				el?.tagName === "TEXTAREA" ||
-				el?.isContentEditable ||
-				el?.closest(".modal")
-			)
-				return;
+			if (is_typing_context()) return;
 			if (!$store.value.selected_field.value && !$store.value.selected_section.value) return;
 			e.preventDefault();
 			$store.value.duplicate_selection();
@@ -253,14 +242,7 @@ function handle_keydown(e) {
 	}
 
 	if (e.altKey && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
-		const el = document.activeElement;
-		if (
-			el?.tagName === "INPUT" ||
-			el?.tagName === "TEXTAREA" ||
-			el?.isContentEditable ||
-			el?.closest(".modal")
-		)
-			return;
+		if (is_typing_context()) return;
 		if (!$store.value.selected_field.value && !$store.value.selected_section.value) return;
 		e.preventDefault();
 		$store.value.move_selection(e.key === "ArrowUp" ? -1 : 1);
@@ -269,14 +251,7 @@ function handle_keydown(e) {
 
 	if (e.key === "Delete" || e.key === "Backspace") {
 		// Never hijack delete/backspace from text editing contexts
-		const el = document.activeElement;
-		if (
-			el?.tagName === "INPUT" ||
-			el?.tagName === "TEXTAREA" ||
-			el?.isContentEditable ||
-			el?.closest(".modal")
-		)
-			return;
+		if (is_typing_context()) return;
 		const sf = $store.value.selected_field.value;
 		const ss = $store.value.selected_section.value;
 		if ($store.value.selected_fields.value.length > 1) {

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -280,7 +280,10 @@ function handle_keydown(e) {
 			return;
 		const sf = $store.value.selected_field.value;
 		const ss = $store.value.selected_section.value;
-		if (sf) {
+		if ($store.value.selected_fields.value.length > 1) {
+			$store.value.remove_selected_fields();
+			e.preventDefault();
+		} else if (sf) {
 			sf.remove = true;
 			$store.value.selected_field.value = null;
 			e.preventDefault();

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -456,10 +456,10 @@ defineExpose({ toggle_preview, show_preview, $store });
 	align-items: center;
 	gap: 6px;
 	padding: 4px 12px;
-	background: var(--blue-50);
-	border-bottom: 1px solid var(--blue-100);
+	background: var(--gray-50);
+	border-bottom: 1px solid var(--gray-200);
 	font-size: var(--text-xs);
-	color: var(--blue-700);
+	color: var(--gray-700);
 }
 
 .pfb-hint-icon {
@@ -479,7 +479,7 @@ defineExpose({ toggle_preview, show_preview, $store });
 	border: none;
 	background: transparent;
 	cursor: pointer;
-	color: var(--blue-400);
+	color: var(--gray-500);
 	border-radius: var(--radius);
 	line-height: 1;
 	opacity: 0.7;
@@ -487,7 +487,7 @@ defineExpose({ toggle_preview, show_preview, $store });
 
 .pfb-hint-dismiss:hover {
 	opacity: 1;
-	background: var(--blue-100);
+	background: var(--gray-200);
 }
 
 /* ── Canvas toolbar ──────────────────────────────────────── */
@@ -549,22 +549,6 @@ defineExpose({ toggle_preview, show_preview, $store });
 	border: 1px solid var(--yellow-200);
 	border-radius: var(--radius);
 	padding: 3px 8px;
-}
-
-.canvas-icon-btn {
-	display: flex;
-	align-items: center;
-	padding: 3px;
-	border: none;
-	background: transparent;
-	cursor: pointer;
-	color: var(--gray-400);
-	border-radius: var(--radius);
-}
-
-.canvas-icon-btn:hover {
-	background: var(--gray-100);
-	color: var(--gray-600);
 }
 
 /* ── Zoom control ────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -252,6 +252,22 @@ function handle_keydown(e) {
 		}
 	}
 
+	// Alt+↑/↓ nudges the selected field/section up or down in its list
+	if (e.altKey && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
+		const el = document.activeElement;
+		if (
+			el?.tagName === "INPUT" ||
+			el?.tagName === "TEXTAREA" ||
+			el?.isContentEditable ||
+			el?.closest(".modal")
+		)
+			return;
+		if (!$store.value.selected_field.value && !$store.value.selected_section.value) return;
+		e.preventDefault();
+		$store.value.move_selection(e.key === "ArrowUp" ? -1 : 1);
+		return;
+	}
+
 	if (e.key === "Delete" || e.key === "Backspace") {
 		// Never hijack delete/backspace from text editing contexts
 		const el = document.activeElement;

--- a/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatBuilder.vue
@@ -252,7 +252,6 @@ function handle_keydown(e) {
 		}
 	}
 
-	// Alt+↑/↓ nudges the selected field/section up or down in its list
 	if (e.altKey && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
 		const el = document.activeElement;
 		if (

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -190,51 +190,69 @@
 		</div>
 
 		<!-- ── Outline ────────────────────────────────────────── -->
-		<div v-else-if="activeTab === 'outline'" class="pfb-tab-body">
+		<div v-else-if="activeTab === 'outline'" class="pfb-tab-body pfb-tree">
 			<div v-if="!visible_sections.length" class="pfb-empty">
 				{{ __("No sections yet. Add sections to the canvas.") }}
 			</div>
-			<template v-for="(section, i) in visible_sections" :key="i">
+			<div v-for="(section, i) in visible_sections" :key="i" class="pfb-tree-node">
 				<div
-					class="pfb-outline-item"
+					class="pfb-tree-row"
 					:class="{ active: store.selected_section.value === section }"
 					@click="select_section(section)"
 				>
 					<button
-						class="pfb-outline-caret"
+						class="pfb-tree-chevron"
 						:class="{ collapsed: is_collapsed(section) }"
-						:title="__('Toggle')"
 						@click.stop="toggle_collapse(section)"
-						v-html="frappe.utils.icon('chevron-down', 'xs')"
+						v-html="frappe.utils.icon('chevron-down', 'sm')"
 					></button>
-					<span class="pfb-outline-idx text-muted">{{ i + 1 }}</span>
-					<span class="pfb-outline-label">
+					<span
+						class="pfb-tree-icon"
+						v-html="frappe.utils.icon('rectangle-horizontal', 'sm')"
+					></span>
+					<span class="pfb-tree-label">
 						{{ section.label || __("Untitled section") }}
 					</span>
 				</div>
-				<template v-if="!is_collapsed(section)">
-					<template v-for="(column, ci) in outline_columns(section)" :key="ci">
-						<div
-							class="pfb-outline-item pfb-outline-col"
-							@click="select_section(section)"
-						>
-							<span class="pfb-outline-label text-muted">
+				<div v-if="!is_collapsed(section)" class="pfb-tree-children">
+					<div v-for="(column, ci) in section.columns" :key="ci" class="pfb-tree-node">
+						<div class="pfb-tree-row" @click="select_section(section)">
+							<button
+								v-if="visible_fields(column).length"
+								class="pfb-tree-chevron"
+								:class="{ collapsed: is_collapsed(column) }"
+								@click.stop="toggle_collapse(column)"
+								v-html="frappe.utils.icon('chevron-down', 'sm')"
+							></button>
+							<span v-else class="pfb-tree-spacer"></span>
+							<span
+								class="pfb-tree-icon"
+								v-html="frappe.utils.icon('columns-2', 'sm')"
+							></span>
+							<span class="pfb-tree-label text-muted">
 								{{ __("Column {0}", [ci + 1]) }}
 							</span>
 						</div>
-						<div
-							v-for="(field, fi) in column.fields"
-							:key="fi"
-							class="pfb-outline-item pfb-outline-field"
-							:class="{ active: store.selected_field.value === field }"
-							@click="select_field(field, section)"
-						>
-							<span class="pfb-outline-label">{{ field_label(field) }}</span>
-							<span class="pfb-outline-type text-muted">{{ field.fieldtype }}</span>
+						<div v-if="!is_collapsed(column)" class="pfb-tree-children">
+							<div
+								v-for="(field, fi) in visible_fields(column)"
+								:key="fi"
+								class="pfb-tree-row"
+								:class="{ active: store.selected_field.value === field }"
+								@click="select_field(field, section)"
+							>
+								<span class="pfb-tree-spacer"></span>
+								<span
+									class="pfb-tree-icon"
+									v-html="frappe.utils.icon(field_icon(field), 'sm')"
+								></span>
+								<span class="pfb-tree-label">{{ field_label(field) }}</span>
+								<span class="pfb-tree-badge">{{ field.fieldtype }}</span>
+							</div>
 						</div>
-					</template>
-				</template>
-			</template>
+					</div>
+				</div>
+			</div>
 		</div>
 
 		<!-- ── Format ─────────────────────────────────────────── -->
@@ -521,20 +539,35 @@ function field_label(f) {
 	return f.label || f.fieldname || f.fieldtype || __("Field");
 }
 
-function outline_columns(section) {
-	return (section.columns || []).map((col) => ({
-		fields: (col.fields || []).filter((f) => !f.remove),
-	}));
+function visible_fields(column) {
+	return (column.fields || []).filter((f) => !f.remove);
 }
 
-let collapsed_sections = ref(new Set());
-function is_collapsed(section) {
-	return collapsed_sections.value.has(section);
+const FIELD_ICONS = {
+	Table: "table",
+	Repeater: "rows-3",
+	Image: "image",
+	"Attach Image": "image",
+	Attach: "image",
+	HTML: "file-text",
+	"Text Editor": "file-text",
+	"Small Text": "file-text",
+	"Long Text": "file-text",
+	Text: "file-text",
+	Barcode: "square",
+};
+function field_icon(f) {
+	return FIELD_ICONS[f.fieldtype] || "type";
 }
-function toggle_collapse(section) {
-	const next = new Set(collapsed_sections.value);
-	next.has(section) ? next.delete(section) : next.add(section);
-	collapsed_sections.value = next;
+
+let collapsed_nodes = ref(new Set());
+function is_collapsed(node) {
+	return collapsed_nodes.value.has(node);
+}
+function toggle_collapse(node) {
+	const next = new Set(collapsed_nodes.value);
+	next.has(node) ? next.delete(node) : next.add(node);
+	collapsed_nodes.value = next;
 }
 
 function clone_as_section() {
@@ -1011,31 +1044,38 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	letter-spacing: 0;
 }
 
-/* ── Outline tab ─────────────────────────────────────────── */
-.pfb-outline-item {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 6px 8px;
-	border-radius: var(--radius);
-	cursor: pointer;
-	margin-top: 2px;
-	font-size: var(--text-sm);
+/* ── Outline tab (tree) ──────────────────────────────────── */
+.pfb-tree {
+	padding-top: 4px;
 }
 
-.pfb-outline-item:hover {
+.pfb-tree-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 4px 6px;
+	border-radius: var(--radius);
+	cursor: pointer;
+	font-size: var(--text-sm);
+	user-select: none;
+}
+
+.pfb-tree-row:hover {
 	background: var(--gray-100);
 }
 
-.pfb-outline-item.active {
+.pfb-tree-row.active {
 	background: var(--gray-200);
 	color: var(--gray-900);
 	font-weight: 500;
 }
 
-.pfb-outline-caret {
+.pfb-tree-chevron {
 	display: flex;
 	align-items: center;
+	justify-content: center;
+	width: 16px;
+	height: 16px;
 	padding: 0;
 	border: none;
 	background: transparent;
@@ -1045,35 +1085,43 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	transition: transform 0.12s ease;
 }
 
-.pfb-outline-caret.collapsed {
+.pfb-tree-chevron.collapsed {
 	transform: rotate(-90deg);
 }
 
-.pfb-outline-idx {
-	font-size: var(--text-tiny);
-	font-variant-numeric: tabular-nums;
-	min-width: 18px;
-	text-align: right;
+.pfb-tree-spacer {
+	width: 16px;
+	flex-shrink: 0;
 }
 
-.pfb-outline-label {
+.pfb-tree-icon {
+	display: flex;
+	align-items: center;
+	color: var(--gray-500);
+	flex-shrink: 0;
+}
+
+.pfb-tree-row.active .pfb-tree-icon {
+	color: var(--gray-700);
+}
+
+.pfb-tree-label {
 	flex: 1;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
-.pfb-outline-col {
-	padding-left: 30px;
-}
-
-.pfb-outline-field {
-	padding-left: 42px;
-}
-
-.pfb-outline-type {
+.pfb-tree-badge {
 	font-size: var(--text-tiny);
+	color: var(--gray-500);
 	flex-shrink: 0;
+}
+
+.pfb-tree-children {
+	margin-left: 15px;
+	border-left: 1px solid var(--gray-200);
+	padding-left: 3px;
 }
 
 /* ── Format tab ──────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -194,18 +194,47 @@
 			<div v-if="!visible_sections.length" class="pfb-empty">
 				{{ __("No sections yet. Add sections to the canvas.") }}
 			</div>
-			<div
-				v-for="(section, i) in visible_sections"
-				:key="i"
-				class="pfb-outline-item"
-				:class="{ active: store.selected_section.value === section }"
-				@click="select_section(section)"
-			>
-				<span class="pfb-outline-idx text-muted">{{ i + 1 }}</span>
-				<span class="pfb-outline-label">
-					{{ section.label || __("Untitled section") }}
-				</span>
-			</div>
+			<template v-for="(section, i) in visible_sections" :key="i">
+				<div
+					class="pfb-outline-item"
+					:class="{ active: store.selected_section.value === section }"
+					@click="select_section(section)"
+				>
+					<button
+						class="pfb-outline-caret"
+						:class="{ collapsed: is_collapsed(section) }"
+						:title="__('Toggle')"
+						@click.stop="toggle_collapse(section)"
+						v-html="frappe.utils.icon('chevron-down', 'xs')"
+					></button>
+					<span class="pfb-outline-idx text-muted">{{ i + 1 }}</span>
+					<span class="pfb-outline-label">
+						{{ section.label || __("Untitled section") }}
+					</span>
+				</div>
+				<template v-if="!is_collapsed(section)">
+					<template v-for="(column, ci) in outline_columns(section)" :key="ci">
+						<div
+							class="pfb-outline-item pfb-outline-col"
+							@click="select_section(section)"
+						>
+							<span class="pfb-outline-label text-muted">
+								{{ __("Column {0}", [ci + 1]) }}
+							</span>
+						</div>
+						<div
+							v-for="(field, fi) in column.fields"
+							:key="fi"
+							class="pfb-outline-item pfb-outline-field"
+							:class="{ active: store.selected_field.value === field }"
+							@click="select_field(field, section)"
+						>
+							<span class="pfb-outline-label">{{ field_label(field) }}</span>
+							<span class="pfb-outline-type text-muted">{{ field.fieldtype }}</span>
+						</div>
+					</template>
+				</template>
+			</template>
 		</div>
 
 		<!-- ── Format ─────────────────────────────────────────── -->
@@ -481,6 +510,31 @@ function build_field(df) {
 function select_section(section) {
 	store.scroll_to_section.value = section;
 	store.select_section(section);
+}
+
+function select_field(field, section) {
+	if (section) store.scroll_to_section.value = section;
+	store.select_field(field);
+}
+
+function field_label(f) {
+	return f.label || f.fieldname || f.fieldtype || __("Field");
+}
+
+function outline_columns(section) {
+	return (section.columns || []).map((col) => ({
+		fields: (col.fields || []).filter((f) => !f.remove),
+	}));
+}
+
+let collapsed_sections = ref(new Set());
+function is_collapsed(section) {
+	return collapsed_sections.value.has(section);
+}
+function toggle_collapse(section) {
+	const next = new Set(collapsed_sections.value);
+	next.has(section) ? next.delete(section) : next.add(section);
+	collapsed_sections.value = next;
 }
 
 function clone_as_section() {
@@ -974,9 +1028,25 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 .pfb-outline-item.active {
-	background: var(--blue-50);
-	color: var(--primary);
+	background: var(--gray-200);
+	color: var(--gray-900);
 	font-weight: 500;
+}
+
+.pfb-outline-caret {
+	display: flex;
+	align-items: center;
+	padding: 0;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	color: var(--gray-500);
+	flex-shrink: 0;
+	transition: transform 0.12s ease;
+}
+
+.pfb-outline-caret.collapsed {
+	transform: rotate(-90deg);
 }
 
 .pfb-outline-idx {
@@ -991,6 +1061,19 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.pfb-outline-col {
+	padding-left: 30px;
+}
+
+.pfb-outline-field {
+	padding-left: 42px;
+}
+
+.pfb-outline-type {
+	font-size: var(--text-tiny);
+	flex-shrink: 0;
 }
 
 /* ── Format tab ──────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -54,6 +54,8 @@
 					:clone="clone_field"
 					item-key="fieldname"
 					v-bind="DRAG_OPTIONS"
+					@start="setDragging(true)"
+					@end="setDragging(false)"
 				>
 					<template #item="{ element }">
 						<div
@@ -87,6 +89,8 @@
 				:clone="clone_field"
 				item-key="fieldname"
 				v-bind="DRAG_OPTIONS"
+				@start="setDragging(true)"
+				@end="setDragging(false)"
 			>
 				<template #item="{ element }">
 					<div
@@ -114,6 +118,8 @@
 				:clone="clone_as_section"
 				item-key="fieldname"
 				v-bind="DRAG_OPTIONS"
+				@start="setDragging(true)"
+				@end="setDragging(false)"
 			>
 				<template #item="{ element }">
 					<div class="pfb-block-card" :title="element.desc" @click="add_page_break">
@@ -166,6 +172,8 @@
 					:clone="clone_field"
 					item-key="fieldname"
 					v-bind="DRAG_OPTIONS"
+					@start="setDragging(true)"
+					@end="setDragging(false)"
 				>
 					<template #item="{ element }">
 						<div
@@ -314,7 +322,7 @@
 <script setup>
 import draggable from "vuedraggable";
 import Autocomplete from "../../vue-components/Autocomplete.vue";
-import { DRAG_OPTIONS, get_table_columns, pluck } from "../utils";
+import { DRAG_OPTIONS, get_table_columns, pluck, setDragging } from "../utils";
 import { mountColorControl } from "./inspector/useColorControl";
 import { useStore } from "../stores";
 import { computed, onMounted, onUnmounted, nextTick, ref, watch, inject } from "vue";

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -191,19 +191,19 @@
 
 		<!-- ── Outline ────────────────────────────────────────── -->
 		<div v-else-if="activeTab === 'outline'" class="pfb-tab-body pfb-tree">
-			<div v-if="!visible_sections.length" class="pfb-empty">
+			<div v-if="!outline_tree.length" class="pfb-empty">
 				{{ __("No sections yet. Add sections to the canvas.") }}
 			</div>
-			<div v-for="(section, i) in visible_sections" :key="i" class="pfb-tree-node">
+			<div v-for="(node, i) in outline_tree" :key="i" class="pfb-tree-node">
 				<div
 					class="pfb-tree-row"
-					:class="{ active: store.selected_section.value === section }"
-					@click="select_section(section)"
+					:class="{ active: store.selected_section.value === node.section }"
+					@click="select_section(node.section)"
 				>
 					<button
 						class="pfb-tree-chevron"
-						:class="{ collapsed: is_collapsed(section) }"
-						@click.stop="toggle_collapse(section)"
+						:class="{ collapsed: is_collapsed(node.section) }"
+						@click.stop="toggle_collapse(node.section)"
 						v-html="frappe.utils.icon('chevron-down', 'sm')"
 					></button>
 					<span
@@ -211,17 +211,17 @@
 						v-html="frappe.utils.icon('rectangle-horizontal', 'sm')"
 					></span>
 					<span class="pfb-tree-label">
-						{{ section.label || __("Untitled section") }}
+						{{ node.section.label || __("Untitled section") }}
 					</span>
 				</div>
-				<div v-if="!is_collapsed(section)" class="pfb-tree-children">
-					<div v-for="(column, ci) in section.columns" :key="ci" class="pfb-tree-node">
-						<div class="pfb-tree-row" @click="select_section(section)">
+				<div v-if="!is_collapsed(node.section)" class="pfb-tree-children">
+					<div v-for="(col, ci) in node.columns" :key="ci" class="pfb-tree-node">
+						<div class="pfb-tree-row" @click="select_section(node.section)">
 							<button
-								v-if="visible_fields(column).length"
+								v-if="col.fields.length"
 								class="pfb-tree-chevron"
-								:class="{ collapsed: is_collapsed(column) }"
-								@click.stop="toggle_collapse(column)"
+								:class="{ collapsed: is_collapsed(col.column) }"
+								@click.stop="toggle_collapse(col.column)"
 								v-html="frappe.utils.icon('chevron-down', 'sm')"
 							></button>
 							<span v-else class="pfb-tree-spacer"></span>
@@ -233,13 +233,13 @@
 								{{ __("Column {0}", [ci + 1]) }}
 							</span>
 						</div>
-						<div v-if="!is_collapsed(column)" class="pfb-tree-children">
+						<div v-if="!is_collapsed(col.column)" class="pfb-tree-children">
 							<div
-								v-for="(field, fi) in visible_fields(column)"
+								v-for="(field, fi) in col.fields"
 								:key="fi"
 								class="pfb-tree-row"
 								:class="{ active: store.selected_field.value === field }"
-								@click="select_field(field, section)"
+								@click="select_field(field, node.section)"
 							>
 								<span class="pfb-tree-spacer"></span>
 								<span
@@ -539,9 +539,15 @@ function field_label(f) {
 	return f.label || f.fieldname || f.fieldtype || __("Field");
 }
 
-function visible_fields(column) {
-	return (column.fields || []).filter((f) => !f.remove);
-}
+let outline_tree = computed(() =>
+	visible_sections.value.map((section) => ({
+		section,
+		columns: (section.columns || []).map((column) => ({
+			column,
+			fields: (column.fields || []).filter((f) => !f.remove),
+		})),
+	}))
+);
 
 const FIELD_ICONS = {
 	Table: "table",

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -76,7 +76,11 @@
 			</div>
 
 			<div v-if="!field_groups.length" class="pfb-empty">
-				{{ __("No fields match your search.") }}
+				{{
+					search_text
+						? __("No fields match your search.")
+						: __("This document type has no printable fields.")
+				}}
 			</div>
 		</div>
 
@@ -162,7 +166,7 @@
 					data-theme="red"
 					data-icon-button="true"
 					:title="__('Delete snippet')"
-					@click.stop="store.delete_section_snippet(snip.name)"
+					@click.stop="confirm_delete_snippet(snip.name)"
 					v-html="frappe.utils.icon('trash', 'xs')"
 				></button>
 			</div>
@@ -555,15 +559,24 @@ function save_preset() {
 		({ name }) => {
 			store.save_style_preset(name);
 			active_preset.value = name.trim();
+			frappe.show_alert({ message: __("Style preset saved"), indicator: "green" });
 		},
 		__("Save Style Preset"),
 		__("Save")
 	);
 }
 function delete_preset() {
-	if (!active_preset.value) return;
-	store.delete_style_preset(active_preset.value);
-	active_preset.value = "";
+	const name = active_preset.value;
+	if (!name) return;
+	frappe.confirm(__("Delete the style preset '{0}'?", [name]), () => {
+		store.delete_style_preset(name);
+		active_preset.value = "";
+	});
+}
+function confirm_delete_snippet(name) {
+	frappe.confirm(__("Delete the section snippet '{0}'?", [name]), () =>
+		store.delete_section_snippet(name)
+	);
 }
 
 // ── helpers ────────────────────────────────────────────────

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -259,6 +259,17 @@
 									v-html="frappe.utils.icon(field_icon(field), 'sm')"
 								></span>
 								<span class="pfb-tree-label">{{ field_label(field) }}</span>
+								<span
+									v-if="field_broken(field)"
+									class="pfb-tree-warn"
+									:title="
+										__('Field “{0}” no longer exists on {1}', [
+											field.fieldname,
+											meta.name,
+										])
+									"
+									v-html="frappe.utils.icon('triangle-alert', 'sm')"
+								></span>
 								<span class="pfb-tree-badge">{{ field.fieldtype }}</span>
 							</div>
 						</div>
@@ -549,6 +560,19 @@ function select_field(field, section) {
 
 function field_label(f) {
 	return f.label || f.fieldname || f.fieldtype || __("Field");
+}
+
+// Fieldnames the doctype currently defines (plus the always-present ID field).
+let known_fieldnames = computed(() => {
+	const s = new Set((meta.value?.fields || []).map((df) => df.fieldname));
+	s.add("name");
+	return s;
+});
+// A real doctype field is broken when its fieldname is gone from the schema.
+// Custom blocks (HTML/Image/Barcode/Field Template) carry their own data, so skip them.
+function field_broken(f) {
+	if (f.custom || f.fieldtype === "Field Template" || !f.fieldname) return false;
+	return !known_fieldnames.value.has(f.fieldname);
 }
 
 let outline_tree = computed(() =>
@@ -1139,6 +1163,12 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	font-size: var(--text-tiny);
 	color: var(--gray-500);
 	flex-shrink: 0;
+}
+
+.pfb-tree-warn {
+	display: inline-flex;
+	flex-shrink: 0;
+	color: var(--text-on-orange, #b95000);
 }
 
 .pfb-tree-children {

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -903,8 +903,6 @@ function handle_slash_key(e) {
 		focus_search();
 	}
 }
-
-watch(print_format, () => (store.dirty.value = true), { deep: true });
 </script>
 
 <style scoped>

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -320,7 +320,11 @@
 						@change="apply_preset($event.target.value)"
 					>
 						<option value="">{{ __("Choose a preset…") }}</option>
-						<option v-for="p in store.style_presets.value" :key="p.name" :value="p.name">
+						<option
+							v-for="p in store.style_presets.value"
+							:key="p.name"
+							:value="p.name"
+						>
 							{{ p.name }}
 						</option>
 					</select>

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -575,6 +575,11 @@ function toggle_collapse(node) {
 	next.has(node) ? next.delete(node) : next.add(node);
 	collapsed_nodes.value = next;
 }
+// undo/redo/load replace every section/column object, so drop the now-stale refs
+watch(
+	() => layout.value,
+	() => (collapsed_nodes.value = new Set())
+);
 
 function clone_as_section() {
 	return { label: "", columns: [{ label: "", fields: [] }], page_break: true };

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -281,6 +281,41 @@
 		<!-- ── Format ─────────────────────────────────────────── -->
 		<div v-else-if="activeTab === 'format'" class="pfb-tab-body pfb-format-tab">
 			<div class="form-group">
+				<label class="control-label">{{ __("Style Preset") }}</label>
+				<div class="pfb-preset-row">
+					<select
+						class="form-control form-control-sm"
+						:value="active_preset"
+						@change="apply_preset($event.target.value)"
+					>
+						<option value="">{{ __("Choose a preset…") }}</option>
+						<option v-for="p in store.style_presets.value" :key="p.name" :value="p.name">
+							{{ p.name }}
+						</option>
+					</select>
+					<button
+						class="es-button"
+						data-size="sm"
+						data-variant="ghost"
+						data-icon-button="true"
+						:title="__('Save current style as a preset')"
+						@click="save_preset"
+						v-html="frappe.utils.icon('save', 'sm')"
+					></button>
+					<button
+						v-if="active_preset"
+						class="es-button"
+						data-size="sm"
+						data-variant="ghost"
+						data-theme="red"
+						data-icon-button="true"
+						:title="__('Delete preset')"
+						@click="delete_preset"
+						v-html="frappe.utils.icon('trash', 'sm')"
+					></button>
+				</div>
+			</div>
+			<div class="form-group">
 				<label class="control-label">{{ __("Page Margins (mm)") }}</label>
 				<div class="pfb-margin-grid">
 					<div class="pfb-margin-cell" v-for="df in margins" :key="df.fieldname">
@@ -464,6 +499,35 @@ function mount_color_controls() {
 			},
 		});
 	}
+}
+
+// ── style presets ──────────────────────────────────────────
+let active_preset = ref("");
+function apply_preset(name) {
+	active_preset.value = name;
+	if (name) store.apply_style_preset(name);
+}
+function save_preset() {
+	frappe.prompt(
+		{
+			label: __("Preset name"),
+			fieldname: "name",
+			fieldtype: "Data",
+			reqd: 1,
+			default: active_preset.value || "",
+		},
+		({ name }) => {
+			store.save_style_preset(name);
+			active_preset.value = name.trim();
+		},
+		__("Save Style Preset"),
+		__("Save")
+	);
+}
+function delete_preset() {
+	if (!active_preset.value) return;
+	store.delete_style_preset(active_preset.value);
+	active_preset.value = "";
 }
 
 // ── helpers ────────────────────────────────────────────────
@@ -1178,6 +1242,16 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 /* ── Format tab ──────────────────────────────────────────── */
 .pfb-format-tab .form-group {
 	margin-bottom: 10px;
+}
+
+.pfb-preset-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.pfb-preset-row select {
+	flex: 1;
 }
 
 .pfb-format-tab .form-group:last-child {

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -281,8 +281,8 @@
 								v-for="(field, fi) in col.fields"
 								:key="fi"
 								class="pfb-tree-row"
-								:class="{ active: store.selected_field.value === field }"
-								@click="select_field(field, node.section)"
+								:class="{ active: store.selected_fields.value.includes(field) }"
+								@click="select_field(field, node.section, $event)"
 							>
 								<span class="pfb-tree-spacer"></span>
 								<span
@@ -648,9 +648,10 @@ function select_section(section) {
 	store.select_section(section);
 }
 
-function select_field(field, section) {
-	if (section) store.scroll_to_section.value = section;
-	store.select_field(field);
+function select_field(field, section, e) {
+	const additive = !!(e && (e.metaKey || e.ctrlKey || e.shiftKey));
+	if (section && !additive) store.scroll_to_section.value = section;
+	store.select_field(field, additive);
 }
 
 function field_label(f) {

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -1,13 +1,15 @@
 <template>
 	<div class="pfb-sidebar">
 		<!-- Tab bar -->
-		<div class="pfb-tabbar">
+		<div class="pfb-tabbar" role="tablist">
 			<button
 				v-for="tab in tabs"
 				:key="tab.id"
 				class="pfb-tab"
 				:class="{ active: activeTab === tab.id }"
 				:title="tab.label"
+				role="tab"
+				:aria-selected="activeTab === tab.id"
 				@click="activeTab = tab.id"
 			>
 				<span class="pfb-tab-label">{{ tab.label }}</span>
@@ -239,7 +241,7 @@
 		</div>
 
 		<!-- ── Outline ────────────────────────────────────────── -->
-		<div v-else-if="activeTab === 'outline'" class="pfb-tab-body pfb-tree">
+		<div v-else-if="activeTab === 'outline'" class="pfb-tab-body pfb-tree" role="tree">
 			<div v-if="!outline_tree.length" class="pfb-empty">
 				{{ __("No sections yet. Add sections to the canvas.") }}
 			</div>
@@ -247,7 +249,13 @@
 				<div
 					class="pfb-tree-row"
 					:class="{ active: store.selected_section.value === node.section }"
+					role="treeitem"
+					tabindex="0"
+					:aria-expanded="!is_collapsed(node.section)"
+					:aria-selected="store.selected_section.value === node.section"
 					@click="select_section(node.section)"
+					@keydown.enter.prevent="select_section(node.section)"
+					@keydown.space.prevent="select_section(node.section)"
 				>
 					<button
 						class="pfb-tree-chevron"
@@ -265,7 +273,14 @@
 				</div>
 				<div v-if="!is_collapsed(node.section)" class="pfb-tree-children">
 					<div v-for="(col, ci) in node.columns" :key="ci" class="pfb-tree-node">
-						<div class="pfb-tree-row" @click="select_section(node.section)">
+						<div
+							class="pfb-tree-row"
+							role="treeitem"
+							tabindex="0"
+							@click="select_section(node.section)"
+							@keydown.enter.prevent="select_section(node.section)"
+							@keydown.space.prevent="select_section(node.section)"
+						>
 							<button
 								v-if="col.fields.length"
 								class="pfb-tree-chevron"
@@ -288,7 +303,12 @@
 								:key="fi"
 								class="pfb-tree-row"
 								:class="{ active: store.selected_fields.value.includes(field) }"
+								role="treeitem"
+								tabindex="0"
+								:aria-selected="store.selected_fields.value.includes(field)"
 								@click="select_field(field, node.section, $event)"
+								@keydown.enter.prevent="select_field(field, node.section, $event)"
+								@keydown.space.prevent="select_field(field, node.section, $event)"
 							>
 								<span class="pfb-tree-spacer"></span>
 								<span

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -53,6 +53,7 @@
 					:sort="false"
 					:clone="clone_field"
 					item-key="fieldname"
+					v-bind="DRAG_OPTIONS"
 				>
 					<template #item="{ element }">
 						<div
@@ -85,6 +86,7 @@
 				:sort="false"
 				:clone="clone_field"
 				item-key="fieldname"
+				v-bind="DRAG_OPTIONS"
 			>
 				<template #item="{ element }">
 					<div
@@ -111,6 +113,7 @@
 				:sort="false"
 				:clone="clone_as_section"
 				item-key="fieldname"
+				v-bind="DRAG_OPTIONS"
 			>
 				<template #item="{ element }">
 					<div class="pfb-block-card" :title="element.desc" @click="add_page_break">
@@ -162,6 +165,7 @@
 					:sort="false"
 					:clone="clone_field"
 					item-key="fieldname"
+					v-bind="DRAG_OPTIONS"
 				>
 					<template #item="{ element }">
 						<div
@@ -310,7 +314,7 @@
 <script setup>
 import draggable from "vuedraggable";
 import Autocomplete from "../../vue-components/Autocomplete.vue";
-import { get_table_columns, pluck } from "../utils";
+import { DRAG_OPTIONS, get_table_columns, pluck } from "../utils";
 import { mountColorControl } from "./inspector/useColorControl";
 import { useStore } from "../stores";
 import { computed, onMounted, onUnmounted, nextTick, ref, watch, inject } from "vue";

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -134,6 +134,37 @@
 					</div>
 				</template>
 			</draggable>
+
+			<div class="pfb-group-label mt-3">{{ __("Saved Sections") }}</div>
+			<div v-if="!store.section_snippets.value.length" class="pfb-empty">
+				{{ __("Save a section as a snippet to reuse it here.") }}
+			</div>
+			<div
+				v-for="snip in store.section_snippets.value"
+				:key="snip.name"
+				class="pfb-block-card"
+				:title="__('Insert saved section')"
+				@click="store.insert_section_snippet(snip.name)"
+			>
+				<span
+					class="pfb-block-icon"
+					v-html="frappe.utils.icon('layout-template', 'sm')"
+				></span>
+				<div class="pfb-block-info">
+					<div class="pfb-block-name">{{ snip.name }}</div>
+					<div class="pfb-block-desc text-muted">{{ __("Click to insert") }}</div>
+				</div>
+				<button
+					class="es-button"
+					data-size="xs"
+					data-variant="ghost"
+					data-theme="red"
+					data-icon-button="true"
+					:title="__('Delete snippet')"
+					@click.stop="store.delete_section_snippet(snip.name)"
+					v-html="frappe.utils.icon('trash', 'xs')"
+				></button>
+			</div>
 		</div>
 
 		<!-- ── Templates ─────────────────────────────────────── -->

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -515,14 +515,13 @@ const color_settings = [
 	{ fieldname: "value_color", label: __("Value Color") },
 ];
 let color_hosts = ref({});
+let color_controls = {};
 
-// The Format tab is v-if, so its DOM is recreated on each visit — (re)mount the
-// Frappe color controls into the fresh host divs when the tab is shown.
 function mount_color_controls() {
 	for (const c of color_settings) {
 		const host = color_hosts.value[c.fieldname];
 		if (!host) continue;
-		mountColorControl(host, {
+		color_controls[c.fieldname] = mountColorControl(host, {
 			value: print_format.value[c.fieldname] || "",
 			placeholder: c.label,
 			fieldname: c.fieldname,
@@ -662,14 +661,11 @@ function field_label(f) {
 	return f.label || f.fieldname || f.fieldtype || __("Field");
 }
 
-// Fieldnames the doctype currently defines (plus the always-present ID field).
 let known_fieldnames = computed(() => {
 	const s = new Set((meta.value?.fields || []).map((df) => df.fieldname));
 	s.add("name");
 	return s;
 });
-// A real doctype field is broken when its fieldname is gone from the schema.
-// Custom blocks (HTML/Image/Barcode/Field Template) carry their own data, so skip them.
 function field_broken(f) {
 	if (f.custom || f.fieldtype === "Field Template" || !f.fieldname) return false;
 	return !known_fieldnames.value.has(f.fieldname);
@@ -711,7 +707,6 @@ function toggle_collapse(node) {
 	next.has(node) ? next.delete(node) : next.add(node);
 	collapsed_nodes.value = next;
 }
-// undo/redo/load replace every section/column object, so drop the now-stale refs
 watch(
 	() => layout.value,
 	() => (collapsed_nodes.value = new Set())
@@ -801,6 +796,18 @@ watch(activeTab, (tab) => {
 	if (tab === "templates") fetch_templates();
 	if (tab === "format") nextTick(mount_color_controls);
 });
+
+watch(
+	() => color_settings.map((c) => print_format.value?.[c.fieldname]),
+	() => {
+		for (const c of color_settings) {
+			const ctrl = color_controls[c.fieldname];
+			if (!ctrl) continue;
+			const model = print_format.value?.[c.fieldname] || "";
+			if ((ctrl.get_value() || "") !== model) ctrl.set_value(model);
+		}
+	}
+);
 
 let print_templates_list = computed(() => {
 	const templates = raw_templates.value;

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -18,9 +18,10 @@
 		<div v-if="activeTab === 'fields'" class="pfb-tab-body pfb-fields-tab">
 			<!-- Search -->
 			<div class="pfb-search-wrap">
-				<svg class="icon icon-xs pfb-search-icon text-muted">
-					<use href="#icon-search"></use>
-				</svg>
+				<span
+					class="pfb-search-icon text-muted"
+					v-html="frappe.utils.icon('search', 'xs')"
+				></span>
 				<input
 					ref="search_input"
 					class="pfb-search"
@@ -213,9 +214,10 @@
 							@click="add_to_layout(element)"
 						>
 							<div class="pfb-template-thumb">
-								<svg class="icon icon-sm text-muted">
-									<use href="#icon-table"></use>
-								</svg>
+								<span
+									class="text-muted"
+									v-html="frappe.utils.icon('table', 'sm')"
+								></span>
 							</div>
 							<div class="pfb-template-info">
 								<div class="pfb-template-name">{{ element.display_label }}</div>
@@ -1089,7 +1091,8 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 /* ── Block card (Blocks tab) ─────────────────────────────── */
-.pfb-block-card {
+.pfb-block-card,
+.pfb-template-card {
 	display: flex;
 	align-items: center;
 	gap: 10px;
@@ -1101,7 +1104,8 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	margin-top: 6px;
 }
 
-.pfb-block-card:hover {
+.pfb-block-card:hover,
+.pfb-template-card:hover {
 	background: var(--gray-100);
 	border-color: var(--gray-500);
 }
@@ -1132,23 +1136,6 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 /* ── Template card (Templates tab) ──────────────────────── */
-.pfb-template-card {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	padding: 8px 10px;
-	border-radius: var(--radius);
-	border: 1px solid var(--border-color);
-	background: var(--gray-50);
-	cursor: grab;
-	margin-top: 6px;
-}
-
-.pfb-template-card:hover {
-	background: var(--gray-100);
-	border-color: var(--gray-500);
-}
-
 .pfb-template-thumb {
 	display: flex;
 	align-items: center;

--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -1130,9 +1130,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 }
 
 .pfb-tree-children {
-	margin-left: 15px;
-	border-left: 1px solid var(--gray-200);
-	padding-left: 3px;
+	margin-left: 18px;
 }
 
 /* ── Format tab ──────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -371,7 +371,7 @@
 					data-variant="ghost"
 					data-theme="red"
 					data-icon-button="true"
-					@click.stop="df['remove'] = true"
+					@click.stop="store.remove_field(df)"
 					v-html="frappe.utils.icon('x', 'xs')"
 				></button>
 			</div>
@@ -453,7 +453,7 @@
 								data-variant="ghost"
 								data-theme="red"
 								data-icon-button="true"
-								@click.stop="df['remove'] = true"
+								@click.stop="store.remove_field(df)"
 								v-html="frappe.utils.icon('x', 'sm')"
 							></button>
 						</div>
@@ -1097,8 +1097,7 @@ thead:hover .col-resize-handle::after {
 	cursor: grabbing;
 }
 
-.field--chip.sortable-chosen,
-.field--chip.sortable-ghost {
+.field--chip.sortable-chosen {
 	cursor: grabbing;
 }
 

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -14,7 +14,7 @@
 		:data-fieldtype="preview_data_attr(df.fieldtype)"
 		v-show="!df.remove"
 		:title="df.label || df.fieldname"
-		@click.stop="select_field"
+		@click.stop="select_field($event)"
 	>
 		<!-- ── Preview mode: show actual doc values ─────────── -->
 		<template v-if="preview_doc">
@@ -528,7 +528,9 @@ let rendered_template = ref(null);
 
 let custom_style = computed(() => parse_inline_style(props.df.custom_style));
 
-let is_selected = computed(() => store.selected_field.value === props.df);
+let is_selected = computed(
+	() => store.selected_field.value === props.df || store.selected_fields.value.includes(props.df)
+);
 let preview_doc = computed(() => store.preview_doc.value);
 let is_field_visible = computed(() => evaluate_visible_if(props.df.visible_if, preview_doc.value));
 
@@ -883,9 +885,10 @@ function thumb(col, row) {
 	};
 }
 
-function select_field() {
-	store.select_field(props.df);
-	if (props.df.fieldtype !== "HTML") {
+function select_field(e) {
+	const additive = !!(e && (e.metaKey || e.ctrlKey || e.shiftKey));
+	store.select_field(props.df, additive);
+	if (!additive && props.df.fieldtype !== "HTML") {
 		editing.value = true;
 	}
 }

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -14,7 +14,11 @@
 		:data-fieldtype="preview_data_attr(df.fieldtype)"
 		v-show="!df.remove"
 		:title="df.label || df.fieldname"
+		:aria-label="df.label || df.fieldname"
+		tabindex="0"
 		@click.stop="select_field($event)"
+		@keydown.enter.prevent="kbd_select($event)"
+		@keydown.space.prevent="kbd_select($event)"
 	>
 		<!-- ── Preview mode: show actual doc values ─────────── -->
 		<template v-if="preview_doc">
@@ -894,6 +898,9 @@ function select_field(e) {
 	if (!additive && props.df.fieldtype !== "HTML") {
 		editing.value = true;
 	}
+}
+function kbd_select(e) {
+	store.select_field(props.df, !!(e.shiftKey || e.metaKey || e.ctrlKey));
 }
 
 let short_fieldtype = computed(() => {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -371,6 +371,7 @@
 					data-variant="ghost"
 					data-theme="red"
 					data-icon-button="true"
+					:title="__('Remove field')"
 					@click.stop="store.remove_field(df)"
 					v-html="frappe.utils.icon('x', 'xs')"
 				></button>
@@ -426,6 +427,7 @@
 								data-size="xs"
 								data-variant="ghost"
 								data-icon-button="true"
+								:title="__('Edit HTML')"
 								@click.stop="edit_html"
 								v-html="frappe.utils.icon('pencil', 'sm')"
 							></button>
@@ -453,6 +455,7 @@
 								data-variant="ghost"
 								data-theme="red"
 								data-icon-button="true"
+								:title="__('Remove field')"
 								@click.stop="store.remove_field(df)"
 								v-html="frappe.utils.icon('x', 'sm')"
 							></button>

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -360,6 +360,15 @@
 					class="es-button"
 					data-size="xs"
 					data-variant="ghost"
+					data-icon-button="true"
+					:title="__('Duplicate')"
+					@click.stop="store.duplicate_field(df)"
+					v-html="frappe.utils.icon('copy-plus', 'xs')"
+				></button>
+				<button
+					class="es-button"
+					data-size="xs"
+					data-variant="ghost"
 					data-theme="red"
 					data-icon-button="true"
 					@click.stop="df['remove'] = true"
@@ -428,6 +437,15 @@
 								:title="__('Copy')"
 								@click.stop="store.copy_field(df)"
 								v-html="frappe.utils.icon('copy', 'sm')"
+							></button>
+							<button
+								class="es-button"
+								data-size="xs"
+								data-variant="ghost"
+								data-icon-button="true"
+								:title="__('Duplicate')"
+								@click.stop="store.duplicate_field(df)"
+								v-html="frappe.utils.icon('copy-plus', 'sm')"
 							></button>
 							<button
 								class="es-button"

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -50,9 +50,24 @@
 					</div>
 				</template>
 				<template #footer>
-					<SectionInsert @insert="add_section_at(layout.sections.length)" />
+					<SectionInsert
+						v-if="layout.sections && layout.sections.length"
+						@insert="add_section_at(layout.sections.length)"
+					/>
 				</template>
 			</draggable>
+
+			<button
+				v-if="!layout.sections || !layout.sections.length"
+				class="body-empty"
+				@click="add_section_at(0)"
+			>
+				<span class="body-empty-icon" v-html="frappe.utils.icon('plus', 'md')"></span>
+				<span class="body-empty-title">{{ __("Add a section") }}</span>
+				<span class="body-empty-hint">
+					{{ __("Sections hold the columns and fields of your document.") }}
+				</span>
+			</button>
 
 			<div class="zone-divider">
 				<span class="zone-divider-label">
@@ -246,6 +261,49 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 
 .sections-container {
 	margin-bottom: 1rem;
+}
+
+/* ── Empty-body call to action ────────────────────────────── */
+.body-empty {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 4px;
+	width: 100%;
+	padding: 2rem 1rem;
+	border: 1px dashed var(--gray-300);
+	border-radius: var(--radius);
+	background: var(--gray-50);
+	color: var(--text-muted);
+	cursor: pointer;
+	transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.body-empty:hover {
+	border-color: var(--gray-500);
+	background: var(--gray-100);
+	color: var(--text-color);
+}
+
+.body-empty-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	margin-bottom: 2px;
+	border-radius: 50%;
+	background: var(--gray-200);
+	color: var(--gray-700);
+}
+
+.body-empty-title {
+	font-size: var(--text-md);
+	font-weight: var(--weight-medium);
+}
+
+.body-empty-hint {
+	font-size: var(--text-sm);
 }
 
 /* ── Zone dividers ────────────────────────────────────────── */

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -234,9 +234,6 @@ let page_number_style = computed(() => {
 	}
 	return style;
 });
-
-watch(layout, () => (store.dirty.value = true), { deep: true });
-watch(print_format, () => (store.dirty.value = true), { deep: true });
 </script>
 
 <style scoped>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -39,6 +39,8 @@
 				handle=".section-drag-handle"
 				filter=".section-columns, .column, .field"
 				v-bind="DRAG_OPTIONS"
+				@start="setDragging(true)"
+				@end="setDragging(false)"
 				@add="on_section_add"
 			>
 				<template #item="{ element, index }">
@@ -72,7 +74,7 @@ import draggable from "vuedraggable";
 import LetterHeadZoneEditor from "../letterhead/LetterHeadZoneEditor.vue";
 import PrintFormatSection from "./PrintFormatSection.vue";
 import SectionInsert from "./SectionInsert.vue";
-import { DRAG_OPTIONS } from "../../utils";
+import { DRAG_OPTIONS, setDragging } from "../../utils";
 import { useStore } from "../../stores";
 import { computed, inject, watch, nextTick, onMounted, onUnmounted, ref } from "vue";
 

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormat.vue
@@ -38,6 +38,7 @@
 				item-key="id"
 				handle=".section-drag-handle"
 				filter=".section-columns, .column, .field"
+				v-bind="DRAG_OPTIONS"
 				@add="on_section_add"
 			>
 				<template #item="{ element, index }">
@@ -71,6 +72,7 @@ import draggable from "vuedraggable";
 import LetterHeadZoneEditor from "../letterhead/LetterHeadZoneEditor.vue";
 import PrintFormatSection from "./PrintFormatSection.vue";
 import SectionInsert from "./SectionInsert.vue";
+import { DRAG_OPTIONS } from "../../utils";
 import { useStore } from "../../stores";
 import { computed, inject, watch, nextTick, onMounted, onUnmounted, ref } from "vue";
 

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -25,6 +25,15 @@
 				class="es-button"
 				data-size="xs"
 				data-variant="ghost"
+				data-icon-button="true"
+				:title="__('Duplicate section')"
+				@click.stop="store.duplicate_section(section)"
+				v-html="frappe.utils.icon('copy-plus', 'xs')"
+			></button>
+			<button
+				class="es-button"
+				data-size="xs"
+				data-variant="ghost"
 				data-theme="red"
 				data-icon-button="true"
 				:title="__('Remove section')"
@@ -72,6 +81,17 @@
 						@click.stop="store.copy_section(section)"
 					>
 						<span v-html="frappe.utils.icon('copy', 'sm')"></span>
+					</button>
+					<button
+						v-if="!is_header"
+						class="es-button"
+						data-size="xs"
+						data-variant="ghost"
+						data-icon-button="true"
+						:title="__('Duplicate section')"
+						@click.stop="store.duplicate_section(section)"
+					>
+						<span v-html="frappe.utils.icon('copy-plus', 'sm')"></span>
 					</button>
 					<button
 						v-if="!is_header"

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -59,7 +59,11 @@
 				'section--grid-columns': is_grid && section.grid_borders === 'columns',
 			}"
 			:style="section_inline_style"
+			tabindex="0"
+			:aria-label="section.label || __('Untitled section')"
 			@click.stop="select_section"
+			@keydown.enter.prevent="select_section"
+			@keydown.space.prevent="select_section"
 		>
 			<div class="section-toolbar">
 				<div class="section-toolbar-left">

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -124,6 +124,8 @@
 							:preventOnFilter="false"
 							:emptyInsertThreshold="100"
 							v-bind="DRAG_OPTIONS"
+							@start="setDragging(true)"
+							@end="setDragging(false)"
 							@add="select_section"
 						>
 							<template #item="{ element }">
@@ -177,7 +179,7 @@ import draggable from "vuedraggable";
 import Field from "./Field.vue";
 import { computed, inject } from "vue";
 import { useColumnResize } from "../../composables/useColumnResize";
-import { DRAG_OPTIONS, evaluate_visible_if, parse_inline_style } from "../../utils";
+import { DRAG_OPTIONS, evaluate_visible_if, parse_inline_style, setDragging } from "../../utils";
 
 const props = defineProps(["section", "is_header", "zone"]);
 

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -34,6 +34,15 @@
 				class="es-button"
 				data-size="xs"
 				data-variant="ghost"
+				data-icon-button="true"
+				:title="__('Save as snippet')"
+				@click.stop="save_as_snippet"
+				v-html="frappe.utils.icon('bookmark-plus', 'xs')"
+			></button>
+			<button
+				class="es-button"
+				data-size="xs"
+				data-variant="ghost"
 				data-theme="red"
 				data-icon-button="true"
 				:title="__('Remove section')"
@@ -92,6 +101,17 @@
 						@click.stop="store.duplicate_section(section)"
 					>
 						<span v-html="frappe.utils.icon('copy-plus', 'sm')"></span>
+					</button>
+					<button
+						v-if="!is_header"
+						class="es-button"
+						data-size="xs"
+						data-variant="ghost"
+						data-icon-button="true"
+						:title="__('Save as snippet')"
+						@click.stop="save_as_snippet"
+					>
+						<span v-html="frappe.utils.icon('bookmark-plus', 'sm')"></span>
 					</button>
 					<button
 						v-if="!is_header"
@@ -290,6 +310,24 @@ function select_section() {
 
 function remove_section() {
 	store.remove_section(props.section);
+}
+
+function save_as_snippet() {
+	frappe.prompt(
+		{
+			label: __("Snippet name"),
+			fieldname: "name",
+			fieldtype: "Data",
+			reqd: 1,
+			default: props.section.label || "",
+		},
+		({ name }) => {
+			store.save_section_snippet(name, props.section);
+			frappe.show_alert({ message: __("Section saved as snippet"), indicator: "green" }, 3);
+		},
+		__("Save Section as Snippet"),
+		__("Save")
+	);
 }
 
 function remove_column(index) {

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -123,6 +123,7 @@
 							filter="a, input, textarea, select, button, label, summary, [contenteditable], [role='button'], [tabindex]"
 							:preventOnFilter="false"
 							:emptyInsertThreshold="100"
+							v-bind="DRAG_OPTIONS"
 							@add="select_section"
 						>
 							<template #item="{ element }">
@@ -176,7 +177,7 @@ import draggable from "vuedraggable";
 import Field from "./Field.vue";
 import { computed, inject } from "vue";
 import { useColumnResize } from "../../composables/useColumnResize";
-import { evaluate_visible_if, parse_inline_style } from "../../utils";
+import { DRAG_OPTIONS, evaluate_visible_if, parse_inline_style } from "../../utils";
 
 const props = defineProps(["section", "is_header", "zone"]);
 

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -444,13 +444,13 @@ function remove_column(index) {
 	min-height: 3rem;
 }
 
-.column:has(.sortable-ghost) .empty-drop-zone {
+.column:has(.pfb-drag-ghost) .empty-drop-zone {
 	background: transparent;
-	border-color: var(--blue-300);
+	border-color: var(--gray-400);
 	border-style: solid;
 }
 
-.column:has(.sortable-ghost) .empty-drop-zone-hint {
+.column:has(.pfb-drag-ghost) .empty-drop-zone-hint {
 	display: none;
 }
 

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSetup.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSetup.vue
@@ -108,8 +108,8 @@ defineEmits(["start-default", "start-blank"]);
 }
 
 .pfb-setup-option:hover {
-	border-color: var(--primary);
-	background: var(--blue-50);
+	border-color: var(--gray-500);
+	background: var(--gray-50);
 }
 
 .pfb-setup-option-icon {
@@ -118,7 +118,7 @@ defineEmits(["start-default", "start-blank"]);
 }
 
 .pfb-setup-option:hover .pfb-setup-option-icon {
-	color: var(--primary);
+	color: var(--gray-700);
 }
 
 .pfb-setup-option-body {

--- a/frappe/public/js/print_format_builder/components/editor/SectionInsert.vue
+++ b/frappe/public/js/print_format_builder/components/editor/SectionInsert.vue
@@ -51,10 +51,6 @@ defineEmits(["insert"]);
 	box-shadow: none;
 }
 
-.section-insert:hover .section-insert-line {
-	background: var(--gray-400);
-}
-
 .section-insert:hover .section-insert-btn {
 	border-color: var(--gray-400);
 	color: var(--text-color);

--- a/frappe/public/js/print_format_builder/components/inspector/BulkPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/BulkPropertiesPanel.vue
@@ -1,0 +1,49 @@
+<template>
+	<div class="pfb-insp-body">
+		<InspectorSection :label="__('{0} fields selected', [count])">
+			<SegmentedRow
+				:label="__('Align')"
+				:model-value="common_align"
+				:options="align_opts"
+				@update:model-value="(v) => store.align_selected_fields(v)"
+			/>
+			<div class="pfb-insp-row">
+				<button
+					class="es-button pfb-bulk-delete"
+					data-variant="ghost"
+					data-theme="red"
+					@click="store.remove_selected_fields()"
+				>
+					<span v-html="frappe.utils.icon('trash', 'sm')"></span>
+					{{ __("Remove selected") }}
+				</button>
+			</div>
+		</InspectorSection>
+	</div>
+</template>
+
+<script setup>
+import { computed, inject } from "vue";
+import InspectorSection from "./InspectorSection.vue";
+import SegmentedRow from "./SegmentedRow.vue";
+import { align_opts } from "./align_opts";
+
+let store = inject("$store");
+
+let count = computed(() => store.selected_fields.value.length);
+let common_align = computed(() => {
+	const aligns = store.selected_fields.value.map((df) => df.align || "left");
+	const first = aligns[0];
+	return aligns.every((a) => a === first) ? first : "";
+});
+</script>
+
+<style scoped>
+.pfb-bulk-delete {
+	width: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+}
+</style>

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -46,9 +46,11 @@
 			"
 			class="pfb-inspector-empty"
 		>
-			<svg class="icon icon-md text-muted" style="margin-bottom: 8px">
-				<use href="#icon-text-cursor"></use>
-			</svg>
+			<span
+				class="text-muted"
+				style="margin-bottom: 8px"
+				v-html="frappe.utils.icon('text-cursor', 'md')"
+			></span>
 			<p class="text-muted">{{ __("Click a field to edit its properties") }}</p>
 		</div>
 

--- a/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/FieldInspector.vue
@@ -20,7 +20,7 @@
 		</div>
 
 		<!-- Breadcrumb: navigate up to parent section when a field is selected -->
-		<div v-if="selected_field && parent_section" class="pfb-breadcrumb">
+		<div v-if="selected_field && parent_section && !is_multi_select" class="pfb-breadcrumb">
 			<button
 				class="pfb-breadcrumb-btn"
 				@click="select_parent_section"
@@ -62,6 +62,9 @@
 			<LetterHeadZoneInspector zone="header" />
 		</template>
 
+		<!-- ── Multi-select bulk inspector ─────────────────────── -->
+		<BulkPropertiesPanel v-else-if="is_multi_select" />
+
 		<!-- ── Table field inspector ───────────────────────────────── -->
 		<TableFieldInspector v-else-if="selected_field && is_table_field" />
 
@@ -84,11 +87,13 @@ import SectionPropertiesPanel from "./SectionPropertiesPanel.vue";
 import RepeaterFieldInspector from "./RepeaterFieldInspector.vue";
 import TableFieldInspector from "./TableFieldInspector.vue";
 import FieldPropertiesPanel from "./FieldPropertiesPanel.vue";
+import BulkPropertiesPanel from "./BulkPropertiesPanel.vue";
 
 let store = inject("$store");
 let { letterhead, layout, print_format } = useStore();
 
 let selected_field = computed(() => store.selected_field.value);
+let is_multi_select = computed(() => store.selected_fields.value.length > 1);
 let selected_section = computed(() => store.selected_section.value);
 let selected_letterhead = computed(() => store.selected_letterhead.value);
 let selected_lh_footer = computed(() => store.selected_lh_footer.value);
@@ -97,6 +102,7 @@ let is_table_field = computed(() => selected_field.value?.fieldtype === "Table")
 let is_repeater_field = computed(() => selected_field.value?.fieldtype === "Repeater");
 
 let inspector_kind = computed(() => {
+	if (is_multi_select.value) return __("Selection");
 	if (selected_lh_footer.value) return __("Letter Head");
 	if (selected_letterhead.value) return __("Letter Head");
 	if (selected_field.value) {
@@ -108,6 +114,7 @@ let inspector_kind = computed(() => {
 });
 
 let inspector_subtitle = computed(() => {
+	if (is_multi_select.value) return __("{0} fields", [store.selected_fields.value.length]);
 	if (selected_lh_footer.value) return __("Footer");
 	if (selected_letterhead.value) return letterhead.value?.name || "";
 	if (selected_field.value) {

--- a/frappe/public/js/print_format_builder/components/inspector/LetterHeadZoneInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/LetterHeadZoneInspector.vue
@@ -366,9 +366,9 @@ function lh_create_letterhead() {
 	font-size: var(--text-tiny);
 	font-weight: var(--weight-semibold);
 	letter-spacing: 0;
-	color: var(--blue-500);
-	background: var(--blue-50);
-	border-bottom: 1px solid var(--blue-200);
+	color: var(--gray-600);
+	background: var(--gray-50);
+	border-bottom: 1px solid var(--gray-200);
 	padding: 7px 14px;
 	flex-shrink: 0;
 }

--- a/frappe/public/js/print_format_builder/components/inspector/SectionPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/SectionPropertiesPanel.vue
@@ -100,7 +100,7 @@
 		<!-- PRINT -->
 		<InspectorSection :label="__('Print')" :init-open="false">
 			<ToggleRow
-				:label="__('Start on new page')"
+				:label="__('Page break after')"
 				:model-value="!!selected_section.page_break"
 				@update:model-value="(v) => (selected_section.page_break = v)"
 			/>

--- a/frappe/public/js/print_format_builder/components/inspector/SectionPropertiesPanel.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/SectionPropertiesPanel.vue
@@ -97,6 +97,20 @@
 			/>
 		</InspectorSection>
 
+		<!-- PRINT -->
+		<InspectorSection :label="__('Print')" :init-open="false">
+			<ToggleRow
+				:label="__('Start on new page')"
+				:model-value="!!selected_section.page_break"
+				@update:model-value="(v) => (selected_section.page_break = v)"
+			/>
+			<ToggleRow
+				:label="__('Keep together')"
+				:model-value="!!selected_section.keep_together"
+				@update:model-value="(v) => (selected_section.keep_together = v)"
+			/>
+		</InspectorSection>
+
 		<!-- STYLE -->
 		<InspectorSection :label="__('Style')" :init-open="false" :padded="false">
 			<StyleSection v-model="selected_section.custom_style" />
@@ -117,6 +131,7 @@ import InspectorSection from "./InspectorSection.vue";
 import StepperRow from "./StepperRow.vue";
 import SpacingRow from "./SpacingRow.vue";
 import StyleSection from "./StyleSection.vue";
+import ToggleRow from "./ToggleRow.vue";
 import VisibilitySection from "./VisibilitySection.vue";
 import { mountColorControl } from "./useColorControl";
 

--- a/frappe/public/js/print_format_builder/components/inspector/TableFieldInspector.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/TableFieldInspector.vue
@@ -195,6 +195,18 @@
 										@update:model-value="(v) => (col.merge_direction = v)"
 									/>
 								</div>
+								<div class="pfb-col-cond">
+									<label class="pfb-insp-label">{{
+										__("Show column when")
+									}}</label>
+									<input
+										class="pfb-insp-input"
+										type="text"
+										:placeholder="__('e.g. doc.apply_discount')"
+										:value="col.column_condition || ''"
+										@input="col.column_condition = $event.target.value"
+									/>
+								</div>
 							</div>
 						</div>
 					</template>
@@ -237,6 +249,20 @@
 		<!-- VISIBILITY section -->
 		<InspectorSection :label="__('Visibility')" :padded="false">
 			<VisibilitySection v-model="selected_field.visible_if" :previewDoc="preview_doc" />
+			<div class="pfb-row-cond">
+				<label class="pfb-insp-label">{{ __("Show row when") }}</label>
+				<input
+					class="pfb-insp-input"
+					type="text"
+					:placeholder="__('e.g. row.qty > 0')"
+					:value="selected_field.row_condition || ''"
+					@input="selected_field.row_condition = $event.target.value"
+				/>
+				<p class="pfb-insp-hint text-muted">
+					{{ __("Leave blank to show every row. Reference the row with") }}
+					<code>row.fieldname</code>.
+				</p>
+			</div>
 		</InspectorSection>
 	</div>
 </template>
@@ -561,5 +587,20 @@ function set_image_size(col, value) {
 .pfb-col-editor .pfb-col-remove,
 .pfb-col-editor .pfb-merge-drag {
 	color: var(--gray-400);
+}
+
+.pfb-col-cond {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 8px 14px 10px;
+	border-top: 1px solid var(--gray-100);
+}
+
+.pfb-row-cond {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 0 14px 12px;
 }
 </style>

--- a/frappe/public/js/print_format_builder/components/inspector/ToggleRow.vue
+++ b/frappe/public/js/print_format_builder/components/inspector/ToggleRow.vue
@@ -1,0 +1,27 @@
+<template>
+	<div class="pfb-insp-row">
+		<span class="pfb-insp-label">{{ label }}</span>
+		<label class="switch-control" :title="label">
+			<span class="input-area">
+				<input
+					type="checkbox"
+					role="switch"
+					:aria-label="label"
+					:checked="modelValue"
+					@change="$emit('update:modelValue', $event.target.checked)"
+				/>
+			</span>
+			<span class="switch-visual" aria-hidden="true">
+				<span class="switch-thumb"></span>
+			</span>
+		</label>
+	</div>
+</template>
+
+<script setup>
+defineProps({
+	label: { type: String, default: "" },
+	modelValue: { type: Boolean, default: false },
+});
+defineEmits(["update:modelValue"]);
+</script>

--- a/frappe/public/js/print_format_builder/inspector.css
+++ b/frappe/public/js/print_format_builder/inspector.css
@@ -316,3 +316,11 @@
 	user-select: none;
 	-webkit-user-select: none;
 }
+
+/* While a drag is in progress the whole page is unselectable, so the mouse-move
+   can't extend a selection across gaps or neighbouring elements. */
+body.pfb-dragging,
+body.pfb-dragging * {
+	user-select: none !important;
+	-webkit-user-select: none !important;
+}

--- a/frappe/public/js/print_format_builder/inspector.css
+++ b/frappe/public/js/print_format_builder/inspector.css
@@ -305,3 +305,14 @@
 	background: var(--gray-500);
 	border-radius: 2px;
 }
+
+/* Drag sources must not start a text selection when grabbed: forceFallback uses a
+   real mousedown-drag (unlike native HTML5 drag, which never selected text). */
+.pfb-field-row,
+.pfb-block-card,
+.pfb-template-card,
+.drag-container .field,
+.sections-container .section-drag-handle {
+	user-select: none;
+	-webkit-user-select: none;
+}

--- a/frappe/public/js/print_format_builder/inspector.css
+++ b/frappe/public/js/print_format_builder/inspector.css
@@ -276,3 +276,32 @@
 	cursor: grabbing !important;
 	pointer-events: none;
 }
+
+/* Ghost placeholder collapses to a thin insertion line marking the drop position.
+   Only builder draggables use this class (via DRAG_OPTIONS ghostClass). */
+.pfb-drag-ghost {
+	height: 0 !important;
+	min-height: 0 !important;
+	margin: 4px 0 !important;
+	padding: 0 !important;
+	border: none !important;
+	overflow: visible !important;
+	position: relative !important;
+	opacity: 1 !important;
+	box-shadow: none !important;
+}
+
+.pfb-drag-ghost > * {
+	visibility: hidden !important;
+}
+
+.pfb-drag-ghost::after {
+	content: "";
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: -1px;
+	height: 2px;
+	background: var(--gray-500);
+	border-radius: 2px;
+}

--- a/frappe/public/js/print_format_builder/inspector.css
+++ b/frappe/public/js/print_format_builder/inspector.css
@@ -267,8 +267,6 @@
 	margin: 0;
 }
 
-/* The floating element dragged with SortableJS's fallback (DRAG_OPTIONS
-   forceFallback). It is appended to <body>, so this must stay global/unscoped. */
 .pfb-drag-fallback {
 	opacity: 0.95 !important;
 	box-shadow: 0 10px 28px rgba(0, 0, 0, 0.16);
@@ -277,8 +275,6 @@
 	pointer-events: none;
 }
 
-/* Ghost placeholder collapses to a thin insertion line marking the drop position.
-   Only builder draggables use this class (via DRAG_OPTIONS ghostClass). */
 .pfb-drag-ghost {
 	height: 0 !important;
 	min-height: 0 !important;
@@ -306,8 +302,6 @@
 	border-radius: 2px;
 }
 
-/* Drag sources must not start a text selection when grabbed: forceFallback uses a
-   real mousedown-drag (unlike native HTML5 drag, which never selected text). */
 .pfb-field-row,
 .pfb-block-card,
 .pfb-template-card,
@@ -317,8 +311,6 @@
 	-webkit-user-select: none;
 }
 
-/* While a drag is in progress the whole page is unselectable, so the mouse-move
-   can't extend a selection across gaps or neighbouring elements. */
 body.pfb-dragging,
 body.pfb-dragging * {
 	user-select: none !important;

--- a/frappe/public/js/print_format_builder/inspector.css
+++ b/frappe/public/js/print_format_builder/inspector.css
@@ -266,3 +266,13 @@
 	cursor: pointer;
 	margin: 0;
 }
+
+/* The floating element dragged with SortableJS's fallback (DRAG_OPTIONS
+   forceFallback). It is appended to <body>, so this must stay global/unscoped. */
+.pfb-drag-fallback {
+	opacity: 0.95 !important;
+	box-shadow: 0 10px 28px rgba(0, 0, 0, 0.16);
+	border-radius: var(--radius);
+	cursor: grabbing !important;
+	pointer-events: none;
+}

--- a/frappe/public/js/print_format_builder/print_format_builder.bundle.js
+++ b/frappe/public/js/print_format_builder/print_format_builder.bundle.js
@@ -39,6 +39,7 @@ class PrintFormatBuilder {
 
 		let app = createApp(PrintFormatBuilderComponent, { print_format_name: print_format });
 		SetVueGlobals(app);
+		this.app = app;
 		this.$component = app.mount(this.$wrapper.get(0));
 
 		watch(
@@ -63,6 +64,10 @@ class PrintFormatBuilder {
 				$toggle_preview_btn.text(value ? __("Hide Preview") : __("Show Preview"));
 			}
 		);
+	}
+
+	destroy() {
+		this.app?.unmount();
 	}
 }
 

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -328,6 +328,32 @@ export function getStore(print_format_name) {
 		if (selected_field.value) copy_field(selected_field.value);
 		else if (selected_section.value) copy_section(selected_section.value);
 	}
+	function duplicate_field(df) {
+		if (!df || !layout.value) return;
+		const col = find_field_column(df);
+		if (!col) return;
+		const clone = freshen_field(clone_plain(df));
+		col.fields.splice(col.fields.indexOf(df) + 1, 0, clone);
+		selected_section.value = null;
+		selected_field.value = clone;
+	}
+	function duplicate_section(section) {
+		if (!section || !layout.value) return;
+		const sections = layout.value.sections;
+		const idx = sections.indexOf(section);
+		// header/footer zones live outside sections and can't be duplicated
+		if (idx === -1) return;
+		const clone = clone_plain(section);
+		delete clone.remove;
+		(clone.columns || []).forEach((c) => (c.fields || []).forEach(freshen_field));
+		sections.splice(idx + 1, 0, clone);
+		selected_field.value = null;
+		selected_section.value = clone;
+	}
+	function duplicate_selection() {
+		if (selected_field.value) duplicate_field(selected_field.value);
+		else if (selected_section.value) duplicate_section(selected_section.value);
+	}
 	function find_field_column(df) {
 		const lv = layout.value;
 		const zones = [lv?.header, lv?.footer, ...(lv?.sections || [])].filter(Boolean);
@@ -408,6 +434,9 @@ export function getStore(print_format_name) {
 		copy_field,
 		copy_section,
 		copy_selection,
+		duplicate_field,
+		duplicate_section,
+		duplicate_selection,
 		paste_clipboard,
 		undo,
 		redo,

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -25,6 +25,13 @@ function set_clipboard(value) {
 	}
 }
 
+// keep the in-memory copy fresh when another tab copies something
+if (typeof window !== "undefined") {
+	window.addEventListener("storage", (e) => {
+		if (e.key === CLIPBOARD_KEY) clipboard.value = load_clipboard();
+	});
+}
+
 function clone_plain(obj) {
 	return JSON.parse(JSON.stringify(obj));
 }

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -354,6 +354,21 @@ export function getStore(print_format_name) {
 		if (selected_field.value) duplicate_field(selected_field.value);
 		else if (selected_section.value) duplicate_section(selected_section.value);
 	}
+	function move_in_array(arr, item, dir) {
+		const i = arr.indexOf(item);
+		const j = i + dir;
+		if (i === -1 || j < 0 || j >= arr.length) return;
+		arr.splice(i, 1);
+		arr.splice(j, 0, item);
+	}
+	function move_selection(dir) {
+		if (selected_field.value) {
+			const col = find_field_column(selected_field.value);
+			if (col) move_in_array(col.fields, selected_field.value, dir);
+		} else if (selected_section.value) {
+			move_in_array(layout.value?.sections || [], selected_section.value, dir);
+		}
+	}
 	function find_field_column(df) {
 		const lv = layout.value;
 		const zones = [lv?.header, lv?.footer, ...(lv?.sections || [])].filter(Boolean);
@@ -437,6 +452,7 @@ export function getStore(print_format_name) {
 		duplicate_field,
 		duplicate_section,
 		duplicate_selection,
+		move_selection,
 		paste_clipboard,
 		undo,
 		redo,

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -101,6 +101,8 @@ export function getStore(print_format_name) {
 	let edit_letterhead = ref(false);
 	let scroll_to_section = ref(null);
 	let selected_field = ref(null);
+	// Multi-selection layer; selected_field stays the "primary" for the inspector.
+	let selected_fields = ref([]);
 	let selected_section = ref(null);
 	let selected_letterhead = ref(false);
 	let selected_lh_footer = ref(false);
@@ -248,10 +250,37 @@ export function getStore(print_format_name) {
 		serialize_layout(snapshot);
 		return { ...print_format.value, format_data: JSON.stringify(snapshot) };
 	}
-	function select_field(df) {
-		selected_field.value = df;
+	function select_field(df, additive = false) {
+		if (additive && df) {
+			const arr = selected_fields.value.slice();
+			const i = arr.indexOf(df);
+			if (i === -1) arr.push(df);
+			else arr.splice(i, 1);
+			selected_fields.value = arr;
+			selected_field.value = arr[arr.length - 1] || null;
+		} else {
+			selected_fields.value = df ? [df] : [];
+			selected_field.value = df;
+		}
 		selected_letterhead.value = false;
 		selected_lh_footer.value = false;
+	}
+	// Keep the multi-selection in step when the primary is set directly
+	// (paste, duplicate, keyboard nav) rather than through select_field.
+	watch(selected_field, (nf) => {
+		if (!nf) {
+			if (selected_fields.value.length) selected_fields.value = [];
+		} else if (!selected_fields.value.includes(nf)) {
+			selected_fields.value = [nf];
+		}
+	});
+	function remove_selected_fields() {
+		selected_fields.value.forEach((df) => (df.remove = true));
+		selected_fields.value = [];
+		selected_field.value = null;
+	}
+	function align_selected_fields(align) {
+		selected_fields.value.forEach((df) => (df.align = align));
 	}
 	function select_section(section) {
 		selected_section.value = section;
@@ -518,6 +547,9 @@ export function getStore(print_format_name) {
 		edit_letterhead,
 		scroll_to_section,
 		selected_field,
+		selected_fields,
+		remove_selected_fields,
+		align_selected_fields,
 		selected_section,
 		selected_letterhead,
 		selected_lh_footer,

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -16,16 +16,20 @@ function load_clipboard() {
 
 const clipboard = ref(load_clipboard());
 
-function set_clipboard(value) {
-	clipboard.value = value;
+function persist_local(key, value) {
 	try {
-		localStorage.setItem(CLIPBOARD_KEY, JSON.stringify(value));
+		localStorage.setItem(key, JSON.stringify(value));
+		return true;
 	} catch {
-		// ignore quota / privacy-mode failures; in-memory copy still works
+		return false;
 	}
 }
 
-// keep the in-memory copy fresh when another tab copies something
+function set_clipboard(value) {
+	clipboard.value = value;
+	persist_local(CLIPBOARD_KEY, value);
+}
+
 if (typeof window !== "undefined") {
 	window.addEventListener("storage", (e) => {
 		if (e.key === CLIPBOARD_KEY) clipboard.value = load_clipboard();
@@ -36,7 +40,6 @@ function clone_plain(obj) {
 	return JSON.parse(JSON.stringify(obj));
 }
 
-// Style presets — the visual settings a preset captures, plus its persistence.
 const STYLE_PRESETS_KEY = "pfb_style_presets";
 const STYLE_PRESET_KEYS = [
 	"font",
@@ -57,14 +60,9 @@ function load_style_presets() {
 	}
 }
 function persist_style_presets(list) {
-	try {
-		localStorage.setItem(STYLE_PRESETS_KEY, JSON.stringify(list));
-	} catch {
-		// ignore quota / privacy-mode failures; in-memory copy still works
-	}
+	persist_local(STYLE_PRESETS_KEY, list);
 }
 
-// Section snippets — named, reusable sections shared across print formats.
 const SECTION_SNIPPETS_KEY = "pfb_section_snippets";
 function load_section_snippets() {
 	try {
@@ -74,11 +72,7 @@ function load_section_snippets() {
 	}
 }
 function persist_section_snippets(list) {
-	try {
-		localStorage.setItem(SECTION_SNIPPETS_KEY, JSON.stringify(list));
-	} catch {
-		// ignore quota / privacy-mode failures; in-memory copy still works
-	}
+	persist_local(SECTION_SNIPPETS_KEY, list);
 }
 
 // A pasted custom element (HTML/Image/Barcode block) gets a fresh fieldname so
@@ -101,7 +95,6 @@ export function getStore(print_format_name) {
 	let edit_letterhead = ref(false);
 	let scroll_to_section = ref(null);
 	let selected_field = ref(null);
-	// Multi-selection layer; selected_field stays the "primary" for the inspector.
 	let selected_fields = ref([]);
 	let selected_section = ref(null);
 	let selected_letterhead = ref(false);
@@ -265,8 +258,6 @@ export function getStore(print_format_name) {
 		selected_letterhead.value = false;
 		selected_lh_footer.value = false;
 	}
-	// Keep the multi-selection in step when the primary is set directly
-	// (paste, duplicate, keyboard nav) rather than through select_field.
 	watch(selected_field, (nf) => {
 		if (!nf) {
 			if (selected_fields.value.length) selected_fields.value = [];
@@ -415,7 +406,6 @@ export function getStore(print_format_name) {
 		if (!section || !layout.value) return;
 		const sections = layout.value.sections;
 		const idx = sections.indexOf(section);
-		// header/footer zones live outside sections and can't be duplicated
 		if (idx === -1) return;
 		const clone = clone_plain(section);
 		delete clone.remove;
@@ -425,8 +415,20 @@ export function getStore(print_format_name) {
 		selected_section.value = clone;
 	}
 	function duplicate_selection() {
-		if (selected_field.value) duplicate_field(selected_field.value);
-		else if (selected_section.value) duplicate_section(selected_section.value);
+		if (selected_fields.value.length > 1) {
+			const clones = [];
+			selected_fields.value.slice().forEach((df) => {
+				selected_field.value = null;
+				duplicate_field(df);
+				if (selected_field.value) clones.push(selected_field.value);
+			});
+			selected_fields.value = clones;
+			selected_field.value = clones[clones.length - 1] || null;
+		} else if (selected_field.value) {
+			duplicate_field(selected_field.value);
+		} else if (selected_section.value) {
+			duplicate_section(selected_section.value);
+		}
 	}
 	function move_in_array(arr, item, dir) {
 		const i = arr.indexOf(item);
@@ -435,8 +437,31 @@ export function getStore(print_format_name) {
 		arr.splice(i, 1);
 		arr.splice(j, 0, item);
 	}
+	function move_fields_in_column(col, fields, dir) {
+		const selected = new Set(fields);
+		const ordered = fields
+			.slice()
+			.sort((a, b) => col.fields.indexOf(a) - col.fields.indexOf(b));
+		const seq = dir > 0 ? ordered.reverse() : ordered;
+		for (const df of seq) {
+			const i = col.fields.indexOf(df);
+			const j = i + dir;
+			if (j < 0 || j >= col.fields.length) continue;
+			if (selected.has(col.fields[j])) continue;
+			move_in_array(col.fields, df, dir);
+		}
+	}
 	function move_selection(dir) {
-		if (selected_field.value) {
+		if (selected_fields.value.length > 1) {
+			const groups = new Map();
+			selected_fields.value.forEach((df) => {
+				const col = find_field_column(df);
+				if (!col) return;
+				if (!groups.has(col)) groups.set(col, []);
+				groups.get(col).push(df);
+			});
+			groups.forEach((fields, col) => move_fields_in_column(col, fields, dir));
+		} else if (selected_field.value) {
 			const col = find_field_column(selected_field.value);
 			if (col) move_in_array(col.fields, selected_field.value, dir);
 		} else if (selected_section.value) {
@@ -444,8 +469,6 @@ export function getStore(print_format_name) {
 		}
 	}
 
-	// Style presets — a named bundle of the format's visual settings, persisted
-	// to localStorage so one look can be reused across print formats.
 	const style_presets = ref(load_style_presets());
 	function save_style_preset(name) {
 		name = (name || "").trim();
@@ -484,8 +507,6 @@ export function getStore(print_format_name) {
 
 		if (clip.type === "field") {
 			const clone = freshen_field(clone_plain(clip.data));
-			// Insert after the selected field in its column; else append to the
-			// selected section (or the last body section).
 			const col = selected_field.value && find_field_column(selected_field.value);
 			if (col) {
 				col.fields.splice(col.fields.indexOf(selected_field.value) + 1, 0, clone);
@@ -502,8 +523,6 @@ export function getStore(print_format_name) {
 			insert_section(clip.data);
 		}
 	}
-	// Clone a section, freshen its custom fields, and drop it in after the
-	// selected section (or at the end). Shared by paste and snippet insert.
 	function insert_section(data) {
 		if (!data || !layout.value) return;
 		const clone = clone_plain(data);

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -64,6 +64,23 @@ function persist_style_presets(list) {
 	}
 }
 
+// Section snippets — named, reusable sections shared across print formats.
+const SECTION_SNIPPETS_KEY = "pfb_section_snippets";
+function load_section_snippets() {
+	try {
+		return JSON.parse(localStorage.getItem(SECTION_SNIPPETS_KEY)) || [];
+	} catch {
+		return [];
+	}
+}
+function persist_section_snippets(list) {
+	try {
+		localStorage.setItem(SECTION_SNIPPETS_KEY, JSON.stringify(list));
+	} catch {
+		// ignore quota / privacy-mode failures; in-memory copy still works
+	}
+}
+
 // A pasted custom element (HTML/Image/Barcode block) gets a fresh fieldname so
 // duplicates don't collide; real doctype fields keep theirs.
 function freshen_field(f) {
@@ -453,16 +470,41 @@ export function getStore(print_format_name) {
 			selected_section.value = null;
 			selected_field.value = clone;
 		} else if (clip.type === "section") {
-			const clone = clone_plain(clip.data);
-			delete clone.remove;
-			(clone.columns || []).forEach((c) => (c.fields || []).forEach(freshen_field));
-			const sections = layout.value.sections;
-			const idx = selected_section.value ? sections.indexOf(selected_section.value) : -1;
-			if (idx !== -1) sections.splice(idx + 1, 0, clone);
-			else sections.push(clone);
-			selected_field.value = null;
-			selected_section.value = clone;
+			insert_section(clip.data);
 		}
+	}
+	// Clone a section, freshen its custom fields, and drop it in after the
+	// selected section (or at the end). Shared by paste and snippet insert.
+	function insert_section(data) {
+		if (!data || !layout.value) return;
+		const clone = clone_plain(data);
+		delete clone.remove;
+		(clone.columns || []).forEach((c) => (c.fields || []).forEach(freshen_field));
+		const sections = layout.value.sections;
+		const idx = selected_section.value ? sections.indexOf(selected_section.value) : -1;
+		if (idx !== -1) sections.splice(idx + 1, 0, clone);
+		else sections.push(clone);
+		selected_field.value = null;
+		selected_section.value = clone;
+	}
+
+	const section_snippets = ref(load_section_snippets());
+	function save_section_snippet(name, section) {
+		name = (name || "").trim();
+		if (!name || !section) return;
+		const list = section_snippets.value.filter((s) => s.name !== name);
+		list.push({ name, section: clone_plain(section) });
+		list.sort((a, b) => a.name.localeCompare(b.name));
+		section_snippets.value = list;
+		persist_section_snippets(list);
+	}
+	function insert_section_snippet(name) {
+		const snip = section_snippets.value.find((s) => s.name === name);
+		if (snip) insert_section(snip.section);
+	}
+	function delete_section_snippet(name) {
+		section_snippets.value = section_snippets.value.filter((s) => s.name !== name);
+		persist_section_snippets(section_snippets.value);
 	}
 
 	return {
@@ -509,6 +551,10 @@ export function getStore(print_format_name) {
 		save_style_preset,
 		apply_style_preset,
 		delete_style_preset,
+		section_snippets,
+		save_section_snippet,
+		insert_section_snippet,
+		delete_section_snippet,
 		paste_clipboard,
 		undo,
 		redo,

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -36,6 +36,34 @@ function clone_plain(obj) {
 	return JSON.parse(JSON.stringify(obj));
 }
 
+// Style presets — the visual settings a preset captures, plus its persistence.
+const STYLE_PRESETS_KEY = "pfb_style_presets";
+const STYLE_PRESET_KEYS = [
+	"font",
+	"font_size",
+	"label_color",
+	"value_color",
+	"margin_top",
+	"margin_right",
+	"margin_bottom",
+	"margin_left",
+	"page_number",
+];
+function load_style_presets() {
+	try {
+		return JSON.parse(localStorage.getItem(STYLE_PRESETS_KEY)) || [];
+	} catch {
+		return [];
+	}
+}
+function persist_style_presets(list) {
+	try {
+		localStorage.setItem(STYLE_PRESETS_KEY, JSON.stringify(list));
+	} catch {
+		// ignore quota / privacy-mode failures; in-memory copy still works
+	}
+}
+
 // A pasted custom element (HTML/Image/Barcode block) gets a fresh fieldname so
 // duplicates don't collide; real doctype fields keep theirs.
 function freshen_field(f) {
@@ -369,6 +397,30 @@ export function getStore(print_format_name) {
 			move_in_array(layout.value?.sections || [], selected_section.value, dir);
 		}
 	}
+
+	// Style presets — a named bundle of the format's visual settings, persisted
+	// to localStorage so one look can be reused across print formats.
+	const style_presets = ref(load_style_presets());
+	function save_style_preset(name) {
+		name = (name || "").trim();
+		if (!name || !print_format.value) return;
+		const style = {};
+		for (const key of STYLE_PRESET_KEYS) style[key] = print_format.value[key];
+		const list = style_presets.value.filter((p) => p.name !== name);
+		list.push({ name, style });
+		list.sort((a, b) => a.name.localeCompare(b.name));
+		style_presets.value = list;
+		persist_style_presets(list);
+	}
+	function apply_style_preset(name) {
+		const preset = style_presets.value.find((p) => p.name === name);
+		if (!preset || !print_format.value) return;
+		Object.assign(print_format.value, preset.style);
+	}
+	function delete_style_preset(name) {
+		style_presets.value = style_presets.value.filter((p) => p.name !== name);
+		persist_style_presets(style_presets.value);
+	}
 	function find_field_column(df) {
 		const lv = layout.value;
 		const zones = [lv?.header, lv?.footer, ...(lv?.sections || [])].filter(Boolean);
@@ -453,6 +505,10 @@ export function getStore(print_format_name) {
 		duplicate_section,
 		duplicate_selection,
 		move_selection,
+		style_presets,
+		save_style_preset,
+		apply_style_preset,
+		delete_style_preset,
 		paste_clipboard,
 		undo,
 		redo,

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -87,7 +87,6 @@ export function getStore(print_format_name) {
 	// variables
 	let print_format = ref(null);
 	let letterhead = ref(null);
-	let doctype = ref(null);
 	let meta = ref(null);
 	let layout = ref(null);
 	let dirty = ref(false);
@@ -204,9 +203,6 @@ export function getStore(print_format_name) {
 				},
 			],
 		};
-	}
-	function update({ fieldname, value }) {
-		print_format.value[fieldname] = value;
 	}
 	function save_changes() {
 		frappe.dom.freeze(__("Saving..."));
@@ -383,9 +379,13 @@ export function getStore(print_format_name) {
 		},
 		{ deep: true }
 	);
-	watch(print_format, () => {
-		dirty.value = true;
-	});
+	watch(
+		print_format,
+		() => {
+			dirty.value = true;
+		},
+		{ deep: true }
+	);
 
 	function copy_field(df) {
 		if (!df) return;
@@ -564,7 +564,6 @@ export function getStore(print_format_name) {
 	return {
 		print_format,
 		letterhead,
-		doctype,
 		meta,
 		layout,
 		dirty,
@@ -586,7 +585,6 @@ export function getStore(print_format_name) {
 		load_preview_doc,
 		persisted_preview_doc_name,
 		fetch,
-		update,
 		save_changes,
 		reset_changes,
 		get_preview_format_doc,

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -2,9 +2,28 @@ import { create_default_layout, serialize_layout } from "../utils";
 import { useLayoutHistory } from "./useLayoutHistory";
 import { watch, ref, inject, computed, nextTick } from "vue";
 
-// Copy/paste clipboard — module-level so a field or section copied in one print
-// format can be pasted into another.
-const clipboard = ref(null);
+// Copy/paste clipboard — persisted to localStorage so a field or section copied
+// in one print format can be pasted into another, even across reloads or tabs.
+const CLIPBOARD_KEY = "pfb_clipboard";
+
+function load_clipboard() {
+	try {
+		return JSON.parse(localStorage.getItem(CLIPBOARD_KEY)) || null;
+	} catch {
+		return null;
+	}
+}
+
+const clipboard = ref(load_clipboard());
+
+function set_clipboard(value) {
+	clipboard.value = value;
+	try {
+		localStorage.setItem(CLIPBOARD_KEY, JSON.stringify(value));
+	} catch {
+		// ignore quota / privacy-mode failures; in-memory copy still works
+	}
+}
 
 function clone_plain(obj) {
 	return JSON.parse(JSON.stringify(obj));
@@ -292,11 +311,11 @@ export function getStore(print_format_name) {
 
 	function copy_field(df) {
 		if (!df) return;
-		clipboard.value = { type: "field", data: clone_plain(df) };
+		set_clipboard({ type: "field", data: clone_plain(df) });
 	}
 	function copy_section(section) {
 		if (!section) return;
-		clipboard.value = { type: "section", data: clone_plain(section) };
+		set_clipboard({ type: "section", data: clone_plain(section) });
 	}
 	function copy_selection() {
 		if (selected_field.value) copy_field(selected_field.value);
@@ -313,7 +332,8 @@ export function getStore(print_format_name) {
 		return null;
 	}
 	function paste_clipboard() {
-		const clip = clipboard.value;
+		const clip = load_clipboard() || clipboard.value;
+		clipboard.value = clip;
 		if (!clip || !layout.value) return;
 
 		if (clip.type === "field") {

--- a/frappe/public/js/print_format_builder/stores/index.js
+++ b/frappe/public/js/print_format_builder/stores/index.js
@@ -270,6 +270,12 @@ export function getStore(print_format_name) {
 		selected_fields.value = [];
 		selected_field.value = null;
 	}
+	function remove_field(df) {
+		df.remove = true;
+		const rest = selected_fields.value.filter((f) => f !== df);
+		if (rest.length !== selected_fields.value.length) selected_fields.value = rest;
+		if (selected_field.value === df) selected_field.value = rest[rest.length - 1] || null;
+	}
 	function align_selected_fields(align) {
 		selected_fields.value.forEach((df) => (df.align = align));
 	}
@@ -568,6 +574,7 @@ export function getStore(print_format_name) {
 		selected_field,
 		selected_fields,
 		remove_selected_fields,
+		remove_field,
 		align_selected_fields,
 		selected_section,
 		selected_letterhead,

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -138,6 +138,16 @@ export function pluck(object, keys) {
 	return out;
 }
 
+// Smooth drag: use SortableJS's own clone instead of the browser's native HTML5
+// drag image (which jitters), and float it on <body> so overflow containers don't
+// clip it. Shared by every draggable in the builder for a consistent feel.
+export const DRAG_OPTIONS = {
+	forceFallback: true,
+	fallbackOnBody: true,
+	fallbackTolerance: 4,
+	fallbackClass: "pfb-drag-fallback",
+};
+
 export const TABLE_COLUMN_PLUCK_KEYS = [
 	"label",
 	"fieldname",

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -146,6 +146,7 @@ export const DRAG_OPTIONS = {
 	fallbackOnBody: true,
 	fallbackTolerance: 4,
 	fallbackClass: "pfb-drag-fallback",
+	ghostClass: "pfb-drag-ghost",
 };
 
 export const TABLE_COLUMN_PLUCK_KEYS = [

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -138,9 +138,6 @@ export function pluck(object, keys) {
 	return out;
 }
 
-// Smooth drag: use SortableJS's own clone instead of the browser's native HTML5
-// drag image (which jitters), and float it on <body> so overflow containers don't
-// clip it. Shared by every draggable in the builder for a consistent feel.
 export const DRAG_OPTIONS = {
 	forceFallback: true,
 	fallbackOnBody: true,
@@ -149,9 +146,6 @@ export const DRAG_OPTIONS = {
 	ghostClass: "pfb-drag-ghost",
 };
 
-// forceFallback drags with a real mousedown, which the browser treats as a text
-// selection. Suppress selection for the duration of the drag and clear any range
-// that already started. Wire to every draggable's @start/@end.
 export function setDragging(active) {
 	document.body.classList.toggle("pfb-dragging", active);
 	if (active) window.getSelection()?.removeAllRanges();

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -149,6 +149,14 @@ export const DRAG_OPTIONS = {
 	ghostClass: "pfb-drag-ghost",
 };
 
+// forceFallback drags with a real mousedown, which the browser treats as a text
+// selection. Suppress selection for the duration of the drag and clear any range
+// that already started. Wire to every draggable's @start/@end.
+export function setDragging(active) {
+	document.body.classList.toggle("pfb-dragging", active);
+	if (active) window.getSelection()?.removeAllRanges();
+}
+
 export const TABLE_COLUMN_PLUCK_KEYS = [
 	"label",
 	"fieldname",

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -148,6 +148,7 @@ export const TABLE_COLUMN_PLUCK_KEYS = [
 	"merged_fields",
 	"merge_direction",
 	"image_size",
+	"column_condition",
 ];
 
 export const FIELD_PLUCK_KEYS = [

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -1,4 +1,5 @@
-{% if doc.get(df.fieldname) %}
+{%- set _rows = df.get('_rows') if df.get('_rows') is not none else doc.get(df.fieldname) -%}
+{% if _rows and df.table_columns %}
 {% set _style = df.table_style or "lined" %}
 {% set _bordered = df.table_bordered != False %}
 {% set _plain_header = df.table_header == "plain" %}
@@ -35,7 +36,6 @@
 		</thead>
 		{%- endif -%}
 		<tbody>
-			{%- set _rows = df.get('_rows') if df.get('_rows') is not none else doc.get(df.fieldname) -%}
 			{% for row in _rows %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}"{% if row.get("page_break") and not loop.first %} style="page-break-before: always"{% endif %}>
 				{% for column in columns %}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -35,7 +35,8 @@
 		</thead>
 		{%- endif -%}
 		<tbody>
-			{% for row in doc.get(df.fieldname) %}
+			{%- set _rows = df.get('_rows') if df.get('_rows') is not none else doc.get(df.fieldname) -%}
+			{% for row in _rows %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}"{% if row.get("page_break") and not loop.first %} style="page-break-before: always"{% endif %}>
 				{% for column in columns %}
 				{# Column's own field is always the implicit primary line; merged_fields holds the extra fields. #}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -92,7 +92,7 @@
 	{%- if section.custom_style -%}
 		{%- set ns3.section_style = ns3.section_style + section.custom_style|string -%}
 	{%- endif -%}
-	<div class="section {{ resolve_class({'page-break': section.page_break}) }}{{ ' section--grid' if section.field_borders else '' }}{{ ' section--grid-' + section.grid_borders if section.field_borders and section.grid_borders else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style|e }}"{% endif %}>
+	<div class="section {{ resolve_class({'page-break': section.page_break, 'keep-together': section.keep_together}) }}{{ ' section--grid' if section.field_borders else '' }}{{ ' section--grid-' + section.grid_borders if section.field_borders and section.grid_borders else '' }}"{% if ns3.section_style %} style="{{ ns3.section_style|e }}"{% endif %}>
 		{% if section.label and section.show_label != 'hide' %}
 		<div class="section-label">{{ _(section.label) }}</div>
 		{% endif %}

--- a/frappe/templates/print_format/print_format.html
+++ b/frappe/templates/print_format/print_format.html
@@ -69,6 +69,11 @@
 				{%- if df.source and doc.get(df.source) -%}
 					{%- set ns.has_content = true -%}
 				{%- endif -%}
+			{%- elif df.fieldtype == 'Table' -%}
+				{%- set _tr = df.get('_rows') if df.get('_rows') is not none else doc.get(df.fieldname) -%}
+				{%- if _tr and df.table_columns -%}
+					{%- set ns.has_content = true -%}
+				{%- endif -%}
 			{%- elif doc.get(df.fieldname) -%}
 				{%- set ns.has_content = true -%}
 			{%- endif -%}

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -234,6 +234,28 @@
 	text-align: left;
 }
 
+/* numeric merged cells keep their right alignment */
+.print-format-doc .child-table [data-fieldtype="Currency"].column-value--merged,
+.print-format-doc .child-table [data-fieldtype="Float"].column-value--merged,
+.print-format-doc .child-table [data-fieldtype="Int"].column-value--merged {
+	text-align: right;
+}
+
+.print-format-doc .child-table [data-fieldtype="Currency"].column-value--merged .cell-merged,
+.print-format-doc .child-table [data-fieldtype="Float"].column-value--merged .cell-merged,
+.print-format-doc .child-table [data-fieldtype="Int"].column-value--merged .cell-merged,
+.print-format-doc .child-table [data-fieldtype="Currency"].column-value--merged .cell-lines--horizontal,
+.print-format-doc .child-table [data-fieldtype="Float"].column-value--merged .cell-lines--horizontal,
+.print-format-doc .child-table [data-fieldtype="Int"].column-value--merged .cell-lines--horizontal {
+	justify-content: flex-end;
+}
+
+.print-format-doc .child-table [data-fieldtype="Currency"].column-value--merged .cell-lines,
+.print-format-doc .child-table [data-fieldtype="Float"].column-value--merged .cell-lines,
+.print-format-doc .child-table [data-fieldtype="Int"].column-value--merged .cell-lines {
+	align-items: flex-end;
+}
+
 .print-format-doc .child-table .cell-merged {
 	display: flex;
 	align-items: flex-start;

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -1,4 +1,5 @@
-.print-format-doc .col, .print-format-doc *[class^="col-"] {
+.print-format-doc .col,
+.print-format-doc *[class^="col-"] {
 	max-width: none !important;
 }
 .print-format-doc {
@@ -114,11 +115,21 @@
 	flex: none;
 }
 
-.print-format-doc .field.left-right.field-align-right { justify-content: flex-end; }
-.print-format-doc .field.left-right.field-align-center { justify-content: center; }
-.print-format-doc .field.left-right.field-justify-space-between { justify-content: space-between; }
-.print-format-doc .field.left-right.field-justify-space-between .value { text-align: right; }
-.print-format-doc .field.left-right.field-justify-space-evenly { justify-content: space-evenly; }
+.print-format-doc .field.left-right.field-align-right {
+	justify-content: flex-end;
+}
+.print-format-doc .field.left-right.field-align-center {
+	justify-content: center;
+}
+.print-format-doc .field.left-right.field-justify-space-between {
+	justify-content: space-between;
+}
+.print-format-doc .field.left-right.field-justify-space-between .value {
+	text-align: right;
+}
+.print-format-doc .field.left-right.field-justify-space-evenly {
+	justify-content: space-evenly;
+}
 
 /* Repeater */
 .print-format-doc .pfb-repeater-table {
@@ -244,9 +255,18 @@
 .print-format-doc .child-table [data-fieldtype="Currency"].column-value--merged .cell-merged,
 .print-format-doc .child-table [data-fieldtype="Float"].column-value--merged .cell-merged,
 .print-format-doc .child-table [data-fieldtype="Int"].column-value--merged .cell-merged,
-.print-format-doc .child-table [data-fieldtype="Currency"].column-value--merged .cell-lines--horizontal,
-.print-format-doc .child-table [data-fieldtype="Float"].column-value--merged .cell-lines--horizontal,
-.print-format-doc .child-table [data-fieldtype="Int"].column-value--merged .cell-lines--horizontal {
+.print-format-doc
+	.child-table
+	[data-fieldtype="Currency"].column-value--merged
+	.cell-lines--horizontal,
+.print-format-doc
+	.child-table
+	[data-fieldtype="Float"].column-value--merged
+	.cell-lines--horizontal,
+.print-format-doc
+	.child-table
+	[data-fieldtype="Int"].column-value--merged
+	.cell-lines--horizontal {
 	justify-content: flex-end;
 }
 
@@ -388,7 +408,8 @@
 	width: 1.5em;
 }
 
-.print-format-doc .field[data-fieldtype="Long Text"] .value, .print-format-doc .field[data-fieldtype="Text"] .value {
+.print-format-doc .field[data-fieldtype="Long Text"] .value,
+.print-format-doc .field[data-fieldtype="Text"] .value {
 	white-space: pre-line;
 }
 

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -323,6 +323,11 @@
 	page-break-after: always;
 }
 
+.print-format-doc .section.keep-together {
+	page-break-inside: avoid;
+	break-inside: avoid;
+}
+
 /* Override Bootstrap's tr { page-break-inside: avoid } so tall child-table rows
    flow across pages; keep thead repeating on each new page. */
 @media print {

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -510,32 +510,29 @@ class PrintFormatGenerator:
 		from frappe.www.printview import column_has_value
 
 		eval_locals = {"doc": self.doc, "print_settings": self.print_settings}
-		for section in layout.get("sections", []):
-			for column in section.get("columns", []):
-				for df in column.get("fields", []):
-					if df.get("fieldtype") != "Table" or not df.get("table_columns"):
+		for column in self.layout_columns(layout):
+			for df in column.get("fields", []):
+				if df.get("fieldtype") != "Table" or not df.get("table_columns"):
+					continue
+				rows = df.get("_rows") if df.get("_rows") is not None else self.doc.get(df.get("fieldname"))
+				rows = rows or []
+				kept = []
+				for col in df["table_columns"]:
+					if not self.column_condition_met(col, eval_locals):
 						continue
-					rows = (
-						df.get("_rows") if df.get("_rows") is not None else self.doc.get(df.get("fieldname"))
-					)
-					rows = rows or []
-					kept = []
-					for col in df["table_columns"]:
-						if not self.column_condition_met(col, eval_locals):
-							continue
-						if (
-							rows
-							and col.get("fieldname") != "idx"
-							and not column_has_value(rows, col.get("fieldname"), frappe._dict(col))
-						):
-							continue
-						kept.append(col)
-					total = sum(col.get("width") or 0 for col in kept)
-					if total:
-						for col in kept:
-							if col.get("width"):
-								col["width"] = round(col["width"] / total * 100, 2)
-					df["table_columns"] = kept
+					if (
+						rows
+						and col.get("fieldname") != "idx"
+						and not column_has_value(rows, col.get("fieldname"), frappe._dict(col))
+					):
+						continue
+					kept.append(col)
+				total = sum(col.get("width") or 0 for col in kept)
+				if total:
+					for col in kept:
+						if col.get("width"):
+							col["width"] = round(col["width"] / total * 100, 2)
+				df["table_columns"] = kept
 		return layout
 
 	def column_condition_met(self, col, eval_locals):

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -557,7 +557,7 @@ class PrintFormatGenerator:
 		df["renderer"] = self._FIELD_RENDERERS.get(fieldtype) or fieldtype.replace(" ", "")
 		df["section"] = section
 		self.prepare_barcode(df)
-		self.filter_repeater_rows(df)
+		self.filter_conditional_rows(df)
 
 	def set_field_renderers(self, layout):
 		eval_locals = {"doc": self.doc, "print_settings": self.print_settings}
@@ -581,7 +581,7 @@ class PrintFormatGenerator:
 
 		return layout
 
-	def filter_repeater_rows(self, df):
+	def filter_conditional_rows(self, df):
 		"""Drop repeater/table rows whose row_condition is falsy; a bad expression fails
 		open (keeps the row) so a typo never silently blanks the table."""
 		fieldtype = df.get("fieldtype")

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -456,7 +456,7 @@ class PrintFormatGenerator:
 				print_format.page_number = "Bottom Center"
 		layout = self.apply_permlevel_access(layout)
 		layout = self.set_field_renderers(layout)
-		layout = self.prune_empty_table_columns(layout)
+		layout = self.prune_table_columns(layout)
 		layout = self.process_margin_texts(layout)
 		return layout
 
@@ -504,23 +504,29 @@ class PrintFormatGenerator:
 				]
 		return layout
 
-	def prune_empty_table_columns(self, layout):
+	def prune_table_columns(self, layout):
+		"""Drop table columns that fail their column_condition (doc-scoped) or that are
+		empty across all rows, then renormalize widths. A bad condition fails open."""
 		from frappe.www.printview import column_has_value
 
+		eval_locals = {"doc": self.doc, "print_settings": self.print_settings}
 		for section in layout.get("sections", []):
 			for column in section.get("columns", []):
 				for df in column.get("fields", []):
 					if df.get("fieldtype") != "Table" or not df.get("table_columns"):
 						continue
 					rows = self.doc.get(df.get("fieldname")) or []
-					if not rows:
-						continue
-					kept = [
-						col
-						for col in df["table_columns"]
-						if col.get("fieldname") == "idx"
-						or column_has_value(rows, col.get("fieldname"), frappe._dict(col))
-					]
+					kept = []
+					for col in df["table_columns"]:
+						if not self.column_condition_met(col, eval_locals):
+							continue
+						if (
+							rows
+							and col.get("fieldname") != "idx"
+							and not column_has_value(rows, col.get("fieldname"), frappe._dict(col))
+						):
+							continue
+						kept.append(col)
 					total = sum(col.get("width") or 0 for col in kept)
 					if total:
 						for col in kept:
@@ -528,6 +534,15 @@ class PrintFormatGenerator:
 								col["width"] = round(col["width"] / total * 100, 2)
 					df["table_columns"] = kept
 		return layout
+
+	def column_condition_met(self, col, eval_locals):
+		condition = col.get("column_condition")
+		if not condition:
+			return True
+		try:
+			return bool(frappe.safe_eval(condition, None, eval_locals))
+		except Exception:
+			return True
 
 	def _prepare_field(self, df, section, eval_locals):
 		if df.get("visible_if"):
@@ -564,14 +579,21 @@ class PrintFormatGenerator:
 		return layout
 
 	def filter_repeater_rows(self, df):
-		"""Drop repeater rows whose row_condition is falsy; a bad expression fails open
-		(keeps the row) so a typo never silently blanks the table."""
-		if df.get("fieldtype") != "Repeater" or not df.get("row_condition") or not df.get("source"):
+		"""Drop repeater/table rows whose row_condition is falsy; a bad expression fails
+		open (keeps the row) so a typo never silently blanks the table."""
+		fieldtype = df.get("fieldtype")
+		if fieldtype == "Repeater":
+			source = df.get("source")
+		elif fieldtype == "Table":
+			source = df.get("fieldname")
+		else:
+			return
+		if not df.get("row_condition") or not source:
 			return
 		condition = df["row_condition"]
 		eval_locals = {"doc": self.doc, "print_settings": self.print_settings}
 		kept = []
-		for row in self.doc.get(df["source"]) or []:
+		for row in self.doc.get(source) or []:
 			try:
 				keep = frappe.safe_eval(condition, None, {**eval_locals, "row": row})
 			except Exception:

--- a/frappe/utils/print_format_generator.py
+++ b/frappe/utils/print_format_generator.py
@@ -515,7 +515,10 @@ class PrintFormatGenerator:
 				for df in column.get("fields", []):
 					if df.get("fieldtype") != "Table" or not df.get("table_columns"):
 						continue
-					rows = self.doc.get(df.get("fieldname")) or []
+					rows = (
+						df.get("_rows") if df.get("_rows") is not None else self.doc.get(df.get("fieldname"))
+					)
+					rows = rows or []
 					kept = []
 					for col in df["table_columns"]:
 						if not self.column_condition_met(col, eval_locals):

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -45,6 +45,9 @@ SERVER_ONLY_CLASSES = {
 	# per-section "keep together" is page-break-inside:avoid — a pure pagination
 	# concern with no effect on the non-paginated canvas, so it's print-only
 	"keep-together",
+	# per-section "page break" is page-break-after:always — likewise pagination-only;
+	# the canvas renders a separate .page-break-indicator element, not this class
+	"page-break",
 }
 CANVAS_ONLY_CLASSES = set()
 

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -42,6 +42,9 @@ SERVER_ONLY_CLASSES = {
 	# opt-in colon after labels: driven by a Print Setting the builder canvas doesn't read,
 	# so the class is added to the print body only, never on the canvas
 	"show-label-colon",
+	# per-section "keep together" is page-break-inside:avoid — a pure pagination
+	# concern with no effect on the non-paginated canvas, so it's print-only
+	"keep-together",
 }
 CANVAS_ONLY_CLASSES = set()
 


### PR DESCRIPTION
Fixes and feature work for the beta print format builder.

### Fixes
- **Child-table conditional visibility** — per-row "Show row when" (`row.fieldname`) drops non-matching rows; per-column "Show column when" (`doc.fieldname`) drops the column and renormalizes widths. Both fail open on a bad expression, and `print_settings` is available like it is for repeaters.
- **Merged column alignment** — a merged numeric column (e.g. Quantity) keeps its right alignment instead of forcing left.
- **Cross-format copy-paste** — the builder clipboard is persisted to `localStorage`, so content copied in one format can be pasted into another across reloads/tabs.

### Outline
- Rebuilt the Outline tab into a selectable **section -> column -> field** tree with node icons and per-node collapse.
- Flags fields whose `fieldname` no longer exists on the doctype with a warning badge.

### Builder UX
- Smooth drag via the SortableJS fallback clone; drag placeholder is now a thin insertion line; no page text-selection during a drag.
- Persistent "Add a section" CTA on an empty canvas.
- **Duplicate** field/section (button + `Cmd/Ctrl+D`).
- **Nudge** the selected field/section with `Alt+Up/Down`.

### Sections & styling
- **Per-section print controls** — *Start on new page* and *Keep together* (`page-break-inside: avoid`).
- **Style presets** — save a format's font/colors/margins/page-number and reuse across formats.
- **Section snippets** — save any section as a named snippet and drop it into other formats.

### Multi-select
- `Cmd/Ctrl/Shift+click` fields in the canvas or outline; a bulk panel offers **align** and **remove** for the whole selection, and `Delete` clears them at once.

no-docs
