### PR TITLE
fix: list view filter on child table link field with ignore user permissions

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -314,6 +314,16 @@ def validate_ignore_user_permissions(form_doctype, link_fieldname, link_doctype)
 	):
 		return
 
+	for table_field in meta.get_table_fields():
+		child_field = frappe.get_meta(table_field.options).get_field(link_fieldname)
+		if (
+			child_field
+			and child_field.fieldtype == "Link"
+			and child_field.options == link_doctype
+			and child_field.ignore_user_permissions
+		):
+			return
+
 	link_field = meta.get_field(link_fieldname)
 	if not link_field:
 		_throw(

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -314,17 +314,30 @@ def validate_ignore_user_permissions(form_doctype, link_fieldname, link_doctype)
 	):
 		return
 
+	matched_child_field = None
 	for table_field in meta.get_table_fields():
+		if not frappe.db.exists("DocType", table_field.options):
+			continue
+
 		child_field = frappe.get_meta(table_field.options).get_field(link_fieldname)
-		if (
-			child_field
-			and child_field.fieldtype == "Link"
-			and child_field.options == link_doctype
-			and child_field.ignore_user_permissions
-		):
+		if not child_field or child_field.fieldtype not in ("Link", "Dynamic Link"):
+			continue
+
+		if child_field.fieldtype == "Link" and child_field.options != link_doctype:
+			continue
+
+		if child_field.ignore_user_permissions:
 			return
 
+		matched_child_field = child_field
+
 	link_field = meta.get_field(link_fieldname)
+	field_doctype = form_doctype
+
+	if not link_field and matched_child_field:
+		link_field = matched_child_field
+		field_doctype = matched_child_field.parent
+
 	if not link_field:
 		_throw(
 			_("Field <code>{0}</code> not found in {1}").format(
@@ -354,7 +367,7 @@ def validate_ignore_user_permissions(form_doctype, link_fieldname, link_doctype)
 	if not ignore_user_permissions:
 		_throw(
 			_("The field {0} in {1} does not allow ignoring user permissions").format(
-				bold(_(meta.get_label(link_fieldname), context=form_doctype)), bold(_(form_doctype))
+				bold(_(link_field.label or link_fieldname, context=field_doctype)), bold(_(field_doctype))
 			)
 		)
 
@@ -369,8 +382,8 @@ def validate_ignore_user_permissions(form_doctype, link_fieldname, link_doctype)
 	if found_doctype != link_doctype:
 		_throw(
 			_("The field {0} in {1} links to {2} and not {3}").format(
-				bold(_(meta.get_label(link_fieldname), context=form_doctype)),
-				bold(_(form_doctype)),
+				bold(_(link_field.label or link_fieldname, context=field_doctype)),
+				bold(_(field_doctype)),
 				bold(_(found_doctype)),
 				bold(escape_html(link_doctype)),
 			)

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -408,95 +408,149 @@ class TestSearch(IntegrationTestCase):
 		"""List view filters target a child table field; the ignore_user_permissions flag
 		lives on the child table's link field, not on the parent."""
 
-		for dt in (
-			"Test Search Child Parent",
-			"Test Search Child Parent Dup",
-			"Test Search Child Row",
-			"Test Search Child Target",
-		):
+		target = "Test Search Child Target"
+		child = "Test Search Child Row"
+		parent = "Test Search Child Parent"
+		parent_dup = "Test Search Child Parent Dup"
+
+		def make_doctype(name, fields, **kwargs):
+			if frappe.db.exists("DocType", name):
+				frappe.delete_doc("DocType", name, force=True)
+			new_doctype(name=name, fields=fields, **kwargs).insert()
+			self.addCleanup(lambda: frappe.delete_doc("DocType", name, force=True, ignore_missing=True))
+
+		def link_to_target(fieldname, label, ignore_user_permissions):
+			return {
+				"label": label,
+				"fieldname": fieldname,
+				"fieldtype": "Link",
+				"options": target,
+				"ignore_user_permissions": ignore_user_permissions,
+			}
+
+		def rows_field():
+			return {"label": "Rows", "fieldname": "rows", "fieldtype": "Table", "options": child}
+
+		make_doctype(
+			target,
+			[{"label": "Title", "fieldname": "title", "fieldtype": "Data"}],
+			permissions=[{"role": "System Manager", "read": 1, "write": 1}],
+			search_fields="title",
+		)
+		make_doctype(
+			child,
+			[
+				link_to_target("member", "Member", 1),
+				link_to_target("plain_member", "Plain Member", 0),
+				{
+					"label": "Member Doctype",
+					"fieldname": "member_doctype",
+					"fieldtype": "Link",
+					"options": "DocType",
+				},
+				{
+					"label": "Dynamic Member",
+					"fieldname": "dynamic_member",
+					"fieldtype": "Dynamic Link",
+					"options": "member_doctype",
+					"ignore_user_permissions": 1,
+				},
+			],
+			istable=1,
+		)
+		make_doctype(parent, [rows_field()])
+		make_doctype(parent_dup, [link_to_target("member", "Member", 0), rows_field()])
+
+		allowed = frappe.get_doc({"doctype": target, "title": "Allowed Document"}).insert()
+		restricted = frappe.get_doc({"doctype": target, "title": "Restricted Document"}).insert()
+
+		test_user = "test_search_child_user@example.com"
+		if not frappe.db.exists("User", test_user):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": test_user,
+					"first_name": "Test Search Child User",
+					"user_type": "System User",
+				}
+			).insert(ignore_permissions=True).add_roles("System Manager")
+			self.addCleanup(lambda: frappe.delete_doc("User", test_user, force=True))
+
+		add_user_permission(target, allowed.name, test_user)
+		self.addCleanup(lambda: frappe.db.delete("User Permission", {"user": test_user}))
+
+		def values(**kwargs):
+			return [r["value"] for r in search_link(doctype=target, txt="Document", **kwargs)]
+
+		with self.set_user(test_user):
+			self.assertNotIn(restricted.name, values(ignore_user_permissions=False))
+
+			for reference_doctype in (parent, parent_dup):
+				self.assertIn(
+					restricted.name,
+					values(
+						ignore_user_permissions=True,
+						reference_doctype=reference_doctype,
+						link_fieldname="member",
+					),
+				)
+
+			self.assertIn(
+				restricted.name,
+				values(
+					ignore_user_permissions=True,
+					reference_doctype=parent,
+					link_fieldname="dynamic_member",
+				),
+			)
+
+			with self.assertRaisesRegex(frappe.ValidationError, "does not allow ignoring user permissions"):
+				values(ignore_user_permissions=True, reference_doctype=parent, link_fieldname="plain_member")
+
+			with self.assertRaisesRegex(frappe.ValidationError, "not found"):
+				values(ignore_user_permissions=True, reference_doctype=parent, link_fieldname="unknown_field")
+
+	def test_search_link_ignore_user_permissions_dangling_child_table(self):
+		"""A child table pointing at a deleted doctype should not escape as DoesNotExistError."""
+
+		for dt in ("Test Search Dangling Parent", "Test Search Dangling Row"):
 			if frappe.db.exists("DocType", dt):
 				frappe.delete_doc("DocType", dt, force=True)
 
 		new_doctype(
-			name="Test Search Child Target",
+			name="Test Search Dangling Row",
+			istable=1,
 			fields=[{"label": "Title", "fieldname": "title", "fieldtype": "Data"}],
 		).insert()
 
 		new_doctype(
-			name="Test Search Child Row",
-			istable=1,
-			fields=[
-				{
-					"label": "Member",
-					"fieldname": "member",
-					"fieldtype": "Link",
-					"options": "Test Search Child Target",
-					"ignore_user_permissions": 1,
-				}
-			],
-		).insert()
-
-		# field lives only in the child table
-		new_doctype(
-			name="Test Search Child Parent",
+			name="Test Search Dangling Parent",
 			fields=[
 				{
 					"label": "Rows",
 					"fieldname": "rows",
 					"fieldtype": "Table",
-					"options": "Test Search Child Row",
+					"options": "Test Search Dangling Row",
 				}
 			],
 		).insert()
+		self.addCleanup(
+			lambda: frappe.delete_doc(
+				"DocType", "Test Search Dangling Parent", force=True, ignore_missing=True
+			)
+		)
 
-		# same fieldname on parent (no flag) and child (with flag)
-		new_doctype(
-			name="Test Search Child Parent Dup",
-			fields=[
-				{
-					"label": "Member",
-					"fieldname": "member",
-					"fieldtype": "Link",
-					"options": "Test Search Child Target",
-					"ignore_user_permissions": 0,
-				},
-				{
-					"label": "Rows",
-					"fieldname": "rows",
-					"fieldtype": "Table",
-					"options": "Test Search Child Row",
-				},
-			],
-		).insert()
+		frappe.delete_doc("DocType", "Test Search Dangling Row", force=True)
+		frappe.clear_cache()
 
-		for dt in (
-			"Test Search Child Parent",
-			"Test Search Child Parent Dup",
-			"Test Search Child Row",
-			"Test Search Child Target",
-		):
-			self.addCleanup(lambda dt=dt: frappe.delete_doc("DocType", dt, force=True, ignore_missing=True))
-
-		# should not throw for either parent when the child link field allows ignoring
-		for reference_doctype in ("Test Search Child Parent", "Test Search Child Parent Dup"):
+		with self.assertRaisesRegex(frappe.ValidationError, "not found"):
 			search_link(
-				doctype="Test Search Child Target",
+				doctype="User",
 				txt="test",
 				ignore_user_permissions=True,
-				reference_doctype=reference_doctype,
-				link_fieldname="member",
+				reference_doctype="Test Search Dangling Parent",
+				link_fieldname="nonexistent_field",
 			)
-
-		# should still throw for a field that no parent or child table exposes
-		self.assertRaises(
-			frappe.ValidationError,
-			search_link,
-			doctype="Test Search Child Target",
-			txt="test",
-			ignore_user_permissions=True,
-			reference_doctype="Test Search Child Parent",
-			link_fieldname="nonexistent_field",
-		)
 
 
 @frappe.validate_and_sanitize_search_inputs

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -404,6 +404,100 @@ class TestSearch(IntegrationTestCase):
 			link_fieldname="value",
 		)
 
+	def test_search_link_ignore_user_permissions_child_table(self):
+		"""List view filters target a child table field; the ignore_user_permissions flag
+		lives on the child table's link field, not on the parent."""
+
+		for dt in (
+			"Test Search Child Parent",
+			"Test Search Child Parent Dup",
+			"Test Search Child Row",
+			"Test Search Child Target",
+		):
+			if frappe.db.exists("DocType", dt):
+				frappe.delete_doc("DocType", dt, force=True)
+
+		new_doctype(
+			name="Test Search Child Target",
+			fields=[{"label": "Title", "fieldname": "title", "fieldtype": "Data"}],
+		).insert()
+
+		new_doctype(
+			name="Test Search Child Row",
+			istable=1,
+			fields=[
+				{
+					"label": "Member",
+					"fieldname": "member",
+					"fieldtype": "Link",
+					"options": "Test Search Child Target",
+					"ignore_user_permissions": 1,
+				}
+			],
+		).insert()
+
+		# field lives only in the child table
+		new_doctype(
+			name="Test Search Child Parent",
+			fields=[
+				{
+					"label": "Rows",
+					"fieldname": "rows",
+					"fieldtype": "Table",
+					"options": "Test Search Child Row",
+				}
+			],
+		).insert()
+
+		# same fieldname on parent (no flag) and child (with flag)
+		new_doctype(
+			name="Test Search Child Parent Dup",
+			fields=[
+				{
+					"label": "Member",
+					"fieldname": "member",
+					"fieldtype": "Link",
+					"options": "Test Search Child Target",
+					"ignore_user_permissions": 0,
+				},
+				{
+					"label": "Rows",
+					"fieldname": "rows",
+					"fieldtype": "Table",
+					"options": "Test Search Child Row",
+				},
+			],
+		).insert()
+
+		for dt in (
+			"Test Search Child Parent",
+			"Test Search Child Parent Dup",
+			"Test Search Child Row",
+			"Test Search Child Target",
+		):
+			self.addCleanup(lambda dt=dt: frappe.delete_doc("DocType", dt, force=True, ignore_missing=True))
+
+		# should not throw for either parent when the child link field allows ignoring
+		for reference_doctype in ("Test Search Child Parent", "Test Search Child Parent Dup"):
+			search_link(
+				doctype="Test Search Child Target",
+				txt="test",
+				ignore_user_permissions=True,
+				reference_doctype=reference_doctype,
+				link_fieldname="member",
+			)
+
+		# should still throw for a field that no parent or child table exposes
+		self.assertRaises(
+			frappe.ValidationError,
+			search_link,
+			doctype="Test Search Child Target",
+			txt="test",
+			ignore_user_permissions=True,
+			reference_doctype="Test Search Child Parent",
+			link_fieldname="nonexistent_field",
+		)
+
 
 @frappe.validate_and_sanitize_search_inputs
 def get_data(doctype, txt, searchfield, start, page_len, filters):


### PR DESCRIPTION
## Summary

Filtering a list view by a child table Link field with **Ignore User Permissions** enabled could fail with a validation error instead of loading values.

This happened because `validate_ignore_user_permissions()` only checked fields on the parent doctype. When the filter referred to a child table field, it either reported the field as missing or incorrectly rejected it based on a parent field with the same name.

## Changes

- Extend the validation to also check the parent doctype's child tables.
- Allow the filter when a child table contains a Link field with the matching fieldname, points to the requested doctype, and has **Ignore User Permissions** enabled.

## Result

List view filters now correctly honor **Ignore User Permissions** for Link fields in child tables, matching the existing behavior for parent fields.

Closes #40943.