### PR TITLE
fix(restore): Cleanup copy during failure and throw proper error message

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -816,7 +816,14 @@ def extract_files(site_name, file_path):
 			subprocess.check_output(["tar", "xvf", tar_path, "--strip", "2"], cwd=abs_site_path)
 		elif file_path.endswith(".tgz"):
 			subprocess.check_output(["tar", "zxvf", tar_path, "--strip", "2"], cwd=abs_site_path)
+		else:
+			raise ValueError(f"Unsupported archive format for {tar_name}: expected .tar or .tgz")
 	except Exception:
+		if os.path.exists(tar_path):
+			try:
+				os.remove(tar_path)
+			except OSError:
+				pass
 		raise
 	finally:
 		frappe.destroy()


### PR DESCRIPTION
Restore CLI command missed copied file path during failure case. Also unsupported file extensions showed wrong message though restore process didn't succeed. Handled both this cases.