### PR TITLE
fix(print): round child-table corners (paginated) and drop the styled-header divider

### DIFF
--- a/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/components/PrintFormatControls.vue
@@ -146,32 +146,47 @@
 			<div v-if="!store.section_snippets.value.length" class="pfb-empty">
 				{{ __("Save a section as a snippet to reuse it here.") }}
 			</div>
-			<div
-				v-for="snip in store.section_snippets.value"
-				:key="snip.name"
-				class="pfb-block-card"
-				:title="__('Insert saved section')"
-				@click="store.insert_section_snippet(snip.name)"
+			<draggable
+				:list="store.section_snippets.value"
+				:group="{ name: 'sections', pull: 'clone', put: false }"
+				:sort="false"
+				:clone="clone_snippet_section"
+				item-key="name"
+				filter="button"
+				:preventOnFilter="false"
+				v-bind="DRAG_OPTIONS"
+				@start="setDragging(true)"
+				@end="setDragging(false)"
 			>
-				<span
-					class="pfb-block-icon"
-					v-html="frappe.utils.icon('layout-template', 'sm')"
-				></span>
-				<div class="pfb-block-info">
-					<div class="pfb-block-name">{{ snip.name }}</div>
-					<div class="pfb-block-desc text-muted">{{ __("Click to insert") }}</div>
-				</div>
-				<button
-					class="es-button"
-					data-size="xs"
-					data-variant="ghost"
-					data-theme="red"
-					data-icon-button="true"
-					:title="__('Delete snippet')"
-					@click.stop="confirm_delete_snippet(snip.name)"
-					v-html="frappe.utils.icon('trash', 'xs')"
-				></button>
-			</div>
+				<template #item="{ element: snip }">
+					<div
+						class="pfb-block-card"
+						:title="__('Drag into the layout, or click to insert')"
+						@click="store.insert_section_snippet(snip.name)"
+					>
+						<span
+							class="pfb-block-icon"
+							v-html="frappe.utils.icon('layout-template', 'sm')"
+						></span>
+						<div class="pfb-block-info">
+							<div class="pfb-block-name">{{ snip.name }}</div>
+							<div class="pfb-block-desc text-muted">
+								{{ __("Drag or click to insert") }}
+							</div>
+						</div>
+						<button
+							class="es-button"
+							data-size="xs"
+							data-variant="ghost"
+							data-theme="red"
+							data-icon-button="true"
+							:title="__('Delete snippet')"
+							@click.stop="confirm_delete_snippet(snip.name)"
+							v-html="frappe.utils.icon('trash', 'xs')"
+						></button>
+					</div>
+				</template>
+			</draggable>
 		</div>
 
 		<!-- ── Templates ─────────────────────────────────────── -->
@@ -429,7 +444,7 @@
 <script setup>
 import draggable from "vuedraggable";
 import Autocomplete from "../../vue-components/Autocomplete.vue";
-import { DRAG_OPTIONS, get_table_columns, pluck, setDragging } from "../utils";
+import { DRAG_OPTIONS, clone_plain, get_table_columns, pluck, setDragging } from "../utils";
 import { mountColorControl } from "./inspector/useColorControl";
 import { useStore } from "../stores";
 import { computed, onMounted, onUnmounted, nextTick, ref, watch, inject } from "vue";
@@ -749,6 +764,10 @@ watch(
 
 function clone_as_section() {
 	return { label: "", columns: [{ label: "", fields: [] }], page_break: true };
+}
+
+function clone_snippet_section(snip) {
+	return clone_plain(snip.section);
 }
 
 function add_page_break() {
@@ -1154,6 +1173,7 @@ function handle_slash_key(e) {
 
 .pfb-block-info {
 	min-width: 0;
+	flex: 1;
 }
 
 .pfb-block-name {

--- a/frappe/public/js/print_format_builder/components/editor/Field.vue
+++ b/frappe/public/js/print_format_builder/components/editor/Field.vue
@@ -324,6 +324,7 @@ const preview_root = computed(() => {
 				"child-table",
 				`child-table--${df.table_style || "lined"}`,
 				df.table_header === "plain" ? "child-table--plain-header" : "",
+				df.table_bordered !== false ? "child-table--bordered" : "",
 			],
 			style: custom,
 		};

--- a/frappe/public/js/print_format_builder/components/editor/FieldPreviewTable.vue
+++ b/frappe/public/js/print_format_builder/components/editor/FieldPreviewTable.vue
@@ -33,6 +33,11 @@
 				</th>
 			</tr>
 		</thead>
+		<tfoot>
+			<tr>
+				<td class="table-foot" :colspan="df.table_columns?.length || 1"></td>
+			</tr>
+		</tfoot>
 		<tbody>
 			<tr
 				v-for="(row, i) in (preview_doc[df.fieldname] || []).slice(0, 4)"

--- a/frappe/public/js/print_format_builder/components/editor/FieldPreviewTable.vue
+++ b/frappe/public/js/print_format_builder/components/editor/FieldPreviewTable.vue
@@ -2,135 +2,115 @@
 	<div v-if="df.label && df.show_label !== 'hide'" class="label">
 		{{ df.label }}
 	</div>
-	<!-- radius lives on a wrapper: border-radius is a no-op on a
-	     border-collapse:collapse table, same as the PDF markup -->
-	<div
-		:style="
-			df.table_radius != null
-				? { borderRadius: df.table_radius + 'px', overflow: 'hidden' }
-				: {}
-		"
+	<table
+		class="table"
+		:style="{
+			...(df.table_radius != null ? { '--pfb-radius': df.table_radius + 'px' } : {}),
+			...(df.table_header_bg && df.table_header !== 'plain'
+				? { '--pfb-header-bg': df.table_header_bg }
+				: {}),
+		}"
 	>
-		<table
-			class="table"
-			:class="{ 'table-bordered': df.table_bordered !== false }"
-			:style="
-				df.table_bordered !== false && df.table_border_color
-					? { borderColor: df.table_border_color }
-					: {}
-			"
-		>
-			<thead v-if="df.table_header !== 'none'">
-				<!-- inline !important mirrors the server markup: the shared
-					     stylesheet's own !important rules must lose to these -->
-				<tr
-					:style="
-						df.table_header_bg && df.table_header !== 'plain'
-							? `background-color: ${df.table_header_bg} !important`
-							: ''
-					"
+		<thead v-if="df.table_header !== 'none'">
+			<tr>
+				<th
+					v-for="(col, ci) in df.table_columns"
+					:key="col.fieldname"
+					class="column-header"
+					:class="{ 'column-value--merged': has_merge(col) }"
+					:data-fieldtype="col.fieldtype"
+					:data-fieldname="col.fieldname"
+					:style="(col.width ? `width: ${col.width}%; ` : '') + cell_style(df)"
 				>
-					<th
-						v-for="(col, ci) in df.table_columns"
-						:key="col.fieldname"
-						class="column-header"
-						:class="{ 'column-value--merged': has_merge(col) }"
-						:data-fieldtype="col.fieldtype"
-						:data-fieldname="col.fieldname"
-						:style="(col.width ? `width: ${col.width}%; ` : '') + cell_style(df)"
-					>
-						{{ col.label || col.fieldname }}
-						<span
-							v-if="ci < df.table_columns.length - 1"
-							class="col-resize-handle"
-							@pointerdown.prevent.stop="start_col_resize($event, ci)"
-							@mousedown.prevent.stop
-							@click.stop
-						></span>
-					</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr
-					v-for="(row, i) in (preview_doc[df.fieldname] || []).slice(0, 4)"
-					:key="i"
-					:class="i % 2 === 0 ? 'odd' : 'even'"
+					{{ col.label || col.fieldname }}
+					<span
+						v-if="ci < df.table_columns.length - 1"
+						class="col-resize-handle"
+						@pointerdown.prevent.stop="start_col_resize($event, ci)"
+						@mousedown.prevent.stop
+						@click.stop
+					></span>
+				</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr
+				v-for="(row, i) in (preview_doc[df.fieldname] || []).slice(0, 4)"
+				:key="i"
+				:class="i % 2 === 0 ? 'odd' : 'even'"
+			>
+				<td
+					v-for="col in df.table_columns"
+					:key="col.fieldname"
+					class="column-value"
+					:class="{ 'column-value--merged': has_merge(col) }"
+					:data-fieldtype="col.fieldtype"
+					:data-fieldname="col.fieldname"
+					:style="(col.width ? `width: ${col.width}%; ` : '') + cell_style(df)"
 				>
-					<td
-						v-for="col in df.table_columns"
-						:key="col.fieldname"
-						class="column-value"
-						:class="{ 'column-value--merged': has_merge(col) }"
-						:data-fieldtype="col.fieldtype"
-						:data-fieldname="col.fieldname"
-						:style="(col.width ? `width: ${col.width}%; ` : '') + cell_style(df)"
-					>
-						<!-- Merged cell: image (if any) floats left, text lines stack -->
-						<div v-if="has_merge(col)" class="cell-merged">
-							<template v-if="image_merge(col)">
-								<img
-									v-if="cell_image(col, row)"
-									:src="cell_image(col, row)"
-									class="cell-thumb-img"
-									:style="thumb_box(col)"
-									:alt="col.label || col.fieldname"
-								/>
-								<span v-else class="cell-thumb" :style="thumb(col, row).style">{{
-									thumb(col, row).abbr
-								}}</span>
-							</template>
-							<div
-								class="cell-lines"
-								:class="{
-									'cell-lines--horizontal': col.merge_direction === 'horizontal',
-								}"
-							>
-								<div
-									v-for="(mf, mi) in text_merges(col)"
-									:key="mi"
-									class="cell-line"
-									:class="`cell-line--${mf.style || 'primary'}`"
-								>
-									{{ format_merged(row, i, mf.fieldname) }}
-								</div>
-							</div>
-						</div>
-						<!-- Single (default) -->
-						<template v-else>
+					<!-- Merged cell: image (if any) floats left, text lines stack -->
+					<div v-if="has_merge(col)" class="cell-merged">
+						<template v-if="image_merge(col)">
 							<img
-								v-if="
-									is_image_field(col, row[col.fieldname]) && row[col.fieldname]
-								"
-								:src="row[col.fieldname]"
-								class="preview-table-img"
+								v-if="cell_image(col, row)"
+								:src="cell_image(col, row)"
+								class="cell-thumb-img"
+								:style="thumb_box(col)"
 								:alt="col.label || col.fieldname"
 							/>
-							<div
-								v-else-if="cell_server_html(i, col)"
-								class="preview-table-html"
-								v-html="cell_server_html(i, col)"
-							></div>
-							<span v-else>{{ format_cell(row, col) }}</span>
+							<span v-else class="cell-thumb" :style="thumb(col, row).style">{{
+								thumb(col, row).abbr
+							}}</span>
 						</template>
-					</td>
-				</tr>
-				<tr v-if="!preview_doc[df.fieldname]?.length">
-					<td :colspan="df.table_columns?.length || 1" class="text-muted pfb-table-note">
-						{{ __("No rows") }}
-					</td>
-				</tr>
-				<tr v-if="(preview_doc[df.fieldname] || []).length > 4">
-					<td :colspan="df.table_columns?.length || 1" class="text-muted pfb-table-note">
-						{{
-							__("+ {0} more rows in this document — all print in the real output", [
-								preview_doc[df.fieldname].length - 4,
-							])
-						}}
-					</td>
-				</tr>
-			</tbody>
-		</table>
-	</div>
+						<div
+							class="cell-lines"
+							:class="{
+								'cell-lines--horizontal': col.merge_direction === 'horizontal',
+							}"
+						>
+							<div
+								v-for="(mf, mi) in text_merges(col)"
+								:key="mi"
+								class="cell-line"
+								:class="`cell-line--${mf.style || 'primary'}`"
+							>
+								{{ format_merged(row, i, mf.fieldname) }}
+							</div>
+						</div>
+					</div>
+					<!-- Single (default) -->
+					<template v-else>
+						<img
+							v-if="is_image_field(col, row[col.fieldname]) && row[col.fieldname]"
+							:src="row[col.fieldname]"
+							class="preview-table-img"
+							:alt="col.label || col.fieldname"
+						/>
+						<div
+							v-else-if="cell_server_html(i, col)"
+							class="preview-table-html"
+							v-html="cell_server_html(i, col)"
+						></div>
+						<span v-else>{{ format_cell(row, col) }}</span>
+					</template>
+				</td>
+			</tr>
+			<tr v-if="!preview_doc[df.fieldname]?.length">
+				<td :colspan="df.table_columns?.length || 1" class="text-muted pfb-table-note">
+					{{ __("No rows") }}
+				</td>
+			</tr>
+			<tr v-if="(preview_doc[df.fieldname] || []).length > 4">
+				<td :colspan="df.table_columns?.length || 1" class="text-muted pfb-table-note">
+					{{
+						__("+ {0} more rows in this document — all print in the real output", [
+							preview_doc[df.fieldname].length - 4,
+						])
+					}}
+				</td>
+			</tr>
+		</tbody>
+	</table>
 </template>
 
 <script setup>

--- a/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
+++ b/frappe/public/js/print_format_builder/components/editor/PrintFormatSection.vue
@@ -164,7 +164,7 @@
 							group="fields"
 							:animation="150"
 							item-key="id"
-							filter="a, input, textarea, select, button, label, summary, [contenteditable], [role='button'], [tabindex]"
+							filter="a, input, textarea, select, button, label, summary, [contenteditable], [role='button'], [tabindex]:not(.field--chip):not(.field--preview)"
 							:preventOnFilter="false"
 							:emptyInsertThreshold="100"
 							v-bind="DRAG_OPTIONS"

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -8,24 +8,20 @@
 {%- set _cell_style = ('padding:' + _cell_pad|string + 'px') if _cell_pad is not none else '' -%}
 {%- set _border_color = df.table_border_color if df.table_border_color else none -%}
 {%- set _cell_style = ((_cell_style + ';') if _cell_style else '') + (('border-color:' + _border_color + ' !important') if _border_color else '') -%}
-{%- set _header_style = ('background-color:' + df.table_header_bg + ' !important') if df.table_header_bg and not _plain_header else '' -%}
 {%- set _radius = df.table_radius if df.table_radius is defined and df.table_radius is not none else none -%}
-{%- set _radius_style = ('border-radius:' + _radius|string + 'px;overflow:hidden') if _radius is not none else '' -%}
-<div class="child-table child-table--{{ _style }}{% if _plain_header %} child-table--plain-header{% endif %}"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
+{%- set _frame_style = (('--pfb-radius:' + _radius|string + 'px;') if _radius is not none else '') + (('--pfb-header-bg:' + df.table_header_bg + ';') if df.table_header_bg and not _plain_header else '') -%}
+<div class="child-table child-table--{{ _style }}{% if _plain_header %} child-table--plain-header{% endif %}{% if _bordered %} child-table--bordered{% endif %}"{% if df.custom_style %} style="{{ df.custom_style|e }}"{% endif %} {{ field_attributes(df) }}>
 	{%- set _show_label = df.show_label if df.show_label else 'show' -%}
 	{% if df.label and _show_label != 'hide' %}
 	<div class="label">
 		{{ _(df.label) }}
 	</div>
 	{% endif %}
-	{#- border-radius has no effect on a border-collapse:collapse table per spec, so the
-	   radius + clip live on a wrapper div around the table instead of on the table itself -#}
-	<div{% if _radius_style %} style="{{ _radius_style|e }}"{% endif %}>
-	<table class="table{% if _bordered %} table-bordered{% endif %}"{% if _bordered and _border_color %} style="border-color: {{ _border_color|e }}"{% endif %}>
+	<table class="table"{% if _frame_style %} style="{{ _frame_style|e }}"{% endif %}>
 		{% set columns = df.table_columns %}
 		{%- if not _no_header -%}
 		<thead>
-			<tr class="table-row"{% if _header_style %} style="{{ _header_style|e }}"{% endif %}>
+			<tr class="table-row">
 				{% for column in columns %}
 				{%- set _merged_col = column.merged_fields and column.merged_fields|length > 0 -%}
 				<th class="column-header{% if _merged_col %} column-value--merged{% endif %}" width="{{ column.width }}%"{% if _cell_style %} style="{{ _cell_style|e }}"{% endif %} {{ field_attributes(column) }}>
@@ -89,6 +85,5 @@
 			{% endfor %}
 		</tbody>
 	</table>
-	</div>
 </div>
 {% endif %}

--- a/frappe/templates/print_format/macros/Table.html
+++ b/frappe/templates/print_format/macros/Table.html
@@ -31,6 +31,9 @@
 			</tr>
 		</thead>
 		{%- endif -%}
+		<tfoot>
+			<tr class="table-row"><td class="table-foot" colspan="{{ columns|length }}"></td></tr>
+		</tfoot>
 		<tbody>
 			{% for row in _rows %}
 			<tr class="table-row {{ loop.cycle('odd', 'even') }}" data-idx="{{ row.idx }}"{% if row.get("page_break") and not loop.first %} style="page-break-before: always"{% endif %}>

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -213,11 +213,11 @@
 	border-bottom-right-radius: var(--pfb-radius, 0);
 }
 
-.print-format-doc .child-table .table tbody tr:last-child td:first-child {
+.print-format-doc .child-table .table .table-foot {
+	padding: 0;
+	height: 0;
+	border: none !important;
 	border-bottom-left-radius: var(--pfb-radius, 0);
-}
-
-.print-format-doc .child-table .table tbody tr:last-child td:last-child {
 	border-bottom-right-radius: var(--pfb-radius, 0);
 }
 
@@ -249,6 +249,13 @@
 
 .print-format-doc .child-table--bordered .table thead th {
 	border-top: 1px solid var(--gray-300) !important;
+}
+
+.print-format-doc .child-table--bordered .table .table-foot {
+	height: var(--pfb-radius, 0);
+	border-left: 1px solid var(--gray-300) !important;
+	border-right: 1px solid var(--gray-300) !important;
+	border-bottom: 1px solid var(--gray-300) !important;
 }
 
 /* plain header: no fill, a single rule under the header row instead */

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -197,8 +197,9 @@
 	vertical-align: top;
 }
 
-/* lined: a divider under the header and under each row */
-.print-format-doc .child-table--lined .table th,
+/* lined: a divider under each body row. The header needs none — the styled
+   header's fill (clipped by the wrapper radius) separates it, and the plain
+   header has its own rule below. */
 .print-format-doc .child-table--lined .table td {
 	border-bottom: 1px solid var(--gray-300) !important;
 }

--- a/frappe/templates/print_format/print_format_doc.css
+++ b/frappe/templates/print_format/print_format_doc.css
@@ -162,32 +162,63 @@
 
 .print-format-doc .child-table .table {
 	font-size: 0.9em;
-	border-collapse: collapse;
+	border-collapse: separate;
+	border-spacing: 0;
+	margin: 0;
 	width: 100%;
 	table-layout: fixed;
 	word-break: break-word;
 }
 
-/* Table variants are three independent axes: Style (--lined/--striped/--plain)
-   draws horizontal lines/fills, .table-bordered draws vertical lines + frame,
-   --plain-header restyles the header. The base kills every border with
-   !important (Bootstrap print sets .table-bordered cell borders !important)
-   so each axis opts back in without touching the others. */
+@media print {
+	.print-format-doc .child-table .table {
+		border-collapse: separate !important;
+		border-spacing: 0 !important;
+	}
+}
+
 .print-format-doc .child-table .table th {
 	color: var(--gray-800);
 	font-weight: 600;
 	font-size: 0.85em;
 	padding: 0.5882em 0.7843em;
 	border: none !important;
-	/* Bootstrap print paints th white !important, which would cover the
-	   thead tr fill; transparent cells let the row background through */
-	background-color: transparent !important;
 }
 
-/* header background lives on the row, not each cell, so a wrapper's border-radius
-   clips one continuous bar instead of fighting per-cell backgrounds at the seams */
-.print-format-doc .child-table .table thead tr {
-	background-color: var(--gray-100) !important;
+.print-format-doc .child-table .table thead th {
+	background-color: var(--pfb-header-bg, var(--gray-100)) !important;
+}
+
+.print-format-doc .child-table:not(.child-table--plain-header) .table thead th:first-child {
+	border-top-left-radius: var(--pfb-radius, 0);
+}
+
+.print-format-doc .child-table:not(.child-table--plain-header) .table thead th:last-child {
+	border-top-right-radius: var(--pfb-radius, 0);
+}
+
+.print-format-doc
+	.child-table--lined:not(.child-table--bordered):not(.child-table--plain-header)
+	.table
+	thead
+	th:first-child {
+	border-bottom-left-radius: var(--pfb-radius, 0);
+}
+
+.print-format-doc
+	.child-table--lined:not(.child-table--bordered):not(.child-table--plain-header)
+	.table
+	thead
+	th:last-child {
+	border-bottom-right-radius: var(--pfb-radius, 0);
+}
+
+.print-format-doc .child-table .table tbody tr:last-child td:first-child {
+	border-bottom-left-radius: var(--pfb-radius, 0);
+}
+
+.print-format-doc .child-table .table tbody tr:last-child td:last-child {
+	border-bottom-right-radius: var(--pfb-radius, 0);
 }
 
 .print-format-doc .child-table .table td {
@@ -197,34 +228,32 @@
 	vertical-align: top;
 }
 
-/* lined: a divider under each body row. The header needs none — the styled
-   header's fill (clipped by the wrapper radius) separates it, and the plain
-   header has its own rule below. */
 .print-format-doc .child-table--lined .table td {
 	border-bottom: 1px solid var(--gray-300) !important;
 }
 
-/* striped: alternating row fill instead of dividers */
 .print-format-doc .child-table--striped .table .even td {
 	background-color: var(--gray-50) !important;
 }
 
-/* bordered: column separators + outer frame; adjacent cell borders collapse */
-.print-format-doc .child-table .table-bordered {
-	border: 1px solid var(--gray-300);
+.print-format-doc .child-table--bordered .table th,
+.print-format-doc .child-table--bordered .table td {
+	border-right: 1px solid var(--gray-300) !important;
+	border-bottom: 1px solid var(--gray-300) !important;
 }
 
-.print-format-doc .child-table .table-bordered td {
+.print-format-doc .child-table--bordered .table th:first-child,
+.print-format-doc .child-table--bordered .table td:first-child {
 	border-left: 1px solid var(--gray-300) !important;
-	border-right: 1px solid var(--gray-300) !important;
+}
+
+.print-format-doc .child-table--bordered .table thead th {
+	border-top: 1px solid var(--gray-300) !important;
 }
 
 /* plain header: no fill, a single rule under the header row instead */
-.print-format-doc .child-table--plain-header .table thead tr {
+.print-format-doc .child-table--plain-header .table thead th {
 	background-color: transparent !important;
-}
-
-.print-format-doc .child-table--plain-header .table th {
 	border-bottom: 1px solid var(--gray-300) !important;
 }
 
@@ -353,8 +382,8 @@
    flow across pages; keep thead repeating on each new page. */
 @media print {
 	.print-format-doc .child-table tr {
-		page-break-inside: auto;
-		break-inside: auto;
+		page-break-inside: avoid;
+		break-inside: avoid;
 	}
 	.print-format-doc .child-table thead {
 		display: table-header-group;

--- a/frappe/utils/test_print_format_parity.py
+++ b/frappe/utils/test_print_format_parity.py
@@ -68,6 +68,15 @@ def _field_vue_text():
 
 
 @functools.cache
+def _canvas_logic_text():
+	"""The preview surface that reads df.* — Field.vue dispatches to the
+	FieldPreview* components, which lean on the composables; a df prop handled
+	in any of them is mirrored, so the check spans .vue markup + composables."""
+	js = "\n".join(p.read_text() for p in sorted((BUILDER_DIR / "composables").glob("*.js")))
+	return _canvas_text() + "\n" + js
+
+
+@functools.cache
 def _shared_css_selector_tokens():
 	"""Class names and data-* attributes used by the shared stylesheet's selectors."""
 	css = SHARED_CSS.read_text()
@@ -158,11 +167,11 @@ class TestPrintSurfaceMarkupContract(UnitTestCase):
 		skip = {"get", "renderer", "section", "html"}
 		macro = macro_path.read_text()
 		props = set(re.findall(r"df\.([a-z_]+)", macro)) - skip
-		missing = sorted(p for p in props if f"df.{p}" not in _field_vue_text())
+		missing = sorted(p for p in props if f"df.{p}" not in _canvas_logic_text())
 		self.assertFalse(
 			missing,
-			f"{macro_path.name} reads df properties {missing} that Field.vue never handles — "
-			"the canvas preview will silently ignore them. Mirror them in Field.vue's preview markup.",
+			f"{macro_path.name} reads df properties {missing} that the canvas preview never handles — "
+			"the preview will silently ignore them. Mirror them in Field.vue or its FieldPreview* components.",
 		)
 
 
@@ -328,7 +337,8 @@ class TestPrintSurfaceParity(IntegrationTestCase):
 			'data-fieldname="first_name"',
 			'data-fieldtype="Data"',
 			"child-table child-table--lined",
-			'<table class="table table-bordered">',
+			"child-table--bordered",
+			'<table class="table">',
 			"column-header",
 			'data-fieldname="idx"',
 			'data-fieldname="email_id"',


### PR DESCRIPTION
Child-table styling for the beta print format builder, plus two builder fixes found on the way.

- **Styled header divider.** `child-table--lined` drew a `border-bottom` on header cells, cutting a line across a Styled header's fill. Scoped the `--lined` divider to `td` only.
- **Rounded child tables that paginate.** `table_radius` rounds the frame's top corners and the last row's bottom corners; with Style **Rows** + a Styled header, the header's own bottom corners round too so it reads as a rounded bar. Child tables switch to `border-collapse: separate` (with an `@media print` override — Bootstrap forces `collapse !important` in print), and the frame, column separators and rounding all live on the **cells**. `--pfb-radius` / `--pfb-header-bg` are set directly on the `<table>`.
- **Builder: canvas field drag was broken.** `[tabindex]` in the field draggable's `filter` (#e7db35b) started matching the Field root once it became keyboard-focusable (#4e21ff5) — Sortable tests every ancestor up to the item root, so every field drag aborted. Narrowed to `[tabindex]:not(.field--chip):not(.field--preview)`.
- **Builder: saved section snippets are now draggable** into the layout (clone-on-drag, click-to-insert still works), and the delete icon no longer crowds the label.
- **Parity test.** #41047 split the table/repeater preview into `FieldPreview*` components, so `_assert_df_props_mirrored` (scanning only `Field.vue`) went stale; widened to the whole canvas surface and refreshed the markup contract.

Why cells and not a wrapper: a bordered *box* — a wrapper `div` or the `<table>` itself — stretches its fragment to the page bottom and draws its side borders through the page-break gap (the blank strip below the last row). Cells stop at the last row, and in `separate` mode `border-radius` rounds a cell's actual border, so the frame can be both rounded and paginated.

Verified by rendering real multi-page PDFs through `PrintFormatGenerator` on frappe's bundled Chromium (not headless system Chrome, which disagrees on fragmentation): page-break edge, repeated header, last-page bottom, and the multi-document merge path. `test_print_format_parity` (5), `test_print_format` (28) and `test_print_format_generator` (64) green.
