### PR TITLE
fix: prevent grid row-edit dropdown from being clipped on short forms

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -629,8 +629,12 @@
 		overflow: auto;
 
 		&:has(.awesomplete > [role="listbox"]:not([hidden])) {
-			min-height: unquote("min(60vh, 360px)");
+			overflow: visible;
 		}
+	}
+
+	&:has(.grid-form-body .awesomplete > [role="listbox"]:not([hidden])) {
+		overflow: visible;
 	}
 
 	// Tabs styling for child table grid row forms

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -627,6 +627,10 @@
 	.grid-form-body {
 		max-height: 80vh;
 		overflow: auto;
+
+		&:has(.awesomplete > [role="listbox"]:not([hidden])) {
+			min-height: unquote("min(60vh, 360px)");
+		}
 	}
 
 	// Tabs styling for child table grid row forms


### PR DESCRIPTION
Resolve: #35451, #36324

---

**After Fix:**

https://github.com/user-attachments/assets/27e14d63-4adc-46e7-bd0d-b8474562f181



