### PR TITLE
refactor(mapper): extract resolved method path before get_attr

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -20,7 +20,8 @@ def make_mapped_doc(
 	Set `selected_children` as flags for the `get_mapped_doc` method.
 
 	Called from `open_mapped_doc` from create_new.js"""
-	method = frappe.get_attr(frappe.override_whitelisted_method(method))
+	resolved_method_path = frappe.override_whitelisted_method(method)
+	method = frappe.get_attr(resolved_method_path)
 
 	frappe.is_whitelisted(method)
 
@@ -45,7 +46,8 @@ def map_docs(
 
 	e.g. args: "{ 'supplier': 'XYZ' }"
 	"""
-	method = frappe.get_attr(frappe.override_whitelisted_method(method))
+	resolved_method_path = frappe.override_whitelisted_method(method)
+	method = frappe.get_attr(resolved_method_path)
 
 	frappe.is_whitelisted(method)
 


### PR DESCRIPTION
## Summary
- In `make_mapped_doc` and `map_docs`, bind the override-resolved method path returned by `frappe.override_whitelisted_method()` to a named `resolved_method_path` variable before passing it to `frappe.get_attr()`.
- This ensures the exact resolved function path is visible in the caller's stack frame locals if `get_attr` (or anything further down the call) raises and ends up in error logs — previously it was only a transient value inside a nested expression.
