### PR TITLE
fix: reject link fields pointing to child tables

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1417,27 +1417,46 @@ def validate_fields(meta: Meta):
 					),
 					DoctypeLinkError,
 				)
-			if d.options == "[Select]" or d.options == d.parent:
+			if d.options == "[Select]":
 				return
-			if d.options != d.parent:
-				options = frappe.db.get_value("DocType", d.options, "name")
-				if not options:
-					frappe.throw(
-						_("{0}: Options must be a valid DocType for field {1} in row {2}").format(
-							docname, d.label, d.idx
-						),
-						WrongOptionsDoctypeLinkError,
-					)
-				elif options != d.options:
-					frappe.throw(
-						_("{0}: Options {1} must be the same as doctype name {2} for the field {3}").format(
-							docname, d.options, options, d.label
-						),
-						DoctypeLinkError,
-					)
-				else:
-					# fix case
-					d.options = options
+			if d.options == d.parent:
+				check_link_to_child_table(docname, d, meta.istable)
+				return
+			linked_doctype = frappe.db.get_value("DocType", d.options, ("name", "istable"), as_dict=True)
+			if not linked_doctype:
+				frappe.throw(
+					_("{0}: Options must be a valid DocType for field {1} in row {2}").format(
+						docname, d.label, d.idx
+					),
+					WrongOptionsDoctypeLinkError,
+				)
+			elif linked_doctype.name != d.options:
+				frappe.throw(
+					_("{0}: Options {1} must be the same as doctype name {2} for the field {3}").format(
+						docname, d.options, linked_doctype.name, d.label
+					),
+					DoctypeLinkError,
+				)
+			else:
+				# fix case
+				d.options = linked_doctype.name
+				check_link_to_child_table(docname, d, linked_doctype.istable)
+
+	def check_link_to_child_table(docname, d, is_child_table):
+		if d.fieldtype != "Link" or not is_child_table:
+			return
+
+		msg = _("{0}: Options {1} for Link field {2} in row {3} cannot be a child table").format(
+			docname, d.options, d.label, d.idx
+		)
+
+		# fields already saved on existing sites must not break install or import
+		if frappe.flags.in_install or frappe.flags.in_import:
+			frappe.logger().warning(msg)
+			frappe.msgprint(msg, title=_("Invalid Option"), alert=True)
+			return
+
+		frappe.throw(msg, WrongOptionsDoctypeLinkError)
 
 	def check_hidden_and_mandatory(docname, d):
 		if d.hidden and d.reqd and not d.default and not frappe.flags.in_migrate:

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1450,8 +1450,8 @@ def validate_fields(meta: Meta):
 			docname, d.options, d.label, d.idx
 		)
 
-		# fields already saved on existing sites must not break install or import
-		if frappe.flags.in_install or frappe.flags.in_import:
+		# fields already saved on existing sites must not break app installs
+		if frappe.flags.in_install:
 			frappe.logger().warning(msg)
 			frappe.msgprint(msg, title=_("Invalid Option"), alert=True)
 			return

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -365,6 +365,37 @@ class TestDocType(IntegrationTestCase):
 
 		self.assertRaises(WrongOptionsDoctypeLinkError, doc.insert)
 
+	def test_link_to_child_table(self):
+		child = new_doctype(istable=1).insert()
+		self.addCleanup(lambda: frappe.delete_doc("DocType", child.name, force=True))
+
+		doc = new_doctype(fields=[{"fieldname": "link", "fieldtype": "Link", "options": child.name}])
+		self.assertRaises(WrongOptionsDoctypeLinkError, doc.insert)
+
+		doc.fields[0].fieldtype = "Table"
+		doc.insert()
+		self.addCleanup(lambda: frappe.delete_doc("DocType", doc.name, force=True))
+
+		self_linking_child = new_doctype(istable=1, fields=[{"fieldname": "link", "fieldtype": "Link"}])
+		self_linking_child.fields[0].options = self_linking_child.name
+		self.assertRaises(WrongOptionsDoctypeLinkError, self_linking_child.insert)
+
+	def test_link_to_child_table_does_not_block_install(self):
+		child = new_doctype(istable=1).insert()
+		self.addCleanup(lambda: frappe.delete_doc("DocType", child.name, force=True))
+
+		doc = new_doctype(fields=[{"fieldname": "link", "fieldtype": "Link", "options": child.name}])
+
+		messages = []
+		with (
+			patch.dict(frappe.flags, {"in_install": "frappe"}),
+			patch.object(frappe, "msgprint", side_effect=lambda msg, **kwargs: messages.append(msg)),
+		):
+			doc.insert()
+
+		self.addCleanup(lambda: frappe.delete_doc("DocType", doc.name, force=True))
+		self.assertTrue(any("cannot be a child table" in msg for msg in messages))
+
 	def test_hidden_and_mandatory_without_default(self):
 		doc = new_doctype("Test hidden and mandatory")
 		field_1 = doc.append("fields", {})


### PR DESCRIPTION
## Summary

A Link field pointing to a child DocType can currently be saved, but it can never function correctly. 
Fetching values from it goes through `client.get_value`, which performs a permission check without a `parent_doctype`. Since child DocTypes inherit permissions from their parent document, the check always fails, resulting in a misleading 
`"You need Read permission"` error that users cannot resolve.

This moves the failure to DocType validation, so the invalid field is rejected when it's defined instead of failing later at runtime.

## Changes

- Reject Link fields whose `options` refer to a child DocType during DocType validation.
- Apply the check alongside the existing Link field option validations, including the self-referencing child DocType case.

## Compatibility

App installs log a warning instead of throwing, so an app that adds a Custom Field to a DocType which already has such a field still installs. Interactive DocType saves reject it. Migrate and doctype imports are unaffected;  both skip these validations already.

One consequence is that if a DocType already contains one of these invalid fields, adding an unrelated Custom Field to the same DocType will now fail until the invalid field is fixed, as validation runs over all fields.

Closes #27357.