### PR TITLE
feat: add print option in form menu on mobile

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -88,29 +88,18 @@ frappe.ui.form.Sidebar = class {
 	}
 
 	setup_print() {
-		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings");
-		const allow_print_for_draft = cint(print_settings.allow_print_for_draft);
-		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
-
-		if (
-			!frappe.model.is_submittable(this.frm.doc.doctype) ||
-			this.frm.doc.docstatus == 1 ||
-			(allow_print_for_cancelled && this.frm.doc.docstatus == 2) ||
-			(allow_print_for_draft && this.frm.doc.docstatus == 0)
-		) {
-			if (frappe.model.can_print(null, this.frm) && !this.frm.meta.issingle) {
-				let print_icon = this.page.add_action_icon(
-					"printer",
-					() => {
-						this.frm.print_doc();
-					},
-					"",
-					__("Print")
-				);
-				print_icon.css("background-color", "transparent");
-				print_icon.addClass("p-0");
-				this.sidebar.find(".form-print").append(print_icon);
-			}
+		if (frappe.model.can_print_doc(this.frm)) {
+			let print_icon = this.page.add_action_icon(
+				"printer",
+				() => {
+					this.frm.print_doc();
+				},
+				"",
+				__("Print")
+			);
+			print_icon.css("background-color", "transparent");
+			print_icon.addClass("p-0");
+			this.sidebar.find(".form-print").append(print_icon);
 		}
 	}
 

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -28,7 +28,6 @@ frappe.ui.form.Toolbar = class Toolbar {
 		} else {
 			if (this.frm.doc.__islocal) {
 				this.page.hide_menu();
-				this.print_icon && this.print_icon.addClass("hide");
 			} else {
 				const is_children_visible =
 					this.page.menu.children().filter(function () {
@@ -42,7 +41,6 @@ frappe.ui.form.Toolbar = class Toolbar {
 				} else {
 					this.page.hide_menu();
 				}
-				this.print_icon && this.print_icon.removeClass("hide");
 			}
 		}
 	}
@@ -477,26 +475,15 @@ frappe.ui.form.Toolbar = class Toolbar {
 	}
 
 	add_print() {
-		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings");
-		const allow_print_for_draft = cint(print_settings.allow_print_for_draft);
-		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
-
-		if (
-			!frappe.model.is_submittable(this.frm.doc.doctype) ||
-			this.frm.doc.docstatus == 1 ||
-			(allow_print_for_cancelled && this.frm.doc.docstatus == 2) ||
-			(allow_print_for_draft && this.frm.doc.docstatus == 0)
-		) {
-			if (frappe.model.can_print(null, this.frm) && !this.frm.meta.issingle) {
-				let menu_item = this.page.add_menu_item(
-					__("Print"),
-					() => {
-						this.frm.print_doc();
-					},
-					true
-				);
-				menu_item.parent().addClass("hidden-xl");
-			}
+		if (frappe.model.can_print_doc(this.frm)) {
+			let menu_item = this.page.add_menu_item(
+				__("Print"),
+				() => {
+					this.frm.print_doc();
+				},
+				true
+			);
+			menu_item.parent().addClass("hidden-xl");
 		}
 	}
 

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -370,7 +370,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 	}
 
 	make_menu_items() {
-		// Print
+		this.add_print();
 		this.add_discard();
 		this.add_open_sidebar();
 		this.add_email();
@@ -473,6 +473,30 @@ frappe.ui.form.Toolbar = class Toolbar {
 				},
 				true
 			);
+		}
+	}
+
+	add_print() {
+		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings");
+		const allow_print_for_draft = cint(print_settings.allow_print_for_draft);
+		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
+
+		if (
+			!frappe.model.is_submittable(this.frm.doc.doctype) ||
+			this.frm.doc.docstatus == 1 ||
+			(allow_print_for_cancelled && this.frm.doc.docstatus == 2) ||
+			(allow_print_for_draft && this.frm.doc.docstatus == 0)
+		) {
+			if (frappe.model.can_print(null, this.frm) && !this.frm.meta.issingle) {
+				let menu_item = this.page.add_menu_item(
+					__("Print"),
+					() => {
+						this.frm.print_doc();
+					},
+					true
+				);
+				menu_item.parent().addClass("hidden-xl");
+			}
 		}
 	}
 

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -437,6 +437,24 @@ $.extend(frappe.model, {
 		return frappe.boot.user.can_print.indexOf(doctype) !== -1;
 	},
 
+	can_print_doc: function (frm) {
+		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings");
+		const allow_print_for_draft = cint(print_settings.allow_print_for_draft);
+		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
+
+		const docstatus_allows_print =
+			!frappe.model.is_submittable(frm.doc.doctype) ||
+			frm.doc.docstatus == 1 ||
+			(allow_print_for_cancelled && frm.doc.docstatus == 2) ||
+			(allow_print_for_draft && frm.doc.docstatus == 0);
+
+		return !!(
+			docstatus_allows_print &&
+			frappe.model.can_print(null, frm) &&
+			!frm.meta.issingle
+		);
+	},
+
 	can_email: function (doctype, frm) {
 		if (frm) return frm.perm[0].email === 1;
 		return frappe.boot.user.can_email.indexOf(doctype) !== -1;


### PR DESCRIPTION
## Summary

Printing a document on mobile is cumbersome because the Print action is only available in the sidebar, which is hidden behind an overlay.

## Changes

- Add **Print** to the form menu on small screens.
- Reuse the same visibility conditions as the existing sidebar Print action, including Print Settings, `can_print`, and single DocType checks.
- Show it only below the `lg` breakpoint, so desktop behavior remains unchanged.

<img width="416" height="806" alt="Screenshot 2026-07-19 at 2 18 26 PM" src="https://github.com/user-attachments/assets/fa131a5e-b008-4c8b-a0b4-0b01907bd5ef" />

`no-docs`

Closes #38150.