### PR TITLE
fix(grid): resolve last column's rendering issue for table inside a dialog

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -862,7 +862,8 @@
 
 .form-grid {
 	// Pin action and index columns so wide grids stay usable.
-	.grid-row > .row .col:last-child,
+	// :not(.grid-data-last) excludes the case where the last column is data field (table in a dialog)
+	.grid-row > .row .col:last-child:not(.grid-data-last),
 	.grid-row > .dialog-assignment-row .col:first-child,
 	.grid-row > .dialog-assignment-row .col:last-child {
 		max-width: 30px;


### PR DESCRIPTION
When creating a table inside a dialog with `in_place_edit: true`, the last columns is stuck with `max-width` of `30px`

### Before Fix
<img width="925" height="426" alt="Screenshot 2026-07-20 at 1 11 42 PM" src="https://github.com/user-attachments/assets/f38c96f1-1b88-4910-902f-8210c9b0baf1" />

### After Fix
<img width="1243" height="473" alt="Screenshot 2026-07-20 at 1 03 51 PM" src="https://github.com/user-attachments/assets/14927531-d5e9-4346-92be-1ad878b8b953" />


## Code to Reproduce
```javascript
function show_sample_table_dialog() {
	const dialog = new frappe.ui.Dialog({
		title: __("Sample Table Dialog"),
		size: "large",
		fields: [
			{
				label: __("Sample Table"),
				fieldtype: "Table",
				fieldname: "sample_table",
				in_place_edit: true,
				fields: [
					{
						fieldtype: "Data",
						fieldname: "a",
						label: __("A"),
						in_list_view: 1,
                        columns:2,
					},

                    {
                        fieldtype: "Data",
                        fieldname: "b",
                        label: __("B"),
                        in_list_view: 1,
                        columns: 2,
                    },

                    {
                        fieldtype: "Data",
                        fieldname: "c",
                        label: __("C"),
                        in_list_view: 1,
                        columns: 2,
                    },

                    {
                        fieldtype: "Data",
                        fieldname: "d",
                        label: __("D"),
                        in_list_view: 1,
                        columns: 2,
                    },

				],
			},
		],
		primary_action_label: __("Done"),
		primary_action() {
			dialog.hide();
		},
	});

	const grid = dialog.fields_dict.sample_table.grid;

	dialog.show();

	// prefill with sample data
	grid.df.data = [
        { a: "Exercitation tempor minim amet tempor non cillum deserunt est enim duis.", b: "Exercitation tempor minim amet tempor non cillum deserunt est enim duis", c: "Exercitation tempor minim amet tempor non cillum deserunt est enim duis", d: "Exercitation tempor minim amet tempor non cillum deserunt est enim duis" },
        { a: "Exercitation tempor minim amet tempor non cillum deserunt est enim duis", b: "Exercitation tempor minim amet tempor non cillum deserunt est enim duis", c: "Exercitation tempor minim amet tempor non cillum deserunt est enim duis", d: "Exercitation tempor minim amet tempor non cillum deserunt est enim duis"},
	];
	grid.refresh();
}

```
