### PR TITLE
fix(treeview): identify tree nodes by node_id instead of label

### DIFF
--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -21,19 +21,31 @@ def get_all_nodes(doctype: str, label: str, parent: str, tree_method: str | None
 
 	frappe.is_whitelisted(callable_tree_method)
 
-	data = callable_tree_method(doctype, parent, **filters)
-	out = [dict(parent=label, data=data)]
+	# A tree method may return a `node_id` per node when `value` alone is not unique
+	# (e.g. the same item appearing at several places in a BOM tree). Recursion is
+	# keyed on that id so sibling branches don't collapse into one another.
+	# `parent_node_id` is only forwarded when set, since most tree methods take a
+	# fixed set of keyword arguments and would reject an unexpected one.
+	parent_node_id = filters.pop("parent_node_id", None)
+
+	def get_data(parent, node_id, **kwargs):
+		if node_id:
+			kwargs["parent_node_id"] = node_id
+		return callable_tree_method(doctype, parent, **kwargs)
+
+	data = get_data(parent, parent_node_id, **filters)
+	out = [dict(parent=parent_node_id or label, data=data)]
 
 	filters.pop("is_root", None)
-	to_check = [d.get("value") for d in data if d.get("expandable")]
+	to_check = [(d.get("value"), d.get("node_id")) for d in data if d.get("expandable")]
 
 	while to_check:
-		parent = to_check.pop()
-		data = callable_tree_method(doctype, parent, is_root=False, **filters)
-		out.append(dict(parent=parent, data=data))
+		parent, node_id = to_check.pop()
+		data = get_data(parent, node_id, is_root=False, **filters)
+		out.append(dict(parent=node_id or parent, data=data))
 		for d in data:
 			if d.get("expandable"):
-				to_check.append(d.get("value"))
+				to_check.append((d.get("value"), d.get("node_id")))
 
 	return out
 

--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -8,6 +8,7 @@ frappe.ui.Tree = class {
 		parent,
 		label,
 		root_value,
+		root_node_id,
 		icon_set,
 		toolbar,
 		expandable,
@@ -46,7 +47,7 @@ frappe.ui.Tree = class {
 		var args = Object.assign({}, this.args);
 		args.parent = value;
 		args.is_root = is_root;
-		if (node_id && node_id !== value) args.parent_node_id = node_id;
+		if (node_id) args.parent_node_id = node_id;
 
 		return new Promise((resolve) => {
 			frappe.call({
@@ -65,7 +66,7 @@ frappe.ui.Tree = class {
 		args.label = label || value;
 		args.parent = value;
 		args.is_root = is_root;
-		if (node_id && node_id !== value) args.parent_node_id = node_id;
+		if (node_id) args.parent_node_id = node_id;
 
 		args.tree_method = this.method;
 
@@ -91,7 +92,11 @@ frappe.ui.Tree = class {
 				// `label` is not necessarily unique (e.g. the same item can appear at
 				// several places in a BOM tree), so nodes are keyed by `node_id` when
 				// the tree method supplies one, falling back to `label` otherwise.
-				this.node_id = (data && data.node_id) || this.label;
+				// `has_node_id` records whether the id was actually supplied: that, and
+				// not a comparison against `value`, is what marks a tree method as
+				// having opted in to being sent `parent_node_id`.
+				this.has_node_id = Boolean(data && data.node_id);
+				this.node_id = this.has_node_id ? data.node_id : this.label;
 				this.parent_node_id = this.parent_node_id || this.parent_label;
 				if (this.parent_node_id) {
 					this.parent_node = tree.nodes[this.parent_node_id];
@@ -113,6 +118,10 @@ frappe.ui.Tree = class {
 			is_root: true,
 			data: {
 				value: this.root_value,
+				// The root has no record of its own, so a tree that keys its nodes by
+				// id must say what identity the root stands for (e.g. the document
+				// whose children the top level represents).
+				node_id: this.root_node_id,
 			},
 		});
 		this.expand_node(this.root_node, false);
@@ -169,7 +178,10 @@ frappe.ui.Tree = class {
 	load_children(node, deep = false) {
 		const value = node.data.value,
 			is_root = node.is_root,
-			node_id = node.node_id;
+			// Only forwarded for trees that opted in by supplying a `node_id`; most
+			// tree methods accept a fixed set of keyword arguments and would raise on
+			// an unexpected one.
+			node_id = node.has_node_id ? node.node_id : null;
 
 		return deep
 			? frappe.run_serially([

--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -42,10 +42,11 @@ frappe.ui.Tree = class {
 		this.setup_root_node();
 	}
 
-	get_nodes(value, is_root) {
+	get_nodes(value, is_root, node_id) {
 		var args = Object.assign({}, this.args);
 		args.parent = value;
 		args.is_root = is_root;
+		if (node_id && node_id !== value) args.parent_node_id = node_id;
 
 		return new Promise((resolve) => {
 			frappe.call({
@@ -59,11 +60,12 @@ frappe.ui.Tree = class {
 		});
 	}
 
-	get_all_nodes(value, is_root, label) {
+	get_all_nodes(value, is_root, label, node_id) {
 		var args = Object.assign({}, this.args);
 		args.label = label || value;
 		args.parent = value;
 		args.is_root = is_root;
+		if (node_id && node_id !== value) args.parent_node_id = node_id;
 
 		args.tree_method = this.method;
 
@@ -82,15 +84,20 @@ frappe.ui.Tree = class {
 	setup_treenode_class() {
 		let tree = this;
 		this.TreeNode = class {
-			constructor({ parent, label, parent_label, expandable, is_root, data }) {
+			constructor({ parent, label, parent_label, parent_node_id, expandable, is_root, data }) {
 				$.extend(this, arguments[0]);
 				this.loaded = 0;
 				this.expanded = 0;
-				if (this.parent_label) {
-					this.parent_node = tree.nodes[this.parent_label];
+				// `label` is not necessarily unique (e.g. the same item can appear at
+				// several places in a BOM tree), so nodes are keyed by `node_id` when
+				// the tree method supplies one, falling back to `label` otherwise.
+				this.node_id = (data && data.node_id) || this.label;
+				this.parent_node_id = this.parent_node_id || this.parent_label;
+				if (this.parent_node_id) {
+					this.parent_node = tree.nodes[this.parent_node_id];
 				}
 
-				tree.nodes[this.label] = this;
+				tree.nodes[this.node_id] = this;
 				tree.make_node_element(this);
 				tree.on_render && tree.on_render(this);
 			}
@@ -135,6 +142,7 @@ frappe.ui.Tree = class {
 		return new this.TreeNode({
 			parent: $li.appendTo(node.$ul),
 			parent_label: node.label,
+			parent_node_id: node.node_id,
 			label: data.value,
 			title: data.title,
 			expandable: data.expandable,
@@ -160,17 +168,18 @@ frappe.ui.Tree = class {
 
 	load_children(node, deep = false) {
 		const value = node.data.value,
-			is_root = node.is_root;
+			is_root = node.is_root,
+			node_id = node.node_id;
 
 		return deep
 			? frappe.run_serially([
-					() => this.get_all_nodes(value, is_root, node.label),
+					() => this.get_all_nodes(value, is_root, node.label, node_id),
 					(data_list) => this.render_children_of_all_nodes(data_list),
 					() => this.set_selected_node(node),
 					() => this.on_node_render && this.on_node_render(node, deep),
 			  ])
 			: frappe.run_serially([
-					() => this.get_nodes(value, is_root),
+					() => this.get_nodes(value, is_root, node_id),
 					(data_set) => this.render_node_children(node, data_set),
 					() => this.set_selected_node(node),
 					() => this.on_node_render && this.on_node_render(node, deep),

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -243,6 +243,7 @@ frappe.views.TreeView = class TreeView {
 			parent: this.body,
 			label: use_label,
 			root_value: use_value,
+			root_node_id: this.opts.root_node_id,
 			expandable: true,
 
 			args: this.args,


### PR DESCRIPTION
## Problem

`frappe.ui.Tree` keys its node map on `label`, which is the node's display value and is not guaranteed to be unique. When the same value appears at more than one place in a tree:

- nodes overwrite each other in `tree.nodes`, so `parent_node` resolves to whichever node was created last
- the deep-load recursion in `get_all_nodes` is keyed on `value`, so sibling branches collapse into one another and expanding any one of them yields the union of all their children

This is visible in the BOM Creator, where the same item can legitimately be used as a sub-assembly at several levels. Expanding any instance shows the raw materials of every instance. Fix on the ERPNext side: frappe/erpnext#57271

## Change

A tree method can now return a `node_id` per node. When present it is used as the node's identity — for the node map, for parent lookups, and as the recursion key — and is sent back to the tree method as `parent_node_id` so it can scope its query to the specific node being expanded.

## Backwards compatibility

`parent_node_id` is only forwarded when a tree method opted in by returning `node_id`. Most tree methods accept a fixed set of keyword arguments and would raise on an unexpected one, so passing it unconditionally is not safe. Trees that do not return `node_id` fall back to `label` and behave exactly as before.

I exercised the Account, Warehouse, Item Group, Department and Task trees through `get_all_nodes` — node counts and grouping are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
