### PR TITLE
fix: correct misleading error message location in Email Inbox

### DIFF
--- a/frappe/public/js/frappe/views/inbox/inbox_view.js
+++ b/frappe/public/js/frappe/views/inbox/inbox_view.js
@@ -19,7 +19,7 @@ frappe.views.InboxView = class InboxView extends frappe.views.ListView {
 		} else if (!route[3] || (route[3] !== "All Accounts" && !is_valid(route[3]))) {
 			frappe.throw(
 				__(
-					"No email account associated with the User. Please add an account under User > Email Inbox."
+					"No email account associated with the User. Please add an account under User > Settings > User Emails."
 				)
 			);
 		}


### PR DESCRIPTION
The error shown when a user has no linked email account pointed to a non-existent 'User > Email Inbox' section. Email accounts are actually configured under User > Settings > User Emails.
 

Closes https://github.com/frappe/frappe/issues/41054