### PR TITLE
fix: non-read permissions return false before a doctype's meta is loaded

### DIFF
--- a/cypress/integration/permissions.js
+++ b/cypress/integration/permissions.js
@@ -39,3 +39,35 @@ context.skip("Permissions API", () => {
 		cy.call("logout");
 	});
 });
+
+context("Permissions before a doctype's meta is loaded", () => {
+	before(() => {
+		cy.login("frappe@example.com");
+		cy.visit("/app");
+	});
+
+	it("Resolves delete for ToDo before its meta is loaded", () => {
+		cy.window()
+			.then((win) => {
+				const { frappe, locals } = win;
+
+				delete locals.DocType["ToDo"];
+				delete frappe.perm.doctype_perm["ToDo"];
+
+				expect(frappe.get_meta("ToDo")).to.not.exist;
+				expect(frappe.perm.has_perm("ToDo", 0, "delete")).to.equal(true);
+
+				return new Promise((resolve) => frappe.model.with_doctype("ToDo", resolve));
+			})
+			.then(() => {
+				cy.window().then((win) => {
+					expect(win.frappe.get_meta("ToDo")).to.exist;
+					expect(win.frappe.perm.has_perm("ToDo", 0, "delete")).to.equal(true);
+				});
+			});
+	});
+
+	after(() => {
+		cy.call("logout");
+	});
+});

--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -119,6 +119,13 @@ $.extend(frappe.perm, {
 						perm[0][right] = 1;
 					}
 				}
+
+				if (
+					frappe.boot.user?.can_create?.includes(doctype) ||
+					frappe.boot.user?.in_create?.includes(doctype)
+				) {
+					perm[0].create = 1;
+				}
 			}
 			return perm;
 		}

--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -3,6 +3,8 @@
 
 frappe.provide("frappe.perm");
 
+const boot_backed_rights = ["select", "delete", "submit", "cancel"];
+
 // backward compatibilty
 Object.assign(window, {
 	READ: "read",
@@ -107,8 +109,16 @@ $.extend(frappe.perm, {
 		let perm = [{ read: 0, permlevel: 0, rights_without_if_owner: new Set() }];
 
 		if (!meta) {
-			if (frappe.boot.user.can_read.includes(doctype)) {
+			if (frappe.boot.user?.all_read?.includes(doctype)) {
 				perm[0].read = 1;
+			}
+
+			if (!doc) {
+				for (const right of boot_backed_rights) {
+					if (frappe.boot.user?.["can_" + right]?.includes(doctype)) {
+						perm[0][right] = 1;
+					}
+				}
 			}
 			return perm;
 		}


### PR DESCRIPTION
## Summary

Follow-up to #40997.

`has_perm()` could still return `false` for some permission types until a DocType's metadata was loaded, because the pre-meta path in `_get_perm()` only handled `read`.

## Changes

- Resolve `select`, `delete`, `submit`, `cancel`, and `create` permissions from bootinfo before metadata is available.
  - `create` checks both `can_create` and `in_create`, since a doctype can appear in either depending on how it's created.
- Resolve `read` from `all_read` instead of `can_read`, so read-only doctypes are handled correctly.
- Skip these pre-meta checks when a specific document is passed, since `if_owner` rules are only applied after the metadata is loaded.

## Notes

This only covers **level 0** permissions. Bootinfo doesn't include `permlevel` data, so higher permission levels still wait for the DocType meta to load.

`write`, `amend`, `share`, and custom permission types also continue to require metadata. Supporting those would need a broader change to include per-level role permissions in bootinfo.

Fixes #40960 (problem 2, partially).