### PR TITLE
refactor(print-format): split Field.vue into preview components

### DIFF
--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -44,27 +44,7 @@
 				/>
 				<span v-else class="text-muted">{{ __("No image — set one in the panel") }}</span>
 			</template>
-			<template v-else-if="df.fieldtype == 'Barcode' && df.custom">
-				<img
-					v-if="df.barcode_format == 'QR' && qr_src"
-					:src="qr_src"
-					:style="{ width: df.width || '35mm' }"
-				/>
-				<div
-					v-else-if="barcode_svg"
-					class="pf-barcode-svg"
-					:style="df.width ? { width: df.width } : {}"
-					v-html="barcode_svg"
-				></div>
-				<span
-					v-else-if="barcode_raw_value && df.barcode_format !== 'QR'"
-					class="text-muted"
-					>{{ __("Invalid value for {0}", [df.barcode_format || "CODE128"]) }}</span
-				>
-				<span v-else class="text-muted">{{
-					__("No barcode value — set one in the panel")
-				}}</span>
-			</template>
+			<FieldPreviewBarcode v-else-if="df.fieldtype == 'Barcode' && df.custom" :df="df" />
 			<div
 				v-else-if="df.fieldtype == 'Field Template'"
 				v-html="rendered_template || ''"
@@ -504,6 +484,7 @@
 
 <script setup>
 import ConfigureColumnsVue from "../inspector/ConfigureColumns.vue";
+import FieldPreviewBarcode from "./FieldPreviewBarcode.vue";
 import {
 	render_jinja_html,
 	sanitize_html,
@@ -514,7 +495,6 @@ import {
 } from "../../utils";
 import { createApp, ref, nextTick, watch, computed, inject } from "vue";
 import { useColumnResize } from "../../composables/useColumnResize";
-import JsBarcode from "jsbarcode";
 
 const props = defineProps(["df", "field_orientation"]);
 
@@ -654,56 +634,6 @@ watch(
 			template_render_failed.value = true;
 		}
 	},
-	{ immediate: true }
-);
-
-// ── Barcode element (custom layout block) ─────────────────
-let qr_src = ref(null);
-
-let barcode_raw_value = computed(() => {
-	if (props.df.fieldtype !== "Barcode" || !props.df.custom) return null;
-	if (props.df.barcode_field) {
-		return preview_doc.value?.[props.df.barcode_field] ?? null;
-	}
-	return props.df.barcode_value || null;
-});
-
-let barcode_svg = computed(() => {
-	const value = barcode_raw_value.value;
-	if (!value || props.df.barcode_format === "QR") return null;
-	const str = String(value);
-	if (str.startsWith("<svg")) return sanitize_html(str);
-	const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-	try {
-		JsBarcode(svg, str, {
-			format: props.df.barcode_format || "CODE128",
-			displayValue: props.df.show_text !== false,
-			height: 40,
-			margin: 0,
-		});
-		svg.setAttribute("width", "100%");
-		return svg.outerHTML;
-	} catch {
-		return null;
-	}
-});
-
-watch(
-	[barcode_raw_value, () => props.df.barcode_format],
-	frappe.utils.debounce(async ([value, format]) => {
-		if (format !== "QR" || !value) {
-			qr_src.value = null;
-			return;
-		}
-		try {
-			const r = await frappe.call("frappe.utils.print_format_generator.get_qr_code", {
-				value: String(value),
-			});
-			qr_src.value = r.message || null;
-		} catch {
-			qr_src.value = null;
-		}
-	}, 300),
 	{ immediate: true }
 );
 
@@ -1331,11 +1261,6 @@ thead:hover .col-resize-handle::after {
 .preview-table-html {
 	word-break: break-word;
 	white-space: normal;
-}
-
-.pf-barcode-svg {
-	display: inline-block;
-	max-width: 100%;
 }
 
 .pf-builder-thumb {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -485,16 +485,10 @@
 <script setup>
 import ConfigureColumnsVue from "../inspector/ConfigureColumns.vue";
 import FieldPreviewBarcode from "./FieldPreviewBarcode.vue";
-import {
-	render_jinja_html,
-	sanitize_html,
-	strip_html_to_text,
-	evaluate_visible_if,
-	thumb_hue,
-	parse_inline_style,
-} from "../../utils";
+import { render_jinja_html, evaluate_visible_if, parse_inline_style } from "../../utils";
 import { createApp, ref, nextTick, watch, computed, inject } from "vue";
 import { useColumnResize } from "../../composables/useColumnResize";
+import { useFieldFormat } from "../../composables/useFieldFormat";
 
 const props = defineProps(["df", "field_orientation"]);
 
@@ -637,190 +631,24 @@ watch(
 	{ immediate: true }
 );
 
-let preview_value = computed(() => {
-	if (!preview_doc.value || !props.df.fieldname) return null;
-	const raw = preview_doc.value[props.df.fieldname];
-	if (raw === null || raw === undefined || raw === "") return null;
-	const ft = props.df.fieldtype;
-	// Check fields return an <input> element from frappe.format — handle directly
-	if (ft === "Check") return raw ? __("Yes") : __("No");
-	try {
-		const formatted = frappe.format(raw, props.df, { only_value: true }, preview_doc.value);
-		// If frappe.format returned HTML markup, extract the text content
-		if (typeof formatted === "string" && formatted.includes("<")) {
-			return strip_html_to_text(formatted, String(raw));
-		}
-		return formatted;
-	} catch {
-		return String(raw);
-	}
-});
-
-let preview_value_html = computed(() => {
-	if (!preview_doc.value || !props.df.fieldname || props.df.fieldtype === "Check") return null;
-	const server = store.preview_values.value?.[props.df.fieldname];
-	if (server === null || server === undefined || server === "") return null;
-	return sanitize_html(String(server));
-});
-
-// Same math as macros/Rating.html: value is a 0-1 fraction, df.options holds the star count
-let rating_stars = computed(() => {
-	const total = parseInt(props.df.options) || 5;
-	const value = (preview_doc.value && preview_doc.value[props.df.fieldname]) || 0;
-	return { total, filled: Math.min(Math.floor(value * total + 0.5), total) };
-});
-
-const IMAGE_FIELDTYPES = new Set(["Attach Image", "Image", "Attach"]);
-const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|webp|svg|bmp|ico)(\?.*)?$/i;
-function is_image_field(col, value) {
-	if (IMAGE_FIELDTYPES.has(col?.fieldtype)) return true;
-	// Heuristic: any field whose value looks like an image URL
-	if (value && typeof value === "string" && IMAGE_EXTENSIONS.test(value)) return true;
-	return false;
-}
-
-const HTML_CONTENT_FIELDTYPES = new Set(["Text Editor", "Long Text"]);
-
-// Cell padding + border colour as an inline style string; the border colour
-// needs !important to beat the shared stylesheet's own !important border
-// rules, exactly like the server markup (macros/Table.html) does.
-function cell_style(df) {
-	const parts = [];
-	if (df.table_cell_padding != null) parts.push(`padding: ${df.table_cell_padding}px`);
-	if (df.table_border_color) parts.push(`border-color: ${df.table_border_color} !important`);
-	return parts.join("; ");
-}
-
-function repeater_cell(col, i, row) {
-	return (col.template || [])
-		.map((tok) => {
-			if (tok.t === "s") return tok.v || "";
-			const server = store.preview_child_values.value?.[props.df.source]?.[i]?.[tok.v];
-			if (server !== null && server !== undefined && server !== "") {
-				return strip_html_to_text(String(server));
-			}
-			const child_df = repeater_child_df(tok.v);
-			return child_df ? format_cell(row || {}, child_df) : row?.[tok.v] ?? "";
-		})
-		.join("");
-}
-
-function repeater_child_df(fieldname) {
-	const source = store.meta.value?.fields?.find((f) => f.fieldname === props.df.source);
-	if (!source) return null;
-	return frappe.get_meta(source.options)?.fields?.find((f) => f.fieldname === fieldname) || null;
-}
-
-function multiselect_display(df) {
-	const server = store.preview_values.value?.[df.fieldname];
-	if (server !== null && server !== undefined && server !== "") {
-		return strip_html_to_text(String(server));
-	}
-	const rows = preview_doc.value?.[df.fieldname] || [];
-	if (!rows.length) return "—";
-	const child_meta = frappe.get_meta(df.options);
-	const link_field = child_meta?.fields.find((f) => f.fieldtype === "Link");
-	if (!link_field) return "—";
-	return (
-		rows
-			.map((r) => r[link_field.fieldname])
-			.filter(Boolean)
-			.join(", ") || "—"
-	);
-}
-
-function cell_server_html(i, col) {
-	const v = store.preview_child_values.value?.[props.df.fieldname]?.[i]?.[col.fieldname];
-	if (v === null || v === undefined || v === "") return null;
-	return sanitize_html(String(v));
-}
-
-function format_cell(row, col) {
-	const raw = row[col.fieldname];
-	if (raw === null || raw === undefined || raw === "") return "";
-	if (col.fieldtype === "Check") return raw ? __("Yes") : __("No");
-	// HTML content fields: sanitize then return for v-html rendering
-	if (HTML_CONTENT_FIELDTYPES.has(col.fieldtype)) return sanitize_html(raw);
-	try {
-		const formatted = frappe.format(raw, col, { only_value: true }, row);
-		if (typeof formatted === "string" && formatted.includes("<")) {
-			return strip_html_to_text(formatted, String(raw));
-		}
-		return formatted;
-	} catch {
-		return String(raw);
-	}
-}
-
-// ── Merged cell helpers ────────────────────────────────────
-// Image fieldtypes that store a URL directly, so they can float left.
-const MERGE_IMAGE_FIELDTYPES = new Set(["Attach Image", "Attach"]);
-
-// The column's own field is always the implicit first (primary) line;
-// col.merged_fields holds only the extra fields merged in beside it.
-function merged_fields(col) {
-	const extra = (col.merged_fields || []).filter((mf) => mf && mf.fieldname);
-	if (!extra.length) return [];
-	return [{ fieldname: col.fieldname, fieldtype: col.fieldtype, style: "primary" }, ...extra];
-}
-
-function has_merge(col) {
-	return (col.merged_fields || []).length > 0;
-}
-
-// The first merged field that is an image — rendered on the left.
-function image_merge(col) {
-	return merged_fields(col).find((mf) => MERGE_IMAGE_FIELDTYPES.has(mf.fieldtype)) || null;
-}
-
-// Remaining fields render as stacked text lines.
-function text_merges(col) {
-	const img = image_merge(col);
-	return merged_fields(col).filter((mf) => mf.fieldname !== img?.fieldname);
-}
-
-function format_merged(row, i, fieldname) {
-	const server = store.preview_child_values.value?.[props.df.fieldname]?.[i]?.[fieldname];
-	if (server !== null && server !== undefined && server !== "") {
-		return strip_html_to_text(String(server)).trim();
-	}
-	const dcol = frappe.meta.get_docfield(props.df.options, fieldname) || {
-		fieldname,
-		fieldtype: "Data",
-	};
-	const val = format_cell(row, dcol);
-	if (typeof val === "string" && val.includes("<")) {
-		return strip_html_to_text(val).trim();
-	}
-	return val;
-}
-
-function cell_image(col, row) {
-	const img = image_merge(col);
-	const v = img ? row[img.fieldname] : null;
-	return typeof v === "string" && v ? v : null;
-}
-
-function thumb_box(col) {
-	const s = (col.image_size || 40) + "px";
-	return { width: s, height: s };
-}
-
-// Initials fallback (abbr + coloured box) when an image field is merged
-// but the row has no image. Colour keyed off the first text field.
-function thumb(col, row) {
-	const raw = String(row[text_merges(col)[0]?.fieldname] ?? "");
-	const hue = thumb_hue(raw);
-	return {
-		abbr: frappe.get_abbr(raw) || "?",
-		style: {
-			...thumb_box(col),
-			fontSize: Math.floor((col.image_size || 40) * 0.4) + "px",
-			background: `hsl(${hue}, 65%, 92%)`,
-			color: `hsl(${hue}, 55%, 35%)`,
-		},
-	};
-}
+const {
+	preview_value,
+	preview_value_html,
+	rating_stars,
+	is_image_field,
+	cell_style,
+	repeater_cell,
+	multiselect_display,
+	cell_server_html,
+	format_cell,
+	has_merge,
+	image_merge,
+	text_merges,
+	format_merged,
+	cell_image,
+	thumb_box,
+	thumb,
+} = useFieldFormat(props, store, preview_doc);
 
 function select_field(e) {
 	const additive = !!(e && (e.metaKey || e.ctrlKey || e.shiftKey));

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -219,57 +219,7 @@
 					</table>
 				</div>
 			</template>
-			<!-- Repeater field -->
-			<template v-else-if="df.fieldtype == 'Repeater'">
-				<div v-if="df.label && df.show_label !== 'hide'" class="label">
-					{{ df.label }}
-				</div>
-				<table class="pfb-repeater-table">
-					<colgroup>
-						<col
-							v-for="(col, ci) in df.repeater_columns || []"
-							:key="ci"
-							:style="col.width ? { width: col.width + '%' } : {}"
-						/>
-					</colgroup>
-					<tbody>
-						<tr
-							v-for="(row, i) in (preview_doc[df.source] || []).slice(0, 6)"
-							:key="i"
-						>
-							<td
-								v-for="(col, ci) in df.repeater_columns || []"
-								:key="ci"
-								class="pfb-repeater-cell"
-								:style="{
-									textAlign: col.align || 'left',
-									...(col.color ? { color: col.color } : {}),
-								}"
-							>
-								{{ repeater_cell(col, i, row) }}
-							</td>
-						</tr>
-						<tr v-if="!(preview_doc[df.source] || []).length">
-							<td class="text-muted pfb-table-note">
-								{{ df.source ? __("No rows") : __("Pick a source table") }}
-							</td>
-						</tr>
-						<tr v-if="(preview_doc[df.source] || []).length > 6">
-							<td
-								:colspan="df.repeater_columns?.length || 1"
-								class="text-muted pfb-table-note"
-							>
-								{{
-									__(
-										"+ {0} more rows in this document — all print in the real output",
-										[preview_doc[df.source].length - 6]
-									)
-								}}
-							</td>
-						</tr>
-					</tbody>
-				</table>
-			</template>
+			<FieldPreviewRepeater v-else-if="df.fieldtype == 'Repeater'" :df="df" />
 			<!-- Regular field -->
 			<template v-else>
 				<div
@@ -485,6 +435,7 @@
 <script setup>
 import ConfigureColumnsVue from "../inspector/ConfigureColumns.vue";
 import FieldPreviewBarcode from "./FieldPreviewBarcode.vue";
+import FieldPreviewRepeater from "./FieldPreviewRepeater.vue";
 import { render_jinja_html, evaluate_visible_if, parse_inline_style } from "../../utils";
 import { createApp, ref, nextTick, watch, computed, inject } from "vue";
 import { useColumnResize } from "../../composables/useColumnResize";
@@ -637,7 +588,6 @@ const {
 	rating_stars,
 	is_image_field,
 	cell_style,
-	repeater_cell,
 	multiselect_display,
 	cell_server_html,
 	format_cell,

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -66,159 +66,7 @@
 					{{ multiselect_display(df) }}
 				</div>
 			</template>
-			<!-- Table field -->
-			<template v-else-if="df.fieldtype == 'Table'">
-				<div v-if="df.label && df.show_label !== 'hide'" class="label">
-					{{ df.label }}
-				</div>
-				<!-- radius lives on a wrapper: border-radius is a no-op on a
-				     border-collapse:collapse table, same as the PDF markup -->
-				<div
-					:style="
-						df.table_radius != null
-							? { borderRadius: df.table_radius + 'px', overflow: 'hidden' }
-							: {}
-					"
-				>
-					<table
-						class="table"
-						:class="{ 'table-bordered': df.table_bordered !== false }"
-						:style="
-							df.table_bordered !== false && df.table_border_color
-								? { borderColor: df.table_border_color }
-								: {}
-						"
-					>
-						<thead v-if="df.table_header !== 'none'">
-							<!-- inline !important mirrors the server markup: the shared
-								     stylesheet's own !important rules must lose to these -->
-							<tr
-								:style="
-									df.table_header_bg && df.table_header !== 'plain'
-										? `background-color: ${df.table_header_bg} !important`
-										: ''
-								"
-							>
-								<th
-									v-for="(col, ci) in df.table_columns"
-									:key="col.fieldname"
-									class="column-header"
-									:class="{ 'column-value--merged': has_merge(col) }"
-									:data-fieldtype="col.fieldtype"
-									:data-fieldname="col.fieldname"
-									:style="
-										(col.width ? `width: ${col.width}%; ` : '') +
-										cell_style(df)
-									"
-								>
-									{{ col.label || col.fieldname }}
-									<span
-										v-if="ci < df.table_columns.length - 1"
-										class="col-resize-handle"
-										@pointerdown.prevent.stop="start_col_resize($event, ci)"
-										@mousedown.prevent.stop
-										@click.stop
-									></span>
-								</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr
-								v-for="(row, i) in (preview_doc[df.fieldname] || []).slice(0, 4)"
-								:key="i"
-								:class="i % 2 === 0 ? 'odd' : 'even'"
-							>
-								<td
-									v-for="col in df.table_columns"
-									:key="col.fieldname"
-									class="column-value"
-									:class="{ 'column-value--merged': has_merge(col) }"
-									:data-fieldtype="col.fieldtype"
-									:data-fieldname="col.fieldname"
-									:style="
-										(col.width ? `width: ${col.width}%; ` : '') +
-										cell_style(df)
-									"
-								>
-									<!-- Merged cell: image (if any) floats left, text lines stack -->
-									<div v-if="has_merge(col)" class="cell-merged">
-										<template v-if="image_merge(col)">
-											<img
-												v-if="cell_image(col, row)"
-												:src="cell_image(col, row)"
-												class="cell-thumb-img"
-												:style="thumb_box(col)"
-												:alt="col.label || col.fieldname"
-											/>
-											<span
-												v-else
-												class="cell-thumb"
-												:style="thumb(col, row).style"
-												>{{ thumb(col, row).abbr }}</span
-											>
-										</template>
-										<div
-											class="cell-lines"
-											:class="{
-												'cell-lines--horizontal':
-													col.merge_direction === 'horizontal',
-											}"
-										>
-											<div
-												v-for="(mf, mi) in text_merges(col)"
-												:key="mi"
-												class="cell-line"
-												:class="`cell-line--${mf.style || 'primary'}`"
-											>
-												{{ format_merged(row, i, mf.fieldname) }}
-											</div>
-										</div>
-									</div>
-									<!-- Single (default) -->
-									<template v-else>
-										<img
-											v-if="
-												is_image_field(col, row[col.fieldname]) &&
-												row[col.fieldname]
-											"
-											:src="row[col.fieldname]"
-											class="preview-table-img"
-											:alt="col.label || col.fieldname"
-										/>
-										<div
-											v-else-if="cell_server_html(i, col)"
-											class="preview-table-html"
-											v-html="cell_server_html(i, col)"
-										></div>
-										<span v-else>{{ format_cell(row, col) }}</span>
-									</template>
-								</td>
-							</tr>
-							<tr v-if="!preview_doc[df.fieldname]?.length">
-								<td
-									:colspan="df.table_columns?.length || 1"
-									class="text-muted pfb-table-note"
-								>
-									{{ __("No rows") }}
-								</td>
-							</tr>
-							<tr v-if="(preview_doc[df.fieldname] || []).length > 4">
-								<td
-									:colspan="df.table_columns?.length || 1"
-									class="text-muted pfb-table-note"
-								>
-									{{
-										__(
-											"+ {0} more rows in this document — all print in the real output",
-											[preview_doc[df.fieldname].length - 4]
-										)
-									}}
-								</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-			</template>
+			<FieldPreviewTable v-else-if="df.fieldtype == 'Table'" :df="df" />
 			<FieldPreviewRepeater v-else-if="df.fieldtype == 'Repeater'" :df="df" />
 			<!-- Regular field -->
 			<template v-else>
@@ -436,9 +284,9 @@
 import ConfigureColumnsVue from "../inspector/ConfigureColumns.vue";
 import FieldPreviewBarcode from "./FieldPreviewBarcode.vue";
 import FieldPreviewRepeater from "./FieldPreviewRepeater.vue";
+import FieldPreviewTable from "./FieldPreviewTable.vue";
 import { render_jinja_html, evaluate_visible_if, parse_inline_style } from "../../utils";
 import { createApp, ref, nextTick, watch, computed, inject } from "vue";
-import { useColumnResize } from "../../composables/useColumnResize";
 import { useFieldFormat } from "../../composables/useFieldFormat";
 
 const props = defineProps(["df", "field_orientation"]);
@@ -582,23 +430,11 @@ watch(
 	{ immediate: true }
 );
 
-const {
-	preview_value,
-	preview_value_html,
-	rating_stars,
-	is_image_field,
-	cell_style,
-	multiselect_display,
-	cell_server_html,
-	format_cell,
-	has_merge,
-	image_merge,
-	text_merges,
-	format_merged,
-	cell_image,
-	thumb_box,
-	thumb,
-} = useFieldFormat(props, store, preview_doc);
+const { preview_value, preview_value_html, rating_stars, multiselect_display } = useFieldFormat(
+	props,
+	store,
+	preview_doc
+);
 
 function select_field(e) {
 	const additive = !!(e && (e.metaKey || e.ctrlKey || e.shiftKey));
@@ -711,26 +547,6 @@ function get_column_to_add(fieldname) {
 	return { ...frappe.meta.get_docfield(props.df.options, fieldname), width: 10 };
 }
 
-const { start: start_column_resize } = useColumnResize();
-
-function start_col_resize(e, ci) {
-	const cols = props.df.table_columns;
-	const left = cols[ci];
-	const right = cols[ci + 1];
-	if (!right) return;
-	const table_width = e.target.closest("table").getBoundingClientRect().width;
-	const start_x = e.clientX;
-	const start_left = left.width || 10;
-	const start_right = right.width || 10;
-	const on_move = (ev) => {
-		let delta = Math.round(((ev.clientX - start_x) / table_width) * 100);
-		delta = Math.max(5 - start_left, Math.min(start_right - 5, delta));
-		left.width = start_left + delta;
-		right.width = start_right - delta;
-	};
-	start_column_resize(e.target, "col-resize-handle--active", on_move);
-}
-
 function validate_table_columns() {
 	if (props.df.fieldtype != "Table") return;
 	let total = 0;
@@ -751,51 +567,7 @@ watch(
 );
 </script>
 
-<style>
-body.pfb-col-resizing,
-body.pfb-col-resizing * {
-	cursor: col-resize !important;
-	user-select: none;
-}
-</style>
-
 <style scoped>
-.column-header {
-	position: relative;
-}
-
-.col-resize-handle {
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	right: -4px;
-	width: 8px;
-	cursor: col-resize;
-	z-index: 1;
-}
-
-.col-resize-handle::after {
-	content: "";
-	position: absolute;
-	top: 2px;
-	bottom: 2px;
-	left: 3px;
-	width: 2px;
-	border-radius: 1px;
-	background: var(--gray-400);
-	opacity: 0;
-	transition: opacity 0.15s;
-}
-
-thead:hover .col-resize-handle::after {
-	opacity: 0.4;
-}
-
-.col-resize-handle:hover::after,
-.col-resize-handle--active::after {
-	opacity: 1;
-}
-
 .field--chip {
 	display: flex;
 	flex-direction: column;
@@ -991,12 +763,6 @@ thead:hover .col-resize-handle::after {
 }
 
 /* Top-right actions pill: drag + remove — hidden until hover/selected */
-.pfb-table-note {
-	text-align: center;
-	font-size: 11px;
-	padding: 6px;
-}
-
 .field-preview-actions {
 	display: none;
 	position: absolute;
@@ -1027,18 +793,6 @@ thead:hover .col-resize-handle::after {
 
 .field-preview-actions .field-drag-handle:hover {
 	color: var(--gray-600);
-}
-
-/* Table/repeater/merged-cell visuals come from the shared print stylesheet
-   (templates/print_format/print_format_doc.css) via the .print-format-doc scope */
-.preview-table-img {
-	max-width: 100%;
-	max-height: 100px;
-}
-
-.preview-table-html {
-	word-break: break-word;
-	white-space: normal;
 }
 
 .pf-builder-thumb {

--- a/frappe/public/js/print_format_builder/components/editor/FieldPreviewBarcode.vue
+++ b/frappe/public/js/print_format_builder/components/editor/FieldPreviewBarcode.vue
@@ -1,0 +1,83 @@
+<template>
+	<img
+		v-if="df.barcode_format == 'QR' && qr_src"
+		:src="qr_src"
+		:style="{ width: df.width || '35mm' }"
+	/>
+	<div
+		v-else-if="barcode_svg"
+		class="pf-barcode-svg"
+		:style="df.width ? { width: df.width } : {}"
+		v-html="barcode_svg"
+	></div>
+	<span v-else-if="barcode_raw_value && df.barcode_format !== 'QR'" class="text-muted">{{
+		__("Invalid value for {0}", [df.barcode_format || "CODE128"])
+	}}</span>
+	<span v-else class="text-muted">{{ __("No barcode value — set one in the panel") }}</span>
+</template>
+
+<script setup>
+import { ref, computed, watch, inject } from "vue";
+import JsBarcode from "jsbarcode";
+import { sanitize_html } from "../../utils";
+
+const props = defineProps(["df"]);
+const store = inject("$store");
+const preview_doc = computed(() => store.preview_doc.value);
+
+let qr_src = ref(null);
+
+let barcode_raw_value = computed(() => {
+	if (props.df.fieldtype !== "Barcode" || !props.df.custom) return null;
+	if (props.df.barcode_field) {
+		return preview_doc.value?.[props.df.barcode_field] ?? null;
+	}
+	return props.df.barcode_value || null;
+});
+
+let barcode_svg = computed(() => {
+	const value = barcode_raw_value.value;
+	if (!value || props.df.barcode_format === "QR") return null;
+	const str = String(value);
+	if (str.startsWith("<svg")) return sanitize_html(str);
+	const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+	try {
+		JsBarcode(svg, str, {
+			format: props.df.barcode_format || "CODE128",
+			displayValue: props.df.show_text !== false,
+			height: 40,
+			margin: 0,
+		});
+		svg.setAttribute("width", "100%");
+		return svg.outerHTML;
+	} catch {
+		return null;
+	}
+});
+
+watch(
+	[barcode_raw_value, () => props.df.barcode_format],
+	frappe.utils.debounce(async ([value, format]) => {
+		if (format !== "QR" || !value) {
+			qr_src.value = null;
+			return;
+		}
+		try {
+			const r = await frappe.call("frappe.utils.print_format_generator.get_qr_code", {
+				value: String(value),
+			});
+			qr_src.value = r.message || null;
+		} catch {
+			qr_src.value = null;
+		}
+	}, 300),
+	{ immediate: true }
+);
+</script>
+
+<style scoped>
+.pf-barcode-svg {
+	display: inline-block;
+	max-width: 100%;
+}
+</style>

--- a/frappe/public/js/print_format_builder/components/editor/FieldPreviewRepeater.vue
+++ b/frappe/public/js/print_format_builder/components/editor/FieldPreviewRepeater.vue
@@ -1,0 +1,61 @@
+<template>
+	<div v-if="df.label && df.show_label !== 'hide'" class="label">
+		{{ df.label }}
+	</div>
+	<table class="pfb-repeater-table">
+		<colgroup>
+			<col
+				v-for="(col, ci) in df.repeater_columns || []"
+				:key="ci"
+				:style="col.width ? { width: col.width + '%' } : {}"
+			/>
+		</colgroup>
+		<tbody>
+			<tr v-for="(row, i) in (preview_doc[df.source] || []).slice(0, 6)" :key="i">
+				<td
+					v-for="(col, ci) in df.repeater_columns || []"
+					:key="ci"
+					class="pfb-repeater-cell"
+					:style="{
+						textAlign: col.align || 'left',
+						...(col.color ? { color: col.color } : {}),
+					}"
+				>
+					{{ repeater_cell(col, i, row) }}
+				</td>
+			</tr>
+			<tr v-if="!(preview_doc[df.source] || []).length">
+				<td class="text-muted pfb-table-note">
+					{{ df.source ? __("No rows") : __("Pick a source table") }}
+				</td>
+			</tr>
+			<tr v-if="(preview_doc[df.source] || []).length > 6">
+				<td :colspan="df.repeater_columns?.length || 1" class="text-muted pfb-table-note">
+					{{
+						__("+ {0} more rows in this document — all print in the real output", [
+							preview_doc[df.source].length - 6,
+						])
+					}}
+				</td>
+			</tr>
+		</tbody>
+	</table>
+</template>
+
+<script setup>
+import { computed, inject } from "vue";
+import { useFieldFormat } from "../../composables/useFieldFormat";
+
+const props = defineProps(["df"]);
+const store = inject("$store");
+const preview_doc = computed(() => store.preview_doc.value);
+const { repeater_cell } = useFieldFormat(props, store, preview_doc);
+</script>
+
+<style scoped>
+.pfb-table-note {
+	text-align: center;
+	font-size: 11px;
+	padding: 6px;
+}
+</style>

--- a/frappe/public/js/print_format_builder/components/editor/FieldPreviewTable.vue
+++ b/frappe/public/js/print_format_builder/components/editor/FieldPreviewTable.vue
@@ -1,0 +1,240 @@
+<template>
+	<div v-if="df.label && df.show_label !== 'hide'" class="label">
+		{{ df.label }}
+	</div>
+	<!-- radius lives on a wrapper: border-radius is a no-op on a
+	     border-collapse:collapse table, same as the PDF markup -->
+	<div
+		:style="
+			df.table_radius != null
+				? { borderRadius: df.table_radius + 'px', overflow: 'hidden' }
+				: {}
+		"
+	>
+		<table
+			class="table"
+			:class="{ 'table-bordered': df.table_bordered !== false }"
+			:style="
+				df.table_bordered !== false && df.table_border_color
+					? { borderColor: df.table_border_color }
+					: {}
+			"
+		>
+			<thead v-if="df.table_header !== 'none'">
+				<!-- inline !important mirrors the server markup: the shared
+					     stylesheet's own !important rules must lose to these -->
+				<tr
+					:style="
+						df.table_header_bg && df.table_header !== 'plain'
+							? `background-color: ${df.table_header_bg} !important`
+							: ''
+					"
+				>
+					<th
+						v-for="(col, ci) in df.table_columns"
+						:key="col.fieldname"
+						class="column-header"
+						:class="{ 'column-value--merged': has_merge(col) }"
+						:data-fieldtype="col.fieldtype"
+						:data-fieldname="col.fieldname"
+						:style="(col.width ? `width: ${col.width}%; ` : '') + cell_style(df)"
+					>
+						{{ col.label || col.fieldname }}
+						<span
+							v-if="ci < df.table_columns.length - 1"
+							class="col-resize-handle"
+							@pointerdown.prevent.stop="start_col_resize($event, ci)"
+							@mousedown.prevent.stop
+							@click.stop
+						></span>
+					</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr
+					v-for="(row, i) in (preview_doc[df.fieldname] || []).slice(0, 4)"
+					:key="i"
+					:class="i % 2 === 0 ? 'odd' : 'even'"
+				>
+					<td
+						v-for="col in df.table_columns"
+						:key="col.fieldname"
+						class="column-value"
+						:class="{ 'column-value--merged': has_merge(col) }"
+						:data-fieldtype="col.fieldtype"
+						:data-fieldname="col.fieldname"
+						:style="(col.width ? `width: ${col.width}%; ` : '') + cell_style(df)"
+					>
+						<!-- Merged cell: image (if any) floats left, text lines stack -->
+						<div v-if="has_merge(col)" class="cell-merged">
+							<template v-if="image_merge(col)">
+								<img
+									v-if="cell_image(col, row)"
+									:src="cell_image(col, row)"
+									class="cell-thumb-img"
+									:style="thumb_box(col)"
+									:alt="col.label || col.fieldname"
+								/>
+								<span v-else class="cell-thumb" :style="thumb(col, row).style">{{
+									thumb(col, row).abbr
+								}}</span>
+							</template>
+							<div
+								class="cell-lines"
+								:class="{
+									'cell-lines--horizontal': col.merge_direction === 'horizontal',
+								}"
+							>
+								<div
+									v-for="(mf, mi) in text_merges(col)"
+									:key="mi"
+									class="cell-line"
+									:class="`cell-line--${mf.style || 'primary'}`"
+								>
+									{{ format_merged(row, i, mf.fieldname) }}
+								</div>
+							</div>
+						</div>
+						<!-- Single (default) -->
+						<template v-else>
+							<img
+								v-if="
+									is_image_field(col, row[col.fieldname]) && row[col.fieldname]
+								"
+								:src="row[col.fieldname]"
+								class="preview-table-img"
+								:alt="col.label || col.fieldname"
+							/>
+							<div
+								v-else-if="cell_server_html(i, col)"
+								class="preview-table-html"
+								v-html="cell_server_html(i, col)"
+							></div>
+							<span v-else>{{ format_cell(row, col) }}</span>
+						</template>
+					</td>
+				</tr>
+				<tr v-if="!preview_doc[df.fieldname]?.length">
+					<td :colspan="df.table_columns?.length || 1" class="text-muted pfb-table-note">
+						{{ __("No rows") }}
+					</td>
+				</tr>
+				<tr v-if="(preview_doc[df.fieldname] || []).length > 4">
+					<td :colspan="df.table_columns?.length || 1" class="text-muted pfb-table-note">
+						{{
+							__("+ {0} more rows in this document — all print in the real output", [
+								preview_doc[df.fieldname].length - 4,
+							])
+						}}
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</template>
+
+<script setup>
+import { computed, inject } from "vue";
+import { useColumnResize } from "../../composables/useColumnResize";
+import { useFieldFormat } from "../../composables/useFieldFormat";
+
+const props = defineProps(["df"]);
+const store = inject("$store");
+const preview_doc = computed(() => store.preview_doc.value);
+
+const {
+	cell_style,
+	is_image_field,
+	cell_server_html,
+	format_cell,
+	has_merge,
+	image_merge,
+	text_merges,
+	format_merged,
+	cell_image,
+	thumb_box,
+	thumb,
+} = useFieldFormat(props, store, preview_doc);
+
+const { start: start_column_resize } = useColumnResize();
+
+function start_col_resize(e, ci) {
+	const cols = props.df.table_columns;
+	const left = cols[ci];
+	const right = cols[ci + 1];
+	if (!right) return;
+	const table_width = e.target.closest("table").getBoundingClientRect().width;
+	const start_x = e.clientX;
+	const start_left = left.width || 10;
+	const start_right = right.width || 10;
+	const on_move = (ev) => {
+		let delta = Math.round(((ev.clientX - start_x) / table_width) * 100);
+		delta = Math.max(5 - start_left, Math.min(start_right - 5, delta));
+		left.width = start_left + delta;
+		right.width = start_right - delta;
+	};
+	start_column_resize(e.target, "col-resize-handle--active", on_move);
+}
+</script>
+
+<style>
+body.pfb-col-resizing,
+body.pfb-col-resizing * {
+	cursor: col-resize !important;
+	user-select: none;
+}
+</style>
+
+<style scoped>
+.column-header {
+	position: relative;
+}
+
+.col-resize-handle {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	right: -4px;
+	width: 8px;
+	cursor: col-resize;
+	z-index: 1;
+}
+
+.col-resize-handle::after {
+	content: "";
+	position: absolute;
+	top: 2px;
+	bottom: 2px;
+	left: 3px;
+	width: 2px;
+	border-radius: 1px;
+	background: var(--gray-400);
+	opacity: 0;
+	transition: opacity 0.15s;
+}
+
+thead:hover .col-resize-handle::after {
+	opacity: 0.4;
+}
+
+.col-resize-handle:hover::after,
+.col-resize-handle--active::after {
+	opacity: 1;
+}
+
+.pfb-table-note {
+	text-align: center;
+	font-size: 11px;
+	padding: 6px;
+}
+
+.preview-table-img {
+	max-width: 100%;
+	max-height: 100px;
+}
+
+.preview-table-html {
+	word-break: break-word;
+	white-space: normal;
+}
+</style>

--- a/frappe/public/js/print_format_builder/composables/useFieldFormat.js
+++ b/frappe/public/js/print_format_builder/composables/useFieldFormat.js
@@ -1,0 +1,210 @@
+import { computed } from "vue";
+import { sanitize_html, strip_html_to_text, thumb_hue } from "../utils";
+
+const IMAGE_FIELDTYPES = new Set(["Attach Image", "Image", "Attach"]);
+const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|webp|svg|bmp|ico)(\?.*)?$/i;
+const HTML_CONTENT_FIELDTYPES = new Set(["Text Editor", "Long Text"]);
+const MERGE_IMAGE_FIELDTYPES = new Set(["Attach Image", "Attach"]);
+
+export function useFieldFormat(props, store, preview_doc) {
+	const preview_value = computed(() => {
+		if (!preview_doc.value || !props.df.fieldname) return null;
+		const raw = preview_doc.value[props.df.fieldname];
+		if (raw === null || raw === undefined || raw === "") return null;
+		const ft = props.df.fieldtype;
+		if (ft === "Check") return raw ? __("Yes") : __("No");
+		try {
+			const formatted = frappe.format(
+				raw,
+				props.df,
+				{ only_value: true },
+				preview_doc.value
+			);
+			if (typeof formatted === "string" && formatted.includes("<")) {
+				return strip_html_to_text(formatted, String(raw));
+			}
+			return formatted;
+		} catch {
+			return String(raw);
+		}
+	});
+
+	const preview_value_html = computed(() => {
+		if (!preview_doc.value || !props.df.fieldname || props.df.fieldtype === "Check")
+			return null;
+		const server = store.preview_values.value?.[props.df.fieldname];
+		if (server === null || server === undefined || server === "") return null;
+		return sanitize_html(String(server));
+	});
+
+	// Same math as macros/Rating.html: value is a 0-1 fraction, df.options holds the star count
+	const rating_stars = computed(() => {
+		const total = parseInt(props.df.options) || 5;
+		const value = (preview_doc.value && preview_doc.value[props.df.fieldname]) || 0;
+		return { total, filled: Math.min(Math.floor(value * total + 0.5), total) };
+	});
+
+	function is_image_field(col, value) {
+		if (IMAGE_FIELDTYPES.has(col?.fieldtype)) return true;
+		if (value && typeof value === "string" && IMAGE_EXTENSIONS.test(value)) return true;
+		return false;
+	}
+
+	// Border colour needs !important to beat the shared stylesheet's own !important
+	// border rules, exactly like the server markup (macros/Table.html) does.
+	function cell_style(df) {
+		const parts = [];
+		if (df.table_cell_padding != null) parts.push(`padding: ${df.table_cell_padding}px`);
+		if (df.table_border_color) parts.push(`border-color: ${df.table_border_color} !important`);
+		return parts.join("; ");
+	}
+
+	function repeater_cell(col, i, row) {
+		return (col.template || [])
+			.map((tok) => {
+				if (tok.t === "s") return tok.v || "";
+				const server = store.preview_child_values.value?.[props.df.source]?.[i]?.[tok.v];
+				if (server !== null && server !== undefined && server !== "") {
+					return strip_html_to_text(String(server));
+				}
+				const child_df = repeater_child_df(tok.v);
+				return child_df ? format_cell(row || {}, child_df) : row?.[tok.v] ?? "";
+			})
+			.join("");
+	}
+
+	function repeater_child_df(fieldname) {
+		const source = store.meta.value?.fields?.find((f) => f.fieldname === props.df.source);
+		if (!source) return null;
+		return (
+			frappe.get_meta(source.options)?.fields?.find((f) => f.fieldname === fieldname) || null
+		);
+	}
+
+	function multiselect_display(df) {
+		const server = store.preview_values.value?.[df.fieldname];
+		if (server !== null && server !== undefined && server !== "") {
+			return strip_html_to_text(String(server));
+		}
+		const rows = preview_doc.value?.[df.fieldname] || [];
+		if (!rows.length) return "—";
+		const child_meta = frappe.get_meta(df.options);
+		const link_field = child_meta?.fields.find((f) => f.fieldtype === "Link");
+		if (!link_field) return "—";
+		return (
+			rows
+				.map((r) => r[link_field.fieldname])
+				.filter(Boolean)
+				.join(", ") || "—"
+		);
+	}
+
+	function cell_server_html(i, col) {
+		const v = store.preview_child_values.value?.[props.df.fieldname]?.[i]?.[col.fieldname];
+		if (v === null || v === undefined || v === "") return null;
+		return sanitize_html(String(v));
+	}
+
+	function format_cell(row, col) {
+		const raw = row[col.fieldname];
+		if (raw === null || raw === undefined || raw === "") return "";
+		if (col.fieldtype === "Check") return raw ? __("Yes") : __("No");
+		if (HTML_CONTENT_FIELDTYPES.has(col.fieldtype)) return sanitize_html(raw);
+		try {
+			const formatted = frappe.format(raw, col, { only_value: true }, row);
+			if (typeof formatted === "string" && formatted.includes("<")) {
+				return strip_html_to_text(formatted, String(raw));
+			}
+			return formatted;
+		} catch {
+			return String(raw);
+		}
+	}
+
+	// The column's own field is always the implicit first (primary) line;
+	// col.merged_fields holds only the extra fields merged in beside it.
+	function merged_fields(col) {
+		const extra = (col.merged_fields || []).filter((mf) => mf && mf.fieldname);
+		if (!extra.length) return [];
+		return [
+			{ fieldname: col.fieldname, fieldtype: col.fieldtype, style: "primary" },
+			...extra,
+		];
+	}
+
+	function has_merge(col) {
+		return (col.merged_fields || []).length > 0;
+	}
+
+	function image_merge(col) {
+		return merged_fields(col).find((mf) => MERGE_IMAGE_FIELDTYPES.has(mf.fieldtype)) || null;
+	}
+
+	function text_merges(col) {
+		const img = image_merge(col);
+		return merged_fields(col).filter((mf) => mf.fieldname !== img?.fieldname);
+	}
+
+	function format_merged(row, i, fieldname) {
+		const server = store.preview_child_values.value?.[props.df.fieldname]?.[i]?.[fieldname];
+		if (server !== null && server !== undefined && server !== "") {
+			return strip_html_to_text(String(server)).trim();
+		}
+		const dcol = frappe.meta.get_docfield(props.df.options, fieldname) || {
+			fieldname,
+			fieldtype: "Data",
+		};
+		const val = format_cell(row, dcol);
+		if (typeof val === "string" && val.includes("<")) {
+			return strip_html_to_text(val).trim();
+		}
+		return val;
+	}
+
+	function cell_image(col, row) {
+		const img = image_merge(col);
+		const v = img ? row[img.fieldname] : null;
+		return typeof v === "string" && v ? v : null;
+	}
+
+	function thumb_box(col) {
+		const s = (col.image_size || 40) + "px";
+		return { width: s, height: s };
+	}
+
+	// Initials fallback when an image field is merged but the row has no image.
+	function thumb(col, row) {
+		const raw = String(row[text_merges(col)[0]?.fieldname] ?? "");
+		const hue = thumb_hue(raw);
+		return {
+			abbr: frappe.get_abbr(raw) || "?",
+			style: {
+				...thumb_box(col),
+				fontSize: Math.floor((col.image_size || 40) * 0.4) + "px",
+				background: `hsl(${hue}, 65%, 92%)`,
+				color: `hsl(${hue}, 55%, 35%)`,
+			},
+		};
+	}
+
+	return {
+		preview_value,
+		preview_value_html,
+		rating_stars,
+		is_image_field,
+		cell_style,
+		repeater_cell,
+		repeater_child_df,
+		multiselect_display,
+		cell_server_html,
+		format_cell,
+		merged_fields,
+		has_merge,
+		image_merge,
+		text_merges,
+		format_merged,
+		cell_image,
+		thumb_box,
+		thumb,
+	};
+}


### PR DESCRIPTION
Splits the 1348-line `Field.vue` — effectively two components fused (a builder chip + a per-fieldtype preview renderer) — into focused pieces. Pure DOM-preserving moves, no behaviour change.

- `useFieldFormat.js` — the shared cell/value formatting helpers (`format_cell`, merged-cell layout, `preview_value`, …) used by the preview children.
- `FieldPreviewBarcode.vue`, `FieldPreviewRepeater.vue`, `FieldPreviewTable.vue` — the barcode / repeater / child-table preview renderers, each mounted only in preview mode. Column-resize + its styles moved with the table.
- `Field.vue` keeps the builder chip, the preview dispatcher, and the builder-mode column-config dialog.

`Field.vue`: 1348 → 805 lines. Scoped styles were moved alongside their markup so nothing goes unstyled.

Verified: build passes, and the canvas↔server class-parity contract holds. The preview markup mirrors the server macros, so the moves preserve it — worth a quick builder smoke-test (open a format with a child table, pick a doc, confirm Table/Repeater/Barcode previews render) before merge.
