### PR TITLE
feat(perf): speed up loading of imports

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -129,8 +129,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
 }
 
 # --------------------------------------------------------------------------------------------
-# Creating a background thread to load  atttributes/symbols in background.
-# We argue that most of those attributes are hit anyway on `bench start` and/or very first request to server.
+# We argue that most of _LAZY_IMPORT attributes are hit anyway on `bench start` and/or very first request to server.
 # So it doesn't make sense to do Lazy Imports for Frappe (namespace) code, as we end up with adding significant "perceived" latency on User side .
 # We also argue it is SAFE, as a dedicated lock/sync is used by Python internally to cleanly initialize a module (Even if it has some code that could run on init, so no side-effects).
 # https://docs.python.org/3/whatsnew/3.3.html#a-finer-grained-import-lock
@@ -139,16 +138,13 @@ import_thread_lock = threading.RLock()
 
 def _import_frappe_modules_in_background():
 	for name, (module_path, attr_name) in _LAZY_IMPORTS.items():
-		import_thread_lock.acquire()
-		if name not in globals():
-			mod = importlib.import_module(module_path)
-			value = getattr(mod, attr_name)
-			globals()[name] = value
-		import_thread_lock.release()
+		with import_thread_lock:
+			if name not in globals():
+				mod = importlib.import_module(module_path)
+				value = getattr(mod, attr_name)
+				globals()[name] = value
 
 
-# Any exception inside the thread should trigger the `assert` statement by being unable to find an expected name/module defined in _LAZY_IMPORTS !
-threading.Thread(target=_import_frappe_modules_in_background).start()
 # ----------------------------------------------------------------------------------------------
 
 
@@ -156,15 +152,14 @@ def __getattr__(name: str):
 	if name in _LAZY_IMPORTS:
 		value = None
 		# NOTE: we priortize the direct request to load a module from parent thread, `globals()` and `import_thread_lock` are used to sync this information to the background thread.
-		import_thread_lock.acquire()
-		if name not in globals():
-			module_path, attr_name = _LAZY_IMPORTS[name]
-			mod = importlib.import_module(module_path)
-			value = getattr(mod, attr_name)
-			globals()[name] = value
-		else:
-			value = globals()[name]
-		import_thread_lock.release()
+		with import_thread_lock:
+			if name not in globals():
+				module_path, attr_name = _LAZY_IMPORTS[name]
+				mod = importlib.import_module(module_path)
+				value = getattr(mod, attr_name)
+				globals()[name] = value
+			else:
+				value = globals()[name]
 		assert value is not None, (
 			f"Failed to load an Expected module {name}, most likely bug in our background import loading thread!"
 		)
@@ -1519,3 +1514,27 @@ delete_doc_if_exists = delete_doc
 
 frappe._optimizations.optimize_all()
 frappe._optimizations.register_fault_handler()
+
+# ===========================================================================================================================================
+# background_thread should be run at the end, as it would compete through `per module` lock (as itself would be importing from frappe namespace).
+# So only after `__init__`finished importing it could start importing (through importlib machinery).
+background_thread = threading.Thread(target=_import_frappe_modules_in_background, args=())
+
+
+def finish_background_import_loading():
+	# NOTE: we make sure to check no dead-lock, if __init__ has been imported, then should be NO reason to deadlock, just may take few 100s Of milliseconds to load.
+	# by the time it would get `forked` it would already be finished almost always. (if not, timeout should compensate for that).
+	global background_thread
+	background_thread.join(
+		timeout=6
+	)  # can be joined many times, so for each fork, if finished once , then would be instant.
+	if background_thread.is_alive():
+		raise Exception(
+			"Thread responsible for loading import didn't finish in expected time or Deadlocked, either way its a BUG. !!"
+		)
+
+
+# Background threads are difficut to manage in case of `forks`, not a clearly defined behaviour. Ideally no background thread should be running just before forking.
+os.register_at_fork(before=finish_background_import_loading)
+background_thread.start()
+# ========================================================================================================================================================

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -128,13 +128,46 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
 	"redirect_to_message": ("frappe.utils.response", "redirect_to_message"),
 }
 
+# --------------------------------------------------------------------------------------------
+# Creating a background thread to load  atttributes/symbols in background.
+# We argue that most of those attributes are hit anyway on `bench start` and/or very first request to server.
+# So it doesn't make sense to do Lazy Imports for Frappe (namespace) code, as we end up with adding significant "perceived" latency on User side .
+# We also argue it is SAFE, as a dedicated lock/sync is used by Python internally to cleanly initialize a module (Even if it has some code that could run on init, so no side-effects).
+# https://docs.python.org/3/whatsnew/3.3.html#a-finer-grained-import-lock
+import_thread_lock = threading.RLock()
+
+
+def _import_frappe_modules_in_background():
+	for name, (module_path, attr_name) in _LAZY_IMPORTS.items():
+		import_thread_lock.acquire()
+		if name not in globals():
+			mod = importlib.import_module(module_path)
+			value = getattr(mod, attr_name)
+			globals()[name] = value
+		import_thread_lock.release()
+
+
+# Any exception inside the thread should trigger the `assert` statement by being unable to find an expected name/module defined in _LAZY_IMPORTS !
+threading.Thread(target=_import_frappe_modules_in_background).start()
+# ----------------------------------------------------------------------------------------------
+
 
 def __getattr__(name: str):
 	if name in _LAZY_IMPORTS:
-		module_path, attr_name = _LAZY_IMPORTS[name]
-		mod = importlib.import_module(module_path)
-		value = getattr(mod, attr_name)
-		globals()[name] = value
+		value = None
+		# NOTE: we priortize the direct request to load a module from parent thread, `globals()` and `import_thread_lock` are used to sync this information to the background thread.
+		import_thread_lock.acquire()
+		if name not in globals():
+			module_path, attr_name = _LAZY_IMPORTS[name]
+			mod = importlib.import_module(module_path)
+			value = getattr(mod, attr_name)
+			globals()[name] = value
+		else:
+			value = globals()[name]
+		import_thread_lock.release()
+		assert value is not None, (
+			f"Failed to load an Expected module {name}, most likely bug in our background import loading thread!"
+		)
 		return value
 	raise AttributeError(f"module 'frappe' has no attribute {name!r}")
 


### PR DESCRIPTION
Speeding up loading of `frappe.`  attributes, using a background thread.
As such `attributes` are hit/resolved on `bench start` or on foremost request to backend server, it doesn't make much sense to resolve such attributes on demand, as such latency is directly perceived by user.
This change enables significantly faster completion of `bench start` command, and reduce (user-side) latency in initial calls like `/login` or `/homepage`.  