### PR TITLE
fix: get_list_context called twice when rendering a portal list

### DIFF
--- a/frappe/tests/test_portal.py
+++ b/frappe/tests/test_portal.py
@@ -1,0 +1,49 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.website.doctype.help_article import help_article
+from frappe.www import portal
+
+
+class TestPortalList(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		category = frappe.get_doc(doctype="Help Category", category_name="Test Portal Category").insert()
+		cls.article = frappe.get_doc(
+			doctype="Help Article",
+			title="Test Portal Article",
+			category=category.name,
+			content="content",
+			published=1,
+		).insert()
+
+	def setUp(self):
+		self.form_dict = frappe.local.form_dict
+		self.path = getattr(frappe.local, "path", None)
+		frappe.local.form_dict = frappe._dict(doctype="Help Article")
+		frappe.local.path = "kb"
+
+	def tearDown(self):
+		frappe.local.form_dict = self.form_dict
+		if self.path is None:
+			del frappe.local.path
+		else:
+			frappe.local.path = self.path
+
+	def test_list_context_is_resolved_once_per_render(self):
+		with patch.object(
+			help_article, "get_list_context", wraps=help_article.get_list_context
+		) as get_list_context:
+			context = portal.get_context(frappe._dict(), doctype="Help Article")
+
+		get_list_context.assert_called_once()
+		self.assertIn("meta", get_list_context.call_args.args[0])
+		self.assertTrue(context.row_template.endswith("help_article_row.html"))
+		self.assertTrue(any(self.article.route in row for row in context.result))
+
+	def test_list_context_is_not_taken_from_query_params(self):
+		frappe.local.form_dict.list_context = "injected"
+		context = portal.get_context(frappe._dict(), doctype="Help Article")
+		self.assertTrue(any(self.article.route in row for row in context.result))

--- a/frappe/tests/test_portal.py
+++ b/frappe/tests/test_portal.py
@@ -39,9 +39,18 @@ class TestPortalList(IntegrationTestCase):
 			context = portal.get_context(frappe._dict(), doctype="Help Article")
 
 		get_list_context.assert_called_once()
-		self.assertIn("meta", get_list_context.call_args.args[0])
 		self.assertTrue(context.row_template.endswith("help_article_row.html"))
 		self.assertTrue(any(self.article.route in row for row in context.result))
+
+	def test_page_context_does_not_leak_into_rows(self):
+		def get_list_context_returning_page_context(context):
+			context.row_template = "website/doctype/web_page/templates/web_page_row.html"
+			return context
+
+		with patch.object(help_article, "get_list_context", get_list_context_returning_page_context):
+			context = portal.get_context(frappe._dict(title="Knowledge Base", name="kb"))
+
+		self.assertTrue(any(self.article.title in row for row in context.result))
 
 	def test_list_context_is_not_taken_from_query_params(self):
 		frappe.local.form_dict.list_context = "injected"

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -24,6 +24,24 @@ def get_list_data(
 	**kwargs,
 ):
 	"""Return processed HTML page for a standard listing."""
+	list_context = get_list_context(frappe._dict(), doctype, web_form_name)
+	return get_list_data_for_context(
+		list_context, doctype, txt, limit_start, limit=limit, web_form_name=web_form_name, **kwargs
+	)
+
+
+def get_list_data_for_context(
+	list_context,
+	doctype: str,
+	txt: str | None = None,
+	limit_start: int = 0,
+	fields: list | None = None,
+	cmd: str | None = None,
+	limit: int = 20,
+	web_form_name: str | None = None,
+	**kwargs,
+):
+	"""Return rows for a standard listing, using an already resolved list context."""
 	limit_start = cint(limit_start)
 
 	if frappe.is_table(doctype):
@@ -37,7 +55,6 @@ def get_list_data(
 	meta = frappe.get_meta(doctype)
 
 	filters = prepare_filters(doctype, controller, kwargs)
-	list_context = get_list_context(frappe._dict(), doctype, web_form_name)
 	list_context.title_field = getattr(controller, "website", {}).get(
 		"page_title_field", meta.title_field or "name"
 	)

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -24,14 +24,14 @@ def get_list_data(
 	**kwargs,
 ):
 	"""Return processed HTML page for a standard listing."""
-	list_context = get_list_context(frappe._dict(), doctype, web_form_name)
 	return get_list_data_for_context(
-		list_context, doctype, txt, limit_start, limit=limit, web_form_name=web_form_name, **kwargs
+		None, doctype, txt, limit_start, limit=limit, web_form_name=web_form_name, **kwargs
 	)
 
 
 def get_list_data_for_context(
 	list_context,
+	/,
 	doctype: str,
 	txt: str | None = None,
 	limit_start: int = 0,
@@ -41,7 +41,7 @@ def get_list_data_for_context(
 	web_form_name: str | None = None,
 	**kwargs,
 ):
-	"""Return rows for a standard listing, using an already resolved list context."""
+	"""Return rows for a standard listing, resolving the list context if one is not given."""
 	limit_start = cint(limit_start)
 
 	if frappe.is_table(doctype):
@@ -55,6 +55,9 @@ def get_list_data_for_context(
 	meta = frappe.get_meta(doctype)
 
 	filters = prepare_filters(doctype, controller, kwargs)
+	if list_context is None:
+		list_context = get_list_context(frappe._dict(), doctype, web_form_name)
+
 	list_context.title_field = getattr(controller, "website", {}).get(
 		"page_title_field", meta.title_field or "name"
 	)

--- a/frappe/www/portal.py
+++ b/frappe/www/portal.py
@@ -4,7 +4,7 @@ import frappe
 from frappe import _, cint
 from frappe.model.document import Document
 from frappe.utils.data import quoted
-from frappe.www.list import get_list_context, get_list_data
+from frappe.www.list import get_list_context, get_list_data_for_context
 
 no_cache = 1
 
@@ -18,8 +18,12 @@ def get_context(context, **dict_params):
 		if frappe.session.user == "Guest" and not meta.allow_guest_to_view:
 			frappe.throw(_("Login to view"), frappe.PermissionError)
 		context.meta = meta
-		context.update(get_list_context(context, doctype) or {})
-		context.update(get(**frappe.local.form_dict))
+		list_context = get_list_context(context, doctype, frappe.local.form_dict.web_form_name)
+		context.update(list_context)
+
+		list_params = frappe.local.form_dict.copy()
+		list_params.pop("list_context", None)
+		context.update(get(list_context, **list_params))
 		context.home_page = "/portal"
 		context.doctype = frappe.local.form_dict.doctype
 	return context
@@ -36,6 +40,7 @@ def set_route(context):
 
 
 def get(
+	list_context,
 	doctype: str,
 	txt: str | None = None,
 	limit_start: int = 0,
@@ -45,13 +50,12 @@ def get(
 ):
 	"""Return processed HTML page for a standard listing."""
 	limit_start = cint(limit_start)
-	raw_result = get_list_data(doctype, txt, limit_start, limit=limit + 1, **kwargs)
+	raw_result = get_list_data_for_context(list_context, doctype, txt, limit_start, limit=limit + 1, **kwargs)
 	show_more = len(raw_result) > limit
 	if show_more:
 		raw_result = raw_result[:-1]
 
 	meta = frappe.get_meta(doctype)
-	list_context = frappe.flags.list_context
 
 	if not raw_result:
 		return {"result": [], "txt": txt}

--- a/frappe/www/portal.py
+++ b/frappe/www/portal.py
@@ -23,7 +23,7 @@ def get_context(context, **dict_params):
 
 		list_params = frappe.local.form_dict.copy()
 		list_params.pop("list_context", None)
-		context.update(get(list_context, **list_params))
+		context.update(get(list_context=list_context, **list_params))
 		context.home_page = "/portal"
 		context.doctype = frappe.local.form_dict.doctype
 	return context
@@ -40,12 +40,13 @@ def set_route(context):
 
 
 def get(
-	list_context,
 	doctype: str,
 	txt: str | None = None,
 	limit_start: int = 0,
 	limit: int = 20,
 	pathname: str | None = None,
+	*,
+	list_context,
 	**kwargs,
 ):
 	"""Return processed HTML page for a standard listing."""

--- a/frappe/www/portal.py
+++ b/frappe/www/portal.py
@@ -18,12 +18,9 @@ def get_context(context, **dict_params):
 		if frappe.session.user == "Guest" and not meta.allow_guest_to_view:
 			frappe.throw(_("Login to view"), frappe.PermissionError)
 		context.meta = meta
-		list_context = get_list_context(context, doctype, frappe.local.form_dict.web_form_name)
+		list_context = get_list_context(frappe._dict(), doctype, frappe.local.form_dict.web_form_name)
 		context.update(list_context)
-
-		list_params = frappe.local.form_dict.copy()
-		list_params.pop("list_context", None)
-		context.update(get(list_context=list_context, **list_params))
+		context.update(get(list_context, **frappe.local.form_dict))
 		context.home_page = "/portal"
 		context.doctype = frappe.local.form_dict.doctype
 	return context
@@ -40,17 +37,20 @@ def set_route(context):
 
 
 def get(
-	doctype: str,
+	list_context=None,
+	/,
+	doctype: str | None = None,
 	txt: str | None = None,
 	limit_start: int = 0,
 	limit: int = 20,
 	pathname: str | None = None,
-	*,
-	list_context,
 	**kwargs,
 ):
 	"""Return processed HTML page for a standard listing."""
 	limit_start = cint(limit_start)
+	if list_context is None:
+		list_context = get_list_context(frappe._dict(), doctype, kwargs.get("web_form_name"))
+
 	raw_result = get_list_data_for_context(list_context, doctype, txt, limit_start, limit=limit + 1, **kwargs)
 	show_more = len(raw_result) > limit
 	if show_more:


### PR DESCRIPTION
## Summary

Rendering a portal list page called the doctype's `get_list_context` hook twice, once while building the page context and again while loading the list data. 
This duplicated any work performed in the hook (such as queries or sidebar construction), and the second call received an empty context instead of the page context.

## Changes

- Split `get_list_data` into:
  - `get_list_data()`, the existing whitelisted entry point that resolves the context.
  - `get_list_data_for_context()`, which accepts an already resolved context.
- Update the portal render path to resolve the context once and pass it through.
- Pass `web_form_name` when resolving the portal context, preserving the previous behavior now that row rendering no longer reads `frappe.flags.list_context` directly.
- Keep `frappe.flags.list_context` set for compatibility with existing code.

## Notes

`portal.get()` now takes the resolved context as its first argument. Any apps calling it directly will need to update, though Frappe itself has no such callers.

Closes #23098.