### PR TITLE
fix(login): hide Edge's native password reveal icon

### DIFF
--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -340,6 +340,10 @@ body {
 			.password-field {
 				input {
 					padding-right: 38px;
+
+					&::-ms-reveal {
+						display: none; /* Hide Edge's native password reveal icon */
+					}
 				}
 
 				.toggle-password {


### PR DESCRIPTION
Resolve: #40832

---
**Before:**

https://github.com/user-attachments/assets/f31a4c22-3487-4c3e-8b04-86059a97e71d


**After:**

https://github.com/user-attachments/assets/a72c726e-7ae9-4e34-b713-1c0f6d2a0f6c

