### PR TITLE
fix: broken spacing in email templates

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -603,7 +603,7 @@ class User(Document):
 			template=template if not custom_template else None,
 			content=content if custom_template else None,
 			args=args,
-			header=[subject, "green"],
+			with_container=True,
 			delayed=(not now) if now is not None else self.flags.delay_emails,
 			retry=3,
 		)

--- a/frappe/core/doctype/user_invitation/user_invitation.py
+++ b/frappe/core/doctype/user_invitation/user_invitation.py
@@ -59,6 +59,7 @@ class UserInvitation(Document):
 			subject=_("Invitation to join {0} cancelled").format(email_title),
 			template="user_invitation_cancelled",
 			args={"title": email_title},
+			with_container=True,
 			now=True,
 		)
 		return True
@@ -76,6 +77,7 @@ class UserInvitation(Document):
 			subject=_("Invitation to join {0} expired").format(email_title),
 			template="user_invitation_expired",
 			args={"title": email_title},
+			with_container=True,
 			now=False,
 		)
 
@@ -113,6 +115,7 @@ class UserInvitation(Document):
 			subject=_("You've been invited to join {0}").format(email_title),
 			template="user_invitation",
 			args={"title": email_title, "invite_link": invite_link},
+			with_container=True,
 			now=True,
 		)
 		self.db_set("email_sent_at", frappe.utils.now())

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -431,6 +431,7 @@ def get_formatted_html(
 		params.update(
 			{
 				"brand_logo": get_brand_logo(email_account) if with_container or header else None,
+				"brand_name": get_brand_name() if with_container or header else None,
 				"with_container": with_container,
 				"header": get_header(header),
 				"content": message,
@@ -697,3 +698,7 @@ def sanitize_email_header(header: str):
 
 def get_brand_logo(email_account):
 	return email_account.get("brand_logo")
+
+
+def get_brand_name():
+	return frappe.get_website_settings("app_name") or frappe.get_system_settings("app_name")

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -697,7 +697,7 @@ def sanitize_email_header(header: str):
 
 
 def get_brand_logo(email_account):
-	return email_account.get("brand_logo")
+	return (email_account and email_account.get("brand_logo")) or frappe.get_website_settings("app_logo")
 
 
 def get_brand_name():

--- a/frappe/email/test_email_body.py
+++ b/frappe/email/test_email_body.py
@@ -181,7 +181,7 @@ w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 """
 		transformed_html = """
 <h3>Hi John</h3>
-<p style="margin:1em 0 !important">This is a test email</p>
+<p style="margin:0 0 1em !important">This is a test email</p>
 """
 		self.assertTrue(transformed_html in inline_style_in_html(html))
 

--- a/frappe/public/scss/email.bundle.scss
+++ b/frappe/public/scss/email.bundle.scss
@@ -28,6 +28,11 @@ $border-radius-lg: 8px;
 $orange-bg: #ffeae1;
 $orange-color: #cb5a2a;
 
+$canvas-bg: #f5f4f2;
+$card-border: #ededed;
+$hairline: #f0f0f0;
+$body-text: #525252;
+
 body {
 	line-height: 1.5;
 	color: $text-color;
@@ -45,6 +50,7 @@ p {
 	p {
 		margin: 0 0 16px !important;
 		line-height: 1.6;
+		color: $body-text;
 	}
 }
 
@@ -71,14 +77,14 @@ hr {
 	font-size: 14px;
 	line-height: 1.4;
 	.brand-logo {
-		margin: auto;
-		text-align: center;
+		margin: 0;
+		text-align: left;
 		border: 0;
 		outline: none;
 		text-decoration: none;
-		max-height: 40px;
+		max-height: 28px;
 		width: auto;
-		margin-bottom: 24px;
+		display: block;
 	}
 	td {
 		font-family: $font-stack;
@@ -120,27 +126,40 @@ hr {
 }
 
 .email-header-title {
-	margin: 0 0 20px !important;
-	font-size: 18px;
-	font-weight: 600;
-	line-height: 1.3;
+	margin: 0 0 16px !important;
+	font-size: 20px;
+	font-weight: 700;
+	line-height: 1.25;
+	letter-spacing: -0.02em;
 	color: $gray-900;
 }
 
 .body-table.with-container {
-	background-color: $gray-100;
+	background-color: $canvas-bg;
 	color: $text-color;
 	.body-content {
-		padding: 60px 40px;
+		padding: 48px 24px;
 	}
 	.email-container {
 		max-width: 600px;
 		border-spacing: 0;
-		padding: 40px;
 		border-radius: 12px;
-		border: 1px solid $gray-200;
+		border: 1px solid $card-border;
 		overflow: hidden;
 		background-color: white;
+		.email-masthead {
+			padding: 24px 36px 20px;
+			border-bottom: 1px solid $hairline;
+		}
+		.email-title-cell {
+			padding: 28px 36px 0;
+		}
+		.email-body-cell {
+			padding: 8px 36px 12px;
+		}
+		.email-footer-cell {
+			padding: 0 36px 28px;
+		}
 		.email-body {
 			border-radius: 0 0 4px 4px;
 			border-top: none;
@@ -159,11 +178,22 @@ hr {
 @media only screen and (max-width: 700px) {
 	.body-table.with-container {
 		.body-content {
-			padding: 30px 20px;
+			padding: 24px 12px;
 		}
 		.email-container {
-			padding: 20px;
 			width: auto;
+			.email-masthead {
+				padding: 20px 24px 16px;
+			}
+			.email-title-cell {
+				padding: 24px 24px 0;
+			}
+			.email-body-cell {
+				padding: 8px 24px 12px;
+			}
+			.email-footer-cell {
+				padding: 0 24px 24px;
+			}
 		}
 	}
 }
@@ -171,10 +201,10 @@ hr {
 .email-footer-container {
 	font-size: 12px;
 	line-height: 1.6;
-	color: $text-muted;
+	color: $gray-500;
 
 	&.with-divider {
-		margin-top: 32px;
+		margin-top: 24px;
 		padding-top: 16px;
 		border-top: 1px solid $gray-100;
 	}
@@ -186,15 +216,16 @@ hr {
 
 .verification-code {
 	display: inline-block;
-	font-size: 24px;
-	font-weight: 600;
-	letter-spacing: 6px;
+	font-family: "SF Mono", "Menlo", "Consolas", monospace;
+	font-size: 32px;
+	font-weight: 700;
+	letter-spacing: 0.18em;
 	color: $gray-900;
-	background-color: $gray-50;
-	border: 1px solid $gray-200;
-	border-radius: $border-radius-lg;
-	padding: 12px 18px 12px 24px;
-	margin: 4px 0 16px;
+	background-color: $canvas-bg;
+	border: 1px solid #e5e4e1;
+	border-radius: 10px;
+	padding: 18px 26px 18px 32px;
+	margin: 4px 0 20px;
 }
 
 .email-unsubscribe a {
@@ -204,21 +235,22 @@ hr {
 
 .btn {
 	text-decoration: none;
-	padding: 10px 20px;
-	font-size: 14px;
-	font-weight: 500;
+	padding: 11px 22px;
+	font-size: 13px;
+	font-weight: 600;
+	letter-spacing: -0.01em;
 	border: 1px solid;
-	border-radius: $border-radius;
+	border-radius: $border-radius-lg;
 	color: $gray-800;
 	background-color: $gray-100;
 	border-color: transparent;
 	display: inline-block;
-	line-height: 20px;
+	line-height: 18px;
 	margin: 8px 0;
 
 	&.btn-primary {
 		color: #fff;
-		background-color: $primary;
+		background-color: $gray-900;
 	}
 }
 

--- a/frappe/public/scss/email.bundle.scss
+++ b/frappe/public/scss/email.bundle.scss
@@ -88,6 +88,8 @@ hr {
 		vertical-align: middle;
 	}
 	.email-masthead a {
+		display: flex;
+		align-items: center;
 		text-decoration: none;
 		color: $gray-900;
 	}

--- a/frappe/public/scss/email.bundle.scss
+++ b/frappe/public/scss/email.bundle.scss
@@ -105,6 +105,15 @@ hr {
 .email-body {
 	font-size: 14px;
 	color: $text-color;
+	a:not(.btn) {
+		color: $gray-900;
+		font-weight: 600;
+		text-decoration: underline;
+	}
+	.text-muted a {
+		color: $text-muted !important;
+		font-weight: normal !important;
+	}
 	.gray-container {
 		background-color: $gray-50;
 		border-radius: $border-radius-lg;
@@ -155,10 +164,20 @@ hr {
 			padding: 28px 36px 0;
 		}
 		.email-body-cell {
-			padding: 8px 36px 12px;
+			padding: 8px 36px 28px;
 		}
 		.email-footer-cell {
-			padding: 0 36px 28px;
+			padding: 0 36px;
+		}
+		.email-footer-cell.filled {
+			background-color: #fafafa;
+			border-top: 1px solid $gray-100;
+			padding: 18px 36px 22px;
+		}
+		.email-footer-cell.filled .email-footer-container.with-divider {
+			margin-top: 0;
+			padding-top: 0;
+			border-top: none;
 		}
 		.email-body {
 			border-radius: 0 0 4px 4px;
@@ -189,10 +208,13 @@ hr {
 				padding: 24px 24px 0;
 			}
 			.email-body-cell {
-				padding: 8px 24px 12px;
+				padding: 8px 24px 24px;
 			}
 			.email-footer-cell {
-				padding: 0 24px 24px;
+				padding: 0 24px;
+			}
+			.email-footer-cell.filled {
+				padding: 16px 24px 20px;
 			}
 		}
 	}

--- a/frappe/public/scss/email.bundle.scss
+++ b/frappe/public/scss/email.bundle.scss
@@ -102,7 +102,7 @@ hr {
 	.gray-container {
 		background-color: $gray-50;
 		border-radius: $border-radius-lg;
-		padding: 25px 15px;
+		padding: 16px 20px;
 	}
 }
 
@@ -182,6 +182,19 @@ hr {
 	& > div:not(:last-child) {
 		margin-bottom: 4px;
 	}
+}
+
+.verification-code {
+	display: inline-block;
+	font-size: 24px;
+	font-weight: 600;
+	letter-spacing: 6px;
+	color: $gray-900;
+	background-color: $gray-50;
+	border: 1px solid $gray-200;
+	border-radius: $border-radius-lg;
+	padding: 12px 18px 12px 24px;
+	margin: 4px 0 16px;
 }
 
 .email-unsubscribe a {
@@ -310,6 +323,21 @@ hr {
 /* auto email report */
 .report-title {
 	margin-bottom: 20px;
+}
+
+/* document follow */
+.follow-panel {
+	margin-bottom: 16px;
+}
+
+.follow-panel-title {
+	margin-bottom: 8px;
+	font-weight: 600;
+}
+
+.follow-timeline {
+	margin: 0;
+	line-height: 1.7;
 }
 
 /* csslint ignore:end */

--- a/frappe/public/scss/email.bundle.scss
+++ b/frappe/public/scss/email.bundle.scss
@@ -43,7 +43,8 @@ p {
 
 .with-container {
 	p {
-		margin: 0 0 12px !important;
+		margin: 0 0 16px !important;
+		line-height: 1.6;
 	}
 }
 
@@ -77,7 +78,7 @@ hr {
 		text-decoration: none;
 		max-height: 40px;
 		width: auto;
-		margin-bottom: 16px;
+		margin-bottom: 24px;
 	}
 	td {
 		font-family: $font-stack;
@@ -119,9 +120,11 @@ hr {
 }
 
 .email-header-title {
-	margin: 0 0 16px !important;
-	font-size: 20px;
+	margin: 0 0 20px !important;
+	font-size: 18px;
 	font-weight: 600;
+	line-height: 1.3;
+	color: $gray-900;
 }
 
 .body-table.with-container {
@@ -133,8 +136,9 @@ hr {
 	.email-container {
 		max-width: 600px;
 		border-spacing: 0;
-		padding: 30px;
-		border-radius: $border-radius-lg;
+		padding: 40px;
+		border-radius: 12px;
+		border: 1px solid $gray-200;
 		overflow: hidden;
 		background-color: white;
 		.email-body {
@@ -165,10 +169,18 @@ hr {
 }
 
 .email-footer-container {
-	margin-top: 40px;
+	font-size: 12px;
+	line-height: 1.6;
+	color: $text-muted;
+
+	&.with-divider {
+		margin-top: 32px;
+		padding-top: 16px;
+		border-top: 1px solid $gray-100;
+	}
 
 	& > div:not(:last-child) {
-		margin-bottom: 5px;
+		margin-bottom: 4px;
 	}
 }
 
@@ -179,15 +191,17 @@ hr {
 
 .btn {
 	text-decoration: none;
-	padding: 8px 16px;
+	padding: 10px 20px;
 	font-size: 14px;
+	font-weight: 500;
 	border: 1px solid;
 	border-radius: $border-radius;
-	color: $white;
-	background-color: $gray-500;
+	color: $gray-800;
+	background-color: $gray-100;
 	border-color: transparent;
 	display: inline-block;
 	line-height: 20px;
+	margin: 8px 0;
 
 	&.btn-primary {
 		color: #fff;
@@ -432,10 +446,10 @@ blockquote {
 
 .indicator {
 	display: inline-block;
-	width: 10px;
-	height: 10px;
+	width: 8px;
+	height: 8px;
 	border-radius: 50%;
-	margin-right: 6px;
+	margin-right: 8px;
 	vertical-align: middle;
 }
 

--- a/frappe/public/scss/email.bundle.scss
+++ b/frappe/public/scss/email.bundle.scss
@@ -77,14 +77,27 @@ hr {
 	font-size: 14px;
 	line-height: 1.4;
 	.brand-logo {
-		margin: 0;
+		margin: 0 10px 0 0;
 		text-align: left;
 		border: 0;
 		outline: none;
 		text-decoration: none;
 		max-height: 28px;
 		width: auto;
-		display: block;
+		display: inline-block;
+		vertical-align: middle;
+	}
+	.email-masthead a {
+		text-decoration: none;
+		color: $gray-900;
+	}
+	.brand-name {
+		display: inline-block;
+		vertical-align: middle;
+		font-size: 15px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: $gray-900;
 	}
 	td {
 		font-family: $font-stack;
@@ -248,6 +261,20 @@ hr {
 	border-radius: 10px;
 	padding: 18px 26px 18px 32px;
 	margin: 4px 0 20px;
+}
+
+.callout {
+	border-radius: $border-radius-lg;
+	padding: 14px 16px;
+	font-size: 12px;
+	line-height: 1.6;
+	margin: 20px 0 16px;
+}
+
+.callout-warning {
+	background-color: #fff8f0;
+	border: 1px solid #fde8c7;
+	color: #8a5a00;
 }
 
 .email-unsubscribe a {

--- a/frappe/public/scss/email.bundle.scss
+++ b/frappe/public/scss/email.bundle.scss
@@ -38,12 +38,12 @@ a {
 }
 
 p {
-	margin: 1em 0 !important;
+	margin: 0 0 1em !important;
 }
 
 .with-container {
 	p {
-		margin: 5px 0 !important;
+		margin: 0 0 12px !important;
 	}
 }
 
@@ -77,7 +77,7 @@ hr {
 		text-decoration: none;
 		max-height: 40px;
 		width: auto;
-		margin-bottom: 10px;
+		margin-bottom: 16px;
 	}
 	td {
 		font-family: $font-stack;
@@ -119,7 +119,7 @@ hr {
 }
 
 .email-header-title {
-	margin-top: 20px !important;
+	margin: 0 0 16px !important;
 	font-size: 20px;
 	font-weight: 600;
 }
@@ -179,8 +179,8 @@ hr {
 
 .btn {
 	text-decoration: none;
-	padding: 4px 20px;
-	font-size: 13px;
+	padding: 8px 16px;
+	font-size: 14px;
 	border: 1px solid;
 	border-radius: $border-radius;
 	color: $white;

--- a/frappe/templates/emails/account_deletion_notification.html
+++ b/frappe/templates/emails/account_deletion_notification.html
@@ -1,4 +1,2 @@
 <p>{{_("Dear User,")}}</p>
-<br>
 <p>{{_("As per your request, your account and data on {0} associated with email {1} has been permanently deleted").format(host_name, email)}}.</p>
-

--- a/frappe/templates/emails/auto_reply.html
+++ b/frappe/templates/emails/auto_reply.html
@@ -1,7 +1,6 @@
 <h3>{{ _("Thank you for your email") }}</h3>
 <p>{{ _("Your query has been received. We will reply back shortly. If you have any additional information, please reply to this mail.") }}</p>
 <p>{{ _("Reference: {0} {1}").format(reference_doctype, reference_name) }}</p>
-<p style="font-size: 80%; color: #888">
+<div class="more-info">
 	{{ _("This is an automatically generated reply") }}
-</p>
-
+</div>

--- a/frappe/templates/emails/data_deletion_approval.html
+++ b/frappe/templates/emails/data_deletion_approval.html
@@ -1,8 +1,5 @@
 <p>{{_("User {0} has requested for data deletion").format(user)}}.</p>
 <p>{{_("Click on the link below to approve the request")}}.</p>
-
-<p style="margin: 30px 0px;">
-    <a href="{{ url }}" rel="nofollow" class="btn btn-primary btn-sm primary-action" style="padding: 8px 20px;">
-        {{ _("Confirm Request") }}
-    </a>
+<p>
+	<a href="{{ url }}" rel="nofollow" class="btn btn-primary">{{ _("Confirm Request") }}</a>
 </p>

--- a/frappe/templates/emails/delete_data_confirmation.html
+++ b/frappe/templates/emails/delete_data_confirmation.html
@@ -2,11 +2,10 @@
 <p>{{_("We have received a request for deletion of {0} data associated with: {1}").format(host_name, email)}}.</p>
 <p>{{_("This will permanently remove your data.")}}</p>
 <p>{{_("Click on the link below to verify your request")}}.</p>
-
-<p style="margin: 30px 0px;">
-    <a href="{{ link }}" rel="nofollow" class="btn btn-primary btn-sm primary-action" style="padding: 8px 20px;">{{ _("Confirm Request") }}</a>
+<p>
+	<a href="{{ link }}" rel="nofollow" class="btn btn-primary">{{ _("Confirm Request") }}</a>
 </p>
-<p style="font-size: 85%;">
-    {% set verification_link = '<a href="{{ link }}">' + _("Verification Link") + '</a>' %}
-    {{_("You can also copy-paste this {0} to your browser").format(verification_link) }}
+<p class="text-muted text-small">
+	{% set verification_link = '<a href="' + link + '">' + _("Verification Link") + '</a>' %}
+	{{_("You can also copy-paste this {0} to your browser").format(verification_link) }}
 </p>

--- a/frappe/templates/emails/document_follow.html
+++ b/frappe/templates/emails/document_follow.html
@@ -1,8 +1,4 @@
-<table border="0" cellpadding="0" cellspacing="0" width="100%">
-	<tr>
-		<h3>Document Follow Notification</h3>
-	</tr>
-</table>
+<h3>Document Follow Notification</h3>
 {% for doc in docinfo%}
 <table class="panel-header" border="0" cellpadding="0" cellspacing="0" width="100%">
 	<tr height="10"></tr>

--- a/frappe/templates/emails/document_follow.html
+++ b/frappe/templates/emails/document_follow.html
@@ -1,84 +1,54 @@
 <h3>Document Follow Notification</h3>
-{% for doc in docinfo%}
-<table class="panel-header" border="0" cellpadding="0" cellspacing="0" width="100%">
-	<tr height="10"></tr>
-	<tr>
-		<td width="15"></td>
-		<td>
-			<div class="text-medium text-muted">
-				<span><a href="{{doc.reference_url}}">{{ doc.reference_doctype }}: {{doc.reference_docname }}</a></span>
-			</div>
-		</td>
-		<td width="15"></td>
-	</tr>
-	<tr height="10"></tr>
-</table>
-<table class="panel-body" border="0" cellpadding="0" cellspacing="0" width="100%">
-	<tr height="10"></tr>
-	<tr>
-		<td width="15"></td>
-		<td>
-			<div>
-				<ul class="list-unstyled" style="line-height: 1.7">
-					{% for data in timeline %}
-						{% if (data.doctype == doc.reference_doctype and data.doc_name == doc.reference_docname) %}
-							{% if data.type == "comment" %}
-								<li>
-									<span style ='color:#8d99a6!important'>
-										{{data.data.time}}:
-									</span>
-									<b>"{{data.data.comment}}"</b>
-									{{data.data.by}}
-								</li>
-							{% elif data.type == "row added" %}
-								<li>
-									<span style ='color:#8d99a6!important'>
-										{{data.data.time}}:
-									</span>
-									Row Added to Table Field
-									<b>{{data.data.to}}</b>
-									By:
-									<b>{{data.by}}</b>
-								</li>
-							{% elif data.type == "field changed" %}
-								<li>
-									<span style ='color:#8d99a6!important'>
-										{{data.data.time}}:
-									</span>Field:
-									<b>"{{data.data.field}}"</b>
-									changed from
-									<b>"{{data.data.from}}"</b>
-									to
-									<b>"{{data.data.to}}"</b>
-									By:
-									<b>{{data.by}}</b>
-								</li>
-							{% elif data.type == "row changed" %}
-								<li>
-									<span style ='color:#8d99a6!important'>
-										{{data.data.time}}:
-									</span>
-									Table Field:
-									<b>"{{data.data.table_field}}"</b>
-									Row# {{data.data.row}} Field:
-									<b>"{{data.data.field}}"</b>
-									changed from
-									<b>"{{data.data.from}}" </b>
-									to <b>"{{data.data.to}}"</b>
-									By:
-									<b>{{data.by}}</b>
-								</li>
-							{% endif %}
-						{% endif %}
-					{% endfor %}
-				</ul>
-			</div>
-		</td>
-		<td width="15"></td>
-	</tr>
-	<tr height="10"></tr>
-</table>
-<table border="0" cellpadding="0" cellspacing="0" width="100%">
-	<tr height="20"></tr>
-</table>
+{% for doc in docinfo %}
+<div class="gray-container follow-panel">
+	<div class="follow-panel-title text-medium">
+		<a href="{{doc.reference_url}}">{{ doc.reference_doctype }}: {{ doc.reference_docname }}</a>
+	</div>
+	<ul class="list-unstyled follow-timeline">
+		{% for data in timeline %}
+			{% if (data.doctype == doc.reference_doctype and data.doc_name == doc.reference_docname) %}
+				{% if data.type == "comment" %}
+					<li>
+						<span class="text-muted">{{data.data.time}}:</span>
+						<b>"{{data.data.comment}}"</b>
+						{{data.data.by}}
+					</li>
+				{% elif data.type == "row added" %}
+					<li>
+						<span class="text-muted">{{data.data.time}}:</span>
+						Row Added to Table Field
+						<b>{{data.data.to}}</b>
+						By:
+						<b>{{data.by}}</b>
+					</li>
+				{% elif data.type == "field changed" %}
+					<li>
+						<span class="text-muted">{{data.data.time}}:</span>
+						Field:
+						<b>"{{data.data.field}}"</b>
+						changed from
+						<b>"{{data.data.from}}"</b>
+						to
+						<b>"{{data.data.to}}"</b>
+						By:
+						<b>{{data.by}}</b>
+					</li>
+				{% elif data.type == "row changed" %}
+					<li>
+						<span class="text-muted">{{data.data.time}}:</span>
+						Table Field:
+						<b>"{{data.data.table_field}}"</b>
+						Row# {{data.data.row}} Field:
+						<b>"{{data.data.field}}"</b>
+						changed from
+						<b>"{{data.data.from}}"</b>
+						to <b>"{{data.data.to}}"</b>
+						By:
+						<b>{{data.by}}</b>
+					</li>
+				{% endif %}
+			{% endif %}
+		{% endfor %}
+	</ul>
+</div>
 {% endfor %}

--- a/frappe/templates/emails/download_data.html
+++ b/frappe/templates/emails/download_data.html
@@ -1,10 +1,9 @@
 <p>{{_("Dear {0}").format(user_name)}},</p>
 <p>{{_("We have received a request from you to download your {0} data associated with: {1}").format(host_name, user)}}.</p>
 <p>{{_("Click on the link below to download your data")}}.</p>
-
-<p style="margin: 30px 0px;">
-    <a href="{{ link }}" rel="nofollow" class="btn btn-primary btn-sm primary-action" style="padding: 8px 20px;">{{ _("Download Data") }}</a>
+<p>
+	<a href="{{ link }}" rel="nofollow" class="btn btn-primary">{{ _("Download Data") }}</a>
 </p>
-<p style="font-size: 85%;">
-    {{_("You can also copy-paste this")}} <a href="{{ link }}">{{_("Download Link")}}</a> {{_("to your browser")}}
+<p class="text-muted text-small">
+	{{_("You can also copy-paste this")}} <a href="{{ link }}">{{_("Download Link")}}</a> {{_("to your browser")}}
 </p>

--- a/frappe/templates/emails/email_footer.html
+++ b/frappe/templates/emails/email_footer.html
@@ -1,4 +1,4 @@
-<div class="email-footer-container text-muted">
+<div class="email-footer-container text-muted {% if email_account_footer or sender_address or default_mail_footer %}with-divider{% endif %}">
 	<!-- email_account_footer -->
 	{% if email_account_footer %}
 	<div class="email-account-footer">

--- a/frappe/templates/emails/file_backup_notification.html
+++ b/frappe/templates/emails/file_backup_notification.html
@@ -1,6 +1,4 @@
-Hello,
-
-<br>
-<p> {{ _("Please use following links to download file backup.") }} </p>
-<p> {{ _("Public Files Backup:") }} <a href='{{ backup_path_files }}'>{{ backup_path_files }}</a> </p>
-<p> {{ _("Private Files Backup:") }} <a href='{{ backup_path_private_files }}'>{{ backup_path_private_files }}</a> </p>
+<p>{{ _("Hello,") }}</p>
+<p>{{ _("Please use following links to download file backup.") }}</p>
+<p>{{ _("Public Files Backup:") }} <a href='{{ backup_path_files }}'>{{ backup_path_files }}</a></p>
+<p>{{ _("Private Files Backup:") }} <a href='{{ backup_path_private_files }}'>{{ backup_path_private_files }}</a></p>

--- a/frappe/templates/emails/login_with_email_link.html
+++ b/frappe/templates/emails/login_with_email_link.html
@@ -1,5 +1,6 @@
-<h1 class="email-header-title">{{ _('Click on the button to log in to {0}').format(app_name) }}</h1>
-<p class="text-muted">{{ _('The link will expire in {0} minutes').format(minutes) }}</p>
+<h1 class="email-header-title">{{ _("Log in to {0}").format(app_name) }}</h1>
+<p>{{ _("Click the button below to sign in to your account. This link will expire in {0} minutes.").format(minutes) }}</p>
 <p>
-	<a href="{{ link or '#'}}" class="btn btn-primary">{{ _('Log In To {0}').format(app_name) }}</a>
+	<a href="{{ link or '#'}}" class="btn btn-primary">{{ _("Log In to {0}").format(app_name) }}</a>
 </p>
+<p class="text-muted text-small">{{ _("If you didn't request this link, you can ignore this email. Someone may have entered your email address by mistake.") }}</p>

--- a/frappe/templates/emails/login_with_email_link.html
+++ b/frappe/templates/emails/login_with_email_link.html
@@ -1,39 +1,5 @@
-{% macro table(content, table_class) %}
-<table class="{{ table_class or '' }}" cellpadding="0" cellspacing="0" width="100%" align="center">
-	<tbody>
-		<tr>
-			<td align="center">
-				{{ content }}
-			</td>
-		</tr>
-	</tbody>
-</table>
-{% endmacro %}
-
-{% macro body() %}
-<table width="100%" cellspacing="0" cellpadding="0">
-	<tbody>
-		<tr>
-			<td align="center">
-				<div class="email-header-title">
-					{{ _('Click on the button to log in to {0}').format(app_name) }}
-				</div>
-				<div>{{ _('The link will expire in {0} minutes').format(minutes) }}</div>
-			</td>
-		</tr>
-		<tr>
-			<td align="center">
-				<a href="{{ link or '#'}}" class="btn btn-primary" style="background-color: #171717; text-decoration: none; margin-top: 30px;">
-					{{ _('Log In To {0}').format(app_name) }}
-				</a>
-			</td>
-		</tr>
-	</tbody>
-</table>
-{% endmacro %}
-
-<div class="body-table with-container">
-	<div class="body-content">
-		{{ table(table(body(), 'email-body'), 'email-container') }}
-	</div>
-</div>
+<h1 class="email-header-title">{{ _('Click on the button to log in to {0}').format(app_name) }}</h1>
+<p class="text-muted">{{ _('The link will expire in {0} minutes').format(minutes) }}</p>
+<p>
+	<a href="{{ link or '#'}}" class="btn btn-primary">{{ _('Log In To {0}').format(app_name) }}</a>
+</p>

--- a/frappe/templates/emails/new_notification.html
+++ b/frappe/templates/emails/new_notification.html
@@ -1,6 +1,4 @@
-<p>
-	<p class="text-color">{{ body_content }}</p>
-</p>
+<p>{{ body_content }}</p>
 {% if description %}
 <blockquote>
 	{{ description | markdown }}

--- a/frappe/templates/emails/new_user.html
+++ b/frappe/templates/emails/new_user.html
@@ -1,10 +1,13 @@
+<h1 class="email-header-title">{{ _("Complete your registration") }}</h1>
 <p>
 	{{_("Hello")}} {{ first_name | e }}{% if last_name %} {{ last_name | e }}{% endif %},
 </p>
 {% set site_link = "<a href='" + site_url + "'>" + site_url + "</a>" %}
-<p>{{_("A new account has been created for you at {0}").format(site_link)}}.</p>
-<p>{{_("Your login id is")}}: <b>{{ user }}</b></p>
-<p>{{_("Click on the link below to complete your registration and set a new password")}}.</p>
+<p>
+	{{_("A new account has been created for you at {0}.").format(site_link)}}
+	{{_("Your login ID is:")}} <b>{{ user }}</b>
+</p>
+<p>{{_("Click the button below to complete your registration and set a new password.")}}</p>
 <p>
 	<a href="{{ link }}" rel="nofollow" class="btn btn-primary">{{ _("Complete Registration") }}</a>
 </p>
@@ -15,6 +18,5 @@
 </p>
 {% endif %}
 <p class="text-muted text-small">
-	{{_("You can also copy-paste following link in your browser")}}<br>
-	<a href="{{ link }}">{{ link }}</a>
+	{{_("Or copy and paste this link:")}} <a href="{{ link }}">{{ link }}</a>
 </p>

--- a/frappe/templates/emails/new_user.html
+++ b/frappe/templates/emails/new_user.html
@@ -3,22 +3,18 @@
 </p>
 {% set site_link = "<a href='" + site_url + "'>" + site_url + "</a>" %}
 <p>{{_("A new account has been created for you at {0}").format(site_link)}}.</p>
-<p>{{_("Your login id is")}}: <b>{{ user }}</b>
+<p>{{_("Your login id is")}}: <b>{{ user }}</b></p>
 <p>{{_("Click on the link below to complete your registration and set a new password")}}.</p>
-
-<p style="margin: 15px 0px;">
+<p>
 	<a href="{{ link }}" rel="nofollow" class="btn btn-primary">{{ _("Complete Registration") }}</a>
 </p>
-
 {% if created_by != "Administrator" %}
-<br>
-<p style="margin-top: 15px">
+<p>
 	{{_("Thanks")}},<br>
 	{{ created_by }}
 </p>
 {% endif %}
-<br>
-<p>
+<p class="text-muted text-small">
 	{{_("You can also copy-paste following link in your browser")}}<br>
 	<a href="{{ link }}">{{ link }}</a>
 </p>

--- a/frappe/templates/emails/password_reset.html
+++ b/frappe/templates/emails/password_reset.html
@@ -1,6 +1,10 @@
+<h1 class="email-header-title">{{ _("Reset your password") }}</h1>
 <p>{{_("Dear")}} {{ first_name }}{% if last_name %} {{ last_name}}{% endif %},</p>
-<p>{{_("Please click on the following link to set your new password")}}:</p>
-<p><a class="btn btn-primary" href="{{ link }}">{{_("Reset your password")}}</a></p>
+<p>{{_("We received a request to reset the password for your account. Click the button below to set a new password.")}}</p>
+<p><a class="btn btn-primary" href="{{ link }}">{{_("Reset Password")}}</a></p>
+<div class="callout callout-warning">
+	{{_("If you did not request a password reset, please ignore this email. Your password will remain unchanged.")}}
+</div>
 <p>
 	{{_("Thank you")}},<br>
 	{{ created_by }}

--- a/frappe/templates/emails/security_txt_expiry_alert.html
+++ b/frappe/templates/emails/security_txt_expiry_alert.html
@@ -1,6 +1,6 @@
 <h3>{{_("Security.txt will expire soon!")}}</h3>
 
-<table border="0" cellpadding="0" cellspacing="0" width="100%">
+<table border="0" cellpadding="4" cellspacing="0" width="100%">
 	<tr>
 		<td><strong>{{_("Site")}}</strong></td>
 		<td>{{ site }}</td>

--- a/frappe/templates/emails/standard.html
+++ b/frappe/templates/emails/standard.html
@@ -15,11 +15,11 @@
 					width="{% if header %} 600 {% else %} 100% {% endif %}">
 					{% if brand_logo %}
 					<tr>
-						<td width="40" align="left" valign="middle">
+						<td align="left" valign="middle" class="email-masthead">
 							<a href="{{ site_url or 'https://frappeframework.com' }}">
 								<img
 									src="{{ brand_logo or '/assets/frappe/images/frappe-framework-logo.svg' }}"
-									height="40"
+									height="28"
 									class="brand-logo"
 								/>
 							</a>
@@ -27,12 +27,12 @@
 					</tr>
 					{% endif %}
 					<tr>
-						<td valign="top">
+						<td valign="top" class="email-title-cell">
 							{{ header or "" }}
 						</td>
 					</tr>
 					<tr>
-						<td valign="top">
+						<td valign="top" class="email-body-cell">
 							<table class="email-body" border="0" cellpadding="0" cellspacing="0" width="100%">
 								<tr>
 									<td valign="top">
@@ -43,7 +43,7 @@
 						</td>
 					</tr>
 					<tr>
-						<td valign="top">
+						<td valign="top" class="email-footer-cell">
 							<table class="email-footer" border="0" cellpadding="0" cellspacing="0" width="100%">
 								<tr>
 									<td valign="top" data-email-footer="true">

--- a/frappe/templates/emails/standard.html
+++ b/frappe/templates/emails/standard.html
@@ -43,7 +43,7 @@
 						</td>
 					</tr>
 					<tr>
-						<td valign="top" class="email-footer-cell">
+						<td valign="top" class="email-footer-cell {% if footer and 'with-divider' in footer %}filled{% endif %}">
 							<table class="email-footer" border="0" cellpadding="0" cellspacing="0" width="100%">
 								<tr>
 									<td valign="top" data-email-footer="true">

--- a/frappe/templates/emails/standard.html
+++ b/frappe/templates/emails/standard.html
@@ -36,7 +36,7 @@
 							<table class="email-body" border="0" cellpadding="0" cellspacing="0" width="100%">
 								<tr>
 									<td valign="top">
-										<p>{{ content }}</p>
+										<div>{{ content }}</div>
 									</td>
 								</tr>
 							</table>

--- a/frappe/templates/emails/standard.html
+++ b/frappe/templates/emails/standard.html
@@ -12,16 +12,21 @@
 		<tr>
 			<td class="body-content" align="center" valign="top">
 				<table class="email-container" border="0" cellpadding="0" cellspacing="0"
-					width="{% if header %} 600 {% else %} 100% {% endif %}">
-					{% if brand_logo %}
+					width="{% if header or with_container %} 600 {% else %} 100% {% endif %}">
+					{% if brand_logo or brand_name %}
 					<tr>
 						<td align="left" valign="middle" class="email-masthead">
 							<a href="{{ site_url or 'https://frappeframework.com' }}">
+								{% if brand_logo %}
 								<img
 									src="{{ brand_logo or '/assets/frappe/images/frappe-framework-logo.svg' }}"
 									height="28"
 									class="brand-logo"
 								/>
+								{% endif %}
+								{% if brand_name %}
+								<span class="brand-name">{{ brand_name }}</span>
+								{% endif %}
 							</a>
 						</td>
 					</tr>

--- a/frappe/templates/emails/upcoming_events.html
+++ b/frappe/templates/emails/upcoming_events.html
@@ -1,7 +1,7 @@
 {% for e in events %}
 <p>
 	<span class="text-bold">{{ e.starts_on }}: </span><span>{{ e.subject }}</span>
-	<div>{{ e.description or '' }}</div>
+	{% if e.description %}<br>{{ e.description }}{% endif %}
 </p>
 {% endfor %}
 <p class="more-info">

--- a/frappe/templates/emails/upcoming_events.html
+++ b/frappe/templates/emails/upcoming_events.html
@@ -1,7 +1,7 @@
 {% for e in events %}
 <p>
 	<span class="text-bold">{{ e.starts_on }}: </span><span>{{ e.subject }}</span>
-	{% if e.description %}<br>{{ e.description }}{% endif %}
+	{% if e.description %}<br><span class="text-muted">{{ e.description }}</span>{% endif %}
 </p>
 {% endfor %}
 <p class="more-info">

--- a/frappe/templates/emails/user_invitation.html
+++ b/frappe/templates/emails/user_invitation.html
@@ -1,20 +1,7 @@
-<span style = "display: block; margin-bottom: 1.5rem;">
-  {{ _("Hello,") }}
-</span>
-<span style = "display: block; margin-bottom: 1rem;">
-  {{ _("You've been invited to join {0}.").format(title) }}
-</span>
-<span style = "display: block; margin-bottom: 0.5rem;">
-  {{ _("Click below to get started:") }}
-</span>
-<a
-  href = "{{ invite_link }}"
-  target = "_blank"
-  class = "btn btn-primary"
-  style = "display: block; margin-bottom: 1rem; width: fit-content"
->
-  {{ _("Accept Invitation") }}
-</a>
-<span>
-  {{ _("If you have any questions, reach out to your system administrator.") }}
-</span>
+<p>{{ _("Hello,") }}</p>
+<p>{{ _("You've been invited to join {0}.").format(title) }}</p>
+<p>{{ _("Click below to get started:") }}</p>
+<p>
+	<a href="{{ invite_link }}" target="_blank" class="btn btn-primary">{{ _("Accept Invitation") }}</a>
+</p>
+<p>{{ _("If you have any questions, reach out to your system administrator.") }}</p>

--- a/frappe/templates/emails/user_invitation.html
+++ b/frappe/templates/emails/user_invitation.html
@@ -1,6 +1,9 @@
+<h1 class="email-header-title">{{ _("You've been invited") }}</h1>
 <p>{{ _("Hello,") }}</p>
-<p>{{ _("You've been invited to join {0}.").format(title) }}</p>
-<p>{{ _("Click below to get started:") }}</p>
+<p>
+	{{ _("You've been invited to join {0}.").format(frappe.bold(title)) }}
+	{{ _("Click below to accept your invitation and get started.") }}
+</p>
 <p>
 	<a href="{{ invite_link }}" target="_blank" class="btn btn-primary">{{ _("Accept Invitation") }}</a>
 </p>

--- a/frappe/templates/emails/user_invitation_cancelled.html
+++ b/frappe/templates/emails/user_invitation_cancelled.html
@@ -1,9 +1,3 @@
-<span style = "display: block; margin-bottom: 1.5rem;">
-  {{ _("Hello,") }}
-</span>
-<span style = "display: block; margin-bottom: 1rem;">
-  {{ _("Your invitation to join {0} has been cancelled by the site administrator.").format(title) }}
-</span>
-<span style = "display: block;">
-  {{ _("If this was a mistake or you need access again, please reach out to your team.") }}
-</span>
+<p>{{ _("Hello,") }}</p>
+<p>{{ _("Your invitation to join {0} has been cancelled by the site administrator.").format(title) }}</p>
+<p>{{ _("If this was a mistake or you need access again, please reach out to your team.") }}</p>

--- a/frappe/templates/emails/user_invitation_cancelled.html
+++ b/frappe/templates/emails/user_invitation_cancelled.html
@@ -1,3 +1,4 @@
+<h1 class="email-header-title">{{ _("Invitation cancelled") }}</h1>
 <p>{{ _("Hello,") }}</p>
-<p>{{ _("Your invitation to join {0} has been cancelled by the site administrator.").format(title) }}</p>
+<p>{{ _("Your invitation to join {0} has been cancelled by the site administrator.").format(frappe.bold(title)) }}</p>
 <p>{{ _("If this was a mistake or you need access again, please reach out to your team.") }}</p>

--- a/frappe/templates/emails/user_invitation_expired.html
+++ b/frappe/templates/emails/user_invitation_expired.html
@@ -1,3 +1,4 @@
+<h1 class="email-header-title">{{ _("Invitation expired") }}</h1>
 <p>{{ _("Hello,") }}</p>
-<p>{{ _("Your invitation to join {0} has expired.").format(title) }}</p>
+<p>{{ _("Your invitation to join {0} has expired.").format(frappe.bold(title)) }}</p>
 <p>{{ _("You can ask your team to resend the invitation if you'd still like to join.") }}</p>

--- a/frappe/templates/emails/user_invitation_expired.html
+++ b/frappe/templates/emails/user_invitation_expired.html
@@ -1,9 +1,3 @@
-<span style = "display: block; margin-bottom: 1.5rem;">
-  {{ _("Hello,") }}
-</span>
-<span style = "display: block; margin-bottom: 1rem;">
-  {{ _("Your invitation to join {0} has expired.").format(title) }}
-</span>
-<span style = "display: block;">
-  {{ _("You can ask your team to resend the invitation if you'd still like to join.") }}
-</span>
+<p>{{ _("Hello,") }}</p>
+<p>{{ _("Your invitation to join {0} has expired.").format(title) }}</p>
+<p>{{ _("You can ask your team to resend the invitation if you'd still like to join.") }}</p>

--- a/frappe/templates/emails/verification_code.html
+++ b/frappe/templates/emails/verification_code.html
@@ -1,3 +1,4 @@
-<p>{{ _("Your verification code is") }}:</p>
+<h1 class="email-header-title">{{ _("Verification code") }}</h1>
+<p>{{ _("Use the code below to complete your sign-in.") }}</p>
 <div class="verification-code">{{ code }}</div>
 <p class="text-muted text-small">{{ _("If you did not request this code, you can safely ignore this email.") }}</p>

--- a/frappe/templates/emails/verification_code.html
+++ b/frappe/templates/emails/verification_code.html
@@ -1,1 +1,3 @@
-<p>{{ _("Your verification code is {0}").format(frappe.bold(code)) }}</p>
+<p>{{ _("Your verification code is") }}:</p>
+<div class="verification-code">{{ code }}</div>
+<p class="text-muted text-small">{{ _("If you did not request this code, you can safely ignore this email.") }}</p>

--- a/frappe/templates/emails/workflow_action.html
+++ b/frappe/templates/emails/workflow_action.html
@@ -1,11 +1,9 @@
 <p>{{ message }}</p>
-<div>
-	<p style="margin: 10px 0">
-		{% for action in actions %}
-		<a class="btn {% if action.is_primary %} btn-primary {% endif %}" style="margin-right: 10px" href="{{ action.action_link }}">{{_(action.action_name)}}</a>
-		{% endfor %}
-	</p>
-	<div class="text-muted text-small" style="padding-top: 20px;">
-		{{ _("The contents of this email are strictly confidential. Please do not forward this email to anyone.") }}
-	</div>
+<p>
+	{% for action in actions %}
+	<a class="btn {% if action.is_primary %} btn-primary {% endif %}" style="margin-right: 8px" href="{{ action.action_link }}">{{_(action.action_name)}}</a>
+	{% endfor %}
+</p>
+<div class="more-info">
+	{{ _("The contents of this email are strictly confidential. Please do not forward this email to anyone.") }}
 </div>

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -153,6 +153,7 @@ def send_login_link(email: str):
 			recipients=email,
 			template="login_with_email_link",
 			args={"link": link, "minutes": expiry, "app_name": app_name},
+			with_container=True,
 			now=True,
 		)
 	except frappe.DoesNotExistError:


### PR DESCRIPTION
- remove stray `<p>` wrapper around email content in standard.html and fix paragraph rhythm in email css (bottom-only margins, 16px inside container)
- redesign container emails per espresso mockup: warm canvas, card with logo masthead + hairline divider, 36px content padding, 20px/700 titles, `#525252` body text, dark 8px-radius buttons
- verification code shown in a monospace letter-spaced code box; document follow rebuilt on `gray-container` panels instead of spacer-row tables
- login link email now uses the standard container (`with_container=True`) instead of faking its own
- sweep all templates: drop inline margin hacks, `<br>` spacers, invalid html nesting and dead classes
- fix verification link in delete_data_confirmation rendering a literal `{{ link }}` as href
- update `test_inline_styling` for the new bottom-only paragraph margin

All css classes are inlined into `style` attributes by premailer at send time, so styling survives clients that strip stylesheets.

> [!NOTE]
> The screenshots in the description are generated previews, not real outgoing emails. Each template was rendered locally through `get_formatted_html` with sample args and captured headless. The logo and "Frappe" wordmark shown are the default fallbacks — on a real site the masthead picks up Email Account `brand_logo`, else Website Settings App Logo / App Name. 

### Before / After

| | Before | After |
|---|---|---|
| Login Link |  <img width="802" height="438" alt="image" src="https://github.com/user-attachments/assets/e665d591-22a9-4952-a07e-e0bfc3858874" /> |  <img width="2092" height="1004" alt="image" src="https://github.com/user-attachments/assets/6001fcff-683e-4df5-895e-868137572d16" /> 
| New user | ![before](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/before_new_user.png) | ![after](https://github.com/user-attachments/assets/de2fb60d-bd08-47c8-94d3-f05514acc93e)
| Password reset | ![before](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/before_password_reset.png) | ![after](https://github.com/user-attachments/assets/7cfb454b-2ad9-4309-81df-a79b04b4dfcb) |
| Verification code | ![before](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/before_verification_code.png) | ![after](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_verification_code.png) |
| User invitation | ![before](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/before_user_invitation.png) | ![after](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_user_invitation.png) |
| Workflow action | ![before](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/before_workflow_action.png) | ![after](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_workflow_action.png) |
| Notification | ![before](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/before_new_notification.png) | ![after](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_new_notification.png) |
| Delete data confirmation | ![before](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/before_delete_data_confirmation.png) | ![after](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_delete_data_confirmation.png) |
| Auto reply | ![before](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/before_auto_reply.png) | ![after](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_auto_reply.png) |

<details>
<summary>All other templates (after)</summary>

**Login with email link**

![login_with_email_link](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_login_with_email_link.png)

**Document follow**

![document_follow](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_document_follow.png)

**Auto email report**

![auto_email_report](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_auto_email_report.png)

**Upcoming events**

![upcoming_events](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_upcoming_events.png)

**Security.txt expiry**

![security_txt_expiry_alert](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_security_txt_expiry_alert.png)

**New message**

![new_message](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_new_message.png)

**Data deletion approval**

![data_deletion_approval](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_data_deletion_approval.png)

**Download data**

![download_data](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_download_data.png)

**Account deletion**

![account_deletion_notification](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_account_deletion_notification.png)

**Invitation cancelled**

![user_invitation_cancelled](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_user_invitation_cancelled.png)

**Invitation expired**

![user_invitation_expired](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_user_invitation_expired.png)

**Auto repeat fail**

![auto_repeat_fail](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_auto_repeat_fail.png)

**Administrator logged in**

![administrator_logged_in](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_administrator_logged_in.png)

**File backup**

![file_backup_notification](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_file_backup_notification.png)

**Print link**

![print_link](https://raw.githubusercontent.com/iamejaaz/frappe/email-spacing-screenshots/fx_print_link.png)

</details>



